### PR TITLE
fix(product): suppress WebKit's right-mousedown word selection under context menus

### DIFF
--- a/apps/packages/product-client/src/primitives/PopoverButton.test.tsx
+++ b/apps/packages/product-client/src/primitives/PopoverButton.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { PopoverButton } from "#product/primitives/PopoverButton";
+
+afterEach(cleanup);
+
+describe("PopoverButton", () => {
+  // WebKit's secondary-button mousedown default selects the word under the
+  // pointer before `contextmenu` fires. PopoverButton always suppresses the
+  // browser context menu, so the pre-selection must be suppressed with it —
+  // otherwise right-clicking a transcript file mention flashes a text
+  // highlight under the menu. fireEvent returns false iff preventDefault ran.
+  it("prevents the secondary-button mousedown default on contextMenu triggers", () => {
+    render(
+      <PopoverButton
+        trigger={<button type="button">target</button>}
+        triggerMode="contextMenu"
+      >
+        {() => <div>menu</div>}
+      </PopoverButton>,
+    );
+    const trigger = screen.getByRole("button", { name: "target" });
+
+    expect(fireEvent.mouseDown(trigger, { button: 2 })).toBe(false);
+  });
+
+  it("leaves primary-button mousedown untouched", () => {
+    render(
+      <PopoverButton
+        trigger={<button type="button">target</button>}
+        triggerMode="contextMenu"
+      >
+        {() => <div>menu</div>}
+      </PopoverButton>,
+    );
+    const trigger = screen.getByRole("button", { name: "target" });
+
+    expect(fireEvent.mouseDown(trigger, { button: 0 })).toBe(true);
+  });
+
+  it("prevents the secondary-button mousedown default on click triggers too", () => {
+    render(
+      <PopoverButton
+        trigger={<button type="button">target</button>}
+      >
+        {() => <div>menu</div>}
+      </PopoverButton>,
+    );
+    const trigger = screen.getByRole("button", { name: "target" });
+
+    expect(fireEvent.mouseDown(trigger, { button: 2 })).toBe(false);
+  });
+});

--- a/apps/packages/product-client/src/primitives/PopoverButton.tsx
+++ b/apps/packages/product-client/src/primitives/PopoverButton.tsx
@@ -107,6 +107,18 @@ export function PopoverButton({
     }
   };
 
+  // WebKit selects the word under the pointer as the secondary-button
+  // mousedown default, before `contextmenu` ever fires. Every trigger mode
+  // suppresses the browser context menu (handleContextMenu), so that
+  // pre-selection is never wanted: without this, two-finger-clicking a
+  // transcript file mention flashes a text highlight under the menu.
+  // Primary-button behavior (text selection, focus, drag) is untouched.
+  const handleMouseDown = (event: ReactMouseEvent) => {
+    if (event.button === 2) {
+      event.preventDefault();
+    }
+  };
+
   const handleDoubleClick = (event: ReactMouseEvent) => {
     if (stopPropagation) {
       event.stopPropagation();
@@ -142,6 +154,7 @@ export function PopoverButton({
           onClick={handleClick}
           onDoubleClick={handleDoubleClick}
           onContextMenu={handleContextMenu}
+          onMouseDown={handleMouseDown}
         >
           {trigger}
         </PopoverTrigger>
@@ -156,6 +169,7 @@ export function PopoverButton({
             onClick={handleClick}
             onDoubleClick={handleDoubleClick}
             onContextMenu={handleContextMenu}
+            onMouseDown={handleMouseDown}
           >
             {trigger}
           </Slot>


### PR DESCRIPTION
## Summary
Two-finger-clicking a transcript file mention selected the word under the pointer before the context menu opened: WebKit performs that selection as the secondary-button mousedown default, ahead of the `contextmenu` event every `PopoverButton` trigger mode already suppresses. This prevents the secondary-button mousedown default on the trigger so the menu opens with no highlight flash.

- Primary-button selection, focus, and drag behavior are untouched.
- New regression tests in `PopoverButton.test.tsx`; the negative control (fix reverted) fails them.

Extracted from local `pro185-preview` testing (authored alongside #1869, but standalone — applies cleanly to `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)