### PR TITLE
fix(product): smooth virtualized transcript scrolling

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/transcript/ChatTranscriptView.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/ChatTranscriptView.tsx
@@ -42,10 +42,14 @@ export function ChatTranscriptView({
     visibleOptimisticPrompt: model.visibleOptimisticPrompt,
   });
 
-  const renderVirtualRow = useChatTranscriptRowRenderer({
+  const {
+    renderRow: renderVirtualRow,
+    getRowRenderRevision,
+  } = useChatTranscriptRowRenderer({
     activeSessionId: model.activeSessionId,
     latestLiveExplorationBlock: model.latestLiveExplorationBlock,
     latestLiveStatus: model.latestLiveStatus,
+    latestCompletedTurnId: model.latestCompletedTurnId,
     latestTurnId: model.latestTurnId,
     optimisticPromptTrailingStatus: model.optimisticPromptTrailingStatus,
     outboxActions,
@@ -80,6 +84,7 @@ export function ChatTranscriptView({
         onLoadOlderHistory={model.onLoadOlderHistory}
         onScrollSample={onScrollSample}
         renderRow={renderVirtualRow}
+        getRowRenderRevision={getRowRenderRevision}
         columnClassName={model.columnClassName}
         gutterClassName={model.gutterClassName}
         scrollHandleRef={scrollHandleRef}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.test.tsx
@@ -178,6 +178,25 @@ describe("FullTranscriptRowList", () => {
     const disabled = container.querySelectorAll("button[disabled]");
     expect(disabled).toHaveLength(0);
   });
+
+  it("uses renderer identity as the safe revision fallback", () => {
+    const props = makeProps(vi.fn(), 50);
+    const rendered = render(
+      <FullTranscriptRowList
+        {...props}
+        renderRow={() => <div>first renderer</div>}
+      />,
+    );
+
+    rendered.rerender(
+      <FullTranscriptRowList
+        {...props}
+        renderRow={() => <div>next renderer</div>}
+      />,
+    );
+
+    expect(rendered.getByText("next renderer")).toBeTruthy();
+  });
 });
 
 function stubCapturingResizeObserver(): () => void {

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.tsx
@@ -57,6 +57,7 @@ export function FullTranscriptRowList({
   onLoadOlderHistory,
   onScrollSample,
   renderRow,
+  getRowRenderRevision,
   columnClassName = CHAT_COLUMN_CLASSNAME,
   gutterClassName = CHAT_SURFACE_GUTTER_CLASSNAME,
   fallbackReason,
@@ -283,6 +284,7 @@ export function FullTranscriptRowList({
                 row={row}
                 rowIndex={rowIndex}
                 renderRow={renderRow}
+                renderRevision={getRowRenderRevision?.(row) ?? renderRow}
               />
             ))}
           </div>
@@ -321,6 +323,7 @@ const MemoizedFullTranscriptRow = memo(function MemoizedFullTranscriptRow({
   row: TranscriptVirtualRow;
   rowIndex: number;
   renderRow: TranscriptRowRenderer;
+  renderRevision: unknown;
 }) {
   const rowContext = useMemo(
     () => ({ rowUnitId: `chatrow:${row.key}`, rowIndex }),
@@ -340,5 +343,5 @@ const MemoizedFullTranscriptRow = memo(function MemoizedFullTranscriptRow({
 }, (prev, next) =>
   prev.row === next.row
   && prev.rowIndex === next.rowIndex
-  && prev.renderRow === next.renderRow
+  && prev.renderRevision === next.renderRevision
 );

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useDeferredValue,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
 } from "react";
@@ -229,10 +230,18 @@ export function MessageList({
   // transcript — not a single turn's blocks. Derived once here and threaded
   // to every turn row via context. Keyed off the effective (deferred while
   // typing) transcript so it stays consistent with what the rows render.
+  const proposedPlanToolCallIdsRef = useRef<ReadonlySet<string>>(new Set());
+  const previousProposedPlanToolCallIds = proposedPlanToolCallIdsRef.current;
   const proposedPlanToolCallIds = useMemo(
-    () => collectToolCallIdsWithProposedPlan(effectiveTranscriptViewState.transcript),
-    [effectiveTranscriptViewState.transcript],
+    () => collectToolCallIdsWithProposedPlan(
+      effectiveTranscriptViewState.transcript,
+      previousProposedPlanToolCallIds,
+    ),
+    [effectiveTranscriptViewState.transcript, previousProposedPlanToolCallIds],
   );
+  useLayoutEffect(() => {
+    proposedPlanToolCallIdsRef.current = proposedPlanToolCallIds;
+  }, [proposedPlanToolCallIds]);
 
   const handleTranscriptScroll = useCallback((sample?: { programmatic: boolean }) => {
     // Tag the scroll source: a persistent stream of `source.programmatic`
@@ -302,6 +311,7 @@ export function MessageList({
       turn={input.turn}
       transcript={input.transcript}
       latestTurnId={input.latestTurnId}
+      latestCompletedTurnId={input.latestCompletedTurnId}
       latestLiveExplorationBlock={input.latestLiveExplorationBlock}
       latestLiveStatus={input.latestLiveStatus}
       outboxStartedAtByPromptId={input.outboxStartedAtByPromptId}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptItemBlock.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptItemBlock.tsx
@@ -1,6 +1,7 @@
 import type {
   TranscriptItem,
   TranscriptState,
+  ToolCallItem,
 } from "@anyharness/sdk";
 import { useCallback } from "react";
 import { ReasoningBlock } from "#product/components/workspace/chat/tool-calls/ReasoningBlock";
@@ -74,11 +75,9 @@ export function TranscriptItemBlock({
   onOpenArtifact: (workspaceId: string, artifactId: string) => void;
   onHandOffPlanToNewSession?: PlanHandoffHandler;
 }) {
-  const toolCallIdsWithProposedPlan = useProposedPlanToolCallIds();
   const sessionId = useTranscriptSessionId();
   const openSession = useTranscriptOpenSession();
   const canOpenSession = useTranscriptCanOpenSession();
-  const recordRelationshipHint = useSessionDirectoryStore((state) => state.recordRelationshipHint);
   const reportAssistantRevealState = useCallback((state: AssistantMessageRevealState) => {
     recordAssistantRevealProgress(item.itemId, state);
     onAssistantRevealStateChange?.(item.itemId, state);
@@ -116,7 +115,7 @@ export function TranscriptItemBlock({
               parentTitle={transcript.sessionMeta.title}
               onOpenChild={canOpenChild
                 ? (targetSessionId) => {
-                  recordRelationshipHint(targetSessionId, {
+                  useSessionDirectoryStore.getState().recordRelationshipHint(targetSessionId, {
                     kind: wakeProvenance.type === "subagentWake"
                       ? "subagent_child"
                       : childRole === "cowork-coding-child"
@@ -213,48 +212,13 @@ export function TranscriptItemBlock({
       );
 
     case "tool_call": {
-      if (isClaudeExitPlanModeCall(item)) {
-        if (hasProposedPlanForToolCallItem(toolCallIdsWithProposedPlan, item)) {
-          return null;
-        }
-        const body = extractClaudePlanBody(item) ?? "";
-        return (
-          <div data-transcript-activity-shell className="flex justify-start relative">
-            <div className="flex flex-col w-full max-w-full space-y-1 break-words">
-              <TranscriptActivityBlock entryItemId={item.itemId} animateEntry={animateActivityEntry}>
-                <ClaudePlanCard
-                  content={body}
-                  isStreaming={item.status === "in_progress"}
-                />
-              </TranscriptActivityBlock>
-            </div>
-          </div>
-        );
-      }
-      const modeSwitchDisplay = deriveModeSwitchDisplay(item);
-      if (modeSwitchDisplay) {
-        return (
-          <div data-transcript-activity-shell className="flex justify-start relative">
-            <div className="flex flex-col w-full max-w-full break-words">
-              <TranscriptActivityBlock entryItemId={item.itemId} animateEntry={animateActivityEntry}>
-                <ModeTransitionDivider label={modeSwitchDisplay.label} />
-              </TranscriptActivityBlock>
-            </div>
-          </div>
-        );
-      }
       return (
-        <div data-transcript-activity-shell className="flex justify-start relative">
-          <div className="flex flex-col w-full max-w-full space-y-1 break-words">
-            <TranscriptActivityBlock entryItemId={item.itemId} animateEntry={animateActivityEntry}>
-              <TranscriptToolCallItemBlock
-                item={item}
-                workspaceId={workspaceId}
-                onOpenArtifact={onOpenArtifact}
-              />
-            </TranscriptActivityBlock>
-          </div>
-        </div>
+        <ToolCallTranscriptItem
+          item={item}
+          animateActivityEntry={animateActivityEntry}
+          workspaceId={workspaceId}
+          onOpenArtifact={onOpenArtifact}
+        />
       );
     }
 
@@ -283,4 +247,65 @@ export function TranscriptItemBlock({
     default:
       return null;
   }
+}
+
+function ToolCallTranscriptItem({
+  item,
+  animateActivityEntry,
+  workspaceId,
+  onOpenArtifact,
+}: {
+  item: ToolCallItem;
+  animateActivityEntry: boolean;
+  workspaceId: string | null;
+  onOpenArtifact: (workspaceId: string, artifactId: string) => void;
+}) {
+  // Only tool calls participate in proposed-plan suppression. Keeping this
+  // context subscription out of the generic item component prevents a rare
+  // plan transition from invalidating every mounted prose/thought item.
+  const toolCallIdsWithProposedPlan = useProposedPlanToolCallIds();
+
+  if (isClaudeExitPlanModeCall(item)) {
+    if (hasProposedPlanForToolCallItem(toolCallIdsWithProposedPlan, item)) {
+      return null;
+    }
+    const body = extractClaudePlanBody(item) ?? "";
+    return (
+      <div data-transcript-activity-shell className="flex justify-start relative">
+        <div className="flex flex-col w-full max-w-full space-y-1 break-words">
+          <TranscriptActivityBlock entryItemId={item.itemId} animateEntry={animateActivityEntry}>
+            <ClaudePlanCard
+              content={body}
+              isStreaming={item.status === "in_progress"}
+            />
+          </TranscriptActivityBlock>
+        </div>
+      </div>
+    );
+  }
+  const modeSwitchDisplay = deriveModeSwitchDisplay(item);
+  if (modeSwitchDisplay) {
+    return (
+      <div data-transcript-activity-shell className="flex justify-start relative">
+        <div className="flex flex-col w-full max-w-full break-words">
+          <TranscriptActivityBlock entryItemId={item.itemId} animateEntry={animateActivityEntry}>
+            <ModeTransitionDivider label={modeSwitchDisplay.label} />
+          </TranscriptActivityBlock>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div data-transcript-activity-shell className="flex justify-start relative">
+      <div className="flex flex-col w-full max-w-full space-y-1 break-words">
+        <TranscriptActivityBlock entryItemId={item.itemId} animateEntry={animateActivityEntry}>
+          <TranscriptToolCallItemBlock
+            item={item}
+            workspaceId={workspaceId}
+            onOpenArtifact={onOpenArtifact}
+          />
+        </TranscriptActivityBlock>
+      </div>
+    </div>
+  );
 }

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
@@ -32,9 +32,6 @@ import {
   collectTurnFileRevertPatchEntries,
 } from "#product/domain/chats/transcript/turn-file-patches";
 import {
-  latestCompletedTurn,
-} from "#product/domain/chats/transcript/last-turn-file-changes";
-import {
   resolveTurnStoppedNotice,
 } from "#product/domain/chats/transcript/turn-stopped-presentation";
 import type { TranscriptVirtualRow } from "#product/domain/chats/transcript/transcript-virtual-rows";
@@ -54,6 +51,7 @@ export function TranscriptTurnRow({
   turn,
   transcript,
   latestTurnId,
+  latestCompletedTurnId,
   latestLiveExplorationBlock,
   latestLiveStatus,
   outboxStartedAtByPromptId,
@@ -69,6 +67,7 @@ export function TranscriptTurnRow({
   turn: TurnRecord;
   transcript: TranscriptState;
   latestTurnId: string | null;
+  latestCompletedTurnId: string | null;
   latestLiveExplorationBlock: Extract<TurnDisplayBlock, { kind: "collapsed_actions" }> | null;
   latestLiveStatus: ReactNode;
   outboxStartedAtByPromptId: ReadonlyMap<string, string>;
@@ -81,10 +80,6 @@ export function TranscriptTurnRow({
 }) {
   const isLatestTurn = row.turnId === latestTurnId;
   const isLatestTurnInProgress = isLatestTurn && !turn.completedAt;
-  const latestCompletedTurnId = useMemo(
-    () => latestCompletedTurn(transcript)?.turnId ?? null,
-    [transcript],
-  );
   const sessionGoal = useSessionGoal();
   const presentation = row.presentation;
   const renderPresentation = row.renderPresentation;

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualTranscriptRow.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualTranscriptRow.test.tsx
@@ -1,0 +1,61 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TranscriptVirtualRow } from "#product/domain/chats/transcript/transcript-virtual-rows";
+import { MemoizedVirtualTranscriptRow } from "./VirtualTranscriptRow";
+
+const ROW: TranscriptVirtualRow = {
+  kind: "pending_prompt",
+  key: "pending-prompt:session-1",
+};
+
+afterEach(cleanup);
+
+describe("MemoizedVirtualTranscriptRow", () => {
+  it("keeps an unchanged row mounted across renderer identity churn", () => {
+    const firstRenderer = vi.fn(() => <div>first</div>);
+    const nextRenderer = vi.fn(() => <div>next</div>);
+    const measureElement = vi.fn();
+    const stableRevision = {};
+    const rendered = render(
+      <MemoizedVirtualTranscriptRow
+        row={ROW}
+        rowIndex={0}
+        virtualIndex={0}
+        renderRow={firstRenderer}
+        renderRevision={stableRevision}
+        measureElement={measureElement}
+      />,
+    );
+
+    rendered.rerender(
+      <MemoizedVirtualTranscriptRow
+        row={ROW}
+        rowIndex={0}
+        virtualIndex={0}
+        renderRow={nextRenderer}
+        renderRevision={stableRevision}
+        measureElement={measureElement}
+      />,
+    );
+
+    expect(firstRenderer).toHaveBeenCalledTimes(1);
+    expect(nextRenderer).not.toHaveBeenCalled();
+    expect(rendered.getByText("first")).toBeTruthy();
+
+    rendered.rerender(
+      <MemoizedVirtualTranscriptRow
+        row={ROW}
+        rowIndex={0}
+        virtualIndex={0}
+        renderRow={nextRenderer}
+        renderRevision={{}}
+        measureElement={measureElement}
+      />,
+    );
+
+    expect(nextRenderer).toHaveBeenCalledTimes(1);
+    expect(rendered.getByText("next")).toBeTruthy();
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualTranscriptRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualTranscriptRow.tsx
@@ -18,6 +18,7 @@ export const MemoizedVirtualTranscriptRow = memo(function MemoizedVirtualTranscr
   rowIndex: number;
   virtualIndex: number;
   renderRow: TranscriptVirtualRowRenderer;
+  renderRevision: unknown;
   measureElement: (element: Element | null) => void;
 }) {
   const rowContext = useMemo(
@@ -40,6 +41,6 @@ export const MemoizedVirtualTranscriptRow = memo(function MemoizedVirtualTranscr
   prev.row === next.row
   && prev.rowIndex === next.rowIndex
   && prev.virtualIndex === next.virtualIndex
-  && prev.renderRow === next.renderRow
+  && prev.renderRevision === next.renderRevision
   && prev.measureElement === next.measureElement
 );

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualTranscriptRowList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualTranscriptRowList.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useState } from "react";
 import {
   parseTranscriptVirtualizationMode,
   resolveTranscriptVirtualizationEnabled,
@@ -15,22 +15,14 @@ const LEGACY_ENABLE_VIRTUALIZATION_STORAGE_KEY = "proliferate:enableTranscriptVi
 const LEGACY_DISABLE_VIRTUALIZATION_STORAGE_KEY = "proliferate:disableTranscriptVirtualization";
 
 export function VirtualTranscriptRowList(props: TranscriptRowListBaseProps) {
-  const { activeSessionId, rows, selectedWorkspaceId } = props;
+  const { activeSessionId, selectedWorkspaceId } = props;
   const [virtualizationMode] = useState(readTranscriptVirtualizationMode);
-  // Latch the auto decision per session: swapping list implementations
-  // mid-session remounts the whole transcript DOM, which reads as a full-page
-  // jump right as a chat crosses the row threshold. A session that starts
-  // small stays on the full list until re-entered; the full list stays
-  // correct (just less efficient) at larger row counts.
-  const latchedSessionRef = useRef<{ sessionId: string; enabled: boolean } | null>(null);
-  const latched = latchedSessionRef.current;
-  const virtualizationEnabled = latched?.sessionId === activeSessionId
-    ? latched.enabled
-    : resolveTranscriptVirtualizationEnabled({
-        mode: virtualizationMode,
-        rowCount: rows.length,
-      });
-  latchedSessionRef.current = { sessionId: activeSessionId, enabled: virtualizationEnabled };
+  // Auto uses one stable virtualized implementation from the first row onward.
+  // This avoids both a threshold remount and the old false latch that left a
+  // live session on the full-DOM path forever.
+  const virtualizationEnabled = resolveTranscriptVirtualizationEnabled({
+    mode: virtualizationMode,
+  });
   const [fallbackReason, setFallbackReason] = useState<string | null>(null);
   useLayoutEffect(() => {
     setFallbackReason(null);

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualTranscriptViewport.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualTranscriptViewport.tsx
@@ -23,6 +23,7 @@ export function VirtualTranscriptViewport({
   onViewportScroll,
   renderableRows,
   renderRow,
+  getRowRenderRevision,
   scrollRef,
   selectionRootRef,
   topSpacerHeight,
@@ -40,6 +41,7 @@ export function VirtualTranscriptViewport({
   onViewportScroll: (viewport: HTMLDivElement) => void;
   renderableRows: readonly TranscriptRenderableRow[];
   renderRow: TranscriptRowListBaseProps["renderRow"];
+  getRowRenderRevision?: TranscriptRowListBaseProps["getRowRenderRevision"];
   scrollRef: RefObject<HTMLDivElement | null>;
   selectionRootRef: TranscriptRowListBaseProps["selectionRootRef"];
   topSpacerHeight: number;
@@ -95,6 +97,7 @@ export function VirtualTranscriptViewport({
                 rowIndex={renderableRow.rowIndex}
                 virtualIndex={virtualRow.index}
                 renderRow={renderRow}
+                renderRevision={getRowRenderRevision?.(row) ?? renderRow}
                 measureElement={measureElement}
               />
             );

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx
@@ -6,11 +6,33 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TranscriptVirtualRow } from "#product/domain/chats/transcript/transcript-virtual-rows";
 import { VirtualizedTranscriptRowList } from "./VirtualizedTranscriptRowList";
 
+const observedVirtualizerOptions = vi.hoisted(() => [] as Array<{
+  estimateSize: unknown;
+  getItemKey: unknown;
+}>);
+
+vi.mock("@tanstack/react-virtual", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-virtual")>();
+  return {
+    ...actual,
+    useVirtualizer: (
+      options: Parameters<typeof actual.useVirtualizer>[0],
+    ) => {
+      observedVirtualizerOptions.push({
+        estimateSize: options.estimateSize,
+        getItemKey: options.getItemKey,
+      });
+      return actual.useVirtualizer(options);
+    },
+  };
+});
+
 const ROWS: TranscriptVirtualRow[] = [
   { kind: "pending_prompt", key: "pending-prompt:session-1" },
 ];
 
 beforeEach(() => {
+  observedVirtualizerOptions.length = 0;
   class TestResizeObserver {
     observe() {}
     unobserve() {}
@@ -59,6 +81,67 @@ describe("VirtualizedTranscriptRowList", () => {
     const button = container.querySelector('[aria-label="Scroll to bottom"]');
     expect(button).toBeTruthy();
     expect(button?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("preserves measurement accessors across an unchanged scroll render", () => {
+    const props = makeProps();
+    const rendered = render(<VirtualizedTranscriptRowList {...props} />);
+    const firstOptions = observedVirtualizerOptions.at(-1);
+    const optionCountBeforeScroll = observedVirtualizerOptions.length;
+    expect(firstOptions).toBeTruthy();
+
+    const viewport = getViewport(rendered.container);
+    Object.defineProperty(viewport, "clientHeight", { value: 300, configurable: true });
+    Object.defineProperty(viewport, "scrollHeight", { value: 2_000, configurable: true });
+    viewport.scrollTop = 120;
+    act(() => {
+      fireEvent.scroll(viewport);
+    });
+    const nextOptions = observedVirtualizerOptions.at(-1);
+
+    expect(observedVirtualizerOptions.length).toBeGreaterThan(optionCountBeforeScroll);
+    expect(nextOptions?.getItemKey).toBe(firstOptions?.getItemKey);
+    expect(nextOptions?.estimateSize).toBe(firstOptions?.estimateSize);
+  });
+
+  it("rotates measurement accessors only when ordered row composition changes", () => {
+    const props = makeProps();
+    const rendered = render(<VirtualizedTranscriptRowList {...props} />);
+    const firstOptions = observedVirtualizerOptions.at(-1);
+
+    rendered.rerender(
+      <VirtualizedTranscriptRowList
+        {...props}
+        rows={ROWS.map((row) => ({ ...row }))}
+      />,
+    );
+    const contentUpdateOptions = observedVirtualizerOptions.at(-1);
+    expect(contentUpdateOptions?.getItemKey).toBe(firstOptions?.getItemKey);
+    expect(contentUpdateOptions?.estimateSize).toBe(firstOptions?.estimateSize);
+
+    rendered.rerender(
+      <VirtualizedTranscriptRowList
+        {...props}
+        activeSessionId="session-2"
+      />,
+    );
+    const sessionUpdateOptions = observedVirtualizerOptions.at(-1);
+    expect(sessionUpdateOptions?.getItemKey).not.toBe(firstOptions?.getItemKey);
+    expect(sessionUpdateOptions?.estimateSize).not.toBe(firstOptions?.estimateSize);
+
+    rendered.rerender(
+      <VirtualizedTranscriptRowList
+        {...props}
+        activeSessionId="session-2"
+        rows={[
+          ...ROWS,
+          { kind: "pending_prompt", key: "pending-prompt:session-2" },
+        ]}
+      />,
+    );
+    const compositionUpdateOptions = observedVirtualizerOptions.at(-1);
+    expect(compositionUpdateOptions?.getItemKey).not.toBe(sessionUpdateOptions?.getItemKey);
+    expect(compositionUpdateOptions?.estimateSize).not.toBe(sessionUpdateOptions?.estimateSize);
   });
 
   it("reveals the scroll-to-bottom affordance after a user wheels up", () => {

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.tsx
@@ -12,7 +12,6 @@ import {
   type HistoryPrefetchDecisionReason,
   type HistoryPrefetchTrigger,
   type HistoryPrependScrollAnchor,
-  type TranscriptRenderableRow,
   type TranscriptRowListBaseProps,
 } from "#product/hooks/chat/ui/transcript-row-list-model";
 import { TranscriptFloatingControls } from "./TranscriptRowListShared";
@@ -20,20 +19,9 @@ import { useAboveChangeCompensation } from "#product/hooks/chat/ui/use-above-cha
 import { useTranscriptStickToBottom } from "#product/hooks/chat/ui/use-transcript-stick-to-bottom";
 import { VirtualTranscriptViewport } from "./VirtualTranscriptViewport";
 import { useTranscriptVirtualizerBlankFallback } from "#product/hooks/chat/ui/use-transcript-virtualizer-blank-fallback";
+import { useTranscriptVirtualAnchorCapture } from "#product/hooks/chat/ui/use-transcript-virtual-anchor-capture";
 
 const VIRTUALIZER_OVERSCAN = 8;
-
-interface VirtualScrollAnchor {
-  key: TranscriptRenderableRow["key"];
-  offsetWithinRowPx: number;
-  rowIndex: number;
-  rowCount: number;
-  // Real measured DOM metrics at capture, for the composition-change fallback
-  // (turn-row split) where offset+estimate math lands wrong. See the restore
-  // effect below.
-  scrollHeight: number;
-  scrollTop: number;
-}
 
 interface VirtualizedTranscriptRowListProps extends TranscriptRowListBaseProps {
   onFallback: (reason: string) => void;
@@ -55,6 +43,7 @@ export function VirtualizedTranscriptRowList({
   onLoadOlderHistory,
   onScrollSample,
   renderRow,
+  getRowRenderRevision,
   columnClassName,
   gutterClassName,
   onFallback,
@@ -63,7 +52,6 @@ export function VirtualizedTranscriptRowList({
 }: VirtualizedTranscriptRowListProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
-  const pendingAnchorRef = useRef<VirtualScrollAnchor | null>(null);
   const pendingPrependAnchorRef = useRef<HistoryPrependScrollAnchor | null>(null);
   const lastOlderHistoryCursorRequestRef = useRef<number | null>(null);
   const lastPrefetchDecisionLogRef = useRef<string | null>(null);
@@ -90,11 +78,14 @@ export function VirtualizedTranscriptRowList({
     () => buildRenderableRows(rows, isLoadingOlderHistory),
     [isLoadingOlderHistory, rows],
   );
-  const estimatedInitialBottomOffset =
-    TRANSCRIPT_TOP_PADDING_PX
-    + estimateRenderableRowsHeight(renderableRows)
-    + structuralBottomInsetPx;
-
+  // initialOffset is consumed only when the virtualizer mounts. Avoid reducing
+  // the entire transcript again on every scroll-driven virtualizer render.
+  const estimatedInitialBottomOffset = useMemo(
+    () => TRANSCRIPT_TOP_PADDING_PX
+      + estimateRenderableRowsHeight(renderableRows)
+      + structuralBottomInsetPx,
+    [renderableRows, structuralBottomInsetPx],
+  );
   const virtualizer = useVirtualizer({
     count: renderableRows.length,
     getScrollElement: () => scrollRef.current,
@@ -105,6 +96,14 @@ export function VirtualizedTranscriptRowList({
     paddingEnd: structuralBottomInsetPx,
     initialOffset: () => estimatedInitialBottomOffset,
     useAnimationFrameWithResizeObserver: true,
+  });
+  const pendingAnchorRef = useTranscriptVirtualAnchorCapture({
+    activeSessionId,
+    getVirtualItems: () => virtualizer.getVirtualItems(),
+    pinnedRef,
+    renderableRows,
+    scrollRef,
+    selectedWorkspaceId,
   });
   // Content-search jump-to-match: bring an off-screen row into view so its
   // painted marks mount before the overlay queries the DOM for the active one.
@@ -347,37 +346,6 @@ export function VirtualizedTranscriptRowList({
     };
   }, [pinnedRef, scrollToBottom]);
 
-  useLayoutEffect(() => () => {
-    const viewport = scrollRef.current;
-    if (!viewport || pinnedRef.current) {
-      pendingAnchorRef.current = null;
-      return;
-    }
-
-    const firstVisibleVirtualRow = virtualizer
-      .getVirtualItems()
-      .find((item) => item.end >= viewport.scrollTop);
-    if (!firstVisibleVirtualRow) {
-      pendingAnchorRef.current = null;
-      return;
-    }
-
-    const row = renderableRows[firstVisibleVirtualRow.index];
-    if (!row) {
-      pendingAnchorRef.current = null;
-      return;
-    }
-
-    pendingAnchorRef.current = {
-      key: row.key,
-      offsetWithinRowPx: Math.max(viewport.scrollTop - firstVisibleVirtualRow.start, 0),
-      rowIndex: firstVisibleVirtualRow.index,
-      rowCount: renderableRows.length,
-      scrollHeight: viewport.scrollHeight,
-      scrollTop: viewport.scrollTop,
-    };
-  });
-
   useTranscriptVirtualizerBlankFallback({
     activeSessionId, bottomSpacerHeight,
     firstVirtualItem, lastVirtualItem,
@@ -400,6 +368,7 @@ export function VirtualizedTranscriptRowList({
         onViewportScroll={handleViewportScroll}
         renderableRows={renderableRows}
         renderRow={renderRow}
+        getRowRenderRevision={getRowRenderRevision}
         scrollRef={scrollRef}
         selectionRootRef={selectionRootRef}
         topSpacerHeight={topSpacerHeight}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.tsx
@@ -3,8 +3,6 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import type { TranscriptVirtualizationMode } from "#product/domain/chats/transcript/transcript-virtualization-config";
 import {
   buildRenderableRows,
-  estimateRenderableRowHeight,
-  estimateRenderableRowsHeight,
   HISTORY_PREFETCH_TOP_THRESHOLD_PX,
   logHistoryPrefetchDecisionOnce,
   TRANSCRIPT_TOP_PADDING_PX,
@@ -20,6 +18,7 @@ import { useTranscriptStickToBottom } from "#product/hooks/chat/ui/use-transcrip
 import { VirtualTranscriptViewport } from "./VirtualTranscriptViewport";
 import { useTranscriptVirtualizerBlankFallback } from "#product/hooks/chat/ui/use-transcript-virtualizer-blank-fallback";
 import { useTranscriptVirtualAnchorCapture } from "#product/hooks/chat/ui/use-transcript-virtual-anchor-capture";
+import { useTranscriptVirtualMeasurementModel } from "#product/hooks/chat/ui/use-transcript-virtual-measurement-model";
 
 const VIRTUALIZER_OVERSCAN = 8;
 
@@ -78,19 +77,29 @@ export function VirtualizedTranscriptRowList({
     () => buildRenderableRows(rows, isLoadingOlderHistory),
     [isLoadingOlderHistory, rows],
   );
+  const {
+    estimateSize,
+    estimatedRowsHeight,
+    getItemKey,
+    rowCompositionKey,
+  } = useTranscriptVirtualMeasurementModel({
+    activeSessionId,
+    renderableRows,
+    selectedWorkspaceId,
+  });
   // initialOffset is consumed only when the virtualizer mounts. Avoid reducing
   // the entire transcript again on every scroll-driven virtualizer render.
   const estimatedInitialBottomOffset = useMemo(
     () => TRANSCRIPT_TOP_PADDING_PX
-      + estimateRenderableRowsHeight(renderableRows)
+      + estimatedRowsHeight
       + structuralBottomInsetPx,
-    [renderableRows, structuralBottomInsetPx],
+    [estimatedRowsHeight, structuralBottomInsetPx],
   );
   const virtualizer = useVirtualizer({
     count: renderableRows.length,
     getScrollElement: () => scrollRef.current,
-    getItemKey: (index) => renderableRows[index]?.key ?? index,
-    estimateSize: (index) => estimateRenderableRowHeight(renderableRows[index]),
+    getItemKey,
+    estimateSize,
     overscan: VIRTUALIZER_OVERSCAN,
     paddingStart: TRANSCRIPT_TOP_PADDING_PX,
     paddingEnd: structuralBottomInsetPx,
@@ -98,12 +107,11 @@ export function VirtualizedTranscriptRowList({
     useAnimationFrameWithResizeObserver: true,
   });
   const pendingAnchorRef = useTranscriptVirtualAnchorCapture({
-    activeSessionId,
     getVirtualItems: () => virtualizer.getVirtualItems(),
     pinnedRef,
     renderableRows,
+    rowCompositionKey,
     scrollRef,
-    selectedWorkspaceId,
   });
   // Content-search jump-to-match: bring an off-screen row into view so its
   // painted marks mount before the overlay queries the DOM for the active one.

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-rendering.test.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-rendering.test.ts
@@ -8,12 +8,27 @@ import {
 } from "./transcript-presentation-test-fixtures";
 import { buildTurnPresentation } from "./transcript-presentation";
 import {
+  collectToolCallIdsWithProposedPlan,
   findTrailingLiveExplorationBlock,
   findTrailingLiveWorkBlock,
   turnHasActiveToolWork,
 } from "./transcript-rendering";
 
 describe("transcript rendering helpers", () => {
+  it("preserves the proposed-plan index identity when unrelated prose changes", () => {
+    const transcript = createTranscriptState("session-1");
+    const previous = new Set<string>();
+
+    const first = collectToolCallIdsWithProposedPlan(transcript, previous);
+    transcript.itemsById = {
+      message: assistantItem("message", "turn-1", 1),
+    };
+    const next = collectToolCallIdsWithProposedPlan(transcript, first);
+
+    expect(first).toBe(previous);
+    expect(next).toBe(first);
+  });
+
   it("does not keep a completed trailing inline action live after the action phase", () => {
     const transcript = createTranscriptState("session-1");
     transcript.itemsById = {

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-rendering.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-rendering.ts
@@ -15,6 +15,7 @@ import {
 import type { PromptOutboxEntry } from "../../sessions/intents/session-intent-model";
 
 const EMPTY_OUTBOX_STARTED_AT_BY_PROMPT_ID = new Map<string, string>();
+const EMPTY_PROPOSED_PLAN_TOOL_CALL_IDS: ReadonlySet<string> = new Set();
 
 export function buildOutboxStartedAtByPromptId(
   entries: readonly PromptOutboxEntry[],
@@ -81,12 +82,16 @@ export function getAssistantProseContent(
 
 export function collectToolCallIdsWithProposedPlan(
   transcript: TranscriptState,
-): Set<string> {
+  previous: ReadonlySet<string> = EMPTY_PROPOSED_PLAN_TOOL_CALL_IDS,
+): ReadonlySet<string> {
   const toolCallIds = new Set<string>();
   for (const item of Object.values(transcript.itemsById)) {
     if (item.kind === "proposed_plan") {
       addProposedPlanSourceIds(item.plan, toolCallIds);
     }
+  }
+  if (areSetsEqual(toolCallIds, previous)) {
+    return previous;
   }
   return toolCallIds;
 }
@@ -111,6 +116,10 @@ function addProposedPlanSourceIds(
   if (plan.sourceItemId) {
     output.add(plan.sourceItemId);
   }
+}
+
+function areSetsEqual<T>(left: ReadonlySet<T>, right: ReadonlySet<T>): boolean {
+  return left.size === right.size && [...left].every((value) => right.has(value));
 }
 
 export function findTrailingLiveExplorationBlock(

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-row-model.test.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-row-model.test.ts
@@ -998,29 +998,18 @@ describe("transcript virtualization config", () => {
     expect(parseTranscriptVirtualizationMode(null)).toBe("auto");
   });
 
-  it("enables virtualization automatically only for large row counts", () => {
+  it("keeps auto virtualization enabled from the first row", () => {
     expect(resolveTranscriptVirtualizationEnabled({
       mode: "auto",
-      rowCount: 79,
-      autoRowThreshold: 80,
-    })).toBe(false);
-    expect(resolveTranscriptVirtualizationEnabled({
-      mode: "auto",
-      rowCount: 80,
-      autoRowThreshold: 80,
     })).toBe(true);
   });
 
   it("allows explicit on/off overrides", () => {
     expect(resolveTranscriptVirtualizationEnabled({
       mode: "on",
-      rowCount: 1,
-      autoRowThreshold: 80,
     })).toBe(true);
     expect(resolveTranscriptVirtualizationEnabled({
       mode: "off",
-      rowCount: 1000,
-      autoRowThreshold: 80,
     })).toBe(false);
   });
 });

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-virtualization-config.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-virtualization-config.ts
@@ -1,8 +1,6 @@
 export const TRANSCRIPT_VIRTUALIZATION_STORAGE_KEY =
   "proliferate:transcriptVirtualization";
 
-export const TRANSCRIPT_VIRTUALIZATION_AUTO_ROW_THRESHOLD = 20;
-
 export type TranscriptVirtualizationMode = "auto" | "on" | "off";
 
 export function parseTranscriptVirtualizationMode(
@@ -16,16 +14,10 @@ export function parseTranscriptVirtualizationMode(
 
 export function resolveTranscriptVirtualizationEnabled(input: {
   mode: TranscriptVirtualizationMode;
-  rowCount: number;
-  autoRowThreshold?: number;
 }): boolean {
-  if (input.mode === "on") {
-    return true;
-  }
-  if (input.mode === "off") {
-    return false;
-  }
-  return input.rowCount >= (
-    input.autoRowThreshold ?? TRANSCRIPT_VIRTUALIZATION_AUTO_ROW_THRESHOLD
-  );
+  // Mount the normal path once and keep it stable as a live transcript grows.
+  // Threshold switching either strands new chats on the full-DOM renderer or
+  // remounts the viewport at the threshold, both of which defeat smooth scroll.
+  // `off` remains an explicit diagnostic escape hatch.
+  return input.mode !== "off";
 }

--- a/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-view-types.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-view-types.ts
@@ -32,6 +32,7 @@ export interface ChatTranscriptTurnRowRenderInput {
   turn: TurnRecord;
   transcript: TranscriptState;
   latestTurnId: string | null;
+  latestCompletedTurnId: string | null;
   latestLiveExplorationBlock: Extract<TurnDisplayBlock, { kind: "collapsed_actions" }> | null;
   latestLiveStatus: ReactNode;
   outboxStartedAtByPromptId: ReadonlyMap<string, string>;

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-row-list-model.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-row-list-model.ts
@@ -54,6 +54,7 @@ export interface TranscriptRowListBaseProps {
   onLoadOlderHistory: () => void;
   onScrollSample: (sample?: TranscriptScrollSample) => void;
   renderRow: (row: TranscriptVirtualRow, rowIndex: number) => ReactNode;
+  getRowRenderRevision?: (row: TranscriptVirtualRow) => unknown;
   columnClassName?: string;
   gutterClassName?: string;
   scrollHandleRef?: RefObject<ChatTranscriptScrollHandle | null>;

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-row-renderer.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-row-renderer.test.tsx
@@ -1,0 +1,191 @@
+/* @vitest-environment jsdom */
+
+import { render, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { createTranscriptState, type TranscriptState } from "@anyharness/sdk";
+import type { ReactNode } from "react";
+import type { TranscriptVirtualRow } from "#product/domain/chats/transcript/transcript-virtual-rows";
+import type { ChatTranscriptTurnRowRenderInput } from "./chat-transcript-view-types";
+import { MemoizedVirtualTranscriptRow } from "#product/components/workspace/chat/transcript/VirtualTranscriptRow";
+import { useChatTranscriptRowRenderer } from "./use-chat-transcript-row-renderer";
+
+const HISTORICAL_ROW = {
+  kind: "turn",
+  key: "turn:history:block:content",
+  turnId: "history",
+} as TranscriptVirtualRow;
+const LATEST_ROW = {
+  kind: "turn",
+  key: "turn:latest:block:content",
+  turnId: "latest",
+} as TranscriptVirtualRow;
+const EMPTY_OUTBOX_ENTRIES = [] as const;
+const OUTBOX_ACTIONS = {
+  retryPrompt: (_clientPromptId: string) => {},
+  dismissPrompt: (_clientPromptId: string) => {},
+};
+const OUTBOX_STARTED_AT_BY_PROMPT_ID = new Map<string, string>();
+const MEASURE_ELEMENT = (_element: Element | null) => {};
+
+function IntegratedLatestRow({
+  latestLiveStatus,
+  renderTurnRow,
+  transcript,
+}: {
+  latestLiveStatus: ReactNode;
+  renderTurnRow: (input: ChatTranscriptTurnRowRenderInput) => ReactNode;
+  transcript: TranscriptState;
+}) {
+  const rendering = useChatTranscriptRowRenderer({
+    activeSessionId: "session-1",
+    latestLiveExplorationBlock: null,
+    latestLiveStatus,
+    latestCompletedTurnId: null,
+    latestTurnId: "latest",
+    optimisticPromptTrailingStatus: null,
+    outboxActions: OUTBOX_ACTIONS,
+    outboxStartedAtByPromptId: OUTBOX_STARTED_AT_BY_PROMPT_ID,
+    renderPendingPromptRow: () => null,
+    renderTurnRow,
+    selectedWorkspaceId: "workspace-1",
+    sessionViewState: "working",
+    transcript,
+    visibleOutboxEntries: EMPTY_OUTBOX_ENTRIES,
+    visibleOptimisticPrompt: null,
+  });
+  return (
+    <MemoizedVirtualTranscriptRow
+      row={LATEST_ROW}
+      rowIndex={0}
+      virtualIndex={0}
+      renderRow={rendering.renderRow}
+      renderRevision={rendering.getRowRenderRevision(LATEST_ROW)}
+      measureElement={MEASURE_ELEMENT}
+    />
+  );
+}
+
+describe("useChatTranscriptRowRenderer", () => {
+  it("keeps historical revisions stable across stream batches and targets live status", () => {
+    const renderPendingPromptRow = vi.fn(() => null);
+    const renderTurnRow = vi.fn(() => null);
+    const outboxActions = { retryPrompt: vi.fn(), dismissPrompt: vi.fn() };
+    const outboxStartedAtByPromptId = new Map<string, string>();
+    let transcript = createTranscriptState("session-1");
+    let latestLiveStatus = null as ReactNode;
+
+    const { result, rerender } = renderHook(() => useChatTranscriptRowRenderer({
+      activeSessionId: "session-1",
+      latestLiveExplorationBlock: null,
+      latestLiveStatus,
+      latestCompletedTurnId: "history",
+      latestTurnId: "latest",
+      optimisticPromptTrailingStatus: null,
+      outboxActions,
+      outboxStartedAtByPromptId,
+      renderPendingPromptRow,
+      renderTurnRow,
+      selectedWorkspaceId: "workspace-1",
+      sessionViewState: "working",
+      transcript,
+      visibleOutboxEntries: [],
+      visibleOptimisticPrompt: null,
+    }));
+    const historicalRevision = result.current.getRowRenderRevision(HISTORICAL_ROW);
+    const latestRevision = result.current.getRowRenderRevision(LATEST_ROW);
+    const firstRenderer = result.current.renderRow;
+
+    transcript = { ...transcript, itemsById: { ...transcript.itemsById } };
+    rerender();
+
+    expect(result.current.renderRow).not.toBe(firstRenderer);
+    expect(result.current.getRowRenderRevision(HISTORICAL_ROW)).toBe(historicalRevision);
+    expect(result.current.getRowRenderRevision(LATEST_ROW)).toBe(latestRevision);
+
+    latestLiveStatus = <span>Working</span>;
+    rerender();
+
+    expect(result.current.getRowRenderRevision(HISTORICAL_ROW)).toBe(historicalRevision);
+    expect(result.current.getRowRenderRevision(LATEST_ROW)).not.toBe(latestRevision);
+
+    const historicalRevisionBeforeLinkMetadata = result.current.getRowRenderRevision(HISTORICAL_ROW);
+    transcript = {
+      ...transcript,
+      linkCompletionsByCompletionId: { ...transcript.linkCompletionsByCompletionId },
+    };
+    rerender();
+
+    expect(result.current.getRowRenderRevision(HISTORICAL_ROW))
+      .not.toBe(historicalRevisionBeforeLinkMetadata);
+  });
+
+  it("updates the mounted latest row only for row-visible revision changes", () => {
+    let transcript = createTranscriptState("session-1");
+    transcript = {
+      ...transcript,
+      sessionMeta: { ...transcript.sessionMeta, title: "Original" },
+      turnOrder: ["latest"],
+      turnsById: {
+        latest: {
+          turnId: "latest",
+          itemOrder: [],
+          startedAt: "2026-08-05T00:00:00.000Z",
+          completedAt: null,
+          stopReason: null,
+          fileBadges: [],
+        },
+      },
+    };
+    let latestLiveStatus: ReactNode = "idle";
+    const renderTurnRow = vi.fn((input: ChatTranscriptTurnRowRenderInput) => (
+      <div data-testid="integrated-latest-row">
+        {input.latestLiveStatus}:{input.transcript.sessionMeta.title}
+      </div>
+    ));
+    const rendered = render(
+      <IntegratedLatestRow
+        latestLiveStatus={latestLiveStatus}
+        renderTurnRow={renderTurnRow}
+        transcript={transcript}
+      />,
+    );
+
+    expect(rendered.getByTestId("integrated-latest-row").textContent).toBe("idle:Original");
+    expect(renderTurnRow).toHaveBeenCalledTimes(1);
+
+    transcript = { ...transcript, itemsById: { ...transcript.itemsById } };
+    rendered.rerender(
+      <IntegratedLatestRow
+        latestLiveStatus={latestLiveStatus}
+        renderTurnRow={renderTurnRow}
+        transcript={transcript}
+      />,
+    );
+    expect(renderTurnRow).toHaveBeenCalledTimes(1);
+
+    latestLiveStatus = "working";
+    rendered.rerender(
+      <IntegratedLatestRow
+        latestLiveStatus={latestLiveStatus}
+        renderTurnRow={renderTurnRow}
+        transcript={transcript}
+      />,
+    );
+    expect(rendered.getByTestId("integrated-latest-row").textContent).toBe("working:Original");
+    expect(renderTurnRow).toHaveBeenCalledTimes(2);
+
+    transcript = {
+      ...transcript,
+      sessionMeta: { ...transcript.sessionMeta, title: "Renamed" },
+    };
+    rendered.rerender(
+      <IntegratedLatestRow
+        latestLiveStatus={latestLiveStatus}
+        renderTurnRow={renderTurnRow}
+        transcript={transcript}
+      />,
+    );
+    expect(rendered.getByTestId("integrated-latest-row").textContent).toBe("working:Renamed");
+    expect(renderTurnRow).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-row-renderer.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-row-renderer.ts
@@ -1,4 +1,4 @@
-import { useCallback, type ReactNode } from "react";
+import { useCallback, useMemo, type ReactNode } from "react";
 import type { PromptOutboxEntry } from "#product/domain/sessions/intents/session-intent-model";
 import type {
   PendingPromptEntry,
@@ -15,10 +15,16 @@ import type {
 } from "./chat-transcript-view-types";
 import { resolvePendingPromptRenderTarget } from "#product/lib/domain/chat/transcript/chat-transcript-view-rules";
 
+export interface ChatTranscriptRowRendering {
+  renderRow: (row: TranscriptVirtualRow, rowIndex: number) => ReactNode;
+  getRowRenderRevision: (row: TranscriptVirtualRow) => object;
+}
+
 export function useChatTranscriptRowRenderer({
   activeSessionId,
   latestLiveExplorationBlock,
   latestLiveStatus,
+  latestCompletedTurnId,
   latestTurnId,
   optimisticPromptTrailingStatus,
   outboxActions,
@@ -35,6 +41,7 @@ export function useChatTranscriptRowRenderer({
   activeSessionId: string;
   latestLiveExplorationBlock: Extract<TurnDisplayBlock, { kind: "collapsed_actions" }> | null;
   latestLiveStatus: ReactNode;
+  latestCompletedTurnId: string | null;
   latestTurnId: string | null;
   optimisticPromptTrailingStatus: ReactNode;
   outboxActions: ChatTranscriptOutboxActions;
@@ -47,8 +54,8 @@ export function useChatTranscriptRowRenderer({
   transcript: TranscriptState;
   visibleOutboxEntries: readonly PromptOutboxEntry[];
   visibleOptimisticPrompt: PendingPromptEntry | null;
-}): (row: TranscriptVirtualRow, rowIndex: number) => ReactNode {
-  return useCallback((row: TranscriptVirtualRow, rowIndex: number) => {
+}): ChatTranscriptRowRendering {
+  const renderRow = useCallback((row: TranscriptVirtualRow, rowIndex: number) => {
     if (row.kind === "pending_prompt" || row.kind === "outbox_prompt") {
       const target = resolvePendingPromptRenderTarget({
         row,
@@ -84,6 +91,7 @@ export function useChatTranscriptRowRenderer({
       turn,
       transcript,
       latestTurnId,
+      latestCompletedTurnId,
       latestLiveExplorationBlock,
       latestLiveStatus,
       outboxStartedAtByPromptId,
@@ -92,6 +100,7 @@ export function useChatTranscriptRowRenderer({
     });
   }, [
     activeSessionId,
+    latestCompletedTurnId,
     latestLiveExplorationBlock,
     latestLiveStatus,
     latestTurnId,
@@ -107,4 +116,62 @@ export function useChatTranscriptRowRenderer({
     visibleOutboxEntries,
     visibleOptimisticPrompt,
   ]);
+
+  // Row wrappers intentionally ignore renderRow's whole-transcript identity.
+  // These explicit revisions carry only the external inputs that can change a
+  // row whose immutable row model stayed the same. A streaming tail update now
+  // repaints the tail row while historical rows retain their memoized subtree.
+  const turnRenderRevision = useMemo(() => ({}), [
+    outboxStartedAtByPromptId,
+    renderTurnRow,
+    selectedWorkspaceId,
+    sessionViewState,
+    transcript.linkCompletionsByCompletionId,
+    transcript.sessionMeta.title,
+  ]);
+  const latestTurnRenderRevision = useMemo(() => ({}), [
+    latestLiveExplorationBlock,
+    latestLiveStatus,
+    latestTurnId,
+    turnRenderRevision,
+  ]);
+  const latestCompletedTurnRenderRevision = useMemo(() => ({}), [
+    latestCompletedTurnId,
+    turnRenderRevision,
+  ]);
+  const pendingPromptRenderRevision = useMemo(() => ({}), [
+    activeSessionId,
+    optimisticPromptTrailingStatus,
+    outboxActions,
+    renderPendingPromptRow,
+    visibleOptimisticPrompt,
+    visibleOutboxEntries,
+  ]);
+  const goalEventRenderRevision = useMemo(() => ({}), [renderGoalEventRow]);
+
+  const getRowRenderRevision = useCallback((row: TranscriptVirtualRow): object => {
+    if (row.kind === "pending_prompt" || row.kind === "outbox_prompt") {
+      return pendingPromptRenderRevision;
+    }
+    if (row.kind === "goal_event") {
+      return goalEventRenderRevision;
+    }
+    if (row.turnId === latestTurnId) {
+      return latestTurnRenderRevision;
+    }
+    if (row.turnId === latestCompletedTurnId) {
+      return latestCompletedTurnRenderRevision;
+    }
+    return turnRenderRevision;
+  }, [
+    goalEventRenderRevision,
+    latestCompletedTurnId,
+    latestCompletedTurnRenderRevision,
+    latestTurnId,
+    latestTurnRenderRevision,
+    pendingPromptRenderRevision,
+    turnRenderRevision,
+  ]);
+
+  return { renderRow, getRowRenderRevision };
 }

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-view-model.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-view-model.ts
@@ -24,6 +24,7 @@ import { collectVisibleTurnIds } from "#product/lib/domain/chat/transcript/chat-
 import { useLatestTranscriptLiveStatus } from "./use-latest-transcript-live-status";
 import { useSharedTranscriptRowModel } from "./use-shared-transcript-row-model";
 import { useOptimisticPromptHandoff } from "./use-optimistic-prompt-handoff";
+import { latestCompletedTurn } from "#product/domain/chats/transcript/last-turn-file-changes";
 
 const noop = () => {};
 const EMPTY_OUTBOX_ENTRIES: readonly PromptOutboxEntry[] = [];
@@ -49,6 +50,7 @@ export interface ChatTranscriptViewModel {
   virtualRows: readonly TranscriptVirtualRow[];
   visibleTurnIds: readonly string[];
   latestTurnId: string | null;
+  latestCompletedTurnId: string | null;
   latestLiveExplorationBlock: Extract<TurnDisplayBlock, { kind: "collapsed_actions" }> | null;
   latestLiveStatus: ReactNode;
 }
@@ -85,6 +87,10 @@ export function useChatTranscriptViewModel({
   const columnClassName = layout?.columnClassName;
   const gutterClassName = layout?.gutterClassName;
   const latestTurnId = transcript.turnOrder[transcript.turnOrder.length - 1] ?? null;
+  const latestCompletedTurnId = useMemo(
+    () => latestCompletedTurn(transcript)?.turnId ?? null,
+    [transcript],
+  );
   const latestTurn = latestTurnId ? transcript.turnsById[latestTurnId] ?? null : null;
   const latestTurnHasAssistantRenderableContent = turnHasAssistantRenderableTranscriptContent(
     latestTurn,
@@ -174,6 +180,7 @@ export function useChatTranscriptViewModel({
     virtualRows,
     visibleTurnIds,
     latestTurnId,
+    latestCompletedTurnId,
     latestLiveExplorationBlock,
     latestLiveStatus,
   };

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.test.tsx
@@ -316,6 +316,21 @@ describe("useTranscriptStickToBottom", () => {
     expect(handle.current.api.isPinnedToBottom).toBe(false);
   });
 
+  it("records the bottom baseline when a guarded snap is already satisfied", () => {
+    const handle = renderHarness();
+    const { viewport } = handle.current;
+    setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 700 });
+
+    act(() => {
+      handle.current.api.scrollToBottom();
+    });
+
+    // This is still inside the re-pin band, so only the upward direction tells
+    // the engine that the user is leaving the bottom.
+    userScroll(handle, 690);
+    expect(handle.current.api.isPinnedToBottom).toBe(false);
+  });
+
   it("re-pins only within the tight bottom band", () => {
     const handle = renderHarness();
     const { viewport } = handle.current;

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
@@ -153,16 +153,29 @@ export function useTranscriptStickToBottom({
     if (!viewport) {
       return;
     }
+    const requestedTop = resolveAutoFollowScrollTop(
+      viewport,
+      autoFollowBottomInsetRef.current,
+      consumedAutoFollowBottomInsetRef.current,
+    );
+    const reachableTop = Math.min(
+      requestedTop,
+      Math.max(0, viewport.scrollHeight - viewport.clientHeight),
+    );
+    if (Math.abs(viewport.scrollTop - reachableTop) <= PROGRAMMATIC_MATCH_TOL_PX) {
+      // Keep direction tracking aligned even when the browser (or the
+      // virtualizer's initial offset) already placed us at the target. Without
+      // this baseline, the first small upward user scroll can look downward
+      // relative to the stale pre-mount position and immediately re-pin.
+      lastScrollTopRef.current = viewport.scrollTop;
+      return;
+    }
     // Pin against the real DOM scroll height, never virtualizer.scrollToIndex:
     // index scrolling positions by the *estimated* size of unmeasured rows
     // (e.g. the row appended by this very update) and visibly bounces when the
     // measurement corrects a frame later.
     notifyProgrammaticScroll(() => {
-      viewport.scrollTop = resolveAutoFollowScrollTop(
-        viewport,
-        autoFollowBottomInsetRef.current,
-        consumedAutoFollowBottomInsetRef.current,
-      );
+      viewport.scrollTop = requestedTop;
     });
   }, [notifyProgrammaticScroll, scrollRef]);
 
@@ -238,13 +251,7 @@ export function useTranscriptStickToBottom({
         glueFrameRef.current = null;
         return;
       }
-      notifyProgrammaticScroll(() => {
-        viewport.scrollTop = resolveAutoFollowScrollTop(
-          viewport,
-          autoFollowBottomInsetRef.current,
-          consumedAutoFollowBottomInsetRef.current,
-        );
-      });
+      scrollToBottom();
       const height = viewport.scrollHeight;
       if (height === lastHeight) {
         stableFrames += 1;
@@ -260,7 +267,7 @@ export function useTranscriptStickToBottom({
       glueFrameRef.current = requestAnimationFrame(tick);
     };
     glueFrameRef.current = requestAnimationFrame(tick);
-  }, [notifyProgrammaticScroll, scrollRef]);
+  }, [scrollRef, scrollToBottom]);
 
   // Session re-entry: snap instantly, then glue for a few frames so the
   // measurement backlog of freshly mounted rows (virtualizer estimates

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtual-anchor-capture.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtual-anchor-capture.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useMemo, useRef, type RefObject } from "react";
+import { useLayoutEffect, useRef, type RefObject } from "react";
 import type {
   ContentHeightScrollAnchor,
   TranscriptRenderableRow,
@@ -18,30 +18,20 @@ export interface TranscriptVirtualScrollAnchor extends ContentHeightScrollAnchor
 }
 
 export function useTranscriptVirtualAnchorCapture({
-  activeSessionId,
   getVirtualItems,
   pinnedRef,
   renderableRows,
+  rowCompositionKey,
   scrollRef,
-  selectedWorkspaceId,
 }: {
-  activeSessionId: string;
   getVirtualItems: () => readonly TranscriptVirtualItemSnapshot[];
   pinnedRef: RefObject<boolean>;
   renderableRows: readonly TranscriptRenderableRow[];
+  rowCompositionKey: string;
   scrollRef: RefObject<HTMLDivElement | null>;
-  selectedWorkspaceId: string | null;
 }): RefObject<TranscriptVirtualScrollAnchor | null> {
   const captureAnchorRef = useRef<() => void>(() => {});
   const pendingAnchorRef = useRef<TranscriptVirtualScrollAnchor | null>(null);
-  const rowCompositionKey = useMemo(
-    () => [
-      selectedWorkspaceId ?? "workspace",
-      activeSessionId,
-      ...renderableRows.map((row) => row.key),
-    ].join("\0"),
-    [activeSessionId, renderableRows, selectedWorkspaceId],
-  );
 
   // Keep the capture closure current without reading layout. The keyed cleanup
   // below invokes the last committed closure only when row composition changes.

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtual-anchor-capture.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtual-anchor-capture.ts
@@ -1,0 +1,91 @@
+import { useLayoutEffect, useMemo, useRef, type RefObject } from "react";
+import type {
+  ContentHeightScrollAnchor,
+  TranscriptRenderableRow,
+} from "#product/hooks/chat/ui/transcript-row-list-model";
+
+interface TranscriptVirtualItemSnapshot {
+  index: number;
+  start: number;
+  end: number;
+}
+
+export interface TranscriptVirtualScrollAnchor extends ContentHeightScrollAnchor {
+  key: TranscriptRenderableRow["key"];
+  offsetWithinRowPx: number;
+  rowIndex: number;
+  rowCount: number;
+}
+
+export function useTranscriptVirtualAnchorCapture({
+  activeSessionId,
+  getVirtualItems,
+  pinnedRef,
+  renderableRows,
+  scrollRef,
+  selectedWorkspaceId,
+}: {
+  activeSessionId: string;
+  getVirtualItems: () => readonly TranscriptVirtualItemSnapshot[];
+  pinnedRef: RefObject<boolean>;
+  renderableRows: readonly TranscriptRenderableRow[];
+  scrollRef: RefObject<HTMLDivElement | null>;
+  selectedWorkspaceId: string | null;
+}): RefObject<TranscriptVirtualScrollAnchor | null> {
+  const captureAnchorRef = useRef<() => void>(() => {});
+  const pendingAnchorRef = useRef<TranscriptVirtualScrollAnchor | null>(null);
+  const rowCompositionKey = useMemo(
+    () => [
+      selectedWorkspaceId ?? "workspace",
+      activeSessionId,
+      ...renderableRows.map((row) => row.key),
+    ].join("\0"),
+    [activeSessionId, renderableRows, selectedWorkspaceId],
+  );
+
+  // Keep the capture closure current without reading layout. The keyed cleanup
+  // below invokes the last committed closure only when row composition changes.
+  useLayoutEffect(() => {
+    captureAnchorRef.current = () => {
+      const viewport = scrollRef.current;
+      if (!viewport || pinnedRef.current) {
+        pendingAnchorRef.current = null;
+        return;
+      }
+
+      const firstVisibleVirtualRow = getVirtualItems()
+        .find((item) => item.end >= viewport.scrollTop);
+      if (!firstVisibleVirtualRow) {
+        pendingAnchorRef.current = null;
+        return;
+      }
+
+      const row = renderableRows[firstVisibleVirtualRow.index];
+      if (!row) {
+        pendingAnchorRef.current = null;
+        return;
+      }
+
+      pendingAnchorRef.current = {
+        key: row.key,
+        offsetWithinRowPx: Math.max(viewport.scrollTop - firstVisibleVirtualRow.start, 0),
+        rowIndex: firstVisibleVirtualRow.index,
+        rowCount: renderableRows.length,
+        // Preserve real DOM metrics for a completing turn that splits one row
+        // above the visible anchor before the new row has been measured.
+        scrollHeight: viewport.scrollHeight,
+        scrollTop: viewport.scrollTop,
+      };
+    };
+  });
+
+  // The cleanup runs before the ordered row-key composition changes. Native
+  // scroll range commits leave it untouched and therefore perform no layout
+  // reads on the scroll hot path.
+  useLayoutEffect(
+    () => () => captureAnchorRef.current(),
+    [rowCompositionKey],
+  );
+
+  return pendingAnchorRef;
+}

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtual-measurement-model.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtual-measurement-model.ts
@@ -1,0 +1,61 @@
+import { useCallback, useMemo } from "react";
+import {
+  estimateRenderableRowHeight,
+  type TranscriptRenderableRow,
+} from "#product/hooks/chat/ui/transcript-row-list-model";
+
+type VirtualMeasurementEntry = readonly [key: string, estimatedSize: number];
+
+export function useTranscriptVirtualMeasurementModel({
+  activeSessionId,
+  renderableRows,
+  selectedWorkspaceId,
+}: {
+  activeSessionId: string;
+  renderableRows: readonly TranscriptRenderableRow[];
+  selectedWorkspaceId: string | null;
+}) {
+  // TanStack keys its measurement memo on getItemKey identity. Serialize only
+  // the ordered key/estimate inputs, then retain the parsed model and accessors
+  // across content-only row snapshots. They rotate only when row composition
+  // or session scope changes, which is exactly when measurements must rebuild.
+  const measurementSignature = useMemo(
+    () => JSON.stringify(renderableRows.map((row) => [
+      row.key,
+      estimateRenderableRowHeight(row),
+    ] satisfies VirtualMeasurementEntry)),
+    [renderableRows],
+  );
+  const measurementEntries = useMemo(
+    () => JSON.parse(measurementSignature) as VirtualMeasurementEntry[],
+    [measurementSignature],
+  );
+  const rowCompositionKey = useMemo(
+    () => JSON.stringify([
+      selectedWorkspaceId,
+      activeSessionId,
+      measurementSignature,
+    ]),
+    [activeSessionId, measurementSignature, selectedWorkspaceId],
+  );
+  const getItemKey = useCallback(
+    (index: number) => measurementEntries[index]?.[0] ?? index,
+    [measurementEntries, rowCompositionKey],
+  );
+  const estimateSize = useCallback(
+    (index: number) => measurementEntries[index]?.[1]
+      ?? estimateRenderableRowHeight(undefined),
+    [measurementEntries, rowCompositionKey],
+  );
+  const estimatedRowsHeight = useMemo(
+    () => measurementEntries.reduce((sum, entry) => sum + entry[1], 0),
+    [measurementEntries],
+  );
+
+  return {
+    estimateSize,
+    estimatedRowsHeight,
+    getItemKey,
+    rowCompositionKey,
+  };
+}

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtualizer-blank-fallback.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtualizer-blank-fallback.test.tsx
@@ -1,0 +1,148 @@
+/* @vitest-environment jsdom */
+
+import { useRef } from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useTranscriptVirtualizerBlankFallback } from "./use-transcript-virtualizer-blank-fallback";
+
+let frames: FrameRequestCallback[];
+
+beforeEach(() => {
+  frames = [];
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    frames.push(callback);
+    return frames.length;
+  });
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function flushFrame() {
+  const callback = frames.shift();
+  callback?.(0);
+}
+
+function Harness({
+  firstVirtualItem,
+  lastVirtualItem,
+  onFallback,
+}: {
+  firstVirtualItem: { index: number; start: number; end: number } | null;
+  lastVirtualItem: { index: number; start: number; end: number } | null;
+  onFallback: (reason: string) => void;
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const lastBlankReportSignatureRef = useRef<string | null>(null);
+  useTranscriptVirtualizerBlankFallback({
+    activeSessionId: "session-1",
+    bottomSpacerHeight: 0,
+    firstVirtualItem,
+    lastVirtualItem,
+    lastBlankReportSignatureRef,
+    onFallback,
+    renderableRowCount: 100,
+    rowCount: 100,
+    scrollRef,
+    selectedWorkspaceId: "workspace-1",
+    topSpacerHeight: 0,
+    totalContentHeight: 10_000,
+    virtualItemCount: firstVirtualItem && lastVirtualItem ? 2 : 0,
+  });
+  return (
+    <div ref={scrollRef} data-testid="viewport">
+      <div data-transcript-virtual-row="true" />
+    </div>
+  );
+}
+
+function setViewportMetrics(viewport: HTMLDivElement, scrollTop: number) {
+  Object.defineProperty(viewport, "clientHeight", { value: 400, configurable: true });
+  Object.defineProperty(viewport, "scrollHeight", { value: 10_000, configurable: true });
+  viewport.scrollTop = scrollTop;
+}
+
+describe("useTranscriptVirtualizerBlankFallback", () => {
+  it("does no rectangle measurement for a healthy logical virtual range", () => {
+    const onFallback = vi.fn();
+    const rectangleRead = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect");
+    const rendered = render(
+      <Harness
+        firstVirtualItem={{ index: 4, start: 350, end: 500 }}
+        lastVirtualItem={{ index: 8, start: 900, end: 1_050 }}
+        onFallback={onFallback}
+      />,
+    );
+    setViewportMetrics(rendered.getByTestId("viewport") as HTMLDivElement, 400);
+
+    act(flushFrame);
+
+    expect(rectangleRead).not.toHaveBeenCalled();
+    expect(onFallback).not.toHaveBeenCalled();
+  });
+
+  it("requires two DOM-confirmed blank frames before falling back", () => {
+    const onFallback = vi.fn();
+    const rendered = render(
+      <Harness
+        firstVirtualItem={{ index: 0, start: 0, end: 100 }}
+        lastVirtualItem={{ index: 1, start: 100, end: 200 }}
+        onFallback={onFallback}
+      />,
+    );
+    const viewport = rendered.getByTestId("viewport") as HTMLDivElement;
+    setViewportMetrics(viewport, 2_000);
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function () {
+      const top = this === viewport ? 0 : 1_000;
+      const bottom = this === viewport ? 400 : 1_100;
+      return { top, bottom } as DOMRect;
+    });
+
+    act(flushFrame);
+    expect(onFallback).not.toHaveBeenCalled();
+    expect(frames).toHaveLength(1);
+
+    act(flushFrame);
+    expect(onFallback).not.toHaveBeenCalled();
+    expect(frames).toHaveLength(1);
+
+    act(flushFrame);
+    expect(onFallback).toHaveBeenCalledWith("blank_viewport");
+  });
+
+  it("does not fall back when a suspicious blank recovers before DOM confirmation", () => {
+    const onFallback = vi.fn();
+    const rendered = render(
+      <Harness
+        firstVirtualItem={{ index: 0, start: 0, end: 100 }}
+        lastVirtualItem={{ index: 1, start: 100, end: 200 }}
+        onFallback={onFallback}
+      />,
+    );
+    const viewport = rendered.getByTestId("viewport") as HTMLDivElement;
+    const row = viewport.querySelector<HTMLElement>("[data-transcript-virtual-row='true']")!;
+    setViewportMetrics(viewport, 2_000);
+    let rowVisible = false;
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function () {
+      if (this === viewport) {
+        return { top: 0, bottom: 400 } as DOMRect;
+      }
+      return rowVisible && this === row
+        ? { top: 100, bottom: 200 } as DOMRect
+        : { top: 1_000, bottom: 1_100 } as DOMRect;
+    });
+
+    act(flushFrame);
+    act(flushFrame);
+    rowVisible = true;
+    act(flushFrame);
+
+    expect(onFallback).not.toHaveBeenCalled();
+    expect(frames).toHaveLength(0);
+  });
+});

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtualizer-blank-fallback.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtualizer-blank-fallback.ts
@@ -1,10 +1,13 @@
-import { useEffect, type RefObject } from "react";
+import { useEffect, useRef, type RefObject } from "react";
 import {
   hashMeasurementScope,
   isMainThreadMeasurementEnabled,
 } from "#product/lib/infra/measurement/measurement-port";
 
 const BLANK_VIEWPORT_MIN_SCROLLABLE_PX = 32;
+const BLANK_VIEWPORT_LOGICAL_CONFIRMATION_FRAMES = 2;
+const BLANK_VIEWPORT_DOM_CONFIRMATION_FRAMES = 2;
+const VIRTUAL_RANGE_OVERLAP_EPSILON_PX = 1;
 
 interface TranscriptVirtualItemSnapshot {
   index: number;
@@ -41,19 +44,71 @@ export function useTranscriptVirtualizerBlankFallback({
   totalContentHeight: number;
   virtualItemCount: number;
 }): void {
+  const suspicionRef = useRef<{
+    signature: string;
+    logicalFrames: number;
+    domBlankFrames: number;
+  } | null>(null);
+
   useEffect(() => {
     if (rowCount === 0) {
+      suspicionRef.current = null;
       return;
     }
 
-    const frame = window.requestAnimationFrame(() => {
+    let frame: number | null = null;
+    const inspect = () => {
       const viewport = scrollRef.current;
       if (!viewport) {
+        suspicionRef.current = null;
         return;
       }
 
+      // Hidden/suspended tabs can retain a scrollHeight while exposing a zero
+      // viewport. That is not a virtualizer failure and must never permanently
+      // swap a long transcript back to the full-DOM renderer.
+      if (viewport.clientHeight <= VIRTUAL_RANGE_OVERLAP_EPSILON_PX
+        || document.visibilityState === "hidden") {
+        suspicionRef.current = null;
+        return;
+      }
       const scrollableDistance = viewport.scrollHeight - viewport.clientHeight;
       if (scrollableDistance < BLANK_VIEWPORT_MIN_SCROLLABLE_PX) {
+        suspicionRef.current = null;
+        return;
+      }
+
+      // TanStack already gives us the mounted range in scroll coordinates.
+      // Use that cheap logical overlap check on the normal scroll path; DOM
+      // rectangles are only read after a stable suspicious range survives two
+      // animation frames.
+      if (virtualRangeOverlapsViewport({
+        firstVirtualItem,
+        lastVirtualItem,
+        scrollTop: viewport.scrollTop,
+        clientHeight: viewport.clientHeight,
+      })) {
+        suspicionRef.current = null;
+        return;
+      }
+
+      const suspectSignature = [
+        activeSessionId,
+        Math.round(viewport.scrollTop),
+        Math.round(viewport.clientHeight),
+        firstVirtualItem?.index ?? "none",
+        lastVirtualItem?.index ?? "none",
+      ].join(":");
+      const previousSuspicion = suspicionRef.current;
+      const logicalFrames = previousSuspicion?.signature === suspectSignature
+        ? previousSuspicion.logicalFrames + 1
+        : 1;
+      const domBlankFrames = previousSuspicion?.signature === suspectSignature
+        ? previousSuspicion.domBlankFrames
+        : 0;
+      suspicionRef.current = { signature: suspectSignature, logicalFrames, domBlankFrames };
+      if (logicalFrames < BLANK_VIEWPORT_LOGICAL_CONFIRMATION_FRAMES) {
+        frame = window.requestAnimationFrame(inspect);
         return;
       }
 
@@ -67,6 +122,18 @@ export function useTranscriptVirtualizerBlankFallback({
       }).length;
 
       if (visibleRowCount > 0) {
+        suspicionRef.current = null;
+        return;
+      }
+
+      const confirmedDomBlankFrames = domBlankFrames + 1;
+      suspicionRef.current = {
+        signature: suspectSignature,
+        logicalFrames,
+        domBlankFrames: confirmedDomBlankFrames,
+      };
+      if (confirmedDomBlankFrames < BLANK_VIEWPORT_DOM_CONFIRMATION_FRAMES) {
+        frame = window.requestAnimationFrame(inspect);
         return;
       }
 
@@ -104,11 +171,16 @@ export function useTranscriptVirtualizerBlankFallback({
         });
       }
 
+      suspicionRef.current = null;
       onFallback("blank_viewport");
-    });
+    };
+
+    frame = window.requestAnimationFrame(inspect);
 
     return () => {
-      window.cancelAnimationFrame(frame);
+      if (frame !== null) {
+        window.cancelAnimationFrame(frame);
+      }
     };
   }, [
     activeSessionId,
@@ -125,4 +197,23 @@ export function useTranscriptVirtualizerBlankFallback({
     totalContentHeight,
     virtualItemCount,
   ]);
+}
+
+export function virtualRangeOverlapsViewport({
+  firstVirtualItem,
+  lastVirtualItem,
+  scrollTop,
+  clientHeight,
+}: {
+  firstVirtualItem: TranscriptVirtualItemSnapshot | null;
+  lastVirtualItem: TranscriptVirtualItemSnapshot | null;
+  scrollTop: number;
+  clientHeight: number;
+}): boolean {
+  if (!firstVirtualItem || !lastVirtualItem || clientHeight <= 0) {
+    return false;
+  }
+  const viewportEnd = scrollTop + clientHeight;
+  return lastVirtualItem.end > scrollTop + VIRTUAL_RANGE_OVERLAP_EPSILON_PX
+    && firstVirtualItem.start < viewportEnd - VIRTUAL_RANGE_OVERLAP_EPSILON_PX;
 }

--- a/apps/packages/product-client/src/primitives/patterns/AutoHideScrollArea.test.tsx
+++ b/apps/packages/product-client/src/primitives/patterns/AutoHideScrollArea.test.tsx
@@ -1,0 +1,87 @@
+/* @vitest-environment jsdom */
+
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AutoHideScrollArea } from "./AutoHideScrollArea";
+
+let frames: FrameRequestCallback[];
+let resizeObserverConstructions: number;
+let resizeObserverDisconnects: number;
+
+beforeEach(() => {
+  frames = [];
+  resizeObserverConstructions = 0;
+  resizeObserverDisconnects = 0;
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    frames.push(callback);
+    return frames.length;
+  });
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  vi.stubGlobal("ResizeObserver", class {
+    constructor(_callback: ResizeObserverCallback) {
+      resizeObserverConstructions += 1;
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {
+      resizeObserverDisconnects += 1;
+    }
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function flushFrames() {
+  const pending = frames;
+  frames = [];
+  for (const callback of pending) {
+    callback(0);
+  }
+}
+
+describe("AutoHideScrollArea", () => {
+  it("keeps one observer and coalesces thumb geometry during scroll bursts", () => {
+    const firstScroll = vi.fn();
+    const latestScroll = vi.fn();
+    const rendered = render(
+      <AutoHideScrollArea className="h-80" onViewportScroll={firstScroll}>
+        <div>content</div>
+      </AutoHideScrollArea>,
+    );
+    const viewport = rendered.container.querySelector<HTMLDivElement>(".scrollbar-none")!;
+    Object.defineProperty(viewport, "clientHeight", { value: 300, configurable: true });
+    Object.defineProperty(viewport, "scrollHeight", { value: 3_000, configurable: true });
+    viewport.scrollTop = 0;
+    act(flushFrames);
+
+    rendered.rerender(
+      <AutoHideScrollArea className="h-80" onViewportScroll={latestScroll}>
+        <div>content</div>
+      </AutoHideScrollArea>,
+    );
+    expect(resizeObserverConstructions).toBe(1);
+    expect(resizeObserverDisconnects).toBe(0);
+
+    act(() => {
+      viewport.scrollTop = 100;
+      fireEvent.scroll(viewport);
+      viewport.scrollTop = 200;
+      fireEvent.scroll(viewport);
+      viewport.scrollTop = 300;
+      fireEvent.scroll(viewport);
+    });
+
+    expect(firstScroll).not.toHaveBeenCalled();
+    expect(latestScroll).toHaveBeenCalledTimes(3);
+    expect(frames).toHaveLength(1);
+
+    act(flushFrames);
+    const thumb = rendered.container.querySelector<HTMLElement>("[aria-hidden='true'] > div")!;
+    expect(thumb.style.height).toBe("30px");
+    expect(thumb.style.transform).toBe("translateY(30px)");
+  });
+});

--- a/apps/packages/product-client/src/primitives/patterns/AutoHideScrollArea.test.tsx
+++ b/apps/packages/product-client/src/primitives/patterns/AutoHideScrollArea.test.tsx
@@ -84,4 +84,42 @@ describe("AutoHideScrollArea", () => {
     expect(thumb.style.height).toBe("30px");
     expect(thumb.style.transform).toBe("translateY(30px)");
   });
+
+  it("restores thumb geometry after horizontal mode remounts it", () => {
+    const rendered = render(
+      <AutoHideScrollArea className="h-80">
+        <div>content</div>
+      </AutoHideScrollArea>,
+    );
+    const viewport = rendered.container.querySelector<HTMLDivElement>(".scrollbar-none")!;
+    Object.defineProperty(viewport, "clientHeight", { value: 300, configurable: true });
+    Object.defineProperty(viewport, "scrollHeight", { value: 3_000, configurable: true });
+    viewport.scrollTop = 300;
+
+    act(() => {
+      fireEvent.scroll(viewport);
+      flushFrames();
+    });
+    expect(rendered.container.querySelector<HTMLElement>("[aria-hidden='true'] > div")?.style.height)
+      .toBe("30px");
+
+    rendered.rerender(
+      <AutoHideScrollArea className="h-80" allowHorizontal>
+        <div>content</div>
+      </AutoHideScrollArea>,
+    );
+    expect(rendered.container.querySelector("[aria-hidden='true'] > div")).toBeNull();
+
+    rendered.rerender(
+      <AutoHideScrollArea className="h-80">
+        <div>content</div>
+      </AutoHideScrollArea>,
+    );
+    const remountedThumb = rendered.container.querySelector<HTMLElement>(
+      "[aria-hidden='true'] > div",
+    );
+    expect(remountedThumb?.style.height).toBe("30px");
+    expect(remountedThumb?.style.transform).toBe("translateY(30px)");
+    expect(remountedThumb?.style.pointerEvents).toBe("auto");
+  });
 });

--- a/apps/packages/product-client/src/primitives/patterns/AutoHideScrollArea.tsx
+++ b/apps/packages/product-client/src/primitives/patterns/AutoHideScrollArea.tsx
@@ -1,5 +1,6 @@
 import {
   forwardRef,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useRef,
@@ -72,6 +73,28 @@ export const AutoHideScrollArea = forwardRef<HTMLDivElement, AutoHideScrollAreaP
       onViewportScrollRef.current = onViewportScroll;
     }, [onViewportScroll]);
 
+    const applyThumbStateToDom = useCallback((state: ScrollThumbState) => {
+      const track = thumbTrackRef.current;
+      const thumb = thumbRef.current;
+      if (!track || !thumb) {
+        return;
+      }
+      track.style.opacity = state.visible && state.size > 0 ? "1" : "0";
+      thumb.style.pointerEvents = state.visible && state.size > 0 ? "auto" : "none";
+      thumb.style.height = `${state.size}px`;
+      thumb.style.transform = `translateY(${state.offset}px)`;
+    }, []);
+
+    const setThumbTrackNode = useCallback((node: HTMLDivElement | null) => {
+      thumbTrackRef.current = node;
+      applyThumbStateToDom(thumbStateRef.current);
+    }, [applyThumbStateToDom]);
+
+    const setThumbNode = useCallback((node: HTMLDivElement | null) => {
+      thumbRef.current = node;
+      applyThumbStateToDom(thumbStateRef.current);
+    }, [applyThumbStateToDom]);
+
     const clearHideTimer = () => {
       if (hideTimerRef.current != null) {
         window.clearTimeout(hideTimerRef.current);
@@ -84,15 +107,7 @@ export const AutoHideScrollArea = forwardRef<HTMLDivElement, AutoHideScrollAreaP
         return;
       }
       thumbStateRef.current = next;
-      const track = thumbTrackRef.current;
-      const thumb = thumbRef.current;
-      if (!track || !thumb) {
-        return;
-      }
-      track.style.opacity = next.visible && next.size > 0 ? "1" : "0";
-      thumb.style.pointerEvents = next.visible && next.size > 0 ? "auto" : "none";
-      thumb.style.height = `${next.size}px`;
-      thumb.style.transform = `translateY(${next.offset}px)`;
+      applyThumbStateToDom(next);
     };
 
     const updateThumb = (visible = false) => {
@@ -260,12 +275,12 @@ export const AutoHideScrollArea = forwardRef<HTMLDivElement, AutoHideScrollAreaP
 
         {!allowHorizontal && (
           <div
-            ref={thumbTrackRef}
+            ref={setThumbTrackNode}
             aria-hidden="true"
             className="pointer-events-none absolute right-[3px] top-[3px] bottom-[3px] w-1.5 opacity-0 transition-opacity duration-hover"
           >
             <div
-              ref={thumbRef}
+              ref={setThumbNode}
               className="pointer-events-auto absolute right-0 w-1.5 rounded-full bg-scrollbar-thumb transition-colors duration-hover hover:bg-scrollbar-thumb-active"
               style={{
                 height: 0,

--- a/apps/packages/product-client/src/primitives/patterns/AutoHideScrollArea.tsx
+++ b/apps/packages/product-client/src/primitives/patterns/AutoHideScrollArea.tsx
@@ -3,7 +3,6 @@ import {
   useEffect,
   useImperativeHandle,
   useRef,
-  useState,
   type CSSProperties,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
@@ -57,13 +56,21 @@ export const AutoHideScrollArea = forwardRef<HTMLDivElement, AutoHideScrollAreaP
   ) {
     const viewportRef = useRef<HTMLDivElement>(null);
     const contentRef = useRef<HTMLDivElement>(null);
+    const thumbTrackRef = useRef<HTMLDivElement>(null);
+    const thumbRef = useRef<HTMLDivElement>(null);
+    const onViewportScrollRef = useRef(onViewportScroll);
     const hideTimerRef = useRef<number | null>(null);
+    const thumbFrameRef = useRef<number | null>(null);
+    const pendingThumbVisibleRef = useRef(false);
     const dragOffsetRef = useRef(0);
     const draggingRef = useRef(false);
     const thumbStateRef = useRef<ScrollThumbState>(HIDDEN_THUMB_STATE);
-    const [thumb, setThumb] = useState<ScrollThumbState>(HIDDEN_THUMB_STATE);
 
     useImperativeHandle(ref, () => viewportRef.current as HTMLDivElement);
+
+    useEffect(() => {
+      onViewportScrollRef.current = onViewportScroll;
+    }, [onViewportScroll]);
 
     const clearHideTimer = () => {
       if (hideTimerRef.current != null) {
@@ -77,7 +84,15 @@ export const AutoHideScrollArea = forwardRef<HTMLDivElement, AutoHideScrollAreaP
         return;
       }
       thumbStateRef.current = next;
-      setThumb(next);
+      const track = thumbTrackRef.current;
+      const thumb = thumbRef.current;
+      if (!track || !thumb) {
+        return;
+      }
+      track.style.opacity = next.visible && next.size > 0 ? "1" : "0";
+      thumb.style.pointerEvents = next.visible && next.size > 0 ? "auto" : "none";
+      thumb.style.height = `${next.size}px`;
+      thumb.style.transform = `translateY(${next.offset}px)`;
     };
 
     const updateThumb = (visible = false) => {
@@ -106,6 +121,19 @@ export const AutoHideScrollArea = forwardRef<HTMLDivElement, AutoHideScrollAreaP
       });
     };
 
+    const requestThumbUpdate = (visible = false) => {
+      pendingThumbVisibleRef.current = pendingThumbVisibleRef.current || visible;
+      if (thumbFrameRef.current !== null) {
+        return;
+      }
+      thumbFrameRef.current = window.requestAnimationFrame(() => {
+        thumbFrameRef.current = null;
+        const nextVisible = pendingThumbVisibleRef.current;
+        pendingThumbVisibleRef.current = false;
+        updateThumb(nextVisible);
+      });
+    };
+
     const scheduleHide = () => {
       clearHideTimer();
       if (draggingRef.current) return;
@@ -121,39 +149,29 @@ export const AutoHideScrollArea = forwardRef<HTMLDivElement, AutoHideScrollAreaP
       const viewport = viewportRef.current;
       const content = contentRef.current;
       if (!viewport || !content) return;
-      let resizeFrame: number | null = null;
-
-      const requestResizeUpdate = () => {
-        if (resizeFrame !== null) {
-          return;
-        }
-        resizeFrame = window.requestAnimationFrame(() => {
-          resizeFrame = null;
-          updateThumb(false);
-        });
-      };
 
       const handleScroll = () => {
-        updateThumb(true);
-        onViewportScroll?.(viewport);
+        requestThumbUpdate(true);
+        onViewportScrollRef.current?.(viewport);
         scheduleHide();
       };
       viewport.addEventListener("scroll", handleScroll, { passive: true });
 
-      const observer = new ResizeObserver(requestResizeUpdate);
+      const observer = new ResizeObserver(() => requestThumbUpdate(false));
       observer.observe(viewport);
       observer.observe(content);
-      requestResizeUpdate();
+      requestThumbUpdate(false);
 
       return () => {
         clearHideTimer();
-        if (resizeFrame !== null) {
-          window.cancelAnimationFrame(resizeFrame);
+        if (thumbFrameRef.current !== null) {
+          window.cancelAnimationFrame(thumbFrameRef.current);
+          thumbFrameRef.current = null;
         }
         viewport.removeEventListener("scroll", handleScroll);
         observer.disconnect();
       };
-    }, [onViewportScroll]);
+    }, []);
 
     useEffect(() => {
       const handlePointerMove = (event: PointerEvent) => {
@@ -176,7 +194,7 @@ export const AutoHideScrollArea = forwardRef<HTMLDivElement, AutoHideScrollAreaP
         );
         viewport.scrollTop =
           (nextOffset / maxOffset) * Math.max(scrollHeight - clientHeight, 0);
-        updateThumb(true);
+        requestThumbUpdate(true);
       };
 
       const handlePointerUp = () => {
@@ -200,7 +218,7 @@ export const AutoHideScrollArea = forwardRef<HTMLDivElement, AutoHideScrollAreaP
       draggingRef.current = true;
       clearHideTimer();
 
-      const thumbTop = thumb.offset;
+      const thumbTop = thumbStateRef.current.offset;
       dragOffsetRef.current = event.clientY - viewport.getBoundingClientRect().top - thumbTop;
       const current = thumbStateRef.current;
       if (!current.visible) {
@@ -240,18 +258,19 @@ export const AutoHideScrollArea = forwardRef<HTMLDivElement, AutoHideScrollAreaP
           </div>
         </div>
 
-        {!allowHorizontal && thumb.size > 0 && (
+        {!allowHorizontal && (
           <div
+            ref={thumbTrackRef}
             aria-hidden="true"
-            className={`pointer-events-none absolute right-[3px] top-[3px] bottom-[3px] w-1.5 transition-opacity duration-hover ${
-              thumb.visible ? "opacity-100" : "opacity-0"
-            }`}
+            className="pointer-events-none absolute right-[3px] top-[3px] bottom-[3px] w-1.5 opacity-0 transition-opacity duration-hover"
           >
             <div
+              ref={thumbRef}
               className="pointer-events-auto absolute right-0 w-1.5 rounded-full bg-scrollbar-thumb transition-colors duration-hover hover:bg-scrollbar-thumb-active"
               style={{
-                height: `${thumb.size}px`,
-                transform: `translateY(${thumb.offset}px)`,
+                height: 0,
+                pointerEvents: "none",
+                transform: "translateY(0)",
               }}
               onPointerDown={handleThumbPointerDown}
             />

--- a/scripts/frontend_structure_allowlist.txt
+++ b/scripts/frontend_structure_allowlist.txt
@@ -18,7 +18,6 @@
 # max-lines entries.
 
 apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts 425 workspace bootstrap actions + gateway billing-block capture into the status screen (C8); split on next growth
-apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.tsx 416 virtualized transcript list pending row-window split (recorded in debt repair)
 apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.tsx 525 existing markdown transcript renderer pending split
 # Relocated from apps/desktop/src by the Desktop-product move into product-client
 # (web-desktop-unification slice 04). Same files, same counts/reasons — relocation,

--- a/scripts/max_lines_allowlist.txt
+++ b/scripts/max_lines_allowlist.txt
@@ -68,7 +68,7 @@ apps/packages/product-client/src/lib/domain/workspaces/cloud/logical-workspaces.
 apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar.test.ts 691 workspace git-status threading extends existing oversized test file
 apps/packages/product-client/src/lib/infra/measurement/measurement-port.ts 734 product-owned measurement port barrel (R1 ruling) mirroring the retained measurement surface through a swappable no-op sink; split deferred
 apps/packages/product-client/src/domain/chats/cloud/transcript-view.test.ts 1160 relocated existing oversized domain test; no growth
-apps/packages/product-client/src/domain/chats/transcript/transcript-row-model.test.ts 1155 relocated existing oversized domain test; no growth
+apps/packages/product-client/src/domain/chats/transcript/transcript-row-model.test.ts 1144 relocated existing oversized domain test; no growth
 apps/packages/product-client/src/domain/chats/transcript/transcript-row-model.ts 905 relocated existing oversized domain source; no growth
 apps/packages/product-client/src/domain/chats/transcript/transcript-presentation.test.ts 868 relocated existing oversized domain test; no growth
 apps/packages/product-client/src/domain/workspaces/cloud-work-inventory.test.ts 859 relocated existing oversized domain test; no growth

--- a/specs/developing/debugging/performance-profiling.md
+++ b/specs/developing/debugging/performance-profiling.md
@@ -146,9 +146,10 @@ localStorage.setItem("proliferate:transcriptVirtualization", "on")
 localStorage.setItem("proliferate:transcriptVirtualization", "off")
 ```
 
-`auto` is the default and virtualizes only larger transcripts. Use `on` to force
-the virtual path while profiling scroll behavior, and `off` to verify the full
-render path. The older `proliferate:enableTranscriptVirtualization` and
+`auto` is the default and uses one stable virtual path from the first row as a
+transcript grows. Use `on` to explicitly force that same path while profiling,
+and `off` to verify the full render path. The older
+`proliferate:enableTranscriptVirtualization` and
 `proliferate:disableTranscriptVirtualization` keys are still read only as
 fallbacks when the tri-state key is absent.
 


### PR DESCRIPTION
## What changed

- use the virtualized transcript renderer from the first row in normal auto mode, avoiding both the permanent full-DOM latch and threshold remounts
- isolate streaming updates with row-local render revisions and stable proposed-plan context values so historical rows do not repaint with the live tail
- preserve TanStack's measurement cache across native-scroll and content-only streaming renders, rotating accessors only when ordered row composition or session scope changes
- remove scroll-hot-path React state and repeated observer/listener setup from the custom scrollbar, including correct thumb state after horizontal-mode remounts
- avoid redundant bottom writes, repeated scroll-only anchor layout reads, and repeated full-transcript initial-height reductions
- require two consecutive DOM-confirmed blank frames before the virtualizer can fall back to a full render
- document that normal auto mode virtualizes from the first row

## Root cause

PRO-76 combined several independent costs. New chats latched the auto-virtualization decision while still below the threshold, so they remained full-DOM as they grew. When virtualization was active, the renderer captured the whole transcript and a new proposed-plan Set on every stream batch, invalidating every mounted row. The virtualizer's inline key accessor also changed identity on scroll and stream renders, forcing its measurement model to walk the full transcript. Native scrolling additionally performed synchronous geometry reads, React thumb commits, and effect teardown/recreation, while one transient blank frame could permanently remount the full list and snap it.

## Impact

Long and actively streaming transcripts keep a stable virtualized viewport and measurement cache. Scrolling away from the live tail no longer competes with redundant bottom snaps, and historical rows remain memoized while only affected rows update.

Linear: [PRO-76](https://linear.app/proliferate-team/issue/PRO-76/scrolling-oddities-latency-broadly)

## Validation

- 81 focused transcript, virtualization, stickiness, scrollbar, and row-rendering tests
- `tsc -p tsconfig.domain.json --noEmit`
- `tsc -p tsconfig.json --noEmit`
- max-lines, frontend-structure, design-attribution, docs-integrity, and diff checks
- rendered `main`-profile check confirmed one-row auto mode uses the virtual renderer, has no fallback, remains top-aligned at 16 px, and has no scroll overflow
- independent React, scroll/virtualization, and final exact-head review rounds are clean
