### PR TITLE
fix(product): repair AgentsPaneComposer composer-pattern import paths

### DIFF
--- a/apps/packages/product-client/src/components/workspace/delegated-work/agents-pane/AgentsPaneComposer.tsx
+++ b/apps/packages/product-client/src/components/workspace/delegated-work/agents-pane/AgentsPaneComposer.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useState, type KeyboardEvent } from "react";
 import { ArrowUp } from "#product/primitives/icons/core";
 import { Textarea } from "#product/primitives/Textarea";
-import { ComposerActionButton } from "#product/primitives/patterns/ComposerActionButton";
-import { ComposerTextareaFrame } from "#product/primitives/patterns/ComposerTextareaFrame";
+import { ComposerActionButton } from "#product/primitives/patterns/composer/ComposerActionButton";
+import { ComposerTextareaFrame } from "#product/primitives/patterns/composer/ComposerTextareaFrame";
 import { ChatComposerSurface } from "#product/components/workspace/chat/composer/ChatComposerSurface";
 import { useSessionIntentActions } from "#product/hooks/sessions/workflows/use-session-intent-actions";
 


### PR DESCRIPTION
Repairs the two composer-pattern import paths in `AgentsPaneComposer.tsx` that landed stale via the agent-ops stack transplant (#1773): the stack was authored before #1851 moved `ComposerActionButton`/`ComposerTextareaFrame` into `primitives/patterns/composer/`, and since the file was new on the stack the rebase surfaced no conflict. Vite fails to resolve the old paths, so `AgentsPane.test.tsx` and `AgentsPaneDetail.test.tsx` error at collection on main.

Verified: agents-pane vitest suites fail on main (two independent runs), pass with this fix (4 files / 33 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)