### PR TITLE
fix(product): let chat file links reopen the right panel (PRO-242)

### DIFF
--- a/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.test.ts
+++ b/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.test.ts
@@ -323,3 +323,57 @@ describe("useMainScreenRightPanel drag wiring", () => {
     ).toBe(startWidth);
   });
 });
+
+describe("useMainScreenRightPanel external durable open writes", () => {
+  it("honors a store-level open written while a session override holds the frame closed (PRO-242)", () => {
+    const { result, rerender } = renderRightPanel();
+    // A toggle seeds the session override; closing leaves it at open:false,
+    // which used to shadow every later store-level open write.
+    act(() => {
+      result.current.setRightPanelOpen(true);
+    });
+    act(() => {
+      result.current.setRightPanelOpen(false);
+    });
+    rerender();
+    expect(result.current.rightPanelOpen).toBe(false);
+
+    // A chat file-link click opens the frame through the store, the same
+    // write `openViewerTargetInRightPanel` issues.
+    act(() => {
+      useWorkspaceUiStore.getState().setRightPanelOpenForWorkspace(WORKSPACE_ID, true);
+    });
+    rerender();
+    expect(result.current.rightPanelOpen).toBe(true);
+
+    // The user can still close it afterwards.
+    act(() => {
+      result.current.setRightPanelOpen(false);
+    });
+    rerender();
+    expect(result.current.rightPanelOpen).toBe(false);
+  });
+
+  it("keeps the frame shell-level on workspace switches instead of adopting the next workspace's persisted open", () => {
+    const OTHER_WORKSPACE_ID = "workspace-switch-test";
+    const { result, rerender } = renderHook(
+      ({ workspaceUiKey }: { workspaceUiKey: string }) =>
+        useMainScreenRightPanel({
+          workspaceUiKey,
+          materializedWorkspaceId: workspaceUiKey,
+          isCloudWorkspaceSelected: false,
+          rightPanelSuppressed: false,
+        }),
+      { initialProps: { workspaceUiKey: WORKSPACE_ID } },
+    );
+    act(() => {
+      result.current.setRightPanelOpen(true);
+    });
+    act(() => {
+      useWorkspaceUiStore.getState().setRightPanelOpenForWorkspace(OTHER_WORKSPACE_ID, false);
+    });
+
+    rerender({ workspaceUiKey: OTHER_WORKSPACE_ID });
+    expect(result.current.rightPanelOpen).toBe(true);
+  });
+});

--- a/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.ts
+++ b/apps/packages/product-client/src/hooks/main/facade/use-main-screen-right-panel.ts
@@ -98,6 +98,27 @@ export function useMainScreenRightPanel({
   );
   const rightPanelDurableState = rightPanelSessionDurableState
     ?? persistedRightPanelDurableState;
+  // External openers (chat file links, attachment previews) reveal the frame
+  // by writing the durable store (`setRightPanelOpenForWorkspace`). Once a
+  // session override exists those writes would stay invisible behind it, so a
+  // same-workspace change of the persisted open flag folds into the override.
+  // A workspaceUiKey change only re-baselines: the frame stays shell-level
+  // across workspace switches.
+  const persistedOpenBaselineRef = useRef({
+    key: workspaceUiKey,
+    open: persistedRightPanelDurableState.open,
+  });
+  useEffect(() => {
+    const baseline = persistedOpenBaselineRef.current;
+    const open = persistedRightPanelDurableState.open;
+    persistedOpenBaselineRef.current = { key: workspaceUiKey, open };
+    if (baseline.key !== workspaceUiKey || baseline.open === open) {
+      return;
+    }
+    setRightPanelSessionDurableState((session) => (
+      session === null || session.open === open ? session : { ...session, open }
+    ));
+  }, [persistedRightPanelDurableState.open, workspaceUiKey]);
   const rightPanelMaterializedState = materializedWorkspaceId
     ? rightPanelMaterializedByWorkspace[materializedWorkspaceId]
       ?? DEFAULT_RIGHT_PANEL_MATERIALIZED_STATE


### PR DESCRIPTION
## Summary

- Clicking a blue file link in a chat response looked actionable (hover underline, pointer cursor) but visibly did nothing whenever the user had toggled or drag-collapsed the right panel earlier in that shell session.
- The click actually ran the whole open-viewer pipeline — viewer tab activated, right-panel entry materialized, durable `open: true` written — but `useMainScreenRightPanel`'s session override (`rightPanelSessionDurableState`, seeded by any manual toggle/drag) permanently shadowed the persisted state, so the frame never revealed. On a fresh shell with no prior toggle the same click worked, which is why the feature seemed "already supported".
- Fix: fold same-workspace transitions of the persisted `open` flag into the session override, so store-level openers (chat file links via `openViewerTargetInRightPanel`, attachment previews, file target actions) surface. A `workspaceUiKey` change only re-baselines, keeping the frame shell-level across workspace switches, and users can still close the panel afterwards.

Linear: [PRO-242](https://linear.app/proliferate-team/issue/PRO-242/file-hyperlink-doesnt-work-in-chat)

## Testing

- Tier 1 (package unit): two new regression tests in `use-main-screen-right-panel.test.ts` — a store-level open written while the session override holds the frame closed must open it (fails on the previous code), and a workspace switch must not adopt the next workspace's persisted open state. Full file: 12/12 green; adjacent suites (`hooks/main/facade`, `use-file-reference-actions`, `lib/domain/workspaces/shell`): 61/61 green.
- Live verification in the running desktop client (dev profile, CDP-driven): with the panel toggled closed, clicking a `README.md` link in an assistant reply now opens the right pane on the file viewer; traced store writes and the adoption effect end to end. Cold-shell behavior and manual close-after-open unchanged.

## Observability

- none

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- `pnpm exec vitest run src/hooks/main/facade src/hooks/workspaces/workflows/files/use-file-reference-actions.test.tsx src/lib/domain/workspaces/shell` (product-client) — 61 passed
- `pnpm --filter @proliferate/product-client build` — typecheck + emit clean

## How to test manually

1. `make run PROFILE=<profile>` and open a workspace with a session whose assistant reply contains a file link (e.g. ask the agent to reply with `[README.md](README.md)`).
2. Close the right panel with the header toggle (this is the state that used to kill file links).
3. Click the blue file link in the chat response — the right panel must open showing the file in the viewer.
4. Close the panel with the toggle again — it must close normally.