### PR TITLE
fix(product): scope workspaces filter to name and branch (PRO-122)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/repo-setup/WorkspacesCommandList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/WorkspacesCommandList.test.tsx
@@ -114,27 +114,51 @@ describe("WorkspacesCommandList", () => {
     expect(screen.queryByText("Cloud")).toBeNull();
   });
 
-  it("matches the filter against the PR number", () => {
+  it("matches the filter against the workspace name or branch only", () => {
+    render(
+      <WorkspacesCommandList
+        groups={groups([
+          item({ id: "ws-a", title: "Alpha", branch: "feat/statuses" }),
+          item({ id: "ws-b", title: "Beta", branch: "fix/login" }),
+        ])}
+        onWorkspaceSelect={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText("Filter by name or branch...");
+
+    fireEvent.change(input, { target: { value: "alpha" } });
+    expect(screen.queryByText("Alpha")).toBeTruthy();
+    expect(screen.queryByText("Beta")).toBeNull();
+
+    fireEvent.change(input, { target: { value: "fix/login" } });
+    expect(screen.queryByText("Alpha")).toBeNull();
+    expect(screen.queryByText("Beta")).toBeTruthy();
+  });
+
+  it("does not match the filter against id, meta, PR number, or placement", () => {
     render(
       <WorkspacesCommandList
         groups={groups([
           item({
             id: "ws-pr",
             title: "Alpha",
+            branch: null,
+            meta: "acme/repo",
             prStatus: { kind: "open", number: 805 },
             prNumberLabel: "#805",
+            placementLabel: "Cloud",
           }),
-          item({ id: "ws-plain", title: "Beta" }),
         ])}
         onWorkspaceSelect={vi.fn()}
       />,
     );
 
-    fireEvent.change(screen.getByPlaceholderText("Filter workspaces..."), {
-      target: { value: "#805" },
-    });
+    const input = screen.getByPlaceholderText("Filter by name or branch...");
 
-    expect(screen.queryByText("Alpha")).toBeTruthy();
-    expect(screen.queryByText("Beta")).toBeNull();
+    for (const query of ["ws-pr", "acme/repo", "#805", "Cloud"]) {
+      fireEvent.change(input, { target: { value: query } });
+      expect(screen.queryByText("Alpha")).toBeNull();
+    }
   });
 });

--- a/apps/packages/product-client/src/components/workspace/repo-setup/WorkspacesCommandList.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/WorkspacesCommandList.tsx
@@ -56,7 +56,7 @@ export interface WorkspacesCommandItemView {
   attention?: "conflicts" | null;
   /** "↑2 ↓1" — present only when ahead or behind > 0; hidden when selected. */
   aheadBehindLabel?: string | null;
-  /** "#805" — rendered after the PR dot; included in the filter value. */
+  /** "#805" — rendered after the PR dot. */
   prNumberLabel?: string | null;
   /**
    * Session count for the workspace. Rendered as glyph + number in the
@@ -94,7 +94,7 @@ export interface WorkspacesCommandListProps {
 
 export function WorkspacesCommandList({
   groups,
-  filterPlaceholder = "Filter workspaces...",
+  filterPlaceholder = "Filter by name or branch...",
   emptyLabel = "No workspaces yet",
   filterRowActions = null,
   onWorkspaceSelect,
@@ -106,6 +106,14 @@ export function WorkspacesCommandList({
     <Command
       className={twMerge("bg-transparent", className)}
       label="Workspaces"
+      // Match only workspace name / branch (item keywords), never the id
+      // value; a binary score keeps the recency ordering intact.
+      filter={(_value, search, keywords) =>
+        keywords?.some((keyword) =>
+          keyword.toLowerCase().includes(search.toLowerCase()),
+        )
+          ? 1
+          : 0}
     >
       <div className="flex shrink-0 items-center gap-2 border-b border-border">
         <CommandInput
@@ -178,7 +186,8 @@ function WorkspaceCommandRow({
 
   return (
     <CommandItem
-      value={`${item.id} ${item.title} ${branch ?? ""} ${meta ?? ""} ${item.prNumberLabel ?? ""} ${placementLabel ?? ""}`.trim()}
+      value={item.id}
+      keywords={branch ? [item.title, branch] : [item.title]}
       onSelect={onSelect ? () => onSelect(item.id) : undefined}
       className="min-h-9"
     >


### PR DESCRIPTION
Fixes [PRO-122](https://linear.app/proliferate-team/issue/PRO-122/filter-workspaces-search-does-not-make-sense-what-its-searching).

## Problem

The workspaces page filter matched against the workspace **id**, repo meta, PR number, and placement label in addition to the visible name — so typing e.g. a few letters could surface rows with no visible relation to the query, and it was unclear what the search was actually searching.

## Change

- Filter now matches **only the workspace name or branch name**: the cmdk item `value` is the (unique) workspace id used purely for selection identity, and name/branch are passed as `keywords` with a custom binary substring filter.
- The binary score also preserves the recency grouping/order instead of cmdk's score-based reshuffle.
- Placeholder updated to `Filter by name or branch...` so the scope is self-describing.
- The dashed Create row is `forceMount` and unaffected.

## Tests

- Replaced the PR-number-matching test with tests asserting matches on name and branch, and non-matches on id / meta / PR number / placement.
- `pnpm vitest run src/components/workspace/repo-setup/WorkspacesCommandList.test.tsx` — 9 passed.
- `pnpm exec tsc -p tsconfig.json --noEmit` in `apps/packages/product-client` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)