### PR TITLE
fix(product): wire closed-session restore icon

### DIFF
--- a/apps/packages/product-client/src/components/workspace/shell/tabs/ClosedChatTabsMenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/tabs/ClosedChatTabsMenu.tsx
@@ -56,7 +56,17 @@ export function ClosedChatTabsMenu({
                 {formatRelativeTime(row.closedAt)}
               </span>
             )}
-            <RotateCcw className="icon-compact shrink-0 text-muted-foreground" aria-hidden="true" />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              title={`Restore ${row.title}`}
+              aria-label={`Restore ${row.title}`}
+              className="size-6 shrink-0 rounded-md text-muted-foreground"
+              onClick={() => onRestoreSession(row.id)}
+            >
+              <RotateCcw className="icon-compact" />
+            </Button>
           </div>
         ))}
       </div>

--- a/apps/packages/product-client/src/components/workspace/shell/topbar/HeaderTabsActions.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/topbar/HeaderTabsActions.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ClosedSessionsTrigger } from "#product/components/workspace/shell/topbar/HeaderTabsActions";
+import type {
+  HeaderChatMenuEntry,
+} from "#product/lib/domain/workspaces/tabs/workspace-header-tabs-view-model-types";
+
+const closedSession: HeaderChatMenuEntry = {
+  id: "session-1",
+  title: "Session one",
+  agentKind: "claude",
+  viewState: "idle",
+  isResolvingSession: false,
+  hasUnreadActivity: false,
+  isActive: false,
+  isVisible: false,
+  closedAt: "2026-08-10T20:00:00.000Z",
+};
+
+describe("ClosedSessionsTrigger", () => {
+  afterEach(cleanup);
+
+  it("restores the selected session from its restore icon and closes the popover", async () => {
+    const onRestoreSession = vi.fn();
+    const onDeleteSession = vi.fn();
+
+    render(
+      <ClosedSessionsTrigger
+        closedChatTabs={[closedSession]}
+        onRestoreSession={onRestoreSession}
+        onDeleteSession={onDeleteSession}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Closed sessions (1)" }));
+    fireEvent.click(screen.getByRole("button", { name: "Restore Session one" }));
+
+    expect(onRestoreSession).toHaveBeenCalledOnce();
+    expect(onRestoreSession).toHaveBeenCalledWith("session-1");
+    expect(onDeleteSession).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Restore Session one" })).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Linear tickets

- [PRO-158 — Session popover- rollback icon doesn't do anything](https://linear.app/proliferate-team/issue/PRO-158/session-popover-rollback-icon-doesnt-do-anything)

## Summary

- Make the closed-sessions popover's far-right restore glyph an accessible button wired to the existing row restore callback.
- Preserve the existing session-title restore action and delete action.
- Add a full-popover interaction regression covering restore, callback identity, delete isolation, and popover closure.

## Root cause

The history-popover row rendered the far-right `RotateCcw` as a bare `aria-hidden` SVG under an inert row `div`. The existing `onRestoreSession(row.id)` handler lived only on a sibling button containing the session icon and title. A pointer event on the SVG could bubble only to the inert row, never sideways to that sibling button, so it invoked no callback, did not close the popover, and did not update tab visibility or selection.

The row already represents a hidden live session. Its existing callback reveals that session (and its parent when applicable), clears the hidden marker, selects/activates it, and closes the popover. No new runtime or server capability is required.

## Impact

Users who clicked the explicit far-right restore affordance saw no response, even though clicking the session title restored the tab. The glyph now has a keyboard-accessible hit target named `Restore <session title>` and follows the same established restore path.

## Proof

Before the implementation change, the new test opened the real Radix popover and failed because the only accessible row controls were the session title and delete button; no restore button existed. After wrapping the glyph and wiring the callback, the same test passes and verifies the selected session ID, delete isolation, and popover closure.

## Testing

Tier 1 component and package coverage:

- `pnpm exec vitest run src/components/workspace/shell/topbar/HeaderTabsActions.test.tsx`
- `pnpm test` in `apps/packages/product-client`
- `pnpm typecheck` in `apps/packages/product-client`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_appearance_scaling.py`
- `git diff --check`

## Observability

None. This change adds no new workflow or failure path; it makes an existing callback reachable from the visible affordance. Existing session activation error reporting remains unchanged.

## Readiness

- [x] I followed the pull-request procedure for scope, title, body, and proof.
