### PR TITLE
fix(product): compact composer controls when the pane narrows (PRO-151)

### DIFF
--- a/apps/packages/product-client/src/components/home/screen/HomeComposerForm.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeComposerForm.tsx
@@ -156,7 +156,10 @@ export function HomeComposerForm({
       </DebugProfiler>
 
       <DebugProfiler id="home-composer">
-        <div className="relative z-10" data-focus-zone="chat">
+        {/* @container: Home has no ChatComposerDock column, so the composer
+            wrapper itself anchors the control row's compact-tier container
+            queries (see chat-layout.ts). */}
+        <div className="relative z-10 @container" data-focus-zone="chat">
           <ChatComposerSurface>
             <form
               className="relative flex flex-col"

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInputControlRow.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInputControlRow.test.tsx
@@ -178,6 +178,27 @@ describe("ChatInputControlRow", () => {
     expect(mode.querySelector("svg")).toBeNull();
   });
 
+  it("mounts no trailing pending slot while a mode change is submitting", () => {
+    const controls = createControls();
+    controls[0] = { ...controls[0], pendingState: "submitting" };
+    renderControlRow({ sessionConfigControls: controls });
+
+    // Submitting renders no glyph, so the trailing wrapper must not mount:
+    // a zero-width flex item still claims the pill's gap, pushing the compact
+    // icon off-center and snapping the width when the pending state clears.
+    const mode = screen.getByRole("button", { name: "Mode: Default" });
+    expect(mode.querySelector(".ml-auto")).toBeNull();
+  });
+
+  it("keeps the queued clock in the mode pill's trailing slot", () => {
+    const controls = createControls();
+    controls[0] = { ...controls[0], pendingState: "queued" };
+    renderControlRow({ sessionConfigControls: controls });
+
+    const mode = screen.getByRole("button", { name: "Mode: Default" });
+    expect(mode.querySelector(".ml-auto svg")).not.toBeNull();
+  });
+
   it("swaps an icon-configured working mode's word for its icon under the compact tier", () => {
     const controls = createControls();
     controls[0] = {

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInputControlRow.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInputControlRow.test.tsx
@@ -178,6 +178,18 @@ describe("ChatInputControlRow", () => {
     expect(mode.querySelector("svg")).toBeNull();
   });
 
+  it("caps the model pill by its wrapper so it cannot paint over the mode pill", () => {
+    renderControlRow();
+
+    // Both bounds in one arbitrary value: the 15rem identity budget AND the
+    // wrapper width. A bare rem cap replaces the primitive's max-w-full in
+    // tailwind-merge, and the pill's column-flex wrapper does not otherwise
+    // constrain the button — it overflows onto the mode pill instead of
+    // truncating.
+    const model = screen.getByRole("button", { name: "Model: Opus 4.1" });
+    expect(model.className).toContain("max-w-[min(15rem,100%)]");
+  });
+
   it("mounts no trailing pending slot while a mode change is submitting", () => {
     const controls = createControls();
     controls[0] = { ...controls[0], pendingState: "submitting" };

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInputControlRow.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInputControlRow.test.tsx
@@ -178,6 +178,42 @@ describe("ChatInputControlRow", () => {
     expect(mode.querySelector("svg")).toBeNull();
   });
 
+  it("swaps an icon-configured working mode's word for its icon under the compact tier", () => {
+    const controls = createControls();
+    controls[0] = {
+      ...controls[0],
+      key: "mode",
+      options: [
+        { value: "bypassPermissions", label: "Bypass", selected: true },
+        { value: "plan", label: "Plan", selected: false },
+      ],
+    };
+    renderControlRow({ sessionConfigControls: controls });
+
+    const mode = screen.getByRole("button", { name: "Mode: Bypass" });
+    // One button, CSS-swapped: the icon renders only under the compact
+    // container tier, the word hides there, and the pill stops shrinking so
+    // the icon can never be squeezed into its neighbors.
+    const iconWrapper = mode.querySelector("svg")?.parentElement;
+    expect(iconWrapper?.className).toContain("hidden");
+    expect(iconWrapper?.className).toContain("@max-[32rem]:flex");
+    const label = screen.getByText("Bypass");
+    expect(label.closest('[class*="@max-[32rem]:hidden"]')).not.toBeNull();
+    expect(mode.className).toContain("@max-[32rem]:shrink-0");
+  });
+
+  it("hides the reasoning level word under the compact tier, keeping the bars", () => {
+    renderControlRow();
+
+    const label = screen.getByText("Medium");
+    expect(label.closest('[class*="@max-[32rem]:hidden"]')).not.toBeNull();
+    const reasoning = screen.getByRole("button", { name: "Reasoning: Medium" });
+    expect(
+      reasoning.querySelector("[data-level-bars-icon]")
+        ?.closest('[class*="@max-[32rem]:hidden"]'),
+    ).toBeNull();
+  });
+
   it("orders model, working mode, reasoning bars, and fast mode in the visible row", () => {
     renderControlRow();
 

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInputControlRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInputControlRow.tsx
@@ -89,19 +89,17 @@ export function ComposerLeadingControls({
         />
       </div>
 
-      {/* 2. Primary working mode control (bypass/plan/etc) */}
+      {/* 2. Primary working mode control (bypass/plan/etc). The trigger is
+          the flex item itself (no wrapper span): SessionModeControl owns its
+          compact-tier shrink behavior, and a min-w-0 wrapper would let the
+          cluster squeeze the pill below its icon regardless. */}
       {controlGroups.modeControl && (
-        <span
-          className={`inline-flex min-w-0 ${
-            runtimeControlsDisabled ? "pointer-events-none opacity-55" : ""
-          }`}
-        >
-          <SessionModeControl
-            agentKind={agentKind}
-            control={controlGroups.modeControl}
-            triggerStyle="value"
-          />
-        </span>
+        <SessionModeControl
+          agentKind={agentKind}
+          control={controlGroups.modeControl}
+          triggerStyle="value"
+          className={runtimeControlsDisabled ? "pointer-events-none opacity-55" : ""}
+        />
       )}
 
       {/* 3. Reasoning/effort bars */}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerFastModeToggle.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerFastModeToggle.tsx
@@ -6,7 +6,10 @@ import type { LiveSessionControlDescriptor } from "#product/lib/domain/chat/sess
 import { Zap } from "#product/primitives/icons/product";
 import { Tooltip } from "#product/primitives/Tooltip";
 import { ComposerControlButton } from "#product/primitives/patterns/ComposerControlButton";
-import { PendingConfigIndicator } from "#product/components/workspace/chat/input/PendingConfigIndicator";
+import {
+  PendingConfigIndicator,
+  showsPendingConfigIndicator,
+} from "#product/components/workspace/chat/input/PendingConfigIndicator";
 
 interface ComposerFastModeToggleProps {
   control: LiveSessionControlDescriptor;
@@ -48,7 +51,7 @@ export function ComposerFastModeToggle({ control }: ComposerFastModeToggleProps)
     />
   );
 
-  if (control.pendingState) {
+  if (showsPendingConfigIndicator(control.pendingState)) {
     return (
       <Tooltip content={tooltip}>
         <span className="inline-flex items-center gap-1">

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerIntegrationsControl.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerIntegrationsControl.tsx
@@ -1,5 +1,9 @@
 import { useNavigate } from "react-router-dom";
 import { Button } from "#product/primitives/Button";
+import {
+  COMPOSER_COMPACT_HIDDEN_CLASSNAME,
+  COMPOSER_COMPACT_SHRINK_NONE_CLASSNAME,
+} from "#product/config/chat-layout";
 import { ComposerControlButton } from "#product/primitives/patterns/ComposerControlButton";
 import { PopoverButton } from "#product/primitives/PopoverButton";
 import { ArrowUpRight, Settings } from "#product/primitives/icons/core";
@@ -53,6 +57,11 @@ export function ComposerIntegrationsControl() {
         <ComposerControlButton
           iconOnly={connectedCount === 0 && !isUrgent}
           label={triggerLabel}
+          // Compact tier: the connected count yields to the glyph alone. The
+          // urgent re-auth label stays visible (and shrinkable) at every
+          // width — a warning reduced to a dot is no warning.
+          labelWrapperClassName={isUrgent ? "" : COMPOSER_COMPACT_HIDDEN_CLASSNAME}
+          className={isUrgent ? "" : COMPOSER_COMPACT_SHRINK_NONE_CLASSNAME}
           aria-label={triggerAriaLabel}
           icon={
             isUrgent ? (

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
@@ -9,7 +9,10 @@ import type { ModelSelectorProps } from "#product/lib/domain/chat/models/model-s
 import { ComposerControlButton } from "#product/primitives/patterns/ComposerControlButton";
 import { PopoverButton } from "#product/primitives/PopoverButton";
 import { ProviderIcon } from "#product/primitives/icons/provider-icons";
-import { PendingConfigIndicator } from "#product/components/workspace/chat/input/PendingConfigIndicator";
+import {
+  PendingConfigIndicator,
+  showsPendingConfigIndicator,
+} from "#product/components/workspace/chat/input/PendingConfigIndicator";
 import { ComposerFieldInlineError } from "#product/components/workspace/chat/input/ComposerFieldInlineError";
 import { ComposerModelPickerPopover } from "#product/components/workspace/chat/input/ComposerModelPickerPopover";
 import { useModelSupportStore } from "#product/stores/chat/model-support-store";
@@ -132,8 +135,8 @@ export function ComposerModelSelectorControl({
             data-composer-selected-model={selectedModelId}
             icon={currentModel ? <ProviderIcon kind={currentModel.kind} className="icon-control shrink-0 [font-size:var(--text-body)]" /> : undefined}
             label={triggerLabel}
-            trailing={currentModel?.pendingState
-              ? <PendingConfigIndicator pendingState={currentModel.pendingState} />
+            trailing={showsPendingConfigIndicator(currentModel?.pendingState ?? null)
+              ? <PendingConfigIndicator pendingState={currentModel?.pendingState ?? null} />
               : null}
             aria-label={`Model: ${triggerLabel}`}
             aria-invalid={unsupportedSelectionMessage ? true : undefined}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
@@ -120,7 +120,7 @@ export function ComposerModelSelectorControl({
         data-composer-selected-model={selectedModelId}
         icon={currentModel ? <ProviderIcon kind={currentModel.kind} className="icon-control shrink-0 [font-size:var(--text-body)]" /> : undefined}
         label={triggerLabel}
-        className="max-w-[15rem]"
+        className="max-w-[min(15rem,100%)]"
       />
     );
   }
@@ -143,7 +143,7 @@ export function ComposerModelSelectorControl({
             aria-describedby={unsupportedSelectionMessage
               ? MODEL_UNSUPPORTED_MESSAGE_ID
               : undefined}
-            className="max-w-[15rem]"
+            className="max-w-[min(15rem,100%)]"
           />
         )}
         side="top"

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerReasoningEffortBars.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerReasoningEffortBars.tsx
@@ -6,6 +6,7 @@ import {
   type ReasoningEffortTierTone,
 } from "#product/lib/domain/chat/session-controls/session-reasoning-effort-control";
 import { resolveSessionControlTooltip } from "#product/lib/domain/chat/session-controls/session-toggle-control";
+import { COMPOSER_COMPACT_HIDDEN_CLASSNAME } from "#product/config/chat-layout";
 import type { LiveSessionControlDescriptor } from "#product/lib/domain/chat/session-controls/session-controls";
 import { Tooltip } from "#product/primitives/Tooltip";
 import { AnimatedSwapText } from "#product/primitives/AnimatedSwapText";
@@ -71,6 +72,8 @@ export function ComposerReasoningEffortBars({
         currentIndex={effectiveIndex}
         onStep={(nextValue: string) => control.onSelect(nextValue)}
         label={labelNode}
+        // Compact tier: the level word yields, the bars keep reading the level.
+        labelWrapperClassName={COMPOSER_COMPACT_HIDDEN_CLASSNAME}
         emphasis="none"
         className={`gap-0.5 ${toneClass} ${chipClass}`}
         disabled={!control.settable}

--- a/apps/packages/product-client/src/components/workspace/chat/input/PendingConfigIndicator.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/PendingConfigIndicator.tsx
@@ -6,15 +6,28 @@ interface PendingConfigIndicatorProps {
   className?: string;
 }
 
+/**
+ * True when the pending state renders a visible glyph. Submitting and
+ * settling are deliberately invisible — the optimistically-updated control is
+ * itself the feedback — so callers must gate their trailing slot on this
+ * instead of on `pendingState` being set: a trailing wrapper around a
+ * null-rendering indicator is a zero-width flex item that still claims the
+ * pill's gap and pushes an icon-only control off-center.
+ */
+export function showsPendingConfigIndicator(
+  pendingState: PendingSessionConfigChangeStatus | null,
+): boolean {
+  return pendingState === "queued";
+}
+
 export function PendingConfigIndicator({
   pendingState,
   className = "size-3 shrink-0 text-muted-foreground/70",
 }: PendingConfigIndicatorProps) {
-  // Submitting renders nothing because the optimistically-updated control is itself the feedback;
-  // queued keeps the clock because the change is waiting on the running turn.
-  if (pendingState === "queued") {
-    return <Clock className={className} />;
+  // Queued keeps the clock because the change is waiting on the running turn.
+  if (!showsPendingConfigIndicator(pendingState)) {
+    return null;
   }
 
-  return null;
+  return <Clock className={className} />;
 }

--- a/apps/packages/product-client/src/components/workspace/chat/input/SessionConfigControls.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/SessionConfigControls.tsx
@@ -11,7 +11,10 @@ import { Tooltip } from "#product/primitives/Tooltip";
 import { POPOVER_SURFACE_CLASS, PopoverButton } from "#product/primitives/PopoverButton";
 import { PopoverMenuItem } from "#product/primitives/PopoverMenuItem";
 import { ComposerControlButton } from "#product/primitives/patterns/ComposerControlButton";
-import { PendingConfigIndicator } from "#product/components/workspace/chat/input/PendingConfigIndicator";
+import {
+  PendingConfigIndicator,
+  showsPendingConfigIndicator,
+} from "#product/components/workspace/chat/input/PendingConfigIndicator";
 import { SessionModeControl } from "#product/components/workspace/chat/input/SessionModeControl";
 
 interface SessionConfigControlsProps {
@@ -83,7 +86,9 @@ function ToggleControl({ control }: { control: LiveSessionControlDescriptor }) {
           active={!!control.isEnabled}
           icon={<Icon className={`icon-control [font-size:var(--text-body)] ${control.isEnabled ? "" : "opacity-65"}`} />}
           label={triggerLabel}
-          trailing={<PendingConfigIndicator pendingState={control.pendingState} />}
+          trailing={showsPendingConfigIndicator(control.pendingState)
+        ? <PendingConfigIndicator pendingState={control.pendingState} />
+        : null}
           aria-label={tooltip}
           className="max-w-[12rem]"
           data-session-config-control={control.key}
@@ -104,7 +109,9 @@ function ToggleControl({ control }: { control: LiveSessionControlDescriptor }) {
       active={!!control.isEnabled}
       label={control.label}
       detail={control.detail}
-      trailing={<PendingConfigIndicator pendingState={control.pendingState} />}
+      trailing={showsPendingConfigIndicator(control.pendingState)
+        ? <PendingConfigIndicator pendingState={control.pendingState} />
+        : null}
       className="max-w-[12rem]"
       data-session-config-control={control.key}
       data-session-config-selected={selectedOption?.value ?? ""}
@@ -138,7 +145,9 @@ function SelectControl({ control }: { control: LiveSessionControlDescriptor }) {
         <ComposerControlButton
           label={control.label}
           detail={control.detail}
-          trailing={<PendingConfigIndicator pendingState={control.pendingState} />}
+          trailing={showsPendingConfigIndicator(control.pendingState)
+        ? <PendingConfigIndicator pendingState={control.pendingState} />
+        : null}
           className="max-w-[14rem]"
           data-session-config-control={control.key}
           data-session-config-selected={selectedOption?.value ?? ""}

--- a/apps/packages/product-client/src/components/workspace/chat/input/SessionModeControl.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/SessionModeControl.tsx
@@ -16,7 +16,10 @@ import { Check } from "#product/primitives/icons/core";
 import { PopoverMenuItem } from "#product/primitives/PopoverMenuItem";
 import { ComposerControlButton } from "#product/primitives/patterns/ComposerControlButton";
 import { AnimatedSwapText } from "#product/primitives/AnimatedSwapText";
-import { PendingConfigIndicator } from "#product/components/workspace/chat/input/PendingConfigIndicator";
+import {
+  PendingConfigIndicator,
+  showsPendingConfigIndicator,
+} from "#product/components/workspace/chat/input/PendingConfigIndicator";
 
 type ModeControlDescriptor = LiveSessionControlDescriptor & {
   key: ConfiguredSessionControlKey;
@@ -74,8 +77,10 @@ export function SessionModeControl({
     swapsToIconWhenCompact ? COMPOSER_COMPACT_SHRINK_NONE_CLASSNAME : ""
   } ${className}`;
   // No disclosure chevron on the compact trigger: the mode name itself steps
-  // immediately to the next runtime-provided value.
-  const triggerTrailing = control.pendingState
+  // immediately to the next runtime-provided value. Gated on the glyph being
+  // visible, not on pendingState existing — a trailing wrapper around a
+  // null-rendering indicator still claims the pill's gap.
+  const triggerTrailing = showsPendingConfigIndicator(control.pendingState)
     ? <PendingConfigIndicator pendingState={control.pendingState} />
     : null;
 

--- a/apps/packages/product-client/src/components/workspace/chat/input/SessionModeControl.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/SessionModeControl.tsx
@@ -1,5 +1,10 @@
 import { CHAT_MODE_CONTROL_LABELS } from "#product/copy/chat/chat-copy";
 import {
+  COMPOSER_COMPACT_HIDDEN_CLASSNAME,
+  COMPOSER_COMPACT_ONLY_FLEX_CLASSNAME,
+  COMPOSER_COMPACT_SHRINK_NONE_CLASSNAME,
+} from "#product/config/chat-layout";
+import {
   getNextSessionModeValue,
   resolveSessionControlPresentation,
 } from "#product/lib/domain/chat/session-controls/session-mode-control";
@@ -21,12 +26,15 @@ interface SessionModeControlProps {
   agentKind: string | null;
   control: ModeControlDescriptor;
   triggerStyle?: "full" | "value";
+  /** Merged onto the trigger button (e.g. the disabled-state opacity). */
+  className?: string;
 }
 
 export function SessionModeControl({
   agentKind,
   control,
   triggerStyle = "full",
+  className = "",
 }: SessionModeControlProps) {
   const currentOption = control.options.find((option) => option.selected) ?? null;
   const currentValue = currentOption?.value ?? null;
@@ -48,9 +56,23 @@ export function SessionModeControl({
   const visibleTriggerDetail = triggerStyle === "value" ? null : animatedValue;
   const compactTrigger = triggerStyle === "value";
   const nextValue = getNextSessionModeValue(control.options, currentValue);
-  const triggerIcon = compactTrigger
+  // The value-style trigger has no leading icon at full width, but below the
+  // composer's compact container tier it swaps the mode name for the mode
+  // icon so the pill keeps a fixed icon footprint instead of truncating
+  // mid-word. Modes without a configured icon keep their text at every width.
+  const swapsToIconWhenCompact = compactTrigger && currentPresentation.icon !== null;
+  const triggerIcon = compactTrigger && !swapsToIconWhenCompact
     ? undefined
     : <SessionControlIcon icon={currentPresentation.icon} className="icon-control [font-size:var(--text-body)]" />;
+  const compactSwapProps = swapsToIconWhenCompact
+    ? {
+      iconWrapperClassName: COMPOSER_COMPACT_ONLY_FLEX_CLASSNAME,
+      labelWrapperClassName: COMPOSER_COMPACT_HIDDEN_CLASSNAME,
+    }
+    : {};
+  const triggerClassName = `max-w-[12rem] ${
+    swapsToIconWhenCompact ? COMPOSER_COMPACT_SHRINK_NONE_CLASSNAME : ""
+  } ${className}`;
   // No disclosure chevron on the compact trigger: the mode name itself steps
   // immediately to the next runtime-provided value.
   const triggerTrailing = control.pendingState
@@ -66,7 +88,8 @@ export function SessionModeControl({
         label={visibleTriggerLabel}
         detail={visibleTriggerDetail}
         trailing={triggerTrailing}
-        className="max-w-[12rem]"
+        className={triggerClassName}
+        {...compactSwapProps}
         data-session-mode-trigger=""
         data-session-mode-selected={currentValue ?? ""}
       />
@@ -82,7 +105,8 @@ export function SessionModeControl({
       trailing={triggerTrailing}
       title={`${CHAT_MODE_CONTROL_LABELS.cycleHint} (${CHAT_MODE_CONTROL_LABELS.shortcut})`}
       aria-label={`${control.label}: ${currentOption?.label ?? currentDetail ?? ""}`}
-      className="max-w-[12rem]"
+      className={triggerClassName}
+      {...compactSwapProps}
       data-session-mode-trigger=""
       data-session-mode-selected={currentValue ?? ""}
       data-session-mode-next={nextValue ?? ""}

--- a/apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceShellRightRail.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceShellRightRail.test.tsx
@@ -52,7 +52,7 @@ describe("WorkspaceShellRightRail", () => {
     // The animated width var clamped so the chat pane keeps its minimum: the
     // rail yields before the composer collapses (MAIN_PANE_MIN_WIDTH).
     expect(rail?.style.width).toBe(
-      "min(var(--workspace-right-width), calc(100% - 420px))",
+      "min(var(--workspace-right-width), calc(100% - 440px))",
     );
     expect(rail?.className).toContain("bg-sidebar-background");
     expect(content?.className).toContain("absolute inset-y-0 right-0");

--- a/apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceShellRightRail.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceShellRightRail.test.tsx
@@ -49,7 +49,11 @@ describe("WorkspaceShellRightRail", () => {
 
     const rail = container.querySelector<HTMLElement>("[data-right-panel-rail]");
     const content = container.querySelector<HTMLElement>("[data-right-panel-content]");
-    expect(rail?.style.width).toBe("var(--workspace-right-width)");
+    // The animated width var clamped so the chat pane keeps its minimum: the
+    // rail yields before the composer collapses (MAIN_PANE_MIN_WIDTH).
+    expect(rail?.style.width).toBe(
+      "min(var(--workspace-right-width), calc(100% - 420px))",
+    );
     expect(rail?.className).toContain("bg-sidebar-background");
     expect(content?.className).toContain("absolute inset-y-0 right-0");
     expect(content?.className).toContain("opacity-100");

--- a/apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceShellRightRail.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceShellRightRail.tsx
@@ -2,7 +2,10 @@ import type { ComponentProps, MouseEventHandler } from "react";
 import { DebugProfiler } from "#product/components/diagnostics/DebugProfiler";
 import { RightPanel } from "#product/components/workspace/shell/right-panel/RightPanel";
 import { WorkspaceResizeSeparator } from "#product/components/workspace/shell/screen/WorkspaceResizeSeparator";
-import { RIGHT_PANEL_MIN_WIDTH } from "#product/lib/domain/workspaces/shell/right-panel-model";
+import {
+  MAIN_PANE_MIN_WIDTH,
+  RIGHT_PANEL_MIN_WIDTH,
+} from "#product/lib/domain/workspaces/shell/right-panel-model";
 
 interface WorkspaceShellRightRailProps
   extends Omit<ComponentProps<typeof RightPanel>, "isOpen"> {
@@ -45,8 +48,12 @@ export function WorkspaceShellRightRail({
         // explicit toggle animates the collapse the drag triggered, and
         // `prefers-reduced-motion` zeroes `--duration-panel` so the panel snaps
         // shut instead.
+        // The min() clamp keeps MAIN_PANE_MIN_WIDTH of this flex row for the
+        // chat pane: the rail yields before the composer collapses. 100%
+        // resolves against the row, and the registered width property still
+        // animates inside the clamp.
         className="relative isolate shrink-0 overflow-hidden bg-sidebar-background"
-        style={{ width: "var(--workspace-right-width)" }}
+        style={{ width: `min(var(--workspace-right-width), calc(100% - ${MAIN_PANE_MIN_WIDTH}px))` }}
         data-right-panel-rail
       >
         <DebugProfiler id="workspace-right-panel">

--- a/apps/packages/product-client/src/config/chat-layout.ts
+++ b/apps/packages/product-client/src/config/chat-layout.ts
@@ -6,6 +6,21 @@
 export const CHAT_COLUMN_CLASSNAME = "mx-auto w-full max-w-transcript-thread";
 export const CHAT_SURFACE_GUTTER_CLASSNAME = "px-4";
 
+/**
+ * Compact control tier: below this composer-container width the labeled
+ * control pills shed their words — the working-mode pill swaps its name for
+ * the mode icon, the reasoning pill keeps only the level bars, and the
+ * integrations pill keeps only the glyph — so the control row degrades to
+ * icons instead of truncating mid-word or painting over its neighbors.
+ * Class-string constants (not a bare width) because Tailwind's scanner needs
+ * the complete variant text in source; they resolve against the nearest
+ * `@container` ancestor (the dock column in chat, the composer wrapper on
+ * Home).
+ */
+export const COMPOSER_COMPACT_HIDDEN_CLASSNAME = "@max-[32rem]:hidden";
+export const COMPOSER_COMPACT_ONLY_FLEX_CLASSNAME = "hidden @max-[32rem]:flex";
+export const COMPOSER_COMPACT_SHRINK_NONE_CLASSNAME = "@max-[32rem]:shrink-0";
+
 export const CHAT_SCROLL_BASE_BOTTOM_PADDING_PX = 40;
 // True visual clearance between the pinned live tail and the dock's top edge.
 // Added on top of the measured dock height (which already includes the dock's

--- a/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.test.ts
+++ b/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.test.ts
@@ -109,7 +109,7 @@ describe("useMainScreenRightPanel drag wiring", () => {
 
   it("lets a drag widen the panel past the legacy ceiling when the window affords it", () => {
     // A wide shell row: the drag's ceiling is the row minus the chat pane's
-    // floor (2000 − 420 = 1580), not the legacy fixed 700.
+    // floor (2000 − 440 = 1560), not the legacy fixed 700.
     const row = document.createElement("div");
     row.getBoundingClientRect = () => ({ width: 2000 } as DOMRect);
     const rail = document.createElement("div");
@@ -151,11 +151,11 @@ describe("useMainScreenRightPanel drag wiring", () => {
       });
       rerender();
 
-      // Asks for 920; the 1000px row only affords 1000 − 420 = 580.
+      // Asks for 920; the 1000px row only affords 1000 − 440 = 560.
       fireDrag(result.current.onRightSeparatorDown, [500]);
       rerender();
 
-      expect(result.current.rightPanelWidth).toBe(580);
+      expect(result.current.rightPanelWidth).toBe(560);
     } finally {
       row.remove();
     }

--- a/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.test.ts
+++ b/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.test.ts
@@ -135,6 +135,38 @@ describe("useMainScreenRightPanel drag wiring", () => {
     }
   });
 
+  it("keeps a sub-threshold rail open while the drag widens it", () => {
+    // The floor clamp has rendered the rail at 204 — below the collapse
+    // threshold. Seeded there, an outward drag must resize (pinned to the
+    // panel's floor), and only an inward shove may close.
+    const row = document.createElement("div");
+    row.getBoundingClientRect = () => ({ width: 1000 } as DOMRect);
+    const rail = document.createElement("div");
+    rail.setAttribute("data-right-panel-rail", "");
+    rail.getBoundingClientRect = () => ({ width: 204 } as DOMRect);
+    row.appendChild(rail);
+    document.body.appendChild(row);
+
+    try {
+      const { result, rerender } = renderRightPanel();
+      act(() => {
+        result.current.setRightPanelOpen(true);
+      });
+      rerender();
+
+      fireDrag(result.current.onRightSeparatorDown, [50]);
+      rerender();
+      expect(result.current.rightPanelOpen).toBe(true);
+      expect(result.current.rightPanelWidth).toBe(RIGHT_PANEL_MIN_WIDTH);
+
+      fireDrag(result.current.onRightSeparatorDown, [-20]);
+      rerender();
+      expect(result.current.rightPanelOpen).toBe(false);
+    } finally {
+      row.remove();
+    }
+  });
+
   it("caps a widening drag at the chat pane's floor", () => {
     const row = document.createElement("div");
     row.getBoundingClientRect = () => ({ width: 1000 } as DOMRect);

--- a/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.test.ts
+++ b/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.test.ts
@@ -76,6 +76,37 @@ function renderRightPanel() {
 }
 
 describe("useMainScreenRightPanel drag wiring", () => {
+  it("seeds a drag from the rendered rail width when the floor clamp holds it below the persisted width", () => {
+    // A rail whose rendered width sits below the persisted 700 — the shape
+    // the MAIN_PANE_MIN_WIDTH clamp produces on a small window.
+    const rail = document.createElement("div");
+    rail.setAttribute("data-right-panel-rail", "");
+    rail.getBoundingClientRect = () =>
+      ({ width: 420 } as DOMRect);
+    document.body.appendChild(rail);
+
+    try {
+      const { result, rerender } = renderRightPanel();
+      act(() => {
+        result.current.setRightPanelOpen(true);
+      });
+      act(() => {
+        result.current.setRightPanelWidth(700);
+      });
+      rerender();
+
+      // Drag 30px narrower. Seeded from the rendered 420 this lands at 390;
+      // seeded from the persisted 700 it would land at 670 — the first 280px
+      // of pointer travel would be dead.
+      fireDrag(result.current.onRightSeparatorDown, [-30]);
+      rerender();
+
+      expect(result.current.rightPanelWidth).toBe(390);
+    } finally {
+      rail.remove();
+    }
+  });
+
   it("resizes the panel through a real mousedown/mousemove/mouseup sequence", () => {
     const { result, rerender } = renderRightPanel();
     act(() => {

--- a/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.test.ts
+++ b/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.test.ts
@@ -107,6 +107,60 @@ describe("useMainScreenRightPanel drag wiring", () => {
     }
   });
 
+  it("lets a drag widen the panel past the legacy ceiling when the window affords it", () => {
+    // A wide shell row: the drag's ceiling is the row minus the chat pane's
+    // floor (2000 − 420 = 1580), not the legacy fixed 700.
+    const row = document.createElement("div");
+    row.getBoundingClientRect = () => ({ width: 2000 } as DOMRect);
+    const rail = document.createElement("div");
+    rail.setAttribute("data-right-panel-rail", "");
+    rail.getBoundingClientRect = () => ({ width: 420 } as DOMRect);
+    row.appendChild(rail);
+    document.body.appendChild(row);
+
+    try {
+      const { result, rerender } = renderRightPanel();
+      act(() => {
+        result.current.setRightPanelOpen(true);
+      });
+      rerender();
+
+      // Widen by 500 from the rendered 420 → 920, beyond the old 700 cap.
+      fireDrag(result.current.onRightSeparatorDown, [500]);
+      rerender();
+
+      expect(result.current.rightPanelWidth).toBe(920);
+    } finally {
+      row.remove();
+    }
+  });
+
+  it("caps a widening drag at the chat pane's floor", () => {
+    const row = document.createElement("div");
+    row.getBoundingClientRect = () => ({ width: 1000 } as DOMRect);
+    const rail = document.createElement("div");
+    rail.setAttribute("data-right-panel-rail", "");
+    rail.getBoundingClientRect = () => ({ width: 420 } as DOMRect);
+    row.appendChild(rail);
+    document.body.appendChild(row);
+
+    try {
+      const { result, rerender } = renderRightPanel();
+      act(() => {
+        result.current.setRightPanelOpen(true);
+      });
+      rerender();
+
+      // Asks for 920; the 1000px row only affords 1000 − 420 = 580.
+      fireDrag(result.current.onRightSeparatorDown, [500]);
+      rerender();
+
+      expect(result.current.rightPanelWidth).toBe(580);
+    } finally {
+      row.remove();
+    }
+  });
+
   it("resizes the panel through a real mousedown/mousemove/mouseup sequence", () => {
     const { result, rerender } = renderRightPanel();
     act(() => {

--- a/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.ts
+++ b/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.ts
@@ -12,8 +12,10 @@ import { useResize } from "#product/hooks/ui/layout/use-resize";
 import {
   DEFAULT_RIGHT_PANEL_DURABLE_STATE,
   DEFAULT_RIGHT_PANEL_MATERIALIZED_STATE,
+  MAIN_PANE_MIN_WIDTH,
   RIGHT_PANEL_DEFAULT_WIDTH,
-  RIGHT_PANEL_MAX_WIDTH,
+  RIGHT_PANEL_FALLBACK_MAX_WIDTH,
+  RIGHT_PANEL_MIN_WIDTH,
   clampRightPanelWidth,
   normalizeRightPanelDurableState,
   resolveRightPanelDragOutcome,
@@ -220,13 +222,21 @@ export function useMainScreenRightPanel({
   // can drop the geometry easing while the width is pointer-driven.
   const rightPanelDragCollapsedRef = useRef(false);
   const rightPanelDragWidthRef = useRef<number | null>(null);
+  // The drag's ceiling, measured at mousedown: the rail's row (window minus
+  // the sidebar at its current width — zero when folded) minus the chat
+  // pane's floor. There is no fixed maximum; a wider window affords a wider
+  // panel. Falls back to the legacy ceiling only when no rail is rendered.
+  const rightPanelDragMaxWidthRef = useRef<number>(RIGHT_PANEL_FALLBACK_MAX_WIDTH);
   const [rightPanelResizing, setRightPanelResizing] = useState(false);
   const handleRightPanelDrag = useCallback(
     (rawWidth: number) => {
       if (rightPanelDragCollapsedRef.current || !workspaceUiKey) {
         return;
       }
-      const outcome = resolveRightPanelDragOutcome(rawWidth);
+      const outcome = resolveRightPanelDragOutcome(
+        rawWidth,
+        rightPanelDragMaxWidthRef.current,
+      );
       if (outcome.kind === "collapse") {
         rightPanelDragCollapsedRef.current = true;
         // Resizing ends here so the collapse itself animates: the last
@@ -271,11 +281,18 @@ export function useMainScreenRightPanel({
     onResize: handleRightPanelDrag,
     onResizeEnd: handleRightSeparatorDragEnd,
     reverse: true,
+    // No static bounds: the raw pointer width must stay visible for the
+    // collapse decision, and the ceiling is per-gesture, measured below.
     min: 0,
-    max: RIGHT_PANEL_MAX_WIDTH,
   });
   const onRightSeparatorDown = useCallback(
     (event: MouseEvent) => {
+      const railRow = document
+        .querySelector("[data-right-panel-rail]")
+        ?.parentElement?.getBoundingClientRect().width;
+      rightPanelDragMaxWidthRef.current = railRow
+        ? Math.max(RIGHT_PANEL_MIN_WIDTH, railRow - MAIN_PANE_MIN_WIDTH)
+        : RIGHT_PANEL_FALLBACK_MAX_WIDTH;
       rightPanelDragCollapsedRef.current = false;
       rightPanelDragWidthRef.current = null;
       setRightPanelResizing(true);

--- a/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.ts
+++ b/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.ts
@@ -252,9 +252,22 @@ export function useMainScreenRightPanel({
       setRightPanelWidthForWorkspace(workspaceUiKey, draggedWidth);
     }
   }, [setRightPanelWidthForWorkspace, workspaceUiKey]);
+  // The rail's rendered width can sit below the persisted width while the
+  // main-pane floor clamps it (MAIN_PANE_MIN_WIDTH in the rail's width
+  // style). Seeding the drag from the rendered edge keeps the separator under
+  // the pointer from the first pixel — starting from the larger persisted
+  // value would replay the clamped-away difference as dead travel before
+  // anything moved.
+  const resolveRenderedRailWidth = useCallback(() => {
+    const railWidth = document
+      .querySelector("[data-right-panel-rail]")
+      ?.getBoundingClientRect().width;
+    return railWidth ? railWidth : rightPanelWidth;
+  }, [rightPanelWidth]);
   const beginRightSeparatorDrag = useResize({
     direction: "horizontal",
     size: rightPanelWidth,
+    resolveSize: resolveRenderedRailWidth,
     onResize: handleRightPanelDrag,
     onResizeEnd: handleRightSeparatorDragEnd,
     reverse: true,

--- a/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.ts
+++ b/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.ts
@@ -227,6 +227,10 @@ export function useMainScreenRightPanel({
   // pane's floor. There is no fixed maximum; a wider window affords a wider
   // panel. Falls back to the legacy ceiling only when no rail is rendered.
   const rightPanelDragMaxWidthRef = useRef<number>(RIGHT_PANEL_FALLBACK_MAX_WIDTH);
+  // The gesture's seed width. The floor clamp can render the rail below the
+  // collapse threshold, so the collapse decision needs the start to tell a
+  // widening drag from a closing shove.
+  const rightPanelDragStartWidthRef = useRef<number>(Number.POSITIVE_INFINITY);
   const [rightPanelResizing, setRightPanelResizing] = useState(false);
   const handleRightPanelDrag = useCallback(
     (rawWidth: number) => {
@@ -236,6 +240,7 @@ export function useMainScreenRightPanel({
       const outcome = resolveRightPanelDragOutcome(
         rawWidth,
         rightPanelDragMaxWidthRef.current,
+        rightPanelDragStartWidthRef.current,
       );
       if (outcome.kind === "collapse") {
         rightPanelDragCollapsedRef.current = true;
@@ -293,12 +298,13 @@ export function useMainScreenRightPanel({
       rightPanelDragMaxWidthRef.current = railRow
         ? Math.max(RIGHT_PANEL_MIN_WIDTH, railRow - MAIN_PANE_MIN_WIDTH)
         : RIGHT_PANEL_FALLBACK_MAX_WIDTH;
+      rightPanelDragStartWidthRef.current = resolveRenderedRailWidth();
       rightPanelDragCollapsedRef.current = false;
       rightPanelDragWidthRef.current = null;
       setRightPanelResizing(true);
       beginRightSeparatorDrag(event);
     },
-    [beginRightSeparatorDrag],
+    [beginRightSeparatorDrag, resolveRenderedRailWidth],
   );
 
   const userOpenOverrideActive = Boolean(

--- a/apps/packages/product-client/src/hooks/ui/layout/use-resize.test.ts
+++ b/apps/packages/product-client/src/hooks/ui/layout/use-resize.test.ts
@@ -51,6 +51,27 @@ describe("useResize", () => {
     expect(onResize).not.toHaveBeenCalled();
   });
 
+  it("seeds the gesture from resolveSize at mousedown when the rendered size diverges", () => {
+    const onResize = vi.fn();
+    const { result } = renderHook(() =>
+      useResize({
+        direction: "horizontal",
+        size: 700,
+        resolveSize: () => 400,
+        onResize,
+      }));
+
+    act(() => {
+      result.current(mouseDownEvent(0));
+    });
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mousemove", { clientX: 30 }));
+    });
+    // From the rendered 400, not the tracked 700: the first pixel of pointer
+    // travel moves the panel instead of replaying the divergence as dead zone.
+    expect(onResize).toHaveBeenLastCalledWith(430);
+  });
+
   it("appends exactly one cursor-overlay div for the duration of the drag, and removes it on mouseup", () => {
     const { result } = renderHook(() =>
       useResize({ direction: "horizontal", size: 200, onResize: vi.fn() }));

--- a/apps/packages/product-client/src/hooks/ui/layout/use-resize.ts
+++ b/apps/packages/product-client/src/hooks/ui/layout/use-resize.ts
@@ -5,6 +5,13 @@ interface UseResizeOptions {
   direction: "horizontal" | "vertical";
   /** Current size of the panel in px — captured on mousedown as the starting value */
   size: number;
+  /**
+   * Resolves the starting size at mousedown instead of `size`, for panels
+   * whose rendered size can sit away from the tracked value (e.g. a
+   * CSS-clamped width). Seeding from the rendered size keeps the separator
+   * under the pointer from the first pixel of the gesture.
+   */
+  resolveSize?: () => number;
   /** Called on every mouse move with the proposed new size in px */
   onResize: (size: number) => void;
   /**
@@ -26,6 +33,7 @@ interface UseResizeOptions {
 export function useResize({
   direction,
   size,
+  resolveSize,
   onResize,
   onResizeEnd,
   reverse = false,
@@ -46,7 +54,7 @@ export function useResize({
       e.stopPropagation();
 
       const startPos = direction === "horizontal" ? e.clientX : e.clientY;
-      startRef.current = { pos: startPos, size };
+      startRef.current = { pos: startPos, size: resolveSize?.() ?? size };
 
       const cursor = direction === "horizontal" ? "col-resize" : "row-resize";
       const overlay = document.createElement("div");
@@ -75,7 +83,7 @@ export function useResize({
       document.addEventListener("mouseup", handleMouseUp);
       activeDragCleanupRef.current = handleMouseUp;
     },
-    [direction, size, onResize, onResizeEnd, reverse, min, max],
+    [direction, size, resolveSize, onResize, onResizeEnd, reverse, min, max],
   );
 
   // Mirrors handleMouseUp's teardown without firing onResize or removing the

--- a/apps/packages/product-client/src/lib/domain/preferences/workspace-ui/migration.test.ts
+++ b/apps/packages/product-client/src/lib/domain/preferences/workspace-ui/migration.test.ts
@@ -298,10 +298,13 @@ describe("workspace UI state migration", () => {
     } as never);
 
     expect(didMigrate).toBe(true);
+    // 900 survives migration: there is no fixed panel maximum — a width
+    // chosen on a larger window restores intact, and the rail's rendered
+    // clamp bounds what actually paints on the current window.
     expect(state.rightPanelDurableByWorkspace).toEqual({
       w1: {
         open: false,
-        width: 700,
+        width: 900,
       },
     });
     expect(state.rightPanelMaterializedByWorkspace).toEqual({

--- a/apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel-model.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel-model.ts
@@ -44,7 +44,16 @@ export const RIGHT_PANEL_DEFAULT_WIDTH = 420;
  * panel habitually occupies, so it constrains nothing a real user wants.
  */
 export const RIGHT_PANEL_MIN_WIDTH = 380;
-export const RIGHT_PANEL_MAX_WIDTH = 700;
+/**
+ * Fallback drag ceiling for contexts where the shell geometry cannot be
+ * measured (no rendered rail, tests). It is not the policy maximum: the panel
+ * may take everything the window affords — an arbitrary window width, minus
+ * the sidebar at its current width (zero when folded), minus the chat pane's
+ * `MAIN_PANE_MIN_WIDTH` floor. The drag measures that ceiling from the rail's
+ * row at mousedown, and the rail's rendered width enforces the same bound in
+ * CSS when the window shrinks afterwards.
+ */
+export const RIGHT_PANEL_FALLBACK_MAX_WIDTH = 700;
 /**
  * Floor the main (chat) pane keeps against the right rail. The rail's
  * rendered width is clamped so the pane never drops below this, whatever the
@@ -52,8 +61,9 @@ export const RIGHT_PANEL_MAX_WIDTH = 700;
  * it, a wide panel on a small window squeezes the pane toward zero and the
  * composer controls paint over each other. 420 = the composer's compact
  * control tier (see `chat-layout.ts`) fully laid out at its icon floor, plus
- * the chat column gutter. The persisted width is deliberately not clamped:
- * the user's chosen panel width comes back as soon as the window affords it.
+ * the chat column gutter. The same floor bounds how far a resize drag can
+ * widen the panel. The persisted width is deliberately not clamped: the
+ * user's chosen panel width comes back as soon as the window affords it.
  */
 export const MAIN_PANE_MIN_WIDTH = 420;
 /**
@@ -138,11 +148,22 @@ export function availableRightPanelTools(_isCloudWorkspaceSelected: boolean): Ri
   return DEFAULT_RIGHT_PANEL_TOOL_ORDER;
 }
 
-export function clampRightPanelWidth(width: number): number {
+/**
+ * Clamps to the panel's floor and an optional ceiling. The default ceiling is
+ * unbounded: persistence and restore keep a width chosen on a larger window,
+ * and the rail's rendered width bounds what actually paints per window. Only
+ * a live drag passes its measured ceiling here.
+ */
+export function clampRightPanelWidth(
+  width: number,
+  maxWidth: number = Number.POSITIVE_INFINITY,
+): number {
   if (!Number.isFinite(width)) {
     return RIGHT_PANEL_DEFAULT_WIDTH;
   }
-  return Math.min(RIGHT_PANEL_MAX_WIDTH, Math.max(RIGHT_PANEL_MIN_WIDTH, width));
+  // A ceiling below the floor (a degenerately small window) pins to the floor.
+  const effectiveMax = Math.max(RIGHT_PANEL_MIN_WIDTH, maxWidth);
+  return Math.min(effectiveMax, Math.max(RIGHT_PANEL_MIN_WIDTH, width));
 }
 
 /**
@@ -151,13 +172,17 @@ export function clampRightPanelWidth(width: number): number {
  * Resize and collapse are two different gestures expressed through one drag, so
  * the decision has to see the width the pointer actually asked for. Above the
  * collapse threshold the width is clamped as usual — including sticking at
- * `RIGHT_PANEL_MIN_WIDTH` — and below it the panel closes.
+ * `RIGHT_PANEL_MIN_WIDTH` and at the caller-measured `maxWidth` ceiling — and
+ * below it the panel closes.
  */
-export function resolveRightPanelDragOutcome(rawWidth: number): RightPanelDragOutcome {
+export function resolveRightPanelDragOutcome(
+  rawWidth: number,
+  maxWidth: number = Number.POSITIVE_INFINITY,
+): RightPanelDragOutcome {
   if (Number.isFinite(rawWidth) && rawWidth < RIGHT_PANEL_COLLAPSE_DRAG_THRESHOLD) {
     return { kind: "collapse" };
   }
-  return { kind: "resize", width: clampRightPanelWidth(rawWidth) };
+  return { kind: "resize", width: clampRightPanelWidth(rawWidth, maxWidth) };
 }
 
 export function normalizeRightPanelDurableState(

--- a/apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel-model.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel-model.ts
@@ -46,6 +46,17 @@ export const RIGHT_PANEL_DEFAULT_WIDTH = 420;
 export const RIGHT_PANEL_MIN_WIDTH = 380;
 export const RIGHT_PANEL_MAX_WIDTH = 700;
 /**
+ * Floor the main (chat) pane keeps against the right rail. The rail's
+ * rendered width is clamped so the pane never drops below this, whatever the
+ * persisted panel width, sidebar width, and window size add up to — without
+ * it, a wide panel on a small window squeezes the pane toward zero and the
+ * composer controls paint over each other. 420 = the composer's compact
+ * control tier (see `chat-layout.ts`) fully laid out at its icon floor, plus
+ * the chat column gutter. The persisted width is deliberately not clamped:
+ * the user's chosen panel width comes back as soon as the window affords it.
+ */
+export const MAIN_PANE_MIN_WIDTH = 420;
+/**
  * Raw drag width below which a resize gesture stops resizing and collapses the
  * panel instead. This cannot live in `clampRightPanelWidth`: clamping's whole
  * job is to refuse widths under the minimum, so a clamped value can never

--- a/apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel-model.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel-model.ts
@@ -59,13 +59,15 @@ export const RIGHT_PANEL_FALLBACK_MAX_WIDTH = 700;
  * rendered width is clamped so the pane never drops below this, whatever the
  * persisted panel width, sidebar width, and window size add up to — without
  * it, a wide panel on a small window squeezes the pane toward zero and the
- * composer controls paint over each other. 420 = the composer's compact
- * control tier (see `chat-layout.ts`) fully laid out at its icon floor, plus
- * the chat column gutter. The same floor bounds how far a resize drag can
+ * composer controls paint over each other. 440 = the composer's compact
+ * control tier (see `chat-layout.ts`) at its natural width — every pill at
+ * content size, the model name untruncated, the inter-pill rhythm intact —
+ * plus the chat column gutter, so minimizing the pane never compresses the
+ * control row's spacing. The same floor bounds how far a resize drag can
  * widen the panel. The persisted width is deliberately not clamped: the
  * user's chosen panel width comes back as soon as the window affords it.
  */
-export const MAIN_PANE_MIN_WIDTH = 420;
+export const MAIN_PANE_MIN_WIDTH = 440;
 /**
  * Raw drag width below which a resize gesture stops resizing and collapses the
  * panel instead. This cannot live in `clampRightPanelWidth`: clamping's whole

--- a/apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel-model.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel-model.ts
@@ -175,13 +175,22 @@ export function clampRightPanelWidth(
  * the decision has to see the width the pointer actually asked for. Above the
  * collapse threshold the width is clamped as usual — including sticking at
  * `RIGHT_PANEL_MIN_WIDTH` and at the caller-measured `maxWidth` ceiling — and
- * below it the panel closes.
+ * below it the panel closes, but only while the gesture is actually shrinking:
+ * the floor clamp can render the rail below the threshold, and a drag seeded
+ * from that rendered width must not close the panel the user is trying to
+ * widen, so a sub-threshold raw width that sits at or above `startWidth` is a
+ * resize.
  */
 export function resolveRightPanelDragOutcome(
   rawWidth: number,
   maxWidth: number = Number.POSITIVE_INFINITY,
+  startWidth: number = Number.POSITIVE_INFINITY,
 ): RightPanelDragOutcome {
-  if (Number.isFinite(rawWidth) && rawWidth < RIGHT_PANEL_COLLAPSE_DRAG_THRESHOLD) {
+  if (
+    Number.isFinite(rawWidth)
+    && rawWidth < RIGHT_PANEL_COLLAPSE_DRAG_THRESHOLD
+    && rawWidth < startWidth
+  ) {
     return { kind: "collapse" };
   }
   return { kind: "resize", width: clampRightPanelWidth(rawWidth, maxWidth) };

--- a/apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel.test.ts
@@ -321,6 +321,19 @@ describe("right panel domain", () => {
     expect(resolveRightPanelDragOutcome(-120)).toEqual({ kind: "collapse" });
   });
 
+  it("does not collapse a widening drag seeded below the threshold", () => {
+    // The floor clamp can render the rail below the collapse threshold. A
+    // gesture seeded at that rendered width and moving outward is a resize
+    // (pinned to the floor) — closing here would take the panel away from a
+    // user who is trying to grow it.
+    expect(resolveRightPanelDragOutcome(250, 1000, 204)).toEqual({
+      kind: "resize",
+      width: RIGHT_PANEL_MIN_WIDTH,
+    });
+    // A shrinking shove from the same seed still closes.
+    expect(resolveRightPanelDragOutcome(180, 1000, 204)).toEqual({ kind: "collapse" });
+  });
+
   it("treats a non-finite drag width as a resize, never a collapse", () => {
     // A broken measurement must not close the panel behind the user's back.
     expect(resolveRightPanelDragOutcome(Number.NaN)).toEqual({ kind: "resize", width: 420 });

--- a/apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/shell/right-panel.test.ts
@@ -7,7 +7,7 @@ import {
   resolveRightPanelDragOutcome,
   rightPanelViewerHeaderKey,
   RIGHT_PANEL_COLLAPSE_DRAG_THRESHOLD,
-  RIGHT_PANEL_MAX_WIDTH,
+  RIGHT_PANEL_FALLBACK_MAX_WIDTH,
   RIGHT_PANEL_MIN_WIDTH,
 } from "#product/lib/domain/workspaces/shell/right-panel-model";
 import {
@@ -265,10 +265,16 @@ describe("right panel domain", () => {
 
   it("clamps persisted right panel widths to the legible minimum", () => {
     expect(clampRightPanelWidth(100)).toBe(380);
-    expect(clampRightPanelWidth(900)).toBe(700);
+    // No fixed maximum: a width chosen on a larger window persists and
+    // restores intact; per-window bounding is the rail's rendered clamp and
+    // the drag's measured ceiling.
+    expect(clampRightPanelWidth(900)).toBe(900);
+    expect(clampRightPanelWidth(900, 700)).toBe(700);
+    // A ceiling below the floor (degenerately small window) pins to the floor.
+    expect(clampRightPanelWidth(900, 100)).toBe(380);
     expect(clampRightPanelWidth(Number.NaN)).toBe(420);
     expect(RIGHT_PANEL_MIN_WIDTH).toBe(380);
-    expect(RIGHT_PANEL_MAX_WIDTH).toBe(700);
+    expect(RIGHT_PANEL_FALLBACK_MAX_WIDTH).toBe(700);
   });
 
   it("re-clamps widths persisted below the raised minimum", () => {
@@ -296,9 +302,14 @@ describe("right panel domain", () => {
       kind: "resize",
       width: RIGHT_PANEL_MIN_WIDTH,
     });
+    // The ceiling is the caller's per-gesture measurement, not a constant.
+    expect(resolveRightPanelDragOutcome(2000, 1580)).toEqual({
+      kind: "resize",
+      width: 1580,
+    });
     expect(resolveRightPanelDragOutcome(2000)).toEqual({
       kind: "resize",
-      width: RIGHT_PANEL_MAX_WIDTH,
+      width: 2000,
     });
   });
 

--- a/apps/packages/product-client/src/primitives/patterns/ComposerControlButton.tsx
+++ b/apps/packages/product-client/src/primitives/patterns/ComposerControlButton.tsx
@@ -16,6 +16,13 @@ interface ComposerControlButtonProps extends Omit<ButtonHTMLAttributes<HTMLButto
   emphasizeLabel?: boolean;
   labelClassName?: string;
   detailClassName?: string;
+  /**
+   * Classes on the wrapper spans, for width-conditional variants that must
+   * remove the whole flex item (`hidden` on the inner content alone would
+   * leave a zero-width item that still claims a flex gap).
+   */
+  iconWrapperClassName?: string;
+  labelWrapperClassName?: string;
 }
 
 export const ComposerControlButton = forwardRef<HTMLButtonElement, ComposerControlButtonProps>(
@@ -29,6 +36,8 @@ export const ComposerControlButton = forwardRef<HTMLButtonElement, ComposerContr
     emphasizeLabel = false,
     labelClassName = "",
     detailClassName = "",
+    iconWrapperClassName = "",
+    labelWrapperClassName = "",
     className = "",
     type = "button",
     ...props
@@ -68,11 +77,11 @@ export const ComposerControlButton = forwardRef<HTMLButtonElement, ComposerContr
         {/* flex, not inline: an inline wrapper baseline-aligns inline-flex
             icons (e.g. the level bars) instead of letting the button's
             items-center actually center them. */}
-        {icon && <span className="flex shrink-0 items-center">{icon}</span>}
+        {icon && <span className={`flex shrink-0 items-center ${iconWrapperClassName}`}>{icon}</span>}
         {iconOnly ? (
           <span className="sr-only">{iconOnlyLabel}</span>
         ) : (
-          <span className="flex min-w-0 items-center gap-1">
+          <span className={`flex min-w-0 items-center gap-1 ${labelWrapperClassName}`}>
             <span
               className={`min-w-0 truncate text-left ${
                 emphasizeLabel ? "text-composer-control-active-foreground" : ""

--- a/apps/packages/product-client/src/primitives/patterns/LevelBarsButton.tsx
+++ b/apps/packages/product-client/src/primitives/patterns/LevelBarsButton.tsx
@@ -23,6 +23,8 @@ interface LevelBarsButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonEleme
   levelOptionAttribute?: string;
   /** Overrides the derived current-level label (e.g. to animate label swaps). */
   label?: ReactNode;
+  /** Forwarded to `ComposerControlButton` (width-conditional label removal). */
+  labelWrapperClassName?: string;
 }
 
 // HTML bars, not an inline SVG: WebKit does not compositor-accelerate

--- a/apps/packages/product-client/src/stores/preferences/workspace-ui-store.test.ts
+++ b/apps/packages/product-client/src/stores/preferences/workspace-ui-store.test.ts
@@ -109,7 +109,10 @@ describe("workspace ui tab persistence", () => {
 
     expect(useWorkspaceUiStore.getState().rightPanelMaterializedByWorkspace.w1?.activeEntryKey)
       .toBe("terminal:t1");
-    expect(useWorkspaceUiStore.getState().rightPanelDurableByWorkspace.w1?.width).toBe(700);
+    // No fixed maximum: widths persist as chosen (the rail's rendered clamp
+    // and the drag's measured ceiling bound them per window); only the
+    // legibility floor clamps here.
+    expect(useWorkspaceUiStore.getState().rightPanelDurableByWorkspace.w1?.width).toBe(900);
   });
 
   it("stores shell tab state without notifying on unchanged writes", () => {

--- a/specs/codebase/systems/product/chat/composer.md
+++ b/specs/codebase/systems/product/chat/composer.md
@@ -257,6 +257,37 @@ Cowork hides the permission/access `mode` because its access policy is
 product-defined, but retains independent working-mode controls such as
 `collaboration_mode` together with model tuning in the combined picker.
 
+### Compact control tier (narrow composers)
+
+Below a 32rem composer-container width (`chat-layout.ts` owns the class-string
+constants; the dock column's `@container` anchors the query in chat, and the
+Home composer wrapper anchors its own), labeled control pills shed their words
+so the row degrades to icons instead of truncating mid-word or painting over
+neighboring controls:
+
+- The working-mode pill swaps its mode name for the mode's configured icon
+  (`SessionControlIcon`) and stops shrinking at that icon footprint. A mode
+  value without a configured icon keeps its text at every width. This is the
+  one sanctioned exception to "no leading mode icon": the icon renders only
+  under the compact tier, never beside the name.
+- The reasoning pill hides the level word; the lit level bars keep reading
+  the level.
+- The integrations pill hides the connected count and keeps the glyph. The
+  urgent re-auth label stays visible (and shrinkable) at every width.
+- The model pill keeps its provider icon and name and remains the flexible
+  item — it truncates with an ellipsis before any icon pill compresses.
+- Each swap is CSS visibility on one button (wrapper-span classes via
+  `ComposerControlButton`), so `data-*` driver attributes, handlers, and
+  `aria-label`s are width-independent. Pending-state indicators stay visible
+  at every width.
+
+The compact tier is sized so the row fits at the main pane's floor:
+`MAIN_PANE_MIN_WIDTH` (`right-panel-model.ts`) clamps the right rail's
+rendered width so the chat pane never drops below 420px, whatever the
+persisted panel width, sidebar width, and window size add up to. The
+persisted panel width is not clamped — the user's chosen width returns when
+the window affords it.
+
 ## 2. Dock Regions
 
 `resolveComposerDockSlots`

--- a/specs/codebase/systems/product/chat/composer.md
+++ b/specs/codebase/systems/product/chat/composer.md
@@ -275,18 +275,25 @@ neighboring controls:
 - The integrations pill hides the connected count and keeps the glyph. The
   urgent re-auth label stays visible (and shrinkable) at every width.
 - The model pill keeps its provider icon and name and remains the flexible
-  item — it truncates with an ellipsis before any icon pill compresses.
+  item — it truncates with an ellipsis before any icon pill compresses. Its
+  max-width is `min(15rem, 100%)`: the wrapper bound is load-bearing, because
+  a bare rem cap replaces the primitive's `max-w-full` in tailwind-merge and
+  the pill's column-flex wrapper (`items-start`, for the inline error) does
+  not otherwise constrain the button — an uncapped button paints over the
+  mode pill instead of truncating.
 - Each swap is CSS visibility on one button (wrapper-span classes via
   `ComposerControlButton`), so `data-*` driver attributes, handlers, and
   `aria-label`s are width-independent. Pending-state indicators stay visible
   at every width.
 
-The compact tier is sized so the row fits at the main pane's floor:
+The main pane's floor is sized so the compact row sits at its natural width:
 `MAIN_PANE_MIN_WIDTH` (`right-panel-model.ts`) clamps the right rail's
-rendered width so the chat pane never drops below 420px, whatever the
-persisted panel width, sidebar width, and window size add up to. The
-persisted panel width is not clamped — the user's chosen width returns when
-the window affords it.
+rendered width so the chat pane never drops below 440px, whatever the
+persisted panel width, sidebar width, and window size add up to. At the
+floor, every pill renders at content size with the shared 8px rhythm intact —
+minimizing the pane must not compress the spacing between pills or truncate
+the model name for the canonical control row. The persisted panel width is
+not clamped — the user's chosen width returns when the window affords it.
 
 ## 2. Dock Regions
 


### PR DESCRIPTION
## Summary

Fixes [PRO-151](https://linear.app/proliferate-team/issue/PRO-151/when-the-width-of-the-main-pane-reduces-close-to-its-minimum-the-icons): when the main pane narrowed, composer control pills truncated mid-word ("Bypas") and, near the minimum, painted over each other — the leading cluster's `shrink-0` pills overflowed the control-row grid into the trailing cluster while shrinkable pills compressed below their icons.

Two changes, per the ticket's direction:

**Compact control tier.** Below a 32rem composer-container width (the dock column's existing `@container`; Home's composer wrapper now anchors its own) the labeled pills shed their words instead of clipping:
- working mode swaps its name for the mode's configured `SessionControlIcon` and stops shrinking at that icon footprint (a mode with no configured icon keeps its text);
- the reasoning pill drops the level word — the lit bars keep reading the level;
- the integrations pill drops the connected count, keeping the glyph (the urgent re-auth label stays visible at every width);
- the model pill remains the flexible item and truncates with an ellipsis before any icon pill compresses.

Each swap is CSS visibility on the same button via new `iconWrapperClassName`/`labelWrapperClassName` wrapper hooks on `ComposerControlButton` (hiding inner content alone would leave a zero-width flex item still claiming a gap — the uneven-gap failure composer.md §1.2 forbids). `data-*` driver attributes, click handlers, and `aria-label`s are width-independent, so the release scenarios' selectors (`config-session.ts`) are untouched.

**Main-pane floor.** The right rail's rendered width is clamped to `min(var(--workspace-right-width), calc(100% - MAIN_PANE_MIN_WIDTH))` so the chat pane never drops below 420px — previously a 700px panel plus a 420px sidebar on a 1024px-min window squeezed the pane toward zero. The rail yields before the composer collapses; the registered width property still animates inside the clamp, and the *persisted* panel width is deliberately not clamped, so the user's chosen width returns when the window affords it.

## Constitution / spec notes (please review)

- **Pinning updates, same PR:** `WorkspaceShellRightRail.test.tsx` width-style assertion updated for the clamp; composer.md §1.2 gains a "Compact control tier" section carving the one sanctioned exception to "no leading mode icon" (icon only under the compact tier, never beside the name). New `ChatInputControlRow` tests pin the swap classes; the existing "no svg in the mode trigger" tests still pass and now pin the no-configured-icon fallback.
- **Pre-existing spec staleness (not addressed here):** composer.md §1.1/§1.2 still describe the combined `Model · Effort` pill and forbid standalone effort-bars/Fast controls, but #1724 restored the standalone controls without updating the spec. This PR documents the compact tier against the as-built anatomy and leaves the §1.1 reconciliation as a follow-up.

## Evidence

- `pnpm exec tsc -p tsconfig.json --noEmit` (product-client) — clean
- `pnpm exec tsc` (apps/desktop, against rebuilt product-client dist) — clean
- `pnpm vitest run src/components/workspace/chat/input src/components/home` — 21 files, 160 passed; targeted run incl. `ChatInputControlRow`, `SessionModeControl`, `WorkspaceShellRightRail`, `ComposerIntegrationsControl`, `ComposerModelSelectorControl` — 40 passed
- `python3 scripts/check_docs.py` — 208 files pass; `python3 scripts/check_design_attribution.py` — pass
- Manual: verified live against the `pro-151` profile renderer — at 470px viewport the effort pill drops "Default" keeping the bars, the integrations pill drops to the glyph, the model pill stays, and nothing overlaps or clips; at 1200px all labels render exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review follow-up (Greptile)

- **"Clamp creates a resize dead zone" — real, fixed** (`89fe363e5`): drags now seed from the rail's rendered width via a new `resolveSize` mousedown hook on `useResize`, so the separator tracks the pointer from the first pixel when the floor clamp holds the rail below the persisted width. New tests in `use-resize.test.ts` and `use-main-screen-right-panel.test.ts`.
- **"Clamp ignores the sidebar width" — not reproducible**: the rail's `100%` resolves against the middle flex row (chat column + rail), which excludes the sidebar by construction. Measured live: window 1100 / sidebar 275 → middle 825, rail `min(420, 825−420) = 405`, chat column exactly 420.
