### PR TITLE
fix(desktop): stop repeated worker failure notifications

### DIFF
--- a/apps/packages/product-client/src/copy/cloud/desktop-worker-copy.ts
+++ b/apps/packages/product-client/src/copy/cloud/desktop-worker-copy.ts
@@ -1,5 +1,30 @@
-export function desktopWorkerStartupFailureCopy(error: unknown): string {
+const WORKER_CREDENTIALS_LOCKED_DETAIL =
+  "Cannot replace worker credentials while a Proliferate Worker is still running.";
+
+export type DesktopWorkerStartupFailureKind =
+  | "credentials_locked"
+  | "startup_failed";
+
+export interface DesktopWorkerStartupFailureNotice {
+  kind: DesktopWorkerStartupFailureKind;
+  headline: string;
+  consequence: string;
+  cause: string;
+}
+
+export function desktopWorkerStartupFailureNotice(
+  error: unknown,
+): DesktopWorkerStartupFailureNotice {
   const detail = error instanceof Error ? error.message : String(error ?? "");
-  const normalizedDetail = detail.trim().length > 0 ? detail.trim() : "Unknown error";
-  return `Cloud integrations worker failed to start: ${normalizedDetail}`;
+  const cause = detail.trim().length > 0 ? detail.trim() : "Unknown error";
+  const credentialsLocked = cause.includes(WORKER_CREDENTIALS_LOCKED_DETAIL);
+
+  return {
+    kind: credentialsLocked ? "credentials_locked" : "startup_failed",
+    headline: "Cloud integrations unavailable",
+    consequence: credentialsLocked
+      ? "An earlier Proliferate Worker is still running. Quit other Proliferate apps; if none are open, restart your computer, then retry."
+      : "Proliferate will keep trying in the background. Retry now, or dismiss this notice.",
+    cause,
+  };
 }

--- a/apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.test.tsx
+++ b/apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.test.tsx
@@ -367,6 +367,38 @@ describe("useDesktopWorkerEnrollment", () => {
     }
   });
 
+  it("refreshes the notification when a retry fails for a different cause", async () => {
+    vi.useFakeTimers();
+    try {
+      workflowMocks.ensureDesktopWorker
+        .mockImplementationOnce(async (_organizationId, _worker, deps) => {
+          deps.onFailure("control plane unavailable");
+          return false;
+        })
+        .mockImplementationOnce(async (_organizationId, _worker, deps) => {
+          deps.onFailure("worker process exited");
+          return false;
+        });
+      const harness = await loadEnrollmentHarness();
+
+      await act(async () => {
+        harness.signIn("user-a");
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(harness.getErrorToastCalls()).toHaveLength(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20_000);
+      });
+      expect(harness.getErrorToastCalls()).toHaveLength(2);
+      expect(harness.getErrorToastCalls()[1]?.[0]).toEqual(
+        expect.objectContaining({ cause: "worker process exited" }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not resurface a dismissed failure during background retries", async () => {
     vi.useFakeTimers();
     try {
@@ -394,6 +426,41 @@ describe("useDesktopWorkerEnrollment", () => {
       });
       expect(workflowMocks.ensureDesktopWorker).toHaveBeenCalledTimes(2);
       expect(harness.getErrorToastCalls()).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resurfaces a dismissed notification when the failure cause changes", async () => {
+    vi.useFakeTimers();
+    try {
+      workflowMocks.ensureDesktopWorker
+        .mockImplementationOnce(async (_organizationId, _worker, deps) => {
+          deps.onFailure("control plane unavailable");
+          return false;
+        })
+        .mockImplementationOnce(async (_organizationId, _worker, deps) => {
+          deps.onFailure("worker process exited");
+          return false;
+        });
+      const harness = await loadEnrollmentHarness();
+
+      await act(async () => {
+        harness.signIn("user-a");
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      const notice = harness.getErrorToastCalls()[0]?.[0] as {
+        onDismiss: () => void;
+      };
+      act(() => notice.onDismiss());
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20_000);
+      });
+      expect(harness.getErrorToastCalls()).toHaveLength(2);
+      expect(harness.getErrorToastCalls()[1]?.[0]).toEqual(
+        expect.objectContaining({ cause: "worker process exited" }),
+      );
     } finally {
       vi.useRealTimers();
     }

--- a/apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.test.tsx
+++ b/apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.test.tsx
@@ -26,10 +26,17 @@ const workflowMocks = vi.hoisted(() => ({
 // store delegates to it, so capture calls here instead of reading store state.
 const toastMocks = vi.hoisted(() => ({
   showProductToast: vi.fn<(message: string, kind?: "error" | "info") => void>(),
+  showProductErrorToast: vi.fn<(input: Record<string, unknown>) => void>(),
+  dismissToast: vi.fn<(id?: string) => void>(),
 }));
 
 vi.mock("#product/components/feedback/product-toast", () => ({
   showProductToast: toastMocks.showProductToast,
+  showProductErrorToast: toastMocks.showProductErrorToast,
+}));
+
+vi.mock("#product/primitives/utils/show-toast", () => ({
+  dismissToast: toastMocks.dismissToast,
 }));
 
 vi.mock("#product/lib/workflows/cloud/ensure-desktop-worker", () => ({
@@ -58,6 +65,8 @@ async function loadEnrollmentHarness() {
     activeOrganizationValidated: false,
   });
   toastMocks.showProductToast.mockClear();
+  toastMocks.showProductErrorToast.mockClear();
+  toastMocks.dismissToast.mockClear();
   // The enrollment hook reads captureException through the product telemetry
   // facade (host boundary), so the harness mounts a ProductHostProvider.
   // Both provider and hook come from the same post-reset module registry so
@@ -88,6 +97,7 @@ async function loadEnrollmentHarness() {
         validated: true,
       }),
     getToastCalls: () => toastMocks.showProductToast.mock.calls,
+    getErrorToastCalls: () => toastMocks.showProductErrorToast.mock.calls,
     nudgeRender: () => rendered.rerender({ ...props }),
   };
 }
@@ -270,7 +280,7 @@ describe("useDesktopWorkerEnrollment", () => {
     }
   });
 
-  it("shows the native startup failure to the user", async () => {
+  it("shows one persistent actionable startup notification", async () => {
     workflowMocks.ensureDesktopWorker.mockImplementationOnce(async (
       _organizationId,
       _worker,
@@ -283,12 +293,135 @@ describe("useDesktopWorkerEnrollment", () => {
 
     harness.signIn("user-a");
     await waitFor(() => {
-      expect(harness.getToastCalls()).toEqual([
+      expect(harness.getErrorToastCalls()).toEqual([
         [
-          "Cloud integrations worker failed to start: worker exited: enrollment contract mismatch",
-          "error",
+          expect.objectContaining({
+            id: "desktop-worker-startup-failure",
+            headline: "Cloud integrations unavailable",
+            consequence:
+              "Proliferate will keep trying in the background. Retry now, or dismiss this notice.",
+            cause: "worker exited: enrollment contract mismatch",
+            retry: expect.any(Function),
+            onDismiss: expect.any(Function),
+          }),
         ],
       ]);
+    });
+    expect(harness.getToastCalls()).toEqual([]);
+  });
+
+  it("explains how to recover when an earlier worker owns the credentials", async () => {
+    workflowMocks.ensureDesktopWorker.mockImplementationOnce(async (
+      _organizationId,
+      _worker,
+      deps,
+    ) => {
+      deps.onFailure(
+        "Cannot replace worker credentials while a Proliferate Worker is still running.",
+      );
+      return false;
+    });
+    const harness = await loadEnrollmentHarness();
+
+    harness.signIn("user-a");
+    await waitFor(() => {
+      expect(harness.getErrorToastCalls()).toEqual([
+        [
+          expect.objectContaining({
+            headline: "Cloud integrations unavailable",
+            consequence:
+              "An earlier Proliferate Worker is still running. Quit other Proliferate apps; if none are open, restart your computer, then retry.",
+          }),
+        ],
+      ]);
+    });
+  });
+
+  it("keeps retrying without raising the same notification again", async () => {
+    vi.useFakeTimers();
+    try {
+      workflowMocks.ensureDesktopWorker.mockImplementation(async (
+        _organizationId,
+        _worker,
+        deps,
+      ) => {
+        deps.onFailure("worker is still unavailable");
+        return false;
+      });
+      const harness = await loadEnrollmentHarness();
+
+      await act(async () => {
+        harness.signIn("user-a");
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(workflowMocks.ensureDesktopWorker).toHaveBeenCalledTimes(1);
+      expect(harness.getErrorToastCalls()).toHaveLength(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20_000);
+      });
+      expect(workflowMocks.ensureDesktopWorker).toHaveBeenCalledTimes(2);
+      expect(harness.getErrorToastCalls()).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not resurface a dismissed failure during background retries", async () => {
+    vi.useFakeTimers();
+    try {
+      workflowMocks.ensureDesktopWorker.mockImplementation(async (
+        _organizationId,
+        _worker,
+        deps,
+      ) => {
+        deps.onFailure("worker is still unavailable");
+        return false;
+      });
+      const harness = await loadEnrollmentHarness();
+
+      await act(async () => {
+        harness.signIn("user-a");
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      const notice = harness.getErrorToastCalls()[0]?.[0] as {
+        onDismiss: () => void;
+      };
+      act(() => notice.onDismiss());
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20_000);
+      });
+      expect(workflowMocks.ensureDesktopWorker).toHaveBeenCalledTimes(2);
+      expect(harness.getErrorToastCalls()).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries immediately from the notification and clears it on recovery", async () => {
+    workflowMocks.ensureDesktopWorker
+      .mockImplementationOnce(async (_organizationId, _worker, deps) => {
+        deps.onFailure("worker is still unavailable");
+        return false;
+      })
+      .mockResolvedValueOnce(true);
+    const harness = await loadEnrollmentHarness();
+
+    harness.signIn("user-a");
+    await waitFor(() => {
+      expect(harness.getErrorToastCalls()).toHaveLength(1);
+    });
+    const notice = harness.getErrorToastCalls()[0]?.[0] as {
+      retry: () => void;
+    };
+    act(() => notice.retry());
+
+    await waitFor(() => {
+      expect(workflowMocks.ensureDesktopWorker).toHaveBeenCalledTimes(2);
+      expect(toastMocks.dismissToast).toHaveBeenCalledWith(
+        "desktop-worker-startup-failure",
+      );
     });
   });
 
@@ -318,6 +451,6 @@ describe("useDesktopWorkerEnrollment", () => {
       failOldEnrollment?.();
       await flushEffects();
     });
-    expect(harness.getToastCalls()).toEqual([]);
+    expect(harness.getErrorToastCalls()).toEqual([]);
   });
 });

--- a/apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.test.tsx
+++ b/apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.test.tsx
@@ -466,6 +466,52 @@ describe("useDesktopWorkerEnrollment", () => {
     }
   });
 
+  it("refreshes an active notification when a previously dismissed cause returns", async () => {
+    vi.useFakeTimers();
+    try {
+      workflowMocks.ensureDesktopWorker
+        .mockImplementationOnce(async (_organizationId, _worker, deps) => {
+          deps.onFailure("control plane unavailable");
+          return false;
+        })
+        .mockImplementationOnce(async (_organizationId, _worker, deps) => {
+          deps.onFailure("worker process exited");
+          return false;
+        })
+        .mockImplementationOnce(async (_organizationId, _worker, deps) => {
+          deps.onFailure("control plane unavailable");
+          return false;
+        });
+      const harness = await loadEnrollmentHarness();
+
+      await act(async () => {
+        harness.signIn("user-a");
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      const firstNotice = harness.getErrorToastCalls()[0]?.[0] as {
+        onDismiss: () => void;
+      };
+      act(() => firstNotice.onDismiss());
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20_000);
+      });
+      expect(harness.getErrorToastCalls()[1]?.[0]).toEqual(
+        expect.objectContaining({ cause: "worker process exited" }),
+      );
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20_000);
+      });
+      expect(harness.getErrorToastCalls()).toHaveLength(3);
+      expect(harness.getErrorToastCalls()[2]?.[0]).toEqual(
+        expect.objectContaining({ cause: "control plane unavailable" }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("retries immediately from the notification and clears it on recovery", async () => {
     workflowMocks.ensureDesktopWorker
       .mockImplementationOnce(async (_organizationId, _worker, deps) => {

--- a/apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.ts
+++ b/apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.ts
@@ -26,6 +26,7 @@ const DESKTOP_WORKER_FAILURE_TOAST_ID = "desktop-worker-startup-failure";
 interface EnrollmentFailureNotification {
   identityKey: string;
   kind: DesktopWorkerStartupFailureKind;
+  cause: string;
 }
 
 // Enrollment retries are intentionally process-wide, so notification state is
@@ -47,8 +48,11 @@ function sameFailure(
   failure: EnrollmentFailureNotification | null,
   identity: string,
   kind: DesktopWorkerStartupFailureKind,
+  cause: string,
 ): boolean {
-  return failure?.identityKey === identity && failure.kind === kind;
+  return failure?.identityKey === identity
+    && failure.kind === kind
+    && failure.cause === cause;
 }
 
 function clearFailureNotification(identity?: string): void {
@@ -144,14 +148,25 @@ export function useDesktopWorkerEnrollment(
         }
         const notice = desktopWorkerStartupFailureNotice(error);
         if (
-          sameFailure(activeFailureNotification, nextIdentityKey, notice.kind)
-          || sameFailure(dismissedFailureNotification, nextIdentityKey, notice.kind)
+          sameFailure(
+            activeFailureNotification,
+            nextIdentityKey,
+            notice.kind,
+            notice.cause,
+          )
+          || sameFailure(
+            dismissedFailureNotification,
+            nextIdentityKey,
+            notice.kind,
+            notice.cause,
+          )
         ) {
           return;
         }
         const notification = {
           identityKey: nextIdentityKey,
           kind: notice.kind,
+          cause: notice.cause,
         };
         activeFailureNotification = notification;
         showErrorToast({
@@ -165,7 +180,14 @@ export function useDesktopWorkerEnrollment(
             setRetryNonce((nonce) => nonce + 1);
           },
           onDismiss: () => {
-            if (sameFailure(activeFailureNotification, nextIdentityKey, notice.kind)) {
+            if (
+              sameFailure(
+                activeFailureNotification,
+                nextIdentityKey,
+                notice.kind,
+                notice.cause,
+              )
+            ) {
               activeFailureNotification = null;
               dismissedFailureNotification = notification;
             }

--- a/apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.ts
+++ b/apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.ts
@@ -1,7 +1,11 @@
 import { useEffect, useState } from "react";
 import type { DesktopWorkerBridge } from "@proliferate/product-client/host/desktop-bridge";
 import type { AuthState } from "@proliferate/product-client/host/product-host";
-import { desktopWorkerStartupFailureCopy } from "#product/copy/cloud/desktop-worker-copy";
+import { dismissToast } from "#product/primitives/utils/show-toast";
+import {
+  desktopWorkerStartupFailureNotice,
+  type DesktopWorkerStartupFailureKind,
+} from "#product/copy/cloud/desktop-worker-copy";
 import {
   ensureDesktopWorker,
   teardownDesktopWorker,
@@ -17,6 +21,19 @@ import { useProductTelemetry } from "#product/hooks/telemetry/facade/use-product
 // silently keeping the previous identity's credentials.
 let enrolledIdentityKey: string | null = null;
 
+const DESKTOP_WORKER_FAILURE_TOAST_ID = "desktop-worker-startup-failure";
+
+interface EnrollmentFailureNotification {
+  identityKey: string;
+  kind: DesktopWorkerStartupFailureKind;
+}
+
+// Enrollment retries are intentionally process-wide, so notification state is
+// process-wide too. Remounting the lifecycle root must not resurface a failure
+// the user dismissed or animate a replacement for the same failed condition.
+let activeFailureNotification: EnrollmentFailureNotification | null = null;
+let dismissedFailureNotification: EnrollmentFailureNotification | null = null;
+
 // Delay before retrying a failed enrollment. Long enough not to hammer an
 // unreachable control plane, short enough that integrations recover without
 // a restart.
@@ -24,6 +41,42 @@ const ENROLLMENT_RETRY_DELAY_MS = 15_000;
 
 function identityKey(userId: string, organizationId: string | null): string {
   return `${userId}::${organizationId ?? ""}`;
+}
+
+function sameFailure(
+  failure: EnrollmentFailureNotification | null,
+  identity: string,
+  kind: DesktopWorkerStartupFailureKind,
+): boolean {
+  return failure?.identityKey === identity && failure.kind === kind;
+}
+
+function clearFailureNotification(identity?: string): void {
+  const activeMatches =
+    activeFailureNotification !== null
+    && (identity === undefined || activeFailureNotification.identityKey === identity);
+  const dismissedMatches =
+    dismissedFailureNotification !== null
+    && (identity === undefined || dismissedFailureNotification.identityKey === identity);
+
+  if (activeMatches) {
+    activeFailureNotification = null;
+    dismissToast(DESKTOP_WORKER_FAILURE_TOAST_ID);
+  }
+  if (dismissedMatches) {
+    dismissedFailureNotification = null;
+  }
+}
+
+function clearFailureNotificationForOtherIdentity(identity: string): void {
+  if (
+    (activeFailureNotification !== null
+      && activeFailureNotification.identityKey !== identity)
+    || (dismissedFailureNotification !== null
+      && dismissedFailureNotification.identityKey !== identity)
+  ) {
+    clearFailureNotification();
+  }
 }
 
 // Enrollment guard transitions:
@@ -54,7 +107,7 @@ export function useDesktopWorkerEnrollment(
   const activeOrganizationId = useOrganizationStore(
     (state) => state.activeOrganizationId,
   );
-  const showToast = useToastStore((state) => state.show);
+  const showErrorToast = useToastStore((state) => state.showError);
   const { captureException } = useProductTelemetry();
   const [retryNonce, setRetryNonce] = useState(0);
   useEffect(() => {
@@ -62,6 +115,7 @@ export function useDesktopWorkerEnrollment(
       return;
     }
     if (authStatus !== "authenticated" || !authUserId) {
+      clearFailureNotification();
       // Signed out: stop the worker and clear the guard so the next login
       // (any user) re-enrolls with a fresh identity.
       if (enrolledIdentityKey !== null) {
@@ -71,6 +125,7 @@ export function useDesktopWorkerEnrollment(
       return;
     }
     const nextIdentityKey = identityKey(authUserId, activeOrganizationId);
+    clearFailureNotificationForOtherIdentity(nextIdentityKey);
     if (enrolledIdentityKey === nextIdentityKey) {
       return;
     }
@@ -87,11 +142,43 @@ export function useDesktopWorkerEnrollment(
         if (cancelled || enrolledIdentityKey !== nextIdentityKey) {
           return;
         }
-        showToast(desktopWorkerStartupFailureCopy(error), "error");
+        const notice = desktopWorkerStartupFailureNotice(error);
+        if (
+          sameFailure(activeFailureNotification, nextIdentityKey, notice.kind)
+          || sameFailure(dismissedFailureNotification, nextIdentityKey, notice.kind)
+        ) {
+          return;
+        }
+        const notification = {
+          identityKey: nextIdentityKey,
+          kind: notice.kind,
+        };
+        activeFailureNotification = notification;
+        showErrorToast({
+          id: DESKTOP_WORKER_FAILURE_TOAST_ID,
+          headline: notice.headline,
+          consequence: notice.consequence,
+          cause: notice.cause,
+          retry: () => {
+            dismissedFailureNotification = null;
+            enrolledIdentityKey = null;
+            setRetryNonce((nonce) => nonce + 1);
+          },
+          onDismiss: () => {
+            if (sameFailure(activeFailureNotification, nextIdentityKey, notice.kind)) {
+              activeFailureNotification = null;
+              dismissedFailureNotification = notification;
+            }
+          },
+        });
       },
       captureException,
     }).then((enrolled) => {
-      if (enrolled || enrolledIdentityKey !== nextIdentityKey) {
+      if (enrolled) {
+        clearFailureNotification(nextIdentityKey);
+        return;
+      }
+      if (enrolledIdentityKey !== nextIdentityKey) {
         return;
       }
       // Enrollment failed (e.g. a network blip right after an org switch's
@@ -111,5 +198,5 @@ export function useDesktopWorkerEnrollment(
         window.clearTimeout(retryTimer);
       }
     };
-  }, [authStatus, authUserId, activeOrganizationId, retryNonce, showToast, worker, captureException]);
+  }, [authStatus, authUserId, activeOrganizationId, retryNonce, showErrorToast, worker, captureException]);
 }

--- a/apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.ts
+++ b/apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.ts
@@ -168,6 +168,7 @@ export function useDesktopWorkerEnrollment(
           kind: notice.kind,
           cause: notice.cause,
         };
+        dismissedFailureNotification = null;
         activeFailureNotification = notification;
         showErrorToast({
           id: DESKTOP_WORKER_FAILURE_TOAST_ID,


### PR DESCRIPTION
## Summary

- replace repeated auto-dismissing worker startup errors with one persistent, actionable notification per failure incident
- refresh or resurface the stable notification when a retry fails for a different underlying cause
- explain the stale-worker credential lock in user-facing language while keeping the native error behind Details
- preserve background enrollment retries, remember dismissal, and clear the notification on recovery or identity changes

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] No support relationship applies. No tracker, report, user, support ID, or private source data appears in this PR.

## Verification

- `pnpm --filter @proliferate/product-client build` (Node 22)
- `pnpm --filter @proliferate/product-client typecheck` (Node 22)
- `(cd apps/packages/product-client && pnpm exec vitest run src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.test.tsx --maxWorkers=1)` (18 tests)
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_design_attribution.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`
