### PR TITLE
fix(product): open workspace creation flow

### DIFF
--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-sidebar-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-sidebar-actions.ts
@@ -66,6 +66,16 @@ export function useWorkspaceSidebarActions() {
     focusNewChatComposer();
   }, [focusNewChatComposer, goToTopLevelRoute, patchTargetSelection]);
 
+  const handleStartWorktreeWorkspaceCreation = useCallback(() => {
+    patchTargetSelection({
+      destination: "repository",
+      repoLaunchKind: "worktree",
+      selectedSshTargetId: null,
+    });
+    goToTopLevelRoute(APP_ROUTES.home);
+    focusNewChatComposer();
+  }, [focusNewChatComposer, goToTopLevelRoute, patchTargetSelection]);
+
   const handleGoWorkflows = useCallback(() => {
     goToTopLevelRoute(APP_ROUTES.workflows);
   }, [goToTopLevelRoute]);
@@ -230,6 +240,7 @@ export function useWorkspaceSidebarActions() {
     handleAddRepo,
     handleGoHome,
     handleGoHomeForRepository,
+    handleStartWorktreeWorkspaceCreation,
     handleGoWorkflows,
     handleGoWorkspaces,
     handleSidebarIndicatorAction,

--- a/apps/packages/product-client/src/pages/WorkspacesPage.test.tsx
+++ b/apps/packages/product-client/src/pages/WorkspacesPage.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import type { AppCommandActions } from "#product/hooks/app/workflows/app-command-action-types";
+import { WorkspacesPage } from "#product/pages/WorkspacesPage";
+import { AppCommandActionsProvider } from "#product/providers/AppCommandActionsProvider";
+import {
+  readHomeNextTargetSelectionState,
+  resetHomeNextTargetSelectionForTests,
+} from "#product/hooks/home/ui/use-home-next-target-selection-state";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+
+const mocks = vi.hoisted(() => ({
+  createCloudWorkspaceAndEnter: vi.fn(),
+  createLocalWorkspaceAndEnter: vi.fn(),
+  createWorktreeAndEnter: vi.fn(),
+  openWorkspaceSession: vi.fn(),
+  retireWorkspace: vi.fn(),
+  retryCleanup: vi.fn(),
+  selectWorkspace: vi.fn(),
+  newWorktreeCommand: vi.fn(),
+}));
+
+vi.mock("@proliferate/cloud-sdk-react", () => ({
+  useRepositories: () => ({ data: { repositories: [] } }),
+}));
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => ({
+    desktop: {},
+    links: { openExternal: vi.fn() },
+  }),
+}));
+
+vi.mock("#product/components/workspace/shell/screen/MainSidebarPageShell", () => ({
+  MainSidebarPageShell: ({ children }: { children: ReactNode }) => <main>{children}</main>,
+}));
+
+vi.mock("#product/hooks/cloud/derived/use-cloud-availability-state", () => ({
+  useCloudAvailabilityState: () => ({ cloudActive: false }),
+}));
+
+vi.mock("#product/hooks/cloud/workflows/use-create-cloud-workspace", () => ({
+  useCreateCloudWorkspace: () => ({
+    createCloudWorkspaceAndEnter: mocks.createCloudWorkspaceAndEnter,
+    isCreatingCloudWorkspace: false,
+  }),
+}));
+
+vi.mock("#product/hooks/capabilities/derived/use-web-app-target", () => ({
+  useWebAppTarget: () => ({ available: false, baseUrl: null }),
+}));
+
+vi.mock("#product/hooks/workspaces/derived/use-logical-workspaces", () => ({
+  useLogicalWorkspaces: () => ({ logicalWorkspaces: [] }),
+}));
+
+vi.mock("#product/hooks/workspaces/derived/use-workspace-git-statuses", () => ({
+  useWorkspaceGitStatuses: () => ({ syncByLogicalId: {} }),
+}));
+
+vi.mock("#product/hooks/workspaces/derived/use-workspace-sidebar-state", () => ({
+  useWorkspaceSidebarState: () => ({ groups: [] }),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/selection/use-workspace-selection", () => ({
+  useWorkspaceSelection: () => ({ selectWorkspace: mocks.selectWorkspace }),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/use-workspace-activation-workflow", () => ({
+  useWorkspaceActivationWorkflow: () => ({ openWorkspaceSession: mocks.openWorkspaceSession }),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/use-workspace-entry-actions", () => ({
+  useWorkspaceEntryActions: () => ({
+    createLocalWorkspaceAndEnter: mocks.createLocalWorkspaceAndEnter,
+    createWorktreeAndEnter: mocks.createWorktreeAndEnter,
+    isCreatingWorktreeWorkspace: false,
+  }),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/use-workspace-retire-actions", () => ({
+  useWorkspaceRetireActions: () => ({
+    markDone: mocks.retireWorkspace,
+    retryCleanup: mocks.retryCleanup,
+  }),
+}));
+
+function action(execute = vi.fn()): AppCommandActions["goHome"] {
+  return { execute, disabledReason: null };
+}
+
+function appCommands(): AppCommandActions {
+  return {
+    openSettings: action(),
+    showKeyboardShortcuts: action(),
+    goHome: action(),
+    goWorkflows: action(),
+    openWebApp: action(),
+    openSupport: action(),
+    addRepository: action(),
+    newLocalWorkspace: action(),
+    newWorktreeWorkspace: action(mocks.newWorktreeCommand),
+    newCloudWorkspace: action(),
+    copyWorkspacePath: action(),
+    copyBranchName: action(),
+  };
+}
+
+beforeAll(() => {
+  // cmdk keeps its active item visible; jsdom has no layout implementation.
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetHomeNextTargetSelectionForTests();
+  useSessionSelectionStore.getState().clearSelection();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("WorkspacesPage creation", () => {
+  it("enters Home's repository worktree flow before creating a workspace", async () => {
+    render(
+      <MemoryRouter initialEntries={["/workspaces"]}>
+        <AppCommandActionsProvider value={appCommands()}>
+          <Routes>
+            <Route path="/workspaces" element={<WorkspacesPage />} />
+            <Route path="/" element={<p>Home repository launch</p>} />
+          </Routes>
+        </AppCommandActionsProvider>
+      </MemoryRouter>,
+    );
+
+    expect(readHomeNextTargetSelectionState()).toMatchObject({
+      destination: "cowork",
+      repoLaunchKind: "worktree",
+    });
+
+    fireEvent.click(screen.getByText("Create"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Home repository launch")).toBeTruthy();
+    });
+    expect(readHomeNextTargetSelectionState()).toMatchObject({
+      destination: "repository",
+      repoLaunchKind: "worktree",
+    });
+    expect(mocks.createWorktreeAndEnter).not.toHaveBeenCalled();
+    expect(mocks.newWorktreeCommand).not.toHaveBeenCalled();
+  });
+});

--- a/apps/packages/product-client/src/pages/WorkspacesPage.tsx
+++ b/apps/packages/product-client/src/pages/WorkspacesPage.tsx
@@ -12,7 +12,6 @@ import { useCloudAvailabilityState } from "#product/hooks/cloud/derived/use-clou
 import { useWorkspaceGitStatuses } from "#product/hooks/workspaces/derived/use-workspace-git-statuses";
 import { useWorkspaceSidebarState } from "#product/hooks/workspaces/derived/use-workspace-sidebar-state";
 import { useWorkspaceSidebarActions } from "#product/hooks/workspaces/workflows/use-workspace-sidebar-actions";
-import { useAppCommandActionsContext } from "#product/providers/AppCommandActionsProvider";
 import { getShortcutDisplayLabel } from "#product/lib/domain/shortcuts/matching";
 import { formatSidebarRelativeTime } from "#product/lib/domain/workspaces/display/workspace-display";
 import {
@@ -36,7 +35,6 @@ const PR_STATUS_UNAVAILABLE_LABEL = "PR status unavailable — gh not signed in"
  */
 export function WorkspacesPage() {
   const actions = useWorkspaceSidebarActions();
-  const appCommands = useAppCommandActionsContext();
   const { cloudActive } = useCloudAvailabilityState();
   const { data: repoConfigs } = useRepositories(cloudActive);
   const { groups } = useWorkspaceSidebarState({
@@ -81,7 +79,7 @@ export function WorkspacesPage() {
             </Tooltip>
           ) : null}
           onWorkspaceSelect={actions.handleSelectWorkspace}
-          onCreate={() => appCommands.newWorktreeWorkspace.execute("palette")}
+          onCreate={actions.handleStartWorktreeWorkspaceCreation}
           createShortcutLabel={getShortcutDisplayLabel(SHORTCUTS.newWorktree)}
         />
       </div>


### PR DESCRIPTION
## Linear tickets

- [PRO-118 — Create Workspcaes button in Workspaces does not work](https://linear.app/proliferate-team/issue/PRO-118/create-workspcaes-button-in-workspaces-does-not-work)

## Summary

- route the Workspaces overview Create row into Home's repository worktree launch flow
- preserve the canonical repository, branch, host, authentication, and readiness gates
- add a route-level cmdk regression test

## Root cause

Entering the top-level Workspaces overview intentionally clears selected workspace state. The Create row still invoked a repository-scoped worktree command, so target resolution disabled it. Because the invocation was marked as a palette action, that disabled branch returned without showing the reason, leaving the visible row as a silent no-op.

## Impact

Create now opens Home in repository/worktree mode instead of silently doing nothing. No workspace is created until the user selects and confirms the target through the canonical launch flow.

## Validation

- `pnpm --dir apps/packages/product-client exec vitest run src/pages/WorkspacesPage.test.tsx src/components/workspace/repo-setup/WorkspacesCommandList.test.tsx src/hooks/workspaces/workflows/use-workspace-navigation-workflow.test.tsx --reporter=verbose`
- `pnpm --filter @proliferate/product-client build`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `git diff --check`

## Testing and observability

Tier 1 route integration covers the real cmdk click through target-state and route transition. No telemetry or observability changes are needed; this restores an existing UI action.

## Tracker

The originating tracker issue links this draft PR.