### PR TITLE
fix(product): theme cards — radio-group roving tabindex + arrow keys

### DIFF
--- a/apps/packages/product-client/src/components/settings/panes/AppearancePane.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/AppearancePane.test.tsx
@@ -23,13 +23,14 @@ vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
  * both at once, so a preview that resolves to the wrong ramp silently tells
  * them their setting did nothing.
  *
- * What changed is where the contract lives. The previews are now the product's
- * real renderers with canned content rather than lookalike markup, so the lock
- * is that the pane keeps *reaching* those renderers — a future edit that
- * "simplifies" a preview back into hand-written divs would take the ramp
- * wiring with it, and that is exactly the regression. jsdom cannot resolve
- * `var(...)` to a pixel value, so this asserts the semantic classes and
- * custom-property chains each half carries, not computed sizes.
+ * What changed is where the contract lives. The chat preview is now the
+ * product's real renderer with canned content rather than lookalike markup; the
+ * code preview is a bespoke drawn diff (AppearanceCodePreview). The lock is
+ * that the pane keeps *reaching* those real components — a future edit that
+ * "simplifies" a preview back into hand-written divs would take the ramp wiring
+ * with it, and that is exactly the regression. jsdom cannot resolve `var(...)`
+ * to a pixel value, so this asserts the semantic classes and custom-property
+ * chains each half carries, not computed sizes.
  */
 
 import { AppearancePane } from "#product/components/settings/panes/AppearancePane";
@@ -40,8 +41,8 @@ describe("AppearancePane previews", () => {
   it("drives the code preview through the readable-code ramp and the mono family", () => {
     const { container } = render(<AppearancePane />);
 
-    // DiffViewer's root carries the pairing; nothing in the pane may override
-    // it with a UI-ramp or fixed size.
+    // AppearanceCodePreview's root carries the pairing; nothing in the pane may
+    // override it with a UI-ramp or fixed size.
     const codeRoot = container.querySelector(".text-readable-code");
     expect(codeRoot).not.toBeNull();
     expect(codeRoot?.className).toContain("font-mono");
@@ -87,6 +88,54 @@ describe("AppearancePane previews", () => {
     fireEvent.click(getByRole("radio", { name: "System" }));
     expect(getByRole("radio", { name: "System" }).getAttribute("aria-checked")).toBe("true");
     expect(getByRole("radio", { name: "Light" }).getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("implements the radio-group keyboard contract: roving tabindex + arrow navigation", () => {
+    const { getByRole } = render(<AppearancePane />);
+
+    // Set up: select Light mode to establish a known starting point.
+    fireEvent.click(getByRole("radio", { name: "Light" }));
+
+    const systemRadio = getByRole("radio", { name: "System" });
+    const lightRadio = getByRole("radio", { name: "Light" });
+    const darkRadio = getByRole("radio", { name: "Dark" });
+
+    // Initially, the selected radio has tabindex 0, the others have -1.
+    expect(lightRadio.getAttribute("tabindex")).toBe("0");
+    expect(systemRadio.getAttribute("tabindex")).toBe("-1");
+    expect(darkRadio.getAttribute("tabindex")).toBe("-1");
+
+    // ArrowRight moves selection forward (Light → Dark) and updates roving tabindex.
+    lightRadio.focus();
+    fireEvent.keyDown(lightRadio, { key: "ArrowRight" });
+    expect(darkRadio.getAttribute("aria-checked")).toBe("true");
+    expect(lightRadio.getAttribute("aria-checked")).toBe("false");
+    expect(darkRadio.getAttribute("tabindex")).toBe("0");
+    expect(lightRadio.getAttribute("tabindex")).toBe("-1");
+
+    // ArrowLeft moves backward (Dark → Light).
+    fireEvent.keyDown(darkRadio, { key: "ArrowLeft" });
+    expect(lightRadio.getAttribute("aria-checked")).toBe("true");
+    expect(darkRadio.getAttribute("aria-checked")).toBe("false");
+
+    // ArrowDown wraps: from Dark (the last) to System (the first).
+    fireEvent.click(darkRadio);
+    fireEvent.keyDown(darkRadio, { key: "ArrowDown" });
+    expect(systemRadio.getAttribute("aria-checked")).toBe("true");
+    expect(darkRadio.getAttribute("aria-checked")).toBe("false");
+
+    // ArrowUp wraps: from System (the first) to Dark (the last).
+    fireEvent.keyDown(systemRadio, { key: "ArrowUp" });
+    expect(darkRadio.getAttribute("aria-checked")).toBe("true");
+    expect(systemRadio.getAttribute("aria-checked")).toBe("false");
+
+    // Home jumps to the first radio.
+    fireEvent.keyDown(darkRadio, { key: "Home" });
+    expect(systemRadio.getAttribute("aria-checked")).toBe("true");
+
+    // End jumps to the last radio.
+    fireEvent.keyDown(systemRadio, { key: "End" });
+    expect(darkRadio.getAttribute("aria-checked")).toBe("true");
   });
 
   it("keeps every preview size off hardcoded pixels", () => {

--- a/apps/packages/product-client/src/components/settings/panes/AppearancePane.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/AppearancePane.test.tsx
@@ -107,22 +107,31 @@ describe("AppearancePane previews", () => {
 
     // ArrowRight moves selection forward (Light → Dark) and updates roving tabindex.
     lightRadio.focus();
-    fireEvent.keyDown(lightRadio, { key: "ArrowRight" });
+    // fireEvent returns false when the handler called preventDefault. Without
+    // that, arrows would scroll the settings pane while also changing the theme.
+    expect(fireEvent.keyDown(lightRadio, { key: "ArrowRight" })).toBe(false);
     expect(darkRadio.getAttribute("aria-checked")).toBe("true");
     expect(lightRadio.getAttribute("aria-checked")).toBe("false");
     expect(darkRadio.getAttribute("tabindex")).toBe("0");
     expect(lightRadio.getAttribute("tabindex")).toBe("-1");
+    // Roving tabindex is only half the contract: DOM focus has to travel with
+    // the selection, or the user arrows to Dark and then Tab escapes from a
+    // tabindex=-1 element to somewhere unrelated.
+    expect(document.activeElement).toBe(darkRadio);
 
-    // ArrowLeft moves backward (Dark → Light).
+    // ArrowLeft moves backward (Dark → Light), focus following again.
     fireEvent.keyDown(darkRadio, { key: "ArrowLeft" });
+    expect(document.activeElement).toBe(lightRadio);
     expect(lightRadio.getAttribute("aria-checked")).toBe("true");
     expect(darkRadio.getAttribute("aria-checked")).toBe("false");
 
-    // ArrowDown wraps: from Dark (the last) to System (the first).
+    // ArrowDown wraps: from Dark (the last) to System (the first). Focus has to
+    // make the wrap too — this is the jump most likely to be dropped.
     fireEvent.click(darkRadio);
     fireEvent.keyDown(darkRadio, { key: "ArrowDown" });
     expect(systemRadio.getAttribute("aria-checked")).toBe("true");
     expect(darkRadio.getAttribute("aria-checked")).toBe("false");
+    expect(document.activeElement).toBe(systemRadio);
 
     // ArrowUp wraps: from System (the first) to Dark (the last).
     fireEvent.keyDown(systemRadio, { key: "ArrowUp" });
@@ -136,6 +145,22 @@ describe("AppearancePane previews", () => {
     // End jumps to the last radio.
     fireEvent.keyDown(systemRadio, { key: "End" });
     expect(darkRadio.getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("leaves modified arrow keys to their owners", () => {
+    const { getByRole } = render(<AppearancePane />);
+
+    // ⌘⌥←/→ are the registered prev/next-tab accelerators. A radio group that
+    // grabs modified arrows would change the user's theme as a side effect of a
+    // tab switch, so the group must decline them and leave the event alone.
+    fireEvent.click(getByRole("radio", { name: "Light" }));
+    const lightRadio = getByRole("radio", { name: "Light" });
+
+    for (const modifier of ["metaKey", "ctrlKey", "altKey", "shiftKey"] as const) {
+      expect(fireEvent.keyDown(lightRadio, { key: "ArrowRight", [modifier]: true })).toBe(true);
+      expect(getByRole("radio", { name: "Light" }).getAttribute("aria-checked")).toBe("true");
+      expect(getByRole("radio", { name: "Dark" }).getAttribute("aria-checked")).toBe("false");
+    }
   });
 
   it("keeps every preview size off hardcoded pixels", () => {

--- a/apps/packages/product-client/src/components/settings/panes/ThemePreviewCards.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/ThemePreviewCards.tsx
@@ -1,4 +1,4 @@
-import { useId, type FC } from "react";
+import { useId, useRef, type FC, type KeyboardEvent } from "react";
 import { themePreviewColors } from "@proliferate/design/tokens";
 import { Button } from "#product/primitives/Button";
 import { Check } from "#product/primitives/icons/core";
@@ -134,19 +134,66 @@ export interface ThemePreviewCardsProps {
 }
 
 export function ThemePreviewCards({ value, onChange }: ThemePreviewCardsProps) {
+  // Roving tabindex pattern: the selected radio gets tabIndex={0}, the others
+  // get tabIndex={-1}. Keyboard navigation moves both selection and focus.
+  const buttonRefs = useRef(new Map<ColorMode, HTMLButtonElement>());
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    const currentIndex = CARD_ORDER.indexOf(value);
+    let nextIndex: number | undefined;
+
+    switch (event.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        nextIndex = (currentIndex + 1) % CARD_ORDER.length;
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        nextIndex = (currentIndex - 1 + CARD_ORDER.length) % CARD_ORDER.length;
+        break;
+      case "Home":
+        nextIndex = 0;
+        break;
+      case "End":
+        nextIndex = CARD_ORDER.length - 1;
+        break;
+    }
+
+    if (nextIndex !== undefined) {
+      event.preventDefault();
+      const nextMode = CARD_ORDER[nextIndex];
+      onChange(nextMode);
+      // Selection follows focus: move focus to the newly selected radio.
+      buttonRefs.current.get(nextMode)?.focus();
+    }
+  };
+
   return (
-    <div role="radiogroup" aria-label="Theme" className="grid w-full grid-cols-3 gap-3">
+    <div
+      role="radiogroup"
+      aria-label="Theme"
+      className="grid w-full grid-cols-3 gap-3"
+      onKeyDown={handleKeyDown}
+    >
       {CARD_ORDER.map((mode) => {
         const selected = value === mode;
         const Artwork = MODE_ARTWORK[mode];
         return (
           <Button
             key={mode}
+            ref={(el) => {
+              if (el) {
+                buttonRefs.current.set(mode, el);
+              } else {
+                buttonRefs.current.delete(mode);
+              }
+            }}
             type="button"
             variant="unstyled"
             size="unstyled"
             role="radio"
             aria-checked={selected}
+            tabIndex={selected ? 0 : -1}
             data-selected={selected ? "" : undefined}
             className="group flex min-w-0 flex-col items-center gap-1.5 rounded-lg text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
             onClick={() => onChange(mode)}

--- a/apps/packages/product-client/src/components/settings/panes/ThemePreviewCards.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/ThemePreviewCards.tsx
@@ -139,6 +139,15 @@ export function ThemePreviewCards({ value, onChange }: ThemePreviewCardsProps) {
   const buttonRefs = useRef(new Map<ColorMode, HTMLButtonElement>());
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    // A modified arrow is somebody else's chord, not ours: ⌘⌥←/→ are the
+    // registered prev/next-tab accelerators. The global dispatcher normally
+    // eats those in the capture phase, but an unconsumed chord would otherwise
+    // fall through to here and silently retarget the user's theme. WAI-ARIA
+    // radio groups ignore modified arrows.
+    if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
+      return;
+    }
+
     const currentIndex = CARD_ORDER.indexOf(value);
     let nextIndex: number | undefined;
 


### PR DESCRIPTION
## Summary

This PR fixes an accessibility finding from the adversarial review of merged PR #1687 (the theme preview cards redesign).

**Finding**: The theme preview cards component rendered a `<div role="radiogroup">` containing three `Button` elements with `role="radio"` and `aria-checked`, but it lacked the required keyboard contract for radio groups: no roving tabindex and no arrow-key handling. Keyboard users encountered three separate tab stops and arrow keys did nothing, violating the WAI-ARIA radio-group pattern.

## Changes

### Fix 1: ThemePreviewCards keyboard contract
Implemented the standard ARIA radio-group pattern:
- **Roving tabindex**: The selected radio gets `tabIndex={0}`, others get `tabIndex={-1}`. `ColorMode` is a closed union and the store always holds a valid mode, so exactly one card is always the tab stop.
- **Arrow-key navigation**: ArrowRight/ArrowDown move to the next mode (wrapping), ArrowLeft/ArrowUp move to previous (wrapping). Selection follows focus per WAI-ARIA APG.
- **Home/End keys**: Jump to first/last radio respectively.
- **Modified arrows are declined**: `⌘⌥←/→` are the registered prev/next-tab accelerators. The global shortcut dispatcher normally consumes those in the capture phase, but an unconsumed chord fell through to this handler and silently retargeted the user's theme. Per APG, a radio group ignores modified arrows.
- Used `useRef<Map<ColorMode, HTMLButtonElement>>` to track button refs for programmatic focus management.

### Fix 2: Stale comment corrections in AppearancePane.test.tsx
- Line ~43: Updated comment from "DiffViewer's root" to "AppearanceCodePreview's root" (the pane no longer uses DiffViewer).
- Docblock: Clarified that the chat preview uses real renderers, but the code preview is a bespoke drawn diff (AppearanceCodePreview).

### Fix 3: Test coverage, verified by mutation testing
The keyboard test locks:
- Roving tabindex (selected has 0, others have -1)
- ArrowRight/ArrowLeft navigation, asserting **both** `aria-checked` and `document.activeElement` — DOM focus must travel with the selection, or the user arrows to Dark and then Tab escapes from a `tabindex=-1` element
- Wrapping in both directions, including that focus makes the wrap
- `preventDefault()` firing, so arrows don't also scroll the settings pane
- Home/End
- That each of meta/ctrl/alt/shift + ArrowRight leaves the selection alone and the event unhandled

Rather than a single negative control, each moving part was mutated independently. **All six mutants fail the suite:**

| mutant | result |
|---|---|
| delete the `.focus()` call | FAIL |
| delete `event.preventDefault()` | FAIL |
| delete the ref-map focus line | FAIL |
| clamp instead of wrap | FAIL |
| delete `tabIndex={selected ? 0 : -1}` | FAIL |
| delete the modifier guard | FAIL |

(The first three were *green* against the original version of this test — the ref plumbing that the roving-tabindex pattern exists for was unasserted. See the review thread.)

## Validation

- `vitest run src/components/settings/panes/` — 22 files, 156 tests pass
- `python3 scripts/report_frontend_structure.py --strict` — 0 new violations (1 pre-existing LARGE_FRONTEND_FILE in ToastBody.tsx)
- `python3 scripts/check_appearance_scaling.py` — passed
- `tsc --noEmit` — no errors
- Six-mutant kill sweep, above

## Not in scope

The shared `RadioCardGroup` primitive has the same defect (no keyboard contract at all) and is tracked separately rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
