### PR TITLE
perf(product): keep sidebar separator drags smooth

### DIFF
--- a/apps/packages/product-client/src/app/authenticated-workspace-shell-motion.test.ts
+++ b/apps/packages/product-client/src/app/authenticated-workspace-shell-motion.test.ts
@@ -15,6 +15,7 @@ describe("authenticated workspace shell motion", () => {
     expect(stylesheet).toContain("var(--ease-out-cubic)");
     expect(stylesheet).toContain("[data-snap-left-geometry=\"true\"]");
     expect(stylesheet).toContain("[data-snap-right-geometry=\"true\"]");
+    expect(stylesheet).toContain("--workspace-left-geometry-duration: 0ms");
     expect(stylesheet).toContain("--workspace-right-geometry-duration: 0ms");
     expect(stylesheet).toContain("[data-manual-workspace-geometry=\"true\"]");
   });

--- a/apps/packages/product-client/src/app/authenticated.css
+++ b/apps/packages/product-client/src/app/authenticated.css
@@ -21,6 +21,8 @@
   transition-timing-function: var(--ease-out-cubic), var(--ease-out-cubic);
 }
 
+/* A live left-separator drag and the explicitly snapped toggle path both
+   publish exact geometry; ordinary open/close changes keep panel easing. */
 .standard-workspace-shell[data-snap-left-geometry="true"] {
   --workspace-left-geometry-duration: 0ms;
 }

--- a/apps/packages/product-client/src/components/settings/screen/SettingsScreen.tsx
+++ b/apps/packages/product-client/src/components/settings/screen/SettingsScreen.tsx
@@ -33,12 +33,7 @@ import { ArrowLeft } from "lucide-react";
 import { SETTINGS_COPY } from "#product/copy/settings/settings-copy";
 import { useCloudAvailabilityState } from "#product/hooks/cloud/derived/use-cloud-availability-state";
 import { useMacWindowControlsInsetClass } from "#product/hooks/ui/layout/use-mac-window-controls";
-import { useResize } from "#product/hooks/ui/layout/use-resize";
-import {
-  WORKSPACE_SIDEBAR_MAX_WIDTH,
-  WORKSPACE_SIDEBAR_MIN_WIDTH,
-} from "#product/lib/domain/preferences/workspace-ui/sidebar";
-import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+import { useWorkspaceSidebarResize } from "#product/hooks/preferences/ui/use-workspace-sidebar-resize";
 import { useUpdater } from "#product/hooks/access/tauri/use-updater";
 import { useIsAdmin } from "#product/hooks/access/cloud/organizations/use-is-admin";
 import { useActiveOrganization } from "#product/hooks/organizations/facade/use-active-organization";
@@ -115,15 +110,10 @@ export function SettingsScreen({
 
   // The settings sidebar shares the main sidebar's persisted width, so
   // resizing either surface keeps both in step.
-  const sidebarWidth = useWorkspaceUiStore((s) => s.sidebarWidth);
-  const setSidebarWidth = useWorkspaceUiStore((s) => s.setSidebarWidth);
-  const onSidebarSeparatorDown = useResize({
-    direction: "horizontal",
-    size: sidebarWidth,
-    onResize: setSidebarWidth,
-    min: WORKSPACE_SIDEBAR_MIN_WIDTH,
-    max: WORKSPACE_SIDEBAR_MAX_WIDTH,
-  });
+  const {
+    sidebarWidth,
+    onSidebarSeparatorDown,
+  } = useWorkspaceSidebarResize();
 
   // Only a host that actually paints macOS window buttons reserves room for
   // them; on Web the inset was dead space above the nav.

--- a/apps/packages/product-client/src/components/workspace/cowork/CoworkWorkspaceShell.tsx
+++ b/apps/packages/product-client/src/components/workspace/cowork/CoworkWorkspaceShell.tsx
@@ -6,6 +6,7 @@ import { IconButton } from "#product/primitives/IconButton";
 import { SplitPanelLeft } from "#product/primitives/icons/app-shell";
 import { CoworkArtifactsPanel } from "#product/components/workspace/cowork/CoworkArtifactsPanel";
 import { CoworkWorkspaceHeader } from "#product/components/workspace/cowork/CoworkWorkspaceHeader";
+import { useWorkspaceSidebarResize } from "#product/hooks/preferences/ui/use-workspace-sidebar-resize";
 import { useResize } from "#product/hooks/ui/layout/use-resize";
 import { useMacWindowControlsInsetClass } from "#product/hooks/ui/layout/use-mac-window-controls";
 import { useShortcutHandler } from "#product/hooks/shortcuts/lifecycle/use-shortcut-handler";
@@ -15,10 +16,6 @@ import {
   resolveMainSidebarEdgeClassName,
 } from "#product/lib/domain/preferences/workspace-chrome";
 import { useProductHost } from "#product/host/ProductHostProvider";
-import {
-  WORKSPACE_SIDEBAR_MAX_WIDTH,
-  WORKSPACE_SIDEBAR_MIN_WIDTH,
-} from "#product/lib/domain/preferences/workspace-ui/sidebar";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 import { useCoworkUiStore } from "#product/stores/cowork/cowork-ui-store";
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
@@ -44,14 +41,15 @@ export function CoworkWorkspaceShell({
   const {
     sidebarOpen,
     setSidebarOpen,
-    sidebarWidth,
-    setSidebarWidth,
   } = useWorkspaceUiStore(useShallow((state) => ({
     sidebarOpen: state.sidebarOpen,
     setSidebarOpen: state.setSidebarOpen,
-    sidebarWidth: state.sidebarWidth,
-    setSidebarWidth: state.setSidebarWidth,
   })));
+  const {
+    sidebarWidth,
+    sidebarResizing,
+    onSidebarSeparatorDown: onLeftSeparatorDown,
+  } = useWorkspaceSidebarResize();
   const canShowArtifactPanel = workspaceId !== null;
   const rightPanelOpen = useCoworkUiStore(
     (state) => (workspaceId ? state.artifactPanelOpenByWorkspaceId[workspaceId] === true : false),
@@ -74,13 +72,6 @@ export function CoworkWorkspaceShell({
   const activeSlot = useSessionDirectoryStore((state) =>
     activeSessionId ? state.entriesById[activeSessionId] ?? null : null
   );
-  const onLeftSeparatorDown = useResize({
-    direction: "horizontal",
-    size: sidebarWidth,
-    onResize: setSidebarWidth,
-    min: WORKSPACE_SIDEBAR_MIN_WIDTH,
-    max: WORKSPACE_SIDEBAR_MAX_WIDTH,
-  });
   const onRightSeparatorDown = useResize({
     direction: "horizontal",
     size: rightPanelWidth,
@@ -124,7 +115,11 @@ export function CoworkWorkspaceShell({
       >
         <div
           id="cowork-sidebar"
-          className={`flex shrink-0 flex-col overflow-hidden bg-sidebar transition-[width] duration-panel ease-in-out ${resolveMainSidebarEdgeClassName({
+          className={`flex shrink-0 flex-col overflow-hidden bg-sidebar ${
+            sidebarResizing
+              ? "transition-none"
+              : "transition-[width] duration-panel ease-in-out"
+          } ${resolveMainSidebarEdgeClassName({
             desktop: desktopHost,
             transparent: transparentChromeEnabled,
           })}`}

--- a/apps/packages/product-client/src/components/workspace/shell/screen/MainSidebarPageShell.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/MainSidebarPageShell.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { IconButton } from "#product/primitives/IconButton";
 import { SplitPanelLeft } from "#product/primitives/icons/app-shell";
-import { useResize } from "#product/hooks/ui/layout/use-resize";
+import { useWorkspaceSidebarResize } from "#product/hooks/preferences/ui/use-workspace-sidebar-resize";
 import { useMacWindowControlsInsetClass } from "#product/hooks/ui/layout/use-mac-window-controls";
 import { useTransparentChromeEnabled } from "#product/hooks/theme/derived/use-transparent-chrome";
 import {
@@ -9,10 +9,6 @@ import {
   resolveStandardWorkspaceChromeClasses,
 } from "#product/lib/domain/preferences/workspace-chrome";
 import { useProductHost } from "#product/host/ProductHostProvider";
-import {
-  WORKSPACE_SIDEBAR_MAX_WIDTH,
-  WORKSPACE_SIDEBAR_MIN_WIDTH,
-} from "#product/lib/domain/preferences/workspace-ui/sidebar";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 import { MainSidebar } from "#product/components/workspace/shell/sidebar/MainSidebar";
 import { SidebarUpdateFooterButton } from "#product/components/app/sidebar/SidebarUpdateFooterButton";
@@ -23,9 +19,12 @@ interface MainSidebarPageShellProps {
 
 export function MainSidebarPageShell({ children }: MainSidebarPageShellProps) {
   const sidebarOpen = useWorkspaceUiStore((s) => s.sidebarOpen);
-  const sidebarWidth = useWorkspaceUiStore((s) => s.sidebarWidth);
   const setSidebarOpen = useWorkspaceUiStore((s) => s.setSidebarOpen);
-  const setSidebarWidth = useWorkspaceUiStore((s) => s.setSidebarWidth);
+  const {
+    sidebarWidth,
+    sidebarResizing,
+    onSidebarSeparatorDown,
+  } = useWorkspaceSidebarResize();
   const transparentChromeEnabled = useTransparentChromeEnabled();
   const desktopHost = useProductHost().desktop !== null;
   // Only a host that actually paints macOS window buttons reserves room for
@@ -37,14 +36,6 @@ export function MainSidebarPageShell({ children }: MainSidebarPageShellProps) {
     showHeaderDivider: false,
     showContentTopBorder: false,
   });
-  const onLeftSeparatorDown = useResize({
-    direction: "horizontal",
-    size: sidebarWidth,
-    onResize: setSidebarWidth,
-    min: WORKSPACE_SIDEBAR_MIN_WIDTH,
-    max: WORKSPACE_SIDEBAR_MAX_WIDTH,
-  });
-
   return (
     <div
       className={`flex h-screen overflow-hidden ${chromeClasses.root}`}
@@ -54,7 +45,11 @@ export function MainSidebarPageShell({ children }: MainSidebarPageShellProps) {
         id="main-sidebar"
         // isolate: keeps sidebar-internal z-indexes below the resize
         // separator's overlapping hit strip (z-10 in the page context).
-        className={`isolate flex shrink-0 flex-col overflow-hidden bg-sidebar transition-[width] duration-panel ease-in-out ${resolveMainSidebarEdgeClassName({
+        className={`isolate flex shrink-0 flex-col overflow-hidden bg-sidebar ${
+          sidebarResizing
+            ? "transition-none"
+            : "transition-[width] duration-panel ease-in-out"
+        } ${resolveMainSidebarEdgeClassName({
           desktop: desktopHost,
           transparent: transparentChromeEnabled,
         })}`}
@@ -83,7 +78,7 @@ export function MainSidebarPageShell({ children }: MainSidebarPageShellProps) {
           role="separator"
           aria-orientation="vertical"
           aria-controls="main-sidebar"
-          onMouseDown={onLeftSeparatorDown}
+          onMouseDown={onSidebarSeparatorDown}
           className="relative z-10 -ml-1 flex w-1 shrink-0 cursor-col-resize items-center justify-center transition-colors hover:bg-primary/30 active:bg-primary/50"
         />
       )}

--- a/apps/packages/product-client/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
@@ -84,6 +84,7 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
   const {
     sidebarOpen,
     sidebarWidth,
+    sidebarResizing,
     rightPanelOpen,
     rightPanelState,
     rightPanelWidth,
@@ -102,6 +103,7 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
     rightWidth: hasWorkspaceShell && !hasLaunchIntentOnlyShell && rightPanelOpen
       ? rightPanelWidth
       : 0,
+    snapLeft: sidebarResizing,
     snapRight: rightPanelResizing,
     onToggleLeft: actions.onToggleSidebar,
   });

--- a/apps/packages/product-client/src/hooks/main/facade/use-main-screen-state.test.tsx
+++ b/apps/packages/product-client/src/hooks/main/facade/use-main-screen-state.test.tsx
@@ -1,0 +1,159 @@
+/* @vitest-environment jsdom */
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { MouseEvent as ReactMouseEvent } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useMainScreenState } from "#product/hooks/main/facade/use-main-screen-state";
+import { WORKSPACE_SIDEBAR_DEFAULT_WIDTH } from "#product/lib/domain/preferences/workspace-ui/sidebar";
+import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+
+const rightPanelState = vi.hoisted(() => ({
+  rightPanelState: { activeTab: "files" as const },
+  setRightPanelState: vi.fn(),
+  rightPanelOpen: false,
+  setRightPanelOpen: vi.fn(),
+  rightPanelWidth: 360,
+  setRightPanelWidth: vi.fn(),
+  rightPanelResizing: false,
+  rightPanelFocusRequestToken: 0,
+  requestRightPanelFocus: vi.fn(),
+  onRightSeparatorDown: vi.fn(),
+}));
+
+vi.mock("@anyharness/sdk-react", () => ({
+  useCurrentPullRequestQuery: () => ({ data: undefined }),
+  useGitStatusQuery: () => ({ data: undefined }),
+}));
+
+vi.mock("#product/hooks/main/facade/use-main-screen-right-panel", () => ({
+  useMainScreenRightPanel: () => rightPanelState,
+}));
+
+vi.mock("#product/hooks/workspaces/facade/use-selected-cloud-runtime-state", () => ({
+  useSelectedCloudRuntimeState: () => ({ state: null }),
+}));
+
+vi.mock("#product/hooks/workspaces/derived/use-hot-paint-gate", () => ({
+  useIsHotPaintGatePendingForWorkspace: () => false,
+}));
+
+vi.mock("#product/hooks/workspaces/cache/use-workspaces", () => ({
+  useWorkspaces: () => ({ data: { workspaces: [], repoRoots: [], cloudWorkspaces: [] } }),
+}));
+
+vi.mock("#product/stores/chat/chat-launch-intent-store", () => ({
+  useChatLaunchIntentStore: (selector: (state: { activeIntent: null }) => unknown) =>
+    selector({ activeIntent: null }),
+}));
+
+vi.mock("#product/stores/sessions/session-selection-store", () => ({
+  useSessionSelectionStore: (selector: (state: {
+    pendingWorkspaceEntry: null;
+    selectedWorkspaceId: null;
+    selectedLogicalWorkspaceId: null;
+  }) => unknown) => selector({
+    pendingWorkspaceEntry: null,
+    selectedWorkspaceId: null,
+    selectedLogicalWorkspaceId: null,
+  }),
+}));
+
+function mouseDownEvent(clientX: number): ReactMouseEvent {
+  return {
+    clientX,
+    clientY: 0,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  } as unknown as ReactMouseEvent;
+}
+
+describe("useMainScreenState sidebar drag", () => {
+  beforeEach(() => {
+    useWorkspaceUiStore.setState({
+      sidebarOpen: true,
+      sidebarWidth: WORKSPACE_SIDEBAR_DEFAULT_WIDTH,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("keeps live mousemoves transient and commits the final width once on release", () => {
+    const durableWidths: number[] = [];
+    const unsubscribe = useWorkspaceUiStore.subscribe((state, previous) => {
+      if (state.sidebarWidth !== previous.sidebarWidth) {
+        durableWidths.push(state.sidebarWidth);
+      }
+    });
+    const { result } = renderHook(() => useMainScreenState());
+
+    act(() => {
+      result.current.layout.onLeftSeparatorDown(mouseDownEvent(100));
+    });
+    act(() => {
+      for (let clientX = 101; clientX <= 200; clientX += 1) {
+        document.dispatchEvent(new MouseEvent("mousemove", { clientX }));
+      }
+    });
+
+    expect(result.current.layout.sidebarWidth).toBe(375);
+    expect(result.current.layout.sidebarResizing).toBe(true);
+    expect(durableWidths).toHaveLength(0);
+    expect(useWorkspaceUiStore.getState().sidebarWidth)
+      .toBe(WORKSPACE_SIDEBAR_DEFAULT_WIDTH);
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mouseup"));
+    });
+
+    expect(useWorkspaceUiStore.getState().sidebarWidth).toBe(375);
+    expect(result.current.layout.sidebarResizing).toBe(false);
+    expect(durableWidths).toEqual([375]);
+    unsubscribe();
+  });
+
+  it("does not commit when a separator press ends without movement", () => {
+    const durableWidths: number[] = [];
+    const unsubscribe = useWorkspaceUiStore.subscribe((state, previous) => {
+      if (state.sidebarWidth !== previous.sidebarWidth) {
+        durableWidths.push(state.sidebarWidth);
+      }
+    });
+    const { result } = renderHook(() => useMainScreenState());
+
+    act(() => {
+      result.current.layout.onLeftSeparatorDown(mouseDownEvent(100));
+      document.dispatchEvent(new MouseEvent("mouseup"));
+    });
+
+    expect(useWorkspaceUiStore.getState().sidebarWidth)
+      .toBe(WORKSPACE_SIDEBAR_DEFAULT_WIDTH);
+    expect(durableWidths).toEqual([]);
+    unsubscribe();
+  });
+
+  it("commits the latest live width when the owning surface unmounts mid-drag", () => {
+    const durableWidths: number[] = [];
+    const unsubscribe = useWorkspaceUiStore.subscribe((state, previous) => {
+      if (state.sidebarWidth !== previous.sidebarWidth) {
+        durableWidths.push(state.sidebarWidth);
+      }
+    });
+    const { result, unmount } = renderHook(() => useMainScreenState());
+
+    act(() => {
+      result.current.layout.onLeftSeparatorDown(mouseDownEvent(100));
+      document.dispatchEvent(new MouseEvent("mousemove", { clientX: 150 }));
+    });
+    expect(result.current.layout.sidebarWidth).toBe(325);
+    expect(durableWidths).toEqual([]);
+
+    act(() => unmount());
+
+    expect(useWorkspaceUiStore.getState().sidebarWidth).toBe(325);
+    expect(durableWidths).toEqual([325]);
+    unsubscribe();
+  });
+});

--- a/apps/packages/product-client/src/hooks/main/facade/use-main-screen-state.ts
+++ b/apps/packages/product-client/src/hooks/main/facade/use-main-screen-state.ts
@@ -7,20 +7,16 @@ import {
   type MouseEvent,
   type SetStateAction,
 } from "react";
-import { useResize } from "#product/hooks/ui/layout/use-resize";
 import {
   useMainScreenRightPanel,
   type MainScreenRightPanelState,
 } from "#product/hooks/main/facade/use-main-screen-right-panel";
+import { useWorkspaceSidebarResize } from "#product/hooks/preferences/ui/use-workspace-sidebar-resize";
 import { useSelectedCloudRuntimeState } from "#product/hooks/workspaces/facade/use-selected-cloud-runtime-state";
 import { useIsHotPaintGatePendingForWorkspace } from "#product/hooks/workspaces/derived/use-hot-paint-gate";
 import { useWorkspaces } from "#product/hooks/workspaces/cache/use-workspaces";
 import { shouldMountWorkspaceShell } from "#product/lib/domain/chat/surface/chat-surface";
 import { parseCloudWorkspaceSyntheticId } from "#product/lib/domain/workspaces/cloud/cloud-ids";
-import {
-  WORKSPACE_SIDEBAR_MAX_WIDTH,
-  WORKSPACE_SIDEBAR_MIN_WIDTH,
-} from "#product/lib/domain/preferences/workspace-ui/sidebar";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 import { resolveSelectedWorkspaceIdentity } from "#product/lib/domain/workspaces/selection/workspace-ui-key";
 import { useChatLaunchIntentStore } from "#product/stores/chat/chat-launch-intent-store";
@@ -40,6 +36,8 @@ export interface MainScreenLayoutState extends MainScreenRightPanelState {
   setSidebarOpen: Dispatch<SetStateAction<boolean>>;
   sidebarWidth: number;
   setSidebarWidth: Dispatch<SetStateAction<number>>;
+  /** True while the left separator is driving live, non-durable geometry. */
+  sidebarResizing: boolean;
   terminalActivationRequest: TerminalActivationRequest | null;
   setTerminalActivationRequest: Dispatch<SetStateAction<TerminalActivationRequest | null>>;
   publishDialog: PublishDialogState;
@@ -97,15 +95,12 @@ export function useMainScreenState(): MainScreenState {
   const isCloudWorkspaceSelected = selectedCloudWorkspaceId !== null;
   const sidebarOpen = useWorkspaceUiStore((state) => state.sidebarOpen);
   const setSidebarOpen = useWorkspaceUiStore((state) => state.setSidebarOpen);
-  const sidebarWidth = useWorkspaceUiStore((state) => state.sidebarWidth);
-  const setSidebarWidth = useWorkspaceUiStore((state) => state.setSidebarWidth);
-  const onLeftSeparatorDown = useResize({
-    direction: "horizontal",
-    size: sidebarWidth,
-    onResize: setSidebarWidth,
-    min: WORKSPACE_SIDEBAR_MIN_WIDTH,
-    max: WORKSPACE_SIDEBAR_MAX_WIDTH,
-  });
+  const {
+    sidebarWidth,
+    setSidebarWidth,
+    sidebarResizing,
+    onSidebarSeparatorDown: onLeftSeparatorDown,
+  } = useWorkspaceSidebarResize();
 
   // The right panel's frame — geometry, open state, focus requests and the
   // separator drag that can collapse it — is its own concern; this facade only
@@ -180,6 +175,7 @@ export function useMainScreenState(): MainScreenState {
       setSidebarOpen,
       sidebarWidth,
       setSidebarWidth,
+      sidebarResizing,
       terminalActivationRequest,
       setTerminalActivationRequest,
       publishDialog,

--- a/apps/packages/product-client/src/hooks/main/workflows/use-main-screen-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/main/workflows/use-main-screen-actions.test.tsx
@@ -247,6 +247,7 @@ function mainScreenLayout(overrides: Partial<MainScreenLayoutState> = {}): {
       setSidebarOpen: vi.fn(),
       sidebarWidth: 280,
       setSidebarWidth: vi.fn(),
+      sidebarResizing: false,
       rightPanelOpen: false,
       setRightPanelOpen,
       rightPanelFocusRequestToken: 0,

--- a/apps/packages/product-client/src/hooks/preferences/ui/use-workspace-sidebar-resize.ts
+++ b/apps/packages/product-client/src/hooks/preferences/ui/use-workspace-sidebar-resize.ts
@@ -1,0 +1,73 @@
+import {
+  useCallback,
+  useRef,
+  useState,
+  type Dispatch,
+  type MouseEvent,
+  type SetStateAction,
+} from "react";
+import { useResize } from "#product/hooks/ui/layout/use-resize";
+import {
+  WORKSPACE_SIDEBAR_MAX_WIDTH,
+  WORKSPACE_SIDEBAR_MIN_WIDTH,
+} from "#product/lib/domain/preferences/workspace-ui/sidebar";
+import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+
+interface WorkspaceSidebarResizeState {
+  sidebarWidth: number;
+  setSidebarWidth: Dispatch<SetStateAction<number>>;
+  sidebarResizing: boolean;
+  onSidebarSeparatorDown: (event: MouseEvent) => void;
+}
+
+// Owns the shared sidebar's pointer-driven width. Live drag values stay local
+// so the durable workspace-ui store (and its persistence subscriber) observes
+// one completed gesture instead of every mousemove.
+export function useWorkspaceSidebarResize(): WorkspaceSidebarResizeState {
+  const durableSidebarWidth = useWorkspaceUiStore((state) => state.sidebarWidth);
+  const setSidebarWidth = useWorkspaceUiStore((state) => state.setSidebarWidth);
+  const [sessionSidebarWidth, setSessionSidebarWidth] = useState<number | null>(null);
+  const [sidebarResizing, setSidebarResizing] = useState(false);
+  const draggedSidebarWidthRef = useRef<number | null>(null);
+
+  const handleSidebarResize = useCallback((width: number) => {
+    draggedSidebarWidthRef.current = width;
+    setSessionSidebarWidth(width);
+  }, []);
+
+  const handleSidebarResizeEnd = useCallback(() => {
+    const draggedWidth = draggedSidebarWidthRef.current;
+    draggedSidebarWidthRef.current = null;
+    setSidebarResizing(false);
+
+    if (
+      draggedWidth !== null
+      && draggedWidth !== useWorkspaceUiStore.getState().sidebarWidth
+    ) {
+      setSidebarWidth(draggedWidth);
+    }
+    setSessionSidebarWidth(null);
+  }, [setSidebarWidth]);
+
+  const beginSidebarResize = useResize({
+    direction: "horizontal",
+    size: sessionSidebarWidth ?? durableSidebarWidth,
+    onResize: handleSidebarResize,
+    onResizeEnd: handleSidebarResizeEnd,
+    min: WORKSPACE_SIDEBAR_MIN_WIDTH,
+    max: WORKSPACE_SIDEBAR_MAX_WIDTH,
+  });
+
+  const onSidebarSeparatorDown = useCallback((event: MouseEvent) => {
+    draggedSidebarWidthRef.current = null;
+    setSidebarResizing(true);
+    beginSidebarResize(event);
+  }, [beginSidebarResize]);
+
+  return {
+    sidebarWidth: sessionSidebarWidth ?? durableSidebarWidth,
+    setSidebarWidth,
+    sidebarResizing,
+    onSidebarSeparatorDown,
+  };
+}

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-shell-geometry.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-shell-geometry.test.tsx
@@ -21,15 +21,23 @@ function stubReducedMotion(matches: boolean): void {
 function GeometryHarness({
   leftWidth,
   rightWidth,
+  snapLeft = false,
   snapRight = false,
   onToggleLeft = () => {},
 }: {
   leftWidth: number;
   rightWidth: number;
+  snapLeft?: boolean;
   snapRight?: boolean;
   onToggleLeft?: () => void;
 }) {
-  const geometry = useWorkspaceShellGeometry({ leftWidth, rightWidth, snapRight, onToggleLeft });
+  const geometry = useWorkspaceShellGeometry({
+    leftWidth,
+    rightWidth,
+    snapLeft,
+    snapRight,
+    onToggleLeft,
+  });
   return (
     <>
       <div
@@ -137,6 +145,37 @@ describe("useWorkspaceShellGeometry", () => {
     act(() => frames.shift()?.(motion.duration.panelMs));
     expect(root.style.getPropertyValue("--workspace-left-width")).toBe("280px");
     expect(root.style.getPropertyValue("--workspace-right-width")).toBe("500px");
+  });
+
+  it("applies pointer-driven left widths immediately without a release tween on manual renderers", () => {
+    vi.stubGlobal("CSS", {});
+    stubReducedMotion(false);
+    const frames: FrameRequestCallback[] = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+    const { getByTestId, rerender } = render(
+      <GeometryHarness leftWidth={275} rightWidth={360} />,
+    );
+
+    // A live left drag lands on the cursor-provided width and schedules no
+    // interpolation work for that edge.
+    rerender(
+      <GeometryHarness leftWidth={375} rightWidth={360} snapLeft />,
+    );
+    const root = getByTestId("geometry");
+    expect(root.dataset.snap).toBe("true");
+    expect(frames).toHaveLength(0);
+    expect(root.style.getPropertyValue("--workspace-left-width")).toBe("375px");
+
+    // Releasing at the same target removes the snap contract without adding
+    // a 240ms tail animation after the pointer has stopped.
+    rerender(<GeometryHarness leftWidth={375} rightWidth={360} />);
+    expect(root.dataset.snap).toBe("false");
+    expect(frames).toHaveLength(0);
+    expect(root.style.getPropertyValue("--workspace-left-width")).toBe("375px");
   });
 
   it("clears a pending pin snap before a rapid ordinary toggle", () => {

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-shell-geometry.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-shell-geometry.ts
@@ -19,6 +19,11 @@ interface UseWorkspaceShellGeometryOptions {
   leftWidth: number;
   rightWidth: number;
   /**
+   * Held true while the left separator drag is live. Pointer-driven geometry
+   * must not retain the open/close easing or the edge trails the cursor.
+   */
+  snapLeft?: boolean;
+  /**
    * Held true while the right separator drag is live. A pointer-driven width
    * must land exactly where the cursor is on every frame — easing it would
    * rubber-band the panel edge behind the pointer and keep re-laying the
@@ -50,13 +55,14 @@ function easeOutCubic(progress: number): number {
 export function useWorkspaceShellGeometry({
   leftWidth,
   rightWidth,
+  snapLeft: requestedSnapLeft = false,
   snapRight = false,
   onToggleLeft,
 }: UseWorkspaceShellGeometryOptions): WorkspaceShellGeometry {
   const rootRef = useRef<HTMLDivElement>(null);
   const frameRef = useRef<number | null>(null);
   const snapClearFrameRef = useRef<number | null>(null);
-  const [snapLeft, setSnapLeft] = useState(false);
+  const [toggleSnapLeft, setToggleSnapLeft] = useState(false);
   const renderedRef = useRef<WorkspaceShellWidths>({
     left: leftWidth,
     right: rightWidth,
@@ -71,20 +77,22 @@ export function useWorkspaceShellGeometry({
     }
 
     if (!options?.snapGeometry) {
-      setSnapLeft(false);
+      setToggleSnapLeft(false);
       onToggleLeft();
       return;
     }
 
-    setSnapLeft(true);
+    setToggleSnapLeft(true);
     onToggleLeft();
     snapClearFrameRef.current = window.requestAnimationFrame(() => {
       snapClearFrameRef.current = window.requestAnimationFrame(() => {
         snapClearFrameRef.current = null;
-        setSnapLeft(false);
+        setToggleSnapLeft(false);
       });
     });
   }, [onToggleLeft]);
+
+  const snapLeft = requestedSnapLeft || toggleSnapLeft;
 
   useLayoutEffect(() => {
     if (!usesManualInterpolation) {


### PR DESCRIPTION
## Linear tickets

- [PRO-95 — Sidebar dragging lags](https://linear.app/proliferate-team/issue/PRO-95/sidebar-dragging-lags)

## Summary

- keep pointer-driven sidebar widths in transient React state and commit the durable workspace preference once when the gesture ends
- apply the shared resize path to standard workspace, page, Cowork, and Settings sidebars
- snap left-shell geometry during a live drag while preserving the existing eased open/close motion

## Root cause

Each document `mousemove` called the persisted Zustand `setSidebarWidth` action. The workspace UI lifecycle then selected and sanitized both persisted slices, serialized both for equality, serialized the current slice again for storage, and wrote it through the host storage adapter for every pointer event.

At the same time, the standard shell transitioned `--workspace-left-width` for the full 240 ms panel duration. The page and Cowork shells likewise transitioned `width`. Every incoming mousemove retargeted that layout transition; the manual fallback cancelled and restarted its equivalent rAF tween. The separator therefore eased toward stale targets instead of staying under the cursor while the whole shell repeatedly re-laid out.

## Verification

- fail-before regression on `origin/main`: 100 real document mousemoves produced 100 durable sidebar-width updates
- pass-after regression: the same gesture renders the exact final 375 px width, produces 0 durable updates during the drag, and exactly 1 on release
- release-without-movement produces 0 commits; unmount-mid-drag commits the latest width once
- manual geometry fallback schedules 0 interpolation frames during the drag and 0 tail frames on release
- `@proliferate/product-client` production build and typecheck pass
- 25 focused resize/shell tests pass
- 5,457 product-client tests pass when excluding the unrelated browser-only Markdown cascade test
- frontend boundary, appearance scaling, design attribution, and diff checks pass

The full default test command reached 5,457 passing tests; its only failure was the browser-only Markdown cascade suite because Google Chrome is not installed at the expected macOS application path.

## Observability

No telemetry schema or event changes. The existing workspace UI diagnostic will naturally report one durable sidebar-width write per completed gesture instead of one per pointer event.