### PR TITLE
fix(product): keep worktree receipts above composer

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/ChatView.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/ChatView.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type DragEvent,
   type JSX,
 } from "react";
@@ -258,6 +259,9 @@ export const ChatView = memo(function ChatView({
         ref={rootRef}
         data-focus-zone="chat"
         tabIndex={-1}
+        style={{
+          "--chat-composer-safe-area": `${dockSafeAreaPx}px`,
+        } as CSSProperties}
         className="chat-selection-root relative flex h-full min-h-0 flex-1 flex-col select-none overflow-hidden outline-none"
         onPointerDownCapture={handleRootPointerDownCapture}
         onDragEnter={handleFileDrag}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.test.tsx
@@ -1,10 +1,12 @@
 /* @vitest-environment jsdom */
 
-import { createRef } from "react";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { createRef, useState } from "react";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TranscriptVirtualRow } from "#product/domain/chats/transcript/transcript-virtual-rows";
+import { WorkspaceCreationReceiptView } from "./WorkspaceCreationReceipt";
 import { FullTranscriptRowList } from "./FullTranscriptRowList";
+import type { WorkspaceCreationReceiptPresentation } from "#product/lib/domain/workspaces/creation/creation-receipt";
 
 const ROWS: TranscriptVirtualRow[] = [
   {
@@ -12,6 +14,30 @@ const ROWS: TranscriptVirtualRow[] = [
     key: "pending-prompt:session-1",
   },
 ];
+
+const RECEIPT_PRESENTATION: WorkspaceCreationReceiptPresentation = {
+  line: "Worktree created",
+  busyLabel: null,
+  showSpinner: false,
+  logLines: [{ tone: "default", text: "Created at /workspace/feature" }],
+  defaultExpanded: false,
+  showRerun: true,
+  rerunDisabled: false,
+  rerunLabel: "Rerun setup",
+  showCreationRetry: false,
+};
+
+function ExpandableReceipt() {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <WorkspaceCreationReceiptView
+      presentation={RECEIPT_PRESENTATION}
+      expanded={expanded}
+      onToggleExpanded={() => setExpanded((current) => !current)}
+      onRerun={() => {}}
+    />
+  );
+}
 
 beforeEach(() => {
   class TestResizeObserver {
@@ -151,6 +177,69 @@ describe("FullTranscriptRowList", () => {
     expect(viewport.scrollTop).toBe(840);
   });
 
+  it("reveals a receipt above a growing composer through transcript scroll accounting", () => {
+    const onScrollSample = vi.fn();
+    const props = {
+      ...makeProps(vi.fn(), 50),
+      bottomInsetPx: 96,
+      nonDisplacingBottomInsetPx: 96,
+      onScrollSample,
+      renderRow: () => <ExpandableReceipt />,
+    };
+    const rendered = render(<FullTranscriptRowList {...props} />);
+    const viewport = getViewport(rendered.container);
+    Object.defineProperties(viewport, {
+      clientHeight: { configurable: true, value: 480 },
+      scrollHeight: { configurable: true, value: 1_000 },
+    });
+    viewport.scrollTop = 100;
+    viewport.scrollLeft = 0;
+    viewport.getBoundingClientRect = () => makeRect(0, 0, 320, 480);
+
+    rendered.rerender(
+      <FullTranscriptRowList
+        {...props}
+        bottomInsetPx={156}
+        nonDisplacingBottomInsetPx={156}
+      />,
+    );
+    const receipt = rendered.container.querySelector<HTMLElement>(
+      "[data-workspace-creation-receipt]",
+    );
+    expect(receipt).toBeTruthy();
+    receipt!.getBoundingClientRect = () => makeRect(
+      12,
+      560 - viewport.scrollTop,
+      296,
+      receipt?.querySelector("[aria-expanded='true']") ? 180 : 40,
+    );
+    const fallbackReveal = vi.fn();
+    receipt!.scrollIntoView = fallbackReveal;
+
+    const frames: FrameRequestCallback[] = [];
+    vi.mocked(window.requestAnimationFrame).mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    fireEvent.click(rendered.getByRole("button", { name: /Worktree created/ }));
+    act(() => {
+      frames.shift()?.(0);
+    });
+
+    expect(viewport.scrollTop).toBe(416);
+    expect(receipt!.getBoundingClientRect().bottom).toBe(324);
+    expect(viewport.scrollLeft).toBe(0);
+    expect(
+      rendered.container.querySelector<HTMLElement>(
+        "[data-transcript-bottom-overlay-inset]",
+      )?.style.height,
+    ).toBe("156px");
+    expect(fallbackReveal).not.toHaveBeenCalled();
+
+    fireEvent.scroll(viewport);
+    expect(onScrollSample).toHaveBeenLastCalledWith({ programmatic: true });
+  });
+
   it("top-aligns a short transcript above the structural inset", () => {
     const { container } = render(
       <FullTranscriptRowList
@@ -250,4 +339,18 @@ function getViewport(container: HTMLElement): HTMLDivElement {
   const viewport = container.querySelector<HTMLDivElement>(".scrollbar-none");
   expect(viewport).toBeTruthy();
   return viewport!;
+}
+
+function makeRect(left: number, top: number, width: number, height: number): DOMRect {
+  return {
+    bottom: top + height,
+    height,
+    left,
+    right: left + width,
+    top,
+    width,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect;
 }

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.tsx
@@ -31,6 +31,7 @@ import {
 } from "./TranscriptRowListShared";
 import { useTranscriptStickToBottom } from "#product/hooks/chat/ui/use-transcript-stick-to-bottom";
 import type { TranscriptVirtualRow } from "#product/domain/chats/transcript/transcript-virtual-rows";
+import { TranscriptElementRevealBoundary } from "./TranscriptElementRevealContext";
 
 type TranscriptRowRenderer = (
   row: TranscriptVirtualRow,
@@ -270,26 +271,33 @@ export function FullTranscriptRowList({
           data-transcript-virtualization-setting={virtualizationMode}
           data-transcript-virtualization-fallback={fallbackReason ?? undefined}
         >
-          <div
-            ref={selectionRootRef}
-            data-chat-transcript-root="true"
-            tabIndex={-1}
-            className={`${columnClassName} select-none outline-none [--text-chat:var(--text-message)] [--text-chat--line-height:var(--text-message--line-height)] [--text-chat-meta:calc(var(--text-chat)_-_2px)]`}
+          <TranscriptElementRevealBoundary
+            bottomInsetPx={bottomInsetPx}
+            notifyProgrammaticScroll={notifyProgrammaticScroll}
+            scrollRef={scrollRef}
+            setPinned={setPinned}
           >
-            {TRANSCRIPT_TOP_PADDING_PX > 0 && (
-              <div aria-hidden="true" style={{ height: TRANSCRIPT_TOP_PADDING_PX }} />
-            )}
-            {isLoadingOlderHistory && <TranscriptHistoryLoadingRow />}
-            {rows.map((row, rowIndex) => (
-              <MemoizedFullTranscriptRow
-                key={row.key}
-                row={row}
-                rowIndex={rowIndex}
-                renderRow={renderRow}
-                renderRevision={getRowRenderRevision?.(row) ?? renderRow}
-              />
-            ))}
-          </div>
+            <div
+              ref={selectionRootRef}
+              data-chat-transcript-root="true"
+              tabIndex={-1}
+              className={`${columnClassName} select-none outline-none [--text-chat:var(--text-message)] [--text-chat--line-height:var(--text-message--line-height)] [--text-chat-meta:calc(var(--text-chat)_-_2px)]`}
+            >
+              {TRANSCRIPT_TOP_PADDING_PX > 0 && (
+                <div aria-hidden="true" style={{ height: TRANSCRIPT_TOP_PADDING_PX }} />
+              )}
+              {isLoadingOlderHistory && <TranscriptHistoryLoadingRow />}
+              {rows.map((row, rowIndex) => (
+                <MemoizedFullTranscriptRow
+                  key={row.key}
+                  row={row}
+                  rowIndex={rowIndex}
+                  renderRow={renderRow}
+                  renderRevision={getRowRenderRevision?.(row) ?? renderRow}
+                />
+              ))}
+            </div>
+          </TranscriptElementRevealBoundary>
         </div>
         {structuralBottomInsetPx > 0 && (
           <div

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptElementRevealContext.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptElementRevealContext.tsx
@@ -1,0 +1,82 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  type ReactNode,
+  type RefObject,
+} from "react";
+
+type RevealTranscriptElement = (element: HTMLElement) => boolean;
+
+const TranscriptElementRevealContext = createContext<RevealTranscriptElement | null>(null);
+
+export function useTranscriptElementReveal(): RevealTranscriptElement | null {
+  return useContext(TranscriptElementRevealContext);
+}
+
+export function TranscriptElementRevealBoundary({
+  bottomInsetPx,
+  children,
+  notifyProgrammaticScroll,
+  scrollRef,
+  setPinned,
+}: {
+  bottomInsetPx: number;
+  children: ReactNode;
+  notifyProgrammaticScroll: (write: () => void) => void;
+  scrollRef: RefObject<HTMLDivElement | null>;
+  setPinned: (pinned: boolean) => void;
+}) {
+  const revealElement = useCallback((element: HTMLElement) => {
+    const viewport = scrollRef.current;
+    if (!viewport || !viewport.contains(element)) {
+      return false;
+    }
+
+    const nextScrollTop = resolveTranscriptRevealScrollTop({
+      bottomInsetPx,
+      elementRect: element.getBoundingClientRect(),
+      viewport,
+      viewportRect: viewport.getBoundingClientRect(),
+    });
+    if (nextScrollTop === viewport.scrollTop) {
+      return true;
+    }
+
+    setPinned(false);
+    notifyProgrammaticScroll(() => {
+      viewport.scrollTop = nextScrollTop;
+    });
+    return true;
+  }, [bottomInsetPx, notifyProgrammaticScroll, scrollRef, setPinned]);
+
+  return (
+    <TranscriptElementRevealContext.Provider value={revealElement}>
+      {children}
+    </TranscriptElementRevealContext.Provider>
+  );
+}
+
+function resolveTranscriptRevealScrollTop({
+  bottomInsetPx,
+  elementRect,
+  viewport,
+  viewportRect,
+}: {
+  bottomInsetPx: number;
+  elementRect: DOMRect;
+  viewport: HTMLDivElement;
+  viewportRect: DOMRect;
+}): number {
+  const safeArea = Math.min(Math.max(0, bottomInsetPx), viewportRect.height);
+  const visibleBottom = viewportRect.bottom - safeArea;
+  let delta = 0;
+  if (elementRect.bottom > visibleBottom) {
+    delta = elementRect.bottom - visibleBottom;
+  } else if (elementRect.top < viewportRect.top) {
+    delta = elementRect.top - viewportRect.top;
+  }
+
+  const maxScrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+  return Math.min(maxScrollTop, Math.max(0, viewport.scrollTop + delta));
+}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualTranscriptViewport.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualTranscriptViewport.tsx
@@ -14,12 +14,15 @@ import {
   MemoizedVirtualTranscriptRow,
 } from "./VirtualTranscriptRow";
 import type { TranscriptVirtualizationMode } from "#product/domain/chats/transcript/transcript-virtualization-config";
+import { TranscriptElementRevealBoundary } from "./TranscriptElementRevealContext";
 
 export function VirtualTranscriptViewport({
+  bottomInsetPx,
   bottomSpacerHeight,
   nonDisplacingBottomInsetPx,
   contentRef,
   measureElement,
+  notifyProgrammaticScroll,
   onUserScrollIntent,
   onViewportScroll,
   renderableRows,
@@ -27,18 +30,21 @@ export function VirtualTranscriptViewport({
   getRowRenderRevision,
   scrollRef,
   selectionRootRef,
+  setPinned,
   topSpacerHeight,
   virtualItems,
   virtualizationMode,
   columnClassName = CHAT_COLUMN_CLASSNAME,
   gutterClassName = CHAT_SURFACE_GUTTER_CLASSNAME,
 }: {
+  bottomInsetPx: number;
   bottomSpacerHeight: number;
   nonDisplacingBottomInsetPx: number;
   columnClassName?: string;
   contentRef?: RefObject<HTMLDivElement | null>;
   gutterClassName?: string;
   measureElement: (element: Element | null) => void;
+  notifyProgrammaticScroll: (write: () => void) => void;
   onUserScrollIntent: (direction: -1 | 1) => void;
   onViewportScroll: (viewport: HTMLDivElement) => void;
   renderableRows: readonly TranscriptRenderableRow[];
@@ -46,6 +52,7 @@ export function VirtualTranscriptViewport({
   getRowRenderRevision?: TranscriptRowListBaseProps["getRowRenderRevision"];
   scrollRef: RefObject<HTMLDivElement | null>;
   selectionRootRef: TranscriptRowListBaseProps["selectionRootRef"];
+  setPinned: (pinned: boolean) => void;
   topSpacerHeight: number;
   virtualItems: readonly VirtualItem[];
   virtualizationMode: TranscriptVirtualizationMode;
@@ -63,52 +70,59 @@ export function VirtualTranscriptViewport({
         data-transcript-virtualization-mode="virtual"
         data-transcript-virtualization-setting={virtualizationMode}
       >
-        <div
-          ref={selectionRootRef}
-          data-chat-transcript-root="true"
-          tabIndex={-1}
-          className={`${columnClassName} select-none outline-none [--text-chat:var(--text-message)] [--text-chat--line-height:var(--text-message--line-height)] [--text-chat-meta:calc(var(--text-chat)_-_2px)]`}
+        <TranscriptElementRevealBoundary
+          bottomInsetPx={bottomInsetPx}
+          notifyProgrammaticScroll={notifyProgrammaticScroll}
+          scrollRef={scrollRef}
+          setPinned={setPinned}
         >
-          {topSpacerHeight > 0 && (
-            <div aria-hidden="true" style={{ height: topSpacerHeight }} />
-          )}
-          {virtualItems.map((virtualRow) => {
-            const renderableRow = renderableRows[virtualRow.index];
-            if (renderableRow?.kind === "history_loader") {
+          <div
+            ref={selectionRootRef}
+            data-chat-transcript-root="true"
+            tabIndex={-1}
+            className={`${columnClassName} select-none outline-none [--text-chat:var(--text-message)] [--text-chat--line-height:var(--text-message--line-height)] [--text-chat-meta:calc(var(--text-chat)_-_2px)]`}
+          >
+            {topSpacerHeight > 0 && (
+              <div aria-hidden="true" style={{ height: topSpacerHeight }} />
+            )}
+            {virtualItems.map((virtualRow) => {
+              const renderableRow = renderableRows[virtualRow.index];
+              if (renderableRow?.kind === "history_loader") {
+                return (
+                  <div
+                    key={renderableRow.key}
+                    ref={measureElement}
+                    data-transcript-virtual-row="true"
+                    data-index={virtualRow.index}
+                    className="w-full"
+                  >
+                    <TranscriptHistoryLoadingRow />
+                  </div>
+                );
+              }
+
+              const row = renderableRow?.row;
+              if (!row) {
+                return null;
+              }
+
               return (
-                <div
-                  key={renderableRow.key}
-                  ref={measureElement}
-                  data-transcript-virtual-row="true"
-                  data-index={virtualRow.index}
-                  className="w-full"
-                >
-                  <TranscriptHistoryLoadingRow />
-                </div>
+                <MemoizedVirtualTranscriptRow
+                  key={row.key}
+                  row={row}
+                  rowIndex={renderableRow.rowIndex}
+                  virtualIndex={virtualRow.index}
+                  renderRow={renderRow}
+                  renderRevision={getRowRenderRevision?.(row) ?? renderRow}
+                  measureElement={measureElement}
+                />
               );
-            }
-
-            const row = renderableRow?.row;
-            if (!row) {
-              return null;
-            }
-
-            return (
-              <MemoizedVirtualTranscriptRow
-                key={row.key}
-                row={row}
-                rowIndex={renderableRow.rowIndex}
-                virtualIndex={virtualRow.index}
-                renderRow={renderRow}
-                renderRevision={getRowRenderRevision?.(row) ?? renderRow}
-                measureElement={measureElement}
-              />
-            );
-          })}
-          {bottomSpacerHeight > 0 && (
-            <div aria-hidden="true" style={{ height: bottomSpacerHeight }} />
-          )}
-        </div>
+            })}
+            {bottomSpacerHeight > 0 && (
+              <div aria-hidden="true" style={{ height: bottomSpacerHeight }} />
+            )}
+          </div>
+        </TranscriptElementRevealBoundary>
       </div>
       {nonDisplacingBottomInsetPx > 0 && (
         <div

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.tsx
@@ -368,12 +368,14 @@ export function VirtualizedTranscriptRowList({
   return (
     <div className="relative h-full">
       <VirtualTranscriptViewport
+        bottomInsetPx={bottomInsetPx}
         bottomSpacerHeight={bottomSpacerHeight}
         nonDisplacingBottomInsetPx={effectiveNonDisplacingBottomInsetPx}
         columnClassName={columnClassName}
         contentRef={contentRef}
         gutterClassName={gutterClassName}
         measureElement={virtualizer.measureElement}
+        notifyProgrammaticScroll={notifyProgrammaticScroll}
         onUserScrollIntent={notifyUserScrollIntent}
         onViewportScroll={handleViewportScroll}
         renderableRows={renderableRows}
@@ -381,6 +383,7 @@ export function VirtualizedTranscriptRowList({
         getRowRenderRevision={getRowRenderRevision}
         scrollRef={scrollRef}
         selectionRootRef={selectionRootRef}
+        setPinned={setPinned}
         topSpacerHeight={topSpacerHeight}
         virtualItems={virtualItems}
         virtualizationMode={virtualizationMode}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/WorkspaceCreationReceipt.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/WorkspaceCreationReceipt.test.tsx
@@ -97,7 +97,7 @@ describe("WorkspaceCreationReceiptView", () => {
     expect(container.querySelector("svg")).not.toBeNull();
   });
 
-  it("reveals an expanded receipt above the measured composer safe area", () => {
+  it("reveals an expanded pre-transcript receipt above the measured composer safe area", () => {
     function Harness() {
       const [expanded, setExpanded] = useState(false);
       return (

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/WorkspaceCreationReceipt.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/WorkspaceCreationReceipt.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 
-import { cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { useState, type CSSProperties } from "react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WorkspaceCreationReceiptView } from "#product/components/workspace/chat/transcript/WorkspaceCreationReceipt";
 import type { WorkspaceCreationReceiptPresentation } from "#product/lib/domain/workspaces/creation/creation-receipt";
 
@@ -32,7 +33,35 @@ function renderReceipt(overrides: Partial<WorkspaceCreationReceiptPresentation>)
   );
 }
 
-afterEach(cleanup);
+let originalScrollIntoView: PropertyDescriptor | undefined;
+const scrollIntoView = vi.fn();
+
+beforeEach(() => {
+  originalScrollIntoView = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "scrollIntoView",
+  );
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+    configurable: true,
+    value: scrollIntoView,
+  });
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    callback(0);
+    return 1;
+  });
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+});
+
+afterEach(() => {
+  cleanup();
+  scrollIntoView.mockReset();
+  vi.unstubAllGlobals();
+  if (originalScrollIntoView) {
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", originalScrollIntoView);
+  } else {
+    delete (HTMLElement.prototype as { scrollIntoView?: unknown }).scrollIntoView;
+  }
+});
 
 describe("WorkspaceCreationReceiptView", () => {
   // The busy phases change the label text ("Creating worktree" →
@@ -66,5 +95,54 @@ describe("WorkspaceCreationReceiptView", () => {
 
     expect(container.querySelector("[data-loading-spinner]")).toBeNull();
     expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("reveals an expanded receipt above the measured composer safe area", () => {
+    function Harness() {
+      const [expanded, setExpanded] = useState(false);
+      return (
+        <div style={{ "--chat-composer-safe-area": "156px" } as CSSProperties}>
+          <WorkspaceCreationReceiptView
+            presentation={presentation({
+              line: "Worktree created",
+              logLines: [{ tone: "default", text: "Created at /workspace/feature" }],
+              showRerun: true,
+            })}
+            expanded={expanded}
+            onToggleExpanded={() => setExpanded((current) => !current)}
+            onRerun={() => {}}
+          />
+        </div>
+      );
+    }
+
+    const { container, getByRole } = render(<Harness />);
+    const receipt = container.querySelector<HTMLElement>("[data-workspace-creation-receipt]");
+
+    expect(receipt?.style.scrollMarginBlockEnd).toBe(
+      "var(--chat-composer-safe-area, 40px)",
+    );
+    fireEvent.click(getByRole("button", { name: /Worktree created/ }));
+
+    expect(getByRole("button", { name: "Rerun setup" })).toBeTruthy();
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      block: "nearest",
+      inline: "nearest",
+    });
+  });
+
+  it("does not move the transcript when a historical receipt mounts expanded", () => {
+    render(
+      <WorkspaceCreationReceiptView
+        presentation={presentation({
+          line: "Worktree created",
+          logLines: [{ tone: "destructive", text: "Setup failed" }],
+        })}
+        expanded
+        onToggleExpanded={() => {}}
+      />,
+    );
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/WorkspaceCreationReceipt.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/WorkspaceCreationReceipt.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useId, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { useRerunSetupMutation } from "@anyharness/sdk-react";
 import { Button } from "#product/primitives/Button";
 import { IconButton } from "#product/primitives/IconButton";
@@ -63,6 +63,8 @@ export function WorkspaceCreationReceiptView({
 }: WorkspaceCreationReceiptViewProps) {
   const labels = WORKSPACE_CREATION_RECEIPT_LABELS;
   const logId = useId();
+  const receiptRef = useRef<HTMLDivElement>(null);
+  const previousExpandedRef = useRef(expanded);
   const hasLog = presentation.logLines.length > 0;
   const showActions = expanded
     && (presentation.showRerun || presentation.showCreationRetry || showSeeTerminal);
@@ -75,8 +77,29 @@ export function WorkspaceCreationReceiptView({
       });
   }, [presentation.logLines]);
 
+  useEffect(() => {
+    const wasExpanded = previousExpandedRef.current;
+    previousExpandedRef.current = expanded;
+    // Historical failures can mount expanded; only a user expansion should move the viewport.
+    if (!expanded || wasExpanded) {
+      return;
+    }
+    const frame = window.requestAnimationFrame(() => {
+      receiptRef.current?.scrollIntoView?.({
+        block: "nearest",
+        inline: "nearest",
+      });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [expanded]);
+
   return (
-    <div data-workspace-creation-receipt className="min-w-0 py-1 text-chat">
+    <div
+      ref={receiptRef}
+      data-workspace-creation-receipt
+      className="min-w-0 py-1 text-chat"
+      style={{ scrollMarginBlockEnd: "var(--chat-composer-safe-area, 40px)" }}
+    >
       <Button
         variant="ghost"
         size="sm"

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/WorkspaceCreationReceipt.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/WorkspaceCreationReceipt.tsx
@@ -17,6 +17,7 @@ import {
 import { usePendingWorkspaceEntryActions } from "#product/hooks/workspaces/workflows/use-pending-workspace-entry-actions";
 import { useWorkspaceShellActions } from "#product/components/workspace/shell/providers/WorkspaceShellActionsContext";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+import { useTranscriptElementReveal } from "./TranscriptElementRevealContext";
 
 const LINE_TONE_CLASS = {
   default: "",
@@ -64,6 +65,7 @@ export function WorkspaceCreationReceiptView({
   const labels = WORKSPACE_CREATION_RECEIPT_LABELS;
   const logId = useId();
   const receiptRef = useRef<HTMLDivElement>(null);
+  const revealTranscriptElement = useTranscriptElementReveal();
   const previousExpandedRef = useRef(expanded);
   const hasLog = presentation.logLines.length > 0;
   const showActions = expanded
@@ -85,13 +87,17 @@ export function WorkspaceCreationReceiptView({
       return;
     }
     const frame = window.requestAnimationFrame(() => {
-      receiptRef.current?.scrollIntoView?.({
+      const receipt = receiptRef.current;
+      if (!receipt || revealTranscriptElement?.(receipt)) {
+        return;
+      }
+      receipt.scrollIntoView?.({
         block: "nearest",
         inline: "nearest",
       });
     });
     return () => window.cancelAnimationFrame(frame);
-  }, [expanded]);
+  }, [expanded, revealTranscriptElement]);
 
   return (
     <div

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatDockInset } from "./use-chat-dock-inset";
+
+interface DockDimensions {
+  dockHeight: number;
+  surfaceHeight: number;
+}
+
+let resizeCallback: ResizeObserverCallback | null = null;
+
+beforeEach(() => {
+  class TestResizeObserver {
+    constructor(callback: ResizeObserverCallback) {
+      resizeCallback = callback;
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal("ResizeObserver", TestResizeObserver);
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    callback(0);
+    return 1;
+  });
+  vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function () {
+    return makeRect(
+      Number(this.dataset.testLeft ?? 0),
+      Number(this.dataset.testTop ?? 0),
+      Number(this.dataset.testWidth ?? 0),
+      Number(this.dataset.testHeight ?? 0),
+    );
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  resizeCallback = null;
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("useChatDockInset", () => {
+  it("publishes a new safe area when the measured composer grows at narrow width", () => {
+    const rendered = render(
+      <Harness dimensions={{ dockHeight: 116, surfaceHeight: 72 }} />,
+    );
+
+    expect(screen.getByTestId("safe-area").textContent).toBe("132");
+
+    rendered.rerender(
+      <Harness dimensions={{ dockHeight: 176, surfaceHeight: 132 }} />,
+    );
+    act(() => {
+      resizeCallback?.([], {} as ResizeObserver);
+    });
+
+    expect(screen.getByTestId("safe-area").textContent).toBe("192");
+  });
+});
+
+function Harness({ dimensions }: { dimensions: DockDimensions }) {
+  const { dockRef, dockSafeAreaPx } = useChatDockInset();
+  return (
+    <div>
+      <output data-testid="safe-area">{dockSafeAreaPx}</output>
+      <div
+        ref={dockRef}
+        data-test-left="0"
+        data-test-top="100"
+        data-test-width="320"
+        data-test-height={dimensions.dockHeight}
+      >
+        <div
+          data-chat-composer-surface
+          data-test-left="12"
+          data-test-top="108"
+          data-test-width="296"
+          data-test-height={dimensions.surfaceHeight}
+        />
+        <div
+          data-chat-composer-footer
+          data-test-left="12"
+          data-test-top={108 + dimensions.surfaceHeight}
+          data-test-width="296"
+          data-test-height="20"
+        />
+      </div>
+    </div>
+  );
+}
+
+function makeRect(left: number, top: number, width: number, height: number): DOMRect {
+  return {
+    bottom: top + height,
+    height,
+    left,
+    right: left + width,
+    top,
+    width,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect;
+}


### PR DESCRIPTION
## Summary

- Publish the measured composer safe area as an inherited chat layout value.
- Reveal expanded worktree receipts through the full and virtualized transcript scroll owners, using actual viewport geometry, the existing composer scroll range, and programmatic-scroll accounting.
- Keep nearest-edge scrolling as a pre-transcript fallback and preserve the current read position when a historical failed receipt initially mounts expanded.

The older dock-attached worktree panel has already been replaced on `main` by an inline transcript receipt. This closes the remaining expansion and composer-clearance behavior from [PRO-46](https://linear.app/proliferate-team/issue/PRO-46/fix-worktree-status-popup-overlapping-the-follow-up-composer).

The original popup dismissal criterion is superseded by that migration. The current receipt is lifecycle context embedded in the transcript, is collapsed by default, and is replaced by the current creation state; making it dismissible would remove conversation history rather than resolve the overlap.

## Testing

- Tier 1 regression coverage for measured dock growth at 320px width, dynamic composer clearance, full-transcript reveal geometry, programmatic-scroll classification, pre-transcript fallback, historical expanded mounts, and both transcript implementations.
- `pnpm --filter @proliferate/product-client exec vitest run src/components/workspace/chat/transcript/WorkspaceCreationReceipt.test.tsx src/components/workspace/chat/transcript/FullTranscriptRowList.test.tsx src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx src/hooks/chat/ui/use-chat-dock-inset.test.tsx` (19 passed).
- Full ProductClient run excluding the local Chrome-only cascade fixture: 797 files and 5,417 tests passed.
- `pnpm --filter @proliferate/product-client typecheck`.
- `pnpm --filter @proliferate/product-client build`.
- Chromium component fixture at 480x720 confirmed the expanded receipt has no horizontal overflow and its setup actions remain visible.

## Observability

- None. This changes client-side layout and scroll behavior without adding a failure path, telemetry field, or user-content surface.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] No support relationship or private source material applies.

## Verification

- `python3 scripts/check_docs.py`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_appearance_scaling.py`
- `python3 scripts/check_design_attribution.py`
- `python3 scripts/check_max_lines.py --strict-structure`
- `python3 scripts/check_session_mutation_admission.py`
- `python3 scripts/check_toast_copy.py`
- `git diff --check`