### PR TITLE
fix(sdk): sync generated cloud SDK artifacts with the drift gate

### DIFF
--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -4570,6 +4570,11 @@ export interface components {
             sandboxStatus?: string | null;
             /** Anyharnessworkspaceid */
             anyharnessWorkspaceId?: string | null;
+            /**
+             * Workerdegraded
+             * @default false
+             */
+            workerDegraded: boolean;
         };
         /** CloudWorktreeRetentionPolicyRequest */
         CloudWorktreeRetentionPolicyRequest: {
@@ -9488,8 +9493,8 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                organization_id: string;
                 name: string;
+                organization_id: string;
             };
             cookie?: never;
         };
@@ -9524,8 +9529,8 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                organization_id: string;
                 name: string;
+                organization_id: string;
             };
             cookie?: never;
         };
@@ -9693,9 +9698,9 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
+                name: string;
                 git_owner: string;
                 git_repo_name: string;
-                name: string;
             };
             cookie?: never;
         };
@@ -9730,9 +9735,9 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
+                name: string;
                 git_owner: string;
                 git_repo_name: string;
-                name: string;
             };
             cookie?: never;
         };


### PR DESCRIPTION
## Summary

- Regenerate cloud SDK TypeScript artifacts to fix the drift gate that landed in #1528
- The gate commit cc1d3af0a added verification but the artifacts were already stale
- Main changes: path parameter ordering (name moved before organization_id/git_owner/git_repo_name) and a new workerDegraded field
- No lockfile changes needed - the generator runs fine with the committed pnpm-lock.yaml

## Test plan

- [x] Ran `make cloud-client-generate` to regenerate artifacts
- [x] Verified re-running the generator yields clean `git status` (idempotent)
- [x] Verified generation works with the committed pnpm-lock.yaml (no wholesale re-resolution)
- [x] Typechecked cloud SDK package: `pnpm run typecheck` passes
- [x] CI will verify the "Verify generated cloud SDK artifacts are committed" step now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)