### PR TITLE
fix(product): remove inert rollback icon from closed-sessions menu (PRO-158)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/shell/tabs/ClosedChatTabsMenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/tabs/ClosedChatTabsMenu.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import { motion } from "@proliferate/design/motion";
 import { AnimatedCollapsibleContent } from "#product/primitives/AnimatedCollapsibleContent";
 import { Button } from "#product/primitives/Button";
-import { Trash, RotateCcw } from "#product/primitives/icons/core";
+import { Trash } from "#product/primitives/icons/core";
 import { formatRelativeTime } from "#product/lib/domain/workspaces/display/workspace-display";
 import type {
   HeaderChatMenuEntry,
@@ -157,7 +157,6 @@ export function ClosedChatTabsMenu({
                   {formatRelativeTime(row.closedAt)}
                 </span>
               )}
-              <RotateCcw className="icon-compact shrink-0 text-muted-foreground" aria-hidden="true" />
             </div>
           </AnimatedCollapsibleContent>
         ))}


### PR DESCRIPTION
## Summary
Removes the per-row `RotateCcw` (rollback) icon from the closed-sessions history menu in the workspace tab strip. The icon was purely decorative (`aria-hidden`, no click handler) — clicking the row already restores the session — but it looked like an actionable button that did nothing.

Fixes [PRO-158](https://linear.app/proliferate-team/issue/PRO-158/session-popover-rollback-icon-doesnt-do-anything).

## Testing
- `pnpm exec tsc -p tsconfig.json --noEmit` in `apps/packages/product-client` — clean
- `pnpm vitest run src/components/workspace/shell/tabs/ClosedChatTabsMenu.test.tsx` — 3/3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)