### PR TITLE
fix(product): autofocus search popovers

### DIFF
--- a/apps/packages/product-client/src/components/home/screen/HomeTargetPicker.test.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeTargetPicker.test.tsx
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { HomeTargetPicker } from "#product/components/home/screen/HomeTargetPicker";
 import type { SettingsRepositoryEntry } from "#product/lib/domain/settings/repositories";
@@ -192,6 +192,19 @@ describe("HomeTargetPicker", () => {
 
     expect(callbacks.onSelectBranch).toHaveBeenCalledWith("staging");
     expect(callbacks.onSelectRuntime).not.toHaveBeenCalled();
+  });
+
+  it("focuses the search field whenever a searchable target picker opens", async () => {
+    renderPicker();
+
+    fireEvent.click(screen.getByRole("button", { name: /Project: Keystone repository/i }));
+    const projectSearch = screen.getByPlaceholderText("Search projects");
+    await waitFor(() => expect(document.activeElement).toBe(projectSearch));
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    fireEvent.click(screen.getByRole("button", { name: /Branch: main/i }));
+    const branchSearch = screen.getByPlaceholderText("Search branches");
+    await waitFor(() => expect(document.activeElement).toBe(branchSearch));
   });
 
   it("filters repositories and branches in their own selectors", () => {

--- a/apps/packages/product-client/src/components/workspace/git/GitReviewTargetSelector.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/git/GitReviewTargetSelector.test.tsx
@@ -1,0 +1,34 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GitReviewTargetSelector } from "./GitReviewTargetSelector";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("GitReviewTargetSelector", () => {
+  it("focuses branch search when the picker opens", async () => {
+    render(
+      <GitReviewTargetSelector
+        mode="branch"
+        baseRef="origin/main"
+        branchRefs={[{
+          name: "origin/main",
+          isDefault: true,
+          isHead: false,
+          isRemote: true,
+          upstream: null,
+        }]}
+        isRuntimeReady
+        onSelect={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /origin\/main/i }));
+    const search = screen.getByPlaceholderText("Search branches");
+
+    await waitFor(() => expect(document.activeElement).toBe(search));
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/git/GitReviewTargetSelector.tsx
+++ b/apps/packages/product-client/src/components/workspace/git/GitReviewTargetSelector.tsx
@@ -86,6 +86,7 @@ export function GitReviewTargetSelector({
               value={search}
               onChange={(event) => setSearch(event.target.value)}
               placeholder="Search branches"
+              autoFocus
               className="h-full border-0 bg-transparent px-0 text-ui focus:ring-0"
             />
           </div>

--- a/apps/packages/product-client/src/primitives/PopoverSearchField.tsx
+++ b/apps/packages/product-client/src/primitives/PopoverSearchField.tsx
@@ -6,6 +6,7 @@ export interface PopoverSearchFieldProps {
   value: string;
   onChange: (value: string) => void;
   placeholder?: string;
+  /** Picker search owns focus when its surface opens unless explicitly disabled. */
   autoFocus?: boolean;
   /** Accessible name when the placeholder alone is not descriptive enough. */
   ariaLabel?: string;
@@ -27,7 +28,7 @@ export function PopoverSearchField({
   value,
   onChange,
   placeholder = "Search",
-  autoFocus,
+  autoFocus = true,
   ariaLabel,
   onKeyDown,
 }: PopoverSearchFieldProps) {

--- a/apps/packages/product-client/src/primitives/__tests__/PopoverButton.test.tsx
+++ b/apps/packages/product-client/src/primitives/__tests__/PopoverButton.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { useState } from "react";
 import { Button } from "#product/primitives/Button";
 import { PopoverButton } from "#product/primitives/PopoverButton";
+import { PopoverSearchField } from "#product/primitives/PopoverSearchField";
 
 afterEach(() => {
   cleanup();
@@ -32,7 +33,32 @@ function ControlledPopoverHarness() {
   );
 }
 
+function SearchPopoverHarness() {
+  const [search, setSearch] = useState("");
+
+  return (
+    <PopoverButton trigger={<Button variant="ghost">Choose project</Button>}>
+      {() => (
+        <PopoverSearchField
+          value={search}
+          onChange={setSearch}
+          placeholder="Search projects"
+        />
+      )}
+    </PopoverButton>
+  );
+}
+
 describe("PopoverButton", () => {
+  it("focuses a picker search field when the popover opens", async () => {
+    render(<SearchPopoverHarness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose project" }));
+    const search = screen.getByPlaceholderText("Search projects");
+
+    await waitFor(() => expect(document.activeElement).toBe(search));
+  });
+
   it("honors an external close after the trigger opened the popover", async () => {
     render(<ControlledPopoverHarness />);
 

--- a/specs/DESIGN_SYSTEM.md
+++ b/specs/DESIGN_SYSTEM.md
@@ -798,7 +798,7 @@ index is the closed set, not a sample of it.
 | `Popover` | [Popover.tsx](../apps/packages/product-client/src/primitives/Popover.tsx) | Raw `@radix-ui/react-popover` wrapper; `PopoverButton` composes it. |
 | `PopoverButton` | [PopoverButton.tsx](../apps/packages/product-client/src/primitives/PopoverButton.tsx) | Popover-backed trigger/content wrapper with `triggerMode` (`click`/`doubleClick`/`contextMenu`); the sanctioned menu/popover trigger. |
 | `PopoverMenuItem` | [PopoverMenuItem.tsx](../apps/packages/product-client/src/primitives/PopoverMenuItem.tsx) | Plain-button popover menu row; the sanctioned menu-item companion to `PopoverButton`. |
-| `PopoverSearchField` | [PopoverSearchField.tsx](../apps/packages/product-client/src/primitives/PopoverSearchField.tsx) | Search input for popover pickers, with an in-place list-navigation keyboard hook. |
+| `PopoverSearchField` | [PopoverSearchField.tsx](../apps/packages/product-client/src/primitives/PopoverSearchField.tsx) | Search input for popover pickers; owns focus when mounted by default and supports in-place list-navigation keyboard handling. |
 | `ProgressBar` | [ProgressBar.tsx](../apps/packages/product-client/src/primitives/ProgressBar.tsx) | Determinate progress bar. |
 | `RadioCardGroup` | [RadioCardGroup.tsx](../apps/packages/product-client/src/primitives/RadioCardGroup.tsx) | Radio-selectable card group with label/description/icon per option. |
 | `RangeSlider` | [RangeSlider.tsx](../apps/packages/product-client/src/primitives/RangeSlider.tsx) | Native range input styled to tokens. |


### PR DESCRIPTION
## Summary

- Make the canonical picker search field own focus whenever its popover surface mounts.
- Cover the legacy Git review branch picker that does not yet use the canonical search primitive.
- Add focused regressions for the shared popover behavior plus the Home project, Home branch, and Git review branch pickers.
- Document the autofocus contract in the design-system index.

Searchable popovers previously inherited `PopoverButton`'s focus-neutral opening behavior while `PopoverSearchField` treated autofocus as opt-in. That left focus on the trigger or composer and forced an extra click before typing. After this change, typing immediately filters the opened picker.

## Testing

Tier 1 UI/component coverage:

- 15 focused Vitest tests passed across the shared popover, Home target picker, and Git review target picker.
- ProductClient TypeScript compilation passed.
- Frontend boundary validation passed.
- Documentation integrity validation passed for the committed tree.
- Full GitHub CI, CodeQL, intent tests, self-host smoke, and Vercel preview passed.
- Manual QA passed in the isolated `pro-112` desktop profile.

## Review

- Independent static review found no blockers, decisions, or follow-ups.
- Inventory confirmed every live searchable popover is covered, including the legacy Git review branch picker.

## Observability

- None. This changes local focus behavior only and adds no telemetry or runtime state.

## Readiness

- [x] I followed the pull-request procedure for scope, title, labels, body, and readiness.

## Verification

- `pnpm --filter @proliferate/product-client exec vitest run src/primitives/__tests__/PopoverButton.test.tsx src/components/home/screen/HomeTargetPicker.test.tsx src/components/workspace/git/GitReviewTargetSelector.test.tsx`
- `pnpm --filter @proliferate/product-client exec tsc -p tsconfig.json --noEmit --pretty false`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_docs.py`
