### PR TITLE
fix(product): let transparent chrome actually reveal macOS sidebar vibrancy

### DIFF
--- a/apps/packages/product-client/src/components/workspace/shell/screen/MainSidebarPageShell.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/MainSidebarPageShell.tsx
@@ -3,14 +3,15 @@ import { IconButton } from "#product/primitives/IconButton";
 import { SplitPanelLeft } from "#product/primitives/icons/app-shell";
 import { useWorkspaceSidebarResize } from "#product/hooks/preferences/ui/use-workspace-sidebar-resize";
 import {
-  MAC_WINDOW_CONTROLS_INSET_CLASS,
   useHasMacWindowControls,
+  useMacWindowControlsInsetClass,
 } from "#product/hooks/ui/layout/use-mac-window-controls";
 import { useGlassChromeCanvas } from "#product/hooks/theme/derived/use-glass-chrome-canvas";
 import { useTransparentChromeEnabled } from "#product/hooks/theme/derived/use-transparent-chrome";
 import {
   resolveMainSidebarEdgeClassName,
   resolveStandardWorkspaceChromeClasses,
+  SIDEBAR_GLASS_CLASS,
 } from "#product/lib/domain/preferences/workspace-chrome";
 import { useProductHost } from "#product/host/ProductHostProvider";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
@@ -34,9 +35,7 @@ export function MainSidebarPageShell({ children }: MainSidebarPageShellProps) {
   // Only a host that actually paints macOS window buttons reserves room for
   // them; on Web (and non-Mac desktop) the inset was dead space above the nav.
   const hasMacWindowControls = useHasMacWindowControls();
-  const macWindowControlsInsetClass = hasMacWindowControls
-    ? MAC_WINDOW_CONTROLS_INSET_CLASS
-    : "";
+  const macWindowControlsInsetClass = useMacWindowControlsInsetClass();
   // Vibrancy only exists behind the window on macOS Desktop (apply_vibrancy
   // in src-tauri/src/lib.rs); elsewhere a translucent sidebar would expose
   // the bare window fill. Matches WorkspaceShellSidebar so the main sidebar
@@ -59,7 +58,7 @@ export function MainSidebarPageShell({ children }: MainSidebarPageShellProps) {
         // isolate: keeps sidebar-internal z-indexes below the resize
         // separator's overlapping hit strip (z-10 in the page context).
         className={`isolate flex shrink-0 flex-col overflow-hidden ${
-          glassSidebar ? "bg-sidebar/60" : "bg-sidebar"
+          glassSidebar ? SIDEBAR_GLASS_CLASS : "bg-sidebar"
         } ${
           sidebarResizing
             ? "transition-none"

--- a/apps/packages/product-client/src/components/workspace/shell/screen/MainSidebarPageShell.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/MainSidebarPageShell.tsx
@@ -6,6 +6,7 @@ import {
   MAC_WINDOW_CONTROLS_INSET_CLASS,
   useHasMacWindowControls,
 } from "#product/hooks/ui/layout/use-mac-window-controls";
+import { useGlassChromeCanvas } from "#product/hooks/theme/derived/use-glass-chrome-canvas";
 import { useTransparentChromeEnabled } from "#product/hooks/theme/derived/use-transparent-chrome";
 import {
   resolveMainSidebarEdgeClassName,
@@ -41,6 +42,7 @@ export function MainSidebarPageShell({ children }: MainSidebarPageShellProps) {
   // the bare window fill. Matches WorkspaceShellSidebar so the main sidebar
   // keeps one look across route shells.
   const glassSidebar = transparentChromeEnabled && hasMacWindowControls;
+  useGlassChromeCanvas(glassSidebar);
   const chromeClasses = resolveStandardWorkspaceChromeClasses({
     transparent: transparentChromeEnabled,
     sidebarOpen,
@@ -57,7 +59,7 @@ export function MainSidebarPageShell({ children }: MainSidebarPageShellProps) {
         // isolate: keeps sidebar-internal z-indexes below the resize
         // separator's overlapping hit strip (z-10 in the page context).
         className={`isolate flex shrink-0 flex-col overflow-hidden ${
-          glassSidebar ? "bg-sidebar/70" : "bg-sidebar"
+          glassSidebar ? "bg-sidebar/60" : "bg-sidebar"
         } ${
           sidebarResizing
             ? "transition-none"
@@ -82,7 +84,7 @@ export function MainSidebarPageShell({ children }: MainSidebarPageShellProps) {
           </div>
         </div>
         <div className="min-h-0 flex-1 overflow-hidden">
-          <MainSidebar />
+          <MainSidebar glassBackground={glassSidebar} />
         </div>
       </div>
 

--- a/apps/packages/product-client/src/components/workspace/shell/screen/MainSidebarPageShell.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/MainSidebarPageShell.tsx
@@ -2,7 +2,10 @@ import type { ReactNode } from "react";
 import { IconButton } from "#product/primitives/IconButton";
 import { SplitPanelLeft } from "#product/primitives/icons/app-shell";
 import { useWorkspaceSidebarResize } from "#product/hooks/preferences/ui/use-workspace-sidebar-resize";
-import { useMacWindowControlsInsetClass } from "#product/hooks/ui/layout/use-mac-window-controls";
+import {
+  useHasMacWindowControls,
+  useMacWindowControlsInsetClass,
+} from "#product/hooks/ui/layout/use-mac-window-controls";
 import { useTransparentChromeEnabled } from "#product/hooks/theme/derived/use-transparent-chrome";
 import {
   resolveMainSidebarEdgeClassName,
@@ -30,6 +33,12 @@ export function MainSidebarPageShell({ children }: MainSidebarPageShellProps) {
   // Only a host that actually paints macOS window buttons reserves room for
   // them; on Web (and non-Mac desktop) the inset was dead space above the nav.
   const macWindowControlsInsetClass = useMacWindowControlsInsetClass();
+  // Vibrancy only exists behind the window on macOS Desktop (apply_vibrancy
+  // in src-tauri/src/lib.rs); elsewhere a translucent sidebar would expose
+  // the bare window fill. Matches WorkspaceShellSidebar so the main sidebar
+  // keeps one look across route shells.
+  const hasMacWindowControls = useHasMacWindowControls();
+  const glassSidebar = transparentChromeEnabled && hasMacWindowControls;
   const chromeClasses = resolveStandardWorkspaceChromeClasses({
     transparent: transparentChromeEnabled,
     sidebarOpen,
@@ -45,7 +54,9 @@ export function MainSidebarPageShell({ children }: MainSidebarPageShellProps) {
         id="main-sidebar"
         // isolate: keeps sidebar-internal z-indexes below the resize
         // separator's overlapping hit strip (z-10 in the page context).
-        className={`isolate flex shrink-0 flex-col overflow-hidden bg-sidebar ${
+        className={`isolate flex shrink-0 flex-col overflow-hidden ${
+          glassSidebar ? "bg-sidebar/70" : "bg-sidebar"
+        } ${
           sidebarResizing
             ? "transition-none"
             : "transition-[width] duration-panel ease-in-out"

--- a/apps/packages/product-client/src/components/workspace/shell/screen/MainSidebarPageShell.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/MainSidebarPageShell.tsx
@@ -3,8 +3,8 @@ import { IconButton } from "#product/primitives/IconButton";
 import { SplitPanelLeft } from "#product/primitives/icons/app-shell";
 import { useWorkspaceSidebarResize } from "#product/hooks/preferences/ui/use-workspace-sidebar-resize";
 import {
+  MAC_WINDOW_CONTROLS_INSET_CLASS,
   useHasMacWindowControls,
-  useMacWindowControlsInsetClass,
 } from "#product/hooks/ui/layout/use-mac-window-controls";
 import { useTransparentChromeEnabled } from "#product/hooks/theme/derived/use-transparent-chrome";
 import {
@@ -32,12 +32,14 @@ export function MainSidebarPageShell({ children }: MainSidebarPageShellProps) {
   const desktopHost = useProductHost().desktop !== null;
   // Only a host that actually paints macOS window buttons reserves room for
   // them; on Web (and non-Mac desktop) the inset was dead space above the nav.
-  const macWindowControlsInsetClass = useMacWindowControlsInsetClass();
+  const hasMacWindowControls = useHasMacWindowControls();
+  const macWindowControlsInsetClass = hasMacWindowControls
+    ? MAC_WINDOW_CONTROLS_INSET_CLASS
+    : "";
   // Vibrancy only exists behind the window on macOS Desktop (apply_vibrancy
   // in src-tauri/src/lib.rs); elsewhere a translucent sidebar would expose
   // the bare window fill. Matches WorkspaceShellSidebar so the main sidebar
   // keeps one look across route shells.
-  const hasMacWindowControls = useHasMacWindowControls();
   const glassSidebar = transparentChromeEnabled && hasMacWindowControls;
   const chromeClasses = resolveStandardWorkspaceChromeClasses({
     transparent: transparentChromeEnabled,

--- a/apps/packages/product-client/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
@@ -245,6 +245,10 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
               <WorkspaceShellSidebar
                 open={sidebarOpen}
                 width={sidebarWidth}
+                // Vibrancy only exists behind the window on macOS Desktop
+                // (apply_vibrancy in src-tauri/src/lib.rs); elsewhere a
+                // translucent sidebar would expose the bare window fill.
+                glassBackground={transparentChromeEnabled && hasMacWindowControls}
                 showAnimatedDivider={transparentChromeEnabled}
                 snapGeometry={workspaceGeometry.snapLeft}
                 onToggleSidebar={workspaceGeometry.toggleLeft}

--- a/apps/packages/product-client/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
@@ -24,6 +24,7 @@ import { OfflineIndicator } from "#product/components/app/OfflineIndicator";
 import { useMainScreenState } from "#product/hooks/main/facade/use-main-screen-state";
 import { useMainScreenShortcuts } from "#product/hooks/main/lifecycle/use-main-screen-shortcuts";
 import { useMainScreenActions } from "#product/hooks/main/workflows/use-main-screen-actions";
+import { useGlassChromeCanvas } from "#product/hooks/theme/derived/use-glass-chrome-canvas";
 import { useTransparentChromeEnabled } from "#product/hooks/theme/derived/use-transparent-chrome";
 import { useDebugRenderCount } from "#product/hooks/ui/debug/use-debug-render-count";
 import { useHasMacWindowControls } from "#product/hooks/ui/layout/use-mac-window-controls";
@@ -98,6 +99,7 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
   } = layout;
   const transparentChromeEnabled = useTransparentChromeEnabled();
   const hasMacWindowControls = useHasMacWindowControls();
+  useGlassChromeCanvas(transparentChromeEnabled && hasMacWindowControls);
   const workspaceGeometry = useWorkspaceShellGeometry({
     leftWidth: sidebarOpen ? sidebarWidth : 0,
     rightWidth: hasWorkspaceShell && !hasLaunchIntentOnlyShell && rightPanelOpen

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx
@@ -54,7 +54,13 @@ import { useShortcutRevealVisible } from "#product/providers/ShortcutRevealProvi
 import { useReleaseNotice } from "#product/hooks/updates/facade/use-release-notice";
 import { useRepositoryHeaderNewChat } from "#product/hooks/workspaces/ui/use-repository-header-new-chat";
 
-export const MainSidebar = memo(function MainSidebar({ showRightBorder = true }: { showRightBorder?: boolean }) {
+export const MainSidebar = memo(function MainSidebar({
+  showRightBorder = true,
+  glassBackground = false,
+}: {
+  showRightBorder?: boolean;
+  glassBackground?: boolean;
+}) {
   useDebugRenderCount("workspace-sidebar");
   useSessionActivityReconciler();
   const { notice, dismissNotice, openChangelog } = useReleaseNotice();
@@ -243,7 +249,7 @@ export const MainSidebar = memo(function MainSidebar({ showRightBorder = true }:
 
   return (
     <DebugProfiler id="workspace-sidebar">
-      <ProductSidebarFrame showRightBorder={showRightBorder} footer={(
+      <ProductSidebarFrame showRightBorder={showRightBorder} glassBackground={glassBackground} footer={(
           <DebugProfiler id="workspace-sidebar-footer">
             {sidebarOpen && notice ? (
               <ReleaseNoticeCard

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/ProductSidebarLayout.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/ProductSidebarLayout.test.tsx
@@ -1,0 +1,33 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ProductSidebarFrame } from "#product/components/workspace/shell/sidebar/ProductSidebarLayout";
+
+describe("ProductSidebarFrame", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("paints its own opaque sidebar background by default", () => {
+    const { container } = render(
+      <ProductSidebarFrame>
+        <span>content</span>
+      </ProductSidebarFrame>,
+    );
+    const frame = container.firstElementChild as HTMLElement;
+    expect(frame.classList.contains("bg-sidebar")).toBe(true);
+    expect(frame.classList.contains("bg-transparent")).toBe(false);
+  });
+
+  it("cedes the background to the shell panel when glassBackground is set", () => {
+    const { container } = render(
+      <ProductSidebarFrame glassBackground>
+        <span>content</span>
+      </ProductSidebarFrame>,
+    );
+    const frame = container.firstElementChild as HTMLElement;
+    expect(frame.classList.contains("bg-transparent")).toBe(true);
+    expect(frame.classList.contains("bg-sidebar")).toBe(false);
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/ProductSidebarLayout.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/ProductSidebarLayout.tsx
@@ -9,15 +9,23 @@ export function ProductSidebarFrame({
   footer = null,
   className = "",
   showRightBorder = true,
+  glassBackground = false,
 }: {
   children: ReactNode;
   footer?: ReactNode;
   className?: string;
   showRightBorder?: boolean;
+  /**
+   * When the enclosing shell panel owns the sidebar background (the
+   * translucent glass treatment), the frame must not paint its own opaque
+   * bg-sidebar over it — that layer would sit above the panel's and turn
+   * the glass solid again.
+   */
+  glassBackground?: boolean;
 }) {
   return (
     <div
-      className={`flex h-full flex-col gap-2 ${showRightBorder ? "border-r border-border" : ""} bg-sidebar text-sidebar-foreground select-none ${className}`}
+      className={`flex h-full flex-col gap-2 ${showRightBorder ? "border-r border-border" : ""} ${glassBackground ? "bg-transparent" : "bg-sidebar"} text-sidebar-foreground select-none ${className}`}
     >
       {children}
       {footer}

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.test.tsx
@@ -357,3 +357,59 @@ describe("WorkspaceShellSidebar hover peek", () => {
     expect(peekState(panel)).toBe("closed");
   });
 });
+
+describe("WorkspaceShellSidebar glass background", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  function renderGlassSidebar(open: boolean) {
+    render(
+      <WorkspaceShellSidebar
+        open={open}
+        width={280}
+        glassBackground
+        onToggleSidebar={() => {}}
+      />,
+    );
+    const panel = document.getElementById("main-sidebar");
+    if (!panel) {
+      throw new Error("sidebar panel did not render");
+    }
+    return panel;
+  }
+
+  it("paints the docked panel translucent", () => {
+    const panel = renderGlassSidebar(true);
+    expect(panel.classList.contains("bg-sidebar/70")).toBe(true);
+    expect(panel.classList.contains("bg-sidebar")).toBe(false);
+  });
+
+  /**
+   * The collapsed-hover peek floats the same panel over the content pane,
+   * where a translucent fill would bleed chat content through instead of
+   * window vibrancy — the peek must stay opaque even in glass mode.
+   */
+  it("keeps the peek overlay opaque", () => {
+    const panel = renderGlassSidebar(false);
+    const trigger = document.querySelector("[data-sidebar-peek-trigger]");
+    if (!trigger) {
+      throw new Error("peek trigger did not render");
+    }
+
+    fireEvent.mouseEnter(trigger);
+
+    expect(peekState(panel)).toBe("open");
+    expect(panel.classList.contains("bg-sidebar")).toBe(true);
+    expect(panel.classList.contains("bg-sidebar/70")).toBe(false);
+  });
+
+  it("stays opaque when glass is not requested", () => {
+    render(
+      <WorkspaceShellSidebar open width={280} onToggleSidebar={() => {}} />,
+    );
+    const panel = document.getElementById("main-sidebar");
+    expect(panel?.classList.contains("bg-sidebar")).toBe(true);
+    expect(panel?.classList.contains("bg-sidebar/70")).toBe(false);
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.test.tsx
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { motion } from "@proliferate/design/motion";
@@ -11,10 +11,17 @@ vi.mock("#product/components/diagnostics/DebugProfiler", () => ({
 }));
 
 vi.mock("#product/components/workspace/shell/sidebar/MainSidebar", () => ({
-  MainSidebar: ({ showRightBorder }: { showRightBorder?: boolean }) => (
+  MainSidebar: ({
+    showRightBorder,
+    glassBackground,
+  }: {
+    showRightBorder?: boolean;
+    glassBackground?: boolean;
+  }) => (
     <div
       data-testid="main-sidebar-body"
       data-show-right-border={showRightBorder ? "true" : "false"}
+      data-glass-background={glassBackground ? "true" : "false"}
     >
       <button type="button">Main navigation item</button>
     </div>
@@ -381,7 +388,7 @@ describe("WorkspaceShellSidebar glass background", () => {
 
   it("paints the docked panel translucent", () => {
     const panel = renderGlassSidebar(true);
-    expect(panel.classList.contains("bg-sidebar/70")).toBe(true);
+    expect(panel.classList.contains("bg-sidebar/60")).toBe(true);
     expect(panel.classList.contains("bg-sidebar")).toBe(false);
   });
 
@@ -401,7 +408,7 @@ describe("WorkspaceShellSidebar glass background", () => {
 
     expect(peekState(panel)).toBe("open");
     expect(panel.classList.contains("bg-sidebar")).toBe(true);
-    expect(panel.classList.contains("bg-sidebar/70")).toBe(false);
+    expect(panel.classList.contains("bg-sidebar/60")).toBe(false);
   });
 
   it("stays opaque when glass is not requested", () => {
@@ -410,6 +417,23 @@ describe("WorkspaceShellSidebar glass background", () => {
     );
     const panel = document.getElementById("main-sidebar");
     expect(panel?.classList.contains("bg-sidebar")).toBe(true);
-    expect(panel?.classList.contains("bg-sidebar/70")).toBe(false);
+    expect(panel?.classList.contains("bg-sidebar/60")).toBe(false);
+  });
+
+  /**
+   * The frame inside the panel must cede its background in glass mode — an
+   * opaque inner frame paints over the panel's translucency and turns the
+   * glass solid again no matter what the panel class says.
+   */
+  it("forwards glass to the inner sidebar frame", () => {
+    renderGlassSidebar(true);
+    expect(screen.getByTestId("main-sidebar-body").dataset.glassBackground).toBe("true");
+  });
+
+  it("keeps the inner frame opaque when glass is not requested", () => {
+    render(
+      <WorkspaceShellSidebar open width={280} onToggleSidebar={() => {}} />,
+    );
+    expect(screen.getByTestId("main-sidebar-body").dataset.glassBackground).toBe("false");
   });
 });

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.tsx
@@ -3,6 +3,7 @@ import { DebugProfiler } from "#product/components/diagnostics/DebugProfiler";
 import { MainSidebar } from "#product/components/workspace/shell/sidebar/MainSidebar";
 import { WorkspaceSidebarHeaderControls } from "#product/components/workspace/shell/sidebar/WorkspaceSidebarHeaderControls";
 import { useWorkspaceSidebarPeek } from "#product/hooks/workspaces/ui/use-workspace-sidebar-peek";
+import { SIDEBAR_GLASS_CLASS } from "#product/lib/domain/preferences/workspace-chrome";
 
 interface WorkspaceShellSidebarProps {
   open: boolean;
@@ -49,7 +50,7 @@ export function WorkspaceShellSidebar({
   // over the content pane, where a translucent fill would bleed chat content
   // through instead of window vibrancy.
   const panelBackgroundClass = glassBackground && (open || toggleClosing)
-    ? "bg-sidebar/60"
+    ? SIDEBAR_GLASS_CLASS
     : "bg-sidebar";
 
   const panelStateClass = open

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.tsx
@@ -39,7 +39,7 @@ export function WorkspaceShellSidebar({
       <div className="flex h-full min-h-0 flex-col">
         <div className="h-[46px] shrink-0" data-tauri-drag-region="true" />
         <div className="flex-1 min-h-0 overflow-hidden">
-          <MainSidebar showRightBorder={false} />
+          <MainSidebar showRightBorder={false} glassBackground={glassBackground} />
         </div>
       </div>
     </DebugProfiler>
@@ -49,7 +49,7 @@ export function WorkspaceShellSidebar({
   // over the content pane, where a translucent fill would bleed chat content
   // through instead of window vibrancy.
   const panelBackgroundClass = glassBackground && (open || toggleClosing)
-    ? "bg-sidebar/70"
+    ? "bg-sidebar/60"
     : "bg-sidebar";
 
   const panelStateClass = open

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceShellSidebar.tsx
@@ -7,6 +7,7 @@ import { useWorkspaceSidebarPeek } from "#product/hooks/workspaces/ui/use-worksp
 interface WorkspaceShellSidebarProps {
   open: boolean;
   width: number;
+  glassBackground?: boolean;
   showAnimatedDivider?: boolean;
   snapGeometry?: boolean;
   onToggleSidebar: (options?: { snapGeometry?: boolean }) => void;
@@ -15,6 +16,7 @@ interface WorkspaceShellSidebarProps {
 export function WorkspaceShellSidebar({
   open,
   width,
+  glassBackground = false,
   showAnimatedDivider = false,
   snapGeometry = false,
   onToggleSidebar,
@@ -42,6 +44,13 @@ export function WorkspaceShellSidebar({
       </div>
     </DebugProfiler>
   );
+
+  // Glass only while docked: the collapsed-hover peek floats the same panel
+  // over the content pane, where a translucent fill would bleed chat content
+  // through instead of window vibrancy.
+  const panelBackgroundClass = glassBackground && (open || toggleClosing)
+    ? "bg-sidebar/70"
+    : "bg-sidebar";
 
   const panelStateClass = open
     ? `pointer-events-auto translate-x-0 opacity-100 ${
@@ -86,7 +95,7 @@ export function WorkspaceShellSidebar({
       >
         <div
           id="main-sidebar"
-          className={`absolute inset-y-0 left-0 flex flex-col overflow-hidden bg-sidebar will-change-[opacity,translate] ${panelStateClass}`}
+          className={`absolute inset-y-0 left-0 flex flex-col overflow-hidden ${panelBackgroundClass} will-change-[opacity,translate] ${panelStateClass}`}
           style={{ width }}
           inert={!open && !peekVisible}
           data-sidebar-peek={peekState}

--- a/apps/packages/product-client/src/hooks/theme/derived/use-glass-chrome-canvas.test.tsx
+++ b/apps/packages/product-client/src/hooks/theme/derived/use-glass-chrome-canvas.test.tsx
@@ -28,6 +28,20 @@ describe("useGlassChromeCanvas", () => {
     expect(document.documentElement.style.backgroundColor).toBe("rgb(20, 20, 20)");
   });
 
+  it("keeps the canvas transparent while any concurrent mount is still active", () => {
+    document.documentElement.style.backgroundColor = "rgb(20, 20, 20)";
+
+    const first = renderHook(() => useGlassChromeCanvas(true));
+    const second = renderHook(() => useGlassChromeCanvas(true));
+    expect(document.documentElement.style.backgroundColor).toBe("transparent");
+
+    first.unmount();
+    expect(document.documentElement.style.backgroundColor).toBe("transparent");
+
+    second.unmount();
+    expect(document.documentElement.style.backgroundColor).toBe("rgb(20, 20, 20)");
+  });
+
   it("leaves the canvas untouched while inactive", () => {
     document.documentElement.style.backgroundColor = "rgb(20, 20, 20)";
 

--- a/apps/packages/product-client/src/hooks/theme/derived/use-glass-chrome-canvas.test.tsx
+++ b/apps/packages/product-client/src/hooks/theme/derived/use-glass-chrome-canvas.test.tsx
@@ -1,0 +1,40 @@
+/* @vitest-environment jsdom */
+
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useGlassChromeCanvas } from "#product/hooks/theme/derived/use-glass-chrome-canvas";
+
+describe("useGlassChromeCanvas", () => {
+  afterEach(() => {
+    document.documentElement.style.backgroundColor = "";
+  });
+
+  it("makes the canvas transparent while active and restores it after", () => {
+    document.documentElement.style.backgroundColor = "rgb(20, 20, 20)";
+
+    const { rerender, unmount } = renderHook(
+      ({ active }: { active: boolean }) => useGlassChromeCanvas(active),
+      { initialProps: { active: true } },
+    );
+    expect(document.documentElement.style.backgroundColor).toBe("transparent");
+
+    rerender({ active: false });
+    expect(document.documentElement.style.backgroundColor).toBe("rgb(20, 20, 20)");
+
+    rerender({ active: true });
+    expect(document.documentElement.style.backgroundColor).toBe("transparent");
+
+    unmount();
+    expect(document.documentElement.style.backgroundColor).toBe("rgb(20, 20, 20)");
+  });
+
+  it("leaves the canvas untouched while inactive", () => {
+    document.documentElement.style.backgroundColor = "rgb(20, 20, 20)";
+
+    const { unmount } = renderHook(() => useGlassChromeCanvas(false));
+    expect(document.documentElement.style.backgroundColor).toBe("rgb(20, 20, 20)");
+
+    unmount();
+    expect(document.documentElement.style.backgroundColor).toBe("rgb(20, 20, 20)");
+  });
+});

--- a/apps/packages/product-client/src/hooks/theme/derived/use-glass-chrome-canvas.ts
+++ b/apps/packages/product-client/src/hooks/theme/derived/use-glass-chrome-canvas.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+
+/**
+ * The design system paints the page canvas opaque (`:root { background:
+ * var(--color-background) }` in product.css), and `:root` outranks the later
+ * `html, body { background: transparent }` rule by specificity. An opaque
+ * canvas blocks the macOS window's vibrancy no matter how transparent the DOM
+ * below it is, so while glass chrome is active the shell overrides the canvas
+ * with an inline style (which outranks any stylesheet rule) and restores the
+ * stylesheet value when glass turns off or the shell unmounts.
+ */
+export function useGlassChromeCanvas(active: boolean): void {
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+    const root = document.documentElement;
+    const previous = root.style.backgroundColor;
+    root.style.backgroundColor = "transparent";
+    return () => {
+      root.style.backgroundColor = previous;
+    };
+  }, [active]);
+}

--- a/apps/packages/product-client/src/hooks/theme/derived/use-glass-chrome-canvas.ts
+++ b/apps/packages/product-client/src/hooks/theme/derived/use-glass-chrome-canvas.ts
@@ -8,17 +8,34 @@ import { useEffect } from "react";
  * below it is, so while glass chrome is active the shell overrides the canvas
  * with an inline style (which outranks any stylesheet rule) and restores the
  * stylesheet value when glass turns off or the shell unmounts.
+ *
+ * AuthenticatedAppHost can keep StandardWorkspaceShell mounted-but-hidden
+ * while MainSidebarPageShell is shown (and vice versa), so this hook can be
+ * mounted twice concurrently; a module-level refcount ensures only the first
+ * active mount saves the pre-existing inline background and only the last
+ * active mount to unmount restores it, instead of each instance racing to
+ * save/restore independently and leaving "transparent" stuck.
  */
+let activeCount = 0;
+let savedBackground: string | null = null;
+
 export function useGlassChromeCanvas(active: boolean): void {
   useEffect(() => {
     if (!active) {
       return;
     }
     const root = document.documentElement;
-    const previous = root.style.backgroundColor;
+    if (activeCount === 0) {
+      savedBackground = root.style.backgroundColor;
+    }
+    activeCount += 1;
     root.style.backgroundColor = "transparent";
     return () => {
-      root.style.backgroundColor = previous;
+      activeCount -= 1;
+      if (activeCount === 0) {
+        root.style.backgroundColor = savedBackground ?? "";
+        savedBackground = null;
+      }
     };
   }, [active]);
 }

--- a/apps/packages/product-client/src/lib/domain/preferences/workspace-chrome.ts
+++ b/apps/packages/product-client/src/lib/domain/preferences/workspace-chrome.ts
@@ -25,6 +25,13 @@ const TERMINAL_GLASS_TABLIST_RAIL_CLASS =
 const TERMINAL_SOLID_TABLIST_RAIL_CLASS =
   "relative flex shrink-0 items-center gap-1 overflow-hidden pr-1";
 
+// The main sidebar is the one surface that goes translucent while docked
+// under transparent chrome (WorkspaceShellSidebar, MainSidebarPageShell). No
+// backdrop-blur here: unlike the header/tablist bands above, the sidebar
+// relies on the macOS window's native vibrancy showing through, not a CSS
+// blur over page content.
+export const SIDEBAR_GLASS_CLASS = "bg-sidebar/60";
+
 export interface StandardWorkspaceChromeClasses {
   root: string;
   contentShell: string;
@@ -81,10 +88,13 @@ export function resolveStandardWorkspaceChromeClasses({
 
   return {
     root: transparent ? "bg-transparent" : "bg-sidebar",
-    // The content shell always paints opaque. The sidebar and chat center are
-    // opaque regardless of chrome mode, so a transparent shell only ever
-    // exposed window vibrancy through the header/footer/right-panel bands —
-    // rendering them as off-shade stripes on every theme.
+    // The content shell always paints opaque. The main sidebar is the
+    // exception (see SIDEBAR_GLASS_CLASS) — it renders translucent glass
+    // while docked under transparent chrome. Everywhere else (the chat
+    // center) stays opaque regardless of chrome mode, so a transparent shell
+    // otherwise only ever exposed window vibrancy through the
+    // header/footer/right-panel bands — rendering them as off-shade stripes
+    // on every theme.
     contentShell: transparent
       ? "bg-background"
       : [


### PR DESCRIPTION
## Problem

The Settings → Appearance "Transparent chrome" toggle was inert: glass on vs off looked identical. The Rust side was always correct (transparent window, `macos-private-api`, `apply_vibrancy` with the Sidebar material) — proven with a red `set_background_color` probe that showed through only during startup, before the page painted.

## Root cause — two opaque web layers

1. **Opaque `<html>` canvas by specificity.** `design/product.css` sets `:root { background: var(--color-background) }`. `:root` is a pseudo-class (specificity 0,1,0), so it beats the later `html, body { background: transparent }` type-selector rule (0,0,1). The transparent canvas the stylesheet intends never applied.
2. **Opaque inner sidebar frame.** `ProductSidebarFrame` hardcoded `bg-sidebar`, painting a solid layer inside the shell panel's translucent one — even with a transparent canvas, the sidebar stayed solid.

## Fix

- New `useGlassChromeCanvas(active)` hook sets an inline `background-color: transparent` on `documentElement` (inline style outranks all stylesheet specificity) and restores on cleanup. Scoped to toggle-on + macOS desktop, so hosted web keeps its opaque canvas.
- `ProductSidebarFrame` gains a `glassBackground` prop (threaded from `StandardWorkspaceShell` and `MainSidebarPageShell` through `MainSidebar`) so exactly one layer owns the sidebar background.
- Glass fill is `bg-sidebar/60` so the vibrancy reads clearly. Glass applies only while the sidebar is docked — the collapsed hover-peek floats over content and stays opaque.

## Verification

- 28 tests across the hook, frame, and shell sidebar (incl. negative controls: default stays opaque, hook inactive leaves the canvas untouched).
- Live in the dev app: toggle on → sidebar renders wallpaper-tinted vibrancy while the content pane stays opaque; toggle off → flat `bg-sidebar`.