### PR TITLE
fix(anyharness): stop forwarding the catalog default-model sentinel as ANTHROPIC_MODEL

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_env.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_env.rs
@@ -18,6 +18,15 @@ use std::collections::BTreeMap;
 
 use crate::domains::agents::model::{AgentKind, ResolvedAgent};
 
+/// Claude's catalog-declared sentinel model id (`catalogs/agents/catalog.json`,
+/// claude's `models[]`): "use the harness's own default", not a real model
+/// name the CLI understands. A session can carry this as its resolved
+/// `requested_model_id` (it is a legitimate, `defaultVisible` picker entry —
+/// [`ActiveCatalog::validate_launch_in_universe`] resolves it like any other
+/// row), so launch env must recognize and skip it rather than forward it as
+/// `ANTHROPIC_MODEL`, which the CLI rejects with `model_not_found`.
+const CATALOG_DEFAULT_MODEL_SENTINEL: &str = "default";
+
 pub(super) fn build_session_launch_env(
     resolved_agent: &ResolvedAgent,
     requested_model_id: Option<&str>,
@@ -52,6 +61,7 @@ fn build_claude_session_launch_env(
     if let Some(model_id) = requested_model_id
         .map(str::trim)
         .filter(|value| !value.is_empty())
+        .filter(|value| *value != CATALOG_DEFAULT_MODEL_SENTINEL)
     {
         env.insert("ANTHROPIC_MODEL".to_string(), model_id.to_string());
     }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_env.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_env.rs
@@ -61,7 +61,7 @@ fn build_claude_session_launch_env(
     if let Some(model_id) = requested_model_id
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .filter(|value| *value != CATALOG_DEFAULT_MODEL_SENTINEL)
+        .filter(|value| !value.eq_ignore_ascii_case(CATALOG_DEFAULT_MODEL_SENTINEL))
     {
         env.insert("ANTHROPIC_MODEL".to_string(), model_id.to_string());
     }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_env_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_env_tests.rs
@@ -71,6 +71,36 @@ fn build_session_launch_env_sets_requested_model_for_claude() {
     );
 }
 
+/// The catalog's `"default"` model row (`catalogs/agents/catalog.json`,
+/// claude's `models[]`) is a sentinel meaning "use the harness's own
+/// default", not a real model name — the claude CLI rejects
+/// `ANTHROPIC_MODEL=default` with `model_not_found`. Launch env must omit the
+/// var entirely so the CLI falls back to its own default.
+#[test]
+fn build_session_launch_env_omits_model_for_claude_default_sentinel() {
+    let env = build_session_launch_env(
+        &resolved_agent(AgentKind::Claude, Some("/tmp/managed/claude")),
+        Some("default"),
+    )
+    .expect("build env");
+
+    assert!(
+        !env.contains_key("ANTHROPIC_MODEL"),
+        "sentinel \"default\" must not be forwarded as ANTHROPIC_MODEL, got {env:?}"
+    );
+}
+
+#[test]
+fn build_session_launch_env_sets_requested_model_for_real_claude_model_id() {
+    let env = build_session_launch_env(
+        &resolved_agent(AgentKind::Claude, Some("/tmp/managed/claude")),
+        Some("haiku"),
+    )
+    .expect("build env");
+
+    assert_eq!(env.get("ANTHROPIC_MODEL").map(String::as_str), Some("haiku"));
+}
+
 #[test]
 fn build_session_launch_env_ignores_claude_without_native_path() {
     let env = build_session_launch_env(&resolved_agent(AgentKind::Claude, None), None)
@@ -89,6 +119,17 @@ fn build_session_launch_env_sets_requested_model_without_claude_native_path() {
         Some("sonnet")
     );
     assert!(!env.contains_key("CLAUDE_CODE_EXECUTABLE"));
+}
+
+#[test]
+fn build_session_launch_env_omits_model_for_blank_requested_model() {
+    let env = build_session_launch_env(
+        &resolved_agent(AgentKind::Claude, Some("/tmp/managed/claude")),
+        Some("   "),
+    )
+    .expect("build env");
+
+    assert!(!env.contains_key("ANTHROPIC_MODEL"));
 }
 
 /// Codex's isolated home is no longer built here — it is route-auth's native

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_env_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_env_tests.rs
@@ -101,6 +101,43 @@ fn build_session_launch_env_sets_requested_model_for_real_claude_model_id() {
     assert_eq!(env.get("ANTHROPIC_MODEL").map(String::as_str), Some("haiku"));
 }
 
+/// The sentinel filter is an exact (case-insensitive) match, not a
+/// contains-match. A real model id that merely happens to contain the word
+/// "default" is a legitimate model name and must still be forwarded — this
+/// guards against the filter ever widening to `.contains(..)`.
+#[test]
+fn build_session_launch_env_forwards_model_id_that_merely_contains_the_sentinel_word() {
+    let env = build_session_launch_env(
+        &resolved_agent(AgentKind::Claude, Some("/tmp/managed/claude")),
+        Some("default-ish-model"),
+    )
+    .expect("build env");
+
+    assert_eq!(
+        env.get("ANTHROPIC_MODEL").map(String::as_str),
+        Some("default-ish-model")
+    );
+}
+
+/// The sentinel filter only ever skips inserting `ANTHROPIC_MODEL`; it must
+/// not disturb any other env this layer contributes (e.g.
+/// `CLAUDE_CODE_EXECUTABLE`).
+#[test]
+fn build_session_launch_env_keeps_other_env_when_sentinel_is_filtered() {
+    let env = build_session_launch_env(
+        &resolved_agent(AgentKind::Claude, Some("/tmp/managed/claude")),
+        Some("default"),
+    )
+    .expect("build env");
+
+    assert_eq!(
+        env.get("CLAUDE_CODE_EXECUTABLE").map(String::as_str),
+        Some("/tmp/managed/claude")
+    );
+    assert!(!env.contains_key("ANTHROPIC_MODEL"));
+    assert_eq!(env.len(), 1, "no stray keys expected, got {env:?}");
+}
+
 #[test]
 fn build_session_launch_env_ignores_claude_without_native_path() {
     let env = build_session_launch_env(&resolved_agent(AgentKind::Claude, None), None)


### PR DESCRIPTION
## Bug

`anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_env.rs` exports `ANTHROPIC_MODEL` from `requested_model_id`, filtering only empty/whitespace strings. But the agent catalog (`catalogs/agents/catalog.json`) defines a claude model entry `{"id": "default", "displayName": "Default 4.8", "description": "Use the default model (currently Opus 4.8)", ...}` that is a **sentinel** meaning "use the harness's own default" — not a real model name the claude CLI understands.

`ActiveCatalog::validate_launch_in_universe` (`anyharness/crates/anyharness-lib/src/domains/agents/catalog/service.rs`) resolves this sentinel row like any other catalog entry (it is `defaultVisible` and selectable), so a session created against the "default" option ends up with `requested_model_id = Some("default")`. Launch env then forwards `ANTHROPIC_MODEL=default` to the claude CLI, which fails the session with `model_not_found` ("There's an issue with the selected model (default)").

**Live-confirmed:** sessions with `requested_model_id=haiku` complete; `requested_model_id=default` fail 100%. Non-claude harnesses escape only because `launch_env.rs` gives them an empty env regardless of model id.

**Blast radius:** any claude session launched on the catalog's "default" model option. Workflows gen-2 makes this deterministic for nodes with no explicit model (they inherit the sentinel).

## Fix

Minimal, in the same filter chain that already strips empty/whitespace: also skip exporting `ANTHROPIC_MODEL` when the requested id equals the catalog's default sentinel (`"default"`), pulled into a named, documented constant (`CATALOG_DEFAULT_MODEL_SENTINEL`) rather than an inline literal, since no existing constant/helper for this sentinel exists elsewhere in the codebase (checked `domains/agents/model.rs`, `domains/agents/catalog/service.rs` and `schema.rs` — the sentinel is a plain catalog-declared string with no dedicated Rust representation). When the sentinel is present, `ANTHROPIC_MODEL` is omitted entirely so the CLI falls back to its own default — exactly the existing behavior for "no selection".

`catalog.json` itself is untouched, so the JS catalog validator (`scripts/agent-catalog/**`) is not implicated.

## Test

Added to `anyharness/crates/anyharness-lib/src/domains/sessions/runtime/launch_env_tests.rs`:
- `build_session_launch_env_omits_model_for_claude_default_sentinel` — sentinel id `"default"` → no `ANTHROPIC_MODEL` key (this is the regression test; fails without the fix).
- `build_session_launch_env_sets_requested_model_for_real_claude_model_id` — real id `"haiku"` → exported.
- `build_session_launch_env_omits_model_for_blank_requested_model` — whitespace-only id → not exported (pre-existing behavior, now covered explicitly).

**Negative control:** reverted the one-line fix, reran `cargo test -p anyharness-lib --lib launch_env -j 4` — exactly the new sentinel test failed (`ANTHROPIC_MODEL: "default"` in the panic output), all other tests stayed green. Restored the fix; full targeted suite passes (11/11).

## Verification

```
cargo test -p anyharness-lib --lib launch_env -j 4
running 11 tests
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 1934 filtered out
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)