### PR TITLE
fix(product): remove the duplicate Support row from the main sidebar primary nav (PRO-152)

### DIFF
--- a/apps/packages/product-client/src/components/playground/WorkspaceStatusPlayground.tsx
+++ b/apps/packages/product-client/src/components/playground/WorkspaceStatusPlayground.tsx
@@ -316,13 +316,11 @@ function FullSidebarPane() {
           homeActive
           workspacesActive={false}
           workflowsActive={false}
-          supportActive={false}
           onGoHome={() => {}}
           onGoWorkspaces={() => {}}
           onGoWorkflows={() => {}}
-          onOpenSupport={() => {}}
           shortcutRevealVisible={shortcutReveal}
-          shortcutLabels={{ newChat: "⌘N", support: "⌘?" }}
+          shortcutLabels={{ newChat: "⌘N" }}
         />
         <div className="flex min-h-0 flex-col px-2">
           <SidebarRepositoriesHeader

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.test.tsx
@@ -1,11 +1,10 @@
 /* @vitest-environment jsdom */
 
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MainSidebar } from "#product/components/workspace/shell/sidebar/MainSidebar";
-import { useSupportModalStore } from "#product/stores/support/support-modal-store";
 
 const releaseNoticeState = vi.hoisted(() => ({
   notice: null as null | {
@@ -188,40 +187,6 @@ vi.mock("#product/hooks/workspaces/derived/use-sidebar-shortcut-targets", () => 
   useSidebarShortcutTargets: () => [],
 }));
 
-vi.mock("#product/hooks/support/derived/use-support-report-snapshot", () => ({
-  useSupportReportSnapshot: () => ({
-    openedAt: "2026-05-30T00:00:00.000Z",
-    source: "sidebar",
-    context: {
-      source: "sidebar",
-      intent: "general",
-      workspaceName: "hedgehog",
-      workspaceLocation: "local",
-    },
-    defaultScope: "app_only",
-    defaultWorkspaceId: null,
-    workspaceOptions: [],
-  }),
-}));
-
-vi.mock("#product/hooks/support/workflows/use-open-support-report-window", () => ({
-  useOpenSupportReportWindow: () => ({
-    openBug: vi.fn(() => {
-      useSupportModalStore.getState().openFeedback();
-    }),
-    openFeature: vi.fn(),
-    canSubmit: true,
-    disabledReason: null,
-  }),
-}));
-
-vi.mock("#product/hooks/support/facade/use-support-availability", () => ({
-  useSupportAvailability: () => ({
-    canSubmit: true,
-    disabledReason: null,
-  }),
-}));
-
 vi.mock("#product/stores/sessions/session-selection-store", () => ({
   useSessionSelectionStore: (selector: (state: { pendingWorkspaceEntry: null }) => unknown) =>
     selector({ pendingWorkspaceEntry: null }),
@@ -346,16 +311,13 @@ describe("MainSidebar host capabilities", () => {
   });
 });
 
-describe("MainSidebar support modal", () => {
-  it("opens the feedback modal from Support", async () => {
+describe("MainSidebar support entry points", () => {
+  it("does not render a Support row in the primary navigation (PRO-152)", () => {
     renderMainSidebar();
 
-    fireEvent.click(screen.getByRole("button", { name: /Support/ }));
-
-    await waitFor(() => {
-      expect(useSupportModalStore.getState().open).toBe(true);
-      expect(useSupportModalStore.getState().kind).toBe("bug");
-    });
+    expect(screen.queryByRole("button", { name: /Support/ })).toBeNull();
+    // The capability-routed help footer stays the single sidebar entry point.
+    expect(screen.getByTestId("sidebar-account-footer")).not.toBeNull();
   });
 });
 

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
@@ -33,7 +33,6 @@ import type { SidebarWorkspaceItemState } from "#product/lib/domain/workspaces/s
 import { useCloudBilling } from "#product/hooks/cloud/facade/use-cloud-billing";
 import { useDebugRenderCount } from "#product/hooks/ui/debug/use-debug-render-count";
 import { useSidebarShortcutTargets } from "#product/hooks/workspaces/derived/use-sidebar-shortcut-targets";
-import { useOpenSupportReportWindow } from "#product/hooks/support/workflows/use-open-support-report-window";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 import { useWorkspaceDisplayNameActions } from "#product/hooks/workspaces/workflows/use-workspace-display-name-actions";
@@ -66,7 +65,6 @@ export const MainSidebar = memo(function MainSidebar({ showRightBorder = true }:
   useSessionActivityReconciler();
   const { notice, dismissNotice, openChangelog } = useReleaseNotice();
   const actions = useWorkspaceSidebarActions();
-  const { openBug: handleOpenSupport } = useOpenSupportReportWindow({ source: "sidebar" });
   const shortcutRevealVisible = useShortcutRevealVisible();
   const sidebarShortcutTargetIds = useSidebarShortcutTargets();
   const {
@@ -319,7 +317,6 @@ export const MainSidebar = memo(function MainSidebar({ showRightBorder = true }:
   );
   const primaryNavShortcutLabels = useMemo(() => ({
     newChat: getShortcutDisplayLabel(SHORTCUTS.newDefault),
-    support: getShortcutDisplayLabel(SHORTCUTS.openSupport),
   }), []);
 
   return (
@@ -343,11 +340,9 @@ export const MainSidebar = memo(function MainSidebar({ showRightBorder = true }:
               homeActive={isOnHome && !selectedWorkspaceId && !pendingWorkspaceEntry}
               workspacesActive={isOnWorkspaces}
               workflowsActive={isOnWorkflows}
-              supportActive={false}
               onGoHome={actions.handleGoHome}
               onGoWorkspaces={actions.handleGoWorkspaces}
               onGoWorkflows={actions.handleGoWorkflows}
-              onOpenSupport={handleOpenSupport}
               shortcutRevealVisible={shortcutRevealVisible}
               shortcutLabels={primaryNavShortcutLabels}
             />

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarPrimaryNavigation.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarPrimaryNavigation.tsx
@@ -1,5 +1,5 @@
 import { AppShellNewChatIcon } from "#product/primitives/icons/app-shell";
-import { Fork, LifeBuoy } from "#product/primitives/icons/core";
+import { Fork } from "#product/primitives/icons/core";
 import { Grid } from "#product/primitives/icons/platform";
 import type { SidebarNavItemView } from "#product/components/workspace/shell/sidebar/ProductSidebarNavigation";
 import { ProductSidebarPrimaryNavigation } from "#product/components/workspace/shell/sidebar/ProductSidebarNavigation";
@@ -8,29 +8,24 @@ interface SidebarPrimaryNavigationProps {
   homeActive: boolean;
   workspacesActive: boolean;
   workflowsActive: boolean;
-  supportActive: boolean;
   shortcutRevealVisible: boolean;
   shortcutLabels: {
     newChat: string;
-    support: string;
   };
   onGoHome: () => void;
   onGoWorkspaces: () => void;
   onGoWorkflows: () => void;
-  onOpenSupport: () => void;
 }
 
 export function SidebarPrimaryNavigation({
   homeActive,
   workspacesActive,
   workflowsActive,
-  supportActive,
   shortcutRevealVisible,
   shortcutLabels,
   onGoHome,
   onGoWorkspaces,
   onGoWorkflows,
-  onOpenSupport,
 }: SidebarPrimaryNavigationProps) {
   const navItems: SidebarNavItemView[] = [
     {
@@ -57,13 +52,6 @@ export function SidebarPrimaryNavigation({
         </span>
       ),
     },
-    {
-      id: "support",
-      active: supportActive,
-      icon: <LifeBuoy className="icon-indicator" strokeWidth={1.75} />,
-      label: "Support",
-      shortcutLabel: shortcutLabels.support,
-    },
   ];
 
   const handleNavSelect = (id: string) => {
@@ -76,9 +64,6 @@ export function SidebarPrimaryNavigation({
         break;
       case "workflows":
         onGoWorkflows();
-        break;
-      case "support":
-        onOpenSupport();
         break;
       default:
         break;


### PR DESCRIPTION
## Summary

Fixes [PRO-152 "Support shown twice"](https://linear.app/proliferate-team/issue/PRO-152/support-shown-twice).

The main sidebar presented the same support action twice:

- a **Support** row in the primary navigation (`SidebarPrimaryNavigation`), and
- the footer **"?" help popover**'s "Send feedback" entry (`SidebarHelpSection`),

both displaying the same `SHORTCUTS.openSupport` shortcut label.

## Root cause

Navigation composition, not duplicated source data: the primary nav hardcoded a Support action row (`supportActive={false}` — it was never a real navigation destination) on top of the help footer that already owns support. The nav row was also spec-non-conforming: it called `useOpenSupportReportWindow().openBug` directly, bypassing `deriveSupportMenuAction`, so on an operator/self-managed server it would have opened the vendor feedback modal instead of the operator's configured destination — a direct violation of `specs/codebase/systems/product/support/README.md` ("Product UI must never route a self-managed user to vendor support").

## Fix

Remove the Support row and its plumbing (`supportActive`, `onOpenSupport`, `shortcutLabels.support`, the `LifeBuoy` icon import, and the `useOpenSupportReportWindow` call in `MainSidebar`). The conforming, capability-routed entry points remain untouched:

- sidebar footer help popover (`SidebarHelpFooter`/`SidebarHelpSection`)
- command palette "Open Support" entry
- global `openSupport` keyboard shortcut (bound in `use-app-shortcuts.ts` via `useAppNavigationCommandActions`, which routes vendor/operator/none correctly)
- settings sidebar footer Support action (designed per the settings IA doc; out of scope here)

## Testing

- `pnpm vitest run src/components/workspace/shell/sidebar` — 9 files, 72 tests pass, including a new regression test asserting the primary nav renders no Support row while the help footer entry point remains.
- Negative control: with the source fix reverted (test kept), the suite fails.
- `pnpm typecheck` (product-client) and `python3 scripts/check_frontend_boundaries.py` pass.
- No visual/browser validation: the shared bugathon browser lock was held by another worker, so no dev server was started per the validation rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)