### PR TITLE
fix(mobile): retain shared target sources in EAS archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ reference/
 dist/
 out/
 target/
+# EAS applies the repository ignore rules when it assembles the mobile
+# monorepo archive. Keep this ProductClient source domain in that archive even
+# though its ownership-correct name matches Cargo's build-output directory.
+!apps/packages/product-client/src/lib/domain/automations/target/
+!apps/packages/product-client/src/lib/domain/automations/target/**
 apps/desktop/index.js
 # ProductClient qualification build canary output (Desktop host build)
 apps/desktop/dist-product-client-qualification/

--- a/scripts/ci-cd/mobile-eas-archive.test.mjs
+++ b/scripts/ci-cd/mobile-eas-archive.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+const mobileBuildInputs = [
+  "apps/mobile",
+  "apps/packages/design",
+  "apps/packages/product-client",
+  "anyharness/sdk",
+  "anyharness/sdk-react",
+  "catalogs/agents",
+  "cloud/sdk",
+  "cloud/sdk-react",
+];
+
+test("mobile EAS archives retain every tracked shared build input", () => {
+  const ignoredTrackedFiles = execFileSync(
+    "git",
+    [
+      "ls-files",
+      "--cached",
+      "--ignored",
+      "--exclude-standard",
+      "--",
+      ...mobileBuildInputs,
+    ],
+    { cwd: repoRoot, encoding: "utf8" },
+  ).trim();
+
+  assert.equal(
+    ignoredTrackedFiles,
+    "",
+    `EAS would omit these tracked mobile build inputs:\n${ignoredTrackedFiles}`,
+  );
+});


### PR DESCRIPTION
## Summary
- re-include the ProductClient automation target domain in monorepo archives assembled for mobile EAS builds
- add a CI regression test that rejects any tracked shared mobile build input hidden by repository ignore rules

## Root cause
The root `.gitignore` rule for Cargo `target/` output also matched the tracked ProductClient source directory named `automations/target`. Normal GitHub checkouts retained tracked files, but EAS archive assembly omitted them, so the iOS post-install ProductClient build failed with TS2307.

## Validation
- `node --test scripts/ci-cd/*.test.mjs` (173 passed)
- `eas build:inspect --platform ios --stage archive --profile staging-testflight`
- verified archived `target/selection.ts` and `target/records.ts` are present