### PR TITLE
fix(product): skip redundant relative tab activation

### DIFF
--- a/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-workspace-tab-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-workspace-tab-actions.test.tsx
@@ -1,0 +1,296 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useShortcutDispatcher } from "#product/hooks/shortcuts/lifecycle/use-shortcut-dispatcher";
+import { useWorkspaceContentShortcuts } from "#product/hooks/workspaces/ui/use-workspace-content-shortcuts";
+import {
+  cancelPendingDeferredChatActivation,
+} from "#product/hooks/workspaces/workflows/tabs/use-chat-tab-activation";
+import {
+  useWorkspaceTabActions,
+  type WorkspaceTabActionsContext,
+} from "#product/hooks/workspaces/workflows/tabs/use-workspace-tab-actions";
+import { WORKSPACE_UI_DEFAULTS } from "#product/lib/domain/preferences/workspace-ui/model";
+import {
+  resolveWorkspaceShellActivation,
+} from "#product/lib/domain/workspaces/tabs/shell-activation";
+import {
+  chatWorkspaceShellTabKey,
+  getWorkspaceShellTabKey,
+  type WorkspaceShellTab,
+} from "#product/lib/domain/workspaces/tabs/shell-tabs";
+import {
+  clearShortcutHandlerRegistryForTests,
+} from "#product/lib/domain/shortcuts/registry";
+import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+
+const WORKSPACE_ID = "workspace-1";
+const SESSION_A: WorkspaceShellTab = { kind: "chat", sessionId: "session-a" };
+const SESSION_B: WorkspaceShellTab = { kind: "chat", sessionId: "session-b" };
+
+const hookMocks = vi.hoisted(() => ({
+  archiveSession: vi.fn(),
+  closeActiveTab: vi.fn(() => "noop" as const),
+  createEmptySession: vi.fn(),
+  restoreSession: vi.fn(),
+  selectSession: vi.fn(async () => undefined),
+}));
+
+vi.mock("#product/hooks/chat/derived/use-active-session-config-state", () => ({
+  useActiveSessionLaunchState: () => ({ currentLaunchIdentity: null }),
+}));
+
+vi.mock("#product/hooks/chat/derived/use-configured-launch-readiness", () => ({
+  useConfiguredLaunchReadiness: () => ({
+    disabledReason: "No launch configuration.",
+    launchCatalog: { launchAgents: [] },
+    selection: null,
+  }),
+}));
+
+vi.mock("#product/hooks/sessions/facade/use-session-selection-actions", () => ({
+  useSessionSelectionActions: () => ({ selectSession: hookMocks.selectSession }),
+}));
+
+vi.mock("#product/hooks/sessions/workflows/use-session-creation-actions", () => ({
+  useSessionCreationActions: () => ({
+    createEmptySessionWithResolvedConfig: hookMocks.createEmptySession,
+  }),
+}));
+
+vi.mock("#product/hooks/sessions/workflows/use-session-restore-actions", () => ({
+  useSessionRestoreActions: () => ({
+    restoreLastDismissedSession: hookMocks.restoreSession,
+  }),
+}));
+
+vi.mock("#product/hooks/workspaces/derived/use-workspace-runtime-block", () => ({
+  useWorkspaceRuntimeBlock: () => ({
+    getWorkspaceRuntimeBlockReason: () => null,
+  }),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/tabs/use-chat-session-archive-action", () => ({
+  useChatSessionArchiveAction: () => hookMocks.archiveSession,
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/tabs/use-close-active-workspace-tab", () => ({
+  useCloseActiveWorkspaceTab: () => hookMocks.closeActiveTab,
+}));
+
+describe("workspace relative-tab keyboard flow", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("navigator", {
+      platform: "MacIntel",
+      userAgent: "Mac OS X",
+    });
+    clearShortcutHandlerRegistryForTests();
+    vi.clearAllMocks();
+
+    useSessionSelectionStore.getState().clearSelection();
+    useSessionSelectionStore.setState({ _hydrated: true });
+    useSessionSelectionStore.getState().activateWorkspace({
+      logicalWorkspaceId: WORKSPACE_ID,
+      workspaceId: WORKSPACE_ID,
+      initialActiveSessionId: SESSION_A.sessionId,
+    });
+    resetWorkspaceUi([SESSION_A], SESSION_A);
+  });
+
+  afterEach(() => {
+    cancelPendingDeferredChatActivation(WORKSPACE_ID, "intent-replaced");
+    cleanup();
+    clearShortcutHandlerRegistryForTests();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    ["Ctrl+Tab", { shiftKey: false, repeat: false }],
+    ["Ctrl+Shift+Tab", { shiftKey: true, repeat: false }],
+    ["repeated Ctrl+Tab", { shiftKey: false, repeat: true }],
+    ["repeated Ctrl+Shift+Tab", { shiftKey: true, repeat: true }],
+  ])("leaves the sole active session unchanged for %s", (_label, init) => {
+    const context = createContext({ orderedTabs: [SESSION_A], activeTab: SESSION_A });
+    const beforeEpoch = currentSessionActivationEpoch();
+    const beforeSurface = currentShellActivation([SESSION_A]);
+    render(<ShortcutHarness context={context} />);
+
+    const event = dispatchCtrlTab(init);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(currentPendingActivation()).toBeNull();
+    expect(currentSessionActivationEpoch()).toBe(beforeEpoch);
+    expect(currentShellActivation([SESSION_A])).toEqual(beforeSurface);
+    expect(hookMocks.selectSession).not.toHaveBeenCalled();
+  });
+
+  it("does not cycle into a hidden session", () => {
+    const context = createContext({
+      orderedTabs: [SESSION_A],
+      activeTab: SESSION_A,
+      liveSessionIds: [SESSION_A.sessionId, SESSION_B.sessionId],
+    });
+    render(<ShortcutHarness context={context} />);
+
+    const event = dispatchCtrlTab({ shiftKey: false, repeat: false });
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(currentPendingActivation()).toBeNull();
+    expect(currentShellActivation([SESSION_A]).renderSurface).toEqual({
+      kind: "chat-session",
+      sessionId: SESSION_A.sessionId,
+    });
+  });
+
+  it("still activates the sole tab from the chat shell", () => {
+    useSessionSelectionStore.getState().setActiveSessionId(null);
+    useWorkspaceUiStore.getState().writeShellIntent({
+      workspaceId: WORKSPACE_ID,
+      intent: "chat-shell",
+    });
+    const context = createContext({ orderedTabs: [SESSION_A], activeTab: null });
+    render(<ShortcutHarness context={context} />);
+
+    const event = dispatchCtrlTab({ shiftKey: false, repeat: false });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(currentPendingActivation()).toMatchObject({
+      intent: chatWorkspaceShellTabKey(SESSION_A.sessionId),
+      sessionId: SESSION_A.sessionId,
+    });
+  });
+
+  it.each([
+    ["next", false],
+    ["previous", true],
+  ])("still activates another tab when cycling %s", (_label, shiftKey) => {
+    resetWorkspaceUi([SESSION_A, SESSION_B], SESSION_A);
+    const context = createContext({
+      orderedTabs: [SESSION_A, SESSION_B],
+      activeTab: SESSION_A,
+    });
+    render(<ShortcutHarness context={context} />);
+
+    const event = dispatchCtrlTab({ shiftKey, repeat: false });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(currentPendingActivation()).toMatchObject({
+      intent: chatWorkspaceShellTabKey(SESSION_B.sessionId),
+      sessionId: SESSION_B.sessionId,
+    });
+    expect(currentShellActivation([SESSION_A, SESSION_B]).renderSurface).toEqual({
+      kind: "chat-session-pending",
+      sessionId: SESSION_B.sessionId,
+    });
+  });
+});
+
+function ShortcutHarness({ context }: { context: WorkspaceTabActionsContext }) {
+  const actions = useWorkspaceTabActions(context);
+  useWorkspaceContentShortcuts(actions);
+  useShortcutDispatcher();
+  return null;
+}
+
+function createContext({
+  orderedTabs,
+  activeTab,
+  liveSessionIds,
+}: {
+  orderedTabs: WorkspaceShellTab[];
+  activeTab: WorkspaceShellTab | null;
+  liveSessionIds?: string[];
+}): WorkspaceTabActionsContext {
+  const visibleSessionIds = orderedTabs.flatMap((tab) =>
+    tab.kind === "chat" ? [tab.sessionId] : []
+  );
+  return {
+    workspaceUiKey: WORKSPACE_ID,
+    materializedWorkspaceId: WORKSPACE_ID,
+    selectedWorkspaceId: WORKSPACE_ID,
+    visibleChatSessionIds: visibleSessionIds,
+    liveChatSessionIds: liveSessionIds ?? visibleSessionIds,
+    childToParent: new Map(),
+    shellRows: [],
+    orderedTabs,
+    activeShellTab: activeTab,
+    activeShellTabKey: activeTab ? getWorkspaceShellTabKey(activeTab) : null,
+  };
+}
+
+function resetWorkspaceUi(
+  orderedTabs: WorkspaceShellTab[],
+  activeTab: WorkspaceShellTab,
+): void {
+  const visibleSessionIds = orderedTabs.flatMap((tab) =>
+    tab.kind === "chat" ? [tab.sessionId] : []
+  );
+  useWorkspaceUiStore.setState({
+    ...WORKSPACE_UI_DEFAULTS,
+    _hydrated: true,
+    activeShellTabKeyByWorkspace: {
+      [WORKSPACE_ID]: getWorkspaceShellTabKey(activeTab),
+    },
+    shellTabOrderByWorkspace: {
+      [WORKSPACE_ID]: orderedTabs.map(getWorkspaceShellTabKey),
+    },
+    visibleChatSessionIdsByWorkspace: {
+      [WORKSPACE_ID]: visibleSessionIds,
+    },
+    shellActivationEpochByWorkspace: { [WORKSPACE_ID]: 0 },
+    pendingChatActivationByWorkspace: {},
+    urgentHighlightedChatSessionByWorkspace: {},
+  });
+}
+
+function dispatchCtrlTab(init: Pick<KeyboardEventInit, "repeat" | "shiftKey">): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    key: "Tab",
+    code: "Tab",
+    ctrlKey: true,
+    shiftKey: init.shiftKey,
+    repeat: init.repeat,
+    bubbles: true,
+    cancelable: true,
+  });
+  act(() => {
+    window.dispatchEvent(event);
+  });
+  return event;
+}
+
+function currentPendingActivation() {
+  return useWorkspaceUiStore.getState()
+    .pendingChatActivationByWorkspace[WORKSPACE_ID] ?? null;
+}
+
+function currentSessionActivationEpoch(): number {
+  return useSessionSelectionStore.getState()
+    .sessionActivationIntentEpochByWorkspace[WORKSPACE_ID] ?? 0;
+}
+
+function currentShellActivation(orderedTabs: WorkspaceShellTab[]) {
+  const workspaceUiState = useWorkspaceUiStore.getState();
+  const selectionState = useSessionSelectionStore.getState();
+  return resolveWorkspaceShellActivation({
+    workspaceId: WORKSPACE_ID,
+    storedIntent: workspaceUiState.activeShellTabKeyByWorkspace[WORKSPACE_ID] ?? null,
+    orderedTabs: orderedTabs.map(getWorkspaceShellTabKey),
+    activeSessionId: selectionState.activeSessionId,
+    activeViewerTargetKey: null,
+    liveChatSessionIds: new Set(
+      orderedTabs.flatMap((tab) => tab.kind === "chat" ? [tab.sessionId] : []),
+    ),
+    openViewerTargetKeys: new Set(),
+    pendingChatActivation: currentPendingActivation(),
+    currentShellActivationEpoch:
+      workspaceUiState.shellActivationEpochByWorkspace[WORKSPACE_ID] ?? 0,
+    currentSessionActivationEpoch: currentSessionActivationEpoch(),
+    currentWorkspaceSelectionNonce: selectionState.workspaceSelectionNonce,
+  });
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/tabs/shell-tabs.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/tabs/shell-tabs.test.ts
@@ -119,6 +119,55 @@ describe("workspace shell tab ordering", () => {
     })).toEqual(tabs[0]);
   });
 
+  it("does not reactivate the only active shell tab", () => {
+    const chatTab: WorkspaceShellTab = { kind: "chat", sessionId: "only" };
+    const viewerTab: WorkspaceShellTab = {
+      kind: "viewer",
+      target: fileViewerTarget("src/only.ts"),
+    };
+
+    for (const tab of [chatTab, viewerTab]) {
+      expect(resolveRelativeWorkspaceShellTab({
+        tabs: [tab],
+        activeTab: tab,
+        delta: -1,
+      })).toBeNull();
+      expect(resolveRelativeWorkspaceShellTab({
+        tabs: [tab],
+        activeTab: tab,
+        delta: 1,
+      })).toBeNull();
+    }
+  });
+
+  it("enters the only shell tab when there is no valid active anchor", () => {
+    const onlyTab: WorkspaceShellTab = { kind: "chat", sessionId: "only" };
+
+    expect(resolveRelativeWorkspaceShellTab({
+      tabs: [onlyTab],
+      activeTab: null,
+      delta: 1,
+    })).toEqual(onlyTab);
+    expect(resolveRelativeWorkspaceShellTab({
+      tabs: [onlyTab],
+      activeTab: { kind: "chat", sessionId: "stale" },
+      delta: -1,
+    })).toEqual(onlyTab);
+  });
+
+  it("cycles both directions through multiple mixed shell tabs", () => {
+    expect(resolveRelativeWorkspaceShellTab({
+      tabs,
+      activeTab: tabs[0],
+      delta: 1,
+    })).toEqual(tabs[1]);
+    expect(resolveRelativeWorkspaceShellTab({
+      tabs,
+      activeTab: tabs[0],
+      delta: -1,
+    })).toEqual(tabs[2]);
+  });
+
   it("resolves numeric shortcuts against chat tabs only", () => {
     const mixedTabs: WorkspaceShellTab[] = [
       { kind: "viewer", target: fileViewerTarget("src/a.ts") },

--- a/apps/packages/product-client/src/lib/domain/workspaces/tabs/shell-tabs.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/tabs/shell-tabs.ts
@@ -266,6 +266,10 @@ export function resolveRelativeWorkspaceShellTab(args: {
   }
 
   const nextIndex = (activeIndex + delta + tabs.length) % tabs.length;
+  if (nextIndex === activeIndex) {
+    return null;
+  }
+
   return tabs[nextIndex] ?? null;
 }
 


### PR DESCRIPTION
## Linear tickets

- [PRO-105 — Control+tab shortcut should not do anything in a single-session workflow](https://linear.app/proliferate-team/issue/PRO-105/controltab-shortcut-should-not-do-anything-in-a-single-session)

## Summary

- Decline relative-tab shortcuts when cycling resolves to the current active tab, preserving native browser behavior and avoiding redundant session activation state.
- Cover one-tab, hidden-session, no-anchor, viewer-tab, repeat-key, and multi-tab behavior through domain and real keyboard/store regression tests.

## Testing

- Tier 1: `pnpm --filter @proliferate/product-client build`
- Tier 1: `pnpm --filter @proliferate/product-client exec vitest run --exclude src/app/authenticated-markdown-cascade.test.ts` (804 files, 5,465 tests; the excluded visual cascade test requires a local Google Chrome binary)
- Tier 1: focused red/green regression and adjacent shortcut/activation suites (51 tests)
- `python3 scripts/check_max_lines.py`
- `python3 scripts/report_frontend_structure.py --strict`
- `python3 scripts/check_design_attribution.py`
- `git diff --check`

## Observability

- none

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- Before the fix, six focused assertions reproduced the redundant same-tab activation, including consumed keyboard events and pending activation state.
- After the fix, Ctrl+Tab and Ctrl+Shift+Tab leave a sole active tab unchanged while no-anchor and multi-tab cycling continue to work.