### PR TITLE
fix(product): keep empty composer arrows inert

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerCaretPlugin.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerCaretPlugin.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  type LexicalEditor,
+} from "lexical";
+import {
+  ComposerRichTextEditor,
+  type ComposerRichTextEditorProps,
+} from "#product/components/workspace/chat/input/ComposerRichTextEditor";
+
+let originalRangeRectDescriptor: PropertyDescriptor | undefined;
+
+afterEach(() => {
+  cleanup();
+  if (originalRangeRectDescriptor === undefined) {
+    Reflect.deleteProperty(Range.prototype, "getBoundingClientRect");
+  } else {
+    Object.defineProperty(
+      Range.prototype,
+      "getBoundingClientRect",
+      originalRangeRectDescriptor,
+    );
+  }
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  originalRangeRectDescriptor = Object.getOwnPropertyDescriptor(
+    Range.prototype,
+    "getBoundingClientRect",
+  );
+  vi.stubGlobal("DragEvent", class DragEvent extends Event {});
+  vi.stubGlobal("ClipboardEvent", class ClipboardEvent extends Event {});
+  vi.spyOn(window, "scrollBy").mockImplementation(() => {});
+});
+
+describe("ComposerCaretPlugin", () => {
+  it("keeps repeated horizontal arrows inert in an empty editor", async () => {
+    mockRangeRect({ height: 15, left: 24, top: 18 });
+    const onChange = vi.fn();
+    const onSubmit = vi.fn();
+    const harness = renderEditor({
+      value: "",
+      onChange,
+      canSubmit: false,
+      onSubmit,
+    });
+    await harness.ready();
+    mockComposerBounds(harness.root, harness.frame);
+
+    act(() => {
+      harness.root.focus();
+      resetText(harness.editor, "");
+    });
+    onChange.mockClear();
+
+    for (const key of ["ArrowLeft", "ArrowRight", "ArrowLeft", "ArrowRight"]) {
+      expect(fireEvent.keyDown(harness.root, { key })).toBe(true);
+      fireEvent(document, new Event("selectionchange"));
+    }
+
+    await act(async () => {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    });
+
+    const caret = harness.frame.querySelector<HTMLElement>(
+      "[data-chat-composer-caret]",
+    )!;
+    expect(caret.style.display).toBe("none");
+    expect(harness.root.style.caretColor).toBe("");
+    expect(harness.root.textContent).toBe("");
+    expect(harness.frame.textContent).toBe("Message");
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("leaves horizontal caret and selection navigation browser-owned for text", async () => {
+    const onChange = vi.fn();
+    const harness = renderEditor({ value: "draft", onChange });
+    await harness.ready();
+
+    act(() => {
+      harness.editor.update(() => {
+        $getRoot().getAllTextNodes()[0]!.select(3, 3);
+      }, { discrete: true });
+    });
+    onChange.mockClear();
+
+    expect(fireEvent.keyDown(harness.root, { key: "ArrowLeft" })).toBe(true);
+    expect(fireEvent.keyDown(harness.root, { key: "ArrowRight" })).toBe(true);
+
+    act(() => {
+      harness.editor.update(() => {
+        $getRoot().getAllTextNodes()[0]!.select(1, 4);
+      }, { discrete: true });
+    });
+    expect(
+      fireEvent.keyDown(harness.root, { key: "ArrowLeft", shiftKey: true }),
+    ).toBe(true);
+    expect(
+      fireEvent.keyDown(harness.root, { key: "ArrowRight", shiftKey: true }),
+    ).toBe(true);
+
+    harness.editor.getEditorState().read(() => {
+      const selection = $getSelection();
+      expect($isRangeSelection(selection)).toBe(true);
+      if ($isRangeSelection(selection)) {
+        expect(selection.anchor.offset).toBe(1);
+        expect(selection.focus.offset).toBe(4);
+      }
+    });
+    expect(harness.root.textContent).toBe("draft");
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+function renderEditor(overrides: Partial<ComposerRichTextEditorProps> = {}) {
+  let editor: LexicalEditor | null = null;
+  const rendered = render(
+    <ComposerRichTextEditor
+      value="seed"
+      onChange={vi.fn()}
+      canSubmit
+      onSubmit={vi.fn()}
+      placeholder="Message"
+      disabled={false}
+      editorRef={(next) => {
+        editor = next;
+      }}
+      {...overrides}
+    />,
+  );
+  const root = rendered.container.querySelector<HTMLElement>(
+    "[data-chat-composer-editor]",
+  )!;
+  const frame = rendered.container.querySelector<HTMLElement>(
+    "[data-chat-composer-editor-frame]",
+  )!;
+  return {
+    get editor() {
+      return editor!;
+    },
+    frame,
+    root,
+    ready: () => waitFor(() => expect(editor).toBeTruthy()),
+  };
+}
+
+function mockComposerBounds(root: HTMLElement, frame: HTMLElement) {
+  vi.spyOn(frame, "getBoundingClientRect").mockReturnValue(
+    domRect({ height: 34, left: 10, top: 8, width: 200 }),
+  );
+  vi.spyOn(root, "getBoundingClientRect").mockReturnValue(
+    domRect({ height: 30, left: 12, top: 10, width: 180 }),
+  );
+}
+
+function domRect({
+  height,
+  left,
+  top,
+  width,
+}: {
+  height: number;
+  left: number;
+  top: number;
+  width: number;
+}): DOMRect {
+  return {
+    bottom: top + height,
+    height,
+    left,
+    right: left + width,
+    toJSON: () => ({}),
+    top,
+    width,
+    x: left,
+    y: top,
+  } as DOMRect;
+}
+
+function resetText(editor: LexicalEditor, text: string) {
+  editor.update(() => {
+    const paragraph = $createParagraphNode();
+    if (text) paragraph.append($createTextNode(text));
+    $getRoot().clear().append(paragraph);
+    paragraph.selectEnd();
+  }, { discrete: true });
+}
+
+function mockRangeRect({
+  height,
+  left,
+  top,
+}: {
+  height: number;
+  left: number;
+  top: number;
+}) {
+  Object.defineProperty(Range.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value: vi.fn(() => ({
+      bottom: top + height,
+      height,
+      left,
+      right: left,
+      toJSON: () => ({}),
+      top,
+      width: 0,
+      x: left,
+      y: top,
+    } satisfies DOMRect)),
+  });
+}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerCaretPlugin.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerCaretPlugin.tsx
@@ -113,13 +113,14 @@ export function ComposerCaretPlugin({
         if (!$isRangeSelection(selection) || !selection.isCollapsed()) return null;
         const anchor = selection.anchor;
         const anchorNode = anchor.getNode();
-        return createDOMRange(
+        const range = createDOMRange(
           activeEditor,
           anchorNode,
           anchor.offset,
           anchorNode,
           anchor.offset,
         );
+        return range?.collapsed ? range : null;
       });
 
       if (range === null) return null;


### PR DESCRIPTION
## Summary
- Keep the shared composer on the native caret when Lexical represents an empty paragraph with a non-collapsed DOM range around its managed line break.
- Preserve the one-pixel replacement caret for genuine collapsed text selections; Left/Right remain browser-owned.
- Add focused regression coverage for empty and non-empty horizontal navigation.

## Scope
The refreshed PR is 2 files and 225 changed lines: 2 additions / 1 deletion in production code, plus a 222-line colocated test harness and two focused tests. Broader changes from the original branch were removed.

## Testing
- Focused caret suite: 2 tests passed.
- Shared chat-input suites: 20 files, 131 tests passed.
- ProductClient typecheck passed.
- Max-lines, frontend boundaries, appearance scaling, design attribution, strict frontend structure, component-library conformance, and `git diff --check` passed.
- Mutation proof: removing the collapsed-DOM-range guard makes the empty-composer regression fail (`display: block` instead of `none`).
- Live Chromium at 1280x900: repeated Left/Right in an empty composer preserved the empty draft, placeholder, disabled Send state, and native caret with no glyph; in `draft`, Left visibly moved the caret before the final `t` and Right returned it to the end without changing text.

## Observability
None. This is local presentation behavior with no new failure path, telemetry, or logging.

## Readiness
- [x] Targets `main` at the current base.
- [x] Preserves horizontal input/event ownership in the browser.
- [x] Shared-composer consumers remain covered.
- [x] Ready for founder QA; do not merge until that gate is complete.