### PR TITLE
fix(product): keep file references actionable

### DIFF
--- a/apps/packages/product-client/src/components/content/ui/FilePathLink.tsx
+++ b/apps/packages/product-client/src/components/content/ui/FilePathLink.tsx
@@ -15,8 +15,11 @@ interface FilePathLinkProps {
  * Inline file-path link rendered in chat markdown and tool-call output.
  *
  * Behavior:
- *  - Click -> open the file in the workspace right-sidebar viewer.
- *  - Context menu -> external open targets, copy path, reveal in Finder.
+ *  - Click -> open workspace files in the right-sidebar viewer and external
+ *    Desktop files in the configured external target.
+ *  - Actionable references expose external targets, copy, and reveal through
+ *    the context menu.
+ *  - An unavailable path is plain text with no file-reference controls.
  *
  * Style: local file/doc link in `text-link-foreground`, no pill,
  * no border, underline on hover only.

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRowPrimitives.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRowPrimitives.tsx
@@ -74,17 +74,19 @@ export function ActionFileLink({
   displayName,
 }: {
   pathLabel: string;
-  /** null = authoritatively external; undefined = infer from workspace root. */
+  /** A known workspace-relative path, or absent to infer from pathLabel. */
   workspacePath: string | null | undefined;
   displayName: string;
 }) {
   return (
+    // Keep FileReferenceBadge's semantic link color: the surrounding activity
+    // row is intentionally muted, but this child is an actionable file target.
     <FileReferenceBadge
       rawPath={pathLabel}
       label={displayName}
       workspacePath={workspacePath}
       variant="inline"
-      className={`min-w-0 truncate !px-0 ${CHAT_BUTTON_TEXT_CLASS} !font-normal !text-inherit underline decoration-current decoration-dotted decoration-[0.5px] underline-offset-2 hover:!text-inherit hover:decoration-dotted [&>span:first-child]:hidden`}
+      className={`min-w-0 truncate !px-0 ${CHAT_BUTTON_TEXT_CLASS} !font-normal underline decoration-current decoration-dotted decoration-[0.5px] underline-offset-2 hover:decoration-dotted [&>span:first-child]:hidden`}
     />
   );
 }

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRows.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRows.test.tsx
@@ -27,9 +27,14 @@ function render(ui: ReactElement) {
   return testingRender(ui, { wrapper: WebProductHostWrapper });
 }
 
-const { openPrimaryMock, fileReferenceActionsCalls } = vi.hoisted(() => ({
+const {
+  openPrimaryMock,
+  fileReferenceActionsCalls,
+  fileReferenceActionState,
+} = vi.hoisted(() => ({
   openPrimaryMock: vi.fn(),
   fileReferenceActionsCalls: [] as Array<{ rawPath: string; workspacePath?: string | null }>,
+  fileReferenceActionState: { canOpenPrimary: true },
 }));
 
 vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", () => ({
@@ -50,7 +55,7 @@ vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", 
       pathKindPending: false,
       canOpenInSidebar: true,
       canOpenExternal: true,
-      canOpenPrimary: true,
+      canOpenPrimary: fileReferenceActionState.canOpenPrimary,
       canReveal: true,
       primaryUnavailableReason: null,
       copyPath: vi.fn(),
@@ -67,11 +72,12 @@ afterEach(() => {
   cleanup();
   openPrimaryMock.mockClear();
   fileReferenceActionsCalls.length = 0;
+  fileReferenceActionState.canOpenPrimary = true;
 });
 
 describe("CollapsedActionRows read rows", () => {
 
-  it("renders read ledger rows as clickable file references", () => {
+  it("renders read ledger rows as blue, clickable file references", () => {
     const transcript = createTranscriptState("session-1");
     transcript.itemsById = {
       read: toolItem("read", "turn-1", 1, "file_read"),
@@ -89,6 +95,12 @@ describe("CollapsedActionRows read rows", () => {
       ?.querySelector("[data-file-reference-badge='inline']");
     const readRow = badge?.closest("[title]");
     expect(badge?.textContent).toContain("read.ts");
+    expect(badge?.tagName).toBe("BUTTON");
+    expect(badge?.getAttribute("aria-disabled")).toBeNull();
+    expect(badge?.className).toContain("text-link-foreground");
+    expect(badge?.className).toContain("hover:text-link-foreground");
+    expect(badge?.className).not.toContain("!text-inherit");
+    expect(badge?.className).not.toContain("hover:!text-inherit");
     expect(badge?.className).toContain("decoration-dotted");
     expect(badge?.className).toContain("[&>span:first-child]:hidden");
     expect(readRow?.getAttribute("title")).toContain("read.ts");
@@ -97,6 +109,30 @@ describe("CollapsedActionRows read rows", () => {
     expect(openPrimaryMock).toHaveBeenCalledTimes(1);
     expect(fileReferenceActionsCalls.find((call) => call.rawPath === "read.ts")?.workspacePath)
       .toBe("read.ts");
+  });
+
+  it("renders a read target with no primary action as plain text", () => {
+    fileReferenceActionState.canOpenPrimary = false;
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = {
+      read: toolItem("read", "turn-1", 1, "file_read"),
+    };
+
+    render(
+      <CollapsedActions
+        itemIds={["read"]}
+        transcript={transcript}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Read files/i }));
+
+    const reference = screen.getByText("read.ts")
+      .closest("[data-file-reference-badge='inline']");
+    expect(reference?.tagName).toBe("SPAN");
+    expect(reference?.getAttribute("aria-disabled")).toBeNull();
+    expect(reference?.className).not.toContain("text-link-foreground");
+    expect(reference?.className).not.toContain("cursor-not-allowed");
+    expect(reference?.className).toContain("!no-underline");
   });
 
   it("opens raw-input fallback reads through workspace-root inference", () => {
@@ -151,7 +187,35 @@ describe("CollapsedActionRows read rows", () => {
     expect(openPrimaryMock).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps structured reads without a workspace path authoritatively external", () => {
+  it("infers a relative structured read when nullable workspace metadata is missing", () => {
+    const transcript = createTranscriptState("session-1");
+    const read = toolItem("read", "turn-1", 1, "file_read");
+    const part = read.contentParts[0];
+    if (part?.type === "file_read") {
+      part.path = "src/legacy/read.ts";
+      part.basename = "read.ts";
+      part.workspacePath = null;
+    }
+    transcript.itemsById = { read };
+
+    render(
+      <CollapsedActions
+        itemIds={["read"]}
+        transcript={transcript}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Read/i }));
+
+    const call = fileReferenceActionsCalls.find(
+      (entry) => entry.rawPath === "src/legacy/read.ts",
+    );
+    expect(call?.workspacePath).toBeUndefined();
+
+    fireEvent.click(screen.getByText("read.ts"));
+    expect(openPrimaryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("infers classification for structured reads without workspace metadata", () => {
     const transcript = createTranscriptState("session-1");
     const read = toolItem("read", "turn-1", 1, "file_read");
     const part = read.contentParts[0];
@@ -172,6 +236,6 @@ describe("CollapsedActionRows read rows", () => {
 
     const call = fileReferenceActionsCalls.find((entry) => entry.rawPath === "/etc/hosts");
     expect(call).toBeTruthy();
-    expect(call?.workspacePath).toBeNull();
+    expect(call?.workspacePath).toBeUndefined();
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRows.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRows.tsx
@@ -75,15 +75,14 @@ function ReadRows({ item }: { item: ToolCallItem }) {
   const fileReads = item.contentParts.filter(
     (part): part is FileReadContentPart => part.type === "file_read",
   );
-  // Structured parts are server-normalized: a missing workspacePath there is
-  // an authoritative "outside the workspace" ruling (null = external-only).
-  // Raw-input fallbacks carry no such ruling, so leave workspacePath undefined
-  // and let the file-reference resolver infer it from the workspace root.
+  // The SDK collapses an omitted workspacePath and an explicit null to the same
+  // value. Preserve a non-empty normalized path, but otherwise let the shared
+  // resolver classify the raw path against the current workspace root.
   const targets = fileReads.length > 0
     ? fileReads.map((part) => ({
-      rawPath: part.workspacePath ?? part.path,
-      workspacePath: part.workspacePath ?? null,
-      displayName: part.basename || basename(part.workspacePath ?? part.path),
+      rawPath: part.workspacePath || part.path,
+      workspacePath: part.workspacePath || undefined,
+      displayName: part.basename || basename(part.workspacePath || part.path),
     }))
     : [{ ...deriveReadPathTarget(item), workspacePath: undefined }];
 
@@ -124,7 +123,7 @@ function FileActionRow({
   icon: ReactNode;
   verb: string;
   pathLabel: string;
-  /** null = authoritatively external; undefined = infer from workspace root. */
+  /** A known workspace-relative path, or absent to infer from pathLabel. */
   workspacePath: string | null | undefined;
   displayName: string;
   failed: boolean;

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileChangeCall.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileChangeCall.test.tsx
@@ -1,6 +1,6 @@
 import { createElement, type ReactElement } from "react";
 import { renderToStaticMarkup as renderReactToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
 import { FileChangeCall } from "#product/components/workspace/chat/tool-calls/FileChangeCall";
 import { makeTestProductHost } from "#product/test/product-host-fixtures";
@@ -9,6 +9,11 @@ import { makeTestProductHost } from "#product/test/product-host-fixtures";
 // useProductHost().clipboard for its copy control, so a bare { desktop: null }
 // cast (no clipboard) crashes; makeTestProductHost supplies every capability.
 const webTestHost = makeTestProductHost({ desktop: null });
+const fileReferenceActionState = vi.hoisted(() => ({
+  canOpenInSidebar: true,
+  canOpenExternal: true,
+  canOpenPrimary: true,
+}));
 
 function renderToStaticMarkup(ui: ReactElement) {
   return renderReactToStaticMarkup(
@@ -27,8 +32,9 @@ vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", 
       workspacePath: rawPath,
     },
     openTargets: [],
-    canOpenInSidebar: true,
-    canOpenExternal: true,
+    canOpenInSidebar: fileReferenceActionState.canOpenInSidebar,
+    canOpenExternal: fileReferenceActionState.canOpenExternal,
+    canOpenPrimary: fileReferenceActionState.canOpenPrimary,
     copyPath: vi.fn(),
     openInSidebar: vi.fn(),
     openDefault: vi.fn(),
@@ -37,6 +43,12 @@ vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", 
     reveal: vi.fn(),
   }),
 }));
+
+afterEach(() => {
+  fileReferenceActionState.canOpenInSidebar = true;
+  fileReferenceActionState.canOpenExternal = true;
+  fileReferenceActionState.canOpenPrimary = true;
+});
 
 describe("FileChangeCall", () => {
   it("renders expanded edit diffs as file cards without an aggregate files-changed header", () => {
@@ -106,5 +118,25 @@ describe("FileChangeCall", () => {
 
     expect(html).toContain("Too large to render inline");
     expect(html).not.toContain("overflow-x-auto overflow-y-auto");
+  });
+
+  it("keeps a retryable unresolved file path clickable", () => {
+    fileReferenceActionState.canOpenInSidebar = false;
+    fileReferenceActionState.canOpenExternal = false;
+    fileReferenceActionState.canOpenPrimary = true;
+
+    const html = renderToStaticMarkup(
+      createElement(FileChangeCall, {
+        operation: "edit",
+        path: "README.md",
+        basename: "README.md",
+        additions: 1,
+        deletions: 1,
+        patch: "@@ -1 +1 @@\n-old\n+new",
+        status: "completed",
+      }),
+    );
+
+    expect(html).toContain("select-text [direction:rtl]");
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileChangeCall.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileChangeCall.tsx
@@ -106,7 +106,7 @@ export function FileChangeCall({
             collapsible={false}
             headerTone="inlineTool"
             showOpenAction={false}
-            onOpenFile={fileReferenceActions.canOpenInSidebar || fileReferenceActions.canOpenExternal
+            onOpenFile={fileReferenceActions.canOpenPrimary
               ? handleOpenFile
               : undefined}
           >

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileReadCall.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileReadCall.tsx
@@ -8,7 +8,7 @@ import type { FileReadScope } from "@anyharness/sdk";
 
 interface FileReadCallProps {
   path: string;
-  /** null = authoritatively external; undefined = infer from workspace root. */
+  /** A known workspace-relative path, or absent to infer from path. */
   workspacePath?: string | null;
   basename?: string | null;
   line?: number | null;
@@ -59,7 +59,7 @@ export function FileReadCall({
       </span>
       <ToolFileChip
         basename={resolvedBasename}
-        pathLabel={workspacePath ?? path}
+        pathLabel={workspacePath || path}
         workspacePath={workspacePath}
       />
       {scopeLabel && <span className="truncate text-ui-sm text-faint">{scopeLabel}</span>}

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolFileChip.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolFileChip.tsx
@@ -4,8 +4,8 @@ interface ToolFileChipProps {
   basename: string;
   pathLabel: string;
   /**
-   * Workspace-relative path. null = authoritatively external (external-only
-   * actions); undefined = unknown, infer from the workspace root.
+   * Known workspace-relative path. Missing nullable metadata is inferred from
+   * pathLabel by the shared file-reference resolver.
    */
   workspacePath: string | null | undefined;
 }
@@ -14,8 +14,11 @@ interface ToolFileChipProps {
  * File chip used in tool-call headers (`Read`, `Edited`, etc.).
  *
  * Behavior matches `FilePathLink`:
- *  - Click -> open in the workspace right-sidebar viewer when possible.
- *  - Right-click -> external open targets, copy path, reveal in Finder.
+ *  - Click -> open in the workspace viewer, or use the configured Desktop
+ *    target for an external file.
+ *  - Actionable references expose external targets, copy, and reveal through
+ *    the context menu.
+ *  - An unavailable path is non-interactive text.
  *
  * Visual is intentionally a chip (border + background + file icon) so tool
  * results stay scannable; markdown prose uses the flat `FilePathLink` instead.

--- a/apps/packages/product-client/src/components/workspace/file-references/FileReferenceBadge.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/file-references/FileReferenceBadge.test.tsx
@@ -18,6 +18,8 @@ type MockActionsState = {
   pathKindPending: boolean;
   workspacePath: string | null;
   absolutePath: string | null;
+  canOpenPrimary: boolean;
+  primaryUnavailableReason: string | null;
 };
 
 const state: MockActionsState = {
@@ -25,6 +27,8 @@ const state: MockActionsState = {
   pathKindPending: false,
   workspacePath: "src/App.tsx",
   absolutePath: "/repo/src/App.tsx",
+  canOpenPrimary: true,
+  primaryUnavailableReason: null,
 };
 
 vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", () => ({
@@ -39,8 +43,8 @@ vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", 
     },
     pathKind: state.pathKind,
     pathKindPending: state.pathKindPending,
-    canOpenPrimary: true,
-    primaryUnavailableReason: null,
+    canOpenPrimary: state.canOpenPrimary,
+    primaryUnavailableReason: state.primaryUnavailableReason,
     openPrimary: vi.fn(),
   }),
 }));
@@ -73,6 +77,8 @@ afterEach(() => {
   state.pathKindPending = false;
   state.workspacePath = "src/App.tsx";
   state.absolutePath = "/repo/src/App.tsx";
+  state.canOpenPrimary = true;
+  state.primaryUnavailableReason = null;
 });
 
 describe("FileReferenceBadge glyph selection", () => {
@@ -137,5 +143,38 @@ describe("FileReferenceBadge glyph selection", () => {
     state.absolutePath = "/Users/pablo/tmp/scratch-file";
     const { container } = renderBadge("/Users/pablo/tmp/scratch-file", "logo.svg");
     expect(usesExternalMentionGlyph(container)).toBe(false);
+  });
+});
+
+describe("FileReferenceBadge interaction semantics", () => {
+  it("renders an actionable inline reference as a blue button", () => {
+    const { container } = renderBadge("src/App.tsx");
+    const reference = container.querySelector("[data-file-reference-badge='inline']");
+
+    expect(reference?.tagName).toBe("BUTTON");
+    expect(reference?.getAttribute("aria-disabled")).toBeNull();
+    expect(reference?.className).toContain("text-link-foreground");
+    expect(reference?.className).not.toContain("cursor-not-allowed");
+  });
+
+  it("keeps a retry reason on an actionable reference", () => {
+    state.primaryUnavailableReason = "Could not resolve this path. Click to retry.";
+    const { container } = renderBadge("src/App.tsx");
+    const reference = container.querySelector("[data-file-reference-badge='inline']");
+
+    expect(reference?.getAttribute("title"))
+      .toBe("Could not resolve this path. Click to retry.");
+  });
+
+  it("renders an unavailable reference as plain text instead of a disabled link", () => {
+    state.canOpenPrimary = false;
+    const { container } = renderBadge("/tmp/unavailable.txt");
+    const reference = container.querySelector("[data-file-reference-badge='inline']");
+
+    expect(reference?.tagName).toBe("SPAN");
+    expect(reference?.getAttribute("aria-disabled")).toBeNull();
+    expect(reference?.className).not.toContain("text-link-foreground");
+    expect(reference?.className).not.toContain("cursor-not-allowed");
+    expect(reference?.className).toContain("cursor-default");
   });
 });

--- a/apps/packages/product-client/src/components/workspace/file-references/FileReferenceBadge.tsx
+++ b/apps/packages/product-client/src/components/workspace/file-references/FileReferenceBadge.tsx
@@ -78,21 +78,8 @@ export function FileReferenceBadge({
     void actions.openPrimary();
   }, [actions, stopPropagation]);
 
-  const trigger = (
-    <Button
-      type="button"
-      variant="ghost"
-      size="unstyled"
-      data-chat-transcript-ignore
-      data-file-reference-badge={variant}
-      data-path-kind={actions.pathKind ?? "unknown"}
-      aria-busy={actions.pathKindPending || undefined}
-      aria-disabled={!actions.canOpenPrimary}
-      title={actions.primaryUnavailableReason ?? rawPath}
-      onClick={handleClick}
-      onContextMenuCapture={onContextMenuCapture}
-      className={`${resolveBadgeClassName(variant, className)} ${!actions.canOpenPrimary ? "cursor-not-allowed opacity-60 hover:no-underline" : ""}`}
-    >
+  const contents = (
+    <>
       <span className={iconShellClassName}>
         {useExternalInlineIcon ? (
           <span
@@ -120,6 +107,39 @@ export function FileReferenceBadge({
       >
         {displayLabel}
       </span>
+    </>
+  );
+  if (!actions.canOpenPrimary) {
+    return (
+      <span
+        data-chat-transcript-ignore
+        data-file-reference-badge={variant}
+        data-file-reference-unavailable="true"
+        data-path-kind={actions.pathKind ?? "unknown"}
+        aria-busy={actions.pathKindPending || undefined}
+        title={actions.primaryUnavailableReason ?? rawPath}
+        className={resolveUnavailableBadgeClassName(variant, className)}
+      >
+        {contents}
+      </span>
+    );
+  }
+
+  const trigger = (
+    <Button
+      type="button"
+      variant="ghost"
+      size="unstyled"
+      data-chat-transcript-ignore
+      data-file-reference-badge={variant}
+      data-path-kind={actions.pathKind ?? "unknown"}
+      aria-busy={actions.pathKindPending || undefined}
+      title={actions.primaryUnavailableReason ?? rawPath}
+      onClick={handleClick}
+      onContextMenuCapture={onContextMenuCapture}
+      className={resolveBadgeClassName(variant, className)}
+    >
+      {contents}
     </Button>
   );
 
@@ -127,7 +147,7 @@ export function FileReferenceBadge({
     <PopoverButton
       trigger={trigger}
       triggerMode="contextMenu"
-      stopPropagation
+      stopPropagation={stopPropagation}
       className={FILE_REFERENCE_MENU_CLASS}
     >
       {(close) => (
@@ -135,6 +155,24 @@ export function FileReferenceBadge({
       )}
     </PopoverButton>
   );
+}
+
+function resolveUnavailableBadgeClassName(
+  variant: FileReferenceBadgeVariant,
+  className: string,
+): string {
+  if (variant === "chip") {
+    return [
+      "inline-flex h-auto min-w-0 max-w-full cursor-default items-center gap-px rounded-sm border border-border/60 bg-muted/45 px-1 py-px font-mono text-ui leading-none text-foreground/70 shadow-none",
+      className,
+    ].filter(Boolean).join(" ");
+  }
+
+  return [
+    "group/inline-mention m-0 inline-flex cursor-default appearance-none whitespace-normal break-words border-0 bg-transparent px-0.5 py-0 text-left align-baseline font-[inherit] font-medium text-inherit shadow-none",
+    className,
+    "!no-underline",
+  ].filter(Boolean).join(" ");
 }
 
 function resolveBadgeClassName(
@@ -153,4 +191,3 @@ function resolveBadgeClassName(
     className,
   ].filter(Boolean).join(" ");
 }
-

--- a/apps/packages/product-client/src/hooks/editor/workflows/use-open-in-default-editor.test.tsx
+++ b/apps/packages/product-client/src/hooks/editor/workflows/use-open-in-default-editor.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenTarget } from "@proliferate/product-client/host/desktop-bridge";
+import { useOpenInDefaultEditor } from "#product/hooks/editor/workflows/use-open-in-default-editor";
+
+const mocks = vi.hoisted(() => ({
+  files: null as null | {
+    listOpenTargets: ReturnType<typeof vi.fn>;
+    openTarget: ReturnType<typeof vi.fn>;
+  },
+  preferredTargetId: "",
+}));
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => ({
+    clipboard: { writeText: vi.fn(async () => undefined) },
+    desktop: mocks.files ? { files: mocks.files } : null,
+  }),
+}));
+
+vi.mock("#product/stores/preferences/user-preferences-store", () => ({
+  useUserPreferencesStore: (
+    selector: (state: { defaultOpenInTargetId: string }) => unknown,
+  ) => selector({ defaultOpenInTargetId: mocks.preferredTargetId }),
+}));
+
+afterEach(() => {
+  mocks.files = null;
+  mocks.preferredTargetId = "";
+  vi.clearAllMocks();
+});
+
+describe("useOpenInDefaultEditor", () => {
+  it("retries target discovery after a transient bridge failure", async () => {
+    const target: OpenTarget = {
+      id: "cursor",
+      label: "Cursor",
+      kind: "editor",
+      iconId: "cursor",
+    };
+    let rejectInitialRequest: (reason?: unknown) => void = () => undefined;
+    const initialRequest = new Promise<OpenTarget[]>((_, reject) => {
+      rejectInitialRequest = reject;
+    });
+    const listOpenTargets = vi.fn()
+      .mockImplementationOnce(() => initialRequest)
+      .mockResolvedValueOnce([target]);
+    const openTarget = vi.fn(async () => undefined);
+    mocks.files = { listOpenTargets, openTarget };
+
+    const { result } = renderHook(() => useOpenInDefaultEditor("file"));
+
+    await waitFor(() => {
+      expect(listOpenTargets).toHaveBeenCalledTimes(1);
+    });
+    await act(async () => {
+      rejectInitialRequest(new Error("Desktop bridge temporarily unavailable"));
+      await initialRequest.catch(() => undefined);
+    });
+
+    let opened = false;
+    await act(async () => {
+      opened = await result.current.openInDefaultEditor("/tmp/outside.txt:12:3");
+    });
+
+    expect(opened).toBe(true);
+    expect(listOpenTargets).toHaveBeenCalledTimes(2);
+    expect(openTarget).toHaveBeenCalledWith("cursor", "/tmp/outside.txt");
+    expect(result.current.ready).toBe(true);
+  });
+});

--- a/apps/packages/product-client/src/hooks/editor/workflows/use-open-in-default-editor.ts
+++ b/apps/packages/product-client/src/hooks/editor/workflows/use-open-in-default-editor.ts
@@ -27,8 +27,13 @@ function loadTargets(files: DesktopFilesBridge, pathKind: PathKind): Promise<Ope
   }
   let targetsPromise = targetsByKind.get(pathKind);
   if (!targetsPromise) {
-    targetsPromise = files.listOpenTargets(pathKind).catch(() => [] as OpenTarget[]);
+    targetsPromise = files.listOpenTargets(pathKind);
     targetsByKind.set(pathKind, targetsPromise);
+    void targetsPromise.catch(() => {
+      if (targetsByKind.get(pathKind) === targetsPromise) {
+        targetsByKind.delete(pathKind);
+      }
+    });
   }
   return targetsPromise;
 }
@@ -82,9 +87,17 @@ export function useOpenInDefaultEditor(pathKind: PathKind = "file"): UseOpenInDe
       return;
     }
     setTargets(null);
-    void loadTargets(files, pathKind).then((loaded) => {
-      if (!cancelled) setTargets(loaded);
-    });
+    void loadTargets(files, pathKind).then(
+      (loaded) => {
+        if (!cancelled) setTargets(loaded);
+      },
+      () => {
+        // Keep the unresolved state so an explicit open action retries target
+        // discovery instead of treating a transient bridge failure as an
+        // authoritative empty target list.
+        if (!cancelled) setTargets(null);
+      },
+    );
     return () => {
       cancelled = true;
     };
@@ -95,7 +108,15 @@ export function useOpenInDefaultEditor(pathKind: PathKind = "file"): UseOpenInDe
       if (!files) {
         throw new Error("Local file access is not available.");
       }
-      const list = targets ?? (await loadTargets(files, pathKind));
+      let list = targets;
+      if (list === null) {
+        try {
+          list = await loadTargets(files, pathKind);
+          setTargets(list);
+        } catch {
+          return false;
+        }
+      }
       const preferred = resolvePreferredOpenTarget(openableTargets(list), { defaultOpenInTargetId });
       if (!preferred) return false;
       const { path } = splitPathLineSuffix(absolutePath);

--- a/apps/packages/product-client/src/hooks/editor/workflows/use-open-in-default-editor.ts
+++ b/apps/packages/product-client/src/hooks/editor/workflows/use-open-in-default-editor.ts
@@ -34,8 +34,8 @@ function loadTargets(files: DesktopFilesBridge, pathKind: PathKind): Promise<Ope
 }
 
 interface UseOpenInDefaultEditorResult {
-  /** Open a path in the user's preferred external editor. */
-  openInDefaultEditor: (absolutePath: string) => Promise<void>;
+  /** Open a path in the preferred external target and report whether it launched. */
+  openInDefaultEditor: (absolutePath: string) => Promise<boolean>;
   /** Open a path in a specific shell target. */
   openTarget: (targetId: string, absolutePath: string) => Promise<void>;
   /** Reveal a path in Finder. */
@@ -97,9 +97,14 @@ export function useOpenInDefaultEditor(pathKind: PathKind = "file"): UseOpenInDe
       }
       const list = targets ?? (await loadTargets(files, pathKind));
       const preferred = resolvePreferredOpenTarget(openableTargets(list), { defaultOpenInTargetId });
-      if (!preferred) return;
+      if (!preferred) return false;
       const { path } = splitPathLineSuffix(absolutePath);
-      await files.openTarget(preferred.id, path).catch(() => {});
+      try {
+        await files.openTarget(preferred.id, path);
+        return true;
+      } catch {
+        return false;
+      }
     },
     [files, pathKind, targets, defaultOpenInTargetId],
   );

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.test.tsx
@@ -7,7 +7,7 @@ import { WorkspacePathProvider } from "#product/providers/WorkspacePathProvider"
 import { useFileReferenceActions } from "#product/hooks/workspaces/workflows/files/use-file-reference-actions";
 
 const editorMocks = vi.hoisted(() => ({
-  openInDefaultEditor: vi.fn(async () => undefined),
+  openInDefaultEditor: vi.fn(async () => true),
 }));
 
 const statMocks = vi.hoisted(() => ({
@@ -126,6 +126,7 @@ vi.mock("#product/hooks/workspaces/workflows/files/use-fuzzy-file-resolver", () 
 afterEach(() => {
   hostMocks.desktopAvailable = true;
   hostMocks.isDirectory.mockResolvedValue(false);
+  editorMocks.openInDefaultEditor.mockResolvedValue(true);
   statMocks.kind = "file";
   statMocks.sizeBytes = undefined;
   statMocks.isFetching = false;
@@ -158,6 +159,23 @@ describe("useFileReferenceActions", () => {
     expect(hostMocks.reveal).not.toHaveBeenCalled();
     expect(hostMocks.isDirectory).not.toHaveBeenCalled();
     expect(editorMocks.openInDefaultEditor).not.toHaveBeenCalled();
+  });
+
+  it("infers a workspace file when nullable path metadata is missing", async () => {
+    const { result } = renderHook(
+      () => useFileReferenceActions({
+        rawPath: "src/App.tsx",
+        workspacePath: null,
+      }),
+      { wrapper: workspaceWrapper("/repo") },
+    );
+
+    expect(result.current.reference.workspacePath).toBe("src/App.tsx");
+    await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
+    expect(viewerMocks.openTarget).toHaveBeenCalledWith({
+      kind: "file",
+      path: "src/App.tsx",
+    });
   });
 
   it("reveals a workspace directory in Finder instead of opening it as a file", async () => {
@@ -250,7 +268,7 @@ describe("useFileReferenceActions", () => {
     });
   });
 
-  it("disables primary opening after exact stat and unique correction both fail", async () => {
+  it("keeps primary opening retryable after exact stat and correction both fail", async () => {
     statMocks.kind = null;
     statMocks.error = new Error("not found");
     statMocks.refetch.mockResolvedValue({ data: undefined });
@@ -264,8 +282,11 @@ describe("useFileReferenceActions", () => {
       await expect(result.current.openPrimary()).resolves.toBe("unavailable");
     });
 
-    await waitFor(() => expect(result.current.canOpenPrimary).toBe(false));
-    expect(result.current.primaryUnavailableReason).toBe("This path is unavailable.");
+    await waitFor(() => {
+      expect(result.current.primaryUnavailableReason)
+        .toBe("Could not resolve this path. Click to retry.");
+    });
+    expect(result.current.canOpenPrimary).toBe(true);
     expect(viewerMocks.openTarget).not.toHaveBeenCalled();
   });
 
@@ -287,7 +308,7 @@ describe("useFileReferenceActions", () => {
     expect(viewerMocks.openTarget).toHaveBeenCalledTimes(opensViewer ? 1 : 0);
   });
 
-  it("fails closed for an external file that cannot be represented in the viewer", async () => {
+  it("opens an external file with the configured Desktop target", async () => {
     statMocks.kind = null;
     const { result } = renderHook(
       () => useFileReferenceActions({ rawPath: "/tmp/outside.txt" }),
@@ -295,8 +316,67 @@ describe("useFileReferenceActions", () => {
     );
 
     await waitFor(() => expect(result.current.pathKind).toBe("file"));
+    expect(result.current.canOpenPrimary).toBe(true);
+    await expect(result.current.openPrimary()).resolves.toBe("open-external");
+    expect(editorMocks.openInDefaultEditor).toHaveBeenCalledWith("/tmp/outside.txt");
+    expect(hostMocks.reveal).not.toHaveBeenCalled();
+    expect(viewerMocks.openTarget).not.toHaveBeenCalled();
+  });
+
+  it("keeps an external file retryable when its Desktop target fails", async () => {
+    statMocks.kind = null;
+    editorMocks.openInDefaultEditor.mockResolvedValue(false);
+    const { result } = renderHook(
+      () => useFileReferenceActions({ rawPath: "/tmp/outside.txt" }),
+      { wrapper: workspaceWrapper("/repo") },
+    );
+
+    await waitFor(() => expect(result.current.pathKind).toBe("file"));
+    await act(async () => {
+      await expect(result.current.openPrimary()).resolves.toBe("unavailable");
+    });
+
+    await waitFor(() => {
+      expect(result.current.primaryUnavailableReason)
+        .toBe("Could not open this path. Click to retry.");
+    });
+    expect(result.current.canOpenPrimary).toBe(true);
+  });
+
+  it("keeps external path resolution retryable when the Desktop bridge rejects", async () => {
+    statMocks.kind = null;
+    hostMocks.isDirectory.mockRejectedValue(new Error("bridge unavailable"));
+    const { result } = renderHook(
+      () => useFileReferenceActions({ rawPath: "/tmp/outside.txt" }),
+      { wrapper: workspaceWrapper("/repo") },
+    );
+
+    await waitFor(() => {
+      expect(hostMocks.isDirectory).toHaveBeenCalled();
+      expect(result.current.pathKindPending).toBe(false);
+    });
+    await act(async () => {
+      await expect(result.current.openPrimary()).resolves.toBe("unavailable");
+    });
+
+    await waitFor(() => {
+      expect(result.current.primaryUnavailableReason)
+        .toBe("Could not resolve this path. Click to retry.");
+    });
+    expect(result.current.canOpenPrimary).toBe(true);
+  });
+
+  it("keeps an external file unavailable on Web", async () => {
+    hostMocks.desktopAvailable = false;
+    statMocks.kind = null;
+    const { result } = renderHook(
+      () => useFileReferenceActions({ rawPath: "/tmp/outside.txt" }),
+      { wrapper: workspaceWrapper("/repo") },
+    );
+
     expect(result.current.canOpenPrimary).toBe(false);
     await expect(result.current.openPrimary()).resolves.toBe("unavailable");
+    expect(editorMocks.openInDefaultEditor).not.toHaveBeenCalled();
     expect(hostMocks.reveal).not.toHaveBeenCalled();
     expect(viewerMocks.openTarget).not.toHaveBeenCalled();
   });

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.test.tsx
@@ -325,7 +325,9 @@ describe("useFileReferenceActions", () => {
 
   it("keeps an external file retryable when its Desktop target fails", async () => {
     statMocks.kind = null;
-    editorMocks.openInDefaultEditor.mockResolvedValue(false);
+    editorMocks.openInDefaultEditor
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
     const { result } = renderHook(
       () => useFileReferenceActions({ rawPath: "/tmp/outside.txt" }),
       { wrapper: workspaceWrapper("/repo") },
@@ -341,6 +343,14 @@ describe("useFileReferenceActions", () => {
         .toBe("Could not open this path. Click to retry.");
     });
     expect(result.current.canOpenPrimary).toBe(true);
+
+    await act(async () => {
+      await expect(result.current.openPrimary()).resolves.toBe("open-external");
+    });
+    await waitFor(() => {
+      expect(result.current.primaryUnavailableReason).toBeNull();
+    });
+    expect(editorMocks.openInDefaultEditor).toHaveBeenCalledTimes(2);
   });
 
   it("keeps external path resolution retryable when the Desktop bridge rejects", async () => {

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.ts
@@ -65,13 +65,15 @@ export function useFileReferenceActions({
   });
   const [externalPathKind, setExternalPathKind] = useState<FileReferencePathKind | null>(null);
   const [externalPathKindPending, setExternalPathKindPending] = useState(false);
-  const [workspaceResolutionFailed, setWorkspaceResolutionFailed] = useState(false);
+  const [pathResolutionFailed, setPathResolutionFailed] = useState(false);
+  const [primaryOpenFailed, setPrimaryOpenFailed] = useState(false);
   const workspacePathKind = resolveWorkspaceStatPathKind(statQuery.data);
   const pathKind = reference.workspacePath ? workspacePathKind : externalPathKind;
 
   useEffect(() => {
-    setWorkspaceResolutionFailed(false);
-  }, [materializedWorkspaceId, reference.workspacePath]);
+    setPathResolutionFailed(false);
+    setPrimaryOpenFailed(false);
+  }, [materializedWorkspaceId, reference.absolutePath, reference.workspacePath]);
 
   useEffect(() => {
     let cancelled = false;
@@ -114,6 +116,7 @@ export function useFileReferenceActions({
   const resolvedPrimaryAction = resolveFileReferencePrimaryAction({
     pathKind,
     canOpenViewer: canOpenInSidebar,
+    canOpenExternal,
     canReveal,
   });
   const canResolvePathKind = Boolean(
@@ -121,19 +124,23 @@ export function useFileReferenceActions({
     || (reference.absolutePath && files),
   );
   const canOpenPrimary = resolvedPrimaryAction !== "unavailable"
-    || (pathKind === null && canResolvePathKind && !workspaceResolutionFailed);
+    || (pathKind === null && canResolvePathKind);
   const pathKindPending = externalPathKindPending || statQuery.isFetching;
   const primaryUnavailableReason = pathKindPending
     ? "Checking whether this path is a file or folder…"
-    : pathKind === "directory" && !canReveal
-      ? "Reveal in Finder is available in the Desktop app."
-      : pathKind === "file" && !canOpenInSidebar
-        ? "This file is outside the current workspace."
-        : pathKind === null && workspaceResolutionFailed
-          ? "This path is unavailable."
-          : pathKind === null
-            ? "Resolve this path in the workspace."
-          : null;
+    : primaryOpenFailed
+      ? "Could not open this path. Click to retry."
+      : pathKind === "directory" && !canReveal
+        ? "Reveal in Finder is available in the Desktop app."
+        : !reference.workspacePath && reference.absolutePath && !files
+          ? "External files are available in the Desktop app."
+          : pathKind === "file" && !canOpenInSidebar && !canOpenExternal
+            ? "External files are available in the Desktop app."
+            : pathKind === null && pathResolutionFailed
+              ? "Could not resolve this path. Click to retry."
+              : pathKind === null
+                ? "Resolve this path in the workspace."
+                : null;
   const openTargets = useMemo(
     () => targets.filter((target) => target.kind !== "copy"),
     [targets],
@@ -194,9 +201,9 @@ export function useFileReferenceActions({
 
   const openDefault = useCallback(async () => {
     if (!reference.absolutePath) {
-      return;
+      return false;
     }
-    await openInDefaultEditor(reference.absolutePath);
+    return openInDefaultEditor(reference.absolutePath);
   }, [openInDefaultEditor, reference.absolutePath]);
 
   const reveal = useCallback(async () => {
@@ -231,24 +238,37 @@ export function useFileReferenceActions({
           }
         }
         if (!resolvedPathKind || !resolvedWorkspacePath) {
-          setWorkspaceResolutionFailed(true);
+          setPathResolutionFailed(true);
           return "unavailable";
         }
       }
     }
     if (!resolvedPathKind && reference.absolutePath && files) {
-      resolvedPathKind = await files.isDirectory(reference.absolutePath)
-        ? "directory"
-        : "file";
+      try {
+        resolvedPathKind = await files.isDirectory(reference.absolutePath)
+          ? "directory"
+          : "file";
+      } catch {
+        setPathResolutionFailed(true);
+        return "unavailable";
+      }
     }
 
     const action = resolveFileReferencePrimaryAction({
       pathKind: resolvedPathKind,
       canOpenViewer: Boolean(resolvedWorkspacePath),
+      canOpenExternal: Boolean(files && reference.absolutePath),
       canReveal: Boolean(files && reference.absolutePath),
     });
     if (action === "reveal") {
-      await reveal();
+      try {
+        await reveal();
+      } catch {
+        setPrimaryOpenFailed(true);
+        return "unavailable";
+      }
+      setPathResolutionFailed(false);
+      setPrimaryOpenFailed(false);
       return action;
     }
     if (action === "open-viewer") {
@@ -264,7 +284,18 @@ export function useFileReferenceActions({
           });
         }
       }
-      setWorkspaceResolutionFailed(false);
+      setPathResolutionFailed(false);
+      setPrimaryOpenFailed(false);
+      return action;
+    }
+    if (action === "open-external") {
+      const opened = await openDefault();
+      if (!opened) {
+        setPrimaryOpenFailed(true);
+        return "unavailable";
+      }
+      setPathResolutionFailed(false);
+      setPrimaryOpenFailed(false);
       return action;
     }
     return action;
@@ -273,6 +304,7 @@ export function useFileReferenceActions({
     activateViewerTarget,
     fuzzyResolveFilePath,
     materializedWorkspaceId,
+    openDefault,
     openTarget,
     pathKind,
     reference.absolutePath,

--- a/apps/packages/product-client/src/lib/domain/files/path-references.test.ts
+++ b/apps/packages/product-client/src/lib/domain/files/path-references.test.ts
@@ -57,6 +57,18 @@ describe("resolveFileReference", () => {
     });
   });
 
+  it("infers a relative workspace path when nullable metadata was omitted on the wire", () => {
+    expect(resolveFileReference({
+      rawPath: "src/App.tsx",
+      workspaceRoot: "/repo",
+      resolveAbsolute,
+      workspacePathOverride: null,
+    })).toMatchObject({
+      absolutePath: "/repo/src/App.tsx",
+      workspacePath: "src/App.tsx",
+    });
+  });
+
   it("maps absolute paths under the workspace back to workspace-relative paths", () => {
     expect(resolveFileReference({
       rawPath: "/repo/src/App.tsx:12:4",
@@ -76,8 +88,40 @@ describe("resolveFileReference", () => {
       rawPath: "/tmp/file.txt",
       workspaceRoot: "/repo",
       resolveAbsolute,
+      workspacePathOverride: null,
     })).toMatchObject({
       absolutePath: "/tmp/file.txt",
+      workspacePath: null,
+    });
+  });
+
+  it("normalizes absolute traversal before deciding workspace membership", () => {
+    expect(resolveFileReference({
+      rawPath: "/repo/sub/../../tmp/file.txt",
+      workspaceRoot: "/repo",
+      resolveAbsolute,
+      workspacePathOverride: null,
+    })).toMatchObject({
+      workspacePath: null,
+    });
+
+    expect(resolveFileReference({
+      rawPath: "/repo/src/../App.tsx",
+      workspaceRoot: "/repo",
+      resolveAbsolute,
+      workspacePathOverride: null,
+    })).toMatchObject({
+      workspacePath: "App.tsx",
+    });
+  });
+
+  it("rejects a relative path that escapes the workspace after normalization", () => {
+    expect(resolveFileReference({
+      rawPath: "src/../../tmp/file.txt",
+      workspaceRoot: "/repo",
+      resolveAbsolute,
+      workspacePathOverride: null,
+    })).toMatchObject({
       workspacePath: null,
     });
   });
@@ -85,11 +129,42 @@ describe("resolveFileReference", () => {
 
 describe("resolveFileReferencePrimaryAction", () => {
   it.each([
-    [{ pathKind: "file" as const, canOpenViewer: true, canReveal: true }, "open-viewer"],
-    [{ pathKind: "file" as const, canOpenViewer: false, canReveal: true }, "unavailable"],
-    [{ pathKind: "directory" as const, canOpenViewer: true, canReveal: true }, "reveal"],
-    [{ pathKind: "directory" as const, canOpenViewer: true, canReveal: false }, "unavailable"],
-    [{ pathKind: null, canOpenViewer: true, canReveal: true }, "unavailable"],
+    [{
+      pathKind: "file" as const,
+      canOpenViewer: true,
+      canOpenExternal: true,
+      canReveal: true,
+    }, "open-viewer"],
+    [{
+      pathKind: "file" as const,
+      canOpenViewer: false,
+      canOpenExternal: true,
+      canReveal: true,
+    }, "open-external"],
+    [{
+      pathKind: "file" as const,
+      canOpenViewer: false,
+      canOpenExternal: false,
+      canReveal: true,
+    }, "unavailable"],
+    [{
+      pathKind: "directory" as const,
+      canOpenViewer: true,
+      canOpenExternal: true,
+      canReveal: true,
+    }, "reveal"],
+    [{
+      pathKind: "directory" as const,
+      canOpenViewer: true,
+      canOpenExternal: true,
+      canReveal: false,
+    }, "unavailable"],
+    [{
+      pathKind: null,
+      canOpenViewer: true,
+      canOpenExternal: true,
+      canReveal: true,
+    }, "unavailable"],
   ])("routes %o to %s", (input, expected) => {
     expect(resolveFileReferencePrimaryAction(input)).toBe(expected);
   });

--- a/apps/packages/product-client/src/lib/domain/files/path-references.ts
+++ b/apps/packages/product-client/src/lib/domain/files/path-references.ts
@@ -10,7 +10,11 @@ export interface ResolvedFileReference {
 }
 
 export type FileReferencePathKind = "file" | "directory";
-export type FileReferencePrimaryAction = "open-viewer" | "reveal" | "unavailable";
+export type FileReferencePrimaryAction =
+  | "open-viewer"
+  | "open-external"
+  | "reveal"
+  | "unavailable";
 
 export function resolveWorkspaceStatPathKind(stat: {
   kind: "file" | "directory" | "symlink";
@@ -30,15 +34,20 @@ export function resolveWorkspaceStatPathKind(stat: {
 /**
  * Keep primary file-reference behavior host-independent and fail closed while
  * the path kind is unknown. A directory must never be routed through the file
- * viewer, and a file must never silently fall back to Finder.
+ * viewer, and an external file must use the configured external open target
+ * rather than silently falling back to Finder.
  */
 export function resolveFileReferencePrimaryAction(args: {
   pathKind: FileReferencePathKind | null;
   canOpenViewer: boolean;
+  canOpenExternal: boolean;
   canReveal: boolean;
 }): FileReferencePrimaryAction {
   if (args.pathKind === "file") {
-    return args.canOpenViewer ? "open-viewer" : "unavailable";
+    if (args.canOpenViewer) {
+      return "open-viewer";
+    }
+    return args.canOpenExternal ? "open-external" : "unavailable";
   }
   if (args.pathKind === "directory") {
     return args.canReveal ? "reveal" : "unavailable";
@@ -54,9 +63,11 @@ export function resolveFileReference(args: {
 }): ResolvedFileReference {
   const trimmed = args.rawPath.trim();
   const { path, line, column } = splitPathLineSuffix(trimmed);
-  const workspacePath = args.workspacePathOverride !== undefined
-    ? normalizeWorkspacePathOverride(args.workspacePathOverride)
-    : resolveWorkspacePathFromReference(path, args.workspaceRoot);
+  // The SDK normalizes both an omitted wire field and an explicit null to
+  // `null`, so absence cannot safely mean "authoritatively external" here.
+  // Use a non-empty override when supplied; otherwise classify the raw path.
+  const workspacePath = normalizeWorkspacePathOverride(args.workspacePathOverride)
+    ?? resolveWorkspacePathFromReference(path, args.workspaceRoot);
 
   return {
     rawPath: args.rawPath,
@@ -118,11 +129,16 @@ export function fileReferenceBasename(path: string): string {
   return segments[segments.length - 1] ?? path;
 }
 
-function normalizeWorkspacePathOverride(path: string | null): string | null {
+function normalizeWorkspacePathOverride(path: string | null | undefined): string | null {
   if (!path) {
     return null;
   }
-  return stripRelativePrefix(path.trim());
+  const trimmed = stripRelativePrefix(path.trim());
+  if (trimmed === "~" || trimmed.startsWith("~/")) {
+    return null;
+  }
+  const normalized = normalizeLexicalPath(trimmed);
+  return normalized && !normalized.startsWith("/") ? normalized : null;
 }
 
 function resolveWorkspacePathFromReference(
@@ -134,23 +150,30 @@ function resolveWorkspacePathFromReference(
     return null;
   }
 
-  const normalizedRoot = normalizeRoot(workspaceRoot);
-  if (trimmed.startsWith("/")) {
-    if (!normalizedRoot) {
-      return null;
-    }
-    if (trimmed === normalizedRoot) {
-      return null;
-    }
-    const prefix = `${normalizedRoot}/`;
-    return trimmed.startsWith(prefix) ? trimmed.slice(prefix.length) : null;
-  }
-
-  if (trimmed === "~" || trimmed.startsWith("~/") || trimmed.startsWith("../")) {
+  if (trimmed === "~" || trimmed.startsWith("~/")) {
     return null;
   }
 
-  return stripRelativePrefix(trimmed);
+  const normalizedPath = normalizeLexicalPath(trimmed);
+  if (!normalizedPath) {
+    return null;
+  }
+
+  const normalizedRoot = normalizeRoot(workspaceRoot);
+  if (normalizedPath.startsWith("/")) {
+    if (!normalizedRoot) {
+      return null;
+    }
+    if (normalizedPath === normalizedRoot) {
+      return null;
+    }
+    const prefix = normalizedRoot === "/" ? "/" : `${normalizedRoot}/`;
+    return normalizedPath.startsWith(prefix)
+      ? normalizedPath.slice(prefix.length)
+      : null;
+  }
+
+  return normalizedPath;
 }
 
 function stripRelativePrefix(path: string): string {
@@ -165,5 +188,29 @@ function normalizeRoot(root: string | null): string | null {
   if (!root) {
     return null;
   }
-  return root.endsWith("/") ? root.slice(0, -1) : root;
+  const normalized = normalizeLexicalPath(root.trim());
+  return normalized?.startsWith("/") ? normalized : null;
+}
+
+function normalizeLexicalPath(path: string): string | null {
+  const absolute = path.startsWith("/");
+  const segments: string[] = [];
+  for (const segment of path.split("/")) {
+    if (!segment || segment === ".") {
+      continue;
+    }
+    if (segment === "..") {
+      if (segments.length === 0) {
+        return null;
+      }
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+
+  if (segments.length === 0) {
+    return absolute ? "/" : null;
+  }
+  return `${absolute ? "/" : ""}${segments.join("/")}`;
 }

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -138,8 +138,8 @@ Rules:
   mistaken for a link. Favicon requests go to the linked site itself (no
   third-party favicon service), so no list of linked hosts leaks anywhere. The
   provider mention and the file-path mention share one inline-mention treatment
-  (muted link color, no underline at rest, brighten to foreground + dashed
-  underline on hover); this only renders because the global `a` reset lives in
+  (semantic blue link color, no underline at rest, and a dashed underline on
+  hover); this only renders because the global `a` reset lives in
   `@layer base` (see the frontend styling guide) — unlayered, it would strip the
   anchor's color/underline.
 - Web falls back to unhighlighted (identically styled) code blocks; shiki stays
@@ -261,8 +261,16 @@ toggles its ledger; the summary does not route to the Changes pane.
 Every row revealed inside an activity ledger repeats its own semantic glyph
 (including mixed parsed shell operations), at the same text-relative size and
 inherited ink as its label. Completed command details use `Ran …`; only the
-active command uses `Running …`. An edit detail shows one pen glyph followed by
-an inherited-color, dotted-underlined filename, not a second file-type glyph.
+active command uses `Running …`. A read target with missing nullable workspace
+metadata is classified from its raw path against the current workspace root.
+An openable file target uses the semantic blue link color even though the
+surrounding activity row is muted: a workspace file opens in the viewer, while
+an external Desktop file uses the configured external target. It remains
+pointer- and keyboard-activatable while retrying path resolution or a failed
+external launch. A read target with no available primary action remains muted
+plain text without link or file-menu semantics rather than a disabled control.
+An edit detail shows one pen glyph followed by an inherited-color,
+dotted-underlined filename, not a second file-type glyph.
 When a transcript patch is available, clicking the edit row outside its
 filename toggles the inline diff. Clicking either the filename or the trailing
 open-file arrow opens the file without changing the row's expanded state. The


### PR DESCRIPTION
## Summary

- keep actionable inline file references semantic blue and remove muted-row color overrides
- recover workspace membership from missing nullable metadata with traversal-safe lexical normalization
- route external Desktop files through the configured open target and keep resolution or launch failures retryable
- render genuinely unavailable targets as plain text instead of disabled-looking links
- align completed file-change cards with the shared primary-action contract
- evict failed open-target discovery requests so a transient Desktop bridge failure can recover on retry

## Root cause

The file-reference badge inherited muted activity-row color, while the path metadata reducer collapsed omitted and null workspace paths into the same value. A later primary-action guard then treated inferred, external, and failed references as unavailable, producing disabled cursor and click behavior even for targets the Desktop host could open.

## User impact

Workspace references open in the viewer, external Desktop references use the configured target, and all rendered inline links remain keyboard- and pointer-actionable. Transient resolution, target-discovery, and launch failures can recover on a later click. Targets with no available action no longer masquerade as links.

## Validation

- `pnpm --filter @proliferate/product-client build`
- focused ProductClient Vitest suite: 102 tests passed across path resolution, target discovery, file references, read/edit ledgers, file changes, viewer, and transcript consumers
- `python3 scripts/check_docs.py`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_appearance_scaling.py`
- `python3 scripts/check_design_attribution.py`
- `git diff --check`
- independent correctness, accessibility, failure-path, and integration reviews: clean