### PR TITLE
fix(product): rebuild the light palette

### DIFF
--- a/apps/packages/design/scripts/check-theme.mjs
+++ b/apps/packages/design/scripts/check-theme.mjs
@@ -153,6 +153,97 @@ for (const [name, value] of tokenEntries) {
   );
 }
 
+// Light neutrals come from one ink. The retired opaque slate literals are
+// checked across the whole light column so a peripheral role (for example a
+// tab underline) cannot reintroduce the old ramp outside the core color group.
+for (const retired of [
+  "#edf0f2",
+  "#d5d9de",
+  "#dde1e6",
+  "#e9ecef",
+  "#f2f4f6",
+  "#f7f8fa",
+  "#e4e7ea",
+  "#dbdfe4",
+  "#bfc5cc",
+  "#c6ccd2",
+  "#5a5f66",
+  "#646a72",
+  "#16181b",
+]) {
+  for (const [name, value] of tokenEntries) {
+    assert(
+      !value.light.toLowerCase().includes(retired),
+      `${name} reintroduced retired light neutral ${retired}`,
+    );
+  }
+}
+
+for (const [name, expected] of Object.entries({
+  "--color-foreground": "#1a1c1f",
+  "--color-background": "#ffffff",
+  "--color-surface": "#ffffff",
+  "--color-surface-elevated": "#ffffff",
+  "--color-card": "#ffffff",
+  "--color-popover": "#ffffff",
+  "--color-surface-under": "#f6f6f6",
+  "--color-sidebar": "#f6f6f6",
+  "--color-sidebar-background": "#f6f6f6",
+  "--color-surface-editor": "#fafafa",
+  "--color-primary": "#1a1c1f",
+  "--color-primary-foreground": "#ffffff",
+  "--color-composer-background": "#ffffff",
+  "--color-composer-backdrop-filter": "none",
+  "--color-composer-control-foreground": "var(--color-muted-foreground)",
+  "--color-composer-control-muted-foreground": "var(--color-faint)",
+  "--color-composer-control-active-foreground": "var(--color-foreground)",
+  "--color-composer-send-background": "var(--color-primary)",
+  "--color-composer-send-foreground": "var(--color-primary-foreground)",
+  "--color-link-foreground": "#0b6bcb",
+  "--color-info": "#0b6bcb",
+  "--color-special": "#0b6bcb",
+  "--color-ring": "#0b6bcb",
+  "--color-highlight-muted": "#0b6bcb",
+  "--color-highlight": "#e5f2ff",
+  "--color-sidebar-ring": "var(--color-ring)",
+  "--color-diff-main-surface": "var(--color-surface)",
+  "--color-diff-code-surface": "var(--color-surface-editor)",
+  "--shadow-subtle": "0 1px 2px rgba(26, 28, 31, 0.06)",
+  "--shadow-popover": "0 0 0 0.5px rgba(26, 28, 31, 0.05), 0 4px 12px rgba(26, 28, 31, 0.1)",
+  "--shadow-modal": "0 16px 40px rgba(26, 28, 31, 0.18)",
+  "--shadow-user-message": "0 1px 2px rgba(26, 28, 31, 0.05)",
+  "--color-composer-shadow": "0 0 0 0.5px rgba(26, 28, 31, 0.06), 0 1px 3px rgba(26, 28, 31, 0.08), 0 4px 12px rgba(26, 28, 31, 0.06)",
+})) {
+  assert(themeTokens[name]?.light === expected, `${name} drifted from the light palette planes`);
+}
+
+for (const [name, expected] of Object.entries({
+  "--color-foreground-secondary": "rgba(26, 28, 31, 0.65)",
+  "--color-foreground-tertiary": "rgba(26, 28, 31, 0.62)",
+  "--color-muted-foreground": "rgba(26, 28, 31, 0.65)",
+  "--color-faint": "rgba(26, 28, 31, 0.62)",
+  "--color-border-light": "rgba(26, 28, 31, 0.114)",
+  "--color-border": "rgba(26, 28, 31, 0.14)",
+  "--color-border-heavy": "rgba(26, 28, 31, 0.18)",
+  "--color-input": "rgba(26, 28, 31, 0.2)",
+  "--color-hover": "rgba(26, 28, 31, 0.053)",
+  "--color-selected": "rgba(26, 28, 31, 0.065)",
+  "--color-active": "rgba(26, 28, 31, 0.078)",
+  "--color-sidebar-foreground": "rgba(26, 28, 31, 0.85)",
+  "--color-sidebar-muted-foreground": "rgba(26, 28, 31, 0.62)",
+  "--color-surface-control": "rgba(26, 28, 31, 0.049)",
+  "--color-surface-elevated-secondary": "rgba(26, 28, 31, 0.049)",
+  "--color-muted": "rgba(26, 28, 31, 0.049)",
+  "--color-diff-panel-surface": "rgba(26, 28, 31, 0.03)",
+  "--color-scrollbar-thumb": "rgba(26, 28, 31, 0.12)",
+  "--color-scrollbar-thumb-active": "rgba(26, 28, 31, 0.24)",
+})) {
+  assert(
+    themeTokens[name]?.light === expected,
+    `${name} drifted from its single-ink light palette rung`,
+  );
+}
+
 /* ------------------------------------------------------------------ *
  * 3. Motion authority
  * ------------------------------------------------------------------ */

--- a/apps/packages/design/src/tokens.ts
+++ b/apps/packages/design/src/tokens.ts
@@ -94,15 +94,15 @@ export const themeTokens = {
   },
   "--diff-view-context-number": {
     dark: "color-mix(in lab, var(--diff-view-surface) 98.5%, var(--diffs-mixer))",
-    light: "#f2f4f6",
+    light: "color-mix(in srgb, #ffffff 96.5%, #1a1c1f)",
     themeFallback: "#292929",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/white-anchored-diffs]",
   },
   "--diff-view-context-surface": {
     dark: "color-mix(in srgb, var(--diff-view-surface) 94%, var(--color-diff-main-surface))",
-    light: "#f7f8fa",
+    light: "color-mix(in srgb, #ffffff 97.5%, #1a1c1f)",
     themeFallback: "#252525",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/white-anchored-diffs]",
   },
   "--diff-view-header-surface": {
     dark: "var(--color-diff-header-surface)",
@@ -111,15 +111,15 @@ export const themeTokens = {
   },
   "--diff-view-hover-surface": {
     dark: "color-mix(in srgb, var(--diff-view-surface) 92%, var(--color-diff-main-surface))",
-    light: "#e9ecef",
+    light: "color-mix(in srgb, #ffffff 91%, #1a1c1f)",
     themeFallback: "#252525",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/white-anchored-diffs]",
   },
   "--diff-view-separator-surface": {
     dark: "color-mix(in srgb, var(--diff-view-surface) 94%, var(--color-foreground))",
-    light: "#dde1e6",
+    light: "color-mix(in srgb, #ffffff 88%, #1a1c1f)",
     themeFallback: "#333333",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/white-anchored-diffs]",
   },
   "--diff-view-surface": {
     dark: "var(--color-diff-surface)",
@@ -133,9 +133,9 @@ export const themeTokens = {
   },
   "--color-active": {
     dark: "color-mix(in oklab, #ffffff 5.2%, transparent)",
-    light: "#dbdfe4",
+    light: "rgba(26, 28, 31, 0.078)",
     themeFallback: "rgba(255, 255, 255, 0.052)",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-background": {
     dark: "#181818",
@@ -144,21 +144,21 @@ export const themeTokens = {
   },
   "--color-border": {
     dark: "color-mix(in oklab, #ffffff 8.4%, transparent)",
-    light: "#d5d9de",
+    light: "rgba(26, 28, 31, 0.14)",
     themeFallback: "rgba(255, 255, 255, 0.084)",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-border-heavy": {
     dark: "color-mix(in oklab, #ffffff 12%, transparent)",
-    light: "#bfc5cc",
+    light: "rgba(26, 28, 31, 0.18)",
     themeFallback: "rgba(255, 255, 255, 0.12)",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-border-light": {
     dark: "color-mix(in oklab, #ffffff 5%, transparent)",
-    light: "#e4e7ea",
+    light: "rgba(26, 28, 31, 0.114)",
     themeFallback: "rgba(255, 255, 255, 0.05)",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-card": {
     dark: "#212121",
@@ -194,18 +194,18 @@ export const themeTokens = {
   },
   "--color-composer-control-active-foreground": {
     dark: "var(--color-foreground)",
-    light: "#16181b",
-    provenance: "[RETUNE:light/independent-scale]",
+    light: "var(--color-foreground)",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-composer-control-foreground": {
     dark: "var(--color-muted-foreground)",
-    light: "#5a5f66",
-    provenance: "[RETUNE:light/independent-scale]",
+    light: "var(--color-muted-foreground)",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-composer-control-muted-foreground": {
     dark: "var(--color-faint)",
-    light: "#646a72",
-    provenance: "[RETUNE:light/independent-scale]",
+    light: "var(--color-faint)",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-composer-send-background": {
     dark: "var(--color-foreground)",
@@ -219,8 +219,8 @@ export const themeTokens = {
   },
   "--color-composer-shadow": {
     dark: "var(--shadow-subtle)",
-    light: "0 1px 3px rgb(16 24 40 / 0.08), 0 4px 12px rgb(16 24 40 / 0.06)",
-    provenance: "[RETUNE:light/independent-scale]",
+    light: "0 0 0 0.5px rgba(26, 28, 31, 0.06), 0 1px 3px rgba(26, 28, 31, 0.08), 0 4px 12px rgba(26, 28, 31, 0.06)",
+    provenance: "[RETUNE:light/ink-tinted-elevation]",
   },
   "--color-compute-target-amber": {
     dark: "#b59a3a",
@@ -329,9 +329,9 @@ export const themeTokens = {
   },
   "--color-diff-chat-file-header-hover-surface": {
     dark: "color-mix(in srgb, var(--color-diff-chat-file-header-surface) 97%, var(--color-foreground))",
-    light: "#e9ecef",
+    light: "color-mix(in srgb, #ffffff 91%, #1a1c1f)",
     themeFallback: "#2d2d2d",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/white-anchored-diffs]",
   },
   "--color-diff-chat-file-header-surface": {
     dark: "var(--color-diff-surface)",
@@ -340,9 +340,9 @@ export const themeTokens = {
   },
   "--color-diff-chat-inline-tool-header-hover-surface": {
     dark: "color-mix(in srgb, var(--color-diff-chat-inline-tool-header-surface) 97%, var(--color-foreground))",
-    light: "#e9ecef",
+    light: "color-mix(in srgb, #ffffff 91%, #1a1c1f)",
     themeFallback: "#282828",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/white-anchored-diffs]",
   },
   "--color-diff-chat-inline-tool-header-surface": {
     dark: "color-mix(in srgb, var(--color-diff-surface) 86%, var(--color-overlay))",
@@ -358,9 +358,9 @@ export const themeTokens = {
   },
   "--color-diff-chat-turn-icon-surface": {
     dark: "color-mix(in srgb, var(--color-background) 88%, var(--color-overlay))",
-    light: "#e9ecef",
+    light: "color-mix(in srgb, #ffffff 91%, #1a1c1f)",
     themeFallback: "#151515",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/white-anchored-diffs]",
   },
   "--color-diff-code-surface": {
     dark: "#111111",
@@ -384,15 +384,15 @@ export const themeTokens = {
   },
   "--color-diff-panel-surface": {
     dark: "color-mix(in oklab, #ffffff 3%, transparent)",
-    light: "var(--color-surface-elevated-secondary)",
+    light: "rgba(26, 28, 31, 0.03)",
     themeFallback: "rgba(255, 255, 255, 0.03)",
-    provenance: "[SHIPPED]",
+    provenance: "[RETUNE:light/white-anchored-diffs]",
   },
   "--color-diff-sidebar-file-header-hover-surface": {
     dark: "color-mix(in srgb, var(--color-diff-sidebar-file-header-surface) 97%, var(--color-foreground))",
-    light: "#e9ecef",
+    light: "color-mix(in srgb, #ffffff 91%, #1a1c1f)",
     themeFallback: "#282828",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/white-anchored-diffs]",
   },
   "--color-diff-sidebar-file-header-surface": {
     dark: "var(--color-diff-chat-inline-tool-header-surface)",
@@ -401,22 +401,21 @@ export const themeTokens = {
   },
   "--color-diff-surface": {
     dark: "color-mix(in srgb, #181818 94%, #ffffff)",
-    light: "#f2f4f6",
+    light: "color-mix(in srgb, #ffffff 95%, #1a1c1f)",
     themeFallback: "#262626",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/white-anchored-diffs]",
   },
   /**
-   * The faintest legible ink. Light is authored against the DARKEST plane it
-   * lands on (the sidebar / under-surface `#edf0f2`), not against white: at
-   * `#686e76` it measured 5.15:1 on white but only 4.50:1 on the sidebar, so
-   * every sidebar timestamp and byte count sat a hair under the floor while the
-   * guard — which only measured the two white planes — read green.
+   * The faintest legible ink. Light is authored against the darkest plane it
+   * lands on, including the alpha control fill over white. The reference
+   * proposal's 55% ink resolved to only 3.74:1 there; 62% clears the 4.5:1
+   * floor on every measured light plane without introducing an opaque gray.
    */
   "--color-faint": {
     dark: "color-mix(in oklab, #ffffff 50%, transparent)",
-    light: "#646a72",
+    light: "rgba(26, 28, 31, 0.62)",
     themeFallback: "rgba(255, 255, 255, 0.5)",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-file-icon-accent": {
     dark: "hsl(0 0% 89%)",
@@ -445,21 +444,21 @@ export const themeTokens = {
   },
   "--color-foreground": {
     dark: "#ffffff",
-    light: "#16181b",
-    provenance: "[RETUNE:light/independent-scale]",
+    light: "#1a1c1f",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-foreground-secondary": {
     dark: "color-mix(in oklab, #ffffff 70%, transparent)",
-    light: "#5a5f66",
+    light: "rgba(26, 28, 31, 0.65)",
     themeFallback: "rgba(255, 255, 255, 0.7)",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
-  // Same tier as `--color-faint`, so it carries the same sidebar-plane value.
+  // Same tier as `--color-faint`, including its darkest-plane contrast floor.
   "--color-foreground-tertiary": {
     dark: "color-mix(in oklab, #ffffff 50%, transparent)",
-    light: "#646a72",
+    light: "rgba(26, 28, 31, 0.62)",
     themeFallback: "rgba(255, 255, 255, 0.5)",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-git-green": {
     dark: "#40c977",
@@ -478,55 +477,49 @@ export const themeTokens = {
   },
   "--color-highlight": {
     dark: "rgba(51, 156, 255, 0.12)",
-    light: "#e4effc",
-    provenance: "[RETUNE:light/independent-scale]",
+    light: "#e5f2ff",
+    provenance: "[RETUNE:light/single-accent]",
   },
   "--color-highlight-muted": {
     dark: "rgba(51, 156, 255, 0.5)",
     light: "#0b6bcb",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/single-accent]",
   },
   "--color-hover": {
     dark: "color-mix(in oklab, #ffffff 7.8%, transparent)",
-    light: "#e4e7ea",
+    light: "rgba(26, 28, 31, 0.053)",
     themeFallback: "rgba(255, 255, 255, 0.078)",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-info": {
     dark: "#339cff",
     light: "#0b6bcb",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/single-accent]",
   },
   "--color-input": {
     dark: "color-mix(in oklab, #ffffff 12%, transparent)",
-    light: "#c6ccd2",
+    light: "rgba(26, 28, 31, 0.2)",
     themeFallback: "rgba(255, 255, 255, 0.12)",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
-  // Retuned against a measured reference capture of a dark transcript surface,
-  // whose live link/accent tone resolves to rgb(131, 195, 255) — a materially
-  // lighter, less saturated blue than the #339cff we shipped, which read as
-  // dark and heavy against the #181818 chat surface. The same reference's light
-  // theme resolves its accent to #339cff, so the light half keeps the shipped
-  // value and this token stops being mode-independent: one link tone per mode,
-  // lighter in dark, unchanged in light. Still ONE link token — no per-surface
-  // link colors. `--color-special` and `--color-highlight*` are deliberately
-  // untouched: this retune is about link legibility, not the accent family.
+  // Dark uses a lighter blue so prose links remain legible on #181818. Light
+  // joins the single #0b6bcb accent used by focus, info, and special roles.
+  // This remains one link token with no per-surface variants.
   "--color-link-foreground": {
     dark: "#83c3ff",
     light: "#0b6bcb",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/single-accent]",
   },
   "--color-muted": {
     dark: "#212121",
-    light: "#f2f4f6",
-    provenance: "[RETUNE:light/independent-scale]",
+    light: "rgba(26, 28, 31, 0.049)",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-muted-foreground": {
     dark: "color-mix(in oklab, #ffffff 70%, transparent)",
-    light: "#5a5f66",
+    light: "rgba(26, 28, 31, 0.65)",
     themeFallback: "rgba(255, 255, 255, 0.7)",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-overlay": {
     dark: "#000000",
@@ -550,8 +543,8 @@ export const themeTokens = {
   },
   "--color-primary": {
     dark: "#ffffff",
-    light: "#16181b",
-    provenance: "[RETUNE:light/independent-scale]",
+    light: "#1a1c1f",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-primary-foreground": {
     dark: "#0d0d0d",
@@ -568,17 +561,17 @@ export const themeTokens = {
     dark: "color-mix(in oklab, #ffffff 28%, transparent)",
     light: "#0b6bcb",
     themeFallback: "rgba(255, 255, 255, 0.28)",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/single-accent]",
   },
   "--color-scrollbar-thumb": {
     dark: "rgba(255, 255, 255, 0.08)",
-    light: "rgba(22,24,27,0.16)",
-    provenance: "[RETUNE:light/independent-scale]",
+    light: "rgba(26, 28, 31, 0.12)",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-scrollbar-thumb-active": {
     dark: "rgba(255, 255, 255, 0.16)",
-    light: "rgba(22,24,27,0.28)",
-    provenance: "[RETUNE:light/independent-scale]",
+    light: "rgba(26, 28, 31, 0.24)",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-secondary-foreground": {
     dark: "#ffffff",
@@ -587,9 +580,9 @@ export const themeTokens = {
   },
   "--color-selected": {
     dark: "color-mix(in oklab, #ffffff 3.2%, transparent)",
-    light: "#dde1e6",
+    light: "rgba(26, 28, 31, 0.065)",
     themeFallback: "rgba(255, 255, 255, 0.032)",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-sidebar": {
     // Round-2 measurement against the reference app's dark capture: the
@@ -597,8 +590,8 @@ export const themeTokens = {
     // surface, not recessed to --color-surface-under. Supersedes the
     // surface-recess ruling from the prior retune.
     dark: "#222222",
-    light: "#edf0f2",
-    provenance: "[RETUNE:light/independent-scale]",
+    light: "#f6f6f6",
+    provenance: "[RETUNE:light/two-plane-system]",
   },
   "--color-sidebar-accent-foreground": {
     dark: "#ffffff",
@@ -607,19 +600,19 @@ export const themeTokens = {
   },
   "--color-sidebar-background": {
     dark: "#181818",
-    light: "#edf0f2",
-    provenance: "[RETUNE:light/independent-scale]",
+    light: "#f6f6f6",
+    provenance: "[RETUNE:light/two-plane-system]",
   },
   "--color-sidebar-foreground": {
     dark: "color-mix(in oklab, #ffffff 85%, transparent)",
-    light: "#16181b",
+    light: "rgba(26, 28, 31, 0.85)",
     themeFallback: "rgba(255, 255, 255, 0.85)",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-sidebar-muted-foreground": {
     dark: "rgba(255, 255, 255, 0.481)",
-    light: "#545a61",
-    provenance: "[RETUNE:light/independent-scale]",
+    light: "rgba(26, 28, 31, 0.62)",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-sidebar-primary": {
     dark: "#ffffff",
@@ -654,7 +647,7 @@ export const themeTokens = {
   "--color-special": {
     dark: "#339cff",
     light: "#0b6bcb",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/single-accent]",
   },
   /**
    * [RETUNE:color/special-foreground] — the accent had no paired text color, so
@@ -700,14 +693,14 @@ export const themeTokens = {
    */
   "--color-surface-control": {
     dark: "color-mix(in oklab, #2b2b2b 96%, transparent)",
-    light: "#f2f4f6",
+    light: "rgba(26, 28, 31, 0.049)",
     themeFallback: "rgba(43, 43, 43, 0.96)",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-surface-editor": {
     dark: "#282828",
-    light: "#f7f8fa",
-    provenance: "[RETUNE:light/independent-scale]",
+    light: "#fafafa",
+    provenance: "[RETUNE:light/two-plane-system]",
   },
   "--color-surface-elevated": {
     dark: "#212121",
@@ -716,14 +709,14 @@ export const themeTokens = {
   },
   "--color-surface-elevated-secondary": {
     dark: "color-mix(in oklab, #ffffff 3%, transparent)",
-    light: "#f2f4f6",
+    light: "rgba(26, 28, 31, 0.049)",
     themeFallback: "rgba(255, 255, 255, 0.03)",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--color-surface-under": {
     dark: "#141414",
-    light: "#edf0f2",
-    provenance: "[RETUNE:light/independent-scale]",
+    light: "#f6f6f6",
+    provenance: "[RETUNE:light/two-plane-system]",
   },
   "--color-terminal-black": {
     dark: "rgba(255, 255, 255, 0.5)",
@@ -892,21 +885,21 @@ export const themeTokens = {
   },
   "--diffs-bg-addition-hover-override": {
     dark: "color-mix(in srgb, var(--color-diff-main-surface) 82%, var(--color-diff-added))",
-    light: "#d3ecdd",
+    light: "#d3ebdd",
     themeFallback: "#14311f",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/white-anchored-diffs]",
   },
   "--diffs-bg-addition-number-override": {
     dark: "color-mix(in srgb, var(--color-diff-main-surface) 91%, var(--color-diff-added))",
-    light: "#d9efe3",
+    light: "#d9eee2",
     themeFallback: "#16241c",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/white-anchored-diffs]",
   },
   "--diffs-bg-addition-override": {
     dark: "color-mix(in srgb, var(--color-diff-main-surface) 88%, var(--color-diff-added))",
-    light: "#e3f3e9",
+    light: "#e4f3ea",
     themeFallback: "#15291d",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/white-anchored-diffs]",
   },
   "--diffs-bg-context-override": {
     dark: "var(--diff-view-context-surface)",
@@ -915,15 +908,15 @@ export const themeTokens = {
   },
   "--diffs-bg-deletion-hover-override": {
     dark: "color-mix(in srgb, var(--color-diff-main-surface) 82%, var(--color-diff-deleted))",
-    light: "#f7d8d6",
+    light: "#f7d7d5",
     themeFallback: "#3c1c1b",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/white-anchored-diffs]",
   },
   "--diffs-bg-deletion-number-override": {
     dark: "color-mix(in srgb, var(--color-diff-main-surface) 91%, var(--color-diff-deleted))",
-    light: "#f9e0de",
+    light: "#f9dfdd",
     themeFallback: "#2a1a1a",
-    provenance: "[RETUNE:light/independent-scale]",
+    provenance: "[RETUNE:light/white-anchored-diffs]",
   },
   "--diffs-bg-deletion-override": {
     dark: "color-mix(in srgb, var(--color-diff-main-surface) 88%, var(--color-diff-deleted))",
@@ -1221,18 +1214,18 @@ export const themeTokens = {
   },
   "--shadow-modal": {
     dark: "0 25px 50px -12px rgb(0 0 0 / 0.5)",
-    light: "0 16px 40px rgb(16 24 40 / 0.16)",
-    provenance: "[RETUNE:light/independent-scale]",
+    light: "0 16px 40px rgba(26, 28, 31, 0.18)",
+    provenance: "[RETUNE:light/ink-tinted-elevation]",
   },
   "--shadow-popover": {
     dark: "0 4px 12px rgb(0 0 0 / 0.12)",
-    light: "0 4px 12px rgb(16 24 40 / 0.10)",
-    provenance: "[RETUNE:light/independent-scale]",
+    light: "0 0 0 0.5px rgba(26, 28, 31, 0.05), 0 4px 12px rgba(26, 28, 31, 0.1)",
+    provenance: "[RETUNE:light/ink-tinted-elevation]",
   },
   "--shadow-subtle": {
     dark: "0 1px 2px 0 rgb(0 0 0 / 0.05)",
-    light: "0 1px 2px rgb(16 24 40 / 0.06)",
-    provenance: "[RETUNE:light/independent-scale]",
+    light: "0 1px 2px rgba(26, 28, 31, 0.06)",
+    provenance: "[RETUNE:light/ink-tinted-elevation]",
   },
   /**
    * Lift for the user-message bubble, which only light mode needs — see
@@ -1242,8 +1235,8 @@ export const themeTokens = {
    */
   "--shadow-user-message": {
     dark: "none",
-    light: "var(--shadow-subtle)",
-    provenance: "[RETUNE:light/independent-scale]",
+    light: "0 1px 2px rgba(26, 28, 31, 0.05)",
+    provenance: "[RETUNE:light/ink-tinted-elevation]",
   },
   "--size-icon-button-lg": {
     dark: "1.75rem",
@@ -1613,8 +1606,8 @@ export const themeTokens = {
   },
   "--workspace-shell-tab-active-underline": {
     dark: "rgb(255 255 255)",
-    light: "#16181b",
-    provenance: "[TABS:active-underline]",
+    light: "var(--color-foreground)",
+    provenance: "[RETUNE:light/alpha-neutral-system]",
   },
   "--workspace-shell-tab-active-underline-size": {
     dark: "2px",

--- a/apps/packages/product-client/src/components/playground/transcript/PlaygroundMarkdownTranscript.tsx
+++ b/apps/packages/product-client/src/components/playground/transcript/PlaygroundMarkdownTranscript.tsx
@@ -19,7 +19,7 @@ This settled response demonstrates **strong emphasis**, *italic emphasis*, and a
 - Nested structure
   - Second-level item
     - Third-level item
-- File references keep their renderer: [MarkdownBody.tsx](/Users/pablohansen/proliferate/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.tsx)
+- File references keep their renderer: [MarkdownBody.tsx](/workspace/proliferate/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.tsx)
 
 1. First ordered item
 2. Second ordered item

--- a/apps/packages/product-client/src/lib/domain/preferences/appearance-css-drift.test.ts
+++ b/apps/packages/product-client/src/lib/domain/preferences/appearance-css-drift.test.ts
@@ -293,6 +293,17 @@ describe("generated design-package semantic text tokens", () => {
 describe("right-panel tab typography", () => {
   const rightPanelRule = readRule(productCss, /\.right-panel-tab-system\s*\{([\s\S]*?)\}/);
 
+  it("derives the light sticky backdrop from the light surface", () => {
+    const lightRule = readRule(
+      productCss,
+      /:root\[data-mode="light"\] \.right-panel-tab-system\s*\{([\s\S]*?)\}/,
+    );
+    expect(lightRule).toContain(
+      "--right-panel-tab-sticky-surface: color-mix(in srgb, var(--color-surface) 88%, transparent);",
+    );
+    expect(lightRule).not.toContain("#181818");
+  });
+
   it("consumes compact UI, control-weight, and control-icon tokens", () => {
     expect(rightPanelRule).toContain("font-size: var(--text-ui-sm);");
     expect(rightPanelRule).toContain("line-height: var(--text-ui-sm--line-height);");
@@ -473,16 +484,22 @@ describe("tab and sidebar status tokens across modes", () => {
   });
 
   it("keeps the light column on the adopted readable inks, not dark's bright ones", () => {
-    // The exact light literals adopted with the independent light column: a
-    // near-black underline and darkened status inks that hold contrast on a
-    // white sidebar. Locked so "fix light mode" edits can't quietly regress
-    // to the dark palette's values, which are unreadable on light surfaces.
+    // The underline follows the light palette's single neutral ink authority;
+    // status colors keep their independently authored accessible literals.
+    expect(readDeclaration(lightRoot, "--workspace-shell-tab-active-underline")).toBe(
+      "var(--color-foreground)",
+    );
+    expect(readDeclaration(lightRoot, "--color-foreground")).toBe(
+      rgbToHex([0x1a, 0x1c, 0x1f]),
+    );
+
+    // Locked so light-mode edits cannot quietly regress statuses to the dark
+    // palette's values, which are unreadable on light surfaces.
     // Expressed as RGB channels (like the composer locks above): tokens.ts
     // owns the literal spelling, so no second raw-hex literal lives here.
     const LIGHT_STATUS_INKS: ReadonlyArray<
       readonly [token: string, channels: readonly [number, number, number]]
     > = [
-      ["--workspace-shell-tab-active-underline", [0x16, 0x18, 0x1b]],
       ["--color-sidebar-status-error", [0xc0, 0x26, 0x22]],
       ["--color-sidebar-status-unseen", [0x0b, 0x6b, 0xcb]],
       ["--color-sidebar-status-waiting", [0x8a, 0x5a, 0x00]],

--- a/scripts/check_theme_contrast.py
+++ b/scripts/check_theme_contrast.py
@@ -18,27 +18,26 @@ landed at 3.28:1 at 11px, and the persistent `selected` state read weaker than
 the transient `hover`. Those are all mechanically detectable, so they are
 detected here rather than re-discovered by eye.
 
-Text is measured against EVERY opaque plane the product paints it on, not just
-the page: in light mode six of those planes are near-white and three are not, so
-measuring only `surface` and `background` left the sidebar, the under-surface,
-and the one-step-off-white fills unchecked. That blind spot is exactly where the
-faint tier was failing while this check reported green, so the plane list is the
-contract too — a new elevation role belongs in `TEXT_PLANES`.
+Text is measured against EVERY plane the product paints it on, not just the
+page: in light mode the editor, rail, and translucent control fills all differ
+from white, so measuring only `surface` and `background` left them unchecked.
+That blind spot is exactly where the faint tier was failing while this check
+reported green, so the plane list is the contract too — a new elevation role
+belongs in `TEXT_PLANES`.
 
 Floors (both modes, no per-mode exemptions):
-  * body text        >= 7.0:1   against every opaque plane
-  * secondary text   >= 4.5:1   against every opaque plane
-  * faint text       >= 4.5:1   against every opaque plane
+  * body text        >= 7.0:1   against every measured plane
+  * secondary text   >= 4.5:1   against every measured plane
+  * faint text       >= 4.5:1   against every measured plane
   * borders          >= 1.25:1  against the surface they divide
   * hover/selected/active mutually distinguishable, AND selected carries more
     ink than hover — a persistent state may never read fainter than a
     transient one.
 
-Four measured pairs do not meet those floors and are NOT silently exempted: they
-are pinned in `DECLARED_DEVIATIONS` with their exact measured ratio, so each one
-is visible in review and can only ever improve. Two are pre-existing dark-mode
-facts outside the light retune's scope; two are approved light values that miss
-by a hundredth. See that table for the per-entry reasoning.
+Five measured dark-mode pairs do not meet those floors and are NOT silently
+exempted: they are pinned in `DECLARED_DEVIATIONS` with their exact measured
+ratio, so each one is visible in review and can only ever improve. See that
+table for the per-entry reasoning.
 
 Exit codes: 0 = all floors met (or met as pinned), 1 = at least one violation.
 
@@ -87,7 +86,7 @@ TEXT_ROLES: tuple[tuple[str, float], ...] = (
     # gating against and previously was not.
     ("--color-link-foreground", SECONDARY_FLOOR),
 )
-# Every opaque plane the product actually paints text on, not just the two the
+# Every plane the product actually paints text on, not just the two the
 # page starts from. In light mode `surface`, `background`, `card`, `popover`,
 # `surface-elevated` and `surface-control` are all near-white, so measuring only
 # the first two left the three darkest light planes — the sidebar, the
@@ -104,16 +103,23 @@ TEXT_PLANES: tuple[str, ...] = (
     "--color-surface-elevated",
     "--color-surface-elevated-secondary",
     "--color-surface-control",
+    "--color-surface-editor",
     "--color-surface-under",
     "--color-muted",
     "--color-sidebar",
 )
 
-# Each border role is measured against the plane it actually divides.
+# Each border role is measured against the plane it actually divides. The
+# lightest edge is additionally proven on the rail, recessed plane, and
+# translucent control fill because the light system promises one border rung
+# that composes on every parent rather than per-surface gray forks.
 BORDER_PAIRS: tuple[tuple[str, str], ...] = (
     ("--color-border", "--color-surface"),
     ("--color-border", "--color-background"),
     ("--color-border-light", "--color-surface"),
+    ("--color-border-light", "--color-sidebar"),
+    ("--color-border-light", "--color-surface-under"),
+    ("--color-border-light", "--color-surface-control"),
     ("--color-border-heavy", "--color-surface"),
     ("--color-input", "--color-surface"),
 )
@@ -123,6 +129,18 @@ BORDER_PAIRS: tuple[tuple[str, str], ...] = (
 SIDEBAR_PAIRS: tuple[tuple[str, str, float], ...] = (
     ("--color-sidebar-foreground", "--color-sidebar", BODY_FLOOR),
     ("--color-sidebar-muted-foreground", "--color-sidebar", SECONDARY_FLOOR),
+)
+
+# Some sidebar ink sits inside a translucent control painted on the rail. That
+# nested stack must be composed in order; measuring either role against the rail
+# alone misses the file-tree search and badge treatment.
+STACKED_TEXT_PAIRS: tuple[tuple[str, str, str, float], ...] = (
+    (
+        "--color-sidebar-muted-foreground",
+        "--color-surface-control",
+        "--color-sidebar",
+        SECONDARY_FLOOR,
+    ),
 )
 
 STATE_ROLES = ("--color-hover", "--color-selected", "--color-active")
@@ -141,16 +159,20 @@ DECLARED_DEVIATIONS: dict[tuple[str, str], tuple[float, str]] = {
         "pre-existing dark value, untouched by the light retune; raising it "
         "changes every hairline divider in dark mode and needs its own review",
     ),
-    ("light", "--color-border-light against --color-surface"): (
-        1.24,
-        "approved light value #e4e7ea measures 1.24:1, one hundredth under the "
-        "floor; it is the deliberate hairline weight and doubles as the hover "
-        "fill, so it was not nudged to clear an arbitrary rounding boundary",
+    ("dark", "--color-border-light against --color-sidebar"): (
+        1.156,
+        "newly measured dark rail pair, outside the light retune; pinned here "
+        "so it cannot regress before the dark hairline system is reviewed",
     ),
-    ("light", "--color-selected vs --color-active"): (
-        1.019,
-        "approved #dde1e6 vs #dbdfe4 differ by one step by design — selected and "
-        "active are adjacent, and both are separately distinguishable from hover",
+    ("dark", "--color-border-light against --color-surface-under"): (
+        1.127,
+        "newly measured dark recessed-plane pair, outside the light retune; "
+        "pinned here so it cannot regress before the dark hairline system is reviewed",
+    ),
+    ("dark", "--color-border-light against --color-surface-control"): (
+        1.164,
+        "newly measured dark control-fill pair, outside the light retune; "
+        "pinned here so it cannot regress before the dark hairline system is reviewed",
     ),
     ("dark", "--color-selected carries at least as much ink as --color-hover"): (
         1.08,
@@ -540,8 +562,30 @@ def measure_mode(mode: str, declarations: dict[str, str]) -> tuple[list[Measurem
             )
         )
 
+    for role, overlay, base_plane, floor in STACKED_TEXT_PAIRS:
+        base = planes.get(base_plane)
+        if base is None:
+            continue
+        nested_plane = resolved(overlay, base)
+        if nested_plane is None:
+            continue
+        ink = resolved(role, nested_plane)
+        if ink is None:
+            continue
+        measurements.append(
+            Measurement(
+                mode,
+                f"{role} on {overlay} over {base_plane}",
+                contrast(ink, nested_plane),
+                floor,
+                f"{ink.hex()} on {nested_plane.hex()}",
+            )
+        )
+
     for role, plane in BORDER_PAIRS:
-        backdrop = resolved(plane)
+        # Reuse the page-composited plane so translucent fills such as
+        # `--color-surface-control` are measured as people actually see them.
+        backdrop = planes.get(plane)
         if backdrop is None:
             continue
         stroke = resolved(role, backdrop)

--- a/scripts/test_check_theme_contrast.py
+++ b/scripts/test_check_theme_contrast.py
@@ -13,6 +13,8 @@ import unittest
 import unittest.mock
 
 from scripts.check_theme_contrast import (
+    BORDER_PAIRS,
+    STACKED_TEXT_PAIRS,
     TEXT_PLANES,
     Measurement,
     Resolver,
@@ -213,10 +215,10 @@ class PlaneCoverage(unittest.TestCase):
     rather than silently widening the blind spot.
     """
 
-    def test_every_opaque_elevation_role_is_measured(self) -> None:
-        # Every `--color-*` role in the authority that names an opaque plane text
-        # is painted on. Transient state fills are excluded deliberately — see
-        # the note on TEXT_PLANES.
+    def test_every_text_plane_is_measured(self) -> None:
+        # Every `--color-*` role in the authority that names a plane text is
+        # painted on. Translucent planes are composited by the checker; transient
+        # state fills are excluded deliberately — see the note on TEXT_PLANES.
         expected = {
             "--color-surface",
             "--color-background",
@@ -225,6 +227,7 @@ class PlaneCoverage(unittest.TestCase):
             "--color-surface-elevated",
             "--color-surface-elevated-secondary",
             "--color-surface-control",
+            "--color-surface-editor",
             "--color-surface-under",
             "--color-muted",
             "--color-sidebar",
@@ -238,13 +241,63 @@ class PlaneCoverage(unittest.TestCase):
         for role in ("--color-hover", "--color-selected", "--color-active"):
             self.assertNotIn(role, TEXT_PLANES)
 
-    def test_the_faint_tier_is_measured_against_the_darkest_light_plane(self) -> None:
-        # The regression that shipped: #686e76 cleared 4.5:1 on white but not on
-        # the sidebar. Graded against the plane, not the page.
-        faint = Rgb(0x64, 0x6A, 0x72)
-        sidebar = Rgb(0xED, 0xF0, 0xF2)
-        self.assertGreaterEqual(contrast(faint, sidebar), 4.5)
-        self.assertLess(contrast(Rgb(0x68, 0x6E, 0x76), sidebar), 4.5)
+    def test_the_faint_tier_is_measured_after_alpha_composition(self) -> None:
+        # Alpha ink has no final color until it is composited over the plane. The
+        # rejected 55% proposal missed 4.5:1 on every light plane; 62% clears the
+        # darkest nested control fill as well as white, rail, and editor.
+        ink = Rgb(0x1A, 0x1C, 0x1F)
+        white = Rgb(0xFF, 0xFF, 0xFF)
+        rail = Rgb(0xF6, 0xF6, 0xF6)
+        control = composite(ink, 0.049, white)
+        rail_control = composite(ink, 0.049, rail)
+        planes = (
+            white,
+            rail,
+            Rgb(0xFA, 0xFA, 0xFA),
+            control,
+            rail_control,
+        )
+        for plane in planes:
+            self.assertGreaterEqual(contrast(composite(ink, 0.62, plane), plane), 4.5)
+            self.assertLess(contrast(composite(ink, 0.55, plane), plane), 4.5)
+
+    def test_sidebar_muted_ink_clears_a_control_on_its_rail(self) -> None:
+        self.assertIn(
+            (
+                "--color-sidebar-muted-foreground",
+                "--color-surface-control",
+                "--color-sidebar",
+                4.5,
+            ),
+            STACKED_TEXT_PAIRS,
+        )
+        ink = Rgb(0x1A, 0x1C, 0x1F)
+        rail = Rgb(0xF6, 0xF6, 0xF6)
+        rail_control = composite(ink, 0.049, rail)
+        self.assertGreaterEqual(contrast(composite(ink, 0.62, rail), rail), 4.5)
+        self.assertGreaterEqual(
+            contrast(composite(ink, 0.62, rail_control), rail_control), 4.5
+        )
+        self.assertLess(contrast(composite(ink, 0.61, rail_control), rail_control), 4.5)
+        self.assertLess(contrast(composite(ink, 0.60, rail), rail), 4.5)
+
+    def test_the_lightest_border_is_measured_on_every_light_parent(self) -> None:
+        expected = {
+            ("--color-border-light", "--color-surface"),
+            ("--color-border-light", "--color-sidebar"),
+            ("--color-border-light", "--color-surface-under"),
+            ("--color-border-light", "--color-surface-control"),
+        }
+        self.assertTrue(expected.issubset(set(BORDER_PAIRS)))
+
+        ink = Rgb(0x1A, 0x1C, 0x1F)
+        white = Rgb(0xFF, 0xFF, 0xFF)
+        rail = Rgb(0xF6, 0xF6, 0xF6)
+        control = composite(ink, 0.049, white)
+        rail_control = composite(ink, 0.049, rail)
+        for plane in (white, rail, control, rail_control):
+            self.assertGreaterEqual(contrast(composite(ink, 0.114, plane), plane), 1.25)
+        self.assertLess(contrast(composite(ink, 0.113, rail_control), rail_control), 1.25)
 
 
 if __name__ == "__main__":

--- a/specs/codebase/platforms/product/design-system.md
+++ b/specs/codebase/platforms/product/design-system.md
@@ -206,118 +206,114 @@ Color is expressed as roles, never as a palette. A component asks for
 Every role has a dark and a light half in the same record, so a new role cannot
 ship half-themed.
 
-### The house form: symmetric opacity
+### The house form: one neutral ink per mode
 
-Most non-literal colors are `color-mix(in oklab, …)` against the mode's own
-foreground:
+Dark foreground and edge overlays derive from white; light neutrals derive from
+one near-black ink, `#1a1c1f`. Light borders, state fills, secondary text,
+control fills, scrollbars, and shadows use that ink with role-specific alpha
+instead of an opaque gray ramp. The alpha form composes over both the white
+content plane and the tinted rail without creating a separate gray for each
+parent surface.
 
-```
-dark:  color-mix(in oklab, #ffffff 70%, transparent)
-light: color-mix(in oklab, var(--color-foreground) 70%, transparent)
-```
+The percentages are independently authored per mode because equal numeric
+alpha does not produce equal contrast over opposite backgrounds. In light mode,
+secondary text uses 65% ink while the faint tier uses 62%; the latter is the
+lowest clean two-decimal alpha that clears 4.5:1 on every measured plane,
+including the translucent control fill. The contrast contract, not numeric
+symmetry, chooses the rung.
 
-The percentage is identical in both halves. Dark mixes white into the surface,
-light mixes the near-black foreground (`#1a1c1f`) into it, and the *same* number
-produces the *same* perceived step in each mode. That symmetry is why the
-hierarchy survives a mode switch without a second set of tuned values: there is
-one ladder of percentages, applied from opposite ends.
+Dark foreground-derived roles retain `color-mix(in oklab, …)` for perceptual
+steps. Light neutral overlays use direct `rgba(26, 28, 31, alpha)` values so
+their source ink and composition are explicit. The diff-view family uses
+white-anchored `color-mix(in srgb, #ffffff …, #1a1c1f)` values because those are
+surface-on-surface blends rather than translucent overlays.
 
-`oklab` is the mixing space for foreground-derived roles because it keeps
-perceptual lightness steps even; the diff-view family mixes in `srgb`/`lab`
-because those values are surface-on-surface blends whose shipped appearance is
-tied to the space they were tuned in.
-
-> **`color-mix()` cannot live in Tailwind's `@theme`, so every mix carries a
-> resolved literal.** Each such token declares a `themeFallback` — a flat
+> **`color-mix()` cannot live in Tailwind's `@theme`, so every default/dark mix
+> projected there carries a resolved literal.** Each such mix declares a
+> `themeFallback` — a flat
 > `rgba()`/hex with no `var()` and no `color-mix()` — which the generator emits
 > into the `@theme` half while `:root` keeps the live relative expression.
-> `check-theme.mjs` requires the fallback on every `color-mix()` token and
-> requires it to be fully resolved, so `@theme` can never silently drop a color.
+> `check-theme.mjs` requires the fallback on every projected default/dark mix
+> and requires it to be fully resolved, so `@theme` can never silently drop a color.
 > The same literals are what the React Native bridge consumes.
 
 ### Surfaces
 
-A recessed-to-raised ladder in dark; light collapses most of it to white and
-carries the hierarchy with borders instead.
+A recessed-to-raised ladder in dark; light uses white content over one `#f6f6f6`
+rail, with `#fafafa` reserved for editor/code chrome. Translucent neutral washes
+separate controls from either opaque parent.
 
 | Token | Dark | Light | Role |
 | --- | --- | --- | --- |
-| `--color-surface-under` | `#141414` | `#f9f9f9` | Recessed backdrop behind the app frame (sidebar rail well). |
+| `--color-surface-under` | `#141414` | `#f6f6f6` | Recessed backdrop behind the app frame. |
 | `--color-surface` / `--color-background` | `#181818` | `#ffffff` | The root app surface — also the chat/content pane background. |
-| `--color-sidebar` | `#222222` | `var(--color-surface-under)` | Sidebar body. Round-2 measurement against the reference app's dark capture: the sidebar rail sits one step ABOVE root (`#222222`), not recessed below it — supersedes the prior surface-recess ruling. |
-| `--color-surface-elevated` / `--color-card` | `#212121` | `#ffffff` / `var(--color-surface-elevated)` | Raised cards and panels. |
-| `--color-surface-elevated-secondary` | 3% white | 2% foreground | A raise expressed as a wash, for surfaces that must sit on an unknown parent. |
+| `--color-sidebar` | `#222222` | `#f6f6f6` | Sidebar body; light shares the one rail plane. |
+| `--color-sidebar-background` | `#181818` | `#f6f6f6` | Shell rail backdrop. |
+| `--color-surface-elevated` / `--color-card` | `#212121` | `#ffffff` | Raised cards and panels. |
+| `--color-surface-elevated-secondary` | 3% white | 4.9% light ink | A wash for surfaces that must sit on an unknown parent. |
 | `--color-popover` | `#2d2d2d` | `#ffffff` | Popover/menu/toast body — the highest opaque step. |
-| `--color-surface-editor` | `#282828` | `#f7f7f7` | Code/editor chrome. |
+| `--color-surface-editor` | `#282828` | `#fafafa` | Code/editor chrome. |
 | `--color-diff-code-surface` | `#111111` | `var(--color-surface-editor)` | Diff code gutter/body, deliberately below root in dark. |
-| `--color-surface-control` | `color-mix(in oklab, #2b2b2b 96%, transparent)` | `rgba(237, 237, 237, 0.4)` | Translucent control chrome (pickers, inline fields). |
-| `--color-composer-background` | `color-mix(in oklab, #2d2d2d 96%, transparent)` | `rgba(255, 255, 255, 0.864)` | The composer input surface. |
+| `--color-surface-control` / `--color-muted` | 96% dark control / `#212121` | 4.9% light ink | Control chrome and low raised fills. |
+| `--color-composer-background` | `#2d2d2d` | `#ffffff` | The fully opaque composer input surface. |
 
 The dark ladder steps `#141414 → #181818 → #212121/#222222 → #282828 → #2d2d2d`:
 roughly four to five levels of lightness per step, small enough that no step
 reads as a color change and large enough to separate two adjacent panels
-without a border. The sidebar now sits at the `#222222` rung, essentially
-alongside `--color-surface-elevated` — one step lighter than the root app
-surface it borders, reading as a raised rail rather than a recessed well.
+without a border. The sidebar sits at the `#222222` rung in dark, one step
+lighter than the root. Light deliberately has only the white content plane, the
+`#f6f6f6` rail, and the `#fafafa` editor plane; reusable fills remain alpha ink
+rather than adding opaque intermediate planes.
 
-**The composer is translucent, not a card.** Both modes let the transcript read
-through it. It is also the one surface with a per-mode backdrop treatment:
-`--color-composer-backdrop-filter` is `blur(16px)` in light and `none` in dark.
-Dark is deliberately un-blurred — WKWebView re-blurs the whole transcript on
-every keystroke, a cost the token's own comment records. The two alphas differ
-(96% dark, 86.4% light) because each was tuned for its own backdrop treatment;
-raising light to dark's 96% would cancel the blur rather than match it. The
-authored `backdrop-filter` declarations for that surface live in `product.css`,
-and the appearance gate bans the property everywhere else
-(`BACKDROP_FILTER_RE`), so no second surface can start blurring by accident.
+The composer is opaque in both modes and uses no backdrop filter. That keeps
+transcript paint out of the input surface and avoids re-blurring the transcript
+while typing.
 
 ### Borders
 
-| Token | Both modes | Where |
-| --- | --- | --- |
-| `--color-border-light` | 5% | Hairlines inside a component: list separators, table rules. |
-| `--color-border` | 8.4% | The default border for panels, inputs, cards. |
-| `--color-border-heavy` | 12% | Active/selected borders and any edge that must read as deliberate. |
+| Token | Dark | Light | Where |
+| --- | --- | --- | --- |
+| `--color-border-light` | 5% white | 11.4% light ink | Hairlines inside a component: list separators, table rules. |
+| `--color-border` | 8.4% white | 14% light ink | The default border for panels, inputs, cards. |
+| `--color-border-heavy` | 12% white | 18% light ink | Active/selected borders and deliberate edges. |
+| `--color-input` | 12% white | 20% light ink | Form-control outline. |
 
-Three steps, each roughly 1.5× the last. Because the system is near-flat (see
-[Elevation](#elevation)), these borders — not shadows — are the primary means of
-separating one surface from another, which is why the default sits at a
-fractional 8.4% rather than a round 8%: it is the shipped value the whole UI was
-tuned against.
+Light's values are stronger than the visual proposal's 4.9% / 7.8% / 11.7%
+steps because those missed the repository's 1.25:1 edge floor. The chosen alpha
+ramp keeps every weight composed from the one ink while clearing the enforced
+floor on white, the rail, and the translucent control fill.
 
 ### Text
 
 | Token | Dark | Light | Role |
 | --- | --- | --- | --- |
 | `--color-foreground` | `#ffffff` | `#1a1c1f` | Primary text. |
-| `--color-foreground-secondary` | 70% | 70% | Secondary text, descriptions. |
-| `--color-foreground-tertiary` | 50% | 50% | Tertiary text, placeholders, disabled labels. |
-| `--color-muted-foreground` | 70% | `var(--color-foreground-secondary)` | The widely-used alias for secondary. |
-| `--color-faint` | 50% | `var(--color-foreground-tertiary)` | The widely-used alias for tertiary. |
+| `--color-foreground-secondary` | 70% white | 65% light ink | Secondary text, descriptions. |
+| `--color-foreground-tertiary` | 50% white | 62% light ink | Tertiary text, placeholders, disabled labels. |
+| `--color-muted-foreground` | 70% white | 65% light ink | The widely-used secondary role. |
+| `--color-faint` | 50% white | 62% light ink | The widely-used tertiary role. |
 | `--color-sidebar-foreground` | 85% | 85% | Sidebar body text: below primary, above secondary. |
-| `--color-sidebar-muted-foreground` | `rgba(255, 255, 255, 0.481)` | `var(--color-foreground-tertiary)` | Sidebar meta. |
+| `--color-sidebar-muted-foreground` | 48.1% white | 62% light ink | Sidebar meta, including controls painted on the rail. |
 
-Three steps carry text hierarchy — 100% / 70% / 50% — with 85% reserved for the
-sidebar, whose text sits on a darker surface than the rest of the app and needs
-slightly more weight to match. `muted-foreground` and `faint` are older names
-for secondary and tertiary; they are the same two steps and remain because
-hundreds of call sites use them.
+The light faint tier is deliberately close to secondary: 55% light ink resolves
+to about 3.74–3.84:1 across the actual planes, while 62% clears 4.5:1 everywhere.
+The guard measures white, rail, editor, control, muted, card, popover, and raised
+planes after alpha composition. `muted-foreground` and `faint` remain distinct
+role names because hundreds of call sites use them.
 
 ### Interaction states
 
-| Token | Both modes | State |
-| --- | --- | --- |
-| `--color-hover` | 7.8% | Pointer hover. |
-| `--color-active` | 5.2% | Press/open (`active:`, `data-[state=open]`). |
-| `--color-selected` | 3.2% | Persistent selection. |
+| Token | Dark | Light | State |
+| --- | --- | --- | --- |
+| `--color-hover` | 7.8% white | 5.3% light ink | Pointer hover. |
+| `--color-selected` | 3.2% white | 6.5% light ink | Persistent selection. |
+| `--color-active` | 5.2% white | 7.8% light ink | Press/open (`active:`, `data-[state=open]`). |
 
-One vocabulary, three values, reused everywhere. The ladder orders the states by
-*how long they last*, not by how important they are: hover 7.8% > press 5.2% >
-selected 3.2%. Transient pointer feedback is the loudest because it is gone the
-moment the pointer leaves; a selected row keeps its tint for as long as the
-selection stands, so it is the quietest of the three — loud enough to find,
-quiet enough to live with. Press sits between them because it reads *against* an
-already-hovered surface.
+One vocabulary is reused everywhere. The light ladder is ordered so selected
+carries more ink than hover and active carries more than selected; all adjacent
+steps clear the state-distinction floor. Dark retains its historical ordering,
+with the selected-direction miss recorded by the contrast ratchet rather than
+hidden.
 
 Consumers use these three roles directly — the shell, sidebar, lists and menus
 all paint from the same three tokens, so they cannot drift apart. The gate
@@ -331,31 +327,27 @@ invented where one of these three belongs.
 
 | Family | Token | Dark | Light |
 | --- | --- | --- | --- |
-| Destructive | `--color-destructive` | `#fa423e` | `#e02e2a` |
-| | `--color-destructive-subtle` | `rgba(250,66,62,0.12)` | same |
+| Destructive | `--color-destructive` | `#fa423e` | `#c02622` |
+| | `--color-destructive-subtle` | `rgba(250,66,62,0.12)` | `#fbe9e8` |
 | | `--color-destructive-foreground` | `#ffffff` | `#ffffff` |
-| Success | `--color-success` | `#40c977` | `#00a240` |
-| | `--color-success-subtle` | `rgba(64,201,119,0.14)` | same |
-| Warning | `--color-warning` | `rgba(255, 180, 50, 0.15)` | `#fff8e6` |
-| | `--color-warning-foreground` | `#ffb432` | `var(--color-foreground)` |
-| | `--color-warning-border` | `rgba(255, 180, 50, 0.25)` | `var(--color-border)` |
+| Success | `--color-success` | `#40c977` | `#0a7c3f` |
+| | `--color-success-subtle` | `rgba(64,201,119,0.14)` | `#e6f4ec` |
+| Warning | `--color-warning` | `rgba(255, 180, 50, 0.15)` | `#fdf3dc` |
+| | `--color-warning-foreground` | `#ffb432` | `#8a5a00` |
+| | `--color-warning-border` | `rgba(255, 180, 50, 0.25)` | `#e8d9ae` |
 | | `--color-warning-subtle` | `rgba(242,201,76,0.14)` | same |
-| Info | `--color-info` | `#339cff` | `#0285ff` |
+| Info | `--color-info` | `#339cff` | `#0b6bcb` |
 
-Each family is a hue plus a `-subtle` tint for fills; the `-subtle` variants are
-mode-independent because a 12–14% tint of a saturated hue reads the same over
-either background. The `warning` family is the exception in shape: its base
-token is already a tint rather than a hue, with the hue held in
-`warning-foreground`.
+Each family is independently authored per mode. These status values are outside
+the neutral retune: changing the one-ink ladder must not move success,
+destructive, warning, or review-state hues.
 
 Git and review state carry a parallel set of roles rather than reusing these:
 `--color-git-green`/`-red`/`-yellow`, `--color-diff-added`,
 `--color-diff-deleted`, `--color-pr-merged` (`#ad7bf9`/`#8250df`),
-`--color-status-in-progress`. Two are visibly derived from the semantic pair
-(`git-green` is `success`, dark for dark and light for light) and two are not
-(`--color-diff-added` is `#00a240` in *both* modes, because it must hold against
-the diff's own surfaces rather than the app background). Keeping them separate is
-what lets a diff retune its greens without moving every success badge.
+`--color-status-in-progress`. Git green matches success in each mode, but the
+roles stay separate so diff surface tints can move without changing every
+success badge.
 
 ### Accents
 
@@ -363,28 +355,17 @@ what lets a diff retune its greens without moving every success badge.
 | --- | --- | --- | --- |
 | `--color-primary` | `#ffffff` | `#1a1c1f` | Primary action fill. |
 | `--color-primary-foreground` | `#0d0d0d` | `#ffffff` | Text on that fill. |
-| `--color-link-foreground` | `#83c3ff` | `#339cff` | Links. |
-| `--color-special` | `#339cff` | `#339cff` | Accent for highlighted/special affordances. |
-| `--color-ring` | 28% | 30% | Focus ring. |
-| `--color-highlight` | `rgba(51, 156, 255, 0.12)` | `#e5f3ff` | Search/selection highlight fill. |
+| `--color-link-foreground` | `#83c3ff` | `#0b6bcb` | Links. |
+| `--color-special` | `#339cff` | `#0b6bcb` | Accent for highlighted/special affordances. |
+| `--color-ring` | 28% white | `#0b6bcb` | Focus ring. |
+| `--color-highlight` | `rgba(51, 156, 255, 0.12)` | `#e5f2ff` | Search/selection highlight fill. |
 
 **Primary is the inverted foreground pair, not a brand hue.** The primary button
 is white-on-near-black in dark and near-black-on-white in light. The product's
-one chromatic accent is a single blue hue, so blue always means "this is a link
-or a called-out thing" and never "this is the primary action". `--color-special`
-and `--color-highlight` hold that hue at `#339cff` in both modes.
-`--color-link-foreground` is the one member of the family that is *not*
-mode-independent: dark carries a lighter step of the same hue (`#83c3ff`) because
-`#339cff` link text sits too dark against the dark surfaces to read as clickable
-at prose weight, while light keeps `#339cff`, which needs the contrast the other
-way. It is still a single link token — there are no per-surface link colors.
-
-The focus ring is one of only two tokens in the whole authority where the
-symmetric-opacity rule is broken on purpose — the light half carries a different
-percentage from the dark: `--color-ring` (28% / 30%) and
-`--color-surface-elevated-secondary` (3% / 2%). Both are shipped hand-tunes, not
-derivations. Every other foreground-mix token uses the same number in both
-halves.
+one chromatic accent is blue, so blue means link, focus, information, or a
+called-out affordance and never the primary action. Light uses `#0b6bcb` for
+link, focus, info, special, and sidebar-ring roles; dark uses a brighter link
+step where prose contrast requires it. There are no per-surface link colors.
 
 ### Special-purpose palettes
 
@@ -396,9 +377,9 @@ listed by count because the individual values carry no design rule beyond
 | --- | --- | --- |
 | `--color-terminal-*` | 16 | The ANSI 8 + bright 8 set for the embedded terminal; also projected into `codeColors.terminal`. |
 | `--color-delegated-agent-*` | 8 | Per-agent identity hues, authored in `hsl()`: the dark half is a light, desaturated tint of a hue and the light half is a darker, more saturated version of the same hue, so agent 3 is recognizably "the red one" in either mode. |
-| `--color-diff-*` | 15 | Diff and review chrome: main/panel/header/code surfaces plus the chat-embedded file, turn and inline-tool headers. |
-| `--diff-view-*` | 6 | The diff *view*'s own surface family: base surface, header, context, hover, separator, context gutter number. |
-| `--diffs-*` | 16 | The diff renderer's override contract: addition/deletion/context/separator fills (each a `color-mix()` of the diff surface with the add/delete hue), plus its font, size, leading, minimum gutter width and mixer color. |
+| `--color-diff-*` | 15 | Diff and review chrome: main/panel/header/code surfaces plus the chat-embedded file, turn and inline-tool headers. Light neutral surfaces mix white toward the one light ink. |
+| `--diff-view-*` | 6 | The diff view's base, header, context, hover, separator, and context-number surfaces; light values are white-anchored mixes. |
+| `--diffs-*` | 16 | The renderer override contract: independently authored addition/deletion/context/separator fills plus type and gutter geometry. |
 | `--color-compute-target-*` | 9 | Compute-target identity colors — nine named hues, mode-independent. |
 | `--color-file-icon-*` | 5 | File-tree glyph tones (folder, accent, neutral, muted, red). |
 | `--scratch-*` | 6 | The scratch editor's type and marker geometry, derived from the message role and expressed in `em`. |
@@ -406,28 +387,23 @@ listed by count because the individual values carry no design rule beyond
 
 ## Elevation
 
-The system is near-flat by design. There are exactly three shadows:
+The system is near-flat by design. Three elevation roles are authored per mode:
 
-| Token | Value | Where |
-| --- | --- | --- |
-| `--shadow-subtle` | `0 1px 2px 0 rgb(0 0 0 / 0.05)` | Anything that sits *on* the page — reached through `--color-composer-shadow`. |
-| `--shadow-popover` | `0 4px 12px rgb(0 0 0 / 0.12)` | Anything that floats *over* the page: popovers, menus, tooltips, toasts. |
-| `--shadow-modal` | `0 25px 50px -12px rgb(0 0 0 / 0.5)` | Anything that takes *over* the page: dialogs, modal shells, the command palette. |
+| Token | Dark | Light | Where |
+| --- | --- | --- | --- |
+| `--shadow-subtle` | `0 1px 2px 0 rgb(0 0 0 / 0.05)` | `0 1px 2px rgba(26, 28, 31, 0.06)` | Elements that sit on the page. |
+| `--shadow-popover` | `0 4px 12px rgb(0 0 0 / 0.12)` | 0.5px 5% ink edge + 12px 10% ink shadow | Popovers, menus, tooltips, toasts. |
+| `--shadow-modal` | `0 25px 50px -12px rgb(0 0 0 / 0.5)` | `0 16px 40px rgba(26, 28, 31, 0.18)` | Dialogs, modal shells, command palette. |
 
-Depth is carried by borders and surface steps first, shadow second. Three roles
-are enough because shadow is only asked one question — is this element on the
-page, over it, or in front of it — and each answer is roughly an order of
-magnitude from the next in blur (2 / 12 / 50px) and opacity (5% / 12% / 50%). In
-dark especially, a shadow over a `#181818` surface does very little work, so the
-surface ladder and the border ladder do it instead. The floating surfaces pair
-their shadow with a hairline `ring-[0.5px]` rather than a heavier shadow, which is
-the same near-flat instinct applied at the edge.
+Depth is carried by borders and surface steps first, shadow second. Light shadow
+color derives from the same `#1a1c1f` ink as the neutral ladder, so elevation
+does not reintroduce a blue slate cast.
 
-Both modes share all three values: a shadow is a light-direction cue, not a
-color, so it does not invert.
+Two component roles refine the shared scale: the light user-message bubble uses
+a 5% ink 2px shadow, and the light composer combines a 0.5px ink edge with 3px
+and 12px shadow layers. Dark keeps the user-message shadow absent and aliases
+the composer to `--shadow-subtle`.
 
-One extra name rides on these roles: `--color-composer-shadow` resolves to
-`--shadow-subtle`, keeping the composer's outline shadow on the shared scale.
 From the class side, the appearance gate bans every other elevation spelling —
 `shadow-sm/md/lg/xl/2xl/inner` (stock Tailwind emits a non-token shadow),
 `shadow-floating`, `shadow-keystone`, and `shadow-[…]` — through
@@ -983,8 +959,11 @@ independent code path and then asserts, in order:
   `compile()`, so a malformed `@theme`/`@utility` block fails the design build
   instead of 500-ing a consumer app's JIT stylesheet at runtime.
 - **Provenance and fallback discipline:** every token has a provenance tag, and
-  every `color-mix()` token has a resolved `@theme` fallback (Tailwind's
-  `@theme` block cannot hold `color-mix()`).
+  every default/dark `color-mix()` projected into `@theme` has a resolved
+  fallback (Tailwind's `@theme` block cannot hold `color-mix()`).
+- **The light palette contract:** retired opaque slate literals stay absent,
+  the white/rail/editor planes and single accent stay pinned, and every neutral
+  alpha role remains on its adopted `#1a1c1f` rung.
 - **Motion authority:** each duration/ease/cadence/delay number and each
   `--duration-*`/`--ease-*`/`--activity-*` token matches `motion.ts` in both
   halves.
@@ -1017,14 +996,17 @@ consolidation:
 
 Tags are historical, not permissions. `[SHIPPED]` does not mean a value is
 protected and `[RETUNE:…]` does not mean it is still in flight — the tag records
-where the value came from, and any value is one edit plus one build away from
-changing.
+where the value came from. `tokens.ts` remains the authority; an intentional
+light-palette change also updates the exact invariant map in `check-theme.mjs`
+before rebuilding, so the architectural lock cannot drift silently with the
+value it guards.
 
 ### Gates
 
 | Gate | Purpose |
 | --- | --- |
 | [check-theme.mjs](../../../../apps/packages/design/scripts/check-theme.mjs) | Everything in the section above: the generated CSS is a faithful, compilable projection of the authority, and hand-authored CSS owns no values. |
+| [check_theme_contrast.py](../../../../scripts/check_theme_contrast.py) | Text contrast on every content, rail, editor, and control plane; border contrast on white, rail, recessed, and control surfaces; and ordered, distinguishable interaction-state fills. Pre-existing misses are exact ratchets rather than silent exemptions. |
 | [check_appearance_scaling.py](../../../../scripts/check_appearance_scaling.py) | Banned class shapes at every call site (arbitrary radius/z/gap/size, non-token shadows, low-alpha foreground overlays, retired state classes, fixed text/glyph sizes, numeric durations and inline beziers, unowned `backdrop-filter`, raw hex, unsanctioned long lists). Its contract is owned by [appearance-scaling.md](../../systems/product/settings/appearance-scaling.md). |
 | [check_frontend_boundaries.py](../../../../scripts/check_frontend_boundaries.py) | Radix containment inside ProductClient's library tiers, the closed `primitives/**` root/support-directory set, the nested primitives purity/layer law, and the broader frontend import boundaries. |
 | [check_docs.py](../../../../scripts/check_docs.py) | Documentation links and anchors — a renamed source file breaks CI instead of silently orphaning a reference in this document. |


### PR DESCRIPTION
## Summary

- replace the opaque light slate ramp with a single ink-derived neutral system
- keep semantic status colors stable while retuning planes, accents, diffs, and elevation
- expand palette and contrast guardrails, including nested controls on the rail
- sanitize the deterministic Markdown playground path and document the contract

## Why

The prior light palette mixed unrelated opaque grays, leaked stale dark/neutral values into peripheral roles, and left contrast blind spots on editor and nested rail/control surfaces. The supplied palette architecture also proposed several alphas below the repository's existing floors, so this keeps the architecture while choosing the smallest compliant rungs.

## Impact

Light mode now uses `#1a1c1f` as its neutral ink, white content, a `#f6f6f6` rail, a `#fafafa` editor plane, and `#0b6bcb` as the accent. Faint/sidebar text, borders, and selected states remain readable and mechanically guarded. Dark values are unchanged.

## Validation

- `pnpm --filter @proliferate/design build`
- `python3 -m unittest scripts/test_check_theme_contrast.py`
- `python3 scripts/check_theme_contrast.py`
- `pnpm --filter @proliferate/product-client exec vitest run src/lib/domain/preferences/appearance-css-drift.test.ts src/config/theme.test.ts src/config/playground.test.ts`
- `pnpm --filter @proliferate/product-client exec tsc -p tsconfig.json --noEmit`
- `python3 scripts/check_appearance_scaling.py`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_design_attribution.py`
- `python3 scripts/check_docs.py`