### PR TITLE
docs(process): PR template Testing + Observability sections (D16)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,18 @@
 
 -
 
+## Testing
+
+<!-- State the tier(s) exercised per specs/TESTING.md, or why none is feasible. -->
+
+-
+
+## Observability
+
+<!-- State the observability delta per specs/OBSERVABILITY.md, or "none". -->
+
+-
+
 ## Readiness
 
 - [ ] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)


### PR DESCRIPTION
## Slice

D16 — the review-mode enforcement ruled 2026-08-07 (softened: sections prompt, no body-parsing CI).

## What
Two sections added to `.github/pull_request_template.md`, matching the ruled wording in `guides/process/docs-system.md`:
- **Testing** — state the tier(s) per `specs/TESTING.md`, or why none is feasible
- **Observability** — state the delta per `specs/OBSERVABILITY.md`, or "none"

No CI ceremony; review-mode only.

## Testing
Docs-only; `check_docs.py` green (333 files).

## Observability
None.