### PR TITLE
fix(product): guard composer code-fence ancestor walk against detached selection (PRO-209)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerEditorDocument.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerEditorDocument.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { $createTextNode, $getRoot, createEditor } from "lexical";
+import {
+  COMPOSER_NODES,
+  isComposerSelectionPointInsideCode,
+} from "#product/components/workspace/chat/input/ComposerEditorDocument";
+
+function withEditorUpdate(run: () => void) {
+  const editor = createEditor({
+    nodes: COMPOSER_NODES,
+    onError: (error) => {
+      throw error;
+    },
+  });
+  editor.update(run, { discrete: true });
+}
+
+describe("isComposerSelectionPointInsideCode", () => {
+  // A cleared composer can briefly leave the selection pointing at the root
+  // or at a node no longer attached to the document. The ancestor walk must
+  // still terminate for those points (PRO-209: it previously spun forever,
+  // freezing the renderer on the next keystroke).
+  it("returns false when the selection point is the root node", () => {
+    withEditorUpdate(() => {
+      expect(isComposerSelectionPointInsideCode($getRoot(), 0)).toBe(false);
+    });
+  }, 2000);
+
+  it("returns false when the selection point is a detached node", () => {
+    withEditorUpdate(() => {
+      expect(isComposerSelectionPointInsideCode($createTextNode("orphan"), 0)).toBe(false);
+    });
+  }, 2000);
+});

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerEditorDocument.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerEditorDocument.tsx
@@ -143,8 +143,8 @@ export function isComposerSelectionPointInsideCode(
   if (isComposerNodeInsideCodeBlock(node)) return true;
 
   let paragraph: LexicalNode | null = node;
-  while (paragraph?.getParent()?.getType() !== "root") {
-    paragraph = paragraph?.getParent() ?? null;
+  while (paragraph && paragraph.getParent()?.getType() !== "root") {
+    paragraph = paragraph.getParent();
   }
   if (!paragraph || paragraph.getType() !== "paragraph") return false;
 


### PR DESCRIPTION
## Summary

Fixes [PRO-209](https://linear.app/proliferate-team/issue/PRO-209/composer-freezes-app-on-rapid-second-send-infinite-loop-in): the composer froze the entire window when a message was sent while the previous send was still materializing.

`isComposerSelectionPointInsideCode` (introduced in #1708) walked ancestors with an optional-chained loop condition:

```ts
while (paragraph?.getParent()?.getType() !== "root") {
  paragraph = paragraph?.getParent() ?? null;
}
```

When the Lexical selection points at the root or a detached node — the editor state right after a send clears the draft — `paragraph` becomes `null`, `undefined !== "root"` stays true, and the loop spins forever inside the editor update listener during a keydown microtask checkpoint. The renderer main thread pegs at 100% CPU and the window stops responding entirely ("can't send messages").

## Fix

Guard the walk on the cursor itself, the same pattern `offsetWithinNode` in this file already uses. Root/detached points now fall out of the loop and return `false`.

## Testing

- New regression tests pin both degenerate selection points (root node, detached node). Against the unguarded loop they hang the suite, which CI catches as a timeout; with the guard they pass in milliseconds.
- Full composer input suite: 120/120 pass.
- Manually verified end-to-end via CDP: a rapid 5-message send burst (the deterministic repro — second send ~300ms after the first) stays fully responsive; before the fix the renderer wedged on the second send, confirmed by `Debugger.pause` stacks landing in this loop.

## Notes

- Bug is on `main` only — merged after the `release-2026-08-08` cut, so v0.4.8 in production is unaffected. This should land before the next release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)