### PR TITLE
fix(product): soften workspace resize separator drag feedback

### DIFF
--- a/apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceResizeSeparator.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceResizeSeparator.tsx
@@ -2,7 +2,9 @@ import type { MouseEventHandler } from "react";
 
 /**
  * Vertical drag handle between the workspace shell panels. The negative
- * margin keeps the 4px hit area overlapping the adjacent panel edge.
+ * margin keeps the 4px hit area overlapping the adjacent panel edge; hover
+ * and drag feedback stays a 1px line pinned to the panel boundary so it
+ * brightens the existing hairline instead of filling the hit area.
  */
 export function WorkspaceResizeSeparator({
   edge,
@@ -19,9 +21,9 @@ export function WorkspaceResizeSeparator({
       aria-orientation="vertical"
       aria-controls={ariaControls}
       onMouseDown={onMouseDown}
-      className={`relative z-10 flex w-1 shrink-0 cursor-col-resize items-center justify-center ${
-        edge === "left" ? "-ml-1" : "-mr-1"
-      } hover:bg-primary/30 active:bg-primary/50 transition-colors`}
+      className={`relative z-10 w-1 shrink-0 cursor-col-resize before:absolute before:inset-y-0 before:w-[0.5px] before:transition-colors ${
+        edge === "left" ? "-ml-1 before:right-0" : "-mr-1 before:left-0"
+      } hover:before:bg-border-heavy active:before:bg-primary/30`}
     />
   );
 }


### PR DESCRIPTION
## Summary

- The workspace shell's panel resize separators (left sidebar ↔ center, center ↔ right panel) filled their entire 4px hit strip with `primary/30` on hover and `primary/50` while dragging — a wide bright band at the pane boundary (PRO-169: dragging sidebar focus state should be less obvious).
- The 4px grab area is unchanged; the visible feedback is now a half-pixel `::before` line pinned to the panel-boundary hairline so it brightens the existing `border` hairline instead of filling the strip: `border-heavy` on hover, `primary/30` while dragging. Reads as a subtle gray line in both themes while staying visible.
- Both instances of the shared `WorkspaceResizeSeparator` get the treatment. The independent inline copies (cowork shell, settings screen, main-sidebar page shell) are untouched — follow-up candidates.

## Testing

- Unit/typecheck tier: `pnpm exec tsc --noEmit` in `apps/packages/product-client` and `pnpm exec tsc` in `apps/desktop` pass; `python3 scripts/check_design_attribution.py` passes. The only test touching the rail mocks the separator, so no assertions pin the styling.
- Manual product tier: ran the full local profile stack from this branch and drove the renderer in a browser via CDP. Verified rest/hover/drag states of the right separator at 6× zoom in dark and light modes, including a genuine pointer drag (separator tracks the pointer; feedback stays a hairline). Hover/active states additionally verified via DevTools forced pseudo-states.

## Observability

- none

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- `cd apps/packages/product-client && pnpm exec tsc -p tsconfig.json --noEmit`
- `cd apps/desktop && pnpm exec tsc`
- `python3 scripts/check_design_attribution.py`
- Local visual check: `make run PROFILE=<name> USE_EXISTING_POSTGRES=1`, open the workspace shell, drag either panel separator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)