### PR TITLE
fix(product): scope workspace creation receipts to their session

### DIFF
--- a/apps/packages/product-client/src/hooks/workspaces/derived/use-workspace-creation-receipt.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/derived/use-workspace-creation-receipt.test.tsx
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Session, Workspace } from "@anyharness/sdk";
+import {
+  AnyHarnessRuntime,
+  AnyHarnessWorkspace,
+  anyHarnessSessionsKey,
+} from "@anyharness/sdk-react";
+import { buildWorkspaceArrivalEvent } from "#product/lib/domain/workspaces/creation/arrival";
+import {
+  createEmptySessionRecord,
+  patchSessionRecord,
+  putSessionRecord,
+} from "#product/stores/sessions/session-records";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+import { useWorkspaceCreationReceiptKey } from "#product/hooks/workspaces/derived/use-workspace-creation-receipt";
+
+const WORKSPACE_ID = "workspace-1";
+const CACHE_SCOPE_KEY = "runtime:test";
+const FIRST_CLIENT_SESSION_ID = "client-session:first";
+const FIRST_RUNTIME_SESSION_ID = "runtime-session:first";
+const SECOND_CLIENT_SESSION_ID = "client-session:second";
+const SECOND_RUNTIME_SESSION_ID = "runtime-session:second";
+
+const mocks = vi.hoisted(() => ({
+  workspace: null as Workspace | null,
+}));
+
+vi.mock("#product/hooks/workspaces/cache/use-workspaces", () => ({
+  useWorkspaces: () => ({
+    data: mocks.workspace
+      ? {
+        workspaces: [mocks.workspace],
+        repoRoots: [],
+      }
+      : undefined,
+  }),
+}));
+
+describe("useWorkspaceCreationReceiptKey", () => {
+  beforeEach(() => {
+    mocks.workspace = makeWorkspace();
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+    useSessionSelectionStore.setState({
+      pendingWorkspaceEntry: null,
+      selectedLogicalWorkspaceId: WORKSPACE_ID,
+      selectedWorkspaceId: WORKSPACE_ID,
+      workspaceSelectionNonce: 1,
+      workspaceArrivalEvent: buildWorkspaceArrivalEvent({
+        workspaceId: WORKSPACE_ID,
+        source: "worktree-created",
+        receiptClientSessionId: FIRST_CLIENT_SESSION_ID,
+      }),
+      workspaceSessionRecovery: null,
+      activeSessionId: FIRST_CLIENT_SESSION_ID,
+      activeSessionVersion: 1,
+      sessionActivationIntentEpochByWorkspace: {},
+      hotPaintGate: null,
+    });
+    putSessionRecord(createEmptySessionRecord(FIRST_CLIENT_SESSION_ID, "codex", {
+      workspaceId: WORKSPACE_ID,
+      materializedSessionId: FIRST_RUNTIME_SESSION_ID,
+    }));
+    putSessionRecord(createEmptySessionRecord(SECOND_CLIENT_SESSION_ID, "codex", {
+      workspaceId: WORKSPACE_ID,
+      materializedSessionId: SECOND_RUNTIME_SESSION_ID,
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    mocks.workspace = null;
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+  });
+
+  it("keeps a live worktree receipt on its first session when switching tabs", () => {
+    const queryClient = createQueryClient([
+      // AnyHarness lists by updatedAt descending. Creation ownership must use
+      // createdAt instead of trusting this transport order.
+      makeSession({
+        id: SECOND_RUNTIME_SESSION_ID,
+        createdAt: "2026-08-11T12:01:00.000Z",
+        updatedAt: "2026-08-11T12:03:00.000Z",
+      }),
+      makeSession({
+        id: FIRST_RUNTIME_SESSION_ID,
+        createdAt: "2026-08-11T12:00:00.000Z",
+        updatedAt: "2026-08-11T12:02:00.000Z",
+      }),
+    ]);
+    const { result } = renderReceiptKey(queryClient);
+
+    expect(result.current).toBe(WORKSPACE_ID);
+
+    act(() => {
+      useSessionSelectionStore.getState().activateHotSession({
+        sessionId: SECOND_CLIENT_SESSION_ID,
+      });
+    });
+
+    expect(result.current).toBeNull();
+    expect(useSessionSelectionStore.getState().workspaceArrivalEvent?.workspaceId)
+      .toBe(WORKSPACE_ID);
+
+    act(() => {
+      useSessionSelectionStore.getState().activateHotSession({
+        sessionId: FIRST_CLIENT_SESSION_ID,
+      });
+    });
+
+    expect(result.current).toBe(WORKSPACE_ID);
+  });
+
+  it("bridges only the owning projected session until server identity arrives", () => {
+    patchSessionRecord(FIRST_CLIENT_SESSION_ID, { materializedSessionId: null });
+    useSessionSelectionStore.setState({
+      hotPaintGate: {
+        workspaceId: WORKSPACE_ID,
+        sessionId: FIRST_CLIENT_SESSION_ID,
+        nonce: 1,
+        operationId: null,
+        kind: "workspace_hot_reopen",
+      },
+    });
+    const queryClient = createQueryClient();
+    const { result } = renderReceiptKey(queryClient);
+
+    // The owner alias is available before the runtime session and its list
+    // query exist, so the pending receipt never flashes back to Thinking.
+    expect(result.current).toBe(WORKSPACE_ID);
+
+    act(() => {
+      useSessionSelectionStore.getState().activateHotSession({
+        sessionId: SECOND_CLIENT_SESSION_ID,
+      });
+    });
+    expect(result.current).toBeNull();
+
+    act(() => {
+      useSessionSelectionStore.getState().activateHotSession({
+        sessionId: FIRST_CLIENT_SESSION_ID,
+      });
+    });
+    expect(result.current).toBe(WORKSPACE_ID);
+
+    act(() => {
+      patchSessionRecord(FIRST_CLIENT_SESSION_ID, {
+        materializedSessionId: FIRST_RUNTIME_SESSION_ID,
+      });
+      queryClient.setQueryData(
+        anyHarnessSessionsKey(CACHE_SCOPE_KEY, WORKSPACE_ID),
+        [makeSession({
+          id: FIRST_RUNTIME_SESSION_ID,
+          createdAt: "2026-08-11T12:00:00.000Z",
+          updatedAt: "2026-08-11T12:02:00.000Z",
+        })],
+      );
+      useSessionSelectionStore.setState({ hotPaintGate: null });
+    });
+
+    expect(result.current).toBe(WORKSPACE_ID);
+  });
+});
+
+function createQueryClient(sessions?: Session[]): QueryClient {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Number.POSITIVE_INFINITY,
+      },
+    },
+  });
+  if (sessions) {
+    queryClient.setQueryData(
+      anyHarnessSessionsKey(CACHE_SCOPE_KEY, WORKSPACE_ID),
+      sessions,
+    );
+  }
+  return queryClient;
+}
+
+function renderReceiptKey(queryClient: QueryClient) {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <AnyHarnessRuntime
+        runtimeUrl="http://runtime.test"
+        cacheScopeKey={CACHE_SCOPE_KEY}
+      >
+        <AnyHarnessWorkspace
+          workspaceId={WORKSPACE_ID}
+          resolveConnection={async () => ({
+            runtimeUrl: "http://runtime.test",
+            anyharnessWorkspaceId: WORKSPACE_ID,
+          })}
+        >
+          {children}
+        </AnyHarnessWorkspace>
+      </AnyHarnessRuntime>
+    </QueryClientProvider>
+  );
+  return renderHook(() => useWorkspaceCreationReceiptKey(), { wrapper });
+}
+
+function makeWorkspace(): Workspace {
+  return {
+    availability: "available",
+    cleanupState: "none",
+    createdAt: "2026-08-11T11:59:00.000Z",
+    id: WORKSPACE_ID,
+    kind: "worktree",
+    lifecycleState: "active",
+    path: "/repo/worktrees/feature",
+    repoRootId: "repo-root-1",
+    surface: "standard",
+    updatedAt: "2026-08-11T12:00:00.000Z",
+  };
+}
+
+function makeSession(overrides: Pick<Session, "id" | "createdAt" | "updatedAt">): Session {
+  return {
+    actionCapabilities: { fork: false, targetedFork: false },
+    agentKind: "codex",
+    status: "idle",
+    workspaceId: WORKSPACE_ID,
+    ...overrides,
+  };
+}

--- a/apps/packages/product-client/src/hooks/workspaces/derived/use-workspace-creation-receipt.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/derived/use-workspace-creation-receipt.ts
@@ -96,15 +96,16 @@ export function useWorkspaceCreationReceiptKey(): string | null {
     if (!workspace) {
       return null;
     }
-    // Live-arrival bridge: the arrival event is published in the same flow
-    // that clears the pending entry, so its presence means this very
-    // selection just performed the creation — definitionally the workspace's
-    // first session. Skipping the query-backed proof below keeps the receipt
-    // mounted across the creating→created handoff; without it the key goes
-    // null for a round trip and the pending row flashes back to "Thinking".
+    // Live-arrival bridge: finalization records the stable ProductClient alias
+    // that owned the pending creation. That owner can keep the receipt mounted
+    // before its runtime session and the query-backed proof below exist,
+    // avoiding a creating→Thinking→created flash without leaking the synthetic
+    // row into sibling sessions in the same workspace.
     if (
       workspaceArrivalEvent?.workspaceId === workspace.id
       && (workspace.kind === "worktree" || workspaceArrivalEvent.source === "local-created")
+      && workspaceArrivalEvent.receiptClientSessionId !== null
+      && workspaceArrivalEvent.receiptClientSessionId === activeSessionId
     ) {
       return workspaceUiKey;
     }
@@ -131,6 +132,7 @@ export function useWorkspaceCreationReceiptKey(): string | null {
     }
     return null;
   }, [
+    activeSessionId,
     activeMaterializedSessionId,
     materializedWorkspaceId,
     pendingWorkspaceEntry,

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-pending-workspace-entry-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-pending-workspace-entry-actions.ts
@@ -120,6 +120,7 @@ export function usePendingWorkspaceEntryActions() {
             setWorkspaceArrivalEvent(buildWorkspaceArrivalEvent({
               workspaceId: entry.request.workspaceId,
               source: current.source,
+              receiptClientSessionId: initialActiveSessionId,
               setupScript: current.setupScript,
               baseBranchName: current.baseBranchName,
             }));

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-entry-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-entry-actions.test.tsx
@@ -251,6 +251,11 @@ describe("useWorkspaceEntryActions", () => {
     });
     unsubscribe();
     expect(useSessionSelectionStore.getState().pendingWorkspaceEntry).toBeNull();
+    expect(useSessionSelectionStore.getState().workspaceArrivalEvent).toMatchObject({
+      workspaceId: "workspace-created",
+      source: "worktree-created",
+      receiptClientSessionId: projectedSessionId,
+    });
     expect(useWorkspaceUiStore.getState().workspaceLastInteracted["workspace-created"])
       .toEqual(expect.any(String));
     expect(pendingEntryAtInteraction).toMatchObject({

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-entry-flow.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-entry-flow.ts
@@ -187,6 +187,7 @@ export function useWorkspaceEntryFlow() {
     setWorkspaceArrivalEvent(buildWorkspaceArrivalEvent({
       workspaceId,
       source: entry.source,
+      receiptClientSessionId: projectedActiveSessionId,
       setupScript: entry.setupScript,
       baseBranchName: entry.baseBranchName,
     }));

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/workspace-entry-finalization.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/workspace-entry-finalization.ts
@@ -106,6 +106,7 @@ export async function finalizePendingWorkspaceSelection(
   deps.setWorkspaceArrivalEvent(buildWorkspaceArrivalEvent({
     workspaceId: input.workspaceId,
     source: input.entry.source,
+    receiptClientSessionId: projectedActiveSessionId,
     setupScript: input.entry.setupScript,
     baseBranchName: input.entry.baseBranchName,
   }));

--- a/apps/packages/product-client/src/lib/domain/chat/submit/workspace-setup-activity.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/submit/workspace-setup-activity.test.ts
@@ -8,6 +8,7 @@ function arrival(
   return {
     workspaceId: "workspace-1",
     source: "local-created",
+    receiptClientSessionId: null,
     setupScript: null,
     createdAt: 1,
     ...overrides,

--- a/apps/packages/product-client/src/lib/domain/workspaces/creation/arrival.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/creation/arrival.ts
@@ -3,6 +3,12 @@ import type { SetupScriptExecution } from "@anyharness/sdk";
 export interface WorkspaceArrivalEvent {
   workspaceId: string;
   source: "local-created" | "worktree-created" | "cloud-created" | "cowork-created";
+  /**
+   * Stable ProductClient alias for the session created with this workspace.
+   * The arrival itself is workspace-scoped; only the synthetic transcript
+   * receipt uses this owner to bridge the pre-materialization query gap.
+   */
+  receiptClientSessionId: string | null;
   setupScript?: SetupScriptExecution | null;
   baseBranchName?: string | null;
   createdAt: number;
@@ -21,12 +27,14 @@ export function summarizeSetupFailure(setup: SetupScriptExecution): string {
 export function buildWorkspaceArrivalEvent(input: {
   workspaceId: string;
   source: WorkspaceArrivalEvent["source"];
+  receiptClientSessionId?: string | null;
   setupScript?: SetupScriptExecution | null;
   baseBranchName?: string | null;
 }): WorkspaceArrivalEvent {
   return {
     workspaceId: input.workspaceId,
     source: input.source,
+    receiptClientSessionId: input.receiptClientSessionId ?? null,
     setupScript: input.setupScript ?? null,
     baseBranchName: input.baseBranchName ?? null,
     createdAt: Date.now(),

--- a/apps/packages/product-client/src/lib/workflows/chat/complete-chat-prompt-submit-side-effects.test.ts
+++ b/apps/packages/product-client/src/lib/workflows/chat/complete-chat-prompt-submit-side-effects.test.ts
@@ -8,6 +8,7 @@ function arrival(
   return {
     workspaceId: "workspace-1",
     source: "local-created",
+    receiptClientSessionId: null,
     setupScript: null,
     createdAt: 1,
     ...overrides,

--- a/apps/packages/product-client/src/stores/sessions/session-selection-store.test.ts
+++ b/apps/packages/product-client/src/stores/sessions/session-selection-store.test.ts
@@ -73,6 +73,7 @@ describe("session selection store invariants", () => {
       workspaceArrivalEvent: {
         workspaceId: "workspace-a",
         source: "local-created",
+        receiptClientSessionId: "session-old",
         createdAt: 100,
       },
       activeSessionId: "session-old",
@@ -103,6 +104,7 @@ describe("session selection store invariants", () => {
       workspaceArrivalEvent: {
         workspaceId: "workspace-a",
         source: "local-created",
+        receiptClientSessionId: "session-old",
         createdAt: 100,
       },
       activeSessionId: "session-a",
@@ -120,6 +122,7 @@ describe("session selection store invariants", () => {
       workspaceArrivalEvent: {
         workspaceId: "workspace-a",
         source: "local-created",
+        receiptClientSessionId: "session-a",
         createdAt: 100,
       },
       activeSessionId: "session-a",

--- a/specs/codebase/systems/product/chat/composer.md
+++ b/specs/codebase/systems/product/chat/composer.md
@@ -522,6 +522,18 @@ echoes it back as a `plan_reference` content part.
 
 `deriveActiveTodoTracker` reads `plan` items straight off the transcript (latest in-progress item with entries, any `sourceAgentKind`) instead of `deriveCanonicalPlan`. The SDK's canonical derivation excludes Claude's `TodoWrite` because the *formal plan UI* treats it as internal bookkeeping — but internal task tracking is exactly what the progress pill surfaces, so the tracker deliberately bypasses that gate. Keep the two derivations separate: the SDK exclusion still governs the formal plan surfaces, and the pill-side derivation must not feed them.
 
+### 3.5 Workspace-creation receipts belong to one session
+
+The local/worktree creation receipt is a synthetic transcript projection, not
+a persisted session event. Its settled row belongs only to the session created
+with the workspace. During the pending-to-materialized handoff, the workspace
+arrival event carries that ProductClient session alias so the row stays mounted
+without waiting for the session-list query. After materialization or reload,
+the earliest server `createdAt` session (ID tie-break) is authoritative. The
+arrival event remains workspace-scoped for setup and arrival lifecycle state;
+switching session tabs must not clear it or project its receipt into another
+session.
+
 ## 4. Visual rules (minimalist pattern)
 
 These are the calls that get broken most easily.


### PR DESCRIPTION
## Linear tickets

- [PRO-123 — Workspace created shows up for every single session in worktree even when it isn't the one that 'created' worktree](https://linear.app/proliferate-team/issue/PRO-123/workspace-created-shows-up-for-every-single-session-in-worktree-even)

## Summary

- Scope the synthetic workspace-creation transcript receipt to the ProductClient session alias that owned the creation flow.
- Preserve the workspace-wide arrival event for setup lifecycle consumers while preventing sibling session tabs from receiving the receipt.
- Keep the server session list authoritative after materialization or reload, using earliest `createdAt` with the existing ID tie-break.

## Testing

- Tier 1 regression coverage uses the real QueryClient, AnyHarness runtime/workspace providers, production session directory/selection stores, production session query key, and production first-session ordering logic.
- `fnm exec --using=v22.21.1 -- pnpm --filter @proliferate/product-client build`
- `fnm exec --using=v22.21.1 -- pnpm --filter @proliferate/product-client typecheck`
- `fnm exec --using=v22.21.1 -- pnpm --filter @proliferate/product-client exec vitest run --exclude src/app/authenticated-markdown-cascade.test.ts` (804 files, 5,456 tests)
- `python3 scripts/check_docs.py`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `python3 scripts/check_design_attribution.py`

## Observability

- None. This is a deterministic projection/ownership correction with no new runtime failure mode or external dependency.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] The support relationship is linked through the tracker API. No tracker, report, user, or support IDs or private source data appear in this PR.

## Verification

- Before the fix, the new session-switch regression failed because the sibling session received the workspace receipt key.
- After the fix, the same regression passes across both a populated server-session cache and the projected-to-materialized identity handoff.
- The repository-wide ProductClient test command reaches 804 passing files and 5,456 passing tests; its remaining browser fixture cannot launch because this machine does not have the hard-coded Google Chrome application path. The full non-browser lane above passes.