### PR TITLE
fix(product): remove Go to hover affordance from workspaces rows (PRO-127)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/repo-setup/WorkspacesCommandList.tsx
+++ b/apps/packages/product-client/src/components/workspace/repo-setup/WorkspacesCommandList.tsx
@@ -13,10 +13,10 @@
  * live in the dot's tooltip (compound label). Session count reuses that same
  * glyph-plus-number vocabulary so the trailing cluster reads as one system.
  *
- * Rows are ~36px, `--accent` fill when selected; the selected row swaps the
- * date for `Go to →` (and hides the ahead/behind label). Group headings carry
- * the item count in `--faint`. An optional dashed "Create" row closes the
- * list with an optional creation-shortcut hint.
+ * Rows are ~36px, `--accent` fill when selected — the fill alone marks the
+ * clickable row; content never swaps on selection. Group headings carry the
+ * item count in `--faint`. An optional dashed "Create" row closes the list
+ * with an optional creation-shortcut hint.
  */
 import { ChevronRight, FolderPlus, GitPullRequest } from "lucide-react";
 import { GitBranchIcon } from "#product/primitives/icons/workspace-git";
@@ -54,7 +54,7 @@ export interface WorkspacesCommandItemView {
   running?: boolean;
   /** Merge conflicts in the worktree — destructive tint on the well glyph. */
   attention?: "conflicts" | null;
-  /** "↑2 ↓1" — present only when ahead or behind > 0; hidden when selected. */
+  /** "↑2 ↓1" — present only when ahead or behind > 0. */
   aheadBehindLabel?: string | null;
   /** "#805" — rendered after the PR dot. */
   prNumberLabel?: string | null;
@@ -245,15 +245,12 @@ function WorkspaceCommandRow({
             </span>
           ) : null}
           {item.aheadBehindLabel ? (
-            <span className="text-ui-sm tabular-nums text-faint group-data-[selected=true]:hidden">
+            <span className="text-ui-sm tabular-nums text-faint">
               {item.aheadBehindLabel}
             </span>
           ) : null}
-          <span className="w-16 text-right text-ui-sm tabular-nums text-faint group-data-[selected=true]:hidden">
+          <span className="w-16 text-right text-ui-sm tabular-nums text-faint">
             {item.updatedLabel ?? ""}
-          </span>
-          <span className="hidden w-16 text-right text-ui-sm text-faint group-data-[selected=true]:inline">
-            Go to →
           </span>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Remove the `Go to →` label that replaced the last-used date when a workspaces-list row is highlighted (cursor hover or keyboard selection). The accent fill already marks the row, and clicking anywhere on it navigates, so the swap was redundant and made row content flicker on hover.
- Keep the ahead/behind label visible on the highlighted row for the same reason — it was hidden only to clear space next to `Go to →`. Row content is now stable across selection states.

Fixes [PRO-127](https://linear.app/proliferate-team/issue/PRO-127/ui-in-workspaces).

## Testing

- Component tier (specs/TESTING.md): `pnpm vitest run src/components/workspace/repo-setup/WorkspacesCommandList.test.tsx` in `apps/packages/product-client` — 9/9 pass. No test pinned the removed swap; existing tests still cover the row's trailing cluster (ahead/behind, session count, placement).
- `pnpm typecheck` in `apps/packages/product-client` passes.

## Observability

- none

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Verification

- `pnpm vitest run src/components/workspace/repo-setup/WorkspacesCommandList.test.tsx` → 9 passed
- `pnpm typecheck` (product-client) → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)