### PR TITLE
fix(product): keep the hover-pinned todo checklist stable through step advances (PRO-85)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/input/TodoProgressPill.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/TodoProgressPill.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PlanEntry } from "@anyharness/sdk";
 import { TodoProgressPill } from "./TodoProgressPill";
@@ -38,6 +38,14 @@ function plan(completedCount: number, total: number): { entries: PlanEntry[] } {
 
 function pill() {
   return screen.queryByText(/Step \d+\/\d+/);
+}
+
+function pillSurface() {
+  return document.querySelector<HTMLElement>("[data-todo-progress-pill]");
+}
+
+function checklistCard() {
+  return document.querySelector<HTMLElement>("[data-todo-progress-card]");
 }
 
 beforeEach(() => {
@@ -99,6 +107,56 @@ describe("TodoProgressPill", () => {
     mocks.tracker = plan(5, 9);
     rerender(<TodoProgressPill />);
     expect(pill()).toBeNull();
+  });
+
+  it("keeps the hover-pinned checklist mounted, in place, through step advances", () => {
+    mocks.tracker = plan(1, 5);
+    const { rerender } = render(<TodoProgressPill />);
+    mocks.tracker = plan(2, 5);
+    rerender(<TodoProgressPill />);
+    expect(pill()).not.toBeNull();
+
+    fireEvent.mouseEnter(pillSurface()!);
+    const cardBefore = checklistCard();
+    expect(cardBefore).not.toBeNull();
+    expect(cardBefore!.querySelectorAll("[data-loading-spinner]")).toHaveLength(1);
+
+    // A step advancing while the pointer is on the pill/checklist must not
+    // unpin: the card stays the same mounted node (so the in-progress
+    // spinner's rotation never restarts) and its rows update in place.
+    mocks.tracker = plan(3, 5);
+    rerender(<TodoProgressPill />);
+    const cardAfter = checklistCard();
+    expect(cardAfter).not.toBeNull();
+    expect(cardAfter!.isSameNode(cardBefore)).toBe(true);
+    expect(cardAfter!.querySelectorAll("[data-loading-spinner]")).toHaveLength(1);
+
+    // No fade/hide may be scheduled by the hovered advance: well past the
+    // step linger window, pill and checklist are still up at full opacity.
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(checklistCard()).not.toBeNull();
+    expect(pill()).not.toBeNull();
+  });
+
+  it("fades on the hover schedule after leaving a checklist that advanced while pinned", () => {
+    mocks.tracker = plan(1, 4);
+    const { rerender } = render(<TodoProgressPill />);
+    mocks.tracker = plan(2, 4);
+    rerender(<TodoProgressPill />);
+
+    fireEvent.mouseEnter(pillSurface()!);
+    mocks.tracker = plan(3, 4);
+    rerender(<TodoProgressPill />);
+    expect(checklistCard()).not.toBeNull();
+
+    fireEvent.mouseLeave(pillSurface()!);
+    act(() => {
+      vi.advanceTimersByTime(1800);
+    });
+    expect(pill()).toBeNull();
+    expect(checklistCard()).toBeNull();
   });
 
   it("unmounts at fade start under reduced motion instead of lingering at opacity 0", () => {

--- a/apps/packages/product-client/src/components/workspace/chat/input/TodoProgressPill.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/TodoProgressPill.tsx
@@ -122,6 +122,10 @@ interface TodoPillSnapshot {
  * hide, or pin/checklist on hover. Keyed by session (see `TodoProgressPill`
  * below), so cross-session tracker deltas can never read as an advance.
  *
+ * An advance that lands while the pointer is on the pill/checklist does not
+ * restart that cycle: the pinned checklist stays mounted and updates in
+ * place. Hover owns dismissal until the pointer leaves.
+ *
  * Rendering works off the last non-null tracker snapshot rather than the
  * live tracker: when a completed plan leaves the transcript the pill keeps
  * lingering through its scheduled fade instead of being yanked mid-linger.
@@ -134,6 +138,12 @@ function SessionTodoProgressPill() {
   const snapshotRef = useRef<TodoPillSnapshot | null>(null);
   const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Whether the pointer is actually on the pill/checklist right now. Distinct
+  // from `state.pinned`, which deliberately survives mouse-leave through the
+  // leave-grace window — the step-advance effect must only hold its fire for
+  // a real hover, never for that grace period (holding fire there would leave
+  // the pill pinned open with no timer left to dismiss it).
+  const hoveredRef = useRef(false);
 
   const summary = tracker ? summarizeTodoProgress(tracker.entries) : null;
   if (tracker && summary) {
@@ -169,6 +179,16 @@ function SessionTodoProgressPill() {
       return;
     }
 
+    if (hoveredRef.current) {
+      // The user is inspecting the pinned checklist. Re-running the
+      // show -> fade cycle here would unpin it: the card vanishes from under
+      // the pointer, remounts on the next pointer move (restarting the
+      // in-progress spinner's rotation), and the pill fades away mid-hover.
+      // Hold the pin instead — the checklist rows update in place, and
+      // dismissal stays owned by mouse-leave.
+      return;
+    }
+
     clearTimers();
     dispatch({ type: "step_advanced" });
     fadeTimerRef.current = setTimeout(() => dispatch({ type: "fade_start" }), TODO_PILL_STEP_FADE_START_MS);
@@ -195,11 +215,13 @@ function SessionTodoProgressPill() {
   }
 
   function handleMouseEnter() {
+    hoveredRef.current = true;
     clearTimers();
     dispatch({ type: "hover_on" });
   }
 
   function handleMouseLeave() {
+    hoveredRef.current = false;
     clearTimers();
     dispatch({ type: "hover_off" });
     fadeTimerRef.current = setTimeout(() => dispatch({ type: "fade_start" }), TODO_PILL_HOVER_FADE_START_MS);

--- a/apps/packages/product-client/src/domain/chats/composer/todo-progress-pill-state.ts
+++ b/apps/packages/product-client/src/domain/chats/composer/todo-progress-pill-state.ts
@@ -11,6 +11,11 @@
  *   - hovering pins the pill (cancels any fade) and reveals the checklist
  *   - mouse-leave restarts a short fade: starts at 1.2s, hidden by 1.8s
  *
+ * A step advance while the pointer is actually on the pill/checklist never
+ * reaches this reducer: the connected component holds its fire so the pinned
+ * checklist stays mounted and updates in place (`step_advanced` would unpin
+ * it out from under the pointer and remount its in-progress spinner).
+ *
  * `pinned` intentionally survives `hover_off` and only drops when the
  * leave-fade actually starts: the checklist card renders while pinned, and
  * it sits above the pill across a small gap — the card must stay mounted

--- a/specs/codebase/systems/product/chat/composer.md
+++ b/specs/codebase/systems/product/chat/composer.md
@@ -485,9 +485,12 @@ and therefore never shifts the dock when it shows or hides.
   (fade starts at 3.4s, 600ms opacity ease), then unmounts. Hovering pins it
   (cancels the fade, reveals a checklist card above it with one row per
   entry); mouse-leave unpins and restarts a short fade (starts at 1.2s, gone
-  by 1.8s). `todo-progress-pill-state.ts` owns this show → linger → fade →
+  by 1.8s). A step advance while the pointer is on the pill/checklist does
+  not restart that cycle: the pinned checklist stays mounted and its rows
+  update in place, so the in-progress spinner never remounts mid-hover.
+  `todo-progress-pill-state.ts` owns this show → linger → fade →
   hide state machine as a pure reducer (`todoPillReducer`); the connected
-  component only owns the timers.
+  component only owns the timers and the hovered guard.
 - **No dock-slot precedence.** Because it floats independently of
   `activeSlot`/`attachedSlot`, it never competes with `ConnectedApprovalCard`,
   `ConnectedUserInputCard`, or `ConnectedMcpElicitationCard` for the slot —


### PR DESCRIPTION
## Summary

- Fixes PRO-85: the blue in-progress spinner in the hover-pinned todo checklist ("Tasks" checklist above the composer) visibly flickered and shifted during live sessions.
- Root cause: while the pointer pinned the checklist open, any step advance (a task completing, becoming in-progress, or the list growing) dispatched `step_advanced`, whose reducer arm force-unpins. The checklist unmounted from under the cursor, remounted on the next pointer move — restarting the in-progress `Spinner`'s rotation animation from 0° — and the advance's fade/hide timers then faded the pill away mid-hover. With frequent TodoWrite updates this read as the current task's indicator flickering/jumping. This also contradicted the documented contract ("hovering pins it, cancels the fade; mouse-leave unpins") and the state machine's own comment that fade/hide can only arrive from a mouse-leave while pinned.
- Fix: `SessionTodoProgressPill` tracks real hover in a ref — deliberately distinct from `state.pinned`, which survives mouse-leave through the leave-grace window — and holds the advance show→fade cycle while hovered. The pinned checklist stays mounted, its rows (and the blue spinner) update in place, and dismissal stays owned by mouse-leave. Advances during the leave-grace window keep today's behavior, so the pill can never leak open without a dismissal timer.
- Spec (`specs/codebase/systems/product/chat/composer.md`) updated in the same PR.

## Testing

- Tier 1 (unit/component, per specs/TESTING.md): two new regression tests in `TodoProgressPill.test.tsx` — the pinned checklist stays the same mounted DOM node through a hovered step advance with no fade/hide scheduled (fails on the previous behavior; verified red before the fix), and the leave-fade still dismisses after a hovered advance (guards the no-timer leak).
- `pnpm vitest run src/components/workspace/chat/input src/domain/chats/composer` — 26 files, 169 tests passed.
- `npx tsc -p tsconfig.json --noEmit` (product-client) — clean.
- `python3 scripts/check_docs.py` and `python3 scripts/check_design_attribution.py` — passed.
- No browser visual run: the bugathon browser lock is deliberately held by the coordinator (host memory pressure).

## Observability

- none

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- Negative control: the new "keeps the hover-pinned checklist mounted, in place, through step advances" test was run before applying the fix and failed exactly at the unpin (`expected null not to be null` on the checklist card), then passed after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
