### PR TITLE
chore(scripts): seven AnyHarness grid boundary rules with seeded debt allowlist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,9 @@ jobs:
         run: python3 scripts/check_server_boundaries.py
 
       - name: Check AnyHarness layer boundaries
-        run: python3 scripts/check_anyharness_boundaries.py
+        run: |
+          python3 -m unittest scripts/test_check_anyharness_boundaries.py
+          python3 scripts/check_anyharness_boundaries.py
 
       - name: Check session mutation admission
         run: python3 scripts/check_session_mutation_admission.py

--- a/scripts/anyharness_boundaries_allowlist.txt
+++ b/scripts/anyharness_boundaries_allowlist.txt
@@ -5,6 +5,140 @@
 #
 # This is migration debt, not permission for new code. If a cleanup reduces a
 # count, update this file in the same PR.
+#
+# The checker cannot see `#[cfg(test)]` boundaries inside otherwise-production
+# files, so a handful of counts below cover setup code in inline test mods. Those
+# entries say so in their reason and are not cleanup targets.
 
 DOMAIN_CONTRACT_REQUEST_RESPONSE anyharness/crates/anyharness-lib/src/domains/goals/runtime.rs 1 strict-mirror goal runtime uses SetSessionGoalRequest to drive the sidecar ext method; contract mapping pending move above the API boundary
 DOMAIN_CONTRACT_REQUEST_RESPONSE anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs 1 strict-mirror loop runtime uses SetSessionLoopRequest to drive the sidecar ext method; contract mapping pending move above the API boundary
+
+# Rule: domains/** reach live/ only via the runtime valve.
+# 12 files, 21 occurrences.
+DOMAIN_LIVE_VALVE anyharness/crates/anyharness-lib/src/domains/agents/auth/login_terminal.rs 4 agent login holds the live login-terminal service directly (4 leaves in one group import); target = agents runtime valve (grid plan PR 6c)
+DOMAIN_LIVE_VALVE anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/entry.rs 1 inline fully-qualified live probe type in a fn signature; target = agents runtime valve (grid plan PR 6c)
+DOMAIN_LIVE_VALVE anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/probe.rs 3 model snapshot calls live session probe directly (3 leaves in one group import); target = agents runtime valve (grid plan PR 6c)
+DOMAIN_LIVE_VALVE anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/test_support.rs 3 test-fixture support file (not excluded by should_skip) builds live probe snapshots; target = agents runtime valve or move under tests/ (grid plan PR 6c)
+DOMAIN_LIVE_VALVE anyharness/crates/anyharness-lib/src/domains/materialization/service.rs 1 materialization service holds live terminals directly; target = materialization runtime valve (grid plan PR 6a)
+DOMAIN_LIVE_VALVE anyharness/crates/anyharness-lib/src/domains/mobility/service.rs 1 mobility service holds live terminals directly; target = mobility runtime valve (grid plan PR 6a)
+DOMAIN_LIVE_VALVE anyharness/crates/anyharness-lib/src/domains/plans/decision_op.rs 2 plan decision op imports actor command types (Resolution, ResolveInteractionCommandError) via the live::sessions root re-export, not ::model; target = model re-export or plans runtime valve (grid plan PR 6e)
+DOMAIN_LIVE_VALVE anyharness/crates/anyharness-lib/src/domains/sessions/execution_summary.rs 1 summary reads LiveSessionExecutionSnapshot from live::sessions::handle, not ::model; target = re-export the snapshot as a model shape (grid plan PR 6d)
+DOMAIN_LIVE_VALVE anyharness/crates/anyharness-lib/src/domains/sessions/subagents/hooks.rs 1 subagent hooks hold LiveSessionManager directly; target = sessions runtime valve (grid plan PR 6d)
+DOMAIN_LIVE_VALVE anyharness/crates/anyharness-lib/src/domains/workspaces/access_gate.rs 2 access gate holds live terminals directly (1 use-line + 1 re-import inside the inline cfg(test) mod the engine cannot see); target = workspaces runtime valve (grid plan PR 6b)
+DOMAIN_LIVE_VALVE anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 1 retire preflight holds live terminals directly; target = workspaces runtime valve (grid plan PR 6b)
+DOMAIN_LIVE_VALVE anyharness/crates/anyharness-lib/src/domains/workspaces/setup_runtime.rs 1 workspace setup holds live terminals directly; target = workspaces runtime valve (grid plan PR 6b)
+
+# Rule: live/** never fetches from domain stores/services.
+# 7 files, 18 occurrences.
+LIVE_DOMAIN_STORE_IMPORT anyharness/crates/anyharness-lib/src/live/sessions/background_work/mod.rs 1 import inside the inline cfg(test) mod the engine cannot see; target = none, engine-invisible cfg boundary
+LIVE_DOMAIN_STORE_IMPORT anyharness/crates/anyharness-lib/src/live/sessions/probe.rs 1 probe reaches domain service (resolve_agent_unrouted); target = capability trait or relocation (grid plan PR 7)
+LIVE_DOMAIN_STORE_IMPORT anyharness/crates/anyharness-lib/src/live/terminals/command_runs/pty.rs 5 live/terminals uses the older lock-based doctrine, deliberately retained; ratchet only, do not fix
+LIVE_DOMAIN_STORE_IMPORT anyharness/crates/anyharness-lib/src/live/terminals/command_runs/setup_process.rs 3 live/terminals uses the older lock-based doctrine, deliberately retained; ratchet only, do not fix
+LIVE_DOMAIN_STORE_IMPORT anyharness/crates/anyharness-lib/src/live/terminals/driver/pty.rs 3 live/terminals uses the older lock-based doctrine, deliberately retained; ratchet only, do not fix
+LIVE_DOMAIN_STORE_IMPORT anyharness/crates/anyharness-lib/src/live/terminals/handle.rs 1 live/terminals uses the older lock-based doctrine, deliberately retained; ratchet only, do not fix
+LIVE_DOMAIN_STORE_IMPORT anyharness/crates/anyharness-lib/src/live/terminals/manager.rs 4 live/terminals uses the older lock-based doctrine, deliberately retained; ratchet only, do not fix
+
+# Rule: api/** calls domain facades, never stores.
+# 5 files, 15 occurrences.
+API_STORE_ESCAPE anyharness/crates/anyharness-lib/src/api/http/hosting.rs 2 1 handler constructs WorkspaceStore directly (1 import + 1 ctor); target = facade method (grid plan PR 3)
+API_STORE_ESCAPE anyharness/crates/anyharness-lib/src/api/http/mobility.rs 1 1 handler reaches store directly; target = facade method (grid plan PR 3)
+API_STORE_ESCAPE anyharness/crates/anyharness-lib/src/api/http/sessions_pending.rs 1 1 handler reaches store directly; target = facade method (grid plan PR 3)
+API_STORE_ESCAPE anyharness/crates/anyharness-lib/src/api/http/workspaces_lifecycle.rs 1 1 handler reaches store directly; target = facade method (grid plan PR 3)
+API_STORE_ESCAPE anyharness/crates/anyharness-lib/src/api/http/workspaces_purge.rs 10 1 handler reaches store directly at :65; the other 9 are store setup inside the inline cfg(test) mod the engine cannot see; target = facade method (grid plan PR 3)
+
+# Rule: *_policy.rs files are pure.
+# 1 files, 2 occurrences.
+POLICY_PURITY anyharness/crates/anyharness-lib/src/domains/workspaces/retention_policy.rs 2 misnamed policy: DB-backed store with clock (Utc::now at :44 and :66); target = split into store + pure policy (grid plan PR 8c)
+
+# Rule: SQL in domains/** lives in the store.
+# 9 files, 39 occurrences.
+DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/activity/feeds.rs 1 SQL inside the inline cfg(test) mod the engine cannot see; target = none, engine-invisible cfg boundary
+DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/plans/decision_op.rs 1 SQL inside the inline cfg(test) mod the engine cannot see; target = none, engine-invisible cfg boundary
+DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/plans/service.rs 4 plan service queries plans/plan_interaction_links inline; target = plans store methods (grid plan PR 8b)
+DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/sessions/links/completions.rs 19 session-link completions embed 19 SQL lines outside the store; target = sessions/links store (grid plan PR 8a)
+DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/workflows/workspace_materialization/test_support.rs 1 format!-built COUNT query in a test-support file (not excluded by should_skip); target = none, test fixture
+DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/workspaces/access_gate.rs 1 SQL inside the inline cfg(test) mod the engine cannot see; target = none, engine-invisible cfg boundary
+DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/workspaces/access_store.rs 5 access store is a store by role but not by path; target = rename/move under workspaces/store/ (grid plan PR 8c)
+DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/workspaces/inventory.rs 1 SQL inside the inline cfg(test) mod the engine cannot see; target = none, engine-invisible cfg boundary
+DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/workspaces/retention_policy.rs 6 misnamed policy: DB-backed store with embedded SQL; target = split into store + pure policy (grid plan PR 8c)
+
+# Rule: domains/** use domain twins, not wire contract types.
+# 78 files, 86 occurrences.
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/activity/model.rs 1 1 wire type import below the mapper boundary; target = activity domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/activity/service.rs 1 1 wire type import below the mapper boundary; target = activity domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/activity/session_ports.rs 1 1 wire type import below the mapper boundary; target = activity domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/activity/store.rs 1 1 wire type import below the mapper boundary; target = activity domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/agents/installer/seed/health.rs 1 1 wire type import below the mapper boundary; target = agents domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/agents/installer/seed/mod.rs 1 1 wire type import inside the inline cfg(test) mod the engine cannot see; target = none, engine-invisible cfg boundary
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/agents/installer/seed/types.rs 1 1 wire type import below the mapper boundary; target = agents domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/cowork/mcp/definition.rs 1 1 wire type import below the mapper boundary; target = cowork domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs 1 1 wire type import below the mapper boundary; target = cowork domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/goals/model.rs 1 1 wire type import below the mapper boundary; target = goals domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/goals/runtime.rs 2 2 wire type imports below the mapper boundary (one inside the inline cfg(test) mod); target = goals domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/goals/service.rs 1 1 wire type import below the mapper boundary; target = goals domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/goals/session_ports.rs 1 1 wire type import below the mapper boundary; target = goals domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/goals/store.rs 1 1 wire type import below the mapper boundary; target = goals domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/goals/wire.rs 1 1 wire type import below the mapper boundary; target = goals domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/loops/model.rs 1 1 wire type import below the mapper boundary; target = loops domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs 3 3 wire type imports below the mapper boundary (one inside the inline cfg(test) mod); target = loops domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/loops/schedule.rs 1 1 wire type import below the mapper boundary; target = loops domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/loops/service.rs 1 1 wire type import below the mapper boundary; target = loops domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/loops/session_ports.rs 1 1 wire type import below the mapper boundary; target = loops domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/loops/store.rs 1 1 wire type import below the mapper boundary; target = loops domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/loops/wire.rs 1 1 wire type import below the mapper boundary; target = loops domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/plans/decision_op.rs 1 1 wire type import below the mapper boundary; target = plans domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/plans/document.rs 1 1 wire type import inside the inline cfg(test) mod the engine cannot see; target = none, engine-invisible cfg boundary
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/plans/model.rs 1 1 wire type import below the mapper boundary; target = plans domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/plans/permission_advisor.rs 1 1 wire type import below the mapper boundary; target = plans domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/plans/runtime.rs 1 1 wire type import below the mapper boundary; target = plans domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/plans/service.rs 1 1 wire type import below the mapper boundary; target = plans domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/plans/store.rs 1 1 wire type import below the mapper boundary; target = plans domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/reviews/mcp/definition.rs 1 1 wire type import below the mapper boundary; target = reviews domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/reviews/model.rs 1 1 wire type import below the mapper boundary; target = reviews domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/reviews/runtime/events.rs 1 1 wire type import below the mapper boundary; target = reviews domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/reviews/runtime/feedback.rs 1 1 wire type import below the mapper boundary; target = reviews domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/reviews/runtime/launching.rs 1 1 wire type import below the mapper boundary; target = reviews domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/reviews/runtime/workflow.rs 1 1 wire type import below the mapper boundary; target = reviews domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/reviews/service/detail.rs 1 1 wire type import below the mapper boundary; target = reviews domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/reviews/service/queries.rs 1 1 wire type import below the mapper boundary; target = reviews domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/reviews/session_observer.rs 1 1 wire type import below the mapper boundary; target = reviews domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/reviews/store/feedback.rs 1 1 wire type import below the mapper boundary; target = reviews domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/active_activity_roster.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/active_goals.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/active_loops.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/delegation.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/execution_summary.rs 2 2 wire type imports below the mapper boundary (one inside the inline cfg(test) mod); target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/extensions.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/live_config/controls.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/live_config/mod.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/live_config/raw.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/live_ports.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/mcp_bindings/assembly.rs 2 2 wire type imports below the mapper boundary (one inside the inline cfg(test) mod); target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/mcp_bindings/contract.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/mcp_bindings/product_launch.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/mcp_bindings/summaries.rs 2 2 wire type imports below the mapper boundary (one inside the inline cfg(test) mod); target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/model.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/prompt/capabilities.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/prompt/mod.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/prompt/prepare.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/prompt/provenance.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/replay.rs 2 2 wire type imports below the mapper boundary (one inside the inline cfg(test) mod); target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/runtime/config.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/runtime/creation.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/runtime/interactions.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/runtime/pending_prompts.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/runtime/replay.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/runtime/view.rs 2 2 wire type imports below the mapper boundary (one inside the inline cfg(test) mod); target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/runtime_event.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/store/persisted_payloads.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/subagents/hooks.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/subagents/mcp/definition.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/subagents/transcript.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/workflows/execution.rs 1 1 wire type import below the mapper boundary; target = workflows domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/workspaces/access_model.rs 1 1 wire type import below the mapper boundary; target = workspaces domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/workspaces/creator_context.rs 1 1 wire type import below the mapper boundary; target = workspaces domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/workspaces/retention.rs 1 1 wire type import below the mapper boundary; target = workspaces domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 1 1 wire type import below the mapper boundary; target = workspaces domain twins (grid plan PR 10.x)

--- a/scripts/anyharness_boundaries_allowlist.txt
+++ b/scripts/anyharness_boundaries_allowlist.txt
@@ -9,6 +9,30 @@
 # The checker cannot see `#[cfg(test)]` boundaries inside otherwise-production
 # files, so a handful of counts below cover setup code in inline test mods. Those
 # entries say so in their reason and are not cleanup targets.
+#
+# Known scope limits (deliberate, not bugs to file):
+#
+# - Store-by-role files. A file named `*_store.rs` that sits outside a `store/`
+#   directory (e.g. `domains/workspaces/access_store.rs`) is a store by role but
+#   not by path. `in_domain_store` keys off `store.rs` or a `store/` path segment,
+#   so such a file is policed by DOMAIN_SQL_OUTSIDE_STORE — it reads as
+#   "SQL outside the store" — but it is NOT treated as store code by the
+#   importable-store rules (DOMAIN_STORE_API_IMPORT, DOMAIN_STORE_LIVE_IMPORT).
+#   The fix is to move the file under `store/`, which retires the SQL row and
+#   enrols it in the store rules at the same time; until then the asymmetry stands.
+#
+# - Counts are per-line, so formatting can move them. A rustfmt reflow that splits
+#   or joins an embedded SQL string, or rewraps a long signature, legitimately
+#   changes a count without changing what the code does. That is expected and the
+#   fix is a one-line count edit here, in the same PR as the reflow — not a rule
+#   change. Over-count and stale-count both fail, so the checker will tell you the
+#   new number.
+#
+# - AppState field access is only partly mechanical. API_STORE_ESCAPE catches the
+#   store case (`state.<x>_store`), because a `*_store` field name is a reliable
+#   signal. Reaching any other domain innard through an AppState field — a service
+#   that exposes a store, a runtime that hands back a repository — has no such
+#   name to key off and stays a judgment call for review, not a rule.
 
 DOMAIN_CONTRACT_REQUEST_RESPONSE anyharness/crates/anyharness-lib/src/domains/goals/runtime.rs 1 strict-mirror goal runtime uses SetSessionGoalRequest to drive the sidecar ext method; contract mapping pending move above the API boundary
 DOMAIN_CONTRACT_REQUEST_RESPONSE anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs 1 strict-mirror loop runtime uses SetSessionLoopRequest to drive the sidecar ext method; contract mapping pending move above the API boundary
@@ -29,8 +53,8 @@ DOMAIN_LIVE_VALVE anyharness/crates/anyharness-lib/src/domains/workspaces/retire
 DOMAIN_LIVE_VALVE anyharness/crates/anyharness-lib/src/domains/workspaces/setup_runtime.rs 1 workspace setup holds live terminals directly; target = workspaces runtime valve (grid plan PR 6b)
 
 # Rule: live/** never fetches from domain stores/services.
-# 7 files, 18 occurrences.
-LIVE_DOMAIN_STORE_IMPORT anyharness/crates/anyharness-lib/src/live/sessions/background_work/mod.rs 1 import inside the inline cfg(test) mod the engine cannot see; target = none, engine-invisible cfg boundary
+# 7 files, 19 occurrences.
+LIVE_DOMAIN_STORE_IMPORT anyharness/crates/anyharness-lib/src/live/sessions/background_work/mod.rs 2 both inside the inline cfg(test) mod the engine cannot see (1 import + 1 SessionStore::new in a fixture); target = none, engine-invisible cfg boundary
 LIVE_DOMAIN_STORE_IMPORT anyharness/crates/anyharness-lib/src/live/sessions/probe.rs 1 probe reaches domain service (resolve_agent_unrouted); target = capability trait or relocation (grid plan PR 7)
 LIVE_DOMAIN_STORE_IMPORT anyharness/crates/anyharness-lib/src/live/terminals/command_runs/pty.rs 5 live/terminals uses the older lock-based doctrine, deliberately retained; ratchet only, do not fix
 LIVE_DOMAIN_STORE_IMPORT anyharness/crates/anyharness-lib/src/live/terminals/command_runs/setup_process.rs 3 live/terminals uses the older lock-based doctrine, deliberately retained; ratchet only, do not fix
@@ -39,31 +63,50 @@ LIVE_DOMAIN_STORE_IMPORT anyharness/crates/anyharness-lib/src/live/terminals/han
 LIVE_DOMAIN_STORE_IMPORT anyharness/crates/anyharness-lib/src/live/terminals/manager.rs 4 live/terminals uses the older lock-based doctrine, deliberately retained; ratchet only, do not fix
 
 # Rule: api/** calls domain facades, never stores.
-# 5 files, 15 occurrences.
+# 6 files, 16 occurrences.
+API_STORE_ESCAPE anyharness/crates/anyharness-lib/src/api/http/health.rs 1 health handler reads a domain store reached via the AppState.agent_seed_store field, so no store type appears on the line; target = facade method (grid plan PR 3)
 API_STORE_ESCAPE anyharness/crates/anyharness-lib/src/api/http/hosting.rs 2 1 handler constructs WorkspaceStore directly (1 import + 1 ctor); target = facade method (grid plan PR 3)
 API_STORE_ESCAPE anyharness/crates/anyharness-lib/src/api/http/mobility.rs 1 1 handler reaches store directly; target = facade method (grid plan PR 3)
 API_STORE_ESCAPE anyharness/crates/anyharness-lib/src/api/http/sessions_pending.rs 1 1 handler reaches store directly; target = facade method (grid plan PR 3)
 API_STORE_ESCAPE anyharness/crates/anyharness-lib/src/api/http/workspaces_lifecycle.rs 1 1 handler reaches store directly; target = facade method (grid plan PR 3)
 API_STORE_ESCAPE anyharness/crates/anyharness-lib/src/api/http/workspaces_purge.rs 10 1 handler reaches store directly at :65; the other 9 are store setup inside the inline cfg(test) mod the engine cannot see; target = facade method (grid plan PR 3)
 
-# Rule: *_policy.rs files are pure.
-# 1 files, 2 occurrences.
+# Rule: policy.rs and *_policy.rs files are pure.
+# 2 files, 3 occurrences.
+POLICY_PURITY anyharness/crates/anyharness-lib/src/domains/workflows/control/policy.rs 1 store-holding policy file: imports WorkflowRunStore at :8 and keeps it as a field, so the decision reads the DB instead of taking facts; target = pass the controlling run id in, or rename to a gate (cleanup PR TBD)
 POLICY_PURITY anyharness/crates/anyharness-lib/src/domains/workspaces/retention_policy.rs 2 misnamed policy: DB-backed store with clock (Utc::now at :44 and :66); target = split into store + pure policy (grid plan PR 8c)
 
 # Rule: SQL in domains/** lives in the store.
-# 9 files, 39 occurrences.
+# 9 files, 52 occurrences.
+#
+# Counts rose from 39 with no code change: the rule now also reads the heads of
+# SQL statements split across lines (`"UPDATE sessions` / `SET col = ?1`) and
+# conflict-resolving inserts (`INSERT OR IGNORE INTO`), which the two-keywords-on-
+# one-line patterns could not see. Most of the codebase's UPDATEs are split, so
+# the old numbers understated this debt substantially.
 DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/activity/feeds.rs 1 SQL inside the inline cfg(test) mod the engine cannot see; target = none, engine-invisible cfg boundary
 DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/plans/decision_op.rs 1 SQL inside the inline cfg(test) mod the engine cannot see; target = none, engine-invisible cfg boundary
 DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/plans/service.rs 4 plan service queries plans/plan_interaction_links inline; target = plans store methods (grid plan PR 8b)
-DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/sessions/links/completions.rs 19 session-link completions embed 19 SQL lines outside the store; target = sessions/links store (grid plan PR 8a)
+DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/sessions/links/completions.rs 30 session-link completions embed 30 SQL lines outside the store (19 previously counted + 11 now visible: 4 INSERT OR IGNORE heads, 3 split UPDATE heads, 3 SET clauses, 1 split SELECT head); target = sessions/links store (grid plan PR 8a)
 DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/workflows/workspace_materialization/test_support.rs 1 format!-built COUNT query in a test-support file (not excluded by should_skip); target = none, test fixture
-DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/workspaces/access_gate.rs 1 SQL inside the inline cfg(test) mod the engine cannot see; target = none, engine-invisible cfg boundary
+DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/workspaces/access_gate.rs 2 both inside the inline cfg(test) mod the engine cannot see (1 previously counted + 1 DROP TABLE now visible); target = none, engine-invisible cfg boundary
 DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/workspaces/access_store.rs 5 access store is a store by role but not by path; target = rename/move under workspaces/store/ (grid plan PR 8c)
 DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/workspaces/inventory.rs 1 SQL inside the inline cfg(test) mod the engine cannot see; target = none, engine-invisible cfg boundary
-DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/workspaces/retention_policy.rs 6 misnamed policy: DB-backed store with embedded SQL; target = split into store + pure policy (grid plan PR 8c)
+DOMAIN_SQL_OUTSIDE_STORE anyharness/crates/anyharness-lib/src/domains/workspaces/retention_policy.rs 7 misnamed policy: DB-backed store with embedded SQL (6 previously counted + the split SELECT head at :29 the old patterns missed); target = split into store + pure policy (grid plan PR 8c)
+
+# Rule: the runtime valve holds live/ powers but never re-exports them
+# (DOMAIN_VALVE_LIVE_REEXPORT). Zero occurrences — the rule lands clean and has no
+# seeded debt, so any hit is new code and fails the build.
 
 # Rule: domains/** use domain twins, not wire contract types.
-# 78 files, 86 occurrences.
+# 85 files, 116 occurrences.
+#
+# Counts rose from 78 files / 86 occurrences with no code change: the rule now also
+# reads inline `anyharness_contract::` paths (fn signatures, struct literals,
+# turbofish), which no use-statement declares and the import-only pass could not
+# see. Seven files had no row at all. Reasons below distinguish an "import" (a use
+# statement) from an "inline path".
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/activity/feeds.rs 1 1 inline wire path (:311 FeedKind in a struct literal) inside the inline cfg(test) mod the engine cannot see; target = none, engine-invisible cfg boundary
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/activity/model.rs 1 1 wire type import below the mapper boundary; target = activity domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/activity/service.rs 1 1 wire type import below the mapper boundary; target = activity domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/activity/session_ports.rs 1 1 wire type import below the mapper boundary; target = activity domain twins (grid plan PR 10.x)
@@ -71,8 +114,9 @@ DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/activity/sto
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/agents/installer/seed/health.rs 1 1 wire type import below the mapper boundary; target = agents domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/agents/installer/seed/mod.rs 1 1 wire type import inside the inline cfg(test) mod the engine cannot see; target = none, engine-invisible cfg boundary
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/agents/installer/seed/types.rs 1 1 wire type import below the mapper boundary; target = agents domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/cowork/mcp/calls_helpers.rs 1 1 inline wire path (:31 NormalizedSessionControl fn param) below the mapper boundary; target = cowork domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/cowork/mcp/definition.rs 1 1 wire type import below the mapper boundary; target = cowork domain twins (grid plan PR 10.x)
-DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs 1 1 wire type import below the mapper boundary; target = cowork domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/cowork/runtime.rs 3 1 wire type import + 2 inline wire paths (:120 struct field, :765 return type) below the mapper boundary; target = cowork domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/goals/model.rs 1 1 wire type import below the mapper boundary; target = goals domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/goals/runtime.rs 2 2 wire type imports below the mapper boundary (one inside the inline cfg(test) mod); target = goals domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/goals/service.rs 1 1 wire type import below the mapper boundary; target = goals domain twins (grid plan PR 10.x)
@@ -80,9 +124,9 @@ DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/goals/sessio
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/goals/store.rs 1 1 wire type import below the mapper boundary; target = goals domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/goals/wire.rs 1 1 wire type import below the mapper boundary; target = goals domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/loops/model.rs 1 1 wire type import below the mapper boundary; target = loops domain twins (grid plan PR 10.x)
-DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs 3 3 wire type imports below the mapper boundary (one inside the inline cfg(test) mod); target = loops domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs 7 3 wire type imports (one inside the inline cfg(test) mod) + 4 inline wire paths (:490/:491 match arms, :536 comparison, :754 fn param) below the mapper boundary; target = loops domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/loops/schedule.rs 1 1 wire type import below the mapper boundary; target = loops domain twins (grid plan PR 10.x)
-DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/loops/service.rs 1 1 wire type import below the mapper boundary; target = loops domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/loops/service.rs 2 1 wire type import + 1 inline wire path (:245 struct field) below the mapper boundary; target = loops domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/loops/session_ports.rs 1 1 wire type import below the mapper boundary; target = loops domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/loops/store.rs 1 1 wire type import below the mapper boundary; target = loops domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/loops/wire.rs 1 1 wire type import below the mapper boundary; target = loops domain twins (grid plan PR 10.x)
@@ -90,12 +134,13 @@ DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/plans/decisi
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/plans/document.rs 1 1 wire type import inside the inline cfg(test) mod the engine cannot see; target = none, engine-invisible cfg boundary
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/plans/model.rs 1 1 wire type import below the mapper boundary; target = plans domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/plans/permission_advisor.rs 1 1 wire type import below the mapper boundary; target = plans domain twins (grid plan PR 10.x)
-DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/plans/runtime.rs 1 1 wire type import below the mapper boundary; target = plans domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/plans/runtime.rs 4 1 wire type import + 3 inline wire paths building an OriginContext (:374-:376) inside the inline cfg(test) mod the engine cannot see; target = plans domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/plans/service.rs 1 1 wire type import below the mapper boundary; target = plans domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/plans/store.rs 1 1 wire type import below the mapper boundary; target = plans domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/reviews/mcp/calls.rs 1 1 inline wire path (:98 ReviewRunDetail fn param) below the mapper boundary; target = reviews domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/reviews/mcp/definition.rs 1 1 wire type import below the mapper boundary; target = reviews domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/reviews/model.rs 1 1 wire type import below the mapper boundary; target = reviews domain twins (grid plan PR 10.x)
-DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/reviews/runtime/events.rs 1 1 wire type import below the mapper boundary; target = reviews domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/reviews/runtime/events.rs 2 1 wire type import + 1 inline wire path (:110 match pattern) below the mapper boundary; target = reviews domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/reviews/runtime/feedback.rs 1 1 wire type import below the mapper boundary; target = reviews domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/reviews/runtime/launching.rs 1 1 wire type import below the mapper boundary; target = reviews domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/reviews/runtime/workflow.rs 1 1 wire type import below the mapper boundary; target = reviews domain twins (grid plan PR 10.x)
@@ -125,7 +170,7 @@ DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/pro
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/replay.rs 2 2 wire type imports below the mapper boundary (one inside the inline cfg(test) mod); target = sessions domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/runtime/config.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/runtime/creation.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
-DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork.rs 2 1 wire type import + 1 inline wire path (:20 fn param) below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/runtime/interactions.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/runtime/pending_prompts.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
@@ -133,12 +178,16 @@ DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/run
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/runtime/replay.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/runtime/view.rs 2 2 wire type imports below the mapper boundary (one inside the inline cfg(test) mod); target = sessions domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/runtime_event.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/service/config.rs 3 3 inline wire paths (SessionLiveConfigSnapshot in return types at :8/:35 and a HashMap value at :22) below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/store/events.rs 4 4 inline wire paths (SessionEvent/SessionEventEnvelope at :53/:55/:73 and a turbofish deserialize at :527) below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/store/persisted_payloads.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/subagents/hooks.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/subagents/mcp/calls_helpers.rs 1 1 inline wire path (:43 NormalizedSessionControl fn param) below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/subagents/mcp/definition.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/sessions/subagents/transcript.rs 1 1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/workflows/execution.rs 1 1 wire type import below the mapper boundary; target = workflows domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/workspaces/access_model.rs 1 1 wire type import below the mapper boundary; target = workspaces domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/workspaces/creator_context.rs 1 1 wire type import below the mapper boundary; target = workspaces domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/workspaces/purge.rs 1 1 inline wire path (:361 WorkspaceRetireBlocker slice fn param) below the mapper boundary; target = workspaces domain twins (grid plan PR 10.x)
 DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/workspaces/retention.rs 1 1 wire type import below the mapper boundary; target = workspaces domain twins (grid plan PR 10.x)
-DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 1 1 wire type import below the mapper boundary; target = workspaces domain twins (grid plan PR 10.x)
+DOMAIN_CONTRACT_IMPORT anyharness/crates/anyharness-lib/src/domains/workspaces/retire_preflight.rs 7 1 wire type import + 6 inline wire paths mapping git operations (:557 return type, :560-:572 variants) below the mapper boundary; target = workspaces domain twins (grid plan PR 10.x)

--- a/scripts/anyharness_boundaries_allowlist.txt
+++ b/scripts/anyharness_boundaries_allowlist.txt
@@ -33,6 +33,19 @@
 #   signal. Reaching any other domain innard through an AppState field — a service
 #   that exposes a store, a runtime that hands back a repository — has no such
 #   name to key off and stays a judgment call for review, not a rule.
+#   The store pattern is also bound to the identifier `state`, which is how every
+#   api/** handler param is spelled today; `app_state.foo_store` or a rebound clone
+#   evades it, and that too is review's job.
+#
+# - SQL detection is lexical, so an uppercase SQL verb heading an ordinary string
+#   matches. `bail!("UPDATE failed for {id}")` is indistinguishable from
+#   `"UPDATE sessions SET .."` without parsing Rust, so a hit like that is a
+#   seedable false positive, not a defect — say so in the reason and move on.
+#   Two narrower cases are handled: the exact literal `"SELECT"` (a keyword
+#   constant or serde rename) is excluded, while `"SELECT " + cols` still counts.
+#   SQL quoted inside a `/* .. */` block comment also counts, because comment
+#   stripping only understands `//`. All of these shapes are pinned by unit tests
+#   so the limitation stays visible instead of drifting.
 
 DOMAIN_CONTRACT_REQUEST_RESPONSE anyharness/crates/anyharness-lib/src/domains/goals/runtime.rs 1 strict-mirror goal runtime uses SetSessionGoalRequest to drive the sidecar ext method; contract mapping pending move above the API boundary
 DOMAIN_CONTRACT_REQUEST_RESPONSE anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs 1 strict-mirror loop runtime uses SetSessionLoopRequest to drive the sidecar ext method; contract mapping pending move above the API boundary

--- a/scripts/anyharness_boundaries_allowlist.txt
+++ b/scripts/anyharness_boundaries_allowlist.txt
@@ -64,7 +64,7 @@ LIVE_DOMAIN_STORE_IMPORT anyharness/crates/anyharness-lib/src/live/terminals/man
 
 # Rule: api/** calls domain facades, never stores.
 # 6 files, 16 occurrences.
-API_STORE_ESCAPE anyharness/crates/anyharness-lib/src/api/http/health.rs 1 health handler reads a domain store reached via the AppState.agent_seed_store field, so no store type appears on the line; target = facade method (grid plan PR 3)
+API_STORE_ESCAPE anyharness/crates/anyharness-lib/src/api/http/health.rs 1 in-memory health snapshot named like a store (Arc<RwLock<AgentSeedHealth>>, not SQL); matches the state.*_store pattern; benign - seeded rather than special-cased to keep the pattern simple
 API_STORE_ESCAPE anyharness/crates/anyharness-lib/src/api/http/hosting.rs 2 1 handler constructs WorkspaceStore directly (1 import + 1 ctor); target = facade method (grid plan PR 3)
 API_STORE_ESCAPE anyharness/crates/anyharness-lib/src/api/http/mobility.rs 1 1 handler reaches store directly; target = facade method (grid plan PR 3)
 API_STORE_ESCAPE anyharness/crates/anyharness-lib/src/api/http/sessions_pending.rs 1 1 handler reaches store directly; target = facade method (grid plan PR 3)

--- a/scripts/check_anyharness_boundaries.py
+++ b/scripts/check_anyharness_boundaries.py
@@ -72,9 +72,12 @@ SESSION_EVENT_SINK_PREFIXES = (
     "anyharness/crates/anyharness-lib/src/live/sessions/event_sink/",
 )
 TOKEN_RE = re.compile(r"r#[A-Za-z_][A-Za-z0-9_]*|[A-Za-z_][A-Za-z0-9_]*|::|[{}(),;*]")
-USE_START_RE = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?use\s+")
+# `\b` rather than `\s+` after `use`: a statement whose path is pushed to the next
+# line leaves `use` (or `pub use`) alone on the head line, and demanding trailing
+# whitespace made such a statement invisible to the whole import pass.
+USE_START_RE = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?use\b")
 # A re-export specifically, not a private import: `pub use ..`, `pub(crate) use ..`.
-PUB_USE_START_RE = re.compile(r"^\s*pub(?:\([^)]*\))?\s+use\s+")
+PUB_USE_START_RE = re.compile(r"^\s*pub(?:\([^)]*\))?\s+use\b")
 SESSION_COMMAND_USE_RE = re.compile(
     r"(?:\bSessionCommand|crate::live::sessions::actor::command::SessionCommand)\s*::"
 )
@@ -122,6 +125,10 @@ STORE_CONSTRUCTOR_RE = re.compile(r"\b[A-Za-z][A-Za-z0-9_]*Store::new\b")
 # today's single match is a benign false positive, seeded in the allowlist rather
 # than special-cased: the field-name shape is the durable signal we want to hold,
 # and a real `*_store` field added later would be caught for the right reason.
+# The pattern is bound to the identifier `state`, which every one of api/**'s
+# handler params is spelled as today (`State(state)`); an `app_state.foo_store` or
+# a rebound clone evades it. That is judgment territory, like the rest of the
+# AppState-field surface noted in the allowlist's Known scope limits stanza.
 APP_STATE_STORE_FIELD_RE = re.compile(r"\bstate\.[a-z_]*_store\b")
 # Inline `anyharness_contract::` path uses (fn signatures, struct literals,
 # turbofish) that no use-statement declares. Mirrors DOMAIN_LIVE_VALVE's
@@ -136,19 +143,29 @@ POLICY_IMPURITY_RES = (
     re.compile(r"\brand::"),
 )
 # Calibrated against domains/**: these patterns hit every embedded-SQL line found
-# outside store code with zero false positives (no log strings, no identifiers
-# that merely contain a keyword).
+# outside store code, with no false positives in the current tree.
 #
 # The first six are whole-statement shapes that fit on one line. The next three
 # are keyword-anchored heads for the far more common case of SQL that rustfmt (or
 # the author) split across lines: `"UPDATE sessions` / `SET col = ?1` /
 # `WHERE id = ?1` each land on their own line, so a rule that demanded two
 # keywords together saw none of them. Keeping the clause heads uppercase-only and
-# anchored to a line start or an opening quote is what keeps prose out: English
-# never writes a bare capitalised `SELECT` at the head of a line, and a lowercase
-# "select the agent" comment or log string cannot match. `UPDATE` additionally
-# requires a lowercase table identifier after it, so `DO UPDATE SET` fragments and
-# prose like "run UPDATE both stamps" do not count twice or at all.
+# anchored to a line start or an opening quote is what keeps most prose out: a
+# lowercase "select the agent" comment or log string cannot match, and `UPDATE`
+# additionally requires a lowercase table identifier after it, so `DO UPDATE SET`
+# fragments do not count twice.
+#
+# Known limits, accepted rather than chased (pinned by unit tests so they stay
+# visible):
+#   * An uppercase SQL verb heading a non-SQL string still matches --
+#     `bail!("UPDATE failed for {id}")` is lexically indistinguishable from
+#     `"UPDATE sessions SET .."`. No regex can separate them; a match here is a
+#     seedable false positive, not a defect.
+#   * `SELECT` excludes only the exact literal `"SELECT"` (a keyword constant or
+#     a serde rename), via `(?!")`. A built fragment `"SELECT " + cols` must keep
+#     matching, so the exclusion cannot extend to a quote after whitespace.
+#   * Block comments are scanned as code: strip_line_comment only understands
+#     `//`, so SQL quoted inside `/* .. */` counts.
 SQL_RES = (
     re.compile(r"\bINSERT INTO\b"),
     re.compile(r"\bSELECT\b.*\bFROM\b"),
@@ -159,7 +176,7 @@ SQL_RES = (
     re.compile(r"\bparams!|\brusqlite::params\b"),
     # Split-statement heads: the write verb and its table on one line, the clauses
     # on the next.
-    re.compile(r'(?:^|")\s*SELECT\b'),
+    re.compile(r'(?:^|")\s*SELECT\b(?!")'),
     re.compile(r'(?:^|")\s*UPDATE\s+[a-z_]'),
     re.compile(r"^\s*SET\b"),
     # Conflict-resolving inserts and drops, which the two bare-verb patterns above
@@ -454,6 +471,22 @@ def iter_use_statements(path: Path) -> list[tuple[int, list[str]]]:
             start_line = 0
 
     return statements
+
+
+def use_statement_linenos(path: Path) -> set[int]:
+    """Every line number a use statement occupies, head and continuations alike.
+
+    The line pass must not re-flag text the import pass already parsed. Testing
+    each line for a `use` prefix is not enough: in a root-brace group
+    (`use {\\n    anyharness_contract::v1::Foo,\\n};`) the interesting leaf sits on
+    a continuation line that carries no prefix, so the prefix test let the line
+    pass fire there while the import pass fired at the head — one import counted
+    twice. Skipping the statement's whole line span fixes that by construction.
+    """
+    covered: set[int] = set()
+    for start_line, lines in iter_use_statements(path):
+        covered.update(range(start_line, start_line + len(lines)))
+    return covered
 
 
 def tokenize_use_statement(start_line: int, lines: list[str]) -> list[Token]:
@@ -925,8 +958,12 @@ def check_domain_valve_live_reexport(
 
     One violation per re-exporting statement, not per leaf: the statement is the
     laundering act, and a group `pub use crate::live::sessions::{A, B}` is one act.
+
+    The `pub use` prefix is matched against the statement's joined text, not just
+    its first line: `pub use\\n    crate::live::sessions::Handle;` is the same
+    re-export, and testing only line one let that spelling launder silently.
     """
-    if not PUB_USE_START_RE.search(lines[0]):
+    if not PUB_USE_START_RE.search(" ".join(line.strip() for line in lines)):
         return
     add_if(
         violations,
@@ -954,14 +991,18 @@ def check_line_patterns(violations: list[Violation], path: Path) -> None:
     # the same law, just the other half of the surface.
     check_live_store_line = is_under(rel, LIVE_PREFIX)
     check_contract_inline = in_domains
+    # Lines the import pass already owns. Computed once per file, for the whole
+    # span of each statement rather than just its head line -- see
+    # use_statement_linenos.
+    import_pass_linenos = use_statement_linenos(path)
 
     for lineno, raw_line in enumerate(path.read_text().splitlines(), start=1):
         line = strip_line_comment(raw_line)
         is_use_line = line.lstrip().startswith("use ")
-        # The new rules also share the use-statement pass, so they must not
-        # re-count `pub use` lines that `is_use_line` misses.
-        starts_use_statement = USE_START_RE.search(line) is not None
-        if check_live_valve and not starts_use_statement:
+        # The rules that share the use-statement pass must not re-count any line
+        # of a use statement, head or continuation.
+        inside_use_statement = lineno in import_pass_linenos
+        if check_live_valve and not inside_use_statement:
             add_if(
                 violations,
                 has_non_model_live_use(line),
@@ -970,7 +1011,7 @@ def check_line_patterns(violations: list[Violation], path: Path) -> None:
                 lineno,
                 DOMAIN_LIVE_VALVE_MESSAGE,
             )
-        if check_api_store_escape and not starts_use_statement:
+        if check_api_store_escape and not inside_use_statement:
             add_if(
                 violations,
                 STORE_METHOD_CALL_RE.search(line) is not None
@@ -981,7 +1022,7 @@ def check_line_patterns(violations: list[Violation], path: Path) -> None:
                 lineno,
                 API_STORE_ESCAPE_MESSAGE,
             )
-        if check_live_store_line and not starts_use_statement:
+        if check_live_store_line and not inside_use_statement:
             add_if(
                 violations,
                 STORE_METHOD_CALL_RE.search(line) is not None
@@ -991,7 +1032,7 @@ def check_line_patterns(violations: list[Violation], path: Path) -> None:
                 lineno,
                 LIVE_DOMAIN_STORE_MESSAGE,
             )
-        if check_contract_inline and not starts_use_statement:
+        if check_contract_inline and not inside_use_statement:
             add_if(
                 violations,
                 CONTRACT_INLINE_PATH_RE.search(line) is not None,
@@ -1000,7 +1041,7 @@ def check_line_patterns(violations: list[Violation], path: Path) -> None:
                 lineno,
                 DOMAIN_CONTRACT_IMPORT_MESSAGE,
             )
-        if check_policy_purity and not starts_use_statement:
+        if check_policy_purity and not inside_use_statement:
             add_if(
                 violations,
                 any(pattern.search(line) is not None for pattern in POLICY_IMPURITY_RES),

--- a/scripts/check_anyharness_boundaries.py
+++ b/scripts/check_anyharness_boundaries.py
@@ -3,14 +3,46 @@
 from __future__ import annotations
 
 from collections import Counter, defaultdict
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 import re
 import sys
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-LIB_SRC = REPO_ROOT / "anyharness" / "crates" / "anyharness-lib" / "src"
+LIB_SRC_RELATIVE = ("anyharness", "crates", "anyharness-lib", "src")
+LIB_SRC = REPO_ROOT.joinpath(*LIB_SRC_RELATIVE)
 ALLOWLIST_PATH = REPO_ROOT / "scripts" / "anyharness_boundaries_allowlist.txt"
+
+# Tests point the scan at a fabricated tree via `scan_root(...)` (or by calling
+# `check_file`/`collect_violations` with an explicit root). When no override is
+# active the module constants win, so CLI behaviour is unchanged.
+_ROOT_OVERRIDE: Path | None = None
+
+
+def repo_root() -> Path:
+    return _ROOT_OVERRIDE if _ROOT_OVERRIDE is not None else REPO_ROOT
+
+
+def lib_src() -> Path:
+    if _ROOT_OVERRIDE is not None:
+        return _ROOT_OVERRIDE.joinpath(*LIB_SRC_RELATIVE)
+    return LIB_SRC
+
+
+@contextmanager
+def scan_root(root: Path | None):
+    """Temporarily treat `root` as the repository root for path classification."""
+    global _ROOT_OVERRIDE
+    if root is None:
+        yield
+        return
+    previous = _ROOT_OVERRIDE
+    _ROOT_OVERRIDE = Path(root).resolve()
+    try:
+        yield
+    finally:
+        _ROOT_OVERRIDE = previous
 
 HTTP_TRANSPORT_ROOTS = {"axum", "headers", "http", "http_body", "tower", "utoipa"}
 PRODUCT_DOMAIN_ROOTS = {"domains"}
@@ -50,6 +82,89 @@ CONTRACT_REQUEST_RESPONSE_RE = re.compile(
     r"([A-Z][A-Za-z0-9_]*(?:Request|Response))\b"
 )
 
+LIB_SRC_PREFIX = "anyharness/crates/anyharness-lib/src/"
+API_PREFIX = f"{LIB_SRC_PREFIX}api/"
+DOMAINS_PREFIX = f"{LIB_SRC_PREFIX}domains/"
+LIVE_PREFIX = f"{LIB_SRC_PREFIX}live/"
+
+# The domain runtime valve: the only files in a domain allowed to hold live/
+# handles, managers and services. Everything else takes facts, not machinery.
+DOMAIN_RUNTIME_VALVE_FILES = {"runtime.rs", "live_ports.rs"}
+DOMAIN_RUNTIME_VALVE_DIR = "runtime"
+# Domains legally implement live-defined observer traits, which means importing
+# the live model shapes those traits speak in (`crate::live::<area>::model::..`).
+# That inversion is sanctioned; only "power" imports are valved.
+LIVE_MODEL_SEGMENT = "model"
+STORE_SEGMENTS = {"store"}
+STORE_OR_SERVICE_SEGMENTS = {"store", "service"}
+DOMAIN_STORE_FORBIDDEN_ROOTS = {"acp", "live"}
+POLICY_FILE_SUFFIX = "_policy.rs"
+CONTRACT_CRATE_ROOT = "anyharness_contract"
+
+# Inline `crate::live::<area>::<second>` path uses (fn param types, turbofish,
+# fully-qualified calls). `<second>` lets the model-shape exception apply to
+# inline uses exactly as it does to use-statements.
+LIVE_INLINE_PATH_RE = re.compile(
+    r"\bcrate::live::(?P<area>[A-Za-z_][A-Za-z0-9_]*)"
+    r"(?:::(?P<second>[A-Za-z_][A-Za-z0-9_]*))?"
+)
+STORE_METHOD_CALL_RE = re.compile(r"\.store\(\)")
+STORE_CONSTRUCTOR_RE = re.compile(r"\b[A-Za-z][A-Za-z0-9_]*Store::new\b")
+POLICY_IMPURITY_RES = (
+    re.compile(r"\bUtc::now\b"),
+    re.compile(r"\bLocal::now\b"),
+    re.compile(r"\bSystemTime::now\b"),
+    re.compile(r"\bInstant::now\b"),
+    re.compile(r"\bUuid::new_v4\b"),
+    re.compile(r"\brand::"),
+)
+# Calibrated against domains/**: these seven patterns hit every embedded-SQL
+# line found outside store code with zero false positives (no log strings, no
+# identifiers that merely contain a keyword).
+SQL_RES = (
+    re.compile(r"\bINSERT INTO\b"),
+    re.compile(r"\bSELECT\b.*\bFROM\b"),
+    re.compile(r"\bON CONFLICT\b"),
+    re.compile(r"\bCREATE TABLE\b"),
+    re.compile(r"\bDELETE FROM\b"),
+    re.compile(r"\bUPDATE\b.*\bSET\b"),
+    re.compile(r"\bparams!|\brusqlite::params\b"),
+)
+
+DOMAIN_LIVE_VALVE_MESSAGE = (
+    "domain code may reach live/ only through the domain's runtime valve "
+    "(runtime.rs, runtime/**, live_ports.rs) — promote this use case to the "
+    "runtime; see anyharness-structure.md"
+)
+LIVE_DOMAIN_STORE_MESSAGE = (
+    "live/ never fetches — pass facts in the launch bundle or add a capability "
+    "trait wired in app/"
+)
+API_STORE_ESCAPE_MESSAGE = (
+    "handlers call domain facades, never stores — add a facade method; "
+    "see anyharness-structure.md"
+)
+POLICY_PURITY_MESSAGE = (
+    "policy files are pure: facts in, decisions out — no clock, no ids, no "
+    "store; mint in execute"
+)
+DOMAIN_SQL_OUTSIDE_STORE_MESSAGE = (
+    "SQL belongs in the domain's store — move this query into store.rs/store/**; "
+    "see anyharness-structure.md"
+)
+DOMAIN_CONTRACT_IMPORT_MESSAGE = (
+    "domain code must not import wire contract types below the API mapper "
+    "boundary — use a domain twin; see anyharness-structure.md"
+)
+
+
+def path_relative_to_root(path: Path) -> str:
+    """Repo-relative posix path; already-relative paths pass through unchanged."""
+    try:
+        return path.relative_to(repo_root()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
 
 @dataclass(frozen=True)
 class Violation:
@@ -58,9 +173,14 @@ class Violation:
     lineno: int
     message: str
 
+    def __post_init__(self) -> None:
+        # Resolved at construction so a violation keeps its reported path after a
+        # `scan_root(...)` override is unwound.
+        object.__setattr__(self, "_relative_path", path_relative_to_root(self.path))
+
     @property
     def relative_path(self) -> str:
-        return self.path.relative_to(REPO_ROOT).as_posix()
+        return self._relative_path  # type: ignore[attr-defined]
 
     def format(self) -> str:
         return f"{self.relative_path}:{self.lineno}: [{self.rule_id}] {self.message}"
@@ -125,7 +245,7 @@ def strip_line_comment(line: str) -> str:
 
 
 def relative(path: Path) -> str:
-    return path.relative_to(REPO_ROOT).as_posix()
+    return path_relative_to_root(path)
 
 
 def is_under(relative_path: str, prefix: str) -> bool:
@@ -195,16 +315,75 @@ def in_session_event_sink(relative_path: str) -> bool:
     return any(is_under(relative_path, prefix) for prefix in SESSION_EVENT_SINK_PREFIXES)
 
 
+def domain_relative_parts(relative_path: str) -> tuple[str, ...]:
+    """The path parts below `domains/`, e.g. ('sessions', 'runtime', 'fork.rs')."""
+    if not is_under(relative_path, DOMAINS_PREFIX):
+        return ()
+    return tuple(relative_path[len(DOMAINS_PREFIX) :].split("/"))
+
+
+def in_domain_runtime_valve(relative_path: str) -> bool:
+    """Files allowed to hold live/ machinery: runtime.rs, runtime/**, live_ports.rs."""
+    parts = domain_relative_parts(relative_path)
+    if not parts:
+        return False
+    if parts[-1] in DOMAIN_RUNTIME_VALVE_FILES:
+        return True
+    return DOMAIN_RUNTIME_VALVE_DIR in parts[:-1]
+
+
+def is_live_model_import(import_path: ImportPath) -> bool:
+    """crate::live::<area>::model::.. — the sanctioned observer-trait inversion."""
+    return (
+        len(import_path.parts) >= 4
+        and import_path.parts[0] == "crate"
+        and import_path.parts[1] == "live"
+        and import_path.parts[3] == LIVE_MODEL_SEGMENT
+    )
+
+
+def in_domain_store(relative_path: str) -> bool:
+    """domains/<d>/**/store/** or a store.rs sitting inside a domain."""
+    parts = domain_relative_parts(relative_path)
+    if len(parts) < 2:
+        return False
+    if parts[-1] == "store.rs":
+        return True
+    return "store" in parts[:-1]
+
+
+def is_policy_file(relative_path: str) -> bool:
+    return bool(domain_relative_parts(relative_path)) and relative_path.endswith(
+        POLICY_FILE_SUFFIX
+    )
+
+
+def has_segment(import_path: ImportPath, segments: set[str]) -> bool:
+    return any(part in segments for part in import_path.parts)
+
+
+def is_domain_store_or_service_import(import_path: ImportPath) -> bool:
+    return import_path.starts_with_crate("domains") and has_segment(
+        import_path, STORE_OR_SERVICE_SEGMENTS
+    )
+
+
+def is_domain_store_import(import_path: ImportPath) -> bool:
+    return import_path.starts_with_crate("domains") and has_segment(
+        import_path, STORE_SEGMENTS
+    )
+
+
 def should_skip(path: Path) -> bool:
     if path.name.endswith("_tests.rs") or path.name == "tests.rs":
         return True
-    return any(part == "tests" for part in path.relative_to(LIB_SRC).parts)
+    return any(part == "tests" for part in path.relative_to(lib_src()).parts)
 
 
 def iter_anyharness_files() -> list[Path]:
     return [
         path
-        for path in sorted(LIB_SRC.rglob("*.rs"))
+        for path in sorted(lib_src().rglob("*.rs"))
         if path.is_file() and not should_skip(path)
     ]
 
@@ -459,26 +638,28 @@ def check_integrations_import(
     )
 
 
-def check_session_store_import(
+def check_domain_store_import(
     violations: list[Violation],
     path: Path,
     import_path: ImportPath,
 ) -> None:
+    """Generalized from the sessions-only rule: every domain store is a leaf."""
     add_if(
         violations,
         import_path.starts_with_crate("api"),
-        "SESSION_STORE_API_IMPORT",
+        "DOMAIN_STORE_API_IMPORT",
         path,
         import_path.crate_root_line,
-        "domains/sessions/store/** must not import api/**",
+        "domain store code must not import api/** — stores are persistence leaves",
     )
     add_if(
         violations,
-        import_path.crate_root in LIVE_RUNTIME_ROOTS,
-        "SESSION_STORE_LIVE_IMPORT",
+        import_path.crate_root in DOMAIN_STORE_FORBIDDEN_ROOTS,
+        "DOMAIN_STORE_LIVE_IMPORT",
         path,
         import_path.crate_root_line,
-        "domains/sessions/store/** must not import live runtime modules",
+        "domain store code must not import live/acp runtime modules — stores are "
+        "persistence leaves",
     )
 
 
@@ -595,16 +776,146 @@ def check_domain_contract_import(
     )
 
 
+def check_domain_live_valve_import(
+    violations: list[Violation],
+    path: Path,
+    import_path: ImportPath,
+) -> None:
+    add_if(
+        violations,
+        import_path.crate_root == "live" and not is_live_model_import(import_path),
+        "DOMAIN_LIVE_VALVE",
+        path,
+        import_path.crate_root_line,
+        DOMAIN_LIVE_VALVE_MESSAGE,
+    )
+
+
+def check_live_domain_store_import(
+    violations: list[Violation],
+    path: Path,
+    import_path: ImportPath,
+) -> None:
+    add_if(
+        violations,
+        is_domain_store_or_service_import(import_path),
+        "LIVE_DOMAIN_STORE_IMPORT",
+        path,
+        import_path.crate_root_line,
+        LIVE_DOMAIN_STORE_MESSAGE,
+    )
+
+
+def check_api_store_escape_import(
+    violations: list[Violation],
+    path: Path,
+    import_path: ImportPath,
+) -> None:
+    add_if(
+        violations,
+        is_domain_store_import(import_path),
+        "API_STORE_ESCAPE",
+        path,
+        import_path.crate_root_line,
+        API_STORE_ESCAPE_MESSAGE,
+    )
+
+
+def check_policy_purity_import(
+    violations: list[Violation],
+    path: Path,
+    import_path: ImportPath,
+) -> None:
+    add_if(
+        violations,
+        has_segment(import_path, STORE_SEGMENTS) or import_path.crate_root == "adapters",
+        "POLICY_PURITY",
+        path,
+        import_path.crate_root_line,
+        POLICY_PURITY_MESSAGE,
+    )
+
+
+def check_domain_contract_crate_import(
+    violations: list[Violation],
+    path: Path,
+    start_line: int,
+    import_paths: list[ImportPath],
+) -> None:
+    """One violation per use-statement, matching the engine's import granularity."""
+    add_if(
+        violations,
+        any(import_path.root == CONTRACT_CRATE_ROOT for import_path in import_paths),
+        "DOMAIN_CONTRACT_IMPORT",
+        path,
+        start_line,
+        DOMAIN_CONTRACT_IMPORT_MESSAGE,
+    )
+
+
+def has_non_model_live_use(line: str) -> bool:
+    """An inline `crate::live::..` path use that is not a live model shape."""
+    for match in LIVE_INLINE_PATH_RE.finditer(line):
+        if match.group("second") != LIVE_MODEL_SEGMENT:
+            return True
+    return False
+
+
 def check_line_patterns(violations: list[Violation], path: Path) -> None:
     rel = relative(path)
     allow_session_private = in_live_sessions(rel)
     allow_command_tx = in_command_tx_allowed_path(rel)
     allow_app_state = in_api_or_app(rel)
     check_contract_types = is_domain_path(rel)
+    in_domains = is_under(rel, DOMAINS_PREFIX)
+    check_live_valve = in_domains and not in_domain_runtime_valve(rel)
+    check_api_store_escape = is_under(rel, API_PREFIX)
+    check_policy_purity = is_policy_file(rel)
+    check_domain_sql = in_domains and not in_domain_store(rel)
 
     for lineno, raw_line in enumerate(path.read_text().splitlines(), start=1):
         line = strip_line_comment(raw_line)
         is_use_line = line.lstrip().startswith("use ")
+        # The new rules also share the use-statement pass, so they must not
+        # re-count `pub use` lines that `is_use_line` misses.
+        starts_use_statement = USE_START_RE.search(line) is not None
+        if check_live_valve and not starts_use_statement:
+            add_if(
+                violations,
+                has_non_model_live_use(line),
+                "DOMAIN_LIVE_VALVE",
+                path,
+                lineno,
+                DOMAIN_LIVE_VALVE_MESSAGE,
+            )
+        if check_api_store_escape and not starts_use_statement:
+            add_if(
+                violations,
+                STORE_METHOD_CALL_RE.search(line) is not None
+                or STORE_CONSTRUCTOR_RE.search(line) is not None,
+                "API_STORE_ESCAPE",
+                path,
+                lineno,
+                API_STORE_ESCAPE_MESSAGE,
+            )
+        if check_policy_purity and not starts_use_statement:
+            add_if(
+                violations,
+                any(pattern.search(line) is not None for pattern in POLICY_IMPURITY_RES),
+                "POLICY_PURITY",
+                path,
+                lineno,
+                POLICY_PURITY_MESSAGE,
+            )
+        if check_domain_sql:
+            add_if(
+                violations,
+                any(pattern.search(line) is not None for pattern in SQL_RES),
+                "DOMAIN_SQL_OUTSIDE_STORE",
+                path,
+                lineno,
+                DOMAIN_SQL_OUTSIDE_STORE_MESSAGE,
+            )
         add_if(
             violations,
             not allow_session_private and SESSION_COMMAND_USE_RE.search(line) is not None,
@@ -640,37 +951,50 @@ def check_line_patterns(violations: list[Violation], path: Path) -> None:
             )
 
 
-def check_file(path: Path) -> list[Violation]:
+def check_file(path: Path, root: Path | None = None) -> list[Violation]:
+    with scan_root(root):
+        return _check_file(path)
+
+
+def _check_file(path: Path) -> list[Violation]:
     rel = relative(path)
     violations: list[Violation] = []
-    in_api = is_under(rel, "anyharness/crates/anyharness-lib/src/api/")
-    in_domains = is_under(rel, "anyharness/crates/anyharness-lib/src/domains/")
+    in_api = is_under(rel, API_PREFIX)
+    in_domains = is_under(rel, DOMAINS_PREFIX)
+    in_live = is_under(rel, LIVE_PREFIX)
     in_core_domain = is_core_domain_path(rel)
-    in_adapters = is_under(rel, "anyharness/crates/anyharness-lib/src/adapters/")
-    in_integrations = is_under(rel, "anyharness/crates/anyharness-lib/src/integrations/")
-    in_session_store = is_under(
-        rel,
-        "anyharness/crates/anyharness-lib/src/domains/sessions/store/",
-    )
+    in_adapters = is_under(rel, f"{LIB_SRC_PREFIX}adapters/")
+    in_integrations = is_under(rel, f"{LIB_SRC_PREFIX}integrations/")
+    in_domain_store_leaf = in_domain_store(rel)
     in_event_sink = in_session_event_sink(rel)
-    in_persistence = is_under(rel, "anyharness/crates/anyharness-lib/src/persistence/")
+    in_persistence = is_under(rel, f"{LIB_SRC_PREFIX}persistence/")
+    in_live_valve = in_domains and in_domain_runtime_valve(rel)
+    in_policy = is_policy_file(rel)
 
     for start_line, lines in iter_use_statements(path):
-        for import_path in parse_use_paths(start_line, lines):
+        import_paths = parse_use_paths(start_line, lines)
+        for import_path in import_paths:
             if not import_path.parts:
                 continue
             if in_api:
                 check_api_import(violations, path, import_path)
+                check_api_store_escape_import(violations, path, import_path)
             if in_domains:
                 check_domains_import(violations, path, import_path)
+                if not in_live_valve:
+                    check_domain_live_valve_import(violations, path, import_path)
+            if in_live:
+                check_live_domain_store_import(violations, path, import_path)
+            if in_policy:
+                check_policy_purity_import(violations, path, import_path)
             if in_core_domain:
                 check_core_domain_import(violations, path, import_path)
             if in_adapters:
                 check_adapters_import(violations, path, import_path)
             if in_integrations:
                 check_integrations_import(violations, path, import_path)
-            if in_session_store:
-                check_session_store_import(violations, path, import_path)
+            if in_domain_store_leaf:
+                check_domain_store_import(violations, path, import_path)
             if in_event_sink:
                 check_event_sink_import(violations, path, import_path)
             if in_persistence:
@@ -678,50 +1002,49 @@ def check_file(path: Path) -> list[Violation]:
             check_live_session_private_import(violations, path, import_path)
             check_app_state_import(violations, path, import_path)
             check_domain_contract_import(violations, path, import_path)
+        if in_domains:
+            check_domain_contract_crate_import(violations, path, start_line, import_paths)
 
     check_line_patterns(violations, path)
     return violations
 
 
-def load_allowlist() -> dict[tuple[str, str], AllowlistEntry]:
-    if not ALLOWLIST_PATH.exists():
+def load_allowlist(allowlist_path: Path | None = None) -> dict[tuple[str, str], AllowlistEntry]:
+    path = ALLOWLIST_PATH if allowlist_path is None else Path(allowlist_path)
+    if not path.exists():
         return {}
+    try:
+        label = path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        label = path.as_posix()
     entries: dict[tuple[str, str], AllowlistEntry] = {}
-    for lineno, raw_line in enumerate(ALLOWLIST_PATH.read_text().splitlines(), start=1):
+    for lineno, raw_line in enumerate(path.read_text().splitlines(), start=1):
         line = raw_line.strip()
         if not line or line.startswith("#"):
             continue
         parts = line.split(maxsplit=3)
         if len(parts) != 4:
-            raise ValueError(
-                f"{ALLOWLIST_PATH.relative_to(REPO_ROOT)}:{lineno}: "
-                "expected RULE_ID path count reason"
-            )
+            raise ValueError(f"{label}:{lineno}: expected RULE_ID path count reason")
         rule_id, relative_path, count_raw, reason = parts
         try:
             count = int(count_raw)
         except ValueError as error:
-            raise ValueError(
-                f"{ALLOWLIST_PATH.relative_to(REPO_ROOT)}:{lineno}: count must be an integer"
-            ) from error
+            raise ValueError(f"{label}:{lineno}: count must be an integer") from error
         if count < 1:
-            raise ValueError(
-                f"{ALLOWLIST_PATH.relative_to(REPO_ROOT)}:{lineno}: count must be positive"
-            )
+            raise ValueError(f"{label}:{lineno}: count must be positive")
         key = (rule_id, relative_path)
         if key in entries:
-            raise ValueError(
-                f"{ALLOWLIST_PATH.relative_to(REPO_ROOT)}:{lineno}: duplicate allowlist entry"
-            )
+            raise ValueError(f"{label}:{lineno}: duplicate allowlist entry")
         entries[key] = AllowlistEntry(rule_id, relative_path, count, reason)
     return entries
 
 
-def collect_violations() -> list[Violation]:
-    violations: list[Violation] = []
-    for path in iter_anyharness_files():
-        violations.extend(check_file(path))
-    return violations
+def collect_violations(root: Path | None = None) -> list[Violation]:
+    with scan_root(root):
+        violations: list[Violation] = []
+        for path in iter_anyharness_files():
+            violations.extend(_check_file(path))
+        return violations
 
 
 def apply_allowlist(

--- a/scripts/check_anyharness_boundaries.py
+++ b/scripts/check_anyharness_boundaries.py
@@ -116,9 +116,12 @@ STORE_CONSTRUCTOR_RE = re.compile(r"\b[A-Za-z][A-Za-z0-9_]*Store::new\b")
 # A handler can also reach a domain store without naming a store type at all, by
 # reading a store field off AppState (`state.agent_seed_store.health()`). Neither
 # the import pass nor the two patterns above see that, because no store type is
-# mentioned on the line. AppState carries exactly one `*_store` field today
-# (`agent_seed_store`), and it is a real domain store, so the field-name shape is
-# a clean signal; any future `*_store` field is a store by the same naming law.
+# mentioned on the line. AppState carries exactly one `*_store` field today,
+# `agent_seed_store`, and it is NOT a DB store -- it is an in-memory
+# `Arc<RwLock<AgentSeedHealth>>` snapshot that merely follows the naming law. So
+# today's single match is a benign false positive, seeded in the allowlist rather
+# than special-cased: the field-name shape is the durable signal we want to hold,
+# and a real `*_store` field added later would be caught for the right reason.
 APP_STATE_STORE_FIELD_RE = re.compile(r"\bstate\.[a-z_]*_store\b")
 # Inline `anyharness_contract::` path uses (fn signatures, struct literals,
 # turbofish) that no use-statement declares. Mirrors DOMAIN_LIVE_VALVE's

--- a/scripts/check_anyharness_boundaries.py
+++ b/scripts/check_anyharness_boundaries.py
@@ -73,6 +73,8 @@ SESSION_EVENT_SINK_PREFIXES = (
 )
 TOKEN_RE = re.compile(r"r#[A-Za-z_][A-Za-z0-9_]*|[A-Za-z_][A-Za-z0-9_]*|::|[{}(),;*]")
 USE_START_RE = re.compile(r"^\s*(?:pub(?:\([^)]*\))?\s+)?use\s+")
+# A re-export specifically, not a private import: `pub use ..`, `pub(crate) use ..`.
+PUB_USE_START_RE = re.compile(r"^\s*pub(?:\([^)]*\))?\s+use\s+")
 SESSION_COMMAND_USE_RE = re.compile(
     r"(?:\bSessionCommand|crate::live::sessions::actor::command::SessionCommand)\s*::"
 )
@@ -99,6 +101,7 @@ STORE_SEGMENTS = {"store"}
 STORE_OR_SERVICE_SEGMENTS = {"store", "service"}
 DOMAIN_STORE_FORBIDDEN_ROOTS = {"acp", "live"}
 POLICY_FILE_SUFFIX = "_policy.rs"
+POLICY_FILE_NAME = "policy.rs"
 CONTRACT_CRATE_ROOT = "anyharness_contract"
 
 # Inline `crate::live::<area>::<second>` path uses (fn param types, turbofish,
@@ -110,6 +113,17 @@ LIVE_INLINE_PATH_RE = re.compile(
 )
 STORE_METHOD_CALL_RE = re.compile(r"\.store\(\)")
 STORE_CONSTRUCTOR_RE = re.compile(r"\b[A-Za-z][A-Za-z0-9_]*Store::new\b")
+# A handler can also reach a domain store without naming a store type at all, by
+# reading a store field off AppState (`state.agent_seed_store.health()`). Neither
+# the import pass nor the two patterns above see that, because no store type is
+# mentioned on the line. AppState carries exactly one `*_store` field today
+# (`agent_seed_store`), and it is a real domain store, so the field-name shape is
+# a clean signal; any future `*_store` field is a store by the same naming law.
+APP_STATE_STORE_FIELD_RE = re.compile(r"\bstate\.[a-z_]*_store\b")
+# Inline `anyharness_contract::` path uses (fn signatures, struct literals,
+# turbofish) that no use-statement declares. Mirrors DOMAIN_LIVE_VALVE's
+# import-pass + line-pass pairing.
+CONTRACT_INLINE_PATH_RE = re.compile(r"\banyharness_contract::")
 POLICY_IMPURITY_RES = (
     re.compile(r"\bUtc::now\b"),
     re.compile(r"\bLocal::now\b"),
@@ -118,9 +132,20 @@ POLICY_IMPURITY_RES = (
     re.compile(r"\bUuid::new_v4\b"),
     re.compile(r"\brand::"),
 )
-# Calibrated against domains/**: these seven patterns hit every embedded-SQL
-# line found outside store code with zero false positives (no log strings, no
-# identifiers that merely contain a keyword).
+# Calibrated against domains/**: these patterns hit every embedded-SQL line found
+# outside store code with zero false positives (no log strings, no identifiers
+# that merely contain a keyword).
+#
+# The first six are whole-statement shapes that fit on one line. The next three
+# are keyword-anchored heads for the far more common case of SQL that rustfmt (or
+# the author) split across lines: `"UPDATE sessions` / `SET col = ?1` /
+# `WHERE id = ?1` each land on their own line, so a rule that demanded two
+# keywords together saw none of them. Keeping the clause heads uppercase-only and
+# anchored to a line start or an opening quote is what keeps prose out: English
+# never writes a bare capitalised `SELECT` at the head of a line, and a lowercase
+# "select the agent" comment or log string cannot match. `UPDATE` additionally
+# requires a lowercase table identifier after it, so `DO UPDATE SET` fragments and
+# prose like "run UPDATE both stamps" do not count twice or at all.
 SQL_RES = (
     re.compile(r"\bINSERT INTO\b"),
     re.compile(r"\bSELECT\b.*\bFROM\b"),
@@ -129,6 +154,15 @@ SQL_RES = (
     re.compile(r"\bDELETE FROM\b"),
     re.compile(r"\bUPDATE\b.*\bSET\b"),
     re.compile(r"\bparams!|\brusqlite::params\b"),
+    # Split-statement heads: the write verb and its table on one line, the clauses
+    # on the next.
+    re.compile(r'(?:^|")\s*SELECT\b'),
+    re.compile(r'(?:^|")\s*UPDATE\s+[a-z_]'),
+    re.compile(r"^\s*SET\b"),
+    # Conflict-resolving inserts and drops, which the two bare-verb patterns above
+    # miss because the verb and `INTO`/the table are separated by a modifier.
+    re.compile(r"\bINSERT\s+OR\s+[A-Z]+\s+INTO\b"),
+    re.compile(r"\bDROP TABLE\b"),
 )
 
 DOMAIN_LIVE_VALVE_MESSAGE = (
@@ -155,6 +189,11 @@ DOMAIN_SQL_OUTSIDE_STORE_MESSAGE = (
 DOMAIN_CONTRACT_IMPORT_MESSAGE = (
     "domain code must not import wire contract types below the API mapper "
     "boundary — use a domain twin; see anyharness-structure.md"
+)
+DOMAIN_VALVE_LIVE_REEXPORT_MESSAGE = (
+    "the runtime valve may hold live/ powers but must not re-export them — a "
+    "`pub use crate::live::..` republishes the power domain-wide; expose a domain "
+    "port instead; see anyharness-structure.md"
 )
 
 
@@ -353,9 +392,15 @@ def in_domain_store(relative_path: str) -> bool:
 
 
 def is_policy_file(relative_path: str) -> bool:
-    return bool(domain_relative_parts(relative_path)) and relative_path.endswith(
-        POLICY_FILE_SUFFIX
-    )
+    """`*_policy.rs` and a file named exactly `policy.rs`, anywhere under domains/**.
+
+    The suffix test alone missed `domains/<d>/**/policy.rs`, which is the same
+    thing by role and by name — a module whose whole job is deciding.
+    """
+    parts = domain_relative_parts(relative_path)
+    if not parts:
+        return False
+    return parts[-1] == POLICY_FILE_NAME or relative_path.endswith(POLICY_FILE_SUFFIX)
 
 
 def has_segment(import_path: ImportPath, segments: set[str]) -> bool:
@@ -861,6 +906,35 @@ def has_non_model_live_use(line: str) -> bool:
     return False
 
 
+def is_non_model_live_reexport(import_path: ImportPath) -> bool:
+    """A re-exported live power: `crate::live::<area>::<not-model>`."""
+    return import_path.crate_root == "live" and not is_live_model_import(import_path)
+
+
+def check_domain_valve_live_reexport(
+    violations: list[Violation],
+    path: Path,
+    start_line: int,
+    lines: list[str],
+    import_paths: list[ImportPath],
+) -> None:
+    """Valve files may hold live powers; re-exporting them launders the valve away.
+
+    One violation per re-exporting statement, not per leaf: the statement is the
+    laundering act, and a group `pub use crate::live::sessions::{A, B}` is one act.
+    """
+    if not PUB_USE_START_RE.search(lines[0]):
+        return
+    add_if(
+        violations,
+        any(is_non_model_live_reexport(import_path) for import_path in import_paths),
+        "DOMAIN_VALVE_LIVE_REEXPORT",
+        path,
+        start_line,
+        DOMAIN_VALVE_LIVE_REEXPORT_MESSAGE,
+    )
+
+
 def check_line_patterns(violations: list[Violation], path: Path) -> None:
     rel = relative(path)
     allow_session_private = in_live_sessions(rel)
@@ -872,6 +946,11 @@ def check_line_patterns(violations: list[Violation], path: Path) -> None:
     check_api_store_escape = is_under(rel, API_PREFIX)
     check_policy_purity = is_policy_file(rel)
     check_domain_sql = in_domains and not in_domain_store(rel)
+    # live/** can construct or call a domain store inline without importing one,
+    # which the import-only rule could not see. Same rule id, same message: it is
+    # the same law, just the other half of the surface.
+    check_live_store_line = is_under(rel, LIVE_PREFIX)
+    check_contract_inline = in_domains
 
     for lineno, raw_line in enumerate(path.read_text().splitlines(), start=1):
         line = strip_line_comment(raw_line)
@@ -892,11 +971,31 @@ def check_line_patterns(violations: list[Violation], path: Path) -> None:
             add_if(
                 violations,
                 STORE_METHOD_CALL_RE.search(line) is not None
-                or STORE_CONSTRUCTOR_RE.search(line) is not None,
+                or STORE_CONSTRUCTOR_RE.search(line) is not None
+                or APP_STATE_STORE_FIELD_RE.search(line) is not None,
                 "API_STORE_ESCAPE",
                 path,
                 lineno,
                 API_STORE_ESCAPE_MESSAGE,
+            )
+        if check_live_store_line and not starts_use_statement:
+            add_if(
+                violations,
+                STORE_METHOD_CALL_RE.search(line) is not None
+                or STORE_CONSTRUCTOR_RE.search(line) is not None,
+                "LIVE_DOMAIN_STORE_IMPORT",
+                path,
+                lineno,
+                LIVE_DOMAIN_STORE_MESSAGE,
+            )
+        if check_contract_inline and not starts_use_statement:
+            add_if(
+                violations,
+                CONTRACT_INLINE_PATH_RE.search(line) is not None,
+                "DOMAIN_CONTRACT_IMPORT",
+                path,
+                lineno,
+                DOMAIN_CONTRACT_IMPORT_MESSAGE,
             )
         if check_policy_purity and not starts_use_statement:
             add_if(
@@ -1004,6 +1103,10 @@ def _check_file(path: Path) -> list[Violation]:
             check_domain_contract_import(violations, path, import_path)
         if in_domains:
             check_domain_contract_crate_import(violations, path, start_line, import_paths)
+        if in_live_valve:
+            check_domain_valve_live_reexport(
+                violations, path, start_line, lines, import_paths
+            )
 
     check_line_patterns(violations, path)
     return violations

--- a/scripts/test_check_anyharness_boundaries.py
+++ b/scripts/test_check_anyharness_boundaries.py
@@ -403,6 +403,63 @@ class DomainValveLiveReexportTest(BoundaryRuleTestCase):
         self.assertEqual(len(matches), 1)
         self.assertEqual(matches[0].lineno, 1)
 
+    def test_pub_use_split_across_lines_still_fires(self) -> None:
+        # The `pub use` keyword and its path can sit on separate lines. Matching
+        # the prefix against only the first line let this spelling launder a live
+        # power silently.
+        violations = self.run_rules(
+            {
+                "domains/sessions/runtime.rs": (
+                    "pub use\n    crate::live::sessions::LiveSessionHandle;\n"
+                )
+            }
+        )
+
+        matches = self.for_rule(violations, "DOMAIN_VALVE_LIVE_REEXPORT")
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].lineno, 1)
+
+    def test_split_pub_use_of_model_shape_still_passes(self) -> None:
+        # The split spelling must not smuggle the `::model` exemption away either.
+        violations = self.run_rules(
+            {
+                "domains/sessions/runtime.rs": (
+                    "pub use\n    crate::live::sessions::model::LiveSessionSnapshot;\n"
+                )
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "DOMAIN_VALVE_LIVE_REEXPORT"), [])
+
+    def test_split_private_use_still_passes(self) -> None:
+        # Splitting a private `use` does not turn it into a re-export.
+        violations = self.run_rules(
+            {
+                "domains/sessions/runtime.rs": (
+                    "use\n    crate::live::sessions::LiveSessionManager;\n"
+                )
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "DOMAIN_VALVE_LIVE_REEXPORT"), [])
+
+    def test_restricted_pub_visibilities_fire(self) -> None:
+        # `pub(crate)`, `pub(super)` and `pub(in ..)` all republish beyond the
+        # valve module, so each is laundering.
+        for visibility in ["pub(crate)", "pub(super)", "pub(in crate::domains)"]:
+            with self.subTest(visibility=visibility):
+                violations = self.run_rules(
+                    {
+                        "domains/sessions/runtime.rs": (
+                            f"{visibility} use crate::live::sessions::LiveSessionManager;\n"
+                        )
+                    }
+                )
+
+                self.assertEqual(
+                    len(self.for_rule(violations, "DOMAIN_VALVE_LIVE_REEXPORT")), 1
+                )
+
     def test_non_valve_domain_file_is_not_checked_by_this_rule(self) -> None:
         # A non-valve file re-exporting live is already a DOMAIN_LIVE_VALVE hit;
         # this rule exists for the files that rule cannot see.
@@ -610,6 +667,50 @@ class DomainContractImportTest(BoundaryRuleTestCase):
         matches = self.for_rule(violations, "DOMAIN_CONTRACT_IMPORT")
         self.assertEqual(len(matches), 1)
         self.assertEqual(matches[0].lineno, 1)
+
+    def test_root_brace_group_import_counts_once(self) -> None:
+        # `use {` puts the leaf on a continuation line that carries no `use`
+        # prefix. Guarding the line pass by "is a use-statement head" let the
+        # inline pass fire on line 2 while the import pass fired on line 1,
+        # counting one import twice.
+        violations = self.run_rules(
+            {
+                "domains/goals/runtime.rs": (
+                    "use {\n    anyharness_contract::v1::Goal,\n};\n"
+                )
+            }
+        )
+
+        matches = self.for_rule(violations, "DOMAIN_CONTRACT_IMPORT")
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].lineno, 1)
+
+    def test_root_brace_group_pub_use_counts_once(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/goals/runtime.rs": (
+                    "pub use {\n    anyharness_contract::v1::Goal,\n};\n"
+                )
+            }
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "DOMAIN_CONTRACT_IMPORT")), 1)
+
+    def test_inline_contract_path_below_a_use_statement_still_fires(self) -> None:
+        # Skipping use-statement lines must not spill over into ordinary code:
+        # the fn signature on line 3 is a genuine inline path.
+        violations = self.run_rules(
+            {
+                "domains/goals/service.rs": (
+                    "use {\n    crate::domains::goals::model::GoalRecord,\n};\n"
+                    "fn map(input: anyharness_contract::v1::Goal) -> GoalRecord {}\n"
+                )
+            }
+        )
+
+        matches = self.for_rule(violations, "DOMAIN_CONTRACT_IMPORT")
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].lineno, 4)
 
     def test_two_import_lines_count_twice(self) -> None:
         violations = self.run_rules(
@@ -914,6 +1015,74 @@ class DomainSqlOutsideStoreTest(BoundaryRuleTestCase):
         )
 
         self.assertEqual(self.for_rule(violations, "DOMAIN_SQL_OUTSIDE_STORE"), [])
+
+    def test_bare_select_keyword_literals_do_not_match(self) -> None:
+        # `"SELECT"` as an entire string literal is a keyword constant or a serde
+        # rename, never a query. The `(?!")` exclusion covers exactly that shape.
+        violations = self.run_rules(
+            {
+                "domains/workflows/service.rs": (
+                    '    const KEYWORD: &str = "SELECT";\n'
+                    '    #[serde(rename = "SELECT")]\n'
+                )
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "DOMAIN_SQL_OUTSIDE_STORE"), [])
+
+    def test_built_query_fragment_still_matches(self) -> None:
+        # The exclusion must stay narrow: `"SELECT "` with trailing space is a
+        # real query being concatenated, so it must keep matching.
+        violations = self.run_rules(
+            {
+                "domains/workflows/service.rs": (
+                    '    let sql = "SELECT ".to_string() + &columns;\n'
+                )
+            }
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "DOMAIN_SQL_OUTSIDE_STORE")), 1)
+
+    def test_bare_select_head_in_raw_string_still_matches(self) -> None:
+        # A lone `SELECT` at line end inside a raw string is how the real
+        # migrations spell a split query; it must not be swept up by the
+        # keyword-literal exclusion.
+        violations = self.run_rules(
+            {"domains/workflows/service.rs": "        SELECT\n            id\n"}
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "DOMAIN_SQL_OUTSIDE_STORE")), 1)
+
+    def test_known_limitation_uppercase_verb_in_message_string_matches(self) -> None:
+        # PINNED LIMITATION, not desired behaviour: `"UPDATE failed .."` is
+        # lexically identical to `"UPDATE sessions .."`, so no regex can tell them
+        # apart. Such a hit is a seedable false positive. If this test ever starts
+        # failing because the match disappeared, confirm real split UPDATEs are
+        # still caught before celebrating.
+        violations = self.run_rules(
+            {
+                "domains/workflows/service.rs": (
+                    '    anyhow::bail!("UPDATE failed for session {id}");\n'
+                )
+            }
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "DOMAIN_SQL_OUTSIDE_STORE")), 1)
+
+    def test_known_limitation_sql_in_block_comment_matches(self) -> None:
+        # PINNED LIMITATION: strip_line_comment only understands `//`, so SQL
+        # inside a `/* .. */` block is scanned as code.
+        violations = self.run_rules(
+            {
+                "domains/workflows/service.rs": (
+                    "    /*\n"
+                    "     * SELECT * FROM workflow_runs WHERE id = ?1\n"
+                    "     */\n"
+                )
+            }
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "DOMAIN_SQL_OUTSIDE_STORE")), 1)
 
 
 class AllowlistRatchetTest(unittest.TestCase):

--- a/scripts/test_check_anyharness_boundaries.py
+++ b/scripts/test_check_anyharness_boundaries.py
@@ -1,0 +1,608 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import check_anyharness_boundaries as check_module
+
+LIB_SRC_RELATIVE = "anyharness/crates/anyharness-lib/src"
+
+
+class BoundaryRuleTestCase(unittest.TestCase):
+    """Runs the real engine over a fabricated anyharness-lib tree."""
+
+    def run_rules(self, files: dict[str, str]) -> list[check_module.Violation]:
+        """`files` keys are paths relative to anyharness-lib/src."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            for name, content in files.items():
+                path = root / LIB_SRC_RELATIVE / name
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(content, encoding="utf-8")
+            return check_module.collect_violations(root=root)
+
+    def rule_ids(self, violations: list[check_module.Violation]) -> set[str]:
+        return {violation.rule_id for violation in violations}
+
+    def for_rule(
+        self, violations: list[check_module.Violation], rule_id: str
+    ) -> list[check_module.Violation]:
+        return [violation for violation in violations if violation.rule_id == rule_id]
+
+
+class DomainLiveValveTest(BoundaryRuleTestCase):
+    def test_domain_service_importing_live_service_fails(self) -> None:
+        violations = self.run_rules(
+            {"domains/mobility/service.rs": "use crate::live::terminals::TerminalService;\n"}
+        )
+
+        matches = self.for_rule(violations, "DOMAIN_LIVE_VALVE")
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(
+            matches[0].relative_path,
+            f"{LIB_SRC_RELATIVE}/domains/mobility/service.rs",
+        )
+        self.assertIn("runtime valve", matches[0].message)
+
+    def test_inline_live_path_use_fails(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/agents/entry.rs": (
+                    "pub struct Entry {\n"
+                    "    snapshot: crate::live::sessions::probe::ProbeSnapshot,\n"
+                    "}\n"
+                )
+            }
+        )
+
+        matches = self.for_rule(violations, "DOMAIN_LIVE_VALVE")
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].lineno, 2)
+
+    def test_runtime_valve_files_may_hold_live_machinery(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/goals/runtime.rs": "use crate::live::sessions::LiveSessionManager;\n",
+                "domains/sessions/live_ports.rs": (
+                    "use crate::live::sessions::handle::LiveSessionHandle;\n"
+                ),
+                "domains/workspaces/runtime/mod.rs": (
+                    "use crate::live::terminals::TerminalService;\n"
+                    "fn probe() -> crate::live::sessions::probe::ProbeSnapshot { todo!() }\n"
+                ),
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "DOMAIN_LIVE_VALVE"), [])
+
+    def test_live_model_imports_are_the_sanctioned_inversion(self) -> None:
+        # Domains implement live-defined observer traits, so they must be able to
+        # name the model shapes those traits speak in.
+        violations = self.run_rules(
+            {
+                "domains/plans/session_observer.rs": (
+                    "use crate::live::sessions::model::{\n"
+                    "    AcpChunkPayload, SessionObserverContext,\n"
+                    "};\n"
+                    "fn ctx() -> crate::live::sessions::model::SessionObserverContext { todo!() }\n"
+                )
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "DOMAIN_LIVE_VALVE"), [])
+
+    def test_commented_live_use_is_ignored(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/plans/decision_op.rs": (
+                    "// NOTE: crate::live::sessions::actor is private; do not reach for it.\n"
+                    "pub struct Op;\n"
+                )
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "DOMAIN_LIVE_VALVE"), [])
+
+    def test_pub_use_reexport_counts_once(self) -> None:
+        # `pub use` is a use-statement, so the import pass owns it; the inline
+        # line pass must not double-count it.
+        violations = self.run_rules(
+            {"domains/sessions/mod.rs": "pub use crate::live::sessions::LiveSessionManager;\n"}
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "DOMAIN_LIVE_VALVE")), 1)
+
+    def test_test_files_are_skipped(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/mobility/service_tests.rs": (
+                    "use crate::live::terminals::TerminalService;\n"
+                ),
+                "domains/mobility/tests/live.rs": (
+                    "use crate::live::terminals::TerminalService;\n"
+                ),
+            }
+        )
+
+        self.assertEqual(violations, [])
+
+
+class LiveDomainStoreImportTest(BoundaryRuleTestCase):
+    def test_live_importing_domain_store_fails(self) -> None:
+        violations = self.run_rules(
+            {"live/terminals/manager.rs": "use crate::domains::terminals::store::TerminalStore;\n"}
+        )
+
+        matches = self.for_rule(violations, "LIVE_DOMAIN_STORE_IMPORT")
+        self.assertEqual(len(matches), 1)
+        self.assertIn("live/ never fetches", matches[0].message)
+
+    def test_live_importing_domain_service_fails(self) -> None:
+        violations = self.run_rules(
+            {
+                "live/sessions/probe.rs": (
+                    "use crate::domains::agents::readiness::service::resolve_agent_unrouted;\n"
+                )
+            }
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "LIVE_DOMAIN_STORE_IMPORT")), 1)
+
+    def test_live_importing_domain_model_passes(self) -> None:
+        violations = self.run_rules(
+            {
+                "live/sessions/handle.rs": (
+                    "use crate::domains::sessions::model::SessionRecord;\n"
+                    "use crate::domains::workspaces::types::WorkspaceKind;\n"
+                )
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "LIVE_DOMAIN_STORE_IMPORT"), [])
+
+
+class ApiStoreEscapeTest(BoundaryRuleTestCase):
+    def test_store_accessor_call_fails(self) -> None:
+        violations = self.run_rules(
+            {
+                "api/http/mobility.rs": (
+                    "async fn handler(state: AppState) {\n"
+                    "    state\n"
+                    "        .session_service\n"
+                    "        .store()\n"
+                    "        .list();\n"
+                    "}\n"
+                )
+            }
+        )
+
+        matches = self.for_rule(violations, "API_STORE_ESCAPE")
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].lineno, 4)
+        self.assertIn("domain facades", matches[0].message)
+
+    def test_store_constructor_fails(self) -> None:
+        violations = self.run_rules(
+            {
+                "api/http/hosting.rs": (
+                    "async fn handler(state: AppState) {\n"
+                    "    let store = WorkspaceStore::new(state.db.clone());\n"
+                    "}\n"
+                )
+            }
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "API_STORE_ESCAPE")), 1)
+
+    def test_store_import_fails(self) -> None:
+        violations = self.run_rules(
+            {"api/http/hosting.rs": "use crate::domains::workspaces::store::WorkspaceStore;\n"}
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "API_STORE_ESCAPE")), 1)
+
+    def test_facade_call_passes(self) -> None:
+        violations = self.run_rules(
+            {
+                "api/http/workspaces.rs": (
+                    "use crate::domains::workspaces::service::WorkspaceService;\n"
+                    "async fn handler(state: AppState) {\n"
+                    "    state.workspace_service.list().await;\n"
+                    "}\n"
+                )
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "API_STORE_ESCAPE"), [])
+
+    def test_commented_store_call_is_ignored(self) -> None:
+        violations = self.run_rules(
+            {"api/http/workspaces.rs": "// was: state.workspace_service.store().list()\n"}
+        )
+
+        self.assertEqual(self.for_rule(violations, "API_STORE_ESCAPE"), [])
+
+
+class PolicyPurityTest(BoundaryRuleTestCase):
+    def test_clock_in_policy_fails(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/workspaces/retention_policy.rs": (
+                    "fn decide() -> String {\n"
+                    "    chrono::Utc::now().to_rfc3339()\n"
+                    "}\n"
+                )
+            }
+        )
+
+        matches = self.for_rule(violations, "POLICY_PURITY")
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].lineno, 2)
+        self.assertIn("facts in, decisions out", matches[0].message)
+
+    def test_id_minting_in_policy_fails(self) -> None:
+        violations = self.run_rules(
+            {"domains/sessions/launch_policy.rs": "let id = Uuid::new_v4().to_string();\n"}
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "POLICY_PURITY")), 1)
+
+    def test_store_import_in_policy_fails(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/plans/decide_policy.rs": (
+                    "use crate::domains::plans::store::PlanStore;\n"
+                    "use crate::adapters::git::GitService;\n"
+                )
+            }
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "POLICY_PURITY")), 2)
+
+    def test_pure_policy_passes(self) -> None:
+        # `&self` on a plain data struct and a Display impl are NOT impurity;
+        # the rule deliberately does not police them.
+        violations = self.run_rules(
+            {
+                "domains/agents/installer/install_policy.rs": (
+                    "use crate::domains::agents::model::ArtifactRole;\n"
+                    "impl std::fmt::Display for Reason {\n"
+                    "    fn fmt(&self, f: &mut std::fmt::Formatter<'_>)"
+                    " -> std::fmt::Result { Ok(()) }\n"
+                    "}\n"
+                    "impl Plan {\n"
+                    "    pub fn has_reinstalls(&self) -> bool { false }\n"
+                    "}\n"
+                    "pub fn plan(facts: &Facts) -> Option<Reason> { None }\n"
+                )
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "POLICY_PURITY"), [])
+
+    def test_live_model_import_in_policy_passes(self) -> None:
+        # launch_policy.rs legally takes live model shapes as fact inputs.
+        violations = self.run_rules(
+            {
+                "domains/sessions/runtime/launch_policy.rs": (
+                    "use crate::live::sessions::model::{LaunchEnv, SessionLaunch};\n"
+                )
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "POLICY_PURITY"), [])
+
+    def test_non_policy_file_is_not_checked(self) -> None:
+        violations = self.run_rules(
+            {"domains/workspaces/service.rs": "let now = chrono::Utc::now();\n"}
+        )
+
+        self.assertEqual(self.for_rule(violations, "POLICY_PURITY"), [])
+
+
+class DomainStoreImportTest(BoundaryRuleTestCase):
+    def test_store_dir_importing_api_and_live_fails(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/sessions/store/events.rs": (
+                    "use crate::api::http::ApiError;\n"
+                    "use crate::live::sessions::LiveSessionManager;\n"
+                    "use crate::acp::permission_payload::permission_options;\n"
+                )
+            }
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "DOMAIN_STORE_API_IMPORT")), 1)
+        self.assertEqual(len(self.for_rule(violations, "DOMAIN_STORE_LIVE_IMPORT")), 2)
+
+    def test_bare_store_rs_is_covered_too(self) -> None:
+        # The generalized rule reaches every domain's store, not just sessions'.
+        violations = self.run_rules(
+            {"domains/plans/store.rs": "use crate::api::http::ApiError;\n"}
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "DOMAIN_STORE_API_IMPORT")), 1)
+
+    def test_session_specific_rule_ids_are_gone(self) -> None:
+        violations = self.run_rules(
+            {"domains/sessions/store/events.rs": "use crate::api::http::ApiError;\n"}
+        )
+
+        self.assertNotIn("SESSION_STORE_API_IMPORT", self.rule_ids(violations))
+        self.assertNotIn("SESSION_STORE_LIVE_IMPORT", self.rule_ids(violations))
+
+    def test_clean_store_passes(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/plans/store.rs": (
+                    "use crate::domains::plans::model::PlanRecord;\n"
+                    "use crate::persistence::Db;\n"
+                )
+            }
+        )
+
+        self.assertEqual(violations, [])
+
+
+class DomainContractImportTest(BoundaryRuleTestCase):
+    def test_contract_import_fails(self) -> None:
+        violations = self.run_rules(
+            {"domains/goals/model.rs": "use anyharness_contract::v1::Goal;\n"}
+        )
+
+        matches = self.for_rule(violations, "DOMAIN_CONTRACT_IMPORT")
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].lineno, 1)
+        self.assertIn("domain twin", matches[0].message)
+
+    def test_multi_leaf_group_import_counts_once(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/goals/runtime.rs": (
+                    "use anyharness_contract::v1::{\n"
+                    "    Goal, GoalStatus, GoalUpdatedPayload, SessionEventEnvelope,\n"
+                    "};\n"
+                )
+            }
+        )
+
+        matches = self.for_rule(violations, "DOMAIN_CONTRACT_IMPORT")
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].lineno, 1)
+
+    def test_two_import_lines_count_twice(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/loops/runtime.rs": (
+                    "use anyharness_contract::v1::Loop;\n"
+                    "use crate::domains::loops::model::LoopRecord;\n"
+                    "use anyharness_contract::v1::SessionEventEnvelope;\n"
+                )
+            }
+        )
+
+        matches = self.for_rule(violations, "DOMAIN_CONTRACT_IMPORT")
+        self.assertEqual([violation.lineno for violation in matches], [1, 3])
+
+    def test_request_response_rule_still_fires_alongside(self) -> None:
+        # A single line can legitimately trigger both the narrow legacy rule and
+        # the broad new one.
+        violations = self.run_rules(
+            {
+                "domains/goals/runtime.rs": (
+                    "use anyharness_contract::v1::SetSessionGoalRequest;\n"
+                )
+            }
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "DOMAIN_CONTRACT_IMPORT")), 1)
+        self.assertEqual(
+            len(self.for_rule(violations, "DOMAIN_CONTRACT_REQUEST_RESPONSE")), 1
+        )
+
+    def test_contract_import_outside_domains_passes(self) -> None:
+        violations = self.run_rules(
+            {
+                "api/http/goals.rs": "use anyharness_contract::v1::Goal;\n",
+                "live/sessions/handle.rs": "use anyharness_contract::v1::SessionEvent;\n",
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "DOMAIN_CONTRACT_IMPORT"), [])
+
+    def test_domain_local_imports_pass(self) -> None:
+        violations = self.run_rules(
+            {"domains/goals/model.rs": "use crate::domains::goals::wire::GoalWire;\n"}
+        )
+
+        self.assertEqual(violations, [])
+
+
+class DomainSqlOutsideStoreTest(BoundaryRuleTestCase):
+    def test_insert_outside_store_fails(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/sessions/links/completions.rs": (
+                    "fn queue(conn: &Connection) {\n"
+                    '    conn.execute("INSERT INTO session_pending_prompts (id) VALUES (?1)",\n'
+                    "        params![id])\n"
+                    "}\n"
+                )
+            }
+        )
+
+        matches = self.for_rule(violations, "DOMAIN_SQL_OUTSIDE_STORE")
+        self.assertEqual([violation.lineno for violation in matches], [2, 3])
+        self.assertIn("domain's store", matches[0].message)
+
+    def test_select_from_and_upsert_fail(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/plans/service.rs": (
+                    '    "SELECT * FROM plans WHERE id = ?1",\n'
+                    "    ON CONFLICT(id) DO UPDATE SET updated_at = excluded.updated_at\n"
+                    '    "DELETE FROM plans WHERE id = ?1",\n'
+                )
+            }
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "DOMAIN_SQL_OUTSIDE_STORE")), 3)
+
+    def test_sql_inside_store_passes(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/plans/store.rs": (
+                    '    conn.execute("INSERT INTO plans (id) VALUES (?1)", params![id]);\n'
+                ),
+                "domains/sessions/store/events.rs": (
+                    '    conn.query_row("SELECT * FROM session_events WHERE id = ?1", [], f);\n'
+                ),
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "DOMAIN_SQL_OUTSIDE_STORE"), [])
+
+    def test_prose_and_log_strings_are_not_sql(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/workspaces/service.rs": (
+                    '    tracing::info!("select a workspace from the roster");\n'
+                    '    let label = "Update settings";\n'
+                    "    // INSERT INTO used to happen here; moved to the store\n"
+                    "    let selected = pick_from(&candidates);\n"
+                )
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "DOMAIN_SQL_OUTSIDE_STORE"), [])
+
+    def test_sql_outside_domains_passes(self) -> None:
+        violations = self.run_rules(
+            {
+                "persistence/migrations.rs": (
+                    '    conn.execute("CREATE TABLE plans (id TEXT)", []);\n'
+                )
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "DOMAIN_SQL_OUTSIDE_STORE"), [])
+
+
+class AllowlistRatchetTest(unittest.TestCase):
+    def make_violations(self, rule_id: str, path: str, count: int) -> list[check_module.Violation]:
+        return [
+            check_module.Violation(rule_id, Path(path), lineno, "message")
+            for lineno in range(1, count + 1)
+        ]
+
+    def allowlist(self, *rows: tuple[str, str, int]) -> dict[tuple[str, str], object]:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory).resolve() / "allowlist.txt"
+            path.write_text(
+                "# header\n"
+                + "".join(f"{rule} {rel} {count} seeded debt\n" for rule, rel, count in rows),
+                encoding="utf-8",
+            )
+            return check_module.load_allowlist(allowlist_path=path)
+
+    def test_count_at_the_allowed_number_passes(self) -> None:
+        rel = "anyharness/crates/anyharness-lib/src/domains/mobility/service.rs"
+        allowlist = self.allowlist(("DOMAIN_LIVE_VALVE", rel, 2))
+        violations = self.make_violations("DOMAIN_LIVE_VALVE", rel, 2)
+
+        failures, stale = check_module.apply_allowlist(violations, allowlist)
+
+        self.assertEqual(failures, [])
+        self.assertEqual(stale, [])
+
+    def test_over_count_fails(self) -> None:
+        rel = "anyharness/crates/anyharness-lib/src/domains/mobility/service.rs"
+        allowlist = self.allowlist(("DOMAIN_LIVE_VALVE", rel, 2))
+        violations = self.make_violations("DOMAIN_LIVE_VALVE", rel, 3)
+
+        failures, stale = check_module.apply_allowlist(violations, allowlist)
+
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(failures[0].rule_id, "DOMAIN_LIVE_VALVE")
+        self.assertEqual(stale, [])
+
+    def test_unallowlisted_rule_fails(self) -> None:
+        rel = "anyharness/crates/anyharness-lib/src/api/http/hosting.rs"
+        violations = self.make_violations("API_STORE_ESCAPE", rel, 1)
+
+        failures, stale = check_module.apply_allowlist(violations, {})
+
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(stale, [])
+
+    def test_stale_count_is_reported(self) -> None:
+        rel = "anyharness/crates/anyharness-lib/src/domains/plans/service.rs"
+        allowlist = self.allowlist(("DOMAIN_SQL_OUTSIDE_STORE", rel, 4))
+        violations = self.make_violations("DOMAIN_SQL_OUTSIDE_STORE", rel, 1)
+
+        failures, stale = check_module.apply_allowlist(violations, allowlist)
+
+        self.assertEqual(failures, [])
+        self.assertEqual(len(stale), 1)
+        self.assertIn("stale allowlist count", stale[0])
+        self.assertIn("observed 1, allowed 4", stale[0])
+
+    def test_fully_cleaned_entry_is_reported_stale(self) -> None:
+        rel = "anyharness/crates/anyharness-lib/src/live/sessions/probe.rs"
+        allowlist = self.allowlist(("LIVE_DOMAIN_STORE_IMPORT", rel, 1))
+
+        failures, stale = check_module.apply_allowlist([], allowlist)
+
+        self.assertEqual(failures, [])
+        self.assertEqual(len(stale), 1)
+        self.assertIn("observed 0, allowed 1", stale[0])
+
+    def test_malformed_allowlist_line_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory).resolve() / "allowlist.txt"
+            path.write_text("DOMAIN_LIVE_VALVE some/path\n", encoding="utf-8")
+
+            with self.assertRaises(ValueError) as caught:
+                check_module.load_allowlist(allowlist_path=path)
+
+        self.assertIn("expected RULE_ID path count reason", str(caught.exception))
+
+    def test_zero_count_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory).resolve() / "allowlist.txt"
+            path.write_text("DOMAIN_LIVE_VALVE some/path 0 reason\n", encoding="utf-8")
+
+            with self.assertRaises(ValueError) as caught:
+                check_module.load_allowlist(allowlist_path=path)
+
+        self.assertIn("count must be positive", str(caught.exception))
+
+
+class ShippedAllowlistTest(unittest.TestCase):
+    def test_repo_allowlist_covers_the_repo_exactly(self) -> None:
+        """The checked-in allowlist is a ratchet: no failures and no stale rows."""
+        allowlist = check_module.load_allowlist()
+        violations = check_module.collect_violations()
+
+        failures, stale = check_module.apply_allowlist(violations, allowlist)
+
+        self.assertEqual([violation.format() for violation in failures], [])
+        self.assertEqual(stale, [])
+
+    def test_mobility_service_is_valved(self) -> None:
+        """Calibration anchor: this file must stay visible to the valve rule."""
+        violations = check_module.collect_violations()
+        flagged = {
+            violation.relative_path
+            for violation in violations
+            if violation.rule_id == "DOMAIN_LIVE_VALVE"
+        }
+
+        self.assertIn(
+            "anyharness/crates/anyharness-lib/src/domains/mobility/service.rs", flagged
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_anyharness_boundaries.py
+++ b/scripts/test_check_anyharness_boundaries.py
@@ -1052,7 +1052,9 @@ class ShippedAllowlistTest(unittest.TestCase):
              "split UPDATE head"),
             ("DOMAIN_SQL_OUTSIDE_STORE", "domains/sessions/links/completions.rs", 118,
              "SET clause line"),
-            # A domain store reached through an AppState field.
+            # A `state.*_store` field access, which carries no store type on the
+            # line for the import pass to see. This particular one is benign (an
+            # in-memory health snapshot), but the shape is what the rule watches.
             ("API_STORE_ESCAPE", "api/http/health.rs", 37, "AppState store field"),
             # An inline contract path with no use statement to declare it.
             ("DOMAIN_CONTRACT_IMPORT", "domains/sessions/store/events.rs", 53,

--- a/scripts/test_check_anyharness_boundaries.py
+++ b/scripts/test_check_anyharness_boundaries.py
@@ -223,6 +223,200 @@ class ApiStoreEscapeTest(BoundaryRuleTestCase):
 
         self.assertEqual(self.for_rule(violations, "API_STORE_ESCAPE"), [])
 
+    def test_app_state_store_field_access_fails(self) -> None:
+        # No store type is named on the line, so neither the import pass nor the
+        # ctor/accessor patterns see it — the field name is the only signal.
+        violations = self.run_rules(
+            {
+                "api/http/health.rs": (
+                    "async fn health(state: AppState) -> Json<HealthResponse> {\n"
+                    "    Json(HealthResponse {\n"
+                    "        agent_seed: state.agent_seed_store.health(),\n"
+                    "    })\n"
+                    "}\n"
+                )
+            }
+        )
+
+        matches = self.for_rule(violations, "API_STORE_ESCAPE")
+        self.assertEqual([violation.lineno for violation in matches], [3])
+        self.assertIn("facade", matches[0].message)
+
+    def test_non_store_app_state_fields_pass(self) -> None:
+        violations = self.run_rules(
+            {
+                "api/http/workspaces.rs": (
+                    "async fn handler(state: AppState) {\n"
+                    "    state.foo.list();\n"
+                    "    state.db.execution_store_id();\n"
+                    "    state.workspace_runtime.start().await;\n"
+                    "    state.runtime_home.display();\n"
+                    "    state.storefront.render();\n"
+                    "}\n"
+                )
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "API_STORE_ESCAPE"), [])
+
+    def test_app_state_store_field_outside_api_passes(self) -> None:
+        # The rule is about handlers reaching past the facade; app/ wires the
+        # store into AppState in the first place.
+        violations = self.run_rules(
+            {"app/mod.rs": "    let health = state.agent_seed_store.health();\n"}
+        )
+
+        self.assertEqual(self.for_rule(violations, "API_STORE_ESCAPE"), [])
+
+
+class LiveDomainStoreLinePassTest(BoundaryRuleTestCase):
+    """live/** can reach a store inline, with no import to catch."""
+
+    def test_inline_store_constructor_in_live_fails(self) -> None:
+        violations = self.run_rules(
+            {
+                "live/sessions/background_work/mod.rs": (
+                    "fn seeded() -> SessionStore {\n"
+                    "    let store = SessionStore::new(db);\n"
+                    "    store\n"
+                    "}\n"
+                )
+            }
+        )
+
+        matches = self.for_rule(violations, "LIVE_DOMAIN_STORE_IMPORT")
+        self.assertEqual([violation.lineno for violation in matches], [2])
+        self.assertIn("never fetches", matches[0].message)
+
+    def test_inline_store_accessor_in_live_fails(self) -> None:
+        violations = self.run_rules(
+            {"live/terminals/manager.rs": "    let rows = self.ports.store().list()?;\n"}
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "LIVE_DOMAIN_STORE_IMPORT")), 1)
+
+    def test_live_use_line_is_not_double_counted(self) -> None:
+        # The import pass already counts this statement; the line pass must not.
+        violations = self.run_rules(
+            {
+                "live/sessions/probe.rs": (
+                    "use crate::domains::sessions::store::SessionStore;\n"
+                )
+            }
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "LIVE_DOMAIN_STORE_IMPORT")), 1)
+
+    def test_clean_live_file_passes(self) -> None:
+        violations = self.run_rules(
+            {
+                "live/sessions/driver/mod.rs": (
+                    "fn drive(facts: LaunchBundle) {\n"
+                    "    facts.apply();\n"
+                    "}\n"
+                )
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "LIVE_DOMAIN_STORE_IMPORT"), [])
+
+    def test_inline_store_outside_live_passes(self) -> None:
+        violations = self.run_rules(
+            {"domains/sessions/service.rs": "    let store = SessionStore::new(db);\n"}
+        )
+
+        self.assertEqual(self.for_rule(violations, "LIVE_DOMAIN_STORE_IMPORT"), [])
+
+
+class DomainValveLiveReexportTest(BoundaryRuleTestCase):
+    """A valve may hold live powers; re-exporting one republishes it domain-wide."""
+
+    def test_valve_reexporting_live_power_fails(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/sessions/runtime.rs": (
+                    "pub use crate::live::sessions::LiveSessionManager;\n"
+                )
+            }
+        )
+
+        matches = self.for_rule(violations, "DOMAIN_VALVE_LIVE_REEXPORT")
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].lineno, 1)
+        self.assertIn("re-export", matches[0].message)
+
+    def test_valve_reexporting_live_model_shape_passes(self) -> None:
+        # The observer-trait inversion: model shapes are sanctioned everywhere the
+        # valve rule allows them, so re-exporting one is not laundering a power.
+        violations = self.run_rules(
+            {
+                "domains/sessions/runtime.rs": (
+                    "pub use crate::live::sessions::model::LiveSessionSnapshot;\n"
+                )
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "DOMAIN_VALVE_LIVE_REEXPORT"), [])
+
+    def test_private_use_in_valve_passes(self) -> None:
+        # Holding the power is the valve's whole job; only republishing is banned.
+        violations = self.run_rules(
+            {
+                "domains/sessions/runtime.rs": (
+                    "use crate::live::sessions::LiveSessionManager;\n"
+                )
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "DOMAIN_VALVE_LIVE_REEXPORT"), [])
+
+    def test_rule_covers_every_valve_shape(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/goals/runtime.rs": (
+                    "pub use crate::live::sessions::LiveSessionManager;\n"
+                ),
+                "domains/sessions/live_ports.rs": (
+                    "pub use crate::live::sessions::handle::LiveSessionHandle;\n"
+                ),
+                "domains/workspaces/runtime/mod.rs": (
+                    "pub use crate::live::terminals::TerminalService;\n"
+                ),
+            }
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "DOMAIN_VALVE_LIVE_REEXPORT")), 3)
+
+    def test_group_reexport_counts_once(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/sessions/runtime.rs": (
+                    "pub use crate::live::sessions::{\n"
+                    "    LiveSessionHandle,\n"
+                    "    LiveSessionManager,\n"
+                    "};\n"
+                )
+            }
+        )
+
+        matches = self.for_rule(violations, "DOMAIN_VALVE_LIVE_REEXPORT")
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].lineno, 1)
+
+    def test_non_valve_domain_file_is_not_checked_by_this_rule(self) -> None:
+        # A non-valve file re-exporting live is already a DOMAIN_LIVE_VALVE hit;
+        # this rule exists for the files that rule cannot see.
+        violations = self.run_rules(
+            {
+                "domains/sessions/hooks.rs": (
+                    "pub use crate::live::sessions::LiveSessionManager;\n"
+                )
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "DOMAIN_VALVE_LIVE_REEXPORT"), [])
+        self.assertEqual(len(self.for_rule(violations, "DOMAIN_LIVE_VALVE")), 1)
+
 
 class PolicyPurityTest(BoundaryRuleTestCase):
     def test_clock_in_policy_fails(self) -> None:
@@ -299,6 +493,52 @@ class PolicyPurityTest(BoundaryRuleTestCase):
         )
 
         self.assertEqual(self.for_rule(violations, "POLICY_PURITY"), [])
+
+    def test_bare_policy_rs_is_a_policy_file(self) -> None:
+        # `policy.rs` is the same thing as `*_policy.rs` by role and by name; the
+        # suffix test alone missed it.
+        violations = self.run_rules(
+            {
+                "domains/workflows/control/policy.rs": (
+                    "use crate::domains::workflows::store::WorkflowRunStore;\n"
+                    "pub struct WorkflowSessionControllerPolicy {\n"
+                    "    store: WorkflowRunStore,\n"
+                    "}\n"
+                )
+            }
+        )
+
+        matches = self.for_rule(violations, "POLICY_PURITY")
+        self.assertEqual([violation.lineno for violation in matches], [1])
+        self.assertIn("no store", matches[0].message)
+
+    def test_suffix_policy_files_still_matched(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/workspaces/retention_policy.rs": (
+                    "let now = chrono::Utc::now();\n"
+                ),
+                "domains/agents/installer/install_policy.rs": (
+                    "let id = Uuid::new_v4();\n"
+                ),
+            }
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "POLICY_PURITY")), 2)
+
+    def test_policy_rs_outside_domains_is_not_checked(self) -> None:
+        violations = self.run_rules(
+            {"adapters/git/policy.rs": "let now = chrono::Utc::now();\n"}
+        )
+
+        self.assertEqual(self.for_rule(violations, "POLICY_PURITY"), [])
+
+    def test_bare_policy_rs_purity_patterns_fire(self) -> None:
+        violations = self.run_rules(
+            {"domains/workflows/control/policy.rs": "let now = Utc::now();\n"}
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "POLICY_PURITY")), 1)
 
 
 class DomainStoreImportTest(BoundaryRuleTestCase):
@@ -418,6 +658,97 @@ class DomainContractImportTest(BoundaryRuleTestCase):
 
         self.assertEqual(violations, [])
 
+    def test_inline_contract_path_fails(self) -> None:
+        # No use statement declares these, so the import-only pass saw nothing.
+        violations = self.run_rules(
+            {
+                "domains/sessions/store/events.rs": (
+                    "fn append(\n"
+                    "    event: anyharness_contract::v1::SessionEvent,\n"
+                    ") -> Result<anyharness_contract::v1::SessionEventEnvelope> {\n"
+                    "    todo!()\n"
+                    "}\n"
+                )
+            }
+        )
+
+        matches = self.for_rule(violations, "DOMAIN_CONTRACT_IMPORT")
+        self.assertEqual([violation.lineno for violation in matches], [2, 3])
+        self.assertIn("domain twin", matches[0].message)
+
+    def test_inline_contract_turbofish_fails(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/sessions/store/events.rs": (
+                    "    let event ="
+                    " serde_json::from_str::<anyharness_contract::v1::SessionEvent>(json);\n"
+                )
+            }
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "DOMAIN_CONTRACT_IMPORT")), 1)
+
+    def test_use_line_is_not_double_counted_by_the_line_pass(self) -> None:
+        # The use-statement pass already counts this; the inline pass must skip it.
+        violations = self.run_rules(
+            {
+                "domains/goals/model.rs": (
+                    "use anyharness_contract::v1::GoalRecord;\n"
+                )
+            }
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "DOMAIN_CONTRACT_IMPORT")), 1)
+
+    def test_pub_use_contract_reexport_is_not_double_counted(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/goals/wire.rs": (
+                    "pub use anyharness_contract::v1::GoalRecord;\n"
+                )
+            }
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "DOMAIN_CONTRACT_IMPORT")), 1)
+
+    def test_multi_line_use_statement_counts_once_with_inline_pass_active(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/goals/model.rs": (
+                    "use anyharness_contract::v1::{\n"
+                    "    GoalRecord,\n"
+                    "    GoalStatus,\n"
+                    "};\n"
+                )
+            }
+        )
+
+        matches = self.for_rule(violations, "DOMAIN_CONTRACT_IMPORT")
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].lineno, 1)
+
+    def test_commented_inline_contract_path_is_ignored(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/goals/service.rs": (
+                    "    // was: anyharness_contract::v1::GoalRecord, now a twin\n"
+                )
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "DOMAIN_CONTRACT_IMPORT"), [])
+
+    def test_inline_contract_path_outside_domains_passes(self) -> None:
+        violations = self.run_rules(
+            {
+                "api/http/goals.rs": (
+                    "fn map(record: anyharness_contract::v1::GoalRecord) {}\n"
+                )
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "DOMAIN_CONTRACT_IMPORT"), [])
+
 
 class DomainSqlOutsideStoreTest(BoundaryRuleTestCase):
     def test_insert_outside_store_fails(self) -> None:
@@ -482,6 +813,102 @@ class DomainSqlOutsideStoreTest(BoundaryRuleTestCase):
             {
                 "persistence/migrations.rs": (
                     '    conn.execute("CREATE TABLE plans (id TEXT)", []);\n'
+                )
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "DOMAIN_SQL_OUTSIDE_STORE"), [])
+
+    def test_multi_line_update_is_caught(self) -> None:
+        # The dominant real shape: rustfmt puts the verb, the SET and the WHERE on
+        # separate lines, so no line carries two keywords.
+        violations = self.run_rules(
+            {
+                "domains/sessions/links/completions.rs": (
+                    "fn bump(tx: &Transaction) {\n"
+                    "    tx.execute(\n"
+                    '        "UPDATE sessions\n'
+                    "         SET pending_prompt_seq_cursor = pending_prompt_seq_cursor + 1\n"
+                    '         WHERE id = ?1",\n'
+                    "    )\n"
+                    "}\n"
+                )
+            }
+        )
+
+        matches = self.for_rule(violations, "DOMAIN_SQL_OUTSIDE_STORE")
+        # The verb head and the SET clause; the bare WHERE line is not a keyword we
+        # anchor on, because it never heads a statement.
+        self.assertEqual([violation.lineno for violation in matches], [3, 4])
+
+    def test_multi_line_select_head_is_caught(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/workspaces/retention_policy.rs": (
+                    "fn get(conn: &Connection) {\n"
+                    "    conn.query_row(\n"
+                    '        "SELECT max_materialized_worktrees_per_repo, updated_at\n'
+                    "           FROM worktree_retention_policy\n"
+                    '          WHERE id = 1",\n'
+                    "    )\n"
+                    "}\n"
+                )
+            }
+        )
+
+        matches = self.for_rule(violations, "DOMAIN_SQL_OUTSIDE_STORE")
+        self.assertEqual([violation.lineno for violation in matches], [3])
+
+    def test_single_line_sql_still_caught(self) -> None:
+        # The one-line shapes the original patterns covered must keep firing, and
+        # must not double-count now that keyword-anchored patterns exist too.
+        violations = self.run_rules(
+            {
+                "domains/plans/service.rs": (
+                    '    conn.execute("UPDATE plans SET name = ?2 WHERE id = ?1", []);\n'
+                    '    conn.query_row("SELECT * FROM plans WHERE id = ?1", [], f);\n'
+                )
+            }
+        )
+
+        matches = self.for_rule(violations, "DOMAIN_SQL_OUTSIDE_STORE")
+        self.assertEqual([violation.lineno for violation in matches], [1, 2])
+
+    def test_conflict_resolving_insert_and_drop_are_caught(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/sessions/links/completions.rs": (
+                    '    "INSERT OR IGNORE INTO session_link_wake_schedules (id)\n'
+                    '    conn.execute("DROP TABLE workspace_access_modes", [])?;\n'
+                )
+            }
+        )
+
+        self.assertEqual(len(self.for_rule(violations, "DOMAIN_SQL_OUTSIDE_STORE")), 2)
+
+    def test_lowercase_prose_keywords_are_not_sql(self) -> None:
+        # The keyword-anchored patterns are uppercase-only precisely so English
+        # prose and log strings cannot trip them.
+        violations = self.run_rules(
+            {
+                "domains/workspaces/service.rs": (
+                    '    tracing::info!("select the agent for this workspace");\n'
+                    '    let msg = "update the retention setting";\n'
+                    "    let set = compute_set();\n"
+                    '    tracing::warn!("could not update policy");\n'
+                    "    let selected = pick_from(&candidates);\n"
+                )
+            }
+        )
+
+        self.assertEqual(self.for_rule(violations, "DOMAIN_SQL_OUTSIDE_STORE"), [])
+
+    def test_uppercase_prose_and_do_update_fragments_are_not_double_counted(self) -> None:
+        violations = self.run_rules(
+            {
+                "domains/workflows/service.rs": (
+                    "    // run UPDATE both stamps the intent and increments the counter\n"
+                    "    let mode = Method::UPDATE;\n"
                 )
             }
         )
@@ -601,6 +1028,53 @@ class ShippedAllowlistTest(unittest.TestCase):
 
         self.assertIn(
             "anyharness/crates/anyharness-lib/src/domains/mobility/service.rs", flagged
+        )
+
+    def test_known_truths_the_hardened_rules_must_see(self) -> None:
+        """Calibration anchors for the four rules widened after review.
+
+        Each entry is a real offender the pre-hardening rule was blind to, so a
+        regression that narrows a pattern back fails here and not just as a count.
+        """
+        violations = check_module.collect_violations()
+        flagged = {
+            (violation.rule_id, violation.relative_path, violation.lineno)
+            for violation in violations
+        }
+        prefix = "anyharness/crates/anyharness-lib/src"
+
+        for rule_id, path, lineno, why in [
+            # Multi-line embedded SQL: the SELECT head with FROM on the next line.
+            ("DOMAIN_SQL_OUTSIDE_STORE", "domains/workspaces/retention_policy.rs", 29,
+             "split SELECT head"),
+            # A split UPDATE and its SET clause.
+            ("DOMAIN_SQL_OUTSIDE_STORE", "domains/sessions/links/completions.rs", 117,
+             "split UPDATE head"),
+            ("DOMAIN_SQL_OUTSIDE_STORE", "domains/sessions/links/completions.rs", 118,
+             "SET clause line"),
+            # A domain store reached through an AppState field.
+            ("API_STORE_ESCAPE", "api/http/health.rs", 37, "AppState store field"),
+            # An inline contract path with no use statement to declare it.
+            ("DOMAIN_CONTRACT_IMPORT", "domains/sessions/store/events.rs", 53,
+             "inline contract path"),
+            # A store-holding file named exactly policy.rs.
+            ("POLICY_PURITY", "domains/workflows/control/policy.rs", 8,
+             "bare policy.rs"),
+        ]:
+            with self.subTest(rule=rule_id, path=path, why=why):
+                self.assertIn((rule_id, f"{prefix}/{path}", lineno), flagged)
+
+    def test_valve_live_reexport_rule_has_no_debt(self) -> None:
+        """DOMAIN_VALVE_LIVE_REEXPORT landed clean; it must stay at zero."""
+        violations = check_module.collect_violations()
+
+        self.assertEqual(
+            [
+                violation.format()
+                for violation in violations
+                if violation.rule_id == "DOMAIN_VALVE_LIVE_REEXPORT"
+            ],
+            [],
         )
 
 


### PR DESCRIPTION
PR 1 of the AnyHarness grid program (plan: `anyharness-grid-plan.md` on `worktree-anyharness-structure-doc`; law: `anyharness-structure.md` same branch). Python only — no Rust changes, no behavior changes.

## What

Extends `scripts/check_anyharness_boundaries.py` with eight rule families and seeds `scripts/anyharness_boundaries_allowlist.txt` with today's measured debt (123 data rows covering 229 seeded occurrences), so every wall in the structure doc exists in CI from this PR on and cleanup PRs prove progress by shrinking the allowlist (stale counts already fail the build).

New rules (seed counts post-hardening):

- `DOMAIN_LIVE_VALVE` — `crate::live` (import or inline path) in `domains/**` only from `runtime.rs` / `runtime/**` / `live_ports.rs`. Shapes exception: `crate::live::<area>::model::*` imports are legal anywhere (the sanctioned observer-trait inversion). Seeds: 12 files (mobility + materialization services and 7 stragglers).
- `DOMAIN_VALVE_LIVE_REEXPORT` — `pub use crate::live::<power>` inside a valve file (`::model` exempt): the valve may hold live machinery, not republish it domain-wide. Zero debt today; hard rule from day one.
- `LIVE_DOMAIN_STORE_IMPORT` — `live/**` must not import or inline-construct any domain's store/service (use-statement walk plus a per-line pass for `*Store::new(...)`). Seeds: 19 occurrences — `live/terminals` files (older doctrine, deliberately retained, marked "ratchet only"), `live/sessions/probe.rs`, one `SessionStore::new` in a cfg(test) mod the engine can't see past.
- `API_STORE_ESCAPE` — `.store()` calls, `*Store::new`, store imports, or `state.*_store` AppState-field reaches under `api/**`. Seeds: 16 occurrences / 6 files (5 real handler escapes targeted by grid plan PR 3, plus `health.rs` reading `state.agent_seed_store` — an in-memory `Arc<RwLock<AgentSeedHealth>>` snapshot, not a DB store; seeded as a benign false positive to keep the field-name signal).
- `POLICY_PURITY` — clocks (`Utc::now` etc.), `Uuid::new_v4`, `rand::`, store/adapters imports inside `*_policy.rs` or files named exactly `policy.rs`. Deliberately NOT `&self` (over-fires on Display impls / plain data methods — stays a review rule). Seeds: 3 files incl. `workspaces/retention_policy.rs` and `workflows/control/policy.rs`.
- `DOMAIN_STORE_API_IMPORT` / `DOMAIN_STORE_LIVE_IMPORT` — the sessions-store rule generalized to every domain's store module (the `SESSION_STORE_*` rule IDs are folded in and removed).
- `DOMAIN_SQL_OUTSIDE_STORE` — SQL text in domain files outside store modules, 12 patterns including split-line forms (`SELECT`/`FROM` on separate lines, `UPDATE` + leading `SET`, `INSERT OR … INTO`, `DROP TABLE`). Seeds: 52 occurrences across 9 files.
- `DOMAIN_CONTRACT_IMPORT` — any `anyharness_contract` path in `domains/**`, use-statements AND inline qualified paths (the narrower `DOMAIN_CONTRACT_REQUEST_RESPONSE` rule is unchanged). Seeds: 116 occurrences across 85 files.

Every seed row's reason names its cleanup PR in the grid plan.

## Hardening (post-review, same PR)

An adversarial review of the initial cut produced 9 findings; 6 became code fixes here, 3 are documented as known scope limits in the allowlist header:

- **Multi-line SQL (the P1)**: the SQL rule matched single-line statements only, while 31% of in-tree SELECTs and 88% of UPDATEs split across lines (e.g. `retention_policy.rs:29-31`). Pattern set widened 7→12; seeds re-measured 39→52.
- **AppState store fields**: `state.*_store` reaches in `api/**` were invisible (imports/constructors only). New third disjunct of `API_STORE_ESCAPE`.
- **Valve re-exports**: a valve file could launder `crate::live` power via `pub use`. New `DOMAIN_VALVE_LIVE_REEXPORT` rule, zero debt.
- **Inline qualified paths**: `anyharness_contract::Foo` in expression position bypassed the use-statement walk. Contract rule now runs a guarded line pass; seeds 86→116.
- **Inline store construction in `live/**`**: same gap, same fix; one real find seeded (`background_work/mod.rs:316`, cfg(test)).
- **Exact `policy.rs`**: purity rule matched only `*_policy.rs`; `workflows/control/policy.rs` was invisible.

Known scope limits (allowlist header): store-by-role files (`*_store.rs` outside `store/`) are policed for SQL but invisible to the importable-store rules; counts are per-line so a rustfmt reflow may legitimately shift one; AppState-field access beyond the `state.*_store` shape stays judgment; `"UPDATE failed"` vs `"UPDATE sessions"` is lexically indistinguishable so uppercase-SQL-verb-in-string false positives are accepted rather than chased (none exist in the current tree).

## Delta re-review closure (same PR)

The hardening itself was adversarially re-reviewed (verdict: no P1s; all seed re-derivations exact; byte-identical output on untouched rules). Its three latent P2 findings — none triggered by any code in today's tree — are closed in the final commit, under a proven invariant: real-tree checker output is byte-identical before/after (sha256-equal violation dumps, 229 = 229; allowlist rows untouched), so stacked PRs need no base-sync.

- **Root-brace-group `use {…}` double-count**: the inline pass now skips the exact line spans consumed by use statements instead of re-testing line prefixes — `use {\n anyharness_contract::…,\n};` counts once, not twice.
- **Split `pub use` evasion of the valve re-export rule**: `pub use\n crate::live::…;` previously started no use statement at all (`use\s+` required a same-line path) and was invisible to the entire import pass. Both start regexes now end at `use\b` and the re-export check matches the joined statement text.
- **Uppercase-SQL-in-string false positives**: the anchored SELECT pattern gained a `(?!")` exclusion killing `const KEYWORD: &str = "SELECT";` / `#[serde(rename = "SELECT")]` shapes at zero lost detection (measured: `"SELECT " + cols` real queries still match); the indistinguishable `"UPDATE failed"` shape is documented as a known limit with behavior-pinning tests rather than chased.

## Tests

`scripts/test_check_anyharness_boundaries.py` — 90 tests (45 initial + 33 hardening + 12 P2 closure, stdlib unittest, temp-tree fixtures in the style of `test_check_frontend_boundaries.py`; the checker's scan root was made injectable for tests, CLI behavior unchanged). Wired into the CI step ahead of the checker run, mirroring the frontend step.

Verified independently: checker exit 0 on the seeded tree; 90/90 tests green; negative controls run per rule (remove a seed → exit 1 naming the exact file:line; restore → exit 0) and per P2 fix (monkeypatch-revert each fix → its new tests fail with the exact predicted error; restore → green); byte-identical output on all pre-existing rules before/after hardening AND before/after the P2 closure; 15/15 mutants killed by the suite in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
