### PR TITLE
fix(product): keep composer caret inside its editor

### DIFF
--- a/apps/packages/design/src/css/product.css
+++ b/apps/packages/design/src/css/product.css
@@ -327,8 +327,8 @@ body {
 
 /* The composer uses a fail-safe one-pixel visual caret because current macOS
    WebKit paints its redesigned native caret at two CSS pixels. Layout-critical
-   styles are inline on the overlay; this rule is the native fallback whenever
-   the overlay cannot resolve a valid collapsed selection. */
+   styles are inline on the editor-owned visual caret; this rule is the native
+   fallback whenever that caret cannot resolve a valid collapsed selection. */
 [data-chat-composer-editor] {
   caret-color: var(--color-text-caret);
 }

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerCaretPlugin.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerCaretPlugin.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, type RefObject } from "react";
 import { createDOMRange } from "@lexical/selection";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import {
@@ -15,38 +15,38 @@ interface ComposerCaretMeasurement {
   top: number;
 }
 
+interface ComposerCaretPluginProps {
+  caretRef: RefObject<HTMLSpanElement | null>;
+  frameRef: RefObject<HTMLDivElement | null>;
+}
+
 const CARET_WIDTH_PX = 1;
+const CARET_BOUNDS_TOLERANCE_PX = 1;
+const HIDDEN_ANCESTOR_SELECTOR = '[aria-hidden="true"], [hidden], [inert]';
 
 /**
  * Replaces WebKit's two-CSS-pixel redesigned insertion caret with a one-pixel
  * visual caret. The browser selection remains authoritative; this plugin only
  * paints its collapsed position and immediately restores the native caret when
- * it cannot prove that the replacement is visible.
+ * it cannot prove that the replacement is visible inside its editor frame.
  */
-export function ComposerCaretPlugin() {
+export function ComposerCaretPlugin({
+  caretRef,
+  frameRef,
+}: ComposerCaretPluginProps) {
   const [editor] = useLexicalComposerContext();
-  // The composer keeps DOM focus while a popover is open (PopoverButton
-  // prevents onOpenAutoFocus so opening a reasoning/model/integrations
-  // popover never blurs the editor). Our replacement caret is a fixed,
-  // maximum-z-index span, so without this check it kept blinking in front
-  // of any popover surface stacked above the composer. Suppress the
-  // replacement caret for the duration of any open popover; the native
-  // (now-invisible, caret-color: transparent) caret has already been
-  // hidden too, so nothing blinks while an overlay is up.
+  // Focus deliberately stays in the composer while its native popovers are
+  // open. Suppress the replacement until the surface closes; the native
+  // fallback remains confined to the editor's own stacking context.
   const nativeOverlayOpen = useNativeOverlayOpen();
   const overlayOpenRef = useRef(nativeOverlayOpen);
   overlayOpenRef.current = nativeOverlayOpen;
-  // Re-run the hide/reposition pass whenever overlay presence flips — this
-  // covers both directions: hiding immediately when a popover opens (even
-  // if the caret was already visible and idle, with no other Lexical
-  // update in flight), and repainting it once the popover closes.
   const scheduleForOverlayRef = useRef<(() => void) | null>(null);
   useEffect(() => {
     scheduleForOverlayRef.current?.();
   }, [nativeOverlayOpen]);
 
   useEffect(() => {
-    let caretElement: HTMLSpanElement | null = null;
     let rootElement: HTMLElement | null = null;
     let rootCleanup: (() => void) | null = null;
     let isComposing = false;
@@ -68,40 +68,11 @@ export function ComposerCaretPlugin() {
     };
 
     const hideReplacementCaret = () => {
-      if (caretElement !== null) {
-        caretElement.style.display = "none";
+      const caret = caretRef.current;
+      if (caret !== null) {
+        caret.style.display = "none";
       }
       restoreNativeCaret();
-    };
-
-    const destroyReplacementCaret = () => {
-      hideReplacementCaret();
-      caretElement?.remove();
-      caretElement = null;
-    };
-
-    const ensureReplacementCaret = (root: HTMLElement): HTMLSpanElement | null => {
-      const ownerDocument = root.ownerDocument;
-      if (caretElement !== null && caretElement.ownerDocument === ownerDocument) {
-        return caretElement;
-      }
-
-      caretElement?.remove();
-      const body = ownerDocument.body;
-      if (body === null) return null;
-
-      const nextCaret = ownerDocument.createElement("span");
-      nextCaret.setAttribute("aria-hidden", "true");
-      nextCaret.setAttribute("data-chat-composer-caret", "");
-      nextCaret.style.backgroundColor = "currentColor";
-      nextCaret.style.display = "none";
-      nextCaret.style.pointerEvents = "none";
-      nextCaret.style.position = "fixed";
-      nextCaret.style.width = `${CARET_WIDTH_PX}px`;
-      nextCaret.style.zIndex = "2147483647";
-      body.appendChild(nextCaret);
-      caretElement = nextCaret;
-      return nextCaret;
     };
 
     const rootHasFocus = (root: HTMLElement): boolean => {
@@ -109,9 +80,33 @@ export function ComposerCaretPlugin() {
       return activeElement !== null && root.contains(activeElement);
     };
 
+    const replacementCanPaint = (
+      root: HTMLElement,
+      frame: HTMLElement,
+      caret: HTMLElement,
+    ): boolean => {
+      if (
+        !root.isConnected
+        || !frame.isConnected
+        || !caret.isConnected
+        || !frame.contains(root)
+        || !frame.contains(caret)
+        || root.closest(HIDDEN_ANCESTOR_SELECTOR) !== null
+      ) {
+        return false;
+      }
+
+      const computedStyle = root.ownerDocument.defaultView?.getComputedStyle(root);
+      return computedStyle?.display !== "none"
+        && computedStyle?.visibility !== "hidden"
+        && computedStyle?.visibility !== "collapse"
+        && computedStyle?.getPropertyValue("content-visibility") !== "hidden";
+    };
+
     const measureCaret = (
       activeEditor: LexicalEditor,
       root: HTMLElement,
+      frame: HTMLElement,
     ): ComposerCaretMeasurement | null => {
       const range = activeEditor.getEditorState().read((): Range | null => {
         const selection = $getSelection();
@@ -129,12 +124,24 @@ export function ComposerCaretPlugin() {
 
       if (range === null) return null;
       const rangeRect = range.getBoundingClientRect();
+      const rootRect = root.getBoundingClientRect();
+      const frameRect = frame.getBoundingClientRect();
       const measuredHeight = rangeRect.height;
       if (
-        !Number.isFinite(rangeRect.left)
+        !hasFiniteArea(rootRect)
+        || !hasFiniteArea(frameRect)
+        || !Number.isFinite(rangeRect.left)
         || !Number.isFinite(rangeRect.top)
         || !Number.isFinite(measuredHeight)
         || measuredHeight <= 0
+      ) return null;
+
+      const rangeBottom = rangeRect.top + measuredHeight;
+      if (
+        !pointFitsHorizontalBounds(rangeRect.left, rootRect)
+        || !pointFitsHorizontalBounds(rangeRect.left, frameRect)
+        || !rangeFitsVerticalBounds(rangeRect.top, rangeBottom, rootRect)
+        || !rangeFitsVerticalBounds(rangeRect.top, rangeBottom, frameRect)
       ) return null;
 
       const ownerWindow = root.ownerDocument.defaultView;
@@ -152,8 +159,13 @@ export function ComposerCaretPlugin() {
           || computedStyle?.color
           || "currentColor",
         height: snap(height),
-        left: snap(rangeRect.left),
-        top: snap(rangeRect.top + ((measuredHeight - height) / 2)),
+        left: snap(rangeRect.left - frameRect.left - frame.clientLeft),
+        top: snap(
+          rangeRect.top
+            - frameRect.top
+            - frame.clientTop
+            + ((measuredHeight - height) / 2),
+        ),
       };
     };
 
@@ -164,15 +176,24 @@ export function ComposerCaretPlugin() {
       }
 
       const root = rootElement;
-      if (root === null || isComposing || !rootHasFocus(root) || overlayOpenRef.current) {
+      const frame = frameRef.current;
+      const caret = caretRef.current;
+      if (
+        root === null
+        || frame === null
+        || caret === null
+        || isComposing
+        || !rootHasFocus(root)
+        || overlayOpenRef.current
+        || !replacementCanPaint(root, frame, caret)
+      ) {
         hideReplacementCaret();
         return;
       }
 
       try {
-        const measurement = measureCaret(editor, root);
-        const caret = measurement === null ? null : ensureReplacementCaret(root);
-        if (measurement === null || caret === null) {
+        const measurement = measureCaret(editor, root, frame);
+        if (measurement === null) {
           hideReplacementCaret();
           return;
         }
@@ -185,7 +206,7 @@ export function ComposerCaretPlugin() {
         caret.style.display = "block";
 
         if (
-          !caret.isConnected
+          !replacementCanPaint(root, frame, caret)
           || caret.style.display === "none"
           || caret.style.width !== `${CARET_WIDTH_PX}px`
           || measurement.height <= 0
@@ -230,7 +251,7 @@ export function ComposerCaretPlugin() {
     const unregisterRoot = editor.registerRootListener((nextRoot) => {
       rootCleanup?.();
       rootCleanup = null;
-      destroyReplacementCaret();
+      hideReplacementCaret();
       rootElement = nextRoot;
       isComposing = false;
 
@@ -239,6 +260,7 @@ export function ComposerCaretPlugin() {
       previousCaretColorPriority = nextRoot.style.getPropertyPriority("caret-color");
       const ownerDocument = nextRoot.ownerDocument;
       const ownerWindow = ownerDocument.defaultView;
+      const frame = frameRef.current;
 
       const handleFocus = () => scheduleReplacementCaret();
       const handleBlur = () => queueMicrotask(() => {
@@ -261,6 +283,36 @@ export function ComposerCaretPlugin() {
       ownerWindow?.addEventListener("resize", scheduleReplacementCaret);
       ownerWindow?.addEventListener("scroll", scheduleReplacementCaret, true);
 
+      const ResizeObserverConstructor = ownerWindow?.ResizeObserver;
+      const resizeObserver = ResizeObserverConstructor && frame
+        ? new ResizeObserverConstructor(scheduleReplacementCaret)
+        : null;
+      resizeObserver?.observe(nextRoot);
+      if (frame !== null && frame !== nextRoot) resizeObserver?.observe(frame);
+
+      const MutationObserverConstructor = ownerWindow?.MutationObserver;
+      const visibilityObserver = MutationObserverConstructor
+        ? new MutationObserverConstructor(scheduleReplacementCaret)
+        : null;
+      if (visibilityObserver !== null) {
+        // The plugin mutates the root's inline caret-color itself, so observing
+        // its style attribute would schedule an endless measure/mutate loop.
+        visibilityObserver.observe(nextRoot, {
+          attributeFilter: ["aria-hidden", "class", "hidden", "inert"],
+          attributes: true,
+        });
+        for (
+          let ancestor: HTMLElement | null = nextRoot.parentElement;
+          ancestor !== null;
+          ancestor = ancestor.parentElement
+        ) {
+          visibilityObserver.observe(ancestor, {
+            attributeFilter: ["aria-hidden", "class", "hidden", "inert", "style"],
+            attributes: true,
+          });
+        }
+      }
+
       rootCleanup = () => {
         nextRoot.removeEventListener("focus", handleFocus);
         nextRoot.removeEventListener("blur", handleBlur);
@@ -269,6 +321,8 @@ export function ComposerCaretPlugin() {
         ownerDocument.removeEventListener("selectionchange", scheduleReplacementCaret);
         ownerWindow?.removeEventListener("resize", scheduleReplacementCaret);
         ownerWindow?.removeEventListener("scroll", scheduleReplacementCaret, true);
+        resizeObserver?.disconnect();
+        visibilityObserver?.disconnect();
         if (scheduledFrame !== null) {
           ownerWindow?.cancelAnimationFrame(scheduledFrame);
           scheduledFrame = null;
@@ -282,11 +336,32 @@ export function ComposerCaretPlugin() {
       unregisterUpdate();
       unregisterRoot();
       rootCleanup?.();
-      destroyReplacementCaret();
+      hideReplacementCaret();
       rootElement = null;
       scheduleForOverlayRef.current = null;
     };
-  }, [editor]);
+  }, [caretRef, editor, frameRef]);
 
   return null;
+}
+
+function hasFiniteArea(rect: DOMRect): boolean {
+  return Number.isFinite(rect.left)
+    && Number.isFinite(rect.right)
+    && Number.isFinite(rect.top)
+    && Number.isFinite(rect.bottom)
+    && Number.isFinite(rect.width)
+    && Number.isFinite(rect.height)
+    && rect.width > 0
+    && rect.height > 0;
+}
+
+function pointFitsHorizontalBounds(x: number, rect: DOMRect): boolean {
+  return x >= rect.left - CARET_BOUNDS_TOLERANCE_PX
+    && x <= rect.right + CARET_BOUNDS_TOLERANCE_PX;
+}
+
+function rangeFitsVerticalBounds(top: number, bottom: number, rect: DOMRect): boolean {
+  return top >= rect.top - CARET_BOUNDS_TOLERANCE_PX
+    && bottom <= rect.bottom + CARET_BOUNDS_TOLERANCE_PX;
 }

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.test.tsx
@@ -34,6 +34,7 @@ afterEach(() => {
     );
   }
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 beforeEach(() => {
   originalRangeRectDescriptor = Object.getOwnPropertyDescriptor(
@@ -42,6 +43,7 @@ beforeEach(() => {
   );
   vi.stubGlobal("DragEvent", class DragEvent extends Event {});
   vi.stubGlobal("ClipboardEvent", class ClipboardEvent extends Event {});
+  vi.spyOn(window, "scrollBy").mockImplementation(() => {});
 });
 
 describe("ComposerRichTextEditor", () => {
@@ -294,10 +296,11 @@ describe("ComposerRichTextEditor", () => {
     expect(composingSubmit).not.toHaveBeenCalled();
   });
 
-  it("shows a one-pixel replacement caret only after valid geometry", async () => {
+  it("shows an editor-owned one-pixel caret only after valid local geometry", async () => {
     mockRangeRect({ height: 15, left: 24, top: 18 });
     const harness = renderEditor();
     await harness.ready();
+    mockComposerBounds(harness.root, harness.frame);
     harness.root.style.setProperty("--color-text-caret", "rgb(1, 2, 3)");
 
     act(() => {
@@ -306,15 +309,19 @@ describe("ComposerRichTextEditor", () => {
     });
 
     const caret = await waitFor(() => {
-      const nextCaret = document.body.querySelector<HTMLElement>(
+      const nextCaret = harness.frame.querySelector<HTMLElement>(
         "[data-chat-composer-caret]",
       );
       expect(nextCaret?.style.display).toBe("block");
       return nextCaret!;
     });
+    expect(caret.parentElement).toBe(harness.frame);
+    expect(caret.style.position).toBe("absolute");
+    expect(caret.style.zIndex).toBe("");
     expect(caret.style.width).toBe("1px");
     expect(caret.style.height).toBe("15px");
-    expect(caret.style.left).toBe("24px");
+    expect(caret.style.left).toBe("14px");
+    expect(caret.style.top).toBe("10px");
     expect(caret.style.backgroundColor).toBe("rgb(1, 2, 3)");
     expect(harness.root.style.caretColor).toBe("transparent");
 
@@ -351,6 +358,7 @@ describe("ComposerRichTextEditor", () => {
     mockRangeRect({ height: 0, left: 24, top: 18 });
     const harness = renderEditor();
     await harness.ready();
+    mockComposerBounds(harness.root, harness.frame);
 
     act(() => {
       harness.root.focus();
@@ -359,9 +367,74 @@ describe("ComposerRichTextEditor", () => {
 
     await waitFor(() => expect(harness.root.style.caretColor).toBe(""));
     expect(
-      document.body.querySelector<HTMLElement>("[data-chat-composer-caret]")
+      harness.frame.querySelector<HTMLElement>("[data-chat-composer-caret]")
         ?.style.display,
     ).not.toBe("block");
+  });
+
+  it("keeps the native caret when the selection rectangle escapes the editor", async () => {
+    mockRangeRect({ height: 15, left: 240, top: 18 });
+    const harness = renderEditor();
+    await harness.ready();
+    mockComposerBounds(harness.root, harness.frame);
+
+    act(() => {
+      harness.root.focus();
+      resetText(harness.editor, "outside");
+    });
+
+    await waitFor(() => expect(harness.root.style.caretColor).toBe(""));
+    expect(
+      harness.frame.querySelector<HTMLElement>("[data-chat-composer-caret]")
+        ?.style.display,
+    ).not.toBe("block");
+  });
+
+  it("restores the native caret whenever the mounted editor becomes hidden or inert", async () => {
+    mockRangeRect({ height: 15, left: 24, top: 18 });
+    const harness = renderEditor();
+    await harness.ready();
+    mockComposerBounds(harness.root, harness.frame);
+
+    act(() => {
+      harness.root.focus();
+      resetText(harness.editor, "visibility");
+    });
+
+    const caret = harness.frame.querySelector<HTMLElement>("[data-chat-composer-caret]")!;
+    await waitFor(() => expect(caret.style.display).toBe("block"));
+
+    harness.container.setAttribute("aria-hidden", "true");
+    await waitFor(() => expect(caret.style.display).toBe("none"));
+    expect(harness.root.style.caretColor).toBe("");
+
+    harness.container.removeAttribute("aria-hidden");
+    await waitFor(() => expect(caret.style.display).toBe("block"));
+    expect(harness.root.style.caretColor).toBe("transparent");
+
+    harness.container.setAttribute("inert", "");
+    await waitFor(() => expect(caret.style.display).toBe("none"));
+    expect(harness.root.style.caretColor).toBe("");
+  });
+
+  it("remeasures local caret geometry when the editor frame resizes", async () => {
+    const notifyResize = stubCapturingResizeObserver();
+    mockRangeRect({ height: 15, left: 24, top: 18 });
+    const harness = renderEditor();
+    await harness.ready();
+    mockComposerBounds(harness.root, harness.frame);
+
+    act(() => {
+      harness.root.focus();
+      resetText(harness.editor, "resize");
+    });
+
+    const caret = harness.frame.querySelector<HTMLElement>("[data-chat-composer-caret]")!;
+    await waitFor(() => expect(caret.style.left).toBe("14px"));
+
+    mockRangeRect({ height: 15, left: 54, top: 18 });
+    act(() => notifyResize());
+    await waitFor(() => expect(caret.style.left).toBe("44px"));
   });
 });
 
@@ -379,8 +452,13 @@ function renderEditor(overrides: Partial<ComposerRichTextEditorProps> = {}) {
   let props = { ...defaults, ...overrides };
   const rendered = render(<ComposerRichTextEditor {...props} />);
   const root = rendered.container.querySelector<HTMLElement>("[data-chat-composer-editor]")!;
+  const frame = rendered.container.querySelector<HTMLElement>(
+    "[data-chat-composer-editor-frame]",
+  )!;
   return {
+    container: rendered.container,
     get editor() { return editor!; },
+    frame,
     root,
     ready: () => waitFor(() => expect(editor).toBeTruthy()),
     rerender(next: Partial<ComposerRichTextEditorProps>) {
@@ -388,6 +466,58 @@ function renderEditor(overrides: Partial<ComposerRichTextEditorProps> = {}) {
       rendered.rerender(<ComposerRichTextEditor {...props} />);
     },
     unmount: rendered.unmount,
+  };
+}
+
+function mockComposerBounds(root: HTMLElement, frame: HTMLElement) {
+  vi.spyOn(frame, "getBoundingClientRect").mockReturnValue(
+    domRect({ height: 34, left: 10, top: 8, width: 200 }),
+  );
+  vi.spyOn(root, "getBoundingClientRect").mockReturnValue(
+    domRect({ height: 30, left: 12, top: 10, width: 180 }),
+  );
+}
+
+function domRect({
+  height,
+  left,
+  top,
+  width,
+}: {
+  height: number;
+  left: number;
+  top: number;
+  width: number;
+}): DOMRect {
+  return {
+    bottom: top + height,
+    height,
+    left,
+    right: left + width,
+    toJSON: () => ({}),
+    top,
+    width,
+    x: left,
+    y: top,
+  } as DOMRect;
+}
+
+function stubCapturingResizeObserver(): () => void {
+  const callbacks: ResizeObserverCallback[] = [];
+  class CapturingResizeObserver {
+    constructor(callback: ResizeObserverCallback) {
+      callbacks.push(callback);
+    }
+
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal("ResizeObserver", CapturingResizeObserver);
+  return () => {
+    for (const callback of callbacks) {
+      callback([], {} as ResizeObserver);
+    }
   };
 }
 

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
@@ -80,6 +80,8 @@ export function ComposerRichTextEditor({
   className = "",
 }: ComposerRichTextEditorProps) {
   const eventTimeStampRef = useRef<number | undefined>(undefined);
+  const caretRef = useRef<HTMLSpanElement | null>(null);
+  const editorFrameRef = useRef<HTMLDivElement | null>(null);
   const initialConfig = {
     namespace: "ProliferateChatComposer",
     nodes: COMPOSER_NODES,
@@ -101,7 +103,11 @@ export function ComposerRichTextEditor({
   };
   return (
     <LexicalComposer initialConfig={initialConfig}>
-      <div data-chat-composer-editor-frame className="relative min-h-[inherit]">
+      <div
+        ref={editorFrameRef}
+        data-chat-composer-editor-frame
+        className="relative min-h-[inherit]"
+      >
         <RichTextPlugin
           contentEditable={(
             <ContentEditable
@@ -142,6 +148,18 @@ export function ComposerRichTextEditor({
           )}
           ErrorBoundary={LexicalErrorBoundary}
         />
+        <span
+          ref={caretRef}
+          aria-hidden="true"
+          data-chat-composer-caret
+          style={{
+            backgroundColor: "currentColor",
+            display: "none",
+            pointerEvents: "none",
+            position: "absolute",
+            width: "1px",
+          }}
+        />
       </div>
       <HistoryPlugin />
       <ListPlugin />
@@ -153,7 +171,7 @@ export function ComposerRichTextEditor({
         onCommandKey={onCommandKey}
       />
       <ComposerLinkPastePlugin markdownTransformers={OUTPUT_TRANSFORMERS} />
-      <ComposerCaretPlugin />
+      <ComposerCaretPlugin caretRef={caretRef} frameRef={editorFrameRef} />
       <ComposerNativeEventTimestampPlugin eventTimeStampRef={eventTimeStampRef} />
       <ComposerEditorBridge
         value={value}
@@ -314,4 +332,3 @@ function selectionIsInList(): boolean {
   }
   return $isListItemNode(node);
 }
-

--- a/apps/packages/product-client/src/lib/domain/focus-zone.test.ts
+++ b/apps/packages/product-client/src/lib/domain/focus-zone.test.ts
@@ -77,13 +77,14 @@ describe("focus-zone helpers", () => {
     expect(focus).toHaveBeenCalledWith({ preventScroll: false });
   });
 
-  it("does not focus a composer kept mounted inside an aria-hidden route host", () => {
+  it("does not focus a composer kept mounted inside a hidden or inert route host", () => {
     const editorQuerySelector = vi.fn();
+    const closest = vi.fn(() => ({}));
     vi.stubGlobal("document", {
       activeElement: null,
       querySelector: vi.fn(() => ({
         querySelector: editorQuerySelector,
-        closest: vi.fn(() => ({})),
+        closest,
       })),
     });
     vi.stubGlobal("window", {
@@ -91,6 +92,7 @@ describe("focus-zone helpers", () => {
     });
 
     expect(focusChatInputOnActivation()).toBe(false);
+    expect(closest).toHaveBeenCalledWith('[aria-hidden="true"], [inert]');
     expect(editorQuerySelector).not.toHaveBeenCalled();
   });
 

--- a/apps/packages/product-client/src/lib/domain/focus-zone.ts
+++ b/apps/packages/product-client/src/lib/domain/focus-zone.ts
@@ -79,10 +79,10 @@ export function focusChatInputOnActivation(): boolean {
     return false;
   }
   // Hidden routes (settings and friends) keep the composer mounted behind an
-  // overlay inside an aria-hidden host, where it is still programmatically
-  // focusable; never focus a composer the user cannot see.
+  // overlay inside an aria-hidden, inert host; never focus a composer the user
+  // cannot see.
   const chatZone = document.querySelector(`[${FOCUS_ZONE_ATTR}="chat"]`);
-  if (!chatZone || chatZone.closest('[aria-hidden="true"]')) {
+  if (!chatZone || chatZone.closest('[aria-hidden="true"], [inert]')) {
     return false;
   }
   return focusChatInput();

--- a/apps/packages/product-client/src/pages/AuthenticatedAppHost.test.tsx
+++ b/apps/packages/product-client/src/pages/AuthenticatedAppHost.test.tsx
@@ -10,8 +10,30 @@ vi.mock("#product/hooks/organizations/lifecycle/use-organization-selection-lifec
   useOrganizationSelectionLifecycle: vi.fn(),
 }));
 
+const focusChatInputOnActivation = vi.hoisted(() => vi.fn(() => true));
+
+vi.mock("#product/lib/domain/focus-zone", () => ({
+  focusChatInputOnActivation,
+}));
+
 vi.mock("#product/pages/WorkflowsPage", () => ({
   WorkflowsPage: () => <section data-testid="workflows" />,
+}));
+
+vi.mock("#product/pages/DesktopWorkspaceDeepLinkPage", () => ({
+  DesktopWorkspaceDeepLinkPage: () => <section data-testid="workspace-deep-link" />,
+}));
+
+vi.mock("#product/pages/MainPage", () => ({
+  MainPage: () => null,
+}));
+
+vi.mock("#product/pages/SettingsPage", () => ({
+  SettingsPage: () => null,
+}));
+
+vi.mock("#product/pages/WorkspacesPage", () => ({
+  WorkspacesPage: () => <section data-testid="workspaces" />,
 }));
 
 let mainMounts = 0;
@@ -63,26 +85,37 @@ describe("AuthenticatedAppHost", () => {
   afterEach(() => {
     cleanup();
     mainMounts = 0;
+    vi.clearAllMocks();
   });
 
-  it("keeps the workspace mounted behind Settings and restores it on return", () => {
+  it("keeps the workspace mounted but inert behind Settings and restores focus on return", async () => {
     render(
       <MemoryRouter initialEntries={["/"]}>
         <AuthenticatedAppHost MainComponent={TestMain} SettingsComponent={TestSettings} />
       </MemoryRouter>,
     );
 
-    expect(screen.getByTestId("workspace").dataset.visible).toBe("true");
+    const workspace = screen.getByTestId("workspace");
+    const workspaceHost = workspace.parentElement!;
+    expect(workspace.dataset.visible).toBe("true");
+    expect(workspaceHost.hasAttribute("inert")).toBe(false);
     expect(mainMounts).toBe(1);
+    expect(focusChatInputOnActivation).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByText("Open settings"));
 
     expect(screen.getByTestId("settings").dataset.returnTo).toBe("/");
-    expect(screen.getByTestId("workspace").dataset.visible).toBe("false");
+    expect(workspace.dataset.visible).toBe("false");
+    expect(workspaceHost.getAttribute("aria-hidden")).toBe("true");
+    expect(workspaceHost.hasAttribute("inert")).toBe(true);
+    expect(focusChatInputOnActivation).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByText("Back"));
 
-    expect(screen.getByTestId("workspace").dataset.visible).toBe("true");
+    expect(workspace.dataset.visible).toBe("true");
+    expect(workspaceHost.hasAttribute("aria-hidden")).toBe(false);
+    expect(workspaceHost.hasAttribute("inert")).toBe(false);
+    await waitFor(() => expect(focusChatInputOnActivation).toHaveBeenCalledOnce());
   });
 
   it("keeps the workspace mounted while on Workflows and restores it without remounting", () => {
@@ -97,7 +130,9 @@ describe("AuthenticatedAppHost", () => {
     fireEvent.click(screen.getByText("Open workflows"));
 
     expect(screen.getByTestId("workflows")).toBeTruthy();
-    expect(screen.getByTestId("workspace").dataset.visible).toBe("false");
+    const workspace = screen.getByTestId("workspace");
+    expect(workspace.dataset.visible).toBe("false");
+    expect(workspace.parentElement?.hasAttribute("inert")).toBe(true);
 
     fireEvent.click(screen.getByText("Go home"));
 

--- a/apps/packages/product-client/src/pages/AuthenticatedAppHost.tsx
+++ b/apps/packages/product-client/src/pages/AuthenticatedAppHost.tsx
@@ -7,6 +7,7 @@ import { SettingsPage } from "#product/pages/SettingsPage";
 import { WorkflowsPage } from "#product/pages/WorkflowsPage";
 import { WorkspacesPage } from "#product/pages/WorkspacesPage";
 import { useOrganizationSelectionLifecycle } from "#product/hooks/organizations/lifecycle/use-organization-selection-lifecycle";
+import { focusChatInputOnActivation } from "#product/lib/domain/focus-zone";
 
 type MainRouteComponent = ComponentType<{ workspaceVisible?: boolean }>;
 type SettingsRouteComponent = ComponentType<{ returnTo?: string }>;
@@ -33,6 +34,15 @@ export function AuthenticatedAppHost({
   }, [isSettingsRoute, location.hash, location.pathname, location.search]);
 
   const isHomeRoute = location.pathname === APP_ROUTES.home;
+  const wasHomeRouteRef = useRef(isHomeRoute);
+  useEffect(() => {
+    const becameHomeRoute = isHomeRoute && !wasHomeRouteRef.current;
+    wasHomeRouteRef.current = isHomeRoute;
+    if (becameHomeRoute) {
+      focusChatInputOnActivation();
+    }
+  }, [isHomeRoute]);
+
   // The workspace shell stays mounted (hidden) across every authenticated
   // route: cold-mounting it on return from /workflows or /workspaces is
   // seconds of synchronous hydration work.
@@ -47,6 +57,7 @@ export function AuthenticatedAppHost({
       <div
         aria-hidden={isHomeRoute ? undefined : "true"}
         className={workspaceHostClassName}
+        inert={isHomeRoute ? undefined : true}
       >
         <MainComponent workspaceVisible={isHomeRoute} />
       </div>


### PR DESCRIPTION
## Summary

- Keep the one-pixel visual composer caret inside the editor frame so it follows sidebar, right-rail, scroll, and stacking changes.
- Restore the native caret whenever geometry is invalid or the editor is disconnected, hidden, inert, blurred, composing, or no longer has a collapsed selection.
- Make the retained workspace route host inert off Home and restore composer focus through the existing non-stealing activation guard on return.
- Add regression coverage for local geometry, bounds, visibility, resize, route inertness, and focus restoration.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] The support relationship is linked through the tracker API. No tracker, report, user, or support IDs or private source data appear in this PR.

## Verification

- `NODE_OPTIONS=--localstorage-file=/tmp/product-client-test-storage pnpm --filter @proliferate/product-client test` (781 files, 5,222 tests passed)
- `pnpm --filter @proliferate/product-client typecheck`
- `pnpm --filter @proliferate/product-client exec vitest run src/components/workspace/chat/input/ComposerRichTextEditor.test.tsx src/pages/AuthenticatedAppHost.test.tsx src/lib/domain/focus-zone.test.ts` (32 passed)
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_design_attribution.py`
- `git diff --check origin/main...HEAD`
- Two independent review passes returned clean; a Chromium probe confirmed frame-local geometry and inert focus behavior.
