### PR TITLE
fix(product): settle local-workspace creation receipts without the worktree fork icon (PRO-251)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/transcript/WorkspaceCreationReceipt.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/WorkspaceCreationReceipt.test.tsx
@@ -9,6 +9,7 @@ function presentation(
   overrides: Partial<WorkspaceCreationReceiptPresentation>,
 ): WorkspaceCreationReceiptPresentation {
   return {
+    noun: "worktree",
     line: "Creating worktree",
     busyLabel: null,
     showSpinner: false,
@@ -58,13 +59,37 @@ describe("WorkspaceCreationReceiptView", () => {
     ).toBeTruthy();
   });
 
-  it("shows the fork glyph and no spinner once work settles", () => {
+  it("shows the fork glyph and no spinner once a worktree receipt settles", () => {
     const { container } = renderReceipt({
+      noun: "worktree",
       line: "Worktree created",
       showSpinner: false,
     });
 
     expect(container.querySelector("[data-loading-spinner]")).toBeNull();
     expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  // The fork mark is a worktree-only signal (PRO-251). A plain local
+  // workspace receipt settles with no leading glyph rather than borrowing it.
+  it("settles a workspace receipt with no leading glyph", () => {
+    const { container } = renderReceipt({
+      noun: "workspace",
+      line: "Workspace created",
+      showSpinner: false,
+    });
+
+    expect(container.querySelector("[data-loading-spinner]")).toBeNull();
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("keeps the spinner while a workspace creation is in flight", () => {
+    const { container } = renderReceipt({
+      noun: "workspace",
+      line: "Creating workspace",
+      showSpinner: true,
+    });
+
+    expect(container.querySelectorAll("[data-loading-spinner]")).toHaveLength(1);
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/WorkspaceCreationReceipt.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/WorkspaceCreationReceipt.test.tsx
@@ -64,23 +64,33 @@ describe("WorkspaceCreationReceiptView", () => {
       noun: "worktree",
       line: "Worktree created",
       showSpinner: false,
+      logLines: [{ text: "Worktree created at /repo/worktrees/prism", tone: "default" }],
     });
 
     expect(container.querySelector("[data-loading-spinner]")).toBeNull();
-    expect(container.querySelector("svg")).not.toBeNull();
+    // Fork glyph plus the log-disclosure chevron.
+    expect(container.querySelectorAll("button svg")).toHaveLength(2);
   });
 
   // The fork mark is a worktree-only signal (PRO-251). A plain local
   // workspace receipt settles with no leading glyph rather than borrowing it.
+  // A real created-phase receipt always carries log lines, so the disclosure
+  // chevron must not stand in for the glyph the assertion is about.
   it("settles a workspace receipt with no leading glyph", () => {
     const { container } = renderReceipt({
       noun: "workspace",
       line: "Workspace created",
       showSpinner: false,
+      logLines: [{ text: "Workspace created at /repo/checkout", tone: "default" }],
     });
 
     expect(container.querySelector("[data-loading-spinner]")).toBeNull();
-    expect(container.querySelector("svg")).toBeNull();
+    // Only the log-disclosure chevron remains; the leading slot is an empty
+    // same-size placeholder so the label keeps its x when the spinner clears.
+    expect(container.querySelectorAll("button svg")).toHaveLength(1);
+    const button = container.querySelector("button");
+    expect(button!.firstElementChild!.tagName).toBe("SPAN");
+    expect(button!.firstElementChild!.classList.contains("icon-compact")).toBe(true);
   });
 
   it("keeps the spinner while a workspace creation is in flight", () => {

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/WorkspaceCreationReceipt.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/WorkspaceCreationReceipt.tsx
@@ -96,12 +96,15 @@ export function WorkspaceCreationReceiptView({
             every time the phase changes the text ("Creating worktree" →
             "Worktree created · Setup running"). Settled, the fork mark is a
             worktree-only signal (PRO-251): a plain workspace receipt shows
-            no glyph rather than borrowing the worktree one. */}
+            no glyph rather than borrowing the worktree one, with a same-size
+            placeholder so the label holds its x when the spinner clears. */}
         {presentation.showSpinner ? (
           <Spinner className="icon-compact shrink-0 text-muted-foreground" />
         ) : presentation.noun === "worktree" ? (
           <Fork aria-hidden="true" className="icon-compact shrink-0 text-faint" />
-        ) : null}
+        ) : (
+          <span aria-hidden="true" className="icon-compact shrink-0" />
+        )}
         <span className="min-w-0 truncate">{presentation.line}</span>
         {presentation.busyLabel && (
           <span className="shrink-0 text-faint">· {presentation.busyLabel}</span>

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/WorkspaceCreationReceipt.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/WorkspaceCreationReceipt.tsx
@@ -94,12 +94,14 @@ export function WorkspaceCreationReceiptView({
         {/* The spinner owns the leading icon slot while work is in flight.
             Trailing the label instead means the indicator jumps to a new x
             every time the phase changes the text ("Creating worktree" →
-            "Worktree created · Setup running"). */}
+            "Worktree created · Setup running"). Settled, the fork mark is a
+            worktree-only signal (PRO-251): a plain workspace receipt shows
+            no glyph rather than borrowing the worktree one. */}
         {presentation.showSpinner ? (
           <Spinner className="icon-compact shrink-0 text-muted-foreground" />
-        ) : (
+        ) : presentation.noun === "worktree" ? (
           <Fork aria-hidden="true" className="icon-compact shrink-0 text-faint" />
-        )}
+        ) : null}
         <span className="min-w-0 truncate">{presentation.line}</span>
         {presentation.busyLabel && (
           <span className="shrink-0 text-faint">· {presentation.busyLabel}</span>

--- a/apps/packages/product-client/src/lib/domain/workspaces/creation/creation-receipt.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/creation/creation-receipt.test.ts
@@ -51,6 +51,9 @@ describe("presentWorkspaceCreationReceipt", () => {
     });
 
     expect(presentation.line).toBe("Creating worktree");
+    // The noun rides the presentation so the view can key the settled
+    // leading glyph on it (fork = worktree-only, PRO-251).
+    expect(presentation.noun).toBe("worktree");
     expect(presentation.showSpinner).toBe(true);
     expect(presentation.busyLabel).toBeNull();
     expect(presentation.defaultExpanded).toBe(false);
@@ -110,6 +113,7 @@ describe("presentWorkspaceCreationReceipt", () => {
       errorMessage: null,
     });
 
+    expect(presentation.noun).toBe("workspace");
     expect(presentation.logLines).toEqual([
       { text: "Workspace creation failed.", tone: "destructive" },
     ]);

--- a/apps/packages/product-client/src/lib/domain/workspaces/creation/creation-receipt.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/creation/creation-receipt.ts
@@ -86,6 +86,12 @@ export interface WorkspaceCreationReceiptLogLine {
 }
 
 export interface WorkspaceCreationReceiptPresentation {
+  /**
+   * What was created. The view keys the settled leading glyph on this: the
+   * fork mark is a worktree-only signal (PRO-251), so plain workspace
+   * receipts settle with no icon.
+   */
+  noun: WorkspaceCreationReceiptNoun;
   /** The receipt sentence. Failure is carried by the words, never by color. */
   line: string;
   /** Trailing muted label while setup is in flight ("Setup running"). */
@@ -140,6 +146,7 @@ export function presentWorkspaceCreationReceipt(
       logLines.push({ text: `$ ${source.setupCommand}`, tone: "default" });
     }
     return {
+      noun: source.noun,
       line: labels.creating[source.noun],
       busyLabel: null,
       showSpinner: true,
@@ -165,6 +172,7 @@ export function presentWorkspaceCreationReceipt(
       tone: "destructive",
     });
     return {
+      noun: source.noun,
       line: labels.creationFailed[source.noun],
       busyLabel: null,
       showSpinner: false,
@@ -195,6 +203,7 @@ export function presentWorkspaceCreationReceipt(
 
   if (setup.status === "failed") {
     return {
+      noun,
       line: labels.createdSetupFailed[noun],
       busyLabel: null,
       showSpinner: false,
@@ -223,6 +232,7 @@ export function presentWorkspaceCreationReceipt(
         tone: "default",
       };
     return {
+      noun,
       line: createdLine,
       busyLabel: isQueued ? labels.setupQueuedStatus : labels.setupRunningStatus,
       showSpinner: true,
@@ -243,6 +253,7 @@ export function presentWorkspaceCreationReceipt(
   if (setup.status === "succeeded") {
     if (previousRunLine) {
       return {
+        noun,
         line: labels.createdSetupCompleted[noun],
         busyLabel: null,
         showSpinner: false,
@@ -264,6 +275,7 @@ export function presentWorkspaceCreationReceipt(
       };
     }
     return {
+      noun,
       line: createdLine,
       busyLabel: null,
       showSpinner: false,
@@ -286,6 +298,7 @@ export function presentWorkspaceCreationReceipt(
 
   // No setup run recorded — either no setup script, or status not yet known.
   return {
+    noun,
     line: createdLine,
     busyLabel: null,
     showSpinner: false,


### PR DESCRIPTION
## Summary

Fixes [PRO-251](https://linear.app/proliferate-team/issue/PRO-251/new-worktree-icon-shows-for-local-workspaces-too): the workspace-creation transcript receipt hardcoded the `Fork` glyph as its settled leading icon, so a "Work locally" creation rendered **"Workspace created"** beside the app's worktree mark. Since #1840 made Fork the sidebar's worktree identity glyph, the receipt read as claiming a local checkout was a worktree.

The copy layer already distinguished the noun ("Worktree created" vs "Workspace created", derived from `workspace.kind`); the icon just never saw it.

## Change

- `creation-receipt.ts`: expose `noun` on `WorkspaceCreationReceiptPresentation` (already present on every `WorkspaceCreationReceiptSource` variant).
- `WorkspaceCreationReceipt.tsx`: key the settled leading glyph on the noun — Fork for worktree receipts only; plain workspace receipts settle with no icon (per Pablo's ruling). The spinner still owns the slot while creation/setup is in flight.

## Not touched

The sidebar worktree identity glyph from #1840 is correct (it only renders for `kind === "worktree"` rows, verified against runtime kind-assignment invariants) and is unchanged.

## Testing

- `creation-receipt.test.ts`: asserts the noun is forwarded for both nouns.
- `WorkspaceCreationReceipt.test.tsx`: new cases — workspace receipt settles with no leading glyph; workspace creation in flight keeps the spinner; worktree receipt keeps the fork.
- Negative control: un-gating the icon makes exactly the new no-glyph assertion fail.
- `vitest` 19/19 passing; package `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)