### PR TITLE
fix(product): disambiguate running vs done sessions in the transcript (PRO-119)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.test.tsx
@@ -10,12 +10,14 @@ import {
   type PromptOutboxEntry,
 } from "#product/domain/sessions/intents/session-intent-model";
 import { TranscriptPendingPromptRow } from "#product/components/workspace/chat/transcript/TranscriptPendingPromptRow";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 
 const NOW = "2026-05-20T17:00:00.000Z";
 
 describe("TranscriptPendingPromptRow", () => {
   afterEach(() => {
     cleanup();
+    useSessionSelectionStore.setState({ pendingWorkspaceEntry: null });
   });
 
   it("renders closed-session send failures as a compact line", () => {
@@ -178,7 +180,10 @@ describe("TranscriptPendingPromptRow", () => {
     expect(footer?.querySelector("[data-turn-assistant-footer-slot]")?.className).toContain("h-6");
   });
 
-  it("hosts the workspace-creation receipt in the frontier slot instead of the trailing status", () => {
+  it("hosts the receipt alone while the workspace creation is still in flight", () => {
+    useSessionSelectionStore.setState({
+      pendingWorkspaceEntry: { source: "worktree-created" } as never,
+    });
     const { container } = render(
       <TranscriptPendingPromptRow
         activeSessionId="session-1"
@@ -198,6 +203,30 @@ describe("TranscriptPendingPromptRow", () => {
     const receipt = screen.getByTestId("receipt");
     const frontier = container.querySelector("[data-pending-frontier]");
     expect(frontier?.contains(receipt)).toBe(true);
+  });
+
+  it("renders the working status below the settled receipt until the first turn lands (PRO-119)", () => {
+    // No pending workspace entry: the creation settled, the session exists,
+    // and the prompt is in flight — the frontier must not read as a dead
+    // session while the agent boots.
+    const { container } = render(
+      <TranscriptPendingPromptRow
+        activeSessionId="session-1"
+        rowIndex={0}
+        prompt={createOptimisticPendingPrompt("Make me a worktree", "prompt-1", NOW)}
+        outboxEntry={null}
+        optimisticTrailingStatus={<div data-testid="thinking">Thinking</div>}
+        outboxActions={{
+          retryPrompt: vi.fn(),
+          dismissPrompt: vi.fn(),
+        }}
+        workspaceReceipt={<div data-testid="receipt">Worktree created</div>}
+      />,
+    );
+
+    const frontier = container.querySelector("[data-pending-frontier]");
+    expect(frontier?.contains(screen.getByTestId("receipt"))).toBe(true);
+    expect(frontier?.contains(screen.getByTestId("thinking"))).toBe(true);
   });
 
   it("keeps the failed_before_dispatch line unaffected by the workspaceReceipt prop", () => {

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.tsx
@@ -21,6 +21,8 @@ import {
 import {
   resolvePendingPromptTrailingStatus,
 } from "#product/components/workspace/chat/transcript/TranscriptTurnChrome";
+import { isReceiptPendingEntry } from "#product/lib/domain/workspaces/creation/creation-receipt";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import type { PromptOutboxEntry } from "#product/domain/sessions/intents/session-intent-model";
 
 const OUTBOX_ACCEPTED_RUNNING_ECHO_GRACE_MS = 15_000;
@@ -48,14 +50,23 @@ export function TranscriptPendingPromptRow({
   /**
    * The workspace-creation receipt, when this row hosts it (no turn exists
    * yet to host it inline — see `hostsWorkspaceReceipt` on the row model).
-   * Takes precedence over both `optimisticTrailingStatus` and the outbox
-   * trailing status: while the workspace is still being created, "Thinking"/
-   * "Sending…" are false claims (no session exists yet to think or send),
-   * so the receipt — with its own spinner and failure states — replaces
-   * them in the frontier slot instead of rendering alongside/below them.
+   * While the workspace is still being created, "Thinking"/"Sending…" are
+   * false claims (no session exists yet to think or send), so the receipt —
+   * with its own spinner and failure states — owns the frontier slot alone.
+   * Once creation settles, the working status renders below the receipt: a
+   * session now exists and the prompt is genuinely in flight.
    */
   workspaceReceipt?: ReactNode;
 }) {
+  // While the creation itself is in flight the receipt (with its own spinner)
+  // is the only honest frontier content. Once the workspace materializes the
+  // receipt settles into a static "Worktree created" line, yet it keeps this
+  // frontier slot until the first turn lands — through worktree setup, agent
+  // boot, and prompt dispatch. Without the working status below it, that
+  // whole window reads as a dead session (PRO-119).
+  const creationInFlight = useSessionSelectionStore(
+    (state) => isReceiptPendingEntry(state.pendingWorkspaceEntry),
+  );
   if (outboxEntry?.deliveryState === "failed_before_dispatch") {
     return (
       <TurnShell isFirst={rowIndex === 0}>
@@ -67,9 +78,17 @@ export function TranscriptPendingPromptRow({
     );
   }
 
-  const trailingStatus = workspaceReceipt ?? (outboxEntry
+  const workingStatus = outboxEntry
     ? <OutboxPromptTrailingStatus entry={outboxEntry} />
-    : optimisticTrailingStatus);
+    : optimisticTrailingStatus;
+  const trailingStatus = workspaceReceipt
+    ? (
+      <>
+        {workspaceReceipt}
+        {!creationInFlight && workingStatus}
+      </>
+    )
+    : workingStatus;
   const outboxControls = outboxEntry
     ? renderOutboxPromptControls(outboxEntry, outboxActions)
     : null;

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnChrome.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnChrome.test.tsx
@@ -55,13 +55,16 @@ describe("TurnAssistantActionRow", () => {
     expect(container.innerHTML).toContain("opacity-0 group-hover/turn:opacity-100");
   });
 
-  it("hover-gates the copy button on the final message too (never permanent chrome)", () => {
+  it("keeps the copy button permanently visible on the final completed message", () => {
+    // PRO-119: the persistent copy button is the transcript's "session is
+    // done" marker — without it a finished session is indistinguishable from
+    // a quiet running one.
     const { container } = render(
-      <TurnAssistantActionRow content="reply" showCopyButton timestampLabel="5:02pm" />,
+      <TurnAssistantActionRow content="reply" showCopyButton timestampLabel="5:02pm" alwaysVisible />,
     );
     const copyWrapper = container.querySelector("[data-turn-assistant-footer-slot] > span");
-    expect(copyWrapper?.className).toContain("opacity-0 group-hover/turn:opacity-100");
-    expect(copyWrapper?.className).not.toMatch(/(?<!:)opacity-100/);
+    expect(copyWrapper?.className).toContain("opacity-100");
+    expect(copyWrapper?.className).not.toContain("opacity-0");
   });
 
   it("hover-gates the date like the copy button", () => {
@@ -71,6 +74,16 @@ describe("TurnAssistantActionRow", () => {
     // (The outer copy-button wrapper span also has "5:02pm" as its
     // textContent since it contains the date span, so pick the innermost
     // match — the one with no further descendant spans.)
+    const timestamp = Array.from(container.querySelectorAll("span")).find(
+      (span) => span.textContent === "5:02pm" && span.querySelector("span") === null,
+    );
+    expect(timestamp?.className).toContain("opacity-0 group-hover/turn:opacity-100");
+  });
+
+  it("keeps the date hover-gated even when the copy button is permanent", () => {
+    const { container } = render(
+      <TurnAssistantActionRow content="reply" showCopyButton timestampLabel="5:02pm" alwaysVisible />,
+    );
     const timestamp = Array.from(container.querySelectorAll("span")).find(
       (span) => span.textContent === "5:02pm" && span.querySelector("span") === null,
     );

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnChrome.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnChrome.tsx
@@ -62,12 +62,22 @@ export function TurnAssistantActionRow({
   showCopyButton = false,
   reserveSlot = false,
   timestampLabel = null,
+  alwaysVisible = false,
   metMarker = null,
 }: {
   content: string | null;
   showCopyButton?: boolean;
   reserveSlot?: boolean;
   timestampLabel?: string | null;
+  /**
+   * When true the copy button is persistently visible (opacity-100) instead
+   * of hover-gated. Set only for the transcript's final completed AI message:
+   * the permanent button is the "session is done" marker that distinguishes a
+   * finished session from a quiet running one (PRO-119). Every earlier
+   * message keeps hover-to-reveal, and the timestamp stays hover-only on
+   * every message including the final one.
+   */
+  alwaysVisible?: boolean;
   /**
    * Inline "✓ Goal achieved in Xs" marker rendered between the copy button
    * and the timestamp — only on the final completed message when the active
@@ -80,12 +90,10 @@ export function TurnAssistantActionRow({
     return null;
   }
 
-  // Hover-to-reveal on EVERY message, including the final one — the copy
-  // button is never permanent chrome. (The goal-met marker below stays
-  // persistently visible; it reports state rather than offering an action.)
-  const visibilityClassName =
+  const hoverVisibilityClassName =
     "opacity-0 group-hover/turn:opacity-100 group-focus-within/turn:opacity-100";
-  const timestampVisibilityClassName = visibilityClassName;
+  const visibilityClassName = alwaysVisible ? "opacity-100" : hoverVisibilityClassName;
+  const timestampVisibilityClassName = hoverVisibilityClassName;
 
   return (
     // The footer sits in the same TURN_ITEM_GAP_CLASS flex column as the

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
@@ -322,6 +322,11 @@ export function TranscriptTurnRow({
           showCopyButton={assistantFooterMode === "copy"}
           reserveSlot={assistantFooterMode === "reserved"}
           timestampLabel={tailAssistantActionTime}
+          // The permanent copy button is the "session is done" marker
+          // (PRO-119): only the transcript's final completed message carries
+          // it, and it yields back to hover-only the moment a newer turn
+          // takes the frontier.
+          alwaysVisible={isFinalCompletedTurn && isLatestTurn}
           metMarker={metMarker}
         />
       </div>


### PR DESCRIPTION
## Summary

- Restore the persistently visible copy button on the transcript's final completed message — the "session is done" marker. It yields back to hover-only the moment a newer turn takes the frontier; the timestamp stays hover-gated on every message. This reverses a deliberate #1529 retune decision ("copy is never permanent chrome") and repins the `TurnAssistantActionRow` visibility test to the new contract — flagging per the constitution; PRO-119 was filed against exactly this gap.
- Render the working status below the workspace-creation receipt once creation settles. Previously a pending prompt row hosting the receipt suppressed "Thinking" for the entire worktree-setup → agent-boot → dispatch window (~60s observed locally), so a launching session read as dead. The receipt still owns the frontier alone while creation is genuinely in flight.

Fixes PRO-119.

## Testing

- Unit (Tier 1): `pnpm vitest run src/components/workspace/chat/transcript` in `apps/packages/product-client` — 177 passing, including new pins for the permanent-copy contract and the receipt/working-status split.
- Manual (Tier 3): drove a local pro-119 profile stack via CDP. Verified: multi-turn done session shows the resting copy icon only under the last message; the icon disappears while a follow-up turn streams and returns on completion; "Thinking" appears within ~1s of send on the in-session path.
- Typecheck: `tsc --noEmit` clean in product-client and desktop; appearance-scaling and design-attribution guards pass.

## Observability

- none

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- Live screenshots during verification confirmed both frontier signals; the new-worktree launch stacking is additionally pinned by `TranscriptPendingPromptRow` unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)