### PR TITLE
fix(product): thread attachmentSnapshots through deferred cloud launch consumption

### DIFF
--- a/apps/packages/product-client/src/hooks/home/lifecycle/use-home-deferred-launch-runner.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/lifecycle/use-home-deferred-launch-runner.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
 import type { CreateSessionWithResolvedConfigOptions } from "#product/hooks/sessions/workflows/session-creation-types";
+import { createPromptAttachmentSnapshot } from "#product/domain/chats/composer/prompt-attachment-snapshot";
 import {
   buildPendingWorkspaceUiKey,
 } from "#product/lib/domain/workspaces/creation/pending-entry";
@@ -205,6 +206,38 @@ describe("useHomeDeferredLaunchRunner", () => {
     });
     expect(useDeferredHomeLaunchStore.getState().launches["cloud-2:attempt-2"]?.status)
       .toBe("pending");
+  });
+
+  it("forwards the queued attachment snapshots when the prompt replays", async () => {
+    // PRO-230 remainder (#1893) dropped `attachmentSnapshots` from this call,
+    // silently discarding any file attached while the cloud workspace was
+    // still provisioning. Every other launch path threads it through
+    // `promptAttachmentSendFields`; this asserts the deferred path does too.
+    mocks.workspaceCollections.cloudWorkspaces = [cloudWorkspace({ status: "ready" })];
+    const attachment = createPromptAttachmentSnapshot({
+      id: "attachment-1",
+      name: "notes.txt",
+      mimeType: "text/plain",
+      size: 42,
+      kind: "text_resource",
+      source: "upload",
+    }, { tag: "file" });
+    enqueueLaunch(deferredLaunch({ attachmentSnapshots: [attachment] }));
+
+    renderHook(() => useHomeDeferredLaunchRunner());
+
+    await waitFor(() => {
+      expect(mocks.createSessionWithResolvedConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: "run the migration",
+          attachmentSnapshots: [attachment],
+          optimisticContentParts: expect.arrayContaining([
+            expect.objectContaining({ type: "text", text: "run the migration" }),
+            expect.objectContaining({ type: "resource", name: "notes.txt" }),
+          ]),
+        }),
+      );
+    });
   });
 
   it("announces a background send failure with its workspace instead of the composer copy", async () => {

--- a/apps/packages/product-client/src/hooks/home/lifecycle/use-home-deferred-launch-runner.ts
+++ b/apps/packages/product-client/src/hooks/home/lifecycle/use-home-deferred-launch-runner.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";import { useWorkspaces } from "#product/hooks/workspaces/cache/use-workspaces";
+import type { CloudWorkspaceSummary } from "#product/lib/domain/workspaces/cloud/cloud-workspace-model";
+import { useWorkspaces } from "#product/hooks/workspaces/cache/use-workspaces";
+import { promptAttachmentSendFields } from "#product/domain/chats/composer/prompt-attachment-content-parts";
 import { useSessionCreationActions } from "#product/hooks/sessions/workflows/use-session-creation-actions";
 import {
   notifyQueuedPromptSendFailure,
@@ -211,6 +213,7 @@ export function useHomeDeferredLaunchRunner() {
         promptId: launch.promptId,
         launchIntentId: launch.launchIntentId,
         launchControlValues: launch.launchControlValues,
+        ...promptAttachmentSendFields(launch.promptText, launch.attachmentSnapshots),
         activateOnCreate: attended,
         targetWorkspaceUiKey: attended ? null : launch.workspaceId,
         ...(launch.modeId ? { modeId: launch.modeId } : {}),


### PR DESCRIPTION
## Summary

Found by the wf2 gen-2 code-review workflow (run review3) reviewing #1893; verified first-hand on origin/main.

PR #1893 (merge commit `4a399390fe70905b9c6fa2742bfb5b16b0c78dd6`, branch `pro-230-remainder`) introduced a merge-resolution regression in `use-home-deferred-launch-runner.ts`:

**User-facing failure:** when a user attaches a file to a prompt while the target cloud workspace is still provisioning, the prompt gets queued on the deferred-launch store (`deferred-home-launch-store.ts`, which explicitly documents `attachmentSnapshots` as "In-memory only (holds Files)"). The enqueue path (`launch-home-cloud-target.ts`) correctly carries `attachmentSnapshots` into that queue entry. But when the cloud workspace becomes ready and `consumeLaunch` replays the queued prompt, it called `createSessionWithResolvedConfig({ ...text: launch.promptText... })` without threading `launch.attachmentSnapshots` through — so the attached file is silently dropped and only the text ships. Every other launch path threads attachments through `promptAttachmentSendFields` (the non-deferred cloud path, and all four call sites in `use-home-next-launch-prompt-actions.ts`); this was the one path that didn't.

- Also splits a merge-collapsed two-statement import line (`...cloud-workspace-model";import { useWorkspaces }...`) in the same file into two lines.

## Fix

In `consumeLaunch`, spread `...promptAttachmentSendFields(launch.promptText, launch.attachmentSnapshots)` into the `createSessionWithResolvedConfig` call — mirroring the exact idiom used at every other call site in `use-home-next-launch-prompt-actions.ts`.

## Test plan

Added a regression test in `use-home-deferred-launch-runner.test.tsx`: `"forwards the queued attachment snapshots when the prompt replays"`, asserting the consume path forwards both `attachmentSnapshots` and the projected `optimisticContentParts` to `createSessionWithResolvedConfig`.

Negative control: reverted the fix locally and reran the new test — it timed out waiting for `attachmentSnapshots`/`optimisticContentParts` to appear in the call, confirming it catches the regression. Restored the fix; test passes again.

Literal check output (product-client, worktree on `fix/deferred-launch-attachment-drop`):

```
$ npx vitest run
 Test Files  920 passed (920)
      Tests  6568 passed (6568)

$ pnpm typecheck
EXIT CODE: 0
```

- [x] `npx vitest run src/hooks/home/lifecycle/use-home-deferred-launch-runner.test.tsx` — 9 passed (9)
- [x] `npx vitest run` (full product-client suite) — 920 files / 6568 tests passed
- [x] `pnpm typecheck` (product-client) — exit 0, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)