### PR TITLE
feat(anyharness): spawn_agent — peer agents over one shared session-creation routine

### DIFF
--- a/anyharness/crates/anyharness-lib/src/app/test_support.rs
+++ b/anyharness/crates/anyharness-lib/src/app/test_support.rs
@@ -1,11 +1,24 @@
 use std::ffi::OsString;
 use std::sync::{Arc, Mutex, OnceLock};
 
+use crate::domains::repo_roots::service::RepoRootService;
+use crate::domains::repo_roots::store::RepoRootStore;
 use crate::domains::sessions::attachment_storage::PromptAttachmentStorage;
+use crate::domains::sessions::deletion::SessionDeleteWorkflow;
+use crate::domains::sessions::links::service::SessionLinkService;
+use crate::domains::sessions::links::store::SessionLinkStore;
 use crate::domains::sessions::live_ports::SessionAttachmentSource;
 use crate::domains::sessions::mcp_bindings::crypto::DATA_KEY_ENV_VAR;
 use crate::domains::sessions::store::SessionStore;
+use crate::domains::sessions::subagents::service::SubagentService;
+use crate::domains::sessions::subagents::store::SubagentStore;
+use crate::domains::terminals::store::TerminalStore;
+use crate::domains::workspaces::access_gate::WorkspaceAccessGate;
+use crate::domains::workspaces::deletion::WorkspaceDeleteWorkflow;
+use crate::domains::workspaces::runtime::WorkspaceRuntime;
+use crate::domains::workspaces::store::{WorkspaceAccessStore, WorkspaceStore};
 use crate::live::sessions::model::ActorCapabilities;
+use crate::live::terminals::TerminalService;
 use crate::persistence::Db;
 
 /// Store-backed [`ActorCapabilities`] for tests: the same wiring as
@@ -161,6 +174,59 @@ pub(crate) fn insert_session_row(
         origin: Some(crate::origin::OriginContext::system_local_runtime()),
     };
     store.insert(&record).expect("insert session row");
+}
+
+/// A store-backed [`SubagentService`] and the link service behind it.
+///
+/// The spawn gates (`validate_parent_can_spawn`,
+/// `validate_caller_can_spawn_agent`) read the session store, the link store,
+/// the workspace record and the access gate together, so proving what they
+/// refuse needs the real wiring rather than a stub — this is the same
+/// composition `app/mod.rs` builds, over an in-memory db. The link service is
+/// handed back because the state those gates read (a subagent link, a promoted
+/// one, eight of them) is written through it.
+pub(crate) struct SubagentServiceFixture {
+    pub service: SubagentService,
+    pub links: SessionLinkService,
+    pub sessions: SessionStore,
+}
+
+pub(crate) fn subagent_service_fixture(db: &Db) -> SubagentServiceFixture {
+    let sessions = SessionStore::new(db.clone());
+    let links = SessionLinkService::new(SessionLinkStore::new(db.clone()), sessions.clone());
+    let session_delete_workflow = SessionDeleteWorkflow::new(db.clone());
+    let runtime_home = std::env::temp_dir().join(format!(
+        "anyharness-subagent-service-test-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let workspace_runtime = Arc::new(WorkspaceRuntime::new(
+        WorkspaceStore::new(db.clone()),
+        WorkspaceDeleteWorkflow::new(db.clone(), session_delete_workflow.clone()),
+        RepoRootService::new(RepoRootStore::new(db.clone())),
+        runtime_home.clone(),
+    ));
+    let access_gate = Arc::new(WorkspaceAccessGate::new(
+        WorkspaceStore::new(db.clone()),
+        sessions.clone(),
+        WorkspaceAccessStore::new(db.clone()),
+        Arc::new(TerminalService::new(
+            TerminalStore::new(db.clone()),
+            runtime_home,
+        )),
+    ));
+    let service = SubagentService::new(
+        sessions.clone(),
+        session_delete_workflow,
+        links.clone(),
+        SubagentStore::new(db.clone()),
+        workspace_runtime,
+        access_gate,
+    );
+    SubagentServiceFixture {
+        service,
+        links,
+        sessions,
+    }
 }
 
 pub(crate) fn seed_workspace_with_repo_root(db: &Db, workspace_id: &str, kind: &str, path: &str) {

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/calls.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/calls.rs
@@ -4,8 +4,8 @@ use anyharness_contract::v1::ConfigApplyState;
 use serde_json::{json, Value};
 
 use super::calls_helpers::{
-    default_model_for_agent, initial_config_string, launch_agents_to_json, mode_options_to_json,
-    prompt_outcome_label, summaries_to_json,
+    cleanup_wake_schedule_after_failed_dispatch, default_model_for_agent, launch_agents_to_json,
+    mode_options_to_json, prompt_outcome_label, summaries_to_json,
 };
 use super::config_ops::{
     compose_agent_config_options, controls_to_json, current_selection_to_json,
@@ -17,12 +17,13 @@ use super::peer_ops::{
     authorize_transcript_read, consume_reply_wake, lease_target_workspace_for_peer_write,
     prepare_agent_message,
 };
+use super::spawn_ops::{create_agent_session, CreateAgentSessionRequest};
 use super::tools::{
     canonical_tool_name, is_spawn_style_tool, ChildSessionArgs, CloseAgentArgs, ConfigureAgentArgs,
     CreateSubagentArgs, GetAgentConfigOptionsArgs, ListAgentsArgs, PromoteSubagentArgs,
     ReadAgentTranscriptArgs, ReadAgentTranscriptMode, ReadSubagentEventsArgs,
     ReadSubagentLatestTurnsArgs, ScheduleAgentWakeArgs, SearchSubagentTranscriptArgs,
-    SendAgentMessageArgs, SendSubagentMessageArgs,
+    SendAgentMessageArgs, SendSubagentMessageArgs, SpawnAgentArgs,
 };
 use super::AgentOpsPeerGates;
 use crate::domains::sessions::admission::SessionMutationKind;
@@ -42,7 +43,6 @@ use crate::domains::sessions::transcript_read::{
 };
 use crate::domains::sessions::wakes::service::AgentWakeService;
 use crate::integrations::mcp::json_rpc::deserialize_args;
-use crate::origin::OriginContext;
 
 pub async fn call_tool(
     service: &SubagentService,
@@ -73,7 +73,11 @@ pub async fn call_tool(
         "get_subagent_launch_options" => get_subagent_launch_options(service, session_runtime, ctx),
         "spawn_subagent" => {
             let args: CreateSubagentArgs = deserialize_args(arguments)?;
-            spawn_subagent(service, session_runtime, ctx, args).await
+            spawn_subagent(service, ownership, wake_service, session_runtime, ctx, args).await
+        }
+        "spawn_agent" => {
+            let args: SpawnAgentArgs = deserialize_args(arguments)?;
+            spawn_agent(service, ownership, wake_service, session_runtime, ctx, args).await
         }
         "list_subagents" => service
             .list_subagents(&ctx.parent_session_id)
@@ -291,11 +295,12 @@ fn get_subagent_launch_options(
 
 async fn spawn_subagent(
     service: &SubagentService,
+    ownership: &AgentOwnershipService,
+    wake_service: &AgentWakeService,
     session_runtime: &SessionRuntime,
     ctx: &AgentOpsMcpContext,
     args: CreateSubagentArgs,
 ) -> anyhow::Result<Value> {
-    let parent_session_id = &ctx.parent_session_id;
     if !ctx.can_create {
         anyhow::bail!(
             "{}",
@@ -304,139 +309,109 @@ async fn spawn_subagent(
                 .unwrap_or("subagent creation is not available for this session")
         );
     }
-    let parent = service.validate_parent_can_spawn(parent_session_id)?;
-    let prompt = args.prompt;
-    if prompt.trim().is_empty() {
-        anyhow::bail!("prompt is required");
-    }
-    let agent_kind = args.harness_id.unwrap_or_else(|| parent.agent_kind.clone());
-    let model_id = initial_config_string(args.initial_config.as_ref(), &["modelId", "model"])
-        .or(parent.current_model_id.clone())
-        .or(parent.requested_model_id.clone());
-    let mode_id = initial_config_string(args.initial_config.as_ref(), &["modeId", "mode"])
-        .or(parent.current_mode_id.clone())
-        .or(parent.requested_mode_id.clone());
-    let label = args
-        .label
-        .map(|value| value.trim().to_string())
-        .filter(|v| !v.is_empty());
+    let parent = service.validate_parent_can_spawn(&ctx.parent_session_id)?;
+    let request = CreateAgentSessionRequest::subagent(&parent, args)?;
+    let wake_requested = request.wake_on_completion;
+    let applied = applied_initial_config(&request);
+    let created = create_agent_session(
+        service,
+        ownership,
+        wake_service,
+        session_runtime,
+        &parent,
+        request,
+    )
+    .await?;
 
-    let child = session_runtime
-        .create_durable_session(
-            &parent.workspace_id,
-            &agent_kind,
-            None,
-            model_id.as_deref(),
-            mode_id.as_deref(),
-            None,
-            Vec::new(),
-            None,
-            crate::domains::sessions::model::SessionMcpBindingPolicy::InheritWorkspace,
-            false,
-            OriginContext::system_local_runtime(),
-        )
-        .map_err(|error| anyhow::anyhow!("{error:?}"))?;
-    let link = match service.link_child(parent_session_id, &child.id, label.clone(), None, None) {
-        Ok(link) => link,
-        Err(error) => {
-            let _ = service.delete_session(&child.id);
-            return Err(error.into());
-        }
-    };
-    let wake_scheduled = if args.wake_on_completion {
-        match service.schedule_wake_for_target(parent_session_id, None, Some(&child.id)) {
-            Ok((_, inserted)) => inserted,
-            Err(error) => {
-                cleanup_child_session_after_failed_launch(service, &child.id, "schedule wake");
-                return Err(error.into());
-            }
-        }
-    } else {
-        false
-    };
-
-    let started = match session_runtime.start_persisted_session(&child).await {
-        Ok(started) => started,
-        Err(error) => {
-            if args.wake_on_completion {
-                cleanup_wake_schedule_after_failed_dispatch(service, &link.id, "start subagent");
-            }
-            cleanup_child_session_after_failed_launch(service, &child.id, "start subagent");
-            return Err(anyhow::anyhow!("{error:?}"));
-        }
-    };
-    let outcome = match session_runtime
-        .send_text_prompt_with_provenance(
-            &started.id,
-            prompt,
-            parent_to_child_provenance(parent_session_id, &link.id, label.clone()),
-        )
-        .await
-    {
-        Ok(outcome) => outcome,
-        Err(error) => {
-            if args.wake_on_completion {
-                cleanup_wake_schedule_after_failed_dispatch(
-                    service,
-                    &link.id,
-                    "send initial prompt",
-                );
-            }
-            cleanup_child_session_after_failed_launch(service, &child.id, "send initial prompt");
-            return Err(anyhow::anyhow!("{error:?}"));
-        }
-    };
     Ok(json!({
-        "sessionLinkId": link.id,
-        "subagentId": link.public_id,
-        "childSessionId": started.id,
-        "label": label,
-        "appliedInitialConfig": {
-            "harnessId": agent_kind,
-            "modelId": model_id,
-            "modeId": mode_id,
-        },
+        "sessionLinkId": created.link.id,
+        "subagentId": created.link.public_id,
+        "childSessionId": created.session.id,
+        "label": created.link.label,
+        "appliedInitialConfig": applied,
         "wake": {
-            "scheduled": args.wake_on_completion,
-            "created": wake_scheduled,
-            "scope": if args.wake_on_completion { Some("next_completion") } else { None::<&str> },
+            "scheduled": wake_requested,
+            "created": created.wake_created,
+            "scope": if wake_requested { Some("next_completion") } else { None::<&str> },
         },
-        "wakeScheduled": args.wake_on_completion,
-        "wakeScheduleCreated": wake_scheduled,
-        "wakeScope": if args.wake_on_completion { Some("next_completion") } else { None::<&str> },
-        "promptStatus": prompt_outcome_label(&outcome),
+        "wakeScheduled": wake_requested,
+        "wakeScheduleCreated": created.wake_created,
+        "wakeScope": if wake_requested { Some("next_completion") } else { None::<&str> },
+        "promptStatus": prompt_outcome_label(&created.prompt_outcome),
         "readCursor": { "sinceSeq": 0 },
     }))
 }
 
-fn cleanup_wake_schedule_after_failed_dispatch(
+/// Create a PEER agent the caller owns (ADR §3.4).
+///
+/// The same routine `spawn_subagent` uses, in `Owned` mode — which is the whole
+/// of the difference. What is NOT here is as important as what is: no fanout
+/// cap and no depth rule, because ruling 9 puts no numeric limit on owned
+/// agents and a peer is not subordinate to anything. What IS here is ruling 3's
+/// spawn block, enforced before dispatch reaches this function, and the
+/// caller's own workspace being writable.
+///
+/// It stays in `MUTATING_TOOL_NAMES` because it mutates exactly one workspace —
+/// the caller's, the one it creates the session in — which is the workspace the
+/// route already leased. There is no target session yet, so unlike
+/// `close_agent` there is no target permit to take first and no reason to lease
+/// anything itself.
+async fn spawn_agent(
     service: &SubagentService,
-    session_link_id: &str,
-    context: &str,
-) {
-    if let Err(error) = service.delete_wake_schedule_for_link(session_link_id) {
-        tracing::warn!(
-            session_link_id,
-            context,
-            error = ?error,
-            "failed to clean up subagent wake schedule after dispatch failure"
+    ownership: &AgentOwnershipService,
+    wake_service: &AgentWakeService,
+    session_runtime: &SessionRuntime,
+    ctx: &AgentOpsMcpContext,
+    args: SpawnAgentArgs,
+) -> anyhow::Result<Value> {
+    if !ctx.can_spawn_agent {
+        anyhow::bail!(
+            "{}",
+            ctx.spawn_agent_block_reason
+                .as_deref()
+                .unwrap_or("spawning agents is not available for this session")
         );
     }
+    let caller = service.validate_caller_can_spawn_agent(&ctx.parent_session_id)?;
+    let request = CreateAgentSessionRequest::owned_agent(&caller, args)?;
+    let wake_requested = request.wake_on_completion;
+    let applied = applied_initial_config(&request);
+    let created = create_agent_session(
+        service,
+        ownership,
+        wake_service,
+        session_runtime,
+        &caller,
+        request,
+    )
+    .await?;
+
+    Ok(json!({
+        // `sessionId` is the handle for everything afterwards: this agent is a
+        // peer, so it is addressed the way `list_agents` addresses one.
+        "sessionId": created.session.id,
+        "workspaceId": created.session.workspace_id,
+        "label": created.link.label,
+        // The ownership handle, for the subagent-vocabulary form of
+        // `close_agent`. `sessionId` works there too.
+        "agentId": created.link.public_id,
+        "ownership": "owned_agent",
+        "appliedInitialConfig": applied,
+        "wake": {
+            "scheduled": wake_requested,
+            "created": created.wake_created,
+            "scope": if wake_requested { Some("next_turn_finish") } else { None::<&str> },
+        },
+        "promptStatus": prompt_outcome_label(&created.prompt_outcome),
+    }))
 }
 
-fn cleanup_child_session_after_failed_launch(
-    service: &SubagentService,
-    child_session_id: &str,
-    context: &str,
-) {
-    if let Err(error) = service.delete_session(child_session_id) {
-        tracing::warn!(
-            child_session_id,
-            context,
-            error = ?error,
-            "failed to clean up subagent child session after launch failure"
-        );
-    }
+fn applied_initial_config(request: &CreateAgentSessionRequest) -> Value {
+    json!({
+        "harnessId": request.agent_kind,
+        "modelId": request.model_id,
+        "modeId": request.mode_id,
+    })
 }
 
 async fn send_subagent_message(

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/calls_helpers.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/calls_helpers.rs
@@ -2,6 +2,29 @@ use serde_json::{json, Value};
 
 use crate::domains::agents::readiness::launch_options::ResolvedWorkspaceLaunchOptions;
 use crate::domains::sessions::runtime::SendPromptOutcome;
+use crate::domains::sessions::subagents::service::SubagentService;
+
+/// Undo a link-scoped `wakeOnCompletion` arm whose prompt then failed to
+/// dispatch. Shared by the spawn path and `send_subagent_message`, which arm
+/// the same row for the same reason.
+///
+/// Unlike the session-scoped reply arm, this row is not shared between callers:
+/// it is keyed by the link, and only the link's parent can arm it, so removing
+/// it takes nothing away from anybody else.
+pub(super) fn cleanup_wake_schedule_after_failed_dispatch(
+    service: &SubagentService,
+    session_link_id: &str,
+    context: &str,
+) {
+    if let Err(error) = service.delete_wake_schedule_for_link(session_link_id) {
+        tracing::warn!(
+            session_link_id,
+            context,
+            error = ?error,
+            "failed to clean up subagent wake schedule after dispatch failure"
+        );
+    }
+}
 
 pub(super) fn default_model_for_agent(
     catalog: &ResolvedWorkspaceLaunchOptions,

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/context.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/context.rs
@@ -14,7 +14,10 @@ pub struct AgentOpsMcpContext {
     /// Whether this session may spawn a PEER agent. Separate from `can_create`
     /// because the fanout cap is the difference between them: an owner sitting
     /// at eight subagents may still spawn an owned agent (ruling 9), so
-    /// deriving one from the other would apply a cap the ADR removed.
+    /// deriving one from the other would apply a cap the ADR removed. It is
+    /// NOT a weaker flag: an unpromoted subagent has it false, exactly as it
+    /// has `can_create` false, because `validate_caller_can_spawn_agent` reads
+    /// subordination too.
     pub can_spawn_agent: bool,
     pub spawn_agent_block_reason: Option<String>,
     pub existing_subagent_count: usize,
@@ -93,6 +96,7 @@ fn resolve_create_block_reason(error: SubagentError) -> Result<String, ProductMc
     match error {
         reason @ (SubagentError::Disabled
         | SubagentError::DepthLimit
+        | SubagentError::Subordinate
         | SubagentError::FanoutLimit
         | SubagentError::MutationBlocked(_)) => Ok(reason.to_string()),
         not_found @ (SubagentError::ParentNotFound(_)

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/context.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/context.rs
@@ -11,6 +11,12 @@ pub struct AgentOpsMcpContext {
     pub workspace_id: String,
     pub can_create: bool,
     pub create_block_reason: Option<String>,
+    /// Whether this session may spawn a PEER agent. Separate from `can_create`
+    /// because the fanout cap is the difference between them: an owner sitting
+    /// at eight subagents may still spawn an owned agent (ruling 9), so
+    /// deriving one from the other would apply a cap the ADR removed.
+    pub can_spawn_agent: bool,
+    pub spawn_agent_block_reason: Option<String>,
     pub existing_subagent_count: usize,
     pub max_subagents_per_parent: usize,
     /// True while this session is somebody's subagent and has not been
@@ -60,6 +66,11 @@ pub fn resolve_context(
         Ok(_) => None,
         Err(error) => Some(resolve_create_block_reason(error)?),
     };
+    let spawn_agent_block_reason =
+        match service.validate_caller_can_spawn_agent(&request.session_id) {
+            Ok(_) => None,
+            Err(error) => Some(resolve_create_block_reason(error)?),
+        };
     let is_unpromoted_subagent = service
         .find_subagent_parent(&request.session_id)
         .map_err(ProductMcpContextError::Internal)?
@@ -70,6 +81,8 @@ pub fn resolve_context(
         workspace_id: request.workspace_id.clone(),
         can_create: create_block_reason.is_none(),
         create_block_reason,
+        can_spawn_agent: spawn_agent_block_reason.is_none(),
+        spawn_agent_block_reason,
         existing_subagent_count,
         max_subagents_per_parent: MAX_SUBAGENTS_PER_PARENT,
         is_unpromoted_subagent,

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/mod.rs
@@ -10,6 +10,9 @@ pub mod definition;
 // exactly the same pair, so it reuses these rather than restating a lock-order
 // contract in a second place.
 pub(crate) mod peer_ops;
+// The one routine that creates an agent, shared by both spawn shapes so they
+// cannot drift apart on anything that is not about ownership (ADR §3.3).
+mod spawn_ops;
 pub mod tools;
 
 use std::sync::Arc;

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/peer_ops.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/peer_ops.rs
@@ -524,6 +524,16 @@ mod tests {
             !body[..gate_at].contains("canonical_tool_name(name)"),
             "the spawn gate must match the wire name, not the canonicalized one"
         );
+        // Order alone would still be satisfied by a gate that logs and falls
+        // through, so the block between the check and the dispatch has to
+        // actually construct the refusal. Nothing in the crate calls
+        // `call_tool`, so this needle is what stands in for exercising it.
+        let gate_body = &body[gate_at..dispatch_at];
+        assert!(
+            gate_body.contains("return Err(anyhow::anyhow!(")
+                && gate_body.contains("is not available to a subagent"),
+            "the spawn gate must REFUSE, not merely notice: {gate_body}"
+        );
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/spawn_ops.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/spawn_ops.rs
@@ -1,0 +1,646 @@
+//! The one routine that brings a new agent into existence.
+//!
+//! `spawn_subagent` and `spawn_agent` differ in exactly one thing — what the
+//! caller ends up owning — and ADR §3.3 makes that a parameter rather than a
+//! second copy of the sequence. The sequence itself is delicate and was worth
+//! having once: create the durable row, write the ownership row, arm the wake,
+//! start the actor, dispatch the first prompt, and unwind everything on any
+//! failure so a half-built agent never survives the call.
+//!
+//! `AgentSessionOwnership` is the only branch inside it, and it decides three
+//! things at once, all of which follow from the same fact:
+//!
+//! | | Subagent | OwnedAgent |
+//! | --- | --- | --- |
+//! | link row | `relation = 'subagent'`, capped at insert | `relation = 'owned_agent'`, uncapped (ruling 9) |
+//! | first prompt | a parent delegating (link-scoped provenance) | a peer talking (envelope, ADR §3.4) |
+//! | wake | link-scoped, on the child's next completion | session-scoped, the same table `schedule_agent_wake` writes |
+//!
+//! Everything else — inheritance of the caller's harness/model/mode, the
+//! compensating cleanup, the shape of the result — is shared, which is the
+//! point: the two spawn shapes cannot drift apart on the parts that are not
+//! about ownership.
+
+use crate::domains::sessions::delegation::parent_to_child_provenance;
+use crate::domains::sessions::links::model::{SessionLinkRecord, SessionLinkRelation};
+use crate::domains::sessions::model::{SessionMcpBindingPolicy, SessionRecord};
+use crate::domains::sessions::ownership::service::AgentOwnershipService;
+use crate::domains::sessions::prompt::envelope::{agent_message, AgentMessageSender};
+use crate::domains::sessions::prompt::provenance::PromptProvenance;
+use crate::domains::sessions::runtime::{SendPromptOutcome, SessionRuntime};
+use crate::domains::sessions::store::agent_wakes::AgentWakeReason;
+use crate::domains::sessions::subagents::service::SubagentService;
+use crate::domains::sessions::wakes::service::AgentWakeService;
+use crate::origin::OriginContext;
+
+use super::calls_helpers::{cleanup_wake_schedule_after_failed_dispatch, initial_config_string};
+use super::tools::{CreateSubagentArgs, SpawnAgentArgs};
+
+/// What the caller owns once the agent exists — and therefore what the agent
+/// IS. See the module docs for the three things it decides.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum AgentSessionOwnership {
+    /// A linked subagent in the caller's own workspace: subordinate, capped,
+    /// and taken down by the caller's own close.
+    Subagent,
+    /// A peer the caller owns outright. It is never "unpromoted": it has the
+    /// full tool surface from birth, and nothing about it is subordinate
+    /// except that the caller may close it.
+    OwnedAgent,
+}
+
+impl AgentSessionOwnership {
+    /// The `session_links.relation` an agent created under this mode must end
+    /// up with. Everything downstream reads the relation and nothing else —
+    /// `cascades_to_child`, the fanout subselect, `promote`'s refusal — so the
+    /// mode and the stored row have to agree exactly.
+    fn relation(self) -> SessionLinkRelation {
+        match self {
+            Self::Subagent => SessionLinkRelation::Subagent,
+            Self::OwnedAgent => SessionLinkRelation::OwnedAgent,
+        }
+    }
+}
+
+/// A resolved request to create one agent. Building this is pure — it is the
+/// arg-to-launch-config mapping and nothing else — which is why the two tools'
+/// inheritance rules are testable without a runtime.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CreateAgentSessionRequest {
+    pub ownership: AgentSessionOwnership,
+    pub workspace_id: String,
+    pub agent_kind: String,
+    pub model_id: Option<String>,
+    pub mode_id: Option<String>,
+    pub label: Option<String>,
+    pub prompt: String,
+    pub wake_on_completion: bool,
+}
+
+/// A created, started, prompted agent.
+pub(super) struct CreatedAgentSession {
+    pub link: SessionLinkRecord,
+    pub session: SessionRecord,
+    /// `false` when no wake was asked for, or when one was already armed.
+    pub wake_created: bool,
+    pub prompt_outcome: SendPromptOutcome,
+}
+
+impl CreateAgentSessionRequest {
+    /// Resolve `spawn_subagent`'s arguments against the parent session.
+    ///
+    /// Omitted harness/model/mode inherit the parent's CURRENT values, falling
+    /// back to what it requested at launch — the behavior
+    /// `get_subagent_launch_options` advertises as
+    /// `"source": "current_parent_session"`.
+    pub fn subagent(parent: &SessionRecord, args: CreateSubagentArgs) -> anyhow::Result<Self> {
+        Self::inherit_from(
+            parent,
+            AgentSessionOwnership::Subagent,
+            args.prompt,
+            args.label,
+            args.harness_id,
+            args.initial_config.as_ref(),
+            args.wake_on_completion,
+        )
+    }
+
+    /// Resolve `spawn_agent`'s arguments against the calling session. The
+    /// inheritance rule is deliberately the same one subagents get: an agent
+    /// asking for a peer without naming a harness means "one like me".
+    pub fn owned_agent(caller: &SessionRecord, args: SpawnAgentArgs) -> anyhow::Result<Self> {
+        if let Some(requested) = args
+            .workspace_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            // The argument is accepted rather than ignored on purpose: silently
+            // dropping it would spawn the agent somewhere the caller did not
+            // ask for. Other workspaces become reachable with `spawn_workspace`
+            // (ADR §6 step 7); until then this tool creates the session in the
+            // workspace whose write lease the route already holds.
+            if requested != caller.workspace_id {
+                anyhow::bail!(
+                    "spawn_agent creates the agent in your own workspace ({}), and cannot yet \
+                     target {requested}. Send a message to an agent already in that workspace, \
+                     or ask a person to open one.",
+                    caller.workspace_id
+                );
+            }
+        }
+        Self::inherit_from(
+            caller,
+            AgentSessionOwnership::OwnedAgent,
+            args.prompt,
+            args.label,
+            args.harness_id,
+            args.initial_config.as_ref(),
+            args.wake_on_completion,
+        )
+    }
+
+    fn inherit_from(
+        caller: &SessionRecord,
+        ownership: AgentSessionOwnership,
+        prompt: String,
+        label: Option<String>,
+        harness_id: Option<String>,
+        initial_config: Option<&serde_json::Value>,
+        wake_on_completion: bool,
+    ) -> anyhow::Result<Self> {
+        if prompt.trim().is_empty() {
+            anyhow::bail!("prompt is required");
+        }
+        Ok(Self {
+            ownership,
+            workspace_id: caller.workspace_id.clone(),
+            agent_kind: harness_id.unwrap_or_else(|| caller.agent_kind.clone()),
+            model_id: initial_config_string(initial_config, &["modelId", "model"])
+                .or_else(|| caller.current_model_id.clone())
+                .or_else(|| caller.requested_model_id.clone()),
+            mode_id: initial_config_string(initial_config, &["modeId", "mode"])
+                .or_else(|| caller.current_mode_id.clone())
+                .or_else(|| caller.requested_mode_id.clone()),
+            label: label
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty()),
+            prompt,
+            wake_on_completion,
+        })
+    }
+
+    /// Whether the new session may spawn agents of its own.
+    ///
+    /// A subagent may not — that is ruling 3, and the durable flag is the
+    /// second half of the block the depth rule enforces. An owned agent may:
+    /// it is a peer from birth, never "unpromoted", so withholding the flag
+    /// would leave it permanently unable to do what a promoted agent can.
+    fn child_subagents_enabled(&self) -> bool {
+        match self.ownership {
+            AgentSessionOwnership::Subagent => false,
+            AgentSessionOwnership::OwnedAgent => true,
+        }
+    }
+}
+
+/// Create, own, start and prompt one new agent, unwinding on any failure.
+pub(super) async fn create_agent_session(
+    service: &SubagentService,
+    ownership: &AgentOwnershipService,
+    wake_service: &AgentWakeService,
+    session_runtime: &SessionRuntime,
+    caller: &SessionRecord,
+    request: CreateAgentSessionRequest,
+) -> anyhow::Result<CreatedAgentSession> {
+    let child = session_runtime
+        .create_durable_session(
+            &request.workspace_id,
+            &request.agent_kind,
+            None,
+            request.model_id.as_deref(),
+            request.mode_id.as_deref(),
+            None,
+            Vec::new(),
+            None,
+            SessionMcpBindingPolicy::InheritWorkspace,
+            request.child_subagents_enabled(),
+            OriginContext::system_local_runtime(),
+        )
+        .map_err(|error| anyhow::anyhow!("{error:?}"))?;
+
+    // The ownership row is the first thing that can legitimately refuse (the
+    // fanout cap is enforced at this insert), so it runs before anything is
+    // started and its failure only has the empty session to undo.
+    let link = match link_new_agent(service, ownership, caller, &child.id, &request) {
+        Ok(link) => link,
+        Err(error) => {
+            let _ = service.delete_session(&child.id);
+            return Err(error);
+        }
+    };
+
+    // Armed before the first prompt is dispatched: the wake fires on a
+    // COMPLETED turn, and the turn this call is about to start is the first one
+    // the caller wants to hear about.
+    let wake_created = match arm_spawn_wake(service, wake_service, caller, &child.id, &request) {
+        Ok(created) => created,
+        Err(error) => {
+            cleanup_child_session_after_failed_launch(service, &child.id, "schedule wake");
+            return Err(error);
+        }
+    };
+
+    let started = match session_runtime.start_persisted_session(&child).await {
+        Ok(started) => started,
+        Err(error) => {
+            unwind_after_failed_dispatch(service, &link, &child.id, &request, "start agent");
+            return Err(anyhow::anyhow!("{error:?}"));
+        }
+    };
+
+    let (text, provenance) = first_prompt(caller, &link, &request);
+    let prompt_outcome = match session_runtime
+        .send_text_prompt_with_provenance(&started.id, text, provenance)
+        .await
+    {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            unwind_after_failed_dispatch(
+                service,
+                &link,
+                &child.id,
+                &request,
+                "send initial prompt",
+            );
+            return Err(anyhow::anyhow!("{error:?}"));
+        }
+    };
+
+    Ok(CreatedAgentSession {
+        link,
+        session: started,
+        wake_created,
+        prompt_outcome,
+    })
+}
+
+fn link_new_agent(
+    service: &SubagentService,
+    ownership: &AgentOwnershipService,
+    caller: &SessionRecord,
+    child_session_id: &str,
+    request: &CreateAgentSessionRequest,
+) -> anyhow::Result<SessionLinkRecord> {
+    // Two writers, because they are not the same write: a subagent link goes
+    // through the atomic capped insert, an owned link through the plain one.
+    let link = match request.ownership {
+        AgentSessionOwnership::Subagent => service.link_child(
+            &caller.id,
+            child_session_id,
+            request.label.clone(),
+            None,
+            None,
+        )?,
+        AgentSessionOwnership::OwnedAgent => {
+            ownership.link_owned_agent(&caller.id, child_session_id, request.label.clone())?
+        }
+    };
+    // Which is exactly why the relation is checked rather than passed: the two
+    // paths each choose their own, and a spawn that wrote the other mode's
+    // relation would be silently wrong in every reader downstream. Failing
+    // here means the caller sees an error and the compensating delete runs,
+    // instead of an agent existing under the wrong ownership.
+    anyhow::ensure!(
+        link.relation == request.ownership.relation(),
+        "internal: a {:?} spawn wrote a '{}' ownership row",
+        request.ownership,
+        link.relation
+    );
+    Ok(link)
+}
+
+fn arm_spawn_wake(
+    service: &SubagentService,
+    wake_service: &AgentWakeService,
+    caller: &SessionRecord,
+    child_session_id: &str,
+    request: &CreateAgentSessionRequest,
+) -> anyhow::Result<bool> {
+    if !request.wake_on_completion {
+        return Ok(false);
+    }
+    match request.ownership {
+        // The link-scoped schedule, keyed by the row `link_new_agent` just
+        // wrote; it fires off the child's completion record.
+        AgentSessionOwnership::Subagent => Ok(service
+            .schedule_wake_for_target(&caller.id, None, Some(child_session_id))?
+            .1),
+        // A peer has no link the wake machinery reads, so it uses the
+        // session-scoped table — the same row `schedule_agent_wake` would
+        // write, which is what makes "interact with it afterward like any
+        // peer" true of the wake too. `ExplicitSchedule`, not `Reply`: nothing
+        // has been replied to, so no later message may consume it.
+        AgentSessionOwnership::OwnedAgent => Ok(wake_service
+            .arm(
+                &caller.id,
+                child_session_id,
+                AgentWakeReason::ExplicitSchedule,
+            )?
+            .created),
+    }
+}
+
+/// The first prompt, in the voice the relationship implies.
+///
+/// A subagent is being delegated to, so its prompt is the parent's task text
+/// with link-scoped provenance — the shape the transcript has always rendered.
+/// An owned agent is a peer being spoken to for the first time, so ADR §3.4
+/// wraps it in the same envelope every later `send_agent_message` uses: it is
+/// told who is talking and how to reply, and there is no second dialect for
+/// "the first message".
+fn first_prompt(
+    caller: &SessionRecord,
+    link: &SessionLinkRecord,
+    request: &CreateAgentSessionRequest,
+) -> (String, PromptProvenance) {
+    match request.ownership {
+        AgentSessionOwnership::Subagent => (
+            request.prompt.clone(),
+            parent_to_child_provenance(&caller.id, &link.id, request.label.clone()),
+        ),
+        AgentSessionOwnership::OwnedAgent => {
+            agent_message(&AgentMessageSender::from_session(caller), &request.prompt).into_parts()
+        }
+    }
+}
+
+/// Take back everything a failed start or dispatch left behind.
+///
+/// Deleting the session is what actually clears a session-scoped wake (the
+/// schedule rows go with the session). The link-scoped schedule is keyed by the
+/// link rather than the child, so it is deleted explicitly first — belt and
+/// braces for the case where the session delete is the thing that fails.
+fn unwind_after_failed_dispatch(
+    service: &SubagentService,
+    link: &SessionLinkRecord,
+    child_session_id: &str,
+    request: &CreateAgentSessionRequest,
+    context: &str,
+) {
+    if request.wake_on_completion && request.ownership == AgentSessionOwnership::Subagent {
+        cleanup_wake_schedule_after_failed_dispatch(service, &link.id, context);
+    }
+    cleanup_child_session_after_failed_launch(service, child_session_id, context);
+}
+
+fn cleanup_child_session_after_failed_launch(
+    service: &SubagentService,
+    child_session_id: &str,
+    context: &str,
+) {
+    if let Err(error) = service.delete_session(child_session_id) {
+        tracing::warn!(
+            child_session_id,
+            context,
+            error = ?error,
+            "failed to clean up the new agent's session after launch failure"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domains::sessions::agent_ops::tools::SpawnAgentArgs;
+    use serde_json::json;
+
+    fn session(id: &str) -> SessionRecord {
+        SessionRecord {
+            id: id.to_string(),
+            workspace_id: "workspace-1".to_string(),
+            agent_kind: "claude".to_string(),
+            native_session_id: None,
+            agent_auth_contexts: None,
+            requested_model_id: Some("requested-model".to_string()),
+            current_model_id: Some("current-model".to_string()),
+            requested_mode_id: Some("requested-mode".to_string()),
+            current_mode_id: Some("current-mode".to_string()),
+            title: Some("Schema audit".to_string()),
+            thinking_level_id: None,
+            thinking_budget_tokens: None,
+            status: "idle".to_string(),
+            created_at: "2026-08-08T00:00:00Z".to_string(),
+            updated_at: "2026-08-08T00:00:00Z".to_string(),
+            last_prompt_at: None,
+            closed_at: None,
+            dismissed_at: None,
+            mcp_bindings_ciphertext: None,
+            mcp_binding_summaries_json: None,
+            mcp_binding_policy: SessionMcpBindingPolicy::InheritWorkspace,
+            system_prompt_append: None,
+            subagents_enabled: true,
+            action_capabilities_json: None,
+            origin: None,
+        }
+    }
+
+    fn link(relation: SessionLinkRelation) -> SessionLinkRecord {
+        use crate::domains::sessions::links::model::SessionLinkWorkspaceRelation;
+        SessionLinkRecord {
+            id: "link-1".to_string(),
+            public_id: Some("subagent_abc".to_string()),
+            relation,
+            parent_session_id: "ses_caller".to_string(),
+            child_session_id: "ses_child".to_string(),
+            workspace_relation: SessionLinkWorkspaceRelation::SameWorkspace,
+            label: Some("API surface check".to_string()),
+            created_by_turn_id: None,
+            created_by_tool_call_id: None,
+            created_at: "2026-08-08T00:00:00Z".to_string(),
+            closed_at: None,
+            promoted_at: None,
+            closed_by_session_id: None,
+            close_reason: None,
+        }
+    }
+
+    fn subagent_args() -> CreateSubagentArgs {
+        CreateSubagentArgs {
+            prompt: "Audit the schema".to_string(),
+            label: Some("  API surface check  ".to_string()),
+            harness_id: None,
+            initial_config: None,
+            wake_on_completion: true,
+        }
+    }
+
+    fn spawn_agent_args() -> SpawnAgentArgs {
+        SpawnAgentArgs {
+            prompt: "Audit the schema".to_string(),
+            label: Some("  API surface check  ".to_string()),
+            harness_id: None,
+            initial_config: None,
+            wake_on_completion: true,
+            workspace_id: None,
+        }
+    }
+
+    /// The equivalence the refactor rests on. Every field `spawn_subagent`
+    /// used to compute inline is computed here now, so this is what would
+    /// catch a passthrough quietly going missing in the move.
+    #[test]
+    fn a_subagent_request_inherits_the_parent_and_carries_the_wake_flag_through() {
+        let request = CreateAgentSessionRequest::subagent(&session("ses_caller"), subagent_args())
+            .expect("build request");
+
+        assert_eq!(request.ownership, AgentSessionOwnership::Subagent);
+        assert_eq!(request.workspace_id, "workspace-1");
+        assert_eq!(request.agent_kind, "claude");
+        assert_eq!(request.model_id.as_deref(), Some("current-model"));
+        assert_eq!(request.mode_id.as_deref(), Some("current-mode"));
+        assert_eq!(request.label.as_deref(), Some("API surface check"));
+        assert_eq!(request.prompt, "Audit the schema");
+        assert!(
+            request.wake_on_completion,
+            "wakeOnCompletion must survive the arg-to-request mapping, or a spawn that asked to \
+             be woken silently is not"
+        );
+        // A subagent may not spawn: ruling 3's durable half.
+        assert!(!request.child_subagents_enabled());
+    }
+
+    #[test]
+    fn explicit_launch_choices_beat_inheritance_and_a_blank_label_is_dropped() {
+        let args = CreateSubagentArgs {
+            prompt: "Audit the schema".to_string(),
+            label: Some("   ".to_string()),
+            harness_id: Some("codex".to_string()),
+            initial_config: Some(json!({ "modelId": "gpt-5", "modeId": "plan" })),
+            wake_on_completion: false,
+        };
+
+        let request =
+            CreateAgentSessionRequest::subagent(&session("ses_caller"), args).expect("build");
+
+        assert_eq!(request.agent_kind, "codex");
+        assert_eq!(request.model_id.as_deref(), Some("gpt-5"));
+        assert_eq!(request.mode_id.as_deref(), Some("plan"));
+        assert_eq!(request.label, None);
+        assert!(!request.wake_on_completion);
+    }
+
+    #[test]
+    fn a_parent_with_no_current_values_falls_back_to_what_it_requested() {
+        let mut parent = session("ses_caller");
+        parent.current_model_id = None;
+        parent.current_mode_id = None;
+
+        let request =
+            CreateAgentSessionRequest::subagent(&parent, subagent_args()).expect("build request");
+
+        assert_eq!(request.model_id.as_deref(), Some("requested-model"));
+        assert_eq!(request.mode_id.as_deref(), Some("requested-mode"));
+    }
+
+    #[test]
+    fn an_owned_agent_inherits_the_same_way_but_is_born_able_to_spawn() {
+        let request =
+            CreateAgentSessionRequest::owned_agent(&session("ses_caller"), spawn_agent_args())
+                .expect("build request");
+
+        assert_eq!(request.ownership, AgentSessionOwnership::OwnedAgent);
+        assert_eq!(request.agent_kind, "claude");
+        assert_eq!(request.model_id.as_deref(), Some("current-model"));
+        assert_eq!(request.label.as_deref(), Some("API surface check"));
+        assert!(request.wake_on_completion);
+        // Never "unpromoted": it has the full surface from birth (ADR §3.4).
+        assert!(request.child_subagents_enabled());
+    }
+
+    #[test]
+    fn neither_spawn_accepts_an_empty_prompt() {
+        for blank in ["", "   ", "\n\t"] {
+            assert!(CreateAgentSessionRequest::subagent(
+                &session("ses_caller"),
+                CreateSubagentArgs {
+                    prompt: blank.to_string(),
+                    ..subagent_args()
+                },
+            )
+            .is_err());
+            assert!(CreateAgentSessionRequest::owned_agent(
+                &session("ses_caller"),
+                SpawnAgentArgs {
+                    prompt: blank.to_string(),
+                    ..spawn_agent_args()
+                },
+            )
+            .is_err());
+        }
+    }
+
+    #[test]
+    fn spawn_agent_takes_the_callers_own_workspace_and_refuses_another() {
+        let caller = session("ses_caller");
+
+        let same = CreateAgentSessionRequest::owned_agent(
+            &caller,
+            SpawnAgentArgs {
+                workspace_id: Some("  workspace-1  ".to_string()),
+                ..spawn_agent_args()
+            },
+        )
+        .expect("naming your own workspace is fine");
+        assert_eq!(same.workspace_id, "workspace-1");
+
+        // Refused rather than ignored: silently spawning in the caller's
+        // workspace would put the agent somewhere it was not asked for, and the
+        // route's write lease covers only this workspace anyway.
+        let error = CreateAgentSessionRequest::owned_agent(
+            &caller,
+            SpawnAgentArgs {
+                workspace_id: Some("workspace-2".to_string()),
+                ..spawn_agent_args()
+            },
+        )
+        .err()
+        .expect("another workspace is refused");
+        assert!(error.to_string().contains("workspace-2"));
+    }
+
+    #[test]
+    fn the_ownership_mode_picks_the_relation_the_link_row_gets() {
+        // An owned agent's row must NOT say `subagent`: everything downstream —
+        // the close cascade, the fanout subselect, the promote refusal — reads
+        // the relation and nothing else. `link_new_agent` checks the row it
+        // wrote against this, so a spawn that took the wrong writer fails
+        // rather than producing a mislabelled agent.
+        assert_eq!(
+            AgentSessionOwnership::Subagent.relation(),
+            SessionLinkRelation::Subagent
+        );
+        assert_eq!(
+            AgentSessionOwnership::OwnedAgent.relation(),
+            SessionLinkRelation::OwnedAgent
+        );
+    }
+
+    #[test]
+    fn a_subagents_first_prompt_is_the_authored_text_and_a_peers_is_enveloped() {
+        let caller = session("ses_caller");
+        let mut request =
+            CreateAgentSessionRequest::subagent(&caller, subagent_args()).expect("build");
+
+        let (text, provenance) =
+            first_prompt(&caller, &link(SessionLinkRelation::Subagent), &request);
+        assert_eq!(text, "Audit the schema");
+        assert_eq!(
+            provenance,
+            PromptProvenance::AgentSession {
+                source_session_id: "ses_caller".to_string(),
+                session_link_id: Some("link-1".to_string()),
+                label: Some("API surface check".to_string()),
+            }
+        );
+
+        request.ownership = AgentSessionOwnership::OwnedAgent;
+        let (text, provenance) =
+            first_prompt(&caller, &link(SessionLinkRelation::OwnedAgent), &request);
+        // The peer is told who is talking and how to answer, and the body is
+        // verbatim inside it — the same envelope `send_agent_message` builds.
+        assert!(text.starts_with("Message from agent \"Schema audit\" (session ses_caller):"));
+        assert!(text.contains("Audit the schema"));
+        assert!(text.ends_with("To reply, use send_agent_message with sessionId \"ses_caller\"."));
+        assert_eq!(
+            provenance,
+            PromptProvenance::AgentSession {
+                source_session_id: "ses_caller".to_string(),
+                // Unlinked, like every other peer message: the ownership row
+                // exists, but the message does not claim it.
+                session_link_id: None,
+                label: Some("Schema audit".to_string()),
+            }
+        );
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/spawn_ops.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/spawn_ops.rs
@@ -14,7 +14,7 @@
 //! | --- | --- | --- |
 //! | link row | `relation = 'subagent'`, capped at insert | `relation = 'owned_agent'`, uncapped (ruling 9) |
 //! | first prompt | a parent delegating (link-scoped provenance) | a peer talking (envelope, ADR §3.4) |
-//! | wake | link-scoped, on the child's next completion | session-scoped, the same table `schedule_agent_wake` writes |
+//! | wake | link-scoped, on the child's next completion | session-scoped and reply-consumable, the same row a `wakeOnReply` send arms |
 //!
 //! Everything else — inheritance of the caller's harness/model/mode, the
 //! compensating cleanup, the shape of the result — is shared, which is the
@@ -319,14 +319,16 @@ fn arm_spawn_wake(
         // A peer has no link the wake machinery reads, so it uses the
         // session-scoped table — the same row `schedule_agent_wake` would
         // write, which is what makes "interact with it afterward like any
-        // peer" true of the wake too. `ExplicitSchedule`, not `Reply`: nothing
-        // has been replied to, so no later message may consume it.
+        // peer" true of the wake too. The reason is `Reply`, because a spawn
+        // IS a send awaiting an answer: the first prompt is the question, and
+        // the peer's reply is the answer that makes the pointer redundant.
+        // `ExplicitSchedule` would survive that reply and wake the owner a
+        // second time with a contentless pointer to a message it already has —
+        // and, because a re-arm keeps the STRONGER reason, would swallow any
+        // `wakeOnReply` the owner armed on the same peer before that first
+        // turn finished, disabling its consumption too.
         AgentSessionOwnership::OwnedAgent => Ok(wake_service
-            .arm(
-                &caller.id,
-                child_session_id,
-                AgentWakeReason::ExplicitSchedule,
-            )?
+            .arm(&caller.id, child_session_id, AgentWakeReason::Reply)?
             .created),
     }
 }
@@ -392,8 +394,15 @@ fn cleanup_child_session_after_failed_launch(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::test_support;
+    use crate::domains::sessions::admission::{NoControllerPolicy, SessionMutationAdmission};
+    use crate::domains::sessions::agent_ops::peer_ops::consume_reply_wake;
     use crate::domains::sessions::agent_ops::tools::SpawnAgentArgs;
+    use crate::domains::sessions::extensions::SessionTurnOutcome;
+    use crate::domains::sessions::store::SessionStore;
+    use crate::persistence::Db;
     use serde_json::json;
+    use std::sync::Arc;
 
     fn session(id: &str) -> SessionRecord {
         SessionRecord {
@@ -603,6 +612,185 @@ mod tests {
         assert_eq!(
             AgentSessionOwnership::OwnedAgent.relation(),
             SessionLinkRelation::OwnedAgent
+        );
+    }
+
+    /// The wake half of the spawn, over real stores.
+    ///
+    /// Both writers this function chooses between are store-backed, so the
+    /// choice is provable without a runtime: arm through the production
+    /// `arm_spawn_wake` and read the rows back. `ses_owner` spawns, `ses_peer`
+    /// is the agent it spawns.
+    struct WakeFixture {
+        subagents: SubagentService,
+        wakes: AgentWakeService,
+        sessions: SessionStore,
+        owner: SessionRecord,
+    }
+
+    fn wake_fixture() -> WakeFixture {
+        let db = Db::open_in_memory().expect("open db");
+        test_support::seed_workspace_with_repo_root(&db, "workspace-1", "local", "/tmp/workspace-1");
+        let fixture = test_support::subagent_service_fixture(&db);
+        let owner = session("ses_owner");
+        fixture.sessions.insert(&owner).expect("insert owner");
+        fixture
+            .sessions
+            .insert(&session("ses_peer"))
+            .expect("insert peer");
+        let wakes = AgentWakeService::new(
+            fixture.sessions.clone(),
+            Arc::new(SessionMutationAdmission::new(Arc::new(NoControllerPolicy))),
+        );
+        WakeFixture {
+            subagents: fixture.service,
+            wakes,
+            sessions: fixture.sessions,
+            owner,
+        }
+    }
+
+    fn peer_request(wake_on_completion: bool) -> CreateAgentSessionRequest {
+        CreateAgentSessionRequest::owned_agent(
+            &session("ses_owner"),
+            SpawnAgentArgs {
+                wake_on_completion,
+                ..spawn_agent_args()
+            },
+        )
+        .expect("build request")
+    }
+
+    #[tokio::test]
+    async fn the_peers_reply_consumes_the_wake_its_spawn_armed() {
+        // The arg description promises exactly this: "its reply already wakes
+        // you with the full message; this is the safety net for one that
+        // answers nobody". Only a REPLY arm behaves that way — an explicit
+        // schedule survives the reply and fires a second, contentless pointer
+        // at the same turn's end, so the owner burns a turn on a pointer to a
+        // message it already has.
+        let fixture = wake_fixture();
+
+        assert!(arm_spawn_wake(
+            &fixture.subagents,
+            &fixture.wakes,
+            &fixture.owner,
+            "ses_peer",
+            &peer_request(true),
+        )
+        .expect("arm the spawn wake"));
+
+        let armed = fixture
+            .sessions
+            .list_agent_wakes_for_target("ses_peer")
+            .expect("read the armed row");
+        assert_eq!(armed.len(), 1);
+        assert_eq!(armed[0].watcher_session_id, "ses_owner");
+        assert!(
+            armed[0].armed_for_reply,
+            "a spawn wake must be consumable by the peer's reply"
+        );
+
+        // The peer answers its owner: the schedule comes off...
+        assert!(consume_reply_wake(&fixture.wakes, "ses_peer", "ses_owner"));
+        // ...so the turn that carried the reply wakes nobody, and no pointer
+        // is queued behind the message the owner already received.
+        assert!(fixture
+            .wakes
+            .consume_for_finished_turn("ses_peer", SessionTurnOutcome::Completed)
+            .await
+            .expect("the peer's first turn finishes")
+            .is_empty());
+        assert!(fixture
+            .sessions
+            .list_pending_prompts("ses_owner")
+            .expect("owner's pending prompts")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_peer_that_answers_nobody_still_wakes_its_owner_at_turn_finish() {
+        // The other half of the same contract: the safety net has to actually
+        // catch. Nothing replied, so the schedule is still armed when the turn
+        // ends and the owner gets its pointer.
+        let fixture = wake_fixture();
+        arm_spawn_wake(
+            &fixture.subagents,
+            &fixture.wakes,
+            &fixture.owner,
+            "ses_peer",
+            &peer_request(true),
+        )
+        .expect("arm the spawn wake");
+
+        let fired = fixture
+            .wakes
+            .consume_for_finished_turn("ses_peer", SessionTurnOutcome::Completed)
+            .await
+            .expect("the peer's first turn finishes");
+
+        assert_eq!(fired.len(), 1);
+        assert_eq!(fired[0].consumed.watcher_session_id, "ses_owner");
+    }
+
+    #[tokio::test]
+    async fn a_spawn_that_asked_for_no_wake_arms_nothing() {
+        // `wakeOnCompletion: false` must leave the table empty — otherwise the
+        // owner is woken about an agent it said it did not need to hear from.
+        let fixture = wake_fixture();
+
+        assert!(!arm_spawn_wake(
+            &fixture.subagents,
+            &fixture.wakes,
+            &fixture.owner,
+            "ses_peer",
+            &peer_request(false),
+        )
+        .expect("no wake asked for"));
+
+        assert!(fixture
+            .sessions
+            .list_agent_wakes_for_target("ses_peer")
+            .expect("read schedules")
+            .is_empty());
+    }
+
+    #[test]
+    fn a_subagent_spawn_takes_the_link_scoped_wake_and_writes_no_session_row() {
+        // The other side of the mode split. A subagent's wake hangs off the
+        // link completion row, so the session-scoped table must stay empty —
+        // if both were written the parent would be woken twice, and if the
+        // peer branch leaked into this one the wake would fire off a
+        // completion record that never arrives.
+        let fixture = wake_fixture();
+        fixture
+            .sessions
+            .insert(&session("ses_child"))
+            .expect("insert child");
+        fixture
+            .subagents
+            .link_child("ses_owner", "ses_child", None, None, None)
+            .expect("link the subagent");
+
+        let mut request = peer_request(true);
+        request.ownership = AgentSessionOwnership::Subagent;
+
+        assert!(arm_spawn_wake(
+            &fixture.subagents,
+            &fixture.wakes,
+            &fixture.owner,
+            "ses_child",
+            &request,
+        )
+        .expect("arm the subagent wake"));
+
+        assert!(
+            fixture
+                .sessions
+                .list_agent_wakes_for_target("ses_child")
+                .expect("read schedules")
+                .is_empty(),
+            "a subagent's wake is link-scoped and must not write a session-scoped row"
         );
     }
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/tools.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/tools.rs
@@ -32,9 +32,16 @@ pub const DEPRECATED_TOOL_ALIASES: &[(&str, &str)] = &[
 // reasons — and it must, because a close acts on the target session and so
 // takes that session's mutation permit, which has to be OUTSIDE any workspace
 // lease.
+//
+// `spawn_agent` IS here, and for the opposite reason to `close_agent`: a spawn
+// has no target yet, so there is no target session permit to take and no other
+// workspace involved. What it mutates is the CALLER's workspace — it creates a
+// session in it — which is precisely the workspace the route's lease covers,
+// exactly as for `spawn_subagent`.
 pub const MUTATING_TOOL_NAMES: &[&str] = &[
     "spawn_subagent",
     "create_subagent",
+    "spawn_agent",
     "send_subagent_message",
     "schedule_subagent_wake",
     "schedule_agent_wake",
@@ -51,6 +58,7 @@ pub const SPAWN_STYLE_TOOL_NAMES: &[&str] = &[
     "get_subagent_launch_options",
     "spawn_subagent",
     "create_subagent",
+    "spawn_agent",
 ];
 
 pub fn is_spawn_style_tool(name: &str) -> bool {
@@ -77,6 +85,27 @@ pub struct CreateSubagentArgs {
     pub initial_config: Option<Value>,
     #[serde(default)]
     pub wake_on_completion: bool,
+}
+
+/// `spawn_agent`'s arguments. Deliberately the same shape as
+/// `CreateSubagentArgs` — the launch vocabulary an agent already knows — plus
+/// `workspaceId`, which ADR §3.4 names. Until `spawn_workspace` lands there is
+/// only one workspace this tool can use, so naming a different one is refused
+/// rather than ignored (`spawn_ops::CreateAgentSessionRequest::owned_agent`).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpawnAgentArgs {
+    pub prompt: String,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub harness_id: Option<String>,
+    #[serde(default)]
+    pub initial_config: Option<Value>,
+    #[serde(default)]
+    pub wake_on_completion: bool,
+    #[serde(default)]
+    pub workspace_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -342,6 +371,39 @@ pub fn build_tool_list(ctx: &AgentOpsMcpContext) -> Vec<Value> {
         ),
     ]);
 
+    // Advertised on `can_spawn_agent`, NOT `can_create`: the fanout cap bounds
+    // subordinates, and an owned agent is not one (ruling 9). A parent sitting
+    // at eight subagents can still spawn a peer.
+    if ctx.can_spawn_agent && !ctx.is_unpromoted_subagent {
+        tools.push(tool_definition(
+            "spawn_agent",
+            "Create a new top-level agent you own, in your workspace, and send it a first message. \
+             It is a PEER, not a subagent: it is not capped, it does not close when you close, and \
+             it can spawn agents of its own from the start. Talk to it afterwards with \
+             send_agent_message and its sessionId, exactly like any other agent. Use \
+             spawn_subagent instead when you want a subordinate helper that closes with you.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "prompt": { "type": "string", "description": "First message, delivered inside an envelope naming you and your session id so the agent can reply." },
+                    "label": { "type": "string", "description": "Short name for the agent, shown wherever it appears." },
+                    "harnessId": { "type": "string", "description": "Defaults to your own harness. See get_subagent_launch_options for what this workspace can launch." },
+                    "initialConfig": {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "properties": {
+                            "modelId": { "type": "string" },
+                            "modeId": { "type": "string" }
+                        }
+                    },
+                    "wakeOnCompletion": { "type": "boolean", "description": "Wake you when the new agent finishes its first turn. Its reply already wakes you with the full message; this is the safety net for one that answers nobody." },
+                    "workspaceId": { "type": "string", "description": "Must be your own workspace. Spawning into another workspace is not available yet." }
+                },
+                "required": ["prompt"]
+            }),
+        ));
+    }
+
     if ctx.can_create && !ctx.is_unpromoted_subagent {
         tools.push(
             tool_definition(
@@ -491,6 +553,11 @@ mod tests {
             } else {
                 Some("blocked".to_string())
             },
+            // Independent of `can_create` on purpose: the cases these tests
+            // build `can_create = false` for are the fanout cap, which does not
+            // bound owned agents (ruling 9).
+            can_spawn_agent: true,
+            spawn_agent_block_reason: None,
             existing_subagent_count,
             max_subagents_per_parent: 8,
             is_unpromoted_subagent: false,
@@ -811,6 +878,10 @@ mod tests {
         assert!(is_spawn_style_tool("create_subagent"));
         assert!(is_spawn_style_tool("spawn_subagent"));
         assert!(is_spawn_style_tool("get_subagent_launch_options"));
+        // Ruling 3 says ANY spawn-style tool, and spawning a peer is the most
+        // spawn-style thing there is: an unpromoted subagent that could reach
+        // this would be spawning its way around the block it is under.
+        assert!(is_spawn_style_tool("spawn_agent"));
         assert!(!is_spawn_style_tool("send_agent_message"));
         assert!(!is_spawn_style_tool("close_agent"));
         for (alias, canonical) in DEPRECATED_TOOL_ALIASES {
@@ -821,6 +892,98 @@ mod tests {
                 );
             }
         }
+    }
+
+    // --- spawn_agent (ADR §3.4, ruling 9) --------------------------------
+
+    #[test]
+    fn an_unpromoted_subagent_is_offered_no_way_to_spawn_a_peer_either() {
+        let names = tool_names(&build_tool_list(&unpromoted_subagent_context()))
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+
+        assert!(
+            !names.iter().any(|name| name == "spawn_agent"),
+            "spawn_agent is advertised to an unpromoted subagent"
+        );
+        // And the gate that actually binds, since the list above is frozen at
+        // launch: dispatch refuses the wire name.
+        assert!(is_spawn_style_tool("spawn_agent"));
+    }
+
+    #[test]
+    fn a_capped_parent_can_still_spawn_a_peer() {
+        // Ruling 9: the cap of eight bounds LINKED children. An owned agent is
+        // not one, so the fanout cap must not reach it — which is the whole
+        // reason `can_spawn_agent` is not derived from `can_create`.
+        let capped = build_tool_list(&context(false, 8));
+        let names = tool_names(&capped);
+
+        assert!(
+            !names.contains(&"spawn_subagent"),
+            "the cap still bites subagents"
+        );
+        assert!(names.contains(&"spawn_agent"));
+    }
+
+    #[test]
+    fn spawn_agent_is_withheld_when_the_caller_itself_cannot_create_agents() {
+        // Not a cap — the caller's own state (closed, disabled, an ineligible
+        // or unwritable workspace) is what `can_spawn_agent` reports.
+        let blocked = AgentOpsMcpContext {
+            can_spawn_agent: false,
+            spawn_agent_block_reason: Some("subagents are disabled for this session".to_string()),
+            ..context(true, 0)
+        };
+
+        assert!(!tool_names(&build_tool_list(&blocked)).contains(&"spawn_agent"));
+    }
+
+    #[test]
+    fn spawn_agent_takes_the_subagent_launch_vocabulary_plus_a_workspace() {
+        let spawn = build_tool_list(&context(true, 1))
+            .into_iter()
+            .find(|tool| tool.get("name").and_then(Value::as_str) == Some("spawn_agent"))
+            .expect("spawn_agent is advertised");
+
+        for field in [
+            "prompt",
+            "label",
+            "harnessId",
+            "initialConfig",
+            "wakeOnCompletion",
+        ] {
+            assert!(
+                spawn
+                    .pointer(&format!("/inputSchema/properties/{field}"))
+                    .is_some(),
+                "spawn_agent does not accept {field}, which spawn_subagent does"
+            );
+        }
+        // ADR §3.4 names `workspaceId`. It is accepted so that passing it is an
+        // explicit refusal rather than a silent spawn somewhere else.
+        assert!(spawn
+            .pointer("/inputSchema/properties/workspaceId")
+            .is_some());
+        assert_eq!(
+            spawn
+                .pointer("/inputSchema/required")
+                .and_then(Value::as_array)
+                .map(|required| required.len()),
+            Some(1),
+            "only the first message is required"
+        );
+    }
+
+    #[test]
+    fn spawn_agent_leases_at_the_route_because_it_creates_in_the_callers_workspace() {
+        // The mirror of `close_agent`: a close acts on an existing target
+        // session somewhere else, so it fences itself. A spawn has no target
+        // yet — what it mutates is the caller's own workspace, which is exactly
+        // what the route leased.
+        assert!(MUTATING_TOOL_NAMES.contains(&"spawn_agent"));
+        assert!(MUTATING_TOOL_NAMES.contains(&"spawn_subagent"));
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/tools.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/tools.rs
@@ -388,12 +388,20 @@ pub fn build_tool_list(ctx: &AgentOpsMcpContext) -> Vec<Value> {
                     "prompt": { "type": "string", "description": "First message, delivered inside an envelope naming you and your session id so the agent can reply." },
                     "label": { "type": "string", "description": "Short name for the agent, shown wherever it appears." },
                     "harnessId": { "type": "string", "description": "Defaults to your own harness. See get_subagent_launch_options for what this workspace can launch." },
+                    // Open, and open for the same reason `spawn_subagent` is:
+                    // one launch vocabulary across both spawns, so an agent
+                    // that learned one does not meet a stricter second. Only
+                    // `modelId` and `modeId` are read; `appliedInitialConfig`
+                    // in the result is what the new agent actually launched
+                    // with, so anything else passed is visibly absent there
+                    // rather than silently honoured. Tightening it is a change
+                    // to make on both tools at once or not at all.
                     "initialConfig": {
                         "type": "object",
                         "additionalProperties": true,
                         "properties": {
-                            "modelId": { "type": "string" },
-                            "modeId": { "type": "string" }
+                            "modelId": { "type": "string", "description": "Defaults to your current model." },
+                            "modeId": { "type": "string", "description": "Defaults to your current mode." }
                         }
                     },
                     "wakeOnCompletion": { "type": "boolean", "description": "Wake you when the new agent finishes its first turn. Its reply already wakes you with the full message; this is the safety net for one that answers nobody." },

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/ownership/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/ownership/service.rs
@@ -4,8 +4,12 @@
 //! stopping an agent is the runtime's job (`close_session_tree`); this module
 //! decides WHETHER the caller may, and leaves the row that says who did it.
 
-use crate::domains::sessions::links::model::{SessionLinkRecord, SessionLinkRelation};
-use crate::domains::sessions::links::service::SessionLinkService;
+use crate::domains::sessions::links::model::{
+    SessionLinkRecord, SessionLinkRelation, SessionLinkWorkspaceRelation,
+};
+use crate::domains::sessions::links::service::{
+    CreateSessionLinkError, CreateSessionLinkInput, SessionLinkService,
+};
 use crate::domains::sessions::model::SessionRecord;
 use crate::domains::sessions::store::SessionStore;
 
@@ -30,6 +34,8 @@ pub enum OwnershipError {
     NotASubagent,
     #[error("that agent is closed")]
     Closed,
+    #[error(transparent)]
+    Link(#[from] CreateSessionLinkError),
     #[error(transparent)]
     Internal(#[from] anyhow::Error),
 }
@@ -126,6 +132,37 @@ impl AgentOwnershipService {
             .find_by_id(&link.child_session_id)?
             .ok_or_else(|| OwnershipError::TargetNotFound(link.child_session_id.clone()))?;
         Ok(OwnedAgent { link, target })
+    }
+
+    /// Record that `owner` owns a newly spawned PEER agent.
+    ///
+    /// `relation = 'owned_agent'` is the whole of the difference from a
+    /// subagent link (ADR §3.2): no fanout cap, no depth rule, and
+    /// `runtime::lifecycle::cascades_to_child` never follows the row, so
+    /// closing the owner leaves this agent running. The row exists at all
+    /// because ownership has to be readable — it is what lets the creator
+    /// close this agent later.
+    ///
+    /// `spawn_agent` is this relation's only producer. Promotion never writes
+    /// it: a promoted subagent keeps `relation = 'subagent'` and gains
+    /// `promoted_at`, because the row also records how the agent came to be.
+    pub fn link_owned_agent(
+        &self,
+        owner_session_id: &str,
+        agent_session_id: &str,
+        label: Option<String>,
+    ) -> Result<SessionLinkRecord, OwnershipError> {
+        Ok(self.link_service.create_link(CreateSessionLinkInput {
+            relation: SessionLinkRelation::OwnedAgent,
+            parent_session_id: owner_session_id.to_string(),
+            child_session_id: agent_session_id.to_string(),
+            // The agent is a peer, but it is still born in one workspace, and
+            // in this tool that is the caller's own.
+            workspace_relation: SessionLinkWorkspaceRelation::SameWorkspace,
+            label,
+            created_by_turn_id: None,
+            created_by_tool_call_id: None,
+        })?)
     }
 
     /// Promote one of the caller's linked subagents to a peer.
@@ -433,6 +470,73 @@ mod tests {
             .err()
             .expect("an owned agent cannot be promoted");
         assert!(matches!(error, OwnershipError::NotASubagent));
+    }
+
+    #[test]
+    fn spawning_a_peer_writes_an_owned_agent_row_the_owner_resolves() {
+        // ADR §3.2's settled ruling, at the only place that writes it:
+        // `spawn_agent` creates `relation = 'owned_agent'`. If this wrote
+        // 'subagent' the new agent would silently acquire everything
+        // subordination implies — a fanout slot, the close cascade, and the
+        // spawn block — none of which a peer is under.
+        let fixture = fixture(&["ses_owner", "ses_peer"]);
+
+        let link = fixture
+            .ownership
+            .link_owned_agent("ses_owner", "ses_peer", Some("Schema audit".to_string()))
+            .expect("link the owned agent");
+
+        assert_eq!(link.relation, SessionLinkRelation::OwnedAgent);
+        assert_eq!(link.parent_session_id, "ses_owner");
+        assert_eq!(link.child_session_id, "ses_peer");
+        assert_eq!(link.label.as_deref(), Some("Schema audit"));
+        // Born a peer, not promoted into one: `promoted_at` describes a
+        // subagent's history and this agent never had that history.
+        assert!(link.promoted_at.is_none());
+        assert!(!link.is_unpromoted_subagent());
+        assert!(link
+            .public_id
+            .as_deref()
+            .is_some_and(|id| id.starts_with("agent_")));
+
+        // The row is ownership, so close and promote resolve it — and the peer
+        // is not promotable, because it is already top level.
+        let owned = fixture
+            .ownership
+            .resolve_owned("ses_owner", None, Some("ses_peer"))
+            .expect("the owner owns it");
+        assert_eq!(owned.link.id, link.id);
+        assert!(matches!(
+            fixture.ownership.promote(&owned).err(),
+            Some(OwnershipError::NotASubagent)
+        ));
+    }
+
+    #[test]
+    fn an_owned_agent_link_does_not_claim_a_subagent_parent_slot() {
+        // Negative control on the relation: the child of an owned link must not
+        // read as somebody's subagent anywhere, or the depth rule and the
+        // fanout count would both pick it up.
+        let fixture = fixture(&["ses_owner", "ses_peer"]);
+        fixture
+            .ownership
+            .link_owned_agent("ses_owner", "ses_peer", None)
+            .expect("link the owned agent");
+
+        assert!(fixture
+            .links
+            .find_subagent_parent("ses_peer")
+            .expect("subagent parent lookup")
+            .is_none());
+        assert!(fixture
+            .links
+            .list_subagent_children("ses_owner")
+            .expect("subagent children")
+            .is_empty());
+        assert!(!fixture
+            .ownership
+            .is_unpromoted_subagent("ses_peer")
+            .expect("spawn block lookup"));
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/service.rs
@@ -41,6 +41,8 @@ pub enum SubagentError {
     CrossWorkspace,
     #[error("subagent children cannot create subagents")]
     DepthLimit,
+    #[error("a subagent cannot spawn agents of its own until it is promoted")]
+    Subordinate,
     #[error("subagents are disabled for this session")]
     Disabled,
     #[error("parent already has the maximum number of subagents")]
@@ -135,20 +137,35 @@ impl SubagentService {
 
     /// The `spawn_agent` form of [`Self::validate_parent_can_spawn`].
     ///
-    /// An owned agent is a PEER: ruling 9 puts no numeric limit on it and there
-    /// is no subordination to depth-limit, so neither the fanout cap nor the
-    /// depth rule applies. Everything about the CALLER still does, plus the
-    /// workspace the new session lands in being mutable — which for this tool
-    /// is the caller's own, the one whose write lease the route already took.
+    /// What the two forms do NOT share is everything the fanout cap and the
+    /// depth rule say about the agent being CREATED: an owned agent is a peer,
+    /// ruling 9 puts no numeric limit on it, and it is subordinate to nobody,
+    /// so a caller holding eight subagents may still spawn one. What they do
+    /// share is every rule about the CALLER — including subordination, below —
+    /// plus the workspace the new session lands in being mutable, which for
+    /// this tool is the caller's own, the one whose write lease the route
+    /// already took.
     ///
-    /// The one gate NOT restated here is ruling 3's spawn block: an unpromoted
-    /// subagent is refused before dispatch reaches any tool body
-    /// (`agent_ops::calls::call_tool`), where the refusal can say why.
+    /// Ruling 3's spawn block IS restated here, even though
+    /// `agent_ops::calls::call_tool` already refuses an unpromoted subagent
+    /// before dispatch reaches any tool body. The dispatch gate is where the
+    /// refusal can say why; this is the gate that makes the capability itself
+    /// false, so `can_spawn_agent` means what its name claims and the tool body
+    /// refuses on its own rather than trusting one caller to have checked.
+    /// Subordination is read exactly as the depth rule reads it — an open
+    /// subagent link naming this session as the child, not yet promoted.
     pub fn validate_caller_can_spawn_agent(
         &self,
         caller_session_id: &str,
     ) -> Result<SessionRecord, SubagentError> {
         let caller = self.validate_caller_can_create(caller_session_id)?;
+        if self
+            .link_service
+            .find_subagent_parent(caller_session_id)?
+            .is_some_and(|link| link.is_unpromoted_subagent())
+        {
+            return Err(SubagentError::Subordinate);
+        }
         self.access_gate
             .assert_can_mutate_for_workspace(&caller.workspace_id)
             .map_err(map_access_error)?;
@@ -668,16 +685,8 @@ fn map_access_error(error: WorkspaceAccessError) -> SubagentError {
 mod tests {
     use super::*;
     use crate::app::test_support;
-    use crate::domains::repo_roots::service::RepoRootService;
-    use crate::domains::repo_roots::store::RepoRootStore;
-    use crate::domains::sessions::links::store::SessionLinkStore;
     use crate::domains::sessions::model::SessionMcpBindingPolicy;
-    use crate::domains::terminals::store::TerminalStore;
-    use crate::live::terminals::TerminalService;
-    use crate::domains::workspaces::deletion::WorkspaceDeleteWorkflow;
-    use crate::domains::workspaces::store::{WorkspaceAccessStore, WorkspaceStore};
     use crate::persistence::Db;
-    use std::sync::Arc;
 
     /// `spawn_subagent` creates every child with `subagents_enabled = false`;
     /// a human-created session carries the user's preference.
@@ -711,60 +720,17 @@ mod tests {
         }
     }
 
-    fn fixture() -> (SubagentService, SessionLinkService) {
+    fn fixture(session_ids: &[&str]) -> test_support::SubagentServiceFixture {
         let db = Db::open_in_memory().expect("open db");
-        test_support::seed_workspace_with_repo_root(
-            &db,
-            "workspace-1",
-            "local",
-            "/tmp/workspace-1",
-        );
-        let runtime_home = std::env::temp_dir().join(format!(
-            "anyharness-subagents-test-{}",
-            uuid::Uuid::new_v4()
-        ));
-        let session_store = SessionStore::new(db.clone());
-        let link_service =
-            SessionLinkService::new(SessionLinkStore::new(db.clone()), session_store.clone());
-        let workspace_runtime = Arc::new(WorkspaceRuntime::new(
-            WorkspaceStore::new(db.clone()),
-            WorkspaceDeleteWorkflow::new(db.clone(), SessionDeleteWorkflow::new(db.clone())),
-            RepoRootService::new(RepoRootStore::new(db.clone())),
-            runtime_home.clone(),
-        ));
-        let access_gate = Arc::new(WorkspaceAccessGate::new(
-            WorkspaceStore::new(db.clone()),
-            session_store.clone(),
-            WorkspaceAccessStore::new(db.clone()),
-            Arc::new(TerminalService::new(
-                TerminalStore::new(db.clone()),
-                runtime_home,
-            )),
-        ));
-        let service = SubagentService::new(
-            session_store,
-            SessionDeleteWorkflow::new(db.clone()),
-            link_service.clone(),
-            SubagentStore::new(db),
-            workspace_runtime,
-            access_gate,
-        );
-        (service, link_service)
-    }
-
-    fn link_child(links: &SessionLinkService, parent: &str, child: &str) -> String {
-        links
-            .create_link(CreateSessionLinkInput {
-                relation: SessionLinkRelation::Subagent,
-                parent_session_id: parent.to_string(),
-                child_session_id: child.to_string(),
-                workspace_relation: SessionLinkWorkspaceRelation::SameWorkspace,
-                label: Some("Schema audit".to_string()),
-                created_by_turn_id: None,
-                created_by_tool_call_id: None,
-            })
-            .expect("create link")
-            .id
+        test_support::seed_workspace_with_repo_root(&db, "workspace-1", "local", "/tmp/workspace-1");
+        let fixture = test_support::subagent_service_fixture(&db);
+        for id in session_ids {
+            fixture
+                .sessions
+                .insert(&session_record(id, true))
+                .expect("insert session");
+        }
+        fixture
     }
 
     /// Ruling 7 / ADR §3.3: promotion makes a child a peer, and a peer spawns.
@@ -773,32 +739,39 @@ mod tests {
     /// lift the born-with block as well or it lifts nothing that exists.
     #[test]
     fn promotion_lets_a_spawned_child_spawn_its_own_agents() {
-        let (service, links) = fixture();
-        let store = service.session_store();
-        store
-            .insert(&session_record("ses_parent", true))
-            .expect("insert parent");
+        let fixture = fixture(&["ses_parent"]);
         // Exactly how `spawn_subagent` creates a child.
-        store
+        fixture
+            .sessions
             .insert(&session_record("ses_child", false))
             .expect("insert child");
-        store
+        fixture
+            .sessions
             .insert(&session_record("ses_sibling", false))
             .expect("insert sibling");
-        let child_link = link_child(&links, "ses_parent", "ses_child");
-        link_child(&links, "ses_parent", "ses_sibling");
+        let child_link = fixture
+            .service
+            .link_child("ses_parent", "ses_child", None, None, None)
+            .expect("link the child")
+            .id;
+        fixture
+            .service
+            .link_child("ses_parent", "ses_sibling", None, None, None)
+            .expect("link the sibling");
 
         // Before promotion the child is subordinate and cannot spawn.
         assert!(matches!(
-            service.validate_parent_can_spawn("ses_child"),
+            fixture.service.validate_parent_can_spawn("ses_child"),
             Err(SubagentError::Disabled)
         ));
 
-        assert!(links
+        assert!(fixture
+            .links
             .promote_link(&child_link, "2026-08-08T01:00:00Z")
             .expect("promote the child"));
 
-        service
+        fixture
+            .service
             .validate_parent_can_spawn("ses_child")
             .expect("a promoted agent is a peer and may spawn its own children");
 
@@ -806,7 +779,7 @@ mod tests {
         // only. The sibling, still owned, is still refused — so the assertion
         // above is the promotion and not a blanket removal of the check.
         assert!(matches!(
-            service.validate_parent_can_spawn("ses_sibling"),
+            fixture.service.validate_parent_can_spawn("ses_sibling"),
             Err(SubagentError::Disabled)
         ));
     }
@@ -816,26 +789,137 @@ mod tests {
     /// both keep the refusal.
     #[test]
     fn a_session_with_subagents_switched_off_is_still_refused() {
-        let (service, _links) = fixture();
-        service
-            .session_store()
+        let fixture = fixture(&[]);
+        fixture
+            .sessions
             .insert(&session_record("ses_solo_off", false))
             .expect("insert session");
-        service
-            .session_store()
+        fixture
+            .sessions
             .insert(&session_record("ses_solo_on", true))
             .expect("insert session");
 
         assert!(matches!(
-            service.validate_parent_can_spawn("ses_solo_off"),
+            fixture.service.validate_parent_can_spawn("ses_solo_off"),
             Err(SubagentError::Disabled)
         ));
 
         // Non-vacuity: an otherwise identical session with the preference on
         // passes every gate in this validation, so `Disabled` above is the flag
         // and not some other refusal in the fixture.
-        service
+        fixture
+            .service
             .validate_parent_can_spawn("ses_solo_on")
             .expect("an ordinary session with subagents enabled may spawn");
+    }
+
+    #[test]
+    fn an_unpromoted_subagent_may_not_spawn_a_peer_either() {
+        // Ruling 3 is about SUBORDINATION, not about which spawn tool is being
+        // called: a session that may not create a subagent may not create a
+        // peer that outlives its parent either. Enforced here rather than only
+        // at `call_tool` so `can_spawn_agent` is false for the caller and the
+        // tool body refuses on its own — any future path into
+        // `calls::spawn_agent` that skips the dispatch gate still stops.
+        let fixture = fixture(&["ses_owner", "ses_subagent"]);
+        let link = fixture
+            .service
+            .link_child("ses_owner", "ses_subagent", None, None, None)
+            .expect("link the subagent");
+
+        let error = fixture
+            .service
+            .validate_caller_can_spawn_agent("ses_subagent")
+            .err()
+            .expect("a subordinate caller may not spawn");
+        assert!(matches!(error, SubagentError::Subordinate));
+        // The same caller is refused `spawn_subagent` for the same reason, so
+        // the two spawn tools now have the same answer to subordination.
+        assert!(matches!(
+            fixture
+                .service
+                .validate_parent_can_spawn("ses_subagent")
+                .err()
+                .expect("a subordinate caller may not spawn a subagent either"),
+            SubagentError::DepthLimit
+        ));
+
+        // Promotion is exactly what lifts it — the link stays, the block goes.
+        assert!(fixture
+            .links
+            .promote_link(&link.id, "2026-08-08T01:00:00Z")
+            .expect("promote"));
+        fixture
+            .service
+            .validate_caller_can_spawn_agent("ses_subagent")
+            .expect("a promoted agent is a peer and may spawn");
+    }
+
+    #[test]
+    fn a_top_level_caller_may_spawn_a_peer() {
+        // The negative control for the check above: no subagent link, no
+        // refusal. Without this the test above would pass just as well if
+        // `validate_caller_can_spawn_agent` refused everybody.
+        let fixture = fixture(&["ses_owner"]);
+
+        fixture
+            .service
+            .validate_caller_can_spawn_agent("ses_owner")
+            .expect("a top-level caller may spawn a peer");
+    }
+
+    #[test]
+    fn the_fanout_cap_does_not_reach_the_peer_spawn_gate() {
+        // Ruling 9 at the seam that decides it. An owner holding the maximum
+        // number of subagents is refused another subagent and still allowed a
+        // peer: the cap bounds subordinates, and a peer is not one. Pinned
+        // here because the split between the two validators is the only thing
+        // keeping the cap out — reinstating it inside
+        // `validate_caller_can_create` would be invisible from the tool list.
+        let mut ids = vec!["ses_owner".to_string()];
+        for index in 0..MAX_SUBAGENTS_PER_PARENT {
+            ids.push(format!("ses_child_{index}"));
+        }
+        let borrowed: Vec<&str> = ids.iter().map(String::as_str).collect();
+        let fixture = fixture(&borrowed);
+        for index in 0..MAX_SUBAGENTS_PER_PARENT {
+            fixture
+                .service
+                .link_child("ses_owner", &format!("ses_child_{index}"), None, None, None)
+                .expect("link a subagent");
+        }
+
+        assert!(matches!(
+            fixture
+                .service
+                .validate_parent_can_spawn("ses_owner")
+                .err()
+                .expect("the ninth subagent is refused"),
+            SubagentError::FanoutLimit
+        ));
+        fixture
+            .service
+            .validate_caller_can_spawn_agent("ses_owner")
+            .expect("a capped owner may still spawn a peer");
+    }
+
+    #[test]
+    fn a_closed_caller_may_not_spawn_a_peer() {
+        // The prechecks both validators share still apply to the peer path;
+        // this is the one that says the split did not drop them.
+        let fixture = fixture(&["ses_owner"]);
+        fixture
+            .sessions
+            .update_status("ses_owner", "closed", "2026-08-08T02:00:00Z")
+            .expect("mark closed");
+
+        assert!(matches!(
+            fixture
+                .service
+                .validate_caller_can_spawn_agent("ses_owner")
+                .err()
+                .expect("a closed caller may not spawn"),
+            SubagentError::Closed
+        ));
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/service.rs
@@ -90,42 +90,82 @@ impl SubagentService {
         }
     }
 
-    pub fn validate_parent_can_spawn(
+    /// The prechecks every agent creation shares, whatever the caller ends up
+    /// owning: the caller exists and is still open, its workspace is a standard
+    /// one, and creating agents is enabled for that session.
+    ///
+    /// What is deliberately NOT here is everything about SUBORDINATION — the
+    /// depth rule and the fanout cap — because those describe a linked
+    /// subagent, not a peer the caller merely owns (ADR §3.4, ruling 9).
+    fn validate_caller_can_create(
         &self,
-        parent_session_id: &str,
+        caller_session_id: &str,
     ) -> Result<SessionRecord, SubagentError> {
-        let parent = self
+        let caller = self
             .session_store
-            .find_by_id(parent_session_id)?
-            .ok_or_else(|| SubagentError::ParentNotFound(parent_session_id.to_string()))?;
-        if parent.closed_at.is_some() || parent.status == "closed" {
+            .find_by_id(caller_session_id)?
+            .ok_or_else(|| SubagentError::ParentNotFound(caller_session_id.to_string()))?;
+        if caller.closed_at.is_some() || caller.status == "closed" {
             return Err(SubagentError::Closed);
         }
         let workspace = self
             .workspace_runtime
-            .get_workspace(&parent.workspace_id)?
-            .ok_or_else(|| SubagentError::WorkspaceNotFound(parent.workspace_id.clone()))?;
+            .get_workspace(&caller.workspace_id)?
+            .ok_or_else(|| SubagentError::WorkspaceNotFound(caller.workspace_id.clone()))?;
         if workspace.surface != WorkspaceSurface::Standard {
             return Err(SubagentError::IneligibleWorkspace);
         }
-        // Depth is capped at one level of subordination, and promotion is
-        // exactly what lifts it (ADR §3.3): a promoted agent is a peer, so it
-        // may spawn its own children even though its ownership row survives.
-        let ownership = self.link_service.find_subagent_parent(parent_session_id)?;
-        let is_promoted_child = ownership
-            .as_ref()
-            .is_some_and(|link| link.promoted_at.is_some());
         // `spawn_subagent` creates every child with `subagents_enabled = false`;
         // that flag is how a spawned child carries its subordination, and it is
         // the only server-side consumer of the flag (agent ops mounts on every
         // session, and this validation is recomputed per call). So promotion has
-        // to lift it too, or the depth lift below is dead code for every real
-        // child and ruling 7 never takes effect. Derived from `promoted_at`
-        // rather than rewriting the session row, so promotion stays ONE durable
-        // fact on the link instead of two rows in two tables that can diverge.
-        if !parent.subagents_enabled && !is_promoted_child {
+        // to lift it too, or ruling 7 never takes effect for any real child.
+        // Derived from `promoted_at` rather than rewriting the session row, so
+        // promotion stays ONE durable fact on the link instead of two rows in
+        // two tables that can diverge.
+        let ownership = self.link_service.find_subagent_parent(caller_session_id)?;
+        let is_promoted_child = ownership
+            .as_ref()
+            .is_some_and(|link| link.promoted_at.is_some());
+        if !caller.subagents_enabled && !is_promoted_child {
             return Err(SubagentError::Disabled);
         }
+        Ok(caller)
+    }
+
+    /// The `spawn_agent` form of [`Self::validate_parent_can_spawn`].
+    ///
+    /// An owned agent is a PEER: ruling 9 puts no numeric limit on it and there
+    /// is no subordination to depth-limit, so neither the fanout cap nor the
+    /// depth rule applies. Everything about the CALLER still does, plus the
+    /// workspace the new session lands in being mutable — which for this tool
+    /// is the caller's own, the one whose write lease the route already took.
+    ///
+    /// The one gate NOT restated here is ruling 3's spawn block: an unpromoted
+    /// subagent is refused before dispatch reaches any tool body
+    /// (`agent_ops::calls::call_tool`), where the refusal can say why.
+    pub fn validate_caller_can_spawn_agent(
+        &self,
+        caller_session_id: &str,
+    ) -> Result<SessionRecord, SubagentError> {
+        let caller = self.validate_caller_can_create(caller_session_id)?;
+        self.access_gate
+            .assert_can_mutate_for_workspace(&caller.workspace_id)
+            .map_err(map_access_error)?;
+        Ok(caller)
+    }
+
+    pub fn validate_parent_can_spawn(
+        &self,
+        parent_session_id: &str,
+    ) -> Result<SessionRecord, SubagentError> {
+        let parent = self.validate_caller_can_create(parent_session_id)?;
+        // Depth is capped at one level of subordination, and promotion is
+        // exactly what lifts it (ADR §3.3): a promoted agent is a peer, so it
+        // may spawn its own children even though its ownership row survives.
+        // (`validate_caller_can_create` already lifted `subagents_enabled` for
+        // a promoted child from the same link.)
+        let ownership = self.link_service.find_subagent_parent(parent_session_id)?;
         if ownership.is_some_and(|link| link.is_unpromoted_subagent()) {
             return Err(SubagentError::DepthLimit);
         }

--- a/anyharness/sdk/src/reducer/__tests__/transcript.test.ts
+++ b/anyharness/sdk/src/reducer/__tests__/transcript.test.ts
@@ -1247,6 +1247,7 @@ describe("transcript reducer", () => {
     ["mcp__subagents__get_agent_config_options"],
     ["mcp__subagents__configure_agent"],
     ["mcp__subagents__promote_subagent"],
+    ["mcp__subagents__spawn_agent"],
   ])("classifies the renamed agent ops tool %s as subagent activity", (nativeToolName) => {
     const state = reduceEvents(
       [

--- a/anyharness/sdk/src/reducer/transcript.ts
+++ b/anyharness/sdk/src/reducer/transcript.ts
@@ -1433,6 +1433,7 @@ function deriveToolCallSemanticKind(
     // Peer agent ops. They are not subagent operations, but "subagent" is the
     // only agent-activity semantic kind today; the dedicated presentation
     // lands with the agent-ops client work.
+    || normalizedEffectiveToolName === "mcp__subagents__spawn_agent"
     || normalizedEffectiveToolName === "mcp__subagents__send_agent_message"
     || normalizedEffectiveToolName === "mcp__subagents__list_agents"
     || normalizedEffectiveToolName === "mcp__subagents__read_agent_transcript"

--- a/apps/packages/product-client/src/domain/chats/subagents/subagent-tool-presentation.ts
+++ b/apps/packages/product-client/src/domain/chats/subagents/subagent-tool-presentation.ts
@@ -44,6 +44,8 @@ export function formatSubagentMcpActionLabel(toolName: string | null | undefined
     case "mcp__subagents__close_agent":
     case "mcp__subagents__close_subagent":
       return "Closed agent";
+    case "mcp__subagents__spawn_agent":
+      return "Spawned agent";
     case "mcp__subagents__send_agent_message":
       return "Sent agent message";
     case "mcp__subagents__list_agents":
@@ -97,6 +99,11 @@ export function formatSubagentHeaderVerb({
   }
   // Peer agent ops. Without their own entries these fall through to the
   // creation verb below, which would claim a spawn that never happened.
+  // `spawn_agent` is the opposite hazard: it IS a spawn, but of a peer, and the
+  // fallback verb would call the new agent somebody's subagent.
+  if (toolName === "mcp__subagents__spawn_agent") {
+    return isRunning ? "Spawning agent" : "Agent spawned";
+  }
   if (toolName === "mcp__subagents__send_agent_message") {
     return isRunning ? "Sending message to agent" : "Message sent to agent";
   }
@@ -129,7 +136,9 @@ export function isSubagentCreationAction(item: ToolNameOwner): boolean {
   // Only the product-MCP spawn receipt collapses into a creation group (the
   // create_subagent name is its pre-agent-ops alias). Native subagent calls
   // stay as durable transcript items throughout their lifecycle and must not
-  // match here.
+  // match here. Neither does `spawn_agent`: the creation group is the subagent
+  // launch ledger, and a peer is nobody's subagent, so folding it in would put
+  // an owned agent under a parent's fanout in the UI.
   const toolName = normalizeToolName(item.nativeToolName);
   return toolName === "mcp__subagents__spawn_subagent"
     || toolName === "mcp__subagents__create_subagent";

--- a/apps/packages/product-client/src/lib/domain/chat/subagents/subagent-tool-presentation.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/subagents/subagent-tool-presentation.test.ts
@@ -114,6 +114,29 @@ describe("subagent tool presentation", () => {
     })).toBe("Subagent promoted");
   });
 
+  it("reads a peer spawn as a spawn without calling the new agent a subagent", () => {
+    expect(formatSubagentMcpActionLabel("mcp__subagents__spawn_agent"))
+      .toBe("Spawned agent");
+    expect(formatSubagentHeaderVerb({
+      item: { nativeToolName: "mcp__subagents__spawn_agent" },
+      executionState: "running",
+      isRunning: true,
+    })).toBe("Spawning agent");
+    // The fallback verb is "Subagent created", so an unclassified spawn_agent
+    // would silently misreport a peer as somebody's subagent.
+    expect(formatSubagentHeaderVerb({
+      item: { nativeToolName: "mcp__subagents__spawn_agent" },
+      executionState: "completed",
+      isRunning: false,
+    })).toBe("Agent spawned");
+  });
+
+  it("keeps a peer spawn out of the subagent launch ledger", () => {
+    expect(isSubagentProvisioningAction({
+      nativeToolName: "mcp__subagents__spawn_agent",
+    })).toBe(false);
+  });
+
   it("derives concise status receipt presentation with the child target", () => {
     const presentation = deriveSubagentMcpReceiptPresentation(toolCallItem({
       nativeToolName: "mcp__subagents__get_subagent_status",

--- a/specs/anyharness/sessions.md
+++ b/specs/anyharness/sessions.md
@@ -128,6 +128,13 @@ read off one row:
 Promotion stamps `promoted_at`; it does not change the relation, because the
 parent stays the owner. It is one idempotent write, and it is one-way.
 
+The two ownership relations are written by different tools and never converge.
+`spawn_subagent` writes `subagent` and `spawn_agent` writes `owned_agent`; a
+promoted subagent keeps `subagent` forever. So `owned_agent` means "born a
+peer", `subagent` with `promoted_at` set means "became a peer", and the
+difference stays legible for the life of the row. A `Promoted` row and an
+`Owned peer` row confer the same capabilities from here on.
+
 `closed_by_session_id` and `close_reason` record which agent closed this one and
 why. Both stay `NULL` for a session a person closed through the UI or the HTTP
 close route — the columns record an *agent's* close, not every close.
@@ -215,11 +222,12 @@ The model is intentionally small:
 - PR2 does not cascade-delete child sessions when a parent is deleted; deleting
   either session removes only the link and attached completion/schedule rows
 - nested subagents are blocked; an UNPROMOTED subagent child receives no
-  spawn-style tools (`get_subagent_launch_options`, `spawn_subagent`, and the
-  deprecated `create_subagent` alias) and `validate_parent_can_spawn` refuses it
-  with a depth limit
+  spawn-style tools (`get_subagent_launch_options`, `spawn_subagent`, the
+  deprecated `create_subagent` alias, and `spawn_agent`) and
+  `validate_parent_can_spawn` refuses it with a depth limit
 - parents are limited to eight *unpromoted* subagents at a time; promoted
-  children no longer occupy a slot
+  children no longer occupy a slot. The cap counts subagents only: an owner
+  sitting at the cap may still spawn owned agents, which are uncapped
 - `subagents_enabled` is a durable create-time session policy. Missing legacy
   rows default enabled in the session store/read model. Resume reads the stored
   policy and does not silently re-enable disabled sessions. `spawn_subagent`
@@ -265,6 +273,7 @@ Current tools:
 
 - `get_subagent_launch_options`
 - `spawn_subagent` (deprecated alias: `create_subagent`)
+- `spawn_agent`
 - `list_subagents`
 - `send_subagent_message`
 - `get_subagent_status`
@@ -279,6 +288,25 @@ one launched before its promotion holds a list that did. The spawn gate
 therefore runs again at dispatch in `agent_ops/calls.rs`, against the caller's
 state at the moment it acts, and matches the wire name so the deprecated
 `create_subagent` spelling cannot walk around it.
+
+`spawn_subagent` and `spawn_agent` are two modes of one routine,
+`create_agent_session` in `agent_ops/spawn_ops.rs`. Both create a durable
+session in the caller's workspace, inheriting the caller's agent kind, model and
+mode unless overridden, write the ownership link, arm the optional wake, start
+the runtime, and send the first prompt — unwinding the session, link and wake if
+any step fails. They differ in three places, all keyed off the ownership mode:
+
+- the link relation, `subagent` or `owned_agent`
+- the wake: a subagent's is link-scoped, hung off the completion row, while a
+  peer has no link completion to wait on and so takes a session-scoped wake
+- the first prompt: a subagent's carries parent-to-child provenance with the
+  `session_link_id`, a peer's is an envelope-wrapped peer message with none
+
+A peer is created with the full tool surface, including the spawn tools, so it
+is never in the "unpromoted" state and needs no promotion. It also does not
+cascade: closing the owner does not close it. `spawn_agent` creates in the
+caller's own workspace, so it takes the route's workspace write lease and no
+target permit — there is no target yet.
 
 `promote_subagent` promotes one of the caller's subagents to a peer. The agent
 keeps its transcript, its label and its owner, and gains the full tool surface

--- a/specs/anyharness/sessions.md
+++ b/specs/anyharness/sessions.md
@@ -223,8 +223,14 @@ The model is intentionally small:
   either session removes only the link and attached completion/schedule rows
 - nested subagents are blocked; an UNPROMOTED subagent child receives no
   spawn-style tools (`get_subagent_launch_options`, `spawn_subagent`, the
-  deprecated `create_subagent` alias, and `spawn_agent`) and
-  `validate_parent_can_spawn` refuses it with a depth limit
+  deprecated `create_subagent` alias, and `spawn_agent`), and both spawn gates
+  refuse it at the service as well: `validate_parent_can_spawn` with a depth
+  limit, `validate_caller_can_spawn_agent` as a subordinate caller. The tool
+  bodies read those gates, so the block does not rest on dispatch alone
+- the cowork depth rule is narrower than either: `validate_parent_can_spawn`
+  also refuses the child of a cowork coding session, and `spawn_agent` is
+  outside that rule. Cowork is unused and slated for deletion, so the gap is
+  disclosed rather than closed
 - parents are limited to eight *unpromoted* subagents at a time; promoted
   children no longer occupy a slot. The cap counts subagents only: an owner
   sitting at the cap may still spawn owned agents, which are uncapped
@@ -298,7 +304,10 @@ any step fails. They differ in three places, all keyed off the ownership mode:
 
 - the link relation, `subagent` or `owned_agent`
 - the wake: a subagent's is link-scoped, hung off the completion row, while a
-  peer has no link completion to wait on and so takes a session-scoped wake
+  peer has no link completion to wait on and so takes a session-scoped wake.
+  The peer's is armed as a REPLY wake, the same kind `wakeOnReply` arms on a
+  send: the first prompt is a question, so the peer's answer consumes the
+  schedule and only a peer that answers nobody produces the pointer
 - the first prompt: a subagent's carries parent-to-child provenance with the
   `session_link_id`, a peer's is an envelope-wrapped peer message with none
 

--- a/specs/codebase/platforms/product/agent-features/definitions/subagents.md
+++ b/specs/codebase/platforms/product/agent-features/definitions/subagents.md
@@ -76,6 +76,13 @@ An agent is in exactly one of three states, and the row says which:
 | Promoted | `relation = 'subagent'`, `promoted_at IS NOT NULL` | yes | no | no |
 | Owned peer | `relation = 'owned_agent'` | yes | no | no |
 
+Which row an agent gets is decided once, at spawn, by which tool created it.
+`spawn_subagent` writes `subagent`; `spawn_agent` writes `owned_agent`. Nothing
+ever converts one into the other — promotion stamps `promoted_at` and leaves the
+relation alone. So the two right-hand states are reached by different routes and
+stay distinguishable forever: `owned_agent` was born a peer, a stamped
+`subagent` became one. Their capabilities from that point are identical.
+
 `promote_subagent` moves a subagent to promoted. It is one write, idempotent,
 and one-way. The relation does not change, because the owner does not change:
 the parent still owns a promoted agent and may still close it deliberately. What
@@ -86,11 +93,22 @@ The spawn block is the visible consequence for the child. A spawned child is
 created with its session-level subagents policy OFF as well, which is the same
 subordination expressed on the session row; promotion lifts both, so a promoted
 agent can genuinely spawn rather than merely being offered the tools. An
-unpromoted subagent is offered no spawn-style tool at all — not `spawn_subagent`, not
-`get_subagent_launch_options`, not the `create_subagent` alias. That is stricter
-than the fanout cap, which merely refuses a spawn: a capped parent still sees
-its launch options, because the cap is a temporary condition of an agent that is
-allowed to think in terms of spawning. Subordination is not.
+unpromoted subagent is offered no spawn-style tool at all — not
+`spawn_subagent`, not `spawn_agent`, not `get_subagent_launch_options`, not the
+`create_subagent` alias. That is stricter than the fanout cap, which merely
+refuses a spawn: a capped parent still sees its launch options, because the cap
+is a temporary condition of an agent that is allowed to think in terms of
+spawning. Subordination is not.
+
+The cap is also narrower than it looks. It counts unpromoted subagents, which
+are the children that cascade and that a parent is responsible for; owned agents
+are peers from birth and are not capped. An owner holding eight subagents is
+refused `spawn_subagent` and still offered `spawn_agent`.
+
+`spawn_agent` creates a peer in the caller's own workspace and returns the new
+`sessionId` and an `agentId`. It reports no `subagentId`, because there is no
+subagent: the handle for a peer is its session id, the same one the peer tools
+take.
 
 Because tool lists are frozen at launch, the block is enforced at call time, on
 the wire name, against the caller's state at the moment it acts. `tools/list` is
@@ -142,6 +160,11 @@ should be tied to the prompt being sent, because it avoids the race where the
 child finishes before the parent schedules a separate wake via
 `schedule_subagent_wake`.
 
+`spawn_agent` takes the same `wakeOnCompletion` flag for the same reason, but
+arms a different mechanism. A subagent's wake hangs off the link completion row;
+a peer has no link completion to wait on, so its wake is session-scoped and
+fires at the end of the new agent's next finished turn.
+
 The peer-scoped `schedule_agent_wake` closes the same race from the other side,
 and that is the reason it exists as a standalone tool as well as a
 `wakeOnReply` flag. Its schedule is consumed when the target's turn FINISHES,
@@ -173,9 +196,10 @@ hooks, then marks the parent-child link closed. If closing the live session
 fails, the active link remains discoverable so a later close call can retry
 rather than orphaning hidden work.
 
-The cascade skips promoted children. Closing an owner takes down the subagents
-still subordinate to it and leaves the agents it promoted running; their
-ownership rows survive, so they can still be closed individually.
+The cascade skips promoted children and owned agents alike — it follows
+subordination, not ownership. Closing an owner takes down the subagents still
+subordinate to it and leaves the agents it promoted or spawned as peers running;
+their ownership rows survive, so they can still be closed individually.
 
 Closing an agent that is WORKING does not interrupt it. The call authorizes the
 close, records who closed it and why on the still-open ownership row, and

--- a/specs/codebase/platforms/product/agent-features/definitions/subagents.md
+++ b/specs/codebase/platforms/product/agent-features/definitions/subagents.md
@@ -108,11 +108,30 @@ refused `spawn_subagent` and still offered `spawn_agent`.
 `spawn_agent` creates a peer in the caller's own workspace and returns the new
 `sessionId` and an `agentId`. It reports no `subagentId`, because there is no
 subagent: the handle for a peer is its session id, the same one the peer tools
-take.
+take. Its launch vocabulary is `spawn_subagent`'s, deliberately: the same
+`harnessId` and the same open `initialConfig` object, of which `modelId` and
+`modeId` are read. `appliedInitialConfig` in the result reports what the new
+agent actually launched with, so a key that was not honoured is visibly absent
+rather than silently dropped. Whether to close that object is a decision for
+both spawn tools together, not one of them.
+
+The client does not yet learn about a peer spawn from the stream. The
+subagent-mutation invalidation deliberately does not list `spawn_agent` — the
+new agent is not a subagent and does not belong in a parent's fanout — and
+there is no session-created event in its place, so a peer spawned by an agent
+appears on the next refresh rather than immediately. Closing that is client
+work, tracked with the rest of the client surface.
 
 Because tool lists are frozen at launch, the block is enforced at call time, on
 the wire name, against the caller's state at the moment it acts. `tools/list` is
 advertisement; dispatch is the gate.
+
+Subordination is also refused one layer down, by the gate each spawn tool reads
+before it creates anything: the subagent gate answers with a depth limit, the
+peer gate with a subordinate caller. Both are the same predicate — an open
+subagent link naming the caller as the child, not yet promoted — so an
+unpromoted subagent is refused whichever way it is reached, and no path into a
+spawn depends on dispatch having checked first.
 
 ## Peer Configuration
 
@@ -164,6 +183,14 @@ child finishes before the parent schedules a separate wake via
 arms a different mechanism. A subagent's wake hangs off the link completion row;
 a peer has no link completion to wait on, so its wake is session-scoped and
 fires at the end of the new agent's next finished turn.
+
+It is armed as a reply wake, the kind `wakeOnReply` arms on a send, because a
+spawn is a send awaiting an answer. If the peer replies, the reply carries the
+content and consumes the schedule, so no pointer follows it; if the peer answers
+nobody, the pointer fires when its turn ends. Arming it as a standing schedule
+instead would wake the owner twice for one turn, and — because a re-arm keeps
+the stronger reason — would also swallow the consumption of any `wakeOnReply`
+the owner armed on that peer before its first turn finished.
 
 The peer-scoped `schedule_agent_wake` closes the same race from the other side,
 and that is the reason it exists as a standalone tool as well as a


### PR DESCRIPTION
Sixth slice of the agent-operations stack (ADR §6 step 6; stacked on #1731 → #1729 → #1728 → #1727 → #1726). Adds `spawn_agent` and the shared session-creation routine.

## What this does

`spawn_subagent` had the whole session-creation core inlined — durable record, link row, wake arming, runtime start, first prompt, and the unwind for each of those failing. A peer spawn needs all of it, so the core moves to `agent_ops/spawn_ops.rs` as `create_agent_session`, parameterised by an ownership mode. `spawn_subagent` refactors onto it with no behaviour change and the same response shape.

`spawn_agent` is the second mode: it creates a peer the caller owns. The link row is `relation='owned_agent'`, so the close cascade already declines to follow it, the subagent fanout cap and depth limit don't apply, and the child is born with the full tool surface rather than as an unpromoted subagent. Its wake is session-scoped (no link completion to hang off) and its first prompt is an envelope-wrapped peer message rather than carrying a `session_link_id`.

The fanout cap is why `can_spawn_agent` is its own context field rather than derived from `can_create`: an owner holding eight subagents may still spawn a peer. Gating is otherwise shared — `spawn_agent` joins `SPAWN_STYLE_TOOL_NAMES`, so an unpromoted subagent is neither offered it nor allowed to dispatch it, and `MUTATING_TOOL_NAMES`, because it creates in the caller's own workspace.

Client-side, `spawn_agent` was unclassified on both sides of the wire, and `formatSubagentHeaderVerb` falls back to "Subagent created" — so the one tool whose point is that the new agent is *not* a subagent was the one being labelled as one. Now reads "Spawning agent" / "Agent spawned", and stays out of the subagent launch ledger.

## Spec note

ADR §3.4 lets `spawn_agent` name any workspace. Implemented here as the caller's workspace only — a cross-workspace spawn would have to lease a workspace the route never took, which is PR7's `spawn_workspace` problem. The argument is accepted and validated so the wire shape is already right; a mismatch is refused with both workspace ids named. §3.4 also said "no parent link", which contradicts §3.2's `owned_agent` row; the row wins (ADR amended).

Separately: `spawn_subagent` creates children with `subagents_enabled = false`, so a *promoted* subagent still hits `SubagentError::Disabled` and cannot spawn, contradicting ruling 7. Not fixed here — it is PR5 territory and has been routed to the PR5 fix pass on #1731.

## Testing

`cargo test -p anyharness-lib --lib -- agent_ops ownership subagents links session_admission` (122 passed); SDK reducer transcript suite (46); product-client subagent presentation suite (15); `check_docs.py` (209 files). Negative controls: writing `subagent` for the peer path, dropping `spawn_agent` from the dispatch gate, dropping the `wakeOnCompletion` passthrough, and removing the client header verb each fail a named test. The arg→request mapping was made a pure function and pinned with new tests, because no pre-existing behavioural test of the spawn flow exists (needs a live harness).

## Observability

No new metrics. Failed spawns unwind through the existing `tracing::warn` on wake-schedule cleanup; the response reports `wake.scheduled` / `wake.created` separately so an armed-but-not-created wake is visible to the caller rather than silent.
