### PR TITLE
fix(product): restore sessions from the full closed row

### DIFF
--- a/apps/packages/product-client/src/components/workspace/shell/tabs/ClosedChatTabsMenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/tabs/ClosedChatTabsMenu.tsx
@@ -24,7 +24,16 @@ export function ClosedChatTabsMenu({
           <div
             key={row.id}
             data-telemetry-mask="true"
-            className={`group/row flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-hover active:bg-active ${row.isActive ? "bg-selected" : ""}`}
+            className={`group/row flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-hover active:bg-active ${row.isActive ? "bg-selected" : ""}`}
+            onClick={(event) => {
+              const targetButton = event.target instanceof Element
+                ? event.target.closest("button")
+                : null;
+              if (targetButton && event.currentTarget.contains(targetButton)) {
+                return;
+              }
+              onRestoreSession(row.id);
+            }}
           >
             <Button
               type="button"

--- a/apps/packages/product-client/src/components/workspace/shell/topbar/HeaderTabsActions.hit-target.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/topbar/HeaderTabsActions.hit-target.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ClosedSessionsTrigger } from "#product/components/workspace/shell/topbar/HeaderTabsActions";
+import type {
+  HeaderChatMenuEntry,
+} from "#product/lib/domain/workspaces/tabs/workspace-header-tabs-view-model-types";
+
+const closedSession: HeaderChatMenuEntry = {
+  id: "session-1",
+  title: "Session one",
+  agentKind: "claude",
+  viewState: "idle",
+  isResolvingSession: false,
+  hasUnreadActivity: false,
+  isActive: false,
+  isVisible: false,
+  closedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+};
+
+describe("ClosedSessionsTrigger row hit target", () => {
+  afterEach(cleanup);
+
+  it("restores exactly once from the title, row background, and timestamp", async () => {
+    const user = userEvent.setup();
+    const onRestoreSession = vi.fn();
+    const onDeleteSession = vi.fn();
+
+    render(
+      <ClosedSessionsTrigger
+        closedChatTabs={[closedSession]}
+        onRestoreSession={onRestoreSession}
+        onDeleteSession={onDeleteSession}
+      />,
+    );
+
+    await openClosedSessions(user);
+    await user.click(screen.getByRole("button", { name: "Session one" }));
+    expect(onRestoreSession).toHaveBeenCalledTimes(1);
+    expect(onRestoreSession).toHaveBeenLastCalledWith("session-1");
+    expect(onDeleteSession).not.toHaveBeenCalled();
+    await expectClosedSessionsToClose();
+
+    await openClosedSessions(user);
+    const row = screen.getByText("Session one").closest("[data-telemetry-mask='true']");
+    expect(row).not.toBeNull();
+    await user.click(row!);
+    expect(onRestoreSession).toHaveBeenCalledTimes(2);
+    expect(onRestoreSession).toHaveBeenLastCalledWith("session-1");
+    expect(onDeleteSession).not.toHaveBeenCalled();
+    await expectClosedSessionsToClose();
+
+    await openClosedSessions(user);
+    await user.click(screen.getByText("1h ago"));
+    expect(onRestoreSession).toHaveBeenCalledTimes(3);
+    expect(onRestoreSession).toHaveBeenLastCalledWith("session-1");
+    expect(onDeleteSession).not.toHaveBeenCalled();
+    await expectClosedSessionsToClose();
+  });
+
+  it("keeps Delete isolated from the row restore action", async () => {
+    const user = userEvent.setup();
+    const onRestoreSession = vi.fn();
+    const onDeleteSession = vi.fn();
+
+    render(
+      <ClosedSessionsTrigger
+        closedChatTabs={[closedSession]}
+        onRestoreSession={onRestoreSession}
+        onDeleteSession={onDeleteSession}
+      />,
+    );
+
+    await openClosedSessions(user);
+    await user.click(screen.getByRole("button", { name: "Delete Session one" }));
+
+    expect(onDeleteSession).toHaveBeenCalledOnce();
+    expect(onDeleteSession).toHaveBeenCalledWith("session-1");
+    expect(onRestoreSession).not.toHaveBeenCalled();
+    await expectClosedSessionsToClose();
+  });
+
+  it("retains native keyboard restore behavior on the title button", async () => {
+    const user = userEvent.setup();
+    const onRestoreSession = vi.fn();
+    const onDeleteSession = vi.fn();
+
+    render(
+      <ClosedSessionsTrigger
+        closedChatTabs={[closedSession]}
+        onRestoreSession={onRestoreSession}
+        onDeleteSession={onDeleteSession}
+      />,
+    );
+
+    await openClosedSessions(user);
+    screen.getByRole("button", { name: "Session one" }).focus();
+    await user.keyboard("{Enter}");
+
+    expect(onRestoreSession).toHaveBeenCalledOnce();
+    expect(onRestoreSession).toHaveBeenCalledWith("session-1");
+    expect(onDeleteSession).not.toHaveBeenCalled();
+    await expectClosedSessionsToClose();
+  });
+});
+
+async function openClosedSessions(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: "Closed sessions (1)" }));
+  await screen.findByText("Session one");
+}
+
+async function expectClosedSessionsToClose() {
+  await waitFor(() => {
+    expect(screen.queryByText("Session one")).toBeNull();
+  });
+}


### PR DESCRIPTION
## Linear tickets

- [PRO-156 — Only text in session dropdown is clickable](https://linear.app/proliferate-team/issue/PRO-156/only-text-in-session-dropdown-is-clickable)

## Summary

- Restore a closed session when any non-button part of its highlighted row is clicked, including padding, gaps, timestamp, and the trailing glyph.
- Ignore row-level bubbling from nested controls so the title restore, Delete, and explicit restore actions each fire exactly once.

## Testing

- `pnpm --filter @proliferate/product-client exec vitest run src/components/workspace/shell/topbar/HeaderTabsActions.hit-target.test.tsx` (3 passed)
- `pnpm --filter @proliferate/product-client typecheck`
- `pnpm --filter @proliferate/product-client build`
- Full package run: 5,457 passed and 1 skipped; the remaining Chrome-only stylesheet qualification could not launch because the local Google Chrome channel is not installed.
- Compatibility merge with the sibling restore-icon change: 4 focused integration tests passed.
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_appearance_scaling.py`
- `python3 scripts/check_design_attribution.py`
- `git diff --check`

## Observability

- None. This changes local pointer dispatch only.

## Readiness

- [x] I followed the pull-request procedure for scope, title, labels, body, and readiness.