### PR TITLE
fix(product): prevent native caret and placeholder overlap

### DIFF
--- a/apps/packages/design/src/css/product.css
+++ b/apps/packages/design/src/css/product.css
@@ -115,6 +115,16 @@ body {
   caret-color: var(--color-text-caret);
 }
 
+/* Current macOS WebKit paints native insertion carets at two CSS pixels, while
+   native placeholders otherwise begin at that same origin. Offset only the
+   focused placeholder: entered text and its caret keep their established
+   alignment. The base layer lets a specialized control override this contract. */
+@layer base {
+  :is(input, textarea):focus::placeholder {
+    text-indent: 2px;
+  }
+}
+
 :is(input, textarea, [contenteditable]:not([contenteditable="false"]), [data-ui-thin-caret])::selection {
   background-color: var(--color-text-selection);
   color: inherit;

--- a/apps/packages/product-client/src/primitives/PopoverSearchField.tsx
+++ b/apps/packages/product-client/src/primitives/PopoverSearchField.tsx
@@ -34,8 +34,6 @@ export function PopoverSearchField({
   return (
     <div className="flex items-center gap-2 px-2.5 py-[7px]">
       <Search className="icon-paired shrink-0 text-muted-foreground/75" />
-      {/* The native WebKit caret occupies two pixels at the insertion origin.
-          Move only the focused placeholder so entered text stays aligned. */}
       <Input
         variant="unstyled"
         value={value}
@@ -44,7 +42,7 @@ export function PopoverSearchField({
         autoFocus={autoFocus}
         aria-label={ariaLabel}
         onKeyDown={onKeyDown}
-        className="h-auto min-w-0 flex-1 border-0 bg-transparent px-0 py-0 text-ui text-foreground shadow-none outline-none placeholder:text-muted-foreground focus:placeholder:indent-0.5 focus:ring-0 disabled:opacity-60"
+        className="h-auto min-w-0 flex-1 border-0 bg-transparent px-0 py-0 text-ui text-foreground shadow-none outline-none placeholder:text-muted-foreground focus:ring-0 disabled:opacity-60"
       />
     </div>
   );

--- a/apps/packages/product-client/src/primitives/PopoverSearchField.tsx
+++ b/apps/packages/product-client/src/primitives/PopoverSearchField.tsx
@@ -34,14 +34,17 @@ export function PopoverSearchField({
   return (
     <div className="flex items-center gap-2 px-2.5 py-[7px]">
       <Search className="icon-paired shrink-0 text-muted-foreground/75" />
+      {/* The native WebKit caret occupies two pixels at the insertion origin.
+          Move only the focused placeholder so entered text stays aligned. */}
       <Input
+        variant="unstyled"
         value={value}
         onChange={(event) => onChange(event.target.value)}
         placeholder={placeholder}
         autoFocus={autoFocus}
         aria-label={ariaLabel}
         onKeyDown={onKeyDown}
-        className="h-auto min-w-0 flex-1 border-0 bg-transparent px-0 py-0 text-ui shadow-none focus:ring-0"
+        className="h-auto min-w-0 flex-1 border-0 bg-transparent px-0 py-0 text-ui text-foreground shadow-none outline-none placeholder:text-muted-foreground focus:placeholder:indent-0.5 focus:ring-0 disabled:opacity-60"
       />
     </div>
   );

--- a/apps/packages/product-client/src/primitives/__tests__/PopoverSearchField.test.ts
+++ b/apps/packages/product-client/src/primitives/__tests__/PopoverSearchField.test.ts
@@ -41,34 +41,41 @@ afterAll(async () => {
   await viteServer?.close();
 }, 60_000);
 
-describe("PopoverSearchField", () => {
-  it("keeps the focused placeholder clear of the native caret without shifting entered text", async () => {
+describe("native placeholder caret spacing", () => {
+  it("keeps focused input and textarea placeholders clear without shifting entered text", async () => {
     const page = await browser.newPage({ viewport: { width: 360, height: 160 } });
     try {
       await page.goto(fixtureUrl, { waitUntil: "networkidle" });
-      const input = page.getByPlaceholder("Search models");
+      const fields = [
+        page.getByPlaceholder("Search models"),
+        page.getByPlaceholder("Search files"),
+        page.getByPlaceholder("Add objective"),
+      ];
 
-      await input.focus();
-      const focusedIndent = await input.evaluate((element) => ({
-        input: getComputedStyle(element).textIndent,
-        placeholder: getComputedStyle(element, "::placeholder").textIndent,
-      }));
-      expect(focusedIndent).toEqual({
-        input: "0px",
-        placeholder: "2px",
-      });
+      for (const field of fields) {
+        await field.focus();
+        const focusedIndent = await field.evaluate((element) => ({
+          input: getComputedStyle(element).textIndent,
+          placeholder: getComputedStyle(element, "::placeholder").textIndent,
+        }));
+        expect(focusedIndent).toEqual({
+          input: "0px",
+          placeholder: "2px",
+        });
 
-      await input.fill("claude");
-      expect(
-        await input.evaluate((element) => getComputedStyle(element).textIndent),
-      ).toBe("0px");
+        await field.fill("entered text");
+        expect(
+          await field.evaluate((element) => getComputedStyle(element).textIndent),
+        ).toBe("0px");
 
-      await page.getByRole("button", { name: "Done" }).focus();
-      expect(
-        await input.evaluate(
-          (element) => getComputedStyle(element, "::placeholder").textIndent,
-        ),
-      ).toBe("0px");
+        await field.fill("");
+        await page.getByRole("button", { name: "Done" }).focus();
+        expect(
+          await field.evaluate(
+            (element) => getComputedStyle(element, "::placeholder").textIndent,
+          ),
+        ).toBe("0px");
+      }
     } finally {
       await page.close();
     }
@@ -94,6 +101,8 @@ function renderFixtureHtml(): string {
       </head>
       <body>
         <div id="fixture">${searchField}</div>
+        <input placeholder="Search files" />
+        <textarea placeholder="Add objective"></textarea>
         <button type="button">Done</button>
       </body>
     </html>`;

--- a/apps/packages/product-client/src/primitives/__tests__/PopoverSearchField.test.ts
+++ b/apps/packages/product-client/src/primitives/__tests__/PopoverSearchField.test.ts
@@ -1,0 +1,117 @@
+import { fileURLToPath } from "node:url";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { PopoverSearchField } from "#product/primitives/PopoverSearchField";
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createServer, type Plugin, type ViteDevServer } from "vite";
+
+const WEB_ROOT = fileURLToPath(new URL("../../../../../web/", import.meta.url));
+const WEB_VITE_CONFIG = fileURLToPath(
+  new URL("../../../../../web/vite.config.ts", import.meta.url),
+);
+
+let viteServer: ViteDevServer;
+let browser: Browser;
+let fixtureUrl: string;
+
+beforeAll(async () => {
+  viteServer = await createServer({
+    configFile: WEB_VITE_CONFIG,
+    root: WEB_ROOT,
+    logLevel: "silent",
+    plugins: [fixtureRoute(renderFixtureHtml())],
+    server: {
+      host: "127.0.0.1",
+      port: 0,
+      strictPort: false,
+    },
+  });
+  await viteServer.listen();
+  const baseUrl = viteServer.resolvedUrls?.local[0];
+  if (!baseUrl) {
+    throw new Error("Popover search field fixture did not receive a Vite URL.");
+  }
+  fixtureUrl = new URL("__popover-search-field", baseUrl).href;
+  browser = await chromium.launch({ channel: "chrome", headless: true });
+}, 60_000);
+
+afterAll(async () => {
+  await browser?.close();
+  await viteServer?.close();
+}, 60_000);
+
+describe("PopoverSearchField", () => {
+  it("keeps the focused placeholder clear of the native caret without shifting entered text", async () => {
+    const page = await browser.newPage({ viewport: { width: 360, height: 160 } });
+    try {
+      await page.goto(fixtureUrl, { waitUntil: "networkidle" });
+      const input = page.getByPlaceholder("Search models");
+
+      await input.focus();
+      const focusedIndent = await input.evaluate((element) => ({
+        input: getComputedStyle(element).textIndent,
+        placeholder: getComputedStyle(element, "::placeholder").textIndent,
+      }));
+      expect(focusedIndent).toEqual({
+        input: "0px",
+        placeholder: "2px",
+      });
+
+      await input.fill("claude");
+      expect(
+        await input.evaluate((element) => getComputedStyle(element).textIndent),
+      ).toBe("0px");
+
+      await page.getByRole("button", { name: "Done" }).focus();
+      expect(
+        await input.evaluate(
+          (element) => getComputedStyle(element, "::placeholder").textIndent,
+        ),
+      ).toBe("0px");
+    } finally {
+      await page.close();
+    }
+  }, 60_000);
+});
+
+function renderFixtureHtml(): string {
+  const searchField = renderToStaticMarkup(createElement(PopoverSearchField, {
+    value: "",
+    onChange: () => undefined,
+    placeholder: "Search models",
+  }));
+
+  return `<!doctype html>
+    <html>
+      <head>
+        <meta charset="utf-8" />
+        <link rel="stylesheet" href="/src/index.css" />
+        <style>
+          body { padding: 24px; }
+          #fixture { width: 288px; }
+        </style>
+      </head>
+      <body>
+        <div id="fixture">${searchField}</div>
+        <button type="button">Done</button>
+      </body>
+    </html>`;
+}
+
+function fixtureRoute(html: string): Plugin {
+  return {
+    name: "popover-search-field-fixture",
+    configureServer(server) {
+      server.middlewares.use((request, response, next) => {
+        if (request.url !== "/__popover-search-field") {
+          next();
+          return;
+        }
+        response.statusCode = 200;
+        response.setHeader("Content-Type", "text/html; charset=utf-8");
+        response.end(html);
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- offset focused native `input` and `textarea` placeholders from the insertion caret in shared design CSS
- leave the caret and entered text at their established alignment
- keep the borderless shared popover search field on the explicit unstyled Input contract
- add a compiled-CSS browser regression covering a shared picker, raw input, and textarea across focus, typing, and blur

## Why

Current macOS WebKit paints native insertion carets two CSS pixels wide. Native placeholders otherwise begin at the same origin, so the caret can obscure the first glyph anywhere an empty field receives focus—not only in the model picker.

The base-layer design rule moves only the focused placeholder by 2px. It covers shared Inputs, Textareas, command inputs, and hand-rolled native controls while still allowing a specialized component utility to override the behavior.

## Testing

Tier 1 unit/contract coverage:

- `pnpm --filter @proliferate/product-client exec vitest run src/components/workspace/chat/input/ComposerModelSelectorControl.test.tsx src/primitives/__tests__/PopoverButton.test.tsx src/primitives/__tests__/PopoverSearchField.test.ts` — 14 passed
- `pnpm --filter @proliferate/product-client typecheck`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_appearance_scaling.py`
- `python3 scripts/check_design_attribution.py`
- isolated local profile: Desktop, hosted Web, API, and AnyHarness all started successfully; both frontends returned 200 and API health returned OK
- full GitHub CI, including shared frontend packages and repository Cargo checks

## Observability

None. This changes shared presentation and regression coverage only; it introduces no new product flow, failure path, or telemetry surface.

## Tracking

The fixing relationship is linked through the issue tracker.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Verification

The real-browser regression verifies all three representative field types:

- focused placeholder computed indent: `2px`
- focused input/textarea and entered-text computed indent: `0px`
- blurred placeholder computed indent: `0px`