### PR TITLE
fix(product): point user-facing docs links at the published docs site

### DIFF
--- a/apps/packages/product-client/src/components/settings/shared/RunCommandHelp.tsx
+++ b/apps/packages/product-client/src/components/settings/shared/RunCommandHelp.tsx
@@ -1,14 +1,12 @@
 import { Button } from "#product/primitives/Button";
 import { ExternalLink } from "#product/primitives/icons/core";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
+import { COMMAND_ENVIRONMENT_DOCS_URL } from "#product/config/capabilities";
 
 interface RunCommandHelpProps {
   scope: string;
   className?: string;
 }
-
-const COMMAND_ENVIRONMENT_DOCS_URL =
-  "https://github.com/proliferate-ai/proliferate/blob/main/specs/anyharness/workspace-command-environment.md";
 
 export function RunCommandHelp({
   scope,

--- a/apps/packages/product-client/src/config/capabilities.test.ts
+++ b/apps/packages/product-client/src/config/capabilities.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import * as capabilities from "#product/config/capabilities";
+
+// User-facing docs links must land on the published docs site. GitHub blob
+// paths break silently when repo files move and drop the user into source
+// code instead of documentation (PRO-135).
+describe("product docs links", () => {
+  const docsUrlEntries = Object.entries(capabilities).filter(([name]) =>
+    name.endsWith("DOCS_URL"),
+  );
+
+  it("covers every docs link this module exports", () => {
+    expect(docsUrlEntries.map(([name]) => name).sort()).toEqual([
+      "ANYHARNESS_UPDATE_DOCS_URL",
+      "CLOUD_SETUP_DOCS_URL",
+      "COMMAND_ENVIRONMENT_DOCS_URL",
+      "PROLIFERATE_DOCS_URL",
+    ]);
+  });
+
+  it("points every docs link at the published docs site, never at repository paths", () => {
+    for (const [name, url] of docsUrlEntries) {
+      expect(url, name).toMatch(/^https:\/\/proliferate\.com\/docs(\/|$)/);
+    }
+  });
+
+  it("maps each surface to its published page", () => {
+    // Shared by the Cloud settings panes, whose operator problems span the
+    // whole self-hosting section (deploy, authentication, add-ons).
+    expect(capabilities.CLOUD_SETUP_DOCS_URL).toBe(
+      "https://proliferate.com/docs/deployment",
+    );
+    // RunCommandHelp under Settings → Repo → Actions; the page documents the
+    // setup script, the run command, and the environment both execute in.
+    expect(capabilities.COMMAND_ENVIRONMENT_DOCS_URL).toBe(
+      "https://proliferate.com/docs/product/workspaces/setup-action-scripts",
+    );
+    // Deliberately the docs root; see the constant's comment.
+    expect(capabilities.ANYHARNESS_UPDATE_DOCS_URL).toBe(
+      "https://proliferate.com/docs",
+    );
+  });
+});

--- a/apps/packages/product-client/src/config/capabilities.ts
+++ b/apps/packages/product-client/src/config/capabilities.ts
@@ -3,18 +3,31 @@ export const OFFICIAL_HOSTED_API_ORIGINS = [
   "https://api.proliferate.com",
 ] as const;
 
-export const CLOUD_SETUP_DOCS_URL =
-  "https://github.com/proliferate-ai/proliferate/blob/main/guides/deploying/self-hosted-deploy.md";
+/**
+ * Operator-facing self-hosting docs. The Cloud settings panes share this one
+ * link across every operator-repairable state (unreachable control plane,
+ * missing GitHub OAuth, cloud compute not configured), so it points at the
+ * deployment section root rather than any single add-on page.
+ */
+export const CLOUD_SETUP_DOCS_URL = "https://proliferate.com/docs/deployment";
 
 export const PROLIFERATE_DOCS_URL = "https://proliferate.com/docs";
 
 /**
  * Where a user goes when a target's AnyHarness is too old for the model they
- * picked. The docs root, deliberately: this repo publishes no per-page docs
- * routes, and a link to a section that does not exist is worse than a link to
- * one the user has to search.
+ * picked. The docs root, deliberately: no published page covers updating a
+ * target's runtime for both hosted and self-hosted deployments, and a link to
+ * a page about the wrong deployment is worse than one the user has to search
+ * from.
  */
 export const ANYHARNESS_UPDATE_DOCS_URL = PROLIFERATE_DOCS_URL;
+
+/**
+ * The published page for the repo setup script and run command, including the
+ * environment both execute in.
+ */
+export const COMMAND_ENVIRONMENT_DOCS_URL =
+  "https://proliferate.com/docs/product/workspaces/setup-action-scripts";
 
 export const PROLIFERATE_PRICING_URL = "https://proliferate.com/pricing";
 


### PR DESCRIPTION
## Summary

- Fixes PRO-135: user-facing docs links still pointed at GitHub blob paths from before the docs site launched, dropping users into repository source and breaking silently whenever the underlying file moves.
- `RunCommandHelp` (Settings → Repo → Actions) linked to `github.com/.../specs/anyharness/workspace-command-environment.md`; it now opens `https://proliferate.com/docs/product/workspaces/setup-action-scripts`, the published page for the setup script, the run command, and the environment both execute in.
- `CLOUD_SETUP_DOCS_URL` (shared by `CloudUnavailablePane`, `CloudNotConfiguredPane`, and `CloudAuthUnavailablePane`) linked to `github.com/.../guides/deploying/self-hosted-deploy.md`; it now opens `https://proliferate.com/docs/deployment`, the self-hosting section root. The three panes cover different operator problems (unreachable control plane, missing GitHub OAuth, cloud compute not configured), so the shared "Open setup docs" link lands on the section that covers all of them rather than any single add-on page.
- The command-environment URL moves into `config/capabilities.ts` so every external product link lives in one module.
- `ANYHARNESS_UPDATE_DOCS_URL` deliberately stays at the docs root; its comment is updated because the old rationale ("this repo publishes no per-page docs routes") is no longer true. No published page covers updating a target's runtime for both hosted and self-hosted deployments, so the root remains the honest target.

Out-of-scope observation for follow-up: `https://proliferate.com/pricing` returns 404 today, and it is both the client fallback (`PROLIFERATE_PRICING_URL`) and the server-provided `pricing.url` (`server/proliferate/constants/deployment.py` `VENDOR_PRICING_URL`). Not a docs link, and picking its correct destination is a product decision, so it is not changed here.

## Testing

- Tier 1 (unit): new `src/config/capabilities.test.ts` pins each docs-link mapping, enumerates every `*_DOCS_URL` export, and rejects any future docs link that does not land on `https://proliferate.com/docs`.
- `pnpm --filter @proliferate/product-client exec vitest run src/config src/components/settings` — 31 files, 230 tests passed.
- `pnpm --filter @proliferate/product-client typecheck` — passed.
- Live destination checks: `curl` returns 200 for `https://proliferate.com/docs/deployment` and `https://proliferate.com/docs/product/workspaces/setup-action-scripts`; both pages verified by content (deployment section, "Setup & action scripts").

## Observability

- none

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- `pnpm --filter @proliferate/product-client exec vitest run src/config/capabilities.test.ts` — 3 tests passed.
- `grep -rn "github.com/proliferate-ai/proliferate/blob" apps/` — no remaining user-facing blob links (only a playground markdown fixture linking the repo root, which is demo content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
