### PR TITLE
fix(product): render fenced code blocks in chat

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.test.tsx
@@ -1,0 +1,188 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatInput } from "#product/components/workspace/chat/input/ChatInput";
+import type { PromptAttachmentController } from "#product/hooks/chat/ui/use-chat-prompt-attachments";
+
+const chatInputMocks = vi.hoisted(() => ({
+  lexicalPaste: vi.fn(),
+}));
+
+vi.mock("#product/stores/sessions/session-selection-store", () => ({
+  useSessionSelectionStore: (selector: (state: unknown) => unknown) => selector({
+    workspaceSelectionNonce: 0,
+  }),
+}));
+vi.mock("#product/stores/chat/chat-input-store", () => ({
+  useChatInputStore: (selector: (state: unknown) => unknown) => selector({
+    focusRequestNonce: 0,
+  }),
+}));
+vi.mock("#product/hooks/chat/derived/use-active-session-identity", () => ({
+  useActiveSessionId: () => null,
+  useActiveSessionCanCancelState: () => false,
+  useActiveSessionRunningState: () => false,
+}));
+vi.mock("#product/hooks/chat/derived/use-chat-availability-state", () => ({
+  useChatAvailabilityState: () => ({
+    isDisabled: false,
+    sendBlockedReason: null,
+    areRuntimeControlsDisabled: false,
+  }),
+}));
+vi.mock("#product/hooks/chat/ui/use-chat-composer-keyboard", () => ({
+  useChatComposerKeyboard: () => ({ handleKeyDown: vi.fn() }),
+}));
+vi.mock("#product/hooks/chat/ui/use-chat-draft-state", () => ({
+  useChatDraftControls: () => ({
+    workspaceUiKey: null,
+    materializedWorkspaceId: null,
+    getDraft: () => ({ nodes: [] }),
+    setDraft: vi.fn(),
+    isEmpty: true,
+  }),
+}));
+vi.mock("#product/hooks/chat/facade/use-chat-model-selector-state", () => ({
+  useChatModelSelectorState: () => ({
+    launchControls: [],
+    launchAgentKind: null,
+  }),
+}));
+vi.mock("#product/hooks/chat/workflows/use-chat-prompt-actions", () => ({
+  useChatPromptActions: () => ({ handleSubmit: vi.fn(), handleCancel: vi.fn() }),
+}));
+vi.mock("#product/hooks/chat/ui/use-composer-submit-gate", () => ({
+  useComposerSubmitGate: () => ({ isSubmitting: false, run: vi.fn() }),
+}));
+vi.mock("#product/hooks/chat/facade/use-chat-session-controls", () => ({
+  useChatSessionControls: () => ({ agentKind: null, controls: [], modeControl: null }),
+}));
+vi.mock("#product/hooks/chat/ui/use-queued-prompt-edit", () => ({
+  useQueuedPromptEdit: () => ({
+    isEditing: false,
+    editingSeq: null,
+    editDraft: "",
+    setEditDraftText: vi.fn(),
+    cancelEdit: vi.fn(),
+    commitEdit: vi.fn(),
+  }),
+  useEditLastQueuedPrompt: () => vi.fn(),
+}));
+vi.mock("#product/hooks/plans/facade/use-plan-draft-attachments", () => ({
+  usePlanDraftAttachments: () => ({
+    attachments: [],
+    removePlan: vi.fn(),
+    clearPlans: vi.fn(),
+    blocks: [],
+    contentParts: [],
+    hasPlans: false,
+  }),
+}));
+vi.mock("#product/hooks/chat/workflows/use-prompt-attachment-preview-actions", () => ({
+  usePromptAttachmentPreviewActions: () => ({ openAttachmentPreview: vi.fn() }),
+}));
+vi.mock("#product/hooks/ui/debug/use-debug-render-count", () => ({
+  useDebugRenderCount: () => {},
+}));
+vi.mock("#product/components/diagnostics/DebugProfiler", () => ({
+  DebugProfiler: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock("#product/components/workspace/chat/input/ChatInputControlRow", () => ({
+  ChatInputControlRow: () => null,
+}));
+vi.mock(
+  "#product/components/workspace/chat/input/workspace-status/ConnectedWorkspaceStatusComposerControl",
+  () => ({ ConnectedWorkspaceStatusComposerControl: () => null }),
+);
+vi.mock("#product/components/workspace/chat/input/ChatInputDraftArea", () => ({
+  ChatInputDraftArea: ({ textareaRef }: { textareaRef: { current: HTMLDivElement | null } }) => (
+    <div
+      ref={textareaRef}
+      data-testid="mock-chat-editor"
+      onPaste={(event) => {
+        event.preventDefault();
+        chatInputMocks.lexicalPaste(event.clipboardData.getData("text/plain"));
+      }}
+    />
+  ),
+}));
+
+beforeEach(() => { chatInputMocks.lexicalPaste.mockReset(); });
+afterEach(cleanup);
+
+describe("ChatInput paste ownership", () => {
+  it("claims mixed file and text payloads before the editor", () => {
+    const attachments = createAttachments(true);
+    render(
+      <ChatInput
+        attachments={attachments.controller}
+        suppressActiveSessionState
+        suppressAutoFocus
+      />,
+    );
+    const file = new File(["image"], "capture.png", { type: "image/png" });
+    const event = pasteEvent("clipboard fallback", [file]);
+
+    fireEvent(screen.getByTestId("mock-chat-editor"), event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(attachments.addFiles).toHaveBeenCalledOnce();
+    expect(chatInputMocks.lexicalPaste).not.toHaveBeenCalled();
+  });
+
+  it("leaves mixed text available to the editor when attachments are disabled", () => {
+    const attachments = createAttachments(false);
+    render(
+      <ChatInput
+        attachments={attachments.controller}
+        suppressActiveSessionState
+        suppressAutoFocus
+      />,
+    );
+    const event = pasteEvent("clipboard fallback", [
+      new File(["image"], "capture.png", { type: "image/png" }),
+    ]);
+
+    fireEvent(screen.getByTestId("mock-chat-editor"), event);
+
+    expect(attachments.addFiles).not.toHaveBeenCalled();
+    expect(chatInputMocks.lexicalPaste).toHaveBeenCalledWith("clipboard fallback");
+  });
+});
+
+function createAttachments(canAttachFiles: boolean) {
+  const addFiles = vi.fn();
+  return {
+    addFiles,
+    controller: {
+      attachments: [],
+      addFiles,
+      addTextPaste: vi.fn(() => false),
+      removeAttachment: vi.fn(),
+      clearAttachments: vi.fn(),
+      clearSubmittedAttachments: vi.fn(),
+      snapshotForSubmit: vi.fn(() => []),
+      hasAttachments: false,
+      hasSupportedAttachments: false,
+      canAttachFiles,
+      supportsAttachments: canAttachFiles,
+    } as PromptAttachmentController,
+  };
+}
+
+function pasteEvent(text: string, files: File[]): ClipboardEvent {
+  const event = new Event("paste", {
+    bubbles: true,
+    cancelable: true,
+  }) as ClipboardEvent;
+  Object.defineProperty(event, "clipboardData", {
+    value: {
+      files,
+      getData: (type: string) => type === "text/plain" ? text : "",
+      types: ["Files", "text/plain"],
+    },
+  });
+  return event;
+}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx
@@ -5,7 +5,6 @@ import {
   useRef,
   useState,
   type ChangeEvent,
-  type ClipboardEvent,
   type MouseEvent,
 } from "react";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
@@ -51,7 +50,7 @@ import { ChatComposerSurface } from "#product/components/workspace/chat/composer
 import { Input } from "#product/primitives/Input";
 import { useDebugRenderCount } from "#product/hooks/ui/debug/use-debug-render-count";
 import { usePromptAttachmentPreviewActions } from "#product/hooks/chat/workflows/use-prompt-attachment-preview-actions";
-import { handlePromptAttachmentPaste } from "#product/lib/domain/chat/composer/prompt-attachment-paste";
+import { useChatInputPaste } from "#product/hooks/chat/ui/use-chat-input-paste";
 import type { PromptAttachmentPreviewHandler } from "#product/components/workspace/chat/content/PromptContentRenderer";
 
 const CHAT_INPUT_ATTACHMENT_ACCEPT =
@@ -140,6 +139,10 @@ export function ChatInput({
     && !areRuntimeControlsDisabled
     && !isSubmitting
     && attachments.canAttachFiles;
+  const { handleFilePasteCapture, handlePaste } = useChatInputPaste({
+    attachments,
+    canAcceptPastedAttachments,
+  });
   const onSubmit = useCallback(async () => {
     // End the typing burst NOW so the transcript renders urgently: the
     // composer clearing and the sent message appearing must be one frame.
@@ -250,23 +253,6 @@ export function ChatInput({
     [openAttachmentPreview],
   );
 
-  const handlePaste = useCallback((event: ClipboardEvent<HTMLDivElement>) => {
-    // The editor owns formatted Markdown paste first. Once it has imported a
-    // list or link, do not reinterpret the same clipboard text as an
-    // attachment at the composer surface.
-    const shouldPreventDefault = handlePromptAttachmentPaste({
-      defaultPrevented: event.defaultPrevented,
-      canAcceptAttachments: canAcceptPastedAttachments,
-      fileCount: event.clipboardData.files.length,
-      plainText: event.clipboardData.getData("text/plain"),
-      addFiles: () => attachments.addFiles(event.clipboardData.files),
-      addTextPaste: attachments.addTextPaste,
-    });
-    if (shouldPreventDefault) {
-      event.preventDefault();
-    }
-  }, [attachments, canAcceptPastedAttachments]);
-
   const handleComposerSurfaceClick = useCallback((event: MouseEvent<HTMLDivElement>) => {
     // Portal-rendered popovers (model picker, etc.) bubble clicks through the
     // React tree even though their DOM lives outside the surface — those
@@ -327,6 +313,7 @@ export function ChatInput({
         <ChatComposerSurface
           overflowMode="clip"
           onClick={handleComposerSurfaceClick}
+          onPasteCapture={handleFilePasteCapture}
           onPaste={handlePaste}
         >
           <form className="relative flex flex-col">

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerCodeFenceMarkdown.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerCodeFenceMarkdown.tsx
@@ -1,0 +1,140 @@
+import {
+  $createLineBreakNode,
+  $createParagraphNode,
+  $createTextNode,
+} from "lexical";
+import { CODE, type MultilineElementTransformer } from "@lexical/markdown";
+
+const COMPOSER_CODE_FENCE_START = /^([ \t]*`{3,})([^`\r\n]*?)[ \t]*$/;
+const COMPOSER_CODE_FENCE_END = /^[ \t]*(`{3,})[ \t]*$/;
+const REQUIRED_CODE_FENCE_END = CODE.regExpEnd instanceof RegExp
+  ? CODE.regExpEnd
+  : CODE.regExpEnd?.regExp ?? COMPOSER_CODE_FENCE_END;
+
+/** Whether Markdown contains a backtick fence with a matching closing line. */
+export function containsCompleteComposerCodeFence(markdown: string): boolean {
+  return findCompleteComposerCodeFence(markdown) !== null;
+}
+
+export interface CompleteComposerCodeFence {
+  markdown: string;
+  start: number;
+  end: number;
+}
+
+/** Finds the first complete fence and the surrounding line breaks it replaces. */
+export function findCompleteComposerCodeFence(
+  markdown: string,
+): CompleteComposerCodeFence | null {
+  const lines = composerMarkdownLines(markdown);
+  for (let index = 0; index < lines.length; index += 1) {
+    const openingMatch = lines[index]!.text.match(COMPOSER_CODE_FENCE_START);
+    if (!openingMatch) continue;
+    const openingFenceLength = openingMatch[1]!.trim().length;
+    for (let closingIndex = index + 1; closingIndex < lines.length; closingIndex += 1) {
+      const closingLine = lines[closingIndex]!;
+      const closingMatch = closingLine.text.match(COMPOSER_CODE_FENCE_END);
+      if (!closingMatch || closingMatch[1]!.length < openingFenceLength) {
+        continue;
+      }
+      const openingLine = lines[index]!;
+      return {
+        markdown: markdown.slice(openingLine.start, closingLine.end),
+        start: openingLine.start,
+        end: closingLine.end,
+      };
+    }
+    return null;
+  }
+  return null;
+}
+
+/** Whether an offset falls after an opening fence with no matching close. */
+export function isComposerOffsetInsideOpenCodeFence(
+  markdown: string,
+  offset: number,
+): boolean {
+  const lines = markdown.slice(0, offset).split(/\r?\n/);
+  let openingFenceLength: number | null = null;
+
+  for (const line of lines) {
+    if (openingFenceLength === null) {
+      const openingMatch = line.match(COMPOSER_CODE_FENCE_START);
+      if (openingMatch) openingFenceLength = openingMatch[1]!.trim().length;
+      continue;
+    }
+    const closingMatch = line.match(COMPOSER_CODE_FENCE_END);
+    if (closingMatch && closingMatch[1]!.length >= openingFenceLength) {
+      openingFenceLength = null;
+    }
+  }
+  return openingFenceLength !== null;
+}
+
+/** Lexical's code transform with a required, length-compatible close fence. */
+export const COMPOSER_CODE_TRANSFORMER: MultilineElementTransformer = {
+  ...CODE,
+  handleImportAfterStartMatch: (args) => {
+    const openingFenceLength = args.startMatch[1]?.trim().length ?? 0;
+    if (openingFenceLength < 3) return null;
+    if (!hasMatchingComposerCodeFence(
+      args.lines,
+      args.startLineIndex,
+      openingFenceLength,
+    )) {
+      const paragraph = $createParagraphNode();
+      const remainingLines = args.lines.slice(args.startLineIndex);
+      for (let index = 0; index < remainingLines.length; index += 1) {
+        paragraph.append($createTextNode(remainingLines[index]!));
+        if (index < remainingLines.length - 1) {
+          paragraph.append($createLineBreakNode());
+        }
+      }
+      args.rootNode.append(paragraph);
+      return [true, args.lines.length - 1];
+    }
+
+    const normalizedStartMatch = Object.assign([...args.startMatch], {
+      index: args.startMatch.index,
+      input: args.startMatch.input,
+    }) as RegExpMatchArray;
+    normalizedStartMatch[2] = args.startMatch[2]?.trim() ?? "";
+    return CODE.handleImportAfterStartMatch?.({
+      ...args,
+      startMatch: normalizedStartMatch,
+      transformer: CODE,
+    });
+  },
+  regExpEnd: REQUIRED_CODE_FENCE_END,
+  regExpStart: COMPOSER_CODE_FENCE_START,
+};
+
+function hasMatchingComposerCodeFence(
+  lines: readonly string[],
+  openingLineIndex: number,
+  openingFenceLength: number,
+): boolean {
+  for (let index = openingLineIndex + 1; index < lines.length; index += 1) {
+    const closingMatch = lines[index]!.match(COMPOSER_CODE_FENCE_END);
+    if (closingMatch && closingMatch[1]!.length >= openingFenceLength) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function composerMarkdownLines(markdown: string) {
+  const lines: Array<{ text: string; start: number; end: number }> = [];
+  let start = 0;
+  for (const text of markdown.split(/\r?\n/)) {
+    const end = start + text.length;
+    lines.push({ text, start, end });
+    start = lineBreakEndAfter(markdown, end);
+  }
+  return lines;
+}
+
+function lineBreakEndAfter(markdown: string, offset: number): number {
+  if (markdown.startsWith("\r\n", offset)) return offset + 2;
+  return markdown[offset] === "\n" ? offset + 1 : offset;
+}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerCommandEditor.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerCommandEditor.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createTextDraft,
@@ -12,6 +12,7 @@ import { ComposerCommandEditor } from "#product/components/workspace/chat/input/
 import {
   isComposerFormattedPaste,
   isComposerLinkPaste,
+  isComposerMarkdownCodeBlockPaste,
   isComposerMarkdownListPaste,
   isExactHttpsComposerPaste,
 } from "#product/components/workspace/chat/input/ComposerLinkPastePlugin";
@@ -362,6 +363,97 @@ describe("ComposerCommandEditor", () => {
     expect(textarea.querySelector("ul li")?.textContent).toContain("item");
   });
 
+  it("keeps inline command discovery closed while editing a code block", async () => {
+    slashCommandMock.commands = [createSlashCommand("review", "Review the current changes")];
+    const onSubmit = vi.fn();
+    const { container, textarea } = renderEditor({
+      draft: createTextDraft("```\n/rev\n```"),
+      onSubmit,
+    });
+    const textNode = textarea.querySelector("code [data-lexical-text]")?.firstChild;
+    expect(textNode).toBeTruthy();
+    const range = document.createRange();
+    range.setStart(textNode!, 4);
+    range.collapse(true);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    await act(async () => {
+      fireEvent(document, new Event("selectionchange"));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).not.toContain("Review the current changes");
+    });
+    expect(fireEvent.keyDown(textarea, { key: "Enter" })).toBe(false);
+    expect(slashCommandMock.selectedCount).toBe(0);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces a file trigger after a code block without shifting its range", async () => {
+    fileMentionMock.results = [
+      { path: "docs/setup.md", name: "setup.md", parent: "docs" },
+    ];
+    const onDraftChange = vi.fn();
+    const { textarea } = renderEditor({
+      draft: createTextDraft("```\nconst ready = true;\n```\n\n@set"),
+      onDraftChange,
+    });
+    const textNode = textarea.querySelector("p [data-lexical-text]")?.firstChild;
+    expect(textNode?.textContent).toBe("@set");
+    const range = document.createRange();
+    range.setStart(textNode!, 4);
+    range.collapse(true);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    await act(async () => {
+      fireEvent(document, new Event("selectionchange"));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(fileMentionMock.lastQuery).toBe("set"));
+    fireEvent.keyDown(textarea, { key: "Enter", repeat: false });
+    await waitFor(() => expect(onDraftChange.mock.calls.some(
+      ([draft]) => serializeChatDraftToPrompt(draft)
+        === "```\nconst ready = true;\n```\n\n[setup.md](docs/setup.md) ",
+    )).toBe(true));
+  });
+
+  it("replaces a file trigger before a code block without consuming the block", async () => {
+    fileMentionMock.results = [
+      { path: "docs/setup.md", name: "setup.md", parent: "docs" },
+    ];
+    const onDraftChange = vi.fn();
+    const { textarea } = renderEditor({
+      draft: createTextDraft("@set\n\n```\nconst ready = true;\n```"),
+      onDraftChange,
+    });
+    const textNode = textarea.querySelector("p [data-lexical-text]")?.firstChild;
+    expect(textNode?.textContent).toBe("@set");
+    const range = document.createRange();
+    range.setStart(textNode!, 4);
+    range.collapse(true);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    await act(async () => {
+      fireEvent(document, new Event("selectionchange"));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(fileMentionMock.lastQuery).toBe("set"));
+    fireEvent.keyDown(textarea, { key: "Enter", repeat: false });
+    await waitFor(() => expect(onDraftChange.mock.calls.some(
+      ([draft]) => serializeChatDraftToPrompt(draft)
+        === "[setup.md](docs/setup.md) \n\n```\nconst ready = true;\n```",
+    )).toBe(true));
+  });
+
   it("recognizes exact HTTPS URLs and complete pasted Markdown HTTPS links", () => {
     expect(isExactHttpsComposerPaste("https://example.com/path?q=1")).toBe(true);
     expect(isExactHttpsComposerPaste("http://example.com")).toBe(false);
@@ -375,7 +467,16 @@ describe("ComposerCommandEditor", () => {
     expect(isComposerMarkdownListPaste("1. first\n2. second")).toBe(true);
     expect(isComposerMarkdownListPaste("a hyphen - inside prose")).toBe(false);
     expect(isComposerMarkdownListPaste("-")).toBe(false);
+    expect(isComposerMarkdownCodeBlockPaste("```\nconst ready = true;\n```")).toBe(true);
+    expect(isComposerMarkdownCodeBlockPaste("```ts\nconst ready = true;\n````")).toBe(true);
+    expect(isComposerMarkdownCodeBlockPaste("```c++\nconst ready = true;\n```")).toBe(true);
+    expect(isComposerMarkdownCodeBlockPaste("```python linenos\nprint('ok')\n```")).toBe(true);
+    expect(isComposerMarkdownCodeBlockPaste("````\nconst ready = true;\n```")).toBe(false);
+    expect(isComposerMarkdownCodeBlockPaste("```\nconst ready = true;")).toBe(false);
+    expect(isComposerMarkdownCodeBlockPaste("```const ready = true;```")).toBe(false);
     expect(isComposerFormattedPaste("- first")).toBe(true);
+    expect(isComposerFormattedPaste("```\nconst ready = true;\n```")).toBe(true);
+    expect(isComposerFormattedPaste("```\nconst ready = true;")).toBe(true);
 
     const { textarea: typed } = renderEditor({
       draft: createTextDraft("[Docs](https://example.com)"),

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerCommandEditor.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerCommandEditor.tsx
@@ -80,14 +80,21 @@ export function ComposerCommandEditor({
     plainText: markdown,
     anchorOffset: markdown.length,
     focusOffset: markdown.length,
+    selectionInCodeBlock: false,
   });
   const plainText = editorContext.plainText;
   const [searchSuppressed, setSearchSuppressed] = useState(false);
   const trigger = useMemo(() => (
-    searchSuppressed || disabled
+    searchSuppressed || disabled || editorContext.selectionInCodeBlock
       ? null
       : findComposerMenuTrigger(plainText, editorContext.focusOffset)
-  ), [disabled, editorContext.focusOffset, plainText, searchSuppressed]);
+  ), [
+    disabled,
+    editorContext.focusOffset,
+    editorContext.selectionInCodeBlock,
+    plainText,
+    searchSuppressed,
+  ]);
   commandTriggerRef.current = trigger;
   const slashTrigger = trigger?.kind === "slash" ? trigger : null;
   const mentionTrigger = trigger?.kind === "mention" ? trigger : null;
@@ -128,7 +135,7 @@ export function ComposerCommandEditor({
   // already followed it is absorbed so completing a trigger never leaves a
   // double space behind.
   const replaceEndFor = useCallback((activeTrigger: ComposerMenuTrigger) => (
-    /\s/u.test(plainText[activeTrigger.end] ?? "")
+    plainText[activeTrigger.end] === " "
       ? activeTrigger.end + 1
       : activeTrigger.end
   ), [plainText]);
@@ -203,7 +210,7 @@ export function ComposerCommandEditor({
   const handleCommandKey = useCallback((event: KeyboardEvent) => {
     if (!editorRef.current || event.defaultPrevented || event.isComposing) return false;
     const context = getComposerEditorContext(editorRef.current);
-    const activeTrigger = searchSuppressed || disabled
+    const activeTrigger = searchSuppressed || disabled || context.selectionInCodeBlock
       ? null
       : findComposerMenuTrigger(context.plainText, context.focusOffset);
     commandTriggerRef.current = activeTrigger;

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerEditorDocument.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerEditorDocument.tsx
@@ -1,9 +1,12 @@
 import {
+  $createParagraphNode,
   $createRangeSelection,
   $getRoot,
   $getSelection,
+  $isElementNode,
   $isRangeSelection,
   $setSelection,
+  type ElementNode,
   type LexicalEditor,
   type LexicalNode,
   type RangeSelection,
@@ -27,6 +30,10 @@ import {
   COMPOSER_FILE_MENTION_TRANSFORMER,
   ComposerFileMentionNode,
 } from "#product/components/workspace/chat/input/ComposerFileMentionNode";
+import {
+  COMPOSER_CODE_TRANSFORMER,
+  isComposerOffsetInsideOpenCodeFence,
+} from "#product/components/workspace/chat/input/ComposerCodeFenceMarkdown";
 
 /**
  * The composer's document model: which node types exist in a draft, how markdown
@@ -38,6 +45,7 @@ import {
  * and none of it needs React.
  */
 export const COMPOSER_NODES = [
+  ...COMPOSER_CODE_TRANSFORMER.dependencies,
   ListNode,
   ListItemNode,
   LinkNode,
@@ -47,12 +55,14 @@ export const COMPOSER_NODES = [
 /**
  * Markdown recognized while editing.
  *
- * Emphasis and lists become real nodes as the user types. A workspace file link
- * becomes a mention chip. A web link is intentionally absent, so
+ * Emphasis, lists, and complete fenced code blocks become real nodes as the
+ * user types. A workspace file link becomes a mention chip. A web link is
+ * intentionally absent, so
  * `[Docs](https://example.com)` typed into the draft stays literal text — the
  * paste plugin, not typing, is what creates web links.
  */
 export const COMPOSER_INPUT_TRANSFORMERS: Transformer[] = [
+  COMPOSER_CODE_TRANSFORMER,
   UNORDERED_LIST,
   ORDERED_LIST,
   BOLD_ITALIC_STAR,
@@ -74,6 +84,7 @@ export interface ComposerEditorContext {
   plainText: string;
   anchorOffset: number;
   focusOffset: number;
+  selectionInCodeBlock: boolean;
 }
 
 /**
@@ -87,19 +98,83 @@ export function readComposerEditorContext(): ComposerEditorContext {
   const selection = $getSelection();
   const plainText = $getRoot().getTextContent();
   if (!$isRangeSelection(selection)) {
-    return { plainText, anchorOffset: plainText.length, focusOffset: plainText.length };
+    return {
+      plainText,
+      anchorOffset: plainText.length,
+      focusOffset: plainText.length,
+      selectionInCodeBlock: false,
+    };
   }
   return {
     plainText,
     anchorOffset: globalPointOffset(selection.anchor.getNode(), selection.anchor.offset),
     focusOffset: globalPointOffset(selection.focus.getNode(), selection.focus.offset),
+    selectionInCodeBlock: isComposerSelectionPointInsideCode(
+      selection.focus.getNode(),
+      selection.focus.offset,
+    ),
   };
 }
 
 export function getComposerEditorContext(editor: LexicalEditor): ComposerEditorContext {
-  let context: ComposerEditorContext = { plainText: "", anchorOffset: 0, focusOffset: 0 };
+  let context: ComposerEditorContext = {
+    plainText: "",
+    anchorOffset: 0,
+    focusOffset: 0,
+    selectionInCodeBlock: false,
+  };
   editor.getEditorState().read(() => { context = readComposerEditorContext(); });
   return context;
+}
+
+export function isComposerNodeInsideCodeBlock(node: LexicalNode): boolean {
+  let current: LexicalNode | null = node;
+  while (current) {
+    if (current.getType() === "code") return true;
+    current = current.getParent();
+  }
+  return false;
+}
+
+export function isComposerSelectionPointInsideCode(
+  node: LexicalNode,
+  offset: number,
+): boolean {
+  if (isComposerNodeInsideCodeBlock(node)) return true;
+
+  let paragraph: LexicalNode | null = node;
+  while (paragraph?.getParent()?.getType() !== "root") {
+    paragraph = paragraph?.getParent() ?? null;
+  }
+  if (!paragraph || paragraph.getType() !== "paragraph") return false;
+
+  const pointOffset = offsetWithinNode(node, offset, paragraph);
+  return pointOffset !== null && isComposerOffsetInsideOpenCodeFence(
+    paragraph.getTextContent(),
+    pointOffset,
+  );
+}
+
+/** Moves the caret after an imported block so normal typing can continue. */
+export function selectComposerContinuationAfter(nodes: readonly LexicalNode[]) {
+  const lastNode = nodes[nodes.length - 1];
+  if (!lastNode) return;
+  if (lastNode.getType() !== "code") {
+    $setSelection(null);
+    lastNode.selectEnd();
+    return;
+  }
+
+  const nextNode = lastNode.getNextSibling();
+  if (nextNode) {
+    $setSelection(null);
+    nextNode.selectStart();
+    return;
+  }
+  const continuation = $createParagraphNode();
+  lastNode.insertAfter(continuation);
+  $setSelection(null);
+  continuation.selectStart();
 }
 
 export function replaceComposerTextRange(
@@ -151,22 +226,77 @@ function replaceComposerRange(
 }
 
 function globalPointOffset(node: LexicalNode, localOffset: number): number {
-  let offset = 0;
-  for (const textNode of $getRoot().getAllTextNodes()) {
-    if (textNode.is(node)) return offset + localOffset;
-    offset += textNode.getTextContentSize();
+  return offsetWithinNode(node, localOffset, $getRoot())
+    ?? $getRoot().getTextContentSize();
+}
+
+function offsetWithinNode(
+  node: LexicalNode,
+  localOffset: number,
+  ancestor: LexicalNode,
+): number | null {
+  let current: LexicalNode | null = node;
+  let offset = $isElementNode(node)
+    ? textSizeBeforeChild(node, localOffset)
+    : localOffset;
+  while (current && !current.is(ancestor)) {
+    for (const sibling of current.getPreviousSiblings()) {
+      offset += sibling.getTextContentSize();
+      if ($isElementNode(sibling) && !sibling.isInline()) offset += 2;
+    }
+    current = current.getParent();
   }
-  return offset;
+  return current ? offset : null;
 }
 
 function pointAtOffset(offset: number): { node: TextNode; offset: number } | null {
-  const nodes = $getRoot().getAllTextNodes();
   let traversed = 0;
-  for (const node of nodes) {
-    const end = traversed + node.getTextContentSize();
-    if (offset <= end) return { node, offset: Math.max(0, offset - traversed) };
+  let point: { node: TextNode; offset: number } | null = null;
+  const visit = (node: LexicalNode) => {
+    if (point) return;
+    if ($isElementNode(node)) {
+      const children = node.getChildren();
+      for (let index = 0; index < children.length; index += 1) {
+        const child = children[index]!;
+        visit(child);
+        if (point) return;
+        if (
+          index < children.length - 1
+          && $isElementNode(child)
+          && !child.isInline()
+        ) traversed += 2;
+      }
+      return;
+    }
+    if (node.getType() !== "text") {
+      traversed += node.getTextContentSize();
+      return;
+    }
+    const textNode = node as TextNode;
+    const end = traversed + textNode.getTextContentSize();
+    if (offset >= traversed && offset <= end) {
+      point = { node: textNode, offset: offset - traversed };
+    }
     traversed = end;
-  }
-  const last = nodes[nodes.length - 1];
+  };
+  visit($getRoot());
+  if (point) return point;
+  const textNodes = $getRoot().getAllTextNodes();
+  const last = textNodes[textNodes.length - 1];
   return last ? { node: last, offset: last.getTextContentSize() } : null;
+}
+
+function textSizeBeforeChild(node: ElementNode, end: number) {
+  const children = node.getChildren();
+  let size = 0;
+  for (let index = 0; index < Math.min(end, children.length); index += 1) {
+    const child = children[index]!;
+    size += child.getTextContentSize();
+    if (
+      index < children.length - 1
+      && $isElementNode(child)
+      && !child.isInline()
+    ) size += 2;
+  }
+  return size;
 }

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerFencedCodePlugin.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerFencedCodePlugin.test.tsx
@@ -1,0 +1,359 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  KEY_ENTER_COMMAND,
+  type LexicalEditor,
+} from "lexical";
+import {
+  ComposerRichTextEditor,
+  type ComposerRichTextEditorProps,
+} from "#product/components/workspace/chat/input/ComposerRichTextEditor";
+import { getComposerEditorContext } from "#product/components/workspace/chat/input/ComposerEditorDocument";
+
+let originalRangeRectDescriptor: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  originalRangeRectDescriptor = Object.getOwnPropertyDescriptor(
+    Range.prototype,
+    "getBoundingClientRect",
+  );
+  vi.stubGlobal("DragEvent", class DragEvent extends Event {});
+  vi.stubGlobal("ClipboardEvent", class ClipboardEvent extends Event {});
+  vi.spyOn(window, "scrollBy").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  if (originalRangeRectDescriptor === undefined) {
+    Reflect.deleteProperty(Range.prototype, "getBoundingClientRect");
+  } else {
+    Object.defineProperty(
+      Range.prototype,
+      "getBoundingClientRect",
+      originalRangeRectDescriptor,
+    );
+  }
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("ComposerFencedCodePlugin", () => {
+  it("promotes a typed code fence only after its matching close fence", async () => {
+    const onChange = vi.fn();
+    const onSubmit = vi.fn();
+    const harness = renderEditor({ value: "", onChange, onSubmit });
+    await harness.ready();
+    act(() => resetText(harness.editor, ""));
+    onChange.mockClear();
+
+    fireEvent.keyDown(harness.root, { key: "b", ctrlKey: true });
+    await typeCharacters(harness.editor, "intro", harness.root);
+    fireEvent.keyDown(harness.root, { key: "b", ctrlKey: true });
+    insertSoftLineBreak(harness.editor);
+    await typeCharacters(harness.editor, "``` ", harness.root);
+    expect(harness.root.querySelector('code[spellcheck="false"]')).toBeNull();
+    insertSoftLineBreak(harness.editor);
+    await typeCharacters(harness.editor, "const ready = true;", harness.root);
+    insertSoftLineBreak(harness.editor);
+    await typeCharacters(harness.editor, "``", harness.root);
+    expect(harness.root.querySelector('code[spellcheck="false"]')).toBeNull();
+
+    await typeCharacters(harness.editor, "`", harness.root);
+    const codeBlock = await waitFor(() => {
+      const code = harness.root.querySelector<HTMLElement>('code[spellcheck="false"]');
+      expect(code).toBeTruthy();
+      return code!;
+    });
+
+    expect(codeBlock.textContent).toBe("const ready = true;");
+    expect(harness.root.textContent).toContain("intro");
+    expect(harness.root.querySelector(".font-semibold")?.textContent).toBe("intro");
+    expect(codeBlock.className).toContain("font-mono");
+    expect(getComposerEditorContext(harness.editor).selectionInCodeBlock).toBe(false);
+    expect(harness.editor.getEditorState().read(() => {
+      const selection = $getSelection();
+      return $isRangeSelection(selection) && selection.focus.getNode().isAttached();
+    })).toBe(true);
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe(
+      "**intro**\n\n```\nconst ready = true;\n```\n",
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    await typeCharacters(harness.editor, "after", harness.root);
+    expect(harness.root.querySelector("p:last-child")?.textContent).toBe("after");
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe(
+      "**intro**\n\n```\nconst ready = true;\n```\n\nafter",
+    );
+
+    act(() => {
+      harness.editor.update(() => {
+        $getRoot().getChildren().find((node) => node.getType() === "code")?.selectEnd();
+      }, { discrete: true });
+    });
+    expect(getComposerEditorContext(harness.editor).selectionInCodeBlock).toBe(true);
+    insertSoftLineBreak(harness.editor);
+    await waitFor(() => expect(codeBlock.querySelector("br")).toBeTruthy());
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    act(() => {
+      harness.editor.dispatchCommand(KEY_ENTER_COMMAND, keyEvent("Enter"));
+      harness.editor.dispatchCommand(
+        KEY_ENTER_COMMAND,
+        keyEvent("Enter", { ctrlKey: true }),
+      );
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+  });
+
+  it("restores only fully closed fenced Markdown as a code block", async () => {
+    const closed = renderEditor({ value: "```c++\nconst ready = true;\n```" });
+    await closed.ready();
+    expect(closed.root.querySelector('code[data-language="c++"]')?.textContent).toBe(
+      "const ready = true;",
+    );
+
+    cleanup();
+    const unclosed = renderEditor({ value: "```\nconst ready = true;" });
+    await unclosed.ready();
+    expect(unclosed.root.querySelector('code[spellcheck="false"]')).toBeNull();
+    expect(unclosed.root.textContent).toContain("```");
+    expect(unclosed.root.textContent).toContain("const ready = true;");
+  });
+
+  it("promotes a restored incomplete fence after a blank line is closed", async () => {
+    const harness = renderEditor({ value: "```\nfirst\n\nsecond" });
+    await harness.ready();
+    expect(harness.root.querySelector("code")).toBeNull();
+    act(() => {
+      harness.editor.update(() => { $getRoot().selectEnd(); }, { discrete: true });
+    });
+
+    insertSoftLineBreak(harness.editor);
+    await typeCharacters(harness.editor, "```", harness.root);
+
+    const codeBlock = await waitFor(() => {
+      const next = harness.root.querySelector<HTMLElement>("code");
+      expect(next).toBeTruthy();
+      return next!;
+    });
+    expect(codeBlock.textContent).toBe("first\n\nsecond");
+  });
+
+  it("imports a complete pasted code fence as an editable Markdown block", async () => {
+    const onChange = vi.fn();
+    const harness = renderEditor({ value: "", onChange });
+    await harness.ready();
+    act(() => resetText(harness.editor, ""));
+    onChange.mockClear();
+    const markdown = "```ts\nconst ready = true;\n```";
+    const event = pasteEvent(markdown);
+
+    act(() => { fireEvent(harness.root, event); });
+
+    const codeBlock = await waitFor(() => {
+      const code = harness.root.querySelector<HTMLElement>('code[data-language="ts"]');
+      expect(code).toBeTruthy();
+      return code!;
+    });
+    expect(event.defaultPrevented).toBe(true);
+    expect(codeBlock.textContent).toBe("const ready = true;");
+    expect(getComposerEditorContext(harness.editor).selectionInCodeBlock).toBe(false);
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe(`${markdown}\n`);
+  });
+
+  it("keeps an incomplete pasted fence completable after blank lines", async () => {
+    const onChange = vi.fn();
+    const harness = renderEditor({ value: "", onChange });
+    await harness.ready();
+    act(() => resetText(harness.editor, ""));
+    onChange.mockClear();
+    const markdown = "```ts\nfirst\n\nsecond";
+    const event = pasteEvent(markdown);
+
+    act(() => { fireEvent(harness.root, event); });
+
+    await waitFor(() => expect(onChange.mock.calls.at(-1)?.[0]).toBe(
+      "\\`\\`\\`ts\nfirst\n\nsecond",
+    ));
+    expect(event.defaultPrevented).toBe(true);
+    expect(harness.root.querySelector("code")).toBeNull();
+    expect(harness.root.querySelectorAll("p")).toHaveLength(1);
+    expect(getComposerEditorContext(harness.editor).selectionInCodeBlock).toBe(true);
+
+    insertSoftLineBreak(harness.editor);
+    await typeCharacters(harness.editor, "```", harness.root);
+
+    const codeBlock = await waitFor(() => {
+      const code = harness.root.querySelector<HTMLElement>('code[data-language="ts"]');
+      expect(code).toBeTruthy();
+      return code!;
+    });
+    expect(codeBlock.textContent).toBe("first\n\nsecond");
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe(`${markdown}\n\`\`\`\n`);
+  });
+
+  it("keeps formatted paste literal while an opening fence is incomplete", async () => {
+    const onChange = vi.fn();
+    const harness = renderEditor({ value: "", onChange });
+    await harness.ready();
+    act(() => resetText(harness.editor, ""));
+    onChange.mockClear();
+    await typeCharacters(harness.editor, "```", harness.root);
+    insertSoftLineBreak(harness.editor);
+    expect(getComposerEditorContext(harness.editor).selectionInCodeBlock).toBe(true);
+    await typeCharacters(
+      harness.editor,
+      "**literal** [file](src/file.ts) ",
+      harness.root,
+    );
+    expect(harness.root.querySelector(".font-semibold")).toBeNull();
+    expect(harness.root.querySelector("[data-composer-file-mention]")).toBeNull();
+    const filePaste = pasteEvent("", [
+      new File(["image"], "screenshot.png", { type: "image/png" }),
+    ]);
+    act(() => { fireEvent(harness.root, filePaste); });
+    expect(filePaste.defaultPrevented).toBe(false);
+    insertSoftLineBreak(harness.editor);
+    const plainPaste = pasteEvent("const plain = true;");
+    act(() => { fireEvent(harness.root, plainPaste); });
+    await waitFor(() => expect(harness.root.textContent).toContain("const plain = true;"));
+    expect(plainPaste.defaultPrevented).toBe(true);
+    insertSoftLineBreak(harness.editor);
+    const pastedCode = "- item\n[Docs](https://example.com)\nhttps://example.com";
+    const event = pasteEvent(pastedCode);
+
+    act(() => { fireEvent(harness.root, event); });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(harness.root.querySelector("ul")).toBeNull();
+    expect(harness.root.querySelector("a")).toBeNull();
+    await waitFor(() => {
+      expect(harness.root.textContent).toContain("[Docs](https://example.com)");
+    });
+
+    insertSoftLineBreak(harness.editor);
+    await typeCharacters(harness.editor, "```", harness.root);
+    const codeBlock = await waitFor(() => {
+      const next = harness.root.querySelector<HTMLElement>("code");
+      expect(next).toBeTruthy();
+      return next!;
+    });
+    const code = [
+      "**literal** [file](src/file.ts) ",
+      "const plain = true;",
+      pastedCode,
+    ].join("\n");
+    expect(codeBlock.textContent).toBe(code);
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe(`\`\`\`\n${code}\n\`\`\`\n`);
+  });
+
+  it("keeps formatted Markdown paste literal inside a code block", async () => {
+    const onChange = vi.fn();
+    const harness = renderEditor({
+      value: "```\nconst docs = \"\";\n```",
+      onChange,
+    });
+    await harness.ready();
+    act(() => {
+      harness.editor.update(() => {
+        $getRoot().getFirstChild()?.selectEnd();
+      }, { discrete: true });
+    });
+    onChange.mockClear();
+    const markdownLink = "[Docs](https://example.com)";
+
+    act(() => { fireEvent(harness.root, pasteEvent(markdownLink)); });
+
+    await waitFor(() => {
+      expect(harness.root.querySelector("code")?.textContent).toContain(markdownLink);
+    });
+    expect(harness.root.querySelector("code a")).toBeNull();
+    expect(onChange.mock.calls.at(-1)?.[0]).toContain(markdownLink);
+  });
+});
+
+function renderEditor(overrides: Partial<ComposerRichTextEditorProps> = {}) {
+  let editor: LexicalEditor | null = null;
+  const props: ComposerRichTextEditorProps = {
+    value: "seed",
+    onChange: vi.fn(),
+    canSubmit: true,
+    onSubmit: vi.fn(),
+    placeholder: "Message",
+    disabled: false,
+    editorRef: (next) => { editor = next; },
+    ...overrides,
+  };
+  const { container } = render(<ComposerRichTextEditor {...props} />);
+  return {
+    get editor() { return editor!; },
+    root: container.querySelector<HTMLElement>("[data-chat-composer-editor]")!,
+    ready: () => waitFor(() => expect(editor).toBeTruthy()),
+  };
+}
+
+function resetText(editor: LexicalEditor, text: string) {
+  editor.update(() => {
+    const paragraph = $createParagraphNode();
+    if (text) paragraph.append($createTextNode(text));
+    $getRoot().clear().append(paragraph);
+    paragraph.selectEnd();
+  }, { discrete: true });
+}
+
+function insertText(editor: LexicalEditor, text: string) {
+  editor.update(() => {
+    const selection = $getSelection();
+    if ($isRangeSelection(selection)) selection.insertText(text);
+  }, { discrete: true });
+}
+
+async function typeCharacters(
+  editor: LexicalEditor,
+  text: string,
+  root?: HTMLElement,
+) {
+  for (const character of text) {
+    if (root) {
+      fireEvent(root, new InputEvent("beforeinput", {
+        bubbles: true,
+        data: character,
+        inputType: "insertText",
+      }));
+    }
+    act(() => insertText(editor, character));
+    await Promise.resolve();
+  }
+}
+
+function insertSoftLineBreak(editor: LexicalEditor) {
+  act(() => {
+    editor.dispatchCommand(
+      KEY_ENTER_COMMAND,
+      keyEvent("Enter", { shiftKey: true }),
+    );
+  });
+}
+
+function keyEvent(key: string, init: KeyboardEventInit = {}): KeyboardEvent {
+  return new KeyboardEvent("keydown", { key, bubbles: true, ...init });
+}
+
+function pasteEvent(text: string, files: File[] = []): ClipboardEvent {
+  const event = new ClipboardEvent("paste", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "clipboardData", {
+    value: {
+      files,
+      getData: (type: string) => type === "text/plain" ? text : "",
+      types: files.length > 0 ? ["Files"] : ["text/plain"],
+    },
+  });
+  return event;
+}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerFencedCodePlugin.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerFencedCodePlugin.tsx
@@ -1,0 +1,77 @@
+import { useEffect } from "react";
+import {
+  $addUpdateTag,
+  $createParagraphNode,
+  $isLineBreakNode,
+  $isParagraphNode,
+  HISTORY_PUSH_TAG,
+  type LexicalNode,
+  TextNode,
+} from "lexical";
+import { $generateNodesFromMarkdownString } from "@lexical/markdown";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  COMPOSER_CODE_TRANSFORMER,
+  findCompleteComposerCodeFence,
+} from "#product/components/workspace/chat/input/ComposerCodeFenceMarkdown";
+import {
+  selectComposerContinuationAfter,
+} from "#product/components/workspace/chat/input/ComposerEditorDocument";
+
+/** Promotes a typed Markdown fence only after its matching close fence exists. */
+export function ComposerFencedCodePlugin() {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => editor.registerNodeTransform(TextNode, (textNode) => {
+    const paragraph = textNode.getParent();
+    if (!$isParagraphNode(paragraph) || paragraph.getParent()?.getType() !== "root") {
+      return;
+    }
+    const markdown = paragraph.getTextContent();
+    const fence = findCompleteComposerCodeFence(markdown);
+    if (!fence) return;
+
+    const importedNodes = $generateNodesFromMarkdownString(
+      fence.markdown,
+      [COMPOSER_CODE_TRANSFORMER],
+    );
+    const codeNode = importedNodes.length === 1 ? importedNodes[0] : null;
+    if (!codeNode || codeNode.getType() !== "code") return;
+
+    const children = paragraph.getChildren();
+    const fenceStart = childBoundaryAtOffset(children, fence.start);
+    const fenceEnd = childBoundaryAtOffset(children, fence.end);
+    if (fenceStart === null || fenceEnd === null) return;
+
+    let replaceStart = fenceStart;
+    let replaceEnd = fenceEnd;
+    if ($isLineBreakNode(children[replaceStart - 1])) replaceStart -= 1;
+    if ($isLineBreakNode(children[replaceEnd])) replaceEnd += 1;
+
+    const suffixChildren = children.slice(replaceEnd);
+    const suffix = suffixChildren.length > 0 ? $createParagraphNode() : null;
+    suffix?.append(...suffixChildren);
+    for (const child of children.slice(replaceStart, replaceEnd)) child.remove();
+
+    if (paragraph.isEmpty()) paragraph.replace(codeNode);
+    else paragraph.insertAfter(codeNode);
+    if (suffix) codeNode.insertAfter(suffix);
+    selectComposerContinuationAfter([codeNode]);
+    $addUpdateTag(HISTORY_PUSH_TAG);
+  }), [editor]);
+
+  return null;
+}
+
+function childBoundaryAtOffset(
+  children: readonly LexicalNode[],
+  targetOffset: number,
+): number | null {
+  let traversed = 0;
+  for (let index = 0; index < children.length; index += 1) {
+    if (targetOffset === traversed) return index;
+    traversed += children[index]!.getTextContentSize();
+    if (targetOffset === traversed) return index + 1;
+  }
+  return targetOffset === traversed ? children.length : null;
+}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerLinkPastePlugin.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerLinkPastePlugin.tsx
@@ -6,6 +6,7 @@ import {
   $isRangeSelection,
   COMMAND_PRIORITY_HIGH,
   PASTE_COMMAND,
+  type RangeSelection,
 } from "lexical";
 import { $createLinkNode, $toggleLink } from "@lexical/link";
 import {
@@ -13,6 +14,14 @@ import {
   type Transformer,
 } from "@lexical/markdown";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  containsCompleteComposerCodeFence,
+  isComposerOffsetInsideOpenCodeFence,
+} from "#product/components/workspace/chat/input/ComposerCodeFenceMarkdown";
+import {
+  isComposerSelectionPointInsideCode,
+  selectComposerContinuationAfter,
+} from "#product/components/workspace/chat/input/ComposerEditorDocument";
 
 const EXACT_HTTPS_URL = /^https:\/\/[^\s]+$/u;
 const MARKDOWN_HTTPS_LINK =
@@ -67,8 +76,19 @@ export function isComposerMarkdownListPaste(value: string): boolean {
   return MARKDOWN_LIST_ITEM.test(value);
 }
 
+export function isComposerMarkdownCodeBlockPaste(value: string): boolean {
+  return containsCompleteComposerCodeFence(value);
+}
+
+function isComposerIncompleteCodeFencePaste(value: string): boolean {
+  return isComposerOffsetInsideOpenCodeFence(value, value.length);
+}
+
 export function isComposerFormattedPaste(value: string): boolean {
-  return isComposerLinkPaste(value) || isComposerMarkdownListPaste(value);
+  return isComposerLinkPaste(value)
+    || isComposerMarkdownListPaste(value)
+    || isComposerMarkdownCodeBlockPaste(value)
+    || isComposerIncompleteCodeFencePaste(value);
 }
 
 export function ComposerLinkPastePlugin({
@@ -82,14 +102,29 @@ export function ComposerLinkPastePlugin({
     const unregisterCommand = editor.registerCommand(PASTE_COMMAND, (event) => {
       if (event.defaultPrevented) return false;
       const clipboard = "clipboardData" in event ? event.clipboardData : null;
+      if ((clipboard?.files?.length ?? 0) > 0) return false;
       const value = clipboard?.getData("text/plain") ?? "";
+      const selection = $getSelection();
+      if (!$isRangeSelection(selection)) return false;
+      if (composerSelectionIsInsideCode(selection)) {
+        event.preventDefault();
+        selection.insertRawText(value);
+        return true;
+      }
+
       const markdownParts = parseMarkdownHttpsComposerPaste(value);
       const isExactUrl = isExactHttpsComposerPaste(value);
       const isMarkdownList = isComposerMarkdownListPaste(value);
-      if (!isExactUrl && markdownParts === null && !isMarkdownList) return false;
+      const isMarkdownCodeBlock = isComposerMarkdownCodeBlockPaste(value);
+      const isIncompleteCodeFence = isComposerIncompleteCodeFencePaste(value);
+      if (
+        !isExactUrl
+        && markdownParts === null
+        && !isMarkdownList
+        && !isMarkdownCodeBlock
+        && !isIncompleteCodeFence
+      ) return false;
 
-      const selection = $getSelection();
-      if (!$isRangeSelection(selection)) return false;
       event.preventDefault();
 
       if (isExactUrl) {
@@ -104,17 +139,16 @@ export function ComposerLinkPastePlugin({
         return true;
       }
 
-      // A pasted Markdown list is an authored block, not a typed shortcut in
-      // progress. Import the complete fragment so list structure and any inline
-      // emphasis/links arrive together. Typed Markdown still follows the normal
-      // shortcut contract because this path is paste-only.
-      if (isMarkdownList) {
+      // Import authored block fragments together. The code transformer keeps
+      // an incomplete fence in one paragraph with soft line breaks, so typing
+      // its closing fence later can still promote the whole fragment.
+      if (isMarkdownList || isMarkdownCodeBlock || isIncompleteCodeFence) {
         const nodes = $generateNodesFromMarkdownString(
           value,
           markdownTransformers,
         );
         $insertNodes(nodes);
-        nodes[nodes.length - 1]?.selectEnd();
+        selectComposerContinuationAfter(nodes);
         return true;
       }
 
@@ -135,8 +169,15 @@ export function ComposerLinkPastePlugin({
     // Lexical already handled the event.
     const handleNativePaste = (event: ClipboardEvent) => {
       if (event.defaultPrevented) return;
+      if ((event.clipboardData?.files?.length ?? 0) > 0) return;
       const value = event.clipboardData?.getData("text/plain") ?? "";
-      if (!isComposerFormattedPaste(value)) return;
+      let selectionInsideCode = false;
+      editor.getEditorState().read(() => {
+        const selection = $getSelection();
+        selectionInsideCode = $isRangeSelection(selection)
+          && composerSelectionIsInsideCode(selection);
+      });
+      if (!selectionInsideCode && !isComposerFormattedPaste(value)) return;
       if (editor.dispatchCommand(PASTE_COMMAND, event)) {
         event.stopPropagation();
       }
@@ -153,4 +194,16 @@ export function ComposerLinkPastePlugin({
   }, [editor, markdownTransformers]);
 
   return null;
+}
+
+function composerSelectionIsInsideCode(
+  selection: RangeSelection,
+): boolean {
+  return isComposerSelectionPointInsideCode(
+    selection.anchor.getNode(),
+    selection.anchor.offset,
+  ) || isComposerSelectionPointInsideCode(
+    selection.focus.getNode(),
+    selection.focus.offset,
+  );
 }

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerMarkdownShortcutPlugin.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerMarkdownShortcutPlugin.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+import { $getSelection, $isRangeSelection } from "lexical";
+import {
+  registerMarkdownShortcuts,
+  type Transformer,
+} from "@lexical/markdown";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { isComposerSelectionPointInsideCode } from "#product/components/workspace/chat/input/ComposerEditorDocument";
+
+/** Keeps Markdown shortcuts literal while a structural or raw fence owns the caret. */
+export function ComposerMarkdownShortcutPlugin({
+  transformers,
+}: {
+  transformers: Transformer[];
+}) {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    let removeShortcuts: (() => void) | null = registerMarkdownShortcuts(
+      editor,
+      transformers,
+    );
+    const syncShortcuts = () => {
+      const shouldEnable = editor.getEditorState().read(() => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) return true;
+        return !isComposerSelectionPointInsideCode(
+          selection.anchor.getNode(),
+          selection.anchor.offset,
+        ) && !isComposerSelectionPointInsideCode(
+          selection.focus.getNode(),
+          selection.focus.offset,
+        );
+      });
+      if (shouldEnable && !removeShortcuts) {
+        removeShortcuts = registerMarkdownShortcuts(editor, transformers);
+      } else if (!shouldEnable && removeShortcuts) {
+        removeShortcuts();
+        removeShortcuts = null;
+      }
+    };
+
+    const removeRootListener = editor.registerRootListener((root, previousRoot) => {
+      previousRoot?.removeEventListener("beforeinput", syncShortcuts, true);
+      root?.addEventListener("beforeinput", syncShortcuts, true);
+    });
+    return () => {
+      removeRootListener();
+      removeShortcuts?.();
+    };
+  }, [editor, transformers]);
+
+  return null;
+}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
@@ -20,10 +20,10 @@ import { ContentEditable } from "@lexical/react/LexicalContentEditable";
 import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
 import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
 import { ListPlugin } from "@lexical/react/LexicalListPlugin";
-import { MarkdownShortcutPlugin } from "@lexical/react/LexicalMarkdownShortcutPlugin";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { ComposerCaretPlugin } from "#product/components/workspace/chat/input/ComposerCaretPlugin";
+import { ComposerFencedCodePlugin } from "#product/components/workspace/chat/input/ComposerFencedCodePlugin";
 import {
   COMPOSER_INPUT_TRANSFORMERS,
   COMPOSER_NODES,
@@ -32,6 +32,7 @@ import {
   type ComposerEditorContext,
 } from "#product/components/workspace/chat/input/ComposerEditorDocument";
 import { ComposerLinkPastePlugin } from "#product/components/workspace/chat/input/ComposerLinkPastePlugin";
+import { ComposerMarkdownShortcutPlugin } from "#product/components/workspace/chat/input/ComposerMarkdownShortcutPlugin";
 import { CHAT_TRANSCRIPT_LINK_CLASS } from "#product/config/transcript-link-styles";
 import type { ComposerKeyboardEventLike } from "#product/lib/domain/chat/composer/composer-keyboard";
 import type { ChatComposerEditorSnapshot } from "#product/lib/domain/chat/composer/file-mention-draft-model";
@@ -89,6 +90,7 @@ export function ComposerRichTextEditor({
     theme: {
       paragraph: "m-0 min-h-[1lh]",
       text: { bold: "font-semibold", italic: "italic" },
+      code: "box-border my-2 block w-full min-w-0 max-w-full overflow-x-auto whitespace-pre rounded-lg border border-transparent bg-[var(--color-code-block-background,var(--color-card))] p-3 font-mono text-chat font-normal text-foreground",
       list: {
         ul: "list-disc pl-5",
         ol: "list-decimal pl-5",
@@ -163,7 +165,8 @@ export function ComposerRichTextEditor({
       </div>
       <HistoryPlugin />
       <ListPlugin />
-      <MarkdownShortcutPlugin transformers={INPUT_TRANSFORMERS} />
+      <ComposerMarkdownShortcutPlugin transformers={INPUT_TRANSFORMERS} />
+      <ComposerFencedCodePlugin />
       <ComposerBehaviorPlugin
         canSubmit={canSubmit}
         onSubmit={onSubmit}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.test.tsx
@@ -88,6 +88,22 @@ describe("MarkdownBody presentation", () => {
     expect(highlightedHtml).toContain('data-markdown-code-content="true"');
   });
 
+  it("renders an unlabeled single-line fence as a code block", () => {
+    const html = renderMarkdown("```\nconst ready = true;\n```");
+
+    expect(html).toContain('data-markdown-code-block="true"');
+    expect(html).toContain("const ready = true;");
+    expect(html).not.toContain('data-markdown-inline-code="true"');
+  });
+
+  it("keeps an empty fence distinct from inline code", () => {
+    const html = renderMarkdown("```\n```");
+
+    expect(html).toContain('data-markdown-code-block="true"');
+    expect(html).not.toContain('data-markdown-inline-code="true"');
+    expect(html).not.toContain("undefined");
+  });
+
   it("preserves injected workspace links while stabilizing only the render copy", () => {
     const source = "Open [config](/tmp/project/config";
     const renderLink = vi.fn(({ href }: MarkdownLinkRenderInput) => (

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.tsx
@@ -1,6 +1,7 @@
 import {
   Children,
   cloneElement,
+  createContext,
   createElement,
   isValidElement,
   memo,
@@ -130,6 +131,8 @@ type MdCodeProps = MdElementProps & {
   renderCodeBlock?: MarkdownCodeBlockRenderer;
 };
 
+const MarkdownCodeBlockContext = createContext(false);
+
 // Message prose reads at --prose-text-size, which the assistant/user message
 // wrappers set to --text-message (the composer size). Every other MarkdownBody
 // context — tool-row detail bodies, plan cards, work history — leaves the var
@@ -210,7 +213,11 @@ const STATIC_MARKDOWN_COMPONENTS = {
     if (dangerouslySetInnerHTML) {
       return <pre {...rest} dangerouslySetInnerHTML={dangerouslySetInnerHTML} />;
     }
-    return <>{children}</>;
+    return (
+      <MarkdownCodeBlockContext.Provider value>
+        {children}
+      </MarkdownCodeBlockContext.Provider>
+    );
   },
 };
 
@@ -443,6 +450,7 @@ function MarkdownCode({
   node: _node,
   ...rest
 }: MdCodeProps) {
+  const isCodeBlock = useContext(MarkdownCodeBlockContext);
   if (dangerouslySetInnerHTML) {
     return (
       <code
@@ -453,9 +461,9 @@ function MarkdownCode({
       />
     );
   }
-  const match = /language-(\w+)/.exec(codeClassName || "");
-  const codeString = String(children).replace(/\n$/, "");
-  if (match || codeString.includes("\n")) {
+  const match = /language-([^\s]+)/.exec(codeClassName || "");
+  const codeString = String(children ?? "").replace(/\n$/, "");
+  if (isCodeBlock || match) {
     const language = match?.[1] ?? null;
     const renderedCodeBlock = renderCodeBlock?.({ code: codeString, language });
     if (renderedCodeBlock !== null && renderedCodeBlock !== undefined) {

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/UserMessage.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/UserMessage.test.tsx
@@ -85,6 +85,22 @@ describe("UserMessage", () => {
     expect(container.querySelector("[data-file-path-link]")?.textContent).toContain("file");
   });
 
+  it("renders an unlabeled single-line fence as a code block in the sent bubble", () => {
+    const { container } = render(
+      <UserMessage
+        sessionId="session-1"
+        content={"```\nconst ready = true;\n```"}
+        contentParts={[]}
+      />,
+    );
+
+    expect(container.querySelector('[data-markdown-code-block="true"]')).toBeTruthy();
+    expect(container.querySelector('[data-markdown-inline-code="true"]')).toBeNull();
+    expect(container.querySelector("[data-markdown-code-content]")?.textContent).toContain(
+      "const ready = true;",
+    );
+  });
+
   it("does not execute raw HTML or unsafe Markdown links", () => {
     const { container } = render(
       <UserMessage

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-input-paste.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-input-paste.ts
@@ -1,0 +1,41 @@
+import { useCallback, type ClipboardEvent } from "react";
+import type { PromptAttachmentController } from "#product/hooks/chat/ui/use-chat-prompt-attachments";
+import { handlePromptAttachmentPaste } from "#product/lib/domain/chat/composer/prompt-attachment-paste";
+
+export function useChatInputPaste({
+  attachments,
+  canAcceptPastedAttachments,
+}: {
+  attachments: PromptAttachmentController;
+  canAcceptPastedAttachments: boolean;
+}) {
+  const claimPromptAttachmentPaste = useCallback((
+    event: ClipboardEvent<HTMLDivElement>,
+  ) => handlePromptAttachmentPaste({
+    defaultPrevented: event.defaultPrevented,
+    canAcceptAttachments: canAcceptPastedAttachments,
+    fileCount: event.clipboardData.files.length,
+    plainText: event.clipboardData.getData("text/plain"),
+    addFiles: () => attachments.addFiles(event.clipboardData.files),
+    addTextPaste: attachments.addTextPaste,
+  }), [attachments, canAcceptPastedAttachments]);
+
+  const handleFilePasteCapture = useCallback((event: ClipboardEvent<HTMLDivElement>) => {
+    if (event.clipboardData.files.length === 0) return;
+    if (!claimPromptAttachmentPaste(event)) return;
+
+    // Claim file-bearing payloads before Lexical's target listener can import
+    // a text fallback and prevent the attachment owner from seeing the files.
+    event.preventDefault();
+    event.stopPropagation();
+  }, [claimPromptAttachmentPaste]);
+
+  const handlePaste = useCallback((event: ClipboardEvent<HTMLDivElement>) => {
+    // The editor owns formatted Markdown paste first. Once it has imported a
+    // list or link, do not reinterpret the same clipboard text as an
+    // attachment at the composer surface.
+    if (claimPromptAttachmentPaste(event)) event.preventDefault();
+  }, [claimPromptAttachmentPaste]);
+
+  return { handleFilePasteCapture, handlePaste };
+}

--- a/specs/codebase/systems/product/chat/composer.md
+++ b/specs/codebase/systems/product/chat/composer.md
@@ -84,14 +84,18 @@ Home and queued-edit state retain the same opaque snapshot locally while their
 Markdown draft is live. Empty drafts, plain-text compatibility writes, and
 external draft replacements discard the snapshot.
 
-The live editor recognizes `*`/`_` emphasis, `**`/`__` strong emphasis, and
-line-leading unordered and ordered list shortcuts. Cmd/Ctrl-B and Cmd/Ctrl-I
-toggle marks through the rich-text command layer. Tab/Shift-Tab indent or
-outdent only when the selection is inside a list item. Every composer surface —
-workspace, Home, and queued edits — submits on plain Enter or Cmd/Ctrl-Enter,
-including from a list item, and Shift-Enter inserts a newline without
-submitting. Queued edits use the workspace editor's minimum height, row cap,
-and overflow scrolling.
+The live editor recognizes `*`/`_` emphasis, `**`/`__` strong emphasis,
+line-leading unordered and ordered list shortcuts, and triple-backtick fenced
+code blocks. A typed fence becomes a code block only after a matching closing
+fence exists on its own line; an incomplete fence remains literal text. A
+complete pasted fence is imported as the same editable code block. The editor
+serializes that block back to fenced Markdown, so draft and submission
+boundaries remain unchanged. Cmd/Ctrl-B and Cmd/Ctrl-I toggle marks through the
+rich-text command layer. Tab/Shift-Tab indent or outdent only when the selection
+is inside a list item. Every composer surface — workspace, Home, and queued
+edits — submits on plain Enter or Cmd/Ctrl-Enter, including from a list item or
+code block, and Shift-Enter inserts a newline without submitting. Queued edits
+use the workspace editor's minimum height, row cap, and overflow scrolling.
 
 Lexical's high-priority Enter and Tab commands own this decision before native
 editor mutation. The surface applies the shared submit contract exactly once;


### PR DESCRIPTION
## Summary

- Render fully enclosed Markdown fences typed or pasted in the chat composer as editable code blocks while incomplete fences remain literal text.
- Preserve surrounding rich content, code-local typing and paste behavior, attachment ownership, and command/mention behavior across code-block boundaries.
- Render sent user-message fences reliably, including unlabeled one-line and empty blocks, and document the composer contract.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] This PR has no support relationship or private source attribution.

## Verification

- `pnpm --filter @proliferate/product-client test` (795 files, 5,317 tests)
- `pnpm --filter @proliferate/product-client typecheck`
- `pnpm --filter @proliferate/product-client build`
- `pnpm --filter proliferate build`
- `pnpm --filter @proliferate/web typecheck`
- `pnpm --filter @proliferate/web build`
- Repository documentation, frontend structure, appearance, attribution, source-size, boundary, and diff guards
- Playwright browser verification at desktop and mobile widths for editing, overflow, continuation text, and sent transcript rendering

## Observability

None. This is deterministic client-side rendering with no new telemetry or failure path.