### PR TITLE
fix(product): restore hot reopened session identity

### DIFF
--- a/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WORKSPACE_UI_DEFAULTS } from "#product/lib/domain/preferences/workspace-ui/model";
+import type { LogicalWorkspace } from "#product/lib/domain/workspaces/cloud/logical-workspace-model";
+import { resolveWorkspaceShellActivation } from "#product/lib/domain/workspaces/tabs/shell-activation";
+import { chatWorkspaceShellTabKey } from "#product/lib/domain/workspaces/tabs/shell-tabs";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 import {
   createEmptySessionRecord,
@@ -20,6 +24,10 @@ vi.mock("./connection", () => ({
   resolveSelectionConnection: vi.fn(),
 }));
 
+vi.mock("./run-workspace-selection", () => ({
+  runWorkspaceSelection: vi.fn(),
+}));
+
 describe("runHotWorkspaceReopen", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -32,9 +40,11 @@ describe("runHotWorkspaceReopen", () => {
       },
     });
     useSessionSelectionStore.setState({
+      selectedLogicalWorkspaceId: null,
       selectedWorkspaceId: null,
       workspaceSelectionNonce: 0,
       activeSessionId: null,
+      sessionActivationIntentEpochByWorkspace: {},
       hotPaintGate: null,
       pendingWorkspaceEntry: null,
       workspaceArrivalEvent: null,
@@ -48,6 +58,8 @@ describe("runHotWorkspaceReopen", () => {
       transcriptHydrated: true,
     });
     useWorkspaceUiStore.setState({
+      ...WORKSPACE_UI_DEFAULTS,
+      _hydrated: true,
       lastViewedSessionByWorkspace: {
         "workspace-1": "session-1",
       },
@@ -113,9 +125,86 @@ describe("runHotWorkspaceReopen", () => {
     expect(deps.reconcileHotWorkspace).not.toHaveBeenCalled();
     expect(useSessionSelectionStore.getState().selectedWorkspaceId).toBe("workspace-2");
   });
+
+  it("reopens the client slot behind a durable last-viewed id without blanking the shell", () => {
+    const clientSessionA = "client-session:codex:older";
+    const clientSessionB = "client-session:codex:new-empty";
+    const runtimeSessionB = "runtime-session-new-empty";
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+    putSessionRecord({
+      ...createEmptySessionRecord(clientSessionA, "codex", {
+        workspaceId: "workspace-1",
+        materializedSessionId: "runtime-session-older",
+      }),
+      transcriptHydrated: true,
+    });
+    putSessionRecord({
+      ...createEmptySessionRecord(clientSessionB, "codex", {
+        workspaceId: "workspace-1",
+        materializedSessionId: runtimeSessionB,
+      }),
+      transcriptHydrated: true,
+    });
+    const logicalWorkspace = localLogicalWorkspace();
+    const intent = chatWorkspaceShellTabKey(clientSessionB);
+    useWorkspaceUiStore.setState({
+      ...WORKSPACE_UI_DEFAULTS,
+      _hydrated: true,
+      activeShellTabKeyByWorkspace: {
+        [logicalWorkspace.id]: intent,
+      },
+      lastViewedSessionByWorkspace: {
+        [logicalWorkspace.id]: runtimeSessionB,
+      },
+      visibleChatSessionIdsByWorkspace: {
+        [logicalWorkspace.id]: [clientSessionA, clientSessionB],
+      },
+    });
+    useSessionSelectionStore.getState().activateWorkspace({
+      logicalWorkspaceId: logicalWorkspace.id,
+      workspaceId: "workspace-1",
+      initialActiveSessionId: clientSessionB,
+    });
+    useSessionSelectionStore.getState().deselectWorkspacePreservingSessions();
+    const deps = depsForHotReopen([logicalWorkspace]);
+
+    const didHotReopen = runHotWorkspaceReopen(deps, {
+      workspaceId: logicalWorkspace.id,
+    });
+
+    const state = useSessionSelectionStore.getState();
+    expect(didHotReopen).toBe(true);
+    expect(state.selectedLogicalWorkspaceId).toBe(logicalWorkspace.id);
+    expect(state.selectedWorkspaceId).toBe("workspace-1");
+    expect(state.activeSessionId).toBe(clientSessionB);
+    expect(resolveWorkspaceShellActivation({
+      workspaceId: "workspace-1",
+      storedIntent: intent,
+      orderedTabs: [
+        chatWorkspaceShellTabKey(clientSessionA),
+        chatWorkspaceShellTabKey(clientSessionB),
+      ],
+      activeSessionId: state.activeSessionId,
+      activeViewerTargetKey: null,
+      liveChatSessionIds: new Set([clientSessionA, clientSessionB]),
+      openViewerTargetKeys: new Set(),
+      pendingChatActivation: null,
+      currentShellActivationEpoch: 0,
+      currentSessionActivationEpoch:
+        state.sessionActivationIntentEpochByWorkspace["workspace-1"] ?? 0,
+      currentWorkspaceSelectionNonce: state.workspaceSelectionNonce,
+    })).toEqual({
+      renderSurface: { kind: "chat-session", sessionId: clientSessionB },
+      highlightedTabKey: intent,
+    });
+    expect(deps.bootstrapWorkspace).not.toHaveBeenCalled();
+  });
 });
 
-function depsForHotReopen(): WorkspaceSelectionDeps {
+function depsForHotReopen(
+  logicalWorkspaces: LogicalWorkspace[] = [],
+): WorkspaceSelectionDeps {
   return {
     localRuntime: null,
     cloudClient: null,
@@ -124,7 +213,7 @@ function depsForHotReopen(): WorkspaceSelectionDeps {
       invalidateCloudWorkspaceStartState: vi.fn().mockResolvedValue(undefined),
       refreshCloudWorkspaceConnection: vi.fn(),
     },
-    logicalWorkspaces: [],
+    logicalWorkspaces,
     rawWorkspaces: [{ id: "workspace-1" } as never, { id: "workspace-2" } as never],
     setSelectedLogicalWorkspaceId: vi.fn(),
     setSelectedWorkspace,
@@ -133,6 +222,16 @@ function depsForHotReopen(): WorkspaceSelectionDeps {
     bootstrapWorkspace: vi.fn(),
     reconcileHotWorkspace: vi.fn().mockResolvedValue("completed"),
   };
+}
+
+function localLogicalWorkspace(): LogicalWorkspace {
+  return {
+    id: "logical:workspace-1",
+    localWorkspace: { id: "workspace-1" },
+    cloudWorkspace: null,
+    mobilityWorkspace: null,
+    preferredMaterializationId: "workspace-1",
+  } as LogicalWorkspace;
 }
 
 function setSelectedWorkspace(

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.ts
@@ -15,6 +15,7 @@ import {
   removeSessionRecord,
 } from "#product/stores/sessions/session-records";
 import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import {
   finishMeasurementOperation,
@@ -68,6 +69,8 @@ export function runHotWorkspaceReopen(
     logicalWorkspace,
     initialActiveSessionId: request.options?.initialActiveSessionId ?? null,
     lastViewedSessionByWorkspace: useWorkspaceUiStore.getState().lastViewedSessionByWorkspace,
+    clientSessionIdByMaterializedSessionId:
+      useSessionDirectoryStore.getState().clientSessionIdByMaterializedSessionId,
     sessionSlots: getSessionRecords(),
     isPendingSessionId,
   });

--- a/apps/packages/product-client/src/lib/domain/workspaces/selection/hot-reopen.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/selection/hot-reopen.test.ts
@@ -75,6 +75,7 @@ describe("resolveHotReopenCandidate", () => {
       lastViewedSessionByWorkspace: {
         "workspace-1": "session-last",
       },
+      clientSessionIdByMaterializedSessionId: {},
       sessionSlots: {
         "session-initial": slot({
           sessionId: "session-initial",
@@ -105,6 +106,7 @@ describe("resolveHotReopenCandidate", () => {
       lastViewedSessionByWorkspace: {
         "logical:repo": "session-logical",
       },
+      clientSessionIdByMaterializedSessionId: {},
       sessionSlots: {
         "session-fallback": slot({
           sessionId: "session-fallback",
@@ -133,6 +135,7 @@ describe("resolveHotReopenCandidate", () => {
       logicalWorkspace: logicalWorkspace(),
       initialActiveSessionId: null,
       lastViewedSessionByWorkspace: {},
+      clientSessionIdByMaterializedSessionId: {},
       sessionSlots: {
         "session-cached": slot({
           sessionId: "session-cached",
@@ -145,6 +148,40 @@ describe("resolveHotReopenCandidate", () => {
 
     expect(candidate?.source).toBe("cached_slot");
     expect(candidate?.sessionId).toBe("session-cached");
+  });
+
+  it("resolves a durable remembered id to its cached client slot", () => {
+    const candidate = resolveHotReopenCandidate({
+      resolvedWorkspaceId: "workspace-1",
+      logicalWorkspace: logicalWorkspace(),
+      initialActiveSessionId: null,
+      lastViewedSessionByWorkspace: {
+        "logical:repo": "runtime-session-new",
+      },
+      clientSessionIdByMaterializedSessionId: {
+        "runtime-session-old": "client-session:codex:old",
+        "runtime-session-new": "client-session:codex:new",
+      },
+      sessionSlots: {
+        "client-session:codex:old": slot({
+          sessionId: "client-session:codex:old",
+          workspaceId: "workspace-1",
+          hydrated: true,
+        }),
+        "client-session:codex:new": slot({
+          sessionId: "client-session:codex:new",
+          workspaceId: "workspace-1",
+          hydrated: true,
+        }),
+      },
+      isPendingSessionId: () => false,
+    });
+
+    expect(candidate).toEqual({
+      sessionId: "client-session:codex:new",
+      workspaceId: "workspace-1",
+      source: "last_viewed",
+    });
   });
 });
 

--- a/apps/packages/product-client/src/lib/domain/workspaces/selection/hot-reopen.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/selection/hot-reopen.ts
@@ -44,11 +44,18 @@ export function resolveHotReopenCandidate(input: {
   logicalWorkspace: LogicalWorkspace | null;
   initialActiveSessionId?: string | null;
   lastViewedSessionByWorkspace: Record<string, string>;
+  clientSessionIdByMaterializedSessionId: Record<string, string>;
   sessionSlots: Record<string, HotReopenSessionSlotSnapshot>;
   isPendingSessionId: (sessionId: string) => boolean;
 }): HotReopenCandidate | null {
-  const slotFor = (sessionId: string | null | undefined) =>
-    sessionId ? input.sessionSlots[sessionId] ?? null : null;
+  const slotFor = (sessionId: string | null | undefined) => {
+    if (!sessionId) {
+      return null;
+    }
+    const clientSessionId =
+      input.clientSessionIdByMaterializedSessionId[sessionId] ?? sessionId;
+    return input.sessionSlots[clientSessionId] ?? null;
+  };
   const toCandidate = (
     sessionId: string | null | undefined,
     source: HotReopenCandidate["source"],


### PR DESCRIPTION
## Linear tickets

- [PRO-106 — Empty session](https://linear.app/proliferate-team/issue/PRO-106/empty-session)

## Summary

- Resolve durable last-viewed session IDs through the live client-session inverse index before hot reopen chooses a cached slot.
- Preserve the new empty chat as both the active session and rendered shell after leaving for Home and reopening the workspace with a numbered shortcut.
- Add a production-store regression that exercises Home-style deselection, hot reopen, and the real shell activation resolver.

## Root cause

New sessions remain keyed locally by a transient client identity after the backend assigns a durable runtime identity. Creation persists that runtime identity as the workspace's last-viewed session, while cached session slots remain keyed by the client identity.

Hot reopen previously treated the persisted runtime ID as a slot key. The lookup missed the new session, fell through to the first eligible cached slot, and selected an older session. The durable shell intent still pointed at the new client-keyed chat. Shell activation requires its chat intent, active session, live set, and ordered tab to agree, so that mismatch intentionally resolved to the empty chat shell.

The fix translates a remembered runtime ID through the existing materialized-to-client index before checking slot eligibility.

## Testing

- Fail-before proof: the production-store regression selected the older client slot instead of the newly created empty session.
- Focused hot-reopen suites: 13 tests passed.
- Shortcut preservation suites: 31 tests passed, including numbered workspace and Cmd+Option+number chat-tab behavior.
- Full ProductClient run: 803 test files and 5,456 tests passed, with 1 test skipped. The only failed suite is the unrelated authenticated Markdown browser fixture because Google Chrome is not installed at the configured system path.
- ProductClient typecheck and build passed.
- Repository max-lines, frontend boundaries, session mutation admission, design attribution, strict frontend structure, and diff checks passed.

## Observability

- No telemetry added. The bug is a deterministic local identity-projection invariant covered at the store, workflow, and rendered-shell resolution boundaries.

## Coordination

- This minimal standalone change overlaps the hot-reopen inverse-index hunk in the broader open PR #1737. Whichever lands second should rebase and drop the duplicate hunk.

## Readiness

- [x] I followed the pull-request procedure for scope, title, body, and draft readiness.

## Support and attribution (optional)

- [x] No support relationship or private source material applies.