### PR TITLE
fix(product): make file mentions scrollable

### DIFF
--- a/apps/packages/product-client/src/components/playground/PlaygroundComposerSurfaces.tsx
+++ b/apps/packages/product-client/src/components/playground/PlaygroundComposerSurfaces.tsx
@@ -208,7 +208,7 @@ function PlaygroundFileMentionComposerSurface({
           results={results}
           highlightedIndex={0}
           listRef={listRef}
-          query="tok"
+          query="a"
           isLoading={false}
           isError={false}
           isPending={false}
@@ -228,7 +228,7 @@ function PlaygroundFileMentionComposerSurface({
             data-telemetry-mask
             className="mb-2 flex min-h-14 flex-grow select-text items-start px-5 text-composer text-foreground"
           >
-            <span>Look at @tok</span>
+            <span>Look at @a</span>
           </div>
           <PlaygroundComposerControlRow />
         </form>

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerFileMentionSearch.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerFileMentionSearch.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ComposerFileMentionSearch } from "#product/components/workspace/chat/input/ComposerFileMentionSearch";
+
+afterEach(cleanup);
+
+describe("ComposerFileMentionSearch", () => {
+  it("renders long result sets inside the shared scrolling listbox", () => {
+    const results = Array.from({ length: 14 }, (_, index) => ({
+      path: `src/file-${index}.ts`,
+      name: `file-${index}.ts`,
+      parent: "src",
+    }));
+
+    render(
+      <ComposerFileMentionSearch
+        results={results}
+        highlightedIndex={0}
+        listRef={createRef<HTMLDivElement>()}
+        query="file"
+        isLoading={false}
+        isError={false}
+        isPending={false}
+        runtimeReady
+        onSelect={vi.fn()}
+        onRowMouseEnter={vi.fn()}
+        setRowRef={vi.fn()}
+        getRowId={(index) => `file-result-${index}`}
+      />,
+    );
+
+    const listbox = screen.getByRole("listbox", { name: "File mentions" });
+    expect(screen.getAllByRole("option")).toHaveLength(14);
+    expect(listbox.className).toContain("max-h-[min(320px,40dvh)]");
+    expect(listbox.className).toContain("overflow-y-auto");
+    expect(screen.getByText("file-13.ts")).toBeTruthy();
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerInlineMenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerInlineMenu.tsx
@@ -35,9 +35,10 @@ export function ComposerInlineMenuPanel({
         ref={listRef}
         role="listbox"
         aria-label={label}
-        // 320px is the height at which the list still reads as a menu rather
-        // than a panel: ~10 rows visible, the rest scrolled.
-        className="file-tree-scroll flex max-h-[320px] min-h-0 flex-col overflow-y-auto"
+        // Ten rows on a normal viewport, with a proportional cap when the
+        // window is short. Remaining rows stay reachable through native
+        // wheel/trackpad scrolling and keyboard navigation.
+        className="file-tree-scroll flex max-h-[min(320px,40dvh)] min-h-0 flex-col overflow-y-auto [scrollbar-gutter:stable]"
       >
         {children}
       </div>

--- a/apps/packages/product-client/src/config/chat.ts
+++ b/apps/packages/product-client/src/config/chat.ts
@@ -12,3 +12,9 @@ export const HOME_CHAT_COMPOSER_INPUT = {
   maxRows: 8,
   minHeightRem: 2.75,
 } as const;
+
+/**
+ * Maximum result page supported by workspace file search. The mention menu
+ * keeps the full page and scrolls inside its visual height cap.
+ */
+export const CHAT_FILE_MENTION_SEARCH_LIMIT = 200;

--- a/apps/packages/product-client/src/config/playground.test.ts
+++ b/apps/packages/product-client/src/config/playground.test.ts
@@ -14,7 +14,10 @@ import { renderAttachedSlot } from "#product/components/playground/composer-slot
 import { renderOutboundSlot } from "#product/components/playground/composer-slots/PlaygroundOutboundSlotFixtures";
 import { PlaygroundLoadingStates } from "#product/components/playground/loading/PlaygroundLoadingStates";
 import { renderComposerSurfaceForScenario } from "#product/components/playground/PlaygroundComposerSurfaces";
-import { PLAYGROUND_SLASH_COMMANDS } from "#product/lib/domain/chat/__fixtures__/playground/composer-surface-fixtures";
+import {
+  PLAYGROUND_FILE_MENTIONS,
+  PLAYGROUND_SLASH_COMMANDS,
+} from "#product/lib/domain/chat/__fixtures__/playground/composer-surface-fixtures";
 import {
   PLAYGROUND_SUBAGENT_STRIP_ROWS,
 } from "#product/lib/domain/chat/__fixtures__/playground/delegation-fixtures";
@@ -286,10 +289,12 @@ describe("playground scenarios", () => {
     expect(Object.keys(SCENARIOS)).toContain("file-mention-empty");
 
     const resultsText = visibleText(renderComposerSurfaceMarkup("file-mention-search"));
+    expect(PLAYGROUND_FILE_MENTIONS.length).toBeGreaterThan(10);
     expect(resultsText).toContain("tokens.ts");
     // The directory is the row's disambiguator and must be visible next to the
     // basename, not hidden behind a tooltip.
     expect(resultsText).toContain("apps/packages/design/src");
+    expect(resultsText).toContain("composer.md");
 
     expect(renderComposerSurfaceMarkup("file-mention-empty"))
       .toContain("No matching files.");

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-file-mention-menu.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-file-mention-menu.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CHAT_FILE_MENTION_SEARCH_LIMIT } from "#product/config/chat";
+import { useChatFileMentionMenu } from "#product/hooks/chat/ui/use-chat-file-mention-menu";
+
+const mocks = vi.hoisted(() => ({
+  searchArgs: null as Record<string, unknown> | null,
+  searchDebouncedQuery: "cmp",
+  searchIsPlaceholderData: false,
+  searchResults: [] as Array<{ path: string; name: string }>,
+}));
+
+vi.mock("#product/hooks/workspaces/derived/files/use-workspace-file-context", () => ({
+  useWorkspaceFileContext: () => ({ materializedWorkspaceId: "workspace-1" }),
+}));
+
+vi.mock("#product/hooks/workspaces/facade/use-selected-cloud-runtime-state", () => ({
+  useSelectedCloudRuntimeState: () => ({ state: null }),
+}));
+
+vi.mock("#product/hooks/workspaces/ui/files/use-workspace-file-search", () => ({
+  useWorkspaceFileSearch: (args: Record<string, unknown>) => {
+    mocks.searchArgs = args;
+    return {
+      query: "cmp",
+      debouncedQuery: mocks.searchDebouncedQuery,
+      searchEnabled: true,
+      isLoading: false,
+      isError: false,
+      isPlaceholderData: mocks.searchIsPlaceholderData,
+      results: mocks.searchResults,
+    };
+  },
+}));
+
+describe("useChatFileMentionMenu", () => {
+  beforeEach(() => {
+    mocks.searchArgs = null;
+    mocks.searchDebouncedQuery = "cmp";
+    mocks.searchIsPlaceholderData = false;
+    mocks.searchResults = Array.from({ length: 200 }, (_, index) => ({
+      path: `src/composer-${index}.ts`,
+      name: `composer-${index}.ts`,
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("keeps the runtime's full bounded result page instead of stopping at eight rows", () => {
+    const { result } = renderHook(() => useChatFileMentionMenu({
+      open: true,
+      query: "cmp",
+      onSelect: vi.fn(),
+    }));
+
+    expect(mocks.searchArgs).toMatchObject({
+      limit: 200,
+      query: "cmp",
+      workspaceId: "workspace-1",
+    });
+    expect(CHAT_FILE_MENTION_SEARCH_LIMIT).toBe(200);
+    expect(result.current.results).toHaveLength(200);
+    expect(result.current.results[8]?.path).toBe("src/composer-8.ts");
+    expect(result.current.results[199]?.path).toBe("src/composer-199.ts");
+  });
+
+  it("keeps prior-query placeholder rows out of the selectable menu", () => {
+    mocks.searchIsPlaceholderData = true;
+
+    const { result } = renderHook(() => useChatFileMentionMenu({
+      open: true,
+      query: "cmp",
+      onSelect: vi.fn(),
+    }));
+
+    expect(result.current.results).toEqual([]);
+    expect(result.current.isPending).toBe(true);
+  });
+
+  it("keeps rows hidden while the debounce still represents an older token", () => {
+    mocks.searchDebouncedQuery = "old-query";
+
+    const { result } = renderHook(() => useChatFileMentionMenu({
+      open: true,
+      query: "cmp",
+      onSelect: vi.fn(),
+    }));
+
+    expect(result.current.results).toEqual([]);
+    expect(result.current.isPending).toBe(true);
+  });
+});

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-file-mention-menu.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-file-mention-menu.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from "react";
+import { CHAT_FILE_MENTION_SEARCH_LIMIT } from "#product/config/chat";
 import { useComposerMenuNavigation } from "#product/hooks/chat/ui/use-composer-menu-navigation";
 import { useSelectedCloudRuntimeState } from "#product/hooks/workspaces/facade/use-selected-cloud-runtime-state";
 import { useWorkspaceFileContext } from "#product/hooks/workspaces/derived/files/use-workspace-file-context";
@@ -8,19 +9,6 @@ import {
   rankFileMentionResults,
   type FileMentionResult,
 } from "#product/lib/domain/chat/composer/file-mention-search";
-
-/**
- * How many mention rows the menu offers. The menu is a pick-one-fast surface,
- * not a file browser: a short list keeps the panel inside the composer's own
- * overlay height instead of covering the transcript.
- */
-const MENTION_RESULT_LIMIT = 8;
-/**
- * Raw hits requested from the runtime before basename-first ranking narrows
- * them down. Over-fetching is what lets ranking promote a deep-but-exact
- * basename match above a shallow path-substring hit.
- */
-const MENTION_SEARCH_LIMIT = 40;
 
 interface UseChatFileMentionMenuArgs {
   open: boolean;
@@ -53,14 +41,20 @@ export function useChatFileMentionMenu({
     workspaceId: materializedWorkspaceId,
     runtimeReady,
     query,
-    limit: MENTION_SEARCH_LIMIT,
+    limit: CHAT_FILE_MENTION_SEARCH_LIMIT,
   });
+  const resultsAreCurrent = search.debouncedQuery === search.query
+    && !search.isPlaceholderData;
 
   const results = useMemo(() => (
-    open
-      ? rankFileMentionResults(search.results, search.debouncedQuery, MENTION_RESULT_LIMIT)
+    open && resultsAreCurrent
+      ? rankFileMentionResults(
+          search.results,
+          search.debouncedQuery,
+          CHAT_FILE_MENTION_SEARCH_LIMIT,
+        )
       : []
-  ), [open, search.debouncedQuery, search.results]);
+  ), [open, resultsAreCurrent, search.debouncedQuery, search.results]);
 
   const navigation = useComposerMenuNavigation({
     open,
@@ -79,8 +73,8 @@ export function useChatFileMentionMenu({
     results,
     isLoading: search.isLoading,
     isError: search.isError,
-    /** True once a query has been typed but no search has been issued yet. */
-    isPending: open && query.trim().length > 0 && !search.searchEnabled,
+    /** True while the current token is waiting for its own result page. */
+    isPending: open && search.query.length > 0 && (!search.searchEnabled || !resultsAreCurrent),
     runtimeReady,
     highlightedIndex: navigation.highlightedIndex,
     listRef: navigation.listRef,

--- a/apps/packages/product-client/src/hooks/chat/ui/use-composer-menu-navigation.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-composer-menu-navigation.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useComposerMenuNavigation } from "#product/hooks/chat/ui/use-composer-menu-navigation";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("useComposerMenuNavigation", () => {
+  it("scrolls a later keyboard-highlighted row into the nearest visible edge", () => {
+    const scrollIntoView = vi.fn();
+    const laterRow = document.createElement("button");
+    Object.defineProperty(laterRow, "scrollIntoView", { value: scrollIntoView });
+    const { result } = renderHook(() => useComposerMenuNavigation({
+      open: true,
+      query: "a",
+      itemCount: 14,
+    }));
+
+    act(() => {
+      result.current.setRowRef(13, laterRow);
+      result.current.moveHighlight(13);
+    });
+
+    expect(result.current.highlightedIndex).toBe(13);
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+    expect(result.current.activeDescendantId).toBe(result.current.getRowId(13));
+  });
+});

--- a/apps/packages/product-client/src/hooks/workspaces/ui/files/use-workspace-file-search.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/files/use-workspace-file-search.ts
@@ -66,6 +66,7 @@ export function useWorkspaceFileSearch({
     searchEnabled,
     isLoading: searchEnabled && queryResult.isLoading,
     isError: searchEnabled && queryResult.isError,
+    isPlaceholderData: searchEnabled && Boolean(queryResult.isPlaceholderData),
     results,
   };
 }

--- a/apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/composer-surface-fixtures.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/__fixtures__/playground/composer-surface-fixtures.ts
@@ -54,6 +54,16 @@ export const PLAYGROUND_FILE_MENTIONS: FileMentionResult[] = [
   { path: "apps/packages/design/src/tokens.ts", name: "tokens.ts", parent: "apps/packages/design/src" },
   { path: "specs/README.md", name: "README.md", parent: "specs" },
   { path: "Cargo.toml", name: "Cargo.toml", parent: "" },
+  { path: "AGENTS.md", name: "AGENTS.md", parent: "" },
+  { path: "apps/desktop/src/App.tsx", name: "App.tsx", parent: "apps/desktop/src" },
+  { path: "apps/web/src/main.tsx", name: "main.tsx", parent: "apps/web/src" },
+  { path: "server/proliferate/api.py", name: "api.py", parent: "server/proliferate" },
+  { path: "server/proliferate/constants.py", name: "constants.py", parent: "server/proliferate" },
+  { path: "anyharness/crates/anyharness-lib/src/api/http/files.rs", name: "files.rs", parent: "anyharness/crates/anyharness-lib/src/api/http" },
+  { path: "anyharness/sdk/src/client/files.ts", name: "files.ts", parent: "anyharness/sdk/src/client" },
+  { path: "scripts/check_docs.py", name: "check_docs.py", parent: "scripts" },
+  { path: "specs/codebase/systems/product/chat/composer.md", name: "composer.md", parent: "specs/codebase/systems/product/chat" },
+  { path: "Makefile", name: "Makefile", parent: "" },
 ];
 
 export const PLAYGROUND_LONG_COMPOSER_DRAFT = [

--- a/apps/packages/product-client/src/lib/domain/chat/composer/file-mention-search.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/composer/file-mention-search.test.ts
@@ -75,7 +75,7 @@ describe("rankFileMentionResults", () => {
     { path: "src/unrelated.ts", name: "unrelated.ts" },
   ];
 
-  it("ranks basename prefix matches above basename and path substrings", () => {
+  it("ranks substring tiers ahead of the remaining runtime matches", () => {
     const results = rankFileMentionResults(candidates, "read", 10);
 
     expect(results.map((result) => result.path)).toEqual([
@@ -83,11 +83,13 @@ describe("rankFileMentionResults", () => {
       "readme.md",
       "src/reader.ts",
       "src/thread-reader.ts",
+      "src/unrelated.ts",
     ]);
   });
 
-  it("drops candidates that match nothing", () => {
-    expect(rankFileMentionResults(candidates, "zzz", 10)).toEqual([]);
+  it("preserves runtime fuzzy matches outside the substring tiers", () => {
+    expect(rankFileMentionResults(candidates, "rdr", 10).map((result) => result.path))
+      .toEqual(candidates.map((candidate) => candidate.path));
   });
 
   it("keeps every candidate when the query is empty", () => {
@@ -102,7 +104,7 @@ describe("rankFileMentionResults", () => {
   it("exposes the parent directory as the row's disambiguator", () => {
     const results = rankFileMentionResults(candidates, "readme", 10);
 
-    expect(results).toEqual([
+    expect(results.slice(0, 2)).toEqual([
       { path: "docs/setup/readme.md", name: "readme.md", parent: "docs/setup" },
       { path: "readme.md", name: "readme.md", parent: "" },
     ]);

--- a/apps/packages/product-client/src/lib/domain/chat/composer/file-mention-search.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/composer/file-mention-search.ts
@@ -100,10 +100,11 @@ function isInsideMarkdownCode(text: string, position: number): boolean {
 /**
  * Turns raw workspace file-search hits into mention rows.
  *
- * Search results arrive path-ordered from the runtime; the composer wants
- * basename-first relevance because the user is typing a file name, not a path.
- * Paths the mention format cannot represent (absolute, escaped, out-of-tree)
- * are dropped rather than inserted as a broken link.
+ * Search results arrive fuzzy-ranked from the runtime. The composer promotes
+ * the easy-to-explain basename/path substring tiers while preserving the
+ * runtime order for every other fuzzy match. Paths the mention format cannot
+ * represent (absolute, escaped, out-of-tree) are dropped rather than inserted
+ * as a broken link.
  */
 export function rankFileMentionResults(
   candidates: readonly FileMentionCandidate[],
@@ -123,9 +124,6 @@ export function rankFileMentionResults(
 
     const name = candidate.name || workspaceFileBasename(path);
     const rank = matchRank(name.toLowerCase(), path.toLowerCase(), needle);
-    if (rank === null) {
-      continue;
-    }
     ranked.push({
       rank,
       result: { path, name, parent: parentPath(path) },
@@ -139,7 +137,7 @@ export function rankFileMentionResults(
     .map((entry) => entry.result);
 }
 
-function matchRank(name: string, path: string, needle: string): number | null {
+function matchRank(name: string, path: string, needle: string): number {
   if (needle.length === 0) {
     return 3;
   }
@@ -152,7 +150,10 @@ function matchRank(name: string, path: string, needle: string): number | null {
   if (path.includes(needle)) {
     return 2;
   }
-  return null;
+  // The runtime already established that this is a fuzzy match. Keep it in
+  // its runtime-relative order instead of silently applying a stricter second
+  // filter in the composer.
+  return 3;
 }
 
 function parentPath(path: string): string {

--- a/specs/codebase/systems/product/chat/composer.md
+++ b/specs/codebase/systems/product/chat/composer.md
@@ -162,6 +162,12 @@ Discovery follows the current caret rather than the end of the document, and a
 selection replaces only the active slash-token range while preserving text and
 formatting around it.
 
+File-mention discovery keeps the runtime's full supported result page instead
+of applying a smaller presentation limit or discarding fuzzy matches with a
+stricter client-side filter. The shared inline-menu viewport stays visually
+capped at about ten rows and scrolls the remaining matches; Arrow-key navigation
+keeps the highlighted row in view while focus remains in the composer editor.
+
 Composer focus follows the app lifecycle. The workspace composer takes focus
 after mount and workspace switches (`ChatInput.tsx`), and the Home composer
 takes focus after mount (`HomeComposerForm.tsx`); both surfaces mark their


### PR DESCRIPTION
## Summary

- remove the independent eight-row file-mention cap and request the runtime's full supported 200-result page
- preserve runtime fuzzy matches while keeping basename/path substring tiers promoted
- keep the shared inline menu compact with native scrolling, short-viewport sizing, a stable scrollbar gutter, and keyboard visibility
- hide prior-query placeholder results until the current debounced search page arrives
- add long-list hook, component, navigation, ranking, and playground regression coverage

The root cause was a presentation cap that rendered only 8 of 40 fetched results, so the existing scroll container never overflowed. The runtime currently caps file-search responses at 200 and does not expose pagination or `hasMore`; this PR therefore makes the complete supported page available rather than claiming unbounded repository search.

## Testing

- ProductClient build and TypeScript compilation: `pnpm --filter @proliferate/product-client build`
- Tier 1 focused regression suite: 7 files, 61 tests passed
- Full ProductClient suite: 818 files, 5,515 tests passed
- `python3 scripts/check_docs.py`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_appearance_scaling.py`
- `python3 scripts/check_design_attribution.py`
- `git diff --check`
- Rendered playground QA: all 14 options remained mounted in a native-scroll listbox; wheel scrolling reached the final option, with a 320px cap at the default viewport and a 288px cap at a 720px viewport
- All GitHub checks passed on head `b0cb6393f98d9201a9f3db9556faca68676042b0`

## Observability

- None. This changes local search presentation and selection behavior without adding a new runtime or network failure mode.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker API. No tracker, report, user, or support IDs or private source data appear in this PR.

## Verification

- Founder-approved implementation reviewed in independent correctness, UI/UX, test/performance, adversarial, and merge-readiness passes; no code or behavior blockers remain.