### PR TITLE
fix(product): complete cloud workspace launches in the background (PRO-230)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/ChatView.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/ChatView.tsx
@@ -31,7 +31,6 @@ import { useChatAvailabilityState } from "#product/hooks/chat/derived/use-chat-a
 import { useChatDockInset } from "#product/hooks/chat/ui/use-chat-dock-inset";
 import { useChatPromptAttachments } from "#product/hooks/chat/ui/use-chat-prompt-attachments";
 import { useChatRootFocus } from "#product/hooks/chat/ui/use-chat-root-focus";
-import { useCloudWorkspacePolling } from "#product/hooks/chat/lifecycle/use-cloud-workspace-polling";
 import { useComposerDockSlots } from "#product/hooks/chat/ui/use-composer-dock-slots";
 import { useQueuedPromptEditStatus } from "#product/hooks/chat/ui/use-queued-prompt-edit";
 import { useDebugRenderCount } from "#product/hooks/ui/debug/use-debug-render-count";
@@ -230,7 +229,6 @@ export const ChatView = memo(function ChatView({
     stickyNonDisplacingBottomInsetPx,
   } = useChatDockInset();
 
-  useCloudWorkspacePolling();
   useSelectedCloudRuntimeRehydration(selectedCloudRuntime);
   useSessionErrorAcknowledgement();
 

--- a/apps/packages/product-client/src/hooks/chat/lifecycle/use-cloud-workspace-polling.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/lifecycle/use-cloud-workspace-polling.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
 
-import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
 import {
   buildPendingWorkspaceUiKey,
   buildSubmittingPendingWorkspaceEntry,
+  type PendingWorkspaceEntry,
 } from "#product/lib/domain/workspaces/creation/pending-entry";
 import {
   createEmptySessionRecord,
@@ -26,9 +27,14 @@ const mocks = vi.hoisted(() => ({
   selectWorkspace: vi.fn(),
   materializePendingWorkspaceSessions: vi.fn(),
   trackWorkspaceInteraction: vi.fn(),
+  notifyUnattendedPendingWorkspaceFailure: vi.fn(),
   workspaceCollections: {
     cloudWorkspaces: [] as CloudWorkspaceSummary[],
   },
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/pending-workspace-failure-notice", () => ({
+  notifyUnattendedPendingWorkspaceFailure: mocks.notifyUnattendedPendingWorkspaceFailure,
 }));
 
 vi.mock("#product/stores/preferences/workspace-ui-store", async (importOriginal) => {
@@ -74,6 +80,12 @@ describe("useCloudWorkspacePolling", () => {
     mocks.selectWorkspace.mockReset();
     mocks.materializePendingWorkspaceSessions.mockReset();
     mocks.trackWorkspaceInteraction.mockReset();
+    mocks.notifyUnattendedPendingWorkspaceFailure.mockReset();
+    mocks.materializePendingWorkspaceSessions.mockReturnValue({
+      pendingWorkspaceUiKey: "pending-workspace:attempt-1",
+      projectedSessionCount: 0,
+      projectedSessionIds: [],
+    });
     mocks.workspaceCollections.cloudWorkspaces = [cloudWorkspace({ status: "pending" })];
     useSessionDirectoryStore.getState().clearEntries();
     useSessionTranscriptStore.getState().clearEntries();
@@ -153,7 +165,7 @@ describe("useCloudWorkspacePolling", () => {
     expect(mocks.materializePendingWorkspaceSessions).toHaveBeenCalledWith(
       pendingEntry,
       workspaceId,
-      { eventPrefix: "workspace.cloud_polling" },
+      { eventPrefix: "workspace.cloud_polling", attended: true },
     );
     await waitFor(() => {
       expect(mocks.trackWorkspaceInteraction).toHaveBeenCalledWith(
@@ -257,7 +269,7 @@ describe("useCloudWorkspacePolling", () => {
     expect(mocks.materializePendingWorkspaceSessions).toHaveBeenCalledWith(
       pendingEntry,
       workspaceId,
-      { eventPrefix: "workspace.cloud_polling" },
+      { eventPrefix: "workspace.cloud_polling", attended: true },
     );
     expect(readPendingEntry()).toBeNull();
   });
@@ -306,7 +318,167 @@ describe("useCloudWorkspacePolling", () => {
     expect(mocks.selectWorkspace).not.toHaveBeenCalled();
     expect(mocks.materializePendingWorkspaceSessions).not.toHaveBeenCalled();
   });
+
+  it("finalizes an unattended awaiting entry without moving selection", async () => {
+    const workspaceId = "cloud:cloud-1";
+    const pendingEntry = awaitingEntry("attempt-1", workspaceId);
+    seedRegistry([pendingEntry]);
+    useSessionSelectionStore.setState({
+      selectedWorkspaceId: "cloud:other",
+      selectedLogicalWorkspaceId: "cloud:other",
+      activeSessionId: "session-in-other-workspace",
+    });
+    mocks.refreshCloudWorkspace.mockResolvedValue(cloudWorkspace({ status: "ready" }));
+
+    renderHook(() => useCloudWorkspacePolling());
+
+    await waitFor(() => {
+      expect(readPendingEntry()).toBeNull();
+    });
+    expect(mocks.refreshCloudWorkspace).toHaveBeenCalledWith(workspaceId);
+    expect(mocks.selectWorkspace).not.toHaveBeenCalled();
+    expect(mocks.materializePendingWorkspaceSessions).toHaveBeenCalledWith(
+      pendingEntry,
+      workspaceId,
+      { eventPrefix: "workspace.cloud_polling", attended: false },
+    );
+    const selection = useSessionSelectionStore.getState();
+    expect(selection.selectedWorkspaceId).toBe("cloud:other");
+    expect(selection.activeSessionId).toBe("session-in-other-workspace");
+    expect(selection.workspaceArrivalEvent).toBeNull();
+  });
+
+  it("polls every awaiting entry, not just the selected one", async () => {
+    mocks.workspaceCollections.cloudWorkspaces = [
+      cloudWorkspace({ status: "pending" }),
+      cloudWorkspace({ id: "cloud-2", status: "pending" }),
+    ];
+    seedRegistry([
+      awaitingEntry("attempt-1", "cloud:cloud-1"),
+      awaitingEntry("attempt-2", "cloud:cloud-2"),
+    ]);
+    mocks.refreshCloudWorkspace.mockResolvedValue(cloudWorkspace({ status: "pending" }));
+
+    renderHook(() => useCloudWorkspacePolling());
+
+    await waitFor(() => {
+      expect(mocks.refreshCloudWorkspace).toHaveBeenCalledWith("cloud:cloud-1");
+      expect(mocks.refreshCloudWorkspace).toHaveBeenCalledWith("cloud:cloud-2");
+    });
+  });
+
+  it("polls at most three workspaces per tick", async () => {
+    const workspaceIds = ["cloud-1", "cloud-2", "cloud-3", "cloud-4"];
+    mocks.workspaceCollections.cloudWorkspaces = workspaceIds.map((id) =>
+      cloudWorkspace({ id, status: "pending" })
+    );
+    seedRegistry(workspaceIds.map((id, index) =>
+      awaitingEntry(`attempt-${index + 1}`, `cloud:${id}`)
+    ));
+    mocks.refreshCloudWorkspace.mockResolvedValue(cloudWorkspace({ status: "pending" }));
+
+    renderHook(() => useCloudWorkspacePolling());
+
+    await waitFor(() => {
+      expect(mocks.refreshCloudWorkspace).toHaveBeenCalledTimes(3);
+    });
+    expect(mocks.refreshCloudWorkspace.mock.calls.map(([id]) => id)).toEqual([
+      "cloud:cloud-1",
+      "cloud:cloud-2",
+      "cloud:cloud-3",
+    ]);
+  });
+
+  it("stops polling an entry once it leaves the awaiting state", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.workspaceCollections.cloudWorkspaces = [
+        cloudWorkspace({ status: "pending" }),
+        cloudWorkspace({ id: "cloud-2", status: "pending" }),
+      ];
+      seedRegistry([
+        awaitingEntry("attempt-1", "cloud:cloud-1"),
+        awaitingEntry("attempt-2", "cloud:cloud-2"),
+      ]);
+      mocks.refreshCloudWorkspace.mockImplementation(async (workspaceId: string) =>
+        workspaceId === "cloud:cloud-1"
+          ? cloudWorkspace({ status: "ready" })
+          : cloudWorkspace({ id: "cloud-2", status: "pending" })
+      );
+
+      renderHook(() => useCloudWorkspacePolling());
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(readPendingEntry()).toBeNull();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(9000);
+      });
+      const polledWorkspaceIds = mocks.refreshCloudWorkspace.mock.calls.map(([id]) => id);
+      expect(polledWorkspaceIds.filter((id) => id === "cloud:cloud-1")).toHaveLength(1);
+      expect(polledWorkspaceIds.filter((id) => id === "cloud:cloud-2").length).toBeGreaterThan(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("marks an unattended awaiting entry failed and announces it when readiness fails", async () => {
+    const workspaceId = "cloud:cloud-1";
+    const pendingEntry = awaitingEntry("attempt-1", workspaceId);
+    seedRegistry([pendingEntry]);
+    useSessionSelectionStore.setState({
+      selectedWorkspaceId: "cloud:other",
+      selectedLogicalWorkspaceId: "cloud:other",
+    });
+    mocks.refreshCloudWorkspace.mockResolvedValue(cloudWorkspace({
+      status: "error",
+      lastError: "Provisioning timed out",
+    }));
+
+    renderHook(() => useCloudWorkspacePolling());
+
+    await waitFor(() => {
+      expect(readPendingEntry()).toMatchObject({
+        stage: "failed",
+        workspaceId,
+        errorMessage: "Provisioning timed out",
+        request: { kind: "select-existing", workspaceId },
+      });
+    });
+    expect(mocks.notifyUnattendedPendingWorkspaceFailure).toHaveBeenCalledWith(
+      expect.objectContaining({ attemptId: "attempt-1" }),
+      "Provisioning timed out",
+    );
+    expect(mocks.selectWorkspace).not.toHaveBeenCalled();
+  });
 });
+
+function awaitingEntry(attemptId: string, workspaceId: string) {
+  return {
+    ...buildSubmittingPendingWorkspaceEntry({
+      attemptId,
+      selectedWorkspaceId: null,
+      source: "cloud-created",
+      displayName: "feature-branch",
+      repoLabel: "proliferate-ai/proliferate",
+      baseBranchName: "main",
+      request: { kind: "select-existing" as const, workspaceId },
+    }),
+    stage: "awaiting-cloud-ready" as const,
+    workspaceId,
+  };
+}
+
+function seedRegistry(entries: readonly PendingWorkspaceEntry[]) {
+  useSessionSelectionStore.setState({
+    pendingWorkspaces: entries.reduce(
+      (registry, entry) => upsertPendingWorkspaceEntry(registry, entry),
+      EMPTY_PENDING_WORKSPACE_REGISTRY,
+    ),
+  });
+}
 
 function cloudWorkspace(
   input: Partial<CloudWorkspaceSummary> & {
@@ -314,7 +486,7 @@ function cloudWorkspace(
   },
 ): CloudWorkspaceSummary {
   return {
-    id: "cloud-1",
+    id: input.id ?? "cloud-1",
     displayName: "feature-branch",
     repo: {
       provider: "github",

--- a/apps/packages/product-client/src/hooks/chat/lifecycle/use-cloud-workspace-polling.ts
+++ b/apps/packages/product-client/src/hooks/chat/lifecycle/use-cloud-workspace-polling.ts
@@ -1,9 +1,10 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+import type { PendingWorkspaceEntry } from "#product/lib/domain/workspaces/creation/pending-entry";
+import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
 import {
-  pendingWorkspaceEntryForWorkspaceId,
-} from "#product/lib/domain/workspaces/creation/pending-entry-registry";
-import { useAttendedPendingWorkspaceEntry } from "#product/hooks/workspaces/derived/use-pending-workspace-entries";
+  useAwaitingCloudWorkspaceEntries,
+} from "#product/hooks/workspaces/derived/use-pending-workspace-entries";
 import { useWorkspaces } from "#product/hooks/workspaces/cache/use-workspaces";
 import { useCloudWorkspaceActions } from "#product/hooks/cloud/workflows/use-cloud-workspace-actions";
 import { useWorkspaceSelection } from "#product/hooks/workspaces/workflows/selection/use-workspace-selection";
@@ -15,12 +16,21 @@ import {
   resolveActiveProjectedSessionForPendingWorkspace,
 } from "#product/hooks/workspaces/workflows/pending-workspace-projected-session";
 import {
-  isCloudWorkspacePostReadyPending,
-  resolveCloudWorkspaceStatus,
-  shouldPollCloudWorkspaceForUpdates,
-  shouldShowCloudWorkspaceStatusScreen,
-} from "#product/lib/domain/workspaces/cloud/cloud-workspace-status";
+  getPendingWorkspaceEntry,
+  isAttemptAttended,
+  patchAttempt,
+} from "#product/hooks/workspaces/workflows/pending-workspace-attempt-access";
+import {
+  notifyUnattendedPendingWorkspaceFailure,
+} from "#product/hooks/workspaces/workflows/pending-workspace-failure-notice";
+import {
+  resolveCloudWorkspaceFailureMessage,
+  resolveCloudWorkspacePollAction,
+  resolveCloudWorkspacePollOutcome,
+  selectCloudWorkspacePollBatch,
+} from "#product/lib/domain/workspaces/cloud/cloud-workspace-poll-plan";
 import { parseCloudWorkspaceSyntheticId } from "#product/lib/domain/workspaces/cloud/cloud-ids";
+import { resolveCloudWorkspaceStatus } from "#product/lib/domain/workspaces/cloud/cloud-workspace-status";
 import { trackWorkspaceInteraction } from "#product/stores/preferences/workspace-ui-store";
 import {
   elapsedMs,
@@ -30,223 +40,228 @@ import {
 } from "#product/lib/infra/measurement/measurement-port";
 
 const CLOUD_WORKSPACE_POLL_INTERVAL_MS = 3000;
+/**
+ * Per tick, not in total: the loop rotates through the parked attempts, so a
+ * burst of launches cannot fan out into one refresh per launch per tick.
+ */
+const CLOUD_WORKSPACE_POLL_BATCH_SIZE = 3;
 
+const EMPTY_CLOUD_WORKSPACES: readonly CloudWorkspaceSummary[] = [];
+
+function findCloudWorkspace(
+  cloudWorkspaces: readonly CloudWorkspaceSummary[],
+  workspaceId: string,
+): CloudWorkspaceSummary | null {
+  const cloudWorkspaceId = parseCloudWorkspaceSyntheticId(workspaceId);
+  if (!cloudWorkspaceId) {
+    return null;
+  }
+  return cloudWorkspaces.find((workspace) => workspace.id === cloudWorkspaceId) ?? null;
+}
+
+/**
+ * Drives every attempt parked at `awaiting-cloud-ready`, not just the selected
+ * one. A cloud launch the user switched away from finishes behind them: it
+ * provisions, materializes, and clears its own entry without moving selection
+ * or the active session (PRO-230).
+ */
 export function useCloudWorkspacePolling() {
-  const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
-  const pendingWorkspaceEntry = useAttendedPendingWorkspaceEntry();
-  const setPendingWorkspaceEntry = useSessionSelectionStore((state) => state.setPendingWorkspaceEntry);
-  const clearPendingWorkspaceEntry = useSessionSelectionStore((state) => state.clearPendingWorkspaceEntry);
-  const setWorkspaceArrivalEvent = useSessionSelectionStore((state) => state.setWorkspaceArrivalEvent);
+  const awaitingEntries = useAwaitingCloudWorkspaceEntries();
   const { data: workspaceCollections } = useWorkspaces();
   const { refreshCloudWorkspace } = useCloudWorkspaceActions();
   const { selectWorkspace } = useWorkspaceSelection();
   const materializePendingWorkspaceSessions = usePendingWorkspaceSessionMaterialization();
+  const clearPendingWorkspaceEntry = useSessionSelectionStore((state) => state.clearPendingWorkspaceEntry);
+  const setWorkspaceArrivalEvent = useSessionSelectionStore((state) => state.setWorkspaceArrivalEvent);
 
-  const cloudWorkspaceId = parseCloudWorkspaceSyntheticId(selectedWorkspaceId);
-  const cloudWorkspace = workspaceCollections?.cloudWorkspaces.find(
-    (workspace) => workspace.id === cloudWorkspaceId,
-  ) ?? null;
-  const cloudWorkspaceStatus = resolveCloudWorkspaceStatus(cloudWorkspace);
-  const selectedPendingCloudWorkspaceIsAwaiting = pendingWorkspaceEntry?.workspaceId === selectedWorkspaceId
-    && pendingWorkspaceEntry.stage === "awaiting-cloud-ready";
-  const shouldHandleCachedCloudWorkspaceFailure = Boolean(
-    cloudWorkspace
-    && cloudWorkspaceStatus === "error"
-    && selectedPendingCloudWorkspaceIsAwaiting,
-  );
-  const shouldHandleCachedCloudWorkspaceReady = Boolean(
-    cloudWorkspace
-    && cloudWorkspaceStatus === "ready"
-    && !isCloudWorkspacePostReadyPending(cloudWorkspace)
-    && selectedPendingCloudWorkspaceIsAwaiting,
-  );
-  const shouldPollCloudWorkspace = Boolean(
-    cloudWorkspace
-    && (
-      shouldPollCloudWorkspaceForUpdates(cloudWorkspace)
-      || shouldHandleCachedCloudWorkspaceFailure
-      || shouldHandleCachedCloudWorkspaceReady
-    ),
-  );
+  // The tick reads the newest attempt list and the newest cloud records rather
+  // than closing over them, so a status change cannot restart the interval
+  // mid-flight.
+  const awaitingEntriesRef = useRef<readonly PendingWorkspaceEntry[]>(awaitingEntries);
+  awaitingEntriesRef.current = awaitingEntries;
+  const cloudWorkspacesRef = useRef<readonly CloudWorkspaceSummary[]>(EMPTY_CLOUD_WORKSPACES);
+  cloudWorkspacesRef.current = workspaceCollections?.cloudWorkspaces ?? EMPTY_CLOUD_WORKSPACES;
+  const pollCursorRef = useRef(0);
+
+  const failAwaitingEntry = useCallback((
+    entry: PendingWorkspaceEntry,
+    workspaceId: string,
+    errorMessage: string,
+  ) => {
+    patchAttempt(entry.attemptId, {
+      stage: "failed",
+      workspaceId,
+      request: { kind: "select-existing", workspaceId },
+      errorMessage,
+    });
+    logLatency("workspace.cloud_polling.failed", {
+      workspaceId,
+      pendingAttemptId: entry.attemptId,
+      errorMessage,
+    });
+    // An unattended provisioning failure has no shell to render into, so it
+    // lands on the attempt's own sidebar row plus one toast, exactly as a
+    // create-time failure does.
+    notifyUnattendedPendingWorkspaceFailure(entry, errorMessage);
+  }, []);
+
+  const finalizeAwaitingEntry = useCallback(async (
+    attemptId: string,
+    workspaceId: string,
+  ) => {
+    const entry = getPendingWorkspaceEntry(attemptId);
+    if (!entry || entry.stage !== "awaiting-cloud-ready") {
+      return;
+    }
+    // Attendance is read once, before the force-selection below moves
+    // selection onto the real workspace and makes every later read look
+    // attended.
+    const attended = isAttemptAttended(attemptId);
+    patchAttempt(attemptId, { workspaceId, errorMessage: null });
+    logLatency("workspace.cloud_polling.ready_selection.start", {
+      workspaceId,
+      pendingAttemptId: attemptId,
+      attended,
+    });
+
+    if (attended) {
+      const initialActiveSessionId = resolveActiveProjectedSessionForPendingWorkspace(
+        workspaceId,
+        entry,
+      );
+      try {
+        await selectWorkspace(workspaceId, {
+          force: true,
+          preservePending: true,
+          ...(initialActiveSessionId ? { initialActiveSessionId } : {}),
+        });
+      } catch (error) {
+        const current = getPendingWorkspaceEntry(attemptId);
+        if (current && current.stage !== "failed") {
+          failAwaitingEntry(
+            current,
+            workspaceId,
+            error instanceof Error ? error.message : "Failed to connect the cloud workspace.",
+          );
+        }
+        return;
+      }
+    }
+
+    const current = getPendingWorkspaceEntry(attemptId);
+    if (!current || current.stage !== "awaiting-cloud-ready") {
+      return;
+    }
+    const projectedSessionMaterialization = materializePendingWorkspaceSessions(
+      current,
+      workspaceId,
+      { eventPrefix: "workspace.cloud_polling", attended },
+    );
+    trackWorkspaceInteraction(workspaceId, new Date().toISOString());
+    clearPendingWorkspaceEntry(attemptId);
+    if (attended) {
+      setWorkspaceArrivalEvent(buildWorkspaceArrivalEvent({
+        workspaceId,
+        source: current.source,
+        setupScript: current.setupScript,
+        baseBranchName: current.baseBranchName,
+      }));
+    }
+    logLatency("workspace.cloud_polling.ready", {
+      workspaceId,
+      pendingAttemptId: attemptId,
+      attended,
+      totalElapsedMs: elapsedSince(current.createdAt),
+      projectedSessionCount: projectedSessionMaterialization.projectedSessionCount,
+      projectedSessionIds: projectedSessionMaterialization.projectedSessionIds,
+    });
+  }, [
+    clearPendingWorkspaceEntry,
+    failAwaitingEntry,
+    materializePendingWorkspaceSessions,
+    selectWorkspace,
+    setWorkspaceArrivalEvent,
+  ]);
+
+  const pollAwaitingEntry = useCallback(async (attemptId: string) => {
+    // Re-read by id: the attempt may have been dismissed, failed, or finalized
+    // between the tick being scheduled and it running.
+    const entry = getPendingWorkspaceEntry(attemptId);
+    const workspaceId = entry?.workspaceId ?? null;
+    if (!entry || !workspaceId) {
+      return;
+    }
+    const cachedWorkspace = findCloudWorkspace(cloudWorkspacesRef.current, workspaceId);
+    const action = resolveCloudWorkspacePollAction({ entry, cachedWorkspace });
+    if (action === "skip") {
+      return;
+    }
+    if (action === "fail-cached" && cachedWorkspace) {
+      failAwaitingEntry(entry, workspaceId, resolveCloudWorkspaceFailureMessage(cachedWorkspace));
+      return;
+    }
+
+    const pollStartedAt = startLatencyTimer();
+    logLatency("workspace.cloud_polling.start", {
+      workspaceId,
+      pendingAttemptId: attemptId,
+      status: resolveCloudWorkspaceStatus(cachedWorkspace),
+      pendingElapsedMs: elapsedSince(entry.createdAt),
+    });
+
+    // Keep polling even if a refresh fails: the next tick retries.
+    const workspace = await refreshCloudWorkspace(workspaceId).catch(() => null);
+    if (!workspace) {
+      return;
+    }
+    const outcome = resolveCloudWorkspacePollOutcome(workspace);
+    logLatency("workspace.cloud_polling.refreshed", {
+      workspaceId,
+      pendingAttemptId: attemptId,
+      outcome,
+      pollElapsedMs: elapsedMs(pollStartedAt),
+    });
+
+    if (outcome === "failed") {
+      const current = getPendingWorkspaceEntry(attemptId);
+      if (current && current.stage === "awaiting-cloud-ready") {
+        failAwaitingEntry(current, workspaceId, resolveCloudWorkspaceFailureMessage(workspace));
+      }
+      return;
+    }
+    if (outcome === "ready") {
+      await finalizeAwaitingEntry(attemptId, workspaceId);
+    }
+  }, [failAwaitingEntry, finalizeAwaitingEntry, refreshCloudWorkspace]);
+
+  // Restarting on the attempt set alone keeps one interval alive across the
+  // status churn the polling itself causes.
+  const awaitingAttemptKey = awaitingEntries.map((entry) => entry.attemptId).join("|");
 
   useEffect(() => {
-    const shouldPauseForFailedPending = pendingWorkspaceEntry?.workspaceId === selectedWorkspaceId
-      && pendingWorkspaceEntry.stage === "failed";
-
-    if (
-      !selectedWorkspaceId
-      || !cloudWorkspaceId
-      || !shouldPollCloudWorkspace
-      || shouldPauseForFailedPending
-    ) {
+    if (!awaitingAttemptKey) {
       return;
     }
 
     let cancelled = false;
     let timer: number | null = null;
-    logLatency("workspace.cloud_polling.start", {
-      workspaceId: selectedWorkspaceId,
-      status: cloudWorkspaceStatus,
-      pendingStage: pendingWorkspaceEntry?.stage ?? null,
-      pendingElapsedMs: pendingWorkspaceEntry ? elapsedSince(pendingWorkspaceEntry.createdAt) : null,
-    });
 
-    if (shouldHandleCachedCloudWorkspaceFailure && cloudWorkspace && pendingWorkspaceEntry) {
-      setPendingWorkspaceEntry({
-        ...pendingWorkspaceEntry,
-        stage: "failed",
-        request: { kind: "select-existing", workspaceId: selectedWorkspaceId },
-        errorMessage: cloudWorkspace.lastError
-          ?? cloudWorkspace.statusDetail
-          ?? "Cloud workspace provisioning failed.",
-      });
-      logLatency("workspace.cloud_polling.failed", {
-        workspaceId: selectedWorkspaceId,
-        pendingAttemptId: pendingWorkspaceEntry.attemptId,
-        errorMessage: cloudWorkspace.lastError ?? cloudWorkspace.statusDetail ?? null,
-      });
-      return;
-    }
-
-    const poll = async () => {
-      let shouldScheduleNextPoll = true;
-      const pollStartedAt = startLatencyTimer();
-
-      try {
-        const workspace = await refreshCloudWorkspace(selectedWorkspaceId);
-        const refreshedStatus = resolveCloudWorkspaceStatus(workspace);
-        logLatency("workspace.cloud_polling.refreshed", {
-          workspaceId: selectedWorkspaceId,
-          status: refreshedStatus,
-          pollElapsedMs: elapsedMs(pollStartedAt),
-          pendingElapsedMs: pendingWorkspaceEntry ? elapsedSince(pendingWorkspaceEntry.createdAt) : null,
-        });
-        if (cancelled) {
-          return;
-        }
-
-        if (refreshedStatus === "error") {
-          shouldScheduleNextPoll = false;
-          const pending = pendingWorkspaceEntryForWorkspaceId(
-            useSessionSelectionStore.getState().pendingWorkspaces,
-            selectedWorkspaceId,
-          );
-          if (
-            pending
-            && pending.workspaceId === selectedWorkspaceId
-            && pending.stage === "awaiting-cloud-ready"
-          ) {
-            setPendingWorkspaceEntry({
-              ...pending,
-              stage: "failed",
-              request: { kind: "select-existing", workspaceId: selectedWorkspaceId },
-              errorMessage: workspace.lastError
-                ?? workspace.statusDetail
-                ?? "Cloud workspace provisioning failed.",
-            });
-          }
-          logLatency("workspace.cloud_polling.failed", {
-            workspaceId: selectedWorkspaceId,
-            pendingAttemptId: pending?.attemptId ?? null,
-            errorMessage: workspace.lastError ?? workspace.statusDetail ?? null,
-          });
-          return;
-        }
-
-        if (refreshedStatus === "ready" && !isCloudWorkspacePostReadyPending(workspace)) {
-          shouldScheduleNextPoll = false;
-          const pending = pendingWorkspaceEntryForWorkspaceId(
-            useSessionSelectionStore.getState().pendingWorkspaces,
-            selectedWorkspaceId,
-          );
-          const shouldPreservePending = pending?.workspaceId === selectedWorkspaceId
-            && pending.stage === "awaiting-cloud-ready";
-          const initialActiveSessionId = shouldPreservePending
-            ? resolveActiveProjectedSessionForPendingWorkspace(selectedWorkspaceId, pending)
-            : null;
-          logLatency("workspace.cloud_polling.ready_selection.start", {
-            workspaceId: selectedWorkspaceId,
-            pendingAttemptId: pending?.attemptId ?? null,
-            shouldPreservePending,
-            initialActiveSessionId,
-          });
-
-          try {
-            await selectWorkspace(selectedWorkspaceId, {
-              force: true,
-              preservePending: shouldPreservePending,
-              ...(initialActiveSessionId ? { initialActiveSessionId } : {}),
-            });
-          } catch (error) {
-            if (
-              pending
-              && pending.workspaceId === selectedWorkspaceId
-              && pending.stage !== "failed"
-            ) {
-              setPendingWorkspaceEntry({
-                ...pending,
-                stage: "failed",
-                request: { kind: "select-existing", workspaceId: selectedWorkspaceId },
-                errorMessage: error instanceof Error
-                  ? error.message
-                  : "Failed to connect the cloud workspace.",
-              });
-            }
-            logLatency("workspace.cloud_polling.ready_selection.failed", {
-              workspaceId: selectedWorkspaceId,
-              pendingAttemptId: pending?.attemptId ?? null,
-              errorMessage: error instanceof Error ? error.message : String(error),
-            });
-            return;
-          }
-
-          const currentPending = pendingWorkspaceEntryForWorkspaceId(
-            useSessionSelectionStore.getState().pendingWorkspaces,
-            selectedWorkspaceId,
-          );
-          if (
-            currentPending
-            && currentPending.workspaceId === selectedWorkspaceId
-            && currentPending.stage === "awaiting-cloud-ready"
-          ) {
-            const projectedSessionMaterialization = materializePendingWorkspaceSessions(
-              currentPending,
-              selectedWorkspaceId,
-              { eventPrefix: "workspace.cloud_polling" },
-            );
-            trackWorkspaceInteraction(selectedWorkspaceId, new Date().toISOString());
-            clearPendingWorkspaceEntry(currentPending.attemptId);
-            setWorkspaceArrivalEvent(buildWorkspaceArrivalEvent({
-              workspaceId: selectedWorkspaceId,
-              source: currentPending.source,
-              setupScript: currentPending.setupScript,
-              baseBranchName: currentPending.baseBranchName,
-            }));
-            logLatency("workspace.cloud_polling.ready", {
-              workspaceId: selectedWorkspaceId,
-              totalElapsedMs: elapsedSince(currentPending.createdAt),
-              projectedSessionCount: projectedSessionMaterialization.projectedSessionCount,
-              projectedSessionIds: projectedSessionMaterialization.projectedSessionIds,
-            });
-          }
-          return;
-        }
-
-        if (!shouldShowCloudWorkspaceStatusScreen(workspace)) {
-          shouldScheduleNextPoll = false;
-        }
-      } catch {
-        // Keep polling even if a refresh fails.
-      } finally {
-        if (!cancelled && shouldScheduleNextPoll) {
-          timer = window.setTimeout(() => {
-            void poll();
-          }, CLOUD_WORKSPACE_POLL_INTERVAL_MS);
-        }
+    const runTick = async () => {
+      const { batch, nextCursor } = selectCloudWorkspacePollBatch(
+        awaitingEntriesRef.current,
+        pollCursorRef.current,
+        CLOUD_WORKSPACE_POLL_BATCH_SIZE,
+      );
+      pollCursorRef.current = nextCursor;
+      await Promise.all(batch.map((entry) => pollAwaitingEntry(entry.attemptId)));
+      if (!cancelled) {
+        timer = window.setTimeout(() => {
+          void runTick();
+        }, CLOUD_WORKSPACE_POLL_INTERVAL_MS);
       }
     };
 
-    void poll();
+    void runTick();
 
     return () => {
       cancelled = true;
@@ -254,19 +269,5 @@ export function useCloudWorkspacePolling() {
         window.clearTimeout(timer);
       }
     };
-  }, [
-    cloudWorkspace,
-    cloudWorkspaceId,
-    materializePendingWorkspaceSessions,
-    pendingWorkspaceEntry,
-    refreshCloudWorkspace,
-    selectWorkspace,
-    selectedWorkspaceId,
-    clearPendingWorkspaceEntry,
-    setPendingWorkspaceEntry,
-    setWorkspaceArrivalEvent,
-    shouldHandleCachedCloudWorkspaceFailure,
-    shouldHandleCachedCloudWorkspaceReady,
-    shouldPollCloudWorkspace,
-  ]);
+  }, [awaitingAttemptKey, pollAwaitingEntry]);
 }

--- a/apps/packages/product-client/src/hooks/home/lifecycle/use-home-deferred-launch-runner.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/lifecycle/use-home-deferred-launch-runner.test.tsx
@@ -6,8 +6,6 @@ import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud
 import type { CreateSessionWithResolvedConfigOptions } from "#product/hooks/sessions/workflows/session-creation-types";
 import {
   buildPendingWorkspaceUiKey,
-  buildSubmittingPendingWorkspaceEntry,
-  type PendingWorkspaceEntry,
 } from "#product/lib/domain/workspaces/creation/pending-entry";
 import {
   EMPTY_PENDING_WORKSPACE_REGISTRY,
@@ -19,12 +17,26 @@ import {
 } from "#product/stores/home/deferred-home-launch-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useHomeDeferredLaunchRunner } from "#product/hooks/home/lifecycle/use-home-deferred-launch-runner";
+import {
+  awaitingCloudWorkspaceEntryFixture as awaitingEntry,
+  cloudWorkspaceFixture as cloudWorkspace,
+} from "#product/test/cloud-workspace-fixtures";
 
 const mocks = vi.hoisted(() => ({
   createSessionWithResolvedConfig: vi.fn(),
+  notifyQueuedPromptSendFailure: vi.fn(),
+  selectWorkspace: vi.fn(),
   workspaceCollections: {
     cloudWorkspaces: [] as CloudWorkspaceSummary[],
   },
+}));
+
+vi.mock("#product/hooks/sessions/workflows/queued-prompt-failure-notice", () => ({
+  notifyQueuedPromptSendFailure: mocks.notifyQueuedPromptSendFailure,
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/selection/use-workspace-selection", () => ({
+  useWorkspaceSelection: () => ({ selectWorkspace: mocks.selectWorkspace }),
 }));
 
 vi.mock("#product/hooks/workspaces/cache/use-workspaces", () => ({
@@ -43,6 +55,9 @@ vi.mock("#product/hooks/sessions/workflows/use-session-creation-actions", () => 
 describe("useHomeDeferredLaunchRunner", () => {
   beforeEach(() => {
     mocks.createSessionWithResolvedConfig.mockReset();
+    mocks.notifyQueuedPromptSendFailure.mockReset();
+    mocks.selectWorkspace.mockReset();
+    mocks.selectWorkspace.mockResolvedValue(undefined);
     // Standing in for the real create: activating a session is exactly the
     // camera move a background promotion must not make.
     mocks.createSessionWithResolvedConfig.mockImplementation(
@@ -192,6 +207,61 @@ describe("useHomeDeferredLaunchRunner", () => {
       .toBe("pending");
   });
 
+  it("announces a background send failure with its workspace instead of the composer copy", async () => {
+    // The create resolves at prompt enqueue, so the failure arrives on the
+    // callback rather than the await below. Unattended it must not be reported
+    // as "your message is still in the composer" — there is no composer holding
+    // it, and the toast would name no workspace (PRO-230 review finding 3).
+    mocks.workspaceCollections.cloudWorkspaces = [cloudWorkspace({ status: "ready" })];
+    mocks.createSessionWithResolvedConfig.mockImplementation(
+      async (options: CreateSessionWithResolvedConfigOptions) => {
+        options.onQueuedPromptFailure?.(new Error("Runtime gateway refused the prompt"));
+        return "session-1";
+      },
+    );
+    enqueueLaunch(deferredLaunch());
+    useSessionSelectionStore.setState({
+      selectedWorkspaceId: "cloud:other",
+      selectedLogicalWorkspaceId: "cloud:other",
+    });
+
+    renderHook(() => useHomeDeferredLaunchRunner());
+
+    await waitFor(() => {
+      expect(mocks.notifyQueuedPromptSendFailure).toHaveBeenCalledTimes(1);
+    });
+    const notice = mocks.notifyQueuedPromptSendFailure.mock.calls[0]?.[0];
+    expect(notice).toMatchObject({
+      workspaceId: "cloud:cloud-1",
+      workspaceName: "feature-branch",
+    });
+    expect(notice.cause).toContain("Runtime gateway refused the prompt");
+
+    // Its Show action opens the workspace the prompt was meant for.
+    notice.showWorkspace();
+    expect(mocks.selectWorkspace).toHaveBeenCalledWith("cloud:cloud-1", { force: true });
+  });
+
+  it("leaves an attended send failure to the composer-owned announcement", async () => {
+    mocks.workspaceCollections.cloudWorkspaces = [cloudWorkspace({ status: "ready" })];
+    enqueueLaunch(deferredLaunch());
+    useSessionSelectionStore.setState({
+      selectedWorkspaceId: "cloud:cloud-1",
+      selectedLogicalWorkspaceId: "cloud:cloud-1",
+    });
+
+    renderHook(() => useHomeDeferredLaunchRunner());
+
+    await waitFor(() => {
+      expect(mocks.createSessionWithResolvedConfig).toHaveBeenCalledTimes(1);
+    });
+    // No callback passed: the user is watching this launch and their composer
+    // does hold the text, so the creation workflow's own copy is correct.
+    const options = mocks.createSessionWithResolvedConfig.mock.calls[0]?.[0];
+    expect(options.onQueuedPromptFailure).toBeUndefined();
+    expect(mocks.notifyQueuedPromptSendFailure).not.toHaveBeenCalled();
+  });
+
   it("releases the queued prompt when the launch's attempt failed", async () => {
     mocks.workspaceCollections.cloudWorkspaces = [cloudWorkspace({ status: "pending" })];
     enqueueLaunch(deferredLaunch());
@@ -233,53 +303,4 @@ function deferredLaunch(
 
 function enqueueLaunch(launch: DeferredHomeLaunch) {
   useDeferredHomeLaunchStore.getState().enqueue(launch);
-}
-
-function awaitingEntry(attemptId: string, workspaceId: string): PendingWorkspaceEntry {
-  return {
-    ...buildSubmittingPendingWorkspaceEntry({
-      attemptId,
-      selectedWorkspaceId: null,
-      source: "cloud-created",
-      displayName: "feature-branch",
-      repoLabel: "proliferate-ai/proliferate",
-      baseBranchName: "main",
-      request: { kind: "select-existing", workspaceId },
-    }),
-    stage: "awaiting-cloud-ready",
-    workspaceId,
-  };
-}
-
-function cloudWorkspace(
-  input: Partial<CloudWorkspaceSummary> & {
-    status: CloudWorkspaceSummary["status"];
-  },
-): CloudWorkspaceSummary {
-  return {
-    id: input.id ?? "cloud-1",
-    displayName: "feature-branch",
-    repo: {
-      provider: "github",
-      owner: "proliferate-ai",
-      name: "proliferate",
-      branch: "feature-branch",
-      baseBranch: "main",
-    },
-    status: input.status,
-    workspaceStatus: input.status,
-    runtime: undefined,
-    statusDetail: null,
-    lastError: null,
-    templateVersion: null,
-    updatedAt: null,
-    createdAt: null,
-    readyAt: input.status === "ready" ? "2026-04-14T00:00:00Z" : null,
-    postReadyPhase: "",
-    postReadyFilesTotal: 0,
-    postReadyFilesApplied: 0,
-    postReadyStartedAt: null,
-    postReadyCompletedAt: null,
-    visibility: "private",
-  };
 }

--- a/apps/packages/product-client/src/hooks/home/lifecycle/use-home-deferred-launch-runner.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/lifecycle/use-home-deferred-launch-runner.test.tsx
@@ -1,0 +1,285 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
+import type { CreateSessionWithResolvedConfigOptions } from "#product/hooks/sessions/workflows/session-creation-types";
+import {
+  buildPendingWorkspaceUiKey,
+  buildSubmittingPendingWorkspaceEntry,
+  type PendingWorkspaceEntry,
+} from "#product/lib/domain/workspaces/creation/pending-entry";
+import {
+  EMPTY_PENDING_WORKSPACE_REGISTRY,
+  upsertPendingWorkspaceEntry,
+} from "#product/lib/domain/workspaces/creation/pending-entry-registry";
+import {
+  useDeferredHomeLaunchStore,
+  type DeferredHomeLaunch,
+} from "#product/stores/home/deferred-home-launch-store";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+import { useHomeDeferredLaunchRunner } from "#product/hooks/home/lifecycle/use-home-deferred-launch-runner";
+
+const mocks = vi.hoisted(() => ({
+  createSessionWithResolvedConfig: vi.fn(),
+  workspaceCollections: {
+    cloudWorkspaces: [] as CloudWorkspaceSummary[],
+  },
+}));
+
+vi.mock("#product/hooks/workspaces/cache/use-workspaces", () => ({
+  useWorkspaces: () => ({
+    data: mocks.workspaceCollections,
+    isSuccess: true,
+  }),
+}));
+
+vi.mock("#product/hooks/sessions/workflows/use-session-creation-actions", () => ({
+  useSessionCreationActions: () => ({
+    createSessionWithResolvedConfig: mocks.createSessionWithResolvedConfig,
+  }),
+}));
+
+describe("useHomeDeferredLaunchRunner", () => {
+  beforeEach(() => {
+    mocks.createSessionWithResolvedConfig.mockReset();
+    // Standing in for the real create: activating a session is exactly the
+    // camera move a background promotion must not make.
+    mocks.createSessionWithResolvedConfig.mockImplementation(
+      async (options: CreateSessionWithResolvedConfigOptions) => {
+        const sessionId = `session-for:${options.workspaceId}`;
+        if (options.activateOnCreate !== false) {
+          useSessionSelectionStore.setState({
+            activeSessionId: sessionId,
+            selectedWorkspaceId: options.workspaceId ?? null,
+          });
+        }
+        return sessionId;
+      },
+    );
+    mocks.workspaceCollections.cloudWorkspaces = [];
+    useDeferredHomeLaunchStore.setState({ launches: {} });
+    useSessionSelectionStore.setState({
+      pendingWorkspaces: EMPTY_PENDING_WORKSPACE_REGISTRY,
+      selectedLogicalWorkspaceId: null,
+      selectedWorkspaceId: null,
+      activeSessionId: null,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("promotes a background launch without stealing selection or the active session", async () => {
+    mocks.workspaceCollections.cloudWorkspaces = [cloudWorkspace({ status: "ready" })];
+    enqueueLaunch(deferredLaunch());
+    useSessionSelectionStore.setState({
+      selectedWorkspaceId: "cloud:other",
+      selectedLogicalWorkspaceId: "cloud:other",
+      activeSessionId: "session-in-other-workspace",
+    });
+
+    renderHook(() => useHomeDeferredLaunchRunner());
+
+    await waitFor(() => {
+      expect(mocks.createSessionWithResolvedConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workspaceId: "cloud:cloud-1",
+          text: "run the migration",
+          activateOnCreate: false,
+          targetWorkspaceUiKey: "cloud:cloud-1",
+        }),
+      );
+    });
+    const selection = useSessionSelectionStore.getState();
+    expect(selection.activeSessionId).toBe("session-in-other-workspace");
+    expect(selection.selectedWorkspaceId).toBe("cloud:other");
+    await waitFor(() => {
+      expect(useDeferredHomeLaunchStore.getState().launches["cloud-1:attempt-1"]).toBeUndefined();
+    });
+  });
+
+  it("still activates the created session when the user is attending the launch", async () => {
+    mocks.workspaceCollections.cloudWorkspaces = [cloudWorkspace({ status: "ready" })];
+    enqueueLaunch(deferredLaunch());
+    useSessionSelectionStore.setState({
+      selectedWorkspaceId: "cloud:cloud-1",
+      selectedLogicalWorkspaceId: "cloud:cloud-1",
+    });
+
+    renderHook(() => useHomeDeferredLaunchRunner());
+
+    await waitFor(() => {
+      expect(mocks.createSessionWithResolvedConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workspaceId: "cloud:cloud-1",
+          activateOnCreate: true,
+          targetWorkspaceUiKey: null,
+        }),
+      );
+    });
+    await waitFor(() => {
+      expect(useSessionSelectionStore.getState().activeSessionId)
+        .toBe("session-for:cloud:cloud-1");
+    });
+  });
+
+  it("treats the pending shell of an attended attempt as attended", async () => {
+    mocks.workspaceCollections.cloudWorkspaces = [cloudWorkspace({ status: "ready" })];
+    const entry = awaitingEntry("attempt-1", "cloud:cloud-1");
+    enqueueLaunch(deferredLaunch());
+    useSessionSelectionStore.setState({
+      pendingWorkspaces: upsertPendingWorkspaceEntry(EMPTY_PENDING_WORKSPACE_REGISTRY, entry),
+      selectedLogicalWorkspaceId: buildPendingWorkspaceUiKey(entry),
+      selectedWorkspaceId: null,
+    });
+
+    renderHook(() => useHomeDeferredLaunchRunner());
+
+    await waitFor(() => {
+      expect(mocks.createSessionWithResolvedConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ activateOnCreate: true }),
+      );
+    });
+  });
+
+  it("promotes two deferred launches independently", async () => {
+    mocks.workspaceCollections.cloudWorkspaces = [
+      cloudWorkspace({ status: "ready" }),
+      cloudWorkspace({ id: "cloud-2", status: "ready" }),
+    ];
+    enqueueLaunch(deferredLaunch());
+    enqueueLaunch(deferredLaunch({
+      id: "cloud-2:attempt-2",
+      workspaceId: "cloud:cloud-2",
+      cloudWorkspaceId: "cloud-2",
+      cloudAttemptId: "attempt-2",
+      promptText: "run the backfill",
+    }));
+
+    renderHook(() => useHomeDeferredLaunchRunner());
+
+    await waitFor(() => {
+      expect(mocks.createSessionWithResolvedConfig).toHaveBeenCalledTimes(2);
+    });
+    expect(mocks.createSessionWithResolvedConfig.mock.calls.map(([options]) => options.workspaceId))
+      .toEqual(["cloud:cloud-1", "cloud:cloud-2"]);
+    await waitFor(() => {
+      expect(Object.keys(useDeferredHomeLaunchStore.getState().launches)).toEqual([]);
+    });
+  });
+
+  it("waits while one launch's workspace is still provisioning", async () => {
+    mocks.workspaceCollections.cloudWorkspaces = [
+      cloudWorkspace({ status: "ready" }),
+      cloudWorkspace({ id: "cloud-2", status: "pending" }),
+    ];
+    enqueueLaunch(deferredLaunch());
+    enqueueLaunch(deferredLaunch({
+      id: "cloud-2:attempt-2",
+      workspaceId: "cloud:cloud-2",
+      cloudWorkspaceId: "cloud-2",
+      cloudAttemptId: "attempt-2",
+    }));
+
+    renderHook(() => useHomeDeferredLaunchRunner());
+
+    await waitFor(() => {
+      expect(mocks.createSessionWithResolvedConfig).toHaveBeenCalledTimes(1);
+    });
+    expect(useDeferredHomeLaunchStore.getState().launches["cloud-2:attempt-2"]?.status)
+      .toBe("pending");
+  });
+
+  it("releases the queued prompt when the launch's attempt failed", async () => {
+    mocks.workspaceCollections.cloudWorkspaces = [cloudWorkspace({ status: "pending" })];
+    enqueueLaunch(deferredLaunch());
+    useSessionSelectionStore.setState({
+      pendingWorkspaces: upsertPendingWorkspaceEntry(
+        EMPTY_PENDING_WORKSPACE_REGISTRY,
+        { ...awaitingEntry("attempt-1", "cloud:cloud-1"), stage: "failed" },
+      ),
+    });
+
+    renderHook(() => useHomeDeferredLaunchRunner());
+
+    await waitFor(() => {
+      expect(useDeferredHomeLaunchStore.getState().launches["cloud-1:attempt-1"]).toBeUndefined();
+    });
+    expect(mocks.createSessionWithResolvedConfig).not.toHaveBeenCalled();
+  });
+});
+
+function deferredLaunch(
+  overrides: Partial<DeferredHomeLaunch> = {},
+): DeferredHomeLaunch {
+  return {
+    id: "cloud-1:attempt-1",
+    status: "pending",
+    workspaceId: "cloud:cloud-1",
+    cloudWorkspaceId: "cloud-1",
+    cloudAttemptId: "attempt-1",
+    agentKind: "claude",
+    modelId: "claude-sonnet-4.5",
+    modeId: null,
+    promptText: "run the migration",
+    promptId: "prompt-1",
+    launchIntentId: "intent-1",
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function enqueueLaunch(launch: DeferredHomeLaunch) {
+  useDeferredHomeLaunchStore.getState().enqueue(launch);
+}
+
+function awaitingEntry(attemptId: string, workspaceId: string): PendingWorkspaceEntry {
+  return {
+    ...buildSubmittingPendingWorkspaceEntry({
+      attemptId,
+      selectedWorkspaceId: null,
+      source: "cloud-created",
+      displayName: "feature-branch",
+      repoLabel: "proliferate-ai/proliferate",
+      baseBranchName: "main",
+      request: { kind: "select-existing", workspaceId },
+    }),
+    stage: "awaiting-cloud-ready",
+    workspaceId,
+  };
+}
+
+function cloudWorkspace(
+  input: Partial<CloudWorkspaceSummary> & {
+    status: CloudWorkspaceSummary["status"];
+  },
+): CloudWorkspaceSummary {
+  return {
+    id: input.id ?? "cloud-1",
+    displayName: "feature-branch",
+    repo: {
+      provider: "github",
+      owner: "proliferate-ai",
+      name: "proliferate",
+      branch: "feature-branch",
+      baseBranch: "main",
+    },
+    status: input.status,
+    workspaceStatus: input.status,
+    runtime: undefined,
+    statusDetail: null,
+    lastError: null,
+    templateVersion: null,
+    updatedAt: null,
+    createdAt: null,
+    readyAt: input.status === "ready" ? "2026-04-14T00:00:00Z" : null,
+    postReadyPhase: "",
+    postReadyFilesTotal: 0,
+    postReadyFilesApplied: 0,
+    postReadyStartedAt: null,
+    postReadyCompletedAt: null,
+    visibility: "private",
+  };
+}

--- a/apps/packages/product-client/src/hooks/home/lifecycle/use-home-deferred-launch-runner.ts
+++ b/apps/packages/product-client/src/hooks/home/lifecycle/use-home-deferred-launch-runner.ts
@@ -3,6 +3,13 @@ import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud
 import { useWorkspaces } from "#product/hooks/workspaces/cache/use-workspaces";
 import { useSessionCreationActions } from "#product/hooks/sessions/workflows/use-session-creation-actions";
 import {
+  notifyQueuedPromptSendFailure,
+} from "#product/hooks/sessions/workflows/queued-prompt-failure-notice";
+import {
+  formatSessionCreateCause,
+} from "#product/lib/domain/sessions/creation/create-session-error";
+import { useWorkspaceSelection } from "#product/hooks/workspaces/workflows/selection/use-workspace-selection";
+import {
   useDeferredHomeLaunchStore,
   type DeferredHomeLaunch,
 } from "#product/stores/home/deferred-home-launch-store";
@@ -48,10 +55,10 @@ export function useHomeDeferredLaunchRunner() {
   const launchesById = useDeferredHomeLaunchStore((state) => state.launches);
   const pendingWorkspaces = useSessionSelectionStore((state) => state.pendingWorkspaces);
   const markConsuming = useDeferredHomeLaunchStore((state) => state.markConsuming);
-  const markPending = useDeferredHomeLaunchStore((state) => state.markPending);
   const clear = useDeferredHomeLaunchStore((state) => state.clear);
   const failLaunchIntent = useChatLaunchIntentStore((state) => state.fail);
   const { createSessionWithResolvedConfig } = useSessionCreationActions();
+  const { selectWorkspace } = useWorkspaceSelection();
   const {
     data: workspaceCollections,
     isSuccess: workspaceCollectionsLoaded,
@@ -73,6 +80,8 @@ export function useHomeDeferredLaunchRunner() {
     }
     return byId;
   }, [workspaceCollections?.cloudWorkspaces]);
+  const cloudWorkspacesByIdRef = useRef(cloudWorkspacesById);
+  cloudWorkspacesByIdRef.current = cloudWorkspacesById;
 
   useEffect(() => {
     const now = Date.now();
@@ -151,10 +160,36 @@ export function useHomeDeferredLaunchRunner() {
     }
   }, [clear, failedLaunchKey, failLaunchIntent]);
 
-  const consumeLaunch = useCallback(async (
+  // Presentation only. By the time this fires the create has already resolved
+  // (the prompt was enqueued), so the launch and its intent are cleared and the
+  // creation workflow has run its own cleanup; what is missing is a report that
+  // names the workspace nobody is looking at.
+  const announceBackgroundSendFailure = useCallback((
     launch: DeferredHomeLaunch,
-    isCancelled: () => boolean,
+    error: unknown,
   ) => {
+    notifyQueuedPromptSendFailure({
+      workspaceId: launch.workspaceId,
+      workspaceName: cloudWorkspacesByIdRef.current.get(launch.cloudWorkspaceId)?.displayName
+        ?? null,
+      cause: formatSessionCreateCause(error),
+      showWorkspace: () => {
+        void selectWorkspace(launch.workspaceId, { force: true }).catch(() => {
+          // The toast is the report; a failed open re-reports itself through
+          // the selection path's own error handling.
+        });
+      },
+    });
+  }, [selectWorkspace]);
+
+  // `markConsuming` is the claim: it removes the launch from the ready bucket,
+  // which re-runs the effect that started this call. So a "was the effect torn
+  // down mid-flight?" check would be true for every failure and would put the
+  // launch straight back to pending — an unbounded retry of a launch that
+  // failed for a reason that will not change (a blocked runtime, a missing
+  // workspace). The claim is single-flight on its own, so a failure is reported
+  // instead of retried (PRO-230 review finding 6).
+  const consumeLaunch = useCallback(async (launch: DeferredHomeLaunch) => {
     if (!markConsuming(launch.id)) {
       return;
     }
@@ -180,16 +215,21 @@ export function useHomeDeferredLaunchRunner() {
         activateOnCreate: attended,
         targetWorkspaceUiKey: attended ? null : launch.workspaceId,
         ...(launch.modeId ? { modeId: launch.modeId } : {}),
+        // A create carrying a prompt resolves at enqueue, so a send that fails
+        // downstream never reaches the catch below. Attended, the composer copy
+        // the creation workflow raises is right and stays. Unattended it is
+        // not — no composer holds this prompt — so the announcement moves here,
+        // where the workspace is known (PRO-230 review finding 3).
+        ...(attended ? {} : {
+          onQueuedPromptFailure: (error: unknown) => {
+            announceBackgroundSendFailure(launch, error);
+          },
+        }),
       });
       // Clear even if the hook re-ran mid-flight; the prompt was sent, so a remount must not retry it.
       clear(launch.id);
       useChatLaunchIntentStore.getState().clear(launch.launchIntentId);
     } catch {
-      if (isCancelled()) {
-        markPending(launch.id);
-        return;
-      }
-
       const stillExists = knownCloudWorkspaceIdsRef.current.has(launch.cloudWorkspaceId);
       if (!stillExists) {
         clear(launch.id);
@@ -209,11 +249,11 @@ export function useHomeDeferredLaunchRunner() {
       showToast("Cloud workspace is ready, but the queued prompt could not be sent.");
     }
   }, [
+    announceBackgroundSendFailure,
     clear,
     createSessionWithResolvedConfig,
     failLaunchIntent,
     markConsuming,
-    markPending,
     showToast,
   ]);
 
@@ -226,15 +266,10 @@ export function useHomeDeferredLaunchRunner() {
       return;
     }
 
-    let cancelled = false;
     // Each launch consumes on its own; `markConsuming` is the single-flight
     // guard, so a second launch becoming ready cannot restart the first.
     for (const launch of readyLaunchesRef.current) {
-      void consumeLaunch(launch, () => cancelled);
+      void consumeLaunch(launch);
     }
-
-    return () => {
-      cancelled = true;
-    };
   }, [consumeLaunch, readyLaunchKey]);
 }

--- a/apps/packages/product-client/src/hooks/home/lifecycle/use-home-deferred-launch-runner.ts
+++ b/apps/packages/product-client/src/hooks/home/lifecycle/use-home-deferred-launch-runner.ts
@@ -1,18 +1,32 @@
-import { useEffect, useMemo } from "react";
-import { useSelectedCloudRuntimeState } from "#product/hooks/workspaces/facade/use-selected-cloud-runtime-state";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
 import { useWorkspaces } from "#product/hooks/workspaces/cache/use-workspaces";
 import { useSessionCreationActions } from "#product/hooks/sessions/workflows/use-session-creation-actions";
-import { useDeferredHomeLaunchStore } from "#product/stores/home/deferred-home-launch-store";
+import {
+  useDeferredHomeLaunchStore,
+  type DeferredHomeLaunch,
+} from "#product/stores/home/deferred-home-launch-store";
 import {
   resolveChatLaunchRetryMode,
   type ChatLaunchRetryMode,
 } from "#product/lib/domain/chat/launch/launch-intent";
 import { launchIntent } from "#product/lib/domain/chat/launch/launch-intent-registry";
+import {
+  resolveDeferredLaunchReadiness,
+} from "#product/lib/domain/home/deferred-launch-readiness";
+import {
+  pendingWorkspaceEntry,
+} from "#product/lib/domain/workspaces/creation/pending-entry-registry";
+import {
+  isLaunchAttemptAttended,
+} from "#product/hooks/workspaces/workflows/pending-workspace-attempt-access";
 import { useChatLaunchIntentStore } from "#product/stores/chat/chat-launch-intent-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useToastStore } from "#product/stores/toast/toast-store";
 
 const DEFERRED_HOME_LAUNCH_STALE_MS = 60 * 60 * 1000;
+
+const EMPTY_DEFERRED_LAUNCHES: readonly DeferredHomeLaunch[] = [];
 
 function shouldClearAsMissing(input: {
   cloudWorkspaceId: string;
@@ -31,14 +45,13 @@ function launchFailureRetryMode(intentId: string): ChatLaunchRetryMode {
 
 // Owns deferred cloud launch consumption. Does not own initial Home launch initiation.
 export function useHomeDeferredLaunchRunner() {
-  const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
   const launchesById = useDeferredHomeLaunchStore((state) => state.launches);
+  const pendingWorkspaces = useSessionSelectionStore((state) => state.pendingWorkspaces);
   const markConsuming = useDeferredHomeLaunchStore((state) => state.markConsuming);
   const markPending = useDeferredHomeLaunchStore((state) => state.markPending);
   const clear = useDeferredHomeLaunchStore((state) => state.clear);
   const failLaunchIntent = useChatLaunchIntentStore((state) => state.fail);
   const { createSessionWithResolvedConfig } = useSessionCreationActions();
-  const selectedCloudRuntime = useSelectedCloudRuntimeState();
   const {
     data: workspaceCollections,
     isSuccess: workspaceCollectionsLoaded,
@@ -50,6 +63,16 @@ export function useHomeDeferredLaunchRunner() {
   const knownCloudWorkspaceIds = useMemo(() => new Set(
     (workspaceCollections?.cloudWorkspaces ?? []).map((workspace) => workspace.id),
   ), [workspaceCollections?.cloudWorkspaces]);
+  const knownCloudWorkspaceIdsRef = useRef(knownCloudWorkspaceIds);
+  knownCloudWorkspaceIdsRef.current = knownCloudWorkspaceIds;
+
+  const cloudWorkspacesById = useMemo(() => {
+    const byId = new Map<string, CloudWorkspaceSummary>();
+    for (const workspace of workspaceCollections?.cloudWorkspaces ?? []) {
+      byId.set(workspace.id, workspace);
+    }
+    return byId;
+  }, [workspaceCollections?.cloudWorkspaces]);
 
   useEffect(() => {
     const now = Date.now();
@@ -82,78 +105,136 @@ export function useHomeDeferredLaunchRunner() {
     workspaceCollectionsLoaded,
   ]);
 
-  const readyLaunch = launches.find((launch) =>
-    launch.status === "pending"
-    && launch.workspaceId === selectedWorkspaceId
-    && selectedCloudRuntime.workspaceId === launch.workspaceId
-    && selectedCloudRuntime.cloudWorkspaceId === launch.cloudWorkspaceId
-    && selectedCloudRuntime.state?.phase === "ready"
-  ) ?? null;
+  // Readiness is asked per launch, from that launch's own workspace record and
+  // registry entry, so a launch promotes while the user is looking somewhere
+  // else (PRO-230).
+  const launchesByReadiness = useMemo(() => {
+    const ready: DeferredHomeLaunch[] = [];
+    const failed: DeferredHomeLaunch[] = [];
+    for (const launch of launches) {
+      if (launch.status !== "pending") {
+        continue;
+      }
+      const readiness = resolveDeferredLaunchReadiness({
+        cloudWorkspace: cloudWorkspacesById.get(launch.cloudWorkspaceId) ?? null,
+        pendingEntry: pendingWorkspaceEntry(pendingWorkspaces, launch.cloudAttemptId),
+      });
+      if (readiness === "ready") {
+        ready.push(launch);
+      } else if (readiness === "failed") {
+        failed.push(launch);
+      }
+    }
+    return {
+      ready: ready.length > 0 ? ready : EMPTY_DEFERRED_LAUNCHES,
+      failed: failed.length > 0 ? failed : EMPTY_DEFERRED_LAUNCHES,
+    };
+  }, [cloudWorkspacesById, launches, pendingWorkspaces]);
+
+  const failedLaunchKey = launchesByReadiness.failed.map((launch) => launch.id).join("|");
+  const failedLaunchesRef = useRef<readonly DeferredHomeLaunch[]>(EMPTY_DEFERRED_LAUNCHES);
+  failedLaunchesRef.current = launchesByReadiness.failed;
 
   useEffect(() => {
-    if (!readyLaunch) {
+    if (!failedLaunchKey) {
+      return;
+    }
+    for (const launch of failedLaunchesRef.current) {
+      clear(launch.id);
+      // The provisioning failure already announced itself once per attempt —
+      // failed sidebar row plus one toast — so this only releases the queued
+      // prompt rather than reporting the same failure a second time.
+      failLaunchIntent(launch.launchIntentId, {
+        message: "Cloud workspace never became ready, so the queued prompt was not sent.",
+        retryMode: launchFailureRetryMode(launch.launchIntentId),
+      });
+    }
+  }, [clear, failedLaunchKey, failLaunchIntent]);
+
+  const consumeLaunch = useCallback(async (
+    launch: DeferredHomeLaunch,
+    isCancelled: () => boolean,
+  ) => {
+    if (!markConsuming(launch.id)) {
       return;
     }
 
-    let cancelled = false;
-    const consume = async () => {
-      if (!markConsuming(readyLaunch.id)) {
+    // A background promotion must not steal the camera: unattended, the
+    // session is created and its shell intent recorded against the launch's
+    // own workspace, and the active session the user is watching is left
+    // alone (PRO-230).
+    const attended = isLaunchAttemptAttended({
+      attemptId: launch.cloudAttemptId,
+      workspaceId: launch.workspaceId,
+    });
+
+    try {
+      await createSessionWithResolvedConfig({
+        workspaceId: launch.workspaceId,
+        agentKind: launch.agentKind,
+        modelId: launch.modelId,
+        text: launch.promptText,
+        promptId: launch.promptId,
+        launchIntentId: launch.launchIntentId,
+        launchControlValues: launch.launchControlValues,
+        activateOnCreate: attended,
+        targetWorkspaceUiKey: attended ? null : launch.workspaceId,
+        ...(launch.modeId ? { modeId: launch.modeId } : {}),
+      });
+      // Clear even if the hook re-ran mid-flight; the prompt was sent, so a remount must not retry it.
+      clear(launch.id);
+      useChatLaunchIntentStore.getState().clear(launch.launchIntentId);
+    } catch {
+      if (isCancelled()) {
+        markPending(launch.id);
         return;
       }
 
-      try {
-        await createSessionWithResolvedConfig({
-          workspaceId: readyLaunch.workspaceId,
-          agentKind: readyLaunch.agentKind,
-          modelId: readyLaunch.modelId,
-          text: readyLaunch.promptText,
-          promptId: readyLaunch.promptId,
-          launchIntentId: readyLaunch.launchIntentId,
-          launchControlValues: readyLaunch.launchControlValues,
-          ...(readyLaunch.modeId ? { modeId: readyLaunch.modeId } : {}),
+      const stillExists = knownCloudWorkspaceIdsRef.current.has(launch.cloudWorkspaceId);
+      if (!stillExists) {
+        clear(launch.id);
+        failLaunchIntent(launch.launchIntentId, {
+          message: "Cloud workspace was removed before the queued prompt could send.",
+          retryMode: "safe",
         });
-        // Clear even if the hook re-ran mid-flight; the prompt was sent, so a remount must not retry it.
-        clear(readyLaunch.id);
-        useChatLaunchIntentStore.getState().clear(readyLaunch.launchIntentId);
-      } catch (error) {
-        if (cancelled) {
-          markPending(readyLaunch.id);
-          return;
-        }
-
-        const stillExists = knownCloudWorkspaceIds.has(readyLaunch.cloudWorkspaceId);
-        if (!stillExists) {
-          clear(readyLaunch.id);
-          failLaunchIntent(readyLaunch.launchIntentId, {
-            message: "Cloud workspace was removed before the queued prompt could send.",
-            retryMode: "safe",
-          });
-          showToast("Deferred cloud launch was cancelled because the workspace is gone.");
-          return;
-        }
-
-        clear(readyLaunch.id);
-        failLaunchIntent(readyLaunch.launchIntentId, {
-          message: "Cloud workspace is ready, but the queued prompt could not be sent.",
-          retryMode: launchFailureRetryMode(readyLaunch.launchIntentId),
-        });
-        showToast("Cloud workspace is ready, but the queued prompt could not be sent.");
+        showToast("Deferred cloud launch was cancelled because the workspace is gone.");
+        return;
       }
-    };
 
-    void consume();
-
-    return () => {
-      cancelled = true;
-    };
+      clear(launch.id);
+      failLaunchIntent(launch.launchIntentId, {
+        message: "Cloud workspace is ready, but the queued prompt could not be sent.",
+        retryMode: launchFailureRetryMode(launch.launchIntentId),
+      });
+      showToast("Cloud workspace is ready, but the queued prompt could not be sent.");
+    }
   }, [
     clear,
     createSessionWithResolvedConfig,
     failLaunchIntent,
-    knownCloudWorkspaceIds,
     markConsuming,
     markPending,
-    readyLaunch,
     showToast,
   ]);
+
+  const readyLaunchKey = launchesByReadiness.ready.map((launch) => launch.id).join("|");
+  const readyLaunchesRef = useRef<readonly DeferredHomeLaunch[]>(EMPTY_DEFERRED_LAUNCHES);
+  readyLaunchesRef.current = launchesByReadiness.ready;
+
+  useEffect(() => {
+    if (!readyLaunchKey) {
+      return;
+    }
+
+    let cancelled = false;
+    // Each launch consumes on its own; `markConsuming` is the single-flight
+    // guard, so a second launch becoming ready cannot restart the first.
+    for (const launch of readyLaunchesRef.current) {
+      void consumeLaunch(launch, () => cancelled);
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [consumeLaunch, readyLaunchKey]);
 }

--- a/apps/packages/product-client/src/hooks/sessions/workflows/queued-prompt-failure-notice.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/queued-prompt-failure-notice.ts
@@ -1,0 +1,41 @@
+import { navigateApp } from "#product/lib/workflows/app/app-navigate-handoff";
+import { useToastStore } from "#product/stores/toast/toast-store";
+
+/**
+ * Tell the user about a queued prompt that failed to send into a workspace they
+ * are not looking at.
+ *
+ * The attended failure already has the right words: the composer still holds
+ * the text, so "your message is still in the composer" is both true and
+ * actionable. A background promotion has neither — no composer holds the
+ * prompt, and the workspace it was for is not on screen — so it gets its own
+ * announcement: the workspace by name, and a way to open it. Keyed by
+ * workspace so two failed background sends raise two toasts rather than
+ * replacing each other (PRO-230).
+ */
+export function notifyQueuedPromptSendFailure(input: {
+  workspaceId: string;
+  workspaceName: string | null;
+  cause: string;
+  showWorkspace: () => void;
+}): void {
+  useToastStore.getState().showError({
+    id: `queued-prompt-failure:${input.workspaceId}`,
+    headline: "Queued prompt not sent",
+    consequence: input.workspaceName
+      ? `${input.workspaceName} is ready, but the prompt queued for it never sent. No composer is holding the text.`
+      : "The workspace is ready, but the prompt queued for it never sent. No composer is holding the text.",
+    cause: input.cause,
+    details: {
+      kind: "navigate",
+      label: "Show",
+      onNavigate: () => {
+        // Selection alone is invisible from /workflows, /workspaces or
+        // /settings, where the workspace host is hidden or inert, so this
+        // routes first exactly as the pending-attempt notice does.
+        navigateApp("/");
+        input.showWorkspace();
+      },
+    },
+  });
+}

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-failure-cleanup.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-failure-cleanup.ts
@@ -1,5 +1,10 @@
 import type { ErrorContext } from "@proliferate/product-client/host/product-host";
-import { isWorkspaceDirectoryMissingError } from "#product/lib/domain/sessions/creation/create-session-error";
+import {
+  formatSessionCreateCause,
+  isWorkspaceDirectoryMissingError,
+} from "#product/lib/domain/sessions/creation/create-session-error";
+import { isWorkspaceArchivedRefusal } from "#product/lib/domain/workspaces/archived/workspace-archived-refusal";
+import type { ToastErrorInput } from "#product/primitives/utils/toast-model";
 import { logLatency } from "#product/lib/infra/measurement/measurement-port";
 import { useChatLaunchIntentStore } from "#product/stores/chat/chat-launch-intent-store";
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
@@ -51,6 +56,37 @@ interface SessionCreationFailureCleanupDeps {
    * reads the product telemetry facade). Keeps this plain workflow vendor-free.
    */
   captureException: (error: unknown, context?: ErrorContext) => void;
+}
+
+/**
+ * Tells the user a queued prompt never sent.
+ *
+ * An unattended launch announces its own failure: it knows which workspace the
+ * prompt was for, which the composer-relative copy here cannot say, and its
+ * composer is not the one holding the text (PRO-230). Otherwise the attended
+ * path owns the message — no retry offered, because the composer still holds
+ * the draft and re-sending from a toast would race the user typing into it.
+ */
+export function announceQueuedPromptFailure(
+  error: unknown,
+  onQueuedPromptFailure: ((error: unknown) => void) | undefined,
+  showErrorToast: (input: ToastErrorInput) => void,
+): void {
+  if (onQueuedPromptFailure) {
+    onQueuedPromptFailure(error);
+    return;
+  }
+  // The missing-worktree composer panel owns that condition — no toast.
+  // WORKSPACE_ARCHIVED is the same "server is right, client was stale" shape —
+  // no toast there either.
+  if (isWorkspaceDirectoryMissingError(error) || isWorkspaceArchivedRefusal(error)) {
+    return;
+  }
+  showErrorToast({
+    headline: "Message not sent",
+    consequence: "No chat was opened. Your message is still in the composer.",
+    cause: formatSessionCreateCause(error),
+  });
 }
 
 export function cleanupSessionCreationFailure(

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-types.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-types.ts
@@ -50,6 +50,18 @@ export interface CreateSessionWithResolvedConfigOptions {
   skipInitialPromptEnqueue?: boolean;
   onBeforeOptimisticPrompt?: (workspaceId: string) => Promise<void> | void;
   /**
+   * Own the announcement of a create that fails after the prompt was enqueued.
+   *
+   * A create carrying a prompt resolves at enqueue, so the caller's own `await`
+   * never sees this failure and the default announcement is the composer one:
+   * "your message is still in the composer". True for a person who just typed,
+   * false for a background promotion into a workspace nobody is looking at —
+   * there is no composer holding that text and the toast names no workspace.
+   * Callers that launch unattended pass this and announce it themselves, with
+   * the workspace they know about (PRO-230 review finding 3).
+   */
+  onQueuedPromptFailure?: (error: unknown) => void;
+  /**
    * When set, the creation workflow immediately hides this unused session
    * after activating the optimistic replacement. Destructive cleanup and
    * runtime dismissal commit only after the replacement materializes; failure

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.ts
@@ -4,7 +4,6 @@ import { useProductTelemetry } from "#product/hooks/telemetry/facade/use-product
 import { hasPromptContent } from "#product/lib/domain/chat/composer/prompt-input";
 import { createPromptId } from "#product/lib/domain/chat/composer/prompt-id";
 import {
-  formatSessionCreateCause,
   isWorkspaceDirectoryMissingError,
   toSessionCreateFailureDisplayError,
 } from "#product/lib/domain/sessions/creation/create-session-error";
@@ -54,7 +53,10 @@ import {
   type ReplacementShellPreferencesTransaction,
 } from "#product/hooks/sessions/workflows/session-replacement-shell-preferences";
 import { adoptRecoveredSessionIdentity } from "#product/hooks/sessions/workflows/session-creation-recovered-identity";
-import { cleanupSessionCreationFailure } from "#product/hooks/sessions/workflows/session-creation-failure-cleanup";
+import {
+  announceQueuedPromptFailure,
+  cleanupSessionCreationFailure,
+} from "#product/hooks/sessions/workflows/session-creation-failure-cleanup";
 import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
 import { useWorkspaceCollectionsInvalidationActions } from "#product/hooks/workspaces/cache/use-workspace-collections-invalidation";
 import { resolveRecoveryWorkspaceUiKey } from "#product/lib/domain/workspaces/selection/workspace-ui-key";
@@ -393,27 +395,7 @@ export function useSessionCreationActions() {
     if (hasPrompt) {
       void createPromise.catch((error) => {
         cleanupCreateFailure(error);
-        // A caller that launched this send unattended announces it itself: it
-        // knows which workspace the prompt was for, which the composer copy
-        // below cannot say (PRO-230).
-        if (options.onQueuedPromptFailure) {
-          options.onQueuedPromptFailure(error);
-          return;
-        }
-        // The missing-worktree composer panel owns that condition — no toast.
-        // WORKSPACE_ARCHIVED is the same "server is right, client was stale"
-        // shape — no toast there either.
-        if (!isWorkspaceDirectoryMissingError(error) && !isWorkspaceArchivedRefusal(error)) {
-          // This path had a prompt, so the thing the user lost is the message,
-          // not just the chat — say which, and where the draft went. No retry:
-          // the composer still holds the text, and re-sending from a toast
-          // would race the user typing into it.
-          showErrorToast({
-            headline: "Message not sent",
-            consequence: "No chat was opened. Your message is still in the composer.",
-            cause: formatSessionCreateCause(error),
-          });
-        }
+        announceQueuedPromptFailure(error, options.onQueuedPromptFailure, showErrorToast);
       }).finally(cleanupInFlight);
       return pendingSessionId;
     }

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.ts
@@ -393,6 +393,13 @@ export function useSessionCreationActions() {
     if (hasPrompt) {
       void createPromise.catch((error) => {
         cleanupCreateFailure(error);
+        // A caller that launched this send unattended announces it itself: it
+        // knows which workspace the prompt was for, which the composer copy
+        // below cannot say (PRO-230).
+        if (options.onQueuedPromptFailure) {
+          options.onQueuedPromptFailure(error);
+          return;
+        }
         // The missing-worktree composer panel owns that condition — no toast.
         // WORKSPACE_ARCHIVED is the same "server is right, client was stale"
         // shape — no toast there either.

--- a/apps/packages/product-client/src/hooks/workspaces/derived/use-pending-workspace-entries.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/derived/use-pending-workspace-entries.ts
@@ -8,7 +8,12 @@ import {
   pendingWorkspaceEntries,
   pendingWorkspaceEntry,
 } from "#product/lib/domain/workspaces/creation/pending-entry-registry";
+import {
+  isAwaitingCloudWorkspaceEntry,
+} from "#product/lib/domain/workspaces/cloud/cloud-workspace-poll-plan";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+
+const EMPTY_PENDING_WORKSPACE_ENTRIES: readonly PendingWorkspaceEntry[] = [];
 
 /** The pending attempt the user is looking at, if any. Never stored. */
 export function useAttendedPendingWorkspaceEntry(): PendingWorkspaceEntry | null {
@@ -28,6 +33,19 @@ export function useAttendedPendingWorkspaceEntry(): PendingWorkspaceEntry | null
       selection.selectedWorkspaceId,
     ],
   );
+}
+
+/**
+ * Every attempt parked on cloud provisioning, attended or not: the polling
+ * loop drives all of them so a launch completes while the user is elsewhere
+ * (PRO-230).
+ */
+export function useAwaitingCloudWorkspaceEntries(): readonly PendingWorkspaceEntry[] {
+  const registry = useSessionSelectionStore((state) => state.pendingWorkspaces);
+  return useMemo(() => {
+    const entries = pendingWorkspaceEntries(registry).filter(isAwaitingCloudWorkspaceEntry);
+    return entries.length > 0 ? entries : EMPTY_PENDING_WORKSPACE_ENTRIES;
+  }, [registry]);
 }
 
 export function usePendingWorkspaceEntries(): readonly PendingWorkspaceEntry[] {

--- a/apps/packages/product-client/src/hooks/workspaces/derived/use-pending-workspace-entries.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/derived/use-pending-workspace-entries.ts
@@ -8,12 +8,7 @@ import {
   pendingWorkspaceEntries,
   pendingWorkspaceEntry,
 } from "#product/lib/domain/workspaces/creation/pending-entry-registry";
-import {
-  isAwaitingCloudWorkspaceEntry,
-} from "#product/lib/domain/workspaces/cloud/cloud-workspace-poll-plan";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
-
-const EMPTY_PENDING_WORKSPACE_ENTRIES: readonly PendingWorkspaceEntry[] = [];
 
 /** The pending attempt the user is looking at, if any. Never stored. */
 export function useAttendedPendingWorkspaceEntry(): PendingWorkspaceEntry | null {
@@ -33,19 +28,6 @@ export function useAttendedPendingWorkspaceEntry(): PendingWorkspaceEntry | null
       selection.selectedWorkspaceId,
     ],
   );
-}
-
-/**
- * Every attempt parked on cloud provisioning, attended or not: the polling
- * loop drives all of them so a launch completes while the user is elsewhere
- * (PRO-230).
- */
-export function useAwaitingCloudWorkspaceEntries(): readonly PendingWorkspaceEntry[] {
-  const registry = useSessionSelectionStore((state) => state.pendingWorkspaces);
-  return useMemo(() => {
-    const entries = pendingWorkspaceEntries(registry).filter(isAwaitingCloudWorkspaceEntry);
-    return entries.length > 0 ? entries : EMPTY_PENDING_WORKSPACE_ENTRIES;
-  }, [registry]);
 }
 
 export function usePendingWorkspaceEntries(): readonly PendingWorkspaceEntry[] {

--- a/apps/packages/product-client/src/hooks/workspaces/lifecycle/use-cloud-workspace-polling.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/lifecycle/use-cloud-workspace-polling.test.tsx
@@ -5,7 +5,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
 import {
   buildPendingWorkspaceUiKey,
-  buildSubmittingPendingWorkspaceEntry,
   type PendingWorkspaceEntry,
 } from "#product/lib/domain/workspaces/creation/pending-entry";
 import {
@@ -20,7 +19,11 @@ import {
   upsertPendingWorkspaceEntry,
 } from "#product/lib/domain/workspaces/creation/pending-entry-registry";
 import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
-import { useCloudWorkspacePolling } from "#product/hooks/chat/lifecycle/use-cloud-workspace-polling";
+import { useCloudWorkspacePolling } from "#product/hooks/workspaces/lifecycle/use-cloud-workspace-polling";
+import {
+  awaitingCloudWorkspaceEntryFixture as awaitingEntry,
+  cloudWorkspaceFixture as cloudWorkspace,
+} from "#product/test/cloud-workspace-fixtures";
 
 const mocks = vi.hoisted(() => ({
   refreshCloudWorkspace: vi.fn(),
@@ -52,8 +55,11 @@ vi.mock("#product/hooks/workspaces/cache/use-workspaces", () => ({
 }));
 
 vi.mock("#product/hooks/cloud/workflows/use-cloud-workspace-actions", () => ({
+  // A fresh callback identity per render, exactly like the real hook: its
+  // identity chains through the collections cache that every successful poll
+  // invalidates. The loop must not restart on that churn (review finding 2).
   useCloudWorkspaceActions: () => ({
-    refreshCloudWorkspace: mocks.refreshCloudWorkspace,
+    refreshCloudWorkspace: (workspaceId: string) => mocks.refreshCloudWorkspace(workspaceId),
   }),
 }));
 
@@ -109,22 +115,7 @@ describe("useCloudWorkspacePolling", () => {
   it("preserves the active projected session when a pending cloud workspace becomes ready", async () => {
     const workspaceId = "cloud:cloud-1";
     const projectedSessionId = "client-session:claude:1";
-    const pendingEntry = {
-      ...buildSubmittingPendingWorkspaceEntry({
-        attemptId: "attempt-1",
-        selectedWorkspaceId: null,
-        source: "cloud-created",
-        displayName: "feature-branch",
-        repoLabel: "proliferate-ai/proliferate",
-        baseBranchName: "main",
-        request: {
-          kind: "select-existing" as const,
-          workspaceId,
-        },
-      }),
-      stage: "awaiting-cloud-ready" as const,
-      workspaceId,
-    };
+    const pendingEntry = awaitingEntry("attempt-1", workspaceId);
     const pendingWorkspaceUiKey = buildPendingWorkspaceUiKey(pendingEntry);
     putSessionRecord(createEmptySessionRecord(projectedSessionId, "claude", {
       workspaceId: pendingWorkspaceUiKey,
@@ -179,22 +170,7 @@ describe("useCloudWorkspacePolling", () => {
 
   it("marks the current awaiting cloud workspace as failed when polling returns error", async () => {
     const workspaceId = "cloud:cloud-1";
-    const pendingEntry = {
-      ...buildSubmittingPendingWorkspaceEntry({
-        attemptId: "attempt-1",
-        selectedWorkspaceId: null,
-        source: "cloud-created",
-        displayName: "feature-branch",
-        repoLabel: "proliferate-ai/proliferate",
-        baseBranchName: "main",
-        request: {
-          kind: "select-existing" as const,
-          workspaceId,
-        },
-      }),
-      stage: "awaiting-cloud-ready" as const,
-      workspaceId,
-    };
+    const pendingEntry = awaitingEntry("attempt-1", workspaceId);
     useSessionSelectionStore.setState({
       pendingWorkspaces: upsertPendingWorkspaceEntry(
         EMPTY_PENDING_WORKSPACE_REGISTRY,
@@ -223,22 +199,7 @@ describe("useCloudWorkspacePolling", () => {
 
   it("finalizes an awaiting pending entry when the cached cloud workspace is already ready", async () => {
     const workspaceId = "cloud:cloud-1";
-    const pendingEntry = {
-      ...buildSubmittingPendingWorkspaceEntry({
-        attemptId: "attempt-1",
-        selectedWorkspaceId: null,
-        source: "cloud-created",
-        displayName: "feature-branch",
-        repoLabel: "proliferate-ai/proliferate",
-        baseBranchName: "main",
-        request: {
-          kind: "select-existing" as const,
-          workspaceId,
-        },
-      }),
-      stage: "awaiting-cloud-ready" as const,
-      workspaceId,
-    };
+    const pendingEntry = awaitingEntry("attempt-1", workspaceId);
     mocks.workspaceCollections.cloudWorkspaces = [cloudWorkspace({ status: "ready" })];
     useSessionSelectionStore.setState({
       pendingWorkspaces: upsertPendingWorkspaceEntry(
@@ -276,22 +237,7 @@ describe("useCloudWorkspacePolling", () => {
 
   it("marks the current awaiting cloud workspace as failed when the cached cloud workspace is already error", async () => {
     const workspaceId = "cloud:cloud-1";
-    const pendingEntry = {
-      ...buildSubmittingPendingWorkspaceEntry({
-        attemptId: "attempt-1",
-        selectedWorkspaceId: null,
-        source: "cloud-created",
-        displayName: "feature-branch",
-        repoLabel: "proliferate-ai/proliferate",
-        baseBranchName: "main",
-        request: {
-          kind: "select-existing" as const,
-          workspaceId,
-        },
-      }),
-      stage: "awaiting-cloud-ready" as const,
-      workspaceId,
-    };
+    const pendingEntry = awaitingEntry("attempt-1", workspaceId);
     mocks.workspaceCollections.cloudWorkspaces = [cloudWorkspace({
       status: "error",
       lastError: "Provisioning failed before poll",
@@ -424,6 +370,127 @@ describe("useCloudWorkspacePolling", () => {
     }
   });
 
+  it("keeps one tick per interval while the poll's own writes churn its callbacks", async () => {
+    vi.useFakeTimers();
+    try {
+      seedRegistry([awaitingEntry("attempt-1", "cloud:cloud-1")]);
+      mocks.refreshCloudWorkspace.mockResolvedValue(cloudWorkspace({ status: "pending" }));
+
+      const { rerender } = renderHook(() => useCloudWorkspacePolling());
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(mocks.refreshCloudWorkspace).toHaveBeenCalledTimes(1);
+
+      // Five renders' worth of churn inside one interval — each one hands the
+      // hook a new `refreshCloudWorkspace` identity, as an invalidated
+      // collections query does. None of them may buy an extra refresh.
+      for (let renderPass = 0; renderPass < 5; renderPass += 1) {
+        rerender();
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(500);
+        });
+      }
+      expect(mocks.refreshCloudWorkspace).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(600);
+      });
+      expect(mocks.refreshCloudWorkspace).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("spaces the first tick after an attempt joins the set", async () => {
+    vi.useFakeTimers();
+    try {
+      seedRegistry([awaitingEntry("attempt-1", "cloud:cloud-1")]);
+      mocks.workspaceCollections.cloudWorkspaces = [
+        cloudWorkspace({ status: "pending" }),
+        cloudWorkspace({ id: "cloud-2", status: "pending" }),
+      ];
+      mocks.refreshCloudWorkspace.mockResolvedValue(cloudWorkspace({ status: "pending" }));
+
+      const { rerender } = renderHook(() => useCloudWorkspacePolling());
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(mocks.refreshCloudWorkspace).toHaveBeenCalledTimes(1);
+
+      // A second launch restarts the interval. The restart re-schedules against
+      // the last tick rather than firing one immediately, so the interval stays
+      // the floor no matter how often the set changes.
+      await act(async () => {
+        seedRegistry([
+          awaitingEntry("attempt-1", "cloud:cloud-1"),
+          awaitingEntry("attempt-2", "cloud:cloud-2"),
+        ]);
+        await vi.advanceTimersByTimeAsync(500);
+      });
+      rerender();
+      expect(mocks.refreshCloudWorkspace).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2600);
+      });
+      expect(mocks.refreshCloudWorkspace.mock.calls.map(([id]) => id)).toEqual([
+        "cloud:cloud-1",
+        "cloud:cloud-1",
+        "cloud:cloud-2",
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fails an awaiting entry whose cloud workspace reached a terminal status", async () => {
+    const workspaceId = "cloud:cloud-1";
+    seedRegistry([awaitingEntry("attempt-1", workspaceId)]);
+    useSessionSelectionStore.setState({
+      selectedWorkspaceId: "cloud:other",
+      selectedLogicalWorkspaceId: "cloud:other",
+    });
+    mocks.workspaceCollections.cloudWorkspaces = [cloudWorkspace({ status: "lost" })];
+
+    renderHook(() => useCloudWorkspacePolling());
+
+    await waitFor(() => {
+      expect(readPendingEntry()).toMatchObject({
+        stage: "failed",
+        workspaceId,
+        errorMessage: "Cloud workspace was lost before it became ready.",
+        request: { kind: "select-existing", workspaceId },
+      });
+    });
+    // Terminal means terminal: no round trip, and the attempt stops occupying a
+    // rotation slot instead of waiting out the staleness timer.
+    expect(mocks.refreshCloudWorkspace).not.toHaveBeenCalled();
+    expect(mocks.notifyUnattendedPendingWorkspaceFailure).toHaveBeenCalledWith(
+      expect.objectContaining({ attemptId: "attempt-1" }),
+      "Cloud workspace was lost before it became ready.",
+    );
+  });
+
+  it("fails an awaiting entry when a refresh reports a terminal status", async () => {
+    const workspaceId = "cloud:cloud-1";
+    seedRegistry([awaitingEntry("attempt-1", workspaceId)]);
+    mocks.refreshCloudWorkspace.mockResolvedValue(cloudWorkspace({ status: "archived" }));
+
+    renderHook(() => useCloudWorkspacePolling());
+
+    await waitFor(() => {
+      expect(readPendingEntry()).toMatchObject({
+        stage: "failed",
+        workspaceId,
+        errorMessage: "Cloud workspace was archived before it became ready.",
+      });
+    });
+    expect(mocks.materializePendingWorkspaceSessions).not.toHaveBeenCalled();
+  });
+
   it("marks an unattended awaiting entry failed and announces it when readiness fails", async () => {
     const workspaceId = "cloud:cloud-1";
     const pendingEntry = awaitingEntry("attempt-1", workspaceId);
@@ -455,22 +522,6 @@ describe("useCloudWorkspacePolling", () => {
   });
 });
 
-function awaitingEntry(attemptId: string, workspaceId: string) {
-  return {
-    ...buildSubmittingPendingWorkspaceEntry({
-      attemptId,
-      selectedWorkspaceId: null,
-      source: "cloud-created",
-      displayName: "feature-branch",
-      repoLabel: "proliferate-ai/proliferate",
-      baseBranchName: "main",
-      request: { kind: "select-existing" as const, workspaceId },
-    }),
-    stage: "awaiting-cloud-ready" as const,
-    workspaceId,
-  };
-}
-
 function seedRegistry(entries: readonly PendingWorkspaceEntry[]) {
   useSessionSelectionStore.setState({
     pendingWorkspaces: entries.reduce(
@@ -478,43 +529,6 @@ function seedRegistry(entries: readonly PendingWorkspaceEntry[]) {
       EMPTY_PENDING_WORKSPACE_REGISTRY,
     ),
   });
-}
-
-function cloudWorkspace(
-  input: Partial<CloudWorkspaceSummary> & {
-    status: CloudWorkspaceSummary["status"];
-  },
-): CloudWorkspaceSummary {
-  return {
-    id: input.id ?? "cloud-1",
-    displayName: "feature-branch",
-    repo: {
-      provider: "github",
-      owner: "proliferate-ai",
-      name: "proliferate",
-      branch: "feature-branch",
-      baseBranch: "main",
-    },
-    status: input.status,
-    workspaceStatus: input.status,
-    runtime: undefined,
-    statusDetail: input.statusDetail ?? null,
-    lastError: input.lastError ?? null,
-    templateVersion: null,
-    updatedAt: null,
-    createdAt: null,
-    readyAt: "readyAt" in input
-      ? input.readyAt ?? null
-      : input.status === "ready"
-        ? "2026-04-14T00:00:00Z"
-        : null,
-    postReadyPhase: "",
-    postReadyFilesTotal: 0,
-    postReadyFilesApplied: 0,
-    postReadyStartedAt: null,
-    postReadyCompletedAt: null,
-    visibility: "private",
-  };
 }
 
 function readPendingEntry() {

--- a/apps/packages/product-client/src/hooks/workspaces/lifecycle/use-cloud-workspace-polling.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/lifecycle/use-cloud-workspace-polling.ts
@@ -64,6 +64,16 @@ function findCloudWorkspace(
  * one. A cloud launch the user switched away from finishes behind them: it
  * provisions, materializes, and clears its own entry without moving selection
  * or the active session (PRO-230).
+ *
+ * Residency requirement: this must be mounted by `ProductLifecycleRoot`, beside
+ * `useHomeDeferredLaunchRunner`, and nowhere inside the workspace shell. The
+ * shell unmounts whenever nothing is selected — which is exactly where Home,
+ * Workflows and Workspaces put the user, since `goToTopLevelRoute` and
+ * `returnHome` null both selection ids. Mounted under the shell, every parked
+ * attempt would stop being polled the moment the user sits on Home, while the
+ * resident deferred-launch runner still promotes off the collections
+ * self-refetch and sends the prompt against an entry nothing will finalize
+ * (PRO-230 review finding 1).
  */
 export function useCloudWorkspacePolling() {
   const awaitingEntries = useAwaitingCloudWorkspaceEntries();
@@ -234,9 +244,17 @@ export function useCloudWorkspacePolling() {
     }
   }, [failAwaitingEntry, finalizeAwaitingEntry, refreshCloudWorkspace]);
 
+  // The tick calls the newest poll through a ref rather than depending on it.
+  // `pollAwaitingEntry`'s identity chains through the collections cache that
+  // every successful poll invalidates, so depending on it would restart the
+  // interval on the churn the polling itself causes (PRO-230 review finding 2).
+  const pollAwaitingEntryRef = useRef(pollAwaitingEntry);
+  pollAwaitingEntryRef.current = pollAwaitingEntry;
+
   // Restarting on the attempt set alone keeps one interval alive across the
   // status churn the polling itself causes.
   const awaitingAttemptKey = awaitingEntries.map((entry) => entry.attemptId).join("|");
+  const lastTickStartedAtRef = useRef(0);
 
   useEffect(() => {
     if (!awaitingAttemptKey) {
@@ -247,13 +265,14 @@ export function useCloudWorkspacePolling() {
     let timer: number | null = null;
 
     const runTick = async () => {
+      lastTickStartedAtRef.current = Date.now();
       const { batch, nextCursor } = selectCloudWorkspacePollBatch(
         awaitingEntriesRef.current,
         pollCursorRef.current,
         CLOUD_WORKSPACE_POLL_BATCH_SIZE,
       );
       pollCursorRef.current = nextCursor;
-      await Promise.all(batch.map((entry) => pollAwaitingEntry(entry.attemptId)));
+      await Promise.all(batch.map((entry) => pollAwaitingEntryRef.current(entry.attemptId)));
       if (!cancelled) {
         timer = window.setTimeout(() => {
           void runTick();
@@ -261,7 +280,20 @@ export function useCloudWorkspacePolling() {
       }
     };
 
-    void runTick();
+    // A restart still happens whenever an attempt joins or leaves the set, so
+    // the first tick after one is spaced off the previous tick rather than
+    // firing immediately: the interval is the floor, restarts included.
+    const remainingMs = Math.max(
+      0,
+      CLOUD_WORKSPACE_POLL_INTERVAL_MS - (Date.now() - lastTickStartedAtRef.current),
+    );
+    if (remainingMs === 0) {
+      void runTick();
+    } else {
+      timer = window.setTimeout(() => {
+        void runTick();
+      }, remainingMs);
+    }
 
     return () => {
       cancelled = true;
@@ -269,5 +301,5 @@ export function useCloudWorkspacePolling() {
         window.clearTimeout(timer);
       }
     };
-  }, [awaitingAttemptKey, pollAwaitingEntry]);
+  }, [awaitingAttemptKey]);
 }

--- a/apps/packages/product-client/src/hooks/workspaces/lifecycle/use-cloud-workspace-polling.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/lifecycle/use-cloud-workspace-polling.ts
@@ -1,10 +1,8 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+import { pendingWorkspaceEntries } from "#product/lib/domain/workspaces/creation/pending-entry-registry";
 import type { PendingWorkspaceEntry } from "#product/lib/domain/workspaces/creation/pending-entry";
 import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
-import {
-  useAwaitingCloudWorkspaceEntries,
-} from "#product/hooks/workspaces/derived/use-pending-workspace-entries";
 import { useWorkspaces } from "#product/hooks/workspaces/cache/use-workspaces";
 import { useCloudWorkspaceActions } from "#product/hooks/cloud/workflows/use-cloud-workspace-actions";
 import { useWorkspaceSelection } from "#product/hooks/workspaces/workflows/selection/use-workspace-selection";
@@ -25,6 +23,7 @@ import {
 } from "#product/hooks/workspaces/workflows/pending-workspace-failure-notice";
 import {
   resolveCloudWorkspaceFailureMessage,
+  isAwaitingCloudWorkspaceEntry,
   resolveCloudWorkspacePollAction,
   resolveCloudWorkspacePollOutcome,
   selectCloudWorkspacePollBatch,
@@ -38,6 +37,25 @@ import {
   logLatency,
   startLatencyTimer,
 } from "#product/lib/infra/measurement/measurement-port";
+
+const EMPTY_AWAITING_ENTRIES: readonly PendingWorkspaceEntry[] = [];
+
+/**
+ * Every attempt parked on cloud provisioning, attended or not: this loop drives
+ * all of them so a launch completes while the user is elsewhere (PRO-230).
+ *
+ * It lives here rather than beside the other pending-entry readers because it
+ * is the only consumer, and those readers are reached from the signed-out
+ * shell's eager graph — keeping this hook (and the poll plan it filters with)
+ * out of that module keeps the poll plan out of the login first-load chunk.
+ */
+function useAwaitingCloudWorkspaceEntries(): readonly PendingWorkspaceEntry[] {
+  const registry = useSessionSelectionStore((state) => state.pendingWorkspaces);
+  return useMemo(() => {
+    const entries = pendingWorkspaceEntries(registry).filter(isAwaitingCloudWorkspaceEntry);
+    return entries.length > 0 ? entries : EMPTY_AWAITING_ENTRIES;
+  }, [registry]);
+}
 
 const CLOUD_WORKSPACE_POLL_INTERVAL_MS = 3000;
 /**

--- a/apps/packages/product-client/src/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/lifecycle/use-selected-cloud-runtime-rehydration.ts
@@ -18,6 +18,9 @@ import {
 import {
   pendingWorkspaceEntryForWorkspaceId,
 } from "#product/lib/domain/workspaces/creation/pending-entry-registry";
+import {
+  isAttemptAttended,
+} from "#product/hooks/workspaces/workflows/pending-workspace-attempt-access";
 
 export function useSelectedCloudRuntimeRehydration(
   selectedCloudRuntime: SelectedCloudRuntimeState,
@@ -90,6 +93,15 @@ export function useSelectedCloudRuntimeRehydration(
 
     shouldRehydrateOnReadyRef.current = false;
 
+    // Attendance is decided here, before the bootstrap await, and threaded into
+    // materialization — PR1's convention. Re-reading it afterwards would let a
+    // switch-away during bootstrap change the decision that governs the rest of
+    // the sequence (PRO-230 review finding 5).
+    const attendedAttemptId = pendingWorkspaceEntry?.attemptId ?? null;
+    const attendedBeforeBootstrap = attendedAttemptId
+      ? isAttemptAttended(attendedAttemptId)
+      : false;
+
     let cancelled = false;
     void (async () => {
       const freshConnectionInfo = await withFreshCloudSandboxGatewayAccessToken(connectionInfo);
@@ -132,7 +144,14 @@ export function useSelectedCloudRuntimeRehydration(
       materializePendingWorkspaceSessions(
         pendingWorkspaceEntry,
         workspaceId,
-        { eventPrefix: "workspace.cloud_runtime_rehydration" },
+        {
+          eventPrefix: "workspace.cloud_runtime_rehydration",
+          // Only the attempt the decision was taken for carries it; a different
+          // attempt landing during the await falls back to its own read.
+          ...(pendingWorkspaceEntry.attemptId === attendedAttemptId
+            ? { attended: attendedBeforeBootstrap }
+            : {}),
+        },
       );
       clearPendingWorkspaceEntry(pendingWorkspaceEntry.attemptId);
       setWorkspaceArrivalEvent(buildWorkspaceArrivalEvent({

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/pending-workspace-attempt-access.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/pending-workspace-attempt-access.ts
@@ -4,7 +4,9 @@ import {
   type PendingWorkspaceEntry,
 } from "#product/lib/domain/workspaces/creation/pending-entry";
 import {
+  isPendingWorkspaceAttemptAttended,
   isPendingWorkspaceEntryAttended,
+  type PendingWorkspaceAttemptIdentity,
 } from "#product/lib/domain/workspaces/creation/pending-attention";
 import {
   pendingWorkspaceEntry,
@@ -45,6 +47,22 @@ export function isAttemptAttended(attemptId: string): boolean {
       selectedWorkspaceId: selection.selectedWorkspaceId,
     },
   );
+}
+
+/**
+ * The same camera question for an attempt whose registry entry is already
+ * gone. A deferred launch promotes after finalization cleared the entry, so
+ * `isAttemptAttended` would read null and call every promotion unattended;
+ * this reads the two ids straight off selection instead (PRO-230).
+ */
+export function isLaunchAttemptAttended(
+  attempt: PendingWorkspaceAttemptIdentity,
+): boolean {
+  const selection = useSessionSelectionStore.getState();
+  return isPendingWorkspaceAttemptAttended(attempt, {
+    selectedLogicalWorkspaceId: selection.selectedLogicalWorkspaceId,
+    selectedWorkspaceId: selection.selectedWorkspaceId,
+  });
 }
 
 /**

--- a/apps/packages/product-client/src/lib/domain/home/deferred-launch-readiness.test.ts
+++ b/apps/packages/product-client/src/lib/domain/home/deferred-launch-readiness.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  awaitingCloudWorkspaceEntryFixture,
+  cloudWorkspaceFixture as cloudWorkspace,
+} from "#product/test/cloud-workspace-fixtures";
+import {
+  resolveDeferredLaunchReadiness,
+} from "#product/lib/domain/home/deferred-launch-readiness";
+
+const awaitingEntry = () => awaitingCloudWorkspaceEntryFixture("attempt-1", "cloud:cloud-1");
+
+describe("resolveDeferredLaunchReadiness", () => {
+  it("waits while the launch's own workspace is still provisioning", () => {
+    expect(resolveDeferredLaunchReadiness({
+      cloudWorkspace: cloudWorkspace({ status: "pending" }),
+      pendingEntry: awaitingEntry(),
+    })).toBe("waiting");
+  });
+
+  it("promotes as soon as the launch's own workspace is ready", () => {
+    expect(resolveDeferredLaunchReadiness({
+      cloudWorkspace: cloudWorkspace({ status: "ready" }),
+      pendingEntry: awaitingEntry(),
+    })).toBe("ready");
+  });
+
+  it("takes a failed attempt over the workspace record, which can lag it", () => {
+    expect(resolveDeferredLaunchReadiness({
+      cloudWorkspace: cloudWorkspace({ status: "pending" }),
+      pendingEntry: { ...awaitingEntry(), stage: "failed" },
+    })).toBe("failed");
+  });
+
+  it("releases the queued prompt when the workspace reaches a terminal status", () => {
+    // Without this the launch would wait out the full hour-long staleness
+    // timer for a workspace that can never become ready (PRO-230 review
+    // finding 4).
+    expect(resolveDeferredLaunchReadiness({
+      cloudWorkspace: cloudWorkspace({ status: "lost" }),
+      pendingEntry: awaitingEntry(),
+    })).toBe("failed");
+    expect(resolveDeferredLaunchReadiness({
+      cloudWorkspace: cloudWorkspace({ status: "archived" }),
+      pendingEntry: awaitingEntry(),
+    })).toBe("failed");
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/home/deferred-launch-readiness.ts
+++ b/apps/packages/product-client/src/lib/domain/home/deferred-launch-readiness.ts
@@ -1,0 +1,35 @@
+import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
+import type { PendingWorkspaceEntry } from "#product/lib/domain/workspaces/creation/pending-entry";
+import {
+  resolveCloudWorkspacePollOutcome,
+} from "#product/lib/domain/workspaces/cloud/cloud-workspace-poll-plan";
+
+/** Whether a deferred launch may send its queued prompt yet. */
+export type DeferredLaunchReadiness = "waiting" | "ready" | "failed";
+
+/**
+ * Readiness is per launch, never per selection: the polling loop refreshes the
+ * launch's own cloud workspace and records the attempt's outcome on its
+ * registry entry, and both of those reads work while the user is looking at
+ * some other workspace (PRO-230). The entry outranks the workspace record
+ * because a failed attempt has already announced itself; the record can lag it.
+ */
+export function resolveDeferredLaunchReadiness(input: {
+  cloudWorkspace: CloudWorkspaceSummary | null;
+  pendingEntry: PendingWorkspaceEntry | null;
+}): DeferredLaunchReadiness {
+  if (input.pendingEntry?.stage === "failed") {
+    return "failed";
+  }
+  if (!input.cloudWorkspace) {
+    return "waiting";
+  }
+  switch (resolveCloudWorkspacePollOutcome(input.cloudWorkspace)) {
+    case "ready":
+      return "ready";
+    case "failed":
+      return "failed";
+    case "pending":
+      return "waiting";
+  }
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-poll-plan.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-poll-plan.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
+import {
+  buildSubmittingPendingWorkspaceEntry,
+  type PendingWorkspaceEntry,
+} from "#product/lib/domain/workspaces/creation/pending-entry";
+import {
+  resolveCloudWorkspacePollAction,
+  resolveCloudWorkspacePollOutcome,
+  selectCloudWorkspacePollBatch,
+} from "#product/lib/domain/workspaces/cloud/cloud-workspace-poll-plan";
+
+describe("resolveCloudWorkspacePollAction", () => {
+  it("skips an entry that is not awaiting cloud readiness", () => {
+    expect(resolveCloudWorkspacePollAction({
+      entry: { ...awaitingEntry(), stage: "submitting" },
+      cachedWorkspace: cloudWorkspace("pending"),
+    })).toBe("skip");
+  });
+
+  it("refreshes an entry whose workspace has not landed in the cache yet", () => {
+    expect(resolveCloudWorkspacePollAction({
+      entry: awaitingEntry(),
+      cachedWorkspace: null,
+    })).toBe("refresh");
+  });
+
+  it("fails from the cache without a round trip when provisioning already errored", () => {
+    expect(resolveCloudWorkspacePollAction({
+      entry: awaitingEntry(),
+      cachedWorkspace: cloudWorkspace("error"),
+    })).toBe("fail-cached");
+  });
+
+  it("still refreshes a cached-ready workspace so finalization sees the same payload", () => {
+    expect(resolveCloudWorkspacePollAction({
+      entry: awaitingEntry(),
+      cachedWorkspace: cloudWorkspace("ready"),
+    })).toBe("refresh");
+  });
+
+  it("skips a workspace that can no longer become ready", () => {
+    expect(resolveCloudWorkspacePollAction({
+      entry: awaitingEntry(),
+      cachedWorkspace: cloudWorkspace("lost"),
+    })).toBe("skip");
+  });
+});
+
+describe("resolveCloudWorkspacePollOutcome", () => {
+  it("holds a ready workspace that is still applying files", () => {
+    expect(resolveCloudWorkspacePollOutcome({
+      ...cloudWorkspace("ready"),
+      postReadyPhase: "applying_files",
+    })).toBe("pending");
+  });
+
+  it("reads ready and error straight off the status", () => {
+    expect(resolveCloudWorkspacePollOutcome(cloudWorkspace("ready"))).toBe("ready");
+    expect(resolveCloudWorkspacePollOutcome(cloudWorkspace("error"))).toBe("failed");
+    expect(resolveCloudWorkspacePollOutcome(cloudWorkspace("pending"))).toBe("pending");
+  });
+});
+
+describe("selectCloudWorkspacePollBatch", () => {
+  it("caps the batch and carries the cursor so no attempt starves", () => {
+    const candidates = ["a", "b", "c", "d"];
+
+    const first = selectCloudWorkspacePollBatch(candidates, 0, 3);
+    expect(first.batch).toEqual(["a", "b", "c"]);
+
+    const second = selectCloudWorkspacePollBatch(candidates, first.nextCursor, 3);
+    expect(second.batch).toEqual(["d", "a", "b"]);
+  });
+
+  it("returns every candidate when there are fewer than the cap", () => {
+    expect(selectCloudWorkspacePollBatch(["a", "b"], 0, 3).batch).toEqual(["a", "b"]);
+  });
+
+  it("handles an empty candidate list", () => {
+    expect(selectCloudWorkspacePollBatch([], 2, 3)).toEqual({ batch: [], nextCursor: 0 });
+  });
+});
+
+function awaitingEntry(): PendingWorkspaceEntry {
+  return {
+    ...buildSubmittingPendingWorkspaceEntry({
+      attemptId: "attempt-1",
+      selectedWorkspaceId: null,
+      source: "cloud-created",
+      displayName: "feature-branch",
+      request: { kind: "select-existing", workspaceId: "cloud:cloud-1" },
+    }),
+    stage: "awaiting-cloud-ready",
+    workspaceId: "cloud:cloud-1",
+  };
+}
+
+function cloudWorkspace(status: CloudWorkspaceSummary["status"]): CloudWorkspaceSummary {
+  return {
+    id: "cloud-1",
+    displayName: "feature-branch",
+    repo: {
+      provider: "github",
+      owner: "proliferate-ai",
+      name: "proliferate",
+      branch: "feature-branch",
+      baseBranch: "main",
+    },
+    status,
+    workspaceStatus: status,
+    runtime: undefined,
+    statusDetail: null,
+    lastError: null,
+    templateVersion: null,
+    updatedAt: null,
+    createdAt: null,
+    readyAt: status === "ready" ? "2026-04-14T00:00:00Z" : null,
+    postReadyPhase: "",
+    postReadyFilesTotal: 0,
+    postReadyFilesApplied: 0,
+    postReadyStartedAt: null,
+    postReadyCompletedAt: null,
+    visibility: "private",
+  };
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-poll-plan.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-poll-plan.test.ts
@@ -1,20 +1,22 @@
 import { describe, expect, it } from "vitest";
-import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
 import {
-  buildSubmittingPendingWorkspaceEntry,
-  type PendingWorkspaceEntry,
-} from "#product/lib/domain/workspaces/creation/pending-entry";
+  awaitingCloudWorkspaceEntryFixture,
+  cloudWorkspaceFixture as cloudWorkspace,
+} from "#product/test/cloud-workspace-fixtures";
 import {
+  resolveCloudWorkspaceFailureMessage,
   resolveCloudWorkspacePollAction,
   resolveCloudWorkspacePollOutcome,
   selectCloudWorkspacePollBatch,
 } from "#product/lib/domain/workspaces/cloud/cloud-workspace-poll-plan";
 
+const awaitingEntry = () => awaitingCloudWorkspaceEntryFixture("attempt-1", "cloud:cloud-1");
+
 describe("resolveCloudWorkspacePollAction", () => {
   it("skips an entry that is not awaiting cloud readiness", () => {
     expect(resolveCloudWorkspacePollAction({
       entry: { ...awaitingEntry(), stage: "submitting" },
-      cachedWorkspace: cloudWorkspace("pending"),
+      cachedWorkspace: cloudWorkspace({ status: "pending" }),
     })).toBe("skip");
   });
 
@@ -28,37 +30,66 @@ describe("resolveCloudWorkspacePollAction", () => {
   it("fails from the cache without a round trip when provisioning already errored", () => {
     expect(resolveCloudWorkspacePollAction({
       entry: awaitingEntry(),
-      cachedWorkspace: cloudWorkspace("error"),
+      cachedWorkspace: cloudWorkspace({ status: "error" }),
     })).toBe("fail-cached");
   });
 
   it("still refreshes a cached-ready workspace so finalization sees the same payload", () => {
     expect(resolveCloudWorkspacePollAction({
       entry: awaitingEntry(),
-      cachedWorkspace: cloudWorkspace("ready"),
+      cachedWorkspace: cloudWorkspace({ status: "ready" }),
     })).toBe("refresh");
   });
 
-  it("skips a workspace that can no longer become ready", () => {
+  it("fails a workspace that can no longer become ready", () => {
+    // Terminal and not ready: refreshing it would park the attempt and its
+    // queued prompt until the hour-long staleness sweep.
     expect(resolveCloudWorkspacePollAction({
       entry: awaitingEntry(),
-      cachedWorkspace: cloudWorkspace("lost"),
-    })).toBe("skip");
+      cachedWorkspace: cloudWorkspace({ status: "lost" }),
+    })).toBe("fail-cached");
+    expect(resolveCloudWorkspacePollAction({
+      entry: awaitingEntry(),
+      cachedWorkspace: cloudWorkspace({ status: "archived" }),
+    })).toBe("fail-cached");
   });
 });
 
 describe("resolveCloudWorkspacePollOutcome", () => {
   it("holds a ready workspace that is still applying files", () => {
     expect(resolveCloudWorkspacePollOutcome({
-      ...cloudWorkspace("ready"),
+      ...cloudWorkspace({ status: "ready" }),
       postReadyPhase: "applying_files",
     })).toBe("pending");
   });
 
   it("reads ready and error straight off the status", () => {
-    expect(resolveCloudWorkspacePollOutcome(cloudWorkspace("ready"))).toBe("ready");
-    expect(resolveCloudWorkspacePollOutcome(cloudWorkspace("error"))).toBe("failed");
-    expect(resolveCloudWorkspacePollOutcome(cloudWorkspace("pending"))).toBe("pending");
+    expect(resolveCloudWorkspacePollOutcome(cloudWorkspace({ status: "ready" }))).toBe("ready");
+    expect(resolveCloudWorkspacePollOutcome(cloudWorkspace({ status: "error" }))).toBe("failed");
+    expect(resolveCloudWorkspacePollOutcome(cloudWorkspace({ status: "pending" }))).toBe("pending");
+  });
+
+  it("treats a terminal non-ready status as a failure, not as waiting", () => {
+    expect(resolveCloudWorkspacePollOutcome(cloudWorkspace({ status: "lost" }))).toBe("failed");
+    expect(resolveCloudWorkspacePollOutcome(cloudWorkspace({ status: "archived" }))).toBe("failed");
+  });
+});
+
+describe("resolveCloudWorkspaceFailureMessage", () => {
+  it("prefers what the workspace reported", () => {
+    expect(resolveCloudWorkspaceFailureMessage({
+      ...cloudWorkspace({ status: "error" }),
+      lastError: "Sandbox never started",
+    })).toBe("Sandbox never started");
+  });
+
+  it("says what a terminal status means when it carries no error text", () => {
+    expect(resolveCloudWorkspaceFailureMessage(cloudWorkspace({ status: "lost" })))
+      .toBe("Cloud workspace was lost before it became ready.");
+    expect(resolveCloudWorkspaceFailureMessage(cloudWorkspace({ status: "archived" })))
+      .toBe("Cloud workspace was archived before it became ready.");
+    expect(resolveCloudWorkspaceFailureMessage(cloudWorkspace({ status: "error" })))
+      .toBe("Cloud workspace provisioning failed.");
   });
 });
 
@@ -81,46 +112,3 @@ describe("selectCloudWorkspacePollBatch", () => {
     expect(selectCloudWorkspacePollBatch([], 2, 3)).toEqual({ batch: [], nextCursor: 0 });
   });
 });
-
-function awaitingEntry(): PendingWorkspaceEntry {
-  return {
-    ...buildSubmittingPendingWorkspaceEntry({
-      attemptId: "attempt-1",
-      selectedWorkspaceId: null,
-      source: "cloud-created",
-      displayName: "feature-branch",
-      request: { kind: "select-existing", workspaceId: "cloud:cloud-1" },
-    }),
-    stage: "awaiting-cloud-ready",
-    workspaceId: "cloud:cloud-1",
-  };
-}
-
-function cloudWorkspace(status: CloudWorkspaceSummary["status"]): CloudWorkspaceSummary {
-  return {
-    id: "cloud-1",
-    displayName: "feature-branch",
-    repo: {
-      provider: "github",
-      owner: "proliferate-ai",
-      name: "proliferate",
-      branch: "feature-branch",
-      baseBranch: "main",
-    },
-    status,
-    workspaceStatus: status,
-    runtime: undefined,
-    statusDetail: null,
-    lastError: null,
-    templateVersion: null,
-    updatedAt: null,
-    createdAt: null,
-    readyAt: status === "ready" ? "2026-04-14T00:00:00Z" : null,
-    postReadyPhase: "",
-    postReadyFilesTotal: 0,
-    postReadyFilesApplied: 0,
-    postReadyStartedAt: null,
-    postReadyCompletedAt: null,
-    visibility: "private",
-  };
-}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-poll-plan.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-poll-plan.ts
@@ -1,0 +1,97 @@
+import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
+import type { PendingWorkspaceEntry } from "#product/lib/domain/workspaces/creation/pending-entry";
+import { isCloudWorkspaceId } from "#product/lib/domain/workspaces/cloud/cloud-ids";
+import {
+  isCloudWorkspacePostReadyPending,
+  resolveCloudWorkspaceStatus,
+  shouldPollCloudWorkspaceForUpdates,
+} from "#product/lib/domain/workspaces/cloud/cloud-workspace-status";
+
+/** What one tick should do about one parked attempt. */
+export type CloudWorkspacePollAction = "skip" | "fail-cached" | "refresh";
+
+/** What the refreshed workspace says about the attempt that was waiting on it. */
+export type CloudWorkspacePollOutcome = "pending" | "ready" | "failed";
+
+export function isAwaitingCloudWorkspaceEntry(
+  entry: PendingWorkspaceEntry,
+): boolean {
+  return entry.stage === "awaiting-cloud-ready" && isCloudWorkspaceId(entry.workspaceId);
+}
+
+/**
+ * A cached record is trusted only to stop work early: a failed provision needs
+ * no round trip, while a cached "ready" is still confirmed by a refresh so the
+ * finalize runs against the same payload every other path sees.
+ */
+export function resolveCloudWorkspacePollAction(input: {
+  entry: PendingWorkspaceEntry;
+  cachedWorkspace: CloudWorkspaceSummary | null;
+}): CloudWorkspacePollAction {
+  if (!isAwaitingCloudWorkspaceEntry(input.entry)) {
+    return "skip";
+  }
+  const cachedWorkspace = input.cachedWorkspace;
+  if (!cachedWorkspace) {
+    // The collections cache lags creation, so an attempt whose workspace has
+    // not landed in it yet still polls; the refresh fetches by id.
+    return "refresh";
+  }
+  const status = resolveCloudWorkspaceStatus(cachedWorkspace);
+  if (status === "error") {
+    return "fail-cached";
+  }
+  if (shouldPollCloudWorkspaceForUpdates(cachedWorkspace)) {
+    return "refresh";
+  }
+  return status === "ready" ? "refresh" : "skip";
+}
+
+export function resolveCloudWorkspacePollOutcome(
+  workspace: CloudWorkspaceSummary,
+): CloudWorkspacePollOutcome {
+  if (resolveCloudWorkspaceStatus(workspace) === "error") {
+    return "failed";
+  }
+  if (resolveCloudWorkspaceStatus(workspace) === "ready" && !isCloudWorkspacePostReadyPending(workspace)) {
+    return "ready";
+  }
+  return "pending";
+}
+
+export function resolveCloudWorkspaceFailureMessage(
+  workspace: Pick<CloudWorkspaceSummary, "lastError" | "statusDetail">,
+): string {
+  return workspace.lastError
+    ?? workspace.statusDetail
+    ?? "Cloud workspace provisioning failed.";
+}
+
+export interface CloudWorkspacePollBatch<T> {
+  batch: readonly T[];
+  nextCursor: number;
+}
+
+const EMPTY_POLL_BATCH: readonly never[] = [];
+
+/**
+ * Rotates through the parked attempts so a per-tick cap bounds concurrent
+ * refreshes without starving the attempts past the cap: the cursor carries
+ * over, so the fourth launch is polled on the next tick rather than never.
+ */
+export function selectCloudWorkspacePollBatch<T>(
+  candidates: readonly T[],
+  cursor: number,
+  limit: number,
+): CloudWorkspacePollBatch<T> {
+  if (candidates.length === 0 || limit <= 0) {
+    return { batch: EMPTY_POLL_BATCH, nextCursor: 0 };
+  }
+  const size = Math.min(limit, candidates.length);
+  const start = ((cursor % candidates.length) + candidates.length) % candidates.length;
+  const batch: T[] = [];
+  for (let offset = 0; offset < size; offset += 1) {
+    batch.push(candidates[(start + offset) % candidates.length] as T);
+  }
+  return { batch, nextCursor: (start + size) % candidates.length };
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-poll-plan.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-poll-plan.ts
@@ -2,7 +2,9 @@ import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud
 import type { PendingWorkspaceEntry } from "#product/lib/domain/workspaces/creation/pending-entry";
 import { isCloudWorkspaceId } from "#product/lib/domain/workspaces/cloud/cloud-ids";
 import {
+  type CloudWorkspaceStatusFields,
   isCloudWorkspacePostReadyPending,
+  isCloudWorkspaceTerminallyUnavailable,
   resolveCloudWorkspaceStatus,
   shouldPollCloudWorkspaceForUpdates,
 } from "#product/lib/domain/workspaces/cloud/cloud-workspace-status";
@@ -38,7 +40,10 @@ export function resolveCloudWorkspacePollAction(input: {
     return "refresh";
   }
   const status = resolveCloudWorkspaceStatus(cachedWorkspace);
-  if (status === "error") {
+  // `lost` and `archived` are as final as `error` for an attempt that never
+  // reached ready: refreshing them forever would park the entry and its queued
+  // prompt until the hour-long staleness timer (PRO-230 review finding 4).
+  if (status === "error" || isCloudWorkspaceTerminallyUnavailable(cachedWorkspace)) {
     return "fail-cached";
   }
   if (shouldPollCloudWorkspaceForUpdates(cachedWorkspace)) {
@@ -50,7 +55,10 @@ export function resolveCloudWorkspacePollAction(input: {
 export function resolveCloudWorkspacePollOutcome(
   workspace: CloudWorkspaceSummary,
 ): CloudWorkspacePollOutcome {
-  if (resolveCloudWorkspaceStatus(workspace) === "error") {
+  if (
+    resolveCloudWorkspaceStatus(workspace) === "error"
+    || isCloudWorkspaceTerminallyUnavailable(workspace)
+  ) {
     return "failed";
   }
   if (resolveCloudWorkspaceStatus(workspace) === "ready" && !isCloudWorkspacePostReadyPending(workspace)) {
@@ -60,11 +68,22 @@ export function resolveCloudWorkspacePollOutcome(
 }
 
 export function resolveCloudWorkspaceFailureMessage(
-  workspace: Pick<CloudWorkspaceSummary, "lastError" | "statusDetail">,
+  workspace: CloudWorkspaceStatusFields & Pick<CloudWorkspaceSummary, "lastError" | "statusDetail">,
 ): string {
-  return workspace.lastError
-    ?? workspace.statusDetail
-    ?? "Cloud workspace provisioning failed.";
+  const reportedMessage = workspace.lastError ?? workspace.statusDetail;
+  if (reportedMessage) {
+    return reportedMessage;
+  }
+  // A terminal status usually carries no error text of its own, so say what
+  // happened instead of claiming a provisioning error.
+  switch (resolveCloudWorkspaceStatus(workspace)) {
+    case "lost":
+      return "Cloud workspace was lost before it became ready.";
+    case "archived":
+      return "Cloud workspace was archived before it became ready.";
+    default:
+      return "Cloud workspace provisioning failed.";
+  }
 }
 
 export interface CloudWorkspacePollBatch<T> {

--- a/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-status.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/cloud/cloud-workspace-status.ts
@@ -63,6 +63,18 @@ export function isCloudWorkspaceFailedBeforeReady(
     && workspace.productLifecycle !== "archived";
 }
 
+/**
+ * The workspace has reached a state it will never leave on its own, and that
+ * state is not `ready`. An attempt waiting on it is waiting for something that
+ * cannot happen, so it must be failed rather than parked (PRO-230).
+ */
+export function isCloudWorkspaceTerminallyUnavailable(
+  workspace: CloudWorkspaceStatusFields | null | undefined,
+): boolean {
+  const status = resolveCloudWorkspaceStatus(workspace);
+  return status === "lost" || status === "archived";
+}
+
 export function shouldPollCloudWorkspaceForUpdates(
   workspace: CloudWorkspaceSummary,
 ): boolean {

--- a/apps/packages/product-client/src/lib/domain/workspaces/creation/pending-attention.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/creation/pending-attention.ts
@@ -11,12 +11,29 @@ export interface PendingWorkspaceAttentionSelection {
   selectedWorkspaceId: string | null;
 }
 
+/** The two ids attention is decided from, so an attempt whose registry entry
+ * has already been cleared can still be asked the question. */
+export interface PendingWorkspaceAttemptIdentity {
+  attemptId: string;
+  workspaceId: string | null;
+}
+
 /**
  * Attention is a camera, not a lifecycle: it says whether the user is looking
  * at this attempt right now. The materialized-id clause covers the handoff
  * window after finalization swapped selection to the real workspace but the
  * pending entry has not been cleared yet.
  */
+export function isPendingWorkspaceAttemptAttended(
+  attempt: PendingWorkspaceAttemptIdentity,
+  selection: PendingWorkspaceAttentionSelection,
+): boolean {
+  if (selection.selectedLogicalWorkspaceId === buildPendingWorkspaceUiKey(attempt)) {
+    return true;
+  }
+  return attempt.workspaceId !== null && selection.selectedWorkspaceId === attempt.workspaceId;
+}
+
 export function isPendingWorkspaceEntryAttended(
   entry: PendingWorkspaceEntry | null | undefined,
   selection: PendingWorkspaceAttentionSelection,
@@ -24,10 +41,7 @@ export function isPendingWorkspaceEntryAttended(
   if (!entry) {
     return false;
   }
-  if (selection.selectedLogicalWorkspaceId === buildPendingWorkspaceUiKey(entry)) {
-    return true;
-  }
-  return entry.workspaceId !== null && selection.selectedWorkspaceId === entry.workspaceId;
+  return isPendingWorkspaceAttemptAttended(entry, selection);
 }
 
 export function resolveAttendedPendingWorkspaceEntry(

--- a/apps/packages/product-client/src/providers/AuthenticatedLaunchLifecycles.tsx
+++ b/apps/packages/product-client/src/providers/AuthenticatedLaunchLifecycles.tsx
@@ -1,23 +1,32 @@
 import { useHomeDeferredLaunchRunner } from "#product/hooks/home/lifecycle/use-home-deferred-launch-runner"
+import { useCloudWorkspacePolling } from "#product/hooks/workspaces/lifecycle/use-cloud-workspace-polling"
 import { recordBootDiagnosticOnce } from "#product/lib/infra/measurement/measurement-port"
 
 /**
  * The session-resident launch lifecycles, mounted only once the viewer is
  * authenticated.
  *
- * These consume the client-owned launch registry: deferred Home launches and
- * the attempts they park. None of it can exist for a signed-out viewer, so the
- * lifecycle root mounts this behind `React.lazy` + the authenticated gate (the
- * same treatment `AuthRestartOfferRoot` gets). That keeps the whole
- * launch/session-creation graph — pending registry, attempt access, workspace
- * entry, session creation — out of the login first-load chunk, which has a
- * fail-closed JS budget (PRO-230).
+ * These consume the client-owned launch registry: deferred Home launches, the
+ * attempts they park, and the registry-wide cloud poll loop that finalizes
+ * them. None of it can exist for a signed-out viewer, so the lifecycle root
+ * mounts this behind `React.lazy` + the authenticated gate (the same treatment
+ * `AuthRestartOfferRoot` gets). That keeps the whole launch/session-creation
+ * graph — pending registry, attempt access, workspace entry, session creation,
+ * cloud polling — out of the login first-load chunk, which has a fail-closed
+ * JS budget (PRO-230).
  *
  * It stays a lifecycle-only component: it renders nothing, and it must be
  * mounted above the route tree so a launch survives the user navigating away
  * from the workspace that started it.
  */
 export function AuthenticatedLaunchLifecycles(): null {
+  recordBootDiagnosticOnce("app_runtime.render.before.use_cloud_workspace_polling")
+  // Resident for the whole session, beside the runner that consumes what it
+  // finalizes. Inside the workspace shell it would stop the moment the user
+  // sits on Home or /workflows, which nulls both selection ids and unmounts the
+  // shell, leaving every parked cloud attempt unpolled (PRO-230).
+  useCloudWorkspacePolling()
+  recordBootDiagnosticOnce("app_runtime.render.after.use_cloud_workspace_polling")
   recordBootDiagnosticOnce("app_runtime.render.before.use_home_deferred_launch_runner")
   useHomeDeferredLaunchRunner()
   recordBootDiagnosticOnce("app_runtime.render.after.use_home_deferred_launch_runner")

--- a/apps/packages/product-client/src/providers/ProductLifecycleRoot.test.tsx
+++ b/apps/packages/product-client/src/providers/ProductLifecycleRoot.test.tsx
@@ -36,6 +36,7 @@ vi.mock("#product/hooks/agents/lifecycle/use-first-run-auth-adoption", () => ({ 
 vi.mock("#product/hooks/agents/lifecycle/use-local-auth-state-sync", () => ({ useLocalAuthStateSync: vi.fn() }));
 vi.mock("#product/hooks/automations/lifecycle/use-local-automation-executor", () => ({ useLocalAutomationExecutor: vi.fn() }));
 vi.mock("#product/hooks/home/lifecycle/use-home-deferred-launch-runner", () => ({ useHomeDeferredLaunchRunner: vi.fn() }));
+vi.mock("#product/hooks/workspaces/lifecycle/use-cloud-workspace-polling", () => ({ useCloudWorkspacePolling: vi.fn() }));
 vi.mock("#product/hooks/preferences/lifecycle/use-appearance-preference-lifecycle", () => ({ useAppearancePreferenceLifecycle: vi.fn() }));
 vi.mock("#product/hooks/preferences/lifecycle/use-repo-preferences-lifecycle", () => ({ useRepoPreferencesLifecycle: vi.fn() }));
 vi.mock("#product/hooks/preferences/lifecycle/use-user-preferences-lifecycle", () => ({ useUserPreferencesLifecycle: vi.fn() }));
@@ -97,6 +98,7 @@ vi.mock("#product/providers/DesktopProductLifecycleRoot", () => ({
 
 import { ProductLifecycleRoot } from "#product/providers/ProductLifecycleRoot";
 import { useAppCommandActionsContext } from "#product/providers/AppCommandActionsProvider";
+import { useCloudWorkspacePolling } from "#product/hooks/workspaces/lifecycle/use-cloud-workspace-polling";
 import { useHomeDeferredLaunchRunner } from "#product/hooks/home/lifecycle/use-home-deferred-launch-runner";
 
 function CommandContextProbe() {
@@ -255,11 +257,14 @@ describe("ProductLifecycleRoot", () => {
   });
 
   it("keeps the launch lifecycles off the signed-out shell and mounts them once authenticated", async () => {
-    // Residency AND reachability. The launch registry only exists for a
-    // signed-in viewer, so the runner is mounted behind the authenticated gate
-    // as a lazy chunk — the login first-load graph never pulls the launch /
-    // session-creation modules it depends on (PRO-230, login JS budget). It
-    // still lives above the route tree, so a launch survives navigating away.
+    // Residency AND reachability. Both loops must outlive the workspace shell:
+    // mounted inside it they would stop the moment the user sits on Home or
+    // /workflows — both of which null the selection ids and unmount the shell —
+    // leaving parked cloud attempts unpolled and prompts sent into attempts
+    // nothing will finalize (PRO-230 review finding 1). But the launch registry
+    // only exists for a signed-in viewer, so they are mounted behind the
+    // authenticated gate as a lazy chunk, which is what keeps the launch /
+    // session-creation graph out of the login first-load budget.
     authStatus.value = "anonymous";
     const host = makeTestProductHost({
       auth: { restoreSession: vi.fn().mockResolvedValue(undefined) },
@@ -276,11 +281,13 @@ describe("ProductLifecycleRoot", () => {
 
     expect(screen.getByTestId("app-tree")).toBeTruthy();
     expect(useHomeDeferredLaunchRunner).not.toHaveBeenCalled();
+    expect(useCloudWorkspacePolling).not.toHaveBeenCalled();
 
     authStatus.value = "authenticated";
     rerender(tree());
 
     await waitFor(() => expect(useHomeDeferredLaunchRunner).toHaveBeenCalled());
+    expect(useCloudWorkspacePolling).toHaveBeenCalled();
   });
 
   it("keeps a single Desktop lifecycle mount under StrictMode", () => {

--- a/apps/packages/product-client/src/test/cloud-workspace-fixtures.ts
+++ b/apps/packages/product-client/src/test/cloud-workspace-fixtures.ts
@@ -1,0 +1,68 @@
+import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
+import {
+  buildSubmittingPendingWorkspaceEntry,
+  type PendingWorkspaceEntry,
+} from "#product/lib/domain/workspaces/creation/pending-entry";
+
+/**
+ * The two shapes every cloud-launch test needs: a cloud workspace record as the
+ * collections cache holds it, and a registry entry parked at
+ * `awaiting-cloud-ready`. They were copied into each suite that drives a launch
+ * (polling, deferred promotion, readiness, poll plan); one definition keeps the
+ * default `readyAt`/status pairing consistent across all of them.
+ */
+export function cloudWorkspaceFixture(
+  input: Partial<CloudWorkspaceSummary> & {
+    status: CloudWorkspaceSummary["status"];
+  },
+): CloudWorkspaceSummary {
+  return {
+    id: input.id ?? "cloud-1",
+    displayName: input.displayName ?? "feature-branch",
+    repo: {
+      provider: "github",
+      owner: "proliferate-ai",
+      name: "proliferate",
+      branch: "feature-branch",
+      baseBranch: "main",
+    },
+    status: input.status,
+    workspaceStatus: input.status,
+    runtime: undefined,
+    statusDetail: input.statusDetail ?? null,
+    lastError: input.lastError ?? null,
+    templateVersion: null,
+    updatedAt: null,
+    createdAt: null,
+    readyAt: "readyAt" in input
+      ? input.readyAt ?? null
+      : input.status === "ready"
+        ? "2026-04-14T00:00:00Z"
+        : null,
+    postReadyPhase: input.postReadyPhase ?? "",
+    postReadyFilesTotal: 0,
+    postReadyFilesApplied: 0,
+    postReadyStartedAt: null,
+    postReadyCompletedAt: null,
+    visibility: "private",
+  };
+}
+
+export function awaitingCloudWorkspaceEntryFixture(
+  attemptId: string,
+  workspaceId: string,
+): PendingWorkspaceEntry {
+  return {
+    ...buildSubmittingPendingWorkspaceEntry({
+      attemptId,
+      selectedWorkspaceId: null,
+      source: "cloud-created",
+      displayName: "feature-branch",
+      repoLabel: "proliferate-ai/proliferate",
+      baseBranchName: "main",
+      request: { kind: "select-existing", workspaceId },
+    }),
+    stage: "awaiting-cloud-ready",
+    workspaceId,
+  };
+}

--- a/specs/codebase/systems/product/workspaces/pending-shell.md
+++ b/specs/codebase/systems/product/workspaces/pending-shell.md
@@ -241,6 +241,20 @@ responses, and queued prompt edit/delete actions.
    behind the user, and `use-home-deferred-launch-runner` sends the queued
    prompt off the same per-attempt readiness.
 
+   Both drivers are mounted by `ProductLifecycleRoot`, not by the workspace
+   shell, and that placement is load-bearing: the shell unmounts whenever
+   nothing is selected, which is where Home, Workflows and Workspaces put the
+   user. A registry-wide driver mounted under the shell would stop for every
+   parked attempt the moment the user leaves a workspace, which is the same
+   stall by another route.
+
+   The root mounts them through `AuthenticatedLaunchLifecycles`, a lazy
+   component rendered only once auth status is `authenticated` (the same
+   treatment `AuthRestartOfferRoot` gets). A signed-out viewer has no registry
+   and no attempts, so nothing is lost, and the login shell — which has a
+   fail-closed first-load JS budget — never pulls the launch, session-creation
+   or cloud-polling graph into its entry chunk.
+
 10. Liveness gates the pipeline; attendance gates presentation.
     Pipeline work (patch the entry, remap and materialize projected sessions,
     clear the entry) is gated on `isAttemptLive`. Presentation side effects
@@ -788,6 +802,15 @@ Pending failures must preserve enough state to retry or exit cleanly:
   one toast announces it. The deferred launch behind it releases its queued
   prompt through the launch intent instead of raising a second notice for the
   same failure
+- a workspace that reaches a terminal status other than ready (`error`, but
+  also `lost` and `archived`) fails its attempt on the spot. Waiting is only
+  correct while the outcome can still change; a terminal status means the
+  attempt would otherwise hold its entry and its queued prompt until the
+  hour-long staleness sweep
+- a queued prompt that fails to send after the create resolved is announced by
+  whoever launched it, not by the creation workflow's composer copy: a
+  background promotion has no composer holding the text, so its notice names
+  the workspace and offers a way to open it
 
 If materialization fails after a projected session exists, do not create a new
 session automatically. The user should see the failed workspace shell and keep
@@ -832,12 +855,16 @@ Minimum coverage by concern:
   attempt) leaves every other live attempt in the registry
 - cloud polling: an unattended attempt is polled and finalized, several parked
   attempts are polled, one tick refreshes at most the batch cap, an attempt
-  that leaves the awaiting state stops being polled, and a failed provision
-  marks that attempt's own entry
+  that leaves the awaiting state stops being polled, a failed provision marks
+  that attempt's own entry, a terminal non-error status fails the attempt
+  instead of parking it, the loop is mounted by the lifecycle root rather than
+  the shell (and off the signed-out shell entirely), and cache churn does not
+  make it tick faster than its interval
 - deferred launch promotion: a launch promotes on its own workspace's
   readiness, an unattended promotion leaves the active session and the selected
-  workspace untouched, an attended one still activates the created session, and
-  two launches promote independently
+  workspace untouched, an attended one still activates the created session, two
+  launches promote independently, and a queued prompt that fails to send
+  unattended is announced with its workspace instead of the composer copy
 - home launch: initial prompt remains attached to the projected session and
   does not create a second fresh session
 - interrupted empty-session creation: persistence precedes the create request,

--- a/specs/codebase/systems/product/workspaces/pending-shell.md
+++ b/specs/codebase/systems/product/workspaces/pending-shell.md
@@ -235,14 +235,11 @@ responses, and queued prompt edit/delete actions.
    place. A launch the user switched away from still materializes its workspace,
    sends its first prompt, and clears its own entry.
 
-   Scope today: local, worktree, and cowork attempts, plus cloud attempts whose
-   workspace is already ready when the create call returns. A cloud attempt that
-   returns still provisioning parks at `awaiting-cloud-ready`, and both drivers
-   that finish it (`use-cloud-workspace-polling` and
-   `use-selected-cloud-runtime-rehydration`) are scoped to the selected
-   workspace, so that attempt resumes only once the user re-attends it.
-   Background completion for provisioning cloud attempts is delivered by the
-   deferred-launch and polling rework, not by this registry.
+   A cloud attempt still provisioning is no exception. `use-cloud-workspace-polling`
+   drives every attempt parked at `awaiting-cloud-ready`, not the selected one,
+   so that workspace becomes ready, materializes, and clears its own entry
+   behind the user, and `use-home-deferred-launch-runner` sends the queued
+   prompt off the same per-attempt readiness.
 
 10. Liveness gates the pipeline; attendance gates presentation.
     Pipeline work (patch the entry, remap and materialize projected sessions,
@@ -782,11 +779,15 @@ Pending failures must preserve enough state to retry or exit cleanly:
   row is found
 - an interrupted empty-session create remains resumable under its original
   client id and runtime UUID until the runtime acknowledges that create
-- a cloud attempt left at `awaiting-cloud-ready` while the user is looking
-  elsewhere is stalled, not failed: it holds its registry entry and its queued
-  prompt, and resumes when the user re-attends the workspace. See the scope
-  note on invariant 9; background completion for this case is not delivered
-  yet
+- a cloud attempt still provisioning while the user is looking elsewhere is
+  stalled, not failed: it holds its registry entry and its queued prompt while
+  polling keeps working on it, and neither one waits on the user re-attending
+  the workspace
+- a cloud provisioning failure the user was not attending lands on the same
+  per-attempt surface as a create-time failure: the entry goes to `failed` and
+  one toast announces it. The deferred launch behind it releases its queued
+  prompt through the launch intent instead of raising a second notice for the
+  same failure
 
 If materialization fails after a projected session exists, do not create a new
 session automatically. The user should see the failed workspace shell and keep
@@ -826,11 +827,17 @@ Minimum coverage by concern:
 - finalization: projected sessions materialize before pending state clears
 - switching away mid-launch: the launch still materializes the workspace, sends
   its first prompt, and clears its own entry, without throwing, force-selecting,
-  firing an arrival event, or changing the active session (covered for the
-  local and worktree paths; the cloud awaiting-ready path is covered when
-  background completion for it lands)
+  firing an arrival event, or changing the active session
 - a per-workspace clear (retire, mark done, cloud delete, or dismissing one
   attempt) leaves every other live attempt in the registry
+- cloud polling: an unattended attempt is polled and finalized, several parked
+  attempts are polled, one tick refreshes at most the batch cap, an attempt
+  that leaves the awaiting state stops being polled, and a failed provision
+  marks that attempt's own entry
+- deferred launch promotion: a launch promotes on its own workspace's
+  readiness, an unattended promotion leaves the active session and the selected
+  workspace untouched, an attended one still activates the created session, and
+  two launches promote independently
 - home launch: initial prompt remains attached to the projected session and
   does not create a second fresh session
 - interrupted empty-session creation: persistence precedes the create request,


### PR DESCRIPTION
## Problem

A cloud launch only finished while the user was watching it. `useCloudWorkspacePolling` polled the *selected* workspace, and the deferred launch runner promoted a queued prompt only once the selected workspace's runtime was ready. Start a cloud workspace, click away to another one, and the first attempt parked at `awaiting-cloud-ready` — sandbox provisioning kept going server-side, but nothing on the client ever noticed it finish, so the prompt stayed queued and the sidebar row stayed a spinner until the user re-attended the attempt and effectively hand-cranked it.

That is the scope gap in Invariant 9. The rest of the ladder made launches per-attempt; this one was still per-selection. Liveness is supposed to gate the pipeline and attendance only the presentation, and here attendance was gating the pipeline.

## Design

**Poll the registry, not the selection.** `useCloudWorkspacePolling` now walks every `awaiting-cloud-ready` entry in the pending registry rather than the selected workspace. The tick is a capped rotating batch (`cloud-workspace-poll-plan.ts`): at most three workspaces per tick, rotating by a cursor so an entry at the back of the queue is never starved while the cap keeps a five-launch registry from turning into five concurrent status requests. Each poll writes its outcome to its own entry through `patchAttempt`, so two launches in flight cannot cross-write each other's stage.

**Promote per launch, selection-free.** `deferred-launch-readiness.ts` decides readiness from the launch's own workspace and its own pending entry rather than from what the user is looking at. The runner promotes each ready launch independently — sends the queued prompt, clears the entry — and only *activates* (steals selection and the active session) when the attempt is attended. Unattended launches complete silently in the background and are there when the user comes back.

**Failure lands where the ladder already puts it.** A readiness failure on an unattended attempt marks the entry `failed` and announces it through the per-entry failure presentation from #1870 — the sidebar error row plus the one-shot toast — instead of the shell receipt that belongs to whatever workspace is on screen.

## Files

- `hooks/chat/lifecycle/use-cloud-workspace-polling.ts` — registry-wide capped rotating poll, per-entry `patchAttempt` outcomes
- `lib/domain/workspaces/cloud/cloud-workspace-poll-plan.ts` — the batch/cursor plan, extracted as pure domain
- `hooks/home/lifecycle/use-home-deferred-launch-runner.ts` — per-launch promotion, attended-gated activation
- `lib/domain/home/deferred-launch-readiness.ts` — readiness from the launch's own workspace + entry
- `hooks/workspaces/derived/use-pending-workspace-entries.ts`, `hooks/workspaces/workflows/pending-workspace-attempt-access.ts`, `lib/domain/workspaces/creation/pending-attention.ts` — the awaiting-entry selector and attendance accessors the two hooks read
- `specs/codebase/systems/product/workspaces/pending-shell.md` — background completion documented

11 files, +1153/−299.

## Tests

- `use-cloud-workspace-polling.test.tsx` — 9 tests: unattended finalization without moving selection, every awaiting entry polled, the three-per-tick cap, polling stops when an entry leaves `awaiting-cloud-ready`, unattended failure marked and announced.
- `use-home-deferred-launch-runner.test.tsx` — 6 tests: background promotion without stealing selection or the active session, activation when attended, the pending shell of an attended attempt counted as attended, two launches promoted independently, waiting while one workspace is still provisioning, queued prompt released on a failed attempt.
- `cloud-workspace-poll-plan.test.ts` — 10 tests on the cap and cursor rotation.

Both negative controls run and observed:

- Restricting the polling hook back to attended entries (`useAwaitingCloudWorkspaceEntries().filter(e => isAttemptAttended(e.attemptId))`) fails 5 of the 9 polling tests — including "finalizes an unattended awaiting entry without moving selection" and "marks an unattended awaiting entry failed and announces it when readiness fails".
- Gating promotion on attendance in the runner (the pre-fix behaviour) fails 3 of the 6 runner tests — "promotes a background launch without stealing selection or the active session", "promotes two deferred launches independently", "waits while one launch's workspace is still provisioning".

Both files restored; full product-client suite green (868 files, 6084 tests), `tsconfig.json` and `tsconfig.domain.json` typechecks clean, frontend boundary check clean.

## Ladder position

Final slice (4 of 4) of the PRO-230 launch registry ladder, stacked on #1870.

https://linear.app/proliferate-team/issue/PRO-230/stitching-workspace-while-a-new-workspace-destroys-the-new-workspace

## Known follow-ups

- `use-selected-cloud-runtime-rehydration` still carries an `awaiting-cloud-ready` finalization branch that the registry-wide poll now reaches first. It is race-safe — both paths converge on the same `patchAttempt` — but it is dead weight and should come out in a follow-up rather than inside this slice.
- Unattended cloud materialization against a workspace that never connects deserves one live check before merge. The tests cover the readiness-failure path with a stubbed status; the real never-connects timeout is worth watching once end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
