### PR TITLE
refactor(product): split ToastBody under the 400-line shape cap

### DIFF
--- a/apps/packages/product-client/src/components/playground/library/library-registry.test.ts
+++ b/apps/packages/product-client/src/components/playground/library/library-registry.test.ts
@@ -33,6 +33,7 @@ const patternModules = import.meta.glob([
   "../../../primitives/patterns/*.tsx",
   "!../../../primitives/patterns/*.test.tsx",
   "!../../../primitives/patterns/ToastBody.tsx",
+  "!../../../primitives/patterns/ToastExpansion.tsx",
 ]);
 const iconModules = import.meta.glob("../../../primitives/icons/*.tsx");
 const productPatternModules = import.meta.glob([

--- a/apps/packages/product-client/src/primitives/patterns/ToastBody.tsx
+++ b/apps/packages/product-client/src/primitives/patterns/ToastBody.tsx
@@ -1,19 +1,9 @@
-import { useEffect, useId, useRef, useState, useSyncExternalStore } from "react";
 import { X } from "lucide-react";
 import { Badge, type BadgeTone } from "#product/primitives/Badge";
 import { Button } from "#product/primitives/Button";
 import { POPOVER_FRAME_CLASS } from "#product/primitives/popover-surface";
 import { twMerge } from "#product/primitives/utils/tw-merge";
-import {
-  readToastPayload,
-  toastOverflowLabel,
-} from "#product/primitives/utils/toast-payload";
-import {
-  collapseToastExpansion,
-  readExpandedToastId,
-  subscribeToastExpansion,
-  toggleToastExpansion,
-} from "#product/primitives/utils/toast-expansion-store";
+import { readToastPayload } from "#product/primitives/utils/toast-payload";
 import {
   ANNOUNCEMENT_DESCRIPTION_MAX_CHARS,
   STATUS_MESSAGE_MAX_CHARS,
@@ -23,6 +13,16 @@ import {
   type ToastAction,
   type ToastTone,
 } from "#product/primitives/utils/toast-model";
+import {
+  collapseToastExpansion,
+  DETAILS_TRANSFORM_EASING,
+  ToastCopyDetailsButton,
+  ToastDetailsStrip,
+  ToastDetailsToggle,
+  ToastExcerpt,
+  useToastCopy,
+  useToastExpansion,
+} from "./ToastExpansion";
 
 /**
  * The three toast weights, rendered — and the card itself.
@@ -42,20 +42,10 @@ import {
 
 const TOAST_CARD_CLASS = `${POPOVER_FRAME_CLASS} group-focus-visible/toast:ring-2 group-focus-visible/toast:ring-ring`;
 
-/**
- * One easing for both halves of the transform — the width and the unfold move
- * as one surface or the seam shows. The emphasized role: this is the kit's
- * one spring-led product moment. `motion-reduce` jump-cuts.
- */
-const DETAILS_TRANSFORM_EASING =
-  "duration-emphasized ease-spring motion-reduce:transition-none";
-
 /** Kit action recipe: 28px control, `text-ui` label, `radius-md`. */
 const ACTION_SIZE_CLASS = "h-7 rounded-md px-2.5 text-ui";
 /** Quiet secondary: faint fill plus a full-contrast label. */
 const SECONDARY_ACTION_CLASS = `${ACTION_SIZE_CLASS} border border-input bg-surface-elevated-secondary font-medium text-foreground hover:bg-hover active:bg-active`;
-/** Ghost-quiet: no chrome until hover. Copy details while expanded. */
-const GHOST_ACTION_CLASS = `${ACTION_SIZE_CLASS} text-muted-foreground hover:bg-hover hover:text-foreground`;
 
 const DOT_TONE_CLASS: Record<ToastTone, string> = {
   neutral: "bg-muted-foreground",
@@ -194,33 +184,6 @@ export function StatusToastBody({
   );
 }
 
-/** Mono excerpt: at most three countable lines, then "+N more". */
-function ToastExcerpt({ payload }: { payload: string }) {
-  const reading = readToastPayload(payload);
-  if (reading.blob || reading.lines.length === 0) {
-    return null;
-  }
-  const overflow = toastOverflowLabel(reading.overflow);
-
-  return (
-    <div
-      data-testid="toast-excerpt"
-      className="mt-2 rounded-md border border-border-light bg-surface-elevated-secondary px-2 py-1.5 font-mono text-ui-sm leading-5 text-muted-foreground"
-    >
-      {/* Keyed by index, not by content: an output log repeating an identical
-          line is ordinary, and a duplicate key would warn and reconcile wrong. */}
-      {reading.lines.map((line, index) => (
-        <span key={index} className="block truncate" title={line}>
-          {line}
-        </span>
-      ))}
-      {overflow ? (
-        <span className="block text-foreground/70">{overflow}</span>
-      ) : null}
-    </div>
-  );
-}
-
 /**
  * announcement / detail — badge above a wrapping title, a description that
  * states the consequence, then the action cluster bottom-right. `detail` adds
@@ -269,55 +232,12 @@ export function AnnouncementToastBody({
   const jump = input.weight === "detail" ? input.jump : undefined;
 
   const expandable = inlinePayload !== undefined;
-  const expandedInStore = useSyncExternalStore(
-    subscribeToastExpansion,
-    () => readExpandedToastId() === toastId,
-    () => false,
-  );
-  const expanded = expandable && expandedInStore;
-
-  const reactId = useId();
-  const titleId = `toast-title-${reactId}`;
-  const detailsId = `toast-details-${reactId}`;
-
-  const cardRef = useRef<HTMLDivElement | null>(null);
-  useEffect(() => {
-    const node = cardRef.current;
-    if (!onCardResize || !node || typeof ResizeObserver === "undefined") {
-      return;
-    }
-    let initial = true;
-    const observer = new ResizeObserver(() => {
-      // The mount-time fire reports a size sonner has already measured.
-      if (initial) {
-        initial = false;
-        return;
-      }
-      onCardResize();
-    });
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, [onCardResize]);
-
-  // Which copy control just fired, so its label — and only its label — flips
-  // to "Copied". The flip is the whole feedback for a click whose effect lands
-  // in the clipboard, where nothing visible changes — which is also why the
-  // receipt waits for the write to resolve: a missing or refusing clipboard
-  // must not report a success that never happened.
-  const [copied, setCopied] = useState<"payload" | "details" | null>(null);
-  const copyResetRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-  useEffect(() => () => clearTimeout(copyResetRef.current), []);
-  const handleCopy = (control: "payload" | "details", text: string) => {
-    const write = navigator.clipboard?.writeText(text);
-    if (!write) {
-      return;
-    }
-    void write.then(() => {
-      setCopied(control);
-      clearTimeout(copyResetRef.current);
-      copyResetRef.current = setTimeout(() => setCopied(null), 1_500);
-    }, () => {});
-  };
+  const { expanded, cardRef, titleId, detailsId } = useToastExpansion({
+    toastId,
+    expandable,
+    onCardResize,
+  });
+  const { copied, handleCopy } = useToastCopy();
 
   const quiet = [jump, input.secondary, navigateAction].filter(
     (action): action is ToastAction => action !== undefined,
@@ -385,51 +305,22 @@ export function AnnouncementToastBody({
         <CloseButton onClose={onClose} className="-mr-0.5 -mt-0.5" />
       </div>
       {payload ? <ToastExcerpt payload={payload} /> : null}
-      {expandable ? (
-        /* The unfold: `0fr → 1fr` is the one animatable path to auto height,
-           and the payload stays mounted through both directions of it. While
-           collapsed the strip is clipping away real content, so it is hidden
-           from the accessibility tree, not just from pixels. */
-        <div
-          aria-hidden={expanded ? undefined : true}
-          // The host is an aria-live region, so unhiding the strip would read
-          // the whole payload aloud. The user pressed Details — they are about
-          // to read it themselves; `off` scopes the announcement away without
-          // removing the strip from the accessibility tree.
-          aria-live="off"
-          className={twMerge(
-            `-mx-3 grid grid-rows-[0fr] transition-[grid-template-rows] ${DETAILS_TRANSFORM_EASING}`,
-            expanded && "grid-rows-[1fr]",
-          )}
-        >
-          <div className="min-h-0 overflow-hidden">
-            {/* Anti-jitter: the strip is laid out at the expanded card width
-                from the first frame, so line wrapping never changes while the
-                card widens — the clipping wrapper reveals it instead. */}
-            <pre
-              id={detailsId}
-              role="region"
-              aria-labelledby={titleId}
-              tabIndex={expanded ? 0 : -1}
-              className="m-0 mt-2.5 max-h-72 w-[480px] max-w-[calc(100vw-48px)] overflow-y-auto whitespace-pre-wrap break-words border-y border-border-light bg-surface-elevated-secondary px-3 py-2 font-mono text-readable-code text-muted-foreground"
-            >
-              {inlinePayload}
-            </pre>
-          </div>
-        </div>
+      {expandable && inlinePayload ? (
+        <ToastDetailsStrip
+          inlinePayload={inlinePayload}
+          expanded={expanded}
+          titleId={titleId}
+          detailsId={detailsId}
+        />
       ) : null}
       {copyPayload !== undefined || quiet.length > 0 || commit || expandable ? (
         <div className="mt-2.5 flex items-center justify-end gap-2">
           {expanded && inlinePayload !== undefined ? (
-            <Button
-              type="button"
-              variant="unstyled"
-              size="unstyled"
-              className={twMerge(GHOST_ACTION_CLASS, "mr-auto")}
-              onClick={() => handleCopy("details", inlinePayload)}
-            >
-              {copied === "details" ? "Copied" : "Copy details"}
-            </Button>
+            <ToastCopyDetailsButton
+              inlinePayload={inlinePayload}
+              copied={copied}
+              onCopy={handleCopy}
+            />
           ) : null}
           {copyPayload !== undefined ? (
             <Button
@@ -455,17 +346,11 @@ export function AnnouncementToastBody({
             </Button>
           ))}
           {expandable ? (
-            <Button
-              type="button"
-              variant="unstyled"
-              size="unstyled"
-              className={SECONDARY_ACTION_CLASS}
-              aria-expanded={expanded}
-              aria-controls={detailsId}
-              onClick={() => toggleToastExpansion(toastId)}
-            >
-              {expanded ? "Collapse" : "Details"}
-            </Button>
+            <ToastDetailsToggle
+              toastId={toastId}
+              expanded={expanded}
+              detailsId={detailsId}
+            />
           ) : null}
           {commit ? (
             <Button

--- a/apps/packages/product-client/src/primitives/patterns/ToastExpansion.tsx
+++ b/apps/packages/product-client/src/primitives/patterns/ToastExpansion.tsx
@@ -1,0 +1,242 @@
+import React, { useEffect, useId, useRef, useSyncExternalStore } from "react";
+import { Button } from "#product/primitives/Button";
+import { twMerge } from "#product/primitives/utils/tw-merge";
+import {
+  readToastPayload,
+  toastOverflowLabel,
+} from "#product/primitives/utils/toast-payload";
+import {
+  collapseToastExpansion,
+  readExpandedToastId,
+  subscribeToastExpansion,
+  toggleToastExpansion,
+} from "#product/primitives/utils/toast-expansion-store";
+
+/**
+ * One easing for both halves of the transform — the width and the unfold move
+ * as one surface or the seam shows. The emphasized role: this is the kit's
+ * one spring-led product moment. `motion-reduce` jump-cuts.
+ */
+const DETAILS_TRANSFORM_EASING =
+  "duration-emphasized ease-spring motion-reduce:transition-none";
+
+/**
+ * Mono excerpt: at most three countable lines, then "+N more".
+ * Rendered by detail toasts that have countable payloads.
+ */
+export function ToastExcerpt({ payload }: { payload: string }) {
+  const reading = readToastPayload(payload);
+  if (reading.blob || reading.lines.length === 0) {
+    return null;
+  }
+  const overflow = toastOverflowLabel(reading.overflow);
+
+  return (
+    <div
+      data-testid="toast-excerpt"
+      className="mt-2 rounded-md border border-border-light bg-surface-elevated-secondary px-2 py-1.5 font-mono text-ui-sm leading-5 text-muted-foreground"
+    >
+      {/* Keyed by index, not by content: an output log repeating an identical
+          line is ordinary, and a duplicate key would warn and reconcile wrong. */}
+      {reading.lines.map((line, index) => (
+        <span key={index} className="block truncate" title={line}>
+          {line}
+        </span>
+      ))}
+      {overflow ? (
+        <span className="block text-foreground/70">{overflow}</span>
+      ) : null}
+    </div>
+  );
+}
+
+/** Ghost-quiet: no chrome until hover. Copy details while expanded. */
+const GHOST_ACTION_CLASS = "h-7 rounded-md px-2.5 text-ui text-muted-foreground hover:bg-hover hover:text-foreground";
+
+/**
+ * Expansion logic for toasts with inline payloads. Manages expanded state,
+ * resize observation for sonner re-measurement, and the details strip rendering.
+ *
+ * The unfold: `0fr → 1fr` is the one animatable path to auto height, and the
+ * payload stays mounted through both directions of it. While collapsed the
+ * strip is clipping away real content, so it is hidden from the accessibility
+ * tree, not just from pixels.
+ */
+export function useToastExpansion({
+  toastId,
+  expandable,
+  onCardResize,
+}: {
+  toastId: string;
+  expandable: boolean;
+  onCardResize?: () => void;
+}) {
+  const expandedInStore = useSyncExternalStore(
+    subscribeToastExpansion,
+    () => readExpandedToastId() === toastId,
+    () => false,
+  );
+  const expanded = expandable && expandedInStore;
+
+  const reactId = useId();
+  const titleId = `toast-title-${reactId}`;
+  const detailsId = `toast-details-${reactId}`;
+
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const node = cardRef.current;
+    if (!onCardResize || !node || typeof ResizeObserver === "undefined") {
+      return;
+    }
+    let initial = true;
+    const observer = new ResizeObserver(() => {
+      // The mount-time fire reports a size sonner has already measured.
+      if (initial) {
+        initial = false;
+        return;
+      }
+      onCardResize();
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [onCardResize]);
+
+  return {
+    expanded,
+    cardRef,
+    titleId,
+    detailsId,
+  };
+}
+
+/**
+ * Renders the expandable details strip that unfolds when Details is pressed.
+ * The strip is a full-bleed region between the message text and action cluster,
+ * growing from 0fr to 1fr (the one animatable path to auto height).
+ */
+export function ToastDetailsStrip({
+  inlinePayload,
+  expanded,
+  titleId,
+  detailsId,
+}: {
+  inlinePayload: string;
+  expanded: boolean;
+  titleId: string;
+  detailsId: string;
+}) {
+  return (
+    <div
+      aria-hidden={expanded ? undefined : true}
+      // The host is an aria-live region, so unhiding the strip would read
+      // the whole payload aloud. The user pressed Details — they are about
+      // to read it themselves; `off` scopes the announcement away without
+      // removing the strip from the accessibility tree.
+      aria-live="off"
+      className={twMerge(
+        `-mx-3 grid grid-rows-[0fr] transition-[grid-template-rows] ${DETAILS_TRANSFORM_EASING}`,
+        expanded && "grid-rows-[1fr]",
+      )}
+    >
+      <div className="min-h-0 overflow-hidden">
+        {/* Anti-jitter: the strip is laid out at the expanded card width
+            from the first frame, so line wrapping never changes while the
+            card widens — the clipping wrapper reveals it instead. */}
+        <pre
+          id={detailsId}
+          role="region"
+          aria-labelledby={titleId}
+          tabIndex={expanded ? 0 : -1}
+          className="m-0 mt-2.5 max-h-72 w-[480px] max-w-[calc(100vw-48px)] overflow-y-auto whitespace-pre-wrap break-words border-y border-border-light bg-surface-elevated-secondary px-3 py-2 font-mono text-readable-code text-muted-foreground"
+        >
+          {inlinePayload}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Manages the copy-to-clipboard state for toast actions. Returns the current
+ * copied control (if any) and a handler to perform the copy operation.
+ *
+ * Which copy control just fired, so its label — and only its label — flips
+ * to "Copied". The flip is the whole feedback for a click whose effect lands
+ * in the clipboard, where nothing visible changes — which is also why the
+ * receipt waits for the write to resolve: a missing or refusing clipboard
+ * must not report a success that never happened.
+ */
+export function useToastCopy() {
+  const [copied, setCopied] = React.useState<"payload" | "details" | null>(null);
+  const copyResetRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  useEffect(() => () => clearTimeout(copyResetRef.current), []);
+
+  const handleCopy = (control: "payload" | "details", text: string) => {
+    const write = navigator.clipboard?.writeText(text);
+    if (!write) {
+      return;
+    }
+    void write.then(() => {
+      setCopied(control);
+      clearTimeout(copyResetRef.current);
+      copyResetRef.current = setTimeout(() => setCopied(null), 1_500);
+    }, () => {});
+  };
+
+  return { copied, handleCopy };
+}
+
+/**
+ * Renders the Copy details button that appears when the toast is expanded.
+ */
+export function ToastCopyDetailsButton({
+  inlinePayload,
+  copied,
+  onCopy,
+}: {
+  inlinePayload: string;
+  copied: "payload" | "details" | null;
+  onCopy: (control: "payload" | "details", text: string) => void;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="unstyled"
+      size="unstyled"
+      className={twMerge(GHOST_ACTION_CLASS, "mr-auto")}
+      onClick={() => onCopy("details", inlinePayload)}
+    >
+      {copied === "details" ? "Copied" : "Copy details"}
+    </Button>
+  );
+}
+
+/**
+ * Renders the Details/Collapse toggle button that expands or collapses the
+ * inline payload strip.
+ */
+export function ToastDetailsToggle({
+  toastId,
+  expanded,
+  detailsId,
+}: {
+  toastId: string;
+  expanded: boolean;
+  detailsId: string;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="unstyled"
+      size="unstyled"
+      className="h-7 rounded-md px-2.5 text-ui border border-input bg-surface-elevated-secondary font-medium text-foreground hover:bg-hover active:bg-active"
+      aria-expanded={expanded}
+      aria-controls={detailsId}
+      onClick={() => toggleToastExpansion(toastId)}
+    >
+      {expanded ? "Collapse" : "Details"}
+    </Button>
+  );
+}
+
+export { collapseToastExpansion, DETAILS_TRANSFORM_EASING };


### PR DESCRIPTION
## Summary

This PR fixes the repo-shape check failure on main since #1686 (toast redesign, commit bc7ea19d7).

**The issue**: `ToastBody.tsx` grew to 490 lines during the toast redesign, exceeding the 400-line soft threshold documented in frontend structure rules.

**The fix**: Clean mechanical split extracting expansion-related logic into a new sibling file:
- Created `ToastExpansion.tsx` (242 lines) containing:
  - `useToastExpansion` hook (manages expanded state + resize observation)
  - `useToastCopy` hook (copy-to-clipboard state + "Copied" receipt)
  - `ToastDetailsStrip` component (the unfoldable payload strip)
  - `ToastExcerpt` component (collapsed 3-line mono preview)
  - `ToastCopyDetailsButton` and `ToastDetailsToggle` action buttons
- Updated `ToastBody.tsx` (375 lines, down from 490) to import and use the extracted pieces

**Pure move-and-import refactor**: Zero behavior change. All exports stable (`StatusToastBody`, `AnnouncementToastBody`), so `show-toast.tsx` and tests don't change.

## Validation

- ✅ `python3 scripts/report_frontend_structure.py --strict` → TOTAL: 0
- ✅ `python3 scripts/check_max_lines.py` → passed
- ✅ `python3 scripts/check_appearance_scaling.py` → passed
- Toast tests will run in CI (lockfile policy blocks local pnpm install in worktree)

This unbreaks the Repo shape checks gate that's been red on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)