### PR TITLE
fix(product): let Shift+Tab and Shift+Enter exit composer lists (PRO-267)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerListExit.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerListExit.test.tsx
@@ -96,6 +96,47 @@ describe("composer list exit", () => {
     expect(lastMarkdown(onChange)).toBe("- a\n\nb\n\n- c");
   });
 
+  it("keeps ordered numbering continuous when a middle item exits", async () => {
+    const onChange = vi.fn();
+    const harness = renderEditor({ onChange });
+    await harness.ready();
+    act(() => resetEditor(harness.editor));
+    act(() => { fireEvent(harness.root, pasteEvent("1. a\n2. b\n3. c")); });
+    await waitFor(() => expect(harness.root.querySelectorAll("ol li")).toHaveLength(3));
+
+    act(() => {
+      selectEndOfText(harness.editor, "b");
+      harness.editor.dispatchCommand(KEY_TAB_COMMAND, keyEvent("Tab", { shiftKey: true }));
+    });
+
+    await waitFor(() => expect(harness.root.querySelectorAll("ol")).toHaveLength(2));
+    const lists = harness.root.querySelectorAll("ol");
+    expect(lists[1]?.getAttribute("start")).toBe("3");
+    expect(lastMarkdown(onChange)).toBe("1. a\n\nb\n\n3. c");
+  });
+
+  it("promotes an orphaned sublist when its parent item exits", async () => {
+    const harness = renderEditor();
+    await harness.ready();
+    act(() => resetEditor(harness.editor));
+    act(() => { fireEvent(harness.root, pasteEvent("- parent\n- child")); });
+    await waitFor(() => expect(harness.root.querySelectorAll("ul li")).toHaveLength(2));
+    act(() => {
+      selectEndOfText(harness.editor, "child");
+      harness.editor.dispatchCommand(KEY_TAB_COMMAND, keyEvent("Tab"));
+    });
+    await waitFor(() => expect(harness.root.querySelector("ul ul")).toBeTruthy());
+
+    act(() => {
+      selectEndOfText(harness.editor, "parent");
+      harness.editor.dispatchCommand(KEY_TAB_COMMAND, keyEvent("Tab", { shiftKey: true }));
+    });
+
+    await waitFor(() => expect(harness.root.querySelector("ul ul")).toBeNull());
+    expect(harness.root.querySelector("p")?.textContent).toBe("parent");
+    expect(harness.root.querySelector("ul li")?.textContent).toBe("child");
+  });
+
   it("still un-nests nested items through Lexical's own outdent on Shift+Tab", async () => {
     const harness = renderEditor();
     await harness.ready();

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerListExit.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerListExit.test.tsx
@@ -1,0 +1,299 @@
+// @vitest-environment jsdom
+
+// List-exit behavior for PRO-267: Shift+Tab outdents top-level list items
+// into paragraphs, and Shift+Enter exits the list from an empty item or an
+// empty trailing line. Lives beside ComposerRichTextEditor.test.tsx, which is
+// at the max-lines budget.
+
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  $createParagraphNode,
+  $getRoot,
+  $getSelection,
+  $isElementNode,
+  $isRangeSelection,
+  KEY_ENTER_COMMAND,
+  KEY_TAB_COMMAND,
+  type LexicalEditor,
+  type LexicalNode,
+} from "lexical";
+import { $isListItemNode, type ListItemNode } from "@lexical/list";
+import {
+  ComposerRichTextEditor,
+  type ComposerRichTextEditorProps,
+} from "#product/components/workspace/chat/input/ComposerRichTextEditor";
+
+let originalRangeRectDescriptor: PropertyDescriptor | undefined;
+
+afterEach(() => {
+  cleanup();
+  if (originalRangeRectDescriptor === undefined) {
+    Reflect.deleteProperty(Range.prototype, "getBoundingClientRect");
+  } else {
+    Object.defineProperty(Range.prototype, "getBoundingClientRect", originalRangeRectDescriptor);
+  }
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+beforeEach(() => {
+  originalRangeRectDescriptor = Object.getOwnPropertyDescriptor(
+    Range.prototype,
+    "getBoundingClientRect",
+  );
+  // jsdom ranges have no geometry; the caret plugin measures on every
+  // selection change and must not throw mid-update.
+  Object.defineProperty(Range.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({
+      bottom: 0, height: 0, left: 0, right: 0, toJSON: () => ({}), top: 0, width: 0, x: 0, y: 0,
+    }),
+  });
+  vi.stubGlobal("DragEvent", class DragEvent extends Event {});
+  vi.stubGlobal("ClipboardEvent", class ClipboardEvent extends Event {});
+  vi.spyOn(window, "scrollBy").mockImplementation(() => {});
+});
+
+describe("composer list exit", () => {
+  it("converts a top-level list item to a paragraph on Shift+Tab", async () => {
+    const onChange = vi.fn();
+    const harness = renderEditor({ onChange });
+    await harness.ready();
+    act(() => resetEditor(harness.editor));
+    act(() => { fireEvent(harness.root, pasteEvent("- one\n- two")); });
+    await waitFor(() => expect(harness.root.querySelectorAll("ul li")).toHaveLength(2));
+
+    // Selection updates and the command must share one act() block: between
+    // blocks, jsdom selection reconciliation resets the editor selection.
+    act(() => {
+      selectEndOfText(harness.editor, "two");
+      harness.editor.dispatchCommand(KEY_TAB_COMMAND, keyEvent("Tab", { shiftKey: true }));
+    });
+
+    await waitFor(() => expect(harness.root.querySelectorAll("ul li")).toHaveLength(1));
+    expect(harness.root.querySelector("ul li")?.textContent).toBe("one");
+    expect(harness.root.querySelector("p:last-child")?.textContent).toBe("two");
+    expect(lastMarkdown(onChange)).toBe("- one\n\ntwo");
+  });
+
+  it("splits the list around a middle item outdented with Shift+Tab", async () => {
+    const onChange = vi.fn();
+    const harness = renderEditor({ onChange });
+    await harness.ready();
+    act(() => resetEditor(harness.editor));
+    act(() => { fireEvent(harness.root, pasteEvent("- a\n- b\n- c")); });
+    await waitFor(() => expect(harness.root.querySelectorAll("ul li")).toHaveLength(3));
+
+    act(() => {
+      selectEndOfText(harness.editor, "b");
+      harness.editor.dispatchCommand(KEY_TAB_COMMAND, keyEvent("Tab", { shiftKey: true }));
+    });
+
+    await waitFor(() => expect(harness.root.querySelectorAll("ul")).toHaveLength(2));
+    const lists = harness.root.querySelectorAll("ul");
+    expect(lists[0]?.textContent).toBe("a");
+    expect(lists[1]?.textContent).toBe("c");
+    expect(lastMarkdown(onChange)).toBe("- a\n\nb\n\n- c");
+  });
+
+  it("still un-nests nested items through Lexical's own outdent on Shift+Tab", async () => {
+    const harness = renderEditor();
+    await harness.ready();
+    act(() => resetEditor(harness.editor));
+    act(() => { fireEvent(harness.root, pasteEvent("- one\n- two")); });
+    await waitFor(() => expect(harness.root.querySelectorAll("li")).toHaveLength(2));
+    act(() => {
+      selectEndOfText(harness.editor, "two");
+      harness.editor.dispatchCommand(KEY_TAB_COMMAND, keyEvent("Tab"));
+    });
+    await waitFor(() => expect(harness.root.querySelector("ul ul")).toBeTruthy());
+
+    act(() => {
+      selectEndOfText(harness.editor, "two");
+      harness.editor.dispatchCommand(KEY_TAB_COMMAND, keyEvent("Tab", { shiftKey: true }));
+    });
+
+    await waitFor(() => expect(harness.root.querySelector("ul ul")).toBeNull());
+    expect(harness.root.querySelectorAll("ul li")).toHaveLength(2);
+  });
+
+  it("exits the list on Shift+Enter from an empty item", async () => {
+    const onChange = vi.fn();
+    const harness = renderEditor({ onChange });
+    await harness.ready();
+    act(() => resetEditor(harness.editor));
+    await typeCharacters(harness.editor, "1. ");
+    await waitFor(() => expect(harness.root.querySelector("ol li")).toBeTruthy());
+
+    act(() => {
+      harness.editor.dispatchCommand(KEY_ENTER_COMMAND, keyEvent("Enter", { shiftKey: true }));
+    });
+
+    await waitFor(() => expect(harness.root.querySelector("ol")).toBeNull());
+    act(() => insertText(harness.editor, "plain"));
+    await waitFor(() => expect(lastMarkdown(onChange)).toBe("plain"));
+    expect(harness.root.querySelector("ol, ul")).toBeNull();
+  });
+
+  it("moves the caret below the list when Shift+Enter lands on an empty trailing line", async () => {
+    const onChange = vi.fn();
+    const harness = renderEditor({ onChange });
+    await harness.ready();
+    act(() => resetEditor(harness.editor));
+    await typeCharacters(harness.editor, "1. one");
+    act(() => {
+      harness.editor.dispatchCommand(KEY_ENTER_COMMAND, keyEvent("Enter", { shiftKey: true }));
+    });
+    await waitFor(() => expect(harness.root.querySelector("ol li br")).toBeTruthy());
+
+    act(() => {
+      harness.editor.dispatchCommand(KEY_ENTER_COMMAND, keyEvent("Enter", { shiftKey: true }));
+    });
+
+    await waitFor(() => expect(harness.root.querySelector("ol li br")).toBeNull());
+    expect(harness.root.querySelector("ol li")?.textContent).toBe("one");
+    act(() => insertText(harness.editor, "out"));
+    await waitFor(() => expect(lastMarkdown(onChange)).toBe("1. one\n\nout"));
+    expect(harness.root.querySelectorAll("ol li")).toHaveLength(1);
+  });
+
+  it("un-nests one level on Shift+Enter from an empty nested item", async () => {
+    const harness = renderEditor();
+    await harness.ready();
+    act(() => resetEditor(harness.editor));
+    act(() => { fireEvent(harness.root, pasteEvent("- one\n- two")); });
+    await waitFor(() => expect(harness.root.querySelectorAll("li")).toHaveLength(2));
+    act(() => {
+      selectEndOfText(harness.editor, "two");
+      harness.editor.dispatchCommand(KEY_TAB_COMMAND, keyEvent("Tab"));
+    });
+    await waitFor(() => expect(harness.root.querySelector("ul ul")).toBeTruthy());
+
+    act(() => {
+      emptyItemContaining(harness.editor, "two");
+      harness.editor.dispatchCommand(KEY_ENTER_COMMAND, keyEvent("Enter", { shiftKey: true }));
+    });
+    await waitFor(() => expect(harness.root.querySelector("ul ul")).toBeNull());
+    expect(harness.root.querySelectorAll("ul li")).toHaveLength(2);
+
+    act(() => {
+      selectEmptyItem(harness.editor);
+      harness.editor.dispatchCommand(KEY_ENTER_COMMAND, keyEvent("Enter", { shiftKey: true }));
+    });
+    await waitFor(() => expect(harness.root.querySelectorAll("ul li")).toHaveLength(1));
+    expect(harness.root.querySelector("ul li")?.textContent).toBe("one");
+  });
+
+  it("keeps inserting a plain newline on Shift+Enter mid-item", async () => {
+    const onSubmit = vi.fn();
+    const harness = renderEditor({ onSubmit });
+    await harness.ready();
+    act(() => resetEditor(harness.editor));
+    await typeCharacters(harness.editor, "1. one");
+
+    act(() => {
+      harness.editor.dispatchCommand(KEY_ENTER_COMMAND, keyEvent("Enter", { shiftKey: true }));
+    });
+
+    await waitFor(() => expect(harness.root.querySelector("ol li br")).toBeTruthy());
+    expect(harness.root.querySelectorAll("ol li")).toHaveLength(1);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});
+
+function renderEditor(overrides: Partial<ComposerRichTextEditorProps> = {}) {
+  let editor: LexicalEditor | null = null;
+  const props: ComposerRichTextEditorProps = {
+    value: "",
+    onChange: vi.fn(),
+    canSubmit: true,
+    onSubmit: vi.fn(),
+    placeholder: "Message",
+    disabled: false,
+    editorRef: (next) => { editor = next; },
+    ...overrides,
+  };
+  const rendered = render(<ComposerRichTextEditor {...props} />);
+  const root = rendered.container.querySelector<HTMLElement>("[data-chat-composer-editor]")!;
+  return {
+    get editor() { return editor!; },
+    root,
+    ready: () => waitFor(() => expect(editor).toBeTruthy()),
+  };
+}
+
+function lastMarkdown(onChange: ReturnType<typeof vi.fn>): string | undefined {
+  return onChange.mock.calls[onChange.mock.calls.length - 1]?.[0] as string | undefined;
+}
+
+function resetEditor(editor: LexicalEditor) {
+  editor.update(() => {
+    const paragraph = $createParagraphNode();
+    $getRoot().clear().append(paragraph);
+    paragraph.selectEnd();
+  }, { discrete: true });
+}
+
+function insertText(editor: LexicalEditor, text: string) {
+  editor.update(() => {
+    const selection = $getSelection();
+    if ($isRangeSelection(selection)) selection.insertText(text);
+  }, { discrete: true });
+}
+
+async function typeCharacters(editor: LexicalEditor, text: string) {
+  for (const character of text) {
+    act(() => insertText(editor, character));
+    await Promise.resolve();
+  }
+}
+
+function selectEndOfText(editor: LexicalEditor, content: string) {
+  editor.getRootElement()?.focus();
+  editor.update(() => {
+    const text = $getRoot().getAllTextNodes().find((node) => node.getTextContent() === content);
+    if (!text) throw new Error(`no text node with content "${content}"`);
+    text.select(content.length, content.length);
+  }, { discrete: true });
+}
+
+function selectEmptyItem(editor: LexicalEditor) {
+  editor.getRootElement()?.focus();
+  editor.update(() => {
+    const empty = collectListItems($getRoot()).find((item) => item.getChildrenSize() === 0);
+    if (!empty) throw new Error("no empty list item to select");
+    empty.select();
+  }, { discrete: true });
+}
+
+function collectListItems(node: LexicalNode): ListItemNode[] {
+  const items: ListItemNode[] = [];
+  if ($isListItemNode(node)) items.push(node);
+  if ($isElementNode(node)) {
+    for (const child of node.getChildren()) items.push(...collectListItems(child));
+  }
+  return items;
+}
+
+function emptyItemContaining(editor: LexicalEditor, content: string) {
+  editor.getRootElement()?.focus();
+  editor.update(() => {
+    const text = $getRoot().getAllTextNodes().find((node) => node.getTextContent() === content);
+    if (!text) throw new Error(`no text node with content "${content}"`);
+    const item = text.getParentOrThrow();
+    text.remove();
+    item.select();
+  }, { discrete: true });
+}
+
+function keyEvent(key: string, init: KeyboardEventInit = {}): KeyboardEvent {
+  return new KeyboardEvent("keydown", { key, bubbles: true, ...init });
+}
+
+function pasteEvent(text: string): ClipboardEvent {
+  const event = new ClipboardEvent("paste", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "clipboardData", {
+    value: { getData: (type: string) => type === "text/plain" ? text : "" },
+  });
+  return event;
+}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerListExit.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerListExit.tsx
@@ -1,0 +1,123 @@
+// List-exit surgery for the chat composer (PRO-267). Lexical's stock
+// OUTDENT_CONTENT_COMMAND only shrinks nesting, so it is a silent no-op for
+// items already at the top level — and since plain Enter submits in the
+// composer, lists were inescapable. The composer owns the missing exits:
+// Shift+Tab outdents top-level items into paragraphs, and Shift+Enter exits
+// from an empty item or an empty trailing line.
+
+import {
+  $createParagraphNode,
+  $getSelection,
+  $isLineBreakNode,
+  $isRangeSelection,
+  $isTextNode,
+  OUTDENT_CONTENT_COMMAND,
+  type LexicalEditor,
+  type LexicalNode,
+  type ParagraphNode,
+} from "lexical";
+import { $isListItemNode, $isListNode, type ListItemNode } from "@lexical/list";
+
+export function $nearestListItem(node: LexicalNode): ListItemNode | null {
+  let current: LexicalNode | null = node;
+  while (current !== null && !$isListItemNode(current)) current = current.getParent();
+  return $isListItemNode(current) ? current : null;
+}
+
+// The missing outdent step for indent-0 items — each becomes a paragraph,
+// splitting its list around it. Nested items (and wrapper items holding a
+// nested list) still take Lexical's own outdent path.
+export function $outdentTopLevelListItems(): boolean {
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection)) return false;
+  const items = new Set<ListItemNode>();
+  for (const node of selection.getNodes()) {
+    const item = $nearestListItem(node);
+    if (item) items.add(item);
+  }
+  if (items.size === 0) return false;
+  for (const item of items) {
+    if (item.getIndent() > 0 || item.getChildren().some($isListNode)) return false;
+  }
+  for (const item of items) $convertListItemToParagraph(item);
+  return true;
+}
+
+// Plain Enter submits the message, so Shift+Enter doubles as the list exit:
+// on an empty item it leaves the list (or un-nests one level), and on an
+// empty trailing line it moves the caret into a paragraph below the list.
+export function $exitListForShiftEnter(editor: LexicalEditor): boolean {
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
+  const item = $nearestListItem(selection.anchor.getNode());
+  if (!item) return false;
+  const effectivelyEmpty = item
+    .getChildren()
+    .every((child) => $isTextNode(child) && child.getTextContentSize() === 0);
+  if (effectivelyEmpty) {
+    if (item.getIndent() > 0) return editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
+    $convertListItemToParagraph(item);
+    return true;
+  }
+  if (item.getIndent() > 0) return false;
+  const { anchor } = selection;
+  const caretOnEmptyTrailingLine = $isLineBreakNode(item.getLastChild())
+    && anchor.type === "element"
+    && anchor.getNode().is(item)
+    && anchor.offset === item.getChildrenSize();
+  if (!caretOnEmptyTrailingLine) return false;
+  item.getLastChild()?.remove();
+  const list = item.getParentOrThrow();
+  const trailingStart = $orderedStartAfter(item);
+  const nextItem = item.getNextSibling();
+  const paragraph = $createParagraphNode();
+  item.insertAfter(paragraph);
+  $healTrailingList(paragraph, nextItem, trailingStart);
+  if (item.getChildrenSize() === 0) {
+    item.remove();
+    if (list.isAttached() && list.getChildrenSize() === 0) list.remove();
+  }
+  paragraph.selectEnd();
+  return true;
+}
+
+function $convertListItemToParagraph(item: ListItemNode): void {
+  const trailingStart = $orderedStartAfter(item);
+  const nextItem = item.getNextSibling();
+  // ListItemNode.replace splits the list around the item, transfers its
+  // children, remaps an element-anchored caret, and prunes the emptied list.
+  const paragraph = item.replace($createParagraphNode(), true);
+  $healTrailingList(paragraph, nextItem, trailingStart);
+}
+
+// Visible number the items after `item` should keep once a paragraph lands
+// before them, or null for unordered lists.
+function $orderedStartAfter(item: ListItemNode): number | null {
+  const list = item.getParent();
+  if (!$isListNode(list) || list.getListType() !== "number") return null;
+  return list.getStart() + item.getIndexWithinParent() + 1;
+}
+
+// After a paragraph lands between the halves of a split list, the trailing
+// half restarts ordered numbering at the head's start, and when the exited
+// item owned a nested sublist, that sublist's wrapper now leads the trailing
+// half as an indented bullet with no parent. Repair both.
+function $healTrailingList(
+  paragraph: ParagraphNode,
+  firstTrailingItem: LexicalNode | null,
+  orderedStart: number | null,
+): void {
+  if (!$isListItemNode(firstTrailingItem)) return;
+  const trailingList = firstTrailingItem.getParent();
+  if (!$isListNode(trailingList) || trailingList.getPreviousSibling() !== paragraph) return;
+  if (orderedStart !== null && trailingList.getListType() === "number") {
+    trailingList.setStart(orderedStart);
+  }
+  const first = trailingList.getFirstChild();
+  if (!$isListItemNode(first)) return;
+  const children = first.getChildren();
+  const orphanedSublist = children.length === 1 ? children[0] : null;
+  if (!$isListNode(orphanedSublist)) return;
+  for (const promoted of orphanedSublist.getChildren()) first.insertBefore(promoted);
+  first.remove();
+}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
@@ -1,16 +1,22 @@
 import { useEffect, useRef, type MutableRefObject, type Ref } from "react";
 import {
+  $copyNode,
+  $createParagraphNode,
   $getRoot,
   $getSelection,
+  $isLineBreakNode,
   $isRangeSelection,
+  $isTextNode,
   COMMAND_PRIORITY_HIGH,
   INDENT_CONTENT_COMMAND,
   KEY_ENTER_COMMAND,
   KEY_TAB_COMMAND,
   OUTDENT_CONTENT_COMMAND,
+  type ElementNode,
   type LexicalEditor,
+  type LexicalNode,
 } from "lexical";
-import { $isListItemNode } from "@lexical/list";
+import { $isListItemNode, $isListNode, type ListItemNode } from "@lexical/list";
 import {
   $convertFromMarkdownString,
   $convertToMarkdownString,
@@ -322,6 +328,11 @@ function ComposerBehaviorPlugin({
       if (onCommandKey?.(event)) return true;
       const plainEnter = !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey;
       const primaryEnter = !event.shiftKey && !event.altKey && (event.metaKey || event.ctrlKey);
+      const shiftEnter = event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey;
+      if (shiftEnter && $exitListForShiftEnter(editor)) {
+        event.preventDefault();
+        return true;
+      }
       if (!plainEnter && !primaryEnter) return false;
       event.preventDefault();
       if (!event.repeat && canSubmit) onSubmit();
@@ -335,6 +346,7 @@ function ComposerBehaviorPlugin({
         return event.defaultPrevented;
       }
       event.preventDefault();
+      if (event.shiftKey && $outdentTopLevelListItems()) return true;
       return editor.dispatchCommand(
         event.shiftKey ? OUTDENT_CONTENT_COMMAND : INDENT_CONTENT_COMMAND,
         undefined,
@@ -349,11 +361,91 @@ function ComposerBehaviorPlugin({
 function selectionIsInList(): boolean {
   const selection = $getSelection();
   if (!$isRangeSelection(selection)) return false;
-  let node = selection.anchor.getNode();
-  while (node && !$isListItemNode(node)) {
-    const parent = node.getParent();
-    if (!parent) return false;
-    node = parent;
+  return $nearestListItem(selection.anchor.getNode()) !== null;
+}
+
+function $nearestListItem(node: LexicalNode): ListItemNode | null {
+  let current: LexicalNode | null = node;
+  while (current !== null && !$isListItemNode(current)) current = current.getParent();
+  return $isListItemNode(current) ? current : null;
+}
+
+// Lexical's stock OUTDENT_CONTENT_COMMAND only shrinks nesting, so it is a
+// silent no-op for items already at the top level (PRO-267). The missing
+// outdent step — item becomes a paragraph, splitting its list around it — is
+// owned here. Nested items (and wrapper items holding a nested list) still
+// take Lexical's own outdent path.
+function $outdentTopLevelListItems(): boolean {
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection)) return false;
+  const items = new Set<ListItemNode>();
+  for (const node of selection.getNodes()) {
+    const item = $nearestListItem(node);
+    if (item) items.add(item);
   }
-  return $isListItemNode(node);
+  if (items.size === 0) return false;
+  for (const item of items) {
+    if (item.getIndent() > 0 || item.getChildren().some($isListNode)) return false;
+  }
+  for (const item of items) $convertListItemToParagraph(item);
+  return true;
+}
+
+// Plain Enter submits the message, so Shift+Enter doubles as the list exit:
+// on an empty item it leaves the list (or un-nests one level), and on an
+// empty trailing line it moves the caret into a paragraph below the list.
+function $exitListForShiftEnter(editor: LexicalEditor): boolean {
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
+  const item = $nearestListItem(selection.anchor.getNode());
+  if (!item) return false;
+  const effectivelyEmpty = item
+    .getChildren()
+    .every((child) => $isTextNode(child) && child.getTextContentSize() === 0);
+  if (effectivelyEmpty) {
+    if (item.getIndent() > 0) return editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
+    $convertListItemToParagraph(item);
+    return true;
+  }
+  if (item.getIndent() > 0) return false;
+  const { anchor } = selection;
+  const caretOnEmptyTrailingLine = $isLineBreakNode(item.getLastChild())
+    && anchor.type === "element"
+    && anchor.getNode().is(item)
+    && anchor.offset === item.getChildrenSize();
+  if (!caretOnEmptyTrailingLine) return false;
+  item.getLastChild()?.remove();
+  const list = item.getParentOrThrow();
+  $splitListAfterItem(item, list);
+  const paragraph = $createParagraphNode();
+  list.insertAfter(paragraph);
+  if (item.getChildrenSize() === 0) {
+    item.remove();
+    if (list.getChildrenSize() === 0) list.remove();
+  }
+  paragraph.selectEnd();
+  return true;
+}
+
+function $convertListItemToParagraph(item: ListItemNode): void {
+  const selection = $getSelection();
+  const caretWasOnItem = $isRangeSelection(selection)
+    && selection.anchor.type === "element"
+    && selection.anchor.getNode().is(item);
+  const list = item.getParentOrThrow();
+  const paragraph = $createParagraphNode();
+  paragraph.append(...item.getChildren());
+  $splitListAfterItem(item, list);
+  list.insertAfter(paragraph);
+  item.remove();
+  if (list.getChildrenSize() === 0) list.remove();
+  if (caretWasOnItem || paragraph.isEmpty()) paragraph.selectEnd();
+}
+
+function $splitListAfterItem(item: ListItemNode, list: ElementNode): void {
+  const trailing = item.getNextSiblings();
+  if (trailing.length === 0) return;
+  const trailingList = $copyNode(list);
+  trailingList.append(...trailing);
+  list.insertAfter(trailingList);
 }

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, type MutableRefObject, type Ref } from "react";
 import {
-  $copyNode,
   $createParagraphNode,
   $getRoot,
   $getSelection,
@@ -12,9 +11,9 @@ import {
   KEY_ENTER_COMMAND,
   KEY_TAB_COMMAND,
   OUTDENT_CONTENT_COMMAND,
-  type ElementNode,
   type LexicalEditor,
   type LexicalNode,
+  type ParagraphNode,
 } from "lexical";
 import { $isListItemNode, $isListNode, type ListItemNode } from "@lexical/list";
 import {
@@ -416,36 +415,56 @@ function $exitListForShiftEnter(editor: LexicalEditor): boolean {
   if (!caretOnEmptyTrailingLine) return false;
   item.getLastChild()?.remove();
   const list = item.getParentOrThrow();
-  $splitListAfterItem(item, list);
+  const trailingStart = $orderedStartAfter(item);
+  const nextItem = item.getNextSibling();
   const paragraph = $createParagraphNode();
-  list.insertAfter(paragraph);
+  item.insertAfter(paragraph);
+  $healTrailingList(paragraph, nextItem, trailingStart);
   if (item.getChildrenSize() === 0) {
     item.remove();
-    if (list.getChildrenSize() === 0) list.remove();
+    if (list.isAttached() && list.getChildrenSize() === 0) list.remove();
   }
   paragraph.selectEnd();
   return true;
 }
 
 function $convertListItemToParagraph(item: ListItemNode): void {
-  const selection = $getSelection();
-  const caretWasOnItem = $isRangeSelection(selection)
-    && selection.anchor.type === "element"
-    && selection.anchor.getNode().is(item);
-  const list = item.getParentOrThrow();
-  const paragraph = $createParagraphNode();
-  paragraph.append(...item.getChildren());
-  $splitListAfterItem(item, list);
-  list.insertAfter(paragraph);
-  item.remove();
-  if (list.getChildrenSize() === 0) list.remove();
-  if (caretWasOnItem || paragraph.isEmpty()) paragraph.selectEnd();
+  const trailingStart = $orderedStartAfter(item);
+  const nextItem = item.getNextSibling();
+  // ListItemNode.replace splits the list around the item, transfers its
+  // children, remaps an element-anchored caret, and prunes the emptied list.
+  const paragraph = item.replace($createParagraphNode(), true);
+  $healTrailingList(paragraph, nextItem, trailingStart);
 }
 
-function $splitListAfterItem(item: ListItemNode, list: ElementNode): void {
-  const trailing = item.getNextSiblings();
-  if (trailing.length === 0) return;
-  const trailingList = $copyNode(list);
-  trailingList.append(...trailing);
-  list.insertAfter(trailingList);
+// Visible number the items after `item` should keep once a paragraph lands
+// before them, or null for unordered lists.
+function $orderedStartAfter(item: ListItemNode): number | null {
+  const list = item.getParent();
+  if (!$isListNode(list) || list.getListType() !== "number") return null;
+  return list.getStart() + item.getIndexWithinParent() + 1;
+}
+
+// After a paragraph lands between the halves of a split list, the trailing
+// half restarts ordered numbering at the head's start, and when the exited
+// item owned a nested sublist, that sublist's wrapper now leads the trailing
+// half as an indented bullet with no parent. Repair both.
+function $healTrailingList(
+  paragraph: ParagraphNode,
+  firstTrailingItem: LexicalNode | null,
+  orderedStart: number | null,
+): void {
+  if (!$isListItemNode(firstTrailingItem)) return;
+  const trailingList = firstTrailingItem.getParent();
+  if (!$isListNode(trailingList) || trailingList.getPreviousSibling() !== paragraph) return;
+  if (orderedStart !== null && trailingList.getListType() === "number") {
+    trailingList.setStart(orderedStart);
+  }
+  const first = trailingList.getFirstChild();
+  if (!$isListItemNode(first)) return;
+  const children = first.getChildren();
+  const orphanedSublist = children.length === 1 ? children[0] : null;
+  if (!$isListNode(orphanedSublist)) return;
+  for (const promoted of orphanedSublist.getChildren()) first.insertBefore(promoted);
+  first.remove();
 }

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
@@ -1,21 +1,15 @@
 import { useEffect, useRef, type MutableRefObject, type Ref } from "react";
 import {
-  $createParagraphNode,
   $getRoot,
   $getSelection,
-  $isLineBreakNode,
   $isRangeSelection,
-  $isTextNode,
   COMMAND_PRIORITY_HIGH,
   INDENT_CONTENT_COMMAND,
   KEY_ENTER_COMMAND,
   KEY_TAB_COMMAND,
   OUTDENT_CONTENT_COMMAND,
   type LexicalEditor,
-  type LexicalNode,
-  type ParagraphNode,
 } from "lexical";
-import { $isListItemNode, $isListNode, type ListItemNode } from "@lexical/list";
 import {
   $convertFromMarkdownString,
   $convertToMarkdownString,
@@ -38,6 +32,11 @@ import {
   type ComposerEditorContext,
 } from "#product/components/workspace/chat/input/ComposerEditorDocument";
 import { ComposerLinkPastePlugin } from "#product/components/workspace/chat/input/ComposerLinkPastePlugin";
+import {
+  $exitListForShiftEnter,
+  $nearestListItem,
+  $outdentTopLevelListItems,
+} from "#product/components/workspace/chat/input/ComposerListExit";
 import { ComposerMarkdownShortcutPlugin } from "#product/components/workspace/chat/input/ComposerMarkdownShortcutPlugin";
 import { CHAT_TRANSCRIPT_LINK_CLASS } from "#product/config/transcript-link-styles";
 import type { ComposerKeyboardEventLike } from "#product/lib/domain/chat/composer/composer-keyboard";
@@ -361,110 +360,4 @@ function selectionIsInList(): boolean {
   const selection = $getSelection();
   if (!$isRangeSelection(selection)) return false;
   return $nearestListItem(selection.anchor.getNode()) !== null;
-}
-
-function $nearestListItem(node: LexicalNode): ListItemNode | null {
-  let current: LexicalNode | null = node;
-  while (current !== null && !$isListItemNode(current)) current = current.getParent();
-  return $isListItemNode(current) ? current : null;
-}
-
-// Lexical's stock OUTDENT_CONTENT_COMMAND only shrinks nesting, so it is a
-// silent no-op for items already at the top level (PRO-267). The missing
-// outdent step — item becomes a paragraph, splitting its list around it — is
-// owned here. Nested items (and wrapper items holding a nested list) still
-// take Lexical's own outdent path.
-function $outdentTopLevelListItems(): boolean {
-  const selection = $getSelection();
-  if (!$isRangeSelection(selection)) return false;
-  const items = new Set<ListItemNode>();
-  for (const node of selection.getNodes()) {
-    const item = $nearestListItem(node);
-    if (item) items.add(item);
-  }
-  if (items.size === 0) return false;
-  for (const item of items) {
-    if (item.getIndent() > 0 || item.getChildren().some($isListNode)) return false;
-  }
-  for (const item of items) $convertListItemToParagraph(item);
-  return true;
-}
-
-// Plain Enter submits the message, so Shift+Enter doubles as the list exit:
-// on an empty item it leaves the list (or un-nests one level), and on an
-// empty trailing line it moves the caret into a paragraph below the list.
-function $exitListForShiftEnter(editor: LexicalEditor): boolean {
-  const selection = $getSelection();
-  if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
-  const item = $nearestListItem(selection.anchor.getNode());
-  if (!item) return false;
-  const effectivelyEmpty = item
-    .getChildren()
-    .every((child) => $isTextNode(child) && child.getTextContentSize() === 0);
-  if (effectivelyEmpty) {
-    if (item.getIndent() > 0) return editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
-    $convertListItemToParagraph(item);
-    return true;
-  }
-  if (item.getIndent() > 0) return false;
-  const { anchor } = selection;
-  const caretOnEmptyTrailingLine = $isLineBreakNode(item.getLastChild())
-    && anchor.type === "element"
-    && anchor.getNode().is(item)
-    && anchor.offset === item.getChildrenSize();
-  if (!caretOnEmptyTrailingLine) return false;
-  item.getLastChild()?.remove();
-  const list = item.getParentOrThrow();
-  const trailingStart = $orderedStartAfter(item);
-  const nextItem = item.getNextSibling();
-  const paragraph = $createParagraphNode();
-  item.insertAfter(paragraph);
-  $healTrailingList(paragraph, nextItem, trailingStart);
-  if (item.getChildrenSize() === 0) {
-    item.remove();
-    if (list.isAttached() && list.getChildrenSize() === 0) list.remove();
-  }
-  paragraph.selectEnd();
-  return true;
-}
-
-function $convertListItemToParagraph(item: ListItemNode): void {
-  const trailingStart = $orderedStartAfter(item);
-  const nextItem = item.getNextSibling();
-  // ListItemNode.replace splits the list around the item, transfers its
-  // children, remaps an element-anchored caret, and prunes the emptied list.
-  const paragraph = item.replace($createParagraphNode(), true);
-  $healTrailingList(paragraph, nextItem, trailingStart);
-}
-
-// Visible number the items after `item` should keep once a paragraph lands
-// before them, or null for unordered lists.
-function $orderedStartAfter(item: ListItemNode): number | null {
-  const list = item.getParent();
-  if (!$isListNode(list) || list.getListType() !== "number") return null;
-  return list.getStart() + item.getIndexWithinParent() + 1;
-}
-
-// After a paragraph lands between the halves of a split list, the trailing
-// half restarts ordered numbering at the head's start, and when the exited
-// item owned a nested sublist, that sublist's wrapper now leads the trailing
-// half as an indented bullet with no parent. Repair both.
-function $healTrailingList(
-  paragraph: ParagraphNode,
-  firstTrailingItem: LexicalNode | null,
-  orderedStart: number | null,
-): void {
-  if (!$isListItemNode(firstTrailingItem)) return;
-  const trailingList = firstTrailingItem.getParent();
-  if (!$isListNode(trailingList) || trailingList.getPreviousSibling() !== paragraph) return;
-  if (orderedStart !== null && trailingList.getListType() === "number") {
-    trailingList.setStart(orderedStart);
-  }
-  const first = trailingList.getFirstChild();
-  if (!$isListItemNode(first)) return;
-  const children = first.getChildren();
-  const orphanedSublist = children.length === 1 ? children[0] : null;
-  if (!$isListNode(orphanedSublist)) return;
-  for (const promoted of orphanedSublist.getChildren()) first.insertBefore(promoted);
-  first.remove();
 }


### PR DESCRIPTION
Fixes [PRO-267](https://linear.app/proliferate-team/issue/PRO-267/cant-un-tab-here-always-stays-indented-no-matter-what).

## Problem

Once the composer converts `1. ` / `- ` into a real list, there is no way out. Lexical's stock `OUTDENT_CONTENT_COMMAND` only decrements nesting, so it is a silent no-op for items already at the top level — Shift+Tab swallows the keypress and changes nothing. And because plain Enter submits the message, the universal "Enter on an empty item exits the list" convention doesn't exist here either; Shift+Enter just inserts line breaks inside the same item. The only escape was Backspace with the caret at the very start of the item.

## Fix

All in `ComposerBehaviorPlugin` (`ComposerRichTextEditor.tsx`):

- **Shift+Tab** on indent-0 list items converts them to paragraphs, splitting the list around middle items (mirrors `ListItemNode.collapseAtStart`'s top-level branch). Nested items — and wrapper items holding a nested list — still take Lexical's own outdent path.
- **Shift+Enter** on an effectively-empty item exits the list, or un-nests one level when nested. On an empty trailing line (i.e. after a prior Shift+Enter) it consumes the line break and moves the caret into a paragraph below the list — so the reported flow (`1. foo`, Shift+Enter, Shift+Enter) now lands outside the list. Mid-item Shift+Enter still inserts a plain newline.

## Tests

New `ComposerListExit.test.tsx` (separate file: the existing editor test file sits at 598 of the 600 max-lines cap) covers all five new behaviors plus two preserved ones (nested un-nest via Lexical, plain newline mid-item). Negative control done: with the fix reverted, exactly the five behavior tests fail and the preserved-behavior tests pass. Full `chat/input` directory green (185 tests), `tsc` clean, max-lines/boundaries/component-library checkers pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)