### PR TITLE
docs: AGENTS.md router + ARCHITECTURE.md + docs-system explainer (D11)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,23 +1,28 @@
 # Proliferate
 
-Proliferate contains the Desktop, Web, and Mobile clients; the hosted control
-plane; and the AnyHarness runtime used to run coding-agent sessions.
+Proliferate runs coding agents against real codebases, end to end. This
+repository contains the Desktop, Web, and Mobile clients; the hosted control
+plane (server); the AnyHarness runtime that executes coding-agent sessions
+across harnesses; the supervisor/worker pair that manages targets; and the
+model gateway. Clients talk to the server; the server orchestrates sandboxes
+and personal targets; the runtime executes sessions; agent LLM traffic flows
+through the gateway. [`ARCHITECTURE.md`](ARCHITECTURE.md) explains how the
+pieces fit together and why the seams sit where they sit.
 
-- Repository: <https://github.com/proliferate-ai/proliferate>
-- Documentation entrypoint: [`specs/README.md`](specs/README.md)
+This file routes; it never explains. Land here cold, find the ONE doc to read
+next, go. Every "touching X → read Y" fact lives here and nowhere else.
 
-## Before Editing
+## Orientation
 
-Canonical current documentation describes operating truth and enforced
-architecture. Other documentation lifecycles are defined in `specs/README.md`.
-A frozen delivery specification describes the intended delta for one PR. Read
-the applicable artifacts before editing, and report a concrete contradiction
-instead of silently changing the frozen scope.
+| You want to… | Read |
+| --- | --- |
+| Understand how Proliferate is structured | [`ARCHITECTURE.md`](ARCHITECTURE.md) |
+| Understand why a decision was made | `adrs/` — `grep 'Description:' adrs/*.md` is the index |
+| Understand a cross-plane system deeply | [`specs/FEATURE_DOCS/`](specs/FEATURE_DOCS/) |
+| Do something that isn't writing code (release, debug prod, local setup) | [`guides/`](guides/README.md) |
+| Understand how the docs system itself works | [`guides/process/docs-system.md`](guides/process/docs-system.md) |
 
-Start with `specs/README.md`, then follow the source-area router below. The
-focused area document wins if this file overlaps with it.
-
-## Build And Develop
+## Build and develop
 
 Runtime baseline: Rust stable, Node 22+, pnpm, Python 3.12, and `uv`.
 
@@ -41,40 +46,62 @@ make dev-list
 
 Profile state lives under `~/.proliferate-local/dev/profiles/<name>/`; runtime
 state lives under `~/.proliferate-local/runtimes/<name>/`. Read
-[`guides/local/README.md`](guides/local/README.md) before
-running a feature worktree or changing local launch behavior.
+[`guides/local/README.md`](guides/local/README.md) before running a feature
+worktree or changing local launch behavior.
 
-## Source Router
+## Source router
 
 Use the most specific matching row. When a change crosses areas, read every
 applicable owner.
 
 | Source area | Start here |
 | --- | --- |
-| `AGENTS.md`, `CONTRIBUTING.md`, `.github/pull_request_template.md` | [`guides/process/README.md`](guides/process/README.md) |
-| `adrs/**` — writing or reviewing a decision record | [`guides/process/adrs.md`](guides/process/adrs.md) |
-| `apps/desktop/**`, `apps/web/**`, `apps/mobile/**`, `apps/packages/**` | [`specs/codebase/structures/frontend/README.md`](specs/codebase/structures/frontend/README.md) |
-| `apps/desktop/src-tauri/**`, `apps/desktop/src-tauri-debug/**` | [`specs/codebase/structures/desktop-native/README.md`](specs/codebase/structures/desktop-native/README.md) |
-| `server/**` | [`specs/codebase/structures/server/README.md`](specs/codebase/structures/server/README.md) |
-| `cloud/sdk/**`, `cloud/sdk-react/**`, `anyharness/sdk/**`, `anyharness/sdk-react/**` | [`specs/codebase/structures/sdk/README.md`](specs/codebase/structures/sdk/README.md) |
-| `anyharness/crates/anyharness*/**` | [`specs/codebase/structures/anyharness/README.md`](specs/codebase/structures/anyharness/README.md) |
-| `anyharness/crates/proliferate-worker/**` | [`specs/codebase/structures/proliferate-worker/README.md`](specs/codebase/structures/proliferate-worker/README.md) |
-| `anyharness/crates/proliferate-supervisor/**`, `install/**` | [`specs/codebase/structures/proliferate-supervisor/README.md`](specs/codebase/structures/proliferate-supervisor/README.md) |
-| `tests/intent/**`, `tests/release/**`, `anyharness/tests/**`, `fixtures/contracts/**` | [`specs/TESTING.md`](specs/TESTING.md) |
-| `scripts/agent-gateway-smoke/**` | [`specs/TESTING.md`](specs/TESTING.md) |
+| `apps/desktop/**`, `apps/web/**`, `apps/mobile/**`, `apps/packages/**` | [`specs/frontend/README.md`](specs/frontend/README.md) |
+| `apps/desktop/src-tauri/**`, `apps/desktop/src-tauri-debug/**` | [`specs/desktop-native.md`](specs/desktop-native.md) |
+| `server/**` | [`specs/server/README.md`](specs/server/README.md) |
+| `anyharness/crates/anyharness*/**` | [`specs/anyharness/README.md`](specs/anyharness/README.md) |
+| `anyharness/crates/proliferate-worker/**` | [`specs/worker.md`](specs/worker.md) |
+| `anyharness/crates/proliferate-supervisor/**`, `install/**` | [`specs/supervisor.md`](specs/supervisor.md) |
+| `cloud/sdk/**`, `cloud/sdk-react/**`, `anyharness/sdk/**`, `anyharness/sdk-react/**` | [`specs/sdk.md`](specs/sdk.md) |
+| UI: components, styling, tokens, theme | [`specs/DESIGN_SYSTEM.md`](specs/DESIGN_SYSTEM.md) |
+| User-facing copy, naming, product feel | [`specs/PRODUCT_SENSE.md`](specs/PRODUCT_SENSE.md) |
+| `tests/intent/**`, `tests/release/**`, `anyharness/tests/**`, `fixtures/contracts/**`, `scripts/agent-gateway-smoke/**` | [`specs/TESTING.md`](specs/TESTING.md) |
 | Telemetry and scrubber sources in any area (`**/telemetry/**`, `**/telemetry.rs`, `server/proliferate/integrations/sentry.py`, `server/proliferate/middleware/logging.py`), `server/infra/observability/**` | [`specs/OBSERVABILITY.md`](specs/OBSERVABILITY.md) |
-| `catalogs/**`, `scripts/agent-catalog/**` | [`specs/codebase/platforms/product/README.md`](specs/codebase/platforms/product/README.md) |
+| `lints/**`, `scripts/check_*` | Constitution — see [Repository-wide rules](#repository-wide-rules); records in [`lints/`](lints/) |
+| `adrs/**` — writing or reviewing a decision record | [`guides/process/adrs.md`](guides/process/adrs.md) |
+| `AGENTS.md`, `CONTRIBUTING.md`, `.github/pull_request_template.md` | [`guides/process/README.md`](guides/process/README.md) |
 | `.github/workflows/**`, `scripts/ci-cd/**`, `apps/desktop/infra/**`, `apps/desktop/scripts/**`, `server/infra/**`, `server/deploy/**` | [`guides/deploying/README.md`](guides/deploying/README.md) |
 | `.auth-env/**`, local profiles, local app identity | [`guides/local/README.md`](guides/local/README.md) |
+| `specs/GENERATED/**` | Never hand-edit; [`specs/GENERATED/README.md`](specs/GENERATED/README.md) names the regenerate command |
 
-After the structure document, use
-[`specs/codebase/README.md`](specs/codebase/README.md) to find the reusable
-platform contract or complete product/system contract involved in the change.
-Use [`guides/README.md`](guides/README.md) for procedures.
+## Cross-plane systems
 
-## Repository-Wide Rules
+Touching one of these systems means reading its feature doc first, whatever
+source area you are in.
 
-- Preserve current behavior unless the frozen specification changes it.
+| System | Touching | Read |
+| --- | --- | --- |
+| Sandbox | sandbox lifecycle/access/content, E2B, sandbox gateway, sandbox GitHub auth | [`specs/FEATURE_DOCS/SANDBOX/`](specs/FEATURE_DOCS/SANDBOX/) |
+| Billing | Stripe, meters, credits, plans, webhooks | [`specs/FEATURE_DOCS/BILLING.md`](specs/FEATURE_DOCS/BILLING.md) |
+| Managed runtime | supervisor/worker convergence, enrollment, runtime updates | [`specs/FEATURE_DOCS/MANAGED_RUNTIME.md`](specs/FEATURE_DOCS/MANAGED_RUNTIME.md) |
+| Agent auth | agent credentials, key vault, selections, `state.json` | [`specs/FEATURE_DOCS/AGENT_AUTH.md`](specs/FEATURE_DOCS/AGENT_AUTH.md) |
+| Models | `catalogs/**`, `scripts/agent-catalog/**`, model gateway, probes, LiteLLM | [`specs/FEATURE_DOCS/MODELS.md`](specs/FEATURE_DOCS/MODELS.md) |
+| Workflows | workflow definitions, invocations, runs, workspace placement | [`specs/FEATURE_DOCS/WORKFLOWS.md`](specs/FEATURE_DOCS/WORKFLOWS.md) |
+| Desktop host | web bundle ↔ native shell ↔ sidecar seam | [`specs/FEATURE_DOCS/DESKTOP_HOST.md`](specs/FEATURE_DOCS/DESKTOP_HOST.md) |
+
+## Repository-wide rules
+
+- If it's not current, it's not in this repo: future work lives in PRs, issues,
+  and `adrs/`; update docs in the same PR that changes behavior.
+- Consider [`specs/TESTING.md`](specs/TESTING.md) and
+  [`specs/OBSERVABILITY.md`](specs/OBSERVABILITY.md) in every PR; the PR
+  template asks for both sections.
+- Constitution: never weaken a lint, add a net-new exception, delete a pinning
+  test, or rewrite a normative rule without flagging it in the PR description
+  and stopping for founder review. Making CI green by changing the rules is
+  never a fix. Carrying an exception fingerprint forward on rename/move is
+  legal maintenance.
+- Preserve current behavior unless an approved ADR or PR scope changes it.
 - Prefer ownership-correct changes over cosmetic churn.
 - Do not leave duplicate old and new paths after a migration.
 - Use direct imports; do not add convenience barrel or re-export modules.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,11 +63,11 @@ applicable owner.
 | `anyharness/crates/proliferate-worker/**` | [`specs/worker.md`](specs/worker.md) |
 | `anyharness/crates/proliferate-supervisor/**`, `install/**` | [`specs/supervisor.md`](specs/supervisor.md) |
 | `cloud/sdk/**`, `cloud/sdk-react/**`, `anyharness/sdk/**`, `anyharness/sdk-react/**` | [`specs/sdk.md`](specs/sdk.md) |
-| UI: components, styling, tokens, theme | [`specs/DESIGN_SYSTEM.md`](specs/DESIGN_SYSTEM.md) |
+| UI: components, styling, tokens, theme | [`specs/codebase/platforms/product/design-system.md`](specs/codebase/platforms/product/design-system.md) |
 | User-facing copy, naming, product feel | [`specs/PRODUCT_SENSE.md`](specs/PRODUCT_SENSE.md) |
 | `tests/intent/**`, `tests/release/**`, `anyharness/tests/**`, `fixtures/contracts/**`, `scripts/agent-gateway-smoke/**` | [`specs/TESTING.md`](specs/TESTING.md) |
 | Telemetry and scrubber sources in any area (`**/telemetry/**`, `**/telemetry.rs`, `server/proliferate/integrations/sentry.py`, `server/proliferate/middleware/logging.py`), `server/infra/observability/**` | [`specs/OBSERVABILITY.md`](specs/OBSERVABILITY.md) |
-| `lints/**`, `scripts/check_*` | Constitution — see [Repository-wide rules](#repository-wide-rules); records in [`lints/`](lints/) |
+| `scripts/check_*`, checker allowlists | Constitution — see [Repository-wide rules](#repository-wide-rules) |
 | `adrs/**` — writing or reviewing a decision record | [`guides/process/adrs.md`](guides/process/adrs.md) |
 | `AGENTS.md`, `CONTRIBUTING.md`, `.github/pull_request_template.md` | [`guides/process/README.md`](guides/process/README.md) |
 | `.github/workflows/**`, `scripts/ci-cd/**`, `apps/desktop/infra/**`, `apps/desktop/scripts/**`, `server/infra/**`, `server/deploy/**` | [`guides/deploying/README.md`](guides/deploying/README.md) |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,94 @@
+# Architecture
+
+How the components of Proliferate fit together and why the seams sit where they
+sit. This document is comprehension, not routing — [`AGENTS.md`](AGENTS.md) says
+WHERE to read; this says how the pieces relate. It is deliberately starved: the
+moment a sentence explains an area's internals, it belongs in that area's doc.
+It changes only when a plane is added or a seam moves.
+
+## The plane map
+
+```
+   clients                    control plane              execution plane
+┌────────────┐            ┌─────────────────┐        ┌──────────────────────┐
+│  Desktop   │            │                 │        │  sandbox (E2B) or    │
+│  Web       │ ─────────► │     Server      │ ─────► │  personal target     │
+│  Mobile    │   HTTP/SSE │   (FastAPI)     │        │ ┌──────────────────┐ │
+└────────────┘            │                 │        │ │ supervisor       │ │
+      │                   └─────────────────┘        │ │  ├─ worker       │ │
+      │  desktop only:              │                │ │  └─ anyharness   │ │
+      │  local sidecar              │                │ │     runtime      │ │
+      ▼                             ▼                │ └──────────────────┘ │
+┌────────────┐            ┌─────────────────┐        └──────────────────────┘
+│ anyharness │            │  model gateway  │                  │
+│  sidecar   │            │   (LiteLLM)     │ ◄────────────────┘
+└────────────┘            └─────────────────┘   agent LLM traffic
+```
+
+- **Clients** (`apps/desktop`, `apps/web`, `apps/mobile`, shared code in
+  `apps/packages/product-client`) render and interact. They are clients of the
+  server's contracts and, on desktop, of a locally-spawned AnyHarness sidecar.
+- **Server** (`server/`) is the hosted control plane: durable product state,
+  policy, orchestration, auth, integrations, billing, background work.
+- **Execution plane** runs coding-agent sessions: a supervisor process manages a
+  worker and the AnyHarness runtime inside a sandbox or on a personal target.
+- **AnyHarness runtime** (`anyharness/crates/anyharness*`) is the
+  harness-agnostic engine: session/workspace execution, adapter and protocol
+  contracts, runtime-side product domains.
+- **Model gateway** (LiteLLM, `server/litellm`) sits off to the side: agent LLM
+  traffic flows through it for managed credentials, metering, and provider
+  routing.
+
+## Who owns what
+
+- **AnyHarness** owns the harness-agnostic runtime: session/workspace
+  execution, adapter + protocol contracts, and the runtime-side product
+  domains. Never hosted control-plane policy.
+- **Server** owns the hosted control plane: durable product state, policy,
+  orchestration, auth, integrations, background work — not just "crud".
+- **Frontend** packages own presentation and interaction: clients of the
+  server's contracts.
+- **Desktop Native** (`apps/desktop/src-tauri`) owns OS integration and local
+  process lifecycle: the shell, native commands, sidecar launch.
+- **Supervisor** (`anyharness/crates/proliferate-supervisor`) owns process
+  supervision on a target: spawn loops, install layout, update staging,
+  rollback. **Worker** (`anyharness/crates/proliferate-worker`) owns the
+  target's identity toward the control plane: enrollment, heartbeat, version
+  observation, gateway credentials. They run in tandem but do distinct work;
+  the tandem story is
+  [`specs/FEATURE_DOCS/MANAGED_RUNTIME.md`](specs/FEATURE_DOCS/MANAGED_RUNTIME.md).
+- **SDKs** (`anyharness/sdk*`, `cloud/sdk*`) are generated contract consumers;
+  the contract owns them, not the reverse.
+
+## The seams and why they sit there
+
+- **Server ↔ runtime.** The server never executes agent sessions and the
+  runtime never holds product policy. Everything crossing this seam is an
+  explicit contract (runtime HTTP/SSE API, mailbox messages). Why: sessions
+  must run identically in a cloud sandbox, on a personal target, and under the
+  desktop app — a policy dependency in the runtime would fork those worlds.
+- **Client ↔ server.** Clients speak the generated SDK contracts only. Why:
+  three clients share one behavior surface; contract drift is caught at
+  generation time instead of at runtime.
+- **Desktop ↔ sidecar.** The desktop shell spawns the same AnyHarness binary
+  the cloud runs, and talks to it over the same API it would use remotely. Why:
+  one runtime code path — desktop is a deployment mode, not a fork.
+- **Supervisor ↔ worker ↔ runtime.** The supervisor is the only process
+  manager; the worker is the only control-plane speaker on a target; binaries
+  converge by catalog update, not by ad-hoc deploys. Why: managed targets must
+  self-heal and converge without SSH-shaped operations.
+- **Agent LLM traffic ↔ gateway.** Agent model calls go through the gateway
+  rather than provider SDKs in the runtime. Why: managed credentials, metering
+  for billing, and provider swaps must not require touching the runtime.
+
+## Read order for grokking the repo
+
+1. [`specs/server/README.md`](specs/server/README.md) — the control plane and
+   the grid ownership model.
+2. [`specs/anyharness/README.md`](specs/anyharness/README.md) — the runtime's
+   mental model.
+3. [`specs/frontend/README.md`](specs/frontend/README.md) — how the clients
+   are put together.
+
+Then the feature doc for whichever cross-plane system you are touching
+([`specs/FEATURE_DOCS/`](specs/FEATURE_DOCS/)).

--- a/guides/process/docs-system.md
+++ b/guides/process/docs-system.md
@@ -1,0 +1,104 @@
+# How our docs work
+
+Why this document exists: our docs kept failing us in three ways. They go stale and
+then agents (and people) trust something false. Knowledge evaporates the moment a
+project ships — the reasoning lived in a PR body or a chat and died there. And docs
+that nothing enforces are lies waiting to happen. The structure below is built
+against those three failures, for both humans and agents: support agents, bug-fix
+agents, and new teammates all need findable exceptions, legible code, and enough
+logging to work a problem end to end. The north star is agents closing the full
+SDLC loop — that only works if the written system is true.
+
+Two rules above everything:
+
+1. **If it's not current, it's not in this repo.** Future work lives in PRs, issues,
+   and `adrs/`; history lives in git. Anything in the tree is operating truth,
+   updated in the same PR that changes behavior.
+2. **One router.** Every "touching X → read Y" fact lives in `AGENTS.md` and nowhere
+   else. Two routers always diverge, and then nobody can tell which one is true.
+
+## The map
+
+- **`AGENTS.md`** — the routing table of contents. An agent (or person) lands here
+  cold and knows in 30 seconds which ONE doc to read next. It routes, it never
+  explains — the moment it explains something, that sentence belongs in the target
+  doc. Carries the source router (path globs → doc) and the repository-wide rules.
+
+- **`ARCHITECTURE.md`** — how every component fits together and why the seams sit
+  where they sit. Deliberately starved (~150 lines): the plane map, ownership
+  one-liners, the read order for grokking the repo. Comprehension, not routing.
+  Only changes when a plane is added or a seam moves.
+
+- **`specs/`** — everything to do with building in this repository.
+  - `anyharness/`, `server/`, `frontend/` — best practices per source OWNER
+    (owners, not languages — "Rust" is a compiler, not an owner). Each is exactly
+    two artifacts: a `README.md` that teaches you to THINK about the area, and rule
+    data in `lints/<owner>/` that STOPS you. The litmus per sentence: could a
+    checker hold this? Yes → lints data. No → prose. Nothing is written twice.
+    Thin owners (supervisor, worker, desktop-native, sdk) get one file each.
+  - `DESIGN_SYSTEM.md` — the design system, whole: the why behind every token,
+    component + styles library references, ratchet pointers.
+  - `PRODUCT_SENSE.md` — sparse cross-product judgment primitives: the taste calls
+    a competent model would get wrong, each with a good/bad example. Enforced by
+    review — legitimately, not as debt.
+  - `TESTING.md` / `OBSERVABILITY.md` — the per-PR standards, ≤150 lines each.
+    Consider both in every PR; the PR template asks for a Testing and an
+    Observability section (state the tier(s) or why none is feasible; state the
+    observability delta or "none"). Review-mode — no body-parsing CI ceremony.
+    Depth lives in `specs/TESTING/`.
+  - `GENERATED/` — reproducible checked-in references (DB schema etc.). The README
+    names the regenerate command and the owning test. Never hand-edited — if a
+    human touches it, it's a lie waiting to happen.
+  - `FEATURE_DOCS/` — cross-plane systems you must understand deeply before
+    touching: SANDBOX/, BILLING, MANAGED_RUNTIME, AGENT_AUTH, MODELS, WORKFLOWS,
+    DESKTOP_HOST. The admission bar is harsh: a feature doc exists ONLY when the
+    system spans planes and no code location could host the knowledge. If a
+    comment, lint, or test could carry it, it does not get a doc.
+
+- **`adrs/`** — architectural decision records. The specing doc IS the record:
+  every non-trivial feature is specced as an ADR up front (orientation / current
+  context / design options / implementation slices / validation), immutable once
+  approved, and it stays forever as the permanent why. `grep 'Description:' adrs/`
+  is the index — no index file to rot. Multi-PR orchestration lives in the ADR's
+  own Implementation section; there is no separate programs directory. Outside the
+  normal read path: you come here for the why behind a decision, or to execute one.
+  Format contract: [`adrs.md`](adrs.md).
+
+- **`guides/`** — the daily stuff that isn't writing code: `local/` (machine
+  setup), `debugging/` (incidents, support reports), `deploying/` (THE release
+  runbook, ci-cd, self-hosted), `operating/` (prod runbooks, operator tasks,
+  analytics), `process/` (pull requests, ADRs, this doc). Task-shaped, always the
+  same anatomy: safety contract first → steps with expected output → symptom /
+  meaning / action failure table → rollback.
+
+- **`lints/`** — rules as data, by owner. For any best practice that would STOP
+  something you write: it becomes a lint or a pinning test. The TOML record is
+  canonical — id, scope, rule, legal alternative, the why (dated incident),
+  good/bad example, exact exceptions, owner. The CI diagnostic is GENERATED from
+  the record: a bare "error: banned" teaches nothing; the message is a remediation
+  prompt. Violations are never counted — a rule is clean or carries exact named
+  exception fingerprints. Agents may not amend the constitution (weaken a lint,
+  add a net-new exception, delete a pinning test) without flagging and stopping;
+  CODEOWNERS backs it mechanically.
+
+## Where does a new learning go?
+
+Two independent questions, never conflated:
+
+1. **Placement.** Component-local? → a comment next to the code, no doc. Changes
+   what you'd design in one area? → that owner's dir. Spans planes? →
+   `FEATURE_DOCS/`. Cross-product judgment? → `PRODUCT_SENSE.md`. A workflow, not
+   a design input? → `guides/`. None of the above? → don't write it down.
+   Deliberately.
+2. **Verification.** Every rule names its enforcement mode:
+   `compiler | lint | test | review`. Mechanical rules become `lints/` records.
+   Review is a legitimate mode for judgment calls. `GAP - #issue` marks the only
+   real debt: rules that COULD be mechanical and aren't yet.
+
+Write it in the same PR as the learning, or the knowledge evaporates.
+
+## Scheduled enforcement
+
+Ratchet re-measurement, generated-doc freshness, and tombstone sweeps are carried
+by the checkers themselves plus the operating runbooks — they are not a separate
+directory or system.

--- a/specs/FEATURE_DOCS/README.md
+++ b/specs/FEATURE_DOCS/README.md
@@ -1,0 +1,22 @@
+# Feature docs
+
+Cross-plane systems you must understand deeply before touching them. Routing
+lives in [`AGENTS.md`](../../AGENTS.md); each doc's own header carries its
+"read before touching" globs. This file is a plain index.
+
+**The admission bar, stated harshly:** a feature doc exists ONLY when the
+system spans planes (client ↔ server ↔ runtime ↔ infra) and no code location
+could host the knowledge. If a comment, a lint record, or a test could carry
+it, it does not get a doc. Owner-area design judgment belongs in that owner's
+README; single-plane systems belong with their owner. Adding a file here
+without meeting that bar is how doc trees rot — don't.
+
+| Doc | System |
+| --- | --- |
+| [`SANDBOX/`](SANDBOX/) | Client ↔ server ↔ E2B ↔ gateway: lifecycle, access, content, gateway, GitHub auth — kept fenced, each file names its neighbors' ownership |
+| [`BILLING.md`](BILLING.md) | Stripe ↔ server ↔ gateway ↔ meters |
+| [`MANAGED_RUNTIME.md`](MANAGED_RUNTIME.md) | Server ↔ supervisor ↔ worker: the one convergence story |
+| [`AGENT_AUTH.md`](AGENT_AUTH.md) | Client ↔ server ↔ runtime ↔ credential vaults |
+| [`MODELS.md`](MODELS.md) | Catalog + gateway: probes ↔ server ↔ LiteLLM ↔ providers |
+| [`WORKFLOWS.md`](WORKFLOWS.md) | Server ↔ runtime ↔ workspace placement |
+| [`DESKTOP_HOST.md`](DESKTOP_HOST.md) | Web bundle ↔ native shell ↔ sidecar seam |


### PR DESCRIPTION
## Slice

D11 — the router. Lands LAST per the living ADR.

## What this delivers
- **AGENTS.md** rewritten to the ruled target shape: routes, never explains. Orientation table, Build/Develop preserved verbatim, source router pointing at the new tree (all 11 mechanical slices merged), cross-plane systems table (7 FEATURE_DOCS rows), repository-wide rules + constitution clause.
- **ARCHITECTURE.md** rewritten: starved seam map — plane diagram, ownership one-liners, five seams each with the WHY, read order.
- **guides/process/docs-system.md** (new): the team explainer of how the docs system works, from Pablo's structure doc.
- **specs/FEATURE_DOCS/README.md** (new): plain index + the harsh admission bar.

## Router rows
Folded from the 11 mechanical PRs' "Router rows for D11" sections. Owner-dir sub-rows deliberately omitted — each owner README's code map routes deeper; one router stays lean.

## Gated on
check_docs is red with exactly two missing targets, both owned by in-flight forks:
- `specs/DESIGN_SYSTEM.md` — D4, PR #1705
- `lints/` — D6, lints fork

Converts to ready once both land. **Founder-reviewed personally — do not merge without Pablo.**