### PR TITLE
fix(product): keep the transcript glued through prompt submit (PRO-174)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/transcript/ChatTranscriptView.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/ChatTranscriptView.tsx
@@ -81,7 +81,7 @@ export function ChatTranscriptView({
         isSessionBusy={
           model.sessionViewState === "working" || model.sessionViewState === "needs_input"
         }
-        pendingPromptText={model.visibleOptimisticPrompt?.text ?? null}
+        lastPromptSubmittedAtMs={model.lastPromptSubmittedAtMs}
         onLoadOlderHistory={model.onLoadOlderHistory}
         onScrollSample={onScrollSample}
         renderRow={renderVirtualRow}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.test.tsx
@@ -131,11 +131,33 @@ describe("FullTranscriptRowList", () => {
     fireEvent.scroll(viewport, { target: { scrollTop: 400 } });
     expect(button?.getAttribute("aria-hidden")).toBe("false");
 
-    // pendingPromptText's null -> non-null transition is an explicit
-    // return-to-bottom intent; it must re-pin even though the user scrolled
-    // away and the pin was never re-earned.
-    rerender(<FullTranscriptRowList {...props} pendingPromptText="hello" />);
+    // A rising submission stamp is an explicit return-to-bottom intent; it
+    // must re-pin even though the user scrolled away and the pin was never
+    // re-earned.
+    rerender(<FullTranscriptRowList {...props} lastPromptSubmittedAtMs={1_000} />);
 
+    expect(viewport.scrollTop).toBe(1_000);
+    expect(button?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("does not re-pin when the newest submission stamp falls (entry left the outbox)", () => {
+    const props = { ...makeProps(vi.fn(), 50), lastPromptSubmittedAtMs: 2_000 };
+    const { container, rerender } = render(<FullTranscriptRowList {...props} />);
+    const viewport = getViewport(container);
+    const button = container.querySelector('[aria-label="Scroll to bottom"]');
+    Object.defineProperty(viewport, "scrollHeight", { value: 1_000, configurable: true });
+    Object.defineProperty(viewport, "clientHeight", { value: 0, configurable: true });
+    fireEvent.scroll(viewport, { target: { scrollTop: 400 } });
+    expect(button?.getAttribute("aria-hidden")).toBe("false");
+
+    // The newest entry leaving the outbox (delivery, dismissal) lowers the
+    // stamp; that is not a submit and must not fight the user's position.
+    rerender(<FullTranscriptRowList {...props} lastPromptSubmittedAtMs={1_000} />);
+    expect(viewport.scrollTop).toBe(400);
+    expect(button?.getAttribute("aria-hidden")).toBe("false");
+
+    // The next real submit raises it past every stamp seen before — re-pin.
+    rerender(<FullTranscriptRowList {...props} lastPromptSubmittedAtMs={3_000} />);
     expect(viewport.scrollTop).toBe(1_000);
     expect(button?.getAttribute("aria-hidden")).toBe("true");
   });
@@ -266,7 +288,7 @@ function makeProps(
     selectedWorkspaceId: "workspace-1",
     activeSessionId: "session-1",
     isSessionBusy: false,
-    pendingPromptText: null,
+    lastPromptSubmittedAtMs: null,
     onLoadOlderHistory,
     onScrollSample: vi.fn(),
     renderRow: (row: TranscriptVirtualRow) => <div>{row.key}</div>,

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.test.tsx
@@ -121,6 +121,25 @@ describe("FullTranscriptRowList", () => {
     expect(viewport.scrollTop).toBe(600);
   });
 
+  it("re-pins to the bottom on prompt submit even if the pin was already lost", () => {
+    const props = makeProps(vi.fn(), 50);
+    const { container, rerender } = render(<FullTranscriptRowList {...props} />);
+    const viewport = getViewport(container);
+    const button = container.querySelector('[aria-label="Scroll to bottom"]');
+    Object.defineProperty(viewport, "scrollHeight", { value: 1_000, configurable: true });
+    Object.defineProperty(viewport, "clientHeight", { value: 0, configurable: true });
+    fireEvent.scroll(viewport, { target: { scrollTop: 400 } });
+    expect(button?.getAttribute("aria-hidden")).toBe("false");
+
+    // pendingPromptText's null -> non-null transition is an explicit
+    // return-to-bottom intent; it must re-pin even though the user scrolled
+    // away and the pin was never re-earned.
+    rerender(<FullTranscriptRowList {...props} pendingPromptText="hello" />);
+
+    expect(viewport.scrollTop).toBe(1_000);
+    expect(button?.getAttribute("aria-hidden")).toBe("true");
+  });
+
   it("adds manual scroll range for composer cards without moving the transcript", () => {
     const notifyResize = stubCapturingResizeObserver();
     const props = makeProps(vi.fn(), 50);

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.test.tsx
@@ -162,6 +162,29 @@ describe("FullTranscriptRowList", () => {
     expect(button?.getAttribute("aria-hidden")).toBe("true");
   });
 
+  it("submit re-pins to the soft bottom, preserving the manual-only overlay range", () => {
+    const props = {
+      ...makeProps(vi.fn(), 50),
+      bottomInsetPx: 160,
+      nonDisplacingBottomInsetPx: 160,
+    };
+    const { container, rerender } = render(<FullTranscriptRowList {...props} />);
+    const viewport = getViewport(container);
+    const button = container.querySelector('[aria-label="Scroll to bottom"]');
+    Object.defineProperty(viewport, "scrollHeight", { value: 1_000, configurable: true });
+    Object.defineProperty(viewport, "clientHeight", { value: 0, configurable: true });
+    fireEvent.scroll(viewport, { target: { scrollTop: 400 } });
+    expect(button?.getAttribute("aria-hidden")).toBe("false");
+
+    // Unlike the scroll-to-bottom button, a submit must not consume the
+    // manual-only overlay range: the follow target is the soft bottom above
+    // the dock-slot card (hard bottom 1000 minus the 160px overlay range),
+    // so the stream never slides under the card.
+    rerender(<FullTranscriptRowList {...props} lastPromptSubmittedAtMs={1_000} />);
+    expect(viewport.scrollTop).toBe(840);
+    expect(button?.getAttribute("aria-hidden")).toBe("true");
+  });
+
   it("adds manual scroll range for composer cards without moving the transcript", () => {
     const notifyResize = stubCapturingResizeObserver();
     const props = makeProps(vi.fn(), 50);

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.tsx
@@ -53,7 +53,7 @@ export function FullTranscriptRowList({
   selectedWorkspaceId,
   activeSessionId,
   isSessionBusy,
-  pendingPromptText,
+  lastPromptSubmittedAtMs,
   onLoadOlderHistory,
   onScrollSample,
   renderRow,
@@ -80,7 +80,6 @@ export function FullTranscriptRowList({
     notifyUserScrollIntent,
     scrollToBottom,
     handleScrollToBottomClick,
-    pinToBottom,
     notifyProgrammaticScroll,
     setPinned,
     resetForSession,
@@ -88,6 +87,7 @@ export function FullTranscriptRowList({
     scrollRef,
     onScrollSample,
     autoFollowBottomInsetPx: effectiveNonDisplacingBottomInsetPx,
+    lastPromptSubmittedAtMs,
   });
 
   // Content-search jump-to-match. The full list mounts every row, so the
@@ -221,20 +221,6 @@ export function FullTranscriptRowList({
     };
   }, [isLoadingOlderHistory, maybeLoadOlderHistory, rows.length]);
 
-  // Submitting a prompt is an explicit return-to-bottom intent. Re-pin on the
-  // optimistic prompt's arrival — before the pinned snap effect below reads
-  // the pin — so a pin silently lost during typing cannot leave the sent
-  // bubble clipped behind the dock. Only the null -> non-null transition
-  // qualifies; the prompt materializing (clearing the text) must not re-pin.
-  const previousPendingPromptTextRef = useRef(pendingPromptText);
-  useLayoutEffect(() => {
-    const hadPendingPrompt = previousPendingPromptTextRef.current != null;
-    previousPendingPromptTextRef.current = pendingPromptText;
-    if (!hadPendingPrompt && pendingPromptText != null) {
-      pinToBottom();
-    }
-  }, [pendingPromptText, pinToBottom]);
-
   useLayoutEffect(() => {
     if (!pinnedRef.current) {
       return;
@@ -243,7 +229,7 @@ export function FullTranscriptRowList({
   }, [
     structuralBottomInsetPx,
     isSessionBusy,
-    pendingPromptText,
+    lastPromptSubmittedAtMs,
     pinnedRef,
     rows,
     scrollToBottom,

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.tsx
@@ -80,6 +80,7 @@ export function FullTranscriptRowList({
     notifyUserScrollIntent,
     scrollToBottom,
     handleScrollToBottomClick,
+    pinToBottom,
     notifyProgrammaticScroll,
     setPinned,
     resetForSession,
@@ -219,6 +220,20 @@ export function FullTranscriptRowList({
       window.cancelAnimationFrame(frame);
     };
   }, [isLoadingOlderHistory, maybeLoadOlderHistory, rows.length]);
+
+  // Submitting a prompt is an explicit return-to-bottom intent. Re-pin on the
+  // optimistic prompt's arrival — before the pinned snap effect below reads
+  // the pin — so a pin silently lost during typing cannot leave the sent
+  // bubble clipped behind the dock. Only the null -> non-null transition
+  // qualifies; the prompt materializing (clearing the text) must not re-pin.
+  const previousPendingPromptTextRef = useRef(pendingPromptText);
+  useLayoutEffect(() => {
+    const hadPendingPrompt = previousPendingPromptTextRef.current != null;
+    previousPendingPromptTextRef.current = pendingPromptText;
+    if (!hadPendingPrompt && pendingPromptText != null) {
+      pinToBottom();
+    }
+  }, [pendingPromptText, pinToBottom]);
 
   useLayoutEffect(() => {
     if (!pinnedRef.current) {

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx
@@ -169,6 +169,31 @@ describe("VirtualizedTranscriptRowList", () => {
     expect(button?.getAttribute("aria-hidden")).toBe("false");
   });
 
+  it("re-pins to the bottom on prompt submit even if the pin was already lost", () => {
+    const props = makeProps();
+    const { container, rerender } = render(<VirtualizedTranscriptRowList {...props} />);
+    const viewport = getViewport(container);
+    const button = container.querySelector('[aria-label="Scroll to bottom"]');
+    Object.defineProperty(viewport, "scrollHeight", { value: 2000, configurable: true });
+    Object.defineProperty(viewport, "clientHeight", { value: 300, configurable: true });
+    // Short of the reachable bottom (2000 - 300 = 1700) so the re-pin below
+    // has an actual scrollTop write to assert on, not a same-position no-op.
+    viewport.scrollTop = 1_400;
+
+    act(() => {
+      fireEvent.wheel(viewport, { deltaY: -80 });
+    });
+    expect(button?.getAttribute("aria-hidden")).toBe("false");
+
+    // pendingPromptText's null -> non-null transition is an explicit
+    // return-to-bottom intent; it must re-pin even though the user scrolled
+    // away and the pin was never re-earned.
+    rerender(<VirtualizedTranscriptRowList {...props} pendingPromptText="hello" />);
+
+    expect(viewport.scrollTop).toBe(2000);
+    expect(button?.getAttribute("aria-hidden")).toBe("true");
+  });
+
   it("adds an overlay spacer without changing the current scroll position", () => {
     const props = makeProps();
     const { container, rerender } = render(

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx
@@ -58,7 +58,7 @@ function makeProps() {
     selectedWorkspaceId: "workspace-1",
     activeSessionId: "session-1",
     isSessionBusy: false,
-    pendingPromptText: null,
+    lastPromptSubmittedAtMs: null,
     onLoadOlderHistory: vi.fn(),
     onScrollSample: vi.fn(),
     renderRow: (row: TranscriptVirtualRow) => <div>{row.key}</div>,
@@ -185,11 +185,43 @@ describe("VirtualizedTranscriptRowList", () => {
     });
     expect(button?.getAttribute("aria-hidden")).toBe("false");
 
-    // pendingPromptText's null -> non-null transition is an explicit
-    // return-to-bottom intent; it must re-pin even though the user scrolled
-    // away and the pin was never re-earned.
-    rerender(<VirtualizedTranscriptRowList {...props} pendingPromptText="hello" />);
+    // A rising submission stamp is an explicit return-to-bottom intent; it
+    // must re-pin even though the user scrolled away and the pin was never
+    // re-earned.
+    rerender(
+      <VirtualizedTranscriptRowList {...props} lastPromptSubmittedAtMs={1_000} />,
+    );
 
+    expect(viewport.scrollTop).toBe(2000);
+    expect(button?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("does not re-pin when the newest submission stamp falls (entry left the outbox)", () => {
+    const props = { ...makeProps(), lastPromptSubmittedAtMs: 2_000 };
+    const { container, rerender } = render(<VirtualizedTranscriptRowList {...props} />);
+    const viewport = getViewport(container);
+    const button = container.querySelector('[aria-label="Scroll to bottom"]');
+    Object.defineProperty(viewport, "scrollHeight", { value: 2000, configurable: true });
+    Object.defineProperty(viewport, "clientHeight", { value: 300, configurable: true });
+    viewport.scrollTop = 1_400;
+
+    act(() => {
+      fireEvent.wheel(viewport, { deltaY: -80 });
+    });
+    expect(button?.getAttribute("aria-hidden")).toBe("false");
+
+    // The newest entry leaving the outbox (delivery, dismissal) lowers the
+    // stamp; that is not a submit and must not fight the user's position.
+    rerender(
+      <VirtualizedTranscriptRowList {...props} lastPromptSubmittedAtMs={1_000} />,
+    );
+    expect(viewport.scrollTop).toBe(1_400);
+    expect(button?.getAttribute("aria-hidden")).toBe("false");
+
+    // The next real submit raises it past every stamp seen before — re-pin.
+    rerender(
+      <VirtualizedTranscriptRowList {...props} lastPromptSubmittedAtMs={3_000} />,
+    );
     expect(viewport.scrollTop).toBe(2000);
     expect(button?.getAttribute("aria-hidden")).toBe("true");
   });

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.tsx
@@ -66,6 +66,7 @@ export function VirtualizedTranscriptRowList({
     notifyUserScrollIntent,
     scrollToBottom,
     handleScrollToBottomClick,
+    pinToBottom,
     notifyProgrammaticScroll,
     setPinned,
     resetForSession,
@@ -315,6 +316,20 @@ export function VirtualizedTranscriptRowList({
     startAboveChangeCompensation,
     virtualizer,
   ]);
+
+  // Submitting a prompt is an explicit return-to-bottom intent. Re-pin on the
+  // optimistic prompt's arrival — before the pinned snap effect below reads
+  // the pin — so a pin silently lost during typing cannot leave the sent
+  // bubble clipped behind the dock. Only the null -> non-null transition
+  // qualifies; the prompt materializing (clearing the text) must not re-pin.
+  const previousPendingPromptTextRef = useRef(pendingPromptText);
+  useLayoutEffect(() => {
+    const hadPendingPrompt = previousPendingPromptTextRef.current != null;
+    previousPendingPromptTextRef.current = pendingPromptText;
+    if (!hadPendingPrompt && pendingPromptText != null) {
+      pinToBottom();
+    }
+  }, [pendingPromptText, pinToBottom]);
 
   useLayoutEffect(() => {
     if (!pinnedRef.current) {

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.tsx
@@ -38,7 +38,7 @@ export function VirtualizedTranscriptRowList({
   selectedWorkspaceId,
   activeSessionId,
   isSessionBusy,
-  pendingPromptText,
+  lastPromptSubmittedAtMs,
   onLoadOlderHistory,
   onScrollSample,
   renderRow,
@@ -66,7 +66,6 @@ export function VirtualizedTranscriptRowList({
     notifyUserScrollIntent,
     scrollToBottom,
     handleScrollToBottomClick,
-    pinToBottom,
     notifyProgrammaticScroll,
     setPinned,
     resetForSession,
@@ -74,6 +73,7 @@ export function VirtualizedTranscriptRowList({
     scrollRef,
     onScrollSample,
     autoFollowBottomInsetPx: effectiveNonDisplacingBottomInsetPx,
+    lastPromptSubmittedAtMs,
   });
   const renderableRows = useMemo(
     () => buildRenderableRows(rows, isLoadingOlderHistory),
@@ -317,20 +317,6 @@ export function VirtualizedTranscriptRowList({
     virtualizer,
   ]);
 
-  // Submitting a prompt is an explicit return-to-bottom intent. Re-pin on the
-  // optimistic prompt's arrival — before the pinned snap effect below reads
-  // the pin — so a pin silently lost during typing cannot leave the sent
-  // bubble clipped behind the dock. Only the null -> non-null transition
-  // qualifies; the prompt materializing (clearing the text) must not re-pin.
-  const previousPendingPromptTextRef = useRef(pendingPromptText);
-  useLayoutEffect(() => {
-    const hadPendingPrompt = previousPendingPromptTextRef.current != null;
-    previousPendingPromptTextRef.current = pendingPromptText;
-    if (!hadPendingPrompt && pendingPromptText != null) {
-      pinToBottom();
-    }
-  }, [pendingPromptText, pinToBottom]);
-
   useLayoutEffect(() => {
     if (!pinnedRef.current) {
       return;
@@ -338,7 +324,7 @@ export function VirtualizedTranscriptRowList({
     scrollToBottom();
   }, [
     isSessionBusy,
-    pendingPromptText,
+    lastPromptSubmittedAtMs,
     pinnedRef,
     renderableRows.length,
     scrollToBottom,

--- a/apps/packages/product-client/src/domain/sessions/intents/session-intent-selectors.test.ts
+++ b/apps/packages/product-client/src/domain/sessions/intents/session-intent-selectors.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { createSendPromptIntent } from "./session-intent-model";
+import { lastPromptSubmittedAtMs } from "./session-intent-selectors";
+import { createOptimisticPendingPrompt } from "../../chats/pending-prompts/pending-prompts";
+
+describe("lastPromptSubmittedAtMs", () => {
+  it("stamps the newest submission from outbox createdAt regardless of placement", () => {
+    const early = {
+      ...createSendPromptIntent({
+        clientPromptId: "prompt-early",
+        clientSessionId: "session-1",
+        text: "First",
+        blocks: [{ type: "text" as const, text: "First" }],
+      }),
+      createdAt: "2026-01-01T00:00:01.000Z",
+    };
+    // Queue placement is still a submit: sending while the agent is busy must
+    // re-pin even though the entry renders in the dock, not the transcript.
+    const lateQueued = {
+      ...createSendPromptIntent({
+        clientPromptId: "prompt-late",
+        clientSessionId: "session-1",
+        text: "Second",
+        blocks: [{ type: "text" as const, text: "Second" }],
+        placement: "queue" as const,
+      }),
+      createdAt: "2026-01-01T00:00:05.000Z",
+    };
+
+    expect(lastPromptSubmittedAtMs([], null)).toBeNull();
+    expect(lastPromptSubmittedAtMs([lateQueued, early], null))
+      .toBe(Date.parse("2026-01-01T00:00:05.000Z"));
+
+    const optimistic = createOptimisticPendingPrompt(
+      "Third",
+      "prompt-optimistic",
+      "2026-01-01T00:00:09.000Z",
+    );
+    expect(lastPromptSubmittedAtMs([lateQueued, early], optimistic))
+      .toBe(Date.parse("2026-01-01T00:00:09.000Z"));
+  });
+});

--- a/apps/packages/product-client/src/domain/sessions/intents/session-intent-selectors.ts
+++ b/apps/packages/product-client/src/domain/sessions/intents/session-intent-selectors.ts
@@ -345,3 +345,34 @@ function isActivePendingPromptMutationIntent(
     || intent.status === "dispatching"
     || intent.status === "accepted";
 }
+
+/**
+ * Newest prompt-submission stamp, feeding the stick-to-bottom engine's submit
+ * re-pin. Every real submit enqueues a send_prompt intent with a fresh
+ * createdAt (the session-level optimistic prompt covers surfaces that inject
+ * one directly), so the maximum rises exactly once per send. Consumers must
+ * treat only an increase as a submit: delivery or dismissal can remove the
+ * newest entry and lower the maximum.
+ */
+export function lastPromptSubmittedAtMs(
+  entries: readonly PromptOutboxEntry[],
+  optimisticPrompt: PendingPromptEntry | null,
+): number | null {
+  let latest: number | null = null;
+  for (const entry of entries) {
+    const createdAtMs = Date.parse(entry.createdAt);
+    if (!Number.isNaN(createdAtMs) && (latest === null || createdAtMs > latest)) {
+      latest = createdAtMs;
+    }
+  }
+  const optimisticQueuedAtMs = optimisticPrompt
+    ? Date.parse(optimisticPrompt.queuedAt)
+    : Number.NaN;
+  if (
+    !Number.isNaN(optimisticQueuedAtMs)
+    && (latest === null || optimisticQueuedAtMs > latest)
+  ) {
+    latest = optimisticQueuedAtMs;
+  }
+  return latest;
+}

--- a/apps/packages/product-client/src/domain/sessions/intents/session-intent.test.ts
+++ b/apps/packages/product-client/src/domain/sessions/intents/session-intent.test.ts
@@ -11,14 +11,12 @@ import {
 } from "./session-intent-model";
 import {
   isPromptOutboxPlacementBusy,
-  lastPromptSubmittedAtMs,
   pendingConfigChangesForSessionIntents,
   projectPendingPromptsWithSessionIntents,
   renderableOutboxEntriesForTranscript,
   resolvePromptOutboxPlacement,
   selectNextDispatchableSessionIntent,
 } from "./session-intent-selectors";
-import { createOptimisticPendingPrompt } from "../../chats/pending-prompts/pending-prompts";
 import {
   patchSessionIntent,
   upsertSessionIntent,
@@ -57,42 +55,6 @@ describe("session intents", () => {
       [queued, failed],
       createTranscriptState("session-1"),
     ).map((entry) => entry.clientPromptId)).toEqual(["prompt-failed"]);
-  });
-
-  it("stamps the newest submission from outbox createdAt regardless of placement", () => {
-    const early = {
-      ...createSendPromptIntent({
-        clientPromptId: "prompt-early",
-        clientSessionId: "session-1",
-        text: "First",
-        blocks: [{ type: "text" as const, text: "First" }],
-      }),
-      createdAt: "2026-01-01T00:00:01.000Z",
-    };
-    // Queue placement is still a submit: sending while the agent is busy must
-    // re-pin even though the entry renders in the dock, not the transcript.
-    const lateQueued = {
-      ...createSendPromptIntent({
-        clientPromptId: "prompt-late",
-        clientSessionId: "session-1",
-        text: "Second",
-        blocks: [{ type: "text" as const, text: "Second" }],
-        placement: "queue",
-      }),
-      createdAt: "2026-01-01T00:00:05.000Z",
-    };
-
-    expect(lastPromptSubmittedAtMs([], null)).toBeNull();
-    expect(lastPromptSubmittedAtMs([lateQueued, early], null))
-      .toBe(Date.parse("2026-01-01T00:00:05.000Z"));
-
-    const optimistic = createOptimisticPendingPrompt(
-      "Third",
-      "prompt-optimistic",
-      "2026-01-01T00:00:09.000Z",
-    );
-    expect(lastPromptSubmittedAtMs([lateQueued, early], optimistic))
-      .toBe(Date.parse("2026-01-01T00:00:09.000Z"));
   });
 
   it("dispatches one ordered intent per session at a time", () => {

--- a/apps/packages/product-client/src/domain/sessions/intents/session-intent.test.ts
+++ b/apps/packages/product-client/src/domain/sessions/intents/session-intent.test.ts
@@ -11,12 +11,14 @@ import {
 } from "./session-intent-model";
 import {
   isPromptOutboxPlacementBusy,
+  lastPromptSubmittedAtMs,
   pendingConfigChangesForSessionIntents,
   projectPendingPromptsWithSessionIntents,
   renderableOutboxEntriesForTranscript,
   resolvePromptOutboxPlacement,
   selectNextDispatchableSessionIntent,
 } from "./session-intent-selectors";
+import { createOptimisticPendingPrompt } from "../../chats/pending-prompts/pending-prompts";
 import {
   patchSessionIntent,
   upsertSessionIntent,
@@ -55,6 +57,42 @@ describe("session intents", () => {
       [queued, failed],
       createTranscriptState("session-1"),
     ).map((entry) => entry.clientPromptId)).toEqual(["prompt-failed"]);
+  });
+
+  it("stamps the newest submission from outbox createdAt regardless of placement", () => {
+    const early = {
+      ...createSendPromptIntent({
+        clientPromptId: "prompt-early",
+        clientSessionId: "session-1",
+        text: "First",
+        blocks: [{ type: "text" as const, text: "First" }],
+      }),
+      createdAt: "2026-01-01T00:00:01.000Z",
+    };
+    // Queue placement is still a submit: sending while the agent is busy must
+    // re-pin even though the entry renders in the dock, not the transcript.
+    const lateQueued = {
+      ...createSendPromptIntent({
+        clientPromptId: "prompt-late",
+        clientSessionId: "session-1",
+        text: "Second",
+        blocks: [{ type: "text" as const, text: "Second" }],
+        placement: "queue",
+      }),
+      createdAt: "2026-01-01T00:00:05.000Z",
+    };
+
+    expect(lastPromptSubmittedAtMs([], null)).toBeNull();
+    expect(lastPromptSubmittedAtMs([lateQueued, early], null))
+      .toBe(Date.parse("2026-01-01T00:00:05.000Z"));
+
+    const optimistic = createOptimisticPendingPrompt(
+      "Third",
+      "prompt-optimistic",
+      "2026-01-01T00:00:09.000Z",
+    );
+    expect(lastPromptSubmittedAtMs([lateQueued, early], optimistic))
+      .toBe(Date.parse("2026-01-01T00:00:09.000Z"));
   });
 
   it("dispatches one ordered intent per session at a time", () => {

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-row-list-model.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-row-list-model.ts
@@ -54,7 +54,8 @@ export interface TranscriptRowListBaseProps {
   selectedWorkspaceId: string | null;
   activeSessionId: string;
   isSessionBusy: boolean;
-  pendingPromptText: string | null;
+  /** Epoch ms of the newest prompt submission; drives the engine's submit re-pin. */
+  lastPromptSubmittedAtMs: number | null;
   onLoadOlderHistory: () => void;
   onScrollSample: (sample?: TranscriptScrollSample) => void;
   renderRow: (row: TranscriptVirtualRow, rowIndex: number) => ReactNode;

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.test.tsx
@@ -4,10 +4,26 @@ import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useChatDockInset } from "./use-chat-dock-inset";
 
+// Counts real flushSync entries so the "synchronous" tests fail if the sync
+// flush is ever downgraded to a plain measure() (which act() would also
+// commit, masking the difference).
+const flushSyncCalls = vi.hoisted(() => ({ count: 0 }));
+vi.mock("react-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-dom")>();
+  return {
+    ...actual,
+    flushSync: <T,>(fn: () => T): T => {
+      flushSyncCalls.count += 1;
+      return actual.flushSync(fn);
+    },
+  };
+});
+
 let rafCallbacks: Array<FrameRequestCallback | null>;
 
 beforeEach(() => {
   rafCallbacks = [];
+  flushSyncCalls.count = 0;
   vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
     rafCallbacks.push(cb);
     return rafCallbacks.length;
@@ -33,10 +49,10 @@ function flushRafRound() {
 }
 
 /** jsdom never lays out, so element rects must be stubbed directly. */
-function stubElementHeight(el: HTMLElement, height: number) {
+function stubElementRect(el: HTMLElement, height: number, top = 0) {
   el.getBoundingClientRect = () => ({
-    x: 0, y: 0, width: 0, height,
-    top: 0, left: 0, right: 0, bottom: height,
+    x: 0, y: top, width: 0, height,
+    top, left: 0, right: 0, bottom: top + height,
     toJSON() {},
   } as DOMRect);
 }
@@ -125,18 +141,20 @@ describe("useChatDockInset", () => {
   it("defers a dock height increase to the rAF-coalesced path", () => {
     const notifyResize = stubCapturingResizeObserver();
     const handle = renderHarness();
-    stubElementHeight(handle.dockEl, 200);
+    stubElementRect(handle.dockEl, 200);
 
     act(() => {
       notifyResize();
     });
     // Growth does not commit until the deferred frame runs.
     expect(handle.current.dockHeightPx).toBe(0);
+    expect(flushSyncCalls.count).toBe(0);
 
     act(() => {
       flushRafRound();
     });
     expect(handle.current.dockHeightPx).toBe(200);
+    expect(flushSyncCalls.count).toBe(0);
   });
 
   it("applies a dock height decrease synchronously within the observer callback (submit collapse)", () => {
@@ -144,7 +162,7 @@ describe("useChatDockInset", () => {
     const handle = renderHarness();
 
     // Establish a taller baseline first, via the normal rAF-deferred path.
-    stubElementHeight(handle.dockEl, 200);
+    stubElementRect(handle.dockEl, 200);
     act(() => {
       notifyResize();
       flushRafRound();
@@ -152,11 +170,12 @@ describe("useChatDockInset", () => {
     expect(handle.current.dockHeightPx).toBe(200);
 
     // The collapse path must land before the next paint — no rAF flush needed.
-    stubElementHeight(handle.dockEl, 80);
+    stubElementRect(handle.dockEl, 80);
     act(() => {
       notifyResize();
     });
     expect(handle.current.dockHeightPx).toBe(80);
+    expect(flushSyncCalls.count).toBe(1);
     expect(rafCallbacks.filter(Boolean)).toHaveLength(0);
   });
 
@@ -164,10 +183,10 @@ describe("useChatDockInset", () => {
     const notifyResize = stubCapturingResizeObserver();
     const handle = renderHarness();
 
-    // Baseline: tall draft surface inside the dock.
-    stubElementHeight(handle.dockEl, 200);
-    stubElementHeight(handle.surfaceEl, 120);
-    stubElementHeight(handle.footerEl, 40);
+    // Baseline: tall draft surface inside the dock, footer below it.
+    stubElementRect(handle.dockEl, 200);
+    stubElementRect(handle.surfaceEl, 120, 0);
+    stubElementRect(handle.footerEl, 40, 120);
     act(() => {
       notifyResize();
       flushRafRound();
@@ -175,14 +194,50 @@ describe("useChatDockInset", () => {
     expect(handle.current.dockHeightPx).toBe(200);
 
     // Queued send: the draft clears (surface collapses) in the same commit
-    // the outbound card mounts, so the dock rect net-grows. The structural
-    // channel still shrank — the sync path must fire, no rAF flush needed.
-    stubElementHeight(handle.dockEl, 240);
-    stubElementHeight(handle.surfaceEl, 40);
+    // the outbound card mounts above it, so the dock rect net-grows and the
+    // surface offset-top rises. The structural inset still shrank — the sync
+    // path must fire, no rAF flush needed.
+    stubElementRect(handle.dockEl, 240);
+    stubElementRect(handle.surfaceEl, 40, 120);
+    stubElementRect(handle.footerEl, 40, 160);
     act(() => {
       notifyResize();
     });
     expect(handle.current.dockHeightPx).toBe(240);
+    expect(flushSyncCalls.count).toBe(1);
     expect(rafCallbacks.filter(Boolean)).toHaveLength(0);
+  });
+
+  it("defers a dock-slot card dismissal (structural inset unchanged) to the rAF path", () => {
+    const notifyResize = stubCapturingResizeObserver();
+    const handle = renderHarness();
+
+    // Baseline: a 120px card sits above the surface (offset-top 120).
+    stubElementRect(handle.dockEl, 320);
+    stubElementRect(handle.surfaceEl, 120, 120);
+    stubElementRect(handle.footerEl, 40, 240);
+    act(() => {
+      notifyResize();
+      flushRafRound();
+    });
+    expect(handle.current.dockHeightPx).toBe(320);
+
+    // Dismissing the card shrinks the dock rect but not the structural
+    // inset (dock and offset-top fall together): that shrink is the
+    // non-displacing overlay share and must not force a sync flush.
+    stubElementRect(handle.dockEl, 200);
+    stubElementRect(handle.surfaceEl, 120, 0);
+    stubElementRect(handle.footerEl, 40, 120);
+    act(() => {
+      notifyResize();
+    });
+    expect(handle.current.dockHeightPx).toBe(320);
+    expect(flushSyncCalls.count).toBe(0);
+
+    act(() => {
+      flushRafRound();
+    });
+    expect(handle.current.dockHeightPx).toBe(200);
+    expect(flushSyncCalls.count).toBe(0);
   });
 });

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.test.tsx
@@ -1,0 +1,141 @@
+/* @vitest-environment jsdom */
+
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatDockInset } from "./use-chat-dock-inset";
+
+let rafCallbacks: Array<FrameRequestCallback | null>;
+
+beforeEach(() => {
+  rafCallbacks = [];
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    rafCallbacks.push(cb);
+    return rafCallbacks.length;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+    rafCallbacks[id - 1] = null;
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+/** Run one round of currently-queued rAF callbacks. */
+function flushRafRound() {
+  const pending = rafCallbacks;
+  rafCallbacks = [];
+  for (const cb of pending) {
+    cb?.(0);
+  }
+}
+
+/** jsdom never lays out, so the dock's rect must be stubbed directly. */
+function stubDockHeight(el: HTMLElement, height: number) {
+  el.getBoundingClientRect = () => ({
+    x: 0, y: 0, width: 0, height,
+    top: 0, left: 0, right: 0, bottom: height,
+    toJSON() {},
+  } as DOMRect);
+}
+
+/** Captures the ResizeObserver callback so the test can fire it manually. */
+function stubCapturingResizeObserver(): () => void {
+  const callbacks: ResizeObserverCallback[] = [];
+  class CapturingResizeObserver {
+    constructor(callback: ResizeObserverCallback) {
+      callbacks.push(callback);
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal("ResizeObserver", CapturingResizeObserver);
+  const observerStub = {
+    observe() {},
+    unobserve() {},
+    disconnect() {},
+  } as unknown as ResizeObserver;
+  return () => {
+    for (const callback of [...callbacks]) {
+      callback([], observerStub);
+    }
+  };
+}
+
+interface HarnessHandle {
+  dockHeightPx: number;
+}
+
+function renderHarness() {
+  const handle: { current: HarnessHandle | null } = { current: null };
+  let dockEl: HTMLDivElement | null = null;
+
+  function Harness() {
+    const { dockRef, dockHeightPx } = useChatDockInset();
+    handle.current = { dockHeightPx };
+    return (
+      <div
+        ref={(node) => {
+          dockRef.current = node;
+          dockEl = node;
+        }}
+      />
+    );
+  }
+
+  render(<Harness />);
+  return {
+    get current() {
+      return handle.current!;
+    },
+    get dockEl() {
+      return dockEl!;
+    },
+  };
+}
+
+// jsdom does no real layout, so these tests only cover the trigger wiring:
+// which path (synchronous flush vs. rAF-deferred) the ResizeObserver callback
+// takes, not the resulting metrics math.
+describe("useChatDockInset", () => {
+  it("defers a dock height increase to the rAF-coalesced path", () => {
+    const notifyResize = stubCapturingResizeObserver();
+    const handle = renderHarness();
+    stubDockHeight(handle.dockEl, 200);
+
+    act(() => {
+      notifyResize();
+    });
+    // Growth does not commit until the deferred frame runs.
+    expect(handle.current.dockHeightPx).toBe(0);
+
+    act(() => {
+      flushRafRound();
+    });
+    expect(handle.current.dockHeightPx).toBe(200);
+  });
+
+  it("applies a dock height decrease synchronously within the observer callback (submit collapse)", () => {
+    const notifyResize = stubCapturingResizeObserver();
+    const handle = renderHarness();
+
+    // Establish a taller baseline first, via the normal rAF-deferred path.
+    stubDockHeight(handle.dockEl, 200);
+    act(() => {
+      notifyResize();
+      flushRafRound();
+    });
+    expect(handle.current.dockHeightPx).toBe(200);
+
+    // The collapse path must land before the next paint — no rAF flush needed.
+    stubDockHeight(handle.dockEl, 80);
+    act(() => {
+      notifyResize();
+    });
+    expect(handle.current.dockHeightPx).toBe(80);
+    expect(rafCallbacks.filter(Boolean)).toHaveLength(0);
+  });
+});

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.test.tsx
@@ -32,8 +32,8 @@ function flushRafRound() {
   }
 }
 
-/** jsdom never lays out, so the dock's rect must be stubbed directly. */
-function stubDockHeight(el: HTMLElement, height: number) {
+/** jsdom never lays out, so element rects must be stubbed directly. */
+function stubElementHeight(el: HTMLElement, height: number) {
   el.getBoundingClientRect = () => ({
     x: 0, y: 0, width: 0, height,
     top: 0, left: 0, right: 0, bottom: height,
@@ -72,6 +72,8 @@ interface HarnessHandle {
 function renderHarness() {
   const handle: { current: HarnessHandle | null } = { current: null };
   let dockEl: HTMLDivElement | null = null;
+  let surfaceEl: HTMLDivElement | null = null;
+  let footerEl: HTMLDivElement | null = null;
 
   function Harness() {
     const { dockRef, dockHeightPx } = useChatDockInset();
@@ -82,7 +84,20 @@ function renderHarness() {
           dockRef.current = node;
           dockEl = node;
         }}
-      />
+      >
+        <div
+          data-chat-composer-surface
+          ref={(node) => {
+            surfaceEl = node;
+          }}
+        />
+        <div
+          data-chat-composer-footer
+          ref={(node) => {
+            footerEl = node;
+          }}
+        />
+      </div>
     );
   }
 
@@ -94,6 +109,12 @@ function renderHarness() {
     get dockEl() {
       return dockEl!;
     },
+    get surfaceEl() {
+      return surfaceEl!;
+    },
+    get footerEl() {
+      return footerEl!;
+    },
   };
 }
 
@@ -104,7 +125,7 @@ describe("useChatDockInset", () => {
   it("defers a dock height increase to the rAF-coalesced path", () => {
     const notifyResize = stubCapturingResizeObserver();
     const handle = renderHarness();
-    stubDockHeight(handle.dockEl, 200);
+    stubElementHeight(handle.dockEl, 200);
 
     act(() => {
       notifyResize();
@@ -123,7 +144,7 @@ describe("useChatDockInset", () => {
     const handle = renderHarness();
 
     // Establish a taller baseline first, via the normal rAF-deferred path.
-    stubDockHeight(handle.dockEl, 200);
+    stubElementHeight(handle.dockEl, 200);
     act(() => {
       notifyResize();
       flushRafRound();
@@ -131,11 +152,37 @@ describe("useChatDockInset", () => {
     expect(handle.current.dockHeightPx).toBe(200);
 
     // The collapse path must land before the next paint — no rAF flush needed.
-    stubDockHeight(handle.dockEl, 80);
+    stubElementHeight(handle.dockEl, 80);
     act(() => {
       notifyResize();
     });
     expect(handle.current.dockHeightPx).toBe(80);
+    expect(rafCallbacks.filter(Boolean)).toHaveLength(0);
+  });
+
+  it("applies a surface collapse synchronously even when the dock net-grows (queued send)", () => {
+    const notifyResize = stubCapturingResizeObserver();
+    const handle = renderHarness();
+
+    // Baseline: tall draft surface inside the dock.
+    stubElementHeight(handle.dockEl, 200);
+    stubElementHeight(handle.surfaceEl, 120);
+    stubElementHeight(handle.footerEl, 40);
+    act(() => {
+      notifyResize();
+      flushRafRound();
+    });
+    expect(handle.current.dockHeightPx).toBe(200);
+
+    // Queued send: the draft clears (surface collapses) in the same commit
+    // the outbound card mounts, so the dock rect net-grows. The structural
+    // channel still shrank — the sync path must fire, no rAF flush needed.
+    stubElementHeight(handle.dockEl, 240);
+    stubElementHeight(handle.surfaceEl, 40);
+    act(() => {
+      notifyResize();
+    });
+    expect(handle.current.dockHeightPx).toBe(240);
     expect(rafCallbacks.filter(Boolean)).toHaveLength(0);
   });
 });

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.test.tsx
@@ -274,4 +274,38 @@ describe("useChatDockInset", () => {
     expect(flushSyncCalls.count).toBe(1);
     expect(handle.current.dockHeightPx).toBe(80);
   });
+
+  it("sync-flushes a collapse back below a measured-but-uncommitted growth", () => {
+    // Mirror image of the previous test: here the deferred measure read GROWN
+    // geometry whose commit is still pending when the collapse lands. The
+    // committed baseline alone would miss a collapse back to the old height
+    // (not below it) — the stale tall snapshot would then commit and drop, so
+    // the gate must also honor the last measure-read baseline.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const notifyResize = stubCapturingResizeObserver();
+    const handle = renderHarness();
+    stubElementRect(handle.dockEl, 200);
+    act(() => {
+      notifyResize();
+      flushRafRound();
+    });
+    expect(handle.current.dockHeightPx).toBe(200);
+
+    // Growth to 240 queues a deferred measure; the un-act'ed rAF flush reads
+    // 240 but leaves its React update pending (a delayed default-lane commit).
+    stubElementRect(handle.dockEl, 240);
+    act(() => {
+      notifyResize();
+    });
+    flushRafRound();
+
+    // Collapse back to the previously-committed 200 — not below it. The sync
+    // path must still fire, or the pending 240 would commit and then drop.
+    stubElementRect(handle.dockEl, 200);
+    act(() => {
+      notifyResize();
+    });
+    expect(flushSyncCalls.count).toBe(1);
+    expect(handle.current.dockHeightPx).toBe(200);
+  });
 });

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.test.tsx
@@ -240,4 +240,38 @@ describe("useChatDockInset", () => {
     expect(handle.current.dockHeightPx).toBe(200);
     expect(flushSyncCalls.count).toBe(0);
   });
+
+  it("keeps the sync gate armed when a deferred measure reads freshly-collapsed geometry", () => {
+    // The un-act'ed rAF flush below intentionally leaves a React update
+    // pending (that is the scenario); silence the act() warning it triggers.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const notifyResize = stubCapturingResizeObserver();
+    const handle = renderHarness();
+    stubElementRect(handle.dockEl, 200);
+    act(() => {
+      notifyResize();
+      flushRafRound();
+    });
+    expect(handle.current.dockHeightPx).toBe(200);
+
+    // Growth queues a deferred measure for the next frame...
+    stubElementRect(handle.dockEl, 240);
+    act(() => {
+      notifyResize();
+    });
+    // ...then a collapse lands in the DOM before that rAF runs. The deferred
+    // measure reads the already-collapsed geometry, but its state has NOT
+    // committed — the gate baseline must not advance yet (advancing at
+    // measure-read time is exactly what would let the collapse frame paint
+    // against the stale taller inset).
+    stubElementRect(handle.dockEl, 80);
+    flushRafRound();
+
+    // The collapse's own ResizeObserver delivery must still take the sync path.
+    act(() => {
+      notifyResize();
+    });
+    expect(flushSyncCalls.count).toBe(1);
+    expect(handle.current.dockHeightPx).toBe(80);
+  });
 });

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.ts
@@ -9,11 +9,10 @@ import {
 
 export function useChatDockInset() {
   const dockRef = useRef<HTMLDivElement>(null);
-  const lastMeasuredDockHeightRef = useRef(0);
-  // Surface + footer sum — the channel that drives the transcript's
-  // structural bottom inset (computeChatStableBottomInsetPx minus the
-  // non-displacing offset-top share).
-  const lastMeasuredStructuralHeightRef = useRef(0);
+  // The transcript's structural bottom inset (stable dock reserve minus the
+  // non-displacing offset-top share) as of the last committed measure. The
+  // ResizeObserver's shrink gate compares candidate geometry against this.
+  const lastMeasuredStructuralInsetRef = useRef(0);
   const [metrics, setMetrics] = useState({
     composerSurfaceHeightPx: 0,
     composerSurfaceOffsetTopPx: 0,
@@ -29,13 +28,15 @@ export function useChatDockInset() {
 
     let frameId: number | null = null;
 
-    const measure = () => {
+    // Shared by measure() and the observer's shrink gate so the gate compares
+    // exactly what a measure would commit — no rounding or channel drift.
+    const readDockMetrics = () => {
       const dockRect = dock.getBoundingClientRect();
       const composerSurface = dock.querySelector<HTMLElement>("[data-chat-composer-surface]");
       const composerFooter = dock.querySelector<HTMLElement>("[data-chat-composer-footer]");
       const surfaceRect = composerSurface?.getBoundingClientRect() ?? null;
       const footerRect = composerFooter?.getBoundingClientRect() ?? null;
-      const nextMetrics = {
+      return {
         composerSurfaceHeightPx: surfaceRect ? Math.max(0, Math.ceil(surfaceRect.height)) : 0,
         composerSurfaceOffsetTopPx: surfaceRect
           ? Math.max(0, Math.ceil(surfaceRect.top - dockRect.top))
@@ -43,9 +44,14 @@ export function useChatDockInset() {
         composerFooterHeightPx: footerRect ? Math.max(0, Math.ceil(footerRect.height)) : 0,
         dockHeightPx: Math.max(0, Math.ceil(dockRect.height)),
       };
-      lastMeasuredDockHeightRef.current = nextMetrics.dockHeightPx;
-      lastMeasuredStructuralHeightRef.current =
-        nextMetrics.composerSurfaceHeightPx + nextMetrics.composerFooterHeightPx;
+    };
+
+    const structuralInsetOf = (dockMetrics: ReturnType<typeof readDockMetrics>) =>
+      computeChatStableBottomInsetPx(dockMetrics) - dockMetrics.composerSurfaceOffsetTopPx;
+
+    const measure = () => {
+      const nextMetrics = readDockMetrics();
+      lastMeasuredStructuralInsetRef.current = structuralInsetOf(nextMetrics);
       setMetrics((current) =>
         current.composerSurfaceHeightPx === nextMetrics.composerSurfaceHeightPx
         && current.composerSurfaceOffsetTopPx === nextMetrics.composerSurfaceOffsetTopPx
@@ -75,31 +81,28 @@ export function useChatDockInset() {
       });
     };
 
-    const readHeightPx = (element: Element | null) =>
-      element ? Math.max(0, Math.ceil(element.getBoundingClientRect().height)) : 0;
-
     const observer = new ResizeObserver(() => {
-      // A shrink on either channel is the submit-collapse path: clearing the
-      // draft drops the surface (and usually the dock) in the same frame the
-      // prompt row mounts. The rAF-deferred measure would let that frame paint
-      // against the stale (taller) inset, then drop the whole transcript a
-      // notch when the correction lands. ResizeObserver fires after layout and
-      // before paint, so flushing the measure synchronously commits the
-      // corrected inset — and the pinned snap that depends on it — before the
-      // collapse frame paints. The dock rect alone is not enough: a queued
-      // send mounts its outbound card in the very commit that collapses the
-      // surface, so the dock can net-grow while the structural inset shrinks —
-      // only the surface+footer sum catches that. Growth keeps the rAF
-      // coalescing path: next-frame is prompt enough for typing, and a sync
-      // flush per keystroke would tax input latency.
-      const dockHeightPx = readHeightPx(dock);
-      const structuralHeightPx =
-        readHeightPx(dock.querySelector("[data-chat-composer-surface]"))
-        + readHeightPx(dock.querySelector("[data-chat-composer-footer]"));
-      if (
-        dockHeightPx < lastMeasuredDockHeightRef.current
-        || structuralHeightPx < lastMeasuredStructuralHeightRef.current
-      ) {
+      // Any structural-inset shrink must commit before the shrink frame
+      // paints: while pinned, the rAF-deferred measure would let that frame
+      // paint against the stale (taller) inset, then drop the whole
+      // transcript a notch when the correction lands. ResizeObserver fires
+      // after layout and before paint, so flushing the measure synchronously
+      // commits the corrected inset — and the pinned snap that depends on it —
+      // before the frame paints. The submit collapse is the loudest case, but
+      // Escape-clears, select-all deletes, and backspacing across a line wrap
+      // are the same visual class and take the same path (a few sync flushes
+      // across a held backspace is the accepted price of never notching).
+      // Gating on the derived structural inset — not the dock rect — matters
+      // in both directions: a queued send mounts its outbound card in the
+      // very commit that collapses the surface, so the dock can net-grow
+      // while the structural inset shrinks; and a dock-slot card dismissal
+      // shrinks the dock while the structural inset stays put, which must
+      // NOT force a sync flush (that shrink is the non-displacing overlay
+      // share, whose clamp the scroll engine already classifies as
+      // non-user). Growth keeps the rAF coalescing path: next-frame is
+      // prompt enough for typing, and a sync flush per grow-keystroke would
+      // tax input latency.
+      if (structuralInsetOf(readDockMetrics()) < lastMeasuredStructuralInsetRef.current) {
         if (frameId !== null) {
           window.cancelAnimationFrame(frameId);
           frameId = null;

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.ts
@@ -7,30 +7,52 @@ import {
 } from "#product/config/chat-layout";
 
 
+interface ChatDockMetrics {
+  composerSurfaceHeightPx: number;
+  composerSurfaceOffsetTopPx: number;
+  composerFooterHeightPx: number;
+  dockHeightPx: number;
+}
+
+/**
+ * The transcript's structural bottom inset: the stable dock reserve minus the
+ * non-displacing offset-top share. The shrink gate below compares candidate
+ * geometry against this.
+ */
+function structuralInsetOf(dockMetrics: ChatDockMetrics): number {
+  return computeChatStableBottomInsetPx(dockMetrics) - dockMetrics.composerSurfaceOffsetTopPx;
+}
+
 export function useChatDockInset() {
   const dockRef = useRef<HTMLDivElement>(null);
-  // The transcript's structural bottom inset (stable dock reserve minus the
-  // non-displacing offset-top share) as of the last COMMITTED metrics. The
-  // ResizeObserver's shrink gate compares candidate geometry against this.
+  // Structural inset as of the last COMMITTED metrics.
   const lastCommittedStructuralInsetRef = useRef(0);
-  const [metrics, setMetrics] = useState({
+  // Structural inset as of the last measure READ, which may be ahead of the
+  // committed one while its state update is still pending (a rAF-deferred
+  // growth measure whose default-lane commit is delayed under load). The gate
+  // takes the max of both: a shrink below either baseline must flush, and a
+  // stale-high read can only cost an extra harmless sync flush, never a
+  // missed one.
+  const lastMeasuredStructuralInsetRef = useRef(0);
+  const [metrics, setMetrics] = useState<ChatDockMetrics>({
     composerSurfaceHeightPx: 0,
     composerSurfaceOffsetTopPx: 0,
     composerFooterHeightPx: 0,
     dockHeightPx: 0,
   });
 
-  // The gate must compare against what the transcript has actually committed,
-  // not against what a measure has merely read: a rAF-deferred measure that
-  // runs in the same frame as a collapse (growth queued the frame before,
-  // collapse committed by a discrete event in between) would otherwise lower
-  // the baseline before its state ever commits, disarming the sync gate for
-  // exactly the frame it protects. Advancing the ref in a layout effect keyed
-  // on the committed metrics keeps it truthful on both paths — inside a
-  // flushSync it runs within the flush, still pre-paint.
+  // A measure-read alone must never LOWER the gate baseline: a rAF-deferred
+  // measure that runs in the same frame as a collapse (growth queued the
+  // frame before, collapse committed by a discrete event in between) reads
+  // the already-collapsed geometry before its state ever commits, and using
+  // that read as the sole baseline would disarm the sync gate for exactly
+  // the frame it protects. Advancing this ref in a layout effect keyed on
+  // the committed metrics keeps it truthful on both paths — inside a
+  // flushSync it runs within the flush, still pre-paint. (A measure-read may
+  // still RAISE the effective baseline via lastMeasuredStructuralInsetRef —
+  // see the gate.)
   useLayoutEffect(() => {
-    lastCommittedStructuralInsetRef.current =
-      computeChatStableBottomInsetPx(metrics) - metrics.composerSurfaceOffsetTopPx;
+    lastCommittedStructuralInsetRef.current = structuralInsetOf(metrics);
   }, [metrics]);
 
   useLayoutEffect(() => {
@@ -59,11 +81,9 @@ export function useChatDockInset() {
       };
     };
 
-    const structuralInsetOf = (dockMetrics: ReturnType<typeof readDockMetrics>) =>
-      computeChatStableBottomInsetPx(dockMetrics) - dockMetrics.composerSurfaceOffsetTopPx;
-
     const measure = () => {
       const nextMetrics = readDockMetrics();
+      lastMeasuredStructuralInsetRef.current = structuralInsetOf(nextMetrics);
       setMetrics((current) =>
         current.composerSurfaceHeightPx === nextMetrics.composerSurfaceHeightPx
         && current.composerSurfaceOffsetTopPx === nextMetrics.composerSurfaceOffsetTopPx
@@ -116,7 +136,18 @@ export function useChatDockInset() {
       // tax input latency. Note the flush drains ALL pending work at this
       // root (a queued live-tail stream batch included), so its cost scales
       // with the pending tree, not with the dock subtree.
-      if (structuralInsetOf(readDockMetrics()) < lastCommittedStructuralInsetRef.current) {
+      //
+      // The baseline is the max of committed and last-read: a growth measure
+      // whose default-lane commit is still pending under load would leave the
+      // committed baseline stale-low, letting a collapse back to the old
+      // height slip to the deferred path — and the stale tall snapshot would
+      // then commit and drop, the very notch this gate exists to prevent.
+      // Either ref being stale-high only costs an extra sync flush.
+      const shrinkGateBaseline = Math.max(
+        lastCommittedStructuralInsetRef.current,
+        lastMeasuredStructuralInsetRef.current,
+      );
+      if (structuralInsetOf(readDockMetrics()) < shrinkGateBaseline) {
         if (frameId !== null) {
           window.cancelAnimationFrame(frameId);
           frameId = null;

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.ts
@@ -10,6 +10,10 @@ import {
 export function useChatDockInset() {
   const dockRef = useRef<HTMLDivElement>(null);
   const lastMeasuredDockHeightRef = useRef(0);
+  // Surface + footer sum — the channel that drives the transcript's
+  // structural bottom inset (computeChatStableBottomInsetPx minus the
+  // non-displacing offset-top share).
+  const lastMeasuredStructuralHeightRef = useRef(0);
   const [metrics, setMetrics] = useState({
     composerSurfaceHeightPx: 0,
     composerSurfaceOffsetTopPx: 0,
@@ -40,6 +44,8 @@ export function useChatDockInset() {
         dockHeightPx: Math.max(0, Math.ceil(dockRect.height)),
       };
       lastMeasuredDockHeightRef.current = nextMetrics.dockHeightPx;
+      lastMeasuredStructuralHeightRef.current =
+        nextMetrics.composerSurfaceHeightPx + nextMetrics.composerFooterHeightPx;
       setMetrics((current) =>
         current.composerSurfaceHeightPx === nextMetrics.composerSurfaceHeightPx
         && current.composerSurfaceOffsetTopPx === nextMetrics.composerSurfaceOffsetTopPx
@@ -69,19 +75,31 @@ export function useChatDockInset() {
       });
     };
 
+    const readHeightPx = (element: Element | null) =>
+      element ? Math.max(0, Math.ceil(element.getBoundingClientRect().height)) : 0;
+
     const observer = new ResizeObserver(() => {
-      // A dock shrink is the submit-collapse path: clearing the draft drops
-      // the dock's height in the same frame the optimistic prompt row mounts.
-      // The rAF-deferred measure would let that frame paint against the stale
-      // (taller) inset, then drop the whole transcript a notch when the
-      // correction lands. ResizeObserver fires after layout and before paint,
-      // so flushing the measure synchronously commits the corrected inset —
-      // and the pinned snap that depends on it — before the collapse frame
-      // paints. Growth keeps the rAF coalescing path: next-frame is prompt
-      // enough for typing, and a sync flush per keystroke would tax input
-      // latency.
-      const dockHeightPx = Math.ceil(dock.getBoundingClientRect().height);
-      if (dockHeightPx < lastMeasuredDockHeightRef.current) {
+      // A shrink on either channel is the submit-collapse path: clearing the
+      // draft drops the surface (and usually the dock) in the same frame the
+      // prompt row mounts. The rAF-deferred measure would let that frame paint
+      // against the stale (taller) inset, then drop the whole transcript a
+      // notch when the correction lands. ResizeObserver fires after layout and
+      // before paint, so flushing the measure synchronously commits the
+      // corrected inset — and the pinned snap that depends on it — before the
+      // collapse frame paints. The dock rect alone is not enough: a queued
+      // send mounts its outbound card in the very commit that collapses the
+      // surface, so the dock can net-grow while the structural inset shrinks —
+      // only the surface+footer sum catches that. Growth keeps the rAF
+      // coalescing path: next-frame is prompt enough for typing, and a sync
+      // flush per keystroke would tax input latency.
+      const dockHeightPx = readHeightPx(dock);
+      const structuralHeightPx =
+        readHeightPx(dock.querySelector("[data-chat-composer-surface]"))
+        + readHeightPx(dock.querySelector("[data-chat-composer-footer]"));
+      if (
+        dockHeightPx < lastMeasuredDockHeightRef.current
+        || structuralHeightPx < lastMeasuredStructuralHeightRef.current
+      ) {
         if (frameId !== null) {
           window.cancelAnimationFrame(frameId);
           frameId = null;

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.ts
@@ -10,15 +10,28 @@ import {
 export function useChatDockInset() {
   const dockRef = useRef<HTMLDivElement>(null);
   // The transcript's structural bottom inset (stable dock reserve minus the
-  // non-displacing offset-top share) as of the last committed measure. The
+  // non-displacing offset-top share) as of the last COMMITTED metrics. The
   // ResizeObserver's shrink gate compares candidate geometry against this.
-  const lastMeasuredStructuralInsetRef = useRef(0);
+  const lastCommittedStructuralInsetRef = useRef(0);
   const [metrics, setMetrics] = useState({
     composerSurfaceHeightPx: 0,
     composerSurfaceOffsetTopPx: 0,
     composerFooterHeightPx: 0,
     dockHeightPx: 0,
   });
+
+  // The gate must compare against what the transcript has actually committed,
+  // not against what a measure has merely read: a rAF-deferred measure that
+  // runs in the same frame as a collapse (growth queued the frame before,
+  // collapse committed by a discrete event in between) would otherwise lower
+  // the baseline before its state ever commits, disarming the sync gate for
+  // exactly the frame it protects. Advancing the ref in a layout effect keyed
+  // on the committed metrics keeps it truthful on both paths — inside a
+  // flushSync it runs within the flush, still pre-paint.
+  useLayoutEffect(() => {
+    lastCommittedStructuralInsetRef.current =
+      computeChatStableBottomInsetPx(metrics) - metrics.composerSurfaceOffsetTopPx;
+  }, [metrics]);
 
   useLayoutEffect(() => {
     const dock = dockRef.current;
@@ -51,7 +64,6 @@ export function useChatDockInset() {
 
     const measure = () => {
       const nextMetrics = readDockMetrics();
-      lastMeasuredStructuralInsetRef.current = structuralInsetOf(nextMetrics);
       setMetrics((current) =>
         current.composerSurfaceHeightPx === nextMetrics.composerSurfaceHeightPx
         && current.composerSurfaceOffsetTopPx === nextMetrics.composerSurfaceOffsetTopPx
@@ -101,8 +113,10 @@ export function useChatDockInset() {
       // share, whose clamp the scroll engine already classifies as
       // non-user). Growth keeps the rAF coalescing path: next-frame is
       // prompt enough for typing, and a sync flush per grow-keystroke would
-      // tax input latency.
-      if (structuralInsetOf(readDockMetrics()) < lastMeasuredStructuralInsetRef.current) {
+      // tax input latency. Note the flush drains ALL pending work at this
+      // root (a queued live-tail stream batch included), so its cost scales
+      // with the pending tree, not with the dock subtree.
+      if (structuralInsetOf(readDockMetrics()) < lastCommittedStructuralInsetRef.current) {
         if (frameId !== null) {
           window.cancelAnimationFrame(frameId);
           frameId = null;

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-dock-inset.ts
@@ -1,4 +1,5 @@
 import { useLayoutEffect, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import {
   computeChatDockLowerBackdropTopPx,
   computeChatStableBottomInsetPx,
@@ -8,6 +9,7 @@ import {
 
 export function useChatDockInset() {
   const dockRef = useRef<HTMLDivElement>(null);
+  const lastMeasuredDockHeightRef = useRef(0);
   const [metrics, setMetrics] = useState({
     composerSurfaceHeightPx: 0,
     composerSurfaceOffsetTopPx: 0,
@@ -37,6 +39,7 @@ export function useChatDockInset() {
         composerFooterHeightPx: footerRect ? Math.max(0, Math.ceil(footerRect.height)) : 0,
         dockHeightPx: Math.max(0, Math.ceil(dockRect.height)),
       };
+      lastMeasuredDockHeightRef.current = nextMetrics.dockHeightPx;
       setMetrics((current) =>
         current.composerSurfaceHeightPx === nextMetrics.composerSurfaceHeightPx
         && current.composerSurfaceOffsetTopPx === nextMetrics.composerSurfaceOffsetTopPx
@@ -67,6 +70,25 @@ export function useChatDockInset() {
     };
 
     const observer = new ResizeObserver(() => {
+      // A dock shrink is the submit-collapse path: clearing the draft drops
+      // the dock's height in the same frame the optimistic prompt row mounts.
+      // The rAF-deferred measure would let that frame paint against the stale
+      // (taller) inset, then drop the whole transcript a notch when the
+      // correction lands. ResizeObserver fires after layout and before paint,
+      // so flushing the measure synchronously commits the corrected inset —
+      // and the pinned snap that depends on it — before the collapse frame
+      // paints. Growth keeps the rAF coalescing path: next-frame is prompt
+      // enough for typing, and a sync flush per keystroke would tax input
+      // latency.
+      const dockHeightPx = Math.ceil(dock.getBoundingClientRect().height);
+      if (dockHeightPx < lastMeasuredDockHeightRef.current) {
+        if (frameId !== null) {
+          window.cancelAnimationFrame(frameId);
+          frameId = null;
+        }
+        flushSync(measure);
+        return;
+      }
       scheduleMeasure();
     });
 

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-view-model.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-view-model.ts
@@ -11,7 +11,10 @@ import {
   resolveVisibleOptimisticPrompt,
   shouldShowPendingPromptActivity,
 } from "#product/domain/chats/pending-prompts/pending-prompts";
-import { renderableOutboxEntriesForTranscript } from "#product/domain/sessions/intents/session-intent-selectors";
+import {
+  lastPromptSubmittedAtMs as resolveLastPromptSubmittedAtMs,
+  renderableOutboxEntriesForTranscript,
+} from "#product/domain/sessions/intents/session-intent-selectors";
 import type { TranscriptVirtualRow } from "#product/domain/chats/transcript/transcript-virtual-rows";
 import type { TurnDisplayBlock } from "#product/domain/chats/transcript/transcript-presentation";
 import type { GoalTranscriptEvent } from "#product/domain/activity/goal-transcript-events";
@@ -45,6 +48,7 @@ export interface ChatTranscriptViewModel {
   gutterClassName: string | undefined;
   visibleOptimisticPrompt: PendingPromptEntry | null;
   optimisticPromptTrailingStatus: ReactNode;
+  lastPromptSubmittedAtMs: number | null;
   visibleOutboxEntries: readonly PromptOutboxEntry[];
   outboxStartedAtByPromptId: ReadonlyMap<string, string>;
   virtualRows: readonly TranscriptVirtualRow[];
@@ -135,6 +139,13 @@ export function useChatTranscriptViewModel({
     () => buildOutboxStartedAtByPromptId(outboxEntries),
     [outboxEntries],
   );
+  // Derived from the raw outbox (not the transcript-visible subset): the
+  // submit re-pin keys on the act of sending, which exists even for entries
+  // the transcript never renders (queue placement, instant echo).
+  const lastPromptSubmittedAtMs = useMemo(
+    () => resolveLastPromptSubmittedAtMs(outboxEntries, optimisticPrompt),
+    [optimisticPrompt, outboxEntries],
+  );
   const virtualRows = useSharedTranscriptRowModel({
     activeSessionId,
     transcript,
@@ -180,6 +191,7 @@ export function useChatTranscriptViewModel({
     gutterClassName,
     visibleOptimisticPrompt,
     optimisticPromptTrailingStatus,
+    lastPromptSubmittedAtMs,
     visibleOutboxEntries,
     outboxStartedAtByPromptId,
     virtualRows,

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
@@ -43,6 +43,8 @@ export interface TranscriptStickToBottom {
   scrollToBottom: () => void;
   /** Snap + re-pin, for the scroll-to-bottom button. */
   handleScrollToBottomClick: () => void;
+  /** Snap + re-pin + glue for an explicit prompt submit (send = return-to-bottom intent). */
+  pinToBottom: () => void;
   /** Wrap ANY external scrollTop/scrollToOffset write so its scroll event is excluded from pin/direction. */
   notifyProgrammaticScroll: (write: () => void) => void;
   /** Force the pin state (history prepend / anchor restore intentionally unpin to hold the user's position). */
@@ -282,6 +284,18 @@ export function useTranscriptStickToBottom({
     glueFrameRef.current = requestAnimationFrame(tick);
   }, [scrollRef, scrollToBottom]);
 
+  // A prompt submit is an explicit return-to-bottom intent: re-pin even when
+  // the pin was silently lost earlier (so the sent bubble can never render
+  // clipped behind the dock), and glue across the composer-collapse /
+  // row-measurement settle so the multi-frame geometry change lands as one
+  // silent jump, exactly like session re-entry.
+  const pinToBottom = useCallback(() => {
+    consumedAutoFollowBottomInsetRef.current = autoFollowBottomInsetRef.current;
+    setPinned(true);
+    scrollToBottom();
+    startGlueLoop();
+  }, [scrollToBottom, setPinned, startGlueLoop]);
+
   // Session re-entry: snap instantly, then glue for a few frames so the
   // measurement backlog of freshly mounted rows (virtualizer estimates
   // correcting to real heights) lands as one silent jump instead of a visible
@@ -344,6 +358,7 @@ export function useTranscriptStickToBottom({
     notifyUserScrollIntent,
     scrollToBottom,
     handleScrollToBottomClick,
+    pinToBottom,
     notifyProgrammaticScroll,
     setPinned,
     resetForSession,

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
@@ -28,6 +28,13 @@ export interface UseTranscriptStickToBottomOptions {
    * bottom or clicks the scroll-to-bottom button.
    */
   autoFollowBottomInsetPx?: number;
+  /**
+   * Epoch ms of the newest prompt submission (outbox enqueue or session-level
+   * optimistic prompt). A monotonic increase re-pins: sending is an explicit
+   * return-to-bottom intent. Entries leaving the outbox (delivery, dismissal)
+   * can only lower the stamp and must not re-pin.
+   */
+  lastPromptSubmittedAtMs?: number | null;
 }
 
 export interface TranscriptStickToBottom {
@@ -43,8 +50,6 @@ export interface TranscriptStickToBottom {
   scrollToBottom: () => void;
   /** Snap + re-pin, for the scroll-to-bottom button. */
   handleScrollToBottomClick: () => void;
-  /** Snap + re-pin + glue for an explicit prompt submit (send = return-to-bottom intent). */
-  pinToBottom: () => void;
   /** Wrap ANY external scrollTop/scrollToOffset write so its scroll event is excluded from pin/direction. */
   notifyProgrammaticScroll: (write: () => void) => void;
   /** Force the pin state (history prepend / anchor restore intentionally unpin to hold the user's position). */
@@ -65,6 +70,7 @@ export function useTranscriptStickToBottom({
   onScrollSample,
   repinThresholdPx = REPIN_BOTTOM_THRESHOLD_PX,
   autoFollowBottomInsetPx = 0,
+  lastPromptSubmittedAtMs = null,
 }: UseTranscriptStickToBottomOptions): TranscriptStickToBottom {
   const pinnedRef = useRef(true);
   const [isPinnedToBottom, setIsPinnedToBottom] = useState(true);
@@ -288,13 +294,22 @@ export function useTranscriptStickToBottom({
   // the pin was silently lost earlier (so the sent bubble can never render
   // clipped behind the dock), and glue across the composer-collapse /
   // row-measurement settle so the multi-frame geometry change lands as one
-  // silent jump, exactly like session re-entry.
-  const pinToBottom = useCallback(() => {
-    consumedAutoFollowBottomInsetRef.current = autoFollowBottomInsetRef.current;
-    setPinned(true);
-    scrollToBottom();
-    startGlueLoop();
-  }, [scrollToBottom, setPinned, startGlueLoop]);
+  // silent jump, exactly like session re-entry. Registered after the inset
+  // effect above but before consumer layout effects, so their pinned snaps
+  // read the restored pin. Only a monotonic increase of the submission stamp
+  // qualifies — see the option's contract.
+  const lastPromptSubmittedAtRef = useRef(lastPromptSubmittedAtMs);
+  useLayoutEffect(() => {
+    const previous = lastPromptSubmittedAtRef.current;
+    lastPromptSubmittedAtRef.current = lastPromptSubmittedAtMs;
+    if (
+      lastPromptSubmittedAtMs != null
+      && (previous == null || lastPromptSubmittedAtMs > previous)
+    ) {
+      handleScrollToBottomClick();
+      startGlueLoop();
+    }
+  }, [handleScrollToBottomClick, lastPromptSubmittedAtMs, startGlueLoop]);
 
   // Session re-entry: snap instantly, then glue for a few frames so the
   // measurement backlog of freshly mounted rows (virtualizer estimates
@@ -358,7 +373,6 @@ export function useTranscriptStickToBottom({
     notifyUserScrollIntent,
     scrollToBottom,
     handleScrollToBottomClick,
-    pinToBottom,
     notifyProgrammaticScroll,
     setPinned,
     resetForSession,

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
@@ -292,12 +292,15 @@ export function useTranscriptStickToBottom({
 
   // A prompt submit is an explicit return-to-bottom intent: re-pin even when
   // the pin was silently lost earlier (so the sent bubble can never render
-  // clipped behind the dock), and glue across the composer-collapse /
+  // clipped behind the dock), snap, and glue across the composer-collapse /
   // row-measurement settle so the multi-frame geometry change lands as one
-  // silent jump, exactly like session re-entry. Registered after the inset
-  // effect above but before consumer layout effects, so their pinned snaps
-  // read the restored pin. Only a monotonic increase of the submission stamp
-  // qualifies — see the option's contract.
+  // silent jump, exactly like session re-entry. Unlike the scroll-to-bottom
+  // button, a submit does NOT consume the manual-only overlay range: the
+  // follow target stays the soft bottom above any dock-slot card, so the
+  // stream never slides under it. Registered after the inset effect above but
+  // before consumer layout effects, so their pinned snaps read the restored
+  // pin. Only a monotonic increase of the submission stamp qualifies — see
+  // the option's contract.
   const lastPromptSubmittedAtRef = useRef(lastPromptSubmittedAtMs);
   useLayoutEffect(() => {
     const previous = lastPromptSubmittedAtRef.current;
@@ -306,10 +309,11 @@ export function useTranscriptStickToBottom({
       lastPromptSubmittedAtMs != null
       && (previous == null || lastPromptSubmittedAtMs > previous)
     ) {
-      handleScrollToBottomClick();
+      setPinned(true);
+      scrollToBottom();
       startGlueLoop();
     }
-  }, [handleScrollToBottomClick, lastPromptSubmittedAtMs, startGlueLoop]);
+  }, [lastPromptSubmittedAtMs, scrollToBottom, setPinned, startGlueLoop]);
 
   // Session re-entry: snap instantly, then glue for a few frames so the
   // measurement backlog of freshly mounted rows (virtualizer estimates

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
@@ -297,7 +297,8 @@ export function useTranscriptStickToBottom({
   // silent jump, exactly like session re-entry. Unlike the scroll-to-bottom
   // button, a submit does NOT consume the manual-only overlay range: the
   // follow target stays the soft bottom above any dock-slot card, so the
-  // stream never slides under it. Registered after the inset effect above but
+  // stream never slides under it (a range the user already consumed stays
+  // consumed until they scroll away). Registered after the inset effect above but
   // before consumer layout effects, so their pinned snaps read the restored
   // pin. Only a monotonic increase of the submission stamp qualifies — see
   // the option's contract.

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -550,7 +550,10 @@ state. Composer-surface height remains structural and continues to re-stick
 promptly when the input itself grows. A shrink of the derived structural
 inset (the stable dock reserve minus the non-displacing offset-top share,
 recomputed from fresh rects inside the ResizeObserver callback by the same
-code path a measure commits) flushes the inset re-measure synchronously —
+code path a measure commits, and compared against the widest of the last
+committed structural inset and the last measure-read one — a measure whose
+commit is still pending must be able to raise the shrink baseline but never
+lower it) flushes the inset re-measure synchronously —
 still pre-paint — instead of deferring a frame, so the collapse frame never
 paints against the stale taller inset and then drops the whole transcript a
 notch. This covers any structural collapse (submit, Escape-clear, deleting

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -506,13 +506,17 @@ Submitting a prompt is an explicit return-to-bottom intent. The engine itself
 detects the submit through its `lastPromptSubmittedAtMs` option: the newest
 creation stamp across the session's prompt outbox plus the session-level
 optimistic prompt (`lastPromptSubmittedAtMs` in the intent selectors, wired
-down from the transcript view model). Every real submit enqueues an outbox
+down from the transcript view model). Every prompt send enqueues an outbox
 intent — including queue-placed sends, which never render as transcript rows —
 so the stamp rises exactly once per send, and a monotonic increase re-pins,
 snaps, and runs the same glue loop so the composer collapse and new-row
 measurement settle land as one silent jump, even when the pin was silently
 lost earlier. Entries leaving the outbox (materialization, delivery,
-dismissal) can only lower the stamp and must not re-pin.
+dismissal) can only lower the stamp and must not re-pin. Unlike the
+scroll-to-bottom button, a submit does not consume the manual-only overlay
+range: auto-follow keeps targeting the soft bottom above any dock-slot card.
+Interaction resolutions (answering an inline question or permission request)
+are `resolve_interaction` intents, not sends, and do not re-pin today.
 
 When the transcript is shorter than the viewport, both row-list paths
 top-align the conversation (no `mt-auto` bottom anchor): a fresh conversation
@@ -542,14 +546,19 @@ if another card stacks, only its newly added height remains manual-only. If a
 consumed overlay shrinks or disappears, the browser's upward clamp to the new
 hard bottom is layout movement, not user intent, and must preserve the pinned
 state. Composer-surface height remains structural and continues to re-stick
-promptly when the input itself grows. A shrink of the dock rect or of the
-surface+footer sum (the channel that drives the structural inset) flushes the
-inset re-measure synchronously inside the ResizeObserver callback — still
-pre-paint — instead of deferring a frame, so the collapse frame never paints
-against the stale taller inset and then drops the whole transcript a notch.
-Watching the dock rect alone is not enough: a queued send mounts its outbound
-card in the very commit that collapses the surface, so the dock can net-grow
-while the structural inset shrinks. Growth keeps the rAF-coalesced next-frame
+promptly when the input itself grows. A shrink of the derived structural
+inset (the stable dock reserve minus the non-displacing offset-top share,
+recomputed from fresh rects inside the ResizeObserver callback by the same
+code path a measure commits) flushes the inset re-measure synchronously —
+still pre-paint — instead of deferring a frame, so the collapse frame never
+paints against the stale taller inset and then drops the whole transcript a
+notch. This covers any structural collapse (submit, Escape-clear, deleting
+across a line wrap), and only structural collapse: a queued send mounts its
+outbound card in the very commit that collapses the surface, so the dock rect
+can net-grow while the structural inset shrinks (sync flush), while a
+dock-slot card dismissal shrinks the dock rect without touching the
+structural inset (stays on the deferred path — that movement is the
+non-displacing overlay share). Growth keeps the rAF-coalesced next-frame
 path.
 
 A send intent with `placement: "queue"` is represented by the composer's

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -514,7 +514,8 @@ measurement settle land as one silent jump, even when the pin was silently
 lost earlier. Entries leaving the outbox (materialization, delivery,
 dismissal) can only lower the stamp and must not re-pin. Unlike the
 scroll-to-bottom button, a submit does not consume the manual-only overlay
-range: auto-follow keeps targeting the soft bottom above any dock-slot card.
+range: auto-follow keeps targeting the soft bottom above any dock-slot card
+(a range the user already consumed stays consumed until they scroll away).
 Interaction resolutions (answering an inline question or permission request)
 are `resolve_interaction` intents, not sends, and do not re-pin today.
 

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -502,12 +502,17 @@ re-show while pinned, a short pre-paint rAF "glue" loop holds the viewport at th
 true bottom until row measurement settles, collapsing the resume backlog into one
 jump instead of a visible crawl.
 
-Submitting a prompt is an explicit return-to-bottom intent. The optimistic
-prompt's arrival (`pendingPromptText` transitioning null -> non-null) re-pins
-through the engine's `pinToBottom` — even when the pin was silently lost
-earlier — then snaps and runs the same glue loop so the composer collapse and
-new-row measurement settle land as one silent jump. Materialization clearing
-the pending text must not re-pin, and a queued send produces no transition.
+Submitting a prompt is an explicit return-to-bottom intent. The engine itself
+detects the submit through its `lastPromptSubmittedAtMs` option: the newest
+creation stamp across the session's prompt outbox plus the session-level
+optimistic prompt (`lastPromptSubmittedAtMs` in the intent selectors, wired
+down from the transcript view model). Every real submit enqueues an outbox
+intent — including queue-placed sends, which never render as transcript rows —
+so the stamp rises exactly once per send, and a monotonic increase re-pins,
+snaps, and runs the same glue loop so the composer collapse and new-row
+measurement settle land as one silent jump, even when the pin was silently
+lost earlier. Entries leaving the outbox (materialization, delivery,
+dismissal) can only lower the stamp and must not re-pin.
 
 When the transcript is shorter than the viewport, both row-list paths
 top-align the conversation (no `mt-auto` bottom anchor): a fresh conversation
@@ -537,11 +542,15 @@ if another card stacks, only its newly added height remains manual-only. If a
 consumed overlay shrinks or disappears, the browser's upward clamp to the new
 hard bottom is layout movement, not user intent, and must preserve the pinned
 state. Composer-surface height remains structural and continues to re-stick
-promptly when the input itself grows. A dock shrink (clearing the draft at
-submit) flushes its inset re-measure synchronously inside the ResizeObserver
-callback — still pre-paint — instead of deferring a frame, so the collapse
-frame never paints against the stale taller inset and then drops the whole
-transcript a notch; growth keeps the rAF-coalesced next-frame path.
+promptly when the input itself grows. A shrink of the dock rect or of the
+surface+footer sum (the channel that drives the structural inset) flushes the
+inset re-measure synchronously inside the ResizeObserver callback — still
+pre-paint — instead of deferring a frame, so the collapse frame never paints
+against the stale taller inset and then drops the whole transcript a notch.
+Watching the dock rect alone is not enough: a queued send mounts its outbound
+card in the very commit that collapses the surface, so the dock can net-grow
+while the structural inset shrinks. Growth keeps the rAF-coalesced next-frame
+path.
 
 A send intent with `placement: "queue"` is represented by the composer's
 outbound queue and must not also produce a transcript row. A queued send that

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -502,6 +502,13 @@ re-show while pinned, a short pre-paint rAF "glue" loop holds the viewport at th
 true bottom until row measurement settles, collapsing the resume backlog into one
 jump instead of a visible crawl.
 
+Submitting a prompt is an explicit return-to-bottom intent. The optimistic
+prompt's arrival (`pendingPromptText` transitioning null -> non-null) re-pins
+through the engine's `pinToBottom` — even when the pin was silently lost
+earlier — then snaps and runs the same glue loop so the composer collapse and
+new-row measurement settle land as one silent jump. Materialization clearing
+the pending text must not re-pin, and a queued send produces no transition.
+
 When the transcript is shorter than the viewport, both row-list paths
 top-align the conversation (no `mt-auto` bottom anchor): a fresh conversation
 reads from the top, and unused viewport height sits below it,
@@ -530,7 +537,11 @@ if another card stacks, only its newly added height remains manual-only. If a
 consumed overlay shrinks or disappears, the browser's upward clamp to the new
 hard bottom is layout movement, not user intent, and must preserve the pinned
 state. Composer-surface height remains structural and continues to re-stick
-promptly when the input itself grows.
+promptly when the input itself grows. A dock shrink (clearing the draft at
+submit) flushes its inset re-measure synchronously inside the ResizeObserver
+callback — still pre-paint — instead of deferring a frame, so the collapse
+frame never paints against the stale taller inset and then drops the whole
+transcript a notch; growth keeps the rAF-coalesced next-frame path.
 
 A send intent with `placement: "queue"` is represented by the composer's
 outbound queue and must not also produce a transcript row. A queued send that


### PR DESCRIPTION
Fixes [PRO-174](https://linear.app/proliferate-team/issue/PRO-174/long-text-is-bumpy-on-submission).

## What was bumpy

Frame-by-frame analysis of the ticket's recording (plus Pablo's two-frame repro) showed two layered defects at prompt submit:

1. **The notch.** The composer dock is an absolute overlay; the transcript reserves space for it via a measured bottom inset. That measure was ResizeObserver + rAF deferred (post-paint), so the frame where the draft cleared painted the history against the stale taller inset — one notch too high with a phantom gap — then dropped it ~the composer-height delta when the deferred correction landed. This violates the spec's frontier invariant (transcript.md: "the frontier must remain at one composer-relative coordinate ... submit -> immediate Thinking -> ...").

2. **The clipped bubble (aggravated variant).** Every follow mechanism is gated on the stick-to-bottom pin, and the submit path never re-pinned. A pin silently lost during fast typing while a reply streamed left the sent bubble clipped behind the dock (chevron showing) until an unrelated snap ~1.5s later.

## The fix (as it stands after three self-review rounds)

- `use-chat-dock-inset.ts`: any shrink of the **derived structural inset** (the stable dock reserve minus the non-displacing offset-top share, recomputed inside the ResizeObserver callback by the same `readDockMetrics` path a measure commits) flushes the measure synchronously via `flushSync` — RO fires after layout and before paint, so the corrected inset and the pinned snap that depends on it commit before the collapse frame paints. This catches the queued send (outbound card mounts in the same commit the surface collapses, so the dock rect net-grows while the structural inset shrinks) and deliberately does NOT force-flush dock-slot card dismissals (dock shrinks, structural inset unchanged). Growth keeps the rAF-coalesced path. The shrink gate's baseline is the **max of the last committed and last measure-read** structural insets (round 2 caught that a measure-read alone must never lower the baseline — a deferred measure reading freshly-collapsed geometry would disarm the gate for the collapse frame; round 3 caught the mirror image — a growth measure whose default-lane commit is delayed under load must still be able to raise it, or a collapse back to the old height slips to the deferred path and the stale tall snapshot commits-then-drops). A stale-high baseline can only cost an extra harmless sync flush, never a missed one. Both directions are negative-controlled in tests.
- `use-transcript-stick-to-bottom.ts`: the engine itself detects a submit via the new `lastPromptSubmittedAtMs` option — the newest `createdAt` across the session's prompt outbox (plus the session-level optimistic prompt), derived by a new `lastPromptSubmittedAtMs` selector and wired down from the transcript view model. The originally-proposed `pendingPromptText` trigger was **dead in production** (its only writer is test-only; real submits enqueue outbox intents), so the trigger now keys on the real signal, fires exactly once per send on a monotonic stamp increase (queue-placed sends and retries included; deliveries/dismissals only lower the stamp and never re-pin), and lives in one place instead of duplicated per row list. A submit re-pins to the **soft bottom**: unlike the scroll-to-bottom button it does not consume the manual-only overlay range, so streams never follow under a dock-slot card.
- Spec updated in the same PR per the docs lifecycle (`specs/codebase/systems/product/chat/transcript.md`).

## Tests

- Row-list suites: pin lost -> stamp rise re-pins/snaps/hides the chevron; a falling stamp (entry left the outbox) must NOT re-pin; submit re-pins to the soft bottom, preserving the overlay range (fails against the consuming variant — negative-controlled).
- `use-chat-dock-inset.test.tsx`: sync tests count real `flushSync` entries (fail if downgraded to a deferred measure — negative-controlled); queued-send net-growth collapse flushes; card dismissal defers; both stale-baseline interleavings (deferred read of collapsed geometry; collapse under a measured-but-uncommitted growth) stay on the sync path.
- `session-intent-selectors.test.ts`: stamp derivation incl. queue placement and optimistic-prompt precedence.
- Diff-derived scope green (152 files / 1101 tests), package typecheck clean.

## Known limitations (documented, deliberate)

- Structural shrinks from backspacing across a line wrap also take the `flushSync` path (a few sync flushes across a held backspace) — accepted price of never notching; Escape-clear and select-all-delete are the same visual class and equally covered.
- `resolve_interaction` answers (inline questions/permissions) are not sends and do not re-pin — pre-existing gap, noted in the spec, follow-up candidate.
- The stamp is wall-clock; a backwards clock jump degrades to pre-PR behavior (no re-pin) until the clock catches up, never a wrong re-pin.

## Not yet verified live

The paint-level claim (single paint at final position) is verified by reasoning + unit tests with negative controls, not yet by a 60fps screen capture of the running app. Worth one manual pass of the spec's handoff sequence before merge: long draft -> submit -> Thinking, plus the preserved behaviors (upward scroll still unpins; chevron click still re-pins and consumes the overlay range; per-line draft growth still shifts next-frame).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

