### PR TITLE
fix(product): keep pasted code from poisoning the composer (PRO-159)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerCommandEditor.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerCommandEditor.test.tsx
@@ -448,9 +448,11 @@ describe("ComposerCommandEditor", () => {
 
     await waitFor(() => expect(fileMentionMock.lastQuery).toBe("set"));
     fireEvent.keyDown(textarea, { key: "Enter", repeat: false });
+    // The document ends with a code block, so the fenced-code plugin keeps a
+    // continuation paragraph after it — serialized as the trailing newline.
     await waitFor(() => expect(onDraftChange.mock.calls.some(
       ([draft]) => serializeChatDraftToPrompt(draft)
-        === "[setup.md](docs/setup.md) \n\n```\nconst ready = true;\n```",
+        === "[setup.md](docs/setup.md) \n\n```\nconst ready = true;\n```\n",
     )).toBe(true));
   });
 

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerFencedCodePlugin.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerFencedCodePlugin.test.tsx
@@ -322,6 +322,37 @@ describe("ComposerFencedCodePlugin", () => {
     );
   });
 
+  it("resets inherited text formats when an external value replaces the draft", async () => {
+    mockRangeRect();
+    const onChange = vi.fn();
+    const harness = renderEditor({ value: "seed", onChange });
+    await harness.ready();
+
+    // Rich-paste debris can leave format bits on the live selection; they
+    // survive a root clear, so without the reset every message typed after a
+    // send would inherit the `code` format (PRO-159).
+    act(() => {
+      harness.editor.update(() => {
+        const selection = $getRoot().selectEnd();
+        selection.format = 16;
+        selection.dirty = true;
+      }, { discrete: true });
+    });
+
+    onChange.mockClear();
+    harness.rerender({ value: "", snapshot: undefined });
+    await waitFor(() => expect(harness.root.textContent).toBe(""));
+
+    expect(harness.editor.getEditorState().read(() => {
+      const selection = $getSelection();
+      return $isRangeSelection(selection) ? selection.format : null;
+    })).toBe(0);
+
+    act(() => insertText(harness.editor, "plain again"));
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe("plain again");
+  });
+
   it("keeps formatted Markdown paste literal inside a code block", async () => {
     const onChange = vi.fn();
     const harness = renderEditor({
@@ -349,7 +380,7 @@ describe("ComposerFencedCodePlugin", () => {
 
 function renderEditor(overrides: Partial<ComposerRichTextEditorProps> = {}) {
   let editor: LexicalEditor | null = null;
-  const props: ComposerRichTextEditorProps = {
+  let props: ComposerRichTextEditorProps = {
     value: "seed",
     onChange: vi.fn(),
     canSubmit: true,
@@ -359,11 +390,15 @@ function renderEditor(overrides: Partial<ComposerRichTextEditorProps> = {}) {
     editorRef: (next) => { editor = next; },
     ...overrides,
   };
-  const { container } = render(<ComposerRichTextEditor {...props} />);
+  const rendered = render(<ComposerRichTextEditor {...props} />);
   return {
     get editor() { return editor!; },
-    root: container.querySelector<HTMLElement>("[data-chat-composer-editor]")!,
+    root: rendered.container.querySelector<HTMLElement>("[data-chat-composer-editor]")!,
     ready: () => waitFor(() => expect(editor).toBeTruthy()),
+    rerender(next: Partial<ComposerRichTextEditorProps>) {
+      props = { ...props, ...next };
+      rendered.rerender(<ComposerRichTextEditor {...props} />);
+    },
   };
 }
 

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerFencedCodePlugin.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerFencedCodePlugin.test.tsx
@@ -9,6 +9,7 @@ import {
   $getSelection,
   $isRangeSelection,
   KEY_ENTER_COMMAND,
+  PASTE_COMMAND,
   type LexicalEditor,
 } from "lexical";
 import {
@@ -254,6 +255,73 @@ describe("ComposerFencedCodePlugin", () => {
     expect(onChange.mock.calls.at(-1)?.[0]).toBe(`\`\`\`\n${code}\n\`\`\`\n`);
   });
 
+  it("keeps pasted inline-code characters but strips the code text format", async () => {
+    mockRangeRect();
+    const onChange = vi.fn();
+    const harness = renderEditor({ value: "", onChange });
+    await harness.ready();
+    act(() => resetText(harness.editor, ""));
+    onChange.mockClear();
+
+    // A copied rendered code span arrives as text/html <code>; Lexical maps a
+    // single-line <code> to the inline-code text format rather than a block.
+    act(() => {
+      harness.editor.dispatchCommand(
+        PASTE_COMMAND,
+        htmlPasteEvent("<code>const ready = true;</code>", "const ready = true;"),
+      );
+    });
+
+    await waitFor(() => {
+      expect(harness.root.textContent).toBe("const ready = true;");
+    });
+    expect(harness.root.querySelector("code")).toBeNull();
+    act(() => {
+      harness.editor.update(() => {
+        $getRoot().getAllTextNodes().at(-1)?.selectEnd();
+      }, { discrete: true });
+    });
+    await typeCharacters(harness.editor, " and typed", harness.root);
+    expect(harness.root.querySelector("code")).toBeNull();
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe("const ready = true; and typed");
+  });
+
+  it("imports a pasted rendered code block as one escapable block", async () => {
+    const onChange = vi.fn();
+    const harness = renderEditor({ value: "", onChange });
+    await harness.ready();
+    act(() => resetText(harness.editor, ""));
+    onChange.mockClear();
+
+    act(() => {
+      harness.editor.dispatchCommand(
+        PASTE_COMMAND,
+        htmlPasteEvent(
+          "<pre><code>const x = 1;\nconst y = 2;</code></pre>",
+          "const x = 1;\nconst y = 2;",
+        ),
+      );
+    });
+
+    const codeBlock = await waitFor(() => {
+      const code = harness.root.querySelector<HTMLElement>('code[spellcheck="false"]');
+      expect(code).toBeTruthy();
+      return code!;
+    });
+    // One block, not Lexical's nested <pre><code> double conversion.
+    expect(harness.root.querySelectorAll("code")).toHaveLength(1);
+    expect(codeBlock.textContent).toBe("const x = 1;const y = 2;");
+    // The trailing continuation paragraph is the escape hatch below the block.
+    await waitFor(() => {
+      expect(harness.editor.getEditorState().read(() =>
+        $getRoot().getLastChild()?.getType(),
+      )).toBe("paragraph");
+    });
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe(
+      "```\nconst x = 1;\nconst y = 2;\n```\n",
+    );
+  });
+
   it("keeps formatted Markdown paste literal inside a code block", async () => {
     const onChange = vi.fn();
     const harness = renderEditor({
@@ -353,6 +421,38 @@ function pasteEvent(text: string, files: File[] = []): ClipboardEvent {
       files,
       getData: (type: string) => type === "text/plain" ? text : "",
       types: files.length > 0 ? ["Files"] : ["text/plain"],
+    },
+  });
+  return event;
+}
+
+// jsdom has no Range.getBoundingClientRect; Lexical's scroll-into-view path
+// needs one once the editor root has taken focus (a paste commit restores it).
+function mockRangeRect() {
+  Object.defineProperty(Range.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({
+      bottom: 0,
+      height: 0,
+      left: 0,
+      right: 0,
+      toJSON: () => ({}),
+      top: 0,
+      width: 0,
+      x: 0,
+      y: 0,
+    }),
+  });
+}
+
+function htmlPasteEvent(html: string, plain: string): ClipboardEvent {
+  const event = new ClipboardEvent("paste", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "clipboardData", {
+    value: {
+      files: [],
+      getData: (type: string) =>
+        type === "text/html" ? html : type === "text/plain" ? plain : "",
+      types: ["text/html", "text/plain"],
     },
   });
   return event;

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerFencedCodePlugin.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerFencedCodePlugin.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import {
   $addUpdateTag,
   $createParagraphNode,
+  $isElementNode,
   $isLineBreakNode,
   $isParagraphNode,
   HISTORY_PUSH_TAG,
@@ -18,47 +19,83 @@ import {
   selectComposerContinuationAfter,
 } from "#product/components/workspace/chat/input/ComposerEditorDocument";
 
+const CODE_NODE_KLASS = COMPOSER_CODE_TRANSFORMER.dependencies[0]!;
+
 /** Promotes a typed Markdown fence only after its matching close fence exists. */
 export function ComposerFencedCodePlugin() {
   const [editor] = useLexicalComposerContext();
 
-  useEffect(() => editor.registerNodeTransform(TextNode, (textNode) => {
-    const paragraph = textNode.getParent();
-    if (!$isParagraphNode(paragraph) || paragraph.getParent()?.getType() !== "root") {
-      return;
-    }
-    const markdown = paragraph.getTextContent();
-    const fence = findCompleteComposerCodeFence(markdown);
-    if (!fence) return;
+  useEffect(() => {
+    const unregisterTextTransform = editor.registerNodeTransform(TextNode, (textNode) => {
+      // The composer has no way to author the inline-code text format (typed
+      // backticks stay literal), so any occurrence is rich-paste debris. Left
+      // alone it renders unstyled yet serializes backtick-wrapped, turning
+      // subsequent messages into code (PRO-159) — keep the characters, drop
+      // the format.
+      if (textNode.hasFormat("code")) {
+        textNode.toggleFormat("code");
+        return;
+      }
+      const paragraph = textNode.getParent();
+      if (!$isParagraphNode(paragraph) || paragraph.getParent()?.getType() !== "root") {
+        return;
+      }
+      const markdown = paragraph.getTextContent();
+      const fence = findCompleteComposerCodeFence(markdown);
+      if (!fence) return;
 
-    const importedNodes = $generateNodesFromMarkdownString(
-      fence.markdown,
-      [COMPOSER_CODE_TRANSFORMER],
-    );
-    const codeNode = importedNodes.length === 1 ? importedNodes[0] : null;
-    if (!codeNode || codeNode.getType() !== "code") return;
+      const importedNodes = $generateNodesFromMarkdownString(
+        fence.markdown,
+        [COMPOSER_CODE_TRANSFORMER],
+      );
+      const codeNode = importedNodes.length === 1 ? importedNodes[0] : null;
+      if (!codeNode || codeNode.getType() !== "code") return;
 
-    const children = paragraph.getChildren();
-    const fenceStart = childBoundaryAtOffset(children, fence.start);
-    const fenceEnd = childBoundaryAtOffset(children, fence.end);
-    if (fenceStart === null || fenceEnd === null) return;
+      const children = paragraph.getChildren();
+      const fenceStart = childBoundaryAtOffset(children, fence.start);
+      const fenceEnd = childBoundaryAtOffset(children, fence.end);
+      if (fenceStart === null || fenceEnd === null) return;
 
-    let replaceStart = fenceStart;
-    let replaceEnd = fenceEnd;
-    if ($isLineBreakNode(children[replaceStart - 1])) replaceStart -= 1;
-    if ($isLineBreakNode(children[replaceEnd])) replaceEnd += 1;
+      let replaceStart = fenceStart;
+      let replaceEnd = fenceEnd;
+      if ($isLineBreakNode(children[replaceStart - 1])) replaceStart -= 1;
+      if ($isLineBreakNode(children[replaceEnd])) replaceEnd += 1;
 
-    const suffixChildren = children.slice(replaceEnd);
-    const suffix = suffixChildren.length > 0 ? $createParagraphNode() : null;
-    suffix?.append(...suffixChildren);
-    for (const child of children.slice(replaceStart, replaceEnd)) child.remove();
+      const suffixChildren = children.slice(replaceEnd);
+      const suffix = suffixChildren.length > 0 ? $createParagraphNode() : null;
+      suffix?.append(...suffixChildren);
+      for (const child of children.slice(replaceStart, replaceEnd)) child.remove();
 
-    if (paragraph.isEmpty()) paragraph.replace(codeNode);
-    else paragraph.insertAfter(codeNode);
-    if (suffix) codeNode.insertAfter(suffix);
-    selectComposerContinuationAfter([codeNode]);
-    $addUpdateTag(HISTORY_PUSH_TAG);
-  }), [editor]);
+      if (paragraph.isEmpty()) paragraph.replace(codeNode);
+      else paragraph.insertAfter(codeNode);
+      if (suffix) codeNode.insertAfter(suffix);
+      selectComposerContinuationAfter([codeNode]);
+      $addUpdateTag(HISTORY_PUSH_TAG);
+    });
+
+    const unregisterCodeTransform = editor.registerNodeTransform(CODE_NODE_KLASS, (codeNode) => {
+      if (!$isElementNode(codeNode)) return;
+      // Lexical's HTML import converts a pasted <pre><code> pair into a code
+      // block nested inside another one; dissolve the inner block into its
+      // parent so the paste is one editable block.
+      if (codeNode.getParent()?.getType() === "code") {
+        for (const child of codeNode.getChildren()) codeNode.insertBefore(child);
+        codeNode.remove();
+        return;
+      }
+      // A code block has no closing fence to type past, so a document that
+      // ends with one traps the caret. Guarantee the continuation paragraph
+      // the typed-fence path already creates.
+      if (codeNode.getParent()?.getType() === "root" && codeNode.getNextSibling() === null) {
+        codeNode.insertAfter($createParagraphNode());
+      }
+    });
+
+    return () => {
+      unregisterTextTransform();
+      unregisterCodeTransform();
+    };
+  }, [editor]);
 
   return null;
 }

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.test.tsx
@@ -228,6 +228,37 @@ describe("ComposerRichTextEditor", () => {
     );
   });
 
+  it("resets inherited text formats when an external value replaces the draft", async () => {
+    mockRangeRect({ height: 15, left: 24, top: 18 });
+    const onChange = vi.fn();
+    const harness = renderEditor({ value: "seed", onChange });
+    await harness.ready();
+
+    // Rich-paste debris can leave format bits on the live selection; they
+    // survive a root clear, so without the reset every message typed after a
+    // send would inherit the `code` format (PRO-159).
+    act(() => {
+      harness.editor.update(() => {
+        const selection = $getRoot().selectEnd();
+        selection.format = 16;
+        selection.dirty = true;
+      }, { discrete: true });
+    });
+
+    onChange.mockClear();
+    harness.rerender({ value: "", snapshot: undefined });
+    await waitFor(() => expect(harness.root.textContent).toBe(""));
+
+    expect(harness.editor.getEditorState().read(() => {
+      const selection = $getSelection();
+      return $isRangeSelection(selection) ? selection.format : null;
+    })).toBe(0);
+
+    act(() => insertText(harness.editor, "plain again"));
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe("plain again");
+  });
+
   it("restores pasted-link identity from the controlled snapshot", async () => {
     const onChange = vi.fn();
     const harness = renderEditor({ onChange });

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.test.tsx
@@ -228,37 +228,6 @@ describe("ComposerRichTextEditor", () => {
     );
   });
 
-  it("resets inherited text formats when an external value replaces the draft", async () => {
-    mockRangeRect({ height: 15, left: 24, top: 18 });
-    const onChange = vi.fn();
-    const harness = renderEditor({ value: "seed", onChange });
-    await harness.ready();
-
-    // Rich-paste debris can leave format bits on the live selection; they
-    // survive a root clear, so without the reset every message typed after a
-    // send would inherit the `code` format (PRO-159).
-    act(() => {
-      harness.editor.update(() => {
-        const selection = $getRoot().selectEnd();
-        selection.format = 16;
-        selection.dirty = true;
-      }, { discrete: true });
-    });
-
-    onChange.mockClear();
-    harness.rerender({ value: "", snapshot: undefined });
-    await waitFor(() => expect(harness.root.textContent).toBe(""));
-
-    expect(harness.editor.getEditorState().read(() => {
-      const selection = $getSelection();
-      return $isRangeSelection(selection) ? selection.format : null;
-    })).toBe(0);
-
-    act(() => insertText(harness.editor, "plain again"));
-    await waitFor(() => expect(onChange).toHaveBeenCalled());
-    expect(onChange.mock.calls.at(-1)?.[0]).toBe("plain again");
-  });
-
   it("restores pasted-link identity from the controlled snapshot", async () => {
     const onChange = vi.fn();
     const harness = renderEditor({ onChange });

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
@@ -257,7 +257,15 @@ function ComposerEditorBridge({
     editor.update(() => {
       $getRoot().clear();
       if (value) $convertFromMarkdownString(value, INPUT_TRANSFORMERS);
-      $getRoot().selectEnd();
+      // Reset inherited text formats along with the content: the selection's
+      // format bits survive a root clear, so a code-formatted draft would
+      // otherwise re-apply `code` to everything typed after a send (PRO-159).
+      const selection = $getRoot().selectEnd();
+      if (selection.format !== 0 || selection.style !== "") {
+        selection.format = 0;
+        selection.style = "";
+        selection.dirty = true;
+      }
     }, { tag: EXTERNAL_VALUE_TAG });
   }, [editor, snapshot, value]);
 

--- a/specs/codebase/systems/product/chat/composer.md
+++ b/specs/codebase/systems/product/chat/composer.md
@@ -111,6 +111,18 @@ edits — submits on plain Enter or Cmd/Ctrl-Enter, including from a list item o
 code block, and Shift-Enter inserts a newline without submitting. Queued edits
 use the workspace editor's minimum height, row cap, and overflow scrolling.
 
+Rich clipboard code is normalized on entry. A pasted rendered code block
+(`text/html` `<pre><code>`) imports as one editable code block — Lexical's
+double `<pre>`/`<code>` conversion is dissolved — and a code block that ends
+the draft always keeps a continuation paragraph after it, so the caret can
+always leave the block (the same continuation the typed-fence path creates).
+The inline-code text format is not part of the composer's document model:
+there is no way to author it (typed backticks stay literal), so rich pastes
+that carry it keep their characters and drop the format. An external draft
+replacement resets inherited selection formats along with the content;
+without that reset the format bits survive the clear and re-apply to
+everything typed after a send (PRO-159).
+
 Lexical's high-priority Enter and Tab commands own this decision before native
 editor mutation. The surface applies the shared submit contract exactly once;
 Shift-Enter and list indentation stay Lexical-owned. The


### PR DESCRIPTION
## Summary

- Fixes PRO-159: after pasting a rendered code block into the composer, every subsequent message — in the same session and every other session of the workspace — serialized as code until an app restart.
- Root cause had two shapes, both from rich (`text/html`) clipboard code:
  - A single-line `<code>` imported as Lexical's inline-code **text format**: invisible (the composer theme styles no code format), unescapable, serialized backtick-wrapped — and the format bits live on the *selection*, which survives the post-send root clear. The one editor instance is shared across session tabs, so the poison followed the user everywhere until a restart remounted it.
  - A multi-line `<pre><code>` imported as a code block **nested inside another code block** (both of Lexical's import rules fire), trapping the caret with no continuation line to escape to.
- Three normalizations, matching the composer's document model:
  - The external-value clear/import path in `ComposerEditorBridge` resets the selection's `format`/`style` along with the content, so a send never bequeaths formats to the next message.
  - The inline-code text format is unauthorable in the composer (typed backticks stay literal), so a `TextNode` transform keeps pasted characters and drops the format.
  - A code-node transform dissolves the double `<pre>`/`<code>` conversion into one block and guarantees the same continuation paragraph after a draft-final code block that the typed-fence path already creates (`selectComposerContinuationAfter`).
- `specs/codebase/systems/product/chat/composer.md` documents the normalization contract.

## Testing

- Unit (Tier 1, jsdom): new coverage in `ComposerFencedCodePlugin.test.tsx` (inline-code strip keeps characters; `<pre><code>` imports as one escapable block with the continuation paragraph) and `ComposerRichTextEditor.test.tsx` (external value replacement resets inherited selection formats). One existing `ComposerCommandEditor` expectation updated for the continuation paragraph's trailing newline — the same shape the pasted-fence test already asserts.
- `pnpm vitest run src/components/workspace/chat/input/` — all composer suites green (the 5 pre-existing `ProductHostProvider` resolution failures in this package reproduce identically on `main`).
- `pnpm typecheck` — clean.
- End-to-end (local, not committed): a Playwright harness drove the real editor + real `chat-input-store` loop in Chromium and WebKit with real keystrokes and three paste transports (synthetic `ClipboardEvent`, async-clipboard Cmd+V, macOS system pasteboard Cmd+V). Before: reproduced the full reported poison (invisible code, unescapable, `format=16` typing after send and across session switches). After: every scenario stays clean — single code block + escape paragraph on multi-line paste, plain characters on inline paste, `format=0` typing after send and across sessions.

## Observability

- none

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- Paste a rendered code block (e.g. copy from a docs page or the transcript) into the composer: multi-line arrives as one visible code block with a paragraph below it; a copied inline code span arrives as plain characters.
- Type, select-all, overtype, send with Enter — the sent message renders as code only when it really is a fenced block, and the next message you type is plain, in the same session and after switching session tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)