### PR TITLE
fix(product): keep window zoom proportional across panes and macOS chrome (PRO-166)

### DIFF
--- a/apps/desktop/src-tauri/src/commands/window_chrome.rs
+++ b/apps/desktop/src-tauri/src/commands/window_chrome.rs
@@ -18,7 +18,8 @@ impl Default for WindowChromeZoom {
 
 impl WindowChromeZoom {
     fn factor(&self) -> f64 {
-        self.0.lock().map(|guard| *guard).unwrap_or(1.0)
+        // A poisoning panic cannot tear an f64 store, so the value stays true.
+        *self.0.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 }
 
@@ -72,21 +73,20 @@ pub fn set_webview_zoom(
     }
 
     let clamped = scale_factor.clamp(0.8, 1.2);
+    // Hold the lock across zoom + store + chrome: concurrent zoom commands
+    // serialize, so the webview zoom, the stored factor, and the button
+    // layout always reflect a single command rather than an interleaving.
+    // `set_zoom` posts to the event loop without waiting, so nothing under
+    // this lock blocks on the main thread.
+    let mut guard = zoom.0.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     window.set_zoom(clamped).map_err(|error| error.to_string())?;
-    if let Ok(mut guard) = zoom.0.lock() {
-        *guard = clamped;
-    }
+    *guard = clamped;
 
     #[cfg(target_os = "macos")]
-    {
-        // Re-read the stored factor instead of using `clamped`: concurrent
-        // zoom commands then converge on whichever factor was stored last,
-        // rather than on whichever reposition happened to finish last.
-        apply_traffic_light_position(
-            window.ns_window().map_err(|error| error.to_string())?,
-            zoom.factor(),
-        )?;
-    }
+    apply_traffic_light_position(
+        window.ns_window().map_err(|error| error.to_string())?,
+        clamped,
+    )?;
 
     Ok(())
 }

--- a/apps/desktop/src-tauri/src/commands/window_chrome.rs
+++ b/apps/desktop/src-tauri/src/commands/window_chrome.rs
@@ -1,41 +1,85 @@
+use std::sync::Mutex;
+
 const MAC_TRAFFIC_LIGHT_X: f64 = 13.0;
 // Matches the shared workspace header and right-panel tab-system height.
 const MAC_HEADER_HEIGHT: f64 = 46.0;
 
+/// Webview page zoom scales the DOM header the traffic lights sit in, but the
+/// native buttons never zoom. The active factor is kept here so the buttons
+/// can be laid out against the zoomed header geometry — including when the
+/// chrome is re-applied on window focus, after AppKit resets it.
+pub struct WindowChromeZoom(Mutex<f64>);
+
+impl Default for WindowChromeZoom {
+    fn default() -> Self {
+        Self(Mutex::new(1.0))
+    }
+}
+
+impl WindowChromeZoom {
+    fn factor(&self) -> f64 {
+        self.0.lock().map(|guard| *guard).unwrap_or(1.0)
+    }
+}
+
 #[tauri::command]
-pub fn apply_macos_window_chrome(window: tauri::Window) -> Result<(), String> {
+pub fn apply_macos_window_chrome(
+    window: tauri::Window,
+    zoom: tauri::State<'_, WindowChromeZoom>,
+) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
-        apply_traffic_light_position(&window, MAC_TRAFFIC_LIGHT_X, MAC_HEADER_HEIGHT)
+        apply_traffic_light_position(
+            window.ns_window().map_err(|error| error.to_string())?,
+            zoom.factor(),
+        )
     }
 
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = window;
+        let _ = (window, zoom);
         Ok(())
     }
 }
 
 #[tauri::command]
-pub fn set_webview_zoom(window: tauri::WebviewWindow, scale_factor: f64) -> Result<(), String> {
+pub fn set_webview_zoom(
+    window: tauri::WebviewWindow,
+    zoom: tauri::State<'_, WindowChromeZoom>,
+    scale_factor: f64,
+) -> Result<(), String> {
     if !scale_factor.is_finite() {
         return Err("webview zoom scale must be finite".to_string());
     }
 
-    window
-        .set_zoom(scale_factor.clamp(0.8, 1.2))
-        .map_err(|error| error.to_string())
+    let clamped = scale_factor.clamp(0.8, 1.2);
+    window.set_zoom(clamped).map_err(|error| error.to_string())?;
+    if let Ok(mut guard) = zoom.0.lock() {
+        *guard = clamped;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        apply_traffic_light_position(
+            window.ns_window().map_err(|error| error.to_string())?,
+            clamped,
+        )?;
+    }
+
+    Ok(())
 }
 
 #[cfg(target_os = "macos")]
 fn apply_traffic_light_position(
-    window: &tauri::Window,
-    x: f64,
-    header_height: f64,
+    ns_window: *mut std::ffi::c_void,
+    scale: f64,
 ) -> Result<(), String> {
     use objc2_app_kit::{NSView, NSWindow, NSWindowButton};
+    use std::sync::OnceLock;
 
-    let ns_window = window.ns_window().map_err(|error| error.to_string())?;
+    // AppKit owns the initial layout; capture its pitch before the first
+    // reposition so scaled applications never compound on their own output.
+    static BASE_BUTTON_PITCH: OnceLock<f64> = OnceLock::new();
 
     unsafe {
         let ns_window = &*ns_window.cast::<NSWindow>();
@@ -52,13 +96,15 @@ fn apply_traffic_light_position(
             .ok_or_else(|| "title bar container view not found".to_string())?;
 
         let close_rect = NSView::frame(&close);
-        let title_bar_frame_height = header_height.max(close_rect.size.height);
+        let title_bar_frame_height = (MAC_HEADER_HEIGHT * scale).max(close_rect.size.height);
         let mut title_bar_rect = NSView::frame(&title_bar_container_view);
         title_bar_rect.size.height = title_bar_frame_height;
         title_bar_rect.origin.y = ns_window.frame().size.height - title_bar_frame_height;
         title_bar_container_view.setFrame(title_bar_rect);
 
-        let space_between = NSView::frame(&miniaturize).origin.x - close_rect.origin.x;
+        let space_between = BASE_BUTTON_PITCH
+            .get_or_init(|| NSView::frame(&miniaturize).origin.x - close_rect.origin.x)
+            * scale;
         let button_y = (title_bar_frame_height - close_rect.size.height) / 2.0;
         let mut buttons = vec![close, miniaturize];
         if let Some(zoom) = zoom {
@@ -67,7 +113,7 @@ fn apply_traffic_light_position(
 
         for (index, button) in buttons.into_iter().enumerate() {
             let mut rect = NSView::frame(&button);
-            rect.origin.x = x + (index as f64 * space_between);
+            rect.origin.x = (MAC_TRAFFIC_LIGHT_X * scale) + (index as f64 * space_between);
             rect.origin.y = button_y;
             button.setFrameOrigin(rect.origin);
         }

--- a/apps/desktop/src-tauri/src/commands/window_chrome.rs
+++ b/apps/desktop/src-tauri/src/commands/window_chrome.rs
@@ -5,9 +5,9 @@ const MAC_TRAFFIC_LIGHT_X: f64 = 13.0;
 const MAC_HEADER_HEIGHT: f64 = 46.0;
 
 /// Webview page zoom scales the DOM header the traffic lights sit in, but the
-/// native buttons never zoom. The active factor is kept here so the buttons
-/// can be laid out against the zoomed header geometry — including when the
-/// chrome is re-applied on window focus, after AppKit resets it.
+/// native buttons never zoom. The active factor is kept here so every chrome
+/// application — boot, resize, focus, zoom change — lays the buttons out
+/// against the zoomed header geometry.
 pub struct WindowChromeZoom(Mutex<f64>);
 
 impl Default for WindowChromeZoom {
@@ -20,6 +20,25 @@ impl WindowChromeZoom {
     fn factor(&self) -> f64 {
         self.0.lock().map(|guard| *guard).unwrap_or(1.0)
     }
+}
+
+/// Applies the scaled chrome outside a command context. The window config no
+/// longer pins the traffic lights (the runtime would re-pin them unscaled on
+/// every redraw), so lib.rs calls this before first paint and on `Resized`,
+/// where AppKit re-lays the standard buttons out to their defaults.
+pub fn reapply_window_chrome<R: tauri::Runtime>(window: &tauri::Window<R>) {
+    #[cfg(target_os = "macos")]
+    {
+        use tauri::Manager;
+
+        let scale = window.state::<WindowChromeZoom>().factor();
+        if let Ok(ns_window) = window.ns_window() {
+            let _ = apply_traffic_light_position(ns_window, scale);
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    let _ = window;
 }
 
 #[tauri::command]
@@ -60,9 +79,12 @@ pub fn set_webview_zoom(
 
     #[cfg(target_os = "macos")]
     {
+        // Re-read the stored factor instead of using `clamped`: concurrent
+        // zoom commands then converge on whichever factor was stored last,
+        // rather than on whichever reposition happened to finish last.
         apply_traffic_light_position(
             window.ns_window().map_err(|error| error.to_string())?,
-            clamped,
+            zoom.factor(),
         )?;
     }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -217,6 +217,7 @@ pub fn run() {
         .manage(renderer_diagnostic_log)
         .manage(workspace_activity_indicator::WorkspaceActivityIndicatorStore::default())
         .manage(ssh_tunnel::SshTunnelState::default())
+        .manage(window_chrome::WindowChromeZoom::default())
         .invoke_handler(tauri::generate_handler![
             anonymous_telemetry::load_anonymous_telemetry_bootstrap,
             anonymous_telemetry::save_anonymous_telemetry_state,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -282,7 +282,14 @@ pub fn run() {
     });
 
     #[cfg(target_os = "macos")]
-    let builder = builder.on_window_event(quit_flow::handle_window_event);
+    let builder = builder.on_window_event(|window, event| {
+        quit_flow::handle_window_event(window, event);
+        // AppKit re-lays the standard window buttons out to their defaults on
+        // resize; keep them on the zoom-scaled chrome geometry.
+        if window.label() == "main" && matches!(event, tauri::WindowEvent::Resized(_)) {
+            window_chrome::reapply_window_chrome(window);
+        }
+    });
 
     builder
         .setup(move |app| {
@@ -300,6 +307,9 @@ pub fn run() {
                 if let Some(window) = app.get_webview_window("main") {
                     use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial};
                     let _ = apply_vibrancy(&window, NSVisualEffectMaterial::Sidebar, None, None);
+                }
+                if let Some(window) = app.get_window("main") {
+                    window_chrome::reapply_window_chrome(&window);
                 }
             }
 

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -25,11 +25,7 @@
         "dragDropEnabled": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "transparent": true,
-        "trafficLightPosition": {
-          "x": 13,
-          "y": 16
-        }
+        "transparent": true
       }
     ],
     "security": {

--- a/apps/desktop/src-tauri/tauri.dev.json
+++ b/apps/desktop/src-tauri/tauri.dev.json
@@ -15,8 +15,7 @@
         "dragDropEnabled": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "transparent": true,
-        "trafficLightPosition": { "x": 13, "y": 16 }
+        "transparent": true
       }
     ]
   },

--- a/apps/packages/product-client/src/app/authenticated-workspace-shell-motion.test.ts
+++ b/apps/packages/product-client/src/app/authenticated-workspace-shell-motion.test.ts
@@ -2,21 +2,45 @@ import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 
 const stylesheetPath = new URL("./authenticated.css", import.meta.url);
+const consumerPaths = [
+  new URL(
+    "../components/workspace/shell/sidebar/WorkspaceShellSidebar.tsx",
+    import.meta.url,
+  ),
+  new URL(
+    "../components/workspace/shell/screen/WorkspaceShellRightRail.tsx",
+    import.meta.url,
+  ),
+  new URL(
+    "../components/workspace/shell/topbar/GlobalHeader.tsx",
+    import.meta.url,
+  ),
+];
 
 describe("authenticated workspace shell motion", () => {
-  it("registers synchronized length variables and uses reduced-motion-aware roles", async () => {
+  it("keeps the geometry vars unregistered and snap-duration aware", async () => {
     const stylesheet = await readFile(stylesheetPath, "utf8");
 
-    expect(stylesheet).toContain("@property --workspace-left-width");
-    expect(stylesheet).toContain("@property --workspace-right-width");
-    expect(stylesheet).toContain("syntax: \"<length>\"");
-    expect(stylesheet).toContain("transition-property: --workspace-left-width, --workspace-right-width");
+    // Registering the vars as <length> makes WebKit apply page zoom to them
+    // twice (once at the custom property, once at the consumer), rendering
+    // the panes at width·zoom² under window zoom (PRO-166).
+    expect(stylesheet).not.toContain("@property --workspace-left-width");
+    expect(stylesheet).not.toContain("@property --workspace-right-width");
+
     expect(stylesheet).toContain("var(--duration-panel)");
-    expect(stylesheet).toContain("var(--ease-out-cubic)");
     expect(stylesheet).toContain("[data-snap-left-geometry=\"true\"]");
     expect(stylesheet).toContain("[data-snap-right-geometry=\"true\"]");
     expect(stylesheet).toContain("--workspace-left-geometry-duration: 0ms");
     expect(stylesheet).toContain("--workspace-right-geometry-duration: 0ms");
-    expect(stylesheet).toContain("[data-manual-workspace-geometry=\"true\"]");
+  });
+
+  it("eases each geometry consumer against the shared snap durations", async () => {
+    for (const consumerPath of consumerPaths) {
+      const source = await readFile(consumerPath, "utf8");
+      expect(source).toMatch(
+        /\[transition-duration:var\(--workspace-(left|right)-geometry-duration\)\]/,
+      );
+      expect(source).toContain("ease-out-cubic");
+    }
   });
 });

--- a/apps/packages/product-client/src/app/authenticated.css
+++ b/apps/packages/product-client/src/app/authenticated.css
@@ -1,24 +1,14 @@
 /* Authenticated-only interaction styles stay behind the lazy product boundary
  * so chat affordances do not consume the public login shell's CSS budget. */
 
-@property --workspace-left-width {
-  syntax: "<length>";
-  inherits: true;
-  initial-value: 0px;
-}
-
-@property --workspace-right-width {
-  syntax: "<length>";
-  inherits: true;
-  initial-value: 0px;
-}
-
+/* --workspace-left-width/--workspace-right-width stay unregistered on
+   purpose: WebKit applies page zoom to a registered <length> custom property
+   once when it computes and again at the consumer, so a zoomed window renders
+   the panes at width·zoom² (PRO-166). Each consumer eases its own concrete
+   property against these shared durations instead. */
 .standard-workspace-shell {
   --workspace-left-geometry-duration: var(--duration-panel);
   --workspace-right-geometry-duration: var(--duration-panel);
-  transition-property: --workspace-left-width, --workspace-right-width;
-  transition-duration: var(--workspace-left-geometry-duration), var(--workspace-right-geometry-duration);
-  transition-timing-function: var(--ease-out-cubic), var(--ease-out-cubic);
 }
 
 /* A live left-separator drag and the explicitly snapped toggle path both
@@ -33,10 +23,6 @@
    the collapse a drag past the threshold triggers, which clears this flag. */
 .standard-workspace-shell[data-snap-right-geometry="true"] {
   --workspace-right-geometry-duration: 0ms;
-}
-
-.standard-workspace-shell[data-manual-workspace-geometry="true"] {
-  transition: none;
 }
 
 /* Transcript Markdown owns one scoped semantic type contract. The body scale

--- a/apps/packages/product-client/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
@@ -104,7 +104,6 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
       ? rightPanelWidth
       : 0,
     snapLeft: sidebarResizing,
-    snapRight: rightPanelResizing,
     onToggleLeft: actions.onToggleSidebar,
   });
   const chromeClasses = useMemo(
@@ -224,7 +223,6 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
               <WorkspaceShellShortcuts enabled={visible} />
             ) : null}
             <div
-              ref={workspaceGeometry.rootRef}
               // relative: the collapsed sidebar's hover peek is an overlay
               // anchored to this shell box, so it never displaces content.
               className={`standard-workspace-shell relative h-screen flex overflow-hidden ${chromeClasses.root}`}
@@ -237,9 +235,6 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
               } as CSSProperties}
               data-snap-left-geometry={workspaceGeometry.snapLeft ? "true" : "false"}
               data-snap-right-geometry={rightPanelResizing ? "true" : "false"}
-              data-manual-workspace-geometry={
-                workspaceGeometry.usesManualInterpolation ? "true" : "false"
-              }
               data-workspace-shell
               data-workspace-ui-key={selectedLogicalWorkspaceId ?? selectedWorkspaceId ?? ""}
               data-workspace-session-id={activeSessionId ?? ""}

--- a/apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceShellRightRail.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/WorkspaceShellRightRail.tsx
@@ -47,12 +47,12 @@ export function WorkspaceShellRightRail({
         // rather than a disappearance: the same panel duration that animates an
         // explicit toggle animates the collapse the drag triggered, and
         // `prefers-reduced-motion` zeroes `--duration-panel` so the panel snaps
-        // shut instead.
+        // shut instead. Live drags zero the geometry duration instead of
+        // easing, so the edge lands on the cursor every frame.
         // The min() clamp keeps MAIN_PANE_MIN_WIDTH of this flex row for the
         // chat pane: the rail yields before the composer collapses. 100%
-        // resolves against the row, and the registered width property still
-        // animates inside the clamp.
-        className="relative isolate shrink-0 overflow-hidden bg-sidebar-background"
+        // resolves against the row.
+        className="relative isolate shrink-0 overflow-hidden bg-sidebar-background transition-[width] ease-out-cubic [transition-duration:var(--workspace-right-geometry-duration)]"
         style={{ width: `min(var(--workspace-right-width), calc(100% - ${MAIN_PANE_MIN_WIDTH}px))` }}
         data-right-panel-rail
       >

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.tsx
@@ -77,7 +77,7 @@ export function WorkspaceShellSidebar({
       </div>
 
       <div
-        className={`relative shrink-0 ${
+        className={`relative shrink-0 transition-[width] ease-out-cubic [transition-duration:var(--workspace-left-geometry-duration)] ${
           open || toggleClosing
             ? "isolate overflow-hidden"
             : "pointer-events-none z-overlay"
@@ -119,7 +119,7 @@ export function WorkspaceShellSidebar({
       {showAnimatedDivider ? (
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-y-0 z-raised w-px bg-border"
+          className="pointer-events-none absolute inset-y-0 z-raised w-px bg-border transition-[left] ease-out-cubic [transition-duration:var(--workspace-left-geometry-duration)]"
           style={{ left: "max(-1px, calc(var(--workspace-left-width) - 1px))" }}
           data-workspace-left-divider
         />

--- a/apps/packages/product-client/src/components/workspace/shell/topbar/GlobalHeader.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/topbar/GlobalHeader.tsx
@@ -98,7 +98,7 @@ export const GlobalHeader = memo(function GlobalHeader({
   return (
     <DebugProfiler id="global-header">
       <div
-        className="flex h-full min-w-0 flex-1 items-center gap-1 pr-2"
+        className="flex h-full min-w-0 flex-1 items-center gap-1 pr-2 transition-[padding-left] ease-out-cubic [transition-duration:var(--workspace-left-geometry-duration)]"
         style={{
           paddingLeft: "max(8px, calc(var(--workspace-left-header-dwell) - var(--workspace-left-width)))",
         }}
@@ -123,7 +123,7 @@ export const GlobalHeader = memo(function GlobalHeader({
 
         <DebugProfiler id="global-header-actions">
           <div
-            className="flex shrink-0 items-center gap-1.5"
+            className="flex shrink-0 items-center gap-1.5 transition-[padding-right] ease-out-cubic [transition-duration:var(--workspace-right-geometry-duration)]"
             style={{
               paddingRight: "max(0px, calc(36px - var(--workspace-right-width)))",
             }}

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-shell-geometry.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-shell-geometry.test.tsx
@@ -2,49 +2,30 @@
 
 import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { motion } from "@proliferate/design/motion";
 import { useWorkspaceShellGeometry } from "#product/hooks/workspaces/ui/use-workspace-shell-geometry";
-
-function stubReducedMotion(matches: boolean): void {
-  vi.stubGlobal("matchMedia", vi.fn(() => ({
-    matches,
-    media: "(prefers-reduced-motion: reduce)",
-    onchange: null,
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  })));
-}
 
 function GeometryHarness({
   leftWidth,
   rightWidth,
   snapLeft = false,
-  snapRight = false,
   onToggleLeft = () => {},
 }: {
   leftWidth: number;
   rightWidth: number;
   snapLeft?: boolean;
-  snapRight?: boolean;
   onToggleLeft?: () => void;
 }) {
   const geometry = useWorkspaceShellGeometry({
     leftWidth,
     rightWidth,
     snapLeft,
-    snapRight,
     onToggleLeft,
   });
   return (
     <>
       <div
-        ref={geometry.rootRef}
         style={geometry.style}
         data-testid="geometry"
-        data-manual={geometry.usesManualInterpolation ? "true" : "false"}
         data-snap={geometry.snapLeft ? "true" : "false"}
       />
       <button type="button" onClick={() => geometry.toggleLeft({ snapGeometry: true })}>
@@ -64,48 +45,7 @@ afterEach(() => {
 });
 
 describe("useWorkspaceShellGeometry", () => {
-  it("leaves interpolation to CSS when registered properties are supported", () => {
-    vi.stubGlobal("CSS", { registerProperty: vi.fn() });
-    stubReducedMotion(false);
-    const { getByTestId, rerender } = render(
-      <GeometryHarness leftWidth={0} rightWidth={0} />,
-    );
-
-    rerender(<GeometryHarness leftWidth={280} rightWidth={360} />);
-    const root = getByTestId("geometry");
-    expect(root.dataset.manual).toBe("false");
-    expect(root.style.getPropertyValue("--workspace-left-width")).toBe("280px");
-    expect(root.style.getPropertyValue("--workspace-right-width")).toBe("360px");
-  });
-
-  it("drives unsupported renderers with one time-based rAF loop", () => {
-    vi.stubGlobal("CSS", {});
-    stubReducedMotion(false);
-    const frames: FrameRequestCallback[] = [];
-    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
-      frames.push(callback);
-      return frames.length;
-    });
-    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
-    const { getByTestId, rerender } = render(
-      <GeometryHarness leftWidth={0} rightWidth={0} />,
-    );
-
-    rerender(<GeometryHarness leftWidth={280} rightWidth={360} />);
-    const root = getByTestId("geometry");
-    expect(root.dataset.manual).toBe("true");
-    expect(frames).toHaveLength(1);
-
-    act(() => frames.shift()?.(0));
-    act(() => frames.shift()?.(motion.duration.panelMs));
-    expect(root.style.getPropertyValue("--workspace-left-width")).toBe("280px");
-    expect(root.style.getPropertyValue("--workspace-right-width")).toBe("360px");
-  });
-
-  it("snaps unsupported renderers when reduced motion is active", () => {
-    vi.stubGlobal("CSS", {});
-    stubReducedMotion(true);
-    const requestFrame = vi.spyOn(window, "requestAnimationFrame");
+  it("publishes pane widths as unregistered geometry vars", () => {
     const { getByTestId, rerender } = render(
       <GeometryHarness leftWidth={0} rightWidth={0} />,
     );
@@ -114,73 +54,26 @@ describe("useWorkspaceShellGeometry", () => {
     const root = getByTestId("geometry");
     expect(root.style.getPropertyValue("--workspace-left-width")).toBe("280px");
     expect(root.style.getPropertyValue("--workspace-right-width")).toBe("360px");
-    expect(requestFrame).not.toHaveBeenCalled();
   });
 
-  it("applies pointer-driven right widths immediately on manual renderers", () => {
-    vi.stubGlobal("CSS", {});
-    stubReducedMotion(false);
-    const frames: FrameRequestCallback[] = [];
-    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
-      frames.push(callback);
-      return frames.length;
-    });
-    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
-    const { getByTestId, rerender } = render(
-      <GeometryHarness leftWidth={0} rightWidth={360} />,
-    );
-
-    // A drag move with only the right width changing never schedules a tween.
-    rerender(<GeometryHarness leftWidth={0} rightWidth={480} snapRight />);
-    const root = getByTestId("geometry");
-    expect(frames).toHaveLength(0);
-    expect(root.style.getPropertyValue("--workspace-right-width")).toBe("480px");
-
-    // A simultaneous left change still eases while the right lands directly.
-    rerender(<GeometryHarness leftWidth={280} rightWidth={500} snapRight />);
-    expect(root.style.getPropertyValue("--workspace-right-width")).toBe("500px");
-    expect(root.style.getPropertyValue("--workspace-left-width")).toBe("0px");
-
-    act(() => frames.shift()?.(0));
-    act(() => frames.shift()?.(motion.duration.panelMs));
-    expect(root.style.getPropertyValue("--workspace-left-width")).toBe("280px");
-    expect(root.style.getPropertyValue("--workspace-right-width")).toBe("500px");
-  });
-
-  it("applies pointer-driven left widths immediately without a release tween on manual renderers", () => {
-    vi.stubGlobal("CSS", {});
-    stubReducedMotion(false);
-    const frames: FrameRequestCallback[] = [];
-    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
-      frames.push(callback);
-      return frames.length;
-    });
-    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+  it("reports a live left drag through the snap contract", () => {
     const { getByTestId, rerender } = render(
       <GeometryHarness leftWidth={275} rightWidth={360} />,
     );
 
-    // A live left drag lands on the cursor-provided width and schedules no
-    // interpolation work for that edge.
-    rerender(
-      <GeometryHarness leftWidth={375} rightWidth={360} snapLeft />,
-    );
+    rerender(<GeometryHarness leftWidth={375} rightWidth={360} snapLeft />);
     const root = getByTestId("geometry");
     expect(root.dataset.snap).toBe("true");
-    expect(frames).toHaveLength(0);
     expect(root.style.getPropertyValue("--workspace-left-width")).toBe("375px");
 
-    // Releasing at the same target removes the snap contract without adding
-    // a 240ms tail animation after the pointer has stopped.
+    // Releasing at the same target removes the snap contract while the
+    // published geometry stays on the cursor-provided width.
     rerender(<GeometryHarness leftWidth={375} rightWidth={360} />);
     expect(root.dataset.snap).toBe("false");
-    expect(frames).toHaveLength(0);
     expect(root.style.getPropertyValue("--workspace-left-width")).toBe("375px");
   });
 
   it("clears a pending pin snap before a rapid ordinary toggle", () => {
-    vi.stubGlobal("CSS", { registerProperty: vi.fn() });
-    stubReducedMotion(false);
     const frames: FrameRequestCallback[] = [];
     const cancelFrame = vi.spyOn(window, "cancelAnimationFrame");
     vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
@@ -199,5 +92,24 @@ describe("useWorkspaceShellGeometry", () => {
     expect(getByTestId("geometry").dataset.snap).toBe("false");
     expect(cancelFrame).toHaveBeenCalled();
     expect(onToggleLeft).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases a pin snap after the double-frame handoff", () => {
+    const frames: FrameRequestCallback[] = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+    const { getByRole, getByTestId } = render(
+      <GeometryHarness leftWidth={0} rightWidth={0} />,
+    );
+
+    act(() => getByRole("button", { name: "Pin" }).click());
+    expect(getByTestId("geometry").dataset.snap).toBe("true");
+
+    act(() => frames.shift()?.(0));
+    act(() => frames.shift()?.(16));
+    expect(getByTestId("geometry").dataset.snap).toBe("false");
   });
 });

--- a/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-shell-geometry.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/use-workspace-shell-geometry.ts
@@ -1,19 +1,10 @@
 import {
   useCallback,
   useEffect,
-  useLayoutEffect,
   useRef,
   useState,
   type CSSProperties,
-  type RefObject,
 } from "react";
-import { motion } from "@proliferate/design/motion";
-import { usePrefersReducedMotion } from "#product/hooks/ui/motion/use-prefers-reduced-motion";
-
-interface WorkspaceShellWidths {
-  left: number;
-  right: number;
-}
 
 interface UseWorkspaceShellGeometryOptions {
   leftWidth: number;
@@ -23,52 +14,32 @@ interface UseWorkspaceShellGeometryOptions {
    * must not retain the open/close easing or the edge trails the cursor.
    */
   snapLeft?: boolean;
-  /**
-   * Held true while the right separator drag is live. A pointer-driven width
-   * must land exactly where the cursor is on every frame — easing it would
-   * rubber-band the panel edge behind the pointer and keep re-laying the
-   * panes out for the full panel duration after each move.
-   */
-  snapRight?: boolean;
   onToggleLeft: () => void;
 }
 
 interface WorkspaceShellGeometry {
-  rootRef: RefObject<HTMLDivElement | null>;
   style: CSSProperties;
   snapLeft: boolean;
   toggleLeft: (options?: { snapGeometry?: boolean }) => void;
-  usesManualInterpolation: boolean;
 }
 
-function needsManualInterpolation(): boolean {
-  if (typeof window === "undefined" || typeof CSS === "undefined") {
-    return false;
-  }
-  return typeof CSS.registerProperty !== "function";
-}
-
-function easeOutCubic(progress: number): number {
-  return 1 - ((1 - progress) ** 3);
-}
-
+/**
+ * Publishes the pane widths as `--workspace-left-width`/`--workspace-right-width`
+ * on the shell root. The vars stay unregistered on purpose: WebKit applies
+ * page zoom to a registered `<length>` custom property once when it computes
+ * and again at the consumer, so a zoomed window renders width·zoom² (PRO-166).
+ * Untyped vars substitute textually; each consumer eases its own concrete
+ * property (width/left/padding) against the shared geometry durations, which
+ * the snap attributes zero during pointer-driven drags.
+ */
 export function useWorkspaceShellGeometry({
   leftWidth,
   rightWidth,
   snapLeft: requestedSnapLeft = false,
-  snapRight = false,
   onToggleLeft,
 }: UseWorkspaceShellGeometryOptions): WorkspaceShellGeometry {
-  const rootRef = useRef<HTMLDivElement>(null);
-  const frameRef = useRef<number | null>(null);
   const snapClearFrameRef = useRef<number | null>(null);
   const [toggleSnapLeft, setToggleSnapLeft] = useState(false);
-  const renderedRef = useRef<WorkspaceShellWidths>({
-    left: leftWidth,
-    right: rightWidth,
-  });
-  const usesManualInterpolation = useRef(needsManualInterpolation()).current;
-  const reducedMotion = usePrefersReducedMotion();
 
   const toggleLeft = useCallback((options?: { snapGeometry?: boolean }) => {
     if (snapClearFrameRef.current !== null) {
@@ -92,88 +63,18 @@ export function useWorkspaceShellGeometry({
     });
   }, [onToggleLeft]);
 
-  const snapLeft = requestedSnapLeft || toggleSnapLeft;
-
-  useLayoutEffect(() => {
-    if (!usesManualInterpolation) {
-      renderedRef.current = { left: leftWidth, right: rightWidth };
-      return;
-    }
-
-    if (frameRef.current !== null) {
-      window.cancelAnimationFrame(frameRef.current);
-      frameRef.current = null;
-    }
-
-    const root = rootRef.current;
-    if (!root) {
-      return;
-    }
-
-    const from = renderedRef.current;
-    const target = { left: leftWidth, right: rightWidth };
-    const setWidths = (widths: WorkspaceShellWidths) => {
-      renderedRef.current = widths;
-      root.style.setProperty("--workspace-left-width", `${widths.left}px`);
-      root.style.setProperty("--workspace-right-width", `${widths.right}px`);
-    };
-
-    const animateLeft = !snapLeft && from.left !== target.left;
-    const animateRight = !snapRight && from.right !== target.right;
-    if (reducedMotion || (!animateLeft && !animateRight)) {
-      setWidths(target);
-      return;
-    }
-
-    if (snapLeft || snapRight) {
-      setWidths({
-        left: snapLeft ? target.left : from.left,
-        right: snapRight ? target.right : from.right,
-      });
-    }
-
-    let startedAt: number | null = null;
-    const tick = (timestamp: number) => {
-      startedAt ??= timestamp;
-      const progress = Math.min(1, (timestamp - startedAt) / motion.duration.panelMs);
-      const eased = easeOutCubic(progress);
-      const widths = {
-        left: animateLeft ? from.left + ((target.left - from.left) * eased) : target.left,
-        right: animateRight ? from.right + ((target.right - from.right) * eased) : target.right,
-      };
-      setWidths(widths);
-
-      if (progress < 1) {
-        frameRef.current = window.requestAnimationFrame(tick);
-      } else {
-        frameRef.current = null;
-      }
-    };
-
-    frameRef.current = window.requestAnimationFrame(tick);
-  }, [leftWidth, reducedMotion, rightWidth, snapLeft, snapRight, usesManualInterpolation]);
-
   useEffect(() => () => {
-    if (frameRef.current !== null) {
-      window.cancelAnimationFrame(frameRef.current);
-    }
     if (snapClearFrameRef.current !== null) {
       window.cancelAnimationFrame(snapClearFrameRef.current);
     }
   }, []);
 
-  const rendered = usesManualInterpolation
-    ? renderedRef.current
-    : { left: leftWidth, right: rightWidth };
-
   return {
-    rootRef,
-    snapLeft,
+    snapLeft: requestedSnapLeft || toggleSnapLeft,
     style: {
-      "--workspace-left-width": `${rendered.left}px`,
-      "--workspace-right-width": `${rendered.right}px`,
+      "--workspace-left-width": `${leftWidth}px`,
+      "--workspace-right-width": `${rightWidth}px`,
     } as CSSProperties,
     toggleLeft,
-    usesManualInterpolation,
   };
 }


### PR DESCRIPTION
## Summary

Window zoom (Cmd+= / Cmd+-) broke layout proportions in two independent ways; both are fixed here and both were verified live by DOM/AX measurement in a dev build.

**1. Workspace panes rendered at width·zoom² (the clipping/dead-band in the ticket screenshots).**
`--workspace-left-width`/`--workspace-right-width` were registered via `@property syntax: "<length>"` so they could be CSS-transitioned. WebKit applies page zoom to a registered `<length>` custom property once when the custom property computes and again at the consumer, so the sidebar column and right rail rendered at `width·zoom²` while their contents laid out at `width·zoom`: below 100% the sidebar clipped its own rows mid-glyph; above 100% a dead band opened beside them. Fix: keep the vars unregistered (textual substitution is zoom-correct) and move the open/close easing onto each consumer's concrete property (`width`, `left`, `padding-left/right`), driven by the same snap-aware `--workspace-*-geometry-duration` vars, so live drags still land on the cursor. The geometry hook's rAF fallback existed only because unregistered custom properties cannot transition; plain-property transitions run everywhere, so the manual-interpolation path, its root ref, and `data-manual-workspace-geometry` are deleted (net −180 lines).

**2. The native traffic lights didn't scale with the zoomed header.**
The webview reserves the controls corner in zoomed CSS px (`pl-[82px]`, 46px header) but the buttons sat at fixed AppKit points — overlapping the sidebar toggle at 80%, opening a gap and sinking below the header centerline at 120%. Fix: reposition the buttons (origin, pitch, title-bar height) with the active zoom factor, held in `WindowChromeZoom` managed state. The window-config `trafficLightPosition` had to go: tao and wry re-pin the buttons to the unscaled config inset from their draw hooks on every content re-layout, stomping any scaled positions (reproduced via window resize). The app now owns the layout: before first paint (setup), on `Resized`, on focus (existing renderer effect), and on zoom change; zoom commands serialize under the state lock so concurrent steps cannot leave stale chrome; the base button pitch is captured once so scaled applications never compound.

- `Cargo.lock` hunk is the mechanical version sync left behind by the release-2026-08-13 bump.
- **Constitution flag:** `authenticated-workspace-shell-motion.test.ts` pinned the registered-property motion contract (`@property` + `transition-property` on the vars). This PR intentionally inverts that contract, so the pin now asserts the vars stay **unregistered** (with the WebKit rationale inline) and that every geometry consumer eases against the shared snap durations.

Linear: [PRO-166](https://linear.app/proliferate-team/issue/PRO-166/obvious-major-sidebar-width-issues)

## Testing

- Live dev-build verification via in-page DOM measurement: at 80%/90%/110%/120% zoom, the outer sidebar column, inner `#main-sidebar`, and the published var all compute exactly `275px` (before: outer computed `275·zoom`, e.g. 220px at 80%); `window.innerWidth` confirms page zoom reflows CSS px. Native buttons measured via the accessibility tree scale as `13·z` origin / `20·z` pitch, survive window resizes, and return to the exact baseline at 100%.
- `pnpm --filter @proliferate/product-client` typecheck clean; geometry-hook, shell-motion, and all 19 workspace-shell test files pass (111 tests).
- `cargo check -p proliferate` and `cargo clippy -p proliferate` clean.

## Observability

- None: cosmetic native/window geometry. Command failures still surface through existing `Result` errors; internal re-apply paths stay silent (per-resize-tick cadence).

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Verification

- macOS Desktop: Cmd+- to 80% — sidebar rows must not clip (pre-fix: "Add a repository to get started" truncated mid-word) and the sidebar toggle must clear the traffic lights on their centerline. Cmd+= to 120% — no dead band right of the sidebar rows, no oversized corner gap. Resize the window at either zoom — geometry holds. Back to 100% — identical to pre-fix rendering. Toggle the sidebar and drag both separators — open/close still eases, drags still track the cursor exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)