### PR TITLE
fix(product): remove logo from sidebar brand row (PRO-139)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
@@ -3,7 +3,6 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { useShallow } from "zustand/react/shallow";
 import { useRemoveCloudRepoEnvironment, useRepositories } from "@proliferate/cloud-sdk-react";
 import { ConfirmationDialog } from "#product/primitives/patterns/ConfirmationDialog";
-import { ProliferateIcon } from "#product/primitives/icons/proliferate-icons";
 import { DebugProfiler } from "#product/components/diagnostics/DebugProfiler";
 import { SidebarAccountFooter } from "#product/components/app/sidebar/SidebarAccountFooter";
 import { ReleaseNoticeCard } from "#product/components/workspace/shell/sidebar/ReleaseNoticeCard";
@@ -338,10 +337,7 @@ export const MainSidebar = memo(function MainSidebar({ showRightBorder = true }:
           </DebugProfiler>
         )}>
         <ProductSidebarBody>
-          <ProductSidebarBrandRow
-            icon={<ProliferateIcon className="icon-paired shrink-0" />}
-            label="Proliferate"
-          />
+          <ProductSidebarBrandRow label="Proliferate" />
           <DebugProfiler id="workspace-sidebar-primary-nav">
             <SidebarPrimaryNavigation
               homeActive={isOnHome && !selectedWorkspaceId && !pendingWorkspaceEntry}


### PR DESCRIPTION
## Summary
Removes the Proliferate logo mark to the left of the "Proliferate" wordmark in the main sidebar brand row, per PRO-139.

`ProductSidebarBrandRow`'s `icon` prop is already optional (defaults to `null`), so the change only drops the icon at the call site and removes the now-unused `ProliferateIcon` import.

Linear: https://linear.app/proliferate-team/issue/PRO-139/sidebar-should-not-have-logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)