### PR TITLE
test(product): enforce configured class merging

### DIFF
--- a/apps/desktop/scripts/check-design-system.sh
+++ b/apps/desktop/scripts/check-design-system.sh
@@ -76,21 +76,6 @@ for f in $TYPE_HITS; do
   FAIL=1
 done
 
-# tailwind-merge must be imported via the configured wrapper: the stock config
-# classifies our custom text-* size tokens as COLORS and silently deletes them
-# on merge. Only the wrapper module itself may import the library. This rule
-# scans apps/web too (every workspace that depends on tailwind-merge); web is
-# deliberately NOT in TYPE_ROOTS — its px conventions are untouched here.
-TW_MERGE_ROOTS=("${TYPE_ROOTS[@]}" ../web/src)
-TW_MERGE_MODULE="../packages/product-client/src/primitives/utils/tw-merge.ts"
-RAW_TW_HITS=$(grep -rln 'from "tailwind-merge"' "${TW_MERGE_ROOTS[@]}" 2>/dev/null || true)
-for f in $RAW_TW_HITS; do
-  if [[ "$f" != "$TW_MERGE_MODULE" ]]; then
-    echo "FAIL [raw tailwind-merge import — use #product/primitives/utils/tw-merge]: $f"
-    FAIL=1
-  fi
-done
-
 if [[ $FAIL -eq 1 ]]; then
   echo
   echo "Design-system check failed. Spell type through the semantic tokens"

--- a/apps/packages/product-client/src/primitives/utils/tw-merge.ts
+++ b/apps/packages/product-client/src/primitives/utils/tw-merge.ts
@@ -87,10 +87,9 @@ export const CONTROL_HEIGHT_TOKEN_IDS = ["control"] as const;
 
 /**
  * The one true twMerge: knows the design-package font-size tokens. Import it
- * from here — never from "tailwind-merge" directly. check-design-system.sh
- * enforces this across desktop, web, and the shared UI packages — every
- * workspace that depends on tailwind-merge (mobile is React Native and has
- * no tailwind-merge surface).
+ * from here — never from "tailwind-merge" directly. The repository frontend
+ * boundary checker enforces this across every frontend source root, including
+ * test files.
  */
 export const twMerge = extendTailwindMerge<"icon-size">({
   extend: {

--- a/scripts/check_frontend_boundaries.py
+++ b/scripts/check_frontend_boundaries.py
@@ -2740,6 +2740,40 @@ def find_radix_import_violations() -> list[Violation]:
     return violations
 
 
+def find_tailwind_merge_import_violations() -> list[Violation]:
+    """Keep Tailwind class merging behind the configured ProductClient wrapper.
+
+    The stock package does not know ProductClient's semantic text utilities and
+    can discard them as conflicting color classes.  The wrapper extends that
+    configuration, so every frontend caller must import it instead of reaching
+    the package directly.
+    """
+
+    violations: list[Violation] = []
+    wrapper_path = (
+        PRODUCT_CLIENT_PRIMITIVES_SRC / "utils" / "tw-merge.ts"
+    ).resolve()
+    for path in iter_files_in_roots(ALL_FRONTEND_SRC_ROOTS, include_tests=True):
+        if path.resolve() == wrapper_path:
+            continue
+        for statement in collect_module_specifiers(path, path.read_text()):
+            if not is_package_source(statement.source, "tailwind-merge"):
+                continue
+            violations.append(
+                Violation(
+                    "TAILWIND_MERGE_IMPORT_OUTSIDE_WRAPPER",
+                    path,
+                    statement.lineno,
+                    (
+                        "tailwind-merge may only be imported by "
+                        "apps/packages/product-client/src/primitives/utils/tw-merge.ts; "
+                        "use #product/primitives/utils/tw-merge"
+                    ),
+                )
+            )
+    return violations
+
+
 def find_warning_ink_violations() -> list[Violation]:
     """Rule: `--color-warning` is a FILL token, never ink.
 
@@ -2880,6 +2914,7 @@ def collect_violations() -> list[Violation]:
     for path in iter_files_in_roots([MOBILE_SRC], include_tests=True):
         violations.extend(find_mobile_product_client_import_violations(path))
     violations.extend(find_radix_import_violations())
+    violations.extend(find_tailwind_merge_import_violations())
     violations.extend(find_primitives_top_level_violations())
     violations.extend(find_warning_ink_violations())
     return violations

--- a/scripts/check_frontend_boundaries.py
+++ b/scripts/check_frontend_boundaries.py
@@ -266,6 +266,14 @@ def relative(path: Path) -> str:
     return path.relative_to(REPO_ROOT).as_posix()
 
 
+def read_source_text(path: Path, cache: dict[Path, str] | None = None) -> str:
+    if cache is None:
+        return path.read_text()
+    if path not in cache:
+        cache[path] = path.read_text()
+    return cache[path]
+
+
 def is_under(relative_path: str, prefix: str) -> bool:
     return relative_path.startswith(prefix)
 
@@ -2708,17 +2716,27 @@ def find_product_client_violations(path: Path) -> list[Violation]:
     return violations
 
 
-def find_radix_import_violations() -> list[Violation]:
+def find_radix_import_violations(
+    paths: list[Path] | None = None,
+    *,
+    source_cache: dict[Path, str] | None = None,
+) -> list[Violation]:
     """Rule: `@radix-ui/*` imports are legal only in root primitive files and
     the nested `patterns/` tier per the component-library taxonomy in
     specs/codebase/platforms/product/design-system.md.
     """
     violations: list[Violation] = []
-    for path in iter_files_in_roots(ALL_FRONTEND_SRC_ROOTS, include_tests=True):
+    candidates = (
+        paths
+        if paths is not None
+        else iter_files_in_roots(ALL_FRONTEND_SRC_ROOTS, include_tests=True)
+    )
+    for path in candidates:
         rel = relative(path)
         if is_ui_component_library_path(rel):
             continue
-        for lineno, raw_line in enumerate(path.read_text().splitlines(), start=1):
+        text = read_source_text(path, source_cache)
+        for lineno, raw_line in enumerate(text.splitlines(), start=1):
             if is_block_comment_line(raw_line):
                 continue
             line = strip_line_comment(raw_line)
@@ -2740,7 +2758,11 @@ def find_radix_import_violations() -> list[Violation]:
     return violations
 
 
-def find_tailwind_merge_import_violations() -> list[Violation]:
+def find_tailwind_merge_import_violations(
+    paths: list[Path] | None = None,
+    *,
+    source_cache: dict[Path, str] | None = None,
+) -> list[Violation]:
     """Keep Tailwind class merging behind the configured ProductClient wrapper.
 
     The stock package does not know ProductClient's semantic text utilities and
@@ -2750,13 +2772,27 @@ def find_tailwind_merge_import_violations() -> list[Violation]:
     """
 
     violations: list[Violation] = []
-    wrapper_path = (
-        PRODUCT_CLIENT_PRIMITIVES_SRC / "utils" / "tw-merge.ts"
-    ).resolve()
-    for path in iter_files_in_roots(ALL_FRONTEND_SRC_ROOTS, include_tests=True):
-        if path.resolve() == wrapper_path:
+    wrapper_path = PRODUCT_CLIENT_PRIMITIVES_SRC / "utils" / "tw-merge.ts"
+    candidates = (
+        paths
+        if paths is not None
+        else iter_files_in_roots(ALL_FRONTEND_SRC_ROOTS, include_tests=True)
+    )
+    for path in candidates:
+        if path == wrapper_path:
             continue
-        for statement in collect_module_specifiers(path, path.read_text()):
+        text = read_source_text(path, source_cache)
+        # Avoid fully tokenizing every frontend source file for a package used
+        # by only a few of them. Normal module sources contain the package name
+        # verbatim. Keep escaped spellings and finite expressions split at the
+        # package delimiter on the parser-backed path too, so string cooking
+        # and constant-expression evaluation remain authoritative.
+        if (
+            "tailwind-merge" not in text
+            and not ("tailwind" in text and "merge" in text)
+        ):
+            continue
+        for statement in collect_module_specifiers(path, text):
             if not is_package_source(statement.source, "tailwind-merge"):
                 continue
             violations.append(
@@ -2913,8 +2949,20 @@ def collect_violations() -> list[Violation]:
         violations.extend(find_product_client_domain_violations(path))
     for path in iter_files_in_roots([MOBILE_SRC], include_tests=True):
         violations.extend(find_mobile_product_client_import_violations(path))
-    violations.extend(find_radix_import_violations())
-    violations.extend(find_tailwind_merge_import_violations())
+    all_frontend_paths = iter_files_in_roots(
+        ALL_FRONTEND_SRC_ROOTS, include_tests=True
+    )
+    frontend_source_cache: dict[Path, str] = {}
+    violations.extend(
+        find_radix_import_violations(
+            all_frontend_paths, source_cache=frontend_source_cache
+        )
+    )
+    violations.extend(
+        find_tailwind_merge_import_violations(
+            all_frontend_paths, source_cache=frontend_source_cache
+        )
+    )
     violations.extend(find_primitives_top_level_violations())
     violations.extend(find_warning_ink_violations())
     return violations

--- a/scripts/check_frontend_boundaries.py
+++ b/scripts/check_frontend_boundaries.py
@@ -15,6 +15,7 @@ try:
         Token,
         collect_imports,
         collect_module_specifiers,
+        could_contain_literal_sequence,
         tokenize_typescript,
     )
 except ModuleNotFoundError:  # Direct `python3 scripts/...` execution.
@@ -23,6 +24,7 @@ except ModuleNotFoundError:  # Direct `python3 scripts/...` execution.
         Token,
         collect_imports,
         collect_module_specifiers,
+        could_contain_literal_sequence,
         tokenize_typescript,
     )
 
@@ -2782,15 +2784,7 @@ def find_tailwind_merge_import_violations(
         if path == wrapper_path:
             continue
         text = read_source_text(path, source_cache)
-        # Avoid fully tokenizing every frontend source file for a package used
-        # by only a few of them. Normal module sources contain the package name
-        # verbatim. Keep escaped spellings and finite expressions split at the
-        # package delimiter on the parser-backed path too, so string cooking
-        # and constant-expression evaluation remain authoritative.
-        if (
-            "tailwind-merge" not in text
-            and not ("tailwind" in text and "merge" in text)
-        ):
+        if not could_contain_literal_sequence(text, "tailwind-merge"):
             continue
         for statement in collect_module_specifiers(path, text):
             if not is_package_source(statement.source, "tailwind-merge"):

--- a/scripts/frontend_imports.py
+++ b/scripts/frontend_imports.py
@@ -124,6 +124,135 @@ def _decode_javascript_string(raw: str) -> str:
     return "".join(cooked)
 
 
+def _decode_prefilter_character(
+    raw: str,
+    index: int,
+) -> tuple[str | None, int]:
+    """Decode one candidate character without slowing the hot lexer path."""
+
+    if raw[index] != "\\" or index + 1 >= len(raw):
+        return raw[index], index + 1
+
+    escaped = raw[index + 1]
+    if escaped == "\n":
+        return None, index + 2
+    if escaped == "\r":
+        return (
+            None,
+            index + 3
+            if index + 2 < len(raw) and raw[index + 2] == "\n"
+            else index + 2,
+        )
+    if escaped == "x" and index + 3 < len(raw):
+        digits = raw[index + 2 : index + 4]
+        if all(char in "0123456789abcdefABCDEF" for char in digits):
+            return chr(int(digits, 16)), index + 4
+    if escaped == "u":
+        if index + 2 < len(raw) and raw[index + 2] == "{":
+            close = raw.find("}", index + 3)
+            digits = raw[index + 3 : close] if close >= 0 else ""
+            if digits and all(
+                char in "0123456789abcdefABCDEF" for char in digits
+            ):
+                value = int(digits, 16)
+                if value <= 0x10FFFF:
+                    return chr(value), close + 1
+        elif index + 5 < len(raw):
+            digits = raw[index + 2 : index + 6]
+            if all(char in "0123456789abcdefABCDEF" for char in digits):
+                return chr(int(digits, 16)), index + 6
+
+    simple_escapes = {
+        "b": "\b",
+        "f": "\f",
+        "n": "\n",
+        "r": "\r",
+        "t": "\t",
+        "v": "\v",
+        "0": "\0",
+    }
+    return simple_escapes.get(escaped, escaped), index + 2
+
+
+def could_contain_literal_sequence(text: str, target: str) -> bool:
+    """Conservatively find a cooked string assembled from source literals.
+
+    The finite module-source evaluator may choose among and concatenate quoted
+    strings or constant template fragments.  This lightweight prefilter keeps
+    every target-prefix state in source order, decodes JavaScript escapes, and
+    deliberately treats every quote and template-suffix-shaped brace as a
+    possible lexical boundary.  It may return a false positive, but it does
+    not reject escaped, fragmented, parenthesized, conditional, logical,
+    sequence, asserted, or template-built literal strings.
+    """
+
+    if not target:
+        return True
+
+    offsets = {0}
+
+    def advance_fragment(
+        start: int,
+        *,
+        quote: str | None = None,
+        template_fragment: bool = False,
+    ) -> tuple[bool, set[int]]:
+        possible = set(offsets)
+        consumed = 0
+        cursor = start
+        while cursor < len(text):
+            if template_fragment:
+                if text[cursor] == "`" or (
+                    text[cursor] == "$"
+                    and cursor + 1 < len(text)
+                    and text[cursor + 1] == "{"
+                ):
+                    break
+            elif text[cursor] == quote:
+                break
+
+            value, cursor = _decode_prefilter_character(text, cursor)
+            if value is None:
+                continue
+            possible = {
+                offset
+                for offset in possible
+                if offset + consumed < len(target)
+                and target[offset + consumed] == value
+            }
+            if not possible:
+                return False, set()
+            consumed += 1
+            if any(offset + consumed == len(target) for offset in possible):
+                return True, set()
+
+        return (
+            False,
+            {offset + consumed for offset in possible} if consumed else set(),
+        )
+
+    for index, char in enumerate(text):
+        if char in {"'", '"', "`"}:
+            complete, additions = advance_fragment(
+                index + 1,
+                quote=char,
+                template_fragment=char == "`",
+            )
+            if complete:
+                return True
+            offsets.update(additions)
+        if char == "}":
+            complete, additions = advance_fragment(
+                index + 1,
+                template_fragment=True,
+            )
+            if complete:
+                return True
+            offsets.update(additions)
+
+    return False
+
+
 class _TypeScriptLexer:
     def __init__(self, text: str, *, jsx: bool) -> None:
         self.text = text
@@ -2761,10 +2890,12 @@ def _looks_like_assertion_type(tokens: list[Token]) -> bool:
     return not nesting
 
 
-def collect_imports(path: Path, text: str) -> list[ImportStatement]:
-    """Collect static imports, re-exports, and quoted dynamic imports."""
+def _collect_imports_from_tokens(
+    text: str,
+    tokens: list[Token],
+) -> list[ImportStatement]:
+    """Collect import statements from an existing TypeScript token stream."""
 
-    tokens = tokenize_typescript(text, jsx=path.suffix == ".tsx")
     imports: list[ImportStatement] = []
     index = 0
 
@@ -2917,6 +3048,16 @@ def collect_imports(path: Path, text: str) -> list[ImportStatement]:
     return imports
 
 
+def collect_imports(
+    path: Path,
+    text: str,
+) -> list[ImportStatement]:
+    """Collect static imports, re-exports, and quoted dynamic imports."""
+
+    tokens = tokenize_typescript(text, jsx=path.suffix == ".tsx")
+    return _collect_imports_from_tokens(text, tokens)
+
+
 def collect_module_specifiers(path: Path, text: str) -> list[ImportStatement]:
     """Collect every literal TypeScript/Metro module-loading form we enforce.
 
@@ -2927,8 +3068,8 @@ def collect_module_specifiers(path: Path, text: str) -> list[ImportStatement]:
     ``jest.mock(...)`` calls without changing the established import-only API.
     """
 
-    imports = collect_imports(path, text)
     tokens = tokenize_typescript(text, jsx=path.suffix == ".tsx")
+    imports = _collect_imports_from_tokens(text, tokens)
     parens = _matching_pairs(tokens, "(", ")")
     occupied_ranges = [
         (statement.start, statement.start + len(statement.statement))

--- a/scripts/test_check_frontend_boundaries.py
+++ b/scripts/test_check_frontend_boundaries.py
@@ -166,9 +166,11 @@ class TailwindMergeImportBoundaryTest(unittest.TestCase):
     ) -> list[tuple[str, str, int]]:
         product_client_src = root / "apps/packages/product-client/src"
         roots = [
-            product_client_src,
             root / "apps/desktop/src",
             root / "apps/web/src",
+            root / "apps/mobile/src",
+            root / "apps/packages/design/src",
+            product_client_src,
         ]
         with patch.multiple(
             check_module,
@@ -193,6 +195,9 @@ class TailwindMergeImportBoundaryTest(unittest.TestCase):
                     "apps/packages/product-client/src/components/Consumer.tsx": (
                         'import { twMerge } from "#product/primitives/utils/tw-merge";\n'
                     ),
+                    "apps/web/src/PackageName.ts": (
+                        'export const packageName = "tailwind-merge";\n'
+                    ),
                 },
             )
 
@@ -200,21 +205,65 @@ class TailwindMergeImportBoundaryTest(unittest.TestCase):
 
         self.assertEqual(violations, [])
 
-    def test_direct_tailwind_merge_module_loads_fail_in_every_frontend_host(self) -> None:
+    def test_direct_tailwind_merge_module_loads_fail_in_every_frontend_root(
+        self,
+    ) -> None:
+        cases = [
+            (
+                "apps/packages/product-client/src/components/Static.tsx",
+                'import { twMerge } from "tailwind-merge";\n',
+            ),
+            (
+                "apps/desktop/src/Dynamic.ts",
+                'export const load = () => import("tailwind-" + "merge");\n',
+            ),
+            (
+                "apps/web/src/CommonJs.ts",
+                'export const merge = require("tailwind-merge");\n',
+            ),
+            (
+                "apps/mobile/src/ImportEquals.ts",
+                'import twMerge = require("tailwind-merge");\n',
+            ),
+            (
+                "apps/packages/design/src/ReExport.ts",
+                'export { twMerge } from "tailwind-merge/subpath";\n',
+            ),
+            (
+                "apps/desktop/src/__tests__/TailwindMerge.test.ts",
+                'vi.mock("tailwind-merge", () => ({}));\n',
+            ),
+        ]
+
+        for relative_path, source in cases:
+            with self.subTest(path=relative_path):
+                with tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory).resolve()
+                    self.write_files(root, {relative_path: source})
+
+                    violations = self.run_rule(root)
+
+                self.assertEqual(
+                    violations,
+                    [
+                        (
+                            relative_path,
+                            "TAILWIND_MERGE_IMPORT_OUTSIDE_WRAPPER",
+                            1,
+                        )
+                    ],
+                )
+
+    def test_escaped_package_spelling_remains_parser_backed(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory).resolve()
+            relative_path = "apps/web/src/Escaped.ts"
             self.write_files(
                 root,
                 {
-                    "apps/packages/product-client/src/components/Static.tsx": (
-                        'import { twMerge } from "tailwind-merge";\n'
-                    ),
-                    "apps/desktop/src/Dynamic.ts": (
-                        'export const load = () => import("tailwind-merge");\n'
-                    ),
-                    "apps/web/src/CommonJs.ts": (
-                        'export const merge = require("tailwind-merge");\n'
-                    ),
+                    relative_path: (
+                        r'import { twMerge } from "tailwind\u002dmerge";' "\n"
+                    )
                 },
             )
 
@@ -224,22 +273,33 @@ class TailwindMergeImportBoundaryTest(unittest.TestCase):
             violations,
             [
                 (
-                    "apps/desktop/src/Dynamic.ts",
+                    relative_path,
                     "TAILWIND_MERGE_IMPORT_OUTSIDE_WRAPPER",
                     1,
-                ),
-                (
-                    "apps/packages/product-client/src/components/Static.tsx",
-                    "TAILWIND_MERGE_IMPORT_OUTSIDE_WRAPPER",
-                    1,
-                ),
-                (
-                    "apps/web/src/CommonJs.ts",
-                    "TAILWIND_MERGE_IMPORT_OUTSIDE_WRAPPER",
-                    1,
-                ),
+                )
             ],
         )
+
+    def test_non_candidate_files_are_not_tokenized(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            self.write_files(
+                root,
+                {
+                    "apps/desktop/src/Unrelated.ts": (
+                        'import { clsx } from "clsx";\n'
+                    ),
+                },
+            )
+            with patch.object(
+                check_module,
+                "collect_module_specifiers",
+                wraps=check_module.collect_module_specifiers,
+            ) as collect_module_specifiers:
+                violations = self.run_rule(root)
+
+        self.assertEqual(violations, [])
+        collect_module_specifiers.assert_not_called()
 
 
 class ProductClientPrimitivesTopLevelShapeTest(unittest.TestCase):

--- a/scripts/test_check_frontend_boundaries.py
+++ b/scripts/test_check_frontend_boundaries.py
@@ -153,6 +153,95 @@ class RadixImportBoundaryTest(unittest.TestCase):
         self.assertEqual(violations, [])
 
 
+class TailwindMergeImportBoundaryTest(unittest.TestCase):
+    def write_files(self, directory: Path, files: dict[str, str]) -> None:
+        for name, content in files.items():
+            path = directory / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
+
+    def run_rule(
+        self,
+        root: Path,
+    ) -> list[tuple[str, str, int]]:
+        product_client_src = root / "apps/packages/product-client/src"
+        roots = [
+            product_client_src,
+            root / "apps/desktop/src",
+            root / "apps/web/src",
+        ]
+        with patch.multiple(
+            check_module,
+            REPO_ROOT=root,
+            PRODUCT_CLIENT_PRIMITIVES_SRC=product_client_src / "primitives",
+            ALL_FRONTEND_SRC_ROOTS=roots,
+        ):
+            return sorted(
+                (violation.relative_path, violation.rule_id, violation.lineno)
+                for violation in check_module.find_tailwind_merge_import_violations()
+            )
+
+    def test_only_configured_product_client_wrapper_imports_tailwind_merge(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            self.write_files(
+                root,
+                {
+                    "apps/packages/product-client/src/primitives/utils/tw-merge.ts": (
+                        'import { extendTailwindMerge } from "tailwind-merge";\n'
+                    ),
+                    "apps/packages/product-client/src/components/Consumer.tsx": (
+                        'import { twMerge } from "#product/primitives/utils/tw-merge";\n'
+                    ),
+                },
+            )
+
+            violations = self.run_rule(root)
+
+        self.assertEqual(violations, [])
+
+    def test_direct_tailwind_merge_module_loads_fail_in_every_frontend_host(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            self.write_files(
+                root,
+                {
+                    "apps/packages/product-client/src/components/Static.tsx": (
+                        'import { twMerge } from "tailwind-merge";\n'
+                    ),
+                    "apps/desktop/src/Dynamic.ts": (
+                        'export const load = () => import("tailwind-merge");\n'
+                    ),
+                    "apps/web/src/CommonJs.ts": (
+                        'export const merge = require("tailwind-merge");\n'
+                    ),
+                },
+            )
+
+            violations = self.run_rule(root)
+
+        self.assertEqual(
+            violations,
+            [
+                (
+                    "apps/desktop/src/Dynamic.ts",
+                    "TAILWIND_MERGE_IMPORT_OUTSIDE_WRAPPER",
+                    1,
+                ),
+                (
+                    "apps/packages/product-client/src/components/Static.tsx",
+                    "TAILWIND_MERGE_IMPORT_OUTSIDE_WRAPPER",
+                    1,
+                ),
+                (
+                    "apps/web/src/CommonJs.ts",
+                    "TAILWIND_MERGE_IMPORT_OUTSIDE_WRAPPER",
+                    1,
+                ),
+            ],
+        )
+
+
 class ProductClientPrimitivesTopLevelShapeTest(unittest.TestCase):
     def test_only_allowed_top_level_entries_pass(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/test_check_frontend_boundaries.py
+++ b/scripts/test_check_frontend_boundaries.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from scripts import check_frontend_boundaries as check_module
+from scripts import frontend_imports as frontend_imports_module
 from scripts import report_frontend_structure as structure_module
 from scripts.frontend_imports import collect_imports, collect_module_specifiers
 
@@ -254,52 +255,64 @@ class TailwindMergeImportBoundaryTest(unittest.TestCase):
                     ],
                 )
 
-    def test_escaped_package_spelling_remains_parser_backed(self) -> None:
-        with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory).resolve()
-            relative_path = "apps/web/src/Escaped.ts"
-            self.write_files(
-                root,
-                {
-                    relative_path: (
-                        r'import { twMerge } from "tailwind\u002dmerge";' "\n"
-                    )
-                },
-            )
+    def test_obscured_package_spelling_remains_parser_backed(self) -> None:
+        cases = [
+            r'import { twMerge } from "tailw\u0069nd-merge";' "\n",
+            r'import { twMerge } from "tailwind-\u006derge";' "\n",
+            'import("tail" + "wind-merge");\n',
+            'require("tailwind-" + "mer" + "ge");\n',
+            (
+                r'import("\u0074\u0061\u0069\u006c\u0077\u0069\u006e'
+                r'\u0064\u002d\u006d\u0065\u0072\u0067\u0065");' "\n"
+            ),
+            'jest.mock("tail" + "wind-" + "merge/" + "default-config");\n',
+            'import(`tail${"wind"}-merge`);\n',
+            (
+                'import(("tail" + (true ? "wind" : "unused") + '
+                '"-merge") as string);\n'
+            ),
+        ]
 
-            violations = self.run_rule(root)
+        for source in cases:
+            with self.subTest(source=source):
+                with tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory).resolve()
+                    relative_path = "apps/web/src/Obscured.ts"
+                    self.write_files(root, {relative_path: source})
 
-        self.assertEqual(
-            violations,
-            [
-                (
-                    relative_path,
-                    "TAILWIND_MERGE_IMPORT_OUTSIDE_WRAPPER",
-                    1,
+                    violations = self.run_rule(root)
+
+                self.assertEqual(
+                    violations,
+                    [
+                        (
+                            relative_path,
+                            "TAILWIND_MERGE_IMPORT_OUTSIDE_WRAPPER",
+                            1,
+                        )
+                    ],
                 )
-            ],
-        )
 
-    def test_non_candidate_files_are_not_tokenized(self) -> None:
+    def test_each_source_is_tokenized_once(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory).resolve()
             self.write_files(
                 root,
                 {
-                    "apps/desktop/src/Unrelated.ts": (
-                        'import { clsx } from "clsx";\n'
+                    "apps/desktop/src/Candidate.ts": (
+                        'import("tail" + "wind-merge");\n'
                     ),
                 },
             )
             with patch.object(
-                check_module,
-                "collect_module_specifiers",
-                wraps=check_module.collect_module_specifiers,
-            ) as collect_module_specifiers:
+                frontend_imports_module,
+                "tokenize_typescript",
+                wraps=frontend_imports_module.tokenize_typescript,
+            ) as tokenize_typescript:
                 violations = self.run_rule(root)
 
-        self.assertEqual(violations, [])
-        collect_module_specifiers.assert_not_called()
+        self.assertEqual(len(violations), 1)
+        tokenize_typescript.assert_called_once()
 
 
 class ProductClientPrimitivesTopLevelShapeTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- reject direct `tailwind-merge` module loads across ProductClient, Desktop, Web, Mobile, and Design sources, including tests
- keep semantic class configuration owned by `primitives/utils/tw-merge.ts`
- cover static imports, re-exports, dynamic imports, CommonJS, mocks, escaped spellings, finite expressions, templates, and subpaths
- move the guard into the central frontend boundary checker and remove the duplicate Desktop-only grep

## Why
The stock merger does not know ProductClient semantic text utilities and can silently discard them as conflicting color classes. The configured wrapper extends that behavior and must remain the only direct package owner.

## Validation
- `python3 -m unittest scripts.test_check_frontend_boundaries` (77 passed)
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_design_attribution.py`
- `apps/desktop/scripts/check-design-system.sh`
- `git diff --check`
- exact prior-head versus repaired-head checker benchmark remained within run-to-run variance