### PR TITLE
fix(design): stop bumping placeholders — paint a 1px caret in empty fields (PRO-249)

### DIFF
--- a/apps/packages/design/src/css/product.css
+++ b/apps/packages/design/src/css/product.css
@@ -111,17 +111,60 @@ body {
   line-height: var(--text-ui--line-height);
 }
 
-:is(input, textarea, [contenteditable]:not([contenteditable="false"]), [data-ui-thin-caret]) {
-  caret-color: var(--color-text-caret);
+/* Layered per the shared-reset rule in specs/frontend/styling.md: unlayered
+   CSS beats every layer, which would both strip caret utilities off matching
+   elements and defeat the empty-field caret suppression below — that rule must
+   win this one by specificity inside the same layer. */
+@layer base {
+  :is(input, textarea, [contenteditable]:not([contenteditable="false"]), [data-ui-thin-caret]) {
+    caret-color: var(--color-text-caret);
+  }
 }
 
-/* Current macOS WebKit paints native insertion carets at two CSS pixels, while
-   native placeholders otherwise begin at that same origin. Offset only the
-   focused placeholder: entered text and its caret keep their established
-   alignment. The base layer lets a specialized control override this contract. */
+/* Current macOS WebKit paints native insertion carets at two CSS pixels, at the
+   same origin where a native placeholder's first glyph begins. Rather than
+   nudging the focused placeholder aside (which visibly bumped it on every
+   focus/blur while it stayed on screen), suppress the native caret only while
+   the placeholder is shown — an empty field's caret provably sits at the
+   content-box origin — and paint the same one-pixel replacement caret the chat
+   composer uses, as a background bar at that origin. Typing any character
+   dismisses the placeholder, which atomically restores the native caret in the
+   same style rule (IME composition included). Entered text, its caret, and the
+   resting placeholder never move. The base layer lets a specialized control
+   override this contract. */
 @layer base {
-  :is(input, textarea):focus::placeholder {
-    text-indent: 2px;
+  /* activity-motion */
+  :is(input, textarea):focus:placeholder-shown {
+    animation: ui-empty-field-caret-blink 1s steps(1, end) infinite;
+    background-image: linear-gradient(var(--color-text-caret), var(--color-text-caret));
+    background-origin: content-box;
+    background-repeat: no-repeat;
+    background-size: 1px min(1lh, 1.25em);
+    caret-color: transparent;
+  }
+  /* Single-line inputs center their one line box in the content box; textareas
+     stack lines from the content-box top. Align the bar with where the first
+     glyph actually renders in each. */
+  input:focus:placeholder-shown {
+    background-position: 0 50%;
+  }
+  textarea:focus:placeholder-shown {
+    background-position: 0 calc((1lh - min(1lh, 1.25em)) / 2);
+  }
+}
+
+@keyframes ui-empty-field-caret-blink {
+  0%, 54% {
+    background-image: linear-gradient(var(--color-text-caret), var(--color-text-caret));
+  }
+  55%, 100% {
+    background-image: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :is(input, textarea):focus:placeholder-shown {
+    animation: none;
   }
 }
 

--- a/apps/packages/design/src/css/product.css
+++ b/apps/packages/design/src/css/product.css
@@ -125,13 +125,16 @@ body {
    same origin where a native placeholder's first glyph begins. Rather than
    nudging the focused placeholder aside (which visibly bumped it on every
    focus/blur while it stayed on screen), suppress the native caret only while
-   the placeholder is shown — an empty field's caret provably sits at the
+   the placeholder is shown — an empty start-aligned field's caret sits at the
    content-box origin — and paint the same one-pixel replacement caret the chat
    composer uses, as a background bar at that origin. Typing any character
    dismisses the placeholder, which atomically restores the native caret in the
    same style rule (IME composition included). Entered text, its caret, and the
    resting placeholder never move. The base layer lets a specialized control
-   override this contract. */
+   override this contract, but an override must replace it whole: overriding
+   only the background leaves an invisible caret; overriding only caret-color
+   doubles it. A centered or right-to-left field must opt out the same way —
+   the bar is pinned to the left content edge. */
 @layer base {
   /* activity-motion */
   :is(input, textarea):focus:placeholder-shown {
@@ -139,7 +142,7 @@ body {
     background-image: linear-gradient(var(--color-text-caret), var(--color-text-caret));
     background-origin: content-box;
     background-repeat: no-repeat;
-    background-size: 1px min(1lh, 1.25em);
+    background-size: 1px 1.25em;
     caret-color: transparent;
   }
   /* Single-line inputs center their one line box in the content box; textareas
@@ -149,7 +152,20 @@ body {
     background-position: 0 50%;
   }
   textarea:focus:placeholder-shown {
-    background-position: 0 calc((1lh - min(1lh, 1.25em)) / 2);
+    background-position: 0 0;
+  }
+  /* Refine with line-box units where the engine has them. This stays a
+     separate progressive layer because an engine that lacks `lh` drops the
+     declaration, and background-size would fall back to `auto` — a gradient
+     with no intrinsic size then floods the whole content box. The base
+     declarations above must therefore stand alone without `lh`. */
+  @supports (height: 1lh) {
+    :is(input, textarea):focus:placeholder-shown {
+      background-size: 1px min(1lh, 1.25em);
+    }
+    textarea:focus:placeholder-shown {
+      background-position: 0 calc((1lh - min(1lh, 1.25em)) / 2);
+    }
   }
 }
 

--- a/apps/packages/product-client/src/primitives/__tests__/PopoverSearchField.test.ts
+++ b/apps/packages/product-client/src/primitives/__tests__/PopoverSearchField.test.ts
@@ -65,8 +65,8 @@ describe("empty-field replacement caret", () => {
       ];
 
       for (const field of fields) {
-        // Ensure the field is blurred first: PopoverSearchField auto-focuses on
-        // mount, so the "Search models" input would otherwise still be focused.
+        // Park focus on the button so each field starts provably blurred,
+        // regardless of where the previous loop iteration left it.
         await page.getByRole("button", { name: "Done" }).focus();
 
         // Blurred + empty: native caret intact, no replacement bar, no indent.

--- a/apps/packages/product-client/src/primitives/__tests__/PopoverSearchField.test.ts
+++ b/apps/packages/product-client/src/primitives/__tests__/PopoverSearchField.test.ts
@@ -41,10 +41,22 @@ afterAll(async () => {
   await viteServer?.close();
 }, 60_000);
 
-describe("native placeholder caret spacing", () => {
-  it("keeps focused input and textarea placeholders clear without shifting entered text", async () => {
+// INTENTIONAL CONTRACT CHANGE (PRO-249): this replaces the #1799 pin that
+// asserted the FOCUSED placeholder carried a 2px text-indent. That fix moved
+// the placeholder 2px on every focus/blur of an empty native field. The new
+// contract never moves the placeholder: while a native field is empty and
+// focused, the native caret is suppressed (`caret-color: transparent`) and a
+// 1px replacement caret is painted as a background bar at the content-box
+// origin — the same 1px-caret philosophy the Lexical chat composer uses. Typing
+// dismisses `:placeholder-shown` and atomically restores the native caret.
+describe("empty-field replacement caret", () => {
+  it("suppresses the native caret and paints a 1px bar without moving the placeholder", async () => {
+    // Reduced motion disables the blink animation, so the base rule's static
+    // background-image applies deterministically — never assert a mid-blink
+    // computed background-image without this.
     const page = await browser.newPage({ viewport: { width: 360, height: 160 } });
     try {
+      await page.emulateMedia({ reducedMotion: "reduce" });
       await page.goto(fixtureUrl, { waitUntil: "networkidle" });
       const fields = [
         page.getByPlaceholder("Search models"),
@@ -53,28 +65,80 @@ describe("native placeholder caret spacing", () => {
       ];
 
       for (const field of fields) {
-        await field.focus();
-        const focusedIndent = await field.evaluate((element) => ({
-          input: getComputedStyle(element).textIndent,
-          placeholder: getComputedStyle(element, "::placeholder").textIndent,
+        // Ensure the field is blurred first: PopoverSearchField auto-focuses on
+        // mount, so the "Search models" input would otherwise still be focused.
+        await page.getByRole("button", { name: "Done" }).focus();
+
+        // Blurred + empty: native caret intact, no replacement bar, no indent.
+        const blurred = await field.evaluate((element) => ({
+          caretColor: getComputedStyle(element).caretColor,
+          backgroundImage: getComputedStyle(element).backgroundImage,
+          placeholderIndent: getComputedStyle(element, "::placeholder").textIndent,
         }));
-        expect(focusedIndent).toEqual({
-          input: "0px",
-          placeholder: "2px",
-        });
+        expect(blurred.caretColor).not.toBe("rgba(0, 0, 0, 0)");
+        expect(blurred.backgroundImage).toBe("none");
+        expect(blurred.placeholderIndent).toBe("0px");
 
+        // Focused + empty: native caret suppressed, 1px bar painted at the
+        // content-box origin, and — the PRO-249 regression pin — the
+        // placeholder does NOT move (its own and its ::placeholder text-indent
+        // both stay 0px).
+        await field.focus();
+        const focused = await field.evaluate((element) => ({
+          caretColor: getComputedStyle(element).caretColor,
+          backgroundImage: getComputedStyle(element).backgroundImage,
+          backgroundSize: getComputedStyle(element).backgroundSize,
+          backgroundOrigin: getComputedStyle(element).backgroundOrigin,
+          elementIndent: getComputedStyle(element).textIndent,
+          placeholderIndent: getComputedStyle(element, "::placeholder").textIndent,
+        }));
+        expect(focused.caretColor).toBe("rgba(0, 0, 0, 0)");
+        expect(focused.backgroundImage).toContain("linear-gradient");
+        expect(focused.backgroundSize.startsWith("1px")).toBe(true);
+        expect(focused.backgroundOrigin).toBe("content-box");
+        expect(focused.elementIndent).toBe("0px");
+        expect(focused.placeholderIndent).toBe("0px");
+
+        // Typing dismisses the placeholder, which restores the native caret and
+        // drops the replacement bar in the same style rule.
         await field.fill("entered text");
-        expect(
-          await field.evaluate((element) => getComputedStyle(element).textIndent),
-        ).toBe("0px");
+        const typed = await field.evaluate((element) => ({
+          caretColor: getComputedStyle(element).caretColor,
+          backgroundImage: getComputedStyle(element).backgroundImage,
+        }));
+        expect(typed.backgroundImage).toBe("none");
+        expect(typed.caretColor).not.toBe("rgba(0, 0, 0, 0)");
 
+        // Cleared + blurred (focus moves to the Done button): bar gone, native
+        // caret restored.
         await field.fill("");
         await page.getByRole("button", { name: "Done" }).focus();
+        const cleared = await field.evaluate((element) => ({
+          caretColor: getComputedStyle(element).caretColor,
+          backgroundImage: getComputedStyle(element).backgroundImage,
+        }));
+        expect(cleared.backgroundImage).toBe("none");
+        expect(cleared.caretColor).not.toBe("rgba(0, 0, 0, 0)");
+      }
+    } finally {
+      await page.close();
+    }
+  }, 60_000);
+
+  it("blinks the replacement caret when motion is allowed", async () => {
+    const page = await browser.newPage({ viewport: { width: 360, height: 160 } });
+    try {
+      await page.emulateMedia({ reducedMotion: "no-preference" });
+      await page.goto(fixtureUrl, { waitUntil: "networkidle" });
+      for (const field of [
+        page.getByPlaceholder("Search models"),
+        page.getByPlaceholder("Search files"),
+        page.getByPlaceholder("Add objective"),
+      ]) {
+        await field.focus();
         expect(
-          await field.evaluate(
-            (element) => getComputedStyle(element, "::placeholder").textIndent,
-          ),
-        ).toBe("0px");
+          await field.evaluate((element) => getComputedStyle(element).animationName),
+        ).toBe("ui-empty-field-caret-blink");
       }
     } finally {
       await page.close();


### PR DESCRIPTION
## Summary

- Fixes [PRO-249](https://linear.app/proliferate-team/issue/PRO-249/caret-bumps-placeholder-text-in-an-odd-way): the `2px` focused-placeholder `text-indent` from #1799 visibly bumped every native placeholder right on focus and back on blur (model popover search, agents-pane composer, command palette, all `PopoverSearchField` consumers).
- Replaces it with the chat composer's replacement-caret philosophy applied to native fields: while a field is focused **and** `:placeholder-shown`, suppress the native two-pixel WebKit caret (`caret-color: transparent`) and paint a one-pixel bar via `background-image` at the content-box origin (`background-origin: content-box`), blinking on the composer's cadence (`steps(1, end)`, infinite, `/* activity-motion */`-marked), static under `prefers-reduced-motion`. An empty field's caret provably sits at the text origin, so no measurement is needed; typing dismisses the placeholder, which atomically restores the native caret from the same rule (IME included). The placeholder never moves.
- Wraps the shared `caret-color` reset in `@layer base` per `specs/frontend/styling.md` (it was unlayered, which beat the suppression rule from inside the layer and silently strips caret utilities). The neighboring `::selection` reset has the same latent unlayered issue — left untouched as a follow-up.

## Pinning-test change (flagged for founder review)

`PopoverSearchField.test.ts` pinned the #1799 contract (`text-indent: 2px` on focus). That is exactly the behavior PRO-249 removes, so the pin is rewritten — not weakened — to the new contract: caret suppressed + 1px bar painted + **placeholder text-indent stays 0px on focus** (the PRO-249 regression pin), native caret restored on typing and blur, and blink animation present when motion is allowed. Assertions are deterministic via `reducedMotion` emulation.

## Trade-off

While a field is empty the caret is the painted 1px bar; the first typed character brings back the native 2px caret. The width change is masked by typing motion and matches the composer's 1px caret at rest.

## Testing

Tier 1, colocated:

- `pnpm --filter @proliferate/design build` — `check-theme: ok (308 live tokens)`
- `pnpm --filter @proliferate/product-client exec vitest run src/primitives/__tests__/PopoverSearchField.test.ts` — 2 passed
- Negative control: reverting the CSS makes both tests fail (`expected 'rgb(255, 255, 255)' to be 'rgba(0, 0, 0, 0)'`, `expected 'none' to be 'ui-empty-field-caret-blink'`); restoring goes green
- `python3 scripts/check_appearance_scaling.py`, `python3 scripts/check_design_attribution.py` — pass
- `pnpm --filter @proliferate/product-client typecheck` — exit 0
- `vitest run src/lib/domain/preferences/appearance-css-drift.test.ts` — 34 passed
- Visual proof in real Chrome (reduced motion): 1px bar at text origin, vertically centered in single-line inputs, first-line-aligned in textareas, placeholder unmoved

## Observability

None — shared presentation and regression coverage only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)