### PR TITLE
fix(agent-auth): hold the harness settings toggle for a native-auth harness (PRO-129)

### DIFF
--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessSettingsSection.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessSettingsSection.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentAuthSelection, AgentAuthState } from "@proliferate/cloud-sdk";
+import { HarnessSettingsSection } from "#product/components/settings/panes/agents/harness/HarnessSettingsSection";
+
+const queries = vi.hoisted(() => ({
+  state: { data: undefined as AgentAuthState | undefined },
+  selections: { data: undefined as AgentAuthSelection[] | undefined },
+  mutate: vi.fn(),
+}));
+
+vi.mock("@proliferate/cloud-sdk-react", () => ({
+  useAgentAuthState: () => queries.state,
+  useAuthSelections: () => queries.selections,
+  usePutAuthSelections: () => ({ mutate: queries.mutate }),
+}));
+
+vi.mock("#product/hooks/cloud/derived/use-cloud-availability-state", () => ({
+  useCloudAvailabilityState: () => ({ cloudActive: false }),
+}));
+
+function stateDocument(overrides: Partial<AgentAuthState> = {}): AgentAuthState {
+  return { version: 2, revision: 3, user_id: "user-1", harnesses: [], ...overrides };
+}
+
+function renderClaudeSettings() {
+  return render(<HarnessSettingsSection harnessKind="claude" surface="local" />);
+}
+
+afterEach(() => {
+  cleanup();
+  queries.state.data = undefined;
+  queries.selections.data = undefined;
+  queries.mutate.mockClear();
+});
+
+describe("HarnessSettingsSection", () => {
+  it("reads the persisted toggle from the harness_settings rider for a native-auth harness", () => {
+    // PRO-129: a native-login harness has NO `harnesses` entry in the rendered
+    // document (absent means native), so the persisted value must come from
+    // the response's harness_settings rider or the switch snaps back to its
+    // default after every toggle.
+    queries.state.data = stateDocument({
+      harness_settings: { claude: { chrome: true } },
+    });
+    queries.selections.data = [];
+    renderClaudeSettings();
+    expect(
+      screen
+        .getByRole("switch", { name: "Use Claude Code with Chrome" })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
+  });
+
+  it("falls back to the delivered settings passenger when the rider is absent", () => {
+    // Older self-hosted servers respond without the rider; a routed harness
+    // still carries its settings inside the document.
+    queries.state.data = stateDocument({
+      harnesses: [
+        {
+          harness_kind: "claude",
+          sources: [{ kind: "gateway", base_url: "https://gw", key: "sk-vk" }],
+          settings: { chrome: true },
+        },
+      ],
+    });
+    queries.selections.data = [];
+    renderClaudeSettings();
+    expect(
+      screen
+        .getByRole("switch", { name: "Use Claude Code with Chrome" })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
+  });
+
+  it("commits the flipped value through the selections PUT", () => {
+    queries.state.data = stateDocument({ harness_settings: {} });
+    queries.selections.data = [];
+    renderClaudeSettings();
+    fireEvent.click(screen.getByRole("switch", { name: "Use Claude Code with Chrome" }));
+    expect(queries.mutate).toHaveBeenCalledWith({
+      harnessKind: "claude",
+      surface: "local",
+      body: { sources: [], settings: { chrome: true } },
+    });
+  });
+
+  it("does not commit while either read is still loading", () => {
+    // The PUT is full desired state: committing before the selections read
+    // resolves would clear the harness's auth sources, and committing before
+    // the state read would drop sibling setting keys.
+    queries.state.data = stateDocument();
+    queries.selections.data = undefined;
+    renderClaudeSettings();
+    const toggle = screen.getByRole("switch", {
+      name: "Use Claude Code with Chrome",
+    }) as HTMLButtonElement;
+    expect(toggle.disabled).toBe(true);
+    fireEvent.click(toggle);
+    expect(queries.mutate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessSettingsSection.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessSettingsSection.tsx
@@ -81,11 +81,18 @@ function HarnessSettingRow({
   const selectionsQuery = useAuthSelections(surface, queriesEnabled);
   const putSelections = usePutAuthSelections();
 
-  // Read persisted value from the auth state response.
+  // Read the persisted value from the state response's `harness_settings`
+  // rider. The rendered document only carries a harness's `settings`
+  // passenger when that harness has an enabled selection (the fail-closed law
+  // forbids a settings-only harness entry), so a native-auth harness — the
+  // default local Claude login — has NO entry there and reading the document
+  // alone snaps every toggle back to its default (PRO-129). The per-harness
+  // passenger remains as the fallback for servers that predate the rider.
   const harness = stateQuery.data?.harnesses?.find(
     (h) => h.harness_kind === harnessKind,
   );
-  const persisted = harness?.settings as Record<string, boolean> | undefined;
+  const persisted = (stateQuery.data?.harness_settings?.[harnessKind]
+    ?? harness?.settings) as Record<string, boolean> | undefined;
   const currentValue = persisted?.[setting.key] ?? setting.default;
 
   // Build the current sources for this harness+surface so the PUT does not
@@ -121,7 +128,15 @@ function HarnessSettingRow({
         checked={currentValue}
         onChange={handleToggle}
         aria-label={setting.label}
-        disabled={!isLocalSurface && !cloudActive}
+        // Both reads must have resolved before a toggle is safe: the PUT is
+        // full desired state, so committing while selections are still
+        // loading would silently clear the harness's auth sources, and
+        // committing before the state read would drop sibling setting keys.
+        disabled={
+          (!isLocalSurface && !cloudActive)
+          || stateQuery.data === undefined
+          || selectionsQuery.data === undefined
+        }
       />
     </SettingsRow>
   );

--- a/apps/packages/product-client/src/lib/domain/agents/local-auth-state.test.ts
+++ b/apps/packages/product-client/src/lib/domain/agents/local-auth-state.test.ts
@@ -129,6 +129,22 @@ describe("stampIssuingServerOrigin", () => {
     });
   });
 
+  it("strips the harness_settings rider before the runtime push", () => {
+    // `harness_settings` is the settings pane's read of persisted toggles for
+    // harnesses with no enabled selection; the runtime's copy is the
+    // per-harness `settings` passenger inside `harnesses`, so the rider must
+    // never reach the persisted state.json.
+    const stamped = stampIssuingServerOrigin(
+      { ...state(), harness_settings: { claude: { chrome: true } } },
+      "https://proliferate.corp.example",
+    );
+    expect("harness_settings" in stamped).toBe(false);
+    expect(stamped).toEqual({
+      ...state(),
+      issuing_server_origin: "https://proliferate.corp.example",
+    });
+  });
+
   it("overwrites a previous stamp on re-push after a server switch", () => {
     const first = stampIssuingServerOrigin(state(), "https://old-server.example");
     const second = stampIssuingServerOrigin(first, "https://new-server.example");

--- a/apps/packages/product-client/src/lib/domain/agents/local-auth-state.ts
+++ b/apps/packages/product-client/src/lib/domain/agents/local-auth-state.ts
@@ -47,7 +47,15 @@ export function stampIssuingServerOrigin(
   // `fingerprint` is a server-response rider for the delivery ack (echoed back
   // via POST /state/ack after the runtime confirms the push), never part of
   // the state.json contract the runtime persists — strip it before pushing.
-  const { fingerprint: _fingerprint, ...document } = state;
+  // `harness_settings` is likewise a response-only rider (the settings pane's
+  // read of persisted toggles for harnesses with no enabled selection); the
+  // runtime's copy of settings is the per-harness `settings` passenger inside
+  // `harnesses`, so the rider is stripped the same way.
+  const {
+    fingerprint: _fingerprint,
+    harness_settings: _harnessSettings,
+    ...document
+  } = state;
   return { ...document, issuing_server_origin: issuingServerOrigin };
 }
 

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -3329,6 +3329,15 @@ export interface components {
          *     canonical document), NOT part of the state.json wire contract: the desktop
          *     echoes it through ``POST /state/ack`` after a successful runtime push and
          *     must strip it before pushing the document to the local runtime.
+         *
+         *     ``harness_settings`` is a second response-only rider: the surface's full
+         *     persisted harness-settings map (``agent_auth_harness_settings``), keyed by
+         *     harness_kind. The document's per-harness ``settings`` passenger only rides
+         *     when the harness has an enabled selection — the fail-closed law forbids a
+         *     settings-only ``harnesses`` entry — so the settings pane reads this rider
+         *     to show persisted toggle values for a native-auth harness. Like
+         *     ``fingerprint``, the desktop strips it before pushing the document to the
+         *     local runtime.
          */
         AgentAuthStateResponse: {
             /** Version */
@@ -3341,6 +3350,12 @@ export interface components {
             harnesses: components["schemas"]["AgentAuthStateHarness"][];
             /** Fingerprint */
             fingerprint?: string | null;
+            /** Harness Settings */
+            harness_settings?: {
+                [key: string]: {
+                    [key: string]: unknown;
+                };
+            } | null;
         };
         /**
          * AgentAuthStateSource

--- a/lints/server/ratchets.toml
+++ b/lints/server/ratchets.toml
@@ -40,8 +40,8 @@ reason = "C-train composition re-attaches C-1 both-surface sync-completion pokes
 
 [[max_lines]]
 path = "server/proliferate/server/cloud/agent_gateway/service.py"
-max_lines = 834
-reason = "delivery-ack hardening (server-bounded ack revision + trust-boundary docs) nudged the gateway service over the 800 server-layer cap; split pending with the service taxonomy pass; typed-config write gate threads the registry providerConfig vocabulary into the store put and pins R5's azure field set ; +21: FR-3 adds get_verification_verdicts reading the governing enrollment's per-harness gateway-enablement verdicts for the additive capabilities surface"
+max_lines = 820
+reason = "delivery-ack hardening (server-bounded ack revision + trust-boundary docs) nudged the gateway service over the 800 server-layer cap; split pending with the service taxonomy pass; typed-config write gate threads the registry providerConfig vocabulary into the store put and pins R5's azure field set ; +21: FR-3 adds get_verification_verdicts reading the governing enrollment's per-harness gateway-enablement verdicts for the additive capabilities surface; PRO-129 splits put_harness_settings out to a dedicated harness_settings.py module (settings are not auth), pulling the file back down to 820"
 
 [[max_lines]]
 path = "server/proliferate/server/cloud/materialization/materialize/agent_auth.py"

--- a/server/proliferate/server/cloud/agent_gateway/api.py
+++ b/server/proliferate/server/cloud/agent_gateway/api.py
@@ -21,7 +21,7 @@ from proliferate.auth.dependencies import current_product_user
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
 from proliferate.permissions import CurrentOrgUser, current_path_org_admin
-from proliferate.server.cloud.agent_gateway import service
+from proliferate.server.cloud.agent_gateway import harness_settings, service
 from proliferate.server.cloud.agent_gateway.models import (
     AgentApiKeyCreateRequest,
     AgentApiKeyResponse,
@@ -177,7 +177,7 @@ async def put_agent_auth_selections_endpoint(
     )
     # Persist settings alongside sources when provided.
     if body.settings is not None:
-        await service.put_harness_settings(
+        await harness_settings.put_harness_settings(
             db,
             user_id=user.id,
             harness_kind=harness_kind,
@@ -217,11 +217,11 @@ async def get_agent_auth_state_endpoint(
     materializer writes into the user's own sandbox. Nothing crosses a user
     boundary.
     """
-    state, fingerprint, harness_settings = await service.get_auth_state(
+    state, fingerprint, settings_by_harness = await service.get_auth_state(
         db, user_id=user.id, surface=surface
     )
     return agent_auth_state_payload(
-        state, fingerprint=fingerprint, harness_settings=harness_settings
+        state, fingerprint=fingerprint, harness_settings=settings_by_harness
     )
 
 

--- a/server/proliferate/server/cloud/agent_gateway/api.py
+++ b/server/proliferate/server/cloud/agent_gateway/api.py
@@ -217,8 +217,12 @@ async def get_agent_auth_state_endpoint(
     materializer writes into the user's own sandbox. Nothing crosses a user
     boundary.
     """
-    state, fingerprint = await service.get_auth_state(db, user_id=user.id, surface=surface)
-    return agent_auth_state_payload(state, fingerprint=fingerprint)
+    state, fingerprint, harness_settings = await service.get_auth_state(
+        db, user_id=user.id, surface=surface
+    )
+    return agent_auth_state_payload(
+        state, fingerprint=fingerprint, harness_settings=harness_settings
+    )
 
 
 @router.post("/state/ack", response_model=AgentAuthDeliveryAckResponse)

--- a/server/proliferate/server/cloud/agent_gateway/harness_settings.py
+++ b/server/proliferate/server/cloud/agent_gateway/harness_settings.py
@@ -1,0 +1,44 @@
+"""Harness settings service: per-harness configuration toggles — not auth.
+
+``agent_auth_harness_settings`` stores catalog-declared toggle values (for
+example claude's "Use Claude Code with Chrome"), riding the agent-auth
+surface as the delivery vehicle only (AGENT_AUTH.md "Not auth: harness
+settings"). Split from ``service.py`` along the seam the store layer
+already draws (``db/store/agent_gateway/harness_settings.py``), keeping
+the auth service under its line ceiling.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.store import agent_gateway as agent_gateway_store
+from proliferate.server.cloud.errors import CloudApiError
+
+
+async def put_harness_settings(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    harness_kind: str,
+    surface: str,
+    settings_dict: dict[str, object],
+) -> dict[str, object]:
+    """Validate shape (all values must be bool) and upsert harness settings."""
+    for key, value in settings_dict.items():
+        if not isinstance(key, str) or not isinstance(value, bool):
+            raise CloudApiError(
+                "invalid_harness_settings",
+                "Settings must be a dict[str, bool]. "
+                f"Key {key!r} has value of type {type(value).__name__}.",
+                status_code=400,
+            )
+    return await agent_gateway_store.put_harness_settings(
+        db,
+        user_id=user_id,
+        harness_kind=harness_kind,
+        surface=surface,
+        settings=settings_dict,
+    )

--- a/server/proliferate/server/cloud/agent_gateway/models.py
+++ b/server/proliferate/server/cloud/agent_gateway/models.py
@@ -157,6 +157,15 @@ class AgentAuthStateResponse(BaseModel):
     canonical document), NOT part of the state.json wire contract: the desktop
     echoes it through ``POST /state/ack`` after a successful runtime push and
     must strip it before pushing the document to the local runtime.
+
+    ``harness_settings`` is a second response-only rider: the surface's full
+    persisted harness-settings map (``agent_auth_harness_settings``), keyed by
+    harness_kind. The document's per-harness ``settings`` passenger only rides
+    when the harness has an enabled selection — the fail-closed law forbids a
+    settings-only ``harnesses`` entry — so the settings pane reads this rider
+    to show persisted toggle values for a native-auth harness. Like
+    ``fingerprint``, the desktop strips it before pushing the document to the
+    local runtime.
     """
 
     version: int
@@ -164,6 +173,7 @@ class AgentAuthStateResponse(BaseModel):
     user_id: str | None = None
     harnesses: list[AgentAuthStateHarness]
     fingerprint: str | None = None
+    harness_settings: dict[str, dict[str, Any]] | None = None
 
 
 class AgentAuthStateAckRequest(BaseModel):
@@ -341,9 +351,11 @@ def agent_auth_state_payload(
     state: dict[str, object],
     *,
     fingerprint: str | None = None,
+    harness_settings: dict[str, dict[str, Any]] | None = None,
 ) -> AgentAuthStateResponse:
     response = AgentAuthStateResponse.model_validate(state)
     response.fingerprint = fingerprint
+    response.harness_settings = harness_settings
     return response
 
 

--- a/server/proliferate/server/cloud/agent_gateway/models.py
+++ b/server/proliferate/server/cloud/agent_gateway/models.py
@@ -173,7 +173,7 @@ class AgentAuthStateResponse(BaseModel):
     user_id: str | None = None
     harnesses: list[AgentAuthStateHarness]
     fingerprint: str | None = None
-    harness_settings: dict[str, dict[str, Any]] | None = None
+    harness_settings: dict[str, dict[str, object]] | None = None
 
 
 class AgentAuthStateAckRequest(BaseModel):
@@ -351,7 +351,7 @@ def agent_auth_state_payload(
     state: dict[str, object],
     *,
     fingerprint: str | None = None,
-    harness_settings: dict[str, dict[str, Any]] | None = None,
+    harness_settings: dict[str, dict[str, object]] | None = None,
 ) -> AgentAuthStateResponse:
     response = AgentAuthStateResponse.model_validate(state)
     response.fingerprint = fingerprint

--- a/server/proliferate/server/cloud/agent_gateway/service.py
+++ b/server/proliferate/server/cloud/agent_gateway/service.py
@@ -396,7 +396,7 @@ async def get_auth_state(
     *,
     user_id: UUID,
     surface: str,
-) -> tuple[dict[str, object], str]:
+) -> tuple[dict[str, object], str, dict[str, dict[str, object]]]:
     """Render the user's state.json v2 (document, fingerprint) for one surface.
 
     Same render path as the cloud materializer. A surface with no resolvable
@@ -404,8 +404,22 @@ async def get_auth_state(
     fingerprint (the renderer's sha256 of the canonical document) rides the
     response so the desktop can echo it back through the delivery ack — the
     server never has to trust a client-computed hash.
+
+    The third element is the surface's full persisted harness-settings map
+    (``agent_auth_harness_settings``), keyed by harness_kind. It exists for
+    the ``harness_settings`` response rider: the rendered document only
+    carries a harness's ``settings`` passenger when that harness has an
+    enabled selection (the fail-closed law forbids emitting a settings-only
+    entry), so the settings pane would otherwise read defaults back for a
+    native-auth harness and its toggles would never hold.
     """
-    return await build_agent_auth_state(db, user_id, surface=surface)
+    state, fingerprint = await build_agent_auth_state(db, user_id, surface=surface)
+    harness_settings = await agent_gateway_store.list_harness_settings_for_surface(
+        db,
+        user_id=user_id,
+        surface=surface,
+    )
+    return state, fingerprint, harness_settings
 
 
 async def ack_auth_state_delivery(

--- a/server/proliferate/server/cloud/agent_gateway/service.py
+++ b/server/proliferate/server/cloud/agent_gateway/service.py
@@ -365,32 +365,6 @@ async def put_auth_selections(
     return rows
 
 
-async def put_harness_settings(
-    db: AsyncSession,
-    *,
-    user_id: UUID,
-    harness_kind: str,
-    surface: str,
-    settings_dict: dict[str, object],
-) -> dict[str, object]:
-    """Validate shape (all values must be bool) and upsert harness settings."""
-    for key, value in settings_dict.items():
-        if not isinstance(key, str) or not isinstance(value, bool):
-            raise CloudApiError(
-                "invalid_harness_settings",
-                "Settings must be a dict[str, bool]. "
-                f"Key {key!r} has value of type {type(value).__name__}.",
-                status_code=400,
-            )
-    return await agent_gateway_store.put_harness_settings(
-        db,
-        user_id=user_id,
-        harness_kind=harness_kind,
-        surface=surface,
-        settings=settings_dict,
-    )
-
-
 async def get_auth_state(
     db: AsyncSession,
     *,
@@ -415,9 +389,7 @@ async def get_auth_state(
     """
     state, fingerprint = await build_agent_auth_state(db, user_id, surface=surface)
     harness_settings = await agent_gateway_store.list_harness_settings_for_surface(
-        db,
-        user_id=user_id,
-        surface=surface,
+        db, user_id=user_id, surface=surface
     )
     return state, fingerprint, harness_settings
 

--- a/server/tests/integration/test_agent_gateway_api.py
+++ b/server/tests/integration/test_agent_gateway_api.py
@@ -1000,9 +1000,8 @@ class TestAgentAuthState:
         empty = await _get_state(client, headers, "local")
         assert empty.status_code == 200, empty.text
         payload = empty.json()
-        # `fingerprint` is a response-only rider for the delivery ack (C-2's
-        # "Applied means acknowledged" seam), never part of the state.json
-        # wire contract the desktop pushes to the runtime.
+        # `fingerprint` is a response-only delivery-ack rider, never part of
+        # the state.json wire contract the desktop pushes to the runtime.
         fingerprint = payload.pop("fingerprint")
         assert isinstance(fingerprint, str) and len(fingerprint) == 64
         assert payload == {

--- a/server/tests/integration/test_agent_gateway_api.py
+++ b/server/tests/integration/test_agent_gateway_api.py
@@ -1010,6 +1010,7 @@ class TestAgentAuthState:
             "revision": 0,
             "user_id": user_id,
             "harnesses": [],
+            "harness_settings": {},
         }
 
     @pytest.mark.asyncio

--- a/server/tests/unit/test_agent_auth_settings_rider.py
+++ b/server/tests/unit/test_agent_auth_settings_rider.py
@@ -1,0 +1,62 @@
+"""The ``harness_settings`` response rider on ``GET /agent-auth/state``.
+
+Regression for the harness-settings toggle snapping back to its default
+(PRO-129): the rendered ``state.json`` document only carries a harness's
+``settings`` passenger when that harness has an enabled selection — the
+fail-closed law forbids a settings-only ``harnesses`` entry — so a
+native-auth harness's persisted toggles are invisible in the document. The
+state RESPONSE therefore carries the surface's full persisted settings map
+as a response-only rider (the ``fingerprint`` pattern), which the settings
+pane reads and the desktop strips before the runtime push.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from proliferate.server.cloud.agent_gateway.models import agent_auth_state_payload
+from proliferate.server.cloud.materialization.materialize import agent_auth
+from tests.unit.test_agent_auth_materialization import _inputs, _selection
+
+
+class TestHarnessSettingsRider:
+    def test_settings_without_a_selection_never_ride_the_document(self) -> None:
+        # Pins the render-side law the rider exists to compensate for: a
+        # harness with persisted settings but no enabled selection is ABSENT
+        # from the document (absent means native), not present-but-empty
+        # (which would refuse the launch).
+        state, _ = agent_auth.render_agent_auth_state(
+            dataclasses.replace(_inputs(()), harness_settings={"claude": {"chrome": True}})
+        )
+        assert state["harnesses"] == []
+
+    def test_payload_carries_the_rider_for_a_settings_only_harness(self) -> None:
+        harness_settings = {"claude": {"chrome": True}}
+        state, fingerprint = agent_auth.render_agent_auth_state(
+            dataclasses.replace(_inputs(()), harness_settings=harness_settings)
+        )
+        payload = agent_auth_state_payload(
+            state, fingerprint=fingerprint, harness_settings=harness_settings
+        )
+        assert payload.harnesses == []
+        assert payload.harness_settings == harness_settings
+        # Response-only: the rider never enters the canonical document (or its
+        # fingerprint), exactly like `fingerprint` itself.
+        assert "harness_settings" not in state
+
+    def test_payload_rider_coexists_with_the_delivered_settings_passenger(self) -> None:
+        # A harness WITH an enabled selection still carries its settings
+        # passenger inside the document; the rider is the same map, so the
+        # settings pane reads one surface regardless of route.
+        harness_settings = {"claude": {"chrome": True}}
+        state, fingerprint = agent_auth.render_agent_auth_state(
+            dataclasses.replace(
+                _inputs((_selection(harness="claude", source_kind="gateway"),)),
+                harness_settings=harness_settings,
+            )
+        )
+        payload = agent_auth_state_payload(
+            state, fingerprint=fingerprint, harness_settings=harness_settings
+        )
+        assert payload.harnesses[0].settings == {"chrome": True}
+        assert payload.harness_settings == harness_settings

--- a/specs/FEATURE_DOCS/AGENT_AUTH.md
+++ b/specs/FEATURE_DOCS/AGENT_AUTH.md
@@ -151,6 +151,19 @@ CLI-flag/env deltas — entirely outside the auth pipeline. Read
 the content; nothing in it is a secret and nothing in it affects which
 credentials a session runs on.
 
+The passenger needs a vehicle: a harness only gets a `harnesses` entry
+when it has an enabled selection ("Absent means native; present-but-empty
+fails closed" forbids a settings-only entry), so a native-auth harness's
+persisted settings never appear in the rendered document. The settings
+pane therefore reads them from the `harness_settings` **response rider**
+on `GET /state` — the surface's full persisted map, keyed by
+harness_kind, carried next to `fingerprint` and stripped the same way by
+the desktop before the runtime push
+([local-auth-state.ts](../../apps/packages/product-client/src/lib/domain/agents/local-auth-state.ts)).
+The runtime consequence stands: a native-auth harness's settings do not
+reach `resolve_settings_deltas`, because the document that would carry
+them is exactly the one a selection-less harness is absent from.
+
 `provider_hint` on a selection row is likewise display-only ("this key is
 my Anthropic key"); the renderer never puts it on the wire and nothing at
 launch reads it.
@@ -1144,6 +1157,21 @@ Deltas between this document and the integration stack
       `deployment` was dropped from the UI field spec and the server's
       create validation because the renderer deliberately never translated
       it.
+- [ ] **A native-auth harness's settings never reach the runtime.** The
+      `harness_settings` response rider makes the settings pane read and
+      hold persisted toggle values for a selection-less harness (PRO-129),
+      but the delivered `state.json` still cannot carry them: the
+      fail-closed law forbids a settings-only `harnesses` entry, and every
+      deployed runtime reads present-but-empty `sources` as a refused
+      launch, so the launch-time `resolve_settings_deltas` join sees no
+      settings for a native-auth harness. Closing this needs a
+      wire-contract change the old-runtime fleet can survive (for example
+      a settings channel outside `harnesses`, ignored by old readers),
+      plus the matching runtime read. Separately, claude's `--chrome`
+      mapping lands on the agent-process sidecar's argv, and the pinned
+      `@proliferate/claude-agent-acp` does not forward unrecognized argv
+      to the wrapped CLI — the flag is inert until the sidecar forwards
+      it (its own repo + a catalog pin bump).
 - [ ] **Module split.** The route prefix split landed (S1): vault,
       selections, state, and org policy now live under `/v1/cloud/agent-auth/`,
       and enrollment/capabilities stayed at `/v1/cloud/agent-gateway/`

--- a/specs/FEATURE_DOCS/AGENT_AUTH.md
+++ b/specs/FEATURE_DOCS/AGENT_AUTH.md
@@ -1007,6 +1007,7 @@ server/proliferate/
     │   ├── api.py                             /v1/cloud/agent-auth routes
     │   ├── service.py                         write orchestration, org-policy enforcement,
     │   │                                      re-materialize trigger
+    │   ├── harness_settings.py                settings toggle validation + upsert (not auth)
     │   └── selection_rules.py                 per-harness cardinality
     └── materialization/
         ├── service.py                         after-commit task scheduling


### PR DESCRIPTION
## Summary

- Fixes PRO-129: the "Use Claude Code with Chrome" switch in the Claude harness settings pane snapped back to off after every click for a native-login harness (the default local Claude setup), so the control appeared dead.
- Root cause: the toggle persists correctly (`agent_auth_harness_settings`), but the settings pane read the value back from the rendered `state.json` document, which only carries a harness's `settings` passenger when that harness has an enabled auth selection — the fail-closed law ("absent means native; present-but-empty fails closed") forbids a settings-only `harnesses` entry, so a native-auth harness's persisted settings were invisible on read.
- Fix: `GET /v1/cloud/agent-auth/state` now carries the surface's full persisted settings map as a second **response-only rider** (`harness_settings`), following the existing `fingerprint` rider pattern. The settings pane reads the rider (falling back to the delivered per-harness passenger for pre-rider servers), and the desktop strips it in `stampIssuingServerOrigin` before the runtime push — the delivered `state.json` contract and the cloud materializer output are byte-identical to before, so no deployed runtime sees a new shape.
- Also hardened the toggle against a latent data-loss edge: the PUT is full desired state, so committing while the selections read was still loading would have silently cleared the harness's auth sources. The switch is now disabled until both reads resolve.
- `cloud/sdk/src/generated/openapi.ts` is regenerated via `make cloud-client-generate` (only the new field).

Known gaps recorded in `specs/FEATURE_DOCS/AGENT_AUTH.md` "Current gaps" (out of scope here):
- A native-auth harness's settings still never reach the runtime's `resolve_settings_deltas` join — carrying them needs a wire-contract change the deployed runtime fleet can survive, plus the matching Rust read.
- The `--chrome` mapping lands on the agent-process sidecar's argv, and the pinned `@proliferate/claude-agent-acp` does not forward unrecognized argv to the wrapped CLI (separate repo + catalog pin bump).

## Testing

- Tier 1 unit (frontend, vitest): new `HarnessSettingsSection.test.tsx` — rider read for a native-auth harness (verified red against the unfixed read as a negative control), passenger fallback for pre-rider servers, PUT payload shape, and the no-commit-while-loading guard. Extended `local-auth-state.test.ts` — the rider is stripped before the runtime push. `pnpm vitest run src/components/settings/panes/agents/harness/ src/hooks/agents/lifecycle/use-local-auth-state-sync.test.tsx src/lib/domain/agents/local-auth-state.test.ts`: all passing (8 files / 89 tests for the harness+sync sweep, 17 for the two focused files).
- Tier 1 unit (server, pytest): new `tests/unit/test_agent_auth_settings_rider.py` — settings without a selection never ride the document (pins the render law), the payload carries the rider and it stays out of the canonical document/fingerprint, and the rider coexists with the delivered passenger. Neighboring suites `test_agent_auth_materialization.py`, `test_agent_auth_state_contract_fixture.py`, `test_agent_gateway_domain.py`: 51 passed.
- `tsc --noEmit` (product-client), `ruff check`/`format --check` (changed server files), `check_server_boundaries.py`, `check_frontend_boundaries.py`, `check_design_attribution.py`, `check_docs.py`: all passing.

## Observability

- none (no new logs/metrics; the rider is a read-path response field).

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- Negative control: reverting only the component's rider read makes `HarnessSettingsSection.test.tsx > reads the persisted toggle from the harness_settings rider for a native-auth harness` fail; restoring the fix turns it green.
- Delivery-contract safety: the renderer (`render_agent_auth_state`) is untouched — the rider is attached at the API payload layer only, the cloud materializer path never sees it, and the desktop strips it before `apply_state_file`, pinned by the new strip test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## CI repair (commit 516e58ee5)

- `agent_gateway/service.py` had grown to 827 lines, past its 813-line max-lines allowlist entry. `put_harness_settings` moved verbatim to a new `server/cloud/agent_gateway/harness_settings.py` service module — settings are explicitly not auth, and the store layer already draws this exact seam (`db/store/agent_gateway/harness_settings.py`). `api.py` now calls the new module; a local variable in the state endpoint was renamed to avoid shadowing the module import.
- **Constitution flag — allowlist entry removed, not added:** `service.py` lands at 799 lines, back under the 800 server-layer cap, and `check_max_lines.py` fails on stale allowlist entries, so its `scripts/max_lines_allowlist.txt` line (813) is deleted. This removes an exception (ratchet tightening); the checker itself and all coverage are untouched.
- Re-verified: `check_max_lines.py`, `check_server_boundaries.py`, `check_docs.py` pass; `ruff check`/`format --check` clean; focused suites green (`test_agent_auth_settings_rider.py` 3 passed; the four agent-auth/gateway unit suites 54 passed); app-import smoke of the rewired modules passes. No wire-contract change, so the generated SDK is untouched.


## Lint repair (commit 71eac119f)

- The two rider annotations in `agent_gateway/models.py` tripped the mypy explicit-any ratchet. They now use `dict[str, dict[str, object]]` — the type `service.get_auth_state` already returns; the values are catalog-declared JSON primitives validated at the write path. Pydantic renders `object` and `Any` to the same unconstrained schema, so `make cloud-client-generate` produces a byte-identical `openapi.ts` (SDK contract unchanged). Verified with the CI lint command: `check_mypy_baseline.py --compare-ref origin/main` passes (523 existing diagnostics, none new), ruff check/format clean, and the four agent-auth/gateway unit suites still pass (54).
