### PR TITLE
feat(agent-ops): spawn_workspace and cross-workspace spawn_agent

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/session_admission_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/session_admission_tests.rs
@@ -727,3 +727,102 @@ fn the_peer_tools_take_the_permit_before_the_target_workspace_lease() {
         assert!(lease_at < dispatch_at, "{tool}: dispatch escaped the locks");
     }
 }
+
+/// One private function's body, squashed to single spaces. Same extraction the
+/// peer-tool guard above does inline; the workspace-spawn tools need it too.
+fn private_fn_body(rel_path: &str, fn_name: &str) -> String {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(rel_path);
+    let text =
+        std::fs::read_to_string(&path).unwrap_or_else(|error| panic!("read {rel_path}: {error}"));
+    let signature = format!("async fn {fn_name}(");
+    let start = text
+        .find(&signature)
+        .unwrap_or_else(|| panic!("{rel_path}: {fn_name} not found"));
+    let rest = &text[start..];
+    let end = rest.find("\n}\n").map(|idx| idx + 3).unwrap_or(rest.len());
+    squash_whitespace(&rest[..end])
+}
+
+#[test]
+fn spawn_agent_holds_the_target_workspace_lease_across_creation() {
+    // `spawn_agent` can now create a peer in a workspace that is not the
+    // caller's (ADR §3.3), so it left `MUTATING_TOOL_NAMES` for the same reason
+    // `send_agent_message` and `configure_agent` did: the route's lease is the
+    // CALLER's workspace, which is the wrong one. It takes the TARGET
+    // workspace's write lease itself instead.
+    //
+    // Unlike the peer tools there is no admission permit, and none is possible:
+    // the target SESSION does not exist until the call creates it, so there is
+    // nothing to admit. With one lease and no permit LOCK-01 has no order to
+    // invert — what is left to prove is that the one lease is HELD across the
+    // creation, because that is what a concurrent retire preflight on the
+    // target workspace has to collide with.
+    assert!(
+        !crate::domains::sessions::agent_ops::tools::MUTATING_TOOL_NAMES.contains(&"spawn_agent"),
+        "spawn_agent must stay OUT of MUTATING_TOOL_NAMES — the route lease is the caller's \
+         workspace, and taking it here would both lease the wrong workspace and (were a permit \
+         ever added) invert LOCK-01"
+    );
+    let body = private_fn_body("src/domains/sessions/agent_ops/calls.rs", "spawn_agent");
+    let body = body.as_str();
+    // The BINDING, not the call: `let _ = lease_..(..)` drops the lease at the
+    // end of its own statement, which reads identically in call ORDER and
+    // fences nothing.
+    let lease_at = body
+        .find("let _target_workspace_lease = lease_target_workspace_for_peer_write(")
+        .expect(
+            "spawn_agent must BIND the TARGET workspace lease as `_target_workspace_lease` — \
+             an unbound `let _ =` drops it immediately",
+        );
+    let create_at = body
+        .find("create_agent_session(")
+        .expect("spawn_agent must create through the shared create_agent_session routine");
+    assert!(
+        lease_at < create_at,
+        "spawn_agent: the target workspace lease must be taken BEFORE create_agent_session, and \
+         it is held to the end of the function, so creation happens inside it"
+    );
+    // And the lease is on the TARGET, not on the caller's `ctx.workspace_id`.
+    assert!(
+        body.contains(
+            "lease_target_workspace_for_peer_write( &gates.workspace_operation_gate, \
+             service.access_gate(), &request.workspace_id,"
+        ),
+        "spawn_agent must lease `request.workspace_id` (the target), not the caller's workspace"
+    );
+}
+
+#[test]
+fn spawn_workspace_has_nothing_to_lease_and_says_so() {
+    // `spawn_workspace` creates a workspace, so at call time the thing a
+    // workspace operation lease would name does not exist. The human worktree
+    // route has the same problem and solves it the same way: no operation
+    // lease, an ACCESS-gate assertion on the repo root instead. Recording it
+    // here so a later reader does not "fix" the missing lease.
+    assert!(
+        !crate::domains::sessions::agent_ops::tools::MUTATING_TOOL_NAMES
+            .contains(&"spawn_workspace"),
+        "spawn_workspace must stay OUT of MUTATING_TOOL_NAMES — the route would lease the \
+         CALLER's workspace, which is not what the call mutates"
+    );
+    let body = private_fn_body(
+        "src/domains/sessions/agent_ops/workspace_ops.rs",
+        "spawn_workspace",
+    );
+    let body = body.as_str();
+    assert!(
+        !body.contains("acquire_shared(") && !body.contains("acquire_exclusive("),
+        "spawn_workspace must not take a workspace operation lease — there is no workspace to \
+         lease until it returns"
+    );
+    let gate_at = body
+        .find("assert_can_mutate_for_repo_root(")
+        .expect("spawn_workspace must gate on the repo root, as the human worktree route does");
+    let create_at = body
+        .find("spawn_worktree_workspace(")
+        .expect("spawn_workspace must delegate creation to the worktree path");
+    assert!(
+        gate_at < create_at,
+        "spawn_workspace: the repo-root access gate must run before anything is created"
+    );
+}

--- a/anyharness/crates/anyharness-lib/src/app/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/app/mod.rs
@@ -592,6 +592,8 @@ impl AppState {
                 agent_wake_service: agent_wake_service.clone(),
                 session_runtime: session_runtime.clone(),
                 workspace_runtime: workspace_runtime.clone(),
+                workspace_worktree_runtime: workspace_worktree_runtime.clone(),
+                repo_root_service: repo_root_service.clone(),
                 agent_ownership_service: agent_ownership_service.clone(),
                 session_admission: session_admission.clone(),
                 workspace_operation_gate: workspace_operation_gate.clone(),

--- a/anyharness/crates/anyharness-lib/src/app/product_mcp.rs
+++ b/anyharness/crates/anyharness-lib/src/app/product_mcp.rs
@@ -5,14 +5,15 @@ use crate::domains::cowork::mcp::{
     self as cowork_mcp, auth::CoworkMcpAuth, tools as cowork_mcp_tools, CoworkProductMcpServer,
 };
 use crate::domains::cowork::runtime::CoworkRuntime;
+use crate::domains::repo_roots::service::RepoRootService;
 use crate::domains::reviews::mcp::{
     self as review_mcp, auth::ReviewMcpAuth, tools as review_mcp_tools, ReviewProductMcpServer,
 };
 use crate::domains::reviews::runtime::ReviewRuntime;
 use crate::domains::sessions::admission::SessionMutationAdmission;
 use crate::domains::sessions::agent_ops::{
-    self as agent_ops_mcp, auth::AgentOpsMcpAuth, tools as agent_ops_mcp_tools,
-    AgentOpsPeerGates, AgentOpsProductMcpServer,
+    self as agent_ops_mcp, auth::AgentOpsMcpAuth, tools as agent_ops_mcp_tools, AgentOpsPeerGates,
+    AgentOpsProductMcpServer, AgentOpsWorkspaceOps,
 };
 use crate::domains::sessions::mcp_bindings::product_catalog::ProductMcpLaunchCatalog;
 use crate::domains::sessions::ownership::service::AgentOwnershipService;
@@ -28,6 +29,7 @@ use crate::domains::sessions::wakes::service::AgentWakeService;
 use crate::domains::workspaces::model::WorkspaceSurface;
 use crate::domains::workspaces::operation_gate::{WorkspaceOperationGate, WorkspaceOperationKind};
 use crate::domains::workspaces::runtime::WorkspaceRuntime;
+use crate::domains::workspaces::worktree_runtime::WorkspaceWorktreeRuntime;
 
 pub(super) struct LaunchCatalogDeps {
     pub(super) runtime_base_url: String,
@@ -44,6 +46,10 @@ pub(super) struct EndpointRegistryDeps {
     pub(super) agent_wake_service: Arc<AgentWakeService>,
     pub(super) session_runtime: Arc<SessionRuntime>,
     pub(super) workspace_runtime: Arc<WorkspaceRuntime>,
+    // The agent ops server creates workspaces through the very services the
+    // human routes use; see `AgentOpsWorkspaceOps`.
+    pub(super) workspace_worktree_runtime: Arc<WorkspaceWorktreeRuntime>,
+    pub(super) repo_root_service: Arc<RepoRootService>,
     pub(super) agent_ownership_service: Arc<AgentOwnershipService>,
     pub(super) session_admission: Arc<SessionMutationAdmission>,
     pub(super) workspace_operation_gate: Arc<WorkspaceOperationGate>,
@@ -117,6 +123,8 @@ pub(super) fn build_product_mcp_endpoint_registry(
         agent_wake_service,
         session_runtime,
         workspace_runtime,
+        workspace_worktree_runtime,
+        repo_root_service,
         agent_ownership_service,
         session_admission,
         workspace_operation_gate,
@@ -137,7 +145,11 @@ pub(super) fn build_product_mcp_endpoint_registry(
                 subagent_service.clone(),
                 agent_wake_service,
                 session_runtime,
-                workspace_runtime.clone(),
+                AgentOpsWorkspaceOps {
+                    workspace_runtime: workspace_runtime.clone(),
+                    worktree_runtime: workspace_worktree_runtime,
+                    repo_roots: repo_root_service,
+                },
                 agent_ownership_service,
                 AgentOpsPeerGates {
                     session_admission,

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/calls.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/calls.rs
@@ -96,10 +96,11 @@ pub async fn call_tool(
         "get_workspace_options" => {
             let caller = caller_session(service, &ctx.parent_session_id)?;
             workspace_ops::get_workspace_options(
-                &workspaces.workspace_runtime,
-                &workspaces.repo_roots,
+                workspaces.workspace_runtime.clone(),
+                workspaces.repo_roots.clone(),
                 &caller,
             )
+            .await
         }
         "spawn_workspace" => {
             let args: SpawnWorkspaceArgs = deserialize_args(arguments)?;
@@ -497,10 +498,11 @@ fn caller_session(
         .ok_or_else(|| anyhow::anyhow!("calling session not found: {caller_session_id}"))
 }
 
-/// A workspace an agent may be put into: it has to exist and be a standard
-/// workspace, the same eligibility `validate_caller_can_create` applies to the
-/// caller's own. Whether it may be MUTATED right now is the access gate's
-/// question, asked when the lease is taken.
+/// A workspace an agent may be put into: it has to exist, be a standard
+/// workspace, and still have its checkout — the same eligibility
+/// `validate_caller_can_create` applies to the caller's own. Whether it may be
+/// MUTATED right now is the access gate's question, asked when the lease is
+/// taken.
 fn assert_spawnable_workspace(
     workspace_runtime: &crate::domains::workspaces::runtime::WorkspaceRuntime,
     workspace_id: &str,
@@ -516,6 +518,19 @@ fn assert_spawnable_workspace(
     if workspace.surface != WorkspaceSurface::Standard {
         anyhow::bail!(
             "workspace {workspace_id} is not a standard workspace; agents cannot be spawned in it"
+        );
+    }
+    // A workspace row whose directory has been deleted is not somewhere an
+    // agent can run. Without this the session is created, `start_persisted_session`
+    // fails on the missing cwd, and the whole thing unwinds — correct, but a
+    // noisier answer than a refusal that names the reason. The predicate is the
+    // proven-deleted one (it fails OPEN on unreadable paths), so this refuses
+    // only when the checkout is genuinely gone.
+    if workspace.checkout_directory_missing() {
+        anyhow::bail!(
+            "workspace {workspace_id}'s checkout is gone from disk ({}), so an agent cannot be \
+             started there. Ask a person to restore it, or spawn a workspace of your own.",
+            workspace.path
         );
     }
     Ok(())
@@ -543,7 +558,7 @@ async fn spawn_workspace(
     let caller = caller_session(service, &ctx.parent_session_id)?;
     workspace_ops::spawn_workspace(
         &workspaces.workspace_runtime,
-        &workspaces.worktree_runtime,
+        workspaces.worktree_runtime.as_ref(),
         &workspaces.repo_roots,
         service.access_gate(),
         &caller,
@@ -1249,4 +1264,175 @@ fn close_result(
             "That agent is closed. Its transcript stays readable."
         },
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domains::agents::readiness::launch_options::{
+        ResolvedLaunchAgentOption, ResolvedLaunchModelOption, ResolvedWorkspaceLaunchOptions,
+    };
+    use crate::domains::sessions::agent_ops::spawn_ops::{
+        resolve_launch_against_target_workspace, CreateAgentSessionRequest,
+    };
+    use crate::domains::sessions::model::{SessionMcpBindingPolicy, SessionRecord};
+    use crate::domains::sessions::agent_ops::tools::SpawnAgentArgs;
+
+    fn session(id: &str, workspace_id: &str) -> SessionRecord {
+        SessionRecord {
+            id: id.to_string(),
+            workspace_id: workspace_id.to_string(),
+            agent_kind: "claude".to_string(),
+            native_session_id: None,
+            agent_auth_contexts: None,
+            requested_model_id: Some("caller-model".to_string()),
+            current_model_id: Some("caller-model".to_string()),
+            requested_mode_id: Some("caller-mode".to_string()),
+            current_mode_id: Some("caller-mode".to_string()),
+            title: None,
+            thinking_level_id: None,
+            thinking_budget_tokens: None,
+            status: "idle".to_string(),
+            created_at: "2026-08-08T00:00:00Z".to_string(),
+            updated_at: "2026-08-08T00:00:00Z".to_string(),
+            last_prompt_at: None,
+            closed_at: None,
+            dismissed_at: None,
+            mcp_bindings_ciphertext: None,
+            mcp_binding_summaries_json: None,
+            mcp_binding_policy: SessionMcpBindingPolicy::InheritWorkspace,
+            system_prompt_append: None,
+            subagents_enabled: true,
+            action_capabilities_json: None,
+            origin: None,
+        }
+    }
+
+    fn target_catalog(workspace_id: &str) -> anyhow::Result<ResolvedWorkspaceLaunchOptions> {
+        assert_eq!(workspace_id, "workspace-2", "the TARGET's catalog, always");
+        Ok(ResolvedWorkspaceLaunchOptions {
+            agents: vec![ResolvedLaunchAgentOption {
+                kind: "claude".to_string(),
+                display_name: "claude".to_string(),
+                default_model_id: Some("target-model".to_string()),
+                unattended_mode_id: Some("target-mode".to_string()),
+                models: vec![ResolvedLaunchModelOption {
+                    id: "target-model".to_string(),
+                    display_name: "target-model".to_string(),
+                    aliases: Vec::new(),
+                    is_default: true,
+                    default_opt_in: None,
+                    description: None,
+                    provider: None,
+                    status: None,
+                    effort: None,
+                    live_effort_candidates: Vec::new(),
+                    fast_mode: false,
+                    modes: Some(vec!["target-mode".to_string()]),
+                }],
+            }],
+        })
+    }
+
+    #[test]
+    fn applied_initial_config_reports_what_the_cross_workspace_peer_actually_launched_with() {
+        // `subagents.md` promises `appliedInitialConfig` reports what the agent
+        // launched with, "so a key that was not honoured is visibly absent
+        // there" — and the cross-workspace path is exactly where the request
+        // and the row diverge: an inherited model the target does not offer is
+        // replaced by the target's default, and the inherited mode with it.
+        // Reporting the REQUEST here would tell the caller it got something it
+        // did not.
+        let caller = session("ses_caller", "workspace-1");
+        let mut request = CreateAgentSessionRequest::owned_agent(
+            &caller,
+            SpawnAgentArgs {
+                prompt: "Audit the schema".to_string(),
+                label: None,
+                harness_id: None,
+                initial_config: None,
+                wake_on_completion: false,
+                workspace_id: Some("workspace-2".to_string()),
+            },
+        )
+        .expect("build request");
+        assert!(request.is_cross_workspace(&caller));
+        assert_eq!(request.model_id.as_deref(), Some("caller-model"));
+
+        resolve_launch_against_target_workspace(&mut request, target_catalog)
+            .expect("the target's catalog decides");
+
+        // The row `create_durable_session` writes carries the RESOLVED
+        // selection, which is what the response then reads back.
+        let mut created = session("ses_peer", &request.workspace_id);
+        created.agent_kind = request.agent_kind.clone();
+        created.requested_model_id = request.model_id.clone();
+        created.current_model_id = None;
+        created.requested_mode_id = request.mode_id.clone();
+        created.current_mode_id = None;
+
+        let applied = applied_initial_config(&created);
+        assert_eq!(applied["harnessId"], "claude");
+        assert_eq!(
+            applied["modelId"], "target-model",
+            "the caller's model does not exist in the target workspace, so reporting it would be \
+             a lie the caller has no way to detect"
+        );
+        assert_eq!(applied["modeId"], "target-mode");
+        assert_ne!(applied["modelId"], "caller-model");
+        assert_ne!(applied["modeId"], "caller-mode");
+    }
+
+    #[test]
+    fn a_target_workspace_whose_checkout_is_gone_is_refused_before_anything_is_created() {
+        // Without this arm the session is created, `start_persisted_session`
+        // fails on the missing cwd, and the whole call unwinds — correct, but
+        // it answers "spawn failed" where it could answer "that workspace's
+        // checkout is gone". The gate already refuses a missing row and a
+        // non-standard surface; this is the third fact it can cheaply read.
+        use crate::app::test_support;
+        use crate::domains::repo_roots::service::RepoRootService;
+        use crate::domains::repo_roots::store::RepoRootStore;
+        use crate::domains::sessions::deletion::SessionDeleteWorkflow;
+        use crate::domains::workspaces::deletion::WorkspaceDeleteWorkflow;
+        use crate::domains::workspaces::runtime::WorkspaceRuntime;
+        use crate::domains::workspaces::store::WorkspaceStore;
+        use crate::persistence::Db;
+
+        let db = Db::open_in_memory().expect("open db");
+        let home = std::env::temp_dir().join(format!("anyharness-spawnable-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&home).expect("create runtime home");
+        let runtime = WorkspaceRuntime::new(
+            WorkspaceStore::new(db.clone()),
+            WorkspaceDeleteWorkflow::new(db.clone(), SessionDeleteWorkflow::new(db.clone())),
+            RepoRootService::new(RepoRootStore::new(db.clone())),
+            home.clone(),
+        );
+
+        test_support::seed_workspace_with_repo_root(
+            &db,
+            "workspace-here",
+            "local",
+            &home.to_string_lossy(),
+        );
+        test_support::seed_workspace_with_repo_root(
+            &db,
+            "workspace-gone",
+            "local",
+            &home.join("deleted-checkout").to_string_lossy(),
+        );
+
+        assert_spawnable_workspace(&runtime, "workspace-here")
+            .expect("a workspace whose checkout is on disk is spawnable");
+
+        let error = assert_spawnable_workspace(&runtime, "workspace-gone")
+            .err()
+            .expect("a workspace whose checkout was deleted is refused");
+        assert!(
+            error.to_string().contains("gone from disk"),
+            "unexpected refusal: {error}"
+        );
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/calls.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/calls.rs
@@ -23,9 +23,10 @@ use super::tools::{
     CreateSubagentArgs, GetAgentConfigOptionsArgs, ListAgentsArgs, PromoteSubagentArgs,
     ReadAgentTranscriptArgs, ReadAgentTranscriptMode, ReadSubagentEventsArgs,
     ReadSubagentLatestTurnsArgs, ScheduleAgentWakeArgs, SearchSubagentTranscriptArgs,
-    SendAgentMessageArgs, SendSubagentMessageArgs, SpawnAgentArgs,
+    SendAgentMessageArgs, SendSubagentMessageArgs, SpawnAgentArgs, SpawnWorkspaceArgs,
 };
-use super::AgentOpsPeerGates;
+use super::workspace_ops;
+use super::{AgentOpsPeerGates, AgentOpsWorkspaceOps};
 use crate::domains::sessions::admission::SessionMutationKind;
 use crate::domains::sessions::authorize::{authorize, AgentAccessIntent};
 use crate::domains::sessions::ownership::service::{AgentOwnershipService, OwnedAgent};
@@ -42,14 +43,17 @@ use crate::domains::sessions::transcript_read::{
     read_session_events, read_session_latest_turns, search_session_transcript,
 };
 use crate::domains::sessions::wakes::service::AgentWakeService;
+use crate::domains::workspaces::model::WorkspaceSurface;
 use crate::integrations::mcp::json_rpc::deserialize_args;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn call_tool(
     service: &SubagentService,
     wake_service: &AgentWakeService,
     session_runtime: &SessionRuntime,
     ownership: &AgentOwnershipService,
     gates: &AgentOpsPeerGates,
+    workspaces: &AgentOpsWorkspaceOps,
     ctx: &AgentOpsMcpContext,
     name: &str,
     arguments: Option<Value>,
@@ -77,7 +81,29 @@ pub async fn call_tool(
         }
         "spawn_agent" => {
             let args: SpawnAgentArgs = deserialize_args(arguments)?;
-            spawn_agent(service, ownership, wake_service, session_runtime, ctx, args).await
+            spawn_agent(
+                service,
+                ownership,
+                wake_service,
+                session_runtime,
+                gates,
+                workspaces,
+                ctx,
+                args,
+            )
+            .await
+        }
+        "get_workspace_options" => {
+            let caller = caller_session(service, &ctx.parent_session_id)?;
+            workspace_ops::get_workspace_options(
+                &workspaces.workspace_runtime,
+                &workspaces.repo_roots,
+                &caller,
+            )
+        }
+        "spawn_workspace" => {
+            let args: SpawnWorkspaceArgs = deserialize_args(arguments)?;
+            spawn_workspace(service, workspaces, ctx, args).await
         }
         "list_subagents" => service
             .list_subagents(&ctx.parent_session_id)
@@ -312,7 +338,6 @@ async fn spawn_subagent(
     let parent = service.validate_parent_can_spawn(&ctx.parent_session_id)?;
     let request = CreateAgentSessionRequest::subagent(&parent, args)?;
     let wake_requested = request.wake_on_completion;
-    let applied = applied_initial_config(&request);
     let created = create_agent_session(
         service,
         ownership,
@@ -322,6 +347,7 @@ async fn spawn_subagent(
         request,
     )
     .await?;
+    let applied = applied_initial_config(&created.session);
 
     Ok(json!({
         "sessionLinkId": created.link.id,
@@ -351,16 +377,22 @@ async fn spawn_subagent(
 /// spawn block, enforced before dispatch reaches this function, and the
 /// caller's own workspace being writable.
 ///
-/// It stays in `MUTATING_TOOL_NAMES` because it mutates exactly one workspace —
-/// the caller's, the one it creates the session in — which is the workspace the
-/// route already leased. There is no target session yet, so unlike
-/// `close_agent` there is no target permit to take first and no reason to lease
-/// anything itself.
+/// Since `spawn_workspace`, `workspaceId` may name any workspace — that is the
+/// second step of ADR §5's flow 4. That changes the fencing: the session lands
+/// in the TARGET workspace, so it is the TARGET's write lease this takes, in
+/// the call, exactly as `send_agent_message` and `configure_agent` do (and why
+/// this tool left `MUTATING_TOOL_NAMES`; the route's lease is the CALLER's).
+/// There is still no target SESSION — this call is what creates it — so there
+/// is no admission permit to take, and with a single lease and no permit there
+/// is no lock order to invert (PR1227-LOCK-01).
+#[allow(clippy::too_many_arguments)]
 async fn spawn_agent(
     service: &SubagentService,
     ownership: &AgentOwnershipService,
     wake_service: &AgentWakeService,
     session_runtime: &SessionRuntime,
+    gates: &AgentOpsPeerGates,
+    workspaces: &AgentOpsWorkspaceOps,
     ctx: &AgentOpsMcpContext,
     args: SpawnAgentArgs,
 ) -> anyhow::Result<Value> {
@@ -374,8 +406,34 @@ async fn spawn_agent(
     }
     let caller = service.validate_caller_can_spawn_agent(&ctx.parent_session_id)?;
     let request = CreateAgentSessionRequest::owned_agent(&caller, args)?;
+    if request.is_cross_workspace(&caller) {
+        // Worth a line of its own: this is the one call that reaches out of the
+        // caller's workspace, and the lease taken below is that OTHER
+        // workspace's. When a retire preflight blocks, this says who was in it.
+        tracing::info!(
+            caller_session_id = %caller.id,
+            caller_workspace_id = %caller.workspace_id,
+            target_workspace_id = %request.workspace_id,
+            "spawn_agent creating a peer in another workspace"
+        );
+    }
+    // Read-only up to here. A target workspace that does not exist or is not a
+    // standard one is refused before any gate is taken.
+    assert_spawnable_workspace(&workspaces.workspace_runtime, &request.workspace_id)?;
     let wake_requested = request.wake_on_completion;
-    let applied = applied_initial_config(&request);
+    // The caller's own workspace still has to be writable — the route stopped
+    // checking when this tool left `MUTATING_TOOL_NAMES`. No lease on it:
+    // nothing here mutates the caller's workspace.
+    assert_workspace_can_be_mutated(service.access_gate(), &ctx.workspace_id)?;
+    // The TARGET workspace's write lease, held across creation, start and the
+    // first prompt. It is that workspace's retire preflight that has to see a
+    // session being built inside it.
+    let _target_workspace_lease = lease_target_workspace_for_peer_write(
+        &gates.workspace_operation_gate,
+        service.access_gate(),
+        &request.workspace_id,
+    )
+    .await?;
     let created = create_agent_session(
         service,
         ownership,
@@ -385,6 +443,7 @@ async fn spawn_agent(
         request,
     )
     .await?;
+    let applied = applied_initial_config(&created.session);
 
     Ok(json!({
         // `sessionId` is the handle for everything afterwards: this agent is a
@@ -406,12 +465,91 @@ async fn spawn_agent(
     }))
 }
 
-fn applied_initial_config(request: &CreateAgentSessionRequest) -> Value {
+/// What the new agent actually launched with, read off the row that exists
+/// rather than off the request.
+///
+/// The two can differ: the shared routine resolves the launch selection against
+/// the TARGET workspace's catalog first, and an inherited model that workspace
+/// does not offer is replaced by its default there. Reporting the request would
+/// tell the caller it got something it did not.
+fn applied_initial_config(session: &crate::domains::sessions::model::SessionRecord) -> Value {
     json!({
-        "harnessId": request.agent_kind,
-        "modelId": request.model_id,
-        "modeId": request.mode_id,
+        "harnessId": session.agent_kind,
+        "modelId": session
+            .current_model_id
+            .clone()
+            .or_else(|| session.requested_model_id.clone()),
+        "modeId": session
+            .current_mode_id
+            .clone()
+            .or_else(|| session.requested_mode_id.clone()),
     })
+}
+
+/// The caller's own session row, for the tools that need it beyond the id.
+fn caller_session(
+    service: &SubagentService,
+    caller_session_id: &str,
+) -> anyhow::Result<crate::domains::sessions::model::SessionRecord> {
+    service
+        .session_store()
+        .find_by_id(caller_session_id)?
+        .ok_or_else(|| anyhow::anyhow!("calling session not found: {caller_session_id}"))
+}
+
+/// A workspace an agent may be put into: it has to exist and be a standard
+/// workspace, the same eligibility `validate_caller_can_create` applies to the
+/// caller's own. Whether it may be MUTATED right now is the access gate's
+/// question, asked when the lease is taken.
+fn assert_spawnable_workspace(
+    workspace_runtime: &crate::domains::workspaces::runtime::WorkspaceRuntime,
+    workspace_id: &str,
+) -> anyhow::Result<()> {
+    let workspace = workspace_runtime
+        .get_workspace(workspace_id)?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "workspace {workspace_id} does not exist. Use list_agents or spawn_workspace to \
+                 get a workspaceId you can spawn into."
+            )
+        })?;
+    if workspace.surface != WorkspaceSurface::Standard {
+        anyhow::bail!(
+            "workspace {workspace_id} is not a standard workspace; agents cannot be spawned in it"
+        );
+    }
+    Ok(())
+}
+
+/// `spawn_workspace` (ADR §3.4, §6 step 7).
+///
+/// Eligibility is the same `can_spawn_agent` signal a peer spawn uses — ADR
+/// §3.4 marks this "promoted / top level agents only", and ruling 3's block on
+/// unpromoted subagents is enforced at dispatch, before this runs.
+async fn spawn_workspace(
+    service: &SubagentService,
+    workspaces: &AgentOpsWorkspaceOps,
+    ctx: &AgentOpsMcpContext,
+    args: SpawnWorkspaceArgs,
+) -> anyhow::Result<Value> {
+    if !ctx.can_spawn_agent {
+        anyhow::bail!(
+            "{}",
+            ctx.spawn_agent_block_reason
+                .as_deref()
+                .unwrap_or("spawning workspaces is not available for this session")
+        );
+    }
+    let caller = caller_session(service, &ctx.parent_session_id)?;
+    workspace_ops::spawn_workspace(
+        &workspaces.workspace_runtime,
+        &workspaces.worktree_runtime,
+        &workspaces.repo_roots,
+        service.access_gate(),
+        &caller,
+        args,
+    )
+    .await
 }
 
 async fn send_subagent_message(

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/mod.rs
@@ -14,6 +14,10 @@ pub(crate) mod peer_ops;
 // cannot drift apart on anything that is not about ownership (ADR §3.3).
 mod spawn_ops;
 pub mod tools;
+// Where an agent may put a NEW workspace, and how one gets made — the
+// local-only gate, the creator stamp, and the server-side creation defaults
+// (ADR §3.3/§3.4). Retirement is deliberately absent: ruling 11.
+mod workspace_ops;
 
 use std::sync::Arc;
 
@@ -22,6 +26,7 @@ use serde_json::Value;
 
 use self::auth::AgentOpsMcpAuth;
 use self::context::AgentOpsMcpContext;
+use crate::domains::repo_roots::service::RepoRootService;
 use crate::domains::sessions::admission::SessionMutationAdmission;
 use crate::domains::sessions::ownership::service::AgentOwnershipService;
 use crate::domains::sessions::runtime::SessionRuntime;
@@ -29,6 +34,7 @@ use crate::domains::sessions::subagents::service::SubagentService;
 use crate::domains::sessions::wakes::service::AgentWakeService;
 use crate::domains::workspaces::operation_gate::WorkspaceOperationGate;
 use crate::domains::workspaces::runtime::WorkspaceRuntime;
+use crate::domains::workspaces::worktree_runtime::WorkspaceWorktreeRuntime;
 use crate::integrations::mcp::product_server::{
     ProductMcpAuthHeader, ProductMcpContextError, ProductMcpDefinition, ProductMcpRequestContext,
     ProductMcpServer, ProductMcpTokenValidation,
@@ -45,12 +51,25 @@ pub struct AgentOpsPeerGates {
     pub workspace_operation_gate: Arc<WorkspaceOperationGate>,
 }
 
+/// Everything the workspace tools need to describe and create one, bundled
+/// because they are the SAME dependencies the human creation surfaces use — the
+/// worktree runtime behind `POST /v1/workspaces/worktrees`, the workspace
+/// runtime behind `POST /v1/workspaces`, and the repo-root service behind the
+/// picker. Bundled rather than added as three more constructor arguments so the
+/// point stays legible: this is the human creation path, borrowed.
+#[derive(Clone)]
+pub struct AgentOpsWorkspaceOps {
+    pub workspace_runtime: Arc<WorkspaceRuntime>,
+    pub worktree_runtime: Arc<WorkspaceWorktreeRuntime>,
+    pub repo_roots: Arc<RepoRootService>,
+}
+
 #[derive(Clone)]
 pub struct AgentOpsProductMcpServer {
     service: Arc<SubagentService>,
     wake_service: Arc<AgentWakeService>,
     session_runtime: Arc<SessionRuntime>,
-    workspace_runtime: Arc<WorkspaceRuntime>,
+    workspaces: AgentOpsWorkspaceOps,
     ownership: Arc<AgentOwnershipService>,
     peer_gates: AgentOpsPeerGates,
     auth: Arc<AgentOpsMcpAuth>,
@@ -62,7 +81,7 @@ impl AgentOpsProductMcpServer {
         service: Arc<SubagentService>,
         wake_service: Arc<AgentWakeService>,
         session_runtime: Arc<SessionRuntime>,
-        workspace_runtime: Arc<WorkspaceRuntime>,
+        workspaces: AgentOpsWorkspaceOps,
         ownership: Arc<AgentOwnershipService>,
         peer_gates: AgentOpsPeerGates,
         auth: Arc<AgentOpsMcpAuth>,
@@ -71,7 +90,7 @@ impl AgentOpsProductMcpServer {
             service,
             wake_service,
             session_runtime,
-            workspace_runtime,
+            workspaces,
             ownership,
             peer_gates,
             auth,
@@ -99,7 +118,7 @@ impl ProductMcpServer for AgentOpsProductMcpServer {
         &self,
         request: &ProductMcpRequestContext,
     ) -> Result<Self::Context, ProductMcpContextError> {
-        context::resolve_context(&self.service, &self.workspace_runtime, request)
+        context::resolve_context(&self.service, &self.workspaces.workspace_runtime, request)
     }
 
     fn tools(&self, ctx: &Self::Context) -> Vec<Value> {
@@ -118,6 +137,7 @@ impl ProductMcpServer for AgentOpsProductMcpServer {
             &self.session_runtime,
             &self.ownership,
             &self.peer_gates,
+            &self.workspaces,
             ctx,
             name,
             arguments,

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/spawn_ops.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/spawn_ops.rs
@@ -21,7 +21,9 @@
 //! point: the two spawn shapes cannot drift apart on the parts that are not
 //! about ownership.
 
-use crate::domains::agents::readiness::launch_options::ResolvedWorkspaceLaunchOptions;
+use crate::domains::agents::readiness::launch_options::{
+    ResolvedLaunchAgentOption, ResolvedLaunchModelOption, ResolvedWorkspaceLaunchOptions,
+};
 use crate::domains::sessions::delegation::parent_to_child_provenance;
 use crate::domains::sessions::links::model::{SessionLinkRecord, SessionLinkRelation};
 use crate::domains::sessions::model::{SessionMcpBindingPolicy, SessionRecord};
@@ -82,6 +84,11 @@ pub(super) struct CreateAgentSessionRequest {
     /// target's default. See [`resolve_launch_against_target_workspace`].
     pub model_id_explicit: bool,
     pub mode_id: Option<String>,
+    /// The same NAMED-vs-INHERITED distinction `model_id_explicit` draws, for
+    /// the same reason: a mode the target does not offer is a refusal when the
+    /// caller asked for it and a substitution when it only came along for the
+    /// ride.
+    pub mode_id_explicit: bool,
     pub label: Option<String>,
     pub prompt: String,
     pub wake_on_completion: bool,
@@ -164,6 +171,7 @@ impl CreateAgentSessionRequest {
             anyhow::bail!("prompt is required");
         }
         let named_model_id = initial_config_string(initial_config, &["modelId", "model"]);
+        let named_mode_id = initial_config_string(initial_config, &["modeId", "mode"]);
         Ok(Self {
             ownership,
             workspace_id,
@@ -172,7 +180,8 @@ impl CreateAgentSessionRequest {
             model_id: named_model_id
                 .or_else(|| caller.current_model_id.clone())
                 .or_else(|| caller.requested_model_id.clone()),
-            mode_id: initial_config_string(initial_config, &["modeId", "mode"])
+            mode_id_explicit: named_mode_id.is_some(),
+            mode_id: named_mode_id
                 .or_else(|| caller.current_mode_id.clone())
                 .or_else(|| caller.requested_mode_id.clone()),
             label: label
@@ -213,7 +222,8 @@ impl CreateAgentSessionRequest {
 /// there, which fails later, at spawn, with a durable half-built session
 /// already inserted.
 ///
-/// The two selections are treated differently on purpose:
+/// All three selections are treated the same way, which is the point — the
+/// target's universe decides, never the caller's:
 ///
 /// - the harness is always refused when the target cannot launch it. There is
 ///   no sensible substitute — "one like me" is the request, and quietly picking
@@ -222,11 +232,19 @@ impl CreateAgentSessionRequest {
 ///   INHERITED from the caller is replaced by the target's own default: the
 ///   caller never asked for it, it only asked for "one like me", and the
 ///   target's default is exactly what the human create flow would pick there.
+/// - the mode follows the model's rule exactly. Modes are a per-model control
+///   (`ResolvedLaunchModelOption::modes`, from `controls.mode.values`), so a
+///   NAMED mode the target's model does not list is refused and an INHERITED
+///   one is replaced by that harness's curated default (`unattended_mode_id`),
+///   or dropped when the harness declares none.
 ///
-/// A target whose catalog resolves to no launchable agents at all says nothing
-/// about the request — it means readiness could not be established on this
-/// machine — so it is passed through rather than turned into a refusal that
-/// names nothing.
+/// Two arms deliberately pass through rather than refuse, and they are the same
+/// asymmetry: a target whose catalog resolves to NO launchable agents says
+/// nothing about the request — readiness could not be established on this
+/// machine — and a model that declares NO mode control says nothing about the
+/// mode. Refusing on either would name nothing the caller could act on. The
+/// cost is that an unresolvable workspace admits any harness/model/mode here;
+/// they are re-checked at start, where the failure is specific.
 ///
 /// The catalog arrives as a closure, so *which workspace id this asks about* is
 /// testable without a runtime.
@@ -253,14 +271,18 @@ where
             join_quoted(catalog.agents.iter().map(|agent| agent.kind.as_str()))
         );
     };
+    resolve_model_against_agent(request, agent)?;
+    resolve_mode_against_agent(request, agent)
+}
+
+fn resolve_model_against_agent(
+    request: &mut CreateAgentSessionRequest,
+    agent: &ResolvedLaunchAgentOption,
+) -> anyhow::Result<()> {
     let Some(model_id) = request.model_id.clone() else {
         return Ok(());
     };
-    let offered = agent
-        .models
-        .iter()
-        .any(|model| model.id == model_id || model.aliases.iter().any(|alias| *alias == model_id));
-    if offered {
+    if find_model(agent, &model_id).is_some() {
         return Ok(());
     }
     if request.model_id_explicit {
@@ -275,6 +297,56 @@ where
     // have chosen by itself rather than refusing a launch nobody specified.
     request.model_id = agent.default_model_id.clone();
     Ok(())
+}
+
+/// The mode, against the model the request SETTLED on — which is why this runs
+/// after the model is resolved: an inherited model replaced by the target's
+/// default brings the target's mode menu with it, and validating against the
+/// model the caller arrived with would check the wrong list.
+fn resolve_mode_against_agent(
+    request: &mut CreateAgentSessionRequest,
+    agent: &ResolvedLaunchAgentOption,
+) -> anyhow::Result<()> {
+    let Some(mode_id) = request.mode_id.clone() else {
+        return Ok(());
+    };
+    let model = request
+        .model_id
+        .clone()
+        .and_then(|model_id| find_model(agent, &model_id));
+    // `modes: None` is an authoritative "this model has no mode control", not
+    // an empty menu, so there is nothing here to check the selection against.
+    let Some(offered) = model.and_then(|model| model.modes.as_ref()) else {
+        return Ok(());
+    };
+    if offered.iter().any(|offered| *offered == mode_id) {
+        return Ok(());
+    }
+    if request.mode_id_explicit {
+        anyhow::bail!(
+            "mode {mode_id:?} is not available for {} in workspace {}. Available there: {}.",
+            request.agent_kind,
+            request.workspace_id,
+            join_quoted(offered.iter().map(String::as_str))
+        );
+    }
+    // Inherited only. The curated unattended mode is what this harness is
+    // vetted to run with when nobody is watching, and `None` there is an
+    // authoritative "no vetted default" — so the mode is dropped and the
+    // target picks its own at launch, rather than carrying over one the
+    // target's model does not list.
+    request.mode_id = agent.unattended_mode_id.clone();
+    Ok(())
+}
+
+fn find_model<'a>(
+    agent: &'a ResolvedLaunchAgentOption,
+    model_id: &str,
+) -> Option<&'a ResolvedLaunchModelOption> {
+    agent
+        .models
+        .iter()
+        .find(|model| model.id == model_id || model.aliases.iter().any(|alias| alias == model_id))
 }
 
 fn join_quoted<'a>(values: impl Iterator<Item = &'a str>) -> String {
@@ -394,9 +466,16 @@ fn link_new_agent(
             None,
             None,
         )?,
-        AgentSessionOwnership::OwnedAgent => {
-            ownership.link_owned_agent(&caller.id, child_session_id, request.label.clone())?
-        }
+        // The two workspace ids are handed over rather than assumed: a peer
+        // can land in a workspace the caller spawned, and the link row records
+        // which of the two it was.
+        AgentSessionOwnership::OwnedAgent => ownership.link_owned_agent(
+            &caller.id,
+            &caller.workspace_id,
+            child_session_id,
+            &request.workspace_id,
+            request.label.clone(),
+        )?,
     };
     // Which is exactly why the relation is checked rather than passed: the two
     // paths each choose their own, and a spawn that wrote the other mode's
@@ -750,6 +829,16 @@ mod tests {
         }
     }
 
+    /// A model that declares a mode control, which is the only case a mode can
+    /// be checked against. `modes: None` on `model_option` is the other case,
+    /// and it is a real one — see the pass-through test below.
+    fn model_option_offering(id: &str, modes: &[&str]) -> ResolvedLaunchModelOption {
+        ResolvedLaunchModelOption {
+            modes: Some(modes.iter().map(|mode| (*mode).to_string()).collect()),
+            ..model_option(id)
+        }
+    }
+
     fn agent_option(kind: &str, model_ids: &[&str]) -> ResolvedLaunchAgentOption {
         ResolvedLaunchAgentOption {
             kind: kind.to_string(),
@@ -757,6 +846,19 @@ mod tests {
             default_model_id: model_ids.first().map(|id| (*id).to_string()),
             unattended_mode_id: None,
             models: model_ids.iter().map(|id| model_option(id)).collect(),
+        }
+    }
+
+    fn agent_option_offering(
+        kind: &str,
+        model_id: &str,
+        modes: &[&str],
+        unattended_mode_id: Option<&str>,
+    ) -> ResolvedLaunchAgentOption {
+        ResolvedLaunchAgentOption {
+            unattended_mode_id: unattended_mode_id.map(ToString::to_string),
+            models: vec![model_option_offering(model_id, modes)],
+            ..agent_option(kind, &[model_id])
         }
     }
 
@@ -782,11 +884,21 @@ mod tests {
                 self.asked.borrow_mut().push(workspace_id.to_string());
                 Ok(ResolvedWorkspaceLaunchOptions {
                     agents: match workspace_id {
-                        "workspace-1" => {
-                            vec![agent_option("claude", &["caller-only-model"])]
-                        }
+                        "workspace-1" => vec![agent_option_offering(
+                            "claude",
+                            "caller-only-model",
+                            &["caller-only-mode"],
+                            Some("caller-only-mode"),
+                        )],
                         "workspace-2" => vec![
-                            agent_option("claude", &["target-only-model"]),
+                            agent_option_offering(
+                                "claude",
+                                "target-only-model",
+                                &["target-only-mode"],
+                                Some("target-only-mode"),
+                            ),
+                            // No mode control at all, which is the arm that
+                            // has nothing to check a mode against.
                             agent_option("codex", &["target-codex-model"]),
                         ],
                         _ => Vec::new(),
@@ -825,6 +937,79 @@ mod tests {
         // the caller workspace's default.
         assert_eq!(request.model_id.as_deref(), Some("target-only-model"));
         assert_ne!(request.model_id.as_deref(), Some("caller-only-model"));
+        // The mode is the third selection and follows the same rule: inherited,
+        // not offered there, so it becomes the target harness's curated default
+        // rather than travelling across as-is.
+        assert_eq!(request.mode_id.as_deref(), Some("target-only-mode"));
+    }
+
+    #[test]
+    fn a_mode_only_the_callers_workspace_offers_is_refused_when_the_caller_named_it() {
+        let spy = CatalogSpy::new();
+        let mut request = CreateAgentSessionRequest::owned_agent(
+            &session("ses_caller"),
+            SpawnAgentArgs {
+                workspace_id: Some("workspace-2".to_string()),
+                initial_config: Some(
+                    json!({ "modelId": "target-only-model", "modeId": "caller-only-mode" }),
+                ),
+                ..spawn_agent_args()
+            },
+        )
+        .expect("build request");
+        assert!(request.mode_id_explicit);
+
+        let error = resolve_launch_against_target_workspace(&mut request, spy.resolver())
+            .err()
+            .expect("a named mode outside the target's menu is refused");
+
+        let message = error.to_string();
+        assert!(message.contains("caller-only-mode"), "{message}");
+        // The refusal names what IS offered there, so the agent can retry.
+        assert!(message.contains("target-only-mode"), "{message}");
+    }
+
+    #[test]
+    fn a_mode_the_target_workspace_offers_is_kept_verbatim() {
+        let spy = CatalogSpy::new();
+        let mut request = CreateAgentSessionRequest::owned_agent(
+            &session("ses_caller"),
+            SpawnAgentArgs {
+                workspace_id: Some("workspace-2".to_string()),
+                initial_config: Some(
+                    json!({ "modelId": "target-only-model", "modeId": "target-only-mode" }),
+                ),
+                ..spawn_agent_args()
+            },
+        )
+        .expect("build request");
+
+        resolve_launch_against_target_workspace(&mut request, spy.resolver()).expect("accepted");
+
+        assert_eq!(request.mode_id.as_deref(), Some("target-only-mode"));
+    }
+
+    #[test]
+    fn a_model_with_no_mode_control_has_nothing_to_check_the_mode_against() {
+        // `modes: None` is "this model declares no mode control", not "no modes
+        // are allowed". Refusing there would name an empty list, so the caller's
+        // mode is passed through — the same asymmetry the empty catalog has.
+        let spy = CatalogSpy::new();
+        let mut request = CreateAgentSessionRequest::owned_agent(
+            &session("ses_caller"),
+            SpawnAgentArgs {
+                harness_id: Some("codex".to_string()),
+                workspace_id: Some("workspace-2".to_string()),
+                initial_config: Some(json!({ "modeId": "anything-at-all" })),
+                ..spawn_agent_args()
+            },
+        )
+        .expect("build request");
+
+        resolve_launch_against_target_workspace(&mut request, spy.resolver())
+            .expect("a model with no mode control decides nothing about the mode");
+
+        assert_eq!(request.mode_id.as_deref(), Some("anything-at-all"));
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/spawn_ops.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/spawn_ops.rs
@@ -21,6 +21,7 @@
 //! point: the two spawn shapes cannot drift apart on the parts that are not
 //! about ownership.
 
+use crate::domains::agents::readiness::launch_options::ResolvedWorkspaceLaunchOptions;
 use crate::domains::sessions::delegation::parent_to_child_provenance;
 use crate::domains::sessions::links::model::{SessionLinkRecord, SessionLinkRelation};
 use crate::domains::sessions::model::{SessionMcpBindingPolicy, SessionRecord};
@@ -68,9 +69,18 @@ impl AgentSessionOwnership {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct CreateAgentSessionRequest {
     pub ownership: AgentSessionOwnership,
+    /// Where the new agent lands. A subagent's is always the caller's own
+    /// (ADR §5 flow 4: "subagents stay own-workspace only"); a peer's is
+    /// whatever `spawn_agent` was asked for, which since `spawn_workspace`
+    /// exists can be a workspace the caller just created.
     pub workspace_id: String,
     pub agent_kind: String,
     pub model_id: Option<String>,
+    /// Whether `model_id` was NAMED by the caller or inherited from it. The
+    /// two behave differently when the target workspace does not offer that
+    /// model: a named model is an error, an inherited one is replaced by the
+    /// target's default. See [`resolve_launch_against_target_workspace`].
+    pub model_id_explicit: bool,
     pub mode_id: Option<String>,
     pub label: Option<String>,
     pub prompt: String,
@@ -97,6 +107,10 @@ impl CreateAgentSessionRequest {
         Self::inherit_from(
             parent,
             AgentSessionOwnership::Subagent,
+            // Own workspace only, always. A subagent is subordinate to the
+            // caller AND to the caller's checkout; `spawn_workspace` +
+            // `spawn_agent` is the cross-workspace path (ADR §5 flow 4).
+            parent.workspace_id.clone(),
             args.prompt,
             args.label,
             args.harness_id,
@@ -108,30 +122,25 @@ impl CreateAgentSessionRequest {
     /// Resolve `spawn_agent`'s arguments against the calling session. The
     /// inheritance rule is deliberately the same one subagents get: an agent
     /// asking for a peer without naming a harness means "one like me".
+    ///
+    /// `workspaceId` names where the peer lands and defaults to the caller's
+    /// own. Any workspace is allowed — that is the second half of ADR §5's
+    /// flow 4, where `spawn_workspace` creates a workspace and `spawn_agent`
+    /// puts an agent in it. Whether that workspace EXISTS, is standard, and is
+    /// writable is not decided here: this mapping is pure, and the caller
+    /// resolves and fences the target before `create_agent_session` runs.
     pub fn owned_agent(caller: &SessionRecord, args: SpawnAgentArgs) -> anyhow::Result<Self> {
-        if let Some(requested) = args
+        let target_workspace_id = args
             .workspace_id
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty())
-        {
-            // The argument is accepted rather than ignored on purpose: silently
-            // dropping it would spawn the agent somewhere the caller did not
-            // ask for. Other workspaces become reachable with `spawn_workspace`
-            // (ADR §6 step 7); until then this tool creates the session in the
-            // workspace whose write lease the route already holds.
-            if requested != caller.workspace_id {
-                anyhow::bail!(
-                    "spawn_agent creates the agent in your own workspace ({}), and cannot yet \
-                     target {requested}. Send a message to an agent already in that workspace, \
-                     or ask a person to open one.",
-                    caller.workspace_id
-                );
-            }
-        }
+            .map(ToString::to_string)
+            .unwrap_or_else(|| caller.workspace_id.clone());
         Self::inherit_from(
             caller,
             AgentSessionOwnership::OwnedAgent,
+            target_workspace_id,
             args.prompt,
             args.label,
             args.harness_id,
@@ -140,9 +149,11 @@ impl CreateAgentSessionRequest {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn inherit_from(
         caller: &SessionRecord,
         ownership: AgentSessionOwnership,
+        workspace_id: String,
         prompt: String,
         label: Option<String>,
         harness_id: Option<String>,
@@ -152,11 +163,13 @@ impl CreateAgentSessionRequest {
         if prompt.trim().is_empty() {
             anyhow::bail!("prompt is required");
         }
+        let named_model_id = initial_config_string(initial_config, &["modelId", "model"]);
         Ok(Self {
             ownership,
-            workspace_id: caller.workspace_id.clone(),
+            workspace_id,
             agent_kind: harness_id.unwrap_or_else(|| caller.agent_kind.clone()),
-            model_id: initial_config_string(initial_config, &["modelId", "model"])
+            model_id_explicit: named_model_id.is_some(),
+            model_id: named_model_id
                 .or_else(|| caller.current_model_id.clone())
                 .or_else(|| caller.requested_model_id.clone()),
             mode_id: initial_config_string(initial_config, &["modeId", "mode"])
@@ -168,6 +181,11 @@ impl CreateAgentSessionRequest {
             prompt,
             wake_on_completion,
         })
+    }
+
+    /// Whether the new agent lands somewhere other than the caller's checkout.
+    pub fn is_cross_workspace(&self, caller: &SessionRecord) -> bool {
+        self.workspace_id != caller.workspace_id
     }
 
     /// Whether the new session may spawn agents of its own.
@@ -184,6 +202,93 @@ impl CreateAgentSessionRequest {
     }
 }
 
+/// Resolve the launch selection against the workspace the agent will actually
+/// run in — never the caller's (ADR §5 flow 4).
+///
+/// This is the spawn-side twin of `config_ops`' composition rule, and it exists
+/// for the same reason: since `spawn_workspace`, the target workspace is
+/// routinely NOT the caller's, and two workspaces can have entirely different
+/// catalogs, readiness and auth contexts. Composing the caller's would let an
+/// agent launch a harness or model the target machine cannot actually run
+/// there, which fails later, at spawn, with a durable half-built session
+/// already inserted.
+///
+/// The two selections are treated differently on purpose:
+///
+/// - the harness is always refused when the target cannot launch it. There is
+///   no sensible substitute — "one like me" is the request, and quietly picking
+///   a different harness would be a different agent.
+/// - a model the caller NAMED is refused for the same reason. A model merely
+///   INHERITED from the caller is replaced by the target's own default: the
+///   caller never asked for it, it only asked for "one like me", and the
+///   target's default is exactly what the human create flow would pick there.
+///
+/// A target whose catalog resolves to no launchable agents at all says nothing
+/// about the request — it means readiness could not be established on this
+/// machine — so it is passed through rather than turned into a refusal that
+/// names nothing.
+///
+/// The catalog arrives as a closure, so *which workspace id this asks about* is
+/// testable without a runtime.
+pub(super) fn resolve_launch_against_target_workspace<C>(
+    request: &mut CreateAgentSessionRequest,
+    resolve_workspace_launch_options: C,
+) -> anyhow::Result<()>
+where
+    C: FnOnce(&str) -> anyhow::Result<ResolvedWorkspaceLaunchOptions>,
+{
+    let catalog = resolve_workspace_launch_options(&request.workspace_id)?;
+    if catalog.agents.is_empty() {
+        return Ok(());
+    }
+    let Some(agent) = catalog
+        .agents
+        .iter()
+        .find(|agent| agent.kind == request.agent_kind)
+    else {
+        anyhow::bail!(
+            "{} cannot be launched in workspace {}. Launchable there: {}.",
+            request.agent_kind,
+            request.workspace_id,
+            join_quoted(catalog.agents.iter().map(|agent| agent.kind.as_str()))
+        );
+    };
+    let Some(model_id) = request.model_id.clone() else {
+        return Ok(());
+    };
+    let offered = agent
+        .models
+        .iter()
+        .any(|model| model.id == model_id || model.aliases.iter().any(|alias| *alias == model_id));
+    if offered {
+        return Ok(());
+    }
+    if request.model_id_explicit {
+        anyhow::bail!(
+            "model {model_id:?} is not available for {} in workspace {}. Available there: {}.",
+            request.agent_kind,
+            request.workspace_id,
+            join_quoted(agent.models.iter().map(|model| model.id.as_str()))
+        );
+    }
+    // Inherited, not asked for: fall back to what the target workspace would
+    // have chosen by itself rather than refusing a launch nobody specified.
+    request.model_id = agent.default_model_id.clone();
+    Ok(())
+}
+
+fn join_quoted<'a>(values: impl Iterator<Item = &'a str>) -> String {
+    let joined = values
+        .map(|value| format!("{value:?}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    if joined.is_empty() {
+        "nothing".to_string()
+    } else {
+        joined
+    }
+}
+
 /// Create, own, start and prompt one new agent, unwinding on any failure.
 pub(super) async fn create_agent_session(
     service: &SubagentService,
@@ -191,8 +296,15 @@ pub(super) async fn create_agent_session(
     wake_service: &AgentWakeService,
     session_runtime: &SessionRuntime,
     caller: &SessionRecord,
-    request: CreateAgentSessionRequest,
+    mut request: CreateAgentSessionRequest,
 ) -> anyhow::Result<CreatedAgentSession> {
+    // Against the TARGET workspace's options, before a single durable row
+    // exists: a harness or model that workspace cannot run would otherwise
+    // fail at start, with a half-built session already inserted.
+    resolve_launch_against_target_workspace(&mut request, |workspace_id| {
+        session_runtime.resolved_workspace_launch_options(workspace_id)
+    })?;
+    let request = request;
     let child = session_runtime
         .create_durable_session(
             &request.workspace_id,
@@ -395,6 +507,9 @@ fn cleanup_child_session_after_failed_launch(
 mod tests {
     use super::*;
     use crate::app::test_support;
+    use crate::domains::agents::readiness::launch_options::{
+        ResolvedLaunchAgentOption, ResolvedLaunchModelOption,
+    };
     use crate::domains::sessions::admission::{NoControllerPolicy, SessionMutationAdmission};
     use crate::domains::sessions::agent_ops::peer_ops::consume_reply_wake;
     use crate::domains::sessions::agent_ops::tools::SpawnAgentArgs;
@@ -570,7 +685,7 @@ mod tests {
     }
 
     #[test]
-    fn spawn_agent_takes_the_callers_own_workspace_and_refuses_another() {
+    fn spawn_agent_lands_the_peer_in_the_workspace_it_was_given() {
         let caller = session("ses_caller");
 
         let same = CreateAgentSessionRequest::owned_agent(
@@ -582,20 +697,256 @@ mod tests {
         )
         .expect("naming your own workspace is fine");
         assert_eq!(same.workspace_id, "workspace-1");
+        assert!(!same.is_cross_workspace(&caller));
 
-        // Refused rather than ignored: silently spawning in the caller's
-        // workspace would put the agent somewhere it was not asked for, and the
-        // route's write lease covers only this workspace anyway.
-        let error = CreateAgentSessionRequest::owned_agent(
+        // The other half of ADR §5 flow 4: `spawn_workspace` makes a workspace,
+        // and this is the tool that puts an agent in it. Refusing here (as the
+        // pre-`spawn_workspace` build did) would leave the new workspace with
+        // no way to get an agent into it.
+        let elsewhere = CreateAgentSessionRequest::owned_agent(
             &caller,
             SpawnAgentArgs {
                 workspace_id: Some("workspace-2".to_string()),
                 ..spawn_agent_args()
             },
         )
-        .err()
-        .expect("another workspace is refused");
-        assert!(error.to_string().contains("workspace-2"));
+        .expect("another workspace is allowed");
+        assert_eq!(elsewhere.workspace_id, "workspace-2");
+        assert!(elsewhere.is_cross_workspace(&caller));
+
+        // Omitted still means "here".
+        let defaulted =
+            CreateAgentSessionRequest::owned_agent(&caller, spawn_agent_args()).expect("build");
+        assert_eq!(defaulted.workspace_id, "workspace-1");
+    }
+
+    #[test]
+    fn a_subagent_is_pinned_to_the_callers_workspace_with_no_way_to_ask_otherwise() {
+        // Ruling: subagents stay own-workspace only (ADR §5 flow 4). The tool
+        // takes no workspace argument at all, so this pins the derivation.
+        let request = CreateAgentSessionRequest::subagent(&session("ses_caller"), subagent_args())
+            .expect("build request");
+
+        assert_eq!(request.workspace_id, "workspace-1");
+        assert!(!request.is_cross_workspace(&session("ses_caller")));
+    }
+
+    // --- launch validation against the TARGET workspace (ADR §5 flow 4) ---
+
+    fn model_option(id: &str) -> ResolvedLaunchModelOption {
+        ResolvedLaunchModelOption {
+            id: id.to_string(),
+            display_name: id.to_string(),
+            aliases: Vec::new(),
+            is_default: false,
+            default_opt_in: None,
+            description: None,
+            provider: None,
+            status: None,
+            effort: None,
+            live_effort_candidates: Vec::new(),
+            fast_mode: false,
+            modes: None,
+        }
+    }
+
+    fn agent_option(kind: &str, model_ids: &[&str]) -> ResolvedLaunchAgentOption {
+        ResolvedLaunchAgentOption {
+            kind: kind.to_string(),
+            display_name: kind.to_string(),
+            default_model_id: model_ids.first().map(|id| (*id).to_string()),
+            unattended_mode_id: None,
+            models: model_ids.iter().map(|id| model_option(id)).collect(),
+        }
+    }
+
+    /// Records which workspace id the launch resolution asked the catalog
+    /// about, and answers with deliberately DISJOINT menus per workspace, so
+    /// composing the wrong one is visible in the outcome and not only in the
+    /// spy. Same shape as `config_ops`' spy, for the same guarantee.
+    struct CatalogSpy {
+        asked: std::cell::RefCell<Vec<String>>,
+    }
+
+    impl CatalogSpy {
+        fn new() -> Self {
+            Self {
+                asked: std::cell::RefCell::new(Vec::new()),
+            }
+        }
+
+        fn resolver(
+            &self,
+        ) -> impl FnOnce(&str) -> anyhow::Result<ResolvedWorkspaceLaunchOptions> + '_ {
+            move |workspace_id: &str| {
+                self.asked.borrow_mut().push(workspace_id.to_string());
+                Ok(ResolvedWorkspaceLaunchOptions {
+                    agents: match workspace_id {
+                        "workspace-1" => {
+                            vec![agent_option("claude", &["caller-only-model"])]
+                        }
+                        "workspace-2" => vec![
+                            agent_option("claude", &["target-only-model"]),
+                            agent_option("codex", &["target-codex-model"]),
+                        ],
+                        _ => Vec::new(),
+                    },
+                })
+            }
+        }
+    }
+
+    fn cross_workspace_request() -> CreateAgentSessionRequest {
+        CreateAgentSessionRequest::owned_agent(
+            &session("ses_caller"),
+            SpawnAgentArgs {
+                workspace_id: Some("workspace-2".to_string()),
+                ..spawn_agent_args()
+            },
+        )
+        .expect("build request")
+    }
+
+    #[test]
+    fn the_launch_selection_is_resolved_against_the_target_workspace_not_the_caller() {
+        let spy = CatalogSpy::new();
+        let mut request = cross_workspace_request();
+        // Inherited from the caller, whose workspace is the only place that
+        // model exists.
+        assert_eq!(request.model_id.as_deref(), Some("current-model"));
+        assert!(!request.model_id_explicit);
+
+        resolve_launch_against_target_workspace(&mut request, spy.resolver())
+            .expect("an inherited model the target lacks falls back, it does not fail");
+
+        // The whole point: workspace-2, never workspace-1.
+        assert_eq!(spy.asked.borrow().as_slice(), ["workspace-2"]);
+        // And it landed on the TARGET's default, not the caller's model and not
+        // the caller workspace's default.
+        assert_eq!(request.model_id.as_deref(), Some("target-only-model"));
+        assert_ne!(request.model_id.as_deref(), Some("caller-only-model"));
+    }
+
+    #[test]
+    fn a_model_only_the_callers_workspace_offers_is_refused_when_the_caller_named_it() {
+        let spy = CatalogSpy::new();
+        let mut request = CreateAgentSessionRequest::owned_agent(
+            &session("ses_caller"),
+            SpawnAgentArgs {
+                workspace_id: Some("workspace-2".to_string()),
+                initial_config: Some(json!({ "modelId": "caller-only-model" })),
+                ..spawn_agent_args()
+            },
+        )
+        .expect("build request");
+        assert!(request.model_id_explicit);
+
+        let error = resolve_launch_against_target_workspace(&mut request, spy.resolver())
+            .err()
+            .expect("a named model outside the target's catalog is refused");
+
+        assert!(error.to_string().contains("caller-only-model"));
+        // Resolving against the caller's catalog would have accepted it.
+        assert_eq!(spy.asked.borrow().as_slice(), ["workspace-2"]);
+    }
+
+    #[test]
+    fn a_model_the_target_workspace_offers_is_kept_verbatim() {
+        let spy = CatalogSpy::new();
+        let mut request = CreateAgentSessionRequest::owned_agent(
+            &session("ses_caller"),
+            SpawnAgentArgs {
+                workspace_id: Some("workspace-2".to_string()),
+                initial_config: Some(json!({ "modelId": "target-only-model" })),
+                ..spawn_agent_args()
+            },
+        )
+        .expect("build request");
+
+        resolve_launch_against_target_workspace(&mut request, spy.resolver()).expect("accepted");
+
+        assert_eq!(request.model_id.as_deref(), Some("target-only-model"));
+    }
+
+    #[test]
+    fn a_harness_the_target_cannot_launch_is_refused_and_names_what_it_can() {
+        let spy = CatalogSpy::new();
+        let mut request = CreateAgentSessionRequest::owned_agent(
+            &session("ses_caller"),
+            SpawnAgentArgs {
+                harness_id: Some("grok".to_string()),
+                workspace_id: Some("workspace-2".to_string()),
+                ..spawn_agent_args()
+            },
+        )
+        .expect("build request");
+
+        let error = resolve_launch_against_target_workspace(&mut request, spy.resolver())
+            .err()
+            .expect("an unlaunchable harness is refused");
+
+        let message = error.to_string();
+        assert!(message.contains("grok"));
+        assert!(message.contains("claude"));
+        assert!(message.contains("codex"));
+    }
+
+    #[test]
+    fn a_workspace_whose_catalog_resolves_to_nothing_is_passed_through() {
+        // No launchable agents means readiness could not be established here,
+        // not that the request is wrong. Refusing would name nothing.
+        let spy = CatalogSpy::new();
+        let mut request = CreateAgentSessionRequest::owned_agent(
+            &session("ses_caller"),
+            SpawnAgentArgs {
+                workspace_id: Some("workspace-unknown".to_string()),
+                ..spawn_agent_args()
+            },
+        )
+        .expect("build request");
+
+        resolve_launch_against_target_workspace(&mut request, spy.resolver())
+            .expect("an empty catalog decides nothing");
+
+        assert_eq!(request.agent_kind, "claude");
+        assert_eq!(request.model_id.as_deref(), Some("current-model"));
+    }
+
+    #[test]
+    fn the_real_resolver_is_handed_the_target_workspace_too() {
+        // The spy tests above pin the ROUTINE. This pins the one call site that
+        // feeds it: `create_agent_session` has both the caller and the request
+        // in scope, and passing `caller.workspace_id` would compile, pass every
+        // test above, and quietly compose a cross-workspace spawn against the
+        // wrong catalog.
+        let source = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("src/domains/sessions/agent_ops/spawn_ops.rs"),
+        )
+        .expect("read spawn_ops.rs");
+        let body = source
+            .split_once("pub(super) async fn create_agent_session(")
+            .expect("create_agent_session exists")
+            .1;
+        let body = body
+            .split_once("\npub ")
+            .map(|(head, _)| head)
+            .unwrap_or(body);
+        let call = body
+            .split_once("resolve_launch_against_target_workspace(")
+            .expect("create_agent_session must resolve the launch selection first")
+            .1;
+        let call = &call[..call.find("})?;").expect("closure ends") + 4];
+        assert!(
+            call.contains("session_runtime.resolved_workspace_launch_options(workspace_id)"),
+            "create_agent_session must resolve against the workspace the routine names — the \
+             TARGET's"
+        );
+        assert!(
+            !call.contains("caller."),
+            "create_agent_session must not resolve the launch selection against the CALLER's \
+             workspace: the target authorizes its own harnesses and models"
+        );
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/tools.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/tools.rs
@@ -33,15 +33,21 @@ pub const DEPRECATED_TOOL_ALIASES: &[(&str, &str)] = &[
 // takes that session's mutation permit, which has to be OUTSIDE any workspace
 // lease.
 //
-// `spawn_agent` IS here, and for the opposite reason to `close_agent`: a spawn
-// has no target yet, so there is no target session permit to take and no other
-// workspace involved. What it mutates is the CALLER's workspace — it creates a
-// session in it — which is precisely the workspace the route's lease covers,
-// exactly as for `spawn_subagent`.
+// `spawn_agent` is ALSO absent, since `spawn_workspace` gave it somewhere else
+// to spawn into. It creates a session in the TARGET workspace — which is the
+// workspace whose retire preflight has to see that work — so it takes that
+// workspace's write lease itself, exactly like `send_agent_message`. It has no
+// permit to order against (there is no target session until it makes one), so
+// it holds one lease and nothing else.
+//
+// `spawn_workspace` is absent for a different reason again: the workspace it
+// mutates does not exist yet, so there is nothing to lease at all. It gates on
+// the repo root's ACCESS state instead — the same thing the human worktree
+// route (`api/http/workspaces_worktrees.rs`) does, and for the same reason.
+// `get_workspace_options` is read-only, like every other `get_*` here.
 pub const MUTATING_TOOL_NAMES: &[&str] = &[
     "spawn_subagent",
     "create_subagent",
-    "spawn_agent",
     "send_subagent_message",
     "schedule_subagent_wake",
     "schedule_agent_wake",
@@ -59,6 +65,12 @@ pub const SPAWN_STYLE_TOOL_NAMES: &[&str] = &[
     "spawn_subagent",
     "create_subagent",
     "spawn_agent",
+    // Ruling 3 names workspaces explicitly: an unpromoted subagent "cannot call
+    // ANY spawn-style tool (subagent, agent, workspace)". `get_workspace_options`
+    // joins its `get_subagent_launch_options` sibling for the same reason — the
+    // shape of a spawn it may not perform is not information it can act on.
+    "get_workspace_options",
+    "spawn_workspace",
 ];
 
 pub fn is_spawn_style_tool(name: &str) -> bool {
@@ -89,9 +101,9 @@ pub struct CreateSubagentArgs {
 
 /// `spawn_agent`'s arguments. Deliberately the same shape as
 /// `CreateSubagentArgs` — the launch vocabulary an agent already knows — plus
-/// `workspaceId`, which ADR §3.4 names. Until `spawn_workspace` lands there is
-/// only one workspace this tool can use, so naming a different one is refused
-/// rather than ignored (`spawn_ops::CreateAgentSessionRequest::owned_agent`).
+/// `workspaceId`, which ADR §3.4 names. It defaults to the caller's own
+/// workspace and accepts any other: naming one is the second step of ADR §5's
+/// flow 4, after `spawn_workspace` returned it.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SpawnAgentArgs {
@@ -106,6 +118,28 @@ pub struct SpawnAgentArgs {
     pub wake_on_completion: bool,
     #[serde(default)]
     pub workspace_id: Option<String>,
+}
+
+/// `spawn_workspace`'s arguments — the three ADR §3.4 allows, plus a label for
+/// the provenance stamp. Everything else about workspace creation (base branch,
+/// name-conflict policy, setup script, checkout mode, surface) is server-side
+/// policy: §3.1's alternatives section rejects exposing the full creation
+/// surface to agents.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpawnWorkspaceArgs {
+    /// Defaults to the caller's own repo root — "the same git repo" of ADR §1
+    /// requirement 7.
+    #[serde(default)]
+    pub repo_root_id: Option<String>,
+    /// `worktree` (default) or `local`.
+    #[serde(default)]
+    pub mode: Option<String>,
+    /// Required iff `mode` is `worktree`.
+    #[serde(default)]
+    pub branch_name: Option<String>,
+    #[serde(default)]
+    pub label: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -275,6 +309,11 @@ pub fn build_tool_list(ctx: &AgentOpsMcpContext) -> Vec<Value> {
             "Describe subagent creation defaults, limits, supported agent/model choices, and available parent mode hints.",
             json!({ "type": "object", "properties": {} }),
         ));
+        tools.push(tool_definition(
+            "get_workspace_options",
+            "Describe the workspaces you could spawn: every git repo configured on this machine (id, name, path, default and current branch) and, per repo, the two ways to open one — a new branch in its own checkout (worktree) or the existing checkout in place (local). Repos this machine does not actually have are listed as unavailable with the reason. Read this before spawn_workspace.",
+            json!({ "type": "object", "properties": {} }),
+        ));
     }
 
     tools.extend([
@@ -405,9 +444,32 @@ pub fn build_tool_list(ctx: &AgentOpsMcpContext) -> Vec<Value> {
                         }
                     },
                     "wakeOnCompletion": { "type": "boolean", "description": "Wake you when the new agent finishes its first turn. Its reply already wakes you with the full message; this is the safety net for one that answers nobody." },
-                    "workspaceId": { "type": "string", "description": "Must be your own workspace. Spawning into another workspace is not available yet." }
+                    "workspaceId": { "type": "string", "description": "Where to put the agent. Defaults to your own workspace; pass the workspaceId from spawn_workspace to put it somewhere new. The harness and model are checked against THAT workspace's catalog, not yours." }
                 },
                 "required": ["prompt"]
+            }),
+        ));
+        tools.push(tool_definition(
+            "spawn_workspace",
+            "Create a new workspace on this machine and get back its workspaceId, so you can \
+             spawn_agent into it. mode=worktree (the default) makes a new branch in its own \
+             checkout and leaves every existing checkout alone; mode=local opens a repo's \
+             existing checkout in place, sharing files and git state with whoever else is in it. \
+             Call get_workspace_options first for the repos you can use. Base branch, name \
+             collisions and the setup script are handled for you. Workspaces you spawn cannot be \
+             removed by you or any other agent — only a person can retire one.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "repoRootId": { "type": "string", "description": "Repo to open, from get_workspace_options. Defaults to the repo your own workspace is in." },
+                    "mode": {
+                        "type": "string",
+                        "enum": ["worktree", "local"],
+                        "description": "Defaults to worktree."
+                    },
+                    "branchName": { "type": "string", "description": "Branch to create. Required for mode=worktree, ignored for mode=local. A name already in use gets a numeric suffix rather than failing." },
+                    "label": { "type": "string", "description": "Short note recorded with the workspace, shown to whoever looks at where it came from." }
+                }
             }),
         ));
     }
@@ -985,13 +1047,154 @@ mod tests {
     }
 
     #[test]
-    fn spawn_agent_leases_at_the_route_because_it_creates_in_the_callers_workspace() {
-        // The mirror of `close_agent`: a close acts on an existing target
-        // session somewhere else, so it fences itself. A spawn has no target
-        // yet — what it mutates is the caller's own workspace, which is exactly
-        // what the route leased.
-        assert!(MUTATING_TOOL_NAMES.contains(&"spawn_agent"));
+    fn spawn_agent_leases_in_the_call_because_it_can_create_in_another_workspace() {
+        // It used to lease at the route, back when the only workspace it could
+        // reach was the caller's. `spawn_workspace` changed that: the session it
+        // creates lands in the TARGET workspace, and it is the TARGET's retire
+        // preflight that has to see the work — so it takes that lease itself,
+        // like `send_agent_message`. Re-adding it here would take the CALLER's
+        // lease, which for a cross-workspace spawn fences the wrong workspace.
+        assert!(!MUTATING_TOOL_NAMES.contains(&"spawn_agent"));
+        // `spawn_subagent` still leases at the route: a subagent is always in
+        // the caller's own workspace, which is the one in the URL.
         assert!(MUTATING_TOOL_NAMES.contains(&"spawn_subagent"));
+        assert!(MUTATING_TOOL_NAMES.contains(&"create_subagent"));
+    }
+
+    // --- workspace spawn (ADR §3.4, §6 step 7) ---------------------------
+
+    #[test]
+    fn spawning_a_workspace_takes_no_route_lease_because_there_is_nothing_to_lease() {
+        // A workspace operation lease is keyed by workspace id, and the
+        // workspace this creates has no id until it exists. The route would
+        // therefore lease the CALLER's workspace, which is not what is being
+        // mutated. It gates on the repo root's access state in-call instead —
+        // the same thing `POST /v1/workspaces/worktrees` does.
+        assert!(!MUTATING_TOOL_NAMES.contains(&"spawn_workspace"));
+        // Read-only, like every other `get_*` on this server.
+        assert!(!MUTATING_TOOL_NAMES.contains(&"get_workspace_options"));
+    }
+
+    #[test]
+    fn both_workspace_tools_are_spawn_style() {
+        // Ruling 3 lists workspaces alongside subagents and agents, and the
+        // gate that binds is the dispatch one, so both wire names must be here.
+        assert!(is_spawn_style_tool("spawn_workspace"));
+        assert!(is_spawn_style_tool("get_workspace_options"));
+    }
+
+    #[test]
+    fn spawn_workspace_takes_the_three_arguments_the_adr_allows() {
+        let spawn = build_tool_list(&context(true, 0))
+            .into_iter()
+            .find(|tool| tool.get("name").and_then(Value::as_str) == Some("spawn_workspace"))
+            .expect("spawn_workspace is advertised");
+
+        for field in ["repoRootId", "mode", "branchName"] {
+            assert!(
+                spawn
+                    .pointer(&format!("/inputSchema/properties/{field}"))
+                    .is_some(),
+                "spawn_workspace does not accept {field}"
+            );
+        }
+        // Everything else about workspace creation is server-side policy: the
+        // ADR rejects exposing conflict policy, checkout mode or the setup
+        // script to agents, so their presence here would be a scope leak.
+        for withheld in [
+            "setupScript",
+            "nameConflictPolicy",
+            "checkoutMode",
+            "baseBranch",
+            "targetPath",
+            "surface",
+        ] {
+            assert!(
+                spawn
+                    .pointer(&format!("/inputSchema/properties/{withheld}"))
+                    .is_none(),
+                "spawn_workspace exposes {withheld}, which is server-side policy"
+            );
+        }
+        // Every argument is optional: the default is a worktree off the
+        // caller's own repo.
+        assert!(spawn.pointer("/inputSchema/required").is_none());
+        assert_eq!(
+            spawn
+                .pointer("/inputSchema/properties/mode/enum")
+                .and_then(Value::as_array)
+                .map(|values| values.iter().filter_map(Value::as_str).collect::<Vec<_>>()),
+            Some(vec!["worktree", "local"])
+        );
+    }
+
+    #[test]
+    fn an_unpromoted_subagent_is_offered_no_way_to_spawn_a_workspace() {
+        let names = tool_names(&build_tool_list(&unpromoted_subagent_context()))
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+
+        assert!(!names.iter().any(|name| name == "spawn_workspace"));
+        assert!(!names.iter().any(|name| name == "get_workspace_options"));
+    }
+
+    #[test]
+    fn a_capped_parent_can_still_spawn_a_workspace() {
+        // The fanout cap bounds LINKED children (ruling 9). A workspace is not
+        // one, so the cap must not reach it.
+        let names = tool_names(&build_tool_list(&context(false, 8)))
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+
+        assert!(names.iter().any(|name| name == "spawn_workspace"));
+        assert!(names.iter().any(|name| name == "get_workspace_options"));
+    }
+
+    /// Ruling 11: workspaces an agent spawns are retired by PEOPLE. Nothing on
+    /// this server may undo one, and this is the ratchet that says so — a tool
+    /// named for removal would have to be added here deliberately, which is the
+    /// point at which somebody has to re-read the ruling.
+    #[test]
+    fn no_agent_ops_tool_can_retire_or_delete_a_workspace() {
+        let advertised = tool_names(&build_tool_list(&context(true, 3)))
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        let every_name = advertised
+            .iter()
+            .map(String::as_str)
+            .chain(MUTATING_TOOL_NAMES.iter().copied())
+            .chain(SPAWN_STYLE_TOOL_NAMES.iter().copied())
+            .chain(DEPRECATED_TOOL_ALIASES.iter().map(|(alias, _)| *alias));
+
+        for name in every_name {
+            for forbidden in ["retire", "purge", "delete_workspace", "remove_workspace"] {
+                assert!(
+                    !name.contains(forbidden),
+                    "agent ops advertises {name}, which looks like workspace removal — ruling 11 \
+                     keeps retirement human-only"
+                );
+            }
+        }
+        // And the dispatch surface itself never reaches the destruction paths.
+        let calls = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("src/domains/sessions/agent_ops/workspace_ops.rs"),
+        )
+        .expect("read workspace_ops.rs");
+        for forbidden in [
+            "retire_workspace",
+            "WorkspaceRetireService",
+            "WorkspacePurgeService",
+            "delete_workspace",
+        ] {
+            assert!(
+                !calls.contains(forbidden),
+                "workspace_ops.rs references {forbidden}; ruling 11 keeps retirement human-only"
+            );
+        }
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/tools.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/tools.rs
@@ -128,8 +128,10 @@ pub struct SpawnAgentArgs {
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SpawnWorkspaceArgs {
-    /// Defaults to the caller's own repo root — "the same git repo" of ADR §1
-    /// requirement 7.
+    /// Defaults to the caller's own repo root, and accepts any other configured
+    /// root on this machine — ADR §3.4's `get_workspace_options` contract lists
+    /// them all with the caller's marked as the default (§1 requirement 7's
+    /// "the same git repo" is the summary that amendment supersedes).
     #[serde(default)]
     pub repo_root_id: Option<String>,
     /// `worktree` (default) or `local`.
@@ -416,7 +418,9 @@ pub fn build_tool_list(ctx: &AgentOpsMcpContext) -> Vec<Value> {
     if ctx.can_spawn_agent && !ctx.is_unpromoted_subagent {
         tools.push(tool_definition(
             "spawn_agent",
-            "Create a new top-level agent you own, in your workspace, and send it a first message. \
+            "Create a new top-level agent you own and send it a first message. It lands in \
+             workspaceId, which defaults to your own workspace — pass the one spawn_workspace \
+             returned, or any workspaceId from get_workspace_options, to put it somewhere else. \
              It is a PEER, not a subagent: it is not capped, it does not close when you close, and \
              it can spawn agents of its own from the start. Talk to it afterwards with \
              send_agent_message and its sessionId, exactly like any other agent. Use \
@@ -426,7 +430,7 @@ pub fn build_tool_list(ctx: &AgentOpsMcpContext) -> Vec<Value> {
                 "properties": {
                     "prompt": { "type": "string", "description": "First message, delivered inside an envelope naming you and your session id so the agent can reply." },
                     "label": { "type": "string", "description": "Short name for the agent, shown wherever it appears." },
-                    "harnessId": { "type": "string", "description": "Defaults to your own harness. See get_subagent_launch_options for what this workspace can launch." },
+                    "harnessId": { "type": "string", "description": "Defaults to your own harness. Checked against the TARGET workspace's catalog: get_subagent_launch_options describes YOUR workspace, which is the right answer only when workspaceId is yours." },
                     // Open, and open for the same reason `spawn_subagent` is:
                     // one launch vocabulary across both spawns, so an agent
                     // that learned one does not meet a stricter second. Only
@@ -439,12 +443,12 @@ pub fn build_tool_list(ctx: &AgentOpsMcpContext) -> Vec<Value> {
                         "type": "object",
                         "additionalProperties": true,
                         "properties": {
-                            "modelId": { "type": "string", "description": "Defaults to your current model." },
-                            "modeId": { "type": "string", "description": "Defaults to your current mode." }
+                            "modelId": { "type": "string", "description": "Defaults to your current model. A model you name that the target workspace does not offer is refused; an inherited one it does not offer becomes that workspace's default." },
+                            "modeId": { "type": "string", "description": "Defaults to your current mode, with the same rule as modelId against the target workspace." }
                         }
                     },
                     "wakeOnCompletion": { "type": "boolean", "description": "Wake you when the new agent finishes its first turn. Its reply already wakes you with the full message; this is the safety net for one that answers nobody." },
-                    "workspaceId": { "type": "string", "description": "Where to put the agent. Defaults to your own workspace; pass the workspaceId from spawn_workspace to put it somewhere new. The harness and model are checked against THAT workspace's catalog, not yours." }
+                    "workspaceId": { "type": "string", "description": "Where to put the agent. Defaults to your own workspace. To put it somewhere else, pass the workspaceId spawn_workspace returned (get_workspace_options first, for the repos you can spawn one in), or one list_agents reports for an existing agent. The harness, model and mode are all checked against the TARGET workspace's catalog, not yours." }
                 },
                 "required": ["prompt"]
             }),
@@ -454,10 +458,12 @@ pub fn build_tool_list(ctx: &AgentOpsMcpContext) -> Vec<Value> {
             "Create a new workspace on this machine and get back its workspaceId, so you can \
              spawn_agent into it. mode=worktree (the default) makes a new branch in its own \
              checkout and leaves every existing checkout alone; mode=local opens a repo's \
-             existing checkout in place, sharing files and git state with whoever else is in it. \
-             Call get_workspace_options first for the repos you can use. Base branch, name \
-             collisions and the setup script are handled for you. Workspaces you spawn cannot be \
-             removed by you or any other agent — only a person can retire one.",
+             existing checkout in place, sharing files and git state with whoever else is in it — \
+             and giving you back the workspace that already covers that checkout if there is one, \
+             rather than a second one. Call get_workspace_options first for the repos you can \
+             use. Base branch, name collisions and the setup script are handled for you. \
+             Workspaces you spawn cannot be removed by you or any other agent — only a person can \
+             retire one.",
             json!({
                 "type": "object",
                 "properties": {
@@ -468,7 +474,7 @@ pub fn build_tool_list(ctx: &AgentOpsMcpContext) -> Vec<Value> {
                         "description": "Defaults to worktree."
                     },
                     "branchName": { "type": "string", "description": "Branch to create. Required for mode=worktree, ignored for mode=local. A name already in use gets a numeric suffix rather than failing." },
-                    "label": { "type": "string", "description": "Short note recorded with the workspace, shown to whoever looks at where it came from." }
+                    "label": { "type": "string", "description": "Short note recorded with the workspace, shown to whoever looks at where it came from. Trimmed to 200 characters." }
                 }
             }),
         ));
@@ -1084,6 +1090,47 @@ mod tests {
     }
 
     #[test]
+    fn spawn_agent_tells_the_agent_where_the_peer_lands_and_what_authorizes_it() {
+        // A session's tool list is frozen at launch, so this copy is the whole
+        // of the contract for as long as that agent runs — a description that
+        // still says "in your workspace" is not self-correcting, and an agent
+        // that reads `get_subagent_launch_options` as authoritative for a
+        // CROSS-workspace spawn gets a refusal it was told to expect success
+        // from. Both facts are pinned here rather than left to a reader.
+        let spawn = build_tool_list(&context(true, 0))
+            .into_iter()
+            .find(|tool| tool.get("name").and_then(Value::as_str) == Some("spawn_agent"))
+            .expect("spawn_agent is advertised");
+        let description = spawn
+            .get("description")
+            .and_then(Value::as_str)
+            .expect("spawn_agent has a description");
+
+        assert!(
+            !description.contains("in your workspace"),
+            "spawn_agent no longer creates only in the caller's workspace"
+        );
+        assert!(description.contains("workspaceId"));
+        assert!(description.contains("spawn_workspace"));
+
+        for field in ["harnessId", "workspaceId"] {
+            let field_description = spawn
+                .pointer(&format!("/inputSchema/properties/{field}/description"))
+                .and_then(Value::as_str)
+                .unwrap_or_else(|| panic!("{field} has a description"));
+            assert!(
+                field_description.contains("TARGET"),
+                "{field} is validated against the target workspace's catalog, and its description \
+                 has to say so: {field_description}"
+            );
+        }
+        assert!(spawn
+            .pointer("/inputSchema/properties/workspaceId/description")
+            .and_then(Value::as_str)
+            .is_some_and(|description| description.contains("get_workspace_options")));
+    }
+
+    #[test]
     fn spawn_workspace_takes_the_three_arguments_the_adr_allows() {
         let spawn = build_tool_list(&context(true, 0))
             .into_iter()
@@ -1116,9 +1163,18 @@ mod tests {
                 "spawn_workspace exposes {withheld}, which is server-side policy"
             );
         }
-        // Every argument is optional: the default is a worktree off the
-        // caller's own repo.
+        // No `required` array, which is NOT the same as "every argument is
+        // optional": the default mode is `worktree`, and `worktree` requires
+        // `branchName`, so an argument-free call always fails. The requirement
+        // is conditional and JSON Schema cannot say so here without a `oneOf`
+        // the harnesses read inconsistently, so it is stated in `branchName`'s
+        // own description instead. What this pins is that nothing was made
+        // unconditionally required — `repoRootId` and `mode` genuinely default.
         assert!(spawn.pointer("/inputSchema/required").is_none());
+        assert!(spawn
+            .pointer("/inputSchema/properties/branchName/description")
+            .and_then(Value::as_str)
+            .is_some_and(|description| description.contains("Required for mode=worktree")));
         assert_eq!(
             spawn
                 .pointer("/inputSchema/properties/mode/enum")

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/workspace_ops.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/workspace_ops.rs
@@ -1,0 +1,804 @@
+//! Where an agent may put a NEW workspace, and how one gets made.
+//!
+//! Two tools live here, and they are the first half of ADR §5's flow 4:
+//! `get_workspace_options` describes what a spawned workspace can be, and
+//! `spawn_workspace` makes one. The agent then calls `spawn_agent` with the new
+//! `workspaceId`. Two steps by design — the ADR's alternatives section rejects
+//! exposing the full creation surface, so this is three arguments and
+//! server-side policy for everything else.
+//!
+//! Nothing here re-implements workspace creation. A `worktree` spawn goes
+//! through `WorkspaceWorktreeRuntime::create_worktree`, the same call
+//! `POST /v1/workspaces/worktrees` makes; a `local` spawn goes through
+//! `WorkspaceRuntime::create_workspace_with_origin_and_creator_context`, the
+//! same call `POST /v1/workspaces` makes. What this module adds is the three
+//! things the human routes do not need:
+//!
+//! 1. the local-only gate (ADR §1 requirement 7, §3.3) — agents may only make
+//!    workspaces that are real local checkouts on this machine;
+//! 2. creator stamping — `WorkspaceCreatorContext::Agent` with the calling
+//!    session id, so "created by agent X" is a durable fact and not a guess;
+//! 3. server-side defaults for everything §3.4 keeps away from the agent: base
+//!    branch, name-conflict policy, and the setup script.
+//!
+//! What is deliberately NOT here is any way to un-make a workspace. Ruling 11
+//! keeps retirement human-only, and
+//! `no_agent_ops_tool_can_retire_or_delete_a_workspace`
+//! in `tools.rs` is the ratchet that keeps it that way.
+
+use std::path::Path;
+
+use serde_json::{json, Value};
+
+use crate::domains::repo_roots::model::RepoRootRecord;
+use crate::domains::repo_roots::service::RepoRootService;
+use crate::domains::sessions::model::SessionRecord;
+use crate::domains::workspaces::access_gate::WorkspaceAccessGate;
+use crate::domains::workspaces::creator_context::WorkspaceCreatorContext;
+use crate::domains::workspaces::model::{WorkspaceKind, WorkspaceRecord};
+use crate::domains::workspaces::runtime::WorkspaceRuntime;
+use crate::domains::workspaces::worktree_checkout::WorktreeCheckoutMode;
+use crate::domains::workspaces::worktree_names::WorktreeNameConflictPolicy;
+use crate::domains::workspaces::worktree_runtime::{
+    CreateWorktreeWorkflowInput, WorkspaceWorktreeRuntime,
+};
+use crate::origin::OriginContext;
+
+use super::peer_ops::assert_workspace_can_be_mutated;
+use super::tools::SpawnWorkspaceArgs;
+
+/// The two shapes a workspace comes in, as the agent names them. Deliberately
+/// the same two words the human picker uses and `WorkspaceKind` stores.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum WorkspaceSpawnMode {
+    /// A new branch in its own checkout, made with `git worktree add`. The
+    /// default: it is the only mode that leaves the caller's own checkout
+    /// alone.
+    Worktree,
+    /// The repo root's existing checkout, opened in place. No new files, no new
+    /// branch — a second workspace over the same directory.
+    Local,
+}
+
+impl WorkspaceSpawnMode {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Worktree => "worktree",
+            Self::Local => "local",
+        }
+    }
+
+    fn parse(value: Option<&str>) -> anyhow::Result<Self> {
+        match value.map(str::trim).filter(|value| !value.is_empty()) {
+            None | Some("worktree") => Ok(Self::Worktree),
+            Some("local") => Ok(Self::Local),
+            Some(other) => anyhow::bail!(
+                "unknown mode {other:?}; use \"worktree\" for a new branch in its own checkout, \
+                 or \"local\" to open the repo's existing checkout in place"
+            ),
+        }
+    }
+}
+
+/// Why an agent may not put a workspace here.
+///
+/// One rule stated three ways, which is the "if running locally" gate of ADR §1
+/// requirement 7 and §3.3: **the workspace an agent spawns has to be a real
+/// local checkout on this machine, made from a repo this machine actually
+/// has.** Nothing enforced this before — `has_local_checkout()` existed as a
+/// predicate with no caller — so this is the whole of the gate.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub(super) enum WorkspacePlacementRefusal {
+    #[error(
+        "spawn_workspace only works for an agent running on a local checkout. This session's \
+         workspace ({workspace_id}) is not one, so there is no local repo to branch from — ask a \
+         person to open a workspace instead."
+    )]
+    CallerIsNotLocal { workspace_id: String },
+    #[error(
+        "this session's own checkout is gone from disk ({path}), so there is nothing here to \
+         create a workspace from. Ask a person to restore it first."
+    )]
+    CallerCheckoutMissing { workspace_id: String, path: String },
+    #[error(
+        "repo {repo_root_id} is not checked out on this machine ({path}), so a workspace cannot \
+         be created for it here. Use get_workspace_options to see the repos that are."
+    )]
+    RepoRootNotOnThisMachine { repo_root_id: String, path: String },
+}
+
+/// The local-only gate (ADR §3.3), as a pure decision.
+///
+/// The filesystem facts arrive as booleans rather than being read here, so the
+/// rule itself is testable and so that each is read exactly once by the caller.
+///
+/// The first arm is the structural one: `has_local_checkout()` is true for both
+/// workspace kinds that exist today, so it does not fire yet — it is the guard
+/// that a future remote/cloud-style workspace kind trips the moment it is added,
+/// which is exactly the shape ADR §2 describes ("a future remote/cloud-style
+/// kind would return false here"). The second and third arms are the ones that
+/// bite today: a checkout that has been deleted, and a repo root this machine
+/// does not have.
+pub(super) fn assert_local_placement(
+    caller_workspace: &WorkspaceRecord,
+    caller_checkout_missing: bool,
+    repo_root: &RepoRootRecord,
+    repo_root_checkout_present: bool,
+) -> Result<(), WorkspacePlacementRefusal> {
+    if !caller_workspace.has_local_checkout() {
+        return Err(WorkspacePlacementRefusal::CallerIsNotLocal {
+            workspace_id: caller_workspace.id.clone(),
+        });
+    }
+    if caller_checkout_missing {
+        return Err(WorkspacePlacementRefusal::CallerCheckoutMissing {
+            workspace_id: caller_workspace.id.clone(),
+            path: caller_workspace.path.clone(),
+        });
+    }
+    if !repo_root_checkout_present {
+        return Err(WorkspacePlacementRefusal::RepoRootNotOnThisMachine {
+            repo_root_id: repo_root.id.clone(),
+            path: repo_root.path.clone(),
+        });
+    }
+    Ok(())
+}
+
+/// What `spawn_workspace` stamps on every workspace it makes (ADR §3.4).
+///
+/// `WorkspaceCreatorContext::Agent` already existed with exactly these fields —
+/// ADR §2 says "'Created by agent X' = filling a field, not building anything" —
+/// so this fills them rather than inventing a provenance shape. The calling
+/// session id is the load-bearing one: it is what §4's transcript receipt and
+/// the workspace's provenance display resolve back to an agent.
+///
+/// `session_link_id` stays `None` on purpose. A workspace is not the far end of
+/// a `session_links` row; the link that eventually matters is the one
+/// `spawn_agent` writes for the agent placed here, and claiming one here would
+/// point at a relationship that does not exist.
+pub(super) fn agent_creator_context(
+    caller: &SessionRecord,
+    label: Option<String>,
+) -> WorkspaceCreatorContext {
+    WorkspaceCreatorContext::Agent {
+        source_session_id: caller.id.clone(),
+        source_session_workspace_id: Some(caller.workspace_id.clone()),
+        session_link_id: None,
+        source_workspace_id: Some(caller.workspace_id.clone()),
+        label,
+    }
+}
+
+/// The repo's name as a person would say it: what the human picker shows.
+fn repo_root_name(repo_root: &RepoRootRecord) -> String {
+    repo_root
+        .display_name
+        .clone()
+        .or_else(|| repo_root.remote_repo_name.clone())
+        .unwrap_or_else(|| {
+            Path::new(&repo_root.path)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("repo")
+                .to_string()
+        })
+}
+
+fn repo_root_checkout_present(repo_root: &RepoRootRecord) -> bool {
+    Path::new(&repo_root.path).is_dir()
+}
+
+/// `get_workspace_options` (ADR §3.4): the configured local repo roots and, per
+/// root, the two creation modes.
+///
+/// Read-only and permit-free — it opens no lease and touches no record. Roots
+/// this machine does not actually have are still listed, marked unavailable
+/// with the reason, rather than hidden: an agent that cannot see why a repo is
+/// missing has no way to say anything useful about it.
+pub(super) fn get_workspace_options(
+    workspace_runtime: &WorkspaceRuntime,
+    repo_roots: &RepoRootService,
+    caller: &SessionRecord,
+) -> anyhow::Result<Value> {
+    let caller_workspace = workspace_runtime
+        .get_workspace(&caller.workspace_id)?
+        .ok_or_else(|| anyhow::anyhow!("workspace not found: {}", caller.workspace_id))?;
+    let caller_checkout_missing = caller_workspace.checkout_directory_missing();
+    let roots = repo_roots.list_repo_roots()?;
+
+    let mut options = Vec::with_capacity(roots.len());
+    for root in &roots {
+        let present = repo_root_checkout_present(root);
+        let refusal =
+            assert_local_placement(&caller_workspace, caller_checkout_missing, root, present).err();
+        // Reading the branch shells out to git, so only for roots that are
+        // actually here.
+        let current_branch = present
+            .then(|| crate::domains::workspaces::resolver::resolve_git_context(&root.path).ok())
+            .flatten()
+            .and_then(|context| context.current_branch);
+        options.push(json!({
+            "repoRootId": root.id,
+            "name": repo_root_name(root),
+            "path": root.path,
+            "defaultBranch": root.default_branch,
+            "currentBranch": current_branch,
+            "isCallersRepo": root.id == caller_workspace.repo_root_id,
+            "modes": [
+                WorkspaceSpawnMode::Worktree.as_str(),
+                WorkspaceSpawnMode::Local.as_str(),
+            ],
+            "available": refusal.is_none(),
+            "unavailableReason": refusal.map(|refusal| refusal.to_string()),
+        }));
+    }
+
+    Ok(json!({
+        "callerSessionId": caller.id,
+        "callerWorkspaceId": caller_workspace.id,
+        "defaultRepoRootId": caller_workspace.repo_root_id,
+        "repoRoots": options,
+        "modes": [
+            {
+                "mode": WorkspaceSpawnMode::Worktree.as_str(),
+                "requiresBranchName": true,
+                "description": "A new branch in its own checkout, made with git worktree add. \
+                                Leaves every existing checkout untouched.",
+                "runsSetupScript": true,
+            },
+            {
+                "mode": WorkspaceSpawnMode::Local.as_str(),
+                "requiresBranchName": false,
+                "description": "The repo's existing checkout, opened in place as a second \
+                                workspace. Shares files and git state with whoever else is in it.",
+                "runsSetupScript": false,
+            },
+        ],
+        "notes": [
+            "Workspaces you spawn are yours to use, not to remove: only a person can retire one.",
+            "Base branch and name-conflict handling are decided server-side; a branch name that \
+             is taken gets a numeric suffix rather than failing.",
+            "The setup script for a worktree is whatever this machine last ran for your own \
+             workspace. You never pass one, and none runs for mode=local.",
+            "Put an agent in a workspace you spawned with spawn_agent and its workspaceId.",
+        ],
+    }))
+}
+
+/// `spawn_workspace` (ADR §3.4).
+///
+/// ## Gating
+///
+/// No route lease, and none is possible: the workspace this creates does not
+/// exist yet, so there is nothing to take a `WorkspaceOperationKind` lease on —
+/// which is exactly why the tool is absent from `tools::MUTATING_TOOL_NAMES`.
+/// What it takes instead is what the human worktree route takes for the same
+/// reason (`api/http/workspaces_worktrees.rs`): the ACCESS gate on the repo
+/// root, plus the caller's own workspace being mutable. There is no target
+/// session either, so no admission permit — with one gate and no lease there is
+/// no lock order to get wrong (PR1227-LOCK-01 is satisfied vacuously).
+pub(super) async fn spawn_workspace(
+    workspace_runtime: &WorkspaceRuntime,
+    worktree_runtime: &WorkspaceWorktreeRuntime,
+    repo_roots: &RepoRootService,
+    access_gate: &WorkspaceAccessGate,
+    caller: &SessionRecord,
+    args: SpawnWorkspaceArgs,
+) -> anyhow::Result<Value> {
+    let mode = WorkspaceSpawnMode::parse(args.mode.as_deref())?;
+    let caller_workspace = workspace_runtime
+        .get_workspace(&caller.workspace_id)?
+        .ok_or_else(|| anyhow::anyhow!("workspace not found: {}", caller.workspace_id))?;
+    let repo_root_id = args
+        .repo_root_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        // ADR §3.4: defaults to the caller's own root — "the same git repo" of
+        // requirement 7.
+        .unwrap_or_else(|| caller_workspace.repo_root_id.clone());
+    let repo_root = repo_roots
+        .get_repo_root(&repo_root_id)?
+        .ok_or_else(|| anyhow::anyhow!("repo root not found: {repo_root_id}"))?;
+
+    // The local-only gate, before any access check: "you cannot make one of
+    // these here" is a clearer refusal than "that repo is read-only".
+    assert_local_placement(
+        &caller_workspace,
+        caller_workspace.checkout_directory_missing(),
+        &repo_root,
+        repo_root_checkout_present(&repo_root),
+    )?;
+
+    // The caller has to be somewhere it may still act, and the repo root has to
+    // be mutable — the same access assertion the human worktree route makes.
+    assert_workspace_can_be_mutated(access_gate, &caller.workspace_id)?;
+    access_gate.assert_can_mutate_for_repo_root(&repo_root.id)?;
+
+    let label = args
+        .label
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
+
+    match mode {
+        WorkspaceSpawnMode::Worktree => {
+            spawn_worktree_workspace(
+                workspace_runtime,
+                worktree_runtime,
+                caller,
+                &caller_workspace,
+                &repo_root,
+                args.branch_name.as_deref(),
+                label,
+            )
+            .await
+        }
+        WorkspaceSpawnMode::Local => {
+            spawn_local_workspace(workspace_runtime, caller, &repo_root, label)
+        }
+    }
+}
+
+fn validate_branch_name(branch_name: Option<&str>) -> anyhow::Result<String> {
+    let branch_name = branch_name
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            anyhow::anyhow!("branchName is required for mode=worktree — name the branch to create")
+        })?;
+    if branch_name.starts_with('-')
+        || branch_name.starts_with('/')
+        || branch_name.ends_with('/')
+        || branch_name.contains("..")
+        || branch_name.contains(char::is_whitespace)
+    {
+        anyhow::bail!(
+            "branchName {branch_name:?} is not a usable git branch name; use something like \
+             \"fix-webhook-retry\""
+        );
+    }
+    Ok(branch_name.to_string())
+}
+
+/// The base branch a person would have picked: the repo's default, then
+/// whatever the caller's own workspace came from. `main` is the last resort and
+/// matches what cowork's creation path already assumes.
+fn base_branch_for(repo_root: &RepoRootRecord, caller_workspace: &WorkspaceRecord) -> String {
+    repo_root
+        .default_branch
+        .as_deref()
+        .or(caller_workspace.original_branch.as_deref())
+        .or(caller_workspace.current_branch.as_deref())
+        .unwrap_or("main")
+        .to_string()
+}
+
+async fn spawn_worktree_workspace(
+    workspace_runtime: &WorkspaceRuntime,
+    worktree_runtime: &WorkspaceWorktreeRuntime,
+    caller: &SessionRecord,
+    caller_workspace: &WorkspaceRecord,
+    repo_root: &RepoRootRecord,
+    branch_name: Option<&str>,
+    label: Option<String>,
+) -> anyhow::Result<Value> {
+    let branch_name = validate_branch_name(branch_name)?;
+    let base_branch = base_branch_for(repo_root, caller_workspace);
+    let target_path = workspace_runtime
+        .default_worktree_destination_path(&repo_root.id, &branch_name)
+        .map_err(|error| {
+            anyhow::anyhow!("failed to resolve a destination for the new worktree: {error}")
+        })?;
+    if let Some(parent) = target_path.parent() {
+        tokio::fs::create_dir_all(parent).await.map_err(|error| {
+            anyhow::anyhow!("failed to create the managed worktree destination: {error}")
+        })?;
+    }
+    // ADR §3.4: the setup script "runs automatically for worktrees … the agent
+    // never thinks about it". The one this machine last ran for the caller's
+    // own workspace IS the setup this repo uses here, so it is reused rather
+    // than re-derived from a detector the human flow drives interactively.
+    let setup_script = worktree_runtime
+        .latest_setup_command(&caller_workspace.id)
+        .unwrap_or_else(|error| {
+            tracing::warn!(
+                workspace_id = %caller_workspace.id,
+                error = ?error,
+                "could not read the last setup command; spawning the worktree without setup"
+            );
+            None
+        });
+
+    let created = worktree_runtime
+        .create_worktree(CreateWorktreeWorkflowInput {
+            repo_root_id: repo_root.id.clone(),
+            target_path: target_path.to_string_lossy().to_string(),
+            new_branch_name: branch_name.clone(),
+            base_branch: Some(base_branch.clone()),
+            checkout_mode: WorktreeCheckoutMode::NewBranch,
+            setup_script: setup_script.clone(),
+            surface: "standard".to_string(),
+            // Server-side policy (ADR §3.4): a name an agent picked that is
+            // already taken gets a suffix instead of an error it would have to
+            // retry around.
+            name_conflict_policy: WorktreeNameConflictPolicy::SuffixPathAndBranch,
+            origin: OriginContext::system_local_runtime(),
+            creator_context: Some(agent_creator_context(caller, label)),
+        })
+        .await?;
+
+    Ok(spawn_result(
+        &created.worktree.workspace,
+        repo_root,
+        WorkspaceSpawnMode::Worktree,
+        caller,
+        Some(base_branch),
+        json!({
+            "started": created.setup_started,
+            "command": setup_script,
+            "source": "the setup this machine last ran for your workspace",
+        }),
+    ))
+}
+
+fn spawn_local_workspace(
+    workspace_runtime: &WorkspaceRuntime,
+    caller: &SessionRecord,
+    repo_root: &RepoRootRecord,
+    label: Option<String>,
+) -> anyhow::Result<Value> {
+    let created = workspace_runtime.create_workspace_with_origin_and_creator_context(
+        &repo_root.path,
+        OriginContext::system_local_runtime(),
+        Some(agent_creator_context(caller, label)),
+    )?;
+    Ok(spawn_result(
+        &created.workspace,
+        repo_root,
+        WorkspaceSpawnMode::Local,
+        caller,
+        None,
+        // ADR §3.4: never for local. Opening an existing checkout in place has
+        // nothing to set up — the files are already there, and running a setup
+        // command would act on somebody else's working tree.
+        json!({ "started": false, "command": null, "source": "not run for mode=local" }),
+    ))
+}
+
+fn spawn_result(
+    workspace: &WorkspaceRecord,
+    repo_root: &RepoRootRecord,
+    mode: WorkspaceSpawnMode,
+    caller: &SessionRecord,
+    base_branch: Option<String>,
+    setup: Value,
+) -> Value {
+    json!({
+        // The handle for the next step, named the way `spawn_agent` takes it.
+        "workspaceId": workspace.id,
+        "repoRootId": repo_root.id,
+        "repoName": repo_root_name(repo_root),
+        "mode": mode.as_str(),
+        "kind": match workspace.kind {
+            WorkspaceKind::Local => "local",
+            WorkspaceKind::Worktree => "worktree",
+        },
+        "path": workspace.path,
+        "branchName": workspace.current_branch,
+        "baseBranch": base_branch,
+        "createdBySessionId": caller.id,
+        "setupScript": setup,
+        "notes": [
+            "Call spawn_agent with this workspaceId to put an agent in it.",
+            "You cannot retire or delete this workspace; only a person can.",
+        ],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domains::workspaces::model::{
+        WorkspaceCleanupState, WorkspaceLifecycleState, WorkspaceSurface,
+    };
+
+    fn workspace(kind: WorkspaceKind) -> WorkspaceRecord {
+        WorkspaceRecord {
+            id: "workspace-1".to_string(),
+            kind,
+            repo_root_id: "root-1".to_string(),
+            path: "/repos/proliferate".to_string(),
+            surface: WorkspaceSurface::Standard,
+            original_branch: Some("main".to_string()),
+            current_branch: Some("main".to_string()),
+            display_name: None,
+            origin: None,
+            creator_context: None,
+            lifecycle_state: WorkspaceLifecycleState::Active,
+            cleanup_state: WorkspaceCleanupState::None,
+            cleanup_operation: None,
+            cleanup_error_message: None,
+            cleanup_failed_at: None,
+            cleanup_attempted_at: None,
+            created_at: "2026-08-08T00:00:00Z".to_string(),
+            updated_at: "2026-08-08T00:00:00Z".to_string(),
+        }
+    }
+
+    fn repo_root() -> RepoRootRecord {
+        RepoRootRecord {
+            id: "root-1".to_string(),
+            kind: "external".to_string(),
+            path: "/repos/proliferate".to_string(),
+            display_name: Some("proliferate".to_string()),
+            default_branch: Some("main".to_string()),
+            remote_provider: None,
+            remote_owner: None,
+            remote_repo_name: None,
+            remote_url: None,
+            created_at: "2026-08-08T00:00:00Z".to_string(),
+            updated_at: "2026-08-08T00:00:00Z".to_string(),
+        }
+    }
+
+    fn session() -> SessionRecord {
+        use crate::domains::sessions::model::SessionMcpBindingPolicy;
+        SessionRecord {
+            id: "ses_caller".to_string(),
+            workspace_id: "workspace-1".to_string(),
+            agent_kind: "claude".to_string(),
+            native_session_id: None,
+            agent_auth_contexts: None,
+            requested_model_id: None,
+            current_model_id: None,
+            requested_mode_id: None,
+            current_mode_id: None,
+            title: Some("Schema audit".to_string()),
+            thinking_level_id: None,
+            thinking_budget_tokens: None,
+            status: "idle".to_string(),
+            created_at: "2026-08-08T00:00:00Z".to_string(),
+            updated_at: "2026-08-08T00:00:00Z".to_string(),
+            last_prompt_at: None,
+            closed_at: None,
+            dismissed_at: None,
+            mcp_bindings_ciphertext: None,
+            mcp_binding_summaries_json: None,
+            mcp_binding_policy: SessionMcpBindingPolicy::InheritWorkspace,
+            system_prompt_append: None,
+            subagents_enabled: true,
+            action_capabilities_json: None,
+            origin: None,
+        }
+    }
+
+    // --- the local-only gate (ADR §1 requirement 7, §3.3) ----------------
+
+    #[test]
+    fn a_local_caller_with_a_checked_out_repo_may_spawn() {
+        for kind in [WorkspaceKind::Local, WorkspaceKind::Worktree] {
+            assert_local_placement(&workspace(kind), false, &repo_root(), true)
+                .expect("both local kinds may spawn");
+        }
+    }
+
+    #[test]
+    fn a_repo_this_machine_does_not_have_is_refused() {
+        // The arm that bites today: a repo root row whose checkout is not on
+        // this machine is not somewhere a local workspace can be made, and
+        // creating one would leave a record pointing at nothing.
+        let error = assert_local_placement(
+            &workspace(WorkspaceKind::Worktree),
+            false,
+            &repo_root(),
+            false,
+        )
+        .err()
+        .expect("a repo root with no checkout here is refused");
+
+        assert_eq!(
+            error,
+            WorkspacePlacementRefusal::RepoRootNotOnThisMachine {
+                repo_root_id: "root-1".to_string(),
+                path: "/repos/proliferate".to_string(),
+            }
+        );
+        assert!(error
+            .to_string()
+            .contains("not checked out on this machine"));
+    }
+
+    #[test]
+    fn a_caller_whose_own_checkout_is_gone_is_refused() {
+        let error = assert_local_placement(
+            &workspace(WorkspaceKind::Worktree),
+            true,
+            &repo_root(),
+            true,
+        )
+        .err()
+        .expect("a deleted caller checkout is refused");
+
+        assert!(matches!(
+            error,
+            WorkspacePlacementRefusal::CallerCheckoutMissing { .. }
+        ));
+        // And it is checked BEFORE the repo root, so the agent is told about
+        // its own situation rather than about the repo.
+        let both_broken =
+            assert_local_placement(&workspace(WorkspaceKind::Local), true, &repo_root(), false)
+                .err()
+                .expect("refused");
+        assert!(matches!(
+            both_broken,
+            WorkspacePlacementRefusal::CallerCheckoutMissing { .. }
+        ));
+    }
+
+    #[test]
+    fn the_gate_reads_the_local_checkout_predicate_the_adr_names() {
+        // ADR §2/§3.3: `has_local_checkout()` is THE predicate, and a future
+        // remote/cloud-style workspace kind returning false from it must be
+        // refused. Both kinds that exist today return true, so this pins that
+        // the gate is wired to that predicate rather than to a kind list that
+        // would silently admit a new kind.
+        for kind in [WorkspaceKind::Local, WorkspaceKind::Worktree] {
+            let caller = workspace(kind);
+            assert!(caller.has_local_checkout());
+            assert!(assert_local_placement(&caller, false, &repo_root(), true).is_ok());
+        }
+    }
+
+    // --- creator stamping (ADR §3.4) --------------------------------------
+
+    #[test]
+    fn every_spawned_workspace_records_the_session_that_asked_for_it() {
+        let context = agent_creator_context(&session(), Some("billing hotfix".to_string()));
+
+        assert_eq!(
+            context,
+            WorkspaceCreatorContext::Agent {
+                source_session_id: "ses_caller".to_string(),
+                source_session_workspace_id: Some("workspace-1".to_string()),
+                // A workspace is not the far end of a link row.
+                session_link_id: None,
+                source_workspace_id: Some("workspace-1".to_string()),
+                label: Some("billing hotfix".to_string()),
+            }
+        );
+        // Not Human, and not Automation: those are the two provenances a person
+        // reading the workspace would take at face value.
+        assert!(!matches!(context, WorkspaceCreatorContext::Human { .. }));
+    }
+
+    #[test]
+    fn the_creator_stamp_survives_a_workspace_with_no_label() {
+        let context = agent_creator_context(&session(), None);
+        match context {
+            WorkspaceCreatorContext::Agent {
+                source_session_id,
+                label,
+                ..
+            } => {
+                assert_eq!(source_session_id, "ses_caller");
+                assert_eq!(label, None);
+            }
+            other => panic!("expected agent provenance, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn both_creation_paths_actually_stamp_the_context_they_build() {
+        // `agent_creator_context` being right is worth nothing if a creation
+        // path passes `None` — and `creator_context` is an `Option`, so that
+        // compiles. Every call this module makes into the human creation
+        // services has to carry the stamp.
+        let source = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("src/domains/sessions/agent_ops/workspace_ops.rs"),
+        )
+        .expect("read workspace_ops.rs");
+        // Only the shipping half: this test's own needles live below the split.
+        let source = source
+            .split_once("#[cfg(test)]")
+            .expect("workspace_ops.rs has a test module")
+            .0;
+        assert_eq!(
+            source.matches("Some(agent_creator_context(").count(),
+            2,
+            "both creation paths — worktree and local — must pass \
+             Some(agent_creator_context(..)); `creator_context` is an Option, so dropping the \
+             stamp compiles"
+        );
+        assert!(
+            !source.contains("creator_context: None"),
+            "no creation path here may go out unstamped"
+        );
+    }
+
+    // --- arguments and server-side defaults -------------------------------
+
+    #[test]
+    fn mode_defaults_to_worktree_and_rejects_anything_else() {
+        assert_eq!(
+            WorkspaceSpawnMode::parse(None).expect("default"),
+            WorkspaceSpawnMode::Worktree
+        );
+        assert_eq!(
+            WorkspaceSpawnMode::parse(Some("  ")).expect("blank is a default"),
+            WorkspaceSpawnMode::Worktree
+        );
+        assert_eq!(
+            WorkspaceSpawnMode::parse(Some("local")).expect("local"),
+            WorkspaceSpawnMode::Local
+        );
+        let error = WorkspaceSpawnMode::parse(Some("sandbox"))
+            .err()
+            .expect("an unknown mode is refused");
+        // The refusal names both real modes, since ADR §3.4 gives the agent
+        // exactly two and nothing else describes them at call time.
+        assert!(error.to_string().contains("worktree"));
+        assert!(error.to_string().contains("local"));
+    }
+
+    #[test]
+    fn a_worktree_needs_a_branch_name_and_a_usable_one() {
+        assert_eq!(
+            validate_branch_name(Some("  fix-webhook-retry  ")).expect("trimmed"),
+            "fix-webhook-retry"
+        );
+        for bad in [None, Some(""), Some("   ")] {
+            assert!(validate_branch_name(bad).is_err());
+        }
+        for bad in ["-force", "/leading", "trailing/", "a..b", "two words"] {
+            assert!(
+                validate_branch_name(Some(bad)).is_err(),
+                "{bad:?} should not be accepted as a branch name"
+            );
+        }
+    }
+
+    #[test]
+    fn the_base_branch_is_server_side_policy_not_an_argument() {
+        // ADR §3.4: "Base branch + conflict policy (suffix) are server-side
+        // defaults." The repo's own default wins; the caller's workspace is the
+        // fallback, and only then `main`.
+        let mut root = repo_root();
+        assert_eq!(
+            base_branch_for(&root, &workspace(WorkspaceKind::Local)),
+            "main"
+        );
+
+        root.default_branch = Some("develop".to_string());
+        assert_eq!(
+            base_branch_for(&root, &workspace(WorkspaceKind::Local)),
+            "develop"
+        );
+
+        root.default_branch = None;
+        let mut caller = workspace(WorkspaceKind::Worktree);
+        caller.original_branch = Some("release-1".to_string());
+        assert_eq!(base_branch_for(&root, &caller), "release-1");
+
+        caller.original_branch = None;
+        caller.current_branch = None;
+        assert_eq!(base_branch_for(&root, &caller), "main");
+    }
+
+    #[test]
+    fn a_repo_root_is_named_the_way_the_picker_names_it() {
+        let mut root = repo_root();
+        assert_eq!(repo_root_name(&root), "proliferate");
+
+        root.display_name = None;
+        root.remote_repo_name = Some("proliferate-fork".to_string());
+        assert_eq!(repo_root_name(&root), "proliferate-fork");
+
+        root.remote_repo_name = None;
+        assert_eq!(repo_root_name(&root), "proliferate");
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/workspace_ops.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/agent_ops/workspace_ops.rs
@@ -27,6 +27,7 @@
 //! in `tools.rs` is the ratchet that keeps it that way.
 
 use std::path::Path;
+use std::sync::Arc;
 
 use serde_json::{json, Value};
 
@@ -35,17 +36,60 @@ use crate::domains::repo_roots::service::RepoRootService;
 use crate::domains::sessions::model::SessionRecord;
 use crate::domains::workspaces::access_gate::WorkspaceAccessGate;
 use crate::domains::workspaces::creator_context::WorkspaceCreatorContext;
-use crate::domains::workspaces::model::{WorkspaceKind, WorkspaceRecord};
+use crate::domains::workspaces::model::{WorkspaceKind, WorkspaceLifecycleState, WorkspaceRecord};
 use crate::domains::workspaces::runtime::WorkspaceRuntime;
 use crate::domains::workspaces::worktree_checkout::WorktreeCheckoutMode;
 use crate::domains::workspaces::worktree_names::WorktreeNameConflictPolicy;
 use crate::domains::workspaces::worktree_runtime::{
-    CreateWorktreeWorkflowInput, WorkspaceWorktreeRuntime,
+    CreateWorktreeWorkflowInput, CreateWorktreeWorkflowResult, WorkspaceWorktreeRuntime,
 };
 use crate::origin::OriginContext;
 
 use super::peer_ops::assert_workspace_can_be_mutated;
 use super::tools::SpawnWorkspaceArgs;
+
+/// The longest label a spawned workspace will carry.
+///
+/// `label` is agent-authored, unbounded on the wire, and §4 renders it to a
+/// person beside the workspace's provenance. Nothing downstream truncates it,
+/// so it is bounded here, where the value enters the system.
+const MAX_LABEL_CHARS: usize = 200;
+
+/// The worktree half of workspace creation, as this module uses it.
+///
+/// A seam, not an abstraction. `WorkspaceWorktreeRuntime` is the only
+/// implementation and production passes it unchanged; it exists because that
+/// runtime is only constructible with the whole retention/preflight stack
+/// behind it, while the two decisions this module owns — the local-only gate
+/// and everything `mode=local` does — are settled before a worktree is
+/// touched. Taking the dependency as a trait is what lets those be tested
+/// through the real `spawn_workspace` body, and what lets a test see the
+/// `CreateWorktreeWorkflowInput` this module builds.
+#[async_trait::async_trait]
+pub(super) trait WorktreeSpawner: Send + Sync {
+    fn latest_setup_command(&self, workspace_id: &str) -> anyhow::Result<Option<String>>;
+
+    async fn create_worktree(
+        &self,
+        input: CreateWorktreeWorkflowInput,
+    ) -> anyhow::Result<CreateWorktreeWorkflowResult>;
+}
+
+#[async_trait::async_trait]
+impl WorktreeSpawner for WorkspaceWorktreeRuntime {
+    fn latest_setup_command(&self, workspace_id: &str) -> anyhow::Result<Option<String>> {
+        WorkspaceWorktreeRuntime::latest_setup_command(self, workspace_id)
+    }
+
+    async fn create_worktree(
+        &self,
+        input: CreateWorktreeWorkflowInput,
+    ) -> anyhow::Result<CreateWorktreeWorkflowResult> {
+        WorkspaceWorktreeRuntime::create_worktree(self, input)
+            .await
+            .map_err(anyhow::Error::from)
+    }
+}
 
 /// The two shapes a workspace comes in, as the agent names them. Deliberately
 /// the same two words the human picker uses and `WorkspaceKind` stores.
@@ -101,48 +145,113 @@ pub(super) enum WorkspacePlacementRefusal {
     )]
     CallerCheckoutMissing { workspace_id: String, path: String },
     #[error(
+        "this session's own checkout ({path}) could not be read, so whether there is anything \
+         here to create a workspace from is unknown ({error}). Ask a person to look at it."
+    )]
+    CallerCheckoutUnreadable {
+        workspace_id: String,
+        path: String,
+        error: String,
+    },
+    #[error(
         "repo {repo_root_id} is not checked out on this machine ({path}), so a workspace cannot \
          be created for it here. Use get_workspace_options to see the repos that are."
     )]
     RepoRootNotOnThisMachine { repo_root_id: String, path: String },
+    #[error(
+        "repo {repo_root_id}'s checkout ({path}) could not be read, so whether it is on this \
+         machine is unknown ({error}). Use get_workspace_options to see the repos that are."
+    )]
+    RepoRootCheckoutUnreadable {
+        repo_root_id: String,
+        path: String,
+        error: String,
+    },
+}
+
+/// What the filesystem says about a checkout the gate needs to be there.
+///
+/// Three states, not two, because the gate FAILS CLOSED: an unreadable path is
+/// not a present one, and it is not an absent one either — reporting it as
+/// either would put a refusal reason in front of the agent that names the wrong
+/// fact. `WorkspaceRecord::checkout_directory_missing` deliberately fails OPEN
+/// on the same errors, because it drives destructive "your worktree is gone"
+/// UI; this gate only ever refuses a creation, so the conservative direction is
+/// the opposite one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum CheckoutPresence {
+    Present,
+    Missing,
+    /// The path could not be read at all — permissions, a dead mount, transient
+    /// I/O. Carries the message so the refusal can name what actually failed.
+    Unreadable(String),
+}
+
+/// Read one checkout's presence. A file where a directory should be counts as
+/// `Missing`: there is no checkout there either way, and "not a directory" is
+/// not a reason the agent can act on differently.
+pub(super) fn checkout_presence(path: &str) -> CheckoutPresence {
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_dir() => CheckoutPresence::Present,
+        Ok(_) => CheckoutPresence::Missing,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => CheckoutPresence::Missing,
+        Err(error) => CheckoutPresence::Unreadable(error.to_string()),
+    }
 }
 
 /// The local-only gate (ADR §3.3), as a pure decision.
 ///
-/// The filesystem facts arrive as booleans rather than being read here, so the
-/// rule itself is testable and so that each is read exactly once by the caller.
+/// The filesystem facts arrive already read, so the rule itself is testable and
+/// so that each path is read exactly once by the caller.
 ///
 /// The first arm is the structural one: `has_local_checkout()` is true for both
 /// workspace kinds that exist today, so it does not fire yet — it is the guard
 /// that a future remote/cloud-style workspace kind trips the moment it is added,
 /// which is exactly the shape ADR §2 describes ("a future remote/cloud-style
-/// kind would return false here"). The second and third arms are the ones that
-/// bite today: a checkout that has been deleted, and a repo root this machine
-/// does not have.
+/// kind would return false here"). The remaining arms are the ones that bite
+/// today: a checkout that has been deleted, a repo root this machine does not
+/// have, and — for either of them — a path this process cannot read.
 pub(super) fn assert_local_placement(
     caller_workspace: &WorkspaceRecord,
-    caller_checkout_missing: bool,
+    caller_checkout: &CheckoutPresence,
     repo_root: &RepoRootRecord,
-    repo_root_checkout_present: bool,
+    repo_root_checkout: &CheckoutPresence,
 ) -> Result<(), WorkspacePlacementRefusal> {
     if !caller_workspace.has_local_checkout() {
         return Err(WorkspacePlacementRefusal::CallerIsNotLocal {
             workspace_id: caller_workspace.id.clone(),
         });
     }
-    if caller_checkout_missing {
-        return Err(WorkspacePlacementRefusal::CallerCheckoutMissing {
-            workspace_id: caller_workspace.id.clone(),
-            path: caller_workspace.path.clone(),
-        });
+    match caller_checkout {
+        CheckoutPresence::Present => {}
+        CheckoutPresence::Missing => {
+            return Err(WorkspacePlacementRefusal::CallerCheckoutMissing {
+                workspace_id: caller_workspace.id.clone(),
+                path: caller_workspace.path.clone(),
+            })
+        }
+        CheckoutPresence::Unreadable(error) => {
+            return Err(WorkspacePlacementRefusal::CallerCheckoutUnreadable {
+                workspace_id: caller_workspace.id.clone(),
+                path: caller_workspace.path.clone(),
+                error: error.clone(),
+            })
+        }
     }
-    if !repo_root_checkout_present {
-        return Err(WorkspacePlacementRefusal::RepoRootNotOnThisMachine {
+    match repo_root_checkout {
+        CheckoutPresence::Present => Ok(()),
+        CheckoutPresence::Missing => Err(WorkspacePlacementRefusal::RepoRootNotOnThisMachine {
             repo_root_id: repo_root.id.clone(),
             path: repo_root.path.clone(),
-        });
+        }),
+        CheckoutPresence::Unreadable(error) => {
+            Err(WorkspacePlacementRefusal::RepoRootCheckoutUnreadable {
+                repo_root_id: repo_root.id.clone(),
+                path: repo_root.path.clone(),
+                error: error.clone(),
+            })
+        }
     }
-    Ok(())
 }
 
 /// What `spawn_workspace` stamps on every workspace it makes (ADR §3.4).
@@ -185,10 +294,6 @@ fn repo_root_name(repo_root: &RepoRootRecord) -> String {
         })
 }
 
-fn repo_root_checkout_present(repo_root: &RepoRootRecord) -> bool {
-    Path::new(&repo_root.path).is_dir()
-}
-
 /// `get_workspace_options` (ADR §3.4): the configured local repo roots and, per
 /// root, the two creation modes.
 ///
@@ -196,7 +301,24 @@ fn repo_root_checkout_present(repo_root: &RepoRootRecord) -> bool {
 /// this machine does not actually have are still listed, marked unavailable
 /// with the reason, rather than hidden: an agent that cannot see why a repo is
 /// missing has no way to say anything useful about it.
-pub(super) fn get_workspace_options(
+///
+/// The whole body runs on the blocking pool, for the reason the human workspace
+/// routes do it (`api/http/workspaces.rs`): `resolve_git_context` shells out to
+/// git four or five times PER repo root, and this is an axum request task.
+pub(super) async fn get_workspace_options(
+    workspace_runtime: Arc<WorkspaceRuntime>,
+    repo_roots: Arc<RepoRootService>,
+    caller: &SessionRecord,
+) -> anyhow::Result<Value> {
+    let caller = caller.clone();
+    tokio::task::spawn_blocking(move || {
+        build_workspace_options(&workspace_runtime, &repo_roots, &caller)
+    })
+    .await
+    .map_err(|error| anyhow::anyhow!("workspace options task failed: {error}"))?
+}
+
+fn build_workspace_options(
     workspace_runtime: &WorkspaceRuntime,
     repo_roots: &RepoRootService,
     caller: &SessionRecord,
@@ -204,14 +326,15 @@ pub(super) fn get_workspace_options(
     let caller_workspace = workspace_runtime
         .get_workspace(&caller.workspace_id)?
         .ok_or_else(|| anyhow::anyhow!("workspace not found: {}", caller.workspace_id))?;
-    let caller_checkout_missing = caller_workspace.checkout_directory_missing();
+    let caller_checkout = checkout_presence(&caller_workspace.path);
     let roots = repo_roots.list_repo_roots()?;
 
     let mut options = Vec::with_capacity(roots.len());
     for root in &roots {
-        let present = repo_root_checkout_present(root);
+        let root_checkout = checkout_presence(&root.path);
+        let present = root_checkout == CheckoutPresence::Present;
         let refusal =
-            assert_local_placement(&caller_workspace, caller_checkout_missing, root, present).err();
+            assert_local_placement(&caller_workspace, &caller_checkout, root, &root_checkout).err();
         // Reading the branch shells out to git, so only for roots that are
         // actually here.
         let current_branch = present
@@ -259,8 +382,11 @@ pub(super) fn get_workspace_options(
             "Workspaces you spawn are yours to use, not to remove: only a person can retire one.",
             "Base branch and name-conflict handling are decided server-side; a branch name that \
              is taken gets a numeric suffix rather than failing.",
-            "The setup script for a worktree is whatever this machine last ran for your own \
-             workspace. You never pass one, and none runs for mode=local.",
+            "The setup script for a worktree is whatever this machine last ran for a workspace of \
+             THAT repo; a repo with no such run gets none. You never pass one, and none runs for \
+             mode=local.",
+            "mode=local is idempotent: a repo that already has a local workspace gives you that \
+             one back rather than a second one over the same checkout.",
             "Put an agent in a workspace you spawned with spawn_agent and its workspaceId.",
         ],
     }))
@@ -279,8 +405,8 @@ pub(super) fn get_workspace_options(
 /// session either, so no admission permit — with one gate and no lease there is
 /// no lock order to get wrong (PR1227-LOCK-01 is satisfied vacuously).
 pub(super) async fn spawn_workspace(
-    workspace_runtime: &WorkspaceRuntime,
-    worktree_runtime: &WorkspaceWorktreeRuntime,
+    workspace_runtime: &Arc<WorkspaceRuntime>,
+    worktree_runtime: &impl WorktreeSpawner,
     repo_roots: &RepoRootService,
     access_gate: &WorkspaceAccessGate,
     caller: &SessionRecord,
@@ -296,8 +422,11 @@ pub(super) async fn spawn_workspace(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToString::to_string)
-        // ADR §3.4: defaults to the caller's own root — "the same git repo" of
-        // requirement 7.
+        // ADR §3.4: defaults to the caller's own root. Any OTHER configured
+        // root on this machine is allowed too — §3.4's `get_workspace_options`
+        // contract lists them all and marks the caller's as the default, which
+        // is the detailed spec; §1 requirement 7's "the same git repo" is the
+        // summary it supersedes (amended there).
         .unwrap_or_else(|| caller_workspace.repo_root_id.clone());
     let repo_root = repo_roots
         .get_repo_root(&repo_root_id)?
@@ -307,9 +436,9 @@ pub(super) async fn spawn_workspace(
     // these here" is a clearer refusal than "that repo is read-only".
     assert_local_placement(
         &caller_workspace,
-        caller_workspace.checkout_directory_missing(),
+        &checkout_presence(&caller_workspace.path),
         &repo_root,
-        repo_root_checkout_present(&repo_root),
+        &checkout_presence(&repo_root.path),
     )?;
 
     // The caller has to be somewhere it may still act, and the repo root has to
@@ -317,12 +446,7 @@ pub(super) async fn spawn_workspace(
     assert_workspace_can_be_mutated(access_gate, &caller.workspace_id)?;
     access_gate.assert_can_mutate_for_repo_root(&repo_root.id)?;
 
-    let label = args
-        .label
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToString::to_string);
+    let label = normalized_label(args.label.as_deref());
 
     match mode {
         WorkspaceSpawnMode::Worktree => {
@@ -338,9 +462,18 @@ pub(super) async fn spawn_workspace(
             .await
         }
         WorkspaceSpawnMode::Local => {
-            spawn_local_workspace(workspace_runtime, caller, &repo_root, label)
+            spawn_local_workspace(workspace_runtime, caller, &repo_root, label).await
         }
     }
+}
+
+/// Trimmed, dropped when empty, and bounded — see [`MAX_LABEL_CHARS`]. Counted
+/// in characters rather than bytes so a label of emoji is not cut mid-codepoint.
+fn normalized_label(label: Option<&str>) -> Option<String> {
+    label
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.chars().take(MAX_LABEL_CHARS).collect())
 }
 
 fn validate_branch_name(branch_name: Option<&str>) -> anyhow::Result<String> {
@@ -377,9 +510,62 @@ fn base_branch_for(repo_root: &RepoRootRecord, caller_workspace: &WorkspaceRecor
         .to_string()
 }
 
+/// The setup command a worktree of `repo_root` should run, or none.
+///
+/// ADR §3.4 says the setup script "runs automatically for worktrees … the agent
+/// never thinks about it", and the command a human already vetted for a repo IS
+/// that repo's answer — which makes WHICH repo the whole question. The caller's
+/// own last setup run answers it only when the new worktree is of the caller's
+/// own repo; for any other root the answer has to come from that root's own
+/// workspaces, because a `pnpm install && pnpm build` approved for repo A was
+/// never approved to run inside a fresh checkout of repo B. A root nobody has
+/// ever run setup for gets no setup command rather than somebody else's.
+fn setup_command_for_new_worktree(
+    workspace_runtime: &WorkspaceRuntime,
+    worktree_runtime: &impl WorktreeSpawner,
+    caller_workspace: &WorkspaceRecord,
+    repo_root: &RepoRootRecord,
+) -> Option<String> {
+    if repo_root.id == caller_workspace.repo_root_id {
+        return latest_setup_command_for(worktree_runtime, &caller_workspace.id);
+    }
+    let workspaces = workspace_runtime
+        .list_repo_root_workspaces(&repo_root.id)
+        .unwrap_or_else(|error| {
+            tracing::warn!(
+                repo_root_id = %repo_root.id,
+                error = ?error,
+                "could not list the target repo's workspaces; spawning the worktree without setup"
+            );
+            Vec::new()
+        });
+    // Most recently updated first (the store's ordering), so "the latest setup
+    // command for this repo" means the same thing it does for the caller.
+    workspaces
+        .iter()
+        .filter(|workspace| workspace.lifecycle_state == WorkspaceLifecycleState::Active)
+        .find_map(|workspace| latest_setup_command_for(worktree_runtime, &workspace.id))
+}
+
+fn latest_setup_command_for(
+    worktree_runtime: &impl WorktreeSpawner,
+    workspace_id: &str,
+) -> Option<String> {
+    worktree_runtime
+        .latest_setup_command(workspace_id)
+        .unwrap_or_else(|error| {
+            tracing::warn!(
+                workspace_id,
+                error = ?error,
+                "could not read the last setup command; spawning the worktree without setup"
+            );
+            None
+        })
+}
+
 async fn spawn_worktree_workspace(
     workspace_runtime: &WorkspaceRuntime,
-    worktree_runtime: &WorkspaceWorktreeRuntime,
+    worktree_runtime: &impl WorktreeSpawner,
     caller: &SessionRecord,
     caller_workspace: &WorkspaceRecord,
     repo_root: &RepoRootRecord,
@@ -398,20 +584,12 @@ async fn spawn_worktree_workspace(
             anyhow::anyhow!("failed to create the managed worktree destination: {error}")
         })?;
     }
-    // ADR §3.4: the setup script "runs automatically for worktrees … the agent
-    // never thinks about it". The one this machine last ran for the caller's
-    // own workspace IS the setup this repo uses here, so it is reused rather
-    // than re-derived from a detector the human flow drives interactively.
-    let setup_script = worktree_runtime
-        .latest_setup_command(&caller_workspace.id)
-        .unwrap_or_else(|error| {
-            tracing::warn!(
-                workspace_id = %caller_workspace.id,
-                error = ?error,
-                "could not read the last setup command; spawning the worktree without setup"
-            );
-            None
-        });
+    let setup_script = setup_command_for_new_worktree(
+        workspace_runtime,
+        worktree_runtime,
+        caller_workspace,
+        repo_root,
+    );
 
     let created = worktree_runtime
         .create_worktree(CreateWorktreeWorkflowInput {
@@ -440,35 +618,96 @@ async fn spawn_worktree_workspace(
         json!({
             "started": created.setup_started,
             "command": setup_script,
-            "source": "the setup this machine last ran for your workspace",
+            "source": "the setup this machine last ran for a workspace of this repo",
         }),
+        false,
     ))
 }
 
-fn spawn_local_workspace(
-    workspace_runtime: &WorkspaceRuntime,
+/// `mode=local`, which is idempotent PER REPO ROOT.
+///
+/// Opening a checkout in place is not a creation an agent can take back: ruling
+/// 11 gives it no way to retire anything, so a retry loop that created a second
+/// row over the same directory would leave duplicates only a person can clear,
+/// and the two would be indistinguishable to everyone downstream. A person
+/// making the same call sees the duplicate in the picker immediately; an agent
+/// does not. So an active local workspace for this root IS the answer to
+/// "open this repo in place", and the result says it was reused rather than
+/// made.
+///
+/// This is the agent surface only. `POST /v1/workspaces` and the shared
+/// `resolve_or_create_workspace` are untouched: the human route's
+/// non-idempotence is a deliberate "create another one", which is a request an
+/// agent has no way to express here.
+async fn spawn_local_workspace(
+    workspace_runtime: &Arc<WorkspaceRuntime>,
     caller: &SessionRecord,
     repo_root: &RepoRootRecord,
     label: Option<String>,
 ) -> anyhow::Result<Value> {
-    let created = workspace_runtime.create_workspace_with_origin_and_creator_context(
-        &repo_root.path,
-        OriginContext::system_local_runtime(),
-        Some(agent_creator_context(caller, label)),
-    )?;
+    // ADR §3.4: never for local. Opening an existing checkout in place has
+    // nothing to set up — the files are already there, and running a setup
+    // command would act on somebody else's working tree.
+    let setup = json!({ "started": false, "command": null, "source": "not run for mode=local" });
+
+    if let Some(existing) = existing_local_workspace(workspace_runtime, repo_root)? {
+        return Ok(spawn_result(
+            &existing,
+            repo_root,
+            WorkspaceSpawnMode::Local,
+            caller,
+            None,
+            setup,
+            true,
+        ));
+    }
+
+    // Creating resolves the git context, which shells out several times, so it
+    // goes to the blocking pool the way the human route does
+    // (`api/http/workspaces.rs` wraps the same call in `run_blocking`).
+    let runtime = workspace_runtime.clone();
+    let path = repo_root.path.clone();
+    let creator_context = Some(agent_creator_context(caller, label));
+    let created = tokio::task::spawn_blocking(move || {
+        runtime.create_workspace_with_origin_and_creator_context(
+            &path,
+            OriginContext::system_local_runtime(),
+            creator_context,
+        )
+    })
+    .await
+    .map_err(|error| anyhow::anyhow!("local workspace create task failed: {error}"))??;
+
     Ok(spawn_result(
         &created.workspace,
         repo_root,
         WorkspaceSpawnMode::Local,
         caller,
         None,
-        // ADR §3.4: never for local. Opening an existing checkout in place has
-        // nothing to set up — the files are already there, and running a setup
-        // command would act on somebody else's working tree.
-        json!({ "started": false, "command": null, "source": "not run for mode=local" }),
+        setup,
+        false,
     ))
 }
 
+/// The active local workspace over this repo root's checkout, if there is one.
+///
+/// Matched on the repo root rather than on the path so a path that normalises
+/// differently (a symlinked or relative root row) still finds the workspace
+/// that is genuinely the same one.
+fn existing_local_workspace(
+    workspace_runtime: &WorkspaceRuntime,
+    repo_root: &RepoRootRecord,
+) -> anyhow::Result<Option<WorkspaceRecord>> {
+    Ok(workspace_runtime
+        .list_repo_root_workspaces(&repo_root.id)?
+        .into_iter()
+        .find(|workspace| {
+            workspace.kind == WorkspaceKind::Local
+                && workspace.lifecycle_state == WorkspaceLifecycleState::Active
+        }))
+}
+
+#[allow(clippy::too_many_arguments)]
 fn spawn_result(
     workspace: &WorkspaceRecord,
     repo_root: &RepoRootRecord,
@@ -476,6 +715,7 @@ fn spawn_result(
     caller: &SessionRecord,
     base_branch: Option<String>,
     setup: Value,
+    reused: bool,
 ) -> Value {
     json!({
         // The handle for the next step, named the way `spawn_agent` takes it.
@@ -491,6 +731,10 @@ fn spawn_result(
         "branchName": workspace.current_branch,
         "baseBranch": base_branch,
         "createdBySessionId": caller.id,
+        // True when this call handed back a workspace that already existed
+        // instead of making one. Only `mode=local` can reuse; a worktree spawn
+        // always creates, suffixing a taken branch name rather than reusing.
+        "reused": reused,
         "setupScript": setup,
         "notes": [
             "Call spawn_agent with this workspaceId to put an agent in it.",
@@ -502,9 +746,22 @@ fn spawn_result(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use std::process::Command;
+    use std::sync::Mutex;
+
+    use crate::domains::repo_roots::store::RepoRootStore;
+    use crate::domains::sessions::deletion::SessionDeleteWorkflow;
+    use crate::domains::terminals::store::TerminalStore;
+    use crate::domains::workspaces::deletion::WorkspaceDeleteWorkflow;
     use crate::domains::workspaces::model::{
         WorkspaceCleanupState, WorkspaceLifecycleState, WorkspaceSurface,
     };
+    use crate::domains::workspaces::store::{WorkspaceAccessStore, WorkspaceStore};
+    use crate::domains::workspaces::types::CreateWorktreeResult;
+    use crate::live::terminals::TerminalService;
+    use crate::persistence::Db;
 
     fn workspace(kind: WorkspaceKind) -> WorkspaceRecord {
         WorkspaceRecord {
@@ -581,8 +838,13 @@ mod tests {
     #[test]
     fn a_local_caller_with_a_checked_out_repo_may_spawn() {
         for kind in [WorkspaceKind::Local, WorkspaceKind::Worktree] {
-            assert_local_placement(&workspace(kind), false, &repo_root(), true)
-                .expect("both local kinds may spawn");
+            assert_local_placement(
+                &workspace(kind),
+                &CheckoutPresence::Present,
+                &repo_root(),
+                &CheckoutPresence::Present,
+            )
+            .expect("both local kinds may spawn");
         }
     }
 
@@ -593,9 +855,9 @@ mod tests {
         // creating one would leave a record pointing at nothing.
         let error = assert_local_placement(
             &workspace(WorkspaceKind::Worktree),
-            false,
+            &CheckoutPresence::Present,
             &repo_root(),
-            false,
+            &CheckoutPresence::Missing,
         )
         .err()
         .expect("a repo root with no checkout here is refused");
@@ -616,9 +878,9 @@ mod tests {
     fn a_caller_whose_own_checkout_is_gone_is_refused() {
         let error = assert_local_placement(
             &workspace(WorkspaceKind::Worktree),
-            true,
+            &CheckoutPresence::Missing,
             &repo_root(),
-            true,
+            &CheckoutPresence::Present,
         )
         .err()
         .expect("a deleted caller checkout is refused");
@@ -629,14 +891,78 @@ mod tests {
         ));
         // And it is checked BEFORE the repo root, so the agent is told about
         // its own situation rather than about the repo.
-        let both_broken =
-            assert_local_placement(&workspace(WorkspaceKind::Local), true, &repo_root(), false)
-                .err()
-                .expect("refused");
+        let both_broken = assert_local_placement(
+            &workspace(WorkspaceKind::Local),
+            &CheckoutPresence::Missing,
+            &repo_root(),
+            &CheckoutPresence::Missing,
+        )
+        .err()
+        .expect("refused");
         assert!(matches!(
             both_broken,
             WorkspacePlacementRefusal::CallerCheckoutMissing { .. }
         ));
+    }
+
+    #[test]
+    fn a_path_the_gate_cannot_read_refuses_and_names_the_check() {
+        // The gate FAILS CLOSED, and says which of its two filesystem facts it
+        // could not establish. Reading an unreadable path as "present" would
+        // let a creation through on an unproven fact; reading it as "missing"
+        // would tell the agent a checkout was deleted when it may be sitting
+        // behind a permission error.
+        let caller = assert_local_placement(
+            &workspace(WorkspaceKind::Worktree),
+            &CheckoutPresence::Unreadable("permission denied".to_string()),
+            &repo_root(),
+            &CheckoutPresence::Present,
+        )
+        .err()
+        .expect("an unreadable caller checkout is refused, not admitted");
+        assert!(matches!(
+            caller,
+            WorkspacePlacementRefusal::CallerCheckoutUnreadable { .. }
+        ));
+        assert!(caller.to_string().contains("permission denied"));
+        assert!(
+            !caller.to_string().contains("gone from disk"),
+            "an unreadable path must not be reported as a deleted one"
+        );
+
+        let root = assert_local_placement(
+            &workspace(WorkspaceKind::Worktree),
+            &CheckoutPresence::Present,
+            &repo_root(),
+            &CheckoutPresence::Unreadable("host is down".to_string()),
+        )
+        .err()
+        .expect("an unreadable repo root is refused, not admitted");
+        assert!(matches!(
+            root,
+            WorkspacePlacementRefusal::RepoRootCheckoutUnreadable { .. }
+        ));
+        assert!(root.to_string().contains("host is down"));
+    }
+
+    #[test]
+    fn presence_is_read_from_the_filesystem_the_way_the_gate_needs_it() {
+        let dir = temp_dir("presence");
+        assert_eq!(
+            checkout_presence(&dir.path().to_string_lossy()),
+            CheckoutPresence::Present
+        );
+        assert_eq!(
+            checkout_presence(&dir.path().join("nope").to_string_lossy()),
+            CheckoutPresence::Missing
+        );
+        // A file where a checkout should be: no checkout either way.
+        let file = dir.path().join("a-file");
+        std::fs::write(&file, "not a checkout").expect("write file");
+        assert_eq!(
+            checkout_presence(&file.to_string_lossy()),
+            CheckoutPresence::Missing
+        );
     }
 
     #[test]
@@ -649,7 +975,13 @@ mod tests {
         for kind in [WorkspaceKind::Local, WorkspaceKind::Worktree] {
             let caller = workspace(kind);
             assert!(caller.has_local_checkout());
-            assert!(assert_local_placement(&caller, false, &repo_root(), true).is_ok());
+            assert!(assert_local_placement(
+                &caller,
+                &CheckoutPresence::Present,
+                &repo_root(),
+                &CheckoutPresence::Present
+            )
+            .is_ok());
         }
     }
 
@@ -800,5 +1132,509 @@ mod tests {
 
         root.remote_repo_name = None;
         assert_eq!(repo_root_name(&root), "proliferate");
+    }
+
+    #[test]
+    fn an_agent_authored_label_is_trimmed_and_bounded() {
+        assert_eq!(
+            normalized_label(Some("  billing hotfix  ")).as_deref(),
+            Some("billing hotfix")
+        );
+        for empty in [None, Some(""), Some("   ")] {
+            assert_eq!(normalized_label(empty), None);
+        }
+        // Unbounded, agent-authored and rendered to a person by §4: bounded
+        // where it enters, because nothing downstream does it.
+        let long = "x".repeat(MAX_LABEL_CHARS + 500);
+        assert_eq!(
+            normalized_label(Some(&long)).map(|label| label.chars().count()),
+            Some(MAX_LABEL_CHARS)
+        );
+        // Counted in characters, so a multi-byte label is never cut in half.
+        let emoji = "🙂".repeat(MAX_LABEL_CHARS + 10);
+        let capped = normalized_label(Some(&emoji)).expect("kept");
+        assert_eq!(capped.chars().count(), MAX_LABEL_CHARS);
+        assert!(capped.chars().all(|character| character == '🙂'));
+    }
+
+    // --- the tool bodies, executed -----------------------------------------
+    //
+    // Everything above proves a rule; these run `spawn_workspace` and
+    // `get_workspace_options` themselves, over a real store and real git
+    // checkouts in a temp dir. The worktree runtime arrives as a spy — it is
+    // the one dependency that is not constructible without the whole
+    // retention/preflight stack, and taking it as [`WorktreeSpawner`] is what
+    // lets a test see the `CreateWorktreeWorkflowInput` this module builds.
+
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn temp_dir(prefix: &str) -> TempDir {
+        let path = std::env::temp_dir().join(format!(
+            "anyharness-agent-ops-{prefix}-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&path).expect("create temp dir");
+        TempDir { path }
+    }
+
+    fn run_git<const N: usize>(cwd: &Path, args: [&str; N]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .expect("spawn git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_repo(path: &Path) {
+        std::fs::create_dir_all(path).expect("create repo dir");
+        run_git(path, ["init", "-b", "main"]);
+        run_git(path, ["config", "user.email", "agent@example.com"]);
+        run_git(path, ["config", "user.name", "Agent"]);
+        std::fs::write(path.join("README.md"), "seed\n").expect("write seed file");
+        run_git(path, ["add", "README.md"]);
+        run_git(path, ["commit", "-m", "Initial commit"]);
+    }
+
+    /// A `WorktreeSpawner` that creates nothing and records everything.
+    ///
+    /// `latest_setup_command` answers per WORKSPACE id, which is the whole
+    /// point: the cross-repo question is which workspace's setup run gets
+    /// reused, and a spy that answered one command for everybody could not
+    /// tell a right answer from a wrong one.
+    #[derive(Default)]
+    struct WorktreeSpy {
+        setup_commands: Mutex<HashMap<String, String>>,
+        created: Mutex<Vec<CreateWorktreeWorkflowInput>>,
+    }
+
+    impl WorktreeSpy {
+        fn with_setup_command(self, workspace_id: &str, command: &str) -> Self {
+            self.setup_commands
+                .lock()
+                .expect("spy poisoned")
+                .insert(workspace_id.to_string(), command.to_string());
+            self
+        }
+
+        fn only_creation(&self) -> CreateWorktreeWorkflowInput {
+            let created = self.created.lock().expect("spy poisoned");
+            assert_eq!(created.len(), 1, "expected exactly one worktree creation");
+            created[0].clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl WorktreeSpawner for WorktreeSpy {
+        fn latest_setup_command(&self, workspace_id: &str) -> anyhow::Result<Option<String>> {
+            Ok(self
+                .setup_commands
+                .lock()
+                .expect("spy poisoned")
+                .get(workspace_id)
+                .cloned())
+        }
+
+        async fn create_worktree(
+            &self,
+            input: CreateWorktreeWorkflowInput,
+        ) -> anyhow::Result<CreateWorktreeWorkflowResult> {
+            let mut created = WorkspaceRecord {
+                id: format!("workspace-worktree-{}", input.new_branch_name),
+                repo_root_id: input.repo_root_id.clone(),
+                path: input.target_path.clone(),
+                current_branch: Some(input.new_branch_name.clone()),
+                ..workspace(WorkspaceKind::Worktree)
+            };
+            created.original_branch = input.base_branch.clone();
+            self.created.lock().expect("spy poisoned").push(input);
+            Ok(CreateWorktreeWorkflowResult {
+                worktree: CreateWorktreeResult {
+                    workspace: created,
+                    setup_script: None,
+                    base_fetch: None,
+                },
+                setup_started: false,
+            })
+        }
+    }
+
+    struct Fixture {
+        _home: TempDir,
+        repos: TempDir,
+        workspace_runtime: Arc<WorkspaceRuntime>,
+        repo_roots: RepoRootService,
+        access_gate: WorkspaceAccessGate,
+        caller: SessionRecord,
+        caller_workspace_id: String,
+        caller_repo_root_id: String,
+    }
+
+    impl Fixture {
+        /// A second git repo on this machine, registered as a repo root but
+        /// with no workspace of its own — the cross-repo case.
+        fn other_repo(&self, name: &str) -> RepoRootRecord {
+            let path = self.repos.path().join(name);
+            init_repo(&path);
+            self.workspace_runtime
+                .resolve_repo_root_from_path(&path.to_string_lossy())
+                .expect("register the other repo root")
+        }
+
+        fn workspaces_for(&self, repo_root_id: &str) -> Vec<WorkspaceRecord> {
+            self.workspace_runtime
+                .list_repo_root_workspaces(repo_root_id)
+                .expect("list workspaces")
+        }
+    }
+
+    fn fixture() -> Fixture {
+        let db = Db::open_in_memory().expect("open db");
+        let home = temp_dir("home");
+        let repos = temp_dir("repos");
+        let caller_repo = repos.path().join("caller-repo");
+        init_repo(&caller_repo);
+
+        let repo_roots = RepoRootService::new(RepoRootStore::new(db.clone()));
+        let workspace_runtime = Arc::new(WorkspaceRuntime::new(
+            WorkspaceStore::new(db.clone()),
+            WorkspaceDeleteWorkflow::new(db.clone(), SessionDeleteWorkflow::new(db.clone())),
+            repo_roots.clone(),
+            home.path().to_path_buf(),
+        ));
+        let resolved = workspace_runtime
+            .create_workspace(&caller_repo.to_string_lossy())
+            .expect("open the caller's own checkout");
+        let access_gate = WorkspaceAccessGate::new(
+            WorkspaceStore::new(db.clone()),
+            crate::domains::sessions::store::SessionStore::new(db.clone()),
+            WorkspaceAccessStore::new(db.clone()),
+            Arc::new(TerminalService::new(
+                TerminalStore::new(db.clone()),
+                home.path().to_path_buf(),
+            )),
+        );
+        let mut caller = session();
+        caller.workspace_id = resolved.workspace.id.clone();
+
+        Fixture {
+            _home: home,
+            repos,
+            workspace_runtime,
+            repo_roots,
+            access_gate,
+            caller,
+            caller_workspace_id: resolved.workspace.id,
+            caller_repo_root_id: resolved.repo_root.id,
+        }
+    }
+
+    async fn spawn(
+        fixture: &Fixture,
+        worktrees: &WorktreeSpy,
+        args: SpawnWorkspaceArgs,
+    ) -> anyhow::Result<Value> {
+        spawn_workspace(
+            &fixture.workspace_runtime,
+            worktrees,
+            &fixture.repo_roots,
+            &fixture.access_gate,
+            &fixture.caller,
+            args,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn the_local_only_gate_refuses_through_the_real_tool_body() {
+        let fixture = fixture();
+        let other = fixture.other_repo("gone-repo");
+        std::fs::remove_dir_all(fixture.repos.path().join("gone-repo")).expect("delete the repo");
+
+        let error = spawn(
+            &fixture,
+            &WorktreeSpy::default(),
+            SpawnWorkspaceArgs {
+                repo_root_id: Some(other.id.clone()),
+                mode: Some("local".to_string()),
+                ..SpawnWorkspaceArgs::default()
+            },
+        )
+        .await
+        .err()
+        .expect("a repo root whose checkout is gone is refused");
+        assert!(
+            error.to_string().contains("not checked out on this machine"),
+            "unexpected refusal: {error}"
+        );
+        // And nothing was created on the way to the refusal.
+        assert!(fixture.workspaces_for(&other.id).is_empty());
+
+        // The caller's own side of the same gate, through the same body.
+        std::fs::remove_dir_all(fixture.repos.path().join("caller-repo"))
+            .expect("delete the caller's checkout");
+        let error = spawn(
+            &fixture,
+            &WorktreeSpy::default(),
+            SpawnWorkspaceArgs {
+                mode: Some("local".to_string()),
+                ..SpawnWorkspaceArgs::default()
+            },
+        )
+        .await
+        .err()
+        .expect("a caller with no checkout left is refused");
+        assert!(
+            error.to_string().contains("gone from disk"),
+            "unexpected refusal: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_local_spawn_creates_one_workspace_and_a_second_call_returns_it() {
+        let fixture = fixture();
+        let other = fixture.other_repo("other-repo");
+
+        let first = spawn(
+            &fixture,
+            &WorktreeSpy::default(),
+            SpawnWorkspaceArgs {
+                repo_root_id: Some(other.id.clone()),
+                mode: Some("local".to_string()),
+                label: Some("  billing hotfix  ".to_string()),
+                ..SpawnWorkspaceArgs::default()
+            },
+        )
+        .await
+        .expect("open the other repo in place");
+
+        assert_eq!(first["mode"], "local");
+        assert_eq!(first["kind"], "local");
+        assert_eq!(first["reused"], false);
+        assert_eq!(first["createdBySessionId"], "ses_caller");
+        assert_eq!(first["setupScript"]["started"], false);
+        let created_id = first["workspaceId"].as_str().expect("workspaceId").to_string();
+
+        // The row exists, in the right repo, stamped with the agent that asked.
+        let rows = fixture.workspaces_for(&other.id);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, created_id);
+        assert_eq!(rows[0].kind, WorkspaceKind::Local);
+        assert_eq!(
+            rows[0].creator_context,
+            Some(WorkspaceCreatorContext::Agent {
+                source_session_id: "ses_caller".to_string(),
+                source_session_workspace_id: Some(fixture.caller_workspace_id.clone()),
+                session_link_id: None,
+                source_workspace_id: Some(fixture.caller_workspace_id.clone()),
+                label: Some("billing hotfix".to_string()),
+            })
+        );
+
+        // Ruling 11 gives an agent no way to undo a workspace, and agents
+        // retry. So the second call is the same workspace, said out loud —
+        // not a second indistinguishable row over the same checkout.
+        let second = spawn(
+            &fixture,
+            &WorktreeSpy::default(),
+            SpawnWorkspaceArgs {
+                repo_root_id: Some(other.id.clone()),
+                mode: Some("local".to_string()),
+                ..SpawnWorkspaceArgs::default()
+            },
+        )
+        .await
+        .expect("the second call is answered, not refused");
+
+        assert_eq!(second["workspaceId"].as_str(), Some(created_id.as_str()));
+        assert_eq!(second["reused"], true);
+        assert_eq!(
+            fixture.workspaces_for(&other.id).len(),
+            1,
+            "two local spawns of one repo root must leave ONE workspace"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_worktree_of_another_repo_never_runs_the_callers_setup_command() {
+        // H1: the setup command is a human-vetted shell command, scoped to the
+        // repo it was vetted for. Reusing the caller's for a DIFFERENT repo
+        // runs it inside a checkout nobody authorised it for.
+        let fixture = fixture();
+        let other = fixture.other_repo("other-repo");
+        let spy = WorktreeSpy::default()
+            .with_setup_command(&fixture.caller_workspace_id, "pnpm install && pnpm build");
+
+        spawn(
+            &fixture,
+            &spy,
+            SpawnWorkspaceArgs {
+                repo_root_id: Some(other.id.clone()),
+                mode: Some("worktree".to_string()),
+                branch_name: Some("fix-webhook-retry".to_string()),
+                ..SpawnWorkspaceArgs::default()
+            },
+        )
+        .await
+        .expect("spawn a worktree of the other repo");
+
+        let input = spy.only_creation();
+        assert_eq!(
+            input.setup_script, None,
+            "a repo with no setup run of its own gets NO setup command — never the caller's"
+        );
+        // The rest of the server-side policy, on the same call.
+        assert_eq!(input.repo_root_id, other.id);
+        assert_eq!(input.new_branch_name, "fix-webhook-retry");
+        assert_eq!(input.base_branch.as_deref(), Some("main"));
+        assert_eq!(input.checkout_mode, WorktreeCheckoutMode::NewBranch);
+        assert_eq!(
+            input.name_conflict_policy,
+            WorktreeNameConflictPolicy::SuffixPathAndBranch
+        );
+        assert!(matches!(
+            input.creator_context,
+            Some(WorkspaceCreatorContext::Agent { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_worktree_takes_the_setup_command_of_the_repo_it_is_actually_for() {
+        let fixture = fixture();
+        let other = fixture.other_repo("other-repo");
+        // The other repo now has a workspace of its own, with its own setup
+        // run — that is the command this repo uses here.
+        let opened = spawn(
+            &fixture,
+            &WorktreeSpy::default(),
+            SpawnWorkspaceArgs {
+                repo_root_id: Some(other.id.clone()),
+                mode: Some("local".to_string()),
+                ..SpawnWorkspaceArgs::default()
+            },
+        )
+        .await
+        .expect("open the other repo in place");
+        let other_workspace_id = opened["workspaceId"].as_str().expect("workspaceId");
+
+        let spy = WorktreeSpy::default()
+            .with_setup_command(&fixture.caller_workspace_id, "pnpm install && pnpm build")
+            .with_setup_command(other_workspace_id, "make deps");
+
+        spawn(
+            &fixture,
+            &spy,
+            SpawnWorkspaceArgs {
+                repo_root_id: Some(other.id.clone()),
+                mode: Some("worktree".to_string()),
+                branch_name: Some("fix-webhook-retry".to_string()),
+                ..SpawnWorkspaceArgs::default()
+            },
+        )
+        .await
+        .expect("spawn a worktree of the other repo");
+
+        assert_eq!(
+            spy.only_creation().setup_script.as_deref(),
+            Some("make deps")
+        );
+    }
+
+    #[tokio::test]
+    async fn a_worktree_of_the_callers_own_repo_still_reuses_the_callers_setup_command() {
+        // The negative half of H1: scoping the reuse to the caller's own repo
+        // must not stop it happening there, which is the case ADR §3.4 is
+        // actually about.
+        let fixture = fixture();
+        let spy = WorktreeSpy::default()
+            .with_setup_command(&fixture.caller_workspace_id, "pnpm install && pnpm build");
+
+        spawn(
+            &fixture,
+            &spy,
+            SpawnWorkspaceArgs {
+                mode: Some("worktree".to_string()),
+                branch_name: Some("fix-webhook-retry".to_string()),
+                ..SpawnWorkspaceArgs::default()
+            },
+        )
+        .await
+        .expect("spawn a worktree of the caller's own repo");
+
+        let input = spy.only_creation();
+        assert_eq!(
+            input.setup_script.as_deref(),
+            Some("pnpm install && pnpm build")
+        );
+        // And an omitted `repoRootId` still means the caller's own root.
+        assert_eq!(input.repo_root_id, fixture.caller_repo_root_id);
+    }
+
+    #[tokio::test]
+    async fn workspace_options_describe_every_configured_root_and_why_one_is_unusable() {
+        let fixture = fixture();
+        let present = fixture.other_repo("present-repo");
+        let gone = fixture.other_repo("gone-repo");
+        std::fs::remove_dir_all(fixture.repos.path().join("gone-repo")).expect("delete the repo");
+
+        let options = get_workspace_options(
+            fixture.workspace_runtime.clone(),
+            Arc::new(fixture.repo_roots.clone()),
+            &fixture.caller,
+        )
+        .await
+        .expect("describe the options");
+
+        assert_eq!(
+            options["defaultRepoRootId"].as_str(),
+            Some(fixture.caller_repo_root_id.as_str())
+        );
+        let roots = options["repoRoots"].as_array().expect("repoRoots");
+        assert_eq!(roots.len(), 3);
+
+        let find = |id: &str| {
+            roots
+                .iter()
+                .find(|root| root["repoRootId"].as_str() == Some(id))
+                .cloned()
+                .unwrap_or_else(|| panic!("{id} is listed"))
+        };
+
+        let own = find(&fixture.caller_repo_root_id);
+        assert_eq!(own["available"], true);
+        assert_eq!(own["isCallersRepo"], true);
+        assert_eq!(own["unavailableReason"], Value::Null);
+        assert_eq!(own["currentBranch"].as_str(), Some("main"));
+
+        let present = find(&present.id);
+        assert_eq!(present["available"], true);
+        assert_eq!(present["isCallersRepo"], false);
+
+        // Listed, not hidden, WITH the reason — an agent that cannot see why a
+        // repo is unusable has nothing useful to say about it.
+        let gone = find(&gone.id);
+        assert_eq!(gone["available"], false);
+        assert!(gone["unavailableReason"]
+            .as_str()
+            .is_some_and(|reason| reason.contains("not checked out on this machine")));
+        assert_eq!(gone["currentBranch"], Value::Null);
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/links/model.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/links/model.rs
@@ -60,16 +60,38 @@ impl fmt::Display for SessionLinkRelation {
     }
 }
 
+/// Where the child of a link lives relative to its parent.
+///
+/// A durable fact, not a derived one: the workspace ids on both sessions can
+/// move (mobility) or be retired, so the relation the link was CREATED with is
+/// what says whether the two agents were ever meant to share a checkout.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SessionLinkWorkspaceRelation {
     SameWorkspace,
+    /// The child was placed in a workspace that is not the parent's. Since
+    /// `spawn_agent` took a `workspaceId` this is an ordinary outcome, not an
+    /// exotic one: an owner may staff a workspace it just spawned.
+    CrossWorkspace,
     CoworkManagedWorkspace,
 }
 
 impl SessionLinkWorkspaceRelation {
+    /// Which of the two ordinary relations a parent/child pair is, from the
+    /// only fact that decides it. Cowork's managed relation is not reachable
+    /// from here — it names a workspace the cowork feature owns, which is a
+    /// different claim than "these two are not in the same place".
+    pub fn between(parent_workspace_id: &str, child_workspace_id: &str) -> Self {
+        if parent_workspace_id == child_workspace_id {
+            Self::SameWorkspace
+        } else {
+            Self::CrossWorkspace
+        }
+    }
+
     pub fn as_str(self) -> &'static str {
         match self {
             Self::SameWorkspace => "same_workspace",
+            Self::CrossWorkspace => "cross_workspace",
             Self::CoworkManagedWorkspace => "cowork_managed_workspace",
         }
     }
@@ -77,6 +99,7 @@ impl SessionLinkWorkspaceRelation {
     pub fn parse(value: &str) -> Result<Self, SessionLinkParseError> {
         match value {
             "same_workspace" => Ok(Self::SameWorkspace),
+            "cross_workspace" => Ok(Self::CrossWorkspace),
             "cowork_managed_workspace" => Ok(Self::CoworkManagedWorkspace),
             other => Err(SessionLinkParseError::UnknownWorkspaceRelation(
                 other.to_string(),

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/ownership/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/ownership/service.rs
@@ -146,19 +146,28 @@ impl AgentOwnershipService {
     /// `spawn_agent` is this relation's only producer. Promotion never writes
     /// it: a promoted subagent keeps `relation = 'subagent'` and gains
     /// `promoted_at`, because the row also records how the agent came to be.
+    ///
+    /// The two workspace ids are taken rather than assumed. `spawn_agent` may
+    /// place a peer in a workspace that is not the caller's, so the row records
+    /// which of the two it was — a durable claim on a public field
+    /// (`SessionLinkView::workspace_relation`), and one that is far cheaper to
+    /// get right at insert than to reinterpret later.
     pub fn link_owned_agent(
         &self,
         owner_session_id: &str,
+        owner_workspace_id: &str,
         agent_session_id: &str,
+        agent_workspace_id: &str,
         label: Option<String>,
     ) -> Result<SessionLinkRecord, OwnershipError> {
         Ok(self.link_service.create_link(CreateSessionLinkInput {
             relation: SessionLinkRelation::OwnedAgent,
             parent_session_id: owner_session_id.to_string(),
             child_session_id: agent_session_id.to_string(),
-            // The agent is a peer, but it is still born in one workspace, and
-            // in this tool that is the caller's own.
-            workspace_relation: SessionLinkWorkspaceRelation::SameWorkspace,
+            workspace_relation: SessionLinkWorkspaceRelation::between(
+                owner_workspace_id,
+                agent_workspace_id,
+            ),
             label,
             created_by_turn_id: None,
             created_by_tool_call_id: None,
@@ -483,7 +492,13 @@ mod tests {
 
         let link = fixture
             .ownership
-            .link_owned_agent("ses_owner", "ses_peer", Some("Schema audit".to_string()))
+            .link_owned_agent(
+                "ses_owner",
+                "workspace-1",
+                "ses_peer",
+                "workspace-1",
+                Some("Schema audit".to_string()),
+            )
             .expect("link the owned agent");
 
         assert_eq!(link.relation, SessionLinkRelation::OwnedAgent);
@@ -513,6 +528,56 @@ mod tests {
     }
 
     #[test]
+    fn the_owned_link_records_which_workspace_the_peer_actually_landed_in() {
+        // `spawn_agent` takes a `workspaceId`, so a peer is routinely NOT in
+        // the owner's workspace. `workspace_relation` is durable and public
+        // (`SessionLinkView`), so stamping every row `same_workspace` would
+        // write a claim that is false for exactly the rows the cross-workspace
+        // feature creates — and one nothing downstream could later recover.
+        let fixture = fixture(&["ses_owner", "ses_here", "ses_elsewhere"]);
+
+        let same = fixture
+            .ownership
+            .link_owned_agent("ses_owner", "workspace-1", "ses_here", "workspace-1", None)
+            .expect("link the peer next door");
+        assert_eq!(
+            same.workspace_relation,
+            SessionLinkWorkspaceRelation::SameWorkspace
+        );
+
+        let elsewhere = fixture
+            .ownership
+            .link_owned_agent(
+                "ses_owner",
+                "workspace-1",
+                "ses_elsewhere",
+                "workspace-2",
+                None,
+            )
+            .expect("link the peer in the workspace the owner spawned");
+        assert_eq!(
+            elsewhere.workspace_relation,
+            SessionLinkWorkspaceRelation::CrossWorkspace
+        );
+
+        // And it survives the round trip through the store, which is what
+        // makes it a durable fact rather than a value in this call.
+        let reread = fixture
+            .ownership
+            .resolve_owned("ses_owner", None, Some("ses_elsewhere"))
+            .expect("the owner owns it");
+        assert_eq!(
+            reread.link.workspace_relation,
+            SessionLinkWorkspaceRelation::CrossWorkspace
+        );
+        assert_eq!(
+            reread.link.workspace_relation.as_str(),
+            "cross_workspace",
+            "the stored spelling is the one the public view serialises"
+        );
+    }
+
+    #[test]
     fn an_owned_agent_link_does_not_claim_a_subagent_parent_slot() {
         // Negative control on the relation: the child of an owned link must not
         // read as somebody's subagent anywhere, or the depth rule and the
@@ -520,7 +585,7 @@ mod tests {
         let fixture = fixture(&["ses_owner", "ses_peer"]);
         fixture
             .ownership
-            .link_owned_agent("ses_owner", "ses_peer", None)
+            .link_owned_agent("ses_owner", "workspace-1", "ses_peer", "workspace-1", None)
             .expect("link the owned agent");
 
         assert!(fixture

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/subagents/service.rs
@@ -142,9 +142,15 @@ impl SubagentService {
     /// ruling 9 puts no numeric limit on it, and it is subordinate to nobody,
     /// so a caller holding eight subagents may still spawn one. What they do
     /// share is every rule about the CALLER — including subordination, below —
-    /// plus the workspace the new session lands in being mutable, which for
-    /// this tool is the caller's own, the one whose write lease the route
-    /// already took.
+    /// and that includes the CALLER's workspace still being mutable, asserted
+    /// below.
+    ///
+    /// The workspace the new session LANDS in is a separate question here, and
+    /// it is not this gate's. Since `spawn_workspace`, `spawn_agent` may place
+    /// a peer in any workspace, so the tool left `MUTATING_TOOL_NAMES` (the
+    /// route's lease is the caller's, which is the wrong one) and takes the
+    /// TARGET workspace's write lease itself, in the call, held across
+    /// creation, start and the first prompt.
     ///
     /// Ruling 3's spawn block IS restated here, even though
     /// `agent_ops::calls::call_tool` already refuses an unpromoted subagent

--- a/anyharness/crates/anyharness-lib/src/domains/workspaces/worktree_runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workspaces/worktree_runtime.rs
@@ -59,6 +59,23 @@ impl WorkspaceWorktreeRuntime {
         }
     }
 
+    /// The setup command this machine last ran for `workspace_id`, if any.
+    ///
+    /// The human creation flow carries a setup script in the request, chosen
+    /// interactively from detected hints. Surfaces that create a worktree with
+    /// no human in the loop — `spawn_workspace` on the agent ops MCP — need a
+    /// server-side answer to "what setup does this repo use here", and the
+    /// command already run for an existing workspace of the same repo IS that
+    /// answer, rather than a second detection policy that could disagree with
+    /// what the human picked.
+    pub fn latest_setup_command(&self, workspace_id: &str) -> anyhow::Result<Option<String>> {
+        Ok(self
+            .setup_runtime
+            .latest_setup_run(workspace_id)
+            .map_err(anyhow::Error::from)?
+            .map(|run| run.command))
+    }
+
     pub async fn create_worktree(
         &self,
         input: CreateWorktreeWorkflowInput,

--- a/anyharness/sdk/src/reducer/__tests__/transcript.test.ts
+++ b/anyharness/sdk/src/reducer/__tests__/transcript.test.ts
@@ -1248,6 +1248,8 @@ describe("transcript reducer", () => {
     ["mcp__subagents__configure_agent"],
     ["mcp__subagents__promote_subagent"],
     ["mcp__subagents__spawn_agent"],
+    ["mcp__subagents__get_workspace_options"],
+    ["mcp__subagents__spawn_workspace"],
   ])("classifies the renamed agent ops tool %s as subagent activity", (nativeToolName) => {
     const state = reduceEvents(
       [

--- a/anyharness/sdk/src/reducer/transcript.ts
+++ b/anyharness/sdk/src/reducer/transcript.ts
@@ -1440,6 +1440,12 @@ function deriveToolCallSemanticKind(
     || normalizedEffectiveToolName === "mcp__subagents__schedule_agent_wake"
     || normalizedEffectiveToolName === "mcp__subagents__get_agent_config_options"
     || normalizedEffectiveToolName === "mcp__subagents__configure_agent"
+    // Workspace ops. Not agent operations at all, but they are served by the
+    // same agent-ops MCP and an unclassified one renders as a raw MCP call;
+    // "subagent" keeps them in the agent-activity group until the agent-ops
+    // client work gives them their own presentation.
+    || normalizedEffectiveToolName === "mcp__subagents__get_workspace_options"
+    || normalizedEffectiveToolName === "mcp__subagents__spawn_workspace"
   ) {
     return "subagent";
   }

--- a/apps/packages/product-client/src/domain/chats/subagents/subagent-tool-presentation.ts
+++ b/apps/packages/product-client/src/domain/chats/subagents/subagent-tool-presentation.ts
@@ -58,6 +58,10 @@ export function formatSubagentMcpActionLabel(toolName: string | null | undefined
       return "Read agent config options";
     case "mcp__subagents__configure_agent":
       return "Configured agent";
+    case "mcp__subagents__get_workspace_options":
+      return "Read workspace options";
+    case "mcp__subagents__spawn_workspace":
+      return "Spawned workspace";
     default:
       return null;
   }
@@ -121,6 +125,15 @@ export function formatSubagentHeaderVerb({
   }
   if (toolName === "mcp__subagents__configure_agent") {
     return isRunning ? "Configuring agent" : "Agent configured";
+  }
+  // Workspace ops. Nothing here creates an agent, so the fallback verb below
+  // would report a subagent launch — and, for `spawn_workspace`, a failure
+  // would read as "Subagent launch failed" for a call that never touched one.
+  if (toolName === "mcp__subagents__get_workspace_options") {
+    return isRunning ? "Reading workspace options" : "Workspace options read";
+  }
+  if (toolName === "mcp__subagents__spawn_workspace") {
+    return isRunning ? "Spawning workspace" : "Workspace spawned";
   }
   if (executionState === "failed") {
     return "Subagent launch failed";

--- a/apps/packages/product-client/src/domain/chats/subagents/subagent-tool-presentation.ts
+++ b/apps/packages/product-client/src/domain/chats/subagents/subagent-tool-presentation.ts
@@ -129,10 +129,18 @@ export function formatSubagentHeaderVerb({
   // Workspace ops. Nothing here creates an agent, so the fallback verb below
   // would report a subagent launch — and, for `spawn_workspace`, a failure
   // would read as "Subagent launch failed" for a call that never touched one.
+  // These branches name the failure themselves rather than falling through:
+  // reporting a failed call as a settled success is worse than the wrong noun.
   if (toolName === "mcp__subagents__get_workspace_options") {
+    if (executionState === "failed") {
+      return "Workspace options unavailable";
+    }
     return isRunning ? "Reading workspace options" : "Workspace options read";
   }
   if (toolName === "mcp__subagents__spawn_workspace") {
+    if (executionState === "failed") {
+      return "Workspace spawn failed";
+    }
     return isRunning ? "Spawning workspace" : "Workspace spawned";
   }
   if (executionState === "failed") {

--- a/apps/packages/product-client/src/lib/domain/chat/subagents/subagent-tool-presentation.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/subagents/subagent-tool-presentation.test.ts
@@ -153,12 +153,18 @@ describe("subagent tool presentation", () => {
       isRunning: false,
     })).toBe("Workspace options read");
     // The failure fallback is "Subagent launch failed", which would report a
-    // launch for a call that never touched an agent.
+    // launch for a call that never touched an agent — but the settled verb is
+    // not the answer either: a failed spawn must not read as a successful one.
     expect(formatSubagentHeaderVerb({
       item: { nativeToolName: "mcp__subagents__spawn_workspace" },
       executionState: "failed",
       isRunning: false,
-    })).toBe("Workspace spawned");
+    })).toBe("Workspace spawn failed");
+    expect(formatSubagentHeaderVerb({
+      item: { nativeToolName: "mcp__subagents__get_workspace_options" },
+      executionState: "failed",
+      isRunning: false,
+    })).toBe("Workspace options unavailable");
   });
 
   it("keeps a workspace spawn out of the subagent launch ledger", () => {

--- a/apps/packages/product-client/src/lib/domain/chat/subagents/subagent-tool-presentation.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/subagents/subagent-tool-presentation.test.ts
@@ -137,6 +137,39 @@ describe("subagent tool presentation", () => {
     })).toBe(false);
   });
 
+  it("reads the workspace tools as workspace work, not as a subagent launch", () => {
+    expect(formatSubagentMcpActionLabel("mcp__subagents__get_workspace_options"))
+      .toBe("Read workspace options");
+    expect(formatSubagentMcpActionLabel("mcp__subagents__spawn_workspace"))
+      .toBe("Spawned workspace");
+    expect(formatSubagentHeaderVerb({
+      item: { nativeToolName: "mcp__subagents__spawn_workspace" },
+      executionState: "running",
+      isRunning: true,
+    })).toBe("Spawning workspace");
+    expect(formatSubagentHeaderVerb({
+      item: { nativeToolName: "mcp__subagents__get_workspace_options" },
+      executionState: "completed",
+      isRunning: false,
+    })).toBe("Workspace options read");
+    // The failure fallback is "Subagent launch failed", which would report a
+    // launch for a call that never touched an agent.
+    expect(formatSubagentHeaderVerb({
+      item: { nativeToolName: "mcp__subagents__spawn_workspace" },
+      executionState: "failed",
+      isRunning: false,
+    })).toBe("Workspace spawned");
+  });
+
+  it("keeps a workspace spawn out of the subagent launch ledger", () => {
+    expect(isSubagentProvisioningAction({
+      nativeToolName: "mcp__subagents__spawn_workspace",
+    })).toBe(false);
+    expect(isSubagentProvisioningAction({
+      nativeToolName: "mcp__subagents__get_workspace_options",
+    })).toBe(false);
+  });
+
   it("derives concise status receipt presentation with the child target", () => {
     const presentation = deriveSubagentMcpReceiptPresentation(toolCallItem({
       nativeToolName: "mcp__subagents__get_subagent_status",

--- a/specs/anyharness/sessions.md
+++ b/specs/anyharness/sessions.md
@@ -223,10 +223,11 @@ The model is intentionally small:
   either session removes only the link and attached completion/schedule rows
 - nested subagents are blocked; an UNPROMOTED subagent child receives no
   spawn-style tools (`get_subagent_launch_options`, `spawn_subagent`, the
-  deprecated `create_subagent` alias, and `spawn_agent`), and both spawn gates
-  refuse it at the service as well: `validate_parent_can_spawn` with a depth
-  limit, `validate_caller_can_spawn_agent` as a subordinate caller. The tool
-  bodies read those gates, so the block does not rest on dispatch alone
+  deprecated `create_subagent` alias, `spawn_agent`, `get_workspace_options`
+  and `spawn_workspace`), and both spawn gates refuse it at the service as
+  well: `validate_parent_can_spawn` with a depth limit,
+  `validate_caller_can_spawn_agent` as a subordinate caller. The tool bodies
+  read those gates, so the block does not rest on dispatch alone
 - the cowork depth rule is narrower than either: `validate_parent_can_spawn`
   also refuses the child of a cowork coding session, and `spawn_agent` is
   outside that rule. Cowork is unused and slated for deletion, so the gap is
@@ -287,6 +288,8 @@ Current tools:
 - `schedule_subagent_wake`
 - `promote_subagent`
 - `close_agent` (deprecated alias: `close_subagent`)
+- `get_workspace_options`
+- `spawn_workspace`
 
 Advertisement is not enforcement. A session's tool list is frozen at launch, so
 an agent promoted afterwards holds a list that never showed the spawn tools and
@@ -297,10 +300,12 @@ state at the moment it acts, and matches the wire name so the deprecated
 
 `spawn_subagent` and `spawn_agent` are two modes of one routine,
 `create_agent_session` in `agent_ops/spawn_ops.rs`. Both create a durable
-session in the caller's workspace, inheriting the caller's agent kind, model and
-mode unless overridden, write the ownership link, arm the optional wake, start
-the runtime, and send the first prompt — unwinding the session, link and wake if
-any step fails. They differ in three places, all keyed off the ownership mode:
+session, inheriting the caller's agent kind, model and mode unless overridden,
+write the ownership link, arm the optional wake, start the runtime, and send the
+first prompt — unwinding the session, link and wake if any step fails. A
+subagent is always created in the caller's own workspace and has no argument to
+ask otherwise; `spawn_agent` takes an optional `workspaceId` and defaults to the
+caller's. They differ in three places, all keyed off the ownership mode:
 
 - the link relation, `subagent` or `owned_agent`
 - the wake: a subagent's is link-scoped, hung off the completion row, while a
@@ -313,9 +318,36 @@ any step fails. They differ in three places, all keyed off the ownership mode:
 
 A peer is created with the full tool surface, including the spawn tools, so it
 is never in the "unpromoted" state and needs no promotion. It also does not
-cascade: closing the owner does not close it. `spawn_agent` creates in the
-caller's own workspace, so it takes the route's workspace write lease and no
-target permit — there is no target yet.
+cascade: closing the owner does not close it.
+
+Because `spawn_agent` can create in a workspace that is not the caller's, it is
+absent from `MUTATING_TOOL_NAMES`: the route's lease is the CALLER's workspace,
+which is the wrong one. It takes the TARGET workspace's write lease in the call
+instead, held across creation, start and the first prompt, so a concurrent
+retire preflight on that workspace sees the session being built inside it. There
+is no admission permit and none is possible — the target session does not exist
+until the call creates it — so PR1227-LOCK-01 has no order to invert.
+
+The launch selection is resolved against the TARGET workspace's catalog, not the
+caller's. A harness that workspace cannot launch is refused, naming what it can;
+a model the caller NAMED that the target does not offer is refused; a model
+merely INHERITED from the caller is replaced by the target's default for that
+harness. A workspace whose catalog resolves to nothing is passed through
+unchanged, so an environment without resolvable readiness does not become
+un-spawnable.
+
+`get_workspace_options` and `spawn_workspace` let an agent create a workspace of
+its own. Both are spawn-style, so an unpromoted subagent gets neither.
+`get_workspace_options` is read-only: the configured repo roots, which of them
+this machine actually has, and the two creation modes. `spawn_workspace` takes
+only a repo root, a mode, a branch name and a label — everything else is
+server-side policy — and creates through the same runtimes the human routes use.
+It is absent from `MUTATING_TOOL_NAMES` for a different reason than
+`spawn_agent`: the workspace it creates does not exist yet, so there is nothing
+to lease. It gates the way the human worktree route gates, on
+`assert_can_mutate_for_repo_root` plus the caller's own workspace still being
+mutable. Retirement is not on this surface at all — see
+[workspaces.md](workspaces.md#agent-requested-creation).
 
 `promote_subagent` promotes one of the caller's subagents to a peer. The agent
 keeps its transcript, its label and its owner, and gains the full tool surface

--- a/specs/anyharness/sessions.md
+++ b/specs/anyharness/sessions.md
@@ -99,7 +99,12 @@ It stores an advisory relationship between two existing sessions:
   `review_agent`
 - parent session id
 - child session id
-- workspace relation, currently `same_workspace`
+- workspace relation: `same_workspace`, `cross_workspace`, or
+  `cowork_managed_workspace`. It is decided when the link is written, by
+  comparing the two sessions' workspace ids, and is a durable fact rather than a
+  derived one — both sessions' workspaces can later move or be retired, so the
+  row records where the child actually landed at creation. `spawn_agent` writes
+  `cross_workspace` whenever its `workspaceId` is not the caller's own.
 - optional label for display and wake copy
 - optional creator turn id
 - optional creator tool-call id

--- a/specs/anyharness/workspaces.md
+++ b/specs/anyharness/workspaces.md
@@ -176,27 +176,51 @@ paths above, not a third path. `mode=worktree` calls
 `POST /v1/workspaces/worktrees`; `mode=local` calls
 `create_workspace_with_origin_and_creator_context`, the routine behind
 `POST /v1/workspaces`. Everything workspace creation already enforces —
-path-uniqueness for worktrees, non-idempotent local create, managed repo paths —
-applies unchanged.
+path-uniqueness for worktrees, managed repo paths — applies unchanged.
 
-What the agent surface adds is three things:
+The **repo root an agent may target is any configured root present on this
+machine**, not only the caller's own. `get_workspace_options` enumerates every
+root with `available` and, when it is not, an `unavailableReason`; the tool
+refuses anything that enumeration marks unusable. (This widens the original
+"same git repo" phrasing of the agent-ops ADR §1 requirement 1.7; the ADR's §3.4
+repo-root-selection contract is the one that governs, and 1.7 carries the
+amendment note. Placement stays local-only either way.)
+
+What the agent surface adds is four things:
 
 - a **local-only gate**: the caller's workspace must have a local checkout that
   still exists, and the target repo root must be checked out on this machine.
   There is no cloud/sandbox placement to select today, so the gate is expressed
   against `has_local_checkout()` plus those two filesystem facts, and refuses
-  with the reason rather than silently creating something elsewhere.
+  with the reason rather than silently creating something elsewhere. The two
+  filesystem facts are read as a three-valued `CheckoutPresence`
+  (present / missing / unreadable) and the gate fails CLOSED: a path the server
+  cannot stat refuses and names the check, rather than being treated as present.
 - **server-side defaults for everything an agent does not pass.** The tool takes
   only a repo root, a mode, a branch name and a label; base branch
   (`repo_root.default_branch`, then the caller workspace's original/current
   branch, then `main`), target path, surface, `checkout_mode = NewBranch` and
-  `name_conflict_policy = SuffixPathAndBranch` are chosen server-side. The setup
-  script is the command this machine last ran for the caller's own workspace,
-  and never runs for `mode=local`.
+  `name_conflict_policy = SuffixPathAndBranch` are chosen server-side. `label`
+  is trimmed and bounded to 200 characters.
+- **a setup script chosen per REPO ROOT, never carried across repos.** When the
+  target root is the caller's own, the new worktree reuses the command this
+  machine last ran for the caller's workspace. When it is a different root, the
+  command is taken from that root's own active workspaces instead; if none of
+  them has ever run one, the new worktree gets no setup command. A setup script
+  is one repo's build instructions and running it in another repo's checkout is
+  a defect, not a convenience. `mode=local` never runs one.
 - **a creator stamp**: `WorkspaceCreatorContext::Agent` carrying the calling
   session id, so the workspace's provenance resolves back to the agent that
   asked for it. `session_link_id` stays `None` — a workspace is not the far end
   of a `session_links` row.
+
+**`mode=local` is idempotent per repo root on this surface.** The human route
+creates a second local workspace happily; the agent route does not. If an active
+local workspace already exists for the requested root, `spawn_workspace` returns
+it with `reused: true` instead of creating a duplicate. The reason is ruling 11:
+agents retry, and only a person can retire a workspace, so a retried call that
+created a second row would leave litter no agent can clean up. Worktree mode
+keeps the non-idempotent behavior — a branch name makes each request distinct.
 
 Retirement, purge and deletion are NOT reachable from this surface. A workspace
 an agent created is retired by a person, through the same routes as any other.

--- a/specs/anyharness/workspaces.md
+++ b/specs/anyharness/workspaces.md
@@ -167,6 +167,40 @@ The HTTP worktree creation response returns the new workspace identity. Setup
 script execution is asynchronous in the current API surface; callers should not
 expect synchronous setup-script output in the creation response.
 
+### Agent-Requested Creation
+
+`spawn_workspace` on the agent ops MCP server
+(`domains/sessions/agent_ops/workspace_ops.rs`) is a second CALLER of the two
+paths above, not a third path. `mode=worktree` calls
+`WorkspaceWorktreeRuntime::create_worktree`, the routine behind
+`POST /v1/workspaces/worktrees`; `mode=local` calls
+`create_workspace_with_origin_and_creator_context`, the routine behind
+`POST /v1/workspaces`. Everything workspace creation already enforces —
+path-uniqueness for worktrees, non-idempotent local create, managed repo paths —
+applies unchanged.
+
+What the agent surface adds is three things:
+
+- a **local-only gate**: the caller's workspace must have a local checkout that
+  still exists, and the target repo root must be checked out on this machine.
+  There is no cloud/sandbox placement to select today, so the gate is expressed
+  against `has_local_checkout()` plus those two filesystem facts, and refuses
+  with the reason rather than silently creating something elsewhere.
+- **server-side defaults for everything an agent does not pass.** The tool takes
+  only a repo root, a mode, a branch name and a label; base branch
+  (`repo_root.default_branch`, then the caller workspace's original/current
+  branch, then `main`), target path, surface, `checkout_mode = NewBranch` and
+  `name_conflict_policy = SuffixPathAndBranch` are chosen server-side. The setup
+  script is the command this machine last ran for the caller's own workspace,
+  and never runs for `mode=local`.
+- **a creator stamp**: `WorkspaceCreatorContext::Agent` carrying the calling
+  session id, so the workspace's provenance resolves back to the agent that
+  asked for it. `session_link_id` stays `None` — a workspace is not the far end
+  of a `session_links` row.
+
+Retirement, purge and deletion are NOT reachable from this surface. A workspace
+an agent created is retired by a person, through the same routes as any other.
+
 `proliferate-worker` uses this endpoint for
 `materialize_workspace(mode=worktree)`. If worktree creation returns a
 non-success response that could represent a compatible existing worktree, the

--- a/specs/codebase/platforms/product/agent-features/definitions/subagents.md
+++ b/specs/codebase/platforms/product/agent-features/definitions/subagents.md
@@ -95,20 +95,23 @@ subordination expressed on the session row; promotion lifts both, so a promoted
 agent can genuinely spawn rather than merely being offered the tools. An
 unpromoted subagent is offered no spawn-style tool at all — not
 `spawn_subagent`, not `spawn_agent`, not `get_subagent_launch_options`, not the
-`create_subagent` alias. That is stricter than the fanout cap, which merely
-refuses a spawn: a capped parent still sees its launch options, because the cap
-is a temporary condition of an agent that is allowed to think in terms of
-spawning. Subordination is not.
+`create_subagent` alias, and not the workspace pair `get_workspace_options` /
+`spawn_workspace`. That is stricter than the fanout cap, which merely refuses a
+spawn: a capped parent still sees its launch options, because the cap is a
+temporary condition of an agent that is allowed to think in terms of spawning.
+Subordination is not.
 
 The cap is also narrower than it looks. It counts unpromoted subagents, which
 are the children that cascade and that a parent is responsible for; owned agents
 are peers from birth and are not capped. An owner holding eight subagents is
-refused `spawn_subagent` and still offered `spawn_agent`.
+refused `spawn_subagent` and still offered `spawn_agent`. The workspace pair is
+not capped either: a workspace holds no agent by itself.
 
-`spawn_agent` creates a peer in the caller's own workspace and returns the new
-`sessionId` and an `agentId`. It reports no `subagentId`, because there is no
-subagent: the handle for a peer is its session id, the same one the peer tools
-take. Its launch vocabulary is `spawn_subagent`'s, deliberately: the same
+`spawn_agent` creates a peer and returns the new `sessionId` and an `agentId`.
+It reports no `subagentId`, because there is no subagent: the handle for a peer
+is its session id, the same one the peer tools take. It takes an optional
+`workspaceId` and defaults to the caller's, so the common case still needs no
+argument. Its launch vocabulary is `spawn_subagent`'s, deliberately: the same
 `harnessId` and the same open `initialConfig` object, of which `modelId` and
 `modeId` are read. `appliedInitialConfig` in the result reports what the new
 agent actually launched with, so a key that was not honoured is visibly absent
@@ -132,6 +135,48 @@ peer gate with a subordinate caller. Both are the same predicate — an open
 subagent link naming the caller as the child, not yet promoted — so an
 unpromoted subagent is refused whichever way it is reached, and no path into a
 spawn depends on dispatch having checked first.
+
+## Peer Placement
+
+A peer created in ANOTHER workspace is checked against that workspace, not
+against the caller's. The two can differ completely — a workspace authorizes its
+own harnesses, models and auth contexts — so the launch selection is composed
+against the target's catalog before anything is created. A harness the target
+cannot launch is refused and the refusal names what it can; a model the caller
+NAMED that the target does not offer is refused; and a model merely INHERITED
+from the caller, which the caller never asked for, is quietly replaced by the
+target's default for that harness rather than failing the call. The
+`appliedInitialConfig` in the response is read off the created session, so it
+reports what the agent actually launched with.
+
+This is the same principle peer configuration follows below, applied one step
+earlier: the target's universe decides, never the caller's.
+
+## Workspace Spawn
+
+`get_workspace_options` and `spawn_workspace` let a promoted agent make itself
+somewhere to work. `get_workspace_options` mirrors the human creation surface —
+the configured repo roots, which of them this machine actually has, the caller's
+own root marked as the default, and the two modes — and marks a repo it cannot
+use as unavailable WITH the reason rather than hiding it.
+
+`spawn_workspace` takes three things and a label: a repo root (defaulting to the
+caller's), a mode, and, for `mode=worktree`, a branch name. Everything else is
+server-side policy — base branch, path, name-conflict handling, setup script —
+because those are choices a human makes from a form with the repo in front of
+them, and an agent guessing at them is how you get eleven half-configured
+worktrees. A branch name that is already taken is suffixed rather than refused.
+
+Placement is local-only: the workspace lands on this machine, in a repo this
+machine has checked out, or the call is refused with which of those was false.
+Every workspace it makes carries `WorkspaceCreatorContext::Agent` with the
+calling session id, so the provenance a person sees names the agent that asked.
+
+The asymmetry is deliberate: an agent may create a workspace and may not retire
+one. Creation is recoverable — an unwanted workspace is a directory and a row.
+Retirement destroys a checkout that may hold the only copy of work, so it stays
+a decision a person makes. No tool on this server reaches a retire, purge or
+delete path, and a test asserts it by name.
 
 ## Peer Configuration
 

--- a/specs/codebase/platforms/product/agent-features/definitions/subagents.md
+++ b/specs/codebase/platforms/product/agent-features/definitions/subagents.md
@@ -149,6 +149,21 @@ target's default for that harness rather than failing the call. The
 `appliedInitialConfig` in the response is read off the created session, so it
 reports what the agent actually launched with.
 
+`modeId` follows the SAME named-versus-inherited policy, against the modes the
+chosen model advertises in the target's catalog: a mode the caller named that
+the target's model does not offer is refused, and one that only came along with
+the inheritance is replaced by the target harness's unattended default. A model
+whose catalog entry carries no mode control at all states no opinion about
+modes, so there is nothing to check against and the mode passes through
+untouched.
+
+That pass-through is the same asymmetry an EMPTY target catalog has: when the
+target workspace advertises no launch options, composition has nothing to
+validate against and the caller's selection passes through verbatim. The check
+is "the target says no", not "the target says yes" — an unreadable or
+not-yet-populated catalog must not become a refusal for every peer spawn into
+that workspace.
+
 This is the same principle peer configuration follows below, applied one step
 earlier: the target's universe decides, never the caller's.
 
@@ -161,16 +176,30 @@ own root marked as the default, and the two modes — and marks a repo it cannot
 use as unavailable WITH the reason rather than hiding it.
 
 `spawn_workspace` takes three things and a label: a repo root (defaulting to the
-caller's), a mode, and, for `mode=worktree`, a branch name. Everything else is
-server-side policy — base branch, path, name-conflict handling, setup script —
-because those are choices a human makes from a form with the repo in front of
-them, and an agent guessing at them is how you get eleven half-configured
-worktrees. A branch name that is already taken is suffixed rather than refused.
+caller's, but ANY configured root this machine has is allowed), a mode, and, for
+`mode=worktree`, a branch name. Everything else is server-side policy — base
+branch, path, name-conflict handling, setup script — because those are choices a
+human makes from a form with the repo in front of them, and an agent guessing at
+them is how you get eleven half-configured worktrees. A branch name that is
+already taken is suffixed rather than refused. The label is trimmed and bounded
+to 200 characters.
+
+The setup script is chosen for the REPO the worktree is for, never carried over
+from the caller: same root, reuse the caller's last command; different root, take
+that root's own active workspaces' last command, or none. Running one repo's
+build steps inside another repo's checkout is a defect, not a shortcut.
+
+`mode=local` is idempotent per repo root here, unlike the human route: an active
+local workspace that already exists for the requested root is returned with
+`reused: true` rather than duplicated. Agents retry, and the asymmetry below
+gives them no way to undo a duplicate.
 
 Placement is local-only: the workspace lands on this machine, in a repo this
-machine has checked out, or the call is refused with which of those was false.
-Every workspace it makes carries `WorkspaceCreatorContext::Agent` with the
-calling session id, so the provenance a person sees names the agent that asked.
+machine has checked out, or the call is refused with which of those was false —
+including when the server cannot read the path at all, which refuses rather than
+assuming the checkout is there. Every workspace it makes carries
+`WorkspaceCreatorContext::Agent` with the calling session id, so the provenance a
+person sees names the agent that asked.
 
 The asymmetry is deliberate: an agent may create a workspace and may not retire
 one. Creation is recoverable — an unwanted workspace is a directory and a row.


### PR DESCRIPTION
Part 7 of the agent-operations stack (ADR §6 step 7). Stacked on #1732.

## What this does

Adds `get_workspace_options` and `spawn_workspace` to the agent-ops MCP, and lifts PR6's caller-workspace restriction on `spawn_agent` so the two-step flow of ADR §5 works: describe → create → put an agent in it.

`spawn_workspace` calls the same runtimes the human routes call — `WorkspaceWorktreeRuntime::create_worktree` for `mode=worktree`, `create_workspace_with_origin_and_creator_context` for `mode=local`. It adds only what the human routes do not need: the local-only gate, the `WorkspaceCreatorContext::Agent` stamp, and server-side defaults for base branch, path, name-conflict policy and setup script (the command this machine last ran for the caller's workspace — no second detection policy). The agent passes three things and a label.

`spawn_agent` now takes any `workspaceId`, defaulting to the caller's. It therefore leaves `MUTATING_TOOL_NAMES` — the route's lease is the caller's workspace, the wrong one — and takes the target workspace's write lease in the call, held across creation, start and the first prompt. No admission permit exists or can: the target session does not exist until the call creates it. The launch selection is now composed against the target workspace's catalog inside the shared creation routine: a harness the target cannot launch is refused naming what it can; a model the caller NAMED that the target does not offer is refused; a model merely INHERITED from the caller is quietly replaced by the target's default.

Retirement stays human-only (ruling 11), with a name-and-source ratchet: no agent-ops tool reaches a retire, purge or delete path, asserted by name over the advertised list, both tool-name lists, the aliases, and the source of `workspace_ops.rs`.

## Spec notes

- Local-only is implemented as `has_local_checkout()` plus two filesystem facts (the caller's checkout still on disk, the target repo root a directory here), because no local-vs-cloud placement concept exists in the codebase — ADR §2 says as much. §1 req 1.7's "(if running locally)" parenthetical has no state to read today; raised as a contradiction, not silently resolved.
- ADR §3.4 says `spawn_workspace` is "promoted / top level agents only"; gated on `can_spawn_agent` (the peer-spawn signal) so the workspace pair and `spawn_agent` read the same subordination answer.

## Testing

Full `anyharness-lib --lib` on the rebased head: **1735 passed / 1 failed** — only the known pre-existing `sweep_tests::the_sweep_removes_only_abandoned_and_old_scratch_roots` red. Scoped suites (`agent_ops workspaces ownership subagents session_admission`) 269/269 pre-rebase. SDK vitest 48 passed, product-client vitest 17 passed. `check_docs.py` green (209 files).

Four negative controls run and reverted:
1. Local-only gate arm removed → `a_repo_this_machine_does_not_have_is_refused` failed.
2. Creator stamp, two levels — call sites dropped to `None` and the stamp's session id blanked → three tests failed. This control exposed that `creator_context` being an `Option` let a dropped stamp compile silently; the call-site ratchet added here is its product.
3. Launch selection composed against the caller instead of the target → 6 failures via PR4's disjoint-catalog CatalogSpy, including the call-site ratchet `the_real_resolver_is_handed_the_target_workspace_too` (also born from this control).
4. `spawn_agent` re-added to `MUTATING_TOOL_NAMES` → both lease-in-the-call ratchets failed.

## Observability

A cross-workspace `spawn_agent` logs caller session, caller workspace and target workspace at info — the one call that reaches out of its own workspace, and the one whose lease a retire preflight elsewhere can block on.

## Known deferrals

Stack-introduced lint reds (`check_max_lines`, session-mutation-admission classification, anyharness-boundaries allowlist) are swept at the top of the stack with founder-flagged allowlist entries, as disclosed on #1731.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
