### PR TITLE
refactor(anyharness): mobility resolve/decide/execute — decisions leave the effect path (grid PR 6b)

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/mobility/runtime/destroy_source.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/mobility/runtime/destroy_source.rs
@@ -2,9 +2,30 @@
 //!
 //! Live because it force-closes live terminals and because destroying the
 //! materialization goes through `WorkspaceRuntime`.
+//!
+//! Pipeline: resolve every fact (workspace record, repo default branch, live
+//! terminals, session rows) → decide the whole effect sequence in
+//! `mobility_policy::plan_source_destruction` → execute the plan in order. The
+//! resolve pass replaces the old fetch/act interleaving, so the `Local`
+//! default-branch precondition is now proved before the first irreversible
+//! effect instead of being discovered by the materialization call after the
+//! terminals are closed and the sessions deleted.
+//!
+//! There is no compensation slot here on purpose: force-closing a terminal,
+//! deleting a session row, and removing a worktree are all irreversible, so a
+//! mid-sequence failure cannot be rolled back. The plan is therefore ordered
+//! cheapest-to-recover first (terminals, which the user can reopen) and the
+//! partial progress is logged before the error propagates. The caller holds the
+//! exclusive workspace lease for the whole call, so no concurrent writer can
+//! invalidate the resolved facts between decide and execute.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
+use super::mobility_policy::{
+    plan_source_destruction, DefaultBranchFact, SourceDestructionFacts, SourceDestructionRejection,
+    TerminalFact,
+};
 use super::MobilityRuntime;
 use crate::domains::agents::portability::delete_session_agent_artifacts;
 use crate::domains::mobility::model::DestroyedWorkspaceSourceSummary;
@@ -16,42 +37,122 @@ impl MobilityRuntime {
         &self,
         workspace_id: &str,
     ) -> Result<DestroyedWorkspaceSourceSummary, MobilityError> {
+        // --- resolve -------------------------------------------------------
         let workspace = self.mobility_service.load_workspace(workspace_id)?;
         let workspace_path = PathBuf::from(&workspace.path);
         let default_branch = if workspace.kind == WorkspaceKind::Local {
             let repo_root_id = workspace.repo_root_id.clone();
-            Some(
+            DefaultBranchFact::Resolved(
                 self.workspace_runtime
                     .resolve_repo_root_default_branch(&repo_root_id)
                     .map_err(MobilityError::Internal)?,
             )
         } else {
-            None
+            DefaultBranchFact::NotRequired
         };
-
-        let active_terminals = self.active_terminals_blocking(workspace_id);
-        let mut closed_terminal_ids = Vec::new();
-        for terminal in active_terminals {
-            self.terminal_service
-                .close_terminal_blocking(&terminal.id)
-                .map_err(MobilityError::Internal)?;
-            closed_terminal_ids.push(terminal.id);
-        }
+        let terminals = self
+            .terminal_service
+            .list_terminals_blocking(workspace_id)
+            .into_iter()
+            .map(|terminal| TerminalFact {
+                terminal_id: terminal.id,
+                status: terminal.status,
+            })
+            .collect::<Vec<_>>();
         let sessions = self
             .session_service
             .store()
             .list_by_workspace(workspace_id)?;
-        let mut deleted_session_ids = Vec::new();
-        let runtime_home = Some(self.session_runtime.runtime_home());
-        for session in sessions {
-            delete_session_agent_artifacts(&session, &workspace_path, runtime_home)?;
-            self.session_service.delete_session(&session.id)?;
-            deleted_session_ids.push(session.id);
+
+        // --- decide --------------------------------------------------------
+        let plan = plan_source_destruction(&SourceDestructionFacts {
+            workspace_kind: workspace.kind,
+            default_branch,
+            terminals,
+            session_ids: sessions.iter().map(|session| session.id.clone()).collect(),
+        })
+        .map_err(|rejection| match rejection {
+            // Same message and surface the materialization call used to raise
+            // once the effects had already run.
+            SourceDestructionRejection::MissingLocalDefaultBranch => MobilityError::Internal(
+                anyhow::anyhow!("default branch is required to park a local workspace"),
+            ),
+        })?;
+
+        // --- execute -------------------------------------------------------
+        let mut closed_terminal_ids = Vec::new();
+        for terminal_id in &plan.close_terminal_ids {
+            if let Err(error) = self.terminal_service.close_terminal_blocking(terminal_id) {
+                tracing::error!(
+                    workspace_id = %workspace_id,
+                    terminal_id = %terminal_id,
+                    closed_terminal_count = closed_terminal_ids.len(),
+                    error = %error,
+                    "mobility destroy-source aborted while closing terminals; no session was deleted"
+                );
+                return Err(MobilityError::Internal(error));
+            }
+            closed_terminal_ids.push(terminal_id.clone());
         }
 
-        self.workspace_runtime
-            .destroy_source_workspace_materialization(&workspace, default_branch.as_deref())
-            .map_err(MobilityError::Internal)?;
+        // The plan names ids; the records travel beside it. Resolve the plan's
+        // ids back to their rows BEFORE the first deletion so a mismatch fails
+        // with nothing half-deleted.
+        let sessions_by_id = sessions
+            .iter()
+            .map(|session| (session.id.as_str(), session))
+            .collect::<HashMap<_, _>>();
+        let planned_sessions = plan
+            .delete_session_ids
+            .iter()
+            .map(|session_id| {
+                sessions_by_id
+                    .get(session_id.as_str())
+                    .copied()
+                    .ok_or_else(|| {
+                        MobilityError::Internal(anyhow::anyhow!(
+                            "destroy-source plan named unknown session {session_id}"
+                        ))
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut deleted_session_ids = Vec::new();
+        let runtime_home = Some(self.session_runtime.runtime_home());
+        for session in planned_sessions {
+            if let Err(error) =
+                delete_session_agent_artifacts(session, &workspace_path, runtime_home)
+                    .and_then(|()| self.session_service.delete_session(&session.id))
+            {
+                tracing::error!(
+                    workspace_id = %workspace_id,
+                    session_id = %session.id,
+                    closed_terminal_count = closed_terminal_ids.len(),
+                    deleted_session_count = deleted_session_ids.len(),
+                    error = %error,
+                    "mobility destroy-source aborted while deleting sessions; the materialization was left in place"
+                );
+                return Err(MobilityError::Internal(error));
+            }
+            deleted_session_ids.push(session.id.clone());
+        }
+
+        if let Err(error) = self
+            .workspace_runtime
+            .destroy_source_workspace_materialization(
+                &workspace,
+                plan.materialization.default_branch(),
+            )
+        {
+            tracing::error!(
+                workspace_id = %workspace_id,
+                closed_terminal_count = closed_terminal_ids.len(),
+                deleted_session_count = deleted_session_ids.len(),
+                error = %error,
+                "mobility destroy-source aborted while destroying the materialization"
+            );
+            return Err(MobilityError::Internal(error));
+        }
 
         Ok(DestroyedWorkspaceSourceSummary {
             workspace_id: workspace.id,

--- a/anyharness/crates/anyharness-lib/src/domains/mobility/runtime/mobility_policy.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/mobility/runtime/mobility_policy.rs
@@ -1,0 +1,416 @@
+//! Pure mobility decisions for the mobility runtime.
+//!
+//! Everything here is data-in / data-out: no store, no clock, no uuid, no
+//! `&self`. `preflight.rs` and `destroy_source.rs` perform the resolve steps
+//! (workspace/session/terminal loads, git inspection, live probes) and hand the
+//! gathered facts in; this module owns the decisions — which terminals count as
+//! active, which sessions mobility v1 can carry, what blocks a move, and what
+//! the destroy-source effect sequence is.
+//!
+//! Two shapes appear per use case: a `*Facts` struct the IO layer fills in, and
+//! a decision (a plan, an assessment, or a predicate) the IO layer executes.
+//! Plans carry ids only — the records and the capabilities they name travel
+//! beside the plan, never inside it.
+
+use crate::domains::mobility::model::{MobilityBlocker, MAX_MOBILITY_ARCHIVE_BODY_BYTES};
+use crate::domains::mobility::service::is_supported_agent_kind;
+use crate::domains::terminals::model::{TerminalRecord, TerminalStatus};
+use crate::domains::workspaces::access_model::WorkspaceAccessMode;
+use crate::domains::workspaces::model::WorkspaceKind;
+
+/// A terminal is "active" for mobility purposes while it still owns a process:
+/// starting or running. Exited and failed terminals need no force-close and
+/// raise no warning. Single home for the rule — `runtime/mod.rs` filters live
+/// records with [`terminal_is_active`], `destroy_source.rs` decides over
+/// [`TerminalFact`]s.
+pub(super) fn terminal_status_is_active(status: &TerminalStatus) -> bool {
+    matches!(status, TerminalStatus::Starting | TerminalStatus::Running)
+}
+
+/// [`terminal_status_is_active`] over a whole live record, for the runtime's
+/// gather helpers.
+pub(super) fn terminal_is_active(terminal: &TerminalRecord) -> bool {
+    terminal_status_is_active(&terminal.status)
+}
+
+/// Whether mobility v1 can carry a session of this agent kind, and the reason
+/// text shown when it cannot. The support predicate itself stays in
+/// `service.rs` — it also gates which sessions enter the durable export bundle,
+/// so there is exactly one answer for both paths; this fn owns the surfaced
+/// reason.
+pub(super) fn classify_session_support(agent_kind: &str) -> SessionSupport {
+    if is_supported_agent_kind(agent_kind) {
+        return SessionSupport {
+            supported: true,
+            reason: None,
+        };
+    }
+    SessionSupport {
+        supported: false,
+        reason: Some("Unsupported agent kind for workspace mobility v1".to_string()),
+    }
+}
+
+pub(super) struct SessionSupport {
+    pub supported: bool,
+    pub reason: Option<String>,
+}
+
+/// Whether the workspace can move: no blockers, nothing else. One rule with two
+/// consumers — it gates the (expensive) archive size estimate and it is the
+/// `can_move` field of the preflight result.
+pub(super) fn workspace_can_move(blockers: &[MobilityBlocker]) -> bool {
+    blockers.is_empty()
+}
+
+/// The archive-size limit, decided over an already-measured estimate.
+pub(super) fn archive_size_blocker(estimated_bytes: u64) -> Option<MobilityBlocker> {
+    if estimated_bytes <= MAX_MOBILITY_ARCHIVE_BODY_BYTES as u64 {
+        return None;
+    }
+    Some(MobilityBlocker {
+        code: "archive_too_large".to_string(),
+        message: format!(
+            "Archive exceeds the {} byte limit",
+            MAX_MOBILITY_ARCHIVE_BODY_BYTES
+        ),
+        session_id: None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Preflight: can this workspace move right now?
+// ---------------------------------------------------------------------------
+
+/// Whether the repo's default branch was needed and resolved. Only `Local`
+/// workspaces need one (they park onto it); worktrees are removed outright.
+pub(super) enum DefaultBranchFact {
+    /// Not a `Local` workspace — no default branch is involved.
+    NotRequired,
+    Resolved(String),
+    /// Required but the resolver failed.
+    Unresolved,
+}
+
+/// Git inspection result. A failed inspection is a fact, not an error: preflight
+/// reports it as a blocker instead of aborting.
+pub(super) enum PreflightGitStatus {
+    Inspected {
+        detached: bool,
+        operation_in_progress: bool,
+        conflicted: bool,
+        clean: bool,
+    },
+    Unavailable {
+        error: String,
+    },
+}
+
+pub(super) struct PreflightReviewRun {
+    pub run_id: String,
+    pub parent_session_id: String,
+}
+
+/// One session's resolved facts. `supported`/`reason` come from
+/// [`classify_session_support`]; the rest are store and live reads.
+pub(super) struct PreflightSessionFacts {
+    pub session_id: String,
+    pub status: String,
+    pub agent_kind: String,
+    pub supported: bool,
+    pub unsupported_reason: Option<String>,
+    pub awaiting_interaction: bool,
+    pub has_pending_prompts: bool,
+}
+
+/// Every fact the preflight assessment branches on, gathered by `preflight.rs`
+/// in a single resolve pass before any decision is made.
+pub(super) struct PreflightFacts {
+    pub workspace_kind: WorkspaceKind,
+    pub runtime_mode: WorkspaceAccessMode,
+    pub branch_name: Option<String>,
+    pub default_branch: DefaultBranchFact,
+    pub setup_running: bool,
+    pub git_status: PreflightGitStatus,
+    pub active_terminal_ids: Vec<String>,
+    pub active_review_runs: Vec<PreflightReviewRun>,
+    pub sessions: Vec<PreflightSessionFacts>,
+    /// Linked subagent sessions that sit outside the moving set.
+    pub partial_subagent_graph_session_ids: Vec<String>,
+}
+
+pub(super) struct PreflightAssessment {
+    pub blockers: Vec<MobilityBlocker>,
+    pub warnings: Vec<String>,
+}
+
+/// The whole preflight blocker/warning matrix, in the order the API surfaces it.
+///
+/// Blocker order is user-visible (it is serialized straight through), so the
+/// sequence below is deliberate and matches the pre-extraction interleaved
+/// pipeline exactly: workspace-level rules first (mutability, default branch,
+/// setup, git state, default-branch-in-use), then per-terminal warnings, then
+/// review runs, then per-session rules, then the subagent graph. The
+/// archive-size blocker is appended later by the caller, after the estimate is
+/// resolved — see [`archive_size_blocker`].
+pub(super) fn assess_mobility_preflight(facts: &PreflightFacts) -> PreflightAssessment {
+    let mut blockers = Vec::new();
+    let mut warnings = Vec::new();
+
+    if facts.runtime_mode != WorkspaceAccessMode::Normal {
+        blockers.push(MobilityBlocker {
+            code: "workspace_not_mutable".to_string(),
+            message: format!(
+                "Workspace is currently in {} mode",
+                facts.runtime_mode.as_str()
+            ),
+            session_id: None,
+        });
+    }
+
+    if matches!(facts.default_branch, DefaultBranchFact::Unresolved) {
+        blockers.push(MobilityBlocker {
+            code: "default_branch_unknown".to_string(),
+            message: ("Main local workspaces require a resolved repo default branch ".to_string()),
+            session_id: None,
+        });
+    }
+
+    if facts.setup_running {
+        blockers.push(MobilityBlocker {
+            code: "setup_running".to_string(),
+            message: "Workspace setup is still running".to_string(),
+            session_id: None,
+        });
+    }
+
+    match &facts.git_status {
+        PreflightGitStatus::Inspected {
+            detached,
+            operation_in_progress,
+            conflicted,
+            clean,
+        } => {
+            if *detached {
+                blockers.push(MobilityBlocker {
+                    code: "workspace_detached".to_string(),
+                    message: "Workspace must be on a branch before moving".to_string(),
+                    session_id: None,
+                });
+            }
+            if *operation_in_progress {
+                blockers.push(MobilityBlocker {
+                    code: "git_operation_in_progress".to_string(),
+                    message: "Finish the current Git operation before moving".to_string(),
+                    session_id: None,
+                });
+            }
+            if *conflicted {
+                blockers.push(MobilityBlocker {
+                    code: "workspace_conflicted".to_string(),
+                    message: "Resolve Git conflicts before moving".to_string(),
+                    session_id: None,
+                });
+            }
+            if !*clean {
+                blockers.push(MobilityBlocker {
+                    code: "workspace_dirty".to_string(),
+                    message: "Workspace must be committed and clean before moving".to_string(),
+                    session_id: None,
+                });
+            }
+        }
+        PreflightGitStatus::Unavailable { error } => blockers.push(MobilityBlocker {
+            code: "workspace_status_unknown".to_string(),
+            message: format!("Unable to inspect workspace status: {error}"),
+            session_id: None,
+        }),
+    }
+
+    if facts.workspace_kind == WorkspaceKind::Local {
+        if let (Some(current_branch), DefaultBranchFact::Resolved(default_branch)) =
+            (facts.branch_name.as_deref(), &facts.default_branch)
+        {
+            if current_branch == default_branch {
+                blockers.push(MobilityBlocker {
+                    code: "local_default_branch_in_use".to_string(),
+                    message: format!(
+                        "Main local workspaces on '{default_branch}' must move from a worktree instead"
+                    ),
+                    session_id: None,
+                });
+            }
+        }
+    }
+
+    for terminal_id in &facts.active_terminal_ids {
+        warnings.push(format!(
+            "Terminal {terminal_id} will be force-closed after the move commits"
+        ));
+    }
+
+    for run in &facts.active_review_runs {
+        blockers.push(MobilityBlocker {
+            code: "review_active".to_string(),
+            message: format!("Review run {} is still active", run.run_id),
+            session_id: Some(run.parent_session_id.clone()),
+        });
+    }
+
+    for session in &facts.sessions {
+        if matches!(session.status.as_str(), "starting" | "running") {
+            blockers.push(MobilityBlocker {
+                code: "session_running".to_string(),
+                message: format!("Session {} is still active", session.session_id),
+                session_id: Some(session.session_id.clone()),
+            });
+        }
+
+        if session.awaiting_interaction {
+            blockers.push(MobilityBlocker {
+                code: "session_awaiting_interaction".to_string(),
+                message: format!("Session {} is awaiting interaction", session.session_id),
+                session_id: Some(session.session_id.clone()),
+            });
+        }
+
+        if session.has_pending_prompts {
+            blockers.push(MobilityBlocker {
+                code: "pending_prompt".to_string(),
+                message: format!("Session {} has pending prompts", session.session_id),
+                session_id: Some(session.session_id.clone()),
+            });
+        }
+
+        if !session.supported {
+            blockers.push(MobilityBlocker {
+                code: "unsupported_session".to_string(),
+                message: format!(
+                    "Session {} ({}) cannot move because {}",
+                    session.session_id,
+                    session.agent_kind,
+                    session
+                        .unsupported_reason
+                        .clone()
+                        .unwrap_or_else(|| "it is unsupported".to_string())
+                ),
+                session_id: Some(session.session_id.clone()),
+            });
+        }
+    }
+
+    for missing_id in &facts.partial_subagent_graph_session_ids {
+        blockers.push(MobilityBlocker {
+            code: "partial_subagent_graph".to_string(),
+            message: format!(
+                "Session graph includes linked subagent session {missing_id} outside this archive"
+            ),
+            session_id: Some(missing_id.clone()),
+        });
+    }
+
+    PreflightAssessment { blockers, warnings }
+}
+
+/// The sessions that enter the archive: the supported ones. Deduplicated by the
+/// caller into a set for the subagent-graph lookup.
+pub(super) fn movable_session_ids(sessions: &[PreflightSessionFacts]) -> Vec<String> {
+    sessions
+        .iter()
+        .filter(|session| session.supported)
+        .map(|session| session.session_id.clone())
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Destroy source: tear the old materialization down after a committed move
+// ---------------------------------------------------------------------------
+
+pub(super) struct TerminalFact {
+    pub terminal_id: String,
+    pub status: TerminalStatus,
+}
+
+/// Everything destroy-source decides over, resolved in one pass under the
+/// caller's exclusive workspace lease.
+pub(super) struct SourceDestructionFacts {
+    pub workspace_kind: WorkspaceKind,
+    /// The repo default branch, resolved for `Local` workspaces only.
+    pub default_branch: DefaultBranchFact,
+    /// Every live terminal in the workspace, unfiltered.
+    pub terminals: Vec<TerminalFact>,
+    /// Every session row in the workspace, in store order.
+    pub session_ids: Vec<String>,
+}
+
+/// How the source materialization goes away. `Local` workspaces park onto the
+/// repo default branch; worktrees are removed.
+#[derive(Debug)]
+pub(super) enum MaterializationDestruction {
+    RemoveWorktree,
+    ParkLocalOnDefaultBranch { default_branch: String },
+}
+
+impl MaterializationDestruction {
+    /// The `default_branch` argument
+    /// `WorkspaceRuntime::destroy_source_workspace_materialization` expects.
+    pub(super) fn default_branch(&self) -> Option<&str> {
+        match self {
+            Self::RemoveWorktree => None,
+            Self::ParkLocalOnDefaultBranch { default_branch } => Some(default_branch.as_str()),
+        }
+    }
+}
+
+/// The destroy-source effect sequence, as pure data. Effects run in field order:
+/// close terminals, delete sessions, destroy the materialization.
+#[derive(Debug)]
+pub(super) struct SourceDestructionPlan {
+    pub close_terminal_ids: Vec<String>,
+    pub delete_session_ids: Vec<String>,
+    pub materialization: MaterializationDestruction,
+}
+
+/// A precondition destroy-source cannot satisfy. Returned as data so the caller
+/// maps it onto its own error surface.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum SourceDestructionRejection {
+    /// A `Local` workspace with no usable repo default branch to park onto.
+    MissingLocalDefaultBranch,
+}
+
+/// Decide the whole destroy-source sequence from resolved facts.
+///
+/// The `Local` default-branch precondition is checked here, before any effect
+/// runs, rather than being discovered by the materialization call after the
+/// terminals are already closed and the sessions already deleted.
+pub(super) fn plan_source_destruction(
+    facts: &SourceDestructionFacts,
+) -> Result<SourceDestructionPlan, SourceDestructionRejection> {
+    let materialization = match facts.workspace_kind {
+        WorkspaceKind::Worktree => MaterializationDestruction::RemoveWorktree,
+        WorkspaceKind::Local => {
+            let default_branch = match &facts.default_branch {
+                DefaultBranchFact::Resolved(branch) => branch.trim(),
+                DefaultBranchFact::NotRequired | DefaultBranchFact::Unresolved => "",
+            };
+            if default_branch.is_empty() {
+                return Err(SourceDestructionRejection::MissingLocalDefaultBranch);
+            }
+            MaterializationDestruction::ParkLocalOnDefaultBranch {
+                default_branch: default_branch.to_string(),
+            }
+        }
+    };
+
+    Ok(SourceDestructionPlan {
+        close_terminal_ids: facts
+            .terminals
+            .iter()
+            .filter(|terminal| terminal_status_is_active(&terminal.status))
+            .map(|terminal| terminal.terminal_id.clone())
+            .collect(),
+        delete_session_ids: facts.session_ids.clone(),
+        materialization,
+    })
+}

--- a/anyharness/crates/anyharness-lib/src/domains/mobility/runtime/mobility_policy_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/mobility/runtime/mobility_policy_tests.rs
@@ -1,0 +1,527 @@
+//! Hand-built-facts tests for `mobility_policy`. No DB, no live handles, no
+//! clock — every fact is written out in the test body, the same shape as
+//! `domains/sessions/runtime/launch_policy.rs`'s suite.
+
+use super::mobility_policy::{
+    archive_size_blocker, assess_mobility_preflight, classify_session_support, movable_session_ids,
+    plan_source_destruction, terminal_status_is_active, workspace_can_move, DefaultBranchFact,
+    MaterializationDestruction, PreflightFacts, PreflightGitStatus, PreflightReviewRun,
+    PreflightSessionFacts, SourceDestructionFacts, SourceDestructionRejection, TerminalFact,
+};
+use crate::domains::mobility::model::{MobilityBlocker, MAX_MOBILITY_ARCHIVE_BODY_BYTES};
+use crate::domains::terminals::model::TerminalStatus;
+use crate::domains::workspaces::access_model::WorkspaceAccessMode;
+use crate::domains::workspaces::model::WorkspaceKind;
+
+// --- fact builders ---------------------------------------------------------
+
+/// A movable worktree workspace: nothing blocks, nothing warns.
+fn clean_preflight_facts() -> PreflightFacts {
+    PreflightFacts {
+        workspace_kind: WorkspaceKind::Worktree,
+        runtime_mode: WorkspaceAccessMode::Normal,
+        branch_name: Some("feature/move-me".to_string()),
+        default_branch: DefaultBranchFact::NotRequired,
+        setup_running: false,
+        git_status: PreflightGitStatus::Inspected {
+            detached: false,
+            operation_in_progress: false,
+            conflicted: false,
+            clean: true,
+        },
+        active_terminal_ids: Vec::new(),
+        active_review_runs: Vec::new(),
+        sessions: Vec::new(),
+        partial_subagent_graph_session_ids: Vec::new(),
+    }
+}
+
+fn idle_session(session_id: &str) -> PreflightSessionFacts {
+    PreflightSessionFacts {
+        session_id: session_id.to_string(),
+        status: "idle".to_string(),
+        agent_kind: "claude".to_string(),
+        supported: true,
+        unsupported_reason: None,
+        awaiting_interaction: false,
+        has_pending_prompts: false,
+    }
+}
+
+fn codes(blockers: &[MobilityBlocker]) -> Vec<&str> {
+    blockers
+        .iter()
+        .map(|blocker| blocker.code.as_str())
+        .collect()
+}
+
+// --- terminal activity -----------------------------------------------------
+
+#[test]
+fn only_starting_and_running_terminals_are_active() {
+    assert!(terminal_status_is_active(&TerminalStatus::Starting));
+    assert!(terminal_status_is_active(&TerminalStatus::Running));
+    assert!(!terminal_status_is_active(&TerminalStatus::Exited));
+    assert!(!terminal_status_is_active(&TerminalStatus::Failed));
+}
+
+// --- session support -------------------------------------------------------
+
+#[test]
+fn supported_agent_kinds_carry_no_reason() {
+    for kind in ["claude", "codex"] {
+        let support = classify_session_support(kind);
+        assert!(support.supported, "{kind} should be supported");
+        assert!(support.reason.is_none());
+    }
+}
+
+#[test]
+fn unsupported_agent_kind_carries_the_v1_reason() {
+    let support = classify_session_support("cursor");
+
+    assert!(!support.supported);
+    assert_eq!(
+        support.reason.as_deref(),
+        Some("Unsupported agent kind for workspace mobility v1")
+    );
+}
+
+#[test]
+fn only_supported_sessions_are_movable() {
+    let mut unsupported = idle_session("session-2");
+    unsupported.supported = false;
+    let sessions = vec![idle_session("session-1"), unsupported];
+
+    assert_eq!(
+        movable_session_ids(&sessions),
+        vec!["session-1".to_string()]
+    );
+}
+
+// --- can_move / archive size ----------------------------------------------
+
+#[test]
+fn can_move_only_with_no_blockers() {
+    assert!(workspace_can_move(&[]));
+    assert!(!workspace_can_move(&[MobilityBlocker {
+        code: "workspace_dirty".to_string(),
+        message: "dirty".to_string(),
+        session_id: None,
+    }]));
+}
+
+#[test]
+fn archive_size_blocks_only_above_the_limit() {
+    assert!(archive_size_blocker(0).is_none());
+    assert!(archive_size_blocker(MAX_MOBILITY_ARCHIVE_BODY_BYTES as u64).is_none());
+
+    let blocker = archive_size_blocker(MAX_MOBILITY_ARCHIVE_BODY_BYTES as u64 + 1)
+        .expect("one byte over the limit blocks");
+    assert_eq!(blocker.code, "archive_too_large");
+    assert_eq!(blocker.session_id, None);
+}
+
+// --- preflight assessment --------------------------------------------------
+
+#[test]
+fn clean_worktree_workspace_has_no_blockers_or_warnings() {
+    let assessment = assess_mobility_preflight(&clean_preflight_facts());
+
+    assert_eq!(codes(&assessment.blockers), Vec::<&str>::new());
+    assert!(assessment.warnings.is_empty());
+    assert!(workspace_can_move(&assessment.blockers));
+}
+
+#[test]
+fn non_normal_runtime_mode_blocks_the_move() {
+    let mut facts = clean_preflight_facts();
+    facts.runtime_mode = WorkspaceAccessMode::FrozenForHandoff;
+
+    let assessment = assess_mobility_preflight(&facts);
+
+    assert_eq!(codes(&assessment.blockers), vec!["workspace_not_mutable"]);
+    assert_eq!(
+        assessment.blockers[0].message,
+        "Workspace is currently in frozen_for_handoff mode"
+    );
+}
+
+#[test]
+fn unresolved_local_default_branch_blocks_the_move() {
+    let mut facts = clean_preflight_facts();
+    facts.workspace_kind = WorkspaceKind::Local;
+    facts.default_branch = DefaultBranchFact::Unresolved;
+
+    let assessment = assess_mobility_preflight(&facts);
+
+    assert_eq!(codes(&assessment.blockers), vec!["default_branch_unknown"]);
+}
+
+#[test]
+fn local_workspace_sitting_on_the_default_branch_blocks_the_move() {
+    let mut facts = clean_preflight_facts();
+    facts.workspace_kind = WorkspaceKind::Local;
+    facts.branch_name = Some("main".to_string());
+    facts.default_branch = DefaultBranchFact::Resolved("main".to_string());
+
+    let assessment = assess_mobility_preflight(&facts);
+
+    assert_eq!(
+        codes(&assessment.blockers),
+        vec!["local_default_branch_in_use"]
+    );
+    assert_eq!(
+        assessment.blockers[0].message,
+        "Main local workspaces on 'main' must move from a worktree instead"
+    );
+}
+
+#[test]
+fn local_workspace_on_a_side_branch_is_movable() {
+    let mut facts = clean_preflight_facts();
+    facts.workspace_kind = WorkspaceKind::Local;
+    facts.branch_name = Some("feature/side".to_string());
+    facts.default_branch = DefaultBranchFact::Resolved("main".to_string());
+
+    let assessment = assess_mobility_preflight(&facts);
+
+    assert_eq!(codes(&assessment.blockers), Vec::<&str>::new());
+}
+
+#[test]
+fn a_worktree_on_the_repo_default_branch_name_is_not_blocked() {
+    // The default-branch-in-use rule is Local-only: a worktree that happens to
+    // sit on a branch named like the default still moves.
+    let mut facts = clean_preflight_facts();
+    facts.branch_name = Some("main".to_string());
+    facts.default_branch = DefaultBranchFact::Resolved("main".to_string());
+
+    let assessment = assess_mobility_preflight(&facts);
+
+    assert_eq!(codes(&assessment.blockers), Vec::<&str>::new());
+}
+
+#[test]
+fn running_setup_blocks_the_move() {
+    let mut facts = clean_preflight_facts();
+    facts.setup_running = true;
+
+    let assessment = assess_mobility_preflight(&facts);
+
+    assert_eq!(codes(&assessment.blockers), vec!["setup_running"]);
+}
+
+#[test]
+fn every_dirty_git_condition_raises_its_own_blocker_in_order() {
+    let mut facts = clean_preflight_facts();
+    facts.git_status = PreflightGitStatus::Inspected {
+        detached: true,
+        operation_in_progress: true,
+        conflicted: true,
+        clean: false,
+    };
+
+    let assessment = assess_mobility_preflight(&facts);
+
+    assert_eq!(
+        codes(&assessment.blockers),
+        vec![
+            "workspace_detached",
+            "git_operation_in_progress",
+            "workspace_conflicted",
+            "workspace_dirty",
+        ]
+    );
+}
+
+#[test]
+fn unavailable_git_status_blocks_with_the_inspection_error() {
+    let mut facts = clean_preflight_facts();
+    facts.git_status = PreflightGitStatus::Unavailable {
+        error: "not a git repository".to_string(),
+    };
+
+    let assessment = assess_mobility_preflight(&facts);
+
+    assert_eq!(
+        codes(&assessment.blockers),
+        vec!["workspace_status_unknown"]
+    );
+    assert_eq!(
+        assessment.blockers[0].message,
+        "Unable to inspect workspace status: not a git repository"
+    );
+}
+
+#[test]
+fn active_terminals_warn_but_never_block() {
+    let mut facts = clean_preflight_facts();
+    facts.active_terminal_ids = vec!["terminal-1".to_string(), "terminal-2".to_string()];
+
+    let assessment = assess_mobility_preflight(&facts);
+
+    assert_eq!(codes(&assessment.blockers), Vec::<&str>::new());
+    assert_eq!(
+        assessment.warnings,
+        vec![
+            "Terminal terminal-1 will be force-closed after the move commits".to_string(),
+            "Terminal terminal-2 will be force-closed after the move commits".to_string(),
+        ]
+    );
+    assert!(workspace_can_move(&assessment.blockers));
+}
+
+#[test]
+fn active_review_runs_block_and_name_the_parent_session() {
+    let mut facts = clean_preflight_facts();
+    facts.active_review_runs = vec![PreflightReviewRun {
+        run_id: "run-1".to_string(),
+        parent_session_id: "session-1".to_string(),
+    }];
+
+    let assessment = assess_mobility_preflight(&facts);
+
+    assert_eq!(codes(&assessment.blockers), vec!["review_active"]);
+    assert_eq!(
+        assessment.blockers[0].session_id.as_deref(),
+        Some("session-1")
+    );
+}
+
+#[test]
+fn starting_and_running_sessions_block_the_move() {
+    for status in ["starting", "running"] {
+        let mut facts = clean_preflight_facts();
+        let mut session = idle_session("session-1");
+        session.status = status.to_string();
+        facts.sessions = vec![session];
+
+        let assessment = assess_mobility_preflight(&facts);
+
+        assert_eq!(
+            codes(&assessment.blockers),
+            vec!["session_running"],
+            "status {status} should block"
+        );
+        assert_eq!(
+            assessment.blockers[0].session_id.as_deref(),
+            Some("session-1")
+        );
+    }
+}
+
+#[test]
+fn per_session_blockers_stack_in_a_fixed_order() {
+    let mut facts = clean_preflight_facts();
+    facts.sessions = vec![PreflightSessionFacts {
+        session_id: "session-1".to_string(),
+        status: "running".to_string(),
+        agent_kind: "cursor".to_string(),
+        supported: false,
+        unsupported_reason: Some("Unsupported agent kind for workspace mobility v1".to_string()),
+        awaiting_interaction: true,
+        has_pending_prompts: true,
+    }];
+
+    let assessment = assess_mobility_preflight(&facts);
+
+    assert_eq!(
+        codes(&assessment.blockers),
+        vec![
+            "session_running",
+            "session_awaiting_interaction",
+            "pending_prompt",
+            "unsupported_session",
+        ]
+    );
+    assert_eq!(
+        assessment.blockers[3].message,
+        "Session session-1 (cursor) cannot move because Unsupported agent kind for workspace mobility v1"
+    );
+}
+
+#[test]
+fn an_unsupported_session_without_a_reason_falls_back_to_generic_text() {
+    let mut facts = clean_preflight_facts();
+    let mut session = idle_session("session-1");
+    session.agent_kind = "cursor".to_string();
+    session.supported = false;
+    session.unsupported_reason = None;
+    facts.sessions = vec![session];
+
+    let assessment = assess_mobility_preflight(&facts);
+
+    assert_eq!(codes(&assessment.blockers), vec!["unsupported_session"]);
+    assert_eq!(
+        assessment.blockers[0].message,
+        "Session session-1 (cursor) cannot move because it is unsupported"
+    );
+}
+
+#[test]
+fn a_partial_subagent_graph_blocks_per_missing_session() {
+    let mut facts = clean_preflight_facts();
+    facts.partial_subagent_graph_session_ids = vec!["child-1".to_string()];
+
+    let assessment = assess_mobility_preflight(&facts);
+
+    assert_eq!(codes(&assessment.blockers), vec!["partial_subagent_graph"]);
+    assert_eq!(
+        assessment.blockers[0].session_id.as_deref(),
+        Some("child-1")
+    );
+    assert_eq!(
+        assessment.blockers[0].message,
+        "Session graph includes linked subagent session child-1 outside this archive"
+    );
+}
+
+#[test]
+fn blocker_order_is_workspace_then_review_then_session_then_graph() {
+    // The whole matrix at once: the emitted order is user-visible (it is
+    // serialized straight to the API), so it is pinned here.
+    let mut facts = clean_preflight_facts();
+    facts.workspace_kind = WorkspaceKind::Local;
+    facts.runtime_mode = WorkspaceAccessMode::RemoteOwned;
+    facts.branch_name = Some("main".to_string());
+    facts.default_branch = DefaultBranchFact::Resolved("main".to_string());
+    facts.setup_running = true;
+    facts.git_status = PreflightGitStatus::Inspected {
+        detached: false,
+        operation_in_progress: false,
+        conflicted: false,
+        clean: false,
+    };
+    facts.active_terminal_ids = vec!["terminal-1".to_string()];
+    facts.active_review_runs = vec![PreflightReviewRun {
+        run_id: "run-1".to_string(),
+        parent_session_id: "session-1".to_string(),
+    }];
+    let mut session = idle_session("session-1");
+    session.status = "running".to_string();
+    facts.sessions = vec![session];
+    facts.partial_subagent_graph_session_ids = vec!["child-1".to_string()];
+
+    let assessment = assess_mobility_preflight(&facts);
+
+    assert_eq!(
+        codes(&assessment.blockers),
+        vec![
+            "workspace_not_mutable",
+            "setup_running",
+            "workspace_dirty",
+            "local_default_branch_in_use",
+            "review_active",
+            "session_running",
+            "partial_subagent_graph",
+        ]
+    );
+    assert_eq!(assessment.warnings.len(), 1);
+}
+
+// --- destroy source --------------------------------------------------------
+
+#[test]
+fn worktree_destruction_closes_active_terminals_and_deletes_every_session() {
+    let facts = SourceDestructionFacts {
+        workspace_kind: WorkspaceKind::Worktree,
+        default_branch: DefaultBranchFact::NotRequired,
+        terminals: vec![
+            TerminalFact {
+                terminal_id: "terminal-running".to_string(),
+                status: TerminalStatus::Running,
+            },
+            TerminalFact {
+                terminal_id: "terminal-exited".to_string(),
+                status: TerminalStatus::Exited,
+            },
+            TerminalFact {
+                terminal_id: "terminal-starting".to_string(),
+                status: TerminalStatus::Starting,
+            },
+        ],
+        session_ids: vec!["session-1".to_string(), "session-2".to_string()],
+    };
+
+    let plan = plan_source_destruction(&facts).expect("worktree destruction needs no branch");
+
+    assert_eq!(
+        plan.close_terminal_ids,
+        vec![
+            "terminal-running".to_string(),
+            "terminal-starting".to_string()
+        ]
+    );
+    assert_eq!(
+        plan.delete_session_ids,
+        vec!["session-1".to_string(), "session-2".to_string()]
+    );
+    assert!(matches!(
+        plan.materialization,
+        MaterializationDestruction::RemoveWorktree
+    ));
+    assert_eq!(plan.materialization.default_branch(), None);
+}
+
+#[test]
+fn local_destruction_parks_onto_the_resolved_default_branch() {
+    let facts = SourceDestructionFacts {
+        workspace_kind: WorkspaceKind::Local,
+        default_branch: DefaultBranchFact::Resolved("main".to_string()),
+        terminals: Vec::new(),
+        session_ids: Vec::new(),
+    };
+
+    let plan = plan_source_destruction(&facts).expect("resolved branch parks");
+
+    assert!(matches!(
+        plan.materialization,
+        MaterializationDestruction::ParkLocalOnDefaultBranch { .. }
+    ));
+    assert_eq!(plan.materialization.default_branch(), Some("main"));
+}
+
+#[test]
+fn local_destruction_is_rejected_before_any_effect_without_a_default_branch() {
+    // The pre-restructure order discovered this only after the terminals were
+    // closed and every session deleted. Now it is a precondition on the plan.
+    for default_branch in [
+        DefaultBranchFact::Unresolved,
+        DefaultBranchFact::NotRequired,
+        DefaultBranchFact::Resolved("   ".to_string()),
+    ] {
+        let facts = SourceDestructionFacts {
+            workspace_kind: WorkspaceKind::Local,
+            default_branch,
+            terminals: vec![TerminalFact {
+                terminal_id: "terminal-1".to_string(),
+                status: TerminalStatus::Running,
+            }],
+            session_ids: vec!["session-1".to_string()],
+        };
+
+        let rejection =
+            plan_source_destruction(&facts).expect_err("a local park needs a default branch");
+
+        assert_eq!(
+            rejection,
+            SourceDestructionRejection::MissingLocalDefaultBranch
+        );
+    }
+}
+
+#[test]
+fn destruction_of_an_empty_workspace_is_an_empty_plan_not_an_error() {
+    let facts = SourceDestructionFacts {
+        workspace_kind: WorkspaceKind::Worktree,
+        default_branch: DefaultBranchFact::NotRequired,
+        terminals: Vec::new(),
+        session_ids: Vec::new(),
+    };
+
+    let plan = plan_source_destruction(&facts).expect("empty workspace still destroys");
+
+    assert!(plan.close_terminal_ids.is_empty());
+    assert!(plan.delete_session_ids.is_empty());
+}

--- a/anyharness/crates/anyharness-lib/src/domains/mobility/runtime/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/mobility/runtime/mod.rs
@@ -9,6 +9,13 @@
 //! Direction is one-way: the runtime wraps the service and delegates down
 //! (preflight calls `export_workspace_archive` for its size estimate), never
 //! the reverse.
+//!
+//! Each use case here reads as one pipeline: resolve every fact, hand them to
+//! `mobility_policy` for the decision, then execute. `mobility_policy.rs` is the
+//! single decision home for the live mobility use cases; the durable export
+//! path's own pure rules stay next to it in `service.rs` (the runtime cannot
+//! move them without inverting the direction above), and the policy delegates
+//! to them rather than restating them.
 
 use std::sync::Arc;
 
@@ -21,13 +28,16 @@ use crate::domains::reviews::store::ReviewStore;
 use crate::domains::sessions::runtime::SessionRuntime;
 use crate::domains::sessions::service::SessionService;
 use crate::domains::sessions::subagents::service::SubagentService;
-use crate::domains::terminals::model::{TerminalRecord, TerminalStatus};
+use crate::domains::terminals::model::TerminalRecord;
 use crate::domains::workspaces::access_gate::WorkspaceAccessGate;
 use crate::domains::workspaces::runtime::WorkspaceRuntime;
 use crate::live::terminals::TerminalService;
 
 mod destroy_source;
 mod install;
+mod mobility_policy;
+#[cfg(test)]
+mod mobility_policy_tests;
 mod preflight;
 mod prepare_destination;
 
@@ -86,7 +96,7 @@ impl MobilityRuntime {
             .list_terminals(workspace_id)
             .await
             .into_iter()
-            .filter(is_active_terminal)
+            .filter(mobility_policy::terminal_is_active)
             .collect()
     }
 
@@ -94,14 +104,7 @@ impl MobilityRuntime {
         self.terminal_service
             .list_terminals_blocking(workspace_id)
             .into_iter()
-            .filter(is_active_terminal)
+            .filter(mobility_policy::terminal_is_active)
             .collect()
     }
-}
-
-fn is_active_terminal(terminal: &TerminalRecord) -> bool {
-    matches!(
-        terminal.status,
-        TerminalStatus::Starting | TerminalStatus::Running
-    )
 }

--- a/anyharness/crates/anyharness-lib/src/domains/mobility/runtime/preflight.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/mobility/runtime/preflight.rs
@@ -4,24 +4,40 @@
 //! terminals are open, and reaches live session execution state through
 //! `SessionRuntime`. Delegates the archive size estimate down to the durable
 //! service.
+//!
+//! Pipeline: one resolve pass gathers every fact (store rows, git inspection,
+//! live probes) → `mobility_policy::assess_mobility_preflight` decides the
+//! blocker/warning matrix → the only remaining effect is the archive-size
+//! estimate, which is gated on that verdict and re-decided by
+//! `mobility_policy::archive_size_blocker`. Preflight has no compensations: it
+//! is a read-only assessment, the archive export writes nothing.
+//!
+//! The size estimate is deliberately still last. It is the one expensive fetch
+//! (it exports a whole archive), it is skipped entirely when anything else
+//! already blocks the move, and it is a fetch whose own result feeds a further
+//! decision — the doctrine's "effects that change facts force a re-resolve"
+//! rule, minus the effect.
 
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::time::Instant;
 
+use super::mobility_policy::{
+    archive_size_blocker, assess_mobility_preflight, classify_session_support, movable_session_ids,
+    workspace_can_move, DefaultBranchFact, PreflightFacts, PreflightGitStatus, PreflightReviewRun,
+    PreflightSessionFacts,
+};
 use super::MobilityRuntime;
 use crate::adapters::git::executor::run_git_ok;
 use crate::adapters::git::types::GitOperation;
 use crate::adapters::git::GitService;
 use crate::domains::mobility::model::{
-    MobilityBlocker, MobilitySessionCandidate, WorkspaceMobilityExportOptions,
-    WorkspaceMobilityPreflightResult, MAX_MOBILITY_ARCHIVE_BODY_BYTES,
+    MobilitySessionCandidate, WorkspaceMobilityExportOptions, WorkspaceMobilityPreflightResult,
 };
 use crate::domains::mobility::service::{
-    archive_estimated_size_bytes, is_supported_agent_kind, map_access_error, MobilityError,
+    archive_estimated_size_bytes, map_access_error, MobilityError,
 };
 use crate::domains::mobility::workspace_delta::current_branch_name;
-use crate::domains::workspaces::access_model::WorkspaceAccessMode;
 use crate::domains::workspaces::model::WorkspaceKind;
 
 impl MobilityRuntime {
@@ -31,6 +47,8 @@ impl MobilityRuntime {
         exclude_paths: &[String],
     ) -> Result<WorkspaceMobilityPreflightResult, MobilityError> {
         let started = Instant::now();
+
+        // --- resolve -------------------------------------------------------
         let workspace = self.mobility_service.load_workspace(workspace_id)?;
         let runtime_state = self
             .access_gate
@@ -57,30 +75,15 @@ impl MobilityRuntime {
             .session_service
             .list_sessions(Some(workspace_id), true)?
             .into_iter()
-            .map(|session| MobilitySessionCandidate {
-                supported: is_supported_agent_kind(&session.agent_kind),
-                reason: if is_supported_agent_kind(&session.agent_kind) {
-                    None
-                } else {
-                    Some("Unsupported agent kind for workspace mobility v1".to_string())
-                },
-                session,
+            .map(|session| {
+                let support = classify_session_support(&session.agent_kind);
+                MobilitySessionCandidate {
+                    supported: support.supported,
+                    reason: support.reason,
+                    session,
+                }
             })
             .collect::<Vec<_>>();
-
-        let mut blockers = Vec::new();
-        let mut warnings = Vec::new();
-
-        if runtime_state.mode != WorkspaceAccessMode::Normal {
-            blockers.push(MobilityBlocker {
-                code: "workspace_not_mutable".to_string(),
-                message: format!(
-                    "Workspace is currently in {} mode",
-                    runtime_state.mode.as_str()
-                ),
-                session_id: None,
-            });
-        }
 
         let default_branch = if workspace.kind == WorkspaceKind::Local {
             let repo_root_id = workspace.repo_root_id.clone();
@@ -88,169 +91,89 @@ impl MobilityRuntime {
                 .workspace_runtime
                 .resolve_repo_root_default_branch(&repo_root_id)
             {
-                Ok(branch) => Some(branch),
-                Err(_) => {
-                    blockers.push(MobilityBlocker {
-                        code: "default_branch_unknown".to_string(),
-                        message: ("Main local workspaces require a resolved repo default branch "
-                            .to_string()),
-                        session_id: None,
-                    });
-                    None
-                }
+                Ok(branch) => DefaultBranchFact::Resolved(branch),
+                Err(_) => DefaultBranchFact::Unresolved,
             }
         } else {
-            None
+            DefaultBranchFact::NotRequired
         };
 
-        if self.terminal_service.is_setup_running(workspace_id).await {
-            blockers.push(MobilityBlocker {
-                code: "setup_running".to_string(),
-                message: "Workspace setup is still running".to_string(),
-                session_id: None,
-            });
-        }
+        let setup_running = self.terminal_service.is_setup_running(workspace_id).await;
 
-        match GitService::status(workspace_id, &workspace_path) {
-            Ok(status) => {
-                if status.detached {
-                    blockers.push(MobilityBlocker {
-                        code: "workspace_detached".to_string(),
-                        message: "Workspace must be on a branch before moving".to_string(),
-                        session_id: None,
-                    });
-                }
-                if status.operation != GitOperation::None {
-                    blockers.push(MobilityBlocker {
-                        code: "git_operation_in_progress".to_string(),
-                        message: "Finish the current Git operation before moving".to_string(),
-                        session_id: None,
-                    });
-                }
-                if status.conflicted {
-                    blockers.push(MobilityBlocker {
-                        code: "workspace_conflicted".to_string(),
-                        message: "Resolve Git conflicts before moving".to_string(),
-                        session_id: None,
-                    });
-                }
-                if !status.clean {
-                    blockers.push(MobilityBlocker {
-                        code: "workspace_dirty".to_string(),
-                        message: "Workspace must be committed and clean before moving".to_string(),
-                        session_id: None,
-                    });
-                }
-            }
-            Err(error) => blockers.push(MobilityBlocker {
-                code: "workspace_status_unknown".to_string(),
-                message: format!("Unable to inspect workspace status: {error}"),
-                session_id: None,
-            }),
-        }
+        let git_status = match GitService::status(workspace_id, &workspace_path) {
+            Ok(status) => PreflightGitStatus::Inspected {
+                detached: status.detached,
+                operation_in_progress: status.operation != GitOperation::None,
+                conflicted: status.conflicted,
+                clean: status.clean,
+            },
+            Err(error) => PreflightGitStatus::Unavailable {
+                error: error.to_string(),
+            },
+        };
 
-        if workspace.kind == WorkspaceKind::Local {
-            if let (Some(current_branch), Some(default_branch)) =
-                (branch_name.as_deref(), default_branch.as_deref())
-            {
-                if current_branch == default_branch {
-                    blockers.push(MobilityBlocker {
-                        code: "local_default_branch_in_use".to_string(),
-                        message: format!(
-                            "Main local workspaces on '{default_branch}' must move from a worktree instead"
-                        ),
-                        session_id: None,
-                    });
-                }
-            }
-        }
+        let active_terminal_ids = self
+            .active_terminals_async(workspace_id)
+            .await
+            .into_iter()
+            .map(|terminal| terminal.id)
+            .collect::<Vec<_>>();
 
-        for terminal in self.active_terminals_async(workspace_id).await {
-            warnings.push(format!(
-                "Terminal {} will be force-closed after the move commits",
-                terminal.id
-            ));
-        }
-
-        for run in self
+        let active_review_runs = self
             .review_store
             .list_active_runs_for_workspace(workspace_id)?
-        {
-            blockers.push(MobilityBlocker {
-                code: "review_active".to_string(),
-                message: format!("Review run {} is still active", run.id),
-                session_id: Some(run.parent_session_id),
-            });
-        }
+            .into_iter()
+            .map(|run| PreflightReviewRun {
+                run_id: run.id,
+                parent_session_id: run.parent_session_id,
+            })
+            .collect::<Vec<_>>();
 
+        let mut session_facts = Vec::with_capacity(sessions.len());
         for candidate in &sessions {
-            if matches!(candidate.session.status.as_str(), "starting" | "running") {
-                blockers.push(MobilityBlocker {
-                    code: "session_running".to_string(),
-                    message: format!("Session {} is still active", candidate.session.id),
-                    session_id: Some(candidate.session.id.clone()),
-                });
-            }
-
             let execution_summary = self
                 .session_runtime
                 .session_execution_summary(&candidate.session)
                 .await;
-            if !execution_summary.pending_interactions.is_empty() {
-                blockers.push(MobilityBlocker {
-                    code: "session_awaiting_interaction".to_string(),
-                    message: format!("Session {} is awaiting interaction", candidate.session.id),
-                    session_id: Some(candidate.session.id.clone()),
-                });
-            }
-
-            if !self
+            let has_pending_prompts = !self
                 .session_service
                 .store()
                 .list_pending_prompts(&candidate.session.id)?
-                .is_empty()
-            {
-                blockers.push(MobilityBlocker {
-                    code: "pending_prompt".to_string(),
-                    message: format!("Session {} has pending prompts", candidate.session.id),
-                    session_id: Some(candidate.session.id.clone()),
-                });
-            }
-
-            if !candidate.supported {
-                blockers.push(MobilityBlocker {
-                    code: "unsupported_session".to_string(),
-                    message: format!(
-                        "Session {} ({}) cannot move because {}",
-                        candidate.session.id,
-                        candidate.session.agent_kind,
-                        candidate
-                            .reason
-                            .clone()
-                            .unwrap_or_else(|| "it is unsupported".to_string())
-                    ),
-                    session_id: Some(candidate.session.id.clone()),
-                });
-            }
+                .is_empty();
+            session_facts.push(PreflightSessionFacts {
+                session_id: candidate.session.id.clone(),
+                status: candidate.session.status.clone(),
+                agent_kind: candidate.session.agent_kind.clone(),
+                supported: candidate.supported,
+                unsupported_reason: candidate.reason.clone(),
+                awaiting_interaction: !execution_summary.pending_interactions.is_empty(),
+                has_pending_prompts,
+            });
         }
-        let session_ids = sessions
-            .iter()
-            .filter(|candidate| candidate.supported)
-            .map(|candidate| candidate.session.id.clone())
+
+        let movable_ids = movable_session_ids(&session_facts)
+            .into_iter()
             .collect::<HashSet<_>>();
         let (_links, _completions, _wake_schedules, partial_graph) = self
             .subagent_service
-            .mobility_graph_for_sessions(&session_ids)
+            .mobility_graph_for_sessions(&movable_ids)
             .map_err(MobilityError::Internal)?;
-        for missing_id in partial_graph {
-            blockers.push(MobilityBlocker {
-                code: "partial_subagent_graph".to_string(),
-                message: format!(
-                    "Session graph includes linked subagent session {missing_id} outside this archive"
-                ),
-                session_id: Some(missing_id),
-            });
-        }
+
+        // --- decide --------------------------------------------------------
+        let assessment = assess_mobility_preflight(&PreflightFacts {
+            workspace_kind: workspace.kind,
+            runtime_mode: runtime_state.mode,
+            branch_name: branch_name.clone(),
+            default_branch,
+            setup_running,
+            git_status,
+            active_terminal_ids,
+            active_review_runs,
+            sessions: session_facts,
+            partial_subagent_graph_session_ids: partial_graph,
+        });
+        let mut blockers = assessment.blockers;
+        let warnings = assessment.warnings;
         tracing::info!(
             workspace_id = %workspace_id,
             session_count = sessions.len(),
@@ -260,7 +183,8 @@ impl MobilityRuntime {
             "[workspace-latency] mobility.preflight.validation_complete"
         );
 
-        let archive_estimated_bytes = if blockers.is_empty() {
+        // --- resolve the size estimate, then decide over it -----------------
+        let archive_estimated_bytes = if workspace_can_move(&blockers) {
             let archive_started = Instant::now();
             tracing::info!(
                 workspace_id = %workspace_id,
@@ -275,16 +199,7 @@ impl MobilityRuntime {
                 },
             )?;
             let size = archive_estimated_size_bytes(&archive);
-            if size > MAX_MOBILITY_ARCHIVE_BODY_BYTES as u64 {
-                blockers.push(MobilityBlocker {
-                    code: "archive_too_large".to_string(),
-                    message: format!(
-                        "Archive exceeds the {} byte limit",
-                        MAX_MOBILITY_ARCHIVE_BODY_BYTES
-                    ),
-                    session_id: None,
-                });
-            }
+            blockers.extend(archive_size_blocker(size));
             tracing::info!(
                 workspace_id = %workspace_id,
                 archive_estimated_bytes = size,
@@ -296,7 +211,7 @@ impl MobilityRuntime {
             None
         };
 
-        let can_move = blockers.is_empty();
+        let can_move = workspace_can_move(&blockers);
         tracing::info!(
             workspace_id = %workspace_id,
             can_move = can_move,


### PR DESCRIPTION
## What

Grid PR 6b: restructure the two live mobility use cases into the doctrine's
**resolve → decide → execute** pipeline, and move every decision out of the
effect path into a new pure policy file. Closes backlog violation #1, part 2
(`anyharness-structure.md` line 294).

Before this PR both use cases interleaved fetch and act: `preflight_workspace`
pushed blockers into a `Vec` between store reads, git inspections and live
probes; `destroy_source_workspace` closed terminals and deleted sessions and
then handed a maybe-`None` default branch to the materialization call. After it,
each use case reads as one pass of facts, one call into policy, one ordered
sequence of effects.

## The restructure, per use case

### `preflight_workspace` (321 → 236 lines)

One resolve pass gathers everything the assessment branches on — workspace
record, runtime state, repo root, base commit, branch name, session candidates,
repo default branch, setup-running probe, git status, active terminals, active
review runs, per-session execution summary and pending prompts, subagent graph —
and hands it to `assess_mobility_preflight(&PreflightFacts)`, which returns the
whole blocker/warning matrix.

A failed git inspection is now modelled as a **fact**
(`PreflightGitStatus::Unavailable`) rather than a branch inside the pipeline;
likewise an unresolvable default branch (`DefaultBranchFact::Unresolved`). Both
previously pushed their blocker from inside the resolve step. Policy now decides
them.

The archive-size estimate is deliberately still last, after the assessment. It
is the one expensive fetch (it exports an entire archive), it is skipped
whenever anything else already blocks the move, and its own result feeds a
further decision (`archive_size_blocker`). That is the doctrine's
"effects that change facts force a re-resolve" shape, minus the effect. Moving
it into the resolve pass would export an archive on every blocked preflight.

### `destroy_source_workspace` (63 → 164 lines)

Resolve the workspace record, the repo default branch (`Local` only), every live
terminal, and every session row. Then `plan_source_destruction` returns a
`SourceDestructionPlan` — which terminals to close, which sessions to delete,
and how the materialization goes away — or rejects the call. Then the three
effects run in plan order.

The plan carries **ids only**. The `SessionRecord`s it names are resolved back
from the already-loaded rows *before the first deletion*, so a plan naming an
unknown session errors with nothing half-deleted rather than silently skipping
it. Capabilities (`terminal_service`, `workspace_runtime`, `session_runtime`)
stay on `&self` beside the plan, never inside it.

**There is no compensation slot, on purpose.** Force-closing a terminal,
deleting a session row and its agent artifacts, and removing a worktree are all
irreversible — a mid-sequence failure cannot be rolled back, so inventing a
compensation would be a lie. Instead the plan is ordered cheapest-to-recover
first (terminals, which the user can simply reopen) and each failure branch logs
the partial progress (`closed_terminal_count`, `deleted_session_count`) before
propagating. The caller holds an exclusive workspace lease across the whole call
(`WORKSPACE-FENCE-01/02`), so no concurrent writer can invalidate the resolved
facts between decide and execute.

### `runtime/mod.rs`

The local `fn is_active_terminal` is gone; both gather helpers now filter on
`mobility_policy::terminal_is_active`, so the terminal-activity rule has exactly
one home and `destroy_source` decides over the same predicate.

## Policy-home decision

The brief asked for a deliberate choice, since PR 6a left pure free fns with
tests in `mobility/service.rs`. **`mobility_policy.rs` is the single decision
home for the live mobility use cases.** It does not become a second home for the
domain:

- **Delegates, does not absorb:** `classify_session_support` calls
  `service::is_supported_agent_kind` rather than restating the predicate. That
  predicate also gates which sessions enter the durable export bundle, so
  preflight and export must get exactly one answer. The policy owns only the
  *surfaced reason* text, which is preflight's concern alone.
- **Leaves the durable rules where they are:** `service.rs` keeps
  `validate_expected_handoff_runtime_state`,
  `classify_existing_archive_session_for_relocation`, `validate_archive_size`
  and `archive_estimated_size_bytes`. Those belong to the durable export/import
  use cases. Pulling them into a file under `runtime/` would invert the one-way
  runtime → service direction PR 6a established (the runtime wraps the service;
  the service must not depend on a runtime file).

So the split is by **use case owner**, not by purity: pure decisions belonging
to a live use case live in `runtime/mobility_policy.rs`; pure decisions
belonging to a durable use case stay beside that use case in `service.rs`. The
rule is recorded in the `runtime/mod.rs` module doc so the next reader does not
have to re-derive it.

`service.rs` is **untouched** — still exactly 851 lines, matching its exact pin.

## Failure semantics: before vs after

Two orderings changed, both moving failure ahead of effects (rows 1 and 3);
no effect moved ahead of any check. Stated per effect, per step:

| Step | Before | After |
| --- | --- | --- |
| **destroy-source: `Local` workspace with no usable default branch** | Terminals force-closed → every session and its agent artifacts deleted → *then* `destroy_source_workspace_materialization` raises `default branch is required to park a local workspace` → HTTP 500. User is left with an unparked workspace, closed terminals and **permanently deleted sessions**, and a retry cannot restore them. | `plan_source_destruction` rejects during decide. **Same message, same `MobilityError::Internal`, same HTTP 500** — but zero terminals closed and zero sessions deleted. The workspace is exactly as it was and a retry is meaningful. |
| **destroy-source: terminal close fails** | `?` propagates `MobilityError::Internal`; earlier terminals stay closed; no session deleted; materialization untouched. | Identical outcome and identical error. Added: a `tracing::error!` recording how many terminals had closed, and the explicit note that no session was deleted. |
| **destroy-source: session delete / artifact cleanup fails** | `?` propagates; all terminals already closed; earlier sessions already deleted; materialization untouched. | Identical outcome and identical error. Added: structured logging of `closed_terminal_count` / `deleted_session_count`. Also defensive scaffolding: if a plan ever named a session not in the loaded set, that errors *before* the first delete — currently unreachable (the plan's ids are built from the same loaded vec), it exists to fail closed if the plan and the load ever diverge. |
| **destroy-source: session-list resolution fails** | `list_by_workspace` ran *after* the terminal closes, so a session-list failure left terminals already closed. | The list is resolved up front (resolve-before-decide), so the same failure now aborts before any terminal closes — a second small ordering improvement in the same safe direction as the first row. |
| **destroy-source: materialization destroy fails** | `?` propagates; terminals closed and sessions deleted. | Identical outcome and identical error, plus the same structured log. |
| **destroy-source: default-branch *resolution* fails (`Local`)** | `resolve_repo_root_default_branch` error propagates before any effect. | Unchanged — still propagates before any effect, still `MobilityError::Internal`. |
| **preflight: any blocker** | Blockers accumulated inline, in pipeline order. | Same codes, same messages, same `session_id`s, **same order**. The order is user-visible (serialized straight through the API), so it is reproduced exactly and now pinned by `blocker_order_is_workspace_then_review_then_session_then_graph`. |
| **preflight: fallible resolve steps (`load_workspace`, `runtime_state`, `resolve_repo_root`, `rev-parse HEAD`, `current_branch_name`, `list_sessions`, `list_active_runs_for_workspace`, `list_pending_prompts`, `mobility_graph_for_sessions`, `export_workspace_archive`)** | Each `?`/`map_err` aborts preflight with its own error. | Identical error surfaces, and identical relative order — every one of these still runs in the same sequence, so a workspace that failed at a given step before fails at the same step with the same error now. Preflight has no effects, so there is nothing to compensate either way. |
| **preflight: archive too large** | Estimate runs only when `blockers.is_empty()`; the size blocker is appended after. | Unchanged, via `workspace_can_move` + `archive_size_blocker`. Still one export, still skipped when anything else blocks. |

The behaviour changes are the first two rows, both in the same direction:
an irrecoverable partial teardown becomes a clean rejection (identical error
message), and a resolution failure aborts before effects instead of between
them. Nothing else in either use case changes what a caller observes.

## Test inventory

`runtime/mobility_policy_tests.rs` — 26 tests, hand-built facts, no DB, no
mocks, in the `launch_policy.rs` style (builders `clean_preflight_facts()`,
`idle_session()`, `codes()`).

| Policy fn | Decision it makes | Tests |
| --- | --- | --- |
| `terminal_status_is_active` / `terminal_is_active` | which terminals still own a process | 1 |
| `classify_session_support` | can mobility v1 carry this agent kind, and why not | 2 |
| `movable_session_ids` | which sessions enter the archive | 1 |
| `workspace_can_move` | is the move allowed at all | 1 |
| `archive_size_blocker` | is the measured archive over the limit | 1 |
| `assess_mobility_preflight` | the whole blocker/warning matrix and its order | 15 |
| `plan_source_destruction` | the destroy-source effect sequence, and its precondition | 4 |
| `MaterializationDestruction::default_branch` | the argument the materialization call receives | covered by the 4 above |

The 15 `assess_mobility_preflight` tests cover: the clean case, non-normal
runtime mode, unresolved local default branch, local-on-default-branch, local on
a side branch, a worktree whose branch merely shares the default name, running
setup, all four dirty-git conditions in order, unavailable git status, terminals
warning without blocking, review runs naming their parent session, running
sessions, per-session blocker stacking order, the generic-reason fallback, and a
partial subagent graph. Plus the cross-cutting order test.

## Gates

All run on the final tree, in this worktree.

| Gate | Result |
| --- | --- |
| `check_anyharness_boundaries.py` | `AnyHarness boundary check passed.` exit 0 |
| `python3 -m unittest scripts.test_check_anyharness_boundaries` | `Ran 90 tests` — `OK` |
| `check_max_lines.py` | `Max-lines check passed (repo max 600, component max 500, server layer maxes enabled).` |
| `cargo check -p anyharness-lib` | `Finished dev profile` — zero warnings naming any mobility file |
| `cargo test -p anyharness-lib mobility` | `test result: ok. 41 passed; 0 failed` |

**No allowlist row, max-lines pin, or boundary anchor moved.** `service.rs` is
untouched at 851 lines so its exact pin still matches; the two new files are 416
and 527 lines (both under 600); the policy file is genuinely pure so it needs no
`POLICY_PURITY` row; and the existing anchors pointing at
`domains/mobility/service.rs` and `domains/mobility/runtime/mod.rs` still
reference real lines on the correct side of the valve rule. The anchor suite
stays at exactly 90 tests. `.github/workflows/ci.yml` is untouched, and no
`Cargo.lock` change is committed.

### Negative controls

Both were required and both fired.

**1. Invert a policy decision.** Replaced `if default_branch.is_empty()` with
`if false` in `plan_source_destruction`, so a `Local` workspace with no default
branch produces a plan instead of a rejection:

```
thread '...local_destruction_is_rejected_before_any_effect_without_a_default_branch'
panicked at .../mobility_policy_tests.rs:505:45:
a local park needs a default branch: SourceDestructionPlan {
  close_terminal_ids: ["terminal-1"], delete_session_ids: ["session-1"],
  materialization: ParkLocalOnDefaultBranch { default_branch: "" } }

test result: FAILED. 25 passed; 1 failed; 0 ignored; 0 measured; 1488 filtered out
```

Exactly the one predicted test, with the predicted assertion. The payload also
shows precisely what the old code did: it would have closed `terminal-1`,
deleted `session-1`, and only then tried to park onto `""`. Restored →
`test result: ok. 41 passed; 0 failed`.

**2. Confirm `POLICY_PURITY` polices this file.** Added `let _ =
chrono::Utc::now();` to `workspace_can_move`:

```
POLICY_PURITY .../domains/mobility/runtime/mobility_policy.rs: 1 unallowlisted

AnyHarness boundary violations not covered by allowlist:
anyharness/crates/anyharness-lib/src/domains/mobility/runtime/mobility_policy.rs:63: [POLICY_PURITY] policy files are pure: facts in, decisions out — no clock, no ids, no store; mint in execute
BOUNDARIES_EXIT=1
```

Exit 1, naming the file and the exact line. Reverted →
`AnyHarness boundary check passed. BOUNDARIES_EXIT=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

