### PR TITLE
feat(product): step composer chips backward with cmd click (PRO-256)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerEffortStepper.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerEffortStepper.test.tsx
@@ -74,6 +74,22 @@ describe("ComposerEffortStepper", () => {
     expect(control.onSelect).toHaveBeenCalledWith("low");
   });
 
+  it("steps backward on a modifier click", () => {
+    const control = createEffortControl("medium");
+    renderStepper(control);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reasoning: Medium" }), { metaKey: true });
+    expect(control.onSelect).toHaveBeenCalledWith("low");
+  });
+
+  it("wraps backward from the bottom level to the top on a modifier click", () => {
+    const control = createEffortControl("low");
+    renderStepper(control);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reasoning: Low" }), { ctrlKey: true });
+    expect(control.onSelect).toHaveBeenCalledWith("high");
+  });
+
   it("steps the same transition through the cycle-reasoning-effort shortcut", () => {
     const control = createEffortControl("medium");
     renderStepper(control);
@@ -81,6 +97,15 @@ describe("ComposerEffortStepper", () => {
     expect(runShortcutHandler("workspace.cycle-reasoning-effort", { source: "keyboard" }))
       .toBe(true);
     expect(control.onSelect).toHaveBeenCalledWith("high");
+  });
+
+  it("steps backward through the cycle-reasoning-effort-back shortcut", () => {
+    const control = createEffortControl("medium");
+    renderStepper(control);
+
+    expect(runShortcutHandler("workspace.cycle-reasoning-effort-back", { source: "keyboard" }))
+      .toBe(true);
+    expect(control.onSelect).toHaveBeenCalledWith("low");
   });
 
   it("does not register the shortcut away from the main screen", () => {

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerEffortStepper.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerEffortStepper.test.tsx
@@ -114,7 +114,17 @@ describe("ComposerEffortStepper", () => {
 
     expect(runShortcutHandler("workspace.cycle-reasoning-effort", { source: "keyboard" }))
       .toBe(false);
+    expect(runShortcutHandler("workspace.cycle-reasoning-effort-back", { source: "keyboard" }))
+      .toBe(false);
     expect(control.onSelect).not.toHaveBeenCalled();
+  });
+
+  it("carries the step hint in the tooltip copy", () => {
+    renderStepper(createEffortControl("medium"));
+
+    const trigger = screen.getByRole("button", { name: "Reasoning: Medium" });
+    // jsdom's default navigator is non-Apple, so the hint reads "Ctrl click".
+    expect(trigger.getAttribute("title")).toContain("Click to step, Ctrl click to step back.");
   });
 
   it("does not register the shortcut when the level is not settable", () => {

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerEffortStepper.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerEffortStepper.tsx
@@ -1,7 +1,13 @@
 import { useLocation } from "react-router-dom";
 import { APP_ROUTES } from "#product/config/app-routes";
-import { resolveReasoningEffortPresentation } from "#product/lib/domain/chat/session-controls/session-reasoning-effort-control";
-import { resolveSessionControlTooltip } from "#product/lib/domain/chat/session-controls/session-toggle-control";
+import {
+  getSteppedReasoningEffortValue,
+  resolveReasoningEffortPresentation,
+} from "#product/lib/domain/chat/session-controls/session-reasoning-effort-control";
+import {
+  appendSessionControlStepHint,
+  resolveSessionControlTooltip,
+} from "#product/lib/domain/chat/session-controls/session-toggle-control";
 import { COMPOSER_COMPACT_HIDDEN_CLASSNAME } from "#product/config/chat-layout";
 import type { LiveSessionControlDescriptor } from "#product/lib/domain/chat/session-controls/session-controls";
 import { Tooltip } from "#product/primitives/Tooltip";
@@ -43,31 +49,38 @@ export function ComposerEffortStepper({ control }: ComposerEffortStepperProps) {
   const currentLevel =
     currentPresentation.shortLabel ?? control.detail ?? control.label;
   const ariaLabel = `Reasoning: ${currentLevel}`;
-  const tooltip = resolveSessionControlTooltip(
-    "Reasoning",
-    currentLevel,
-    currentOption?.description ?? null,
-  ) + ". Click to step.";
+  const tooltip = appendSessionControlStepHint(
+    resolveSessionControlTooltip(
+      "Reasoning",
+      currentLevel,
+      currentOption?.description ?? null,
+    ),
+    "step",
+  );
 
   // A one-rung ladder has nowhere to step: stepping it would re-select the
   // level that is already selected. Same guard shape as ComposerModeBadge's
   // `nextValue` — the control renders, reads, and is disabled.
   const canStep = control.options.length >= 2;
 
-  const handleStep = () => {
-    const nextIndex = (effectiveIndex + 1) % control.options.length;
-    const nextValue = control.options[nextIndex]?.value;
-    if (nextValue !== undefined) {
-      control.onSelect(nextValue);
+  const handleStep = (direction: 1 | -1) => {
+    const steppedValue = getSteppedReasoningEffortValue(control.options, direction);
+    if (steppedValue !== null) {
+      control.onSelect(steppedValue);
     }
   };
 
   // ⌃⇧E steps the same transition as clicking the ladder, dispatched through
   // the global shortcut registry so it works wherever focus sits — the same
-  // main-screen gate as the model selector's ⌃⇧M.
+  // main-screen gate as the model selector's ⌃⇧M. ⌃⌥⇧E mirrors it backward.
   const location = useLocation();
-  useShortcutHandler("workspace.cycle-reasoning-effort", handleStep, {
-    enabled: location.pathname === APP_ROUTES.home && control.settable && canStep,
+  const shortcutEnabled = location.pathname === APP_ROUTES.home && control.settable && canStep;
+  useShortcutHandler("workspace.cycle-reasoning-effort", () => handleStep(1), {
+    enabled: shortcutEnabled,
+    priority: "contextual",
+  });
+  useShortcutHandler("workspace.cycle-reasoning-effort-back", () => handleStep(-1), {
+    enabled: shortcutEnabled,
     priority: "contextual",
   });
 
@@ -90,7 +103,9 @@ export function ComposerEffortStepper({ control }: ComposerEffortStepperProps) {
         aria-label={ariaLabel}
         data-reasoning-effort-trigger=""
         data-reasoning-effort-selected={currentOption?.value ?? ""}
-        onClick={canStep ? handleStep : undefined}
+        onClick={canStep
+          ? (event) => handleStep(event.metaKey || event.ctrlKey ? -1 : 1)
+          : undefined}
       />
     </Tooltip>
   );

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerEffortStepper.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerEffortStepper.tsx
@@ -34,9 +34,10 @@ const LADDER_LIT_STAGGER_MS = 30;
 
 /**
  * The composer's reasoning-effort control: a six-bar ladder that steps to the
- * next level on click and wraps at the top. No popover and no menu — the glyph
- * is both the readout and the affordance. Replaces ComposerReasoningEffortBars
- * in the composer row.
+ * next level on click and wraps at the top; ⌘/Ctrl click steps back and wraps
+ * at the bottom (⌃⇧E / ⌃⌥⇧E mirror both from the keyboard). No popover and no
+ * menu — the glyph is both the readout and the affordance. Replaces
+ * ComposerReasoningEffortBars in the composer row.
  */
 export function ComposerEffortStepper({ control }: ComposerEffortStepperProps) {
   const currentIndex = control.options.findIndex((option) => option.selected);

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModeBadge.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModeBadge.test.tsx
@@ -34,10 +34,9 @@ describe("ComposerModeBadge", () => {
     render(<ComposerModeBadge agentKind="claude" control={createModeControl("plan")} />);
 
     const badge = screen.getByRole("button", {
-      // jsdom's default navigator is non-Apple, so the appended hint reads
-      // "Ctrl click", not "⌘ click". The description's own trailing period is
-      // absorbed by appendSessionControlStepHint rather than doubling.
-      name: "Permissions: Plan — Plan without execution. Click to switch, Ctrl click to go back.",
+      // The hint lives only in the tooltip/title, never the accessible name —
+      // composer-row tests (and screen readers) address the badge by mode.
+      name: "Permissions: Plan — Plan without execution.",
     });
     expect(badge.querySelector("svg")).not.toBeNull();
     // Icon-only at every width: the badge paints no word at all, and the mode

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModeBadge.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModeBadge.test.tsx
@@ -34,7 +34,10 @@ describe("ComposerModeBadge", () => {
     render(<ComposerModeBadge agentKind="claude" control={createModeControl("plan")} />);
 
     const badge = screen.getByRole("button", {
-      name: "Permissions: Plan — Plan without execution.",
+      // jsdom's default navigator is non-Apple, so the appended hint reads
+      // "Ctrl click", not "⌘ click". The description's own trailing period is
+      // absorbed by appendSessionControlStepHint rather than doubling.
+      name: "Permissions: Plan — Plan without execution. Click to switch, Ctrl click to go back.",
     });
     expect(badge.querySelector("svg")).not.toBeNull();
     // Icon-only at every width: the badge paints no word at all, and the mode
@@ -45,6 +48,13 @@ describe("ComposerModeBadge", () => {
     expect(screen.queryByText("Plan")).toBeNull();
   });
 
+  it("includes the switch hint in the tooltip copy", () => {
+    render(<ComposerModeBadge agentKind="claude" control={createModeControl("plan")} />);
+
+    const badge = screen.getByRole("button", { name: /Permissions: Plan/ });
+    expect(badge.getAttribute("title")).toContain("Click to switch, Ctrl click to go back.");
+  });
+
   it("advances to the next mode on click and wraps at the end", () => {
     const control = createModeControl("bypassPermissions");
     render(<ComposerModeBadge agentKind="claude" control={control} />);
@@ -53,6 +63,35 @@ describe("ComposerModeBadge", () => {
     expect(badge.getAttribute("data-session-mode-next")).toBe("plan");
     fireEvent.click(badge);
     expect(control.onSelect).toHaveBeenCalledWith("plan");
+  });
+
+  it("selects the previous mode on a modifier click", () => {
+    const control = createModeControl("default");
+    render(<ComposerModeBadge agentKind="claude" control={control} />);
+
+    const badge = screen.getByRole("button", { name: /Permissions: Default/ });
+    expect(badge.getAttribute("data-session-mode-previous")).toBe("plan");
+    fireEvent.click(badge, { metaKey: true });
+    expect(control.onSelect).toHaveBeenCalledWith("plan");
+  });
+
+  it("wraps backward from the first mode to the last on a modifier click", () => {
+    const control = createModeControl("plan");
+    render(<ComposerModeBadge agentKind="claude" control={control} />);
+
+    const badge = screen.getByRole("button", { name: /Permissions: Plan/ });
+    expect(badge.getAttribute("data-session-mode-previous")).toBe("bypassPermissions");
+    fireEvent.click(badge, { ctrlKey: true });
+    expect(control.onSelect).toHaveBeenCalledWith("bypassPermissions");
+  });
+
+  it("still selects next on a plain click even though previous is stamped", () => {
+    const control = createModeControl("default");
+    render(<ComposerModeBadge agentKind="claude" control={control} />);
+
+    const badge = screen.getByRole("button", { name: /Permissions: Default/ });
+    fireEvent.click(badge);
+    expect(control.onSelect).toHaveBeenCalledWith("bypassPermissions");
   });
 
   it("keys the glyph on the mode value so each step replays the drop-in", () => {

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModeBadge.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModeBadge.tsx
@@ -61,14 +61,15 @@ export function ComposerModeBadge({
   // already spells the permissions control "Permissions" and the
   // collaboration control "Mode", so the descriptor's own word is the ruled
   // copy for the one and stays honest for the other.
-  const tooltip = appendSessionControlStepHint(
-    resolveSessionControlTooltip(
-      control.label,
-      shortLabel,
-      currentOption?.description ?? null,
-    ),
-    "switch",
+  // The accessible name carries the mode itself; the pointer hint is a mouse
+  // affordance, so it rides only the tooltip and title — same split as
+  // ComposerEffortStepper's aria-label.
+  const accessibleName = resolveSessionControlTooltip(
+    control.label,
+    shortLabel,
+    currentOption?.description ?? null,
   );
+  const tooltip = appendSessionControlStepHint(accessibleName, "switch");
 
   const badge = (
     <ComposerControlButton
@@ -86,7 +87,7 @@ export function ComposerModeBadge({
         </span>
       )}
       label={shortLabel}
-      aria-label={tooltip}
+      aria-label={accessibleName}
       title={tooltip}
       data-session-mode-trigger=""
       data-session-mode-selected={currentValue ?? ""}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModeBadge.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModeBadge.tsx
@@ -1,8 +1,12 @@
 import {
   getNextSessionModeValue,
+  getPreviousSessionModeValue,
   resolveSessionControlPresentation,
 } from "#product/lib/domain/chat/session-controls/session-mode-control";
-import { resolveSessionControlTooltip } from "#product/lib/domain/chat/session-controls/session-toggle-control";
+import {
+  appendSessionControlStepHint,
+  resolveSessionControlTooltip,
+} from "#product/lib/domain/chat/session-controls/session-toggle-control";
 import type { LiveSessionControlDescriptor } from "#product/lib/domain/chat/session-controls/session-controls";
 import type { ConfiguredSessionControlKey } from "#product/lib/domain/chat/session-controls/presentation";
 import { SessionControlIcon } from "#product/components/workspace/chat/session-controls/SessionControlIcon";
@@ -52,14 +56,18 @@ export function ComposerModeBadge({
     ?? control.detail
     ?? control.label;
   const nextValue = getNextSessionModeValue(control.options, currentValue);
+  const previousValue = getPreviousSessionModeValue(control.options, currentValue);
   // `control.label`, not a literal "Permissions": SESSION_CONTROL_LABELS
   // already spells the permissions control "Permissions" and the
   // collaboration control "Mode", so the descriptor's own word is the ruled
   // copy for the one and stays honest for the other.
-  const tooltip = resolveSessionControlTooltip(
-    control.label,
-    shortLabel,
-    currentOption?.description ?? null,
+  const tooltip = appendSessionControlStepHint(
+    resolveSessionControlTooltip(
+      control.label,
+      shortLabel,
+      currentOption?.description ?? null,
+    ),
+    "switch",
   );
 
   const badge = (
@@ -83,7 +91,16 @@ export function ComposerModeBadge({
       data-session-mode-trigger=""
       data-session-mode-selected={currentValue ?? ""}
       data-session-mode-next={nextValue ?? ""}
-      onClick={nextValue ? () => control.onSelect(nextValue) : undefined}
+      data-session-mode-previous={previousValue ?? ""}
+      onClick={nextValue
+        ? (event) => {
+          if ((event.metaKey || event.ctrlKey) && previousValue) {
+            control.onSelect(previousValue);
+            return;
+          }
+          control.onSelect(nextValue);
+        }
+        : undefined}
     />
   );
 

--- a/apps/packages/product-client/src/config/shortcuts/groups.ts
+++ b/apps/packages/product-client/src/config/shortcuts/groups.ts
@@ -67,6 +67,7 @@ export const SHORTCUT_GROUPS = [
       "focusChat",
       "openModelSelector",
       "cycleReasoningEffort",
+      "cycleReasoningEffortBack",
       "openTerminal",
       "toggleLeftSidebar",
       "toggleRightPanel",

--- a/apps/packages/product-client/src/config/shortcuts/workspace-shortcuts.ts
+++ b/apps/packages/product-client/src/config/shortcuts/workspace-shortcuts.ts
@@ -265,6 +265,16 @@ export const WORKSPACE_SHORTCUTS = {
     nonMacMatch: { kind: "fixed-code", code: "KeyE", meta: true, shift: true, alt: false },
     allowInInputs: true,
   },
+  cycleReasoningEffortBack: {
+    id: "workspace.cycle-reasoning-effort-back",
+    label: "⌃⌥⇧E",
+    nonMacLabel: "Ctrl+Alt+Shift+E",
+    description: "Cycle reasoning effort back",
+    owner: "js",
+    match: { kind: "fixed-code", code: "KeyE", meta: false, ctrl: true, shift: true, alt: true },
+    nonMacMatch: { kind: "fixed-code", code: "KeyE", meta: true, shift: true, alt: true },
+    allowInInputs: true,
+  },
   openTerminal: {
     id: "workspace.open-terminal",
     label: "⌘J",

--- a/apps/packages/product-client/src/config/shortcuts/workspace-shortcuts.ts
+++ b/apps/packages/product-client/src/config/shortcuts/workspace-shortcuts.ts
@@ -249,7 +249,7 @@ export const WORKSPACE_SHORTCUTS = {
     id: "workspace.open-model-selector",
     label: "⌃⇧M",
     nonMacLabel: "Ctrl+Shift+M",
-    description: "Open model and reasoning options",
+    description: "Open model options",
     owner: "js",
     match: { kind: "fixed-code", code: "KeyM", meta: false, ctrl: true, shift: true, alt: false },
     nonMacMatch: { kind: "fixed-code", code: "KeyM", meta: true, shift: true, alt: false },

--- a/apps/packages/product-client/src/lib/domain/chat/session-controls/session-reasoning-effort-control.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/session-controls/session-reasoning-effort-control.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveReasoningEffortPresentation } from "./session-reasoning-effort-control";
+import {
+  getSteppedReasoningEffortValue,
+  resolveReasoningEffortPresentation,
+} from "./session-reasoning-effort-control";
 
 describe("resolveReasoningEffortPresentation", () => {
   it("preserves authored catalog labels over internal spellings", () => {
@@ -18,5 +21,59 @@ describe("resolveReasoningEffortPresentation", () => {
     expect(resolveReasoningEffortPresentation("max", "")).toEqual({
       shortLabel: "X High",
     });
+  });
+});
+
+describe("getSteppedReasoningEffortValue", () => {
+  const options = [
+    { value: "low", selected: false },
+    { value: "medium", selected: true },
+    { value: "high", selected: false },
+  ];
+
+  it("steps forward to the next option", () => {
+    expect(getSteppedReasoningEffortValue(options, 1)).toBe("high");
+  });
+
+  it("steps backward to the previous option", () => {
+    expect(getSteppedReasoningEffortValue(options, -1)).toBe("low");
+  });
+
+  it("wraps forward from the top option back to the bottom", () => {
+    const atTop = [
+      { value: "low", selected: false },
+      { value: "medium", selected: false },
+      { value: "high", selected: true },
+    ];
+    expect(getSteppedReasoningEffortValue(atTop, 1)).toBe("low");
+  });
+
+  it("wraps backward from the bottom option to the top", () => {
+    const atBottom = [
+      { value: "low", selected: true },
+      { value: "medium", selected: false },
+      { value: "high", selected: false },
+    ];
+    expect(getSteppedReasoningEffortValue(atBottom, -1)).toBe("high");
+  });
+
+  it("treats index 0 as current when nothing is selected", () => {
+    const noneSelected = [
+      { value: "low", selected: false },
+      { value: "medium", selected: false },
+      { value: "high", selected: false },
+    ];
+    expect(getSteppedReasoningEffortValue(noneSelected, 1)).toBe("medium");
+    expect(getSteppedReasoningEffortValue(noneSelected, -1)).toBe("high");
+  });
+
+  it("returns null for a single-option ladder", () => {
+    expect(getSteppedReasoningEffortValue([{ value: "medium", selected: true }], 1)).toBeNull();
+    expect(getSteppedReasoningEffortValue([{ value: "medium", selected: true }], -1)).toBeNull();
+  });
+
+  it("returns null for an empty ladder", () => {
+    expect(getSteppedReasoningEffortValue([], 1)).toBeNull();
+    expect(getSteppedReasoningEffortValue([], -1)).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/lib/domain/chat/session-controls/session-reasoning-effort-control.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/session-controls/session-reasoning-effort-control.ts
@@ -20,6 +20,20 @@ function normalizeReasoningEffortValue(value: string | null): string | null {
   return normalizedValue === "max" ? "xhigh" : normalizedValue;
 }
 
+export function getSteppedReasoningEffortValue(
+  options: ReadonlyArray<{ value: string; selected: boolean }>,
+  direction: 1 | -1,
+): string | null {
+  if (options.length < 2) {
+    return null;
+  }
+
+  const currentIndex = options.findIndex((option) => option.selected);
+  const effectiveIndex = currentIndex >= 0 ? currentIndex : 0;
+  const steppedIndex = (effectiveIndex + direction + options.length) % options.length;
+  return options[steppedIndex]?.value ?? null;
+}
+
 function resolveShortLabel(value: string | null, label?: string | null): string | null {
   // Authored catalog labels ("Extra High", "Max", "Ultra") win — never rewrite
   // them to internal spellings (chat-composer.md §1.1). Values only fall back

--- a/apps/packages/product-client/src/lib/domain/chat/session-controls/session-toggle-control.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/session-controls/session-toggle-control.ts
@@ -1,3 +1,5 @@
+import { isApplePlatform } from "#product/lib/domain/shortcuts/matching";
+
 export type SessionToggleControlKey = "reasoning" | "fast_mode";
 
 export type SessionToggleControlIconKey =
@@ -42,4 +44,18 @@ export function resolveSessionControlTooltip(
 ): string {
   const title = detail ? `${label}: ${detail}` : label;
   return description ? `${title} — ${description}` : title;
+}
+
+// The ruled modifier spelling is "⌘ click" ("Ctrl click" on non-Apple) — a
+// bare space, never "⌘-click" or "Cmd+Click". The hint lands as its own
+// sentence, so a description that already ends in "." must not read "..".
+export function appendSessionControlStepHint(
+  tooltip: string,
+  action: "step" | "switch",
+): string {
+  const modifier = isApplePlatform() ? "⌘" : "Ctrl";
+  const hint = action === "step"
+    ? `Click to step, ${modifier} click to step back.`
+    : `Click to switch, ${modifier} click to go back.`;
+  return `${tooltip.replace(/\.+$/, "")}. ${hint}`;
 }

--- a/apps/packages/product-client/src/lib/domain/shortcuts/reasoning-effort-shortcut.test.ts
+++ b/apps/packages/product-client/src/lib/domain/shortcuts/reasoning-effort-shortcut.test.ts
@@ -45,3 +45,53 @@ it("resolves Ctrl-Shift-E on non-Apple platforms", () => {
     id: "workspace.cycle-reasoning-effort",
   }));
 });
+
+it("resolves Control-Alt-Shift-E to the backward step on macOS", () => {
+  vi.stubGlobal("navigator", { platform: "MacIntel", userAgent: "Mac OS X" });
+
+  expect(resolveKeyboardShortcut({
+    key: "E",
+    code: "KeyE",
+    metaKey: false,
+    ctrlKey: true,
+    shiftKey: true,
+    altKey: true,
+  } as KeyboardEvent)).toEqual({
+    id: "workspace.cycle-reasoning-effort-back",
+    shortcut: expect.objectContaining({ id: "workspace.cycle-reasoning-effort-back", label: "⌃⌥⇧E" }),
+    trigger: expect.objectContaining({ source: "keyboard" }),
+  });
+});
+
+it("resolves Ctrl-Alt-Shift-E to the backward step on non-Apple platforms", () => {
+  vi.stubGlobal("navigator", { platform: "Linux x86_64", userAgent: "Linux" });
+
+  // On non-Apple, the physical Ctrl key stands in for the "meta" field (see
+  // matching.ts's matchesModifiers), matching the existing forward-chord test
+  // below rather than a literal metaKey press.
+  expect(resolveKeyboardShortcut({
+    key: "E",
+    code: "KeyE",
+    metaKey: false,
+    ctrlKey: true,
+    shiftKey: true,
+    altKey: true,
+  } as KeyboardEvent)).toEqual(expect.objectContaining({
+    id: "workspace.cycle-reasoning-effort-back",
+  }));
+});
+
+it("still resolves the forward chord (alt: false) without regressing to the backward step", () => {
+  vi.stubGlobal("navigator", { platform: "MacIntel", userAgent: "Mac OS X" });
+
+  expect(resolveKeyboardShortcut({
+    key: "E",
+    code: "KeyE",
+    metaKey: false,
+    ctrlKey: true,
+    shiftKey: true,
+    altKey: false,
+  } as KeyboardEvent)).toEqual(expect.objectContaining({
+    id: "workspace.cycle-reasoning-effort",
+  }));
+});

--- a/apps/packages/product-client/src/lib/domain/shortcuts/shortcut-sections.test.ts
+++ b/apps/packages/product-client/src/lib/domain/shortcuts/shortcut-sections.test.ts
@@ -40,7 +40,7 @@ describe("buildShortcutSections", () => {
     expect(findEntry(tabs, "Previous tab")?.labels).toEqual(["⌘⇧[", "⌘⌥←", "⌃⇧⇥"]);
     expect(findEntry(tabs, "Close other tabs")?.labels).toEqual(["⌘⌥O", "⌘⇧O"]);
     expect(findEntry(tabs, "New chat")?.labels).toEqual(["⌘T"]);
-    expect(findEntry(currentWorkspace, "Open model and reasoning options")?.labels)
+    expect(findEntry(currentWorkspace, "Open model options")?.labels)
       .toEqual(["⌃⇧M"]);
   });
 

--- a/specs/codebase/systems/product/chat/composer.md
+++ b/specs/codebase/systems/product/chat/composer.md
@@ -49,7 +49,7 @@ ChatView
     │     └── TodoProgressPill              (transient centered pill above ChatInput — plan/todo progress, any agent)
     ├── ChatInput
     │   └── ChatComposerSurface
-    │       └── form: ComposerCommandEditor + ModelSelector + SessionConfigControls + ChatComposerActions
+    │       └── form: ComposerCommandEditor + ChatInputControlRow (ComposerLeadingControls + ComposerTrailingControls + ChatComposerActions)
     │           (or the blocked-status takeover: ComposerBlockedStatusLine +
     │            ComposerBlockedControlRow while a persistent condition blocks chat)
     └── footerSlot
@@ -208,25 +208,23 @@ display labels or from one provider's raw runtime id shape.
 
 Rules:
 
-- Model and reasoning effort share one composer pill: `Model · Effort`. Its
-  compact root menu presents `Model`, `Effort`, and `Speed` as nested rows when
-  the harness exposes those controls. Each row shows the current value and
-  opens its complete choice list in a side panel. The Model panel retains the
-  searchable grouped catalog; Effort preserves the authored option ladder;
-  Speed presents the default and fast choices. Provider setup and settings
-  remain in the nested Advanced row. Do not render a separate click-to-cycle
-  effort-bars button or a separate Fast icon button. Model-only contexts such
-  as plan handoff may omit the tuning rows.
-- `Ctrl+Shift+M` toggles the active compact root menu open and closed, including
+- The model pill opens the searchable grouped catalog popover
+  (`ComposerModelPickerPopover`) and owns model/harness selection only. Under
+  the ruled composer input grammar (owner rev #1851, superseding the earlier
+  combined `Model · Effort` pill), reasoning effort, `fast_mode`, and the
+  working mode are separate composer chips — see §1.2 for their placement and
+  interaction contracts. Model-only contexts such as plan handoff render just
+  the model selection.
+- `Ctrl+Shift+M` toggles the model picker popover open and closed, including
   while the composer editor is focused. It does nothing while that selector is
   unavailable.
-- Closing the active root menu with `Ctrl+Shift+M`, Escape, or a keyboard model
+- Closing the picker with `Ctrl+Shift+M`, Escape, or a keyboard model
   selection returns focus to the active composer editor without changing its
   draft or caret. Pointer dismissal and model selectors outside an active
   composer keep their own focus behavior.
 - Preserve authored catalog effort labels (`Extra High`, `Max`, `Ultra`, and
-  so on); do not rewrite distinct values to internal spellings such as
-  `Xhigh`.
+  so on) wherever effort values render, including the effort stepper chip; do
+  not rewrite distinct values to internal spellings such as `Xhigh`.
 - The current composer chip uses the active session's effective runtime model
   once AnyHarness reports one. Pending launches may show requested model intent.
 - Picker selected state, dedupe, visibility, and display labels use canonical
@@ -251,15 +249,39 @@ showing the raw session values that required the mapping.
 
 ## 1.2 Session control placement
 
-The chat and Home composers use the same control partition and visible order:
+The chat and Home composers use the same control partition and visible order
+(`ComposerLeadingControls` in `ChatInputControlRow.tsx`, shared verbatim; home
+feeds it launch-time descriptors instead of live-session ones):
 
-1. the combined model/harness, reasoning-effort, and Fast selector
-2. the primary working mode selector
+1. the model/harness selector (§1.1)
+2. the Fast toggle, when the harness exposes `fast_mode`
+3. the reasoning-effort stepper, when the harness exposes an effort ladder
+4. the primary working mode badge
+5. the goal button (live sessions only) and urgent-only integrations
 
-Reasoning effort and `fast_mode` live inside the model selector described in
-§1.1; they must not also render as separate composer controls. The primary
-working mode is compact text plus a subtle disclosure chevron, without a
-leading mode icon.
+`buildComposerSessionControlGroups` owns the partition: it promotes the mode,
+effort, and `fast_mode` descriptors to their dedicated chips. Controls it does
+not promote (the permission/access `mode` while `collaboration_mode` is
+primary, and any other unclaimed configuration control) do not render in the
+composer row at all — there is no overflow or three-dot configuration menu;
+harness configuration surfaces (`SessionConfigControls`, the full-menu
+`SessionModeControl`) remain their home in settings.
+
+The two cycling chips share one interaction contract:
+
+- The reasoning-effort stepper (`ComposerEffortStepper`) is a six-bar ladder
+  chip. Click steps to the next level and wraps at the top; `⌘ click`
+  (`Ctrl click` on non-Apple platforms) steps back and wraps at the bottom.
+  `⌃⇧E` steps forward and `⌃⌥⇧E` steps back from anywhere on the main screen.
+- The working mode badge (`ComposerModeBadge`) is icon-only at every width —
+  the mode's configured glyph and nothing else, remounted per value so the
+  step is legible from the glyph swap. Click steps to the next mode;
+  `⌘ click`/`Ctrl click` steps back. `Shift+Tab` from the composer editor also
+  steps back.
+- Both chips' tooltips use `keepOpenOnPress`, report the value just landed on,
+  and carry the click-to-step and `⌘ click`-to-step-back hints
+  (`appendSessionControlStepHint`); the modifier word is platform-resolved,
+  never hardcoded.
 
 Visible controls use one consistent inter-item rhythm. Compact controls must
 not reserve a trailing pending-state slot when no pending state exists; that
@@ -272,13 +294,13 @@ keeps Codex's collaboration mode independent from its read-only/auto/full-access
 permissions while preserving harnesses such as Claude, Cursor, and OpenCode
 whose working and access behavior still share one mode control.
 
-Permission/access mode and every other unclaimed configuration control render
-only under the rightmost three-dot configuration menu. A reasoning-level
-control with two or more ordered values remains visible in the combined picker
-when the runtime reports it as non-settable, but its choices are disabled.
-Cowork hides the permission/access `mode` because its access policy is
-product-defined, but retains independent working-mode controls such as
-`collaboration_mode` together with model tuning in the combined picker.
+A reasoning-effort ladder with two or more ordered values keeps its chip
+visible when the runtime reports it as non-settable, but the chip is disabled
+— it still reads the level. Cowork hides the permission/access `mode` because
+its access policy is product-defined
+(`filterComposerSessionControlsForSurface`), but retains independent
+working-mode controls such as `collaboration_mode` together with the tuning
+chips.
 
 ### Compact control tier (narrow composers)
 
@@ -288,11 +310,8 @@ Home composer wrapper anchors its own), labeled control pills shed their words
 so the row degrades to icons instead of truncating mid-word or painting over
 neighboring controls:
 
-- The working-mode pill swaps its mode name for the mode's configured icon
-  (`SessionControlIcon`) and stops shrinking at that icon footprint. A mode
-  value without a configured icon keeps its text at every width. This is the
-  one sanctioned exception to "no leading mode icon": the icon renders only
-  under the compact tier, never beside the name.
+- The working-mode badge is already icon-only at every width (§1.2), so the
+  compact tier changes nothing about it.
 - The reasoning pill hides the level word; the lit level bars keep reading
   the level.
 - The integrations pill hides the connected count and keeps the glyph. The


### PR DESCRIPTION
Fixes [PRO-256](https://linear.app/proliferate-team/issue/PRO-256/cmd-click-on-the-reasoning-indicators-or-the-modes-to-step-back).

## What

The two cycling composer chips only stepped forward, so decreasing reasoning effort (or backing out of a mode) meant lapping the whole ladder.

- **⌘ click steps back** (Ctrl click on non-Apple platforms) on both the reasoning-effort ladder (`ComposerEffortStepper`) and the working-mode badge (`ComposerModeBadge`), wrapping at the ends. Plain click is unchanged. `metaKey || ctrlKey` is safe on macOS because Ctrl+click arrives as `contextmenu`, never `click`.
- **Tooltip hints**: both chips now advertise the gesture — "Click to step, ⌘ click to step back." / "Click to switch, ⌘ click to go back." — with the modifier word platform-resolved via `isApplePlatform()`. The new `appendSessionControlStepHint` also absorbs a description's trailing period so hints no longer produce "..".
- **Keyboard symmetry**: `⌃⌥⇧E` (`Ctrl+Alt+Shift+E`) registers as `workspace.cycle-reasoning-effort-back`, mirroring `⌃⇧E` with the same main-screen gate. Mode already had ⇧⇥ backward; it now shares `getPreviousSessionModeValue` with the click path.
- **Domain helpers**: effort stepping moved into `getSteppedReasoningEffortValue` (direction-aware, preserves the existing no-selection fallback semantics) instead of inline index math.

## Doc truth-pass

`specs/codebase/systems/product/chat/composer.md` §1.1/§1.2 still ruled the pre-#1851 combined `Model · Effort` pill ("do not render a separate click-to-cycle effort-bars button") that the shipped input grammar replaced. Those sections now describe the shipped partition (model picker, Fast chip, effort stepper, mode badge), the two chips' interaction contract including this PR's ⌘ click behavior, the removal of the three-dot overflow menu, and the icon-only mode badge in the compact tier. `scripts/check_docs.py` passes.

## Verification

- `vitest run` over `session-controls`, `shortcuts`, `ComposerEffortStepper.test.tsx`, `ComposerModeBadge.test.tsx`: **17 files, 123 tests passed** (new: backward click/wrap on both chips, backward shortcut resolution mac + non-Apple, forward-chord no-regression, stepped-value helper unit tests, tooltip copy).
- Negative control: reverting `ComposerModeBadge.tsx` to origin/main fails its suite; restoring passes 9/9.
- `tsc --noEmit` clean for the package; appearance-scaling pre-commit gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)