### PR TITLE
fix(product): keep session reopen idempotent

### DIFF
--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-activation-guard.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-activation-guard.test.ts
@@ -186,6 +186,30 @@ describe("session activation guard", () => {
       .toBeUndefined();
   });
 
+  it("rewrites guarded shell selection to the client identity returned by selection", async () => {
+    selectWorkspace("materialized-workspace", "logical-workspace");
+
+    const outcome = await selectSessionWithShellIntentRollback({
+      workspaceId: "materialized-workspace",
+      sessionId: "runtime-session",
+      selectSession: async (_sessionId, options) => ({
+        result: "completed",
+        sessionId: "client-session:codex:existing",
+        guard: options!.guard!,
+        activeSessionVersion: 1,
+      }),
+    });
+
+    expect(outcome).toMatchObject({
+      result: "completed",
+      sessionId: "client-session:codex:existing",
+    });
+    expect(useWorkspaceUiStore.getState().activeShellTabKeyByWorkspace["logical-workspace"])
+      .toBe("chat:client-session:codex:existing");
+    expect(useWorkspaceUiStore.getState().pendingChatActivationByWorkspace["logical-workspace"])
+      .toBeNull();
+  });
+
   it("guards backend reuse shell selection and rolls back logical shell intent on stale", async () => {
     selectWorkspace("materialized-workspace", "logical-workspace");
     useWorkspaceUiStore.getState().writeShellIntent({

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-local-state.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-local-state.ts
@@ -1,4 +1,5 @@
 import { batchSessionStoreWrites } from "#product/lib/infra/scheduling/react-batching";
+import { replaceSessionIdInOpenShellState } from "#product/hooks/sessions/workflows/session-replacement-shell-preferences";
 import {
   getSessionRecord,
   patchSessionRecord,
@@ -14,13 +15,61 @@ export function materializeSessionRecord(
   materializedSessionId: string,
   record: SessionRuntimeRecord,
 ): void {
+  const materializedAlias = clientSessionId === materializedSessionId
+    ? null
+    : getSessionRecord(materializedSessionId);
   batchSessionStoreWrites(() => {
+    const nextRecord = preserveHydratedAliasTranscript(
+      record,
+      materializedAlias,
+      clientSessionId,
+    );
     patchSessionRecord(clientSessionId, {
-      ...record,
+      ...nextRecord,
       sessionId: clientSessionId,
       materializedSessionId,
     });
+    if (!materializedAlias || !getSessionRecord(clientSessionId)) {
+      return;
+    }
+
+    useSessionIntentStore.getState().reassignClientSession(
+      materializedSessionId,
+      clientSessionId,
+    );
+    const selection = useSessionSelectionStore.getState();
+    if (selection.activeSessionId === materializedSessionId) {
+      selection.setActiveSessionId(clientSessionId);
+    }
+    replaceSessionIdInOpenShellState({
+      replacedSessionId: materializedSessionId,
+      replacementSessionId: clientSessionId,
+    });
+    removeSessionRecord(materializedSessionId);
   });
+}
+
+function preserveHydratedAliasTranscript(
+  record: SessionRuntimeRecord,
+  materializedAlias: SessionRuntimeRecord | null,
+  clientSessionId: string,
+): SessionRuntimeRecord {
+  if (!materializedAlias?.transcriptHydrated) {
+    return record;
+  }
+  return {
+    ...record,
+    events: materializedAlias.events,
+    transcript: {
+      ...materializedAlias.transcript,
+      sessionMeta: {
+        ...materializedAlias.transcript.sessionMeta,
+        sessionId: clientSessionId,
+      },
+    },
+    optimisticPrompt: materializedAlias.optimisticPrompt ?? record.optimisticPrompt,
+    transcriptHydrated: true,
+  };
 }
 
 /**

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-shell-preferences.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-shell-preferences.ts
@@ -1,5 +1,6 @@
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 import type { ManualChatGroup } from "#product/lib/domain/workspaces/tabs/manual-groups";
+import { chatWorkspaceShellTabKey } from "#product/lib/domain/workspaces/tabs/shell-tabs";
 import {
   replaceSessionIdInManualChatGroups,
   replaceSessionIdInOrderedList,
@@ -61,6 +62,34 @@ export function replaceSessionIdInShellPreferences(input: {
     input.materializedWorkspaceId,
   ])) {
     replaceSessionIdInShellPreferencesForWorkspace(workspaceId, input);
+  }
+}
+
+/**
+ * Converges a live alias into its client shell everywhere that can keep the
+ * alias open. Durable last-viewed state intentionally remains runtime-keyed.
+ */
+export function replaceSessionIdInOpenShellState(input: {
+  replacedSessionId: string;
+  replacementSessionId: string;
+}): void {
+  const state = useWorkspaceUiStore.getState();
+  const workspaceIds = new Set([
+    ...Object.keys(state.activeShellTabKeyByWorkspace),
+    ...Object.keys(state.shellTabOrderByWorkspace),
+    ...Object.keys(state.visibleChatSessionIdsByWorkspace),
+    ...Object.keys(state.manualChatGroupsByWorkspace),
+  ]);
+  const replacedIntent = chatWorkspaceShellTabKey(input.replacedSessionId);
+  const replacementIntent = chatWorkspaceShellTabKey(input.replacementSessionId);
+
+  for (const workspaceId of workspaceIds) {
+    replaceSessionIdInShellPreferencesForWorkspace(workspaceId, input);
+    state.replaceShellIntent({
+      workspaceId,
+      expectedIntent: replacedIntent,
+      nextIntent: replacementIntent,
+    });
   }
 }
 

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-selection-slot-sync.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-selection-slot-sync.ts
@@ -1,0 +1,93 @@
+import type { WorkspaceSession } from "#product/hooks/access/anyharness/sessions/use-workspace-session-cache";
+import { resolveStatusFromExecutionSummary } from "#product/domain/sessions/activity";
+import type { SessionRelationship } from "#product/lib/domain/sessions/directory/relationship";
+import type { MeasurementOperationId } from "#product/lib/domain/telemetry/debug-measurement-catalog";
+import {
+  recordMeasurementMetric,
+  recordMeasurementWorkflowStep,
+} from "#product/lib/infra/measurement/measurement-port";
+import {
+  createEmptySessionRecord,
+  patchSessionRecord,
+  putSessionRecord,
+} from "#product/stores/sessions/session-records";
+import type { SessionRuntimeRecord } from "#product/stores/sessions/session-types";
+
+export function syncSessionSelectionSlot({
+  existingSlot,
+  materializedSessionId,
+  measurementOperationId,
+  sessionId,
+  sessionMeta,
+  sessionRelationship,
+  workspaceId,
+}: {
+  existingSlot: SessionRuntimeRecord | null;
+  materializedSessionId: string;
+  measurementOperationId: MeasurementOperationId | null;
+  sessionId: string;
+  sessionMeta: WorkspaceSession | null;
+  sessionRelationship: SessionRelationship;
+  workspaceId: string;
+}): void {
+  const agentKind = existingSlot?.agentKind ?? sessionMeta?.agentKind ?? "unknown";
+  const storeStartedAt = performance.now();
+
+  if (!existingSlot) {
+    putSessionRecord({
+      ...createEmptySessionRecord(sessionId, agentKind, {
+        workspaceId,
+        materializedSessionId,
+        modelId: sessionMeta?.modelId ?? null,
+        requestedModelId: sessionMeta?.requestedModelId ?? sessionMeta?.modelId ?? null,
+        modeId: sessionMeta?.modeId ?? null,
+        title: sessionMeta?.title ?? null,
+        liveConfig: sessionMeta?.liveConfig ?? null,
+        executionSummary: sessionMeta?.executionSummary ?? null,
+        mcpBindingSummaries: sessionMeta?.mcpBindingSummaries ?? null,
+        lastPromptAt: sessionMeta?.lastPromptAt ?? null,
+        sessionRelationship,
+      }),
+      status: resolveStatusFromExecutionSummary(
+        sessionMeta?.executionSummary ?? null,
+        sessionMeta?.status ?? "idle",
+      ),
+    });
+  } else {
+    patchSessionRecord(sessionId, {
+      workspaceId,
+      agentKind,
+      modelId: sessionMeta?.modelId ?? existingSlot.modelId ?? null,
+      requestedModelId:
+        sessionMeta?.requestedModelId
+        ?? sessionMeta?.modelId
+        ?? existingSlot.requestedModelId
+        ?? null,
+      modeId: sessionMeta?.modeId ?? existingSlot.modeId ?? null,
+      title: sessionMeta?.title ?? existingSlot.title ?? null,
+      liveConfig: sessionMeta?.liveConfig ?? existingSlot.liveConfig ?? null,
+      executionSummary: sessionMeta?.executionSummary ?? existingSlot.executionSummary ?? null,
+      mcpBindingSummaries: sessionMeta?.mcpBindingSummaries ?? existingSlot.mcpBindingSummaries ?? null,
+      status: resolveStatusFromExecutionSummary(
+        sessionMeta?.executionSummary ?? existingSlot.executionSummary ?? null,
+        sessionMeta?.status ?? existingSlot.status,
+      ),
+      lastPromptAt: sessionMeta?.lastPromptAt ?? existingSlot.lastPromptAt ?? null,
+    });
+  }
+
+  if (measurementOperationId) {
+    recordMeasurementMetric({
+      type: "store",
+      category: "session.list",
+      operationId: measurementOperationId,
+      durationMs: performance.now() - storeStartedAt,
+    });
+  }
+  recordMeasurementWorkflowStep({
+    operationId: measurementOperationId,
+    step: "session.select.slot_store",
+    startedAt: storeStartedAt,
+    outcome: existingSlot ? "cache_hit" : "cache_miss",
+  });
+}

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-shell-selection.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-shell-selection.ts
@@ -3,6 +3,7 @@ import type {
   SessionActivationOutcome,
 } from "#product/hooks/sessions/workflows/session-activation-guard";
 import { beginSessionActivationIntent } from "#product/hooks/sessions/workflows/session-activation-guard";
+import { chatWorkspaceShellTabKey } from "#product/lib/domain/workspaces/tabs/shell-tabs";
 import { writeChatShellIntentForSession } from "#product/hooks/workspaces/workflows/tabs/workspace-shell-intent-writer";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 
@@ -47,6 +48,33 @@ export async function selectSessionWithShellIntentRollback(input: {
       ...input.options,
       guard,
     });
+    if (
+      outcome?.result === "completed"
+      && outcome.sessionId !== input.sessionId
+      && shellWrite
+    ) {
+      const currentPending = useWorkspaceUiStore.getState()
+        .pendingChatActivationByWorkspace[shellWrite.shellWorkspaceId] ?? null;
+      if (currentPending?.attemptId === pendingAttemptId) {
+        const completedIntent = chatWorkspaceShellTabKey(outcome.sessionId);
+        const replacement = useWorkspaceUiStore.getState().replaceShellIntent({
+          workspaceId: shellWrite.shellWorkspaceId,
+          expectedIntent: shellWrite.currentIntent,
+          expectedEpoch: shellWrite.epoch,
+          nextIntent: completedIntent,
+        });
+        if (replacement.replaced || replacement.currentIntent === completedIntent) {
+          useWorkspaceUiStore.getState().setPendingChatActivation({
+            workspaceId: shellWrite.shellWorkspaceId,
+            pending: {
+              ...currentPending,
+              sessionId: outcome.sessionId,
+              intent: completedIntent,
+            },
+          });
+        }
+      }
+    }
     if (outcome?.result === "stale" && shellWrite) {
       useWorkspaceUiStore.getState().rollbackShellIntent({
         workspaceId: shellWrite.shellWorkspaceId,

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.test.ts
@@ -57,6 +57,62 @@ describe("projected session materialization", () => {
     expect(useSessionSelectionStore.getState().activeSessionVersion).toBe(versionBefore);
   });
 
+  it("coalesces a hydrated runtime alias into the pending client slot", () => {
+    const clientSessionId = "client-session:codex:materializing-late";
+    const runtimeSessionId = "runtime-session-materializing-late";
+    putSessionRecord(
+      createEmptySessionRecord(clientSessionId, "codex", {
+        workspaceId: "workspace-1",
+        materializedSessionId: null,
+      }),
+    );
+    const runtimeAlias = createEmptySessionRecord(runtimeSessionId, "codex", {
+      workspaceId: "workspace-1",
+      materializedSessionId: runtimeSessionId,
+      title: "Loaded runtime alias",
+    });
+    putSessionRecord({
+      ...runtimeAlias,
+      transcript: {
+        ...runtimeAlias.transcript,
+        sessionMeta: {
+          ...runtimeAlias.transcript.sessionMeta,
+          title: "Hydrated runtime transcript",
+        },
+      },
+      transcriptHydrated: true,
+    });
+    useSessionSelectionStore.getState().setActiveSessionId(runtimeSessionId);
+
+    materializeSessionRecord(
+      clientSessionId,
+      runtimeSessionId,
+      createEmptySessionRecord(clientSessionId, "codex", {
+        workspaceId: "workspace-1",
+        materializedSessionId: runtimeSessionId,
+        title: "Published session summary",
+      }),
+    );
+
+    expect(getSessionRecord(runtimeSessionId)).toBeNull();
+    expect(getSessionRecord(clientSessionId)).toMatchObject({
+      sessionId: clientSessionId,
+      materializedSessionId: runtimeSessionId,
+      transcriptHydrated: true,
+      transcript: {
+        sessionMeta: {
+          sessionId: clientSessionId,
+          title: "Hydrated runtime transcript",
+        },
+      },
+    });
+    expect(useSessionSelectionStore.getState().activeSessionId).toBe(clientSessionId);
+    expect(
+      useSessionDirectoryStore.getState()
+        .clientSessionIdByMaterializedSessionId[runtimeSessionId],
+    ).toBe(clientSessionId);
+  });
+
   it("clears active session when removing an active pending slot", () => {
     useSessionSelectionStore.getState().activateWorkspace({
       logicalWorkspaceId: "workspace-1",

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-find-or-create-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-find-or-create-actions.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSessionFindOrCreateActions } from "#product/hooks/sessions/workflows/use-session-find-or-create-actions";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+
+const workflowMocks = vi.hoisted(() => ({
+  promptSession: vi.fn(),
+  selectSessionWithShellIntentRollback: vi.fn(),
+}));
+
+vi.mock("#product/hooks/sessions/workflows/use-session-prompt-workflow", () => ({
+  useSessionPromptWorkflow: () => ({ promptSession: workflowMocks.promptSession }),
+}));
+
+vi.mock("#product/hooks/sessions/workflows/session-shell-selection", () => ({
+  selectSessionWithShellIntentRollback:
+    workflowMocks.selectSessionWithShellIntentRollback,
+}));
+
+vi.mock("#product/hooks/workspaces/derived/use-workspace-runtime-block", () => ({
+  useWorkspaceRuntimeBlock: () => ({
+    getWorkspaceRuntimeBlockReason: () => null,
+  }),
+}));
+
+afterEach(cleanup);
+
+describe("useSessionFindOrCreateActions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+  });
+
+  it("prompts the client identity returned by guarded backend selection", async () => {
+    const clientSessionId = "client-session:codex:existing";
+    const runtimeSessionId = "runtime-session-existing";
+    workflowMocks.selectSessionWithShellIntentRollback.mockResolvedValueOnce({
+      result: "completed",
+      sessionId: clientSessionId,
+      guard: {
+        workspaceId: "workspace-1",
+        workspaceSelectionNonce: 1,
+        token: 1,
+      },
+      activeSessionVersion: 1,
+    });
+    const createSessionWithResolvedConfig = vi.fn();
+    const { result } = renderHook(() => useSessionFindOrCreateActions({
+      activateSession: vi.fn(),
+      createSessionWithResolvedConfig,
+      ensureWorkspaceSessions: vi.fn().mockResolvedValue([{
+        id: runtimeSessionId,
+        agentKind: "codex",
+        modelId: "gpt-5",
+        workspaceId: "workspace-1",
+      }]),
+      selectSession: vi.fn(),
+    }));
+
+    await act(async () => {
+      await result.current.findOrCreateSessionForLaunch({
+        workspaceId: "workspace-1",
+        agentKind: "codex",
+        modelId: "gpt-5",
+        text: "Continue",
+      });
+    });
+
+    expect(workflowMocks.promptSession).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: clientSessionId,
+      workspaceId: "workspace-1",
+      text: "Continue",
+    }));
+    expect(createSessionWithResolvedConfig).not.toHaveBeenCalled();
+  });
+});

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-find-or-create-actions.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-find-or-create-actions.ts
@@ -17,6 +17,7 @@ import type { MeasurementOperationId } from "#product/lib/domain/telemetry/debug
 import { writeChatShellIntentForSession } from "#product/hooks/workspaces/workflows/tabs/workspace-shell-intent-writer";
 import { selectSessionWithShellIntentRollback } from "#product/hooks/sessions/workflows/session-shell-selection";
 import {
+  findClientSessionIdByMaterializedSessionId,
   getSessionRecords,
 } from "#product/stores/sessions/session-records";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
@@ -135,14 +136,20 @@ export function useSessionFindOrCreateActions({
       session.agentKind === agentKind && session.modelId === modelId
     );
     if (backendSession) {
-      await selectSessionWithShellIntentRollback({
+      const selectionOutcome = await selectSessionWithShellIntentRollback({
         workspaceId,
         sessionId: backendSession.id,
         options: { latencyFlowId },
         selectSession,
       });
+      if (selectionOutcome?.result === "stale") {
+        return;
+      }
+      const selectedSessionId = selectionOutcome?.result === "completed"
+        ? selectionOutcome.sessionId
+        : findClientSessionIdByMaterializedSessionId(backendSession.id) ?? backendSession.id;
       await promptSession({
-        sessionId: backendSession.id,
+        sessionId: selectedSessionId,
         text,
         blocks,
         attachmentSnapshots,

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-selection-actions.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-selection-actions.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createEmptySessionRecord,
   getSessionRecord,
+  patchSessionRecord,
   putSessionRecord,
 } from "#product/stores/sessions/session-records";
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
@@ -127,6 +128,52 @@ describe("guarded query-only session selection", () => {
       reason: "intent-replaced",
     });
     expect(getSessionRecord("runtime-reloaded-codex")).toBeNull();
+    expect(activateSession).not.toHaveBeenCalled();
+  });
+
+  it("focuses the client slot when it materializes during the session-list load", async () => {
+    const clientSessionId = "client-session:codex:materializing";
+    const materializedSessionId = "runtime-session-materializing";
+    putSessionRecord(createEmptySessionRecord(clientSessionId, "codex", {
+      materializedSessionId: null,
+      workspaceId: "workspace-1",
+    }));
+    const sessionsGate = deferred<WorkspaceSession[]>();
+    const ensureWorkspaceSessions = vi.fn(() => sessionsGate.promise);
+    const activateSession = vi.fn();
+    const { result } = renderHook(() => useSessionSelectionWorkflowActions({
+      activateSession,
+      ensureWorkspaceSessions,
+    }));
+    const guard = beginSessionActivationIntent("workspace-1");
+
+    const selection = result.current.selectSession(materializedSessionId, { guard });
+    await vi.waitFor(() => expect(ensureWorkspaceSessions).toHaveBeenCalledOnce());
+
+    patchSessionRecord(clientSessionId, { materializedSessionId });
+    sessionsGate.resolve([{
+      id: materializedSessionId,
+      workspaceId: "workspace-1",
+      agentKind: "codex",
+      modelId: "gpt-5",
+      status: "idle",
+      title: "Materialized session",
+      lastPromptAt: null,
+    } as WorkspaceSession]);
+
+    await expect(selection).resolves.toMatchObject({
+      result: "completed",
+      sessionId: clientSessionId,
+    });
+    expect(useSessionSelectionStore.getState().activeSessionId).toBe(clientSessionId);
+    expect(getSessionRecord(clientSessionId)).toMatchObject({
+      materializedSessionId,
+      sessionRelationship: { kind: "root" },
+      title: "Materialized session",
+    });
+    expect(getSessionRecord(materializedSessionId)).toBeNull();
+    expect(Object.keys(useSessionDirectoryStore.getState().entriesById))
+      .toEqual([clientSessionId]);
     expect(activateSession).not.toHaveBeenCalled();
   });
 });

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-selection-actions.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-selection-actions.test.ts
@@ -1,7 +1,14 @@
 // @vitest-environment jsdom
 
 import { cleanup, renderHook } from "@testing-library/react";
+import type { Session } from "@anyharness/sdk";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WORKSPACE_UI_DEFAULTS } from "#product/lib/domain/preferences/workspace-ui/model";
+import { chatWorkspaceShellTabKey } from "#product/lib/domain/workspaces/tabs/shell-tabs";
+import { buildKnownHeaderSessions } from "#product/lib/domain/workspaces/tabs/workspace-header-tabs-model-helpers";
+import { publishCreatedSessionMaterialization } from "#product/hooks/sessions/workflows/session-creation-publication";
+import { writeChatShellIntentForSession } from "#product/hooks/workspaces/workflows/tabs/workspace-shell-intent-writer";
+import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 import {
   createEmptySessionRecord,
   getSessionRecord,
@@ -11,6 +18,10 @@ import {
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+import {
+  getSessionIntentsForSession,
+  useSessionIntentStore,
+} from "#product/stores/sessions/session-intent-store";
 import { classifyTrustedSessionSelection } from "#product/hooks/sessions/workflows/session-selection-relationship";
 import { useSessionSelectionWorkflowActions } from "#product/hooks/sessions/workflows/use-session-selection-actions";
 import {
@@ -37,6 +48,15 @@ describe("classifyTrustedSessionSelection", () => {
     });
     useSessionDirectoryStore.getState().clearEntries();
     useSessionTranscriptStore.getState().clearEntries();
+    useSessionIntentStore.getState().clear();
+    useWorkspaceUiStore.setState({
+      ...WORKSPACE_UI_DEFAULTS,
+      _hydrated: true,
+      archivingChatSessionIdsByWorkspace: {},
+      pendingChatActivationByWorkspace: {},
+      shellActivationEpochByWorkspace: {},
+      urgentHighlightedChatSessionByWorkspace: {},
+    });
   });
 
   it("promotes a pending mounted session to root when no child hint exists", () => {
@@ -93,6 +113,15 @@ describe("guarded query-only session selection", () => {
     });
     useSessionDirectoryStore.getState().clearEntries();
     useSessionTranscriptStore.getState().clearEntries();
+    useSessionIntentStore.getState().clear();
+    useWorkspaceUiStore.setState({
+      ...WORKSPACE_UI_DEFAULTS,
+      _hydrated: true,
+      archivingChatSessionIdsByWorkspace: {},
+      pendingChatActivationByWorkspace: {},
+      shellActivationEpochByWorkspace: {},
+      urgentHighlightedChatSessionByWorkspace: {},
+    });
   });
 
   it("does not publish a late authoritative slot after replacement invalidates activation", async () => {
@@ -175,6 +204,142 @@ describe("guarded query-only session selection", () => {
     expect(Object.keys(useSessionDirectoryStore.getState().entriesById))
       .toEqual([clientSessionId]);
     expect(activateSession).not.toHaveBeenCalled();
+  });
+
+  it("converges a direct runtime slot when its pending client slot materializes later", async () => {
+    const clientSessionId = "client-session:codex:materializing-late";
+    const materializedSessionId = "runtime-session-materializing-late";
+    const controlClientSessionId = "client-session:claude:control";
+    const controlMaterializedSessionId = "runtime-session-control";
+    putSessionRecord(createEmptySessionRecord(clientSessionId, "codex", {
+      materializedSessionId: null,
+      workspaceId: "workspace-1",
+    }));
+    putSessionRecord(createEmptySessionRecord(controlClientSessionId, "claude", {
+      materializedSessionId: controlMaterializedSessionId,
+      workspaceId: "workspace-1",
+    }));
+    const sessionsGate = deferred<WorkspaceSession[]>();
+    const ensureWorkspaceSessions = vi.fn(() => sessionsGate.promise);
+    const { result } = renderHook(() => useSessionSelectionWorkflowActions({
+      activateSession: vi.fn(),
+      ensureWorkspaceSessions,
+    }));
+    const guard = beginSessionActivationIntent("workspace-1");
+    const materializedSession = {
+      id: materializedSessionId,
+      workspaceId: "workspace-1",
+      agentKind: "codex",
+      modelId: "gpt-5",
+      status: "idle",
+      title: "Materializing session",
+      lastPromptAt: null,
+    } as Session;
+    const controlSession = {
+      id: controlMaterializedSessionId,
+      workspaceId: "workspace-1",
+      agentKind: "claude",
+      modelId: "claude-sonnet",
+      status: "idle",
+      title: "Intentional second session",
+      lastPromptAt: null,
+    } as Session;
+
+    const selection = result.current.selectSession(materializedSessionId, { guard });
+    await vi.waitFor(() => expect(ensureWorkspaceSessions).toHaveBeenCalledOnce());
+    sessionsGate.resolve([materializedSession, controlSession]);
+    await expect(selection).resolves.toMatchObject({
+      result: "completed",
+      sessionId: materializedSessionId,
+    });
+
+    expect(Object.keys(useSessionDirectoryStore.getState().entriesById).sort()).toEqual([
+      clientSessionId,
+      controlClientSessionId,
+      materializedSessionId,
+    ].sort());
+    expect(useSessionSelectionStore.getState().activeSessionId)
+      .toBe(materializedSessionId);
+    writeChatShellIntentForSession({
+      workspaceId: "workspace-1",
+      sessionId: materializedSessionId,
+    });
+    const workspaceUi = useWorkspaceUiStore.getState();
+    workspaceUi.setShellTabOrderForWorkspace("workspace-1", [
+      chatWorkspaceShellTabKey(clientSessionId),
+      chatWorkspaceShellTabKey(materializedSessionId),
+      chatWorkspaceShellTabKey(controlClientSessionId),
+    ]);
+    workspaceUi.setVisibleChatSessionIdsForWorkspace("workspace-1", [
+      clientSessionId,
+      materializedSessionId,
+      controlClientSessionId,
+    ]);
+    useSessionIntentStore.getState().enqueueConfig({
+      clientSessionId: materializedSessionId,
+      workspaceId: "workspace-1",
+      configId: "reasoning_effort",
+      value: "high",
+    });
+
+    publishCreatedSessionMaterialization({
+      agentKind: "codex",
+      fallbackModeId: null,
+      fallbackModelId: "gpt-5",
+      pendingSessionId: clientSessionId,
+      record: {
+        ...createEmptySessionRecord(clientSessionId, "codex", {
+          materializedSessionId,
+          workspaceId: "workspace-1",
+          title: "Materializing session",
+        }),
+        transcriptHydrated: true,
+      },
+      session: materializedSession,
+      trackProductEvent: vi.fn(),
+      upsertWorkspaceSessionRecord: vi.fn(),
+      workspaceId: "workspace-1",
+      workspaceKind: "local",
+    });
+
+    const directory = useSessionDirectoryStore.getState();
+    const knownTabs = buildKnownHeaderSessions({
+      sessions: [materializedSession, controlSession],
+      selectedWorkspaceId: "workspace-1",
+      clientSessionIdByMaterializedSessionId:
+        directory.clientSessionIdByMaterializedSessionId,
+      liveSlots: Object.values(directory.entriesById),
+    });
+    expect(Object.keys(directory.entriesById).sort()).toEqual([
+      clientSessionId,
+      controlClientSessionId,
+    ].sort());
+    expect(Array.from(knownTabs.keys()).sort()).toEqual([
+      clientSessionId,
+      controlClientSessionId,
+    ].sort());
+    expect(directory.clientSessionIdByMaterializedSessionId).toMatchObject({
+      [materializedSessionId]: clientSessionId,
+      [controlMaterializedSessionId]: controlClientSessionId,
+    });
+    expect(useSessionSelectionStore.getState().activeSessionId).toBe(clientSessionId);
+    expect(useWorkspaceUiStore.getState().activeShellTabKeyByWorkspace["workspace-1"])
+      .toBe(chatWorkspaceShellTabKey(clientSessionId));
+    expect(useWorkspaceUiStore.getState().shellTabOrderByWorkspace["workspace-1"])
+      .toEqual([
+        chatWorkspaceShellTabKey(clientSessionId),
+        chatWorkspaceShellTabKey(controlClientSessionId),
+      ]);
+    expect(useWorkspaceUiStore.getState().visibleChatSessionIdsByWorkspace["workspace-1"])
+      .toEqual([clientSessionId, controlClientSessionId]);
+    expect(getSessionRecord(materializedSessionId)).toBeNull();
+    expect(getSessionIntentsForSession(materializedSessionId)).toEqual([]);
+    expect(getSessionIntentsForSession(clientSessionId)).toEqual([
+      expect.objectContaining({
+        clientSessionId,
+        materializedSessionId,
+      }),
+    ]);
   });
 });
 

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-selection-actions.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-selection-actions.ts
@@ -7,7 +7,6 @@ import {
   type SessionActivationOutcome,
 } from "#product/hooks/sessions/workflows/session-activation-guard";
 import type { SessionLatencyFlowOptions } from "#product/hooks/sessions/workflows/session-selection-options";
-import { resolveStatusFromExecutionSummary } from "#product/domain/sessions/activity";
 import { isHotReopenEligibleSessionSlot } from "#product/lib/domain/workspaces/selection/hot-reopen";
 import { resolveWorkspaceUiKey } from "#product/lib/domain/workspaces/selection/workspace-ui-key";
 import {
@@ -19,7 +18,6 @@ import {
   finishOrCancelMeasurementOperation,
   finishMeasurementOperation,
   markOperationForNextCommit,
-  recordMeasurementMetric,
   recordMeasurementWorkflowStep,
   startMeasurementOperation,
 } from "#product/lib/infra/measurement/measurement-port";
@@ -28,12 +26,9 @@ import { annotateLatencyFlow } from "#product/lib/infra/measurement/measurement-
 import { scheduleAfterNextPaint } from "#product/lib/infra/scheduling/schedule-after-next-paint";
 import { rememberLastViewedSession } from "#product/stores/preferences/workspace-ui-store";
 import {
-  createEmptySessionRecord,
   findClientSessionIdByMaterializedSessionId,
   getSessionRecord,
   isPendingSessionId,
-  patchSessionRecord,
-  putSessionRecord,
 } from "#product/stores/sessions/session-records";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useWorkspaceRuntimeBlock } from "#product/hooks/workspaces/derived/use-workspace-runtime-block";
@@ -42,6 +37,7 @@ import {
   SESSION_HOT_SWITCH_MEASUREMENT_SURFACES,
   SESSION_SWITCH_MEASUREMENT_SURFACES,
 } from "#product/hooks/sessions/workflows/session-selection-measurement";
+import { syncSessionSelectionSlot } from "#product/hooks/sessions/workflows/session-selection-slot-sync";
 
 interface UseSessionSelectionWorkflowActionsOptions {
   activateSession: (sessionId: string) => void;
@@ -308,80 +304,15 @@ export function useSessionSelectionWorkflowActions({
     const metadataSessionId = existingSlot?.materializedSessionId
       ?? (sessionId === requestedSessionId ? sessionId : requestedSessionId);
     const sessionMeta = sessions.find((session) => session.id === metadataSessionId) ?? null;
-    const agentKind = existingSlot?.agentKind ?? sessionMeta?.agentKind ?? "unknown";
-
-    if (!existingSlot) {
-      const storeStartedAt = performance.now();
-      putSessionRecord({
-        ...createEmptySessionRecord(sessionId, agentKind, {
-          workspaceId,
-          materializedSessionId: metadataSessionId,
-          modelId: sessionMeta?.modelId ?? null,
-          requestedModelId: sessionMeta?.requestedModelId ?? sessionMeta?.modelId ?? null,
-          modeId: sessionMeta?.modeId ?? null,
-          title: sessionMeta?.title ?? null,
-          liveConfig: sessionMeta?.liveConfig ?? null,
-          executionSummary: sessionMeta?.executionSummary ?? null,
-          mcpBindingSummaries: sessionMeta?.mcpBindingSummaries ?? null,
-          lastPromptAt: sessionMeta?.lastPromptAt ?? null,
-          sessionRelationship: sessionSelectionRelationship,
-        }),
-        status: resolveStatusFromExecutionSummary(
-          sessionMeta?.executionSummary ?? null,
-          sessionMeta?.status ?? "idle",
-        ),
-      });
-      if (measurementOperationId) {
-        recordMeasurementMetric({
-          type: "store",
-          category: "session.list",
-          operationId: measurementOperationId,
-          durationMs: performance.now() - storeStartedAt,
-        });
-      }
-      recordMeasurementWorkflowStep({
-        operationId: measurementOperationId,
-        step: "session.select.slot_store",
-        startedAt: storeStartedAt,
-        outcome: "cache_miss",
-      });
-    } else {
-      const storeStartedAt = performance.now();
-      patchSessionRecord(sessionId, {
-        workspaceId,
-        agentKind,
-        modelId: sessionMeta?.modelId ?? existingSlot.modelId ?? null,
-        requestedModelId:
-          sessionMeta?.requestedModelId
-          ?? sessionMeta?.modelId
-          ?? existingSlot.requestedModelId
-          ?? null,
-        modeId: sessionMeta?.modeId ?? existingSlot.modeId ?? null,
-        title: sessionMeta?.title ?? existingSlot.title ?? null,
-        liveConfig: sessionMeta?.liveConfig ?? existingSlot.liveConfig ?? null,
-        executionSummary: sessionMeta?.executionSummary ?? existingSlot.executionSummary ?? null,
-        mcpBindingSummaries: sessionMeta?.mcpBindingSummaries ?? existingSlot.mcpBindingSummaries ?? null,
-        status: resolveStatusFromExecutionSummary(
-          sessionMeta?.executionSummary ?? existingSlot.executionSummary ?? null,
-          sessionMeta?.status ?? existingSlot.status,
-        ),
-        lastPromptAt: sessionMeta?.lastPromptAt ?? existingSlot.lastPromptAt ?? null,
-      });
-      if (measurementOperationId) {
-        recordMeasurementMetric({
-          type: "store",
-          category: "session.list",
-          operationId: measurementOperationId,
-          durationMs: performance.now() - storeStartedAt,
-        });
-      }
-      recordMeasurementWorkflowStep({
-        operationId: measurementOperationId,
-        step: "session.select.slot_store",
-        startedAt: storeStartedAt,
-        outcome: "cache_hit",
-      });
-    }
+    syncSessionSelectionSlot({
+      existingSlot,
+      materializedSessionId: metadataSessionId,
+      measurementOperationId,
+      sessionId,
+      sessionMeta,
+      sessionRelationship: sessionSelectionRelationship,
+      workspaceId,
+    });
 
     if (committedSessionId !== sessionId) {
       const commitOutcome = commitSelection();

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-selection-actions.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-selection-actions.ts
@@ -29,6 +29,7 @@ import { scheduleAfterNextPaint } from "#product/lib/infra/scheduling/schedule-a
 import { rememberLastViewedSession } from "#product/stores/preferences/workspace-ui-store";
 import {
   createEmptySessionRecord,
+  findClientSessionIdByMaterializedSessionId,
   getSessionRecord,
   isPendingSessionId,
   patchSessionRecord,
@@ -57,16 +58,24 @@ export function useSessionSelectionWorkflowActions({
   const { getWorkspaceRuntimeBlockReason } = useWorkspaceRuntimeBlock();
 
   const selectSession = useCallback(async (
-    sessionId: string,
+    requestedSessionId: string,
     options?: SessionLatencyFlowOptions,
   ): Promise<SessionActivationOutcome | void> => {
+    let sessionId =
+      findClientSessionIdByMaterializedSessionId(requestedSessionId)
+      ?? requestedSessionId;
+    let committedSessionId: string | null = null;
     const guard = options?.guard ?? null;
     const commitSelection = (): SessionActivationOutcome | null => {
       if (!guard) {
         activateSession(sessionId);
+        committedSessionId = sessionId;
         return null;
       }
       const outcome = commitActiveSession(sessionId, guard);
+      if (outcome.result === "completed") {
+        committedSessionId = sessionId;
+      }
       return outcome;
     };
     const staleSelection = (
@@ -106,7 +115,7 @@ export function useSessionSelectionWorkflowActions({
       return staleSelection("intent-replaced");
     }
 
-    const sessionSelectionRelationship = classifyTrustedSessionSelection(sessionId);
+    let sessionSelectionRelationship = classifyTrustedSessionSelection(sessionId);
     if (existingSlot?.sessionRelationship.kind === "pending") {
       existingSlot = {
         ...existingSlot,
@@ -179,6 +188,7 @@ export function useSessionSelectionWorkflowActions({
         if (hotOperationId) {
           markOperationForNextCommit(hotOperationId, SESSION_SWITCH_MEASUREMENT_SURFACES);
         }
+        const hotSlot = existingSlot;
         scheduleAfterNextPaint(() => {
           const currentState = useSessionSelectionStore.getState();
           if (
@@ -193,12 +203,12 @@ export function useSessionSelectionWorkflowActions({
             finishMeasurementOperation(hotOperationId, "completed");
           }
           const selection = useSessionSelectionStore.getState();
-          const viewedSessionId = existingSlot.materializedSessionId ?? sessionId;
+          const viewedSessionId = hotSlot.materializedSessionId ?? sessionId;
           rememberLastViewedSession(
             resolveWorkspaceUiKey(
               selection.selectedLogicalWorkspaceId,
-              existingSlot.workspaceId!,
-            ) ?? existingSlot.workspaceId!,
+              hotSlot.workspaceId!,
+            ) ?? hotSlot.workspaceId!,
             viewedSessionId,
           );
         });
@@ -268,6 +278,19 @@ export function useSessionSelectionWorkflowActions({
     if (guard && !isSessionActivationCurrent(guard)) {
       return staleSelection("intent-replaced");
     }
+    const projectedSessionId =
+      findClientSessionIdByMaterializedSessionId(requestedSessionId);
+    const currentSlot = getSessionRecord(sessionId);
+    const latestSessionId = projectedSessionId
+      ?? (
+        sessionId === requestedSessionId
+        || currentSlot?.materializedSessionId === requestedSessionId
+          ? sessionId
+          : requestedSessionId
+      );
+    sessionId = latestSessionId;
+    sessionSelectionRelationship = classifyTrustedSessionSelection(sessionId);
+    existingSlot = getSessionRecord(sessionId);
     recordMeasurementWorkflowStep({
       operationId: measurementOperationId,
       step: "session.select.ensure_sessions",
@@ -282,7 +305,9 @@ export function useSessionSelectionWorkflowActions({
       elapsedMs: elapsedMs(sessionsLoadStartedAt),
       totalElapsedMs: elapsedMs(startedAt),
     });
-    const sessionMeta = sessions.find((session) => session.id === sessionId) ?? null;
+    const metadataSessionId = existingSlot?.materializedSessionId
+      ?? (sessionId === requestedSessionId ? sessionId : requestedSessionId);
+    const sessionMeta = sessions.find((session) => session.id === metadataSessionId) ?? null;
     const agentKind = existingSlot?.agentKind ?? sessionMeta?.agentKind ?? "unknown";
 
     if (!existingSlot) {
@@ -290,6 +315,7 @@ export function useSessionSelectionWorkflowActions({
       putSessionRecord({
         ...createEmptySessionRecord(sessionId, agentKind, {
           workspaceId,
+          materializedSessionId: metadataSessionId,
           modelId: sessionMeta?.modelId ?? null,
           requestedModelId: sessionMeta?.requestedModelId ?? sessionMeta?.modelId ?? null,
           modeId: sessionMeta?.modeId ?? null,
@@ -319,10 +345,6 @@ export function useSessionSelectionWorkflowActions({
         startedAt: storeStartedAt,
         outcome: "cache_miss",
       });
-      const commitOutcome = commitSelection();
-      if (commitOutcome?.result === "stale") {
-        return commitOutcome;
-      }
     } else {
       const storeStartedAt = performance.now();
       patchSessionRecord(sessionId, {
@@ -359,6 +381,13 @@ export function useSessionSelectionWorkflowActions({
         startedAt: storeStartedAt,
         outcome: "cache_hit",
       });
+    }
+
+    if (committedSessionId !== sessionId) {
+      const commitOutcome = commitSelection();
+      if (commitOutcome?.result === "stale") {
+        return commitOutcome;
+      }
     }
 
     const completedSlot = getSessionRecord(sessionId);

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/selection/initial-session.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/selection/initial-session.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WORKSPACE_UI_DEFAULTS } from "#product/lib/domain/preferences/workspace-ui/model";
+import { chatWorkspaceShellTabKey } from "#product/lib/domain/workspaces/tabs/shell-tabs";
+import {
+  prepareOptimisticWorkspaceSessionShell,
+  resolveInitialActiveSessionId,
+  type InitialSessionRecordDeps,
+} from "#product/hooks/workspaces/workflows/selection/initial-session";
+import { writeChatShellIntentForSession } from "#product/hooks/workspaces/workflows/tabs/workspace-shell-intent-writer";
+import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import {
+  createEmptySessionRecord,
+  getSessionRecord,
+  patchSessionRecord,
+  putSessionRecord,
+} from "#product/stores/sessions/session-records";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+
+const logLatency = vi.fn();
+const deps: InitialSessionRecordDeps = {
+  createEmptySessionRecord,
+  getSessionRecord,
+  logLatency,
+  patchSessionRecord,
+  putSessionRecord,
+  writeChatShellIntentForSession,
+};
+
+beforeEach(() => {
+  logLatency.mockReset();
+  useSessionDirectoryStore.getState().clearEntries();
+  useSessionTranscriptStore.getState().clearEntries();
+  useSessionSelectionStore.getState().clearSelection();
+  useWorkspaceUiStore.setState({
+    ...WORKSPACE_UI_DEFAULTS,
+    _hydrated: true,
+    shellActivationEpochByWorkspace: {},
+    pendingChatActivationByWorkspace: {},
+  });
+  useSessionSelectionStore.getState().activateWorkspace({
+    logicalWorkspaceId: "logical:workspace-1",
+    workspaceId: "workspace-1",
+  });
+});
+
+describe("initial session projection", () => {
+  it("repeatedly restores a materialized identity by focusing its existing client tab", () => {
+    putSessionRecord(createEmptySessionRecord("client-session:codex:1", "codex", {
+      materializedSessionId: "runtime-session-1",
+      workspaceId: "workspace-1",
+    }));
+    putSessionRecord(createEmptySessionRecord("client-session:codex:2", "codex", {
+      materializedSessionId: "runtime-session-2",
+      workspaceId: "workspace-1",
+    }));
+    const input = {
+      workspaceId: "workspace-1",
+      workspaceUiKey: "logical:workspace-1",
+      workspaceUiKeys: ["logical:workspace-1"],
+      options: undefined,
+      workspaceUiState: {
+        lastViewedSessionByWorkspace: {
+          "logical:workspace-1": "runtime-session-2",
+        },
+        visibleChatSessionIdsByWorkspace: {},
+      },
+      clientSessionIdByMaterializedSessionId:
+        useSessionDirectoryStore.getState().clientSessionIdByMaterializedSessionId,
+    };
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const sessionId = resolveInitialActiveSessionId(input, deps);
+      expect(sessionId).toBe("client-session:codex:2");
+      prepareOptimisticWorkspaceSessionShell({
+        sessionId,
+        workspaceId: "workspace-1",
+        workspaceUiKey: "logical:workspace-1",
+      }, deps);
+    }
+
+    expect(useWorkspaceUiStore.getState().activeShellTabKeyByWorkspace["logical:workspace-1"])
+      .toBe(chatWorkspaceShellTabKey("client-session:codex:2"));
+    expect(Object.keys(useSessionDirectoryStore.getState().entriesById).sort()).toEqual([
+      "client-session:codex:1",
+      "client-session:codex:2",
+    ]);
+    expect(getSessionRecord("runtime-session-2")).toBeNull();
+  });
+});

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/selection/initial-session.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/selection/initial-session.ts
@@ -38,6 +38,7 @@ export function resolveInitialActiveSessionId(
       lastViewedSessionByWorkspace: Record<string, string>;
       visibleChatSessionIdsByWorkspace: Record<string, string[]>;
     };
+    clientSessionIdByMaterializedSessionId: Record<string, string>;
   },
   deps: Pick<InitialSessionRecordDeps, "getSessionRecord" | "logLatency">,
 ): string | null {
@@ -54,25 +55,27 @@ export function resolveInitialActiveSessionId(
     return null;
   }
 
-  const cachedSlot = deps.getSessionRecord(candidate);
+  const projectedCandidate =
+    input.clientSessionIdByMaterializedSessionId[candidate] ?? candidate;
+  const cachedSlot = deps.getSessionRecord(projectedCandidate);
   if (!cachedSlot?.workspaceId || cachedSlot.workspaceId === input.workspaceId) {
-    return candidate;
+    return projectedCandidate;
   }
 
   const shouldPreservePendingProjection =
     input.options?.preservePending === true
-    && isTransientClientSessionId(candidate)
+    && isTransientClientSessionId(projectedCandidate)
     && !cachedSlot.materializedSessionId
     && isPendingWorkspaceUiKey(cachedSlot.workspaceId);
   if (shouldPreservePendingProjection) {
     deps.logLatency("workspace.select.projected_initial_session_preserved", {
       workspaceId: input.workspaceId,
       workspaceUiKey: input.workspaceUiKey,
-      sessionId: candidate,
+      sessionId: projectedCandidate,
       existingWorkspaceId: cachedSlot.workspaceId,
       reason: "preserve_pending_projection",
     });
-    return candidate;
+    return projectedCandidate;
   }
 
   return null;

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.test.ts
@@ -113,6 +113,55 @@ describe("runHotWorkspaceReopen", () => {
     expect(deps.reconcileHotWorkspace).not.toHaveBeenCalled();
     expect(useSessionSelectionStore.getState().selectedWorkspaceId).toBe("workspace-2");
   });
+
+  it("repeatedly restores a materialized session through its existing client slot", async () => {
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+    putSessionRecord({
+      ...createEmptySessionRecord("client-session:codex:1", "codex", {
+        materializedSessionId: "runtime-session-1",
+        workspaceId: "workspace-1",
+      }),
+      transcriptHydrated: true,
+    });
+    putSessionRecord({
+      ...createEmptySessionRecord("client-session:codex:2", "codex", {
+        materializedSessionId: "runtime-session-2",
+        workspaceId: "workspace-1",
+      }),
+      transcriptHydrated: true,
+    });
+    useWorkspaceUiStore.setState({
+      lastViewedSessionByWorkspace: {
+        "workspace-1": "runtime-session-2",
+      },
+    });
+    const deps = depsForHotReopen();
+
+    expect(runHotWorkspaceReopen(deps, { workspaceId: "workspace-1" })).toBe(true);
+    expect(useSessionSelectionStore.getState().activeSessionId)
+      .toBe("client-session:codex:2");
+    await vi.runOnlyPendingTimersAsync();
+
+    setSelectedWorkspace("workspace-2");
+    expect(runHotWorkspaceReopen(deps, { workspaceId: "workspace-1" })).toBe(true);
+    expect(useSessionSelectionStore.getState().activeSessionId)
+      .toBe("client-session:codex:2");
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(deps.reconcileHotWorkspace).toHaveBeenCalledTimes(2);
+    expect(deps.reconcileHotWorkspace).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        sessionId: "client-session:codex:2",
+      }),
+    );
+    expect(Object.keys(useSessionDirectoryStore.getState().entriesById).sort()).toEqual([
+      "client-session:codex:1",
+      "client-session:codex:2",
+    ]);
+    expect(useSessionDirectoryStore.getState().entriesById["runtime-session-2"])
+      .toBeUndefined();
+  });
 });
 
 function depsForHotReopen(): WorkspaceSelectionDeps {

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.ts
@@ -16,6 +16,7 @@ import {
 } from "#product/stores/sessions/session-records";
 import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
 import {
   finishMeasurementOperation,
   finishOrCancelMeasurementOperation,
@@ -68,6 +69,8 @@ export function runHotWorkspaceReopen(
     logicalWorkspace,
     initialActiveSessionId: request.options?.initialActiveSessionId ?? null,
     lastViewedSessionByWorkspace: useWorkspaceUiStore.getState().lastViewedSessionByWorkspace,
+    clientSessionIdByMaterializedSessionId:
+      useSessionDirectoryStore.getState().clientSessionIdByMaterializedSessionId,
     sessionSlots: getSessionRecords(),
     isPendingSessionId,
   });

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-workspace-selection.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-workspace-selection.ts
@@ -6,6 +6,7 @@ import {
   putSessionRecord,
 } from "#product/stores/sessions/session-records";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
 import { writeChatShellIntentForSession } from "#product/hooks/workspaces/workflows/tabs/workspace-shell-intent-writer";
 import {
   findLogicalWorkspace,
@@ -82,6 +83,8 @@ export async function runWorkspaceSelection(
         workspaceUiKeys: [request.workspaceId],
         options: request.options,
         workspaceUiState,
+        clientSessionIdByMaterializedSessionId:
+          useSessionDirectoryStore.getState().clientSessionIdByMaterializedSessionId,
       }, INITIAL_SESSION_DEPS);
       deps.cache.cancelPreviousWorkspaceDisplayQueries({
         runtimeUrl: useHarnessConnectionStore.getState().runtimeUrl,
@@ -191,6 +194,8 @@ export async function runWorkspaceSelection(
         workspaceUiKeys: [directWorkspace.id],
         options: request.options,
         workspaceUiState,
+        clientSessionIdByMaterializedSessionId:
+          useSessionDirectoryStore.getState().clientSessionIdByMaterializedSessionId,
       }, INITIAL_SESSION_DEPS);
       deps.cache.cancelPreviousWorkspaceDisplayQueries({
         runtimeUrl: useHarnessConnectionStore.getState().runtimeUrl,
@@ -287,6 +292,8 @@ export async function runWorkspaceSelection(
     workspaceUiKeys: logicalWorkspaceRelatedIds(logicalWorkspace),
     options: request.options,
     workspaceUiState,
+    clientSessionIdByMaterializedSessionId:
+      useSessionDirectoryStore.getState().clientSessionIdByMaterializedSessionId,
   }, INITIAL_SESSION_DEPS);
   deps.cache.cancelPreviousWorkspaceDisplayQueries({
     runtimeUrl: useHarnessConnectionStore.getState().runtimeUrl,

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/chat-tab-activation-runner.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/chat-tab-activation-runner.ts
@@ -14,7 +14,9 @@ import { clearPendingHotSwitchMeasurement } from "#product/hooks/workspaces/work
 import type {
   SelectSessionOptionsWithoutGuard,
 } from "#product/hooks/workspaces/workflows/tabs/workspace-shell-activation-types";
+import { chatWorkspaceShellTabKey } from "#product/lib/domain/workspaces/tabs/shell-tabs";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 
 type WorkspaceUiStoreState = ReturnType<typeof useWorkspaceUiStore.getState>;
@@ -23,8 +25,9 @@ export async function runDeferredChatTabActivation({
   clearPendingChatActivation,
   guard,
   hotOperationId,
-  intent,
   pending,
+  replaceShellIntent,
+  requestedSessionId,
   reuseHotOperationInSelect,
   rollbackShellIntent,
   selectSession,
@@ -36,8 +39,9 @@ export async function runDeferredChatTabActivation({
   clearPendingChatActivation: WorkspaceUiStoreState["clearPendingChatActivation"];
   guard: SessionActivationGuard;
   hotOperationId: MeasurementOperationId | null;
-  intent: `chat:${string}`;
   pending: PendingChatActivation;
+  replaceShellIntent: WorkspaceUiStoreState["replaceShellIntent"];
+  requestedSessionId: string;
   reuseHotOperationInSelect: boolean;
   rollbackShellIntent: WorkspaceUiStoreState["rollbackShellIntent"];
   selectSession: ReturnType<typeof useSessionSelectionActions>["selectSession"];
@@ -63,10 +67,29 @@ export async function runDeferredChatTabActivation({
     };
   }
 
+  const resolvedSessionId =
+    useSessionDirectoryStore.getState()
+      .clientSessionIdByMaterializedSessionId[requestedSessionId]
+    ?? requestedSessionId;
+  const resolvedIntent = chatWorkspaceShellTabKey(resolvedSessionId);
+  const resolvedPending = resolvedSessionId === sessionId
+    ? pending
+    : {
+      ...pending,
+      sessionId: resolvedSessionId,
+      intent: resolvedIntent,
+    };
+  if (resolvedPending !== pending) {
+    useWorkspaceUiStore.getState().setPendingChatActivation({
+      workspaceId: shellStateKey,
+      pending: resolvedPending,
+    });
+  }
+
   const durableStartedAt = performance.now();
   const previousWrite = writeShellIntent({
     workspaceId: shellStateKey,
-    intent,
+    intent: resolvedIntent,
   });
   recordMeasurementWorkflowStep({
     operationId: hotOperationId,
@@ -81,7 +104,7 @@ export async function runDeferredChatTabActivation({
       targetOptions: SelectSessionOptionsWithoutGuard & { guard: SessionActivationGuard },
     ) => Promise<SessionActivationOutcome | void>;
     const selectStartedAt = performance.now();
-    const outcome = await guardedSelectSession(sessionId, {
+    const outcome = await guardedSelectSession(resolvedSessionId, {
       ...selection,
       guard,
       measurementOperationId: hotOperationId ?? selection?.measurementOperationId ?? null,
@@ -97,8 +120,8 @@ export async function runDeferredChatTabActivation({
     if (outcome?.result === "stale") {
       rollbackPendingDurableIntent({
         hotOperationId,
-        intent,
-        pending,
+        intent: resolvedIntent,
+        pending: resolvedPending,
         previousWrite,
         rollbackShellIntent,
         shellStateKey,
@@ -106,31 +129,57 @@ export async function runDeferredChatTabActivation({
       clearMatchingPending({
         clearPendingChatActivation,
         hotOperationId,
-        pending,
+        pending: resolvedPending,
         shellStateKey,
         step: "workspace.shell.pending_clear",
       });
       return outcome;
     }
 
+    let completedPending = resolvedPending;
+    if (outcome?.result === "completed" && outcome.sessionId !== resolvedSessionId) {
+      const completedIntent = chatWorkspaceShellTabKey(outcome.sessionId);
+      const currentPending = useWorkspaceUiStore.getState()
+        .pendingChatActivationByWorkspace[shellStateKey] ?? null;
+      if (currentPending?.attemptId === resolvedPending.attemptId) {
+        const replacement = replaceShellIntent({
+          workspaceId: shellStateKey,
+          expectedIntent: resolvedIntent,
+          expectedEpoch: previousWrite.epoch,
+          nextIntent: completedIntent,
+        });
+        if (replacement.replaced || replacement.currentIntent === completedIntent) {
+          completedPending = {
+            ...resolvedPending,
+            sessionId: outcome.sessionId,
+            intent: completedIntent,
+          };
+          useWorkspaceUiStore.getState().setPendingChatActivation({
+            workspaceId: shellStateKey,
+            pending: completedPending,
+          });
+        }
+      }
+    }
+
     clearMatchingPending({
       clearPendingChatActivation,
       hotOperationId,
-      pending,
+      pending: completedPending,
       shellStateKey,
       step: "workspace.shell.pending_clear",
     });
     return outcome ?? {
       result: "completed",
-      sessionId,
+      sessionId: resolvedSessionId,
       guard,
       activeSessionVersion: useSessionSelectionStore.getState().activeSessionVersion,
     };
   } catch (error) {
     rollbackPendingDurableIntent({
       hotOperationId,
-      intent,
-      pending,
+      intent: resolvedIntent,
+      pending: resolvedPending,
       previousWrite,
       rollbackShellIntent,
       shellStateKey,
@@ -138,7 +187,7 @@ export async function runDeferredChatTabActivation({
     clearMatchingPending({
       clearPendingChatActivation,
       hotOperationId,
-      pending,
+      pending: resolvedPending,
       shellStateKey,
       step: "workspace.shell.pending_clear",
     });

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-chat-tab-activation.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-chat-tab-activation.ts
@@ -44,6 +44,7 @@ export function useChatTabActivation() {
   const writeShellIntent = useWorkspaceUiStore((state) => state.writeShellIntent);
   const setPendingChatActivation = useWorkspaceUiStore((state) => state.setPendingChatActivation);
   const clearPendingChatActivation = useWorkspaceUiStore((state) => state.clearPendingChatActivation);
+  const replaceShellIntent = useWorkspaceUiStore((state) => state.replaceShellIntent);
   const rollbackShellIntent = useWorkspaceUiStore((state) => state.rollbackShellIntent);
   const { selectSession } = useSessionSelectionActions();
 
@@ -123,8 +124,9 @@ export function useChatTabActivation() {
           clearPendingChatActivation,
           guard,
           hotOperationId,
-          intent,
           pending,
+          replaceShellIntent,
+          requestedSessionId,
           reuseHotOperationInSelect: hotMeasurement.reuseInSelect,
           rollbackShellIntent,
           selectSession,
@@ -144,6 +146,7 @@ export function useChatTabActivation() {
     });
   }, [
     clearPendingChatActivation,
+    replaceShellIntent,
     rollbackShellIntent,
     selectSession,
     setPendingChatActivation,

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-chat-tab-activation.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-chat-tab-activation.ts
@@ -23,6 +23,7 @@ import type {
   SelectSessionOptionsWithoutGuard,
 } from "#product/hooks/workspaces/workflows/tabs/workspace-shell-activation-types";
 import { runDeferredChatTabActivation } from "#product/hooks/workspaces/workflows/tabs/chat-tab-activation-runner";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
 
 export type { SelectSessionOptionsWithoutGuard };
 
@@ -49,7 +50,7 @@ export function useChatTabActivation() {
   return useCallback(({
     workspaceId,
     shellWorkspaceId,
-    sessionId,
+    sessionId: requestedSessionId,
     selection,
   }: {
     workspaceId: string;
@@ -59,6 +60,10 @@ export function useChatTabActivation() {
     source?: string;
     selection?: SelectSessionOptionsWithoutGuard;
   }): Promise<SessionActivationOutcome> => {
+    const sessionId =
+      useSessionDirectoryStore.getState()
+        .clientSessionIdByMaterializedSessionId[requestedSessionId]
+      ?? requestedSessionId;
     const shellStateKey = resolveCurrentShellStateKey(workspaceId, shellWorkspaceId);
     const guard = beginSessionActivationIntent(workspaceId);
     const intent = chatWorkspaceShellTabKey(sessionId);

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-workspace-shell-activation.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-workspace-shell-activation.test.tsx
@@ -4,6 +4,8 @@ import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createEmptySessionRecord,
+  getSessionRecord,
+  patchSessionRecord,
   putSessionRecord,
 } from "#product/stores/sessions/session-records";
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
@@ -192,6 +194,113 @@ describe("useWorkspaceShellActivation", () => {
       .toBeUndefined();
   });
 
+  it("uses a client identity that materializes during deferred activation", async () => {
+    const clientSessionId = "client-session:codex:materializing";
+    const materializedSessionId = "runtime-session-materializing";
+    putSessionRecord(createEmptySessionRecord(clientSessionId, "codex", {
+      materializedSessionId: null,
+      workspaceId: "workspace-1",
+    }));
+    hookMocks.selectSession.mockImplementationOnce(async (sessionId: string, options: any) => {
+      if (!getSessionRecord(sessionId)) {
+        putSessionRecord(createEmptySessionRecord(sessionId, "codex", {
+          workspaceId: "workspace-1",
+        }));
+      }
+      return {
+        result: "completed",
+        sessionId,
+        guard: options.guard,
+        activeSessionVersion: useSessionSelectionStore.getState().activeSessionVersion,
+      };
+    });
+    const { result } = renderHook(() => useWorkspaceShellActivation());
+
+    let activationPromise!: Promise<unknown>;
+    act(() => {
+      activationPromise = result.current.activateChatTab({
+        workspaceId: "workspace-1",
+        sessionId: materializedSessionId,
+      });
+    });
+
+    expect(
+      useWorkspaceUiStore.getState().pendingChatActivationByWorkspace["workspace-1"],
+    ).toMatchObject({
+      sessionId: materializedSessionId,
+      intent: `chat:${materializedSessionId}`,
+    });
+
+    patchSessionRecord(clientSessionId, { materializedSessionId });
+
+    await act(async () => {
+      vi.advanceTimersByTime(180);
+      hookMocks.scheduledCallbacks.shift()?.();
+      await activationPromise;
+    });
+
+    expect(hookMocks.selectSession).toHaveBeenCalledWith(
+      clientSessionId,
+      expect.any(Object),
+    );
+    expect(useWorkspaceUiStore.getState().activeShellTabKeyByWorkspace["workspace-1"])
+      .toBe(`chat:${clientSessionId}`);
+    expect(useSessionDirectoryStore.getState().entriesById[materializedSessionId])
+      .toBeUndefined();
+  });
+
+  it("updates the durable tab intent when selection discovers a client identity", async () => {
+    const clientSessionId = "client-session:codex:selecting";
+    const materializedSessionId = "runtime-session-selecting";
+    putSessionRecord(createEmptySessionRecord(clientSessionId, "codex", {
+      materializedSessionId: null,
+      workspaceId: "workspace-1",
+    }));
+    const selectionGate = deferred<any>();
+    hookMocks.selectSession.mockImplementationOnce(() => selectionGate.promise);
+    const { result } = renderHook(() => useWorkspaceShellActivation());
+
+    let activationPromise!: Promise<unknown>;
+    act(() => {
+      activationPromise = result.current.activateChatTab({
+        workspaceId: "workspace-1",
+        sessionId: materializedSessionId,
+      });
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(180);
+      hookMocks.scheduledCallbacks.shift()?.();
+      await Promise.resolve();
+    });
+
+    expect(hookMocks.selectSession).toHaveBeenCalledWith(
+      materializedSessionId,
+      expect.any(Object),
+    );
+    expect(useWorkspaceUiStore.getState().activeShellTabKeyByWorkspace["workspace-1"])
+      .toBe(`chat:${materializedSessionId}`);
+
+    patchSessionRecord(clientSessionId, { materializedSessionId });
+    const guard = hookMocks.selectSession.mock.calls[0]?.[1].guard;
+    await act(async () => {
+      selectionGate.resolve({
+        result: "completed",
+        sessionId: clientSessionId,
+        guard,
+        activeSessionVersion: useSessionSelectionStore.getState().activeSessionVersion,
+      });
+      await activationPromise;
+    });
+
+    expect(useWorkspaceUiStore.getState().activeShellTabKeyByWorkspace["workspace-1"])
+      .toBe(`chat:${clientSessionId}`);
+    expect(useWorkspaceUiStore.getState().pendingChatActivationByWorkspace["workspace-1"])
+      .toBeNull();
+    expect(useSessionDirectoryStore.getState().entriesById[materializedSessionId])
+      .toBeUndefined();
+  });
+
   it("resolves stale without real selection when superseded before phase two", async () => {
     const { result } = renderHook(() => useWorkspaceShellActivation());
 
@@ -294,3 +403,11 @@ describe("useWorkspaceShellActivation", () => {
     );
   });
 });
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-workspace-shell-activation.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-workspace-shell-activation.test.tsx
@@ -154,6 +154,44 @@ describe("useWorkspaceShellActivation", () => {
     );
   });
 
+  it("opens a materialized session by focusing its existing client tab", async () => {
+    putSessionRecord(createEmptySessionRecord("client-session:codex:existing", "codex", {
+      materializedSessionId: "runtime-session-existing",
+      workspaceId: "workspace-1",
+    }));
+    const { result } = renderHook(() => useWorkspaceShellActivation());
+
+    let activationPromise!: Promise<unknown>;
+    act(() => {
+      activationPromise = result.current.activateChatTab({
+        workspaceId: "workspace-1",
+        sessionId: "runtime-session-existing",
+      });
+    });
+
+    expect(
+      useWorkspaceUiStore.getState().pendingChatActivationByWorkspace["workspace-1"],
+    ).toMatchObject({
+      sessionId: "client-session:codex:existing",
+      intent: "chat:client-session:codex:existing",
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(180);
+      hookMocks.scheduledCallbacks.shift()?.();
+      await activationPromise;
+    });
+
+    expect(hookMocks.selectSession).toHaveBeenCalledWith(
+      "client-session:codex:existing",
+      expect.any(Object),
+    );
+    expect(useWorkspaceUiStore.getState().activeShellTabKeyByWorkspace["workspace-1"])
+      .toBe("chat:client-session:codex:existing");
+    expect(useSessionDirectoryStore.getState().entriesById["runtime-session-existing"])
+      .toBeUndefined();
+  });
+
   it("resolves stale without real selection when superseded before phase two", async () => {
     const { result } = renderHook(() => useWorkspaceShellActivation());
 

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+
+import type { AnyHarnessResolvedConnection } from "@anyharness/sdk-react";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkspaceSession } from "#product/hooks/access/anyharness/sessions/use-workspace-session-cache";
+import { useHotWorkspaceReconcileAction } from "#product/hooks/workspaces/workflows/use-hot-workspace-reconcile-action";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import {
+  createEmptySessionRecord,
+  getSessionRecord,
+  putSessionRecord,
+} from "#product/stores/sessions/session-records";
+import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+
+beforeEach(() => {
+  useSessionDirectoryStore.getState().clearEntries();
+  useSessionTranscriptStore.getState().clearEntries();
+});
+
+describe("useHotWorkspaceReconcileAction", () => {
+  it("matches a projected client slot to its materialized runtime session", async () => {
+    const clientSessionId = "client-session:codex:existing";
+    const materializedSessionId = "runtime-session-existing";
+    putSessionRecord(createEmptySessionRecord(clientSessionId, "codex", {
+      materializedSessionId,
+      workspaceId: "workspace-1",
+    }));
+    const rehydrateSessionSlotFromHistory = vi.fn().mockResolvedValue(true);
+    const loadWorkspaceSessions = vi.fn().mockResolvedValue([{
+      id: materializedSessionId,
+      agentKind: "codex",
+      title: "Runtime title",
+      workspaceId: "workspace-1",
+    } as WorkspaceSession]);
+    const { result } = renderHook(() => useHotWorkspaceReconcileAction({
+      cancelDeferredFileTreePrefetch: vi.fn(),
+      loadWorkspaceSessions,
+      prepareFileWorkspace: vi.fn(),
+      rehydrateSessionSlotFromHistory,
+      scheduleDeferredFileTreePrefetch: vi.fn(),
+      workspaceCollections: undefined,
+    }));
+
+    let outcome!: "completed" | "stale" | "session_missing";
+    await act(async () => {
+      outcome = await result.current({
+        workspaceId: "workspace-1",
+        logicalWorkspaceId: "logical:workspace-1",
+        workspaceConnection: {
+          runtimeUrl: "http://runtime.test",
+          anyharnessWorkspaceId: "workspace-1",
+        } as AnyHarnessResolvedConnection,
+        sessionId: clientSessionId,
+        selectionNonce: 1,
+        isCurrent: () => true,
+      });
+    });
+
+    expect(outcome).toBe("completed");
+    expect(rehydrateSessionSlotFromHistory).toHaveBeenCalledWith(
+      clientSessionId,
+      expect.any(Object),
+    );
+    expect(getSessionRecord(clientSessionId)).toMatchObject({
+      title: "Runtime title",
+      transcriptHydrated: true,
+    });
+    expect(useSessionDirectoryStore.getState().entriesById[materializedSessionId])
+      .toBeUndefined();
+  });
+});

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.ts
@@ -165,15 +165,15 @@ export function useHotWorkspaceReconcileAction({
         return "stale";
       }
 
-      const sessionMeta = sessions.find((session) =>
-        session.id === sessionId && !session.dismissedAt
-      ) ?? null;
-      if (!sessionMeta) {
-        return "session_missing";
-      }
-
       const currentSlot = getSessionRecord(sessionId);
       if (!currentSlot) {
+        return "session_missing";
+      }
+      const materializedSessionId = currentSlot.materializedSessionId ?? sessionId;
+      const sessionMeta = sessions.find((session) =>
+        session.id === materializedSessionId && !session.dismissedAt
+      ) ?? null;
+      if (!sessionMeta) {
         return "session_missing";
       }
       const storeStartedAt = performance.now();

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts
@@ -27,15 +27,9 @@ import {
 } from "#product/lib/infra/measurement/measurement-port";
 import type { MeasurementFinishReason } from "#product/lib/domain/telemetry/debug-measurement-catalog";
 import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store";
+import { clearLastViewedSession, useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 import {
-  clearLastViewedSession,
-  useWorkspaceUiStore,
-} from "#product/stores/preferences/workspace-ui-store";
-import {
-  findClientSessionIdByMaterializedSessionId,
-  getSessionRecord,
-  patchSessionRecord,
-  removeSessionRecord,
+  findClientSessionIdByMaterializedSessionId, getSessionRecord, patchSessionRecord, removeSessionRecord,
 } from "#product/stores/sessions/session-records";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { markWorkspaceBootstrappedInSession } from "#product/hooks/workspaces/lifecycle/workspace-bootstrap-memory";

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts
@@ -31,7 +31,12 @@ import {
   clearLastViewedSession,
   useWorkspaceUiStore,
 } from "#product/stores/preferences/workspace-ui-store";
-import { getSessionRecord, patchSessionRecord, removeSessionRecord } from "#product/stores/sessions/session-records";
+import {
+  findClientSessionIdByMaterializedSessionId,
+  getSessionRecord,
+  patchSessionRecord,
+  removeSessionRecord,
+} from "#product/stores/sessions/session-records";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { markWorkspaceBootstrappedInSession } from "#product/hooks/workspaces/lifecycle/workspace-bootstrap-memory";
 import { useDeferredWorkspaceFileTreePrefetch } from "#product/hooks/workspaces/lifecycle/files/use-deferred-workspace-file-tree-prefetch";
@@ -347,6 +352,7 @@ export function useWorkspaceBootstrapActions() {
           isCurrent,
         }, {
           clearLastViewedSession,
+          findClientSessionIdByMaterializedSessionId,
           getActiveSessionId: () => useSessionSelectionStore.getState().activeSessionId,
           getSessionRecord,
           patchSessionRecord,

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/workspace-bootstrap-remembered-session.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/workspace-bootstrap-remembered-session.test.ts
@@ -47,6 +47,7 @@ describe("handleRememberedWorkspaceSessionBootstrap", () => {
       isCurrent: () => true,
     }, {
       clearLastViewedSession: vi.fn(),
+      findClientSessionIdByMaterializedSessionId: vi.fn(() => null),
       getActiveSessionId: () => null,
       getSessionRecord: vi.fn(),
       patchSessionRecord,
@@ -86,6 +87,7 @@ describe("handleRememberedWorkspaceSessionBootstrap", () => {
       isCurrent: () => true,
     }, {
       clearLastViewedSession: vi.fn(),
+      findClientSessionIdByMaterializedSessionId: vi.fn(() => null),
       getActiveSessionId: () => setupSessionId,
       getSessionRecord: vi.fn(() => ({
         sessionId: setupSessionId,
@@ -101,5 +103,105 @@ describe("handleRememberedWorkspaceSessionBootstrap", () => {
     expect(result.shouldReturn).toBe(false);
     expect(setActiveSessionId).not.toHaveBeenCalledWith(null);
     expect(removeSessionRecord).toHaveBeenCalledWith(setupSessionId);
+  });
+
+  it("selects and hydrates the existing client projection for a runtime session", async () => {
+    const clientSessionId = "client-session:codex:existing";
+    const materializedSessionId = "runtime-session-existing";
+    const rehydrateSessionSlotFromHistory = vi.fn().mockResolvedValue(true);
+    const patchSessionRecord = vi.fn();
+    const findClientSessionIdByMaterializedSessionId = vi.fn(
+      (sessionId: string) => sessionId === materializedSessionId
+        ? clientSessionId
+        : null,
+    );
+    vi.mocked(selectSessionWithShellIntentRollback).mockResolvedValueOnce(undefined);
+
+    await handleRememberedWorkspaceSessionBootstrap({
+      lastViewedSessionByWorkspace: {},
+      latencyFlowId: null,
+      logicalWorkspaceId: "logical-workspace-1",
+      measurementOperationId: null,
+      sessions: [session(materializedSessionId)],
+      startedAt: performance.now(),
+      workspaceId: "workspace-1",
+      isCurrent: () => true,
+    }, {
+      clearLastViewedSession: vi.fn(),
+      findClientSessionIdByMaterializedSessionId,
+      getActiveSessionId: () => null,
+      getSessionRecord: vi.fn(),
+      patchSessionRecord,
+      rehydrateSessionSlotFromHistory: rehydrateSessionSlotFromHistory as never,
+      removeSessionRecord: vi.fn(),
+      selectSession: vi.fn() as never,
+      setActiveSessionId: vi.fn(),
+    });
+
+    expect(findClientSessionIdByMaterializedSessionId).toHaveBeenCalledWith(
+      materializedSessionId,
+    );
+    expect(selectSessionWithShellIntentRollback).toHaveBeenCalledWith(expect.objectContaining({
+      workspaceId: "workspace-1",
+      sessionId: clientSessionId,
+    }));
+    expect(rehydrateSessionSlotFromHistory).toHaveBeenCalledWith(
+      clientSessionId,
+      expect.any(Object),
+    );
+    expect(patchSessionRecord).toHaveBeenCalledWith(
+      clientSessionId,
+      { transcriptHydrated: true },
+    );
+  });
+
+  it("hydrates the client identity discovered while selecting a runtime session", async () => {
+    const clientSessionId = "client-session:codex:materializing";
+    const materializedSessionId = "runtime-session-materializing";
+    const rehydrateSessionSlotFromHistory = vi.fn().mockResolvedValue(true);
+    const patchSessionRecord = vi.fn();
+    vi.mocked(selectSessionWithShellIntentRollback).mockResolvedValueOnce({
+      result: "completed",
+      sessionId: clientSessionId,
+      guard: {
+        workspaceId: "workspace-1",
+        workspaceSelectionNonce: 1,
+        token: 1,
+      },
+      activeSessionVersion: 1,
+    });
+
+    await handleRememberedWorkspaceSessionBootstrap({
+      lastViewedSessionByWorkspace: {},
+      latencyFlowId: null,
+      logicalWorkspaceId: "logical-workspace-1",
+      measurementOperationId: null,
+      sessions: [session(materializedSessionId)],
+      startedAt: performance.now(),
+      workspaceId: "workspace-1",
+      isCurrent: () => true,
+    }, {
+      clearLastViewedSession: vi.fn(),
+      findClientSessionIdByMaterializedSessionId: vi.fn(() => null),
+      getActiveSessionId: () => clientSessionId,
+      getSessionRecord: vi.fn(),
+      patchSessionRecord,
+      rehydrateSessionSlotFromHistory: rehydrateSessionSlotFromHistory as never,
+      removeSessionRecord: vi.fn(),
+      selectSession: vi.fn() as never,
+      setActiveSessionId: vi.fn(),
+    });
+
+    expect(selectSessionWithShellIntentRollback).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: materializedSessionId,
+    }));
+    expect(rehydrateSessionSlotFromHistory).toHaveBeenCalledWith(
+      clientSessionId,
+      expect.any(Object),
+    );
+    expect(patchSessionRecord).toHaveBeenCalledWith(
+      clientSessionId,
+      { transcriptHydrated: true },
+    );
   });
 });

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/workspace-bootstrap-remembered-session.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/workspace-bootstrap-remembered-session.ts
@@ -34,6 +34,7 @@ export async function handleRememberedWorkspaceSessionBootstrap(
   },
   deps: {
     clearLastViewedSession: (workspaceId: string, sessionId?: string) => void;
+    findClientSessionIdByMaterializedSessionId: (materializedSessionId: string) => string | null;
     getActiveSessionId: () => string | null;
     getSessionRecord: (sessionId: string) => SessionRuntimeRecord | null;
     patchSessionRecord: (sessionId: string, patch: Partial<SessionRuntimeRecord>) => void;
@@ -62,18 +63,20 @@ export async function handleRememberedWorkspaceSessionBootstrap(
   if (!targetSession || !input.isCurrent()) {
     return { shouldReturn: false };
   }
+  const targetSessionId =
+    deps.findClientSessionIdByMaterializedSessionId(targetSession.id) ?? targetSession.id;
 
   const currentActiveSessionId = deps.getActiveSessionId();
   const currentActiveIsSetupSession = currentActiveSessionId
     ? isWorkspaceSetupSessionId(currentActiveSessionId)
     : false;
-  if (currentActiveSessionId && currentActiveSessionId !== targetSession.id) {
+  if (currentActiveSessionId && currentActiveSessionId !== targetSessionId) {
     const currentActiveSession = deps.getSessionRecord(currentActiveSessionId);
     if (!currentActiveSession || currentActiveSession.workspaceId !== input.workspaceId) {
       deps.setActiveSessionId(null);
       logLatency("workspace.select.stale_active_session_cleared", {
         workspaceId: input.workspaceId,
-        sessionId: targetSession.id,
+        sessionId: targetSessionId,
         currentActiveSessionId,
         currentActiveWorkspaceId: currentActiveSession?.workspaceId ?? null,
         reason: currentActiveSession ? "workspace_mismatch" : "missing_slot",
@@ -82,7 +85,7 @@ export async function handleRememberedWorkspaceSessionBootstrap(
     } else if (!currentActiveIsSetupSession) {
       logLatency("workspace.select.session_select.skipped", {
         workspaceId: input.workspaceId,
-        sessionId: targetSession.id,
+        sessionId: targetSessionId,
         currentActiveSessionId,
         reason: "active_session_changed",
         totalElapsedMs: elapsedMs(input.startedAt),
@@ -92,19 +95,22 @@ export async function handleRememberedWorkspaceSessionBootstrap(
   }
   logLatency("workspace.select.session_select.start", {
     workspaceId: input.workspaceId,
-    sessionId: targetSession.id,
+    sessionId: targetSessionId,
     totalElapsedMs: elapsedMs(input.startedAt),
   });
   const sessionSelectStartedAt = performance.now();
   const selectionOutcome = await selectSessionWithShellIntentRollback({
     workspaceId: input.workspaceId,
-    sessionId: targetSession.id,
+    sessionId: targetSessionId,
     options: { latencyFlowId: input.latencyFlowId },
     selectSession: deps.selectSession,
   });
   if (selectionOutcome?.result === "stale" || !input.isCurrent()) {
     return { shouldReturn: true };
   }
+  const selectedSessionId = selectionOutcome?.result === "completed"
+    ? selectionOutcome.sessionId
+    : deps.findClientSessionIdByMaterializedSessionId(targetSession.id) ?? targetSessionId;
   if (currentActiveIsSetupSession && currentActiveSessionId) {
     deps.removeSessionRecord(currentActiveSessionId);
   }
@@ -114,18 +120,18 @@ export async function handleRememberedWorkspaceSessionBootstrap(
     startedAt: sessionSelectStartedAt,
   });
   const hydrateStartedAt = startLatencyTimer();
-  await deps.rehydrateSessionSlotFromHistory(targetSession.id, {
+  await deps.rehydrateSessionSlotFromHistory(selectedSessionId, {
     replace: true,
     requestHeaders: input.requestHeaders,
     measurementOperationId: input.measurementOperationId,
     isCurrent: () =>
       input.isCurrent()
-      && deps.getActiveSessionId() === targetSession.id,
+      && deps.getActiveSessionId() === selectedSessionId,
   });
   if (!input.isCurrent()) {
     return { shouldReturn: true };
   }
-  deps.patchSessionRecord(targetSession.id, { transcriptHydrated: true });
+  deps.patchSessionRecord(selectedSessionId, { transcriptHydrated: true });
   recordMeasurementWorkflowStep({
     operationId: input.measurementOperationId,
     step: "session.select.history_hydrate",
@@ -133,7 +139,7 @@ export async function handleRememberedWorkspaceSessionBootstrap(
   });
   logLatency("workspace.select.success", {
     workspaceId: input.workspaceId,
-    sessionId: targetSession.id,
+    sessionId: selectedSessionId,
     sessionCount: input.sessions.length,
     totalElapsedMs: elapsedMs(input.startedAt),
   });

--- a/apps/packages/product-client/src/lib/domain/sessions/directory/directory-indexes.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/directory/directory-indexes.ts
@@ -4,9 +4,23 @@ export function updateMaterializedIndex(
   nextMaterializedSessionId: string | null,
   clientSessionId: string,
 ): Record<string, string> {
+  if (previousMaterializedSessionId === nextMaterializedSessionId) {
+    if (!nextMaterializedSessionId || nextMaterializedSessionId in index) {
+      return index;
+    }
+    return {
+      ...index,
+      [nextMaterializedSessionId]: clientSessionId,
+    };
+  }
+
   let next = index;
-  if (previousMaterializedSessionId && previousMaterializedSessionId !== nextMaterializedSessionId) {
-    next = removeMaterializedIndexEntry(next, previousMaterializedSessionId);
+  if (previousMaterializedSessionId) {
+    next = removeMaterializedIndexEntry(
+      next,
+      previousMaterializedSessionId,
+      clientSessionId,
+    );
   }
   if (!nextMaterializedSessionId) {
     return next;
@@ -20,11 +34,44 @@ export function updateMaterializedIndex(
   };
 }
 
+export function reconcileMaterializedIndex(
+  index: Record<string, string>,
+  entriesById: Record<
+    string,
+    { sessionId: string; materializedSessionId: string | null }
+  >,
+): Record<string, string> {
+  let next = index;
+  const mutableIndex = () => {
+    if (next === index) {
+      next = { ...index };
+    }
+    return next;
+  };
+
+  for (const [materializedSessionId, clientSessionId] of Object.entries(index)) {
+    if (entriesById[clientSessionId]?.materializedSessionId !== materializedSessionId) {
+      delete mutableIndex()[materializedSessionId];
+    }
+  }
+  for (const entry of Object.values(entriesById)) {
+    if (entry.materializedSessionId && !(entry.materializedSessionId in next)) {
+      mutableIndex()[entry.materializedSessionId] = entry.sessionId;
+    }
+  }
+  return next;
+}
+
 export function removeMaterializedIndexEntry(
   index: Record<string, string>,
   materializedSessionId: string | null,
+  expectedClientSessionId: string,
 ): Record<string, string> {
-  if (!materializedSessionId || !(materializedSessionId in index)) {
+  if (
+    !materializedSessionId
+    || !(materializedSessionId in index)
+    || index[materializedSessionId] !== expectedClientSessionId
+  ) {
     return index;
   }
   const { [materializedSessionId]: _removed, ...rest } = index;

--- a/apps/packages/product-client/src/lib/domain/sessions/directory/directory-reducer.test.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/directory/directory-reducer.test.ts
@@ -113,4 +113,39 @@ describe("session directory reducer", () => {
       },
     });
   });
+
+  it("promotes a claimant outside a removed workspace to materialized index owner", () => {
+    const sessionA = createDirectoryEntry({
+      sessionId: "session-a",
+      materializedSessionId: "runtime-shared",
+      workspaceId: "workspace-a",
+      agentKind: "proliferate",
+    });
+    const sessionB = createDirectoryEntry({
+      sessionId: "session-b",
+      materializedSessionId: "runtime-shared",
+      workspaceId: "workspace-b",
+      agentKind: "proliferate",
+    });
+    const state: SessionDirectoryReducerState = {
+      entriesById: {
+        "session-a": sessionA,
+        "session-b": sessionB,
+      },
+      clientSessionIdByMaterializedSessionId: {
+        "runtime-shared": "session-b",
+      },
+      sessionIdsByWorkspaceId: {
+        "workspace-a": ["session-a"],
+        "workspace-b": ["session-b"],
+      },
+      relationshipHintsBySessionId: {},
+    };
+
+    const result = removeWorkspaceDirectoryEntries(state, "workspace-b");
+
+    expect(result.state.clientSessionIdByMaterializedSessionId).toEqual({
+      "runtime-shared": "session-a",
+    });
+  });
 });

--- a/apps/packages/product-client/src/lib/domain/sessions/directory/directory-reducer.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/directory/directory-reducer.ts
@@ -3,6 +3,7 @@ import {
   type SessionDirectoryEntry,
 } from "#product/lib/domain/sessions/directory/directory-entry";
 import {
+  reconcileMaterializedIndex,
   removeMaterializedIndexEntry,
   removeSessionFromWorkspaceIndex,
   updateMaterializedIndex,
@@ -45,12 +46,16 @@ export function putDirectoryEntry<TState extends SessionDirectoryReducerState>(
   const relationshipHintsBySessionId = state.relationshipHintsBySessionId[entry.sessionId]
     ? removeRecordKey(state.relationshipHintsBySessionId, entry.sessionId)
     : state.relationshipHintsBySessionId;
-  const clientSessionIdByMaterializedSessionId = updateMaterializedIndex(
+  const updatedMaterializedIndex = updateMaterializedIndex(
     state.clientSessionIdByMaterializedSessionId,
     previous?.materializedSessionId ?? null,
     entry.materializedSessionId,
     entry.sessionId,
   );
+  const clientSessionIdByMaterializedSessionId = previous
+    && previous.materializedSessionId !== entry.materializedSessionId
+    ? reconcileMaterializedIndex(updatedMaterializedIndex, entriesById)
+    : updatedMaterializedIndex;
   const sessionIdsByWorkspaceId = updateWorkspaceIndex(
     state.sessionIdsByWorkspaceId,
     previous?.workspaceId ?? null,
@@ -83,9 +88,13 @@ export function removeDirectoryEntry<TState extends SessionDirectoryReducerState
     return state;
   }
   const { [sessionId]: _removed, ...entriesById } = state.entriesById;
-  const clientSessionIdByMaterializedSessionId = removeMaterializedIndexEntry(
-    state.clientSessionIdByMaterializedSessionId,
-    entry.materializedSessionId,
+  const clientSessionIdByMaterializedSessionId = reconcileMaterializedIndex(
+    removeMaterializedIndexEntry(
+      state.clientSessionIdByMaterializedSessionId,
+      entry.materializedSessionId,
+      sessionId,
+    ),
+    entriesById,
   );
   const { [sessionId]: _removedHint, ...relationshipHintsBySessionId } =
     state.relationshipHintsBySessionId;
@@ -118,10 +127,13 @@ export function removeWorkspaceDirectoryEntries<TState extends SessionDirectoryR
   const entriesById: Record<string, SessionDirectoryEntry> = Object.fromEntries(
     Object.entries(state.entriesById).filter(([sessionId]) => !removed.has(sessionId)),
   );
-  const clientSessionIdByMaterializedSessionId: Record<string, string> = Object.fromEntries(
-    Object.entries(state.clientSessionIdByMaterializedSessionId).filter(([, clientSessionId]) =>
-      !removed.has(clientSessionId)
+  const clientSessionIdByMaterializedSessionId = reconcileMaterializedIndex(
+    Object.fromEntries(
+      Object.entries(state.clientSessionIdByMaterializedSessionId).filter(
+        ([, clientSessionId]) => !removed.has(clientSessionId),
+      ),
     ),
+    entriesById,
   );
   const relationshipHintsBySessionId: Record<string, SessionChildRelationship> = Object.fromEntries(
     Object.entries(state.relationshipHintsBySessionId).filter(([sessionId, hint]) =>

--- a/apps/packages/product-client/src/lib/domain/workspaces/selection/hot-reopen.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/selection/hot-reopen.test.ts
@@ -75,6 +75,7 @@ describe("resolveHotReopenCandidate", () => {
       lastViewedSessionByWorkspace: {
         "workspace-1": "session-last",
       },
+      clientSessionIdByMaterializedSessionId: {},
       sessionSlots: {
         "session-initial": slot({
           sessionId: "session-initial",
@@ -105,6 +106,7 @@ describe("resolveHotReopenCandidate", () => {
       lastViewedSessionByWorkspace: {
         "logical:repo": "session-logical",
       },
+      clientSessionIdByMaterializedSessionId: {},
       sessionSlots: {
         "session-fallback": slot({
           sessionId: "session-fallback",
@@ -133,6 +135,7 @@ describe("resolveHotReopenCandidate", () => {
       logicalWorkspace: logicalWorkspace(),
       initialActiveSessionId: null,
       lastViewedSessionByWorkspace: {},
+      clientSessionIdByMaterializedSessionId: {},
       sessionSlots: {
         "session-cached": slot({
           sessionId: "session-cached",
@@ -145,6 +148,46 @@ describe("resolveHotReopenCandidate", () => {
 
     expect(candidate?.source).toBe("cached_slot");
     expect(candidate?.sessionId).toBe("session-cached");
+  });
+
+  it("restores a materialized identity to its existing client projection", () => {
+    const input = {
+      resolvedWorkspaceId: "workspace-1",
+      logicalWorkspace: logicalWorkspace(),
+      initialActiveSessionId: null,
+      lastViewedSessionByWorkspace: {
+        "logical:repo": "runtime-session-2",
+      },
+      clientSessionIdByMaterializedSessionId: {
+        "runtime-session-1": "client-session:codex:1",
+        "runtime-session-2": "client-session:codex:2",
+      },
+      sessionSlots: {
+        "client-session:codex:1": slot({
+          sessionId: "client-session:codex:1",
+          workspaceId: "workspace-1",
+          hydrated: true,
+        }),
+        "client-session:codex:2": slot({
+          sessionId: "client-session:codex:2",
+          workspaceId: "workspace-1",
+          hydrated: true,
+        }),
+      },
+      isPendingSessionId: () => false,
+    };
+
+    expect(resolveHotReopenCandidate(input)).toEqual({
+      sessionId: "client-session:codex:2",
+      workspaceId: "workspace-1",
+      source: "last_viewed",
+    });
+    expect(resolveHotReopenCandidate(input)).toEqual({
+      sessionId: "client-session:codex:2",
+      workspaceId: "workspace-1",
+      source: "last_viewed",
+    });
+    expect(Object.keys(input.sessionSlots)).toHaveLength(2);
   });
 });
 

--- a/apps/packages/product-client/src/lib/domain/workspaces/selection/hot-reopen.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/selection/hot-reopen.ts
@@ -44,11 +44,18 @@ export function resolveHotReopenCandidate(input: {
   logicalWorkspace: LogicalWorkspace | null;
   initialActiveSessionId?: string | null;
   lastViewedSessionByWorkspace: Record<string, string>;
+  clientSessionIdByMaterializedSessionId: Record<string, string>;
   sessionSlots: Record<string, HotReopenSessionSlotSnapshot>;
   isPendingSessionId: (sessionId: string) => boolean;
 }): HotReopenCandidate | null {
-  const slotFor = (sessionId: string | null | undefined) =>
-    sessionId ? input.sessionSlots[sessionId] ?? null : null;
+  const slotFor = (sessionId: string | null | undefined) => {
+    if (!sessionId) {
+      return null;
+    }
+    const projectedSessionId =
+      input.clientSessionIdByMaterializedSessionId[sessionId] ?? sessionId;
+    return input.sessionSlots[projectedSessionId] ?? null;
+  };
   const toCandidate = (
     sessionId: string | null | undefined,
     source: HotReopenCandidate["source"],

--- a/apps/packages/product-client/src/stores/sessions/session-directory-store.test.ts
+++ b/apps/packages/product-client/src/stores/sessions/session-directory-store.test.ts
@@ -61,6 +61,85 @@ describe("session directory store invariants", () => {
     expect(after.sessionIdsByWorkspaceId).toBe(before.sessionIdsByWorkspaceId);
   });
 
+  it("preserves a valid materialized index owner across another claimant's updates", () => {
+    const store = useSessionDirectoryStore.getState();
+    store.upsertEntry({
+      sessionId: "client-a",
+      materializedSessionId: "runtime-shared",
+      workspaceId: "workspace-a",
+      agentKind: "codex",
+    });
+    store.upsertEntry({
+      sessionId: "client-b",
+      materializedSessionId: "runtime-shared",
+      workspaceId: "workspace-a",
+      agentKind: "codex",
+    });
+
+    store.patchEntry("client-a", { title: "Updated title" });
+
+    expect(useSessionDirectoryStore.getState().clientSessionIdByMaterializedSessionId)
+      .toEqual({ "runtime-shared": "client-b" });
+
+    store.patchEntry("client-a", { materializedSessionId: "runtime-a" });
+
+    expect(useSessionDirectoryStore.getState().clientSessionIdByMaterializedSessionId)
+      .toEqual({
+        "runtime-a": "client-a",
+        "runtime-shared": "client-b",
+      });
+
+    store.removeEntry("client-a");
+
+    expect(useSessionDirectoryStore.getState().clientSessionIdByMaterializedSessionId)
+      .toEqual({ "runtime-shared": "client-b" });
+  });
+
+  it("promotes a remaining claimant when the materialized index owner is rebound", () => {
+    const store = useSessionDirectoryStore.getState();
+    store.upsertEntry({
+      sessionId: "client-a",
+      materializedSessionId: "runtime-shared",
+      workspaceId: "workspace-a",
+      agentKind: "codex",
+    });
+    store.upsertEntry({
+      sessionId: "client-b",
+      materializedSessionId: "runtime-shared",
+      workspaceId: "workspace-a",
+      agentKind: "codex",
+    });
+
+    store.patchEntry("client-b", { materializedSessionId: "runtime-b" });
+
+    expect(useSessionDirectoryStore.getState().clientSessionIdByMaterializedSessionId)
+      .toEqual({
+        "runtime-b": "client-b",
+        "runtime-shared": "client-a",
+      });
+  });
+
+  it("promotes a remaining claimant when the materialized index owner is removed", () => {
+    const store = useSessionDirectoryStore.getState();
+    store.upsertEntry({
+      sessionId: "client-a",
+      materializedSessionId: "runtime-shared",
+      workspaceId: "workspace-a",
+      agentKind: "codex",
+    });
+    store.upsertEntry({
+      sessionId: "client-b",
+      materializedSessionId: "runtime-shared",
+      workspaceId: "workspace-a",
+      agentKind: "codex",
+    });
+
+    store.removeEntry("client-b");
+
+    expect(useSessionDirectoryStore.getState().clientSessionIdByMaterializedSessionId)
+      .toEqual({ "runtime-shared": "client-a" });
+  });
+
   it("applies relationship hints once and prunes stale workspace hints", () => {
     const store = useSessionDirectoryStore.getState();
     store.recordRelationshipHint("child-a", {


### PR DESCRIPTION
## Linear tickets

- [PRO-89 — Opening a workspace can create a duplicate session tab](https://linear.app/proliferate-team/issue/PRO-89/opening-a-workspace-can-create-a-duplicate-session-tab)

## Summary

- Resolve durable runtime session IDs through the live client-session identity index before cold restore, hot reopen, explicit tab activation, bootstrap, and launch prompting.
- Re-resolve identity at asynchronous selection boundaries and compare-and-swap shell intent when materialization completes in flight, so repeated opens focus the existing client tab.
- Atomically coalesce a late direct runtime slot into its canonical client slot during creation publication, including active selection, hydrated transcript state, queued intents, open-shell order/visibility/grouping, and active shell intent.
- Keep reverse materialization ownership valid through rebind/removal while preserving separate tabs for genuinely distinct runtime sessions.

## Root cause

A newly created session is represented locally by a transient client ID while the backend assigns a durable runtime ID. Workspace restore state intentionally persists the durable runtime ID, but the live directory is keyed by the client ID.

The reopen paths previously treated the persisted runtime ID as a directory key. A cold restore therefore missed the existing client-keyed record, projected another record under the runtime ID, and wrote a runtime-keyed shell intent. The header enumerates live directory slots by exact local ID, so both records rendered even though they resolved to the same runtime session and title.

There was also a post-list publication race: the backend runtime could become list-visible before the creation workflow published the client-to-runtime mapping. A concurrent selection would insert a direct runtime-keyed slot; later creation publication patched only the client slot and left that runtime slot alive. The reverse index then chose an owner, but it did not remove the duplicate claimant, so the header still rendered both.

The fix resolves runtime aliases at every reopen/selection boundary and makes materialization the final convergence point. If a direct runtime alias exists, its hydrated transcript is preserved under the client identity, pending intents and active selection are reassigned, open shell references are replaced, and the alias record is removed in the same batched publication. An unrelated client-to-runtime pair remains untouched.

## Testing

- Fail-before proof on current `origin/main`: the exact cold-restore regression returned the durable runtime ID instead of the existing client ID; continuing through the production shell preparation produced directory keys `[client-1, client-2, runtime-2]` and a `chat:runtime-2` intent.
- Fail-before proof for the residual race: the integrated selection/publication regression failed with the direct runtime record still present. It passes after convergence and asserts one header tab, canonical selection/shell/intent ownership, hydrated transcript preservation, and survival of an intentional second session.
- Focused identity-projection matrix: 13 files, 61 tests passed.
- Full ProductClient run: 799 test files and 5,431 tests passed, with 1 test skipped. The only failed suite is the unrelated authenticated Markdown browser fixture because this machine has no Google Chrome binary at `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`.
- `pnpm --filter @proliferate/product-client typecheck`
- `pnpm --filter @proliferate/product-client build`
- `python3 scripts/check_max_lines.py`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_session_mutation_admission.py`
- `python3 scripts/check_design_attribution.py`
- `python3 scripts/report_frontend_structure.py --strict`
- `git diff --check`

## Observability

- No new telemetry is added. This is a deterministic local identity-projection invariant, and the regression checks the user-visible tab cardinality plus the underlying directory, inverse-index, selection, shell, transcript, and intent state.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] No support relationship or private source material applies. The issue association is carried by the ticket-named branch.
