### PR TITLE
feat(anyharness): add agent operations contracts

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/auth.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/auth.rs
@@ -1,0 +1,42 @@
+use std::path::PathBuf;
+
+use crate::integrations::mcp::capability_token::McpCapabilityTokenSignature;
+use crate::integrations::mcp::product_server::{
+    ProductMcpAuth, ProductMcpAuthHeader, ProductMcpRequestContext, ProductMcpTokenValidation,
+};
+
+const SECRET_FILE_NAME: &str = "workspace-mcp-token.key";
+
+#[derive(Clone)]
+pub struct WorkspaceMcpAuth {
+    inner: ProductMcpAuth,
+}
+
+impl WorkspaceMcpAuth {
+    pub fn new(runtime_home: PathBuf) -> Self {
+        Self {
+            inner: ProductMcpAuth::new(
+                runtime_home,
+                SECRET_FILE_NAME,
+                McpCapabilityTokenSignature::HmacSha256,
+                super::definition::ID,
+            ),
+        }
+    }
+
+    pub fn mint_capability_token(
+        &self,
+        workspace_id: &str,
+        session_id: &str,
+    ) -> anyhow::Result<String> {
+        self.inner.mint_capability_token(workspace_id, session_id)
+    }
+
+    pub fn validate_capability_header(
+        &self,
+        header: ProductMcpAuthHeader<'_>,
+        request: &ProductMcpRequestContext,
+    ) -> anyhow::Result<ProductMcpTokenValidation> {
+        self.inner.validate_capability_header(header, request)
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/calls.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/calls.rs
@@ -1,0 +1,101 @@
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use super::context::WorkspaceMcpContext;
+use crate::domains::agent_operations::model::{
+    AgentIdentity, AgentPresentationStatus, ListAgentsInput,
+};
+use crate::domains::agent_operations::runtime::{AgentOperations, AgentOperationsError};
+use crate::integrations::mcp::tools::McpToolCallError;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct EmptyArgs {}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct TargetArgs {
+    agent_id: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ListAgentsArgs {
+    workspace_id: Option<String>,
+    status: Option<AgentPresentationStatus>,
+    cursor: Option<String>,
+    limit: Option<usize>,
+}
+
+pub async fn call_tool(
+    operations: &AgentOperations,
+    ctx: &WorkspaceMcpContext,
+    name: &str,
+    arguments: Option<Value>,
+) -> anyhow::Result<Value> {
+    match name {
+        "whoami" => {
+            parse::<EmptyArgs>(arguments)?;
+            serialize(operations.whoami(&ctx.caller).await)
+        }
+        "list_agents" => {
+            let args = parse::<ListAgentsArgs>(arguments)?;
+            serialize(
+                operations
+                    .list_agents(
+                        &ctx.caller,
+                        ListAgentsInput {
+                            workspace_id: args.workspace_id,
+                            status: args.status,
+                            cursor: args.cursor,
+                            limit: args.limit.unwrap_or(
+                                crate::domains::agent_operations::model::DEFAULT_AGENT_PAGE_SIZE,
+                            ),
+                        },
+                    )
+                    .await,
+            )
+        }
+        "get_agent" => {
+            let args = parse::<TargetArgs>(arguments)?;
+            let target = AgentIdentity::new(operations.runtime_identity().clone(), args.agent_id);
+            serialize(operations.get_agent(&ctx.caller, &target).await)
+        }
+        "list_subagents" => {
+            parse::<EmptyArgs>(arguments)?;
+            serialize(operations.list_subagents(&ctx.caller).await)
+        }
+        declared if super::tools::TOOL_NAMES.contains(&declared) => {
+            Err(anyhow::Error::new(McpToolCallError::new(
+                "WORKSPACE_MCP_OPERATION_NOT_IMPLEMENTED",
+                "This Workspace operation is declared for a later implementation slice.",
+            )))
+        }
+        _ => Err(anyhow::Error::new(McpToolCallError::new(
+            "WORKSPACE_MCP_TOOL_NOT_FOUND",
+            "Unknown Workspace tool.",
+        ))),
+    }
+}
+
+fn parse<T: DeserializeOwned>(arguments: Option<Value>) -> anyhow::Result<T> {
+    serde_json::from_value(arguments.unwrap_or_else(|| json!({}))).map_err(|_| {
+        anyhow::Error::new(McpToolCallError::new(
+            "WORKSPACE_MCP_ARGUMENTS_INVALID",
+            "Workspace tool arguments are invalid.",
+        ))
+    })
+}
+
+fn serialize<T: serde::Serialize>(
+    result: Result<T, AgentOperationsError>,
+) -> anyhow::Result<Value> {
+    match result {
+        Ok(value) => serde_json::to_value(value).map_err(Into::into),
+        Err(error) => Err(anyhow::Error::new(McpToolCallError::new(
+            error.code(),
+            error.public_message(),
+        ))),
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/context.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/context.rs
@@ -1,0 +1,27 @@
+use crate::domains::agent_operations::model::AuthenticatedAgentCaller;
+use crate::domains::agent_operations::runtime::AgentOperations;
+use crate::integrations::mcp::product_server::{ProductMcpContextError, ProductMcpRequestContext};
+
+#[derive(Debug, Clone)]
+pub struct WorkspaceMcpContext {
+    pub caller: AuthenticatedAgentCaller,
+}
+
+pub fn resolve_context(
+    operations: &AgentOperations,
+    request: &ProductMcpRequestContext,
+) -> Result<WorkspaceMcpContext, ProductMcpContextError> {
+    if request.product_mcp_id != super::definition::ID {
+        return Err(ProductMcpContextError::not_found("Workspace MCP not found"));
+    }
+    let caller = operations.authenticated_caller(request.session_id.clone());
+    operations
+        .verify_caller_workspace(&caller, &request.workspace_id)
+        .map_err(|error| match error {
+            crate::domains::agent_operations::runtime::AgentOperationsError::Internal(error) => {
+                ProductMcpContextError::Internal(error)
+            }
+            _ => ProductMcpContextError::not_found("calling agent not found"),
+        })?;
+    Ok(WorkspaceMcpContext { caller })
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/definition.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/definition.rs
@@ -1,0 +1,21 @@
+use crate::integrations::mcp::product_server::{
+    ProductMcpDefinition, ProductMcpPromptPolicy, ProductMcpVisibility,
+};
+
+pub const ID: &str = "workspace";
+pub const ROUTE_SLUG: &str = "workspace";
+pub const ACP_SERVER_NAME: &str = "workspace";
+
+pub const DEFINITION: ProductMcpDefinition = ProductMcpDefinition {
+    id: ID,
+    route_slug: ROUTE_SLUG,
+    acp_server_name: ACP_SERVER_NAME,
+    server_info_name: "proliferate-workspace",
+    display_name: "Workspace",
+    description: "Inspect and operate this Proliferate runtime.",
+    visibility: ProductMcpVisibility::Internal,
+    instructions: "Use Workspace tools to inspect runtime identity, workspaces, agents, and delegated subagents. Authorization is evaluated on every call.",
+    unauthorized_code: "WORKSPACE_MCP_UNAUTHORIZED",
+    request_invalid_code: "WORKSPACE_MCP_REQUEST_INVALID",
+    prompt_policy: ProductMcpPromptPolicy::System,
+};

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/mod.rs
@@ -1,0 +1,69 @@
+pub mod auth;
+mod calls;
+pub mod context;
+pub mod definition;
+pub mod tools;
+
+#[cfg(test)]
+mod tests;
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use self::auth::WorkspaceMcpAuth;
+use self::context::WorkspaceMcpContext;
+use crate::domains::agent_operations::runtime::AgentOperations;
+use crate::integrations::mcp::product_server::{
+    ProductMcpAuthHeader, ProductMcpContextError, ProductMcpDefinition, ProductMcpRequestContext,
+    ProductMcpServer, ProductMcpTokenValidation,
+};
+
+pub struct WorkspaceProductMcpServer {
+    operations: Arc<AgentOperations>,
+    auth: Arc<WorkspaceMcpAuth>,
+}
+
+impl WorkspaceProductMcpServer {
+    pub fn new(operations: Arc<AgentOperations>, auth: Arc<WorkspaceMcpAuth>) -> Self {
+        Self { operations, auth }
+    }
+}
+
+#[async_trait]
+impl ProductMcpServer for WorkspaceProductMcpServer {
+    type Context = WorkspaceMcpContext;
+
+    fn definition(&self) -> &'static ProductMcpDefinition {
+        &definition::DEFINITION
+    }
+
+    fn validate_capability_token(
+        &self,
+        header: ProductMcpAuthHeader<'_>,
+        request: &ProductMcpRequestContext,
+    ) -> anyhow::Result<ProductMcpTokenValidation> {
+        self.auth.validate_capability_header(header, request)
+    }
+
+    fn resolve_context(
+        &self,
+        request: &ProductMcpRequestContext,
+    ) -> Result<Self::Context, ProductMcpContextError> {
+        context::resolve_context(&self.operations, request)
+    }
+
+    fn tools(&self, _ctx: &Self::Context) -> Vec<Value> {
+        tools::build_tool_list()
+    }
+
+    async fn call_tool(
+        &self,
+        ctx: &Self::Context,
+        name: &str,
+        arguments: Option<Value>,
+    ) -> anyhow::Result<Value> {
+        calls::call_tool(&self.operations, ctx, name, arguments).await
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/tests.rs
@@ -1,0 +1,252 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::json;
+
+use super::*;
+use crate::domains::agent_operations::model::RuntimeIdentity;
+use crate::domains::agent_operations::runtime::{
+    AgentExecutionReads, AgentSessionReads, SubagentRelationshipReads,
+};
+use crate::domains::sessions::links::model::{
+    SessionLinkRecord, SessionLinkRelation, SessionLinkWorkspaceRelation,
+};
+use crate::domains::sessions::model::{
+    SessionExecutionState, SessionExecutionStatePhase, SessionMcpBindingPolicy, SessionRecord,
+};
+use crate::integrations::mcp::product_server::{
+    dispatch_product_mcp_request, ProductMcpRequestContext,
+};
+
+struct Sessions(Vec<SessionRecord>);
+
+impl AgentSessionReads for Sessions {
+    fn get_session(&self, session_id: &str) -> anyhow::Result<Option<SessionRecord>> {
+        Ok(self
+            .0
+            .iter()
+            .find(|session| session.id == session_id)
+            .cloned())
+    }
+
+    fn list_sessions(&self) -> anyhow::Result<Vec<SessionRecord>> {
+        Ok(self.0.clone())
+    }
+}
+
+struct Relationships(Vec<SessionLinkRecord>);
+
+impl SubagentRelationshipReads for Relationships {
+    fn find_parent_including_closed(
+        &self,
+        child_session_id: &str,
+    ) -> anyhow::Result<Option<SessionLinkRecord>> {
+        Ok(self
+            .0
+            .iter()
+            .find(|link| link.child_session_id == child_session_id)
+            .cloned())
+    }
+
+    fn list_children_including_closed(
+        &self,
+        parent_session_id: &str,
+    ) -> anyhow::Result<Vec<SessionLinkRecord>> {
+        Ok(self
+            .0
+            .iter()
+            .filter(|link| link.parent_session_id == parent_session_id)
+            .cloned()
+            .collect())
+    }
+}
+
+struct Execution;
+
+#[async_trait]
+impl AgentExecutionReads for Execution {
+    async fn execution_state(
+        &self,
+        _session: &SessionRecord,
+    ) -> anyhow::Result<SessionExecutionState> {
+        Ok(SessionExecutionState {
+            phase: SessionExecutionStatePhase::Idle,
+            has_live_handle: false,
+        })
+    }
+}
+
+fn session(id: &str, workspace_id: &str) -> SessionRecord {
+    SessionRecord {
+        id: id.to_string(),
+        workspace_id: workspace_id.to_string(),
+        agent_kind: "codex".to_string(),
+        native_session_id: None,
+        agent_auth_contexts: None,
+        requested_model_id: None,
+        current_model_id: None,
+        requested_mode_id: None,
+        current_mode_id: None,
+        title: Some(id.to_string()),
+        thinking_level_id: None,
+        thinking_budget_tokens: None,
+        status: "idle".to_string(),
+        created_at: "2026-08-10T00:00:00Z".to_string(),
+        updated_at: "2026-08-10T00:00:00Z".to_string(),
+        last_prompt_at: None,
+        closed_at: None,
+        dismissed_at: None,
+        mcp_bindings_ciphertext: None,
+        mcp_binding_summaries_json: None,
+        mcp_binding_policy: SessionMcpBindingPolicy::InheritWorkspace,
+        system_prompt_append: None,
+        subagents_enabled: true,
+        action_capabilities_json: None,
+        origin: None,
+    }
+}
+
+fn server() -> WorkspaceProductMcpServer {
+    let sessions = Arc::new(Sessions(vec![
+        session("P", "workspace-a"),
+        session("Q", "workspace-b"),
+        session("C", "workspace-a"),
+    ]));
+    let relationships = Arc::new(Relationships(vec![SessionLinkRecord {
+        id: "link-c".to_string(),
+        public_id: Some("subagent-c".to_string()),
+        relation: SessionLinkRelation::Subagent,
+        parent_session_id: "P".to_string(),
+        child_session_id: "C".to_string(),
+        workspace_relation: SessionLinkWorkspaceRelation::SameWorkspace,
+        label: Some("C".to_string()),
+        created_by_turn_id: None,
+        created_by_tool_call_id: None,
+        created_at: "2026-08-10T00:00:00Z".to_string(),
+        closed_at: None,
+    }]));
+    let operations = Arc::new(AgentOperations::new(
+        RuntimeIdentity::new("runtime-1"),
+        sessions,
+        relationships,
+        Arc::new(Execution),
+    ));
+    let auth = Arc::new(WorkspaceMcpAuth::new(
+        std::env::temp_dir().join(format!("workspace-mcp-contract-{}", uuid::Uuid::new_v4())),
+    ));
+    WorkspaceProductMcpServer::new(operations, auth)
+}
+
+fn context(workspace_id: &str, session_id: &str) -> ProductMcpRequestContext {
+    ProductMcpRequestContext::new(workspace_id, session_id, definition::ID)
+}
+
+#[tokio::test]
+async fn workspace_mcp_initialize_list_and_read_calls_use_authenticated_context() {
+    let server = server();
+    let initialize = dispatch_product_mcp_request(
+        &server,
+        context("workspace-a", "P"),
+        json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {} }),
+    )
+    .await
+    .expect("initialize dispatch")
+    .expect("initialize response");
+    assert_eq!(
+        initialize["result"]["serverInfo"]["name"],
+        "proliferate-workspace"
+    );
+
+    let list = dispatch_product_mcp_request(
+        &server,
+        context("workspace-a", "P"),
+        json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {} }),
+    )
+    .await
+    .expect("tools/list dispatch")
+    .expect("tools/list response");
+    assert_eq!(list["result"]["tools"].as_array().unwrap().len(), 18);
+
+    let whoami = dispatch_product_mcp_request(
+        &server,
+        context("workspace-a", "P"),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": { "name": "whoami", "arguments": {} }
+        }),
+    )
+    .await
+    .expect("whoami dispatch")
+    .expect("whoami response");
+    assert_eq!(
+        whoami["result"]["structuredContent"]["agent"]["identity"]["sessionId"],
+        "P"
+    );
+
+    let cross_workspace = dispatch_product_mcp_request(
+        &server,
+        context("workspace-a", "P"),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": { "name": "get_agent", "arguments": { "agentId": "Q" } }
+        }),
+    )
+    .await
+    .expect("get agent dispatch")
+    .expect("get agent response");
+    assert_eq!(
+        cross_workspace["result"]["structuredContent"]["identity"]["sessionId"],
+        "Q"
+    );
+}
+
+#[tokio::test]
+async fn workspace_mcp_denials_are_typed_and_do_not_leak_foreign_subagent_metadata() {
+    let server = server();
+    let denied = dispatch_product_mcp_request(
+        &server,
+        context("workspace-b", "Q"),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "name": "get_agent", "arguments": { "agentId": "C" } }
+        }),
+    )
+    .await
+    .expect("denied dispatch")
+    .expect("denied response");
+    assert_eq!(denied["result"]["isError"], true);
+    assert_eq!(
+        denied["result"]["structuredContent"]["error"]["code"],
+        "AGENT_NOT_FOUND"
+    );
+    let serialized = denied.to_string();
+    assert!(!serialized.contains("workspace-a"));
+    assert!(!serialized.contains("subagent-c"));
+
+    let spoofed = dispatch_product_mcp_request(
+        &server,
+        context("workspace-a", "P"),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "whoami",
+                "arguments": { "callerSessionId": "Q" }
+            }
+        }),
+    )
+    .await
+    .expect("spoof dispatch")
+    .expect("spoof response");
+    assert_eq!(
+        spoofed["result"]["structuredContent"]["error"]["code"],
+        "WORKSPACE_MCP_ARGUMENTS_INVALID"
+    );
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/tests.rs
@@ -15,7 +15,8 @@ use crate::domains::sessions::model::{
     SessionExecutionState, SessionExecutionStatePhase, SessionMcpBindingPolicy, SessionRecord,
 };
 use crate::integrations::mcp::product_server::{
-    dispatch_product_mcp_request, ProductMcpRequestContext,
+    dispatch_product_mcp_request, ProductMcpAuthHeader, ProductMcpRequestContext, ProductMcpServer,
+    ProductMcpTokenValidation,
 };
 
 struct Sessions(Vec<SessionRecord>);
@@ -106,7 +107,7 @@ fn session(id: &str, workspace_id: &str) -> SessionRecord {
     }
 }
 
-fn server() -> WorkspaceProductMcpServer {
+fn server() -> (WorkspaceProductMcpServer, Arc<WorkspaceMcpAuth>) {
     let sessions = Arc::new(Sessions(vec![
         session("P", "workspace-a"),
         session("Q", "workspace-b"),
@@ -134,18 +135,50 @@ fn server() -> WorkspaceProductMcpServer {
     let auth = Arc::new(WorkspaceMcpAuth::new(
         std::env::temp_dir().join(format!("workspace-mcp-contract-{}", uuid::Uuid::new_v4())),
     ));
-    WorkspaceProductMcpServer::new(operations, auth)
+    (
+        WorkspaceProductMcpServer::new(operations, auth.clone()),
+        auth,
+    )
 }
 
 fn context(workspace_id: &str, session_id: &str) -> ProductMcpRequestContext {
     ProductMcpRequestContext::new(workspace_id, session_id, definition::ID)
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum AuthenticatedDispatchError {
+    InvalidCapability,
+}
+
+async fn authenticated_dispatch(
+    server: &WorkspaceProductMcpServer,
+    token: &str,
+    request_context: ProductMcpRequestContext,
+    body: serde_json::Value,
+) -> Result<Option<serde_json::Value>, AuthenticatedDispatchError> {
+    let validation = server
+        .validate_capability_token(
+            ProductMcpAuthHeader::Product { value: token },
+            &request_context,
+        )
+        .expect("validate Workspace capability token");
+    if validation != ProductMcpTokenValidation::Valid {
+        return Err(AuthenticatedDispatchError::InvalidCapability);
+    }
+    Ok(dispatch_product_mcp_request(server, request_context, body)
+        .await
+        .expect("authenticated dispatch"))
+}
+
 #[tokio::test]
 async fn workspace_mcp_initialize_list_and_read_calls_use_authenticated_context() {
-    let server = server();
-    let initialize = dispatch_product_mcp_request(
+    let (server, auth) = server();
+    let token = auth
+        .mint_capability_token("workspace-a", "P")
+        .expect("mint Workspace capability token");
+    let initialize = authenticated_dispatch(
         &server,
+        &token,
         context("workspace-a", "P"),
         json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {} }),
     )
@@ -157,8 +190,9 @@ async fn workspace_mcp_initialize_list_and_read_calls_use_authenticated_context(
         "proliferate-workspace"
     );
 
-    let list = dispatch_product_mcp_request(
+    let list = authenticated_dispatch(
         &server,
+        &token,
         context("workspace-a", "P"),
         json!({ "jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {} }),
     )
@@ -167,8 +201,9 @@ async fn workspace_mcp_initialize_list_and_read_calls_use_authenticated_context(
     .expect("tools/list response");
     assert_eq!(list["result"]["tools"].as_array().unwrap().len(), 18);
 
-    let whoami = dispatch_product_mcp_request(
+    let whoami = authenticated_dispatch(
         &server,
+        &token,
         context("workspace-a", "P"),
         json!({
             "jsonrpc": "2.0",
@@ -185,8 +220,9 @@ async fn workspace_mcp_initialize_list_and_read_calls_use_authenticated_context(
         "P"
     );
 
-    let cross_workspace = dispatch_product_mcp_request(
+    let cross_workspace = authenticated_dispatch(
         &server,
+        &token,
         context("workspace-a", "P"),
         json!({
             "jsonrpc": "2.0",
@@ -206,9 +242,13 @@ async fn workspace_mcp_initialize_list_and_read_calls_use_authenticated_context(
 
 #[tokio::test]
 async fn workspace_mcp_denials_are_typed_and_do_not_leak_foreign_subagent_metadata() {
-    let server = server();
-    let denied = dispatch_product_mcp_request(
+    let (server, auth) = server();
+    let q_token = auth
+        .mint_capability_token("workspace-b", "Q")
+        .expect("mint Q Workspace capability token");
+    let denied = authenticated_dispatch(
         &server,
+        &q_token,
         context("workspace-b", "Q"),
         json!({
             "jsonrpc": "2.0",
@@ -229,8 +269,12 @@ async fn workspace_mcp_denials_are_typed_and_do_not_leak_foreign_subagent_metada
     assert!(!serialized.contains("workspace-a"));
     assert!(!serialized.contains("subagent-c"));
 
-    let spoofed = dispatch_product_mcp_request(
+    let p_token = auth
+        .mint_capability_token("workspace-a", "P")
+        .expect("mint P Workspace capability token");
+    let spoofed = authenticated_dispatch(
         &server,
+        &p_token,
         context("workspace-a", "P"),
         json!({
             "jsonrpc": "2.0",
@@ -249,4 +293,20 @@ async fn workspace_mcp_denials_are_typed_and_do_not_leak_foreign_subagent_metada
         spoofed["result"]["structuredContent"]["error"]["code"],
         "WORKSPACE_MCP_ARGUMENTS_INVALID"
     );
+}
+
+#[tokio::test]
+async fn workspace_capability_scope_rejects_mismatched_workspace_or_session_before_dispatch() {
+    let (server, auth) = server();
+    let token = auth
+        .mint_capability_token("workspace-a", "P")
+        .expect("mint Workspace capability token");
+    let body = json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {} });
+
+    for mismatched_context in [context("workspace-b", "P"), context("workspace-a", "Q")] {
+        assert_eq!(
+            authenticated_dispatch(&server, &token, mismatched_context, body.clone()).await,
+            Err(AuthenticatedDispatchError::InvalidCapability)
+        );
+    }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/tools.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/tools.rs
@@ -1,0 +1,297 @@
+use serde_json::{json, Value};
+
+use crate::integrations::mcp::tools::tool_definition;
+
+pub const TOOL_NAMES: [&str; 18] = [
+    "whoami",
+    "list_workspaces",
+    "list_workspace_options",
+    "list_agents",
+    "get_agent",
+    "list_subagents",
+    "list_agent_launch_options",
+    "list_agent_config_options",
+    "get_task_output",
+    "create_workspace",
+    "create_agent",
+    "configure_agent",
+    "resume_agent",
+    "send_message",
+    "interrupt_agent",
+    "close_subagent",
+    "open_subagent",
+    "promote_subagent",
+];
+
+pub fn build_tool_list() -> Vec<Value> {
+    vec![
+        tool_definition(
+            "whoami",
+            "Return the authenticated caller's runtime, workspace, role, parent, status, and effective capabilities.",
+            empty_schema(),
+        ),
+        tool_definition(
+            "list_workspaces",
+            "List workspaces hosted by this runtime.",
+            paginated_schema(),
+        ),
+        tool_definition(
+            "list_workspace_options",
+            "List current repository and workspace-creation choices for this runtime.",
+            empty_schema(),
+        ),
+        tool_definition(
+            "list_agents",
+            "List ordinary agents in this runtime; subagents are excluded.",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "workspaceId": { "type": "string" },
+                    "status": { "type": "string", "enum": ["running", "available", "closed"] },
+                    "cursor": { "type": "string" },
+                    "limit": { "type": "integer", "minimum": 1, "maximum": 100 }
+                }
+            }),
+        ),
+        tool_definition(
+            "get_agent",
+            "Get one same-runtime ordinary agent or a subagent owned by the caller.",
+            target_schema(),
+        ),
+        tool_definition(
+            "list_subagents",
+            "List the caller's current subagents, including Closed subagents.",
+            empty_schema(),
+        ),
+        tool_definition(
+            "list_agent_launch_options",
+            "List effective launch choices for an agent in a workspace.",
+            workspace_schema(),
+        ),
+        tool_definition(
+            "list_agent_config_options",
+            "List effective live configuration choices for an authorized agent.",
+            target_schema(),
+        ),
+        tool_definition(
+            "get_task_output",
+            "Read a bounded recent visible-message view for an authorized agent. Prefer send_message for a concise update.",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "agentId": { "type": "string" },
+                    "cursor": { "type": "string" },
+                    "limit": { "type": "integer", "minimum": 1, "maximum": 50, "default": 10 }
+                },
+                "required": ["agentId"]
+            }),
+        ),
+        tool_definition(
+            "create_workspace",
+            "Create a workspace on this runtime from a currently listed option.",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "repositoryId": { "type": "string" },
+                    "creationMode": { "type": "string" },
+                    "branch": { "type": "string" },
+                    "displayName": { "type": "string" }
+                },
+                "required": ["repositoryId", "creationMode"]
+            }),
+        ),
+        tool_definition(
+            "create_agent",
+            "Create an ordinary agent or same-workspace subagent using current launch choices.",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "workspaceId": { "type": "string" },
+                    "kind": { "type": "string", "enum": ["ordinary", "subagent"] },
+                    "task": { "type": "string" },
+                    "agentKind": { "type": "string" },
+                    "modelId": { "type": "string" },
+                    "modeId": { "type": "string" }
+                },
+                "required": ["workspaceId", "kind", "task"]
+            }),
+        ),
+        tool_definition(
+            "configure_agent",
+            "Apply one currently listed live configuration choice to an authorized agent.",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "agentId": { "type": "string" },
+                    "configId": { "type": "string" },
+                    "value": { "type": "string" }
+                },
+                "required": ["agentId", "configId", "value"]
+            }),
+        ),
+        tool_definition("resume_agent", "Resume an authorized cold agent.", target_schema()),
+        tool_definition(
+            "send_message",
+            "Durably send an attributed message to an authorized agent.",
+            json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "agentId": { "type": "string" },
+                    "message": { "type": "string" }
+                },
+                "required": ["agentId", "message"]
+            }),
+        ),
+        tool_definition("interrupt_agent", "Interrupt an authorized agent's active turn.", target_schema()),
+        tool_definition("close_subagent", "Close an owned subagent while preserving its conversation.", target_schema()),
+        tool_definition("open_subagent", "Open an owned Closed subagent on the same conversation.", target_schema()),
+        tool_definition("promote_subagent", "Promote an owned Open subagent into an ordinary agent without changing its session.", target_schema()),
+    ]
+}
+
+fn empty_schema() -> Value {
+    json!({ "type": "object", "additionalProperties": false, "properties": {} })
+}
+
+fn paginated_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "cursor": { "type": "string" },
+            "limit": { "type": "integer", "minimum": 1, "maximum": 100 }
+        }
+    })
+}
+
+fn target_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": { "agentId": { "type": "string" } },
+        "required": ["agentId"]
+    })
+}
+
+fn workspace_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": { "workspaceId": { "type": "string" } },
+        "required": ["workspaceId"]
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use sha2::{Digest, Sha256};
+
+    use super::*;
+
+    #[test]
+    fn workspace_mcp_declares_the_exact_frozen_tool_set_for_every_role() {
+        let tools = build_tool_list();
+        let names = tools
+            .iter()
+            .map(|tool| tool["name"].as_str().expect("tool name"))
+            .collect::<Vec<_>>();
+        assert_eq!(names, TOOL_NAMES);
+        assert_eq!(tools.len(), 18);
+    }
+
+    #[test]
+    fn workspace_mcp_tool_schema_snapshots() {
+        let tools = build_tool_list();
+        let actual = tools
+            .iter()
+            .map(|tool| {
+                let bytes = serde_jcs::to_vec(&tool["inputSchema"]).expect("canonical schema");
+                (
+                    tool["name"].as_str().unwrap(),
+                    format!("{:x}", Sha256::digest(bytes)),
+                )
+            })
+            .collect::<Vec<_>>();
+        let expected = vec![
+            (
+                "whoami",
+                "99334726611ccf58a148b0814696bfa6fe08c1b2d027e946beccf5a74331c9aa".to_string(),
+            ),
+            (
+                "list_workspaces",
+                "8594214a14bdfe6be83b5033daa8633803d9dabee600d4f5261d01279cccb563".to_string(),
+            ),
+            (
+                "list_workspace_options",
+                "99334726611ccf58a148b0814696bfa6fe08c1b2d027e946beccf5a74331c9aa".to_string(),
+            ),
+            (
+                "list_agents",
+                "8a7b6993f5bc22d4c75c36bd1c1888d46175c5d5e0c0164acfe98274e697f996".to_string(),
+            ),
+            (
+                "get_agent",
+                "5eaf201fb6b40a613172523762396d833c3c846308801901860839f616feef02".to_string(),
+            ),
+            (
+                "list_subagents",
+                "99334726611ccf58a148b0814696bfa6fe08c1b2d027e946beccf5a74331c9aa".to_string(),
+            ),
+            (
+                "list_agent_launch_options",
+                "0d410ecafd8bb89b734fbe54575ce1321e07445554ed19942980c506ca093f31".to_string(),
+            ),
+            (
+                "list_agent_config_options",
+                "5eaf201fb6b40a613172523762396d833c3c846308801901860839f616feef02".to_string(),
+            ),
+            (
+                "get_task_output",
+                "2080dee0c750ebc85af285847bf07607d3c66130dd941fc77b769d112aa70b85".to_string(),
+            ),
+            (
+                "create_workspace",
+                "6c13aff42df908bfc4df40ffeedd2d9f21d2cb70afb2719b9e7be728fc8c9687".to_string(),
+            ),
+            (
+                "create_agent",
+                "76fd71ec067fcd30cd926cae2d5452c733024105b92c6e96f1f0f5f9b410439a".to_string(),
+            ),
+            (
+                "configure_agent",
+                "2669893bebf02d0ec1cddb5ec9b21302fe2fe1d7601496bb1e5692ef569595a1".to_string(),
+            ),
+            (
+                "resume_agent",
+                "5eaf201fb6b40a613172523762396d833c3c846308801901860839f616feef02".to_string(),
+            ),
+            (
+                "send_message",
+                "cd86d3405f350ab79043b3c38eb069c9b536adc8be841cbf55833e1cf2e31009".to_string(),
+            ),
+            (
+                "interrupt_agent",
+                "5eaf201fb6b40a613172523762396d833c3c846308801901860839f616feef02".to_string(),
+            ),
+            (
+                "close_subagent",
+                "5eaf201fb6b40a613172523762396d833c3c846308801901860839f616feef02".to_string(),
+            ),
+            (
+                "open_subagent",
+                "5eaf201fb6b40a613172523762396d833c3c846308801901860839f616feef02".to_string(),
+            ),
+            (
+                "promote_subagent",
+                "5eaf201fb6b40a613172523762396d833c3c846308801901860839f616feef02".to_string(),
+            ),
+        ];
+        assert_eq!(actual, expected);
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/tools.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/tools.rs
@@ -112,12 +112,20 @@ pub fn build_tool_list() -> Vec<Value> {
                 "properties": {
                     "workspaceId": { "type": "string" },
                     "kind": { "type": "string", "enum": ["ordinary", "subagent"] },
-                    "task": { "type": "string" },
+                    "task": {
+                        "type": "string",
+                        "description": "Required for subagents; optional for ordinary agents."
+                    },
                     "agentKind": { "type": "string" },
                     "modelId": { "type": "string" },
                     "modeId": { "type": "string" }
                 },
-                "required": ["workspaceId", "kind", "task"]
+                "required": ["workspaceId", "kind"],
+                "if": {
+                    "properties": { "kind": { "const": "subagent" } },
+                    "required": ["kind"]
+                },
+                "then": { "required": ["task"] }
             }),
         ),
         tool_definition(
@@ -206,6 +214,26 @@ mod tests {
     }
 
     #[test]
+    fn create_agent_requires_task_only_for_subagents() {
+        let tools = build_tool_list();
+        let schema = tools
+            .iter()
+            .find(|tool| tool["name"] == "create_agent")
+            .map(|tool| &tool["inputSchema"])
+            .expect("create_agent schema");
+
+        assert_eq!(schema["required"], json!(["workspaceId", "kind"]));
+        assert_eq!(
+            schema["if"],
+            json!({
+                "properties": { "kind": { "const": "subagent" } },
+                "required": ["kind"]
+            })
+        );
+        assert_eq!(schema["then"], json!({ "required": ["task"] }));
+    }
+
+    #[test]
     fn workspace_mcp_tool_schema_snapshots() {
         let tools = build_tool_list();
         let actual = tools
@@ -261,7 +289,7 @@ mod tests {
             ),
             (
                 "create_agent",
-                "76fd71ec067fcd30cd926cae2d5452c733024105b92c6e96f1f0f5f9b410439a".to_string(),
+                "9e1467ed625a438a3fa71a4bbd3cdf7bfb504cf35fd881eb5bd99c8e91137228".to_string(),
             ),
             (
                 "configure_agent",

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/mod.rs
@@ -1,0 +1,9 @@
+//! Cross-resource application boundary for agent-initiated runtime operations.
+//!
+//! MCP and HTTP adapters authenticate callers and enter here. This module owns
+//! policy and orchestration only; sessions, links, workspaces, and catalogs
+//! retain their own durable truth and effects.
+
+pub mod mcp;
+pub mod model;
+pub mod runtime;

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/model.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/model.rs
@@ -1,0 +1,228 @@
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_AGENT_PAGE_SIZE: usize = 50;
+pub const MAX_AGENT_PAGE_SIZE: usize = 100;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct RuntimeIdentity(String);
+
+impl RuntimeIdentity {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentIdentity {
+    pub runtime_id: RuntimeIdentity,
+    pub session_id: String,
+}
+
+impl AgentIdentity {
+    pub fn new(runtime_id: RuntimeIdentity, session_id: impl Into<String>) -> Self {
+        Self {
+            runtime_id,
+            session_id: session_id.into(),
+        }
+    }
+}
+
+/// Identity admitted by an authenticated edge. Tool arguments never construct
+/// or override this value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthenticatedAgentCaller {
+    identity: AgentIdentity,
+}
+
+impl AuthenticatedAgentCaller {
+    pub fn new(runtime_id: RuntimeIdentity, session_id: impl Into<String>) -> Self {
+        Self {
+            identity: AgentIdentity::new(runtime_id, session_id),
+        }
+    }
+
+    pub fn identity(&self) -> &AgentIdentity {
+        &self.identity
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceIdentity {
+    pub runtime_id: RuntimeIdentity,
+    pub workspace_id: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRole {
+    Ordinary,
+    Subagent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentPresentationStatus {
+    Running,
+    Available,
+    Closed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentExecutionStatus {
+    Starting,
+    Running,
+    AwaitingInteraction,
+    Idle,
+    Errored,
+    Closed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EffectiveAgentStatus {
+    pub presentation: AgentPresentationStatus,
+    pub execution: AgentExecutionStatus,
+    pub has_live_actor: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentCapability {
+    Whoami,
+    ListWorkspaces,
+    ListWorkspaceOptions,
+    CreateWorkspace,
+    ListAgents,
+    GetAgent,
+    ListSubagents,
+    ListAgentLaunchOptions,
+    ListAgentConfigOptions,
+    GetTaskOutput,
+    CreateAgent,
+    ConfigureAgent,
+    ResumeAgent,
+    SendMessage,
+    InterruptAgent,
+    CloseSubagent,
+    OpenSubagent,
+    PromoteSubagent,
+}
+
+impl AgentCapability {
+    pub const ALL: [Self; 18] = [
+        Self::Whoami,
+        Self::ListWorkspaces,
+        Self::ListWorkspaceOptions,
+        Self::CreateWorkspace,
+        Self::ListAgents,
+        Self::GetAgent,
+        Self::ListSubagents,
+        Self::ListAgentLaunchOptions,
+        Self::ListAgentConfigOptions,
+        Self::GetTaskOutput,
+        Self::CreateAgent,
+        Self::ConfigureAgent,
+        Self::ResumeAgent,
+        Self::SendMessage,
+        Self::InterruptAgent,
+        Self::CloseSubagent,
+        Self::OpenSubagent,
+        Self::PromoteSubagent,
+    ];
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentCreationKind {
+    Ordinary,
+    Subagent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityDenial {
+    CallerClosed,
+    SubagentCannotCreateAgent,
+    SubagentSameWorkspaceRequired,
+    ParentOnly,
+    TargetMustBeSubagent,
+    SubagentOpenRequired,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CapabilityDecision {
+    pub capability: AgentCapability,
+    pub allowed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub denial: Option<CapabilityDenial>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentConfiguration {
+    pub agent_kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentView {
+    pub identity: AgentIdentity,
+    pub workspace: WorkspaceIdentity,
+    pub role: AgentRole,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent: Option<AgentIdentity>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    pub configuration: AgentConfiguration,
+    pub status: EffectiveAgentStatus,
+    pub capabilities: Vec<AgentCapability>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WhoAmIView {
+    pub agent: AgentView,
+    pub effective_capabilities: Vec<AgentCapability>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ListAgentsInput {
+    pub workspace_id: Option<String>,
+    pub status: Option<AgentPresentationStatus>,
+    pub cursor: Option<String>,
+    pub limit: usize,
+}
+
+impl Default for ListAgentsInput {
+    fn default() -> Self {
+        Self {
+            workspace_id: None,
+            status: None,
+            cursor: None,
+            limit: DEFAULT_AGENT_PAGE_SIZE,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentPage {
+    pub agents: Vec<AgentView>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/authorization_policy.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/authorization_policy.rs
@@ -1,0 +1,285 @@
+use crate::domains::agent_operations::model::{
+    AgentCapability, AgentCreationKind, AgentPresentationStatus, AgentRole, CapabilityDecision,
+    CapabilityDenial,
+};
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct CallerFacts {
+    pub role: AgentRole,
+    pub status: AgentPresentationStatus,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct TargetFacts {
+    pub role: AgentRole,
+    pub status: AgentPresentationStatus,
+    pub owned_by_caller: bool,
+}
+
+pub(super) fn effective_capabilities(facts: CallerFacts) -> Vec<AgentCapability> {
+    AgentCapability::ALL
+        .into_iter()
+        .filter(|capability| caller_capability(facts, *capability).allowed)
+        .collect()
+}
+
+pub(super) fn caller_capability(
+    facts: CallerFacts,
+    capability: AgentCapability,
+) -> CapabilityDecision {
+    if facts.status == AgentPresentationStatus::Closed && is_mutation(capability) {
+        return denied(capability, CapabilityDenial::CallerClosed);
+    }
+
+    if facts.role == AgentRole::Subagent
+        && matches!(
+            capability,
+            AgentCapability::CreateAgent
+                | AgentCapability::CloseSubagent
+                | AgentCapability::OpenSubagent
+                | AgentCapability::PromoteSubagent
+        )
+    {
+        return denied(
+            capability,
+            if capability == AgentCapability::CreateAgent {
+                CapabilityDenial::SubagentCannotCreateAgent
+            } else {
+                CapabilityDenial::ParentOnly
+            },
+        );
+    }
+
+    allowed(capability)
+}
+
+pub(super) fn create_agent_decision(
+    caller: CallerFacts,
+    caller_workspace_id: &str,
+    kind: AgentCreationKind,
+    target_workspace_id: &str,
+) -> CapabilityDecision {
+    let base = caller_capability(caller, AgentCapability::CreateAgent);
+    if !base.allowed {
+        return base;
+    }
+    if kind == AgentCreationKind::Subagent && caller_workspace_id != target_workspace_id {
+        return denied(
+            AgentCapability::CreateAgent,
+            CapabilityDenial::SubagentSameWorkspaceRequired,
+        );
+    }
+    base
+}
+
+pub(super) fn target_capabilities(
+    caller: CallerFacts,
+    target: TargetFacts,
+) -> Vec<AgentCapability> {
+    const TARGET_CAPABILITIES: [AgentCapability; 9] = [
+        AgentCapability::GetAgent,
+        AgentCapability::ListAgentConfigOptions,
+        AgentCapability::GetTaskOutput,
+        AgentCapability::ConfigureAgent,
+        AgentCapability::ResumeAgent,
+        AgentCapability::SendMessage,
+        AgentCapability::InterruptAgent,
+        AgentCapability::CloseSubagent,
+        AgentCapability::OpenSubagent,
+    ];
+
+    let mut capabilities = TARGET_CAPABILITIES
+        .into_iter()
+        .filter(|capability| target_capability(caller, target, *capability).allowed)
+        .collect::<Vec<_>>();
+    if target_capability(caller, target, AgentCapability::PromoteSubagent).allowed {
+        capabilities.push(AgentCapability::PromoteSubagent);
+    }
+    capabilities
+}
+
+pub(super) fn target_capability(
+    caller: CallerFacts,
+    target: TargetFacts,
+    capability: AgentCapability,
+) -> CapabilityDecision {
+    let caller_decision = caller_capability(caller, capability);
+    if !caller_decision.allowed {
+        return caller_decision;
+    }
+
+    if target.role == AgentRole::Subagent && !target.owned_by_caller {
+        return denied(capability, CapabilityDenial::ParentOnly);
+    }
+
+    if matches!(
+        capability,
+        AgentCapability::CloseSubagent
+            | AgentCapability::OpenSubagent
+            | AgentCapability::PromoteSubagent
+    ) && target.role != AgentRole::Subagent
+    {
+        return denied(capability, CapabilityDenial::TargetMustBeSubagent);
+    }
+
+    if target.status == AgentPresentationStatus::Closed {
+        return if capability == AgentCapability::OpenSubagent
+            || matches!(
+                capability,
+                AgentCapability::GetAgent | AgentCapability::GetTaskOutput
+            ) {
+            allowed(capability)
+        } else {
+            denied(capability, CapabilityDenial::SubagentOpenRequired)
+        };
+    }
+
+    if capability == AgentCapability::OpenSubagent {
+        return denied(capability, CapabilityDenial::SubagentOpenRequired);
+    }
+
+    allowed(capability)
+}
+
+fn is_mutation(capability: AgentCapability) -> bool {
+    matches!(
+        capability,
+        AgentCapability::CreateWorkspace
+            | AgentCapability::CreateAgent
+            | AgentCapability::ConfigureAgent
+            | AgentCapability::ResumeAgent
+            | AgentCapability::SendMessage
+            | AgentCapability::InterruptAgent
+            | AgentCapability::CloseSubagent
+            | AgentCapability::OpenSubagent
+            | AgentCapability::PromoteSubagent
+    )
+}
+
+fn allowed(capability: AgentCapability) -> CapabilityDecision {
+    CapabilityDecision {
+        capability,
+        allowed: true,
+        denial: None,
+    }
+}
+
+fn denied(capability: AgentCapability, denial: CapabilityDenial) -> CapabilityDecision {
+    CapabilityDecision {
+        capability,
+        allowed: false,
+        denial: Some(denial),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subagent_creation_is_denied_for_both_agent_kinds() {
+        let caller = CallerFacts {
+            role: AgentRole::Subagent,
+            status: AgentPresentationStatus::Available,
+        };
+        for kind in [AgentCreationKind::Ordinary, AgentCreationKind::Subagent] {
+            let decision = create_agent_decision(caller, "workspace-a", kind, "workspace-a");
+            assert_eq!(
+                decision.denial,
+                Some(CapabilityDenial::SubagentCannotCreateAgent)
+            );
+        }
+    }
+
+    #[test]
+    fn ordinary_subagent_creation_is_same_workspace_only() {
+        let caller = CallerFacts {
+            role: AgentRole::Ordinary,
+            status: AgentPresentationStatus::Available,
+        };
+        assert!(
+            create_agent_decision(
+                caller,
+                "workspace-a",
+                AgentCreationKind::Ordinary,
+                "workspace-b"
+            )
+            .allowed
+        );
+        assert_eq!(
+            create_agent_decision(
+                caller,
+                "workspace-a",
+                AgentCreationKind::Subagent,
+                "workspace-b"
+            )
+            .denial,
+            Some(CapabilityDenial::SubagentSameWorkspaceRequired)
+        );
+    }
+
+    #[test]
+    fn target_matrix_is_parent_only_for_subagents_and_runtime_wide_for_ordinary_agents() {
+        for caller_role in [AgentRole::Ordinary, AgentRole::Subagent] {
+            let caller = CallerFacts {
+                role: caller_role,
+                status: AgentPresentationStatus::Available,
+            };
+            assert!(
+                target_capability(
+                    caller,
+                    TargetFacts {
+                        role: AgentRole::Ordinary,
+                        status: AgentPresentationStatus::Available,
+                        owned_by_caller: false,
+                    },
+                    AgentCapability::SendMessage
+                )
+                .allowed
+            );
+            assert_eq!(
+                target_capability(
+                    caller,
+                    TargetFacts {
+                        role: AgentRole::Subagent,
+                        status: AgentPresentationStatus::Available,
+                        owned_by_caller: false,
+                    },
+                    AgentCapability::GetAgent
+                )
+                .denial,
+                Some(CapabilityDenial::ParentOnly)
+            );
+        }
+    }
+
+    #[test]
+    fn owned_closed_subagent_is_readable_and_openable_but_not_mutable() {
+        let caller = CallerFacts {
+            role: AgentRole::Ordinary,
+            status: AgentPresentationStatus::Available,
+        };
+        let target = TargetFacts {
+            role: AgentRole::Subagent,
+            status: AgentPresentationStatus::Closed,
+            owned_by_caller: true,
+        };
+        for capability in [
+            AgentCapability::GetAgent,
+            AgentCapability::GetTaskOutput,
+            AgentCapability::OpenSubagent,
+        ] {
+            assert!(target_capability(caller, target, capability).allowed);
+        }
+        for capability in [
+            AgentCapability::SendMessage,
+            AgentCapability::ConfigureAgent,
+            AgentCapability::PromoteSubagent,
+        ] {
+            assert_eq!(
+                target_capability(caller, target, capability).denial,
+                Some(CapabilityDenial::SubagentOpenRequired)
+            );
+        }
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/mod.rs
@@ -171,6 +171,15 @@ impl AgentOperations {
                 continue;
             }
             let status = self.status_for(&resolved).await?;
+            // NOTE: the advertised `status: "closed"` filter is effectively
+            // unreachable here. Ordinary terminal agents are excluded twice
+            // (the store's `list_visible_all` filters `closed_at IS NULL`, and
+            // the `is_terminal_session()` guard above drops `status == "closed"`
+            // rows), and relationship-closed subagents are dropped by the
+            // `role() == Subagent` guard before this filter runs. Only a
+            // transient execution-state race can yield a Closed presentation.
+            // The schema value is frozen; see the PR review notes for the
+            // contract-level decision this raises.
             if input
                 .status
                 .is_some_and(|filter| status.presentation != filter)
@@ -184,13 +193,26 @@ impl AgentOperations {
             ));
         }
 
+        // Impose a stable total order for pagination: most-recently-updated
+        // first, with the immutable session id as a deterministic tiebreak so
+        // rows sharing an `updated_at` never reorder between paginated calls.
+        agents.sort_by(|left, right| list_order_key(left).cmp(&list_order_key(right)));
+
         let start = match input.cursor.as_deref() {
             None => 0,
-            Some(cursor) => agents
-                .iter()
-                .position(|agent| agent.identity.session_id == cursor)
-                .map(|index| index + 1)
-                .ok_or(AgentOperationsError::InvalidCursor)?,
+            Some(cursor) => {
+                // Resume from the cursor row's position in the stable order
+                // rather than a found-by-scan index, so the boundary stays
+                // correct even if the cursor row itself moved since the last
+                // call. Keys are unique (id tiebreak), so `<= cursor_key`
+                // covers exactly the cursor row and everything before it.
+                let cursor_key = agents
+                    .iter()
+                    .find(|agent| agent.identity.session_id == cursor)
+                    .map(list_order_key)
+                    .ok_or(AgentOperationsError::InvalidCursor)?;
+                agents.partition_point(|agent| list_order_key(agent) <= cursor_key)
+            }
         };
         let end = (start + input.limit).min(agents.len());
         let next_cursor = (end < agents.len()).then(|| agents[end - 1].identity.session_id.clone());
@@ -283,7 +305,11 @@ impl AgentOperations {
         caller: &AuthenticatedAgentCaller,
     ) -> Result<ResolvedAgent, AgentOperationsError> {
         let resolved = self.resolve_record(self.resolve_caller_record(caller)?)?;
-        if resolved.is_terminal_session() && !resolved.is_relationship_closed() {
+        // A terminal caller is closed regardless of relationship state; a
+        // relationship-closed-but-live caller (e.g. a promoted subagent whose
+        // session is still running) stays admitted because its session is not
+        // terminal.
+        if resolved.is_terminal_session() {
             return Err(AgentOperationsError::CallerClosed);
         }
         Ok(resolved)
@@ -435,6 +461,15 @@ impl ResolvedAgent {
     fn is_terminal_session(&self) -> bool {
         self.record.closed_at.is_some() || self.record.status == "closed"
     }
+}
+
+/// Deterministic total-order key for agent listing pagination: `updated_at`
+/// descending, then the immutable session id ascending as a stable tiebreak.
+fn list_order_key(agent: &AgentView) -> (std::cmp::Reverse<&str>, &str) {
+    (
+        std::cmp::Reverse(agent.updated_at.as_str()),
+        agent.identity.session_id.as_str(),
+    )
 }
 
 fn project_status(state: SessionExecutionState) -> EffectiveAgentStatus {

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/mod.rs
@@ -167,6 +167,9 @@ impl AgentOperations {
             if resolved.role() == AgentRole::Subagent {
                 continue;
             }
+            if resolved.is_terminal_session() {
+                continue;
+            }
             let status = self.status_for(&resolved).await?;
             if input
                 .status
@@ -206,6 +209,9 @@ impl AgentOperations {
         self.assert_same_runtime(target)?;
         let caller_agent = self.resolve_caller_agent(caller)?;
         let target_agent = self.resolve_agent(target)?;
+        if target_agent.role() == AgentRole::Ordinary && target_agent.is_terminal_session() {
+            return Err(AgentOperationsError::AgentNotFound);
+        }
         if target_agent.role() == AgentRole::Subagent
             && target_agent.parent_session_id() != Some(caller.identity().session_id.as_str())
         {
@@ -277,9 +283,7 @@ impl AgentOperations {
         caller: &AuthenticatedAgentCaller,
     ) -> Result<ResolvedAgent, AgentOperationsError> {
         let resolved = self.resolve_record(self.resolve_caller_record(caller)?)?;
-        if (resolved.record.closed_at.is_some() || resolved.record.status == "closed")
-            && !resolved.is_relationship_closed()
-        {
+        if resolved.is_terminal_session() && !resolved.is_relationship_closed() {
             return Err(AgentOperationsError::CallerClosed);
         }
         Ok(resolved)
@@ -426,6 +430,10 @@ impl ResolvedAgent {
         self.parent_link
             .as_ref()
             .is_some_and(|link| link.closed_at.is_some())
+    }
+
+    fn is_terminal_session(&self) -> bool {
+        self.record.closed_at.is_some() || self.record.status == "closed"
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/mod.rs
@@ -1,0 +1,481 @@
+mod authorization_policy;
+mod ports;
+
+#[cfg(test)]
+mod tests;
+
+use std::sync::Arc;
+
+use authorization_policy::{CallerFacts, TargetFacts};
+pub use ports::{AgentExecutionReads, AgentSessionReads, SubagentRelationshipReads};
+
+use crate::domains::agent_operations::model::{
+    AgentCapability, AgentConfiguration, AgentCreationKind, AgentExecutionStatus, AgentIdentity,
+    AgentPage, AgentPresentationStatus, AgentRole, AgentView, AuthenticatedAgentCaller,
+    CapabilityDecision, CapabilityDenial, EffectiveAgentStatus, ListAgentsInput, RuntimeIdentity,
+    WhoAmIView, WorkspaceIdentity, MAX_AGENT_PAGE_SIZE,
+};
+use crate::domains::sessions::links::model::SessionLinkRecord;
+use crate::domains::sessions::model::{
+    SessionExecutionState, SessionExecutionStatePhase, SessionRecord,
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum AgentOperationsError {
+    #[error("the caller is outside this runtime")]
+    RuntimeBoundaryDenied,
+    #[error("caller agent not found")]
+    CallerNotFound,
+    #[error("caller agent is closed")]
+    CallerClosed,
+    #[error("agent not found")]
+    AgentNotFound,
+    #[error("capability denied: {capability:?}")]
+    CapabilityDenied {
+        capability: AgentCapability,
+        denial: CapabilityDenial,
+    },
+    #[error("subagent must be opened before this operation")]
+    SubagentOpenRequired,
+    #[error("invalid agent-list cursor")]
+    InvalidCursor,
+    #[error("agent-list limit must be between 1 and {MAX_AGENT_PAGE_SIZE}")]
+    InvalidPageSize,
+    #[error("agent operations failed")]
+    Internal(#[source] anyhow::Error),
+}
+
+impl AgentOperationsError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::RuntimeBoundaryDenied => "AGENT_RUNTIME_FORBIDDEN",
+            Self::CallerNotFound => "AGENT_CALLER_NOT_FOUND",
+            Self::CallerClosed => "AGENT_CALLER_CLOSED",
+            Self::AgentNotFound => "AGENT_NOT_FOUND",
+            Self::CapabilityDenied { .. } => "AGENT_CAPABILITY_DENIED",
+            Self::SubagentOpenRequired => "SUBAGENT_OPEN_REQUIRED",
+            Self::InvalidCursor => "AGENT_CURSOR_INVALID",
+            Self::InvalidPageSize => "AGENT_PAGE_SIZE_INVALID",
+            Self::Internal(_) => "AGENT_OPERATIONS_INTERNAL",
+        }
+    }
+
+    pub fn public_message(&self) -> &'static str {
+        match self {
+            Self::RuntimeBoundaryDenied => "The requested agent is not available in this runtime.",
+            Self::CallerNotFound => "The calling agent was not found.",
+            Self::CallerClosed => "The calling agent is closed.",
+            Self::AgentNotFound => "The requested agent was not found.",
+            Self::CapabilityDenied { .. } => "The calling agent does not have this capability.",
+            Self::SubagentOpenRequired => "Open the subagent before performing this operation.",
+            Self::InvalidCursor => "The agent-list cursor is invalid.",
+            Self::InvalidPageSize => "The requested agent-list page size is invalid.",
+            Self::Internal(_) => "Agent operations failed.",
+        }
+    }
+}
+
+pub struct AgentOperations {
+    runtime_id: RuntimeIdentity,
+    sessions: Arc<dyn AgentSessionReads>,
+    relationships: Arc<dyn SubagentRelationshipReads>,
+    execution: Arc<dyn AgentExecutionReads>,
+}
+
+impl AgentOperations {
+    pub fn new(
+        runtime_id: RuntimeIdentity,
+        sessions: Arc<dyn AgentSessionReads>,
+        relationships: Arc<dyn SubagentRelationshipReads>,
+        execution: Arc<dyn AgentExecutionReads>,
+    ) -> Self {
+        Self {
+            runtime_id,
+            sessions,
+            relationships,
+            execution,
+        }
+    }
+
+    pub fn runtime_identity(&self) -> &RuntimeIdentity {
+        &self.runtime_id
+    }
+
+    pub fn authenticated_caller(&self, session_id: impl Into<String>) -> AuthenticatedAgentCaller {
+        AuthenticatedAgentCaller::new(self.runtime_id.clone(), session_id)
+    }
+
+    pub fn verify_caller_workspace(
+        &self,
+        caller: &AuthenticatedAgentCaller,
+        workspace_id: &str,
+    ) -> Result<(), AgentOperationsError> {
+        let resolved = self.resolve_caller_record(caller)?;
+        if resolved.workspace_id != workspace_id {
+            return Err(AgentOperationsError::CallerNotFound);
+        }
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all, fields(operation = "whoami"))]
+    pub async fn whoami(
+        &self,
+        caller: &AuthenticatedAgentCaller,
+    ) -> Result<WhoAmIView, AgentOperationsError> {
+        let resolved = self.resolve_caller_agent(caller)?;
+        let agent = self.project_agent(&resolved, Some(&resolved)).await?;
+        let effective_capabilities = authorization_policy::effective_capabilities(CallerFacts {
+            role: agent.role,
+            status: agent.status.presentation,
+        });
+        Ok(WhoAmIView {
+            agent,
+            effective_capabilities,
+        })
+    }
+
+    #[tracing::instrument(skip_all, fields(operation = "list_agents"))]
+    pub async fn list_agents(
+        &self,
+        caller: &AuthenticatedAgentCaller,
+        input: ListAgentsInput,
+    ) -> Result<AgentPage, AgentOperationsError> {
+        if input.limit == 0 || input.limit > MAX_AGENT_PAGE_SIZE {
+            return Err(AgentOperationsError::InvalidPageSize);
+        }
+        let caller_agent = self.resolve_caller_agent(caller)?;
+        let caller_status = self.status_for(&caller_agent).await?;
+        let caller_facts = CallerFacts {
+            role: caller_agent.role(),
+            status: caller_status.presentation,
+        };
+
+        let records = self
+            .sessions
+            .list_sessions()
+            .map_err(AgentOperationsError::Internal)?;
+        let mut agents = Vec::new();
+        for record in records {
+            if input
+                .workspace_id
+                .as_deref()
+                .is_some_and(|workspace_id| record.workspace_id != workspace_id)
+            {
+                continue;
+            }
+            let resolved = self.resolve_record(record)?;
+            if resolved.role() == AgentRole::Subagent {
+                continue;
+            }
+            let status = self.status_for(&resolved).await?;
+            if input
+                .status
+                .is_some_and(|filter| status.presentation != filter)
+            {
+                continue;
+            }
+            agents.push(self.project_agent_with_status(
+                &resolved,
+                Some((&caller_agent, caller_facts)),
+                status,
+            ));
+        }
+
+        let start = match input.cursor.as_deref() {
+            None => 0,
+            Some(cursor) => agents
+                .iter()
+                .position(|agent| agent.identity.session_id == cursor)
+                .map(|index| index + 1)
+                .ok_or(AgentOperationsError::InvalidCursor)?,
+        };
+        let end = (start + input.limit).min(agents.len());
+        let next_cursor = (end < agents.len()).then(|| agents[end - 1].identity.session_id.clone());
+        Ok(AgentPage {
+            agents: agents.into_iter().skip(start).take(input.limit).collect(),
+            next_cursor,
+        })
+    }
+
+    #[tracing::instrument(skip_all, fields(operation = "get_agent"))]
+    pub async fn get_agent(
+        &self,
+        caller: &AuthenticatedAgentCaller,
+        target: &AgentIdentity,
+    ) -> Result<AgentView, AgentOperationsError> {
+        self.assert_same_runtime(target)?;
+        let caller_agent = self.resolve_caller_agent(caller)?;
+        let target_agent = self.resolve_agent(target)?;
+        if target_agent.role() == AgentRole::Subagent
+            && target_agent.parent_session_id() != Some(caller.identity().session_id.as_str())
+        {
+            return Err(AgentOperationsError::AgentNotFound);
+        }
+        self.project_agent(&target_agent, Some(&caller_agent)).await
+    }
+
+    #[tracing::instrument(skip_all, fields(operation = "list_subagents"))]
+    pub async fn list_subagents(
+        &self,
+        caller: &AuthenticatedAgentCaller,
+    ) -> Result<Vec<AgentView>, AgentOperationsError> {
+        let caller_agent = self.resolve_caller_agent(caller)?;
+        let links = self
+            .relationships
+            .list_children_including_closed(&caller.identity().session_id)
+            .map_err(AgentOperationsError::Internal)?;
+        let mut agents = Vec::with_capacity(links.len());
+        for link in links {
+            let Some(record) = self
+                .sessions
+                .get_session(&link.child_session_id)
+                .map_err(AgentOperationsError::Internal)?
+            else {
+                continue;
+            };
+            let target = ResolvedAgent {
+                record,
+                parent_link: Some(link),
+            };
+            agents.push(self.project_agent(&target, Some(&caller_agent)).await?);
+        }
+        Ok(agents)
+    }
+
+    pub fn decide_agent_creation(
+        &self,
+        caller: &AuthenticatedAgentCaller,
+        kind: AgentCreationKind,
+        target_workspace_id: &str,
+    ) -> Result<CapabilityDecision, AgentOperationsError> {
+        let caller = self.resolve_caller_agent(caller)?;
+        let status = status_from_record_only(&caller);
+        Ok(authorization_policy::create_agent_decision(
+            CallerFacts {
+                role: caller.role(),
+                status: status.presentation,
+            },
+            &caller.record.workspace_id,
+            kind,
+            target_workspace_id,
+        ))
+    }
+
+    fn resolve_caller_record(
+        &self,
+        caller: &AuthenticatedAgentCaller,
+    ) -> Result<SessionRecord, AgentOperationsError> {
+        self.assert_same_runtime(caller.identity())?;
+        self.sessions
+            .get_session(&caller.identity().session_id)
+            .map_err(AgentOperationsError::Internal)?
+            .ok_or(AgentOperationsError::CallerNotFound)
+    }
+
+    fn resolve_caller_agent(
+        &self,
+        caller: &AuthenticatedAgentCaller,
+    ) -> Result<ResolvedAgent, AgentOperationsError> {
+        let resolved = self.resolve_record(self.resolve_caller_record(caller)?)?;
+        if (resolved.record.closed_at.is_some() || resolved.record.status == "closed")
+            && !resolved.is_relationship_closed()
+        {
+            return Err(AgentOperationsError::CallerClosed);
+        }
+        Ok(resolved)
+    }
+
+    fn resolve_agent(
+        &self,
+        identity: &AgentIdentity,
+    ) -> Result<ResolvedAgent, AgentOperationsError> {
+        self.assert_same_runtime(identity)?;
+        let record = self
+            .sessions
+            .get_session(&identity.session_id)
+            .map_err(AgentOperationsError::Internal)?
+            .ok_or(AgentOperationsError::AgentNotFound)?;
+        self.resolve_record(record)
+    }
+
+    fn resolve_record(&self, record: SessionRecord) -> Result<ResolvedAgent, AgentOperationsError> {
+        let parent_link = self
+            .relationships
+            .find_parent_including_closed(&record.id)
+            .map_err(AgentOperationsError::Internal)?;
+        Ok(ResolvedAgent {
+            record,
+            parent_link,
+        })
+    }
+
+    fn assert_same_runtime(&self, identity: &AgentIdentity) -> Result<(), AgentOperationsError> {
+        if identity.runtime_id != self.runtime_id {
+            return Err(AgentOperationsError::RuntimeBoundaryDenied);
+        }
+        Ok(())
+    }
+
+    async fn project_agent(
+        &self,
+        target: &ResolvedAgent,
+        caller: Option<&ResolvedAgent>,
+    ) -> Result<AgentView, AgentOperationsError> {
+        let status = self.status_for(target).await?;
+        let caller_with_facts = caller.map(|caller| {
+            let caller_status = status_from_record_only(caller);
+            (
+                caller,
+                CallerFacts {
+                    role: caller.role(),
+                    status: caller_status.presentation,
+                },
+            )
+        });
+        Ok(self.project_agent_with_status(target, caller_with_facts, status))
+    }
+
+    fn project_agent_with_status(
+        &self,
+        target: &ResolvedAgent,
+        caller: Option<(&ResolvedAgent, CallerFacts)>,
+        status: EffectiveAgentStatus,
+    ) -> AgentView {
+        let role = target.role();
+        let capabilities = caller
+            .map(|(caller, caller_facts)| {
+                authorization_policy::target_capabilities(
+                    caller_facts,
+                    TargetFacts {
+                        role,
+                        status: status.presentation,
+                        owned_by_caller: target.parent_session_id()
+                            == Some(caller.record.id.as_str()),
+                    },
+                )
+            })
+            .unwrap_or_default();
+        AgentView {
+            identity: AgentIdentity::new(self.runtime_id.clone(), target.record.id.clone()),
+            workspace: WorkspaceIdentity {
+                runtime_id: self.runtime_id.clone(),
+                workspace_id: target.record.workspace_id.clone(),
+            },
+            role,
+            parent: target.parent_session_id().map(|parent_id| {
+                AgentIdentity::new(self.runtime_id.clone(), parent_id.to_string())
+            }),
+            title: target.record.title.clone(),
+            configuration: AgentConfiguration {
+                agent_kind: target.record.agent_kind.clone(),
+                model_id: target
+                    .record
+                    .current_model_id
+                    .clone()
+                    .or_else(|| target.record.requested_model_id.clone()),
+                mode_id: target
+                    .record
+                    .current_mode_id
+                    .clone()
+                    .or_else(|| target.record.requested_mode_id.clone()),
+            },
+            status,
+            capabilities,
+            created_at: target.record.created_at.clone(),
+            updated_at: target.record.updated_at.clone(),
+        }
+    }
+
+    async fn status_for(
+        &self,
+        agent: &ResolvedAgent,
+    ) -> Result<EffectiveAgentStatus, AgentOperationsError> {
+        if agent.is_relationship_closed() {
+            return Ok(closed_status());
+        }
+        let state = self
+            .execution
+            .execution_state(&agent.record)
+            .await
+            .map_err(AgentOperationsError::Internal)?;
+        Ok(project_status(state))
+    }
+}
+
+struct ResolvedAgent {
+    record: SessionRecord,
+    parent_link: Option<SessionLinkRecord>,
+}
+
+impl ResolvedAgent {
+    fn role(&self) -> AgentRole {
+        if self.parent_link.is_some() {
+            AgentRole::Subagent
+        } else {
+            AgentRole::Ordinary
+        }
+    }
+
+    fn parent_session_id(&self) -> Option<&str> {
+        self.parent_link
+            .as_ref()
+            .map(|link| link.parent_session_id.as_str())
+    }
+
+    fn is_relationship_closed(&self) -> bool {
+        self.parent_link
+            .as_ref()
+            .is_some_and(|link| link.closed_at.is_some())
+    }
+}
+
+fn project_status(state: SessionExecutionState) -> EffectiveAgentStatus {
+    let execution = match state.phase {
+        SessionExecutionStatePhase::Starting => AgentExecutionStatus::Starting,
+        SessionExecutionStatePhase::Running => AgentExecutionStatus::Running,
+        SessionExecutionStatePhase::AwaitingInteraction => {
+            AgentExecutionStatus::AwaitingInteraction
+        }
+        SessionExecutionStatePhase::Idle => AgentExecutionStatus::Idle,
+        SessionExecutionStatePhase::Errored => AgentExecutionStatus::Errored,
+        SessionExecutionStatePhase::Closed => AgentExecutionStatus::Closed,
+    };
+    let presentation = match execution {
+        AgentExecutionStatus::Starting
+        | AgentExecutionStatus::Running
+        | AgentExecutionStatus::AwaitingInteraction => AgentPresentationStatus::Running,
+        AgentExecutionStatus::Idle | AgentExecutionStatus::Errored => {
+            AgentPresentationStatus::Available
+        }
+        AgentExecutionStatus::Closed => AgentPresentationStatus::Closed,
+    };
+    EffectiveAgentStatus {
+        presentation,
+        execution,
+        has_live_actor: state.has_live_handle,
+    }
+}
+
+fn status_from_record_only(agent: &ResolvedAgent) -> EffectiveAgentStatus {
+    if agent.is_relationship_closed() {
+        return closed_status();
+    }
+    project_status(SessionExecutionState {
+        phase: match agent.record.status.as_str() {
+            "starting" => SessionExecutionStatePhase::Starting,
+            "running" => SessionExecutionStatePhase::Running,
+            "errored" => SessionExecutionStatePhase::Errored,
+            "closed" => SessionExecutionStatePhase::Closed,
+            _ => SessionExecutionStatePhase::Idle,
+        },
+        has_live_handle: false,
+    })
+}
+
+fn closed_status() -> EffectiveAgentStatus {
+    EffectiveAgentStatus {
+        presentation: AgentPresentationStatus::Closed,
+        execution: AgentExecutionStatus::Closed,
+        has_live_actor: false,
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/ports.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/ports.rs
@@ -1,0 +1,68 @@
+use async_trait::async_trait;
+
+use crate::domains::sessions::links::model::SessionLinkRecord;
+use crate::domains::sessions::links::service::SessionLinkService;
+use crate::domains::sessions::model::{SessionExecutionState, SessionRecord};
+use crate::domains::sessions::runtime::SessionRuntime;
+use crate::domains::sessions::service::SessionService;
+
+pub trait AgentSessionReads: Send + Sync {
+    fn get_session(&self, session_id: &str) -> anyhow::Result<Option<SessionRecord>>;
+    fn list_sessions(&self) -> anyhow::Result<Vec<SessionRecord>>;
+}
+
+impl AgentSessionReads for SessionService {
+    fn get_session(&self, session_id: &str) -> anyhow::Result<Option<SessionRecord>> {
+        self.get_session(session_id)
+    }
+
+    fn list_sessions(&self) -> anyhow::Result<Vec<SessionRecord>> {
+        self.list_sessions(None, false)
+    }
+}
+
+pub trait SubagentRelationshipReads: Send + Sync {
+    fn find_parent_including_closed(
+        &self,
+        child_session_id: &str,
+    ) -> anyhow::Result<Option<SessionLinkRecord>>;
+
+    fn list_children_including_closed(
+        &self,
+        parent_session_id: &str,
+    ) -> anyhow::Result<Vec<SessionLinkRecord>>;
+}
+
+impl SubagentRelationshipReads for SessionLinkService {
+    fn find_parent_including_closed(
+        &self,
+        child_session_id: &str,
+    ) -> anyhow::Result<Option<SessionLinkRecord>> {
+        self.find_subagent_parent_including_closed(child_session_id)
+    }
+
+    fn list_children_including_closed(
+        &self,
+        parent_session_id: &str,
+    ) -> anyhow::Result<Vec<SessionLinkRecord>> {
+        self.list_subagent_children_including_closed(parent_session_id)
+    }
+}
+
+#[async_trait]
+pub trait AgentExecutionReads: Send + Sync {
+    async fn execution_state(
+        &self,
+        session: &SessionRecord,
+    ) -> anyhow::Result<SessionExecutionState>;
+}
+
+#[async_trait]
+impl AgentExecutionReads for SessionRuntime {
+    async fn execution_state(
+        &self,
+        session: &SessionRecord,
+    ) -> anyhow::Result<SessionExecutionState> {
+        Ok(self.session_execution_state(session).await)
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/tests.rs
@@ -1,0 +1,355 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::*;
+use crate::domains::sessions::links::model::{SessionLinkRelation, SessionLinkWorkspaceRelation};
+use crate::domains::sessions::model::SessionMcpBindingPolicy;
+
+#[derive(Default)]
+struct FakeSessions {
+    records: Vec<SessionRecord>,
+}
+
+impl AgentSessionReads for FakeSessions {
+    fn get_session(&self, session_id: &str) -> anyhow::Result<Option<SessionRecord>> {
+        Ok(self
+            .records
+            .iter()
+            .find(|record| record.id == session_id)
+            .cloned())
+    }
+
+    fn list_sessions(&self) -> anyhow::Result<Vec<SessionRecord>> {
+        Ok(self.records.clone())
+    }
+}
+
+#[derive(Default)]
+struct FakeRelationships {
+    links: Vec<SessionLinkRecord>,
+}
+
+impl SubagentRelationshipReads for FakeRelationships {
+    fn find_parent_including_closed(
+        &self,
+        child_session_id: &str,
+    ) -> anyhow::Result<Option<SessionLinkRecord>> {
+        Ok(self
+            .links
+            .iter()
+            .find(|link| link.child_session_id == child_session_id)
+            .cloned())
+    }
+
+    fn list_children_including_closed(
+        &self,
+        parent_session_id: &str,
+    ) -> anyhow::Result<Vec<SessionLinkRecord>> {
+        Ok(self
+            .links
+            .iter()
+            .filter(|link| link.parent_session_id == parent_session_id)
+            .cloned()
+            .collect())
+    }
+}
+
+#[derive(Default)]
+struct FakeExecution {
+    states: HashMap<String, SessionExecutionState>,
+}
+
+#[async_trait]
+impl AgentExecutionReads for FakeExecution {
+    async fn execution_state(
+        &self,
+        session: &SessionRecord,
+    ) -> anyhow::Result<SessionExecutionState> {
+        Ok(self
+            .states
+            .get(&session.id)
+            .copied()
+            .unwrap_or(SessionExecutionState {
+                phase: SessionExecutionStatePhase::Idle,
+                has_live_handle: false,
+            }))
+    }
+}
+
+fn session(id: &str, workspace_id: &str, status: &str) -> SessionRecord {
+    SessionRecord {
+        id: id.to_string(),
+        workspace_id: workspace_id.to_string(),
+        agent_kind: "codex".to_string(),
+        native_session_id: None,
+        agent_auth_contexts: None,
+        requested_model_id: Some("model-1".to_string()),
+        current_model_id: None,
+        requested_mode_id: Some("mode-1".to_string()),
+        current_mode_id: None,
+        title: Some(format!("Agent {id}")),
+        thinking_level_id: None,
+        thinking_budget_tokens: None,
+        status: status.to_string(),
+        created_at: "2026-08-10T00:00:00Z".to_string(),
+        updated_at: "2026-08-10T00:00:00Z".to_string(),
+        last_prompt_at: None,
+        closed_at: None,
+        dismissed_at: None,
+        mcp_bindings_ciphertext: None,
+        mcp_binding_summaries_json: None,
+        mcp_binding_policy: SessionMcpBindingPolicy::InheritWorkspace,
+        system_prompt_append: None,
+        subagents_enabled: true,
+        action_capabilities_json: None,
+        origin: None,
+    }
+}
+
+fn link(parent: &str, child: &str, closed: bool) -> SessionLinkRecord {
+    SessionLinkRecord {
+        id: format!("link-{child}"),
+        public_id: Some(format!("subagent-{child}")),
+        relation: SessionLinkRelation::Subagent,
+        parent_session_id: parent.to_string(),
+        child_session_id: child.to_string(),
+        workspace_relation: SessionLinkWorkspaceRelation::SameWorkspace,
+        label: Some(format!("Child {child}")),
+        created_by_turn_id: None,
+        created_by_tool_call_id: None,
+        created_at: "2026-08-10T00:00:00Z".to_string(),
+        closed_at: closed.then(|| "2026-08-10T01:00:00Z".to_string()),
+    }
+}
+
+fn fixture(closed_c: bool) -> AgentOperations {
+    let sessions = FakeSessions {
+        records: vec![
+            session("P", "workspace-a", "idle"),
+            session("Q", "workspace-b", "idle"),
+            session("R", "workspace-a", "idle"),
+            session("C", "workspace-a", "idle"),
+            session("D", "workspace-a", "idle"),
+        ],
+    };
+    let relationships = FakeRelationships {
+        links: vec![link("P", "C", closed_c), link("R", "D", false)],
+    };
+    AgentOperations::new(
+        RuntimeIdentity::new("runtime-1"),
+        Arc::new(sessions),
+        Arc::new(relationships),
+        Arc::new(FakeExecution::default()),
+    )
+}
+
+fn caller(operations: &AgentOperations, id: &str) -> AuthenticatedAgentCaller {
+    operations.authenticated_caller(id)
+}
+
+fn target(id: &str) -> AgentIdentity {
+    AgentIdentity::new(RuntimeIdentity::new("runtime-1"), id)
+}
+
+#[tokio::test]
+async fn subagent_authorization_matrix_is_runtime_wide_and_parent_scoped() {
+    let operations = fixture(false);
+
+    assert_eq!(
+        operations
+            .get_agent(&caller(&operations, "P"), &target("Q"))
+            .await
+            .expect("P reads cross-workspace ordinary Q")
+            .role,
+        AgentRole::Ordinary
+    );
+    assert_eq!(
+        operations
+            .get_agent(&caller(&operations, "P"), &target("C"))
+            .await
+            .expect("P reads owned C")
+            .role,
+        AgentRole::Subagent
+    );
+    for unrelated in ["Q", "R"] {
+        assert!(matches!(
+            operations
+                .get_agent(&caller(&operations, unrelated), &target("C"))
+                .await,
+            Err(AgentOperationsError::AgentNotFound)
+        ));
+    }
+    assert!(operations
+        .get_agent(&caller(&operations, "C"), &target("Q"))
+        .await
+        .is_ok());
+
+    for kind in [AgentCreationKind::Ordinary, AgentCreationKind::Subagent] {
+        let decision = operations
+            .decide_agent_creation(&caller(&operations, "C"), kind, "workspace-a")
+            .expect("creation decision");
+        assert_eq!(
+            decision.denial,
+            Some(CapabilityDenial::SubagentCannotCreateAgent)
+        );
+    }
+}
+
+#[tokio::test]
+async fn cross_runtime_targets_are_denied_before_lookup() {
+    let operations = fixture(false);
+    let foreign = AgentIdentity::new(RuntimeIdentity::new("runtime-2"), "Q");
+    assert!(matches!(
+        operations
+            .get_agent(&caller(&operations, "P"), &foreign)
+            .await,
+        Err(AgentOperationsError::RuntimeBoundaryDenied)
+    ));
+}
+
+#[tokio::test]
+async fn list_reads_exclude_all_subagents_and_scope_children_to_the_parent() {
+    let operations = fixture(true);
+    let ordinary = operations
+        .list_agents(&caller(&operations, "P"), ListAgentsInput::default())
+        .await
+        .expect("list ordinary agents");
+    assert_eq!(
+        ordinary
+            .agents
+            .iter()
+            .map(|agent| agent.identity.session_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["P", "Q", "R"]
+    );
+
+    let children = operations
+        .list_subagents(&caller(&operations, "P"))
+        .await
+        .expect("list P children");
+    assert_eq!(children.len(), 1);
+    assert_eq!(children[0].identity.session_id, "C");
+    assert_eq!(
+        children[0].status.presentation,
+        AgentPresentationStatus::Closed
+    );
+    assert!(!children
+        .iter()
+        .any(|agent| agent.identity.session_id == "D"));
+}
+
+#[tokio::test]
+async fn whoami_returns_exact_role_parent_scope_and_effective_capabilities() {
+    let operations = fixture(false);
+    let ordinary = operations
+        .whoami(&caller(&operations, "P"))
+        .await
+        .expect("ordinary identity");
+    assert_eq!(ordinary.agent.role, AgentRole::Ordinary);
+    assert!(ordinary.agent.parent.is_none());
+    assert_eq!(ordinary.effective_capabilities, AgentCapability::ALL);
+
+    let child = operations
+        .whoami(&caller(&operations, "C"))
+        .await
+        .expect("subagent identity");
+    assert_eq!(child.agent.role, AgentRole::Subagent);
+    assert_eq!(
+        child.agent.parent.expect("parent").session_id,
+        "P".to_string()
+    );
+    assert!(!child
+        .effective_capabilities
+        .contains(&AgentCapability::CreateAgent));
+    assert!(!child
+        .effective_capabilities
+        .contains(&AgentCapability::PromoteSubagent));
+    assert!(child
+        .effective_capabilities
+        .contains(&AgentCapability::SendMessage));
+}
+
+#[tokio::test]
+async fn status_projection_separates_presentation_from_execution_detail() {
+    let sessions = FakeSessions {
+        records: vec![
+            session("P", "workspace-a", "idle"),
+            session("running", "workspace-a", "running"),
+            session("cold", "workspace-a", "idle"),
+            session("errored", "workspace-a", "errored"),
+            session("closed", "workspace-a", "idle"),
+        ],
+    };
+    let relationships = FakeRelationships {
+        links: vec![link("P", "closed", true)],
+    };
+    let execution = FakeExecution {
+        states: HashMap::from([
+            (
+                "running".to_string(),
+                SessionExecutionState {
+                    phase: SessionExecutionStatePhase::Running,
+                    has_live_handle: true,
+                },
+            ),
+            (
+                "cold".to_string(),
+                SessionExecutionState {
+                    phase: SessionExecutionStatePhase::Idle,
+                    has_live_handle: false,
+                },
+            ),
+            (
+                "errored".to_string(),
+                SessionExecutionState {
+                    phase: SessionExecutionStatePhase::Errored,
+                    has_live_handle: false,
+                },
+            ),
+        ]),
+    };
+    let operations = AgentOperations::new(
+        RuntimeIdentity::new("runtime-1"),
+        Arc::new(sessions),
+        Arc::new(relationships),
+        Arc::new(execution),
+    );
+    let caller = caller(&operations, "P");
+
+    let running = operations
+        .get_agent(&caller, &target("running"))
+        .await
+        .expect("running");
+    assert_eq!(
+        running.status.presentation,
+        AgentPresentationStatus::Running
+    );
+    assert!(running.status.has_live_actor);
+
+    let cold = operations
+        .get_agent(&caller, &target("cold"))
+        .await
+        .expect("cold");
+    assert_eq!(cold.status.presentation, AgentPresentationStatus::Available);
+    assert_eq!(cold.status.execution, AgentExecutionStatus::Idle);
+    assert!(!cold.status.has_live_actor);
+
+    let errored = operations
+        .get_agent(&caller, &target("errored"))
+        .await
+        .expect("errored");
+    assert_eq!(
+        errored.status.presentation,
+        AgentPresentationStatus::Available
+    );
+    assert_eq!(errored.status.execution, AgentExecutionStatus::Errored);
+
+    let closed = operations
+        .get_agent(&caller, &target("closed"))
+        .await
+        .expect("closed owned child");
+    assert_eq!(closed.status.presentation, AgentPresentationStatus::Closed);
+    assert_eq!(closed.status.execution, AgentExecutionStatus::Closed);
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/tests.rs
@@ -241,6 +241,69 @@ async fn list_reads_exclude_all_subagents_and_scope_children_to_the_parent() {
 }
 
 #[tokio::test]
+async fn list_pagination_is_stable_regardless_of_session_row_order() {
+    fn stamped(id: &str, updated_at: &str) -> SessionRecord {
+        let mut record = session(id, "workspace-a", "idle");
+        record.updated_at = updated_at.to_string();
+        record
+    }
+
+    // Distinct `updated_at` values so the stable order (updated_at DESC, id) is
+    // total and observably different from insertion order.
+    let ascending = vec![
+        stamped("A", "2026-08-10T00:00:01Z"),
+        stamped("B", "2026-08-10T00:00:02Z"),
+        stamped("C", "2026-08-10T00:00:03Z"),
+    ];
+    // Same rows, reversed insertion order — simulates the store returning rows
+    // in a different sequence (e.g. `updated_at` churn reordering the DESC
+    // scan) between paginated calls.
+    let mut descending = ascending.clone();
+    descending.reverse();
+
+    // Stable order is `updated_at` DESC regardless of the underlying row order.
+    let expected = vec!["C".to_string(), "B".to_string(), "A".to_string()];
+
+    for records in [ascending, descending] {
+        let operations = AgentOperations::new(
+            RuntimeIdentity::new("runtime-1"),
+            Arc::new(FakeSessions { records }),
+            Arc::new(FakeRelationships::default()),
+            Arc::new(FakeExecution::default()),
+        );
+        let caller = caller(&operations, "A");
+
+        // Walk the whole listing one row per page; a stable order plus
+        // sort-key cursor resumption must visit every agent exactly once.
+        let mut seen = Vec::new();
+        let mut cursor = None;
+        loop {
+            let page = operations
+                .list_agents(
+                    &caller,
+                    ListAgentsInput {
+                        limit: 1,
+                        cursor: cursor.clone(),
+                        ..ListAgentsInput::default()
+                    },
+                )
+                .await
+                .expect("page");
+            seen.extend(
+                page.agents
+                    .iter()
+                    .map(|agent| agent.identity.session_id.clone()),
+            );
+            match page.next_cursor {
+                Some(next) => cursor = Some(next),
+                None => break,
+            }
+        }
+        assert_eq!(seen, expected);
+    }
+}
+
+#[tokio::test]
 async fn whoami_returns_exact_role_parent_scope_and_effective_capabilities() {
     let operations = fixture(false);
     let ordinary = operations

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/tests.rs
@@ -353,3 +353,65 @@ async fn status_projection_separates_presentation_from_execution_detail() {
     assert_eq!(closed.status.presentation, AgentPresentationStatus::Closed);
     assert_eq!(closed.status.execution, AgentExecutionStatus::Closed);
 }
+
+#[tokio::test]
+async fn terminal_ordinary_agents_are_hidden_while_relationship_closed_subagents_remain_readable() {
+    let terminal_by_status = session("terminal-status", "workspace-a", "closed");
+    let mut terminal_by_timestamp = session("terminal-timestamp", "workspace-b", "idle");
+    terminal_by_timestamp.closed_at = Some("2026-08-10T01:00:00Z".to_string());
+    let sessions = FakeSessions {
+        records: vec![
+            session("P", "workspace-a", "idle"),
+            terminal_by_status,
+            terminal_by_timestamp,
+            session("C", "workspace-a", "idle"),
+        ],
+    };
+    let operations = AgentOperations::new(
+        RuntimeIdentity::new("runtime-1"),
+        Arc::new(sessions),
+        Arc::new(FakeRelationships {
+            links: vec![link("P", "C", true)],
+        }),
+        Arc::new(FakeExecution::default()),
+    );
+    let caller = caller(&operations, "P");
+
+    for terminal_id in ["terminal-status", "terminal-timestamp"] {
+        assert!(matches!(
+            operations.get_agent(&caller, &target(terminal_id)).await,
+            Err(AgentOperationsError::AgentNotFound)
+        ));
+    }
+    let ordinary = operations
+        .list_agents(&caller, ListAgentsInput::default())
+        .await
+        .expect("list ordinary agents");
+    assert_eq!(
+        ordinary
+            .agents
+            .iter()
+            .map(|agent| agent.identity.session_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["P"]
+    );
+
+    let closed_child = operations
+        .get_agent(&caller, &target("C"))
+        .await
+        .expect("relationship-Closed subagent remains readable");
+    assert_eq!(
+        closed_child.status.presentation,
+        AgentPresentationStatus::Closed
+    );
+    assert_eq!(
+        operations
+            .list_subagents(&caller)
+            .await
+            .expect("list Closed subagent")
+            .into_iter()
+            .map(|agent| agent.identity.session_id)
+            .collect::<Vec<_>>(),
+        vec!["C"]
+    );
+}

--- a/anyharness/crates/anyharness-lib/src/domains/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/mod.rs
@@ -1,4 +1,5 @@
 pub mod activity;
+pub mod agent_operations;
 pub mod agents;
 pub mod artifacts;
 pub mod cowork;

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/execution_summary.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/execution_summary.rs
@@ -3,42 +3,88 @@ use anyharness_contract::v1::{
     WorkspaceExecutionSummary,
 };
 
-use super::model::SessionRecord;
+use super::model::{SessionExecutionState, SessionExecutionStatePhase, SessionRecord};
 use crate::live::sessions::handle::LiveSessionExecutionSnapshot;
 
 pub fn summarize_session_record(
     record: &SessionRecord,
     live_snapshot: Option<&LiveSessionExecutionSnapshot>,
 ) -> SessionExecutionSummary {
-    match record.status.as_str() {
-        "closed" => SessionExecutionSummary {
-            phase: SessionExecutionPhase::Closed,
-            has_live_handle: false,
-            pending_interactions: Vec::new(),
-            updated_at: record.updated_at.clone(),
+    let state = session_execution_state(record, live_snapshot);
+    SessionExecutionSummary {
+        phase: execution_phase_to_contract(state.phase),
+        has_live_handle: state.has_live_handle,
+        pending_interactions: if state.has_live_handle {
+            live_snapshot
+                .map(|snapshot| snapshot.pending_interactions.clone())
+                .unwrap_or_default()
+        } else {
+            Vec::new()
         },
-        "errored" => SessionExecutionSummary {
-            phase: SessionExecutionPhase::Errored,
+        updated_at: if state.has_live_handle {
+            live_snapshot
+                .map(|snapshot| snapshot.updated_at.clone())
+                .unwrap_or_else(|| record.updated_at.clone())
+        } else {
+            record.updated_at.clone()
+        },
+    }
+}
+
+pub fn session_execution_state(
+    record: &SessionRecord,
+    live_snapshot: Option<&LiveSessionExecutionSnapshot>,
+) -> SessionExecutionState {
+    match record.status.as_str() {
+        "closed" => SessionExecutionState {
+            phase: SessionExecutionStatePhase::Closed,
             has_live_handle: false,
-            pending_interactions: Vec::new(),
-            updated_at: record.updated_at.clone(),
+        },
+        "errored" => SessionExecutionState {
+            phase: SessionExecutionStatePhase::Errored,
+            has_live_handle: false,
         },
         "starting" => live_snapshot
-            .map(|snapshot| snapshot.to_contract_summary(true))
-            .unwrap_or_else(|| SessionExecutionSummary {
-                phase: SessionExecutionPhase::Starting,
+            .map(live_execution_state)
+            .unwrap_or(SessionExecutionState {
+                phase: SessionExecutionStatePhase::Starting,
                 has_live_handle: false,
-                pending_interactions: Vec::new(),
-                updated_at: record.updated_at.clone(),
             }),
         _ => live_snapshot
-            .map(|snapshot| snapshot.to_contract_summary(true))
-            .unwrap_or_else(|| SessionExecutionSummary {
-                phase: SessionExecutionPhase::Idle,
+            .map(live_execution_state)
+            .unwrap_or(SessionExecutionState {
+                phase: SessionExecutionStatePhase::Idle,
                 has_live_handle: false,
-                pending_interactions: Vec::new(),
-                updated_at: record.updated_at.clone(),
             }),
+    }
+}
+
+fn live_execution_state(snapshot: &LiveSessionExecutionSnapshot) -> SessionExecutionState {
+    SessionExecutionState {
+        phase: match snapshot.phase {
+            SessionExecutionPhase::Starting => SessionExecutionStatePhase::Starting,
+            SessionExecutionPhase::Running => SessionExecutionStatePhase::Running,
+            SessionExecutionPhase::AwaitingInteraction => {
+                SessionExecutionStatePhase::AwaitingInteraction
+            }
+            SessionExecutionPhase::Idle => SessionExecutionStatePhase::Idle,
+            SessionExecutionPhase::Errored => SessionExecutionStatePhase::Errored,
+            SessionExecutionPhase::Closed => SessionExecutionStatePhase::Closed,
+        },
+        has_live_handle: true,
+    }
+}
+
+fn execution_phase_to_contract(phase: SessionExecutionStatePhase) -> SessionExecutionPhase {
+    match phase {
+        SessionExecutionStatePhase::Starting => SessionExecutionPhase::Starting,
+        SessionExecutionStatePhase::Running => SessionExecutionPhase::Running,
+        SessionExecutionStatePhase::AwaitingInteraction => {
+            SessionExecutionPhase::AwaitingInteraction
+        }
+        SessionExecutionStatePhase::Idle => SessionExecutionPhase::Idle,
+        SessionExecutionStatePhase::Errored => SessionExecutionPhase::Errored,
+        SessionExecutionStatePhase::Closed => SessionExecutionPhase::Closed,
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/links/service.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/links/service.rs
@@ -226,11 +226,34 @@ impl SessionLinkService {
         self.store.list_subagent_children(parent_session_id)
     }
 
+    pub fn list_subagent_children_including_closed(
+        &self,
+        parent_session_id: &str,
+    ) -> anyhow::Result<Vec<SessionLinkRecord>> {
+        Ok(self
+            .store
+            .list_by_parent_including_closed(parent_session_id)?
+            .into_iter()
+            .filter(|link| link.relation == SessionLinkRelation::Subagent)
+            .collect())
+    }
+
     pub fn find_subagent_parent(
         &self,
         child_session_id: &str,
     ) -> anyhow::Result<Option<SessionLinkRecord>> {
         self.store.find_subagent_parent(child_session_id)
+    }
+
+    pub fn find_subagent_parent_including_closed(
+        &self,
+        child_session_id: &str,
+    ) -> anyhow::Result<Option<SessionLinkRecord>> {
+        Ok(self
+            .store
+            .list_by_child_including_closed(child_session_id)?
+            .into_iter()
+            .find(|link| link.relation == SessionLinkRelation::Subagent))
     }
 
     pub fn find_subagent_link(

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/model.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/model.rs
@@ -150,6 +150,25 @@ pub struct SessionRecord {
     pub origin: Option<OriginContext>,
 }
 
+/// Domain-owned execution facts for consumers that must not depend on the
+/// public HTTP contract. Actor presence is execution detail, not a durable
+/// session lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionExecutionStatePhase {
+    Starting,
+    Running,
+    AwaitingInteraction,
+    Idle,
+    Errored,
+    Closed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SessionExecutionState {
+    pub phase: SessionExecutionStatePhase,
+    pub has_live_handle: bool,
+}
+
 impl SessionRecord {
     pub fn to_contract(&self) -> v1::Session {
         self.to_contract_with_details(None, None)

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/view.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/view.rs
@@ -15,9 +15,11 @@ use anyharness_contract::v1::{
 
 use crate::domains::agents::readiness::launch_options::ResolvedWorkspaceLaunchOptions;
 use crate::domains::sessions::execution_summary::{
-    idle_workspace_execution_summary, summarize_session_record, summarize_workspace_sessions,
+    idle_workspace_execution_summary, session_execution_state, summarize_session_record,
+    summarize_workspace_sessions,
 };
 use crate::domains::sessions::links::model::SessionLinkRecord;
+use crate::domains::sessions::model::SessionExecutionState;
 use crate::domains::sessions::model::{PendingPromptRecord, SessionRecord};
 
 use super::SessionRuntime;
@@ -147,6 +149,15 @@ impl SessionRuntime {
         };
 
         summarize_session_record(record, live_snapshot.as_ref())
+    }
+
+    pub async fn session_execution_state(&self, record: &SessionRecord) -> SessionExecutionState {
+        let live_snapshot = match self.acp_manager.get_handle(&record.id).await {
+            Some(handle) => Some(handle.execution_snapshot().await),
+            None => None,
+        };
+
+        session_execution_state(record, live_snapshot.as_ref())
     }
 
     pub async fn workspace_execution_summary(

--- a/anyharness/crates/anyharness-lib/src/integrations/mcp/product_server/server.rs
+++ b/anyharness/crates/anyharness-lib/src/integrations/mcp/product_server/server.rs
@@ -5,7 +5,9 @@ use super::definition::ProductMcpDefinition;
 use crate::integrations::mcp::json_rpc::{
     jsonrpc_error, jsonrpc_result, CallToolParams, InitializeParams, JsonRpcRequest,
 };
-use crate::integrations::mcp::tools::jsonrpc_tool_result;
+use crate::integrations::mcp::tools::{
+    jsonrpc_tool_result, jsonrpc_typed_tool_error, McpToolCallError,
+};
 
 // ── Error codes ─────────────────────────────────────────────────────────────
 
@@ -202,11 +204,16 @@ where
                     )));
                 }
             };
-            let result = server
-                .call_tool(&ctx, &params.name, params.arguments)
-                .await
-                .map_err(|error| error.to_string());
-            Ok(Some(jsonrpc_tool_result(request.id, result)))
+            let result = server.call_tool(&ctx, &params.name, params.arguments).await;
+            if let Err(error) = &result {
+                if let Some(typed) = error.downcast_ref::<McpToolCallError>() {
+                    return Ok(Some(jsonrpc_typed_tool_error(request.id, typed)));
+                }
+            }
+            Ok(Some(jsonrpc_tool_result(
+                request.id,
+                result.map_err(|error| error.to_string()),
+            )))
         }
         _ => Ok(Some(jsonrpc_error(
             request.id,

--- a/anyharness/crates/anyharness-lib/src/integrations/mcp/tools.rs
+++ b/anyharness/crates/anyharness-lib/src/integrations/mcp/tools.rs
@@ -3,6 +3,22 @@ use serde_json::{json, Value};
 
 use super::json_rpc::jsonrpc_result;
 
+#[derive(Debug, thiserror::Error)]
+#[error("{message}")]
+pub struct McpToolCallError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl McpToolCallError {
+    pub fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
 pub fn jsonrpc_tool_result<T, E>(id: Option<Value>, result: Result<T, E>) -> Value
 where
     T: Serialize,
@@ -46,6 +62,23 @@ pub fn tool_definition(name: &str, description: &str, input_schema: Value) -> Va
         "description": description,
         "inputSchema": input_schema,
     })
+}
+
+pub fn jsonrpc_typed_tool_error(id: Option<Value>, error: &McpToolCallError) -> Value {
+    let structured = json!({
+        "error": {
+            "code": error.code,
+            "message": error.message,
+        }
+    });
+    jsonrpc_result(
+        id,
+        json!({
+            "content": [{ "type": "text", "text": error.message }],
+            "structuredContent": structured,
+            "isError": true,
+        }),
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Status

- Open draft; not authorized for merge.
- Exact head: `a67ace6851fd66fd929763a7437b705759d4a85e`.
- Exact base: `2672c78a4ccc7ba8ab5525bf1fa3fc84f8f0e8ce`.
- GitHub exact-head CI status: green.
- Readiness labels: `area:anyharness` applied; required `release:*` remains pending.

## Frozen spec and slice

- Frozen feature revision: `2026-08-10.1`.
- Slice: **PR 1 — Agent-operations contracts, identity, and authorization**.
- Local-only frozen specification: `/Users/pablohansen/Proliferate Workspace/ADRs/(0) Subagents/Core Docs/5 Consolidated Feature Specification and PR Plan.md`.
- Frozen specification SHA-256: `baea03bdef9dbf0204673a11d38f5c6981a87a0752420e1a848095607f13d6a7`.
- Limitation: the specification path is machine-local and is not a GitHub-accessible artifact.

## Proof run

- The complete focused command inventory and independent-review outcome are preserved in the detailed record below.
- GitHub exact-head workflows passed: CI, Intent Tests, CodeQL, and Self-Host Smoke change detection. The production-compose smoke job was skipped because this slice did not trigger it.
- No dedicated immutable local acceptance bundle was found for PR 1; the retained evidence is the exact-head GitHub checks and the command/test record below.

## Proof not run and why

- Repository-wide `cargo fmt --check` was not claimed: pre-existing formatting drift outside this slice blocked it. Changed-file `rustfmt --check` passed.
- No automatic Workspace MCP injection or full product activation run was performed; activation is owned by PR 10.

## Open blockers

- No implementation or CI blocker is documented at this head.
- Evidence gap: there is no separately checksummed local acceptance receipt for this slice.
- Readiness metadata remains intentionally incomplete: the draft has no `release:*` or `area:*` labels.

## Exact next action

Keep this PR draft while the stack-level PR 10 release gate is completed. When the stack is authorized for release, choose the required release label, reconfirm the head/checks, mark this PR ready, and merge it first.

---

## Detailed implementation record

## What

- add the cross-resource agent-operations boundary for authenticated runtime/session identity, status projection, capability decisions, and typed errors
- implement `whoami`, `list_agents`, `get_agent`, and `list_subagents`
- declare the stable 18-tool Workspace MCP contract without activating or replacing the current MCP
- retain Closed subagent relationships for parent reads while hiding terminal ordinary sessions

## Why

This is PR 1 of the approved Workspace MCP and Subagents stack. Later slices need one ownership-correct policy/use-case boundary so MCP, HTTP, and UI adapters do not duplicate identity, authorization, or lifecycle interpretation.

## Impact

- same-runtime ordinary-agent reads are allowed across workspaces
- subagent reads remain parent-only and non-enumerating
- Closed relationship state wins over live execution state
- open errored sessions present as Available with separate execution detail
- product MCP registration, routes, prompts, and legacy removal are intentionally unchanged

## Checks

- `cargo test -p anyharness-lib agent_operations` — 16 passed
- `cargo test -p anyharness-lib subagent_authorization` — passed
- `python3 scripts/check_anyharness_boundaries.py` — passed
- `python3 scripts/check_docs.py` — passed
- changed-file `rustfmt --check` — passed
- `git diff --check` — passed
- repository-wide `cargo fmt --check` remains blocked by pre-existing formatting drift outside this slice; no out-of-scope formatting changes are included

## Independent review

Three findings were found and resolved before publication: conditional task requirement for subagent creation, terminal ordinary-session projection, and capability-token-bound MCP probe coverage. The repaired head was independently accepted.

## Stack

This draft targets `main`. PR 2 will stack from this accepted head; nothing is authorized to merge.
