### PR TITLE
fix(product): keep terminal output responsive

### DIFF
--- a/apps/packages/product-client/src/hooks/terminals/lifecycle/use-terminal-viewport.test.tsx
+++ b/apps/packages/product-client/src/hooks/terminals/lifecycle/use-terminal-viewport.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TerminalRecord } from "@anyharness/sdk";
+import { useTerminalViewport } from "#product/hooks/terminals/lifecycle/use-terminal-viewport";
+import type {
+  TerminalReplayEntry,
+  TerminalStreamIdentity,
+} from "#product/lib/infra/terminals/terminal-stream-registry";
+
+const mockState = vi.hoisted(() => ({
+  ensureTabConnection: vi.fn(),
+  resizeTab: vi.fn(),
+  subscriptions: [] as Array<{
+    listener: (entry: TerminalReplayEntry) => void;
+    options: { afterOrder?: number };
+    unsubscribe: ReturnType<typeof vi.fn>;
+  }>,
+  writers: [] as Array<{
+    enqueue: ReturnType<typeof vi.fn>;
+    dispose: ReturnType<typeof vi.fn>;
+    onFlush?: (entries: readonly TerminalReplayEntry[]) => void;
+  }>,
+  terminal: { write: vi.fn() },
+}));
+
+vi.mock("#product/hooks/terminals/workflows/use-terminal-actions", () => ({
+  useTerminalActions: () => ({ resizeTab: mockState.resizeTab }),
+}));
+
+vi.mock("#product/hooks/terminals/lifecycle/use-terminal-stream-controller", () => ({
+  useTerminalStreamController: () => ({
+    ensureTabConnection: mockState.ensureTabConnection,
+  }),
+}));
+
+vi.mock("#product/hooks/terminals/lifecycle/use-xterm-surface", () => ({
+  useXtermSurface: () => ({
+    containerRef: { current: null },
+    isReady: true,
+    terminalRef: { current: mockState.terminal },
+  }),
+}));
+
+vi.mock("#product/lib/infra/terminals/terminal-stream-registry", () => ({
+  sendInput: vi.fn(),
+  sendResize: vi.fn(),
+  subscribeWithReplay: vi.fn((
+    _identity: TerminalStreamIdentity,
+    listener: (entry: TerminalReplayEntry) => void,
+    options: { afterOrder?: number },
+  ) => {
+    const subscription = { listener, options, unsubscribe: vi.fn() };
+    mockState.subscriptions.push(subscription);
+    return subscription.unsubscribe;
+  }),
+}));
+
+vi.mock("#product/lib/infra/terminals/terminal-replay-writer", () => ({
+  createTerminalReplayWriter: vi.fn((
+    _terminal: unknown,
+    _scheduler: unknown,
+    onFlush?: (entries: readonly TerminalReplayEntry[]) => void,
+  ) => {
+    const writer = { enqueue: vi.fn(), dispose: vi.fn(), onFlush };
+    mockState.writers.push(writer);
+    return writer;
+  }),
+}));
+
+vi.mock("#product/lib/infra/terminals/terminal-stream-key", () => ({
+  terminalStreamKey: (identity: TerminalStreamIdentity) =>
+    `${identity.workspaceId}:${identity.terminalId}:${identity.runtimeIdentity}`,
+}));
+
+vi.mock("#product/stores/terminal/terminal-store", () => ({
+  useTerminalStore: (selector: (state: {
+    connectionVersionByTerminal: Record<string, number>;
+  }) => unknown) => selector({ connectionVersionByTerminal: {} }),
+}));
+
+const identity: TerminalStreamIdentity = {
+  workspaceId: "workspace-1",
+  terminalId: "terminal-1",
+  runtimeIdentity: "runtime-1",
+};
+
+describe("useTerminalViewport output rendering", () => {
+  beforeEach(() => {
+    mockState.ensureTabConnection.mockResolvedValue(identity);
+    mockState.subscriptions = [];
+    mockState.writers = [];
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("pauses hidden rendering and resumes after the last flushed order", async () => {
+    const rendered = renderHook(
+      ({ visible }) => useTerminalViewport({
+        terminal: terminalRecord(),
+        workspaceId: "workspace-1",
+        visible,
+        canConnect: true,
+        focusRequestToken: 0,
+      }),
+      { initialProps: { visible: true } },
+    );
+
+    await waitFor(() => expect(mockState.subscriptions).toHaveLength(1));
+    expect(mockState.subscriptions[0]?.options).toEqual({ afterOrder: 0 });
+
+    const firstEntry = dataEntry(1, "one");
+    mockState.subscriptions[0]?.listener(firstEntry);
+    expect(mockState.writers[0]?.enqueue).toHaveBeenCalledWith(firstEntry);
+    mockState.writers[0]?.onFlush?.([firstEntry]);
+
+    rendered.rerender({ visible: false });
+    expect(mockState.subscriptions[0]?.unsubscribe).toHaveBeenCalledOnce();
+    expect(mockState.writers[0]?.dispose).toHaveBeenCalledOnce();
+
+    rendered.rerender({ visible: true });
+    await waitFor(() => expect(mockState.subscriptions).toHaveLength(2));
+    expect(mockState.subscriptions[1]?.options).toEqual({ afterOrder: 1 });
+
+    const queuedEntry = dataEntry(2, "queued");
+    mockState.subscriptions[1]?.listener(queuedEntry);
+    rendered.rerender({ visible: false });
+    rendered.rerender({ visible: true });
+    await waitFor(() => expect(mockState.subscriptions).toHaveLength(3));
+    expect(mockState.subscriptions[2]?.options).toEqual({ afterOrder: 1 });
+  });
+});
+
+function terminalRecord(): TerminalRecord {
+  return {
+    commandRun: null,
+    createdAt: "2026-01-01T00:00:00Z",
+    cwd: "/workspace",
+    id: "terminal-1",
+    purpose: "general",
+    status: "running",
+    title: "Terminal",
+    updatedAt: "2026-01-01T00:00:00Z",
+    workspaceId: "workspace-1",
+  };
+}
+
+function dataEntry(order: number, value: string): TerminalReplayEntry {
+  return {
+    type: "data",
+    order,
+    seq: order,
+    data: new TextEncoder().encode(value),
+  };
+}

--- a/apps/packages/product-client/src/hooks/terminals/lifecycle/use-terminal-viewport.test.tsx
+++ b/apps/packages/product-client/src/hooks/terminals/lifecycle/use-terminal-viewport.test.tsx
@@ -5,9 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TerminalRecord } from "@anyharness/sdk";
 import { useTerminalViewport } from "#product/hooks/terminals/lifecycle/use-terminal-viewport";
 import type {
-  TerminalReplayEntry,
   TerminalStreamIdentity,
 } from "#product/lib/infra/terminals/terminal-stream-registry";
+import type { TerminalReplayEntry } from "#product/lib/infra/terminals/terminal-replay-buffer";
 
 const mockState = vi.hoisted(() => ({
   ensureTabConnection: vi.fn(),

--- a/apps/packages/product-client/src/hooks/terminals/lifecycle/use-terminal-viewport.ts
+++ b/apps/packages/product-client/src/hooks/terminals/lifecycle/use-terminal-viewport.ts
@@ -7,10 +7,13 @@ import {
   sendInput,
   sendResize,
   subscribeWithReplay,
-  TERMINAL_OUTPUT_GAP_MESSAGE,
-  type TerminalReplayEntry,
   type TerminalStreamIdentity,
 } from "#product/lib/infra/terminals/terminal-stream-registry";
+import {
+  createTerminalReplayWriter,
+  type TerminalReplayWriter,
+} from "#product/lib/infra/terminals/terminal-replay-writer";
+import { terminalStreamKey } from "#product/lib/infra/terminals/terminal-stream-key";
 import { useTerminalStore } from "#product/stores/terminal/terminal-store";
 
 interface UseTerminalViewportInput {
@@ -31,6 +34,9 @@ export function useTerminalViewport({
 }: UseTerminalViewportInput) {
   const streamIdentityRef = useRef<TerminalStreamIdentity | null>(null);
   const unsubscribeReplayRef = useRef<(() => void) | null>(null);
+  const replayWriterRef = useRef<TerminalReplayWriter | null>(null);
+  const renderedOrderRef = useRef(0);
+  const renderedIdentityKeyRef = useRef<string | null>(null);
   const connectionVersion = useTerminalStore(
     (state) => state.connectionVersionByTerminal[terminal.id] ?? 0,
   );
@@ -64,32 +70,53 @@ export function useTerminalViewport({
   useEffect(() => () => {
     unsubscribeReplayRef.current?.();
     unsubscribeReplayRef.current = null;
+    replayWriterRef.current?.dispose();
+    replayWriterRef.current = null;
   }, []);
 
   useEffect(() => {
     if (!visible || !isTerminalReady || !canConnect || !workspaceId) {
+      unsubscribeReplayRef.current?.();
+      unsubscribeReplayRef.current = null;
+      replayWriterRef.current?.dispose();
+      replayWriterRef.current = null;
       return;
     }
+    let cancelled = false;
     void ensureTabConnection(terminal.id, workspaceId, terminal.status).then((identity) => {
-      if (!identity || !terminalRef.current) {
+      if (cancelled || !identity || !terminalRef.current) {
         return;
       }
-      const existingIdentity = streamIdentityRef.current;
-      if (
-        existingIdentity?.workspaceId === identity.workspaceId
-        && existingIdentity.terminalId === identity.terminalId
-        && existingIdentity.runtimeIdentity === identity.runtimeIdentity
-        && unsubscribeReplayRef.current
-      ) {
-        return;
+      const identityKey = terminalStreamKey(identity);
+      if (renderedIdentityKeyRef.current !== identityKey) {
+        renderedIdentityKeyRef.current = identityKey;
+        renderedOrderRef.current = 0;
       }
       unsubscribeReplayRef.current?.();
+      replayWriterRef.current?.dispose();
       streamIdentityRef.current = identity;
       const term = terminalRef.current;
+      const writer = createTerminalReplayWriter(term, undefined, (entries) => {
+        for (const entry of entries) {
+          if (entry.type !== "local-overflow") {
+            renderedOrderRef.current = Math.max(renderedOrderRef.current, entry.order);
+          }
+        }
+      });
+      replayWriterRef.current = writer;
       unsubscribeReplayRef.current = subscribeWithReplay(identity, (entry) => {
-        writeTerminalReplayEntry(term, entry);
+        writer.enqueue(entry);
+      }, {
+        afterOrder: renderedOrderRef.current,
       });
     });
+    return () => {
+      cancelled = true;
+      unsubscribeReplayRef.current?.();
+      unsubscribeReplayRef.current = null;
+      replayWriterRef.current?.dispose();
+      replayWriterRef.current = null;
+    };
   }, [
     canConnect,
     connectionVersion,
@@ -105,21 +132,4 @@ export function useTerminalViewport({
   return {
     containerRef,
   };
-}
-
-function writeTerminalReplayEntry(
-  terminal: import("@xterm/xterm").Terminal,
-  entry: TerminalReplayEntry,
-): void {
-  if (entry.type === "data") {
-    terminal.write(entry.data);
-    return;
-  }
-  if (entry.type === "runtime-gap" || entry.type === "local-overflow") {
-    terminal.write(`\r\n${TERMINAL_OUTPUT_GAP_MESSAGE}\r\n`);
-    return;
-  }
-  if (entry.type === "exit") {
-    terminal.write("\r\n");
-  }
 }

--- a/apps/packages/product-client/src/lib/infra/terminals/terminal-replay-buffer.ts
+++ b/apps/packages/product-client/src/lib/infra/terminals/terminal-replay-buffer.ts
@@ -1,0 +1,98 @@
+const MAX_REPLAY_DATA_BYTES = 256 * 1024;
+const MAX_REPLAY_ENTRIES = 1000;
+
+export const TERMINAL_OUTPUT_GAP_MESSAGE = "[terminal output gap: earlier output was discarded]";
+
+export type TerminalReplayEntry =
+  | {
+      type: "data";
+      order: number;
+      seq: number;
+      data: Uint8Array;
+    }
+  | {
+      type: "runtime-gap";
+      order: number;
+      requestedAfterSeq: number;
+      floorSeq: number;
+    }
+  | {
+      type: "local-overflow";
+      order: number;
+    }
+  | {
+      type: "exit";
+      order: number;
+      afterSeq: number;
+      code: number | null;
+    };
+
+interface TerminalReplayBufferState {
+  nextOrder: number;
+  replayEntries: TerminalReplayEntry[];
+  replayDataBytes: number;
+  replayFloorOrder: number;
+  overflowMarkedSinceReplay: boolean;
+}
+
+export function nextTerminalReplayOrder(entry: Pick<TerminalReplayBufferState, "nextOrder">) {
+  entry.nextOrder += 1;
+  return entry.nextOrder;
+}
+
+export function trimTerminalReplayEntries(entry: TerminalReplayBufferState): void {
+  let lostEntries = false;
+  while (
+    entry.replayEntries.length > MAX_REPLAY_ENTRIES
+    || entry.replayDataBytes > MAX_REPLAY_DATA_BYTES
+  ) {
+    const removed = removeOldestReplayEntry(entry);
+    if (!removed) {
+      break;
+    }
+    lostEntries = true;
+    recordRemovedEntry(entry, removed);
+  }
+
+  if (!lostEntries || entry.overflowMarkedSinceReplay) {
+    return;
+  }
+
+  while (entry.replayEntries.length >= MAX_REPLAY_ENTRIES) {
+    const removed = removeOldestReplayEntry(entry);
+    if (removed) {
+      recordRemovedEntry(entry, removed);
+    }
+  }
+
+  entry.replayEntries.unshift({
+    type: "local-overflow",
+    order: nextTerminalReplayOrder(entry),
+  });
+  entry.overflowMarkedSinceReplay = true;
+}
+
+function recordRemovedEntry(
+  entry: TerminalReplayBufferState,
+  removed: TerminalReplayEntry,
+): void {
+  if (removed.type !== "local-overflow") {
+    entry.replayFloorOrder = Math.max(entry.replayFloorOrder, removed.order);
+  }
+  if (removed.type === "data") {
+    entry.replayDataBytes -= removed.data.byteLength;
+  }
+}
+
+function removeOldestReplayEntry(
+  entry: TerminalReplayBufferState,
+): TerminalReplayEntry | undefined {
+  const removalIndex =
+    entry.overflowMarkedSinceReplay
+    && entry.replayEntries[0]?.type === "local-overflow"
+    && entry.replayEntries.length > 1
+      ? 1
+      : 0;
+  const [removed] = entry.replayEntries.splice(removalIndex, 1);
+  return removed;
+}

--- a/apps/packages/product-client/src/lib/infra/terminals/terminal-replay-buffer.ts
+++ b/apps/packages/product-client/src/lib/infra/terminals/terminal-replay-buffer.ts
@@ -1,5 +1,5 @@
-const MAX_REPLAY_DATA_BYTES = 256 * 1024;
-const MAX_REPLAY_ENTRIES = 1000;
+export const TERMINAL_REPLAY_MAX_DATA_BYTES = 256 * 1024;
+export const TERMINAL_REPLAY_MAX_ENTRIES = 1000;
 
 export const TERMINAL_OUTPUT_GAP_MESSAGE = "[terminal output gap: earlier output was discarded]";
 
@@ -43,8 +43,8 @@ export function nextTerminalReplayOrder(entry: Pick<TerminalReplayBufferState, "
 export function trimTerminalReplayEntries(entry: TerminalReplayBufferState): void {
   let lostEntries = false;
   while (
-    entry.replayEntries.length > MAX_REPLAY_ENTRIES
-    || entry.replayDataBytes > MAX_REPLAY_DATA_BYTES
+    entry.replayEntries.length > TERMINAL_REPLAY_MAX_ENTRIES
+    || entry.replayDataBytes > TERMINAL_REPLAY_MAX_DATA_BYTES
   ) {
     const removed = removeOldestReplayEntry(entry);
     if (!removed) {
@@ -58,7 +58,7 @@ export function trimTerminalReplayEntries(entry: TerminalReplayBufferState): voi
     return;
   }
 
-  while (entry.replayEntries.length >= MAX_REPLAY_ENTRIES) {
+  while (entry.replayEntries.length >= TERMINAL_REPLAY_MAX_ENTRIES) {
     const removed = removeOldestReplayEntry(entry);
     if (removed) {
       recordRemovedEntry(entry, removed);

--- a/apps/packages/product-client/src/lib/infra/terminals/terminal-replay-writer.test.ts
+++ b/apps/packages/product-client/src/lib/infra/terminals/terminal-replay-writer.test.ts
@@ -49,6 +49,46 @@ describe("terminal replay writer", () => {
     expect(scheduler.cancel).toHaveBeenCalledTimes(1);
     expect(terminal.write).not.toHaveBeenCalled();
   });
+
+  it("bounds entry backlog while animation frames are stalled", () => {
+    const terminal = { write: vi.fn() };
+    const scheduler = createTestScheduler();
+    const onFlush = vi.fn();
+    const writer = createTerminalReplayWriter(terminal, scheduler, onFlush);
+
+    for (let order = 1; order <= 1_010; order += 1) {
+      writer.enqueue(dataEntry(order, "."));
+    }
+    expect(scheduler.request).toHaveBeenCalledTimes(1);
+
+    scheduler.flush();
+
+    const flushedEntries = onFlush.mock.calls[0]?.[0] as TerminalReplayEntry[];
+    expect(flushedEntries[0]?.type).toBe("local-overflow");
+    expect(flushedEntries.filter((entry) => entry.type === "data")).toHaveLength(1_000);
+    expect(flushedEntries[1]?.order).toBe(11);
+    expect(flushedEntries.at(-1)?.order).toBe(1_010);
+    expect(decoder.decode(terminal.write.mock.calls[0]?.[0])).toMatch(
+      /^\r\n\[terminal output gap: earlier output was discarded\]\r\n\.{1000}$/,
+    );
+  });
+
+  it("bounds byte backlog while animation frames are stalled", () => {
+    const terminal = { write: vi.fn() };
+    const scheduler = createTestScheduler();
+    const onFlush = vi.fn();
+    const writer = createTerminalReplayWriter(terminal, scheduler, onFlush);
+    const largeChunk = new Uint8Array(200 * 1024).fill("x".charCodeAt(0));
+
+    writer.enqueue({ type: "data", order: 1, seq: 1, data: largeChunk });
+    writer.enqueue({ type: "data", order: 2, seq: 2, data: largeChunk });
+    scheduler.flush();
+
+    const flushedEntries = onFlush.mock.calls[0]?.[0] as TerminalReplayEntry[];
+    expect(flushedEntries.map((entry) => entry.type)).toEqual(["local-overflow", "data"]);
+    expect(flushedEntries[1]?.order).toBe(2);
+    expect(terminal.write.mock.calls[0]?.[0].byteLength).toBeLessThan(256 * 1024);
+  });
 });
 
 function dataEntry(order: number, value: string): TerminalReplayEntry {

--- a/apps/packages/product-client/src/lib/infra/terminals/terminal-replay-writer.test.ts
+++ b/apps/packages/product-client/src/lib/infra/terminals/terminal-replay-writer.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createTerminalReplayWriter,
 } from "#product/lib/infra/terminals/terminal-replay-writer";
-import type { TerminalReplayEntry } from "#product/lib/infra/terminals/terminal-stream-registry";
+import type { TerminalReplayEntry } from "#product/lib/infra/terminals/terminal-replay-buffer";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();

--- a/apps/packages/product-client/src/lib/infra/terminals/terminal-replay-writer.test.ts
+++ b/apps/packages/product-client/src/lib/infra/terminals/terminal-replay-writer.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createTerminalReplayWriter,
+} from "#product/lib/infra/terminals/terminal-replay-writer";
+import type { TerminalReplayEntry } from "#product/lib/infra/terminals/terminal-stream-registry";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+describe("terminal replay writer", () => {
+  it("coalesces ordered stream bursts into one xterm write per frame", () => {
+    const terminal = { write: vi.fn() };
+    const scheduler = createTestScheduler();
+    const onFlush = vi.fn();
+    const writer = createTerminalReplayWriter(terminal, scheduler, onFlush);
+
+    writer.enqueue(dataEntry(1, "one"));
+    writer.enqueue(dataEntry(2, "two"));
+    writer.enqueue({
+      type: "runtime-gap",
+      order: 3,
+      requestedAfterSeq: 2,
+      floorSeq: 4,
+    });
+    writer.enqueue(dataEntry(4, "four"));
+
+    expect(scheduler.request).toHaveBeenCalledTimes(1);
+    expect(terminal.write).not.toHaveBeenCalled();
+
+    scheduler.flush();
+
+    expect(terminal.write).toHaveBeenCalledTimes(1);
+    expect(decoder.decode(terminal.write.mock.calls[0]?.[0])).toBe(
+      "onetwo\r\n[terminal output gap: earlier output was discarded]\r\nfour",
+    );
+    expect(onFlush).toHaveBeenCalledOnce();
+    expect(onFlush.mock.calls[0]?.[0]).toHaveLength(4);
+  });
+
+  it("cancels queued work when its viewport is hidden or disposed", () => {
+    const terminal = { write: vi.fn() };
+    const scheduler = createTestScheduler();
+    const writer = createTerminalReplayWriter(terminal, scheduler);
+    writer.enqueue(dataEntry(1, "discarded"));
+
+    writer.dispose();
+    scheduler.flush();
+
+    expect(scheduler.cancel).toHaveBeenCalledTimes(1);
+    expect(terminal.write).not.toHaveBeenCalled();
+  });
+});
+
+function dataEntry(order: number, value: string): TerminalReplayEntry {
+  return {
+    type: "data",
+    order,
+    seq: order,
+    data: encoder.encode(value),
+  };
+}
+
+function createTestScheduler() {
+  let callback: FrameRequestCallback | null = null;
+  return {
+    request: vi.fn((next: FrameRequestCallback) => {
+      callback = next;
+      return 1;
+    }),
+    cancel: vi.fn(() => {
+      callback = null;
+    }),
+    flush() {
+      const next = callback;
+      callback = null;
+      next?.(0);
+    },
+  };
+}

--- a/apps/packages/product-client/src/lib/infra/terminals/terminal-replay-writer.ts
+++ b/apps/packages/product-client/src/lib/infra/terminals/terminal-replay-writer.ts
@@ -1,0 +1,81 @@
+import {
+  TERMINAL_OUTPUT_GAP_MESSAGE,
+  type TerminalReplayEntry,
+} from "#product/lib/infra/terminals/terminal-stream-registry";
+
+interface TerminalWriteTarget {
+  write(data: Uint8Array): void;
+}
+
+interface FrameScheduler {
+  request(callback: FrameRequestCallback): number;
+  cancel(handle: number): void;
+}
+
+const textEncoder = new TextEncoder();
+
+export interface TerminalReplayWriter {
+  enqueue(entry: TerminalReplayEntry): void;
+  dispose(): void;
+}
+
+export function createTerminalReplayWriter(
+  terminal: TerminalWriteTarget,
+  scheduler: FrameScheduler = browserFrameScheduler,
+  onFlush?: (entries: readonly TerminalReplayEntry[]) => void,
+): TerminalReplayWriter {
+  let frameHandle: number | null = null;
+  let pendingEntries: TerminalReplayEntry[] = [];
+
+  const flush = () => {
+    frameHandle = null;
+    const entries = pendingEntries;
+    pendingEntries = [];
+    if (entries.length === 0) {
+      return;
+    }
+    terminal.write(joinReplayEntries(entries));
+    onFlush?.(entries);
+  };
+
+  return {
+    enqueue(entry) {
+      pendingEntries.push(entry);
+      frameHandle ??= scheduler.request(flush);
+    },
+    dispose() {
+      if (frameHandle !== null) {
+        scheduler.cancel(frameHandle);
+        frameHandle = null;
+      }
+      pendingEntries = [];
+    },
+  };
+}
+
+function joinReplayEntries(entries: readonly TerminalReplayEntry[]): Uint8Array {
+  const chunks = entries.map(replayEntryBytes);
+  const byteLength = chunks.reduce((total, chunk) => total + chunk.byteLength, 0);
+  const output = new Uint8Array(byteLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return output;
+}
+
+function replayEntryBytes(entry: TerminalReplayEntry): Uint8Array {
+  if (entry.type === "data") {
+    return entry.data;
+  }
+  if (entry.type === "runtime-gap" || entry.type === "local-overflow") {
+    return textEncoder.encode(`\r\n${TERMINAL_OUTPUT_GAP_MESSAGE}\r\n`);
+  }
+  return textEncoder.encode("\r\n");
+}
+
+const browserFrameScheduler: FrameScheduler = {
+  request: (callback) => window.requestAnimationFrame(callback),
+  cancel: (handle) => window.cancelAnimationFrame(handle),
+};

--- a/apps/packages/product-client/src/lib/infra/terminals/terminal-replay-writer.ts
+++ b/apps/packages/product-client/src/lib/infra/terminals/terminal-replay-writer.ts
@@ -1,7 +1,7 @@
 import {
   TERMINAL_OUTPUT_GAP_MESSAGE,
   type TerminalReplayEntry,
-} from "#product/lib/infra/terminals/terminal-stream-registry";
+} from "#product/lib/infra/terminals/terminal-replay-buffer";
 
 interface TerminalWriteTarget {
   write(data: Uint8Array): void;

--- a/apps/packages/product-client/src/lib/infra/terminals/terminal-replay-writer.ts
+++ b/apps/packages/product-client/src/lib/infra/terminals/terminal-replay-writer.ts
@@ -1,5 +1,7 @@
 import {
   TERMINAL_OUTPUT_GAP_MESSAGE,
+  TERMINAL_REPLAY_MAX_DATA_BYTES,
+  TERMINAL_REPLAY_MAX_ENTRIES,
   type TerminalReplayEntry,
 } from "#product/lib/infra/terminals/terminal-replay-buffer";
 
@@ -26,11 +28,21 @@ export function createTerminalReplayWriter(
 ): TerminalReplayWriter {
   let frameHandle: number | null = null;
   let pendingEntries: TerminalReplayEntry[] = [];
+  let pendingDataBytes = 0;
+  let outputGapRequired = false;
+  let overflowMarkerOrder = 0;
 
   const flush = () => {
     frameHandle = null;
-    const entries = pendingEntries;
+    const queuedEntries = pendingEntries;
     pendingEntries = [];
+    pendingDataBytes = 0;
+    const entries: TerminalReplayEntry[] = outputGapRequired
+      && queuedEntries[0]?.type !== "local-overflow"
+      ? [{ type: "local-overflow", order: overflowMarkerOrder }, ...queuedEntries]
+      : queuedEntries;
+    outputGapRequired = false;
+    overflowMarkerOrder = 0;
     if (entries.length === 0) {
       return;
     }
@@ -41,6 +53,23 @@ export function createTerminalReplayWriter(
   return {
     enqueue(entry) {
       pendingEntries.push(entry);
+      if (entry.type === "data") {
+        pendingDataBytes += entry.data.byteLength;
+      }
+      while (
+        pendingEntries.length > TERMINAL_REPLAY_MAX_ENTRIES
+        || pendingDataBytes > TERMINAL_REPLAY_MAX_DATA_BYTES
+      ) {
+        const removed = pendingEntries.shift();
+        if (!removed) {
+          break;
+        }
+        outputGapRequired = true;
+        overflowMarkerOrder = Math.max(overflowMarkerOrder, removed.order);
+        if (removed.type === "data") {
+          pendingDataBytes -= removed.data.byteLength;
+        }
+      }
       frameHandle ??= scheduler.request(flush);
     },
     dispose() {
@@ -49,6 +78,9 @@ export function createTerminalReplayWriter(
         frameHandle = null;
       }
       pendingEntries = [];
+      pendingDataBytes = 0;
+      outputGapRequired = false;
+      overflowMarkerOrder = 0;
     },
   };
 }

--- a/apps/packages/product-client/src/lib/infra/terminals/terminal-stream-registry.test.ts
+++ b/apps/packages/product-client/src/lib/infra/terminals/terminal-stream-registry.test.ts
@@ -76,6 +76,18 @@ describe("terminal stream registry", () => {
     expect(dataText(entries[1])).toBe("two");
   });
 
+  it("resumes a viewport after its last rendered order without duplicating history", () => {
+    const identity = streamIdentity();
+    ensureConnected({ identity, baseUrl: "http://runtime.test" });
+    mockState.connections[0]!.options.onData?.(bytes("one"), dataFrame(1));
+    mockState.connections[0]!.options.onData?.(bytes("two"), dataFrame(2));
+
+    const entries: TerminalReplayEntry[] = [];
+    subscribeWithReplay(identity, (entry) => entries.push(entry), { afterOrder: 1 });
+
+    expect(entries.map(dataText)).toEqual(["two"]);
+  });
+
   it("reconnects live terminals with afterSeq", () => {
     const identity = streamIdentity();
     ensureConnected({ identity, baseUrl: "http://runtime.test" });
@@ -260,6 +272,30 @@ describe("terminal stream registry", () => {
 
     expect(entries.filter((entry) => entry.type === "local-overflow")).toHaveLength(1);
     expect(entries[entries.length - 1]?.type).toBe("data");
+  });
+
+  it("reports an overflow only when a paused viewport fell behind the replay floor", () => {
+    const identity = streamIdentity();
+    ensureConnected({ identity, baseUrl: "http://runtime.test" });
+    for (let seq = 1; seq <= 1010; seq += 1) {
+      mockState.connections[0]!.options.onData?.(bytes(String(seq)), dataFrame(seq));
+    }
+
+    const staleEntries: TerminalReplayEntry[] = [];
+    subscribeWithReplay(identity, (entry) => staleEntries.push(entry), { afterOrder: 1 });
+    expect(staleEntries[0]?.type).toBe("local-overflow");
+    const renderedThrough = staleEntries.find((entry) => dataText(entry) === "1005")?.order;
+    expect(renderedThrough).toBeTypeOf("number");
+    if (renderedThrough === undefined) {
+      throw new Error("expected the rendered cursor entry");
+    }
+
+    const currentEntries: TerminalReplayEntry[] = [];
+    subscribeWithReplay(identity, (entry) => currentEntries.push(entry), {
+      afterOrder: renderedThrough,
+    });
+    expect(currentEntries.some((entry) => entry.type === "local-overflow")).toBe(false);
+    expect(currentEntries.map(dataText).filter(Boolean)).toEqual(["1006", "1007", "1008", "1009", "1010"]);
   });
 });
 

--- a/apps/packages/product-client/src/lib/infra/terminals/terminal-stream-registry.test.ts
+++ b/apps/packages/product-client/src/lib/infra/terminals/terminal-stream-registry.test.ts
@@ -12,9 +12,9 @@ import {
   sendInput,
   sendResize,
   subscribeWithReplay,
-  type TerminalReplayEntry,
   type TerminalStreamIdentity,
 } from "#product/lib/infra/terminals/terminal-stream-registry";
+import type { TerminalReplayEntry } from "#product/lib/infra/terminals/terminal-replay-buffer";
 import {
   clearTerminalIntentionalClose,
   isTerminalIntentionalClose,

--- a/apps/packages/product-client/src/lib/infra/terminals/terminal-stream-registry.ts
+++ b/apps/packages/product-client/src/lib/infra/terminals/terminal-stream-registry.ts
@@ -7,40 +7,17 @@ import {
 } from "@anyharness/sdk";
 import { terminalStreamKey } from "#product/lib/infra/terminals/terminal-stream-key";
 import { resetTerminalCloseIntentForTests } from "#product/lib/infra/terminals/terminal-close-intent";
-
-const MAX_REPLAY_DATA_BYTES = 256 * 1024;
-const MAX_REPLAY_ENTRIES = 1000;
-export const TERMINAL_OUTPUT_GAP_MESSAGE = "[terminal output gap: earlier output was discarded]";
+import {
+  nextTerminalReplayOrder,
+  trimTerminalReplayEntries,
+  type TerminalReplayEntry,
+} from "#product/lib/infra/terminals/terminal-replay-buffer";
 
 export interface TerminalStreamIdentity {
   workspaceId: string;
   terminalId: string;
   runtimeIdentity: string;
 }
-
-export type TerminalReplayEntry =
-  | {
-      type: "data";
-      order: number;
-      seq: number;
-      data: Uint8Array;
-    }
-  | {
-      type: "runtime-gap";
-      order: number;
-      requestedAfterSeq: number;
-      floorSeq: number;
-    }
-  | {
-      type: "local-overflow";
-      order: number;
-    }
-  | {
-      type: "exit";
-      order: number;
-      afterSeq: number;
-      code: number | null;
-    };
 
 interface TerminalRegistryEntry {
   identity: TerminalStreamIdentity;
@@ -202,7 +179,7 @@ export function markExited(identity: TerminalStreamIdentity, code: number | null
   entry.exitCode = code;
   appendReplayEntry(entry, {
     type: "exit",
-    order: nextOrder(entry),
+    order: nextTerminalReplayOrder(entry),
     afterSeq: entry.lastDataSeq,
     code,
   });
@@ -282,7 +259,7 @@ function appendDataEntry(
   entry.lastDataSeq = frame.seq;
   appendReplayEntry(entry, {
     type: "data",
-    order: nextOrder(entry),
+    order: nextTerminalReplayOrder(entry),
     seq: frame.seq,
     data,
   });
@@ -295,7 +272,7 @@ function appendRuntimeGapEntry(
 ): void {
   const replayEntry: TerminalReplayEntry = {
     type: "runtime-gap",
-    order: nextOrder(entry),
+    order: nextTerminalReplayOrder(entry),
     requestedAfterSeq: frame.requestedAfterSeq,
     floorSeq: frame.floorSeq,
   };
@@ -307,7 +284,7 @@ function appendRuntimeGapEntry(
   } else {
     entry.replayEntries.push(replayEntry);
   }
-  trimReplayEntries(entry);
+  trimTerminalReplayEntries(entry);
   emitReplayEntry(entry, replayEntry);
 }
 
@@ -319,61 +296,8 @@ function appendReplayEntry(
   if (replayEntry.type === "data") {
     entry.replayDataBytes += replayEntry.data.byteLength;
   }
-  trimReplayEntries(entry);
+  trimTerminalReplayEntries(entry);
   emitReplayEntry(entry, replayEntry);
-}
-
-function trimReplayEntries(entry: TerminalRegistryEntry): void {
-  let lostEntries = false;
-  while (
-    entry.replayEntries.length > MAX_REPLAY_ENTRIES
-    || entry.replayDataBytes > MAX_REPLAY_DATA_BYTES
-  ) {
-    const removed = removeOldestReplayEntry(entry);
-    if (!removed) {
-      break;
-    }
-    lostEntries = true;
-    if (removed.type !== "local-overflow") {
-      entry.replayFloorOrder = Math.max(entry.replayFloorOrder, removed.order);
-    }
-    if (removed.type === "data") {
-      entry.replayDataBytes -= removed.data.byteLength;
-    }
-  }
-
-  if (!lostEntries || entry.overflowMarkedSinceReplay) {
-    return;
-  }
-
-  while (entry.replayEntries.length >= MAX_REPLAY_ENTRIES) {
-    const removed = removeOldestReplayEntry(entry);
-    if (removed && removed.type !== "local-overflow") {
-      entry.replayFloorOrder = Math.max(entry.replayFloorOrder, removed.order);
-    }
-    if (removed?.type === "data") {
-      entry.replayDataBytes -= removed.data.byteLength;
-    }
-  }
-
-  entry.replayEntries.unshift({
-    type: "local-overflow",
-    order: nextOrder(entry),
-  });
-  entry.overflowMarkedSinceReplay = true;
-}
-
-function removeOldestReplayEntry(
-  entry: TerminalRegistryEntry,
-): TerminalReplayEntry | undefined {
-  const removalIndex =
-    entry.overflowMarkedSinceReplay
-    && entry.replayEntries[0]?.type === "local-overflow"
-    && entry.replayEntries.length > 1
-      ? 1
-      : 0;
-  const [removed] = entry.replayEntries.splice(removalIndex, 1);
-  return removed;
 }
 
 function emitReplayEntry(
@@ -403,9 +327,4 @@ function closeAndDeleteEntry(key: string, entry: TerminalRegistryEntry): void {
   activelyCloseHandle(entry);
   entry.listeners.clear();
   registry.delete(key);
-}
-
-function nextOrder(entry: TerminalRegistryEntry): number {
-  entry.nextOrder += 1;
-  return entry.nextOrder;
 }

--- a/apps/packages/product-client/src/lib/infra/terminals/terminal-stream-registry.ts
+++ b/apps/packages/product-client/src/lib/infra/terminals/terminal-stream-registry.ts
@@ -49,6 +49,7 @@ interface TerminalRegistryEntry {
   nextOrder: number;
   replayEntries: TerminalReplayEntry[];
   replayDataBytes: number;
+  replayFloorOrder: number;
   overflowMarkedSinceReplay: boolean;
   readOnly: boolean;
   exited: boolean;
@@ -134,9 +135,17 @@ export function ensureConnected(options: EnsureConnectedOptions): boolean {
 export function subscribeWithReplay(
   identity: TerminalStreamIdentity,
   listener: (entry: TerminalReplayEntry) => void,
+  options: { afterOrder?: number } = {},
 ): () => void {
   const entry = getOrCreateEntry(identity);
-  const replayEntries = [...entry.replayEntries];
+  const afterOrder = options.afterOrder ?? 0;
+  const missedBufferedOutput = afterOrder < entry.replayFloorOrder;
+  const replayEntries = entry.replayEntries.filter((replayEntry) => {
+    if (replayEntry.type === "local-overflow") {
+      return missedBufferedOutput;
+    }
+    return replayEntry.order > afterOrder;
+  });
   for (const replayEntry of replayEntries) {
     listener(replayEntry);
   }
@@ -250,6 +259,7 @@ function getOrCreateEntry(identity: TerminalStreamIdentity): TerminalRegistryEnt
     nextOrder: 0,
     replayEntries: [],
     replayDataBytes: 0,
+    replayFloorOrder: 0,
     overflowMarkedSinceReplay: false,
     readOnly: false,
     exited: false,
@@ -324,6 +334,9 @@ function trimReplayEntries(entry: TerminalRegistryEntry): void {
       break;
     }
     lostEntries = true;
+    if (removed.type !== "local-overflow") {
+      entry.replayFloorOrder = Math.max(entry.replayFloorOrder, removed.order);
+    }
     if (removed.type === "data") {
       entry.replayDataBytes -= removed.data.byteLength;
     }
@@ -335,6 +348,9 @@ function trimReplayEntries(entry: TerminalRegistryEntry): void {
 
   while (entry.replayEntries.length >= MAX_REPLAY_ENTRIES) {
     const removed = removeOldestReplayEntry(entry);
+    if (removed && removed.type !== "local-overflow") {
+      entry.replayFloorOrder = Math.max(entry.replayFloorOrder, removed.order);
+    }
     if (removed?.type === "data") {
       entry.replayDataBytes -= removed.data.byteLength;
     }

--- a/specs/codebase/systems/product/workspaces/terminals.md
+++ b/specs/codebase/systems/product/workspaces/terminals.md
@@ -12,6 +12,19 @@
   (`use-xterm-surface.ts`, `use-terminal-viewport.ts`) over
   `lib/infra/terminals/terminal-stream-registry.ts`.
 
+## Output Rendering
+
+- Only the visible terminal viewport subscribes to renderer output. Runtime
+  streams stay connected and retain bounded replay while another right-panel
+  entry is active; restoring a terminal resumes after its last rendered order
+  without replaying content already present in xterm.
+- Visible output is coalesced in arrival order and written to xterm once per
+  animation frame. Gap and exit markers share the same ordered batch, so output
+  bursts cannot monopolize the main thread with one render write per runtime
+  frame.
+- If a hidden viewport falls behind the bounded client replay floor, its next
+  render starts with one output-gap marker followed by the retained output.
+
 ## Creation Grid Contract
 
 A terminal PTY must be created with the exact cols/rows the xterm renderer

--- a/specs/codebase/systems/product/workspaces/terminals.md
+++ b/specs/codebase/systems/product/workspaces/terminals.md
@@ -21,7 +21,8 @@
 - Visible output is coalesced in arrival order and written to xterm once per
   animation frame. Gap and exit markers share the same ordered batch, so output
   bursts cannot monopolize the main thread with one render write per runtime
-  frame.
+  frame. The pending render batch shares the registry replay byte and entry
+  bounds, so a backgrounded window cannot accumulate an unbounded frame.
 - If a hidden viewport falls behind the bounded client replay floor, its next
   render starts with one output-gap marker followed by the retained output.
 


### PR DESCRIPTION
## Summary

- Pause xterm rendering for hidden terminal viewports while keeping their runtime streams connected with bounded replay.
- Resume each viewport after its last flushed registry order so switching right-panel entries does not duplicate output.
- Coalesce visible terminal output in arrival order into one xterm write per animation frame, including gap and exit markers.

## Testing

- Tier 1 regression coverage for paused/resumed viewport subscriptions, bounded replay cursors, overflow behavior, ordered batching, stalled-frame bounds, and cancellation.
- `pnpm --filter @proliferate/product-client exec vitest run src/lib/infra/terminals/terminal-replay-writer.test.ts src/lib/infra/terminals/terminal-stream-registry.test.ts src/hooks/terminals/lifecycle/use-terminal-viewport.test.tsx` (21 passed).
- `pnpm --filter @proliferate/product-client typecheck`.
- `pnpm --filter @proliferate/product-client build`.
- Synthetic 10,000-chunk xterm write benchmark improved from 26.1 ms to 20.9 ms in Chromium and from 36 ms to 29 ms in WebKit when batched.

## Observability

- None. This changes client-side terminal rendering and replay subscription behavior without adding a failure path, telemetry field, or user-content surface.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] No support relationship or private source material applies. The issue association is carried by the ticket-named branch.

## Verification

- `python3 scripts/check_docs.py`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/report_frontend_structure.py --strict --summary-only`
- `python3 scripts/check_appearance_scaling.py`
- `python3 scripts/check_design_attribution.py`
- `python3 scripts/check_max_lines.py`
- `python3 scripts/check_session_mutation_admission.py`
- `git diff --check`
- The full ProductClient run completed 5,420 tests successfully with one skipped; its only suite-level failure was the unrelated local absence of the hardcoded branded Chrome channel.