### PR TITLE
fix(product): repair shell-actions imports and agents-pane facade size

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/input/WorkspaceOpenInWebFooterControl.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/WorkspaceOpenInWebFooterControl.tsx
@@ -1,5 +1,5 @@
 import { ExternalLink } from "#product/primitives/icons/core";
-import { useWorkspaceShellActions } from "#product/components/workspace/shell/providers/WorkspaceShellActionsContext";
+import { useWorkspaceShellActions } from "#product/hooks/workspaces/workflows/use-workspace-shell-actions";
 import { ComposerControlButton } from "#product/primitives/patterns/composer/ComposerControlButton";
 
 export function WorkspaceOpenInWebFooterControl() {

--- a/apps/packages/product-client/src/components/workspace/chat/input/WorkspaceRemoteAccessFooterControl.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/WorkspaceRemoteAccessFooterControl.tsx
@@ -1,6 +1,6 @@
 import { Smartphone } from "#product/primitives/icons/platform";
 import { Spinner } from "#product/primitives/Spinner";
-import { useWorkspaceShellActions } from "#product/components/workspace/shell/providers/WorkspaceShellActionsContext";
+import { useWorkspaceShellActions } from "#product/hooks/workspaces/workflows/use-workspace-shell-actions";
 import { ComposerControlButton } from "#product/primitives/patterns/composer/ComposerControlButton";
 
 export function WorkspaceRemoteAccessFooterControl() {

--- a/apps/packages/product-client/src/hooks/agents/facade/use-agents-pane-roster-queries.ts
+++ b/apps/packages/product-client/src/hooks/agents/facade/use-agents-pane-roster-queries.ts
@@ -1,0 +1,49 @@
+import {
+  useSessionSubagentsQuery,
+  useWorkspaceSessionsQuery,
+  useWorkspaceSubagentsQuery,
+} from "@anyharness/sdk-react";
+
+// The roster is fetch-once React Query with event-driven invalidation, which
+// only covers sessions this client happens to stream. A parent's own actor
+// (a different client, a background actor swap) can update the roster with
+// nothing here to invalidate it. This modest poll is a backstop, not the
+// primary freshness mechanism, and only runs while the pane is genuinely
+// open/visible to a user who could see the staleness.
+const AGENTS_PANE_ROSTER_POLL_MS = 15_000;
+
+/**
+ * The Agents pane's three roster data sources, with the staleness-backstop
+ * poll applied while the pane is open. Split from `use-agents-pane.ts` purely
+ * along the data-fetching seam to keep that facade under the documented
+ * frontend file threshold.
+ */
+export function useAgentsPaneRosterQueries({
+  workspaceId,
+  parentSessionId,
+  isOpen,
+}: {
+  workspaceId: string;
+  parentSessionId: string | null;
+  isOpen: boolean;
+}) {
+  const workspaceRosterQuery = useWorkspaceSubagentsQuery({
+    workspaceId,
+    enabled: true,
+    refetchInterval: isOpen ? AGENTS_PANE_ROSTER_POLL_MS : false,
+    refetchOnWindowFocus: isOpen,
+  });
+  const parentRosterQuery = useSessionSubagentsQuery(parentSessionId, {
+    workspaceId,
+    enabled: parentSessionId !== null,
+    refetchInterval: isOpen ? AGENTS_PANE_ROSTER_POLL_MS : false,
+    refetchOnWindowFocus: isOpen,
+  });
+  // Kept dormant until Promote-404 convergence needs an authoritative second
+  // source. A 404 is never treated as success from roster absence alone.
+  const workspaceSessionsQuery = useWorkspaceSessionsQuery({
+    workspaceId,
+    enabled: false,
+  });
+  return { workspaceRosterQuery, parentRosterQuery, workspaceSessionsQuery };
+}

--- a/apps/packages/product-client/src/hooks/agents/facade/use-agents-pane.ts
+++ b/apps/packages/product-client/src/hooks/agents/facade/use-agents-pane.ts
@@ -1,11 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { SubagentParentRoster } from "@anyharness/sdk";
 import {
-  useSessionSubagentsQuery,
-  useWorkspaceSessionsQuery,
-  useWorkspaceSubagentsQuery,
-} from "@anyharness/sdk-react";
-import {
   useAgentsPaneRosterProjection,
 } from "#product/hooks/agents/derived/use-agents-pane-roster-projection";
 import {
@@ -28,15 +23,8 @@ import {
   useAgentsPaneNavigationStore,
 } from "#product/stores/agents/agents-pane-navigation-store";
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import { useAgentsPaneRosterQueries } from "#product/hooks/agents/facade/use-agents-pane-roster-queries";
 import { useWorkspaceActivationWorkflow } from "#product/hooks/workspaces/workflows/use-workspace-activation-workflow";
-
-// The roster is fetch-once React Query with event-driven invalidation, which
-// only covers sessions this client happens to stream. A parent's own actor
-// (a different client, a background actor swap) can update the roster with
-// nothing here to invalidate it. This modest poll is a backstop, not the
-// primary freshness mechanism, and only runs while the pane is genuinely
-// open/visible to a user who could see the staleness.
-const AGENTS_PANE_ROSTER_POLL_MS = 15_000;
 
 function rosterHasChild(
   rosters: readonly SubagentParentRoster[] | undefined,
@@ -101,25 +89,9 @@ export function useAgentsPane({
     setLifecycleError(null);
   }, [workspaceId]);
 
-  const workspaceRosterQuery = useWorkspaceSubagentsQuery({
-    workspaceId,
-    enabled: true,
-    refetchInterval: isOpen ? AGENTS_PANE_ROSTER_POLL_MS : false,
-    refetchOnWindowFocus: isOpen,
-  });
   const parentSessionId = route.kind === "overview" ? null : route.parentDurableId;
-  const parentRosterQuery = useSessionSubagentsQuery(parentSessionId, {
-    workspaceId,
-    enabled: parentSessionId !== null,
-    refetchInterval: isOpen ? AGENTS_PANE_ROSTER_POLL_MS : false,
-    refetchOnWindowFocus: isOpen,
-  });
-  // Kept dormant until Promote-404 convergence needs an authoritative second
-  // source. A 404 is never treated as success from roster absence alone.
-  const workspaceSessionsQuery = useWorkspaceSessionsQuery({
-    workspaceId,
-    enabled: false,
-  });
+  const { workspaceRosterQuery, parentRosterQuery, workspaceSessionsQuery } =
+    useAgentsPaneRosterQueries({ workspaceId, parentSessionId, isOpen });
 
   const hiddenChildIds = useMemo(() => new Set([
     ...suppressedChildIds,


### PR DESCRIPTION
Second train repair for the agent-ops stack transplant (#1773), fixing the two remaining main-red CI failures it introduced:

- **Web/desktop builds**: `WorkspaceOpenInWebFooterControl.tsx` and `WorkspaceRemoteAccessFooterControl.tsx` imported `useWorkspaceShellActions` from the pre-#1851 provider module (`WorkspaceShellActionsContext`), which no longer exports it (TS2305 in the Web/Desktop typecheck jobs). They now import from `#product/hooks/workspaces/workflows/use-workspace-shell-actions` like every other caller.
- **Repo shape (strict structure drift)**: `use-agents-pane.ts` landed at 421 lines, over the 400-line LARGE_FRONTEND_FILE threshold. The three roster queries and their staleness-backstop poll policy moved to a new `use-agents-pane-roster-queries.ts` (393 lines remain), rather than adding ratchet debt.

Verified locally: structure gate TOTAL: 0, targeted vitest over hooks/agents + chat/input + delegated-work green, `pnpm web:typecheck` green (it's the job that caught the TS2305).

Remaining known main-red: `app_state_serves_workspace_mcp_for_an_explicit_session_capability_without_launching_it` (Null vs "local") — real regression under investigation, fix to follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)