### PR TITLE
fix(product): send list prompts with Return

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.test.tsx
@@ -87,29 +87,45 @@ describe("ComposerRichTextEditor", () => {
     expect(harness.root.querySelector("ul li")).toBeTruthy();
   });
 
-  it("keeps list Enter and indentation Lexical-owned", async () => {
+  it("submits numbered-list drafts on Enter and inserts a newline on Shift-Enter", async () => {
     const onSubmit = vi.fn();
     const harness = renderEditor({ onSubmit });
     await harness.ready();
     act(() => resetText(harness.editor, ""));
-    await typeCharacters(harness.editor, "- one");
+    await typeCharacters(harness.editor, "1. one");
+
+    expect(harness.root.querySelectorAll("ol li")).toHaveLength(1);
+    act(() => {
+      harness.editor.dispatchCommand(KEY_ENTER_COMMAND, keyEvent("Enter", { shiftKey: true }));
+    });
+    await waitFor(() => expect(harness.root.querySelector("ol li br")).toBeTruthy());
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    const enter = keyEvent("Enter", { cancelable: true });
+    act(() => {
+      harness.editor.dispatchCommand(KEY_ENTER_COMMAND, enter);
+    });
+    expect(enter.defaultPrevented).toBe(true);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(harness.root.querySelectorAll("ol li")).toHaveLength(1);
+  });
+
+  it("keeps list indentation Lexical-owned", async () => {
+    const harness = renderEditor();
+    await harness.ready();
+    act(() => resetText(harness.editor, ""));
+    act(() => { fireEvent(harness.root, pasteEvent("- one\n- two")); });
+    await waitFor(() => expect(harness.root.querySelectorAll("li")).toHaveLength(2));
 
     act(() => {
-      harness.editor.dispatchCommand(KEY_ENTER_COMMAND, keyEvent("Enter"));
-      insertText(harness.editor, "two");
       harness.editor.dispatchCommand(KEY_TAB_COMMAND, keyEvent("Tab"));
     });
-    await waitFor(() => expect(harness.root.querySelectorAll("li")).toHaveLength(2));
-    expect(onSubmit).not.toHaveBeenCalled();
-    expect(harness.root.querySelector("ul ul")).toBeTruthy();
+    await waitFor(() => expect(harness.root.querySelector("ul ul")).toBeTruthy());
 
     act(() => {
       harness.editor.dispatchCommand(KEY_TAB_COMMAND, keyEvent("Tab", { shiftKey: true }));
-      harness.editor.dispatchCommand(KEY_ENTER_COMMAND, keyEvent("Enter"));
-      harness.editor.dispatchCommand(KEY_ENTER_COMMAND, keyEvent("Enter"));
     });
-    await waitFor(() => expect(harness.root.querySelector("ul + p")).toBeTruthy());
-    expect(onSubmit).not.toHaveBeenCalled();
+    await waitFor(() => expect(harness.root.querySelector("ul ul")).toBeNull());
   });
 
   it("creates bare and selected HTTPS links", async () => {

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
@@ -293,10 +293,8 @@ function ComposerBehaviorPlugin({
     const unregisterEnter = editor.registerCommand(KEY_ENTER_COMMAND, (event) => {
       if (!event || event.defaultPrevented || event.isComposing) return false;
       if (onCommandKey?.(event)) return true;
-      const inList = selectionIsInList();
       const plainEnter = !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey;
       const primaryEnter = !event.shiftKey && !event.altKey && (event.metaKey || event.ctrlKey);
-      if (plainEnter && inList) return false;
       if (!plainEnter && !primaryEnter) return false;
       event.preventDefault();
       if (!event.repeat && canSubmit) onSubmit();

--- a/specs/codebase/systems/product/chat/composer.md
+++ b/specs/codebase/systems/product/chat/composer.md
@@ -86,16 +86,16 @@ external draft replacements discard the snapshot.
 
 The live editor recognizes `*`/`_` emphasis, `**`/`__` strong emphasis, and
 line-leading unordered and ordered list shortcuts. Cmd/Ctrl-B and Cmd/Ctrl-I
-toggle marks through the rich-text command layer. Enter continues or exits a
-list and Tab/Shift-Tab indent or outdent only when the selection is inside a
-list item. Outside lists, every composer surface — workspace, Home, and queued
-edits — submits on plain Enter or Cmd/Ctrl-Enter, and Shift-Enter inserts a
-newline. Queued edits use the workspace editor's minimum height, row cap, and
-overflow scrolling.
+toggle marks through the rich-text command layer. Tab/Shift-Tab indent or
+outdent only when the selection is inside a list item. Every composer surface —
+workspace, Home, and queued edits — submits on plain Enter or Cmd/Ctrl-Enter,
+including from a list item, and Shift-Enter inserts a newline without
+submitting. Queued edits use the workspace editor's minimum height, row cap,
+and overflow scrolling.
 
 Lexical's high-priority Enter and Tab commands own this decision before native
-editor mutation. A list selection stays Lexical-owned; otherwise the surface
-applies the shared submit contract exactly once. The
+editor mutation. The surface applies the shared submit contract exactly once;
+Shift-Enter and list indentation stay Lexical-owned. The
 same native `beforeinput`, `keydown`, or `paste` event timestamp is forwarded to
 typing measurement when that event changes the document.
 


### PR DESCRIPTION
## Summary

- Make plain Return submit a chat draft even when the caret is inside an ordered or unordered list.
- Keep Shift+Return as the newline gesture and preserve Tab/Shift+Tab list indentation.
- Replace the old list-Enter behavior assertion with numbered-list regression coverage and update the canonical composer contract.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] No support relationship or private source data is included.
- [x] The interaction is described in Proliferate vocabulary.

## Verification

- `pnpm --filter @proliferate/product-client exec vitest run src/components/workspace/chat/input/ComposerRichTextEditor.test.tsx src/components/workspace/chat/input/ComposerCommandEditor.test.tsx` - 35 tests passed.
- `pnpm --filter @proliferate/product-client typecheck` - passed.
- `pnpm --filter @proliferate/product-client build` - passed.
- Full product-client suite - 792 of 793 test files passed (5,289 tests); the remaining browser-only file requires a local Google Chrome installation unavailable on this machine.
- `python3 scripts/check_docs.py` - passed for 213 Markdown files.
- `python3 scripts/check_max_lines.py` - passed.
- `python3 scripts/report_frontend_structure.py --strict` - passed with zero violations.
- `python3 scripts/check_frontend_boundaries.py` - passed.
- `python3 scripts/check_design_attribution.py` - passed.
- `python3 scripts/check_appearance_scaling.py` - passed.
- `git diff --check` - passed.
