### PR TITLE
fix(product): unify expanded tool-call detail boxes on the code-block card

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRowPrimitives.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRowPrimitives.tsx
@@ -77,7 +77,7 @@ export function ActionDisclosureRow({
       size="sm"
       data-chat-transcript-ignore
       aria-expanded={expanded}
-      className={`group/action-row h-auto max-w-full justify-start gap-1.5 rounded-none bg-transparent p-0 text-left ${CHAT_BUTTON_TEXT_CLASS} font-normal hover:bg-transparent focus-visible:ring-0 ${
+      className={`group/action-row h-auto max-w-full justify-start gap-1.5 rounded-none bg-transparent p-0 text-left ${CHAT_BUTTON_TEXT_CLASS} font-normal hover:bg-transparent active:bg-transparent focus-visible:ring-0 ${
         failed ? "text-destructive/80 hover:text-destructive" : "text-foreground/60 hover:text-foreground"
       }`}
       onClick={onToggle}

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedCommandActionRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedCommandActionRow.tsx
@@ -37,7 +37,6 @@ export function CommandActionRow({ item }: { item: ToolCallItem }) {
             </code>
           </div>
           <AutoHideScrollArea
-            className="border-t border-border/60"
             viewportClassName={TOOL_CALL_BODY_MAX_HEIGHT_CLASS}
             allowHorizontal
           >

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.tsx
@@ -116,7 +116,7 @@ function EditActionRow({
               event.stopPropagation();
               void fileActions.openPrimary();
             }}
-            className="pointer-events-auto h-auto min-w-0 max-w-full shrink justify-start truncate rounded-none bg-transparent p-0 text-left text-chat font-normal text-current underline decoration-current decoration-dotted decoration-[0.5px] underline-offset-2 hover:bg-transparent hover:text-current focus-visible:ring-1 focus-visible:ring-border"
+            className="pointer-events-auto h-auto min-w-0 max-w-full shrink justify-start truncate rounded-none bg-transparent p-0 text-left text-chat font-normal text-current underline decoration-current decoration-dotted decoration-[0.5px] underline-offset-2 hover:bg-transparent active:bg-transparent hover:text-current focus-visible:ring-1 focus-visible:ring-border"
           >
             {displayName}
           </Button>

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedGenericActionRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedGenericActionRow.tsx
@@ -44,7 +44,6 @@ export function GenericActionRow({ item }: { item: ToolCallItem }) {
               <span>Result</span>
             </div>
             <AutoHideScrollArea
-              className="border-t border-border/60"
               viewportClassName={TOOL_CALL_BODY_MAX_HEIGHT_CLASS}
               allowHorizontal
             >

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolActionDetailsPanel.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolActionDetailsPanel.tsx
@@ -6,14 +6,9 @@ interface ToolActionDetailsPanelProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 /**
- * The one detail-body shell behind every expanded tool call.
- *
- * Recorded exclusion (DESIGN_SYSTEM.md § UI-conformance review, check 1): this
- * is the shape `Card` names, but `Card`'s tint surface is deliberately
- * borderless and this panel needs the `border-border/60` hairline to separate
- * itself from the transcript's own tint at close range. Composing `Card` and
- * repainting the edge from here would be the paint leak the doctrine closes, so
- * the shell stays local until `Card` can express a bordered tint.
+ * The one detail-body shell behind every expanded tool call. Matches the chat
+ * code-block card surface so expanded tool output and fenced code read as one
+ * family; the transparent border keeps size parity with bordered cards.
  */
 export function ToolActionDetailsPanel({
   children,
@@ -24,7 +19,7 @@ export function ToolActionDetailsPanel({
     <div
       {...props}
       className={twMerge(
-        "overflow-hidden rounded-md border border-border/60 bg-surface-elevated-secondary",
+        "overflow-clip rounded-lg border border-transparent bg-[var(--color-code-block-background,var(--color-card))]",
         className,
       )}
     >

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/cowork/CoworkCodingToolLedger.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/cowork/CoworkCodingToolLedger.tsx
@@ -97,7 +97,7 @@ function CodingWorkspaceActionRow({
       variant="ghost"
       size="sm"
       data-chat-transcript-ignore
-      className={`group/action-row h-auto max-w-full justify-start gap-1 rounded-none bg-transparent p-0 text-left ${CHAT_ACTION_TEXT_CLASS} font-normal text-muted-foreground/60 hover:bg-transparent hover:text-foreground focus-visible:ring-0`}
+      className={`group/action-row h-auto max-w-full justify-start gap-1 rounded-none bg-transparent p-0 text-left ${CHAT_ACTION_TEXT_CLASS} font-normal text-muted-foreground/60 hover:bg-transparent active:bg-transparent hover:text-foreground focus-visible:ring-0`}
       onClick={onOpen}
     >
       <span className="min-w-0 truncate">Created coding workspace</span>
@@ -122,7 +122,7 @@ function PromptActionRow({
         variant="ghost"
         size="sm"
         data-chat-transcript-ignore
-        className={`group/action-row h-auto max-w-full justify-start gap-1 rounded-none bg-transparent p-0 text-left ${CHAT_ACTION_TEXT_CLASS} font-normal text-muted-foreground/60 hover:bg-transparent hover:text-foreground focus-visible:ring-0`}
+        className={`group/action-row h-auto max-w-full justify-start gap-1 rounded-none bg-transparent p-0 text-left ${CHAT_ACTION_TEXT_CLASS} font-normal text-muted-foreground/60 hover:bg-transparent active:bg-transparent hover:text-foreground focus-visible:ring-0`}
         aria-expanded={expanded}
         onClick={() => setExpanded((next) => !next)}
       >
@@ -180,7 +180,7 @@ function CodingSessionActionRow({
       variant="ghost"
       size="sm"
       data-chat-transcript-ignore
-      className={`group/action-row h-auto max-w-full justify-start gap-1 rounded-none bg-transparent p-0 text-left ${CHAT_ACTION_TEXT_CLASS} font-normal text-muted-foreground/60 hover:bg-transparent hover:text-foreground focus-visible:ring-0`}
+      className={`group/action-row h-auto max-w-full justify-start gap-1 rounded-none bg-transparent p-0 text-left ${CHAT_ACTION_TEXT_CLASS} font-normal text-muted-foreground/60 hover:bg-transparent active:bg-transparent hover:text-foreground focus-visible:ring-0`}
       onClick={onOpen}
     >
       <span className="min-w-0 truncate">Created coding session</span>

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/SubagentLaunchLedger.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/SubagentLaunchLedger.tsx
@@ -36,7 +36,7 @@ export function SubagentLaunchLedger({
             variant="ghost"
             size="sm"
             data-chat-transcript-ignore
-            className={`group/action-row h-auto max-w-full justify-start gap-1 rounded-none bg-transparent p-0 text-left ${CHAT_ACTION_TEXT_CLASS} font-normal text-muted-foreground/60 hover:bg-transparent hover:text-foreground focus-visible:ring-0`}
+            className={`group/action-row h-auto max-w-full justify-start gap-1 rounded-none bg-transparent p-0 text-left ${CHAT_ACTION_TEXT_CLASS} font-normal text-muted-foreground/60 hover:bg-transparent active:bg-transparent hover:text-foreground focus-visible:ring-0`}
             aria-expanded={promptExpanded}
             onClick={() => setPromptExpanded((next) => !next)}
           >

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/SystemMessage.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/SystemMessage.tsx
@@ -17,7 +17,7 @@ export function SystemMessage({ content }: SystemMessageProps) {
         variant="ghost"
         data-chat-transcript-ignore
         onClick={() => setSystemExpanded(!systemExpanded)}
-        className="flex h-auto w-full justify-start gap-2 rounded-none bg-transparent px-3 py-1.5 text-left font-sans text-chat text-muted-foreground transition-colors hover:bg-transparent hover:text-foreground"
+        className="flex h-auto w-full justify-start gap-2 rounded-none bg-transparent px-3 py-1.5 text-left font-sans text-chat text-muted-foreground transition-colors hover:bg-transparent active:bg-transparent hover:text-foreground"
       >
         <Settings
           aria-hidden="true"

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.tsx
@@ -288,7 +288,7 @@ function OutboxTextActionButton({
       variant="ghost"
       size="sm"
       data-chat-transcript-ignore
-      className="h-auto rounded-none px-1 py-0 text-chat font-normal text-muted-foreground hover:bg-transparent hover:text-foreground focus-visible:ring-0 focus-visible:underline"
+      className="h-auto rounded-none px-1 py-0 text-chat font-normal text-muted-foreground hover:bg-transparent active:bg-transparent hover:text-foreground focus-visible:ring-0 focus-visible:underline"
       onClick={onClick}
     >
       {label}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.test.tsx
@@ -93,17 +93,17 @@ describe("CompletedHistorySequence", () => {
     const commandDisclosure = within(ledger!).getAllByRole("button", { expanded: false })[0]!;
     await user.click(commandDisclosure);
     // The nested panel is ToolActionDetailsPanel now, which is where the three
-    // inline copies of this shell folded — hence rounded-md, the radius the
-    // shared panel's other consumers already used.
+    // inline copies of this shell folded — hence the shared panel's
+    // code-block-card styling.
     const nestedDetailPanel = Array.from(ledger!.querySelectorAll<HTMLElement>("div"))
       .find((node) =>
-        node.className.includes("overflow-hidden")
-        && node.className.includes("rounded-md")
-        && node.className.includes("border-border/60")
+        node.className.includes("overflow-clip")
+        && node.className.includes("rounded-lg")
+        && node.className.includes("bg-[var(--color-code-block-background")
       );
     expect(nestedDetailPanel).not.toBeUndefined();
     expect(nestedDetailPanel?.className).toMatch(/(?:^|\s)border(?:\s|$)/);
-    expect(nestedDetailPanel?.className).toContain("rounded-md");
+    expect(nestedDetailPanel?.className).toContain("rounded-lg");
   });
 });
 

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnSeparator.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnSeparator.tsx
@@ -26,7 +26,7 @@ export function TurnSeparator({
         size="sm"
         data-chat-transcript-ignore
         onClick={onClick}
-        className={`group/turn-separator h-auto max-w-full justify-start gap-1 whitespace-normal bg-transparent px-0 py-0 text-chat font-normal text-muted-foreground hover:bg-transparent hover:text-foreground focus-visible:outline-none focus-visible:ring-0 focus-visible:underline ${
+        className={`group/turn-separator h-auto max-w-full justify-start gap-1 whitespace-normal bg-transparent px-0 py-0 text-chat font-normal text-muted-foreground hover:bg-transparent active:bg-transparent hover:text-foreground focus-visible:outline-none focus-visible:ring-0 focus-visible:underline ${
           borderless ? "rounded-none border-0" : "rounded-md border border-transparent"
         }`}
         aria-expanded={expanded}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/WorkspaceCreationReceipt.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/WorkspaceCreationReceipt.tsx
@@ -20,6 +20,9 @@ import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-st
 import { useWorkspaceCollectionsInvalidation } from "#product/hooks/workspaces/cache/use-workspace-collections-invalidation";
 import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
 import { isWorkspaceArchivedRefusal } from "#product/lib/domain/workspaces/archived/workspace-archived-refusal";
+import { AutoHideScrollArea } from "#product/primitives/patterns/AutoHideScrollArea";
+import { TOOL_CALL_BODY_MAX_HEIGHT_CLASS } from "#product/domain/chats/tools/tool-call-layout";
+import { ToolActionDetailsPanel } from "#product/components/workspace/chat/tool-calls/ToolActionDetailsPanel";
 
 const LINE_TONE_CLASS = {
   default: "",
@@ -118,29 +121,32 @@ export function WorkspaceCreationReceiptView({
       </Button>
 
       {expanded && hasLog && (
-        // Recorded exclusion (DESIGN_SYSTEM.md § UI-conformance review,
-        // check 1): the setup log is an unfilled frame — a hairline around
-        // transcript ground, so the log reads as part of the column rather than
-        // as a raised card. `Card`'s two surfaces both paint a fill, and there
-        // is no borderless-with-edge spelling. Needs a ruling on `Card`.
-        <div
+        <ToolActionDetailsPanel
           id={logId}
           data-chat-transcript-ignore
-          className="group/receipt-log relative mt-1.5 max-w-full rounded-lg border border-border"
+          className="group/receipt-log relative mt-1.5 max-w-full"
         >
-          <div className="flex flex-col gap-0.5 overflow-x-auto px-3.5 py-3 font-mono text-readable-code text-muted-foreground">
-            {presentation.logLines.map((line, index) => (
-              <span key={index} className={`w-max whitespace-pre ${LINE_TONE_CLASS[line.tone]}`}>
-                {line.text}
-              </span>
-            ))}
-          </div>
+          <AutoHideScrollArea
+            className="w-full"
+            viewportClassName={TOOL_CALL_BODY_MAX_HEIGHT_CLASS}
+          >
+            <div className="flex flex-col gap-0.5 px-3 py-2 font-mono text-readable-code text-muted-foreground">
+              {presentation.logLines.map((line, index) => (
+                <span
+                  key={index}
+                  className={`whitespace-pre-wrap break-words ${LINE_TONE_CLASS[line.tone]}`}
+                >
+                  {line.text}
+                </span>
+              ))}
+            </div>
+          </AutoHideScrollArea>
           <div className="pointer-events-none absolute right-1 top-1 opacity-0 transition-opacity duration-hover group-hover/receipt-log:pointer-events-auto group-hover/receipt-log:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">
             <IconButton title={labels.copyLogTitle} size="sm" onClick={handleCopy}>
               <Copy className="icon-paired" />
             </IconButton>
           </div>
-        </div>
+        </ToolActionDetailsPanel>
       )}
 
       {showActions && (

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/WorkspaceCreationReceipt.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/WorkspaceCreationReceipt.tsx
@@ -92,7 +92,7 @@ export function WorkspaceCreationReceiptView({
         onClick={hasLog ? onToggleExpanded : undefined}
         aria-expanded={hasLog ? expanded : undefined}
         aria-controls={hasLog ? logId : undefined}
-        className="group/receipt h-auto max-w-full justify-start gap-1.5 rounded-none bg-transparent p-0 text-left text-chat font-normal text-muted-foreground/60 hover:bg-transparent hover:text-foreground focus-visible:ring-0 focus-visible:underline disabled:cursor-default disabled:opacity-100"
+        className="group/receipt h-auto max-w-full justify-start gap-1.5 rounded-none bg-transparent p-0 text-left text-chat font-normal text-muted-foreground/60 hover:bg-transparent active:bg-transparent hover:text-foreground focus-visible:ring-0 focus-visible:underline disabled:cursor-default disabled:opacity-100"
       >
         {/* The spinner owns the leading icon slot while work is in flight.
             Trailing the label instead means the indicator jumps to a new x


### PR DESCRIPTION
Fixes [PRO-120](https://linear.app/proliferate-team/issue/PRO-120/clicking-on-any-in-chat-tool-call-causes-an-ugly-box-to-appear) — clicking any in-chat tool call opened an ugly, inconsistent box.

## Problem

Two defects, one per commit:

**1. The pressed-state box (the literal complaint).** While actively clicking a tool-call title (e.g. "Workspace created"), a sharp-cornered `bg-active` rectangle flashes around the row. The transcript's quiet disclosure titles suppress the ghost Button's hover box with `hover:bg-transparent` but inherit its `active:bg-active`.

**2. Divergent expanded boxes.** The transcript had four expanded-tool-output box styles:

1. Shared `ToolActionDetailsPanel` — `border-border/60` wash on `bg-surface-elevated-secondary`
2. Inline duplicates of that style in `CollapsedCommandActionRow`, `CollapsedGenericActionRow`, `CollapsedEditActionRows` (drifted copies, not using the shared panel)
3. Bespoke `WorkspaceCreationReceipt` log with a full-strength `border-border` and non-wrapping `w-max whitespace-pre` lines that clipped long paths with no height clamp — the screenshot in the issue

## Fix

- `fdf4272d9`: suppress the pressed background wherever the hover background is already suppressed — `active:bg-transparent` beside every `hover:bg-transparent` on transcript/tool-call disclosure rows (17 sites, 11 files). `TurnMetadata`'s bordered chip keeps its pressed tint deliberately; `CollapsedActions`' summary row is `unstyled` and never leaked.
- `3c1c00daa`: restyle `ToolActionDetailsPanel` to the chat fenced-code-block card language from #1708: `overflow-clip rounded-lg border-transparent bg-[var(--color-code-block-background,var(--color-card))]`. The transparent border keeps size parity with bordered cards. Panel now spreads div props so callers can pass `id`/`data-*`. Fold all three inline copies onto the shared panel (drops their inner `border-t` dividers). Workspace-creation receipt log: wrapping lines (`whitespace-pre-wrap break-words`), `AutoHideScrollArea`, and the standard `TOOL_CALL_BODY_MAX_HEIGHT_CLASS` 224px clamp.

## Reviewer note

`TurnItemSequence.test.tsx` pins the panel's classes; the matcher is updated to the new surface (`overflow-clip` + code-block background var). This is an intentional expectation change, not a behavior change.

## Verification

- Full product-client suite: 5453/5454 (one pre-existing flake in `ComposerCommandEditor` slash-trigger test; passes in isolation); tool-calls + transcript suites re-run green after the pressed-state commit (34 files / 205 tests)
- `tsc` clean
- Exercised live in the koala dev profile via HMR; quick visual path: click any tool-call title, plus playground fixtures `workspace-receipt-setup-succeeded` / `workspace-receipt-setup-failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
