### PR TITLE
fix(product): paint switches instantly with a clean loader instead of skeletons (PRO-182)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/surface/ChatLoadingHero.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/surface/ChatLoadingHero.tsx
@@ -1,5 +1,5 @@
 import { useChatLoadingSubstep } from "#product/hooks/chat/derived/use-chat-loading-substep";
-import { SkeletonBlock } from "#product/primitives/Skeleton";
+import { DotCellLoader } from "#product/primitives/DotCellLoader";
 import { ThinkingText } from "#product/primitives/patterns/ThinkingText";
 import { DebugProfiler } from "#product/components/diagnostics/DebugProfiler";
 import { useDebugRenderCount } from "#product/hooks/ui/debug/use-debug-render-count";
@@ -15,10 +15,11 @@ export function ChatLoadingHero() {
         {showThinking ? (
           <ThinkingText />
         ) : (
-          <div className="flex w-36 flex-col items-center gap-2" aria-hidden="true">
-            <SkeletonBlock className="h-2 w-24" />
-            <SkeletonBlock className="h-2 w-36 bg-muted/45" />
-          </div>
+          <DotCellLoader
+            aria-hidden="true"
+            className="text-muted-foreground"
+            variant="wave"
+          />
         )}
         {caption && (
           <p className="mt-4 text-chat font-medium text-muted-foreground">

--- a/apps/packages/product-client/src/components/workspace/chat/surface/TranscriptSwitchingPlaceholder.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/surface/TranscriptSwitchingPlaceholder.test.tsx
@@ -18,4 +18,14 @@ describe("TranscriptSwitchingPlaceholder", () => {
     expect(gutter.className).toContain(CHAT_SURFACE_GUTTER_CLASSNAME);
     expect(gutter.firstElementChild?.className).toContain(CHAT_COLUMN_CLASSNAME);
   });
+
+  it("shows a delayed clean loader instead of message skeletons (PRO-182)", () => {
+    render(<TranscriptSwitchingPlaceholder label="Switching chat" />);
+
+    const gutter = screen.getByRole("status", { name: "Switching chat" });
+    expect(gutter.querySelector("[data-dot-cell-loader]")).not.toBeNull();
+    // The delayed fade keeps fast switches from flashing the loader.
+    expect(gutter.firstElementChild?.className).toContain("animate-content-fade-in");
+    expect(gutter.textContent).toContain("Switching chat");
+  });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/surface/TranscriptSwitchingPlaceholder.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/surface/TranscriptSwitchingPlaceholder.tsx
@@ -1,31 +1,17 @@
 import { DebugProfiler } from "#product/components/diagnostics/DebugProfiler";
+import { DotCellLoader } from "#product/primitives/DotCellLoader";
 import {
   CHAT_COLUMN_CLASSNAME,
   CHAT_SURFACE_GUTTER_CLASSNAME,
 } from "#product/config/chat-layout";
 
-function AssistantMessageSkeleton() {
-  return (
-    <div className="flex max-w-[88%] flex-col gap-2">
-      <div className="h-3 w-24 rounded-md bg-muted/60" />
-      <div className="h-3 w-full rounded-md bg-muted/45" />
-      <div className="h-3 w-[92%] rounded-md bg-muted/45" />
-      <div className="h-3 w-[68%] rounded-md bg-muted/45" />
-    </div>
-  );
-}
-
-function UserMessageSkeleton() {
-  return (
-    <div className="flex justify-end">
-      <div className="flex w-[min(22rem,72%)] flex-col items-end gap-2">
-        <div className="h-3 w-20 rounded-md bg-muted/60" />
-        <div className="h-10 w-full rounded-md bg-muted/45" />
-      </div>
-    </div>
-  );
-}
-
+/**
+ * The chat pane's switch/load wait state: a centered activity cell instead of
+ * fake message skeletons (PRO-182 — a clean loader reads better than a
+ * transient skeleton that content immediately replaces). The delayed
+ * `content-fade-in` keeps sub-200ms switches loader-free so fast paths never
+ * flash it.
+ */
 export function TranscriptSwitchingPlaceholder({
   label = "Loading chat",
 }: {
@@ -40,13 +26,11 @@ export function TranscriptSwitchingPlaceholder({
         data-chat-switching-placeholder
       >
         <div
-          className={`${CHAT_COLUMN_CLASSNAME} flex flex-1 flex-col gap-6 motion-safe:animate-pulse`}
+          className={`${CHAT_COLUMN_CLASSNAME} flex flex-1 flex-col items-center justify-center gap-3 animate-content-fade-in [animation-delay:var(--duration-disclosure)] [animation-fill-mode:backwards]`}
           aria-hidden="true"
         >
-          <UserMessageSkeleton />
-          <AssistantMessageSkeleton />
-          <UserMessageSkeleton />
-          <AssistantMessageSkeleton />
+          <DotCellLoader className="text-muted-foreground" variant="wave" />
+          <p className="text-chat font-medium text-muted-foreground">{label}</p>
         </div>
       </div>
     </DebugProfiler>

--- a/apps/packages/product-client/src/hooks/app/workflows/use-app-navigation-command-actions.ts
+++ b/apps/packages/product-client/src/hooks/app/workflows/use-app-navigation-command-actions.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { APP_ROUTES } from "#product/config/app-routes";
+import { navigateApp } from "#product/lib/workflows/app/app-navigate-handoff";
 import { useWebAppTarget } from "#product/hooks/capabilities/derived/use-web-app-target";
 import { useWorkspaceNavigationWorkflow } from "#product/hooks/workspaces/workflows/use-workspace-navigation-workflow";
 import { useOpenSupportReportWindow } from "#product/hooks/support/workflows/use-open-support-report-window";
@@ -22,15 +22,17 @@ export type AppNavigationCommandActions = Pick<
 
 // Owns top-level app navigation/support commands shared by shortcuts and palette actions.
 export function useAppNavigationCommandActions(): AppNavigationCommandActions {
-  const navigate = useNavigate();
   const showToast = useToastStore((state) => state.show);
   const { openExternal } = useProductHost().links;
   const webApp = useWebAppTarget();
   const { goToTopLevelRoute } = useWorkspaceNavigationWorkflow();
 
+  // navigateApp instead of useNavigate: these are callback-only commands, and
+  // useNavigate would subscribe every command surface (and the lifecycle root
+  // composing them) to each location change (PRO-170, PRO-182).
   const openSettings = useCallback(() => {
-    navigate("/settings?section=account");
-  }, [navigate]);
+    navigateApp("/settings?section=account");
+  }, []);
   const openShortcutsDialog = useKeyboardShortcutsDialogStore((state) => state.setOpen);
   const showKeyboardShortcuts = useCallback(() => {
     openShortcutsDialog(true);

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/right-panel/use-right-panel-entry-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/right-panel/use-right-panel-entry-actions.ts
@@ -5,7 +5,6 @@ import {
   type SetStateAction,
 } from "react";
 import type { TerminalRecord } from "@anyharness/sdk";
-import { useNavigate } from "react-router-dom";
 import { useTerminalActions } from "#product/hooks/terminals/workflows/use-terminal-actions";
 import {
   parseRightPanelHeaderEntryKey,
@@ -29,6 +28,7 @@ import {
   type ViewerTargetKey,
 } from "#product/lib/domain/workspaces/viewer/viewer-target";
 import { useToastStore } from "#product/stores/toast/toast-store";
+import { navigateApp } from "#product/lib/workflows/app/app-navigate-handoff";
 import type { WorkspaceFileBuffer } from "#product/stores/editor/workspace-file-buffers-store";
 import { useRightPanelViewerActions } from "#product/hooks/workspaces/workflows/right-panel/use-right-panel-viewer-actions";
 import { useWorkspaceRuntimeBlock } from "#product/hooks/workspaces/derived/use-workspace-runtime-block";
@@ -75,7 +75,6 @@ export function useRightPanelEntryActions({
   clearBuffer,
 }: UseRightPanelEntryActionsOptions) {
   const { createTab, closeTab, renameTab } = useTerminalActions();
-  const navigate = useNavigate();
   const showToast = useToastStore((store) => store.show);
   const showErrorToast = useToastStore((store) => store.showError);
   const { getWorkspaceRuntimeBlockReason } = useWorkspaceRuntimeBlock();
@@ -337,9 +336,11 @@ export function useRightPanelEntryActions({
     void createTerminal({ activate: true });
   }, [createTerminal]);
 
+  // navigateApp instead of useNavigate: callback-only, so the right panel is
+  // not subscribed to every location change (PRO-170, PRO-182).
   const handleOpenRepoSettings = useCallback(() => {
-    navigate(repoSettingsHref);
-  }, [navigate, repoSettingsHref]);
+    navigateApp(repoSettingsHref);
+  }, [repoSettingsHref]);
 
   return {
     terminalFocusNonce,

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-navigation-workflow.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-navigation-workflow.test.tsx
@@ -4,9 +4,8 @@ import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useWorkspaceNavigationWorkflow } from "#product/hooks/workspaces/workflows/use-workspace-navigation-workflow";
 
-const routerMocks = vi.hoisted(() => ({
-  navigate: vi.fn(),
-  location: { pathname: "/" },
+const navigateMocks = vi.hoisted(() => ({
+  navigateApp: vi.fn(),
 }));
 
 const harnessMocks = vi.hoisted(() => ({
@@ -47,9 +46,8 @@ const latencyMocks = vi.hoisted(() => ({
   startLatencyFlow: vi.fn(() => "flow-1"),
 }));
 
-vi.mock("react-router-dom", () => ({
-  useLocation: () => routerMocks.location,
-  useNavigate: () => routerMocks.navigate,
+vi.mock("#product/lib/workflows/app/app-navigate-handoff", () => ({
+  navigateApp: navigateMocks.navigateApp,
 }));
 
 vi.mock("#product/stores/sessions/session-selection-store", () => ({
@@ -106,7 +104,7 @@ vi.mock("#product/lib/infra/measurement/measurement-port", () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
-  routerMocks.location.pathname = "/";
+  window.history.replaceState(null, "", "/");
   harnessMocks.state.pendingWorkspaceEntry = null;
   harnessMocks.state.selectedLogicalWorkspaceId = null;
   harnessMocks.state.selectedWorkspaceId = null;
@@ -125,7 +123,7 @@ describe("useWorkspaceNavigationWorkflow", () => {
 
     expect(harnessMocks.state.deselectWorkspacePreservingSessions).toHaveBeenCalledTimes(1);
     expect(editorMocks.resetWorkspaceEditorState).toHaveBeenCalledTimes(1);
-    expect(routerMocks.navigate).toHaveBeenCalledWith("/");
+    expect(navigateMocks.navigateApp).toHaveBeenCalledWith("/");
   });
 
   it("deselects pending workspace state before top-level navigation", () => {
@@ -136,7 +134,7 @@ describe("useWorkspaceNavigationWorkflow", () => {
 
     expect(harnessMocks.state.deselectWorkspacePreservingSessions).toHaveBeenCalledTimes(1);
     expect(editorMocks.resetWorkspaceEditorState).toHaveBeenCalledTimes(1);
-    expect(routerMocks.navigate).toHaveBeenCalledWith("/");
+    expect(navigateMocks.navigateApp).toHaveBeenCalledWith("/");
   });
 
   it("deselects logical-only workspace state before top-level navigation", () => {
@@ -147,17 +145,17 @@ describe("useWorkspaceNavigationWorkflow", () => {
 
     expect(harnessMocks.state.deselectWorkspacePreservingSessions).toHaveBeenCalledTimes(1);
     expect(editorMocks.resetWorkspaceEditorState).toHaveBeenCalledTimes(1);
-    expect(routerMocks.navigate).toHaveBeenCalledWith("/");
+    expect(navigateMocks.navigateApp).toHaveBeenCalledWith("/");
   });
 
   it("selects workspaces through the shared latency and viewed-state workflow", () => {
-    routerMocks.location.pathname = "/settings";
+    window.history.replaceState(null, "", "/settings");
     harnessMocks.state.selectedLogicalWorkspaceId = "logical-current";
     const { result } = renderHook(() => useWorkspaceNavigationWorkflow());
 
     act(() => result.current.selectWorkspaceFromSurface("logical-current", "shortcut"));
 
-    expect(routerMocks.navigate).toHaveBeenCalledWith("/");
+    expect(navigateMocks.navigateApp).toHaveBeenCalledWith("/");
     expect(workspaceUiMocks.markWorkspaceViewed).toHaveBeenCalledWith("logical-current");
     expect(latencyMocks.startLatencyFlow).toHaveBeenCalledWith({
       flowKind: "workspace_switch",
@@ -187,7 +185,7 @@ describe("useWorkspaceNavigationWorkflow", () => {
       "https://web.proliferate.com/cloud/workspaces/cloud-unclaimed-1",
     );
     expect(selectionMocks.selectWorkspace).not.toHaveBeenCalled();
-    expect(routerMocks.navigate).not.toHaveBeenCalled();
+    expect(navigateMocks.navigateApp).not.toHaveBeenCalled();
   });
 
   it("falls through to normal in-desktop selection when this deployment has no web app", () => {

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-navigation-workflow.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-navigation-workflow.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { webWorkspaceDeepLink } from "@proliferate/cloud-sdk";
-import { useLocation, useNavigate } from "react-router-dom";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
+import { navigateApp } from "#product/lib/workflows/app/app-navigate-handoff";
 import { useWebAppTarget } from "#product/hooks/capabilities/derived/use-web-app-target";
 import { useWorkspaceSelection } from "#product/hooks/workspaces/workflows/selection/use-workspace-selection";
 import { useLogicalWorkspaces } from "#product/hooks/workspaces/derived/use-logical-workspaces";
@@ -15,9 +15,13 @@ import { markWorkspaceViewed } from "#product/stores/preferences/workspace-ui-st
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useToastStore } from "#product/stores/toast/toast-store";
 
+// Navigation-only workflow: every consumer calls these inside event handlers,
+// so it reads the URL at call time and navigates through the `navigateApp`
+// handoff instead of `useLocation`/`useNavigate` — in declarative-router mode
+// those subscribe their caller (the sidebar, the lifecycle root, command
+// surfaces) to every location change, re-rendering them on each page switch
+// and Settings section click (PRO-170, PRO-182).
 export function useWorkspaceNavigationWorkflow() {
-  const location = useLocation();
-  const navigate = useNavigate();
   const deselectWorkspacePreservingSessions = useSessionSelectionStore(
     (state) => state.deselectWorkspacePreservingSessions,
   );
@@ -34,20 +38,19 @@ export function useWorkspaceNavigationWorkflow() {
   const showErrorToast = useToastStore((state) => state.showError);
 
   const navigateToWorkspaceShell = useCallback(() => {
-    if (location.pathname !== "/") {
-      navigate("/");
+    if (window.location.pathname !== "/") {
+      navigateApp("/");
     }
-  }, [location.pathname, navigate]);
+  }, []);
 
   const goToTopLevelRoute = useCallback((path: string) => {
     if (selectedWorkspaceId || selectedLogicalWorkspaceId || pendingWorkspaceEntry) {
       deselectWorkspacePreservingSessions();
       resetWorkspaceEditorState();
     }
-    navigate(path);
+    navigateApp(path);
   }, [
     deselectWorkspacePreservingSessions,
-    navigate,
     pendingWorkspaceEntry,
     selectedLogicalWorkspaceId,
     selectedWorkspaceId,

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-retire-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-retire-actions.ts
@@ -1,5 +1,5 @@
-import { useNavigate } from "react-router-dom";
 import { APP_ROUTES } from "#product/config/app-routes";
+import { navigateApp } from "#product/lib/workflows/app/app-navigate-handoff";
 import { useWorkspaceCollectionsInvalidation } from "#product/hooks/workspaces/cache/use-workspace-collections-invalidation";
 import { clearWorkspaceRuntimeState } from "#product/hooks/workspaces/workflows/selection/clear-runtime-state";
 import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
@@ -13,8 +13,10 @@ import {
   retryRetireWorkspaceCleanup,
 } from "#product/lib/access/anyharness/workspaces";
 
+// navigateApp instead of useNavigate: retire actions run only inside click
+// callbacks, and useNavigate would subscribe the sidebar to every location
+// change (PRO-170, PRO-182).
 export function useWorkspaceRetireActions() {
-  const navigate = useNavigate();
   const runtimeUrl = useHarnessConnectionStore((state) => state.runtimeUrl);
   const refresh = useWorkspaceCollectionsInvalidation(runtimeUrl);
   const clearSelection = useSessionSelectionStore((state) => state.clearSelection);
@@ -53,7 +55,7 @@ export function useWorkspaceRetireActions() {
         );
         if (targetIsSelected) {
           setSelectedLogicalWorkspaceId(null);
-          navigate(APP_ROUTES.home);
+          navigateApp(APP_ROUTES.home);
         }
       }
       await refresh();

--- a/apps/packages/product-client/src/pages/WorkspacesPage.test.tsx
+++ b/apps/packages/product-client/src/pages/WorkspacesPage.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { type ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
 import type { AppCommandActions } from "#product/hooks/app/workflows/app-command-action-types";
+import { setAppNavigate } from "#product/lib/workflows/app/app-navigate-handoff";
 import { WorkspacesPage } from "#product/pages/WorkspacesPage";
 import { AppCommandActionsProvider } from "#product/providers/AppCommandActionsProvider";
 import {
@@ -125,10 +126,22 @@ afterEach(() => {
   cleanup();
 });
 
+// Mirrors AuthenticatedAppHost, which registers the router navigate for
+// callback-only `navigateApp` consumers like goToTopLevelRoute.
+function RegisterAppNavigate() {
+  const navigate = useNavigate();
+  useEffect(() => {
+    setAppNavigate(navigate);
+    return () => setAppNavigate(null);
+  }, [navigate]);
+  return null;
+}
+
 describe("WorkspacesPage creation", () => {
   it("enters Home's repository worktree flow before creating a workspace", async () => {
     render(
       <MemoryRouter initialEntries={["/workspaces"]}>
+        <RegisterAppNavigate />
         <AppCommandActionsProvider value={appCommands()}>
           <Routes>
             <Route path="/workspaces" element={<WorkspacesPage />} />

--- a/scripts/appearance_scaling_baseline.json
+++ b/scripts/appearance_scaling_baseline.json
@@ -147,7 +147,6 @@
     "apps/packages/product-client/src/components/workspace/chat/input/workspace-status/WorkspaceStatusComposerControl.tsx|arbitrary-bracket-geometry": 1,
     "apps/packages/product-client/src/components/workspace/chat/plans/PlanHandoffDialog.tsx|foreground-alpha-foundation": 2,
     "apps/packages/product-client/src/components/workspace/chat/surface/SessionContentSearchOverlay.tsx|arbitrary-bracket-geometry": 3,
-    "apps/packages/product-client/src/components/workspace/chat/surface/TranscriptSwitchingPlaceholder.tsx|arbitrary-bracket-geometry": 3,
     "apps/packages/product-client/src/components/workspace/chat/transcript/ProviderLinkMention.tsx|arbitrary-bracket-geometry": 2,
     "apps/packages/product-client/src/components/workspace/cowork/CoworkWorkspaceShell.tsx|arbitrary-bracket-geometry": 1,
     "apps/packages/product-client/src/components/workspace/cowork/sidebar/CoworkManagedWorkspaceList.tsx|arbitrary-bracket-geometry": 2,


### PR DESCRIPTION
Fixes [PRO-182](https://linear.app/proliferate-team/issue/PRO-182/slightly-improved-latency-loading-skeletons-helps-a-lot-with).

## What was happening

Frame-stepping the ticket recording and measuring the live app (debug measurement engine + CDP-driven switches) shows the switch itself is already optimistic — selection state commits synchronously before any await. The felt latency is what happens after:

1. One urgent long task (~110–260ms dev) re-renders the whole shell before the first new frame.
2. `SessionTranscriptPane` defers the session identity (`useDeferredValue`), so the pane paints `TranscriptSwitchingPlaceholder` — four faint pulsing skeleton bars — while the new transcript mounts in the deferred lane: 60–90ms for small transcripts, **400–750ms for real ones**. In dark mode this reads as a dead blank pane (the recording's blanks).
3. Cold opens add the session-directory fetch on top.
4. On every navigation (including each Settings section click), callback-only workflow hooks subscribed always-mounted surfaces — sidebar, lifecycle root, right panel, command surfaces — to the router via `useNavigate`/`useLocation`, re-rendering them all per URL change.

## What this changes

- **Clean loader over transient skeleton** (the ticket's explicit ask): `TranscriptSwitchingPlaceholder` and `ChatLoadingHero` now render a centered `DotCellLoader` + dim label behind a disclosure-duration delayed fade (`animate-content-fade-in`), so sub-200ms hot switches never flash it and slow switches show a deliberate loader instead of a blank pane.
- **Page switches stop paying the router tax**: `use-workspace-navigation-workflow`, `use-app-navigation-command-actions`, `use-workspace-retire-actions`, and `use-right-panel-entry-actions` are callback-only, and now navigate via the `navigateApp` handoff (PRO-170 pattern, #1845) reading `window.location` at call time. Both hosts mount plain `BrowserRouter`, so the read is exact.
- **Build repair**: two composer controls imported `useWorkspaceShellActions` from the provider module and broke `make build` (same class as #1854).

## Verification

- Full product-client suite green (5,940 passed; only the two pre-existing local-Chrome Playwright suites fail on machines without Chrome). Typecheck green. Appearance-scaling guard green (census ratcheted down for the placeholder file).
- Live-verified in the running desktop client: shell swaps in the first commit, the "Switching chat" loader is present during switches and invisible on fast ones, hot switch to content ~135–175ms, sidebar/home/workspaces/worktree-creation navigation all work through the handoff.

## Deliberate non-changes (follow-up candidates)

- `WorkspaceProviders`' `useLocation` and the command palette's home-route check are render-semantic and keep their subscriptions.
- The transcript mount cost itself (virtualized already; remaining cost is per-row markdown) and the right panel's per-switch remount ("Loading file" hanging for seconds in the recording) are separate sinks worth their own tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)