### PR TITLE
feat(server): gen-2 workflow definitions and invocation freeze (workflows gen-2 PR2)

### DIFF
--- a/apps/packages/product-client/src/components/workflows/definitions/WorkflowDefinitionsSurface.tsx
+++ b/apps/packages/product-client/src/components/workflows/definitions/WorkflowDefinitionsSurface.tsx
@@ -233,6 +233,15 @@ function ExistingWorkflowDefinitionEditor({
   }
 
   const definition = workflowDefinitionModel(definitionQuery.data);
+  if (!definition) {
+    return (
+      <WorkflowResourceState
+        title="Unsupported workflow version"
+        description="This workflow was saved by a newer builder and cannot be edited here."
+        onBack={onBack}
+      />
+    );
+  }
   return (
     <PersistedWorkflowEditor
       authCacheScope={authCacheScope}

--- a/apps/packages/product-client/src/domain/workflows/definition.test.ts
+++ b/apps/packages/product-client/src/domain/workflows/definition.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import fullFixture from "../../../../../../fixtures/contracts/workflow-definition/full.json";
 import minimalFixture from "../../../../../../fixtures/contracts/workflow-definition/minimal.json";
+import v2FullFixture from "../../../../../../fixtures/contracts/workflow-definition/v2-full.json";
 import {
   createWorkflowDefinitionDraft,
+  workflowDefinitionFromResponse,
   resolveCanonicalWorkflowModelId,
   workflowDefinitionToDraft,
   workflowDraftToWriteInput,
@@ -295,5 +297,22 @@ describe("workflow definition draft", () => {
       path: "stages.0.steps.0.prompt",
       message,
     });
+  });
+});
+
+describe("gen-2 rows on the shared endpoints", () => {
+  it("maps a v1 response and skips a v2 response instead of crashing", () => {
+    const v1 = workflowDefinitionFromResponse(
+      fullFixture as unknown as Parameters<typeof workflowDefinitionFromResponse>[0],
+    );
+    expect(v1?.schemaVersion).toBe(1);
+
+    // A gen-2 row has schemaVersion 2 and no stages key at all; before the
+    // guard this mapper threw on response.stages.map and white-screened the
+    // Workflows page.
+    const v2 = workflowDefinitionFromResponse(
+      v2FullFixture as unknown as Parameters<typeof workflowDefinitionFromResponse>[0],
+    );
+    expect(v2).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/domain/workflows/definition.ts
+++ b/apps/packages/product-client/src/domain/workflows/definition.ts
@@ -1,6 +1,6 @@
 import type {
   WorkflowDefinitionCreateRequest,
-  WorkflowDefinitionResponse,
+  WorkflowDefinitionAnyResponse,
   WorkflowDefinitionUpdateRequest,
 } from "@proliferate/cloud-sdk";
 
@@ -136,8 +136,12 @@ export function createWorkflowDefinitionDraft(
 }
 
 export function workflowDefinitionFromResponse(
-  response: WorkflowDefinitionResponse,
-): WorkflowDefinition {
+  response: WorkflowDefinitionAnyResponse,
+): WorkflowDefinition | null {
+  if (response.schemaVersion !== 1) {
+    // A gen-2 row has no stages to map; its UI arrives with the v2 surfaces.
+    return null;
+  }
   return {
     id: response.id,
     userId: response.userId,

--- a/apps/packages/product-client/src/hooks/workflows/workflows/use-workflow-definition-actions.ts
+++ b/apps/packages/product-client/src/hooks/workflows/workflows/use-workflow-definition-actions.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import type { WorkflowDefinitionResponse } from "@proliferate/cloud-sdk";
+import type { WorkflowDefinitionAnyResponse } from "@proliferate/cloud-sdk";
 import {
   createWorkflowDefinitionDraft,
   workflowDefinitionToDraft,
@@ -62,7 +62,7 @@ export function useCreateWorkflowDefinitionActions({
 }
 
 export interface WorkflowDefinitionRefetchResult {
-  data?: WorkflowDefinitionResponse;
+  data?: WorkflowDefinitionAnyResponse;
   error?: unknown;
   isError: boolean;
 }
@@ -117,7 +117,11 @@ export function usePersistedWorkflowDefinitionActions({
       if (result.isError || !result.data) {
         throw result.error ?? new Error("Workflow could not be reloaded.");
       }
-      adopt(workflowDefinitionModel(result.data));
+      const next = workflowDefinitionModel(result.data);
+      if (!next) {
+        throw new Error("This workflow was saved by a newer builder and cannot be edited here.");
+      }
+      adopt(next);
     } catch (error) {
       setFailureMessage(workflowDefinitionWriteFailureMessage(error));
     }
@@ -135,7 +139,10 @@ export function usePersistedWorkflowDefinitionActions({
         workflowDefinitionId: base.id,
         body: workflowDraftToUpdateRequest(draft, base.revision, catalog),
       });
-      adopt(workflowDefinitionModel(updated));
+      const saved = workflowDefinitionModel(updated);
+      if (saved) {
+        adopt(saved);
+      }
       onSaved(updated.id);
     } catch (error) {
       recordWriteFailure(error);

--- a/apps/packages/product-client/src/lib/domain/workflows/workflow-definition-authoring.ts
+++ b/apps/packages/product-client/src/lib/domain/workflows/workflow-definition-authoring.ts
@@ -1,4 +1,4 @@
-import type { WorkflowDefinitionResponse } from "@proliferate/cloud-sdk";
+import type { WorkflowDefinitionAnyResponse } from "@proliferate/cloud-sdk";
 import {
   isWorkflowRevisionConflict,
   workflowDefinitionFromResponse,
@@ -12,15 +12,17 @@ export interface WorkflowRepositoryOptionModel {
 }
 
 export function workflowDefinitionModel(
-  response: WorkflowDefinitionResponse,
-): WorkflowDefinition {
+  response: WorkflowDefinitionAnyResponse,
+): WorkflowDefinition | null {
   return workflowDefinitionFromResponse(response);
 }
 
 export function workflowDefinitionModels(
-  responses: readonly WorkflowDefinitionResponse[],
+  responses: readonly WorkflowDefinitionAnyResponse[],
 ): WorkflowDefinition[] {
-  return responses.map(workflowDefinitionFromResponse);
+  return responses
+    .map(workflowDefinitionFromResponse)
+    .filter((definition): definition is WorkflowDefinition => definition !== null);
 }
 
 export function workflowRepositoryOptions(

--- a/cloud/sdk-react/src/hooks/workflows.ts
+++ b/cloud/sdk-react/src/hooks/workflows.ts
@@ -22,6 +22,7 @@ import {
   type ManagedWorkflowInvocationResponse,
   type WorkflowDefinitionCreateRequest,
   type WorkflowDefinitionListResponse,
+  type WorkflowDefinitionAnyResponse,
   type WorkflowDefinitionResponse,
   type WorkflowDefinitionUpdateRequest,
   type WorkflowInvocationCreateRequest,
@@ -77,7 +78,7 @@ export function useWorkflowDefinition(
   enabled = true,
 ) {
   const client = useCloudClient();
-  return useQuery<WorkflowDefinitionResponse>({
+  return useQuery<WorkflowDefinitionAnyResponse>({
     queryKey: workflowDefinitionDetailKey(
       client.baseUrl,
       authCacheScope,

--- a/cloud/sdk/src/client/workflows.ts
+++ b/cloud/sdk/src/client/workflows.ts
@@ -1,4 +1,5 @@
 import type {
+  WorkflowDefinitionAnyResponse,
   WorkflowDefinitionCreateRequest,
   WorkflowDefinitionListResponse,
   WorkflowDefinitionResponse,
@@ -30,8 +31,8 @@ export async function getWorkflowDefinition(
   workflowDefinitionId: string,
   client: ProliferateCloudClient = getProliferateClient(),
   options: WorkflowRequestOptions = {},
-): Promise<WorkflowDefinitionResponse> {
-  return client.requestJson<WorkflowDefinitionResponse>({
+): Promise<WorkflowDefinitionAnyResponse> {
+  return client.requestJson<WorkflowDefinitionAnyResponse>({
     method: "GET",
     path: "/v1/workflows/{workflow_definition_id}",
     pathParams: { workflow_definition_id: workflowDefinitionId },

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -7320,10 +7320,7 @@ export interface components {
         };
         /** WorkflowInvocationPlacementV2 */
         WorkflowInvocationPlacementV2: {
-            /**
-             * Repoconfigid
-             * Format: uuid
-             */
+            /** Repoconfigid */
             repoConfigId: string;
             /**
              * Mode

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -7063,10 +7063,39 @@ export interface components {
             /** Defaultrepoconfigid */
             defaultRepoConfigId?: string | null;
         };
-        /** WorkflowDefinitionListResponse */
-        WorkflowDefinitionListResponse: {
+        /** WorkflowDefinitionCreateRequestV2 */
+        WorkflowDefinitionCreateRequestV2: {
+            /** Title */
+            title: string;
+            /**
+             * Description
+             * @default
+             */
+            description: string;
+            /** Defaultrepoconfigid */
+            defaultRepoConfigId?: string | null;
+            definition: components["schemas"]["WorkflowDefinitionDocumentV2"];
+        };
+        /** WorkflowDefinitionDocumentV2 */
+        WorkflowDefinitionDocumentV2: {
+            /**
+             * Schemaversion
+             * @constant
+             */
+            schemaVersion: 2;
+            /** Nodes */
+            nodes: components["schemas"]["WorkflowNodeV2"][];
+            /** Edges */
+            edges?: components["schemas"]["WorkflowEdgeV2"][];
+            /** Inputs */
+            inputs?: components["schemas"]["WorkflowInputV2"][];
+            /** Doctemplates */
+            docTemplates?: components["schemas"]["WorkflowDocTemplateV2"][];
+        };
+        /** WorkflowDefinitionListAnyResponse */
+        WorkflowDefinitionListAnyResponse: {
             /** Workflows */
-            workflows: components["schemas"]["WorkflowDefinitionResponse"][];
+            workflows: (components["schemas"]["WorkflowDefinitionResponse"] | components["schemas"]["WorkflowDefinitionResponseV2"])[];
         };
         /** WorkflowDefinitionResponse */
         WorkflowDefinitionResponse: {
@@ -7112,6 +7141,45 @@ export interface components {
             /** Deletedat */
             deletedAt: string | null;
         };
+        /** WorkflowDefinitionResponseV2 */
+        WorkflowDefinitionResponseV2: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Userid
+             * Format: uuid
+             */
+            userId: string;
+            /** Title */
+            title: string;
+            /** Description */
+            description: string;
+            /**
+             * Schemaversion
+             * @constant
+             */
+            schemaVersion: 2;
+            /** Revision */
+            revision: number;
+            /** Defaultrepoconfigid */
+            defaultRepoConfigId: string | null;
+            definition: components["schemas"]["WorkflowDefinitionDocumentV2"];
+            /**
+             * Createdat
+             * Format: date-time
+             */
+            createdAt: string;
+            /**
+             * Updatedat
+             * Format: date-time
+             */
+            updatedAt: string;
+            /** Deletedat */
+            deletedAt: string | null;
+        };
         /** WorkflowDefinitionUpdateRequest */
         WorkflowDefinitionUpdateRequest: {
             /** Inputs */
@@ -7129,6 +7197,40 @@ export interface components {
             defaultRepoConfigId?: string | null;
             /** Expectedrevision */
             expectedRevision: number;
+        };
+        /** WorkflowDefinitionUpdateRequestV2 */
+        WorkflowDefinitionUpdateRequestV2: {
+            /** Title */
+            title: string;
+            /**
+             * Description
+             * @default
+             */
+            description: string;
+            /** Defaultrepoconfigid */
+            defaultRepoConfigId?: string | null;
+            definition: components["schemas"]["WorkflowDefinitionDocumentV2"];
+            /** Expectedrevision */
+            expectedRevision: number;
+        };
+        /** WorkflowDocTemplateV2 */
+        WorkflowDocTemplateV2: {
+            /** Slug */
+            slug: string;
+            /** Producingnodeid */
+            producingNodeId: string;
+            /**
+             * Body
+             * @default
+             */
+            body: string;
+        };
+        /** WorkflowEdgeV2 */
+        WorkflowEdgeV2: {
+            /** From */
+            from: string;
+            /** To */
+            to: string;
         };
         /** WorkflowExactModelSelection */
         WorkflowExactModelSelection: {
@@ -7166,6 +7268,18 @@ export interface components {
             /** Required */
             required: boolean;
         };
+        /** WorkflowInputV2 */
+        WorkflowInputV2: {
+            /** Name */
+            name: string;
+            /**
+             * Description
+             * @default
+             */
+            description: string;
+            /** Required */
+            required: boolean;
+        };
         /** WorkflowInvocationCreateRequest */
         WorkflowInvocationCreateRequest: {
             /**
@@ -7185,6 +7299,37 @@ export interface components {
                 [key: string]: boolean | number | string;
             };
             target: components["schemas"]["ManagedCloudWorkflowTarget"];
+        };
+        /** WorkflowInvocationCreateRequestV2 */
+        WorkflowInvocationCreateRequestV2: {
+            /**
+             * Schemaversion
+             * @constant
+             */
+            schemaVersion: 2;
+            /**
+             * Workflowdefinitionid
+             * Format: uuid
+             */
+            workflowDefinitionId: string;
+            /** Arguments */
+            arguments: {
+                [key: string]: boolean | number | string;
+            };
+            placement: components["schemas"]["WorkflowInvocationPlacementV2"];
+        };
+        /** WorkflowInvocationPlacementV2 */
+        WorkflowInvocationPlacementV2: {
+            /**
+             * Repoconfigid
+             * Format: uuid
+             */
+            repoConfigId: string;
+            /**
+             * Mode
+             * @enum {string}
+             */
+            mode: "worktree" | "repo_root";
         };
         /** WorkflowInvocationResponse */
         WorkflowInvocationResponse: {
@@ -7222,6 +7367,65 @@ export interface components {
              * Format: date-time
              */
             createdAt: string;
+        };
+        /** WorkflowInvocationResponseV2 */
+        WorkflowInvocationResponseV2: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Schemaversion
+             * @constant
+             */
+            schemaVersion: 2;
+            /**
+             * Workflowdefinitionid
+             * Format: uuid
+             */
+            workflowDefinitionId: string;
+            /** Definitionrevision */
+            definitionRevision: number;
+            /** Title */
+            title: string;
+            /** Description */
+            description: string;
+            definition: components["schemas"]["WorkflowDefinitionDocumentV2"];
+            /** Arguments */
+            arguments: {
+                [key: string]: boolean | number | string;
+            };
+            placement: components["schemas"]["WorkflowInvocationPlacementV2"];
+            /**
+             * Createdat
+             * Format: date-time
+             */
+            createdAt: string;
+        };
+        /** WorkflowNodeModelConfigV2 */
+        WorkflowNodeModelConfigV2: {
+            /** Agentkind */
+            agentKind: string;
+            /** Modelid */
+            modelId?: string | null;
+            /** Modeid */
+            modeId?: string | null;
+        };
+        /** WorkflowNodeV2 */
+        WorkflowNodeV2: {
+            /** Id */
+            id: string;
+            /**
+             * Type
+             * @enum {string}
+             */
+            type: "agent" | "human_in_loop";
+            /** Title */
+            title: string;
+            /** Prompt */
+            prompt: string;
+            model?: components["schemas"]["WorkflowNodeModelConfigV2"] | null;
         };
         /** WorkflowPromptStep */
         WorkflowPromptStep: {
@@ -12044,7 +12248,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["WorkflowDefinitionListResponse"];
+                    "application/json": components["schemas"]["WorkflowDefinitionListAnyResponse"];
                 };
             };
         };
@@ -12058,7 +12262,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["WorkflowDefinitionCreateRequest"];
+                "application/json": components["schemas"]["WorkflowDefinitionCreateRequestV2"] | components["schemas"]["WorkflowDefinitionCreateRequest"];
             };
         };
         responses: {
@@ -12068,7 +12272,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["WorkflowDefinitionResponse"];
+                    "application/json": components["schemas"]["WorkflowDefinitionResponse"] | components["schemas"]["WorkflowDefinitionResponseV2"];
                 };
             };
             /** @description Validation Error */
@@ -12130,7 +12334,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["WorkflowDefinitionResponse"];
+                    "application/json": components["schemas"]["WorkflowDefinitionResponse"] | components["schemas"]["WorkflowDefinitionResponseV2"];
                 };
             };
             /** @description Validation Error */
@@ -12155,7 +12359,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["WorkflowDefinitionUpdateRequest"];
+                "application/json": components["schemas"]["WorkflowDefinitionUpdateRequestV2"] | components["schemas"]["WorkflowDefinitionUpdateRequest"];
             };
         };
         responses: {
@@ -12165,7 +12369,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["WorkflowDefinitionResponse"];
+                    "application/json": components["schemas"]["WorkflowDefinitionResponse"] | components["schemas"]["WorkflowDefinitionResponseV2"];
                 };
             };
             /** @description Validation Error */
@@ -12227,7 +12431,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ManagedWorkflowInvocationResponse"];
+                    "application/json": components["schemas"]["ManagedWorkflowInvocationResponse"] | components["schemas"]["WorkflowInvocationResponseV2"];
                 };
             };
             /** @description Validation Error */
@@ -12252,7 +12456,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["WorkflowInvocationCreateRequest"];
+                "application/json": components["schemas"]["WorkflowInvocationCreateRequestV2"] | components["schemas"]["WorkflowInvocationCreateRequest"];
             };
         };
         responses: {
@@ -12262,7 +12466,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["WorkflowInvocationResponse"];
+                    "application/json": components["schemas"]["WorkflowInvocationResponse"] | components["schemas"]["WorkflowInvocationResponseV2"];
                 };
             };
             /** @description Created */
@@ -12271,7 +12475,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["WorkflowInvocationResponse"];
+                    "application/json": components["schemas"]["WorkflowInvocationResponse"] | components["schemas"]["WorkflowInvocationResponseV2"];
                 };
             };
             /** @description Validation Error */

--- a/cloud/sdk/src/types/workflows.ts
+++ b/cloud/sdk/src/types/workflows.ts
@@ -9,7 +9,7 @@ export type WorkflowStageDefinition = Schema<"WorkflowStageDefinition">;
 type GeneratedWorkflowDefinitionCreateRequest = Schema<"WorkflowDefinitionCreateRequest">;
 type GeneratedWorkflowDefinitionUpdateRequest = Schema<"WorkflowDefinitionUpdateRequest">;
 type GeneratedWorkflowDefinitionResponse = Schema<"WorkflowDefinitionResponse">;
-type GeneratedWorkflowDefinitionListResponse = Schema<"WorkflowDefinitionListResponse">;
+type GeneratedWorkflowDefinitionListResponse = Schema<"WorkflowDefinitionListAnyResponse">;
 
 export type WorkflowDefinitionCreateRequest =
   Omit<GeneratedWorkflowDefinitionCreateRequest, "description">
@@ -23,9 +23,17 @@ export type WorkflowDefinitionResponse =
   Omit<GeneratedWorkflowDefinitionResponse, "inputs">
   & { inputs: WorkflowInputDefinition[] };
 
+export type WorkflowDefinitionResponseV2 = Schema<"WorkflowDefinitionResponseV2">;
+
+// The shared, unflagged list/detail endpoints are polymorphic: gen-2 rows
+// (schemaVersion 2, no stages) ride beside v1 rows the moment one exists.
+export type WorkflowDefinitionAnyResponse =
+  | WorkflowDefinitionResponse
+  | WorkflowDefinitionResponseV2;
+
 export type WorkflowDefinitionListResponse =
   Omit<GeneratedWorkflowDefinitionListResponse, "workflows">
-  & { workflows: WorkflowDefinitionResponse[] };
+  & { workflows: WorkflowDefinitionAnyResponse[] };
 
 export type WorkflowRunEligibilityBlocker = Schema<"WorkflowRunEligibilityBlocker">;
 export type WorkflowRunEligibilityResponse = Schema<"WorkflowRunEligibilityResponse">;

--- a/delivery-spec-workflows-gen2-pr2-server-v2.md
+++ b/delivery-spec-workflows-gen2-pr2-server-v2.md
@@ -1,0 +1,154 @@
+# Delivery specification: Workflows gen-2 PR2 — server v2
+
+Status: frozen. Source of truth for intent: the Workflows gen-2 ADR
+(`Proliferate Workspace/ADRs/Workflows/Core/Workflows ADR.md`), sections
+"DB models → CP Postgres", "API, end to end, per plane → Server plane", and
+"High level sequencing → PR2 server v2". This spec governs only this PR's
+delta. Contradictions with current area docs are reported, never silently
+resolved.
+
+## Intent
+
+Teach the control plane the gen-2 workflow definition DSL (`schemaVersion: 2`)
+and the gen-2 invocation freeze shape, additively. v1 definitions and
+invocations keep validating and executing exactly as today until PR7. This PR
+is the first rung of the gen-2 ladder that other rungs consume: the runtime
+(PR3/PR4/PR5a) builds against the frozen `invocation_json` shape and the
+contract fixtures landed here; the client (PR5b/PR7) builds against the v2
+endpoints.
+
+## Scope
+
+### 1. v2 definition document validation
+
+New wire models plus a pure cross-field validator, with the v2 document shape:
+
+```json
+{
+  "schemaVersion": 2,
+  "nodes": [
+    { "id": "n_research", "type": "agent", "title": "Research the topic",
+      "prompt": "Research @input:topic and write findings into @doc:research-findings.",
+      "model": { "agentKind": "claude", "modelId": "...", "modeId": "..." } },
+    { "id": "n_review", "type": "human_in_loop", "title": "Review findings",
+      "prompt": "Summarize @doc:research-findings for review." }
+  ],
+  "edges": [ { "from": "n_research", "to": "n_review" } ],
+  "inputs": [ { "name": "topic", "description": "What to research", "required": true } ],
+  "docTemplates": [ { "slug": "research-findings", "producingNodeId": "n_research", "body": "# Findings\n" } ]
+}
+```
+
+Cross-field rules (pure function, designed for lockstep with the runtime's
+PR3 validator via the shared contract fixtures):
+
+- `nodes` non-empty; node ids unique; `type` is `agent | human_in_loop`.
+- `edges` form exactly one linear path covering all nodes: every node has at
+  most one incoming and one outgoing edge, exactly one head and one tail,
+  no cycles, no unreachable nodes; a single-node definition has zero edges.
+- `docTemplates` slugs unique (lowercase kebab); `producingNodeId` resolves to
+  a declared node.
+- Every `@input:name` reference in any prompt resolves to a declared input;
+  every `@doc:slug` reference resolves to a declared docTemplate.
+- `model` is optional per node and is a pass-through
+  `{ agentKind, modelId?, modeId? }`. No catalog validation for v2: the same
+  validator must be implementable identically on the runtime plane, which has
+  no CP catalog. (Deliberate departure from v1's catalog-checked validation;
+  the ADR's v2 validation list contains no catalog rule.)
+- No placement key anywhere in the DSL (`extra=forbid` at every level; a
+  dedicated invalid fixture pins the `placement` rejection).
+
+### 2. v2 endpoints (additive on the existing routes)
+
+- `POST /v1/workflows` and `PUT /v1/workflows/{id}` accept a v2 body
+  `{ title, description?, defaultRepoConfigId?, definition: <v2 document> }`
+  alongside the unchanged v1 flat body. v2 updates keep `expectedRevision`
+  (CP optimistic concurrency is current behavior the ADR table abbreviates).
+- `GET /v1/workflows` and `GET /v1/workflows/{id}` return v2 rows as
+  `{ ..., schemaVersion: 2, definition: {...} }` (no `inputs`/`stages`, no
+  `validatedCatalogVersion`).
+- `GET /v1/workflows/{id}/run-eligibility` returns eligible with no blockers
+  for v2 definitions (shape validity is guaranteed at write; placement is a
+  trigger-time binding).
+- `PUT /v1/workflow-invocations/{id}` accepts the v2 body
+  `{ schemaVersion: 2, workflowDefinitionId, arguments, placement: { repoConfigId, mode: "worktree" | "repo_root" } }`
+  and freezes:
+
+```json
+{
+  "id": "...", "schemaVersion": 2,
+  "workflowDefinitionId": "...", "definitionRevision": 3,
+  "title": "...", "description": "...",
+  "definition": { "the definition_json at trigger time, verbatim": "..." },
+  "arguments": { "topic": "..." },
+  "placement": { "repoConfigId": "...", "mode": "worktree" },
+  "createdAt": "..."
+}
+```
+
+  Idempotent on id via the existing canonical-JSON identity check. Placement
+  repo must exist and belong to the user. Arguments must cover required
+  inputs, name only declared inputs, and be portable scalars. A v2 invocation
+  of a v1 definition (and vice versa) is invalid. No `expectedRevision` in the
+  v2 body: gen-2 freezes whatever the definition is at trigger time, verbatim
+  (ADR snapshot custody ruling).
+- `GET /v1/workflow-invocations/{id}` returns the frozen record directly for
+  v2 (no managed-execution read). v2 invocations create no managed-execution
+  row; `deliver`/`cancel` on them 404 (no managed row exists), which is the
+  correct answer — gen-2 delivery is the client courier's job (PR5b).
+
+### 3. Storage
+
+- Alembic migration: relax `ck_workflow_definition_schema_version` and
+  `ck_workflow_invocation_schema_version` to `schema_version IN (1, 2)`; add
+  nullable `definition_json JSONB` to `workflow_definition`.
+- v2 rows: `schema_version=2`, `definition_json` holds the document,
+  `inputs_json`/`stages_json` stay `[]`, `validated_catalog_version` stays
+  `''` (v2 performs no catalog validation).
+
+### 4. Contract fixtures (`fixtures/contracts/workflow-definition/`)
+
+Both-planes fixtures; the Python tests here are the producer/consumer half,
+the runtime consumes them in PR3 (this closes the fixture gap where
+workflow-definition had a Python-only consumer):
+
+- `v2-full.json` — response-shaped full v2 definition (both node types, model
+  override, inputs, docTemplates).
+- `v2-minimal.json` — single node, zero edges/inputs/docTemplates.
+- `v2-invalid-*.json` — one file per rejected shape, each
+  `{ "expectedIssuePath": ..., "definition": ... }`: duplicate node id,
+  nonlinear edges (branch), edge cycle, unknown edge endpoint, duplicate doc
+  slug, unknown doc producing node, unresolved `@input:`, unresolved `@doc:`,
+  placement key in the DSL.
+- `run-snapshot-v2.json` — the frozen v2 `invocation_json`, byte-shape the
+  courier hands the runtime; an integration test proves the server produces
+  exactly this shape.
+- The existing `full.json`/`minimal.json` (v1) and
+  `fixtures/contracts/workflow-portable-execution/` are untouched (PR1 owns
+  the portable-execution deletion).
+
+### 5. Tests
+
+- Unit: fixture-driven v2 validation suite (valid fixtures pass; every
+  invalid fixture fails at its declared path); v2 wire-model rejection cases.
+- Integration: v2 definition CRUD lifecycle; v2 invocation freeze +
+  idempotency + conflict + argument/placement rejection + cross-version
+  rejection + GET-returns-frozen-record; run-snapshot fixture equality.
+- All existing v1 workflow tests pass unchanged (the "v1 keeps validating"
+  gate).
+
+### 6. Generated artifacts
+
+`server/openapi.json` and the cloud SDK generated client regenerate to carry
+the new models (mechanical, `make cloud-openapi cloud-client-generate`).
+
+## Out of scope
+
+Runtime SQLite schema, envelope rendering, WorkflowActor, runtime HTTP
+surface, client UI, v1 removal, starter templates. The gen-1 managed-execution
+lane is untouched on every rung.
+
+## Gate / revert
+
+Additive; plain revert. Nothing consumes v2 until PR5b lands behind the
+`workflows_v2` client flag.

--- a/delivery-spec-workflows-gen2-pr2-server-v2.md
+++ b/delivery-spec-workflows-gen2-pr2-server-v2.md
@@ -215,3 +215,19 @@ Each item names what changed.
 9. **The frozen invocation embeds the definition verbatim at the storage
    layer** — `invocation_json["definition"]` equals the definition row's
    `definition_json` — and this is now pinned DB-level by the producer test.
+10. **`defaultRepoConfigId` is a runtime-space opaque id (Ruling A,
+    live-testing follow-up, 2026-08-14).** The spec inherited gen-1's
+    behavior of resolving the definition's `defaultRepoConfigId` against the
+    CP repo-config store, but the client sources that field from RUNTIME
+    repo roots (`GET /v1/repo-roots`) — so every id the builder offers was
+    rejected with 400 while ids the builder can never produce were accepted.
+    The CP now applies shape-only validation (UUID-or-null at the request
+    model) and stores the id opaquely; resolution is the engine plane's job
+    at placement time. This required dropping the DB-level resolver too:
+    `workflow_definition.default_repo_config_id`'s FK into `repo_config`
+    (Postgres-enforced CP resolution) is dropped in this PR's migration and
+    recreated on downgrade after the v2-row deletes. v1 keeps its
+    creation-time ownership check at the service layer; `repo_config` is
+    soft-delete-only, so the FK's `ON DELETE SET NULL` never fired in
+    practice. The invocation-freeze path was audited and repeats no such
+    lookup — placement was already shape-only per amendment 6.

--- a/delivery-spec-workflows-gen2-pr2-server-v2.md
+++ b/delivery-spec-workflows-gen2-pr2-server-v2.md
@@ -152,3 +152,66 @@ lane is untouched on every rung.
 
 Additive; plain revert. Nothing consumes v2 until PR5b lands behind the
 `workflows_v2` client flag.
+
+## Amendments (review fix wave, 2026-08-14)
+
+The frozen sections above stand as written; this section corrects the claims
+the Opus review falsified and records the conductor rulings applied on top.
+Each item names what changed.
+
+1. **"Gate / revert: Additive; plain revert" is corrected.** The v2 write
+   path is live on the server the moment this merges, so v2 rows can exist.
+   A plain code revert leaves those rows routing through the v1 response
+   model (`schemaVersion: Literal[1]`) and 500s that user's list; the
+   migration downgrade now deletes v2 rows first (invocations, then
+   definitions) before recreating the narrow `schema_version = 1` CHECKs.
+   Deleting on downgrade is sanctioned: the feature ships dark, so v2 rows
+   exist only where v2 was exercised deliberately.
+2. **"Nothing consumes v2 until PR5b" is corrected.** The shared, unflagged
+   `GET /v1/workflows` list and detail endpoints are consumed by the live v1
+   Workflows UI today. This rung therefore also carries the client-safety
+   floor: `cloud/sdk` re-points its list type at the renamed
+   `WorkflowDefinitionListAnyResponse` generated schema (the stale name had
+   silently degraded to `any`), models the list/detail payloads as the
+   v1|v2 union, and `workflowDefinitionFromResponse` skips non-v1 rows
+   (returns null; the detail surface renders an "Unsupported workflow
+   version" state) instead of crashing on the missing `stages`.
+3. **"All existing v1 workflow tests pass unchanged" is corrected in
+   letter.** Three v1 tests were edited: the union request bodies namespace
+   422 error `loc`s by request-model branch, and the OpenAPI request/response
+   schemas for the shared routes went from `$ref` to `anyOf`. This is a wire
+   contract change on v1 routes for 422 error shapes and the OpenAPI
+   document; no in-repo client parses `loc`.
+4. **§6's `server/openapi.json` claim is corrected**: that file is
+   gitignored; the tracked, CI-verified artifact is
+   `cloud/sdk/src/generated/openapi.ts`.
+5. **§5 argument coverage is completed (Ruling H).** The implemented rule has
+   always been three-part: arguments name only declared inputs, cover every
+   `required` input, and cover every input referenced by any node prompt —
+   referenced-but-optional inputs included. The client satisfies the third
+   rule by sending `""` for blank optional inputs. Now documented and tested.
+6. **Placement validation is relaxed to shape-only (Ruling A).**
+   `placement.repoConfigId` is a non-empty string, not a CP repo config the
+   user owns: for local v1 it carries a RUNTIME repo-root id end to end. The
+   CP freezes placement verbatim and never resolves it — resolution is the
+   engine plane's job. (ADR contradiction journaled for the morning ruling.)
+7. **Reference grammar becomes scan-then-validate (Ruling C, amended C.1).**
+   The scanner detects sigils case-insensitively (so `@INPUT:x` is an error,
+   not silent literal text), captures the following run of non-space non-`@`
+   characters (back-to-back references parse individually), peels trailing
+   prose punctuation from the token, and validates the peeled token against
+   the canonical per-kind grammar. Malformed = wrong-case sigil, empty
+   token, or grammar-fail after the peel: wrong-case tokens, leading dashes,
+   underscore doc slugs, and unpeelable trailing junk (`@doc:plan.md`) are
+   validation errors, never silent non-matches or prefix matches — while a
+   sentence may end directly after a reference (`@doc:research-findings.`
+   is valid). Five `v2-invalid-ref-*` fixtures pin the rejects and
+   `v2-valid-refs.json` pins the accepts for all three planes.
+8. **Cross-version update guards are now symmetric.** The v1 update path
+   rejects v2 rows (400, path `schemaVersion`) before validating or writing;
+   the store only touches `definition_json` when a document is explicitly
+   provided. A v1 PUT replay against an invocation id occupied by a v2
+   invocation is a 409 conflict, not a 400 blaming stored data.
+9. **The frozen invocation embeds the definition verbatim at the storage
+   layer** — `invocation_json["definition"]` equals the definition row's
+   `definition_json` — and this is now pinned DB-level by the producer test.

--- a/fixtures/contracts/workflow-definition/run-snapshot-v2.json
+++ b/fixtures/contracts/workflow-definition/run-snapshot-v2.json
@@ -1,0 +1,79 @@
+{
+  "id": "50000000-0000-4000-8000-000000000001",
+  "schemaVersion": 2,
+  "workflowDefinitionId": "10000000-0000-4000-8000-000000000003",
+  "definitionRevision": 1,
+  "title": "Research and propose",
+  "description": "Research a topic, synthesize a proposal, gate on human review.",
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_research",
+        "type": "agent",
+        "title": "Research the topic",
+        "prompt": "Research @input:topic and write findings into @doc:research-findings.",
+        "model": {
+          "agentKind": "claude",
+          "modelId": "sonnet",
+          "modeId": "default"
+        }
+      },
+      {
+        "id": "n_synthesize",
+        "type": "agent",
+        "title": "Synthesize a proposal",
+        "prompt": "Read @doc:research-findings and write a proposal into @doc:proposal covering @input:topic."
+      },
+      {
+        "id": "n_review",
+        "type": "human_in_loop",
+        "title": "Review the proposal",
+        "prompt": "Summarize @doc:proposal for human review."
+      }
+    ],
+    "edges": [
+      {
+        "from": "n_research",
+        "to": "n_synthesize"
+      },
+      {
+        "from": "n_synthesize",
+        "to": "n_review"
+      }
+    ],
+    "inputs": [
+      {
+        "name": "topic",
+        "description": "What to research",
+        "required": true
+      },
+      {
+        "name": "depth",
+        "description": "Optional depth hint",
+        "required": false
+      }
+    ],
+    "docTemplates": [
+      {
+        "slug": "research-findings",
+        "producingNodeId": "n_research",
+        "body": "# Findings\n\n## Summary\n\n## Evidence\n\n## Open questions\n"
+      },
+      {
+        "slug": "proposal",
+        "producingNodeId": "n_synthesize",
+        "body": "# Proposal\n\n## Summary\n\n## For the next step\n"
+      }
+    ]
+  },
+  "arguments": {
+    "topic": "workflow engines",
+    "depth": "deep"
+  },
+  "placement": {
+    "repoConfigId": "40000000-0000-4000-8000-000000000001",
+    "mode": "worktree"
+  },
+  "createdAt": "2026-08-14T12:30:00Z"
+}

--- a/fixtures/contracts/workflow-definition/v2-full.json
+++ b/fixtures/contracts/workflow-definition/v2-full.json
@@ -1,0 +1,74 @@
+{
+  "id": "10000000-0000-4000-8000-000000000003",
+  "userId": "20000000-0000-4000-8000-000000000002",
+  "title": "Research and propose",
+  "description": "Research a topic, synthesize a proposal, gate on human review.",
+  "schemaVersion": 2,
+  "revision": 1,
+  "defaultRepoConfigId": "40000000-0000-4000-8000-000000000001",
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_research",
+        "type": "agent",
+        "title": "Research the topic",
+        "prompt": "Research @input:topic and write findings into @doc:research-findings.",
+        "model": {
+          "agentKind": "claude",
+          "modelId": "sonnet",
+          "modeId": "default"
+        }
+      },
+      {
+        "id": "n_synthesize",
+        "type": "agent",
+        "title": "Synthesize a proposal",
+        "prompt": "Read @doc:research-findings and write a proposal into @doc:proposal covering @input:topic."
+      },
+      {
+        "id": "n_review",
+        "type": "human_in_loop",
+        "title": "Review the proposal",
+        "prompt": "Summarize @doc:proposal for human review."
+      }
+    ],
+    "edges": [
+      {
+        "from": "n_research",
+        "to": "n_synthesize"
+      },
+      {
+        "from": "n_synthesize",
+        "to": "n_review"
+      }
+    ],
+    "inputs": [
+      {
+        "name": "topic",
+        "description": "What to research",
+        "required": true
+      },
+      {
+        "name": "depth",
+        "description": "Optional depth hint",
+        "required": false
+      }
+    ],
+    "docTemplates": [
+      {
+        "slug": "research-findings",
+        "producingNodeId": "n_research",
+        "body": "# Findings\n\n## Summary\n\n## Evidence\n\n## Open questions\n"
+      },
+      {
+        "slug": "proposal",
+        "producingNodeId": "n_synthesize",
+        "body": "# Proposal\n\n## Summary\n\n## For the next step\n"
+      }
+    ]
+  },
+  "createdAt": "2026-08-14T12:00:00Z",
+  "updatedAt": "2026-08-14T12:00:00Z",
+  "deletedAt": null
+}

--- a/fixtures/contracts/workflow-definition/v2-invalid-bad-node-type.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-bad-node-type.json
@@ -1,5 +1,6 @@
 {
   "rejectedBy": "shape",
+  "expectedIssuePath": "nodes.0.type",
   "definition": {
     "schemaVersion": 2,
     "nodes": [

--- a/fixtures/contracts/workflow-definition/v2-invalid-bad-node-type.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-bad-node-type.json
@@ -1,0 +1,14 @@
+{
+  "rejectedBy": "shape",
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_a",
+        "type": "robot",
+        "title": "Step",
+        "prompt": "Run."
+      }
+    ]
+  }
+}

--- a/fixtures/contracts/workflow-definition/v2-invalid-branching-edges.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-branching-edges.json
@@ -1,0 +1,37 @@
+{
+  "rejectedBy": "structure",
+  "expectedIssuePath": "edges.1.from",
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_a",
+        "type": "agent",
+        "title": "Step n_a",
+        "prompt": "Run step n_a."
+      },
+      {
+        "id": "n_b",
+        "type": "agent",
+        "title": "Step n_b",
+        "prompt": "Run step n_b."
+      },
+      {
+        "id": "n_c",
+        "type": "agent",
+        "title": "Step n_c",
+        "prompt": "Run step n_c."
+      }
+    ],
+    "edges": [
+      {
+        "from": "n_a",
+        "to": "n_b"
+      },
+      {
+        "from": "n_a",
+        "to": "n_c"
+      }
+    ]
+  }
+}

--- a/fixtures/contracts/workflow-definition/v2-invalid-disconnected-chain.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-disconnected-chain.json
@@ -1,6 +1,7 @@
 {
   "rejectedBy": "structure",
   "expectedIssuePath": "edges",
+  "note": "Correct arity and degrees, but the walk from the single head cannot reach every node; this is the fixture that genuinely exercises reachability (and with it, cycles hanging off the path).",
   "definition": {
     "schemaVersion": 2,
     "nodes": [

--- a/fixtures/contracts/workflow-definition/v2-invalid-disconnected-chain.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-disconnected-chain.json
@@ -1,0 +1,47 @@
+{
+  "rejectedBy": "structure",
+  "expectedIssuePath": "edges",
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_a",
+        "type": "agent",
+        "title": "Step n_a",
+        "prompt": "Run step n_a."
+      },
+      {
+        "id": "n_b",
+        "type": "agent",
+        "title": "Step n_b",
+        "prompt": "Run step n_b."
+      },
+      {
+        "id": "n_c",
+        "type": "agent",
+        "title": "Step n_c",
+        "prompt": "Run step n_c."
+      },
+      {
+        "id": "n_d",
+        "type": "agent",
+        "title": "Step n_d",
+        "prompt": "Run step n_d."
+      }
+    ],
+    "edges": [
+      {
+        "from": "n_a",
+        "to": "n_b"
+      },
+      {
+        "from": "n_c",
+        "to": "n_d"
+      },
+      {
+        "from": "n_d",
+        "to": "n_c"
+      }
+    ]
+  }
+}

--- a/fixtures/contracts/workflow-definition/v2-invalid-duplicate-doc-slug.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-duplicate-doc-slug.json
@@ -1,0 +1,27 @@
+{
+  "rejectedBy": "structure",
+  "expectedIssuePath": "docTemplates.1.slug",
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_a",
+        "type": "agent",
+        "title": "Step n_a",
+        "prompt": "Run step n_a."
+      }
+    ],
+    "docTemplates": [
+      {
+        "slug": "findings",
+        "producingNodeId": "n_a",
+        "body": ""
+      },
+      {
+        "slug": "findings",
+        "producingNodeId": "n_a",
+        "body": ""
+      }
+    ]
+  }
+}

--- a/fixtures/contracts/workflow-definition/v2-invalid-duplicate-input-name.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-duplicate-input-name.json
@@ -1,0 +1,25 @@
+{
+  "rejectedBy": "structure",
+  "expectedIssuePath": "inputs.1.name",
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_a",
+        "type": "agent",
+        "title": "Step n_a",
+        "prompt": "Run step n_a."
+      }
+    ],
+    "inputs": [
+      {
+        "name": "topic",
+        "required": true
+      },
+      {
+        "name": "topic",
+        "required": false
+      }
+    ]
+  }
+}

--- a/fixtures/contracts/workflow-definition/v2-invalid-duplicate-node-id.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-duplicate-node-id.json
@@ -1,0 +1,27 @@
+{
+  "rejectedBy": "structure",
+  "expectedIssuePath": "nodes.1.id",
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_a",
+        "type": "agent",
+        "title": "Step n_a",
+        "prompt": "Run step n_a."
+      },
+      {
+        "id": "n_a",
+        "type": "agent",
+        "title": "Step n_a",
+        "prompt": "Run step n_a."
+      }
+    ],
+    "edges": [
+      {
+        "from": "n_a",
+        "to": "n_a"
+      }
+    ]
+  }
+}

--- a/fixtures/contracts/workflow-definition/v2-invalid-edge-cycle.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-edge-cycle.json
@@ -1,0 +1,41 @@
+{
+  "rejectedBy": "structure",
+  "expectedIssuePath": "edges",
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_a",
+        "type": "agent",
+        "title": "Step n_a",
+        "prompt": "Run step n_a."
+      },
+      {
+        "id": "n_b",
+        "type": "agent",
+        "title": "Step n_b",
+        "prompt": "Run step n_b."
+      },
+      {
+        "id": "n_c",
+        "type": "agent",
+        "title": "Step n_c",
+        "prompt": "Run step n_c."
+      }
+    ],
+    "edges": [
+      {
+        "from": "n_a",
+        "to": "n_b"
+      },
+      {
+        "from": "n_b",
+        "to": "n_c"
+      },
+      {
+        "from": "n_c",
+        "to": "n_a"
+      }
+    ]
+  }
+}

--- a/fixtures/contracts/workflow-definition/v2-invalid-edge-cycle.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-edge-cycle.json
@@ -1,6 +1,7 @@
 {
   "rejectedBy": "structure",
   "expectedIssuePath": "edges",
+  "note": "A full cycle carries n edges for n nodes, so the edge-count arity rule rejects it first; this fixture pins arity, while v2-invalid-disconnected-chain pins the reachability walk (the rule a cycle off the head would otherwise evade).",
   "definition": {
     "schemaVersion": 2,
     "nodes": [

--- a/fixtures/contracts/workflow-definition/v2-invalid-placement-in-dsl.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-placement-in-dsl.json
@@ -1,5 +1,6 @@
 {
   "rejectedBy": "shape",
+  "expectedIssuePath": "placement",
   "definition": {
     "schemaVersion": 2,
     "nodes": [

--- a/fixtures/contracts/workflow-definition/v2-invalid-placement-in-dsl.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-placement-in-dsl.json
@@ -1,0 +1,18 @@
+{
+  "rejectedBy": "shape",
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_a",
+        "type": "agent",
+        "title": "Step n_a",
+        "prompt": "Run step n_a."
+      }
+    ],
+    "placement": {
+      "repoConfigId": "40000000-0000-4000-8000-000000000001",
+      "mode": "worktree"
+    }
+  }
+}

--- a/fixtures/contracts/workflow-definition/v2-invalid-ref-bad-case.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-ref-bad-case.json
@@ -1,0 +1,23 @@
+{
+  "rejectedBy": "structure",
+  "expectedIssuePath": "nodes.0.prompt",
+  "note": "Doc slugs are lowercase-only; a wrong-case reference to a declared slug is a malformed reference, not a silent non-match.",
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_a",
+        "type": "agent",
+        "title": "Step",
+        "prompt": "Write findings into @doc:Research-Findings"
+      }
+    ],
+    "docTemplates": [
+      {
+        "slug": "research-findings",
+        "producingNodeId": "n_a",
+        "body": "# Findings\n"
+      }
+    ]
+  }
+}

--- a/fixtures/contracts/workflow-definition/v2-invalid-ref-leading-dash.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-ref-leading-dash.json
@@ -1,0 +1,16 @@
+{
+  "rejectedBy": "structure",
+  "expectedIssuePath": "nodes.0.prompt",
+  "note": "A doc slug cannot start with a dash; the malformed token is an error, not a silent non-match.",
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_a",
+        "type": "agent",
+        "title": "Step",
+        "prompt": "Write into @doc:-leading and stop"
+      }
+    ]
+  }
+}

--- a/fixtures/contracts/workflow-definition/v2-invalid-ref-trailing-junk.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-ref-trailing-junk.json
@@ -1,0 +1,23 @@
+{
+  "rejectedBy": "structure",
+  "expectedIssuePath": "nodes.0.prompt",
+  "note": "Trailing junk after a valid token is an error, not a prefix match: the whole non-space run is the reference attempt.",
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_a",
+        "type": "agent",
+        "title": "Step",
+        "prompt": "Write the plan into @doc:plan.md today"
+      }
+    ],
+    "docTemplates": [
+      {
+        "slug": "plan",
+        "producingNodeId": "n_a",
+        "body": "# Plan\n"
+      }
+    ]
+  }
+}

--- a/fixtures/contracts/workflow-definition/v2-invalid-ref-underscore-slug.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-ref-underscore-slug.json
@@ -1,0 +1,16 @@
+{
+  "rejectedBy": "structure",
+  "expectedIssuePath": "nodes.0.prompt",
+  "note": "Doc slugs are kebab-case; an underscore token is a malformed reference. Input names take underscores, doc slugs never do.",
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_a",
+        "type": "agent",
+        "title": "Step",
+        "prompt": "Write into @doc:research_findings and stop"
+      }
+    ]
+  }
+}

--- a/fixtures/contracts/workflow-definition/v2-invalid-ref-wrong-case-sigil.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-ref-wrong-case-sigil.json
@@ -1,0 +1,23 @@
+{
+  "rejectedBy": "structure",
+  "expectedIssuePath": "nodes.0.prompt",
+  "note": "Sigils are detected case-insensitively so a wrong-case sigil is a malformed reference, never silent literal text.",
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_a",
+        "type": "agent",
+        "title": "Step",
+        "prompt": "Research @INPUT:topic today"
+      }
+    ],
+    "inputs": [
+      {
+        "name": "topic",
+        "description": "",
+        "required": true
+      }
+    ]
+  }
+}

--- a/fixtures/contracts/workflow-definition/v2-invalid-unknown-doc-producer.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-unknown-doc-producer.json
@@ -1,0 +1,22 @@
+{
+  "rejectedBy": "structure",
+  "expectedIssuePath": "docTemplates.0.producingNodeId",
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_a",
+        "type": "agent",
+        "title": "Step n_a",
+        "prompt": "Run step n_a."
+      }
+    ],
+    "docTemplates": [
+      {
+        "slug": "findings",
+        "producingNodeId": "n_ghost",
+        "body": ""
+      }
+    ]
+  }
+}

--- a/fixtures/contracts/workflow-definition/v2-invalid-unknown-edge-node.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-unknown-edge-node.json
@@ -1,0 +1,27 @@
+{
+  "rejectedBy": "structure",
+  "expectedIssuePath": "edges.0.to",
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_a",
+        "type": "agent",
+        "title": "Step n_a",
+        "prompt": "Run step n_a."
+      },
+      {
+        "id": "n_b",
+        "type": "agent",
+        "title": "Step n_b",
+        "prompt": "Run step n_b."
+      }
+    ],
+    "edges": [
+      {
+        "from": "n_a",
+        "to": "n_ghost"
+      }
+    ]
+  }
+}

--- a/fixtures/contracts/workflow-definition/v2-invalid-unresolved-doc-ref.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-unresolved-doc-ref.json
@@ -1,0 +1,15 @@
+{
+  "rejectedBy": "structure",
+  "expectedIssuePath": "nodes.0.prompt",
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_a",
+        "type": "agent",
+        "title": "Step",
+        "prompt": "Write into @doc:missing-doc."
+      }
+    ]
+  }
+}

--- a/fixtures/contracts/workflow-definition/v2-invalid-unresolved-input-ref.json
+++ b/fixtures/contracts/workflow-definition/v2-invalid-unresolved-input-ref.json
@@ -1,0 +1,15 @@
+{
+  "rejectedBy": "structure",
+  "expectedIssuePath": "nodes.0.prompt",
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_a",
+        "type": "agent",
+        "title": "Step",
+        "prompt": "Research @input:missing."
+      }
+    ]
+  }
+}

--- a/fixtures/contracts/workflow-definition/v2-minimal.json
+++ b/fixtures/contracts/workflow-definition/v2-minimal.json
@@ -1,0 +1,26 @@
+{
+  "id": "10000000-0000-4000-8000-000000000004",
+  "userId": "20000000-0000-4000-8000-000000000002",
+  "title": "One step",
+  "description": "",
+  "schemaVersion": 2,
+  "revision": 1,
+  "defaultRepoConfigId": null,
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_only",
+        "type": "agent",
+        "title": "Do the job",
+        "prompt": "Do the job."
+      }
+    ],
+    "edges": [],
+    "inputs": [],
+    "docTemplates": []
+  },
+  "createdAt": "2026-08-14T12:00:00Z",
+  "updatedAt": "2026-08-14T12:00:00Z",
+  "deletedAt": null
+}

--- a/fixtures/contracts/workflow-definition/v2-valid-refs.json
+++ b/fixtures/contracts/workflow-definition/v2-valid-refs.json
@@ -1,0 +1,33 @@
+{
+  "note": "Reference-scan edge cases that must VALIDATE on every plane (Ruling C.1): a sentence may end directly after a reference (trailing prose punctuation peels), references may sit back-to-back (capture stops at the next @), and quoted or comma-followed references resolve.",
+  "definition": {
+    "schemaVersion": 2,
+    "nodes": [
+      {
+        "id": "n_a",
+        "type": "agent",
+        "title": "Step",
+        "prompt": "Research @input:topic. Write into @doc:research-findings@doc:proposal, citing \"@input:topic\"."
+      }
+    ],
+    "inputs": [
+      {
+        "name": "topic",
+        "description": "",
+        "required": true
+      }
+    ],
+    "docTemplates": [
+      {
+        "slug": "research-findings",
+        "producingNodeId": "n_a",
+        "body": "# Findings\n"
+      },
+      {
+        "slug": "proposal",
+        "producingNodeId": "n_a",
+        "body": "# Proposal\n"
+      }
+    ]
+  }
+}

--- a/scripts/check_frontend_boundaries.py
+++ b/scripts/check_frontend_boundaries.py
@@ -159,6 +159,10 @@ PRODUCT_CLIENT_DOMAIN_FIXTURE_IMPORTS = {
         "../../../../../../fixtures/contracts/workflow-definition/minimal.json",
     ): "fixtures/contracts/workflow-definition/minimal.json",
     (
+        "workflows/definition.test.ts",
+        "../../../../../../fixtures/contracts/workflow-definition/v2-full.json",
+    ): "fixtures/contracts/workflow-definition/v2-full.json",
+    (
         "chats/transcript/transcript-presentation.test.ts",
         "../../../../../../../fixtures/contracts/native-subagent-transcript/claude.json",
     ): "fixtures/contracts/native-subagent-transcript/claude.json",
@@ -695,7 +699,7 @@ def find_product_client_domain_violations(path: Path) -> list[Violation]:
                         statement.lineno,
                         (
                             "ProductClient domain relative imports must stay within "
-                            "src/domain; only the four named contract fixtures may escape"
+                            "src/domain; only the five named contract fixtures may escape"
                         ),
                     )
                 )

--- a/server/alembic/versions/c7d9e1f3a5b7_workflow_definitions_v2.py
+++ b/server/alembic/versions/c7d9e1f3a5b7_workflow_definitions_v2.py
@@ -1,0 +1,81 @@
+"""Admit schema_version 2 workflow definitions and invocations.
+
+Gen-2 workflow definitions store their whole document in one
+``definition_json`` blob (nodes, edges, inputs, docTemplates) instead of the
+v1 ``inputs_json``/``stages_json`` split, and gen-2 invocations freeze a
+placement-carrying snapshot. Both tables' schema-version checks widen to
+``IN (1, 2)``; v1 rows are untouched and keep validating until PR7.
+
+Revision ID: c7d9e1f3a5b7
+Revises: b5d7f9a1c3e5
+Create Date: 2026-08-14 01:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "c7d9e1f3a5b7"
+down_revision: str | None = "b5d7f9a1c3e5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workflow_definition",
+        sa.Column(
+            "definition_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+    op.drop_constraint(
+        "ck_workflow_definition_schema_version",
+        "workflow_definition",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_workflow_definition_schema_version",
+        "workflow_definition",
+        "schema_version IN (1, 2)",
+    )
+    op.drop_constraint(
+        "ck_workflow_invocation_schema_version",
+        "workflow_invocation",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_workflow_invocation_schema_version",
+        "workflow_invocation",
+        "schema_version IN (1, 2)",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_workflow_invocation_schema_version",
+        "workflow_invocation",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_workflow_invocation_schema_version",
+        "workflow_invocation",
+        "schema_version = 1",
+    )
+    op.drop_constraint(
+        "ck_workflow_definition_schema_version",
+        "workflow_definition",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_workflow_definition_schema_version",
+        "workflow_definition",
+        "schema_version = 1",
+    )
+    op.drop_column("workflow_definition", "definition_json")

--- a/server/alembic/versions/c7d9e1f3a5b7_workflow_definitions_v2.py
+++ b/server/alembic/versions/c7d9e1f3a5b7_workflow_definitions_v2.py
@@ -58,6 +58,13 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # Pre-v2 code cannot read schema_version 2 rows (its response models pin
+    # Literal[1]), and the narrow CHECKs below cannot be recreated over them.
+    # Deleting v2 rows on downgrade is sanctioned: the feature ships dark
+    # (flag-off beta), so these rows only exist where someone exercised v2
+    # deliberately. Invocations go first — they reference definitions.
+    op.execute(sa.text("DELETE FROM workflow_invocation WHERE schema_version = 2"))
+    op.execute(sa.text("DELETE FROM workflow_definition WHERE schema_version = 2"))
     op.drop_constraint(
         "ck_workflow_invocation_schema_version",
         "workflow_invocation",

--- a/server/alembic/versions/c7d9e1f3a5b7_workflow_definitions_v2.py
+++ b/server/alembic/versions/c7d9e1f3a5b7_workflow_definitions_v2.py
@@ -21,7 +21,7 @@ from sqlalchemy.dialects import postgresql
 from alembic import op
 
 revision: str = "c7d9e1f3a5b7"
-down_revision: str | None = "b5d7f9a1c3e5"
+down_revision: str | None = "da8a01b4ad7a"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/server/alembic/versions/c7d9e1f3a5b7_workflow_definitions_v2.py
+++ b/server/alembic/versions/c7d9e1f3a5b7_workflow_definitions_v2.py
@@ -55,6 +55,16 @@ def upgrade() -> None:
         "workflow_invocation",
         "schema_version IN (1, 2)",
     )
+    # Ruling A: a v2 definition's defaultRepoConfigId lives in the RUNTIME
+    # repo-root id space, so the CP cannot resolve it — an FK into repo_config
+    # is exactly that resolution, enforced by Postgres. v1 rows keep their
+    # creation-time ownership check at the service layer, and repo_config is
+    # soft-delete-only, so the FK's ON DELETE SET NULL never fired in practice.
+    op.drop_constraint(
+        "workflow_definition_default_repo_config_id_fkey",
+        "workflow_definition",
+        type_="foreignkey",
+    )
 
 
 def downgrade() -> None:
@@ -65,6 +75,16 @@ def downgrade() -> None:
     # deliberately. Invocations go first — they reference definitions.
     op.execute(sa.text("DELETE FROM workflow_invocation WHERE schema_version = 2"))
     op.execute(sa.text("DELETE FROM workflow_definition WHERE schema_version = 2"))
+    # Safe once v2 rows are gone: surviving v1 rows only ever stored ids the
+    # service layer resolved against repo_config at write time.
+    op.create_foreign_key(
+        "workflow_definition_default_repo_config_id_fkey",
+        "workflow_definition",
+        "repo_config",
+        ["default_repo_config_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
     op.drop_constraint(
         "ck_workflow_invocation_schema_version",
         "workflow_invocation",

--- a/server/proliferate/db/models/workflows.py
+++ b/server/proliferate/db/models/workflows.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     Integer,
     String,
     Text,
+    Uuid,
     text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
@@ -68,8 +69,11 @@ class WorkflowDefinition(Base):
         server_default=text("1"),
     )
     validated_catalog_version: Mapped[str] = mapped_column(String(128))
+    # Deliberately not an FK (Ruling A): for schema_version 2 rows this is an
+    # opaque RUNTIME repo-root id the CP never resolves; v1 rows validate
+    # ownership at the service layer instead.
     default_repo_config_id: Mapped[uuid.UUID | None] = mapped_column(
-        ForeignKey("repo_config.id", ondelete="SET NULL"),
+        Uuid,
         nullable=True,
     )
     inputs_json: Mapped[list[dict[str, object]]] = mapped_column(

--- a/server/proliferate/db/models/workflows.py
+++ b/server/proliferate/db/models/workflows.py
@@ -27,7 +27,7 @@ class WorkflowDefinition(Base):
     __tablename__ = "workflow_definition"
     __table_args__ = (
         CheckConstraint(
-            "schema_version = 1",
+            "schema_version IN (1, 2)",
             name="ck_workflow_definition_schema_version",
         ),
         CheckConstraint(
@@ -82,6 +82,10 @@ class WorkflowDefinition(Base):
         default=list,
         server_default=text("'[]'::jsonb"),
     )
+    definition_json: Mapped[dict[str, object] | None] = mapped_column(
+        JSONB,
+        nullable=True,
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
@@ -95,7 +99,7 @@ class WorkflowInvocation(Base):
     __tablename__ = "workflow_invocation"
     __table_args__ = (
         CheckConstraint(
-            "schema_version = 1",
+            "schema_version IN (1, 2)",
             name="ck_workflow_invocation_schema_version",
         ),
         Index("ix_workflow_invocation_user_created", "user_id", "created_at", "id"),

--- a/server/proliferate/db/store/workflow_definitions.py
+++ b/server/proliferate/db/store/workflow_definitions.py
@@ -142,6 +142,20 @@ async def update_workflow_definition_if_revision(
     stages_json: list[dict[str, object]],
     definition_json: dict[str, object] | None = None,
 ) -> WorkflowDefinitionSnapshot | None:
+    values: dict[str, object] = {
+        "title": title,
+        "description": description,
+        "validated_catalog_version": validated_catalog_version,
+        "default_repo_config_id": default_repo_config_id,
+        "inputs_json": deepcopy(inputs_json),
+        "stages_json": deepcopy(stages_json),
+        "revision": WorkflowDefinition.revision + 1,
+        "updated_at": utcnow(),
+    }
+    # v1 callers never carry a document; leaving the column untouched here is
+    # what keeps a v2 row's definition_json safe from a v1-shaped update.
+    if definition_json is not None:
+        values["definition_json"] = deepcopy(definition_json)
     result = await db.execute(
         update(WorkflowDefinition)
         .where(
@@ -150,17 +164,7 @@ async def update_workflow_definition_if_revision(
             WorkflowDefinition.revision == expected_revision,
             WorkflowDefinition.deleted_at.is_(None),
         )
-        .values(
-            title=title,
-            description=description,
-            validated_catalog_version=validated_catalog_version,
-            default_repo_config_id=default_repo_config_id,
-            inputs_json=deepcopy(inputs_json),
-            stages_json=deepcopy(stages_json),
-            definition_json=deepcopy(definition_json),
-            revision=WorkflowDefinition.revision + 1,
-            updated_at=utcnow(),
-        )
+        .values(**values)
         .returning(WorkflowDefinition)
     )
     row = result.scalar_one_or_none()

--- a/server/proliferate/db/store/workflow_definitions.py
+++ b/server/proliferate/db/store/workflow_definitions.py
@@ -26,6 +26,7 @@ class WorkflowDefinitionSnapshot:
     default_repo_config_id: UUID | None
     inputs_json: tuple[dict[str, object], ...]
     stages_json: tuple[dict[str, object], ...]
+    definition_json: dict[str, object] | None
     created_at: datetime
     updated_at: datetime
     deleted_at: datetime | None
@@ -43,6 +44,7 @@ def _snapshot(row: WorkflowDefinition) -> WorkflowDefinitionSnapshot:
         default_repo_config_id=row.default_repo_config_id,
         inputs_json=tuple(deepcopy(row.inputs_json or [])),
         stages_json=tuple(deepcopy(row.stages_json or [])),
+        definition_json=deepcopy(row.definition_json),
         created_at=row.created_at,
         updated_at=row.updated_at,
         deleted_at=row.deleted_at,
@@ -102,18 +104,21 @@ async def create_workflow_definition(
     default_repo_config_id: UUID | None,
     inputs_json: list[dict[str, object]],
     stages_json: list[dict[str, object]],
+    schema_version: int = 1,
+    definition_json: dict[str, object] | None = None,
 ) -> WorkflowDefinitionSnapshot:
     now = utcnow()
     row = WorkflowDefinition(
         user_id=user_id,
         title=title,
         description=description,
-        schema_version=1,
+        schema_version=schema_version,
         revision=1,
         validated_catalog_version=validated_catalog_version,
         default_repo_config_id=default_repo_config_id,
         inputs_json=deepcopy(inputs_json),
         stages_json=deepcopy(stages_json),
+        definition_json=deepcopy(definition_json),
         created_at=now,
         updated_at=now,
         deleted_at=None,
@@ -135,6 +140,7 @@ async def update_workflow_definition_if_revision(
     default_repo_config_id: UUID | None,
     inputs_json: list[dict[str, object]],
     stages_json: list[dict[str, object]],
+    definition_json: dict[str, object] | None = None,
 ) -> WorkflowDefinitionSnapshot | None:
     result = await db.execute(
         update(WorkflowDefinition)
@@ -151,6 +157,7 @@ async def update_workflow_definition_if_revision(
             default_repo_config_id=default_repo_config_id,
             inputs_json=deepcopy(inputs_json),
             stages_json=deepcopy(stages_json),
+            definition_json=deepcopy(definition_json),
             revision=WorkflowDefinition.revision + 1,
             updated_at=utcnow(),
         )

--- a/server/proliferate/db/store/workflow_invocations.py
+++ b/server/proliferate/db/store/workflow_invocations.py
@@ -100,6 +100,7 @@ async def create_workflow_invocation(
     creation_request_json: dict[str, object],
     invocation_json: dict[str, object],
     created_at: datetime,
+    schema_version: int = 1,
 ) -> WorkflowInvocationSnapshot:
     row = WorkflowInvocation(
         id=invocation_id,
@@ -108,7 +109,7 @@ async def create_workflow_invocation(
         definition_revision=definition_revision,
         title_snapshot=title_snapshot,
         description_snapshot=description_snapshot,
-        schema_version=1,
+        schema_version=schema_version,
         creation_request_json=deepcopy(creation_request_json),
         invocation_json=deepcopy(invocation_json),
         created_at=created_at,

--- a/server/proliferate/main.py
+++ b/server/proliferate/main.py
@@ -166,12 +166,38 @@ def _redacts_entire_body(request: Request) -> bool:
     return request.method == "POST" and "/agent-auth/keys" in request.url.path
 
 
+def _is_workflow_invocation_put(request: Request) -> bool:
+    return request.method == "PUT" and "/workflow-invocations/" in request.url.path
+
+
 def _is_workflow_invocation_argument_error(request: Request, loc: object) -> bool:
-    if request.method != "PUT" or "/workflow-invocations/" not in request.url.path:
+    if not _is_workflow_invocation_put(request):
         return False
     if not isinstance(loc, tuple | list):
         return False
     return len(loc) >= 2 and loc[0] == "body" and "arguments" in loc[1:]
+
+
+def _redact_workflow_invocation_arguments(value: object) -> object:
+    """Blank the arguments subtree wherever it appears in an echoed input.
+
+    A union request body makes pydantic echo the whole submitted document on
+    branch-level errors, so loc-based matching alone no longer catches every
+    place an argument value can surface.
+    """
+
+    if isinstance(value, dict):
+        return {
+            key: (
+                _REDACTED_INPUT
+                if key == "arguments"
+                else _redact_workflow_invocation_arguments(child)
+            )
+            for key, child in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_workflow_invocation_arguments(child) for child in value]
+    return value
 
 
 async def _validation_error_handler(
@@ -191,7 +217,10 @@ async def _validation_error_handler(
             ):
                 item["input"] = _REDACTED_INPUT
             else:
-                item["input"] = _redact_validation_input(item["input"])
+                redacted = _redact_validation_input(item["input"])
+                if _is_workflow_invocation_put(request):
+                    redacted = _redact_workflow_invocation_arguments(redacted)
+                item["input"] = redacted
         errors.append(item)
     return JSONResponse(status_code=422, content=jsonable_encoder({"detail": errors}))
 

--- a/server/proliferate/server/workflows/api.py
+++ b/server/proliferate/server/workflows/api.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from proliferate.auth.dependencies import current_product_user
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
+from proliferate.db.store.workflow_definitions import WorkflowDefinitionSnapshot
 from proliferate.server.workflows.access import (
     WorkflowDefinitionDependency,
     WorkflowInvocationDependency,
@@ -31,7 +32,6 @@ from proliferate.server.workflows.managed_models import (
 )
 from proliferate.server.workflows.models import (
     WorkflowDefinitionCreateRequest,
-    WorkflowDefinitionListResponse,
     WorkflowDefinitionResponse,
     WorkflowDefinitionUpdateRequest,
     WorkflowInvocationCreateRequest,
@@ -41,6 +41,16 @@ from proliferate.server.workflows.models import (
     workflow_definition_response,
     workflow_invocation_response,
 )
+from proliferate.server.workflows.models_v2 import (
+    WorkflowDefinitionCreateRequestV2,
+    WorkflowDefinitionListAnyResponse,
+    WorkflowDefinitionResponseV2,
+    WorkflowDefinitionUpdateRequestV2,
+    WorkflowInvocationCreateRequestV2,
+    WorkflowInvocationResponseV2,
+    workflow_definition_response_v2,
+    workflow_invocation_response_v2,
+)
 from proliferate.server.workflows.service import (
     create_workflow_definition,
     delete_workflow_definition,
@@ -49,6 +59,20 @@ from proliferate.server.workflows.service import (
     update_workflow_definition,
     workflow_run_eligibility,
 )
+from proliferate.server.workflows.service_v2 import (
+    create_workflow_definition_v2,
+    put_workflow_invocation_v2,
+    update_workflow_definition_v2,
+)
+
+
+def _definition_response(
+    value: WorkflowDefinitionSnapshot,
+) -> WorkflowDefinitionResponse | WorkflowDefinitionResponseV2:
+    if value.schema_version == 2:
+        return workflow_definition_response_v2(value)
+    return workflow_definition_response(value)
+
 
 router = APIRouter(prefix="/workflows", tags=["workflows"])
 invocations_router = APIRouter(prefix="/workflow-invocations", tags=["workflow-invocations"])
@@ -56,30 +80,34 @@ invocations_router = APIRouter(prefix="/workflow-invocations", tags=["workflow-i
 
 @router.get(
     "",
-    response_model=WorkflowDefinitionListResponse,
+    response_model=WorkflowDefinitionListAnyResponse,
     response_model_exclude_unset=True,
 )
 async def list_workflow_definitions_endpoint(
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_product_user),
-) -> WorkflowDefinitionListResponse:
+) -> WorkflowDefinitionListAnyResponse:
     values = await list_workflow_definitions(db, user_id=user.id)
-    return WorkflowDefinitionListResponse(
-        workflows=[workflow_definition_response(value) for value in values]
+    return WorkflowDefinitionListAnyResponse(
+        workflows=[_definition_response(value) for value in values]
     )
 
 
 @router.post(
     "",
-    response_model=WorkflowDefinitionResponse,
+    response_model=WorkflowDefinitionResponse | WorkflowDefinitionResponseV2,
     response_model_exclude_unset=True,
     status_code=status.HTTP_201_CREATED,
 )
 async def create_workflow_definition_endpoint(
-    body: WorkflowDefinitionCreateRequest,
+    body: WorkflowDefinitionCreateRequestV2 | WorkflowDefinitionCreateRequest,
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_product_user),
-) -> WorkflowDefinitionResponse:
+) -> WorkflowDefinitionResponse | WorkflowDefinitionResponseV2:
+    if isinstance(body, WorkflowDefinitionCreateRequestV2):
+        return workflow_definition_response_v2(
+            await create_workflow_definition_v2(db, user_id=user.id, body=body)
+        )
     value = await create_workflow_definition(db, user_id=user.id, body=body)
     return workflow_definition_response(value)
 
@@ -92,6 +120,8 @@ async def get_workflow_run_eligibility_endpoint(
     definition: WorkflowDefinitionDependency,
     db: AsyncSession = Depends(get_async_session),
 ) -> WorkflowRunEligibilityResponse:
+    if definition.schema_version == 2:
+        return WorkflowRunEligibilityResponse(eligible=True, blockers=[])
     blockers = await workflow_run_eligibility(db, definition=definition)
     return WorkflowRunEligibilityResponse(
         eligible=not blockers,
@@ -108,25 +138,29 @@ async def get_workflow_run_eligibility_endpoint(
 
 @router.get(
     "/{workflow_definition_id}",
-    response_model=WorkflowDefinitionResponse,
+    response_model=WorkflowDefinitionResponse | WorkflowDefinitionResponseV2,
     response_model_exclude_unset=True,
 )
 async def get_workflow_definition_endpoint(
     definition: WorkflowDefinitionDependency,
-) -> WorkflowDefinitionResponse:
-    return workflow_definition_response(definition)
+) -> WorkflowDefinitionResponse | WorkflowDefinitionResponseV2:
+    return _definition_response(definition)
 
 
 @router.put(
     "/{workflow_definition_id}",
-    response_model=WorkflowDefinitionResponse,
+    response_model=WorkflowDefinitionResponse | WorkflowDefinitionResponseV2,
     response_model_exclude_unset=True,
 )
 async def update_workflow_definition_endpoint(
-    body: WorkflowDefinitionUpdateRequest,
+    body: WorkflowDefinitionUpdateRequestV2 | WorkflowDefinitionUpdateRequest,
     definition: WorkflowDefinitionDependency,
     db: AsyncSession = Depends(get_async_session),
-) -> WorkflowDefinitionResponse:
+) -> WorkflowDefinitionResponse | WorkflowDefinitionResponseV2:
+    if isinstance(body, WorkflowDefinitionUpdateRequestV2):
+        return workflow_definition_response_v2(
+            await update_workflow_definition_v2(db, current=definition, body=body)
+        )
     value = await update_workflow_definition(db, current=definition, body=body)
     return workflow_definition_response(value)
 
@@ -147,19 +181,31 @@ async def delete_workflow_definition_endpoint(
 
 @invocations_router.put(
     "/{invocation_id}",
-    response_model=WorkflowInvocationResponse,
-    response_model_exclude_none=True,
     responses={
-        status.HTTP_200_OK: {"model": WorkflowInvocationResponse},
-        status.HTTP_201_CREATED: {"model": WorkflowInvocationResponse},
+        status.HTTP_200_OK: {"model": WorkflowInvocationResponse | WorkflowInvocationResponseV2},
+        status.HTTP_201_CREATED: {
+            "model": WorkflowInvocationResponse | WorkflowInvocationResponseV2
+        },
     },
 )
 async def put_workflow_invocation_endpoint(
     invocation_id: str,
-    body: WorkflowInvocationCreateRequest,
+    body: WorkflowInvocationCreateRequestV2 | WorkflowInvocationCreateRequest,
     db: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_product_user),
 ) -> JSONResponse:
+    if isinstance(body, WorkflowInvocationCreateRequestV2):
+        result = await put_workflow_invocation_v2(
+            db,
+            invocation_id_text=invocation_id,
+            user_id=user.id,
+            body=body,
+        )
+        response_v2 = workflow_invocation_response_v2(result.value)
+        return JSONResponse(
+            status_code=status.HTTP_201_CREATED if result.created else status.HTTP_200_OK,
+            content=response_v2.model_dump(by_alias=True, mode="json", exclude_none=True),
+        )
     result = await put_workflow_invocation(
         db,
         invocation_id_text=invocation_id,
@@ -199,12 +245,17 @@ async def list_workflow_invocation_history_endpoint(
 
 @invocations_router.get(
     "/{invocation_id}",
-    response_model=ManagedWorkflowInvocationResponse,
+    response_model=ManagedWorkflowInvocationResponse | WorkflowInvocationResponseV2,
 )
 async def get_workflow_invocation_endpoint(
     invocation: WorkflowInvocationDependency,
     db: AsyncSession = Depends(get_async_session),
 ) -> JSONResponse:
+    if invocation.schema_version == 2:
+        frozen = workflow_invocation_response_v2(invocation)
+        return JSONResponse(
+            content=frozen.model_dump(by_alias=True, mode="json", exclude_none=True)
+        )
     value = await read_managed_workflow(db, invocation=invocation)
     response = managed_workflow_invocation_response(
         value.invocation,

--- a/server/proliferate/server/workflows/api.py
+++ b/server/proliferate/server/workflows/api.py
@@ -12,7 +12,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from proliferate.auth.dependencies import current_product_user
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
-from proliferate.db.store.workflow_definitions import WorkflowDefinitionSnapshot
 from proliferate.server.workflows.access import (
     WorkflowDefinitionDependency,
     WorkflowInvocationDependency,
@@ -48,6 +47,7 @@ from proliferate.server.workflows.models_v2 import (
     WorkflowDefinitionUpdateRequestV2,
     WorkflowInvocationCreateRequestV2,
     WorkflowInvocationResponseV2,
+    workflow_definition_response_any,
     workflow_definition_response_v2,
     workflow_invocation_response_v2,
 )
@@ -65,15 +65,6 @@ from proliferate.server.workflows.service_v2 import (
     update_workflow_definition_v2,
 )
 
-
-def _definition_response(
-    value: WorkflowDefinitionSnapshot,
-) -> WorkflowDefinitionResponse | WorkflowDefinitionResponseV2:
-    if value.schema_version == 2:
-        return workflow_definition_response_v2(value)
-    return workflow_definition_response(value)
-
-
 router = APIRouter(prefix="/workflows", tags=["workflows"])
 invocations_router = APIRouter(prefix="/workflow-invocations", tags=["workflow-invocations"])
 
@@ -89,7 +80,7 @@ async def list_workflow_definitions_endpoint(
 ) -> WorkflowDefinitionListAnyResponse:
     values = await list_workflow_definitions(db, user_id=user.id)
     return WorkflowDefinitionListAnyResponse(
-        workflows=[_definition_response(value) for value in values]
+        workflows=[workflow_definition_response_any(value) for value in values]
     )
 
 
@@ -144,7 +135,7 @@ async def get_workflow_run_eligibility_endpoint(
 async def get_workflow_definition_endpoint(
     definition: WorkflowDefinitionDependency,
 ) -> WorkflowDefinitionResponse | WorkflowDefinitionResponseV2:
-    return _definition_response(definition)
+    return workflow_definition_response_any(definition)
 
 
 @router.put(

--- a/server/proliferate/server/workflows/domain/validation_v2.py
+++ b/server/proliferate/server/workflows/domain/validation_v2.py
@@ -1,0 +1,147 @@
+"""Pure cross-field validation for gen-2 workflow definition documents.
+
+Catalog-free by design: the identical rules run on the runtime plane (which
+has no CP catalog), kept in lockstep through the shared contract fixtures in
+``fixtures/contracts/workflow-definition/``. Issue paths are document-relative
+(``nodes.1.id``), matching the fixtures on both planes.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from proliferate.server.workflows.models_v2 import WorkflowDefinitionDocumentV2
+
+INPUT_REFERENCE_PATTERN = re.compile(r"@input:([A-Za-z][A-Za-z0-9_]*)")
+DOC_REFERENCE_PATTERN = re.compile(r"@doc:([a-z0-9]+(?:-[a-z0-9]+)*)")
+
+
+@dataclass(frozen=True)
+class DefinitionV2Issue:
+    path: str
+    message: str
+
+
+def validate_definition_v2_document(
+    document: WorkflowDefinitionDocumentV2,
+) -> DefinitionV2Issue | None:
+    """Return the first structural issue, or None for a valid document."""
+
+    node_ids: set[str] = set()
+    for index, node in enumerate(document.nodes):
+        if node.id in node_ids:
+            return DefinitionV2Issue(
+                path=f"nodes.{index}.id",
+                message=f"Node id '{node.id}' is duplicated.",
+            )
+        node_ids.add(node.id)
+
+    issue = _validate_linear_path(document, node_ids)
+    if issue is not None:
+        return issue
+
+    input_names: set[str] = set()
+    for index, input_definition in enumerate(document.inputs):
+        if input_definition.name in input_names:
+            return DefinitionV2Issue(
+                path=f"inputs.{index}.name",
+                message=f"Input name '{input_definition.name}' is duplicated.",
+            )
+        input_names.add(input_definition.name)
+
+    doc_slugs: set[str] = set()
+    for index, template in enumerate(document.doc_templates):
+        if template.slug in doc_slugs:
+            return DefinitionV2Issue(
+                path=f"docTemplates.{index}.slug",
+                message=f"Doc template slug '{template.slug}' is duplicated.",
+            )
+        doc_slugs.add(template.slug)
+        if template.producing_node_id not in node_ids:
+            return DefinitionV2Issue(
+                path=f"docTemplates.{index}.producingNodeId",
+                message=(
+                    f"Doc template '{template.slug}' names unknown producing node "
+                    f"'{template.producing_node_id}'."
+                ),
+            )
+
+    for index, node in enumerate(document.nodes):
+        for name in INPUT_REFERENCE_PATTERN.findall(node.prompt):
+            if name not in input_names:
+                return DefinitionV2Issue(
+                    path=f"nodes.{index}.prompt",
+                    message=f"Prompt references undeclared input '{name}'.",
+                )
+        for slug in DOC_REFERENCE_PATTERN.findall(node.prompt):
+            if slug not in doc_slugs:
+                return DefinitionV2Issue(
+                    path=f"nodes.{index}.prompt",
+                    message=f"Prompt references undeclared doc '{slug}'.",
+                )
+
+    return None
+
+
+def _validate_linear_path(
+    document: WorkflowDefinitionDocumentV2,
+    node_ids: set[str],
+) -> DefinitionV2Issue | None:
+    """Edges must form exactly one linear path covering every node."""
+
+    outgoing: dict[str, str] = {}
+    incoming: dict[str, str] = {}
+    for index, edge in enumerate(document.edges):
+        if edge.from_node not in node_ids:
+            return DefinitionV2Issue(
+                path=f"edges.{index}.from",
+                message=f"Edge names unknown node '{edge.from_node}'.",
+            )
+        if edge.to_node not in node_ids:
+            return DefinitionV2Issue(
+                path=f"edges.{index}.to",
+                message=f"Edge names unknown node '{edge.to_node}'.",
+            )
+        if edge.from_node in outgoing:
+            return DefinitionV2Issue(
+                path=f"edges.{index}.from",
+                message=f"Node '{edge.from_node}' has more than one outgoing edge.",
+            )
+        if edge.to_node in incoming:
+            return DefinitionV2Issue(
+                path=f"edges.{index}.to",
+                message=f"Node '{edge.to_node}' has more than one incoming edge.",
+            )
+        outgoing[edge.from_node] = edge.to_node
+        incoming[edge.to_node] = edge.from_node
+
+    if len(document.edges) != len(node_ids) - 1:
+        return DefinitionV2Issue(
+            path="edges",
+            message=(
+                "Edges must form exactly one linear path covering all nodes "
+                f"({len(node_ids)} nodes need {len(node_ids) - 1} edges, "
+                f"got {len(document.edges)})."
+            ),
+        )
+
+    heads = [node.id for node in document.nodes if node.id not in incoming]
+    if len(heads) != 1:
+        return DefinitionV2Issue(
+            path="edges",
+            message="Edges must form exactly one linear path with a single first node.",
+        )
+
+    visited = 0
+    cursor: str | None = heads[0]
+    while cursor is not None:
+        visited += 1
+        cursor = outgoing.get(cursor)
+    if visited != len(node_ids):
+        return DefinitionV2Issue(
+            path="edges",
+            message="Edges must form exactly one linear path covering all nodes.",
+        )
+
+    return None

--- a/server/proliferate/server/workflows/domain/validation_v2.py
+++ b/server/proliferate/server/workflows/domain/validation_v2.py
@@ -13,14 +13,43 @@ from dataclasses import dataclass
 
 from proliferate.server.workflows.models_v2 import WorkflowDefinitionDocumentV2
 
-INPUT_REFERENCE_PATTERN = re.compile(r"@input:([A-Za-z][A-Za-z0-9_]*)")
-DOC_REFERENCE_PATTERN = re.compile(r"@doc:([a-z0-9]+(?:-[a-z0-9]+)*)")
+# Scan-then-validate (Ruling C, amended C.1): sigils are detected
+# case-INsensitively so a wrong-case sigil is an error, not silent literal
+# text; the capture stops at whitespace or the next '@' (back-to-back
+# references parse individually); trailing prose punctuation peels off the
+# token before grammar validation, so a sentence may end directly after a
+# reference. Malformed = wrong-case sigil, empty token, or grammar-fail after
+# the peel. Trailing junk that does not peel ('@doc:plan.md') stays an error,
+# not a prefix match.
+REFERENCE_SCAN_PATTERN = re.compile(r"@(input|doc):([^\s@]*)", re.IGNORECASE)
+TRAILING_PROSE_PUNCTUATION_PATTERN = re.compile("[.,;:!?)\\]}>\"'`*»“”‘’…]+\\Z")
+INPUT_NAME_TOKEN_PATTERN = re.compile(r"[A-Za-z][A-Za-z0-9_]*\Z")
+DOC_SLUG_TOKEN_PATTERN = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*\Z")
 
 
 @dataclass(frozen=True)
 class DefinitionV2Issue:
     path: str
     message: str
+
+
+@dataclass(frozen=True)
+class PromptReference:
+    sigil: str
+    """The sigil word exactly as written (e.g. ``INPUT`` in ``@INPUT:x``)."""
+
+    kind: str
+    """Lowercased sigil: ``input`` or ``doc``."""
+
+    token: str
+    """The captured token after peeling trailing prose punctuation."""
+
+    raw_token: str
+    """The captured token as written, punctuation included."""
+
+    @property
+    def well_formed_sigil(self) -> bool:
+        return self.sigil == self.kind
 
 
 def validate_definition_v2_document(
@@ -68,19 +97,51 @@ def validate_definition_v2_document(
             )
 
     for index, node in enumerate(document.nodes):
-        for name in INPUT_REFERENCE_PATTERN.findall(node.prompt):
-            if name not in input_names:
-                return DefinitionV2Issue(
-                    path=f"nodes.{index}.prompt",
-                    message=f"Prompt references undeclared input '{name}'.",
-                )
-        for slug in DOC_REFERENCE_PATTERN.findall(node.prompt):
-            if slug not in doc_slugs:
-                return DefinitionV2Issue(
-                    path=f"nodes.{index}.prompt",
-                    message=f"Prompt references undeclared doc '{slug}'.",
-                )
+        for reference in scan_prompt_references(node.prompt):
+            problem = _validate_reference(reference, input_names, doc_slugs)
+            if problem is not None:
+                return DefinitionV2Issue(path=f"nodes.{index}.prompt", message=problem)
 
+    return None
+
+
+def scan_prompt_references(prompt: str) -> list[PromptReference]:
+    """Every reference attempt in a prompt, sigils matched case-insensitively."""
+
+    references: list[PromptReference] = []
+    for match in REFERENCE_SCAN_PATTERN.finditer(prompt):
+        raw_token = match.group(2)
+        references.append(
+            PromptReference(
+                sigil=match.group(1),
+                kind=match.group(1).lower(),
+                token=TRAILING_PROSE_PUNCTUATION_PATTERN.sub("", raw_token),
+                raw_token=raw_token,
+            )
+        )
+    return references
+
+
+def _validate_reference(
+    reference: PromptReference,
+    input_names: set[str],
+    doc_slugs: set[str],
+) -> str | None:
+    kind = reference.kind
+    if not reference.well_formed_sigil:
+        return (
+            f"Prompt contains malformed @{kind}: reference "
+            f"'@{reference.sigil}:{reference.raw_token}' (sigils are lowercase)."
+        )
+    if not reference.token:
+        return f"Prompt contains malformed @{kind}: reference with an empty token."
+    grammar = INPUT_NAME_TOKEN_PATTERN if kind == "input" else DOC_SLUG_TOKEN_PATTERN
+    if grammar.fullmatch(reference.token) is None:
+        return f"Prompt contains malformed @{kind}: reference '{reference.token}'."
+    if kind == "input" and reference.token not in input_names:
+        return f"Prompt references undeclared input '{reference.token}'."
+    if kind == "doc" and reference.token not in doc_slugs:
+        return f"Prompt references undeclared doc '{reference.token}'."
     return None
 
 

--- a/server/proliferate/server/workflows/models_v2.py
+++ b/server/proliferate/server/workflows/models_v2.py
@@ -1,0 +1,215 @@
+"""Wire models for gen-2 (schema_version 2) workflow definitions.
+
+The v2 document is one JSON blob — nodes, edges, inputs, docTemplates — with
+no catalog coupling: the identical validation must be implementable on the
+runtime plane, which has no CP catalog. Node ``model`` is a pass-through
+config, and placement never appears in the DSL (it is a trigger-time binding
+frozen into the invocation).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated, Literal
+from uuid import UUID
+
+from pydantic import ConfigDict, Field, StringConstraints, field_validator
+from pydantic.alias_generators import to_camel
+
+from proliferate.db.store.workflow_definitions import WorkflowDefinitionSnapshot
+from proliferate.db.store.workflow_invocations import WorkflowInvocationSnapshot
+from proliferate.server.workflows.models import (
+    WorkflowDefinitionResponse,
+    WorkflowDefinitionWireModel,
+    WorkflowInvocationRequestWireModel,
+    WorkflowInvocationScalar,
+    WorkflowInvocationWireModel,
+    WorkflowWireModel,
+)
+
+NODE_ID_CONSTRAINTS = StringConstraints(
+    strip_whitespace=True,
+    min_length=1,
+    max_length=64,
+    pattern=r"^[A-Za-z][A-Za-z0-9_-]*$",
+)
+DOC_SLUG_CONSTRAINTS = StringConstraints(
+    min_length=1,
+    max_length=64,
+    pattern=r"^[a-z0-9]+(?:-[a-z0-9]+)*$",
+)
+INPUT_NAME_CONSTRAINTS = StringConstraints(
+    min_length=1,
+    max_length=64,
+    pattern=r"^[A-Za-z][A-Za-z0-9_]*$",
+)
+
+
+class WorkflowNodeModelConfigV2(WorkflowDefinitionWireModel):
+    agent_kind: Annotated[
+        str,
+        StringConstraints(strip_whitespace=True, min_length=1, max_length=32),
+    ]
+    model_id: (
+        Annotated[
+            str,
+            StringConstraints(strip_whitespace=True, min_length=1, max_length=255),
+        ]
+        | None
+    ) = None
+    mode_id: (
+        Annotated[
+            str,
+            StringConstraints(strip_whitespace=True, min_length=1, max_length=64),
+        ]
+        | None
+    ) = None
+
+
+class WorkflowNodeV2(WorkflowDefinitionWireModel):
+    id: Annotated[str, NODE_ID_CONSTRAINTS]
+    type: Literal["agent", "human_in_loop"]
+    title: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=255)]
+    prompt: Annotated[str, StringConstraints(min_length=1, max_length=100_000)]
+    model: WorkflowNodeModelConfigV2 | None = None
+
+    @field_validator("prompt")
+    @classmethod
+    def prompt_must_not_be_blank(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("Prompt is required.")
+        return value
+
+
+class WorkflowEdgeV2(WorkflowDefinitionWireModel):
+    from_node: Annotated[str, NODE_ID_CONSTRAINTS] = Field(alias="from")
+    to_node: Annotated[str, NODE_ID_CONSTRAINTS] = Field(alias="to")
+
+
+class WorkflowInputV2(WorkflowDefinitionWireModel):
+    name: Annotated[str, INPUT_NAME_CONSTRAINTS]
+    description: Annotated[str, StringConstraints(max_length=20_000)] = ""
+    required: bool
+
+
+class WorkflowDocTemplateV2(WorkflowDefinitionWireModel):
+    slug: Annotated[str, DOC_SLUG_CONSTRAINTS]
+    producing_node_id: Annotated[str, NODE_ID_CONSTRAINTS]
+    body: Annotated[str, StringConstraints(max_length=200_000)] = ""
+
+
+class WorkflowDefinitionDocumentV2(WorkflowDefinitionWireModel):
+    schema_version: Literal[2]
+    nodes: list[WorkflowNodeV2] = Field(min_length=1, max_length=64)
+    edges: list[WorkflowEdgeV2] = Field(default_factory=list, max_length=64)
+    inputs: list[WorkflowInputV2] = Field(default_factory=list, max_length=64)
+    doc_templates: list[WorkflowDocTemplateV2] = Field(default_factory=list, max_length=64)
+
+    @field_validator("schema_version", mode="before")
+    @classmethod
+    def schema_version_is_an_exact_integer(cls, value: object) -> object:
+        if type(value) is not int:
+            raise ValueError("schemaVersion must be the integer 2.")
+        return value
+
+    def document_json(self) -> dict[str, object]:
+        """The normalized stored/frozen form of this document."""
+
+        return self.model_dump(by_alias=True, mode="json", exclude_none=True)
+
+
+class WorkflowDefinitionCreateRequestV2(WorkflowDefinitionWireModel):
+    title: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=255)]
+    description: Annotated[str, StringConstraints(max_length=20_000)] = ""
+    default_repo_config_id: UUID | None = None
+    definition: WorkflowDefinitionDocumentV2
+
+
+class WorkflowDefinitionUpdateRequestV2(WorkflowDefinitionCreateRequestV2):
+    expected_revision: int = Field(ge=1)
+
+
+class WorkflowDefinitionResponseV2(WorkflowDefinitionWireModel):
+    # Response construction remains name-friendly for internal Python callers,
+    # mirroring the v1 response model.
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        extra="forbid",
+        populate_by_name=True,
+        validate_by_alias=True,
+        validate_by_name=True,
+    )
+
+    id: UUID
+    user_id: UUID
+    title: str
+    description: str
+    schema_version: Literal[2]
+    revision: int
+    default_repo_config_id: UUID | None
+    definition: WorkflowDefinitionDocumentV2
+    created_at: datetime
+    updated_at: datetime
+    deleted_at: datetime | None
+
+
+class WorkflowDefinitionListAnyResponse(WorkflowWireModel):
+    workflows: list[WorkflowDefinitionResponse | WorkflowDefinitionResponseV2]
+
+
+class WorkflowInvocationPlacementV2(WorkflowInvocationWireModel):
+    repo_config_id: UUID
+    mode: Literal["worktree", "repo_root"]
+
+
+class WorkflowInvocationCreateRequestV2(WorkflowInvocationRequestWireModel):
+    schema_version: Literal[2]
+    workflow_definition_id: UUID
+    arguments: dict[str, WorkflowInvocationScalar]
+    placement: WorkflowInvocationPlacementV2
+
+    @field_validator("schema_version", mode="before")
+    @classmethod
+    def schema_version_is_an_exact_integer(cls, value: object) -> object:
+        if type(value) is not int:
+            raise ValueError("schemaVersion must be the integer 2.")
+        return value
+
+
+class WorkflowInvocationResponseV2(WorkflowInvocationWireModel):
+    id: UUID
+    schema_version: Literal[2]
+    workflow_definition_id: UUID
+    definition_revision: int
+    title: str
+    description: str
+    definition: WorkflowDefinitionDocumentV2
+    arguments: dict[str, WorkflowInvocationScalar]
+    placement: WorkflowInvocationPlacementV2
+    created_at: datetime
+
+
+def workflow_definition_response_v2(
+    value: WorkflowDefinitionSnapshot,
+) -> WorkflowDefinitionResponseV2:
+    return WorkflowDefinitionResponseV2.model_validate(
+        {
+            "id": value.id,
+            "userId": value.user_id,
+            "title": value.title,
+            "description": value.description,
+            "schemaVersion": value.schema_version,
+            "revision": value.revision,
+            "defaultRepoConfigId": value.default_repo_config_id,
+            "definition": value.definition_json,
+            "createdAt": value.created_at,
+            "updatedAt": value.updated_at,
+            "deletedAt": value.deleted_at,
+        }
+    )
+
+
+def workflow_invocation_response_v2(
+    value: WorkflowInvocationSnapshot,
+) -> WorkflowInvocationResponseV2:
+    return WorkflowInvocationResponseV2.model_validate(value.invocation_json)

--- a/server/proliferate/server/workflows/models_v2.py
+++ b/server/proliferate/server/workflows/models_v2.py
@@ -25,6 +25,7 @@ from proliferate.server.workflows.models import (
     WorkflowInvocationScalar,
     WorkflowInvocationWireModel,
     WorkflowWireModel,
+    workflow_definition_response,
 )
 
 NODE_ID_CONSTRAINTS = StringConstraints(
@@ -213,3 +214,11 @@ def workflow_invocation_response_v2(
     value: WorkflowInvocationSnapshot,
 ) -> WorkflowInvocationResponseV2:
     return WorkflowInvocationResponseV2.model_validate(value.invocation_json)
+
+
+def workflow_definition_response_any(
+    value: WorkflowDefinitionSnapshot,
+) -> WorkflowDefinitionResponse | WorkflowDefinitionResponseV2:
+    if value.schema_version == 2:
+        return workflow_definition_response_v2(value)
+    return workflow_definition_response(value)

--- a/server/proliferate/server/workflows/models_v2.py
+++ b/server/proliferate/server/workflows/models_v2.py
@@ -122,6 +122,9 @@ class WorkflowDefinitionDocumentV2(WorkflowDefinitionWireModel):
 class WorkflowDefinitionCreateRequestV2(WorkflowDefinitionWireModel):
     title: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=255)]
     description: Annotated[str, StringConstraints(max_length=20_000)] = ""
+    # Shape-only (Ruling A): the id lives in the RUNTIME repo-root id space
+    # (GET /v1/repo-roots), not the CP repo-config table — the CP stores it
+    # opaquely and never resolves it. Resolution is the engine plane's job.
     default_repo_config_id: UUID | None = None
     definition: WorkflowDefinitionDocumentV2
 

--- a/server/proliferate/server/workflows/models_v2.py
+++ b/server/proliferate/server/workflows/models_v2.py
@@ -159,7 +159,10 @@ class WorkflowDefinitionListAnyResponse(WorkflowWireModel):
 
 
 class WorkflowInvocationPlacementV2(WorkflowInvocationWireModel):
-    repo_config_id: UUID
+    # Shape-only (Ruling A): the CP freezes placement verbatim and never
+    # resolves it — for local v1 this carries a RUNTIME repo-root id, which is
+    # not a CP repo-config id at all. Resolution is the engine plane's job.
+    repo_config_id: Annotated[str, StringConstraints(min_length=1)]
     mode: Literal["worktree", "repo_root"]
 
 

--- a/server/proliferate/server/workflows/service.py
+++ b/server/proliferate/server/workflows/service.py
@@ -93,6 +93,11 @@ async def update_workflow_definition(
     current: WorkflowDefinitionSnapshot,
     body: WorkflowDefinitionUpdateRequest,
 ) -> WorkflowDefinitionSnapshot:
+    if current.schema_version != 1:
+        raise InvalidWorkflowDefinition(
+            "A schema version 2 definition cannot be updated with a version 1 body.",
+            path="schemaVersion",
+        )
     if body.expected_revision != current.revision:
         raise WorkflowDefinitionRevisionConflict(
             expected_revision=body.expected_revision,
@@ -223,7 +228,9 @@ async def put_workflow_invocation(
             stored = WorkflowInvocationCreateRequest.model_validate(existing.creation_request_json)
             stored_identity = canonical_json(stored.model_dump(by_alias=True, mode="json"))
         except ValueError as error:
-            raise InvalidWorkflowInvocation("Stored workflow invocation is invalid.") from error
+            # The stored request does not parse as a v1 body (a v2 invocation
+            # already owns this id): the caller collided, the data is fine.
+            raise WorkflowInvocationConflict() from error
         if stored_identity != request_identity:
             raise WorkflowInvocationConflict()
         return WorkflowInvocationPutResult(value=existing, created=False)

--- a/server/proliferate/server/workflows/service_v2.py
+++ b/server/proliferate/server/workflows/service_v2.py
@@ -1,0 +1,308 @@
+"""Application service for gen-2 (schema_version 2) workflow definitions.
+
+The v1 service is untouched; gen-2 rides beside it until PR7. Gen-2
+invocations freeze the definition verbatim with a caller-chosen placement and
+never enter the managed-execution lane — delivery to the local runtime is the
+client courier's job.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.store import repositories as repository_store
+from proliferate.db.store import workflow_definitions as workflow_store
+from proliferate.db.store import workflow_invocations as invocation_store
+from proliferate.db.store.workflow_definitions import WorkflowDefinitionSnapshot
+from proliferate.lib.infra.time.wall_clock import utcnow
+from proliferate.server.workflows.domain.invocation import (
+    ScalarValue,
+    canonical_json,
+)
+from proliferate.server.workflows.domain.validation_v2 import (
+    INPUT_REFERENCE_PATTERN,
+    validate_definition_v2_document,
+)
+from proliferate.server.workflows.errors import (
+    InvalidWorkflowDefinition,
+    InvalidWorkflowInvocation,
+    WorkflowDefinitionNotFound,
+    WorkflowDefinitionRevisionConflict,
+    WorkflowInvocationConflict,
+    WorkflowInvocationNotFound,
+)
+from proliferate.server.workflows.models_v2 import (
+    WorkflowDefinitionCreateRequestV2,
+    WorkflowDefinitionDocumentV2,
+    WorkflowDefinitionUpdateRequestV2,
+    WorkflowInvocationCreateRequestV2,
+    workflow_invocation_response_v2,
+)
+from proliferate.server.workflows.service import WorkflowInvocationPutResult
+
+__all__ = [
+    "create_workflow_definition_v2",
+    "update_workflow_definition_v2",
+    "put_workflow_invocation_v2",
+]
+
+
+async def create_workflow_definition_v2(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    body: WorkflowDefinitionCreateRequestV2,
+) -> WorkflowDefinitionSnapshot:
+    await _validate_default_repository(
+        db,
+        user_id=user_id,
+        repo_config_id=body.default_repo_config_id,
+    )
+    _validate_document(body.definition)
+    return await workflow_store.create_workflow_definition(
+        db,
+        user_id=user_id,
+        title=body.title,
+        description=_normalized_description(body.description),
+        validated_catalog_version="",
+        default_repo_config_id=body.default_repo_config_id,
+        inputs_json=[],
+        stages_json=[],
+        schema_version=2,
+        definition_json=body.definition.document_json(),
+    )
+
+
+async def update_workflow_definition_v2(
+    db: AsyncSession,
+    *,
+    current: WorkflowDefinitionSnapshot,
+    body: WorkflowDefinitionUpdateRequestV2,
+) -> WorkflowDefinitionSnapshot:
+    if current.schema_version != 2:
+        raise InvalidWorkflowDefinition(
+            "A schema version 1 definition cannot be updated with a version 2 document.",
+            path="definition.schemaVersion",
+        )
+    if body.expected_revision != current.revision:
+        raise WorkflowDefinitionRevisionConflict(
+            expected_revision=body.expected_revision,
+            current_revision=current.revision,
+        )
+    await _validate_default_repository(
+        db,
+        user_id=current.user_id,
+        repo_config_id=body.default_repo_config_id,
+    )
+    _validate_document(body.definition)
+    updated = await workflow_store.update_workflow_definition_if_revision(
+        db,
+        user_id=current.user_id,
+        workflow_definition_id=current.id,
+        expected_revision=body.expected_revision,
+        title=body.title,
+        description=_normalized_description(body.description),
+        validated_catalog_version="",
+        default_repo_config_id=body.default_repo_config_id,
+        inputs_json=[],
+        stages_json=[],
+        definition_json=body.definition.document_json(),
+    )
+    if updated is not None:
+        return updated
+    latest = await workflow_store.get_workflow_definition(
+        db,
+        user_id=current.user_id,
+        workflow_definition_id=current.id,
+    )
+    raise WorkflowDefinitionRevisionConflict(
+        expected_revision=body.expected_revision,
+        current_revision=None if latest is None else latest.revision,
+    )
+
+
+async def put_workflow_invocation_v2(
+    db: AsyncSession,
+    *,
+    invocation_id_text: str,
+    user_id: UUID,
+    body: WorkflowInvocationCreateRequestV2,
+) -> WorkflowInvocationPutResult:
+    invocation_id = _canonical_uuid(invocation_id_text)
+    request_json = cast(
+        dict[str, object],
+        body.model_dump(by_alias=True, mode="json"),
+    )
+    try:
+        request_identity = canonical_json(request_json)
+    except ValueError as error:
+        raise InvalidWorkflowInvocation("Workflow invocation is not portable JSON.") from error
+
+    await invocation_store.acquire_workflow_invocation_acceptance_lock(
+        db,
+        invocation_id=invocation_id,
+    )
+    existing = await invocation_store.get_workflow_invocation_global(
+        db,
+        invocation_id=invocation_id,
+    )
+    if existing is not None:
+        if existing.user_id != user_id:
+            raise WorkflowInvocationNotFound()
+        try:
+            stored = WorkflowInvocationCreateRequestV2.model_validate(
+                existing.creation_request_json
+            )
+            stored_identity = canonical_json(stored.model_dump(by_alias=True, mode="json"))
+        except ValueError as error:
+            raise WorkflowInvocationConflict() from error
+        if stored_identity != request_identity:
+            raise WorkflowInvocationConflict()
+        return WorkflowInvocationPutResult(value=existing, created=False)
+
+    definition = await workflow_store.get_workflow_definition(
+        db,
+        user_id=user_id,
+        workflow_definition_id=body.workflow_definition_id,
+    )
+    if definition is None:
+        raise WorkflowDefinitionNotFound()
+    if definition.schema_version != 2 or definition.definition_json is None:
+        raise InvalidWorkflowInvocation(
+            "A schema version 2 invocation requires a schema version 2 definition."
+        )
+
+    placement_repo = await repository_store.get_repo_config_by_id_for_user(
+        db,
+        user_id=user_id,
+        repo_config_id=body.placement.repo_config_id,
+    )
+    if placement_repo is None:
+        raise InvalidWorkflowInvocation("Placement repository was not found.")
+
+    document = WorkflowDefinitionDocumentV2.model_validate(definition.definition_json)
+    arguments: dict[str, ScalarValue] = dict(body.arguments)
+    try:
+        _validate_v2_arguments(document, arguments)
+        canonical_json(arguments)
+    except ValueError as error:
+        raise InvalidWorkflowInvocation(str(error)) from error
+
+    created_at = utcnow()
+    invocation_json: dict[str, object] = {
+        "id": str(invocation_id),
+        "schemaVersion": 2,
+        "workflowDefinitionId": str(definition.id),
+        "definitionRevision": definition.revision,
+        "title": definition.title,
+        "description": definition.description,
+        "definition": definition.definition_json,
+        "arguments": arguments,
+        "placement": {
+            "repoConfigId": str(body.placement.repo_config_id),
+            "mode": body.placement.mode,
+        },
+        "createdAt": created_at.isoformat().replace("+00:00", "Z"),
+    }
+    try:
+        response = workflow_invocation_response_v2(
+            invocation_store.WorkflowInvocationSnapshot(
+                id=invocation_id,
+                user_id=user_id,
+                workflow_definition_id=definition.id,
+                definition_revision=definition.revision,
+                title_snapshot=definition.title,
+                description_snapshot=definition.description,
+                schema_version=2,
+                creation_request_json=request_json,
+                invocation_json=invocation_json,
+                created_at=created_at,
+                updated_at=created_at,
+            )
+        )
+        normalized_invocation_json = cast(
+            dict[str, object],
+            response.model_dump(by_alias=True, mode="json", exclude_none=True),
+        )
+        canonical_json(normalized_invocation_json)
+    except ValueError as error:
+        raise InvalidWorkflowInvocation("Workflow invocation could not be normalized.") from error
+
+    created = await invocation_store.create_workflow_invocation(
+        db,
+        invocation_id=invocation_id,
+        user_id=user_id,
+        workflow_definition_id=definition.id,
+        definition_revision=definition.revision,
+        title_snapshot=definition.title,
+        description_snapshot=definition.description,
+        creation_request_json=request_json,
+        invocation_json=normalized_invocation_json,
+        created_at=created_at,
+        schema_version=2,
+    )
+    return WorkflowInvocationPutResult(value=created, created=True)
+
+
+def _validate_v2_arguments(
+    document: WorkflowDefinitionDocumentV2,
+    arguments: dict[str, ScalarValue],
+) -> None:
+    """Arguments must name declared inputs and cover every input any prompt references."""
+
+    declared = {input_definition.name for input_definition in document.inputs}
+    for name in arguments:
+        if name not in declared:
+            raise ValueError(f"argument '{name}' is not a declared input")
+    for input_definition in document.inputs:
+        if input_definition.required and input_definition.name not in arguments:
+            raise ValueError(f"required input '{input_definition.name}' has no argument")
+    for node in document.nodes:
+        for name in INPUT_REFERENCE_PATTERN.findall(node.prompt):
+            if name not in arguments:
+                raise ValueError(f"prompt input '{name}' has no argument")
+
+
+def _validate_document(document: WorkflowDefinitionDocumentV2) -> None:
+    issue = validate_definition_v2_document(document)
+    if issue is not None:
+        raise InvalidWorkflowDefinition(issue.message, path=f"definition.{issue.path}")
+
+
+def _canonical_uuid(value: str) -> UUID:
+    try:
+        parsed = UUID(value)
+    except ValueError as error:
+        raise InvalidWorkflowInvocation(
+            "invocationId must be a canonical lowercase UUID."
+        ) from error
+    if str(parsed) != value:
+        raise InvalidWorkflowInvocation("invocationId must be a canonical lowercase UUID.")
+    return parsed
+
+
+async def _validate_default_repository(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    repo_config_id: UUID | None,
+) -> None:
+    if repo_config_id is None:
+        return
+    repo = await repository_store.get_repo_config_by_id_for_user(
+        db,
+        user_id=user_id,
+        repo_config_id=repo_config_id,
+    )
+    if repo is None:
+        raise InvalidWorkflowDefinition(
+            "Default repository was not found.",
+            path="defaultRepoConfigId",
+        )
+
+
+def _normalized_description(value: str) -> str:
+    return value if value.strip() else ""

--- a/server/proliferate/server/workflows/service_v2.py
+++ b/server/proliferate/server/workflows/service_v2.py
@@ -13,7 +13,6 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from proliferate.db.store import repositories as repository_store
 from proliferate.db.store import workflow_definitions as workflow_store
 from proliferate.db.store import workflow_invocations as invocation_store
 from proliferate.db.store.workflow_definitions import WorkflowDefinitionSnapshot
@@ -56,11 +55,6 @@ async def create_workflow_definition_v2(
     user_id: UUID,
     body: WorkflowDefinitionCreateRequestV2,
 ) -> WorkflowDefinitionSnapshot:
-    await _validate_default_repository(
-        db,
-        user_id=user_id,
-        repo_config_id=body.default_repo_config_id,
-    )
     _validate_document(body.definition)
     return await workflow_store.create_workflow_definition(
         db,
@@ -92,11 +86,6 @@ async def update_workflow_definition_v2(
             expected_revision=body.expected_revision,
             current_revision=current.revision,
         )
-    await _validate_default_repository(
-        db,
-        user_id=current.user_id,
-        repo_config_id=body.default_repo_config_id,
-    )
     _validate_document(body.definition)
     updated = await workflow_store.update_workflow_definition_if_revision(
         db,
@@ -274,26 +263,6 @@ def _canonical_uuid(value: str) -> UUID:
     if str(parsed) != value:
         raise InvalidWorkflowInvocation("invocationId must be a canonical lowercase UUID.")
     return parsed
-
-
-async def _validate_default_repository(
-    db: AsyncSession,
-    *,
-    user_id: UUID,
-    repo_config_id: UUID | None,
-) -> None:
-    if repo_config_id is None:
-        return
-    repo = await repository_store.get_repo_config_by_id_for_user(
-        db,
-        user_id=user_id,
-        repo_config_id=repo_config_id,
-    )
-    if repo is None:
-        raise InvalidWorkflowDefinition(
-            "Default repository was not found.",
-            path="defaultRepoConfigId",
-        )
 
 
 def _normalized_description(value: str) -> str:

--- a/server/proliferate/server/workflows/service_v2.py
+++ b/server/proliferate/server/workflows/service_v2.py
@@ -23,7 +23,7 @@ from proliferate.server.workflows.domain.invocation import (
     canonical_json,
 )
 from proliferate.server.workflows.domain.validation_v2 import (
-    INPUT_REFERENCE_PATTERN,
+    scan_prompt_references,
     validate_definition_v2_document,
 )
 from proliferate.server.workflows.errors import (
@@ -175,14 +175,6 @@ async def put_workflow_invocation_v2(
             "A schema version 2 invocation requires a schema version 2 definition."
         )
 
-    placement_repo = await repository_store.get_repo_config_by_id_for_user(
-        db,
-        user_id=user_id,
-        repo_config_id=body.placement.repo_config_id,
-    )
-    if placement_repo is None:
-        raise InvalidWorkflowInvocation("Placement repository was not found.")
-
     document = WorkflowDefinitionDocumentV2.model_validate(definition.definition_json)
     arguments: dict[str, ScalarValue] = dict(body.arguments)
     try:
@@ -202,7 +194,7 @@ async def put_workflow_invocation_v2(
         "definition": definition.definition_json,
         "arguments": arguments,
         "placement": {
-            "repoConfigId": str(body.placement.repo_config_id),
+            "repoConfigId": body.placement.repo_config_id,
             "mode": body.placement.mode,
         },
         "createdAt": created_at.isoformat().replace("+00:00", "Z"),
@@ -261,9 +253,9 @@ def _validate_v2_arguments(
         if input_definition.required and input_definition.name not in arguments:
             raise ValueError(f"required input '{input_definition.name}' has no argument")
     for node in document.nodes:
-        for name in INPUT_REFERENCE_PATTERN.findall(node.prompt):
-            if name not in arguments:
-                raise ValueError(f"prompt input '{name}' has no argument")
+        for reference in scan_prompt_references(node.prompt):
+            if reference.kind == "input" and reference.token not in arguments:
+                raise ValueError(f"prompt input '{reference.token}' has no argument")
 
 
 def _validate_document(document: WorkflowDefinitionDocumentV2) -> None:

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -107,6 +107,7 @@ module = [
     "proliferate.server.cloud.workspaces.models",
     "proliferate.server.catalogs.models",
     "proliferate.server.workflows.models",
+    "proliferate.server.workflows.models_v2",
     "proliferate.server.meta",
     "proliferate.server.cloud.repos.models",
     "proliferate.server.cloud.integrations.action_approvals.models",

--- a/server/tests/integration/test_workflow_definitions_api.py
+++ b/server/tests/integration/test_workflow_definitions_api.py
@@ -500,8 +500,14 @@ async def test_unknown_fields_are_rejected_at_every_definition_layer(
             json=body,
         )
         assert response.status_code == 422
+        # The union body namespaces error locs by request-model branch.
+        namespaced = (
+            expected_location[0],
+            "WorkflowDefinitionCreateRequest",
+            *expected_location[1:],
+        )
         assert any(
-            tuple(error["loc"]) == expected_location and error["type"] == "extra_forbidden"
+            tuple(error["loc"]) == namespaced and error["type"] == "extra_forbidden"
             for error in response.json()["detail"]
         )
 

--- a/server/tests/integration/test_workflow_definitions_v2_api.py
+++ b/server/tests/integration/test_workflow_definitions_v2_api.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.constants.cloud import GitProvider
@@ -222,3 +223,39 @@ async def test_v2_default_repository_must_be_owned(
     accepted = await client.post("/v1/workflows", headers=_headers(owner), json=payload)
     assert accepted.status_code == 201
     assert accepted.json()["defaultRepoConfigId"] == str(own_repo.id)
+
+
+@pytest.mark.asyncio
+async def test_v1_body_cannot_update_a_v2_definition(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """The v1 update path must reject v2 rows outright: before the guard it
+    ran v1 validation and NULLed definition_json on the way to a 500."""
+
+    owner = await register_and_login(client, "wf-v2-downgrade-guard@example.com")
+    created = await client.post("/v1/workflows", headers=_headers(owner), json=_v2_payload())
+    assert created.status_code == 201
+    definition_id = str(created.json()["id"])
+
+    downgraded = await client.put(
+        f"/v1/workflows/{definition_id}",
+        headers=_headers(owner),
+        json={**_v1_payload(), "expectedRevision": 1},
+    )
+    assert downgraded.status_code == 400
+    assert downgraded.json()["detail"]["path"] == "schemaVersion"
+
+    # The row is untouched: still v2, document intact, revision unchanged.
+    row = (
+        await db_session.execute(
+            select(WorkflowDefinition).where(WorkflowDefinition.id == UUID(definition_id))
+        )
+    ).scalar_one()
+    assert row.schema_version == 2
+    assert row.definition_json == _fixture_definition("v2-full.json")
+    assert row.revision == 1
+
+    fetched = await client.get(f"/v1/workflows/{definition_id}", headers=_headers(owner))
+    assert fetched.status_code == 200
+    assert fetched.json() == created.json()

--- a/server/tests/integration/test_workflow_definitions_v2_api.py
+++ b/server/tests/integration/test_workflow_definitions_v2_api.py
@@ -204,25 +204,36 @@ async def test_v2_document_rejections_surface_paths(client: AsyncClient) -> None
 
 
 @pytest.mark.asyncio
-async def test_v2_default_repository_must_be_owned(
+async def test_v2_default_repository_is_an_opaque_runtime_space_id(
     client: AsyncClient,
     db_session: AsyncSession,
 ) -> None:
+    """defaultRepoConfigId lives in the runtime repo-root id space (Ruling A):
+    the CP checks shape only (UUID-or-null) and never resolves it."""
+
     owner = await register_and_login(client, "wf-v2-repo-owner@example.com")
-    other = await register_and_login(client, "wf-v2-repo-other@example.com")
-    foreign_repo = await _seed_repo(db_session, user_id=other["user_id"], name="not-yours")
 
     payload = _v2_payload()
-    payload["defaultRepoConfigId"] = str(foreign_repo.id)
-    rejected = await client.post("/v1/workflows", headers=_headers(owner), json=payload)
-    assert rejected.status_code == 400
-    assert rejected.json()["detail"]["path"] == "defaultRepoConfigId"
-
-    own_repo = await _seed_repo(db_session, user_id=owner["user_id"], name="yours")
-    payload["defaultRepoConfigId"] = str(own_repo.id)
+    runtime_space_id = "7f3a9c1e-2b4d-4e6f-8a90-123456789abc"
+    payload["defaultRepoConfigId"] = runtime_space_id
     accepted = await client.post("/v1/workflows", headers=_headers(owner), json=payload)
     assert accepted.status_code == 201
-    assert accepted.json()["defaultRepoConfigId"] == str(own_repo.id)
+    assert accepted.json()["defaultRepoConfigId"] == runtime_space_id
+
+    other = await register_and_login(client, "wf-v2-repo-other@example.com")
+    foreign_repo = await _seed_repo(db_session, user_id=other["user_id"], name="not-yours")
+    payload["defaultRepoConfigId"] = str(foreign_repo.id)
+    cp_id_shaped = await client.post("/v1/workflows", headers=_headers(owner), json=payload)
+    assert cp_id_shaped.status_code == 201
+
+    payload["defaultRepoConfigId"] = "rr_local_9f2c"
+    malformed = await client.post("/v1/workflows", headers=_headers(owner), json=payload)
+    assert malformed.status_code == 422
+
+    payload["defaultRepoConfigId"] = None
+    nullable = await client.post("/v1/workflows", headers=_headers(owner), json=payload)
+    assert nullable.status_code == 201
+    assert nullable.json()["defaultRepoConfigId"] is None
 
 
 @pytest.mark.asyncio

--- a/server/tests/integration/test_workflow_definitions_v2_api.py
+++ b/server/tests/integration/test_workflow_definitions_v2_api.py
@@ -1,0 +1,224 @@
+"""HTTP and real-Postgres acceptance tests for gen-2 workflow definitions."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.cloud import GitProvider
+from proliferate.db.models.cloud.repositories import RepoConfig
+from proliferate.db.models.workflows import WorkflowDefinition
+from proliferate.lib.infra.time.wall_clock import utcnow
+from tests.integration.cloud_api_helpers import register_and_login
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_ROOT = REPO_ROOT / "fixtures" / "contracts" / "workflow-definition"
+
+
+def _headers(tokens: dict[str, str]) -> dict[str, str]:
+    return {"Authorization": f"Bearer {tokens['access_token']}"}
+
+
+def _fixture_definition(name: str) -> dict[str, object]:
+    fixture = json.loads((FIXTURE_ROOT / name).read_text())
+    definition = fixture["definition"]
+    assert isinstance(definition, dict)
+    return deepcopy(definition)
+
+
+def _v2_payload() -> dict[str, object]:
+    return {
+        "title": "Research and propose",
+        "description": "Research a topic, then gate on review.",
+        "defaultRepoConfigId": None,
+        "definition": _fixture_definition("v2-full.json"),
+    }
+
+
+def _v1_payload() -> dict[str, object]:
+    return {
+        "title": "Legacy stage workflow",
+        "description": "",
+        "defaultRepoConfigId": None,
+        "inputs": [{"name": "ticket", "type": "string", "required": True}],
+        "stages": [
+            {
+                "harnessConfig": {"agentKind": "claude", "modelId": None, "effort": None},
+                "steps": [
+                    {
+                        "kind": "agent.prompt",
+                        "prompt": "Investigate {{inputs.ticket}}",
+                        "goal": None,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+async def _seed_repo(db: AsyncSession, *, user_id: str, name: str) -> RepoConfig:
+    now = utcnow()
+    repo = RepoConfig(
+        user_id=UUID(user_id),
+        git_provider=GitProvider.github,
+        git_owner="proliferate-ai",
+        git_repo_name=name,
+        created_at=now,
+        updated_at=now,
+        deleted_at=None,
+    )
+    db.add(repo)
+    await db.commit()
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_v2_definition_crud_lifecycle(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    owner = await register_and_login(client, "wf-v2-owner@example.com")
+
+    created = await client.post("/v1/workflows", headers=_headers(owner), json=_v2_payload())
+    assert created.status_code == 201
+    payload = created.json()
+    assert payload["schemaVersion"] == 2
+    assert payload["revision"] == 1
+    assert payload["definition"] == _fixture_definition("v2-full.json")
+    assert "stages" not in payload
+    assert "validatedCatalogVersion" not in payload
+
+    row = await db_session.get(WorkflowDefinition, UUID(payload["id"]))
+    assert row is not None
+    assert row.schema_version == 2
+    assert row.definition_json == _fixture_definition("v2-full.json")
+    assert row.inputs_json == []
+    assert row.stages_json == []
+
+    fetched = await client.get(f"/v1/workflows/{payload['id']}", headers=_headers(owner))
+    assert fetched.status_code == 200
+    assert fetched.json() == payload
+
+    updated_definition = _fixture_definition("v2-minimal.json")
+    updated = await client.put(
+        f"/v1/workflows/{payload['id']}",
+        headers=_headers(owner),
+        json={
+            "title": "One step now",
+            "description": "",
+            "defaultRepoConfigId": None,
+            "definition": updated_definition,
+            "expectedRevision": 1,
+        },
+    )
+    assert updated.status_code == 200
+    assert updated.json()["revision"] == 2
+    assert updated.json()["definition"] == updated_definition
+
+    stale = await client.put(
+        f"/v1/workflows/{payload['id']}",
+        headers=_headers(owner),
+        json={
+            "title": "One step now",
+            "description": "",
+            "defaultRepoConfigId": None,
+            "definition": updated_definition,
+            "expectedRevision": 1,
+        },
+    )
+    assert stale.status_code == 409
+
+    deleted = await client.delete(
+        f"/v1/workflows/{payload['id']}?expectedRevision=2",
+        headers=_headers(owner),
+    )
+    assert deleted.status_code == 204
+    gone = await client.get(f"/v1/workflows/{payload['id']}", headers=_headers(owner))
+    assert gone.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_v1_and_v2_definitions_list_side_by_side(client: AsyncClient) -> None:
+    owner = await register_and_login(client, "wf-v2-mixed@example.com")
+
+    v1 = await client.post("/v1/workflows", headers=_headers(owner), json=_v1_payload())
+    assert v1.status_code == 201
+    v2 = await client.post("/v1/workflows", headers=_headers(owner), json=_v2_payload())
+    assert v2.status_code == 201
+
+    listed = await client.get("/v1/workflows", headers=_headers(owner))
+    assert listed.status_code == 200
+    by_version = {item["schemaVersion"]: item for item in listed.json()["workflows"]}
+    assert set(by_version) == {1, 2}
+    assert "stages" in by_version[1]
+    assert "definition" in by_version[2]
+
+    eligibility = await client.get(
+        f"/v1/workflows/{v2.json()['id']}/run-eligibility",
+        headers=_headers(owner),
+    )
+    assert eligibility.status_code == 200
+    assert eligibility.json() == {"eligible": True, "blockers": []}
+
+
+@pytest.mark.asyncio
+async def test_v2_document_rejections_surface_paths(client: AsyncClient) -> None:
+    owner = await register_and_login(client, "wf-v2-rejects@example.com")
+
+    branching = _v2_payload()
+    definition = branching["definition"]
+    assert isinstance(definition, dict)
+    definition["edges"] = [
+        {"from": "n_research", "to": "n_synthesize"},
+        {"from": "n_research", "to": "n_review"},
+    ]
+    rejected = await client.post("/v1/workflows", headers=_headers(owner), json=branching)
+    assert rejected.status_code == 400
+    detail = rejected.json()["detail"]
+    assert detail["code"] == "invalid_workflow_definition"
+    assert detail["path"] == "definition.edges.1.from"
+
+    with_placement = _v2_payload()
+    definition = with_placement["definition"]
+    assert isinstance(definition, dict)
+    definition["placement"] = {"repoConfigId": "x", "mode": "worktree"}
+    rejected = await client.post("/v1/workflows", headers=_headers(owner), json=with_placement)
+    assert rejected.status_code == 422
+
+    cross_version = await client.post("/v1/workflows", headers=_headers(owner), json=_v1_payload())
+    assert cross_version.status_code == 201
+    upgraded = await client.put(
+        f"/v1/workflows/{cross_version.json()['id']}",
+        headers=_headers(owner),
+        json={**_v2_payload(), "expectedRevision": 1},
+    )
+    assert upgraded.status_code == 400
+    assert upgraded.json()["detail"]["path"] == "definition.schemaVersion"
+
+
+@pytest.mark.asyncio
+async def test_v2_default_repository_must_be_owned(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    owner = await register_and_login(client, "wf-v2-repo-owner@example.com")
+    other = await register_and_login(client, "wf-v2-repo-other@example.com")
+    foreign_repo = await _seed_repo(db_session, user_id=other["user_id"], name="not-yours")
+
+    payload = _v2_payload()
+    payload["defaultRepoConfigId"] = str(foreign_repo.id)
+    rejected = await client.post("/v1/workflows", headers=_headers(owner), json=payload)
+    assert rejected.status_code == 400
+    assert rejected.json()["detail"]["path"] == "defaultRepoConfigId"
+
+    own_repo = await _seed_repo(db_session, user_id=owner["user_id"], name="yours")
+    payload["defaultRepoConfigId"] = str(own_repo.id)
+    accepted = await client.post("/v1/workflows", headers=_headers(owner), json=payload)
+    assert accepted.status_code == 201
+    assert accepted.json()["defaultRepoConfigId"] == str(own_repo.id)

--- a/server/tests/integration/test_workflow_invocations_api.py
+++ b/server/tests/integration/test_workflow_invocations_api.py
@@ -220,8 +220,10 @@ async def test_invocation_request_rejects_snake_case_wire_fields_without_creatin
         )
 
         assert rejected.status_code == 422
+        # The union body namespaces error locs by request-model branch.
         assert any(
-            tuple(error["loc"]) == ("body", snake_case_key) and error["type"] == "extra_forbidden"
+            tuple(error["loc"]) == ("body", "WorkflowInvocationCreateRequest", snake_case_key)
+            and error["type"] == "extra_forbidden"
             for error in rejected.json()["detail"]
         )
         assert (

--- a/server/tests/integration/test_workflow_invocations_v2_api.py
+++ b/server/tests/integration/test_workflow_invocations_v2_api.py
@@ -1,0 +1,299 @@
+"""Gen-2 workflow invocation freeze API over real PostgreSQL.
+
+Includes the producer half of
+``fixtures/contracts/workflow-definition/run-snapshot-v2.json``: the frozen
+``invocation_json`` the server returns must match the fixture byte-for-byte
+outside the instance-specific identity fields, because that payload is exactly
+what the client courier hands the runtime's ``PUT /v1/workflow-runs``.
+"""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.constants.cloud import GitProvider
+from proliferate.db.models.cloud.repositories import RepoConfig
+from proliferate.db.store import workflow_managed_execution as managed_execution_store
+from proliferate.lib.infra.time.wall_clock import utcnow
+from proliferate.server.workflows.domain.invocation import canonical_json
+from tests.integration.cloud_api_helpers import register_and_login
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_ROOT = REPO_ROOT / "fixtures" / "contracts" / "workflow-definition"
+
+
+def _headers(tokens: dict[str, str]) -> dict[str, str]:
+    return {"Authorization": f"Bearer {tokens['access_token']}"}
+
+
+def _fixture(name: str) -> dict[str, object]:
+    return json.loads((FIXTURE_ROOT / name).read_text())
+
+
+async def _seed_repo(db: AsyncSession, *, user_id: str, name: str) -> RepoConfig:
+    now = utcnow()
+    repo = RepoConfig(
+        user_id=UUID(user_id),
+        git_provider=GitProvider.github,
+        git_owner="proliferate-ai",
+        git_repo_name=name,
+        created_at=now,
+        updated_at=now,
+        deleted_at=None,
+    )
+    db.add(repo)
+    await db.commit()
+    return repo
+
+
+async def _create_v2_definition(
+    client: AsyncClient,
+    tokens: dict[str, str],
+    *,
+    title: str = "Research and propose",
+    description: str = "Research a topic, synthesize a proposal, gate on human review.",
+) -> dict[str, object]:
+    fixture = _fixture("v2-full.json")
+    created = await client.post(
+        "/v1/workflows",
+        headers=_headers(tokens),
+        json={
+            "title": title,
+            "description": description,
+            "defaultRepoConfigId": None,
+            "definition": deepcopy(fixture["definition"]),
+        },
+    )
+    assert created.status_code == 201
+    payload = created.json()
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _invocation_body(
+    definition_id: str,
+    repo_config_id: str,
+    *,
+    mode: str = "worktree",
+    arguments: dict[str, object] | None = None,
+) -> dict[str, object]:
+    return {
+        "schemaVersion": 2,
+        "workflowDefinitionId": definition_id,
+        "arguments": {"topic": "workflow engines", "depth": "deep"}
+        if arguments is None
+        else arguments,
+        "placement": {"repoConfigId": repo_config_id, "mode": mode},
+    }
+
+
+@pytest.mark.asyncio
+async def test_v2_invocation_freezes_the_run_snapshot_contract_shape(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    owner = await register_and_login(client, "wf2-inv-owner@example.com")
+    repo = await _seed_repo(db_session, user_id=owner["user_id"], name="snapshot-repo")
+    definition = await _create_v2_definition(client, owner)
+
+    invocation_id = str(uuid4())
+    body = _invocation_body(str(definition["id"]), str(repo.id))
+    created = await client.put(
+        f"/v1/workflow-invocations/{invocation_id}",
+        headers=_headers(owner),
+        json=body,
+    )
+    assert created.status_code == 201
+    frozen = created.json()
+
+    expected = _fixture("run-snapshot-v2.json")
+    expected["id"] = invocation_id
+    expected["workflowDefinitionId"] = definition["id"]
+    expected["createdAt"] = frozen["createdAt"]
+    placement = expected["placement"]
+    assert isinstance(placement, dict)
+    placement["repoConfigId"] = str(repo.id)
+    assert canonical_json(frozen) == canonical_json(expected)
+
+    # The frozen record contains the definition verbatim.
+    assert frozen["definition"] == definition["definition"]
+
+    # Idempotent replay returns the identical frozen record.
+    replay = await client.put(
+        f"/v1/workflow-invocations/{invocation_id}",
+        headers=_headers(owner),
+        json=body,
+    )
+    assert replay.status_code == 200
+    assert replay.json() == frozen
+
+    # Same id with different input conflicts.
+    conflicting = await client.put(
+        f"/v1/workflow-invocations/{invocation_id}",
+        headers=_headers(owner),
+        json=_invocation_body(
+            str(definition["id"]),
+            str(repo.id),
+            arguments={"topic": "something else"},
+        ),
+    )
+    assert conflicting.status_code == 409
+
+    # GET returns the frozen record directly (no managed-execution read).
+    fetched = await client.get(
+        f"/v1/workflow-invocations/{invocation_id}",
+        headers=_headers(owner),
+    )
+    assert fetched.status_code == 200
+    assert fetched.json() == frozen
+
+    # Gen-2 invocations never enter the managed-execution lane.
+    managed = await managed_execution_store.get_managed_execution(
+        db_session,
+        invocation_id=UUID(invocation_id),
+    )
+    assert managed is None
+    deliver = await client.post(
+        f"/v1/workflow-invocations/{invocation_id}/deliver",
+        headers=_headers(owner),
+    )
+    assert deliver.status_code == 404
+    cancel = await client.post(
+        f"/v1/workflow-invocations/{invocation_id}/cancel",
+        headers=_headers(owner),
+    )
+    assert cancel.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_v2_invocation_argument_and_placement_rejections(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    owner = await register_and_login(client, "wf2-inv-args@example.com")
+    other = await register_and_login(client, "wf2-inv-args-other@example.com")
+    repo = await _seed_repo(db_session, user_id=owner["user_id"], name="args-repo")
+    foreign_repo = await _seed_repo(db_session, user_id=other["user_id"], name="foreign-repo")
+    definition = await _create_v2_definition(client, owner)
+    definition_id = str(definition["id"])
+
+    async def put(body: dict[str, object]) -> int:
+        response = await client.put(
+            f"/v1/workflow-invocations/{uuid4()}",
+            headers=_headers(owner),
+            json=body,
+        )
+        return response.status_code
+
+    # Undeclared argument name.
+    assert (
+        await put(
+            _invocation_body(
+                definition_id,
+                str(repo.id),
+                arguments={"topic": "x", "depth": "y", "ghost": "z"},
+            )
+        )
+        == 400
+    )
+    # Missing required input.
+    assert (
+        await put(_invocation_body(definition_id, str(repo.id), arguments={"depth": "y"})) == 400
+    )
+    # Referenced optional input still needs an argument (prompts reference @input:depth... none do;
+    # @input:topic is referenced and required). Optional-but-unreferenced may be omitted:
+    assert (
+        await put(_invocation_body(definition_id, str(repo.id), arguments={"topic": "x"})) == 201
+    )
+    # Placement repo must belong to the caller.
+    assert await put(_invocation_body(definition_id, str(foreign_repo.id))) == 400
+    # Placement mode is a closed enum.
+    assert await put(_invocation_body(definition_id, str(repo.id), mode="floating")) == 422
+
+    # A v2 invocation of a v1 definition is invalid.
+    v1_created = await client.post(
+        "/v1/workflows",
+        headers=_headers(owner),
+        json={
+            "title": "Legacy",
+            "description": "",
+            "defaultRepoConfigId": None,
+            "inputs": [],
+            "stages": [
+                {
+                    "harnessConfig": {"agentKind": "claude", "modelId": None, "effort": None},
+                    "steps": [{"kind": "agent.prompt", "prompt": "Do it.", "goal": None}],
+                }
+            ],
+        },
+    )
+    assert v1_created.status_code == 201
+    assert await put(_invocation_body(str(v1_created.json()["id"]), str(repo.id))) == 400
+
+    # Owner isolation: someone else's definition answers not-found.
+    intruder_response = await client.put(
+        f"/v1/workflow-invocations/{uuid4()}",
+        headers=_headers(other),
+        json=_invocation_body(definition_id, str(foreign_repo.id)),
+    )
+    assert intruder_response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_v2_invocation_freezes_the_definition_at_trigger_time(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    owner = await register_and_login(client, "wf2-inv-freeze@example.com")
+    repo = await _seed_repo(db_session, user_id=owner["user_id"], name="freeze-repo")
+    definition = await _create_v2_definition(client, owner)
+    definition_id = str(definition["id"])
+
+    invocation_id = str(uuid4())
+    first = await client.put(
+        f"/v1/workflow-invocations/{invocation_id}",
+        headers=_headers(owner),
+        json=_invocation_body(definition_id, str(repo.id)),
+    )
+    assert first.status_code == 201
+    assert first.json()["definitionRevision"] == 1
+
+    minimal = _fixture("v2-minimal.json")
+    updated = await client.put(
+        f"/v1/workflows/{definition_id}",
+        headers=_headers(owner),
+        json={
+            "title": "Rewritten",
+            "description": "",
+            "defaultRepoConfigId": None,
+            "definition": deepcopy(minimal["definition"]),
+            "expectedRevision": 1,
+        },
+    )
+    assert updated.status_code == 200
+
+    # The already-frozen invocation is untouched by the definition edit.
+    fetched = await client.get(
+        f"/v1/workflow-invocations/{invocation_id}",
+        headers=_headers(owner),
+    )
+    assert fetched.status_code == 200
+    assert fetched.json()["definition"] == definition["definition"]
+    assert fetched.json()["title"] == "Research and propose"
+
+    # A new trigger freezes the post-edit definition at its new revision.
+    second = await client.put(
+        f"/v1/workflow-invocations/{uuid4()}",
+        headers=_headers(owner),
+        json=_invocation_body(definition_id, str(repo.id), arguments={}),
+    )
+    assert second.status_code == 201
+    assert second.json()["definitionRevision"] == 2
+    assert second.json()["definition"] == minimal["definition"]

--- a/server/tests/integration/test_workflow_invocations_v2_api.py
+++ b/server/tests/integration/test_workflow_invocations_v2_api.py
@@ -19,7 +19,10 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from proliferate.constants.cloud import GitProvider
+from sqlalchemy import select
+
 from proliferate.db.models.cloud.repositories import RepoConfig
+from proliferate.db.models.workflows import WorkflowDefinition, WorkflowInvocation
 from proliferate.db.store import workflow_managed_execution as managed_execution_store
 from proliferate.lib.infra.time.wall_clock import utcnow
 from proliferate.server.workflows.domain.invocation import canonical_json
@@ -125,6 +128,35 @@ async def test_v2_invocation_freezes_the_run_snapshot_contract_shape(
     # The frozen record contains the definition verbatim.
     assert frozen["definition"] == definition["definition"]
 
+    # Verbatim at the storage layer too: the frozen invocation_json embeds the
+    # exact definition_json bytes of the definition row, not a re-derivation.
+    definition_row = (
+        await db_session.execute(
+            select(WorkflowDefinition).where(WorkflowDefinition.id == UUID(str(definition["id"])))
+        )
+    ).scalar_one()
+    invocation_row = (
+        await db_session.execute(
+            select(WorkflowInvocation).where(WorkflowInvocation.id == UUID(invocation_id))
+        )
+    ).scalar_one()
+    assert invocation_row.invocation_json["definition"] == definition_row.definition_json
+
+    # A v1-shaped PUT replaying against this v2-occupied id is a caller-side
+    # collision: 409, never "stored data is invalid".
+    v1_shaped_replay = await client.put(
+        f"/v1/workflow-invocations/{invocation_id}",
+        headers=_headers(owner),
+        json={
+            "schemaVersion": 1,
+            "workflowDefinitionId": str(definition["id"]),
+            "expectedRevision": 1,
+            "arguments": {},
+            "target": {"kind": "managedCloud"},
+        },
+    )
+    assert v1_shaped_replay.status_code == 409
+
     # Idempotent replay returns the identical frozen record.
     replay = await client.put(
         f"/v1/workflow-invocations/{invocation_id}",
@@ -212,9 +244,23 @@ async def test_v2_invocation_argument_and_placement_rejections(
     assert (
         await put(_invocation_body(definition_id, str(repo.id), arguments={"topic": "x"})) == 201
     )
-    # Placement repo must belong to the caller.
-    assert await put(_invocation_body(definition_id, str(foreign_repo.id))) == 400
-    # Placement mode is a closed enum.
+    # Placement is shape-only (Ruling A): the CP freezes repoConfigId verbatim
+    # and never resolves it — for local v1 it carries a runtime repo-root id,
+    # which is not a CP repo-config id at all. A foreign CP repo id and a
+    # non-UUID runtime id are both accepted; resolution is the engine's job.
+    assert await put(_invocation_body(definition_id, str(foreign_repo.id))) == 201
+    runtime_placed = await client.put(
+        f"/v1/workflow-invocations/{uuid4()}",
+        headers=_headers(owner),
+        json=_invocation_body(definition_id, "rr_local_9f2c", mode="repo_root"),
+    )
+    assert runtime_placed.status_code == 201
+    assert runtime_placed.json()["placement"] == {
+        "repoConfigId": "rr_local_9f2c",
+        "mode": "repo_root",
+    }
+    # Shape still holds: empty ids and unknown modes are rejected.
+    assert await put(_invocation_body(definition_id, "")) == 422
     assert await put(_invocation_body(definition_id, str(repo.id), mode="floating")) == 422
 
     # A v2 invocation of a v1 definition is invalid.
@@ -297,3 +343,46 @@ async def test_v2_invocation_freezes_the_definition_at_trigger_time(
     assert second.status_code == 201
     assert second.json()["definitionRevision"] == 2
     assert second.json()["definition"] == minimal["definition"]
+
+
+@pytest.mark.asyncio
+async def test_v2_referenced_optional_input_needs_an_argument(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Ruling H: every prompt-referenced input needs an argument, optional or
+    not — the client satisfies this by sending "" for blank optionals."""
+
+    owner = await register_and_login(client, "wf2-inv-optional@example.com")
+    repo = await _seed_repo(db_session, user_id=owner["user_id"], name="optional-repo")
+    fixture = _fixture("v2-full.json")
+    definition_doc = deepcopy(fixture["definition"])
+    assert isinstance(definition_doc, dict)
+    nodes = definition_doc["nodes"]
+    assert isinstance(nodes, list) and isinstance(nodes[0], dict)
+    nodes[0]["prompt"] = "Research @input:topic at @input:depth depth into @doc:research-findings"
+    created = await client.post(
+        "/v1/workflows",
+        headers=_headers(owner),
+        json={
+            "title": "Optional referenced",
+            "description": "",
+            "defaultRepoConfigId": None,
+            "definition": definition_doc,
+        },
+    )
+    assert created.status_code == 201
+    definition_id = str(created.json()["id"])
+
+    async def put(arguments: dict[str, object]) -> int:
+        response = await client.put(
+            f"/v1/workflow-invocations/{uuid4()}",
+            headers=_headers(owner),
+            json=_invocation_body(definition_id, str(repo.id), arguments=arguments),
+        )
+        return response.status_code
+
+    # depth is optional but referenced: omitting it refuses the trigger.
+    assert await put({"topic": "engines"}) == 400
+    # The blank-optional convention: an empty string satisfies the rule.
+    assert await put({"topic": "engines", "depth": ""}) == 201

--- a/server/tests/unit/test_workflow_definition_v2_validation.py
+++ b/server/tests/unit/test_workflow_definition_v2_validation.py
@@ -61,14 +61,22 @@ def test_invalid_fixtures_are_rejected(path: Path) -> None:
     fixture = json.loads(path.read_text())
     rejected_by = fixture["rejectedBy"]
     if rejected_by == "shape":
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError) as excinfo:
             WorkflowDefinitionDocumentV2.model_validate(fixture["definition"])
+        expected_path = fixture.get("expectedIssuePath")
+        if expected_path is not None:
+            locs = {
+                ".".join(str(part) for part in error["loc"]) for error in excinfo.value.errors()
+            }
+            assert expected_path in locs, f"{path.stem}: {expected_path!r} not in {locs}"
         return
     assert rejected_by == "structure"
     document = WorkflowDefinitionDocumentV2.model_validate(fixture["definition"])
     issue = validate_definition_v2_document(document)
     assert issue is not None, f"{path.stem} unexpectedly validated"
     assert issue.path == fixture["expectedIssuePath"]
+    if path.stem.startswith("v2-invalid-ref-"):
+        assert "malformed" in issue.message, f"{path.stem}: {issue.message}"
 
 
 def test_run_snapshot_fixture_parses_as_frozen_invocation() -> None:
@@ -101,3 +109,81 @@ def test_single_node_with_stray_edge_is_rejected() -> None:
     issue = validate_definition_v2_document(document)
     assert issue is not None
     assert issue.path == "edges"
+
+
+def _single_node_document(prompt: str) -> WorkflowDefinitionDocumentV2:
+    return WorkflowDefinitionDocumentV2.model_validate(
+        {
+            "schemaVersion": 2,
+            "nodes": [{"id": "n_a", "type": "agent", "title": "T", "prompt": prompt}],
+            "inputs": [{"name": "topic", "required": True}],
+            "docTemplates": [
+                {"slug": "research-findings", "producingNodeId": "n_a", "body": "# F\n"}
+            ],
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("prompt", "fragment"),
+    [
+        # Scan-then-validate (Ruling C, amended C.1): a reference attempt is a
+        # case-insensitive sigil plus a run of non-space non-@ characters;
+        # trailing prose punctuation peels before grammar validation. A token
+        # failing the grammar after the peel, a wrong-case sigil, or an empty
+        # token is a malformed-reference error, never a silent non-match or
+        # prefix match.
+        (
+            "See @doc:Research-Findings for details",
+            "malformed @doc: reference 'Research-Findings'",
+        ),
+        ("See @doc:research-findings-EXTRA now", "malformed @doc: reference"),
+        ("Use @input:my-topic here", "malformed @input: reference 'my-topic'"),
+        ("Use @input:_topic here", "malformed @input: reference '_topic'"),
+        ("Write @doc:research_findings today", "malformed @doc: reference 'research_findings'"),
+        ("See @doc:plan.md today", "malformed @doc: reference 'plan.md'"),
+        ("Research @INPUT:topic today", "malformed @input: reference '@INPUT:topic'"),
+        ("Check the @doc: carefully", "malformed @doc: reference with an empty token"),
+    ],
+)
+def test_malformed_references_are_errors_not_non_matches(prompt: str, fragment: str) -> None:
+    issue = validate_definition_v2_document(_single_node_document(prompt))
+    assert issue is not None, prompt
+    assert issue.path == "nodes.0.prompt"
+    assert fragment in issue.message
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        # C.1: sentence punctuation directly after a reference peels away.
+        "Research @input:topic. Then write @doc:research-findings.",
+        'Cite "@input:topic" and (@doc:research-findings), please…',
+        # Back-to-back references parse individually (capture stops at @).
+        "Merge @doc:research-findings@doc:research-findings now",
+    ],
+)
+def test_prose_punctuation_and_adjacency_stay_valid(prompt: str) -> None:
+    assert validate_definition_v2_document(_single_node_document(prompt)) is None
+
+
+def test_valid_refs_fixture_validates_clean() -> None:
+    fixture = _load("v2-valid-refs.json")
+    definition = fixture["definition"]
+    assert isinstance(definition, dict)
+    document = WorkflowDefinitionDocumentV2.model_validate(definition)
+    assert validate_definition_v2_document(document) is None
+
+
+def test_wellformed_references_still_distinguish_undeclared() -> None:
+    issue = validate_definition_v2_document(
+        _single_node_document("Research @input:topic into @doc:missing-doc please")
+    )
+    assert issue is not None
+    assert "undeclared doc 'missing-doc'" in issue.message
+    assert (
+        validate_definition_v2_document(
+            _single_node_document("Research @input:topic into @doc:research-findings please")
+        )
+        is None
+    )

--- a/server/tests/unit/test_workflow_definition_v2_validation.py
+++ b/server/tests/unit/test_workflow_definition_v2_validation.py
@@ -1,0 +1,103 @@
+"""Fixture-driven validation for gen-2 workflow definition documents.
+
+Consumer half of ``fixtures/contracts/workflow-definition/v2-*.json``. The
+runtime plane consumes the same fixtures (PR3) so the two validators stay in
+lockstep: ``rejectedBy: "shape"`` cases must fail wire-model parsing,
+``rejectedBy: "structure"`` cases must parse and then fail the pure
+cross-field validator at exactly ``expectedIssuePath``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from proliferate.server.workflows.domain.validation_v2 import (
+    validate_definition_v2_document,
+)
+from proliferate.server.workflows.models_v2 import (
+    WorkflowDefinitionDocumentV2,
+    WorkflowDefinitionResponseV2,
+    WorkflowInvocationResponseV2,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_ROOT = REPO_ROOT / "fixtures" / "contracts" / "workflow-definition"
+
+INVALID_FIXTURES = sorted(FIXTURE_ROOT.glob("v2-invalid-*.json"))
+
+
+def _load(name: str) -> dict[str, object]:
+    return json.loads((FIXTURE_ROOT / name).read_text())
+
+
+def test_v2_full_fixture_parses_and_validates() -> None:
+    fixture = _load("v2-full.json")
+    response = WorkflowDefinitionResponseV2.model_validate(fixture)
+    assert response.schema_version == 2
+    assert validate_definition_v2_document(response.definition) is None
+    # The stored form round-trips byte-identically through the wire model.
+    assert response.definition.document_json() == fixture["definition"]
+
+
+def test_v2_minimal_fixture_parses_and_validates() -> None:
+    fixture = _load("v2-minimal.json")
+    response = WorkflowDefinitionResponseV2.model_validate(fixture)
+    assert validate_definition_v2_document(response.definition) is None
+    assert response.definition.edges == []
+    assert response.definition.inputs == []
+    assert response.definition.doc_templates == []
+
+
+def test_invalid_fixture_list_is_nonempty() -> None:
+    assert len(INVALID_FIXTURES) >= 10
+
+
+@pytest.mark.parametrize("path", INVALID_FIXTURES, ids=lambda path: path.stem)
+def test_invalid_fixtures_are_rejected(path: Path) -> None:
+    fixture = json.loads(path.read_text())
+    rejected_by = fixture["rejectedBy"]
+    if rejected_by == "shape":
+        with pytest.raises(ValidationError):
+            WorkflowDefinitionDocumentV2.model_validate(fixture["definition"])
+        return
+    assert rejected_by == "structure"
+    document = WorkflowDefinitionDocumentV2.model_validate(fixture["definition"])
+    issue = validate_definition_v2_document(document)
+    assert issue is not None, f"{path.stem} unexpectedly validated"
+    assert issue.path == fixture["expectedIssuePath"]
+
+
+def test_run_snapshot_fixture_parses_as_frozen_invocation() -> None:
+    fixture = _load("run-snapshot-v2.json")
+    response = WorkflowInvocationResponseV2.model_validate(fixture)
+    assert response.schema_version == 2
+    assert response.placement.mode == "worktree"
+    assert validate_definition_v2_document(response.definition) is None
+    round_tripped = response.model_dump(by_alias=True, mode="json", exclude_none=True)
+    assert round_tripped == fixture
+
+
+def test_schema_version_must_be_exact_integer() -> None:
+    minimal = _load("v2-minimal.json")["definition"]
+    assert isinstance(minimal, dict)
+    with pytest.raises(ValidationError):
+        WorkflowDefinitionDocumentV2.model_validate({**minimal, "schemaVersion": "2"})
+    with pytest.raises(ValidationError):
+        WorkflowDefinitionDocumentV2.model_validate({**minimal, "schemaVersion": 1})
+
+
+def test_single_node_with_stray_edge_is_rejected() -> None:
+    document = WorkflowDefinitionDocumentV2.model_validate(
+        {
+            "schemaVersion": 2,
+            "nodes": [{"id": "n_a", "type": "agent", "title": "T", "prompt": "Run."}],
+            "edges": [{"from": "n_a", "to": "n_a"}],
+        }
+    )
+    issue = validate_definition_v2_document(document)
+    assert issue is not None
+    assert issue.path == "edges"

--- a/server/tests/unit/test_workflow_invocations.py
+++ b/server/tests/unit/test_workflow_invocations.py
@@ -300,18 +300,28 @@ def test_invocation_request_rejects_unknown_top_level_and_target_fields(
 def test_invocation_openapi_pins_exact_request_and_response_shapes() -> None:
     schema = create_app().openapi()
     operation = schema["paths"]["/v1/workflow-invocations/{invocation_id}"]
-    assert operation["put"]["requestBody"]["content"]["application/json"]["schema"] == {
-        "$ref": "#/components/schemas/WorkflowInvocationCreateRequest"
-    }
-    assert operation["put"]["responses"]["200"]["content"]["application/json"]["schema"] == {
-        "$ref": "#/components/schemas/WorkflowInvocationResponse"
-    }
-    assert operation["get"]["responses"]["200"]["content"]["application/json"]["schema"] == {
-        "$ref": "#/components/schemas/ManagedWorkflowInvocationResponse"
-    }
-    assert operation["put"]["responses"]["201"]["content"]["application/json"]["schema"] == {
-        "$ref": "#/components/schemas/WorkflowInvocationResponse"
-    }
+    assert operation["put"]["requestBody"]["content"]["application/json"]["schema"]["anyOf"] == [
+        {"$ref": "#/components/schemas/WorkflowInvocationCreateRequestV2"},
+        {"$ref": "#/components/schemas/WorkflowInvocationCreateRequest"},
+    ]
+    assert operation["put"]["responses"]["200"]["content"]["application/json"]["schema"][
+        "anyOf"
+    ] == [
+        {"$ref": "#/components/schemas/WorkflowInvocationResponse"},
+        {"$ref": "#/components/schemas/WorkflowInvocationResponseV2"},
+    ]
+    assert operation["get"]["responses"]["200"]["content"]["application/json"]["schema"][
+        "anyOf"
+    ] == [
+        {"$ref": "#/components/schemas/ManagedWorkflowInvocationResponse"},
+        {"$ref": "#/components/schemas/WorkflowInvocationResponseV2"},
+    ]
+    assert operation["put"]["responses"]["201"]["content"]["application/json"]["schema"][
+        "anyOf"
+    ] == [
+        {"$ref": "#/components/schemas/WorkflowInvocationResponse"},
+        {"$ref": "#/components/schemas/WorkflowInvocationResponseV2"},
+    ]
 
     components = schema["components"]["schemas"]
     request = components["WorkflowInvocationCreateRequest"]
@@ -349,6 +359,44 @@ def test_invocation_openapi_pins_exact_request_and_response_shapes() -> None:
     assert components["ManagedCloudWorkflowTarget"]["properties"]["kind"]["const"] == (
         "managedCloud"
     )
+
+    request_v2 = components["WorkflowInvocationCreateRequestV2"]
+    assert request_v2["additionalProperties"] is False
+    assert request_v2["required"] == [
+        "schemaVersion",
+        "workflowDefinitionId",
+        "arguments",
+        "placement",
+    ]
+    assert set(request_v2["properties"]) == set(request_v2["required"])
+    assert request_v2["properties"]["schemaVersion"]["const"] == 2
+    assert request_v2["properties"]["placement"] == {
+        "$ref": "#/components/schemas/WorkflowInvocationPlacementV2"
+    }
+
+    placement_v2 = components["WorkflowInvocationPlacementV2"]
+    assert placement_v2["additionalProperties"] is False
+    assert set(placement_v2["required"]) == {"repoConfigId", "mode"}
+    assert set(placement_v2["properties"]["mode"]["enum"]) == {"worktree", "repo_root"}
+
+    response_v2 = components["WorkflowInvocationResponseV2"]
+    assert response_v2["additionalProperties"] is False
+    assert set(response_v2["properties"]) == {
+        "id",
+        "schemaVersion",
+        "workflowDefinitionId",
+        "definitionRevision",
+        "title",
+        "description",
+        "definition",
+        "arguments",
+        "placement",
+        "createdAt",
+    }
+    assert set(response_v2["required"]) == set(response_v2["properties"])
+    assert response_v2["properties"]["definition"] == {
+        "$ref": "#/components/schemas/WorkflowDefinitionDocumentV2"
+    }
 
 
 def test_managed_workflow_openapi_pins_required_nullable_and_status_contracts() -> None:


### PR DESCRIPTION
## Summary

Rung PR2 of the workflows gen-2 ladder (ADR: Workflows gen-2, section "High level sequencing"). Teaches the control plane the gen-2 definition DSL (`schemaVersion: 2`) and the gen-2 invocation freeze shape, additively — v1 keeps validating and executing unchanged until PR7. First commit is the frozen delivery specification for this rung.

- **v2 definition document** `{schemaVersion: 2, nodes, edges, inputs, docTemplates}` with pure, catalog-free cross-field validation (single linear path covering all nodes, unique node ids / doc slugs, `@input:` / `@doc:` references resolve, no placement key anywhere in the DSL). Catalog-free is deliberate: the identical validator lands on the runtime plane in PR3, kept in lockstep via shared contract fixtures.
- **v2 endpoints, additive on the existing routes**: `POST/PUT /v1/workflows` accept `{title, description?, defaultRepoConfigId?, definition}` beside the v1 flat body; list/get return v2 rows with `definition`; run-eligibility answers eligible for v2; `PUT /v1/workflow-invocations/{id}` accepts `{schemaVersion: 2, workflowDefinitionId, arguments, placement: {repoConfigId, mode: worktree|repo_root}}` and freezes the definition **verbatim at trigger time** (no expectedRevision — ADR snapshot-custody ruling). Idempotent on id; replay returns the identical frozen record; divergent replay 409s. **Id-space contract (Ruling A)**: both `defaultRepoConfigId` and `placement.repoConfigId` are RUNTIME repo-root ids (the client sources them from `GET /v1/repo-roots`), not CP repo-config ids. The CP validates shape only — UUID-or-null for `defaultRepoConfigId`, non-empty string for `placement.repoConfigId` — stores/freezes them opaquely, and never resolves them; resolution is the engine plane's job at placement time.
- **No managed-execution lane for gen-2**: no managed row is created; GET returns the frozen record directly; deliver/cancel answer 404. Delivery to the local runtime is the client courier's job (PR5b).
- **Storage**: migration `c7d9e1f3a5b7` widens both schema-version checks to `IN (1, 2)`, adds nullable `definition_json JSONB`, and drops `workflow_definition.default_repo_config_id`'s FK into `repo_config` — a Postgres-enforced CP resolution of what is now a runtime-space id (recreated on downgrade after the v2-row deletes; v1 keeps its service-layer ownership check, and `repo_config` is soft-delete-only so the FK's `ON DELETE SET NULL` never fired). v2 rows keep `inputs_json`/`stages_json` empty and `validated_catalog_version` blank.
- **Contract fixtures** (`fixtures/contracts/workflow-definition/`): `v2-full`, `v2-minimal`, twelve `v2-invalid-*` cases (each declaring `rejectedBy` + `expectedIssuePath`), and `run-snapshot-v2.json` — the frozen `invocation_json` byte-shape the courier hands the runtime. The integration suite is the producer half of that fixture (canonical-JSON equality outside instance identity fields). The old v1 fixtures and `workflow-portable-execution/` are untouched (PR1 owns that deletion).
- **422 hardening**: the union request bodies namespace error locs by model branch and echo the whole submitted document on branch-level errors. The workflow-invocation 422 redaction now blanks `arguments` subtrees wherever they appear in echoed inputs — the existing `never_reflects_value` test caught the leak red before the fix.
- Regenerated `cloud/sdk/src/generated/openapi.ts` (+217 lines of V2 types); `@proliferate/cloud-sdk` and `@proliferate/cloud-sdk-react` typecheck clean.

## Validation

- Unit: 18 new fixture-driven v2 validation tests; openapi pin test extended with V2 component pins; all pre-existing workflow unit suites green.
- Integration (real Postgres, migration exercised): 7 new v2 tests (CRUD lifecycle, mixed v1+v2 listing, rejection paths, owner isolation, freeze-at-trigger vs later edits, run-snapshot contract equality, managed-lane isolation); all 10 pre-existing workflow integration suites green (65 tests total in the workflow scope).
- Id-space contract test: a runtime repo-root UUID unknown to the CP saves 201 and echoes verbatim; a CP-id-shaped UUID also 201s (ownership is irrelevant — wrong space); a non-UUID string 422s; null 201s. Proven live before the fix: the builder's own ids were 400 "Default repository was not found."
- Negative control: disabling the more-than-one-outgoing-edge check makes `v2-invalid-branching-edges` fail; restored and green. The redaction fix's control was the pre-existing leak test observed red before the handler change.
- `ruff check` + `ruff format` clean; mypy ratchet passes with 0 new diagnostics (`models_v2` added to the established pydantic-plugin false-positive override list).
- Note: main's "Login first-load budget (phase-6)" check is red pre-existing from #1840.

Part of the workflows gen-2 overnight ladder (PR1–PR7); PR3/PR4 (runtime) consume the fixtures and the frozen invocation shape, PR5b/PR7 (client) consume the endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
