### PR TITLE
feat(product): sidebar icon pairing + one-glyph git identity with hover peek

### DIFF
--- a/apps/packages/product-client/src/components/playground/WorkspaceStatusPlayground.tsx
+++ b/apps/packages/product-client/src/components/playground/WorkspaceStatusPlayground.tsx
@@ -7,7 +7,10 @@ import {
   ProductSidebarSectionHeader,
 } from "#product/components/workspace/shell/sidebar/ProductSidebarLayout";
 import { RepoGroup, type RepoGroupEnvironmentKind } from "#product/components/workspace/shell/sidebar/RepoGroup";
-import { SidebarPrimaryNavigation } from "#product/components/workspace/shell/sidebar/SidebarPrimaryNavigation";
+import {
+  SidebarPinnedNavigation,
+  SidebarScrollingNavigation,
+} from "#product/components/workspace/shell/sidebar/SidebarPrimaryNavigation";
 import { SidebarRepositoriesHeader } from "#product/components/workspace/shell/sidebar/SidebarRepositoriesHeader";
 import { WorkspaceItem } from "#product/components/workspace/shell/sidebar/WorkspaceItem";
 import type {
@@ -312,19 +315,23 @@ function FullSidebarPane() {
         style={{ width }}
       >
         <ProductSidebarBrandRow label="Proliferate" />
-        <SidebarPrimaryNavigation
+        <SidebarPinnedNavigation
           homeActive
-          workspacesActive={false}
-          workflowsActive={false}
-          supportActive={false}
           onGoHome={() => {}}
-          onGoWorkspaces={() => {}}
-          onGoWorkflows={() => {}}
-          onOpenSupport={() => {}}
           shortcutRevealVisible={shortcutReveal}
-          shortcutLabels={{ newChat: "⌘N", support: "⌘?" }}
+          newChatShortcutLabel="⌘N"
         />
         <div className="flex min-h-0 flex-col px-2">
+          <SidebarScrollingNavigation
+            workspacesActive={false}
+            workflowsActive={false}
+            supportActive={false}
+            onGoWorkspaces={() => {}}
+            onGoWorkflows={() => {}}
+            onOpenSupport={() => {}}
+            shortcutRevealVisible={shortcutReveal}
+            supportShortcutLabel="⌘?"
+          />
           <SidebarRepositoriesHeader
             repositoriesCollapsed={repositoriesCollapsed}
             filtersActive={false}

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.test.tsx
@@ -128,7 +128,9 @@ vi.mock("#product/primitives/PopoverMenuItem", () => ({
 }));
 
 vi.mock("#product/primitives/patterns/AutoHideScrollArea", () => ({
-  AutoHideScrollArea: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AutoHideScrollArea: ({ children }: { children: ReactNode }) => (
+    <div data-testid="sidebar-scroll-area">{children}</div>
+  ),
 }));
 
 vi.mock("#product/primitives/PopoverButton", () => ({
@@ -382,6 +384,41 @@ describe("MainSidebar host capabilities", () => {
     renderMainSidebar();
 
     expect(screen.getByTestId("cowork-threads")).not.toBeNull();
+  });
+});
+
+describe("MainSidebar scroll boundary", () => {
+  function navRow(name: string): HTMLElement {
+    const row = screen
+      .getAllByRole("button", { name: new RegExp(`^${name}`) })
+      .find((element) => element.getAttribute("role") === "button");
+    if (!row) {
+      throw new Error(`Expected a ${name} nav row`);
+    }
+    return row;
+  }
+
+  it("pins New chat above the scroll region", () => {
+    renderMainSidebar();
+
+    const scrollArea = screen.getByTestId("sidebar-scroll-area");
+    expect(scrollArea.contains(navRow("New chat"))).toBe(false);
+  });
+
+  it("scrolls Workspaces, Workflows and Support with the repository list", () => {
+    renderMainSidebar();
+
+    const scrollArea = screen.getByTestId("sidebar-scroll-area");
+    for (const label of ["Workspaces", "Workflows", "Support"]) {
+      expect(scrollArea.contains(navRow(label))).toBe(true);
+    }
+    // ...and above the repositories they now scroll with.
+    const repositories = screen.getByText("Repositories");
+    expect(scrollArea.contains(repositories)).toBe(true);
+    expect(
+      navRow("Support").compareDocumentPosition(repositories)
+        & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });
 

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
@@ -54,6 +54,11 @@ import { useShortcutRevealVisible } from "#product/providers/ShortcutRevealProvi
 import { useReleaseNotice } from "#product/hooks/updates/facade/use-release-notice";
 import { useRepositoryHeaderNewChat } from "#product/hooks/workspaces/ui/use-repository-header-new-chat";
 
+// Platform cannot change at runtime, so the label is resolved once rather
+// than on every render of the sidebar.
+const NEW_CHAT_SHORTCUT_LABEL = getShortcutDisplayLabel(SHORTCUTS.newDefault);
+
+
 export const MainSidebar = memo(function MainSidebar({ showRightBorder = true }: { showRightBorder?: boolean }) {
   useDebugRenderCount("workspace-sidebar");
   useSessionActivityReconciler();
@@ -233,7 +238,6 @@ export const MainSidebar = memo(function MainSidebar({ showRightBorder = true }:
     () => buildShortcutRangeLabelById(sidebarShortcutTargetIds, SHORTCUTS.workspaceByIndex),
     [sidebarShortcutTargetIds],
   );
-  const newChatShortcutLabel = getShortcutDisplayLabel(SHORTCUTS.newDefault);
 
   return (
     <DebugProfiler id="workspace-sidebar">
@@ -258,7 +262,7 @@ export const MainSidebar = memo(function MainSidebar({ showRightBorder = true }:
               homeActive={isOnHome && !selectedWorkspaceId && !pendingWorkspaceEntry}
               onGoHome={actions.handleGoHome}
               shortcutRevealVisible={shortcutRevealVisible}
-              newChatShortcutLabel={newChatShortcutLabel}
+              newChatShortcutLabel={NEW_CHAT_SHORTCUT_LABEL}
             />
           </DebugProfiler>
 

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
@@ -6,7 +6,10 @@ import { ConfirmationDialog } from "#product/primitives/patterns/ConfirmationDia
 import { DebugProfiler } from "#product/components/diagnostics/DebugProfiler";
 import { SidebarAccountFooter } from "#product/components/app/sidebar/SidebarAccountFooter";
 import { ReleaseNoticeCard } from "#product/components/workspace/shell/sidebar/ReleaseNoticeCard";
-import { SidebarPrimaryNavigation } from "#product/components/workspace/shell/sidebar/SidebarPrimaryNavigation";
+import {
+  SidebarPinnedNavigation,
+  SidebarScrollingNavigation,
+} from "#product/components/workspace/shell/sidebar/SidebarPrimaryNavigation";
 import { SidebarPinnedSection } from "#product/components/workspace/shell/sidebar/SidebarPinnedSection";
 import { SidebarRepositoriesHeader } from "#product/components/workspace/shell/sidebar/SidebarRepositoriesHeader";
 import { SidebarWorkspaceContent } from "#product/components/workspace/shell/sidebar/SidebarWorkspaceContent";
@@ -257,22 +260,29 @@ export const MainSidebar = memo(function MainSidebar({ showRightBorder = true }:
         )}>
         <ProductSidebarBody>
           <ProductSidebarBrandRow label="Proliferate" />
+          {/* Only the brand row and New chat stay pinned. Everything below
+              scrolls with the repository list. */}
           <DebugProfiler id="workspace-sidebar-primary-nav">
-            <SidebarPrimaryNavigation
+            <SidebarPinnedNavigation
               homeActive={isOnHome && !selectedWorkspaceId && !pendingWorkspaceEntry}
-              workspacesActive={isOnWorkspaces}
-              workflowsActive={isOnWorkflows}
-              supportActive={false}
               onGoHome={actions.handleGoHome}
-              onGoWorkspaces={actions.handleGoWorkspaces}
-              onGoWorkflows={actions.handleGoWorkflows}
-              onOpenSupport={handleOpenSupport}
               shortcutRevealVisible={shortcutRevealVisible}
-              shortcutLabels={primaryNavShortcutLabels}
+              newChatShortcutLabel={primaryNavShortcutLabels.newChat}
             />
           </DebugProfiler>
 
         <ProductSidebarScrollableContent>
+          <SidebarScrollingNavigation
+            workspacesActive={isOnWorkspaces}
+            workflowsActive={isOnWorkflows}
+            supportActive={false}
+            onGoWorkspaces={actions.handleGoWorkspaces}
+            onGoWorkflows={actions.handleGoWorkflows}
+            onOpenSupport={handleOpenSupport}
+            shortcutRevealVisible={shortcutRevealVisible}
+            supportShortcutLabel={primaryNavShortcutLabels.support}
+          />
+
           <WorkspaceCleanupAttentionSection
             workspaces={cleanupAttentionWorkspaces}
             onRetryCleanup={actions.handleRetryWorkspaceCleanup}

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
@@ -6,10 +6,8 @@ import { ConfirmationDialog } from "#product/primitives/patterns/ConfirmationDia
 import { DebugProfiler } from "#product/components/diagnostics/DebugProfiler";
 import { SidebarAccountFooter } from "#product/components/app/sidebar/SidebarAccountFooter";
 import { ReleaseNoticeCard } from "#product/components/workspace/shell/sidebar/ReleaseNoticeCard";
-import {
-  SidebarPinnedNavigation,
-  SidebarScrollingNavigation,
-} from "#product/components/workspace/shell/sidebar/SidebarPrimaryNavigation";
+import { SidebarPinnedNavigation } from "#product/components/workspace/shell/sidebar/SidebarPrimaryNavigation";
+import { SidebarScrollingNavigationSection } from "#product/components/workspace/shell/sidebar/SidebarScrollingNavigationSection";
 import { SidebarPinnedSection } from "#product/components/workspace/shell/sidebar/SidebarPinnedSection";
 import { SidebarRepositoriesHeader } from "#product/components/workspace/shell/sidebar/SidebarRepositoriesHeader";
 import { SidebarWorkspaceContent } from "#product/components/workspace/shell/sidebar/SidebarWorkspaceContent";
@@ -37,7 +35,6 @@ import type { SidebarWorkspaceItemState } from "#product/lib/domain/workspaces/s
 import { useCloudBilling } from "#product/hooks/cloud/facade/use-cloud-billing";
 import { useDebugRenderCount } from "#product/hooks/ui/debug/use-debug-render-count";
 import { useSidebarShortcutTargets } from "#product/hooks/workspaces/derived/use-sidebar-shortcut-targets";
-import { useOpenSupportReportWindow } from "#product/hooks/support/workflows/use-open-support-report-window";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 import { useWorkspaceDisplayNameActions } from "#product/hooks/workspaces/workflows/use-workspace-display-name-actions";
@@ -62,7 +59,6 @@ export const MainSidebar = memo(function MainSidebar({ showRightBorder = true }:
   useSessionActivityReconciler();
   const { notice, dismissNotice, openChangelog } = useReleaseNotice();
   const actions = useWorkspaceSidebarActions();
-  const { openBug: handleOpenSupport } = useOpenSupportReportWindow({ source: "sidebar" });
   const shortcutRevealVisible = useShortcutRevealVisible();
   const sidebarShortcutTargetIds = useSidebarShortcutTargets();
   const {
@@ -118,8 +114,6 @@ export const MainSidebar = memo(function MainSidebar({ showRightBorder = true }:
     onLeaveWorkspace: actions.handleGoHome,
   });
 
-  const isOnWorkflows = location.pathname.startsWith(APP_ROUTES.workflows);
-  const isOnWorkspaces = location.pathname === APP_ROUTES.workspaces;
   const isOnHome = location.pathname === APP_ROUTES.home;
   const hideRepoRoot = useWorkspaceUiStore((s) => s.hideRepoRoot);
   const pinWorkspace = useWorkspaceUiStore((s) => s.pinWorkspace);
@@ -239,10 +233,7 @@ export const MainSidebar = memo(function MainSidebar({ showRightBorder = true }:
     () => buildShortcutRangeLabelById(sidebarShortcutTargetIds, SHORTCUTS.workspaceByIndex),
     [sidebarShortcutTargetIds],
   );
-  const primaryNavShortcutLabels = useMemo(() => ({
-    newChat: getShortcutDisplayLabel(SHORTCUTS.newDefault),
-    support: getShortcutDisplayLabel(SHORTCUTS.openSupport),
-  }), []);
+  const newChatShortcutLabel = getShortcutDisplayLabel(SHORTCUTS.newDefault);
 
   return (
     <DebugProfiler id="workspace-sidebar">
@@ -267,20 +258,14 @@ export const MainSidebar = memo(function MainSidebar({ showRightBorder = true }:
               homeActive={isOnHome && !selectedWorkspaceId && !pendingWorkspaceEntry}
               onGoHome={actions.handleGoHome}
               shortcutRevealVisible={shortcutRevealVisible}
-              newChatShortcutLabel={primaryNavShortcutLabels.newChat}
+              newChatShortcutLabel={newChatShortcutLabel}
             />
           </DebugProfiler>
 
         <ProductSidebarScrollableContent>
-          <SidebarScrollingNavigation
-            workspacesActive={isOnWorkspaces}
-            workflowsActive={isOnWorkflows}
-            supportActive={false}
+          <SidebarScrollingNavigationSection
             onGoWorkspaces={actions.handleGoWorkspaces}
             onGoWorkflows={actions.handleGoWorkflows}
-            onOpenSupport={handleOpenSupport}
-            shortcutRevealVisible={shortcutRevealVisible}
-            supportShortcutLabel={primaryNavShortcutLabels.support}
           />
 
           <WorkspaceCleanupAttentionSection

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/ProductSidebarNavigation.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/ProductSidebarNavigation.tsx
@@ -16,15 +16,22 @@ export function ProductSidebarPrimaryNavigation({
   navItems,
   onNavSelect,
   shortcutRevealVisible = false,
+  gutter = true,
   className = "",
 }: {
   navItems: SidebarNavItemView[];
   onNavSelect: (id: string) => void;
   shortcutRevealVisible?: boolean;
+  /**
+   * The sidebar's own horizontal gutter. Turn it off when the nav renders
+   * inside a container that already carries one (the scrollable content's
+   * viewport), so its rows stay flush with the rows around them.
+   */
+  gutter?: boolean;
   className?: string;
 }) {
   return (
-    <nav className={`px-2 ${className}`}>
+    <nav className={`${gutter ? "px-2" : ""} ${className}`}>
       <div className="flex flex-col gap-px">
         {navItems.map((item) => (
           <ProductSidebarNavRow

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/RepoGroup.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/RepoGroup.test.tsx
@@ -21,9 +21,15 @@ vi.mock("#product/primitives/icons/platform", () => ({
 }));
 
 vi.mock("#product/primitives/icons/workspace", () => ({
-  FolderClosed: () => <span data-icon="folder-closed" />,
-  FolderFilled: () => <span data-icon="folder-filled" />,
-  FolderRemote: () => <span data-icon="folder-remote" />,
+  FolderClosed: ({ className }: { className?: string }) => (
+    <span data-icon="folder-closed" className={className} />
+  ),
+  FolderFilled: ({ className }: { className?: string }) => (
+    <span data-icon="folder-filled" className={className} />
+  ),
+  FolderRemote: ({ className }: { className?: string }) => (
+    <span data-icon="folder-remote" className={className} />
+  ),
 }));
 
 vi.mock("#product/primitives/PopoverButton", () => ({
@@ -205,6 +211,29 @@ describe("RepoGroup", () => {
 
     expect(document.querySelector('[data-icon="folder-remote"]')).toBeTruthy();
   });
+
+  it.each([
+    ["local_cloud", "folder-remote"],
+    ["local", "folder-filled"],
+  ] as const)(
+    "renders the %s repository folder glyph at the leading paired tier",
+    (environmentKind, icon) => {
+      render(
+        <RepoGroup
+          name="Repo A"
+          collapsed={false}
+          environmentKind={environmentKind}
+          onToggleCollapsed={vi.fn()}
+        >
+          <div>Workspace A</div>
+        </RepoGroup>,
+      );
+
+      const glyph = document.querySelector(`[data-icon="${icon}"]`);
+      expect(glyph?.className).toContain("icon-paired");
+      expect(glyph?.className).not.toContain("icon-indicator");
+    },
+  );
 
   it("keeps the current local folder glyph unchanged on hover", () => {
     const { rerender } = render(

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/RepoGroup.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/RepoGroup.tsx
@@ -259,11 +259,11 @@ function RepoGroupEnvironmentIcon({
   // Remote-capable repos use the fused folder+globe glyph —
   // one icon, never a badge overlay.
   if (kind === "cloud" || kind === "local_cloud") {
-    return <FolderRemote className="icon-indicator shrink-0" />;
+    return <FolderRemote className="icon-paired shrink-0" />;
   }
 
   const FolderIcon = expanded ? FolderFilled : FolderClosed;
-  return <FolderIcon className="icon-indicator shrink-0" />;
+  return <FolderIcon className="icon-paired shrink-0" />;
 }
 
 function repoMenuActionIcon(id: RepoGroupMenuAction["id"]) {

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarIndicators.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarIndicators.test.tsx
@@ -7,8 +7,15 @@ import { CircleAlert } from "#product/primitives/icons/status";
 import { Clock } from "#product/primitives/icons/core";
 import { DotCellLoader } from "#product/primitives/DotCellLoader";
 import type { SidebarStatusIndicator } from "#product/lib/domain/workspaces/sidebar/sidebar-indicators";
-import { SidebarStatusGlyph } from "#product/components/workspace/shell/sidebar/SidebarIndicators";
-import { SidebarWorkspaceGitGlyph } from "#product/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph";
+import {
+  SIDEBAR_GIT_CONFLICTS_LABEL,
+  SidebarGitConflictsAlert,
+  SidebarStatusGlyph,
+} from "#product/components/workspace/shell/sidebar/SidebarIndicators";
+import {
+  resolveSidebarWorkspaceGitIdentity,
+  SidebarWorkspaceGitGlyph,
+} from "#product/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph";
 import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
@@ -59,13 +66,17 @@ describe("SidebarStatusGlyph", () => {
   );
 
   it.each(["waiting_input", "waiting_plan"] as const)(
-    "uses the 12px waiting clock for %s",
+    "uses the quiet 12px waiting clock for %s",
     (kind) => {
       const glyph = renderGlyph(kind);
 
       expect(countElementsByType(glyph, Clock)).toBe(1);
       expect(countElementsByType(glyph, DotCellLoader)).toBe(0);
-      expect(glyphClassName(glyph)).toContain("text-sidebar-status-waiting");
+      expect(glyphClassName(glyph)).toContain("icon-compact");
+      // Waiting is a resting state: it reads in the muted row ink, not in the
+      // status ink the error and conflict alerts keep.
+      expect(glyphClassName(glyph)).toContain("text-sidebar-muted-foreground");
+      expect(glyphClassName(glyph)).not.toContain("text-sidebar-status-waiting");
     },
   );
 
@@ -108,33 +119,130 @@ describe("SidebarWorkspaceGitGlyph", () => {
     ...overrides,
   });
 
-  it("renders a PR as the stable purple identity", () => {
-    const markup = renderedGlyphMarkup(
-      <SidebarWorkspaceGitGlyph status={status()} />,
-    );
-
-    expect(markup).toContain("icon-indicator");
-    expect(markup).toContain("gap-1");
-    expect(markup).toContain("text-sidebar-status-worktree");
-    expect(markup).toContain("PR #805 · Open");
+  const prStatus = (
+    overrides: Partial<WorkspaceGitStatus["pr"] & object>,
+  ): WorkspaceGitStatus => status({
+    pr: {
+      state: "open",
+      number: 805,
+      url: "https://github.com/acme/repo/pull/805",
+      checks: "none",
+      reviewDecision: "none",
+      ...overrides,
+    },
   });
 
-  it("keeps a dim PR identity when status is unavailable", () => {
-    const markup = renderedGlyphMarkup(
-      <SidebarWorkspaceGitGlyph status={null} />,
-    );
+  it.each([
+    ["open", {}, "text-success", "solid"],
+    ["checks pending", { checks: "pending" }, "text-warning-foreground", "hollow"],
+    ["checks failing", { checks: "failing" }, "text-destructive", "solid"],
+    [
+      "changes requested",
+      { reviewDecision: "changes_requested" },
+      "text-warning-foreground",
+      "solid",
+    ],
+    ["draft", { state: "draft" }, "text-muted-foreground", "solid"],
+    ["closed", { state: "closed" }, "text-destructive", "solid"],
+  ] as const)(
+    "colours the state dot for a %s pull request",
+    (_name, overrides, toneClass, fill) => {
+      const identity = resolveSidebarWorkspaceGitIdentity(
+        prStatus(overrides),
+        "worktree",
+      );
 
-    expect(markup).toContain("text-sidebar-muted-foreground/60");
-    expect(markup).toContain("Pull request status unavailable");
-  });
+      expect(identity).toMatchObject({ kind: "pull_request", fill });
 
-  it("renders attention as a separate orange alert", () => {
+      const markup = renderedGlyphMarkup(
+        <SidebarWorkspaceGitGlyph status={prStatus(overrides)} variant="worktree" />,
+      );
+      // The branch strokes stay on the row's muted ink; only the standalone
+      // bottom-right dot carries the state.
+      expect(markup).toContain("text-sidebar-muted-foreground");
+      // Assert on the dot circle itself: the SVG root carries its own
+      // fill="none", so a looser match would pass for either fill.
+      expect(markup).toContain(
+        `<circle class="${toneClass}" cx="15" cy="15" r="3" fill="${
+          fill === "hollow" ? "none" : "currentColor"
+        }" stroke="currentColor"`,
+      );
+    },
+  );
+
+  it("renders a merged pull request as the whole glyph in the merged ink", () => {
+    const merged = prStatus({ state: "merged" });
+
+    expect(resolveSidebarWorkspaceGitIdentity(merged, "worktree"))
+      .toMatchObject({ kind: "merged_pull_request" });
+
     const markup = renderedGlyphMarkup(
-      <SidebarWorkspaceGitGlyph status={status({ attention: "ci_failing" })} />,
+      <SidebarWorkspaceGitGlyph status={merged} variant="worktree" />,
     );
 
     expect(markup).toContain("text-sidebar-status-worktree");
+    expect(markup).toContain("PR #805 · Merged");
+    // Merged is settled: the whole glyph is the signal, so there is no dot.
+    expect(markup).not.toContain('cy="15" r="3"');
+  });
+
+  it("keeps the row's own topology as the identity when there is no PR", () => {
+    const noPr = status({
+      pr: { state: "none", number: null, url: null, checks: "none", reviewDecision: "none" },
+    });
+
+    expect(resolveSidebarWorkspaceGitIdentity(noPr, "worktree"))
+      .toEqual({ kind: "worktree" });
+    expect(resolveSidebarWorkspaceGitIdentity(noPr, "cloud"))
+      .toEqual({ kind: "cloud" });
+
+    expect(renderedGlyphMarkup(
+      <SidebarWorkspaceGitGlyph status={noPr} variant="worktree" />,
+    )).toContain("rotate-90");
+    expect(renderedGlyphMarkup(
+      <SidebarWorkspaceGitGlyph status={noPr} variant="cloud" />,
+    )).toContain("Cloud workspace · no pull request");
+  });
+
+  it("falls back to topology when PR data is unknown rather than absent", () => {
+    expect(resolveSidebarWorkspaceGitIdentity(status({ pr: null }), "worktree"))
+      .toEqual({ kind: "worktree" });
+    expect(resolveSidebarWorkspaceGitIdentity(null, "cloud"))
+      .toEqual({ kind: "cloud" });
+  });
+
+  it.each(["local", "ssh"] as const)(
+    "renders no identity at all for a %s row without a PR",
+    (variant) => {
+      expect(resolveSidebarWorkspaceGitIdentity(null, variant)).toBeNull();
+      expect(renderedGlyphMarkup(
+        <SidebarWorkspaceGitGlyph status={null} variant={variant} />,
+      )).toBe("");
+    },
+  );
+
+  it("leaves check and review attention to the state dot alone", () => {
+    const markup = renderedGlyphMarkup(
+      <SidebarWorkspaceGitGlyph
+        status={prStatus({ checks: "failing" })}
+        variant="worktree"
+      />,
+    );
+
+    // The old separate alert beside the glyph said the same thing the dot
+    // already says.
+    expect(markup).not.toContain("text-sidebar-status-waiting");
+    expect(markup).not.toContain("Pull request checks failing");
+  });
+});
+
+describe("SidebarGitConflictsAlert", () => {
+  it("keeps conflicts as an alert in the row's status cell", () => {
+    const markup = renderedGlyphMarkup(<SidebarGitConflictsAlert />);
+
     expect(markup).toContain("text-sidebar-status-waiting");
-    expect(markup).toContain("Pull request checks failing");
+    expect(markup).toContain(SIDEBAR_GIT_CONFLICTS_LABEL);
+    // Same fixed cell as the activity indicators it sits in place of.
+    expect(markup).toContain("h-5 min-w-5");
   });
 });

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarIndicators.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarIndicators.test.tsx
@@ -6,16 +6,17 @@ import { describe, expect, it } from "vitest";
 import { CircleAlert } from "#product/primitives/icons/status";
 import { Clock } from "#product/primitives/icons/core";
 import { DotCellLoader } from "#product/primitives/DotCellLoader";
-import type { SidebarStatusIndicator } from "#product/lib/domain/workspaces/sidebar/sidebar-indicators";
 import {
   SIDEBAR_GIT_CONFLICTS_LABEL,
-  SidebarGitConflictsAlert,
-  SidebarStatusGlyph,
-} from "#product/components/workspace/shell/sidebar/SidebarIndicators";
+  type SidebarStatusIndicator,
+  type SidebarWorkspaceVariant,
+} from "#product/lib/domain/workspaces/sidebar/sidebar-indicators";
 import {
-  resolveSidebarWorkspaceGitIdentity,
-  SidebarWorkspaceGitGlyph,
-} from "#product/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph";
+  SidebarStatusGlyph,
+  SidebarStatusIndicatorView,
+} from "#product/components/workspace/shell/sidebar/SidebarIndicators";
+import { SidebarWorkspaceGitGlyph } from "#product/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph";
+import { resolveSidebarWorkspaceGitIdentity } from "#product/lib/domain/workspaces/git-status/sidebar-git-identity";
 import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
@@ -27,7 +28,10 @@ type GlyphTestKind =
   | "waiting_input"
   | "waiting_plan"
   | "iterating"
-  | "queued_prompt";
+  | "queued_prompt"
+  | "git_conflicts"
+  | "git_checks_failing"
+  | "git_changes_requested";
 
 function countElementsByType(node: ReactNode, targetType: unknown): number {
   if (Array.isArray(node)) {
@@ -98,6 +102,20 @@ function renderedGlyphMarkup(node: ReactNode): string {
   return renderToStaticMarkup(node as never);
 }
 
+/**
+ * The row's real path: resolve the identity once, and render the glyph only
+ * when there is one. An empty string therefore means the cell collapsed.
+ */
+function renderedIdentityMarkup(
+  status: WorkspaceGitStatus | null,
+  variant: SidebarWorkspaceVariant,
+): string {
+  const identity = resolveSidebarWorkspaceGitIdentity(status, variant);
+  return identity
+    ? renderedGlyphMarkup(<SidebarWorkspaceGitGlyph identity={identity} />)
+    : "";
+}
+
 describe("SidebarWorkspaceGitGlyph", () => {
   const status = (overrides: Partial<WorkspaceGitStatus> = {}): WorkspaceGitStatus => ({
     branch: "feature/sidebar",
@@ -154,9 +172,7 @@ describe("SidebarWorkspaceGitGlyph", () => {
 
       expect(identity).toMatchObject({ kind: "pull_request", fill });
 
-      const markup = renderedGlyphMarkup(
-        <SidebarWorkspaceGitGlyph status={prStatus(overrides)} variant="worktree" />,
-      );
+      const markup = renderedIdentityMarkup(prStatus(overrides), "worktree");
       // The branch strokes stay on the row's muted ink; only the standalone
       // bottom-right dot carries the state.
       expect(markup).toContain("text-sidebar-muted-foreground");
@@ -181,9 +197,7 @@ describe("SidebarWorkspaceGitGlyph", () => {
     expect(resolveSidebarWorkspaceGitIdentity(merged, "worktree"))
       .toMatchObject({ kind: "merged_pull_request" });
 
-    const markup = renderedGlyphMarkup(
-      <SidebarWorkspaceGitGlyph status={merged} variant="worktree" />,
-    );
+    const markup = renderedIdentityMarkup(merged, "worktree");
 
     expect(markup).toContain("text-sidebar-status-worktree");
     expect(markup).toContain("PR #805 · Merged");
@@ -201,12 +215,9 @@ describe("SidebarWorkspaceGitGlyph", () => {
     expect(resolveSidebarWorkspaceGitIdentity(noPr, "cloud"))
       .toEqual({ kind: "cloud" });
 
-    expect(renderedGlyphMarkup(
-      <SidebarWorkspaceGitGlyph status={noPr} variant="worktree" />,
-    )).toContain("rotate-90");
-    expect(renderedGlyphMarkup(
-      <SidebarWorkspaceGitGlyph status={noPr} variant="cloud" />,
-    )).toContain("Cloud workspace · no pull request");
+    expect(renderedIdentityMarkup(noPr, "worktree")).toContain("rotate-90");
+    expect(renderedIdentityMarkup(noPr, "cloud"))
+      .toContain("Cloud workspace · no pull request");
   });
 
   it("falls back to topology when PR data is unknown rather than absent", () => {
@@ -220,19 +231,12 @@ describe("SidebarWorkspaceGitGlyph", () => {
     "renders no identity at all for a %s row without a PR",
     (variant) => {
       expect(resolveSidebarWorkspaceGitIdentity(null, variant)).toBeNull();
-      expect(renderedGlyphMarkup(
-        <SidebarWorkspaceGitGlyph status={null} variant={variant} />,
-      )).toBe("");
+      expect(renderedIdentityMarkup(null, variant)).toBe("");
     },
   );
 
   it("leaves check and review attention to the state dot alone", () => {
-    const markup = renderedGlyphMarkup(
-      <SidebarWorkspaceGitGlyph
-        status={prStatus({ checks: "failing" })}
-        variant="worktree"
-      />,
-    );
+    const markup = renderedIdentityMarkup(prStatus({ checks: "failing" }), "worktree");
 
     // The old separate alert beside the glyph said the same thing the dot
     // already says.
@@ -241,13 +245,26 @@ describe("SidebarWorkspaceGitGlyph", () => {
   });
 });
 
-describe("SidebarGitConflictsAlert", () => {
+describe("git attention in the status cell", () => {
   it("keeps conflicts as an alert in the row's status cell", () => {
-    const markup = renderedGlyphMarkup(<SidebarGitConflictsAlert />);
+    const markup = renderedGlyphMarkup(
+      <SidebarStatusIndicatorView
+        indicator={{ kind: "git_conflicts", tooltip: SIDEBAR_GIT_CONFLICTS_LABEL }}
+      />,
+    );
 
     expect(markup).toContain("text-sidebar-status-waiting");
     expect(markup).toContain(SIDEBAR_GIT_CONFLICTS_LABEL);
     // Same fixed cell as the activity indicators it sits in place of.
     expect(markup).toContain("h-5 min-w-5");
+  });
+
+  it("gives failing checks the error ink and requested changes the waiting ink", () => {
+    expect(glyphClassName(renderGlyph("git_checks_failing")))
+      .toContain("text-sidebar-status-error");
+    expect(glyphClassName(renderGlyph("git_changes_requested")))
+      .toContain("text-sidebar-status-waiting");
+    expect(countElementsByType(renderGlyph("git_checks_failing"), CircleAlert)).toBe(1);
+    expect(countElementsByType(renderGlyph("git_changes_requested"), CircleAlert)).toBe(1);
   });
 });

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarIndicators.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarIndicators.test.tsx
@@ -167,6 +167,11 @@ describe("SidebarWorkspaceGitGlyph", () => {
           fill === "hollow" ? "none" : "currentColor"
         }" stroke="currentColor"`,
       );
+      // The construction itself, not just the dot: the branch column and the
+      // hook arrow are the glyph's identity, and a redraw that loses them
+      // would still satisfy every dot assertion above.
+      expect(markup).toContain('d="M5.4165 6.66664V13.3333"');
+      expect(markup).toContain('d="M8.55 4.35H11.9C13.03 4.35 13.95 5.27 13.95 6.4V9.2"');
     },
   );
 

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarIndicators.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarIndicators.tsx
@@ -28,7 +28,10 @@ export function SidebarStatusGlyph({
       return <CircleAlert className="icon-compact text-sidebar-status-error [font-size:var(--text-sidebar-row)]" />;
     case "waiting_input":
     case "waiting_plan":
-      return <Clock className="icon-compact text-sidebar-status-waiting [font-size:var(--text-sidebar-row)]" />;
+      // Quiet ink: waiting is a resting state, not an alert. The row still
+      // says why through the indicator's tooltip, and the status inks stay
+      // reserved for the states that genuinely need eyes (error, conflicts).
+      return <Clock className="icon-compact text-sidebar-muted-foreground [font-size:var(--text-sidebar-row)]" />;
     case "iterating":
     case "queued_prompt":
       return (
@@ -40,6 +43,35 @@ export function SidebarStatusGlyph({
         />
       );
   }
+}
+
+export const SIDEBAR_GIT_CONFLICTS_LABEL = "Merge conflicts in worktree";
+
+/**
+ * Merge conflicts, rendered in the row's STATUS cell rather than beside the
+ * git identity glyph. Conflicts are a "this needs you" alert like the error
+ * and waiting indicators around it, not part of the row's PR identity; the
+ * other two attention states (failing checks, changes requested) are already
+ * the identity glyph's state dot and are deliberately not repeated here.
+ *
+ * It occupies the same fixed 20px cell as `SidebarStatusIndicatorView`, so a
+ * row swapping between conflicts and live activity does not shift.
+ */
+export function SidebarGitConflictsAlert() {
+  return (
+    <Tooltip
+      content={SIDEBAR_GIT_CONFLICTS_LABEL}
+      className="flex h-5 min-w-5 shrink-0 items-center justify-center"
+    >
+      <span
+        role="img"
+        aria-label={SIDEBAR_GIT_CONFLICTS_LABEL}
+        className="flex h-5 min-w-5 items-center justify-center"
+      >
+        <CircleAlert className="icon-compact text-sidebar-status-waiting [font-size:var(--text-sidebar-row)]" />
+      </span>
+    </Tooltip>
+  );
 }
 
 export function SidebarStatusIndicatorView({

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarIndicators.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarIndicators.tsx
@@ -42,36 +42,15 @@ export function SidebarStatusGlyph({
           className="text-sidebar-muted-foreground"
         />
       );
+    // Git attention the identity glyph's state dot cannot carry. Conflicts
+    // and requested changes are "this needs you" in the waiting ink; failing
+    // checks are the harder red the error indicators use.
+    case "git_conflicts":
+    case "git_changes_requested":
+      return <CircleAlert className="icon-compact text-sidebar-status-waiting [font-size:var(--text-sidebar-row)]" />;
+    case "git_checks_failing":
+      return <CircleAlert className="icon-compact text-sidebar-status-error [font-size:var(--text-sidebar-row)]" />;
   }
-}
-
-export const SIDEBAR_GIT_CONFLICTS_LABEL = "Merge conflicts in worktree";
-
-/**
- * Merge conflicts, rendered in the row's STATUS cell rather than beside the
- * git identity glyph. Conflicts are a "this needs you" alert like the error
- * and waiting indicators around it, not part of the row's PR identity; the
- * other two attention states (failing checks, changes requested) are already
- * the identity glyph's state dot and are deliberately not repeated here.
- *
- * It occupies the same fixed 20px cell as `SidebarStatusIndicatorView`, so a
- * row swapping between conflicts and live activity does not shift.
- */
-export function SidebarGitConflictsAlert() {
-  return (
-    <Tooltip
-      content={SIDEBAR_GIT_CONFLICTS_LABEL}
-      className="flex h-5 min-w-5 shrink-0 items-center justify-center"
-    >
-      <span
-        role="img"
-        aria-label={SIDEBAR_GIT_CONFLICTS_LABEL}
-        className="flex h-5 min-w-5 items-center justify-center"
-      >
-        <CircleAlert className="icon-compact text-sidebar-status-waiting [font-size:var(--text-sidebar-row)]" />
-      </span>
-    </Tooltip>
-  );
 }
 
 export function SidebarStatusIndicatorView({

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarPrimaryNavigation.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarPrimaryNavigation.tsx
@@ -12,6 +12,10 @@ import { ProductSidebarPrimaryNavigation } from "#product/components/workspace/s
  * Support are destinations rather than the primary action; they scroll away
  * with the repository list, which is what buys that list its vertical room
  * back on short windows.
+ *
+ * The glyphs carry no size class: `SidebarNavRow`'s icon well sizes them with
+ * a `[&>svg]` compound selector that beats anything passed here, so a class
+ * on the glyph would describe a size it does not get.
  */
 
 interface SidebarPinnedNavigationProps {
@@ -31,7 +35,7 @@ export function SidebarPinnedNavigation({
     {
       id: "new-chat",
       active: homeActive,
-      icon: <AppShellNewChatIcon className="icon-indicator" />,
+      icon: <AppShellNewChatIcon />,
       label: "New chat",
       shortcutLabel: newChatShortcutLabel,
     },
@@ -71,13 +75,13 @@ export function SidebarScrollingNavigation({
     {
       id: "workspaces",
       active: workspacesActive,
-      icon: <Grid className="icon-indicator" />,
+      icon: <Grid />,
       label: "Workspaces",
     },
     {
       id: "workflows",
       active: workflowsActive,
-      icon: <Fork className="icon-indicator" />,
+      icon: <Fork />,
       label: "Workflows",
       status: (
         <span className="font-mono text-ui-sm uppercase tracking-[0.06em] text-sidebar-muted-foreground">
@@ -88,7 +92,7 @@ export function SidebarScrollingNavigation({
     {
       id: "support",
       active: supportActive,
-      icon: <LifeBuoy className="icon-indicator" strokeWidth={1.75} />,
+      icon: <LifeBuoy strokeWidth={1.75} />,
       label: "Support",
       shortcutLabel: supportShortcutLabel,
     },

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarPrimaryNavigation.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarPrimaryNavigation.tsx
@@ -4,42 +4,70 @@ import { Grid } from "#product/primitives/icons/platform";
 import type { SidebarNavItemView } from "#product/components/workspace/shell/sidebar/ProductSidebarNavigation";
 import { ProductSidebarPrimaryNavigation } from "#product/components/workspace/shell/sidebar/ProductSidebarNavigation";
 
-interface SidebarPrimaryNavigationProps {
+/**
+ * The sidebar's primary navigation, split across the scroll boundary.
+ *
+ * New chat is the one row that must always be reachable, so it stays pinned
+ * with the brand row above the scroll region. Workspaces, Workflows and
+ * Support are destinations rather than the primary action; they scroll away
+ * with the repository list, which is what buys that list its vertical room
+ * back on short windows.
+ */
+
+interface SidebarPinnedNavigationProps {
   homeActive: boolean;
-  workspacesActive: boolean;
-  workflowsActive: boolean;
-  supportActive: boolean;
   shortcutRevealVisible: boolean;
-  shortcutLabels: {
-    newChat: string;
-    support: string;
-  };
+  newChatShortcutLabel: string;
   onGoHome: () => void;
-  onGoWorkspaces: () => void;
-  onGoWorkflows: () => void;
-  onOpenSupport: () => void;
 }
 
-export function SidebarPrimaryNavigation({
+export function SidebarPinnedNavigation({
   homeActive,
-  workspacesActive,
-  workflowsActive,
-  supportActive,
   shortcutRevealVisible,
-  shortcutLabels,
+  newChatShortcutLabel,
   onGoHome,
-  onGoWorkspaces,
-  onGoWorkflows,
-  onOpenSupport,
-}: SidebarPrimaryNavigationProps) {
+}: SidebarPinnedNavigationProps) {
   const navItems: SidebarNavItemView[] = [
     {
       id: "new-chat",
       active: homeActive,
       icon: <AppShellNewChatIcon className="icon-indicator" />,
       label: "New chat",
-      shortcutLabel: shortcutLabels.newChat,
+      shortcutLabel: newChatShortcutLabel,
     },
+  ];
+
+  return (
+    <ProductSidebarPrimaryNavigation
+      navItems={navItems}
+      onNavSelect={onGoHome}
+      shortcutRevealVisible={shortcutRevealVisible}
+    />
+  );
+}
+
+interface SidebarScrollingNavigationProps {
+  workspacesActive: boolean;
+  workflowsActive: boolean;
+  supportActive: boolean;
+  shortcutRevealVisible: boolean;
+  supportShortcutLabel: string;
+  onGoWorkspaces: () => void;
+  onGoWorkflows: () => void;
+  onOpenSupport: () => void;
+}
+
+export function SidebarScrollingNavigation({
+  workspacesActive,
+  workflowsActive,
+  supportActive,
+  shortcutRevealVisible,
+  supportShortcutLabel,
+  onGoWorkspaces,
+  onGoWorkflows,
+  onOpenSupport,
+}: SidebarScrollingNavigationProps) {
+  const navItems: SidebarNavItemView[] = [
     {
       id: "workspaces",
       active: workspacesActive,
@@ -62,15 +90,12 @@ export function SidebarPrimaryNavigation({
       active: supportActive,
       icon: <LifeBuoy className="icon-indicator" strokeWidth={1.75} />,
       label: "Support",
-      shortcutLabel: shortcutLabels.support,
+      shortcutLabel: supportShortcutLabel,
     },
   ];
 
   const handleNavSelect = (id: string) => {
     switch (id) {
-      case "new-chat":
-        onGoHome();
-        break;
       case "workspaces":
         onGoWorkspaces();
         break;
@@ -90,6 +115,9 @@ export function SidebarPrimaryNavigation({
       navItems={navItems}
       onNavSelect={handleNavSelect}
       shortcutRevealVisible={shortcutRevealVisible}
+      // The scroll viewport already carries the sidebar gutter; a second one
+      // would step these rows in from the repository rows beneath them.
+      gutter={false}
     />
   );
 }

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarScrollingNavigationSection.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarScrollingNavigationSection.tsx
@@ -1,4 +1,5 @@
 import { useLocation } from "react-router-dom";
+import { DebugProfiler } from "#product/components/diagnostics/DebugProfiler";
 import { SidebarScrollingNavigation } from "#product/components/workspace/shell/sidebar/SidebarPrimaryNavigation";
 import { APP_ROUTES } from "#product/config/app-routes";
 import { SHORTCUTS } from "#product/config/shortcuts/registry";
@@ -29,15 +30,20 @@ export function SidebarScrollingNavigationSection({
   const { openBug: handleOpenSupport } = useOpenSupportReportWindow({ source: "sidebar" });
 
   return (
-    <SidebarScrollingNavigation
-      workspacesActive={location.pathname === APP_ROUTES.workspaces}
-      workflowsActive={location.pathname.startsWith(APP_ROUTES.workflows)}
-      supportActive={false}
-      onGoWorkspaces={onGoWorkspaces}
-      onGoWorkflows={onGoWorkflows}
-      onOpenSupport={handleOpenSupport}
-      shortcutRevealVisible={shortcutRevealVisible}
-      supportShortcutLabel={getShortcutDisplayLabel(SHORTCUTS.openSupport)}
-    />
+    // These rows kept profiler coverage while they rendered inside the pinned
+    // nav's profiler; splitting the navigation must not silently drop them
+    // out of the render-cost picture.
+    <DebugProfiler id="workspace-sidebar-scrolling-nav">
+      <SidebarScrollingNavigation
+        workspacesActive={location.pathname === APP_ROUTES.workspaces}
+        workflowsActive={location.pathname.startsWith(APP_ROUTES.workflows)}
+        supportActive={false}
+        onGoWorkspaces={onGoWorkspaces}
+        onGoWorkflows={onGoWorkflows}
+        onOpenSupport={handleOpenSupport}
+        shortcutRevealVisible={shortcutRevealVisible}
+        supportShortcutLabel={getShortcutDisplayLabel(SHORTCUTS.openSupport)}
+      />
+    </DebugProfiler>
   );
 }

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarScrollingNavigationSection.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarScrollingNavigationSection.tsx
@@ -7,6 +7,10 @@ import { useOpenSupportReportWindow } from "#product/hooks/support/workflows/use
 import { getShortcutDisplayLabel } from "#product/lib/domain/shortcuts/matching";
 import { useShortcutRevealVisible } from "#product/providers/ShortcutRevealProvider";
 
+// Platform cannot change at runtime, so the label is resolved once rather
+// than on every render of the section.
+const SUPPORT_SHORTCUT_LABEL = getShortcutDisplayLabel(SHORTCUTS.openSupport);
+
 interface SidebarScrollingNavigationSectionProps {
   onGoWorkspaces: () => void;
   onGoWorkflows: () => void;
@@ -42,7 +46,7 @@ export function SidebarScrollingNavigationSection({
         onGoWorkflows={onGoWorkflows}
         onOpenSupport={handleOpenSupport}
         shortcutRevealVisible={shortcutRevealVisible}
-        supportShortcutLabel={getShortcutDisplayLabel(SHORTCUTS.openSupport)}
+        supportShortcutLabel={SUPPORT_SHORTCUT_LABEL}
       />
     </DebugProfiler>
   );

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarScrollingNavigationSection.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarScrollingNavigationSection.tsx
@@ -1,0 +1,43 @@
+import { useLocation } from "react-router-dom";
+import { SidebarScrollingNavigation } from "#product/components/workspace/shell/sidebar/SidebarPrimaryNavigation";
+import { APP_ROUTES } from "#product/config/app-routes";
+import { SHORTCUTS } from "#product/config/shortcuts/registry";
+import { useOpenSupportReportWindow } from "#product/hooks/support/workflows/use-open-support-report-window";
+import { getShortcutDisplayLabel } from "#product/lib/domain/shortcuts/matching";
+import { useShortcutRevealVisible } from "#product/providers/ShortcutRevealProvider";
+
+interface SidebarScrollingNavigationSectionProps {
+  onGoWorkspaces: () => void;
+  onGoWorkflows: () => void;
+}
+
+/**
+ * The destination rows that scroll with the repository list, and the wiring
+ * only they need.
+ *
+ * Route matching, the support-window opener and the Support shortcut label
+ * were the sidebar host's to hold while these rows rendered from it; they
+ * belong with the rows instead, so `MainSidebar` stays the composition point
+ * rather than the wiring point.
+ */
+export function SidebarScrollingNavigationSection({
+  onGoWorkspaces,
+  onGoWorkflows,
+}: SidebarScrollingNavigationSectionProps) {
+  const location = useLocation();
+  const shortcutRevealVisible = useShortcutRevealVisible();
+  const { openBug: handleOpenSupport } = useOpenSupportReportWindow({ source: "sidebar" });
+
+  return (
+    <SidebarScrollingNavigation
+      workspacesActive={location.pathname === APP_ROUTES.workspaces}
+      workflowsActive={location.pathname.startsWith(APP_ROUTES.workflows)}
+      supportActive={false}
+      onGoWorkspaces={onGoWorkspaces}
+      onGoWorkflows={onGoWorkflows}
+      onOpenSupport={handleOpenSupport}
+      shortcutRevealVisible={shortcutRevealVisible}
+      supportShortcutLabel={getShortcutDisplayLabel(SHORTCUTS.openSupport)}
+    />
+  );
+}

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceContent.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceContent.tsx
@@ -254,6 +254,7 @@ export function SidebarWorkspaceContent({
           <>
             <SidebarWorkspaceItems
               items={visibleItems}
+              repoName={group.name}
               shortcutLabelByWorkspaceId={shortcutLabelByWorkspaceId}
               shortcutRevealVisible={shortcutRevealVisible}
               onSelectWorkspace={onSelectWorkspace}

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph.tsx
@@ -1,62 +1,139 @@
-import { GitPullRequest } from "#product/primitives/icons/workspace-git";
-import { CircleAlert } from "#product/primitives/icons/status";
+import type { ReactNode } from "react";
+import { Fork } from "#product/primitives/icons/core";
+import { CloudIcon } from "#product/primitives/icons/platform";
+import {
+  GitBranchIcon,
+  GitBranchStatusIcon,
+  type GitBranchStatusDotFill,
+} from "#product/primitives/icons/workspace-git";
+import { statusDotToneTextClass, type StatusDotTone } from "#product/primitives/StatusDot";
 import { Tooltip } from "#product/primitives/Tooltip";
-import { prStatusCompoundLabel } from "#product/lib/domain/workspaces/git-status/pr-status-presentation";
-import type {
-  WorkspaceGitAttention,
-  WorkspaceGitStatus,
-} from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
+import {
+  prStatusCompoundLabel,
+  prStatusTone,
+  prStatusViewFromGitStatus,
+} from "#product/lib/domain/workspaces/git-status/pr-status-presentation";
+import type { SidebarWorkspaceVariant } from "#product/lib/domain/workspaces/sidebar/sidebar-indicators";
+import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
+
+/**
+ * What the row's trailing identity cell says about a workspace. Exactly one
+ * of these, or nothing at all — the cell is omitted rather than filled with a
+ * placeholder, so a row that has no git identity to report stays quiet.
+ */
+export type SidebarWorkspaceGitIdentity =
+  /** A live PR: branch glyph + the state dot. */
+  | { kind: "pull_request"; tone: StatusDotTone; fill: GitBranchStatusDotFill; label: string }
+  /** A settled PR reads as the whole glyph in the merged ink, with no dot. */
+  | { kind: "merged_pull_request"; label: string }
+  /** No PR — the cell falls back to what the workspace IS. */
+  | { kind: "worktree" }
+  | { kind: "cloud" };
+
+const IDENTITY_GLYPH_CLASS = "icon-indicator [font-size:var(--text-sidebar-row)]";
+
+const WORKTREE_LABEL = "Worktree · no pull request";
+const CLOUD_LABEL = "Cloud workspace · no pull request";
+
+/**
+ * Resolves the ONE identity a workspace row's trailing cell shows.
+ *
+ * A PR wins whenever the branch has one, because it is the strongest thing
+ * true about the row; without a PR the cell falls back to the workspace's own
+ * topology (worktree / cloud). Local and SSH rows resolve to null: a local
+ * checkout with no PR has no git identity worth a permanent glyph, and the
+ * dim always-on placeholder that used to fill this cell is what made the
+ * column read as noise.
+ *
+ * Exported so the row can decide whether the identity cell exists at all
+ * before rendering into it.
+ */
+export function resolveSidebarWorkspaceGitIdentity(
+  status: WorkspaceGitStatus | null,
+  variant: SidebarWorkspaceVariant,
+): SidebarWorkspaceGitIdentity | null {
+  // Null for both "no PR on this branch" (authoritative) and "PR data
+  // unknown" — neither is something to draw.
+  const view = prStatusViewFromGitStatus(status);
+  if (view) {
+    const label = prStatusCompoundLabel(status) ?? "Pull request";
+    if (view.kind === "merged") {
+      return { kind: "merged_pull_request", label };
+    }
+    const { tone, fill } = prStatusTone(view.kind);
+    return { kind: "pull_request", tone, fill, label };
+  }
+
+  switch (variant) {
+    case "worktree":
+      return { kind: "worktree" };
+    case "cloud":
+      return { kind: "cloud" };
+    case "local":
+    case "ssh":
+      return null;
+  }
+}
 
 interface SidebarWorkspaceGitGlyphProps {
   status: WorkspaceGitStatus | null;
+  variant: SidebarWorkspaceVariant;
 }
 
 /**
- * Stable PR identity for the sidebar's trailing area. Every row keeps the PR
- * glyph in place: purple when a PR exists, dim when it does not or status is
- * unavailable. Git attention is a separate orange alert so it does not mutate
- * or replace the row's PR identity.
+ * The workspace row's single trailing git-identity glyph.
+ *
+ * Git attention is NOT rendered here. Failing checks and requested changes
+ * are already the state dot's colour, so repeating them beside the glyph
+ * said the same thing twice; merge conflicts are an activity-style alert and
+ * live in the row's status cell instead.
  */
-export function SidebarWorkspaceGitGlyph({ status }: SidebarWorkspaceGitGlyphProps) {
-  const hasPullRequest = Boolean(status?.pr && status.pr.state !== "none");
-  const pullRequestLabel = hasPullRequest
-    ? prStatusCompoundLabel(status) ?? "Pull request"
-    : status?.pr?.state === "none"
-      ? "No pull request"
-      : "Pull request status unavailable";
-  const attentionLabel = gitAttentionLabel(status?.attention ?? "none");
-  return (
-    <span className="inline-flex shrink-0 items-center gap-1">
-      <Tooltip content={pullRequestLabel} className="inline-flex items-center justify-center">
-        <span role="img" aria-label={pullRequestLabel}>
-          <GitPullRequest
-            className={`icon-indicator [font-size:var(--text-sidebar-row)] ${hasPullRequest
-              ? "text-sidebar-status-worktree"
-              : "text-sidebar-muted-foreground/60"
-            }`}
+export function SidebarWorkspaceGitGlyph({ status, variant }: SidebarWorkspaceGitGlyphProps) {
+  const identity = resolveSidebarWorkspaceGitIdentity(status, variant);
+  if (!identity) {
+    return null;
+  }
+
+  switch (identity.kind) {
+    case "merged_pull_request":
+      return (
+        <IdentityGlyph label={identity.label}>
+          <GitBranchIcon className={`${IDENTITY_GLYPH_CLASS} text-sidebar-status-worktree`} />
+        </IdentityGlyph>
+      );
+    case "pull_request":
+      return (
+        <IdentityGlyph label={identity.label}>
+          <GitBranchStatusIcon
+            className={`${IDENTITY_GLYPH_CLASS} text-sidebar-muted-foreground`}
+            dotClassName={statusDotToneTextClass(identity.tone)}
+            dotFill={identity.fill}
           />
-        </span>
-      </Tooltip>
-      {attentionLabel ? (
-        <Tooltip content={attentionLabel} className="inline-flex items-center justify-center">
-          <span role="img" aria-label={attentionLabel}>
-            <CircleAlert className="icon-indicator text-sidebar-status-waiting [font-size:var(--text-sidebar-row)]" />
-          </span>
-        </Tooltip>
-      ) : null}
-    </span>
-  );
+        </IdentityGlyph>
+      );
+    case "worktree":
+      return (
+        <IdentityGlyph label={WORKTREE_LABEL}>
+          {/* Horizontal fork: the branch-off reading, rhyming with the
+              Workflows nav glyph rather than inventing a second one. */}
+          <Fork className={`${IDENTITY_GLYPH_CLASS} rotate-90 text-sidebar-muted-foreground`} />
+        </IdentityGlyph>
+      );
+    case "cloud":
+      return (
+        <IdentityGlyph label={CLOUD_LABEL}>
+          <CloudIcon className={`${IDENTITY_GLYPH_CLASS} text-sidebar-muted-foreground`} />
+        </IdentityGlyph>
+      );
+  }
 }
 
-function gitAttentionLabel(attention: WorkspaceGitAttention): string | null {
-  switch (attention) {
-    case "conflicts":
-      return "Merge conflicts in worktree";
-    case "ci_failing":
-      return "Pull request checks failing";
-    case "changes_requested":
-      return "Pull request changes requested";
-    case "none":
-      return null;
-  }
+function IdentityGlyph({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <Tooltip content={label} className="inline-flex items-center justify-center">
+      <span role="img" aria-label={label} className="inline-flex items-center justify-center">
+        {children}
+      </span>
+    </Tooltip>
+  );
 }

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph.tsx
@@ -1,99 +1,34 @@
 import type { ReactNode } from "react";
 import { Fork } from "#product/primitives/icons/core";
 import { CloudIcon } from "#product/primitives/icons/platform";
-import {
-  GitBranchIcon,
-  GitBranchStatusIcon,
-  type GitBranchStatusDotFill,
-} from "#product/primitives/icons/workspace-git";
-import { statusDotToneTextClass, type StatusDotTone } from "#product/primitives/StatusDot";
+import { GitBranchIcon, GitBranchStatusIcon } from "#product/primitives/icons/workspace-git";
+import { statusDotToneTextClass } from "#product/primitives/StatusDot";
 import { Tooltip } from "#product/primitives/Tooltip";
 import {
-  prStatusCompoundLabel,
-  prStatusTone,
-  prStatusViewFromGitStatus,
-} from "#product/lib/domain/workspaces/git-status/pr-status-presentation";
-import type { SidebarWorkspaceVariant } from "#product/lib/domain/workspaces/sidebar/sidebar-indicators";
-import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
-
-/**
- * What the row's trailing identity cell says about a workspace. Exactly one
- * of these, or nothing at all — the cell is omitted rather than filled with a
- * placeholder, so a row that has no git identity to report stays quiet.
- */
-export type SidebarWorkspaceGitIdentity =
-  /** A live PR: branch glyph + the state dot. */
-  | { kind: "pull_request"; tone: StatusDotTone; fill: GitBranchStatusDotFill; label: string }
-  /** A settled PR reads as the whole glyph in the merged ink, with no dot. */
-  | { kind: "merged_pull_request"; label: string }
-  /** No PR — the cell falls back to what the workspace IS. */
-  | { kind: "worktree" }
-  | { kind: "cloud" };
+  SIDEBAR_GIT_IDENTITY_CLOUD_LABEL,
+  SIDEBAR_GIT_IDENTITY_WORKTREE_LABEL,
+  type SidebarWorkspaceGitIdentity,
+} from "#product/lib/domain/workspaces/git-status/sidebar-git-identity";
 
 const IDENTITY_GLYPH_CLASS = "icon-indicator [font-size:var(--text-sidebar-row)]";
 
-const WORKTREE_LABEL = "Worktree · no pull request";
-const CLOUD_LABEL = "Cloud workspace · no pull request";
-
-/**
- * Resolves the ONE identity a workspace row's trailing cell shows.
- *
- * A PR wins whenever the branch has one, because it is the strongest thing
- * true about the row; without a PR the cell falls back to the workspace's own
- * topology (worktree / cloud). Local and SSH rows resolve to null: a local
- * checkout with no PR has no git identity worth a permanent glyph, and the
- * dim always-on placeholder that used to fill this cell is what made the
- * column read as noise.
- *
- * Exported so the row can decide whether the identity cell exists at all
- * before rendering into it.
- */
-export function resolveSidebarWorkspaceGitIdentity(
-  status: WorkspaceGitStatus | null,
-  variant: SidebarWorkspaceVariant,
-): SidebarWorkspaceGitIdentity | null {
-  // Null for both "no PR on this branch" (authoritative) and "PR data
-  // unknown" — neither is something to draw.
-  const view = prStatusViewFromGitStatus(status);
-  if (view) {
-    const label = prStatusCompoundLabel(status) ?? "Pull request";
-    if (view.kind === "merged") {
-      return { kind: "merged_pull_request", label };
-    }
-    const { tone, fill } = prStatusTone(view.kind);
-    return { kind: "pull_request", tone, fill, label };
-  }
-
-  switch (variant) {
-    case "worktree":
-      return { kind: "worktree" };
-    case "cloud":
-      return { kind: "cloud" };
-    case "local":
-    case "ssh":
-      return null;
-  }
-}
-
 interface SidebarWorkspaceGitGlyphProps {
-  status: WorkspaceGitStatus | null;
-  variant: SidebarWorkspaceVariant;
+  identity: SidebarWorkspaceGitIdentity;
 }
 
 /**
  * The workspace row's single trailing git-identity glyph.
  *
+ * Takes the already-resolved identity rather than the raw status: the row
+ * needs the same answer to decide whether the cell exists at all, and
+ * resolving it a second time here invited the two to disagree.
+ *
  * Git attention is NOT rendered here. Failing checks and requested changes
- * are already the state dot's colour, so repeating them beside the glyph
- * said the same thing twice; merge conflicts are an activity-style alert and
- * live in the row's status cell instead.
+ * are already the state dot's colour on an open PR, so repeating them beside
+ * the glyph said the same thing twice; the attention the dot cannot carry is
+ * an alert in the row's status cell instead.
  */
-export function SidebarWorkspaceGitGlyph({ status, variant }: SidebarWorkspaceGitGlyphProps) {
-  const identity = resolveSidebarWorkspaceGitIdentity(status, variant);
-  if (!identity) {
-    return null;
-  }
-
+export function SidebarWorkspaceGitGlyph({ identity }: SidebarWorkspaceGitGlyphProps) {
   switch (identity.kind) {
     case "merged_pull_request":
       return (
@@ -113,7 +48,7 @@ export function SidebarWorkspaceGitGlyph({ status, variant }: SidebarWorkspaceGi
       );
     case "worktree":
       return (
-        <IdentityGlyph label={WORKTREE_LABEL}>
+        <IdentityGlyph label={SIDEBAR_GIT_IDENTITY_WORKTREE_LABEL}>
           {/* Horizontal fork: the branch-off reading, rhyming with the
               Workflows nav glyph rather than inventing a second one. */}
           <Fork className={`${IDENTITY_GLYPH_CLASS} rotate-90 text-sidebar-muted-foreground`} />
@@ -121,7 +56,7 @@ export function SidebarWorkspaceGitGlyph({ status, variant }: SidebarWorkspaceGi
       );
     case "cloud":
       return (
-        <IdentityGlyph label={CLOUD_LABEL}>
+        <IdentityGlyph label={SIDEBAR_GIT_IDENTITY_CLOUD_LABEL}>
           <CloudIcon className={`${IDENTITY_GLYPH_CLASS} text-sidebar-muted-foreground`} />
         </IdentityGlyph>
       );

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceItems.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarWorkspaceItems.tsx
@@ -1,11 +1,18 @@
 import type { SidebarIndicatorAction } from "#product/lib/domain/workspaces/sidebar/sidebar-indicators";
 import type { SidebarWorkspaceItemState } from "#product/lib/domain/workspaces/sidebar/sidebar-model";
 import type { WorkspaceAvailabilityCommandKind } from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
+import { formatRelativeTime } from "#product/lib/domain/workspaces/display/workspace-display";
 import { useWorkspaceCopyActions } from "#product/hooks/workspaces/workflows/use-workspace-copy-actions";
 import { WorkspaceItem } from "#product/components/workspace/shell/sidebar/WorkspaceItem";
 
 export interface SidebarWorkspaceItemsProps {
   items: SidebarWorkspaceItemState[];
+  /**
+   * Owning repository shown in the hover peek card. Repo group bodies pass
+   * their group name; rows rendered outside a group (Pinned) fall back to the
+   * item's own repo name.
+   */
+  repoName?: string | null;
   shortcutLabelByWorkspaceId: ReadonlyMap<string, string>;
   shortcutRevealVisible: boolean;
   onSelectWorkspace: (workspaceId: string) => void;
@@ -37,6 +44,7 @@ export interface SidebarWorkspaceItemsProps {
  */
 export function SidebarWorkspaceItems({
   items,
+  repoName = null,
   shortcutLabelByWorkspaceId,
   shortcutRevealVisible,
   onSelectWorkspace,
@@ -67,6 +75,10 @@ export function SidebarWorkspaceItems({
       variant={item.variant}
       statusIndicator={item.statusIndicator}
       branchName={item.branchName}
+      repoName={repoName ?? item.repoName}
+      lastActivityLabel={item.lastInteracted
+        ? formatRelativeTime(item.lastInteracted)
+        : null}
       gitStatus={item.gitStatus}
       needsReview={item.needsReview}
       shortcutLabel={shortcutLabelByWorkspaceId.get(item.id) ?? null}

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.test.tsx
@@ -117,7 +117,7 @@ describe("WorkspaceItem", () => {
     expect(onCopyBranchName).toHaveBeenCalledTimes(1);
   });
 
-  it("renders PR status as the left identity glyph", () => {
+  it("renders PR status as the trailing identity glyph", () => {
     renderWithProductHost(
       <WorkspaceItem
         name="Feature worktree"
@@ -147,7 +147,7 @@ describe("WorkspaceItem", () => {
     expect(cells?.children).toHaveLength(2);
   });
 
-  it("keeps a dim PR identity for an authoritative no-PR branch", () => {
+  it("falls back to the worktree identity for a branch with no PR", () => {
     renderWithProductHost(
       <WorkspaceItem
         name="Feature worktree"
@@ -164,10 +164,10 @@ describe("WorkspaceItem", () => {
       />,
     );
 
-    expect(screen.getByRole("img", { name: "No pull request" })).toBeTruthy();
+    expect(screen.getByRole("img", { name: "Worktree · no pull request" })).toBeTruthy();
   });
 
-  it("keeps a dim PR identity when PR data is unknown", () => {
+  it("falls back to the worktree identity when PR data is unknown", () => {
     renderWithProductHost(
       <WorkspaceItem
         name="Feature worktree"
@@ -176,18 +176,26 @@ describe("WorkspaceItem", () => {
       />,
     );
 
-    expect(screen.getByRole("img", { name: "Pull request status unavailable" })).toBeTruthy();
+    expect(screen.getByRole("img", { name: "Worktree · no pull request" })).toBeTruthy();
   });
 
-  it("keeps the PR identity in place for cloud workspaces", () => {
+  it("shows the cloud identity for a cloud workspace without a PR", () => {
     renderWithProductHost(
       <WorkspaceItem name="Cloud workspace" variant="cloud" />,
     );
 
-    expect(screen.getByRole("img", { name: "Pull request status unavailable" })).toBeTruthy();
+    expect(screen.getByRole("img", { name: "Cloud workspace · no pull request" })).toBeTruthy();
   });
 
-  it("shows git attention beside the PR identity", () => {
+  it("leaves the identity cell out entirely for a local row without a PR", () => {
+    const { container } = renderWithProductHost(
+      <WorkspaceItem name="Local workspace" variant="local" />,
+    );
+
+    expect(container.querySelector("[data-sidebar-trailing-identity]")).toBeNull();
+  });
+
+  it("does not repeat check attention that the state dot already carries", () => {
     renderWithProductHost(
       <WorkspaceItem
         name="Feature worktree"
@@ -197,8 +205,36 @@ describe("WorkspaceItem", () => {
     );
 
     expect(screen.getByRole("img", { name: "PR #805 · Open" })).toBeTruthy();
-    expect(screen.getByRole("img", { name: "Pull request changes requested" }))
-      .toBeTruthy();
+    expect(screen.queryByRole("img", { name: "Pull request changes requested" }))
+      .toBeNull();
+  });
+
+  it("puts merge conflicts in the status cell, not beside the identity glyph", () => {
+    renderWithProductHost(
+      <WorkspaceItem
+        name="Feature worktree"
+        variant="worktree"
+        gitStatus={makeGitStatus({ conflicted: true, attention: "conflicts" })}
+      />,
+    );
+
+    const alert = screen.getByRole("img", { name: "Merge conflicts in worktree" });
+    expect(alert.closest("[data-sidebar-trailing-status]")).not.toBeNull();
+    expect(alert.closest("[data-sidebar-trailing-identity]")).toBeNull();
+  });
+
+  it("lets live activity beat the conflicts alert in the status cell", () => {
+    renderWithProductHost(
+      <WorkspaceItem
+        name="Feature worktree"
+        variant="worktree"
+        statusIndicator={{ kind: "iterating", tooltip: "Iterating" }}
+        gitStatus={makeGitStatus({ conflicted: true, attention: "conflicts" })}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "Iterating" })).toBeTruthy();
+    expect(screen.queryByRole("img", { name: "Merge conflicts in worktree" })).toBeNull();
   });
 
   it("shows the unread dot in the right slot when the row needs review", () => {

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.test.tsx
@@ -6,6 +6,7 @@ import type { ReactElement } from "react";
 import type { ProductHost } from "@proliferate/product-client/host/product-host";
 import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
 import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
+import { sidebarGitAttentionIndicator } from "#product/lib/domain/workspaces/sidebar/sidebar-indicators";
 import { WorkspaceItem } from "#product/components/workspace/shell/sidebar/WorkspaceItem";
 import { WORKSPACE_PEEK_DELAY_MS } from "#product/components/workspace/shell/sidebar/WorkspacePeekCard";
 
@@ -211,31 +212,22 @@ describe("WorkspaceItem", () => {
   });
 
   it("puts merge conflicts in the status cell, not beside the identity glyph", () => {
+    const conflicted = makeGitStatus({ conflicted: true, attention: "conflicts" });
     renderWithProductHost(
       <WorkspaceItem
         name="Feature worktree"
         variant="worktree"
-        gitStatus={makeGitStatus({ conflicted: true, attention: "conflicts" })}
+        // The row is handed the indicator the domain waterfall builds, rather
+        // than deriving conflicts itself. Resolved through the real function
+        // so the two cannot drift apart.
+        statusIndicator={sidebarGitAttentionIndicator(conflicted)}
+        gitStatus={conflicted}
       />,
     );
 
     const alert = screen.getByRole("img", { name: "Merge conflicts in worktree" });
     expect(alert.closest("[data-sidebar-trailing-status]")).not.toBeNull();
     expect(alert.closest("[data-sidebar-trailing-identity]")).toBeNull();
-  });
-
-  it("lets live activity beat the conflicts alert in the status cell", () => {
-    renderWithProductHost(
-      <WorkspaceItem
-        name="Feature worktree"
-        variant="worktree"
-        statusIndicator={{ kind: "iterating", tooltip: "Iterating" }}
-        gitStatus={makeGitStatus({ conflicted: true, attention: "conflicts" })}
-      />,
-    );
-
-    expect(screen.getByRole("img", { name: "Iterating" })).toBeTruthy();
-    expect(screen.queryByRole("img", { name: "Merge conflicts in worktree" })).toBeNull();
   });
 
   it("shows the unread dot in the right slot when the row needs review", () => {

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactElement } from "react";
 import type { ProductHost } from "@proliferate/product-client/host/product-host";
 import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
 import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
 import { WorkspaceItem } from "#product/components/workspace/shell/sidebar/WorkspaceItem";
+import { WORKSPACE_PEEK_DELAY_MS } from "#product/components/workspace/shell/sidebar/WorkspacePeekCard";
 
 const webTestHost = { desktop: null } as ProductHost;
 
@@ -261,6 +262,35 @@ describe("WorkspaceItem", () => {
 
     expect(screen.getByRole("img", { name: "Iterating" })).toBeTruthy();
     expect(screen.queryByRole("img", { name: "Unseen activity" })).toBeNull();
+  });
+
+  it("opens the hover peek card from the row itself", () => {
+    vi.useFakeTimers();
+    try {
+      renderWithProductHost(
+        <WorkspaceItem
+          name="Feature worktree"
+          variant="worktree"
+          repoName="proliferate"
+          lastActivityLabel="38m ago"
+          gitStatus={makeGitStatus()}
+          onSelect={vi.fn()}
+        />,
+      );
+
+      const row = screen.getByText("Feature worktree").closest('[role="button"]');
+      fireEvent.pointerEnter(row!);
+      act(() => {
+        vi.advanceTimersByTime(WORKSPACE_PEEK_DELAY_MS);
+      });
+
+      const card = document.querySelector("[data-workspace-peek-card]");
+      expect(card).not.toBeNull();
+      expect(card?.textContent).toContain("proliferate");
+      expect(card?.textContent).toContain("PR #805 · Open");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("opens the pull request from the context menu", () => {

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.test.tsx
@@ -288,6 +288,12 @@ describe("WorkspaceItem", () => {
       expect(card).not.toBeNull();
       expect(card?.textContent).toContain("proliferate");
       expect(card?.textContent).toContain("PR #805 · Open");
+
+      // Closing has its own forwarding chain to survive: the row's
+      // `onPointerLeave` has to clear `ProductSidebarWorkspaceRow`'s Omit list
+      // and both spreads to reach `SidebarRowSurface`.
+      fireEvent.pointerLeave(row!);
+      expect(document.querySelector("[data-workspace-peek-card]")).toBeNull();
     } finally {
       vi.useRealTimers();
     }

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
@@ -34,6 +34,7 @@ import {
   SidebarWorkspaceGitGlyph,
 } from "#product/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph";
 import { WorkspaceDeleteConfirmMenu } from "#product/components/workspace/shell/sidebar/WorkspaceDeleteConfirmMenu";
+import { useWorkspacePeek } from "#product/components/workspace/shell/sidebar/WorkspacePeekCard";
 import { WorkspaceItemMenu } from "#product/components/workspace/shell/sidebar/WorkspaceItemMenu";
 import { WorkspaceRenamePopover } from "#product/components/workspace/shell/sidebar/WorkspaceRenamePopover";
 import { ProductSidebarWorkspaceRow } from "#product/components/workspace/shell/sidebar/ProductSidebarRepositories";
@@ -65,6 +66,10 @@ interface WorkspaceItemProps {
   shortcutRevealVisible?: boolean;
   /** Current git branch, shown read-only in the three-dot menu git section. */
   branchName?: string | null;
+  /** Owning repository, shown in the hover peek card. */
+  repoName?: string | null;
+  /** Relative last-activity label ("38m ago") for the hover peek card. */
+  lastActivityLabel?: string | null;
   /**
    * Composed git/PR status. Together with `variant` it decides the trailing
    * identity glyph and its tooltip; it also drives the conflicts alert in the
@@ -111,6 +116,8 @@ export function WorkspaceItem({
   shortcutLabel = null,
   shortcutRevealVisible = false,
   branchName = null,
+  repoName = null,
+  lastActivityLabel = null,
   gitStatus = null,
   needsReview = false,
   onSelect,
@@ -223,6 +230,14 @@ export function WorkspaceItem({
     />
   ) : null;
 
+  const { onPointerEnter, onPointerLeave, peekCard } = useWorkspacePeek({
+    name,
+    time: lastActivityLabel,
+    repo: repoName,
+    branch: branchName ?? gitStatus?.branch ?? null,
+    gitStatus,
+  });
+
   const row = (
     <ProductSidebarWorkspaceRow
       active={active}
@@ -236,7 +251,11 @@ export function WorkspaceItem({
       hoverAction={workspaceMenu}
       onSelect={onSelect}
       onContextMenuCapture={onContextMenuCapture}
-      onPointerEnter={onHover}
+      onPointerEnter={(event) => {
+        onHover?.();
+        onPointerEnter(event);
+      }}
+      onPointerLeave={onPointerLeave}
       data-sidebar-workspace-item={workspaceId ?? ""}
       data-sidebar-workspace-variant={variant}
     />
@@ -383,7 +402,7 @@ export function WorkspaceItem({
   );
 
   if (!onRename) {
-    return contextMenu;
+    return <>{contextMenu}{peekCard}</>;
   }
 
   // Wrap with a controlled rename popover. The trigger is a span containing
@@ -392,16 +411,19 @@ export function WorkspaceItem({
   // bonus affordance. Using doubleClick avoids conflicting with onSelect
   // (single click) and the existing right-click context menu.
   return (
-    <WorkspaceRenamePopover
-      currentName={name}
-      defaultName={defaultName ?? name}
-      hasOverride={hasDisplayNameOverride}
-      onRename={onRename}
-      externalOpen={renameOpen}
-      onOpenChange={(isOpen) => {
-        if (!isOpen) setRenameOpen(false);
-      }}
-      trigger={<div>{contextMenu}</div>}
-    />
+    <>
+      <WorkspaceRenamePopover
+        currentName={name}
+        defaultName={defaultName ?? name}
+        hasOverride={hasDisplayNameOverride}
+        onRename={onRename}
+        externalOpen={renameOpen}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) setRenameOpen(false);
+        }}
+        trigger={<div>{contextMenu}</div>}
+      />
+      {peekCard}
+    </>
   );
 }

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
@@ -25,15 +25,8 @@ import type {
   WorkspaceAvailabilityCommandKind,
 } from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
 import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
-import {
-  SidebarGitConflictsAlert,
-  SidebarStatusIndicatorView,
-} from "#product/components/workspace/shell/sidebar/SidebarIndicators";
-import {
-  resolveSidebarWorkspaceGitIdentity,
-  SidebarWorkspaceGitGlyph,
-} from "#product/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph";
 import { WorkspaceDeleteConfirmMenu } from "#product/components/workspace/shell/sidebar/WorkspaceDeleteConfirmMenu";
+import { resolveWorkspaceItemTrailingCells } from "#product/components/workspace/shell/sidebar/WorkspaceItemTrailing";
 import { useWorkspacePeek } from "#product/components/workspace/shell/sidebar/WorkspacePeekCard";
 import { WorkspaceItemMenu } from "#product/components/workspace/shell/sidebar/WorkspaceItemMenu";
 import { WorkspaceRenamePopover } from "#product/components/workspace/shell/sidebar/WorkspaceRenamePopover";
@@ -147,22 +140,15 @@ export function WorkspaceItem({
   const handlePinCommand = () => onPin?.();
   const handleUnpinCommand = () => onUnpin?.();
   const handleMarkDoneCommand = () => setDoneConfirmOpen(true);
-  // The identity cell exists only when there is an identity to put in it, so
-  // a local row with no PR collapses the cell instead of reserving 20px for
-  // nothing.
-  const trailingIdentity = resolveSidebarWorkspaceGitIdentity(gitStatus, variant)
-    ? <SidebarWorkspaceGitGlyph status={gitStatus} variant={variant} />
-    : null;
-  // Right-slot precedence: live activity first, then merge conflicts (the one
-  // git attention state the identity glyph's dot does not already carry).
-  const trailingStatus = statusIndicator ? (
-    <SidebarStatusIndicatorView
-      indicator={statusIndicator}
-      onAction={onIndicatorAction}
-    />
-  ) : gitStatus?.attention === "conflicts" ? (
-    <SidebarGitConflictsAlert />
-  ) : null;
+  const {
+    identity: trailingIdentity,
+    status: trailingStatus,
+  } = resolveWorkspaceItemTrailingCells({
+    gitStatus,
+    variant,
+    statusIndicator,
+    onIndicatorAction,
+  });
   const pullRequestUrl = gitStatus?.pr?.url ?? null;
   const pullRequestNumber = gitStatus?.pr?.number ?? null;
   const handleOpenPullRequestCommand = pullRequestUrl && onOpenPullRequest

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
@@ -26,9 +26,13 @@ import type {
 } from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
 import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
 import {
+  SidebarGitConflictsAlert,
   SidebarStatusIndicatorView,
 } from "#product/components/workspace/shell/sidebar/SidebarIndicators";
-import { SidebarWorkspaceGitGlyph } from "#product/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph";
+import {
+  resolveSidebarWorkspaceGitIdentity,
+  SidebarWorkspaceGitGlyph,
+} from "#product/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph";
 import { WorkspaceDeleteConfirmMenu } from "#product/components/workspace/shell/sidebar/WorkspaceDeleteConfirmMenu";
 import { WorkspaceItemMenu } from "#product/components/workspace/shell/sidebar/WorkspaceItemMenu";
 import { WorkspaceRenamePopover } from "#product/components/workspace/shell/sidebar/WorkspaceRenamePopover";
@@ -62,8 +66,9 @@ interface WorkspaceItemProps {
   /** Current git branch, shown read-only in the three-dot menu git section. */
   branchName?: string | null;
   /**
-   * Composed git/PR status. Drives the persistent PR glyph tone, its tooltip,
-   * the separate attention alert, and the "Open pull request" menu item.
+   * Composed git/PR status. Together with `variant` it decides the trailing
+   * identity glyph and its tooltip; it also drives the conflicts alert in the
+   * status cell and the "Open pull request" menu item.
    */
   gitStatus?: WorkspaceGitStatus | null;
   /** Renders the trailing unseen-activity dot. */
@@ -135,7 +140,22 @@ export function WorkspaceItem({
   const handlePinCommand = () => onPin?.();
   const handleUnpinCommand = () => onUnpin?.();
   const handleMarkDoneCommand = () => setDoneConfirmOpen(true);
-  const trailingIdentity = <SidebarWorkspaceGitGlyph status={gitStatus} />;
+  // The identity cell exists only when there is an identity to put in it, so
+  // a local row with no PR collapses the cell instead of reserving 20px for
+  // nothing.
+  const trailingIdentity = resolveSidebarWorkspaceGitIdentity(gitStatus, variant)
+    ? <SidebarWorkspaceGitGlyph status={gitStatus} variant={variant} />
+    : null;
+  // Right-slot precedence: live activity first, then merge conflicts (the one
+  // git attention state the identity glyph's dot does not already carry).
+  const trailingStatus = statusIndicator ? (
+    <SidebarStatusIndicatorView
+      indicator={statusIndicator}
+      onAction={onIndicatorAction}
+    />
+  ) : gitStatus?.attention === "conflicts" ? (
+    <SidebarGitConflictsAlert />
+  ) : null;
   const pullRequestUrl = gitStatus?.pr?.url ?? null;
   const pullRequestNumber = gitStatus?.pr?.number ?? null;
   const handleOpenPullRequestCommand = pullRequestUrl && onOpenPullRequest
@@ -207,12 +227,7 @@ export function WorkspaceItem({
     <ProductSidebarWorkspaceRow
       active={active}
       archived={archived}
-      trailingStatus={statusIndicator ? (
-        <SidebarStatusIndicatorView
-          indicator={statusIndicator}
-          onAction={onIndicatorAction}
-        />
-      ) : null}
+      trailingStatus={trailingStatus}
       trailingIdentity={trailingIdentity}
       label={name}
       unreadDot={needsReview}

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx
@@ -1,20 +1,6 @@
 import { useState } from "react";
-import { SHORTCUTS } from "#product/config/shortcuts/registry";
-import {
-  Archive,
-  Pencil,
-  Trash,
-} from "#product/primitives/icons/core";
-import { Folder, Pin } from "#product/primitives/icons/workspace";
-import {
-  GitBranchIcon,
-  GitPullRequest,
-} from "#product/primitives/icons/workspace-git";
 import { POPOVER_SURFACE_CLASS, PopoverButton } from "#product/primitives/PopoverButton";
-import { PopoverMenuItem } from "#product/primitives/PopoverMenuItem";
-import { ShortcutBadge } from "#product/primitives/ShortcutBadge";
 import { useWorkspaceSidebarNativeContextMenu } from "#product/hooks/workspaces/ui/use-workspace-sidebar-native-context-menu";
-import { getShortcutDisplayLabel } from "#product/lib/domain/shortcuts/matching";
 import type {
   SidebarIndicatorAction,
   SidebarStatusIndicator,
@@ -25,7 +11,7 @@ import type {
   WorkspaceAvailabilityCommandKind,
 } from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
 import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
-import { WorkspaceDeleteConfirmMenu } from "#product/components/workspace/shell/sidebar/WorkspaceDeleteConfirmMenu";
+import { WorkspaceItemContextMenu } from "#product/components/workspace/shell/sidebar/WorkspaceItemContextMenu";
 import { resolveWorkspaceItemTrailingCells } from "#product/components/workspace/shell/sidebar/WorkspaceItemTrailing";
 import { useWorkspacePeek } from "#product/components/workspace/shell/sidebar/WorkspacePeekCard";
 import { WorkspaceItemMenu } from "#product/components/workspace/shell/sidebar/WorkspaceItemMenu";
@@ -140,6 +126,13 @@ export function WorkspaceItem({
   const handlePinCommand = () => onPin?.();
   const handleUnpinCommand = () => onUnpin?.();
   const handleMarkDoneCommand = () => setDoneConfirmOpen(true);
+  // The context menu closes the popover itself before either of these runs,
+  // so they carry only the state and the command.
+  const handleConfirmDoneCommand = () => {
+    setDoneConfirmOpen(false);
+    onMarkDone?.();
+  };
+  const handleCancelDoneCommand = () => setDoneConfirmOpen(false);
   const {
     identity: trailingIdentity,
     status: trailingStatus,
@@ -263,126 +256,29 @@ export function WorkspaceItem({
       className={`w-64 ${POPOVER_SURFACE_CLASS}`}
     >
       {(close) => (
-        <>
-          {doneConfirmOpen ? (
-            <WorkspaceDeleteConfirmMenu
-              onConfirm={() => {
-                close();
-                setDoneConfirmOpen(false);
-                onMarkDone?.();
-              }}
-              onCancel={() => {
-                close();
-                setDoneConfirmOpen(false);
-              }}
-            />
-          ) : (
-            <>
-              {onRename && (
-                <PopoverMenuItem
-                  icon={<Pencil className="icon-paired shrink-0 text-muted-foreground" />}
-                  label="Rename"
-                  onClick={() => {
-                    close();
-                    handleRenameCommand();
-                  }}
-                />
-              )}
-              {onPin && !pinned && (
-                <PopoverMenuItem
-                  icon={<Pin className="icon-paired shrink-0 text-muted-foreground" />}
-                  label="Pin"
-                  onClick={() => { close(); handlePinCommand(); }}
-                />
-              )}
-              {onUnpin && pinned && (
-                <PopoverMenuItem
-                  icon={<Pin className="icon-paired shrink-0 text-muted-foreground" />}
-                  label="Unpin"
-                  onClick={() => { close(); handleUnpinCommand(); }}
-                />
-              )}
-              {onCopyWorkspaceLocation && (
-                <PopoverMenuItem
-                  icon={<Folder className="icon-paired shrink-0 text-muted-foreground" />}
-                  label={workspaceLocationCopyLabel ?? "Copy workspace location"}
-                  trailing={(
-                    <ShortcutBadge
-                      label={getShortcutDisplayLabel(SHORTCUTS.copyWorkspacePath)}
-                      className="text-muted-foreground"
-                    />
-                  )}
-                  onClick={() => {
-                    close();
-                    handleCopyWorkspaceLocationCommand();
-                  }}
-                />
-              )}
-              {handleOpenPullRequestCommand && (
-                <PopoverMenuItem
-                  icon={<GitPullRequest className="icon-paired shrink-0 text-muted-foreground" />}
-                  label={pullRequestNumber !== null
-                    ? `Open pull request #${pullRequestNumber}`
-                    : "Open pull request"}
-                  onClick={() => {
-                    close();
-                    handleOpenPullRequestCommand();
-                  }}
-                />
-              )}
-              {onCopyBranchName && (
-                <PopoverMenuItem
-                  icon={<GitBranchIcon className="icon-paired shrink-0 text-muted-foreground [font-size:var(--text-sidebar-row)]" />}
-                  label="Copy branch name"
-                  trailing={(
-                    <ShortcutBadge
-                      label={getShortcutDisplayLabel(SHORTCUTS.copyBranchName)}
-                      className="text-muted-foreground"
-                    />
-                  )}
-                  onClick={() => {
-                    close();
-                    handleCopyBranchNameCommand();
-                  }}
-                />
-              )}
-              {onMarkDone && (
-                <PopoverMenuItem
-                  icon={<Trash className="icon-paired shrink-0 text-muted-foreground" />}
-                  label="Delete workspace..."
-                  onClick={() => {
-                    handleMarkDoneCommand();
-                  }}
-                />
-              )}
-              {onArchive && !archived && (
-                <PopoverMenuItem
-                  icon={<Archive className="icon-paired shrink-0 text-muted-foreground" />}
-                  label="Archive..."
-                  onClick={() => { close(); handleArchiveCommand(); }}
-                />
-              )}
-              {onUnarchive && archived && (
-                <PopoverMenuItem
-                  icon={<Archive className="icon-paired shrink-0 text-muted-foreground" />}
-                  label="Unarchive"
-                  onClick={() => { close(); handleUnarchiveCommand(); }}
-                />
-              )}
-              {availabilityCommands.map((command) => (
-                <PopoverMenuItem
-                  key={command.kind}
-                  icon={<GitBranchIcon className="icon-paired shrink-0 text-muted-foreground" />}
-                  label={command.blocker ? `${command.label} — ${command.blocker}` : command.label}
-                  onClick={() => {
-                    close();
-                    onAvailabilityCommand?.(command.kind);
-                  }}
-                />
-              ))}
-            </>
-          )}
-        </>
+        <WorkspaceItemContextMenu
+          close={close}
+          archived={archived}
+          pinned={pinned}
+          workspaceLocationCopyLabel={workspaceLocationCopyLabel}
+          pullRequestNumber={pullRequestNumber}
+          doneConfirmOpen={doneConfirmOpen}
+          onConfirmDone={handleConfirmDoneCommand}
+          onCancelDone={handleCancelDoneCommand}
+          onRename={onRename ? handleRenameCommand : undefined}
+          onPin={onPin ? handlePinCommand : undefined}
+          onUnpin={onUnpin ? handleUnpinCommand : undefined}
+          onCopyWorkspaceLocation={
+            onCopyWorkspaceLocation ? handleCopyWorkspaceLocationCommand : undefined
+          }
+          onOpenPullRequest={handleOpenPullRequestCommand}
+          onCopyBranchName={onCopyBranchName ? handleCopyBranchNameCommand : undefined}
+          onMarkDone={onMarkDone ? handleMarkDoneCommand : undefined}
+          onArchive={onArchive ? handleArchiveCommand : undefined}
+          onUnarchive={onUnarchive ? handleUnarchiveCommand : undefined}
+          availabilityCommands={availabilityCommands}
+          onAvailabilityCommand={onAvailabilityCommand}
+        />
       )}
     </PopoverButton>
   );

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItemContextMenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItemContextMenu.tsx
@@ -1,0 +1,208 @@
+import { SHORTCUTS } from "#product/config/shortcuts/registry";
+import {
+  Archive,
+  Pencil,
+  Trash,
+} from "#product/primitives/icons/core";
+import { Folder, Pin } from "#product/primitives/icons/workspace";
+import {
+  GitBranchIcon,
+  GitPullRequest,
+} from "#product/primitives/icons/workspace-git";
+import { PopoverMenuItem } from "#product/primitives/PopoverMenuItem";
+import { ShortcutBadge } from "#product/primitives/ShortcutBadge";
+import { getShortcutDisplayLabel } from "#product/lib/domain/shortcuts/matching";
+import type {
+  WorkspaceAvailabilityCommand,
+  WorkspaceAvailabilityCommandKind,
+} from "#product/lib/domain/workspaces/cloud/workspace-availability-commands";
+import { WorkspaceDeleteConfirmMenu } from "#product/components/workspace/shell/sidebar/WorkspaceDeleteConfirmMenu";
+
+interface WorkspaceItemContextMenuProps {
+  /** Closes the popover. Handed down from `PopoverButton`'s render prop. */
+  close: () => void;
+  archived: boolean;
+  pinned: boolean;
+  workspaceLocationCopyLabel?: string | null;
+  /** PR number for the "Open pull request" label; null shows the bare label. */
+  pullRequestNumber?: number | null;
+  /** True while the destructive pane replaces the item list entirely. */
+  doneConfirmOpen: boolean;
+  /** Runs after `close()` when the delete confirmation is accepted. */
+  onConfirmDone: () => void;
+  /** Runs after `close()` when the delete confirmation is dismissed. */
+  onCancelDone: () => void;
+  /** Handlers are optional; omitted ones hide their menu item. */
+  onRename?: () => void;
+  onPin?: () => void;
+  onUnpin?: () => void;
+  onCopyWorkspaceLocation?: () => void;
+  onOpenPullRequest?: () => void;
+  onCopyBranchName?: () => void;
+  onMarkDone?: () => void;
+  onArchive?: () => void;
+  onUnarchive?: () => void;
+  /** Workspace-copy availability commands (PR 5), matching the native menu. */
+  availabilityCommands?: WorkspaceAvailabilityCommand[];
+  onAvailabilityCommand?: (kind: WorkspaceAvailabilityCommandKind) => void;
+}
+
+/**
+ * The right-click menu's contents for a sidebar workspace row.
+ *
+ * Split from `WorkspaceItem` for the same reason `WorkspaceItemTrailing` was:
+ * the row owns state and commands, this owns only how they read as a list.
+ * Everything here is declarative — the open/confirm state and every command
+ * handler stay on the row, so this file can be read as the menu's shape
+ * without chasing what any item actually does.
+ *
+ * `close` arrives as a prop rather than being called for the caller, because
+ * the items disagree about it: most close first and then act, while "Delete
+ * workspace..." deliberately leaves the popover open so the confirmation pane
+ * can take its place.
+ */
+export function WorkspaceItemContextMenu({
+  close,
+  archived,
+  pinned,
+  workspaceLocationCopyLabel,
+  pullRequestNumber = null,
+  doneConfirmOpen,
+  onConfirmDone,
+  onCancelDone,
+  onRename,
+  onPin,
+  onUnpin,
+  onCopyWorkspaceLocation,
+  onOpenPullRequest,
+  onCopyBranchName,
+  onMarkDone,
+  onArchive,
+  onUnarchive,
+  availabilityCommands = [],
+  onAvailabilityCommand,
+}: WorkspaceItemContextMenuProps) {
+  if (doneConfirmOpen) {
+    return (
+      <WorkspaceDeleteConfirmMenu
+        onConfirm={() => {
+          close();
+          onConfirmDone();
+        }}
+        onCancel={() => {
+          close();
+          onCancelDone();
+        }}
+      />
+    );
+  }
+
+  return (
+    <>
+      {onRename && (
+        <PopoverMenuItem
+          icon={<Pencil className="icon-paired shrink-0 text-muted-foreground" />}
+          label="Rename"
+          onClick={() => {
+            close();
+            onRename();
+          }}
+        />
+      )}
+      {onPin && !pinned && (
+        <PopoverMenuItem
+          icon={<Pin className="icon-paired shrink-0 text-muted-foreground" />}
+          label="Pin"
+          onClick={() => { close(); onPin(); }}
+        />
+      )}
+      {onUnpin && pinned && (
+        <PopoverMenuItem
+          icon={<Pin className="icon-paired shrink-0 text-muted-foreground" />}
+          label="Unpin"
+          onClick={() => { close(); onUnpin(); }}
+        />
+      )}
+      {onCopyWorkspaceLocation && (
+        <PopoverMenuItem
+          icon={<Folder className="icon-paired shrink-0 text-muted-foreground" />}
+          label={workspaceLocationCopyLabel ?? "Copy workspace location"}
+          trailing={(
+            <ShortcutBadge
+              label={getShortcutDisplayLabel(SHORTCUTS.copyWorkspacePath)}
+              className="text-muted-foreground"
+            />
+          )}
+          onClick={() => {
+            close();
+            onCopyWorkspaceLocation();
+          }}
+        />
+      )}
+      {onOpenPullRequest && (
+        <PopoverMenuItem
+          icon={<GitPullRequest className="icon-paired shrink-0 text-muted-foreground" />}
+          label={pullRequestNumber !== null
+            ? `Open pull request #${pullRequestNumber}`
+            : "Open pull request"}
+          onClick={() => {
+            close();
+            onOpenPullRequest();
+          }}
+        />
+      )}
+      {onCopyBranchName && (
+        <PopoverMenuItem
+          icon={<GitBranchIcon className="icon-paired shrink-0 text-muted-foreground [font-size:var(--text-sidebar-row)]" />}
+          label="Copy branch name"
+          trailing={(
+            <ShortcutBadge
+              label={getShortcutDisplayLabel(SHORTCUTS.copyBranchName)}
+              className="text-muted-foreground"
+            />
+          )}
+          onClick={() => {
+            close();
+            onCopyBranchName();
+          }}
+        />
+      )}
+      {onMarkDone && (
+        <PopoverMenuItem
+          icon={<Trash className="icon-paired shrink-0 text-muted-foreground" />}
+          label="Delete workspace..."
+          // No close(): the popover stays open so the confirmation pane can
+          // replace this list in place.
+          onClick={() => {
+            onMarkDone();
+          }}
+        />
+      )}
+      {onArchive && !archived && (
+        <PopoverMenuItem
+          icon={<Archive className="icon-paired shrink-0 text-muted-foreground" />}
+          label="Archive..."
+          onClick={() => { close(); onArchive(); }}
+        />
+      )}
+      {onUnarchive && archived && (
+        <PopoverMenuItem
+          icon={<Archive className="icon-paired shrink-0 text-muted-foreground" />}
+          label="Unarchive"
+          onClick={() => { close(); onUnarchive(); }}
+        />
+      )}
+      {availabilityCommands.map((command) => (
+        <PopoverMenuItem
+          key={command.kind}
+          icon={<GitBranchIcon className="icon-paired shrink-0 text-muted-foreground" />}
+          label={command.blocker ? `${command.label} — ${command.blocker}` : command.label}
+          onClick={() => {
+            close();
+            onAvailabilityCommand?.(command.kind);
+          }}
+        />
+      ))}
+    </>
+  );
+}

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItemTrailing.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItemTrailing.tsx
@@ -5,14 +5,9 @@ import type {
   SidebarWorkspaceVariant,
 } from "#product/lib/domain/workspaces/sidebar/sidebar-indicators";
 import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
-import {
-  SidebarGitConflictsAlert,
-  SidebarStatusIndicatorView,
-} from "#product/components/workspace/shell/sidebar/SidebarIndicators";
-import {
-  resolveSidebarWorkspaceGitIdentity,
-  SidebarWorkspaceGitGlyph,
-} from "#product/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph";
+import { SidebarStatusIndicatorView } from "#product/components/workspace/shell/sidebar/SidebarIndicators";
+import { SidebarWorkspaceGitGlyph } from "#product/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph";
+import { resolveSidebarWorkspaceGitIdentity } from "#product/lib/domain/workspaces/git-status/sidebar-git-identity";
 
 export interface WorkspaceItemTrailingCells {
   /** Null when the row has no git identity, so the cell collapses. */
@@ -43,19 +38,18 @@ export function resolveWorkspaceItemTrailingCells({
 }: WorkspaceItemTrailingInput): WorkspaceItemTrailingCells {
   // The identity cell exists only when there is an identity to put in it, so
   // a local row with no PR collapses the cell instead of reserving 20px for
-  // nothing.
-  const identity = resolveSidebarWorkspaceGitIdentity(gitStatus, variant)
-    ? <SidebarWorkspaceGitGlyph status={gitStatus} variant={variant} />
+  // nothing. Resolved once and handed to the glyph.
+  const gitIdentity = resolveSidebarWorkspaceGitIdentity(gitStatus, variant);
+  const identity = gitIdentity
+    ? <SidebarWorkspaceGitGlyph identity={gitIdentity} />
     : null;
-  // Right-slot precedence: live activity first, then merge conflicts (the one
-  // git attention state the identity glyph's dot does not already carry).
+  // Nothing to arbitrate here: the status cell's precedence (missing checkout,
+  // then activity, then git attention) is the domain waterfall's.
   const status = statusIndicator ? (
     <SidebarStatusIndicatorView
       indicator={statusIndicator}
       onAction={onIndicatorAction}
     />
-  ) : gitStatus?.attention === "conflicts" ? (
-    <SidebarGitConflictsAlert />
   ) : null;
 
   return { identity, status };

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItemTrailing.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItemTrailing.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from "react";
+import type {
+  SidebarIndicatorAction,
+  SidebarStatusIndicator,
+  SidebarWorkspaceVariant,
+} from "#product/lib/domain/workspaces/sidebar/sidebar-indicators";
+import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
+import {
+  SidebarGitConflictsAlert,
+  SidebarStatusIndicatorView,
+} from "#product/components/workspace/shell/sidebar/SidebarIndicators";
+import {
+  resolveSidebarWorkspaceGitIdentity,
+  SidebarWorkspaceGitGlyph,
+} from "#product/components/workspace/shell/sidebar/SidebarWorkspaceGitGlyph";
+
+export interface WorkspaceItemTrailingCells {
+  /** Null when the row has no git identity, so the cell collapses. */
+  identity: ReactNode;
+  /** Null when the row has nothing to report in its status cell. */
+  status: ReactNode;
+}
+
+interface WorkspaceItemTrailingInput {
+  gitStatus: WorkspaceGitStatus | null;
+  variant: SidebarWorkspaceVariant;
+  statusIndicator: SidebarStatusIndicator | null;
+  onIndicatorAction?: (action: SidebarIndicatorAction) => void;
+}
+
+/**
+ * Fills the workspace row's two trailing cells.
+ *
+ * Resolution rather than rendering: the row decides whether the identity cell
+ * exists at all from the returned node being null, so this cannot be a
+ * component — an always-truthy element would reserve the cell for nothing.
+ */
+export function resolveWorkspaceItemTrailingCells({
+  gitStatus,
+  variant,
+  statusIndicator,
+  onIndicatorAction,
+}: WorkspaceItemTrailingInput): WorkspaceItemTrailingCells {
+  // The identity cell exists only when there is an identity to put in it, so
+  // a local row with no PR collapses the cell instead of reserving 20px for
+  // nothing.
+  const identity = resolveSidebarWorkspaceGitIdentity(gitStatus, variant)
+    ? <SidebarWorkspaceGitGlyph status={gitStatus} variant={variant} />
+    : null;
+  // Right-slot precedence: live activity first, then merge conflicts (the one
+  // git attention state the identity glyph's dot does not already carry).
+  const status = statusIndicator ? (
+    <SidebarStatusIndicatorView
+      indicator={statusIndicator}
+      onAction={onIndicatorAction}
+    />
+  ) : gitStatus?.attention === "conflicts" ? (
+    <SidebarGitConflictsAlert />
+  ) : null;
+
+  return { identity, status };
+}

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspacePeekCard.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspacePeekCard.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
+import {
+  useWorkspacePeek,
+  WORKSPACE_PEEK_DELAY_MS,
+  type WorkspacePeekContent,
+} from "#product/components/workspace/shell/sidebar/WorkspacePeekCard";
+
+function makeGitStatus(overrides: Partial<WorkspaceGitStatus> = {}): WorkspaceGitStatus {
+  return {
+    branch: "pro-112-search-popover",
+    dirty: false,
+    conflicted: false,
+    ahead: 0,
+    behind: 0,
+    hasUpstream: true,
+    pr: {
+      state: "open",
+      number: 805,
+      url: "https://github.com/acme/repo/pull/805",
+      checks: "pending",
+      reviewDecision: "none",
+    },
+    attention: "none",
+    capturedAt: "2026-08-13T10:00:00.000Z",
+    source: "live",
+    ...overrides,
+  };
+}
+
+function content(overrides: Partial<WorkspacePeekContent> = {}): WorkspacePeekContent {
+  return {
+    name: "Find active sessions",
+    time: "38m ago",
+    repo: "proliferate",
+    branch: "pro-112-search-popover",
+    gitStatus: makeGitStatus(),
+    ...overrides,
+  };
+}
+
+function PeekHarness({ peek }: { peek: WorkspacePeekContent | null }) {
+  const { onPointerEnter, onPointerLeave, peekCard } = useWorkspacePeek(peek);
+  return (
+    <>
+      <div
+        data-testid="row"
+        onPointerEnter={onPointerEnter}
+        onPointerLeave={onPointerLeave}
+      >
+        Row
+      </div>
+      {peekCard}
+    </>
+  );
+}
+
+function hoverRow() {
+  fireEvent.pointerEnter(screen.getByTestId("row"));
+}
+
+function card(): HTMLElement | null {
+  return document.querySelector("[data-workspace-peek-card]");
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+});
+
+describe("useWorkspacePeek", () => {
+  it("waits out the hover delay before showing anything", () => {
+    render(<PeekHarness peek={content()} />);
+
+    hoverRow();
+    act(() => {
+      vi.advanceTimersByTime(WORKSPACE_PEEK_DELAY_MS - 1);
+    });
+    expect(card()).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(card()).not.toBeNull();
+  });
+
+  it("never opens for a pointer that passes straight over the row", () => {
+    render(<PeekHarness peek={content()} />);
+
+    hoverRow();
+    fireEvent.pointerLeave(screen.getByTestId("row"));
+    act(() => {
+      vi.advanceTimersByTime(WORKSPACE_PEEK_DELAY_MS * 2);
+    });
+
+    expect(card()).toBeNull();
+  });
+
+  it("closes immediately when the pointer leaves", () => {
+    render(<PeekHarness peek={content()} />);
+
+    hoverRow();
+    act(() => {
+      vi.advanceTimersByTime(WORKSPACE_PEEK_DELAY_MS);
+    });
+    expect(card()).not.toBeNull();
+
+    fireEvent.pointerLeave(screen.getByTestId("row"));
+    expect(card()).toBeNull();
+  });
+});
+
+describe("WorkspacePeekCard", () => {
+  function openPeek(peek: WorkspacePeekContent) {
+    render(<PeekHarness peek={peek} />);
+    hoverRow();
+    act(() => {
+      vi.advanceTimersByTime(WORKSPACE_PEEK_DELAY_MS);
+    });
+  }
+
+  it("shows the git context the row no longer carries", () => {
+    openPeek(content());
+
+    expect(screen.getByText("Find active sessions")).toBeTruthy();
+    expect(screen.getByText("38m ago")).toBeTruthy();
+    expect(screen.getByText("proliferate")).toBeTruthy();
+    expect(screen.getByText("pro-112-search-popover")).toBeTruthy();
+    expect(screen.getByText("PR #805 · Open · Checks pending")).toBeTruthy();
+    expect(screen.getByText("Checks pending")).toBeTruthy();
+  });
+
+  it("stays out of the pointer's way", () => {
+    openPeek(content());
+
+    expect(card()?.className).toContain("pointer-events-none");
+    expect(card()?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("anchors below and inside the row, clamped to the viewport", () => {
+    openPeek(content());
+
+    // jsdom reports a zero rect, so this is the clamped floor: the card never
+    // escapes the viewport margin even for a row at the origin.
+    expect(card()?.style.left).toBe("28px");
+    expect(card()?.style.top).toBe("8px");
+  });
+
+  it("omits the PR row when the branch has no pull request", () => {
+    openPeek(content({
+      gitStatus: makeGitStatus({
+        pr: { state: "none", number: null, url: null, checks: "none", reviewDecision: "none" },
+      }),
+    }));
+
+    expect(screen.queryByText(/^PR #/)).toBeNull();
+    expect(screen.getByText("No CI checks")).toBeTruthy();
+  });
+
+  it("omits rows it has nothing to say in", () => {
+    openPeek(content({ time: null, repo: null, branch: null, gitStatus: null }));
+
+    expect(screen.getByText("Find active sessions")).toBeTruthy();
+    expect(screen.queryByText("proliferate")).toBeNull();
+    expect(screen.getByText("No CI checks")).toBeTruthy();
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspacePeekCard.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspacePeekCard.test.tsx
@@ -153,6 +153,31 @@ describe("WorkspacePeekCard", () => {
     expect(card()?.style.top).toBe("8px");
   });
 
+  it("carries the PR state as the glyph's standalone dot", () => {
+    openPeek(content());
+
+    expect(card()?.innerHTML).toContain('cx="15" cy="15" r="3"');
+  });
+
+  it("renders a merged pull request as the whole glyph in the merged ink", () => {
+    openPeek(content({
+      gitStatus: makeGitStatus({
+        pr: {
+          state: "merged",
+          number: 805,
+          url: "https://github.com/acme/repo/pull/805",
+          checks: "none",
+          reviewDecision: "none",
+        },
+      }),
+    }));
+
+    expect(screen.getByText("PR #805 · Merged")).toBeTruthy();
+    expect(card()?.innerHTML).toContain("text-pr-merged");
+    // Merged is settled, so the glyph is the whole signal: no state dot.
+    expect(card()?.innerHTML).not.toContain('cx="15" cy="15" r="3"');
+  });
+
   it("omits the PR row when the branch has no pull request", () => {
     openPeek(content({
       gitStatus: makeGitStatus({

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspacePeekCard.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspacePeekCard.tsx
@@ -7,6 +7,7 @@ import { FixedPositionLayer } from "#product/primitives/FixedPositionLayer";
 import { POPOVER_FRAME_CLASS } from "#product/primitives/PopoverButton";
 import { statusDotToneTextClass } from "#product/primitives/StatusDot";
 import {
+  prChecksLabel,
   prStatusCompoundLabel,
   prStatusTone,
   prStatusViewFromGitStatus,
@@ -143,17 +144,12 @@ function PeekRow({
   );
 }
 
+/**
+ * The card names the absence too, unlike the shared label: it renders a fixed
+ * row rather than a tooltip segment, so an empty one would read as a bug.
+ */
 function checksLabel(status: WorkspaceGitStatus | null): string {
-  switch (status?.pr?.checks) {
-    case "passing":
-      return "Checks passing";
-    case "pending":
-      return "Checks pending";
-    case "failing":
-      return "Checks failing";
-    default:
-      return "No CI checks";
-  }
+  return prChecksLabel(status?.pr?.checks ?? "none") ?? "No CI checks";
 }
 
 /**

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspacePeekCard.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspacePeekCard.tsx
@@ -19,7 +19,12 @@ export const WORKSPACE_PEEK_DELAY_MS = 450;
 /** Keep in step with the card's own `w-75`, which the clamp math cannot read. */
 const CARD_WIDTH = 300;
 const VIEWPORT_MARGIN = 8;
-/** Enough for the tallest card (header + four rows) to stay on screen. */
+/**
+ * Enough for the tallest card to stay on screen. Read off the card's anatomy
+ * rather than guessed: header (~30px incl. its 6px bottom padding) + four
+ * 26px rows + three 2px gaps + 20px of vertical padding ≈ 152, rounded up to
+ * 160. A fifth row means this number moves with it.
+ */
 const ESTIMATED_CARD_HEIGHT = 160;
 /** Indents the card past the row's leading well, under the row's label. */
 const ANCHOR_INSET = 28;
@@ -64,7 +69,7 @@ export function WorkspacePeekCard({
       aria-hidden="true"
       data-workspace-peek-card
       // Non-interactive: the pointer must keep belonging to the row beneath.
-      className={`pointer-events-none fixed z-popover flex w-75 flex-col gap-0.5 px-3 py-2.5 ${POPOVER_FRAME_CLASS}`}
+      className={`pointer-events-none fixed z-tooltip flex w-75 flex-col gap-0.5 px-3 py-2.5 ${POPOVER_FRAME_CLASS}`}
     >
       <div className="flex items-baseline gap-2 px-0.5 pt-0.5 pb-1.5">
         <span className="min-w-0 flex-1 truncate text-ui font-medium">
@@ -85,7 +90,16 @@ export function WorkspacePeekCard({
 
       {prView && prTone && prLabel ? (
         <PeekRow
-          icon={(
+          icon={prView.kind === "merged" ? (
+            // Merged is settled, so the whole glyph carries it and there is no
+            // dot — the row's own convention. The ink is the shared tone map's
+            // `text-pr-merged` rather than the row's `sidebar-status-worktree`
+            // twin of it: this card sits on the popover surface, where the
+            // rest of its inks are the popover's.
+            <GitBranchIcon
+              className={`${PEEK_ICON_BASE_CLASS} ${statusDotToneTextClass(prTone.tone)}`}
+            />
+          ) : (
             <GitBranchStatusIcon
               className={PEEK_ICON_CLASS}
               dotClassName={statusDotToneTextClass(prTone.tone)}
@@ -106,7 +120,9 @@ export function WorkspacePeekCard({
   );
 }
 
-const PEEK_ICON_CLASS = "icon-paired shrink-0 text-muted-foreground";
+/** Geometry only, so a row that owns its own ink can reuse it. */
+const PEEK_ICON_BASE_CLASS = "icon-paired shrink-0";
+const PEEK_ICON_CLASS = `${PEEK_ICON_BASE_CLASS} text-muted-foreground`;
 
 function PeekRow({
   icon,
@@ -146,6 +162,15 @@ function checksLabel(status: WorkspaceGitStatus | null): string {
  * The anchor is measured when the delay elapses rather than when the pointer
  * arrives, so a row that moved under the pointer (a list settling, a group
  * expanding) still anchors its card correctly.
+ *
+ * RECORDED REFUSAL (rule of two): `../tabs/DelegatedAgentHoverCard.tsx` is
+ * the named twin of this shape — a hover-timed card anchored off the
+ * trigger's rect and clamped to the viewport. It is deliberately NOT promoted
+ * into a shared `useAnchoredHoverCard` primitive here, because the two differ
+ * on exactly the axes such a primitive would have to take: that card is
+ * interactive and holds itself open on a leave timer, this one never takes
+ * the pointer and closes the instant the row is left. Choosing those axes is
+ * a founder decision, not a mechanical lift.
  */
 export function useWorkspacePeek(content: WorkspacePeekContent | null): {
   onPointerEnter: (event: { currentTarget: EventTarget & HTMLElement }) => void;

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspacePeekCard.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspacePeekCard.tsx
@@ -1,0 +1,206 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { Clock } from "#product/primitives/icons/core";
+import { FolderClosed } from "#product/primitives/icons/workspace";
+import { GitBranchIcon, GitBranchStatusIcon } from "#product/primitives/icons/workspace-git";
+import { FixedPositionLayer } from "#product/primitives/FixedPositionLayer";
+import { POPOVER_FRAME_CLASS } from "#product/primitives/PopoverButton";
+import { statusDotToneTextClass } from "#product/primitives/StatusDot";
+import {
+  prStatusCompoundLabel,
+  prStatusTone,
+  prStatusViewFromGitStatus,
+} from "#product/lib/domain/workspaces/git-status/pr-status-presentation";
+import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
+
+/** Long enough that moving the pointer down a list never flashes cards. */
+export const WORKSPACE_PEEK_DELAY_MS = 450;
+
+/** Keep in step with the card's own `w-75`, which the clamp math cannot read. */
+const CARD_WIDTH = 300;
+const VIEWPORT_MARGIN = 8;
+/** Enough for the tallest card (header + four rows) to stay on screen. */
+const ESTIMATED_CARD_HEIGHT = 160;
+/** Indents the card past the row's leading well, under the row's label. */
+const ANCHOR_INSET = 28;
+const ANCHOR_GAP = 4;
+
+export interface WorkspacePeekContent {
+  name: string;
+  /** Relative last-activity label ("38m ago"). */
+  time: string | null;
+  repo: string | null;
+  branch: string | null;
+  gitStatus: WorkspaceGitStatus | null;
+}
+
+interface PeekAnchor {
+  left: number;
+  top: number;
+}
+
+/**
+ * The hover peek for a sidebar workspace row: the git context that no longer
+ * crowds the row itself.
+ *
+ * Read-only and non-interactive by design — it is a longer look at the row,
+ * not a menu, so it never takes the pointer and it leaves the instant the
+ * pointer does.
+ */
+export function WorkspacePeekCard({
+  content,
+  anchor,
+}: {
+  content: WorkspacePeekContent;
+  anchor: PeekAnchor;
+}) {
+  const prView = prStatusViewFromGitStatus(content.gitStatus);
+  const prLabel = prStatusCompoundLabel(content.gitStatus);
+  const prTone = prView ? prStatusTone(prView.kind) : null;
+
+  return createPortal(
+    <FixedPositionLayer
+      position={anchor}
+      aria-hidden="true"
+      data-workspace-peek-card
+      // Non-interactive: the pointer must keep belonging to the row beneath.
+      className={`pointer-events-none fixed z-popover flex w-75 flex-col gap-0.5 px-3 py-2.5 ${POPOVER_FRAME_CLASS}`}
+    >
+      <div className="flex items-baseline gap-2 px-0.5 pt-0.5 pb-1.5">
+        <span className="min-w-0 flex-1 truncate text-ui font-medium">
+          {content.name}
+        </span>
+        {content.time ? (
+          <span className="shrink-0 text-ui-sm text-faint">{content.time}</span>
+        ) : null}
+      </div>
+
+      {content.repo ? (
+        <PeekRow icon={<FolderClosed className={PEEK_ICON_CLASS} />} label={content.repo} />
+      ) : null}
+
+      {content.branch ? (
+        <PeekRow icon={<GitBranchIcon className={PEEK_ICON_CLASS} />} label={content.branch} />
+      ) : null}
+
+      {prView && prTone && prLabel ? (
+        <PeekRow
+          icon={(
+            <GitBranchStatusIcon
+              className={PEEK_ICON_CLASS}
+              dotClassName={statusDotToneTextClass(prTone.tone)}
+              dotFill={prTone.fill}
+            />
+          )}
+          label={prLabel}
+        />
+      ) : null}
+
+      <PeekRow
+        icon={<Clock className={PEEK_ICON_CLASS} />}
+        label={checksLabel(content.gitStatus)}
+        muted
+      />
+    </FixedPositionLayer>,
+    document.body,
+  );
+}
+
+const PEEK_ICON_CLASS = "icon-paired shrink-0 text-muted-foreground";
+
+function PeekRow({
+  icon,
+  label,
+  muted = false,
+}: {
+  icon: ReactNode;
+  label: string;
+  muted?: boolean;
+}) {
+  return (
+    <div className="flex h-6.5 items-center gap-2.5 px-0.5">
+      {icon}
+      <span className={`min-w-0 truncate text-ui ${muted ? "text-muted-foreground" : ""}`}>
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function checksLabel(status: WorkspaceGitStatus | null): string {
+  switch (status?.pr?.checks) {
+    case "passing":
+      return "Checks passing";
+    case "pending":
+      return "Checks pending";
+    case "failing":
+      return "Checks failing";
+    default:
+      return "No CI checks";
+  }
+}
+
+/**
+ * Arms the peek on row hover and hands back the row's pointer handlers.
+ *
+ * The anchor is measured when the delay elapses rather than when the pointer
+ * arrives, so a row that moved under the pointer (a list settling, a group
+ * expanding) still anchors its card correctly.
+ */
+export function useWorkspacePeek(content: WorkspacePeekContent | null): {
+  onPointerEnter: (event: { currentTarget: EventTarget & HTMLElement }) => void;
+  onPointerLeave: () => void;
+  peekCard: ReactNode;
+} {
+  const [anchor, setAnchor] = useState<PeekAnchor | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancel = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => cancel, [cancel]);
+
+  const onPointerEnter = useCallback((
+    event: { currentTarget: EventTarget & HTMLElement },
+  ) => {
+    // `currentTarget` is cleared once the handler returns; hold the element.
+    const row = event.currentTarget;
+    cancel();
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      setAnchor(resolvePeekAnchor(row.getBoundingClientRect()));
+    }, WORKSPACE_PEEK_DELAY_MS);
+  }, [cancel]);
+
+  const onPointerLeave = useCallback(() => {
+    cancel();
+    setAnchor(null);
+  }, [cancel]);
+
+  return {
+    onPointerEnter,
+    onPointerLeave,
+    peekCard: content && anchor
+      ? <WorkspacePeekCard content={content} anchor={anchor} />
+      : null,
+  };
+}
+
+function resolvePeekAnchor(row: DOMRect): PeekAnchor {
+  const maxLeft = Math.max(
+    VIEWPORT_MARGIN,
+    window.innerWidth - CARD_WIDTH - VIEWPORT_MARGIN,
+  );
+  const maxTop = Math.max(
+    VIEWPORT_MARGIN,
+    window.innerHeight - ESTIMATED_CARD_HEIGHT - VIEWPORT_MARGIN,
+  );
+  return {
+    left: Math.min(Math.max(row.left + ANCHOR_INSET, VIEWPORT_MARGIN), maxLeft),
+    top: Math.min(Math.max(row.bottom + ANCHOR_GAP, VIEWPORT_MARGIN), maxTop),
+  };
+}

--- a/apps/packages/product-client/src/lib/domain/telemetry/debug-measurement-catalog.ts
+++ b/apps/packages/product-client/src/lib/domain/telemetry/debug-measurement-catalog.ts
@@ -35,6 +35,7 @@ export type MeasurementSurface =
   | "workspace-sidebar-frame"
   | "workspace-sidebar"
   | "workspace-sidebar-primary-nav"
+  | "workspace-sidebar-scrolling-nav"
   | "workspace-sidebar-content"
   | "workspace-sidebar-footer"
   | "workspace-header-frame"

--- a/apps/packages/product-client/src/lib/domain/workspaces/git-status/pr-status-presentation.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/git-status/pr-status-presentation.ts
@@ -2,6 +2,7 @@ import { formatRelativeTime } from "#product/lib/domain/workspaces/display/works
 import type { StatusDotFill, StatusDotTone } from "#product/primitives/StatusDot";
 import type {
   WorkspaceGitStatus,
+  WorkspacePrChecks,
   WorkspacePrStatus,
 } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
 
@@ -90,6 +91,24 @@ function prStatusKind(pr: WorkspacePrStatus): PrStatusKind | null {
 }
 
 /**
+ * The one phrasing of a PR's check state, shared by every surface that names
+ * it. Null for "none": a PR with no checks has nothing to say here, and each
+ * caller decides whether that silence needs its own words.
+ */
+export function prChecksLabel(checks: WorkspacePrChecks): string | null {
+  switch (checks) {
+    case "failing":
+      return "Checks failing";
+    case "pending":
+      return "Checks pending";
+    case "passing":
+      return "Checks passing";
+    case "none":
+      return null;
+  }
+}
+
+/**
  * Full tooltip for a PR row ("PR #805 · Open · Checks failing"). Draft rows
  * include checks/review segments too; merged/closed rows carry only the state.
  * Snapshot-sourced statuses get an "as of {rel}" suffix so stale data reads as
@@ -109,10 +128,11 @@ export function prStatusCompoundLabel(
   ];
 
   if (pr.state === "open" || pr.state === "draft") {
-    if (pr.checks === "failing") {
-      parts.push("Checks failing");
-    } else if (pr.checks === "pending") {
-      parts.push("Checks pending");
+    // Passing checks stay silent: a green PR reads as "PR #805 · Open", not
+    // as a tooltip that spends a segment saying nothing is wrong.
+    const checksLabel = pr.checks === "passing" ? null : prChecksLabel(pr.checks);
+    if (checksLabel) {
+      parts.push(checksLabel);
     }
     if (pr.reviewDecision === "changes_requested") {
       parts.push("Changes requested");

--- a/apps/packages/product-client/src/lib/domain/workspaces/git-status/sidebar-git-identity.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/git-status/sidebar-git-identity.ts
@@ -1,0 +1,66 @@
+import type { GitBranchStatusDotFill } from "#product/primitives/icons/workspace-git";
+import type { StatusDotTone } from "#product/primitives/StatusDot";
+import {
+  prStatusCompoundLabel,
+  prStatusTone,
+  prStatusViewFromGitStatus,
+} from "#product/lib/domain/workspaces/git-status/pr-status-presentation";
+import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
+import type { SidebarWorkspaceVariant } from "#product/lib/domain/workspaces/sidebar/sidebar-indicators";
+
+/**
+ * What the row's trailing identity cell says about a workspace. Exactly one
+ * of these, or nothing at all — the cell is omitted rather than filled with a
+ * placeholder, so a row that has no git identity to report stays quiet.
+ */
+export type SidebarWorkspaceGitIdentity =
+  /** A live PR: branch glyph + the state dot. */
+  | { kind: "pull_request"; tone: StatusDotTone; fill: GitBranchStatusDotFill; label: string }
+  /** A settled PR reads as the whole glyph in the merged ink, with no dot. */
+  | { kind: "merged_pull_request"; label: string }
+  /** No PR — the cell falls back to what the workspace IS. */
+  | { kind: "worktree" }
+  | { kind: "cloud" };
+
+export const SIDEBAR_GIT_IDENTITY_WORKTREE_LABEL = "Worktree · no pull request";
+export const SIDEBAR_GIT_IDENTITY_CLOUD_LABEL = "Cloud workspace · no pull request";
+
+/**
+ * Resolves the ONE identity a workspace row's trailing cell shows.
+ *
+ * A PR wins whenever the branch has one, because it is the strongest thing
+ * true about the row; without a PR the cell falls back to the workspace's own
+ * topology (worktree / cloud). Local and SSH rows resolve to null: a local
+ * checkout with no PR has no git identity worth a permanent glyph, and the
+ * dim always-on placeholder that used to fill this cell is what made the
+ * column read as noise.
+ *
+ * The row resolves this once and passes the result to both the cell's
+ * existence check and the glyph, so the waterfall runs a single time.
+ */
+export function resolveSidebarWorkspaceGitIdentity(
+  status: WorkspaceGitStatus | null,
+  variant: SidebarWorkspaceVariant,
+): SidebarWorkspaceGitIdentity | null {
+  // Null for both "no PR on this branch" (authoritative) and "PR data
+  // unknown" — neither is something to draw.
+  const view = prStatusViewFromGitStatus(status);
+  if (view) {
+    const label = prStatusCompoundLabel(status) ?? "Pull request";
+    if (view.kind === "merged") {
+      return { kind: "merged_pull_request", label };
+    }
+    const { tone, fill } = prStatusTone(view.kind);
+    return { kind: "pull_request", tone, fill, label };
+  }
+
+  switch (variant) {
+    case "worktree":
+      return { kind: "worktree" };
+    case "cloud":
+      return { kind: "cloud" };
+    case "local":
+    case "ssh":
+      return null;
+  }
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-indicators.test.ts
@@ -3,6 +3,15 @@ import type { WorkspaceExecutionSummary } from "@anyharness/sdk";
 import type { LogicalWorkspace } from "#product/lib/domain/workspaces/cloud/logical-workspace-model";
 import { cloudWorkspaceSyntheticId } from "#product/lib/domain/workspaces/cloud/cloud-ids";
 import {
+  deriveGitAttention,
+  type WorkspaceGitStatus,
+  type WorkspacePrStatus,
+} from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
+import {
+  SIDEBAR_GIT_CONFLICTS_LABEL,
+  sidebarGitAttentionIndicator,
+} from "#product/lib/domain/workspaces/sidebar/sidebar-indicators";
+import {
   buildGroups,
   makeCloudLogicalWorkspace,
   makeCloudWorkspace,
@@ -382,5 +391,143 @@ describe("sidebar indicators", () => {
     const indicator = groups[0]?.items[0]?.statusIndicator;
     expect(indicator?.kind).toBe("worktree_missing");
     expect(indicator?.tooltip).toBe("Worktree no longer exists");
+  });
+});
+
+function pullRequest(overrides: Partial<WorkspacePrStatus> = {}): WorkspacePrStatus {
+  return {
+    state: "open",
+    number: 805,
+    url: "https://github.com/acme/repo/pull/805",
+    checks: "none",
+    reviewDecision: "none",
+    ...overrides,
+  };
+}
+
+function gitStatusWith(args: {
+  pr: WorkspacePrStatus | null;
+  conflicted?: boolean;
+}): WorkspaceGitStatus {
+  const conflicted = args.conflicted ?? false;
+  return {
+    branch: "feature/sidebar",
+    dirty: false,
+    conflicted,
+    ahead: 0,
+    behind: 0,
+    hasUpstream: true,
+    pr: args.pr,
+    // Derived rather than hand-set: these cases only prove anything if the
+    // attention they exercise is the one the model actually produces.
+    attention: deriveGitAttention({ conflicted, pr: args.pr }),
+    capturedAt: "2026-08-04T00:00:00.000Z",
+    source: "live",
+  };
+}
+
+describe("sidebarGitAttentionIndicator", () => {
+  it("reports failing checks on a draft PR, whose dot cannot carry them", () => {
+    const status = gitStatusWith({ pr: pullRequest({ state: "draft", checks: "failing" }) });
+
+    expect(status.attention).toBe("ci_failing");
+    expect(sidebarGitAttentionIndicator(status)).toEqual({
+      kind: "git_checks_failing",
+      tooltip: "PR checks failing",
+    });
+  });
+
+  it("stays silent for failing checks on an open PR, where the dot is already red", () => {
+    const status = gitStatusWith({ pr: pullRequest({ checks: "failing" }) });
+
+    expect(status.attention).toBe("ci_failing");
+    expect(sidebarGitAttentionIndicator(status)).toBeNull();
+  });
+
+  it("reports requested changes when the dot is showing pending checks instead", () => {
+    const status = gitStatusWith({
+      pr: pullRequest({ checks: "pending", reviewDecision: "changes_requested" }),
+    });
+
+    expect(status.attention).toBe("changes_requested");
+    expect(sidebarGitAttentionIndicator(status)).toEqual({
+      kind: "git_changes_requested",
+      tooltip: "PR changes requested",
+    });
+  });
+
+  it("reports requested changes on a merged PR, which never reaches that dot kind", () => {
+    const status = gitStatusWith({
+      pr: pullRequest({ state: "merged", reviewDecision: "changes_requested" }),
+    });
+
+    expect(sidebarGitAttentionIndicator(status)).toEqual({
+      kind: "git_changes_requested",
+      tooltip: "PR changes requested",
+    });
+  });
+
+  it("lets conflicts win over failing checks", () => {
+    const status = gitStatusWith({
+      conflicted: true,
+      pr: pullRequest({ state: "draft", checks: "failing" }),
+    });
+
+    expect(status.attention).toBe("conflicts");
+    expect(sidebarGitAttentionIndicator(status)).toEqual({
+      kind: "git_conflicts",
+      tooltip: SIDEBAR_GIT_CONFLICTS_LABEL,
+    });
+  });
+
+  it("reports nothing when there is no attention, or no status at all", () => {
+    expect(sidebarGitAttentionIndicator(gitStatusWith({ pr: pullRequest() }))).toBeNull();
+    expect(sidebarGitAttentionIndicator(gitStatusWith({ pr: null }))).toBeNull();
+    expect(sidebarGitAttentionIndicator(null)).toBeNull();
+  });
+
+  it("falls through to git attention once the row has no activity to show", () => {
+    const groups = buildGroups({
+      logicalWorkspaces: [
+        makeLocalLogicalWorkspace({
+          id: "draft-pr-red-checks",
+          repoKey: "/tmp/repo-a",
+          repoName: "repo-a",
+          kind: "worktree",
+          executionSummary: workspaceExecutionSummary("idle"),
+        }),
+      ],
+      gitStatusesByLogicalId: {
+        "draft-pr-red-checks": gitStatusWith({
+          pr: pullRequest({ state: "draft", checks: "failing" }),
+        }),
+      },
+    });
+
+    expect(groups[0]?.items[0]?.statusIndicator).toEqual({
+      kind: "git_checks_failing",
+      tooltip: "PR checks failing",
+    });
+  });
+
+  it("keeps live activity ahead of git attention", () => {
+    const groups = buildGroups({
+      logicalWorkspaces: [
+        makeLocalLogicalWorkspace({
+          id: "running-with-red-checks",
+          repoKey: "/tmp/repo-a",
+          repoName: "repo-a",
+          kind: "worktree",
+          executionSummary: workspaceExecutionSummary("running"),
+        }),
+      ],
+      gitStatusesByLogicalId: {
+        "running-with-red-checks": gitStatusWith({
+          pr: pullRequest({ state: "draft", checks: "failing" }),
+        }),
+      },
+    });
+
+    expect(groups[0]?.items[0]?.statusIndicator?.kind).toBe("iterating");
   });
 });

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-indicators.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-indicators.ts
@@ -7,6 +7,8 @@ import { missingCheckoutCopy } from "#product/copy/workspaces/workspace-availabi
 import { isCloudWorkspacePending } from "#product/lib/domain/workspaces/cloud/cloud-workspace-status";
 import type { LogicalWorkspace } from "#product/lib/domain/workspaces/cloud/logical-workspace-model";
 import { cloudWorkspaceSyntheticId } from "#product/lib/domain/workspaces/cloud/cloud-ids";
+import { prStatusViewFromGitStatus } from "#product/lib/domain/workspaces/git-status/pr-status-presentation";
+import type { WorkspaceGitStatus } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
 
 export type SidebarWorkspaceVariant = "local" | "worktree" | "cloud" | "ssh";
 
@@ -48,6 +50,18 @@ export type SidebarStatusIndicator =
   }
   | {
     kind: "queued_prompt";
+    tooltip: string;
+  }
+  | {
+    kind: "git_conflicts";
+    tooltip: string;
+  }
+  | {
+    kind: "git_checks_failing";
+    tooltip: string;
+  }
+  | {
+    kind: "git_changes_requested";
     tooltip: string;
   };
 
@@ -138,6 +152,40 @@ export function sidebarStatusIndicatorFromActivity(args: {
   }
 
   return null;
+}
+
+export const SIDEBAR_GIT_CONFLICTS_LABEL = "Merge conflicts in worktree";
+
+/**
+ * Git attention as the status cell's last resort, below live activity.
+ *
+ * Attention surfaces here only when the identity glyph's state dot does not
+ * already carry it: an open PR with failing checks is already a danger dot,
+ * so repeating it in the status cell would say the same thing twice. Draft,
+ * merged and closed PRs never resolve to those dot kinds, which is why their
+ * failing checks and requested changes would otherwise go unreported.
+ *
+ * No ranking happens here: `deriveGitAttention` has already collapsed
+ * conflicts > ci_failing > changes_requested into the single state it reports.
+ */
+export function sidebarGitAttentionIndicator(
+  status: WorkspaceGitStatus | null,
+): SidebarStatusIndicator | null {
+  switch (status?.attention) {
+    case "conflicts":
+      return { kind: "git_conflicts", tooltip: SIDEBAR_GIT_CONFLICTS_LABEL };
+    case "ci_failing":
+      return prStatusViewFromGitStatus(status)?.kind === "checks_failing"
+        ? null
+        : { kind: "git_checks_failing", tooltip: "PR checks failing" };
+    case "changes_requested":
+      return prStatusViewFromGitStatus(status)?.kind === "changes_requested"
+        ? null
+        : { kind: "git_changes_requested", tooltip: "PR changes requested" };
+    case "none":
+    case undefined:
+      return null;
+  }
 }
 
 export function activeWorkspaceActivity(

--- a/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-workspace-items.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/sidebar/sidebar-workspace-items.ts
@@ -14,6 +14,7 @@ import type { SidebarWorkspaceItemState } from "#product/lib/domain/workspaces/s
 import { isWorkspaceDirectoryMissing } from "#product/lib/domain/workspaces/availability";
 import {
   activeWorkspaceActivity,
+  sidebarGitAttentionIndicator,
   sidebarStatusIndicatorFromActivity,
   sidebarWorkspaceVariantForLogicalWorkspace,
   worktreeMissingStatusIndicator,
@@ -222,6 +223,21 @@ function buildSidebarWorkspaceItem(
     ) ?? null
     : null;
 
+  // The status cell's whole precedence, in one place: a missing checkout
+  // outranks everything, then live session activity, then whatever git
+  // attention the identity glyph's state dot does not already carry.
+  const statusIndicator = entry.localWorkspace
+      && isWorkspaceDirectoryMissing(entry.localWorkspace)
+    ? worktreeMissingStatusIndicator(
+      entry.localWorkspace.kind,
+      { kind: "open_workspace", workspaceId: entry.id },
+    )
+    : (sidebarStatusIndicatorFromActivity({
+      activity,
+      pendingPromptCount: logicalWorkspaceRelatedCount(args.pendingPromptCounts, entry),
+      errorAction: { kind: "open_workspace", workspaceId: entry.id },
+    }) ?? sidebarGitAttentionIndicator(gitStatus));
+
   return {
     workspace: entry,
     item: {
@@ -237,16 +253,7 @@ function buildSidebarWorkspaceItem(
       archived,
       pinnedIds: logicalWorkspaceRelatedIds(entry).filter((id) => args.pinnedSet?.has(id)),
       variant,
-      statusIndicator: entry.localWorkspace && isWorkspaceDirectoryMissing(entry.localWorkspace)
-        ? worktreeMissingStatusIndicator(
-          entry.localWorkspace.kind,
-          { kind: "open_workspace", workspaceId: entry.id },
-        )
-        : sidebarStatusIndicatorFromActivity({
-          activity,
-          pendingPromptCount: logicalWorkspaceRelatedCount(args.pendingPromptCounts, entry),
-          errorAction: { kind: "open_workspace", workspaceId: entry.id },
-        }),
+      statusIndicator,
       lastInteracted,
       needsReview,
       workspaceLocationCopyLabel: copyMetadata.workspaceLocation?.menuLabel ?? null,

--- a/apps/packages/product-client/src/primitives/__tests__/AppearanceGlyphScaling.test.tsx
+++ b/apps/packages/product-client/src/primitives/__tests__/AppearanceGlyphScaling.test.tsx
@@ -103,13 +103,14 @@ describe("appearance-owned glyph sizing", () => {
     const button = getByRole("button", { name: "Add repository" });
     expect(button.className).toContain("[font-size:var(--text-sidebar-row)]");
     expect(button.className).toContain("size-6");
-    // Round-4: the wrapper's own [&_svg]:icon-tight is what actually reaches
+    // Round-4: the wrapper's own [&_svg]:icon-compact is what actually reaches
     // the child glyph — it wins the same twMerge icon-size group as the base
     // RowActionIconButton's [&_svg]:icon-control descendant selector, which
     // otherwise beats any plain size class a caller puts on the child SVG
     // directly (that's why the glyph rendered at 16px regardless of the
     // "icon-compact" class below).
-    expect(button.className).toContain("[&_svg]:icon-tight");
+    expect(button.className).toContain("[&_svg]:icon-compact");
+    expect(button.className).not.toContain("[&_svg]:icon-tight");
     expect(button.querySelector("svg")?.className.baseVal).toContain("icon-compact");
   });
 

--- a/apps/packages/product-client/src/primitives/icons/workspace-git.tsx
+++ b/apps/packages/product-client/src/primitives/icons/workspace-git.tsx
@@ -64,6 +64,54 @@ export function GitBranchIcon({ className, ...props }: IconProps) {
   );
 }
 
+export type GitBranchStatusDotFill = "solid" | "hollow";
+
+export interface GitBranchStatusIconProps extends IconProps {
+  /**
+   * Ink for the state dot only, as a `text-*` class — pass the PR kind's
+   * tone through `statusDotToneTextClass` so the glyph and the dot-based
+   * readings of the same state cannot drift apart. The dot resolves it via
+   * its own `currentColor`, leaving the branch strokes on the consumer's ink.
+   */
+  dotClassName?: string;
+  /** `hollow` is the outline used for states still in flight. */
+  dotFill?: GitBranchStatusDotFill;
+}
+
+/**
+ * PR-status identity glyph: `GitBranchIcon`'s branch column plus a hook
+ * arrow, with a STANDALONE bottom-right state dot carrying the PR state.
+ *
+ * One SVG serves every state — never a per-state fork. Only two things vary:
+ * whether the dot is filled or an outline (`dotFill`), and its ink
+ * (`dotClassName`). Everything else is the consumer's `currentColor`.
+ */
+export function GitBranchStatusIcon({
+  className,
+  dotClassName,
+  dotFill = "solid",
+  ...props
+}: GitBranchStatusIconProps) {
+  return (
+    <svg className={className} viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <circle cx="5.4165" cy="5" r="1.875" stroke="currentColor" strokeWidth="1.33" />
+      <circle cx="5.4165" cy="15" r="1.875" stroke="currentColor" strokeWidth="1.33" />
+      <path d="M5.4165 6.66664V13.3333" stroke="currentColor" strokeWidth="1.33" strokeLinejoin="round" />
+      <path d="M9.4 2.9L7.95 4.35L9.4 5.8" stroke="currentColor" strokeWidth="1.33" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M8.55 4.35H11.9C13.03 4.35 13.95 5.27 13.95 6.4V9.2" stroke="currentColor" strokeWidth="1.33" strokeLinecap="round" />
+      <circle
+        className={dotClassName}
+        cx="15"
+        cy="15"
+        r="3"
+        fill={dotFill === "hollow" ? "none" : "currentColor"}
+        stroke="currentColor"
+        strokeWidth="1.33"
+      />
+    </svg>
+  );
+}
+
 /** Thread-row PR glyph: muted branch pipe + inbound arrow; the
  * status dot is part of the SVG and colored via --pr-status-dot-color
  * (rendered only when `dot` is set). */

--- a/apps/packages/product-client/src/primitives/patterns/sidebar/SidebarActionButton.tsx
+++ b/apps/packages/product-client/src/primitives/patterns/sidebar/SidebarActionButton.tsx
@@ -46,10 +46,12 @@ export interface SidebarActionButtonProps
  * plain class on the child in the cascade, so no consumer's own icon-size
  * class was ever actually winning. That produced a glyph that read 50-60%
  * too big on screen even though the token ratio looked correct in isolation.
- * `[&_svg]:icon-tight` here is the same shape of selector, so it wins the
+ * `[&_svg]:icon-compact` here is the same shape of selector, so it wins the
  * same twMerge `icon-size` group as the base's `[&_svg]:icon-control` and
- * actually reaches the child glyph — landing at 10.5px against the sidebar
- * row's 12px text, the reference's tighter trailing-control proportion.
+ * actually reaches the child glyph — landing at 13px inside the same 24px
+ * hit box, matching the sidebar row's 13px text 1:1. The earlier
+ * `icon-tight` (10.5px) tier read too small beside the 16px leading nav
+ * glyphs; the hit box is unchanged, only the glyph inside it.
  *
  * Rest props are forwarded through to the base's `<button>` so that when this
  * adapter is a Radix trigger (`PopoverTrigger asChild`), the injected
@@ -80,7 +82,7 @@ export const SidebarActionButton = forwardRef<HTMLButtonElement, SidebarActionBu
         onClick={onClick}
         disabled={disabled}
         visibility={isAlwaysVisible ? "always" : "hover"}
-        className={`size-6 border border-transparent text-sidebar-muted-foreground [font-size:var(--text-sidebar-row)] [&_svg]:icon-tight hover:bg-transparent hover:text-sidebar-foreground active:bg-transparent data-[state=open]:bg-transparent data-[state=open]:text-sidebar-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-sidebar-ring ${
+        className={`size-6 border border-transparent text-sidebar-muted-foreground [font-size:var(--text-sidebar-row)] [&_svg]:icon-compact hover:bg-transparent hover:text-sidebar-foreground active:bg-transparent data-[state=open]:bg-transparent data-[state=open]:text-sidebar-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-sidebar-ring ${
           active ? "bg-selected text-sidebar-accent-foreground" : ""
         } ${
           variant === "section"

--- a/apps/packages/product-client/src/primitives/patterns/sidebar/SidebarNavRow.test.tsx
+++ b/apps/packages/product-client/src/primitives/patterns/sidebar/SidebarNavRow.test.tsx
@@ -19,7 +19,11 @@ describe("SidebarNavRow", () => {
     const icon = container.querySelector('[data-testid="nav-icon"]');
     const well = icon?.parentElement;
     expect(well?.className).toContain("w-[var(--icon-paired)]");
-    expect(well?.className).toContain("[&>svg]:icon-indicator");
+    // Well and glyph are the SAME tier: the well's compound selector beats any
+    // plain size class on the child SVG, so this is what the nav (and the
+    // settings sidebar, which passes its own `icon-paired`) actually renders.
+    expect(well?.className).toContain("[&>svg]:icon-paired");
+    expect(well?.className).not.toContain("[&>svg]:icon-indicator");
   });
 
   it("mounts the shortcut badge only while shortcut reveal is active", () => {

--- a/apps/packages/product-client/src/primitives/patterns/sidebar/SidebarNavRow.tsx
+++ b/apps/packages/product-client/src/primitives/patterns/sidebar/SidebarNavRow.tsx
@@ -39,11 +39,14 @@ export function SidebarNavRow({
       {...props}
     >
       {/* The icon carries the row ink, not a dimmer tier, and scales with
-          the label (~1.15em icon-to-text).
+          the label (1.23em icon-to-text — a 16px glyph beside 13px row text).
           The well matches the icon exactly — a fixed w-4 well leaves more
           slack around smaller icons, silently widening the icon→label gap on
-          smaller-text surfaces (settings) vs the main sidebar. */}
-      <div className="flex w-[var(--icon-paired)] shrink-0 items-center justify-center text-current [&>svg]:icon-indicator [&>svg]:shrink-0">
+          smaller-text surfaces (settings) vs the main sidebar. The glyph size
+          is spelled as the same `[&>svg]` compound selector as the well's own
+          width, so it reaches the child SVG rather than losing to whatever
+          size class the caller put there. */}
+      <div className="flex w-[var(--icon-paired)] shrink-0 items-center justify-center text-current [&>svg]:icon-paired [&>svg]:shrink-0">
         {icon}
       </div>
       <div className="flex min-w-0 flex-1 items-center text-current">


### PR DESCRIPTION
Implements the frozen design handoff `HANDOFF-sidebar-update.md` from the sidebar design export (Claude Design project "Proliferate Library", synced 2026-08-13). The design artifacts in that export are the visual truth; this PR is the diff plan executed against them.

## What changed

**Icon-to-text sizing** (row text stays 13px):
- `SidebarNavRow`: icon-well glyphs `icon-indicator` (13px) → `icon-paired` (16px). This also fixes the settings sidebar, whose passed `icon-paired` classNames were losing to the well's compound selector — no `SettingsSidebar` change needed.
- `SidebarActionButton`: hover-action glyphs `icon-tight` (10.5px) → `icon-compact` (13px) in the same 24px hit box.
- `RepoGroup` folder glyphs → `icon-paired`.

**Git identity (Codex-style, one glyph per row):**
- The always-rendered PR ghost is gone. New `GitBranchStatusIcon` (viewBox-20 / 1.33-stroke family, standalone bottom-right state dot) carries PR state via `prStatusTone` through the existing `statusDotToneTextClass` map — one SVG for all states, no per-state forks. Merged PRs render the full `GitBranchIcon` in purple with no dot. Worktree-without-PR → rotated `Fork`; cloud → `CloudIcon`; local/ssh → empty cell (the cell collapses).
- Attention de-duplication: failing checks / changes requested are the dot's color; merge conflicts move to the row's status cell (`SidebarGitConflictsAlert`), behind live activity in precedence.
- Waiting clock ink quiets from `sidebar-status-waiting` to `sidebar-muted-foreground`.
- New `WorkspacePeekCard`: 450ms hover peek anchored below-left of the row (name + relative time, repo, branch, PR compound label, CI state), non-interactive, closes on leave. Built on `FixedPositionLayer` + `POPOVER_FRAME_CLASS`.

**Scroll boundary:** only the brand row + New chat stay pinned; Workspaces/Workflows/Support scroll with the repository list (`SidebarPrimaryNavigation` split into pinned/scrolling halves).

## Notes for review

- `prStatus` on `ProductSidebarWorkspaceRow` (leading-well dot overlay, §3.2) is now dead for desktop rows — left in place for the web row-view consumer.
- The handoff floated a `--pr-status-dot-color` CSS var; implemented instead via `statusDotToneTextClass` + `currentColor` on the dot circle, so the tone→ink map keeps a single owner in `StatusDot.tsx`.
- Peek card geometry uses the ruled spacing scale (`w-75` = 300px, `h-6.5` = 26px) — the appearance guard's arbitrary-bracket census stays at zero.
- `ssh` variant (not enumerated by the handoff) renders nothing, same as `local`.
- Follow-up (out of scope): `RepoGroup`'s header `SidebarActionButton` keeps a now-redundant `[&_svg]:icon-indicator` override (functional no-op).

## Verification

- Full `product-client` vitest suite green, typecheck clean, all `scripts/check_*.py` guards pass (no lint script exists in this package; the guard set is the lint).
- Negative controls: reverting the merged-PR rule and the local-null rule fails 4 tests; a hardcoded-`dotFill` control exposed a weak assertion that was then tightened until the control failed as required.
- Rebased onto `main` over #1828/#1836; the `SidebarActionButton` conflict resolved as the union (PRO-133's open-state ink + rest-prop forwarding kept, glyph tier retargeted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
