### PR TITLE
perf(product): keep right-panel separator drags smooth over heavy previews

### DIFF
--- a/apps/packages/design/src/css/product.css
+++ b/apps/packages/design/src/css/product.css
@@ -777,6 +777,20 @@ mark.content-find-active {
   contain-intrinsic-size: auto var(--diffs-line-height);
 }
 
+/*
+ * Block-level virtualization for the file viewer's rendered-document preview.
+ * A large Markdown file re-wraps every block whenever the pane width changes —
+ * which during a separator drag is every frame — so top-level blocks outside
+ * the scrollport skip layout and paint instead, and a resize (or scroll) only
+ * pays for the visible slice. `auto` in contain-intrinsic-size remembers each
+ * block's real rendered height after first paint; the fallback approximates
+ * one prose line for blocks that have never rendered.
+ */
+.file-preview-virtualized > * {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 24px;
+}
+
 .composer-diff-simple-line {
   --diff-view-surface: var(--color-diff-main-surface);
   --diff-view-header-surface: var(--diff-view-surface);

--- a/apps/packages/product-client/src/app/authenticated-workspace-shell-motion.test.ts
+++ b/apps/packages/product-client/src/app/authenticated-workspace-shell-motion.test.ts
@@ -14,6 +14,8 @@ describe("authenticated workspace shell motion", () => {
     expect(stylesheet).toContain("var(--duration-panel)");
     expect(stylesheet).toContain("var(--ease-out-cubic)");
     expect(stylesheet).toContain("[data-snap-left-geometry=\"true\"]");
+    expect(stylesheet).toContain("[data-snap-right-geometry=\"true\"]");
+    expect(stylesheet).toContain("--workspace-right-geometry-duration: 0ms");
     expect(stylesheet).toContain("[data-manual-workspace-geometry=\"true\"]");
   });
 });

--- a/apps/packages/product-client/src/app/authenticated.css
+++ b/apps/packages/product-client/src/app/authenticated.css
@@ -15,13 +15,22 @@
 
 .standard-workspace-shell {
   --workspace-left-geometry-duration: var(--duration-panel);
+  --workspace-right-geometry-duration: var(--duration-panel);
   transition-property: --workspace-left-width, --workspace-right-width;
-  transition-duration: var(--workspace-left-geometry-duration), var(--duration-panel);
+  transition-duration: var(--workspace-left-geometry-duration), var(--workspace-right-geometry-duration);
   transition-timing-function: var(--ease-out-cubic), var(--ease-out-cubic);
 }
 
 .standard-workspace-shell[data-snap-left-geometry="true"] {
   --workspace-left-geometry-duration: 0ms;
+}
+
+/* A live separator drag drives the right width from the pointer: easing it
+   would trail the cursor by the panel duration and keep both panes re-laying
+   out long after each move. Open/close keeps the eased transition — including
+   the collapse a drag past the threshold triggers, which clears this flag. */
+.standard-workspace-shell[data-snap-right-geometry="true"] {
+  --workspace-right-geometry-duration: 0ms;
 }
 
 .standard-workspace-shell[data-manual-workspace-geometry="true"] {

--- a/apps/packages/product-client/src/components/workspace/files/FileViewerContent.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/FileViewerContent.test.tsx
@@ -1,0 +1,39 @@
+/* @vitest-environment jsdom */
+
+import type { ReadWorkspaceFileResponse } from "@anyharness/sdk";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { FileViewerContent } from "#product/components/workspace/files/FileViewerContent";
+
+afterEach(() => {
+  cleanup();
+});
+
+const MARKDOWN_READ: ReadWorkspaceFileResponse = {
+  content: "# Title\n\nBody paragraph.",
+  isText: true,
+  kind: "file",
+  path: "README.md",
+  sizeBytes: 24,
+  tooLarge: false,
+};
+
+describe("FileViewerContent rendered preview", () => {
+  it("virtualizes the rendered Markdown body so large documents stay cheap to re-lay out", () => {
+    const { container } = render(
+      <FileViewerContent
+        filePath="README.md"
+        workspaceId="workspace-1"
+        effectiveMode="rendered"
+        read={MARKDOWN_READ}
+        activeDiffTarget={null}
+        diffLayout="unified"
+        canShowRichPreview
+        wordWrap={false}
+      />,
+    );
+
+    const body = container.querySelector("[data-markdown-body]");
+    expect(body?.className).toContain("file-preview-virtualized");
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/files/FileViewerContent.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/FileViewerContent.tsx
@@ -82,10 +82,12 @@ function RichPreview({
     // The reference viewer keeps the rendered-markdown gutter tight —
     // document padding, not page margins. The first block's own top margin
     // (e.g. h1 mt-5) would double the top gap, so strip it.
+    // file-preview-virtualized: off-scrollport blocks skip layout/paint, so a
+    // huge rendered document stays cheap to re-wrap while the panel resizes.
     <div className="file-source-scroll h-full min-h-0 min-w-0 overflow-auto bg-background px-4 py-4">
       <MarkdownBody
         content={content}
-        className="[&>*:first-child]:mt-0"
+        className="file-preview-virtualized [&>*:first-child]:mt-0"
         renderCodeBlock={renderDesktopCodeBlock}
         // This body is the file's own bytes, not conversation content. The
         // surface flag keeps message-only reading affordances (the inline-code

--- a/apps/packages/product-client/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
@@ -87,6 +87,7 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
     rightPanelOpen,
     rightPanelState,
     rightPanelWidth,
+    rightPanelResizing,
     rightPanelFocusRequestToken,
     terminalActivationRequest,
     publishDialog,
@@ -101,6 +102,7 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
     rightWidth: hasWorkspaceShell && !hasLaunchIntentOnlyShell && rightPanelOpen
       ? rightPanelWidth
       : 0,
+    snapRight: rightPanelResizing,
     onToggleLeft: actions.onToggleSidebar,
   });
   const chromeClasses = useMemo(
@@ -232,6 +234,7 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
                 "--workspace-left-header-dwell": hasMacWindowControls ? "122px" : "40px",
               } as CSSProperties}
               data-snap-left-geometry={workspaceGeometry.snapLeft ? "true" : "false"}
+              data-snap-right-geometry={rightPanelResizing ? "true" : "false"}
               data-manual-workspace-geometry={
                 workspaceGeometry.usesManualInterpolation ? "true" : "false"
               }

--- a/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.test.ts
+++ b/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
  * a live drag into it — the collapse latch and the reset-on-new-drag are
  * behavior of the hook's glue code, not of that pure function.
  */
-function fireDrag(onMouseDown: (event: ReactMouseEvent) => void, deltas: number[]) {
+function beginDrag(onMouseDown: (event: ReactMouseEvent) => void) {
   const preventDefault = () => {};
   const stopPropagation = () => {};
   act(() => {
@@ -40,17 +40,29 @@ function fireDrag(onMouseDown: (event: ReactMouseEvent) => void, deltas: number[
       { clientX: 0, preventDefault, stopPropagation } as unknown as ReactMouseEvent,
     );
   });
-  for (const delta of deltas) {
-    act(() => {
-      // Reverse direction (right panel is anchored to the right edge): a
-      // positive delta here is the same "drag left to widen" motion
-      // `handleRightPanelDrag`'s `reverse: true` expects.
-      document.dispatchEvent(new MouseEvent("mousemove", { clientX: -delta }));
-    });
-  }
+}
+
+function moveDrag(delta: number) {
+  act(() => {
+    // Reverse direction (right panel is anchored to the right edge): a
+    // positive delta here is the same "drag left to widen" motion
+    // `handleRightPanelDrag`'s `reverse: true` expects.
+    document.dispatchEvent(new MouseEvent("mousemove", { clientX: -delta }));
+  });
+}
+
+function releaseDrag() {
   act(() => {
     document.dispatchEvent(new MouseEvent("mouseup"));
   });
+}
+
+function fireDrag(onMouseDown: (event: ReactMouseEvent) => void, deltas: number[]) {
+  beginDrag(onMouseDown);
+  for (const delta of deltas) {
+    moveDrag(delta);
+  }
+  releaseDrag();
 }
 
 function renderRightPanel() {
@@ -135,5 +147,62 @@ describe("useMainScreenRightPanel drag wiring", () => {
     rerender();
 
     expect(result.current.rightPanelOpen).toBe(true);
+  });
+
+  it("commits the durable width once on release, not on every mousemove", () => {
+    const { result, rerender } = renderRightPanel();
+    act(() => {
+      result.current.setRightPanelOpen(true);
+    });
+    rerender();
+    const startWidth = result.current.rightPanelWidth;
+
+    beginDrag(result.current.onRightSeparatorDown);
+    moveDrag(40);
+    rerender();
+
+    // Mid-gesture: the rendered width tracks the pointer and the drag is
+    // flagged, but the durable store still holds the pre-drag width — the
+    // persistence subscriber must not run per mousemove.
+    expect(result.current.rightPanelResizing).toBe(true);
+    expect(result.current.rightPanelWidth).toBe(startWidth + 40);
+    expect(
+      useWorkspaceUiStore.getState().rightPanelDurableByWorkspace[WORKSPACE_ID]?.width,
+    ).toBe(startWidth);
+
+    releaseDrag();
+    rerender();
+
+    expect(result.current.rightPanelResizing).toBe(false);
+    expect(
+      useWorkspaceUiStore.getState().rightPanelDurableByWorkspace[WORKSPACE_ID]?.width,
+    ).toBe(startWidth + 40);
+  });
+
+  it("ends the resize at the collapse itself and commits no width for a collapse-only gesture", () => {
+    const { result, rerender } = renderRightPanel();
+    act(() => {
+      result.current.setRightPanelOpen(true);
+    });
+    rerender();
+    const startWidth = result.current.rightPanelWidth;
+    const collapseDelta = -(RIGHT_PANEL_MIN_WIDTH - RIGHT_PANEL_COLLAPSE_DRAG_THRESHOLD + 50);
+
+    beginDrag(result.current.onRightSeparatorDown);
+    moveDrag(collapseDelta);
+    rerender();
+
+    // Resizing ends at the collapse, before the mouse is released, so the
+    // close gets its eased geometry back instead of snapping shut.
+    expect(result.current.rightPanelOpen).toBe(false);
+    expect(result.current.rightPanelResizing).toBe(false);
+
+    releaseDrag();
+    rerender();
+
+    // Reopening restores the width from before the drag.
+    expect(
+      useWorkspaceUiStore.getState().rightPanelDurableByWorkspace[WORKSPACE_ID]?.width,
+    ).toBe(startWidth);
   });
 });

--- a/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.ts
+++ b/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.ts
@@ -31,6 +31,8 @@ export interface MainScreenRightPanelState {
   setRightPanelOpen: Dispatch<SetStateAction<boolean>>;
   rightPanelWidth: number;
   setRightPanelWidth: Dispatch<SetStateAction<number>>;
+  /** True while a separator drag is actively resizing the panel. */
+  rightPanelResizing: boolean;
   rightPanelFocusRequestToken: number;
   requestRightPanelFocus: () => void;
   onRightSeparatorDown: (event: MouseEvent) => void;
@@ -74,6 +76,9 @@ export function useMainScreenRightPanel({
   );
   const setRightPanelMaterializedForWorkspace = useWorkspaceUiStore(
     (state) => state.setRightPanelMaterializedForWorkspace,
+  );
+  const setRightPanelWidthForWorkspace = useWorkspaceUiStore(
+    (state) => state.setRightPanelWidthForWorkspace,
   );
   const rightPanelDurableFallback = useMemo(
     () => resolveWithWorkspaceFallback(
@@ -206,28 +211,52 @@ export function useMainScreenRightPanel({
   // this". Collapse ends the gesture: once closed, the remainder of the same
   // drag is ignored so a jittery pointer cannot re-expand the panel from under
   // the user's cursor.
+  //
+  // While the drag is live the width is session state only: writing the
+  // durable store on every mousemove would re-serialize the whole persisted
+  // workspace-ui slice per event (see the persistence subscriber in
+  // `use-workspace-ui-lifecycle`). The gesture is one width choice, so it
+  // commits once, on release. `rightPanelResizing` is exported so the shell
+  // can drop the geometry easing while the width is pointer-driven.
   const rightPanelDragCollapsedRef = useRef(false);
+  const rightPanelDragWidthRef = useRef<number | null>(null);
+  const [rightPanelResizing, setRightPanelResizing] = useState(false);
   const handleRightPanelDrag = useCallback(
     (rawWidth: number) => {
-      if (rightPanelDragCollapsedRef.current) {
+      if (rightPanelDragCollapsedRef.current || !workspaceUiKey) {
         return;
       }
       const outcome = resolveRightPanelDragOutcome(rawWidth);
       if (outcome.kind === "collapse") {
         rightPanelDragCollapsedRef.current = true;
-        // The last credible width stays persisted, so reopening restores the
-        // size the user had chosen rather than the panel's default.
+        // Resizing ends here so the collapse itself animates: the last
+        // credible width stays persisted, and reopening restores the size the
+        // user had chosen rather than the panel's default.
+        setRightPanelResizing(false);
         setRightPanelOpen(false);
         return;
       }
-      setRightPanelWidth(outcome.width);
+      rightPanelDragWidthRef.current = outcome.width;
+      setRightPanelSessionDurableState({
+        ...rightPanelDurableState,
+        width: outcome.width,
+      });
     },
-    [setRightPanelOpen, setRightPanelWidth],
+    [rightPanelDurableState, setRightPanelOpen, workspaceUiKey],
   );
+  const handleRightSeparatorDragEnd = useCallback(() => {
+    setRightPanelResizing(false);
+    const draggedWidth = rightPanelDragWidthRef.current;
+    rightPanelDragWidthRef.current = null;
+    if (draggedWidth !== null && workspaceUiKey) {
+      setRightPanelWidthForWorkspace(workspaceUiKey, draggedWidth);
+    }
+  }, [setRightPanelWidthForWorkspace, workspaceUiKey]);
   const beginRightSeparatorDrag = useResize({
     direction: "horizontal",
     size: rightPanelWidth,
     onResize: handleRightPanelDrag,
+    onResizeEnd: handleRightSeparatorDragEnd,
     reverse: true,
     min: 0,
     max: RIGHT_PANEL_MAX_WIDTH,
@@ -235,6 +264,8 @@ export function useMainScreenRightPanel({
   const onRightSeparatorDown = useCallback(
     (event: MouseEvent) => {
       rightPanelDragCollapsedRef.current = false;
+      rightPanelDragWidthRef.current = null;
+      setRightPanelResizing(true);
       beginRightSeparatorDrag(event);
     },
     [beginRightSeparatorDrag],
@@ -269,6 +300,7 @@ export function useMainScreenRightPanel({
     setRightPanelOpen,
     rightPanelWidth,
     setRightPanelWidth,
+    rightPanelResizing,
     rightPanelFocusRequestToken,
     requestRightPanelFocus,
     onRightSeparatorDown,

--- a/apps/packages/product-client/src/hooks/main/workflows/use-main-screen-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/main/workflows/use-main-screen-actions.test.tsx
@@ -263,6 +263,7 @@ function mainScreenLayout(overrides: Partial<MainScreenLayoutState> = {}): {
       setCommandPaletteOpen: vi.fn(),
       rightPanelWidth: 420,
       setRightPanelWidth: vi.fn(),
+      rightPanelResizing: false,
       onLeftSeparatorDown: vi.fn(),
       onRightSeparatorDown: vi.fn(),
       ...overrides,

--- a/apps/packages/product-client/src/hooks/ui/layout/use-resize.test.ts
+++ b/apps/packages/product-client/src/hooks/ui/layout/use-resize.test.ts
@@ -105,4 +105,41 @@ describe("useResize", () => {
     expect(() => unmount()).not.toThrow();
     expect(overlayDivs()).toHaveLength(0);
   });
+
+  it("fires onResizeEnd exactly once, at mouseup, and never for stray mouseups after it", () => {
+    const onResizeEnd = vi.fn();
+    const { result } = renderHook(() =>
+      useResize({ direction: "horizontal", size: 200, onResize: vi.fn(), onResizeEnd }));
+
+    act(() => {
+      result.current(mouseDownEvent(0));
+    });
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mousemove", { clientX: 30 }));
+    });
+    expect(onResizeEnd).not.toHaveBeenCalled();
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mouseup"));
+    });
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mouseup"));
+    });
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onResizeEnd when the owner unmounts mid-drag, so the gesture's outcome is not lost", () => {
+    const onResizeEnd = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useResize({ direction: "horizontal", size: 200, onResize: vi.fn(), onResizeEnd }));
+
+    act(() => {
+      result.current(mouseDownEvent(0));
+    });
+    unmount();
+
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/packages/product-client/src/hooks/ui/layout/use-resize.ts
+++ b/apps/packages/product-client/src/hooks/ui/layout/use-resize.ts
@@ -7,6 +7,12 @@ interface UseResizeOptions {
   size: number;
   /** Called on every mouse move with the proposed new size in px */
   onResize: (size: number) => void;
+  /**
+   * Called once when the gesture ends — the mouseup, or the owner unmounting
+   * mid-drag. Lets a consumer treat the drag as one gesture (e.g. persist the
+   * final size once) instead of reacting to every intermediate move.
+   */
+  onResizeEnd?: () => void;
   /** If true, dragging right/down shrinks (for panels anchored to right/bottom edge) */
   reverse?: boolean;
   min?: number;
@@ -21,6 +27,7 @@ export function useResize({
   direction,
   size,
   onResize,
+  onResizeEnd,
   reverse = false,
   min = 0,
   max = Infinity,
@@ -61,19 +68,22 @@ export function useResize({
         document.removeEventListener("mousemove", handleMouseMove);
         document.removeEventListener("mouseup", handleMouseUp);
         activeDragCleanupRef.current = null;
+        onResizeEnd?.();
       };
 
       document.addEventListener("mousemove", handleMouseMove);
       document.addEventListener("mouseup", handleMouseUp);
       activeDragCleanupRef.current = handleMouseUp;
     },
-    [direction, size, onResize, reverse, min, max],
+    [direction, size, onResize, onResizeEnd, reverse, min, max],
   );
 
   // Mirrors handleMouseUp's teardown without firing onResize or removing the
   // listeners twice: a normal mouseup already nulls the ref before this could
   // ever run for that gesture, so this only fires for the unmount-mid-drag
-  // case handleMouseUp was never going to see.
+  // case handleMouseUp was never going to see. Ending via unmount still fires
+  // onResizeEnd — the gesture is over either way, and a consumer persisting
+  // the final size must not lose it just because the surface went away.
   useEffect(() => () => {
     activeDragCleanupRef.current?.();
   }, []);

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-shell-geometry.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-shell-geometry.test.tsx
@@ -21,13 +21,15 @@ function stubReducedMotion(matches: boolean): void {
 function GeometryHarness({
   leftWidth,
   rightWidth,
+  snapRight = false,
   onToggleLeft = () => {},
 }: {
   leftWidth: number;
   rightWidth: number;
+  snapRight?: boolean;
   onToggleLeft?: () => void;
 }) {
-  const geometry = useWorkspaceShellGeometry({ leftWidth, rightWidth, onToggleLeft });
+  const geometry = useWorkspaceShellGeometry({ leftWidth, rightWidth, snapRight, onToggleLeft });
   return (
     <>
       <div
@@ -105,6 +107,36 @@ describe("useWorkspaceShellGeometry", () => {
     expect(root.style.getPropertyValue("--workspace-left-width")).toBe("280px");
     expect(root.style.getPropertyValue("--workspace-right-width")).toBe("360px");
     expect(requestFrame).not.toHaveBeenCalled();
+  });
+
+  it("applies pointer-driven right widths immediately on manual renderers", () => {
+    vi.stubGlobal("CSS", {});
+    stubReducedMotion(false);
+    const frames: FrameRequestCallback[] = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+    const { getByTestId, rerender } = render(
+      <GeometryHarness leftWidth={0} rightWidth={360} />,
+    );
+
+    // A drag move with only the right width changing never schedules a tween.
+    rerender(<GeometryHarness leftWidth={0} rightWidth={480} snapRight />);
+    const root = getByTestId("geometry");
+    expect(frames).toHaveLength(0);
+    expect(root.style.getPropertyValue("--workspace-right-width")).toBe("480px");
+
+    // A simultaneous left change still eases while the right lands directly.
+    rerender(<GeometryHarness leftWidth={280} rightWidth={500} snapRight />);
+    expect(root.style.getPropertyValue("--workspace-right-width")).toBe("500px");
+    expect(root.style.getPropertyValue("--workspace-left-width")).toBe("0px");
+
+    act(() => frames.shift()?.(0));
+    act(() => frames.shift()?.(motion.duration.panelMs));
+    expect(root.style.getPropertyValue("--workspace-left-width")).toBe("280px");
+    expect(root.style.getPropertyValue("--workspace-right-width")).toBe("500px");
   });
 
   it("clears a pending pin snap before a rapid ordinary toggle", () => {

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-shell-geometry.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-shell-geometry.ts
@@ -18,6 +18,13 @@ interface WorkspaceShellWidths {
 interface UseWorkspaceShellGeometryOptions {
   leftWidth: number;
   rightWidth: number;
+  /**
+   * Held true while the right separator drag is live. A pointer-driven width
+   * must land exactly where the cursor is on every frame — easing it would
+   * rubber-band the panel edge behind the pointer and keep re-laying the
+   * panes out for the full panel duration after each move.
+   */
+  snapRight?: boolean;
   onToggleLeft: () => void;
 }
 
@@ -43,6 +50,7 @@ function easeOutCubic(progress: number): number {
 export function useWorkspaceShellGeometry({
   leftWidth,
   rightWidth,
+  snapRight = false,
   onToggleLeft,
 }: UseWorkspaceShellGeometryOptions): WorkspaceShellGeometry {
   const rootRef = useRef<HTMLDivElement>(null);
@@ -103,14 +111,17 @@ export function useWorkspaceShellGeometry({
     };
 
     const animateLeft = !snapLeft && from.left !== target.left;
-    const animateRight = from.right !== target.right;
+    const animateRight = !snapRight && from.right !== target.right;
     if (reducedMotion || (!animateLeft && !animateRight)) {
       setWidths(target);
       return;
     }
 
-    if (snapLeft) {
-      setWidths({ left: target.left, right: from.right });
+    if (snapLeft || snapRight) {
+      setWidths({
+        left: snapLeft ? target.left : from.left,
+        right: snapRight ? target.right : from.right,
+      });
     }
 
     let startedAt: number | null = null;
@@ -132,7 +143,7 @@ export function useWorkspaceShellGeometry({
     };
 
     frameRef.current = window.requestAnimationFrame(tick);
-  }, [leftWidth, reducedMotion, rightWidth, snapLeft, usesManualInterpolation]);
+  }, [leftWidth, reducedMotion, rightWidth, snapLeft, snapRight, usesManualInterpolation]);
 
   useEffect(() => () => {
     if (frameRef.current !== null) {


### PR DESCRIPTION
## Summary

Dragging the vertical separator between the chat pane and the right panel was visibly heavy when the panel showed a large rendered Markdown file. Three per-mousemove costs stacked, and each is removed at its source:

- **The geometry easing fought the pointer.** The shell transitions the registered `--workspace-right-width` custom property (and manually tweens it on engines without `CSS.registerProperty`) over the panel duration, so every mousemove retargeted a 240ms ease: the panel edge trailed the cursor, and both panes kept re-laying out long after each move and after release. A live drag now sets `data-snap-right-geometry` (mirroring the existing left-side snap) which zeroes the right geometry duration, and the geometry hook's new `snapRight` input skips the manual tween the same way. Open/close keeps the eased motion — including a drag-past-threshold collapse, which ends the resize state at the moment it closes.
- **Every mousemove wrote the durable store.** `setRightPanelWidth` persisted each intermediate width, and the workspace-ui persistence subscriber re-serializes the whole persisted slice per write (twice, for comparison) before the storage write. The drag now keeps width in session state and commits the durable width once, when the gesture ends — via a new `onResizeEnd` callback on `useResize`, which also fires if the owner unmounts mid-drag so the chosen width is not lost.
- **The rendered preview re-wrapped the entire document per width change.** The file viewer's rendered Markdown had no virtualization, unlike the diff viewers (`.thread-diff-virtualized`, `[data-diff-row-virtualization]`). Its top-level blocks now use the same `content-visibility: auto` + `contain-intrinsic-size: auto` pattern, so a resize (or scroll) only lays out the blocks in the scrollport.

The chat side of the shell is already row-virtualized, so the un-virtualized document preview was the outlier that made wide files feel heavy.

Follow-up recorded rather than expanded here: the Cowork workspace shell keeps its own width-transitioned panes with the same drag pattern; it is under active rework, so it is left untouched.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

Measured (Playwright chromium + webkit — webkit being the engine family the desktop WKWebView runs — against a 3,500-block document at the panel's real 380-700px drag range, using the exact shipped CSS):

- Layout cost per drag step, full document vs `.file-preview-virtualized`: webkit **15.7ms -> 3.6ms** mean (p95 18ms -> 4ms); chromium **9.9ms -> 1.2ms**. The baseline exceeds a 60fps frame budget on webkit by itself; the virtualized cost fits comfortably.
- Pointer tracking, 240ms retargeted ease (pre-fix) vs 0ms (fix): the panel edge trailed a brisk simulated drag by up to **33.5px on webkit / 70px on chromium**, and layout kept settling for **~200-216ms after the pointer stopped**; with the fix both are **0**.
- `content-visibility: auto` + `contain-intrinsic-size: auto` are supported in both engines (the preview virtualization is not a no-op on WKWebView).

- `pnpm --filter @proliferate/product-client build` — clean (includes design `check-theme: ok`).
- `pnpm exec tsc -p tsconfig.json --noEmit` in `apps/packages/product-client` — clean.
- `pnpm vitest run` (full product-client suite) — 793/794 files, 5294 tests pass; the one failure is the pre-existing environmental `src/app/authenticated-markdown-cascade.test.ts`, which requires Google Chrome at `/Applications/Google Chrome.app` for Playwright and fails identically without this change.
- New/updated coverage: `useResize` fires `onResizeEnd` at mouseup and on unmount-mid-drag; the facade keeps the durable store untouched mid-drag and commits once on release; a collapse ends the resize state before mouseup and commits no width; the geometry hook applies pointer-driven right widths immediately on manual renderers while a simultaneous left change still eases; the motion stylesheet declares the right-side snap; the rendered file preview carries the virtualization class.
- Guards: pre-commit appearance-scaling check and `python3 scripts/check_design_attribution.py` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
