### PR TITLE
fix(product): synchronize workspace panel chrome

### DIFF
--- a/apps/desktop/src-tauri/src/commands/window_chrome.rs
+++ b/apps/desktop/src-tauri/src/commands/window_chrome.rs
@@ -1,5 +1,6 @@
 const MAC_TRAFFIC_LIGHT_X: f64 = 13.0;
-const MAC_HEADER_HEIGHT: f64 = 40.0;
+// Matches the shared workspace header and right-panel tab-system height.
+const MAC_HEADER_HEIGHT: f64 = 46.0;
 
 #[tauri::command]
 pub fn apply_macos_window_chrome(window: tauri::Window) -> Result<(), String> {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -28,7 +28,7 @@
         "transparent": true,
         "trafficLightPosition": {
           "x": 13,
-          "y": 14
+          "y": 16
         }
       }
     ],

--- a/apps/desktop/src-tauri/tauri.dev.json
+++ b/apps/desktop/src-tauri/tauri.dev.json
@@ -16,7 +16,7 @@
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "transparent": true,
-        "trafficLightPosition": { "x": 13, "y": 14 }
+        "trafficLightPosition": { "x": 13, "y": 16 }
       }
     ]
   },

--- a/apps/packages/product-client/src/app/authenticated-workspace-shell-motion.test.ts
+++ b/apps/packages/product-client/src/app/authenticated-workspace-shell-motion.test.ts
@@ -1,0 +1,19 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+const stylesheetPath = new URL("./authenticated.css", import.meta.url);
+
+describe("authenticated workspace shell motion", () => {
+  it("registers synchronized length variables and uses reduced-motion-aware roles", async () => {
+    const stylesheet = await readFile(stylesheetPath, "utf8");
+
+    expect(stylesheet).toContain("@property --workspace-left-width");
+    expect(stylesheet).toContain("@property --workspace-right-width");
+    expect(stylesheet).toContain("syntax: \"<length>\"");
+    expect(stylesheet).toContain("transition-property: --workspace-left-width, --workspace-right-width");
+    expect(stylesheet).toContain("var(--duration-panel)");
+    expect(stylesheet).toContain("var(--ease-out-cubic)");
+    expect(stylesheet).toContain("[data-snap-left-geometry=\"true\"]");
+    expect(stylesheet).toContain("[data-manual-workspace-geometry=\"true\"]");
+  });
+});

--- a/apps/packages/product-client/src/app/authenticated.css
+++ b/apps/packages/product-client/src/app/authenticated.css
@@ -1,6 +1,33 @@
 /* Authenticated-only interaction styles stay behind the lazy product boundary
  * so chat affordances do not consume the public login shell's CSS budget. */
 
+@property --workspace-left-width {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 0px;
+}
+
+@property --workspace-right-width {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 0px;
+}
+
+.standard-workspace-shell {
+  --workspace-left-geometry-duration: var(--duration-panel);
+  transition-property: --workspace-left-width, --workspace-right-width;
+  transition-duration: var(--workspace-left-geometry-duration), var(--duration-panel);
+  transition-timing-function: var(--ease-out-cubic), var(--ease-out-cubic);
+}
+
+.standard-workspace-shell[data-snap-left-geometry="true"] {
+  --workspace-left-geometry-duration: 0ms;
+}
+
+.standard-workspace-shell[data-manual-workspace-geometry="true"] {
+  transition: none;
+}
+
 /* Transcript Markdown owns one scoped semantic type contract. The body scale
    comes from its surrounding message (or the secondary-chat fallback), while
    the hierarchy derives from runtime appearance tokens instead of frozen px

--- a/apps/packages/product-client/src/components/app/chrome/MacWindowControlsSafeArea.tsx
+++ b/apps/packages/product-client/src/components/app/chrome/MacWindowControlsSafeArea.tsx
@@ -37,7 +37,7 @@ export function MacWindowControlsSafeArea() {
   return (
     <div
       aria-hidden="true"
-      className="app-region-no-drag fixed left-0 top-0 z-top h-10 w-[82px]"
+      className="app-region-no-drag fixed left-0 top-0 z-top h-[46px] w-[82px]"
       data-tauri-window-controls-safe-area
     />
   );

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx
@@ -135,7 +135,7 @@ export function HomeNextScreen() {
         : null;
   return (
     <div className="relative flex h-full w-full min-w-0 flex-1 overflow-hidden bg-background text-foreground" data-telemetry-block>
-      <div className="absolute inset-x-0 top-0 h-10" data-tauri-drag-region="true" />
+      <div className="absolute inset-x-0 top-0 h-[46px]" data-tauri-drag-region="true" />
       <main className="flex min-h-0 flex-1 flex-col overflow-y-auto">
         <div className={`flex min-h-0 flex-1 basis-0 items-end justify-center pb-24 ${CHAT_SURFACE_GUTTER_CLASSNAME}`}>
           <div className="relative mx-auto w-full max-w-transcript-thread">

--- a/apps/packages/product-client/src/components/settings/screen/SettingsScreen.tsx
+++ b/apps/packages/product-client/src/components/settings/screen/SettingsScreen.tsx
@@ -140,7 +140,7 @@ export function SettingsScreen({
     <div className="flex h-screen flex-col bg-background text-foreground" data-telemetry-block>
       <header className="shrink-0 border-b border-border">
         <div
-          className={`flex h-10 items-center gap-2 pr-3 ${
+          className={`flex h-[46px] items-center gap-2 pr-3 ${
             macWindowControlsInsetClass || "pl-3"
           }`}
           data-tauri-drag-region="true"

--- a/apps/packages/product-client/src/components/workspace/cowork/CoworkWorkspaceShell.tsx
+++ b/apps/packages/product-client/src/components/workspace/cowork/CoworkWorkspaceShell.tsx
@@ -130,7 +130,7 @@ export function CoworkWorkspaceShell({
           })}`}
           style={{ width: sidebarOpen ? sidebarWidth : 0 }}
         >
-          <div className="flex h-10 shrink-0 items-center" data-tauri-drag-region="true">
+          <div className="flex h-[46px] shrink-0 items-center" data-tauri-drag-region="true">
             <div className={`flex h-full items-center gap-2 ${macWindowControlsInsetClass}`}>
               <IconButton
                 tone="sidebar"

--- a/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanel.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanel.tsx
@@ -22,7 +22,6 @@ interface RightPanelProps {
   onStateChange: Dispatch<SetStateAction<RightPanelWorkspaceState>>;
   terminalActivationRequest: RightPanelTerminalActivationRequest | null;
   focusRequestToken?: number;
-  onTogglePanel: () => void;
   onTerminalActivationRequestHandled: (request: RightPanelTerminalActivationRequest) => void;
 }
 

--- a/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelFrame.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelFrame.tsx
@@ -48,7 +48,6 @@ interface RightPanelFrameProps {
   onRenameTerminal: (terminalId: string, title: string) => Promise<void>;
   onCreateTerminal: () => void;
   onOpenRepoSettings: () => void;
-  onTogglePanel: () => void;
   onReorderHeaderEntry: (
     entryKey: RightPanelHeaderEntryKey,
     beforeEntryKey: RightPanelHeaderEntryKey | null,
@@ -85,7 +84,6 @@ export function RightPanelFrame({
   onRenameTerminal,
   onCreateTerminal,
   onOpenRepoSettings,
-  onTogglePanel,
   onReorderHeaderEntry,
 }: RightPanelFrameProps) {
   return (
@@ -114,7 +112,6 @@ export function RightPanelFrame({
         onCreateTerminal={onCreateTerminal}
         onReorderHeaderEntry={onReorderHeaderEntry}
         onOpenRepoSettings={onOpenRepoSettings}
-        onTogglePanel={onTogglePanel}
       />
 
       <RightPanelContent

--- a/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelHeaderActions.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelHeaderActions.tsx
@@ -1,23 +1,19 @@
 import { IconButton } from "#product/primitives/IconButton";
-import { ShortcutBadge } from "#product/primitives/ShortcutBadge";
 import { Settings } from "#product/primitives/icons/core";
-import { SplitPanel } from "#product/primitives/icons/app-shell";
-import { SHORTCUTS } from "#product/config/shortcuts/registry";
-import { getShortcutDisplayLabel } from "#product/lib/domain/shortcuts/matching";
 
 interface RightPanelHeaderActionsProps {
   onOpenRepoSettings: () => void;
-  onTogglePanel: () => void;
-  shortcutRevealVisible: boolean;
 }
 
 export function RightPanelHeaderActions({
   onOpenRepoSettings,
-  onTogglePanel,
-  shortcutRevealVisible,
 }: RightPanelHeaderActionsProps) {
   return (
-    <div className="ui-tab-system-section ui-tab-system-section__trailing" role="presentation">
+    <div
+      className="ui-tab-system-section ui-tab-system-section__trailing"
+      style={{ paddingRight: "calc(var(--workspace-shell-action-size) + 0.25rem)" }}
+      role="presentation"
+    >
       <div className="editor-panel-overflow-action">
         <IconButton
           size="xs"
@@ -27,23 +23,6 @@ export function RightPanelHeaderActions({
         >
           <Settings className="ui-icon" />
           <span className="sr-only">Repo&apos;s settings</span>
-        </IconButton>
-      </div>
-      <div className="editor-panel-overflow-action">
-        <IconButton
-          size="xs"
-          tone="sidebar"
-          className="ui-icon-button workspace-shell-icon-button glass-editor-panel-new-tab-menu-trigger relative"
-          onClick={onTogglePanel}
-        >
-          <SplitPanel className="ui-icon" />
-          {shortcutRevealVisible ? (
-            <ShortcutBadge
-              label={getShortcutDisplayLabel(SHORTCUTS.toggleRightPanel)}
-              className="pointer-events-none absolute -right-1 -bottom-1 z-20 text-muted-foreground"
-            />
-          ) : null}
-          <span className="sr-only">Hide side panel</span>
         </IconButton>
       </div>
     </div>

--- a/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelHeaderTabs.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelHeaderTabs.tsx
@@ -30,7 +30,6 @@ interface RightPanelHeaderTabsProps {
   onRenameTerminal: (terminalId: string, title: string) => Promise<void>;
   onCreateTerminal: () => void;
   onOpenRepoSettings: () => void;
-  onTogglePanel: () => void;
   onReorderHeaderEntry: (
     entryKey: RightPanelHeaderEntryKey,
     beforeEntryKey: RightPanelHeaderEntryKey | null,
@@ -52,7 +51,6 @@ export function RightPanelHeaderTabs({
   onRenameTerminal,
   onCreateTerminal,
   onOpenRepoSettings,
-  onTogglePanel,
   onReorderHeaderEntry,
 }: RightPanelHeaderTabsProps) {
   const [newTabMenuOpen, setNewTabMenuOpen] = useState(false);
@@ -128,8 +126,6 @@ export function RightPanelHeaderTabs({
 
         <RightPanelHeaderActions
           onOpenRepoSettings={onOpenRepoSettings}
-          onTogglePanel={onTogglePanel}
-          shortcutRevealVisible={shortcutRevealVisible}
         />
       </div>
     </div>

--- a/apps/packages/product-client/src/components/workspace/shell/screen/MainSidebarPageShell.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/MainSidebarPageShell.tsx
@@ -60,7 +60,7 @@ export function MainSidebarPageShell({ children }: MainSidebarPageShellProps) {
         })}`}
         style={{ width: sidebarOpen ? sidebarWidth : 0 }}
       >
-        <div className="flex h-10 shrink-0 items-center" data-tauri-drag-region="true">
+        <div className="flex h-[46px] shrink-0 items-center" data-tauri-drag-region="true">
           <div className={`flex h-full items-center gap-2 ${macWindowControlsInsetClass}`}>
             <IconButton
               tone="sidebar"
@@ -92,7 +92,7 @@ export function MainSidebarPageShell({ children }: MainSidebarPageShellProps) {
         className={`relative flex min-w-0 flex-1 flex-col overflow-hidden ${chromeClasses.contentShell}`}
       >
         <div
-          className="absolute left-0 right-0 top-0 z-20 h-10"
+          className="absolute left-0 right-0 top-0 z-20 h-[46px]"
           data-tauri-drag-region="true"
         >
           {!sidebarOpen && (

--- a/apps/packages/product-client/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
@@ -1,5 +1,6 @@
 import { HomeNextScreen } from "#product/components/home/screen/HomeNextScreen";
 import {
+  type CSSProperties,
   useCallback,
   useEffect,
   useMemo,
@@ -16,11 +17,8 @@ import {
 import { WorkspaceShellActionsProvider } from "#product/components/workspace/shell/providers/WorkspaceShellActionsContext";
 import { WorkspaceCommandPalette } from "#product/components/workspace/shell/command-palette/WorkspaceCommandPalette";
 import { WorkspaceShellRightRail } from "#product/components/workspace/shell/screen/WorkspaceShellRightRail";
+import { WorkspaceShellRightPanelToggle } from "#product/components/workspace/shell/screen/WorkspaceShellRightPanelToggle";
 import { WorkspaceShellSidebar } from "#product/components/workspace/shell/sidebar/WorkspaceShellSidebar";
-import {
-  WorkspaceSidebarHeaderControls,
-} from "#product/components/workspace/shell/sidebar/WorkspaceSidebarHeaderControls";
-import { SidebarUpdateFooterButton } from "#product/components/app/sidebar/SidebarUpdateFooterButton";
 import { DebugProfiler } from "#product/components/diagnostics/DebugProfiler";
 import { OfflineIndicator } from "#product/components/app/OfflineIndicator";
 import { useMainScreenState } from "#product/hooks/main/facade/use-main-screen-state";
@@ -28,16 +26,16 @@ import { useMainScreenShortcuts } from "#product/hooks/main/lifecycle/use-main-s
 import { useMainScreenActions } from "#product/hooks/main/workflows/use-main-screen-actions";
 import { useTransparentChromeEnabled } from "#product/hooks/theme/derived/use-transparent-chrome";
 import { useDebugRenderCount } from "#product/hooks/ui/debug/use-debug-render-count";
+import { useHasMacWindowControls } from "#product/hooks/ui/layout/use-mac-window-controls";
+import { useWorkspaceShellGeometry } from "#product/hooks/workspaces/ui/use-workspace-shell-geometry";
 import { useRunWorkspaceCommand } from "#product/hooks/workspaces/workflows/use-run-workspace-command";
 import { useWorkspaceOpenInWebActions } from "#product/hooks/workspaces/workflows/remote-access/use-workspace-open-in-web-actions";
 import { useWorkspaceRemoteAccessActions } from "#product/hooks/workspaces/workflows/remote-access/use-workspace-remote-access-actions";
 import { useWorkspaceRuntimeBlock } from "#product/hooks/workspaces/derived/use-workspace-runtime-block";
 import { useWorkspaceActivityAcknowledgement } from "#product/hooks/workspaces/lifecycle/use-workspace-activity-acknowledgement";
 import {
-  resolveMainSidebarEdgeClassName,
   resolveStandardWorkspaceChromeClasses,
 } from "#product/lib/domain/preferences/workspace-chrome";
-import { useProductHost } from "#product/host/ProductHostProvider";
 import { WorkspacePathProvider } from "#product/providers/WorkspacePathProvider";
 import { useRepoPreferencesStore } from "#product/stores/preferences/repo-preferences-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
@@ -97,7 +95,14 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
     onRightSeparatorDown,
   } = layout;
   const transparentChromeEnabled = useTransparentChromeEnabled();
-  const desktopHost = useProductHost().desktop !== null;
+  const hasMacWindowControls = useHasMacWindowControls();
+  const workspaceGeometry = useWorkspaceShellGeometry({
+    leftWidth: sidebarOpen ? sidebarWidth : 0,
+    rightWidth: hasWorkspaceShell && !hasLaunchIntentOnlyShell && rightPanelOpen
+      ? rightPanelWidth
+      : 0,
+    onToggleLeft: actions.onToggleSidebar,
+  });
   const chromeClasses = useMemo(
     () => resolveStandardWorkspaceChromeClasses({
       transparent: transparentChromeEnabled,
@@ -181,7 +186,7 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
     onOpenWorkspaceInWeb: workspaceWebActions.openCurrentWorkspaceInWeb,
     onOpenTerminal: actions.openTerminalPanel,
     onSyncWorkspaceToWeb: workspaceRemoteAccessActions.syncToWeb,
-    onToggleLeftSidebar: actions.onToggleSidebar,
+    onToggleLeftSidebar: workspaceGeometry.toggleLeft,
     onToggleRightPanel: actions.toggleRightPanel,
   });
 
@@ -215,9 +220,21 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
               <WorkspaceShellShortcuts enabled={visible} />
             ) : null}
             <div
+              ref={workspaceGeometry.rootRef}
               // relative: the collapsed sidebar's hover peek is an overlay
               // anchored to this shell box, so it never displaces content.
-              className={`relative h-screen flex overflow-hidden ${chromeClasses.root}`}
+              className={`standard-workspace-shell relative h-screen flex overflow-hidden ${chromeClasses.root}`}
+              style={{
+                ...workspaceGeometry.style,
+                // Match the pre-animation collapsed header geometry exactly:
+                // controls inset + 24px toggle + 8px trailing space + the
+                // header's former 8px leading padding.
+                "--workspace-left-header-dwell": hasMacWindowControls ? "122px" : "40px",
+              } as CSSProperties}
+              data-snap-left-geometry={workspaceGeometry.snapLeft ? "true" : "false"}
+              data-manual-workspace-geometry={
+                workspaceGeometry.usesManualInterpolation ? "true" : "false"
+              }
               data-workspace-shell
               data-workspace-ui-key={selectedLogicalWorkspaceId ?? selectedWorkspaceId ?? ""}
               data-workspace-session-id={activeSessionId ?? ""}
@@ -228,12 +245,18 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
               <WorkspaceShellSidebar
                 open={sidebarOpen}
                 width={sidebarWidth}
-                edgeClassName={resolveMainSidebarEdgeClassName({
-                  desktop: desktopHost,
-                  transparent: transparentChromeEnabled,
-                })}
-                onToggleSidebar={actions.onToggleSidebar}
+                showAnimatedDivider={transparentChromeEnabled}
+                snapGeometry={workspaceGeometry.snapLeft}
+                onToggleSidebar={workspaceGeometry.toggleLeft}
               />
+
+              {hasWorkspaceShell && !hasLaunchIntentOnlyShell ? (
+                <WorkspaceShellRightPanelToggle
+                  open={rightPanelOpen}
+                  onTogglePanel={actions.toggleRightPanel}
+                />
+              ) : null}
+
               {sidebarOpen && (
                 <WorkspaceResizeSeparator
                   edge="left"
@@ -254,30 +277,15 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
                   >
                     <DebugProfiler id="workspace-header-frame">
                       <>
-                        {!sidebarOpen && (
-                          <WorkspaceSidebarHeaderControls
-                            className="pr-2"
-                            toggleTitle="Show sidebar"
-                            onToggleSidebar={actions.onToggleSidebar}
-                            // Collapsed, the sidebar footer that would normally
-                            // host this control is offscreen and only reachable
-                            // by hovering the peek edge. Mounting it here too
-                            // keeps it keyboard- and touch-reachable without
-                            // depending on that hover.
-                            trailing={<SidebarUpdateFooterButton />}
-                          />
-                        )}
                         {hasWorkspaceShell && !hasLaunchIntentOnlyShell && (
                           <GlobalHeader
                             selectedWorkspace={selectedWorkspace}
                             workspacePath={selectedWorkspace?.path ?? pendingWorkspacePath}
-                            rightPanelOpen={rightPanelOpen}
                             runDisabled={!runCommand.canRun}
                             runLoading={runCommand.isLaunching}
                             runLabel={runCommand.runLabel}
                             runTitle={runCommand.runTitle}
                             onRun={runCommand.onRun}
-                            onTogglePanel={actions.toggleRightPanel}
                           />
                         )}
                       </>
@@ -315,7 +323,7 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
                             workspaceWebActions={workspaceWebActions}
                             workspaceRemoteAccessActions={workspaceRemoteAccessActions}
                             openTerminalPanel={actions.openTerminalPanel}
-                            onToggleLeftSidebar={actions.onToggleSidebar}
+                            onToggleLeftSidebar={workspaceGeometry.toggleLeft}
                             onToggleRightPanel={actions.toggleRightPanel}
                           />
                         </DebugProfiler>
@@ -357,10 +365,10 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
                   onStateChange={layout.setRightPanelState}
                   terminalActivationRequest={terminalActivationRequest}
                   focusRequestToken={rightPanelFocusRequestToken}
-                  onTogglePanel={actions.toggleRightPanel}
                   onTerminalActivationRequestHandled={handleTerminalActivationRequestHandled}
                 />
               </div>
+
             </div>
           </WorkspaceHeaderTabsViewModelProvider>
         </WorkspacePathProvider>

--- a/apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceShellRightPanelToggle.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceShellRightPanelToggle.test.tsx
@@ -1,0 +1,34 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WorkspaceShellRightPanelToggle } from "#product/components/workspace/shell/screen/WorkspaceShellRightPanelToggle";
+
+vi.mock("#product/providers/ShortcutRevealProvider", () => ({
+  useShortcutRevealVisible: () => false,
+}));
+
+describe("WorkspaceShellRightPanelToggle", () => {
+  afterEach(cleanup);
+
+  it("keeps one window-pinned button mounted across panel state changes", () => {
+    const onTogglePanel = vi.fn();
+    const { rerender } = render(
+      <WorkspaceShellRightPanelToggle open={false} onTogglePanel={onTogglePanel} />,
+    );
+    const button = screen.getByRole("button", { name: "Toggle side panel" });
+    const chrome = button.parentElement;
+
+    expect(chrome?.className).toContain("absolute right-2 top-0");
+    expect(chrome?.className).not.toContain("opacity");
+    expect(button.className).toContain("text-muted-foreground");
+
+    rerender(<WorkspaceShellRightPanelToggle open onTogglePanel={onTogglePanel} />);
+
+    expect(screen.getByRole("button", { name: "Toggle side panel" })).toBe(button);
+    expect(button.className).toContain("text-sidebar-muted-foreground");
+    expect(button.className).toContain("glass-editor-panel-new-tab-menu-trigger");
+    fireEvent.click(button);
+    expect(onTogglePanel).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceShellRightPanelToggle.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceShellRightPanelToggle.tsx
@@ -32,7 +32,7 @@ export function WorkspaceShellRightPanelToggle({
         {shortcutRevealVisible ? (
           <ShortcutBadge
             label={getShortcutDisplayLabel(SHORTCUTS.toggleRightPanel)}
-            className="pointer-events-none absolute -right-1 -bottom-1 z-20 text-muted-foreground"
+            className="pointer-events-none absolute -right-1 -bottom-1 z-raised text-muted-foreground"
           />
         ) : null}
       </IconButton>

--- a/apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceShellRightPanelToggle.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceShellRightPanelToggle.tsx
@@ -1,0 +1,41 @@
+import { SHORTCUTS } from "#product/config/shortcuts/registry";
+import { getShortcutDisplayLabel } from "#product/lib/domain/shortcuts/matching";
+import { IconButton } from "#product/primitives/IconButton";
+import { ShortcutBadge } from "#product/primitives/ShortcutBadge";
+import { SplitPanel } from "#product/primitives/icons/app-shell";
+import { useShortcutRevealVisible } from "#product/providers/ShortcutRevealProvider";
+
+interface WorkspaceShellRightPanelToggleProps {
+  open: boolean;
+  onTogglePanel: () => void;
+}
+
+/** Persistent right-side window chrome, independent of either animated surface. */
+export function WorkspaceShellRightPanelToggle({
+  open,
+  onTogglePanel,
+}: WorkspaceShellRightPanelToggleProps) {
+  const shortcutRevealVisible = useShortcutRevealVisible();
+
+  return (
+    <div className="pointer-events-none absolute right-2 top-0 z-popover flex h-[46px] items-center">
+      <IconButton
+        size="md"
+        tone={open ? "sidebar" : "default"}
+        onClick={onTogglePanel}
+        title="Toggle side panel"
+        className={`pointer-events-auto relative workspace-shell-icon-button ${
+          open ? "glass-editor-panel-new-tab-menu-trigger" : ""
+        }`}
+      >
+        <SplitPanel className="icon-control" />
+        {shortcutRevealVisible ? (
+          <ShortcutBadge
+            label={getShortcutDisplayLabel(SHORTCUTS.toggleRightPanel)}
+            className="pointer-events-none absolute -right-1 -bottom-1 z-20 text-muted-foreground"
+          />
+        ) : null}
+      </IconButton>
+    </div>
+  );
+}

--- a/apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceShellRightRail.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceShellRightRail.test.tsx
@@ -1,0 +1,79 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WorkspaceShellRightRail } from "#product/components/workspace/shell/screen/WorkspaceShellRightRail";
+import { DEFAULT_RIGHT_PANEL_WORKSPACE_STATE } from "#product/lib/domain/workspaces/shell/right-panel-model";
+
+vi.mock("#product/components/diagnostics/DebugProfiler", () => ({
+  DebugProfiler: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("#product/components/workspace/shell/right-panel/RightPanel", () => ({
+  RightPanel: ({ isOpen }: { isOpen: boolean }) => (
+    <div data-testid="right-panel" data-open={String(isOpen)} />
+  ),
+}));
+
+vi.mock("#product/components/workspace/shell/screen/WorkspaceResizeSeparator", () => ({
+  WorkspaceResizeSeparator: () => <div data-testid="right-separator" />,
+}));
+
+const RIGHT_PANEL_PROPS = {
+  workspaceId: "workspace-1",
+  workspaceUiKey: "workspace-1",
+  isWorkspaceReady: true,
+  shouldKeepContentVisible: true,
+  isCloudWorkspaceSelected: false,
+  state: DEFAULT_RIGHT_PANEL_WORKSPACE_STATE,
+  repoSettingsHref: "/settings",
+  onStateChange: vi.fn(),
+  terminalActivationRequest: null,
+  onTerminalActivationRequestHandled: vi.fn(),
+};
+
+describe("WorkspaceShellRightRail", () => {
+  afterEach(cleanup);
+
+  it("anchors panel content to the fixed right edge under the animated rail clip", () => {
+    const { container, getByTestId } = render(
+      <WorkspaceShellRightRail
+        visible
+        open
+        width={420}
+        onSeparatorMouseDown={() => {}}
+        {...RIGHT_PANEL_PROPS}
+      />,
+    );
+
+    const rail = container.querySelector<HTMLElement>("[data-right-panel-rail]");
+    const content = container.querySelector<HTMLElement>("[data-right-panel-content]");
+    expect(rail?.style.width).toBe("var(--workspace-right-width)");
+    expect(rail?.className).toContain("bg-sidebar-background");
+    expect(content?.className).toContain("absolute inset-y-0 right-0");
+    expect(content?.className).toContain("opacity-100");
+    expect(content?.style.width).toBe("420px");
+    expect(getByTestId("right-panel").dataset.open).toBe("true");
+    expect(getByTestId("right-separator")).toBeTruthy();
+  });
+
+  it("keeps the closing content mounted, stationary, inert, and fading", () => {
+    const { container, getByTestId } = render(
+      <WorkspaceShellRightRail
+        visible
+        open={false}
+        width={420}
+        onSeparatorMouseDown={() => {}}
+        {...RIGHT_PANEL_PROPS}
+      />,
+    );
+
+    const content = container.querySelector<HTMLElement>("[data-right-panel-content]");
+    expect(content?.className).toContain("right-0");
+    expect(content?.className).toContain("opacity-0");
+    expect(content?.className).not.toContain("translate");
+    expect(content?.hasAttribute("inert")).toBe(true);
+    expect(getByTestId("right-panel").dataset.open).toBe("false");
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceShellRightRail.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceShellRightRail.tsx
@@ -45,17 +45,28 @@ export function WorkspaceShellRightRail({
         // explicit toggle animates the collapse the drag triggered, and
         // `prefers-reduced-motion` zeroes `--duration-panel` so the panel snaps
         // shut instead.
-        className="isolate shrink-0 overflow-hidden transition-[width] duration-panel ease-standard"
-        style={{ width: open ? width : 0 }}
+        className="relative isolate shrink-0 overflow-hidden bg-sidebar-background"
+        style={{ width: "var(--workspace-right-width)" }}
+        data-right-panel-rail
       >
         <DebugProfiler id="workspace-right-panel">
-          {/* Pinning the panel body at the domain minimum keeps its content laid
-              out at a legible width while the container width animates to 0, so
-              a collapse slides the panel out instead of crushing its chrome. */}
-          <div className="h-full" style={{ minWidth: RIGHT_PANEL_MIN_WIDTH }}>
+          <div
+            className={`absolute inset-y-0 right-0 transition-opacity will-change-opacity ${
+              open
+                ? "pointer-events-auto opacity-100 duration-enter ease-out-cubic"
+                : "pointer-events-none opacity-0 duration-exit ease-out-cubic"
+            }`}
+            style={{ width: Math.max(width, RIGHT_PANEL_MIN_WIDTH) }}
+            inert={!open}
+            data-right-panel-content
+          >
             <RightPanel isOpen={open} {...rightPanelProps} />
           </div>
         </DebugProfiler>
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-0 left-0 z-raised w-px bg-border"
+        />
       </div>
     </>
   );

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
@@ -62,7 +62,7 @@ interface ArchiveConfirmationState {
   name: string;
 }
 
-export const MainSidebar = memo(function MainSidebar() {
+export const MainSidebar = memo(function MainSidebar({ showRightBorder = true }: { showRightBorder?: boolean }) {
   useDebugRenderCount("workspace-sidebar");
   useSessionActivityReconciler();
   const { notice, dismissNotice, openChangelog } = useReleaseNotice();
@@ -325,37 +325,37 @@ export const MainSidebar = memo(function MainSidebar() {
 
   return (
     <DebugProfiler id="workspace-sidebar">
-      <ProductSidebarFrame footer={(
-        <DebugProfiler id="workspace-sidebar-footer">
-          {sidebarOpen && notice ? (
-            <ReleaseNoticeCard
-              notice={notice}
-              onDismiss={dismissNotice}
-              onOpenChangelog={openChangelog}
-            />
-          ) : null}
-          <SidebarAccountFooter />
-        </DebugProfiler>
-      )}>
-      <ProductSidebarBody>
-        <ProductSidebarBrandRow
-          icon={<ProliferateIcon className="icon-paired shrink-0" />}
-          label="Proliferate"
-        />
-        <DebugProfiler id="workspace-sidebar-primary-nav">
-          <SidebarPrimaryNavigation
-            homeActive={isOnHome && !selectedWorkspaceId && !pendingWorkspaceEntry}
-            workspacesActive={isOnWorkspaces}
-            workflowsActive={isOnWorkflows}
-            supportActive={false}
-            onGoHome={actions.handleGoHome}
-            onGoWorkspaces={actions.handleGoWorkspaces}
-            onGoWorkflows={actions.handleGoWorkflows}
-            onOpenSupport={handleOpenSupport}
-            shortcutRevealVisible={shortcutRevealVisible}
-            shortcutLabels={primaryNavShortcutLabels}
+      <ProductSidebarFrame showRightBorder={showRightBorder} footer={(
+          <DebugProfiler id="workspace-sidebar-footer">
+            {sidebarOpen && notice ? (
+              <ReleaseNoticeCard
+                notice={notice}
+                onDismiss={dismissNotice}
+                onOpenChangelog={openChangelog}
+              />
+            ) : null}
+            <SidebarAccountFooter />
+          </DebugProfiler>
+        )}>
+        <ProductSidebarBody>
+          <ProductSidebarBrandRow
+            icon={<ProliferateIcon className="icon-paired shrink-0" />}
+            label="Proliferate"
           />
-        </DebugProfiler>
+          <DebugProfiler id="workspace-sidebar-primary-nav">
+            <SidebarPrimaryNavigation
+              homeActive={isOnHome && !selectedWorkspaceId && !pendingWorkspaceEntry}
+              workspacesActive={isOnWorkspaces}
+              workflowsActive={isOnWorkflows}
+              supportActive={false}
+              onGoHome={actions.handleGoHome}
+              onGoWorkspaces={actions.handleGoWorkspaces}
+              onGoWorkflows={actions.handleGoWorkflows}
+              onOpenSupport={handleOpenSupport}
+              shortcutRevealVisible={shortcutRevealVisible}
+              shortcutLabels={primaryNavShortcutLabels}
+            />
+          </DebugProfiler>
 
         <ProductSidebarScrollableContent>
           <WorkspaceCleanupAttentionSection
@@ -415,15 +415,15 @@ export const MainSidebar = memo(function MainSidebar() {
           )}
           {isDesktopHost ? <CoworkThreadsSection /> : null}
         </ProductSidebarScrollableContent>
-      </ProductSidebarBody>
-      <ConfirmationDialog
-        open={archiveConfirmation !== null}
-        title="Archive workspace?"
-        description={`Move ${archiveConfirmation?.name ?? "this workspace"} out of the main sidebar. It will remain available in Settings -> Archived chats, and safe worktree cleanup may run in the background.`}
-        confirmLabel="Archive"
-        onClose={() => setArchiveConfirmation(null)}
-        onConfirm={confirmArchiveWorkspace}
-      />
+        </ProductSidebarBody>
+        <ConfirmationDialog
+          open={archiveConfirmation !== null}
+          title="Archive workspace?"
+          description={`Move ${archiveConfirmation?.name ?? "this workspace"} out of the main sidebar. It will remain available in Settings -> Archived chats, and safe worktree cleanup may run in the background.`}
+          confirmLabel="Archive"
+          onClose={() => setArchiveConfirmation(null)}
+          onConfirm={confirmArchiveWorkspace}
+        />
       </ProductSidebarFrame>
     </DebugProfiler>
   );

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/ProductSidebarLayout.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/ProductSidebarLayout.tsx
@@ -8,13 +8,17 @@ export function ProductSidebarFrame({
   children,
   footer = null,
   className = "",
+  showRightBorder = true,
 }: {
   children: ReactNode;
   footer?: ReactNode;
   className?: string;
+  showRightBorder?: boolean;
 }) {
   return (
-    <div className={`flex h-full flex-col gap-2 border-r border-border bg-sidebar text-sidebar-foreground select-none ${className}`}>
+    <div
+      className={`flex h-full flex-col gap-2 ${showRightBorder ? "border-r border-border" : ""} bg-sidebar text-sidebar-foreground select-none ${className}`}
+    >
       {children}
       {footer}
     </div>

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.test.tsx
@@ -151,11 +151,12 @@ describe("WorkspaceShellSidebar hover peek", () => {
   });
 
   it("centers the pinned toggle in the shared title row", () => {
-    const { getByTestId } = renderSidebar();
+    const { getByTestId, holdZone } = renderSidebar();
     const pinnedChrome = getByTestId("sidebar-header-controls").parentElement?.parentElement;
 
     expect(pinnedChrome?.className).toContain("top-0");
     expect(pinnedChrome?.className).toContain("h-[46px]");
+    expect(holdZone.className).toContain("h-[46px]");
   });
 
   it("keeps the pinned toggle before sidebar navigation in keyboard order", () => {

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.test.tsx
@@ -11,11 +11,30 @@ vi.mock("#product/components/diagnostics/DebugProfiler", () => ({
 }));
 
 vi.mock("#product/components/workspace/shell/sidebar/MainSidebar", () => ({
-  MainSidebar: () => <div data-testid="main-sidebar-body" />,
+  MainSidebar: ({ showRightBorder }: { showRightBorder?: boolean }) => (
+    <div
+      data-testid="main-sidebar-body"
+      data-show-right-border={showRightBorder ? "true" : "false"}
+    >
+      <button type="button">Main navigation item</button>
+    </div>
+  ),
 }));
 
 vi.mock("#product/components/workspace/shell/sidebar/WorkspaceSidebarHeaderControls", () => ({
-  WorkspaceSidebarHeaderControls: () => <div data-testid="sidebar-header-controls" />,
+  WorkspaceSidebarHeaderControls: ({
+    onToggleSidebar,
+  }: {
+    onToggleSidebar: () => void;
+  }) => (
+    <button data-testid="sidebar-header-controls" onClick={onToggleSidebar}>
+      Toggle
+    </button>
+  ),
+}));
+
+vi.mock("#product/components/app/sidebar/SidebarUpdateFooterButton", () => ({
+  SidebarUpdateFooterButton: () => <div data-testid="sidebar-update-control" />,
 }));
 
 const coarsePointer = vi.hoisted(() => ({ value: false }));
@@ -24,9 +43,18 @@ vi.mock("#product/hooks/ui/layout/use-coarse-pointer", () => ({
   useCoarsePointer: () => coarsePointer.value,
 }));
 
-function renderSidebar(open = false) {
+function renderSidebar(
+  open = false,
+  onToggleSidebar: (options?: { snapGeometry?: boolean }) => void = () => {},
+  showAnimatedDivider = false,
+) {
   const result = render(
-    <WorkspaceShellSidebar open={open} width={280} onToggleSidebar={() => {}} />,
+    <WorkspaceShellSidebar
+      open={open}
+      width={280}
+      showAnimatedDivider={showAnimatedDivider}
+      onToggleSidebar={onToggleSidebar}
+    />,
   );
   const panel = document.getElementById("main-sidebar");
   if (!panel) {
@@ -36,7 +64,11 @@ function renderSidebar(open = false) {
   if (!trigger) {
     throw new Error("peek trigger did not render");
   }
-  return { ...result, panel, trigger };
+  const holdZone = document.querySelector("[data-sidebar-peek-hold-zone]");
+  if (!holdZone) {
+    throw new Error("peek hold zone did not render");
+  }
+  return { ...result, panel, trigger, holdZone };
 }
 
 function peekState(panel: HTMLElement): string | null {
@@ -66,11 +98,8 @@ describe("WorkspaceShellSidebar hover peek", () => {
   });
 
   /**
-   * The whole point of the grace period. The collapsed layout puts the "Show
-   * sidebar" toggle in the header, OUTSIDE the peeked panel, so travelling to it
-   * fires `mouseleave` on the panel. Closing on that instant meant the panel
-   * faded out and the resulting click faded it straight back in — two
-   * animations for one gesture.
+   * The grace period lets the pointer travel from the panel into persistent
+   * window chrome without starting a visible close/reopen cycle.
    */
   it("keeps the peek open across a brief exit and re-entry", () => {
     const { panel, trigger } = renderSidebar();
@@ -95,7 +124,7 @@ describe("WorkspaceShellSidebar hover peek", () => {
     expect(peekState(panel)).toBe("open");
   });
 
-  it("closes the peek once the grace period elapses", () => {
+  it("finishes the peek exit after the grace and exit durations", () => {
     const { panel, trigger } = renderSidebar();
     fireEvent.mouseEnter(trigger);
     fireEvent.mouseLeave(panel);
@@ -104,7 +133,68 @@ describe("WorkspaceShellSidebar hover peek", () => {
       vi.advanceTimersByTime(motion.delay.hoverCardHideMs);
     });
 
+    expect(peekState(panel)).toBe("closing");
+
+    act(() => {
+      vi.advanceTimersByTime(motion.duration.exitMs);
+    });
     expect(peekState(panel)).toBe("closed");
+  });
+
+  it("does not arm from the pinned toggle or header hold zone", () => {
+    const { panel, holdZone, getByTestId } = renderSidebar();
+
+    fireEvent.mouseEnter(holdZone);
+    fireEvent.mouseEnter(getByTestId("sidebar-header-controls"));
+
+    expect(peekState(panel)).toBe("closed");
+  });
+
+  it("centers the pinned toggle in the shared title row", () => {
+    const { getByTestId } = renderSidebar();
+    const pinnedChrome = getByTestId("sidebar-header-controls").parentElement?.parentElement;
+
+    expect(pinnedChrome?.className).toContain("top-0");
+    expect(pinnedChrome?.className).toContain("h-[46px]");
+  });
+
+  it("keeps the pinned toggle before sidebar navigation in keyboard order", () => {
+    const { getAllByRole, getByRole, getByTestId } = renderSidebar(true);
+    const buttons = getAllByRole("button");
+
+    expect(buttons.indexOf(getByTestId("sidebar-header-controls")))
+      .toBeLessThan(buttons.indexOf(getByRole("button", { name: "Main navigation item" })));
+  });
+
+  it("renders a full-height divider at the animated edge when requested", () => {
+    renderSidebar(true, () => {}, true);
+    const divider = document.querySelector("[data-workspace-left-divider]");
+
+    expect(divider).not.toBeNull();
+    expect(divider?.className).toContain("inset-y-0");
+    expect(divider?.getAttribute("style")).toContain("--workspace-left-width");
+  });
+
+  it("leaves the full-height workspace shell as the open divider owner", () => {
+    const { getByTestId } = renderSidebar(true);
+
+    expect(getByTestId("main-sidebar-body").getAttribute("data-show-right-border"))
+      .toBe("false");
+  });
+
+  it("lets the header hold zone cancel a peek that is mid-fade-out", () => {
+    const { panel, trigger, holdZone } = renderSidebar();
+    fireEvent.mouseEnter(trigger);
+    fireEvent.mouseLeave(panel);
+    act(() => {
+      vi.advanceTimersByTime(motion.delay.hoverCardHideMs);
+    });
+    expect(peekState(panel)).toBe("closing");
+
+    fireEvent.mouseEnter(holdZone);
+
+    expect(peekState(panel)).toBe("open");
+    expect(panel.className).toContain("translate-x-0");
   });
 
   /**
@@ -163,6 +253,80 @@ describe("WorkspaceShellSidebar hover peek", () => {
     // start from hidden rather than inheriting this hover.
     expect(peekState(panel)).toBe("inactive");
     expect(panel.className).toContain("opacity-100");
+  });
+
+  it("fades in place during toggle-close, then restores the peek offset", () => {
+    const { panel, rerender } = renderSidebar(true);
+
+    rerender(<WorkspaceShellSidebar open={false} width={280} onToggleSidebar={() => {}} />);
+
+    expect(peekState(panel)).toBe("toggle-closing");
+    expect(panel.className).toContain("translate-x-0");
+    expect(panel.className).not.toContain("-translate-x-2");
+    expect(panel.className).toContain("transition-opacity");
+
+    act(() => {
+      vi.advanceTimersByTime(motion.duration.panelMs);
+    });
+
+    expect(peekState(panel)).toBe("closed");
+    expect(panel.className).toContain("-translate-x-2");
+  });
+
+  it("repaints the peek offset before peeking immediately after a toggle-close", () => {
+    const { panel, trigger, rerender } = renderSidebar(true);
+    rerender(<WorkspaceShellSidebar open={false} width={280} onToggleSidebar={() => {}} />);
+
+    fireEvent.mouseEnter(trigger);
+    expect(peekState(panel)).toBe("preparing");
+    expect(panel.className).toContain("transition-none");
+    expect(panel.className).toContain("-translate-x-2");
+
+    act(() => {
+      vi.advanceTimersByTime(40);
+    });
+
+    expect(peekState(panel)).toBe("open");
+    expect(panel.className).toContain("translate-x-0");
+    expect(panel.className).toContain("duration-panel");
+  });
+
+  it("requests a geometry snap when the persistent toggle pins a peek", () => {
+    const onToggleSidebar = vi.fn();
+    const { panel, trigger, getByTestId } = renderSidebar(false, onToggleSidebar);
+    fireEvent.mouseEnter(trigger);
+    expect(peekState(panel)).toBe("open");
+
+    fireEvent.click(getByTestId("sidebar-header-controls"));
+
+    expect(onToggleSidebar).toHaveBeenCalledWith({ snapGeometry: true });
+  });
+
+  it("keeps a mid-exit peek fully visible when pinning snaps it open", () => {
+    const onToggleSidebar = vi.fn();
+    const { panel, trigger, getByTestId, rerender } = renderSidebar(false, onToggleSidebar);
+    fireEvent.mouseEnter(trigger);
+    fireEvent.mouseLeave(panel);
+    act(() => {
+      vi.advanceTimersByTime(motion.delay.hoverCardHideMs);
+    });
+    expect(peekState(panel)).toBe("closing");
+
+    fireEvent.click(getByTestId("sidebar-header-controls"));
+    expect(onToggleSidebar).toHaveBeenCalledWith({ snapGeometry: true });
+
+    rerender(
+      <WorkspaceShellSidebar
+        open
+        width={280}
+        snapGeometry
+        onToggleSidebar={onToggleSidebar}
+      />,
+    );
+    expect(peekState(panel)).toBe("inactive");
+    expect(panel.className).toContain("opacity-100");
+    expect(panel.className).toContain("transition-none");
+    expect(panel.className).not.toContain("duration-enter");
   });
 
   it("keeps the collapsed panel out of the tab order until it peeks", () => {

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.tsx
@@ -35,7 +35,7 @@ export function WorkspaceShellSidebar({
   const body = (
     <DebugProfiler id="workspace-sidebar-frame">
       <div className="flex h-full min-h-0 flex-col">
-        <div className="h-10 shrink-0" data-tauri-drag-region="true" />
+        <div className="h-[46px] shrink-0" data-tauri-drag-region="true" />
         <div className="flex-1 min-h-0 overflow-hidden">
           <MainSidebar showRightBorder={false} />
         </div>
@@ -107,7 +107,7 @@ export function WorkspaceShellSidebar({
       </div>
 
       <div
-        className={`absolute left-0 top-0 z-overlay h-10 ${
+        className={`absolute left-0 top-0 z-overlay h-[46px] ${
           !open && peekVisible ? "pointer-events-auto" : "pointer-events-none"
         }`}
         style={{ width: "var(--workspace-left-header-dwell)" }}

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.tsx
@@ -1,176 +1,129 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { motion } from "@proliferate/design/motion";
+import { SidebarUpdateFooterButton } from "#product/components/app/sidebar/SidebarUpdateFooterButton";
 import { DebugProfiler } from "#product/components/diagnostics/DebugProfiler";
 import { MainSidebar } from "#product/components/workspace/shell/sidebar/MainSidebar";
 import { WorkspaceSidebarHeaderControls } from "#product/components/workspace/shell/sidebar/WorkspaceSidebarHeaderControls";
-import { useCoarsePointer } from "#product/hooks/ui/layout/use-coarse-pointer";
+import { useWorkspaceSidebarPeek } from "#product/hooks/workspaces/ui/use-workspace-sidebar-peek";
 
 interface WorkspaceShellSidebarProps {
   open: boolean;
   width: number;
-  edgeClassName?: string;
-  onToggleSidebar: () => void;
+  showAnimatedDivider?: boolean;
+  snapGeometry?: boolean;
+  onToggleSidebar: (options?: { snapGeometry?: boolean }) => void;
 }
 
 export function WorkspaceShellSidebar({
   open,
   width,
-  edgeClassName = "",
+  showAnimatedDivider = false,
+  snapGeometry = false,
   onToggleSidebar,
 }: WorkspaceShellSidebarProps) {
-  // Hover peek only exists while the sidebar is collapsed, and it is pointer
-  // state, not preference state: nothing about it is persisted, and toggling the
-  // sidebar open discards it.
-  const [peekActive, setPeekActive] = useState(false);
-  const peekCloseTimerRef = useRef<number | null>(null);
-  // A touch tap fires a synthetic `mouseenter` with no matching `mouseleave`
-  // once the finger lifts, so arming the peek from a coarse pointer leaves it
-  // stuck open with no gesture left to close it. The whole interaction model
-  // is hover, which coarse pointers don't have, so it is disabled outright
-  // rather than patched with a second, touch-specific close path.
-  const coarsePointer = useCoarsePointer();
-
-  const cancelPeekClose = useCallback(() => {
-    if (peekCloseTimerRef.current !== null) {
-      window.clearTimeout(peekCloseTimerRef.current);
-      peekCloseTimerRef.current = null;
-    }
-  }, []);
-
-  const activatePeek = useCallback(() => {
-    if (coarsePointer) {
-      return;
-    }
-    cancelPeekClose();
-    setPeekActive(true);
-  }, [cancelPeekClose, coarsePointer]);
-
-  // Closing is deferred, opening is not. The pointer leaves the panel for a
-  // beat during ordinary use -- crossing the gap to the collapsed header's own
-  // toggle, or clipping a corner on the way to it -- and an immediate close
-  // turned every one of those into a full fade-out that a click then had to
-  // fade back in. One grace period, sized to the hover-card's, absorbs the
-  // crossing; a re-entry inside it cancels the close outright, so the panel
-  // never animates at all.
-  const deactivatePeek = useCallback(() => {
-    cancelPeekClose();
-    peekCloseTimerRef.current = window.setTimeout(() => {
-      peekCloseTimerRef.current = null;
-      setPeekActive(false);
-    }, motion.delay.hoverCardHideMs);
-  }, [cancelPeekClose]);
-
-  useEffect(() => cancelPeekClose, [cancelPeekClose]);
-
-  useEffect(() => {
-    // Opening the sidebar disarms any peek, so re-collapsing later starts from
-    // hidden instead of inheriting a hover that ended while the sidebar was open
-    // (the collapsed panel gets no `mouseleave` in that case).
-    if (open) {
-      cancelPeekClose();
-      setPeekActive(false);
-    }
-  }, [cancelPeekClose, open]);
+  const {
+    activatePeek,
+    deactivatePeek,
+    handleToggleSidebar,
+    holdPeek,
+    peekActive,
+    peekExiting,
+    peekPreparing,
+    peekState,
+    peekVisible,
+    toggleClosing,
+  } = useWorkspaceSidebarPeek({ open, onToggleSidebar });
 
   const body = (
     <DebugProfiler id="workspace-sidebar-frame">
       <div className="flex h-full min-h-0 flex-col">
-        <div className="flex h-10 shrink-0 items-center" data-tauri-drag-region="true">
-          <WorkspaceSidebarHeaderControls
-            toggleTitle="Hide sidebar"
-            iconTone="sidebar"
-            onToggleSidebar={onToggleSidebar}
-          />
-        </div>
+        <div className="h-10 shrink-0" data-tauri-drag-region="true" />
         <div className="flex-1 min-h-0 overflow-hidden">
-          <MainSidebar />
+          <MainSidebar showRightBorder={false} />
         </div>
       </div>
     </DebugProfiler>
   );
 
-  // The sidebar is split into two elements on purpose, and both are always
-  // rendered so the sidebar contents never unmount (a remount would throw away
-  // list scroll position every time the sidebar is toggled):
-  //
-  //  - an in-flow spacer that owns the LAYOUT width and animates it, so an
-  //    explicit toggle still slides the content pane across as before;
-  //  - the sidebar panel itself, absolutely positioned at its full width, so it
-  //    is painted independently of whatever the spacer currently reserves.
-  //
-  // Collapsed, the spacer reserves nothing and the panel becomes a hover
-  // overlay: peeking cannot reflow anything to its right, which is the entire
-  // reason the panel does not animate its own width.
+  const panelStateClass = open
+    ? `pointer-events-auto translate-x-0 opacity-100 ${
+        snapGeometry
+          ? "transition-none"
+          : "transition-opacity duration-enter ease-out-cubic"
+      }`
+    : peekActive
+      ? "pointer-events-auto translate-x-0 opacity-100 shadow-popover border-r border-border transition-[opacity,translate] duration-panel ease-out-cubic"
+      : peekExiting
+        ? "pointer-events-auto -translate-x-2 opacity-0 shadow-popover border-r border-border transition-[opacity,translate] duration-exit ease-out-cubic"
+        : toggleClosing
+          ? "pointer-events-none translate-x-0 opacity-0 transition-opacity duration-exit ease-out-cubic"
+          : peekPreparing
+            ? "pointer-events-none -translate-x-2 opacity-0 transition-none"
+            : "pointer-events-none -translate-x-2 opacity-0 transition-[opacity,translate] duration-exit ease-out-cubic";
+
   return (
-    <div
-      // isolate: the resize separator's hit strip overlaps this edge (z-10 in
-      // the page context); a local stacking context keeps sidebar-internal
-      // z-indexes from painting over the dragger. Collapsed, the sidebar must
-      // instead paint OVER the content beside it, so it rises to the overlay
-      // layer rather than isolating.
-      className={`relative shrink-0 transition-[width] duration-panel ease-standard ${
-        // Open, the spacer clips the panel to the width it currently reserves,
-        // so toggling still reads as the sidebar sliding out of its own edge.
-        // Collapsed it must not clip at all, or a zero-width spacer would erase
-        // the overlay it is supposed to let hang over the content.
-        open ? "isolate overflow-hidden" : "pointer-events-none z-overlay"
-      }`}
-      style={{ width: open ? width : 0 }}
-    >
-      <div
-        id="main-sidebar"
-        // While hidden the panel must not trap the pointer or the focus ring:
-        // no pointer events, and `inert` keeps every control inside out of the
-        // tab order and the accessibility tree. Reduced motion needs no branch
-        // here — the generated stylesheet zeroes the interaction durations
-        // under `prefers-reduced-motion`, so the peek snaps instead of fading.
-        //
-        // The peek animates opacity AND a short slide from behind its own left
-        // edge, because opacity alone reads as a pop however long it runs: the
-        // panel is a full-height slab, so with nothing moving there is no
-        // direction to the reveal and the eye only registers the arrival. The
-        // slide is deliberately a fraction of the panel width (not the full
-        // travel a toggle makes) — it says "this came from the edge" without
-        // pretending the layout moved.
-        //
-        // Durations and curves are chosen against what each transition is:
-        // arriving is `panel` geometry with `out-cubic`, which spends the budget
-        // on a quick departure that decelerates into place; `out-quint` covers
-        // ~86% of the distance in the first third and is what made this snap.
-        // Leaving keeps the faster `exit` role and slides back the way it came.
-        // `translate`, not `transform`: Tailwind's translate utilities compile to
-        // the standalone `translate` property, so a transition on `transform`
-        // animates nothing and the slide silently snaps.
-        className={`absolute inset-y-0 left-0 flex flex-col overflow-hidden bg-sidebar transition-[opacity,translate] will-change-[opacity,translate] ${
-          open
-            ? `pointer-events-auto translate-x-0 opacity-100 duration-enter ease-out-cubic ${edgeClassName}`
-            : peekActive
-              ? "pointer-events-auto translate-x-0 opacity-100 shadow-popover border-r border-border duration-panel ease-out-cubic"
-              : "pointer-events-none -translate-x-2 opacity-0 duration-exit ease-out-cubic"
-        }`}
-        style={{ width }}
-        inert={!open && !peekActive}
-        data-sidebar-peek={open ? "inactive" : peekActive ? "open" : "closed"}
-        onMouseEnter={open ? undefined : activatePeek}
-        onMouseLeave={open ? undefined : deactivatePeek}
-      >
-        {body}
+    <>
+      <div className="pointer-events-none absolute left-0 top-0 z-popover flex h-[46px] items-center">
+        <div
+          className="pointer-events-auto flex h-full items-center"
+          onMouseEnter={holdPeek}
+          onMouseLeave={deactivatePeek}
+        >
+          <WorkspaceSidebarHeaderControls
+            toggleTitle={open ? "Hide sidebar" : "Show sidebar"}
+            iconTone={open ? "sidebar" : undefined}
+            onToggleSidebar={handleToggleSidebar}
+            trailing={open ? null : <SidebarUpdateFooterButton />}
+          />
+        </div>
       </div>
-      {/* Narrow edge target that arms the peek, rendered last so it cannot be
-          clipped by the panel and so toggling it inert never reorders the panel
-          above it. It stops accepting the pointer as soon as the panel is up,
-          otherwise it would swallow clicks along the panel's own left edge. */}
+
       <div
-        className={`absolute inset-y-0 left-0 w-2 ${
-          open || peekActive ? "pointer-events-none" : "pointer-events-auto"
+        className={`relative shrink-0 ${
+          open || toggleClosing
+            ? "isolate overflow-hidden"
+            : "pointer-events-none z-overlay"
         }`}
-        data-sidebar-peek-trigger
-        onMouseEnter={activatePeek}
-        // Leaving the strip outward (back past the window edge) closes the
-        // peek. Moving inward hands off to the panel, whose own `onMouseEnter`
-        // re-arms in the same batch, so the crossing never flickers.
+        style={{ width: "var(--workspace-left-width)" }}
+      >
+        <div
+          id="main-sidebar"
+          className={`absolute inset-y-0 left-0 flex flex-col overflow-hidden bg-sidebar will-change-[opacity,translate] ${panelStateClass}`}
+          style={{ width }}
+          inert={!open && !peekVisible}
+          data-sidebar-peek={peekState}
+          onMouseEnter={open ? undefined : holdPeek}
+          onMouseLeave={open ? undefined : deactivatePeek}
+        >
+          {body}
+        </div>
+
+        <div
+          className={`absolute inset-y-0 left-0 w-2 ${
+            open || peekVisible ? "pointer-events-none" : "pointer-events-auto"
+          }`}
+          data-sidebar-peek-trigger
+          onMouseEnter={activatePeek}
+          onMouseLeave={deactivatePeek}
+        />
+      </div>
+
+      <div
+        className={`absolute left-0 top-0 z-overlay h-10 ${
+          !open && peekVisible ? "pointer-events-auto" : "pointer-events-none"
+        }`}
+        style={{ width: "var(--workspace-left-header-dwell)" }}
+        data-sidebar-peek-hold-zone
+        onMouseEnter={holdPeek}
         onMouseLeave={deactivatePeek}
       />
-    </div>
+
+      {showAnimatedDivider ? (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-0 z-raised w-px bg-border"
+          style={{ left: "max(-1px, calc(var(--workspace-left-width) - 1px))" }}
+          data-workspace-left-divider
+        />
+      ) : null}
+    </>
   );
 }

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceSidebarHeaderControls.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceSidebarHeaderControls.tsx
@@ -13,13 +13,10 @@ interface WorkspaceSidebarHeaderControlsProps {
 }
 
 /**
- * Top-left window chrome: the sidebar toggle, plus whatever the caller needs
- * reachable even while the sidebar itself is gone. The update control lives
- * in the sidebar footer while the sidebar is open, but that footer unmounts
- * along with the rest of the panel when it collapses — a caller rendering
- * this component for the collapsed state passes the update button in as
- * `trailing` so it stays a normal tab-focusable element in the always-on
- * chrome, rather than something a hover-only peek has to surface.
+ * Persistent top-left window chrome: the sidebar toggle, plus whatever must
+ * remain reachable while the sidebar is collapsed. The owning shell mounts
+ * this once above both the sidebar and content surfaces so the glyph never
+ * moves or fades during a toggle.
  *
  * The macOS window-controls inset is resolved here rather than passed in by
  * callers, so every call site gets the same host check instead of each one

--- a/apps/packages/product-client/src/components/workspace/shell/topbar/GlobalHeader.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/topbar/GlobalHeader.test.tsx
@@ -73,9 +73,7 @@ function renderHeader() {
     <GlobalHeader
       selectedWorkspace={undefined}
       workspacePath="/repo"
-      rightPanelOpen
       onRun={vi.fn()}
-      onTogglePanel={vi.fn()}
     />,
   );
 }
@@ -96,6 +94,17 @@ describe("GlobalHeader", () => {
     expect(title.style.lineHeight).toBe("var(--text-workspace-title--line-height)");
     expect(title.className.split(" ")).not.toContain("text-ui");
     expect(title.className.split(" ")).not.toContain("text-sidebar-nav");
+  });
+
+  it("derives left and right action dwell from the animated shell widths", () => {
+    renderHeader();
+
+    const title = screen.getByTitle("repo");
+    expect(title.parentElement?.style.paddingLeft).toBe(
+      "max(8px, calc(var(--workspace-left-header-dwell) - var(--workspace-left-width)))",
+    );
+    expect(screen.getByRole("button", { name: "Run workspace command" }).parentElement?.style.paddingRight)
+      .toBe("max(0px, calc(36px - var(--workspace-right-width)))");
   });
 
   it("does not offer a native open action without a Desktop file bridge", () => {

--- a/apps/packages/product-client/src/components/workspace/shell/topbar/GlobalHeader.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/topbar/GlobalHeader.tsx
@@ -17,37 +17,31 @@ import {
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { FilePen } from "#product/primitives/icons/workspace";
 import { Play } from "#product/primitives/icons/core";
-import { SplitPanel } from "#product/primitives/icons/app-shell";
 import type { Workspace } from "@anyharness/sdk";
 import { useDebugRenderCount } from "#product/hooks/ui/debug/use-debug-render-count";
 import { workspaceHeaderTitle } from "#product/lib/domain/workspaces/display/workspace-display";
 import { useToastStore } from "#product/stores/toast/toast-store";
 
-const HEADER_ICON_BUTTON_CLASS = "workspace-shell-icon-button";
 const HEADER_RUN_BUTTON_CLASS = "workspace-shell-action-button font-medium";
 
 interface GlobalHeaderProps {
   selectedWorkspace: Workspace | undefined;
   workspacePath?: string | null;
-  rightPanelOpen: boolean;
   runDisabled?: boolean;
   runLoading?: boolean;
   runLabel?: string;
   runTitle?: string;
   onRun: () => void;
-  onTogglePanel: () => void;
 }
 
 export const GlobalHeader = memo(function GlobalHeader({
   selectedWorkspace,
   workspacePath: workspacePathProp,
-  rightPanelOpen,
   runDisabled = false,
   runLoading = false,
   runLabel = "Run",
   runTitle = "Run workspace command",
   onRun,
-  onTogglePanel,
 }: GlobalHeaderProps) {
   useDebugRenderCount("global-header");
   const [targets, setTargets] = useState<OpenTarget[]>([]);
@@ -103,7 +97,12 @@ export const GlobalHeader = memo(function GlobalHeader({
 
   return (
     <DebugProfiler id="global-header">
-      <div className="flex h-full min-w-0 flex-1 items-center gap-1 px-2">
+      <div
+        className="flex h-full min-w-0 flex-1 items-center gap-1 pr-2"
+        style={{
+          paddingLeft: "max(8px, calc(var(--workspace-left-header-dwell) - var(--workspace-left-width)))",
+        }}
+      >
         <div
           className="min-w-0 max-w-[220px] shrink-0 truncate px-1.5 font-medium text-foreground"
           style={{
@@ -123,7 +122,12 @@ export const GlobalHeader = memo(function GlobalHeader({
         </div>
 
         <DebugProfiler id="global-header-actions">
-          <div className="flex shrink-0 items-center gap-1.5">
+          <div
+            className="flex shrink-0 items-center gap-1.5"
+            style={{
+              paddingRight: "max(0px, calc(36px - var(--workspace-right-width)))",
+            }}
+          >
             <Button
               variant="ghost"
               size="sm"
@@ -147,18 +151,6 @@ export const GlobalHeader = memo(function GlobalHeader({
                 onTargetClick={handleTargetClick}
                 preferredTarget={preferredTarget}
               />
-            )}
-            {!rightPanelOpen && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={onTogglePanel}
-                aria-label="Toggle side panel"
-                title="Toggle side panel"
-                className={HEADER_ICON_BUTTON_CLASS}
-              >
-                <SplitPanel className="icon-paired" />
-              </Button>
             )}
           </div>
         </DebugProfiler>

--- a/apps/packages/product-client/src/hooks/ui/layout/use-mac-window-controls.ts
+++ b/apps/packages/product-client/src/hooks/ui/layout/use-mac-window-controls.ts
@@ -1,7 +1,7 @@
 import { useProductHost } from "#product/host/ProductHostProvider";
 
 /**
- * Left inset that clears the macOS window buttons in a 40px title row.
+ * Left inset that clears the macOS window buttons in a 46px title row.
  * Only apply it through `useMacWindowControlsInsetClass` — a host without
  * those buttons (Web, Windows, Linux) must not reserve the gap, or the space
  * reads as a broken hole at the top of the surface.

--- a/apps/packages/product-client/src/hooks/ui/motion/use-prefers-reduced-motion.ts
+++ b/apps/packages/product-client/src/hooks/ui/motion/use-prefers-reduced-motion.ts
@@ -1,0 +1,27 @@
+import { useSyncExternalStore } from "react";
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+function getReducedMotionPreference(): boolean {
+  return typeof window !== "undefined"
+    && typeof window.matchMedia === "function"
+    && window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+function subscribeToReducedMotionPreference(onStoreChange: () => void): () => void {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return () => {};
+  }
+
+  const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+  mediaQuery.addEventListener("change", onStoreChange);
+  return () => mediaQuery.removeEventListener("change", onStoreChange);
+}
+
+export function usePrefersReducedMotion(): boolean {
+  return useSyncExternalStore(
+    subscribeToReducedMotionPreference,
+    getReducedMotionPreference,
+    () => false,
+  );
+}

--- a/apps/packages/product-client/src/hooks/workspaces/facade/use-right-panel-controller.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/facade/use-right-panel-controller.ts
@@ -37,7 +37,6 @@ export interface UseRightPanelControllerOptions {
   onStateChange: Dispatch<SetStateAction<RightPanelWorkspaceState>>;
   terminalActivationRequest: RightPanelTerminalActivationRequest | null;
   focusRequestToken?: number;
-  onTogglePanel: () => void;
   onTerminalActivationRequestHandled: (request: RightPanelTerminalActivationRequest) => void;
 }
 
@@ -53,7 +52,6 @@ export function useRightPanelController({
   onStateChange,
   terminalActivationRequest,
   focusRequestToken = 0,
-  onTogglePanel,
   onTerminalActivationRequestHandled,
 }: UseRightPanelControllerOptions) {
   const rootRef = useRef<HTMLDivElement>(null);
@@ -186,6 +184,5 @@ export function useRightPanelController({
     onCreateTerminal: actions.handleCreateTerminal,
     onOpenRepoSettings: actions.handleOpenRepoSettings,
     onReorderHeaderEntry: actions.handleReorderHeaderEntry,
-    onTogglePanel,
   };
 }

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-shell-geometry.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-shell-geometry.test.tsx
@@ -1,0 +1,132 @@
+/* @vitest-environment jsdom */
+
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { motion } from "@proliferate/design/motion";
+import { useWorkspaceShellGeometry } from "#product/hooks/workspaces/ui/use-workspace-shell-geometry";
+
+function stubReducedMotion(matches: boolean): void {
+  vi.stubGlobal("matchMedia", vi.fn(() => ({
+    matches,
+    media: "(prefers-reduced-motion: reduce)",
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })));
+}
+
+function GeometryHarness({
+  leftWidth,
+  rightWidth,
+  onToggleLeft = () => {},
+}: {
+  leftWidth: number;
+  rightWidth: number;
+  onToggleLeft?: () => void;
+}) {
+  const geometry = useWorkspaceShellGeometry({ leftWidth, rightWidth, onToggleLeft });
+  return (
+    <>
+      <div
+        ref={geometry.rootRef}
+        style={geometry.style}
+        data-testid="geometry"
+        data-manual={geometry.usesManualInterpolation ? "true" : "false"}
+        data-snap={geometry.snapLeft ? "true" : "false"}
+      />
+      <button type="button" onClick={() => geometry.toggleLeft({ snapGeometry: true })}>
+        Pin
+      </button>
+      <button type="button" onClick={() => geometry.toggleLeft()}>
+        Toggle
+      </button>
+    </>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("useWorkspaceShellGeometry", () => {
+  it("leaves interpolation to CSS when registered properties are supported", () => {
+    vi.stubGlobal("CSS", { registerProperty: vi.fn() });
+    stubReducedMotion(false);
+    const { getByTestId, rerender } = render(
+      <GeometryHarness leftWidth={0} rightWidth={0} />,
+    );
+
+    rerender(<GeometryHarness leftWidth={280} rightWidth={360} />);
+    const root = getByTestId("geometry");
+    expect(root.dataset.manual).toBe("false");
+    expect(root.style.getPropertyValue("--workspace-left-width")).toBe("280px");
+    expect(root.style.getPropertyValue("--workspace-right-width")).toBe("360px");
+  });
+
+  it("drives unsupported renderers with one time-based rAF loop", () => {
+    vi.stubGlobal("CSS", {});
+    stubReducedMotion(false);
+    const frames: FrameRequestCallback[] = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+    const { getByTestId, rerender } = render(
+      <GeometryHarness leftWidth={0} rightWidth={0} />,
+    );
+
+    rerender(<GeometryHarness leftWidth={280} rightWidth={360} />);
+    const root = getByTestId("geometry");
+    expect(root.dataset.manual).toBe("true");
+    expect(frames).toHaveLength(1);
+
+    act(() => frames.shift()?.(0));
+    act(() => frames.shift()?.(motion.duration.panelMs));
+    expect(root.style.getPropertyValue("--workspace-left-width")).toBe("280px");
+    expect(root.style.getPropertyValue("--workspace-right-width")).toBe("360px");
+  });
+
+  it("snaps unsupported renderers when reduced motion is active", () => {
+    vi.stubGlobal("CSS", {});
+    stubReducedMotion(true);
+    const requestFrame = vi.spyOn(window, "requestAnimationFrame");
+    const { getByTestId, rerender } = render(
+      <GeometryHarness leftWidth={0} rightWidth={0} />,
+    );
+
+    rerender(<GeometryHarness leftWidth={280} rightWidth={360} />);
+    const root = getByTestId("geometry");
+    expect(root.style.getPropertyValue("--workspace-left-width")).toBe("280px");
+    expect(root.style.getPropertyValue("--workspace-right-width")).toBe("360px");
+    expect(requestFrame).not.toHaveBeenCalled();
+  });
+
+  it("clears a pending pin snap before a rapid ordinary toggle", () => {
+    vi.stubGlobal("CSS", { registerProperty: vi.fn() });
+    stubReducedMotion(false);
+    const frames: FrameRequestCallback[] = [];
+    const cancelFrame = vi.spyOn(window, "cancelAnimationFrame");
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    const onToggleLeft = vi.fn();
+    const { getByRole, getByTestId } = render(
+      <GeometryHarness leftWidth={0} rightWidth={0} onToggleLeft={onToggleLeft} />,
+    );
+
+    act(() => getByRole("button", { name: "Pin" }).click());
+    expect(getByTestId("geometry").dataset.snap).toBe("true");
+
+    act(() => getByRole("button", { name: "Toggle" }).click());
+    expect(getByTestId("geometry").dataset.snap).toBe("false");
+    expect(cancelFrame).toHaveBeenCalled();
+    expect(onToggleLeft).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-shell-geometry.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-shell-geometry.ts
@@ -1,0 +1,160 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type RefObject,
+} from "react";
+import { motion } from "@proliferate/design/motion";
+import { usePrefersReducedMotion } from "#product/hooks/ui/motion/use-prefers-reduced-motion";
+
+interface WorkspaceShellWidths {
+  left: number;
+  right: number;
+}
+
+interface UseWorkspaceShellGeometryOptions {
+  leftWidth: number;
+  rightWidth: number;
+  onToggleLeft: () => void;
+}
+
+interface WorkspaceShellGeometry {
+  rootRef: RefObject<HTMLDivElement | null>;
+  style: CSSProperties;
+  snapLeft: boolean;
+  toggleLeft: (options?: { snapGeometry?: boolean }) => void;
+  usesManualInterpolation: boolean;
+}
+
+function needsManualInterpolation(): boolean {
+  if (typeof window === "undefined" || typeof CSS === "undefined") {
+    return false;
+  }
+  return typeof CSS.registerProperty !== "function";
+}
+
+function easeOutCubic(progress: number): number {
+  return 1 - ((1 - progress) ** 3);
+}
+
+export function useWorkspaceShellGeometry({
+  leftWidth,
+  rightWidth,
+  onToggleLeft,
+}: UseWorkspaceShellGeometryOptions): WorkspaceShellGeometry {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const frameRef = useRef<number | null>(null);
+  const snapClearFrameRef = useRef<number | null>(null);
+  const [snapLeft, setSnapLeft] = useState(false);
+  const renderedRef = useRef<WorkspaceShellWidths>({
+    left: leftWidth,
+    right: rightWidth,
+  });
+  const usesManualInterpolation = useRef(needsManualInterpolation()).current;
+  const reducedMotion = usePrefersReducedMotion();
+
+  const toggleLeft = useCallback((options?: { snapGeometry?: boolean }) => {
+    if (snapClearFrameRef.current !== null) {
+      window.cancelAnimationFrame(snapClearFrameRef.current);
+      snapClearFrameRef.current = null;
+    }
+
+    if (!options?.snapGeometry) {
+      setSnapLeft(false);
+      onToggleLeft();
+      return;
+    }
+
+    setSnapLeft(true);
+    onToggleLeft();
+    snapClearFrameRef.current = window.requestAnimationFrame(() => {
+      snapClearFrameRef.current = window.requestAnimationFrame(() => {
+        snapClearFrameRef.current = null;
+        setSnapLeft(false);
+      });
+    });
+  }, [onToggleLeft]);
+
+  useLayoutEffect(() => {
+    if (!usesManualInterpolation) {
+      renderedRef.current = { left: leftWidth, right: rightWidth };
+      return;
+    }
+
+    if (frameRef.current !== null) {
+      window.cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    }
+
+    const root = rootRef.current;
+    if (!root) {
+      return;
+    }
+
+    const from = renderedRef.current;
+    const target = { left: leftWidth, right: rightWidth };
+    const setWidths = (widths: WorkspaceShellWidths) => {
+      renderedRef.current = widths;
+      root.style.setProperty("--workspace-left-width", `${widths.left}px`);
+      root.style.setProperty("--workspace-right-width", `${widths.right}px`);
+    };
+
+    const animateLeft = !snapLeft && from.left !== target.left;
+    const animateRight = from.right !== target.right;
+    if (reducedMotion || (!animateLeft && !animateRight)) {
+      setWidths(target);
+      return;
+    }
+
+    if (snapLeft) {
+      setWidths({ left: target.left, right: from.right });
+    }
+
+    let startedAt: number | null = null;
+    const tick = (timestamp: number) => {
+      startedAt ??= timestamp;
+      const progress = Math.min(1, (timestamp - startedAt) / motion.duration.panelMs);
+      const eased = easeOutCubic(progress);
+      const widths = {
+        left: animateLeft ? from.left + ((target.left - from.left) * eased) : target.left,
+        right: animateRight ? from.right + ((target.right - from.right) * eased) : target.right,
+      };
+      setWidths(widths);
+
+      if (progress < 1) {
+        frameRef.current = window.requestAnimationFrame(tick);
+      } else {
+        frameRef.current = null;
+      }
+    };
+
+    frameRef.current = window.requestAnimationFrame(tick);
+  }, [leftWidth, reducedMotion, rightWidth, snapLeft, usesManualInterpolation]);
+
+  useEffect(() => () => {
+    if (frameRef.current !== null) {
+      window.cancelAnimationFrame(frameRef.current);
+    }
+    if (snapClearFrameRef.current !== null) {
+      window.cancelAnimationFrame(snapClearFrameRef.current);
+    }
+  }, []);
+
+  const rendered = usesManualInterpolation
+    ? renderedRef.current
+    : { left: leftWidth, right: rightWidth };
+
+  return {
+    rootRef,
+    snapLeft,
+    style: {
+      "--workspace-left-width": `${rendered.left}px`,
+      "--workspace-right-width": `${rendered.right}px`,
+    } as CSSProperties,
+    toggleLeft,
+    usesManualInterpolation,
+  };
+}

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-sidebar-peek.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-sidebar-peek.test.tsx
@@ -1,0 +1,74 @@
+/* @vitest-environment jsdom */
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { motion } from "@proliferate/design/motion";
+import { useWorkspaceSidebarPeek } from "#product/hooks/workspaces/ui/use-workspace-sidebar-peek";
+
+vi.mock("#product/hooks/ui/layout/use-coarse-pointer", () => ({
+  useCoarsePointer: () => false,
+}));
+
+function stubReducedMotion(matches: boolean): void {
+  vi.stubGlobal("matchMedia", vi.fn(() => ({
+    matches,
+    media: "(prefers-reduced-motion: reduce)",
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })));
+}
+
+describe("useWorkspaceSidebarPeek", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    stubReducedMotion(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("owns the open, exit, and pin-from-exit transitions", () => {
+    const onToggleSidebar = vi.fn();
+    const { result } = renderHook(() => useWorkspaceSidebarPeek({
+      open: false,
+      onToggleSidebar,
+    }));
+
+    act(() => result.current.activatePeek());
+    expect(result.current.peekState).toBe("open");
+
+    act(() => result.current.deactivatePeek());
+    act(() => vi.advanceTimersByTime(motion.delay.hoverCardHideMs));
+    expect(result.current.peekState).toBe("closing");
+
+    act(() => result.current.handleToggleSidebar());
+    expect(onToggleSidebar).toHaveBeenCalledWith({ snapGeometry: true });
+  });
+
+  it("skips JS-managed presence phases with reduced motion", () => {
+    stubReducedMotion(true);
+    const onToggleSidebar = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ open }) => useWorkspaceSidebarPeek({ open, onToggleSidebar }),
+      { initialProps: { open: true } },
+    );
+
+    rerender({ open: false });
+    expect(result.current.toggleClosing).toBe(false);
+
+    act(() => result.current.activatePeek());
+    expect(result.current.peekState).toBe("open");
+    expect(result.current.peekPreparing).toBe(false);
+
+    act(() => result.current.deactivatePeek());
+    act(() => vi.advanceTimersByTime(motion.delay.hoverCardHideMs));
+    expect(result.current.peekState).toBe("closed");
+    expect(result.current.peekVisible).toBe(false);
+  });
+});

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-sidebar-peek.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-sidebar-peek.ts
@@ -1,0 +1,253 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { motion } from "@proliferate/design/motion";
+import { useCoarsePointer } from "#product/hooks/ui/layout/use-coarse-pointer";
+import { usePrefersReducedMotion } from "#product/hooks/ui/motion/use-prefers-reduced-motion";
+
+export type WorkspaceSidebarPeekState =
+  | "inactive"
+  | "open"
+  | "closing"
+  | "preparing"
+  | "toggle-closing"
+  | "closed";
+
+interface UseWorkspaceSidebarPeekOptions {
+  open: boolean;
+  onToggleSidebar: (options?: { snapGeometry?: boolean }) => void;
+}
+
+export function useWorkspaceSidebarPeek({
+  open,
+  onToggleSidebar,
+}: UseWorkspaceSidebarPeekOptions) {
+  const [peekActive, setPeekActive] = useState(false);
+  const [peekExiting, setPeekExiting] = useState(false);
+  const [peekPreparing, setPeekPreparing] = useState(false);
+  const [toggleCloseActive, setToggleCloseActive] = useState(false);
+  const peekCloseTimerRef = useRef<number | null>(null);
+  const peekExitTimerRef = useRef<number | null>(null);
+  const toggleRestTimerRef = useRef<number | null>(null);
+  const peekPrepareFrameRef = useRef<number | null>(null);
+  const peekShowFrameRef = useRef<number | null>(null);
+  const previousOpenRef = useRef(open);
+  const coarsePointer = useCoarsePointer();
+  const reducedMotion = usePrefersReducedMotion();
+
+  // The ordinary close needs one paint at translate 0. Reduced motion skips
+  // that phase entirely so the edge trigger is available immediately.
+  const closingOnThisRender = !reducedMotion && previousOpenRef.current && !open;
+  const toggleClosing = closingOnThisRender || toggleCloseActive;
+  const peekVisible = peekActive || peekExiting || peekPreparing;
+
+  const cancelPeekClose = useCallback(() => {
+    if (peekCloseTimerRef.current !== null) {
+      window.clearTimeout(peekCloseTimerRef.current);
+      peekCloseTimerRef.current = null;
+    }
+  }, []);
+
+  const cancelPeekExit = useCallback(() => {
+    if (peekExitTimerRef.current !== null) {
+      window.clearTimeout(peekExitTimerRef.current);
+      peekExitTimerRef.current = null;
+    }
+  }, []);
+
+  const cancelPeekPreparation = useCallback(() => {
+    if (peekPrepareFrameRef.current !== null) {
+      window.cancelAnimationFrame(peekPrepareFrameRef.current);
+      peekPrepareFrameRef.current = null;
+    }
+    if (peekShowFrameRef.current !== null) {
+      window.cancelAnimationFrame(peekShowFrameRef.current);
+      peekShowFrameRef.current = null;
+    }
+  }, []);
+
+  const cancelToggleRest = useCallback(() => {
+    if (toggleRestTimerRef.current !== null) {
+      window.clearTimeout(toggleRestTimerRef.current);
+      toggleRestTimerRef.current = null;
+    }
+  }, []);
+
+  const activatePeek = useCallback(() => {
+    if (coarsePointer || open) {
+      return;
+    }
+    cancelPeekClose();
+    cancelPeekExit();
+
+    if (peekActive) {
+      setPeekExiting(false);
+      return;
+    }
+
+    if (toggleClosing) {
+      cancelToggleRest();
+      cancelPeekPreparation();
+      setToggleCloseActive(false);
+      setPeekExiting(false);
+
+      if (reducedMotion) {
+        setPeekPreparing(false);
+        setPeekActive(true);
+        return;
+      }
+
+      // Toggle-close rests at translate 0. Paint the peek's -8px rest state
+      // first, then reveal on the following frame so every animated peek
+      // travels from the window edge.
+      setPeekPreparing(true);
+      peekPrepareFrameRef.current = window.requestAnimationFrame(() => {
+        peekPrepareFrameRef.current = null;
+        peekShowFrameRef.current = window.requestAnimationFrame(() => {
+          peekShowFrameRef.current = null;
+          setPeekPreparing(false);
+          setPeekActive(true);
+        });
+      });
+      return;
+    }
+
+    setPeekPreparing(false);
+    setPeekExiting(false);
+    setPeekActive(true);
+  }, [
+    cancelPeekClose,
+    cancelPeekExit,
+    cancelPeekPreparation,
+    cancelToggleRest,
+    coarsePointer,
+    open,
+    peekActive,
+    reducedMotion,
+    toggleClosing,
+  ]);
+
+  const holdPeek = useCallback(() => {
+    if (
+      open
+      || (!peekActive
+        && !peekExiting
+        && !peekPreparing
+        && peekCloseTimerRef.current === null)
+    ) {
+      return;
+    }
+    activatePeek();
+  }, [activatePeek, open, peekActive, peekExiting, peekPreparing]);
+
+  const deactivatePeek = useCallback(() => {
+    if (open || !peekActive) {
+      return;
+    }
+    cancelPeekClose();
+    peekCloseTimerRef.current = window.setTimeout(() => {
+      peekCloseTimerRef.current = null;
+      setPeekActive(false);
+      cancelPeekExit();
+
+      if (reducedMotion) {
+        setPeekExiting(false);
+        return;
+      }
+
+      setPeekExiting(true);
+      peekExitTimerRef.current = window.setTimeout(() => {
+        peekExitTimerRef.current = null;
+        setPeekExiting(false);
+      }, motion.duration.exitMs);
+    }, motion.delay.hoverCardHideMs);
+  }, [cancelPeekClose, cancelPeekExit, open, peekActive, reducedMotion]);
+
+  useLayoutEffect(() => {
+    const wasOpen = previousOpenRef.current;
+    previousOpenRef.current = open;
+
+    if (open || reducedMotion) {
+      cancelToggleRest();
+      setToggleCloseActive(false);
+      return;
+    }
+    if (!wasOpen) {
+      return;
+    }
+
+    setToggleCloseActive(true);
+    cancelToggleRest();
+    toggleRestTimerRef.current = window.setTimeout(() => {
+      toggleRestTimerRef.current = null;
+      setToggleCloseActive(false);
+    }, motion.duration.panelMs);
+  }, [cancelToggleRest, open, reducedMotion]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    cancelPeekClose();
+    cancelPeekExit();
+    cancelPeekPreparation();
+    setPeekActive(false);
+    setPeekExiting(false);
+    setPeekPreparing(false);
+  }, [cancelPeekClose, cancelPeekExit, cancelPeekPreparation, open]);
+
+  useEffect(() => () => {
+    cancelPeekClose();
+    cancelPeekExit();
+    cancelPeekPreparation();
+    cancelToggleRest();
+  }, [cancelPeekClose, cancelPeekExit, cancelPeekPreparation, cancelToggleRest]);
+
+  const handleToggleSidebar = useCallback(() => {
+    const snapGeometry = !open && (peekActive || peekExiting);
+    cancelPeekClose();
+    cancelPeekExit();
+    cancelPeekPreparation();
+    setPeekActive(false);
+    setPeekExiting(false);
+    setPeekPreparing(false);
+    onToggleSidebar({ snapGeometry });
+  }, [
+    cancelPeekClose,
+    cancelPeekExit,
+    cancelPeekPreparation,
+    onToggleSidebar,
+    open,
+    peekActive,
+    peekExiting,
+  ]);
+
+  const peekState: WorkspaceSidebarPeekState = open
+    ? "inactive"
+    : peekActive
+      ? "open"
+      : peekExiting
+        ? "closing"
+        : peekPreparing
+          ? "preparing"
+          : toggleClosing
+            ? "toggle-closing"
+            : "closed";
+
+  return {
+    activatePeek,
+    deactivatePeek,
+    handleToggleSidebar,
+    holdPeek,
+    peekActive,
+    peekExiting,
+    peekPreparing,
+    peekState,
+    peekVisible,
+    toggleClosing,
+  };
+}

--- a/apps/packages/product-client/src/lib/domain/preferences/workspace-chrome.test.ts
+++ b/apps/packages/product-client/src/lib/domain/preferences/workspace-chrome.test.ts
@@ -30,7 +30,7 @@ describe("workspace chrome classes", () => {
       sidebarOpen: true,
     })).toEqual({
       root: "bg-sidebar",
-      contentShell: "bg-background rounded-tl-2xl border-l border-border border-t",
+      contentShell: "bg-background border-l transition-[border-color,border-top-left-radius] duration-panel ease-out-cubic border-t rounded-tl-2xl border-border",
       header: "flex h-[46px] shrink-0 items-center bg-background relative after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-border after:content-['']",
     });
 
@@ -41,7 +41,7 @@ describe("workspace chrome classes", () => {
     expect(resolveStandardWorkspaceChromeClasses({
       transparent: false,
       sidebarOpen: false,
-    }).contentShell).toBe("bg-background");
+    }).contentShell).toBe("bg-background border-l transition-[border-color,border-top-left-radius] duration-panel ease-out-cubic border-t rounded-tl-none border-transparent");
   });
 
   it("matches cowork content chrome to the standard shell", () => {

--- a/apps/packages/product-client/src/lib/domain/preferences/workspace-chrome.ts
+++ b/apps/packages/product-client/src/lib/domain/preferences/workspace-chrome.ts
@@ -85,11 +85,15 @@ export function resolveStandardWorkspaceChromeClasses({
     // opaque regardless of chrome mode, so a transparent shell only ever
     // exposed window vibrancy through the header/footer/right-panel bands —
     // rendering them as off-shade stripes on every theme.
-    contentShell: [
-      "bg-background",
-      sidebarOpen && !transparent ? "rounded-tl-2xl border-l border-border" : "",
-      sidebarOpen && !transparent && showContentTopBorder ? "border-t" : "",
-    ].filter(Boolean).join(" "),
+    contentShell: transparent
+      ? "bg-background"
+      : [
+          "bg-background border-l transition-[border-color,border-top-left-radius] duration-panel ease-out-cubic",
+          showContentTopBorder ? "border-t" : "",
+          sidebarOpen
+            ? "rounded-tl-2xl border-border"
+            : "rounded-tl-none border-transparent",
+        ].filter(Boolean).join(" "),
     header,
   };
 }


### PR DESCRIPTION
## Summary

- synchronize left/sidebar and right-panel geometry so header content dwells, panel content fades in place, and dividers track the animated edges
- keep both panel toggles pinned in window chrome while preserving peek, keyboard, reduced-motion, and unsupported-renderer behavior
- align native macOS controls and all shared top-chrome rows to the same 46px geometry

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Verification

- `pnpm exec vitest run` on 11 focused product-client files: 72 passed
- `pnpm --filter @proliferate/product-client build`
- `cargo test -p proliferate window_chrome --lib` (native compile; 91 tests filtered)
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/report_frontend_structure.py --strict`
- `python3 scripts/check_design_attribution.py`
- `jq empty apps/desktop/src-tauri/tauri.conf.json apps/desktop/src-tauri/tauri.dev.json`
- `git diff --check origin/main...HEAD`