### PR TITLE
fix(product): align edit activity interactions

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx
@@ -28,25 +28,8 @@ function render(ui: ReactElement) {
   return testingRender(ui, { wrapper: WebProductHostWrapper });
 }
 
-const {
-  openPrimaryMock,
-  fileReferenceActionsCalls,
-  fileReferenceOpenState,
-} = vi.hoisted(() => ({
-  openPrimaryMock: vi.fn(),
-  fileReferenceActionsCalls: [] as Array<{ rawPath: string; workspacePath?: string | null }>,
-  fileReferenceOpenState: {
-    canOpenPrimary: true,
-    canOpenInSidebar: true,
-    canOpenExternal: true,
-    canReveal: true,
-    pathKind: "file" as "file" | "directory" | null,
-  },
-}));
-
 vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", () => ({
   useFileReferenceActions: (args: { rawPath: string; workspacePath?: string | null }) => {
-    fileReferenceActionsCalls.push(args);
     return {
       reference: {
         rawPath: args.rawPath,
@@ -58,11 +41,15 @@ vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", 
       },
       openTargets: [],
       defaultOpenTarget: null,
-      ...fileReferenceOpenState,
+      canOpenPrimary: true,
+      canOpenInSidebar: true,
+      canOpenExternal: true,
+      canReveal: true,
+      pathKind: "file",
       copyPath: vi.fn(),
       openInSidebar: vi.fn(),
       openDefault: vi.fn(),
-      openPrimary: openPrimaryMock,
+      openPrimary: vi.fn(),
       openWithTarget: vi.fn(),
       reveal: vi.fn(),
     };
@@ -71,13 +58,6 @@ vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", 
 
 afterEach(() => {
   cleanup();
-  openPrimaryMock.mockClear();
-  fileReferenceActionsCalls.length = 0;
-  fileReferenceOpenState.canOpenPrimary = true;
-  fileReferenceOpenState.canOpenInSidebar = true;
-  fileReferenceOpenState.canOpenExternal = true;
-  fileReferenceOpenState.canReveal = true;
-  fileReferenceOpenState.pathKind = "file";
 });
 
 describe("CollapsedActions", () => {
@@ -563,92 +543,5 @@ describe("CollapsedActions", () => {
     const genericLabels = screen.getAllByText("Tool call");
     expect(genericLabels[genericLabels.length - 1]?.parentElement?.className)
       .toContain("text-foreground/60");
-  });
-
-  it("reveals the edited diff from the row and opens the file from its name or arrow", () => {
-    const transcript = createTranscriptState("session-1");
-    const firstEdit = toolItem("edit-1", "turn-1", 1, "file_change");
-    const firstEditPart = firstEdit.contentParts[0];
-    if (firstEditPart?.type === "file_change") {
-      firstEditPart.patch = "@@ -1 +1 @@\n-old\n+new";
-    }
-    transcript.itemsById = {
-      "edit-1": firstEdit,
-    };
-
-    render(
-      <CollapsedActions
-        itemIds={["edit-1"]}
-        transcript={transcript}
-      />,
-    );
-
-    expect(document.body.innerHTML).not.toContain("data-diff-surface=\"chat\"");
-    fireEvent.click(screen.getByRole("button", { name: /Edited a file/i }));
-    const toggle = screen.getByRole("button", { name: "Toggle diff for edit-1.ts" });
-    fireEvent.click(toggle);
-    expect(document.body.innerHTML).toContain("data-diff-surface=\"chat\"");
-    expect(openPrimaryMock).not.toHaveBeenCalled();
-
-    fireEvent.click(screen.getByRole("button", { name: "edit-1.ts" }));
-    expect(openPrimaryMock).toHaveBeenCalledOnce();
-    expect(toggle.getAttribute("aria-expanded")).toBe("true");
-
-    fireEvent.click(screen.getByRole("button", { name: "Open edit-1.ts" }));
-    expect(openPrimaryMock).toHaveBeenCalledTimes(2);
-    expect(toggle.getAttribute("aria-expanded")).toBe("true");
-  });
-
-  it("keeps edit file controls available while the path kind is resolving", () => {
-    fileReferenceOpenState.canOpenInSidebar = false;
-    fileReferenceOpenState.canOpenExternal = false;
-    fileReferenceOpenState.canReveal = false;
-    fileReferenceOpenState.pathKind = null;
-
-    const transcript = createTranscriptState("session-1");
-    transcript.itemsById = {
-      "edit-1": toolItem("edit-1", "turn-1", 1, "file_change"),
-    };
-
-    render(
-      <CollapsedActions
-        itemIds={["edit-1"]}
-        transcript={transcript}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: /Edited a file/i }));
-    fireEvent.click(screen.getByRole("button", { name: "edit-1.ts" }));
-    fireEvent.click(screen.getByRole("button", { name: "Open edit-1.ts" }));
-
-    expect(openPrimaryMock).toHaveBeenCalledTimes(2);
-  });
-
-  it("opens the file context menu without opening the file or toggling its diff", () => {
-    const transcript = createTranscriptState("session-1");
-    const firstEdit = toolItem("edit-1", "turn-1", 1, "file_change");
-    const firstEditPart = firstEdit.contentParts[0];
-    if (firstEditPart?.type === "file_change") {
-      firstEditPart.patch = "@@ -1 +1 @@\n-old\n+new";
-    }
-    transcript.itemsById = {
-      "edit-1": firstEdit,
-    };
-
-    render(
-      <CollapsedActions
-        itemIds={["edit-1"]}
-        transcript={transcript}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: /Edited a file/i }));
-    const fileName = screen.getByRole("button", { name: "edit-1.ts" });
-    const toggle = screen.getByRole("button", { name: "Toggle diff for edit-1.ts" });
-    fireEvent.contextMenu(fileName);
-
-    expect(screen.getByRole("menuitem", { name: "Copy path" })).toBeTruthy();
-    expect(openPrimaryMock).not.toHaveBeenCalled();
-    expect(toggle.getAttribute("aria-expanded")).toBe("false");
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx
@@ -28,9 +28,20 @@ function render(ui: ReactElement) {
   return testingRender(ui, { wrapper: WebProductHostWrapper });
 }
 
-const { openPrimaryMock, fileReferenceActionsCalls } = vi.hoisted(() => ({
+const {
+  openPrimaryMock,
+  fileReferenceActionsCalls,
+  fileReferenceOpenState,
+} = vi.hoisted(() => ({
   openPrimaryMock: vi.fn(),
   fileReferenceActionsCalls: [] as Array<{ rawPath: string; workspacePath?: string | null }>,
+  fileReferenceOpenState: {
+    canOpenPrimary: true,
+    canOpenInSidebar: true,
+    canOpenExternal: true,
+    canReveal: true,
+    pathKind: "file" as "file" | "directory" | null,
+  },
 }));
 
 vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", () => ({
@@ -46,8 +57,8 @@ vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", 
         workspacePath: args.rawPath,
       },
       openTargets: [],
-      canOpenInSidebar: true,
-      canOpenExternal: true,
+      defaultOpenTarget: null,
+      ...fileReferenceOpenState,
       copyPath: vi.fn(),
       openInSidebar: vi.fn(),
       openDefault: vi.fn(),
@@ -62,6 +73,11 @@ afterEach(() => {
   cleanup();
   openPrimaryMock.mockClear();
   fileReferenceActionsCalls.length = 0;
+  fileReferenceOpenState.canOpenPrimary = true;
+  fileReferenceOpenState.canOpenInSidebar = true;
+  fileReferenceOpenState.canOpenExternal = true;
+  fileReferenceOpenState.canReveal = true;
+  fileReferenceOpenState.pathKind = "file";
 });
 
 describe("CollapsedActions", () => {
@@ -459,29 +475,28 @@ describe("CollapsedActions", () => {
     expect(document.body.innerHTML).toContain("data-diff-surface=\"chat\"");
   });
 
-  it("opens Changes from an edit summary and keeps ledger disclosure separate", () => {
+  it("toggles edited files from the whole summary row", () => {
     const transcript = createTranscriptState("session-1");
     transcript.itemsById = {
       "edit-1": toolItem("edit-1", "turn-1", 1, "file_change"),
       "edit-2": toolItem("edit-2", "turn-1", 2, "file_change"),
     };
-    const onOpenChanges = vi.fn();
-
     render(
       <CollapsedActions
         itemIds={["edit-1", "edit-2"]}
         transcript={transcript}
-        onOpenChanges={onOpenChanges}
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Edited files" }));
-    expect(onOpenChanges).toHaveBeenCalledOnce();
-    expect(document.querySelector("[data-collapsed-actions-ledger]")).toBeNull();
+    const summary = screen.getByRole("button", { name: "Edited files" });
+    expect(summary.getAttribute("aria-expanded")).toBe("false");
 
-    fireEvent.click(screen.getByRole("button", { name: "Expand edited files" }));
+    fireEvent.click(summary);
+    expect(summary.getAttribute("aria-expanded")).toBe("true");
     expect(document.querySelector("[data-collapsed-actions-ledger]")).not.toBeNull();
-    expect(screen.getByRole("button", { name: "Collapse edited files" })).toBeTruthy();
+
+    fireEvent.click(summary);
+    expect(summary.getAttribute("aria-expanded")).toBe("false");
   });
 
   it("repeats each parsed command's semantic icon in the expanded ledger", () => {
@@ -550,7 +565,7 @@ describe("CollapsedActions", () => {
       .toContain("text-foreground/60");
   });
 
-  it("reveals the edited diff from the row and opens the file only from its arrow", () => {
+  it("reveals the edited diff from the row and opens the file from its name or arrow", () => {
     const transcript = createTranscriptState("session-1");
     const firstEdit = toolItem("edit-1", "turn-1", 1, "file_change");
     const firstEditPart = firstEdit.contentParts[0];
@@ -575,8 +590,65 @@ describe("CollapsedActions", () => {
     expect(document.body.innerHTML).toContain("data-diff-surface=\"chat\"");
     expect(openPrimaryMock).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole("button", { name: "Open edit-1.ts" }));
+    fireEvent.click(screen.getByRole("button", { name: "edit-1.ts" }));
     expect(openPrimaryMock).toHaveBeenCalledOnce();
     expect(toggle.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Open edit-1.ts" }));
+    expect(openPrimaryMock).toHaveBeenCalledTimes(2);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("keeps edit file controls available while the path kind is resolving", () => {
+    fileReferenceOpenState.canOpenInSidebar = false;
+    fileReferenceOpenState.canOpenExternal = false;
+    fileReferenceOpenState.canReveal = false;
+    fileReferenceOpenState.pathKind = null;
+
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = {
+      "edit-1": toolItem("edit-1", "turn-1", 1, "file_change"),
+    };
+
+    render(
+      <CollapsedActions
+        itemIds={["edit-1"]}
+        transcript={transcript}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Edited a file/i }));
+    fireEvent.click(screen.getByRole("button", { name: "edit-1.ts" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open edit-1.ts" }));
+
+    expect(openPrimaryMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("opens the file context menu without opening the file or toggling its diff", () => {
+    const transcript = createTranscriptState("session-1");
+    const firstEdit = toolItem("edit-1", "turn-1", 1, "file_change");
+    const firstEditPart = firstEdit.contentParts[0];
+    if (firstEditPart?.type === "file_change") {
+      firstEditPart.patch = "@@ -1 +1 @@\n-old\n+new";
+    }
+    transcript.itemsById = {
+      "edit-1": firstEdit,
+    };
+
+    render(
+      <CollapsedActions
+        itemIds={["edit-1"]}
+        transcript={transcript}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Edited a file/i }));
+    const fileName = screen.getByRole("button", { name: "edit-1.ts" });
+    const toggle = screen.getByRole("button", { name: "Toggle diff for edit-1.ts" });
+    fireEvent.contextMenu(fileName);
+
+    expect(screen.getByRole("menuitem", { name: "Copy path" })).toBeTruthy();
+    expect(openPrimaryMock).not.toHaveBeenCalled();
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActions.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActions.tsx
@@ -21,7 +21,6 @@ interface CollapsedActionsProps {
   autoFollow?: boolean;
   /** Keep the trailing exploration phase visually live between tool events. */
   liveContinuation?: boolean;
-  onOpenChanges?: () => void;
 }
 
 export function CollapsedActions({
@@ -29,7 +28,6 @@ export function CollapsedActions({
   transcript,
   autoFollow = false,
   liveContinuation = false,
-  onOpenChanges,
 }: CollapsedActionsProps) {
   const hasActiveAction = itemIds.some((itemId) => {
     const item = transcript.itemsById[itemId];
@@ -53,7 +51,6 @@ export function CollapsedActions({
   const summaryIcon = currentAction
     ? <CollapsedActionIcon kind={currentAction.kind} />
     : <CollapsedActionIcon kind={resolveCollapsedActionsLeadingKind(actionSummary)} />;
-  const summaryOpensChanges = containsEdits && Boolean(onOpenChanges) && !isLiveAction;
 
   function toggleExpanded() {
     const nextExpanded = !expanded;
@@ -70,12 +67,9 @@ export function CollapsedActions({
           size="unstyled"
           data-chat-transcript-ignore
           data-active={isLiveAction ? "true" : undefined}
-          aria-expanded={summaryOpensChanges ? undefined : expanded}
-          title={summaryOpensChanges ? "Open changes" : undefined}
+          aria-expanded={expanded}
           className="h-auto max-w-full justify-start gap-1 rounded-none bg-transparent p-0 text-left text-chat leading-normal font-normal text-foreground/60 hover:bg-transparent hover:text-foreground focus-visible:text-foreground"
-          onClick={summaryOpensChanges
-            ? onOpenChanges
-            : toggleExpanded}
+          onClick={toggleExpanded}
         >
           <span className="inline-flex min-w-0 shrink items-center gap-1.5 truncate">
             <span
@@ -95,38 +89,15 @@ export function CollapsedActions({
                 : summary}
             </span>
           </span>
-          {!summaryOpensChanges && (
-            <ChevronRightActivity
-              aria-hidden="true"
-              className={`icon-compact shrink-0 text-current transition-transform duration-disclosure ${
-                expanded
-                  ? "rotate-90 opacity-100"
-                  : "opacity-0 group-hover/collapsed-actions:opacity-100 group-focus-visible/collapsed-actions:opacity-100"
-              }`}
-            />
-          )}
+          <ChevronRightActivity
+            aria-hidden="true"
+            className={`icon-compact shrink-0 text-current transition-transform duration-disclosure ${
+              expanded
+                ? "rotate-90 opacity-100"
+                : "opacity-0 group-hover/collapsed-actions:opacity-100 group-focus-visible/collapsed-actions:opacity-100"
+            }`}
+          />
         </Button>
-        {summaryOpensChanges && (
-          <Button
-            type="button"
-            variant="unstyled"
-            size="unstyled"
-            data-chat-transcript-ignore
-            aria-label={expanded ? "Collapse edited files" : "Expand edited files"}
-            aria-expanded={expanded}
-            onClick={toggleExpanded}
-            className="size-5 shrink-0 rounded-none bg-transparent p-0 text-ui text-current hover:bg-transparent focus-visible:text-foreground"
-          >
-            <ChevronRightActivity
-              aria-hidden="true"
-              className={`text-ui icon-compact text-current transition-transform duration-disclosure ${
-                expanded
-                  ? "rotate-90 opacity-100"
-                  : "opacity-0 group-hover/collapsed-actions:opacity-100 group-focus-visible/collapsed-actions:opacity-100"
-              }`}
-            />
-          </Button>
-        )}
       </div>
       <AnimatedCollapsibleContent expanded={expanded}>
         <div className="mt-1 flex flex-col gap-1">

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+
+import type { PropsWithChildren, ReactElement } from "react";
+import {
+  cleanup,
+  fireEvent,
+  render as testingRender,
+  screen,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ProductHost } from "@proliferate/product-client/host/product-host";
+import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
+import { EditRows } from "#product/components/workspace/chat/tool-calls/CollapsedEditActionRows";
+import { toolItem } from "#product/domain/chats/transcript/transcript-presentation-test-fixtures";
+
+const webTestHost = { desktop: null } as ProductHost;
+
+function WebProductHostWrapper({ children }: PropsWithChildren) {
+  return <ProductHostProvider host={webTestHost}>{children}</ProductHostProvider>;
+}
+
+function render(ui: ReactElement) {
+  return testingRender(ui, { wrapper: WebProductHostWrapper });
+}
+
+const { openPrimaryMock, fileReferenceOpenState } = vi.hoisted(() => ({
+  openPrimaryMock: vi.fn(),
+  fileReferenceOpenState: {
+    canOpenPrimary: true,
+    canOpenInSidebar: true,
+    canOpenExternal: true,
+    canReveal: true,
+    pathKind: "file" as "file" | "directory" | null,
+  },
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", () => ({
+  useFileReferenceActions: (args: { rawPath: string; workspacePath?: string | null }) => ({
+    reference: {
+      rawPath: args.rawPath,
+      path: args.rawPath,
+      line: null,
+      column: null,
+      absolutePath: `/repo/${args.rawPath}`,
+      workspacePath: args.rawPath,
+    },
+    openTargets: [],
+    defaultOpenTarget: null,
+    ...fileReferenceOpenState,
+    copyPath: vi.fn(),
+    openInSidebar: vi.fn(),
+    openDefault: vi.fn(),
+    openPrimary: openPrimaryMock,
+    openWithTarget: vi.fn(),
+    reveal: vi.fn(),
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+  openPrimaryMock.mockClear();
+  fileReferenceOpenState.canOpenPrimary = true;
+  fileReferenceOpenState.canOpenInSidebar = true;
+  fileReferenceOpenState.canOpenExternal = true;
+  fileReferenceOpenState.canReveal = true;
+  fileReferenceOpenState.pathKind = "file";
+});
+
+function editItem({ patch = false }: { patch?: boolean } = {}) {
+  const item = toolItem("edit-1", "turn-1", 1, "file_change");
+  const part = item.contentParts[0];
+  if (patch && part?.type === "file_change") {
+    part.patch = "@@ -1 +1 @@\n-old\n+new";
+  }
+  return item;
+}
+
+describe("CollapsedEditActionRows", () => {
+  it("toggles the diff from the row and opens the file from its name or arrow", () => {
+    render(<EditRows item={editItem({ patch: true })} />);
+
+    const toggle = screen.getByRole("button", { name: "Toggle diff for edit-1.ts" });
+    fireEvent.click(toggle);
+    expect(document.body.innerHTML).toContain("data-diff-surface=\"chat\"");
+    expect(openPrimaryMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "edit-1.ts" }));
+    expect(openPrimaryMock).toHaveBeenCalledOnce();
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Open edit-1.ts" }));
+    expect(openPrimaryMock).toHaveBeenCalledTimes(2);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("keeps file controls available while the path kind is resolving", () => {
+    fileReferenceOpenState.canOpenInSidebar = false;
+    fileReferenceOpenState.canOpenExternal = false;
+    fileReferenceOpenState.canReveal = false;
+    fileReferenceOpenState.pathKind = null;
+
+    render(<EditRows item={editItem()} />);
+    fireEvent.click(screen.getByRole("button", { name: "edit-1.ts" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open edit-1.ts" }));
+
+    expect(openPrimaryMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("opens the context menu without opening the file or toggling its diff", () => {
+    render(<EditRows item={editItem({ patch: true })} />);
+
+    const fileName = screen.getByRole("button", { name: "edit-1.ts" });
+    const toggle = screen.getByRole("button", { name: "Toggle diff for edit-1.ts" });
+    fireEvent.contextMenu(fileName);
+
+    expect(screen.getByRole("menuitem", { name: "Copy path" })).toBeTruthy();
+    expect(openPrimaryMock).not.toHaveBeenCalled();
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.tsx
@@ -65,7 +65,7 @@ function EditActionRow({
   const canExpand = Boolean(patch);
   const fileActions = useFileReferenceActions({ rawPath: pathLabel, workspacePath });
   const nativeContextMenu = useFileReferenceNativeContextMenu(fileActions);
-  const canOpenFile = fileActions.canOpenInSidebar || fileActions.canOpenExternal;
+  const canOpenFile = fileActions.canOpenPrimary;
   const displayPolicy = patch
     ? resolveDiffDisplayPolicy({ path: pathLabel, additions, deletions, patch })
     : null;
@@ -103,13 +103,31 @@ function EditActionRow({
         {failed && (
           <span className="shrink-0">{formatFailedEditActionTitle(part.operation)}</span>
         )}
-        <span
-          data-edit-action-file-label
-          title={pathLabel}
-          className="min-w-0 truncate underline decoration-current decoration-dotted decoration-[0.5px] underline-offset-2"
-        >
-          {displayName}
-        </span>
+        {canOpenFile ? (
+          <Button
+            type="button"
+            variant="unstyled"
+            size="unstyled"
+            data-chat-transcript-ignore
+            data-edit-action-file-label
+            title={pathLabel}
+            onClick={(event) => {
+              event.stopPropagation();
+              void fileActions.openPrimary();
+            }}
+            className="pointer-events-auto h-auto min-w-0 max-w-full shrink justify-start truncate rounded-none bg-transparent p-0 text-left text-chat font-normal text-current underline decoration-current decoration-dotted decoration-[0.5px] underline-offset-2 hover:bg-transparent hover:text-current focus-visible:ring-1 focus-visible:ring-border"
+          >
+            {displayName}
+          </Button>
+        ) : (
+          <span
+            data-edit-action-file-label
+            title={pathLabel}
+            className="min-w-0 truncate underline decoration-current decoration-dotted decoration-[0.5px] underline-offset-2"
+          >
+            {displayName}
+          </span>
+        )}
         <FileChangeStats
           additions={additions}
           deletions={deletions}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/ScopedTranscriptBlocks.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/ScopedTranscriptBlocks.tsx
@@ -14,14 +14,12 @@ export function ScopedTranscriptBlocks({
   transcript,
   autoFollowCollapsedActionBlockId,
   animateActivityEntry = false,
-  onOpenChanges,
   renderItem,
 }: {
   displayBlocks: readonly TurnDisplayBlock[];
   transcript: TranscriptState;
   autoFollowCollapsedActionBlockId?: string | null;
   animateActivityEntry?: boolean;
-  onOpenChanges?: () => void;
   renderItem: (itemId: string) => ReactNode;
 }) {
   return (
@@ -33,7 +31,6 @@ export function ScopedTranscriptBlocks({
           transcript={transcript}
           autoFollowCollapsedActionBlockId={autoFollowCollapsedActionBlockId}
           animateActivityEntry={animateActivityEntry}
-          onOpenChanges={onOpenChanges}
           renderItem={renderItem}
         />
       ))}
@@ -46,14 +43,12 @@ export function TurnDisplayBlockNode({
   transcript,
   autoFollowCollapsedActionBlockId,
   animateActivityEntry = false,
-  onOpenChanges,
   renderItem,
 }: {
   block: TurnDisplayBlock;
   transcript: TranscriptState;
   autoFollowCollapsedActionBlockId?: string | null;
   animateActivityEntry?: boolean;
-  onOpenChanges?: () => void;
   renderItem: (itemId: string) => ReactNode;
 }) {
   if (block.kind === "collapsed_actions") {
@@ -68,7 +63,6 @@ export function TurnDisplayBlockNode({
           transcript={transcript}
           autoFollow={ownsLiveContinuation}
           liveContinuation={ownsLiveContinuation}
-          onOpenChanges={onOpenChanges}
         />
       </TranscriptActivityBlock>
     );
@@ -86,7 +80,6 @@ export function TurnDisplayBlockNode({
           transcript={transcript}
           autoFollow={ownsLiveContinuation}
           liveContinuation={ownsLiveContinuation}
-          onOpenChanges={onOpenChanges}
         />
       </TranscriptActivityBlock>
     );
@@ -104,7 +97,6 @@ export function TurnDisplayBlockNode({
           transcript={transcript}
           autoFollow={ownsLiveContinuation}
           liveContinuation={ownsLiveContinuation}
-          onOpenChanges={onOpenChanges}
         />
       </TranscriptActivityBlock>
     );

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
@@ -251,7 +251,6 @@ export function TranscriptTurnRow({
           onAssistantRevealStateChange={handleAssistantRevealStateChange}
           showCompletedArtifactFallback={row.isLastTurnRow}
           workspaceId={selectedWorkspaceId}
-          onOpenTurnChanges={onOpenTurnChanges}
           onOpenArtifact={onOpenArtifact}
           onHandOffPlanToNewSession={onHandOffPlanToNewSession}
         />

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.tsx
@@ -47,7 +47,6 @@ export function TurnItemSequence({
   onAssistantRevealStateChange,
   showCompletedArtifactFallback,
   workspaceId,
-  onOpenTurnChanges,
   onOpenArtifact,
   onHandOffPlanToNewSession,
 }: {
@@ -66,7 +65,6 @@ export function TurnItemSequence({
   ) => void;
   showCompletedArtifactFallback: boolean;
   workspaceId: string | null;
-  onOpenTurnChanges?: () => void;
   onOpenArtifact: (workspaceId: string, artifactId: string) => void;
   onHandOffPlanToNewSession?: PlanHandoffHandler;
 }) {
@@ -151,7 +149,6 @@ export function TurnItemSequence({
                         transcript={transcript}
                         autoFollowCollapsedActionBlockId={null}
                         animateActivityEntry={false}
-                        onOpenChanges={onOpenTurnChanges}
                         renderItem={(itemId) => (
                           <TranscriptFragment
                             itemId={itemId}
@@ -178,7 +175,6 @@ export function TurnItemSequence({
               transcript={transcript}
               autoFollowCollapsedActionBlockId={autoFollowCollapsedActionBlockId}
               animateActivityEntry={animateActivityEntry}
-              onOpenChanges={onOpenTurnChanges}
               renderItem={(itemId) => (
                 <TranscriptFragment
                   itemId={itemId}

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -256,14 +256,17 @@ search/read row may say `Read files` while using the search glyph). Semantic
 icons and labels share the same 60%-foreground ink, and the icon box scales
 with transcript text instead of using a fixed pixel size. The disclosure
 chevron remains layout-reserved but hidden until hover/focus or expansion.
+Clicking the completed activity summary, including a summary containing edits,
+toggles its ledger; the summary does not route to the Changes pane.
 Every row revealed inside an activity ledger repeats its own semantic glyph
 (including mixed parsed shell operations), at the same text-relative size and
 inherited ink as its label. Completed command details use `Ran …`; only the
 active command uses `Running …`. An edit detail shows one pen glyph followed by
 an inherited-color, dotted-underlined filename, not a second file-type glyph.
-When a transcript patch is available, clicking the edit row toggles its inline
-diff; clicking the trailing open-file arrow opens the file without changing the
-row's expanded state. The row retains the file-reference context menu. Edit
+When a transcript patch is available, clicking the edit row outside its
+filename toggles the inline diff. Clicking either the filename or the trailing
+open-file arrow opens the file without changing the row's expanded state. The
+row retains the file-reference context menu. Edit
 counts remain neutral beside the filename until row hover or focus within the
 row gives additions and deletions their semantic colors.
 


### PR DESCRIPTION
## Summary

- Make the completed activity summary, including edit summaries, toggle its file ledger as one disclosure target.
- Open an edited file from either its filename or trailing open control while the remaining row continues to toggle the inline diff.
- Preserve file context menus and keep open controls available while path metadata is still resolving.
- Remove the obsolete Changes-pane callback from the activity-ledger path and document the interaction contract.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] No support relationship applies.

## Verification

- `PATH=/Users/pablohansen/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm --dir apps/packages/product-client exec vitest run src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx src/components/workspace/chat/tool-calls/CollapsedEditActionRows.test.tsx` (19 passed)
- `PATH=/Users/pablohansen/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm --dir apps/packages/product-client exec tsc -p tsconfig.json --noEmit`
- `python3 scripts/report_frontend_structure.py --strict`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `python3 scripts/check_design_attribution.py`
- `python3 scripts/check_docs.py`
- `git diff --check origin/main...HEAD`
- Rendered playground fixture: the edit summary moved from `aria-expanded=false` to `true` and back to `false`; the file-row context menu opened without changing disclosure state.
