### PR TITLE
fix(product): preserve background session activity

### DIFF
--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/use-hot-session-ingest.test.tsx
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/use-hot-session-ingest.test.tsx
@@ -1,11 +1,28 @@
 // @vitest-environment jsdom
 
+import type { SessionEventEnvelope } from "@anyharness/sdk";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionStreamCache } from "#product/hooks/sessions/cache/use-session-stream-cache";
 import { useHotSessionIngest } from "#product/hooks/sessions/lifecycle/use-hot-session-ingest";
-import { reconcileHotSessions } from "#product/lib/workflows/sessions/hot-session-ingest-manager";
+import {
+  createSessionStreamFlushController,
+  type SessionStreamFlushScheduler,
+} from "#product/hooks/sessions/lifecycle/use-session-stream-flush";
+import { resetStreamWorkspaceActivityForTests } from "#product/hooks/sessions/lifecycle/session-stream-side-effects";
+import { closeSessionSlotStream } from "#product/hooks/sessions/lifecycle/session-stream-slot-connection";
+import { useWorkspaceSidebarActivityStates } from "#product/hooks/workspaces/derived/use-workspace-sidebar-activities";
+import { replaySessionHistory } from "#product/lib/domain/sessions/stream/stream-state";
+import { resetHotSessionIngestManagerForTest } from "#product/lib/workflows/sessions/hot-session-ingest-manager";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import { useSessionIngestStore } from "#product/stores/sessions/session-ingest-store";
+import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
+import {
+  createEmptySessionRecord,
+  getSessionRecord,
+  putSessionRecord,
+} from "#product/stores/sessions/session-records";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
 
@@ -18,70 +35,114 @@ vi.mock("#product/hooks/sessions/workflows/use-session-runtime-actions", () => (
   useSessionRuntimeActions: () => runtimeActions,
 }));
 
-vi.mock("#product/lib/workflows/sessions/hot-session-ingest-manager", () => ({
-  reconcileHotSessions: vi.fn(),
-}));
-
 describe("useHotSessionIngest", () => {
   beforeEach(() => {
+    resetHotSessionIngestManagerForTest();
+    resetStreamWorkspaceActivityForTests();
     useSessionDirectoryStore.getState().clearEntries();
     useSessionTranscriptStore.getState().clearEntries();
+    useSessionIntentStore.getState().clear();
     useSessionSelectionStore.getState().clearSelection();
     useWorkspaceUiStore.setState({ visibleChatSessionIdsByWorkspace: {} });
-    vi.mocked(reconcileHotSessions).mockClear();
+    runtimeActions.closeSessionSlotStream.mockReset();
+    runtimeActions.closeSessionSlotStream.mockImplementation(closeSessionSlotStream);
+    runtimeActions.ensureSessionStreamConnected.mockReset();
+    // The SSE connector is the only stateful boundary replaced here. Session
+    // policy, reconciliation, teardown state, stream reduction, and sidebar
+    // projection all use their production implementations.
+    runtimeActions.ensureSessionStreamConnected.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
     cleanup();
+    resetHotSessionIngestManagerForTest();
+    resetStreamWorkspaceActivityForTests();
+    useSessionIntentStore.getState().clear();
     vi.clearAllMocks();
   });
 
-  it("keeps streaming background work hot across workspace and workflow navigation", async () => {
-    putSession({
-      sessionId: "selected-session",
-      workspaceId: "selected-workspace",
-      streaming: false,
-    });
+  it("keeps background activity connected through navigation until a real completion event", async () => {
     putSession({
       sessionId: "background-session",
       workspaceId: "background-workspace",
       streaming: true,
     });
-    useSessionSelectionStore.getState().activateWorkspace({
-      logicalWorkspaceId: "selected-logical-workspace",
+    putSession({
+      sessionId: "selected-session",
       workspaceId: "selected-workspace",
-      initialActiveSessionId: "selected-session",
+      streaming: false,
+    });
+    useSessionSelectionStore.getState().activateWorkspace({
+      logicalWorkspaceId: "background-logical-workspace",
+      workspaceId: "background-workspace",
+      initialActiveSessionId: "background-session",
     });
 
-    renderHook(() => useHotSessionIngest());
+    const { result } = renderHook(() => {
+      useHotSessionIngest();
+      return useWorkspaceSidebarActivityStates();
+    });
 
     await waitFor(() => {
-      expect(latestTargetReasons()).toEqual([
+      expect(currentTargetReasons()).toEqual([
+        ["background-session", "selected"],
+      ]);
+      expect(result.current["background-workspace"]).toBe("iterating");
+    });
+
+    act(() => {
+      useSessionSelectionStore.getState().activateWorkspace({
+        logicalWorkspaceId: "selected-logical-workspace",
+        workspaceId: "selected-workspace",
+        initialActiveSessionId: "selected-session",
+      });
+    });
+
+    await waitFor(() => {
+      expect(currentTargetReasons()).toEqual([
         ["selected-session", "selected"],
         ["background-session", "running"],
       ]);
+      expect(result.current["background-workspace"]).toBe("iterating");
     });
+    expect(runtimeActions.closeSessionSlotStream).not.toHaveBeenCalledWith(
+      "background-session",
+    );
 
     act(() => {
       useSessionSelectionStore.getState().deselectWorkspacePreservingSessions();
     });
 
     await waitFor(() => {
-      expect(latestTargetReasons()).toEqual([
+      expect(currentTargetReasons()).toEqual([
         ["background-session", "running"],
       ]);
+      expect(result.current["background-workspace"]).toBe("iterating");
     });
+    expect(runtimeActions.closeSessionSlotStream).not.toHaveBeenCalledWith(
+      "background-session",
+    );
 
+    const completion = createCompletionController("background-session");
     act(() => {
-      useSessionDirectoryStore.getState().patchEntry("background-session", {
-        streamConnectionState: "disconnected",
-        activity: { isStreaming: false },
-      });
+      completion.controller.enqueue(turnEnded("background-session", 2));
+      completion.scheduler.flush();
     });
 
     await waitFor(() => {
-      expect(latestTargetReasons()).toEqual([]);
+      expect(currentTargetReasons()).toEqual([]);
+      expect(result.current["background-workspace"]).toBe("idle");
+      expect(runtimeActions.closeSessionSlotStream).toHaveBeenCalledWith(
+        "background-session",
+      );
     });
+    expect(getSessionRecord("background-session")).toMatchObject({
+      status: "idle",
+      executionSummary: { phase: "idle" },
+      streamConnectionState: "disconnected",
+      transcript: { isStreaming: false, lastSeq: 2 },
+    });
+    completion.controller.dispose();
   });
 });
 
@@ -94,21 +155,104 @@ function putSession({
   workspaceId: string;
   streaming: boolean;
 }): void {
-  useSessionDirectoryStore.getState().upsertEntry({
+  const state = replaySessionHistory(
     sessionId,
-    workspaceId,
-    agentKind: "codex",
-    status: "idle",
+    streaming ? [turnStarted(sessionId, 1)] : [],
+  );
+  putSessionRecord({
+    ...createEmptySessionRecord(sessionId, "codex", { workspaceId }),
+    events: state.events,
+    transcript: state.transcript,
+    transcriptHydrated: true,
     streamConnectionState: streaming ? "open" : "disconnected",
-    activity: { isStreaming: streaming },
+    status: "idle",
   });
-  useSessionTranscriptStore.getState().ensureEntry(sessionId);
+  useSessionDirectoryStore.getState().patchActivityFromTranscript(
+    sessionId,
+    state.transcript,
+  );
 }
 
-function latestTargetReasons(): string[][] {
-  const calls = vi.mocked(reconcileHotSessions).mock.calls;
-  return (calls.at(-1)?.[0] ?? []).map((target) => [
-    target.clientSessionId,
-    target.reason,
-  ]);
+function currentTargetReasons(): string[][] {
+  return Object.values(useSessionIngestStore.getState().targetsByClientSessionId)
+    .sort((left, right) =>
+      left.priority - right.priority
+      || left.clientSessionId.localeCompare(right.clientSessionId)
+    )
+    .map((target) => [target.clientSessionId, target.reason]);
+}
+
+function createCompletionController(sessionId: string) {
+  const scheduler = createManualScheduler();
+  return {
+    controller: createSessionStreamFlushController({
+      sessionStreamCache: createTestSessionStreamCache(),
+      mountSubagentChildSession: vi.fn(),
+      persistReconciledControlPreferences: vi.fn(),
+      refreshSessionSlotMeta: vi.fn(),
+      rehydrateSessionSlotFromHistory: vi.fn().mockResolvedValue(false),
+      showToast: vi.fn(),
+      scheduler: scheduler.scheduler,
+      sessionId,
+      streamMeasurementOperationId: null,
+      isStillCurrent: () => true,
+      isCurrentStream: () => true,
+      closeCurrentHandle: vi.fn(),
+      scheduleReconnect: vi.fn(),
+      clearActiveSummaryRefreshTimer: vi.fn(),
+      scheduleActiveSummaryRefresh: vi.fn(),
+      scheduleStartupReadyRefresh: vi.fn(),
+    }),
+    scheduler,
+  };
+}
+
+function createTestSessionStreamCache(): SessionStreamCache {
+  return {
+    invalidateWorkspaceCollections: vi.fn(),
+    invalidateSessionSubagents: vi.fn(),
+    invalidateCoworkManagedWorkspaces: vi.fn(),
+    invalidateSessionReviews: vi.fn(),
+    invalidateGitStatus: vi.fn(),
+    refreshPrStatuses: vi.fn(),
+  };
+}
+
+function createManualScheduler() {
+  let callback: (() => void) | null = null;
+  return {
+    scheduler: {
+      schedule(nextCallback: () => void) {
+        callback = nextCallback;
+        return () => {
+          callback = null;
+        };
+      },
+    } satisfies SessionStreamFlushScheduler,
+    flush() {
+      const nextCallback = callback;
+      callback = null;
+      nextCallback?.();
+    },
+  };
+}
+
+function turnStarted(sessionId: string, seq: number): SessionEventEnvelope {
+  return {
+    sessionId,
+    seq,
+    timestamp: `2026-08-10T00:00:0${seq}Z`,
+    turnId: "turn-1",
+    event: { type: "turn_started" },
+  };
+}
+
+function turnEnded(sessionId: string, seq: number): SessionEventEnvelope {
+  return {
+    sessionId,
+    seq,
+    timestamp: `2026-08-10T00:00:0${seq}Z`,
+    turnId: "turn-1",
+    event: { type: "turn_ended", stopReason: "end_turn" },
+  };
 }

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/use-hot-session-ingest.test.tsx
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/use-hot-session-ingest.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useHotSessionIngest } from "#product/hooks/sessions/lifecycle/use-hot-session-ingest";
+import { reconcileHotSessions } from "#product/lib/workflows/sessions/hot-session-ingest-manager";
+import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+
+const runtimeActions = vi.hoisted(() => ({
+  closeSessionSlotStream: vi.fn(),
+  ensureSessionStreamConnected: vi.fn(),
+}));
+
+vi.mock("#product/hooks/sessions/workflows/use-session-runtime-actions", () => ({
+  useSessionRuntimeActions: () => runtimeActions,
+}));
+
+vi.mock("#product/lib/workflows/sessions/hot-session-ingest-manager", () => ({
+  reconcileHotSessions: vi.fn(),
+}));
+
+describe("useHotSessionIngest", () => {
+  beforeEach(() => {
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+    useSessionSelectionStore.getState().clearSelection();
+    useWorkspaceUiStore.setState({ visibleChatSessionIdsByWorkspace: {} });
+    vi.mocked(reconcileHotSessions).mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("keeps streaming background work hot across workspace and workflow navigation", async () => {
+    putSession({
+      sessionId: "selected-session",
+      workspaceId: "selected-workspace",
+      streaming: false,
+    });
+    putSession({
+      sessionId: "background-session",
+      workspaceId: "background-workspace",
+      streaming: true,
+    });
+    useSessionSelectionStore.getState().activateWorkspace({
+      logicalWorkspaceId: "selected-logical-workspace",
+      workspaceId: "selected-workspace",
+      initialActiveSessionId: "selected-session",
+    });
+
+    renderHook(() => useHotSessionIngest());
+
+    await waitFor(() => {
+      expect(latestTargetReasons()).toEqual([
+        ["selected-session", "selected"],
+        ["background-session", "running"],
+      ]);
+    });
+
+    act(() => {
+      useSessionSelectionStore.getState().deselectWorkspacePreservingSessions();
+    });
+
+    await waitFor(() => {
+      expect(latestTargetReasons()).toEqual([
+        ["background-session", "running"],
+      ]);
+    });
+
+    act(() => {
+      useSessionDirectoryStore.getState().patchEntry("background-session", {
+        streamConnectionState: "disconnected",
+        activity: { isStreaming: false },
+      });
+    });
+
+    await waitFor(() => {
+      expect(latestTargetReasons()).toEqual([]);
+    });
+  });
+});
+
+function putSession({
+  sessionId,
+  workspaceId,
+  streaming,
+}: {
+  sessionId: string;
+  workspaceId: string;
+  streaming: boolean;
+}): void {
+  useSessionDirectoryStore.getState().upsertEntry({
+    sessionId,
+    workspaceId,
+    agentKind: "codex",
+    status: "idle",
+    streamConnectionState: streaming ? "open" : "disconnected",
+    activity: { isStreaming: streaming },
+  });
+  useSessionTranscriptStore.getState().ensureEntry(sessionId);
+}
+
+function latestTargetReasons(): string[][] {
+  const calls = vi.mocked(reconcileHotSessions).mock.calls;
+  return (calls.at(-1)?.[0] ?? []).map((target) => [
+    target.clientSessionId,
+    target.reason,
+  ]);
+}

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/use-hot-session-ingest.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/use-hot-session-ingest.ts
@@ -40,20 +40,20 @@ export function useHotSessionIngest(): void {
       materializedWorkspaceId,
     ).value ?? EMPTY_SESSION_IDS
   );
-  const workspaceSessionIds = useSessionDirectoryStore((state) =>
-    selectedWorkspaceId
-      ? state.sessionIdsByWorkspaceId[selectedWorkspaceId] ?? EMPTY_SESSION_IDS
-      : EMPTY_SESSION_IDS
+  const allDirectoryEntriesById = useSessionDirectoryStore((state) => state.entriesById);
+  const candidateSessionIds = useMemo(
+    () => Object.keys(allDirectoryEntriesById),
+    [allDirectoryEntriesById],
   );
   const relevantSessionIds = useMemo(() =>
     uniqueSessionIds([
       activeSessionId,
       ...visibleChatSessionIds,
-      ...workspaceSessionIds,
+      ...candidateSessionIds,
     ]), [
     activeSessionId,
+    candidateSessionIds,
     visibleChatSessionIds,
-    workspaceSessionIds,
   ]);
   const directoryEntriesById = useSessionDirectoryStore(useShallow((state) =>
     Object.fromEntries(
@@ -74,18 +74,18 @@ export function useHotSessionIngest(): void {
   ));
   const targets = useMemo(() => resolveHotSessionTargets({
     activeSessionId,
+    candidateSessionIds,
     directoryEntriesById,
     promptActivityBySessionId,
     selectedWorkspaceId,
     visibleChatSessionIds,
-    workspaceSessionIds,
   }), [
     activeSessionId,
+    candidateSessionIds,
     directoryEntriesById,
     promptActivityBySessionId,
     selectedWorkspaceId,
     visibleChatSessionIds,
-    workspaceSessionIds,
   ]);
   const {
     closeSessionSlotStream,

--- a/apps/packages/product-client/src/lib/domain/sessions/hot-session-policy.test.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/hot-session-policy.test.ts
@@ -144,6 +144,41 @@ describe("resolveHotSessionTargets", () => {
       ["running", "running"],
     ]);
   });
+
+  it("retains every active session when live work exceeds the passive stream budget", () => {
+    const runningSessionIds = Array.from(
+      { length: 13 },
+      (_, index) => `running-${String(index).padStart(2, "0")}`,
+    );
+    const state = fixtures(["selected", ...runningSessionIds]);
+    for (const sessionId of runningSessionIds) {
+      state.directory[sessionId] = {
+        ...state.directory[sessionId]!,
+        workspaceId: "workspace-2",
+        streamConnectionState: "open",
+        activity: {
+          ...state.directory[sessionId]!.activity,
+          isStreaming: true,
+        },
+      };
+    }
+
+    const targets = resolveHotSessionTargets({
+      activeSessionId: "selected",
+      candidateSessionIds: ["selected", ...runningSessionIds],
+      directoryEntriesById: state.directory,
+      maxHotSessionStreams: 12,
+      promptActivityBySessionId: state.promptActivity,
+      selectedWorkspaceId: "workspace-1",
+      visibleChatSessionIds: ["selected"],
+    });
+
+    expect(targets).toHaveLength(14);
+    expect(targets.map((target) => target.clientSessionId)).toEqual([
+      "selected",
+      ...runningSessionIds,
+    ]);
+  });
 });
 
 function fixtures(

--- a/apps/packages/product-client/src/lib/domain/sessions/hot-session-policy.test.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/hot-session-policy.test.ts
@@ -18,7 +18,7 @@ describe("resolveHotSessionTargets", () => {
       promptActivityBySessionId: state.promptActivity,
       selectedWorkspaceId: "workspace-1",
       visibleChatSessionIds: ["selected", "visible"],
-      workspaceSessionIds: ["selected", "visible"],
+      candidateSessionIds: ["selected", "visible"],
     });
 
     expect(targets.map((target) => [target.clientSessionId, target.reason])).toEqual([
@@ -41,7 +41,7 @@ describe("resolveHotSessionTargets", () => {
       promptActivityBySessionId: state.promptActivity,
       selectedWorkspaceId: "workspace-1",
       visibleChatSessionIds: ["selected", "queued", "running", "visible"],
-      workspaceSessionIds: ["selected", "queued", "running", "visible"],
+      candidateSessionIds: ["selected", "queued", "running", "visible"],
     });
 
     expect(targets.map((target) => [target.clientSessionId, target.reason])).toEqual([
@@ -62,7 +62,7 @@ describe("resolveHotSessionTargets", () => {
       promptActivityBySessionId: state.promptActivity,
       selectedWorkspaceId: "workspace-1",
       visibleChatSessionIds: ["a", "b", "c"],
-      workspaceSessionIds: ["a", "b", "c"],
+      candidateSessionIds: ["a", "b", "c"],
     });
 
     expect(targets.map((target) => target.clientSessionId)).toEqual(["c", "a"]);
@@ -77,7 +77,7 @@ describe("resolveHotSessionTargets", () => {
       promptActivityBySessionId: state.promptActivity,
       selectedWorkspaceId: "workspace-1",
       visibleChatSessionIds: ["projected"],
-      workspaceSessionIds: ["projected"],
+      candidateSessionIds: ["projected"],
     });
 
     expect(targets).toMatchObject([{
@@ -86,6 +86,63 @@ describe("resolveHotSessionTargets", () => {
       reason: "selected",
       streamable: false,
     }]);
+  });
+
+  it("keeps a running session hot while another workspace is selected", () => {
+    const state = fixtures(["selected", "background"]);
+    state.directory.background = {
+      ...state.directory.background!,
+      workspaceId: "workspace-2",
+      streamConnectionState: "open",
+      activity: {
+        ...state.directory.background!.activity,
+        isStreaming: true,
+      },
+    };
+
+    const targets = resolveHotSessionTargets({
+      activeSessionId: "selected",
+      candidateSessionIds: ["selected", "background"],
+      directoryEntriesById: state.directory,
+      promptActivityBySessionId: state.promptActivity,
+      selectedWorkspaceId: "workspace-1",
+      visibleChatSessionIds: ["selected"],
+    });
+
+    expect(targets.map((target) => [target.clientSessionId, target.reason])).toEqual([
+      ["selected", "selected"],
+      ["background", "running"],
+    ]);
+  });
+
+  it("keeps only active background work hot when no workspace is selected", () => {
+    const state = fixtures(["running", "idle"]);
+    state.directory.running = {
+      ...state.directory.running!,
+      workspaceId: "workspace-2",
+      streamConnectionState: "open",
+      activity: {
+        ...state.directory.running!.activity,
+        isStreaming: true,
+      },
+    };
+    state.directory.idle = {
+      ...state.directory.idle!,
+      workspaceId: "workspace-3",
+    };
+
+    const targets = resolveHotSessionTargets({
+      activeSessionId: null,
+      candidateSessionIds: ["running", "idle"],
+      directoryEntriesById: state.directory,
+      promptActivityBySessionId: state.promptActivity,
+      selectedWorkspaceId: null,
+      visibleChatSessionIds: [],
+    });
+
+    expect(targets.map((target) => [target.clientSessionId, target.reason])).toEqual([
+      ["running", "running"],
+    ]);
   });
 });
 

--- a/apps/packages/product-client/src/lib/domain/sessions/hot-session-policy.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/hot-session-policy.ts
@@ -39,7 +39,7 @@ export interface ResolveHotSessionTargetsInput {
   selectedWorkspaceId: string | null;
   activeSessionId: string | null;
   visibleChatSessionIds: readonly string[];
-  workspaceSessionIds: readonly string[];
+  candidateSessionIds: readonly string[];
   directoryEntriesById: Record<string, HotSessionDirectoryEntry | undefined>;
   promptActivityBySessionId: Record<string, number | undefined>;
   maxHotSessionStreams?: number;
@@ -56,20 +56,24 @@ const PRIORITY_BY_REASON: Record<HotSessionReason, number> = {
 export function resolveHotSessionTargets(
   input: ResolveHotSessionTargetsInput,
 ): HotSessionTarget[] {
-  if (!input.selectedWorkspaceId) {
-    return [];
-  }
-
   const candidates = new Map<string, HotSessionTarget>();
   const maxHotSessionStreams = input.maxHotSessionStreams ?? MAX_HOT_SESSION_STREAMS;
 
-  const maybeAdd = (sessionId: string | null | undefined, reason: HotSessionReason) => {
+  const maybeAdd = (
+    sessionId: string | null | undefined,
+    reason: HotSessionReason,
+    selectedWorkspaceOnly = false,
+  ) => {
     if (!sessionId) {
       return;
     }
     const entry = input.directoryEntriesById[sessionId];
     const workspaceId = entry?.workspaceId ?? null;
-    if (!entry || !workspaceId || workspaceId !== input.selectedWorkspaceId) {
+    if (
+      !entry
+      || !workspaceId
+      || (selectedWorkspaceOnly && workspaceId !== input.selectedWorkspaceId)
+    ) {
       return;
     }
 
@@ -89,16 +93,18 @@ export function resolveHotSessionTargets(
     });
   };
 
-  maybeAdd(input.activeSessionId, "selected");
+  maybeAdd(input.activeSessionId, "selected", true);
 
   const visibleSet = new Set(input.visibleChatSessionIds);
   for (const sessionId of input.visibleChatSessionIds) {
-    maybeAdd(sessionId, "open_tab");
+    maybeAdd(sessionId, "open_tab", true);
   }
 
-  for (const sessionId of input.workspaceSessionIds) {
+  // Live work remains hot across workspace and route navigation; otherwise
+  // disconnecting its stream can make an idle summary mask active streaming.
+  for (const sessionId of input.candidateSessionIds) {
     const entry = input.directoryEntriesById[sessionId];
-    if (!entry || entry.workspaceId !== input.selectedWorkspaceId) {
+    if (!entry) {
       continue;
     }
 
@@ -120,7 +126,7 @@ export function resolveHotSessionTargets(
     } else if (viewState === "working") {
       maybeAdd(sessionId, "running");
     } else if (visibleSet.has(sessionId)) {
-      maybeAdd(sessionId, "open_tab");
+      maybeAdd(sessionId, "open_tab", true);
     }
   }
 

--- a/apps/packages/product-client/src/lib/domain/sessions/hot-session-policy.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/hot-session-policy.ts
@@ -57,6 +57,7 @@ export function resolveHotSessionTargets(
   input: ResolveHotSessionTargetsInput,
 ): HotSessionTarget[] {
   const candidates = new Map<string, HotSessionTarget>();
+  const liveSessionIds = new Set<string>();
   const maxHotSessionStreams = input.maxHotSessionStreams ?? MAX_HOT_SESSION_STREAMS;
 
   const maybeAdd = (
@@ -109,6 +110,7 @@ export function resolveHotSessionTargets(
     }
 
     if ((input.promptActivityBySessionId[sessionId] ?? 0) > 0) {
+      liveSessionIds.add(sessionId);
       maybeAdd(sessionId, "queued_prompt");
     }
 
@@ -122,15 +124,41 @@ export function resolveHotSessionTargets(
       },
     });
     if (viewState === "needs_input") {
+      liveSessionIds.add(sessionId);
       maybeAdd(sessionId, "needs_input");
     } else if (viewState === "working") {
+      liveSessionIds.add(sessionId);
       maybeAdd(sessionId, "running");
     } else if (visibleSet.has(sessionId)) {
       maybeAdd(sessionId, "open_tab", true);
     }
   }
 
-  return Array.from(candidates.values())
-    .sort((a, b) => a.priority - b.priority || a.clientSessionId.localeCompare(b.clientSessionId))
-    .slice(0, maxHotSessionStreams);
+  const orderedTargets = Array.from(candidates.values())
+    .sort((a, b) => a.priority - b.priority || a.clientSessionId.localeCompare(b.clientSessionId));
+  const mandatorySessionIds = new Set(liveSessionIds);
+  if (input.activeSessionId && candidates.has(input.activeSessionId)) {
+    mandatorySessionIds.add(input.activeSessionId);
+  }
+  const mandatoryTargetCount = orderedTargets.reduce(
+    (count, target) => count + (mandatorySessionIds.has(target.clientSessionId) ? 1 : 0),
+    0,
+  );
+  const passiveTargetBudget = Math.max(0, maxHotSessionStreams - mandatoryTargetCount);
+  let retainedPassiveTargets = 0;
+
+  // The cap limits passive open-tab retention. The selected session and live
+  // work are correctness requirements: evicting a live target closes the only
+  // stream that can deliver completion and leaves the sidebar with stale
+  // activity.
+  return orderedTargets.filter((target) => {
+    if (mandatorySessionIds.has(target.clientSessionId)) {
+      return true;
+    }
+    if (retainedPassiveTargets >= passiveTargetBudget) {
+      return false;
+    }
+    retainedPassiveTargets += 1;
+    return true;
+  });
 }

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-background-activity.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-background-activity.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildGroups,
+  makeLocalLogicalWorkspace,
+} from "#product/lib/domain/workspaces/sidebar/sidebar-test-fixtures";
+
+describe("sidebar background activity", () => {
+  it("shows running activity while another workspace is selected", () => {
+    const groups = buildGroups({
+      logicalWorkspaces: [
+        makeLocalLogicalWorkspace({
+          id: "background-workspace",
+          repoKey: "/tmp/repo-a",
+          repoName: "repo-a",
+          kind: "worktree",
+        }),
+        makeLocalLogicalWorkspace({
+          id: "selected-workspace",
+          repoKey: "/tmp/repo-a",
+          repoName: "repo-a",
+          kind: "worktree",
+        }),
+      ],
+      selectedLogicalWorkspaceId: "selected-workspace",
+      selectedWorkspaceId: "selected-workspace-materialization",
+      workspaceActivities: {
+        "background-workspace-materialization": "iterating",
+      },
+    });
+
+    const background = groups[0]?.items.find((item) => item.id === "background-workspace");
+    const selected = groups[0]?.items.find((item) => item.id === "selected-workspace");
+    expect(background?.active).toBe(false);
+    expect(background?.statusIndicator).toEqual({
+      kind: "iterating",
+      tooltip: "Iterating",
+    });
+    expect(selected?.active).toBe(true);
+    expect(selected?.statusIndicator).toBeNull();
+  });
+});

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -18,6 +18,16 @@ In-app find (Cmd+F) over transcript prose is documented separately in
 - Any deliberate stream close, detach, prune, or reconnect path must flush
   pending batched stream events before discarding the current handle.
 - Never clear `sseHandle` before queued envelopes have a chance to apply.
+- Hot-session retention distinguishes navigation state from live work.
+  Selected sessions and open tabs are scoped to the selected workspace, but a
+  queued prompt, pending interaction, or running turn remains hot across route,
+  session, and workspace navigation until its production stream event makes it
+  terminal.
+- `MAX_HOT_SESSION_STREAMS` limits passive open-tab retention. The selected
+  session and active work are never evicted by that budget, even when more than
+  12 sessions are live, because removing a hot target intentionally closes its
+  stream and can suppress otherwise-stale streaming activity after
+  disconnection.
 - Transcript reducers must preserve structural sharing and must not mutate
   prior transcript state, turns, items, or content-part arrays in place.
 - Long transcripts must stay virtualized on the normal render path.


### PR DESCRIPTION
## Linear tickets

- [PRO-78 — Running session does not show activity indicator in the left sidebar](https://linear.app/proliferate-team/issue/PRO-78/running-session-does-not-show-activity-indicator-in-the-left-sidebar)

## Summary

- Preserve queued, needs-input, and running sessions across workspace and workflow navigation while keeping selected/open-tab discovery scoped to the current workspace.
- Treat the 12-stream limit as a passive open-tab budget: the selected session and every live session are mandatory, including when more than 12 sessions are active.
- Document the cross-workspace hot-session lifecycle contract and add causal regressions through the real manager, close path, production stream reducer, and sidebar projection.

## Root cause

The hot-ingest hook derived candidates only from the selected workspace, while the policy returned no targets without a selected workspace and rejected sessions belonging to another workspace. Navigation therefore omitted an active background session from the next target set. The real hot-session manager interpreted that omission as an intentional teardown and called `closeSessionSlotStream`, which marked the directory entry `streamConnectionState: "disconnected"`. When the directory status was still `idle`, `activity-status` then suppressed the stale transcript `isStreaming` signal for the disconnected stream, so sidebar projection resolved the workspace to `idle` and removed its activity indicator.

## Testing

- Fail-before proof: the new lifecycle regression fails on latest `origin/main` immediately after cross-workspace navigation because only the newly selected session remains hot.
- Focused production-path coverage: `mise exec node@22 -- pnpm --filter @proliferate/product-client exec vitest run src/lib/domain/sessions/hot-session-policy.test.ts src/hooks/sessions/lifecycle/use-hot-session-ingest.test.tsx src/lib/workflows/sessions/hot-session-ingest-manager.test.ts src/hooks/sessions/lifecycle/use-session-stream-flush.test.ts src/lib/domain/workspaces/sidebar/sidebar-background-activity.test.ts` (27 passed).
- `mise exec node@22 -- pnpm --filter @proliferate/product-client typecheck`
- `mise exec node@22 -- pnpm --filter @proliferate/product-client build`
- `python3 scripts/check_max_lines.py`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/report_frontend_structure.py --strict --summary-only`
- `python3 scripts/check_session_mutation_admission.py`
- `python3 scripts/check_design_attribution.py`
- `python3 scripts/check_docs.py`
- Full ProductClient run: 5,455 tests passed and 1 skipped. Three tests in the untouched support-upload queue surface failed both in the full run and in isolation; the browser-backed Markdown cascade suite also cannot launch locally because branded Chrome is not installed.

## Observability

- None. Existing hot-stream and directory activity measurements remain the diagnostic source; this changes retention policy, not the event or logging contract.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md) for scope, title, labels, body, and readiness.
- [x] The cross-workspace stream-lifecycle contract is documented in the same PR.

## Support and attribution (optional)

- [x] The originating bug is linked through the tracker API. No tracker, report, user, support identifier, or private source data appears in this PR.

## Verification

- Start a session, switch to another workspace/session, then navigate to a route with no selected workspace: the background workspace remains `iterating` and its stream is not closed.
- Deliver the production `turn_ended` envelope: the reducer clears streaming activity, hot retention ends, and the sidebar returns to `idle`.
- With 13 background sessions active, all 13 plus the selected session remain retained; idle open tabs alone are budgeted.