### PR TITLE
fix(product): keep session history open after delete

### DIFF
--- a/apps/packages/product-client/src/components/workspace/shell/topbar/HeaderTabsActions.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/topbar/HeaderTabsActions.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+
+import { useState } from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ClosedSessionsTrigger } from "#product/components/workspace/shell/topbar/HeaderTabsActions";
+import type { HeaderChatMenuEntry } from "#product/lib/domain/workspaces/tabs/workspace-header-tabs-view-model-types";
+
+afterEach(cleanup);
+
+const CLOSED_SESSIONS: HeaderChatMenuEntry[] = [
+  closedSession("session-1", "Session one"),
+  closedSession("session-2", "Session two"),
+  closedSession("session-3", "Session three"),
+];
+
+describe("ClosedSessionsTrigger", () => {
+  it("keeps the popover open after deleting a session when other sessions remain", async () => {
+    const onDeleteSession = vi.fn();
+    renderClosedSessions({ onDeleteSession });
+
+    openClosedSessions(3);
+    fireEvent.click(screen.getByRole("button", { name: "Delete Session two" }));
+
+    expect(onDeleteSession).toHaveBeenCalledWith("session-2");
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Session two" })).toBeNull();
+    });
+    expect(screen.getByRole("button", { name: "Session one" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Session three" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Closed sessions (2)", hidden: true }).getAttribute("data-state"),
+    ).toBe("open");
+  });
+
+  it("still closes the popover after restoring a session", async () => {
+    const onRestoreSession = vi.fn();
+    renderClosedSessions({ onRestoreSession });
+
+    openClosedSessions(3);
+    fireEvent.click(screen.getByRole("button", { name: "Session one" }));
+
+    expect(onRestoreSession).toHaveBeenCalledWith("session-1");
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Session one" })).toBeNull();
+    });
+    expect(
+      screen.getByRole("button", { name: "Closed sessions (3)", hidden: true }).getAttribute("data-state"),
+    ).toBe("closed");
+  });
+
+  it("still closes the popover on Escape", async () => {
+    renderClosedSessions();
+
+    openClosedSessions(3);
+    fireEvent.keyDown(document, { key: "Escape", code: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Session one" })).toBeNull();
+    });
+  });
+
+  it("still closes the popover on an outside pointer interaction", async () => {
+    renderClosedSessions();
+
+    openClosedSessions(3);
+    // Radix installs the outside-pointer listener on the next timer and
+    // defers primary-pointer dismissal through the matching click.
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+    fireEvent.pointerDown(document.body);
+    fireEvent.click(document.body);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Session one" })).toBeNull();
+    });
+  });
+
+  it("removes the trigger after deleting the final closed session", async () => {
+    renderClosedSessions({ initialRows: [CLOSED_SESSIONS[0]] });
+
+    openClosedSessions(1);
+    fireEvent.click(screen.getByRole("button", { name: "Delete Session one" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /Closed sessions/ })).toBeNull();
+    });
+  });
+});
+
+function ClosedSessionsHarness({
+  initialRows,
+  onDeleteSession,
+  onRestoreSession,
+}: {
+  initialRows: HeaderChatMenuEntry[];
+  onDeleteSession: (sessionId: string) => void;
+  onRestoreSession: (sessionId: string) => void;
+}) {
+  const [rows, setRows] = useState(initialRows);
+
+  return (
+    <ClosedSessionsTrigger
+      closedChatTabs={rows}
+      onRestoreSession={onRestoreSession}
+      onDeleteSession={(sessionId) => {
+        onDeleteSession(sessionId);
+        setRows((current) => current.filter((row) => row.id !== sessionId));
+      }}
+    />
+  );
+}
+
+function renderClosedSessions({
+  initialRows = CLOSED_SESSIONS,
+  onDeleteSession = vi.fn(),
+  onRestoreSession = vi.fn(),
+}: {
+  initialRows?: HeaderChatMenuEntry[];
+  onDeleteSession?: (sessionId: string) => void;
+  onRestoreSession?: (sessionId: string) => void;
+} = {}) {
+  return render(
+    <ClosedSessionsHarness
+      initialRows={initialRows}
+      onDeleteSession={onDeleteSession}
+      onRestoreSession={onRestoreSession}
+    />,
+  );
+}
+
+function openClosedSessions(count: number) {
+  fireEvent.click(screen.getByRole("button", { name: `Closed sessions (${count})` }));
+  expect(screen.getByRole("button", { name: "Session one" })).toBeTruthy();
+}
+
+function closedSession(id: string, title: string): HeaderChatMenuEntry {
+  return {
+    id,
+    title,
+    agentKind: "claude",
+    viewState: "idle",
+    isResolvingSession: false,
+    hasUnreadActivity: false,
+    isActive: false,
+    isVisible: false,
+    closedAt: null,
+  };
+}

--- a/apps/packages/product-client/src/components/workspace/shell/topbar/HeaderTabsActions.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/topbar/HeaderTabsActions.tsx
@@ -85,10 +85,7 @@ export function ClosedSessionsTrigger({
             onRestoreSession(sessionId);
             close();
           }}
-          onDeleteSession={(sessionId) => {
-            onDeleteSession(sessionId);
-            close();
-          }}
+          onDeleteSession={onDeleteSession}
         />
       )}
     </PopoverButton>


### PR DESCRIPTION
## Linear tickets

- [PRO-157 — Deleting session closes popover](https://linear.app/proliferate-team/issue/PRO-157/deleting-session-closes-popover)

## Summary

- Keep the closed-sessions history popover open when deleting a non-final session.
- Add a production-path DOM regression for delete, restore, Escape, outside interaction, and final-row behavior.

## Root cause

The trash button calls `ClosedSessionsTrigger.onDeleteSession`, whose wrapper started the asynchronous archive workflow and then unconditionally invoked the `PopoverButton` render-prop `close()`. That synchronous call set the locally controlled Radix `open` state to `false` before the archive could complete, removing the portalled content even when other closed sessions remained. Event propagation, row-key reconciliation, store rerenders, and focus restoration were not involved.

## Impact

Users can delete multiple closed sessions without reopening the history popover after every deletion. Restoring a session still closes the popover, Escape and outside interaction still dismiss it through Radix, and deleting the final row still removes the trigger naturally.

## Testing

Tier 1 rendered-component coverage using the real `ClosedSessionsTrigger -> PopoverButton/Popover -> ClosedChatTabsMenu` path:

- Fail-before proof on current main: 1 failed, 4 passed. Only the non-final delete case failed; the trigger changed to `data-state="closed"` and surviving rows disappeared.
- Pass-after proof: 5 passed.
- `pnpm --filter @proliferate/product-client typecheck`
- `pnpm --filter @proliferate/product-client build`
- Full ProductClient suite: 804 of 805 files passed, with 5,459 tests passed and 1 skipped. The remaining unrelated markdown-cascade suite requires branded Google Chrome, which is not installed in this environment.
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_design_attribution.py`
- `git diff --check`

## Observability

None. This changes local presentation-state behavior only and adds no failure path, external call, telemetry event, or identifier.

## Readiness

- [x] I followed the pull-request procedure for scope, title, labels, body, and readiness.

## Verification

- The regression uses stable session IDs, a stateful production-shaped row removal, and the real Radix portal instead of a mocked popover.
- The fix removes only the delete-specific `close()`; all intended dismissal paths remain pinned by tests.
