### PR TITLE
feat(anyharness): peer configuration — get_agent_config_options + configure_agent

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/session_admission_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/session_admission_tests.rs
@@ -652,47 +652,51 @@ fn every_dual_lock_handler_takes_the_permit_before_the_operation_lease() {
 }
 
 #[test]
-fn the_peer_send_takes_the_permit_before_the_target_workspace_lease() {
-    // The one dual-lock site outside `api/http/`: `send_agent_message` is the
-    // first product-MCP tool that can prompt an ARBITRARY session, so it takes
-    // the target session's permit and the TARGET workspace's write lease itself
-    // rather than through the route's `MUTATING_TOOL_NAMES` lease (which is the
-    // CALLER's workspace, and would be taken before the permit — the reversed
-    // order `reversed_order_deadlocks` proves hangs). Same guard as the handler
-    // rows above; separate because the function is private, so it has no
-    // `pub async fn` signature for `handler_body` to find.
+fn the_peer_tools_take_the_permit_before_the_target_workspace_lease() {
+    // The dual-lock sites outside `api/http/`: `send_agent_message` and
+    // `configure_agent` are the product-MCP tools that can perturb an ARBITRARY
+    // session, so each takes the target session's permit and the TARGET
+    // workspace's write lease itself rather than through the route's
+    // `MUTATING_TOOL_NAMES` lease (which is the CALLER's workspace, and would be
+    // taken before the permit — the reversed order `reversed_order_deadlocks`
+    // proves hangs). Same guard as the handler rows above; separate because the
+    // functions are private, so they have no `pub async fn` signature for
+    // `handler_body` to find.
     let rel_path = "src/domains/sessions/agent_ops/calls.rs";
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(rel_path);
     let text =
         std::fs::read_to_string(&path).unwrap_or_else(|error| panic!("read {rel_path}: {error}"));
-    let signature = "async fn send_agent_message(";
-    let start = text
-        .find(signature)
-        .unwrap_or_else(|| panic!("{rel_path}: send_agent_message not found"));
-    let rest = &text[start..];
-    // Private items follow, so stop at this function's own closing brace rather
-    // than at the next `pub` item.
-    let end = rest
-        .find("\n}\n")
-        .map(|idx| idx + 3)
-        .unwrap_or(rest.len());
-    let body = &rest[..end];
 
-    let admit_at = body
-        .find("admit_peer_send(")
-        .expect("send_agent_message must acquire the target session's mutation permit");
-    let lease_at = body
-        .find("lease_target_workspace_for_send(")
-        .expect("send_agent_message must lease the TARGET workspace");
-    assert!(
-        admit_at < lease_at,
-        "send_agent_message: 'admit_peer_send' must come BEFORE \
-         'lease_target_workspace_for_send' — {LOCK_01_ORDER}"
-    );
-    // And the dispatch stays inside both: a permit dropped before the prompt is
-    // enqueued fences nothing.
-    let dispatch_at = body
-        .find("send_text_prompt_with_provenance(")
-        .expect("send_agent_message must dispatch the prompt");
-    assert!(lease_at < dispatch_at);
+    for (tool, dispatch) in [
+        ("send_agent_message", "send_text_prompt_with_provenance("),
+        ("configure_agent", "set_live_session_config_option("),
+    ] {
+        let signature = format!("async fn {tool}(");
+        let start = text
+            .find(&signature)
+            .unwrap_or_else(|| panic!("{rel_path}: {tool} not found"));
+        let rest = &text[start..];
+        // Private items follow, so stop at this function's own closing brace
+        // rather than at the next `pub` item.
+        let end = rest.find("\n}\n").map(|idx| idx + 3).unwrap_or(rest.len());
+        let body = &rest[..end];
+
+        let admit_at = body
+            .find("admit_peer_mutation(")
+            .unwrap_or_else(|| panic!("{tool} must acquire the target session's mutation permit"));
+        let lease_at = body
+            .find("lease_target_workspace_for_peer_write(")
+            .unwrap_or_else(|| panic!("{tool} must lease the TARGET workspace"));
+        assert!(
+            admit_at < lease_at,
+            "{tool}: 'admit_peer_mutation' must come BEFORE \
+             'lease_target_workspace_for_peer_write' — {LOCK_01_ORDER}"
+        );
+        // And the dispatch stays inside both: a permit dropped before the work
+        // lands fences nothing.
+        let dispatch_at = body
+            .find(dispatch)
+            .unwrap_or_else(|| panic!("{tool} must dispatch through {dispatch}"));
+        assert!(lease_at < dispatch_at, "{tool}: dispatch escaped the locks");
+    }
 }

--- a/anyharness/crates/anyharness-lib/src/api/session_admission_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/session_admission_tests.rs
@@ -579,6 +579,12 @@ fn assert_source_order(rel_path: &str, fn_name: &str, first: &str, second: &str,
     );
 }
 
+/// Collapse every run of whitespace to a single space, so a source needle can
+/// span a `let` binding and its call without a rustfmt line wrap breaking it.
+fn squash_whitespace(source: &str) -> String {
+    source.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 const LOCK_01_ORDER: &str =
     "canonical LOCK-01 order: session mutation permit -> workspace operation lease";
 
@@ -679,21 +685,42 @@ fn the_peer_tools_take_the_permit_before_the_target_workspace_lease() {
         // Private items follow, so stop at this function's own closing brace
         // rather than at the next `pub` item.
         let end = rest.find("\n}\n").map(|idx| idx + 3).unwrap_or(rest.len());
-        let body = &rest[..end];
+        // Whitespace runs collapse to one space so a rustfmt wrap of the
+        // argument list cannot break a needle, and so the needles can span the
+        // `let` binding.
+        let body = squash_whitespace(&rest[..end]);
+        let body = body.as_str();
 
+        // The needles pin the BINDING, not just the call. Matching
+        // `admit_peer_mutation(` alone would pass on `let _ = admit_peer_mutation(..)`,
+        // which drops the permit at the end of that statement — textually
+        // identical ORDER, no fence at all across the dispatch below. What this
+        // test exists to prove is that both guards are still HELD when the work
+        // lands, so the named bindings are the thing to ratchet.
         let admit_at = body
-            .find("admit_peer_mutation(")
-            .unwrap_or_else(|| panic!("{tool} must acquire the target session's mutation permit"));
+            .find("let _admission_permit = admit_peer_mutation(")
+            .unwrap_or_else(|| {
+                panic!(
+                    "{tool} must BIND the target session's mutation permit as \
+                     `_admission_permit` — an unbound `let _ =` drops it immediately"
+                )
+            });
         let lease_at = body
-            .find("lease_target_workspace_for_peer_write(")
-            .unwrap_or_else(|| panic!("{tool} must lease the TARGET workspace"));
+            .find("let _target_workspace_lease = lease_target_workspace_for_peer_write(")
+            .unwrap_or_else(|| {
+                panic!(
+                    "{tool} must BIND the TARGET workspace lease as \
+                     `_target_workspace_lease` — an unbound `let _ =` drops it immediately"
+                )
+            });
         assert!(
             admit_at < lease_at,
             "{tool}: 'admit_peer_mutation' must come BEFORE \
              'lease_target_workspace_for_peer_write' — {LOCK_01_ORDER}"
         );
         // And the dispatch stays inside both: a permit dropped before the work
-        // lands fences nothing.
+        // lands fences nothing. Both bindings live to the end of the function,
+        // so a dispatch that appears after them is inside both.
         let dispatch_at = body
             .find(dispatch)
             .unwrap_or_else(|| panic!("{tool} must dispatch through {dispatch}"));

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/calls.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/calls.rs
@@ -1,23 +1,29 @@
 use std::collections::HashMap;
 
+use anyharness_contract::v1::ConfigApplyState;
 use serde_json::{json, Value};
 
 use super::calls_helpers::{
     default_model_for_agent, initial_config_string, launch_agents_to_json, mode_options_to_json,
     prompt_outcome_label, summaries_to_json,
 };
+use super::config_ops::{
+    compose_agent_config_options, controls_to_json, current_selection_to_json,
+    prepare_agent_config_change,
+};
 use super::context::AgentOpsMcpContext;
 use super::peer_ops::{
-    admit_peer_send, assert_workspace_can_be_mutated, authorize_transcript_read,
-    consume_reply_wake, lease_target_workspace_for_send, prepare_agent_message,
+    admit_peer_mutation, assert_workspace_can_be_mutated, authorize_transcript_read,
+    consume_reply_wake, lease_target_workspace_for_peer_write, prepare_agent_message,
+};
+use super::tools::{
+    canonical_tool_name, ChildSessionArgs, ConfigureAgentArgs, CreateSubagentArgs,
+    GetAgentConfigOptionsArgs, ListAgentsArgs, ReadAgentTranscriptArgs, ReadAgentTranscriptMode,
+    ReadSubagentEventsArgs, ReadSubagentLatestTurnsArgs, ScheduleAgentWakeArgs,
+    SearchSubagentTranscriptArgs, SendAgentMessageArgs, SendSubagentMessageArgs,
 };
 use super::AgentOpsPeerGates;
-use super::tools::{
-    canonical_tool_name, ChildSessionArgs, CreateSubagentArgs, ListAgentsArgs,
-    ReadAgentTranscriptArgs, ReadAgentTranscriptMode, ReadSubagentEventsArgs,
-    ReadSubagentLatestTurnsArgs, ScheduleAgentWakeArgs, SearchSubagentTranscriptArgs,
-    SendAgentMessageArgs, SendSubagentMessageArgs,
-};
+use crate::domains::sessions::admission::SessionMutationKind;
 use crate::domains::sessions::authorize::{authorize, AgentAccessIntent};
 use crate::domains::sessions::delegation::{
     parent_to_child_provenance, READ_EVENTS_DEFAULT_LIMIT, READ_EVENTS_MAX_LIMIT,
@@ -73,6 +79,14 @@ pub async fn call_tool(
         "schedule_agent_wake" => {
             let args: ScheduleAgentWakeArgs = deserialize_args(arguments)?;
             schedule_agent_wake(wake_service, &ctx.parent_session_id, args)
+        }
+        "get_agent_config_options" => {
+            let args: GetAgentConfigOptionsArgs = deserialize_args(arguments)?;
+            get_agent_config_options(service, session_runtime, &ctx.parent_session_id, args)
+        }
+        "configure_agent" => {
+            let args: ConfigureAgentArgs = deserialize_args(arguments)?;
+            configure_agent(service, session_runtime, gates, ctx, args).await
         }
         "schedule_subagent_wake" => {
             let args: ChildSessionArgs = deserialize_args(arguments)?;
@@ -564,14 +578,19 @@ async fn send_agent_message(
     let caller_session_id = ctx.parent_session_id.as_str();
     // The caller's own workspace still has to be writable — the route used to
     // check this for us, and stopped once this tool started taking its own
-    // leases (see `lease_target_workspace_for_send`). No lease: nothing here
+    // leases (see `lease_target_workspace_for_peer_write`). No lease: nothing here
     // mutates the caller's workspace.
     assert_workspace_can_be_mutated(service.access_gate(), &ctx.workspace_id)?;
     // Canonical lock order, and the reason this tool is absent from
     // `MUTATING_TOOL_NAMES`: session mutation permit FIRST, then the target
     // workspace's write lease. Both are held across the dispatch below.
-    let _admission_permit = admit_peer_send(&gates.session_admission, &prepared.target.id).await?;
-    let _target_workspace_lease = lease_target_workspace_for_send(
+    let _admission_permit = admit_peer_mutation(
+        &gates.session_admission,
+        &prepared.target.id,
+        SessionMutationKind::Prompt,
+    )
+    .await?;
+    let _target_workspace_lease = lease_target_workspace_for_peer_write(
         &gates.workspace_operation_gate,
         service.access_gate(),
         &prepared.target.workspace_id,
@@ -718,6 +737,101 @@ fn schedule_agent_wake(
         } else {
             "the target's next turn finishes — it is idle now, so nothing fires until someone prompts it"
         },
+    }))
+}
+
+fn get_agent_config_options(
+    service: &SubagentService,
+    session_runtime: &SessionRuntime,
+    caller_session_id: &str,
+    args: GetAgentConfigOptionsArgs,
+) -> anyhow::Result<Value> {
+    let composed = compose_agent_config_options(
+        service.session_store(),
+        caller_session_id,
+        args.session_id.trim(),
+        // The TARGET's workspace, always: its catalog, readiness and auth
+        // contexts decide what it may run, and they need not match the
+        // caller's.
+        |workspace_id| session_runtime.resolved_workspace_launch_options(workspace_id),
+        |session_id| session_runtime.live_config_snapshot(session_id),
+    )?;
+    Ok(json!({
+        "sessionId": composed.target.id,
+        "workspaceId": composed.target.workspace_id,
+        "title": composed.target.title,
+        "agentKind": composed.target.agent_kind,
+        "status": composed.target.status,
+        "optionsWorkspaceId": composed.catalog_workspace_id,
+        "current": current_selection_to_json(&composed.target),
+        "configurable": controls_to_json(&composed.controls),
+        // The human client's exact live-config contract, verbatim: same
+        // rawConfigOptions / normalizedControls an operator sees.
+        "liveConfig": composed.live_config,
+        "notes": [
+            "Pass a configId and one of its values to configure_agent.",
+            "source=live means the agent's harness is advertising that value right now; source=workspace_catalog means the target's workspace authorizes it and applying may relaunch the agent to reach it.",
+            "A target that has never run reports no liveConfig; its model options still come from its workspace catalog.",
+        ],
+    }))
+}
+
+async fn configure_agent(
+    service: &SubagentService,
+    session_runtime: &SessionRuntime,
+    gates: &AgentOpsPeerGates,
+    ctx: &AgentOpsMcpContext,
+    args: ConfigureAgentArgs,
+) -> anyhow::Result<Value> {
+    // Read-only up to here: authorize, compose the target's universe, validate.
+    // A refusal costs no permit and no lease.
+    let prepared = prepare_agent_config_change(
+        service.session_store(),
+        &ctx.parent_session_id,
+        args.session_id.trim(),
+        &args.config_id,
+        &args.value,
+        |workspace_id| session_runtime.resolved_workspace_launch_options(workspace_id),
+        |session_id| session_runtime.live_config_snapshot(session_id),
+    )?;
+    // The caller's own workspace still has to be writable, exactly as for
+    // `send_agent_message`: the route stopped checking once this tool left
+    // `MUTATING_TOOL_NAMES`. No lease — nothing here mutates it.
+    assert_workspace_can_be_mutated(service.access_gate(), &ctx.workspace_id)?;
+    // Canonical lock order, and the reason this tool is absent from
+    // `MUTATING_TOOL_NAMES`: the TARGET's session mutation permit FIRST — a
+    // workflow-controlled agent refuses a foreign config change before any
+    // side effect — then the TARGET workspace's write lease, which is the one
+    // whose retire preflight has to see this work.
+    let _admission_permit = admit_peer_mutation(
+        &gates.session_admission,
+        &prepared.target.id,
+        SessionMutationKind::Config,
+    )
+    .await?;
+    let _target_workspace_lease = lease_target_workspace_for_peer_write(
+        &gates.workspace_operation_gate,
+        service.access_gate(),
+        &prepared.target.workspace_id,
+    )
+    .await?;
+    // The existing apply path, unchanged: it boots an idle target, queues
+    // behind an active turn, and persists requested_*/current_* so a relaunch
+    // converges on the new selection.
+    let (session, live_config, apply_state) = session_runtime
+        .set_live_session_config_option(&prepared.target.id, &prepared.config_id, &prepared.value)
+        .await
+        .map_err(|error| anyhow::anyhow!("{error:?}"))?;
+    Ok(json!({
+        "sessionId": session.id,
+        "workspaceId": session.workspace_id,
+        "title": session.title,
+        "configId": prepared.config_id,
+        "value": prepared.value,
+        "applyState": serde_json::to_value(&apply_state)?,
+        "queued": matches!(apply_state, ConfigApplyState::Queued),
+        "current": current_selection_to_json(&session),
+        "liveConfig": live_config,
     }))
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/config_ops.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/config_ops.rs
@@ -16,7 +16,7 @@ use anyharness_contract::v1::{NormalizedSessionControl, SessionLiveConfigSnapsho
 use serde_json::{json, Value};
 
 use crate::domains::agents::readiness::launch_options::ResolvedWorkspaceLaunchOptions;
-use crate::domains::sessions::authorize::{authorize, AgentAccessError, AgentAccessIntent};
+use crate::domains::sessions::authorize::{self, authorize, AgentAccessError, AgentAccessIntent};
 use crate::domains::sessions::live_config::ACP_MODEL_COMPAT_CONFIG_ID;
 use crate::domains::sessions::model::SessionRecord;
 use crate::domains::sessions::store::SessionStore;
@@ -36,10 +36,26 @@ pub(super) enum AgentConfigError {
     /// again, so its "what can I change now" answer is always "nothing".
     /// Saying so beats handing back an empty menu that reads like a harness
     /// with no controls.
-    #[error(
-        "target session is closed; a closed agent has no configuration left to read or change"
-    )]
+    ///
+    /// This is why the READ path refuses the SAME set the change path's `Send`
+    /// funnel refuses — closed here, and dismissed just below. Keeping the two
+    /// symmetric is the whole point: a read that answered a terminal target
+    /// would hand an agent a full menu and then refuse every item on it, which
+    /// is strictly worse than one refusal it can act on. Read/write symmetry
+    /// here is deliberate, not an accident of where the guard sits.
+    ///
+    /// Only the READ path raises this. On the change path the `Send` funnel
+    /// refuses a closed target first, with its own message — so this one talks
+    /// about reading, which is all it ever answers.
+    #[error("target session is closed; a closed agent's actor never starts again, so it has no configuration left to read")]
     TargetClosed,
+    /// The same refusal, for the same reason, on the other terminal state.
+    /// Dismissed is not closed — the row stays open — but `runtime/
+    /// launch_policy.rs` refuses to boot it, so its composed menu is a list of
+    /// changes that can never be applied. See `target_config_is_unreachable`
+    /// for why the read path refuses rather than advertising it.
+    #[error("target session was dismissed; a dismissed agent is never launched again, so it has no configuration left to read")]
+    TargetDismissed,
     /// An agent reconfiguring itself would route a config command at the very
     /// actor that is blocked inside this tool call, and would queue behind its
     /// own turn. Harness-native controls are the way to change your own model.
@@ -61,6 +77,16 @@ pub(super) enum AgentConfigError {
         config_id: String,
         value: String,
         available: String,
+    },
+    /// The write half of `ComposedControl::settable`. Without it `settable`
+    /// would be advisory-for-display only, and a single-value control would
+    /// accept its own current value — a "change" that moves nothing while the
+    /// read said it could not be changed at all.
+    #[error("configId {config_id:?} on session {session_id} is not settable: {value:?} is its only available value and is already current")]
+    ControlNotSettable {
+        session_id: String,
+        config_id: String,
+        value: String,
     },
     #[error(transparent)]
     Internal(#[from] anyhow::Error),
@@ -87,8 +113,21 @@ pub(super) struct ComposedControl {
 }
 
 impl ComposedControl {
+    /// Whether asking for a change here can move anything. Two or more values
+    /// obviously can. A SINGLE value can too, when it is not the current one —
+    /// a harness advertising one option the session has not selected yet is a
+    /// real change. What is not settable is the dead end: the only value on
+    /// offer is already current, so every request is a no-op.
+    ///
+    /// `validate_change` ENFORCES this, so the `settable: false` an agent reads
+    /// from `get_agent_config_options` is a promise `configure_agent` keeps
+    /// rather than advice it is free to ignore.
     fn settable(&self) -> bool {
-        self.values.len() > 1
+        match self.values.as_slice() {
+            [] => false,
+            [only] => self.current_value.as_deref() != Some(only.value.as_str()),
+            _ => true,
+        }
     }
 
     fn push_value(&mut self, value: String, label: String, source: &'static str) {
@@ -137,8 +176,16 @@ pub(super) struct PreparedConfigChange {
     pub value: String,
 }
 
-/// Gate + compose a read. Any authorized caller may look at any open session's
-/// controls; a closed target is refused rather than answered with an empty menu.
+/// Gate + compose a read. Any authorized caller may look at any LIVE-able
+/// session's controls; a closed or dismissed target is refused rather than
+/// answered with a menu it can never act on.
+///
+/// Read and write stay SYMMETRIC on the terminal states on purpose. The change
+/// path's `Send` funnel already refuses both, so a read path that answered them
+/// would advertise a full menu and then refuse every single item on it — the
+/// advertised-then-refused trap, and the worst shape for an agent that has to
+/// decide what to do next from the read alone. A composed menu for a session
+/// that can never boot again describes nothing, so saying so IS the answer.
 pub(super) fn compose_agent_config_options<C, L>(
     session_store: &SessionStore,
     caller_session_id: &str,
@@ -157,8 +204,8 @@ where
         AgentAccessIntent::Read,
     )?
     .target;
-    if target_is_closed(&target) {
-        return Err(AgentConfigError::TargetClosed);
+    if let Some(error) = target_config_is_unreachable(&target) {
+        return Err(error);
     }
     compose(
         target,
@@ -376,19 +423,30 @@ fn validate_change(
             available: composed.config_ids(),
         });
     };
-    if control
+    if !control
         .values
         .iter()
         .any(|candidate| candidate.value == value)
     {
-        return Ok(());
+        return Err(AgentConfigError::ValueNotAvailable {
+            session_id: composed.target.id.clone(),
+            config_id: config_id.to_string(),
+            value: value.to_string(),
+            available: join_quoted(control.values.iter().map(|value| value.value.as_str())),
+        });
     }
-    Err(AgentConfigError::ValueNotAvailable {
-        session_id: composed.target.id.clone(),
-        config_id: config_id.to_string(),
-        value: value.to_string(),
-        available: join_quoted(control.values.iter().map(|value| value.value.as_str())),
-    })
+    // Value-membership first, so a bogus value still gets the precise "here is
+    // what IS available" error. Only a value that would have been accepted can
+    // reach the settability check, and by then the only way to fail it is the
+    // no-op: the one value on offer is already current.
+    if !control.settable() {
+        return Err(AgentConfigError::ControlNotSettable {
+            session_id: composed.target.id.clone(),
+            config_id: config_id.to_string(),
+            value: value.to_string(),
+        });
+    }
+    Ok(())
 }
 
 fn join_quoted<'a>(values: impl Iterator<Item = &'a str>) -> String {
@@ -403,12 +461,22 @@ fn join_quoted<'a>(values: impl Iterator<Item = &'a str>) -> String {
     }
 }
 
-/// Local copy of `authorize::is_closed`, which is private to that module. The
-/// funnel already refuses a closed target for `Send`; only the READ path needs
-/// this, and only because reading a config is the one read that a closed
-/// session cannot answer. Collapse the two if that predicate is ever exported.
-fn target_is_closed(session: &SessionRecord) -> bool {
-    session.closed_at.is_some() || session.status == "closed"
+/// The READ path's copy of the two terminal states the `Send` funnel already
+/// refuses (`authorize::authorize`). Reading a config is the one read that a
+/// terminal session cannot answer, so the read path takes the same decision
+/// deliberately rather than composing a menu nobody can apply.
+///
+/// `is_closed` is the funnel's own predicate, shared so "closed" means one
+/// thing everywhere; dismissed is checked here the same way the funnel checks
+/// it, off `dismissed_at`.
+fn target_config_is_unreachable(session: &SessionRecord) -> Option<AgentConfigError> {
+    if authorize::is_closed(session) {
+        Some(AgentConfigError::TargetClosed)
+    } else if session.dismissed_at.is_some() {
+        Some(AgentConfigError::TargetDismissed)
+    } else {
+        None
+    }
 }
 
 pub(super) fn controls_to_json(controls: &[ComposedControl]) -> Vec<Value> {
@@ -817,6 +885,63 @@ mod tests {
     }
 
     #[test]
+    fn a_dismissed_target_is_refused_for_both_reads_and_changes() {
+        // Read and write stay symmetric on the terminal states. The change path
+        // was always refused by the `Send` funnel; the READ path refuses too,
+        // because a dismissed session is never launched again
+        // (`runtime/launch_policy.rs`), so a composed menu for it is a list of
+        // changes that can never be applied — advertised, then refused.
+        let store = store_fixture();
+        let mut dismissed = session_record("ses_dismissed", "workspace-2");
+        dismissed.dismissed_at = Some("2026-08-08T01:00:00Z".to_string());
+        store.insert(&dismissed).expect("insert dismissed target");
+
+        let spy = CatalogSpy::new();
+        let read = compose_agent_config_options(
+            &store,
+            "ses_caller",
+            "ses_dismissed",
+            spy.resolver(),
+            no_live_config,
+        )
+        .err()
+        .expect("dismissed target has no options to read");
+        assert!(matches!(read, AgentConfigError::TargetDismissed));
+        // The refusal is about configuration, and it never composed anything to
+        // refuse — the catalog was not even consulted.
+        assert!(read.to_string().contains("configuration"));
+        assert!(spy.asked.borrow().is_empty());
+
+        let change = prepare_agent_config_change(
+            &store,
+            "ses_caller",
+            "ses_dismissed",
+            "model",
+            "target-only-model",
+            CatalogSpy::new().resolver(),
+            no_live_config,
+        )
+        .err()
+        .expect("dismissed target takes no changes");
+        assert!(matches!(
+            change,
+            AgentConfigError::Access(AgentAccessError::TargetDismissed)
+        ));
+
+        // Negative control: the same caller and the same catalog DO compose a
+        // menu for an ordinary target, so the refusals above are the terminal
+        // state and not a blanket block.
+        compose_agent_config_options(
+            &store,
+            "ses_caller",
+            "ses_target",
+            CatalogSpy::new().resolver(),
+            no_live_config,
+        )
+        .expect("an ordinary target still reads");
+    }
+
+    #[test]
     fn the_caller_cannot_configure_itself() {
         let store = store_fixture();
 
@@ -843,6 +968,98 @@ mod tests {
             no_live_config,
         )
         .expect("reading your own options is allowed");
+    }
+
+    #[test]
+    fn a_control_reported_unsettable_also_refuses_the_change() {
+        // `settable` is what the read advertises; this is the write keeping it.
+        // workspace-1's catalog offers exactly one model, and the target has
+        // already selected it — so the menu is a dead end and the only value it
+        // lists is a no-op.
+        let store = store_fixture();
+        let mut target = session_record("ses_single", "workspace-1");
+        target.current_model_id = Some("caller-only-model".to_string());
+        store.insert(&target).expect("insert single-option target");
+
+        let composed = compose_agent_config_options(
+            &store,
+            "ses_caller",
+            "ses_single",
+            CatalogSpy::new().resolver(),
+            no_live_config,
+        )
+        .expect("compose options");
+        let model = composed.control("model").expect("model control");
+        assert_eq!(model.values.len(), 1);
+        assert!(!model.settable(), "the only value is already current");
+
+        let error = prepare_agent_config_change(
+            &store,
+            "ses_caller",
+            "ses_single",
+            "model",
+            "caller-only-model",
+            CatalogSpy::new().resolver(),
+            no_live_config,
+        )
+        .err()
+        .expect("re-asserting the only value is refused, not silently applied");
+        assert!(matches!(
+            error,
+            AgentConfigError::ControlNotSettable { ref config_id, .. } if config_id == "model"
+        ));
+
+        // A value that is not on the menu at all still gets the more specific
+        // "here is what IS available" error, not this one.
+        let unknown_value = prepare_agent_config_change(
+            &store,
+            "ses_caller",
+            "ses_single",
+            "model",
+            "target-only-model",
+            CatalogSpy::new().resolver(),
+            no_live_config,
+        )
+        .err()
+        .expect("an off-menu value is refused");
+        assert!(matches!(
+            unknown_value,
+            AgentConfigError::ValueNotAvailable { .. }
+        ));
+    }
+
+    #[test]
+    fn a_single_value_control_is_settable_while_it_is_not_current() {
+        // The legitimate single-value change: the harness offers one option the
+        // session has not selected yet, so applying it moves something. A
+        // blanket `values.len() > 1` rule would have refused this.
+        let store = store_fixture();
+        let target = session_record("ses_unselected", "workspace-1");
+        store.insert(&target).expect("insert target");
+
+        let composed = compose_agent_config_options(
+            &store,
+            "ses_caller",
+            "ses_unselected",
+            CatalogSpy::new().resolver(),
+            no_live_config,
+        )
+        .expect("compose options");
+        let model = composed.control("model").expect("model control");
+        assert_eq!(model.values.len(), 1);
+        assert_eq!(model.current_value, None);
+        assert!(model.settable(), "one value, none selected yet");
+
+        prepare_agent_config_change(
+            &store,
+            "ses_caller",
+            "ses_unselected",
+            "model",
+            "caller-only-model",
+            CatalogSpy::new().resolver(),
+            no_live_config,
+        )
+        .expect("selecting the one option for the first time is a real change");
     }
 
     #[test]
@@ -892,21 +1109,43 @@ mod tests {
             .find("async fn configure_agent(")
             .expect("configure_agent is defined in calls.rs");
         let rest = &text[start..];
-        let body = &rest[..rest[1..]
-            .find("\nasync fn ")
-            .or_else(|| rest[1..].find("\nfn "))
-            .map_or(rest.len(), |at| at + 1)];
+        // The window ends at whichever item header comes FIRST. Taking the
+        // `async fn` position and only falling back to `fn` when there is none
+        // would swallow every plain `fn` in between, widening the window past
+        // this function and letting an out-of-order call in a later one satisfy
+        // the assertions below.
+        let after = &rest[1..];
+        let end = [after.find("\nasync fn "), after.find("\nfn ")]
+            .into_iter()
+            .flatten()
+            .min()
+            .map_or(rest.len(), |at| at + 1);
+        let body = &rest[..end];
+        // Whitespace runs collapse to one space so the needles can span a `let`
+        // binding without a rustfmt wrap breaking them.
+        let squashed = body.split_whitespace().collect::<Vec<_>>().join(" ");
+        let squashed = squashed.as_str();
 
-        let prepared_at = body
+        let prepared_at = squashed
             .find("prepare_agent_config_change(")
             .expect("configure_agent validates against the target's composed options");
-        let admitted_at = body
-            .find("admit_peer_mutation(")
-            .expect("configure_agent takes the target's session mutation permit");
-        let leased_at = body
-            .find("lease_target_workspace_for_peer_write(")
-            .expect("configure_agent leases the TARGET's workspace, not the route's");
-        let applied_at = body
+        // Pin the BINDING, not the call: `let _ = admit_peer_mutation(..)` drops
+        // the permit at the end of its own statement, and is indistinguishable
+        // from a held one if only the call substring is matched. Order alone is
+        // not the guarantee — the guards have to still be HELD at the apply.
+        let admitted_at = squashed
+            .find("let _admission_permit = admit_peer_mutation(")
+            .expect(
+                "configure_agent must BIND the target's session mutation permit as \
+                 `_admission_permit`; an unbound `let _ =` drops it immediately",
+            );
+        let leased_at = squashed
+            .find("let _target_workspace_lease = lease_target_workspace_for_peer_write(")
+            .expect(
+                "configure_agent must BIND the TARGET workspace lease as \
+                 `_target_workspace_lease`; an unbound `let _ =` drops it immediately",
+            );
+        let applied_at = squashed
             .find("set_live_session_config_option(")
             .expect("configure_agent applies through the existing runtime path");
 
@@ -926,14 +1165,14 @@ mod tests {
         );
         // The apply gets the VALIDATED triple, never the raw arguments: an
         // untrimmed/unvalidated configId or value would bypass the composed
-        // universe entirely. Whitespace is stripped from both sides so a
-        // reformat that wraps the argument list does not read as a regression.
-        let squashed = body
+        // universe entirely. Whitespace is stripped entirely from both sides so
+        // a reformat that wraps the argument list does not read as a regression.
+        let tight = body
             .chars()
             .filter(|c| !c.is_whitespace())
             .collect::<String>();
         assert!(
-            squashed.contains(
+            tight.contains(
                 "set_live_session_config_option(&prepared.target.id,&prepared.config_id,&prepared.value"
             ),
             "configure_agent must apply the validated target/configId/value, not the raw args"
@@ -946,7 +1185,7 @@ mod tests {
         // caller's, which for a cross-workspace target is the wrong workspace
         // to hold open against retire.
         assert!(
-            squashed.contains("&prepared.target.workspace_id,"),
+            tight.contains("&prepared.target.workspace_id,"),
             "the workspace lease must be taken on the TARGET's workspace"
         );
     }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/config_ops.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/config_ops.rs
@@ -1,0 +1,973 @@
+//! What the configure tools decide before the runtime applies anything.
+//!
+//! Two questions, one answer: which knobs does the TARGET have right now, and
+//! is the value the caller named one of them? Both are answered by composing
+//! the target's live snapshot (what its harness advertises) with the launch
+//! options resolved for the TARGET's workspace (what that machine may launch
+//! there) — never the caller's workspace. A cross-workspace target is the
+//! normal case for a peer tool, and the two workspaces can have entirely
+//! different catalogs, readiness and auth contexts.
+//!
+//! The catalog and snapshot arrive as closures rather than a `SessionRuntime`
+//! so the composition — including *which workspace id it asks about* — is
+//! testable without a runtime.
+
+use anyharness_contract::v1::{NormalizedSessionControl, SessionLiveConfigSnapshot};
+use serde_json::{json, Value};
+
+use crate::domains::agents::readiness::launch_options::ResolvedWorkspaceLaunchOptions;
+use crate::domains::sessions::authorize::{authorize, AgentAccessError, AgentAccessIntent};
+use crate::domains::sessions::live_config::ACP_MODEL_COMPAT_CONFIG_ID;
+use crate::domains::sessions::model::SessionRecord;
+use crate::domains::sessions::store::SessionStore;
+
+/// Where a selectable value came from, so the agent can tell an option its
+/// harness is advertising right now from one only the workspace catalog
+/// authorizes (which applies through a relaunch).
+pub(super) const VALUE_SOURCE_LIVE: &str = "live";
+pub(super) const VALUE_SOURCE_WORKSPACE_CATALOG: &str = "workspace_catalog";
+
+#[derive(Debug, thiserror::Error)]
+pub(super) enum AgentConfigError {
+    #[error(transparent)]
+    Access(#[from] AgentAccessError),
+    /// Read intent tolerates a closed target because transcripts outlive the
+    /// agent. Config options do not: a closed session's actor never starts
+    /// again, so its "what can I change now" answer is always "nothing".
+    /// Saying so beats handing back an empty menu that reads like a harness
+    /// with no controls.
+    #[error(
+        "target session is closed; a closed agent has no configuration left to read or change"
+    )]
+    TargetClosed,
+    /// An agent reconfiguring itself would route a config command at the very
+    /// actor that is blocked inside this tool call, and would queue behind its
+    /// own turn. Harness-native controls are the way to change your own model.
+    #[error("configure_agent cannot target the calling session; use your harness's own controls to change your configuration")]
+    SelfTarget,
+    #[error("configId is required")]
+    EmptyConfigId,
+    #[error("value is required")]
+    EmptyValue,
+    #[error("unknown configId {config_id:?} for session {session_id}; call get_agent_config_options first. Available: {available}")]
+    UnknownConfigId {
+        session_id: String,
+        config_id: String,
+        available: String,
+    },
+    #[error("value {value:?} is not available for configId {config_id:?} on session {session_id}; available: {available}")]
+    ValueNotAvailable {
+        session_id: String,
+        config_id: String,
+        value: String,
+        available: String,
+    },
+    #[error(transparent)]
+    Internal(#[from] anyhow::Error),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ComposedValue {
+    pub value: String,
+    pub label: String,
+    pub source: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ComposedControl {
+    /// The identifier `configure_agent` takes — the same `configId` the human
+    /// client posts to `/v1/sessions/{id}/config-options`.
+    pub config_id: String,
+    /// The normalized product key (`model`, `mode`, `effort`, …) when the
+    /// control maps to one.
+    pub key: Option<String>,
+    pub label: String,
+    pub current_value: Option<String>,
+    pub values: Vec<ComposedValue>,
+}
+
+impl ComposedControl {
+    fn settable(&self) -> bool {
+        self.values.len() > 1
+    }
+
+    fn push_value(&mut self, value: String, label: String, source: &'static str) {
+        if self.values.iter().any(|existing| existing.value == value) {
+            return;
+        }
+        self.values.push(ComposedValue {
+            value,
+            label,
+            source,
+        });
+    }
+}
+
+/// The whole answer for one target: who it is, which workspace's catalog was
+/// composed in, the union of its knobs, and the raw live snapshot verbatim.
+#[derive(Debug, Clone)]
+pub(super) struct ComposedAgentConfig {
+    pub target: SessionRecord,
+    /// The workspace whose launch options were composed. Always the target's.
+    pub catalog_workspace_id: String,
+    pub controls: Vec<ComposedControl>,
+    pub live_config: Option<SessionLiveConfigSnapshot>,
+}
+
+impl ComposedAgentConfig {
+    fn control(&self, config_id: &str) -> Option<&ComposedControl> {
+        self.controls
+            .iter()
+            .find(|control| control.config_id == config_id)
+    }
+
+    fn config_ids(&self) -> String {
+        join_quoted(
+            self.controls
+                .iter()
+                .map(|control| control.config_id.as_str()),
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct PreparedConfigChange {
+    pub target: SessionRecord,
+    pub config_id: String,
+    pub value: String,
+}
+
+/// Gate + compose a read. Any authorized caller may look at any open session's
+/// controls; a closed target is refused rather than answered with an empty menu.
+pub(super) fn compose_agent_config_options<C, L>(
+    session_store: &SessionStore,
+    caller_session_id: &str,
+    target_session_id: &str,
+    resolve_workspace_launch_options: C,
+    live_config_snapshot: L,
+) -> Result<ComposedAgentConfig, AgentConfigError>
+where
+    C: FnOnce(&str) -> anyhow::Result<ResolvedWorkspaceLaunchOptions>,
+    L: FnOnce(&str) -> anyhow::Result<Option<SessionLiveConfigSnapshot>>,
+{
+    let target = authorize(
+        session_store,
+        caller_session_id,
+        target_session_id,
+        AgentAccessIntent::Read,
+    )?
+    .target;
+    if target_is_closed(&target) {
+        return Err(AgentConfigError::TargetClosed);
+    }
+    compose(
+        target,
+        resolve_workspace_launch_options,
+        live_config_snapshot,
+    )
+}
+
+/// Gate + compose + validate a change. Everything here is read-only: the
+/// admission permit and the apply come after, at the call site, so a refusal
+/// never costs a permit.
+pub(super) fn prepare_agent_config_change<C, L>(
+    session_store: &SessionStore,
+    caller_session_id: &str,
+    target_session_id: &str,
+    config_id: &str,
+    value: &str,
+    resolve_workspace_launch_options: C,
+    live_config_snapshot: L,
+) -> Result<PreparedConfigChange, AgentConfigError>
+where
+    C: FnOnce(&str) -> anyhow::Result<ResolvedWorkspaceLaunchOptions>,
+    L: FnOnce(&str) -> anyhow::Result<Option<SessionLiveConfigSnapshot>>,
+{
+    let config_id = config_id.trim();
+    if config_id.is_empty() {
+        return Err(AgentConfigError::EmptyConfigId);
+    }
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(AgentConfigError::EmptyValue);
+    }
+    // Send intent, not Read: this reaches the target's actor, so the funnel
+    // decides self/closed/dismissed/internal-only; nothing is
+    // re-decided here. Only the wording of the self refusal is config-specific
+    // — the funnel's message talks about messaging.
+    let target = authorize(
+        session_store,
+        caller_session_id,
+        target_session_id,
+        AgentAccessIntent::Send,
+    )
+    .map_err(|error| match error {
+        AgentAccessError::SelfTarget => AgentConfigError::SelfTarget,
+        other => AgentConfigError::Access(other),
+    })?
+    .target;
+    let composed = compose(
+        target,
+        resolve_workspace_launch_options,
+        live_config_snapshot,
+    )?;
+    validate_change(&composed, config_id, value)?;
+    Ok(PreparedConfigChange {
+        target: composed.target,
+        config_id: config_id.to_string(),
+        value: value.to_string(),
+    })
+}
+
+fn compose<C, L>(
+    target: SessionRecord,
+    resolve_workspace_launch_options: C,
+    live_config_snapshot: L,
+) -> Result<ComposedAgentConfig, AgentConfigError>
+where
+    C: FnOnce(&str) -> anyhow::Result<ResolvedWorkspaceLaunchOptions>,
+    L: FnOnce(&str) -> anyhow::Result<Option<SessionLiveConfigSnapshot>>,
+{
+    // The TARGET's workspace. Composing the caller's would advertise models
+    // that the target's machine/auth contexts may not serve at all.
+    let catalog = resolve_workspace_launch_options(&target.workspace_id)?;
+    let live_config = live_config_snapshot(&target.id)?;
+    let controls = compose_controls(&target, &catalog, live_config.as_ref());
+    Ok(ComposedAgentConfig {
+        catalog_workspace_id: target.workspace_id.clone(),
+        target,
+        controls,
+        live_config,
+    })
+}
+
+fn compose_controls(
+    target: &SessionRecord,
+    catalog: &ResolvedWorkspaceLaunchOptions,
+    live_config: Option<&SessionLiveConfigSnapshot>,
+) -> Vec<ComposedControl> {
+    let mut controls: Vec<ComposedControl> = Vec::new();
+
+    if let Some(snapshot) = live_config {
+        let normalized = &snapshot.normalized_controls;
+        for control in [
+            normalized.model.as_ref(),
+            normalized.collaboration_mode.as_ref(),
+            normalized.mode.as_ref(),
+            normalized.reasoning.as_ref(),
+            normalized.effort.as_ref(),
+            normalized.fast_mode.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        .chain(normalized.extras.iter())
+        {
+            push_control(&mut controls, from_normalized(control));
+        }
+        // Raw options the normalizer did not claim under any key still take a
+        // configId — the apply path routes on the raw id, so anything the
+        // harness advertises stays reachable.
+        for option in &snapshot.raw_config_options {
+            let mut control = ComposedControl {
+                config_id: option.id.clone(),
+                key: option.category.clone(),
+                label: option.name.clone(),
+                current_value: Some(option.current_value.clone()),
+                values: Vec::new(),
+            };
+            for value in &option.options {
+                control.push_value(value.value.clone(), value.name.clone(), VALUE_SOURCE_LIVE);
+            }
+            push_control(&mut controls, control);
+        }
+    }
+
+    // The model universe the TARGET's workspace can serve. This is what makes
+    // a model switch legal even when the harness advertises a shorter list (or
+    // none at all, on a session that has never run): the apply path itself
+    // authorizes catalog models and relaunches when the live actor refuses.
+    let model_config_id = live_config
+        .and_then(|snapshot| snapshot.normalized_controls.model.as_ref())
+        .map(|control| control.raw_config_id.clone())
+        .unwrap_or_else(|| ACP_MODEL_COMPAT_CONFIG_ID.to_string());
+    let model_index = match controls
+        .iter()
+        .position(|control| control.config_id == model_config_id)
+    {
+        Some(index) => index,
+        None => {
+            controls.insert(
+                0,
+                ComposedControl {
+                    config_id: model_config_id,
+                    key: Some("model".to_string()),
+                    label: "Model".to_string(),
+                    current_value: target
+                        .current_model_id
+                        .clone()
+                        .or_else(|| target.requested_model_id.clone()),
+                    values: Vec::new(),
+                },
+            );
+            0
+        }
+    };
+    if let Some(agent) = catalog
+        .agents
+        .iter()
+        .find(|agent| agent.kind == target.agent_kind)
+    {
+        let control = &mut controls[model_index];
+        for model in &agent.models {
+            control.push_value(
+                model.id.clone(),
+                model.display_name.clone(),
+                VALUE_SOURCE_WORKSPACE_CATALOG,
+            );
+            for alias in &model.aliases {
+                control.push_value(
+                    alias.clone(),
+                    model.display_name.clone(),
+                    VALUE_SOURCE_WORKSPACE_CATALOG,
+                );
+            }
+        }
+    }
+
+    controls
+}
+
+fn from_normalized(control: &NormalizedSessionControl) -> ComposedControl {
+    let mut composed = ComposedControl {
+        config_id: control.raw_config_id.clone(),
+        key: Some(control.key.clone()),
+        label: control.label.clone(),
+        current_value: control.current_value.clone(),
+        values: Vec::new(),
+    };
+    for value in &control.values {
+        composed.push_value(value.value.clone(), value.label.clone(), VALUE_SOURCE_LIVE);
+    }
+    composed
+}
+
+fn push_control(controls: &mut Vec<ComposedControl>, control: ComposedControl) {
+    if let Some(existing) = controls
+        .iter_mut()
+        .find(|existing| existing.config_id == control.config_id)
+    {
+        for value in control.values {
+            existing.push_value(value.value, value.label, value.source);
+        }
+        return;
+    }
+    controls.push(control);
+}
+
+fn validate_change(
+    composed: &ComposedAgentConfig,
+    config_id: &str,
+    value: &str,
+) -> Result<(), AgentConfigError> {
+    let Some(control) = composed.control(config_id) else {
+        return Err(AgentConfigError::UnknownConfigId {
+            session_id: composed.target.id.clone(),
+            config_id: config_id.to_string(),
+            available: composed.config_ids(),
+        });
+    };
+    if control
+        .values
+        .iter()
+        .any(|candidate| candidate.value == value)
+    {
+        return Ok(());
+    }
+    Err(AgentConfigError::ValueNotAvailable {
+        session_id: composed.target.id.clone(),
+        config_id: config_id.to_string(),
+        value: value.to_string(),
+        available: join_quoted(control.values.iter().map(|value| value.value.as_str())),
+    })
+}
+
+fn join_quoted<'a>(values: impl Iterator<Item = &'a str>) -> String {
+    let joined = values
+        .map(|value| format!("{value:?}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    if joined.is_empty() {
+        "(none)".to_string()
+    } else {
+        joined
+    }
+}
+
+/// Local copy of `authorize::is_closed`, which is private to that module. The
+/// funnel already refuses a closed target for `Send`; only the READ path needs
+/// this, and only because reading a config is the one read that a closed
+/// session cannot answer. Collapse the two if that predicate is ever exported.
+fn target_is_closed(session: &SessionRecord) -> bool {
+    session.closed_at.is_some() || session.status == "closed"
+}
+
+pub(super) fn controls_to_json(controls: &[ComposedControl]) -> Vec<Value> {
+    controls
+        .iter()
+        .map(|control| {
+            json!({
+                "configId": control.config_id,
+                "key": control.key,
+                "label": control.label,
+                "currentValue": control.current_value,
+                "settable": control.settable(),
+                "values": control.values.iter().map(|value| json!({
+                    "value": value.value,
+                    "label": value.label,
+                    "source": value.source,
+                })).collect::<Vec<_>>(),
+            })
+        })
+        .collect()
+}
+
+/// What the target's row currently records. The live snapshot is the truth for
+/// a running agent; this is what a relaunch would converge back to.
+pub(super) fn current_selection_to_json(target: &SessionRecord) -> Value {
+    json!({
+        "modelId": target.current_model_id.clone().or_else(|| target.requested_model_id.clone()),
+        "requestedModelId": target.requested_model_id,
+        "modeId": target.current_mode_id.clone().or_else(|| target.requested_mode_id.clone()),
+        "requestedModeId": target.requested_mode_id,
+        "thinkingLevelId": target.thinking_level_id,
+        "thinkingBudgetTokens": target.thinking_budget_tokens,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::test_support;
+    use crate::domains::agents::readiness::launch_options::{
+        ResolvedLaunchAgentOption, ResolvedLaunchModelOption,
+    };
+    use crate::domains::sessions::model::SessionMcpBindingPolicy;
+    use crate::persistence::Db;
+    use anyharness_contract::v1::{
+        NormalizedSessionControl, NormalizedSessionControlValue, NormalizedSessionControls,
+        PromptCapabilities,
+    };
+    use std::cell::RefCell;
+
+    fn session_record(id: &str, workspace_id: &str) -> SessionRecord {
+        SessionRecord {
+            id: id.to_string(),
+            workspace_id: workspace_id.to_string(),
+            agent_kind: "claude".to_string(),
+            native_session_id: None,
+            agent_auth_contexts: None,
+            requested_model_id: None,
+            current_model_id: None,
+            requested_mode_id: None,
+            current_mode_id: None,
+            title: None,
+            thinking_level_id: None,
+            thinking_budget_tokens: None,
+            status: "idle".to_string(),
+            created_at: "2026-08-08T00:00:00Z".to_string(),
+            updated_at: "2026-08-08T00:00:00Z".to_string(),
+            last_prompt_at: None,
+            closed_at: None,
+            dismissed_at: None,
+            mcp_bindings_ciphertext: None,
+            mcp_binding_summaries_json: None,
+            mcp_binding_policy: SessionMcpBindingPolicy::InheritWorkspace,
+            system_prompt_append: None,
+            subagents_enabled: true,
+            action_capabilities_json: None,
+            origin: None,
+        }
+    }
+
+    fn store_fixture() -> SessionStore {
+        let db = Db::open_in_memory().expect("open db");
+        test_support::seed_workspace_with_repo_root(
+            &db,
+            "workspace-1",
+            "local",
+            "/tmp/workspace-1",
+        );
+        test_support::seed_workspace_with_repo_root(
+            &db,
+            "workspace-2",
+            "local",
+            "/tmp/workspace-2",
+        );
+        let store = SessionStore::new(db);
+        store
+            .insert(&session_record("ses_caller", "workspace-1"))
+            .expect("insert caller");
+        store
+            .insert(&session_record("ses_target", "workspace-2"))
+            .expect("insert target");
+        store
+    }
+
+    fn model_option(id: &str) -> ResolvedLaunchModelOption {
+        ResolvedLaunchModelOption {
+            id: id.to_string(),
+            display_name: id.to_string(),
+            aliases: Vec::new(),
+            is_default: false,
+            default_opt_in: None,
+            description: None,
+            provider: None,
+            status: None,
+            effort: None,
+            live_effort_candidates: Vec::new(),
+            fast_mode: false,
+            modes: None,
+        }
+    }
+
+    fn catalog(model_ids: &[&str]) -> ResolvedWorkspaceLaunchOptions {
+        ResolvedWorkspaceLaunchOptions {
+            agents: vec![ResolvedLaunchAgentOption {
+                kind: "claude".to_string(),
+                display_name: "Claude".to_string(),
+                default_model_id: model_ids.first().map(|id| (*id).to_string()),
+                unattended_mode_id: None,
+                models: model_ids.iter().map(|id| model_option(id)).collect(),
+            }],
+        }
+    }
+
+    fn snapshot_with_mode(mode_ids: &[&str]) -> SessionLiveConfigSnapshot {
+        SessionLiveConfigSnapshot {
+            raw_config_options: Vec::new(),
+            normalized_controls: NormalizedSessionControls {
+                mode: Some(NormalizedSessionControl {
+                    key: "mode".to_string(),
+                    raw_config_id: "mode".to_string(),
+                    label: "Mode".to_string(),
+                    current_value: mode_ids.first().map(|id| (*id).to_string()),
+                    settable: mode_ids.len() > 1,
+                    values: mode_ids
+                        .iter()
+                        .map(|id| NormalizedSessionControlValue {
+                            value: (*id).to_string(),
+                            label: (*id).to_string(),
+                            description: None,
+                        })
+                        .collect(),
+                }),
+                ..Default::default()
+            },
+            prompt_capabilities: PromptCapabilities::default(),
+            source_seq: 1,
+            updated_at: "2026-08-08T00:00:00Z".to_string(),
+        }
+    }
+
+    /// Records which workspace id the composition asked the catalog about.
+    struct CatalogSpy {
+        asked: RefCell<Vec<String>>,
+    }
+
+    impl CatalogSpy {
+        fn new() -> Self {
+            Self {
+                asked: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn resolver(
+            &self,
+        ) -> impl FnOnce(&str) -> anyhow::Result<ResolvedWorkspaceLaunchOptions> + '_ {
+            move |workspace_id: &str| {
+                self.asked.borrow_mut().push(workspace_id.to_string());
+                // Deliberately different menus per workspace: composing the
+                // wrong one is then visible in the result, not just in the spy.
+                Ok(match workspace_id {
+                    "workspace-1" => catalog(&["caller-only-model"]),
+                    "workspace-2" => catalog(&["target-only-model", "target-second-model"]),
+                    _ => catalog(&[]),
+                })
+            }
+        }
+    }
+
+    fn no_live_config(_session_id: &str) -> anyhow::Result<Option<SessionLiveConfigSnapshot>> {
+        Ok(None)
+    }
+
+    #[test]
+    fn options_for_a_target_in_another_workspace_come_from_the_targets_catalog() {
+        let store = store_fixture();
+        let spy = CatalogSpy::new();
+
+        let composed = compose_agent_config_options(
+            &store,
+            "ses_caller",
+            "ses_target",
+            spy.resolver(),
+            no_live_config,
+        )
+        .expect("compose options");
+
+        // The caller lives in workspace-1; the target in workspace-2.
+        assert_eq!(spy.asked.borrow().as_slice(), ["workspace-2"]);
+        assert_eq!(composed.catalog_workspace_id, "workspace-2");
+        let model = composed.control("model").expect("model control");
+        let values = model
+            .values
+            .iter()
+            .map(|value| value.value.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(values, ["target-only-model", "target-second-model"]);
+        assert!(!values.contains(&"caller-only-model"));
+    }
+
+    #[test]
+    fn a_model_only_the_callers_workspace_offers_is_rejected() {
+        // The other half of the same guarantee: composing the caller's catalog
+        // would make this succeed.
+        let store = store_fixture();
+        let spy = CatalogSpy::new();
+
+        let error = prepare_agent_config_change(
+            &store,
+            "ses_caller",
+            "ses_target",
+            "model",
+            "caller-only-model",
+            spy.resolver(),
+            no_live_config,
+        )
+        .err()
+        .expect("a caller-workspace model is not in the target's universe");
+
+        assert!(matches!(
+            error,
+            AgentConfigError::ValueNotAvailable { ref value, .. } if value == "caller-only-model"
+        ));
+        assert_eq!(spy.asked.borrow().as_slice(), ["workspace-2"]);
+    }
+
+    #[test]
+    fn a_model_the_targets_workspace_offers_is_accepted() {
+        let store = store_fixture();
+        let spy = CatalogSpy::new();
+
+        let prepared = prepare_agent_config_change(
+            &store,
+            "ses_caller",
+            "ses_target",
+            "model",
+            "target-only-model",
+            spy.resolver(),
+            no_live_config,
+        )
+        .expect("target-workspace model is accepted");
+
+        assert_eq!(prepared.target.id, "ses_target");
+        assert_eq!(prepared.config_id, "model");
+        assert_eq!(prepared.value, "target-only-model");
+    }
+
+    #[test]
+    fn an_unknown_config_id_names_what_is_available() {
+        let store = store_fixture();
+        let spy = CatalogSpy::new();
+
+        let error = prepare_agent_config_change(
+            &store,
+            "ses_caller",
+            "ses_target",
+            "telepathy",
+            "on",
+            spy.resolver(),
+            no_live_config,
+        )
+        .err()
+        .expect("unknown configId is rejected");
+
+        assert!(matches!(
+            error,
+            AgentConfigError::UnknownConfigId { ref config_id, .. } if config_id == "telepathy"
+        ));
+        assert!(error.to_string().contains("\"model\""));
+    }
+
+    #[test]
+    fn a_value_outside_the_live_controls_universe_is_rejected() {
+        let store = store_fixture();
+        let spy = CatalogSpy::new();
+
+        let error = prepare_agent_config_change(
+            &store,
+            "ses_caller",
+            "ses_target",
+            "mode",
+            "yolo",
+            spy.resolver(),
+            |_| Ok(Some(snapshot_with_mode(&["plan", "edit"]))),
+        )
+        .err()
+        .expect("a mode the harness does not advertise is rejected");
+
+        assert!(matches!(
+            error,
+            AgentConfigError::ValueNotAvailable { ref config_id, .. } if config_id == "mode"
+        ));
+        assert!(error.to_string().contains("\"plan\""));
+
+        // The same call with an advertised value goes through.
+        let spy = CatalogSpy::new();
+        prepare_agent_config_change(
+            &store,
+            "ses_caller",
+            "ses_target",
+            "mode",
+            "edit",
+            spy.resolver(),
+            |_| Ok(Some(snapshot_with_mode(&["plan", "edit"]))),
+        )
+        .expect("an advertised mode is accepted");
+    }
+
+    #[test]
+    fn live_values_and_catalog_models_merge_under_one_model_control() {
+        let store = store_fixture();
+        let spy = CatalogSpy::new();
+        let mut snapshot = snapshot_with_mode(&["plan"]);
+        snapshot.normalized_controls.model = Some(NormalizedSessionControl {
+            key: "model".to_string(),
+            raw_config_id: "model".to_string(),
+            label: "Model".to_string(),
+            current_value: Some("live-only-model".to_string()),
+            settable: false,
+            values: vec![NormalizedSessionControlValue {
+                value: "live-only-model".to_string(),
+                label: "Live only".to_string(),
+                description: None,
+            }],
+        });
+
+        let composed = compose_agent_config_options(
+            &store,
+            "ses_caller",
+            "ses_target",
+            spy.resolver(),
+            |_| Ok(Some(snapshot)),
+        )
+        .expect("compose options");
+
+        let model = composed.control("model").expect("model control");
+        let sources = model
+            .values
+            .iter()
+            .map(|value| (value.value.as_str(), value.source))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            sources,
+            [
+                ("live-only-model", VALUE_SOURCE_LIVE),
+                ("target-only-model", VALUE_SOURCE_WORKSPACE_CATALOG),
+                ("target-second-model", VALUE_SOURCE_WORKSPACE_CATALOG),
+            ]
+        );
+        assert_eq!(model.current_value.as_deref(), Some("live-only-model"));
+    }
+
+    #[test]
+    fn a_closed_target_is_refused_for_both_reads_and_changes() {
+        let store = store_fixture();
+        let mut closed = session_record("ses_closed", "workspace-2");
+        closed.closed_at = Some("2026-08-08T01:00:00Z".to_string());
+        closed.status = "closed".to_string();
+        store.insert(&closed).expect("insert closed target");
+
+        let read = compose_agent_config_options(
+            &store,
+            "ses_caller",
+            "ses_closed",
+            CatalogSpy::new().resolver(),
+            no_live_config,
+        )
+        .err()
+        .expect("closed target has no options to read");
+        assert!(matches!(read, AgentConfigError::TargetClosed));
+
+        let change = prepare_agent_config_change(
+            &store,
+            "ses_caller",
+            "ses_closed",
+            "model",
+            "target-only-model",
+            CatalogSpy::new().resolver(),
+            no_live_config,
+        )
+        .err()
+        .expect("closed target takes no changes");
+        assert!(matches!(
+            change,
+            AgentConfigError::Access(AgentAccessError::TargetClosed)
+        ));
+    }
+
+    #[test]
+    fn the_caller_cannot_configure_itself() {
+        let store = store_fixture();
+
+        let error = prepare_agent_config_change(
+            &store,
+            "ses_caller",
+            "ses_caller",
+            "model",
+            "caller-only-model",
+            CatalogSpy::new().resolver(),
+            no_live_config,
+        )
+        .err()
+        .expect("self target is rejected");
+
+        assert!(matches!(error, AgentConfigError::SelfTarget));
+
+        // Reading your own options is harmless and stays allowed.
+        compose_agent_config_options(
+            &store,
+            "ses_caller",
+            "ses_caller",
+            CatalogSpy::new().resolver(),
+            no_live_config,
+        )
+        .expect("reading your own options is allowed");
+    }
+
+    #[test]
+    fn blank_arguments_are_rejected_before_any_lookup() {
+        let store = store_fixture();
+        let spy = CatalogSpy::new();
+
+        let blank_id = prepare_agent_config_change(
+            &store,
+            "ses_caller",
+            "ses_target",
+            "  ",
+            "target-only-model",
+            spy.resolver(),
+            no_live_config,
+        )
+        .err()
+        .expect("blank configId is rejected");
+        assert!(matches!(blank_id, AgentConfigError::EmptyConfigId));
+
+        let spy = CatalogSpy::new();
+        let blank_value = prepare_agent_config_change(
+            &store,
+            "ses_caller",
+            "ses_target",
+            "model",
+            "\n",
+            spy.resolver(),
+            no_live_config,
+        )
+        .err()
+        .expect("blank value is rejected");
+        assert!(matches!(blank_value, AgentConfigError::EmptyValue));
+        assert!(spy.asked.borrow().is_empty());
+    }
+
+    /// The tests above prove what validation DECIDES; none of them prove
+    /// `configure_agent` obeys it, because the apply needs a live actor. Same
+    /// source-order guard the send path uses (`peer_ops.rs`), for the same
+    /// reason: the order and the arguments ARE the guarantee.
+    #[test]
+    fn configure_agent_validates_admits_leases_then_applies_the_validated_triple() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/domains/sessions/agent_ops/calls.rs");
+        let text = std::fs::read_to_string(&path).expect("read calls.rs");
+        let start = text
+            .find("async fn configure_agent(")
+            .expect("configure_agent is defined in calls.rs");
+        let rest = &text[start..];
+        let body = &rest[..rest[1..]
+            .find("\nasync fn ")
+            .or_else(|| rest[1..].find("\nfn "))
+            .map_or(rest.len(), |at| at + 1)];
+
+        let prepared_at = body
+            .find("prepare_agent_config_change(")
+            .expect("configure_agent validates against the target's composed options");
+        let admitted_at = body
+            .find("admit_peer_mutation(")
+            .expect("configure_agent takes the target's session mutation permit");
+        let leased_at = body
+            .find("lease_target_workspace_for_peer_write(")
+            .expect("configure_agent leases the TARGET's workspace, not the route's");
+        let applied_at = body
+            .find("set_live_session_config_option(")
+            .expect("configure_agent applies through the existing runtime path");
+
+        // Validate first: a refusal must not cost a permit or a lease.
+        assert!(
+            prepared_at < admitted_at,
+            "the target's options must be validated BEFORE the admission permit"
+        );
+        // Canonical order (admission.rs): permit outermost, then the lease.
+        assert!(
+            admitted_at < leased_at,
+            "the session mutation permit must be taken BEFORE any workspace lease"
+        );
+        assert!(
+            leased_at < applied_at,
+            "the target workspace lease must be held BEFORE the apply"
+        );
+        // The apply gets the VALIDATED triple, never the raw arguments: an
+        // untrimmed/unvalidated configId or value would bypass the composed
+        // universe entirely. Whitespace is stripped from both sides so a
+        // reformat that wraps the argument list does not read as a regression.
+        let squashed = body
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect::<String>();
+        assert!(
+            squashed.contains(
+                "set_live_session_config_option(&prepared.target.id,&prepared.config_id,&prepared.value"
+            ),
+            "configure_agent must apply the validated target/configId/value, not the raw args"
+        );
+        assert!(
+            body.contains("SessionMutationKind::Config"),
+            "the permit must name the Config mutation kind"
+        );
+        // And the lease is on the TARGET's workspace. The route's lease is the
+        // caller's, which for a cross-workspace target is the wrong workspace
+        // to hold open against retire.
+        assert!(
+            squashed.contains("&prepared.target.workspace_id,"),
+            "the workspace lease must be taken on the TARGET's workspace"
+        );
+    }
+
+    #[test]
+    fn an_unknown_target_is_named_in_the_error() {
+        let store = store_fixture();
+
+        let error = compose_agent_config_options(
+            &store,
+            "ses_caller",
+            "ses_ghost",
+            CatalogSpy::new().resolver(),
+            no_live_config,
+        )
+        .err()
+        .expect("unknown target is rejected");
+
+        assert!(matches!(
+            error,
+            AgentConfigError::Access(AgentAccessError::TargetNotFound(ref id)) if id == "ses_ghost"
+        ));
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod calls;
 mod calls_helpers;
+mod config_ops;
 pub mod context;
 pub mod definition;
 mod peer_ops;

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/peer_ops.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/peer_ops.rs
@@ -58,7 +58,7 @@ pub(super) struct PreparedAgentMessage {
 /// that does not exist, itself, a closed or dismissed target (neither takes
 /// more input, and neither is ever spun up again), and an `internal_only`
 /// session (runtime plumbing, not a peer). Whether the target may be perturbed
-/// *right now* is a separate question, answered by [`admit_peer_send`].
+/// *right now* is a separate question, answered by [`admit_peer_mutation`].
 pub(super) fn prepare_agent_message(
     session_store: &SessionStore,
     caller_session_id: &str,
@@ -85,10 +85,10 @@ pub(super) fn prepare_agent_message(
 }
 
 #[derive(Debug, thiserror::Error)]
-pub(super) enum PeerSendGateError {
+pub(super) enum PeerGateError {
     #[error(
         "that agent's execution is controlled by an active workflow run and cannot be \
-         prompted until the run finishes"
+         prompted or reconfigured until the run finishes"
     )]
     ControlledByWorkflow,
     #[error("session admission is unavailable")]
@@ -97,74 +97,75 @@ pub(super) enum PeerSendGateError {
     WorkspaceBlocked(String),
 }
 
-/// The session-mutation admission fence, on the peer send path (spec 2b).
+/// The session-mutation admission fence, on the peer paths (spec 2b).
 ///
-/// `send_agent_message` is the first product-MCP tool that can prompt an
-/// ARBITRARY session, so it is the first that must clear this fence itself.
-/// Every other route into a session's prompt queue takes this permit
-/// (`api/http/sessions_prompt.rs`, the pending-prompt queue, goals/loops/
-/// plans/reviews/config/resume/replay). The older MCP prompt paths were exempt
+/// `send_agent_message` is the first product-MCP tool that can perturb an
+/// ARBITRARY session, so it is the first that must clear this fence itself;
+/// `configure_agent` is the second, and takes the same fence with
+/// [`SessionMutationKind::Config`]. Every other route into a session's prompt
+/// queue or live config takes this permit (`api/http/sessions_prompt.rs`,
+/// `api/http/sessions_config.rs`, the pending-prompt queue, goals/loops/
+/// plans/reviews/resume/replay). The older MCP prompt paths were exempt
 /// for a structural reason — they could only reach the far end of a
 /// `session_links` row, and a workflow-controlled session is never on either
 /// end — and runtime-wide peer reach deletes that argument.
 ///
 /// The permit is held across the dispatch, so a workflow that takes control
-/// mid-send cannot interleave, and a peer send is visible to the destructive
-/// workspace paths that admit a whole workspace's session set.
-pub(super) async fn admit_peer_send(
+/// mid-call cannot interleave, and a peer mutation is visible to the
+/// destructive workspace paths that admit a whole workspace's session set.
+pub(super) async fn admit_peer_mutation(
     admission: &SessionMutationAdmission,
     target_session_id: &str,
-) -> Result<SessionMutationPermit, PeerSendGateError> {
+    kind: SessionMutationKind,
+) -> Result<SessionMutationPermit, PeerGateError> {
     admission
-        .acquire(
-            target_session_id,
-            SessionMutationKind::Prompt,
-            &SessionMutationSource::external(),
-        )
+        .acquire(target_session_id, kind, &SessionMutationSource::external())
         .await
         .map_err(|conflict| match conflict {
             SessionMutationConflict::ControlledByWorkflow { run_id } => {
                 tracing::info!(
                     target_session_id = %target_session_id,
                     controlling_run_id = %run_id,
-                    "peer message rejected: target session is controlled by a workflow"
+                    "peer mutation rejected: target session is controlled by a workflow"
                 );
-                PeerSendGateError::ControlledByWorkflow
+                PeerGateError::ControlledByWorkflow
             }
             SessionMutationConflict::Internal(error) => {
                 tracing::error!(
                     target_session_id = %target_session_id,
                     error = %error,
-                    "peer message admission lookup failed"
+                    "peer mutation admission lookup failed"
                 );
-                PeerSendGateError::AdmissionUnavailable
+                PeerGateError::AdmissionUnavailable
             }
         })
 }
 
-/// The workspace write lease for a peer send — on the TARGET's workspace.
+/// The workspace write lease for a peer write — on the TARGET's workspace.
 ///
 /// The route layer leases the workspace in the URL, which for a cross-workspace
-/// send is the wrong one: the send mutates the TARGET workspace (it enqueues a
-/// durable row against a target session and can boot a harness child process
-/// inside the target's checkout), and it is the target workspace's retire
+/// peer call is the wrong one: the write lands in the TARGET workspace (a send
+/// enqueues a durable row against a target session and can boot a harness child
+/// process inside the target's checkout; a config change writes the target's
+/// live config and can relaunch it), and it is the target workspace's retire
 /// preflight that has to see that work in progress
 /// (`workspaces/retire_preflight.rs` snapshots the gate for `SubagentWrite`).
-/// So `send_agent_message` takes no route lease at all — it is deliberately
-/// absent from `tools::MUTATING_TOOL_NAMES` — and takes this one instead.
+/// So `send_agent_message` and `configure_agent` take no route lease at all —
+/// both are deliberately absent from `tools::MUTATING_TOOL_NAMES` — and take
+/// this one instead.
 ///
-/// MUST be called AFTER [`admit_peer_send`]. The canonical lock order is
+/// MUST be called AFTER [`admit_peer_mutation`]. The canonical lock order is
 /// `session mutation permit -> workspace operation lease`
 /// (PR1227-LOCK-01); the reverse is the order
 /// `api/session_admission_tests.rs` proves deadlocks against retire/purge,
 /// which hold every session permit in a workspace and then reach for that
 /// workspace's exclusive lease. Exactly one workspace lease is taken here, so
 /// there is no second lease to order against either.
-pub(super) async fn lease_target_workspace_for_send(
+pub(super) async fn lease_target_workspace_for_peer_write(
     operation_gate: &WorkspaceOperationGate,
     access_gate: &WorkspaceAccessGate,
     target_workspace_id: &str,
-) -> Result<WorkspaceOperationLease, PeerSendGateError> {
+) -> Result<WorkspaceOperationLease, PeerGateError> {
     let lease = operation_gate
         .acquire_shared(target_workspace_id, WorkspaceOperationKind::SubagentWrite)
         .await;
@@ -179,10 +180,10 @@ pub(super) async fn lease_target_workspace_for_send(
 pub(super) fn assert_workspace_can_be_mutated(
     access_gate: &WorkspaceAccessGate,
     workspace_id: &str,
-) -> Result<(), PeerSendGateError> {
+) -> Result<(), PeerGateError> {
     access_gate
         .assert_can_mutate_for_workspace(workspace_id)
-        .map_err(|error| PeerSendGateError::WorkspaceBlocked(error.to_string()))
+        .map_err(|error| PeerGateError::WorkspaceBlocked(error.to_string()))
 }
 
 /// The reply IS the wake (ADR flow 2). When the caller answers an agent that was
@@ -627,11 +628,11 @@ mod tests {
             run_id: "run_7",
         }));
 
-        let error = admit_peer_send(&admission, "ses_controlled")
+        let error = admit_peer_mutation(&admission, "ses_controlled", SessionMutationKind::Prompt)
             .await
             .err()
             .expect("a workflow-controlled target refuses the send");
-        assert!(matches!(error, PeerSendGateError::ControlledByWorkflow));
+        assert!(matches!(error, PeerGateError::ControlledByWorkflow));
         // The calling agent has to be able to act on this, so it says what is
         // wrong and when to retry — never the run id.
         assert!(
@@ -644,17 +645,33 @@ mod tests {
 
         // Negative control: the same admission admits every other session, so
         // the refusal above is the controller policy and not a blanket block.
-        let permit = admit_peer_send(&admission, "ses_target")
+        let permit = admit_peer_mutation(&admission, "ses_target", SessionMutationKind::Prompt)
             .await
             .expect("an ordinary target is admitted");
         drop(permit);
+
+        // The fence is the same one for a config change, so a controlled target
+        // refuses `configure_agent` for the same reason and with the same
+        // message — and an ordinary one is still admitted.
+        let config_error =
+            admit_peer_mutation(&admission, "ses_controlled", SessionMutationKind::Config)
+                .await
+                .err()
+                .expect("a workflow-controlled target refuses the config change");
+        assert!(matches!(config_error, PeerGateError::ControlledByWorkflow));
+        assert!(!config_error.to_string().contains("run_7"));
+        let config_permit =
+            admit_peer_mutation(&admission, "ses_target", SessionMutationKind::Config)
+                .await
+                .expect("an ordinary target is admitted for a config change");
+        drop(config_permit);
     }
 
     #[tokio::test]
     async fn an_uncontrolled_runtime_admits_every_peer_send() {
         let admission = SessionMutationAdmission::new(Arc::new(NoControllerPolicy));
 
-        let permit = admit_peer_send(&admission, "ses_target")
+        let permit = admit_peer_mutation(&admission, "ses_target", SessionMutationKind::Prompt)
             .await
             .expect("no controller means no fence");
 
@@ -664,15 +681,26 @@ mod tests {
     #[tokio::test]
     async fn a_cross_workspace_send_leases_the_targets_workspace_not_the_callers() {
         let db = Db::open_in_memory().expect("open db");
-        test_support::seed_workspace_with_repo_root(&db, "workspace-1", "local", "/tmp/workspace-1");
-        test_support::seed_workspace_with_repo_root(&db, "workspace-2", "local", "/tmp/workspace-2");
+        test_support::seed_workspace_with_repo_root(
+            &db,
+            "workspace-1",
+            "local",
+            "/tmp/workspace-1",
+        );
+        test_support::seed_workspace_with_repo_root(
+            &db,
+            "workspace-2",
+            "local",
+            "/tmp/workspace-2",
+        );
         let access_gate = access_gate_fixture(&db);
         let operation_gate = WorkspaceOperationGate::new();
 
         // Caller in workspace-1, target in workspace-2.
-        let lease = lease_target_workspace_for_send(&operation_gate, &access_gate, "workspace-2")
-            .await
-            .expect("target workspace lease");
+        let lease =
+            lease_target_workspace_for_peer_write(&operation_gate, &access_gate, "workspace-2")
+                .await
+                .expect("target workspace lease");
 
         assert_eq!(
             operation_gate
@@ -707,11 +735,12 @@ mod tests {
         let access_gate = access_gate_fixture(&db);
         let operation_gate = WorkspaceOperationGate::new();
 
-        let error = lease_target_workspace_for_send(&operation_gate, &access_gate, "workspace-gone")
-            .await
-            .err()
-            .expect("an unmutable target workspace refuses the send");
+        let error =
+            lease_target_workspace_for_peer_write(&operation_gate, &access_gate, "workspace-gone")
+                .await
+                .err()
+                .expect("an unmutable target workspace refuses the send");
 
-        assert!(matches!(error, PeerSendGateError::WorkspaceBlocked(_)));
+        assert!(matches!(error, PeerGateError::WorkspaceBlocked(_)));
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/tools.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/tools.rs
@@ -18,10 +18,10 @@ pub const DEPRECATED_TOOL_ALIASES: &[(&str, &str)] = &[
 // call takes the ROUTE's workspace write lease — the lease on the workspace in
 // the URL, which is always the caller's.
 //
-// `send_agent_message` is deliberately absent. It is the one tool here whose
-// target can live in another workspace, so the caller's lease is the wrong one
-// and it takes the TARGET workspace's lease itself
-// (`peer_ops::lease_target_workspace_for_send`), together with the target
+// `send_agent_message` and `configure_agent` are deliberately absent. They are
+// the tools here whose target can live in another workspace, so the caller's
+// lease is the wrong one and they take the TARGET workspace's lease themselves
+// (`peer_ops::lease_target_workspace_for_peer_write`), together with the target
 // session's mutation permit. That is also the only way to keep the canonical
 // `permit -> workspace lease` order: a route lease taken before the permit is
 // the reversed order `api/session_admission_tests.rs` proves deadlocks against
@@ -129,6 +129,25 @@ pub struct ScheduleAgentWakeArgs {
     pub session_id: String,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetAgentConfigOptionsArgs {
+    pub session_id: String,
+}
+
+/// Deliberately the same two fields as `SetSessionConfigOptionRequest`, the
+/// body the human client posts to `/v1/sessions/{id}/config-options`. Model,
+/// mode and thinking/effort are all `configId` + `value` pairs there; giving
+/// agents a second vocabulary for the same apply path would be a vocabulary to
+/// keep in sync, not a simplification.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigureAgentArgs {
+    pub session_id: String,
+    pub config_id: String,
+    pub value: String,
+}
+
 #[derive(Debug, Default, Deserialize, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum ReadAgentTranscriptMode {
@@ -218,6 +237,30 @@ pub fn build_tool_list(ctx: &AgentOpsMcpContext) -> Vec<Value> {
                     "sessionId": { "type": "string", "description": "Agent to wait on. Any open session, in any workspace." }
                 },
                 "required": ["sessionId"]
+            }),
+        ),
+        tool_definition(
+            "get_agent_config_options",
+            "Describe what another agent's configuration allows changing right now: model, mode, thinking/effort and any other control its harness exposes, each with the configId and values configure_agent accepts. Values are composed from the target's own workspace catalog and its live controls, so they are what THAT agent can run — not what you can. Closed agents have no configuration left and are rejected.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "sessionId": { "type": "string", "description": "Agent to inspect. Any open session, in any workspace." }
+                },
+                "required": ["sessionId"]
+            }),
+        ),
+        tool_definition(
+            "configure_agent",
+            "Change one configuration option on another open agent — model, mode, thinking/effort, or anything else get_agent_config_options lists. Call get_agent_config_options first: configId and value must come from that target's composed options. The change applies immediately when the agent is idle and is queued to its next idle moment when it is mid-turn; either way it persists, so a relaunch keeps it. You cannot configure yourself.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "sessionId": { "type": "string", "description": "Target agent's session id." },
+                    "configId": { "type": "string", "description": "Option identifier from get_agent_config_options (for example \"model\" or \"mode\")." },
+                    "value": { "type": "string", "description": "One of that option's listed values." }
+                },
+                "required": ["sessionId", "configId", "value"]
             }),
         ),
         tool_definition(
@@ -482,6 +525,45 @@ mod tests {
         assert!(MUTATING_TOOL_NAMES.contains(&"schedule_agent_wake"));
         assert!(!MUTATING_TOOL_NAMES.contains(&"list_agents"));
         assert!(!MUTATING_TOOL_NAMES.contains(&"read_agent_transcript"));
+    }
+
+    #[test]
+    fn configure_agent_leases_in_the_call_and_reading_options_leases_nothing() {
+        // Same shape as `send_agent_message`, for the same reason: the target
+        // can be in another workspace, so the route's caller-workspace lease is
+        // the wrong one AND would be taken before the permit.
+        assert!(!MUTATING_TOOL_NAMES.contains(&"configure_agent"));
+        // Read-only: composing a target's options touches nothing.
+        assert!(!MUTATING_TOOL_NAMES.contains(&"get_agent_config_options"));
+    }
+
+    #[test]
+    fn configure_tools_are_offered_to_every_caller() {
+        // Ruling 3: an unpromoted subagent loses the spawn tools and keeps
+        // messaging, reading, waking and configuring.
+        for ctx in [context(true, 2), context(false, 0)] {
+            let tools = build_tool_list(&ctx);
+            let names = tool_names(&tools);
+
+            assert!(names.contains(&"get_agent_config_options"));
+            assert!(names.contains(&"configure_agent"));
+        }
+    }
+
+    #[test]
+    fn configure_agent_takes_the_human_config_option_fields() {
+        // configId/value are the SetSessionConfigOptionRequest fields. A
+        // renamed pair here would be a second vocabulary over one apply path.
+        let configure = build_tool_list(&context(true, 0))
+            .into_iter()
+            .find(|tool| tool.get("name").and_then(Value::as_str) == Some("configure_agent"))
+            .expect("configure_agent is advertised");
+
+        let required = configure
+            .pointer("/inputSchema/required")
+            .and_then(Value::as_array)
+            .expect("required list");
+        assert_eq!(required, &["sessionId", "configId", "value"]);
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/config.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/config.rs
@@ -40,6 +40,26 @@ impl SessionRuntime {
 
         // Config mutations go through the live ACP actor. If the actor is not
         // running yet, start or resume it and return its control handle.
+        //
+        // KNOWN SIDE EFFECT: this boots an idle session BEFORE anything below
+        // can decide the change is unappliable, so a request that ends in a
+        // rejection still leaves the agent running. It matters most for
+        // `configure_agent`, whose composed menu advertises the target
+        // workspace's whole catalog: a model in that catalog that this
+        // session's recorded auth contexts do not authorize is advertised,
+        // accepted by validation, boots the target here, and only then loses at
+        // the live actor with no relaunch fallback.
+        //
+        // The obvious fix — hoist `live_model_switch_authorized` above this —
+        // does NOT work and is deliberately not done. That call is made for
+        // every `config_id`, not only model ones, and returns false for any
+        // value that is not a catalog model (a mode or effort value always
+        // is). It is a "may we relaunch if the live actor refuses" flag, not an
+        // apply gate, so hoisting it changes nothing, and promoting it to a
+        // gate would refuse every non-model control change on the human route
+        // too. Narrowing the advertised set (or a pre-apply liveness-free
+        // authorization keyed on config_id) is the real fix, and is follow-up
+        // work rather than a reorder here.
         let handle = self
             .ensure_live_session_handle(&record, None)
             .await

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/store/agent_wakes.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/store/agent_wakes.rs
@@ -266,7 +266,7 @@ impl SessionStore {
     ///   SKIPPED ENTIRELY — its row stays armed and fires at the target's next
     ///   finished turn after control releases. A pointer is a prompt, and every
     ///   other prompt path refuses a controlled session
-    ///   (`peer_ops::admit_peer_send`).
+    ///   (`peer_ops::admit_peer_mutation`).
     /// - a CLOSED watcher's row is deleted with NO prompt: a closed session
     ///   takes no input (ruling 6), so the schedule can never be fulfilled and
     ///   leaving it would strand the row forever.

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/wakes/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/wakes/service.rs
@@ -14,7 +14,7 @@
 //! reason — a pointer is a PROMPT, and the prompt paths have rules:
 //! - a workflow-controlled watcher is skipped and its schedule left ARMED, so
 //!   the wake lands after the run releases control rather than being injected
-//!   into a session every other prompt path 409s (`peer_ops::admit_peer_send`).
+//!   into a session every other prompt path 409s (`peer_ops::admit_peer_mutation`).
 //!   The controller lookup is a pure read: no permit, no lease, no new edge in
 //!   the canonical `permit -> operation lease` order (PR1227-LOCK-01).
 //! - a closed watcher's schedule is dropped without a pointer (ruling 6: a

--- a/anyharness/sdk/src/reducer/__tests__/transcript.test.ts
+++ b/anyharness/sdk/src/reducer/__tests__/transcript.test.ts
@@ -1244,6 +1244,8 @@ describe("transcript reducer", () => {
     ["mcp__subagents__list_agents"],
     ["mcp__subagents__read_agent_transcript"],
     ["mcp__subagents__schedule_agent_wake"],
+    ["mcp__subagents__get_agent_config_options"],
+    ["mcp__subagents__configure_agent"],
   ])("classifies the renamed agent ops tool %s as subagent activity", (nativeToolName) => {
     const state = reduceEvents(
       [

--- a/anyharness/sdk/src/reducer/transcript.ts
+++ b/anyharness/sdk/src/reducer/transcript.ts
@@ -1436,6 +1436,8 @@ function deriveToolCallSemanticKind(
     || normalizedEffectiveToolName === "mcp__subagents__list_agents"
     || normalizedEffectiveToolName === "mcp__subagents__read_agent_transcript"
     || normalizedEffectiveToolName === "mcp__subagents__schedule_agent_wake"
+    || normalizedEffectiveToolName === "mcp__subagents__get_agent_config_options"
+    || normalizedEffectiveToolName === "mcp__subagents__configure_agent"
   ) {
     return "subagent";
   }

--- a/apps/packages/product-client/src/domain/chats/subagents/subagent-tool-presentation.ts
+++ b/apps/packages/product-client/src/domain/chats/subagents/subagent-tool-presentation.ts
@@ -49,6 +49,10 @@ export function formatSubagentMcpActionLabel(toolName: string | null | undefined
       return "Read agent transcript";
     case "mcp__subagents__schedule_agent_wake":
       return "Scheduled agent wake";
+    case "mcp__subagents__get_agent_config_options":
+      return "Read agent config options";
+    case "mcp__subagents__configure_agent":
+      return "Configured agent";
     default:
       return null;
   }
@@ -98,6 +102,12 @@ export function formatSubagentHeaderVerb({
   }
   if (toolName === "mcp__subagents__schedule_agent_wake") {
     return isRunning ? "Scheduling agent wake" : "Agent wake scheduled";
+  }
+  if (toolName === "mcp__subagents__get_agent_config_options") {
+    return isRunning ? "Reading agent config options" : "Agent config options read";
+  }
+  if (toolName === "mcp__subagents__configure_agent") {
+    return isRunning ? "Configuring agent" : "Agent configured";
   }
   if (executionState === "failed") {
     return "Subagent launch failed";

--- a/apps/packages/product-client/src/lib/domain/chat/subagents/subagent-tool-presentation.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/subagents/subagent-tool-presentation.test.ts
@@ -70,6 +70,10 @@ describe("subagent tool presentation", () => {
       .toBe("Read agent transcript");
     expect(formatSubagentMcpActionLabel("mcp__subagents__schedule_agent_wake"))
       .toBe("Scheduled agent wake");
+    expect(formatSubagentMcpActionLabel("mcp__subagents__get_agent_config_options"))
+      .toBe("Read agent config options");
+    expect(formatSubagentMcpActionLabel("mcp__subagents__configure_agent"))
+      .toBe("Configured agent");
 
     expect(formatSubagentHeaderVerb({
       item: { nativeToolName: "mcp__subagents__send_agent_message" },
@@ -86,6 +90,16 @@ describe("subagent tool presentation", () => {
       executionState: "completed",
       isRunning: false,
     })).toBe("Agent wake scheduled");
+    expect(formatSubagentHeaderVerb({
+      item: { nativeToolName: "mcp__subagents__configure_agent" },
+      executionState: "running",
+      isRunning: true,
+    })).toBe("Configuring agent");
+    expect(formatSubagentHeaderVerb({
+      item: { nativeToolName: "mcp__subagents__get_agent_config_options" },
+      executionState: "completed",
+      isRunning: false,
+    })).toBe("Agent config options read");
   });
 
   it("derives concise status receipt presentation with the child target", () => {

--- a/specs/anyharness/sessions.md
+++ b/specs/anyharness/sessions.md
@@ -554,9 +554,34 @@ The ACP runtime owns:
 - restoring persisted config after resume
 - emitting config updates when ACP changes the active surface
 
+### Who requests a config change
+
+Two callers reach the same `SessionRuntime::set_live_session_config_option`, and
+neither has its own apply machinery:
+
+- the human client, through
+  `POST /v1/sessions/{session_id}/config-options`
+- another agent, through the `configure_agent` tool on the agent ops MCP
+  (`domains/sessions/agent_ops/**`)
+
+The tool takes the same `configId`/`value` pair the route's request body does.
+It differs only in what it must establish before applying, because the session
+it mutates is not the one it was called on:
+
+- the options it validates against are composed for the TARGET session's
+  workspace (`resolved_workspace_launch_options` for that workspace, merged
+  with that session's live snapshot) — never the calling agent's workspace
+- it acquires the TARGET session's `SessionMutationKind::Config` admission
+  permit with an External source, so a workflow-controlled session refuses a
+  foreign change with the same stable conflict the HTTP route answers
+- when the target is in a different workspace than the caller, it also takes
+  that workspace's shared operation lease and access-gate check, in the
+  canonical `permit -> operation lease` order; a same-workspace target reuses
+  the lease the MCP endpoint already holds
+
 ### End-to-end config flow
 
-1. client requests a config change
+1. client or peer agent requests a config change
 2. `SessionRuntime` ensures the actor is live
 3. the actor tries to apply the change through ACP
 4. if the session is busy, the change is queued durably

--- a/specs/anyharness/sessions.md
+++ b/specs/anyharness/sessions.md
@@ -574,10 +574,18 @@ it mutates is not the one it was called on:
 - it acquires the TARGET session's `SessionMutationKind::Config` admission
   permit with an External source, so a workflow-controlled session refuses a
   foreign change with the same stable conflict the HTTP route answers
-- when the target is in a different workspace than the caller, it also takes
-  that workspace's shared operation lease and access-gate check, in the
-  canonical `permit -> operation lease` order; a same-workspace target reuses
-  the lease the MCP endpoint already holds
+- it then takes the TARGET workspace's shared `SubagentWrite` operation lease,
+  unconditionally and with no same/different-workspace branch, in the canonical
+  `permit -> operation lease` order. There is nothing to reuse: `configure_agent`
+  is deliberately absent from `tools::MUTATING_TOOL_NAMES`, so the MCP endpoint
+  holds NO workspace lease for this call, and the route's lease would have been
+  the CALLER's workspace anyway — the wrong one to hold open against the target
+  workspace's retire preflight. `send_agent_message` works the same way; the
+  comment at `agent_ops/tools.rs` on `MUTATING_TOOL_NAMES` is the code-side
+  statement of it.
+- the caller's own workspace is still asserted mutable (an access-gate check,
+  no lease), because the route stopped doing it once the tool left
+  `MUTATING_TOOL_NAMES`
 
 ### End-to-end config flow
 

--- a/specs/codebase/platforms/product/agent-features/definitions/subagents.md
+++ b/specs/codebase/platforms/product/agent-features/definitions/subagents.md
@@ -41,9 +41,10 @@ carried through `initialConfig`.
 
 `subagentId` is the handle for the subagent tool class only. The peer tools in
 the same MCP — `list_agents`, `send_agent_message`, `read_agent_transcript`,
-`schedule_agent_wake` — address any session in the runtime and take `sessionId`,
-because there is no link to derive a scoped handle from. A subagent addressed as
-a peer is addressed by its session id like any other agent.
+`schedule_agent_wake`, `get_agent_config_options`, `configure_agent` — address
+any session in the runtime and take `sessionId`, because there is no link to
+derive a scoped handle from. A subagent addressed as a peer is addressed by its
+session id like any other agent.
 
 "Any session in the runtime" means any session that is an *agent*. The
 peer-reachable set excludes dismissed sessions (deleted from the sidebar, and
@@ -52,8 +53,35 @@ caller itself, and `internal_only` sessions — workflow and review plumbing the
 runtime drives, which are not agents the human is running. That is a discovery
 rule: `list_agents` hides them and `send_agent_message` /
 `read_agent_transcript` refuse them. It is not the execution fence — a session
-an active workflow run controls is refused a peer prompt by the same session
-mutation admission permit that fences the HTTP prompt route.
+an active workflow run controls is refused a peer prompt or a peer config
+change by the same session mutation admission permit that fences the HTTP
+prompt and config routes.
+
+## Peer Configuration
+
+`get_agent_config_options` and `configure_agent` speak the same vocabulary as
+the human client's `POST /v1/sessions/{session_id}/config-options`: one
+`configId` and one `value`, where model, mode and thinking/effort are all just
+config ids. There is no second agent-facing vocabulary over one apply path.
+
+What differs from the human surface is whose universe the value is checked
+against. The options a peer tool reports are composed for the TARGET's
+workspace — its launch catalog, its readiness, its auth contexts — merged with
+the target's own live control snapshot, never the caller's workspace. Two
+agents in different workspaces can have entirely different menus, and a model
+only the caller's workspace can serve is refused. Values are tagged with where
+they came from: `live` means the target's harness is advertising the value now,
+`workspace_catalog` means the target's workspace authorizes it and applying may
+relaunch the agent to reach it (the same live-or-relaunch rule the human path
+uses; see
+[../../../../../anyharness/sessions.md](../../../../../anyharness/sessions.md)).
+
+Two refusals are specific to the peer form. A CLOSED target is rejected for
+both tools rather than answered with an empty menu: its actor never starts
+again, so it has no configuration left to read or change — unlike
+`read_agent_transcript`, which stays readable forever. And an agent may not
+target ITSELF with `configure_agent`: the change would be routed at the very
+actor blocked inside the tool call. Reading your own options is allowed.
 
 ## Wake Race
 

--- a/specs/codebase/platforms/product/agent-features/definitions/subagents.md
+++ b/specs/codebase/platforms/product/agent-features/definitions/subagents.md
@@ -51,8 +51,11 @@ peer-reachable set excludes dismissed sessions (deleted from the sidebar, and
 refused by the boot path), closed sessions unless explicitly asked for, the
 caller itself, and `internal_only` sessions — workflow and review plumbing the
 runtime drives, which are not agents the human is running. That is a discovery
-rule: `list_agents` hides them and `send_agent_message` /
-`read_agent_transcript` refuse them. It is not the execution fence — a session
+rule: `list_agents` hides them. What REFUSES them depends on the intent
+(`domains/sessions/authorize.rs`): `internal_only` is refused for both reads and
+writes, so the two surfaces agree; self, closed and dismissed are refused only
+for writes, because a transcript outlives the agent and `read_agent_transcript`
+stays open on all three. It is not the execution fence — a session
 an active workflow run controls is refused a peer prompt or a peer config
 change by the same session mutation admission permit that fences the HTTP
 prompt and config routes.
@@ -76,12 +79,24 @@ relaunch the agent to reach it (the same live-or-relaunch rule the human path
 uses; see
 [../../../../../anyharness/sessions.md](../../../../../anyharness/sessions.md)).
 
-Two refusals are specific to the peer form. A CLOSED target is rejected for
-both tools rather than answered with an empty menu: its actor never starts
-again, so it has no configuration left to read or change — unlike
-`read_agent_transcript`, which stays readable forever. And an agent may not
-target ITSELF with `configure_agent`: the change would be routed at the very
-actor blocked inside the tool call. Reading your own options is allowed.
+Two refusals are specific to the peer form. A target in a TERMINAL state —
+closed, or dismissed — is rejected by both tools rather than answered with a
+menu: its actor never starts again (`runtime/launch_policy.rs` refuses to boot
+a dismissed session, and a closed one is gone), so every item on the composed
+menu is a change that can never be applied. Read and write are deliberately
+symmetric here, which is the one place peer configuration parts company with
+`read_agent_transcript`: a transcript outlives the agent and stays readable
+forever, but a config menu for a session that can never run again describes
+nothing, and advertising one an agent would then be refused is worse than
+saying so up front. And an agent may not target ITSELF with `configure_agent`:
+the change would be routed at the very actor blocked inside the tool call.
+Reading your own options is allowed.
+
+One control-level rule follows the same principle. Each reported control
+carries `settable`, and it is enforced, not advisory: a control whose only
+available value is already the current one accepts no change, because there is
+nothing to move to. A single-value control the target has NOT selected yet is
+still settable — applying it is a real change.
 
 ## Wake Race
 


### PR DESCRIPTION
Fourth slice of the agent-operations stack (ADR §6 step 4; stacked on #1728 → #1727 → #1726). Adds the two peer-configuration tools.

## What this does

- **`get_agent_config_options`** (Read intent) — composes what a TARGET agent can be configured to: its live `NormalizedSessionControl` set, unclaimed raw options, and the **target workspace's** catalog model ids/aliases merged into the model control (synthesized at `ACP_MODEL_COMPAT_CONFIG_ID` when the target has never run). Values carry `source: "live" | "workspace_catalog"`.
- **`configure_agent`** (Send intent) — generic `configId` + `value`, the same contract a human operator uses; validation → caller-workspace access check → **Config permit on the target** → **target-workspace lease** → existing `set_live_session_config_option`. Returns the verbatim `SessionLiveConfigSnapshot` plus the composed `configurable` set.
- `agent_ops/config_ops.rs` is a pure decision layer: catalog and live snapshot enter as closures, so which-workspace-gets-asked is unit-tested without a runtime.
- The PR2 peer-send fence is **generalized, not duplicated**: `admit_peer_send` → `admit_peer_mutation(admission, target, kind)`, `lease_target_workspace_for_send` → `lease_target_workspace_for_peer_write`. One fence, two callers; the LOCK-01 ratchet in `api/session_admission_tests.rs` now loops over both peer tools.
- `configure_agent` is deliberately absent from `MUTATING_TOOL_NAMES` for the same reason as `send_agent_message`: its target can live in another workspace, so it takes the TARGET workspace's lease in-call, keeping the canonical `permit → lease` order.
- SDK reducer + product-client tool presentation classify the two new tools; specs updated (`subagents.md` peer list + Peer Configuration section, `sessions.md`).

## Spec note (for founder review)

ADR §3.4 sketches `configure_agent` with named model/mode/thinking fields; the shipped tool follows the REAL existing config contract instead — a generic `configId`+`value` pair (thinking/effort is just another config id). The ADR will be amended; flagged here rather than silently diverging.

## Testing

- `cargo test -p anyharness-lib agent_ops::` 50/50; `session_admission` 9/9; full `-p anyharness-lib` 1630 passed / 1 failed (the known pre-existing `sweep_tests` red).
- Negative controls: composing from the caller's workspace instead of the target's → 4 tests fail; deleting the `admit_peer_mutation` call → the seam test and the LOCK-01 ratchet both fail.
- SDK vitest 44/44, product-client 10/10; `scripts/check_docs.py` green (209 files).

## Observability

No new telemetry; refusals log through the existing admission-fence tracing (run id logged, never returned to the caller).
