### PR TITLE
fix(product): recognize, restyle, and correctly open local file references (PRO-185)

### DIFF
--- a/apps/packages/product-client/src/app/authenticated.css
+++ b/apps/packages/product-client/src/app/authenticated.css
@@ -208,7 +208,11 @@
   }
 }
 
-.group\/edit-action:is(:hover, :focus-within) [data-edit-action-row] {
+/* Unlayered, so it outranks any Tailwind text-color utility on the row. A
+   failed row must keep its destructive tint on hover/focus, so it opts out
+   through data-edit-action-failed and promotes itself with group variants. */
+.group\/edit-action:is(:hover, :focus-within)
+  [data-edit-action-row]:not([data-edit-action-failed]) {
   color: var(--color-foreground);
 }
 

--- a/apps/packages/product-client/src/app/authenticated.css
+++ b/apps/packages/product-client/src/app/authenticated.css
@@ -208,11 +208,15 @@
   }
 }
 
-[data-edit-action-row]:is(:hover, :focus-within) .activity-file-change-stat-additions {
+.group\/edit-action:is(:hover, :focus-within) [data-edit-action-row] {
+  color: var(--color-foreground);
+}
+
+.group\/edit-action:is(:hover, :focus-within) .activity-file-change-stat-additions {
   color: var(--color-git-green);
 }
 
-[data-edit-action-row]:is(:hover, :focus-within) .activity-file-change-stat-deletions {
+.group\/edit-action:is(:hover, :focus-within) .activity-file-change-stat-deletions {
   color: var(--color-git-red);
 }
 

--- a/apps/packages/product-client/src/components/content/ui/FileDiffCard.tsx
+++ b/apps/packages/product-client/src/components/content/ui/FileDiffCard.tsx
@@ -17,6 +17,7 @@ interface FileDiffCardProps {
   openActionLabel?: string;
   openActionTitle?: string;
   actions?: ReactNode;
+  actionsAtRest?: boolean;
   children?: ReactNode;
   metadata?: ReactNode;
   embedded?: boolean;
@@ -39,6 +40,7 @@ export function FileDiffCard({
   openActionLabel,
   openActionTitle,
   actions,
+  actionsAtRest = false,
   children,
   metadata,
   embedded = false,
@@ -98,7 +100,9 @@ export function FileDiffCard({
   const headerInnerClass = isSidebar
     ? "group/diff-header @container/diff-header relative flex min-h-9 items-center gap-2.5 px-[calc(var(--diff-view-header-padding-x,0.75rem)+0.5rem)] py-1.5 text-chat hover:bg-[var(--diff-view-separator-surface)]"
     : `group/diff-header @container/diff-header relative flex min-h-7 items-center gap-2 px-[var(--diff-view-header-padding-x,1rem)] py-[var(--diff-view-header-padding-y,0.25rem)] text-chat transition-colors ${chatHeaderHoverClass}`;
-  const actionRevealClass = "opacity-0 transition-opacity duration-hover group-hover/file-diff:opacity-100 group-focus-within/file-diff:opacity-100 group-hover/diff-header:opacity-100 group-focus-within/diff-header:opacity-100";
+  const actionRevealClass = actionsAtRest
+    ? "opacity-100"
+    : "opacity-0 transition-opacity duration-hover group-hover/file-diff:opacity-100 group-focus-within/file-diff:opacity-100 group-hover/diff-header:opacity-100 group-focus-within/diff-header:opacity-100";
   const statsClass = isSidebar
     ? "leading-none"
     : "text-chat leading-none text-muted-foreground";

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRowPrimitives.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRowPrimitives.tsx
@@ -99,14 +99,12 @@ export function ActionFileLink({
   displayName: string;
 }) {
   return (
-    // Keep FileReferenceBadge's semantic link color: the surrounding activity
-    // row is intentionally muted, but this child is an actionable file target.
     <FileReferenceBadge
       rawPath={pathLabel}
       label={displayName}
       workspacePath={workspacePath}
-      variant="inline"
-      className={`min-w-0 truncate !px-0 ${CHAT_BUTTON_TEXT_CLASS} !font-normal underline decoration-current decoration-dotted decoration-[0.5px] underline-offset-2 hover:decoration-dotted [&>span:first-child]:hidden`}
+      variant="plain"
+      className={`min-w-0 truncate ${CHAT_BUTTON_TEXT_CLASS}`}
     />
   );
 }

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRows.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRows.test.tsx
@@ -77,7 +77,7 @@ afterEach(() => {
 
 describe("CollapsedActionRows read rows", () => {
 
-  it("renders read ledger rows as blue, clickable file references", () => {
+  it("renders read ledger rows as row-colored, clickable file references", () => {
     const transcript = createTranscriptState("session-1");
     transcript.itemsById = {
       read: toolItem("read", "turn-1", 1, "file_read"),
@@ -92,17 +92,16 @@ describe("CollapsedActionRows read rows", () => {
     fireEvent.click(screen.getByRole("button", { name: /Read files/i }));
 
     const badge = screen.getByText("Read").parentElement
-      ?.querySelector("[data-file-reference-badge='inline']");
+      ?.querySelector("[data-file-reference-badge='plain']");
     const readRow = badge?.closest("[title]");
     expect(badge?.textContent).toContain("read.ts");
     expect(badge?.tagName).toBe("BUTTON");
     expect(badge?.getAttribute("aria-disabled")).toBeNull();
-    expect(badge?.className).toContain("text-link-foreground");
-    expect(badge?.className).toContain("hover:text-link-foreground");
-    expect(badge?.className).not.toContain("!text-inherit");
-    expect(badge?.className).not.toContain("hover:!text-inherit");
+    expect(badge?.className).toContain("text-current");
+    expect(badge?.className).toContain("hover:text-foreground");
+    expect(badge?.className).not.toContain("text-link-foreground");
     expect(badge?.className).toContain("decoration-dotted");
-    expect(badge?.className).toContain("[&>span:first-child]:hidden");
+    expect(badge?.querySelector("[aria-hidden='true']")).toBeNull();
     expect(readRow?.getAttribute("title")).toContain("read.ts");
 
     fireEvent.click(badge as Element);
@@ -127,12 +126,12 @@ describe("CollapsedActionRows read rows", () => {
     fireEvent.click(screen.getByRole("button", { name: /Read files/i }));
 
     const reference = screen.getByText("read.ts")
-      .closest("[data-file-reference-badge='inline']");
+      .closest("[data-file-reference-badge='plain']");
     expect(reference?.tagName).toBe("SPAN");
     expect(reference?.getAttribute("aria-disabled")).toBeNull();
     expect(reference?.className).not.toContain("text-link-foreground");
     expect(reference?.className).not.toContain("cursor-not-allowed");
-    expect(reference?.className).toContain("!no-underline");
+    expect(reference?.className).toContain("cursor-default");
   });
 
   it("opens raw-input fallback reads through workspace-root inference", () => {

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx
@@ -344,7 +344,7 @@ describe("CollapsedActions", () => {
     expect(html).toContain("data-collapsed-actions-ledger");
     const ledger = document.querySelector("[data-collapsed-actions-ledger]");
     expect(ledger?.textContent).toContain("Read");
-    expect(ledger?.querySelector("[data-file-reference-badge='inline']")?.textContent)
+    expect(ledger?.querySelector("[data-file-reference-badge='plain']")?.textContent)
       .toContain("read.ts");
     expect(html).toContain("overflow-y-auto overflow-x-hidden");
     expect(html).toContain("vertical-scroll-fade-mask");
@@ -436,14 +436,16 @@ describe("CollapsedActions", () => {
     expect(document.body.innerHTML).not.toContain("data-diff-surface=\"chat\"");
     const editRow = ledger?.querySelector("[data-edit-action-row]");
     const editLabel = editRow?.querySelector("[data-edit-action-file-label]");
-    expect(editRow?.textContent).not.toContain("Edit ");
+    expect(editRow?.textContent).toContain("Edited");
     const editIcon = editRow?.querySelector("svg");
     expect(editIcon?.getAttribute("viewBox")).toBe("0 0 20 21");
     expect(editIcon?.querySelector("path")?.getAttribute("d")).toContain("11.3312 4.20472");
     expect(editIcon?.parentElement?.className).toContain("icon-paired");
     expect(editIcon?.parentElement?.className).toContain("text-current");
     expect(editRow?.className).toContain("text-foreground/60");
-    expect(editLabel?.className).toContain("decoration-dotted");
+    expect(
+      editLabel?.querySelector("[data-file-reference-badge='plain']")?.className,
+    ).toContain("decoration-dotted");
     const stats = editRow?.querySelector("[data-thread-find-skip='true']");
     expect(stats?.textContent).toBe("+1-1");
     expect(stats?.querySelector("span")?.className).toContain("text-inherit");
@@ -500,7 +502,7 @@ describe("CollapsedActions", () => {
     const searchRow = screen.getByText("Searched for anchor").parentElement;
     const readRow = screen.getByText("Read").parentElement?.parentElement;
     const commandRow = screen.getByText("Ran pnpm test").parentElement;
-    expect(readRow?.querySelector("[data-file-reference-badge='inline']")?.textContent)
+    expect(readRow?.querySelector("[data-file-reference-badge='plain']")?.textContent)
       .toContain("README.md");
     const searchIcon = searchRow?.querySelector("svg");
     const readIcon = readRow?.children[0]?.querySelector("svg");

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.test.tsx
@@ -117,4 +117,24 @@ describe("CollapsedEditActionRows", () => {
     expect(openPrimaryMock).not.toHaveBeenCalled();
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
   });
+
+  it("keeps the context menu scoped to the filename", () => {
+    render(<EditRows item={editItem({ patch: true })} />);
+
+    const toggle = screen.getByRole("button", { name: "Toggle diff for edit-1.ts" });
+    fireEvent.contextMenu(toggle);
+
+    expect(screen.queryByRole("menuitem", { name: "Copy path" })).toBeNull();
+    expect(openPrimaryMock).not.toHaveBeenCalled();
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("shows a persistent copy action in the expanded diff header", () => {
+    render(<EditRows item={editItem({ patch: true })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle diff for edit-1.ts" }));
+
+    const copy = screen.getByRole("button", { name: "Copy diff for edit-1.ts" });
+    expect(copy.closest(".opacity-100")).toBeTruthy();
+  });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.test.tsx
@@ -1,5 +1,8 @@
 // @vitest-environment jsdom
 
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { PropsWithChildren, ReactElement } from "react";
 import {
   cleanup,
@@ -66,13 +69,24 @@ afterEach(() => {
   fileReferenceOpenState.pathKind = "file";
 });
 
-function editItem({ patch = false }: { patch?: boolean } = {}) {
-  const item = toolItem("edit-1", "turn-1", 1, "file_change");
+function editItem({
+  patch = false,
+  failed = false,
+}: { patch?: boolean; failed?: boolean } = {}) {
+  const item = toolItem("edit-1", "turn-1", 1, "file_change", failed ? "failed" : "completed");
   const part = item.contentParts[0];
   if (patch && part?.type === "file_change") {
     part.patch = "@@ -1 +1 @@\n-old\n+new";
   }
   return item;
+}
+
+function editRow(): HTMLElement {
+  const row = document.querySelector("[data-edit-action-row]");
+  if (!(row instanceof HTMLElement)) {
+    throw new Error("expected an edit action row");
+  }
+  return row;
 }
 
 describe("CollapsedEditActionRows", () => {
@@ -129,6 +143,40 @@ describe("CollapsedEditActionRows", () => {
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
   });
 
+  it("keeps a failed row destructive through hover and focus", () => {
+    render(<EditRows item={editItem({ failed: true })} />);
+    const row = editRow();
+
+    // The group-level promote-to-foreground rule in authenticated.css is
+    // unlayered, so it outranks any Tailwind text-color utility. A failed row
+    // opts out through this flag and promotes itself with group variants;
+    // without both halves the row loses its red tint exactly on hover/focus.
+    expect(row.getAttribute("data-edit-action-failed")).toBe("true");
+    expect(row.className).toContain("text-destructive/80");
+    expect(row.className).toContain("group-hover/edit-action:text-destructive");
+    expect(row.className).toContain("group-focus-within/edit-action:text-destructive");
+    expect(row.className).not.toContain("hover:text-foreground");
+  });
+
+  it("leaves a succeeded row promoting to foreground", () => {
+    render(<EditRows item={editItem()} />);
+    const row = editRow();
+
+    expect(row.getAttribute("data-edit-action-failed")).toBeNull();
+    expect(row.className).toContain("text-foreground/60");
+  });
+
+  it("keeps an unavailable filename from swallowing the row's diff toggle", () => {
+    fileReferenceOpenState.canOpenPrimary = false;
+    render(<EditRows item={editItem({ patch: true })} />);
+
+    const badge = document.querySelector("[data-file-reference-unavailable='true']");
+    // The row's diff toggle is an absolute overlay behind a pointer-events-none
+    // content layer. An inert filename must not re-enable pointer events, or it
+    // becomes a dead zone over the toggle.
+    expect(badge?.className).not.toContain("pointer-events-auto");
+  });
+
   it("shows a persistent copy action in the expanded diff header", () => {
     render(<EditRows item={editItem({ patch: true })} />);
 
@@ -136,5 +184,24 @@ describe("CollapsedEditActionRows", () => {
 
     const copy = screen.getByRole("button", { name: "Copy diff for edit-1.ts" });
     expect(copy.closest(".opacity-100")).toBeTruthy();
+  });
+});
+
+describe("edit-action row hover promotion CSS", () => {
+  const AUTHENTICATED_CSS = readFileSync(
+    resolve(dirname(fileURLToPath(import.meta.url)), "../../../../app/authenticated.css"),
+    "utf8",
+  );
+
+  it("excludes failed rows from the unlayered promote-to-foreground rule", () => {
+    // Unlayered CSS beats every Tailwind utility regardless of specificity, so
+    // without this :not() a failed row turns foreground-grey on hover/focus —
+    // the one moment its destructive tint matters most.
+    expect(AUTHENTICATED_CSS).toContain(
+      "[data-edit-action-row]:not([data-edit-action-failed])",
+    );
+    expect(AUTHENTICATED_CSS).not.toMatch(
+      /:is\(:hover, :focus-within\)\s+\[data-edit-action-row\]\s*\{/,
+    );
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.tsx
@@ -5,6 +5,7 @@ import type {
 } from "@anyharness/sdk";
 import { FileChangeStats } from "#product/components/content/ui/FileChangeStats";
 import { DiffViewer } from "#product/components/content/ui/DiffViewer";
+import { FileDiffCard } from "#product/components/content/ui/FileDiffCard";
 import { basename } from "#product/domain/chats/tools/collapsed-action-labels";
 import { TOOL_CALL_BODY_MAX_HEIGHT_CLASS } from "#product/domain/chats/tools/tool-call-layout";
 import { CollapsedActionIcon } from "#product/components/workspace/chat/tool-calls/CollapsedActionIcon";
@@ -13,14 +14,11 @@ import { GenericActionRow } from "#product/components/workspace/chat/tool-calls/
 import { ToolActionDetailsPanel } from "#product/components/workspace/chat/tool-calls/ToolActionDetailsPanel";
 import { resolveDiffDisplayPolicy } from "#product/lib/domain/workspaces/changes/diff-display-policy";
 import { useFileReferenceActions } from "#product/hooks/workspaces/workflows/files/use-file-reference-actions";
-import { useFileReferenceNativeContextMenu } from "#product/hooks/workspaces/ui/files/use-file-reference-native-context-menu";
-import {
-  FILE_REFERENCE_MENU_CLASS,
-  FileReferenceMenuContent,
-} from "#product/components/workspace/file-references/FileReferenceMenu";
-import { PopoverButton } from "#product/primitives/PopoverButton";
 import { Button } from "#product/primitives/Button";
 import { ArrowUpRight } from "#product/primitives/icons/core";
+import { Copy } from "#product/primitives/icons/core";
+import { FileReferenceBadge } from "#product/components/workspace/file-references/FileReferenceBadge";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 
 export function EditRows({ item }: { item: ToolCallItem }) {
   const fileChanges = item.contentParts.filter(
@@ -57,6 +55,7 @@ function EditActionRow({
   contentSearchUnitId: string;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const host = useProductHost();
   const pathLabel = part.newWorkspacePath ?? part.workspacePath ?? part.newPath ?? part.path;
   const displayName = part.newBasename ?? part.basename ?? basename(pathLabel);
   const additions = part.additions ?? 0;
@@ -65,7 +64,6 @@ function EditActionRow({
   const patch = part.patch?.trim() ? part.patch : null;
   const canExpand = Boolean(patch);
   const fileActions = useFileReferenceActions({ rawPath: pathLabel, workspacePath });
-  const nativeContextMenu = useFileReferenceNativeContextMenu(fileActions);
   const canOpenFile = fileActions.canOpenPrimary;
   const displayPolicy = patch
     ? resolveDiffDisplayPolicy({ path: pathLabel, additions, deletions, patch })
@@ -78,7 +76,6 @@ function EditActionRow({
   const row = (
     <div
       data-edit-action-row
-      onContextMenuCapture={nativeContextMenu.onContextMenuCapture}
       className={`relative flex min-w-0 max-w-full items-center text-left text-chat transition-colors ${
         failed
           ? "text-destructive/80 hover:text-destructive"
@@ -104,31 +101,16 @@ function EditActionRow({
         {failed && (
           <span className="shrink-0">{formatFailedEditActionTitle(part.operation)}</span>
         )}
-        {canOpenFile ? (
-          <Button
-            type="button"
-            variant="unstyled"
-            size="unstyled"
-            data-chat-transcript-ignore
-            data-edit-action-file-label
-            title={pathLabel}
-            onClick={(event) => {
-              event.stopPropagation();
-              void fileActions.openPrimary();
-            }}
-            className="pointer-events-auto h-auto min-w-0 max-w-full shrink justify-start truncate rounded-none bg-transparent p-0 text-left text-chat font-normal text-current underline decoration-current decoration-dotted decoration-[0.5px] underline-offset-2 hover:bg-transparent hover:text-current focus-visible:ring-1 focus-visible:ring-border"
-          >
-            {displayName}
-          </Button>
-        ) : (
-          <span
-            data-edit-action-file-label
-            title={pathLabel}
-            className="min-w-0 truncate underline decoration-current decoration-dotted decoration-[0.5px] underline-offset-2"
-          >
-            {displayName}
-          </span>
-        )}
+        {!failed && <span className="shrink-0">Edited</span>}
+        <span data-edit-action-file-label className="min-w-0 truncate">
+          <FileReferenceBadge
+            rawPath={pathLabel}
+            workspacePath={workspacePath}
+            label={displayName}
+            variant="plain"
+            className="pointer-events-auto text-chat"
+          />
+        </span>
         <FileChangeStats
           additions={additions}
           deletions={deletions}
@@ -157,17 +139,8 @@ function EditActionRow({
   );
 
   return (
-    <div className="min-w-0">
-      <PopoverButton
-        trigger={row}
-        triggerMode="contextMenu"
-        stopPropagation
-        className={FILE_REFERENCE_MENU_CLASS}
-      >
-        {(close) => (
-          <FileReferenceMenuContent actions={fileActions} close={close} />
-        )}
-      </PopoverButton>
+    <div className="group/edit-action min-w-0">
+      {row}
       {expanded && patch && (
         <ToolActionDetailsPanel
           data-diff-surface="chat"
@@ -179,14 +152,42 @@ function EditActionRow({
               <p className="mt-0.5 leading-5">{displayPolicy.placeholderDescription}</p>
             </div>
           ) : (
-            <DiffViewer
-              patch={patch}
+            <FileDiffCard
               filePath={pathLabel}
-              contentSearchUnitId={contentSearchUnitId}
-              className="w-full"
-              viewportClassName={TOOL_CALL_BODY_MAX_HEIGHT_CLASS}
-              variant="chat"
-            />
+              additions={additions}
+              deletions={deletions}
+              isExpanded
+              collapsible={false}
+              headerTone="inlineTool"
+              showOpenAction={false}
+              onOpenFile={canOpenFile ? () => void fileActions.openPrimary() : undefined}
+              actions={(
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={`Copy diff for ${pathLabel}`}
+                  title="Copy diff"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    void host.clipboard.writeText(patch);
+                  }}
+                  className="size-6 rounded-lg border-0 bg-transparent p-0 text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-1"
+                >
+                  <Copy className="icon-paired" />
+                </Button>
+              )}
+              actionsAtRest
+            >
+              <DiffViewer
+                patch={patch}
+                filePath={pathLabel}
+                contentSearchUnitId={contentSearchUnitId}
+                className="w-full"
+                viewportClassName={TOOL_CALL_BODY_MAX_HEIGHT_CLASS}
+                variant="chat"
+              />
+            </FileDiffCard>
           )}
         </ToolActionDetailsPanel>
       )}

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.tsx
@@ -15,8 +15,7 @@ import { ToolActionDetailsPanel } from "#product/components/workspace/chat/tool-
 import { resolveDiffDisplayPolicy } from "#product/lib/domain/workspaces/changes/diff-display-policy";
 import { useFileReferenceActions } from "#product/hooks/workspaces/workflows/files/use-file-reference-actions";
 import { Button } from "#product/primitives/Button";
-import { ArrowUpRight } from "#product/primitives/icons/core";
-import { Copy } from "#product/primitives/icons/core";
+import { ArrowUpRight, Copy } from "#product/primitives/icons/core";
 import { FileReferenceBadge } from "#product/components/workspace/file-references/FileReferenceBadge";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 
@@ -76,9 +75,13 @@ function EditActionRow({
   const row = (
     <div
       data-edit-action-row
+      // A failed row keeps its destructive tint through hover/focus. The
+      // group-level promote-to-foreground rule is unlayered CSS, so it would
+      // outrank any utility here; it excludes rows carrying this flag instead.
+      data-edit-action-failed={failed || undefined}
       className={`relative flex min-w-0 max-w-full items-center text-left text-chat transition-colors ${
         failed
-          ? "text-destructive/80 hover:text-destructive"
+          ? "text-destructive/80 group-hover/edit-action:text-destructive group-focus-within/edit-action:text-destructive"
           : "text-foreground/60 hover:text-foreground"
       }`}
     >
@@ -172,7 +175,7 @@ function EditActionRow({
                     event.stopPropagation();
                     void host.clipboard.writeText(patch);
                   }}
-                  className="size-6 rounded-lg border-0 bg-transparent p-0 text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-1"
+                  className="size-6 rounded-lg border-0 bg-transparent p-0 text-muted-foreground focus-visible:ring-1"
                 >
                   <Copy className="icon-paired" />
                 </Button>

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileReadCall.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileReadCall.test.tsx
@@ -1,0 +1,33 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { FileReadCall } from "#product/components/workspace/chat/tool-calls/FileReadCall";
+
+vi.mock("#product/components/workspace/file-references/FileReferenceBadge", () => ({
+  FileReferenceBadge: ({
+    label,
+    variant,
+  }: {
+    label: string;
+    variant: string;
+  }) => <button data-file-reference-badge={variant}>{label}</button>,
+}));
+
+describe("FileReadCall", () => {
+  it("keeps the read scope inside the glyph-free file reference", () => {
+    const html = renderToStaticMarkup(createElement(FileReadCall, {
+      path: "src/reader.ts",
+      workspacePath: "src/reader.ts",
+      basename: "reader.ts",
+      scope: "range",
+      startLine: 4,
+      endLine: 18,
+      status: "completed",
+    }));
+
+    expect(html).toContain("Read");
+    expect(html).toContain('data-file-reference-badge="plain"');
+    expect(html).toContain("reader.ts (lines 4–18)");
+    expect(html).not.toContain("hover:text-foreground");
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileReadCall.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileReadCall.test.tsx
@@ -1,33 +1,80 @@
-import { createElement } from "react";
-import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
+import { makeTestProductHost } from "#product/test/product-host-fixtures";
 import { FileReadCall } from "#product/components/workspace/chat/tool-calls/FileReadCall";
 
-vi.mock("#product/components/workspace/file-references/FileReferenceBadge", () => ({
-  FileReferenceBadge: ({
-    label,
-    variant,
-  }: {
-    label: string;
-    variant: string;
-  }) => <button data-file-reference-badge={variant}>{label}</button>,
+// The real FileReferenceBadge renders here on purpose: the property under test
+// is which element owns the hover promotion, and a stub badge cannot answer
+// that.
+vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", () => ({
+  useFileReferenceActions: ({ rawPath }: { rawPath: string }) => ({
+    reference: {
+      rawPath,
+      path: rawPath,
+      line: null,
+      column: null,
+      absolutePath: `/repo/${rawPath}`,
+      workspacePath: rawPath,
+    },
+    pathKind: "file",
+    pathKindPending: false,
+    canOpenPrimary: true,
+    primaryActionFailed: false,
+    primaryUnavailableReason: null,
+    openPrimary: vi.fn(),
+  }),
 }));
+
+vi.mock("#product/hooks/workspaces/ui/files/use-file-reference-native-context-menu", () => ({
+  useFileReferenceNativeContextMenu: () => ({ onContextMenuCapture: vi.fn() }),
+}));
+
+const webTestHost = makeTestProductHost({ desktop: null });
+
+afterEach(cleanup);
+
+function renderReadCall({ preview }: { preview?: string } = {}) {
+  return render(
+    <ProductHostProvider host={webTestHost}>
+      <FileReadCall
+        path="src/reader.ts"
+        workspacePath="src/reader.ts"
+        basename="reader.ts"
+        scope="range"
+        startLine={4}
+        endLine={18}
+        preview={preview}
+        status="completed"
+      />
+    </ProductHostProvider>,
+  );
+}
 
 describe("FileReadCall", () => {
   it("keeps the read scope inside the glyph-free file reference", () => {
-    const html = renderToStaticMarkup(createElement(FileReadCall, {
-      path: "src/reader.ts",
-      workspacePath: "src/reader.ts",
-      basename: "reader.ts",
-      scope: "range",
-      startLine: 4,
-      endLine: 18,
-      status: "completed",
-    }));
+    const { container } = renderReadCall();
+    const badge = container.querySelector("[data-file-reference-badge='plain']");
 
-    expect(html).toContain("Read");
-    expect(html).toContain('data-file-reference-badge="plain"');
-    expect(html).toContain("reader.ts (lines 4–18)");
-    expect(html).not.toContain("hover:text-foreground");
+    expect(container.textContent).toContain("Read");
+    expect(badge?.textContent).toBe("reader.ts (lines 4–18)");
+    // A read reference carries no leading file-type glyph; the row's own read
+    // glyph is the only one.
+    expect(badge?.querySelector("span[aria-hidden='true']")).toBeNull();
+  });
+
+  it("promotes only the filename on hover, never the whole row", () => {
+    // An expandable read row is the case that could promote its whole label:
+    // FileReadCall opts out with promoteOnHover={false} so hovering lifts the
+    // filename alone.
+    const { container } = renderReadCall({ preview: "const reader = true;" });
+    const badge = container.querySelector("[data-file-reference-badge='plain']");
+    const row = container.querySelector("[data-tool-action-row]");
+
+    expect(row?.getAttribute("aria-expanded")).toBe("false");
+    expect(badge?.className).toContain("hover:text-foreground");
+    expect(row?.className).not.toContain("hover:text-foreground");
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileReadCall.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileReadCall.tsx
@@ -3,7 +3,7 @@ import { HighlightedCodeBlock } from "#product/components/content/ui/Highlighted
 import { TOOL_CALL_BODY_MAX_HEIGHT_CLASS } from "#product/domain/chats/tools/tool-call-layout";
 import { ToolActionDetailsPanel } from "#product/components/workspace/chat/tool-calls/ToolActionDetailsPanel";
 import { ToolActionRow } from "#product/components/workspace/chat/tool-calls/ToolActionRow";
-import { ToolFileChip } from "#product/components/workspace/chat/tool-calls/ToolFileChip";
+import { FileReferenceBadge } from "#product/components/workspace/file-references/FileReferenceBadge";
 import type { FileReadScope } from "@anyharness/sdk";
 
 interface FileReadCallProps {
@@ -37,6 +37,9 @@ export function FileReadCall({
   const resolvedBasename = basename || extractBasename(path);
   const isPartialRead = scope === "line" || scope === "range";
   const scopeLabel = formatScopeLabel(scope, line, startLine, endLine);
+  const referenceLabel = scopeLabel
+    ? `${resolvedBasename} (${scopeLabel})`
+    : resolvedBasename;
   const previewPanel = preview
     ? (
       <ToolActionDetailsPanel>
@@ -57,12 +60,12 @@ export function FileReadCall({
       <span className="shrink-0 text-inherit">
         {status === "running" ? "Reading" : "Read"}
       </span>
-      <ToolFileChip
-        basename={resolvedBasename}
-        pathLabel={workspacePath || path}
+      <FileReferenceBadge
+        rawPath={workspacePath || path}
+        label={referenceLabel}
         workspacePath={workspacePath}
+        variant="plain"
       />
-      {scopeLabel && <span className="truncate text-ui-sm text-faint">{scopeLabel}</span>}
     </div>
   );
 
@@ -74,6 +77,7 @@ export function FileReadCall({
       duration={duration}
       defaultExpanded={defaultExpanded}
       expandable={!!preview}
+      promoteOnHover={false}
     >
       {previewPanel}
     </ToolActionRow>
@@ -92,7 +96,7 @@ function formatScopeLabel(
   }
   if (scope === "range") {
     if (startLine && endLine) {
-      return `lines ${startLine}-${endLine}`;
+      return `lines ${startLine}–${endLine}`;
     }
     if (startLine) {
       return `from line ${startLine}`;

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/SkillsToolResultRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/SkillsToolResultRow.tsx
@@ -2,6 +2,10 @@ import { AutoHideScrollArea } from "#product/primitives/patterns/AutoHideScrollA
 import { ProliferateIcon } from "#product/primitives/icons/proliferate-icons";
 import { MarkdownBody } from "#product/components/workspace/chat/transcript/MarkdownBody";
 import { renderDesktopCodeBlock } from "#product/components/content/ui/desktop-markdown-code-block";
+import {
+  renderTranscriptInlineCode,
+  renderTranscriptLink,
+} from "#product/components/workspace/chat/transcript/transcript-markdown";
 import { TOOL_CALL_BODY_MAX_HEIGHT_CLASS } from "#product/domain/chats/tools/tool-call-layout";
 import type { SkillsToolResultPresentation } from "#product/domain/chats/tools/skills-tool-result";
 import { ToolActionDetailsPanel } from "#product/components/workspace/chat/tool-calls/ToolActionDetailsPanel";
@@ -95,6 +99,8 @@ function SkillsToolResultDetails({
           <MarkdownBody
             content={presentation.instructions}
             className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+            renderLink={renderTranscriptLink}
+            renderInlineCode={renderTranscriptInlineCode}
             renderCodeBlock={renderDesktopCodeBlock}
           />
           {presentation.resources.length > 0 ? (
@@ -121,6 +127,8 @@ function SkillsToolResultDetails({
             <MarkdownBody
               content={presentation.content}
               className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+              renderLink={renderTranscriptLink}
+              renderInlineCode={renderTranscriptInlineCode}
               renderCodeBlock={renderDesktopCodeBlock}
             />
           ) : (

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolActionRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolActionRow.tsx
@@ -13,6 +13,8 @@ interface ToolActionRowProps {
   expanded?: boolean;
   onExpandedChange?: (next: boolean) => void;
   expandable?: boolean;
+  /** Whether hovering an expandable row promotes all of its text. */
+  promoteOnHover?: boolean;
   className?: string;
 }
 
@@ -27,6 +29,7 @@ export function ToolActionRow({
   expanded: controlledExpanded,
   onExpandedChange,
   expandable = true,
+  promoteOnHover = true,
   className = "",
 }: ToolActionRowProps) {
   const [internalExpanded, setInternalExpanded] = useState(defaultExpanded);
@@ -61,7 +64,7 @@ export function ToolActionRow({
           className={`group/tool-action-row inline-flex min-w-0 max-w-full cursor-pointer items-center gap-1 rounded-none bg-transparent p-0 text-left text-chat leading-normal font-normal outline-none focus-visible:underline ${
             status === "failed"
               ? "text-destructive/80 hover:text-destructive"
-              : "text-muted-foreground hover:text-foreground"
+              : `text-muted-foreground ${promoteOnHover ? "hover:text-foreground" : ""}`
           }`}
           onClick={() => setExpanded(!expanded)}
           onKeyDown={handleKeyDown}

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolFileChip.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolFileChip.tsx
@@ -20,8 +20,9 @@ interface ToolFileChipProps {
  *    the context menu.
  *  - An unavailable path is non-interactive text.
  *
- * Visual is intentionally a chip (border + background + file icon) so tool
- * results stay scannable; markdown prose uses the flat `FilePathLink` instead.
+ * Tool rows are the file-reference styling exception: the row's semantic icon
+ * already identifies the action, so the filename stays glyph-free and inherits
+ * the row color with an always-visible dotted underline.
  */
 export function ToolFileChip({
   basename,
@@ -34,7 +35,7 @@ export function ToolFileChip({
       basename={basename}
       label={basename}
       workspacePath={workspacePath}
-      variant="chip"
+      variant="plain"
     />
   );
 }

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/cowork/CoworkCodingToolLedger.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/cowork/CoworkCodingToolLedger.tsx
@@ -5,6 +5,10 @@ import { MessageSquare } from "#product/primitives/icons/product";
 import { Button } from "#product/primitives/Button";
 import { MarkdownBody } from "#product/components/workspace/chat/transcript/MarkdownBody";
 import { renderDesktopCodeBlock } from "#product/components/content/ui/desktop-markdown-code-block";
+import {
+  renderTranscriptInlineCode,
+  renderTranscriptLink,
+} from "#product/components/workspace/chat/transcript/transcript-markdown";
 import { ToolActionDetailsPanel } from "#product/components/workspace/chat/tool-calls/ToolActionDetailsPanel";
 import { TOOL_CALL_BODY_MAX_HEIGHT_CLASS } from "#product/domain/chats/tools/tool-call-layout";
 import type { CoworkCodingAction } from "#product/domain/chats/tools/cowork-coding-tool-presentation";
@@ -145,6 +149,8 @@ function PromptActionRow({
                 <MarkdownBody
                   content={prompt}
                   className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+                  renderLink={renderTranscriptLink}
+                  renderInlineCode={renderTranscriptInlineCode}
                   renderCodeBlock={renderDesktopCodeBlock}
                 />
               </div>

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.test.tsx
@@ -138,6 +138,22 @@ describe("MarkdownBody presentation", () => {
     expect(html).not.toContain("[the draft](");
   });
 
+  it("never repairs links on the file-content surface", () => {
+    // A file viewer renders a file's own bytes: rewriting its destinations
+    // would corrupt displayed content instead of fixing agent prose.
+    const renderLink = vi.fn(({ href }: MarkdownLinkRenderInput) => (
+      <span data-workspace-file={href}>the draft</span>
+    ));
+    renderMarkdown("Open [the draft](/Users/pablo/My Project/Final Draft.md).", {
+      renderLink,
+      surface: "file-content",
+    });
+
+    expect(renderLink).not.toHaveBeenCalledWith(expect.objectContaining({
+      href: "/Users/pablo/My%20Project/Final%20Draft.md",
+    }));
+  });
+
   it("keeps content-search marks inside the presentation DOM", () => {
     const html = renderToStaticMarkup(
       <ChatContentSearchQueryContext.Provider value="readable">

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.test.tsx
@@ -11,6 +11,10 @@ import {
   type MarkdownLinkRenderInput,
 } from "./MarkdownBody";
 import { CHAT_TRANSCRIPT_LINK_CLASS } from "#product/config/transcript-link-styles";
+import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
+import { makeTestProductHost } from "#product/test/product-host-fixtures";
+
+const markdownTestHost = makeTestProductHost({ desktop: null });
 
 const COMPLETE_MARKDOWN = `# Heading one
 
@@ -47,10 +51,11 @@ function renderMarkdown(
   content: string,
   props: Partial<Parameters<typeof MarkdownBody>[0]> = {},
 ): string {
-  return renderToStaticMarkup(createElement(MarkdownBody, {
-    content,
-    ...props,
-  }));
+  return renderToStaticMarkup(
+    <ProductHostProvider host={markdownTestHost}>
+      {createElement(MarkdownBody, { content, ...props })}
+    </ProductHostProvider>,
+  );
 }
 
 describe("MarkdownBody presentation", () => {
@@ -117,6 +122,20 @@ describe("MarkdownBody presentation", () => {
     }));
     expect(html).toContain('data-workspace-file="/tmp/project/config"');
     expect(html).not.toContain("(/tmp/project/config");
+  });
+
+  it("repairs settled local file links containing literal spaces in the render copy", () => {
+    const source = "Open [the draft](/Users/pablo/My Project/Final Draft.md).";
+    const renderLink = vi.fn(({ href }: MarkdownLinkRenderInput) => (
+      <span data-workspace-file={href}>the draft</span>
+    ));
+    const html = renderMarkdown(source, { renderLink });
+
+    expect(source).toBe("Open [the draft](/Users/pablo/My Project/Final Draft.md).");
+    expect(renderLink).toHaveBeenCalledWith(expect.objectContaining({
+      href: "/Users/pablo/My%20Project/Final%20Draft.md",
+    }));
+    expect(html).not.toContain("[the draft](");
   });
 
   it("keeps content-search marks inside the presentation DOM", () => {

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.tsx
@@ -30,6 +30,7 @@ import {
 } from "./ChatContentSearchContext";
 import { markSearchChildren } from "./MarkdownContentSearchMarks";
 import { stabilizeStreamingMarkdown } from "#product/lib/domain/chat/transcript/streaming-markdown";
+import { normalizeLocalFileLinkMarkdown } from "#product/lib/domain/chat/transcript/file-link-markdown";
 import {
   type HastNode,
   MarkdownRevealContext,
@@ -367,7 +368,9 @@ export const MarkdownBody = memo(function MarkdownBody({
   surface = "message",
 }: MarkdownBodyProps) {
   const parsedContent = useMemo(
-    () => (isStreaming ? stabilizeStreamingMarkdown(content) : content),
+    () => normalizeLocalFileLinkMarkdown(
+      isStreaming ? stabilizeStreamingMarkdown(content) : content,
+    ),
     [content, isStreaming],
   );
   const markdownClassName = [

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.tsx
@@ -1,15 +1,8 @@
 import {
-  Children,
-  cloneElement,
   createContext,
-  createElement,
-  isValidElement,
   memo,
   useContext,
   useMemo,
-  type ContextType,
-  type HTMLAttributes,
-  type ReactElement,
   type ReactNode,
 } from "react";
 import ReactMarkdown from "react-markdown";
@@ -26,16 +19,17 @@ import {
 import {
   ChatContentSearchQueryContext,
   useChatContentSearchPaint,
-  type ChatContentSearchPaint,
 } from "./ChatContentSearchContext";
-import { markSearchChildren } from "./MarkdownContentSearchMarks";
 import { stabilizeStreamingMarkdown } from "#product/lib/domain/chat/transcript/streaming-markdown";
 import { normalizeLocalFileLinkMarkdown } from "#product/lib/domain/chat/transcript/file-link-markdown";
+import { MarkdownRevealContext } from "./MarkdownRevealText";
 import {
-  type HastNode,
-  MarkdownRevealContext,
-  revealChildren,
-} from "./MarkdownRevealText";
+  LI_CLASSNAME,
+  mdHtmlElement,
+  type MdElementProps,
+  type MdTag,
+} from "./MarkdownHtmlElement";
+import { GridTaskListItem } from "./MarkdownTaskListItem";
 
 interface MarkdownBodyProps {
   content: string;
@@ -102,29 +96,6 @@ export type MarkdownCodeBlockRenderer = (
   input: MarkdownCodeBlockRenderInput,
 ) => ReactNode | null | undefined;
 
-type MdElementProps = HTMLAttributes<HTMLElement> & {
-  node?: unknown;
-};
-
-type MdTag =
-  | "blockquote"
-  | "del"
-  | "em"
-  | "h1"
-  | "h2"
-  | "h3"
-  | "h4"
-  | "h5"
-  | "h6"
-  | "li"
-  | "ol"
-  | "p"
-  | "strong"
-  | "table"
-  | "td"
-  | "th"
-  | "ul";
-
 type MdCodeProps = MdElementProps & {
   children?: ReactNode;
   className?: string;
@@ -140,7 +111,7 @@ const MarkdownCodeBlockContext = createContext(false);
 // unset, so the fallback keeps that secondary chrome on --text-chat while
 // conversation bodies grow to match the composer. Authenticated CSS owns the
 // scoped font-size and line-height so chat rules stay out of the login bundle.
-const LI_CLASSNAME = "pl-0.5";
+//
 // Prose elements (paragraphs, headings, lists, blockquotes) fill the full
 // shared 40rem thread column — the same width as wide blocks (tables, code),
 // the composer below, and the new-chat flow — so the measure does not change
@@ -271,89 +242,6 @@ function createMarkdownAnchor(renderLink: MarkdownLinkRenderer | undefined) {
   };
 }
 
-// Plan-view task-list grid: checkbox column sized auto, content column
-// minmax(0,1fr). react-markdown emits tight task items as
-// `li > input + <inline content>` (and loose ones with the input inside the
-// leading <p>), so a pure-CSS grid would scatter the inline runs across
-// cells; instead the item is restructured into checkbox + content wrapper.
-function GridTaskListItem(props: MdElementProps & { children?: ReactNode }) {
-  const { children, dangerouslySetInnerHTML, className, node: _node, ...rest } = props;
-  const isTaskListItem =
-    typeof className === "string" && className.includes("task-list-item");
-  const split = isTaskListItem && !dangerouslySetInnerHTML
-    ? splitTaskListItemChildren(children)
-    : null;
-  if (!split) {
-    return mdHtmlElement("li", LI_CLASSNAME, props);
-  }
-  const mergedClassName = [
-    LI_CLASSNAME,
-    "grid grid-cols-[auto_minmax(0,1fr)]",
-    className,
-  ].filter(Boolean).join(" ");
-  return (
-    <li {...rest} className={mergedClassName}>
-      {cloneElement(split.checkbox, {
-        // Nudge: drop the checkbox 0.25rem so it optically centers on
-        // the first text line.
-        className: [split.checkbox.props.className, "mt-1"].filter(Boolean).join(" "),
-      })}
-      <div className="min-w-0">{split.content}</div>
-    </li>
-  );
-}
-
-interface SplitTaskListItem {
-  checkbox: ReactElement<{ className?: string }>;
-  content: ReactNode[];
-}
-
-function splitTaskListItemChildren(children: ReactNode): SplitTaskListItem | null {
-  const nodes = Children.toArray(children);
-  // Tight items: the checkbox input is a direct child of the <li>.
-  const inputIndex = nodes.findIndex(isCheckboxElement);
-  if (inputIndex >= 0) {
-    return {
-      checkbox: nodes[inputIndex] as SplitTaskListItem["checkbox"],
-      content: [...nodes.slice(0, inputIndex), ...nodes.slice(inputIndex + 1)],
-    };
-  }
-  // Loose items: the checkbox sits at the head of the leading paragraph.
-  const paragraphIndex = nodes.findIndex(
-    (node) => isValidElement(node) && hastTagName(node) === "p",
-  );
-  if (paragraphIndex < 0) {
-    return null;
-  }
-  const paragraph = nodes[paragraphIndex] as ReactElement<{ children?: ReactNode }>;
-  const paragraphChildren = Children.toArray(paragraph.props.children);
-  const nestedInputIndex = paragraphChildren.findIndex(isCheckboxElement);
-  if (nestedInputIndex < 0) {
-    return null;
-  }
-  const strippedParagraph = cloneElement(paragraph, undefined, ...[
-    ...paragraphChildren.slice(0, nestedInputIndex),
-    ...paragraphChildren.slice(nestedInputIndex + 1),
-  ]);
-  return {
-    checkbox: paragraphChildren[nestedInputIndex] as SplitTaskListItem["checkbox"],
-    content: [
-      ...nodes.slice(0, paragraphIndex),
-      strippedParagraph,
-      ...nodes.slice(paragraphIndex + 1),
-    ],
-  };
-}
-
-function isCheckboxElement(node: ReactNode): boolean {
-  return isValidElement(node) && node.type === "input";
-}
-
-function hastTagName(node: ReactElement): string | null {
-  const hast = (node.props as { node?: { tagName?: unknown } }).node;
-  return typeof hast?.tagName === "string" ? hast.tagName : null;
-}
-
 export const MarkdownBody = memo(function MarkdownBody({
   content,
   className = "",
@@ -367,12 +255,13 @@ export const MarkdownBody = memo(function MarkdownBody({
   enableContentSearch = false,
   surface = "message",
 }: MarkdownBodyProps) {
-  const parsedContent = useMemo(
-    () => normalizeLocalFileLinkMarkdown(
-      isStreaming ? stabilizeStreamingMarkdown(content) : content,
-    ),
-    [content, isStreaming],
-  );
+  const parsedContent = useMemo(() => {
+    const source = isStreaming ? stabilizeStreamingMarkdown(content) : content;
+    // The local-file link repair is a *message* affordance. A file viewer
+    // renders a file's own bytes, so rewriting its destinations would corrupt
+    // displayed content rather than fix agent prose.
+    return surface === "file-content" ? source : normalizeLocalFileLinkMarkdown(source);
+  }, [content, isStreaming, surface]);
   const markdownClassName = [
     // Single measure: the thread column (config/chat-layout.ts) uses the same 48rem
     // --container-transcript-thread token as the new-chat flow, and BOTH
@@ -492,37 +381,4 @@ function markdownUrlTransform(value: string): string {
     return "";
   }
   return value;
-}
-
-// Re-export for downstream consumers that import from this module.
-
-// mdHtmlElement is called from within STATIC_MARKDOWN_COMPONENTS entries,
-// which ARE React component functions (hooks-valid call site).
-function mdHtmlElement(
-  tag: MdTag,
-  baseClassName: string,
-  props: MdElementProps,
-  revealState: ContextType<typeof MarkdownRevealContext> = null,
-  searchPaint: ChatContentSearchPaint | null = null,
-) {
-  const {
-    children,
-    dangerouslySetInnerHTML,
-    className,
-    node,
-    ...rest
-  } = props;
-  const mergedClassName = [baseClassName, className].filter(Boolean).join(" ");
-
-  if (dangerouslySetInnerHTML) {
-    return createElement(tag, {
-      ...rest,
-      className: mergedClassName,
-      dangerouslySetInnerHTML,
-    });
-  }
-  const finalChildren = searchPaint
-    ? markSearchChildren(children, searchPaint.query, searchPaint.rowUnitId)
-    : revealChildren(children, node as HastNode | undefined, revealState);
-  return createElement(tag, { ...rest, className: mergedClassName }, finalChildren);
 }

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownHtmlElement.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownHtmlElement.tsx
@@ -1,0 +1,76 @@
+import {
+  createElement,
+  type ContextType,
+  type HTMLAttributes,
+  type ReactElement,
+} from "react";
+import { markSearchChildren } from "./MarkdownContentSearchMarks";
+import type { ChatContentSearchPaint } from "./ChatContentSearchContext";
+import {
+  type HastNode,
+  MarkdownRevealContext,
+  revealChildren,
+} from "./MarkdownRevealText";
+
+export type MdElementProps = HTMLAttributes<HTMLElement> & {
+  node?: unknown;
+};
+
+export type MdTag =
+  | "blockquote"
+  | "del"
+  | "em"
+  | "h1"
+  | "h2"
+  | "h3"
+  | "h4"
+  | "h5"
+  | "h6"
+  | "li"
+  | "ol"
+  | "p"
+  | "strong"
+  | "table"
+  | "td"
+  | "th"
+  | "ul";
+
+export const LI_CLASSNAME = "pl-0.5";
+
+/**
+ * Render one markdown node as its HTML element, merging the override's base
+ * class with whatever react-markdown supplied and running the children through
+ * exactly one of the two text-decoration layers: content-search highlighting
+ * when a paint is active, otherwise streaming word reveal.
+ *
+ * Called from within the markdown component overrides, which ARE React
+ * component functions, so the hook-reading callers stay hooks-valid.
+ */
+export function mdHtmlElement(
+  tag: MdTag,
+  baseClassName: string,
+  props: MdElementProps,
+  revealState: ContextType<typeof MarkdownRevealContext> = null,
+  searchPaint: ChatContentSearchPaint | null = null,
+): ReactElement {
+  const {
+    children,
+    dangerouslySetInnerHTML,
+    className,
+    node,
+    ...rest
+  } = props;
+  const mergedClassName = [baseClassName, className].filter(Boolean).join(" ");
+
+  if (dangerouslySetInnerHTML) {
+    return createElement(tag, {
+      ...rest,
+      className: mergedClassName,
+      dangerouslySetInnerHTML,
+    });
+  }
+  const finalChildren = searchPaint
+    ? markSearchChildren(children, searchPaint.query, searchPaint.rowUnitId)
+    : revealChildren(children, node as HastNode | undefined, revealState);
+  return createElement(tag, { ...rest, className: mergedClassName }, finalChildren);
+}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownTaskListItem.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownTaskListItem.tsx
@@ -1,0 +1,97 @@
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import {
+  LI_CLASSNAME,
+  mdHtmlElement,
+  type MdElementProps,
+} from "./MarkdownHtmlElement";
+
+/**
+ * Plan-view task-list grid: checkbox column sized auto, content column
+ * minmax(0,1fr). react-markdown emits tight task items as
+ * `li > input + <inline content>` (and loose ones with the input inside the
+ * leading <p>), so a pure-CSS grid would scatter the inline runs across
+ * cells; instead the item is restructured into checkbox + content wrapper.
+ */
+export function GridTaskListItem(props: MdElementProps & { children?: ReactNode }) {
+  const { children, dangerouslySetInnerHTML, className, node: _node, ...rest } = props;
+  const isTaskListItem =
+    typeof className === "string" && className.includes("task-list-item");
+  const split = isTaskListItem && !dangerouslySetInnerHTML
+    ? splitTaskListItemChildren(children)
+    : null;
+  if (!split) {
+    return mdHtmlElement("li", LI_CLASSNAME, props);
+  }
+  const mergedClassName = [
+    LI_CLASSNAME,
+    "grid grid-cols-[auto_minmax(0,1fr)]",
+    className,
+  ].filter(Boolean).join(" ");
+  return (
+    <li {...rest} className={mergedClassName}>
+      {cloneElement(split.checkbox, {
+        // Nudge: drop the checkbox 0.25rem so it optically centers on
+        // the first text line.
+        className: [split.checkbox.props.className, "mt-1"].filter(Boolean).join(" "),
+      })}
+      <div className="min-w-0">{split.content}</div>
+    </li>
+  );
+}
+
+interface SplitTaskListItem {
+  checkbox: ReactElement<{ className?: string }>;
+  content: ReactNode[];
+}
+
+function splitTaskListItemChildren(children: ReactNode): SplitTaskListItem | null {
+  const nodes = Children.toArray(children);
+  // Tight items: the checkbox input is a direct child of the <li>.
+  const inputIndex = nodes.findIndex(isCheckboxElement);
+  if (inputIndex >= 0) {
+    return {
+      checkbox: nodes[inputIndex] as SplitTaskListItem["checkbox"],
+      content: [...nodes.slice(0, inputIndex), ...nodes.slice(inputIndex + 1)],
+    };
+  }
+  // Loose items: the checkbox sits at the head of the leading paragraph.
+  const paragraphIndex = nodes.findIndex(
+    (node) => isValidElement(node) && hastTagName(node) === "p",
+  );
+  if (paragraphIndex < 0) {
+    return null;
+  }
+  const paragraph = nodes[paragraphIndex] as ReactElement<{ children?: ReactNode }>;
+  const paragraphChildren = Children.toArray(paragraph.props.children);
+  const nestedInputIndex = paragraphChildren.findIndex(isCheckboxElement);
+  if (nestedInputIndex < 0) {
+    return null;
+  }
+  const strippedParagraph = cloneElement(paragraph, undefined, ...[
+    ...paragraphChildren.slice(0, nestedInputIndex),
+    ...paragraphChildren.slice(nestedInputIndex + 1),
+  ]);
+  return {
+    checkbox: paragraphChildren[nestedInputIndex] as SplitTaskListItem["checkbox"],
+    content: [
+      ...nodes.slice(0, paragraphIndex),
+      strippedParagraph,
+      ...nodes.slice(paragraphIndex + 1),
+    ],
+  };
+}
+
+function isCheckboxElement(node: ReactNode): boolean {
+  return isValidElement(node) && node.type === "input";
+}
+
+function hastTagName(node: ReactElement): string | null {
+  const hast = (node.props as { node?: { tagName?: unknown } }).node;
+  return typeof hast?.tagName === "string" ? hast.tagName : null;
+}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/ProviderLinkMention.interaction.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/ProviderLinkMention.interaction.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
+import { ProviderLinkMention } from "#product/components/workspace/chat/transcript/ProviderLinkMention";
+import { makeTestProductHost } from "#product/test/product-host-fixtures";
+
+describe("ProviderLinkMention interactions", () => {
+  it("opens on primary click and exposes the shared DOM context menu", () => {
+    const openExternal = vi.fn(async () => undefined);
+    const writeText = vi.fn(async () => undefined);
+    const host = makeTestProductHost({ desktop: null });
+    host.links.openExternal = openExternal;
+    host.clipboard.writeText = writeText;
+
+    render(
+      <ProductHostProvider host={host}>
+        <ProviderLinkMention href="https://example.com/docs">docs</ProviderLinkMention>
+      </ProductHostProvider>,
+    );
+
+    const link = screen.getByRole("link", { name: "docs" });
+    fireEvent.click(link);
+    expect(openExternal).toHaveBeenCalledWith("https://example.com/docs");
+
+    fireEvent.contextMenu(link);
+    expect(screen.getByRole("menu", { name: "Link actions" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy link" }));
+    expect(writeText).toHaveBeenCalledWith("https://example.com/docs");
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/ProviderLinkMention.interaction.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/ProviderLinkMention.interaction.test.tsx
@@ -1,10 +1,21 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
 import { ProviderLinkMention } from "#product/components/workspace/chat/transcript/ProviderLinkMention";
 import { makeTestProductHost } from "#product/test/product-host-fixtures";
+
+afterEach(cleanup);
+
+function renderMention(host: ReturnType<typeof makeTestProductHost>) {
+  render(
+    <ProductHostProvider host={host}>
+      <ProviderLinkMention href="https://example.com/docs">docs</ProviderLinkMention>
+    </ProductHostProvider>,
+  );
+  return screen.getByRole("link", { name: "docs" });
+}
 
 describe("ProviderLinkMention interactions", () => {
   it("opens on primary click and exposes the shared DOM context menu", () => {
@@ -28,5 +39,56 @@ describe("ProviderLinkMention interactions", () => {
     expect(screen.getByRole("menu", { name: "Link actions" })).toBeTruthy();
     fireEvent.click(screen.getByRole("menuitem", { name: "Copy link" }));
     expect(writeText).toHaveBeenCalledWith("https://example.com/docs");
+  });
+
+  it("keeps a real target/rel anchor as the native fallback", () => {
+    const link = renderMention(makeTestProductHost({ desktop: null }));
+
+    expect(link.getAttribute("href")).toBe("https://example.com/docs");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("leaves modified and non-primary clicks to the browser", () => {
+    const openExternal = vi.fn(async () => undefined);
+    const host = makeTestProductHost({ desktop: null });
+    host.links.openExternal = openExternal;
+    const link = renderMention(host);
+
+    for (const modifier of [
+      { metaKey: true },
+      { ctrlKey: true },
+      { shiftKey: true },
+      { altKey: true },
+      { button: 1 },
+    ]) {
+      const event = new MouseEvent("click", { bubbles: true, cancelable: true, ...modifier });
+      link.dispatchEvent(event);
+      // Not intercepted: the anchor's own target/rel handles the open, which
+      // is what preserves background-tab and new-window behavior.
+      expect(event.defaultPrevented).toBe(false);
+    }
+
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a noopener window open when the host opener rejects", async () => {
+    const openExternal = vi.fn(async () => {
+      throw new Error("no opener available");
+    });
+    const windowOpen = vi.fn();
+    vi.stubGlobal("open", windowOpen);
+    const host = makeTestProductHost({ desktop: null });
+    host.links.openExternal = openExternal;
+    const link = renderMention(host);
+
+    fireEvent.click(link);
+    await vi.waitFor(() => expect(windowOpen).toHaveBeenCalledWith(
+      "https://example.com/docs",
+      "_blank",
+      "noopener,noreferrer",
+    ));
+
+    vi.unstubAllGlobals();
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/ProviderLinkMention.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/ProviderLinkMention.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import {
@@ -6,6 +7,15 @@ import {
   linkHost,
   rootDomain,
 } from "./ProviderLinkMention";
+import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
+import { makeTestProductHost } from "#product/test/product-host-fixtures";
+
+const providerLinkTestHost = makeTestProductHost({ desktop: null });
+function renderProviderLink(link: ReactNode): string {
+  return renderToStaticMarkup(
+    <ProductHostProvider host={providerLinkTestHost}>{link}</ProductHostProvider>,
+  );
+}
 
 describe("rootDomain", () => {
   it("collapses subdomains to the last two labels", () => {
@@ -60,7 +70,7 @@ describe("linkHost", () => {
 
 describe("ProviderLinkMention", () => {
   it("uses the GitHub brand icon (no favicon) for github hosts", () => {
-    const html = renderToStaticMarkup(
+    const html = renderProviderLink(
       <ProviderLinkMention href="https://github.com/proliferate-ai/proliferate/pull/737">
         PR #737
       </ProviderLinkMention>,
@@ -75,7 +85,7 @@ describe("ProviderLinkMention", () => {
   });
 
   it("uses the host's own favicon for non-github hosts (no third party)", () => {
-    const html = renderToStaticMarkup(
+    const html = renderProviderLink(
       <ProviderLinkMention href="https://console.aws.amazon.com/ecs/home">
         ECS
       </ProviderLinkMention>,
@@ -86,7 +96,7 @@ describe("ProviderLinkMention", () => {
   });
 
   it("normalizes a scheme-less www host to https for the real href", () => {
-    const html = renderToStaticMarkup(
+    const html = renderProviderLink(
       <ProviderLinkMention href="www.example.com/docs">docs</ProviderLinkMention>,
     );
     expect(html).toContain("href=\"https://www.example.com/docs\"");
@@ -94,7 +104,7 @@ describe("ProviderLinkMention", () => {
   });
 
   it("falls back to a plain link for non-URL hrefs", () => {
-    const html = renderToStaticMarkup(
+    const html = renderProviderLink(
       <ProviderLinkMention href="mailto:support@proliferate.com">email</ProviderLinkMention>,
     );
     expect(html).not.toContain("data-provider-link-host");
@@ -105,7 +115,7 @@ describe("ProviderLinkMention", () => {
   });
 
   it("keeps every interaction state fill-free on the mention treatment", () => {
-    const html = renderToStaticMarkup(
+    const html = renderProviderLink(
       <ProviderLinkMention href="https://example.com/docs">docs</ProviderLinkMention>,
     );
 
@@ -114,5 +124,6 @@ describe("ProviderLinkMention", () => {
     expect(html).not.toMatch(/(?:hover|focus|focus-visible|active):bg-(?!transparent)/);
     expect(html).toContain("focus-visible:underline");
     expect(html).toContain("focus-visible:decoration-1");
+    expect(html).toContain('title="https://example.com/docs"');
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/ProviderLinkMention.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/ProviderLinkMention.tsx
@@ -63,12 +63,30 @@ function ExternalProviderLinkMention({
   const trigger = (
     <a
       href={actions.normalizedHref}
+      // Native fallback: a modified click, a middle click, or a host opener
+      // that never resolves still lands in a background tab with no referrer.
+      target="_blank"
+      rel="noopener noreferrer"
       title={actions.normalizedHref}
       data-provider-link-host={host}
       className={INLINE_MENTION_CLASS}
       onClick={(event: MouseEvent<HTMLAnchorElement>) => {
+        // Cmd/Ctrl/Shift/Alt-click and non-primary buttons are the browser's
+        // own open-in-tab/window vocabulary; routing them through the host
+        // opener would collapse every variant into one plain open.
+        if (
+          event.button !== 0
+          || event.metaKey
+          || event.ctrlKey
+          || event.shiftKey
+          || event.altKey
+        ) {
+          return;
+        }
         event.preventDefault();
-        void actions.openInBrowser();
+        void actions.openInBrowser().catch(() => {
+          window.open(actions.normalizedHref, "_blank", "noopener,noreferrer");
+        });
       }}
       onContextMenuCapture={nativeContextMenu.onContextMenuCapture}
     >

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/ProviderLinkMention.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/ProviderLinkMention.tsx
@@ -1,6 +1,10 @@
-import { useState, type ReactNode } from "react";
+import { useState, type MouseEvent, type ReactNode } from "react";
 import { GitHub } from "#product/primitives/icons/platform";
 import { CHAT_TRANSCRIPT_LINK_CLASS } from "#product/config/transcript-link-styles";
+import { PopoverButton, POPOVER_FRAME_CLASS } from "#product/primitives/PopoverButton";
+import { WebLinkMenu } from "#product/components/workspace/chat/transcript/WebLinkMenu";
+import { useWebLinkActions } from "#product/hooks/chat/workflows/use-web-link-actions";
+import { useWebLinkNativeContextMenu } from "#product/hooks/chat/ui/use-web-link-native-context-menu";
 
 /**
  * Inline "mention"-style rendering for external links in markdown bodies, with
@@ -42,18 +46,51 @@ export function ProviderLinkMention({
       </a>
     );
   }
-  const normalizedHref = href.includes("://") ? href : `https://${href}`;
-  return (
+  return <ExternalProviderLinkMention href={href} host={host}>{children}</ExternalProviderLinkMention>;
+}
+
+function ExternalProviderLinkMention({
+  href,
+  host,
+  children,
+}: {
+  href: string;
+  host: string;
+  children?: ReactNode;
+}) {
+  const actions = useWebLinkActions(href);
+  const nativeContextMenu = useWebLinkNativeContextMenu(actions);
+  const trigger = (
     <a
-      href={normalizedHref}
-      target="_blank"
-      rel="noopener noreferrer"
+      href={actions.normalizedHref}
+      title={actions.normalizedHref}
       data-provider-link-host={host}
       className={INLINE_MENTION_CLASS}
+      onClick={(event: MouseEvent<HTMLAnchorElement>) => {
+        event.preventDefault();
+        void actions.openInBrowser();
+      }}
+      onContextMenuCapture={nativeContextMenu.onContextMenuCapture}
     >
       <LinkIcon host={host} />
       <span className="min-w-0 break-words">{children}</span>
     </a>
+  );
+  return (
+    <PopoverButton
+      trigger={trigger}
+      triggerMode="contextMenu"
+      stopPropagation
+      className={`w-50 ${POPOVER_FRAME_CLASS} flex select-none flex-col p-1`}
+    >
+      {(close) => (
+        <WebLinkMenu
+          close={close}
+          onOpen={() => void actions.openInBrowser()}
+          onCopy={() => void actions.copyLink()}
+        />
+      )}
+    </PopoverButton>
   );
 }
 

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/SubagentLaunchLedger.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/SubagentLaunchLedger.tsx
@@ -1,6 +1,10 @@
 import { Button } from "#product/primitives/Button";
 import { MarkdownBody } from "#product/components/workspace/chat/transcript/MarkdownBody";
 import { renderDesktopCodeBlock } from "#product/components/content/ui/desktop-markdown-code-block";
+import {
+  renderTranscriptInlineCode,
+  renderTranscriptLink,
+} from "#product/components/workspace/chat/transcript/transcript-markdown";
 import { AutoHideScrollArea } from "#product/primitives/patterns/AutoHideScrollArea";
 import { StickyNote } from "#product/primitives/icons/product";
 import { ToolActionDetailsPanel } from "#product/components/workspace/chat/tool-calls/ToolActionDetailsPanel";
@@ -59,6 +63,8 @@ export function SubagentLaunchLedger({
                     <MarkdownBody
                       content={prompt}
                       className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+                      renderLink={renderTranscriptLink}
+                      renderInlineCode={renderTranscriptInlineCode}
                       renderCodeBlock={renderDesktopCodeBlock}
                     />
                   </div>

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
@@ -13,6 +13,10 @@ import { Button } from "#product/primitives/Button";
 import { Robot } from "#product/primitives/icons/product";
 import { MarkdownBody } from "#product/components/workspace/chat/transcript/MarkdownBody";
 import { renderDesktopCodeBlock } from "#product/components/content/ui/desktop-markdown-code-block";
+import {
+  renderTranscriptInlineCode,
+  renderTranscriptLink,
+} from "#product/components/workspace/chat/transcript/transcript-markdown";
 import { SubagentLaunchLedger } from "#product/components/workspace/chat/transcript/SubagentLaunchLedger";
 import { TurnSeparator } from "#product/components/workspace/chat/transcript/TurnSeparator";
 import {
@@ -211,6 +215,8 @@ function AgentResultBlock({ content }: { content: string }) {
           <MarkdownBody
             content={content}
             className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+            renderLink={renderTranscriptLink}
+            renderInlineCode={renderTranscriptInlineCode}
             renderCodeBlock={renderDesktopCodeBlock}
           />
         </div>

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/UserMessage.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/UserMessage.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render } from "@testing-library/react";
+import { cleanup } from "@testing-library/react";
 import type { ReactNode } from "react";
 import type { ContentPart } from "@anyharness/sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -9,6 +9,9 @@ import {
   PLAN_IMPLEMENT_HERE_ROW_LABEL,
 } from "#product/copy/plans/plan-prompts";
 import { UserMessage } from "#product/components/workspace/chat/transcript/UserMessage";
+// User prose renders external links through ProviderLinkMention, which routes
+// opening and copying through the product host, so these renders need one.
+import { renderWithProductHost as render } from "#product/test/product-host-test-utils";
 
 vi.mock("#product/components/content/ui/FilePathLink", () => ({
   FilePathLink: ({ rawPath, children }: { rawPath: string; children?: ReactNode }) => (

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/WebLinkMenu.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/WebLinkMenu.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { WebLinkMenu } from "#product/components/workspace/chat/transcript/WebLinkMenu";
+
+describe("WebLinkMenu", () => {
+  it("offers the exact web-link actions in order", () => {
+    const close = vi.fn();
+    const onOpen = vi.fn();
+    const onCopy = vi.fn();
+    render(<WebLinkMenu close={close} onOpen={onOpen} onCopy={onCopy} />);
+
+    expect(screen.getByRole("menu", { name: "Link actions" })).toBeTruthy();
+    const items = screen.getAllByRole("menuitem");
+    expect(items.map((item) => item.textContent)).toEqual([
+      "Open in Browser",
+      "Copy link",
+    ]);
+
+    fireEvent.click(items[0]!);
+    fireEvent.click(items[1]!);
+    expect(onOpen).toHaveBeenCalledOnce();
+    expect(onCopy).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/WebLinkMenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/WebLinkMenu.tsx
@@ -1,0 +1,38 @@
+import { Copy } from "#product/primitives/icons/core";
+import { Globe } from "#product/primitives/icons/platform";
+import { PopoverMenuItem } from "#product/primitives/PopoverMenuItem";
+
+export function WebLinkMenu({
+  close,
+  onOpen,
+  onCopy,
+}: {
+  close: () => void;
+  onOpen: () => void;
+  onCopy: () => void;
+}) {
+  return (
+    <div role="menu" aria-label="Link actions" className="flex flex-col gap-px">
+      <PopoverMenuItem
+        density="compact"
+        role="menuitem"
+        icon={<Globe className="icon-paired" />}
+        label="Open in Browser"
+        onClick={() => {
+          onOpen();
+          close();
+        }}
+      />
+      <PopoverMenuItem
+        density="compact"
+        role="menuitem"
+        icon={<Copy className="icon-paired" />}
+        label="Copy link"
+        onClick={() => {
+          onCopy();
+          close();
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/packages/product-client/src/components/workspace/file-references/FileReferenceBadge.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/file-references/FileReferenceBadge.test.tsx
@@ -63,6 +63,14 @@ function renderBadge(rawPath: string, basename?: string) {
   );
 }
 
+function renderPlainBadge(rawPath: string) {
+  return render(
+    <ProductHostProvider host={webTestHost}>
+      <FileReferenceBadge rawPath={rawPath} variant="plain" />
+    </ProductHostProvider>,
+  );
+}
+
 function glyphSpan(container: HTMLElement) {
   return container.querySelector("[data-file-reference-badge] span[aria-hidden='true']");
 }
@@ -157,13 +165,13 @@ describe("FileReferenceBadge interaction semantics", () => {
     expect(reference?.className).not.toContain("cursor-not-allowed");
   });
 
-  it("keeps a retry reason on an actionable reference", () => {
+  it("keeps the full destination in the actionable reference tooltip", () => {
     state.primaryUnavailableReason = "Could not resolve this path. Click to retry.";
     const { container } = renderBadge("src/App.tsx");
     const reference = container.querySelector("[data-file-reference-badge='inline']");
 
     expect(reference?.getAttribute("title"))
-      .toBe("Could not resolve this path. Click to retry.");
+      .toBe("/repo/src/App.tsx");
   });
 
   it("renders an unavailable reference as plain text instead of a disabled link", () => {
@@ -176,5 +184,17 @@ describe("FileReferenceBadge interaction semantics", () => {
     expect(reference?.className).not.toContain("text-link-foreground");
     expect(reference?.className).not.toContain("cursor-not-allowed");
     expect(reference?.className).toContain("cursor-default");
+    expect(glyphSpan(container)).toBeNull();
+  });
+
+  it("renders tool-call references without a glyph in the row color", () => {
+    const { container } = renderPlainBadge("src/App.tsx");
+    const reference = container.querySelector("[data-file-reference-badge='plain']");
+
+    expect(reference?.tagName).toBe("BUTTON");
+    expect(reference?.className).toContain("text-current");
+    expect(reference?.className).toContain("decoration-dotted");
+    expect(reference?.className).not.toContain("text-link-foreground");
+    expect(glyphSpan(container)).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/components/workspace/file-references/FileReferenceBadge.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/file-references/FileReferenceBadge.test.tsx
@@ -19,6 +19,7 @@ type MockActionsState = {
   workspacePath: string | null;
   absolutePath: string | null;
   canOpenPrimary: boolean;
+  primaryActionFailed: boolean;
   primaryUnavailableReason: string | null;
 };
 
@@ -28,6 +29,7 @@ const state: MockActionsState = {
   workspacePath: "src/App.tsx",
   absolutePath: "/repo/src/App.tsx",
   canOpenPrimary: true,
+  primaryActionFailed: false,
   primaryUnavailableReason: null,
 };
 
@@ -44,6 +46,7 @@ vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", 
     pathKind: state.pathKind,
     pathKindPending: state.pathKindPending,
     canOpenPrimary: state.canOpenPrimary,
+    primaryActionFailed: state.primaryActionFailed,
     primaryUnavailableReason: state.primaryUnavailableReason,
     openPrimary: vi.fn(),
   }),
@@ -86,6 +89,7 @@ afterEach(() => {
   state.workspacePath = "src/App.tsx";
   state.absolutePath = "/repo/src/App.tsx";
   state.canOpenPrimary = true;
+  state.primaryActionFailed = false;
   state.primaryUnavailableReason = null;
 });
 
@@ -166,12 +170,56 @@ describe("FileReferenceBadge interaction semantics", () => {
   });
 
   it("keeps the full destination in the actionable reference tooltip", () => {
-    state.primaryUnavailableReason = "Could not resolve this path. Click to retry.";
+    state.primaryUnavailableReason = "Resolve this path in the workspace.";
     const { container } = renderBadge("src/App.tsx");
     const reference = container.querySelector("[data-file-reference-badge='inline']");
 
     expect(reference?.getAttribute("title"))
       .toBe("/repo/src/App.tsx");
+  });
+
+  it("explains an unavailable reference instead of showing its destination", () => {
+    state.canOpenPrimary = false;
+    state.primaryUnavailableReason = "External files are available in the Desktop app.";
+    const { container } = renderBadge("/Users/pablo/notes/README.md");
+    const reference = container.querySelector("[data-file-reference-badge='inline']");
+
+    expect(reference?.getAttribute("title"))
+      .toBe("External files are available in the Desktop app.");
+  });
+
+  it("reports that the next activation retries after a failed one", () => {
+    // The reference stays actionable on purpose after a transient failure, so
+    // the destination tooltip would hide the only signal that clicking again
+    // does something different.
+    state.primaryActionFailed = true;
+    state.primaryUnavailableReason = "Could not resolve this path. Click to retry.";
+    const { container } = renderBadge("src/App.tsx");
+    const reference = container.querySelector("[data-file-reference-badge='inline']");
+
+    expect(reference?.tagName).toBe("BUTTON");
+    expect(reference?.getAttribute("title"))
+      .toBe("Could not resolve this path. Click to retry.");
+  });
+
+  it("drops a caller's pointer-events opt-in on an inert reference", () => {
+    // An inert reference is text over whatever the call site layered behind it
+    // (an edit row's absolute diff-toggle overlay); re-enabling pointer events
+    // would turn the filename into a dead zone.
+    state.canOpenPrimary = false;
+    const { container } = render(
+      <ProductHostProvider host={webTestHost}>
+        <FileReferenceBadge
+          rawPath="/tmp/unavailable.txt"
+          variant="plain"
+          className="pointer-events-auto text-chat"
+        />
+      </ProductHostProvider>,
+    );
+    const reference = container.querySelector("[data-file-reference-badge='plain']");
+
+    expect(reference?.className).not.toContain("pointer-events-auto");
+    expect(reference?.className).toContain("text-chat");
   });
 
   it("renders an unavailable reference as plain text instead of a disabled link", () => {

--- a/apps/packages/product-client/src/components/workspace/file-references/FileReferenceBadge.tsx
+++ b/apps/packages/product-client/src/components/workspace/file-references/FileReferenceBadge.tsx
@@ -20,7 +20,7 @@ import {
   inlineFileReferenceLabel,
 } from "#product/lib/domain/files/path-references";
 
-type FileReferenceBadgeVariant = "inline" | "chip";
+type FileReferenceBadgeVariant = "inline" | "chip" | "plain";
 
 interface FileReferenceBadgeProps {
   rawPath: string;
@@ -67,6 +67,7 @@ export function FileReferenceBadge({
   const iconShellClassName = variant === "inline"
     ? "relative mr-[3px] inline-block h-[1lh] w-3.5 shrink-0 align-bottom"
     : "inline-flex shrink-0 items-center justify-center";
+  const destinationTitle = actions.reference.absolutePath ?? actions.reference.path;
 
   const handleClick = useCallback((event: MouseEvent<HTMLButtonElement>) => {
     if (stopPropagation) {
@@ -78,9 +79,10 @@ export function FileReferenceBadge({
     void actions.openPrimary();
   }, [actions, stopPropagation]);
 
+  const showGlyph = variant !== "plain" && actions.canOpenPrimary;
   const contents = (
     <>
-      <span className={iconShellClassName}>
+      {showGlyph && <span className={iconShellClassName}>
         {useExternalInlineIcon ? (
           <span
             aria-hidden="true"
@@ -100,7 +102,7 @@ export function FileReferenceBadge({
             toneClassName={variant === "inline" ? "text-current" : "file-reference-icon"}
           />
         )}
-      </span>
+      </span>}
       <span className={variant === "inline"
         ? "min-w-0 break-words"
         : "min-w-0 truncate"}
@@ -117,7 +119,7 @@ export function FileReferenceBadge({
         data-file-reference-unavailable="true"
         data-path-kind={actions.pathKind ?? "unknown"}
         aria-busy={actions.pathKindPending || undefined}
-        title={actions.primaryUnavailableReason ?? rawPath}
+        title={destinationTitle}
         className={resolveUnavailableBadgeClassName(variant, className)}
       >
         {contents}
@@ -134,7 +136,7 @@ export function FileReferenceBadge({
       data-file-reference-badge={variant}
       data-path-kind={actions.pathKind ?? "unknown"}
       aria-busy={actions.pathKindPending || undefined}
-      title={actions.primaryUnavailableReason ?? rawPath}
+      title={destinationTitle}
       onClick={handleClick}
       onContextMenuCapture={onContextMenuCapture}
       className={resolveBadgeClassName(variant, className)}
@@ -168,6 +170,13 @@ function resolveUnavailableBadgeClassName(
     ].filter(Boolean).join(" ");
   }
 
+  if (variant === "plain") {
+    return [
+      "inline min-w-0 cursor-default truncate font-[inherit] font-normal text-inherit",
+      className,
+    ].filter(Boolean).join(" ");
+  }
+
   return [
     "group/inline-mention m-0 inline-flex cursor-default appearance-none whitespace-normal break-words border-0 bg-transparent px-0.5 py-0 text-left align-baseline font-[inherit] font-medium text-inherit shadow-none",
     className,
@@ -182,6 +191,13 @@ function resolveBadgeClassName(
   if (variant === "chip") {
     return [
       "inline-flex h-auto min-w-0 max-w-full items-center gap-px rounded-sm border border-border/60 bg-muted/45 px-1 py-px font-mono text-ui leading-none text-foreground/90 shadow-none transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border",
+      className,
+    ].filter(Boolean).join(" ");
+  }
+
+  if (variant === "plain") {
+    return [
+      "m-0 inline h-auto min-w-0 max-w-full truncate appearance-none border-0 bg-transparent p-0 text-left font-[inherit] font-normal text-current shadow-none underline decoration-current decoration-dotted decoration-[0.5px] underline-offset-2 hover:bg-transparent hover:text-foreground focus-visible:bg-transparent focus-visible:text-foreground focus-visible:outline-none focus-visible:decoration-1 active:bg-transparent",
       className,
     ].filter(Boolean).join(" ");
   }

--- a/apps/packages/product-client/src/components/workspace/file-references/FileReferenceBadge.tsx
+++ b/apps/packages/product-client/src/components/workspace/file-references/FileReferenceBadge.tsx
@@ -68,6 +68,13 @@ export function FileReferenceBadge({
     ? "relative mr-[3px] inline-block h-[1lh] w-3.5 shrink-0 align-bottom"
     : "inline-flex shrink-0 items-center justify-center";
   const destinationTitle = actions.reference.absolutePath ?? actions.reference.path;
+  // An unavailable reference, and one whose last activation failed, explain
+  // themselves — including that activating again retries. Everything else
+  // shows where the reference points.
+  const referenceTitle =
+    (!actions.canOpenPrimary || actions.primaryActionFailed)
+      ? actions.primaryUnavailableReason ?? destinationTitle
+      : destinationTitle;
 
   const handleClick = useCallback((event: MouseEvent<HTMLButtonElement>) => {
     if (stopPropagation) {
@@ -119,7 +126,7 @@ export function FileReferenceBadge({
         data-file-reference-unavailable="true"
         data-path-kind={actions.pathKind ?? "unknown"}
         aria-busy={actions.pathKindPending || undefined}
-        title={destinationTitle}
+        title={referenceTitle}
         className={resolveUnavailableBadgeClassName(variant, className)}
       >
         {contents}
@@ -136,7 +143,7 @@ export function FileReferenceBadge({
       data-file-reference-badge={variant}
       data-path-kind={actions.pathKind ?? "unknown"}
       aria-busy={actions.pathKindPending || undefined}
-      title={destinationTitle}
+      title={referenceTitle}
       onClick={handleClick}
       onContextMenuCapture={onContextMenuCapture}
       className={resolveBadgeClassName(variant, className)}
@@ -159,10 +166,25 @@ export function FileReferenceBadge({
   );
 }
 
+/**
+ * An inert reference is text, not a control: it must not capture clicks that
+ * belong to whatever sits behind it (an edit row's absolute diff-toggle
+ * overlay, for one). Call sites re-enable pointer events for the actionable
+ * badge inside a `pointer-events-none` wrapper, so that opt-in is dropped here
+ * rather than left to Tailwind's class-order-independent cascade.
+ */
+function stripPointerEventsOptIn(className: string): string {
+  return className
+    .split(/\s+/)
+    .filter((token) => token !== "" && !token.endsWith("pointer-events-auto"))
+    .join(" ");
+}
+
 function resolveUnavailableBadgeClassName(
   variant: FileReferenceBadgeVariant,
-  className: string,
+  rawClassName: string,
 ): string {
+  const className = stripPointerEventsOptIn(rawClassName);
   if (variant === "chip") {
     return [
       "inline-flex h-auto min-w-0 max-w-full cursor-default items-center gap-px rounded-sm border border-border/60 bg-muted/45 px-1 py-px font-mono text-ui leading-none text-foreground/70 shadow-none",

--- a/apps/packages/product-client/src/components/workspace/file-references/FileReferenceMenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/file-references/FileReferenceMenu.tsx
@@ -1,6 +1,7 @@
 import { FilePathContextMenuContent } from "#product/components/workspace/open-target/FilePathContextMenuContent";
 import { POPOVER_FRAME_CLASS } from "#product/primitives/PopoverButton";
 import type { useFileReferenceActions } from "#product/hooks/workspaces/workflows/files/use-file-reference-actions";
+import { fileReferenceOpenWithTargets } from "#product/lib/domain/open-targets/model";
 
 type FileReferenceActions = ReturnType<typeof useFileReferenceActions>;
 
@@ -14,7 +15,7 @@ export function FileReferenceMenuContent({
   actions: FileReferenceActions;
   close: () => void;
 }) {
-  const openTargets = filterFileReferenceOpenTargets(actions.openTargets);
+  const openTargets = fileReferenceOpenWithTargets(actions.openTargets);
 
   return (
     <FilePathContextMenuContent
@@ -33,10 +34,4 @@ export function FileReferenceMenuContent({
       ignoreChatTranscript
     />
   );
-}
-
-function filterFileReferenceOpenTargets(
-  targets: FileReferenceActions["openTargets"],
-) {
-  return targets.filter((target) => target.id !== "copy-path");
 }

--- a/apps/packages/product-client/src/components/workspace/files/viewer/FileViewerFrame.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/viewer/FileViewerFrame.tsx
@@ -148,6 +148,9 @@ function FileViewerContentContextMenu({
   return (
     <PopoverButton
       triggerMode="contextMenu"
+      // The viewer shows file content: right-click's word-select is platform
+      // behavior here, not the chrome highlight-flash the default clears.
+      preserveContextualSelection
       // C4: a fixed width tuned for this menu's longest item ("Rich
       // preview" + trailing "On"/"Off"); narrower than
       // `POPOVER_SURFACE_CLASS`'s own `min-w-[240px]` deliberately, this is

--- a/apps/packages/product-client/src/components/workspace/open-target/FilePathContextMenuContent.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/open-target/FilePathContextMenuContent.test.tsx
@@ -1,8 +1,10 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { FilePathContextMenuContent } from "#product/components/workspace/open-target/FilePathContextMenuContent";
+
+afterEach(cleanup);
 
 describe("FilePathContextMenuContent", () => {
   it("exposes an accessible file menu and keyboard-openable editor submenu", () => {
@@ -37,5 +39,35 @@ describe("FilePathContextMenuContent", () => {
     expect(screen.getByRole("menu", { name: "Open with" })).toBeTruthy();
     expect(screen.getByRole("menuitem", { name: "Cursor" })).toBeTruthy();
     expect(screen.getByRole("menuitem", { name: "Zed" })).toBeTruthy();
+  });
+
+  it("keeps the editor submenu open when the hovered item is clicked", () => {
+    render(
+      <FilePathContextMenuContent
+        pathKind="file"
+        canOpenInViewer
+        canOpenExternal
+        canReveal
+        targets={[{ id: "cursor", label: "Cursor", kind: "editor", iconId: "cursor" }]}
+        defaultTarget={{ id: "cursor", label: "Cursor", kind: "editor", iconId: "cursor" }}
+        close={vi.fn()}
+        onOpenInViewer={vi.fn()}
+        onOpenDefault={vi.fn()}
+        onOpenTarget={vi.fn()}
+        onCopyPath={vi.fn()}
+        onRevealInFinder={vi.fn()}
+      />,
+    );
+
+    const openWith = screen.getByRole("menuitem", { name: "Open with" });
+    // Hovering the wrapper is what opens the submenu, so a toggling click
+    // would close it on the user's very first click.
+    fireEvent.mouseEnter(openWith.parentElement as HTMLElement);
+    expect(openWith.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.click(openWith);
+
+    expect(openWith.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByRole("menu", { name: "Open with" })).toBeTruthy();
   });
 });

--- a/apps/packages/product-client/src/components/workspace/open-target/FilePathContextMenuContent.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/open-target/FilePathContextMenuContent.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { FilePathContextMenuContent } from "#product/components/workspace/open-target/FilePathContextMenuContent";
+
+describe("FilePathContextMenuContent", () => {
+  it("exposes an accessible file menu and keyboard-openable editor submenu", () => {
+    render(
+      <FilePathContextMenuContent
+        pathKind="file"
+        canOpenInViewer
+        canOpenExternal
+        canReveal
+        targets={[
+          { id: "cursor", label: "Cursor", kind: "editor", iconId: "cursor" },
+          { id: "zed", label: "Zed", kind: "editor", iconId: "zed" },
+        ]}
+        defaultTarget={{ id: "cursor", label: "Cursor", kind: "editor", iconId: "cursor" }}
+        close={vi.fn()}
+        onOpenInViewer={vi.fn()}
+        onOpenDefault={vi.fn()}
+        onOpenTarget={vi.fn()}
+        onCopyPath={vi.fn()}
+        onRevealInFinder={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("menu", { name: "File actions" })).toBeTruthy();
+    const openWith = screen.getByRole("menuitem", { name: "Open with" });
+    expect(openWith.getAttribute("aria-haspopup")).toBe("menu");
+    expect(openWith.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.keyDown(openWith, { key: "ArrowRight" });
+
+    expect(openWith.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByRole("menu", { name: "Open with" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Cursor" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Zed" })).toBeTruthy();
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/open-target/FilePathContextMenuContent.tsx
+++ b/apps/packages/product-client/src/components/workspace/open-target/FilePathContextMenuContent.tsx
@@ -96,7 +96,10 @@ export function FilePathContextMenuContent({
             className={openWithActive
               ? "bg-[var(--color-link-foreground)] text-white hover:bg-[var(--color-link-foreground)] focus:bg-[var(--color-link-foreground)] [&_*]:text-white"
               : ""}
-            onClick={() => setOpenWithActive((active) => !active)}
+            // Open, never toggle: the wrapper already opened the submenu on
+            // mouseenter/focus, so toggling would make the first click close
+            // what hovering just revealed.
+            onClick={() => setOpenWithActive(true)}
             onKeyDown={(event) => {
               if (event.key === "ArrowRight") {
                 event.preventDefault();
@@ -111,7 +114,7 @@ export function FilePathContextMenuContent({
             <div
               role="menu"
               aria-label="Open with"
-              className={`absolute left-full top-0 z-10 ml-1 flex max-h-[calc(100vh-1rem)] w-[172px] select-none flex-col overflow-y-auto p-1 ${POPOVER_FRAME_CLASS}`}
+              className={`absolute left-full top-0 z-10 ml-1 flex max-h-[calc(100vh-1rem)] min-w-44 select-none flex-col overflow-y-auto p-1 ${POPOVER_FRAME_CLASS}`}
               onMouseEnter={() => setOpenWithActive(true)}
             >
               {targets.map((target) => (

--- a/apps/packages/product-client/src/components/workspace/open-target/FilePathContextMenuContent.tsx
+++ b/apps/packages/product-client/src/components/workspace/open-target/FilePathContextMenuContent.tsx
@@ -4,7 +4,7 @@ import {
 import { ChevronRight, ExternalLink } from "#product/primitives/icons/core";
 import { FileText } from "#product/primitives/icons/workspace";
 import { OpenTargetIcon } from "#product/components/workspace/open-target/OpenTargetIcon";
-import { POPOVER_SURFACE_CLASS } from "#product/primitives/PopoverButton";
+import { POPOVER_FRAME_CLASS } from "#product/primitives/PopoverButton";
 import { PopoverMenuItem } from "#product/primitives/PopoverMenuItem";
 import type { OpenTarget } from "@proliferate/product-client/host/desktop-bridge";
 import type { FileReferencePathKind } from "#product/lib/domain/files/path-references";
@@ -53,13 +53,13 @@ export function FilePathContextMenuContent({
     : {};
 
   return (
-    <div className="relative flex flex-col gap-px">
+    <div role="menu" aria-label="File actions" className="relative flex flex-col gap-px">
       {pathKind !== "directory" && (
         <PopoverMenuItem
           {...FILE_PATH_MENU_ITEM_PROPS}
           {...transcriptProps}
           icon={<FileText className="icon-paired shrink-0" />}
-          label="Open in viewer"
+          label="Open in Proliferate"
           disabled={!canOpenInViewer}
           onClick={() => {
             onOpenInViewer();
@@ -90,14 +90,28 @@ export function FilePathContextMenuContent({
             {...transcriptProps}
             label="Open with"
             disabled={!canOpenExternal}
+            aria-haspopup="menu"
+            aria-expanded={openWithActive}
             trailing={<ChevronRight className="icon-paired" />}
             className={openWithActive
               ? "bg-[var(--color-link-foreground)] text-white hover:bg-[var(--color-link-foreground)] focus:bg-[var(--color-link-foreground)] [&_*]:text-white"
               : ""}
+            onClick={() => setOpenWithActive((active) => !active)}
+            onKeyDown={(event) => {
+              if (event.key === "ArrowRight") {
+                event.preventDefault();
+                setOpenWithActive(true);
+              } else if (event.key === "ArrowLeft" || event.key === "Escape") {
+                event.preventDefault();
+                setOpenWithActive(false);
+              }
+            }}
           />
           {openWithActive && (
             <div
-              className={`absolute left-full top-0 z-10 ml-1 min-w-44 ${POPOVER_SURFACE_CLASS}`}
+              role="menu"
+              aria-label="Open with"
+              className={`absolute left-full top-0 z-10 ml-1 flex max-h-[calc(100vh-1rem)] w-[172px] select-none flex-col overflow-y-auto p-1 ${POPOVER_FRAME_CLASS}`}
               onMouseEnter={() => setOpenWithActive(true)}
             >
               {targets.map((target) => (
@@ -128,16 +142,18 @@ export function FilePathContextMenuContent({
           close();
         }}
       />
-      <PopoverMenuItem
-        {...FILE_PATH_MENU_ITEM_PROPS}
-        {...transcriptProps}
-        label={pathKind === "directory" ? "Reveal folder in Finder" : "Reveal in Finder"}
-        disabled={!canReveal}
-        onClick={() => {
-          onRevealInFinder();
-          close();
-        }}
-      />
+      {defaultTarget?.kind !== "finder" && (
+        <PopoverMenuItem
+          {...FILE_PATH_MENU_ITEM_PROPS}
+          {...transcriptProps}
+          label={pathKind === "directory" ? "Reveal folder in Finder" : "Reveal in Finder"}
+          disabled={!canReveal}
+          onClick={() => {
+            onRevealInFinder();
+            close();
+          }}
+        />
+      )}
     </div>
   );
 }
@@ -150,5 +166,9 @@ function OpenMenuTargetIcon({
   if (!target?.iconId) {
     return <ExternalLink className="icon-paired shrink-0" />;
   }
-  return <OpenTargetIcon iconId={target.iconId} className="icon-paired shrink-0" variant="menu" />;
+  return (
+    <span aria-hidden="true">
+      <OpenTargetIcon iconId={target.iconId} className="icon-paired shrink-0" variant="menu" />
+    </span>
+  );
 }

--- a/apps/packages/product-client/src/config/transcript-link-styles.ts
+++ b/apps/packages/product-client/src/config/transcript-link-styles.ts
@@ -20,4 +20,4 @@
  * rectangle, and the thicker underline is the accessible indicator instead.
  */
 export const CHAT_TRANSCRIPT_LINK_CLASS =
-  "text-link-foreground no-underline hover:bg-transparent hover:text-link-foreground hover:underline hover:decoration-current hover:decoration-[0.5px] hover:underline-offset-2 focus:bg-transparent focus-visible:bg-transparent active:bg-transparent focus-visible:outline-none focus-visible:underline focus-visible:decoration-current focus-visible:decoration-1 focus-visible:underline-offset-2";
+  "cursor-pointer text-link-foreground no-underline hover:bg-transparent hover:text-link-foreground hover:underline hover:decoration-current hover:decoration-dotted hover:decoration-[0.5px] hover:underline-offset-2 focus:bg-transparent focus-visible:bg-transparent active:bg-transparent focus-visible:outline-none focus-visible:underline focus-visible:decoration-current focus-visible:decoration-dotted focus-visible:decoration-1 focus-visible:underline-offset-2";

--- a/apps/packages/product-client/src/hooks/chat/ui/use-web-link-native-context-menu.test.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-web-link-native-context-menu.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildWebLinkNativeContextMenuItems } from "#product/hooks/chat/ui/use-web-link-native-context-menu";
+
+describe("buildWebLinkNativeContextMenuItems", () => {
+  it("keeps the web-link menu concise and ordered", () => {
+    const openInBrowser = vi.fn();
+    const copyLink = vi.fn();
+    const items = buildWebLinkNativeContextMenuItems({ openInBrowser, copyLink });
+
+    expect(items).toMatchObject([
+      { id: "open-in-browser", label: "Open in Browser" },
+      { id: "copy-link", label: "Copy link" },
+    ]);
+    items[0]?.onSelect?.();
+    items[1]?.onSelect?.();
+    expect(openInBrowser).toHaveBeenCalledOnce();
+    expect(copyLink).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/packages/product-client/src/hooks/chat/ui/use-web-link-native-context-menu.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-web-link-native-context-menu.ts
@@ -1,0 +1,27 @@
+import { useNativeContextMenu } from "#product/hooks/ui/native/use-native-context-menu";
+
+interface WebLinkMenuActions {
+  openInBrowser: () => void;
+  copyLink: () => void;
+}
+
+export function useWebLinkNativeContextMenu(actions: WebLinkMenuActions) {
+  return useNativeContextMenu(() => buildWebLinkNativeContextMenuItems(actions));
+}
+
+export function buildWebLinkNativeContextMenuItems(actions: WebLinkMenuActions) {
+  return [
+    {
+      id: "open-in-browser",
+      label: "Open in Browser",
+      icon: { kind: "native" as const, name: "open" as const },
+      onSelect: actions.openInBrowser,
+    },
+    {
+      id: "copy-link",
+      label: "Copy link",
+      icon: { kind: "native" as const, name: "copy" as const },
+      onSelect: actions.copyLink,
+    },
+  ];
+}

--- a/apps/packages/product-client/src/hooks/chat/workflows/use-web-link-actions.test.ts
+++ b/apps/packages/product-client/src/hooks/chat/workflows/use-web-link-actions.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useWebLinkActions } from "#product/hooks/chat/workflows/use-web-link-actions";
+
+const host = vi.hoisted(() => ({
+  openExternal: vi.fn(async () => undefined),
+  writeText: vi.fn(async () => undefined),
+}));
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => ({
+    links: { openExternal: host.openExternal },
+    clipboard: { writeText: host.writeText },
+  }),
+}));
+
+describe("useWebLinkActions", () => {
+  it("normalizes once and routes open and copy through the host", async () => {
+    const { result } = renderHook(() => useWebLinkActions("www.example.com/docs"));
+
+    expect(result.current.normalizedHref).toBe("https://www.example.com/docs");
+    await act(async () => {
+      await result.current.openInBrowser();
+      await result.current.copyLink();
+    });
+
+    expect(host.openExternal).toHaveBeenCalledWith("https://www.example.com/docs");
+    expect(host.writeText).toHaveBeenCalledWith("https://www.example.com/docs");
+  });
+});

--- a/apps/packages/product-client/src/hooks/chat/workflows/use-web-link-actions.ts
+++ b/apps/packages/product-client/src/hooks/chat/workflows/use-web-link-actions.ts
@@ -1,0 +1,18 @@
+import { useCallback, useMemo } from "react";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
+
+export function useWebLinkActions(href: string) {
+  const host = useProductHost();
+  const normalizedHref = useMemo(
+    () => href.includes("://") ? href : `https://${href}`,
+    [href],
+  );
+  const openInBrowser = useCallback(async () => {
+    await host.links.openExternal(normalizedHref);
+  }, [host.links, normalizedHref]);
+  const copyLink = useCallback(async () => {
+    await host.clipboard.writeText(normalizedHref);
+  }, [host.clipboard, normalizedHref]);
+
+  return { normalizedHref, openInBrowser, copyLink };
+}

--- a/apps/packages/product-client/src/hooks/ui/native/use-native-context-menu.ts
+++ b/apps/packages/product-client/src/hooks/ui/native/use-native-context-menu.ts
@@ -4,6 +4,7 @@ import type {
   NativeMenuItem,
 } from "@proliferate/product-client/host/desktop-bridge";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
+import { clearContextualWordSelection } from "#product/lib/infra/dom/contextual-word-selection";
 
 /**
  * Attach the host-provided native context menu to an element. Returns a
@@ -17,8 +18,17 @@ import { useProductHost } from "@proliferate/product-client/host/ProductHostProv
  *
  * `buildItems` runs only when the menu is actually opened, so transient data
  * (e.g. which tab was right-clicked) can be captured via closure.
+ *
+ * Opening the menu also drops the word selection WebKit makes under the
+ * pointer right before dispatching `contextmenu` (a highlight flash under the
+ * menu otherwise). A menu over genuinely selectable content — the file
+ * viewer's content area — opts out with `preserveContextualSelection`, keeping
+ * the platform's TextEdit-style select-word-then-menu behavior there.
  */
-export function useNativeContextMenu(buildItems: () => NativeMenuItem[]) {
+export function useNativeContextMenu(
+  buildItems: () => NativeMenuItem[],
+  { preserveContextualSelection = false }: { preserveContextualSelection?: boolean } = {},
+) {
   const { buildRef, disabledRef, nativeUi, showNativeMenu } = useNativeMenuController(buildItems);
 
   const onContextMenuCapture = useCallback((event: MouseEvent) => {
@@ -35,12 +45,15 @@ export function useNativeContextMenu(buildItems: () => NativeMenuItem[]) {
     const fallbackEvent = event.nativeEvent;
     event.preventDefault();
     event.stopPropagation();
+    if (!preserveContextualSelection) {
+      clearContextualWordSelection(event.currentTarget);
+    }
     void showNativeMenu(undefined, items).then((shown) => {
       if (!shown) {
         dispatchFallbackContextMenu(fallbackTarget, fallbackEvent);
       }
     });
-  }, [buildRef, disabledRef, nativeUi, showNativeMenu]);
+  }, [buildRef, disabledRef, nativeUi, preserveContextualSelection, showNativeMenu]);
 
   return { onContextMenuCapture, showNativeMenu };
 }

--- a/apps/packages/product-client/src/hooks/workspaces/ui/files/use-file-reference-native-context-menu.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/files/use-file-reference-native-context-menu.test.ts
@@ -33,7 +33,7 @@ describe("buildFileReferenceNativeContextMenuItems", () => {
     expect(items).toMatchObject([
       {
         id: "open-viewer",
-        label: "Open in viewer",
+        label: "Open in Proliferate",
         enabled: true,
       },
       {
@@ -58,11 +58,6 @@ describe("buildFileReferenceNativeContextMenuItems", () => {
             label: "Zed",
             icon: { kind: "resource", path: "app-icons/zed.png" },
           },
-          {
-            id: "open-with:terminal",
-            label: "Terminal",
-            icon: { kind: "resource", path: "app-icons/terminal.png" },
-          },
         ],
       },
       { kind: "separator" },
@@ -81,9 +76,9 @@ describe("buildFileReferenceNativeContextMenuItems", () => {
     const submenu = items[2];
     if ("kind" in submenu && submenu.kind === "submenu") {
       const firstChild = submenu.items[0];
-      const thirdChild = submenu.items[2];
+      const secondChild = submenu.items[1];
       if ("id" in firstChild) firstChild.onSelect?.();
-      if ("id" in thirdChild) thirdChild.onSelect?.();
+      if ("id" in secondChild) secondChild.onSelect?.();
     }
     if ("id" in items[4]) items[4].onSelect?.();
     if ("id" in items[5]) items[5].onSelect?.();
@@ -91,9 +86,40 @@ describe("buildFileReferenceNativeContextMenuItems", () => {
     expect(onOpenInSidebar).toHaveBeenCalledTimes(1);
     expect(onOpenDefault).toHaveBeenCalledTimes(1);
     expect(onOpenTarget).toHaveBeenNthCalledWith(1, "cursor");
-    expect(onOpenTarget).toHaveBeenNthCalledWith(2, "terminal");
+    expect(onOpenTarget).toHaveBeenNthCalledWith(2, "zed");
     expect(onCopyPath).toHaveBeenCalledTimes(1);
     expect(onReveal).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps only editors in Open with and hides Reveal when Finder is the default", () => {
+    const finder: OpenTarget = { id: "finder", label: "Finder", kind: "finder", iconId: "finder" };
+    const cursor: OpenTarget = { id: "cursor", label: "Cursor", kind: "editor", iconId: "cursor" };
+    const terminal: OpenTarget = {
+      id: "terminal",
+      label: "Terminal",
+      kind: "terminal",
+      iconId: "terminal",
+    };
+    const items = buildFileReferenceNativeContextMenuItems({
+      openTargets: [finder, cursor, terminal],
+      defaultOpenTarget: finder,
+      pathKind: "file",
+      canOpenInSidebar: true,
+      canOpenExternal: true,
+      canReveal: true,
+      copyPath: vi.fn(),
+      openInSidebar: vi.fn(),
+      openDefault: vi.fn(),
+      openWithTarget: vi.fn(),
+      reveal: vi.fn(),
+    });
+
+    expect(items).not.toContainEqual(expect.objectContaining({ id: "reveal-in-finder" }));
+    const submenu = items.find((item) => "kind" in item && item.kind === "submenu");
+    expect(submenu).toMatchObject({
+      kind: "submenu",
+      items: [{ id: "open-with:cursor" }],
+    });
   });
 
   it("omits the viewer action for folders and keeps Finder capability explicit", () => {

--- a/apps/packages/product-client/src/hooks/workspaces/ui/files/use-file-reference-native-context-menu.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/files/use-file-reference-native-context-menu.ts
@@ -6,6 +6,7 @@ import type {
   OpenTarget,
 } from "@proliferate/product-client/host/desktop-bridge";
 import type { FileReferencePathKind } from "#product/lib/domain/files/path-references";
+import { fileReferenceOpenWithTargets } from "#product/lib/domain/open-targets/model";
 
 interface FileReferenceNativeContextMenuActions {
   openTargets: OpenTarget[];
@@ -42,13 +43,13 @@ export function buildFileReferenceNativeContextMenuItems({
   openWithTarget,
   reveal,
 }: FileReferenceNativeContextMenuActions): NativeMenuItem[] {
-  const targets = filterFileReferenceOpenTargets(openTargets);
+  const targets = fileReferenceOpenWithTargets(openTargets);
   const items: NativeMenuItem[] = [];
 
   if (pathKind !== "directory") {
     items.push({
       id: "open-viewer",
-      label: "Open in viewer",
+      label: "Open in Proliferate",
       enabled: canOpenInSidebar,
       icon: { kind: "native", name: "document" },
       onSelect: openInSidebar,
@@ -86,19 +87,17 @@ export function buildFileReferenceNativeContextMenuItems({
       label: "Copy path",
       onSelect: copyPath,
     },
-    {
+  );
+  if (defaultOpenTarget?.kind !== "finder") {
+    items.push({
       id: "reveal-in-finder",
       label: pathKind === "directory" ? "Reveal folder in Finder" : "Reveal in Finder",
       enabled: canReveal,
       onSelect: reveal,
-    },
-  );
+    });
+  }
 
   return items;
-}
-
-function filterFileReferenceOpenTargets(targets: readonly OpenTarget[]): OpenTarget[] {
-  return targets.filter((target) => target.id !== "copy-path");
 }
 
 function nativeMenuIconForOpenTarget(

--- a/apps/packages/product-client/src/hooks/workspaces/ui/files/use-file-viewer-native-menu.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/files/use-file-viewer-native-menu.ts
@@ -61,7 +61,14 @@ export function useFileViewerNativeMenu(actions: FileViewerNativeMenuActions) {
   return useNativeMenu(() => buildFileViewerNativeMenuItems(actions));
 }
 
-/** Right-click variant for the viewer content area. */
+/**
+ * Right-click variant for the viewer content area. The viewer shows file
+ * content, so WebKit's select-word-under-pointer on right-click is platform
+ * behavior worth keeping — not the highlight-flash bug it is on chrome.
+ */
 export function useFileViewerNativeContextMenu(actions: FileViewerNativeMenuActions) {
-  return useNativeContextMenu(() => buildFileViewerNativeMenuItems(actions));
+  return useNativeContextMenu(
+    () => buildFileViewerNativeMenuItems(actions),
+    { preserveContextualSelection: true },
+  );
 }

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.ts
@@ -126,6 +126,10 @@ export function useFileReferenceActions({
   const canOpenPrimary = resolvedPrimaryAction !== "unavailable"
     || (pathKind === null && canResolvePathKind);
   const pathKindPending = externalPathKindPending || statQuery.isFetching;
+  // A resolution or launch failure leaves the reference actionable on purpose:
+  // the next activation retries it. Surfaces report that instead of the plain
+  // destination so the retry affordance is discoverable.
+  const primaryActionFailed = pathResolutionFailed || primaryOpenFailed;
   const primaryUnavailableReason = pathKindPending
     ? "Checking whether this path is a file or folder…"
     : primaryOpenFailed
@@ -335,6 +339,7 @@ export function useFileReferenceActions({
     canOpenExternal,
     canOpenPrimary,
     canReveal,
+    primaryActionFailed,
     primaryUnavailableReason,
     copyPath,
     openInSidebar,

--- a/apps/packages/product-client/src/lib/domain/chat/assistant-markdown-end-resource.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/assistant-markdown-end-resource.test.ts
@@ -26,6 +26,29 @@ describe("resolveAssistantMarkdownEndResource", () => {
     ].join("\n"))).toBeNull();
   });
 
+  it("resolves a destination whose literal spaces were never encoded", () => {
+    // The card reads the rendered copy, not the raw source: on the raw text a
+    // space-bearing destination is not a link at all, so the exact case the
+    // link repair exists for would otherwise never produce a card.
+    expect(resolveAssistantMarkdownEndResource(
+      "The write-up is [the decision doc](/repo/specs/Final Decision.md).",
+    )).toEqual({
+      rawPath: "/repo/specs/Final Decision.md",
+      path: "/repo/specs/Final Decision.md",
+      displayName: "Final Decision.md",
+      typeLabel: "Document · MD",
+    });
+  });
+
+  it("decodes only encoded spaces, never encoded separators", () => {
+    expect(resolveAssistantMarkdownEndResource("[odd](/repo/a%2Fb.md)")).toEqual({
+      rawPath: "/repo/a%2Fb.md",
+      path: "/repo/a%2Fb.md",
+      displayName: "a%2Fb.md",
+      typeLabel: "Document · MD",
+    });
+  });
+
   it("supports MDX references and returns null for non-document files", () => {
     expect(resolveAssistantMarkdownEndResource("[guide](docs/guide.mdx)")?.displayName)
       .toBe("guide.mdx");

--- a/apps/packages/product-client/src/lib/domain/chat/assistant-markdown-end-resource.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/assistant-markdown-end-resource.ts
@@ -2,6 +2,8 @@ import {
   looksLikeFileReferenceHref,
   splitPathLineSuffix,
 } from "#product/lib/domain/files/path-detection";
+import { decodeEncodedSpaces } from "#product/lib/domain/files/path-references";
+import { normalizeLocalFileLinkMarkdown } from "#product/lib/domain/chat/transcript/file-link-markdown";
 
 export interface AssistantMarkdownEndResource {
   rawPath: string;
@@ -22,7 +24,11 @@ export function resolveAssistantMarkdownEndResource(
 ): AssistantMarkdownEndResource | null {
   if (!markdown) return null;
 
-  const visibleMarkdown = stripMarkdownCode(markdown);
+  // Read the same copy the transcript renders. On the raw source a
+  // space-bearing destination is not a link at all, so the exact `.md`
+  // references this card exists for would never produce one. The repair is
+  // pure and idempotent, so running it here costs nothing else.
+  const visibleMarkdown = stripMarkdownCode(normalizeLocalFileLinkMarkdown(markdown));
   const seen = new Set<string>();
   let resolved: AssistantMarkdownEndResource | null = null;
 
@@ -66,13 +72,9 @@ function stripQueryAndFragment(value: string): string {
   return suffixIndex >= 0 ? value.slice(0, suffixIndex) : value;
 }
 
-function safelyDecodePath(value: string): string {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
-  }
-}
+// Match the file resolver exactly: only the repair's own `%20` is decoded, so
+// a literal `a%2Fb.md` stays one name instead of becoming a nested path.
+const safelyDecodePath = decodeEncodedSpaces;
 
 function basename(path: string): string {
   return path.split(/[\\/]/).filter(Boolean).pop() ?? path;

--- a/apps/packages/product-client/src/lib/domain/chat/transcript/file-link-markdown.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/transcript/file-link-markdown.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { normalizeLocalFileLinkMarkdown } from "#product/lib/domain/chat/transcript/file-link-markdown";
+
+describe("normalizeLocalFileLinkMarkdown", () => {
+  it("repairs explicit local file links containing literal spaces", () => {
+    expect(normalizeLocalFileLinkMarkdown(
+      "Open [the draft](/Users/pablo/My Project/Final Draft.md).",
+    )).toBe(
+      "Open [the draft](</Users/pablo/My%20Project/Final%20Draft.md>).",
+    );
+  });
+
+  it("does not rewrite images, web links, or ordinary prose", () => {
+    const source = [
+      "![preview](/Users/pablo/My Image.png)",
+      "[search](https://example.com/a b)",
+      "Plain text (with spaces)",
+    ].join("\n");
+    expect(normalizeLocalFileLinkMarkdown(source)).toBe(source);
+  });
+
+  it("preserves already encoded and angle-wrapped local destinations", () => {
+    const source = [
+      "[encoded](/Users/pablo/My%20Project/README.md)",
+      "[wrapped](</Users/pablo/My Project/README.md>)",
+    ].join("\n");
+
+    expect(normalizeLocalFileLinkMarkdown(source)).toBe(source);
+  });
+
+  it("preserves inline and fenced code examples", () => {
+    const source = [
+      "`[inline](/Users/pablo/My Project/README.md)`",
+      "```md",
+      "[fenced](/Users/pablo/My Project/README.md)",
+      "```",
+      "~~~md",
+      "[tilde fenced](/Users/pablo/My Project/README.md)",
+      "~~~",
+    ].join("\n");
+
+    expect(normalizeLocalFileLinkMarkdown(source)).toBe(source);
+  });
+
+  it("repairs local destinations containing balanced parentheses", () => {
+    expect(normalizeLocalFileLinkMarkdown(
+      "Open [copy](/Users/pablo/My Project/Final (copy).md).",
+    )).toBe(
+      "Open [copy](</Users/pablo/My%20Project/Final%20(copy).md>).",
+    );
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/chat/transcript/file-link-markdown.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/transcript/file-link-markdown.test.ts
@@ -49,4 +49,88 @@ describe("normalizeLocalFileLinkMarkdown", () => {
       "Open [copy](</Users/pablo/My%20Project/Final%20(copy).md>).",
     );
   });
+
+  it("keeps a link title outside the repaired destination", () => {
+    expect(normalizeLocalFileLinkMarkdown(
+      "See [guide](/repo/My Docs/guide.md \"Read the guide\").",
+    )).toBe(
+      "See [guide](</repo/My%20Docs/guide.md> \"Read the guide\").",
+    );
+    expect(normalizeLocalFileLinkMarkdown(
+      "See [guide](/repo/My Docs/guide.md 'Read the guide').",
+    )).toBe(
+      "See [guide](</repo/My%20Docs/guide.md> 'Read the guide').",
+    );
+    expect(normalizeLocalFileLinkMarkdown(
+      "See [guide](/repo/My Docs/guide.md (Read the guide)).",
+    )).toBe(
+      "See [guide](</repo/My%20Docs/guide.md> (Read the guide)).",
+    );
+  });
+
+  it("leaves a titled link whose destination has no spaces untouched", () => {
+    const source = "See [guide](/repo/docs/guide.md \"Read the guide\").";
+    expect(normalizeLocalFileLinkMarkdown(source)).toBe(source);
+  });
+
+  it("treats a malformed trailing title as part of the destination", () => {
+    expect(normalizeLocalFileLinkMarkdown(
+      "See [guide](/repo/My Docs/guide.md \"unclosed).",
+    )).toBe(
+      "See [guide](</repo/My%20Docs/guide.md%20\"unclosed>).",
+    );
+  });
+
+  it("repairs nested list items indented under a list line", () => {
+    // The PRO-161 core case is a list of file links; a 4-space-indented list
+    // continuation is not indented code, so it must still be repaired.
+    expect(normalizeLocalFileLinkMarkdown([
+      "- Docs:",
+      "    - [guide](/repo/My Docs/guide.md)",
+    ].join("\n"))).toBe([
+      "- Docs:",
+      "    - [guide](</repo/My%20Docs/guide.md>)",
+    ].join("\n"));
+  });
+
+  it("preserves indented code blocks introduced by a blank line", () => {
+    const source = [
+      "Example:",
+      "",
+      "    [guide](/repo/My Docs/guide.md)",
+      "    [other](/repo/My Docs/other.md)",
+      "",
+      "Done.",
+    ].join("\n");
+
+    expect(normalizeLocalFileLinkMarkdown(source)).toBe(source);
+  });
+
+  it("does not let an info-string line close a fenced block", () => {
+    const source = [
+      "```",
+      "[fenced](/Users/pablo/My Project/README.md)",
+      "```md",
+      "[still fenced](/Users/pablo/My Project/README.md)",
+      "```",
+    ].join("\n");
+
+    expect(normalizeLocalFileLinkMarkdown(source)).toBe(source);
+  });
+
+  it("treats an escaped bracket as literal text but still repairs a real link", () => {
+    const escaped = "\\[label](/Users/pablo/My Project/README.md)";
+    expect(normalizeLocalFileLinkMarkdown(escaped)).toBe(escaped);
+
+    expect(normalizeLocalFileLinkMarkdown(
+      "\\\\[label](/Users/pablo/My Project/README.md)",
+    )).toBe(
+      "\\\\[label](</Users/pablo/My%20Project/README.md>)",
+    );
+  });
+
+  it("leaves destinations containing angle brackets untouched", () => {
+    const source = "[weird](/Users/pablo/My <Project>/README.md)";
+    expect(normalizeLocalFileLinkMarkdown(source)).toBe(source);
+  });
 });

--- a/apps/packages/product-client/src/lib/domain/chat/transcript/file-link-markdown.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/transcript/file-link-markdown.ts
@@ -1,0 +1,136 @@
+/**
+ * CommonMark requires destinations containing spaces to be wrapped in angle
+ * brackets or percent-encoded. Agent output is not always that careful. Keep
+ * the stored transcript untouched and repair only explicit local-file links in
+ * the render copy so `[label](/absolute/path with spaces.md)` remains a link.
+ */
+export function normalizeLocalFileLinkMarkdown(content: string): string {
+  let result = "";
+  let cursor = 0;
+  let fencedCode: { marker: "`" | "~"; length: number } | null = null;
+
+  while (cursor < content.length) {
+    const lineStart = cursor === 0 || content[cursor - 1] === "\n";
+    if (lineStart) {
+      const fence = markdownFenceAt(content, cursor);
+      if (fence && (
+        fencedCode === null
+        || (fence.marker === fencedCode.marker && fence.length >= fencedCode.length)
+      )) {
+        fencedCode = fencedCode === null
+          ? { marker: fence.marker, length: fence.length }
+          : null;
+        const lineEnd = content.indexOf("\n", cursor);
+        const end = lineEnd < 0 ? content.length : lineEnd + 1;
+        result += content.slice(cursor, end);
+        cursor = end;
+        continue;
+      }
+    }
+
+    if (fencedCode) {
+      result += content[cursor];
+      cursor += 1;
+      continue;
+    }
+
+    if (content[cursor] === "`") {
+      const runLength = markerRunLength(content, cursor, "`");
+      const closing = content.indexOf("`".repeat(runLength), cursor + runLength);
+      if (closing >= 0) {
+        const end = closing + runLength;
+        result += content.slice(cursor, end);
+        cursor = end;
+        continue;
+      }
+    }
+
+    if (content[cursor] !== "[" || content[cursor - 1] === "!") {
+      result += content[cursor];
+      cursor += 1;
+      continue;
+    }
+
+    const labelEnd = findBalancedClosing(content, cursor + 1, "[", "]");
+    if (labelEnd < 0 || content[labelEnd + 1] !== "(") {
+      result += content[cursor];
+      cursor += 1;
+      continue;
+    }
+    const destinationEnd = findBalancedClosing(content, labelEnd + 2, "(", ")");
+    if (destinationEnd < 0) {
+      result += content[cursor];
+      cursor += 1;
+      continue;
+    }
+
+    const rawDestination = content.slice(labelEnd + 2, destinationEnd);
+    const destination = rawDestination.trim();
+    if (!destination.includes(" ") || !looksLikeLocalDestination(destination)) {
+      result += content.slice(cursor, destinationEnd + 1);
+      cursor = destinationEnd + 1;
+      continue;
+    }
+
+    const label = content.slice(cursor + 1, labelEnd);
+    result += `[${label}](<${destination.replace(/ /g, "%20")}>)`;
+    cursor = destinationEnd + 1;
+  }
+
+  return result;
+}
+
+function looksLikeLocalDestination(destination: string): boolean {
+  return (destination.startsWith("/") && !destination.startsWith("//"))
+    || destination.startsWith("~/")
+    || destination.startsWith("./")
+    || destination.startsWith("../")
+    || /^[a-zA-Z]:[\\/]/.test(destination);
+}
+
+function markdownFenceAt(
+  content: string,
+  lineStart: number,
+): { marker: "`" | "~"; length: number } | null {
+  let cursor = lineStart;
+  let indentation = 0;
+  while (content[cursor] === " " && indentation < 4) {
+    indentation += 1;
+    cursor += 1;
+  }
+  if (indentation > 3) return null;
+  const marker = content[cursor];
+  if (marker !== "`" && marker !== "~") return null;
+  const length = markerRunLength(content, cursor, marker);
+  return length >= 3 ? { marker, length } : null;
+}
+
+function markerRunLength(content: string, start: number, marker: string): number {
+  let end = start;
+  while (content[end] === marker) end += 1;
+  return end - start;
+}
+
+function findBalancedClosing(
+  content: string,
+  start: number,
+  opening: "[" | "(",
+  closing: "]" | ")",
+): number {
+  let depth = 0;
+  for (let cursor = start; cursor < content.length; cursor += 1) {
+    const char = content[cursor];
+    if (char === "\n") return -1;
+    if (char === "\\") {
+      cursor += 1;
+      continue;
+    }
+    if (char === opening) {
+      depth += 1;
+    } else if (char === closing) {
+      if (depth === 0) return cursor;
+      depth -= 1;
+    }
+  }
+  return -1;
+}

--- a/apps/packages/product-client/src/lib/domain/chat/transcript/file-link-markdown.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/transcript/file-link-markdown.ts
@@ -3,28 +3,52 @@
  * brackets or percent-encoded. Agent output is not always that careful. Keep
  * the stored transcript untouched and repair only explicit local-file links in
  * the render copy so `[label](/absolute/path with spaces.md)` remains a link.
+ *
+ * This is a message-surface repair. A file viewer rendering a file's own bytes
+ * must never run it (MarkdownBody gates the call on its `surface` prop), or
+ * displayed file content would be silently rewritten.
  */
 export function normalizeLocalFileLinkMarkdown(content: string): string {
   let result = "";
   let cursor = 0;
   let fencedCode: { marker: "`" | "~"; length: number } | null = null;
+  // CommonMark opens an indented code block only after a blank line (or at the
+  // very start of the document). A 4-space-indented *list continuation* does
+  // not, and lists of file links are the main case this repair exists for, so
+  // the blank-line predecessor is tracked rather than indentation alone.
+  let previousLineBlank = true;
+  let indentedCode = false;
 
   while (cursor < content.length) {
     const lineStart = cursor === 0 || content[cursor - 1] === "\n";
     if (lineStart) {
+      const lineEnd = content.indexOf("\n", cursor);
+      const lineStop = lineEnd < 0 ? content.length : lineEnd + 1;
       const fence = markdownFenceAt(content, cursor);
-      if (fence && (
-        fencedCode === null
-        || (fence.marker === fencedCode.marker && fence.length >= fencedCode.length)
-      )) {
+      if (fence && (fencedCode === null || closesFence(fence, fencedCode))) {
         fencedCode = fencedCode === null
           ? { marker: fence.marker, length: fence.length }
           : null;
-        const lineEnd = content.indexOf("\n", cursor);
-        const end = lineEnd < 0 ? content.length : lineEnd + 1;
-        result += content.slice(cursor, end);
-        cursor = end;
+        indentedCode = false;
+        previousLineBlank = false;
+        result += content.slice(cursor, lineStop);
+        cursor = lineStop;
         continue;
+      }
+
+      if (!fencedCode) {
+        const line = content.slice(cursor, lineStop);
+        const blank = line.trim() === "";
+        if (!blank) {
+          indentedCode = INDENTED_CODE_LINE.test(line)
+            && (previousLineBlank || indentedCode);
+        }
+        previousLineBlank = blank;
+        if (indentedCode && !blank) {
+          result += line;
+          cursor = lineStop;
+          continue;
+        }
       }
     }
 
@@ -45,7 +69,11 @@ export function normalizeLocalFileLinkMarkdown(content: string): string {
       }
     }
 
-    if (content[cursor] !== "[" || content[cursor - 1] === "!") {
+    if (
+      content[cursor] !== "["
+      || content[cursor - 1] === "!"
+      || isBackslashEscaped(content, cursor)
+    ) {
       result += content[cursor];
       cursor += 1;
       continue;
@@ -64,20 +92,56 @@ export function normalizeLocalFileLinkMarkdown(content: string): string {
       continue;
     }
 
-    const rawDestination = content.slice(labelEnd + 2, destinationEnd);
-    const destination = rawDestination.trim();
-    if (!destination.includes(" ") || !looksLikeLocalDestination(destination)) {
+    const repaired = repairLinkDestination(content.slice(labelEnd + 2, destinationEnd));
+    if (repaired === null) {
       result += content.slice(cursor, destinationEnd + 1);
       cursor = destinationEnd + 1;
       continue;
     }
 
     const label = content.slice(cursor + 1, labelEnd);
-    result += `[${label}](<${destination.replace(/ /g, "%20")}>)`;
+    result += `[${label}](${repaired})`;
     cursor = destinationEnd + 1;
   }
 
   return result;
+}
+
+/**
+ * A complete CommonMark link title closing the destination content: whitespace
+ * followed by a balanced `"…"`, `'…'`, or `(…)` group at the very end. Only the
+ * leading capture is the destination, so `[g](/a b/c.md "Read me")` keeps its
+ * title outside the repaired angle brackets instead of folding it into the
+ * href. Anything that is not a well-formed trailing title is left as part of
+ * the destination.
+ */
+const TRAILING_LINK_TITLE =
+  /^([\s\S]*?)\s+("(?:[^"\\]|\\[\s\S])*"|'(?:[^'\\]|\\[\s\S])*'|\((?:[^()\\]|\\[\s\S])*\))$/;
+
+const INDENTED_CODE_LINE = /^(?: {4}|\t)/;
+
+/**
+ * The repaired `(…)` body for a link whose destination needs angle wrapping, or
+ * null when the link must be left exactly as written.
+ */
+function repairLinkDestination(rawDestination: string): string | null {
+  const trimmed = rawDestination.trim();
+  const title = TRAILING_LINK_TITLE.exec(trimmed);
+  const destination = title ? title[1] : trimmed;
+  if (!destination.includes(" ")) {
+    return null;
+  }
+  // Angle wrapping cannot express `<` or `>` in a destination, and these were
+  // not links to begin with: leaving unrelated malformed Markdown untouched is
+  // the contract.
+  if (destination.includes("<") || destination.includes(">")) {
+    return null;
+  }
+  if (!looksLikeLocalDestination(destination)) {
+    return null;
+  }
+  const wrapped = `<${destination.replace(/ /g, "%20")}>`;
+  return title ? `${wrapped} ${title[2]}` : wrapped;
 }
 
 function looksLikeLocalDestination(destination: string): boolean {
@@ -88,10 +152,25 @@ function looksLikeLocalDestination(destination: string): boolean {
     || /^[a-zA-Z]:[\\/]/.test(destination);
 }
 
-function markdownFenceAt(
-  content: string,
-  lineStart: number,
-): { marker: "`" | "~"; length: number } | null {
+interface MarkdownFence {
+  marker: "`" | "~";
+  length: number;
+  /** Whether the marker run is followed by nothing but whitespace. */
+  bare: boolean;
+}
+
+/**
+ * A closing fence carries no info string, so a `` ```md `` line inside a
+ * `` ``` `` block is block content rather than its terminator.
+ */
+function closesFence(
+  fence: MarkdownFence,
+  open: { marker: "`" | "~"; length: number },
+): boolean {
+  return fence.marker === open.marker && fence.length >= open.length && fence.bare;
+}
+
+function markdownFenceAt(content: string, lineStart: number): MarkdownFence | null {
   let cursor = lineStart;
   let indentation = 0;
   while (content[cursor] === " " && indentation < 4) {
@@ -102,13 +181,25 @@ function markdownFenceAt(
   const marker = content[cursor];
   if (marker !== "`" && marker !== "~") return null;
   const length = markerRunLength(content, cursor, marker);
-  return length >= 3 ? { marker, length } : null;
+  if (length < 3) return null;
+  const lineEnd = content.indexOf("\n", cursor + length);
+  const info = content.slice(cursor + length, lineEnd < 0 ? content.length : lineEnd);
+  return { marker, length, bare: info.trim() === "" };
 }
 
 function markerRunLength(content: string, start: number, marker: string): number {
   let end = start;
   while (content[end] === marker) end += 1;
   return end - start;
+}
+
+/** A `[` behind an odd run of backslashes is literal text, not a link start. */
+function isBackslashEscaped(content: string, index: number): boolean {
+  let backslashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && content[cursor] === "\\"; cursor -= 1) {
+    backslashes += 1;
+  }
+  return backslashes % 2 === 1;
 }
 
 function findBalancedClosing(

--- a/apps/packages/product-client/src/lib/domain/files/path-detection.ts
+++ b/apps/packages/product-client/src/lib/domain/files/path-detection.ts
@@ -52,7 +52,7 @@ export function looksLikeFileReferenceHref(value: string): boolean {
 
   const trimmed = value.trim();
   if (trimmed.length === 0 || trimmed.length > 512) return false;
-  if (/\s/.test(trimmed)) return false;
+  if (/\r|\n/.test(trimmed)) return false;
   if (/[*?[\]{}]/.test(trimmed)) return false;
   // Any scheme (https://, mailto:, vscode:) is not a workspace path.
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return false;

--- a/apps/packages/product-client/src/lib/domain/files/path-references.test.ts
+++ b/apps/packages/product-client/src/lib/domain/files/path-references.test.ts
@@ -125,6 +125,18 @@ describe("resolveFileReference", () => {
       workspacePath: null,
     });
   });
+
+  it("decodes Markdown-encoded spaces without reinterpreting encoded separators", () => {
+    expect(resolveFileReference({
+      rawPath: "/repo/My%20Project/literal%2Fname.md",
+      workspaceRoot: "/repo",
+      resolveAbsolute,
+    })).toMatchObject({
+      path: "/repo/My Project/literal%2Fname.md",
+      absolutePath: "/repo/My Project/literal%2Fname.md",
+      workspacePath: "My Project/literal%2Fname.md",
+    });
+  });
 });
 
 describe("resolveFileReferencePrimaryAction", () => {

--- a/apps/packages/product-client/src/lib/domain/files/path-references.ts
+++ b/apps/packages/product-client/src/lib/domain/files/path-references.ts
@@ -79,11 +79,19 @@ export function resolveFileReference(args: {
   };
 }
 
-function decodeEncodedSpaces(path: string): string {
-  // The Markdown render repair percent-encodes literal spaces so CommonMark
-  // will preserve the destination. Decode only that encoding here: decoding
-  // every URI component would reinterpret literal file names containing
-  // sequences such as `%2F` or `%2E%2E` as separators or traversal.
+/**
+ * The Markdown render repair percent-encodes literal spaces so CommonMark will
+ * preserve the destination. Decode only that encoding: decoding every URI
+ * component would reinterpret literal file names containing sequences such as
+ * `%2F` or `%2E%2E` as separators or traversal.
+ *
+ * Scope tradeoff, accepted: this runs for every file reference, including
+ * tool-output paths that were never percent-encoded, so a file literally named
+ * with `%20` in it resolves to the space-bearing name instead. That is far
+ * rarer than an agent emitting a repaired link, and unlike a full
+ * `decodeURIComponent` it cannot manufacture a separator or a traversal.
+ */
+export function decodeEncodedSpaces(path: string): string {
   return path.replace(/%20/gi, " ");
 }
 

--- a/apps/packages/product-client/src/lib/domain/files/path-references.ts
+++ b/apps/packages/product-client/src/lib/domain/files/path-references.ts
@@ -61,7 +61,7 @@ export function resolveFileReference(args: {
   resolveAbsolute: (rawPath: string) => string | null;
   workspacePathOverride?: string | null;
 }): ResolvedFileReference {
-  const trimmed = args.rawPath.trim();
+  const trimmed = decodeEncodedSpaces(args.rawPath.trim());
   const { path, line, column } = splitPathLineSuffix(trimmed);
   // The SDK normalizes both an omitted wire field and an explicit null to
   // `null`, so absence cannot safely mean "authoritatively external" here.
@@ -77,6 +77,14 @@ export function resolveFileReference(args: {
     absolutePath: args.resolveAbsolute(path),
     workspacePath,
   };
+}
+
+function decodeEncodedSpaces(path: string): string {
+  // The Markdown render repair percent-encodes literal spaces so CommonMark
+  // will preserve the destination. Decode only that encoding here: decoding
+  // every URI component would reinterpret literal file names containing
+  // sequences such as `%2F` or `%2E%2E` as separators or traversal.
+  return path.replace(/%20/gi, " ");
 }
 
 /**

--- a/apps/packages/product-client/src/lib/domain/open-targets/model.test.ts
+++ b/apps/packages/product-client/src/lib/domain/open-targets/model.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import {
+  fileReferenceOpenWithTargets,
+  type OpenTarget,
+} from "#product/lib/domain/open-targets/model";
+
+describe("fileReferenceOpenWithTargets", () => {
+  it("keeps concrete editors and excludes Finder, Terminal, and copy actions", () => {
+    const targets: OpenTarget[] = [
+      { id: "finder", label: "Finder", kind: "finder", iconId: "finder" },
+      { id: "cursor", label: "Cursor", kind: "editor", iconId: "cursor" },
+      { id: "terminal", label: "Terminal", kind: "terminal", iconId: "terminal" },
+      { id: "copy-path", label: "Copy path", kind: "copy" },
+    ];
+
+    expect(fileReferenceOpenWithTargets(targets)).toEqual([targets[1]]);
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/open-targets/model.ts
+++ b/apps/packages/product-client/src/lib/domain/open-targets/model.ts
@@ -23,3 +23,9 @@ export interface OpenTarget {
   shortcut?: string;
   iconId?: OpenTargetIconId;
 }
+
+export function fileReferenceOpenWithTargets(
+  targets: readonly OpenTarget[],
+): OpenTarget[] {
+  return targets.filter((target) => target.kind === "editor");
+}

--- a/apps/packages/product-client/src/lib/infra/dom/contextual-word-selection.test.ts
+++ b/apps/packages/product-client/src/lib/infra/dom/contextual-word-selection.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+import { clearContextualWordSelection } from "#product/lib/infra/dom/contextual-word-selection";
+
+function selectContents(element: Element) {
+  const selection = window.getSelection();
+  if (!selection) throw new Error("jsdom selection unavailable");
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return selection;
+}
+
+afterEach(() => {
+  window.getSelection()?.removeAllRanges();
+  document.body.innerHTML = "";
+});
+
+describe("clearContextualWordSelection", () => {
+  it("clears a selection inside the container", () => {
+    document.body.innerHTML = "<button><span>notes.md</span></button>";
+    const button = document.querySelector("button")!;
+    const selection = selectContents(button.firstElementChild!);
+    expect(selection.isCollapsed).toBe(false);
+
+    clearContextualWordSelection(button);
+
+    expect(selection.rangeCount).toBe(0);
+  });
+
+  it("leaves a selection made elsewhere alone", () => {
+    document.body.innerHTML = "<p>prose the user selected</p><button>notes.md</button>";
+    const selection = selectContents(document.querySelector("p")!);
+
+    clearContextualWordSelection(document.querySelector("button")!);
+
+    expect(selection.isCollapsed).toBe(false);
+  });
+
+  it("tolerates no selection and non-element targets", () => {
+    document.body.innerHTML = "<button>notes.md</button>";
+    expect(() => clearContextualWordSelection(document.querySelector("button")!)).not.toThrow();
+    expect(() => clearContextualWordSelection(null)).not.toThrow();
+    expect(() => clearContextualWordSelection(window)).not.toThrow();
+  });
+});

--- a/apps/packages/product-client/src/lib/infra/dom/contextual-word-selection.ts
+++ b/apps/packages/product-client/src/lib/infra/dom/contextual-word-selection.ts
@@ -1,0 +1,27 @@
+/**
+ * macOS WebKit selects the word under the pointer while preparing a context
+ * menu — inside the platform's sendContextMenuEvent, after mousedown but
+ * before the DOM `contextmenu` event is dispatched — so no preventDefault on
+ * either event stops it. A handler that replaces the browser menu calls this
+ * synchronously to drop that just-made selection before it ever paints.
+ *
+ * Only a selection touching `container` is cleared: one living entirely
+ * elsewhere cannot be the contextual word under the pointer, and clearing it
+ * would destroy a selection the user made on purpose.
+ */
+export function clearContextualWordSelection(container: EventTarget | null): void {
+  if (!(container instanceof Element)) {
+    return;
+  }
+  const selection = container.ownerDocument?.getSelection();
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+    return;
+  }
+  const { anchorNode, focusNode } = selection;
+  const touchesContainer =
+    (anchorNode !== null && container.contains(anchorNode))
+    || (focusNode !== null && container.contains(focusNode));
+  if (touchesContainer) {
+    selection.removeAllRanges();
+  }
+}

--- a/apps/packages/product-client/src/primitives/PopoverButton.test.tsx
+++ b/apps/packages/product-client/src/primitives/PopoverButton.test.tsx
@@ -52,4 +52,73 @@ describe("PopoverButton", () => {
 
     expect(fireEvent.mouseDown(trigger, { button: 2 })).toBe(false);
   });
+
+  // WebKit selects the word under the pointer while preparing the context
+  // menu, before `contextmenu` is dispatched and immune to preventDefault.
+  // Opening our menu must drop that selection so no highlight paints under
+  // it — unless the menu covers genuinely selectable content and opts out.
+  it("clears a selection inside the trigger when the context menu opens", () => {
+    render(
+      <PopoverButton
+        trigger={<button type="button">notes.md</button>}
+        triggerMode="contextMenu"
+      >
+        {() => <div>menu</div>}
+      </PopoverButton>,
+    );
+    const trigger = screen.getByRole("button", { name: "notes.md" });
+    const selection = selectContents(trigger);
+    expect(selection.isCollapsed).toBe(false);
+
+    fireEvent.contextMenu(trigger);
+
+    expect(selection.rangeCount).toBe(0);
+  });
+
+  it("leaves a selection outside the trigger alone", () => {
+    render(
+      <>
+        <p>prose the user selected</p>
+        <PopoverButton
+          trigger={<button type="button">notes.md</button>}
+          triggerMode="contextMenu"
+        >
+          {() => <div>menu</div>}
+        </PopoverButton>
+      </>,
+    );
+    const selection = selectContents(screen.getByText("prose the user selected"));
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "notes.md" }));
+
+    expect(selection.isCollapsed).toBe(false);
+  });
+
+  it("keeps the contextual selection when preserveContextualSelection is set", () => {
+    render(
+      <PopoverButton
+        trigger={<button type="button">file content</button>}
+        triggerMode="contextMenu"
+        preserveContextualSelection
+      >
+        {() => <div>menu</div>}
+      </PopoverButton>,
+    );
+    const trigger = screen.getByRole("button", { name: "file content" });
+    const selection = selectContents(trigger);
+
+    fireEvent.contextMenu(trigger);
+
+    expect(selection.isCollapsed).toBe(false);
+  });
 });
+
+function selectContents(element: Element) {
+  const selection = window.getSelection();
+  if (!selection) throw new Error("jsdom selection unavailable");
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return selection;
+}

--- a/apps/packages/product-client/src/primitives/PopoverButton.test.tsx
+++ b/apps/packages/product-client/src/primitives/PopoverButton.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { PopoverButton } from "#product/primitives/PopoverButton";
+
+afterEach(cleanup);
+
+describe("PopoverButton", () => {
+  // WebKit's secondary-button mousedown default selects the word under the
+  // pointer before `contextmenu` fires. PopoverButton always suppresses the
+  // browser context menu, so the pre-selection must be suppressed with it —
+  // otherwise right-clicking a transcript file mention flashes a text
+  // highlight under the menu. fireEvent returns false iff preventDefault ran.
+  it("prevents the secondary-button mousedown default on contextMenu triggers", () => {
+    render(
+      <PopoverButton
+        trigger={<button type="button">target</button>}
+        triggerMode="contextMenu"
+      >
+        {() => <div>menu</div>}
+      </PopoverButton>,
+    );
+    const trigger = screen.getByRole("button", { name: "target" });
+
+    expect(fireEvent.mouseDown(trigger, { button: 2 })).toBe(false);
+  });
+
+  it("leaves primary-button mousedown untouched", () => {
+    render(
+      <PopoverButton
+        trigger={<button type="button">target</button>}
+        triggerMode="contextMenu"
+      >
+        {() => <div>menu</div>}
+      </PopoverButton>,
+    );
+    const trigger = screen.getByRole("button", { name: "target" });
+
+    expect(fireEvent.mouseDown(trigger, { button: 0 })).toBe(true);
+  });
+
+  it("prevents the secondary-button mousedown default on click triggers too", () => {
+    render(
+      <PopoverButton
+        trigger={<button type="button">target</button>}
+      >
+        {() => <div>menu</div>}
+      </PopoverButton>,
+    );
+    const trigger = screen.getByRole("button", { name: "target" });
+
+    expect(fireEvent.mouseDown(trigger, { button: 2 })).toBe(false);
+  });
+});

--- a/apps/packages/product-client/src/primitives/PopoverButton.tsx
+++ b/apps/packages/product-client/src/primitives/PopoverButton.tsx
@@ -107,6 +107,18 @@ export function PopoverButton({
     }
   };
 
+  // WebKit selects the word under the pointer as the secondary-button
+  // mousedown default, before `contextmenu` ever fires. Every trigger mode
+  // suppresses the browser context menu (handleContextMenu), so that
+  // pre-selection is never wanted: without this, two-finger-clicking a
+  // transcript file mention flashes a text highlight under the menu.
+  // Primary-button behavior (text selection, focus, drag) is untouched.
+  const handleMouseDown = (event: ReactMouseEvent) => {
+    if (event.button === 2) {
+      event.preventDefault();
+    }
+  };
+
   const handleDoubleClick = (event: ReactMouseEvent) => {
     if (stopPropagation) {
       event.stopPropagation();
@@ -142,6 +154,7 @@ export function PopoverButton({
           onClick={handleClick}
           onDoubleClick={handleDoubleClick}
           onContextMenu={handleContextMenu}
+          onMouseDown={handleMouseDown}
         >
           {trigger}
         </PopoverTrigger>
@@ -156,6 +169,7 @@ export function PopoverButton({
             onClick={handleClick}
             onDoubleClick={handleDoubleClick}
             onContextMenu={handleContextMenu}
+            onMouseDown={handleMouseDown}
           >
             {trigger}
           </Slot>

--- a/apps/packages/product-client/src/primitives/PopoverButton.tsx
+++ b/apps/packages/product-client/src/primitives/PopoverButton.tsx
@@ -12,6 +12,7 @@ import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { Slot } from "@radix-ui/react-slot";
 import { Popover, PopoverTrigger } from "./Popover";
 import { useNativeOverlayRegistration } from "#product/primitives/overlays/overlay-presence";
+import { clearContextualWordSelection } from "#product/lib/infra/dom/contextual-word-selection";
 import { POPOVER_SURFACE_CLASS } from "./popover-surface";
 
 type PopoverAlign = "start" | "end";
@@ -45,6 +46,12 @@ interface PopoverButtonProps {
   stopPropagation?: boolean;
   /** Which interaction opens the popover. Default: "click". */
   triggerMode?: PopoverTriggerMode;
+  /**
+   * Keep the word selection WebKit makes under the pointer on right-click
+   * (dropped by default because it flashes a highlight under the menu). Set
+   * this on menus over genuinely selectable content, e.g. file-viewer text.
+   */
+  preserveContextualSelection?: boolean;
   /** Controlled open state. When provided, external code can open the popover. */
   externalOpen?: boolean;
   /** Called when the popover closes (for controlled mode). */
@@ -60,6 +67,7 @@ export function PopoverButton({
   className = `w-56 ${POPOVER_SURFACE_CLASS}`,
   stopPropagation = false,
   triggerMode = "click",
+  preserveContextualSelection = false,
   externalOpen,
   onOpenChange,
 }: PopoverButtonProps) {
@@ -107,12 +115,10 @@ export function PopoverButton({
     }
   };
 
-  // WebKit selects the word under the pointer as the secondary-button
-  // mousedown default, before `contextmenu` ever fires. Every trigger mode
-  // suppresses the browser context menu (handleContextMenu), so that
-  // pre-selection is never wanted: without this, two-finger-clicking a
-  // transcript file mention flashes a text highlight under the menu.
-  // Primary-button behavior (text selection, focus, drag) is untouched.
+  // A secondary-button press must not steal focus or start a drag-selection;
+  // note this does NOT stop WebKit's word-select-under-pointer (that happens
+  // in the platform's context-menu path, immune to mousedown preventDefault —
+  // handleContextMenu clears it after the fact instead).
   const handleMouseDown = (event: ReactMouseEvent) => {
     if (event.button === 2) {
       event.preventDefault();
@@ -131,6 +137,12 @@ export function PopoverButton({
 
   const handleContextMenu = (event: ReactMouseEvent) => {
     event.preventDefault();
+    // WebKit has already selected the word under the pointer by now (it does
+    // so before dispatching `contextmenu`, immune to any preventDefault);
+    // drop that selection before it paints under the menu.
+    if (!preserveContextualSelection) {
+      clearContextualWordSelection(event.currentTarget);
+    }
     if (stopPropagation) {
       event.stopPropagation();
     }

--- a/scripts/frontend_structure_allowlist.txt
+++ b/scripts/frontend_structure_allowlist.txt
@@ -19,7 +19,6 @@
 
 apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx 447 blocked-status composer takeover branch (textarea/control-row swap + focus restore); split on next growth
 apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts 425 workspace bootstrap actions + gateway billing-block capture into the status screen (C8); split on next growth
-apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.tsx 525 existing markdown transcript renderer pending split
 # Relocated from apps/desktop/src by the Desktop-product move into product-client
 # (web-desktop-unification slice 04). Same files, same counts/reasons — relocation,
 # not gate-weakening; product-client/src is a structure-report scan root. Counts

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -152,6 +152,11 @@ Rules:
   spaces, never encoded separators or traversal. Never rewrite the transcript
   source, inline/fenced code examples, images, external URLs, or unrelated
   malformed Markdown.
+  - A link title stays outside the repair: only the destination is wrapped, so
+    `[g](/a/My Notes.md "Read it")` keeps its title.
+  - The repair applies to transcript and message surfaces only. A body
+    rendering a file's own content (`surface="file-content"`, the file viewer)
+    is never repaired, because displayed file bytes must render as written.
 - Once the assistant reveal frontier settles, the final unique Markdown file
   reference also renders as a compact end-resource card after prose. Its
   default subtitle identifies `Document · MD`; hover/focus changes that

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -124,7 +124,12 @@ apps/packages/product-client/src/components/workspace/chat/transcript/transcript
 apps/packages/product-client/src/components/workspace/chat/transcript/ProviderLinkMention.tsx
   shared inline provider-icon link mention + URL/host classification
   (isExternalHttpLink, linkHost); rendered by MarkdownBody's default anchor, so
-  every surface (web + cloud chat included) gets icon links
+  every surface (web + cloud chat included) gets icon links and the shared web
+  open/copy behavior
+
+apps/packages/product-client/src/lib/domain/chat/transcript/file-link-markdown.ts
+  pure render-copy repair for explicit local-file Markdown destinations that
+  contain literal spaces; stored and streamed transcript text stays untouched
 
 apps/packages/product-client/src/lib/domain/files/path-detection.ts
   pure path heuristics (looksLikePath, looksLikeFileReferenceHref,
@@ -140,6 +145,13 @@ Rules:
 
 - Detection happens at render time from raw markdown; do not store parsed file
   references in transcript items.
+- CommonMark does not accept an unescaped space in an ordinary link
+  destination. Repair an explicit local destination such as
+  `[notes](/workspace/My Notes.md)` by percent-encoding its spaces in the
+  Markdown render copy only. The file resolver decodes only those encoded
+  spaces, never encoded separators or traversal. Never rewrite the transcript
+  source, inline/fenced code examples, images, external URLs, or unrelated
+  malformed Markdown.
 - Once the assistant reveal frontier settles, the final unique Markdown file
   reference also renders as a compact end-resource card after prose. Its
   default subtitle identifies `Document · MD`; hover/focus changes that
@@ -151,6 +163,12 @@ Rules:
   partial absolute destination while waiting for the real closing delimiter.
 - Mention labels display the workspace-relative path plus a `(line N)` suffix;
   raw absolute hrefs must not be shown as label text.
+- Prose file references use the file or directory visual from the shared file
+  visual table, followed by a medium-weight semantic-blue label. The glyph is
+  baseline-aligned to one line of text. The full destination path is available
+  through the link tooltip. Primary opening and context-menu behavior is the
+  file-reference contract in
+  [`../workspaces/files.md`](../workspaces/files.md#file-reference-opening).
 - External/web link hrefs render as a shared inline provider-icon mention
   (`ProviderLinkMention`): a GitHub brand SVG for github hosts, otherwise the
   site's own favicon — `https://<host>/favicon.ico`, falling back to the root
@@ -159,13 +177,24 @@ Rules:
   (`isExternalHttpLink`) runs before file-path detection so a real path is never
   mistaken for a link. Favicon requests go to the linked site itself (no
   third-party favicon service), so no list of linked hosts leaks anywhere. The
-  provider mention and the file-path mention share one inline-mention treatment
-  (semantic blue link color, no underline at rest, and a dashed underline on
-  hover); this only renders because the global `a` reset lives in
+  provider mention and the prose file-path mention share one inline-mention
+  treatment: semantic blue link color, no underline at rest, pointer cursor,
+  and a dotted 0.5px underline with a 2px offset on hover. Keyboard focus uses
+  the same dotted underline at 1px. This only renders because the global
+  `a` reset lives in
   `@layer base` (see the frontend styling guide) — unlayered, it would strip the
   anchor's color/underline.
+- A web-link tooltip shows its full normalized URL. Primary click opens that URL
+  through the host browser opener. Its context menu contains exactly `Open in
+  Browser`, then `Copy link`; copying uses the normalized URL. The same actions
+  are exposed through the Desktop native context menu and the browser/test DOM
+  fallback.
 - Web falls back to unhighlighted (identically styled) code blocks; shiki stays
   out of the web bundle.
+
+This section governs references to file destinations. Composer attachment
+upload, paste, supported-type, and attachment-viewer behavior is a separate
+system and is not part of this contract.
 
 ## Contextual Assistant-Text Actions
 
@@ -441,20 +470,30 @@ Every row revealed inside an activity ledger repeats its own semantic glyph
 inherited ink as its label. Completed command details use `Ran …`; only the
 active command uses `Running …`. A read target with missing nullable workspace
 metadata is classified from its raw path against the current workspace root.
-An openable file target uses the semantic blue link color even though the
-surrounding activity row is muted: a workspace file opens in the viewer, while
-an external Desktop file uses the configured external target. It remains
-pointer- and keyboard-activatable while retrying path resolution or a failed
-external launch. A read target with no available primary action remains muted
-plain text without link or file-menu semantics rather than a disabled control.
-An edit detail shows one pen glyph followed by an inherited-color,
-dotted-underlined filename, not a second file-type glyph.
+Tool-call file references deliberately do not reuse the prose reference's blue
+tone or file-type glyph. Read and edit details render the filename in the
+surrounding row's current text color with a dotted hairline underline at rest;
+the underline has a 2px offset and the row's semantic read/edit glyph is the
+only leading glyph. Hovering or focusing a read reference promotes only that
+filename to foreground. Hovering or focusing an edit row promotes the whole
+edit hint, including its filename and change stats; an expanded inline-diff
+card stays in that same edit-row hover group.
+
+Reference activation and menus are present only while a primary action can be
+resolved. A transient path-resolution or external-open failure keeps the
+reference pointer- and keyboard-activatable so the next activation retries it.
+Once the host authoritatively determines that no primary action is available,
+the target is inert text without a pointer, file glyph, or file-reference menu;
+it is never a disabled button. Workspace/external routing and the exact file
+menu are defined in
+[`../workspaces/files.md`](../workspaces/files.md#file-reference-opening).
 When a transcript patch is available, clicking the edit row outside its
 filename toggles the inline diff. Clicking either the filename or the trailing
-open-file arrow opens the file without changing the row's expanded state. The
-row retains the file-reference context menu. Edit
-counts remain neutral beside the filename until row hover or focus within the
-row gives additions and deletions their semantic colors.
+open-file arrow opens the file without changing the row's expanded state. Only
+the filename owns the file-reference context menu; right-clicking the rest of
+the row leaves the normal row interaction alone. Edit counts remain neutral
+beside the filename until row hover or focus within the row gives additions and
+deletions their semantic colors.
 
 The completed-turn changed-files card uses one aggregate header and flat file
 rows. Multi-file cards show the first three paths, then a `Show N more files`

--- a/specs/codebase/systems/product/workspaces/files.md
+++ b/specs/codebase/systems/product/workspaces/files.md
@@ -114,6 +114,43 @@ parts in the active session's latest completed turn. It uses the runtime
 `base_worktree` diff scope internally, but `base_worktree` is not a center
 viewer target scope.
 
+## File-Reference Opening
+
+The shared file-reference action model owns links to local files and
+directories in chat prose and transcript tool calls. A primary click routes by
+the resolved target, not by the visual surface that rendered the reference:
+
+- a file inside the current workspace opens or focuses a Proliferate `file`
+  viewer target
+- an absolute Desktop file outside the workspace opens with the configured
+  default target
+- a directory reveals in Finder
+
+An actionable file reference exposes the same ordered context menu in the
+Desktop native menu and the browser/test DOM fallback:
+
+1. `Open in Proliferate` for files; directories omit this item
+2. `Open in {default target}`; when the host has no named default, use `Open
+   externally`
+3. `Open with` as a submenu containing every available editor; Finder,
+   Terminal, and the copy-path pseudo-target are excluded
+4. a separator
+5. `Copy path`
+6. `Reveal in Finder`, or `Reveal folder in Finder` for a directory; omit this
+   item when Finder is already the default target
+
+The default target and each `Open with` entry use the host-provided application
+name and icon. Finder is excluded because reveal is its dedicated action;
+Terminal is not an editor and remains outside this file-link menu. `Copy path`
+copies the resolved absolute path when one exists, otherwise the resolved
+reference path.
+
+Path-kind lookup and the first open are retryable operations. A transient
+lookup or launch failure keeps the reference actionable and reports that the
+next activation retries. If resolution finishes and establishes that none of
+the viewer, external-open, or reveal actions is available, the reference is
+authoritatively unavailable and renders as inert text with no context menu.
+
 ## State Ownership
 
 Remote filesystem and git data belongs to SDK-react/TanStack Query:


### PR DESCRIPTION
Umbrella implementation for [PRO-185 File + link references](https://linear.app/proliferate-team/issue/PRO-185/file-link-references): local file references in transcript prose and tool activity are recognized consistently, styled per surface, and clicking them opens the right target — workspace files in the right-hand viewer, external files via the configured target, directories in Finder.

## Fixes

- [PRO-161](https://linear.app/proliferate-team/issue/PRO-161/links-broken): markdown file links whose destination contains spaces rendered as raw literal text (CommonMark rejects unescaped spaces). New pure module `file-link-markdown.ts` repairs such local destinations in the **render copy only** (`(<dest%20…>)`); the stored/streamed transcript stays byte-identical. The resolver decodes only `%20` — never encoded separators or traversal.
- [PRO-160](https://linear.app/proliferate-team/issue/PRO-160/file-linking-incorrect-logic): tool-row filenames no longer wear blue web-link styling. New `plain` badge variant: inherited row ink, dotted hairline underline at rest, hover promotes only the filename; clicks route through the shared file-reference action model (`openPrimary`).
- [PRO-177](https://linear.app/proliferate-team/issue/PRO-177/clicking-file-in-chat-transcript-doesnt-open-in-the-right-sidebar-for): edit rows split click zones — row body toggles the inline diff, filename or trailing arrow opens the file, and only the filename owns the file-reference context menu.

## Also in this change

- Web-link twin: `WebLinkMenu` (Open in Browser / Copy link), URL tooltip, and host-routed opening on `ProviderLinkMention`.
- Consistency gap-fill: `renderLink`/`renderInlineCode` wired into 5 `MarkdownBody` sites that previously only wired code blocks (`SkillsToolResultRow` ×2, `SubagentLaunchLedger`, `CoworkCodingToolLedger`, `TranscriptAgentGroupBlock`), so paths there become clickable references too.
- Spec amendments are part of the diff: `transcript.md` (file-mention + activity-ledger reference rules, render-copy repair contract) and `files.md` (new **File-Reference Opening** section: routing by resolved target, ordered context menu, retryable vs. authoritatively-unavailable states).

## Verification

- Full `@proliferate/product-client` suite: 867 files / 5,984 tests, all passing; typecheck clean.
- Key behavioral assertions: source-markdown immutability under the space repair, `%20`-only decoding, edit-row click-zone contract including the negative case (row right-click shows no file menu).
- Not yet done: a visual pass in the running app (deferred due to machine memory pressure during implementation).

Deferred follow-up: jump-to-line (`ViewerTarget` has no `line` field; parsed line numbers are display-only today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)