### PR TITLE
fix(release): preserve staging deployment identity

### DIFF
--- a/.github/workflows/_deploy-server.yml
+++ b/.github/workflows/_deploy-server.yml
@@ -262,28 +262,22 @@ jobs:
           echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
 
       # Version pins stamped into the image and reported by /health and /meta.
-      # The canonical hosted release version is the root VERSION file, which must
-      # agree with anyharness/sdk/package.json. Server, runtime, and worker pins
-      # all use that canonical value: the worker/supervisor Cargo package version
-      # is a stale `0.1.0` and must never become a hosted `/meta` pin. Desktop
-      # keeps its own tracked package version.
+      # Server uses the public product version while AnyHarness, worker, and
+      # supervisor use the independently released Runtime version. The
+      # worker/supervisor Cargo package version is a stale `0.1.0` and must never
+      # become a hosted `/meta` pin. Desktop keeps its own tracked package version.
       - name: Resolve version pins
         id: pins
         run: |
           set -euo pipefail
           server_version="$(cat VERSION)"
           runtime_version="$(jq -r '.version' anyharness/sdk/package.json)"
-          if [ "$server_version" != "$runtime_version" ]; then
-            echo "Canonical version mismatch: VERSION=${server_version} but anyharness/sdk/package.json=${runtime_version}. They must agree for hosted release pins." >&2
-            exit 1
-          fi
-          canonical_version="$server_version"
           desktop_version="$(jq -r '.version' apps/desktop/package.json)"
           {
-            echo "server_version=${canonical_version}"
+            echo "server_version=${server_version}"
             echo "desktop_version=${desktop_version}"
-            echo "runtime_version=${canonical_version}"
-            echo "worker_version=${canonical_version}"
+            echo "runtime_version=${runtime_version}"
+            echo "worker_version=${runtime_version}"
             echo "min_desktop_version=${desktop_version}"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -31,7 +31,18 @@ permissions:
   id-token: write
 
 concurrency:
-  group: deploy-staging
+  group: >-
+    deploy-staging-${{
+      github.event_name == 'workflow_dispatch'
+      && format('push-success-{0}-main', github.repository)
+      || format(
+        '{0}-{1}-{2}-{3}',
+        github.event.workflow_run.event,
+        github.event.workflow_run.conclusion,
+        github.event.workflow_run.head_repository.full_name,
+        github.event.workflow_run.head_branch
+      )
+    }}
   cancel-in-progress: false
 
 env:
@@ -39,7 +50,16 @@ env:
 
 jobs:
   plan:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') }}
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch'
+        || (
+          github.event.workflow_run.conclusion == 'success'
+          && github.event.workflow_run.event == 'push'
+          && github.event.workflow_run.head_branch == 'main'
+          && github.event.workflow_run.head_repository.full_name == github.repository
+        )
+      }}
     runs-on: ubuntu-latest
     outputs:
       base_sha: ${{ steps.detect.outputs.base_sha }}

--- a/scripts/ci-cd/deploy-staging-trigger.test.mjs
+++ b/scripts/ci-cd/deploy-staging-trigger.test.mjs
@@ -9,6 +9,20 @@ const workflow = readFileSync(
   path.join(repoRoot, ".github/workflows/deploy-staging.yml"),
   "utf8",
 );
+const repository = "proliferate-ai/proliferate";
+
+function automaticGroup({ event, conclusion, headRepository, headBranch }) {
+  return `deploy-staging-${event}-${conclusion}-${headRepository}-${headBranch}`;
+}
+
+function isTrustedAutomaticRun({ event, conclusion, headRepository, headBranch }) {
+  return (
+    event === "push" &&
+    conclusion === "success" &&
+    headRepository === repository &&
+    headBranch === "main"
+  );
+}
 
 test("staging queues workflow-run events from main only", () => {
   assert.match(
@@ -17,6 +31,32 @@ test("staging queues workflow-run events from main only", () => {
   );
   assert.match(
     workflow,
-    /^concurrency:\n  group: deploy-staging\n  cancel-in-progress: false$/m,
+    /format\('push-success-\{0\}-main', github\.repository\)/,
   );
+  assert.match(workflow, /github\.event\.workflow_run\.event == 'push'/);
+  assert.match(
+    workflow,
+    /github\.event\.workflow_run\.head_repository\.full_name == github\.repository/,
+  );
+  assert.match(workflow, /github\.event\.workflow_run\.conclusion == 'success'/);
+  assert.match(workflow, /^  cancel-in-progress: false$/m);
+});
+
+test("a fork pull request named main cannot enter or displace the trusted queue", () => {
+  const trusted = {
+    event: "push",
+    conclusion: "success",
+    headRepository: repository,
+    headBranch: "main",
+  };
+  const forkPullRequest = {
+    event: "pull_request",
+    conclusion: "success",
+    headRepository: "contributor/proliferate",
+    headBranch: "main",
+  };
+
+  assert.equal(isTrustedAutomaticRun(trusted), true);
+  assert.equal(isTrustedAutomaticRun(forkPullRequest), false);
+  assert.notEqual(automaticGroup(forkPullRequest), automaticGroup(trusted));
 });

--- a/scripts/ci-cd/deploy-staging-trigger.test.mjs
+++ b/scripts/ci-cd/deploy-staging-trigger.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const workflow = readFileSync(
+  path.join(repoRoot, ".github/workflows/deploy-staging.yml"),
+  "utf8",
+);
+
+test("staging queues workflow-run events from main only", () => {
+  assert.match(
+    workflow,
+    /^on:\n  workflow_run:\n    workflows: \["CI"\]\n    types: \[completed\]\n    branches: \[main\]$/m,
+  );
+  assert.match(
+    workflow,
+    /^concurrency:\n  group: deploy-staging\n  cancel-in-progress: false$/m,
+  );
+});

--- a/server/tests/unit/test_hosted_deploy_identity.py
+++ b/server/tests/unit/test_hosted_deploy_identity.py
@@ -1,4 +1,4 @@
-"""Account-identity and log-redaction contracts for hosted server deploys."""
+"""Identity, version-pin, and redaction contracts for hosted server deploys."""
 
 from __future__ import annotations
 
@@ -55,6 +55,37 @@ def test_deploy_masks_account_and_external_aws_identifiers() -> None:
     assert "SUPPORT_FEED_SECRET_ARN" in mask_run
     assert "::add-mask::" in mask_run
     assert configure["with"]["mask-aws-account-id"] is True
+
+
+def test_deploy_preserves_independent_server_and_runtime_version_pins(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "anyharness" / "sdk").mkdir(parents=True)
+    (tmp_path / "apps" / "desktop").mkdir(parents=True)
+    (tmp_path / "VERSION").write_text("0.4.2\n")
+    (tmp_path / "anyharness" / "sdk" / "package.json").write_text(json.dumps({"version": "0.4.1"}))
+    (tmp_path / "apps" / "desktop" / "package.json").write_text(json.dumps({"version": "0.4.2"}))
+    output_path = tmp_path / "github-output"
+    script_path = tmp_path / "resolve-version-pins.sh"
+    script_path.write_text(str(_deploy_steps()["Resolve version pins"]["run"]))
+
+    result = subprocess.run(
+        ["bash", str(script_path)],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env={**os.environ, "GITHUB_OUTPUT": str(output_path)},
+    )
+
+    assert result.returncode == 0, result.stderr
+    pins = dict(line.split("=", 1) for line in output_path.read_text().splitlines() if line)
+    assert pins == {
+        "server_version": "0.4.2",
+        "desktop_version": "0.4.2",
+        "runtime_version": "0.4.1",
+        "worker_version": "0.4.1",
+        "min_desktop_version": "0.4.2",
+    }
 
 
 def test_workflow_and_terraform_consume_one_hosted_contract() -> None:


### PR DESCRIPTION
## Summary

- preserve independent hosted release identities: server stays on root `VERSION`, while AnyHarness and worker use `anyharness/sdk/package.json`
- admit only successful same-repository `main` pushes to automatic staging, while direct manual staging remains supported
- isolate rejected CI events from the trusted staging concurrency group so failed or fork-PR runs cannot displace a deploy
- add executable regressions for split version pins and the staging admission/concurrency contract

## Root cause

[Deploy Staging run 31050735070](https://github.com/proliferate-ai/proliferate/actions/runs/31050735070) failed before image push or ECS mutation because `_deploy-server.yml` required product/server `0.4.2` to equal the independently published Runtime `0.4.1`. No `runtime-v0.4.2` artifact exists, so bumping the Runtime pin would be incorrect.

Separately, `deploy-staging.yml` accepted CI `workflow_run` events into one global concurrency queue before authenticating their event type and source repository. Skipped, failed, or fork-PR-triggered runs could therefore replace a pending trusted deployment; a fork PR whose source branch was named `main` also matched the branch-name filter.

## Impact

Hosted server deploys now stamp the artifact identities owned by each component. Automatic staging accepts only successful same-repository pushes to `main`; direct manual staging serializes with that same trusted queue, while rejected events cannot evict it.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Verification

- `node --test scripts/ci-cd/*.test.mjs` — 172 passed
- `uv run --extra dev pytest -q tests/unit/test_hosted_deploy_identity.py` — 22 passed
- `python3 scripts/check_workflow_managed_boundaries.py`
- `actionlint .github/workflows/deploy-staging.yml`
- YAML parse for both changed workflows
- Ruff check and format check for `server/tests/unit/test_hosted_deploy_identity.py`
