### PR TITLE
perf(product): keep right-side separator drags smooth (PRO-223)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/cowork/CoworkWorkspaceShell.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/cowork/CoworkWorkspaceShell.test.tsx
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { cleanup, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CoworkWorkspaceShell } from "#product/components/workspace/cowork/CoworkWorkspaceShell";
@@ -50,8 +50,15 @@ vi.mock("#product/components/workspace/cowork/CoworkWorkspaceHeader", () => ({
   ),
 }));
 
+const resizeState = vi.hoisted(() => ({
+  options: [] as { reverse?: boolean; onResizeEnd?: () => void }[],
+}));
+
 vi.mock("#product/hooks/ui/layout/use-resize", () => ({
-  useResize: () => vi.fn(),
+  useResize: (options: { reverse?: boolean; onResizeEnd?: () => void }) => {
+    resizeState.options.push(options);
+    return vi.fn();
+  },
 }));
 
 vi.mock("#product/hooks/shortcuts/lifecycle/use-shortcut-handler", () => ({
@@ -83,7 +90,7 @@ vi.mock("#product/stores/preferences/workspace-ui-store", () => ({
 }));
 
 const coworkUiState = vi.hoisted(() => ({
-  artifactPanelOpenByWorkspaceId: {},
+  artifactPanelOpenByWorkspaceId: {} as Record<string, boolean>,
   setArtifactPanelOpen: vi.fn(),
 }));
 
@@ -119,6 +126,8 @@ afterEach(() => {
   vi.clearAllMocks();
   chromeState.transparent = false;
   productHostState.desktop = {};
+  coworkUiState.artifactPanelOpenByWorkspaceId = {};
+  resizeState.options.length = 0;
 });
 
 describe("CoworkWorkspaceShell", () => {
@@ -157,6 +166,30 @@ describe("CoworkWorkspaceShell", () => {
         showWorkspaceStatusPanels: false,
       }),
     );
+  });
+
+  it("drops the artifact pane width easing while the right separator drag is live", () => {
+    coworkUiState.artifactPanelOpenByWorkspaceId = { "workspace-cowork": true };
+    const { container } = render(
+      <CoworkWorkspaceShell
+        workspaceId="workspace-cowork"
+        workspacePath="/tmp/workspace-cowork"
+      />,
+    );
+
+    const pane = () => container.querySelector("[data-cowork-artifact-pane]");
+    expect(pane()?.className).toContain("transition-[width]");
+
+    // The left separator is labelled with aria-controls; the right one is not.
+    const rightSeparator = [...container.querySelectorAll('[role="separator"]')]
+      .find((element) => !element.hasAttribute("aria-controls"));
+    fireEvent.mouseDown(rightSeparator!);
+    expect(pane()?.className).toContain("transition-none");
+    expect(pane()?.className).not.toContain("transition-[width]");
+
+    const rightResizeOptions = resizeState.options.filter((options) => options.reverse).at(-1);
+    act(() => rightResizeOptions?.onResizeEnd?.());
+    expect(pane()?.className).toContain("transition-[width]");
   });
 
   it("never renders an update affordance in the top-left window chrome", () => {

--- a/apps/packages/product-client/src/components/workspace/cowork/CoworkWorkspaceShell.tsx
+++ b/apps/packages/product-client/src/components/workspace/cowork/CoworkWorkspaceShell.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, type MouseEvent } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { ChatView } from "#product/components/workspace/chat/ChatView";
 import { MainSidebar } from "#product/components/workspace/shell/sidebar/MainSidebar";
@@ -72,14 +72,20 @@ export function CoworkWorkspaceShell({
   const activeSlot = useSessionDirectoryStore((state) =>
     activeSessionId ? state.entriesById[activeSessionId] ?? null : null
   );
-  const onRightSeparatorDown = useResize({
+  const [rightPanelResizing, setRightPanelResizing] = useState(false);
+  const beginRightSeparatorDrag = useResize({
     direction: "horizontal",
     size: rightPanelWidth,
     onResize: setRightPanelWidth,
+    onResizeEnd: () => setRightPanelResizing(false),
     reverse: true,
     min: 280,
     max: 760,
   });
+  const onRightSeparatorDown = useCallback((event: MouseEvent) => {
+    setRightPanelResizing(true);
+    beginRightSeparatorDrag(event);
+  }, [beginRightSeparatorDrag]);
 
   const headerTitle = useMemo(() => {
     if (workspaceId && activeSessionId && activeSlot?.workspaceId === workspaceId && activeSlot.title?.trim()) {
@@ -203,8 +209,13 @@ export function CoworkWorkspaceShell({
             )}
 
             <div
-              className="shrink-0 overflow-hidden transition-[width] duration-panel ease-in-out"
+              className={`shrink-0 overflow-hidden ${
+                rightPanelResizing
+                  ? "transition-none"
+                  : "transition-[width] duration-panel ease-in-out"
+              }`}
               style={{ width: canShowArtifactPanel && rightPanelOpen ? rightPanelWidth : 0 }}
+              data-cowork-artifact-pane
             >
               <div className="h-full" style={{ minWidth: 320 }}>
                 {workspaceId ? <CoworkArtifactsPanel workspaceId={workspaceId} /> : null}

--- a/apps/packages/product-client/src/hooks/terminals/lifecycle/use-xterm-surface.test.ts
+++ b/apps/packages/product-client/src/hooks/terminals/lifecycle/use-xterm-surface.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { APPEARANCE_SIZE_IDS, READABLE_CODE_FONT_SCALES } from "#product/lib/domain/preferences/appearance";
 import { TERMINAL_LINE_HEIGHT } from "#product/lib/domain/terminals/terminal-grid";
 import {
+  createSettledResizeReporter,
   resolveXtermSurfaceTypography,
   XTERM_CURSOR_OPTIONS,
+  XTERM_RESIZE_REPORT_SETTLE_MS,
 } from "#product/hooks/terminals/lifecycle/use-xterm-surface";
 
 describe("xterm cursor contract", () => {
@@ -35,5 +37,50 @@ describe("resolveXtermSurfaceTypography", () => {
     const overrideFontSize = READABLE_CODE_FONT_SCALES.xxxlarge.monacoFontSize;
     expect(resolveXtermSurfaceTypography("default", { fontSize: overrideFontSize, lineHeight: 1.25 }))
       .toEqual({ fontSize: overrideFontSize, lineHeight: 1.25 });
+  });
+});
+
+describe("createSettledResizeReporter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reports the final size exactly once after a per-column drag storm settles", () => {
+    const report = vi.fn();
+    const reporter = createSettledResizeReporter(report);
+
+    // A separator drag emits one grid size per column change.
+    for (let cols = 120; cols >= 80; cols -= 1) {
+      reporter.observe({ cols, rows: 40 });
+      vi.advanceTimersByTime(30);
+    }
+    expect(report).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(XTERM_RESIZE_REPORT_SETTLE_MS);
+    expect(report).toHaveBeenCalledTimes(1);
+    expect(report).toHaveBeenCalledWith({ cols: 80, rows: 40 });
+  });
+
+  it("reports a lone resize after the settle delay", () => {
+    const report = vi.fn();
+    const reporter = createSettledResizeReporter(report);
+
+    reporter.observe({ cols: 100, rows: 30 });
+    vi.advanceTimersByTime(XTERM_RESIZE_REPORT_SETTLE_MS);
+    expect(report).toHaveBeenCalledWith({ cols: 100, rows: 30 });
+  });
+
+  it("cancel drops a pending report on dispose", () => {
+    const report = vi.fn();
+    const reporter = createSettledResizeReporter(report);
+
+    reporter.observe({ cols: 100, rows: 30 });
+    reporter.cancel();
+    vi.advanceTimersByTime(XTERM_RESIZE_REPORT_SETTLE_MS * 2);
+    expect(report).not.toHaveBeenCalled();
   });
 });

--- a/apps/packages/product-client/src/hooks/terminals/lifecycle/use-xterm-surface.ts
+++ b/apps/packages/product-client/src/hooks/terminals/lifecycle/use-xterm-surface.ts
@@ -30,6 +30,43 @@ export const XTERM_CURSOR_OPTIONS = {
   cursorWidth: 1,
 } as const;
 
+export const XTERM_RESIZE_REPORT_SETTLE_MS = 200;
+
+/**
+ * Coalesces the grid-size stream a live separator drag produces into one
+ * report per settled size. The surface itself refits on every container
+ * resize so columns track the pointer, but each report crosses to the
+ * runtime PTY (an HTTP resize call plus a SIGWINCH-driven redraw of whatever
+ * runs in the terminal) — streaming one per column change is what made
+ * right-panel drags heavy.
+ */
+export function createSettledResizeReporter(
+  report: (size: { cols: number; rows: number }) => void,
+  settleMs = XTERM_RESIZE_REPORT_SETTLE_MS,
+): {
+  observe: (size: { cols: number; rows: number }) => void;
+  cancel: () => void;
+} {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  return {
+    observe(size) {
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+      timer = setTimeout(() => {
+        timer = null;
+        report(size);
+      }, settleMs);
+    },
+    cancel() {
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+      timer = null;
+    },
+  };
+}
+
 export function resolveXtermSurfaceTypography(
   readableCodeFontSizeId: unknown,
   overrides: Pick<UseXtermSurfaceInput, "fontSize" | "lineHeight"> = {},
@@ -107,6 +144,7 @@ export function useXtermSurface({
     setIsReady(false);
     let cancelled = false;
     let resizeObserver: ResizeObserver | null = null;
+    let settledResizeReporter: ReturnType<typeof createSettledResizeReporter> | null = null;
     let unsubscribeTheme = () => {};
 
     void (async () => {
@@ -163,8 +201,11 @@ export function useXtermSurface({
         onDataRef.current?.(data);
       });
 
-      term.onResize((size) => {
+      settledResizeReporter = createSettledResizeReporter((size) => {
         onResizeRef.current?.(size);
+      });
+      term.onResize((size) => {
+        settledResizeReporter?.observe(size);
       });
 
       resizeObserver = new ResizeObserver(() => {
@@ -177,6 +218,7 @@ export function useXtermSurface({
     return () => {
       cancelled = true;
       resizeObserver?.disconnect();
+      settledResizeReporter?.cancel();
       unsubscribeTheme();
       terminalRef.current?.dispose();
       terminalRef.current = null;

--- a/apps/packages/product-client/src/hooks/ui/layout/use-resize.test.ts
+++ b/apps/packages/product-client/src/hooks/ui/layout/use-resize.test.ts
@@ -163,4 +163,28 @@ describe("useResize", () => {
 
     expect(onResizeEnd).toHaveBeenCalledTimes(1);
   });
+
+  it("ends the gesture when the window loses focus mid-drag", () => {
+    const onResize = vi.fn();
+    const onResizeEnd = vi.fn();
+    const { result } = renderHook(() =>
+      useResize({ direction: "horizontal", size: 300, onResize, onResizeEnd }));
+
+    act(() => {
+      result.current(mouseDownEvent(0));
+    });
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+    });
+
+    // The blur tears the gesture down exactly like a mouseup: the cursor
+    // overlay is gone, the end callback fired, and later mouse traffic is
+    // ignored.
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
+    expect(document.querySelectorAll("div[style*='col-resize']").length).toBe(0);
+    act(() => {
+      document.dispatchEvent(new MouseEvent("mousemove", { clientX: 50 }));
+    });
+    expect(onResize).not.toHaveBeenCalled();
+  });
 });

--- a/apps/packages/product-client/src/hooks/ui/layout/use-resize.ts
+++ b/apps/packages/product-client/src/hooks/ui/layout/use-resize.ts
@@ -75,12 +75,17 @@ export function useResize({
         overlay.remove();
         document.removeEventListener("mousemove", handleMouseMove);
         document.removeEventListener("mouseup", handleMouseUp);
+        window.removeEventListener("blur", handleMouseUp);
         activeDragCleanupRef.current = null;
         onResizeEnd?.();
       };
 
       document.addEventListener("mousemove", handleMouseMove);
       document.addEventListener("mouseup", handleMouseUp);
+      // A window that loses focus mid-drag may never see the mouseup; the
+      // gesture ends here too so consumers' "resizing" state (and this
+      // overlay) cannot outlive the drag.
+      window.addEventListener("blur", handleMouseUp);
       activeDragCleanupRef.current = handleMouseUp;
     },
     [direction, size, resolveSize, onResize, onResizeEnd, reverse, min, max],


### PR DESCRIPTION
## Linear tickets

- [PRO-223 — Right sidebar movement is not smooth](https://linear.app/proliferate-team/issue/PRO-223/right-sidebar-movement-is-not-smooth)

## Summary

- drop the cowork artifact pane's width easing while its separator drag is live (the follow-up #1688 recorded and deferred; #1750 covered cowork's left sidebar only), restoring the eased motion on release so open/close and drag-collapse keep the panel animation
- report xterm grid changes to the runtime PTY once per settled size (trailing 200ms) instead of once per column change; the surface still refits every frame so columns track the pointer

## Root cause

The standard shell's right drag already had the full smooth-drag treatment from #1688 (session-state width, one durable commit per gesture, snapped geometry). Two right-side-only per-mousemove costs remained:

- **Cowork artifact pane easing.** The pane kept `transition-[width] duration-panel` during drags, so every mousemove retargeted a 240ms ease and the pane edge trailed the cursor. Default "New chat" threads use the cowork surface, so this is the right pane most drags actually hit.
- **Per-column PTY resize storm.** `use-xterm-surface` forwarded every `term.onResize` immediately; `use-terminal-viewport` turns each into a runtime HTTP resize call plus a stream resize → PTY SIGWINCH → redraw of whatever runs in the terminal. A 300px drag produced ~40 such round-trips. The new `createSettledResizeReporter` coalesces reporting to one per settled gesture and is cancelled on surface dispose.

## Verification

- Playwright webkit (the desktop WKWebView engine family) driving the running dev renderer with scripted 100-step separator drags, quiet session: right and left drags both hold 60fps — 0 frames >33ms, max 19-24ms; repeated with reversed measurement order to rule out ordering artifacts.
- Instrumented follow-up finding (not addressed here, affects both dividers equally): drags concurrent with a streaming agent turn hitch from 40-110ms streamed-update re-render tasks; tracked separately from this divider-level fix.
- `pnpm --filter @proliferate/product-client build` — clean.
- `pnpm exec tsc -p tsconfig.json --noEmit` in `apps/packages/product-client` — clean.
- Focused suites (cowork shell, xterm surface, right-panel facade, use-resize, main-screen state, shell motion, shell geometry, right rail): 8 files, 42 tests pass, including new coverage: the cowork pane drops easing while the drag is live and restores it on release; the settled reporter emits the final size exactly once per storm, emits lone resizes after the settle delay, and drops pending reports on cancel.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/specs/developing/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or private source data appear in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)