### PR TITLE
feat(anyharness): add durable agent messaging

### DIFF
--- a/anyharness/crates/anyharness-lib/src/app/agent_operations.rs
+++ b/anyharness/crates/anyharness-lib/src/app/agent_operations.rs
@@ -30,13 +30,19 @@ pub(super) fn wire_agent_operations(deps: AgentOperationsWiringDeps) -> Arc<Agen
             deps.session_runtime.clone(),
         )
         .with_workspace_catalogs(
-            deps.workspace_option_runtime,
+            deps.workspace_option_runtime.clone(),
             deps.session_runtime.clone(),
             deps.session_service.clone(),
         )
         .with_ordinary_operations(
-            deps.session_runtime,
+            deps.session_runtime.clone(),
             deps.session_service,
+            deps.session_admission.clone(),
+            deps.workspace_operation_gate.clone(),
+        )
+        .with_messaging(
+            deps.session_runtime,
+            deps.workspace_option_runtime,
             deps.session_admission,
             deps.workspace_operation_gate,
         ),

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/calls.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/calls.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Value};
 use super::context::WorkspaceMcpContext;
 use crate::domains::agent_operations::model::{
     AgentCreationKind, AgentIdentity, AgentPresentationStatus, ConfigureAgentInput,
-    CreateAgentInput, CreateWorkspaceInput, ListAgentsInput, ListWorkspacesInput,
+    CreateAgentInput, CreateWorkspaceInput, ListAgentsInput, ListWorkspacesInput, SendMessageInput,
     WorkspaceIdentity,
 };
 use crate::domains::agent_operations::runtime::{AgentOperations, AgentOperationsError};
@@ -63,6 +63,13 @@ struct ConfigureAgentArgs {
     agent_id: String,
     config_id: String,
     value: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SendMessageArgs {
+    agent_id: String,
+    message: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -220,6 +227,23 @@ pub async fn call_tool(
             let args = parse::<TargetArgs>(arguments)?;
             let target = AgentIdentity::new(operations.runtime_identity().clone(), args.agent_id);
             serialize(operations.resume_agent(&ctx.caller, &target).await)
+        }
+        "send_message" => {
+            let args = parse::<SendMessageArgs>(arguments)?;
+            serialize(
+                operations
+                    .send_message(
+                        &ctx.caller,
+                        SendMessageInput {
+                            target: AgentIdentity::new(
+                                operations.runtime_identity().clone(),
+                                args.agent_id,
+                            ),
+                            message: args.message,
+                        },
+                    )
+                    .await,
+            )
         }
         "interrupt_agent" => {
             let args = parse::<TargetArgs>(arguments)?;

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/tests.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use serde_json::json;
@@ -6,13 +6,23 @@ use serde_json::json;
 use super::*;
 use crate::domains::agent_operations::model::RuntimeIdentity;
 use crate::domains::agent_operations::runtime::{
-    AgentExecutionReads, AgentSessionReads, SubagentRelationshipReads,
+    AgentExecutionReads, AgentMessageQueue, AgentSessionReads, AgentWorkspaceOperations,
+    SubagentRelationshipReads,
 };
+use crate::domains::sessions::admission::{NoControllerPolicy, SessionMutationAdmission};
 use crate::domains::sessions::links::model::{
     SessionLinkRecord, SessionLinkRelation, SessionLinkWorkspaceRelation,
 };
 use crate::domains::sessions::model::{
     SessionExecutionState, SessionExecutionStatePhase, SessionMcpBindingPolicy, SessionRecord,
+};
+use crate::domains::sessions::prompt::provenance::AgentSessionPromptSource;
+use crate::domains::sessions::runtime::SendPromptError;
+use crate::domains::workspaces::model::{test_workspace_record, WorkspaceKind, WorkspaceRecord};
+use crate::domains::workspaces::operation_gate::WorkspaceOperationGate;
+use crate::domains::workspaces::options::{
+    CreateWorkspaceFromOptionsInput, CreateWorkspaceFromOptionsResult, WorkspaceCreationOptions,
+    WorkspaceOptionsError,
 };
 use crate::integrations::mcp::product_server::{
     dispatch_product_mcp_request, ProductMcpAuthHeader, ProductMcpRequestContext, ProductMcpServer,
@@ -77,6 +87,58 @@ impl AgentExecutionReads for Execution {
     }
 }
 
+struct Workspaces(Vec<WorkspaceRecord>);
+
+#[async_trait]
+impl AgentWorkspaceOperations for Workspaces {
+    async fn list_workspaces(&self) -> Result<Vec<WorkspaceRecord>, WorkspaceOptionsError> {
+        Ok(self.0.clone())
+    }
+
+    async fn get_workspace(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Option<WorkspaceRecord>, WorkspaceOptionsError> {
+        Ok(self
+            .0
+            .iter()
+            .find(|workspace| workspace.id == workspace_id)
+            .cloned())
+    }
+
+    async fn list_workspace_options(
+        &self,
+    ) -> Result<WorkspaceCreationOptions, WorkspaceOptionsError> {
+        unreachable!()
+    }
+
+    async fn create_workspace(
+        &self,
+        _caller_workspace_id: &str,
+        _input: CreateWorkspaceFromOptionsInput,
+    ) -> Result<CreateWorkspaceFromOptionsResult, WorkspaceOptionsError> {
+        unreachable!()
+    }
+}
+
+struct Messages(Mutex<Vec<(String, String, AgentSessionPromptSource)>>);
+
+#[async_trait]
+impl AgentMessageQueue for Messages {
+    async fn enqueue_agent_message(
+        &self,
+        target_session_id: &str,
+        message: String,
+        source: AgentSessionPromptSource,
+    ) -> Result<i64, SendPromptError> {
+        self.0
+            .lock()
+            .unwrap()
+            .push((target_session_id.into(), message, source));
+        Ok(41)
+    }
+}
+
 fn session(id: &str, workspace_id: &str) -> SessionRecord {
     SessionRecord {
         id: id.to_string(),
@@ -107,7 +169,11 @@ fn session(id: &str, workspace_id: &str) -> SessionRecord {
     }
 }
 
-fn server() -> (WorkspaceProductMcpServer, Arc<WorkspaceMcpAuth>) {
+fn server() -> (
+    WorkspaceProductMcpServer,
+    Arc<WorkspaceMcpAuth>,
+    Arc<Messages>,
+) {
     let sessions = Arc::new(Sessions(vec![
         session("P", "workspace-a"),
         session("Q", "workspace-b"),
@@ -126,19 +192,35 @@ fn server() -> (WorkspaceProductMcpServer, Arc<WorkspaceMcpAuth>) {
         created_at: "2026-08-10T00:00:00Z".to_string(),
         closed_at: None,
     }]));
-    let operations = Arc::new(AgentOperations::new(
-        RuntimeIdentity::new("runtime-1"),
-        sessions,
-        relationships,
-        Arc::new(Execution),
-    ));
+    let messages = Arc::new(Messages(Mutex::new(Vec::new())));
+    let workspaces = ["workspace-a", "workspace-b"]
+        .into_iter()
+        .map(|id| {
+            let path = format!("/tmp/{id}");
+            let mut workspace = test_workspace_record(WorkspaceKind::Local, &path);
+            workspace.id = id.into();
+            workspace
+        })
+        .collect();
+    let operations = Arc::new(
+        AgentOperations::new(
+            RuntimeIdentity::new("runtime-1"),
+            sessions,
+            relationships,
+            Arc::new(Execution),
+        )
+        .with_messaging(
+            messages.clone(),
+            Arc::new(Workspaces(workspaces)),
+            Arc::new(SessionMutationAdmission::new(Arc::new(NoControllerPolicy))),
+            Arc::new(WorkspaceOperationGate::new()),
+        ),
+    );
     let auth = Arc::new(WorkspaceMcpAuth::new(
         std::env::temp_dir().join(format!("workspace-mcp-contract-{}", uuid::Uuid::new_v4())),
     ));
-    (
-        WorkspaceProductMcpServer::new(operations, auth.clone()),
-        auth,
-    )
+    let server = WorkspaceProductMcpServer::new(operations, auth.clone());
+    (server, auth, messages)
 }
 
 fn context(workspace_id: &str, session_id: &str) -> ProductMcpRequestContext {
@@ -172,7 +254,7 @@ async fn authenticated_dispatch(
 
 #[tokio::test]
 async fn workspace_mcp_initialize_list_and_read_calls_use_authenticated_context() {
-    let (server, auth) = server();
+    let (server, auth, _) = server();
     let token = auth
         .mint_capability_token("workspace-a", "P")
         .expect("mint Workspace capability token");
@@ -242,7 +324,7 @@ async fn workspace_mcp_initialize_list_and_read_calls_use_authenticated_context(
 
 #[tokio::test]
 async fn workspace_mcp_denials_are_typed_and_do_not_leak_foreign_subagent_metadata() {
-    let (server, auth) = server();
+    let (server, auth, _) = server();
     let q_token = auth
         .mint_capability_token("workspace-b", "Q")
         .expect("mint Q Workspace capability token");
@@ -297,7 +379,7 @@ async fn workspace_mcp_denials_are_typed_and_do_not_leak_foreign_subagent_metada
 
 #[tokio::test]
 async fn workspace_capability_scope_rejects_mismatched_workspace_or_session_before_dispatch() {
-    let (server, auth) = server();
+    let (server, auth, _) = server();
     let token = auth
         .mint_capability_token("workspace-a", "P")
         .expect("mint Workspace capability token");
@@ -309,4 +391,93 @@ async fn workspace_capability_scope_rejects_mismatched_workspace_or_session_befo
             Err(AuthenticatedDispatchError::InvalidCapability)
         );
     }
+}
+
+#[tokio::test]
+async fn send_message_dispatch_pins_the_durable_receipt_and_leaves_later_tools_inert() {
+    let (server, auth, messages) = server();
+    let token = auth
+        .mint_capability_token("workspace-a", "P")
+        .expect("mint Workspace capability token");
+    let sent = authenticated_dispatch(
+        &server,
+        &token,
+        context("workspace-a", "P"),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "send_message",
+                "arguments": { "agentId": "Q", "message": "hello from P" }
+            }
+        }),
+    )
+    .await
+    .expect("send dispatch")
+    .expect("send response");
+    assert_eq!(
+        sent["result"]["structuredContent"],
+        json!({
+            "target": { "runtimeId": "runtime-1", "sessionId": "Q" },
+            "queueSeq": 41,
+            "status": "durably_queued"
+        })
+    );
+    let calls = messages.0.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].0, "Q");
+    assert_eq!(calls[0].1, "hello from P");
+    assert_eq!(calls[0].2.source_session_id, "P");
+    assert_eq!(calls[0].2.label, "P");
+    drop(calls);
+
+    let forged = authenticated_dispatch(
+        &server,
+        &token,
+        context("workspace-a", "P"),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "send_message",
+                "arguments": {
+                    "agentId": "Q",
+                    "message": "forged",
+                    "sourceSessionId": "C"
+                }
+            }
+        }),
+    )
+    .await
+    .expect("forged dispatch")
+    .expect("forged response");
+    assert_eq!(
+        forged["result"]["structuredContent"]["error"]["code"],
+        "WORKSPACE_MCP_ARGUMENTS_INVALID"
+    );
+    assert_eq!(messages.0.lock().unwrap().len(), 1);
+
+    let later_slice = authenticated_dispatch(
+        &server,
+        &token,
+        context("workspace-a", "P"),
+        json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "close_subagent",
+                "arguments": { "agentId": "C" }
+            }
+        }),
+    )
+    .await
+    .expect("later-slice dispatch")
+    .expect("later-slice response");
+    assert_eq!(
+        later_slice["result"]["structuredContent"]["error"]["code"],
+        "WORKSPACE_MCP_OPERATION_NOT_IMPLEMENTED"
+    );
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/tests.rs
@@ -126,7 +126,7 @@ struct Messages(Mutex<Vec<(String, String, AgentSessionPromptSource)>>);
 #[async_trait]
 impl AgentMessageQueue for Messages {
     async fn enqueue_agent_message(
-        &self,
+        self: Arc<Self>,
         target_session_id: &str,
         message: String,
         source: AgentSessionPromptSource,

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/tools.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/tools.rs
@@ -257,6 +257,11 @@ mod tests {
     }
 
     #[test]
+    fn send_message_owns_its_target_gate_instead_of_the_caller_route_gate() {
+        assert!(!MUTATING_TOOL_NAMES.contains(&"send_message"));
+    }
+
+    #[test]
     fn workspace_mcp_tool_schema_snapshots() {
         let tools = build_tool_list();
         let actual = tools

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/model.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/model.rs
@@ -266,6 +266,26 @@ pub struct ConfigureAgentResult {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SendMessageInput {
+    pub target: AgentIdentity,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SendMessageStatus {
+    DurablyQueued,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendMessageReceipt {
+    pub target: AgentIdentity,
+    pub queue_seq: i64,
+    pub status: SendMessageStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ListWorkspacesInput {
     pub cursor: Option<String>,
     pub limit: usize,

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/error.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/error.rs
@@ -53,12 +53,18 @@ pub enum AgentOperationsError {
     Resume(EnsureLiveSessionError),
     #[error("agent interrupt failed")]
     Interrupt(SessionLifecycleError),
+    #[error("agent message enqueue failed")]
+    SendMessage(SendPromptError),
     #[error("the initial task must not be blank")]
     InvalidTask,
+    #[error("the message must not be blank")]
+    InvalidMessage,
     #[error("session execution is controlled by an active workflow")]
     ControlledByWorkflow,
     #[error("ordinary agent operations are not configured")]
     OrdinaryOperationsUnavailable,
+    #[error("agent messaging is not configured")]
+    MessagingUnavailable,
     #[error("subagent creation is declared for a later implementation slice")]
     SubagentCreationNotImplemented,
     #[error(transparent)]
@@ -113,9 +119,12 @@ impl AgentOperationsError {
             Self::Resume(error) => resume_code(error),
             Self::Interrupt(SessionLifecycleError::SessionNotFound(_)) => "AGENT_NOT_FOUND",
             Self::Interrupt(SessionLifecycleError::Internal(_)) => "AGENT_OPERATIONS_INTERNAL",
+            Self::SendMessage(error) => message_code(error),
             Self::InvalidTask => "AGENT_TASK_INVALID",
+            Self::InvalidMessage => "AGENT_MESSAGE_INVALID",
             Self::ControlledByWorkflow => "SESSION_CONTROLLED_BY_WORKFLOW",
             Self::OrdinaryOperationsUnavailable => "AGENT_OPERATIONS_UNAVAILABLE",
+            Self::MessagingUnavailable => "AGENT_OPERATIONS_UNAVAILABLE",
             Self::SubagentCreationNotImplemented => "WORKSPACE_MCP_OPERATION_NOT_IMPLEMENTED",
             Self::TaskOutput(TaskOutputError::InvalidLimit) => "TASK_OUTPUT_LIMIT_INVALID",
             Self::TaskOutput(TaskOutputError::InvalidCursor) => "TASK_OUTPUT_CURSOR_INVALID",
@@ -163,13 +172,16 @@ impl AgentOperationsError {
             Self::Interrupt(SessionLifecycleError::Internal(_)) => {
                 "Agent operations failed.".into()
             }
+            Self::SendMessage(error) => message_public_message(error),
             Self::InvalidTask => "The initial task must not be blank.".into(),
+            Self::InvalidMessage => "The message must not be blank.".into(),
             Self::ControlledByWorkflow => {
                 "Session execution is controlled by an active workflow.".into()
             }
             Self::OrdinaryOperationsUnavailable => {
                 "Ordinary agent operations are unavailable.".into()
             }
+            Self::MessagingUnavailable => "Agent messaging is unavailable.".into(),
             Self::SubagentCreationNotImplemented => {
                 "Subagent creation is not implemented yet.".into()
             }
@@ -218,6 +230,13 @@ fn prompt_code(error: &SendPromptError) -> &'static str {
         SendPromptError::WorkspaceDirectoryMissing { .. } => "WORKSPACE_DIRECTORY_MISSING",
         SendPromptError::InvalidPrompt(error) => error.code,
         SendPromptError::Internal(_) => "AGENT_OPERATIONS_INTERNAL",
+    }
+}
+
+fn message_code(error: &SendPromptError) -> &'static str {
+    match error {
+        SendPromptError::EmptyPrompt | SendPromptError::InvalidPrompt(_) => "AGENT_MESSAGE_INVALID",
+        other => prompt_code(other),
     }
 }
 
@@ -307,6 +326,19 @@ fn prompt_public_message(error: &SendPromptError) -> String {
             "The workspace checkout directory is missing.".into()
         }
         SendPromptError::InvalidPrompt(_) => "The initial task is invalid.".into(),
+        SendPromptError::Internal(_) => "Agent operations failed.".into(),
+    }
+}
+
+fn message_public_message(error: &SendPromptError) -> String {
+    match error {
+        SendPromptError::SessionNotFound(_) => "The requested agent was not found.".into(),
+        SendPromptError::SessionClosed => "The agent session is closed.".into(),
+        SendPromptError::EmptyPrompt => "The message must not be blank.".into(),
+        SendPromptError::WorkspaceDirectoryMissing { .. } => {
+            "The workspace checkout directory is missing.".into()
+        }
+        SendPromptError::InvalidPrompt(_) => "The message is invalid.".into(),
         SendPromptError::Internal(_) => "Agent operations failed.".into(),
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/messaging.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/messaging.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+
+use crate::domains::agent_operations::model::{
+    AgentCapability, AuthenticatedAgentCaller, SendMessageInput, SendMessageReceipt,
+    SendMessageStatus,
+};
+use crate::domains::sessions::admission::SessionMutationKind;
+use crate::domains::sessions::prompt::provenance::AgentSessionPromptSource;
+use crate::domains::workspaces::operation_gate::WorkspaceOperationKind;
+
+use super::{
+    ordinary::caller_provenance_label, AgentMessageQueue, AgentOperations, AgentOperationsError,
+};
+
+impl AgentOperations {
+    #[tracing::instrument(skip_all, fields(operation = "send_message"))]
+    pub async fn send_message(
+        &self,
+        caller: &AuthenticatedAgentCaller,
+        input: SendMessageInput,
+    ) -> Result<SendMessageReceipt, AgentOperationsError> {
+        let (_, initial_target) =
+            self.authorize_target(caller, &input.target, AgentCapability::SendMessage)?;
+        if input.message.trim().is_empty() {
+            return Err(AgentOperationsError::InvalidMessage);
+        }
+        let target_workspace_id = initial_target.record.workspace_id.clone();
+
+        let _permit = self
+            .admit_target(&input.target.session_id, SessionMutationKind::Prompt)
+            .await?;
+        let _lease = self
+            .operation_gate()?
+            .acquire_shared(&target_workspace_id, WorkspaceOperationKind::SessionPrompt)
+            .await;
+
+        let (current_caller, current_target) =
+            self.authorize_target(caller, &input.target, AgentCapability::SendMessage)?;
+        self.assert_target_workspace_under_lease(&current_target, &target_workspace_id)
+            .await?;
+
+        let source = AgentSessionPromptSource {
+            source_session_id: current_caller.record.id.clone(),
+            session_link_id: current_target
+                .parent_link
+                .as_ref()
+                .filter(|link| link.parent_session_id == current_caller.record.id)
+                .map(|link| link.id.clone()),
+            label: caller_provenance_label(&current_caller.record),
+        };
+        let queue_seq = self
+            .message_queue()?
+            .enqueue_agent_message(&current_target.record.id, input.message, source)
+            .await
+            .map_err(AgentOperationsError::SendMessage)?;
+
+        Ok(SendMessageReceipt {
+            target: input.target,
+            queue_seq,
+            status: SendMessageStatus::DurablyQueued,
+        })
+    }
+
+    fn message_queue(&self) -> Result<&Arc<dyn AgentMessageQueue>, AgentOperationsError> {
+        self.message_queue
+            .as_ref()
+            .ok_or(AgentOperationsError::MessagingUnavailable)
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/messaging.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/messaging.rs
@@ -48,8 +48,7 @@ impl AgentOperations {
                 .map(|link| link.id.clone()),
             label: caller_provenance_label(&current_caller.record),
         };
-        let queue_seq = self
-            .message_queue()?
+        let queue_seq = Arc::clone(self.message_queue()?)
             .enqueue_agent_message(&current_target.record.id, input.message, source)
             .await
             .map_err(AgentOperationsError::SendMessage)?;

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/messaging_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/messaging_tests.rs
@@ -193,7 +193,7 @@ impl Messages {
 #[async_trait]
 impl AgentMessageQueue for Messages {
     async fn enqueue_agent_message(
-        &self,
+        self: Arc<Self>,
         target_session_id: &str,
         message: String,
         source: AgentSessionPromptSource,

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/messaging_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/messaging_tests.rs
@@ -1,0 +1,600 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use super::*;
+use crate::domains::agent_operations::model::{
+    AgentIdentity, AuthenticatedAgentCaller, RuntimeIdentity, SendMessageInput, SendMessageStatus,
+};
+use crate::domains::sessions::admission::{
+    NoControllerPolicy, SessionControllerPolicy, SessionMutationAdmission,
+};
+use crate::domains::sessions::links::model::{
+    SessionLinkRecord, SessionLinkRelation, SessionLinkWorkspaceRelation,
+};
+use crate::domains::sessions::model::{
+    SessionExecutionState, SessionExecutionStatePhase, SessionMcpBindingPolicy, SessionRecord,
+};
+use crate::domains::sessions::prompt::provenance::AgentSessionPromptSource;
+use crate::domains::sessions::runtime::SendPromptError;
+use crate::domains::workspaces::model::{test_workspace_record, WorkspaceKind, WorkspaceRecord};
+use crate::domains::workspaces::operation_gate::WorkspaceOperationGate;
+use crate::domains::workspaces::options::{
+    CreateWorkspaceFromOptionsInput, CreateWorkspaceFromOptionsResult, WorkspaceCreationOptions,
+    WorkspaceOptionsError,
+};
+
+struct Sessions(Mutex<HashMap<String, SessionRecord>>);
+
+impl Sessions {
+    fn update(&self, session_id: &str, update: impl FnOnce(&mut SessionRecord)) {
+        update(self.0.lock().unwrap().get_mut(session_id).unwrap());
+    }
+}
+
+impl AgentSessionReads for Sessions {
+    fn get_session(&self, session_id: &str) -> anyhow::Result<Option<SessionRecord>> {
+        Ok(self.0.lock().unwrap().get(session_id).cloned())
+    }
+
+    fn list_sessions(&self) -> anyhow::Result<Vec<SessionRecord>> {
+        Ok(self.0.lock().unwrap().values().cloned().collect())
+    }
+}
+
+struct Relationships {
+    records: Mutex<Vec<SessionLinkRecord>>,
+    child_reads: AtomicUsize,
+    child_read: tokio::sync::Notify,
+}
+
+impl Relationships {
+    fn close(&self, child_session_id: &str) {
+        self.records
+            .lock()
+            .unwrap()
+            .iter_mut()
+            .find(|link| link.child_session_id == child_session_id)
+            .unwrap()
+            .closed_at = Some("2026-08-11T01:00:00Z".into());
+    }
+
+    async fn wait_for_child_read(&self) {
+        while self.child_reads.load(Ordering::SeqCst) == 0 {
+            self.child_read.notified().await;
+        }
+    }
+}
+
+impl SubagentRelationshipReads for Relationships {
+    fn find_parent_including_closed(
+        &self,
+        child_session_id: &str,
+    ) -> anyhow::Result<Option<SessionLinkRecord>> {
+        if child_session_id == "child" {
+            self.child_reads.fetch_add(1, Ordering::SeqCst);
+            self.child_read.notify_one();
+        }
+        Ok(self
+            .records
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|link| link.child_session_id == child_session_id)
+            .cloned())
+    }
+
+    fn list_children_including_closed(
+        &self,
+        parent_session_id: &str,
+    ) -> anyhow::Result<Vec<SessionLinkRecord>> {
+        Ok(self
+            .records
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|link| link.parent_session_id == parent_session_id)
+            .cloned()
+            .collect())
+    }
+}
+
+struct Execution;
+
+#[async_trait]
+impl AgentExecutionReads for Execution {
+    async fn execution_state(
+        &self,
+        session: &SessionRecord,
+    ) -> anyhow::Result<SessionExecutionState> {
+        Ok(SessionExecutionState {
+            phase: match session.status.as_str() {
+                "running" => SessionExecutionStatePhase::Running,
+                "errored" => SessionExecutionStatePhase::Errored,
+                _ => SessionExecutionStatePhase::Idle,
+            },
+            has_live_handle: session.status == "running",
+        })
+    }
+}
+
+struct Workspaces {
+    records: Vec<WorkspaceRecord>,
+    get_calls: AtomicUsize,
+}
+
+#[async_trait]
+impl AgentWorkspaceOperations for Workspaces {
+    async fn list_workspaces(&self) -> Result<Vec<WorkspaceRecord>, WorkspaceOptionsError> {
+        Ok(self.records.clone())
+    }
+
+    async fn get_workspace(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Option<WorkspaceRecord>, WorkspaceOptionsError> {
+        self.get_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(self
+            .records
+            .iter()
+            .find(|workspace| workspace.id == workspace_id)
+            .cloned())
+    }
+
+    async fn list_workspace_options(
+        &self,
+    ) -> Result<WorkspaceCreationOptions, WorkspaceOptionsError> {
+        unreachable!()
+    }
+
+    async fn create_workspace(
+        &self,
+        _caller_workspace_id: &str,
+        _input: CreateWorkspaceFromOptionsInput,
+    ) -> Result<CreateWorkspaceFromOptionsResult, WorkspaceOptionsError> {
+        unreachable!()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MessageCall {
+    target_session_id: String,
+    message: String,
+    source: AgentSessionPromptSource,
+}
+
+struct Messages {
+    calls: Mutex<Vec<MessageCall>>,
+    next_seq: AtomicI64,
+    active: AtomicUsize,
+    max_active: AtomicUsize,
+    hold: AtomicBool,
+    entered: tokio::sync::Notify,
+    release: tokio::sync::Notify,
+}
+
+impl Messages {
+    fn new() -> Self {
+        Self {
+            calls: Mutex::new(Vec::new()),
+            next_seq: AtomicI64::new(1),
+            active: AtomicUsize::new(0),
+            max_active: AtomicUsize::new(0),
+            hold: AtomicBool::new(false),
+            entered: tokio::sync::Notify::new(),
+            release: tokio::sync::Notify::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl AgentMessageQueue for Messages {
+    async fn enqueue_agent_message(
+        &self,
+        target_session_id: &str,
+        message: String,
+        source: AgentSessionPromptSource,
+    ) -> Result<i64, SendPromptError> {
+        let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+        self.max_active.fetch_max(active, Ordering::SeqCst);
+        self.calls.lock().unwrap().push(MessageCall {
+            target_session_id: target_session_id.into(),
+            message,
+            source,
+        });
+        self.entered.notify_one();
+        if self.hold.load(Ordering::SeqCst) {
+            self.release.notified().await;
+        }
+        self.active.fetch_sub(1, Ordering::SeqCst);
+        Ok(self.next_seq.fetch_add(1, Ordering::SeqCst))
+    }
+}
+
+struct ControlledTarget(Option<String>);
+
+impl SessionControllerPolicy for ControlledTarget {
+    fn controlling_run_id(&self, session_id: &str) -> anyhow::Result<Option<String>> {
+        Ok((session_id == "peer").then(|| self.0.clone()).flatten())
+    }
+}
+
+struct Fixture {
+    operations: Arc<AgentOperations>,
+    sessions: Arc<Sessions>,
+    relationships: Arc<Relationships>,
+    messages: Arc<Messages>,
+    workspaces: Arc<Workspaces>,
+    gate: Arc<WorkspaceOperationGate>,
+}
+
+fn fixture(closed_child: bool, controlled_peer: bool) -> Fixture {
+    let sessions = Arc::new(Sessions(Mutex::new(
+        [
+            session("parent", "workspace-a", "idle", Some("Parent Label")),
+            session("peer", "workspace-b", "idle", Some("Peer")),
+            session("running", "workspace-b", "running", Some("Running")),
+            session("cold", "workspace-b", "errored", Some("Cold")),
+            session("child", "workspace-a", "idle", Some("Child")),
+            session("foreign-parent", "workspace-b", "idle", None),
+        ]
+        .into_iter()
+        .map(|record| (record.id.clone(), record))
+        .collect(),
+    )));
+    let relationships = Arc::new(Relationships {
+        records: Mutex::new(vec![link("parent", "child", closed_child)]),
+        child_reads: AtomicUsize::new(0),
+        child_read: tokio::sync::Notify::new(),
+    });
+    let workspaces = Arc::new(Workspaces {
+        records: vec![workspace("workspace-a"), workspace("workspace-b")],
+        get_calls: AtomicUsize::new(0),
+    });
+    let messages = Arc::new(Messages::new());
+    let gate = Arc::new(WorkspaceOperationGate::new());
+    let controller_policy: Arc<dyn SessionControllerPolicy> = if controlled_peer {
+        Arc::new(ControlledTarget(Some("workflow-1".into())))
+    } else {
+        Arc::new(NoControllerPolicy)
+    };
+    let admission = Arc::new(SessionMutationAdmission::new(controller_policy));
+    let operations = Arc::new(
+        AgentOperations::new(
+            RuntimeIdentity::new("runtime-1"),
+            sessions.clone(),
+            relationships.clone(),
+            Arc::new(Execution),
+        )
+        .with_messaging(
+            messages.clone(),
+            workspaces.clone(),
+            admission,
+            gate.clone(),
+        ),
+    );
+    Fixture {
+        operations,
+        sessions,
+        relationships,
+        messages,
+        workspaces,
+        gate,
+    }
+}
+
+#[tokio::test]
+async fn send_message_returns_only_a_durable_receipt_and_trusted_caller_provenance() {
+    let fixture = fixture(false, false);
+    let receipt = fixture
+        .operations
+        .send_message(
+            &caller(&fixture, "parent"),
+            input(&fixture, "peer", "  exact message\n"),
+        )
+        .await
+        .expect("send message");
+
+    assert_eq!(receipt.status, SendMessageStatus::DurablyQueued);
+    assert_eq!(receipt.queue_seq, 1);
+    assert_eq!(receipt.target.session_id, "peer");
+    assert_eq!(
+        serde_json::to_value(&receipt).unwrap(),
+        serde_json::json!({
+            "target": { "runtimeId": "runtime-1", "sessionId": "peer" },
+            "queueSeq": 1,
+            "status": "durably_queued"
+        })
+    );
+    assert_eq!(
+        fixture.messages.calls.lock().unwrap().as_slice(),
+        &[MessageCall {
+            target_session_id: "peer".into(),
+            message: "  exact message\n".into(),
+            source: AgentSessionPromptSource {
+                source_session_id: "parent".into(),
+                session_link_id: None,
+                label: "Parent Label".into(),
+            },
+        }]
+    );
+
+    fixture
+        .operations
+        .send_message(
+            &caller(&fixture, "parent"),
+            input(&fixture, "child", "follow up"),
+        )
+        .await
+        .expect("message owned subagent");
+    assert_eq!(
+        fixture.messages.calls.lock().unwrap()[1]
+            .source
+            .session_link_id
+            .as_deref(),
+        Some("link-child")
+    );
+}
+
+#[tokio::test]
+async fn send_message_idle_running_and_cold_targets_share_the_durable_queue_path() {
+    let fixture = fixture(false, false);
+    for (index, target) in ["peer", "running", "cold"].into_iter().enumerate() {
+        let receipt = fixture
+            .operations
+            .send_message(
+                &caller(&fixture, "parent"),
+                input(&fixture, target, &format!("message-{target}")),
+            )
+            .await
+            .expect("state-independent durable enqueue");
+        assert_eq!(receipt.queue_seq, index as i64 + 1);
+        assert_eq!(receipt.status, SendMessageStatus::DurablyQueued);
+    }
+    assert_eq!(fixture.messages.calls.lock().unwrap().len(), 3);
+}
+
+#[tokio::test]
+async fn send_message_denials_happen_before_workspace_or_queue_mutation() {
+    let open = fixture(false, false);
+    assert!(matches!(
+        open.operations
+            .send_message(
+                &caller(&open, "foreign-parent"),
+                input(&open, "child", "secret probe"),
+            )
+            .await,
+        Err(AgentOperationsError::AgentNotFound)
+    ));
+    assert!(matches!(
+        open.operations
+            .send_message(
+                &caller(&open, "parent"),
+                SendMessageInput {
+                    target: AgentIdentity::new(RuntimeIdentity::new("runtime-2"), "peer"),
+                    message: "cross runtime".into(),
+                },
+            )
+            .await,
+        Err(AgentOperationsError::RuntimeBoundaryDenied)
+    ));
+    assert!(matches!(
+        open.operations
+            .send_message(
+                &caller(&open, "parent"),
+                input(&open, "missing", "unknown target"),
+            )
+            .await,
+        Err(AgentOperationsError::AgentNotFound)
+    ));
+    assert!(open.messages.calls.lock().unwrap().is_empty());
+    assert_eq!(open.workspaces.get_calls.load(Ordering::SeqCst), 0);
+
+    open.sessions.update("peer", |record| {
+        record.closed_at = Some("2026-08-11T01:00:00Z".into())
+    });
+    assert!(matches!(
+        open.operations
+            .send_message(
+                &caller(&open, "parent"),
+                input(&open, "peer", "closed session"),
+            )
+            .await,
+        Err(AgentOperationsError::AgentNotFound)
+    ));
+    assert!(open.messages.calls.lock().unwrap().is_empty());
+    assert_eq!(open.workspaces.get_calls.load(Ordering::SeqCst), 0);
+
+    let closed = fixture(true, false);
+    assert!(matches!(
+        closed
+            .operations
+            .send_message(
+                &caller(&closed, "parent"),
+                input(&closed, "child", "closed"),
+            )
+            .await,
+        Err(AgentOperationsError::SubagentOpenRequired)
+    ));
+    assert!(closed.messages.calls.lock().unwrap().is_empty());
+    assert_eq!(closed.workspaces.get_calls.load(Ordering::SeqCst), 0);
+
+    let controlled = fixture(false, true);
+    assert!(matches!(
+        controlled
+            .operations
+            .send_message(
+                &caller(&controlled, "parent"),
+                input(&controlled, "peer", "workflow owned"),
+            )
+            .await,
+        Err(AgentOperationsError::ControlledByWorkflow)
+    ));
+    assert!(controlled.messages.calls.lock().unwrap().is_empty());
+    assert_eq!(controlled.workspaces.get_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn send_message_target_gate_rechecks_and_never_leases_the_caller_workspace() {
+    let fixture = fixture(false, false);
+    let caller_workspace_lock = fixture.gate.acquire_exclusive("workspace-a").await;
+    tokio::time::timeout(
+        Duration::from_millis(250),
+        fixture.operations.send_message(
+            &caller(&fixture, "parent"),
+            input(&fixture, "peer", "cross-workspace"),
+        ),
+    )
+    .await
+    .expect("caller workspace must not be leased")
+    .expect("cross-workspace send");
+    drop(caller_workspace_lock);
+
+    let target_workspace_lock = fixture.gate.acquire_exclusive("workspace-a").await;
+    let operations = fixture.operations.clone();
+    let recheck = tokio::spawn(async move {
+        operations
+            .send_message(
+                &operations.authenticated_caller("parent"),
+                SendMessageInput {
+                    target: AgentIdentity::new(operations.runtime_identity().clone(), "child"),
+                    message: "racing close".into(),
+                },
+            )
+            .await
+    });
+    fixture.relationships.wait_for_child_read().await;
+    fixture.relationships.close("child");
+    drop(target_workspace_lock);
+    assert!(matches!(
+        recheck.await.unwrap(),
+        Err(AgentOperationsError::SubagentOpenRequired)
+    ));
+    assert_eq!(
+        fixture.messages.calls.lock().unwrap().len(),
+        1,
+        "the racing Closed target must not reach the queue owner"
+    );
+}
+
+#[tokio::test]
+async fn send_message_contended_prompt_admission_preserves_single_writer_order() {
+    let fixture = fixture(false, false);
+    fixture.messages.hold.store(true, Ordering::SeqCst);
+    let first_operations = fixture.operations.clone();
+    let first = tokio::spawn(async move {
+        first_operations
+            .send_message(
+                &first_operations.authenticated_caller("parent"),
+                SendMessageInput {
+                    target: AgentIdentity::new(first_operations.runtime_identity().clone(), "peer"),
+                    message: "first".into(),
+                },
+            )
+            .await
+    });
+    fixture.messages.entered.notified().await;
+
+    let second_operations = fixture.operations.clone();
+    let second = tokio::spawn(async move {
+        second_operations
+            .send_message(
+                &second_operations.authenticated_caller("parent"),
+                SendMessageInput {
+                    target: AgentIdentity::new(
+                        second_operations.runtime_identity().clone(),
+                        "peer",
+                    ),
+                    message: "second".into(),
+                },
+            )
+            .await
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(fixture.messages.calls.lock().unwrap().len(), 1);
+
+    fixture.messages.hold.store(false, Ordering::SeqCst);
+    fixture.messages.release.notify_one();
+    let first_receipt = first.await.unwrap().unwrap();
+    let second_receipt = second.await.unwrap().unwrap();
+    assert_eq!((first_receipt.queue_seq, second_receipt.queue_seq), (1, 2));
+    assert_eq!(fixture.messages.max_active.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        fixture
+            .messages
+            .calls
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|call| call.message.as_str())
+            .collect::<Vec<_>>(),
+        vec!["first", "second"]
+    );
+}
+
+fn session(id: &str, workspace_id: &str, status: &str, title: Option<&str>) -> SessionRecord {
+    SessionRecord {
+        id: id.into(),
+        workspace_id: workspace_id.into(),
+        agent_kind: "codex".into(),
+        native_session_id: Some(format!("native-{id}")),
+        agent_auth_contexts: None,
+        requested_model_id: None,
+        current_model_id: None,
+        requested_mode_id: None,
+        current_mode_id: None,
+        title: title.map(str::to_string),
+        thinking_level_id: None,
+        thinking_budget_tokens: None,
+        status: status.into(),
+        created_at: "2026-08-11T00:00:00Z".into(),
+        updated_at: "2026-08-11T00:00:00Z".into(),
+        last_prompt_at: None,
+        closed_at: None,
+        dismissed_at: None,
+        mcp_bindings_ciphertext: None,
+        mcp_binding_summaries_json: None,
+        mcp_binding_policy: SessionMcpBindingPolicy::InheritWorkspace,
+        system_prompt_append: None,
+        subagents_enabled: true,
+        action_capabilities_json: None,
+        origin: None,
+    }
+}
+
+fn link(parent: &str, child: &str, closed: bool) -> SessionLinkRecord {
+    SessionLinkRecord {
+        id: "link-child".into(),
+        public_id: Some("subagent-child".into()),
+        relation: SessionLinkRelation::Subagent,
+        parent_session_id: parent.into(),
+        child_session_id: child.into(),
+        workspace_relation: SessionLinkWorkspaceRelation::SameWorkspace,
+        label: Some("Child".into()),
+        created_by_turn_id: None,
+        created_by_tool_call_id: None,
+        created_at: "2026-08-11T00:00:00Z".into(),
+        closed_at: closed.then(|| "2026-08-11T00:30:00Z".into()),
+    }
+}
+
+fn workspace(id: &str) -> WorkspaceRecord {
+    let path = format!("/tmp/{id}");
+    let mut workspace = test_workspace_record(WorkspaceKind::Local, &path);
+    workspace.id = id.into();
+    workspace
+}
+
+fn caller(fixture: &Fixture, session_id: &str) -> AuthenticatedAgentCaller {
+    fixture.operations.authenticated_caller(session_id)
+}
+
+fn input(fixture: &Fixture, target: &str, message: &str) -> SendMessageInput {
+    SendMessageInput {
+        target: AgentIdentity::new(fixture.operations.runtime_identity().clone(), target),
+        message: message.into(),
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/mod.rs
@@ -1,11 +1,14 @@
 mod authorization_policy;
 mod catalogs;
 mod error;
+mod messaging;
 mod ordinary;
 mod ports;
 mod target_access;
 mod workspaces;
 
+#[cfg(test)]
+mod messaging_tests;
 #[cfg(test)]
 mod ordinary_tests;
 #[cfg(test)]
@@ -15,6 +18,7 @@ use std::sync::Arc;
 
 use authorization_policy::{CallerFacts, TargetFacts};
 pub use error::AgentOperationsError;
+pub(crate) use ports::AgentMessageQueue;
 pub use ports::{
     AgentCatalogReads, AgentConfigMutationState, AgentExecutionReads, AgentLaunchOptionReads,
     AgentSessionMutations, AgentSessionReads, AgentTaskOutputReads, AgentWorkspaceOperations,
@@ -43,6 +47,7 @@ pub struct AgentOperations {
     launch_options: Option<Arc<dyn AgentLaunchOptionReads>>,
     catalog: Option<Arc<dyn AgentCatalogReads>>,
     mutations: Option<Arc<dyn AgentSessionMutations>>,
+    message_queue: Option<Arc<dyn AgentMessageQueue>>,
     task_output: Option<Arc<dyn AgentTaskOutputReads>>,
     session_admission: Option<Arc<SessionMutationAdmission>>,
     workspace_operation_gate: Option<Arc<WorkspaceOperationGate>>,
@@ -64,6 +69,7 @@ impl AgentOperations {
             launch_options: None,
             catalog: None,
             mutations: None,
+            message_queue: None,
             task_output: None,
             session_admission: None,
             workspace_operation_gate: None,
@@ -91,6 +97,20 @@ impl AgentOperations {
     ) -> Self {
         self.mutations = Some(mutations);
         self.task_output = Some(task_output);
+        self.session_admission = Some(session_admission);
+        self.workspace_operation_gate = Some(workspace_operation_gate);
+        self
+    }
+
+    pub(crate) fn with_messaging(
+        mut self,
+        message_queue: Arc<dyn AgentMessageQueue>,
+        workspaces: Arc<dyn AgentWorkspaceOperations>,
+        session_admission: Arc<SessionMutationAdmission>,
+        workspace_operation_gate: Arc<WorkspaceOperationGate>,
+    ) -> Self {
+        self.message_queue = Some(message_queue);
+        self.workspaces = Some(workspaces);
         self.session_admission = Some(session_admission);
         self.workspace_operation_gate = Some(workspace_operation_gate);
         self

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/ordinary.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/ordinary.rs
@@ -222,7 +222,7 @@ impl AgentOperations {
         }
     }
 
-    async fn admit_target(
+    pub(super) async fn admit_target(
         &self,
         session_id: &str,
         kind: SessionMutationKind,
@@ -239,7 +239,7 @@ impl AgentOperations {
             })
     }
 
-    async fn assert_target_workspace_under_lease(
+    pub(super) async fn assert_target_workspace_under_lease(
         &self,
         target: &ResolvedAgent,
         expected_workspace_id: &str,
@@ -301,7 +301,7 @@ impl AgentOperations {
             .ok_or(AgentOperationsError::OrdinaryOperationsUnavailable)
     }
 
-    fn operation_gate(
+    pub(super) fn operation_gate(
         &self,
     ) -> Result<
         &Arc<crate::domains::workspaces::operation_gate::WorkspaceOperationGate>,

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/ports.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/ports.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use crate::domains::agents::catalog::service::ActiveCatalog;
@@ -179,8 +181,11 @@ impl AgentSessionMutations for SessionRuntime {
 
 #[async_trait]
 pub(crate) trait AgentMessageQueue: Send + Sync {
+    // `Arc<Self>` receiver: `enqueue_agent_message` durably commits the pending
+    // row, then detaches consumer activation onto a spawned task, so it needs a
+    // shared-owned handle that outlives the call.
     async fn enqueue_agent_message(
-        &self,
+        self: Arc<Self>,
         target_session_id: &str,
         message: String,
         source: AgentSessionPromptSource,
@@ -190,7 +195,7 @@ pub(crate) trait AgentMessageQueue: Send + Sync {
 #[async_trait]
 impl AgentMessageQueue for SessionRuntime {
     async fn enqueue_agent_message(
-        &self,
+        self: Arc<Self>,
         target_session_id: &str,
         message: String,
         source: AgentSessionPromptSource,

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/ports.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/runtime/ports.rs
@@ -8,6 +8,7 @@ use crate::domains::sessions::live_config::{
     effective_live_config_snapshot, EffectiveLiveConfigSnapshot,
 };
 use crate::domains::sessions::model::{SessionExecutionState, SessionRecord};
+use crate::domains::sessions::prompt::provenance::AgentSessionPromptSource;
 use crate::domains::sessions::runtime::{
     CreateOrdinaryAgentSessionError, EnsureLiveSessionError, SessionLifecycleError, SessionRuntime,
     SetSessionConfigOptionError,
@@ -173,6 +174,28 @@ impl AgentSessionMutations for SessionRuntime {
         session_id: &str,
     ) -> Result<SessionRecord, SessionLifecycleError> {
         self.cancel_live_session(session_id).await
+    }
+}
+
+#[async_trait]
+pub(crate) trait AgentMessageQueue: Send + Sync {
+    async fn enqueue_agent_message(
+        &self,
+        target_session_id: &str,
+        message: String,
+        source: AgentSessionPromptSource,
+    ) -> Result<i64, crate::domains::sessions::runtime::SendPromptError>;
+}
+
+#[async_trait]
+impl AgentMessageQueue for SessionRuntime {
+    async fn enqueue_agent_message(
+        &self,
+        target_session_id: &str,
+        message: String,
+        source: AgentSessionPromptSource,
+    ) -> Result<i64, crate::domains::sessions::runtime::SendPromptError> {
+        SessionRuntime::enqueue_agent_message(self, target_session_id, message, source).await
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/prompt/provenance.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/prompt/provenance.rs
@@ -1,6 +1,23 @@
 use anyharness_contract::v1::PromptProvenance as PublicPromptProvenance;
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AgentSessionPromptSource {
+    pub source_session_id: String,
+    pub session_link_id: Option<String>,
+    pub label: String,
+}
+
+impl AgentSessionPromptSource {
+    pub(crate) fn into_provenance(self) -> PromptProvenance {
+        PromptProvenance::AgentSession {
+            source_session_id: self.source_session_id,
+            session_link_id: self.session_link_id,
+            label: Some(self.label),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub(crate) enum PromptProvenance {

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/prompt/render.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/prompt/render.rs
@@ -9,6 +9,7 @@
 use agent_client_protocol as acp;
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
 
+use super::provenance::PromptProvenance;
 use super::{PromptPayload, PromptValidationError, ResolvedParts, StoredPromptBlock};
 use crate::domains::sessions::plan_references::render_plan_reference_markdown;
 
@@ -30,7 +31,12 @@ pub fn render(
     parts: &ResolvedParts,
     extras: &TurnPromptExtras,
 ) -> Result<Vec<acp::schema::ContentBlock>, RenderError> {
-    let mut blocks = Vec::with_capacity(payload.blocks.len());
+    let mut blocks = Vec::with_capacity(payload.blocks.len() + 1);
+    if let Some(context) = agent_message_context(payload) {
+        blocks.push(acp::schema::ContentBlock::Text(
+            acp::schema::TextContent::new(context),
+        ));
+    }
     for block in &payload.blocks {
         match block {
             StoredPromptBlock::Text { text } => {
@@ -142,6 +148,22 @@ pub fn render(
     Ok(blocks)
 }
 
+fn agent_message_context(payload: &PromptPayload) -> Option<String> {
+    let PromptProvenance::AgentSession {
+        source_session_id,
+        label,
+        ..
+    } = payload.provenance.as_ref()?
+    else {
+        return None;
+    };
+    let label = serde_json::Value::String(label.as_deref().unwrap_or("Agent").to_string());
+    let session_id = serde_json::Value::String(source_session_id.clone());
+    Some(format!(
+        "Message context: This message came from another agent. Sender label: {label}. Sender session ID: {session_id}."
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -212,6 +234,43 @@ mod tests {
             panic!("expected one text block");
         };
         assert_eq!(text.text, "hello");
+    }
+
+    #[test]
+    fn send_message_prompt_provenance_renders_replay_stable_sender_context() {
+        let payload = PromptPayload::text("check the failing test".to_string()).with_provenance(
+            PromptProvenance::AgentSession {
+                source_session_id: "session-1".to_string(),
+                session_link_id: None,
+                label: Some("Build Agent".to_string()),
+            },
+        );
+        let provenance_json = payload
+            .provenance_json()
+            .expect("serialize provenance")
+            .expect("agent provenance");
+        let replayed =
+            PromptPayload::from_persisted(None, "check the failing test", Some(&provenance_json));
+
+        for candidate in [&payload, &replayed] {
+            let blocks = render(
+                candidate,
+                &ResolvedParts::default(),
+                &TurnPromptExtras::default(),
+            )
+            .expect("render agent message");
+            let [acp::schema::ContentBlock::Text(context), acp::schema::ContentBlock::Text(message)] =
+                blocks.as_slice()
+            else {
+                panic!("expected sender context followed by message text");
+            };
+            assert_eq!(
+                context.text,
+                "Message context: This message came from another agent. Sender label: \"Build Agent\". Sender session ID: \"session-1\"."
+            );
+            assert_eq!(message.text, "check the failing test");
+        }
+        assert_eq!(payload.content_parts().len(), 1);
     }
 
     #[test]

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/prompt/render.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/prompt/render.rs
@@ -160,7 +160,7 @@ fn agent_message_context(payload: &PromptPayload) -> Option<String> {
     let label = serde_json::Value::String(label.as_deref().unwrap_or("Agent").to_string());
     let session_id = serde_json::Value::String(source_session_id.clone());
     Some(format!(
-        "Message context: This message came from another agent. Sender label: {label}. Sender session ID: {session_id}."
+        "Message context: This message came from another agent. Sender label: {label}. Sender session ID: {session_id}. To reply, use send_message with agentId {session_id}."
     ))
 }
 
@@ -266,7 +266,7 @@ mod tests {
             };
             assert_eq!(
                 context.text,
-                "Message context: This message came from another agent. Sender label: \"Build Agent\". Sender session ID: \"session-1\"."
+                "Message context: This message came from another agent. Sender label: \"Build Agent\". Sender session ID: \"session-1\". To reply, use send_message with agentId \"session-1\"."
             );
             assert_eq!(message.text, "check the failing test");
         }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs
@@ -40,6 +40,8 @@ mod prompt;
 #[cfg(test)]
 mod prompt_message_actor_tests;
 #[cfg(test)]
+mod prompt_message_cold_start_tests;
+#[cfg(test)]
 mod prompt_message_tests;
 mod replay;
 mod startup;

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs
@@ -37,6 +37,8 @@ mod launch_policy;
 mod lifecycle;
 mod pending_prompts;
 mod prompt;
+#[cfg(test)]
+mod prompt_message_tests;
 mod replay;
 mod startup;
 #[cfg(test)]

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs
@@ -38,6 +38,8 @@ mod lifecycle;
 mod pending_prompts;
 mod prompt;
 #[cfg(test)]
+mod prompt_message_actor_tests;
+#[cfg(test)]
 mod prompt_message_tests;
 mod replay;
 mod startup;

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use anyharness_contract::v1::PromptInputBlock;
 
@@ -15,10 +15,9 @@ use super::{
 };
 
 impl SessionRuntime {
-    /// Persist-first cross-agent delivery. The live actor is ready before the
-    /// durable row commits; after commit, the actor command is only a wake
-    /// signal. Losing that signal or its acknowledgement cannot turn an
-    /// accepted durable message into a reported failure because startup queue
+    /// Persist-first cross-agent delivery. The pending-row sequence is the
+    /// acceptance linearization point. Actor startup and the bounded queue wake
+    /// happen only after that commit and are best-effort because startup queue
     /// replay owns eventual processing.
     pub(crate) async fn enqueue_agent_message(
         &self,
@@ -35,10 +34,9 @@ impl SessionRuntime {
         let record = self
             .get_session_or_not_found(session_id)
             .map_err(map_lifecycle_error_to_prompt)?;
-        let handle = self
-            .ensure_live_session_handle(&record, None)
-            .await
-            .map_err(map_start_error_to_prompt)?;
+        if super::launch_policy::session_is_closed(&record) {
+            return Err(SendPromptError::SessionClosed);
+        }
         let payload = crate::domains::sessions::prompt::PromptPayload::text(message)
             .with_provenance(source.into_provenance());
         let pending = self
@@ -47,16 +45,65 @@ impl SessionRuntime {
             .insert_pending_prompt_payload(session_id, &payload, None)
             .map_err(SendPromptError::Internal)?;
 
-        if let Err(error) = handle.send_queued_prompt(payload, pending.seq).await {
-            tracing::warn!(
-                session_id = %session_id,
-                queue_seq = pending.seq,
-                error = ?error,
-                "durable agent message wake signal was lost; pending prompt will replay"
-            );
-        }
+        self.activate_agent_message_consumer(session_id, payload, pending.seq)
+            .await;
 
         Ok(pending.seq)
+    }
+
+    async fn activate_agent_message_consumer(
+        &self,
+        session_id: &str,
+        payload: crate::domains::sessions::prompt::PromptPayload,
+        queue_seq: i64,
+    ) {
+        const WAKE_ACK_TIMEOUT: Duration = Duration::from_secs(1);
+
+        let record = match self.get_session_or_not_found(session_id) {
+            Ok(record) => record,
+            Err(error) => {
+                tracing::warn!(
+                    session_id = %session_id,
+                    queue_seq,
+                    error = ?error,
+                    "durable agent message consumer activation skipped; pending prompt will replay"
+                );
+                return;
+            }
+        };
+        let handle = match self.ensure_live_session_handle(&record, None).await {
+            Ok(handle) => handle,
+            Err(error) => {
+                tracing::warn!(
+                    session_id = %session_id,
+                    queue_seq,
+                    error = ?error,
+                    "durable agent message consumer startup failed; pending prompt will replay"
+                );
+                return;
+            }
+        };
+
+        match tokio::time::timeout(
+            WAKE_ACK_TIMEOUT,
+            handle.send_queued_prompt(payload, queue_seq),
+        )
+        .await
+        {
+            Ok(Ok(_)) => {}
+            Ok(Err(error)) => tracing::warn!(
+                session_id = %session_id,
+                queue_seq,
+                error = ?error,
+                "durable agent message wake acknowledgement was lost; pending prompt will replay"
+            ),
+            Err(_) => tracing::warn!(
+                session_id = %session_id,
+                queue_seq,
+                timeout_ms = WAKE_ACK_TIMEOUT.as_millis(),
+                "durable agent message wake acknowledgement timed out; pending prompt will replay"
+            ),
+        }
     }
 
     #[tracing::instrument(skip_all, fields(session_id = %session_id))]

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyharness_contract::v1::PromptInputBlock;
@@ -17,10 +18,10 @@ use super::{
 impl SessionRuntime {
     /// Persist-first cross-agent delivery. The pending-row sequence is the
     /// acceptance linearization point. Actor startup and the bounded queue wake
-    /// happen only after that commit and are best-effort because startup queue
-    /// replay owns eventual processing.
+    /// are detached after that commit (see below) and are best-effort because
+    /// startup queue replay owns eventual processing.
     pub(crate) async fn enqueue_agent_message(
-        &self,
+        self: Arc<Self>,
         session_id: &str,
         message: String,
         source: AgentSessionPromptSource,
@@ -45,10 +46,28 @@ impl SessionRuntime {
             .insert_pending_prompt_payload(session_id, &payload, None)
             .map_err(SendPromptError::Internal)?;
 
-        self.activate_agent_message_consumer(session_id, payload, pending.seq)
-            .await;
+        // Detach activation after the durable commit. The pending row above is
+        // the acceptance linearization point and startup queue replay owns
+        // eventual processing, so activation is strictly best-effort. Awaiting
+        // it inline would block the caller (an MCP `send_message` tool call)
+        // for up to the shared startup-readiness timeout (60s in prod) while a
+        // cold target boots, even though the receipt is already durable.
+        //
+        // Lease invariant: the spawned task runs WITHOUT the caller's
+        // target-workspace shared `SessionPrompt` lease (that lease is dropped
+        // when `send_message` returns, right after this fn). This is deliberate
+        // and mirrors the startup-replay path, which activates consumers
+        // without holding any caller lease: the pending row is already durable,
+        // so no lease is required to guarantee eventual delivery, and
+        // re-acquiring one here would reintroduce the block this detach removes.
+        let queue_seq = pending.seq;
+        let session_id = session_id.to_string();
+        tokio::spawn(async move {
+            self.activate_agent_message_consumer(&session_id, payload, queue_seq)
+                .await;
+        });
 
-        Ok(pending.seq)
+        Ok(queue_seq)
     }
 
     async fn activate_agent_message_consumer(

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt.rs
@@ -6,7 +6,7 @@ use crate::domains::sessions::mcp_bindings::assembly::SESSION_RESTART_REQUIRED_D
 use crate::domains::sessions::model::PromptAttachmentState;
 use crate::domains::sessions::prompt::capabilities::capabilities_from_live_config;
 use crate::domains::sessions::prompt::prepare::prepare_prompt;
-use crate::domains::sessions::prompt::provenance::PromptProvenance;
+use crate::domains::sessions::prompt::provenance::{AgentSessionPromptSource, PromptProvenance};
 use crate::domains::sessions::prompt::PromptPrepareContext;
 use crate::live::sessions::{LiveSessionCommandError, PromptAcceptError, PromptAcceptance};
 
@@ -15,6 +15,50 @@ use super::{
 };
 
 impl SessionRuntime {
+    /// Persist-first cross-agent delivery. The live actor is ready before the
+    /// durable row commits; after commit, the actor command is only a wake
+    /// signal. Losing that signal or its acknowledgement cannot turn an
+    /// accepted durable message into a reported failure because startup queue
+    /// replay owns eventual processing.
+    pub(crate) async fn enqueue_agent_message(
+        &self,
+        session_id: &str,
+        message: String,
+        source: AgentSessionPromptSource,
+    ) -> Result<i64, SendPromptError> {
+        self.access_gate
+            .assert_can_mutate_for_session(session_id)
+            .map_err(|error| SendPromptError::Internal(anyhow::anyhow!(error.to_string())))?;
+        if message.trim().is_empty() {
+            return Err(SendPromptError::EmptyPrompt);
+        }
+        let record = self
+            .get_session_or_not_found(session_id)
+            .map_err(map_lifecycle_error_to_prompt)?;
+        let handle = self
+            .ensure_live_session_handle(&record, None)
+            .await
+            .map_err(map_start_error_to_prompt)?;
+        let payload = crate::domains::sessions::prompt::PromptPayload::text(message)
+            .with_provenance(source.into_provenance());
+        let pending = self
+            .session_service
+            .store()
+            .insert_pending_prompt_payload(session_id, &payload, None)
+            .map_err(SendPromptError::Internal)?;
+
+        if let Err(error) = handle.send_queued_prompt(payload, pending.seq).await {
+            tracing::warn!(
+                session_id = %session_id,
+                queue_seq = pending.seq,
+                error = ?error,
+                "durable agent message wake signal was lost; pending prompt will replay"
+            );
+        }
+
+        Ok(pending.seq)
+    }
+
     #[tracing::instrument(skip_all, fields(session_id = %session_id))]
     pub async fn send_prompt(
         &self,

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt.rs
@@ -77,7 +77,7 @@ impl SessionRuntime {
                 tracing::warn!(
                     session_id = %session_id,
                     queue_seq,
-                    error = ?error,
+                    failure_code = agent_message_start_failure_code(&error),
                     "durable agent message consumer startup failed; pending prompt will replay"
                 );
                 return;
@@ -395,6 +395,21 @@ fn map_lifecycle_error_to_prompt(error: SessionLifecycleError) -> SendPromptErro
     }
 }
 
+fn agent_message_start_failure_code(error: &StartSessionError) -> &'static str {
+    match error {
+        StartSessionError::WorkspaceNotFound => "workspace_not_found",
+        StartSessionError::WorkspaceDirectoryMissing { .. } => "workspace_directory_missing",
+        StartSessionError::AgentDescriptorNotFound(_) => "agent_descriptor_not_found",
+        StartSessionError::Closed => "session_closed",
+        StartSessionError::MissingDataKey => "missing_data_key",
+        StartSessionError::RestartRequired(_) => "restart_required",
+        StartSessionError::RouteAuth(_) => "route_auth",
+        StartSessionError::AgentNotReady { .. } => "agent_not_ready",
+        StartSessionError::Internal(_) => "internal",
+        StartSessionError::AcpStart(_) => "acp_start",
+    }
+}
+
 fn map_start_error_to_prompt(error: StartSessionError) -> SendPromptError {
     match error {
         StartSessionError::WorkspaceNotFound => {
@@ -449,6 +464,39 @@ fn map_start_error_to_prompt(error: StartSessionError) -> SendPromptError {
 #[cfg(test)]
 mod dispatch_classification_tests {
     use super::*;
+    use crate::domains::agents::model::ResolvedAgentStatus;
+
+    #[test]
+    fn send_message_start_failure_codes_do_not_expose_details() {
+        let cases = [
+            (
+                StartSessionError::WorkspaceDirectoryMissing {
+                    path: "/secret/workspace".into(),
+                },
+                "workspace_directory_missing",
+            ),
+            (
+                StartSessionError::AgentNotReady {
+                    agent_kind: "secret-agent".into(),
+                    status: ResolvedAgentStatus::Error,
+                    detail: Some("secret readiness detail".into()),
+                },
+                "agent_not_ready",
+            ),
+            (
+                StartSessionError::Internal(anyhow::anyhow!("secret")),
+                "internal",
+            ),
+            (
+                StartSessionError::AcpStart(anyhow::anyhow!("secret")),
+                "acp_start",
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(agent_message_start_failure_code(&error), expected);
+        }
+    }
 
     #[test]
     fn response_dropped_is_a_lost_acknowledgement() {

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt_message_actor_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt_message_actor_tests.rs
@@ -14,7 +14,7 @@ use crate::domains::sessions::prompt::PromptPayload;
 use crate::domains::sessions::task_output::{TaskOutputRole, TaskOutputSender};
 use crate::persistence::Db;
 
-struct EnvVarGuard {
+pub(super) struct EnvVarGuard {
     name: &'static str,
     previous: Option<std::ffi::OsString>,
 }
@@ -36,9 +36,9 @@ impl Drop for EnvVarGuard {
     }
 }
 
-struct ScriptedAgent {
+pub(super) struct ScriptedAgent {
     program: PathBuf,
-    request_log: PathBuf,
+    pub(super) request_log: PathBuf,
     control_dir: PathBuf,
 }
 
@@ -260,7 +260,7 @@ async fn send_message_cold_runtime_reconstruction_replays_two_rows_once_in_order
     std::fs::remove_dir_all(&runtime_home).expect("remove runtime home");
 }
 
-async fn send_message(
+pub(super) async fn send_message(
     state: &AppState,
     message: &str,
 ) -> Result<SendMessageReceipt, crate::domains::agent_operations::runtime::AgentOperationsError> {
@@ -291,7 +291,7 @@ async fn send_direct_prompt(state: &AppState, text: &str) {
         .expect("direct prompt");
 }
 
-fn build_state(runtime_home: &Path, db: Db, seed: bool) -> AppState {
+pub(super) fn build_state(runtime_home: &Path, db: Db, seed: bool) -> AppState {
     let workspace_a = runtime_home.join("workspace-a");
     let workspace_b = runtime_home.join("workspace-b");
     std::fs::create_dir_all(&workspace_a).expect("workspace A");
@@ -336,7 +336,7 @@ fn build_state(runtime_home: &Path, db: Db, seed: bool) -> AppState {
     state
 }
 
-fn assert_agent_output(state: &AppState, expected_texts: &[&str]) {
+pub(super) fn assert_agent_output(state: &AppState, expected_texts: &[&str]) {
     let output = state
         .session_service
         .get_task_output("target", None, 50)
@@ -371,14 +371,14 @@ fn assert_agent_output(state: &AppState, expected_texts: &[&str]) {
         .is_empty());
 }
 
-fn temp_runtime_home(label: &str) -> PathBuf {
+pub(super) fn temp_runtime_home(label: &str) -> PathBuf {
     PathBuf::from(format!(
         "/tmp/anyharness-agent-message-{label}-{}",
         uuid::Uuid::new_v4()
     ))
 }
 
-fn install_scripted_agent_env(script: &ScriptedAgent) -> (EnvVarGuard, EnvVarGuard) {
+pub(super) fn install_scripted_agent_env(script: &ScriptedAgent) -> (EnvVarGuard, EnvVarGuard) {
     let program = EnvVarGuard::set("ANYHARNESS_CLAUDE_AGENT_PROGRAM", &script.program);
     let args = serde_json::to_string(&vec![
         script.request_log.to_string_lossy().to_string(),
@@ -389,7 +389,7 @@ fn install_scripted_agent_env(script: &ScriptedAgent) -> (EnvVarGuard, EnvVarGua
     (program, args)
 }
 
-fn write_scripted_agent(runtime_home: &Path) -> ScriptedAgent {
+pub(super) fn write_scripted_agent(runtime_home: &Path) -> ScriptedAgent {
     std::fs::create_dir_all(runtime_home.join("secrets")).expect("secrets directory");
     std::fs::write(
         runtime_home.join("secrets/global.env"),
@@ -496,7 +496,7 @@ for raw_line in sys.stdin:
     }
 }
 
-fn read_requests(path: &Path) -> Vec<Value> {
+pub(super) fn read_requests(path: &Path) -> Vec<Value> {
     let Ok(contents) = std::fs::read_to_string(path) else {
         return Vec::new();
     };
@@ -507,7 +507,7 @@ fn read_requests(path: &Path) -> Vec<Value> {
         .collect()
 }
 
-fn prompt_texts(path: &Path) -> Vec<String> {
+pub(super) fn prompt_texts(path: &Path) -> Vec<String> {
     read_requests(path)
         .into_iter()
         .filter(|request| request["method"] == "session/prompt")
@@ -521,14 +521,14 @@ fn prompt_texts(path: &Path) -> Vec<String> {
         .collect()
 }
 
-async fn wait_for_prompt_count(path: &Path, expected: usize) {
+pub(super) async fn wait_for_prompt_count(path: &Path, expected: usize) {
     wait_for("scripted prompt count", || {
         prompt_texts(path).len() >= expected
     })
     .await;
 }
 
-async fn wait_for_queue_len(state: &AppState, expected: usize) {
+pub(super) async fn wait_for_queue_len(state: &AppState, expected: usize) {
     wait_for("pending queue length", || {
         state
             .session_service
@@ -556,7 +556,7 @@ async fn wait_for(description: &str, mut condition: impl FnMut() -> bool) {
     .unwrap_or_else(|_| panic!("timed out waiting for {description}"));
 }
 
-async fn wait_for_actor_idle(state: &AppState) {
+pub(super) async fn wait_for_actor_idle(state: &AppState) {
     tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             if state
@@ -587,7 +587,7 @@ async fn wait_for_actor_gone(state: &AppState) {
     .expect("target actor exit");
 }
 
-async fn stop_target_actor(state: &AppState) {
+pub(super) async fn stop_target_actor(state: &AppState) {
     if let Some(handle) = state.acp_manager.get_handle("target").await {
         tokio::time::timeout(Duration::from_secs(2), handle.close())
             .await

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt_message_actor_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt_message_actor_tests.rs
@@ -1,0 +1,598 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyharness_contract::v1::PromptInputBlock;
+use serde_json::Value;
+
+use super::prompt_message_tests::session;
+use crate::app::{test_support, AppState};
+use crate::domains::agent_operations::model::{
+    AgentIdentity, SendMessageInput, SendMessageReceipt,
+};
+use crate::domains::agents::installer::seed::AgentSeedStore;
+use crate::domains::sessions::prompt::PromptPayload;
+use crate::domains::sessions::task_output::{TaskOutputRole, TaskOutputSender};
+use crate::persistence::Db;
+
+struct EnvVarGuard {
+    name: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvVarGuard {
+    fn set(name: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let previous = std::env::var_os(name);
+        std::env::set_var(name, value);
+        Self { name, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match self.previous.take() {
+            Some(value) => std::env::set_var(self.name, value),
+            None => std::env::remove_var(self.name),
+        }
+    }
+}
+
+struct ScriptedAgent {
+    program: PathBuf,
+    request_log: PathBuf,
+    control_dir: PathBuf,
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn send_message_real_actor_executes_idle_running_fifo_and_ignores_a_stale_wake() {
+    let _env_lock = test_support::lock_env();
+    let _bearer = test_support::set_bearer_token_env(None);
+    let _data_key = test_support::set_data_key_env(None);
+    let runtime_home = temp_runtime_home("actor-fifo");
+    let script = write_scripted_agent(&runtime_home);
+    let (_program, _args) = install_scripted_agent_env(&script);
+    let state = build_state(
+        &runtime_home,
+        Db::open_in_memory().expect("in-memory db"),
+        true,
+    );
+
+    let resumed = state
+        .session_runtime
+        .ensure_live_session("target", None)
+        .await
+        .expect("start real target actor");
+    assert_eq!(resumed.native_session_id.as_deref(), Some("native-target"));
+
+    let idle = send_message(&state, "idle agent message")
+        .await
+        .expect("idle send");
+    wait_for_prompt_count(&script.request_log, 1).await;
+    wait_for_queue_len(&state, 0).await;
+    wait_for_actor_idle(&state).await;
+    assert_eq!(prompt_texts(&script.request_log), ["idle agent message"]);
+
+    let handle = state
+        .acp_manager
+        .get_ready_handle("target")
+        .await
+        .expect("ready target handle");
+    handle
+        .send_queued_prompt(
+            PromptPayload::text("stale copied payload".into()),
+            idle.queue_seq,
+        )
+        .await
+        .expect("stale marker acknowledgement");
+    send_direct_prompt(&state, "stale wake fence").await;
+    wait_for_prompt_count(&script.request_log, 2).await;
+    wait_for_actor_idle(&state).await;
+    assert_eq!(
+        prompt_texts(&script.request_log),
+        ["idle agent message", "stale wake fence"]
+    );
+
+    send_direct_prompt(&state, "blocking turn").await;
+    wait_for_path(&script.control_dir.join("turn-seen")).await;
+    let first = send_message(&state, "running message one")
+        .await
+        .expect("first running send");
+    let second = send_message(&state, "running message two")
+        .await
+        .expect("second running send");
+    assert!(first.queue_seq < second.queue_seq);
+    let pending = state
+        .session_service
+        .store()
+        .list_pending_prompts("target")
+        .expect("running queue");
+    assert_eq!(
+        pending
+            .iter()
+            .map(|row| row.text.as_str())
+            .collect::<Vec<_>>(),
+        ["running message one", "running message two"]
+    );
+    assert_eq!(prompt_texts(&script.request_log).len(), 3);
+
+    std::fs::write(script.control_dir.join("release-turn"), b"").expect("release held turn");
+    wait_for_prompt_count(&script.request_log, 5).await;
+    wait_for_queue_len(&state, 0).await;
+    wait_for_actor_idle(&state).await;
+    assert_eq!(
+        prompt_texts(&script.request_log),
+        [
+            "idle agent message",
+            "stale wake fence",
+            "blocking turn",
+            "running message one",
+            "running message two",
+        ]
+    );
+    assert_agent_output(
+        &state,
+        &[
+            "idle agent message",
+            "running message one",
+            "running message two",
+        ],
+    );
+
+    stop_target_actor(&state).await;
+    drop(state);
+    std::fs::remove_dir_all(&runtime_home).expect("remove runtime home");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn send_message_cold_runtime_reconstruction_replays_two_rows_once_in_order() {
+    let _env_lock = test_support::lock_env();
+    let _bearer = test_support::set_bearer_token_env(None);
+    let _data_key = test_support::set_data_key_env(None);
+    let runtime_home = temp_runtime_home("actor-restart");
+    let script = write_scripted_agent(&runtime_home);
+    let (_program, _args) = install_scripted_agent_env(&script);
+
+    let state_a = build_state(
+        &runtime_home,
+        Db::open(&runtime_home).expect("file-backed db"),
+        true,
+    );
+    state_a
+        .session_runtime
+        .ensure_live_session("target", None)
+        .await
+        .expect("start first runtime actor");
+    send_direct_prompt(&state_a, "restart boundary turn").await;
+    wait_for_path(&script.control_dir.join("turn-seen")).await;
+
+    let first = send_message(&state_a, "restart message one")
+        .await
+        .expect("first committed row");
+    let second = send_message(&state_a, "restart message two")
+        .await
+        .expect("second committed row");
+    assert!(first.queue_seq < second.queue_seq);
+    let before_restart = state_a
+        .session_service
+        .store()
+        .list_pending_prompts("target")
+        .expect("rows before restart");
+    assert_eq!(
+        before_restart.iter().map(|row| row.seq).collect::<Vec<_>>(),
+        [first.queue_seq, second.queue_seq]
+    );
+
+    let handle = state_a
+        .acp_manager
+        .get_ready_handle("target")
+        .await
+        .expect("first runtime actor");
+    handle.dismiss().await.expect("detach first runtime actor");
+    std::fs::write(script.control_dir.join("release-turn"), b"")
+        .expect("finish restart-boundary turn");
+    wait_for_actor_gone(&state_a).await;
+    assert_eq!(
+        state_a
+            .session_service
+            .store()
+            .list_pending_prompts("target")
+            .unwrap()
+            .len(),
+        2
+    );
+    drop(state_a);
+    std::fs::remove_file(script.control_dir.join("turn-seen")).expect("clear turn marker");
+
+    let state_b = build_state(
+        &runtime_home,
+        Db::open(&runtime_home).expect("reopen durable db"),
+        false,
+    );
+    let resumed = state_b
+        .session_runtime
+        .ensure_live_session("target", None)
+        .await
+        .expect("reconstruct runtime and actor");
+    assert_eq!(resumed.native_session_id.as_deref(), Some("native-target"));
+    wait_for_prompt_count(&script.request_log, 3).await;
+    wait_for_queue_len(&state_b, 0).await;
+    wait_for_actor_idle(&state_b).await;
+
+    let requests = read_requests(&script.request_log);
+    let loads = requests
+        .iter()
+        .filter(|request| request["method"] == "session/load")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        loads.len(),
+        2,
+        "both runtime actors must load the same native session"
+    );
+    assert!(loads
+        .iter()
+        .all(|request| request["params"]["sessionId"] == "native-target"));
+    let texts = prompt_texts(&script.request_log);
+    assert_eq!(
+        texts,
+        [
+            "restart boundary turn",
+            "restart message one",
+            "restart message two"
+        ]
+    );
+    assert_eq!(
+        texts
+            .iter()
+            .filter(|text| *text == "restart message one")
+            .count(),
+        1
+    );
+    assert_eq!(
+        texts
+            .iter()
+            .filter(|text| *text == "restart message two")
+            .count(),
+        1
+    );
+    assert_agent_output(&state_b, &["restart message one", "restart message two"]);
+
+    stop_target_actor(&state_b).await;
+    drop(state_b);
+    std::fs::remove_dir_all(&runtime_home).expect("remove runtime home");
+}
+
+async fn send_message(
+    state: &AppState,
+    message: &str,
+) -> Result<SendMessageReceipt, crate::domains::agent_operations::runtime::AgentOperationsError> {
+    state
+        .agent_operations
+        .send_message(
+            &state.agent_operations.authenticated_caller("caller"),
+            SendMessageInput {
+                target: AgentIdentity::new(
+                    state.agent_operations.runtime_identity().clone(),
+                    "target",
+                ),
+                message: message.into(),
+            },
+        )
+        .await
+}
+
+async fn send_direct_prompt(state: &AppState, text: &str) {
+    state
+        .session_runtime
+        .send_prompt(
+            "target",
+            vec![PromptInputBlock::Text { text: text.into() }],
+            Some(format!("test:{text}")),
+        )
+        .await
+        .expect("direct prompt");
+}
+
+fn build_state(runtime_home: &Path, db: Db, seed: bool) -> AppState {
+    let workspace_a = runtime_home.join("workspace-a");
+    let workspace_b = runtime_home.join("workspace-b");
+    std::fs::create_dir_all(&workspace_a).expect("workspace A");
+    std::fs::create_dir_all(&workspace_b).expect("workspace B");
+    if seed {
+        test_support::seed_workspace_with_repo_root(
+            &db,
+            "workspace-a",
+            "local",
+            &workspace_a.to_string_lossy(),
+        );
+        test_support::seed_workspace_with_repo_root(
+            &db,
+            "workspace-b",
+            "local",
+            &workspace_b.to_string_lossy(),
+        );
+    }
+    let state = AppState::new(
+        runtime_home.to_path_buf(),
+        "http://127.0.0.1:8457".into(),
+        db,
+        false,
+        AgentSeedStore::not_configured_dev(),
+    )
+    .expect("app state");
+    if seed {
+        let caller = session("caller", "workspace-a", "idle", "Exact Sender");
+        let mut target = session("target", "workspace-b", "idle", "Target");
+        target.last_prompt_at = Some("2026-08-10T23:59:00Z".into());
+        state
+            .session_service
+            .store()
+            .insert(&caller)
+            .expect("caller");
+        state
+            .session_service
+            .store()
+            .insert(&target)
+            .expect("target");
+    }
+    state
+}
+
+fn assert_agent_output(state: &AppState, expected_texts: &[&str]) {
+    let output = state
+        .session_service
+        .get_task_output("target", None, 50)
+        .expect("target task output");
+    let messages = output
+        .messages
+        .iter()
+        .filter(|message| {
+            message.role == TaskOutputRole::User
+                && matches!(&message.sender, TaskOutputSender::Agent { .. })
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        messages
+            .iter()
+            .map(|message| message.text.as_str())
+            .collect::<Vec<_>>(),
+        expected_texts
+    );
+    assert!(messages.iter().all(|message| {
+        message.sender
+            == TaskOutputSender::Agent {
+                session_id: Some("caller".into()),
+                label: "Exact Sender".into(),
+            }
+    }));
+    assert!(state
+        .session_service
+        .get_task_output("caller", None, 50)
+        .expect("caller task output")
+        .messages
+        .is_empty());
+}
+
+fn temp_runtime_home(label: &str) -> PathBuf {
+    PathBuf::from(format!(
+        "/tmp/anyharness-agent-message-{label}-{}",
+        uuid::Uuid::new_v4()
+    ))
+}
+
+fn install_scripted_agent_env(script: &ScriptedAgent) -> (EnvVarGuard, EnvVarGuard) {
+    let program = EnvVarGuard::set("ANYHARNESS_CLAUDE_AGENT_PROGRAM", &script.program);
+    let args = serde_json::to_string(&vec![
+        script.request_log.to_string_lossy().to_string(),
+        script.control_dir.to_string_lossy().to_string(),
+    ])
+    .expect("agent args");
+    let args = EnvVarGuard::set("ANYHARNESS_CLAUDE_AGENT_ARGS_JSON", args);
+    (program, args)
+}
+
+fn write_scripted_agent(runtime_home: &Path) -> ScriptedAgent {
+    std::fs::create_dir_all(runtime_home.join("secrets")).expect("secrets directory");
+    std::fs::write(
+        runtime_home.join("secrets/global.env"),
+        "ANTHROPIC_API_KEY=test-not-a-real-key\nCLAUDE_CODE_USE_BEDROCK=0\n",
+    )
+    .expect("test credentials");
+    let native = runtime_home.join("agents/claude/native/claude");
+    std::fs::create_dir_all(native.parent().expect("native parent")).expect("native directory");
+    std::fs::write(&native, "#!/bin/sh\nexit 0\n").expect("native stub");
+    crate::integrations::agent_cli::executable::make_executable(&native)
+        .expect("executable native stub");
+
+    let control_dir = runtime_home.join("script-control");
+    std::fs::create_dir_all(&control_dir).expect("control directory");
+    let request_log = runtime_home.join("agent-requests.jsonl");
+    let program = runtime_home.join("scripted-agent.py");
+    std::fs::write(
+        &program,
+        r#"#!/usr/bin/env python3
+import json
+import os
+import sys
+import time
+log_path = sys.argv[-2]
+control_dir = sys.argv[-1]
+native_session_id = "native-target"
+def emit(payload):
+    print(json.dumps(payload, separators=(",", ":")), flush=True)
+def control(name):
+    return os.path.join(control_dir, name)
+for raw_line in sys.stdin:
+    message = json.loads(raw_line)
+    with open(log_path, "a", encoding="utf-8") as log:
+        log.write(json.dumps(message, separators=(",", ":")) + "\n")
+    if "id" not in message:
+        continue
+    request_id = message["id"]
+    method = message.get("method")
+    if method == "initialize":
+        emit({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "protocolVersion": 1,
+                "agentCapabilities": {"loadSession": True},
+                "authMethods": [],
+            },
+        })
+    elif method == "session/new":
+        native_session_id = "native-target"
+        emit({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {"sessionId": native_session_id},
+        })
+    elif method == "session/load":
+        native_session_id = message["params"]["sessionId"]
+        emit({"jsonrpc": "2.0", "id": request_id, "result": {}})
+    elif method in ("session/set_model", "session/set_mode", "session/set_config_option"):
+        emit({"jsonrpc": "2.0", "id": request_id, "result": {}})
+    elif method == "session/prompt":
+        text_blocks = [
+            block.get("text", "")
+            for block in message["params"]["prompt"]
+            if block.get("type") == "text"
+        ]
+        text = text_blocks[-1] if text_blocks else ""
+        if text in ("blocking turn", "restart boundary turn"):
+            open(control("turn-seen"), "w", encoding="utf-8").close()
+            while not os.path.exists(control("release-turn")):
+                time.sleep(0.01)
+        emit({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": native_session_id,
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"type": "text", "text": "reply:" + text},
+                    "messageId": "reply-" + str(request_id),
+                },
+            },
+        })
+        emit({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {"stopReason": "end_turn"},
+        })
+    else:
+        emit({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32601, "message": "method not found"},
+        })
+"#,
+    )
+    .expect("scripted agent");
+    crate::integrations::agent_cli::executable::make_executable(&program)
+        .expect("executable scripted agent");
+    ScriptedAgent {
+        program,
+        request_log,
+        control_dir,
+    }
+}
+
+fn read_requests(path: &Path) -> Vec<Value> {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    contents
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).expect("script request JSON"))
+        .collect()
+}
+
+fn prompt_texts(path: &Path) -> Vec<String> {
+    read_requests(path)
+        .into_iter()
+        .filter(|request| request["method"] == "session/prompt")
+        .filter_map(|request| {
+            request["params"]["prompt"]
+                .as_array()?
+                .iter()
+                .rev()
+                .find_map(|block| block["text"].as_str().map(str::to_string))
+        })
+        .collect()
+}
+
+async fn wait_for_prompt_count(path: &Path, expected: usize) {
+    wait_for("scripted prompt count", || {
+        prompt_texts(path).len() >= expected
+    })
+    .await;
+}
+
+async fn wait_for_queue_len(state: &AppState, expected: usize) {
+    wait_for("pending queue length", || {
+        state
+            .session_service
+            .store()
+            .list_pending_prompts("target")
+            .is_ok_and(|rows| rows.len() == expected)
+    })
+    .await;
+}
+
+async fn wait_for_path(path: &Path) {
+    wait_for("script control path", || path.exists()).await;
+}
+
+async fn wait_for(description: &str, mut condition: impl FnMut() -> bool) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if condition() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for {description}"));
+}
+
+async fn wait_for_actor_idle(state: &AppState) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if state
+                .acp_manager
+                .get_ready_handle("target")
+                .await
+                .is_some_and(|handle| !handle.is_busy())
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("target actor idle");
+}
+
+async fn wait_for_actor_gone(state: &AppState) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if state.acp_manager.get_handle("target").await.is_none() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("target actor exit");
+}
+
+async fn stop_target_actor(state: &AppState) {
+    if let Some(handle) = state.acp_manager.get_handle("target").await {
+        tokio::time::timeout(Duration::from_secs(2), handle.close())
+            .await
+            .expect("close actor timeout")
+            .expect("close actor");
+    }
+    wait_for_actor_gone(state).await;
+}

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt_message_cold_start_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt_message_cold_start_tests.rs
@@ -1,0 +1,71 @@
+use super::prompt_message_actor_tests::{
+    assert_agent_output, build_state, install_scripted_agent_env, prompt_texts, read_requests,
+    send_message, stop_target_actor, temp_runtime_home, wait_for_actor_idle, wait_for_prompt_count,
+    wait_for_queue_len, write_scripted_agent,
+};
+use crate::app::test_support;
+use crate::persistence::Db;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn send_message_cold_target_loads_recorded_native_id_and_drains_exactly_once() {
+    let _env_lock = test_support::lock_env();
+    let _bearer = test_support::set_bearer_token_env(None);
+    let _data_key = test_support::set_data_key_env(None);
+    let runtime_home = temp_runtime_home("cold-send");
+    let script = write_scripted_agent(&runtime_home);
+    let (_program, _args) = install_scripted_agent_env(&script);
+    let state = build_state(
+        &runtime_home,
+        Db::open(&runtime_home).expect("file-backed db"),
+        true,
+    );
+
+    let target = state
+        .session_service
+        .get_session("target")
+        .expect("load target")
+        .expect("durable target");
+    assert_eq!(target.native_session_id.as_deref(), Some("native-target"));
+    assert!(
+        target.last_prompt_at.is_some(),
+        "the fixture must force native-session load instead of fresh creation"
+    );
+    assert!(state.acp_manager.get_handle("target").await.is_none());
+
+    let receipt = send_message(&state, "cold activation message")
+        .await
+        .expect("cold send_message receipt");
+    wait_for_prompt_count(&script.request_log, 1).await;
+    wait_for_queue_len(&state, 0).await;
+    wait_for_actor_idle(&state).await;
+
+    let requests = read_requests(&script.request_log);
+    let loads = requests
+        .iter()
+        .filter(|request| request["method"] == "session/load")
+        .collect::<Vec<_>>();
+    assert_eq!(loads.len(), 1);
+    assert_eq!(loads[0]["params"]["sessionId"], "native-target");
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| request["method"] == "session/new")
+            .count(),
+        0
+    );
+    assert_eq!(
+        prompt_texts(&script.request_log),
+        ["cold activation message"]
+    );
+    assert!(state
+        .session_service
+        .store()
+        .find_pending_prompt("target", receipt.queue_seq)
+        .expect("read committed row after drain")
+        .is_none());
+    assert_agent_output(&state, &["cold activation message"]);
+
+    stop_target_actor(&state).await;
+    drop(state);
+    std::fs::remove_dir_all(&runtime_home).expect("remove runtime home");
+}

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt_message_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt_message_tests.rs
@@ -29,7 +29,7 @@ impl Drop for AgentProgramGuard {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn send_message_commits_before_pending_startup_and_bounds_the_readiness_wait() {
+async fn send_message_returns_before_target_startup_readiness_resolves() {
     let _env_lock = test_support::lock_env();
     let _bearer = test_support::set_bearer_token_env(None);
     let _data_key = test_support::set_data_key_env(None);
@@ -37,36 +37,27 @@ async fn send_message_commits_before_pending_startup_and_bounds_the_readiness_wa
         session("caller", "workspace-a", "idle", "Exact Sender"),
         session("target", "workspace-b", "idle", "Target"),
     ]);
-    let startup = state
+    // A pending, never-resolved target startup. Consumer activation blocks on
+    // this readiness gate (bounded by SHARED_STARTUP_READINESS_TIMEOUT = 1s in
+    // test), so if activation still ran inline under the caller, send_message
+    // would take ~1s to return. Detached activation must let the receipt return
+    // promptly, well before the gate resolves.
+    let _startup = state
         .session_runtime
         .acp_manager_for_test()
         .insert_pending_startup_for_test("target")
         .await;
 
-    let operations = state.agent_operations.clone();
-    let send = tokio::spawn(async move {
-        let target = AgentIdentity::new(operations.runtime_identity().clone(), "target");
-        operations
-            .send_message(
-                &operations.authenticated_caller("caller"),
-                SendMessageInput {
-                    target,
-                    message: "persist before startup".into(),
-                },
-            )
-            .await
-    });
-    wait_for_pending_row(&state, "target").await;
-    assert!(
-        !send.is_finished(),
-        "the committed row must precede the bounded startup wait"
-    );
-
-    let receipt = tokio::time::timeout(Duration::from_secs(3), send)
-        .await
-        .expect("startup wait must be bounded")
-        .expect("send task")
-        .expect("startup timeout is post-commit success");
+    // Negative control: this 500ms bound is shorter than the 1s readiness
+    // timeout an inline activation would block on, so it fails if activation is
+    // re-inlined, and is orders of magnitude above the detached path's cost.
+    let receipt = tokio::time::timeout(
+        Duration::from_millis(500),
+        send_message(&state, "target", "persist before startup"),
+    )
+    .await
+    .expect("send_message must return without waiting on target startup readiness")
+    .expect("post-commit success");
     assert_eq!(receipt.status, SendMessageStatus::DurablyQueued);
 
     let row = state
@@ -84,18 +75,6 @@ async fn send_message_commits_before_pending_startup_and_bounds_the_readiness_wa
             label: Some("Exact Sender".into()),
         })
     );
-
-    let runtime = state.session_runtime.clone();
-    let rejoin = tokio::spawn(async move { runtime.ensure_live_session("target", None).await });
-    startup
-        .send(Some(Ok("native-target".into())))
-        .expect("release pending startup");
-    let resumed = tokio::time::timeout(Duration::from_secs(1), rejoin)
-        .await
-        .expect("deduplicated startup rejoin timeout")
-        .expect("rejoin task")
-        .expect("deduplicated startup remains usable after activation timeout");
-    assert_eq!(resumed.native_session_id.as_deref(), Some("native-target"));
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt_message_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt_message_tests.rs
@@ -1,16 +1,12 @@
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::time::Duration;
 
-use anyharness_contract::v1::{PromptProvenance, SessionExecutionPhase};
-use tokio::sync::broadcast;
+use anyharness_contract::v1::PromptProvenance;
 
 use crate::app::{test_support, AppState};
 use crate::domains::agent_operations::model::{AgentIdentity, SendMessageInput, SendMessageStatus};
 use crate::domains::agents::installer::seed::AgentSeedStore;
 use crate::domains::sessions::model::{SessionMcpBindingPolicy, SessionRecord};
-use crate::domains::sessions::store::SessionStore;
-use crate::domains::sessions::task_output::{TaskOutputRole, TaskOutputSender};
-use crate::live::sessions::SessionEventSink;
 use crate::persistence::Db;
 
 struct AgentProgramGuard(Option<std::ffi::OsString>);
@@ -33,70 +29,11 @@ impl Drop for AgentProgramGuard {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn send_message_idle_and_running_commit_attributed_rows_before_the_wake_receipt() {
+async fn send_message_commits_before_pending_startup_and_bounds_the_readiness_wait() {
     let _env_lock = test_support::lock_env();
     let _bearer = test_support::set_bearer_token_env(None);
     let _data_key = test_support::set_data_key_env(None);
-    let (state, _agent_program_guard) = state_with_sessions(&[
-        session("caller", "workspace-a", "idle", "Caller Label"),
-        session("idle-target", "workspace-b", "idle", "Idle"),
-        session("running-target", "workspace-b", "running", "Running"),
-    ]);
-
-    for (target, phase) in [
-        ("idle-target", SessionExecutionPhase::Idle),
-        ("running-target", SessionExecutionPhase::Running),
-    ] {
-        let mut observed = state
-            .session_runtime
-            .acp_manager_for_test()
-            .insert_prompt_observer_with_phase_for_test(target, phase)
-            .await;
-        let receipt = state
-            .agent_operations
-            .send_message(
-                &state.agent_operations.authenticated_caller("caller"),
-                SendMessageInput {
-                    target: AgentIdentity::new(
-                        state.agent_operations.runtime_identity().clone(),
-                        target,
-                    ),
-                    message: format!("message for {target}"),
-                },
-            )
-            .await
-            .expect("durable message");
-        assert_eq!(receipt.status, SendMessageStatus::DurablyQueued);
-
-        let wake = observed.recv().await.expect("wake command");
-        assert_eq!(wake.from_queue_seq, Some(receipt.queue_seq));
-        assert_eq!(wake.prompt_id, None);
-        assert_eq!(wake.payload.text_summary, format!("message for {target}"));
-
-        let row = state
-            .session_service
-            .store()
-            .find_pending_prompt(target, receipt.queue_seq)
-            .expect("read pending prompt")
-            .expect("durable pending prompt");
-        assert_eq!(row.text, format!("message for {target}"));
-        assert_eq!(
-            row.prompt_payload().public_provenance(),
-            Some(PromptProvenance::AgentSession {
-                source_session_id: "caller".into(),
-                session_link_id: None,
-                label: Some("Caller Label".into()),
-            })
-        );
-    }
-}
-
-#[tokio::test(flavor = "current_thread")]
-async fn send_message_survives_wake_loss_and_cold_replay_is_visible_exactly_once() {
-    let _env_lock = test_support::lock_env();
-    let _bearer = test_support::set_bearer_token_env(None);
-    let _data_key = test_support::set_data_key_env(None);
-    let (state, _agent_program_guard) = state_with_sessions(&[
+    let (state, _program) = state_with_sessions(&[
         session("caller", "workspace-a", "idle", "Exact Sender"),
         session("target", "workspace-b", "idle", "Target"),
     ]);
@@ -108,37 +45,123 @@ async fn send_message_survives_wake_loss_and_cold_replay_is_visible_exactly_once
 
     let operations = state.agent_operations.clone();
     let send = tokio::spawn(async move {
+        let target = AgentIdentity::new(operations.runtime_identity().clone(), "target");
+        operations
+            .send_message(
+                &operations.authenticated_caller("caller"),
+                SendMessageInput {
+                    target,
+                    message: "persist before startup".into(),
+                },
+            )
+            .await
+    });
+    wait_for_pending_row(&state, "target").await;
+    assert!(
+        !send.is_finished(),
+        "the committed row must precede the bounded startup wait"
+    );
+
+    let receipt = tokio::time::timeout(Duration::from_secs(3), send)
+        .await
+        .expect("startup wait must be bounded")
+        .expect("send task")
+        .expect("startup timeout is post-commit success");
+    assert_eq!(receipt.status, SendMessageStatus::DurablyQueued);
+
+    let row = state
+        .session_service
+        .store()
+        .find_pending_prompt("target", receipt.queue_seq)
+        .expect("read pending prompt")
+        .expect("row committed before startup readiness");
+    assert_eq!(row.text, "persist before startup");
+    assert_eq!(
+        row.prompt_payload().public_provenance(),
+        Some(PromptProvenance::AgentSession {
+            source_session_id: "caller".into(),
+            session_link_id: None,
+            label: Some("Exact Sender".into()),
+        })
+    );
+
+    let runtime = state.session_runtime.clone();
+    let rejoin = tokio::spawn(async move { runtime.ensure_live_session("target", None).await });
+    startup
+        .send(Some(Ok("native-target".into())))
+        .expect("release pending startup");
+    let resumed = tokio::time::timeout(Duration::from_secs(1), rejoin)
+        .await
+        .expect("deduplicated startup rejoin timeout")
+        .expect("rejoin task")
+        .expect("deduplicated startup remains usable after activation timeout");
+    assert_eq!(resumed.native_session_id.as_deref(), Some("native-target"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn send_message_startup_failure_after_commit_still_returns_the_durable_receipt() {
+    let _env_lock = test_support::lock_env();
+    let _bearer = test_support::set_bearer_token_env(None);
+    let _data_key = test_support::set_data_key_env(None);
+    let (state, _program) = state_with_sessions(&[
+        session("caller", "workspace-a", "idle", "Exact Sender"),
+        session("target", "workspace-b", "idle", "Target"),
+    ]);
+    let startup = state
+        .session_runtime
+        .acp_manager_for_test()
+        .insert_pending_startup_for_test("target")
+        .await;
+    let operations = state.agent_operations.clone();
+    let send = tokio::spawn(async move {
         operations
             .send_message(
                 &operations.authenticated_caller("caller"),
                 SendMessageInput {
                     target: AgentIdentity::new(operations.runtime_identity().clone(), "target"),
-                    message: "survive restart".into(),
+                    message: "survive startup failure".into(),
                 },
             )
             .await
     });
-    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-    assert!(
-        !send.is_finished(),
-        "cold send must wait for the target actor before committing"
-    );
+    wait_for_pending_row(&state, "target").await;
+    startup
+        .send(Some(Err("injected ACP startup failure".into())))
+        .expect("fail pending startup");
+
+    let receipt = tokio::time::timeout(Duration::from_secs(1), send)
+        .await
+        .expect("startup failure receipt timeout")
+        .expect("send task")
+        .expect("startup failure is post-commit success");
+    assert_eq!(receipt.status, SendMessageStatus::DurablyQueued);
     assert!(state
         .session_service
         .store()
-        .list_pending_prompts("target")
+        .find_pending_prompt("target", receipt.queue_seq)
         .unwrap()
-        .is_empty());
-    startup
-        .send(Some(Ok("native-target".into())))
-        .expect("finish cold target startup");
+        .is_some());
+}
 
-    let receipt = send
+#[tokio::test(flavor = "current_thread")]
+async fn send_message_keeps_the_same_receipt_when_the_actor_drops_its_wake_response() {
+    let _env_lock = test_support::lock_env();
+    let _bearer = test_support::set_bearer_token_env(None);
+    let _data_key = test_support::set_data_key_env(None);
+    let (state, _program) = state_with_sessions(&[
+        session("caller", "workspace-a", "idle", "Exact Sender"),
+        session("target", "workspace-b", "idle", "Target"),
+    ]);
+    let mut observed = state
+        .session_runtime
+        .acp_manager_for_test()
+        .insert_prompt_response_dropper_for_test("target")
+        .await;
+
+    let receipt = send_message(&state, "target", "survive ack loss")
         .await
-        .expect("join cold send")
-        .expect("wake loss is post-commit success");
+        .expect("post-commit response loss is success");
     assert_eq!(receipt.status, SendMessageStatus::DurablyQueued);
-    assert_eq!(receipt.target.session_id, "target");
     assert_eq!(
         serde_json::to_value(&receipt).unwrap(),
         serde_json::json!({
@@ -151,88 +174,136 @@ async fn send_message_survives_wake_loss_and_cold_replay_is_visible_exactly_once
         })
     );
 
-    let restarted_store = SessionStore::new(state.db.clone());
-    let pending = restarted_store
-        .list_pending_prompts("target")
-        .expect("restart queue read");
-    assert_eq!(pending.len(), 1);
-    assert_eq!(pending[0].seq, receipt.queue_seq);
+    let wake = tokio::time::timeout(Duration::from_secs(1), observed.recv())
+        .await
+        .expect("wake timeout")
+        .expect("wake command accepted before response sender dropped");
+    assert_eq!(wake.from_queue_seq, Some(receipt.queue_seq));
+    assert_eq!(wake.payload.text_summary, "survive ack loss");
+    assert!(state
+        .session_service
+        .store()
+        .find_pending_prompt("target", receipt.queue_seq)
+        .unwrap()
+        .is_some());
+}
 
-    assert!(replay_one_pending_prompt(&restarted_store, "target"));
-    assert!(
-        !replay_one_pending_prompt(&restarted_store, "target"),
-        "the committed row is consumed by only one replay"
-    );
-    assert!(restarted_store
+#[tokio::test(flavor = "current_thread")]
+async fn send_message_keeps_the_durable_receipt_when_the_wake_actor_is_unavailable() {
+    let _env_lock = test_support::lock_env();
+    let _bearer = test_support::set_bearer_token_env(None);
+    let _data_key = test_support::set_data_key_env(None);
+    let (state, _program) = state_with_sessions(&[
+        session("caller", "workspace-a", "idle", "Exact Sender"),
+        session("target", "workspace-b", "idle", "Target"),
+    ]);
+    state
+        .session_runtime
+        .acp_manager_for_test()
+        .insert_unavailable_session_for_test("target")
+        .await;
+
+    let receipt = send_message(&state, "target", "survive unavailable actor")
+        .await
+        .expect("post-commit ActorUnavailable is success");
+    assert_eq!(receipt.status, SendMessageStatus::DurablyQueued);
+    assert!(state
+        .session_service
+        .store()
+        .find_pending_prompt("target", receipt.queue_seq)
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn send_message_store_failure_returns_error_without_activating_the_actor() {
+    let _env_lock = test_support::lock_env();
+    let _bearer = test_support::set_bearer_token_env(None);
+    let _data_key = test_support::set_data_key_env(None);
+    let (state, _program) = state_with_sessions(&[
+        session("caller", "workspace-a", "idle", "Caller"),
+        session("target", "workspace-b", "idle", "Target"),
+    ]);
+    let mut observed = state
+        .session_runtime
+        .acp_manager_for_test()
+        .insert_prompt_observer_for_test("target")
+        .await;
+    state
+        .db
+        .with_conn(|conn| {
+            conn.execute_batch(
+                "CREATE TRIGGER fail_agent_message_insert \
+                 BEFORE INSERT ON session_pending_prompts \
+                 BEGIN SELECT RAISE(ABORT, 'injected pending-row failure'); END;",
+            )
+        })
+        .expect("install failing insert trigger");
+
+    let error = send_message(&state, "target", "must not wake")
+        .await
+        .expect_err("store failure");
+    assert_eq!(error.code(), "AGENT_OPERATIONS_INTERNAL");
+    assert!(state
+        .session_service
+        .store()
         .list_pending_prompts("target")
         .unwrap()
         .is_empty());
-
-    let output = state
-        .session_service
-        .get_task_output("target", None, 10)
-        .expect("task output");
-    assert_eq!(output.messages.len(), 1);
-    assert_eq!(output.messages[0].role, TaskOutputRole::User);
-    assert_eq!(output.messages[0].text, "survive restart");
-    assert_eq!(
-        output.messages[0].sender,
-        TaskOutputSender::Agent {
-            session_id: Some("caller".into()),
-            label: "Exact Sender".into(),
-        }
-    );
-    assert!(state
-        .session_service
-        .get_task_output("caller", None, 10)
-        .expect("caller output")
-        .messages
-        .is_empty());
-    assert_eq!(
-        state
-            .session_service
-            .get_session("target")
-            .unwrap()
-            .unwrap()
-            .native_session_id
-            .as_deref(),
-        Some("native-target")
-    );
+    assert!(matches!(
+        observed.try_recv(),
+        Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+    ));
 }
 
-fn replay_one_pending_prompt(store: &SessionStore, session_id: &str) -> bool {
-    let Some(row) = store
-        .peek_head_pending_prompt(session_id)
-        .expect("peek restart queue")
-    else {
-        return false;
-    };
-    let payload = row.prompt_payload();
-    let (event_tx, _) = broadcast::channel(16);
-    let last_seq = store.last_event_seq(session_id).expect("last event seq");
-    let mut sink = SessionEventSink::resume_from_seq(
-        session_id.into(),
-        "claude".into(),
-        PathBuf::from("/tmp/workspace-b"),
-        last_seq,
-        event_tx,
-        Arc::new(store.clone()),
-    );
-    sink.begin_turn(
-        payload.text_summary.clone(),
-        row.prompt_id.clone(),
-        payload.content_parts(),
-        payload.public_provenance(),
-    );
-    store
-        .delete_pending_prompt(session_id, row.seq)
-        .expect("consume replayed row");
-    true
+async fn send_message(
+    state: &AppState,
+    target: &str,
+    message: &str,
+) -> Result<
+    crate::domains::agent_operations::model::SendMessageReceipt,
+    crate::domains::agent_operations::runtime::AgentOperationsError,
+> {
+    state
+        .agent_operations
+        .send_message(
+            &state.agent_operations.authenticated_caller("caller"),
+            SendMessageInput {
+                target: AgentIdentity::new(
+                    state.agent_operations.runtime_identity().clone(),
+                    target,
+                ),
+                message: message.into(),
+            },
+        )
+        .await
+}
+
+async fn wait_for_pending_row(state: &AppState, target: &str) {
+    tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            if !state
+                .session_service
+                .store()
+                .list_pending_prompts(target)
+                .unwrap()
+                .is_empty()
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("pending row commit");
 }
 
 fn state_with_sessions(sessions: &[SessionRecord]) -> (AppState, AgentProgramGuard) {
     let db = Db::open_in_memory().expect("in-memory db");
-    let runtime_home = std::env::temp_dir().join(format!("agent-message-{}", uuid::Uuid::new_v4()));
+    let runtime_home = PathBuf::from(format!(
+        "/tmp/anyharness-agent-message-unit-{}",
+        uuid::Uuid::new_v4()
+    ));
     let workspace_a = runtime_home.join("workspace-a");
     let workspace_b = runtime_home.join("workspace-b");
     std::fs::create_dir_all(&workspace_a).expect("workspace A");
@@ -278,7 +349,7 @@ fn state_with_sessions(sessions: &[SessionRecord]) -> (AppState, AgentProgramGua
     (state, agent_program_guard)
 }
 
-fn session(id: &str, workspace_id: &str, status: &str, title: &str) -> SessionRecord {
+pub(super) fn session(id: &str, workspace_id: &str, status: &str, title: &str) -> SessionRecord {
     SessionRecord {
         id: id.into(),
         workspace_id: workspace_id.into(),

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt_message_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt_message_tests.rs
@@ -1,0 +1,309 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyharness_contract::v1::{PromptProvenance, SessionExecutionPhase};
+use tokio::sync::broadcast;
+
+use crate::app::{test_support, AppState};
+use crate::domains::agent_operations::model::{AgentIdentity, SendMessageInput, SendMessageStatus};
+use crate::domains::agents::installer::seed::AgentSeedStore;
+use crate::domains::sessions::model::{SessionMcpBindingPolicy, SessionRecord};
+use crate::domains::sessions::store::SessionStore;
+use crate::domains::sessions::task_output::{TaskOutputRole, TaskOutputSender};
+use crate::live::sessions::SessionEventSink;
+use crate::persistence::Db;
+
+struct AgentProgramGuard(Option<std::ffi::OsString>);
+
+impl AgentProgramGuard {
+    fn set(path: &std::path::Path) -> Self {
+        let previous = std::env::var_os("ANYHARNESS_CLAUDE_AGENT_PROGRAM");
+        std::env::set_var("ANYHARNESS_CLAUDE_AGENT_PROGRAM", path);
+        Self(previous)
+    }
+}
+
+impl Drop for AgentProgramGuard {
+    fn drop(&mut self) {
+        match self.0.as_ref() {
+            Some(value) => std::env::set_var("ANYHARNESS_CLAUDE_AGENT_PROGRAM", value),
+            None => std::env::remove_var("ANYHARNESS_CLAUDE_AGENT_PROGRAM"),
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn send_message_idle_and_running_commit_attributed_rows_before_the_wake_receipt() {
+    let _env_lock = test_support::lock_env();
+    let _bearer = test_support::set_bearer_token_env(None);
+    let _data_key = test_support::set_data_key_env(None);
+    let (state, _agent_program_guard) = state_with_sessions(&[
+        session("caller", "workspace-a", "idle", "Caller Label"),
+        session("idle-target", "workspace-b", "idle", "Idle"),
+        session("running-target", "workspace-b", "running", "Running"),
+    ]);
+
+    for (target, phase) in [
+        ("idle-target", SessionExecutionPhase::Idle),
+        ("running-target", SessionExecutionPhase::Running),
+    ] {
+        let mut observed = state
+            .session_runtime
+            .acp_manager_for_test()
+            .insert_prompt_observer_with_phase_for_test(target, phase)
+            .await;
+        let receipt = state
+            .agent_operations
+            .send_message(
+                &state.agent_operations.authenticated_caller("caller"),
+                SendMessageInput {
+                    target: AgentIdentity::new(
+                        state.agent_operations.runtime_identity().clone(),
+                        target,
+                    ),
+                    message: format!("message for {target}"),
+                },
+            )
+            .await
+            .expect("durable message");
+        assert_eq!(receipt.status, SendMessageStatus::DurablyQueued);
+
+        let wake = observed.recv().await.expect("wake command");
+        assert_eq!(wake.from_queue_seq, Some(receipt.queue_seq));
+        assert_eq!(wake.prompt_id, None);
+        assert_eq!(wake.payload.text_summary, format!("message for {target}"));
+
+        let row = state
+            .session_service
+            .store()
+            .find_pending_prompt(target, receipt.queue_seq)
+            .expect("read pending prompt")
+            .expect("durable pending prompt");
+        assert_eq!(row.text, format!("message for {target}"));
+        assert_eq!(
+            row.prompt_payload().public_provenance(),
+            Some(PromptProvenance::AgentSession {
+                source_session_id: "caller".into(),
+                session_link_id: None,
+                label: Some("Caller Label".into()),
+            })
+        );
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn send_message_survives_wake_loss_and_cold_replay_is_visible_exactly_once() {
+    let _env_lock = test_support::lock_env();
+    let _bearer = test_support::set_bearer_token_env(None);
+    let _data_key = test_support::set_data_key_env(None);
+    let (state, _agent_program_guard) = state_with_sessions(&[
+        session("caller", "workspace-a", "idle", "Exact Sender"),
+        session("target", "workspace-b", "idle", "Target"),
+    ]);
+    let startup = state
+        .session_runtime
+        .acp_manager_for_test()
+        .insert_pending_startup_for_test("target")
+        .await;
+
+    let operations = state.agent_operations.clone();
+    let send = tokio::spawn(async move {
+        operations
+            .send_message(
+                &operations.authenticated_caller("caller"),
+                SendMessageInput {
+                    target: AgentIdentity::new(operations.runtime_identity().clone(), "target"),
+                    message: "survive restart".into(),
+                },
+            )
+            .await
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    assert!(
+        !send.is_finished(),
+        "cold send must wait for the target actor before committing"
+    );
+    assert!(state
+        .session_service
+        .store()
+        .list_pending_prompts("target")
+        .unwrap()
+        .is_empty());
+    startup
+        .send(Some(Ok("native-target".into())))
+        .expect("finish cold target startup");
+
+    let receipt = send
+        .await
+        .expect("join cold send")
+        .expect("wake loss is post-commit success");
+    assert_eq!(receipt.status, SendMessageStatus::DurablyQueued);
+    assert_eq!(receipt.target.session_id, "target");
+    assert_eq!(
+        serde_json::to_value(&receipt).unwrap(),
+        serde_json::json!({
+            "target": {
+                "runtimeId": state.agent_operations.runtime_identity().as_str(),
+                "sessionId": "target"
+            },
+            "queueSeq": receipt.queue_seq,
+            "status": "durably_queued"
+        })
+    );
+
+    let restarted_store = SessionStore::new(state.db.clone());
+    let pending = restarted_store
+        .list_pending_prompts("target")
+        .expect("restart queue read");
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].seq, receipt.queue_seq);
+
+    assert!(replay_one_pending_prompt(&restarted_store, "target"));
+    assert!(
+        !replay_one_pending_prompt(&restarted_store, "target"),
+        "the committed row is consumed by only one replay"
+    );
+    assert!(restarted_store
+        .list_pending_prompts("target")
+        .unwrap()
+        .is_empty());
+
+    let output = state
+        .session_service
+        .get_task_output("target", None, 10)
+        .expect("task output");
+    assert_eq!(output.messages.len(), 1);
+    assert_eq!(output.messages[0].role, TaskOutputRole::User);
+    assert_eq!(output.messages[0].text, "survive restart");
+    assert_eq!(
+        output.messages[0].sender,
+        TaskOutputSender::Agent {
+            session_id: Some("caller".into()),
+            label: "Exact Sender".into(),
+        }
+    );
+    assert!(state
+        .session_service
+        .get_task_output("caller", None, 10)
+        .expect("caller output")
+        .messages
+        .is_empty());
+    assert_eq!(
+        state
+            .session_service
+            .get_session("target")
+            .unwrap()
+            .unwrap()
+            .native_session_id
+            .as_deref(),
+        Some("native-target")
+    );
+}
+
+fn replay_one_pending_prompt(store: &SessionStore, session_id: &str) -> bool {
+    let Some(row) = store
+        .peek_head_pending_prompt(session_id)
+        .expect("peek restart queue")
+    else {
+        return false;
+    };
+    let payload = row.prompt_payload();
+    let (event_tx, _) = broadcast::channel(16);
+    let last_seq = store.last_event_seq(session_id).expect("last event seq");
+    let mut sink = SessionEventSink::resume_from_seq(
+        session_id.into(),
+        "claude".into(),
+        PathBuf::from("/tmp/workspace-b"),
+        last_seq,
+        event_tx,
+        Arc::new(store.clone()),
+    );
+    sink.begin_turn(
+        payload.text_summary.clone(),
+        row.prompt_id.clone(),
+        payload.content_parts(),
+        payload.public_provenance(),
+    );
+    store
+        .delete_pending_prompt(session_id, row.seq)
+        .expect("consume replayed row");
+    true
+}
+
+fn state_with_sessions(sessions: &[SessionRecord]) -> (AppState, AgentProgramGuard) {
+    let db = Db::open_in_memory().expect("in-memory db");
+    let runtime_home = std::env::temp_dir().join(format!("agent-message-{}", uuid::Uuid::new_v4()));
+    let workspace_a = runtime_home.join("workspace-a");
+    let workspace_b = runtime_home.join("workspace-b");
+    std::fs::create_dir_all(&workspace_a).expect("workspace A");
+    std::fs::create_dir_all(&workspace_b).expect("workspace B");
+    std::fs::create_dir_all(runtime_home.join("secrets")).expect("secrets directory");
+    std::fs::write(
+        runtime_home.join("secrets/global.env"),
+        "ANTHROPIC_API_KEY=test-not-a-real-key\n",
+    )
+    .expect("test credential");
+    let agent_program = runtime_home.join("claude-agent-stub");
+    std::fs::write(&agent_program, "#!/bin/sh\nexit 0\n").expect("agent stub");
+    crate::integrations::agent_cli::executable::make_executable(&agent_program)
+        .expect("executable agent stub");
+    let agent_program_guard = AgentProgramGuard::set(&agent_program);
+    test_support::seed_workspace_with_repo_root(
+        &db,
+        "workspace-a",
+        "local",
+        &workspace_a.to_string_lossy(),
+    );
+    test_support::seed_workspace_with_repo_root(
+        &db,
+        "workspace-b",
+        "local",
+        &workspace_b.to_string_lossy(),
+    );
+    let state = AppState::new(
+        runtime_home,
+        "http://127.0.0.1:8457".into(),
+        db,
+        false,
+        AgentSeedStore::not_configured_dev(),
+    )
+    .expect("app state");
+    for session in sessions {
+        state
+            .session_service
+            .store()
+            .insert(session)
+            .expect("insert session");
+    }
+    (state, agent_program_guard)
+}
+
+fn session(id: &str, workspace_id: &str, status: &str, title: &str) -> SessionRecord {
+    SessionRecord {
+        id: id.into(),
+        workspace_id: workspace_id.into(),
+        agent_kind: "claude".into(),
+        native_session_id: Some(format!("native-{id}")),
+        agent_auth_contexts: None,
+        requested_model_id: None,
+        current_model_id: None,
+        requested_mode_id: None,
+        current_mode_id: None,
+        title: Some(title.into()),
+        thinking_level_id: None,
+        thinking_budget_tokens: None,
+        status: status.into(),
+        created_at: "2026-08-11T00:00:00Z".into(),
+        updated_at: "2026-08-11T00:00:00Z".into(),
+        last_prompt_at: None,
+        closed_at: None,
+        dismissed_at: None,
+        mcp_bindings_ciphertext: None,
+        mcp_binding_summaries_json: None,
+        mcp_binding_policy: SessionMcpBindingPolicy::InheritWorkspace,
+        system_prompt_append: None,
+        subagents_enabled: true,
+        action_capabilities_json: None,
+        origin: None,
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/live/sessions/manager/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/manager/mod.rs
@@ -176,6 +176,7 @@ pub(crate) struct ScriptedSessionSpec {
 pub(crate) struct ObservedPrompt {
     pub(crate) prompt_id: Option<String>,
     pub(crate) payload: crate::domains::sessions::prompt::PromptPayload,
+    pub(crate) from_queue_seq: Option<i64>,
 }
 
 #[cfg(test)]
@@ -183,6 +184,18 @@ impl LiveSessionManager {
     pub(crate) async fn insert_prompt_observer_for_test(
         &self,
         session_id: &str,
+    ) -> tokio::sync::mpsc::UnboundedReceiver<ObservedPrompt> {
+        self.insert_prompt_observer_with_phase_for_test(
+            session_id,
+            anyharness_contract::v1::SessionExecutionPhase::Running,
+        )
+        .await
+    }
+
+    pub(crate) async fn insert_prompt_observer_with_phase_for_test(
+        &self,
+        session_id: &str,
+        phase: anyharness_contract::v1::SessionExecutionPhase,
     ) -> tokio::sync::mpsc::UnboundedReceiver<ObservedPrompt> {
         use crate::live::sessions::actor::command::{PromptAcceptance, SessionCommand};
 
@@ -193,7 +206,7 @@ impl LiveSessionManager {
             command_tx,
             event_tx,
             Some(format!("native-{session_id}")),
-            anyharness_contract::v1::SessionExecutionPhase::Running,
+            phase,
         ));
         self.live_sessions
             .write()
@@ -205,14 +218,22 @@ impl LiveSessionManager {
                 if let SessionCommand::Prompt {
                     payload,
                     prompt_id,
+                    from_queue_seq,
                     respond_to,
-                    ..
                 } = command
                 {
-                    let _ = seen_tx.send(ObservedPrompt { prompt_id, payload });
-                    let _ = respond_to.send(Ok(PromptAcceptance::Started {
-                        turn_id: "observed-turn".into(),
-                    }));
+                    let _ = seen_tx.send(ObservedPrompt {
+                        prompt_id,
+                        payload,
+                        from_queue_seq,
+                    });
+                    let acceptance = match from_queue_seq {
+                        Some(seq) => PromptAcceptance::Queued { seq },
+                        None => PromptAcceptance::Started {
+                            turn_id: "observed-turn".into(),
+                        },
+                    };
+                    let _ = respond_to.send(Ok(acceptance));
                 }
             }
         });

--- a/anyharness/crates/anyharness-lib/src/live/sessions/manager/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/manager/mod.rs
@@ -240,6 +240,50 @@ impl LiveSessionManager {
         seen_rx
     }
 
+    /// Register a ready handle whose command consumer accepts one prompt into
+    /// the real mailbox and then drops its reply sender. This exercises the
+    /// ambiguous post-send `ResponseDropped` path without pretending the actor
+    /// was unavailable before command acceptance.
+    pub(crate) async fn insert_prompt_response_dropper_for_test(
+        &self,
+        session_id: &str,
+    ) -> tokio::sync::mpsc::UnboundedReceiver<ObservedPrompt> {
+        use crate::live::sessions::actor::command::SessionCommand;
+
+        let (command_tx, mut command_rx) = tokio::sync::mpsc::channel(1);
+        let (event_tx, _) = tokio::sync::broadcast::channel(1);
+        let handle = Arc::new(LiveSessionHandle::new_for_test(
+            session_id,
+            command_tx,
+            event_tx,
+            Some(format!("native-{session_id}")),
+            anyharness_contract::v1::SessionExecutionPhase::Idle,
+        ));
+        self.live_sessions
+            .write()
+            .await
+            .insert(session_id.to_string(), handle);
+        let (seen_tx, seen_rx) = tokio::sync::mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            if let Some(SessionCommand::Prompt {
+                payload,
+                prompt_id,
+                from_queue_seq,
+                respond_to,
+            }) = command_rx.recv().await
+            {
+                let observed = ObservedPrompt {
+                    prompt_id,
+                    payload,
+                    from_queue_seq,
+                };
+                drop(respond_to);
+                let _ = seen_tx.send(observed);
+            }
+        });
+        seen_rx
+    }
+
     pub(crate) async fn insert_cancel_observer_for_test(
         &self,
         session_id: &str,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/manager/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/manager/startup.rs
@@ -13,6 +13,11 @@ use crate::live::sessions::actor::state::SessionActorConfig;
 use crate::live::sessions::handle::LiveSessionHandle;
 use crate::live::sessions::model::{SessionHooks, SessionLaunch};
 
+#[cfg(not(test))]
+const SHARED_STARTUP_READINESS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+#[cfg(test)]
+const SHARED_STARTUP_READINESS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+
 impl LiveSessionManager {
     #[tracing::instrument(skip_all, fields(session_id = %launch.session.id))]
     pub async fn start_session(
@@ -172,16 +177,24 @@ async fn wait_for_new_startup_readiness(
 async fn wait_for_startup_readiness(
     receiver: &mut watch::Receiver<StartupReadinessState>,
 ) -> anyhow::Result<ActorReadyResult> {
-    loop {
-        if let Some(result) = receiver.borrow().clone() {
-            return result
-                .map(|native_session_id| ActorReadyResult { native_session_id })
-                .map_err(anyhow::Error::msg);
-        }
+    tokio::time::timeout(SHARED_STARTUP_READINESS_TIMEOUT, async {
+        loop {
+            if let Some(result) = receiver.borrow().clone() {
+                return result
+                    .map(|native_session_id| ActorReadyResult { native_session_id })
+                    .map_err(anyhow::Error::msg);
+            }
 
-        receiver
-            .changed()
-            .await
-            .map_err(|_| anyhow::anyhow!("actor startup readiness channel closed before ready"))?;
-    }
+            receiver.changed().await.map_err(|_| {
+                anyhow::anyhow!("actor startup readiness channel closed before ready")
+            })?;
+        }
+    })
+    .await
+    .map_err(|_| {
+        anyhow::anyhow!(
+            "actor startup readiness wait timed out after {}s",
+            SHARED_STARTUP_READINESS_TIMEOUT.as_secs()
+        )
+    })?
 }


### PR DESCRIPTION
## Status

- Open draft; not authorized for merge.
- Exact head: `280b63d3486544bc26e2d3d530c34c98c0f3b6e7`.
- Exact base: `0176215acff423a39693f93546636ad12c944bf2`.
- GitHub exact-head CI status: green.
- Readiness labels: `area:anyharness` applied; required `release:*` remains pending.

## Frozen spec and slice

- Frozen feature revision: `2026-08-10.1`.
- Slice: **PR 4 — Durable cross-agent messaging and provenance**.
- Local-only frozen specification: `/Users/pablohansen/Proliferate Workspace/ADRs/(0) Subagents/Core Docs/5 Consolidated Feature Specification and PR Plan.md`.
- Frozen specification SHA-256: `baea03bdef9dbf0204673a11d38f5c6981a87a0752420e1a848095607f13d6a7`.
- Limitation: the specification path is machine-local and is not a GitHub-accessible artifact.

## Proof run

- The complete focused command, process-backed, and live endpoint inventory is preserved in the detailed record below.
- GitHub exact-head CI and Intent Tests passed.
- Local-only live receipt pinned to this exact head: `/Users/pablohansen/Proliferate Workspace/ADRs/(0) Subagents/Core Docs/11 PR4 Live Acceptance Receipt 2026-08-11.md`; receipt SHA-256 `bd4f4243b1cad0617bb1103e6d1df7e3557b3beff9c4761b99a51da51d8b10f6`; exact binary SHA-256 `2d8b7d0ae03cbc13d115615957f541a645b63d3435aeeab189adab0ad7a01d9d`.

## Proof not run and why

- Automatic Workspace MCP launch injection and the full product UI were not run; activation and UI belong to later slices.
- Automatic terminal completion delivery was not a PR 4 claim; that behavior is implemented and proven in PR 6.

## Open blockers

- No implementation, exact-head CI, or retained live-proof blocker is documented.
- The receipt is local-only and cannot be opened by a remote GitHub reviewer from this PR body.
- Readiness metadata remains intentionally incomplete: the draft has no `release:*` or `area:*` labels.
- This PR is stacked on #1755 and must not merge before it.

## Exact next action

Keep this PR draft. After #1755 is landed and the PR 10 release gate is accepted, reconcile the stacked base, reconfirm exact-head checks, choose and apply the required release label, and merge fourth.

---

## Detailed implementation record

## Summary

- add durable, attributed ordinary-agent send_message delivery through the Workspace MCP
- use the existing pending-prompt queue as the acceptance linearization point
- wake idle/running actors best-effort and resume cold targets on their existing native conversation
- preserve one-way ordinary-agent semantics; reverse delivery requires an explicit send_message call

## Verification

- send_message: 17 tests
- pending_prompts: 6 tests
- prompt_provenance: 2 tests
- live-session manager: 9 tests
- provenance-forgery guard: 1 test
- AnyHarness boundary, session-admission, max-lines, design-attribution, targeted rustfmt, and diff checks
- independent review accepted the immutable head
- isolated real Cursor/Workspace-MCP probe passed idle delivery, cold resume, running FIFO, crash/restart exact-once replay, no implicit reverse, and explicit reverse delivery

## Observability

Handled post-commit activation failures emit only a fixed low-cardinality failure code. Paths, auth details, provider output, prompts, and transcript content are not attached to the new warning.

## Documentation

No repository documentation changed. The frozen feature specification already describes this slice. The external acceptance receipt is Core Docs/11 PR4 Live Acceptance Receipt 2026-08-11.md, SHA-256 bd4f4243b1cad0617bb1103e6d1df7e3557b3beff9c4761b99a51da51d8b10f6.

## Deferred

Subagent creation and reversible Close/Open/Promote remain PR5. Completion notifications remain PR6. HTTP/generated APIs, UI, and automatic Workspace MCP activation remain later slices.
