### PR TITLE
fix(product): surface the skill catalog in the pre-creation home composer (PRO-228)

### DIFF
--- a/apps/packages/product-client/src/components/home/screen/HomeComposerCommandEditor.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeComposerCommandEditor.tsx
@@ -1,0 +1,185 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import type { LexicalEditor } from "lexical";
+import type { AvailableSessionCommand } from "@anyharness/sdk";
+import { ComposerRichTextEditor } from "#product/components/workspace/chat/input/ComposerRichTextEditor";
+import { ComposerSlashCommandSearch } from "#product/components/workspace/chat/input/ComposerSlashCommandSearch";
+import {
+  getComposerEditorContext,
+  replaceComposerTextRange,
+  type ComposerEditorContext,
+} from "#product/components/workspace/chat/input/ComposerEditorDocument";
+import { useChatSlashCommandMenu } from "#product/hooks/chat/ui/use-chat-slash-command-menu";
+import {
+  findComposerMenuTrigger,
+  type ComposerMenuTrigger,
+} from "#product/lib/domain/chat/composer/composer-menu-trigger";
+import type { SessionSlashCommandViewModel } from "#product/lib/domain/chat/composer/session-slash-command-policy";
+import type { ChatComposerEditorSnapshot } from "#product/lib/domain/chat/composer/file-mention-draft-model";
+import type { ChatComposerKeyboardEvent } from "#product/hooks/chat/ui/use-chat-composer-keyboard";
+
+interface HomeComposerCommandEditorProps {
+  value: string;
+  snapshot?: ChatComposerEditorSnapshot;
+  onChange: (
+    markdown: string,
+    eventTimeStampMs: number | undefined,
+    snapshot: ChatComposerEditorSnapshot,
+  ) => void;
+  onKeyDown: (event: ChatComposerKeyboardEvent) => void;
+  canSubmit: boolean;
+  onSubmit: () => void;
+  placeholder: string;
+  /** Raw per-harness catalog; the policy filter is applied by the menu hook. */
+  availableCommands: readonly AvailableSessionCommand[];
+  overlayHostElement: HTMLElement | null;
+}
+
+/**
+ * The home composer's counterpart of the workspace `ComposerCommandEditor`:
+ * the same slash-command menu over the same rich-text editor, fed by the
+ * persisted per-harness catalog instead of a live session's ACP stream
+ * (PRO-228). File mentions are deliberately absent — there is no workspace to
+ * search before the launch creates one.
+ */
+export function HomeComposerCommandEditor({
+  value,
+  snapshot,
+  onChange,
+  onKeyDown,
+  canSubmit,
+  onSubmit,
+  placeholder,
+  availableCommands,
+  overlayHostElement,
+}: HomeComposerCommandEditorProps) {
+  const editorRef = useRef<LexicalEditor | null>(null);
+  const commandTriggerRef = useRef<ComposerMenuTrigger | null>(null);
+  const [editorContext, setEditorContext] = useState<ComposerEditorContext>({
+    plainText: value,
+    anchorOffset: value.length,
+    focusOffset: value.length,
+    selectionInCodeBlock: false,
+  });
+  const plainText = editorContext.plainText;
+  const [searchSuppressed, setSearchSuppressed] = useState(false);
+  const trigger = useMemo(() => (
+    searchSuppressed || editorContext.selectionInCodeBlock
+      ? null
+      : findComposerMenuTrigger(plainText, editorContext.focusOffset)
+  ), [
+    editorContext.focusOffset,
+    editorContext.selectionInCodeBlock,
+    plainText,
+    searchSuppressed,
+  ]);
+  commandTriggerRef.current = trigger;
+  const slashTrigger = trigger?.kind === "slash" ? trigger : null;
+
+  const handleChange = useCallback((
+    markdown: string,
+    eventTimeStampMs: number | undefined,
+    nextSnapshot: ChatComposerEditorSnapshot,
+  ) => {
+    onChange(markdown, eventTimeStampMs, nextSnapshot);
+    setSearchSuppressed(false);
+  }, [onChange]);
+
+  const handleSelectSearchResult = useCallback((command: SessionSlashCommandViewModel) => {
+    const activeTrigger = commandTriggerRef.current;
+    if (activeTrigger?.kind !== "slash" || !editorRef.current) return;
+    // The token the trigger opened is replaced whole, and any single space
+    // that already followed it is absorbed so completing a trigger never
+    // leaves a double space behind (same contract as ComposerCommandEditor).
+    const replaceEnd = plainText[activeTrigger.end] === " "
+      ? activeTrigger.end + 1
+      : activeTrigger.end;
+    replaceComposerTextRange(
+      editorRef.current,
+      activeTrigger.start,
+      replaceEnd,
+      `${command.displayName} `,
+    );
+    setSearchSuppressed(true);
+    editorRef.current.focus();
+  }, [plainText]);
+
+  const search = useChatSlashCommandMenu({
+    open: !!slashTrigger,
+    query: slashTrigger?.query ?? "",
+    onSelect: handleSelectSearchResult,
+    commandsSource: availableCommands,
+  });
+
+  const handleKeyDown = useCallback((event: ChatComposerKeyboardEvent) => {
+    if (event.isComposing || event.nativeEvent?.isComposing || event.defaultPrevented) return;
+    if (slashTrigger) {
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        search.moveHighlight(event.key === "ArrowDown" ? 1 : -1);
+        return;
+      }
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setSearchSuppressed(true);
+        return;
+      }
+    }
+    onKeyDown(event);
+  }, [onKeyDown, search, slashTrigger]);
+
+  const handleCommandKey = useCallback((event: KeyboardEvent) => {
+    if (!editorRef.current || event.defaultPrevented || event.isComposing) return false;
+    const context = getComposerEditorContext(editorRef.current);
+    const activeTrigger = searchSuppressed || context.selectionInCodeBlock
+      ? null
+      : findComposerMenuTrigger(context.plainText, context.focusOffset);
+    commandTriggerRef.current = activeTrigger;
+    // The trigger is recomputed fresh from the DOM here, since the keydown can
+    // land before React re-renders; require the menu that's actually open
+    // (from the last render) to still match a slash trigger.
+    if (activeTrigger?.kind !== "slash" || !slashTrigger) {
+      return false;
+    }
+    if ((event.key === "Enter" || (event.key === "Tab" && !event.shiftKey)) && search.commands.length > 0) {
+      event.preventDefault();
+      search.selectHighlighted();
+      return true;
+    }
+    return false;
+  }, [search, searchSuppressed, slashTrigger]);
+
+  const searchTray = slashTrigger ? (
+    <ComposerSlashCommandSearch
+      commands={search.commands}
+      highlightedIndex={search.highlightedIndex}
+      listRef={search.listRef}
+      onSelect={handleSelectSearchResult}
+      onRowMouseEnter={search.handleRowMouseEnter}
+      setRowRef={search.setRowRef}
+      getRowId={search.getRowId}
+    />
+  ) : null;
+
+  return (
+    <>
+      {searchTray && overlayHostElement ? createPortal(searchTray, overlayHostElement) : null}
+      <ComposerRichTextEditor
+        value={value}
+        snapshot={snapshot}
+        onChange={handleChange}
+        onEditorContextChange={setEditorContext}
+        onKeyDown={handleKeyDown}
+        onCommandKey={handleCommandKey}
+        activeDescendantId={slashTrigger ? search.activeDescendantId : undefined}
+        canSubmit={canSubmit}
+        onSubmit={onSubmit}
+        editorRef={(editor) => { editorRef.current = editor; }}
+        placeholder={placeholder}
+        disabled={false}
+        surface="home"
+        className="min-h-[inherit]"
+      />
+    </>
+  );
+}

--- a/apps/packages/product-client/src/components/home/screen/HomeComposerForm.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeComposerForm.tsx
@@ -184,7 +184,7 @@ export function HomeComposerForm({
               from shifting while a menu opens. */}
           <div
             ref={setComposerOverlayHost}
-            className="absolute inset-x-0 bottom-full z-20 flex flex-col"
+            className="absolute inset-x-0 bottom-full z-popover flex flex-col"
           />
           <ChatComposerSurface
             onPasteCapture={handleFilePasteCapture}

--- a/apps/packages/product-client/src/components/home/screen/HomeComposerForm.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeComposerForm.tsx
@@ -1,15 +1,16 @@
-import { useCallback, useEffect, useRef, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { HOME_CHAT_COMPOSER_INPUT } from "#product/config/chat";
 import { CHAT_COMPOSER_LABELS } from "#product/copy/chat/chat-copy";
 import { ChatComposerActions } from "#product/components/workspace/chat/input/ChatComposerActions";
 import { ChatComposerControlRowFrame } from "#product/components/workspace/chat/composer/ChatComposerControlRowFrame";
 import { ChatComposerSurface } from "#product/components/workspace/chat/composer/ChatComposerSurface";
-import { ComposerRichTextEditor } from "#product/components/workspace/chat/input/ComposerRichTextEditor";
 import { DebugProfiler } from "#product/components/diagnostics/DebugProfiler";
 import { DraftAttachmentPreviewList } from "#product/components/workspace/chat/content/PromptContentRenderer";
+import { HomeComposerCommandEditor } from "#product/components/home/screen/HomeComposerCommandEditor";
 import { focusChatInputOnActivation } from "#product/lib/domain/focus-zone";
 import type { PromptAttachmentController } from "#product/hooks/chat/ui/use-chat-prompt-attachments";
 import { useChatInputPaste } from "#product/hooks/chat/ui/use-chat-input-paste";
+import { useHomeAvailableSlashCommands } from "#product/hooks/home/derived/use-home-available-slash-commands";
 import { useHomeNextComposerState } from "#product/hooks/home/ui/use-home-next-composer-state";
 import {
   finishOrCancelMeasurementOperation,
@@ -113,6 +114,11 @@ export function HomeComposerForm({
   const homeComposerInputMaxHeight =
     `calc(var(--text-composer--line-height) * ${HOME_CHAT_COMPOSER_INPUT.maxRows})`;
 
+  // The slash-command menu's source: the persisted catalog last streamed by a
+  // session of the harness this composer will launch (PRO-228).
+  const availableCommands = useHomeAvailableSlashCommands(modelSelection?.kind ?? null);
+  const [composerOverlayHost, setComposerOverlayHost] = useState<HTMLDivElement | null>(null);
+
   // Measure home-composer typing latency + per-surface commit attribution
   // (no-op unless VITE_PROLIFERATE_DEBUG_MAIN_THREAD is enabled).
   const typingOperationRef = useRef<MeasurementOperationId | null>(null);
@@ -172,6 +178,14 @@ export function HomeComposerForm({
             wrapper itself anchors the control row's compact-tier container
             queries (see chat-layout.ts). */}
         <div className="relative z-10 @container" data-focus-zone="chat">
+          {/* Slash-menu anchor. Unlike the chat dock (bottom-anchored, grows
+              upward in normal flow), the home composer sits mid-screen, so the
+              tray is absolutely anchored above the surface to keep the composer
+              from shifting while a menu opens. */}
+          <div
+            ref={setComposerOverlayHost}
+            className="absolute inset-x-0 bottom-full z-20 flex flex-col"
+          />
           <ChatComposerSurface
             onPasteCapture={handleFilePasteCapture}
             onPaste={handlePaste}
@@ -194,7 +208,7 @@ export function HomeComposerForm({
                   maxHeight: homeComposerInputMaxHeight,
                 }}
               >
-                <ComposerRichTextEditor
+                <HomeComposerCommandEditor
                   value={composer.draft}
                   snapshot={composer.editorSnapshot}
                   onChange={handleDraftChange}
@@ -202,9 +216,8 @@ export function HomeComposerForm({
                   canSubmit={composer.canSubmit}
                   onSubmit={() => { void composer.submit(); }}
                   placeholder={CHAT_COMPOSER_LABELS.placeholder}
-                  disabled={false}
-                  surface="home"
-                  className="min-h-[inherit]"
+                  availableCommands={availableCommands}
+                  overlayHostElement={composerOverlayHost}
                 />
               </div>
 

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-slash-command-menu.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-slash-command-menu.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from "react";
+import type { AvailableSessionCommand } from "@anyharness/sdk";
 import { useActiveSessionTranscript } from "#product/hooks/chat/derived/use-active-session-transcript-state";
 import { useComposerMenuNavigation } from "#product/hooks/chat/ui/use-composer-menu-navigation";
 import {
@@ -13,15 +14,22 @@ interface UseChatSlashCommandMenuArgs {
   open: boolean;
   query: string;
   onSelect: (command: SessionSlashCommandViewModel) => void;
+  /**
+   * Overrides the active session's ACP catalog as the raw command source.
+   * The home composer injects the persisted per-harness catalog here because
+   * no session exists before workspace creation (PRO-228).
+   */
+  commandsSource?: readonly AvailableSessionCommand[];
 }
 
 export function useChatSlashCommandMenu({
   open,
   query,
   onSelect,
+  commandsSource,
 }: UseChatSlashCommandMenuArgs) {
   const transcript = useActiveSessionTranscript();
-  const availableCommands = transcript?.availableCommands ?? EMPTY_COMMANDS;
+  const availableCommands = commandsSource ?? transcript?.availableCommands ?? EMPTY_COMMANDS;
 
   const commands = useMemo(() => {
     if (!open) {

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-available-slash-commands.ts
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-available-slash-commands.ts
@@ -1,0 +1,19 @@
+import type { AvailableSessionCommand } from "@anyharness/sdk";
+import { useSlashCommandCatalogStore } from "#product/stores/chat/slash-command-catalog-store";
+
+const EMPTY: readonly AvailableSessionCommand[] = [];
+
+/**
+ * The launch-time stand-in for a live session's ACP command catalog: the most
+ * recent catalog any session of the selected harness streamed, persisted
+ * across app runs. Pre-creation there is no session to ask (PRO-228), so the
+ * home composer's slash menu reads the last-seen catalog for the harness it
+ * is about to launch.
+ */
+export function useHomeAvailableSlashCommands(
+  agentKind: string | null,
+): readonly AvailableSessionCommand[] {
+  return useSlashCommandCatalogStore((state) => (
+    agentKind ? state.catalogsByAgentKind[agentKind] : undefined
+  )) ?? EMPTY;
+}

--- a/apps/packages/product-client/src/hooks/persistence/lifecycle/use-product-storage-persistence-lifecycle.ts
+++ b/apps/packages/product-client/src/hooks/persistence/lifecycle/use-product-storage-persistence-lifecycle.ts
@@ -17,6 +17,10 @@ import {
   setCloudDisplayNameSuppressionStorageContext,
 } from "#product/hooks/workspaces/lifecycle/cloud-display-name-backfill-suppression";
 import {
+  hydrateSlashCommandCatalog,
+  setSlashCommandCatalogStorageContext,
+} from "#product/stores/chat/slash-command-catalog-store";
+import {
   hydrateSessionReplacementTombstones,
   setSessionReplacementTombstonesStorageContext,
 } from "#product/lib/access/persistence/session-replacement-tombstones-storage";
@@ -52,6 +56,9 @@ export function useProductStoragePersistenceLifecycle(): void {
 
     setCloudDisplayNameSuppressionStorageContext(storage);
     void hydrateCloudDisplayNameSuppression(storage, isStale);
+
+    setSlashCommandCatalogStorageContext(storage);
+    void hydrateSlashCommandCatalog(storage, isStale);
 
     setSessionReplacementTombstonesStorageContext(storage);
     void hydrateSessionReplacementTombstones(storage, isStale).then((entries) => {

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-side-effects.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-side-effects.ts
@@ -15,6 +15,7 @@ import {
   trackSessionInteraction,
   trackWorkspaceInteraction,
 } from "#product/stores/preferences/workspace-ui-store";
+import { useSlashCommandCatalogStore } from "#product/stores/chat/slash-command-catalog-store";
 import {
   notifyTurnEnd,
   notifyUserFacingTurnEnd,
@@ -142,6 +143,13 @@ export function applyBatchedStreamSideEffects(input: {
         break;
       }
     }
+  }
+
+  if (plan.recordAvailableCommandsCatalog && input.agentKind) {
+    useSlashCommandCatalogStore.getState().recordCatalog(
+      input.agentKind,
+      input.transcript.availableCommands,
+    );
   }
 
   for (const intent of plan.persistReconciledControlPreferences) {

--- a/apps/packages/product-client/src/lib/domain/sessions/stream/stream-side-effect-plan.test.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/stream/stream-side-effect-plan.test.ts
@@ -68,7 +68,7 @@ describe("planBatchedStreamSideEffects", () => {
     ]);
   });
 
-  it("plans startup refreshes from available command updates", () => {
+  it("plans startup refreshes and catalog recording from available command updates", () => {
     const plan = planBatchedStreamSideEffects({
       ...baseInput(),
       envelopes: [
@@ -83,6 +83,16 @@ describe("planBatchedStreamSideEffects", () => {
         delayMs: 0,
       },
     ]);
+    expect(plan.recordAvailableCommandsCatalog).toBe(true);
+  });
+
+  it("does not plan catalog recording without an available command update", () => {
+    const plan = planBatchedStreamSideEffects({
+      ...baseInput(),
+      envelopes: [turnStarted(2)],
+    });
+
+    expect(plan.recordAvailableCommandsCatalog).toBe(false);
   });
 
   it("plans subagent relationship, mount, and cache invalidation commands", () => {

--- a/apps/packages/product-client/src/lib/domain/sessions/stream/stream-side-effect-plan.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/stream/stream-side-effect-plan.ts
@@ -79,6 +79,12 @@ export type OrderedStreamSideEffect =
 
 export interface BatchedStreamSideEffectPlan {
   eventEffects: PlannedStreamEventEffect[];
+  /**
+   * True when the batch carried an `available_commands_update`, so the
+   * applier records the session's post-batch command catalog for reuse by
+   * surfaces without a live session (the home composer, PRO-228).
+   */
+  recordAvailableCommandsCatalog: boolean;
   persistReconciledControlPreferences: ReconciledStreamConfigIntent[];
   invalidateWorkspaceCollections: boolean;
   invalidateGitStatus: boolean;
@@ -104,6 +110,7 @@ export function planBatchedStreamSideEffects(input: {
   let lastActivityTimestamp: string | null = null;
   let invalidateSessionSubagents = false;
   let invalidateCowork = false;
+  let recordAvailableCommandsCatalog = false;
   const reviewParentSessionIds = new Set<string>();
   const eventEffects: PlannedStreamEventEffect[] = [];
   const orderedEffects: OrderedStreamSideEffect[] = [];
@@ -111,6 +118,7 @@ export function planBatchedStreamSideEffects(input: {
   for (const envelope of input.envelopes) {
     const event = envelope.event;
     if (event.type === "available_commands_update") {
+      recordAvailableCommandsCatalog = true;
       eventEffects.push({
         kind: "schedule_startup_ready_refresh",
         reason: "available_commands",
@@ -274,6 +282,7 @@ export function planBatchedStreamSideEffects(input: {
 
   return {
     eventEffects,
+    recordAvailableCommandsCatalog,
     persistReconciledControlPreferences: input.reconciledIntents,
     invalidateWorkspaceCollections,
     invalidateGitStatus,

--- a/apps/packages/product-client/src/stores/chat/slash-command-catalog-store.test.ts
+++ b/apps/packages/product-client/src/stores/chat/slash-command-catalog-store.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createMemoryProductStorage } from "#product/test/product-storage-test-utils";
+import {
+  SLASH_COMMAND_CATALOG_STORAGE_KEY,
+  hydrateSlashCommandCatalog,
+  resetSlashCommandCatalogForTests,
+  setSlashCommandCatalogStorageContext,
+  useSlashCommandCatalogStore,
+} from "#product/stores/chat/slash-command-catalog-store";
+
+afterEach(() => {
+  resetSlashCommandCatalogForTests();
+});
+
+const FIX_TICKET = {
+  name: "fix-ticket",
+  description: "Implement a Linear ticket",
+  input: { hint: "ticket id" },
+};
+
+describe("slash command catalog store", () => {
+  it("records a catalog per agent kind, strips meta, and persists through the context", async () => {
+    const memory = createMemoryProductStorage();
+    setSlashCommandCatalogStorageContext(memory.context);
+    await hydrateSlashCommandCatalog(memory.context);
+
+    useSlashCommandCatalogStore.getState().recordCatalog("claude", [
+      { ...FIX_TICKET, meta: { acp: "extension" } },
+    ]);
+    await Promise.resolve();
+
+    expect(useSlashCommandCatalogStore.getState().catalogsByAgentKind).toEqual({
+      claude: [FIX_TICKET],
+    });
+    expect(memory.readJson(SLASH_COMMAND_CATALOG_STORAGE_KEY)).toEqual({
+      claude: [FIX_TICKET],
+    });
+  });
+
+  it("skips the write when the catalog is unchanged", () => {
+    useSlashCommandCatalogStore.getState().recordCatalog("claude", [FIX_TICKET]);
+    const first = useSlashCommandCatalogStore.getState().catalogsByAgentKind;
+
+    useSlashCommandCatalogStore.getState().recordCatalog("claude", [{ ...FIX_TICKET }]);
+
+    expect(useSlashCommandCatalogStore.getState().catalogsByAgentKind).toBe(first);
+  });
+
+  it("hydrates persisted catalogs without overwriting live entries and flushes the merge", async () => {
+    const memory = createMemoryProductStorage();
+    memory.values.set(SLASH_COMMAND_CATALOG_STORAGE_KEY, {
+      claude: [{ name: "stale", description: "persisted before this run" }],
+      codex: [{ name: "review", description: "" }],
+      malformed: "not-an-array",
+    });
+    setSlashCommandCatalogStorageContext(memory.context);
+
+    // Recorded before hydration settles: kept in memory only, so the write
+    // cannot clobber the other harnesses' persisted catalogs.
+    useSlashCommandCatalogStore.getState().recordCatalog("claude", [FIX_TICKET]);
+    expect(memory.readJson(SLASH_COMMAND_CATALOG_STORAGE_KEY)).toEqual({
+      claude: [{ name: "stale", description: "persisted before this run" }],
+      codex: [{ name: "review", description: "" }],
+      malformed: "not-an-array",
+    });
+
+    await hydrateSlashCommandCatalog(memory.context);
+    await Promise.resolve();
+
+    const merged = {
+      claude: [FIX_TICKET],
+      codex: [{ name: "review", description: "", input: null }],
+    };
+    expect(useSlashCommandCatalogStore.getState().catalogsByAgentKind).toEqual(merged);
+    expect(memory.readJson(SLASH_COMMAND_CATALOG_STORAGE_KEY)).toEqual(merged);
+  });
+
+  it("ignores a stale hydration read", async () => {
+    const memory = createMemoryProductStorage();
+    memory.values.set(SLASH_COMMAND_CATALOG_STORAGE_KEY, {
+      claude: [FIX_TICKET],
+    });
+    setSlashCommandCatalogStorageContext(memory.context);
+
+    await hydrateSlashCommandCatalog(memory.context, () => true);
+
+    expect(useSlashCommandCatalogStore.getState().catalogsByAgentKind).toEqual({});
+  });
+});

--- a/apps/packages/product-client/src/stores/chat/slash-command-catalog-store.ts
+++ b/apps/packages/product-client/src/stores/chat/slash-command-catalog-store.ts
@@ -1,0 +1,159 @@
+import type { AvailableSessionCommand } from "@anyharness/sdk";
+import { create } from "zustand";
+import {
+  readPersistedJson,
+  writePersistedJson,
+  type ProductStorageContext,
+} from "#product/lib/infra/persistence/product-storage";
+
+export const SLASH_COMMAND_CATALOG_STORAGE_KEY = "proliferate.slashCommandCatalog.v1";
+
+interface SlashCommandCatalogState {
+  /**
+   * The most recent ACP command catalog each harness kind streamed from any
+   * session, persisted across app runs. Surfaces with no live session to ask
+   * (the pre-creation home composer, PRO-228) read this as their stand-in for
+   * `transcript.availableCommands`.
+   */
+  catalogsByAgentKind: Record<string, AvailableSessionCommand[]>;
+  recordCatalog: (
+    agentKind: string,
+    commands: readonly AvailableSessionCommand[],
+  ) => void;
+}
+
+// This store is a module singleton, so it cannot call `useProductHost()`. Its
+// persistence backend is injected once at the product lifecycle mount (see
+// `useProductStoragePersistenceLifecycle`). Writes before hydration settles
+// stay in-memory — persisting the whole record then would clobber the other
+// harnesses' persisted catalogs — and are flushed merged once hydration lands.
+let storageContext: ProductStorageContext | null = null;
+let hydrationSettled = false;
+let recordedBeforeHydration = false;
+
+export function setSlashCommandCatalogStorageContext(
+  context: ProductStorageContext | null,
+): void {
+  storageContext = context;
+  hydrationSettled = false;
+}
+
+export const useSlashCommandCatalogStore = create<SlashCommandCatalogState>((set, get) => ({
+  catalogsByAgentKind: {},
+
+  recordCatalog: (agentKind, commands) => {
+    const catalog = commands.map(toPersistedCommand);
+    const current = get().catalogsByAgentKind[agentKind];
+    if (current && catalogsEqual(current, catalog)) {
+      return;
+    }
+    const catalogsByAgentKind = {
+      ...get().catalogsByAgentKind,
+      [agentKind]: catalog,
+    };
+    set({ catalogsByAgentKind });
+    if (storageContext && hydrationSettled) {
+      persistCatalogs(storageContext, catalogsByAgentKind);
+    } else {
+      recordedBeforeHydration = true;
+    }
+  },
+}));
+
+/**
+ * One-shot hydration of the persisted catalogs through the injected
+ * ProductStorage. Catalogs a live session already recorded win over the
+ * persisted snapshot, and a read that resolves after unmount (`isStale`) is
+ * ignored so a late read never overwrites live state.
+ */
+export async function hydrateSlashCommandCatalog(
+  context: ProductStorageContext,
+  isStale?: () => boolean,
+): Promise<void> {
+  const result = await readPersistedJson<Record<string, AvailableSessionCommand[]>>(
+    context,
+    SLASH_COMMAND_CATALOG_STORAGE_KEY,
+    {
+      parse: parsePersistedCatalogs,
+      fallback: {},
+      isStale,
+    },
+  );
+  if (result.status !== "settled") {
+    return;
+  }
+  if (Object.keys(result.value).length > 0) {
+    useSlashCommandCatalogStore.setState((state) => ({
+      catalogsByAgentKind: { ...result.value, ...state.catalogsByAgentKind },
+    }));
+  }
+  hydrationSettled = true;
+  if (recordedBeforeHydration) {
+    recordedBeforeHydration = false;
+    persistCatalogs(
+      context,
+      useSlashCommandCatalogStore.getState().catalogsByAgentKind,
+    );
+  }
+}
+
+export function resetSlashCommandCatalogForTests(): void {
+  storageContext = null;
+  hydrationSettled = false;
+  recordedBeforeHydration = false;
+  useSlashCommandCatalogStore.setState({ catalogsByAgentKind: {} });
+}
+
+function persistCatalogs(
+  context: ProductStorageContext,
+  catalogsByAgentKind: Record<string, AvailableSessionCommand[]>,
+): void {
+  void writePersistedJson(context, SLASH_COMMAND_CATALOG_STORAGE_KEY, catalogsByAgentKind);
+}
+
+/**
+ * Keeps only the fields the desktop slash-command policy reads; ACP's opaque
+ * `meta` extension payload stays out of client storage.
+ */
+function toPersistedCommand(command: AvailableSessionCommand): AvailableSessionCommand {
+  return {
+    name: command.name,
+    description: command.description,
+    input: typeof command.input?.hint === "string" ? { hint: command.input.hint } : null,
+  };
+}
+
+function catalogsEqual(
+  a: readonly AvailableSessionCommand[],
+  b: readonly AvailableSessionCommand[],
+): boolean {
+  return a.length === b.length && a.every((command, index) => (
+    command.name === b[index]?.name
+    && command.description === b[index]?.description
+    && (command.input?.hint ?? null) === (b[index]?.input?.hint ?? null)
+  ));
+}
+
+function parsePersistedCatalogs(raw: unknown): Record<string, AvailableSessionCommand[]> {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return {};
+  }
+  const catalogs: Record<string, AvailableSessionCommand[]> = {};
+  for (const [agentKind, commands] of Object.entries(raw)) {
+    if (!Array.isArray(commands)) {
+      continue;
+    }
+    const parsed = commands.filter(isPersistedCommand).map(toPersistedCommand);
+    if (parsed.length > 0) {
+      catalogs[agentKind] = parsed;
+    }
+  }
+  return catalogs;
+}
+
+function isPersistedCommand(value: unknown): value is AvailableSessionCommand {
+  return typeof value === "object"
+    && value !== null
+    && typeof (value as { name?: unknown }).name === "string"
+    && typeof (value as { description?: unknown }).description === "string";
+}

--- a/specs/codebase/systems/product/chat/composer.md
+++ b/specs/codebase/systems/product/chat/composer.md
@@ -169,6 +169,16 @@ Discovery follows the current caret rather than the end of the document, and a
 selection replaces only the active slash-token range while preserving text and
 formatting around it.
 
+The Home composer offers the same slash menu before any session exists
+(`HomeComposerCommandEditor.tsx`). Its source is not a live transcript: each
+session's `available_commands_update` also records that harness's catalog into
+a persisted per-agent-kind store (`slash-command-catalog-store.ts`), and Home
+reads the catalog for the harness the composer is about to launch. The same
+desktop runnable-command policy applies, the tray anchors absolutely above the
+surface (the mid-screen composer must not shift as the menu opens), and file
+mentions are deliberately absent — there is no workspace to search before
+launch. Until a harness has streamed one session, its Home menu is empty.
+
 File-mention discovery keeps the runtime's full supported result page instead
 of applying a smaller presentation limit or discarding fuzzy matches with a
 stricter client-side filter. The shared inline-menu viewport stays visually


### PR DESCRIPTION
## Summary

- The home (pre-workspace-creation) composer rendered `ComposerRichTextEditor` directly, skipping the slash-command layer entirely, and the menu's only data source was the active session's ACP `available_commands_update` — which cannot exist before a workspace/session is created. Typing `/…` on the home screen therefore showed nothing (Linear [PRO-228](https://linear.app/proliferate-team/issue/PRO-228/skill-catalog-does-not-show-up-for-a-branch-new-workspace-pre)).
- Every session's `available_commands_update` now also records that harness's command catalog into a new persisted client store (`slash-command-catalog-store.ts`, keyed by agent kind, `meta` stripped), written from the existing batched stream side-effect plan/apply seam.
- New `HomeComposerCommandEditor` gives the home composer the same slash menu as a live session — same trigger, policy filter, tray, and keyboard contract — fed by the persisted catalog for the harness the composer is about to launch. File mentions stay deliberately absent (no workspace to search yet), and the tray anchors absolutely above the surface so the mid-screen composer doesn't shift when the menu opens.
- Known limits: the catalog is per-harness, not per-repo (project-local skills from a different repo may appear), and a harness that has never streamed a session shows an empty menu until its first session runs.

## Testing

- Unit (Tier 1): new `slash-command-catalog-store.test.ts` (record/strip/persist, unchanged-skip, hydration merge + pre-hydration clobber guard, stale-read ignore); extended `stream-side-effect-plan.test.ts` for the new plan flag.
- Ran neighboring suites: `ComposerCommandEditor`, `ChatInputDraftArea`, `session-stream-side-effects`, `use-product-storage-persistence-lifecycle`, `HomeNextScreen` — all green. `pnpm typecheck` and `scripts/check_frontend_boundaries.py` pass.
- Manual: launch the desktop app, run any session once (populates the catalog), then from the home screen type `/` in the composer before creating the workspace — the skill menu appears; Enter/Tab inserts the command, Escape closes the menu without clearing the draft.

## Observability

- none (client-only state; no telemetry delta — the tray reuses the existing `data-telemetry-mask`ed inline-menu chrome).

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- Typecheck, targeted vitest suites, and the frontend-boundaries checker all pass locally; manual verification recipe above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)