### PR TITLE
fix(product): delete closed sessions from the history popover (PRO-157)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/shell/tabs/ClosedChatTabsMenu.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/tabs/ClosedChatTabsMenu.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+
+import { act, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { motion } from "@proliferate/design/motion";
+import { ClosedChatTabsMenu } from "#product/components/workspace/shell/tabs/ClosedChatTabsMenu";
+import type {
+  HeaderChatMenuEntry,
+} from "#product/lib/domain/workspaces/tabs/workspace-header-tabs-view-model-types";
+
+function menuRow(id: string): HeaderChatMenuEntry {
+  return {
+    id,
+    title: `Session ${id}`,
+    agentKind: "claude",
+    viewState: "idle" as HeaderChatMenuEntry["viewState"],
+    isResolvingSession: false,
+    hasUnreadActivity: false,
+    isActive: false,
+    isVisible: false,
+    closedAt: null,
+  };
+}
+
+function renderMenu(
+  rows: HeaderChatMenuEntry[],
+  onDeleteSession: (sessionId: string) => Promise<boolean>,
+) {
+  return (
+    <ClosedChatTabsMenu
+      rows={rows}
+      renderIcon={() => null}
+      onRestoreSession={() => {}}
+      onDeleteSession={onDeleteSession}
+    />
+  );
+}
+
+function rowDisclosure(container: HTMLElement, title: string): HTMLElement | null {
+  const label = [...container.querySelectorAll<HTMLElement>("button")]
+    .find((button) => button.textContent?.includes(title));
+  return label?.closest("[data-animated-collapsible-content]") ?? null;
+}
+
+describe("ClosedChatTabsMenu", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("collapses only the deleted middle row while neighbors stay expanded", () => {
+    const onDeleteSession = vi.fn(() => new Promise<boolean>(() => {}));
+    const { container } = render(
+      renderMenu([menuRow("a"), menuRow("b"), menuRow("c")], onDeleteSession),
+    );
+
+    fireEvent.click(container.querySelector<HTMLElement>('[aria-label="Delete Session b"]')!);
+
+    // The row collapses immediately; the archive itself waits out the
+    // transition so the animation is not starved by the header re-derivation.
+    expect(rowDisclosure(container, "Session b")?.getAttribute("data-expanded")).toBe("false");
+    expect(rowDisclosure(container, "Session a")?.getAttribute("data-expanded")).toBe("true");
+    expect(rowDisclosure(container, "Session c")?.getAttribute("data-expanded")).toBe("true");
+    expect(onDeleteSession).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(motion.duration.disclosureMs);
+    });
+    expect(onDeleteSession).toHaveBeenCalledWith("b");
+  });
+
+  it("keeps a ghost of the deleted row in place until the collapse finishes", async () => {
+    const onDeleteSession = vi.fn(() => Promise.resolve(true));
+    const rows = [menuRow("a"), menuRow("b"), menuRow("c")];
+    const { container, rerender } = render(renderMenu(rows, onDeleteSession));
+
+    fireEvent.click(container.querySelector<HTMLElement>('[aria-label="Delete Session b"]')!);
+    await act(async () => {
+      vi.advanceTimersByTime(motion.duration.disclosureMs);
+    });
+
+    // The archive completed and the parent dropped the row; the ghost keeps
+    // rendering in its original slot, collapsed, until the transition ends.
+    rerender(renderMenu([menuRow("a"), menuRow("c")], onDeleteSession));
+    const ghost = rowDisclosure(container, "Session b");
+    expect(ghost).not.toBeNull();
+    expect(ghost?.getAttribute("data-expanded")).toBe("false");
+    const order = [...container.querySelectorAll("[data-animated-collapsible-content]")]
+      .map((el) => el.textContent?.match(/Session [abc]/)?.[0]);
+    expect(order).toEqual(["Session a", "Session b", "Session c"]);
+
+    act(() => {
+      vi.runAllTimers();
+    });
+    expect(rowDisclosure(container, "Session b")).toBeNull();
+    expect(rowDisclosure(container, "Session a")?.getAttribute("data-expanded")).toBe("true");
+    expect(rowDisclosure(container, "Session c")?.getAttribute("data-expanded")).toBe("true");
+  });
+
+  it("restores the row when the archive fails", async () => {
+    const onDeleteSession = vi.fn(() => Promise.resolve(false));
+    const { container } = render(
+      renderMenu([menuRow("a"), menuRow("b")], onDeleteSession),
+    );
+
+    fireEvent.click(container.querySelector<HTMLElement>('[aria-label="Delete Session a"]')!);
+    expect(rowDisclosure(container, "Session a")?.getAttribute("data-expanded")).toBe("false");
+
+    await act(async () => {
+      vi.advanceTimersByTime(motion.duration.disclosureMs);
+    });
+    expect(rowDisclosure(container, "Session a")?.getAttribute("data-expanded")).toBe("true");
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/shell/tabs/ClosedChatTabsMenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/tabs/ClosedChatTabsMenu.tsx
@@ -1,4 +1,6 @@
-import type { ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { motion } from "@proliferate/design/motion";
+import { AnimatedCollapsibleContent } from "#product/primitives/AnimatedCollapsibleContent";
 import { Button } from "#product/primitives/Button";
 import { Trash, RotateCcw } from "#product/primitives/icons/core";
 import { formatRelativeTime } from "#product/lib/domain/workspaces/display/workspace-display";
@@ -6,8 +8,18 @@ import type {
   HeaderChatMenuEntry,
 } from "#product/lib/domain/workspaces/tabs/workspace-header-tabs-view-model-types";
 
+// A deleted row outlives the live data as a collapsing ghost so the 0fr
+// transition finishes even when the archive round-trip beats it; the slack
+// covers timer scheduling past the CSS duration.
+const GHOST_FINALIZE_MS = motion.duration.disclosureMs + 80;
+
+interface DeletingRowEntry {
+  row: HeaderChatMenuEntry;
+  index: number;
+}
+
 export function ClosedChatTabsMenu({
-  rows,
+  rows: liveRows,
   renderIcon,
   onRestoreSession,
   onDeleteSession,
@@ -15,58 +27,139 @@ export function ClosedChatTabsMenu({
   rows: HeaderChatMenuEntry[];
   renderIcon: (row: Pick<HeaderChatMenuEntry, "agentKind" | "viewState" | "isResolvingSession">) => ReactNode;
   onRestoreSession: (sessionId: string) => void;
-  onDeleteSession: (sessionId: string) => void;
+  onDeleteSession: (sessionId: string) => Promise<boolean>;
 }) {
+  // Rows collapse the moment delete is clicked, so rows above never move and
+  // rows below slide up; a row only re-expands if the archive fails.
+  const [deletingById, setDeletingById] = useState<
+    ReadonlyMap<string, DeletingRowEntry>
+  >(new Map());
+  const finalizeTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+
+  const clearDeleting = useCallback((sessionId: string) => {
+    const timer = finalizeTimersRef.current.get(sessionId);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      finalizeTimersRef.current.delete(sessionId);
+    }
+    setDeletingById((current) => {
+      if (!current.has(sessionId)) {
+        return current;
+      }
+      const next = new Map(current);
+      next.delete(sessionId);
+      return next;
+    });
+  }, []);
+
+  useEffect(() => () => {
+    for (const timer of finalizeTimersRef.current.values()) {
+      clearTimeout(timer);
+    }
+    finalizeTimersRef.current.clear();
+  }, []);
+
+  // Once a deleted row leaves the live list it is a ghost; drop it after the
+  // collapse transition has fully rendered.
+  useEffect(() => {
+    const liveIds = new Set(liveRows.map((row) => row.id));
+    for (const sessionId of deletingById.keys()) {
+      if (!liveIds.has(sessionId) && !finalizeTimersRef.current.has(sessionId)) {
+        finalizeTimersRef.current.set(
+          sessionId,
+          setTimeout(() => clearDeleting(sessionId), GHOST_FINALIZE_MS),
+        );
+      }
+    }
+  }, [clearDeleting, deletingById, liveRows]);
+
+  const deleteSession = (row: HeaderChatMenuEntry, index: number) => {
+    setDeletingById((current) => new Map(current).set(row.id, { row, index }));
+    // The grid-rows collapse animates on the main thread, so the archive (and
+    // the header re-derivation it triggers) must wait out the transition or it
+    // starves the animation into a single-frame snap. Deliberately not cleared
+    // on unmount: closing the popover must not lose the deletion.
+    setTimeout(() => {
+      void Promise.resolve(onDeleteSession(row.id)).then(
+        (archived) => {
+          if (!archived) {
+            clearDeleting(row.id);
+          }
+        },
+        () => clearDeleting(row.id),
+      );
+    }, motion.duration.disclosureMs);
+  };
+
+  const rows = useMemo(() => {
+    if (deletingById.size === 0) {
+      return liveRows;
+    }
+    const liveIds = new Set(liveRows.map((row) => row.id));
+    const ghosts = [...deletingById.values()]
+      .filter((entry) => !liveIds.has(entry.row.id))
+      .sort((a, b) => a.index - b.index);
+    if (ghosts.length === 0) {
+      return liveRows;
+    }
+    const merged = [...liveRows];
+    for (const ghost of ghosts) {
+      merged.splice(Math.min(ghost.index, merged.length), 0, ghost.row);
+    }
+    return merged;
+  }, [deletingById, liveRows]);
+
   return (
     <div className="flex max-h-[70vh] flex-col overflow-hidden">
       <div className="min-h-0 flex-1 overflow-y-auto">
-        {rows.map((row) => (
-          <div
-            key={row.id}
-            data-telemetry-mask="true"
-            className={`group/row flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-hover active:bg-active ${row.isActive ? "bg-selected" : ""}`}
-            onClick={(event) => {
-              const targetButton = event.target instanceof Element
-                ? event.target.closest("button")
-                : null;
-              if (targetButton && event.currentTarget.contains(targetButton)) {
-                return;
-              }
-              onRestoreSession(row.id);
-            }}
-          >
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="h-auto min-w-0 flex-1 justify-start gap-2 rounded-md p-0 hover:bg-transparent"
-              onClick={() => onRestoreSession(row.id)}
+        {rows.map((row, index) => (
+          <AnimatedCollapsibleContent key={row.id} expanded={!deletingById.has(row.id)}>
+            <div
+              data-telemetry-mask="true"
+              className={`group/row flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-hover active:bg-active ${row.isActive ? "bg-selected" : ""}`}
+              onClick={(event) => {
+                const targetButton = event.target instanceof Element
+                  ? event.target.closest("button")
+                  : null;
+                if (targetButton && event.currentTarget.contains(targetButton)) {
+                  return;
+                }
+                onRestoreSession(row.id);
+              }}
             >
-              <span className="flex size-4 shrink-0 items-center justify-center">
-                {renderIcon(row)}
-              </span>
-              <span className="flex-1 truncate text-left text-ui font-medium text-foreground">
-                {row.title}
-              </span>
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              title={`Delete ${row.title}`}
-              aria-label={`Delete ${row.title}`}
-              className="size-6 shrink-0 rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive focus-visible:opacity-100 group-hover/row:opacity-100"
-              onClick={() => onDeleteSession(row.id)}
-            >
-              <Trash className="icon-compact" />
-            </Button>
-            {row.closedAt && (
-              <span className="shrink-0 text-ui-sm text-muted-foreground">
-                {formatRelativeTime(row.closedAt)}
-              </span>
-            )}
-            <RotateCcw className="icon-compact shrink-0 text-muted-foreground" aria-hidden="true" />
-          </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-auto min-w-0 flex-1 justify-start gap-2 rounded-md p-0 hover:bg-transparent"
+                onClick={() => onRestoreSession(row.id)}
+              >
+                <span className="flex size-4 shrink-0 items-center justify-center">
+                  {renderIcon(row)}
+                </span>
+                <span className="flex-1 truncate text-left text-ui font-medium text-foreground">
+                  {row.title}
+                </span>
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                title={`Delete ${row.title}`}
+                aria-label={`Delete ${row.title}`}
+                className="size-6 shrink-0 rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive focus-visible:opacity-100 group-hover/row:opacity-100"
+                onClick={() => deleteSession(row, index)}
+              >
+                <Trash className="icon-compact" />
+              </Button>
+              {row.closedAt && (
+                <span className="shrink-0 text-ui-sm text-muted-foreground">
+                  {formatRelativeTime(row.closedAt)}
+                </span>
+              )}
+              <RotateCcw className="icon-compact shrink-0 text-muted-foreground" aria-hidden="true" />
+            </div>
+          </AnimatedCollapsibleContent>
         ))}
       </div>
     </div>

--- a/apps/packages/product-client/src/components/workspace/shell/topbar/HeaderTabs.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/topbar/HeaderTabs.tsx
@@ -159,10 +159,11 @@ const HeaderTabsInner = memo(function HeaderTabsInner({
   }, [activeTabIndex, layout.positions, layout.widths]);
 
   const dismissChatSession = useCallback((sessionId: string) => {
-    void chatVisibilityActions.archiveChatSessionTab(sessionId).then((archived) => {
+    return chatVisibilityActions.archiveChatSessionTab(sessionId).then((archived) => {
       if (archived) {
         multiSelect.clearSelection();
       }
+      return archived;
     });
   }, [
     chatVisibilityActions.archiveChatSessionTab,

--- a/apps/packages/product-client/src/components/workspace/shell/topbar/HeaderTabsActions.hit-target.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/topbar/HeaderTabsActions.hit-target.test.tsx
@@ -63,7 +63,7 @@ describe("ClosedSessionsTrigger row hit target", () => {
   it("keeps Delete isolated from the row restore action", async () => {
     const user = userEvent.setup();
     const onRestoreSession = vi.fn();
-    const onDeleteSession = vi.fn();
+    const onDeleteSession = vi.fn(() => Promise.resolve(true));
 
     render(
       <ClosedSessionsTrigger
@@ -76,10 +76,17 @@ describe("ClosedSessionsTrigger row hit target", () => {
     await openClosedSessions(user);
     await user.click(screen.getByRole("button", { name: "Delete Session one" }));
 
-    expect(onDeleteSession).toHaveBeenCalledOnce();
+    // The row collapses immediately; the archive is deferred past the collapse
+    // transition, and the popover stays open showing the remaining rows.
+    const row = screen.getByText("Session one")
+      .closest("[data-animated-collapsible-content]");
+    expect(row?.getAttribute("data-expanded")).toBe("false");
+    await waitFor(() => {
+      expect(onDeleteSession).toHaveBeenCalledOnce();
+    });
     expect(onDeleteSession).toHaveBeenCalledWith("session-1");
     expect(onRestoreSession).not.toHaveBeenCalled();
-    await expectClosedSessionsToClose();
+    expect(screen.getByRole("dialog")).toBeTruthy();
   });
 
   it("retains native keyboard restore behavior on the title button", async () => {

--- a/apps/packages/product-client/src/components/workspace/shell/topbar/HeaderTabsActions.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/topbar/HeaderTabsActions.tsx
@@ -44,7 +44,7 @@ export function NewChatButton({
 interface ClosedSessionsTriggerProps {
   closedChatTabs: HeaderChatMenuEntry[];
   onRestoreSession: (sessionId: string) => void;
-  onDeleteSession: (sessionId: string) => void;
+  onDeleteSession: (sessionId: string) => Promise<boolean>;
 }
 
 export function ClosedSessionsTrigger({
@@ -85,10 +85,7 @@ export function ClosedSessionsTrigger({
             onRestoreSession(sessionId);
             close();
           }}
-          onDeleteSession={(sessionId) => {
-            onDeleteSession(sessionId);
-            close();
-          }}
+          onDeleteSession={onDeleteSession}
         />
       )}
     </PopoverButton>

--- a/apps/packages/product-client/src/hooks/plans/workflows/use-plan-handoff-workflow.ts
+++ b/apps/packages/product-client/src/hooks/plans/workflows/use-plan-handoff-workflow.ts
@@ -236,7 +236,7 @@ interface ExecutePlanHandoffInput {
     optimisticContentParts: ContentPart[];
     workspaceId: string;
   }) => Promise<void>;
-  dismissSession: (sessionId: string) => Promise<void>;
+  dismissSession: (sessionId: string) => Promise<boolean>;
   selectSession: (sessionId: string) => Promise<SessionActivationOutcome | void>;
   hasSession: (sessionId: string) => boolean;
   onCompleted: () => void;

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-dismiss-actions.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-dismiss-actions.test.ts
@@ -1,0 +1,18 @@
+import { AnyHarnessError } from "@anyharness/sdk";
+import { describe, expect, it } from "vitest";
+import { isSessionAlreadyGone } from "#product/hooks/sessions/workflows/use-session-dismiss-actions";
+
+describe("isSessionAlreadyGone", () => {
+  it("treats a runtime 404 as an already-dismissed session", () => {
+    const error = new AnyHarnessError({ title: "Not found", status: 404 });
+    expect(isSessionAlreadyGone(error)).toBe(true);
+  });
+
+  it("keeps other runtime failures as real dismissal failures", () => {
+    expect(isSessionAlreadyGone(new AnyHarnessError({ title: "Boom", status: 500 }))).toBe(false);
+    expect(isSessionAlreadyGone(new Error("network down"))).toBe(false);
+    // The SDK only exposes HTTP status on AnyHarnessError.problem; a flat
+    // status property belongs to its telemetry projection, not this path.
+    expect(isSessionAlreadyGone(Object.assign(new Error("x"), { status: 404 }))).toBe(false);
+  });
+});

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-dismiss-actions.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-dismiss-actions.ts
@@ -12,6 +12,10 @@ import type {
 } from "#product/lib/workflows/workspaces/chat-session-archive";
 import { isWorkspaceSetupSessionId } from "#product/lib/domain/workspaces/selection/setup-session";
 
+function isSessionAlreadyGone(error: unknown): boolean {
+  return (error as { status?: unknown } | null)?.status === 404;
+}
+
 export function useSessionDismissActions() {
   const host = useProductHost();
   const ssh = host.desktop?.ssh ?? null;
@@ -24,9 +28,9 @@ export function useSessionDismissActions() {
   const dismissSession = useCallback(async (
     sessionId: string,
     options?: VisibleChatSessionDismissOptions,
-  ) => {
+  ): Promise<boolean> => {
     if (isWorkspaceSetupSessionId(sessionId)) {
-      return;
+      return false;
     }
     const state = useSessionSelectionStore.getState();
     const closingSlot = getSessionRecord(sessionId);
@@ -35,7 +39,7 @@ export function useSessionDismissActions() {
     const blockedReason = getWorkspaceRuntimeBlockReason(workspaceId);
     if (blockedReason) {
       showToast(blockedReason);
-      return;
+      return false;
     }
 
     try {
@@ -45,11 +49,18 @@ export function useSessionDismissActions() {
         workspaceId: resolvedWorkspaceId,
         sessionId: materializedSessionId,
       });
-    } catch {
-      // Dismiss failed.
+    } catch (error) {
+      // A session the runtime no longer knows is already dismissed; any other
+      // failure keeps local state intact so the surface can offer a retry
+      // instead of reporting a deletion that did not happen.
+      if (!isSessionAlreadyGone(error)) {
+        showToast(error instanceof Error ? error.message : String(error));
+        return false;
+      }
     }
 
     cleanupDismissedSession(sessionId, workspaceId, options);
+    return true;
   }, [
     cleanupDismissedSession,
     dismissSessionMutation,

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-dismiss-actions.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-dismiss-actions.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { AnyHarnessError } from "@anyharness/sdk";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { useDismissSessionMutation } from "@anyharness/sdk-react";
 import { useDismissedSessionCleanup } from "#product/hooks/sessions/workflows/use-dismissed-session-cleanup";
@@ -12,8 +13,8 @@ import type {
 } from "#product/lib/workflows/workspaces/chat-session-archive";
 import { isWorkspaceSetupSessionId } from "#product/lib/domain/workspaces/selection/setup-session";
 
-function isSessionAlreadyGone(error: unknown): boolean {
-  return (error as { status?: unknown } | null)?.status === 404;
+export function isSessionAlreadyGone(error: unknown): boolean {
+  return error instanceof AnyHarnessError && error.problem.status === 404;
 }
 
 export function useSessionDismissActions() {

--- a/apps/packages/product-client/src/lib/access/anyharness/session-runtime.test.ts
+++ b/apps/packages/product-client/src/lib/access/anyharness/session-runtime.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getSessionClientAndWorkspace } from "#product/lib/access/anyharness/session-runtime";
+import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import {
+  createEmptySessionRecord,
+  putSessionRecord,
+} from "#product/stores/sessions/session-records";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+
+describe("getSessionClientAndWorkspace materialized-id resolution", () => {
+  beforeEach(() => {
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+    useHarnessConnectionStore.getState().setRuntimeUrl("http://127.0.0.1:8457");
+    useSessionSelectionStore.setState({ selectedWorkspaceId: "workspace-1" });
+  });
+
+  it("resolves a runtime session id with no directory entry to itself", async () => {
+    // Closed sessions listed from the runtime never get a directory entry
+    // until activated; dismissing one from the History menu must still
+    // address it by its own id (PRO-157).
+    const resolved = await getSessionClientAndWorkspace("runtime-session-1", null, null);
+
+    expect(resolved.materializedSessionId).toBe("runtime-session-1");
+    expect(resolved.workspaceId).toBe("workspace-1");
+  });
+
+  it("prefers the directory mapping when a record exists", async () => {
+    putSessionRecord(createEmptySessionRecord("client-session:codex:1", "codex", {
+      materializedSessionId: "runtime-a",
+      workspaceId: "workspace-2",
+    }));
+
+    const resolved = await getSessionClientAndWorkspace("client-session:codex:1", null, null);
+
+    expect(resolved.materializedSessionId).toBe("runtime-a");
+    expect(resolved.workspaceId).toBe("workspace-2");
+  });
+
+  it("keeps failing fast for ids that are still materializing", async () => {
+    putSessionRecord(createEmptySessionRecord("client-session:codex:2", "codex", {
+      materializedSessionId: null,
+      workspaceId: "workspace-1",
+    }));
+
+    await expect(getSessionClientAndWorkspace("client-session:codex:2", null, null))
+      .rejects.toThrow("Session is still starting");
+  });
+});

--- a/apps/packages/product-client/src/lib/access/anyharness/session-runtime.ts
+++ b/apps/packages/product-client/src/lib/access/anyharness/session-runtime.ts
@@ -30,6 +30,8 @@ import {
 import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
 import {
+  getMaterializedSessionId,
+  isPendingSessionId,
   requireMaterializedSessionId,
 } from "#product/stores/sessions/session-records";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
@@ -129,7 +131,12 @@ export async function getSessionClientAndWorkspace(
     connection,
     target,
     workspaceId,
-    materializedSessionId: requireMaterializedSessionId(sessionId),
+    // A directory entry only exists for sessions touched this app run. Ids
+    // without one (e.g. closed sessions listed from the runtime) are already
+    // materialized runtime ids; only genuinely pending ids must keep failing.
+    materializedSessionId: isPendingSessionId(sessionId)
+      ? requireMaterializedSessionId(sessionId)
+      : getMaterializedSessionId(sessionId) ?? sessionId,
   };
 }
 

--- a/apps/packages/product-client/src/lib/workflows/workspaces/chat-session-archive.test.ts
+++ b/apps/packages/product-client/src/lib/workflows/workspaces/chat-session-archive.test.ts
@@ -120,6 +120,21 @@ describe("archiveVisibleChatSession", () => {
     expect(harness.activations).toEqual(["C"]);
   });
 
+  it("reports a failed runtime dismissal without touching manual groups", async () => {
+    const harness = createArchiveHarness({
+      activeSessionId: "A",
+      liveSessions: candidates("A", "B"),
+      visibleSessionIds: ["A", "B"],
+    });
+
+    const archiveB = harness.archive("B");
+    harness.resolveDismiss("B", false);
+
+    await expect(archiveB).resolves.toBe(false);
+    expect(harness.removedFromGroups).toEqual([]);
+    expect(harness.liveRecordIds()).toContain("B");
+  });
+
   it("reserves a parent and linked child while preserving target-only runtime dismissal", async () => {
     const harness = createArchiveHarness({
       activeSessionId: "child",
@@ -181,7 +196,9 @@ function createArchiveHarness(input: {
   ) => {
     const pending = deferred();
     deferredDismissals.set(sessionId, pending);
-    await pending.promise;
+    if (!await pending.promise) {
+      return false;
+    }
     records.delete(sessionId);
     if (
       activeSessionId
@@ -193,6 +210,7 @@ function createArchiveHarness(input: {
         activations.push(nextActiveSessionId);
       }
     }
+    return true;
   });
 
   return {
@@ -234,12 +252,12 @@ function createArchiveHarness(input: {
       },
     }),
     liveRecordIds: () => [...records],
-    resolveDismiss: (sessionId: string) => {
+    resolveDismiss: (sessionId: string, dismissed = true) => {
       const pending = deferredDismissals.get(sessionId);
       if (!pending) {
         throw new Error(`No pending dismissal for ${sessionId}.`);
       }
-      pending.resolve();
+      pending.resolve(dismissed);
     },
     visibleSessionIds: () => (
       useWorkspaceUiStore.getState().visibleChatSessionIdsByWorkspace[WORKSPACE_ID] ?? []
@@ -248,9 +266,9 @@ function createArchiveHarness(input: {
 }
 
 function deferred() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((complete) => {
-    resolve = complete;
+  let resolve!: (dismissed?: boolean) => void;
+  const promise = new Promise<boolean>((complete) => {
+    resolve = (dismissed = true) => complete(dismissed);
   });
   return { promise, resolve };
 }

--- a/apps/packages/product-client/src/lib/workflows/workspaces/chat-session-archive.ts
+++ b/apps/packages/product-client/src/lib/workflows/workspaces/chat-session-archive.ts
@@ -17,7 +17,7 @@ export async function archiveVisibleChatSession(
     dismissSession: (
       sessionId: string,
       options: VisibleChatSessionDismissOptions,
-    ) => Promise<void>;
+    ) => Promise<boolean>;
     getRuntimeBlockReason: () => string | null;
     notifyRuntimeBlocked: (reason: string) => void;
     removeSessionsFromManualGroups: (sessionIds: string[]) => void;
@@ -40,12 +40,15 @@ export async function archiveVisibleChatSession(
   }
 
   try {
-    await deps.dismissSession(sessionId, {
+    const dismissed = await deps.dismissSession(sessionId, {
       replacedActiveSessionIds: reservation.sessionIds,
       resolveNextActiveSessionId: reservation.replacesActiveSession
         ? () => deps.resolveReservedFallback(reservation.fallbackSessionId)
         : undefined,
     });
+    if (!dismissed) {
+      return false;
+    }
     deps.removeSessionsFromManualGroups(reservation.sessionIds);
     return true;
   } finally {


### PR DESCRIPTION
## Summary

- Deleting a session from the closed-sessions (History) popover silently did nothing: `getSessionClientAndWorkspace` threw for any session without a live session-directory entry (every session not created/activated in the current app run — the popover's typical population, since the closed list is persisted), and `dismissSession` swallowed the throw, so no runtime dismissal was ever issued and the row resurfaced on the next sessions refetch. Bare ids without a directory entry now resolve to themselves (they are already runtime ids, matching `isPendingSessionId` semantics and what session selection does); genuinely pending ids still fail fast with the same message.
- The popover no longer closes on delete. The deleted row collapses in place via `AnimatedCollapsibleContent` (rows above stay static, rows below slide up over the disclosure duration), a ghost of the row outlives the data until the transition finishes, and the archive is deferred by the disclosure duration so the main-thread grid-rows transition is not starved into a single-frame snap by the header re-derivation it triggers. A failed archive expands the row back instead of losing it; closing the popover mid-animation does not lose the deletion.

Fixes PRO-157.

## Testing

- Unit (vitest): new `session-runtime.test.ts` pins the materialized-id resolution (entry-less id → itself, directory mapping preferred, pending id → throws); new `ClosedChatTabsMenu.test.tsx` pins collapse-on-click with static neighbors, deferred archive dispatch, ghost persistence until the transition window ends, and restore-on-failure. Related suites (`chat-session-archive`, `session-records`, `workspace-ui-store`, `AnimatedCollapsibleContent`) pass unchanged.
- Live end-to-end on a dev profile (local AnyHarness runtime, Desktop renderer): closed sessions from both the current and prior app runs delete from the popover with `dismissedAt` confirmed set via `GET /v1/sessions?include_dismissed=true`; the popover stays open with the remaining rows; deleting the last row unmounts the popover and History button together; frame-by-frame sampling of a middle-row delete shows a continuous ~60fps ease-out collapse (36→0px over 200ms) with the row below moving up in lockstep and rows above static.

## Observability

- none

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- `pnpm --filter @proliferate/product-client build` (includes full tsc)
- `pnpm vitest run src/components/workspace/shell/tabs/ClosedChatTabsMenu.test.tsx src/lib/access/anyharness/session-runtime.test.ts src/lib/workflows/workspaces/chat-session-archive.test.ts src/primitives/__tests__/AnimatedCollapsibleContent.test.tsx` — 14 passed
- `python3 scripts/check_appearance_scaling.py && python3 scripts/check_design_attribution.py && python3 scripts/check_frontend_boundaries.py` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Pinned-test change (flagged for review)

- `HeaderTabsActions.hit-target.test.tsx` ("keeps Delete isolated from the row restore action", added in #1761) pinned the pre-PRO-157 behavior that Delete closes the popover and dispatches synchronously. This PR intentionally changes both: the popover stays open and the archive is deferred past the collapse transition. The test now pins the new behavior (immediate collapse, deferred dispatch via waitFor, dialog stays open); the other hit-target cases are unchanged.
