### PR TITLE
feat(anyharness): agent ownership — promote_subagent, close_agent, soft close

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/http/mobility_archive_contract.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/mobility_archive_contract.rs
@@ -217,6 +217,16 @@ fn from_contract_session_link(
         created_by_tool_call_id: record.created_by_tool_call_id,
         created_at: record.created_at,
         closed_at: record.closed_at,
+        // The mobility archive contract does not carry ownership state, so an
+        // imported link lands unpromoted with no close attribution. That is the
+        // fail-CLOSED direction: a promoted agent that moves workspaces comes
+        // back as a plain subagent (fewer tools, cascade-closable) rather than
+        // as an agent nobody can account for. Carrying the three columns means
+        // widening `MobilitySessionLinkRecord`, which is a wire-contract change
+        // and an SDK regeneration.
+        promoted_at: None,
+        closed_by_session_id: None,
+        close_reason: None,
     })
 }
 

--- a/anyharness/crates/anyharness-lib/src/app/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/app/mod.rs
@@ -486,6 +486,11 @@ impl AppState {
         // Ownership — phase 2: the close hook can now reach the runtime whose
         // extension list holds it. Weak, so this is not a reference cycle.
         agent_close_session_hooks.attach_session_runtime(&session_runtime);
+        // Closes this runtime already owed when it started: a request whose
+        // turn never finished because the process died has nothing left to fire
+        // it, so it is settled here instead of leaving the agent open forever.
+        #[cfg(not(test))]
+        agent_close_session_hooks.clone().spawn_startup_pass();
         // Workflow runs — phase 2 (after SessionRuntime): the async facades.
         let workflow_phase_two = workflows::wire_workflow_runtime(
             workflow_wiring,

--- a/anyharness/crates/anyharness-lib/src/app/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/app/mod.rs
@@ -64,6 +64,8 @@ use crate::domains::sessions::mcp_bindings::product_registry::ProductMcpEndpoint
 use crate::domains::sessions::runtime::SessionRuntime;
 use crate::domains::sessions::service::SessionService;
 use crate::domains::sessions::store::SessionStore;
+use crate::domains::sessions::ownership::hooks::AgentCloseSessionHooks;
+use crate::domains::sessions::ownership::service::AgentOwnershipService;
 use crate::domains::sessions::subagents::hooks::SubagentSessionHooks;
 use crate::domains::sessions::subagents::service::SubagentService;
 use crate::domains::sessions::subagents::store::SubagentStore;
@@ -436,12 +438,27 @@ impl AppState {
             acp_manager.clone(),
         ));
         let workflow_run_session_extension = workflow_wiring.session_extension.clone();
+        // Ownership: who may promote or close whom. Its turn-finish hook is the
+        // second half of a soft close, and it needs the runtime it lives inside,
+        // so it is wired in two phases exactly like the workflow extensions —
+        // constructed here, handed the runtime below.
+        let agent_ownership_service = Arc::new(AgentOwnershipService::new(
+            session_link_service.clone(),
+            SessionStore::new(db.clone()),
+        ));
+        let agent_close_session_hooks = Arc::new(AgentCloseSessionHooks::new(
+            agent_ownership_service.clone(),
+            session_admission.clone(),
+            workspace_operation_gate.clone(),
+            workspace_access_gate.clone(),
+        ));
         let session_extensions: Vec<
             Arc<dyn crate::domains::sessions::extensions::SessionExtension>,
         > = vec![
             cowork_session_hooks.clone(),
             subagent_session_hooks.clone(),
             agent_wake_session_hooks.clone(),
+            agent_close_session_hooks.clone(),
             review_session_hooks.clone(),
             integration_gateway_session_launch_extension.clone(),
             goal_session_hooks,
@@ -466,6 +483,9 @@ impl AppState {
             loop_service.clone(),
             activity_service.clone(),
         ));
+        // Ownership — phase 2: the close hook can now reach the runtime whose
+        // extension list holds it. Weak, so this is not a reference cycle.
+        agent_close_session_hooks.attach_session_runtime(&session_runtime);
         // Workflow runs — phase 2 (after SessionRuntime): the async facades.
         let workflow_phase_two = workflows::wire_workflow_runtime(
             workflow_wiring,
@@ -567,6 +587,7 @@ impl AppState {
                 agent_wake_service: agent_wake_service.clone(),
                 session_runtime: session_runtime.clone(),
                 workspace_runtime: workspace_runtime.clone(),
+                agent_ownership_service: agent_ownership_service.clone(),
                 session_admission: session_admission.clone(),
                 workspace_operation_gate: workspace_operation_gate.clone(),
                 agent_ops_mcp_auth,

--- a/anyharness/crates/anyharness-lib/src/app/product_mcp.rs
+++ b/anyharness/crates/anyharness-lib/src/app/product_mcp.rs
@@ -15,6 +15,7 @@ use crate::domains::sessions::agent_ops::{
     AgentOpsPeerGates, AgentOpsProductMcpServer,
 };
 use crate::domains::sessions::mcp_bindings::product_catalog::ProductMcpLaunchCatalog;
+use crate::domains::sessions::ownership::service::AgentOwnershipService;
 use crate::domains::sessions::mcp_bindings::product_launch::{
     ProductMcpLaunchRegistration, ProductMcpSelectionContext,
 };
@@ -43,6 +44,7 @@ pub(super) struct EndpointRegistryDeps {
     pub(super) agent_wake_service: Arc<AgentWakeService>,
     pub(super) session_runtime: Arc<SessionRuntime>,
     pub(super) workspace_runtime: Arc<WorkspaceRuntime>,
+    pub(super) agent_ownership_service: Arc<AgentOwnershipService>,
     pub(super) session_admission: Arc<SessionMutationAdmission>,
     pub(super) workspace_operation_gate: Arc<WorkspaceOperationGate>,
     pub(super) agent_ops_mcp_auth: Arc<AgentOpsMcpAuth>,
@@ -115,6 +117,7 @@ pub(super) fn build_product_mcp_endpoint_registry(
         agent_wake_service,
         session_runtime,
         workspace_runtime,
+        agent_ownership_service,
         session_admission,
         workspace_operation_gate,
         agent_ops_mcp_auth,
@@ -135,6 +138,7 @@ pub(super) fn build_product_mcp_endpoint_registry(
                 agent_wake_service,
                 session_runtime,
                 workspace_runtime.clone(),
+                agent_ownership_service,
                 AgentOpsPeerGates {
                     session_admission,
                     workspace_operation_gate,

--- a/anyharness/crates/anyharness-lib/src/app/sessions.rs
+++ b/anyharness/crates/anyharness-lib/src/app/sessions.rs
@@ -18,6 +18,7 @@ use crate::domains::plans::session_observer::PlanSessionObserver;
 use crate::domains::reviews::service::ReviewService;
 use crate::domains::reviews::session_observer::ReviewSessionObserver;
 use crate::domains::sessions::attachment_storage::PromptAttachmentStorage;
+use crate::domains::sessions::links::store::SessionLinkStore;
 use crate::domains::sessions::live_ports::SessionAttachmentSource;
 use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::model::{ActorCapabilities, PermissionAdvisor, SessionEventObserver};
@@ -64,6 +65,9 @@ pub(super) fn wire_live_sessions(deps: &LiveSessionsWiringDeps) -> LiveSessionMa
         background: Arc::new(store.clone()),
         state: Arc::new(store.clone()),
         attachments: Arc::new(SessionAttachmentSource::new(store, attachment_storage)),
+        // The soft-close fence on turn starts: an agent whose end has been
+        // requested finishes its step and starts nothing new.
+        close_requests: Some(Arc::new(SessionLinkStore::new(deps.db.clone()))),
         observers,
         permission_advisor,
     };

--- a/anyharness/crates/anyharness-lib/src/app/test_support.rs
+++ b/anyharness/crates/anyharness-lib/src/app/test_support.rs
@@ -24,6 +24,9 @@ pub(crate) fn actor_capabilities_for_store(store: &SessionStore) -> ActorCapabil
             store.clone(),
             attachment_storage,
         )),
+        // No link store here (the helper only takes a session store), so no
+        // soft-close fence. Tests that exercise the fence supply their own.
+        close_requests: None,
         observers: Vec::new(),
         permission_advisor: None,
     }

--- a/anyharness/crates/anyharness-lib/src/domains/cowork/delegation/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/cowork/delegation/service.rs
@@ -276,6 +276,9 @@ impl CoworkDelegationService {
             created_by_tool_call_id: None,
             created_at: chrono::Utc::now().to_rfc3339(),
             closed_at: None,
+            promoted_at: None,
+            closed_by_session_id: None,
+            close_reason: None,
         };
         let inserted = self
             .cowork_service

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/calls.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/calls.rs
@@ -13,8 +13,9 @@ use super::config_ops::{
 };
 use super::context::AgentOpsMcpContext;
 use super::peer_ops::{
-    admit_peer_mutation, assert_workspace_can_be_mutated, authorize_transcript_read,
-    consume_reply_wake, lease_target_workspace_for_peer_write, prepare_agent_message,
+    admit_peer_mutation, assert_target_still_takes_messages, assert_workspace_can_be_mutated,
+    authorize_transcript_read, consume_reply_wake, lease_target_workspace_for_peer_write,
+    prepare_agent_message,
 };
 use super::tools::{
     canonical_tool_name, is_spawn_style_tool, ChildSessionArgs, CloseAgentArgs, ConfigureAgentArgs,
@@ -455,6 +456,11 @@ async fn send_subagent_message(
         &link.child_session_id,
         AgentAccessIntent::Send,
     )?;
+    // The same refusal the peer send makes: a child whose end has been
+    // requested is finishing one last step and will never run another prompt.
+    // This is the tool a PARENT uses on its own child, which is exactly the
+    // agent most likely to be end-requested.
+    assert_target_still_takes_messages(service.link_service(), &link.child_session_id)?;
     let wake_scheduled = if args.wake_on_completion {
         service
             .schedule_wake_for_target(parent_session_id, args.subagent_id.as_deref(), None)?
@@ -593,6 +599,7 @@ async fn send_agent_message(
 ) -> anyhow::Result<Value> {
     let prepared = prepare_agent_message(
         service.session_store(),
+        service.link_service(),
         &ctx.parent_session_id,
         args.session_id.trim(),
         &args.message,
@@ -1113,7 +1120,11 @@ fn close_result(
         // `close_subagent` tool list reads the same shape back.
         "childSessionId": settled.child_session_id,
         "label": settled.label,
-        "closed": settled.closed_at.is_some(),
+        // The link OR the session: the pre-gate early return already treats
+        // either one as closed, and reporting only the link would claim a stop
+        // that did not happen if a repair path ever closed a link out from
+        // under a living session.
+        "closed": settled.closed_at.is_some() || owned.target.closed_at.is_some(),
         "closeRequested": close_requested,
         "alreadyClosed": owned.link.closed_at.is_some() || owned.target.closed_at.is_some(),
         "closedAt": settled.closed_at,

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/calls.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/calls.rs
@@ -17,14 +17,16 @@ use super::peer_ops::{
     consume_reply_wake, lease_target_workspace_for_peer_write, prepare_agent_message,
 };
 use super::tools::{
-    canonical_tool_name, ChildSessionArgs, ConfigureAgentArgs, CreateSubagentArgs,
-    GetAgentConfigOptionsArgs, ListAgentsArgs, ReadAgentTranscriptArgs, ReadAgentTranscriptMode,
-    ReadSubagentEventsArgs, ReadSubagentLatestTurnsArgs, ScheduleAgentWakeArgs,
-    SearchSubagentTranscriptArgs, SendAgentMessageArgs, SendSubagentMessageArgs,
+    canonical_tool_name, is_spawn_style_tool, ChildSessionArgs, CloseAgentArgs, ConfigureAgentArgs,
+    CreateSubagentArgs, GetAgentConfigOptionsArgs, ListAgentsArgs, PromoteSubagentArgs,
+    ReadAgentTranscriptArgs, ReadAgentTranscriptMode, ReadSubagentEventsArgs,
+    ReadSubagentLatestTurnsArgs, ScheduleAgentWakeArgs, SearchSubagentTranscriptArgs,
+    SendAgentMessageArgs, SendSubagentMessageArgs,
 };
 use super::AgentOpsPeerGates;
 use crate::domains::sessions::admission::SessionMutationKind;
 use crate::domains::sessions::authorize::{authorize, AgentAccessIntent};
+use crate::domains::sessions::ownership::service::{AgentOwnershipService, OwnedAgent};
 use crate::domains::sessions::delegation::{
     parent_to_child_provenance, READ_EVENTS_DEFAULT_LIMIT, READ_EVENTS_MAX_LIMIT,
 };
@@ -45,11 +47,27 @@ pub async fn call_tool(
     service: &SubagentService,
     wake_service: &AgentWakeService,
     session_runtime: &SessionRuntime,
+    ownership: &AgentOwnershipService,
     gates: &AgentOpsPeerGates,
     ctx: &AgentOpsMcpContext,
     name: &str,
     arguments: Option<Value>,
 ) -> anyhow::Result<Value> {
+    // The spawn gate, at dispatch. `tools/list` also hides these, but that list
+    // is baked into a session at launch: a subagent launched before promotion
+    // holds a stale list forever, and one promoted afterwards holds a list that
+    // never showed them. Only this check runs against the caller's state at the
+    // moment it acts, so this — not the advertisement — is the gate. The wire
+    // name is matched, not the canonical one, so the deprecated `create_subagent`
+    // spelling cannot walk around it.
+    if ctx.is_unpromoted_subagent && is_spawn_style_tool(name) {
+        return Err(anyhow::anyhow!(
+            "{name} is not available to a subagent. You are running as another agent's subagent, \
+             so you cannot spawn agents of your own; ask the agent that spawned you to promote \
+             you, or to spawn what you need."
+        ));
+    }
+
     match canonical_tool_name(name) {
         "get_subagent_launch_options" => get_subagent_launch_options(service, session_runtime, ctx),
         "spawn_subagent" => {
@@ -182,9 +200,13 @@ pub async fn call_tool(
                 })
                 .map_err(anyhow::Error::from)
         }
+        "promote_subagent" => {
+            let args: PromoteSubagentArgs = deserialize_args(arguments)?;
+            promote_subagent(ownership, ctx, args)
+        }
         "close_agent" => {
-            let args: ChildSessionArgs = deserialize_args(arguments)?;
-            close_agent(service, session_runtime, &ctx.parent_session_id, args).await
+            let args: CloseAgentArgs = deserialize_args(arguments)?;
+            close_agent(service, session_runtime, ownership, gates, ctx, args).await
         }
         _ => Err(anyhow::anyhow!("unknown tool: {name}")),
     }
@@ -942,42 +964,165 @@ async fn get_subagent_status(
     }))
 }
 
+/// Promote one of the caller's subagents to a peer.
+///
+/// Ownership, not reachability, so it resolves an ownership ROW rather than
+/// going through `authorize` — the runtime-wide funnel deliberately answers a
+/// different question (who may I reach), and every agent may reach every other
+/// one. Only the parent that spawned this child can promote it.
+///
+/// One indexed UPDATE against a link row in the caller's own workspace, and no
+/// session actor is touched, so this takes the route's workspace lease
+/// (`MUTATING_TOOL_NAMES`) and no session mutation permit: there is no session
+/// mutation to admit.
+fn promote_subagent(
+    ownership: &AgentOwnershipService,
+    ctx: &AgentOpsMcpContext,
+    args: PromoteSubagentArgs,
+) -> anyhow::Result<Value> {
+    let owned = ownership.resolve_owned(
+        &ctx.parent_session_id,
+        args.subagent_id.as_deref(),
+        args.session_id.as_deref(),
+    )?;
+    let outcome = ownership.promote(&owned)?;
+    Ok(json!({
+        "subagentId": outcome.link.public_id,
+        "sessionLinkId": outcome.link.id,
+        "sessionId": outcome.link.child_session_id,
+        "label": outcome.link.label,
+        "promoted": true,
+        "alreadyPromoted": outcome.already_promoted,
+        "promotedAt": outcome.promoted_at,
+        // The two consequences the calling agent has to reason about, stated
+        // rather than implied: it is off the cascade, and off the fanout cap.
+        "closesWithYou": false,
+        "countsAgainstSubagentLimit": false,
+    }))
+}
+
+/// Close an agent the caller owns.
+///
+/// Generalizes the old link-scoped `close_subagent`: same close tree underneath,
+/// but the target is resolved through ownership and may be an agent in another
+/// workspace, so this takes its own fence instead of the route's — the TARGET's
+/// session mutation permit FIRST, then the TARGET workspace's write lease
+/// (PR1227-LOCK-01). A close is the most destructive session mutation there is,
+/// so skipping the permit would let it run straight through a workflow that has
+/// taken control of that session.
+///
+/// Soft close (ADR §4): a target that is mid-turn is not interrupted. The
+/// attribution stamp on the still-open ownership row IS the durable request,
+/// and `ownership::hooks` completes it when that turn finishes.
 async fn close_agent(
     service: &SubagentService,
     session_runtime: &SessionRuntime,
-    parent_session_id: &str,
-    args: ChildSessionArgs,
+    ownership: &AgentOwnershipService,
+    gates: &AgentOpsPeerGates,
+    ctx: &AgentOpsMcpContext,
+    args: CloseAgentArgs,
 ) -> anyhow::Result<Value> {
-    let link = service.resolve_target_including_closed(
-        parent_session_id,
+    let owned = ownership.resolve_owned(
+        &ctx.parent_session_id,
         args.subagent_id.as_deref(),
-        None,
+        args.session_id.as_deref(),
     )?;
-    let already_closed = link.closed_at.is_some();
-    let now = chrono::Utc::now().to_rfc3339();
-    if let Some(child) = service.session_store().find_by_id(&link.child_session_id)? {
-        if child.closed_at.is_none() {
-            session_runtime
-                .close_live_session(&link.child_session_id)
-                .await
-                .map_err(|error| anyhow::anyhow!("{error:?}"))?;
-        }
+    let reason = args
+        .reason
+        .as_deref()
+        .map(str::trim)
+        .filter(|reason| !reason.is_empty());
+
+    // Already closed: idempotent, and the FIRST close's attribution is what the
+    // row keeps. Return before any gate — there is nothing left to admit.
+    if owned.link.closed_at.is_some() || owned.target.closed_at.is_some() {
+        let settled = ownership.reload_link(&owned.link)?;
+        return Ok(close_result(&owned, &settled, false));
     }
-    if !already_closed {
-        service.close_link(&link, &now)?;
+
+    // The caller's own workspace still has to be writable — the route stopped
+    // checking when this tool left `MUTATING_TOOL_NAMES`.
+    assert_workspace_can_be_mutated(service.access_gate(), &ctx.workspace_id)?;
+    let _admission_permit = admit_peer_mutation(
+        &gates.session_admission,
+        &owned.target.id,
+        SessionMutationKind::Close,
+    )
+    .await?;
+    let _target_workspace_lease = lease_target_workspace_for_peer_write(
+        &gates.workspace_operation_gate,
+        service.access_gate(),
+        &owned.target.workspace_id,
+    )
+    .await?;
+
+    // Stamped under the permit, so the request cannot be armed by a call the
+    // fence would have refused.
+    ownership.record_close_attribution(&owned, &ctx.parent_session_id, reason)?;
+
+    if is_mid_turn(session_runtime, &owned).await {
+        // End requested. The row is stamped and open; the turn-finish hook
+        // takes this same pair of gates again and finishes the job.
+        let requested = ownership.reload_link(&owned.link)?;
+        return Ok(close_result(&owned, &requested, true));
     }
-    let refreshed = service.resolve_target_including_closed(
-        parent_session_id,
-        args.subagent_id.as_deref(),
-        None,
-    )?;
-    Ok(json!({
-        "subagentId": refreshed.public_id,
-        "sessionLinkId": refreshed.id,
-        "childSessionId": refreshed.child_session_id,
-        "label": refreshed.label,
-        "closed": true,
-        "alreadyClosed": already_closed,
-        "closedAt": refreshed.closed_at.unwrap_or(now),
-    }))
+
+    session_runtime
+        .close_live_session(&owned.target.id)
+        .await
+        .map_err(|error| anyhow::anyhow!("{error:?}"))?;
+    // The cascade closes the inbound ownership row itself; this covers the case
+    // where the row somehow outlived it, and keeps the close retryable when the
+    // live close failed above (the link stays open, so does the request).
+    let settled = ownership.reload_link(&owned.link)?;
+    let settled = if settled.closed_at.is_none() {
+        ownership.close_link(&settled, &chrono::Utc::now().to_rfc3339())?;
+        ownership.reload_link(&settled)?
+    } else {
+        settled
+    };
+    Ok(close_result(&owned, &settled, false))
+}
+
+/// Whether the target is actually working right now.
+///
+/// Only `Running` defers. `AwaitingInteraction` is a turn that cannot finish
+/// without a human answering a prompt, so "let it finish first" would mean
+/// "never"; `Starting` has no turn to finish and may never emit one. Both close
+/// immediately, which is also what the caller means by "stop this agent".
+async fn is_mid_turn(session_runtime: &SessionRuntime, owned: &OwnedAgent) -> bool {
+    matches!(
+        session_runtime
+            .session_execution_summary(&owned.target)
+            .await
+            .phase,
+        anyharness_contract::v1::SessionExecutionPhase::Running
+    )
+}
+
+fn close_result(
+    owned: &OwnedAgent,
+    settled: &crate::domains::sessions::links::model::SessionLinkRecord,
+    close_requested: bool,
+) -> Value {
+    json!({
+        "subagentId": settled.public_id,
+        "sessionLinkId": settled.id,
+        "sessionId": settled.child_session_id,
+        // The pre-agent-ops field name, kept so a session still holding the
+        // `close_subagent` tool list reads the same shape back.
+        "childSessionId": settled.child_session_id,
+        "label": settled.label,
+        "closed": settled.closed_at.is_some(),
+        "closeRequested": close_requested,
+        "alreadyClosed": owned.link.closed_at.is_some() || owned.target.closed_at.is_some(),
+        "closedAt": settled.closed_at,
+        "closedBySessionId": settled.closed_by_session_id,
+        "closeReason": settled.close_reason,
+        "message": if close_requested {
+            "That agent is mid-step. It will finish the step it is on, then stop."
+        } else {
+            "That agent is closed. Its transcript stays readable."
+        },
+    })
 }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/calls_helpers.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/calls_helpers.rs
@@ -77,6 +77,12 @@ pub(super) fn summaries_to_json(
                 "modeId": summary.mode_id,
                 "createdAt": summary.created_at,
                 "closedAt": summary.closed_at,
+                // Ownership state, so a parent reading its roster can tell a
+                // subordinate child from a promoted peer without a second call.
+                "promoted": summary.promoted_at.is_some(),
+                "promotedAt": summary.promoted_at,
+                "closedBySessionId": summary.closed_by_session_id,
+                "closeReason": summary.close_reason,
             })
         })
         .collect()

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/context.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/context.rs
@@ -13,6 +13,13 @@ pub struct AgentOpsMcpContext {
     pub create_block_reason: Option<String>,
     pub existing_subagent_count: usize,
     pub max_subagents_per_parent: usize,
+    /// True while this session is somebody's subagent and has not been
+    /// promoted. It is deliberately NOT the negation of `can_create`:
+    /// `can_create` is also false at the fanout cap or with subagents disabled,
+    /// which are temporary conditions of a session that is still allowed to
+    /// think in terms of spawning. This one says the session is subordinate, so
+    /// the spawn tools are withheld entirely (ADR §3.3).
+    pub is_unpromoted_subagent: bool,
 }
 
 pub fn resolve_context(
@@ -48,6 +55,10 @@ pub fn resolve_context(
         Ok(_) => None,
         Err(error) => Some(resolve_create_block_reason(error)?),
     };
+    let is_unpromoted_subagent = service
+        .find_subagent_parent(&request.session_id)
+        .map_err(ProductMcpContextError::Internal)?
+        .is_some_and(|link| link.is_unpromoted_subagent());
 
     Ok(AgentOpsMcpContext {
         parent_session_id: request.session_id.clone(),
@@ -56,6 +67,7 @@ pub fn resolve_context(
         create_block_reason,
         existing_subagent_count,
         max_subagents_per_parent: MAX_SUBAGENTS_PER_PARENT,
+        is_unpromoted_subagent,
     })
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/context.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/context.rs
@@ -47,10 +47,15 @@ pub fn resolve_context(
             "subagents are only available in standard workspaces",
         ));
     }
+    // Occupied SLOTS, not children: a promoted child keeps its ownership row
+    // but stopped counting against the cap, both in the spawn pre-check and in
+    // the store subselect that actually rejects the insert. Counting rows here
+    // would report `remainingSubagents: 0` to a parent `spawn_subagent` is
+    // still happy to serve — and the tool description tells agents to trust
+    // these numbers.
     let existing_subagent_count = service
-        .list_subagents(&request.session_id)
-        .map_err(|error| ProductMcpContextError::Internal(error.into()))?
-        .len();
+        .count_occupied_subagent_slots(&request.session_id)
+        .map_err(ProductMcpContextError::Internal)?;
     let create_block_reason = match service.validate_parent_can_spawn(&request.session_id) {
         Ok(_) => None,
         Err(error) => Some(resolve_create_block_reason(error)?),

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/mod.rs
@@ -4,7 +4,12 @@ mod calls_helpers;
 mod config_ops;
 pub mod context;
 pub mod definition;
-mod peer_ops;
+// The peer gates are the runtime's ownership-independent fence: session
+// mutation permit, then the TARGET workspace's write lease, in that order
+// (PR1227-LOCK-01). The deferred close in `sessions::ownership::hooks` takes
+// exactly the same pair, so it reuses these rather than restating a lock-order
+// contract in a second place.
+pub(crate) mod peer_ops;
 pub mod tools;
 
 use std::sync::Arc;
@@ -15,6 +20,7 @@ use serde_json::Value;
 use self::auth::AgentOpsMcpAuth;
 use self::context::AgentOpsMcpContext;
 use crate::domains::sessions::admission::SessionMutationAdmission;
+use crate::domains::sessions::ownership::service::AgentOwnershipService;
 use crate::domains::sessions::runtime::SessionRuntime;
 use crate::domains::sessions::subagents::service::SubagentService;
 use crate::domains::sessions::wakes::service::AgentWakeService;
@@ -42,16 +48,19 @@ pub struct AgentOpsProductMcpServer {
     wake_service: Arc<AgentWakeService>,
     session_runtime: Arc<SessionRuntime>,
     workspace_runtime: Arc<WorkspaceRuntime>,
+    ownership: Arc<AgentOwnershipService>,
     peer_gates: AgentOpsPeerGates,
     auth: Arc<AgentOpsMcpAuth>,
 }
 
 impl AgentOpsProductMcpServer {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         service: Arc<SubagentService>,
         wake_service: Arc<AgentWakeService>,
         session_runtime: Arc<SessionRuntime>,
         workspace_runtime: Arc<WorkspaceRuntime>,
+        ownership: Arc<AgentOwnershipService>,
         peer_gates: AgentOpsPeerGates,
         auth: Arc<AgentOpsMcpAuth>,
     ) -> Self {
@@ -60,6 +69,7 @@ impl AgentOpsProductMcpServer {
             wake_service,
             session_runtime,
             workspace_runtime,
+            ownership,
             peer_gates,
             auth,
         }
@@ -103,6 +113,7 @@ impl ProductMcpServer for AgentOpsProductMcpServer {
             &self.service,
             &self.wake_service,
             &self.session_runtime,
+            &self.ownership,
             &self.peer_gates,
             ctx,
             name,

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/peer_ops.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/peer_ops.rs
@@ -10,6 +10,7 @@ use crate::domains::sessions::admission::{
     SessionMutationSource,
 };
 use crate::domains::sessions::authorize::{authorize, AgentAccessError, AgentAccessIntent};
+use crate::domains::sessions::links::service::SessionLinkService;
 use crate::domains::sessions::model::SessionRecord;
 use crate::domains::sessions::prompt::envelope::{agent_message, AgentMessageSender};
 use crate::domains::sessions::prompt::provenance::PromptProvenance;
@@ -40,6 +41,11 @@ pub(super) fn authorize_transcript_read(
 pub(super) enum AgentMessageError {
     #[error("message is required")]
     EmptyMessage,
+    #[error(
+        "that agent is finishing its final step before closing and takes no new messages. \
+         Its transcript stays readable once it stops"
+    )]
+    TargetEndRequested,
     #[error(transparent)]
     Access(#[from] AgentAccessError),
 }
@@ -61,6 +67,7 @@ pub(super) struct PreparedAgentMessage {
 /// *right now* is a separate question, answered by [`admit_peer_mutation`].
 pub(super) fn prepare_agent_message(
     session_store: &SessionStore,
+    link_service: &SessionLinkService,
     caller_session_id: &str,
     target_session_id: &str,
     message: &str,
@@ -74,6 +81,7 @@ pub(super) fn prepare_agent_message(
         target_session_id,
         AgentAccessIntent::Send,
     )?;
+    assert_target_still_takes_messages(link_service, target_session_id)?;
     let sender = AgentMessageSender::from_session(&access.caller);
     let (text, provenance) = agent_message(&sender, message).into_parts();
     Ok(PreparedAgentMessage {
@@ -82,6 +90,32 @@ pub(super) fn prepare_agent_message(
         text,
         provenance,
     })
+}
+
+/// An end-requested agent takes no new messages.
+///
+/// Ruling 6 refuses sends to a CLOSED session, and before the soft close that
+/// was the whole story: a close was instantaneous, so there was no third state.
+/// There is now — an open session whose ownership row is stamped
+/// `closed_by_session_id IS NOT NULL AND closed_at IS NULL` — and it can be a
+/// whole turn wide. A prompt accepted into that window would enqueue
+/// successfully and then never run: the actor refuses to start a turn while a
+/// close is pending, and after the close it never boots again. Refusing at the
+/// door tells the sender that, instead of stranding the message silently.
+///
+/// One indexed point read (`idx_session_links_pending_close_request`), the same
+/// one the turn-finish hook makes.
+pub(super) fn assert_target_still_takes_messages(
+    link_service: &SessionLinkService,
+    target_session_id: &str,
+) -> Result<(), AgentMessageError> {
+    let pending = link_service
+        .find_pending_close_request(target_session_id)
+        .map_err(|error| AgentMessageError::Access(AgentAccessError::Internal(error)))?;
+    if pending.is_some() {
+        return Err(AgentMessageError::TargetEndRequested);
+    }
+    Ok(())
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -229,6 +263,11 @@ mod tests {
     use crate::app::test_support;
     use crate::domains::sessions::admission::{NoControllerPolicy, SessionControllerPolicy};
     use crate::domains::sessions::extensions::SessionTurnOutcome;
+    use crate::domains::sessions::links::model::{
+        SessionLinkRelation, SessionLinkWorkspaceRelation,
+    };
+    use crate::domains::sessions::links::service::CreateSessionLinkInput;
+    use crate::domains::sessions::links::store::SessionLinkStore;
     use crate::domains::sessions::model::SessionMcpBindingPolicy;
     use crate::domains::sessions::prompt::PromptPayload;
     use crate::domains::sessions::store::agent_wakes::AgentWakeReason;
@@ -269,10 +308,16 @@ mod tests {
     }
 
     fn store_fixture() -> SessionStore {
+        store_and_links_fixture().0
+    }
+
+    /// Two agents in two workspaces, plus the link service the send path reads
+    /// ownership rows from (an end-requested target takes no new messages).
+    fn store_and_links_fixture() -> (SessionStore, SessionLinkService) {
         let db = Db::open_in_memory().expect("open db");
         test_support::seed_workspace_with_repo_root(&db, "workspace-1", "local", "/tmp/workspace-1");
         test_support::seed_workspace_with_repo_root(&db, "workspace-2", "local", "/tmp/workspace-2");
-        let store = SessionStore::new(db);
+        let store = SessionStore::new(db.clone());
         store
             .insert(&session_record(
                 "ses_caller",
@@ -283,7 +328,8 @@ mod tests {
         store
             .insert(&session_record("ses_target", "workspace-2", Some("Schema audit")))
             .expect("insert target");
-        store
+        let links = SessionLinkService::new(SessionLinkStore::new(db), store.clone());
+        (store, links)
     }
 
     fn wake_service_fixture(store: &SessionStore) -> AgentWakeService {
@@ -425,15 +471,29 @@ mod tests {
         std::fs::read_to_string(&path).expect("read calls.rs")
     }
 
+    /// The slice from `signature` to the next top-level fn — whichever comes
+    /// FIRST. Taking the earliest of the two matches rather than falling back
+    /// to the plain-`fn` search only when no `async fn` follows anywhere: the
+    /// fallback form never fires while any async fn exists further down the
+    /// file, so the window silently swallows the next sync function and the
+    /// guards below could be satisfied by a neighbour's text.
+    /// Collapse every whitespace run to one space so the assertions below
+    /// survive rustfmt's line breaking. `let _lease =\n    match foo(` and
+    /// `let _lease = match foo(` are the same guarantee and must read the same.
+    fn squashed(text: &str) -> String {
+        text.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
     fn function_body<'a>(source: &'a str, signature: &str) -> &'a str {
         let start = source
             .find(signature)
-            .unwrap_or_else(|| panic!("{signature} is defined in calls.rs"));
+            .unwrap_or_else(|| panic!("{signature} is not defined in the file under guard"));
         let rest = &source[start..];
-        &rest[..rest[1..]
-            .find("\nasync fn ")
-            .or_else(|| rest[1..].find("\nfn "))
-            .map_or(rest.len(), |at| at + 1)]
+        let end = [rest[1..].find("\nasync fn "), rest[1..].find("\nfn ")]
+            .into_iter()
+            .flatten()
+            .min();
+        &rest[..end.map_or(rest.len(), |at| at + 1)]
     }
 
     #[test]
@@ -509,6 +569,21 @@ mod tests {
             permit_at < stamp_at,
             "the close request must not be armed by a call the fence would refuse"
         );
+        // Order is only half of it: both guards must be HELD to the end of the
+        // scope. `let _ = admit_peer_mutation(...)` drops the permit at the end
+        // of its own statement, destroys the fence, and leaves every ordering
+        // assertion above still passing — so the bindings are pinned by name.
+        let held = squashed(body);
+        assert!(
+            held.contains("let _admission_permit = admit_peer_mutation("),
+            "the permit must be BOUND (`let _admission_permit = ...`), not dropped at the \
+             end of its own statement"
+        );
+        assert!(
+            held.contains("let _target_workspace_lease = lease_target_workspace_for_peer_write("),
+            "the workspace lease must be BOUND (`let _target_workspace_lease = ...`), not \
+             dropped at the end of its own statement"
+        );
     }
 
     #[test]
@@ -519,7 +594,10 @@ mod tests {
         // second lock order.
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("src/domains/sessions/ownership/hooks.rs");
-        let body = std::fs::read_to_string(&path).expect("read ownership/hooks.rs");
+        let source = std::fs::read_to_string(&path).expect("read ownership/hooks.rs");
+        // The one body both deferred callers (turn finish, boot reconciliation)
+        // go through.
+        let body = function_body(&source, "async fn complete_close_request(");
 
         let permit_at = body
             .find("admit_peer_mutation(")
@@ -534,13 +612,23 @@ mod tests {
         assert!(body[permit_at..lease_at].contains("SessionMutationKind::Close"));
         assert!(permit_at < lease_at);
         assert!(lease_at < close_at);
+        // Held, not merely called — same reason as the synchronous half.
+        let held = squashed(body);
+        assert!(
+            held.contains("let _permit = match admit_peer_mutation("),
+            "the deferred permit must be BOUND across the close"
+        );
+        assert!(
+            held.contains("let _lease = match lease_target_workspace_for_peer_write("),
+            "the deferred workspace lease must be BOUND across the close"
+        );
     }
 
     #[test]
     fn an_open_target_in_another_workspace_is_reachable() {
-        let store = store_fixture();
+        let (store, links) = store_and_links_fixture();
 
-        let prepared = prepare_agent_message(&store, "ses_caller", "ses_target", "Ship it?")
+        let prepared = prepare_agent_message(&store, &links, "ses_caller", "ses_target", "Ship it?")
             .expect("prepare message");
 
         assert_eq!(prepared.target.id, "ses_target");
@@ -550,13 +638,13 @@ mod tests {
 
     #[test]
     fn a_closed_target_is_rejected_before_any_prompt_is_built() {
-        let store = store_fixture();
+        let (store, links) = store_and_links_fixture();
         let mut closed = session_record("ses_closed", "workspace-1", Some("Retired"));
         closed.closed_at = Some("2026-08-08T01:00:00Z".to_string());
         closed.status = "closed".to_string();
         store.insert(&closed).expect("insert closed target");
 
-        let error = prepare_agent_message(&store, "ses_caller", "ses_closed", "Ship it?")
+        let error = prepare_agent_message(&store, &links, "ses_caller", "ses_closed", "Ship it?")
             .err()
             .expect("closed target is rejected");
 
@@ -569,12 +657,12 @@ mod tests {
 
     #[test]
     fn a_dismissed_target_is_rejected_before_the_boot_path_can_fail_opaquely() {
-        let store = store_fixture();
+        let (store, links) = store_and_links_fixture();
         let mut dismissed = session_record("ses_dismissed", "workspace-1", Some("Deleted"));
         dismissed.dismissed_at = Some("2026-08-08T01:00:00Z".to_string());
         store.insert(&dismissed).expect("insert dismissed target");
 
-        let error = prepare_agent_message(&store, "ses_caller", "ses_dismissed", "Ship it?")
+        let error = prepare_agent_message(&store, &links, "ses_caller", "ses_dismissed", "Ship it?")
             .err()
             .expect("dismissed target is rejected");
 
@@ -590,12 +678,12 @@ mod tests {
 
     #[test]
     fn an_internal_only_target_is_not_a_peer() {
-        let store = store_fixture();
+        let (store, links) = store_and_links_fixture();
         let mut internal = session_record("ses_internal", "workspace-1", Some("Workflow step"));
         internal.mcp_binding_policy = SessionMcpBindingPolicy::InternalOnly;
         store.insert(&internal).expect("insert internal target");
 
-        let error = prepare_agent_message(&store, "ses_caller", "ses_internal", "Ship it?")
+        let error = prepare_agent_message(&store, &links, "ses_caller", "ses_internal", "Ship it?")
             .err()
             .expect("internal-only target is rejected");
         assert!(matches!(
@@ -612,10 +700,54 @@ mod tests {
     }
 
     #[test]
-    fn an_agent_cannot_message_itself() {
-        let store = store_fixture();
+    fn an_end_requested_target_is_refused_and_told_why() {
+        // The soft-close window: the ownership row is stamped but still open,
+        // so the session is not closed and `authorize` lets the send through.
+        // A prompt accepted here would enqueue and then never run — the actor
+        // starts no turn while a close is pending, and after the close it never
+        // boots again — so the send is refused at the door with a reason the
+        // calling agent can act on.
+        let (store, links) = store_and_links_fixture();
+        let link = links
+            .create_link(CreateSessionLinkInput {
+                relation: SessionLinkRelation::Subagent,
+                parent_session_id: "ses_caller".to_string(),
+                child_session_id: "ses_target".to_string(),
+                workspace_relation: SessionLinkWorkspaceRelation::SameWorkspace,
+                label: Some("Schema audit".to_string()),
+                created_by_turn_id: None,
+                created_by_tool_call_id: None,
+            })
+            .expect("link the target as a subagent");
 
-        let error = prepare_agent_message(&store, "ses_caller", "ses_caller", "Ship it?")
+        // Negative control: before the stamp, the very same send is accepted.
+        prepare_agent_message(&store, &links, "ses_caller", "ses_target", "Ship it?")
+            .expect("an open, un-requested target takes messages");
+
+        links
+            .record_close_attribution(&link.id, "ses_caller", Some("superseded"))
+            .expect("stamp the close request");
+
+        let error = prepare_agent_message(&store, &links, "ses_caller", "ses_target", "Ship it?")
+            .err()
+            .expect("an end-requested target is refused");
+        assert!(matches!(error, AgentMessageError::TargetEndRequested));
+        assert!(
+            error.to_string().contains("takes no new messages"),
+            "unexpected message: {error}"
+        );
+
+        // Reads are unaffected: closing removes the agent, not its record, and
+        // the same is true while it is on its way out.
+        authorize_transcript_read(&store, "ses_caller", "ses_target")
+            .expect("an end-requested agent's transcript stays readable");
+    }
+
+    #[test]
+    fn an_agent_cannot_message_itself() {
+        let (store, links) = store_and_links_fixture();
+
+        let error = prepare_agent_message(&store, &links, "ses_caller", "ses_caller", "Ship it?")
             .err()
             .expect("self send is rejected");
 
@@ -627,9 +759,9 @@ mod tests {
 
     #[test]
     fn an_unknown_target_is_named_in_the_error() {
-        let store = store_fixture();
+        let (store, links) = store_and_links_fixture();
 
-        let error = prepare_agent_message(&store, "ses_caller", "ses_ghost", "Ship it?")
+        let error = prepare_agent_message(&store, &links, "ses_caller", "ses_ghost", "Ship it?")
             .err()
             .expect("unknown target is rejected");
 
@@ -641,14 +773,14 @@ mod tests {
 
     #[test]
     fn a_closed_agents_transcript_stays_readable() {
-        let store = store_fixture();
+        let (store, links) = store_and_links_fixture();
         let mut closed = session_record("ses_closed", "workspace-1", Some("Retired"));
         closed.closed_at = Some("2026-08-08T01:00:00Z".to_string());
         closed.status = "closed".to_string();
         store.insert(&closed).expect("insert closed target");
 
         // The same target that refuses a send.
-        prepare_agent_message(&store, "ses_caller", "ses_closed", "Ship it?")
+        prepare_agent_message(&store, &links, "ses_caller", "ses_closed", "Ship it?")
             .err()
             .expect("closed target refuses sends");
         let target = authorize_transcript_read(&store, "ses_caller", "ses_closed")
@@ -677,9 +809,9 @@ mod tests {
 
     #[test]
     fn a_blank_message_is_rejected() {
-        let store = store_fixture();
+        let (store, links) = store_and_links_fixture();
 
-        let error = prepare_agent_message(&store, "ses_caller", "ses_target", "  \n ")
+        let error = prepare_agent_message(&store, &links, "ses_caller", "ses_target", "  \n ")
             .err()
             .expect("blank message is rejected");
 
@@ -688,9 +820,9 @@ mod tests {
 
     #[test]
     fn the_target_receives_the_envelope_and_the_row_stores_exactly_that_text() {
-        let store = store_fixture();
+        let (store, links) = store_and_links_fixture();
 
-        let prepared = prepare_agent_message(&store, "ses_caller", "ses_target", "Ship it?")
+        let prepared = prepare_agent_message(&store, &links, "ses_caller", "ses_target", "Ship it?")
             .expect("prepare message");
 
         assert_eq!(

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/peer_ops.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/peer_ops.rs
@@ -85,7 +85,7 @@ pub(super) fn prepare_agent_message(
 }
 
 #[derive(Debug, thiserror::Error)]
-pub(super) enum PeerGateError {
+pub(crate) enum PeerGateError {
     #[error(
         "that agent's execution is controlled by an active workflow run and cannot be \
          prompted or reconfigured until the run finishes"
@@ -113,7 +113,7 @@ pub(super) enum PeerGateError {
 /// The permit is held across the dispatch, so a workflow that takes control
 /// mid-call cannot interleave, and a peer mutation is visible to the
 /// destructive workspace paths that admit a whole workspace's session set.
-pub(super) async fn admit_peer_mutation(
+pub(crate) async fn admit_peer_mutation(
     admission: &SessionMutationAdmission,
     target_session_id: &str,
     kind: SessionMutationKind,
@@ -161,7 +161,7 @@ pub(super) async fn admit_peer_mutation(
 /// which hold every session permit in a workspace and then reach for that
 /// workspace's exclusive lease. Exactly one workspace lease is taken here, so
 /// there is no second lease to order against either.
-pub(super) async fn lease_target_workspace_for_peer_write(
+pub(crate) async fn lease_target_workspace_for_peer_write(
     operation_gate: &WorkspaceOperationGate,
     access_gate: &WorkspaceAccessGate,
     target_workspace_id: &str,
@@ -177,7 +177,7 @@ pub(super) async fn lease_target_workspace_for_peer_write(
 
 /// Access-state check with no lease attached — the caller-side half of what the
 /// route used to do for this tool (`assert_workspace_mutable`).
-pub(super) fn assert_workspace_can_be_mutated(
+pub(crate) fn assert_workspace_can_be_mutated(
     access_gate: &WorkspaceAccessGate,
     workspace_id: &str,
 ) -> Result<(), PeerGateError> {
@@ -413,6 +413,127 @@ mod tests {
             dispatched_at < consumed_at,
             "the recipient's wake must be consumed AFTER the send lands"
         );
+    }
+
+    /// Read `calls.rs` once for the guards below. Same technique, and the same
+    /// justification, as `send_agent_message_arms_before_the_dispatch...`
+    /// above: these are orderings inside an async handler that needs a live
+    /// runtime, and the ordering IS the guarantee.
+    fn calls_source() -> String {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/domains/sessions/agent_ops/calls.rs");
+        std::fs::read_to_string(&path).expect("read calls.rs")
+    }
+
+    fn function_body<'a>(source: &'a str, signature: &str) -> &'a str {
+        let start = source
+            .find(signature)
+            .unwrap_or_else(|| panic!("{signature} is defined in calls.rs"));
+        let rest = &source[start..];
+        &rest[..rest[1..]
+            .find("\nasync fn ")
+            .or_else(|| rest[1..].find("\nfn "))
+            .map_or(rest.len(), |at| at + 1)]
+    }
+
+    #[test]
+    fn the_spawn_gate_runs_before_dispatch_not_only_in_the_tool_list() {
+        // Tool lists are frozen at session launch, so hiding the spawn tools in
+        // `tools/list` cannot bind an agent whose state changed afterwards — a
+        // subagent launched before its promotion, or promoted after its launch,
+        // holds a stale list either way. Only this check runs against the
+        // caller's state at the moment it acts. It must also come BEFORE the
+        // dispatch match, or the handler has already run by the time it refuses.
+        let source = calls_source();
+        let body = function_body(&source, "pub async fn call_tool(");
+
+        let gate_at = body
+            .find("is_spawn_style_tool(name)")
+            .expect("call_tool gates the spawn-style tools at dispatch");
+        let dispatch_at = body
+            .find("match canonical_tool_name(name)")
+            .expect("call_tool dispatches on the canonical tool name");
+        assert!(
+            gate_at < dispatch_at,
+            "the spawn gate must refuse BEFORE the tool dispatches"
+        );
+        // Matched on the WIRE name: `canonical_tool_name` would map the
+        // deprecated `create_subagent` spelling onto `spawn_subagent` and let a
+        // launch-frozen subagent walk around the gate under the old name.
+        assert!(
+            !body[..gate_at].contains("canonical_tool_name(name)"),
+            "the spawn gate must match the wire name, not the canonicalized one"
+        );
+    }
+
+    #[test]
+    fn close_agent_takes_the_targets_permit_before_any_workspace_lease() {
+        // H1: a close mutates a session that need not be in the caller's link
+        // tree or workspace, so it must take that session's mutation permit —
+        // otherwise it runs straight through a workflow holding control. And it
+        // must take it OUTERMOST (PR1227-LOCK-01): the reverse order is what
+        // `api/session_admission_tests.rs` proves deadlocks against
+        // retire/purge, which hold every session permit in a workspace and then
+        // reach for that workspace's exclusive lease.
+        let source = calls_source();
+        let body = function_body(&source, "async fn close_agent(");
+
+        let permit_at = body
+            .find("admit_peer_mutation(")
+            .expect("close_agent takes the target session's mutation permit");
+        let lease_at = body
+            .find("lease_target_workspace_for_peer_write(")
+            .expect("close_agent leases the target workspace");
+        let close_at = body
+            .find("close_live_session(")
+            .expect("close_agent closes the live session");
+
+        assert!(
+            body[permit_at..lease_at].contains("SessionMutationKind::Close"),
+            "the permit must be taken for the Close kind"
+        );
+        assert!(
+            permit_at < lease_at,
+            "the session mutation permit must be taken BEFORE the workspace lease"
+        );
+        assert!(
+            lease_at < close_at,
+            "both gates must be held across the close itself"
+        );
+        // The attribution stamp is what arms a deferred close, so it must land
+        // under the permit too — a refused call must arm nothing.
+        let stamp_at = body
+            .find("record_close_attribution(")
+            .expect("close_agent records who closed the agent and why");
+        assert!(
+            permit_at < stamp_at,
+            "the close request must not be armed by a call the fence would refuse"
+        );
+    }
+
+    #[test]
+    fn the_deferred_half_of_a_soft_close_retakes_the_same_gates_in_the_same_order() {
+        // The requesting call returned long ago and control can be acquired in
+        // between, so the turn-finish completion cannot carry the gates — it
+        // re-takes them, and in the same order, or the deferred path becomes a
+        // second lock order.
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/domains/sessions/ownership/hooks.rs");
+        let body = std::fs::read_to_string(&path).expect("read ownership/hooks.rs");
+
+        let permit_at = body
+            .find("admit_peer_mutation(")
+            .expect("the deferred close takes the target's mutation permit");
+        let lease_at = body
+            .find("lease_target_workspace_for_peer_write(")
+            .expect("the deferred close leases the target workspace");
+        let close_at = body
+            .find("close_live_session(")
+            .expect("the deferred close closes the live session");
+
+        assert!(body[permit_at..lease_at].contains("SessionMutationKind::Close"));
+        assert!(permit_at < lease_at);
+        assert!(lease_at < close_at);
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/tools.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/tools.rs
@@ -26,15 +26,36 @@ pub const DEPRECATED_TOOL_ALIASES: &[(&str, &str)] = &[
 // `permit -> workspace lease` order: a route lease taken before the permit is
 // the reversed order `api/session_admission_tests.rs` proves deadlocks against
 // retire/purge. Absent here means "leases itself", never "mutates nothing".
+// `close_agent`/`close_subagent` joined that list when close was link-scoped and
+// therefore always same-workspace. It is now `close_agent(sessionId)`, whose
+// target can be any owned agent anywhere, so it leases itself for the same two
+// reasons — and it must, because a close acts on the target session and so
+// takes that session's mutation permit, which has to be OUTSIDE any workspace
+// lease.
 pub const MUTATING_TOOL_NAMES: &[&str] = &[
     "spawn_subagent",
     "create_subagent",
     "send_subagent_message",
     "schedule_subagent_wake",
     "schedule_agent_wake",
-    "close_agent",
-    "close_subagent",
+    "promote_subagent",
 ];
+
+/// The tools that make a session an owner of new agents. Withheld entirely from
+/// an unpromoted subagent (ADR §3.3) — not merely refused at the fanout cap,
+/// which is what `can_create` covers. Listed by wire name, aliases included,
+/// because `calls::call_tool` enforces this at DISPATCH: a session's tool list
+/// is frozen at launch, so an agent promoted (or not) after launch is holding a
+/// stale advertisement either way.
+pub const SPAWN_STYLE_TOOL_NAMES: &[&str] = &[
+    "get_subagent_launch_options",
+    "spawn_subagent",
+    "create_subagent",
+];
+
+pub fn is_spawn_style_tool(name: &str) -> bool {
+    SPAWN_STYLE_TOOL_NAMES.contains(&name)
+}
 
 /// Resolves a wire tool name to the implementation it dispatches to.
 pub fn canonical_tool_name(name: &str) -> &str {
@@ -63,6 +84,33 @@ pub struct CreateSubagentArgs {
 pub struct ChildSessionArgs {
     #[serde(default)]
     pub subagent_id: Option<String>,
+}
+
+/// Both spellings of "which of my children", because promotion is reachable
+/// from the subagent vocabulary (`subagentId`, what every link-scoped tool
+/// takes) and from the peer vocabulary (`sessionId`, what `list_agents`
+/// returns). They resolve through the same owned-link lookup.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PromoteSubagentArgs {
+    #[serde(default)]
+    pub subagent_id: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+/// `sessionId` is the tool's own argument; `subagentId` is kept for callers
+/// still holding the pre-agent-ops `close_subagent` tool list, whose schema had
+/// only that field.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CloseAgentArgs {
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub subagent_id: Option<String>,
+    #[serde(default)]
+    pub reason: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -185,12 +233,22 @@ pub fn build_tool_list(ctx: &AgentOpsMcpContext) -> Vec<Value> {
     // Peer messaging and peer reads are unconditional: reach is runtime-wide,
     // and every agent has them — including an unpromoted subagent, which loses
     // only the spawn-style tools.
-    let mut tools = vec![
-        tool_definition(
+    let mut tools = Vec::new();
+
+    // Spawn-style tools are withheld from an unpromoted subagent entirely: it
+    // is subordinate, so the shape of its options is not information it can
+    // act on. Promotion returns them. This is advertisement only — the gate
+    // that matters runs in `calls::call_tool`, because tool lists are frozen at
+    // session launch and promotion happens later.
+    if !ctx.is_unpromoted_subagent {
+        tools.push(tool_definition(
             "get_subagent_launch_options",
             "Describe subagent creation defaults, limits, supported agent/model choices, and available parent mode hints.",
             json!({ "type": "object", "properties": {} }),
-        ),
+        ));
+    }
+
+    tools.extend([
         tool_definition(
             "list_subagents",
             "List child sessions owned by this parent session.",
@@ -282,9 +340,9 @@ pub fn build_tool_list(ctx: &AgentOpsMcpContext) -> Vec<Value> {
                 "required": ["sessionId"]
             }),
         ),
-    ];
+    ]);
 
-    if ctx.can_create {
+    if ctx.can_create && !ctx.is_unpromoted_subagent {
         tools.push(
             tool_definition(
                 "spawn_subagent",
@@ -387,12 +445,25 @@ pub fn build_tool_list(ctx: &AgentOpsMcpContext) -> Vec<Value> {
             }),
         ),
         tool_definition(
-            "close_agent",
-            "Close an owned subagent and stop future prompts/wakes while preserving history.",
+            "promote_subagent",
+            "Promote one of your subagents to a peer. It keeps its transcript, its label and you as its owner, and it gains the full tool surface — including spawning its own agents. What it loses is subordination: it no longer closes when you close, and it no longer counts against your subagent limit. Promotion cannot be undone.",
             json!({
                 "type": "object",
                 "properties": {
-                    "subagentId": { "type": "string", "description": "Stable subagent target id." }
+                    "subagentId": { "type": "string", "description": "Stable subagent target id." },
+                    "sessionId": { "type": "string", "description": "The subagent's session id, if you have that instead." }
+                }
+            }),
+        ),
+        tool_definition(
+            "close_agent",
+            "Close an agent you own and stop future prompts and wakes; its transcript stays readable. Its own unpromoted subagents close with it; agents it promoted do not. Closing an agent that is mid-turn does not interrupt it — it finishes the step it is on and then stops.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "sessionId": { "type": "string", "description": "Session id of the agent to close. Must be one you own." },
+                    "subagentId": { "type": "string", "description": "Stable subagent target id, if you have that instead." },
+                    "reason": { "type": "string", "description": "Short note recorded with the close, shown to whoever looks at the agent later." }
                 }
             }),
         ),
@@ -405,8 +476,8 @@ pub fn build_tool_list(ctx: &AgentOpsMcpContext) -> Vec<Value> {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_tool_list, canonical_tool_name, AgentOpsMcpContext, DEPRECATED_TOOL_ALIASES,
-        MUTATING_TOOL_NAMES,
+        build_tool_list, canonical_tool_name, is_spawn_style_tool, AgentOpsMcpContext,
+        DEPRECATED_TOOL_ALIASES, MUTATING_TOOL_NAMES, SPAWN_STYLE_TOOL_NAMES,
     };
     use serde_json::Value;
 
@@ -422,6 +493,16 @@ mod tests {
             },
             existing_subagent_count,
             max_subagents_per_parent: 8,
+            is_unpromoted_subagent: false,
+        }
+    }
+
+    /// A live unpromoted subagent: subordinate, so `validate_parent_can_spawn`
+    /// already refuses it with DepthLimit, and it has no children of its own.
+    fn unpromoted_subagent_context() -> AgentOpsMcpContext {
+        AgentOpsMcpContext {
+            is_unpromoted_subagent: true,
+            ..context(false, 0)
         }
     }
 
@@ -498,9 +579,9 @@ mod tests {
 
     #[test]
     fn peer_messaging_and_reads_are_offered_to_every_caller() {
-        // A caller with no children and no spawn rights is the unpromoted
-        // subagent case: it keeps messaging, listing and reading.
-        for ctx in [context(true, 2), context(false, 0)] {
+        // An unpromoted subagent keeps messaging, listing and reading; it loses
+        // only the spawn-style tools.
+        for ctx in [context(true, 2), unpromoted_subagent_context()] {
             let tools = build_tool_list(&ctx);
             let names = tool_names(&tools);
 
@@ -541,7 +622,7 @@ mod tests {
     fn configure_tools_are_offered_to_every_caller() {
         // Ruling 3: an unpromoted subagent loses the spawn tools and keeps
         // messaging, reading, waking and configuring.
-        for ctx in [context(true, 2), context(false, 0)] {
+        for ctx in [context(true, 2), unpromoted_subagent_context()] {
             let tools = build_tool_list(&ctx);
             let names = tool_names(&tools);
 
@@ -570,7 +651,7 @@ mod tests {
     fn session_scoped_wakes_are_offered_to_every_caller() {
         // Same reasoning as peer messaging: an unpromoted subagent loses spawn
         // tools, not the ability to wait on a peer.
-        for ctx in [context(true, 2), context(false, 0)] {
+        for ctx in [context(true, 2), unpromoted_subagent_context()] {
             let tools = build_tool_list(&ctx);
             let names = tool_names(&tools);
 
@@ -674,5 +755,126 @@ mod tests {
                 "alias {alias} and canonical {canonical} disagree on mutating status"
             );
         }
+    }
+
+    // --- ownership, promotion and close (ADR §3.3, §3.4) -----------------
+
+    #[test]
+    fn an_unpromoted_subagent_is_offered_no_spawn_style_tool() {
+        let tools = build_tool_list(&unpromoted_subagent_context());
+        let names = tool_names(&tools);
+
+        for spawn_tool in SPAWN_STYLE_TOOL_NAMES {
+            assert!(
+                !names.contains(spawn_tool),
+                "{spawn_tool} is advertised to an unpromoted subagent"
+            );
+        }
+    }
+
+    #[test]
+    fn launch_options_come_back_once_the_subagent_is_promoted() {
+        // Same session, one column later: it is still somebody's child, but it
+        // is no longer subordinate, so the spawn surface returns.
+        let promoted = AgentOpsMcpContext {
+            is_unpromoted_subagent: false,
+            ..context(true, 0)
+        };
+        let names_before = tool_names(&build_tool_list(&unpromoted_subagent_context()))
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        let tools_after = build_tool_list(&promoted);
+        let names_after = tool_names(&tools_after);
+
+        assert!(!names_before.iter().any(|name| name == "spawn_subagent"));
+        assert!(names_after.contains(&"spawn_subagent"));
+        assert!(names_after.contains(&"get_subagent_launch_options"));
+    }
+
+    #[test]
+    fn a_capped_parent_still_sees_its_launch_options() {
+        // `can_create` is false at the fanout cap too, and that parent is NOT
+        // subordinate — withholding the option description there would hide the
+        // limit it is bumping against.
+        let tools = build_tool_list(&context(false, 8));
+        let names = tool_names(&tools);
+
+        assert!(names.contains(&"get_subagent_launch_options"));
+        assert!(!names.contains(&"spawn_subagent"));
+    }
+
+    #[test]
+    fn spawn_style_names_cover_the_deprecated_create_alias() {
+        // The dispatch gate matches wire names, so the old name has to be here
+        // or a launch-frozen subagent walks straight through it.
+        assert!(is_spawn_style_tool("create_subagent"));
+        assert!(is_spawn_style_tool("spawn_subagent"));
+        assert!(is_spawn_style_tool("get_subagent_launch_options"));
+        assert!(!is_spawn_style_tool("send_agent_message"));
+        assert!(!is_spawn_style_tool("close_agent"));
+        for (alias, canonical) in DEPRECATED_TOOL_ALIASES {
+            if is_spawn_style_tool(canonical) {
+                assert!(
+                    is_spawn_style_tool(alias),
+                    "alias {alias} escapes the spawn gate its canonical {canonical} is under"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn close_agent_leases_in_the_call_because_it_takes_the_targets_permit() {
+        // A close acts on the TARGET session, so it takes that session's
+        // mutation permit — which must be outside any workspace lease
+        // (PR1227-LOCK-01). A route-level lease would be taken first and invert
+        // the order. It is also the caller's workspace, and the target need not
+        // be in it.
+        assert!(!MUTATING_TOOL_NAMES.contains(&"close_agent"));
+        assert!(!MUTATING_TOOL_NAMES.contains(&"close_subagent"));
+        // Promotion only stamps the caller's own link row, in the caller's own
+        // workspace, and touches no session actor: the route lease is right.
+        assert!(MUTATING_TOOL_NAMES.contains(&"promote_subagent"));
+    }
+
+    #[test]
+    fn promote_and_close_are_offered_to_anyone_who_owns_agents() {
+        for ctx in [context(true, 0), context(false, 3)] {
+            let names_owned = tool_names(&build_tool_list(&ctx))
+                .into_iter()
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+
+            assert!(names_owned.iter().any(|name| name == "promote_subagent"));
+            assert!(names_owned.iter().any(|name| name == "close_agent"));
+        }
+
+        // Owning nothing and unable to spawn: nothing to promote or close.
+        let names = tool_names(&build_tool_list(&unpromoted_subagent_context()))
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        assert!(!names.iter().any(|name| name == "promote_subagent"));
+        assert!(!names.iter().any(|name| name == "close_agent"));
+    }
+
+    #[test]
+    fn close_agent_takes_a_session_id_and_an_optional_reason() {
+        let close = build_tool_list(&context(true, 1))
+            .into_iter()
+            .find(|tool| tool.get("name").and_then(Value::as_str) == Some("close_agent"))
+            .expect("close_agent is advertised");
+
+        assert!(close
+            .pointer("/inputSchema/properties/sessionId")
+            .is_some());
+        assert!(close.pointer("/inputSchema/properties/reason").is_some());
+        // `subagentId` survives for sessions still holding the pre-agent-ops
+        // `close_subagent` schema.
+        assert!(close
+            .pointer("/inputSchema/properties/subagentId")
+            .is_some());
+        // Neither target spelling is required: the call resolves whichever came.
+        assert!(close.pointer("/inputSchema/required").is_none());
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/tools.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/tools.rs
@@ -824,6 +824,30 @@ mod tests {
     }
 
     #[test]
+    fn every_advertised_spawn_tool_is_inside_the_spawn_gate() {
+        // `SPAWN_STYLE_TOOL_NAMES` is the whole of ruling 3's enforcement and
+        // it is hand-maintained. `spawn_agent` and `spawn_workspace` land in
+        // later steps; if one is advertised and not listed here, an unpromoted
+        // subagent silently regains a spawn tool and nothing fails. So the list
+        // is ratcheted against the advertisement: anything named `spawn_*` that
+        // a top-level caller is offered must be gated.
+        let advertised = build_tool_list(&context(true, 0));
+        for name in tool_names(&advertised) {
+            if name.starts_with("spawn_") {
+                assert!(
+                    is_spawn_style_tool(name),
+                    "{name} is advertised but missing from SPAWN_STYLE_TOOL_NAMES, so an \
+                     unpromoted subagent could call it"
+                );
+            }
+        }
+        // The gate is not vacuous: the current list really does hold one.
+        assert!(tool_names(&advertised)
+            .iter()
+            .any(|name| name.starts_with("spawn_")));
+    }
+
+    #[test]
     fn close_agent_leases_in_the_call_because_it_takes_the_targets_permit() {
         // A close acts on the TARGET session, so it takes that session's
         // mutation permit — which must be outside any workspace lease

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/links/model.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/links/model.rs
@@ -3,6 +3,11 @@ use std::fmt;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SessionLinkRelation {
     Subagent,
+    /// A top-level agent one session owns without parenting it: no fanout cap,
+    /// no depth rule, no close cascade. Nothing writes this relation yet — the
+    /// spawn_agent step is its only producer — but ownership reads already span
+    /// it, so an owned agent is closeable the day it can be created.
+    OwnedAgent,
     CoworkCodingSession,
     ReviewAgent,
     Fork,
@@ -12,6 +17,7 @@ impl SessionLinkRelation {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Subagent => "subagent",
+            Self::OwnedAgent => "owned_agent",
             Self::CoworkCodingSession => "cowork_coding_session",
             Self::ReviewAgent => "review_agent",
             Self::Fork => "fork",
@@ -21,6 +27,7 @@ impl SessionLinkRelation {
     pub fn parse(value: &str) -> Result<Self, SessionLinkParseError> {
         match value {
             "subagent" => Ok(Self::Subagent),
+            "owned_agent" => Ok(Self::OwnedAgent),
             "cowork_coding_session" => Ok(Self::CoworkCodingSession),
             "review_agent" => Ok(Self::ReviewAgent),
             "fork" => Ok(Self::Fork),
@@ -31,10 +38,19 @@ impl SessionLinkRelation {
     pub fn public_id_prefix(self) -> &'static str {
         match self {
             Self::Subagent => "subagent",
+            Self::OwnedAgent => "agent",
             Self::CoworkCodingSession => "cowork_agent",
             Self::ReviewAgent => "reviewer",
             Self::Fork => "session_link",
         }
+    }
+
+    /// Whether the relation makes `parent_session_id` the OWNER of
+    /// `child_session_id` — the one predicate behind close and promote rights.
+    /// A fork is a copy and cowork/reviews are the superseded features; none of
+    /// them confers ownership.
+    pub fn is_ownership(self) -> bool {
+        matches!(self, Self::Subagent | Self::OwnedAgent)
     }
 }
 
@@ -88,6 +104,31 @@ pub struct SessionLinkRecord {
     pub created_by_tool_call_id: Option<String>,
     pub created_at: String,
     pub closed_at: Option<String>,
+    /// NULL = a plain linked subagent. Set once, idempotently, by
+    /// `promote_subagent`: the row keeps `relation = 'subagent'` (the former
+    /// parent still owns it and may close it individually) but stops being a
+    /// close-cascade child and regains the spawn tools.
+    pub promoted_at: Option<String>,
+    /// The agent that asked for this link's child to close. NULL on a human
+    /// close, which leaves no trace. Set while `closed_at` is still NULL, it is
+    /// the durable "end requested" record a mid-turn close leaves behind.
+    pub closed_by_session_id: Option<String>,
+    /// Optional free text from the closing agent, rendered beside it.
+    pub close_reason: Option<String>,
+}
+
+impl SessionLinkRecord {
+    /// A linked subagent that has not been promoted — the only child the close
+    /// cascade follows, and the only caller barred from the spawn tools.
+    pub fn is_unpromoted_subagent(&self) -> bool {
+        self.relation == SessionLinkRelation::Subagent && self.promoted_at.is_none()
+    }
+
+    /// An agent-initiated close that has been requested but not completed: the
+    /// target was mid-turn, so the close waits for that turn to finish.
+    pub fn is_close_requested(&self) -> bool {
+        self.closed_at.is_none() && self.closed_by_session_id.is_some()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -122,6 +163,87 @@ mod tests {
             SessionLinkRelation::parse("fork").expect("parse relation"),
             SessionLinkRelation::Fork
         );
+        assert_eq!(SessionLinkRelation::OwnedAgent.as_str(), "owned_agent");
+        assert_eq!(
+            SessionLinkRelation::parse("owned_agent").expect("parse relation"),
+            SessionLinkRelation::OwnedAgent
+        );
+    }
+
+    #[test]
+    fn only_subagent_and_owned_agent_confer_ownership() {
+        for relation in [
+            SessionLinkRelation::Subagent,
+            SessionLinkRelation::OwnedAgent,
+        ] {
+            assert!(relation.is_ownership(), "{relation} should confer ownership");
+        }
+        // A fork is a copy, not a subordinate; cowork and reviews are the
+        // superseded features. None makes the parent an owner, so none is
+        // closeable or promotable through the ownership tools.
+        for relation in [
+            SessionLinkRelation::Fork,
+            SessionLinkRelation::CoworkCodingSession,
+            SessionLinkRelation::ReviewAgent,
+        ] {
+            assert!(
+                !relation.is_ownership(),
+                "{relation} must not confer ownership"
+            );
+        }
+    }
+
+    #[test]
+    fn promotion_and_close_request_are_read_off_the_row() {
+        use super::{SessionLinkRecord, SessionLinkWorkspaceRelation as Ws};
+
+        let base = SessionLinkRecord {
+            id: "link-1".to_string(),
+            public_id: None,
+            relation: SessionLinkRelation::Subagent,
+            parent_session_id: "ses_parent".to_string(),
+            child_session_id: "ses_child".to_string(),
+            workspace_relation: Ws::SameWorkspace,
+            label: None,
+            created_by_turn_id: None,
+            created_by_tool_call_id: None,
+            created_at: "2026-08-08T00:00:00Z".to_string(),
+            closed_at: None,
+            promoted_at: None,
+            closed_by_session_id: None,
+            close_reason: None,
+        };
+
+        assert!(base.is_unpromoted_subagent());
+        assert!(!base.is_close_requested());
+
+        let promoted = SessionLinkRecord {
+            promoted_at: Some("2026-08-08T01:00:00Z".to_string()),
+            ..base.clone()
+        };
+        assert!(!promoted.is_unpromoted_subagent());
+
+        // An owned agent was never a subagent, so it is never a cascade child.
+        let owned = SessionLinkRecord {
+            relation: SessionLinkRelation::OwnedAgent,
+            ..base.clone()
+        };
+        assert!(!owned.is_unpromoted_subagent());
+
+        let requested = SessionLinkRecord {
+            closed_by_session_id: Some("ses_parent".to_string()),
+            ..base.clone()
+        };
+        assert!(requested.is_close_requested());
+
+        // Once the close lands the request is spent: the attribution stays for
+        // "Closed by X", the "still waiting on a turn" reading does not.
+        let closed = SessionLinkRecord {
+            closed_at: Some("2026-08-08T02:00:00Z".to_string()),
+            closed_by_session_id: Some("ses_parent".to_string()),
+            ..base
+        };
+        assert!(!closed.is_close_requested());
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/links/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/links/service.rs
@@ -239,6 +239,16 @@ impl SessionLinkService {
         self.store.find_subagent_parent(child_session_id)
     }
 
+    /// The occupied-slot count the fanout cap is defined by. One predicate,
+    /// shared by the spawn pre-check and the advertised limits.
+    pub fn count_open_unpromoted_subagent_children(
+        &self,
+        parent_session_id: &str,
+    ) -> anyhow::Result<usize> {
+        self.store
+            .count_open_unpromoted_subagent_children(parent_session_id)
+    }
+
     pub fn find_subagent_parents(
         &self,
         child_session_ids: &[String],
@@ -321,6 +331,10 @@ impl SessionLinkService {
         child_session_id: &str,
     ) -> anyhow::Result<Option<SessionLinkRecord>> {
         self.store.find_pending_close_request(child_session_id)
+    }
+
+    pub fn list_pending_close_requests(&self) -> anyhow::Result<Vec<SessionLinkRecord>> {
+        self.store.list_pending_close_requests()
     }
 
     pub fn delete_link(&self, id: &str) -> anyhow::Result<bool> {

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/links/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/links/service.rs
@@ -105,6 +105,9 @@ impl SessionLinkService {
             created_by_tool_call_id: input.created_by_tool_call_id,
             created_at: chrono::Utc::now().to_rfc3339(),
             closed_at: None,
+            promoted_at: None,
+            closed_by_session_id: None,
+            close_reason: None,
         };
         self.store.insert(&record).map_err(|error| {
             if is_unique_constraint_error(&error) {
@@ -176,6 +179,9 @@ impl SessionLinkService {
             created_by_tool_call_id: input.created_by_tool_call_id,
             created_at: chrono::Utc::now().to_rfc3339(),
             closed_at: None,
+            promoted_at: None,
+            closed_by_session_id: None,
+            close_reason: None,
         };
         let outcome = self
             .store
@@ -278,6 +284,43 @@ impl SessionLinkService {
 
     pub fn close_link(&self, id: &str, closed_at: &str) -> anyhow::Result<bool> {
         self.store.close_link(id, closed_at)
+    }
+
+    pub fn promote_link(&self, id: &str, promoted_at: &str) -> anyhow::Result<bool> {
+        self.store.promote_link(id, promoted_at)
+    }
+
+    pub fn record_close_attribution(
+        &self,
+        id: &str,
+        closed_by_session_id: &str,
+        close_reason: Option<&str>,
+    ) -> anyhow::Result<bool> {
+        self.store
+            .record_close_attribution(id, closed_by_session_id, close_reason)
+    }
+
+    pub fn find_owned_link_including_closed(
+        &self,
+        parent_session_id: &str,
+        child_session_id: &str,
+    ) -> anyhow::Result<Option<SessionLinkRecord>> {
+        self.store
+            .find_owned_link_including_closed(parent_session_id, child_session_id)
+    }
+
+    pub fn list_owned_children(
+        &self,
+        parent_session_id: &str,
+    ) -> anyhow::Result<Vec<SessionLinkRecord>> {
+        self.store.list_owned_children(parent_session_id)
+    }
+
+    pub fn find_pending_close_request(
+        &self,
+        child_session_id: &str,
+    ) -> anyhow::Result<Option<SessionLinkRecord>> {
+        self.store.find_pending_close_request(child_session_id)
     }
 
     pub fn delete_link(&self, id: &str) -> anyhow::Result<bool> {

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/links/store.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/links/store.rs
@@ -231,6 +231,14 @@ impl SessionLinkStore {
         })
     }
 
+    /// The one parent row of `child_session_id` for this relation.
+    ///
+    /// `UNIQUE(relation, parent, child)` permits two open rows naming the same
+    /// child from different parents, which `link_child` never creates today.
+    /// The order is still pinned rather than left to SQLite, because this row
+    /// decides `is_unpromoted_subagent` — and therefore whether the child may
+    /// spawn at all. Unpromoted rows sort first, so an ambiguous state fails
+    /// CLOSED (subordinate, no spawn tools) instead of by row order.
     pub fn find_parent_by_relation(
         &self,
         relation: SessionLinkRelation,
@@ -241,6 +249,7 @@ impl SessionLinkStore {
                 "SELECT * FROM session_links
                  WHERE relation = ?1 AND child_session_id = ?2
                    AND closed_at IS NULL
+                 ORDER BY (promoted_at IS NULL) DESC, created_at ASC, id ASC
                  LIMIT 1",
                 params![relation.as_str(), child_session_id],
                 map_session_link,
@@ -315,6 +324,34 @@ impl SessionLinkStore {
         self.list_children_by_relation(SessionLinkRelation::Subagent, parent_session_id)
     }
 
+    /// How many of the parent's eight delegation slots are occupied right now.
+    ///
+    /// This predicate is the fanout cap, so it is written ONCE and read by
+    /// everything that has an opinion about the cap: the spawn pre-check and
+    /// the numbers `get_subagent_launch_options` advertises. Its WHERE clause
+    /// is deliberately identical to the subselect in
+    /// [`Self::insert_subagent_with_child_limit`], which is the cap that
+    /// actually rejects an insert — an advertised count that disagreed with it
+    /// would tell an agent it is out of slots while `spawn_subagent` keeps
+    /// succeeding.
+    pub fn count_open_unpromoted_subagent_children(
+        &self,
+        parent_session_id: &str,
+    ) -> anyhow::Result<usize> {
+        self.db.with_conn(|conn| {
+            let count: i64 = conn.query_row(
+                "SELECT COUNT(*)
+                 FROM session_links
+                 WHERE relation = 'subagent' AND parent_session_id = ?1
+                   AND closed_at IS NULL
+                   AND promoted_at IS NULL",
+                [parent_session_id],
+                |row| row.get(0),
+            )?;
+            Ok(count.max(0) as usize)
+        })
+    }
+
     pub fn find_subagent_parent(
         &self,
         child_session_id: &str,
@@ -346,9 +383,14 @@ impl SessionLinkStore {
     ///
     /// On an open row this is the durable "end requested" record: the close was
     /// authorized and is now waiting for the target's in-flight turn to finish.
-    /// Guarded on `closed_at IS NULL` so a second close of an already-closed
-    /// agent cannot overwrite the original attribution — the first close is the
-    /// one that happened.
+    ///
+    /// Written once, and the FIRST requester is the one recorded. Both guards
+    /// are needed for that: `closed_at IS NULL` stops a second close of an
+    /// already-closed agent from rewriting history, and
+    /// `closed_by_session_id IS NULL` stops a second close during the
+    /// end-requested window — which is a whole turn wide — from doing the same.
+    /// Zero rows updated therefore means "already requested, or already
+    /// closed", which is exactly what the caller wants to report.
     pub fn record_close_attribution(
         &self,
         id: &str,
@@ -359,7 +401,7 @@ impl SessionLinkStore {
             let updated = conn.execute(
                 "UPDATE session_links
                  SET closed_by_session_id = ?1, close_reason = ?2
-                 WHERE id = ?3 AND closed_at IS NULL",
+                 WHERE id = ?3 AND closed_at IS NULL AND closed_by_session_id IS NULL",
                 params![closed_by_session_id, close_reason, id],
             )?;
             Ok(updated > 0)
@@ -428,6 +470,30 @@ impl SessionLinkStore {
                 map_session_link,
             )
             .optional()
+        })
+    }
+
+    /// Every close still owed, runtime-wide — the boot-time reconciliation read.
+    ///
+    /// A close request is durable precisely so a runtime that dies mid-turn
+    /// still owes it, but the turn-finish hook can only pay a debt whose turn
+    /// finishes. If the process died instead, nothing will ever finish that
+    /// turn and the agent would sit open forever, having been told to stop. The
+    /// startup pass sweeps these rows and settles them.
+    ///
+    /// Same predicate (and same partial index) as
+    /// [`Self::find_pending_close_request`], unfiltered by child.
+    pub fn list_pending_close_requests(&self) -> anyhow::Result<Vec<SessionLinkRecord>> {
+        self.db.with_conn(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT * FROM session_links
+                 WHERE closed_at IS NULL
+                   AND closed_by_session_id IS NOT NULL
+                   AND relation IN ('subagent', 'owned_agent')
+                 ORDER BY created_at ASC, id ASC",
+            )?;
+            let rows = stmt.query_map([], map_session_link)?;
+            rows.collect()
         })
     }
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/links/store.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/links/store.rs
@@ -27,8 +27,9 @@ impl SessionLinkStore {
                 "INSERT INTO session_links (
                     id, public_id, relation, parent_session_id, child_session_id,
                     workspace_relation, label, created_by_turn_id,
-                    created_by_tool_call_id, created_at, closed_at
-                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                    created_by_tool_call_id, created_at, closed_at,
+                    promoted_at, closed_by_session_id, close_reason
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
                 params![
                     record.id,
                     record.public_id,
@@ -41,6 +42,9 @@ impl SessionLinkStore {
                     record.created_by_tool_call_id,
                     record.created_at,
                     record.closed_at,
+                    record.promoted_at,
+                    record.closed_by_session_id,
+                    record.close_reason,
                 ],
             )?;
             Ok(())
@@ -54,18 +58,23 @@ impl SessionLinkStore {
     ) -> anyhow::Result<InsertSubagentLinkOutcome> {
         self.db.with_conn(|conn| {
             let inserted = conn.execute(
+                // The cap counts LINKED children only. A promoted child is a
+                // peer that keeps its ownership row, not one of the eight
+                // delegation slots its former parent may fill.
                 "INSERT INTO session_links (
                     id, public_id, relation, parent_session_id, child_session_id,
                     workspace_relation, label, created_by_turn_id,
-                    created_by_tool_call_id, created_at, closed_at
+                    created_by_tool_call_id, created_at, closed_at,
+                    promoted_at, closed_by_session_id, close_reason
                  )
-                 SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11
+                 SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14
                  WHERE (
                     SELECT COUNT(*)
                     FROM session_links
                     WHERE relation = 'subagent' AND parent_session_id = ?4
                       AND closed_at IS NULL
-                 ) < ?12",
+                      AND promoted_at IS NULL
+                 ) < ?15",
                 params![
                     record.id,
                     record.public_id,
@@ -78,6 +87,9 @@ impl SessionLinkStore {
                     record.created_by_tool_call_id,
                     record.created_at,
                     record.closed_at,
+                    record.promoted_at,
+                    record.closed_by_session_id,
+                    record.close_reason,
                     max_children as i64,
                 ],
             )?;
@@ -310,6 +322,115 @@ impl SessionLinkStore {
         self.find_parent_by_relation(SessionLinkRelation::Subagent, child_session_id)
     }
 
+    /// Promotion is one idempotent write. The guard, not a `COALESCE`, is what
+    /// makes it idempotent AND reportable: zero rows updated means "already
+    /// promoted, or closed", so the caller can say so instead of silently
+    /// re-dating the row.
+    ///
+    /// The relation stays `'subagent'`. The row is still the ownership fact
+    /// that lets the former parent close this agent individually; what changes
+    /// is that the cascade stops following it and the spawn tools unlock.
+    pub fn promote_link(&self, id: &str, promoted_at: &str) -> anyhow::Result<bool> {
+        self.db.with_conn(|conn| {
+            let updated = conn.execute(
+                "UPDATE session_links
+                 SET promoted_at = ?1
+                 WHERE id = ?2 AND promoted_at IS NULL AND closed_at IS NULL",
+                params![promoted_at, id],
+            )?;
+            Ok(updated > 0)
+        })
+    }
+
+    /// Stamp who asked for this close and why, WITHOUT closing the link.
+    ///
+    /// On an open row this is the durable "end requested" record: the close was
+    /// authorized and is now waiting for the target's in-flight turn to finish.
+    /// Guarded on `closed_at IS NULL` so a second close of an already-closed
+    /// agent cannot overwrite the original attribution — the first close is the
+    /// one that happened.
+    pub fn record_close_attribution(
+        &self,
+        id: &str,
+        closed_by_session_id: &str,
+        close_reason: Option<&str>,
+    ) -> anyhow::Result<bool> {
+        self.db.with_conn(|conn| {
+            let updated = conn.execute(
+                "UPDATE session_links
+                 SET closed_by_session_id = ?1, close_reason = ?2
+                 WHERE id = ?3 AND closed_at IS NULL",
+                params![closed_by_session_id, close_reason, id],
+            )?;
+            Ok(updated > 0)
+        })
+    }
+
+    /// The one link that makes `parent_session_id` the owner of
+    /// `child_session_id`, across BOTH ownership relations. Open rows win over
+    /// closed ones so a re-linked pair resolves to the live relationship.
+    pub fn find_owned_link_including_closed(
+        &self,
+        parent_session_id: &str,
+        child_session_id: &str,
+    ) -> anyhow::Result<Option<SessionLinkRecord>> {
+        self.db.with_conn(|conn| {
+            conn.query_row(
+                "SELECT * FROM session_links
+                 WHERE parent_session_id = ?1
+                   AND child_session_id = ?2
+                   AND relation IN ('subagent', 'owned_agent')
+                 ORDER BY (closed_at IS NULL) DESC, created_at DESC, id DESC
+                 LIMIT 1",
+                params![parent_session_id, child_session_id],
+                map_session_link,
+            )
+            .optional()
+        })
+    }
+
+    /// Every session `parent_session_id` owns, open rows only — the set
+    /// `close_agent` may target.
+    pub fn list_owned_children(
+        &self,
+        parent_session_id: &str,
+    ) -> anyhow::Result<Vec<SessionLinkRecord>> {
+        self.db.with_conn(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT * FROM session_links
+                 WHERE parent_session_id = ?1
+                   AND relation IN ('subagent', 'owned_agent')
+                   AND closed_at IS NULL
+                 ORDER BY created_at ASC, id ASC",
+            )?;
+            let rows = stmt.query_map([parent_session_id], map_session_link)?;
+            rows.collect()
+        })
+    }
+
+    /// The soft-close read, run once for every session that finishes a turn: is
+    /// there an open ownership link naming this session as end-requested?
+    /// Served by `idx_session_links_pending_close_request`.
+    pub fn find_pending_close_request(
+        &self,
+        child_session_id: &str,
+    ) -> anyhow::Result<Option<SessionLinkRecord>> {
+        self.db.with_conn(|conn| {
+            conn.query_row(
+                "SELECT * FROM session_links
+                 WHERE child_session_id = ?1
+                   AND closed_at IS NULL
+                   AND closed_by_session_id IS NOT NULL
+                   AND relation IN ('subagent', 'owned_agent')
+                 ORDER BY created_at ASC, id ASC
+                 LIMIT 1",
+                [child_session_id],
+                map_session_link,
+            )
+            .optional()
+        })
+    }
+
     /// One query for a whole page of children. `list_agents` renders a subagent
     /// by the label its parent gave it, and doing that per row is a query per
     /// row; the page size is bounded but the shape is not.
@@ -387,6 +508,9 @@ fn map_session_link(row: &rusqlite::Row) -> rusqlite::Result<SessionLinkRecord> 
         created_by_tool_call_id: row.get("created_by_tool_call_id")?,
         created_at: row.get("created_at")?,
         closed_at: row.get("closed_at")?,
+        promoted_at: row.get("promoted_at")?,
+        closed_by_session_id: row.get("closed_by_session_id")?,
+        close_reason: row.get("close_reason")?,
     })
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/live_ports.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/live_ports.rs
@@ -16,10 +16,20 @@ use crate::domains::sessions::model::{
 use crate::domains::sessions::prompt::{
     load_prompt_attachments, PromptPayload, PromptValidationError, ResolvedParts,
 };
+use crate::domains::sessions::links::store::SessionLinkStore;
 use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::model::{
-    AttachmentSource, BackgroundWorkDurable, EventPersist, QueueDurable, SessionStateDurable,
+    AttachmentSource, BackgroundWorkDurable, EventPersist, PendingCloseRequests, QueueDurable,
+    SessionStateDurable,
 };
+
+/// The soft-close fence the actor consults before starting a turn. One indexed
+/// point read against `idx_session_links_pending_close_request`.
+impl PendingCloseRequests for SessionLinkStore {
+    fn has_pending_close_request(&self, session_id: &str) -> anyhow::Result<bool> {
+        Ok(SessionLinkStore::find_pending_close_request(self, session_id)?.is_some())
+    }
+}
 
 impl EventPersist for SessionStore {
     fn append_event(&self, event: &SessionEventRecord) -> anyhow::Result<()> {

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/mod.rs
@@ -14,6 +14,7 @@ pub mod live_config;
 pub mod live_ports;
 pub mod mcp_bindings;
 pub mod model;
+pub mod ownership;
 pub mod plan_references;
 pub mod prompt;
 pub mod replay;

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/ownership/hooks.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/ownership/hooks.rs
@@ -1,0 +1,163 @@
+//! The turn-finish half of a soft close.
+//!
+//! `close_agent` on a WORKING agent does not interrupt it. It authorizes the
+//! close, stamps the ownership row, and returns "end requested"; the agent
+//! finishes the step it is on and this hook closes the tree at turn finish.
+//! That is what §4's confirm copy promises — "it will finish the current step,
+//! then stop" — and it is why the close request is durable: a runtime that
+//! restarts mid-turn still owes the close, and the next finished turn pays it.
+//!
+//! This runs for EVERY session that finishes a turn, like the wake hook next
+//! door, because any session can be the one somebody asked to stop. The lookup
+//! it costs is one indexed point read
+//! (`idx_session_links_pending_close_request`).
+
+use std::sync::{Arc, OnceLock, Weak};
+
+use super::service::AgentOwnershipService;
+use crate::domains::sessions::admission::{SessionMutationAdmission, SessionMutationKind};
+use crate::domains::sessions::agent_ops::peer_ops::{
+    admit_peer_mutation, lease_target_workspace_for_peer_write,
+};
+use crate::domains::sessions::extensions::{SessionExtension, SessionTurnFinishedContext};
+use crate::domains::sessions::runtime::SessionRuntime;
+use crate::domains::workspaces::access_gate::WorkspaceAccessGate;
+use crate::domains::workspaces::operation_gate::WorkspaceOperationGate;
+
+pub struct AgentCloseSessionHooks {
+    ownership: Arc<AgentOwnershipService>,
+    session_admission: Arc<SessionMutationAdmission>,
+    workspace_operation_gate: Arc<WorkspaceOperationGate>,
+    workspace_access_gate: Arc<WorkspaceAccessGate>,
+    /// Injected after `SessionRuntime::new`, which cannot be otherwise: the
+    /// runtime owns the extension list, so holding an `Arc` back to it would be
+    /// a reference cycle. Same two-phase shape the workflow wiring uses.
+    session_runtime: OnceLock<Weak<SessionRuntime>>,
+}
+
+impl AgentCloseSessionHooks {
+    pub fn new(
+        ownership: Arc<AgentOwnershipService>,
+        session_admission: Arc<SessionMutationAdmission>,
+        workspace_operation_gate: Arc<WorkspaceOperationGate>,
+        workspace_access_gate: Arc<WorkspaceAccessGate>,
+    ) -> Self {
+        Self {
+            ownership,
+            session_admission,
+            workspace_operation_gate,
+            workspace_access_gate,
+            session_runtime: OnceLock::new(),
+        }
+    }
+
+    /// Phase two of the wiring. Until this is called the hook is inert, which
+    /// is the correct behavior for the window before the runtime exists: no
+    /// turn can have finished yet.
+    pub fn attach_session_runtime(&self, session_runtime: &Arc<SessionRuntime>) {
+        let _ = self.session_runtime.set(Arc::downgrade(session_runtime));
+    }
+
+    fn session_runtime(&self) -> Option<Arc<SessionRuntime>> {
+        self.session_runtime.get().and_then(Weak::upgrade)
+    }
+}
+
+impl SessionExtension for AgentCloseSessionHooks {
+    fn on_turn_finished(&self, ctx: SessionTurnFinishedContext) {
+        let Some(session_runtime) = self.session_runtime() else {
+            return;
+        };
+        let ownership = self.ownership.clone();
+        let admission = self.session_admission.clone();
+        let operation_gate = self.workspace_operation_gate.clone();
+        let access_gate = self.workspace_access_gate.clone();
+        // Off the actor's turn-finish callback before anything is awaited: the
+        // close shuts this very actor down, and the gates below can block.
+        tokio::spawn(async move {
+            if let Err(error) = complete_requested_close(
+                ownership,
+                session_runtime,
+                admission,
+                operation_gate,
+                access_gate,
+                ctx,
+            )
+            .await
+            {
+                tracing::warn!(error = %error, "failed to complete a requested agent close");
+            }
+        });
+    }
+}
+
+async fn complete_requested_close(
+    ownership: Arc<AgentOwnershipService>,
+    session_runtime: Arc<SessionRuntime>,
+    admission: Arc<SessionMutationAdmission>,
+    operation_gate: Arc<WorkspaceOperationGate>,
+    access_gate: Arc<WorkspaceAccessGate>,
+    ctx: SessionTurnFinishedContext,
+) -> anyhow::Result<()> {
+    let Some(request) = ownership.pending_close_request(&ctx.session_id)? else {
+        return Ok(());
+    };
+
+    // The same fence and the same order the synchronous close took
+    // (PR1227-LOCK-01: session mutation permit, THEN the workspace lease). It
+    // is re-taken rather than carried because the requesting call returned long
+    // ago — and because control can be acquired in between: a workflow that
+    // took this session over after the request must not have it closed out from
+    // under it. A refusal leaves the request armed for the next finished turn.
+    let _permit = match admit_peer_mutation(&admission, &ctx.session_id, SessionMutationKind::Close)
+        .await
+    {
+        Ok(permit) => permit,
+        Err(error) => {
+            tracing::info!(
+                session_id = %ctx.session_id,
+                error = %error,
+                "deferred agent close is still blocked; leaving the request armed"
+            );
+            return Ok(());
+        }
+    };
+    let _lease = match lease_target_workspace_for_peer_write(
+        &operation_gate,
+        &access_gate,
+        &ctx.workspace.id,
+    )
+    .await
+    {
+        Ok(lease) => lease,
+        Err(error) => {
+            tracing::info!(
+                session_id = %ctx.session_id,
+                workspace_id = %ctx.workspace.id,
+                error = %error,
+                "deferred agent close cannot write to the workspace; leaving the request armed"
+            );
+            return Ok(());
+        }
+    };
+
+    tracing::info!(
+        session_id = %ctx.session_id,
+        session_link_id = %request.id,
+        closed_by_session_id = ?request.closed_by_session_id,
+        turn_id = %ctx.turn_id,
+        "closing an agent whose end was requested mid-turn"
+    );
+    session_runtime
+        .close_live_session(&ctx.session_id)
+        .await
+        .map_err(|error| anyhow::anyhow!("{error:?}"))?;
+    // The close cascade stamps the inbound ownership row, so the request is
+    // consumed by the same path a synchronous close uses. Belt and braces for
+    // the retryable case where the live close succeeded but the row did not.
+    let settled = ownership.reload_link(&request)?;
+    if settled.closed_at.is_none() {
+        ownership.close_link(&settled, &chrono::Utc::now().to_rfc3339())?;
+    }
+    Ok(())
+}

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/ownership/hooks.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/ownership/hooks.rs
@@ -61,6 +61,90 @@ impl AgentCloseSessionHooks {
     fn session_runtime(&self) -> Option<Arc<SessionRuntime>> {
         self.session_runtime.get().and_then(Weak::upgrade)
     }
+
+    /// Settle every close this runtime already owed when it started.
+    ///
+    /// The turn-finish hook can only pay a debt whose turn finishes. If the
+    /// runtime died mid-turn instead, nothing will ever finish that turn: the
+    /// agent was told it would stop after its current step, and would otherwise
+    /// sit there open forever, with the request still armed and nothing to fire
+    /// it. Worse, the only thing that COULD fire it is somebody prompting an
+    /// agent that has already been told to stop — which the turn-start fence
+    /// now (correctly) refuses.
+    ///
+    /// So the debt is settled here instead, at boot, through the ordinary close
+    /// path: same gates, same close tree, attribution untouched.
+    pub fn spawn_startup_pass(self: Arc<Self>) {
+        tokio::spawn(async move {
+            match self.reconcile_pending_closes().await {
+                Ok(0) => {}
+                Ok(settled) => tracing::info!(
+                    settled,
+                    "closed agents whose end was requested before this runtime started"
+                ),
+                Err(error) => {
+                    tracing::warn!(error = %error, "the requested-close startup pass failed")
+                }
+            }
+        });
+    }
+
+    /// The startup pass body. Returns how many closes it settled.
+    ///
+    /// A request whose target still has a LIVE handle is left alone: that agent
+    /// is running now, so its turn-finish hook owes the close and will pay it
+    /// without cutting a step short.
+    pub async fn reconcile_pending_closes(&self) -> anyhow::Result<usize> {
+        let Some(session_runtime) = self.session_runtime() else {
+            return Ok(0);
+        };
+        let mut settled = 0usize;
+        for request in self.ownership.pending_close_requests()? {
+            let Some(target) = self
+                .ownership
+                .session_store()
+                .find_by_id(&request.child_session_id)?
+            else {
+                continue;
+            };
+            if target.closed_at.is_some() || target.status == "closed" {
+                // The session went down but the row outlived it. Settle the row
+                // so the request stops being pending; nothing to shut down.
+                self.ownership
+                    .close_link(&request, &chrono::Utc::now().to_rfc3339())?;
+                settled += 1;
+                continue;
+            }
+            if session_runtime
+                .session_execution_summary(&target)
+                .await
+                .has_live_handle
+            {
+                continue;
+            }
+            match complete_close_request(
+                &self.ownership,
+                &session_runtime,
+                &self.session_admission,
+                &self.workspace_operation_gate,
+                &self.workspace_access_gate,
+                &target.id,
+                &target.workspace_id,
+                &request,
+            )
+            .await
+            {
+                Ok(true) => settled += 1,
+                Ok(false) => {}
+                Err(error) => tracing::warn!(
+                    session_id = %target.id,
+                    error = %error,
+                    "failed to settle a close owed from before this runtime started"
+                ),
+            }
+        }
+        Ok(settled)
+    }
 }
 
 impl SessionExtension for AgentCloseSessionHooks {
@@ -102,45 +186,6 @@ async fn complete_requested_close(
     let Some(request) = ownership.pending_close_request(&ctx.session_id)? else {
         return Ok(());
     };
-
-    // The same fence and the same order the synchronous close took
-    // (PR1227-LOCK-01: session mutation permit, THEN the workspace lease). It
-    // is re-taken rather than carried because the requesting call returned long
-    // ago — and because control can be acquired in between: a workflow that
-    // took this session over after the request must not have it closed out from
-    // under it. A refusal leaves the request armed for the next finished turn.
-    let _permit = match admit_peer_mutation(&admission, &ctx.session_id, SessionMutationKind::Close)
-        .await
-    {
-        Ok(permit) => permit,
-        Err(error) => {
-            tracing::info!(
-                session_id = %ctx.session_id,
-                error = %error,
-                "deferred agent close is still blocked; leaving the request armed"
-            );
-            return Ok(());
-        }
-    };
-    let _lease = match lease_target_workspace_for_peer_write(
-        &operation_gate,
-        &access_gate,
-        &ctx.workspace.id,
-    )
-    .await
-    {
-        Ok(lease) => lease,
-        Err(error) => {
-            tracing::info!(
-                session_id = %ctx.session_id,
-                workspace_id = %ctx.workspace.id,
-                error = %error,
-                "deferred agent close cannot write to the workspace; leaving the request armed"
-            );
-            return Ok(());
-        }
-    };
-
     tracing::info!(
         session_id = %ctx.session_id,
         session_link_id = %request.id,
@@ -148,16 +193,81 @@ async fn complete_requested_close(
         turn_id = %ctx.turn_id,
         "closing an agent whose end was requested mid-turn"
     );
+    complete_close_request(
+        &ownership,
+        &session_runtime,
+        &admission,
+        &operation_gate,
+        &access_gate,
+        &ctx.session_id,
+        &ctx.workspace.id,
+        &request,
+    )
+    .await?;
+    Ok(())
+}
+
+/// Shut the agent down and settle its ownership row. One body, two callers: the
+/// turn-finish hook above and the boot-time reconciliation pass, which owe the
+/// same close for the same reason and must therefore take the same gates and
+/// leave the same record.
+///
+/// `Ok(false)` means the gates refused and the request is still armed — never
+/// that the close is unnecessary.
+#[allow(clippy::too_many_arguments)]
+async fn complete_close_request(
+    ownership: &AgentOwnershipService,
+    session_runtime: &SessionRuntime,
+    admission: &SessionMutationAdmission,
+    operation_gate: &WorkspaceOperationGate,
+    access_gate: &WorkspaceAccessGate,
+    session_id: &str,
+    workspace_id: &str,
+    request: &crate::domains::sessions::links::model::SessionLinkRecord,
+) -> anyhow::Result<bool> {
+    // The same fence and the same order the synchronous close took
+    // (PR1227-LOCK-01: session mutation permit, THEN the workspace lease). It
+    // is re-taken rather than carried because the requesting call returned long
+    // ago — and because control can be acquired in between: a workflow that
+    // took this session over after the request must not have it closed out from
+    // under it. A refusal leaves the request armed for the next finished turn.
+    let _permit = match admit_peer_mutation(admission, session_id, SessionMutationKind::Close).await
+    {
+        Ok(permit) => permit,
+        Err(error) => {
+            tracing::info!(
+                session_id = %session_id,
+                error = %error,
+                "deferred agent close is still blocked; leaving the request armed"
+            );
+            return Ok(false);
+        }
+    };
+    let _lease =
+        match lease_target_workspace_for_peer_write(operation_gate, access_gate, workspace_id).await
+        {
+            Ok(lease) => lease,
+            Err(error) => {
+                tracing::info!(
+                    session_id = %session_id,
+                    workspace_id = %workspace_id,
+                    error = %error,
+                    "deferred agent close cannot write to the workspace; leaving the request armed"
+                );
+                return Ok(false);
+            }
+        };
+
     session_runtime
-        .close_live_session(&ctx.session_id)
+        .close_live_session(session_id)
         .await
         .map_err(|error| anyhow::anyhow!("{error:?}"))?;
     // The close cascade stamps the inbound ownership row, so the request is
     // consumed by the same path a synchronous close uses. Belt and braces for
     // the retryable case where the live close succeeded but the row did not.
-    let settled = ownership.reload_link(&request)?;
+    let settled = ownership.reload_link(request)?;
     if settled.closed_at.is_none() {
         ownership.close_link(&settled, &chrono::Utc::now().to_rfc3339())?;
     }
-    Ok(())
+    Ok(true)
 }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/ownership/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/ownership/mod.rs
@@ -1,0 +1,21 @@
+//! Ownership, promotion and close attribution over `session_links`.
+//!
+//! One row is one ownership fact, so there is no registry and no second table:
+//! the three states an agent can be in are read off the columns the ownership
+//! migration added.
+//!
+//! | state | row |
+//! | --- | --- |
+//! | linked subagent | `relation = 'subagent'`, `promoted_at IS NULL` |
+//! | promoted | `relation = 'subagent'`, `promoted_at IS NOT NULL` |
+//! | owned agent | `relation = 'owned_agent'` |
+//!
+//! Ownership is deliberately NOT part of
+//! [`crate::domains::sessions::authorize`]. That funnel answers reachability —
+//! runtime-wide, unowned, "may this agent be messaged or read" — and every peer
+//! tool clears it. Close and promote ACT ON a session rather than putting an
+//! item in its inbox, so they resolve an ownership ROW first, the same way
+//! `send_subagent_message` resolves a link before it touches a child.
+
+pub mod hooks;
+pub mod service;

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/ownership/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/ownership/service.rs
@@ -1,0 +1,650 @@
+//! Resolving ownership, promoting a subagent, and recording a close.
+//!
+//! Everything here is a decision plus at most one durable write. Actually
+//! stopping an agent is the runtime's job (`close_session_tree`); this module
+//! decides WHETHER the caller may, and leaves the row that says who did it.
+
+use crate::domains::sessions::links::model::{SessionLinkRecord, SessionLinkRelation};
+use crate::domains::sessions::links::service::SessionLinkService;
+use crate::domains::sessions::model::SessionRecord;
+use crate::domains::sessions::store::SessionStore;
+
+#[derive(Debug, thiserror::Error)]
+pub enum OwnershipError {
+    #[error("caller session not found: {0}")]
+    OwnerNotFound(String),
+    #[error("target session not found: {0}")]
+    TargetNotFound(String),
+    #[error("a target is required: pass sessionId")]
+    TargetRequired,
+    #[error("subagentId and sessionId refer to different agents")]
+    ConflictingTarget,
+    #[error(
+        "you do not own that agent. You can close and promote the subagents you spawned and the \
+         agents you own; use list_subagents to see them"
+    )]
+    NotOwned,
+    #[error("an agent cannot own itself")]
+    SelfTarget,
+    #[error("that agent is already a top-level agent, not one of your subagents")]
+    NotASubagent,
+    #[error("that agent is closed")]
+    Closed,
+    #[error(transparent)]
+    Internal(#[from] anyhow::Error),
+}
+
+/// An ownership row plus the session it points at, resolved together so callers
+/// never re-read one without the other.
+#[derive(Debug, Clone)]
+pub struct OwnedAgent {
+    pub link: SessionLinkRecord,
+    pub target: SessionRecord,
+}
+
+impl OwnedAgent {
+    /// The handle an agent uses for this target in the subagent tool class.
+    pub fn subagent_id(&self) -> Option<&str> {
+        self.link.public_id.as_deref()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PromotionOutcome {
+    pub link: SessionLinkRecord,
+    pub promoted_at: String,
+    /// `false` when this call did the promoting; `true` when the agent was
+    /// already a peer. Promotion is idempotent — ADR §3.2 makes it one write.
+    pub already_promoted: bool,
+}
+
+#[derive(Clone)]
+pub struct AgentOwnershipService {
+    link_service: SessionLinkService,
+    session_store: SessionStore,
+}
+
+impl AgentOwnershipService {
+    pub fn new(link_service: SessionLinkService, session_store: SessionStore) -> Self {
+        Self {
+            link_service,
+            session_store,
+        }
+    }
+
+    pub fn session_store(&self) -> &SessionStore {
+        &self.session_store
+    }
+
+    /// Resolve a target the caller OWNS, by either handle.
+    ///
+    /// Closed rows resolve too: closing an already-closed agent is idempotent,
+    /// and the close attribution has to stay readable on a closed row.
+    pub fn resolve_owned(
+        &self,
+        owner_session_id: &str,
+        subagent_id: Option<&str>,
+        session_id: Option<&str>,
+    ) -> Result<OwnedAgent, OwnershipError> {
+        let subagent_id = subagent_id.map(str::trim).filter(|value| !value.is_empty());
+        let session_id = session_id.map(str::trim).filter(|value| !value.is_empty());
+        if subagent_id.is_none() && session_id.is_none() {
+            return Err(OwnershipError::TargetRequired);
+        }
+        if session_id == Some(owner_session_id) {
+            return Err(OwnershipError::SelfTarget);
+        }
+
+        let link = match subagent_id {
+            // The public id is already scoped to one row, so ownership is one
+            // equality check on the row it names.
+            Some(public_id) => self
+                .link_service
+                .find_by_public_id(public_id)?
+                .filter(|link| {
+                    link.relation.is_ownership() && link.parent_session_id == owner_session_id
+                })
+                .ok_or(OwnershipError::NotOwned)?,
+            None => {
+                let target_id = session_id.expect("checked above");
+                self.link_service
+                    .find_owned_link_including_closed(owner_session_id, target_id)?
+                    .ok_or(OwnershipError::NotOwned)?
+            }
+        };
+
+        // Both handles supplied: they must name the same agent, or the caller
+        // is confused about which one it is acting on.
+        if let Some(target_id) = session_id {
+            if link.child_session_id != target_id {
+                return Err(OwnershipError::ConflictingTarget);
+            }
+        }
+
+        let target = self
+            .session_store
+            .find_by_id(&link.child_session_id)?
+            .ok_or_else(|| OwnershipError::TargetNotFound(link.child_session_id.clone()))?;
+        Ok(OwnedAgent { link, target })
+    }
+
+    /// Promote one of the caller's linked subagents to a peer.
+    ///
+    /// The row keeps `relation = 'subagent'` and gains `promoted_at` — ADR §3.2
+    /// spells the promoted state as exactly that, and it is what keeps the
+    /// former parent an owner who may still close it individually. What the
+    /// stamp changes: the close cascade stops following the row, the fanout cap
+    /// stops counting it, and the spawn tools unlock for the child.
+    pub fn promote(&self, owned: &OwnedAgent) -> Result<PromotionOutcome, OwnershipError> {
+        if owned.link.relation != SessionLinkRelation::Subagent {
+            // An `owned_agent` row was never linked, so there is nothing to
+            // promote. Saying so beats a silent success that implies a change.
+            return Err(OwnershipError::NotASubagent);
+        }
+        if owned.link.closed_at.is_some() || is_closed(&owned.target) {
+            return Err(OwnershipError::Closed);
+        }
+        if let Some(promoted_at) = owned.link.promoted_at.clone() {
+            return Ok(PromotionOutcome {
+                link: owned.link.clone(),
+                promoted_at,
+                already_promoted: true,
+            });
+        }
+
+        let promoted_at = chrono::Utc::now().to_rfc3339();
+        let promoted = self
+            .link_service
+            .promote_link(&owned.link.id, &promoted_at)?;
+        // Lost the race with a concurrent promote: re-read rather than report a
+        // timestamp this call did not write.
+        let link = self
+            .link_service
+            .find_owned_link_including_closed(
+                &owned.link.parent_session_id,
+                &owned.link.child_session_id,
+            )?
+            .unwrap_or_else(|| owned.link.clone());
+        Ok(PromotionOutcome {
+            promoted_at: link
+                .promoted_at
+                .clone()
+                .unwrap_or_else(|| promoted_at.clone()),
+            already_promoted: !promoted,
+            link,
+        })
+    }
+
+    /// Record who is closing this agent and why, before the runtime stops it.
+    ///
+    /// On an OPEN row the stamp doubles as the durable close request: if the
+    /// target turns out to be mid-turn, this row is what the turn-finish hook
+    /// finds and completes. Attribution is written once — a second close of an
+    /// already-closed agent leaves the first close's record alone.
+    pub fn record_close_attribution(
+        &self,
+        owned: &OwnedAgent,
+        closed_by_session_id: &str,
+        close_reason: Option<&str>,
+    ) -> Result<bool, OwnershipError> {
+        Ok(self.link_service.record_close_attribution(
+            &owned.link.id,
+            closed_by_session_id,
+            close_reason,
+        )?)
+    }
+
+    /// Mark the ownership row closed. Runs AFTER the live session is down, so a
+    /// failed live close leaves the link open and the close retryable.
+    pub fn close_link(
+        &self,
+        link: &SessionLinkRecord,
+        closed_at: &str,
+    ) -> Result<bool, OwnershipError> {
+        Ok(self.link_service.close_link(&link.id, closed_at)?)
+    }
+
+    /// Re-read one ownership row by id, for reporting the settled state.
+    pub fn reload_link(
+        &self,
+        link: &SessionLinkRecord,
+    ) -> Result<SessionLinkRecord, OwnershipError> {
+        Ok(self
+            .link_service
+            .find_owned_link_including_closed(&link.parent_session_id, &link.child_session_id)?
+            .unwrap_or_else(|| link.clone()))
+    }
+
+    /// The soft-close question, asked of every session that finishes a turn:
+    /// did somebody ask for this agent to stop once it was done?
+    pub fn pending_close_request(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<SessionLinkRecord>, OwnershipError> {
+        Ok(self.link_service.find_pending_close_request(session_id)?)
+    }
+
+    /// Whether `session_id` is an UNPROMOTED subagent child — ruling 3's
+    /// predicate, and the only caller barred from the spawn tools.
+    pub fn is_unpromoted_subagent(&self, session_id: &str) -> Result<bool, OwnershipError> {
+        Ok(self
+            .link_service
+            .find_subagent_parent(session_id)?
+            .is_some_and(|link| link.is_unpromoted_subagent()))
+    }
+}
+
+fn is_closed(session: &SessionRecord) -> bool {
+    session.closed_at.is_some() || session.status == "closed"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::test_support;
+    use crate::domains::sessions::links::model::SessionLinkWorkspaceRelation;
+    use crate::domains::sessions::links::service::CreateSessionLinkInput;
+    use crate::domains::sessions::links::store::SessionLinkStore;
+    use crate::domains::sessions::model::{SessionMcpBindingPolicy, SessionRecord};
+    use crate::persistence::Db;
+
+    fn session_record(id: &str) -> SessionRecord {
+        SessionRecord {
+            id: id.to_string(),
+            workspace_id: "workspace-1".to_string(),
+            agent_kind: "claude".to_string(),
+            native_session_id: None,
+            agent_auth_contexts: None,
+            requested_model_id: None,
+            current_model_id: None,
+            requested_mode_id: None,
+            current_mode_id: None,
+            title: Some(format!("Agent {id}")),
+            thinking_level_id: None,
+            thinking_budget_tokens: None,
+            status: "idle".to_string(),
+            created_at: "2026-08-08T00:00:00Z".to_string(),
+            updated_at: "2026-08-08T00:00:00Z".to_string(),
+            last_prompt_at: None,
+            closed_at: None,
+            dismissed_at: None,
+            mcp_bindings_ciphertext: None,
+            mcp_binding_summaries_json: None,
+            mcp_binding_policy: SessionMcpBindingPolicy::InheritWorkspace,
+            system_prompt_append: None,
+            subagents_enabled: true,
+            action_capabilities_json: None,
+            origin: None,
+        }
+    }
+
+    struct Fixture {
+        ownership: AgentOwnershipService,
+        links: SessionLinkService,
+        store: SessionStore,
+    }
+
+    fn fixture(session_ids: &[&str]) -> Fixture {
+        let db = Db::open_in_memory().expect("open db");
+        test_support::seed_workspace_with_repo_root(&db, "workspace-1", "local", "/tmp/workspace-1");
+        let store = SessionStore::new(db.clone());
+        for id in session_ids {
+            store.insert(&session_record(id)).expect("insert session");
+        }
+        let links = SessionLinkService::new(SessionLinkStore::new(db.clone()), store.clone());
+        Fixture {
+            ownership: AgentOwnershipService::new(links.clone(), store.clone()),
+            links,
+            store,
+        }
+    }
+
+    fn link(fixture: &Fixture, relation: SessionLinkRelation, parent: &str, child: &str) -> String {
+        fixture
+            .links
+            .create_link(CreateSessionLinkInput {
+                relation,
+                parent_session_id: parent.to_string(),
+                child_session_id: child.to_string(),
+                workspace_relation: SessionLinkWorkspaceRelation::SameWorkspace,
+                label: Some("Schema audit".to_string()),
+                created_by_turn_id: None,
+                created_by_tool_call_id: None,
+            })
+            .expect("create link")
+            .id
+    }
+
+    #[test]
+    fn an_owner_resolves_its_child_by_session_id_and_by_subagent_id() {
+        let fixture = fixture(&["ses_parent", "ses_child"]);
+        let link_id = link(
+            &fixture,
+            SessionLinkRelation::Subagent,
+            "ses_parent",
+            "ses_child",
+        );
+        let public_id = fixture
+            .links
+            .find_owned_link_including_closed("ses_parent", "ses_child")
+            .expect("find link")
+            .expect("link exists")
+            .public_id
+            .expect("public id");
+
+        let by_session = fixture
+            .ownership
+            .resolve_owned("ses_parent", None, Some("ses_child"))
+            .expect("resolve by session id");
+        assert_eq!(by_session.link.id, link_id);
+        assert_eq!(by_session.target.id, "ses_child");
+
+        let by_public = fixture
+            .ownership
+            .resolve_owned("ses_parent", Some(&public_id), None)
+            .expect("resolve by subagent id");
+        assert_eq!(by_public.link.id, link_id);
+    }
+
+    #[test]
+    fn a_stranger_owns_nothing_even_though_it_may_message_the_same_agent() {
+        // The whole reason ownership is not `authorize`: reach is runtime-wide,
+        // ownership is not. `ses_other` can message `ses_child` all day.
+        let fixture = fixture(&["ses_parent", "ses_child", "ses_other"]);
+        link(
+            &fixture,
+            SessionLinkRelation::Subagent,
+            "ses_parent",
+            "ses_child",
+        );
+
+        let error = fixture
+            .ownership
+            .resolve_owned("ses_other", None, Some("ses_child"))
+            .err()
+            .expect("a stranger does not own it");
+        assert!(matches!(error, OwnershipError::NotOwned));
+    }
+
+    #[test]
+    fn a_child_cannot_turn_the_link_around_and_own_its_parent() {
+        let fixture = fixture(&["ses_parent", "ses_child"]);
+        link(
+            &fixture,
+            SessionLinkRelation::Subagent,
+            "ses_parent",
+            "ses_child",
+        );
+
+        let error = fixture
+            .ownership
+            .resolve_owned("ses_child", None, Some("ses_parent"))
+            .err()
+            .expect("ownership points one way");
+        assert!(matches!(error, OwnershipError::NotOwned));
+    }
+
+    #[test]
+    fn a_fork_relation_is_not_ownership() {
+        // A fork's parent is not its owner: forks are copies, and closing the
+        // original must not be able to reach through this row.
+        let fixture = fixture(&["ses_parent", "ses_fork"]);
+        link(
+            &fixture,
+            SessionLinkRelation::Fork,
+            "ses_parent",
+            "ses_fork",
+        );
+
+        let error = fixture
+            .ownership
+            .resolve_owned("ses_parent", None, Some("ses_fork"))
+            .err()
+            .expect("a fork is not owned");
+        assert!(matches!(error, OwnershipError::NotOwned));
+    }
+
+    #[test]
+    fn an_owned_agent_row_resolves_the_same_way_a_subagent_does() {
+        let fixture = fixture(&["ses_parent", "ses_owned"]);
+        link(
+            &fixture,
+            SessionLinkRelation::OwnedAgent,
+            "ses_parent",
+            "ses_owned",
+        );
+
+        let owned = fixture
+            .ownership
+            .resolve_owned("ses_parent", None, Some("ses_owned"))
+            .expect("an owned agent is owned");
+        assert_eq!(owned.link.relation, SessionLinkRelation::OwnedAgent);
+        // ... but it is already top level, so there is nothing to promote.
+        let error = fixture
+            .ownership
+            .promote(&owned)
+            .err()
+            .expect("an owned agent cannot be promoted");
+        assert!(matches!(error, OwnershipError::NotASubagent));
+    }
+
+    #[test]
+    fn promotion_stamps_the_row_keeps_the_relation_and_is_idempotent() {
+        let fixture = fixture(&["ses_parent", "ses_child"]);
+        link(
+            &fixture,
+            SessionLinkRelation::Subagent,
+            "ses_parent",
+            "ses_child",
+        );
+        let owned = fixture
+            .ownership
+            .resolve_owned("ses_parent", None, Some("ses_child"))
+            .expect("resolve");
+
+        let first = fixture.ownership.promote(&owned).expect("promote");
+        assert!(!first.already_promoted);
+        // The relation is untouched: the parent still owns this agent, which is
+        // what lets it close it individually later.
+        assert_eq!(first.link.relation, SessionLinkRelation::Subagent);
+        assert_eq!(first.link.promoted_at.as_deref(), Some(&*first.promoted_at));
+        assert!(!first.link.is_unpromoted_subagent());
+
+        let reloaded = fixture
+            .ownership
+            .resolve_owned("ses_parent", None, Some("ses_child"))
+            .expect("resolve again");
+        let second = fixture.ownership.promote(&reloaded).expect("promote again");
+        assert!(second.already_promoted);
+        assert_eq!(second.promoted_at, first.promoted_at);
+    }
+
+    #[test]
+    fn promotion_lifts_the_spawn_block_for_that_child_only() {
+        let fixture = fixture(&["ses_parent", "ses_child", "ses_sibling"]);
+        link(
+            &fixture,
+            SessionLinkRelation::Subagent,
+            "ses_parent",
+            "ses_child",
+        );
+        link(
+            &fixture,
+            SessionLinkRelation::Subagent,
+            "ses_parent",
+            "ses_sibling",
+        );
+
+        assert!(fixture
+            .ownership
+            .is_unpromoted_subagent("ses_child")
+            .expect("check child"));
+        // A top-level session was never blocked.
+        assert!(!fixture
+            .ownership
+            .is_unpromoted_subagent("ses_parent")
+            .expect("check parent"));
+
+        let owned = fixture
+            .ownership
+            .resolve_owned("ses_parent", None, Some("ses_child"))
+            .expect("resolve");
+        fixture.ownership.promote(&owned).expect("promote");
+
+        assert!(!fixture
+            .ownership
+            .is_unpromoted_subagent("ses_child")
+            .expect("check promoted child"));
+        // Negative control: the sibling is untouched by its peer's promotion.
+        assert!(fixture
+            .ownership
+            .is_unpromoted_subagent("ses_sibling")
+            .expect("check sibling"));
+    }
+
+    #[test]
+    fn a_closed_agent_cannot_be_promoted() {
+        let fixture = fixture(&["ses_parent", "ses_child"]);
+        link(
+            &fixture,
+            SessionLinkRelation::Subagent,
+            "ses_parent",
+            "ses_child",
+        );
+        fixture
+            .store
+            .mark_closed("ses_child", "2026-08-08T01:00:00Z")
+            .expect("close the child session");
+
+        let owned = fixture
+            .ownership
+            .resolve_owned("ses_parent", None, Some("ses_child"))
+            .expect("a closed agent still resolves");
+        let error = fixture
+            .ownership
+            .promote(&owned)
+            .err()
+            .expect("a closed agent cannot be promoted");
+        assert!(matches!(error, OwnershipError::Closed));
+    }
+
+    #[test]
+    fn close_attribution_is_written_once_and_reads_as_end_requested_while_open() {
+        let fixture = fixture(&["ses_parent", "ses_child"]);
+        link(
+            &fixture,
+            SessionLinkRelation::Subagent,
+            "ses_parent",
+            "ses_child",
+        );
+        let owned = fixture
+            .ownership
+            .resolve_owned("ses_parent", None, Some("ses_child"))
+            .expect("resolve");
+
+        assert!(fixture
+            .ownership
+            .record_close_attribution(&owned, "ses_parent", Some("superseded by the schema audit"))
+            .expect("stamp attribution"));
+
+        // While the link is open the stamp IS the close request the turn-finish
+        // hook completes.
+        let pending = fixture
+            .ownership
+            .pending_close_request("ses_child")
+            .expect("pending lookup")
+            .expect("a close was requested");
+        assert!(pending.is_close_requested());
+        assert_eq!(pending.closed_by_session_id.as_deref(), Some("ses_parent"));
+        assert_eq!(
+            pending.close_reason.as_deref(),
+            Some("superseded by the schema audit")
+        );
+
+        // Once closed, the request is spent and a second close cannot rewrite
+        // who closed it.
+        fixture
+            .ownership
+            .close_link(&pending, "2026-08-08T02:00:00Z")
+            .expect("close the link");
+        assert!(fixture
+            .ownership
+            .pending_close_request("ses_child")
+            .expect("pending lookup")
+            .is_none());
+
+        let reloaded = fixture.ownership.reload_link(&pending).expect("reload");
+        assert!(!fixture
+            .ownership
+            .record_close_attribution(&owned, "ses_other", Some("second close"))
+            .expect("second attribution attempt"));
+        let after = fixture.ownership.reload_link(&reloaded).expect("reload");
+        assert_eq!(after.closed_by_session_id.as_deref(), Some("ses_parent"));
+        assert_eq!(
+            after.close_reason.as_deref(),
+            Some("superseded by the schema audit")
+        );
+    }
+
+    #[test]
+    fn a_human_close_leaves_no_attribution_so_nothing_reads_as_requested() {
+        let fixture = fixture(&["ses_parent", "ses_child"]);
+        link(
+            &fixture,
+            SessionLinkRelation::Subagent,
+            "ses_parent",
+            "ses_child",
+        );
+
+        // No attribution stamped: the link is open and un-requested, which is
+        // exactly the state a human close goes through.
+        assert!(fixture
+            .ownership
+            .pending_close_request("ses_child")
+            .expect("pending lookup")
+            .is_none());
+    }
+
+    #[test]
+    fn a_target_is_required_and_the_two_handles_must_agree() {
+        let fixture = fixture(&["ses_parent", "ses_child", "ses_other"]);
+        link(
+            &fixture,
+            SessionLinkRelation::Subagent,
+            "ses_parent",
+            "ses_child",
+        );
+        let public_id = fixture
+            .links
+            .find_owned_link_including_closed("ses_parent", "ses_child")
+            .expect("find")
+            .expect("exists")
+            .public_id
+            .expect("public id");
+
+        assert!(matches!(
+            fixture
+                .ownership
+                .resolve_owned("ses_parent", None, None)
+                .err()
+                .expect("no target"),
+            OwnershipError::TargetRequired
+        ));
+        assert!(matches!(
+            fixture
+                .ownership
+                .resolve_owned("ses_parent", Some(&public_id), Some("ses_other"))
+                .err()
+                .expect("handles disagree"),
+            OwnershipError::ConflictingTarget
+        ));
+        assert!(matches!(
+            fixture
+                .ownership
+                .resolve_owned("ses_parent", None, Some("ses_parent"))
+                .err()
+                .expect("self target"),
+            OwnershipError::SelfTarget
+        ));
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/ownership/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/ownership/service.rs
@@ -224,6 +224,13 @@ impl AgentOwnershipService {
         Ok(self.link_service.find_pending_close_request(session_id)?)
     }
 
+    /// Every close still owed, runtime-wide. Read once at boot: a request whose
+    /// turn never finished (the runtime died mid-turn) has nothing left to fire
+    /// it, so the startup pass settles it instead.
+    pub fn pending_close_requests(&self) -> Result<Vec<SessionLinkRecord>, OwnershipError> {
+        Ok(self.link_service.list_pending_close_requests()?)
+    }
+
     /// Whether `session_id` is an UNPROMOTED subagent child — ruling 3's
     /// predicate, and the only caller barred from the spawn tools.
     pub fn is_unpromoted_subagent(&self, session_id: &str) -> Result<bool, OwnershipError> {
@@ -583,6 +590,155 @@ mod tests {
         assert_eq!(
             after.close_reason.as_deref(),
             Some("superseded by the schema audit")
+        );
+    }
+
+    #[test]
+    fn the_first_requester_owns_the_attribution_for_the_whole_end_requested_window() {
+        // The window between "close requested" and "closed" is a whole turn
+        // wide, and the docstring promises attribution is written once. Without
+        // the `closed_by_session_id IS NULL` guard a second close inside that
+        // window silently rewrites who asked and why, and §4's
+        // "Closed by X · reason" then credits the wrong agent.
+        let fixture = fixture(&["ses_parent", "ses_child", "ses_other"]);
+        link(
+            &fixture,
+            SessionLinkRelation::Subagent,
+            "ses_parent",
+            "ses_child",
+        );
+        let owned = fixture
+            .ownership
+            .resolve_owned("ses_parent", None, Some("ses_child"))
+            .expect("resolve");
+
+        assert!(fixture
+            .ownership
+            .record_close_attribution(&owned, "ses_parent", Some("superseded"))
+            .expect("first requester stamps"));
+        // Still open, still requested — and a second close lands in that window.
+        assert!(!fixture
+            .ownership
+            .record_close_attribution(&owned, "ses_other", Some("me too"))
+            .expect("second requester is a no-op"));
+
+        let pending = fixture
+            .ownership
+            .pending_close_request("ses_child")
+            .expect("pending lookup")
+            .expect("still requested");
+        assert_eq!(pending.closed_by_session_id.as_deref(), Some("ses_parent"));
+        assert_eq!(pending.close_reason.as_deref(), Some("superseded"));
+    }
+
+    #[test]
+    fn a_close_owed_from_a_dead_runtime_is_still_findable_at_boot() {
+        // The turn-finish hook can only pay a debt whose turn finishes. If the
+        // process died mid-turn the request stays armed with nothing to fire
+        // it, so the startup pass reads it back — runtime-wide, not per child.
+        let fixture = fixture(&["ses_parent", "ses_child", "ses_other", "ses_quiet"]);
+        link(
+            &fixture,
+            SessionLinkRelation::Subagent,
+            "ses_parent",
+            "ses_child",
+        );
+        link(
+            &fixture,
+            SessionLinkRelation::OwnedAgent,
+            "ses_parent",
+            "ses_other",
+        );
+        // Un-requested: an ordinary open child is not swept.
+        link(
+            &fixture,
+            SessionLinkRelation::Subagent,
+            "ses_parent",
+            "ses_quiet",
+        );
+
+        for child in ["ses_child", "ses_other"] {
+            let owned = fixture
+                .ownership
+                .resolve_owned("ses_parent", None, Some(child))
+                .expect("resolve");
+            fixture
+                .ownership
+                .record_close_attribution(&owned, "ses_parent", None)
+                .expect("stamp");
+        }
+
+        let owed = fixture
+            .ownership
+            .pending_close_requests()
+            .expect("sweep the pending requests");
+        let mut children = owed
+            .iter()
+            .map(|link| link.child_session_id.as_str())
+            .collect::<Vec<_>>();
+        children.sort_unstable();
+        assert_eq!(children, vec!["ses_child", "ses_other"]);
+
+        // Settling one takes it out of the sweep; the other is still owed.
+        fixture
+            .ownership
+            .close_link(&owed[0], "2026-08-08T02:00:00Z")
+            .expect("settle one");
+        assert_eq!(
+            fixture
+                .ownership
+                .pending_close_requests()
+                .expect("sweep again")
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn a_promoted_child_frees_the_slot_the_advertised_limits_report() {
+        // The advertised `existingSubagentCount`/`remainingSubagents` and the
+        // spawn pre-check read this count, and the store's insert subselect IS
+        // the cap. All three must agree, or the tool tells an agent it is out
+        // of slots while `spawn_subagent` keeps succeeding.
+        let fixture = fixture(&["ses_parent", "ses_a", "ses_b", "ses_c"]);
+        for child in ["ses_a", "ses_b", "ses_c"] {
+            link(
+                &fixture,
+                SessionLinkRelation::Subagent,
+                "ses_parent",
+                child,
+            );
+        }
+        assert_eq!(
+            fixture
+                .links
+                .count_open_unpromoted_subagent_children("ses_parent")
+                .expect("count slots"),
+            3
+        );
+
+        let owned = fixture
+            .ownership
+            .resolve_owned("ses_parent", None, Some("ses_b"))
+            .expect("resolve");
+        fixture.ownership.promote(&owned).expect("promote");
+
+        assert_eq!(
+            fixture
+                .links
+                .count_open_unpromoted_subagent_children("ses_parent")
+                .expect("count slots after promotion"),
+            2,
+            "a promoted child keeps its ownership row but frees its slot"
+        );
+        // The row is still there — it is only the CAP that stopped counting it.
+        assert_eq!(
+            fixture
+                .links
+                .list_subagent_children("ses_parent")
+                .expect("list children")
+                .len(),
+            3
         );
     }
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork.rs
@@ -147,6 +147,9 @@ impl SessionRuntime {
             created_by_tool_call_id: None,
             created_at: now,
             closed_at: None,
+            promoted_at: None,
+            closed_by_session_id: None,
+            close_reason: None,
         };
         let insert_result = if child_actor_forks {
             self.session_service

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/lifecycle.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/lifecycle.rs
@@ -4,7 +4,7 @@ use std::pin::Pin;
 use std::time::Instant;
 
 use crate::domains::sessions::extensions::SessionClosingContext;
-use crate::domains::sessions::links::model::SessionLinkRelation;
+use crate::domains::sessions::links::model::{SessionLinkRecord, SessionLinkRelation};
 use crate::domains::sessions::model::SessionRecord;
 use crate::domains::sessions::runtime_event::{
     RuntimeEventInjectionResult, RuntimeInjectedSessionEvent,
@@ -138,12 +138,7 @@ impl SessionRuntime {
             .map_err(SessionLifecycleError::Internal)?;
         let mut closed_child_session_ids = std::collections::HashSet::new();
         for link in links {
-            if !matches!(
-                link.relation,
-                SessionLinkRelation::Subagent
-                    | SessionLinkRelation::CoworkCodingSession
-                    | SessionLinkRelation::ReviewAgent
-            ) {
+            if !cascades_to_child(&link) {
                 continue;
             }
             self.close_session_tree(&link.child_session_id, visited)
@@ -189,9 +184,14 @@ impl SessionRuntime {
             .map_err(SessionLifecycleError::Internal)?;
         let now = chrono::Utc::now().to_rfc3339();
         for link in links {
+            // Inbound, not outbound: this session is the CHILD, and it is gone.
+            // Every relationship that pointed at it ends with it, promoted or
+            // not — unlike the outbound cascade, which is about what this
+            // session takes down with it.
             if !matches!(
                 link.relation,
                 SessionLinkRelation::Subagent
+                    | SessionLinkRelation::OwnedAgent
                     | SessionLinkRelation::CoworkCodingSession
                     | SessionLinkRelation::ReviewAgent
             ) {
@@ -331,6 +331,23 @@ impl SessionRuntime {
             Some(ConditionalCancelOutcome::NotActive) => LiveTurnCancelOutcome::NotActive,
             None => LiveTurnCancelOutcome::ActorUnavailable,
         }
+    }
+}
+
+/// Whether closing the PARENT takes this child down with it.
+///
+/// The close cascade is the one place the promotion flag changes lifecycle, and
+/// it is the whole point of promotion: a promoted subagent keeps its row, its
+/// transcript and its owner — it simply stops dying when the owner dies. Ruling
+/// 7 keeps the row precisely so the former parent can still close it
+/// deliberately; only the automatic cascade is severed.
+pub(super) fn cascades_to_child(link: &SessionLinkRecord) -> bool {
+    match link.relation {
+        SessionLinkRelation::Subagent => link.promoted_at.is_none(),
+        SessionLinkRelation::CoworkCodingSession | SessionLinkRelation::ReviewAgent => true,
+        // An owned agent is a peer by construction — it was never subordinate,
+        // so there is no cascade to sever. A fork is a copy, not a dependent.
+        SessionLinkRelation::OwnedAgent | SessionLinkRelation::Fork => false,
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/tests.rs
@@ -104,6 +104,9 @@ fn link_record(
         created_by_tool_call_id: None,
         created_at: "2026-03-25T00:00:00Z".to_string(),
         closed_at: None,
+        promoted_at: None,
+        closed_by_session_id: None,
+        close_reason: None,
     }
 }
 
@@ -1017,3 +1020,51 @@ exit 0
     let _ = std::fs::remove_dir_all(&empty_home);
 }
 
+
+// --- close cascade (ADR §3.3, ruling 7) ---------------------------------
+//
+// `cascades_to_child` is the whole of the "a promoted child is not collateral"
+// rule, so it is tested directly rather than through a live runtime: these
+// assertions fail the moment the promotion check is dropped from the cascade.
+
+#[test]
+fn an_unpromoted_subagent_still_goes_down_with_its_parent() {
+    let link = link_record("link-1", SessionLinkRelation::Subagent, "parent", "child");
+
+    assert!(super::lifecycle::cascades_to_child(&link));
+}
+
+#[test]
+fn a_promoted_subagent_survives_its_former_parents_close() {
+    let mut link = link_record("link-1", SessionLinkRelation::Subagent, "parent", "child");
+    link.promoted_at = Some("2026-03-25T01:00:00Z".to_string());
+
+    assert!(
+        !super::lifecycle::cascades_to_child(&link),
+        "promotion severs the cascade; the row stays so the owner can still close it deliberately"
+    );
+}
+
+#[test]
+fn an_owned_agent_and_a_fork_are_never_cascade_collateral() {
+    let owned = link_record("link-1", SessionLinkRelation::OwnedAgent, "owner", "agent");
+    let fork = link_record("link-2", SessionLinkRelation::Fork, "origin", "copy");
+
+    assert!(!super::lifecycle::cascades_to_child(&owned));
+    assert!(!super::lifecycle::cascades_to_child(&fork));
+}
+
+#[test]
+fn delegated_coding_and_review_children_are_unaffected_by_promotion() {
+    for relation in [
+        SessionLinkRelation::CoworkCodingSession,
+        SessionLinkRelation::ReviewAgent,
+    ] {
+        let mut link = link_record("link-1", relation, "parent", "child");
+        assert!(super::lifecycle::cascades_to_child(&link));
+        // Nothing else in the product stamps `promoted_at` on these rows, but
+        // the cascade must not become promotion-sensitive if something ever does.
+        link.promoted_at = Some("2026-03-25T01:00:00Z".to_string());
+        assert!(super::lifecycle::cascades_to_child(&link));
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/store/tests/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/store/tests/mod.rs
@@ -64,6 +64,9 @@ fn fork_link_record(
         created_by_tool_call_id: None,
         created_at: "2026-03-25T00:00:00Z".to_string(),
         closed_at: None,
+        promoted_at: None,
+        closed_by_session_id: None,
+        close_reason: None,
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/store/tests/sessions.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/store/tests/sessions.rs
@@ -287,6 +287,9 @@ fn subagent_link_record(
         created_by_tool_call_id: None,
         created_at: "2026-03-25T00:00:00Z".to_string(),
         closed_at: None,
+        promoted_at: None,
+        closed_by_session_id: None,
+        close_reason: None,
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/model.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/model.rs
@@ -17,6 +17,13 @@ pub struct SubagentSummary {
     pub mode_id: Option<String>,
     pub created_at: String,
     pub closed_at: Option<String>,
+    /// Set once this child was promoted to a peer: it keeps the row and the
+    /// owner, and stops being subordinate. `None` is an ordinary subagent.
+    pub promoted_at: Option<String>,
+    /// Who closed it and why, when somebody did. Both are `None` on an agent
+    /// closed by a person through the UI — the columns record an AGENT's close.
+    pub closed_by_session_id: Option<String>,
+    pub close_reason: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/service.rs
@@ -108,17 +108,25 @@ impl SubagentService {
         if workspace.surface != WorkspaceSurface::Standard {
             return Err(SubagentError::IneligibleWorkspace);
         }
-        if !parent.subagents_enabled {
-            return Err(SubagentError::Disabled);
-        }
         // Depth is capped at one level of subordination, and promotion is
         // exactly what lifts it (ADR §3.3): a promoted agent is a peer, so it
         // may spawn its own children even though its ownership row survives.
-        if self
-            .link_service
-            .find_subagent_parent(parent_session_id)?
-            .is_some_and(|link| link.is_unpromoted_subagent())
-        {
+        let ownership = self.link_service.find_subagent_parent(parent_session_id)?;
+        let is_promoted_child = ownership
+            .as_ref()
+            .is_some_and(|link| link.promoted_at.is_some());
+        // `spawn_subagent` creates every child with `subagents_enabled = false`;
+        // that flag is how a spawned child carries its subordination, and it is
+        // the only server-side consumer of the flag (agent ops mounts on every
+        // session, and this validation is recomputed per call). So promotion has
+        // to lift it too, or the depth lift below is dead code for every real
+        // child and ruling 7 never takes effect. Derived from `promoted_at`
+        // rather than rewriting the session row, so promotion stays ONE durable
+        // fact on the link instead of two rows in two tables that can diverge.
+        if !parent.subagents_enabled && !is_promoted_child {
+            return Err(SubagentError::Disabled);
+        }
+        if ownership.is_some_and(|link| link.is_unpromoted_subagent()) {
             return Err(SubagentError::DepthLimit);
         }
         if self
@@ -129,17 +137,11 @@ impl SubagentService {
             return Err(SubagentError::DepthLimit);
         }
         // Promoted children no longer occupy one of the parent's slots — the
-        // cap bounds concurrent subordinates, not lifetime descendants. This
-        // must agree with the store's own subselect in
+        // cap bounds concurrent subordinates, not lifetime descendants. One
+        // predicate serves the pre-check here, the advertised limits in the
+        // agent-ops context, and the store's own subselect in
         // `create_subagent_link_with_child_limit`, which is the real cap.
-        if self
-            .link_service
-            .list_subagent_children(parent_session_id)?
-            .iter()
-            .filter(|link| link.promoted_at.is_none())
-            .count()
-            >= MAX_SUBAGENTS_PER_PARENT
-        {
+        if self.count_occupied_subagent_slots(parent_session_id)? >= MAX_SUBAGENTS_PER_PARENT {
             return Err(SubagentError::FanoutLimit);
         }
         self.access_gate
@@ -364,6 +366,26 @@ impl SubagentService {
         child_session_id: &str,
     ) -> anyhow::Result<Option<SessionLinkRecord>> {
         self.link_service.find_subagent_parent(child_session_id)
+    }
+
+    /// How many of this parent's eight subagent slots are taken right now.
+    ///
+    /// Promoted children are excluded, because they no longer occupy a slot —
+    /// and because the store's insert subselect excludes them, so any other
+    /// count would advertise a cap that `spawn_subagent` does not enforce.
+    pub fn count_occupied_subagent_slots(
+        &self,
+        parent_session_id: &str,
+    ) -> anyhow::Result<usize> {
+        self.link_service
+            .count_open_unpromoted_subagent_children(parent_session_id)
+    }
+
+    /// The link service this subagent service already holds. The peer tools
+    /// need it for ownership-row reads (an end-requested target takes no new
+    /// messages) that have nothing to do with the caller's own link tree.
+    pub fn link_service(&self) -> &SessionLinkService {
+        &self.link_service
     }
 
     /// Batched form of [`Self::find_subagent_parent`] for a page of sessions.
@@ -600,4 +622,180 @@ impl SubagentService {
 
 fn map_access_error(error: WorkspaceAccessError) -> SubagentError {
     SubagentError::MutationBlocked(error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::test_support;
+    use crate::domains::repo_roots::service::RepoRootService;
+    use crate::domains::repo_roots::store::RepoRootStore;
+    use crate::domains::sessions::links::store::SessionLinkStore;
+    use crate::domains::sessions::model::SessionMcpBindingPolicy;
+    use crate::domains::terminals::store::TerminalStore;
+    use crate::live::terminals::TerminalService;
+    use crate::domains::workspaces::deletion::WorkspaceDeleteWorkflow;
+    use crate::domains::workspaces::store::{WorkspaceAccessStore, WorkspaceStore};
+    use crate::persistence::Db;
+    use std::sync::Arc;
+
+    /// `spawn_subagent` creates every child with `subagents_enabled = false`;
+    /// a human-created session carries the user's preference.
+    fn session_record(id: &str, subagents_enabled: bool) -> SessionRecord {
+        SessionRecord {
+            id: id.to_string(),
+            workspace_id: "workspace-1".to_string(),
+            agent_kind: "claude".to_string(),
+            native_session_id: None,
+            agent_auth_contexts: None,
+            requested_model_id: None,
+            current_model_id: None,
+            requested_mode_id: None,
+            current_mode_id: None,
+            title: Some(format!("Agent {id}")),
+            thinking_level_id: None,
+            thinking_budget_tokens: None,
+            status: "idle".to_string(),
+            created_at: "2026-08-08T00:00:00Z".to_string(),
+            updated_at: "2026-08-08T00:00:00Z".to_string(),
+            last_prompt_at: None,
+            closed_at: None,
+            dismissed_at: None,
+            mcp_bindings_ciphertext: None,
+            mcp_binding_summaries_json: None,
+            mcp_binding_policy: SessionMcpBindingPolicy::InheritWorkspace,
+            system_prompt_append: None,
+            subagents_enabled,
+            action_capabilities_json: None,
+            origin: None,
+        }
+    }
+
+    fn fixture() -> (SubagentService, SessionLinkService) {
+        let db = Db::open_in_memory().expect("open db");
+        test_support::seed_workspace_with_repo_root(
+            &db,
+            "workspace-1",
+            "local",
+            "/tmp/workspace-1",
+        );
+        let runtime_home = std::env::temp_dir().join(format!(
+            "anyharness-subagents-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let session_store = SessionStore::new(db.clone());
+        let link_service =
+            SessionLinkService::new(SessionLinkStore::new(db.clone()), session_store.clone());
+        let workspace_runtime = Arc::new(WorkspaceRuntime::new(
+            WorkspaceStore::new(db.clone()),
+            WorkspaceDeleteWorkflow::new(db.clone(), SessionDeleteWorkflow::new(db.clone())),
+            RepoRootService::new(RepoRootStore::new(db.clone())),
+            runtime_home.clone(),
+        ));
+        let access_gate = Arc::new(WorkspaceAccessGate::new(
+            WorkspaceStore::new(db.clone()),
+            session_store.clone(),
+            WorkspaceAccessStore::new(db.clone()),
+            Arc::new(TerminalService::new(
+                TerminalStore::new(db.clone()),
+                runtime_home,
+            )),
+        ));
+        let service = SubagentService::new(
+            session_store,
+            SessionDeleteWorkflow::new(db.clone()),
+            link_service.clone(),
+            SubagentStore::new(db),
+            workspace_runtime,
+            access_gate,
+        );
+        (service, link_service)
+    }
+
+    fn link_child(links: &SessionLinkService, parent: &str, child: &str) -> String {
+        links
+            .create_link(CreateSessionLinkInput {
+                relation: SessionLinkRelation::Subagent,
+                parent_session_id: parent.to_string(),
+                child_session_id: child.to_string(),
+                workspace_relation: SessionLinkWorkspaceRelation::SameWorkspace,
+                label: Some("Schema audit".to_string()),
+                created_by_turn_id: None,
+                created_by_tool_call_id: None,
+            })
+            .expect("create link")
+            .id
+    }
+
+    /// Ruling 7 / ADR §3.3: promotion makes a child a peer, and a peer spawns.
+    /// The depth lift alone does not deliver that — a spawned child is born with
+    /// `subagents_enabled = false`, which refuses first — so promotion has to
+    /// lift the born-with block as well or it lifts nothing that exists.
+    #[test]
+    fn promotion_lets_a_spawned_child_spawn_its_own_agents() {
+        let (service, links) = fixture();
+        let store = service.session_store();
+        store
+            .insert(&session_record("ses_parent", true))
+            .expect("insert parent");
+        // Exactly how `spawn_subagent` creates a child.
+        store
+            .insert(&session_record("ses_child", false))
+            .expect("insert child");
+        store
+            .insert(&session_record("ses_sibling", false))
+            .expect("insert sibling");
+        let child_link = link_child(&links, "ses_parent", "ses_child");
+        link_child(&links, "ses_parent", "ses_sibling");
+
+        // Before promotion the child is subordinate and cannot spawn.
+        assert!(matches!(
+            service.validate_parent_can_spawn("ses_child"),
+            Err(SubagentError::Disabled)
+        ));
+
+        assert!(links
+            .promote_link(&child_link, "2026-08-08T01:00:00Z")
+            .expect("promote the child"));
+
+        service
+            .validate_parent_can_spawn("ses_child")
+            .expect("a promoted agent is a peer and may spawn its own children");
+
+        // Negative control: promotion lifted the block for the promoted row
+        // only. The sibling, still owned, is still refused — so the assertion
+        // above is the promotion and not a blanket removal of the check.
+        assert!(matches!(
+            service.validate_parent_can_spawn("ses_sibling"),
+            Err(SubagentError::Disabled)
+        ));
+    }
+
+    /// The lift is scoped to promoted children: a session whose owner never
+    /// promoted it, and an ordinary session whose user turned subagents off,
+    /// both keep the refusal.
+    #[test]
+    fn a_session_with_subagents_switched_off_is_still_refused() {
+        let (service, _links) = fixture();
+        service
+            .session_store()
+            .insert(&session_record("ses_solo_off", false))
+            .expect("insert session");
+        service
+            .session_store()
+            .insert(&session_record("ses_solo_on", true))
+            .expect("insert session");
+
+        assert!(matches!(
+            service.validate_parent_can_spawn("ses_solo_off"),
+            Err(SubagentError::Disabled)
+        ));
+
+        // Non-vacuity: an otherwise identical session with the preference on
+        // passes every gate in this validation, so `Disabled` above is the flag
+        // and not some other refusal in the fixture.
+        service
+            .validate_parent_can_spawn("ses_solo_on")
+            .expect("an ordinary session with subagents enabled may spawn");
+    }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/service.rs
@@ -111,10 +111,13 @@ impl SubagentService {
         if !parent.subagents_enabled {
             return Err(SubagentError::Disabled);
         }
+        // Depth is capped at one level of subordination, and promotion is
+        // exactly what lifts it (ADR §3.3): a promoted agent is a peer, so it
+        // may spawn its own children even though its ownership row survives.
         if self
             .link_service
             .find_subagent_parent(parent_session_id)?
-            .is_some()
+            .is_some_and(|link| link.is_unpromoted_subagent())
         {
             return Err(SubagentError::DepthLimit);
         }
@@ -125,10 +128,16 @@ impl SubagentService {
         {
             return Err(SubagentError::DepthLimit);
         }
+        // Promoted children no longer occupy one of the parent's slots — the
+        // cap bounds concurrent subordinates, not lifetime descendants. This
+        // must agree with the store's own subselect in
+        // `create_subagent_link_with_child_limit`, which is the real cap.
         if self
             .link_service
             .list_subagent_children(parent_session_id)?
-            .len()
+            .iter()
+            .filter(|link| link.promoted_at.is_none())
+            .count()
             >= MAX_SUBAGENTS_PER_PARENT
         {
             return Err(SubagentError::FanoutLimit);
@@ -276,6 +285,9 @@ impl SubagentService {
                 mode_id: child.current_mode_id.or(child.requested_mode_id),
                 created_at: child.created_at,
                 closed_at: link.closed_at,
+                promoted_at: link.promoted_at,
+                closed_by_session_id: link.closed_by_session_id,
+                close_reason: link.close_reason,
             });
         }
         Ok(summaries)

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/run.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/run.rs
@@ -80,7 +80,14 @@ impl SessionActor {
             // mutation already accepted into the actor mailbox wins this
             // boundary, so startup and turn completion cannot capture and run
             // an obsolete head before reorder/steer is applied.
-            let queued_prompt = self.next_pending_prompt_for_drain();
+            //
+            // And it does not happen at all once a close has been requested for
+            // this agent: the soft close promises the in-flight step finishes
+            // and then the agent stops, so turn N+1 must never start into the
+            // window where the turn-finish hook is closing the tree.
+            let queued_prompt = self
+                .next_pending_prompt_for_drain()
+                .filter(|_| !self.new_turns_are_blocked_by_a_pending_close());
             let has_queued_prompt = queued_prompt.is_some();
             match select_idle_work(
                 command_rx,
@@ -159,7 +166,15 @@ impl SessionActor {
                 // The durable row may already have been selected by the idle
                 // drain, so never execute its copied payload directly here or
                 // a fast completed turn could be duplicated.
-                if from_queue_seq.is_some() || self.next_pending_prompt_for_drain().is_some() {
+                //
+                // The same soft-close fence as the drain above: a prompt that
+                // arrives after a close was requested is stored durably and
+                // acknowledged as queued, but it does not start a turn. This is
+                // the other turn-start site, so it needs the same check.
+                if from_queue_seq.is_some()
+                    || self.new_turns_are_blocked_by_a_pending_close()
+                    || self.next_pending_prompt_for_drain().is_some()
+                {
                     let result = self
                         .handle_busy_prompt_queue(payload, prompt_id, from_queue_seq)
                         .await;

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/mod.rs
@@ -57,6 +57,7 @@ mod prompt;
 mod queue;
 mod requested_mode;
 mod shutdown;
+mod soft_close;
 
 async fn actor_exit_test_context(
     pending_interaction: Option<PendingInteractionSummary>,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/soft_close.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/soft_close.rs
@@ -1,0 +1,505 @@
+//! Deterministic proof that a requested close fences turn STARTS.
+//!
+//! A soft close stamps the ownership row and lets the in-flight step finish;
+//! the turn-finish hook then closes the tree from a spawned task. Nothing in
+//! that story stops the actor's idle loop from picking the next durable prompt
+//! off its queue the instant turn N ends — and the close, landing milliseconds
+//! later, would then kill turn N+1 mid-step. That is exactly the interruption
+//! the soft close promises never happens (`specs/anyharness/sessions.md`).
+//!
+//! These tests drive the REAL actor idle loop (`SessionActor::run`) against an
+//! in-process fake ACP agent over `tokio::io::duplex`, with real `session_links`
+//! and `session_pending_prompts` rows behind it. Same construction technique,
+//! and the same justification, as `conditional_cancel.rs`: the actor struct is
+//! built directly rather than through the spawn/startup handshake, which is the
+//! narrowest honest entry into the loop under test.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use agent_client_protocol as acp;
+use anyharness_contract::v1::{
+    SessionActionCapabilities, SessionEventEnvelope, SessionExecutionPhase,
+};
+use tokio::sync::{broadcast, mpsc, oneshot, Mutex};
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+use crate::app::test_support::{actor_capabilities_for_store, seed_workspace_with_repo_root};
+use crate::domains::sessions::links::model::{SessionLinkRelation, SessionLinkWorkspaceRelation};
+use crate::domains::sessions::links::service::{CreateSessionLinkInput, SessionLinkService};
+use crate::domains::sessions::links::store::SessionLinkStore;
+use crate::domains::sessions::model::SessionRecord;
+use crate::domains::sessions::prompt::PromptPayload;
+use crate::domains::sessions::store::SessionStore;
+use crate::live::sessions::actor::command::SessionCommand;
+use crate::live::sessions::actor::config::types::PersistedSessionConfigState;
+use crate::live::sessions::actor::notifications::replay_filter::ResumeReplayFilter;
+use crate::live::sessions::actor::state::{SessionActor, SessionStartupState};
+use crate::live::sessions::background_work::{
+    BackgroundWorkOptions, BackgroundWorkRegistry, BackgroundWorkUpdate,
+};
+use crate::live::sessions::driver::inbound::InboundDoor;
+use crate::live::sessions::handle::LiveSessionHandle;
+use crate::live::sessions::model::{SessionHooks, SystemPromptAppends};
+use crate::live::sessions::rendezvous::broker::InteractionRendezvous;
+use crate::live::sessions::sink::SessionEventSink;
+use crate::persistence::Db;
+
+type DuplexRead = tokio::io::ReadHalf<tokio::io::DuplexStream>;
+type DuplexWrite = tokio::io::WriteHalf<tokio::io::DuplexStream>;
+
+const SESSION_ID: &str = "session-1";
+const PARENT_SESSION_ID: &str = "session-parent";
+const WORKSPACE_ID: &str = "workspace-1";
+const NATIVE_SESSION_ID: &str = "native-1";
+
+struct Harness {
+    actor: SessionActor,
+    command_tx: mpsc::Sender<SessionCommand>,
+    command_rx: mpsc::Receiver<SessionCommand>,
+    notification_rx: mpsc::UnboundedReceiver<acp::schema::SessionNotification>,
+    background_work_rx: mpsc::UnboundedReceiver<BackgroundWorkUpdate>,
+    /// Every `session/prompt` the fake agent received, responder held open so
+    /// the test decides when a turn ends.
+    prompt_responder_rx: mpsc::UnboundedReceiver<acp::Responder<acp::schema::PromptResponse>>,
+    store: SessionStore,
+    links: SessionLinkService,
+    link_id: String,
+    _handle: Arc<LiveSessionHandle>,
+}
+
+fn session_record(id: &str) -> SessionRecord {
+    SessionRecord {
+        id: id.to_string(),
+        workspace_id: WORKSPACE_ID.to_string(),
+        agent_kind: "claude".to_string(),
+        native_session_id: Some(NATIVE_SESSION_ID.to_string()),
+        agent_auth_contexts: None,
+        requested_model_id: None,
+        current_model_id: None,
+        requested_mode_id: None,
+        current_mode_id: None,
+        title: None,
+        thinking_level_id: None,
+        thinking_budget_tokens: None,
+        status: "idle".to_string(),
+        created_at: "2026-03-25T00:00:00Z".to_string(),
+        updated_at: "2026-03-25T00:00:00Z".to_string(),
+        last_prompt_at: None,
+        closed_at: None,
+        dismissed_at: None,
+        mcp_bindings_ciphertext: None,
+        mcp_binding_summaries_json: None,
+        mcp_binding_policy:
+            crate::domains::sessions::model::SessionMcpBindingPolicy::InheritWorkspace,
+        system_prompt_append: None,
+        subagents_enabled: true,
+        action_capabilities_json: None,
+        origin: None,
+    }
+}
+
+/// A real `SessionActor` wired to a fake ACP agent, with the soft-close fence
+/// reading the same in-memory database the test writes ownership rows to.
+async fn spawn_harness() -> Harness {
+    let db = Db::open_in_memory().expect("open db");
+    seed_workspace_with_repo_root(&db, WORKSPACE_ID, "local", "/tmp/workspace");
+    let store = SessionStore::new(db.clone());
+    let session = session_record(SESSION_ID);
+    store.insert(&session).expect("insert session");
+    store
+        .insert(&session_record(PARENT_SESSION_ID))
+        .expect("insert parent session");
+
+    let links = SessionLinkService::new(SessionLinkStore::new(db.clone()), store.clone());
+    let link_id = links
+        .create_link(CreateSessionLinkInput {
+            relation: SessionLinkRelation::Subagent,
+            parent_session_id: PARENT_SESSION_ID.to_string(),
+            child_session_id: SESSION_ID.to_string(),
+            workspace_relation: SessionLinkWorkspaceRelation::SameWorkspace,
+            label: Some("Schema audit".to_string()),
+            created_by_turn_id: None,
+            created_by_tool_call_id: None,
+        })
+        .expect("link the agent to its owner")
+        .id;
+
+    let mut caps = actor_capabilities_for_store(&store);
+    // Production wiring (`app/sessions.rs`): the fence reads the link store.
+    caps.close_requests = Some(Arc::new(SessionLinkStore::new(db)));
+
+    let (command_tx, command_rx) = mpsc::channel::<SessionCommand>(32);
+    let (event_tx, _event_rx) = broadcast::channel::<SessionEventEnvelope>(64);
+    let handle = Arc::new(LiveSessionHandle::new(
+        SESSION_ID,
+        command_tx.clone(),
+        event_tx.clone(),
+        Some(NATIVE_SESSION_ID.to_string()),
+        SessionExecutionPhase::Idle,
+    ));
+
+    let event_sink = Arc::new(Mutex::new(SessionEventSink::new(
+        SESSION_ID.to_string(),
+        "claude".to_string(),
+        PathBuf::from("/tmp/workspace"),
+        event_tx.clone(),
+        caps.events.clone(),
+    )));
+
+    let (background_tx, background_work_rx) = mpsc::unbounded_channel::<BackgroundWorkUpdate>();
+    let background_work_registry = BackgroundWorkRegistry::new(
+        SESSION_ID.to_string(),
+        "claude".to_string(),
+        caps.background.clone(),
+        background_tx,
+        BackgroundWorkOptions::default(),
+    );
+
+    let interaction_broker = Arc::new(InteractionRendezvous::new());
+    let (notification_tx, notification_rx) =
+        mpsc::unbounded_channel::<acp::schema::SessionNotification>();
+
+    let (client_io, agent_io) = tokio::io::duplex(64 * 1024);
+    let (client_read, client_write) = tokio::io::split(client_io);
+    let (agent_read, agent_write) = tokio::io::split(agent_io);
+
+    let inbound = Arc::new(InboundDoor::new(
+        SESSION_ID.to_string(),
+        notification_tx,
+        interaction_broker.clone(),
+        event_sink.clone(),
+        handle.clone(),
+        WORKSPACE_ID.to_string(),
+        "claude".to_string(),
+        None,
+    ));
+    let (conn, acp_shutdown) = establish_test_client(inbound, client_write, client_read).await;
+
+    let (prompt_responder_tx, prompt_responder_rx) =
+        mpsc::unbounded_channel::<acp::Responder<acp::schema::PromptResponse>>();
+    spawn_fake_agent(agent_write, agent_read, prompt_responder_tx);
+
+    let child = tokio::process::Command::new("sleep")
+        .arg("300")
+        .kill_on_drop(true)
+        .spawn()
+        .expect("spawn dummy child process");
+
+    let actor = SessionActor {
+        session_id: SESSION_ID.to_string(),
+        workspace_id: WORKSPACE_ID.to_string(),
+        agent_kind: "claude".to_string(),
+        workspace_path: PathBuf::from("/tmp/workspace"),
+        mcp_servers: Vec::new(),
+        prompts: SystemPromptAppends::default(),
+        event_sink,
+        background_work_registry,
+        resume_replay_filter: ResumeReplayFilter::disabled(),
+        persisted_config_state: PersistedSessionConfigState::from_session(&session),
+        startup_state: SessionStartupState {
+            current_mode_id: None,
+            legacy_mode_state: None,
+            config_options: Vec::new(),
+            current_model_id: None,
+            available_models: Vec::new(),
+            prompt_capabilities: Default::default(),
+        },
+        native_session_id: NATIVE_SESSION_ID.to_string(),
+        action_capabilities: SessionActionCapabilities::default(),
+        supports_native_close: false,
+        conn,
+        caps,
+        hooks: SessionHooks::default(),
+        interaction_broker,
+        handle: handle.clone(),
+        _acp_shutdown: acp_shutdown,
+        child,
+    };
+
+    Harness {
+        actor,
+        command_tx,
+        command_rx,
+        notification_rx,
+        background_work_rx,
+        prompt_responder_rx,
+        store,
+        links,
+        link_id,
+        _handle: handle,
+    }
+}
+
+/// Client (actor-side) ACP connection over the duplex halves, registering the
+/// same inbound handlers as `driver/connection.rs::establish_connection`.
+async fn establish_test_client(
+    client: Arc<InboundDoor>,
+    write: DuplexWrite,
+    read: DuplexRead,
+) -> (acp::ConnectionTo<acp::Agent>, oneshot::Sender<()>) {
+    let (cx_tx, cx_rx) = oneshot::channel::<acp::ConnectionTo<acp::Agent>>();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let transport = acp::ByteStreams::new(write.compat_write(), read.compat());
+
+    let client_for_notif = client.clone();
+    let client_for_perm = client.clone();
+    let client_for_elicitation = client.clone();
+
+    let connect_future = acp::Client
+        .builder()
+        .on_receive_notification(
+            async move |notif: acp::schema::SessionNotification, _cx| {
+                client_for_notif.handle_session_notification(notif).await
+            },
+            acp::on_receive_notification!(),
+        )
+        .on_receive_request(
+            async move |req: acp::schema::RequestPermissionRequest,
+                        responder: acp::Responder<acp::schema::RequestPermissionResponse>,
+                        _cx| {
+                let result = client_for_perm.handle_request_permission(req).await;
+                responder.respond_with_result(result)
+            },
+            acp::on_receive_request!(),
+        )
+        .on_receive_request(
+            async move |req: acp::schema::CreateElicitationRequest,
+                        responder: acp::Responder<acp::schema::CreateElicitationResponse>,
+                        _cx| {
+                let result = client_for_elicitation.standard_mcp_elicitation(req).await;
+                responder.respond_with_result(result)
+            },
+            acp::on_receive_request!(),
+        )
+        .connect_with(
+            transport,
+            move |cx: acp::ConnectionTo<acp::Agent>| async move {
+                let _ = cx_tx.send(cx);
+                let _ = shutdown_rx.await;
+                Ok(())
+            },
+        );
+
+    tokio::task::spawn_local(async move {
+        let _ = connect_future.await;
+    });
+
+    let conn = cx_rx.await.expect("client ACP connection established");
+    (conn, shutdown_tx)
+}
+
+/// A minimal fake agent: it defers every `session/prompt`, handing the responder
+/// to the test, so a turn stays in flight until the test ends it.
+fn spawn_fake_agent(
+    write: DuplexWrite,
+    read: DuplexRead,
+    prompt_responder_tx: mpsc::UnboundedSender<acp::Responder<acp::schema::PromptResponse>>,
+) {
+    let transport = acp::ByteStreams::new(write.compat_write(), read.compat());
+    let connect_future = acp::Agent
+        .builder()
+        .name("soft-close-fake-agent")
+        .on_receive_request(
+            async move |_req: acp::schema::PromptRequest,
+                        responder: acp::Responder<acp::schema::PromptResponse>,
+                        _cx| {
+                let _ = prompt_responder_tx.send(responder);
+                Ok(())
+            },
+            acp::on_receive_request!(),
+        )
+        .on_receive_notification(
+            async move |_notif: acp::schema::CancelNotification, _cx| Ok(()),
+            acp::on_receive_notification!(),
+        )
+        .connect_with(
+            transport,
+            move |_cx: acp::ConnectionTo<acp::Client>| async move {
+                std::future::pending::<()>().await;
+                Ok(())
+            },
+        );
+
+    tokio::task::spawn_local(async move {
+        let _ = connect_future.await;
+    });
+}
+
+/// Turn N runs, a close is requested mid-turn, a prompt is queued behind it.
+/// When turn N finishes, the queued prompt must NOT become turn N+1: the close
+/// is about to land, and a turn started here is a step killed in the middle.
+#[tokio::test]
+async fn a_requested_close_stops_the_queue_from_starting_the_next_turn() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async move {
+            let Harness {
+                actor,
+                command_tx,
+                command_rx,
+                notification_rx,
+                background_work_rx,
+                mut prompt_responder_rx,
+                store,
+                links,
+                link_id,
+                _handle,
+            } = spawn_harness().await;
+
+            let store_for_assertions = store.clone();
+            let actor_task = tokio::task::spawn_local(async move {
+                actor
+                    .run(command_rx, notification_rx, background_work_rx)
+                    .await
+            });
+
+            // Turn N: the ordinary prompt path, through the real idle loop.
+            let (accept_tx, accept_rx) = oneshot::channel();
+            command_tx
+                .send(SessionCommand::Prompt {
+                    payload: PromptPayload::text("turn N".to_string()),
+                    prompt_id: None,
+                    from_queue_seq: None,
+                    respond_to: accept_tx,
+                })
+                .await
+                .expect("send turn N");
+            let _ = accept_rx.await.expect("turn N accepted");
+            let turn_n = tokio::time::timeout(Duration::from_secs(5), prompt_responder_rx.recv())
+                .await
+                .expect("turn N reached the agent")
+                .expect("responder present");
+
+            // Mid-turn: the owner closes this agent. `close_agent` stamps the
+            // still-open ownership row and returns "end requested" — that stamp
+            // IS the durable close request.
+            links
+                .record_close_attribution(&link_id, PARENT_SESSION_ID, Some("superseded"))
+                .expect("stamp the close request");
+            // ...and somebody had already queued a prompt behind the turn.
+            let queued = store
+                .insert_pending_prompt_payload(
+                    SESSION_ID,
+                    &PromptPayload::text("turn N+1".to_string()),
+                    None,
+                )
+                .expect("queue a prompt behind turn N");
+
+            // Turn N finishes normally. Nothing here interrupts it.
+            turn_n
+                .respond(acp::schema::PromptResponse::new(
+                    acp::schema::StopReason::EndTurn,
+                ))
+                .expect("finish turn N");
+
+            // The race: the idle loop is now free to drain. It must not.
+            let started = tokio::time::timeout(
+                Duration::from_millis(750),
+                prompt_responder_rx.recv(),
+            )
+            .await;
+            assert!(
+                started.is_err(),
+                "a queued prompt must NOT start a turn while a close is pending — the close \
+                 would kill it mid-step"
+            );
+
+            // The prompt is not lost, it is simply not started: the durable row
+            // is untouched, and its transcript stays readable after the close.
+            let still_queued = store_for_assertions
+                .list_pending_prompts(SESSION_ID)
+                .expect("pending prompts");
+            assert_eq!(still_queued.len(), 1);
+            assert_eq!(still_queued[0].seq, queued.seq);
+
+            // The request is still armed for the deferred close to consume.
+            assert!(links
+                .find_pending_close_request(SESSION_ID)
+                .expect("pending close lookup")
+                .is_some());
+
+            drop(command_tx);
+            let _ = tokio::time::timeout(Duration::from_secs(5), actor_task).await;
+        })
+        .await;
+}
+
+/// Negative control for the test above: with no close requested, the very same
+/// queued prompt DOES become the next turn. Without this, the assertion above
+/// would also pass if the queue drain were simply broken.
+#[tokio::test]
+async fn without_a_close_request_the_same_queued_prompt_becomes_the_next_turn() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async move {
+            let Harness {
+                actor,
+                command_tx,
+                command_rx,
+                notification_rx,
+                background_work_rx,
+                mut prompt_responder_rx,
+                store,
+                links,
+                link_id: _link_id,
+                _handle,
+            } = spawn_harness().await;
+
+            let actor_task = tokio::task::spawn_local(async move {
+                actor
+                    .run(command_rx, notification_rx, background_work_rx)
+                    .await
+            });
+
+            let (accept_tx, accept_rx) = oneshot::channel();
+            command_tx
+                .send(SessionCommand::Prompt {
+                    payload: PromptPayload::text("turn N".to_string()),
+                    prompt_id: None,
+                    from_queue_seq: None,
+                    respond_to: accept_tx,
+                })
+                .await
+                .expect("send turn N");
+            let _ = accept_rx.await.expect("turn N accepted");
+            let turn_n = tokio::time::timeout(Duration::from_secs(5), prompt_responder_rx.recv())
+                .await
+                .expect("turn N reached the agent")
+                .expect("responder present");
+
+            store
+                .insert_pending_prompt_payload(
+                    SESSION_ID,
+                    &PromptPayload::text("turn N+1".to_string()),
+                    None,
+                )
+                .expect("queue a prompt behind turn N");
+            assert!(links
+                .find_pending_close_request(SESSION_ID)
+                .expect("pending close lookup")
+                .is_none());
+
+            turn_n
+                .respond(acp::schema::PromptResponse::new(
+                    acp::schema::StopReason::EndTurn,
+                ))
+                .expect("finish turn N");
+
+            let turn_n_plus_1 =
+                tokio::time::timeout(Duration::from_secs(5), prompt_responder_rx.recv())
+                    .await
+                    .expect("the queued prompt starts the next turn")
+                    .expect("responder present");
+            turn_n_plus_1
+                .respond(acp::schema::PromptResponse::new(
+                    acp::schema::StopReason::EndTurn,
+                ))
+                .expect("finish turn N+1");
+
+            drop(command_tx);
+            let _ = tokio::time::timeout(Duration::from_secs(5), actor_task).await;
+        })
+        .await;
+}

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/queue.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/queue.rs
@@ -85,6 +85,16 @@ impl SessionActor {
         }
     }
 
+    /// Whether this actor may START another turn.
+    ///
+    /// See [`new_turns_are_blocked_by_a_pending_close`]. Kept as a method so
+    /// both turn-start sites read the same sentence.
+    pub(in crate::live::sessions::actor) fn new_turns_are_blocked_by_a_pending_close(
+        &self,
+    ) -> bool {
+        new_turns_are_blocked_by_a_pending_close(&self.caps, &self.session_id)
+    }
+
     pub(in crate::live::sessions::actor) fn next_pending_prompt_for_drain(
         &self,
     ) -> Option<(PromptPayload, Option<String>, i64)> {
@@ -318,6 +328,51 @@ impl SessionActor {
         let mut sink = self.event_sink.lock().await;
         sink.pending_prompts_reordered(PendingPromptsReorderedPayload { pending_prompts });
         Ok(())
+    }
+}
+
+/// The soft-close fence on STARTING a turn.
+///
+/// `close_agent` on a working agent stamps the ownership row and returns; the
+/// turn-finish hook then closes the tree from a spawned task. Nothing stops the
+/// actor's idle loop from picking the next queued prompt off the durable queue
+/// in that gap, and a turn started there is killed mid-step by the close it
+/// raced — the exact interruption the soft close exists to prevent. So the
+/// stamp fences turn STARTS as well: the step in flight finishes, and nothing
+/// new begins.
+///
+/// Fail-closed. A lookup that errors is treated as "a close may be pending" and
+/// blocks the start, because the cost of being wrong that way is a prompt that
+/// waits, and the cost of being wrong the other way is an agent killed
+/// mid-tool-call.
+///
+/// Free function, not just a method, so the fence can be exercised against real
+/// rows without a live actor.
+pub(crate) fn new_turns_are_blocked_by_a_pending_close(
+    caps: &crate::live::sessions::model::ActorCapabilities,
+    session_id: &str,
+) -> bool {
+    let Some(close_requests) = caps.close_requests.as_ref() else {
+        return false;
+    };
+    match close_requests.has_pending_close_request(session_id) {
+        Ok(pending) => {
+            if pending {
+                tracing::info!(
+                    session_id = %session_id,
+                    "a close was requested for this agent; starting no further turns"
+                );
+            }
+            pending
+        }
+        Err(error) => {
+            tracing::warn!(
+                session_id = %session_id,
+                error = %error,
+                "could not read the pending-close request; refusing to start a turn"
+            );
+            true
+        }
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/live/sessions/model.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/model.rs
@@ -197,6 +197,19 @@ pub trait QueueDurable: Send + Sync {
     ) -> anyhow::Result<PendingPromptReorderOutcome>;
 }
 
+/// The durable "somebody asked this agent to stop" flag, as the actor needs it.
+///
+/// A soft close (`domains/sessions/ownership`) stamps an open ownership row and
+/// lets the in-flight step finish. Between that stamp and the turn-finish hook
+/// actually closing the tree, the actor is free to pick the next durable prompt
+/// off its queue and start turn N+1 — and the hook would then shut the actor
+/// down mid-step, which is precisely the thing the soft close promises will
+/// never happen. So the request is also a fence on STARTING work: while it is
+/// stamped, this actor finishes what it is doing and starts nothing new.
+pub trait PendingCloseRequests: Send + Sync {
+    fn has_pending_close_request(&self, session_id: &str) -> anyhow::Result<bool>;
+}
+
 /// Durable background-work tracker rows.
 pub trait BackgroundWorkDurable: Send + Sync {
     fn upsert_or_refresh_pending_background_work(
@@ -310,6 +323,9 @@ pub struct ActorCapabilities {
     pub background: Arc<dyn BackgroundWorkDurable>,
     pub state: Arc<dyn SessionStateDurable>,
     pub attachments: Arc<dyn AttachmentSource>,
+    /// Consulted before every turn START. `None` only in unit tests that wire
+    /// no link store; production always supplies it.
+    pub close_requests: Option<Arc<dyn PendingCloseRequests>>,
     /// Product reactors, registration order = dispatch order (plans before
     /// reviews). See the dispatch contract on [`SessionEventObserver`].
     pub observers: Vec<Arc<dyn SessionEventObserver>>,

--- a/anyharness/crates/anyharness-lib/src/persistence/migrations.rs
+++ b/anyharness/crates/anyharness-lib/src/persistence/migrations.rs
@@ -228,6 +228,10 @@ pub(super) const MIGRATIONS: &[(&str, &str)] = &[
         "0067_agent_ops_wakes",
         include_str!("sql/0067_agent_ops_wakes.sql"),
     ),
+    (
+        "0068_agent_ops_ownership",
+        include_str!("sql/0068_agent_ops_ownership.sql"),
+    ),
 ];
 
 pub fn run_migrations(conn: &mut Connection) -> rusqlite::Result<()> {

--- a/anyharness/crates/anyharness-lib/src/persistence/sql/0068_agent_ops_ownership.sql
+++ b/anyharness/crates/anyharness-lib/src/persistence/sql/0068_agent_ops_ownership.sql
@@ -1,0 +1,35 @@
+-- Ownership, promotion and close attribution — all three land on the existing
+-- `session_links` row. One row is one ownership fact, and the three states an
+-- agent can be in fall out of the columns rather than out of a new table:
+--
+--   linked subagent      relation = 'subagent'     AND promoted_at IS NULL
+--   promoted             relation = 'subagent'     AND promoted_at IS NOT NULL
+--   owned via spawn      relation = 'owned_agent'
+--
+-- `relation` has no CHECK constraint, so `'owned_agent'` is a value the parser
+-- gains rather than a schema change; nothing writes it until the spawn_agent
+-- step, and historical rows keep parsing.
+--
+-- Promotion is one idempotent write. The close cascade follows only
+-- `relation = 'subagent' AND promoted_at IS NULL`, so a promoted child stops
+-- being taken down with its former parent while the parent still owns it and
+-- may close it individually.
+ALTER TABLE session_links ADD COLUMN promoted_at TEXT;
+
+-- Close attribution, and the durable close REQUEST that makes a soft close
+-- possible. `closed_by_session_id` is set by an agent-initiated `close_agent`
+-- and stays NULL for a human close, which leaves no trace. While
+-- `closed_at IS NULL` a non-NULL `closed_by_session_id` means "end requested":
+-- the target was mid-turn, so the close waits for that turn to finish.
+ALTER TABLE session_links ADD COLUMN closed_by_session_id TEXT;
+
+-- Optional free text the closing agent supplies, rendered as
+-- "Closed by <agent> · <reason>".
+ALTER TABLE session_links ADD COLUMN close_reason TEXT;
+
+-- The turn-finish hook asks one question of every session that finishes a turn:
+-- "does an open link name me as end-requested?". Without this the hook is a
+-- full scan of `session_links` on every completed turn in the runtime.
+CREATE INDEX idx_session_links_pending_close_request
+    ON session_links(child_session_id)
+    WHERE closed_at IS NULL AND closed_by_session_id IS NOT NULL;

--- a/anyharness/sdk/src/reducer/__tests__/transcript.test.ts
+++ b/anyharness/sdk/src/reducer/__tests__/transcript.test.ts
@@ -1246,6 +1246,7 @@ describe("transcript reducer", () => {
     ["mcp__subagents__schedule_agent_wake"],
     ["mcp__subagents__get_agent_config_options"],
     ["mcp__subagents__configure_agent"],
+    ["mcp__subagents__promote_subagent"],
   ])("classifies the renamed agent ops tool %s as subagent activity", (nativeToolName) => {
     const state = reduceEvents(
       [

--- a/anyharness/sdk/src/reducer/transcript.ts
+++ b/anyharness/sdk/src/reducer/transcript.ts
@@ -1427,6 +1427,7 @@ function deriveToolCallSemanticKind(
     || normalizedEffectiveToolName === "mcp__subagents__read_subagent_events"
     || normalizedEffectiveToolName === "mcp__subagents__read_subagent_latest_turns"
     || normalizedEffectiveToolName === "mcp__subagents__search_subagent_transcript"
+    || normalizedEffectiveToolName === "mcp__subagents__promote_subagent"
     || normalizedEffectiveToolName === "mcp__subagents__close_agent"
     || normalizedEffectiveToolName === "mcp__subagents__close_subagent"
     // Peer agent ops. They are not subagent operations, but "subagent" is the

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.test.tsx
@@ -215,7 +215,7 @@ describe("TranscriptToolCallItemBlock", () => {
       }),
     );
 
-    expect(html).toContain("Closed subagent");
+    expect(html).toContain("Closed agent");
     expect(html).toContain("API Surface Check");
     expect(html).not.toContain("Open API Surface Check");
   });

--- a/apps/packages/product-client/src/domain/chats/subagents/subagent-tool-presentation.ts
+++ b/apps/packages/product-client/src/domain/chats/subagents/subagent-tool-presentation.ts
@@ -9,6 +9,7 @@ export type SubagentMcpReceiptAction =
   | "status"
   | "read"
   | "search"
+  | "promote"
   | "close";
 
 export interface SubagentMcpReceiptPresentation {
@@ -38,9 +39,11 @@ export function formatSubagentMcpActionLabel(toolName: string | null | undefined
       return "Read subagent turns";
     case "mcp__subagents__search_subagent_transcript":
       return "Searched subagent transcript";
+    case "mcp__subagents__promote_subagent":
+      return "Promoted subagent";
     case "mcp__subagents__close_agent":
     case "mcp__subagents__close_subagent":
-      return "Closed subagent";
+      return "Closed agent";
     case "mcp__subagents__send_agent_message":
       return "Sent agent message";
     case "mcp__subagents__list_agents":
@@ -86,8 +89,11 @@ export function formatSubagentHeaderVerb({
   if (toolName === "mcp__subagents__search_subagent_transcript") {
     return isRunning ? "Searching subagent transcript" : "Subagent transcript searched";
   }
+  if (toolName === "mcp__subagents__promote_subagent") {
+    return isRunning ? "Promoting subagent" : "Subagent promoted";
+  }
   if (toolName === "mcp__subagents__close_agent" || toolName === "mcp__subagents__close_subagent") {
-    return isRunning ? "Closing subagent" : "Subagent closed";
+    return isRunning ? "Closing agent" : "Agent closed";
   }
   // Peer agent ops. Without their own entries these fall through to the
   // creation verb below, which would claim a spawn that never happened.
@@ -149,8 +155,10 @@ export function deriveSubagentMcpReceiptPresentation(
     ?? readStringField(rawInput, "session_link_id");
   const childSessionId =
     readStringField(rawOutput, "childSessionId")
+    ?? readStringField(rawOutput, "sessionId")
     ?? readStringField(rawInput, "childSessionId")
-    ?? readStringField(rawInput, "child_session_id");
+    ?? readStringField(rawInput, "child_session_id")
+    ?? readStringField(rawInput, "sessionId");
   const title =
     readStringField(rawOutput, "label")
     ?? readStringField(rawInput, "label")
@@ -173,7 +181,11 @@ export function deriveSubagentMcpReceiptPresentation(
     statusLabel,
     detailLabel,
     wakeScheduled: action === "wake",
-    openSessionAllowed: action !== "close" && normalizeStatus(rawStatus) !== "closed",
+    // A close that is only REQUESTED leaves the agent running, so the receipt
+    // still offers to open it.
+    openSessionAllowed:
+      (action !== "close" || readBooleanField(rawOutput, "closeRequested"))
+      && normalizeStatus(rawStatus) !== "closed",
   };
 }
 
@@ -195,6 +207,8 @@ function receiptActionFromToolName(toolName: string | null | undefined): Subagen
       return "read";
     case "mcp__subagents__search_subagent_transcript":
       return "search";
+    case "mcp__subagents__promote_subagent":
+      return "promote";
     case "mcp__subagents__close_agent":
     case "mcp__subagents__close_subagent":
       return "close";
@@ -222,8 +236,10 @@ function actionLabel(
       return running ? "Reading subagent turns" : "Read subagent turns";
     case "search":
       return running ? "Searching subagent" : "Searched subagent";
+    case "promote":
+      return running ? "Promoting subagent" : "Promoted subagent";
     case "close":
-      return running ? "Closing subagent" : "Closed subagent";
+      return running ? "Closing agent" : "Closed agent";
   }
 }
 
@@ -249,8 +265,18 @@ function detailLabelForAction(
         ? `${matches.length} ${matches.length === 1 ? "match" : "matches"}`
         : null;
     }
+    case "promote":
+      return readBooleanField(output, "alreadyPromoted") ? "Already promoted" : "Now a peer";
     case "close":
-      return readBooleanField(output, "alreadyClosed") ? "Already closed" : null;
+      // A close of a working agent is a REQUEST: the agent finishes the step it
+      // is on first, so the receipt must not read as though it already stopped.
+      if (readBooleanField(output, "closeRequested")) {
+        return "Finishing current step";
+      }
+      if (readBooleanField(output, "alreadyClosed")) {
+        return "Already closed";
+      }
+      return readStringField(output, "closeReason");
   }
 }
 

--- a/apps/packages/product-client/src/lib/domain/chat/subagents/subagent-tool-presentation.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/subagents/subagent-tool-presentation.test.ts
@@ -58,7 +58,7 @@ describe("subagent tool presentation", () => {
       item: { nativeToolName: "mcp__subagents__close_agent" },
       executionState: "completed",
       isRunning: false,
-    })).toBe("Subagent closed");
+    })).toBe("Agent closed");
   });
 
   it("names the peer agent ops tools instead of falling back to the creation verb", () => {
@@ -100,6 +100,18 @@ describe("subagent tool presentation", () => {
       executionState: "completed",
       isRunning: false,
     })).toBe("Agent config options read");
+    expect(formatSubagentMcpActionLabel("mcp__subagents__promote_subagent"))
+      .toBe("Promoted subagent");
+    expect(formatSubagentHeaderVerb({
+      item: { nativeToolName: "mcp__subagents__promote_subagent" },
+      executionState: "running",
+      isRunning: true,
+    })).toBe("Promoting subagent");
+    expect(formatSubagentHeaderVerb({
+      item: { nativeToolName: "mcp__subagents__promote_subagent" },
+      executionState: "completed",
+      isRunning: false,
+    })).toBe("Subagent promoted");
   });
 
   it("derives concise status receipt presentation with the child target", () => {
@@ -194,9 +206,79 @@ describe("subagent tool presentation", () => {
 
     expect(presentation).toMatchObject({
       action: "close",
-      actionLabel: "Closed subagent",
+      actionLabel: "Closed agent",
       title: "API Surface Check",
       openSessionAllowed: false,
+    });
+  });
+
+  it("reads a close of a working agent as a request, not a stop", () => {
+    // The agent is mid-step: `close_agent` returned closeRequested, the row is
+    // stamped, and the runtime closes it when the step ends. A receipt that
+    // said "Closed" here would be claiming something that has not happened.
+    const presentation = deriveSubagentMcpReceiptPresentation(toolCallItem({
+      nativeToolName: "mcp__subagents__close_agent",
+      rawOutput: {
+        subagentId: "subagent_123",
+        sessionLinkId: "link-123",
+        sessionId: "child-123",
+        label: "API Surface Check",
+        closed: false,
+        closeRequested: true,
+        closeReason: "duplicate work",
+      },
+    }));
+
+    expect(presentation).toMatchObject({
+      action: "close",
+      childSessionId: "child-123",
+      detailLabel: "Finishing current step",
+      openSessionAllowed: true,
+    });
+  });
+
+  it("surfaces the close reason once the agent is actually closed", () => {
+    const presentation = deriveSubagentMcpReceiptPresentation(toolCallItem({
+      nativeToolName: "mcp__subagents__close_agent",
+      rawOutput: {
+        subagentId: "subagent_123",
+        sessionLinkId: "link-123",
+        sessionId: "child-123",
+        label: "API Surface Check",
+        closed: true,
+        closeRequested: false,
+        closedBySessionId: "ses_owner",
+        closeReason: "duplicate work",
+      },
+    }));
+
+    expect(presentation).toMatchObject({
+      action: "close",
+      detailLabel: "duplicate work",
+      openSessionAllowed: false,
+    });
+  });
+
+  it("derives promotion receipts as openable peer receipts", () => {
+    const presentation = deriveSubagentMcpReceiptPresentation(toolCallItem({
+      nativeToolName: "mcp__subagents__promote_subagent",
+      rawOutput: {
+        subagentId: "subagent_123",
+        sessionLinkId: "link-123",
+        sessionId: "child-123",
+        label: "API Surface Check",
+        promoted: true,
+        alreadyPromoted: false,
+      },
+    }));
+
+    expect(presentation).toMatchObject({
+      action: "promote",
+      actionLabel: "Promoted subagent",
+      title: "API Surface Check",
+      childSessionId: "child-123",
+      detailLabel: "Now a peer",
+      openSessionAllowed: true,
     });
   });
 });

--- a/specs/GENERATED/anyharness-db-schema.sql
+++ b/specs/GENERATED/anyharness-db-schema.sql
@@ -486,7 +486,7 @@ CREATE TABLE session_links (
     workspace_relation TEXT NOT NULL,
     created_by_turn_id TEXT,
     created_by_tool_call_id TEXT,
-    created_at TEXT NOT NULL, label TEXT, public_id TEXT, closed_at TEXT,
+    created_at TEXT NOT NULL, label TEXT, public_id TEXT, closed_at TEXT, promoted_at TEXT, closed_by_session_id TEXT, close_reason TEXT,
     UNIQUE(relation, parent_session_id, child_session_id),
     CHECK(parent_session_id != child_session_id)
 );
@@ -848,6 +848,11 @@ CREATE INDEX idx_session_links_open_parent_relation
 -- index: idx_session_links_parent
 CREATE INDEX idx_session_links_parent
     ON session_links(parent_session_id);
+
+-- index: idx_session_links_pending_close_request
+CREATE INDEX idx_session_links_pending_close_request
+    ON session_links(child_session_id)
+    WHERE closed_at IS NULL AND closed_by_session_id IS NOT NULL;
 
 -- index: idx_session_links_public_id
 CREATE UNIQUE INDEX idx_session_links_public_id

--- a/specs/anyharness/sessions.md
+++ b/specs/anyharness/sessions.md
@@ -95,7 +95,8 @@ session events as the runtime truth for replay or rendering.
 
 It stores an advisory relationship between two existing sessions:
 
-- relation, currently `subagent`
+- relation: `subagent`, `owned_agent`, `fork`, `cowork_coding_session`, or
+  `review_agent`
 - parent session id
 - child session id
 - workspace relation, currently `same_workspace`
@@ -103,12 +104,39 @@ It stores an advisory relationship between two existing sessions:
 - optional creator turn id
 - optional creator tool-call id
 - created timestamp
+- optional promoted timestamp
+- optional closing session id and close reason
 
 The link service validates that parent and child sessions exist, rejects
 self-links, and enforces uniqueness for `(relation, parent_session_id,
 child_session_id)`. For `subagent` links, a child may have only one parent.
 Deleting a session removes any links where that session is the parent or child,
 including completion and wake-schedule rows attached to those links.
+
+#### Ownership
+
+`session_links` is also the ownership substrate. Two relations confer
+ownership — `subagent` and `owned_agent` — and an agent's ownership state is
+read off one row:
+
+| State | Row |
+| --- | --- |
+| Subagent | `relation = 'subagent'` and `promoted_at IS NULL` |
+| Promoted | `relation = 'subagent'` and `promoted_at IS NOT NULL` |
+| Owned peer | `relation = 'owned_agent'` |
+
+Promotion stamps `promoted_at`; it does not change the relation, because the
+parent stays the owner. It is one idempotent write, and it is one-way.
+
+`closed_by_session_id` and `close_reason` record which agent closed this one and
+why. Both stay `NULL` for a session a person closed through the UI or the HTTP
+close route — the columns record an *agent's* close, not every close.
+
+Ownership is deliberately separate from `authorize`
+(`domains/sessions/authorize.rs`), which answers reachability and is
+runtime-wide and unlinked. Reaching an agent and acting on its lifecycle are
+different questions; promotion and close resolve an ownership row first, they do
+not go through the reachability funnel.
 
 Session links are durable product state, but their creator turn/tool metadata is
 provenance only. It must not be used as an authorization, billing, or trust
@@ -186,9 +214,12 @@ The model is intentionally small:
 - `session_links` is the access-control check for every child-id-taking tool
 - PR2 does not cascade-delete child sessions when a parent is deleted; deleting
   either session removes only the link and attached completion/schedule rows
-- nested subagents are blocked; a session that is already a subagent child does
-  not receive subagent MCP tools
-- parents are limited to eight subagents
+- nested subagents are blocked; an UNPROMOTED subagent child receives no
+  spawn-style tools (`get_subagent_launch_options`, `spawn_subagent`, and the
+  deprecated `create_subagent` alias) and `validate_parent_can_spawn` refuses it
+  with a depth limit
+- parents are limited to eight *unpromoted* subagents at a time; promoted
+  children no longer occupy a slot
 - `subagents_enabled` is a durable create-time session policy. Missing legacy
   rows default enabled in the session store/read model. Resume reads the stored
   policy and does not silently re-enable disabled sessions.
@@ -233,6 +264,30 @@ Current tools:
 - `get_subagent_status`
 - `read_subagent_events`
 - `schedule_subagent_wake`
+- `promote_subagent`
+- `close_agent` (deprecated alias: `close_subagent`)
+
+Advertisement is not enforcement. A session's tool list is frozen at launch, so
+an agent promoted afterwards holds a list that never showed the spawn tools and
+one launched before its promotion holds a list that did. The spawn gate
+therefore runs again at dispatch in `agent_ops/calls.rs`, against the caller's
+state at the moment it acts, and matches the wire name so the deprecated
+`create_subagent` spelling cannot walk around it.
+
+`promote_subagent` promotes one of the caller's subagents to a peer. The agent
+keeps its transcript, its label and its owner, and gains the full tool surface
+including spawning its own agents; it stops closing when its owner closes, and
+stops counting against the owner's subagent limit. Only the owning parent may
+promote, and only its own child. It is one indexed UPDATE against a link row in
+the caller's own workspace and touches no session actor, so it takes the route's
+workspace write lease and no session mutation permit.
+
+`close_agent` closes any agent the caller owns, by `sessionId` or by
+`subagentId`, with an optional `reason`. Because the target may live in another
+workspace and because a close acts on the target session, it takes its own fence
+rather than the route's: the TARGET session's mutation permit first, then the
+TARGET workspace's write lease (PR1227-LOCK-01). Skipping the permit would let a
+close run straight through a workflow that had taken control of that session.
 
 `get_subagent_launch_options` is the discovery surface parent agents should use
 before choosing non-default `agentKind`, `modelId`, or `modeId` values. It
@@ -505,6 +560,45 @@ The runtime layer:
 
 Cancel and close follow the same pattern.
 
+#### Close cascade
+
+`close_live_session` closes a tree: children first, then the actor, then the
+inbound links. Which children go down with the parent is decided per link:
+
+- `subagent` cascades only while `promoted_at IS NULL`. Promotion severs the
+  cascade and nothing else — the row survives, so the former parent may still
+  close that agent deliberately.
+- `cowork_coding_session` and `review_agent` always cascade.
+- `owned_agent` never cascades: it is a peer by construction, so there is no
+  subordination to sever.
+- `fork` never cascades: a fork is a copy, not a dependent.
+
+When a session itself closes, every inbound ownership, cowork, and review link
+pointing at it closes with it, promoted or not.
+
+#### Soft close
+
+Closing an agent that is *working* does not interrupt it.
+
+- The target's execution phase is `Running`: the call authorizes the close,
+  stamps `closed_by_session_id`/`close_reason` on the still-open ownership row,
+  and returns `closeRequested`. That stamped-but-open row IS the durable
+  request. The agent finishes the step it is on; at turn finish
+  (`domains/sessions/ownership/hooks.rs`) the close tree runs. Because the
+  request is durable, a runtime that restarts mid-turn still owes the close and
+  the next finished turn pays it.
+- Any other phase closes immediately. `AwaitingInteraction` is a turn that
+  cannot finish without a human, so deferring would mean never; `Starting` has
+  no turn to finish and may never emit one.
+
+The deferred half re-takes the same two gates in the same order rather than
+carrying them, because the requesting call returned long ago and control can be
+acquired in between. A refusal there leaves the request armed for the next
+finished turn rather than dropping it.
+
+Attribution is written once. A second close of an already-closed agent leaves
+the first close's record alone, and returns idempotently before taking any gate.
+
 ### Interaction Resolution
 
 Interaction resolution also goes through `SessionRuntime`.
@@ -688,6 +782,12 @@ Code path:
 - Session event sequences are monotonic per session.
 - Durable records remain authoritative even when no live actor exists.
 - Config changes requested while busy must not be lost.
+- Only the owning parent may promote or close an agent, and ownership is read
+  from a `session_links` row — never from reachability.
+- Promotion is one-way and idempotent, and severs only the close cascade.
+- A close of a working agent never interrupts its in-flight step.
+- A close whose target is outside the caller's own link tree takes the target
+  session's mutation permit before any workspace lease.
 
 ## Extension Points
 

--- a/specs/anyharness/sessions.md
+++ b/specs/anyharness/sessions.md
@@ -222,7 +222,13 @@ The model is intentionally small:
   children no longer occupy a slot
 - `subagents_enabled` is a durable create-time session policy. Missing legacy
   rows default enabled in the session store/read model. Resume reads the stored
-  policy and does not silently re-enable disabled sessions.
+  policy and does not silently re-enable disabled sessions. `spawn_subagent`
+  creates every child with it OFF: that flag is how a spawned child carries its
+  subordination. Promotion lifts it — `validate_parent_can_spawn` treats a
+  promoted child as enabled — so promotion stays one durable fact on the link
+  rather than a second write to the session row that could diverge from it.
+- the advertised subagent count and remaining slots are the same predicate the
+  fanout cap enforces, so the numbers an agent is told match the answer it gets
 
 The subagent domain lives under
 `anyharness/crates/anyharness-lib/src/domains/sessions/subagents/**`.
@@ -576,6 +582,10 @@ inbound links. Which children go down with the parent is decided per link:
 When a session itself closes, every inbound ownership, cowork, and review link
 pointing at it closes with it, promoted or not.
 
+The cascade closes descendants directly. The soft close below is a guarantee for
+the agent a close was AIMED at, not for its subtree: a working subagent of a
+closing parent goes down with the parent, mid-step, as it always has.
+
 #### Soft close
 
 Closing an agent that is *working* does not interrupt it.
@@ -596,8 +606,44 @@ carrying them, because the requesting call returned long ago and control can be
 acquired in between. A refusal there leaves the request armed for the next
 finished turn rather than dropping it.
 
-Attribution is written once. A second close of an already-closed agent leaves
-the first close's record alone, and returns idempotently before taking any gate.
+Once a close is requested, no new turn may START. Otherwise the deferred close
+races the actor's own queue: turn N ends, the idle loop immediately takes the
+next durable prompt, and the close — landing a few milliseconds later from the
+turn-finish hook — kills turn N+1 in the middle of its step, which is exactly the
+interruption a soft close promises never happens. So the actor consults the
+durable request at both of its turn-start points (`live/sessions/actor/run.rs`:
+the queue drain, and the prompt command received while idle) and starts nothing
+while a request stands. The check is fail-closed — a lookup error blocks the
+turn — because a turn wrongly not started is recoverable and a step killed in
+the middle is not.
+
+Prompts aimed at an end-requested agent are therefore never delivered, and the
+paths differ in how they say so:
+
+- An agent's `send_agent_message` / `send_subagent_message` is refused outright,
+  told that the target is finishing its final step before closing and takes no
+  new messages. Reads are untouched: the transcript stays readable during the
+  window and after the close.
+- A prompt from a person on the HTTP route is accepted and stored durably,
+  exactly as a prompt to any busy session is. It simply never starts — the
+  actor's turn-start fence is the seam, and once the close lands the actor does
+  not run again. There is no separate refusal on the human route.
+- Prompts already queued behind the in-flight turn are kept, not cancelled. A
+  close marks the session closed and closes its links; it does not delete
+  `session_pending_prompts` rows. They stay visible as queued work that was
+  never run.
+
+A request whose agent never finishes another turn — the runtime died between the
+stamp and the turn end — is paid at boot. A startup pass sweeps the open
+ownership rows carrying a close request and, for any target with no live handle,
+completes the close through the same body the turn-finish hook uses. A target
+that IS live is left alone; its own turn finish still owes the close.
+
+Attribution is written once, and the first requester owns it for the whole
+end-requested window: a second close arriving while the request is still open
+neither overwrites the record nor re-stamps it. A close of an already-closed
+agent leaves the first close's record alone and returns idempotently before
+taking any gate.
 
 ### Interaction Resolution
 

--- a/specs/codebase/platforms/product/agent-features/definitions/subagents.md
+++ b/specs/codebase/platforms/product/agent-features/definitions/subagents.md
@@ -35,9 +35,9 @@ Tool names follow the same law. A session's tool list is frozen at launch, so
 names, `create_subagent` and `close_subagent`. Aliases dispatch to the same
 implementation and are never advertised in `tools/list`.
 
-Subagents cannot create grandchildren. There are no top-level `modelId` or
-`modeId` fields in subagent tools; harness-specific launch configuration is
-carried through `initialConfig`.
+Subagents cannot create grandchildren *while they are subagents*. There are no
+top-level `modelId` or `modeId` fields in subagent tools; harness-specific
+launch configuration is carried through `initialConfig`.
 
 `subagentId` is the handle for the subagent tool class only. The peer tools in
 the same MCP — `list_agents`, `send_agent_message`, `read_agent_transcript`,
@@ -59,6 +59,39 @@ stays open on all three. It is not the execution fence — a session
 an active workflow run controls is refused a peer prompt or a peer config
 change by the same session mutation admission permit that fences the HTTP
 prompt and config routes.
+
+## Ownership And Promotion
+
+Ownership is a `session_links` row, not reachability. Every agent can reach every
+other agent — that is what the peer tools are for — but only the agent that
+spawned a subagent, or that owns an agent outright, may promote or close it.
+Ownership is read from the row and never inferred from the ability to send a
+message.
+
+An agent is in exactly one of three states, and the row says which:
+
+| State | Row | Can spawn | Closes with its owner | Counts against the owner's limit |
+| --- | --- | --- | --- | --- |
+| Subagent | `relation = 'subagent'`, `promoted_at IS NULL` | no | yes | yes |
+| Promoted | `relation = 'subagent'`, `promoted_at IS NOT NULL` | yes | no | no |
+| Owned peer | `relation = 'owned_agent'` | yes | no | no |
+
+`promote_subagent` moves a subagent to promoted. It is one write, idempotent,
+and one-way. The relation does not change, because the owner does not change:
+the parent still owns a promoted agent and may still close it deliberately. What
+promotion severs is subordination — the close cascade, the fanout slot, and the
+spawn block.
+
+The spawn block is the visible consequence for the child. An unpromoted subagent
+is offered no spawn-style tool at all — not `spawn_subagent`, not
+`get_subagent_launch_options`, not the `create_subagent` alias. That is stricter
+than the fanout cap, which merely refuses a spawn: a capped parent still sees
+its launch options, because the cap is a temporary condition of an agent that is
+allowed to think in terms of spawning. Subordination is not.
+
+Because tool lists are frozen at launch, the block is enforced at call time, on
+the wire name, against the caller's state at the moment it acts. `tools/list` is
+advertisement; dispatch is the gate.
 
 ## Peer Configuration
 
@@ -124,11 +157,32 @@ Closing is not transcript deletion. The child session and historical
 artifacts remain available through history/debug surfaces according to
 retention policy.
 
+`close_agent` closes any agent the caller owns, addressed by `sessionId` or by
+`subagentId`, with an optional `reason`. Its target is not confined to the
+caller's workspace, so it takes its own fence rather than the route's: the
+target session's mutation permit first, then the target workspace's write lease.
+A close is the most destructive session mutation there is; without the permit it
+would run straight through a workflow that had taken control of that session.
+
 Close ordering is intentionally retryable: the runtime closes the child
 session graph first, including any delegated descendants and product close
 hooks, then marks the parent-child link closed. If closing the live session
 fails, the active link remains discoverable so a later close call can retry
 rather than orphaning hidden work.
+
+The cascade skips promoted children. Closing an owner takes down the subagents
+still subordinate to it and leaves the agents it promoted running; their
+ownership rows survive, so they can still be closed individually.
+
+Closing an agent that is WORKING does not interrupt it. The call authorizes the
+close, records who closed it and why on the still-open ownership row, and
+returns "end requested"; the agent finishes the step it is on and the tree
+closes at turn finish. An idle agent closes immediately. The stamped-but-open
+row is the durable request, so the close survives a runtime restart mid-turn.
+
+`closedBySessionId` and `closeReason` are attribution, written once. A second
+close of an already-closed agent is a no-op that preserves the first close's
+record, and a close performed by a person through the UI leaves both unset.
 
 Cowork reuses this same close-ordering law for `close_cowork_agent`; see
 [cowork.md](cowork.md).

--- a/specs/codebase/platforms/product/agent-features/definitions/subagents.md
+++ b/specs/codebase/platforms/product/agent-features/definitions/subagents.md
@@ -82,8 +82,11 @@ the parent still owns a promoted agent and may still close it deliberately. What
 promotion severs is subordination — the close cascade, the fanout slot, and the
 spawn block.
 
-The spawn block is the visible consequence for the child. An unpromoted subagent
-is offered no spawn-style tool at all — not `spawn_subagent`, not
+The spawn block is the visible consequence for the child. A spawned child is
+created with its session-level subagents policy OFF as well, which is the same
+subordination expressed on the session row; promotion lifts both, so a promoted
+agent can genuinely spawn rather than merely being offered the tools. An
+unpromoted subagent is offered no spawn-style tool at all — not `spawn_subagent`, not
 `get_subagent_launch_options`, not the `create_subagent` alias. That is stricter
 than the fanout cap, which merely refuses a spawn: a capped parent still sees
 its launch options, because the cap is a temporary condition of an agent that is
@@ -178,11 +181,25 @@ Closing an agent that is WORKING does not interrupt it. The call authorizes the
 close, records who closed it and why on the still-open ownership row, and
 returns "end requested"; the agent finishes the step it is on and the tree
 closes at turn finish. An idle agent closes immediately. The stamped-but-open
-row is the durable request, so the close survives a runtime restart mid-turn.
+row is the durable request, so the close survives a runtime restart mid-turn —
+a request left owing by a dead runtime is completed by a startup pass.
 
-`closedBySessionId` and `closeReason` are attribution, written once. A second
-close of an already-closed agent is a no-op that preserves the first close's
-record, and a close performed by a person through the UI leaves both unset.
+For the length of that window the agent takes no new work. A peer's
+`send_agent_message` or `send_subagent_message` is refused and told the target is
+finishing its final step before closing; reads are untouched, so the transcript
+stays readable throughout and afterwards. A person's prompt is still accepted and
+queued, but no queued prompt starts a turn once a close is requested — that is
+what keeps the final step from being killed by its own close. Prompts left in the
+queue are not deleted; they are simply never run.
+
+The guarantee covers the agent the close was aimed at. Descendants that go down
+with it are closed directly, working or not.
+
+`closedBySessionId` and `closeReason` are attribution, written once, and the
+first requester keeps them for the whole end-requested window. A second close —
+of an already-closed agent, or of one already finishing — is a no-op that
+preserves the first close's record, and a close performed by a person through the
+UI leaves both unset.
 
 Cowork reuses this same close-ordering law for `close_cowork_agent`; see
 [cowork.md](cowork.md).


### PR DESCRIPTION
Fifth slice of the agent-operations stack (ADR §6 step 5; stacked on #1729 → #1728 → #1727 → #1726). Adds the ownership layer: `promote_subagent`, a generalized `close_agent`, and the soft close.

## What this does

Ownership is a `session_links` row, not reachability. Every agent can reach every other agent — that is what the peer tools are for — but only the agent that spawned a subagent may promote or close it. Migration 0068 puts the three states on the existing row: a subagent is `relation='subagent'` with `promoted_at IS NULL`, a promoted agent is the same row with the stamp set, and `owned_agent` is reserved for the spawn step that follows (PR 6).

Promotion keeps everything and drops subordination: same transcript, same label, same owner, but off the close cascade, off the fanout cap, and with the spawn tools unlocked. It is one write, idempotent, one-way.

`close_agent` now takes a `sessionId` and an optional `reason`. Its target may be in another workspace and a close acts on the target session, so it leaves the route's lease behind and takes its own fence — the target session's mutation permit (`SessionMutationKind::Close`, the same kind the human close route uses), then the target workspace's write lease, in that order (PR1227-LOCK-01). Closing a working agent does not interrupt it: the call stamps the still-open row and returns "end requested", and the agent finishes its step before the tree closes (`closed_by_session_id IS NOT NULL AND closed_at IS NULL` = end requested — no new table). Only a `Running` turn defers; `AwaitingInteraction` cannot finish without a human and closes immediately, as does an idle agent. Close attribution (`closed_by_session_id` + `close_reason`) is stamped guarded, so a second close cannot overwrite the first close's record.

An unpromoted subagent is offered no spawn-style tool at all. Tool lists are frozen at launch, so the gate that binds runs at dispatch, on the wire name; `tools/list` filtering is advertisement only.

## Spec note

The implementation follows ADR §3.2 exactly: promotion stamps `promoted_at` and leaves `relation='subagent'`; the cascade predicate, the DepthLimit lift, and "the parent can still close it individually" (ruling 7) all depend on the row keeping its relation. `'owned_agent'` rows are written only by `spawn_agent` in PR 6. (An earlier working-brief paraphrase said promotion flips the relation — that was wrong; the ADR itself is consistent.)

Deferred, fail-closed: `mobility_archive_contract.rs` imports the three new columns as `None` — carrying them is a wire-contract change plus SDK regen, commented in place.

## Testing

- Full `anyharness-lib --lib`: 1657 passed / 1 failed (the known pre-existing `sweep_tests` red). After rebase onto #1729's head: scoped suites 215/215.
- 25 new tests: ownership resolution, promotion idempotency and scope, cascade behavior, spawn gating, both lock orders.
- Negative controls, each run and restored: reverting the cascade guard, the dispatch-time spawn gate, or the close permit each fails exactly its named test.
- SDK vitest 45/45; product-client vitest 21/21; `check_docs.py` green (209 files).

## Observability

A deferred close logs at info on completion (`session_id`, `session_link_id`, `closed_by_session_id`, `turn_id`) and when a gate refuses and the request stays armed; unexpected failures warn. Promotion and close both return their settled state (`promotedAt`, `closedAt`, `closedBySessionId`, `closeReason`, `alreadyPromoted`/`alreadyClosed`/`closeRequested`) so the calling agent and the transcript read the same facts.
