### PR TITLE
fix(chat): select the full transcript with Cmd+A

### DIFF
--- a/apps/packages/design/src/css/product.css
+++ b/apps/packages/design/src/css/product.css
@@ -1583,12 +1583,6 @@ body {
 /* 4.5s total: trot in (0-30%), pause & celebrate (30-70%), trot out (70-100%) */
 /* Arms down during trot, raise when paused in center, stay up for exit */
 /* Trophy pops in after arms are up, stays for the hold, exits with the trot */
-/* ---- Chat view text selection ---- */
-.chat-selection-root ::selection {
-  background-color: var(--color-text-selection);
-  color: inherit;
-}
-
 .workspace-shell-tab {
   height: var(--workspace-shell-tab-height);
 }

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.test.tsx
@@ -34,6 +34,16 @@ afterEach(() => {
 });
 
 describe("FullTranscriptRowList", () => {
+  it("keeps the complete transcript row stack visibly selectable", () => {
+    const { container } = render(<FullTranscriptRowList {...makeProps(vi.fn(), 50)} />);
+    const selectionRoot = container.querySelector<HTMLElement>(
+      '[data-chat-transcript-root="true"]',
+    );
+
+    expect(selectionRoot?.classList.contains("select-text")).toBe(true);
+    expect(selectionRoot?.classList.contains("select-none")).toBe(false);
+  });
+
   it("continues from a newer older-history cursor while pinned at the top", async () => {
     const onLoadOlderHistory = vi.fn();
     const props = makeProps(onLoadOlderHistory, 50);

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.tsx
@@ -274,7 +274,7 @@ export function FullTranscriptRowList({
             ref={selectionRootRef}
             data-chat-transcript-root="true"
             tabIndex={-1}
-            className={`${columnClassName} select-none outline-none [--text-chat:var(--text-message)] [--text-chat--line-height:var(--text-message--line-height)] [--text-chat-meta:calc(var(--text-chat)_-_2px)]`}
+            className={`${columnClassName} select-text outline-none [--text-chat:var(--text-message)] [--text-chat--line-height:var(--text-message--line-height)] [--text-chat-meta:calc(var(--text-chat)_-_2px)]`}
           >
             {TRANSCRIPT_TOP_PADDING_PX > 0 && (
               <div aria-hidden="true" style={{ height: TRANSCRIPT_TOP_PADDING_PX }} />

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualTranscriptViewport.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualTranscriptViewport.tsx
@@ -67,7 +67,7 @@ export function VirtualTranscriptViewport({
           ref={selectionRootRef}
           data-chat-transcript-root="true"
           tabIndex={-1}
-          className={`${columnClassName} select-none outline-none [--text-chat:var(--text-message)] [--text-chat--line-height:var(--text-message--line-height)] [--text-chat-meta:calc(var(--text-chat)_-_2px)]`}
+          className={`${columnClassName} select-text outline-none [--text-chat:var(--text-message)] [--text-chat--line-height:var(--text-message--line-height)] [--text-chat-meta:calc(var(--text-chat)_-_2px)]`}
         >
           {topSpacerHeight > 0 && (
             <div aria-hidden="true" style={{ height: topSpacerHeight }} />

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx
@@ -76,6 +76,16 @@ function getViewport(container: HTMLElement): HTMLDivElement {
 describe("VirtualizedTranscriptRowList", () => {
   // jsdom does no layout, so the tanstack virtualizer surfaces no virtual items
   // here; these are wiring smoke tests, not layout/measurement tests.
+  it("keeps the complete transcript row stack visibly selectable", () => {
+    const { container } = render(<VirtualizedTranscriptRowList {...makeProps()} />);
+    const selectionRoot = container.querySelector<HTMLElement>(
+      '[data-chat-transcript-root="true"]',
+    );
+
+    expect(selectionRoot?.classList.contains("select-text")).toBe(true);
+    expect(selectionRoot?.classList.contains("select-none")).toBe(false);
+  });
+
   it("mounts and starts pinned (scroll-to-bottom affordance hidden)", () => {
     const { container } = render(<VirtualizedTranscriptRowList {...makeProps()} />);
     const button = container.querySelector('[aria-label="Scroll to bottom"]');

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-selection.test.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-selection.test.ts
@@ -47,6 +47,7 @@ describe("transcript selection decisions", () => {
     expect(resolvePointerOwnership(target({ insideRoot: false }))).toBe("clear-owned");
     expect(resolvePointerOwnership(target({ insideRoot: true, textEntry: true }))).toBe("clear-owned");
     expect(resolvePointerOwnership(target({ insideRoot: true, terminalZone: true }))).toBe("clear-owned");
+    expect(resolvePointerOwnership(target({ insideRoot: true, browserZone: true }))).toBe("clear-owned");
     expect(resolvePointerOwnership(target({ insideRoot: true, nativeInteractive: true }))).toBe("clear-owned");
     expect(resolvePointerOwnership(target({ insideRoot: true, ariaInteractive: true }))).toBe("clear-owned");
     expect(resolvePointerOwnership(target({
@@ -98,6 +99,41 @@ describe("transcript selection decisions", () => {
       eventTarget: inside,
       activeTarget: target(),
     })).toBe("ignore");
+  });
+
+  it("lets the active chat surface own primary-A without a prior selection", () => {
+    expect(resolvePrimaryAAction({
+      owned: false,
+      commandOwnerActive: true,
+      isSelectAll: true,
+      defaultPrevented: false,
+      eventTarget: target(),
+      activeTarget: target(),
+    })).toBe("select-root");
+    expect(resolvePrimaryAAction({
+      owned: false,
+      commandOwnerActive: true,
+      isSelectAll: true,
+      defaultPrevented: false,
+      eventTarget: target(),
+      activeTarget: target({ textEntry: true }),
+    })).toBe("clear-owned");
+    expect(resolvePrimaryAAction({
+      owned: false,
+      commandOwnerActive: true,
+      isSelectAll: true,
+      defaultPrevented: false,
+      eventTarget: target(),
+      activeTarget: target({ terminalZone: true }),
+    })).toBe("clear-owned");
+    expect(resolvePrimaryAAction({
+      owned: false,
+      commandOwnerActive: true,
+      isSelectAll: true,
+      defaultPrevented: false,
+      eventTarget: target(),
+      activeTarget: target({ browserZone: true }),
+    })).toBe("clear-owned");
   });
 
   it("clamps document selection changes only when transcript ownership is active", () => {

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-selection.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-selection.ts
@@ -12,6 +12,7 @@ export interface TranscriptTargetFacts {
   selectableInteractiveText: boolean;
   textEntry: boolean;
   terminalZone: boolean;
+  browserZone: boolean;
   ignoredChrome: boolean;
   nativeInteractive: boolean;
   ariaInteractive: boolean;
@@ -38,6 +39,7 @@ export const EMPTY_TRANSCRIPT_TARGET_FACTS: TranscriptTargetFacts = {
   selectableInteractiveText: false,
   textEntry: false,
   terminalZone: false,
+  browserZone: false,
   ignoredChrome: false,
   nativeInteractive: false,
   ariaInteractive: false,
@@ -59,6 +61,7 @@ export function isPrimarySelectAllEvent(
 export function isBlockedTranscriptTarget(target: TranscriptTargetFacts): boolean {
   return target.textEntry
     || target.terminalZone
+    || target.browserZone
     || target.ignoredChrome
     || target.nativeInteractive
     || target.ariaInteractive;
@@ -95,12 +98,14 @@ export function resolvePointerOwnership(
 
 export function resolvePrimaryAAction({
   owned,
+  commandOwnerActive = false,
   isSelectAll,
   defaultPrevented,
   eventTarget,
   activeTarget,
 }: {
   owned: boolean;
+  commandOwnerActive?: boolean;
   isSelectAll: boolean;
   defaultPrevented: boolean;
   eventTarget: TranscriptTargetFacts;
@@ -109,10 +114,15 @@ export function resolvePrimaryAAction({
   if (!isSelectAll || defaultPrevented) {
     return "ignore";
   }
-  if (!owned) {
+  if (!owned && !commandOwnerActive) {
     return "ignore";
   }
-  return isValidTranscriptKeyboardTarget(eventTarget, activeTarget)
+  const validOwner = commandOwnerActive
+    || eventTarget.insideRoot
+    || activeTarget.insideRoot;
+  return validOwner
+    && !isBlockedTranscriptTarget(eventTarget)
+    && !isBlockedTranscriptTarget(activeTarget)
     ? "select-root"
     : "clear-owned";
 }

--- a/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-select-all.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-select-all.test.tsx
@@ -1,0 +1,243 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatTranscriptSelection } from "#product/hooks/chat/ui/chat-transcript-selection";
+import { useShortcutHandler } from "#product/hooks/shortcuts/lifecycle/use-shortcut-handler";
+import {
+  clearShortcutHandlerRegistryForTests,
+  runShortcutHandler,
+} from "#product/lib/domain/shortcuts/registry";
+import {
+  runSelectAllCommand,
+} from "#product/lib/infra/dom/dom-select-all";
+
+beforeEach(() => {
+  clearShortcutHandlerRegistryForTests();
+  vi.stubGlobal("navigator", {
+    platform: "MacIntel",
+    userAgent: "Mac OS X",
+  });
+});
+
+afterEach(() => {
+  document.getSelection()?.removeAllRanges();
+  cleanup();
+  clearShortcutHandlerRegistryForTests();
+  vi.unstubAllGlobals();
+});
+
+describe("chat transcript select all", () => {
+  it("selects the visible transcript from the native menu with no prior focus or selection", () => {
+    const { getByTestId } = render(<TranscriptSelectionHarness />);
+    const root = getByTestId("transcript-root");
+
+    expect(document.activeElement).toBe(document.body);
+    expect(document.getSelection()?.isCollapsed).toBe(true);
+    expect(runShortcutHandler("app.select-all", { source: "menu" })).toBe(true);
+
+    expect(document.activeElement).toBe(root);
+    expectExactVisibleTranscriptSelection(root);
+  });
+
+  it("selects the transcript when the empty chat surface owns focus", () => {
+    const { getByTestId } = render(<TranscriptSelectionHarness />);
+    const chatRoot = getByTestId("chat-root");
+    const transcriptRoot = getByTestId("transcript-root");
+    chatRoot.focus();
+
+    expect(runSelectAllCommand()).toBe(true);
+
+    expect(document.activeElement).toBe(transcriptRoot);
+    expectExactVisibleTranscriptSelection(transcriptRoot);
+  });
+
+  it("creates the same full selection from a real primary-A keydown", () => {
+    const { getByTestId } = render(<TranscriptSelectionHarness />);
+    const chatRoot = getByTestId("chat-root");
+    const transcriptRoot = getByTestId("transcript-root");
+    chatRoot.focus();
+    const event = new KeyboardEvent("keydown", {
+      key: "a",
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    chatRoot.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(transcriptRoot);
+    expectExactVisibleTranscriptSelection(transcriptRoot);
+    expectSemanticTranscriptCopy();
+  });
+
+  it("copies the complete semantic transcript after an idle native-menu select all", () => {
+    render(<TranscriptSelectionHarness />);
+    expect(runShortcutHandler("app.select-all", { source: "menu" })).toBe(true);
+
+    expectSemanticTranscriptCopy();
+  });
+
+  it("does not let a hidden kept-mounted chat claim the native menu command", () => {
+    const { getByTestId } = render(
+      <div hidden>
+        <TranscriptSelectionHarness />
+      </div>,
+    );
+
+    expect(runSelectAllCommand()).toBe(false);
+    expect(document.activeElement).toBe(document.body);
+    expect(document.getSelection()?.toString()).not.toContain("Assistant response");
+    expect(getByTestId("transcript-root").closest("[hidden]")).not.toBeNull();
+  });
+
+  it("requires an explicit owner when more than one chat transcript is rendered", () => {
+    const { getByTestId } = render(<MultipleTranscriptHarness />);
+    const firstChat = getByTestId("chat-root-first");
+    const firstTranscript = getByTestId("transcript-root-first");
+
+    expect(runSelectAllCommand()).toBe(false);
+    expect(document.getSelection()?.rangeCount).toBe(0);
+
+    firstChat.focus();
+    expect(runSelectAllCommand()).toBe(true);
+
+    expect(document.activeElement).toBe(firstTranscript);
+    expectExactVisibleTranscriptSelection(firstTranscript);
+    expect(document.getSelection()?.toString()).not.toContain("Second assistant response");
+  });
+
+  it("leaves select all with the focused composer text entry", () => {
+    const { getByTestId } = render(<TranscriptSelectionHarness />);
+    const input = getByTestId("composer-input") as HTMLInputElement;
+    input.focus();
+    input.setSelectionRange(3, 3);
+
+    expect(runShortcutHandler("app.select-all", { source: "menu" })).toBe(true);
+
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(input.value.length);
+    expect(document.getSelection()?.toString()).not.toContain("Assistant response");
+  });
+
+  it.each(["terminal", "browser"])(
+    "does not take selection ownership from the focused %s surface",
+    (zone) => {
+      const { getByTestId } = render(<TranscriptSelectionHarness />);
+      const foreignSurface = getByTestId(`${zone}-surface`);
+      foreignSurface.focus();
+
+      expect(runShortcutHandler("app.select-all", { source: "menu" })).toBe(false);
+      expect(document.activeElement).toBe(foreignSurface);
+      expect(document.getSelection()?.toString()).not.toContain("Assistant response");
+    },
+  );
+});
+
+function expectExactVisibleTranscriptSelection(root: HTMLElement) {
+  const selection = document.getSelection();
+  expect(selection).not.toBeNull();
+  expect(selection?.isCollapsed).toBe(false);
+  expect(selection?.toString()).toContain("User prompt");
+  expect(selection?.toString()).toContain("Worked for 5s");
+  expect(selection?.toString()).toContain("Assistant response");
+  expect(selection?.rangeCount).toBe(1);
+
+  const range = selection!.getRangeAt(0);
+  expect(range.startContainer).toBe(root);
+  expect(range.startOffset).toBe(0);
+  expect(range.endContainer).toBe(root);
+  expect(range.endOffset).toBe(root.childNodes.length);
+}
+
+function expectSemanticTranscriptCopy() {
+  const clipboardData = { setData: vi.fn() };
+  const copyEvent = new Event("copy", { cancelable: true });
+  Object.defineProperty(copyEvent, "clipboardData", { value: clipboardData });
+  window.dispatchEvent(copyEvent);
+
+  expect(copyEvent.defaultPrevented).toBe(true);
+  expect(clipboardData.setData).toHaveBeenCalledWith(
+    "text/plain",
+    "User prompt\n\nWorked for 5s\n\nAssistant response",
+  );
+}
+
+function TranscriptSelectionHarness() {
+  const rootRef = useRef<HTMLDivElement>(null);
+  useChatTranscriptSelection({
+    rootRef,
+    getCopyText: () => "User prompt\n\nWorked for 5s\n\nAssistant response",
+  });
+  useShortcutHandler("app.select-all", () => runSelectAllCommand());
+
+  return (
+    <>
+      <div data-testid="chat-root" data-focus-zone="chat" tabIndex={-1}>
+        <div
+          ref={rootRef}
+          data-testid="transcript-root"
+          data-chat-transcript-root="true"
+          className="select-text"
+          tabIndex={-1}
+        >
+          <article data-chat-user-message>User prompt</article>
+          <div data-transcript-status>Worked for 5s</div>
+          <article data-assistant-prose>Assistant response</article>
+        </div>
+        <input
+          data-testid="composer-input"
+          data-chat-composer-editor
+          defaultValue="Draft prompt"
+        />
+      </div>
+      <div data-testid="terminal-surface" data-focus-zone="terminal" tabIndex={0} />
+      <div data-testid="browser-surface" data-focus-zone="browser" tabIndex={0} />
+    </>
+  );
+}
+
+function MultipleTranscriptHarness() {
+  const firstRootRef = useRef<HTMLDivElement>(null);
+  const secondRootRef = useRef<HTMLDivElement>(null);
+  useChatTranscriptSelection({
+    rootRef: firstRootRef,
+    getCopyText: () => "User prompt\n\nWorked for 5s\n\nAssistant response",
+  });
+  useChatTranscriptSelection({
+    rootRef: secondRootRef,
+    getCopyText: () => "Second user prompt\n\nSecond assistant response",
+  });
+
+  return (
+    <>
+      <div data-testid="chat-root-first" data-focus-zone="chat" tabIndex={-1}>
+        <div
+          ref={firstRootRef}
+          data-testid="transcript-root-first"
+          data-chat-transcript-root="true"
+          className="select-text"
+          tabIndex={-1}
+        >
+          <article>User prompt</article>
+          <div>Worked for 5s</div>
+          <article>Assistant response</article>
+        </div>
+      </div>
+      <div data-testid="chat-root-second" data-focus-zone="chat" tabIndex={-1}>
+        <div
+          ref={secondRootRef}
+          data-testid="transcript-root-second"
+          data-chat-transcript-root="true"
+          className="select-text"
+          tabIndex={-1}
+        >
+          <article>Second user prompt</article>
+          <article>Second assistant response</article>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-selection-handlers.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-selection-handlers.ts
@@ -5,12 +5,14 @@ import {
   resolvePointerOwnership,
   resolvePrimaryAAction,
   resolveSelectionChangeAction,
+  type TranscriptPrimaryAAction,
   type TranscriptSelectionClampEdge,
   type TranscriptTargetFacts,
 } from "#product/domain/chats/transcript/transcript-selection";
 import type {
   SelectedResponseSelection,
 } from "#product/domain/chats/transcript/selected-response-context";
+import { SELECT_ALL_COMMAND_EVENT } from "#product/lib/infra/dom/dom-select-all";
 
 interface TranscriptSelectionListenerTargets {
   windowTarget: Pick<Window, "addEventListener" | "removeEventListener">;
@@ -21,6 +23,7 @@ interface TranscriptSelectionListenerHandlers {
   pointerdown: (event: PointerEvent) => void;
   pointerup: () => void;
   keydown: (event: KeyboardEvent) => void;
+  selectall: (event: Event) => void;
   copy: (event: ClipboardEvent) => void;
   selectionchange: () => void;
   scroll: () => void;
@@ -42,6 +45,10 @@ interface ChatTranscriptSelectionHandlerArgs {
     target: EventTarget | null,
     root: HTMLElement | null,
   ) => TranscriptTargetFacts;
+  isSelectAllCommandOwner: (
+    target: EventTarget | null,
+    root: HTMLElement | null,
+  ) => boolean;
   focusRoot: (root: HTMLElement) => void;
   setFullSelectionMarker: (root: HTMLElement) => void;
   isFullSelectionMarker: (selection: Selection, root: HTMLElement) => boolean;
@@ -75,6 +82,7 @@ export function attachChatTranscriptSelectionListeners(
   targets.windowTarget.addEventListener("pointerup", handlers.pointerup, { capture: true });
   targets.windowTarget.addEventListener("pointercancel", handlers.pointerup, { capture: true });
   targets.windowTarget.addEventListener("keydown", handlers.keydown, { capture: true });
+  targets.windowTarget.addEventListener(SELECT_ALL_COMMAND_EVENT, handlers.selectall);
   targets.windowTarget.addEventListener("copy", handlers.copy, { capture: true });
   targets.windowTarget.addEventListener("scroll", handlers.scroll, { capture: true });
   targets.documentTarget.addEventListener("selectionchange", handlers.selectionchange);
@@ -84,6 +92,7 @@ export function attachChatTranscriptSelectionListeners(
     targets.windowTarget.removeEventListener("pointerup", handlers.pointerup, { capture: true });
     targets.windowTarget.removeEventListener("pointercancel", handlers.pointerup, { capture: true });
     targets.windowTarget.removeEventListener("keydown", handlers.keydown, { capture: true });
+    targets.windowTarget.removeEventListener(SELECT_ALL_COMMAND_EVENT, handlers.selectall);
     targets.windowTarget.removeEventListener("copy", handlers.copy, { capture: true });
     targets.windowTarget.removeEventListener("scroll", handlers.scroll, { capture: true });
     targets.documentTarget.removeEventListener("selectionchange", handlers.selectionchange);
@@ -99,6 +108,7 @@ export function createChatTranscriptSelectionHandlers({
   getActiveElement,
   getSelection,
   getTargetFactsForEvent,
+  isSelectAllCommandOwner,
   focusRoot,
   setFullSelectionMarker,
   isFullSelectionMarker,
@@ -162,6 +172,31 @@ export function createChatTranscriptSelectionHandlers({
     publishSelectedResponse();
   };
 
+  const applyPrimaryAAction = (
+    action: TranscriptPrimaryAAction,
+    event: Pick<Event, "preventDefault">,
+  ) => {
+    if (action === "ignore") {
+      return;
+    }
+    if (action === "clear-owned") {
+      clearSelectionState();
+      return;
+    }
+
+    const root = rootRef.current;
+    if (!root) {
+      clearSelectionState();
+      return;
+    }
+
+    event.preventDefault();
+    focusRoot(root);
+    setFullSelectionMarker(root);
+    transcriptOwnedRef.current = true;
+    allTranscriptSelectedRef.current = true;
+  };
+
   const keydown = (event: KeyboardEvent) => {
     if (hasSelectedResponse() && event.key === "Escape") {
       event.preventDefault();
@@ -177,30 +212,41 @@ export function createChatTranscriptSelectionHandlers({
       return;
     }
     const root = rootRef.current;
+    const activeElement = getActiveElement();
+    const isSelectAll = isPrimarySelectAllEvent(event, isApplePlatform());
+    const commandOwnerActive = isSelectAll
+      && (
+        isSelectAllCommandOwner(event.target, root)
+        || isSelectAllCommandOwner(activeElement, root)
+      );
     const action = resolvePrimaryAAction({
       owned: transcriptOwnedRef.current,
-      isSelectAll: isPrimarySelectAllEvent(event, isApplePlatform()),
+      commandOwnerActive,
+      isSelectAll,
       defaultPrevented: event.defaultPrevented,
       eventTarget: getTargetFactsForEvent(event.target, root),
-      activeTarget: getTargetFactsForEvent(getActiveElement(), root),
+      activeTarget: getTargetFactsForEvent(activeElement, root),
     });
+    applyPrimaryAAction(action, event);
+  };
 
-    if (action === "ignore") {
-      return;
-    }
-    if (action === "clear-owned") {
-      clearSelectionState();
-      return;
-    }
-    if (!root) {
-      clearSelectionState();
-      return;
-    }
-
-    event.preventDefault();
-    setFullSelectionMarker(root);
-    transcriptOwnedRef.current = true;
-    allTranscriptSelectedRef.current = true;
+  const selectall = (event: Event) => {
+    const root = rootRef.current;
+    const activeElement = getActiveElement();
+    const activeTarget = getTargetFactsForEvent(activeElement, root);
+    const commandOwnerActive = isSelectAllCommandOwner(activeElement, root);
+    const action = resolvePrimaryAAction({
+      // Native macOS menu accelerators do not emit a WebView keydown. The
+      // active chat surface is therefore a separate command-ownership signal
+      // from an existing native text selection.
+      owned: transcriptOwnedRef.current,
+      commandOwnerActive,
+      isSelectAll: true,
+      defaultPrevented: event.defaultPrevented,
+      eventTarget: getTargetFactsForEvent(event.target, root),
+      activeTarget,
+    });
+    applyPrimaryAAction(action, event);
   };
 
   const selectionchange = () => {
@@ -287,6 +333,7 @@ export function createChatTranscriptSelectionHandlers({
     pointerdown,
     pointerup,
     keydown,
+    selectall,
     copy,
     selectionchange,
     scroll,

--- a/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-selection.test.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-selection.test.ts
@@ -75,6 +75,7 @@ describe("attachChatTranscriptSelectionListeners", () => {
       pointerdown: vi.fn(),
       pointerup: vi.fn(),
       keydown: vi.fn(),
+      selectall: vi.fn(),
       copy: vi.fn(),
       selectionchange: vi.fn(),
       scroll: vi.fn(),
@@ -85,6 +86,7 @@ describe("attachChatTranscriptSelectionListeners", () => {
       { type: "pointerup", options: { capture: true } },
       { type: "pointercancel", options: { capture: true } },
       { type: "keydown", options: { capture: true } },
+      { type: "proliferate:select-all", options: undefined },
       { type: "copy", options: { capture: true } },
       { type: "scroll", options: { capture: true } },
     ]);
@@ -99,6 +101,7 @@ describe("attachChatTranscriptSelectionListeners", () => {
       { type: "pointerup", options: { capture: true } },
       { type: "pointercancel", options: { capture: true } },
       { type: "keydown", options: { capture: true } },
+      { type: "proliferate:select-all", options: undefined },
       { type: "copy", options: { capture: true } },
       { type: "scroll", options: { capture: true } },
     ]);
@@ -125,6 +128,7 @@ describe("createChatTranscriptSelectionHandlers", () => {
       getSelection: () => selection,
       getTargetFactsForEvent: (target) =>
         target === transcriptTarget ? facts({ insideRoot: true }) : facts(),
+      isSelectAllCommandOwner: () => false,
       focusRoot: (targetRoot) => targetRoot.focus(),
       setFullSelectionMarker: () => {
         markerSet = true;
@@ -179,6 +183,7 @@ describe("createChatTranscriptSelectionHandlers", () => {
         if (target === textEntryTarget) return facts({ insideRoot: true, textEntry: true });
         return facts();
       },
+      isSelectAllCommandOwner: () => false,
       focusRoot: (targetRoot) => targetRoot.focus(),
       setFullSelectionMarker: () => {
         markerSet = true;
@@ -232,6 +237,7 @@ describe("createChatTranscriptSelectionHandlers", () => {
       getSelection: () => selection,
       getTargetFactsForEvent: (target) =>
         target === transcriptTarget ? facts({ insideRoot: true }) : facts(),
+      isSelectAllCommandOwner: () => false,
       focusRoot: vi.fn(),
       setFullSelectionMarker: vi.fn(),
       isFullSelectionMarker: () => false,
@@ -295,6 +301,7 @@ describe("createChatTranscriptSelectionHandlers", () => {
         }
         return facts();
       },
+      isSelectAllCommandOwner: () => false,
       focusRoot: vi.fn(),
       setFullSelectionMarker: vi.fn(),
       isFullSelectionMarker: () => false,
@@ -351,6 +358,7 @@ describe("createChatTranscriptSelectionHandlers", () => {
       getActiveElement: () => root,
       getSelection: () => ({ rangeCount: 1 } as Selection),
       getTargetFactsForEvent: () => facts({ insideRoot: true }),
+      isSelectAllCommandOwner: () => false,
       focusRoot: vi.fn(),
       setFullSelectionMarker: vi.fn(),
       isFullSelectionMarker: () => false,
@@ -415,6 +423,7 @@ describe("createChatTranscriptSelectionHandlers", () => {
       getActiveElement: () => root,
       getSelection: () => selection,
       getTargetFactsForEvent: () => facts({ insideRoot: true }),
+      isSelectAllCommandOwner: () => false,
       focusRoot: vi.fn(),
       setFullSelectionMarker: vi.fn(),
       isFullSelectionMarker: () => false,

--- a/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-selection.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-selection.ts
@@ -22,6 +22,7 @@ import {
   getSelectedAssistantResponse,
   isSelectedResponseInViewport,
 } from "#product/hooks/chat/ui/selected-response-selection";
+import { selectElementContents } from "#product/lib/infra/dom/dom-select-all";
 
 interface UseChatTranscriptSelectionArgs {
   rootRef: RefObject<HTMLElement | null>;
@@ -86,9 +87,12 @@ export function useChatTranscriptSelection({
       getActiveElement: () => document.activeElement,
       getSelection: () => document.getSelection(),
       getTargetFactsForEvent: getTargetFacts,
+      isSelectAllCommandOwner,
       focusRoot: (root) => root.focus({ preventScroll: true }),
-      setFullSelectionMarker: setCollapsedRootMarker,
-      isFullSelectionMarker: isCollapsedRootMarkerSelection,
+      setFullSelectionMarker: (root) => {
+        selectElementContents(root);
+      },
+      isFullSelectionMarker: isExactRootSelection,
       isExactRootSelection,
       nodeInsideRoot,
       getSelectionDirection,
@@ -140,10 +144,58 @@ function getTargetFacts(
     selectableInteractiveText: !!element.closest('a, [role="link"]'),
     textEntry: isTextEntryElement(element),
     terminalZone: !!element.closest('[data-focus-zone="terminal"]'),
+    browserZone: !!element.closest('[data-focus-zone="browser"]'),
     ignoredChrome: !!element.closest("[data-chat-transcript-ignore]"),
     nativeInteractive: isNativeInteractiveElement(element),
     ariaInteractive: isAriaInteractiveElement(element),
   };
+}
+
+function isSelectAllCommandOwner(
+  target: EventTarget | null,
+  root: HTMLElement | null,
+): boolean {
+  const element = targetToElement(target);
+  if (!root || !element || !isRenderedTranscriptRoot(root)) {
+    return false;
+  }
+
+  const chatRoot = root.closest<HTMLElement>('[data-focus-zone="chat"]');
+  if (!chatRoot) {
+    return false;
+  }
+
+  if (element === document.body || element === document.documentElement) {
+    const renderedRoots = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-chat-transcript-root="true"]'),
+    ).filter(isRenderedTranscriptRoot);
+    return renderedRoots.length === 1 && renderedRoots[0] === root;
+  }
+
+  return chatRoot.contains(element);
+}
+
+function isRenderedTranscriptRoot(root: HTMLElement): boolean {
+  if (!root.isConnected) {
+    return false;
+  }
+
+  let current: HTMLElement | null = root;
+  while (current) {
+    if (
+      current.hidden
+      || current.hasAttribute("inert")
+      || current.getAttribute("aria-hidden") === "true"
+    ) {
+      return false;
+    }
+    const style = window.getComputedStyle(current);
+    if (style.display === "none" || style.visibility === "hidden") {
+      return false;
+    }
+    current = current.parentElement;
+  }
+  return true;
 }
 
 function targetToElement(target: EventTarget | null): Element | null {
@@ -184,29 +236,6 @@ function isAriaInteractiveElement(element: Element): boolean {
     || role === "menuitem"
     || role === "option"
     || role === "tab";
-}
-
-function setCollapsedRootMarker(root: HTMLElement): void {
-  const selection = document.getSelection();
-  if (!selection) {
-    return;
-  }
-  selection.removeAllRanges();
-  const range = document.createRange();
-  range.selectNodeContents(root);
-  range.collapse(false);
-  selection.addRange(range);
-}
-
-function isCollapsedRootMarkerSelection(
-  selection: Selection,
-  root: HTMLElement,
-): boolean {
-  if (selection.rangeCount !== 1 || !selection.isCollapsed) {
-    return false;
-  }
-  const range = selection.getRangeAt(0);
-  return range.startContainer === root && range.endContainer === root;
 }
 
 function isExactRootSelection(

--- a/apps/packages/product-client/src/lib/domain/preferences/appearance-css-drift.test.ts
+++ b/apps/packages/product-client/src/lib/domain/preferences/appearance-css-drift.test.ts
@@ -582,15 +582,14 @@ describe("appearance scaling CSS defaults", () => {
     expect(bodyRule).toContain("line-height: var(--text-ui--line-height);");
   });
 
-  it("shares semantic caret and selection colors across text-entry renderers", () => {
+  it("shares semantic caret and selection colors across text-entry renderers while transcripts keep native selection paint", () => {
     expect(themeDeclarations["--color-text-caret"]).toBe("var(--color-foreground)");
     expect(themeDeclarations["--color-text-selection"]).toBe(
       "var(--color-highlight, var(--color-input))",
     );
     expect(productCss).toContain("caret-color: var(--color-text-caret);");
     expect(productCss).toContain("background-color: var(--color-text-selection);");
-    expect(productCss).toContain(".chat-selection-root ::selection");
-    expect(productCss).toContain("background-color: var(--color-text-selection);");
+    expect(productCss).not.toContain(".chat-selection-root ::selection");
   });
 
   it("keeps the spinner inline box stationary while its SVG owns motion", () => {

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -152,6 +152,17 @@ block opens the selected-response action menu. The transcript selection hook
 owns detection and dismissal; the menu owns only presentation and keyboard
 navigation.
 
+Transcript-wide selection uses the same native selection surface. When the
+active chat surface owns the command, primary Select All (`Cmd+A` on macOS,
+`Ctrl+A` elsewhere) must create a visible, non-collapsed range across every
+rendered transcript row whether the command arrives from a WebView keydown or
+the Desktop native Edit menu. It must not require an earlier pointer selection.
+Transcript prose keeps the WebView's native selection paint; the chat surface
+must not replace it with the text-entry/editor selection token.
+Composer text entries, terminal zones, and browser zones keep command ownership.
+Copying an exact transcript-root selection serializes the complete loaded
+semantic transcript so DOM virtualization cannot truncate the clipboard text.
+
 Rules:
 
 - Preserve native selection and copy behavior. Assistant prose may be selected


### PR DESCRIPTION
## Summary

- route native macOS Select All and keyboard Cmd+A to the active chat transcript without requiring a prior text selection
- create a visible exact-root range across user, status, metadata, and assistant rows in both full and virtual transcript renderers
- preserve composer, terminal, browser/right-panel, hidden-route, and multi-chat command ownership
- use the WebView's native transcript selection paint and preserve full semantic copy under virtualization

## Root cause

The macOS Edit-menu accelerator emitted the shared Select All command, but the transcript only handled WebView keydown events and required prior transcript ownership. Its production row-stack root also disabled selection, while a chat-scoped CSS override forced a very dark 12%-alpha highlight.

## Validation

- user-confirmed live native Desktop visual behavior in the isolated profile
- `pnpm --filter @proliferate/product-client exec vitest run src/domain/chats/transcript/transcript-selection.test.ts src/hooks/chat/ui/chat-transcript-selection.test.ts src/hooks/chat/ui/chat-transcript-select-all.test.tsx src/components/workspace/chat/transcript/FullTranscriptRowList.test.tsx src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx src/lib/domain/preferences/appearance-css-drift.test.ts` — 73 tests passed
- `pnpm --filter @proliferate/product-client typecheck`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_design_attribution.py`
- `python3 scripts/check_appearance_scaling.py`
- `python3 scripts/check_docs.py`
- three review rounds: behavior/ownership, regression/edge cases, and spec/test/scope

## Testing

Tier 1 integration and contract coverage added for native-menu dispatch, real primary-A keydown, no-prior-selection behavior, exact visible range, full semantic copy, hidden and multiple roots, and foreign focus zones.

## Observability

None. This changes local DOM command routing and selection paint; it adds no failure path, telemetry payload, or new user-content surface.
