### PR TITLE
fix(product): restore worktree identity in sidebar

### DIFF
--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { GitPullRequest } from "#product/primitives/icons/workspace-git";
 import { CircleAlert } from "#product/primitives/icons/status";
 import { Tooltip } from "#product/primitives/Tooltip";
@@ -9,15 +10,20 @@ import type {
 
 interface SidebarWorkspaceGitGlyphProps {
   status: WorkspaceGitStatus | null;
+  /** Workspace identity to use when there is no real pull request. */
+  fallbackIdentity?: ReactNode;
 }
 
 /**
  * Stable PR identity for the sidebar's trailing area. Every row keeps the PR
- * glyph in place: purple when a PR exists, dim when it does not or status is
- * unavailable. Git attention is a separate orange alert so it does not mutate
- * or replace the row's PR identity.
+ * glyph in place when a PR exists; callers may provide the workspace identity
+ * that replaces the dim no-PR glyph. Git attention stays a separate orange
+ * alert so falling back does not hide an actionable git condition.
  */
-export function SidebarWorkspaceGitGlyph({ status }: SidebarWorkspaceGitGlyphProps) {
+export function SidebarWorkspaceGitGlyph({
+  status,
+  fallbackIdentity = null,
+}: SidebarWorkspaceGitGlyphProps) {
   const hasPullRequest = Boolean(status?.pr && status.pr.state !== "none");
   const pullRequestLabel = hasPullRequest
     ? prStatusCompoundLabel(status) ?? "Pull request"
@@ -25,18 +31,25 @@ export function SidebarWorkspaceGitGlyph({ status }: SidebarWorkspaceGitGlyphPro
       ? "No pull request"
       : "Pull request status unavailable";
   const attentionLabel = gitAttentionLabel(status?.attention ?? "none");
+  const pullRequestIdentity = (
+    <Tooltip content={pullRequestLabel} className="inline-flex items-center justify-center">
+      <span role="img" aria-label={pullRequestLabel}>
+        <GitPullRequest
+          className={`icon-indicator [font-size:var(--text-sidebar-row)] ${hasPullRequest
+            ? "text-sidebar-status-worktree"
+            : "text-sidebar-muted-foreground/60"
+          }`}
+        />
+      </span>
+    </Tooltip>
+  );
+  const identity = hasPullRequest
+    ? pullRequestIdentity
+    : (fallbackIdentity ?? pullRequestIdentity);
+
   return (
     <span className="inline-flex shrink-0 items-center gap-1">
-      <Tooltip content={pullRequestLabel} className="inline-flex items-center justify-center">
-        <span role="img" aria-label={pullRequestLabel}>
-          <GitPullRequest
-            className={`icon-indicator [font-size:var(--text-sidebar-row)] ${hasPullRequest
-              ? "text-sidebar-status-worktree"
-              : "text-sidebar-muted-foreground/60"
-            }`}
-          />
-        </span>
-      </Tooltip>
+      {identity}
       {attentionLabel ? (
         <Tooltip content={attentionLabel} className="inline-flex items-center justify-center">
           <span role="img" aria-label={attentionLabel}>

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.test.tsx
@@ -147,7 +147,7 @@ describe("WorkspaceItem", () => {
     expect(cells?.children).toHaveLength(2);
   });
 
-  it("keeps a dim PR identity for an authoritative no-PR branch", () => {
+  it("falls back to worktree identity for an authoritative no-PR branch", () => {
     renderWithProductHost(
       <WorkspaceItem
         name="Feature worktree"
@@ -164,10 +164,11 @@ describe("WorkspaceItem", () => {
       />,
     );
 
-    expect(screen.getByRole("img", { name: "No pull request" })).toBeTruthy();
+    expect(screen.getByRole("img", { name: "Worktree" })).toBeTruthy();
+    expect(screen.queryByRole("img", { name: "No pull request" })).toBeNull();
   });
 
-  it("keeps a dim PR identity when PR data is unknown", () => {
+  it("falls back to worktree identity when PR data is unknown", () => {
     renderWithProductHost(
       <WorkspaceItem
         name="Feature worktree"
@@ -176,7 +177,39 @@ describe("WorkspaceItem", () => {
       />,
     );
 
-    expect(screen.getByRole("img", { name: "Pull request status unavailable" })).toBeTruthy();
+    expect(screen.getByRole("img", { name: "Worktree" })).toBeTruthy();
+    expect(screen.queryByRole("img", { name: "Pull request status unavailable" })).toBeNull();
+  });
+
+  it("shows worktree identity before git status loads", () => {
+    renderWithProductHost(
+      <WorkspaceItem name="Pending worktree" variant="worktree" />,
+    );
+
+    expect(screen.getByRole("img", { name: "Worktree" })).toBeTruthy();
+    expect(screen.queryByRole("img", { name: "Pull request status unavailable" })).toBeNull();
+  });
+
+  it("keeps git attention beside the worktree fallback when there is no PR", () => {
+    renderWithProductHost(
+      <WorkspaceItem
+        name="Conflicted worktree"
+        variant="worktree"
+        gitStatus={makeGitStatus({
+          pr: {
+            state: "none",
+            number: null,
+            url: null,
+            checks: "none",
+            reviewDecision: "none",
+          },
+          attention: "conflicts",
+        })}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "Worktree" })).toBeTruthy();
+    expect(screen.getByRole("img", { name: "Merge conflicts in worktree" })).toBeTruthy();
   });
 
   it("keeps the PR identity in place for cloud workspaces", () => {

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
@@ -7,12 +7,14 @@ import {
 } from "#product/primitives/icons/core";
 import { Folder } from "#product/primitives/icons/workspace";
 import {
+  GitBranch,
   GitBranchIcon,
   GitPullRequest,
 } from "#product/primitives/icons/workspace-git";
 import { POPOVER_SURFACE_CLASS, PopoverButton } from "#product/primitives/PopoverButton";
 import { PopoverMenuItem } from "#product/primitives/PopoverMenuItem";
 import { ShortcutBadge } from "#product/primitives/ShortcutBadge";
+import { Tooltip } from "#product/primitives/Tooltip";
 import { useWorkspaceSidebarNativeContextMenu } from "#product/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu";
 import { getShortcutDisplayLabel } from "#product/lib/domain/shortcuts/matching";
 import type {
@@ -59,8 +61,9 @@ interface WorkspaceItemProps {
   /** Current git branch, shown read-only in the three-dot menu git section. */
   branchName?: string | null;
   /**
-   * Composed git/PR status. Drives the persistent PR glyph tone, its tooltip,
-   * the separate attention alert, and the "Open pull request" menu item.
+   * Composed git/PR status. A real PR owns the identity glyph; otherwise a
+   * worktree keeps its workspace identity. Git attention remains separate,
+   * and the PR URL drives the "Open pull request" menu item.
    */
   gitStatus?: WorkspaceGitStatus | null;
   /** Renders the trailing unseen-activity dot. */
@@ -125,7 +128,12 @@ export function WorkspaceItem({
   const handleArchiveCommand = () => onArchive?.();
   const handleUnarchiveCommand = () => onUnarchive?.();
   const handleMarkDoneCommand = () => setDoneConfirmOpen(true);
-  const trailingIdentity = <SidebarWorkspaceGitGlyph status={gitStatus} />;
+  const trailingIdentity = (
+    <SidebarWorkspaceGitGlyph
+      status={gitStatus}
+      fallbackIdentity={worktreeIdentity(variant)}
+    />
+  );
   const pullRequestUrl = gitStatus?.pr?.url ?? null;
   const pullRequestNumber = gitStatus?.pr?.number ?? null;
   const handleOpenPullRequestCommand = pullRequestUrl && onOpenPullRequest
@@ -371,5 +379,22 @@ export function WorkspaceItem({
       }}
       trigger={<div>{contextMenu}</div>}
     />
+  );
+}
+
+function worktreeIdentity(variant: SidebarWorkspaceVariant) {
+  if (variant !== "worktree") {
+    return null;
+  }
+
+  return (
+    <Tooltip content="Worktree" className="inline-flex shrink-0 items-center justify-center">
+      <span role="img" aria-label="Worktree">
+        <GitBranch
+          className="icon-indicator text-sidebar-status-worktree [font-size:var(--text-sidebar-row)]"
+          strokeWidth={1.75}
+        />
+      </span>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
## Linear tickets

- [PRO-124 — Worktree indicator doesn't show up in sidebar](https://linear.app/proliferate-team/issue/PRO-124/worktree-indicator-doesnt-show-up-in-sidebar)

## Summary

- restore the worktree identity glyph when a sidebar row has no real pull request
- keep real pull requests authoritative while preserving separate git-attention alerts
- pin authoritative no-PR, unknown-PR, unloaded-status, and conflicted-worktree behavior at the production row seam

## Root cause

The sidebar projection preserved the runtime workspace kind as `worktree`, but `WorkspaceItem` unconditionally replaced that identity with `SidebarWorkspaceGitGlyph`. That glyph emits a dim pull-request icon for both absent and unknown PR data, so the correctly projected worktree variant never reached the rendered identity cell. The fix supplies the worktree glyph as the no-PR fallback while leaving real-PR precedence and alert rendering unchanged.

## Testing

- Red proof: the focused workspace-row suite failed exactly the authoritative no-PR and unknown-PR cases while the rendered DOM still carried `data-sidebar-workspace-variant="worktree"`
- Green proof: 83 focused sidebar/domain tests passed
- `pnpm --filter @proliferate/product-client build`
- ProductClient suite: 803 files and 5,455 tests passed; the single remaining suite requires branded Google Chrome, which is not installed locally
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_appearance_scaling.py`
- `python3 scripts/check_design_attribution.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`

## Observability

- none; this changes presentation selection only and adds no failure path or telemetry surface

## Readiness

- [x] I followed the pull-request procedure for scope, title, labels, body, and readiness.

## Verification

- real PR identity still wins over the worktree fallback
- git attention remains visible beside a fallback identity
- modifier-key shortcut overlays retain the existing hide-and-restore geometry