### PR TITLE
perf(transcript): protect scroll frames during streaming

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -34,7 +34,7 @@
     "@proliferate/product-client": "workspace:*",
     "@sentry/react": "^10.67.0",
     "@tanstack/react-query": "^5.101.4",
-    "@tanstack/react-virtual": "3.14.8",
+    "@tanstack/react-virtual": "3.14.9",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-deep-link": "^2.4.9",
     "@tauri-apps/plugin-process": "^2",

--- a/apps/packages/product-client/package.json
+++ b/apps/packages/product-client/package.json
@@ -81,7 +81,7 @@
     "@radix-ui/react-slot": "^1.3.0",
     "@radix-ui/react-tooltip": "^1.2.12",
     "@tanstack/react-query": "^5.101.4",
-    "@tanstack/react-virtual": "3.14.8",
+    "@tanstack/react-virtual": "3.14.9",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",

--- a/apps/packages/product-client/src/components/playground/transcript/PlaygroundRecordingTranscript.tsx
+++ b/apps/packages/product-client/src/components/playground/transcript/PlaygroundRecordingTranscript.tsx
@@ -49,7 +49,7 @@ export function PlaygroundRecordingTranscript({
   }
 
   return (
-    <div className="h-[min(720px,calc(100vh-13rem))] min-h-[420px]">
+    <div className="flex h-[min(720px,calc(100vh-13rem))] min-h-[420px] flex-col">
       <MessageList
         activeSessionId={replay.sessionId}
         selectedWorkspaceId={selectedWorkspaceId ?? replay.workspaceId}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/AssistantMessage.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/AssistantMessage.test.tsx
@@ -9,6 +9,11 @@ import {
   AssistantMessage,
 } from "./AssistantMessage";
 import {
+  TranscriptScrollPriorityProvider,
+  TranscriptUserScrollProvider,
+} from "./TranscriptScrollPriorityContext";
+import { useTranscriptScrollPriority } from "#product/hooks/chat/ui/use-transcript-scroll-priority";
+import {
   selectVisibleTarget,
 } from "#product/lib/domain/chat/transcript/assistant-message-reveal";
 import {
@@ -124,6 +129,81 @@ describe("AssistantMessage streaming reveal", () => {
       (elapsedMs * MAX_STREAM_REVEAL_CHARACTERS_PER_SECOND) / 1_000,
     );
     expect(container.textContent?.length).toBeLessThanOrEqual(maximumVisible);
+  });
+
+  it("pauses reveal commits while the user scrolls and resumes without a catch-up jump", () => {
+    const initialContent = (
+      "A live answer keeps arriving while the reader inspects earlier transcript rows. "
+    ).repeat(8);
+    const renderMessage = (content: string, userScrollActive: boolean) => (
+      <TranscriptUserScrollProvider value={userScrollActive}>
+        <AssistantMessage content={content} isStreaming />
+      </TranscriptUserScrollProvider>
+    );
+    const { container, rerender } = render(renderMessage(initialContent, false));
+
+    flushNextFrame();
+    const visibleBeforeScroll = container.textContent ?? "";
+    expect(visibleBeforeScroll.length).toBeGreaterThan(0);
+    expect(visibleBeforeScroll.length).toBeLessThan(initialContent.length);
+    expect(pendingFrames.size).toBe(1);
+
+    rerender(renderMessage(initialContent, true));
+    expect(pendingFrames.size).toBe(0);
+
+    const expandedContent = `${initialContent}${"More streamed prose. ".repeat(20)}`;
+    rerender(renderMessage(expandedContent, true));
+    expect(container.textContent).toBe(visibleBeforeScroll);
+    expect(pendingFrames.size).toBe(0);
+
+    rerender(renderMessage(expandedContent, false));
+    expect(pendingFrames.size).toBe(1);
+    flushNextFrame();
+
+    const visibleAfterResume = container.textContent ?? "";
+    const maximumFirstFrameGrowth = Math.ceil(
+      (16 * MAX_STREAM_REVEAL_CHARACTERS_PER_SECOND) / 1_000,
+    );
+    expect(visibleAfterResume.length).toBeGreaterThan(visibleBeforeScroll.length);
+    expect(
+      visibleAfterResume.length - visibleBeforeScroll.length,
+    ).toBeLessThanOrEqual(maximumFirstFrameGrowth);
+    expect(visibleAfterResume.length).toBeLessThan(expandedContent.length);
+  });
+
+  it("cancels a queued reveal frame synchronously when scroll intent arrives", () => {
+    const content = "A queued reveal must yield before the browser paints a user scroll. ".repeat(8);
+    let claimScroll: ((sample: {
+      programmatic: boolean;
+      userInitiated?: true;
+    }) => void) | null = null;
+
+    function Harness() {
+      const priority = useTranscriptScrollPriority({
+        latestValue: 1,
+        scopeKey: "workspace:session",
+      });
+      claimScroll = priority.prioritizeScrollSample;
+      return (
+        <TranscriptScrollPriorityProvider
+          isUserScrolling={priority.isUserScrolling}
+          registerSynchronousPause={priority.registerSynchronousPause}
+        >
+          <AssistantMessage content={content} isStreaming />
+        </TranscriptScrollPriorityProvider>
+      );
+    }
+
+    render(<Harness />);
+    expect(pendingFrames.size).toBe(1);
+
+    act(() => {
+      claimScroll?.({ programmatic: false, userInitiated: true });
+      // This assertion runs before React flushes the state update at the end
+      // of act, proving cancellation happened in the input call stack.
+      expect(pendingFrames.size).toBe(0);
+    });
+    expect(pendingFrames.size).toBe(0);
   });
 
   it("rewinds a corrected stream to its common prefix instead of snapping", () => {

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/AssistantMessageContent.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/AssistantMessageContent.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   MarkdownBody,
   type MarkdownCodeBlockRenderer,
@@ -22,6 +28,10 @@ import {
   STREAM_REVEAL_IDLE_MS,
   STREAM_REVEAL_SETTLE_MS,
 } from "#product/config/assistant-message-reveal";
+import {
+  useTranscriptScrollPauseRegistration,
+  useTranscriptUserScrollActive,
+} from "./TranscriptScrollPriorityContext";
 
 // Assistant prose has one source-ordered reveal frontier. The visible content
 // is always a prefix, while recent words keep independent opacity animations.
@@ -46,6 +56,7 @@ export function AssistantMessageContent({
   renderInlineCode?: MarkdownInlineCodeRenderer;
   renderCodeBlock?: MarkdownCodeBlockRenderer;
 }) {
+  const userScrollActive = useTranscriptUserScrollActive();
   const [visibleContent, setVisibleContent] = useState(() =>
     initialVisibleContent(content, animateReveal, initialVisibleLength),
   );
@@ -70,16 +81,16 @@ export function AssistantMessageContent({
     revealPhaseRef.current = phase;
     setRevealPhase(phase);
   };
-  const cancelFlush = () => {
+  const cancelFlush = useCallback(() => {
     if (flushFrameRef.current === null) return;
     window.cancelAnimationFrame(flushFrameRef.current);
     flushFrameRef.current = null;
-  };
+  }, []);
   const commitVisibleContent = (nextContent: string) => {
     visibleContentRef.current = nextContent;
     setVisibleContent(nextContent);
   };
-  const cancelSettle = () => {
+  const cancelSettle = useCallback(() => {
     if (settleDelayRef.current !== null) {
       window.clearTimeout(settleDelayRef.current);
       settleDelayRef.current = null;
@@ -88,7 +99,15 @@ export function AssistantMessageContent({
       window.clearTimeout(settleFinishRef.current);
       settleFinishRef.current = null;
     }
-  };
+  }, []);
+  const pauseReveal = useCallback(() => {
+    cancelFlush();
+    cancelSettle();
+    lastFlushAtRef.current = 0;
+    lastVisibleCommitAtRef.current = 0;
+    revealCharacterBudgetRef.current = 0;
+  }, [cancelFlush, cancelSettle]);
+  useTranscriptScrollPauseRegistration(pauseReveal);
   const beginSettle = () => {
     cancelSettle();
     if (revealPhaseRef.current === "idle") return;
@@ -171,6 +190,11 @@ export function AssistantMessageContent({
       return;
     }
 
+    if (userScrollActive) {
+      pauseReveal();
+      return;
+    }
+
     if (!content.startsWith(visible)) {
       cancelFlush();
       cancelSettle();
@@ -210,12 +234,12 @@ export function AssistantMessageContent({
     commitRevealPhase("active");
     scheduleFlush();
     return cancelFlush;
-  }, [animateReveal, content, isStreaming]);
+  }, [animateReveal, content, isStreaming, pauseReveal, userScrollActive]);
 
   useEffect(() => () => {
     cancelFlush();
     cancelSettle();
-  }, []);
+  }, [cancelFlush, cancelSettle]);
 
   const splitContent = useMemo(
     () => splitAssistantContent(visibleContent),

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.tsx
@@ -77,6 +77,7 @@ export function FullTranscriptRowList({
     isPinnedToBottom,
     pinnedRef,
     onViewportScroll,
+    notifyUserScrollIntent,
     scrollToBottom,
     handleScrollToBottomClick,
     notifyProgrammaticScroll,
@@ -259,6 +260,7 @@ export function FullTranscriptRowList({
       <AutoHideScrollArea
         className="h-full"
         ref={scrollRef}
+        onUserScrollIntent={notifyUserScrollIntent}
         onViewportScroll={handleViewportScroll}
         contentClassName={`${gutterClassName} relative flex min-h-full flex-col`}
       >

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.tsx
@@ -13,13 +13,6 @@ import { useWorkspaceFileActions } from "#product/hooks/workspaces/facade/files/
 import { useDebugRenderCount } from "#product/hooks/ui/debug/use-debug-render-count";
 import { useOpenCoworkArtifact } from "#product/hooks/cowork/workflows/use-open-cowork-artifact";
 import type { PromptPlanAttachmentDescriptor } from "#product/domain/chats/composer/prompt-plan-attachments";
-import {
-  finishOrCancelMeasurementOperation,
-  markOperationForNextCommit,
-  recordMeasurementMetric,
-  startMeasurementOperation,
-} from "#product/lib/infra/measurement/measurement-port";
-import type { MeasurementOperationId } from "#product/lib/domain/telemetry/debug-measurement-catalog";
 import type { PromptOutboxEntry } from "#product/domain/sessions/intents/session-intent-model";
 import { usePromptOutboxActions } from "#product/hooks/chat/workflows/use-prompt-outbox-actions";
 import { useTypingActivityStore } from "#product/lib/infra/interaction/typing-activity-store";
@@ -62,6 +55,7 @@ import { TranscriptTurnRow } from "#product/components/workspace/chat/transcript
 import { TranscriptEntryMotionProvider } from "#product/components/workspace/chat/transcript/TranscriptEntryMotionContext";
 import { TranscriptScrollPriorityProvider } from "#product/components/workspace/chat/transcript/TranscriptScrollPriorityContext";
 import { useTranscriptScrollPriority } from "#product/hooks/chat/ui/use-transcript-scroll-priority";
+import { useTranscriptScrollSample } from "#product/hooks/chat/ui/use-transcript-scroll-sample";
 
 const EMPTY_OUTBOX_ENTRIES: readonly PromptOutboxEntry[] = [];
 const EMPTY_GOAL_EVENTS: readonly GoalTranscriptEvent[] = [];
@@ -115,7 +109,6 @@ export function MessageList({
   canOpenSession,
 }: MessageListProps) {
   useDebugRenderCount("transcript-list");
-  const scrollSampleOperationRef = useRef<MeasurementOperationId | null>(null);
   const {
     retryPrompt,
     dismissPrompt,
@@ -254,61 +247,7 @@ export function MessageList({
     proposedPlanToolCallIdsRef.current = proposedPlanToolCallIds;
   }, [proposedPlanToolCallIds]);
 
-  const handleTranscriptScroll = useCallback((sample?: {
-    programmatic: boolean;
-    userInitiated?: true;
-  }) => {
-    prioritizeScrollSample(sample);
-    // Tag the scroll source: a persistent stream of `source.programmatic`
-    // samples (with no user input) means a stick-to-bottom snap / virtualizer
-    // measurement feedback loop — the difference between "user scrolled" and
-    // "we are scrolling ourselves in circles".
-    recordMeasurementMetric({
-      type: "diagnostic",
-      category: "transcript_scroll",
-      label: sample === undefined
-        ? "source.unknown"
-        : sample.programmatic
-          ? "source.programmatic"
-          : sample.userInitiated
-            ? "source.user"
-            : "source.unclassified",
-      count: 1,
-    });
-    const operationId = startMeasurementOperation({
-      kind: "transcript_scroll",
-      sampleKey: "transcript",
-      surfaces: [
-        "transcript-list",
-        "transcript-context-providers",
-        "transcript-row-list-router",
-        "transcript-virtualized-viewport",
-        "transcript-full-list",
-        "session-transcript-pane",
-        "chat-surface",
-      ],
-      idleTimeoutMs: 750,
-      maxDurationMs: 8000,
-      cooldownMs: 1500,
-    });
-    if (operationId) {
-      scrollSampleOperationRef.current = operationId;
-      markOperationForNextCommit(operationId, [
-        "transcript-list",
-        "transcript-context-providers",
-        "transcript-row-list-router",
-        "transcript-virtualized-viewport",
-        "transcript-full-list",
-        "session-transcript-pane",
-        "chat-surface",
-      ]);
-    }
-  }, [prioritizeScrollSample]);
-
-  useEffect(() => () => {
-    finishOrCancelMeasurementOperation(scrollSampleOperationRef.current, "unmount");
-    scrollSampleOperationRef.current = null;
-  }, []);
+  const handleTranscriptScroll = useTranscriptScrollSample(prioritizeScrollSample);
 
   const renderPendingPromptRow = useCallback((input: ChatTranscriptPendingPromptRenderInput) => (
     <TranscriptPendingPromptRow

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.tsx
@@ -60,6 +60,8 @@ import { GoalTranscriptEventRow } from "#product/components/workspace/chat/trans
 import { TranscriptPendingPromptRow } from "#product/components/workspace/chat/transcript/TranscriptPendingPromptRow";
 import { TranscriptTurnRow } from "#product/components/workspace/chat/transcript/TranscriptTurnRow";
 import { TranscriptEntryMotionProvider } from "#product/components/workspace/chat/transcript/TranscriptEntryMotionContext";
+import { TranscriptScrollPriorityProvider } from "#product/components/workspace/chat/transcript/TranscriptScrollPriorityContext";
+import { useTranscriptScrollPriority } from "#product/hooks/chat/ui/use-transcript-scroll-priority";
 
 const EMPTY_OUTBOX_ENTRIES: readonly PromptOutboxEntry[] = [];
 const EMPTY_GOAL_EVENTS: readonly GoalTranscriptEvent[] = [];
@@ -159,9 +161,18 @@ export function MessageList({
   ]);
   const deferredTranscriptViewState = useDeferredValue(transcriptViewState);
   const typingActive = useTypingActivityStore((state) => state.typingActive);
-  const effectiveTranscriptViewState = typingActive
+  const typingPrioritizedTranscriptViewState = typingActive
     ? deferredTranscriptViewState
     : transcriptViewState;
+  const {
+    effectiveValue: effectiveTranscriptViewState,
+    isUserScrolling,
+    prioritizeScrollSample,
+    registerSynchronousPause,
+  } = useTranscriptScrollPriority({
+    latestValue: typingPrioritizedTranscriptViewState,
+    scopeKey: `${selectedWorkspaceId ?? "workspace"}:${activeSessionId}`,
+  });
 
   // Chat content search (Cmd+F). The index hook owns match counts/navigation;
   // the paint prop + scroll handle drive highlighting and jump-to-match. All of
@@ -243,7 +254,11 @@ export function MessageList({
     proposedPlanToolCallIdsRef.current = proposedPlanToolCallIds;
   }, [proposedPlanToolCallIds]);
 
-  const handleTranscriptScroll = useCallback((sample?: { programmatic: boolean }) => {
+  const handleTranscriptScroll = useCallback((sample?: {
+    programmatic: boolean;
+    userInitiated?: true;
+  }) => {
+    prioritizeScrollSample(sample);
     // Tag the scroll source: a persistent stream of `source.programmatic`
     // samples (with no user input) means a stick-to-bottom snap / virtualizer
     // measurement feedback loop — the difference between "user scrolled" and
@@ -255,7 +270,9 @@ export function MessageList({
         ? "source.unknown"
         : sample.programmatic
           ? "source.programmatic"
-          : "source.user",
+          : sample.userInitiated
+            ? "source.user"
+            : "source.unclassified",
       count: 1,
     });
     const operationId = startMeasurementOperation({
@@ -286,7 +303,7 @@ export function MessageList({
         "chat-surface",
       ]);
     }
-  }, []);
+  }, [prioritizeScrollSample]);
 
   useEffect(() => () => {
     finishOrCancelMeasurementOperation(scrollSampleOperationRef.current, "unmount");
@@ -360,27 +377,32 @@ export function MessageList({
           onOpenSession={onOpenSession}
           canOpenSession={canOpenSession}
         >
-          <TranscriptEntryMotionProvider
-            key={`${effectiveTranscriptViewState.selectedWorkspaceId ?? "workspace"}:${effectiveTranscriptViewState.activeSessionId}`}
-            transcript={effectiveTranscriptViewState.transcript}
+          <TranscriptScrollPriorityProvider
+            isUserScrolling={isUserScrolling}
+            registerSynchronousPause={registerSynchronousPause}
           >
-            <ProposedPlanToolCallIdsProvider value={proposedPlanToolCallIds}>
-              <DebugProfiler id="transcript-row-list-router">
-                <DeferredChatTranscriptView
-                  state={effectiveTranscriptViewState}
-                  outboxActions={outboxActions}
-                  onScrollSample={handleTranscriptScroll}
-                  renderPendingPromptRow={renderPendingPromptRow}
-                  renderTurnRow={renderTurnRow}
-                  renderGoalEventRow={renderGoalEventRow}
-                  renderPendingPromptTrailingStatus={renderPendingPromptTrailingStatusRow}
-                  renderTurnTrailingStatus={renderTurnTrailingStatusRow}
-                  contentSearch={contentSearchPaint}
-                  scrollHandleRef={transcriptScrollHandleRef}
-                />
-              </DebugProfiler>
-            </ProposedPlanToolCallIdsProvider>
-          </TranscriptEntryMotionProvider>
+            <TranscriptEntryMotionProvider
+              key={`${effectiveTranscriptViewState.selectedWorkspaceId ?? "workspace"}:${effectiveTranscriptViewState.activeSessionId}`}
+              transcript={effectiveTranscriptViewState.transcript}
+            >
+              <ProposedPlanToolCallIdsProvider value={proposedPlanToolCallIds}>
+                <DebugProfiler id="transcript-row-list-router">
+                  <DeferredChatTranscriptView
+                    state={effectiveTranscriptViewState}
+                    outboxActions={outboxActions}
+                    onScrollSample={handleTranscriptScroll}
+                    renderPendingPromptRow={renderPendingPromptRow}
+                    renderTurnRow={renderTurnRow}
+                    renderGoalEventRow={renderGoalEventRow}
+                    renderPendingPromptTrailingStatus={renderPendingPromptTrailingStatusRow}
+                    renderTurnTrailingStatus={renderTurnTrailingStatusRow}
+                    contentSearch={contentSearchPaint}
+                    scrollHandleRef={transcriptScrollHandleRef}
+                  />
+                </DebugProfiler>
+              </ProposedPlanToolCallIdsProvider>
+            </TranscriptEntryMotionProvider>
+          </TranscriptScrollPriorityProvider>
         </TranscriptContextProviders>
       </DebugProfiler>
     </DebugProfiler>

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptScrollPriorityContext.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptScrollPriorityContext.tsx
@@ -1,0 +1,45 @@
+import {
+  createContext,
+  useContext,
+  useLayoutEffect,
+  type ReactNode,
+} from "react";
+import type { TranscriptScrollPauseListener } from "#product/hooks/chat/ui/use-transcript-scroll-priority";
+
+const TranscriptUserScrollContext = createContext(false);
+type RegisterSynchronousPause = (
+  listener: TranscriptScrollPauseListener,
+) => () => void;
+const TranscriptScrollPauseRegistryContext =
+  createContext<RegisterSynchronousPause | null>(null);
+
+export const TranscriptUserScrollProvider = TranscriptUserScrollContext.Provider;
+
+export function TranscriptScrollPriorityProvider({
+  children,
+  isUserScrolling,
+  registerSynchronousPause,
+}: {
+  children: ReactNode;
+  isUserScrolling: boolean;
+  registerSynchronousPause: RegisterSynchronousPause;
+}) {
+  return (
+    <TranscriptScrollPauseRegistryContext.Provider value={registerSynchronousPause}>
+      <TranscriptUserScrollProvider value={isUserScrolling}>
+        {children}
+      </TranscriptUserScrollProvider>
+    </TranscriptScrollPauseRegistryContext.Provider>
+  );
+}
+
+export function useTranscriptUserScrollActive() {
+  return useContext(TranscriptUserScrollContext);
+}
+
+export function useTranscriptScrollPauseRegistration(
+  listener: TranscriptScrollPauseListener,
+) {
+  const register = useContext(TranscriptScrollPauseRegistryContext);
+  useLayoutEffect(() => register?.(listener), [listener, register]);
+}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualTranscriptViewport.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualTranscriptViewport.tsx
@@ -20,6 +20,7 @@ export function VirtualTranscriptViewport({
   nonDisplacingBottomInsetPx,
   contentRef,
   measureElement,
+  onUserScrollIntent,
   onViewportScroll,
   renderableRows,
   renderRow,
@@ -38,6 +39,7 @@ export function VirtualTranscriptViewport({
   contentRef?: RefObject<HTMLDivElement | null>;
   gutterClassName?: string;
   measureElement: (element: Element | null) => void;
+  onUserScrollIntent: (direction: -1 | 1) => void;
   onViewportScroll: (viewport: HTMLDivElement) => void;
   renderableRows: readonly TranscriptRenderableRow[];
   renderRow: TranscriptRowListBaseProps["renderRow"];
@@ -52,6 +54,7 @@ export function VirtualTranscriptViewport({
     <AutoHideScrollArea
       className="h-full"
       ref={scrollRef}
+      onUserScrollIntent={onUserScrollIntent}
       onViewportScroll={onViewportScroll}
       contentClassName={`${gutterClassName} relative flex min-h-full flex-col`}
     >

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx
@@ -149,6 +149,7 @@ describe("VirtualizedTranscriptRowList", () => {
     const viewport = getViewport(container);
     Object.defineProperty(viewport, "scrollHeight", { value: 2000, configurable: true });
     Object.defineProperty(viewport, "clientHeight", { value: 300, configurable: true });
+    viewport.scrollTop = 1_700;
 
     act(() => {
       fireEvent.wheel(viewport, { deltaY: -80 });

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.tsx
@@ -63,6 +63,7 @@ export function VirtualizedTranscriptRowList({
     isPinnedToBottom,
     pinnedRef,
     onViewportScroll,
+    notifyUserScrollIntent,
     scrollToBottom,
     handleScrollToBottomClick,
     notifyProgrammaticScroll,
@@ -373,6 +374,7 @@ export function VirtualizedTranscriptRowList({
         contentRef={contentRef}
         gutterClassName={gutterClassName}
         measureElement={virtualizer.measureElement}
+        onUserScrollIntent={notifyUserScrollIntent}
         onViewportScroll={handleViewportScroll}
         renderableRows={renderableRows}
         renderRow={renderRow}

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-row-list-model.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-row-list-model.ts
@@ -2,9 +2,10 @@ import type { ReactNode, RefObject } from "react";
 import type { TranscriptVirtualRow } from "#product/domain/chats/transcript/transcript-virtual-rows";
 import type { ChatTranscriptScrollHandle } from "#product/hooks/chat/ui/chat-transcript-view-types";
 
-/** Classification of a viewport scroll event: our own snap vs the user. */
+/** Classification of a viewport scroll event and whether input intent proved user ownership. */
 export interface TranscriptScrollSample {
   programmatic: boolean;
+  userInitiated?: true;
 }
 
 export const TRANSCRIPT_TOP_PADDING_PX = 16;
@@ -25,6 +26,9 @@ export const DIRECTION_EPSILON_PX = 1;
 // nothing would re-pin and the scroll-to-bottom button would wrongly show while
 // already at the bottom.
 export const SCROLLABLE_OVERFLOW_EPSILON_PX = 1;
+// User input and the rendering gate share one expiry so a late native or
+// virtualizer correction cannot re-open a gate after the proven intent ended.
+export const TRANSCRIPT_USER_SCROLL_SETTLE_MS = 150;
 // Visibility-resume glue loop: hold the viewport at the bottom each frame until
 // measured scrollHeight is stable for this many consecutive frames, capped at
 // GLUE_MAX_FRAMES, so a suspended-then-resumed measurement backlog collapses

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-scroll-priority.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-scroll-priority.test.tsx
@@ -1,0 +1,188 @@
+// @vitest-environment jsdom
+
+import { Suspense, startTransition, useState } from "react";
+import { act, render, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  TRANSCRIPT_USER_SCROLL_SETTLE_MS,
+  useTranscriptScrollPriority,
+} from "./use-transcript-scroll-priority";
+
+interface Snapshot {
+  revision: number;
+}
+
+describe("useTranscriptScrollPriority", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("holds a stable snapshot across stream updates while user scrolling is active", () => {
+    let latestValue: Snapshot = { revision: 1 };
+    const rendered = renderHook(() => useTranscriptScrollPriority({
+      latestValue,
+      scopeKey: "workspace:session",
+    }));
+
+    act(() => {
+      rendered.result.current.prioritizeScrollSample({
+        programmatic: false,
+        userInitiated: true,
+      });
+    });
+    expect(rendered.result.current.isUserScrolling).toBe(true);
+
+    latestValue = { revision: 2 };
+    rendered.rerender();
+    expect(rendered.result.current.effectiveValue.revision).toBe(1);
+
+    act(() => {
+      vi.advanceTimersByTime(TRANSCRIPT_USER_SCROLL_SETTLE_MS - 1);
+    });
+    expect(rendered.result.current.effectiveValue.revision).toBe(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(rendered.result.current.effectiveValue.revision).toBe(2);
+    expect(rendered.result.current.isUserScrolling).toBe(false);
+  });
+
+  it("extends the hold until the final user scroll sample settles", () => {
+    let latestValue: Snapshot = { revision: 1 };
+    const rendered = renderHook(() => useTranscriptScrollPriority({
+      latestValue,
+      scopeKey: "workspace:session",
+    }));
+
+    act(() => {
+      rendered.result.current.prioritizeScrollSample({
+        programmatic: false,
+        userInitiated: true,
+      });
+      vi.advanceTimersByTime(TRANSCRIPT_USER_SCROLL_SETTLE_MS - 10);
+      rendered.result.current.prioritizeScrollSample({ programmatic: false });
+    });
+    latestValue = { revision: 2 };
+    rendered.rerender();
+
+    act(() => {
+      vi.advanceTimersByTime(TRANSCRIPT_USER_SCROLL_SETTLE_MS - 1);
+    });
+    expect(rendered.result.current.effectiveValue.revision).toBe(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(rendered.result.current.effectiveValue.revision).toBe(2);
+  });
+
+  it("cannot reopen a settled hold from an unclassified correction", () => {
+    let latestValue: Snapshot = { revision: 1 };
+    const rendered = renderHook(() => useTranscriptScrollPriority({
+      latestValue,
+      scopeKey: "workspace:session",
+    }));
+
+    act(() => {
+      rendered.result.current.prioritizeScrollSample({
+        programmatic: false,
+        userInitiated: true,
+      });
+      vi.advanceTimersByTime(TRANSCRIPT_USER_SCROLL_SETTLE_MS);
+      rendered.result.current.prioritizeScrollSample({ programmatic: false });
+    });
+    latestValue = { revision: 2 };
+    rendered.rerender();
+
+    expect(rendered.result.current.isUserScrolling).toBe(false);
+    expect(rendered.result.current.effectiveValue.revision).toBe(2);
+  });
+
+  it("does not hold updates for programmatic, unclassified, or unknown scroll samples", () => {
+    let latestValue: Snapshot = { revision: 1 };
+    const rendered = renderHook(() => useTranscriptScrollPriority({
+      latestValue,
+      scopeKey: "workspace:session",
+    }));
+
+    act(() => {
+      rendered.result.current.prioritizeScrollSample({ programmatic: true });
+      rendered.result.current.prioritizeScrollSample({ programmatic: false });
+      rendered.result.current.prioritizeScrollSample();
+    });
+    latestValue = { revision: 2 };
+    rendered.rerender();
+
+    expect(rendered.result.current.effectiveValue.revision).toBe(2);
+  });
+
+  it("cannot carry a frozen transcript across a session switch", () => {
+    let latestValue: Snapshot = { revision: 1 };
+    let scopeKey = "workspace:session-a";
+    const rendered = renderHook(() => useTranscriptScrollPriority({
+      latestValue,
+      scopeKey,
+    }));
+
+    act(() => {
+      rendered.result.current.prioritizeScrollSample({
+        programmatic: false,
+        userInitiated: true,
+      });
+    });
+
+    latestValue = { revision: 2 };
+    scopeKey = "workspace:session-b";
+    rendered.rerender();
+
+    expect(rendered.result.current.effectiveValue.revision).toBe(2);
+  });
+
+  it("never freezes state from an abandoned concurrent render", () => {
+    const suspendedForever = new Promise<void>(() => {});
+    let attemptedRevision = 0;
+    let beginSuspendedUpdate = () => {};
+    let claimScroll: ((sample: {
+      programmatic: boolean;
+      userInitiated?: true;
+    }) => void) | null = null;
+
+    function Harness() {
+      const [revision, setRevision] = useState(1);
+      const priority = useTranscriptScrollPriority({
+        latestValue: { revision },
+        scopeKey: "workspace:session",
+      });
+      attemptedRevision = revision;
+      beginSuspendedUpdate = () => {
+        startTransition(() => setRevision(2));
+      };
+      claimScroll = priority.prioritizeScrollSample;
+      if (revision === 2) {
+        throw suspendedForever;
+      }
+      return <div data-testid="revision">{priority.effectiveValue.revision}</div>;
+    }
+
+    const rendered = render(
+      <Suspense fallback={<div>loading</div>}>
+        <Harness />
+      </Suspense>,
+    );
+    expect(rendered.getByTestId("revision").textContent).toBe("1");
+
+    act(() => beginSuspendedUpdate());
+    expect(attemptedRevision).toBe(2);
+    expect(rendered.getByTestId("revision").textContent).toBe("1");
+
+    act(() => {
+      claimScroll?.({ programmatic: false, userInitiated: true });
+    });
+    expect(rendered.getByTestId("revision").textContent).toBe("1");
+  });
+});

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-scroll-priority.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-scroll-priority.ts
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { TRANSCRIPT_USER_SCROLL_SETTLE_MS } from "#product/hooks/chat/ui/transcript-row-list-model";
+
+export { TRANSCRIPT_USER_SCROLL_SETTLE_MS } from "#product/hooks/chat/ui/transcript-row-list-model";
+
+interface ScrollSample {
+  programmatic: boolean;
+  userInitiated?: true;
+}
+
+interface FrozenTranscriptState<T> {
+  scopeKey: string;
+  value: T;
+}
+
+export type TranscriptScrollPauseListener = () => void;
+
+/**
+ * Native scrolling owns the frame while the user is moving through history.
+ * Hold the last committed transcript snapshot during that short interaction so
+ * live stream renders cannot compete with scroll paints, then publish the
+ * newest snapshot once input has settled. Programmatic follow/anchor scrolls
+ * intentionally do not engage this gate.
+ */
+export function useTranscriptScrollPriority<T>({
+  latestValue,
+  scopeKey,
+}: {
+  latestValue: T;
+  scopeKey: string;
+}) {
+  const committedStateRef = useRef<FrozenTranscriptState<T>>({
+    scopeKey,
+    value: latestValue,
+  });
+  const frozenRef = useRef<FrozenTranscriptState<T> | null>(null);
+  const synchronousPauseListenersRef = useRef<Set<TranscriptScrollPauseListener>>(
+    new Set(),
+  );
+  const settleTimerRef = useRef<number | null>(null);
+  const [isUserScrolling, setIsUserScrolling] = useState(false);
+
+  const clearSettleTimer = useCallback(() => {
+    if (settleTimerRef.current !== null) {
+      window.clearTimeout(settleTimerRef.current);
+      settleTimerRef.current = null;
+    }
+  }, []);
+
+  const releaseFrozenSnapshot = useCallback(() => {
+    clearSettleTimer();
+    frozenRef.current = null;
+    setIsUserScrolling(false);
+  }, [clearSettleTimer]);
+
+  const registerSynchronousPause = useCallback((
+    listener: TranscriptScrollPauseListener,
+  ) => {
+    const listeners = synchronousPauseListenersRef.current;
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  const prioritizeScrollSample = useCallback((sample?: ScrollSample) => {
+    if (sample?.programmatic !== false) {
+      return;
+    }
+
+    if (sample.userInitiated === true) {
+      // Cancel frame schedulers in the input event's call stack. React state
+      // still owns the sustained hold, but cannot pre-empt an already queued
+      // animation frame before its next commit/effect cycle by itself.
+      for (const listener of synchronousPauseListenersRef.current) {
+        listener();
+      }
+    }
+
+    const committedState = committedStateRef.current;
+    const currentScopeKey = committedState.scopeKey;
+    const frozen = frozenRef.current;
+    if (sample.userInitiated !== true && frozen?.scopeKey !== currentScopeKey) {
+      return;
+    }
+    if (frozen?.scopeKey !== currentScopeKey) {
+      frozenRef.current = {
+        scopeKey: currentScopeKey,
+        value: committedState.value,
+      };
+      setIsUserScrolling(true);
+    }
+
+    clearSettleTimer();
+    settleTimerRef.current = window.setTimeout(
+      releaseFrozenSnapshot,
+      TRANSCRIPT_USER_SCROLL_SETTLE_MS,
+    );
+  }, [clearSettleTimer, releaseFrozenSnapshot]);
+
+  // Never let a snapshot from the previous workspace/session cross a scope
+  // transition, even if the user switches sessions mid-momentum-scroll.
+  useLayoutEffect(() => {
+    committedStateRef.current = {
+      scopeKey,
+      value: latestValue,
+    };
+    if (frozenRef.current && frozenRef.current.scopeKey !== scopeKey) {
+      releaseFrozenSnapshot();
+    }
+  }, [latestValue, releaseFrozenSnapshot, scopeKey]);
+
+  useEffect(() => clearSettleTimer, [clearSettleTimer]);
+
+  const frozen = frozenRef.current;
+  const effectiveValue = isUserScrolling && frozen?.scopeKey === scopeKey
+    ? frozen.value
+    : latestValue;
+
+  return {
+    effectiveValue,
+    isUserScrolling,
+    prioritizeScrollSample,
+    registerSynchronousPause,
+  };
+}

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-scroll-sample.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-scroll-sample.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { MeasurementOperationId } from "#product/lib/domain/telemetry/debug-measurement-catalog";
+import {
+  finishOrCancelMeasurementOperation,
+  markOperationForNextCommit,
+  recordMeasurementMetric,
+  startMeasurementOperation,
+} from "#product/lib/infra/measurement/measurement-port";
+import type { TranscriptScrollSample } from "#product/hooks/chat/ui/transcript-row-list-model";
+
+const TRANSCRIPT_SCROLL_SURFACES = [
+  "transcript-list",
+  "transcript-context-providers",
+  "transcript-row-list-router",
+  "transcript-virtualized-viewport",
+  "transcript-full-list",
+  "session-transcript-pane",
+  "chat-surface",
+] as const;
+
+/**
+ * Couples scroll-priority sampling to the transcript's diagnostic measurement
+ * operation without making the transcript container own telemetry lifecycle.
+ */
+export function useTranscriptScrollSample(
+  prioritizeScrollSample: (sample?: TranscriptScrollSample) => void,
+): (sample?: TranscriptScrollSample) => void {
+  const scrollSampleOperationRef = useRef<MeasurementOperationId | null>(null);
+
+  const handleTranscriptScroll = useCallback((sample?: TranscriptScrollSample) => {
+    prioritizeScrollSample(sample);
+    // Tag the scroll source: a persistent stream of `source.programmatic`
+    // samples (with no user input) means a stick-to-bottom snap / virtualizer
+    // measurement feedback loop — the difference between "user scrolled" and
+    // "we are scrolling ourselves in circles".
+    recordMeasurementMetric({
+      type: "diagnostic",
+      category: "transcript_scroll",
+      label: sample === undefined
+        ? "source.unknown"
+        : sample.programmatic
+          ? "source.programmatic"
+          : sample.userInitiated
+            ? "source.user"
+            : "source.unclassified",
+      count: 1,
+    });
+    const operationId = startMeasurementOperation({
+      kind: "transcript_scroll",
+      sampleKey: "transcript",
+      surfaces: [...TRANSCRIPT_SCROLL_SURFACES],
+      idleTimeoutMs: 750,
+      maxDurationMs: 8000,
+      cooldownMs: 1500,
+    });
+    if (operationId) {
+      scrollSampleOperationRef.current = operationId;
+      markOperationForNextCommit(operationId, [...TRANSCRIPT_SCROLL_SURFACES]);
+    }
+  }, [prioritizeScrollSample]);
+
+  useEffect(() => () => {
+    finishOrCancelMeasurementOperation(scrollSampleOperationRef.current, "unmount");
+    scrollSampleOperationRef.current = null;
+  }, []);
+
+  return handleTranscriptScroll;
+}

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.test.tsx
@@ -242,13 +242,15 @@ describe("useTranscriptStickToBottom", () => {
     }
   });
 
-  it("does not unpin on a downward wheel", () => {
-    const handle = renderHarness();
-    setMetrics(handle.current.viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 1000 });
+  it("does not claim a downward wheel at the hard bottom", () => {
+    const onScrollSample = vi.fn();
+    const handle = renderHarness(onScrollSample);
+    setMetrics(handle.current.viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 700 });
     act(() => {
       fireEvent.wheel(handle.current.viewport, { deltaY: 20 });
     });
     expect(handle.current.api.isPinnedToBottom).toBe(true);
+    expect(onScrollSample).not.toHaveBeenCalled();
   });
 
   it("stays pinned on an upward wheel when the content is not scrollable", () => {
@@ -294,6 +296,62 @@ describe("useTranscriptStickToBottom", () => {
     // A genuine user scroll up unpins.
     userScroll(handle, 600);
     expect(handle.current.api.isPinnedToBottom).toBe(false);
+  });
+
+  it("marks scroll priority only from recent positive input intent", () => {
+    let now = 100;
+    vi.spyOn(performance, "now").mockImplementation(() => now);
+    const onScrollSample = vi.fn();
+    const handle = renderHarness(onScrollSample);
+    const { viewport } = handle.current;
+    setMetrics(viewport, { scrollHeight: 1_000, clientHeight: 300, scrollTop: 600 });
+
+    // An unmarked browser or virtualizer correction cannot claim user input.
+    dispatchScroll(handle);
+    expect(onScrollSample).toHaveBeenLastCalledWith({ programmatic: false });
+
+    // Wheel intent claims the frame immediately, before its native scroll.
+    act(() => {
+      fireEvent.wheel(viewport, { deltaY: -40 });
+    });
+    expect(onScrollSample).toHaveBeenLastCalledWith({
+      programmatic: false,
+      userInitiated: true,
+    });
+
+    viewport.scrollTop = 520;
+    dispatchScroll(handle);
+    expect(onScrollSample).toHaveBeenLastCalledWith({
+      programmatic: false,
+      userInitiated: true,
+    });
+
+    // Once the shared intent/gate window expires, a later correction is
+    // unclassified and cannot re-open the rendering hold.
+    now += 151;
+    viewport.scrollTop = 518;
+    dispatchScroll(handle);
+    expect(onScrollSample).toHaveBeenLastCalledWith({ programmatic: false });
+  });
+
+  it("unpins from upward custom-thumb intent before any scroll event", () => {
+    const onScrollSample = vi.fn();
+    const handle = renderHarness(onScrollSample);
+
+    act(() => {
+      handle.current.api.notifyUserScrollIntent(1);
+    });
+    expect(handle.current.api.pinnedRef.current).toBe(true);
+
+    act(() => {
+      handle.current.api.notifyUserScrollIntent(-1);
+    });
+    expect(handle.current.api.pinnedRef.current).toBe(false);
+    expect(handle.current.api.isPinnedToBottom).toBe(false);
+    expect(onScrollSample).toHaveBeenLastCalledWith({
+      programmatic: false,
+      userInitiated: true,
+    });
   });
 
   it("does not leak the programmatic marker when the write changes nothing (watchdog)", () => {
@@ -353,7 +411,7 @@ describe("useTranscriptStickToBottom", () => {
   it("re-pins and snaps on the scroll-to-bottom button click", () => {
     const handle = renderHarness();
     const { viewport } = handle.current;
-    setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 0 });
+    setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 400 });
 
     act(() => {
       fireEvent.wheel(viewport, { deltaY: -50 });

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
@@ -7,8 +7,24 @@ import {
   PROGRAMMATIC_MATCH_TOL_PX,
   REPIN_BOTTOM_THRESHOLD_PX,
   SCROLLABLE_OVERFLOW_EPSILON_PX,
+  TRANSCRIPT_USER_SCROLL_SETTLE_MS,
   type TranscriptScrollSample,
 } from "#product/hooks/chat/ui/transcript-row-list-model";
+
+const USER_SCROLL_KEYS = new Set([
+  "ArrowDown",
+  "ArrowUp",
+  "End",
+  "Home",
+  "PageDown",
+  "PageUp",
+  " ",
+]);
+const USER_SCROLL_UP_KEYS = new Set(["ArrowUp", "Home", "PageUp"]);
+
+function interactionNow(): number {
+  return typeof performance === "undefined" ? Date.now() : performance.now();
+}
 
 /**
  * Whether the viewport actually has room to scroll. The pre-emptive
@@ -19,6 +35,30 @@ import {
  */
 function viewportCanScroll(viewport: HTMLDivElement): boolean {
   return viewport.scrollHeight - viewport.clientHeight > SCROLLABLE_OVERFLOW_EPSILON_PX;
+}
+
+function viewportCanScrollInDirection(
+  viewport: HTMLDivElement,
+  direction: -1 | 1,
+): boolean {
+  if (!viewportCanScroll(viewport)) {
+    return false;
+  }
+  if (direction < 0) {
+    return viewport.scrollTop > DIRECTION_EPSILON_PX;
+  }
+  const maximumTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+  return viewport.scrollTop < maximumTop - DIRECTION_EPSILON_PX;
+}
+
+function keyboardScrollDirection(event: KeyboardEvent): -1 | 1 | null {
+  if (!USER_SCROLL_KEYS.has(event.key)) {
+    return null;
+  }
+  if (event.key === " ") {
+    return event.shiftKey ? -1 : 1;
+  }
+  return USER_SCROLL_UP_KEYS.has(event.key) ? -1 : 1;
 }
 
 export interface UseTranscriptStickToBottomOptions {
@@ -43,6 +83,8 @@ export interface TranscriptStickToBottom {
   pinnedRef: RefObject<boolean>;
   /** Wire to AutoHideScrollArea's onViewportScroll. Owns stickiness + direction + onScrollSample. */
   onViewportScroll: (viewport: HTMLDivElement) => void;
+  /** Mark positive wheel/key/touch/scrollbar intent before its scroll event arrives. */
+  notifyUserScrollIntent: (direction: -1 | 1) => void;
   /** Snap to the active follow target (soft overlay bottom or user-chosen hard bottom). */
   scrollToBottom: () => void;
   /** Snap + re-pin, for the scroll-to-bottom button. */
@@ -75,6 +117,7 @@ export function useTranscriptStickToBottom({
   const glueFrameRef = useRef<number | null>(null);
   const autoFollowBottomInsetRef = useRef(Math.max(0, autoFollowBottomInsetPx));
   const consumedAutoFollowBottomInsetRef = useRef(0);
+  const userScrollIntentUntilRef = useRef(0);
 
   const setPinned = useCallback((next: boolean) => {
     if (pinnedRef.current === next) {
@@ -111,6 +154,17 @@ export function useTranscriptStickToBottom({
     }
     markNonUserScrollPosition(viewport);
   }, [markNonUserScrollPosition, scrollRef]);
+
+  const notifyUserScrollIntent = useCallback((direction: -1 | 1) => {
+    userScrollIntentUntilRef.current =
+      interactionNow() + TRANSCRIPT_USER_SCROLL_SETTLE_MS;
+    if (direction < 0) {
+      setPinned(false);
+    }
+    // Claim the frame at input time instead of waiting for the browser's later
+    // scroll event, which can otherwise race a stream/reveal animation frame.
+    onScrollSample({ programmatic: false, userInitiated: true });
+  }, [onScrollSample, setPinned]);
 
   // Registered before consumer layout effects. Preserve however much of an
   // existing overlay range the user deliberately consumed; if another card is
@@ -231,7 +285,12 @@ export function useTranscriptStickToBottom({
       consumedAutoFollowBottomInsetRef.current = 0;
       setPinned(false);
     }
-    onScrollSample({ programmatic: false });
+    const userInitiated = interactionNow() < userScrollIntentUntilRef.current;
+    onScrollSample(
+      userInitiated
+        ? { programmatic: false, userInitiated: true }
+        : { programmatic: false },
+    );
   }, [onScrollSample, pinnedRef, repinThresholdPx, setPinned]);
 
   const startGlueLoop = useCallback(() => {
@@ -280,6 +339,7 @@ export function useTranscriptStickToBottom({
     programmaticRef.current = null;
     lastScrollTopRef.current = 0;
     consumedAutoFollowBottomInsetRef.current = 0;
+    userScrollIntentUntilRef.current = 0;
     setPinned(true);
     scrollToBottom();
     startGlueLoop();
@@ -299,16 +359,19 @@ export function useTranscriptStickToBottom({
     // bottom is meaningless when there is nowhere to scroll, and acting on it
     // would strand the engine unpinned (no scroll event follows to re-pin).
     const onWheel = (event: WheelEvent) => {
-      if (event.deltaY < 0 && viewportCanScroll(viewport)) {
-        setPinned(false);
+      const direction = event.deltaY < -DIRECTION_EPSILON_PX
+        ? -1
+        : event.deltaY > DIRECTION_EPSILON_PX
+          ? 1
+          : null;
+      if (direction !== null && viewportCanScrollInDirection(viewport, direction)) {
+        notifyUserScrollIntent(direction);
       }
     };
     const onKeyDown = (event: KeyboardEvent) => {
-      if (
-        (event.key === "ArrowUp" || event.key === "PageUp" || event.key === "Home") &&
-        viewportCanScroll(viewport)
-      ) {
-        setPinned(false);
+      const direction = keyboardScrollDirection(event);
+      if (direction !== null && viewportCanScrollInDirection(viewport, direction)) {
+        notifyUserScrollIntent(direction);
       }
     };
     const onTouchStart = (event: TouchEvent) => {
@@ -316,9 +379,16 @@ export function useTranscriptStickToBottom({
     };
     const onTouchMove = (event: TouchEvent) => {
       const y = event.touches[0]?.clientY ?? touchStartY;
-      // Finger dragging down reveals content above (scrolls toward history).
-      if (y - touchStartY > DIRECTION_EPSILON_PX && viewportCanScroll(viewport)) {
-        setPinned(false);
+      const direction = y - touchStartY > DIRECTION_EPSILON_PX
+        ? -1
+        : touchStartY - y > DIRECTION_EPSILON_PX
+          ? 1
+          : null;
+      if (
+        direction !== null
+        && viewportCanScrollInDirection(viewport, direction)
+      ) {
+        notifyUserScrollIntent(direction);
       }
     };
     viewport.addEventListener("wheel", onWheel, { passive: true });
@@ -331,7 +401,7 @@ export function useTranscriptStickToBottom({
       viewport.removeEventListener("touchstart", onTouchStart);
       viewport.removeEventListener("touchmove", onTouchMove);
     };
-  }, [scrollRef, setPinned]);
+  }, [notifyUserScrollIntent, scrollRef]);
 
   // On tab/window re-show while pinned, glue to the bottom for a few frames so
   // the suspended-then-resumed measurement backlog lands as one jump. Listen to
@@ -371,6 +441,7 @@ export function useTranscriptStickToBottom({
     isPinnedToBottom,
     pinnedRef,
     onViewportScroll,
+    notifyUserScrollIntent,
     scrollToBottom,
     handleScrollToBottomClick,
     notifyProgrammaticScroll,

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
@@ -6,59 +6,13 @@ import {
   GLUE_STABLE_FRAMES,
   PROGRAMMATIC_MATCH_TOL_PX,
   REPIN_BOTTOM_THRESHOLD_PX,
-  SCROLLABLE_OVERFLOW_EPSILON_PX,
   TRANSCRIPT_USER_SCROLL_SETTLE_MS,
   type TranscriptScrollSample,
 } from "#product/hooks/chat/ui/transcript-row-list-model";
-
-const USER_SCROLL_KEYS = new Set([
-  "ArrowDown",
-  "ArrowUp",
-  "End",
-  "Home",
-  "PageDown",
-  "PageUp",
-  " ",
-]);
-const USER_SCROLL_UP_KEYS = new Set(["ArrowUp", "Home", "PageUp"]);
+import { useTranscriptUserScrollIntent } from "#product/hooks/chat/ui/use-transcript-user-scroll-intent";
 
 function interactionNow(): number {
   return typeof performance === "undefined" ? Date.now() : performance.now();
-}
-
-/**
- * Whether the viewport actually has room to scroll. The pre-emptive
- * intent-to-leave listeners must not unpin when the content fits entirely in the
- * viewport: that gesture produces no scroll event, so `onViewportScroll` never
- * runs to re-pin, leaving the engine stuck unpinned and the scroll-to-bottom
- * button wrongly visible while already at the bottom.
- */
-function viewportCanScroll(viewport: HTMLDivElement): boolean {
-  return viewport.scrollHeight - viewport.clientHeight > SCROLLABLE_OVERFLOW_EPSILON_PX;
-}
-
-function viewportCanScrollInDirection(
-  viewport: HTMLDivElement,
-  direction: -1 | 1,
-): boolean {
-  if (!viewportCanScroll(viewport)) {
-    return false;
-  }
-  if (direction < 0) {
-    return viewport.scrollTop > DIRECTION_EPSILON_PX;
-  }
-  const maximumTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
-  return viewport.scrollTop < maximumTop - DIRECTION_EPSILON_PX;
-}
-
-function keyboardScrollDirection(event: KeyboardEvent): -1 | 1 | null {
-  if (!USER_SCROLL_KEYS.has(event.key)) {
-    return null;
-  }
-  if (event.key === " ") {
-    return event.shiftKey ? -1 : 1;
-  }
-  return USER_SCROLL_UP_KEYS.has(event.key) ? -1 : 1;
 }
 
 export interface UseTranscriptStickToBottomOptions {
@@ -345,63 +299,9 @@ export function useTranscriptStickToBottom({
     startGlueLoop();
   }, [scrollToBottom, setPinned, startGlueLoop]);
 
-  // Pre-emptive intent-to-leave: flip the pin ref synchronously when the user
-  // acts, BEFORE the next per-frame snap effect reads it, so the snap bails and
-  // the user actually escapes. The scroll-event classifier alone loses this race
-  // because a snap can overwrite scrollTop before the scroll event is read.
-  useEffect(() => {
-    const viewport = scrollRef.current;
-    if (!viewport) {
-      return;
-    }
-    let touchStartY = 0;
-    // All three listeners gate on `viewportCanScroll`: an intent to leave the
-    // bottom is meaningless when there is nowhere to scroll, and acting on it
-    // would strand the engine unpinned (no scroll event follows to re-pin).
-    const onWheel = (event: WheelEvent) => {
-      const direction = event.deltaY < -DIRECTION_EPSILON_PX
-        ? -1
-        : event.deltaY > DIRECTION_EPSILON_PX
-          ? 1
-          : null;
-      if (direction !== null && viewportCanScrollInDirection(viewport, direction)) {
-        notifyUserScrollIntent(direction);
-      }
-    };
-    const onKeyDown = (event: KeyboardEvent) => {
-      const direction = keyboardScrollDirection(event);
-      if (direction !== null && viewportCanScrollInDirection(viewport, direction)) {
-        notifyUserScrollIntent(direction);
-      }
-    };
-    const onTouchStart = (event: TouchEvent) => {
-      touchStartY = event.touches[0]?.clientY ?? 0;
-    };
-    const onTouchMove = (event: TouchEvent) => {
-      const y = event.touches[0]?.clientY ?? touchStartY;
-      const direction = y - touchStartY > DIRECTION_EPSILON_PX
-        ? -1
-        : touchStartY - y > DIRECTION_EPSILON_PX
-          ? 1
-          : null;
-      if (
-        direction !== null
-        && viewportCanScrollInDirection(viewport, direction)
-      ) {
-        notifyUserScrollIntent(direction);
-      }
-    };
-    viewport.addEventListener("wheel", onWheel, { passive: true });
-    viewport.addEventListener("keydown", onKeyDown);
-    viewport.addEventListener("touchstart", onTouchStart, { passive: true });
-    viewport.addEventListener("touchmove", onTouchMove, { passive: true });
-    return () => {
-      viewport.removeEventListener("wheel", onWheel);
-      viewport.removeEventListener("keydown", onKeyDown);
-      viewport.removeEventListener("touchstart", onTouchStart);
-      viewport.removeEventListener("touchmove", onTouchMove);
-    };
-  }, [notifyUserScrollIntent, scrollRef]);
+  // Establish input ownership before the visibility lifecycle can resume the
+  // pinned glue loop.
+  useTranscriptUserScrollIntent({ scrollRef, notifyUserScrollIntent });
 
   // On tab/window re-show while pinned, glue to the bottom for a few frames so
   // the suspended-then-resumed measurement backlog lands as one jump. Listen to

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-user-scroll-intent.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-user-scroll-intent.ts
@@ -1,0 +1,110 @@
+import { useEffect, type RefObject } from "react";
+import {
+  DIRECTION_EPSILON_PX,
+  SCROLLABLE_OVERFLOW_EPSILON_PX,
+} from "#product/hooks/chat/ui/transcript-row-list-model";
+
+const USER_SCROLL_KEYS = new Set([
+  "ArrowDown",
+  "ArrowUp",
+  "End",
+  "Home",
+  "PageDown",
+  "PageUp",
+  " ",
+]);
+const USER_SCROLL_UP_KEYS = new Set(["ArrowUp", "Home", "PageUp"]);
+
+/**
+ * A gesture with no available scroll range produces no scroll event, so it
+ * must not strand the transcript in an unpinned state.
+ */
+function viewportCanScroll(viewport: HTMLDivElement): boolean {
+  return viewport.scrollHeight - viewport.clientHeight > SCROLLABLE_OVERFLOW_EPSILON_PX;
+}
+
+function viewportCanScrollInDirection(
+  viewport: HTMLDivElement,
+  direction: -1 | 1,
+): boolean {
+  if (!viewportCanScroll(viewport)) {
+    return false;
+  }
+  if (direction < 0) {
+    return viewport.scrollTop > DIRECTION_EPSILON_PX;
+  }
+  const maximumTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+  return viewport.scrollTop < maximumTop - DIRECTION_EPSILON_PX;
+}
+
+function keyboardScrollDirection(event: KeyboardEvent): -1 | 1 | null {
+  if (!USER_SCROLL_KEYS.has(event.key)) {
+    return null;
+  }
+  if (event.key === " ") {
+    return event.shiftKey ? -1 : 1;
+  }
+  return USER_SCROLL_UP_KEYS.has(event.key) ? -1 : 1;
+}
+
+/**
+ * Claims wheel, keyboard, and touch scroll intent before the browser dispatches
+ * the resulting scroll event, so a pinned transcript cannot snap first.
+ */
+export function useTranscriptUserScrollIntent({
+  scrollRef,
+  notifyUserScrollIntent,
+}: {
+  scrollRef: RefObject<HTMLDivElement | null>;
+  notifyUserScrollIntent: (direction: -1 | 1) => void;
+}): void {
+  useEffect(() => {
+    const viewport = scrollRef.current;
+    if (!viewport) {
+      return;
+    }
+    let touchStartY = 0;
+    // An intent to leave is meaningless when there is nowhere to scroll. In
+    // that case no scroll event follows to re-pin the transcript.
+    const onWheel = (event: WheelEvent) => {
+      const direction = event.deltaY < -DIRECTION_EPSILON_PX
+        ? -1
+        : event.deltaY > DIRECTION_EPSILON_PX
+          ? 1
+          : null;
+      if (direction !== null && viewportCanScrollInDirection(viewport, direction)) {
+        notifyUserScrollIntent(direction);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      const direction = keyboardScrollDirection(event);
+      if (direction !== null && viewportCanScrollInDirection(viewport, direction)) {
+        notifyUserScrollIntent(direction);
+      }
+    };
+    const onTouchStart = (event: TouchEvent) => {
+      touchStartY = event.touches[0]?.clientY ?? 0;
+    };
+    const onTouchMove = (event: TouchEvent) => {
+      const y = event.touches[0]?.clientY ?? touchStartY;
+      const direction = y - touchStartY > DIRECTION_EPSILON_PX
+        ? -1
+        : touchStartY - y > DIRECTION_EPSILON_PX
+          ? 1
+          : null;
+      if (direction !== null && viewportCanScrollInDirection(viewport, direction)) {
+        notifyUserScrollIntent(direction);
+      }
+    };
+    viewport.addEventListener("wheel", onWheel, { passive: true });
+    viewport.addEventListener("keydown", onKeyDown);
+    viewport.addEventListener("touchstart", onTouchStart, { passive: true });
+    viewport.addEventListener("touchmove", onTouchMove, { passive: true });
+    return () => {
+      viewport.removeEventListener("wheel", onWheel);
+      viewport.removeEventListener("keydown", onKeyDown);
+      viewport.removeEventListener("touchstart", onTouchStart);
+      viewport.removeEventListener("touchmove", onTouchMove);
+    };
+  }, [notifyUserScrollIntent, scrollRef]);
+}

--- a/apps/packages/product-client/src/pages/ChatPlaygroundPage.tsx
+++ b/apps/packages/product-client/src/pages/ChatPlaygroundPage.tsx
@@ -35,10 +35,14 @@ export function ChatPlaygroundPage() {
     selection.kind === "fixture" && selection.key === "git-diff-panel";
   const showAttachmentPreview =
     selection.kind === "fixture" && selection.key === "attachment-previews";
-  const focusMarkdownPresentation =
-    selection.kind === "fixture"
-    && selection.key === "markdown-presentation"
-    && params.get("focus") === "1";
+  const focusTranscript = params.get("focus") === "1"
+    && (
+      selection.kind === "recording"
+      || (
+        selection.kind === "fixture"
+        && selection.key === "markdown-presentation"
+      )
+    );
 
   const handleSelectFixture = (key: ScenarioKey) => {
     const next = new URLSearchParams(params);
@@ -54,7 +58,7 @@ export function ChatPlaygroundPage() {
 
   return (
     <div className="chat-selection-root flex h-screen flex-col bg-background text-foreground">
-      {!focusMarkdownPresentation && (
+      {!focusTranscript && (
         <>
           <header
             aria-label="Populated session preview"
@@ -84,7 +88,7 @@ export function ChatPlaygroundPage() {
           <div className={CHAT_SURFACE_GUTTER_CLASSNAME}>
             {/* Mirror the transcript root's label-size override so fixtures
                 render at product parity (text-chat resolves to message size). */}
-            <div className={`${CHAT_COLUMN_CLASSNAME} flex flex-col gap-6 [--text-chat:var(--text-message)] [--text-chat--line-height:var(--text-message--line-height)] [--text-chat-meta:calc(var(--text-chat)_-_2px)]`}>
+            <div className={`${CHAT_COLUMN_CLASSNAME} flex h-full flex-col gap-6 [--text-chat:var(--text-message)] [--text-chat--line-height:var(--text-message--line-height)] [--text-chat-meta:calc(var(--text-chat)_-_2px)]`}>
               <PlaygroundTranscript
                 selection={selection}
                 replay={replay}
@@ -107,7 +111,7 @@ export function ChatPlaygroundPage() {
         )}
         {showAttachmentPreview && <PlaygroundAttachmentPreviewAside />}
       </main>
-      {!focusMarkdownPresentation && (
+      {!focusTranscript && (
         <footer className="border-t border-border px-4 py-2 text-ui-sm text-muted-foreground">
           <code className="font-mono">?s={selection.raw}</code>
           <span className="mx-2">·</span>

--- a/apps/packages/product-client/src/primitives/patterns/AutoHideScrollArea.test.tsx
+++ b/apps/packages/product-client/src/primitives/patterns/AutoHideScrollArea.test.tsx
@@ -122,4 +122,42 @@ describe("AutoHideScrollArea", () => {
     expect(remountedThumb?.style.transform).toBe("translateY(30px)");
     expect(remountedThumb?.style.pointerEvents).toBe("auto");
   });
+
+  it("reports custom scrollbar intent on grab and drag", () => {
+    const onUserScrollIntent = vi.fn();
+    const rendered = render(
+      <AutoHideScrollArea
+        className="h-80"
+        onUserScrollIntent={onUserScrollIntent}
+      >
+        <div>content</div>
+      </AutoHideScrollArea>,
+    );
+    const viewport = rendered.container.querySelector<HTMLDivElement>(".scrollbar-none")!;
+    Object.defineProperty(viewport, "clientHeight", { value: 300, configurable: true });
+    Object.defineProperty(viewport, "scrollHeight", { value: 3_000, configurable: true });
+    viewport.scrollTop = 300;
+    act(() => {
+      fireEvent.scroll(viewport);
+      flushFrames();
+    });
+    const thumb = rendered.container.querySelector<HTMLElement>(
+      "[aria-hidden='true'] > div",
+    )!;
+
+    act(() => {
+      fireEvent.pointerDown(thumb, { clientY: 35 });
+    });
+    expect(onUserScrollIntent).not.toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.pointerMove(window, { clientY: 20 });
+      fireEvent.pointerMove(window, { clientY: 20 });
+      fireEvent.pointerMove(window, { clientY: 50 });
+    });
+
+    expect(onUserScrollIntent).toHaveBeenCalledTimes(2);
+    expect(onUserScrollIntent).toHaveBeenNthCalledWith(1, -1);
+    expect(onUserScrollIntent).toHaveBeenNthCalledWith(2, 1);
+  });
 });

--- a/apps/packages/product-client/src/primitives/patterns/AutoHideScrollArea.tsx
+++ b/apps/packages/product-client/src/primitives/patterns/AutoHideScrollArea.tsx
@@ -23,6 +23,7 @@ interface AutoHideScrollAreaProps {
   overscrollBehaviorY?: CSSProperties["overscrollBehaviorY"];
   chainVerticalWheel?: boolean;
   onViewportScroll?: (viewport: HTMLDivElement) => void;
+  onUserScrollIntent?: (direction: -1 | 1) => void;
 }
 
 interface ScrollThumbState {
@@ -52,6 +53,7 @@ export const AutoHideScrollArea = forwardRef<HTMLDivElement, AutoHideScrollAreaP
       overscrollBehaviorY,
       chainVerticalWheel = false,
       onViewportScroll,
+      onUserScrollIntent,
     },
     ref,
   ) {
@@ -60,6 +62,7 @@ export const AutoHideScrollArea = forwardRef<HTMLDivElement, AutoHideScrollAreaP
     const thumbTrackRef = useRef<HTMLDivElement>(null);
     const thumbRef = useRef<HTMLDivElement>(null);
     const onViewportScrollRef = useRef(onViewportScroll);
+    const onUserScrollIntentRef = useRef(onUserScrollIntent);
     const hideTimerRef = useRef<number | null>(null);
     const thumbFrameRef = useRef<number | null>(null);
     const pendingThumbVisibleRef = useRef(false);
@@ -72,6 +75,10 @@ export const AutoHideScrollArea = forwardRef<HTMLDivElement, AutoHideScrollAreaP
     useEffect(() => {
       onViewportScrollRef.current = onViewportScroll;
     }, [onViewportScroll]);
+
+    useEffect(() => {
+      onUserScrollIntentRef.current = onUserScrollIntent;
+    }, [onUserScrollIntent]);
 
     const applyThumbStateToDom = useCallback((state: ScrollThumbState) => {
       const track = thumbTrackRef.current;
@@ -207,8 +214,13 @@ export const AutoHideScrollArea = forwardRef<HTMLDivElement, AutoHideScrollAreaP
           Math.max(event.clientY - top - dragOffsetRef.current, 0),
           maxOffset,
         );
-        viewport.scrollTop =
+        const nextScrollTop =
           (nextOffset / maxOffset) * Math.max(scrollHeight - clientHeight, 0);
+        const scrollDelta = nextScrollTop - viewport.scrollTop;
+        if (Math.abs(scrollDelta) > THUMB_MEASUREMENT_EPSILON) {
+          onUserScrollIntentRef.current?.(scrollDelta < 0 ? -1 : 1);
+          viewport.scrollTop = nextScrollTop;
+        }
         requestThumbUpdate(true);
       };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,8 +141,8 @@ importers:
         specifier: ^5.101.4
         version: 5.101.4(react@19.2.8)
       '@tanstack/react-virtual':
-        specifier: 3.14.8
-        version: 3.14.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 3.14.9
+        version: 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tauri-apps/api':
         specifier: ^2
         version: 2.11.1
@@ -468,8 +468,8 @@ importers:
         specifier: ^5.101.4
         version: 5.101.4(react@19.2.8)
       '@tanstack/react-virtual':
-        specifier: 3.14.8
-        version: 3.14.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 3.14.9
+        version: 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@xterm/addon-canvas':
         specifier: ^0.7.0
         version: 0.7.0(@xterm/xterm@6.0.0)
@@ -3392,14 +3392,14 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
-  '@tanstack/react-virtual@3.14.8':
-    resolution: {integrity: sha512-O39GJQpAYEJcIu3uN1//YtmhjSEOyw75vg9CKCatBDPiD5hKtZQoJHfferyrB/LdOD3UWaoMLWtdEjarwIwdDw==}
+  '@tanstack/react-virtual@3.14.9':
+    resolution: {integrity: sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/virtual-core@3.17.6':
-    resolution: {integrity: sha512-h0/Ebo18CkOrChlQIhNtQkM5ySUnh/GumQ/D1st3hG2HWUPEF+ILUc2k29UtivCi/9G7w7G3/f7Xyd5cCFbKBw==}
+  '@tanstack/virtual-core@3.17.7':
+    resolution: {integrity: sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==}
 
   '@tauri-apps/api@2.11.1':
     resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
@@ -9755,13 +9755,13 @@ snapshots:
       '@tanstack/query-core': 5.101.4
       react: 19.2.8
 
-  '@tanstack/react-virtual@3.14.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tanstack/react-virtual@3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@tanstack/virtual-core': 3.17.6
+      '@tanstack/virtual-core': 3.17.7
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@tanstack/virtual-core@3.17.6': {}
+  '@tanstack/virtual-core@3.17.7': {}
 
   '@tauri-apps/api@2.11.1': {}
 

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -321,6 +321,20 @@ happens only when a user scroll lands within a tight bottom band
 window — that loose window kept small upward scrolls "pinned" and let the snap
 yank the user back.
 
+Positive, direction-aware user intent also owns transcript rendering while the
+gesture is active. A wheel, scroll key, touch move, or custom-thumb drag that
+can actually move the viewport opens a 150ms priority window; a no-op gesture
+at either scroll boundary does not. Opening the window synchronously cancels
+the paced prose reveal frame, then renders from the last committed transcript
+snapshot so stream batches, row derivation, Markdown work, and measurement do
+not compete with native scroll paints. Unclassified native scroll events may
+extend an already-open window for momentum, but cannot open one; tagged
+programmatic follow and anchor writes never open or extend it. The newest
+snapshot publishes after the final sample settles, and prose reveal resumes
+from the exact visible prefix at its normal bounded rate rather than jumping to
+the buffered target. Snapshot authority updates only after a committed layout,
+so an interrupted concurrent render cannot leak state or scope into the hold.
+
 While pinned, content growth re-sticks the viewport: the non-virtualized list
 via a `ResizeObserver` on the scroll content plus a per-commit layout effect, the
 virtualized list via measured `totalContentHeight`; both call the engine's


### PR DESCRIPTION
## Summary

- update the transcript virtualizer to the release that synchronizes resize-compensation notifications with scroll-offset corrections
- give real wheel, keyboard, touch, and custom-thumb input temporary ownership of transcript paint frames
- synchronously pause paced prose reveal, hold the last committed transcript snapshot during input, then resume from the exact visible prefix
- preserve programmatic bottom-follow, anchor restoration, scope changes, reduced-motion behavior, and boundary no-ops
- make deterministic recording playback use the production transcript viewport geometry
- document the scroll-priority contract

## Root cause

Two active-stream paths remained after the broader scrolling fix:

1. Resize compensation could update the browser scroll offset one paint before React received the corresponding virtual-row positions.
2. Stream-driven transcript derivation, Markdown reveal, row measurement, and height growth continued while native scrolling was trying to paint.

The published symptom disappeared when the agent stopped because both sources became idle.

## Impact

Physical transcript scrolling now preempts stream presentation work for a 150 ms settling window. Only positive, direction-aware input can open that window. Untagged momentum may extend an already-open interaction, while programmatic follow and corrections cannot open or reopen one. Buffered prose resumes at the normal bounded reveal rate instead of snapping.

## Performance evidence

Deterministic 4,295-event active-stream replay:

| Window | Before | After |
| --- | ---: | ---: |
| input p95 gap | 38 ms | 18 ms |
| input p99 gap | 47 ms | 21–25 ms |
| input max gap | 142 ms | 30–39 ms |
| input gaps above 33 ms | 8 | 0–1 |
| height mutations during input | 3 | 0 |

For the 500 ms after the final wheel event, p99/max were 27 ms, no gap exceeded 33 ms, buffered height resumed in small steps, and the unpinned scroll anchor stayed exactly fixed (0 px range). The following 700 ms kept the same anchor with a 30 ms maximum gap.

## Validation

- 56/56 affected transcript, reveal, stickiness, virtualizer, and scrollbar tests
- full product-client suite: 5,287/5,288 passed during development; the one stale in-flight fixture failure was corrected and the affected suite rerun green
- product-client typecheck
- Web production build
- Desktop renderer production build
- documentation integrity check
- design-attribution check
- three independent review rounds; all findings resolved

The tracker relationship is linked.