### PR TITLE
fix(product): keep the workspace composer on a visible session tab (PRO-106, PRO-101)

### DIFF
--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-activation-guard.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-activation-guard.ts
@@ -11,7 +11,8 @@ export type SessionActivationStaleReason =
   | "slot-missing"
   | "slot-workspace-mismatch"
   | "selection-replaced"
-  | "model-remediation";
+  | "model-remediation"
+  | "tab-hidden";
 
 export interface SessionActivationGuard {
   workspaceId: string;

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.test.ts
@@ -51,6 +51,9 @@ describe("runHotWorkspaceReopen", () => {
       lastViewedSessionByWorkspace: {
         "workspace-1": "session-1",
       },
+      activeShellTabKeyByWorkspace: {},
+      recentlyHiddenChatSessionIdsByWorkspace: {},
+      pendingChatActivationByWorkspace: {},
     });
   });
 
@@ -77,6 +80,70 @@ describe("runHotWorkspaceReopen", () => {
     });
     expect(deps.bootstrapWorkspace).not.toHaveBeenCalled();
     expect(deps.reconcileHotWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("aligns the persisted shell tab intent with the reopened session", () => {
+    useWorkspaceUiStore.setState({
+      activeShellTabKeyByWorkspace: {
+        "workspace-1": "chat:session-stale-draft",
+      },
+    });
+    const deps = depsForHotReopen();
+
+    const didHotReopen = runHotWorkspaceReopen(deps, {
+      workspaceId: "workspace-1",
+    });
+
+    expect(didHotReopen).toBe(true);
+    expect(useSessionSelectionStore.getState().activeSessionId).toBe("session-1");
+    expect(
+      useWorkspaceUiStore.getState().activeShellTabKeyByWorkspace["workspace-1"],
+    ).toBe("chat:session-1");
+  });
+
+  it("does not resurrect a session whose tab was recently hidden", () => {
+    putSessionRecord({
+      ...createEmptySessionRecord("session-2", "codex", {
+        workspaceId: "workspace-1",
+      }),
+      transcriptHydrated: true,
+    });
+    useWorkspaceUiStore.setState({
+      recentlyHiddenChatSessionIdsByWorkspace: {
+        "workspace-1": ["session-1"],
+      },
+    });
+    const deps = depsForHotReopen();
+
+    const didHotReopen = runHotWorkspaceReopen(deps, {
+      workspaceId: "workspace-1",
+    });
+
+    expect(didHotReopen).toBe(true);
+    expect(useSessionSelectionStore.getState().activeSessionId).toBe("session-2");
+  });
+
+  it("reveals a hidden session when it is requested explicitly", () => {
+    useWorkspaceUiStore.setState({
+      recentlyHiddenChatSessionIdsByWorkspace: {
+        "workspace-1": ["session-1"],
+      },
+    });
+    const deps = depsForHotReopen();
+
+    const didHotReopen = runHotWorkspaceReopen(deps, {
+      workspaceId: "workspace-1",
+      options: { initialActiveSessionId: "session-1" },
+    });
+
+    expect(didHotReopen).toBe(true);
+    expect(useSessionSelectionStore.getState().activeSessionId).toBe("session-1");
+    expect(
+      useWorkspaceUiStore.getState().recentlyHiddenChatSessionIdsByWorkspace["workspace-1"],
+    ).toEqual([]);
+    expect(
+      useWorkspaceUiStore.getState().activeShellTabKeyByWorkspace["workspace-1"],
+    ).toBe("chat:session-1");
   });
 
   it("clears the hot gate after paint and starts guarded reconcile", async () => {

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.ts
@@ -1,8 +1,10 @@
 import { findLogicalWorkspace } from "#product/lib/domain/workspaces/cloud/logical-workspace-lookup";
 import { resolveLogicalWorkspaceMaterializationId } from "#product/lib/domain/workspaces/cloud/logical-workspace-materialization";
 import {
+  hotReopenWorkspaceLookupIds,
   resolveHotReopenCandidate,
 } from "#product/lib/domain/workspaces/selection/hot-reopen";
+import { writeChatShellIntentForSession } from "#product/hooks/workspaces/workflows/tabs/workspace-shell-intent-writer";
 import {
   markWorkspaceViewed,
   rememberLastViewedSession,
@@ -63,13 +65,20 @@ export function runHotWorkspaceReopen(
     return false;
   }
 
+  const workspaceUiState = useWorkspaceUiStore.getState();
   const candidate = resolveHotReopenCandidate({
     resolvedWorkspaceId,
     logicalWorkspace,
     initialActiveSessionId: request.options?.initialActiveSessionId ?? null,
-    lastViewedSessionByWorkspace: useWorkspaceUiStore.getState().lastViewedSessionByWorkspace,
+    lastViewedSessionByWorkspace: workspaceUiState.lastViewedSessionByWorkspace,
     sessionSlots: getSessionRecords(),
     isPendingSessionId,
+    hiddenSessionIds: new Set(
+      hotReopenWorkspaceLookupIds(resolvedWorkspaceId, logicalWorkspace).flatMap(
+        (workspaceId) =>
+          workspaceUiState.recentlyHiddenChatSessionIdsByWorkspace[workspaceId] ?? [],
+      ),
+    ),
   });
   if (!candidate) {
     return false;
@@ -114,6 +123,18 @@ export function runHotWorkspaceReopen(
       operationId,
       kind: "workspace_hot_reopen",
     },
+  });
+  // The persisted shell tab intent may still point at whatever tab was active
+  // when the workspace was left (a since-replaced draft, another session, or
+  // the new-chat surface). Without this write the intent disagrees with the
+  // restored active session and activation degrades to the chat-shell surface
+  // while the composer stays armed at an invisible session (PRO-106). Mirrors
+  // the cold path's prepareOptimisticWorkspaceSessionShell.
+  writeChatShellIntentForSession({
+    workspaceId: resolvedWorkspaceId,
+    shellWorkspaceId: logicalWorkspaceId,
+    sessionId: candidate.sessionId,
+    invalidateSessionIntent: false,
   });
   recordMeasurementWorkflowStep({
     operationId,

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/chat-tab-activation-runner.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/chat-tab-activation-runner.ts
@@ -63,6 +63,21 @@ export async function runDeferredChatTabActivation({
     };
   }
 
+  // A close can hide this target between scheduling and this deferred run
+  // without bumping any activation epoch. Committing would bind the shell to a
+  // session with no visible tab (PRO-101), so treat a hidden target as stale.
+  if (isChatTabHiddenForShellKey(shellStateKey, sessionId)) {
+    clearMatchingPending({
+      clearPendingChatActivation,
+      hotOperationId,
+      pending,
+      shellStateKey,
+      step: "workspace.shell.pending_clear",
+    });
+    finishOrCancelMeasurementOperation(hotOperationId, "aborted");
+    return { result: "stale", sessionId, guard, reason: "tab-hidden" };
+  }
+
   const durableStartedAt = performance.now();
   const previousWrite = writeShellIntent({
     workspaceId: shellStateKey,
@@ -145,6 +160,12 @@ export async function runDeferredChatTabActivation({
     finishOrCancelMeasurementOperation(hotOperationId, "error_sanitized");
     throw error;
   }
+}
+
+function isChatTabHiddenForShellKey(shellStateKey: string, sessionId: string): boolean {
+  return (
+    useWorkspaceUiStore.getState().recentlyHiddenChatSessionIdsByWorkspace[shellStateKey] ?? []
+  ).includes(sessionId);
 }
 
 function isPendingChatActivationStillCurrent(

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-chat-tab-visibility-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-chat-tab-visibility-actions.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createEmptySessionRecord,
+  putSessionRecord,
+} from "#product/stores/sessions/session-records";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+import { useChatTabVisibilityActions } from "#product/hooks/workspaces/workflows/tabs/use-chat-tab-visibility-actions";
+
+const activationMocks = vi.hoisted(() => ({
+  activateChatShell: vi.fn(),
+  activateChatTab: vi.fn(),
+}));
+
+vi.mock("#product/hooks/sessions/workflows/use-session-restore-actions", () => ({
+  useSessionRestoreActions: () => ({
+    restoreLastDismissedSession: vi.fn().mockResolvedValue(null),
+  }),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/tabs/use-chat-session-archive-action", () => ({
+  useChatSessionArchiveAction: () => vi.fn(),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/tabs/use-workspace-shell-activation", () => ({
+  useWorkspaceShellActivation: () => activationMocks,
+}));
+
+const WORKSPACE_UI_KEY = "logical:repo";
+const MATERIALIZED_WORKSPACE_ID = "workspace-1";
+
+describe("useChatTabVisibilityActions hide flows", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    activationMocks.activateChatTab.mockResolvedValue({ result: "completed" });
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+    useSessionSelectionStore.setState({
+      selectedWorkspaceId: MATERIALIZED_WORKSPACE_ID,
+      activeSessionId: null,
+      pendingWorkspaceEntry: null,
+    });
+    putSessionRecord({
+      ...createEmptySessionRecord("session-1", "codex", {
+        workspaceId: MATERIALIZED_WORKSPACE_ID,
+        materializedSessionId: "materialized-1",
+      }),
+      transcriptHydrated: true,
+    });
+    useWorkspaceUiStore.setState({
+      lastViewedSessionByWorkspace: {
+        [WORKSPACE_UI_KEY]: "materialized-1",
+        [MATERIALIZED_WORKSPACE_ID]: "materialized-1",
+      },
+      pendingChatActivationByWorkspace: {},
+      recentlyHiddenChatSessionIdsByWorkspace: {},
+      visibleChatSessionIdsByWorkspace: {
+        [WORKSPACE_UI_KEY]: ["session-1", "session-2"],
+      },
+    });
+  });
+
+  function renderVisibilityActions() {
+    return renderHook(() => useChatTabVisibilityActions({
+      workspaceUiKey: WORKSPACE_UI_KEY,
+      materializedWorkspaceId: MATERIALIZED_WORKSPACE_ID,
+      visibleIds: ["session-1", "session-2"],
+      liveIds: ["session-1", "session-2"],
+      childToParent: new Map(),
+    }));
+  }
+
+  it("hiding a tab forgets it as the last-viewed session under both workspace keys", () => {
+    const { result } = renderVisibilityActions();
+
+    act(() => {
+      expect(result.current.hideChatSessionTabs(["session-1"])).toBe(true);
+    });
+
+    const workspaceUiState = useWorkspaceUiStore.getState();
+    expect(
+      workspaceUiState.recentlyHiddenChatSessionIdsByWorkspace[WORKSPACE_UI_KEY],
+    ).toEqual(["session-1"]);
+    expect(workspaceUiState.lastViewedSessionByWorkspace[WORKSPACE_UI_KEY]).toBeUndefined();
+    expect(
+      workspaceUiState.lastViewedSessionByWorkspace[MATERIALIZED_WORKSPACE_ID],
+    ).toBeUndefined();
+  });
+
+  it("closing the active tab selects its neighbor", () => {
+    useSessionSelectionStore.setState({ activeSessionId: "session-2" });
+    const { result } = renderVisibilityActions();
+
+    act(() => {
+      expect(result.current.hideChatSessionTabs(["session-2"], { selectFallback: true })).toBe(true);
+    });
+
+    expect(activationMocks.activateChatTab).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: "session-1" }),
+    );
+  });
+
+  it("resolves the close fallback against a pending activation, not the stale committed active (PRO-101)", () => {
+    // Mirrors the second of two rapid Cmd+W presses: the first close hid
+    // "session-hidden" and its fallback activation of "session-2" is still
+    // pending, so the committed activeSessionId lags on the hidden session.
+    useSessionSelectionStore.setState({ activeSessionId: "session-hidden" });
+    useWorkspaceUiStore.setState({
+      pendingChatActivationByWorkspace: {
+        [WORKSPACE_UI_KEY]: {
+          attemptId: "attempt-1",
+          sessionId: "session-2",
+          intent: "chat:session-2",
+          guardToken: 1,
+          workspaceSelectionNonce: 0,
+          shellEpochAtWrite: 0,
+          sessionActivationEpochAtWrite: 1,
+        },
+      },
+    });
+    const { result } = renderVisibilityActions();
+
+    act(() => {
+      expect(result.current.hideChatSessionTabs(["session-2"], { selectFallback: true })).toBe(true);
+    });
+
+    expect(activationMocks.activateChatTab).toHaveBeenCalledTimes(1);
+    expect(activationMocks.activateChatTab).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: "session-1" }),
+    );
+  });
+
+  it("hiding a tab leaves an unrelated last-viewed session untouched", () => {
+    useWorkspaceUiStore.setState({
+      lastViewedSessionByWorkspace: {
+        [WORKSPACE_UI_KEY]: "materialized-other",
+      },
+    });
+    const { result } = renderVisibilityActions();
+
+    act(() => {
+      expect(result.current.hideChatSessionTabs(["session-1"])).toBe(true);
+    });
+
+    expect(
+      useWorkspaceUiStore.getState().lastViewedSessionByWorkspace[WORKSPACE_UI_KEY],
+    ).toBe("materialized-other");
+  });
+});

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-chat-tab-visibility-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-chat-tab-visibility-actions.ts
@@ -14,7 +14,10 @@ import {
   failLatencyFlow,
   startLatencyFlow,
 } from "#product/lib/infra/measurement/measurement-port";
-import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+import {
+  clearLastViewedSession,
+  useWorkspaceUiStore,
+} from "#product/stores/preferences/workspace-ui-store";
 import { getSessionRecord } from "#product/stores/sessions/session-records";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useToastStore } from "#product/stores/toast/toast-store";
@@ -39,7 +42,6 @@ interface HideOptions {
 
 export function useChatTabVisibilityActions(context: ChatTabVisibilityContext) {
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
-  const activeSessionId = useSessionSelectionStore((state) => state.activeSessionId);
   const {
     childToParent,
     liveIds,
@@ -100,6 +102,41 @@ export function useChatTabVisibilityActions(context: ChatTabVisibilityContext) {
     });
   }, [activateChatTab, childToParent, materializedWorkspaceId, showToast, workspaceUiKey]);
 
+  // During the activation coalesce window the committed activeSessionId lags
+  // the tab the user sees as active (the pending activation). Close flows must
+  // reason about that pending target, or a rapid second close decides the
+  // "active" tab is unaffected and re-selects the tab the first close just hid
+  // (PRO-101).
+  const resolveEffectiveActiveSessionId = useCallback((): string | null => {
+    const pendingByWorkspace =
+      useWorkspaceUiStore.getState().pendingChatActivationByWorkspace;
+    const pending = (workspaceUiKey ? pendingByWorkspace[workspaceUiKey] : null)
+      ?? (materializedWorkspaceId ? pendingByWorkspace[materializedWorkspaceId] : null)
+      ?? null;
+    return pending?.sessionId ?? useSessionSelectionStore.getState().activeSessionId;
+  }, [materializedWorkspaceId, workspaceUiKey]);
+
+  // Hiding a tab must also drop the session from last-viewed bookkeeping
+  // (mirroring dismissal cleanup): workspace reopen prefers the last-viewed
+  // session, and restoring one whose tab is hidden leaves the composer armed
+  // at a session with no visible tab (PRO-106).
+  const rememberHiddenChatSession = useCallback((sessionId: string) => {
+    if (!workspaceUiKey) {
+      return;
+    }
+    rememberHiddenChatSessionForWorkspace(workspaceUiKey, sessionId);
+    const materializedSessionId = getSessionRecord(sessionId)?.materializedSessionId;
+    for (const workspaceKey of new Set([workspaceUiKey, materializedWorkspaceId])) {
+      if (!workspaceKey) {
+        continue;
+      }
+      clearLastViewedSession(workspaceKey, sessionId);
+      if (materializedSessionId && materializedSessionId !== sessionId) {
+        clearLastViewedSession(workspaceKey, materializedSessionId);
+      }
+    }
+  }, [materializedWorkspaceId, rememberHiddenChatSessionForWorkspace, workspaceUiKey]);
+
   const markErroredSessionsViewedBeforeHide = useCallback((idsToHide: string[]) => {
     if (idsToHide.length === 0) {
       return;
@@ -155,32 +192,35 @@ export function useChatTabVisibilityActions(context: ChatTabVisibilityContext) {
     const nextVisible = visibleIds.filter((id) => !expandedHideSet.has(id));
     markErroredSessionsViewedBeforeHide(idsToHide);
     setVisibleChatSessionIdsForWorkspace(workspaceUiKey, nextVisible);
-    idsToHide.forEach((id) => rememberHiddenChatSessionForWorkspace(workspaceUiKey, id));
+    idsToHide.forEach(rememberHiddenChatSession);
 
     if (options?.selectFallback) {
-      const fallbackId = resolveFallbackAfterHidingChatTabs({
-        visibleIdsBeforeHide: visibleIds,
-        idsToHide,
-        activeSessionId,
-      });
-      if (fallbackId) {
-        selectSessionId(fallbackId, "header_tab");
-      } else if (activeSessionId && expandedHideSet.has(activeSessionId)) {
-        activateChatShell({
-          workspaceId: materializedWorkspaceId,
-          shellWorkspaceId: workspaceUiKey,
-          reason: "active-chat-hidden",
+      const effectiveActiveSessionId = resolveEffectiveActiveSessionId();
+      if (effectiveActiveSessionId && expandedHideSet.has(effectiveActiveSessionId)) {
+        const fallbackId = resolveFallbackAfterHidingChatTabs({
+          visibleIdsBeforeHide: visibleIds,
+          idsToHide,
+          activeSessionId: effectiveActiveSessionId,
         });
+        if (fallbackId) {
+          selectSessionId(fallbackId, "header_tab");
+        } else {
+          activateChatShell({
+            workspaceId: materializedWorkspaceId,
+            shellWorkspaceId: workspaceUiKey,
+            reason: "active-chat-hidden",
+          });
+        }
       }
     }
 
     return true;
   }, [
-    activeSessionId,
     childToParent,
     markErroredSessionsViewedBeforeHide,
     materializedWorkspaceId,
-    rememberHiddenChatSessionForWorkspace,
+    rememberHiddenChatSession,
+    resolveEffectiveActiveSessionId,
     selectSessionId,
     setVisibleChatSessionIdsForWorkspace,
     activateChatShell,
@@ -214,16 +254,17 @@ export function useChatTabVisibilityActions(context: ChatTabVisibilityContext) {
     const idsToHide = visibleIds.filter((id) => !keepSet.has(id));
     markErroredSessionsViewedBeforeHide(idsToHide);
     setVisibleChatSessionIdsForWorkspace(workspaceUiKey, keepIds);
-    idsToHide.forEach((id) => rememberHiddenChatSessionForWorkspace(workspaceUiKey, id));
-    if (activeSessionId && !keepSet.has(activeSessionId)) {
+    idsToHide.forEach(rememberHiddenChatSession);
+    const effectiveActiveSessionId = resolveEffectiveActiveSessionId();
+    if (effectiveActiveSessionId && !keepSet.has(effectiveActiveSessionId)) {
       selectSessionId(anchorSessionId, "header_tab");
     }
     return true;
   }, [
-    activeSessionId,
     childToParent,
     markErroredSessionsViewedBeforeHide,
-    rememberHiddenChatSessionForWorkspace,
+    rememberHiddenChatSession,
+    resolveEffectiveActiveSessionId,
     selectSessionId,
     setVisibleChatSessionIdsForWorkspace,
     visibleIds,
@@ -245,15 +286,16 @@ export function useChatTabVisibilityActions(context: ChatTabVisibilityContext) {
     const nextVisible = visibleIds.filter((id) => !hideSet.has(id));
     markErroredSessionsViewedBeforeHide(idsToHide);
     setVisibleChatSessionIdsForWorkspace(workspaceUiKey, nextVisible);
-    idsToHide.forEach((id) => rememberHiddenChatSessionForWorkspace(workspaceUiKey, id));
-    if (activeSessionId && hideSet.has(activeSessionId)) {
+    idsToHide.forEach(rememberHiddenChatSession);
+    const effectiveActiveSessionId = resolveEffectiveActiveSessionId();
+    if (effectiveActiveSessionId && hideSet.has(effectiveActiveSessionId)) {
       selectSessionId(anchorSessionId, "header_tab");
     }
     return true;
   }, [
-    activeSessionId,
     markErroredSessionsViewedBeforeHide,
-    rememberHiddenChatSessionForWorkspace,
+    rememberHiddenChatSession,
+    resolveEffectiveActiveSessionId,
     selectSessionId,
     setVisibleChatSessionIdsForWorkspace,
     visibleIds,

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-workspace-shell-activation.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/use-workspace-shell-activation.test.tsx
@@ -184,6 +184,36 @@ describe("useWorkspaceShellActivation", () => {
       .toHaveBeenCalledWith("mop_1", "aborted");
   });
 
+  it("aborts a deferred activation whose target tab was hidden during the coalesce window", async () => {
+    const { result } = renderHook(() => useWorkspaceShellActivation());
+
+    let activationPromise!: Promise<any>;
+    act(() => {
+      activationPromise = result.current.activateChatTab({
+        workspaceId: "workspace-1",
+        sessionId: "session-1",
+      });
+    });
+    useWorkspaceUiStore.getState()
+      .rememberHiddenChatSessionForWorkspace("workspace-1", "session-1");
+
+    let outcome: any;
+    await act(async () => {
+      vi.advanceTimersByTime(180);
+      hookMocks.scheduledCallbacks.shift()?.();
+      outcome = await activationPromise;
+    });
+
+    expect(outcome).toMatchObject({
+      result: "stale",
+      sessionId: "session-1",
+      reason: "tab-hidden",
+    });
+    expect(hookMocks.selectSession).not.toHaveBeenCalled();
+    expect(useWorkspaceUiStore.getState().activeShellTabKeyByWorkspace["workspace-1"])
+      .toBeUndefined();
+  });
+
   it("aborts the previous pending hot-switch measurement when superseded", async () => {
     const { result } = renderHook(() => useWorkspaceShellActivation());
 

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/workspace-shell-intent-writer.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/tabs/workspace-shell-intent-writer.ts
@@ -37,6 +37,13 @@ export function writeChatShellIntentForSession({
   if (invalidateSessionIntent) {
     invalidateSessionActivationIntent(workspaceId);
   }
+  // The intended active tab must be a visible tab: a recently-hidden entry is
+  // excluded from the tab strip, which would strand activation on the
+  // chat-shell surface while the composer targets this session (PRO-106).
+  useWorkspaceUiStore.getState().clearHiddenChatSessionsForWorkspace(shellStateKey, [sessionId]);
+  if (workspaceId !== shellStateKey) {
+    useWorkspaceUiStore.getState().clearHiddenChatSessionsForWorkspace(workspaceId, [sessionId]);
+  }
   const write = useWorkspaceUiStore.getState().writeShellIntent({
     workspaceId: shellStateKey,
     intent,

--- a/apps/packages/product-client/src/lib/domain/workspaces/selection/hot-reopen.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/selection/hot-reopen.test.ts
@@ -127,6 +127,75 @@ describe("resolveHotReopenCandidate", () => {
     });
   });
 
+  it("skips recently-hidden sessions for last-viewed and cached-slot sources", () => {
+    const sessionSlots = {
+      "session-hidden": slot({
+        sessionId: "session-hidden",
+        workspaceId: "workspace-1",
+        hydrated: true,
+      }),
+      "session-open": slot({
+        sessionId: "session-open",
+        workspaceId: "workspace-1",
+        hydrated: true,
+      }),
+    };
+
+    const candidate = resolveHotReopenCandidate({
+      resolvedWorkspaceId: "workspace-1",
+      logicalWorkspace: null,
+      initialActiveSessionId: null,
+      lastViewedSessionByWorkspace: {
+        "workspace-1": "session-hidden",
+      },
+      sessionSlots,
+      isPendingSessionId: () => false,
+      hiddenSessionIds: new Set(["session-hidden"]),
+    });
+
+    expect(candidate).toEqual({
+      sessionId: "session-open",
+      workspaceId: "workspace-1",
+      source: "cached_slot",
+    });
+
+    expect(resolveHotReopenCandidate({
+      resolvedWorkspaceId: "workspace-1",
+      logicalWorkspace: null,
+      initialActiveSessionId: null,
+      lastViewedSessionByWorkspace: {},
+      sessionSlots: {
+        "session-hidden": sessionSlots["session-hidden"],
+      },
+      isPendingSessionId: () => false,
+      hiddenSessionIds: new Set(["session-hidden"]),
+    })).toBeNull();
+  });
+
+  it("honors an explicit initial session even when its tab is hidden", () => {
+    const candidate = resolveHotReopenCandidate({
+      resolvedWorkspaceId: "workspace-1",
+      logicalWorkspace: null,
+      initialActiveSessionId: "session-hidden",
+      lastViewedSessionByWorkspace: {},
+      sessionSlots: {
+        "session-hidden": slot({
+          sessionId: "session-hidden",
+          workspaceId: "workspace-1",
+          hydrated: true,
+        }),
+      },
+      isPendingSessionId: () => false,
+      hiddenSessionIds: new Set(["session-hidden"]),
+    });
+
+    expect(candidate).toEqual({
+      sessionId: "session-hidden",
+      workspaceId: "workspace-1",
+      source: "initial_active",
+    });
+  });
+
   it("falls back to any eligible cached slot", () => {
     const candidate = resolveHotReopenCandidate({
       resolvedWorkspaceId: "workspace-1",

--- a/apps/packages/product-client/src/lib/domain/workspaces/selection/hot-reopen.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/selection/hot-reopen.ts
@@ -46,6 +46,7 @@ export function resolveHotReopenCandidate(input: {
   lastViewedSessionByWorkspace: Record<string, string>;
   sessionSlots: Record<string, HotReopenSessionSlotSnapshot>;
   isPendingSessionId: (sessionId: string) => boolean;
+  hiddenSessionIds?: ReadonlySet<string>;
 }): HotReopenCandidate | null {
   const slotFor = (sessionId: string | null | undefined) =>
     sessionId ? input.sessionSlots[sessionId] ?? null : null;
@@ -53,6 +54,16 @@ export function resolveHotReopenCandidate(input: {
     sessionId: string | null | undefined,
     source: HotReopenCandidate["source"],
   ): HotReopenCandidate | null => {
+    // Implicit sources must not resurrect a session whose tab the user closed:
+    // a hidden session gets no tab, so activating it strands the shell on the
+    // chat-shell surface with the composer armed at an invisible session.
+    if (
+      source !== "initial_active"
+      && sessionId
+      && input.hiddenSessionIds?.has(sessionId)
+    ) {
+      return null;
+    }
     const slot = slotFor(sessionId);
     return isHotReopenEligibleSessionSlot(
       slot,
@@ -82,16 +93,9 @@ export function resolveHotReopenCandidate(input: {
   }
 
   for (const slot of Object.values(input.sessionSlots)) {
-    if (isHotReopenEligibleSessionSlot(
-      slot,
-      input.resolvedWorkspaceId,
-      input.isPendingSessionId,
-    )) {
-      return {
-        sessionId: slot.sessionId,
-        workspaceId: slot.workspaceId,
-        source: "cached_slot",
-      };
+    const candidate = toCandidate(slot.sessionId, "cached_slot");
+    if (candidate) {
+      return candidate;
     }
   }
 


### PR DESCRIPTION
## Summary

Two Bugathon tickets shared one terminal failure: the workspace lands on the empty "Ready when you are" surface with no session tab selected while the composer stays silently bound to a session that has no visible tab — messages sent there run the workspace but never appear on screen.

- Fixes PRO-106 — after `Cmd+1`-style workspace switches, hot reopen restored `activeSessionId` without writing the persisted shell tab intent (and could resurrect a session whose tab was closed), so the tab-activation resolver degraded to the chat-shell surface with the composer armed at the restored session.
- Fixes PRO-101 — two rapid `Cmd+W` presses: the second close resolved its fallback against the committed `activeSessionId`, which still lagged inside the first close's 180ms activation coalesce, so it re-selected the tab the first close had just hidden and the deferred activation committed the shell onto it.

The change restores one invariant at every writer: **a session activated as the shell's tab must be a visible tab.**

- Hot reopen writes the chat shell intent for its restored session (mirrors the cold path) and skips recently-hidden candidates.
- `writeChatShellIntentForSession` reveals its session from the recently-hidden list.
- Close flows (`hide`, close-others, close-to-right) resolve fallbacks against the effective active session (pending activation target ?? committed active).
- The deferred chat-tab activation runner aborts as stale (`tab-hidden`) when its target was hidden during the coalesce window.
- Hiding a tab forgets it as the workspace's last-viewed session (matching dismissal cleanup).

## Testing

- Unit (vitest, product-client): new/extended coverage in `hot-reopen.test.ts`, `run-hot-workspace-reopen.test.ts` (intent alignment, hidden-candidate skip, explicit reveal), `use-chat-tab-visibility-actions.test.tsx` (PRO-101 pending-vs-committed fallback, last-viewed forget), `use-workspace-shell-activation.test.tsx` (tab-hidden abort). Full `src/hooks/workspaces`, `src/hooks/sessions`, `src/lib/domain/workspaces` sweep: 178 files / 1149 tests passing; package `tsc --noEmit` clean.
- Live repro on a local profile stack (CDP-driven desktop renderer): before the PRO-101 change, two back-to-back `Cmd+W` presses on the right-most tab deterministically produced the orphan (active session = first-closed tab, empty hero, no tab highlighted); after, the same input closes both tabs and lands selected on the remaining neighbor. The PRO-106 repro (new session → home → `Cmd+1`) now reopens with the restored session's tab selected.

## Observability

- New `tab-hidden` value on the existing session-activation stale-reason enum, visible through the existing activation latency/measurement logging. No new events.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- `pnpm vitest run src/hooks/workspaces src/hooks/sessions src/lib/domain/workspaces` (1149 passing)
- `pnpm exec tsc -p tsconfig.json --noEmit` (clean)
- Manual: double `Cmd+W` (Command held) on the right-most tab of a many-session workspace; `⌘T` → home → `Cmd+1`; close a tab → leave → reopen the workspace. In all flows the composer corresponds to a highlighted, visible tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)