### PR TITLE
fix(product): scale the empty-chat ready title to the pane title role (PRO-113)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/surface/ChatReadyHero.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/surface/ChatReadyHero.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { CHAT_PRE_MESSAGE_LABELS } from "#product/copy/chat/chat-copy";
+import { ChatReadyHero } from "./ChatReadyHero";
+
+afterEach(cleanup);
+
+describe("ChatReadyHero", () => {
+  it("renders the ready title at the pane-level title role, not the display hero role", () => {
+    render(<ChatReadyHero />);
+
+    const title = screen.getByRole("heading", {
+      name: CHAT_PRE_MESSAGE_LABELS.readyTitle,
+    });
+    expect(title.className).toContain("text-title");
+    expect(title.className).not.toContain("text-hero");
+  });
+
+  it("keeps the title centered without vestigial top offset", () => {
+    render(<ChatReadyHero />);
+
+    const title = screen.getByRole("heading", {
+      name: CHAT_PRE_MESSAGE_LABELS.readyTitle,
+    });
+    expect(title.className).not.toContain("mt-");
+  });
+
+  it("carries no tracking override on top of the title role", () => {
+    render(<ChatReadyHero />);
+
+    const title = screen.getByRole("heading", {
+      name: CHAT_PRE_MESSAGE_LABELS.readyTitle,
+    });
+    expect(title.className).not.toContain("tracking-");
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/surface/ChatReadyHero.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/surface/ChatReadyHero.tsx
@@ -3,12 +3,15 @@ import { CHAT_PRE_MESSAGE_LABELS } from "#product/copy/chat/chat-copy";
 /**
  * Hero variant shown when a session is hydrated but has no turns yet. Loading
  * and agent-thinking affordances stay in their own surfaces, so this component
- * intentionally remains visually quiet.
+ * intentionally remains visually quiet. It renders inside workspace chrome
+ * that already carries the pane hierarchy, so it uses the same pane-level
+ * title treatment as ChatSurfaceCard — the `hero` display role stays reserved
+ * for full-page surfaces.
  */
 export function ChatReadyHero() {
   return (
     <div className="flex flex-col items-center text-center">
-      <h2 className="mt-6 text-hero font-semibold tracking-[-0.02em] text-foreground">
+      <h2 className="text-title font-semibold text-foreground">
         {CHAT_PRE_MESSAGE_LABELS.readyTitle}
       </h2>
     </div>


### PR DESCRIPTION
## Summary

- Fixes PRO-113: the "Ready when you are" text shown on top of the chat input in a new (empty) chat rendered at the `hero` display role — 26px semibold, the largest type in the app — inside a pane that already carries workspace chrome, so it dominated the view and broke the pane's type hierarchy.
- Root cause: `ChatReadyHero` began as a brand lockup (48px resolving brand mark + 24px title + muted context line). The mark and context line were later removed, but the title kept the lockup's display sizing (swept onto `text-hero` during the closed-ramp migration as the nearest rung to the old `text-2xl`) and kept the mark's `mt-6` spacing, leaving one oversized line floating below optical center.
- Fix: retune the title to the pane-level title role (`text-title font-semibold text-foreground`, 19px) with no per-call-site tracking override, and drop the vestigial `mt-6`. The `hero` role stays reserved for full-page surfaces (home, auth), which are untouched.

## Testing

- Tier 1 (`specs/TESTING.md`): new `ChatReadyHero.test.tsx` pins the title to the pane title role (asserts `text-title`, rejects `text-hero`), rejects vestigial top-margin offset, and rejects any tracking override class. Negative control run: reverting the component change makes both tests fail.
- `pnpm vitest run src/components/workspace/chat/surface` — 8/8 pass.
- `pnpm run typecheck` (product-client, builds dependent SDK/design dists) — pass.
- `python3 scripts/check_appearance_scaling.py`, `check_frontend_boundaries.py`, `report_frontend_structure.py --strict` — all pass.
- Visual browser check not run: the bugathon shared visual slot (`/tmp/proliferate-bugathon-browser.lock`) was held by another worker for the whole run.

## Observability

- none

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- `pnpm vitest run src/components/workspace/chat/surface` → 8 passed
- Negative control: `git show HEAD:...ChatReadyHero.tsx > ChatReadyHero.tsx && vitest` → 2 failed, then restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)
