### PR TITLE
fix(anyharness): clear skip-worktree bits in the capture-index copy; allowlist merge-grown files

### DIFF
--- a/anyharness/crates/anyharness-lib/src/adapters/git/operations/snapshot.rs
+++ b/anyharness/crates/anyharness-lib/src/adapters/git/operations/snapshot.rs
@@ -220,7 +220,46 @@ fn capture_work_tree(
     let seeded_by_copy = real_index
         .as_deref()
         .is_some_and(|index| std::fs::copy(index, &temp_index).is_ok());
-    if !seeded_by_copy {
+    if seeded_by_copy {
+        // The copy also carries skip-worktree bits, and `git add -A` honors
+        // them — it would keep the INDEX content for those paths and silently
+        // drop their on-disk edits from the capture (spec §6.8 only cedes the
+        // BIT across the round trip, never content). Clear the bits in the
+        // capture index so those paths are re-examined like every other.
+        let flagged = Command::new("git")
+            .current_dir(workspace_path)
+            .env("GIT_INDEX_FILE", &temp_index)
+            .env("LC_ALL", "C")
+            .args(["ls-files", "-v", "-z"])
+            .output()
+            .map_err(|error| SnapshotError::Internal(anyhow::anyhow!("git ls-files -v failed to run: {error}")))?;
+        let skip_worktree_paths: Vec<String> = flagged
+            .stdout
+            .split(|byte| *byte == 0)
+            .filter_map(|entry| {
+                let entry = String::from_utf8_lossy(entry);
+                let (tag, path) = entry.split_once(' ')?;
+                (tag == "S" || tag == "s").then(|| path.to_string())
+            })
+            .collect();
+        if !skip_worktree_paths.is_empty() {
+            let mut unset = Command::new("git");
+            unset
+                .current_dir(workspace_path)
+                .env("GIT_INDEX_FILE", &temp_index)
+                .args(["update-index", "--no-skip-worktree", "--"])
+                .args(&skip_worktree_paths);
+            let unset = unset
+                .output()
+                .map_err(|error| SnapshotError::Internal(anyhow::anyhow!("git update-index --no-skip-worktree failed to run: {error}")))?;
+            if !unset.status.success() {
+                return Err(SnapshotError::Internal(anyhow::anyhow!(
+                    "git update-index --no-skip-worktree failed: {}",
+                    String::from_utf8_lossy(&unset.stderr).trim()
+                )));
+            }
+        }
+    } else {
         let seed = Command::new("git")
             .current_dir(workspace_path)
             .env("GIT_INDEX_FILE", &temp_index)

--- a/scripts/frontend_structure_allowlist.txt
+++ b/scripts/frontend_structure_allowlist.txt
@@ -18,6 +18,8 @@
 # max-lines entries.
 
 apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx 447 blocked-status composer takeover branch (textarea/control-row swap + focus restore); split on next growth
+apps/packages/product-client/src/components/workspace/shell/sidebar/MainSidebar.tsx 521 connected sidebar host; main's pinned-section split landed alongside R7's lifecycle archive handlers (resolver, instant archive, optimistic-hide over groups+pinned, scenario dialog) in the merge; extraction pending
+apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-archive-actions.ts 464 R7 lifecycle archive/unarchive orchestrator: verb posts, undo toasts, 409 scenario flow, optimistic-hide set with pending reconciliation; grew past 400 with the flicker-regression rider
 apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts 425 workspace bootstrap actions + gateway billing-block capture into the status screen (C8); split on next growth
 apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.tsx 525 existing markdown transcript renderer pending split
 # Relocated from apps/desktop/src by the Desktop-product move into product-client
@@ -29,7 +31,7 @@ apps/packages/product-client/src/components/content/ui/diff/SplitDiffViewer.tsx 
 apps/packages/product-client/src/components/content/ui/diff/UnifiedDiffViewer.tsx 414 unified diff viewer pending row-renderer split
 apps/packages/product-client/src/components/workspace/repo-setup/CloudRepoActionDialogHost.tsx 433 shared ordered-readiness continuation host for Cloud registration and retry-stable local clone; split by intent owner on next growth
 apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-tombstones.ts 408 async ProductStorage hydration added to the in-memory tombstone model
-apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.ts 451 session creation orchestrator (+lazy materialization and durable empty-create lifecycle, frozen-input replay, and acknowledgement seam); split deferred
+apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.ts 452 session creation orchestrator (+lazy materialization and durable empty-create lifecycle, frozen-input replay, and acknowledgement seam); split deferred
 apps/packages/product-client/src/lib/infra/measurement/measurement-port.ts 734 product-owned measurement port barrel (R1 ruling) mirroring the retained measurement surface through a swappable no-op sink; split deferred
 apps/packages/product-client/src/host/product-host.ts 420 WDU slice 04 (G2/G4): host contract grew from getAnonymousInstallId + getSandboxGatewayAccessToken and their doc contracts
 apps/packages/product-client/src/components/playground/WorkspaceStatusPlayground.tsx 450 status-card playground fixtures pending scenario-module split (#1202 debt repair)


### PR DESCRIPTION
Repairs main CI red from the archiving train merge (run 31783142963).

**Cargo test**: the R7 perf rider seeds the capture index by copying the real index, which carries skip-worktree bits — `git add -A` then keeps INDEX content for those paths and silently drops their on-disk edits from the snapshot. R2's spec §6.8 bound test caught it (`skip_worktree_bit_survives_content_but_not_the_bit_as_a_bound`): only the BIT may be lost across the round trip, never content. Fix: list `S`-flagged paths in the copied index and `update-index --no-skip-worktree` them before the add. Full anyharness-lib suite green locally (1938 passed; the one remaining local failure is the known pre-existing mtime-dependent sweep test, green in CI).

**Repo shape**: allowlists the three files the two-train merge grew past the frontend 400-line preference — MainSidebar.tsx 521 (main's pinned-section structure + R7's lifecycle archive handlers), use-workspace-archive-actions.ts 464 (flicker rider), use-session-creation-actions.ts 451→452.

🤖 Generated with [Claude Code](https://claude.com/claude-code)