### PR TITLE
fix(product): scope the launch-intent pane to its own workspace (PRO-230)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/surface/ChatLaunchIntentPane.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/surface/ChatLaunchIntentPane.test.tsx
@@ -89,6 +89,8 @@ function intent(): ChatLaunchIntent {
     },
     materializedWorkspaceId: null,
     materializedSessionId: null,
+    attemptId: null,
+    targetWorkspaceId: null,
     createdAt: 1_700_000_000_000,
     sendAttemptedAt: null,
     failure: null,

--- a/apps/packages/product-client/src/hooks/chat/derived/use-chat-surface-state.ts
+++ b/apps/packages/product-client/src/hooks/chat/derived/use-chat-surface-state.ts
@@ -5,6 +5,7 @@ import {
   resolveChatSurfaceState,
   type ChatSurfaceState,
 } from "#product/lib/domain/chat/surface/chat-surface";
+import { resolveLaunchIntentScope } from "#product/lib/domain/chat/launch/launch-intent";
 import { shouldShowCloudWorkspaceStatusScreen } from "#product/lib/domain/workspaces/cloud/cloud-workspace-status";
 import { parseCloudWorkspaceSyntheticId } from "#product/lib/domain/workspaces/cloud/cloud-ids";
 import { useChatLaunchIntentStore } from "#product/stores/chat/chat-launch-intent-store";
@@ -22,6 +23,9 @@ export function useChatSurfaceState(shellRenderSurface?: WorkspaceRenderSurface 
   selectedWorkspaceId: string | null;
 } {
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
+  const selectedLogicalWorkspaceId = useSessionSelectionStore(
+    (state) => state.selectedLogicalWorkspaceId,
+  );
   const pendingWorkspaceEntry = useSessionSelectionStore((state) => state.pendingWorkspaceEntry);
   const workspaceArrivalEvent = useSessionSelectionStore((state) => state.workspaceArrivalEvent);
   const activeLaunchIntent = useChatLaunchIntentStore((state) => state.activeIntent);
@@ -84,11 +88,14 @@ export function useChatSurfaceState(shellRenderSurface?: WorkspaceRenderSurface 
     selectedWorkspaceId,
     hasPendingWorkspaceEntry: pendingWorkspaceEntry !== null,
     activeLaunchIntentId: activeLaunchIntent?.id ?? null,
+    launchIntentScope: activeLaunchIntent ? resolveLaunchIntentScope(activeLaunchIntent) : null,
     launchIntentInFlight: activeLaunchIntent ? activeLaunchIntent.failure === null : false,
     launchIntentSessionId:
       activeLaunchIntent?.materializedSessionId
       ?? activeLaunchIntent?.clientSessionId
       ?? null,
+    shellLogicalWorkspaceId: selectedLogicalWorkspaceId,
+    shellWorkspaceId: selectedWorkspaceId,
     selectedLocalWorkspace,
     isArrivalWorkspace: workspaceArrivalEvent?.workspaceId === selectedWorkspaceId,
     shouldShowSelectedCloudWorkspaceStatus: selectedCloudWorkspace
@@ -105,10 +112,13 @@ export function useChatSurfaceState(shellRenderSurface?: WorkspaceRenderSurface 
     isRunning,
     streamConnectionState,
   })), [
+    activeLaunchIntent?.attemptId,
     activeLaunchIntent?.clientSessionId,
     activeLaunchIntent?.failure,
     activeLaunchIntent?.id,
     activeLaunchIntent?.materializedSessionId,
+    activeLaunchIntent?.materializedWorkspaceId,
+    activeLaunchIntent?.targetWorkspaceId,
     activeSessionId,
     hasContent,
     hasTranscriptEntry,
@@ -119,6 +129,7 @@ export function useChatSurfaceState(shellRenderSurface?: WorkspaceRenderSurface 
     selectedCloudRuntime.state?.preserveVisibleContent,
     selectedCloudWorkspace,
     selectedLocalWorkspace,
+    selectedLogicalWorkspaceId,
     selectedWorkspaceId,
     shellRenderScope,
     streamConnectionState,

--- a/apps/packages/product-client/src/hooks/home/workflows/home-next-launch-intent.ts
+++ b/apps/packages/product-client/src/hooks/home/workflows/home-next-launch-intent.ts
@@ -1,5 +1,6 @@
 import {
   resolveChatLaunchRetryMode,
+  resolveLaunchIntentPendingAttemptId,
   resolveLaunchIntentPendingWorkspaceId,
   type ChatLaunchRetryMode,
 } from "#product/lib/domain/chat/launch/launch-intent";
@@ -69,16 +70,20 @@ export function markHomeLaunchIntentMaterializedFromPendingWorkspace(intentId: s
     return;
   }
 
-  const workspaceId = resolveLaunchIntentPendingWorkspaceId(
-    activeIntent,
-    useSessionSelectionStore.getState().pendingWorkspaceEntry,
-  );
-  if (!workspaceId) {
+  const pendingWorkspaceEntry = useSessionSelectionStore.getState().pendingWorkspaceEntry;
+  const workspaceId = resolveLaunchIntentPendingWorkspaceId(activeIntent, pendingWorkspaceEntry);
+  // The attempt id is known as soon as the pending entry exists, well before
+  // (or even absent) a resolved workspaceId — scoping on it here is what lets
+  // a launch that fails before materializing still own only its own shell
+  // instead of overriding every workspace's transcript (PRO-230).
+  const attemptId = resolveLaunchIntentPendingAttemptId(activeIntent, pendingWorkspaceEntry);
+  if (!workspaceId && !attemptId) {
     return;
   }
 
   useChatLaunchIntentStore.getState().markMaterializedIfActive(intentId, {
-    workspaceId,
+    ...(workspaceId ? { workspaceId } : {}),
+    ...(attemptId ? { attemptId } : {}),
   });
 }
 

--- a/apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.test.tsx
@@ -198,6 +198,88 @@ describe("useHomeNextLaunch", () => {
     expect(mocks.navigate).toHaveBeenCalledTimes(1);
   });
 
+  // PR #1867 review finding 1: the intent used to stay unscoped
+  // (attemptId/targetWorkspaceId/materializedWorkspaceId all null) for the
+  // entire in-flight window on the success path, because
+  // markHomeLaunchIntentMaterializedFromPendingWorkspace was only called from
+  // the catch block. This pins that the launch flow now scopes the intent to
+  // its pending attempt synchronously, right after invoking the create call
+  // and before awaiting it — not only after the create promise settles.
+  it("scopes the launch intent to its pending attempt before the create promise resolves (PRO-230)", async () => {
+    const sessionId = "client-session:codex:sync-scope";
+    const pendingEntry = buildSubmittingPendingWorkspaceEntry({
+      attemptId: "sync-scope-attempt",
+      selectedWorkspaceId: null,
+      source: "worktree-created",
+      displayName: "sync-scope",
+      repoLabel: "repo",
+      baseBranchName: "main",
+      request: {
+        kind: "worktree",
+        input: {
+          repoRootId: "repo-root-1",
+          sourceWorkspaceId: null,
+          baseBranch: "main",
+          defaultBranch: "main",
+        },
+      },
+    });
+
+    let resolveCreate: (value: { workspaceId: string; projectedSessionId: string | null }) => void =
+      () => {};
+    const createPromise = new Promise<{ workspaceId: string; projectedSessionId: string | null }>(
+      (resolve) => {
+        resolveCreate = resolve;
+      },
+    );
+    // Mirrors production: beginPendingWorkspace runs synchronously in the
+    // create workflow's body, before its first await, so the pending entry
+    // is already in the store by the time the caller gets the promise back.
+    mocks.createWorktreeAndEnterWithResult.mockImplementation(() => {
+      useSessionSelectionStore.getState().enterPendingWorkspaceShell(pendingEntry, {
+        initialActiveSessionId: sessionId,
+      });
+      return createPromise;
+    });
+
+    const { result } = renderHomeNextLaunch();
+
+    let launchPromise: Promise<boolean> = Promise.resolve(false);
+    act(() => {
+      launchPromise = result.current.launch({
+        text: "scope before resolve",
+        modelSelection: { kind: "codex", modelId: "gpt-5.4" },
+        modeId: null,
+        launchControlValues: {},
+        target: {
+          kind: "worktree",
+          repoRootId: "repo-root-1",
+          sourceWorkspaceId: null,
+          baseBranch: "main",
+          defaultBranch: "main",
+        },
+      });
+    });
+
+    // The create promise is still pending here, so if scoping only happened
+    // in the catch block (the pre-fix behavior), attemptId would still be
+    // null at this point.
+    expect(useChatLaunchIntentStore.getState().activeIntent?.attemptId).toBe("sync-scope-attempt");
+
+    putSessionRecord(createEmptySessionRecord(sessionId, "codex", {
+      workspaceId: buildPendingWorkspaceUiKey(pendingEntry),
+      materializedSessionId: null,
+      modelId: "gpt-5.4",
+    }));
+    resolveCreate({ workspaceId: "workspace-real", projectedSessionId: sessionId });
+
+    let succeeded = false;
+    await act(async () => {
+      succeeded = await launchPromise;
+    });
+    expect(succeeded).toBe(true);
+  });
+
   it("does not invoke the Desktop Cowork workflow from Web Home", async () => {
     mocks.productHost.desktop = null;
     const { result } = renderHomeNextLaunch();

--- a/apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.ts
+++ b/apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.ts
@@ -129,6 +129,13 @@ export function useHomeNextLaunch() {
           draftText: null,
           sourceWorkspaceId: null,
         });
+        // createThreadFromSelection runs its synchronous prefix (including
+        // beginPendingWorkspace) before its first await, so the pending
+        // attempt already exists in the store here. Scope the intent to it
+        // now instead of waiting for the catch block, so the launch-intent
+        // pane owns its own shell for the whole in-flight window instead of
+        // falling through to session-empty (PRO-230 review finding 1).
+        markHomeLaunchIntentMaterializedFromPendingWorkspace(launchIntentId);
         const queuedProjectedSessionId = await promptProjectedPendingWorkspaceSession({
           text: prompt,
           promptId,
@@ -172,6 +179,12 @@ export function useHomeNextLaunch() {
             repoGroupKeyToExpand: target.sourceRoot,
             initialSession,
           });
+        if (createdWorkspacePromise) {
+          // Same reasoning as the cowork branch: the create call's synchronous
+          // prefix (beginPendingWorkspace) has already run, so scope the
+          // intent to the pending attempt now rather than only on failure.
+          markHomeLaunchIntentMaterializedFromPendingWorkspace(launchIntentId);
+        }
         const queuedProjectedSessionId = createdWorkspacePromise
           ? await promptProjectedPendingWorkspaceSession({
             text: prompt,
@@ -230,6 +243,9 @@ export function useHomeNextLaunch() {
         }, {
           initialSession,
         });
+        // Same reasoning as the cowork/local branches above: the pending
+        // attempt already exists synchronously, so scope the intent now.
+        markHomeLaunchIntentMaterializedFromPendingWorkspace(launchIntentId);
         const queuedProjectedSessionId = await promptProjectedPendingWorkspaceSession({
           text: prompt,
           promptId,

--- a/apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.ts
+++ b/apps/packages/product-client/src/hooks/home/workflows/use-home-next-launch.ts
@@ -109,6 +109,11 @@ export function useHomeNextLaunch() {
       },
       materializedWorkspaceId: null,
       materializedSessionId: null,
+      // The pending-workspace attempt (if any) isn't created until after this
+      // intent begins; it gets threaded in once known via
+      // markHomeLaunchIntentMaterializedFromPendingWorkspace.
+      attemptId: null,
+      targetWorkspaceId: target.kind === "local" ? target.existingWorkspaceId : null,
       createdAt: Date.now(),
       sendAttemptedAt: null,
       failure: null,

--- a/apps/packages/product-client/src/hooks/main/facade/use-main-screen-state.ts
+++ b/apps/packages/product-client/src/hooks/main/facade/use-main-screen-state.ts
@@ -15,7 +15,8 @@ import { useWorkspaceSidebarResize } from "#product/hooks/preferences/ui/use-wor
 import { useSelectedCloudRuntimeState } from "#product/hooks/workspaces/facade/use-selected-cloud-runtime-state";
 import { useIsHotPaintGatePendingForWorkspace } from "#product/hooks/workspaces/derived/use-hot-paint-gate";
 import { useWorkspaces } from "#product/hooks/workspaces/cache/use-workspaces";
-import { shouldMountWorkspaceShell } from "#product/lib/domain/chat/surface/chat-surface";
+import { launchIntentOwnsShell, shouldMountWorkspaceShell } from "#product/lib/domain/chat/surface/chat-surface";
+import { resolveLaunchIntentScope } from "#product/lib/domain/chat/launch/launch-intent";
 import { parseCloudWorkspaceSyntheticId } from "#product/lib/domain/workspaces/cloud/cloud-ids";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 import { resolveSelectedWorkspaceIdentity } from "#product/lib/domain/workspaces/selection/workspace-ui-key";
@@ -118,10 +119,21 @@ export function useMainScreenState(): MainScreenState {
   const { data: workspaceCollections } = useWorkspaces();
   const workspaces = workspaceCollections?.workspaces ?? EMPTY_WORKSPACES;
   const repoRoots = workspaceCollections?.repoRoots ?? [];
+  // An intent only mounts the shell for its own workspace: a selected
+  // workspace or pending entry always mounts the shell on their own, and an
+  // active intent additionally mounts it only when the intent scopes to this
+  // shell (or is unscoped and nothing is selected yet). This stops one
+  // workspace's launch intent from hijacking an unrelated shell (PRO-230).
   const activeLaunchIntentIdForShell =
     selectedWorkspaceId || pendingWorkspaceEntry
       ? activeLaunchIntent?.id ?? null
-      : null;
+      : activeLaunchIntent && launchIntentOwnsShell({
+        scope: resolveLaunchIntentScope(activeLaunchIntent),
+        shellLogicalWorkspaceId: selectedLogicalWorkspaceId,
+        shellWorkspaceId: selectedWorkspaceId,
+      })
+        ? activeLaunchIntent.id
+        : null;
   const hasLaunchIntentOnlyShell = false;
   const hasWorkspaceShell = shouldMountWorkspaceShell({
     selectedWorkspaceId,

--- a/apps/packages/product-client/src/lib/domain/chat/launch/launch-intent.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/launch/launch-intent.test.ts
@@ -4,7 +4,9 @@ import type { PendingWorkspaceEntry } from "#product/lib/domain/workspaces/creat
 import {
   resolveChatLaunchIntentView,
   resolveChatLaunchRetryMode,
+  resolveLaunchIntentPendingAttemptId,
   resolveLaunchIntentPendingWorkspaceId,
+  resolveLaunchIntentScope,
 } from "#product/lib/domain/chat/launch/launch-intent";
 
 function intent(overrides: Partial<ChatLaunchIntent> = {}): ChatLaunchIntent {
@@ -22,6 +24,8 @@ function intent(overrides: Partial<ChatLaunchIntent> = {}): ChatLaunchIntent {
     },
     materializedWorkspaceId: null,
     materializedSessionId: null,
+    attemptId: null,
+    targetWorkspaceId: null,
     createdAt: 100,
     sendAttemptedAt: null,
     failure: null,
@@ -142,5 +146,66 @@ describe("chat launch intent view", () => {
       }),
       pendingEntry({ source: "local-created" }),
     )).toBeNull();
+  });
+
+  it("matches the pending attempt id before a workspace id resolves", () => {
+    expect(resolveLaunchIntentPendingAttemptId(
+      intent({
+        targetKind: "worktree",
+        retryInput: {
+          text: "Build the thing",
+          modelSelection: { kind: "codex", modelId: "gpt-5.4" },
+          modeId: null,
+          target: {
+            kind: "worktree",
+            repoRootId: "repo-1",
+            sourceWorkspaceId: null,
+            baseBranch: "main",
+            defaultBranch: "main",
+          },
+        },
+      }),
+      pendingEntry({ source: "worktree-created", workspaceId: null, attemptId: "attempt-2" }),
+    )).toBe("attempt-2");
+  });
+
+  it("does not match an unrelated pending entry's attempt id", () => {
+    expect(resolveLaunchIntentPendingAttemptId(
+      intent({ targetKind: "cowork" }),
+      pendingEntry({ source: "worktree-created", attemptId: "attempt-2" }),
+    )).toBeNull();
+  });
+});
+
+describe("resolveLaunchIntentScope", () => {
+  it("has no scope before an attempt or workspace is known", () => {
+    expect(resolveLaunchIntentScope(intent())).toEqual({
+      pendingUiKey: null,
+      workspaceId: null,
+    });
+  });
+
+  it("scopes to the pending-workspace UI key once an attempt id is known", () => {
+    expect(resolveLaunchIntentScope(intent({ attemptId: "attempt-1" }))).toEqual({
+      pendingUiKey: "pending-workspace:attempt-1",
+      workspaceId: null,
+    });
+  });
+
+  it("scopes to the target workspace id for launches into an existing workspace", () => {
+    expect(resolveLaunchIntentScope(intent({ targetWorkspaceId: "workspace-1" }))).toEqual({
+      pendingUiKey: null,
+      workspaceId: "workspace-1",
+    });
+  });
+
+  it("prefers the materialized workspace id over the target once it resolves", () => {
+    expect(resolveLaunchIntentScope(intent({
+      targetWorkspaceId: "workspace-target",
+      materializedWorkspaceId: "workspace-real",
+    }))).toEqual({
+      pendingUiKey: null,
+      workspaceId: "workspace-real",
+    });
   });
 });

--- a/apps/packages/product-client/src/lib/domain/chat/launch/launch-intent.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/launch/launch-intent.ts
@@ -4,6 +4,7 @@ import type {
   HomeNextModelSelection,
 } from "#product/lib/domain/home/home-next-launch";
 import type { PendingWorkspaceEntry } from "#product/lib/domain/workspaces/creation/pending-entry";
+import { buildPendingWorkspaceUiKey } from "#product/lib/domain/workspaces/creation/pending-entry";
 import type { DesktopAgentLaunchAgent } from "#product/lib/domain/agents/cloud-launch-catalog";
 
 export type ChatLaunchTargetKind = HomeLaunchTarget["kind"];
@@ -53,9 +54,35 @@ export interface ChatLaunchIntent {
   retryInput: ChatLaunchRetryInput;
   materializedWorkspaceId: string | null;
   materializedSessionId: string | null;
+  /** The pending-workspace attempt this launch created, once known. */
+  attemptId: string | null;
+  /** The existing workspace this launch targets, when launching into one. */
+  targetWorkspaceId: string | null;
   createdAt: number;
   sendAttemptedAt: number | null;
   failure: ChatLaunchIntentFailure | null;
+}
+
+/** The workspace UI identities a launch intent is allowed to own the surface of. */
+export interface LaunchIntentScope {
+  pendingUiKey: string | null;
+  workspaceId: string | null;
+}
+
+/**
+ * An intent only owns the launch-intent pane / shell for its own workspace.
+ * Before anything materializes, that scope is the pending-workspace UI key of
+ * its own attempt; once a workspace is targeted or materialized, it is that
+ * workspace's id. A `null` scope in both fields means the intent has not
+ * attached to any workspace yet (the Home first-paint window).
+ */
+export function resolveLaunchIntentScope(intent: ChatLaunchIntent): LaunchIntentScope {
+  return {
+    pendingUiKey: intent.attemptId
+      ? buildPendingWorkspaceUiKey({ attemptId: intent.attemptId })
+      : null,
+    workspaceId: intent.materializedWorkspaceId ?? intent.targetWorkspaceId,
+  };
 }
 
 export interface ChatLaunchIntentViewModel {
@@ -85,6 +112,26 @@ export function resolveChatLaunchRetryMode(
   return "safe";
 }
 
+function pendingWorkspaceMatchesLaunchTarget(
+  target: ChatLaunchRetryInput["target"],
+  pending: PendingWorkspaceEntry,
+): boolean {
+  if (target.kind === "cowork") {
+    return pending.source === "cowork-created";
+  }
+  if (target.kind === "worktree") {
+    return pending.source === "worktree-created";
+  }
+  if (target.kind === "cloud") {
+    return pending.source === "cloud-created";
+  }
+  if (target.kind === "local") {
+    return !target.existingWorkspaceId && pending.source === "local-created";
+  }
+
+  return false;
+}
+
 export function resolveLaunchIntentPendingWorkspaceId(
   intent: ChatLaunchIntent,
   pending: PendingWorkspaceEntry | null,
@@ -93,23 +140,28 @@ export function resolveLaunchIntentPendingWorkspaceId(
     return null;
   }
 
-  const target = intent.retryInput.target;
-  if (target.kind === "cowork") {
-    return pending.source === "cowork-created" ? pending.workspaceId : null;
-  }
-  if (target.kind === "worktree") {
-    return pending.source === "worktree-created" ? pending.workspaceId : null;
-  }
-  if (target.kind === "cloud") {
-    return pending.source === "cloud-created" ? pending.workspaceId : null;
-  }
-  if (target.kind === "local") {
-    return !target.existingWorkspaceId && pending.source === "local-created"
-      ? pending.workspaceId
-      : null;
+  return pendingWorkspaceMatchesLaunchTarget(intent.retryInput.target, pending)
+    ? pending.workspaceId
+    : null;
+}
+
+/**
+ * The attempt id becomes known as soon as the pending workspace entry exists,
+ * well before its `workspaceId` (or a failure) resolves. Callers use this to
+ * scope an intent to its own attempt even when the launch never produces a
+ * workspace at all.
+ */
+export function resolveLaunchIntentPendingAttemptId(
+  intent: ChatLaunchIntent,
+  pending: PendingWorkspaceEntry | null,
+): string | null {
+  if (!pending) {
+    return null;
   }
 
-  return null;
+  return pendingWorkspaceMatchesLaunchTarget(intent.retryInput.target, pending)
+    ? pending.attemptId
+    : null;
 }
 
 export function resolveChatLaunchIntentView(

--- a/apps/packages/product-client/src/lib/domain/chat/surface/chat-surface.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/surface/chat-surface.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  launchIntentOwnsShell,
   resolveChatSurfaceState,
   resolveLaunchIntentSurfaceOverride,
   shouldMountWorkspaceShell,
@@ -14,8 +15,11 @@ function surfaceInput(
     selectedWorkspaceId: "workspace-1",
     hasPendingWorkspaceEntry: false,
     activeLaunchIntentId: null,
+    launchIntentScope: null,
     launchIntentInFlight: false,
     launchIntentSessionId: null,
+    shellLogicalWorkspaceId: "workspace-1",
+    shellWorkspaceId: "workspace-1",
     selectedLocalWorkspace: null,
     isArrivalWorkspace: false,
     shouldShowSelectedCloudWorkspaceStatus: false,
@@ -69,28 +73,61 @@ describe("chat surface", () => {
   it("shows launch intent before session content exists", () => {
     expect(resolveLaunchIntentSurfaceOverride({
       activeLaunchIntentId: "launch-1",
+      launchIntentScope: null,
       launchIntentSessionId: "session-1",
       activeSessionId: null,
       hasVisibleSessionContent: false,
+      shellLogicalWorkspaceId: null,
+      shellWorkspaceId: null,
     })).toEqual({ kind: "launch-intent", intentId: "launch-1" });
   });
 
   it("lets launch-owned transcript content take over from launch intent", () => {
     expect(resolveLaunchIntentSurfaceOverride({
       activeLaunchIntentId: "launch-1",
+      launchIntentScope: null,
       launchIntentSessionId: "session-1",
       activeSessionId: "session-1",
       hasVisibleSessionContent: true,
+      shellLogicalWorkspaceId: null,
+      shellWorkspaceId: null,
     })).toEqual({ kind: "session-transcript", sessionId: "session-1" });
   });
 
   it("lets projected active transcript content take over before materialization", () => {
     expect(resolveLaunchIntentSurfaceOverride({
       activeLaunchIntentId: "launch-1",
+      launchIntentScope: null,
       launchIntentSessionId: null,
       activeSessionId: "previous-session",
       hasVisibleSessionContent: true,
+      shellLogicalWorkspaceId: null,
+      shellWorkspaceId: null,
     })).toEqual({ kind: "session-transcript", sessionId: "previous-session" });
+  });
+
+  it("lets an intent scoped to the shown pending shell still own it", () => {
+    expect(resolveLaunchIntentSurfaceOverride({
+      activeLaunchIntentId: "launch-1",
+      launchIntentScope: { pendingUiKey: "pending-workspace:attempt-1", workspaceId: null },
+      launchIntentSessionId: null,
+      activeSessionId: null,
+      hasVisibleSessionContent: false,
+      shellLogicalWorkspaceId: "pending-workspace:attempt-1",
+      shellWorkspaceId: null,
+    })).toEqual({ kind: "launch-intent", intentId: "launch-1" });
+  });
+
+  it("does not let an intent scoped to another attempt own this pending shell", () => {
+    expect(resolveLaunchIntentSurfaceOverride({
+      activeLaunchIntentId: "launch-1",
+      launchIntentScope: { pendingUiKey: "pending-workspace:attempt-other", workspaceId: null },
+      launchIntentSessionId: null,
+      activeSessionId: null,
+      hasVisibleSessionContent: false,
+      shellLogicalWorkspaceId: "pending-workspace:attempt-1",
+      shellWorkspaceId: null,
+    })).toBeNull();
   });
 
   it("resolves no workspace when nothing is selected or launching", () => {
@@ -116,8 +153,11 @@ describe("chat surface", () => {
       selectedWorkspaceId: null,
       hasPendingWorkspaceEntry: true,
       activeLaunchIntentId: "launch-1",
+      launchIntentScope: { pendingUiKey: "pending-workspace:attempt-1", workspaceId: null },
       launchIntentInFlight: true,
       launchIntentSessionId: "session-1",
+      shellLogicalWorkspaceId: "pending-workspace:attempt-1",
+      shellWorkspaceId: null,
       activeSessionId: "session-1",
       hasContent: false,
       isEmpty: true,
@@ -131,8 +171,11 @@ describe("chat surface", () => {
       selectedWorkspaceId: null,
       hasPendingWorkspaceEntry: true,
       activeLaunchIntentId: "launch-1",
+      launchIntentScope: { pendingUiKey: "pending-workspace:attempt-1", workspaceId: null },
       launchIntentInFlight: false,
       launchIntentSessionId: "session-1",
+      shellLogicalWorkspaceId: "pending-workspace:attempt-1",
+      shellWorkspaceId: null,
       activeSessionId: "session-1",
       hasContent: false,
       isEmpty: true,
@@ -154,7 +197,10 @@ describe("chat surface", () => {
       selectedWorkspaceId: null,
       hasPendingWorkspaceEntry: true,
       activeLaunchIntentId: "launch-1",
+      launchIntentScope: { pendingUiKey: "pending-workspace:attempt-1", workspaceId: null },
       launchIntentSessionId: "session-1",
+      shellLogicalWorkspaceId: "pending-workspace:attempt-1",
+      shellWorkspaceId: null,
       activeSessionId: "session-1",
       hasContent: true,
       isEmpty: false,
@@ -205,5 +251,118 @@ describe("chat surface", () => {
       streamConnectionState: "connecting",
       hasContent: false,
     }))).toEqual({ kind: "session-hydrating", sessionId: "session-1" });
+  });
+
+  describe("launch intent scoping (PRO-230)", () => {
+    it("does not let an intent scoped to workspace A override workspace B's shell", () => {
+      expect(resolveChatSurfaceState(surfaceInput({
+        selectedWorkspaceId: "workspace-b",
+        activeLaunchIntentId: "launch-1",
+        launchIntentScope: { pendingUiKey: null, workspaceId: "workspace-a" },
+        shellLogicalWorkspaceId: "workspace-b",
+        shellWorkspaceId: "workspace-b",
+        activeSessionId: "session-b",
+        hasContent: true,
+        isEmpty: false,
+      }))).toEqual({ kind: "session-transcript", sessionId: "session-b" });
+    });
+
+    it("does not let a failed intent scoped to workspace A override workspace B's shell", () => {
+      expect(resolveChatSurfaceState(surfaceInput({
+        selectedWorkspaceId: "workspace-b",
+        activeLaunchIntentId: "launch-1",
+        launchIntentScope: { pendingUiKey: null, workspaceId: "workspace-a" },
+        launchIntentInFlight: false,
+        shellLogicalWorkspaceId: "workspace-b",
+        shellWorkspaceId: "workspace-b",
+        activeSessionId: "session-b",
+        hasContent: true,
+        isEmpty: false,
+      }))).toEqual({ kind: "session-transcript", sessionId: "session-b" });
+    });
+
+    it("lets an unscoped intent own an empty no-workspace shell", () => {
+      expect(resolveChatSurfaceState(surfaceInput({
+        selectedWorkspaceId: null,
+        activeLaunchIntentId: "launch-1",
+        launchIntentScope: null,
+        shellLogicalWorkspaceId: null,
+        shellWorkspaceId: null,
+        activeSessionId: null,
+        hasContent: false,
+        isEmpty: true,
+      }))).toEqual({ kind: "launch-intent", intentId: "launch-1" });
+    });
+
+    it("does not let an unscoped intent override a different selected workspace's shell", () => {
+      expect(resolveChatSurfaceState(surfaceInput({
+        selectedWorkspaceId: "workspace-b",
+        activeLaunchIntentId: "launch-1",
+        launchIntentScope: null,
+        shellLogicalWorkspaceId: "workspace-b",
+        shellWorkspaceId: "workspace-b",
+        activeSessionId: "session-b",
+        hasContent: true,
+        isEmpty: false,
+      }))).toEqual({ kind: "session-transcript", sessionId: "session-b" });
+    });
+
+    it("lets an intent scoped to the shown pending shell still own it", () => {
+      expect(resolveChatSurfaceState(surfaceInput({
+        selectedWorkspaceId: null,
+        hasPendingWorkspaceEntry: true,
+        activeLaunchIntentId: "launch-1",
+        launchIntentScope: { pendingUiKey: "pending-workspace:attempt-1", workspaceId: null },
+        launchIntentInFlight: true,
+        launchIntentSessionId: null,
+        shellLogicalWorkspaceId: "pending-workspace:attempt-1",
+        shellWorkspaceId: null,
+        activeSessionId: null,
+        hasContent: false,
+        isEmpty: true,
+      }))).toEqual({ kind: "launch-intent", intentId: "launch-1" });
+    });
+  });
+
+  describe("launchIntentOwnsShell", () => {
+    it("owns an empty shell when unscoped", () => {
+      expect(launchIntentOwnsShell({
+        scope: null,
+        shellLogicalWorkspaceId: null,
+        shellWorkspaceId: null,
+      })).toBe(true);
+    });
+
+    it("does not own a selected shell when unscoped", () => {
+      expect(launchIntentOwnsShell({
+        scope: null,
+        shellLogicalWorkspaceId: "workspace-1",
+        shellWorkspaceId: "workspace-1",
+      })).toBe(false);
+    });
+
+    it("owns the shell matching its pending UI key", () => {
+      expect(launchIntentOwnsShell({
+        scope: { pendingUiKey: "pending-workspace:attempt-1", workspaceId: null },
+        shellLogicalWorkspaceId: "pending-workspace:attempt-1",
+        shellWorkspaceId: null,
+      })).toBe(true);
+    });
+
+    it("does not own an unrelated shell when scoped", () => {
+      expect(launchIntentOwnsShell({
+        scope: { pendingUiKey: null, workspaceId: "workspace-a" },
+        shellLogicalWorkspaceId: "workspace-b",
+        shellWorkspaceId: "workspace-b",
+      })).toBe(false);
+    });
+
+    it("owns the shell matching its materialized/target workspace id", () => {
+      expect(launchIntentOwnsShell({
+        scope: { pendingUiKey: null, workspaceId: "workspace-a" },
+        shellLogicalWorkspaceId: "workspace-a",
+        shellWorkspaceId: "workspace-a",
+      })).toBe(true);
+    });
   });
 });

--- a/apps/packages/product-client/src/lib/domain/chat/surface/chat-surface.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/surface/chat-surface.test.ts
@@ -322,6 +322,37 @@ describe("chat surface", () => {
         isEmpty: true,
       }))).toEqual({ kind: "launch-intent", intentId: "launch-1" });
     });
+
+    // PR #1867 review finding 1: on the success path of a new-workspace Home
+    // launch, `beginPendingWorkspace` sets the pending shell synchronously,
+    // but (pre-fix) the intent's attemptId was only scoped in the catch
+    // block, so the intent stayed unscoped for the whole in-flight window.
+    // These two cases pin the begin-time-scoped state (pane owns the pending
+    // shell) against the previously-broken unscoped state (override is null,
+    // which fell through to session-empty and caused the transcript jump).
+    it("(regression) an intent scoped to its pending attempt at begin time owns the pending shell", () => {
+      expect(resolveLaunchIntentSurfaceOverride({
+        activeLaunchIntentId: "launch-1",
+        launchIntentScope: { pendingUiKey: "pending-workspace:attempt-1", workspaceId: null },
+        launchIntentSessionId: null,
+        activeSessionId: null,
+        hasVisibleSessionContent: false,
+        shellLogicalWorkspaceId: "pending-workspace:attempt-1",
+        shellWorkspaceId: null,
+      })).toEqual({ kind: "launch-intent", intentId: "launch-1" });
+    });
+
+    it("(regression) an intent left unscoped while its pending shell already exists does not own it", () => {
+      expect(resolveLaunchIntentSurfaceOverride({
+        activeLaunchIntentId: "launch-1",
+        launchIntentScope: null,
+        launchIntentSessionId: null,
+        activeSessionId: null,
+        hasVisibleSessionContent: false,
+        shellLogicalWorkspaceId: "pending-workspace:attempt-1",
+        shellWorkspaceId: null,
+      })).toBeNull();
+    });
   });
 
   describe("launchIntentOwnsShell", () => {

--- a/apps/packages/product-client/src/lib/domain/chat/surface/chat-surface.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/surface/chat-surface.ts
@@ -1,4 +1,5 @@
 import type { Workspace } from "@anyharness/sdk";
+import type { LaunchIntentScope } from "#product/lib/domain/chat/launch/launch-intent";
 
 export type ChatSurfaceState =
   | { kind: "no-workspace" }
@@ -28,9 +29,15 @@ export interface ResolveChatSurfaceStateInput {
   selectedWorkspaceId: string | null;
   hasPendingWorkspaceEntry: boolean;
   activeLaunchIntentId: string | null;
+  /** The workspace identities the active launch intent may own, if any. */
+  launchIntentScope: LaunchIntentScope | null;
   /** True while the active launch intent is still in flight (not failed). */
   launchIntentInFlight: boolean;
   launchIntentSessionId: string | null;
+  /** The current shell's own selected logical workspace id (pending-workspace UI key or workspace id). */
+  shellLogicalWorkspaceId: string | null;
+  /** The current shell's own selected (materialized) workspace id. */
+  shellWorkspaceId: string | null;
   selectedLocalWorkspace: Workspace | null;
   isArrivalWorkspace: boolean;
   shouldShowSelectedCloudWorkspaceStatus: boolean;
@@ -58,13 +65,56 @@ export function shouldMountWorkspaceShell(args: {
   );
 }
 
+/**
+ * Whether a launch intent with the given scope may own the surface of the
+ * shell identified by `shellLogicalWorkspaceId`/`shellWorkspaceId`.
+ *
+ * A scoped intent (it has created a pending-workspace attempt, targets an
+ * existing workspace, or has materialized one) may only own the matching
+ * shell — this is what stops one workspace's launch intent from hijacking an
+ * unrelated workspace's transcript (PRO-230). An unscoped intent (nothing
+ * known yet — the Home first-paint window before anything materializes) may
+ * only own a shell that itself has no workspace selected.
+ */
+export function launchIntentOwnsShell(args: {
+  scope: LaunchIntentScope | null;
+  shellLogicalWorkspaceId: string | null;
+  shellWorkspaceId: string | null;
+}): boolean {
+  const pendingUiKey = args.scope?.pendingUiKey ?? null;
+  const workspaceId = args.scope?.workspaceId ?? null;
+
+  if (pendingUiKey === null && workspaceId === null) {
+    return args.shellLogicalWorkspaceId === null && args.shellWorkspaceId === null;
+  }
+
+  return Boolean(
+    (pendingUiKey !== null && args.shellLogicalWorkspaceId === pendingUiKey)
+    || (workspaceId !== null && (
+      args.shellWorkspaceId === workspaceId
+      || args.shellLogicalWorkspaceId === workspaceId
+    )),
+  );
+}
+
 export function resolveLaunchIntentSurfaceOverride(args: {
   activeLaunchIntentId: string | null;
+  launchIntentScope: LaunchIntentScope | null;
   launchIntentSessionId: string | null;
   activeSessionId: string | null;
   hasVisibleSessionContent: boolean;
+  shellLogicalWorkspaceId: string | null;
+  shellWorkspaceId: string | null;
 }): LaunchIntentSurfaceOverride | null {
   if (!args.activeLaunchIntentId) {
+    return null;
+  }
+
+  if (!launchIntentOwnsShell({
+    scope: args.launchIntentScope,
+    shellLogicalWorkspaceId: args.shellLogicalWorkspaceId,
+    shellWorkspaceId: args.shellWorkspaceId,
+  })) {
     return null;
   }
 
@@ -121,9 +171,12 @@ export function resolveChatSurfaceState(input: ResolveChatSurfaceStateInput): Ch
 
   const launchIntentOverride = resolveLaunchIntentSurfaceOverride({
     activeLaunchIntentId: input.activeLaunchIntentId,
+    launchIntentScope: input.launchIntentScope,
     launchIntentSessionId: input.launchIntentSessionId,
     activeSessionId: scopedActiveSessionId,
     hasVisibleSessionContent: scopedHasContent,
+    shellLogicalWorkspaceId: input.shellLogicalWorkspaceId,
+    shellWorkspaceId: input.shellWorkspaceId,
   });
   if (launchIntentOverride) {
     return launchIntentOverride;

--- a/apps/packages/product-client/src/stores/chat/chat-launch-intent-store.test.ts
+++ b/apps/packages/product-client/src/stores/chat/chat-launch-intent-store.test.ts
@@ -17,6 +17,8 @@ function intent(overrides: Partial<ChatLaunchIntent> = {}): ChatLaunchIntent {
     },
     materializedWorkspaceId: null,
     materializedSessionId: null,
+    attemptId: null,
+    targetWorkspaceId: null,
     createdAt: 100,
     sendAttemptedAt: null,
     failure: null,
@@ -95,5 +97,26 @@ describe("chat launch intent store", () => {
       .toBe("workspace-1");
     expect(useChatLaunchIntentStore.getState().activeIntent?.materializedSessionId)
       .toBe("session-1");
+  });
+
+  it("carries the pending attempt id only for the active launch intent", () => {
+    useChatLaunchIntentStore.getState().begin(intent({ id: "launch-2" }));
+
+    useChatLaunchIntentStore.getState().markMaterializedIfActive("launch-1", {
+      attemptId: "attempt-old",
+    });
+    expect(useChatLaunchIntentStore.getState().activeIntent?.attemptId).toBeNull();
+
+    useChatLaunchIntentStore.getState().markMaterializedIfActive("launch-2", {
+      attemptId: "attempt-1",
+    });
+    expect(useChatLaunchIntentStore.getState().activeIntent?.attemptId).toBe("attempt-1");
+  });
+
+  it("defaults attemptId and targetWorkspaceId to null on begin", () => {
+    useChatLaunchIntentStore.getState().begin(intent({ id: "launch-3" }));
+
+    expect(useChatLaunchIntentStore.getState().activeIntent?.attemptId).toBeNull();
+    expect(useChatLaunchIntentStore.getState().activeIntent?.targetWorkspaceId).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/stores/chat/chat-launch-intent-store.ts
+++ b/apps/packages/product-client/src/stores/chat/chat-launch-intent-store.ts
@@ -18,6 +18,7 @@ interface ChatLaunchIntentState {
       clientSessionId?: string | null;
       workspaceId?: string | null;
       sessionId?: string | null;
+      attemptId?: string | null;
     },
   ) => void;
   markSendAttemptedIfActive: (intentId: string) => void;
@@ -76,6 +77,10 @@ export const useChatLaunchIntentStore = create<ChatLaunchIntentState>((set) => (
           materialized.sessionId !== undefined
             ? materialized.sessionId
             : state.activeIntent.materializedSessionId,
+        attemptId:
+          materialized.attemptId !== undefined
+            ? materialized.attemptId
+            : state.activeIntent.attemptId,
       },
     };
   }),


### PR DESCRIPTION
Slice PR0 of the [PRO-230](https://linear.app/proliferate-team/issue/PRO-230/stitching-workspace-while-a-new-workspace-destroys-the-new-workspace) launch-registry ladder (parent: PRO-236 Workspace Transitions).

## Problem

`useChatLaunchIntentStore.activeIntent` is a global singleton and `resolveLaunchIntentSurfaceOverride` had no workspace scoping: any active or failed launch intent replaced the transcript of any session that was not the intent's own materialized session. One failed Home launch blocked every session in every workspace with the "Check this thread before retrying" pane, violating pending-shell.md Invariant 4.

## Change

- `ChatLaunchIntent` gains `attemptId` and `targetWorkspaceId`; `resolveLaunchIntentScope` derives the workspace identities an intent may own (pending UI key and/or workspace id).
- New pure gate `launchIntentOwnsShell`: a scoped intent owns only the shell matching its scope; an unscoped intent (Home first-paint window) owns only a shell with no workspace selected. Applied in `resolveLaunchIntentSurfaceOverride` and the shell-mount gate in `use-main-screen-state.ts`.
- `markMaterializedIfActive` optionally carries `attemptId`; `markHomeLaunchIntentMaterializedFromPendingWorkspace` threads it from the pending entry independent of `workspaceId` resolution, so a launch that fails before a workspace exists is still scoped.

This slice deliberately does not touch `pendingWorkspaceEntry`, `activateWorkspace`, finalization, or the sidebar; later slices make launches survive workspace switches (PR1) and allow concurrent launches (PR2/PR3).

## Tests

New "launch intent scoping (PRO-230)" cases in `chat-surface.test.ts` (scoped intent never overrides another workspace's shell; failed intent never overrides another session; unscoped intent still owns an empty shell but not a selected one; matching pending shell preserved), plus `resolveLaunchIntentScope` / store coverage. Full product-client suite green: 856 files / 5983 tests; both tsconfig typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)