### PR TITLE
fix(ci): ship styled macOS DMGs by opting out of tauri's CI styling skip

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -370,6 +370,12 @@ jobs:
           _API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           _API_KEY: ${{ secrets.APPLE_API_KEY }}
           ALLOW_UNSIGNED: ${{ inputs.allow_unsigned && 'true' || 'false' }}
+          # GitHub sets CI=true, which makes tauri-bundler pass --skip-jenkins to
+          # bundle_dmg.sh and silently skip all DMG styling from tauri.conf.json
+          # (background, icon positions, window size). Opt back in; if the Finder
+          # AppleScript fails the DMG build exits non-zero, so this cannot regress
+          # into silently shipping an unstyled DMG. See PRO-110.
+          TAURI_BUNDLER_DMG_IGNORE_CI: "true"
         run: |
           desktop_version="$(node -p "require('./package.json').version")"
           anyharness_version="$(grep '^version' ../../anyharness/crates/anyharness/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')"
@@ -449,6 +455,19 @@ jobs:
             compgen -G "$base/dmg/*.dmg" > /dev/null || { echo "::error::Missing macOS DMG"; exit 1; }
             compgen -G "$base/macos/*.app.tar.gz" > /dev/null || { echo "::error::Missing macOS updater tarball"; exit 1; }
             compgen -G "$base/macos/*.app.tar.gz.sig" > /dev/null || { echo "::error::Missing macOS updater signature"; exit 1; }
+
+            # DMG styling lives in a .DS_Store written by the Finder AppleScript
+            # during bundling. Tauri skips that script when CI=true unless
+            # TAURI_BUNDLER_DMG_IGNORE_CI=true, so assert it actually landed to
+            # keep the unstyled-DMG regression from ever shipping again (PRO-110).
+            dmg=$(compgen -G "$base/dmg/*.dmg" | head -n 1)
+            mount_dir=$(mktemp -d)
+            hdiutil attach "$dmg" -readonly -nobrowse -noautoopen -mountpoint "$mount_dir"
+            styling_ok=true
+            [[ -f "$mount_dir/.DS_Store" ]] || styling_ok=false
+            # Retry the detach once: Spotlight can hold the fresh volume busy.
+            hdiutil detach "$mount_dir" -quiet || { sleep 2; hdiutil detach "$mount_dir" -force; }
+            $styling_ok || { echo "::error::DMG has no .DS_Store — Finder styling was skipped (see PRO-110)"; exit 1; }
           else
             compgen -G "$base/nsis/*-setup.exe" > /dev/null || { echo "::error::Missing Windows NSIS installer"; exit 1; }
             compgen -G "$base/nsis/*-setup.exe.sig" > /dev/null || { echo "::error::Missing Windows updater signature"; exit 1; }


### PR DESCRIPTION
## Problem (PRO-110)

Every released macOS DMG opens as a bare white Finder window — no background art, no drag-to-Applications layout — even though `tauri.conf.json` has declared full DMG styling (background TIFF, icon positions, 660×400 window) since mid-July.

## Root cause

tauri-bundler passes `--skip-jenkins` to its `bundle_dmg.sh` whenever `CI=true` (which GitHub Actions always sets) unless `TAURI_BUNDLER_DMG_IGNORE_CI=true`. `--skip-jenkins` skips the entire Finder AppleScript that writes the DMG's `.DS_Store` — which is where **all** the styling lives; the background TIFF is copied into the volume but nothing references it. The skip is silent: the script's output is swallowed by the tauri CLI, so every release built green while shipping unstyled.

Confirmed against tauri-cli 2.11.4 source (`dmg/mod.rs` L172–180, tauri issue #592) and by mounting the released `Proliferate_0.4.10_aarch64.dmg`: it contains `.background/` and the volume icon but **no `.DS_Store`**.

## Fix

- Set `TAURI_BUNDLER_DMG_IGNORE_CI: "true"` on the Build Tauri app step so the styling AppleScript runs on the runner.
- Add a post-build guard to Verify updater artifacts: mount the DMG and assert `.DS_Store` exists, so this regression class can never ship silently again (e.g. if a tauri upgrade changes the env-var contract).

Failure mode if Finder scripting flakes on a runner: `bundle_dmg.sh` exits non-zero → retryable red job, never a silently unstyled release. Escalation path if chronically flaky: `dmgbuild` (writes `.DS_Store` headlessly) — deliberately not built now.

## Validation

- `actionlint` clean.
- Negative control: guard logic run against released v0.4.10 DMG → fails (no `.DS_Store`), proving it catches the current bug.
- Positive control: guard run against a locally styled DMG (built with tauri's own `bundle_dmg.sh` + this repo's exact config args/assets) → passes; window visually approved by Pablo.
- End-to-end: next `release-desktop` run; the new guard asserts styling mechanically, and the DMG artifact can be mounted for a visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
