### PR TITLE
fix(product): animate the completed-work divider with the disclosure (PRO-181)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolCallSummary.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolCallSummary.test.tsx
@@ -7,7 +7,7 @@ import { ToolCallSummary } from "#product/components/workspace/chat/tool-calls/T
 afterEach(cleanup);
 
 describe("ToolCallSummary", () => {
-  it("shows the completed-work divider only while collapsed and restores turn spacing when expanded", () => {
+  it("keeps the completed-work divider mounted and collapses it in step with the disclosure", () => {
     const { container } = render(
       <ToolCallSummary
         label="Worked for 13m 25s"
@@ -39,14 +39,26 @@ describe("ToolCallSummary", () => {
     expect(ledgerShell?.className).not.toMatch(/(?:^|\s)rounded(?:\s|$)/);
     expect(ledger.parentElement?.className).toContain("mt-4");
     expect(ledger.parentElement?.className).toContain("gap-transcript-turn");
-    expect(container.querySelector("[data-completed-work-divider]")).toBeNull();
+    // The divider stays mounted while expanded — it exits through the same
+    // disclosure motion as the ledger instead of popping out (PRO-181).
+    const expandedDivider = container.querySelector("[data-completed-work-divider]");
+    expect(expandedDivider).not.toBeNull();
+    const expandedDividerShell = expandedDivider?.closest("[data-animated-collapsible-content]");
+    expect(expandedDividerShell?.getAttribute("data-expanded")).toBe("false");
+    expect((expandedDividerShell as HTMLElement | null)?.style.gridTemplateRows).toBe("0fr");
 
     fireEvent.click(disclosure);
-    const motionShell = container.querySelector("[data-animated-collapsible-content]");
+    const collapsedDivider = container.querySelector("[data-completed-work-divider]");
+    expect(collapsedDivider).not.toBeNull();
+    const collapsedDividerShell = collapsedDivider?.closest("[data-animated-collapsible-content]");
+    expect(collapsedDividerShell?.getAttribute("data-expanded")).toBe("true");
+    expect((collapsedDividerShell as HTMLElement | null)?.style.gridTemplateRows).toBe("1fr");
+    const ledgerShellMotion = container
+      .querySelector("[data-completed-work-ledger]")
+      ?.closest("[data-animated-collapsible-content]");
     expect(screen.queryByText("Work ledger")).not.toBeNull();
-    expect(motionShell?.getAttribute("data-expanded")).toBe("false");
-    expect((motionShell as HTMLElement | null)?.style.gridTemplateRows).toBe("0fr");
-    expect(motionShell?.hasAttribute("inert")).toBe(true);
-    expect(container.querySelectorAll("[data-completed-work-divider]")).toHaveLength(1);
+    expect(ledgerShellMotion?.getAttribute("data-expanded")).toBe("false");
+    expect((ledgerShellMotion as HTMLElement | null)?.style.gridTemplateRows).toBe("0fr");
+    expect(ledgerShellMotion?.hasAttribute("inert")).toBe(true);
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolCallSummary.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolCallSummary.tsx
@@ -72,7 +72,14 @@ export function ToolCallSummary({
           {completionContent}
         </div>
       )}
-      {showWorkDivider && !expanded && <ToolCallWorkDivider className="mt-1" />}
+      {showWorkDivider && (
+        // The divider's exit/entry must ride the same disclosure motion as the
+        // ledger above it: unmounting it on toggle pops the content below by
+        // the divider's 5px box against the animation direction (PRO-181).
+        <AnimatedCollapsibleContent expanded={!expanded}>
+          <ToolCallWorkDivider className="mt-1" />
+        </AnimatedCollapsibleContent>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Fixes PRO-181: uncollapsing a completed turn's tool group ("Worked for Ns" disclosure) produced a slight, annoying shift of the content below it.
- Root cause: `ToolCallSummary` unmounted the completed-work hairline (`ToolCallWorkDivider`, 1px border + 4px `mt-1`) the instant `expanded` toggled, while the ledger's height animates continuously over 200ms. The tail message therefore jumped ~5px *against* the animation direction at expand start, and jumped back at collapse start.
- Fix: keep the divider mounted and run its exit/entry through the same `AnimatedCollapsibleContent` motion, inverted (`expanded={!expanded}`). Total height now changes continuously in both directions; end-state layout is pixel-identical (divider fully collapsed to 0 when the ledger is open, restored when closed). Reduced-motion behavior is unchanged (both regions swap instantly via `motion-reduce:transition-none`).

Measured with per-frame rAF sampling in headless Chromium on a faithful static replica of the disclosure DOM (same classes/tokens: grid `0fr↔1fr`, 200ms ease-out, `mt-1` + `border-t` divider, `mt-4` ledger):

| | first frame after toggle | rest of the animation | final y |
| --- | --- | --- | --- |
| before (expand) | **−5.0px** (counter-jump) | monotonic +, eased | 169.0 |
| before (collapse) | **+5.0px** (counter-jump) | monotonic −, eased | 66.0 |
| after (expand) | +7.1px (eased motion only) | monotonic +, eased | 169.0 |
| after (collapse) | −13.9px (two eased frames) | monotonic −, eased | 66.0 |

## Testing

- Tier 1 (component/unit, jsdom): updated `ToolCallSummary.test.tsx` to pin the new contract — the divider stays mounted in both states and its collapsible shell flips `data-expanded`/`grid-template-rows` inversely to the ledger's. Note this replaces the previous pinned assertion that the divider unmounts while expanded; that assertion pinned the defect this PR fixes, and the flag here is the required constitution callout for changing it.
- `pnpm exec vitest run` over `chat/tool-calls/`, `chat/transcript/`, `AnimatedCollapsibleContent`, and `Disclosure` suites — 14 suites / 91 tests green, plus the full transcript folder (186 tests) green.
- `pnpm --filter @proliferate/product-client typecheck` — green.
- `check_frontend_boundaries.py`, `check_appearance_scaling.py`, `check_design_attribution.py`, `check_component_library.py` — all pass.
- Visual in-app validation was not possible in this run (the shared single browser-validation slot stayed occupied), so the pixel evidence above comes from the headless static replica.

## Observability

- none

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- Repro/verify harness: static replica + Playwright frame sampler (before: instant −5px/+5px counter-jumps at toggle; after: monotonic eased motion, identical end-state geometry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
