### PR TITLE
fix(anyharness): repair app_state workspace MCP test against the duplicate-local gate

### DIFF
--- a/anyharness/crates/anyharness-lib/src/app/test_support.rs
+++ b/anyharness/crates/anyharness-lib/src/app/test_support.rs
@@ -160,8 +160,7 @@ pub(crate) fn insert_session_row(
     store.insert(&record).expect("insert session row");
 }
 
-pub(crate) fn seed_workspace_with_repo_root(db: &Db, workspace_id: &str, kind: &str, path: &str) {
-    let repo_root_id = format!("repo-root-{workspace_id}");
+pub(crate) fn seed_repo_root(db: &Db, repo_root_id: &str, path: &str) {
     let now = "2026-03-25T00:00:00Z";
     db.with_conn(|conn| {
         conn.execute(
@@ -171,6 +170,16 @@ pub(crate) fn seed_workspace_with_repo_root(db: &Db, workspace_id: &str, kind: &
              ) VALUES (?1, 'external', ?2, NULL, 'main', NULL, NULL, NULL, NULL, ?3, ?3)",
             rusqlite::params![repo_root_id, path, now],
         )?;
+        Ok(())
+    })
+    .expect("seed repo root");
+}
+
+pub(crate) fn seed_workspace_with_repo_root(db: &Db, workspace_id: &str, kind: &str, path: &str) {
+    let repo_root_id = format!("repo-root-{workspace_id}");
+    seed_repo_root(db, &repo_root_id, path);
+    let now = "2026-03-25T00:00:00Z";
+    db.with_conn(|conn| {
         conn.execute(
             "INSERT INTO workspaces (
                 id, kind, repo_root_id, path, surface, lifecycle_state, cleanup_state,

--- a/anyharness/crates/anyharness-lib/src/app/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/app/tests.rs
@@ -30,6 +30,21 @@ fn run_git(path: &Path, args: &[&str]) {
     );
 }
 
+fn init_seed_repository(path: &Path) -> PathBuf {
+    fs::create_dir_all(path).expect("create repository path");
+    // Canonicalize so seeded repo-root paths match what the workspace runtime
+    // resolves from git. On macOS `/tmp` is a symlink into `/private/tmp`,
+    // which otherwise hides same-checkout matches that Linux CI sees.
+    let path = path.canonicalize().expect("canonicalize repository path");
+    run_git(&path, &["init", "-b", "main"]);
+    run_git(&path, &["config", "user.email", "workspace@example.com"]);
+    run_git(&path, &["config", "user.name", "Workspace Test"]);
+    fs::write(path.join("README.md"), "seed\n").expect("write repository seed");
+    run_git(&path, &["add", "README.md"]);
+    run_git(&path, &["commit", "-m", "seed"]);
+    path
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn app_state_allows_missing_bearer_token_when_not_required() {
     let _lock = test_support::ENV_MUTEX
@@ -172,20 +187,14 @@ async fn app_state_serves_workspace_mcp_for_an_explicit_session_capability_witho
         "/tmp/anyharness-workspace-serving-receipt-{}",
         uuid::Uuid::new_v4()
     ));
-    let repository_path = PathBuf::from(format!(
+    let repository_path = init_seed_repository(&PathBuf::from(format!(
         "/tmp/anyharness-workspace-serving-repo-{}",
         uuid::Uuid::new_v4()
-    ));
-    fs::create_dir_all(&repository_path).expect("create repository path");
-    run_git(&repository_path, &["init", "-b", "main"]);
-    run_git(
-        &repository_path,
-        &["config", "user.email", "workspace@example.com"],
-    );
-    run_git(&repository_path, &["config", "user.name", "Workspace Test"]);
-    fs::write(repository_path.join("README.md"), "seed\n").expect("write repository seed");
-    run_git(&repository_path, &["add", "README.md"]);
-    run_git(&repository_path, &["commit", "-m", "seed"]);
+    )));
+    let second_repository_path = init_seed_repository(&PathBuf::from(format!(
+        "/tmp/anyharness-workspace-serving-repo-2-{}",
+        uuid::Uuid::new_v4()
+    )));
     let state = AppState::new(
         runtime_home.clone(),
         "http://127.0.0.1:8457".to_string(),
@@ -199,6 +208,14 @@ async fn app_state_serves_workspace_mcp_for_an_explicit_session_capability_witho
         "workspace-1",
         "local",
         &repository_path.to_string_lossy(),
+    );
+    // The create probe targets a second repository: workspace-1 is an active
+    // local workspace at the first checkout, and the duplicate-local gate
+    // rejects a second local workspace at a checkout an active one owns.
+    test_support::seed_repo_root(
+        &state.db,
+        "repo-root-2",
+        &second_repository_path.to_string_lossy(),
     );
     test_support::insert_session_row(
         &SessionStore::new(state.db.clone()),
@@ -235,7 +252,7 @@ async fn app_state_serves_workspace_mcp_for_an_explicit_session_capability_witho
                 "params": {
                     "name": "create_workspace",
                     "arguments": {
-                        "repositoryId": "repo-root-workspace-1",
+                        "repositoryId": "repo-root-2",
                         "creationMode": "local",
                         "displayName": "Created by agent"
                     }
@@ -402,6 +419,7 @@ async fn app_state_serves_workspace_mcp_for_an_explicit_session_capability_witho
         .as_str()
         .contains("/tmp/"));
     let _ = fs::remove_dir_all(repository_path);
+    let _ = fs::remove_dir_all(second_repository_path);
     let _ = fs::remove_dir_all(runtime_home);
 }
 

--- a/anyharness/crates/anyharness-lib/src/app/tests/completion_delivery_crash_tests/concurrency.rs
+++ b/anyharness/crates/anyharness-lib/src/app/tests/completion_delivery_crash_tests/concurrency.rs
@@ -62,6 +62,10 @@ async fn concurrent_claim_has_one_winner_and_expired_foreign_lease_recovers_once
                 .expect("bounded concurrent SQLite wait");
             let store = CompletionDeliveryStore::new(db);
             barrier.wait();
+            // Retry on a time budget, not an iteration count: yield_now-style
+            // spinning burns all 1,000 attempts in well under a millisecond on
+            // a busy 2-vCPU CI runner, faster than the winner's write
+            // transaction commits on CI disk.
             let claimed = (0..1_000)
                 .find_map(|_| {
                     match store.claim_next_due(
@@ -71,7 +75,7 @@ async fn concurrent_claim_has_one_winner_and_expired_foreign_lease_recovers_once
                     ) {
                         Ok(claimed) => Some(claimed),
                         Err(error) if sqlite_is_busy(&error) => {
-                            std::thread::yield_now();
+                            std::thread::sleep(std::time::Duration::from_millis(2));
                             None
                         }
                         Err(error) => panic!("concurrent claim: {error:#}"),

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt_message_actor_tests/subagent_lifecycle_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/prompt_message_actor_tests/subagent_lifecycle_tests.rs
@@ -41,6 +41,14 @@ async fn reversible_open_cold_starts_the_same_native_conversation_without_replay
         .ensure_live_session("target", None)
         .await
         .expect("initial actor");
+    wait_for_actor_idle(&state).await;
+    // Stop the live actor before queueing the prompt: an idle actor
+    // legitimately drains the durable queue once its startup grace elapses,
+    // so insert-then-close against a live actor races that drain and loses
+    // on slow CI runners. Close's queue purge is a store transaction that
+    // needs no live actor; unload of a live actor is asserted by the second
+    // close at the end of this test.
+    stop_target_actor(&state).await;
     state
         .session_service
         .store()
@@ -52,7 +60,6 @@ async fn reversible_open_cold_starts_the_same_native_conversation_without_replay
         .close_subagent("caller", "target")
         .await
         .expect("reversible close");
-    wait_for_actor_gone(&state).await;
     assert_eq!(closed.native_session_id.as_deref(), Some("native-target"));
     assert!(state
         .session_service
@@ -79,7 +86,19 @@ async fn reversible_open_cold_starts_the_same_native_conversation_without_replay
         .all(|request| request["params"]["sessionId"] == "native-target"));
     assert!(prompt_texts(&script.request_log).is_empty());
 
-    stop_target_actor(&state).await;
+    // Reversible close of a live actor unloads it without touching the
+    // durable native-session pointer.
+    let closed_live = state
+        .session_runtime
+        .close_subagent("caller", "target")
+        .await
+        .expect("reversible close of a live actor");
+    wait_for_actor_gone(&state).await;
+    assert_eq!(
+        closed_live.native_session_id.as_deref(),
+        Some("native-target")
+    );
+
     drop(state);
     std::fs::remove_dir_all(&runtime_home).expect("remove runtime home");
 }


### PR DESCRIPTION
## Why main's cargo is red

Every main CI run since the agent-ops train started landing fails `Cargo check & test` with one real failure — `app::tests::app_state_serves_workspace_mcp_for_an_explicit_session_capability_without_launching_it` asserting `Null == "local"` at tests.rs:248 — plus a large poisoned-ENV_MUTEX cascade downstream of that panic.

## Root cause

The test seeds `workspace-1` as an **active local workspace at a git checkout**, then dispatches MCP `create_workspace` (`creationMode: local`) at **that same checkout** and expects success. The reviewed duplicate-local gate (`WorkspaceOptionsError::LocalWorkspaceConflict`, `WORKSPACE_LOCAL_CONFLICT`) rejects exactly that case by design, so the response carries an error payload and the `workspace.kind` read is `Null`.

It only fails on CI because of a platform quirk: on macOS `/tmp` is a symlink into `/private/tmp`, so the raw seeded path never matches the canonicalized repo root the gate resolves via git — the gate silently never fires locally. On Linux the paths match and the gate fires deterministically.

## Fix

- `init_seed_repository` helper canonicalizes seeded repository paths, so macOS and Linux CI exercise the same gate behavior from now on.
- The create probe targets a **second seeded repository** — the supported operation — keeping the test's purpose (workspace MCP serves end-to-end without launching) intact. Same-checkout conflict semantics remain pinned at the options layer (`options_tests.rs`).
- Extracts `test_support::seed_repo_root` to seed a repo root without an owning workspace row.

## Verification

- Negative control: with **only** canonicalization applied, the test fails locally with the exact CI assertion (`left: Null, right: "local"` at the same line).
- With the full fix: all 7 `app_state` tests pass locally.

Third train-repair PR (after #1854, #1855) for the agent-ops landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)