### PR TITLE
feat(product): add selected response chat actions

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.test.tsx
@@ -1,13 +1,29 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatInput } from "#product/components/workspace/chat/input/ChatInput";
 import type { PromptAttachmentController } from "#product/hooks/chat/ui/use-chat-prompt-attachments";
 
 const chatInputMocks = vi.hoisted(() => ({
+  clearSelectedResponseContexts: vi.fn(),
+  getSelectedResponseContexts: vi.fn(() => [{
+    id: "excerpt-1",
+    text: "full selected excerpt",
+  }]),
+  handleSubmit: vi.fn(async (input: { onSubmitted?: () => void }) => {
+    input.onSubmitted?.();
+    return true;
+  }),
   lexicalPaste: vi.fn(),
+  removeSelectedResponseContext: vi.fn(),
+}));
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => ({
+    deployment: { apiBaseUrl: "http://localhost" },
+  }),
 }));
 
 vi.mock("#product/stores/sessions/session-selection-store", () => ({
@@ -32,6 +48,9 @@ vi.mock("#product/hooks/chat/derived/use-chat-availability-state", () => ({
     areRuntimeControlsDisabled: false,
   }),
 }));
+vi.mock("#product/hooks/chat/derived/use-composer-blocked-state", () => ({
+  useComposerBlockedState: () => null,
+}));
 vi.mock("#product/hooks/chat/ui/use-chat-composer-keyboard", () => ({
   useChatComposerKeyboard: () => ({ handleKeyDown: vi.fn() }),
 }));
@@ -40,8 +59,12 @@ vi.mock("#product/hooks/chat/ui/use-chat-draft-state", () => ({
     workspaceUiKey: null,
     materializedWorkspaceId: null,
     getDraft: () => ({ nodes: [] }),
+    getSelectedResponseContexts: chatInputMocks.getSelectedResponseContexts,
     setDraft: vi.fn(),
+    removeSelectedResponseContext: chatInputMocks.removeSelectedResponseContext,
+    clearSelectedResponseContexts: chatInputMocks.clearSelectedResponseContexts,
     isEmpty: true,
+    hasSelectedResponseContexts: true,
   }),
 }));
 vi.mock("#product/hooks/chat/facade/use-chat-model-selector-state", () => ({
@@ -51,10 +74,16 @@ vi.mock("#product/hooks/chat/facade/use-chat-model-selector-state", () => ({
   }),
 }));
 vi.mock("#product/hooks/chat/workflows/use-chat-prompt-actions", () => ({
-  useChatPromptActions: () => ({ handleSubmit: vi.fn(), handleCancel: vi.fn() }),
+  useChatPromptActions: () => ({
+    handleSubmit: chatInputMocks.handleSubmit,
+    handleCancel: vi.fn(),
+  }),
 }));
 vi.mock("#product/hooks/chat/ui/use-composer-submit-gate", () => ({
-  useComposerSubmitGate: () => ({ isSubmitting: false, run: vi.fn() }),
+  useComposerSubmitGate: () => ({
+    isSubmitting: false,
+    run: (submit: () => Promise<void>) => { void submit(); },
+  }),
 }));
 vi.mock("#product/hooks/chat/facade/use-chat-session-controls", () => ({
   useChatSessionControls: () => ({ agentKind: null, controls: [], modeControl: null }),
@@ -97,19 +126,34 @@ vi.mock(
   () => ({ ConnectedWorkspaceStatusComposerControl: () => null }),
 );
 vi.mock("#product/components/workspace/chat/input/ChatInputDraftArea", () => ({
-  ChatInputDraftArea: ({ textareaRef }: { textareaRef: { current: HTMLDivElement | null } }) => (
-    <div
-      ref={textareaRef}
-      data-testid="mock-chat-editor"
-      onPaste={(event) => {
-        event.preventDefault();
-        chatInputMocks.lexicalPaste(event.clipboardData.getData("text/plain"));
-      }}
-    />
+  ChatInputDraftArea: ({
+    onSubmit,
+    textareaRef,
+  }: {
+    onSubmit: () => void;
+    textareaRef: { current: HTMLDivElement | null };
+  }) => (
+    <>
+      <div
+        ref={textareaRef}
+        data-testid="mock-chat-editor"
+        onPaste={(event) => {
+          event.preventDefault();
+          chatInputMocks.lexicalPaste(event.clipboardData.getData("text/plain"));
+        }}
+      />
+      <button type="button" onClick={onSubmit}>Submit mock composer</button>
+    </>
   ),
 }));
 
-beforeEach(() => { chatInputMocks.lexicalPaste.mockReset(); });
+beforeEach(() => {
+  vi.clearAllMocks();
+  chatInputMocks.handleSubmit.mockImplementation(async (input) => {
+    input.onSubmitted?.();
+    return true;
+  });
+});
 afterEach(cleanup);
 
 describe("ChatInput paste ownership", () => {
@@ -149,6 +193,53 @@ describe("ChatInput paste ownership", () => {
 
     expect(attachments.addFiles).not.toHaveBeenCalled();
     expect(chatInputMocks.lexicalPaste).toHaveBeenCalledWith("clipboard fallback");
+  });
+});
+
+describe("ChatInput selected response context", () => {
+  it("submits the full excerpt once and clears the captured context after success", async () => {
+    render(
+      <ChatInput
+        attachments={createAttachments(false).controller}
+        suppressActiveSessionState
+        suppressAutoFocus
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit mock composer" }));
+
+    await waitFor(() => expect(chatInputMocks.handleSubmit).toHaveBeenCalledOnce());
+    const payload = chatInputMocks.handleSubmit.mock.calls[0]![0];
+    expect(payload.text.split("full selected excerpt")).toHaveLength(2);
+    expect(payload.blocks).toEqual([{ type: "text", text: payload.text }]);
+    expect(payload.optimisticContentParts).toEqual([{ type: "text", text: payload.text }]);
+    expect(chatInputMocks.clearSelectedResponseContexts).toHaveBeenCalledWith([
+      "excerpt-1",
+    ]);
+  });
+
+  it("keeps retry cleanup attached to the submitted prompt", async () => {
+    let onSubmitted: (() => void) | undefined;
+    chatInputMocks.handleSubmit.mockImplementationOnce(async (input) => {
+      onSubmitted = input.onSubmitted;
+      return false;
+    });
+    render(
+      <ChatInput
+        attachments={createAttachments(false).controller}
+        suppressActiveSessionState
+        suppressAutoFocus
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit mock composer" }));
+
+    await waitFor(() => expect(chatInputMocks.handleSubmit).toHaveBeenCalledOnce());
+    expect(chatInputMocks.clearSelectedResponseContexts).not.toHaveBeenCalled();
+    onSubmitted?.();
+    expect(chatInputMocks.clearSelectedResponseContexts).toHaveBeenCalledWith([
+      "excerpt-1",
+    ]);
   });
 });
 

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx
@@ -56,6 +56,7 @@ import { Input } from "#product/primitives/Input";
 import { useDebugRenderCount } from "#product/hooks/ui/debug/use-debug-render-count";
 import { usePromptAttachmentPreviewActions } from "#product/hooks/chat/workflows/use-prompt-attachment-preview-actions";
 import { useChatInputPaste } from "#product/hooks/chat/ui/use-chat-input-paste";
+import { useChatComposerFocusRequest } from "#product/hooks/chat/ui/use-chat-composer-focus-request";
 import type { PromptAttachmentPreviewHandler } from "#product/components/workspace/chat/content/PromptContentRenderer";
 
 const CHAT_INPUT_ATTACHMENT_ACCEPT =
@@ -325,33 +326,7 @@ export function ChatInput({
     wasBlockedRef.current = isBlocked;
   }, [blockedPresentation, focusComposer, suppressAutoFocus]);
 
-  useEffect(() => {
-    if (focusRequestNonce === 0) {
-      return;
-    }
-
-    let timer: number | null = null;
-    let attempts = 0;
-    let cancelled = false;
-    const attemptFocus = () => {
-      if (cancelled) {
-        return;
-      }
-      attempts += 1;
-      if (focusComposer() || attempts >= 8) {
-        return;
-      }
-      timer = window.setTimeout(attemptFocus, 25);
-    };
-
-    timer = window.setTimeout(attemptFocus, 0);
-    return () => {
-      cancelled = true;
-      if (timer !== null) {
-        window.clearTimeout(timer);
-      }
-    };
-  }, [focusComposer, focusRequestNonce]);
+  useChatComposerFocusRequest({ focusRequestNonce, focusComposer });
 
   return (
     <DebugProfiler id="chat-composer">

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx
@@ -30,6 +30,7 @@ import {
 import { focusChatInput } from "#product/lib/domain/focus-zone";
 import { serializeChatDraftToPrompt } from "#product/lib/domain/chat/composer/file-mention-draft-model";
 import { promptAttachmentSnapshotsToContentParts } from "#product/domain/chats/composer/prompt-attachment-snapshot";
+import { buildPromptWithSelectedResponseContexts } from "#product/domain/chats/transcript/selected-response-context";
 import { useChatInputStore } from "#product/stores/chat/chat-input-store";
 import { mergeSessionConfigControlDescriptors } from "#product/lib/domain/chat/session-controls/session-controls";
 import { buildComposerSessionControlGroups } from "#product/lib/domain/chat/session-controls/composer-control-groups";
@@ -93,8 +94,17 @@ export function ChatInput({
   // PERF: no draft-content subscription here — a keystroke must not re-render
   // the whole composer dock. The draft area subscribes to the live draft
   // itself; this component only needs the isEmpty gate + a submit-time reader.
-  const { workspaceUiKey, materializedWorkspaceId, getDraft, setDraft, isEmpty } =
-    useChatDraftControls();
+  const {
+    workspaceUiKey,
+    materializedWorkspaceId,
+    getDraft,
+    getSelectedResponseContexts,
+    setDraft,
+    removeSelectedResponseContext,
+    clearSelectedResponseContexts,
+    isEmpty,
+    hasSelectedResponseContexts,
+  } = useChatDraftControls();
   const { isDisabled, sendBlockedReason, areRuntimeControlsDisabled } = useChatAvailabilityState({
     activeSessionId: activeSessionIdForUi,
   });
@@ -140,7 +150,7 @@ export function ChatInput({
     attachments.hasSupportedAttachments || planAttachments.hasPlans;
   const effectiveIsEmpty = effectiveIsEditingQueuedPrompt
     ? editDraft.trim().length === 0
-    : isEmpty && !hasSubmittableDraftAttachments;
+    : isEmpty && !hasSubmittableDraftAttachments && !hasSelectedResponseContexts;
   const canSubmit =
     !effectiveIsEmpty && !isDisabled && !sendBlockedReason && !isSubmitting;
   const canAcceptPastedAttachments =
@@ -171,11 +181,15 @@ export function ChatInput({
       // Serialized at submit time (imperative read) so typing keystrokes never
       // re-render this component just to keep promptText fresh.
       const promptText = serializeChatDraftToPrompt(getDraft());
-      const trimmedPromptText = promptText.trim();
+      const selectedResponseContexts = [...getSelectedResponseContexts()];
+      const contextualPrompt = buildPromptWithSelectedResponseContexts(
+        promptText,
+        selectedResponseContexts,
+      );
       const blockPrepareStartedAt = performance.now();
       const attachmentSnapshots = attachments.snapshotForSubmit();
       const blocks = [
-        ...(trimmedPromptText ? [{ type: "text" as const, text: trimmedPromptText }] : []),
+        ...contextualPrompt.blocks,
         ...planAttachments.blocks,
       ];
       recordMeasurementWorkflowStep({
@@ -186,16 +200,21 @@ export function ChatInput({
         count: blocks.length + attachmentSnapshots.length,
       });
       const optimisticContentParts = [
-        ...(trimmedPromptText ? [{ type: "text" as const, text: trimmedPromptText }] : []),
+        ...contextualPrompt.optimisticContentParts,
         ...promptAttachmentSnapshotsToContentParts(attachmentSnapshots),
         ...planAttachments.contentParts,
       ];
       const submitted = await handleSubmit({
-        text: promptText,
+        text: contextualPrompt.text,
         blocks,
         attachmentSnapshots,
         optimisticContentParts,
         measurementOperationId,
+        onSubmitted: () => {
+          clearSelectedResponseContexts(
+            selectedResponseContexts.map((context) => context.id),
+          );
+        },
       });
       if (!submitted) {
         finishOrCancelMeasurementOperation(measurementOperationId, "aborted");
@@ -211,7 +230,9 @@ export function ChatInput({
     attachments,
     commitEdit,
     effectiveIsEditingQueuedPrompt,
+    clearSelectedResponseContexts,
     getDraft,
+    getSelectedResponseContexts,
     handleSubmit,
     planAttachments,
     runSubmit,
@@ -392,6 +413,7 @@ export function ChatInput({
                     draftAttachments={[...attachments.attachments, ...planAttachments.attachments]}
                     onRemoveDraftAttachment={handleRemoveDraftAttachment}
                     onOpenDraftAttachment={handleOpenDraftAttachment}
+                    onRemoveSelectedResponseContext={removeSelectedResponseContext}
                     overlayHostElement={composerOverlayHost}
                     onCancelEdit={cancelEdit}
                   />

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInputDraftArea.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInputDraftArea.test.tsx
@@ -6,11 +6,21 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { WORKSPACE_CHAT_COMPOSER_INPUT } from "#product/config/chat";
 import { ChatInputDraftArea } from "#product/components/workspace/chat/input/ChatInputDraftArea";
 
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => ({
+    deployment: { apiBaseUrl: "http://localhost" },
+  }),
+}));
+
 vi.mock("#product/hooks/chat/ui/use-chat-draft-state", () => ({
   useChatDraftValue: () => ({ nodes: [] }),
+  useChatSelectedResponseContexts: () => [],
 }));
 vi.mock("#product/components/workspace/chat/input/ComposerRichTextEditor", () => ({
   ComposerRichTextEditor: () => <div data-testid="queue-rich-editor" />,
+}));
+vi.mock("#product/components/workspace/chat/input/ComposerCommandEditor", () => ({
+  ComposerCommandEditor: () => <div />,
 }));
 vi.mock("#product/primitives/patterns/ComposerTextareaFrame", () => ({
   ComposerTextareaFrame: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -41,6 +51,7 @@ describe("ChatInputDraftArea", () => {
         draftAttachments={[]}
         onRemoveDraftAttachment={vi.fn()}
         onOpenDraftAttachment={vi.fn()}
+        onRemoveSelectedResponseContext={vi.fn()}
         overlayHostElement={null}
         onCancelEdit={vi.fn()}
       />,

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInputDraftArea.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInputDraftArea.tsx
@@ -10,12 +10,16 @@ import {
   type DraftAttachmentPreviewListProps,
   type PromptAttachmentPreviewHandler,
 } from "#product/components/workspace/chat/content/PromptContentRenderer";
-import { useChatDraftValue } from "#product/hooks/chat/ui/use-chat-draft-state";
+import {
+  useChatDraftValue,
+  useChatSelectedResponseContexts,
+} from "#product/hooks/chat/ui/use-chat-draft-state";
 import { ComposerCommandEditor } from "#product/components/workspace/chat/input/ComposerCommandEditor";
 import { ComposerRichTextEditor } from "#product/components/workspace/chat/input/ComposerRichTextEditor";
 import { ComposerTextareaFrame } from "#product/primitives/patterns/ComposerTextareaFrame";
 import { QueuedPromptEditBanner } from "#product/components/workspace/chat/input/QueuedPromptEditBanner";
 import type { ChatComposerKeyboardEvent } from "#product/hooks/chat/ui/use-chat-composer-keyboard";
+import { SelectedResponseContextList } from "#product/components/workspace/chat/input/SelectedResponseContextList";
 
 interface ChatInputDraftAreaProps {
   /** Picks the follow-up placeholder once the session transcript has turns. */
@@ -39,6 +43,7 @@ interface ChatInputDraftAreaProps {
   draftAttachments: DraftAttachmentPreviewListProps["attachments"];
   onRemoveDraftAttachment: DraftAttachmentPreviewListProps["onRemove"];
   onOpenDraftAttachment: PromptAttachmentPreviewHandler;
+  onRemoveSelectedResponseContext: (id: string) => void;
   overlayHostElement: HTMLElement | null;
   onCancelEdit: () => void;
 }
@@ -60,6 +65,7 @@ export function ChatInputDraftArea({
   draftAttachments,
   onRemoveDraftAttachment,
   onOpenDraftAttachment,
+  onRemoveSelectedResponseContext,
   overlayHostElement,
   onCancelEdit,
 }: ChatInputDraftAreaProps) {
@@ -73,6 +79,7 @@ export function ChatInputDraftArea({
     ? editEditorState.snapshot
     : undefined;
   const draft = useChatDraftValue(workspaceUiKey);
+  const selectedResponseContexts = useChatSelectedResponseContexts(workspaceUiKey);
   const placeholder = hasSessionTurns
     ? CHAT_COMPOSER_LABELS.followUpPlaceholder
     : CHAT_COMPOSER_LABELS.placeholder;
@@ -118,6 +125,10 @@ export function ChatInputDraftArea({
         onRemove={onRemoveDraftAttachment}
         onOpenAttachment={onOpenDraftAttachment}
       />
+      <SelectedResponseContextList
+        contexts={selectedResponseContexts}
+        onRemove={onRemoveSelectedResponseContext}
+      />
       <ComposerCommandEditor
         draft={draft}
         onDraftChange={onDraftChange}
@@ -126,7 +137,7 @@ export function ChatInputDraftArea({
         disabled={isDisabled}
         onSubmit={onSubmit}
         onKeyDown={onKeyDown}
-        topInset={hasDraftAttachments ? "none" : "standard"}
+        topInset={hasDraftAttachments || selectedResponseContexts.length > 0 ? "none" : "standard"}
         overlayHostElement={overlayHostElement}
       />
     </>

--- a/apps/packages/product-client/src/components/workspace/chat/input/SelectedResponseContextList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/SelectedResponseContextList.tsx
@@ -1,0 +1,54 @@
+import { Quote, X } from "lucide-react";
+import type { SelectedResponseContext } from "#product/domain/chats/transcript/selected-response-context";
+import { selectedResponseContextPreview } from "#product/domain/chats/transcript/selected-response-context";
+import { Button } from "#product/primitives/Button";
+
+export function SelectedResponseContextList({
+  contexts,
+  onRemove,
+}: {
+  contexts: readonly SelectedResponseContext[];
+  onRemove: (id: string) => void;
+}) {
+  if (contexts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="flex w-full flex-col gap-1.5 px-2 pt-2 pb-1"
+      data-selected-response-context-list
+      data-telemetry-mask
+    >
+      {contexts.map((context) => (
+        <div
+          key={context.id}
+          className="flex min-w-0 items-start gap-2 rounded-lg border border-border bg-muted/40 px-2.5 py-2 text-foreground"
+        >
+          <Quote
+            aria-hidden="true"
+            className="mt-0.5 icon-paired shrink-0 text-muted-foreground"
+          />
+          <div className="min-w-0 flex-1">
+            <div className="text-ui-sm font-medium text-foreground">Response excerpt</div>
+            <div className="line-clamp-2 text-ui-sm text-muted-foreground">
+              {selectedResponseContextPreview(context.text)}
+            </div>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className="-mr-1 -mt-1 size-6 shrink-0 rounded-md"
+            aria-label="Remove response excerpt"
+            title="Remove response excerpt"
+            onPointerDown={(event) => event.preventDefault()}
+            onClick={() => onRemove(context.id)}
+          >
+            <X aria-hidden="true" className="icon-control" />
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/ChatTranscriptView.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/ChatTranscriptView.tsx
@@ -8,6 +8,7 @@ import { ChatContentSearchQueryContext } from "./ChatContentSearchContext";
 import { useChatTranscriptCopySelection } from "#product/hooks/chat/ui/use-chat-transcript-copy-selection";
 import { useChatTranscriptRowRenderer } from "#product/hooks/chat/ui/use-chat-transcript-row-renderer";
 import { useChatTranscriptViewModel } from "#product/hooks/chat/ui/use-chat-transcript-view-model";
+import { ConnectedSelectedResponseActionMenu } from "#product/components/workspace/chat/transcript/SelectedResponseActionMenu";
 
 const noop = () => {};
 const NOOP_OUTBOX_ACTIONS: ChatTranscriptOutboxActions = {
@@ -35,7 +36,7 @@ export function ChatTranscriptView({
     renderTurnTrailingStatus,
   });
 
-  useChatTranscriptCopySelection({
+  const transcriptSelection = useChatTranscriptCopySelection({
     selectionRootRef,
     transcript: model.transcript,
     visibleTurnIds: model.visibleTurnIds,
@@ -89,6 +90,13 @@ export function ChatTranscriptView({
         gutterClassName={model.gutterClassName}
         scrollHandleRef={scrollHandleRef}
       />
+      {transcriptSelection.selectedResponse ? (
+        <ConnectedSelectedResponseActionMenu
+          selection={transcriptSelection.selectedResponse}
+          focusRequestNonce={transcriptSelection.menuFocusRequestNonce}
+          onDismiss={transcriptSelection.dismissSelectedResponse}
+        />
+      ) : null}
     </ChatContentSearchQueryContext.Provider>
   );
 }

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/SelectedResponseActionMenu.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/SelectedResponseActionMenu.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  SelectedResponseActionMenu,
+  type SelectedResponseAction,
+} from "#product/components/workspace/chat/transcript/SelectedResponseActionMenu";
+import type { SelectedResponseSelection } from "#product/domain/chats/transcript/selected-response-context";
+
+vi.mock("#product/hooks/chat/workflows/use-selected-response-actions", () => ({
+  useSelectedResponseActions: () => ({
+    addToChat: vi.fn(),
+    moreDetails: vi.fn(),
+    askInSideChat: vi.fn(),
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("SelectedResponseActionMenu", () => {
+  it("exposes all actions and supports roving keyboard focus", async () => {
+    const onAction = vi.fn<(action: SelectedResponseAction) => void>();
+    renderMenu({ focusRequestNonce: 1, onAction });
+
+    const items = await screen.findAllByRole("menuitem");
+    expect(items.map((item) => item.textContent)).toEqual([
+      "Add to chat",
+      "More details",
+      "Ask in side chat",
+    ]);
+    expect(items.map((item) => item.tabIndex)).toEqual([0, -1, -1]);
+    await waitFor(() => expect(document.activeElement).toBe(items[0]));
+
+    fireEvent.keyDown(items[0]!, { key: "ArrowDown" });
+    expect(document.activeElement).toBe(items[1]);
+    expect(items.map((item) => item.tabIndex)).toEqual([-1, 0, -1]);
+    fireEvent.click(items[2]!);
+    expect(onAction).toHaveBeenCalledWith("side-chat");
+  });
+
+  it("dismisses on Escape", async () => {
+    const onEscape = vi.fn();
+    renderMenu({ onEscape });
+    const menu = await screen.findByRole("menu", { name: "Selected response actions" });
+
+    fireEvent.keyDown(menu, { key: "Escape" });
+    expect(onEscape).toHaveBeenCalledOnce();
+  });
+});
+
+function renderMenu({
+  focusRequestNonce = 0,
+  onAction = vi.fn(),
+  onDismiss = vi.fn(),
+  onEscape = vi.fn(),
+}: {
+  focusRequestNonce?: number;
+  onAction?: (action: SelectedResponseAction) => void;
+  onDismiss?: () => void;
+  onEscape?: () => void;
+} = {}) {
+  return render(
+    <SelectedResponseActionMenu
+      selection={selection}
+      focusRequestNonce={focusRequestNonce}
+      onAction={onAction}
+      onDismiss={onDismiss}
+      onEscape={onEscape}
+    />,
+  );
+}
+
+const selection: SelectedResponseSelection = {
+  text: "Selected response",
+  anchorRect: {
+    x: 100,
+    y: 120,
+    width: 160,
+    height: 24,
+    top: 120,
+    right: 260,
+    bottom: 144,
+    left: 100,
+  },
+};

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/SelectedResponseActionMenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/SelectedResponseActionMenu.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { MessageCircleQuestion, MessageSquarePlus, MessagesSquare } from "lucide-react";
+import { CHAT_SELECTED_RESPONSE_ACTIONS } from "#product/copy/chat/chat-copy";
+import type { SelectedResponseSelection } from "#product/domain/chats/transcript/selected-response-context";
+import { useSelectedResponseActions } from "#product/hooks/chat/workflows/use-selected-response-actions";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from "#product/primitives/Popover";
+import { PopoverMenuItem } from "#product/primitives/PopoverMenuItem";
+
+export type SelectedResponseAction = "add-to-chat" | "more-details" | "side-chat";
+
+export function ConnectedSelectedResponseActionMenu({
+  selection,
+  focusRequestNonce,
+  onDismiss,
+}: {
+  selection: SelectedResponseSelection;
+  focusRequestNonce: number;
+  onDismiss: (options?: {
+    clearNativeSelection?: boolean;
+    restoreTranscriptFocus?: boolean;
+  }) => void;
+}) {
+  const actions = useSelectedResponseActions();
+  const handleAction = (action: SelectedResponseAction) => {
+    onDismiss({ clearNativeSelection: true });
+    if (action === "add-to-chat") {
+      actions.addToChat(selection.text);
+    } else if (action === "more-details") {
+      actions.moreDetails(selection.text);
+    } else {
+      actions.askInSideChat(selection.text);
+    }
+  };
+
+  return (
+    <SelectedResponseActionMenu
+      selection={selection}
+      focusRequestNonce={focusRequestNonce}
+      onAction={handleAction}
+      onDismiss={() => onDismiss()}
+      onEscape={() => onDismiss({ restoreTranscriptFocus: true })}
+    />
+  );
+}
+
+export function SelectedResponseActionMenu({
+  selection,
+  focusRequestNonce,
+  onAction,
+  onDismiss,
+  onEscape,
+}: {
+  selection: SelectedResponseSelection;
+  focusRequestNonce: number;
+  onAction: (action: SelectedResponseAction) => void;
+  onDismiss: () => void;
+  onEscape: () => void;
+}) {
+  const selectionRef = useRef(selection);
+  selectionRef.current = selection;
+  const virtualAnchorRef = useRef({
+    getBoundingClientRect: (): DOMRect => {
+      const rect = selectionRef.current.anchorRect;
+      return new DOMRect(rect.x, rect.y, rect.width, rect.height);
+    },
+  });
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const [activeItemIndex, setActiveItemIndex] = useState(0);
+
+  useEffect(() => {
+    if (focusRequestNonce <= 0) {
+      return;
+    }
+    const frameId = window.requestAnimationFrame(() => {
+      setActiveItemIndex(0);
+      itemRefs.current[0]?.focus({ preventScroll: true });
+    });
+    return () => window.cancelAnimationFrame(frameId);
+  }, [focusRequestNonce]);
+
+  const handleItemKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    const currentIndex = itemRefs.current.indexOf(event.currentTarget);
+    let nextIndex: number | null = null;
+    if (event.key === "ArrowDown" || event.key === "ArrowRight") {
+      nextIndex = (currentIndex + 1) % itemRefs.current.length;
+    } else if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
+      nextIndex = (currentIndex - 1 + itemRefs.current.length) % itemRefs.current.length;
+    } else if (event.key === "Home") {
+      nextIndex = 0;
+    } else if (event.key === "End") {
+      nextIndex = itemRefs.current.length - 1;
+    }
+    if (nextIndex !== null) {
+      event.preventDefault();
+      setActiveItemIndex(nextIndex);
+      itemRefs.current[nextIndex]?.focus();
+    }
+  };
+
+  const items: Array<{
+    action: SelectedResponseAction;
+    label: string;
+    icon: typeof MessageSquarePlus;
+  }> = [
+    {
+      action: "add-to-chat",
+      label: CHAT_SELECTED_RESPONSE_ACTIONS.addToChat,
+      icon: MessageSquarePlus,
+    },
+    {
+      action: "more-details",
+      label: CHAT_SELECTED_RESPONSE_ACTIONS.moreDetails,
+      icon: MessageCircleQuestion,
+    },
+    {
+      action: "side-chat",
+      label: CHAT_SELECTED_RESPONSE_ACTIONS.askInSideChat,
+      icon: MessagesSquare,
+    },
+  ];
+
+  return (
+    <Popover open onOpenChange={(open) => { if (!open) onDismiss(); }}>
+      <PopoverAnchor virtualRef={virtualAnchorRef} />
+      <PopoverContent
+        variant="menu"
+        role="menu"
+        aria-label={CHAT_SELECTED_RESPONSE_ACTIONS.menuLabel}
+        data-selected-response-actions
+        side="top"
+        align="center"
+        sideOffset={8}
+        collisionPadding={8}
+        sticky="always"
+        updatePositionStrategy="always"
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        onCloseAutoFocus={(event) => event.preventDefault()}
+        onEscapeKeyDown={(event) => {
+          event.preventDefault();
+          onEscape();
+        }}
+      >
+        {items.map((item, index) => {
+          const Icon = item.icon;
+          return (
+            <PopoverMenuItem
+              key={item.action}
+              ref={(node) => { itemRefs.current[index] = node; }}
+              role="menuitem"
+              tabIndex={activeItemIndex === index ? 0 : -1}
+              label={item.label}
+              icon={<Icon aria-hidden="true" className="icon-paired" />}
+              onPointerDown={(event) => event.preventDefault()}
+              onFocus={() => setActiveItemIndex(index)}
+              onKeyDown={handleItemKeyDown}
+              onClick={() => onAction(item.action)}
+            />
+          );
+        })}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/packages/product-client/src/copy/chat/chat-copy.ts
+++ b/apps/packages/product-client/src/copy/chat/chat-copy.ts
@@ -5,6 +5,19 @@ export const CHAT_COMPOSER_LABELS = {
   stop: "Stop run",
 } as const;
 
+export const CHAT_SELECTED_RESPONSE_ACTIONS = {
+  menuLabel: "Selected response actions",
+  addToChat: "Add to chat",
+  moreDetails: "More details",
+  askInSideChat: "Ask in side chat",
+  moreDetailsPrompt: "Explain this selected response text in more detail.",
+  sideChatPrompt: "Help me understand this selected response text.",
+} as const;
+
+export const CHAT_PROMPT_FEEDBACK = {
+  currentModelUnavailable: "The current chat model isn't available for a new conversation.",
+} as const;
+
 // Labels for the animated streaming/status indicator. Dispatch and agent work
 // both read as "Thinking" — the send/queue distinction is plumbing the user
 // shouldn't have to care about, and one voice keeps the status line calm.

--- a/apps/packages/product-client/src/domain/chats/transcript/selected-response-context.test.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/selected-response-context.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPromptWithSelectedResponseContexts,
+  selectedResponseContextPreview,
+} from "./selected-response-context";
+
+describe("selected response context", () => {
+  it("builds one explicit quoted context in every prompt representation", () => {
+    const selectedText = "First line\nSecond line";
+    const payload = buildPromptWithSelectedResponseContexts(
+      "Explain this in more detail.",
+      [{ text: selectedText }],
+    );
+
+    const expected = [
+      "Explain this in more detail.",
+      "",
+      "Selected response text:",
+      "",
+      "> First line",
+      "> Second line",
+    ].join("\n");
+    expect(payload).toEqual({
+      text: expected,
+      blocks: [{ type: "text", text: expected }],
+      optimisticContentParts: [{ type: "text", text: expected }],
+    });
+    expect(payload.text.match(/First line/gu)).toHaveLength(1);
+    expect(payload.text.match(/Second line/gu)).toHaveLength(1);
+  });
+
+  it("keeps each attached response excerpt exactly once", () => {
+    const payload = buildPromptWithSelectedResponseContexts("What differs?", [
+      { text: "alpha" },
+      { text: "beta" },
+    ]);
+
+    expect(payload.text.match(/alpha/gu)).toHaveLength(1);
+    expect(payload.text.match(/beta/gu)).toHaveLength(1);
+    expect(payload.blocks).toHaveLength(1);
+  });
+
+  it("truncates only the visual preview", () => {
+    const selectedText = `start ${"context ".repeat(40)}finish`;
+    const preview = selectedResponseContextPreview(selectedText);
+    const payload = buildPromptWithSelectedResponseContexts("", [{ text: selectedText }]);
+
+    expect(preview.length).toBeLessThan(selectedText.length);
+    expect(preview.endsWith("...")).toBe(true);
+    expect(payload.text).toContain(selectedText);
+  });
+});

--- a/apps/packages/product-client/src/domain/chats/transcript/selected-response-context.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/selected-response-context.ts
@@ -1,0 +1,62 @@
+export interface SelectedResponseContext {
+  id: string;
+  text: string;
+}
+
+export interface SelectedResponseAnchorRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
+export interface SelectedResponseSelection {
+  text: string;
+  anchorRect: SelectedResponseAnchorRect;
+}
+
+export interface SelectedResponsePromptPayload {
+  text: string;
+  blocks: Array<{ type: "text"; text: string }>;
+  optimisticContentParts: Array<{ type: "text"; text: string }>;
+}
+
+const SELECTED_RESPONSE_PREVIEW_CHARACTER_LIMIT = 220;
+
+export function selectedResponseContextPreview(text: string): string {
+  const compact = text.replace(/\s+/gu, " ").trim();
+  if (compact.length <= SELECTED_RESPONSE_PREVIEW_CHARACTER_LIMIT) {
+    return compact;
+  }
+
+  return `${compact.slice(0, SELECTED_RESPONSE_PREVIEW_CHARACTER_LIMIT - 3).trimEnd()}...`;
+}
+
+export function buildPromptWithSelectedResponseContexts(
+  promptText: string,
+  contexts: readonly Pick<SelectedResponseContext, "text">[],
+): SelectedResponsePromptPayload {
+  const sections = [
+    promptText.trim(),
+    ...contexts.map((context) => formatSelectedResponseContext(context.text)),
+  ].filter((section) => section.length > 0);
+  const text = sections.join("\n\n");
+
+  return {
+    text,
+    blocks: text ? [{ type: "text", text }] : [],
+    optimisticContentParts: text ? [{ type: "text", text }] : [],
+  };
+}
+
+function formatSelectedResponseContext(text: string): string {
+  const quoted = text
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n");
+  return `Selected response text:\n\n${quoted}`;
+}

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-selection.test.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-selection.test.ts
@@ -43,11 +43,17 @@ describe("transcript selection decisions", () => {
 
   it("sets ownership only from unblocked transcript targets", () => {
     expect(resolvePointerOwnership(target({ insideRoot: true }))).toBe("set-owned");
+    expect(resolvePointerOwnership(target({ contextualActions: true }))).toBe("ignore");
     expect(resolvePointerOwnership(target({ insideRoot: false }))).toBe("clear-owned");
     expect(resolvePointerOwnership(target({ insideRoot: true, textEntry: true }))).toBe("clear-owned");
     expect(resolvePointerOwnership(target({ insideRoot: true, terminalZone: true }))).toBe("clear-owned");
     expect(resolvePointerOwnership(target({ insideRoot: true, nativeInteractive: true }))).toBe("clear-owned");
     expect(resolvePointerOwnership(target({ insideRoot: true, ariaInteractive: true }))).toBe("clear-owned");
+    expect(resolvePointerOwnership(target({
+      insideRoot: true,
+      nativeInteractive: true,
+      selectableInteractiveText: true,
+    }))).toBe("track-selection");
   });
 
   it("treats ignored controls as chrome without blocking body descendants", () => {

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-selection.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-selection.ts
@@ -8,6 +8,8 @@ export interface TranscriptKeyboardEventLike {
 
 export interface TranscriptTargetFacts {
   insideRoot: boolean;
+  contextualActions: boolean;
+  selectableInteractiveText: boolean;
   textEntry: boolean;
   terminalZone: boolean;
   ignoredChrome: boolean;
@@ -15,7 +17,11 @@ export interface TranscriptTargetFacts {
   ariaInteractive: boolean;
 }
 
-export type TranscriptPointerOwnershipAction = "set-owned" | "clear-owned";
+export type TranscriptPointerOwnershipAction =
+  | "set-owned"
+  | "track-selection"
+  | "clear-owned"
+  | "ignore";
 export type TranscriptPrimaryAAction = "select-root" | "clear-owned" | "ignore";
 export type TranscriptSelectionClampEdge = "start" | "end";
 
@@ -28,6 +34,8 @@ export type TranscriptCopyAction = "copy-semantic" | "clear-owned" | "ignore";
 
 export const EMPTY_TRANSCRIPT_TARGET_FACTS: TranscriptTargetFacts = {
   insideRoot: false,
+  contextualActions: false,
+  selectableInteractiveText: false,
   textEntry: false,
   terminalZone: false,
   ignoredChrome: false,
@@ -68,6 +76,18 @@ export function isValidTranscriptKeyboardTarget(
 export function resolvePointerOwnership(
   target: TranscriptTargetFacts,
 ): TranscriptPointerOwnershipAction {
+  if (target.contextualActions) {
+    return "ignore";
+  }
+  if (
+    target.insideRoot
+    && target.selectableInteractiveText
+    && !target.textEntry
+    && !target.terminalZone
+    && !target.ignoredChrome
+  ) {
+    return "track-selection";
+  }
   return target.insideRoot && !isBlockedTranscriptTarget(target)
     ? "set-owned"
     : "clear-owned";

--- a/apps/packages/product-client/src/hooks/chat/derived/use-chat-availability-state.ts
+++ b/apps/packages/product-client/src/hooks/chat/derived/use-chat-availability-state.ts
@@ -17,6 +17,7 @@ import { useSessionTranscriptStore } from "#product/stores/sessions/session-tran
 import {
   resolveWorkspaceSessionRecoverySendBlockedReason,
 } from "#product/lib/domain/workspaces/selection/session-recovery";
+import type { ModelSelectorSelection } from "#product/lib/domain/chat/models/model-selector-types";
 
 export type ChatAvailabilityState = ChatInputAvailabilityState;
 
@@ -24,6 +25,12 @@ export type ChatAvailabilityState = ChatInputAvailabilityState;
 // pure chat-input resolver; this hook only gathers React state.
 export function useChatAvailabilityState(options?: {
   activeSessionId?: string | null;
+  activeLaunchSelection?: ModelSelectorSelection | null;
+  launchReadiness?: {
+    isLoading: boolean;
+    isReady: boolean;
+    disabledReason: string | null;
+  };
 }): ChatAvailabilityState {
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
   const pendingWorkspaceEntry = useSessionSelectionStore((state) => state.pendingWorkspaceEntry);
@@ -43,7 +50,8 @@ export function useChatAvailabilityState(options?: {
   });
   const { data: workspaceCollections } = useWorkspaces();
   const selectedCloudRuntime = useSelectedCloudRuntimeState();
-  const configuredLaunch = useConfiguredLaunchReadiness();
+  const configuredLaunch = useConfiguredLaunchReadiness(options?.activeLaunchSelection ?? null);
+  const launchReadiness = options?.launchReadiness ?? configuredLaunch;
 
   const selectedCloudWorkspaceId = parseCloudWorkspaceSyntheticId(selectedWorkspaceId);
   const selectedLocalWorkspace = selectedCloudWorkspaceId === null
@@ -67,9 +75,9 @@ export function useChatAvailabilityState(options?: {
     selectedCloudRuntimePhase: selectedCloudRuntime.state?.phase ?? null,
     selectedCloudRuntimeActionBlockReason: selectedCloudRuntime.state?.actionBlockReason ?? null,
     activeSessionId,
-    isConfiguredLaunchLoading: configuredLaunch.isLoading,
-    hasReadyConfiguredLaunch: configuredLaunch.isReady,
-    configuredLaunchDisabledReason: configuredLaunch.disabledReason,
+    isConfiguredLaunchLoading: launchReadiness.isLoading,
+    hasReadyConfiguredLaunch: launchReadiness.isReady,
+    configuredLaunchDisabledReason: launchReadiness.disabledReason,
     sessionRecoverySendReason:
       workspaceSessionRecovery?.sessionId === activeSessionId
         ? resolveWorkspaceSessionRecoverySendBlockedReason(
@@ -81,9 +89,9 @@ export function useChatAvailabilityState(options?: {
   }), [
     activeSessionId,
     connectionState,
-    configuredLaunch.disabledReason,
-    configuredLaunch.isLoading,
-    configuredLaunch.isReady,
+    launchReadiness.disabledReason,
+    launchReadiness.isLoading,
+    launchReadiness.isReady,
     pendingWorkspaceEntry,
     primaryPendingInteractionKind,
     selectedCloudRuntime.state?.actionBlockReason,

--- a/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-selection-handlers.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-selection-handlers.ts
@@ -1,0 +1,301 @@
+import type { RefObject } from "react";
+import {
+  isPrimarySelectAllEvent,
+  resolveCopyAction,
+  resolvePointerOwnership,
+  resolvePrimaryAAction,
+  resolveSelectionChangeAction,
+  type TranscriptSelectionClampEdge,
+  type TranscriptTargetFacts,
+} from "#product/domain/chats/transcript/transcript-selection";
+import type {
+  SelectedResponseSelection,
+} from "#product/domain/chats/transcript/selected-response-context";
+
+interface TranscriptSelectionListenerTargets {
+  windowTarget: Pick<Window, "addEventListener" | "removeEventListener">;
+  documentTarget: Pick<Document, "addEventListener" | "removeEventListener">;
+}
+
+interface TranscriptSelectionListenerHandlers {
+  pointerdown: (event: PointerEvent) => void;
+  pointerup: () => void;
+  keydown: (event: KeyboardEvent) => void;
+  copy: (event: ClipboardEvent) => void;
+  selectionchange: () => void;
+  scroll: () => void;
+}
+
+interface MutableBooleanRef {
+  current: boolean;
+}
+
+interface ChatTranscriptSelectionHandlerArgs {
+  rootRef: RefObject<HTMLElement | null>;
+  getCopyText: () => string;
+  transcriptOwnedRef: MutableBooleanRef;
+  allTranscriptSelectedRef: MutableBooleanRef;
+  pointerSelectingRef: MutableBooleanRef;
+  getActiveElement: () => EventTarget | null;
+  getSelection: () => Selection | null;
+  getTargetFactsForEvent: (
+    target: EventTarget | null,
+    root: HTMLElement | null,
+  ) => TranscriptTargetFacts;
+  focusRoot: (root: HTMLElement) => void;
+  setFullSelectionMarker: (root: HTMLElement) => void;
+  isFullSelectionMarker: (selection: Selection, root: HTMLElement) => boolean;
+  isExactRootSelection: (selection: Selection, root: HTMLElement) => boolean;
+  nodeInsideRoot: (node: Node | null, root: HTMLElement) => boolean;
+  getSelectionDirection: (selection: Selection) => "forward" | "backward";
+  clampSelectionToRoot: (
+    selection: Selection,
+    root: HTMLElement,
+    edge: TranscriptSelectionClampEdge,
+  ) => void;
+  getSelectedResponse: (
+    selection: Selection,
+    root: HTMLElement,
+  ) => SelectedResponseSelection | null;
+  isSelectedResponseVisible: (
+    selection: SelectedResponseSelection,
+    root: HTMLElement,
+  ) => boolean;
+  setSelectedResponse: (selection: SelectedResponseSelection | null) => void;
+  hasSelectedResponse: () => boolean;
+  requestSelectedResponseMenuFocus: () => void;
+  dismissSelectedResponse: (restoreTranscriptFocus: boolean) => void;
+}
+
+export function attachChatTranscriptSelectionListeners(
+  targets: TranscriptSelectionListenerTargets,
+  handlers: TranscriptSelectionListenerHandlers,
+): () => void {
+  targets.windowTarget.addEventListener("pointerdown", handlers.pointerdown, { capture: true });
+  targets.windowTarget.addEventListener("pointerup", handlers.pointerup, { capture: true });
+  targets.windowTarget.addEventListener("pointercancel", handlers.pointerup, { capture: true });
+  targets.windowTarget.addEventListener("keydown", handlers.keydown, { capture: true });
+  targets.windowTarget.addEventListener("copy", handlers.copy, { capture: true });
+  targets.windowTarget.addEventListener("scroll", handlers.scroll, { capture: true });
+  targets.documentTarget.addEventListener("selectionchange", handlers.selectionchange);
+
+  return () => {
+    targets.windowTarget.removeEventListener("pointerdown", handlers.pointerdown, { capture: true });
+    targets.windowTarget.removeEventListener("pointerup", handlers.pointerup, { capture: true });
+    targets.windowTarget.removeEventListener("pointercancel", handlers.pointerup, { capture: true });
+    targets.windowTarget.removeEventListener("keydown", handlers.keydown, { capture: true });
+    targets.windowTarget.removeEventListener("copy", handlers.copy, { capture: true });
+    targets.windowTarget.removeEventListener("scroll", handlers.scroll, { capture: true });
+    targets.documentTarget.removeEventListener("selectionchange", handlers.selectionchange);
+  };
+}
+
+export function createChatTranscriptSelectionHandlers({
+  rootRef,
+  getCopyText,
+  transcriptOwnedRef,
+  allTranscriptSelectedRef,
+  pointerSelectingRef,
+  getActiveElement,
+  getSelection,
+  getTargetFactsForEvent,
+  focusRoot,
+  setFullSelectionMarker,
+  isFullSelectionMarker,
+  isExactRootSelection: isExactRootSelectionForRoot,
+  nodeInsideRoot: nodeInsideRootForRoot,
+  getSelectionDirection: getSelectionDirectionForSelection,
+  clampSelectionToRoot: clampSelectionToRootForSelection,
+  getSelectedResponse,
+  isSelectedResponseVisible,
+  setSelectedResponse,
+  hasSelectedResponse,
+  requestSelectedResponseMenuFocus,
+  dismissSelectedResponse,
+}: ChatTranscriptSelectionHandlerArgs): TranscriptSelectionListenerHandlers {
+  const clearSelectionState = () => {
+    transcriptOwnedRef.current = false;
+    allTranscriptSelectedRef.current = false;
+  };
+
+  const pointerdown = (event: PointerEvent) => {
+    const root = rootRef.current;
+    const targetFacts = getTargetFactsForEvent(event.target, root);
+    const action = resolvePointerOwnership(targetFacts);
+    if (action === "ignore") {
+      return;
+    }
+    if (action === "track-selection") {
+      pointerSelectingRef.current = true;
+      setSelectedResponse(null);
+      clearSelectionState();
+      return;
+    }
+    if (action === "set-owned" && root) {
+      pointerSelectingRef.current = true;
+      transcriptOwnedRef.current = true;
+      allTranscriptSelectedRef.current = false;
+      setSelectedResponse(null);
+      focusRoot(root);
+      return;
+    }
+    pointerSelectingRef.current = false;
+    setSelectedResponse(null);
+    clearSelectionState();
+  };
+
+  const publishSelectedResponse = () => {
+    const root = rootRef.current;
+    const selection = getSelection();
+    setSelectedResponse(
+      root && selection
+        ? getSelectedResponse(selection, root)
+        : null,
+    );
+  };
+
+  const pointerup = () => {
+    if (!pointerSelectingRef.current) {
+      return;
+    }
+    pointerSelectingRef.current = false;
+    publishSelectedResponse();
+  };
+
+  const keydown = (event: KeyboardEvent) => {
+    if (hasSelectedResponse() && event.key === "Escape") {
+      event.preventDefault();
+      dismissSelectedResponse(true);
+      return;
+    }
+    if (
+      hasSelectedResponse()
+      && (event.key === "ContextMenu" || (event.key === "F10" && event.shiftKey))
+    ) {
+      event.preventDefault();
+      requestSelectedResponseMenuFocus();
+      return;
+    }
+    const root = rootRef.current;
+    const action = resolvePrimaryAAction({
+      owned: transcriptOwnedRef.current,
+      isSelectAll: isPrimarySelectAllEvent(event, isApplePlatform()),
+      defaultPrevented: event.defaultPrevented,
+      eventTarget: getTargetFactsForEvent(event.target, root),
+      activeTarget: getTargetFactsForEvent(getActiveElement(), root),
+    });
+
+    if (action === "ignore") {
+      return;
+    }
+    if (action === "clear-owned") {
+      clearSelectionState();
+      return;
+    }
+    if (!root) {
+      clearSelectionState();
+      return;
+    }
+
+    event.preventDefault();
+    setFullSelectionMarker(root);
+    transcriptOwnedRef.current = true;
+    allTranscriptSelectedRef.current = true;
+  };
+
+  const selectionchange = () => {
+    const root = rootRef.current;
+    const selection = getSelection();
+    if (!root || !selection || selection.rangeCount === 0) {
+      allTranscriptSelectedRef.current = false;
+      setSelectedResponse(null);
+      return;
+    }
+
+    if (
+      allTranscriptSelectedRef.current
+      && isFullSelectionMarker(selection, root)
+    ) {
+      setSelectedResponse(null);
+      return;
+    }
+
+    const exactRootSelection = isExactRootSelectionForRoot(selection, root);
+    const action = resolveSelectionChangeAction({
+      owned: transcriptOwnedRef.current,
+      anchorInsideRoot: nodeInsideRootForRoot(selection.anchorNode, root),
+      focusInsideRoot: nodeInsideRootForRoot(selection.focusNode, root),
+      exactRootSelection,
+      direction: getSelectionDirectionForSelection(selection),
+    });
+
+    if (action.clearFullSelection) {
+      allTranscriptSelectedRef.current = false;
+    }
+    if (action.clampEdge) {
+      clampSelectionToRootForSelection(selection, root, action.clampEdge);
+    }
+    if (!pointerSelectingRef.current) {
+      publishSelectedResponse();
+    }
+  };
+
+  const scroll = () => {
+    if (!hasSelectedResponse()) {
+      return;
+    }
+    const root = rootRef.current;
+    const selection = getSelection();
+    const selectedResponse = root && selection
+      ? getSelectedResponse(selection, root)
+      : null;
+    setSelectedResponse(
+      selectedResponse && root && isSelectedResponseVisible(selectedResponse, root)
+        ? selectedResponse
+        : null,
+    );
+  };
+
+  const copy = (event: ClipboardEvent) => {
+    const root = rootRef.current;
+    const selection = getSelection();
+    const action = resolveCopyAction({
+      fullRootSelected: !!root
+        && !!selection
+        && allTranscriptSelectedRef.current
+        && isFullSelectionMarker(selection, root),
+      eventTarget: getTargetFactsForEvent(event.target, root),
+      activeTarget: getTargetFactsForEvent(getActiveElement(), root),
+    });
+
+    if (action === "ignore") {
+      return;
+    }
+    if (action === "clear-owned") {
+      clearSelectionState();
+      return;
+    }
+    if (!event.clipboardData) {
+      return;
+    }
+
+    event.clipboardData.setData("text/plain", getCopyText());
+    event.preventDefault();
+  };
+
+  return {
+    pointerdown,
+    pointerup,
+    keydown,
+    copy,
+    selectionchange,
+    scroll,
+  };
+}
+
+function isApplePlatform(): boolean {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+  return /mac|iphone|ipad|ipod/iu.test(navigator.platform);
+}

--- a/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-selection.test.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-selection.test.ts
@@ -73,15 +73,20 @@ describe("attachChatTranscriptSelectionListeners", () => {
       documentTarget: documentTarget.target,
     }, {
       pointerdown: vi.fn(),
+      pointerup: vi.fn(),
       keydown: vi.fn(),
       copy: vi.fn(),
       selectionchange: vi.fn(),
+      scroll: vi.fn(),
     });
 
     expect(windowTarget.addCalls).toEqual([
       { type: "pointerdown", options: { capture: true } },
+      { type: "pointerup", options: { capture: true } },
+      { type: "pointercancel", options: { capture: true } },
       { type: "keydown", options: { capture: true } },
       { type: "copy", options: { capture: true } },
+      { type: "scroll", options: { capture: true } },
     ]);
     expect(documentTarget.addCalls).toEqual([
       { type: "selectionchange", options: undefined },
@@ -91,8 +96,11 @@ describe("attachChatTranscriptSelectionListeners", () => {
 
     expect(windowTarget.removeCalls).toEqual([
       { type: "pointerdown", options: { capture: true } },
+      { type: "pointerup", options: { capture: true } },
+      { type: "pointercancel", options: { capture: true } },
       { type: "keydown", options: { capture: true } },
       { type: "copy", options: { capture: true } },
+      { type: "scroll", options: { capture: true } },
     ]);
     expect(documentTarget.removeCalls).toEqual([
       { type: "selectionchange", options: undefined },
@@ -112,6 +120,7 @@ describe("createChatTranscriptSelectionHandlers", () => {
       getCopyText: () => "semantic transcript",
       transcriptOwnedRef: { current: false },
       allTranscriptSelectedRef: { current: false },
+      pointerSelectingRef: { current: false },
       getActiveElement: () => transcriptTarget,
       getSelection: () => selection,
       getTargetFactsForEvent: (target) =>
@@ -125,6 +134,12 @@ describe("createChatTranscriptSelectionHandlers", () => {
       nodeInsideRoot: () => false,
       getSelectionDirection: () => "forward",
       clampSelectionToRoot: vi.fn(),
+      getSelectedResponse: () => null,
+      isSelectedResponseVisible: () => true,
+      setSelectedResponse: vi.fn(),
+      hasSelectedResponse: () => false,
+      requestSelectedResponseMenuFocus: vi.fn(),
+      dismissSelectedResponse: vi.fn(),
     });
 
     handlers.pointerdown({ target: transcriptTarget } as PointerEvent);
@@ -156,6 +171,7 @@ describe("createChatTranscriptSelectionHandlers", () => {
       getCopyText: () => "semantic transcript",
       transcriptOwnedRef: owned,
       allTranscriptSelectedRef: fullSelection,
+      pointerSelectingRef: { current: false },
       getActiveElement: () => textEntryTarget,
       getSelection: () => ({ rangeCount: 1 } as Selection),
       getTargetFactsForEvent: (target) => {
@@ -172,6 +188,12 @@ describe("createChatTranscriptSelectionHandlers", () => {
       nodeInsideRoot: () => false,
       getSelectionDirection: () => "forward",
       clampSelectionToRoot: vi.fn(),
+      getSelectedResponse: () => null,
+      isSelectedResponseVisible: () => true,
+      setSelectedResponse: vi.fn(),
+      hasSelectedResponse: () => false,
+      requestSelectedResponseMenuFocus: vi.fn(),
+      dismissSelectedResponse: vi.fn(),
     });
 
     handlers.pointerdown({ target: transcriptTarget } as PointerEvent);
@@ -205,6 +227,7 @@ describe("createChatTranscriptSelectionHandlers", () => {
       getCopyText: () => "semantic transcript",
       transcriptOwnedRef: { current: false },
       allTranscriptSelectedRef: { current: false },
+      pointerSelectingRef: { current: false },
       getActiveElement: () => transcriptTarget,
       getSelection: () => selection,
       getTargetFactsForEvent: (target) =>
@@ -216,6 +239,12 @@ describe("createChatTranscriptSelectionHandlers", () => {
       nodeInsideRoot: (node) => node === anchor,
       getSelectionDirection: () => "forward",
       clampSelectionToRoot,
+      getSelectedResponse: () => null,
+      isSelectedResponseVisible: () => true,
+      setSelectedResponse: vi.fn(),
+      hasSelectedResponse: () => false,
+      requestSelectedResponseMenuFocus: vi.fn(),
+      dismissSelectedResponse: vi.fn(),
     });
 
     handlers.selectionchange();
@@ -224,5 +253,188 @@ describe("createChatTranscriptSelectionHandlers", () => {
     handlers.pointerdown({ target: transcriptTarget } as PointerEvent);
     handlers.selectionchange();
     expect(clampSelectionToRoot).toHaveBeenCalledWith(selection, root, "end");
+  });
+
+  it("publishes an assistant selection after pointer selection and dismisses it on scroll", () => {
+    const root = {} as HTMLElement;
+    const transcriptTarget = {} as EventTarget;
+    const linkTarget = {} as EventTarget;
+    const selection = { rangeCount: 1 } as Selection;
+    const selectedResponse = {
+      text: "selected response",
+      anchorRect: {
+        x: 1,
+        y: 2,
+        width: 3,
+        height: 4,
+        top: 2,
+        right: 4,
+        bottom: 6,
+        left: 1,
+      },
+    };
+    const setSelectedResponse = vi.fn();
+    let hasSelectedResponse = false;
+    let isSelectedResponseVisible = true;
+    const handlers = createChatTranscriptSelectionHandlers({
+      rootRef: { current: root },
+      getCopyText: () => "semantic transcript",
+      transcriptOwnedRef: { current: false },
+      allTranscriptSelectedRef: { current: false },
+      pointerSelectingRef: { current: false },
+      getActiveElement: () => transcriptTarget,
+      getSelection: () => selection,
+      getTargetFactsForEvent: (target) => {
+        if (target === transcriptTarget) return facts({ insideRoot: true });
+        if (target === linkTarget) {
+          return facts({
+            insideRoot: true,
+            nativeInteractive: true,
+            selectableInteractiveText: true,
+          });
+        }
+        return facts();
+      },
+      focusRoot: vi.fn(),
+      setFullSelectionMarker: vi.fn(),
+      isFullSelectionMarker: () => false,
+      isExactRootSelection: () => false,
+      nodeInsideRoot: () => true,
+      getSelectionDirection: () => "forward",
+      clampSelectionToRoot: vi.fn(),
+      getSelectedResponse: () => selectedResponse,
+      isSelectedResponseVisible: () => isSelectedResponseVisible,
+      setSelectedResponse: (value) => {
+        hasSelectedResponse = value !== null;
+        setSelectedResponse(value);
+      },
+      hasSelectedResponse: () => hasSelectedResponse,
+      requestSelectedResponseMenuFocus: vi.fn(),
+      dismissSelectedResponse: vi.fn(),
+    });
+
+    handlers.pointerdown({ target: transcriptTarget } as PointerEvent);
+    handlers.selectionchange();
+    expect(setSelectedResponse).toHaveBeenLastCalledWith(null);
+
+    handlers.pointerup();
+    expect(setSelectedResponse).toHaveBeenLastCalledWith(selectedResponse);
+
+    handlers.pointerdown({ target: {} as EventTarget } as PointerEvent);
+    expect(setSelectedResponse).toHaveBeenLastCalledWith(null);
+
+    handlers.pointerdown({ target: linkTarget } as PointerEvent);
+    handlers.selectionchange();
+    expect(setSelectedResponse).toHaveBeenLastCalledWith(null);
+
+    handlers.pointerup();
+    expect(setSelectedResponse).toHaveBeenLastCalledWith(selectedResponse);
+
+    handlers.scroll();
+    expect(setSelectedResponse).toHaveBeenLastCalledWith(selectedResponse);
+
+    isSelectedResponseVisible = false;
+    handlers.scroll();
+    expect(setSelectedResponse).toHaveBeenLastCalledWith(null);
+  });
+
+  it("moves keyboard focus into an open menu and restores transcript focus on Escape", () => {
+    const root = {} as HTMLElement;
+    const requestSelectedResponseMenuFocus = vi.fn();
+    const dismissSelectedResponse = vi.fn();
+    const handlers = createChatTranscriptSelectionHandlers({
+      rootRef: { current: root },
+      getCopyText: () => "semantic transcript",
+      transcriptOwnedRef: { current: true },
+      allTranscriptSelectedRef: { current: false },
+      pointerSelectingRef: { current: false },
+      getActiveElement: () => root,
+      getSelection: () => ({ rangeCount: 1 } as Selection),
+      getTargetFactsForEvent: () => facts({ insideRoot: true }),
+      focusRoot: vi.fn(),
+      setFullSelectionMarker: vi.fn(),
+      isFullSelectionMarker: () => false,
+      isExactRootSelection: () => false,
+      nodeInsideRoot: () => true,
+      getSelectionDirection: () => "forward",
+      clampSelectionToRoot: vi.fn(),
+      getSelectedResponse: () => null,
+      isSelectedResponseVisible: () => true,
+      setSelectedResponse: vi.fn(),
+      hasSelectedResponse: () => true,
+      requestSelectedResponseMenuFocus,
+      dismissSelectedResponse,
+    });
+
+    const focusMenu = keydownEvent(root, {
+      key: "F10",
+      metaKey: false,
+      shiftKey: true,
+    });
+    handlers.keydown(focusMenu);
+    expect(focusMenu.preventDefault).toHaveBeenCalled();
+    expect(requestSelectedResponseMenuFocus).toHaveBeenCalledOnce();
+
+    const escape = keydownEvent(root, {
+      key: "Escape",
+      metaKey: false,
+    });
+    handlers.keydown(escape);
+    expect(escape.preventDefault).toHaveBeenCalled();
+    expect(dismissSelectedResponse).toHaveBeenCalledWith(true);
+  });
+
+  it("publishes keyboard selections and clears the menu with the native selection", () => {
+    const root = {} as HTMLElement;
+    const anchor = {} as Node;
+    let selection: Selection | null = {
+      rangeCount: 1,
+      anchorNode: anchor,
+      focusNode: anchor,
+    } as Selection;
+    const selectedResponse = {
+      text: "keyboard selection",
+      anchorRect: {
+        x: 1,
+        y: 2,
+        width: 3,
+        height: 4,
+        top: 2,
+        right: 4,
+        bottom: 6,
+        left: 1,
+      },
+    };
+    const setSelectedResponse = vi.fn();
+    const handlers = createChatTranscriptSelectionHandlers({
+      rootRef: { current: root },
+      getCopyText: () => "semantic transcript",
+      transcriptOwnedRef: { current: false },
+      allTranscriptSelectedRef: { current: false },
+      pointerSelectingRef: { current: false },
+      getActiveElement: () => root,
+      getSelection: () => selection,
+      getTargetFactsForEvent: () => facts({ insideRoot: true }),
+      focusRoot: vi.fn(),
+      setFullSelectionMarker: vi.fn(),
+      isFullSelectionMarker: () => false,
+      isExactRootSelection: () => false,
+      nodeInsideRoot: (node) => node === anchor,
+      getSelectionDirection: () => "forward",
+      clampSelectionToRoot: vi.fn(),
+      getSelectedResponse: () => selectedResponse,
+      isSelectedResponseVisible: () => true,
+      setSelectedResponse,
+      hasSelectedResponse: () => true,
+      requestSelectedResponseMenuFocus: vi.fn(),
+      dismissSelectedResponse: vi.fn(),
+    });
+
+    handlers.selectionchange();
+    expect(setSelectedResponse).toHaveBeenLastCalledWith(selectedResponse);
+
+    selection = null;
+    handlers.selectionchange();
+    expect(setSelectedResponse).toHaveBeenLastCalledWith(null);
   });
 });

--- a/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-selection.test.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-selection.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   attachChatTranscriptSelectionListeners,
   createChatTranscriptSelectionHandlers,
-} from "#product/hooks/chat/ui/chat-transcript-selection";
+} from "#product/hooks/chat/ui/chat-transcript-selection-handlers";
 import {
   EMPTY_TRANSCRIPT_TARGET_FACTS,
   type TranscriptSelectionClampEdge,

--- a/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-selection.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-selection.ts
@@ -1,7 +1,9 @@
 import {
+  useCallback,
   useEffect,
   useLayoutEffect,
   useRef,
+  useState,
   type RefObject,
 } from "react";
 import {
@@ -14,6 +16,13 @@ import {
   type TranscriptSelectionClampEdge,
   type TranscriptTargetFacts,
 } from "#product/domain/chats/transcript/transcript-selection";
+import type {
+  SelectedResponseSelection,
+} from "#product/domain/chats/transcript/selected-response-context";
+import {
+  getSelectedAssistantResponse,
+  isSelectedResponseInViewport,
+} from "#product/hooks/chat/ui/selected-response-selection";
 
 interface UseChatTranscriptSelectionArgs {
   rootRef: RefObject<HTMLElement | null>;
@@ -27,13 +36,24 @@ interface TranscriptSelectionListenerTargets {
 
 interface TranscriptSelectionListenerHandlers {
   pointerdown: (event: PointerEvent) => void;
+  pointerup: () => void;
   keydown: (event: KeyboardEvent) => void;
   copy: (event: ClipboardEvent) => void;
   selectionchange: () => void;
+  scroll: () => void;
 }
 
 interface MutableBooleanRef {
   current: boolean;
+}
+
+export interface ChatTranscriptSelectionState {
+  selectedResponse: SelectedResponseSelection | null;
+  menuFocusRequestNonce: number;
+  dismissSelectedResponse: (options?: {
+    clearNativeSelection?: boolean;
+    restoreTranscriptFocus?: boolean;
+  }) => void;
 }
 
 interface ChatTranscriptSelectionHandlerArgs {
@@ -41,6 +61,7 @@ interface ChatTranscriptSelectionHandlerArgs {
   getCopyText: () => string;
   transcriptOwnedRef: MutableBooleanRef;
   allTranscriptSelectedRef: MutableBooleanRef;
+  pointerSelectingRef: MutableBooleanRef;
   getActiveElement: () => EventTarget | null;
   getSelection: () => Selection | null;
   getTargetFactsForEvent: (
@@ -58,6 +79,18 @@ interface ChatTranscriptSelectionHandlerArgs {
     root: HTMLElement,
     edge: TranscriptSelectionClampEdge,
   ) => void;
+  getSelectedResponse: (
+    selection: Selection,
+    root: HTMLElement,
+  ) => SelectedResponseSelection | null;
+  isSelectedResponseVisible: (
+    selection: SelectedResponseSelection,
+    root: HTMLElement,
+  ) => boolean;
+  setSelectedResponse: (selection: SelectedResponseSelection | null) => void;
+  hasSelectedResponse: () => boolean;
+  requestSelectedResponseMenuFocus: () => void;
+  dismissSelectedResponse: (restoreTranscriptFocus: boolean) => void;
 }
 
 export function attachChatTranscriptSelectionListeners(
@@ -65,14 +98,20 @@ export function attachChatTranscriptSelectionListeners(
   handlers: TranscriptSelectionListenerHandlers,
 ): () => void {
   targets.windowTarget.addEventListener("pointerdown", handlers.pointerdown, { capture: true });
+  targets.windowTarget.addEventListener("pointerup", handlers.pointerup, { capture: true });
+  targets.windowTarget.addEventListener("pointercancel", handlers.pointerup, { capture: true });
   targets.windowTarget.addEventListener("keydown", handlers.keydown, { capture: true });
   targets.windowTarget.addEventListener("copy", handlers.copy, { capture: true });
+  targets.windowTarget.addEventListener("scroll", handlers.scroll, { capture: true });
   targets.documentTarget.addEventListener("selectionchange", handlers.selectionchange);
 
   return () => {
     targets.windowTarget.removeEventListener("pointerdown", handlers.pointerdown, { capture: true });
+    targets.windowTarget.removeEventListener("pointerup", handlers.pointerup, { capture: true });
+    targets.windowTarget.removeEventListener("pointercancel", handlers.pointerup, { capture: true });
     targets.windowTarget.removeEventListener("keydown", handlers.keydown, { capture: true });
     targets.windowTarget.removeEventListener("copy", handlers.copy, { capture: true });
+    targets.windowTarget.removeEventListener("scroll", handlers.scroll, { capture: true });
     targets.documentTarget.removeEventListener("selectionchange", handlers.selectionchange);
   };
 }
@@ -82,6 +121,7 @@ export function createChatTranscriptSelectionHandlers({
   getCopyText,
   transcriptOwnedRef,
   allTranscriptSelectedRef,
+  pointerSelectingRef,
   getActiveElement,
   getSelection,
   getTargetFactsForEvent,
@@ -92,6 +132,12 @@ export function createChatTranscriptSelectionHandlers({
   nodeInsideRoot: nodeInsideRootForRoot,
   getSelectionDirection: getSelectionDirectionForSelection,
   clampSelectionToRoot: clampSelectionToRootForSelection,
+  getSelectedResponse,
+  isSelectedResponseVisible,
+  setSelectedResponse,
+  hasSelectedResponse,
+  requestSelectedResponseMenuFocus,
+  dismissSelectedResponse,
 }: ChatTranscriptSelectionHandlerArgs): TranscriptSelectionListenerHandlers {
   const clearSelectionState = () => {
     transcriptOwnedRef.current = false;
@@ -102,16 +148,60 @@ export function createChatTranscriptSelectionHandlers({
     const root = rootRef.current;
     const targetFacts = getTargetFactsForEvent(event.target, root);
     const action = resolvePointerOwnership(targetFacts);
+    if (action === "ignore") {
+      return;
+    }
+    if (action === "track-selection") {
+      pointerSelectingRef.current = true;
+      setSelectedResponse(null);
+      clearSelectionState();
+      return;
+    }
     if (action === "set-owned" && root) {
+      pointerSelectingRef.current = true;
       transcriptOwnedRef.current = true;
       allTranscriptSelectedRef.current = false;
+      setSelectedResponse(null);
       focusRoot(root);
       return;
     }
+    pointerSelectingRef.current = false;
+    setSelectedResponse(null);
     clearSelectionState();
   };
 
+  const publishSelectedResponse = () => {
+    const root = rootRef.current;
+    const selection = getSelection();
+    setSelectedResponse(
+      root && selection
+        ? getSelectedResponse(selection, root)
+        : null,
+    );
+  };
+
+  const pointerup = () => {
+    if (!pointerSelectingRef.current) {
+      return;
+    }
+    pointerSelectingRef.current = false;
+    publishSelectedResponse();
+  };
+
   const keydown = (event: KeyboardEvent) => {
+    if (hasSelectedResponse() && event.key === "Escape") {
+      event.preventDefault();
+      dismissSelectedResponse(true);
+      return;
+    }
+    if (
+      hasSelectedResponse()
+      && (event.key === "ContextMenu" || (event.key === "F10" && event.shiftKey))
+    ) {
+      event.preventDefault();
+      requestSelectedResponseMenuFocus();
+      return;
+    }
     const root = rootRef.current;
     const action = resolvePrimaryAAction({
       owned: transcriptOwnedRef.current,
@@ -144,6 +234,7 @@ export function createChatTranscriptSelectionHandlers({
     const selection = getSelection();
     if (!root || !selection || selection.rangeCount === 0) {
       allTranscriptSelectedRef.current = false;
+      setSelectedResponse(null);
       return;
     }
 
@@ -151,6 +242,7 @@ export function createChatTranscriptSelectionHandlers({
       allTranscriptSelectedRef.current
       && isFullSelectionMarker(selection, root)
     ) {
+      setSelectedResponse(null);
       return;
     }
 
@@ -169,6 +261,25 @@ export function createChatTranscriptSelectionHandlers({
     if (action.clampEdge) {
       clampSelectionToRootForSelection(selection, root, action.clampEdge);
     }
+    if (!pointerSelectingRef.current) {
+      publishSelectedResponse();
+    }
+  };
+
+  const scroll = () => {
+    if (!hasSelectedResponse()) {
+      return;
+    }
+    const root = rootRef.current;
+    const selection = getSelection();
+    const selectedResponse = root && selection
+      ? getSelectedResponse(selection, root)
+      : null;
+    setSelectedResponse(
+      selectedResponse && root && isSelectedResponseVisible(selectedResponse, root)
+        ? selectedResponse
+        : null,
+    );
   };
 
   const copy = (event: ClipboardEvent) => {
@@ -200,19 +311,48 @@ export function createChatTranscriptSelectionHandlers({
 
   return {
     pointerdown,
+    pointerup,
     keydown,
     copy,
     selectionchange,
+    scroll,
   };
 }
 
 export function useChatTranscriptSelection({
   rootRef,
   getCopyText,
-}: UseChatTranscriptSelectionArgs): void {
+}: UseChatTranscriptSelectionArgs): ChatTranscriptSelectionState {
   const getCopyTextRef = useRef(getCopyText);
   const transcriptOwnedRef = useRef(false);
   const allTranscriptSelectedRef = useRef(false);
+  const pointerSelectingRef = useRef(false);
+  const [selectedResponse, setSelectedResponse] = useState<SelectedResponseSelection | null>(null);
+  const selectedResponseRef = useRef<SelectedResponseSelection | null>(null);
+  const [menuFocusRequestNonce, setMenuFocusRequestNonce] = useState(0);
+
+  const commitSelectedResponse = useCallback((selection: SelectedResponseSelection | null) => {
+    selectedResponseRef.current = selection;
+    setSelectedResponse(selection);
+    if (!selection) {
+      setMenuFocusRequestNonce(0);
+    }
+  }, []);
+
+  const dismissSelectedResponse = useCallback((options?: {
+    clearNativeSelection?: boolean;
+    restoreTranscriptFocus?: boolean;
+  }) => {
+    commitSelectedResponse(null);
+    if (options?.clearNativeSelection) {
+      document.getSelection()?.removeAllRanges();
+    }
+    if (options?.restoreTranscriptFocus) {
+      window.requestAnimationFrame(() => {
+        rootRef.current?.focus({ preventScroll: true });
+      });
+    }
+  }, [commitSelectedResponse, rootRef]);
 
   useLayoutEffect(() => {
     getCopyTextRef.current = getCopyText;
@@ -224,6 +364,7 @@ export function useChatTranscriptSelection({
       getCopyText: () => getCopyTextRef.current(),
       transcriptOwnedRef,
       allTranscriptSelectedRef,
+      pointerSelectingRef,
       getActiveElement: () => document.activeElement,
       getSelection: () => document.getSelection(),
       getTargetFactsForEvent: getTargetFacts,
@@ -234,6 +375,16 @@ export function useChatTranscriptSelection({
       nodeInsideRoot,
       getSelectionDirection,
       clampSelectionToRoot,
+      getSelectedResponse: getSelectedAssistantResponse,
+      isSelectedResponseVisible: isSelectedResponseInViewport,
+      setSelectedResponse: commitSelectedResponse,
+      hasSelectedResponse: () => selectedResponseRef.current !== null,
+      requestSelectedResponseMenuFocus: () => {
+        setMenuFocusRequestNonce((nonce) => nonce + 1);
+      },
+      dismissSelectedResponse: (restoreTranscriptFocus) => {
+        dismissSelectedResponse({ restoreTranscriptFocus });
+      },
     });
 
     const detach = attachChatTranscriptSelectionListeners({
@@ -244,9 +395,16 @@ export function useChatTranscriptSelection({
     return () => {
       transcriptOwnedRef.current = false;
       allTranscriptSelectedRef.current = false;
+      pointerSelectingRef.current = false;
       detach();
     };
-  }, [rootRef]);
+  }, [commitSelectedResponse, dismissSelectedResponse, rootRef]);
+
+  return {
+    selectedResponse,
+    menuFocusRequestNonce,
+    dismissSelectedResponse,
+  };
 }
 
 function getTargetFacts(
@@ -260,6 +418,8 @@ function getTargetFacts(
 
   return {
     insideRoot: root.contains(element),
+    contextualActions: !!element.closest("[data-selected-response-actions]"),
+    selectableInteractiveText: !!element.closest('a, [role="link"]'),
     textEntry: isTextEntryElement(element),
     terminalZone: !!element.closest('[data-focus-zone="terminal"]'),
     ignoredChrome: !!element.closest("[data-chat-transcript-ignore]"),

--- a/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-selection.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-selection.ts
@@ -8,17 +8,16 @@ import {
 } from "react";
 import {
   EMPTY_TRANSCRIPT_TARGET_FACTS,
-  isPrimarySelectAllEvent,
-  resolveCopyAction,
-  resolvePointerOwnership,
-  resolvePrimaryAAction,
-  resolveSelectionChangeAction,
   type TranscriptSelectionClampEdge,
   type TranscriptTargetFacts,
 } from "#product/domain/chats/transcript/transcript-selection";
 import type {
   SelectedResponseSelection,
 } from "#product/domain/chats/transcript/selected-response-context";
+import {
+  attachChatTranscriptSelectionListeners,
+  createChatTranscriptSelectionHandlers,
+} from "#product/hooks/chat/ui/chat-transcript-selection-handlers";
 import {
   getSelectedAssistantResponse,
   isSelectedResponseInViewport,
@@ -29,24 +28,6 @@ interface UseChatTranscriptSelectionArgs {
   getCopyText: () => string;
 }
 
-interface TranscriptSelectionListenerTargets {
-  windowTarget: Pick<Window, "addEventListener" | "removeEventListener">;
-  documentTarget: Pick<Document, "addEventListener" | "removeEventListener">;
-}
-
-interface TranscriptSelectionListenerHandlers {
-  pointerdown: (event: PointerEvent) => void;
-  pointerup: () => void;
-  keydown: (event: KeyboardEvent) => void;
-  copy: (event: ClipboardEvent) => void;
-  selectionchange: () => void;
-  scroll: () => void;
-}
-
-interface MutableBooleanRef {
-  current: boolean;
-}
-
 export interface ChatTranscriptSelectionState {
   selectedResponse: SelectedResponseSelection | null;
   menuFocusRequestNonce: number;
@@ -54,269 +35,6 @@ export interface ChatTranscriptSelectionState {
     clearNativeSelection?: boolean;
     restoreTranscriptFocus?: boolean;
   }) => void;
-}
-
-interface ChatTranscriptSelectionHandlerArgs {
-  rootRef: RefObject<HTMLElement | null>;
-  getCopyText: () => string;
-  transcriptOwnedRef: MutableBooleanRef;
-  allTranscriptSelectedRef: MutableBooleanRef;
-  pointerSelectingRef: MutableBooleanRef;
-  getActiveElement: () => EventTarget | null;
-  getSelection: () => Selection | null;
-  getTargetFactsForEvent: (
-    target: EventTarget | null,
-    root: HTMLElement | null,
-  ) => TranscriptTargetFacts;
-  focusRoot: (root: HTMLElement) => void;
-  setFullSelectionMarker: (root: HTMLElement) => void;
-  isFullSelectionMarker: (selection: Selection, root: HTMLElement) => boolean;
-  isExactRootSelection: (selection: Selection, root: HTMLElement) => boolean;
-  nodeInsideRoot: (node: Node | null, root: HTMLElement) => boolean;
-  getSelectionDirection: (selection: Selection) => "forward" | "backward";
-  clampSelectionToRoot: (
-    selection: Selection,
-    root: HTMLElement,
-    edge: TranscriptSelectionClampEdge,
-  ) => void;
-  getSelectedResponse: (
-    selection: Selection,
-    root: HTMLElement,
-  ) => SelectedResponseSelection | null;
-  isSelectedResponseVisible: (
-    selection: SelectedResponseSelection,
-    root: HTMLElement,
-  ) => boolean;
-  setSelectedResponse: (selection: SelectedResponseSelection | null) => void;
-  hasSelectedResponse: () => boolean;
-  requestSelectedResponseMenuFocus: () => void;
-  dismissSelectedResponse: (restoreTranscriptFocus: boolean) => void;
-}
-
-export function attachChatTranscriptSelectionListeners(
-  targets: TranscriptSelectionListenerTargets,
-  handlers: TranscriptSelectionListenerHandlers,
-): () => void {
-  targets.windowTarget.addEventListener("pointerdown", handlers.pointerdown, { capture: true });
-  targets.windowTarget.addEventListener("pointerup", handlers.pointerup, { capture: true });
-  targets.windowTarget.addEventListener("pointercancel", handlers.pointerup, { capture: true });
-  targets.windowTarget.addEventListener("keydown", handlers.keydown, { capture: true });
-  targets.windowTarget.addEventListener("copy", handlers.copy, { capture: true });
-  targets.windowTarget.addEventListener("scroll", handlers.scroll, { capture: true });
-  targets.documentTarget.addEventListener("selectionchange", handlers.selectionchange);
-
-  return () => {
-    targets.windowTarget.removeEventListener("pointerdown", handlers.pointerdown, { capture: true });
-    targets.windowTarget.removeEventListener("pointerup", handlers.pointerup, { capture: true });
-    targets.windowTarget.removeEventListener("pointercancel", handlers.pointerup, { capture: true });
-    targets.windowTarget.removeEventListener("keydown", handlers.keydown, { capture: true });
-    targets.windowTarget.removeEventListener("copy", handlers.copy, { capture: true });
-    targets.windowTarget.removeEventListener("scroll", handlers.scroll, { capture: true });
-    targets.documentTarget.removeEventListener("selectionchange", handlers.selectionchange);
-  };
-}
-
-export function createChatTranscriptSelectionHandlers({
-  rootRef,
-  getCopyText,
-  transcriptOwnedRef,
-  allTranscriptSelectedRef,
-  pointerSelectingRef,
-  getActiveElement,
-  getSelection,
-  getTargetFactsForEvent,
-  focusRoot,
-  setFullSelectionMarker,
-  isFullSelectionMarker,
-  isExactRootSelection: isExactRootSelectionForRoot,
-  nodeInsideRoot: nodeInsideRootForRoot,
-  getSelectionDirection: getSelectionDirectionForSelection,
-  clampSelectionToRoot: clampSelectionToRootForSelection,
-  getSelectedResponse,
-  isSelectedResponseVisible,
-  setSelectedResponse,
-  hasSelectedResponse,
-  requestSelectedResponseMenuFocus,
-  dismissSelectedResponse,
-}: ChatTranscriptSelectionHandlerArgs): TranscriptSelectionListenerHandlers {
-  const clearSelectionState = () => {
-    transcriptOwnedRef.current = false;
-    allTranscriptSelectedRef.current = false;
-  };
-
-  const pointerdown = (event: PointerEvent) => {
-    const root = rootRef.current;
-    const targetFacts = getTargetFactsForEvent(event.target, root);
-    const action = resolvePointerOwnership(targetFacts);
-    if (action === "ignore") {
-      return;
-    }
-    if (action === "track-selection") {
-      pointerSelectingRef.current = true;
-      setSelectedResponse(null);
-      clearSelectionState();
-      return;
-    }
-    if (action === "set-owned" && root) {
-      pointerSelectingRef.current = true;
-      transcriptOwnedRef.current = true;
-      allTranscriptSelectedRef.current = false;
-      setSelectedResponse(null);
-      focusRoot(root);
-      return;
-    }
-    pointerSelectingRef.current = false;
-    setSelectedResponse(null);
-    clearSelectionState();
-  };
-
-  const publishSelectedResponse = () => {
-    const root = rootRef.current;
-    const selection = getSelection();
-    setSelectedResponse(
-      root && selection
-        ? getSelectedResponse(selection, root)
-        : null,
-    );
-  };
-
-  const pointerup = () => {
-    if (!pointerSelectingRef.current) {
-      return;
-    }
-    pointerSelectingRef.current = false;
-    publishSelectedResponse();
-  };
-
-  const keydown = (event: KeyboardEvent) => {
-    if (hasSelectedResponse() && event.key === "Escape") {
-      event.preventDefault();
-      dismissSelectedResponse(true);
-      return;
-    }
-    if (
-      hasSelectedResponse()
-      && (event.key === "ContextMenu" || (event.key === "F10" && event.shiftKey))
-    ) {
-      event.preventDefault();
-      requestSelectedResponseMenuFocus();
-      return;
-    }
-    const root = rootRef.current;
-    const action = resolvePrimaryAAction({
-      owned: transcriptOwnedRef.current,
-      isSelectAll: isPrimarySelectAllEvent(event, isApplePlatform()),
-      defaultPrevented: event.defaultPrevented,
-      eventTarget: getTargetFactsForEvent(event.target, root),
-      activeTarget: getTargetFactsForEvent(getActiveElement(), root),
-    });
-
-    if (action === "ignore") {
-      return;
-    }
-    if (action === "clear-owned") {
-      clearSelectionState();
-      return;
-    }
-    if (!root) {
-      clearSelectionState();
-      return;
-    }
-
-    event.preventDefault();
-    setFullSelectionMarker(root);
-    transcriptOwnedRef.current = true;
-    allTranscriptSelectedRef.current = true;
-  };
-
-  const selectionchange = () => {
-    const root = rootRef.current;
-    const selection = getSelection();
-    if (!root || !selection || selection.rangeCount === 0) {
-      allTranscriptSelectedRef.current = false;
-      setSelectedResponse(null);
-      return;
-    }
-
-    if (
-      allTranscriptSelectedRef.current
-      && isFullSelectionMarker(selection, root)
-    ) {
-      setSelectedResponse(null);
-      return;
-    }
-
-    const exactRootSelection = isExactRootSelectionForRoot(selection, root);
-    const action = resolveSelectionChangeAction({
-      owned: transcriptOwnedRef.current,
-      anchorInsideRoot: nodeInsideRootForRoot(selection.anchorNode, root),
-      focusInsideRoot: nodeInsideRootForRoot(selection.focusNode, root),
-      exactRootSelection,
-      direction: getSelectionDirectionForSelection(selection),
-    });
-
-    if (action.clearFullSelection) {
-      allTranscriptSelectedRef.current = false;
-    }
-    if (action.clampEdge) {
-      clampSelectionToRootForSelection(selection, root, action.clampEdge);
-    }
-    if (!pointerSelectingRef.current) {
-      publishSelectedResponse();
-    }
-  };
-
-  const scroll = () => {
-    if (!hasSelectedResponse()) {
-      return;
-    }
-    const root = rootRef.current;
-    const selection = getSelection();
-    const selectedResponse = root && selection
-      ? getSelectedResponse(selection, root)
-      : null;
-    setSelectedResponse(
-      selectedResponse && root && isSelectedResponseVisible(selectedResponse, root)
-        ? selectedResponse
-        : null,
-    );
-  };
-
-  const copy = (event: ClipboardEvent) => {
-    const root = rootRef.current;
-    const selection = getSelection();
-    const action = resolveCopyAction({
-      fullRootSelected: !!root
-        && !!selection
-        && allTranscriptSelectedRef.current
-        && isFullSelectionMarker(selection, root),
-      eventTarget: getTargetFactsForEvent(event.target, root),
-      activeTarget: getTargetFactsForEvent(getActiveElement(), root),
-    });
-
-    if (action === "ignore") {
-      return;
-    }
-    if (action === "clear-owned") {
-      clearSelectionState();
-      return;
-    }
-    if (!event.clipboardData) {
-      return;
-    }
-
-    event.clipboardData.setData("text/plain", getCopyText());
-    event.preventDefault();
-  };
-
-  return {
-    pointerdown,
-    pointerup,
-    keydown,
-    copy,
-    selectionchange,
-    scroll,
-  };
 }
 
 export function useChatTranscriptSelection({
@@ -539,11 +257,4 @@ function clampSelectionToRoot(
   }
   selection.removeAllRanges();
   selection.addRange(range);
-}
-
-function isApplePlatform(): boolean {
-  if (typeof navigator === "undefined") {
-    return false;
-  }
-  return /mac|iphone|ipad|ipod/iu.test(navigator.platform);
 }

--- a/apps/packages/product-client/src/hooks/chat/ui/selected-response-selection.test.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/selected-response-selection.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getSelectedAssistantResponse,
+  isSelectedResponseInViewport,
+} from "#product/hooks/chat/ui/selected-response-selection";
+
+afterEach(() => {
+  document.body.replaceChildren();
+  document.getSelection()?.removeAllRanges();
+});
+
+describe("getSelectedAssistantResponse", () => {
+  it("keeps an exact selection across links and code in one assistant response", () => {
+    const root = transcriptRoot();
+    const start = root.querySelector("[data-start]")!.firstChild!;
+    const end = root.querySelector("code")!.firstChild!;
+    const selection = selectRange(start, 0, end, end.textContent!.length);
+
+    expect(getSelectedAssistantResponse(selection, root)).toEqual({
+      text: "Alpha linked code",
+      anchorRect: {
+        x: 12,
+        y: 24,
+        width: 80,
+        height: 18,
+        top: 24,
+        right: 92,
+        bottom: 42,
+        left: 12,
+      },
+    });
+  });
+
+  it("rejects selections that cross assistant responses", () => {
+    const root = transcriptRoot();
+    const responses = root.querySelectorAll("[data-assistant-prose]");
+    const start = responses[0]!.querySelector("[data-start]")!.firstChild!;
+    const end = responses[1]!.firstChild!;
+    const selection = selectRange(start, 0, end, end.textContent!.length);
+
+    expect(getSelectedAssistantResponse(selection, root)).toBeNull();
+  });
+
+  it("rejects user text, ignored controls, and collapsed selections", () => {
+    const root = transcriptRoot();
+    const userText = root.querySelector("[data-user]")!.firstChild!;
+    expect(getSelectedAssistantResponse(
+      selectRange(userText, 0, userText, userText.textContent!.length),
+      root,
+    )).toBeNull();
+
+    const ignoredText = root.querySelector("[data-chat-transcript-ignore]")!.firstChild!;
+    expect(getSelectedAssistantResponse(
+      selectRange(ignoredText, 0, ignoredText, ignoredText.textContent!.length),
+      root,
+    )).toBeNull();
+
+    const assistantText = root.querySelector("[data-start]")!.firstChild!;
+    expect(getSelectedAssistantResponse(
+      selectRange(assistantText, 2, assistantText, 2),
+      root,
+    )).toBeNull();
+  });
+});
+
+describe("isSelectedResponseInViewport", () => {
+  it("uses the nearest clipping scroll viewport as well as the window", () => {
+    const viewport = document.createElement("div");
+    viewport.style.overflowY = "auto";
+    const root = document.createElement("div");
+    viewport.append(root);
+    document.body.append(viewport);
+    Object.defineProperty(viewport, "getBoundingClientRect", {
+      value: () => ({ top: 100, right: 500, bottom: 300, left: 100 }),
+    });
+    const selection = {
+      text: "clipped response",
+      anchorRect: {
+        x: 120,
+        y: 40,
+        width: 100,
+        height: 20,
+        top: 40,
+        right: 220,
+        bottom: 60,
+        left: 120,
+      },
+    };
+
+    expect(isSelectedResponseInViewport(selection, root)).toBe(false);
+    selection.anchorRect.y = 140;
+    selection.anchorRect.top = 140;
+    selection.anchorRect.bottom = 160;
+    expect(isSelectedResponseInViewport(selection, root)).toBe(true);
+  });
+});
+
+function transcriptRoot(): HTMLDivElement {
+  const root = document.createElement("div");
+  root.innerHTML = [
+    '<div data-assistant-prose><span data-start>Alpha </span><a href="#details">linked</a> <code>code</code><button data-chat-transcript-ignore>Copy</button></div>',
+    "<div data-assistant-prose>Second response</div>",
+    "<div data-user>User prompt</div>",
+  ].join("");
+  document.body.append(root);
+  return root;
+}
+
+function selectRange(
+  startNode: Node,
+  startOffset: number,
+  endNode: Node,
+  endOffset: number,
+): Selection {
+  const range = document.createRange();
+  range.setStart(startNode, startOffset);
+  range.setEnd(endNode, endOffset);
+  Object.defineProperty(range, "getBoundingClientRect", {
+    value: () => ({
+      x: 12,
+      y: 24,
+      width: 80,
+      height: 18,
+      top: 24,
+      right: 92,
+      bottom: 42,
+      left: 12,
+    }),
+  });
+  const selection = document.getSelection()!;
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return selection;
+}

--- a/apps/packages/product-client/src/hooks/chat/ui/selected-response-selection.test.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/selected-response-selection.test.ts
@@ -43,6 +43,16 @@ describe("getSelectedAssistantResponse", () => {
     expect(getSelectedAssistantResponse(selection, root)).toBeNull();
   });
 
+  it("rejects selections that span ignored transcript controls", () => {
+    const root = transcriptRoot();
+    const start = root.querySelector("[data-start]")!.firstChild!;
+    const end = root.querySelector("[data-end]")!.firstChild!;
+    const selection = selectRange(start, 0, end, end.textContent!.length);
+
+    expect(selection.toString()).toContain("Copy");
+    expect(getSelectedAssistantResponse(selection, root)).toBeNull();
+  });
+
   it("rejects user text, ignored controls, and collapsed selections", () => {
     const root = transcriptRoot();
     const userText = root.querySelector("[data-user]")!.firstChild!;
@@ -100,7 +110,7 @@ describe("isSelectedResponseInViewport", () => {
 function transcriptRoot(): HTMLDivElement {
   const root = document.createElement("div");
   root.innerHTML = [
-    '<div data-assistant-prose><span data-start>Alpha </span><a href="#details">linked</a> <code>code</code><button data-chat-transcript-ignore>Copy</button></div>',
+    '<div data-assistant-prose><span data-start>Alpha </span><a href="#details">linked</a> <code>code</code><button data-chat-transcript-ignore>Copy</button><span data-end> Omega</span></div>',
     "<div data-assistant-prose>Second response</div>",
     "<div data-user>User prompt</div>",
   ].join("");

--- a/apps/packages/product-client/src/hooks/chat/ui/selected-response-selection.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/selected-response-selection.ts
@@ -20,6 +20,7 @@ export function getSelectedAssistantResponse(
     || !endElement
     || startElement.closest("[data-chat-transcript-ignore]")
     || endElement.closest("[data-chat-transcript-ignore]")
+    || range.cloneContents().querySelector("[data-chat-transcript-ignore]")
   ) {
     return null;
   }

--- a/apps/packages/product-client/src/hooks/chat/ui/selected-response-selection.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/selected-response-selection.ts
@@ -1,0 +1,106 @@
+import type { SelectedResponseSelection } from "#product/domain/chats/transcript/selected-response-context";
+
+export function getSelectedAssistantResponse(
+  selection: Selection,
+  root: HTMLElement,
+): SelectedResponseSelection | null {
+  if (selection.rangeCount !== 1 || selection.isCollapsed) {
+    return null;
+  }
+  const text = selection.toString();
+  if (text.trim().length === 0) {
+    return null;
+  }
+
+  const range = selection.getRangeAt(0);
+  const startElement = nodeToElement(range.startContainer);
+  const endElement = nodeToElement(range.endContainer);
+  if (
+    !startElement
+    || !endElement
+    || startElement.closest("[data-chat-transcript-ignore]")
+    || endElement.closest("[data-chat-transcript-ignore]")
+  ) {
+    return null;
+  }
+  const startResponse = startElement.closest("[data-assistant-prose]");
+  const endResponse = endElement.closest("[data-assistant-prose]");
+  if (
+    !startResponse
+    || startResponse !== endResponse
+    || !root.contains(startResponse)
+  ) {
+    return null;
+  }
+
+  const rect = range.getBoundingClientRect();
+  const left = Number.isFinite(rect.left) ? rect.left : 0;
+  const top = Number.isFinite(rect.top) ? rect.top : 0;
+  const width = Number.isFinite(rect.width) ? rect.width : 0;
+  const height = Number.isFinite(rect.height) ? rect.height : 0;
+  const right = Number.isFinite(rect.right) ? rect.right : left + width;
+  const bottom = Number.isFinite(rect.bottom) ? rect.bottom : top + height;
+
+  return {
+    text,
+    anchorRect: {
+      x: Number.isFinite(rect.x) ? rect.x : left,
+      y: Number.isFinite(rect.y) ? rect.y : top,
+      width,
+      height,
+      top,
+      right,
+      bottom,
+      left,
+    },
+  };
+}
+
+export function isSelectedResponseInViewport(
+  selection: SelectedResponseSelection,
+  root?: HTMLElement,
+): boolean {
+  const { anchorRect } = selection;
+  const visibleBounds = clippingBoundsForElement(root);
+  return anchorRect.bottom > visibleBounds.top
+    && anchorRect.right > visibleBounds.left
+    && anchorRect.top < visibleBounds.bottom
+    && anchorRect.left < visibleBounds.right;
+}
+
+function clippingBoundsForElement(root?: HTMLElement) {
+  const bounds = {
+    top: 0,
+    right: window.innerWidth,
+    bottom: window.innerHeight,
+    left: 0,
+  };
+  for (let element: HTMLElement | null = root ?? null; element; element = element.parentElement) {
+    const style = window.getComputedStyle(element);
+    const overflowX = style.overflowX || style.overflow;
+    const overflowY = style.overflowY || style.overflow;
+    const clipsX = clipsOverflow(overflowX);
+    const clipsY = clipsOverflow(overflowY);
+    if (!clipsX && !clipsY) {
+      continue;
+    }
+    const rect = element.getBoundingClientRect();
+    if (clipsX) {
+      bounds.left = Math.max(bounds.left, rect.left);
+      bounds.right = Math.min(bounds.right, rect.right);
+    }
+    if (clipsY) {
+      bounds.top = Math.max(bounds.top, rect.top);
+      bounds.bottom = Math.min(bounds.bottom, rect.bottom);
+    }
+  }
+  return bounds;
+}
+
+function clipsOverflow(value: string): boolean {
+  return value === "auto" || value === "scroll" || value === "hidden" || value === "clip";
+}
+
+function nodeToElement(node: Node): Element | null {
+  return node instanceof Element ? node : node.parentElement;
+}

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-composer-focus-request.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-composer-focus-request.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useChatComposerFocusRequest } from "./use-chat-composer-focus-request";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useChatComposerFocusRequest", () => {
+  it("retries until the composer accepts focus", () => {
+    vi.useFakeTimers();
+    const focusComposer = vi.fn()
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false)
+      .mockReturnValue(true);
+
+    renderHook(() => useChatComposerFocusRequest({
+      focusRequestNonce: 1,
+      focusComposer,
+    }));
+    act(() => vi.runAllTimers());
+
+    expect(focusComposer).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops retrying after eight attempts", () => {
+    vi.useFakeTimers();
+    const focusComposer = vi.fn(() => false);
+
+    renderHook(() => useChatComposerFocusRequest({
+      focusRequestNonce: 1,
+      focusComposer,
+    }));
+    act(() => vi.runAllTimers());
+
+    expect(focusComposer).toHaveBeenCalledTimes(8);
+  });
+
+  it("cancels a pending retry when unmounted", () => {
+    vi.useFakeTimers();
+    const focusComposer = vi.fn(() => false);
+    const { unmount } = renderHook(() => useChatComposerFocusRequest({
+      focusRequestNonce: 1,
+      focusComposer,
+    }));
+
+    act(() => vi.advanceTimersByTime(0));
+    expect(focusComposer).toHaveBeenCalledOnce();
+    unmount();
+    act(() => vi.runAllTimers());
+
+    expect(focusComposer).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-composer-focus-request.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-composer-focus-request.ts
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+
+interface UseChatComposerFocusRequestArgs {
+  focusRequestNonce: number;
+  focusComposer: () => boolean;
+}
+
+export function useChatComposerFocusRequest({
+  focusRequestNonce,
+  focusComposer,
+}: UseChatComposerFocusRequestArgs): void {
+  useEffect(() => {
+    if (focusRequestNonce === 0) {
+      return;
+    }
+
+    let timer: number | null = null;
+    let attempts = 0;
+    let cancelled = false;
+    const attemptFocus = () => {
+      if (cancelled) {
+        return;
+      }
+      attempts += 1;
+      if (focusComposer() || attempts >= 8) {
+        return;
+      }
+      timer = window.setTimeout(attemptFocus, 25);
+    };
+
+    timer = window.setTimeout(attemptFocus, 0);
+    return () => {
+      cancelled = true;
+      if (timer !== null) {
+        window.clearTimeout(timer);
+      }
+    };
+  }, [focusComposer, focusRequestNonce]);
+}

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-draft-state.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-draft-state.ts
@@ -6,8 +6,11 @@ import {
   isChatDraftEmpty,
   type ChatComposerDraft,
 } from "#product/lib/domain/chat/composer/file-mention-draft-model";
+import type { SelectedResponseContext } from "#product/domain/chats/transcript/selected-response-context";
 import { useChatInputStore } from "#product/stores/chat/chat-input-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+
+const EMPTY_SELECTED_RESPONSE_CONTEXTS: readonly SelectedResponseContext[] = [];
 
 /**
  * Live draft value for the composer editor.
@@ -22,6 +25,17 @@ import { useSessionSelectionStore } from "#product/stores/sessions/session-selec
 export function useChatDraftValue(workspaceUiKey: string | null): ChatComposerDraft {
   return useChatInputStore((state) =>
     workspaceUiKey ? state.draftByWorkspaceId[workspaceUiKey] ?? EMPTY_CHAT_DRAFT : EMPTY_CHAT_DRAFT,
+  );
+}
+
+export function useChatSelectedResponseContexts(
+  workspaceUiKey: string | null,
+): readonly SelectedResponseContext[] {
+  return useChatInputStore((state) =>
+    workspaceUiKey
+      ? state.selectedResponseContextsByWorkspaceId[workspaceUiKey]
+        ?? EMPTY_SELECTED_RESPONSE_CONTEXTS
+      : EMPTY_SELECTED_RESPONSE_CONTEXTS,
   );
 }
 
@@ -51,10 +65,21 @@ export function useChatDraftControls() {
       ? isChatDraftEmpty(state.draftByWorkspaceId[workspaceUiKey] ?? EMPTY_CHAT_DRAFT)
       : true,
   );
+  const hasSelectedResponseContexts = useChatInputStore((state) =>
+    workspaceUiKey
+      ? (state.selectedResponseContextsByWorkspaceId[workspaceUiKey]?.length ?? 0) > 0
+      : false,
+  );
   const setDraftForWorkspace = useChatInputStore((state) => state.setDraft);
   const setDraftTextForWorkspace = useChatInputStore((state) => state.setDraftText);
   const appendDraftTextForWorkspace = useChatInputStore((state) => state.appendDraftText);
   const clearDraftForWorkspace = useChatInputStore((state) => state.clearDraft);
+  const removeSelectedResponseContextForWorkspace = useChatInputStore(
+    (state) => state.removeSelectedResponseContext,
+  );
+  const clearSelectedResponseContextsForWorkspace = useChatInputStore(
+    (state) => state.clearSelectedResponseContexts,
+  );
 
   const getDraft = useCallback((): ChatComposerDraft => {
     if (!workspaceUiKey) {
@@ -95,14 +120,41 @@ export function useChatDraftControls() {
     clearDraftForWorkspace(workspaceUiKey);
   }, [clearDraftForWorkspace, workspaceUiKey]);
 
+  const getSelectedResponseContexts = useCallback((): readonly SelectedResponseContext[] => {
+    if (!workspaceUiKey) {
+      return EMPTY_SELECTED_RESPONSE_CONTEXTS;
+    }
+    return useChatInputStore.getState()
+      .selectedResponseContextsByWorkspaceId[workspaceUiKey]
+      ?? EMPTY_SELECTED_RESPONSE_CONTEXTS;
+  }, [workspaceUiKey]);
+
+  const removeSelectedResponseContext = useCallback((id: string) => {
+    if (!workspaceUiKey) {
+      return;
+    }
+    removeSelectedResponseContextForWorkspace(workspaceUiKey, id);
+  }, [removeSelectedResponseContextForWorkspace, workspaceUiKey]);
+
+  const clearSelectedResponseContexts = useCallback((ids?: readonly string[]) => {
+    if (!workspaceUiKey) {
+      return;
+    }
+    clearSelectedResponseContextsForWorkspace(workspaceUiKey, ids);
+  }, [clearSelectedResponseContextsForWorkspace, workspaceUiKey]);
+
   return {
     workspaceUiKey,
     materializedWorkspaceId,
     getDraft,
+    getSelectedResponseContexts,
     setDraft,
     setDraftText,
     appendDraftText,
     clearDraft,
+    removeSelectedResponseContext,
+    clearSelectedResponseContexts,
     isEmpty,
+    hasSelectedResponseContexts,
   };
 }

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-copy-selection.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-copy-selection.ts
@@ -5,7 +5,10 @@ import type {
 } from "#product/domain/chats/transcript/chat-transcript-state";
 import { collectToolCallIdsWithProposedPlan } from "#product/domain/chats/transcript/transcript-rendering";
 import { buildTranscriptCopyText } from "#product/domain/chats/transcript/transcript-copy";
-import { useChatTranscriptSelection } from "./chat-transcript-selection";
+import {
+  useChatTranscriptSelection,
+  type ChatTranscriptSelectionState,
+} from "./chat-transcript-selection";
 
 export function useChatTranscriptCopySelection({
   selectionRootRef,
@@ -17,7 +20,7 @@ export function useChatTranscriptCopySelection({
   transcript: TranscriptState;
   visibleTurnIds: readonly string[];
   visibleOptimisticPrompt: PendingPromptEntry | null;
-}): void {
+}): ChatTranscriptSelectionState {
   const getTranscriptCopyText = useCallback(() => buildTranscriptCopyText({
     transcript,
     visibleTurnIds,
@@ -29,7 +32,7 @@ export function useChatTranscriptCopySelection({
     visibleOptimisticPrompt,
   ]);
 
-  useChatTranscriptSelection({
+  return useChatTranscriptSelection({
     rootRef: selectionRootRef,
     getCopyText: getTranscriptCopyText,
   });

--- a/apps/packages/product-client/src/hooks/chat/workflows/use-chat-prompt-actions.ts
+++ b/apps/packages/product-client/src/hooks/chat/workflows/use-chat-prompt-actions.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { isWorkspaceDirectoryMissingError } from "#product/lib/domain/sessions/creation/create-session-error";
 import type { ContentPart, PromptInputBlock } from "@anyharness/sdk";
 import { useProductTelemetry } from "#product/hooks/telemetry/facade/use-product-telemetry";
@@ -44,6 +44,7 @@ import { useGitPromptSnapshotEffects } from "#product/hooks/workspaces/workflows
 import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
 import { useWorkspaceCollectionsInvalidationActions } from "#product/hooks/workspaces/cache/use-workspace-collections-invalidation";
 import { completeChatPromptSubmitSideEffects } from "#product/lib/workflows/chat/complete-chat-prompt-submit-side-effects";
+import { CHAT_PROMPT_FEEDBACK } from "#product/copy/chat/chat-copy";
 
 export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
   const forceNewSession = options?.forceNewSession ?? false;
@@ -72,11 +73,40 @@ export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
     currentLaunchIdentity,
   } = useActiveSessionLaunchState();
   const { hasSlot } = useActiveSessionSurfaceSnapshot();
-  const { isDisabled, sendBlockedReason } = useChatAvailabilityState({
-    activeSessionId: forceNewSession ? null : activeSessionId,
-  });
-  const scopedLaunchIdentity = forceNewSession ? null : currentLaunchIdentity;
+  const scopedLaunchIdentity = currentLaunchIdentity;
   const configuredLaunch = useConfiguredLaunchReadiness(scopedLaunchIdentity);
+  const requireCurrentLaunch = forceNewSession && scopedLaunchIdentity !== null;
+  const newSessionLaunchSelection = useMemo(() => resolveAvailableLaunchSelection(
+    configuredLaunch.launchCatalog.launchAgents,
+    scopedLaunchIdentity,
+    configuredLaunch.selection,
+    { requirePreferredSelection: requireCurrentLaunch },
+  ), [
+    configuredLaunch.launchCatalog.launchAgents,
+    configuredLaunch.selection,
+    requireCurrentLaunch,
+    scopedLaunchIdentity,
+  ]);
+  const hasLaunchReadinessError = Boolean(
+    configuredLaunch.launchCatalog.error
+    || configuredLaunch.launchCatalog.targetReadinessError,
+  );
+  const currentLaunchReadiness = requireCurrentLaunch
+    ? {
+      isLoading: configuredLaunch.isLoading,
+      isReady: !hasLaunchReadinessError && newSessionLaunchSelection !== null,
+      disabledReason: hasLaunchReadinessError
+        ? configuredLaunch.disabledReason
+        : newSessionLaunchSelection
+          ? null
+          : CHAT_PROMPT_FEEDBACK.currentModelUnavailable,
+    }
+    : undefined;
+  const { disabledReason, isDisabled, sendBlockedReason } = useChatAvailabilityState({
+    activeSessionId: forceNewSession ? null : activeSessionId,
+    activeLaunchSelection: forceNewSession ? scopedLaunchIdentity : null,
+    launchReadiness: currentLaunchReadiness,
+  });
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
   const { invalidateWorkspaceCollectionsForRuntime } = useWorkspaceCollectionsInvalidationActions();
   const gitPromptEffects = useGitPromptSnapshotEffects();
@@ -88,6 +118,8 @@ export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
     attachmentSnapshots?: PromptAttachmentSnapshot[];
     optimisticContentParts?: ContentPart[];
     measurementOperationId?: MeasurementOperationId | null;
+    preserveDraft?: boolean;
+    onSubmitted?: () => void;
   }): Promise<boolean> {
     const pendingWorkspaceUiKey = pendingWorkspaceEntry
       ? buildPendingWorkspaceUiKey(pendingWorkspaceEntry)
@@ -106,6 +138,7 @@ export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
     const text = input?.text.trim() ?? serializeChatDraftToPrompt(currentDraft).trim();
     const blocks = input?.blocks ?? [{ type: "text" as const, text }];
     const attachmentSnapshots = input?.attachmentSnapshots ?? [];
+    const preserveDraft = input?.preserveDraft ?? false;
     if (
       (!hasPromptContent(text, blocks) && attachmentSnapshots.length === 0)
       || isDisabled
@@ -114,11 +147,7 @@ export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
       return false;
     }
 
-    const launchSelection = resolveAvailableLaunchSelection(
-      configuredLaunch.launchCatalog.launchAgents,
-      scopedLaunchIdentity,
-      configuredLaunch.selection,
-    );
+    const launchSelection = newSessionLaunchSelection;
     const targetSessionId = !forceNewSession && hasSlot ? activeSessionId : null;
     const promptId = createPromptId();
     const latencyFlowId = targetSessionId
@@ -132,7 +161,7 @@ export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
       : null;
 
     const clearDraftIfNeeded = () => {
-      if (!draftKey) {
+      if (!draftKey || preserveDraft) {
         return;
       }
       clearDraft(draftKey);
@@ -230,19 +259,19 @@ export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
         showToast("Choose a ready model before sending a message.");
         return false;
       }
-      if (!selectedWorkspaceId) {
-        return true;
+      if (selectedWorkspaceId) {
+        completeChatPromptSubmitSideEffects({
+          workspaceId: selectedWorkspaceId,
+          logicalWorkspaceId: selectedLogicalWorkspaceId,
+          repoRootId: gitPromptEffects.repoRootIdForLogicalWorkspace(selectedLogicalWorkspaceId),
+          getWorkspaceArrivalEvent: () => useSessionSelectionStore.getState().workspaceArrivalEvent,
+          getCachedWorkspaceSetupStatus,
+          agentKind: launchSelection?.kind ?? "unknown",
+          reuseSession: targetSessionId !== null,
+          setWorkspaceArrivalEvent,
+        }, { trackProductEvent: telemetry.track, ...gitPromptEffects.promptSubmitDeps });
       }
-      completeChatPromptSubmitSideEffects({
-        workspaceId: selectedWorkspaceId,
-        logicalWorkspaceId: selectedLogicalWorkspaceId,
-        repoRootId: gitPromptEffects.repoRootIdForLogicalWorkspace(selectedLogicalWorkspaceId),
-        getWorkspaceArrivalEvent: () => useSessionSelectionStore.getState().workspaceArrivalEvent,
-        getCachedWorkspaceSetupStatus,
-        agentKind: launchSelection?.kind ?? "unknown",
-        reuseSession: targetSessionId !== null,
-        setWorkspaceArrivalEvent,
-      }, { trackProductEvent: telemetry.track, ...gitPromptEffects.promptSubmitDeps });
+      input?.onSubmitted?.();
       return true;
     } catch (error) {
       if (latencyFlowId) {
@@ -280,6 +309,8 @@ export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
             ...(input?.optimisticContentParts
               ? { optimisticContentParts: input.optimisticContentParts }
               : {}),
+            preserveDraft,
+            onSubmitted: input?.onSubmitted,
           }),
         });
       }
@@ -288,8 +319,6 @@ export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
   }, [
     activeSessionId,
     clearDraft,
-    configuredLaunch.launchCatalog.launchAgents,
-    configuredLaunch.selection,
     createSessionWithResolvedConfig,
     findOrCreateSession,
     getCachedWorkspaceSetupStatus,
@@ -298,6 +327,7 @@ export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
     forceNewSession,
     invalidateWorkspaceCollectionsForRuntime,
     isDisabled,
+    newSessionLaunchSelection,
     pendingWorkspaceEntry,
     promptActiveSession,
     promptSession,
@@ -308,7 +338,6 @@ export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
     setWorkspaceArrivalEvent,
     showErrorToast,
     showToast,
-    scopedLaunchIdentity,
     telemetry,
   ]);
 
@@ -330,5 +359,6 @@ export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
   return {
     handleSubmit,
     handleCancel,
+    submitDisabledReason: sendBlockedReason ?? (isDisabled ? disabledReason : null),
   };
 }

--- a/apps/packages/product-client/src/hooks/chat/workflows/use-selected-response-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/workflows/use-selected-response-actions.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CHAT_SELECTED_RESPONSE_ACTIONS } from "#product/copy/chat/chat-copy";
+import { useSelectedResponseActions } from "#product/hooks/chat/workflows/use-selected-response-actions";
+
+const mocks = vi.hoisted(() => ({
+  addSelectedResponseContext: vi.fn(),
+  currentSubmit: vi.fn(async () => true),
+  requestFocus: vi.fn(),
+  showToast: vi.fn(),
+  sideChatSubmit: vi.fn(async () => true),
+  submitDisabledReason: null as string | null,
+}));
+
+vi.mock("#product/stores/sessions/session-selection-store", () => ({
+  useSessionSelectionStore: (selector: (state: unknown) => unknown) => selector({
+    selectedLogicalWorkspaceId: "logical-workspace-1",
+    selectedWorkspaceId: "workspace-1",
+  }),
+}));
+
+vi.mock("#product/stores/chat/chat-input-store", () => ({
+  useChatInputStore: (selector: (state: unknown) => unknown) => selector({
+    addSelectedResponseContext: mocks.addSelectedResponseContext,
+    requestFocus: mocks.requestFocus,
+  }),
+}));
+
+vi.mock("#product/hooks/chat/workflows/use-chat-prompt-actions", () => ({
+  useChatPromptActions: (options?: { forceNewSession?: boolean }) => ({
+    handleSubmit: options?.forceNewSession ? mocks.sideChatSubmit : mocks.currentSubmit,
+    submitDisabledReason: mocks.submitDisabledReason,
+  }),
+}));
+
+vi.mock("#product/stores/toast/toast-store", () => ({
+  useToastStore: (selector: (state: unknown) => unknown) => selector({
+    show: mocks.showToast,
+  }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.submitDisabledReason = null;
+});
+
+afterEach(cleanup);
+
+describe("useSelectedResponseActions", () => {
+  it("attaches the exact response excerpt to the current workspace and focuses the composer", () => {
+    const { result } = renderHook(() => useSelectedResponseActions());
+
+    act(() => result.current.addToChat("selected response"));
+
+    expect(mocks.addSelectedResponseContext).toHaveBeenCalledWith(
+      "logical-workspace-1",
+      "selected response",
+    );
+    expect(mocks.requestFocus).toHaveBeenCalledOnce();
+  });
+
+  it("routes more details to the current chat without disturbing its draft", () => {
+    const { result } = renderHook(() => useSelectedResponseActions());
+
+    act(() => result.current.moreDetails("current-chat excerpt"));
+
+    expect(mocks.currentSubmit).toHaveBeenCalledOnce();
+    expect(mocks.sideChatSubmit).not.toHaveBeenCalled();
+    expectSubmittedExcerpt(
+      mocks.currentSubmit,
+      CHAT_SELECTED_RESPONSE_ACTIONS.moreDetailsPrompt,
+      "current-chat excerpt",
+    );
+  });
+
+  it("routes side chat to a forced new conversation with the full excerpt once", () => {
+    const { result } = renderHook(() => useSelectedResponseActions());
+
+    act(() => result.current.askInSideChat("side-chat excerpt"));
+
+    expect(mocks.sideChatSubmit).toHaveBeenCalledOnce();
+    expect(mocks.currentSubmit).not.toHaveBeenCalled();
+    expectSubmittedExcerpt(
+      mocks.sideChatSubmit,
+      CHAT_SELECTED_RESPONSE_ACTIONS.sideChatPrompt,
+      "side-chat excerpt",
+    );
+  });
+
+  it("explains when an immediate response action is blocked", async () => {
+    mocks.currentSubmit.mockResolvedValueOnce(false);
+    mocks.submitDisabledReason = "Resolve workspace setup before sending.";
+    const { result } = renderHook(() => useSelectedResponseActions());
+
+    act(() => result.current.moreDetails("blocked excerpt"));
+
+    await waitFor(() => {
+      expect(mocks.showToast).toHaveBeenCalledWith(
+        "Resolve workspace setup before sending.",
+      );
+    });
+  });
+});
+
+function expectSubmittedExcerpt(
+  submit: ReturnType<typeof vi.fn>,
+  prompt: string,
+  excerpt: string,
+) {
+  const payload = submit.mock.calls[0]![0] as {
+    text: string;
+    blocks: Array<{ type: "text"; text: string }>;
+    optimisticContentParts: Array<{ type: "text"; text: string }>;
+    preserveDraft: boolean;
+  };
+  expect(payload.text.startsWith(prompt)).toBe(true);
+  expect(payload.text.split(excerpt)).toHaveLength(2);
+  expect(payload.blocks).toEqual([{ type: "text", text: payload.text }]);
+  expect(payload.optimisticContentParts).toEqual([{ type: "text", text: payload.text }]);
+  expect(payload.preserveDraft).toBe(true);
+}

--- a/apps/packages/product-client/src/hooks/chat/workflows/use-selected-response-actions.ts
+++ b/apps/packages/product-client/src/hooks/chat/workflows/use-selected-response-actions.ts
@@ -1,0 +1,70 @@
+import { useCallback } from "react";
+import { CHAT_SELECTED_RESPONSE_ACTIONS } from "#product/copy/chat/chat-copy";
+import { buildPromptWithSelectedResponseContexts } from "#product/domain/chats/transcript/selected-response-context";
+import { useChatPromptActions } from "#product/hooks/chat/workflows/use-chat-prompt-actions";
+import { resolveChatDraftWorkspaceId } from "#product/lib/domain/chat/composer/chat-input";
+import { useChatInputStore } from "#product/stores/chat/chat-input-store";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+import { useToastStore } from "#product/stores/toast/toast-store";
+
+export function useSelectedResponseActions() {
+  const selectedLogicalWorkspaceId = useSessionSelectionStore(
+    (state) => state.selectedLogicalWorkspaceId,
+  );
+  const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
+  const workspaceUiKey = resolveChatDraftWorkspaceId(
+    selectedLogicalWorkspaceId,
+    selectedWorkspaceId,
+  );
+  const addSelectedResponseContext = useChatInputStore(
+    (state) => state.addSelectedResponseContext,
+  );
+  const requestComposerFocus = useChatInputStore((state) => state.requestFocus);
+  const showToast = useToastStore((state) => state.show);
+  const currentChat = useChatPromptActions();
+  const sideChat = useChatPromptActions({ forceNewSession: true });
+
+  const addToChat = useCallback((text: string) => {
+    if (!workspaceUiKey) {
+      return;
+    }
+    addSelectedResponseContext(workspaceUiKey, text);
+    requestComposerFocus();
+  }, [addSelectedResponseContext, requestComposerFocus, workspaceUiKey]);
+
+  const moreDetails = useCallback((text: string) => {
+    const payload = buildPromptWithSelectedResponseContexts(
+      CHAT_SELECTED_RESPONSE_ACTIONS.moreDetailsPrompt,
+      [{ text }],
+    );
+    void currentChat.handleSubmit({
+      ...payload,
+      preserveDraft: true,
+    }).then((submitted) => {
+      if (!submitted && currentChat.submitDisabledReason) {
+        showToast(currentChat.submitDisabledReason);
+      }
+    });
+  }, [currentChat.handleSubmit, currentChat.submitDisabledReason, showToast]);
+
+  const askInSideChat = useCallback((text: string) => {
+    const payload = buildPromptWithSelectedResponseContexts(
+      CHAT_SELECTED_RESPONSE_ACTIONS.sideChatPrompt,
+      [{ text }],
+    );
+    void sideChat.handleSubmit({
+      ...payload,
+      preserveDraft: true,
+    }).then((submitted) => {
+      if (!submitted && sideChat.submitDisabledReason) {
+        showToast(sideChat.submitDisabledReason);
+      }
+    });
+  }, [showToast, sideChat.handleSubmit, sideChat.submitDisabledReason]);
+
+  return {
+    addToChat,
+    moreDetails,
+    askInSideChat,
+  };
+}

--- a/apps/packages/product-client/src/lib/domain/chat/models/launch-selection-defaults.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/models/launch-selection-defaults.ts
@@ -85,9 +85,13 @@ export function resolveAvailableLaunchSelection(
   agents: readonly DesktopAgentLaunchAgent[],
   preferredSelection: ModelSelectorSelection | null | undefined,
   fallbackSelection: ModelSelectorSelection | null | undefined,
+  options?: { requirePreferredSelection?: boolean },
 ): ModelSelectorSelection | null {
-  return resolveLaunchableModelSelection(agents, preferredSelection)
-    ?? resolveLaunchableModelSelection(agents, fallbackSelection);
+  const preferred = resolveLaunchableModelSelection(agents, preferredSelection);
+  if (preferred || options?.requirePreferredSelection) {
+    return preferred;
+  }
+  return resolveLaunchableModelSelection(agents, fallbackSelection);
 }
 
 export function resolveConfiguredLaunchAgentSelection(

--- a/apps/packages/product-client/src/lib/domain/chat/models/model-selection-availability.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/models/model-selection-availability.test.ts
@@ -51,6 +51,12 @@ describe("launch selection availability", () => {
       kind: "codex",
       modelId: "gpt-5.4",
     });
+    expect(resolveAvailableLaunchSelection(
+      agents,
+      { kind: "claude", modelId: "sonnet" },
+      { kind: "codex", modelId: "gpt-5.4" },
+      { requirePreferredSelection: true },
+    )).toBeNull();
   });
 
   it("keeps the active session selection when the target can launch it", () => {

--- a/apps/packages/product-client/src/primitives/Popover.tsx
+++ b/apps/packages/product-client/src/primitives/Popover.tsx
@@ -20,8 +20,11 @@ function PopoverContent({
   className,
   align = "center",
   sideOffset = 4,
+  variant = "default",
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+}: React.ComponentProps<typeof PopoverPrimitive.Content> & {
+  variant?: "default" | "menu";
+}) {
   return (
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Content
@@ -29,7 +32,8 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          `z-50 w-72 p-3 outline-none ${POPOVER_FRAME_CLASS}`,
+          `z-50 outline-none ${POPOVER_FRAME_CLASS}`,
+          variant === "menu" ? "w-[220px] p-1" : "w-72 p-3",
           className,
         )}
         {...props}

--- a/apps/packages/product-client/src/stores/chat/chat-input-store.test.ts
+++ b/apps/packages/product-client/src/stores/chat/chat-input-store.test.ts
@@ -10,6 +10,7 @@ describe("chat input store", () => {
   beforeEach(() => {
     useChatInputStore.setState({
       draftByWorkspaceId: {},
+      selectedResponseContextsByWorkspaceId: {},
       editDraftBySessionId: {},
       editingQueueSeqBySessionId: {},
       focusRequestNonce: 0,
@@ -90,6 +91,47 @@ describe("chat input store", () => {
     expect(serializeChatDraftToPrompt(
       useChatInputStore.getState().draftByWorkspaceId["workspace-1"]!,
     )).toBe("hello");
+  });
+
+  it("keeps matching contexts distinct when one is already submitting", () => {
+    const store = useChatInputStore.getState();
+    store.addSelectedResponseContext("workspace-1", "selected response");
+    const submitting = useChatInputStore.getState()
+      .selectedResponseContextsByWorkspaceId["workspace-1"]![0]!;
+    store.addSelectedResponseContext("workspace-1", "selected response");
+    store.clearSelectedResponseContexts("workspace-1", [submitting.id]);
+
+    expect(useChatInputStore.getState().selectedResponseContextsByWorkspaceId["workspace-1"])
+      .toEqual([expect.objectContaining({ text: "selected response" })]);
+  });
+
+  it("clears only the submitted response contexts", () => {
+    const store = useChatInputStore.getState();
+    store.addSelectedResponseContext("workspace-1", "first response");
+    store.addSelectedResponseContext("workspace-1", "second response");
+    const contexts = useChatInputStore.getState()
+      .selectedResponseContextsByWorkspaceId["workspace-1"]!;
+
+    store.clearSelectedResponseContexts("workspace-1", [contexts[0]!.id]);
+
+    expect(useChatInputStore.getState().selectedResponseContextsByWorkspaceId["workspace-1"])
+      .toEqual([contexts[1]]);
+  });
+
+  it("removes response contexts without changing the text draft", () => {
+    const store = useChatInputStore.getState();
+    store.setDraftText("workspace-1", "keep this draft");
+    store.addSelectedResponseContext("workspace-1", "selected response");
+    const context = useChatInputStore.getState()
+      .selectedResponseContextsByWorkspaceId["workspace-1"]![0]!;
+
+    store.removeSelectedResponseContext("workspace-1", context.id);
+
+    expect(useChatInputStore.getState().selectedResponseContextsByWorkspaceId["workspace-1"])
+      .toBeUndefined();
+    expect(serializeChatDraftToPrompt(
+      useChatInputStore.getState().draftByWorkspaceId["workspace-1"]!,
+    )).toBe("keep this draft");
   });
 
   it("tracks queued-message edits by stable queue seq", () => {

--- a/apps/packages/product-client/src/stores/chat/chat-input-store.ts
+++ b/apps/packages/product-client/src/stores/chat/chat-input-store.ts
@@ -6,9 +6,13 @@ import {
   isChatDraftEmpty,
   type ChatComposerDraft,
 } from "#product/lib/domain/chat/composer/file-mention-draft-model";
+import type { SelectedResponseContext } from "#product/domain/chats/transcript/selected-response-context";
+
+let selectedResponseContextSequence = 0;
 
 interface ChatInputState {
   draftByWorkspaceId: Record<string, ChatComposerDraft>;
+  selectedResponseContextsByWorkspaceId: Record<string, SelectedResponseContext[]>;
   editDraftBySessionId: Record<string, string>;
   editingQueueSeqBySessionId: Record<string, number>;
   focusRequestNonce: number;
@@ -16,6 +20,9 @@ interface ChatInputState {
   setDraftText: (workspaceId: string, value: string) => void;
   appendDraftText: (workspaceId: string, value: string) => void;
   clearDraft: (workspaceId: string) => void;
+  addSelectedResponseContext: (workspaceId: string, text: string) => void;
+  removeSelectedResponseContext: (workspaceId: string, id: string) => void;
+  clearSelectedResponseContexts: (workspaceId: string, ids?: readonly string[]) => void;
   setEditDraft: (sessionId: string, value: string) => void;
   setEditingQueueSeq: (sessionId: string, seq: number | null) => void;
   requestFocus: () => void;
@@ -23,6 +30,7 @@ interface ChatInputState {
 
 export const useChatInputStore = create<ChatInputState>((set) => ({
   draftByWorkspaceId: {},
+  selectedResponseContextsByWorkspaceId: {},
   editDraftBySessionId: {},
   editingQueueSeqBySessionId: {},
   focusRequestNonce: 0,
@@ -84,6 +92,66 @@ export const useChatInputStore = create<ChatInputState>((set) => ({
     return {
       draftByWorkspaceId: nextDrafts,
     };
+  }),
+
+  addSelectedResponseContext: (workspaceId, text) => set((state) => {
+    if (text.trim().length === 0) {
+      return state;
+    }
+    const current = state.selectedResponseContextsByWorkspaceId[workspaceId] ?? [];
+    selectedResponseContextSequence += 1;
+    return {
+      selectedResponseContextsByWorkspaceId: {
+        ...state.selectedResponseContextsByWorkspaceId,
+        [workspaceId]: [
+          ...current,
+          {
+            id: `selected-response:${Date.now()}:${selectedResponseContextSequence.toString(36)}`,
+            text,
+          },
+        ],
+      },
+    };
+  }),
+
+  removeSelectedResponseContext: (workspaceId, id) => set((state) => {
+    const current = state.selectedResponseContextsByWorkspaceId[workspaceId] ?? [];
+    const next = current.filter((context) => context.id !== id);
+    if (next.length === current.length) {
+      return state;
+    }
+    const selectedResponseContextsByWorkspaceId = {
+      ...state.selectedResponseContextsByWorkspaceId,
+    };
+    if (next.length === 0) {
+      delete selectedResponseContextsByWorkspaceId[workspaceId];
+    } else {
+      selectedResponseContextsByWorkspaceId[workspaceId] = next;
+    }
+    return { selectedResponseContextsByWorkspaceId };
+  }),
+
+  clearSelectedResponseContexts: (workspaceId, ids) => set((state) => {
+    const current = state.selectedResponseContextsByWorkspaceId[workspaceId] ?? [];
+    if (current.length === 0) {
+      return state;
+    }
+    const idSet = ids ? new Set(ids) : null;
+    const next = idSet
+      ? current.filter((context) => !idSet.has(context.id))
+      : [];
+    if (next.length === current.length) {
+      return state;
+    }
+    const selectedResponseContextsByWorkspaceId = {
+      ...state.selectedResponseContextsByWorkspaceId,
+    };
+    if (next.length === 0) {
+      delete selectedResponseContextsByWorkspaceId[workspaceId];
+    } else {
+      selectedResponseContextsByWorkspaceId[workspaceId] = next;
+    }
+    return { selectedResponseContextsByWorkspaceId };
   }),
 
   setEditDraft: (sessionId, value) => set((state) => {

--- a/specs/codebase/systems/product/chat/README.md
+++ b/specs/codebase/systems/product/chat/README.md
@@ -7,6 +7,7 @@ Start with the product task you intend to change:
 | Create, update, or replace a visible chat | [Chat lifecycle](lifecycle.md) |
 | Change input, controls, picker presentation, panels, or badges | [Composer](composer.md) |
 | Change messages, streaming, replay, rows, or long-history behavior | [Transcript](transcript.md) |
+| Change contextual actions for selected assistant text | [Transcript](transcript.md) and [Composer](composer.md) |
 | Change tab ordering, restoration, or projected-shell mechanics | [Workspaces](../workspaces/README.md) |
 | Change model identity, availability, or selection action classification | [Model Catalog](../../../../FEATURE_DOCS/MODELS.md) |
 | Change session actors, live config, process retirement, or relaunch | [AnyHarness sessions](../../../../anyharness/sessions.md) |

--- a/specs/codebase/systems/product/chat/composer.md
+++ b/specs/codebase/systems/product/chat/composer.md
@@ -88,6 +88,16 @@ Home and queued-edit state retain the same opaque snapshot locally while their
 Markdown draft is live. Empty drafts, plain-text compatibility writes, and
 external draft replacements discard the snapshot.
 
+Assistant-response excerpts added from the transcript are workspace-scoped
+composer context, stored separately from `ChatComposerDraft`. Each excerpt is
+shown above the editor as a removable quoted preview; preview truncation is
+visual only, and submission includes the full selected text exactly once in
+the serialized prompt. An excerpt makes an otherwise empty composer
+submittable. After a successful direct submit, `ChatInput` clears only the
+excerpt ids captured by that submission so context attached during the
+in-flight send is retained. Immediate transcript follow-ups do not clear or
+replace the current composer draft.
+
 The live editor recognizes `*`/`_` emphasis, `**`/`__` strong emphasis,
 line-leading unordered and ordered list shortcuts, and triple-backtick fenced
 code blocks. A typed fence becomes a code block only after a matching closing

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -145,6 +145,40 @@ Rules:
 - Web falls back to unhighlighted (identically styled) code blocks; shiki stays
   out of the web bundle.
 
+## Contextual Assistant-Text Actions
+
+A non-empty native text selection wholly contained by one assistant prose
+block opens the selected-response action menu. The transcript selection hook
+owns detection and dismissal; the menu owns only presentation and keyboard
+navigation.
+
+Rules:
+
+- Preserve native selection and copy behavior. Assistant prose may be selected
+  across inline links and code. Transcript controls marked as ignored chrome,
+  user prompts, tool rows, and selections spanning multiple assistant responses
+  do not qualify.
+- Pointer selection opens the menu after pointer-up. Keyboard selection opens
+  it after the browser's `selectionchange`; Context Menu or Shift+F10 moves
+  focus into its roving menu items without changing the selected text.
+- The menu uses the native range rectangle as a virtual anchor and collision
+  handling keeps it in the viewport. Scrolling updates the anchor while any of
+  the selection remains visible and dismisses the menu after it leaves the
+  viewport.
+- Clearing the selection, clicking outside, Escape, or choosing an action
+  dismisses the menu. Escape restores transcript focus; pointer dismissal does
+  not steal focus.
+- `Add to chat` attaches the exact selected text to the current workspace
+  composer and focuses the editor. `More details` sends a quoted follow-up to
+  the current chat. `Ask in side chat` starts a separate normal chat tab with
+  the current launch identity. Both immediate-send actions preserve any draft
+  already in the composer and surface the existing availability reason when a
+  send is blocked.
+
+The selected text is serialized as one quoted context section. Transport text,
+prompt blocks, and optimistic content are parallel representations of that one
+prompt, not separate context inserts.
+
 ## Delegated-Work Receipts
 
 Subagent creation, parent/child communication, and wake/completion receipts are


### PR DESCRIPTION
## Summary

- Add an accessible, selection-anchored action menu for assistant response text with Add to chat, More details, and Ask in side chat.
- Carry complete response excerpts through composer submissions and immediate follow-ups while preserving drafts, retries, and in-flight context.
- Preserve native text selection, copying, and link behavior; dismiss the menu across focus and scroll boundaries; and document the transcript/composer contracts.

## Testing

- Tier 1: 10 focused ProductClient test files, 49 tests passed.
- Tier 1: `pnpm --filter @proliferate/product-client typecheck`
- Build: `pnpm --filter @proliferate/product-client build`
- Full ProductClient run: 802 files and 5,447 tests passed; the browser-only cascade suite could not launch locally because the required Chrome channel is not installed. CI provides the browser-backed proof.
- Manual: validated all three actions in the isolated Desktop profile `pro97-actions`.

## Observability

- None. Selected excerpts remain local composer state and telemetry-masked; no logs, metrics, or event schemas changed.

## Readiness

- [x] I followed the routing in `AGENTS.md` and read the applicable frontend, design system, product sense, testing, and observability docs.
- [x] I updated current-state documentation for the transcript selection and composer contracts.
- [x] I added focused regression coverage for selection, action dispatch, launch availability, retry cleanup, captured context state, focus retry lifecycle, and ignored transcript controls.

## Verification

- `python3 scripts/report_frontend_structure.py --strict --summary-only`
- `python3 scripts/check_max_lines.py`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_design_attribution.py`
- `python3 scripts/check_docs.py`
- `python3 scripts/check_appearance_scaling.py`
- `python3 scripts/check_theme_contrast.py`
- `python3 scripts/check_toast_copy.py`
- `make build PROFILE=pro97-actions`