### PR TITLE
fix(anyharness): gate grok auto-probes on credentials (PRO-210)

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/targets.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/targets.rs
@@ -8,10 +8,11 @@
 //! The engine no longer iterates auth contexts: one composed observation per
 //! harness, so a target is a harness, full stop.
 
-use crate::domains::agents::model::AgentKind;
+use crate::domains::agents::model::{AgentKind, CredentialState};
 use crate::domains::agents::readiness::service::resolve_agent_unrouted;
 use crate::domains::agents::registry::{built_in_registry, descriptor};
-use std::path::PathBuf;
+use crate::domains::agents::route_auth::launch_route_provides_credentials;
+use std::path::{Path, PathBuf};
 
 /// Harnesses excluded from every UNATTENDED probe.
 ///
@@ -24,6 +25,33 @@ use std::path::PathBuf;
 /// to be consulted only by the whole-machine enumeration, so the pokes that name a
 /// harness directly walked straight past it and spawned `cursor-agent` unattended.
 const AUTO_PROBE_EXCLUDED_HARNESSES: &[AgentKind] = &[AgentKind::Cursor];
+
+/// May an unattended probe spawn Grok? Only when its composed launch world —
+/// native login, ambient `XAI_API_KEY`/`GROK_API_KEY`, or an enrolled
+/// agent-auth route — holds credentials.
+///
+/// Grok's ACP `authenticate` is mandatory before `session/new` (which
+/// otherwise fails "Authentication required"), and its one advertised method,
+/// `grok.com`, resolves inline against whatever credentials exist. When NONE
+/// exist it instead starts a browser OIDC device-code sign-in as a side effect
+/// of the `authenticate` call itself, so an unattended spawn pops an
+/// accounts.x.ai page with no user-visible cause and hangs the probe to its
+/// timeout (PRO-210). Cursor's law, conditioned on credentials instead of
+/// unconditional: a credentialed Grok converges automatically, and a manual
+/// refresh still probes — the user asked, so a sign-in page explains itself.
+///
+/// The two arms mirror `apply_launch_route_upgrade` (readiness/service.rs):
+/// host-scoped credential detection, absorbed route. Install state is
+/// deliberately not consulted — `poke_harness` gates on that separately.
+fn grok_probe_world_has_credentials(runtime_home: &Path) -> bool {
+    let Some(descriptor) = descriptor(AgentKind::Grok.as_str()) else {
+        return false;
+    };
+    matches!(
+        resolve_agent_unrouted(&descriptor, runtime_home).credential_state,
+        CredentialState::Ready | CredentialState::ReadyViaLocalAuth
+    ) || launch_route_provides_credentials(runtime_home, descriptor.kind.as_str())
+}
 
 pub trait ProbeTargets: Send + Sync {
     /// Installed harnesses eligible for the automatic pokes.
@@ -64,9 +92,16 @@ impl ProbeTargets for RuntimeProbeTargets {
     }
 
     fn allows_automatic_probe(&self, harness_kind: &str) -> bool {
-        !AUTO_PROBE_EXCLUDED_HARNESSES
+        if AUTO_PROBE_EXCLUDED_HARNESSES
             .iter()
             .any(|excluded| excluded.as_str() == harness_kind)
+        {
+            return false;
+        }
+        if harness_kind == AgentKind::Grok.as_str() {
+            return grok_probe_world_has_credentials(&self.runtime_home);
+        }
+        true
     }
 
     fn is_installed(&self, harness_kind: &str) -> bool {

--- a/anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/wiring_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/wiring_tests.rs
@@ -19,6 +19,7 @@ use super::test_support::{
     gateway_state, wait_until, CountingPlanProducer, FakeRunner, FixedTargets, TempRuntimeHome,
 };
 use super::{ModelSnapshotService, PokeReason, ProbeEngineConfig};
+use crate::app::test_support::lock_env;
 use crate::domains::agents::installer::progress::InstallProgressPhase;
 use crate::domains::agents::installer::reconcile::execution::probe_after_install_for_test;
 
@@ -339,11 +340,79 @@ fn the_production_exclusion_list_covers_cursor_only() {
     let targets = RuntimeProbeTargets::new(home.path().to_path_buf());
 
     assert!(!targets.allows_automatic_probe("cursor"));
-    for kind in ["claude", "codex", "opencode", "grok"] {
+    for kind in ["claude", "codex", "opencode"] {
         assert!(
             targets.allows_automatic_probe(kind),
-            "{kind} has no keychain-prompt hazard and must converge automatically"
+            "{kind} has no unattended-prompt hazard and must converge automatically"
         );
+    }
+}
+
+/// Grok's automatic probe is credential-gated (PRO-210): its mandatory ACP
+/// `authenticate` opens a browser sign-in when the world holds no credentials,
+/// so a credential-less Grok is never spawned unattended — while EITHER
+/// credential arm (native login file, enrolled agent-auth route) restores
+/// automatic convergence.
+#[test]
+fn grok_automatic_probe_requires_credentials() {
+    use crate::domains::agents::model_snapshot::targets::{ProbeTargets, RuntimeProbeTargets};
+
+    let _env = lock_env();
+    let user_home = TempRuntimeHome::new("grok-credential-gate-user");
+    let _home = EnvGuard::set("HOME", user_home.path().as_os_str());
+    let _xai = EnvGuard::remove("XAI_API_KEY");
+    let _grok_key = EnvGuard::remove("GROK_API_KEY");
+
+    let home = TempRuntimeHome::new("grok-credential-gate");
+    let targets = RuntimeProbeTargets::new(home.path().to_path_buf());
+    assert!(
+        !targets.allows_automatic_probe("grok"),
+        "a credential-less grok must not be spawned unattended"
+    );
+
+    // Arm 1: a native login file (the shape `grok login` writes).
+    std::fs::create_dir_all(user_home.path().join(".grok")).expect("create .grok");
+    std::fs::write(
+        user_home.path().join(".grok/auth.json"),
+        r#"{"https://auth.x.ai::p1":{"key":"tok","refresh_token":"r","expires_at":"2030"}}"#,
+    )
+    .expect("write grok auth");
+    assert!(targets.allows_automatic_probe("grok"));
+    std::fs::remove_file(user_home.path().join(".grok/auth.json")).expect("remove grok auth");
+    assert!(!targets.allows_automatic_probe("grok"));
+
+    // Arm 2: an enrolled agent-auth route (what the launcher injects from).
+    home.write_state_json(&gateway_state(1, &[("grok", "sk-grok")]));
+    assert!(targets.allows_automatic_probe("grok"));
+}
+
+/// Restores an env var on drop, so a panicking test cannot poison the crate-wide
+/// environment for its siblings. Every use sits under [`lock_env`].
+struct EnvGuard {
+    name: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    fn set(name: &'static str, value: &std::ffi::OsStr) -> Self {
+        let previous = std::env::var_os(name);
+        std::env::set_var(name, value);
+        Self { name, previous }
+    }
+
+    fn remove(name: &'static str) -> Self {
+        let previous = std::env::var_os(name);
+        std::env::remove_var(name);
+        Self { name, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match self.previous.take() {
+            Some(value) => std::env::set_var(self.name, value),
+            None => std::env::remove_var(self.name),
+        }
     }
 }
 

--- a/specs/FEATURE_DOCS/MODELS.md
+++ b/specs/FEATURE_DOCS/MODELS.md
@@ -284,6 +284,15 @@ protect live sessions and the machine, not staleness bookkeeping:
   keychain, so an unattended spawn can surface an OS keychain prompt with no
   user-visible cause. Every other harness probes under the events above;
   cursor's observation is written only when a user asks.
+- **Grok probes automatically only when credentialed.** Grok's ACP
+  `authenticate` is mandatory before `session/new`, and its one advertised
+  method (`grok.com`) opens a browser OIDC device-code sign-in whenever the
+  spawned world holds no credentials — so an unattended spawn of a
+  logged-out Grok popped an accounts.x.ai page with no user-visible cause
+  and hung the probe to its timeout (PRO-210). `targets.rs` admits an
+  automatic Grok poke only when host credential detection or the enrolled
+  agent-auth route provides credentials; a manual refresh still probes —
+  the user asked, so the sign-in page explains itself.
 
 The same engine runs everywhere. A cloud sandbox's runtime probes under the
 same events and writes the same document; the Worker syncs it up as the cloud
@@ -530,7 +539,7 @@ anyharness-lib/src/domains/agents/model_snapshot/
 │                         #   that owns both the child and the scratch
 ├── reads.rs              # document/status reads (available in read-only mode)
 ├── status.rs             # the polled status projection (pure)
-└── targets.rs            # which harnesses may be probed (installed; cursor manual-only)
+└── targets.rs            # which harnesses may be probed (installed; cursor manual-only; grok only when credentialed)
 ```
 
 Deleted from the per-context design: `fingerprint.rs`, `staleness.rs` and its

--- a/specs/anyharness/harnesses/grok.md
+++ b/specs/anyharness/harnesses/grok.md
@@ -41,10 +41,26 @@ Provider id `xai`. Readiness is satisfied by `XAI_API_KEY` / `GROK_API_KEY`, or
 by a cached login token at `~/.grok/auth.json` (produced by `grok login`). The
 registry auth slot uses `syncedFiles` materialization for `.grok/auth.json`
 (discovery `grok`, fact `grok-auth-json-oauth`). ACP `authMethods` are
-`cached_token` (the file) and `grok.com` (browser sign-in). Cloud auth is via
+`cached_token` (the file) and `grok.com` (browser sign-in); a Grok with no
+usable cached token advertises only `grok.com`. Cloud auth is via
 the gateway or an `XAI_API_KEY` selection: the registry declares `syncedFiles`
 for `~/.grok/auth.json`, but nothing exports that file to a cloud sandbox, so
 syncing a local Grok login into a cloud sandbox is not wired today.
+
+ACP `authenticate` is **mandatory before `session/new`**, which otherwise
+fails `-32000 "Authentication required" / "no auth method id provided"` — even
+when `XAI_API_KEY` is set (observed live against `@xai-official/grok` 0.2.102).
+The `grok.com` handler resolves inline against whatever credentials the
+spawned world holds (env key, cached token) with no user interaction; when it
+holds NONE, the same call starts an OIDC device-code flow and **opens the
+browser** at `accounts.x.ai/oauth2/device`, blocking until sign-in completes
+or times out. That side effect is why an unattended spawn of a credential-less
+Grok is forbidden: the catalog probe engine admits an automatic Grok poke only
+when host credential detection or the enrolled agent-auth route provides
+credentials (`model_snapshot/targets.rs`, PRO-210); a manual refresh still
+probes, since a user-initiated sign-in page explains itself. Session launches
+are already covered by the create-time readiness gate, which refuses a
+credential-less agent before spawn.
 
 ## ACP Capabilities and Vendor Extensions
 


### PR DESCRIPTION
## Summary

- Fixes PRO-210 ("Grok keeps opening in browser"): every unattended catalog-probe pass (startup, auth-applied, install-completed pokes) of an installed-but-logged-out Grok opened `accounts.x.ai/oauth2/device?user_code=…` in the browser and hung the probe to its 240s timeout.
- Root cause, verified against `@xai-official/grok` 0.2.102 over raw ACP: Grok's `authenticate` is **mandatory** before `session/new` (which otherwise fails `-32000 "Authentication required" / "no auth method id provided"`, even with `XAI_API_KEY` set), and its one advertised method (`grok.com`) resolves inline when the spawned world holds credentials but **starts a browser OIDC device-code flow** when it holds none. The runtime log shows the probe doing exactly that: `session_id=catalog-probe … calling authenticate method_id=grok.com`, with the next probe starting exactly 240s later.
- Fix: `targets.rs` (the probe engine's one policy seam) now admits an automatic Grok poke only when host credential detection (`~/.grok/auth.json`, ambient `XAI_API_KEY`/`GROK_API_KEY`) or the enrolled agent-auth route provides credentials — cursor's existing unattended-prompt law, conditioned on credentials instead of unconditional. Manual refresh still probes (user-initiated sign-in explains itself). Session launches were already refused pre-spawn by the create-time readiness gate.
- Deliberately NOT changed: `authenticate_if_advertised` still calls `authenticate` — a live experiment proved skipping it (or skipping the `grok.com` method) breaks every credentialed Grok world, including gateway-routed sessions, because `session/new` requires the prior `authenticate` round-trip.

## Testing

- Tier 1 (unit, `cargo test -p anyharness-lib --lib model_snapshot`): new `grok_automatic_probe_requires_credentials` drives the real `RuntimeProbeTargets` under env guards — credential-less → excluded; native `auth.json` → admitted; enrolled gateway route in `state.json` → admitted. Updated `the_production_exclusion_list_covers_cursor_only` for the conditional grok arm. 48/48 pass.
- Full `anyharness-lib --lib` suite: 1535 passed, 1 pre-existing failure (`sweep_tests::the_sweep_removes_only_abandoned_and_old_scratch_roots`, fails identically on the base commit with this change stashed — unrelated follow-up).
- Live protocol evidence gathered by driving the installed Grok agent over ACP stdio in an isolated `$HOME` (initialize / session-new with and without `XAI_API_KEY`, never calling `authenticate` so no browser was opened).

## Observability

- None net-new; the existing `skipping an automatic probe for a manual-refresh-only harness` debug line now also covers gated grok pokes, and probe attempts/authenticate calls were already traced (that tracing is how the root cause was pinned).

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- Linear: PRO-210
- Log evidence (local runtime, 2026-08-12): grok probe spawned at 19:52:22, `authenticate method_id=grok.com` at 19:52:23, no `acp_authenticate.completed`, next harness probed at 19:56:22 — the 240s per-probe timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)