### PR TITLE
refactor(agent-auth): registry.json as single allow-list authority (FR-4, rung 5)

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema_tests.rs
@@ -231,3 +231,60 @@ fn draft_catalog_version() -> String {
         .expect("catalogVersion")
         .to_string()
 }
+
+// --------------------------------------------------------------------------
+// registry-authority drift guards (agent-auth.md FR-4)
+// --------------------------------------------------------------------------
+//
+// AgentKind is a type (it stays code), but registry.json is the declared
+// allow-list authority. These tests fail the moment the enum and the registry
+// disagree on which kinds exist or which are gateway-capable, so the Rust
+// render plane's per-kind branching (render.rs) can never silently diverge
+// from the document every other plane reads.
+
+use crate::domains::agents::model::AgentKind;
+use crate::domains::agents::registry::bundled::bundled_agent_registry_document;
+
+#[test]
+fn agent_kind_enum_matches_registry_kinds() {
+    let enum_kinds: std::collections::BTreeSet<&str> =
+        AgentKind::all().iter().map(|kind| kind.as_str()).collect();
+    let registry_kinds: std::collections::BTreeSet<&str> = bundled_agent_registry_document()
+        .agents
+        .iter()
+        .map(|agent| agent.kind.as_str())
+        .collect();
+    assert_eq!(
+        enum_kinds, registry_kinds,
+        "AgentKind::all() must equal registry.json agents[].kind exactly"
+    );
+}
+
+#[test]
+fn registry_gateway_capability_matches_render_assumption() {
+    // Gateway capability = the registry auth block declares a `gateway` slot.
+    let gateway_capable: std::collections::BTreeSet<&str> = bundled_agent_registry_document()
+        .agents
+        .iter()
+        .filter(|agent| agent.auth.slots.iter().any(|slot| slot.id == "gateway"))
+        .map(|agent| agent.kind.as_str())
+        .collect();
+
+    // render.rs::render_gateway serves claude/codex/opencode/grok and returns
+    // UnsupportedRoute for cursor. That runtime assumption is exactly: every
+    // kind EXCEPT cursor is gateway-capable.
+    let expected: std::collections::BTreeSet<&str> = AgentKind::all()
+        .iter()
+        .map(|kind| kind.as_str())
+        .filter(|kind| *kind != "cursor")
+        .collect();
+
+    assert_eq!(
+        gateway_capable, expected,
+        "registry gateway-slot derivation must match render.rs's gateway/UnsupportedRoute split"
+    );
+    assert!(
+        !gateway_capable.contains("cursor"),
+        "cursor must never be gateway-capable (render.rs returns UnsupportedRoute)"
+    );
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/registry/schema.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/registry/schema.rs
@@ -17,6 +17,13 @@ pub struct AgentRegistryDocument {
 #[serde(rename_all = "camelCase")]
 pub struct AgentRegistryAgent {
     pub kind: String,
+    /// How many auth sources this harness may keep enabled at once
+    /// (`single` = radio, `multi` = additive gateway + api_key rows). The
+    /// declared authority for the server/TS single-vs-multi mirrors; the Rust
+    /// render plane does not branch on it (cardinality is a product-layer
+    /// selection rule), so it is carried through untyped and only round-tripped.
+    #[serde(default)]
+    pub auth_cardinality: Option<String>,
     pub display_name: String,
     #[serde(default)]
     pub description: Option<String>,

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessSettingsSection.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessSettingsSection.tsx
@@ -9,33 +9,15 @@ import {
   useAuthSelections,
 } from "@proliferate/cloud-sdk-react";
 import { useCloudAvailabilityState } from "#product/hooks/cloud/derived/use-cloud-availability-state";
+import { getBundledHarnessCatalogSettings } from "#product/lib/domain/agents/bundled-agent-catalog";
+import type { CloudAgentCatalogSettingInput } from "#product/lib/domain/agents/cloud-launch-catalog-types";
 
 // --------------------------------------------------------------------------- #
-// Catalog-declared settings (mirrors catalogs/agents/catalog.json)
+// Catalog-declared settings — read from the bundled catalogs/agents/catalog.json
+// copy (agent-auth.md FR-4: the catalog is the authority; no re-literalled table).
 // --------------------------------------------------------------------------- #
 
-interface CatalogSetting {
-  key: string;
-  type: "boolean";
-  label: string;
-  description?: string;
-  default: boolean;
-  surfaces: AgentAuthSurface[];
-}
-
-const CATALOG_SETTINGS: Record<string, CatalogSetting[]> = {
-  claude: [
-    {
-      key: "chrome",
-      type: "boolean",
-      label: "Use Claude Code with Chrome",
-      description:
-        "Allow Claude Code to control your Chrome browser. Requires the Claude Code Chrome extension.",
-      default: false,
-      surfaces: ["local"],
-    },
-  ],
-};
+type CatalogSetting = CloudAgentCatalogSettingInput;
 
 // --------------------------------------------------------------------------- #
 // Component
@@ -54,10 +36,10 @@ export function HarnessSettingsSection({
   harnessKind,
   surface,
 }: HarnessSettingsSectionProps) {
-  const allSettings = CATALOG_SETTINGS[harnessKind];
-  const settings = allSettings?.filter((s) => s.surfaces.includes(surface));
+  const allSettings = getBundledHarnessCatalogSettings(harnessKind);
+  const settings = allSettings.filter((s) => s.surfaces.includes(surface));
 
-  if (!settings || settings.length === 0) {
+  if (settings.length === 0) {
     return null;
   }
 
@@ -134,7 +116,7 @@ function HarnessSettingRow({
   );
 
   return (
-    <SettingsRow label={setting.label} description={setting.description}>
+    <SettingsRow label={setting.label} description={setting.description ?? undefined}>
       <Switch
         checked={currentValue}
         onChange={handleToggle}

--- a/apps/packages/product-client/src/config/harness-env-vars.ts
+++ b/apps/packages/product-client/src/config/harness-env-vars.ts
@@ -4,18 +4,39 @@
 // agent_gateway/selection_rules.py is the actual source of truth there).
 import { isValidEnvVarName } from "../lib/domain/settings/harness-auth-sources";
 import providerRegistry from "./provider-registry.generated.json";
+import providerDocOverlay from "./provider-doc-overlay.json";
 
 export interface ProviderRegistryEntry {
   id: string;
   displayName: string;
   envVarNames: readonly string[];
   npm?: string;
+  // Featured-tier documentation/console links (PRO-206). The vendored registry
+  // carries no upstream doc URLs, so these come from the hand-curated
+  // provider-doc-overlay.json, merged in as data below. Carried as data only
+  // today; a later rung renders them.
+  docsUrl?: string;
+  consoleUrl?: string;
 }
 
+interface ProviderDocOverlayEntry {
+  docsUrl?: string;
+  consoleUrl?: string;
+}
+
+const PROVIDER_DOC_OVERLAY: Readonly<Record<string, ProviderDocOverlayEntry>> =
+  (providerDocOverlay as { providers?: Record<string, ProviderDocOverlayEntry> }).providers ?? {};
+
 // Re-exported so callers (e.g. the OpenCode "Add provider" modal) don't need
-// to import the generated JSON path directly. Refresh via
-// scripts/vendor-provider-registry.mjs.
-export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = providerRegistry;
+// to import the generated JSON path directly. Refresh the vendored half via
+// scripts/vendor-provider-registry.mjs; the doc-URL overlay is hand-maintained
+// in provider-doc-overlay.json and merged here by provider id.
+export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = (
+  providerRegistry as ProviderRegistryEntry[]
+).map((entry) => {
+  const overlay = PROVIDER_DOC_OVERLAY[entry.id];
+  return overlay ? { ...entry, ...overlay } : entry;
+});
 
 // Which of a provider's env vars actually holds the secret. Registry order is
 // arbitrary and multi-field providers lead with a NON-secret (azure ->

--- a/apps/packages/product-client/src/config/provider-doc-overlay.json
+++ b/apps/packages/product-client/src/config/provider-doc-overlay.json
@@ -1,0 +1,29 @@
+{
+  "note": "Hand-curated documentation and console URLs for the featured provider tier (PRO-206). The vendored provider registry (provider-registry.generated.json) carries no upstream doc URLs, so these are maintained by hand and merged in as data alongside it. Keyed by the models.dev provider id. Rendered by a later rung; carried as data only today.",
+  "providers": {
+    "anthropic": {
+      "docsUrl": "https://docs.anthropic.com/",
+      "consoleUrl": "https://console.anthropic.com/"
+    },
+    "openai": {
+      "docsUrl": "https://platform.openai.com/docs",
+      "consoleUrl": "https://platform.openai.com/api-keys"
+    },
+    "xai": {
+      "docsUrl": "https://docs.x.ai/",
+      "consoleUrl": "https://console.x.ai/"
+    },
+    "amazon-bedrock": {
+      "docsUrl": "https://docs.aws.amazon.com/bedrock/",
+      "consoleUrl": "https://console.aws.amazon.com/bedrock/"
+    },
+    "azure": {
+      "docsUrl": "https://learn.microsoft.com/azure/ai-services/openai/",
+      "consoleUrl": "https://portal.azure.com/"
+    },
+    "google": {
+      "docsUrl": "https://ai.google.dev/gemini-api/docs",
+      "consoleUrl": "https://aistudio.google.com/apikey"
+    }
+  }
+}

--- a/apps/packages/product-client/src/lib/domain/agents/bundled-agent-catalog.ts
+++ b/apps/packages/product-client/src/lib/domain/agents/bundled-agent-catalog.ts
@@ -5,11 +5,30 @@ import {
   projectCloudAgentCatalogToDesktopLaunchCatalog,
   type DesktopAgentLaunchCatalog,
 } from "#product/lib/domain/agents/cloud-launch-catalog";
+import type {
+  CloudAgentCatalogResponseInput,
+  CloudAgentCatalogSettingInput,
+} from "#product/lib/domain/agents/cloud-launch-catalog-types";
+
+const BUNDLED_AGENT_CATALOG: CloudAgentCatalogResponseInput = JSON.parse(bundledAgentCatalogJson);
 
 const BUNDLED_DESKTOP_AGENT_LAUNCH_CATALOG = projectCloudAgentCatalogToDesktopLaunchCatalog(
-  JSON.parse(bundledAgentCatalogJson),
+  BUNDLED_AGENT_CATALOG,
 );
 
 export function getBundledDesktopAgentLaunchCatalog(): DesktopAgentLaunchCatalog {
   return BUNDLED_DESKTOP_AGENT_LAUNCH_CATALOG;
+}
+
+/**
+ * The harness-specific settings catalog.json declares for a harness
+ * (`agents[].settings[]`), read from the bundled copy instead of a
+ * re-literalled table (agent-auth.md FR-4: the catalog is the authority). Empty
+ * for a harness that declares none.
+ */
+export function getBundledHarnessCatalogSettings(
+  harnessKind: string,
+): readonly CloudAgentCatalogSettingInput[] {
+  const agent = BUNDLED_AGENT_CATALOG.agents.find((candidate) => candidate.kind === harnessKind);
+  return agent?.settings ?? [];
 }

--- a/apps/packages/product-client/src/lib/domain/agents/bundled-agent-registry.test.ts
+++ b/apps/packages/product-client/src/lib/domain/agents/bundled-agent-registry.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  getRegistryHarnessKinds,
+  isGatewayCapableHarness,
+  isMultiSourceHarness,
+} from "./bundled-agent-registry";
+
+// Read the repo-root authority document directly (not the bundled copy the
+// module imports) so this asserts the client derivation against the single
+// source of truth (agent-auth.md FR-4). If the bundled copy ever drifts from
+// registry.json, or a derivation rule diverges, this fails.
+interface RegistryAgent {
+  kind: string;
+  authCardinality?: string;
+  auth?: { slots?: { id: string }[] } | null;
+}
+
+const REGISTRY_SOURCE = fileURLToPath(
+  new URL("../../../../../../../catalogs/agents/registry.json", import.meta.url),
+);
+
+const agents: RegistryAgent[] = JSON.parse(readFileSync(REGISTRY_SOURCE, "utf8")).agents;
+
+describe("bundled agent registry mirror", () => {
+  it("harness kinds match registry.json agents[].kind", () => {
+    expect([...getRegistryHarnessKinds()].sort()).toEqual(
+      agents.map((agent) => agent.kind).sort(),
+    );
+  });
+
+  it("gateway-capable derivation matches the registry gateway slot", () => {
+    for (const agent of agents) {
+      const hasGatewaySlot = (agent.auth?.slots ?? []).some((slot) => slot.id === "gateway");
+      expect(isGatewayCapableHarness(agent.kind)).toBe(hasGatewaySlot);
+    }
+    // cursor has no gateway route (agent-auth.md's recipe table).
+    expect(isGatewayCapableHarness("cursor")).toBe(false);
+  });
+
+  it("multi-source derivation matches registry authCardinality", () => {
+    for (const agent of agents) {
+      expect(isMultiSourceHarness(agent.kind)).toBe(agent.authCardinality === "multi");
+    }
+    // opencode is the only multi-source harness today.
+    expect(isMultiSourceHarness("opencode")).toBe(true);
+    expect(isMultiSourceHarness("claude")).toBe(false);
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/agents/bundled-agent-registry.ts
+++ b/apps/packages/product-client/src/lib/domain/agents/bundled-agent-registry.ts
@@ -1,0 +1,59 @@
+// Package-relative copy emitted by scripts/copy-product-client-assets.mjs from
+// the repo-root catalogs/agents/registry.json (gitignored; no checked-in
+// duplicate). registry.json is the single allow-list authority (agent-auth.md
+// FR-4): the harness-kind allow-list, the gateway-capable set, and the
+// single-vs-multi cardinality all derive from it here instead of being
+// re-literalled in the client.
+import bundledAgentRegistryJson from "../../../generated/agent-registry.json?raw";
+
+interface RegistryAuthSlot {
+  id: string;
+}
+
+interface RegistryAgent {
+  kind: string;
+  authCardinality?: "single" | "multi";
+  auth?: { slots?: RegistryAuthSlot[] } | null;
+}
+
+interface RegistryDocument {
+  agents?: RegistryAgent[];
+}
+
+const REGISTRY: RegistryDocument = JSON.parse(bundledAgentRegistryJson);
+
+const AGENTS: readonly RegistryAgent[] = REGISTRY.agents ?? [];
+
+const HARNESS_KINDS: ReadonlySet<string> = new Set(AGENTS.map((agent) => agent.kind));
+
+// Gateway capability is the presence of an auth slot with id "gateway" (cursor
+// has none — no gateway route exists for it). A positive allow-list, so a
+// future harness with no gateway recipe fails closed by default.
+const GATEWAY_CAPABLE_KINDS: ReadonlySet<string> = new Set(
+  AGENTS.filter((agent) => (agent.auth?.slots ?? []).some((slot) => slot.id === "gateway"))
+    .map((agent) => agent.kind),
+);
+
+// Multi-source harnesses (opencode today) keep gateway + any number of api_key
+// rows enabled at once; everything else is single-source (radio). Declared
+// explicitly in the registry because deriving multiplicity from slot count is
+// fragile.
+const MULTI_SOURCE_KINDS: ReadonlySet<string> = new Set(
+  AGENTS.filter((agent) => agent.authCardinality === "multi").map((agent) => agent.kind),
+);
+
+export function getRegistryHarnessKinds(): string[] {
+  return [...HARNESS_KINDS];
+}
+
+export function isRegistryHarnessKind(harnessKind: string): boolean {
+  return HARNESS_KINDS.has(harnessKind);
+}
+
+export function isGatewayCapableHarness(harnessKind: string): boolean {
+  return GATEWAY_CAPABLE_KINDS.has(harnessKind);
+}
+
+export function isMultiSourceHarness(harnessKind: string): boolean {
+  return MULTI_SOURCE_KINDS.has(harnessKind);
+}

--- a/apps/packages/product-client/src/lib/domain/agents/cloud-launch-catalog-types.ts
+++ b/apps/packages/product-client/src/lib/domain/agents/cloud-launch-catalog-types.ts
@@ -176,7 +176,30 @@ export interface CloudAgentCatalogAgentInput {
   harness?: Record<string, unknown> | null;
   authContexts?: CloudAgentCatalogAuthContextInput[];
   session: CloudAgentCatalogSessionInput;
+  settings?: CloudAgentCatalogSettingInput[];
   provenance?: Record<string, unknown> | null;
+}
+
+/**
+ * A harness-specific toggle declared in catalog.json (`agents[].settings[]`).
+ * The settings pane reads these from the bundled catalog copy rather than a
+ * re-literalled table; `mapping` names how the runtime applies the value
+ * (e.g. claude's `--chrome` cli_flag) and is carried through untouched.
+ */
+export interface CloudAgentCatalogSettingInput {
+  key: string;
+  type: "boolean";
+  label: string;
+  description?: string | null;
+  default: boolean;
+  surfaces: ("local" | "cloud")[];
+  mapping?: CloudAgentCatalogSettingMappingInput | null;
+}
+
+export interface CloudAgentCatalogSettingMappingInput {
+  kind: "cli_flag" | "env";
+  flag?: string | null;
+  env?: string | null;
 }
 
 export interface CloudAgentCatalogAuthContextInput {

--- a/apps/packages/product-client/src/lib/domain/settings/harness-auth-sources.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/harness-auth-sources.ts
@@ -3,6 +3,10 @@ import type {
   AgentAuthSource,
   AgentAuthSurface,
 } from "@proliferate/cloud-sdk";
+import {
+  isGatewayCapableHarness as registryIsGatewayCapableHarness,
+  isMultiSourceHarness as registryIsMultiSourceHarness,
+} from "#product/lib/domain/agents/bundled-agent-registry";
 
 // The three auth methods a harness surface can use. Single-source harnesses
 // hold exactly one (radio); multi-source (opencode) may combine gateway +
@@ -18,22 +22,21 @@ export function isValidEnvVarName(name: string): boolean {
 }
 
 // Harnesses that may keep more than one enabled source at once (contract §2).
-// Everything else is single-source (gateway XOR one api_key row).
+// Everything else is single-source (gateway XOR one api_key row). Derived from
+// registry.json's authCardinality (the single allow-list authority, agent-auth.md
+// FR-4) via the bundled registry copy — no re-literalled cursor/opencode set.
 export function isMultiSourceHarness(harnessKind: string): boolean {
-  return harnessKind === "opencode";
+  return registryIsMultiSourceHarness(harnessKind);
 }
 
-// Mirror of the server's GATEWAY_CAPABLE_HARNESSES (selection_rules.py) —
-// a positive allow-list, not a cursor-shaped negative check, so a future
-// harness with no gateway recipe fails closed (omitted here) by default
-// instead of silently inheriting gateway capability. cursor has no gateway
-// recipe (agent-auth.md's per-harness recipe table — "typed refusal, no
-// gateway route exists for cursor"), so it never offers the gateway method
+// The gateway-capable allow-list, derived from registry.json (an auth slot with
+// id "gateway" present) via the bundled registry copy. A positive allow-list,
+// so a future harness with no gateway recipe fails closed by default. cursor has
+// no gateway recipe (agent-auth.md's per-harness recipe table — "typed refusal,
+// no gateway route exists for cursor"), so it never offers the gateway method
 // and never carries a gateway source (see buildDesiredSources).
-const GATEWAY_CAPABLE_HARNESSES = new Set(["claude", "codex", "opencode", "grok"]);
-
 export function isGatewayCapableHarness(harnessKind: string): boolean {
-  return GATEWAY_CAPABLE_HARNESSES.has(harnessKind);
+  return registryIsGatewayCapableHarness(harnessKind);
 }
 
 export interface EditableApiKeyRow {

--- a/catalogs/agents/catalog.json
+++ b/catalogs/agents/catalog.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 2,
-  "catalogVersion": "2026-08-15.1",
+  "catalogVersion": "2026-08-16.1",
   "probedAgainst": {
-    "registryVersion": "2026-08-15.1"
+    "registryVersion": "2026-08-16.1"
   },
   "generatedAt": "2026-07-17T20:49:47.861Z",
   "defaultAgentKind": "claude",

--- a/catalogs/agents/registry.json
+++ b/catalogs/agents/registry.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "registryVersion": "2026-08-15.1",
+  "registryVersion": "2026-08-16.1",
   "generatedAt": "2026-07-17T03:08:00Z",
   "agents": [
     {

--- a/catalogs/agents/registry.json
+++ b/catalogs/agents/registry.json
@@ -5,6 +5,7 @@
   "agents": [
     {
       "kind": "claude",
+      "authCardinality": "single",
       "displayName": "Claude",
       "description": "Claude Code through claude-agent-acp.",
       "native": {
@@ -152,6 +153,7 @@
     },
     {
       "kind": "codex",
+      "authCardinality": "single",
       "displayName": "Codex",
       "description": "OpenAI Codex through codex-acp.",
       "native": {
@@ -285,6 +287,7 @@
     },
     {
       "kind": "cursor",
+      "authCardinality": "single",
       "displayName": "Cursor",
       "description": "Cursor Agent CLI through ACP.",
       "native": null,
@@ -358,6 +361,7 @@
     },
     {
       "kind": "opencode",
+      "authCardinality": "multi",
       "displayName": "OpenCode",
       "description": "OpenCode through its ACP surface.",
       "native": null,
@@ -518,6 +522,7 @@
     },
     {
       "kind": "grok",
+      "authCardinality": "single",
       "displayName": "Grok",
       "description": "xAI's Grok Build coding agent through its native ACP surface.",
       "native": null,

--- a/catalogs/agents/registry.schema.json
+++ b/catalogs/agents/registry.schema.json
@@ -35,6 +35,7 @@
       "type": "object",
       "required": [
         "kind",
+        "authCardinality",
         "displayName",
         "agentProcess",
         "launch",
@@ -50,6 +51,13 @@
             "cursor",
             "opencode",
             "grok"
+          ]
+        },
+        "authCardinality": {
+          "description": "How many auth sources this harness may keep enabled at once. `single` (radio: gateway XOR one api_key row) covers claude/codex/grok/cursor; `multi` (gateway plus any number of api_key rows, composed additively) is opencode-only today. This is the declared authority for the SINGLE_SOURCE/MULTI_SOURCE mirrors; deriving multiplicity from auth.slots length is fragile, so it is stated explicitly.",
+          "enum": [
+            "single",
+            "multi"
           ]
         },
         "displayName": {

--- a/scripts/agent-catalog/catalog.draft.json
+++ b/scripts/agent-catalog/catalog.draft.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 2,
-  "catalogVersion": "2026-08-15.1",
+  "catalogVersion": "2026-08-16.1",
   "probedAgainst": {
-    "registryVersion": "2026-08-15.1"
+    "registryVersion": "2026-08-16.1"
   },
   "generatedAt": "2026-07-17T20:49:47.861Z",
   "defaultAgentKind": "claude",

--- a/scripts/validate-agent-catalog.mjs
+++ b/scripts/validate-agent-catalog.mjs
@@ -280,6 +280,34 @@ function validateRegistryPairing(catalog, registry) {
   }
 }
 
+// registry.json is the declared allow-list authority (agent-auth.md FR-4): the
+// Python/Rust/TS mirrors derive their harness-kind, gateway-capable, and
+// single-vs-multi sets from it. This gate keeps the fields those derivations
+// read well-formed so a bad registry fails here rather than in a mirror drift
+// test with a less obvious message.
+const VALID_AUTH_CARDINALITIES = new Set(["single", "multi"]);
+
+function validateRegistryAuthority(registry) {
+  for (const agent of registry.agents ?? []) {
+    if (!VALID_AUTH_CARDINALITIES.has(agent.authCardinality)) {
+      fail(
+        `registry agent '${agent.kind}' authCardinality '${agent.authCardinality}' `
+        + `must be one of ${[...VALID_AUTH_CARDINALITIES].join(", ")}`,
+      );
+    }
+    // A gateway-capable harness declares a slot with id "gateway"; a
+    // multi-source harness must be gateway-capable (the additive set is
+    // gateway + api_key rows), so a "multi" harness without a gateway slot is
+    // a contradiction the mirrors would silently paper over.
+    const hasGatewaySlot = (agent.auth?.slots ?? []).some((slot) => slot.id === "gateway");
+    if (agent.authCardinality === "multi" && !hasGatewaySlot) {
+      fail(
+        `registry agent '${agent.kind}' is authCardinality 'multi' but declares no gateway slot`,
+      );
+    }
+  }
+}
+
 function versionCore(value) {
   return typeof value === "string"
     ? value.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/)?.[0]
@@ -362,6 +390,7 @@ const catalog = JSON.parse(catalogRaw);
 const registry = JSON.parse(fs.readFileSync(REGISTRY_PATH, "utf8"));
 validateCatalog(catalog);
 validateRegistryPairing(catalog, registry);
+validateRegistryAuthority(registry);
 validateSnapshotEvidence(catalog);
 
 if (errors.length > 0) {

--- a/scripts/validate-agent-catalog.test.mjs
+++ b/scripts/validate-agent-catalog.test.mjs
@@ -57,7 +57,7 @@ function fixture() {
   };
   const registry = {
     registryVersion: "registry.1",
-    agents: [{ kind: "claude" }],
+    agents: [{ kind: "claude", authCardinality: "single" }],
   };
   const snapshot = {
     agentKind: "claude",

--- a/scripts/vendor-provider-registry.mjs
+++ b/scripts/vendor-provider-registry.mjs
@@ -6,7 +6,7 @@
 // (re-run whenever OpenCode-supported providers change upstream; the output
 // below is checked in, there is no build-time fetch).
 
-import { mkdirSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -15,6 +15,11 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 // the desktop host reads it through that package, so this is the only output.
 const productConfigDir = path.join(repoRoot, "apps/packages/product-client/src/config");
 const outputPath = path.join(productConfigDir, "provider-registry.generated.json");
+// Hand-curated documentation/console URLs for the featured provider tier
+// (PRO-206). models.dev does not publish console URLs and its `doc` field is
+// sparse, so this overlay is checked in and merged onto the vendored entries by
+// provider id (overlay wins). No network — it is read from disk.
+const docOverlayPath = path.join(productConfigDir, "provider-doc-overlay.json");
 // Vendored logo marks (models.dev repo is MIT; the marks are kept byte-for-byte
 // in their own currentColor mono form). Consumed via the generated URL map so
 // each mark is a bundler asset in the lazily-loaded picker chunk, never a
@@ -56,11 +61,30 @@ function reduceProviders(raw) {
     if (typeof provider.npm === "string" && provider.npm) {
       entry.npm = provider.npm;
     }
+    // models.dev sometimes carries a `doc` homepage URL upstream; keep it when
+    // present so a regeneration captures it automatically. The hand-curated
+    // overlay (mergeDocOverlay) still wins for the featured tier and adds the
+    // console URLs upstream never provides.
+    if (typeof provider.doc === "string" && provider.doc) {
+      entry.docsUrl = provider.doc;
+    }
     providers.push(entry);
   }
 
   providers.sort((a, b) => a.id.localeCompare(b.id));
   return providers;
+}
+
+// Merge the checked-in doc-URL overlay onto the vendored entries by id (overlay
+// wins). Read from disk, never the network, so the merge is deterministic and
+// reproducible from checked-in inputs alone.
+function mergeDocOverlay(providers) {
+  if (!existsSync(docOverlayPath)) return providers;
+  const overlay = JSON.parse(readFileSync(docOverlayPath, "utf8")).providers ?? {};
+  return providers.map((provider) => {
+    const patch = overlay[provider.id];
+    return patch ? { ...provider, ...patch } : provider;
+  });
 }
 
 // Download one mark per kept provider. A provider with no published logo is
@@ -139,7 +163,7 @@ function writeLogoMap(ids) {
 
 async function main() {
   const raw = await fetchProviders();
-  const providers = reduceProviders(raw);
+  const providers = mergeDocOverlay(reduceProviders(raw));
   mkdirSync(productConfigDir, { recursive: true });
   writeFileSync(outputPath, `${JSON.stringify(providers, null, 2)}\n`);
   console.log(`Wrote ${providers.length} providers to ${path.relative(repoRoot, outputPath)}`);

--- a/server/proliferate/server/catalogs/service.py
+++ b/server/proliferate/server/catalogs/service.py
@@ -75,6 +75,69 @@ def _read_registry_document(path: Path = REGISTRY_PATH) -> dict[str, object]:
     return document
 
 
+def _registry_agents(path: Path = REGISTRY_PATH) -> list[dict[str, object]]:
+    document = _read_registry_document(path)
+    agents = document.get("agents") if isinstance(document, dict) else None
+    if not isinstance(agents, list):
+        return []
+    return [agent for agent in agents if isinstance(agent, dict)]
+
+
+def registry_harness_kinds(*, path: Path = REGISTRY_PATH) -> tuple[str, ...]:
+    """The harness-kind allow-list registry.json declares (agent-auth.md FR-4).
+
+    The declared authority behind ``AGENT_AUTH_HARNESS_KINDS`` — a drift test
+    asserts the hand-tuple equals this derivation, so the constant stays a
+    literal (no store->server import-boundary break) while registry.json remains
+    the single source of truth. Order follows the registry document.
+    """
+    return tuple(
+        agent["kind"]
+        for agent in _registry_agents(path)
+        if isinstance(agent.get("kind"), str)
+    )
+
+
+def registry_gateway_capable_kinds(*, path: Path = REGISTRY_PATH) -> tuple[str, ...]:
+    """Harness kinds whose registry auth block declares a ``gateway`` slot.
+
+    Gateway capability is the presence of an auth slot with id ``gateway``
+    (cursor has none — no gateway route exists for it). The declared authority
+    behind ``AGENT_AUTH_GATEWAY_CAPABLE_HARNESS_KINDS`` and the LiteLLM
+    access-group contract.
+    """
+    kinds: list[str] = []
+    for agent in _registry_agents(path):
+        kind = agent.get("kind")
+        auth = agent.get("auth")
+        slots = auth.get("slots") if isinstance(auth, dict) else None
+        if not isinstance(kind, str) or not isinstance(slots, list):
+            continue
+        if any(isinstance(slot, dict) and slot.get("id") == "gateway" for slot in slots):
+            kinds.append(kind)
+    return tuple(kinds)
+
+
+def registry_single_source_kinds(*, path: Path = REGISTRY_PATH) -> tuple[str, ...]:
+    """Harness kinds registry.json marks ``authCardinality: "single"`` (radio)."""
+    return tuple(
+        agent["kind"]
+        for agent in _registry_agents(path)
+        if isinstance(agent.get("kind"), str)
+        and agent.get("authCardinality") == "single"
+    )
+
+
+def registry_multi_source_kinds(*, path: Path = REGISTRY_PATH) -> tuple[str, ...]:
+    """Harness kinds registry.json marks ``authCardinality: "multi"`` (additive)."""
+    return tuple(
+        agent["kind"]
+        for agent in _registry_agents(path)
+        if isinstance(agent.get("kind"), str)
+        and agent.get("authCardinality") == "multi"
+    )
+
+
 def supported_provider_config_kinds(
     harness_kind: str,
     *,

--- a/server/proliferate/server/catalogs/service.py
+++ b/server/proliferate/server/catalogs/service.py
@@ -92,7 +92,7 @@ def registry_harness_kinds(*, path: Path = REGISTRY_PATH) -> tuple[str, ...]:
     the single source of truth. Order follows the registry document.
     """
     return tuple(
-        agent["kind"] for agent in _registry_agents(path) if isinstance(agent.get("kind"), str)
+        kind for agent in _registry_agents(path) if isinstance(kind := agent.get("kind"), str)
     )
 
 
@@ -119,18 +119,18 @@ def registry_gateway_capable_kinds(*, path: Path = REGISTRY_PATH) -> tuple[str, 
 def registry_single_source_kinds(*, path: Path = REGISTRY_PATH) -> tuple[str, ...]:
     """Harness kinds registry.json marks ``authCardinality: "single"`` (radio)."""
     return tuple(
-        agent["kind"]
+        kind
         for agent in _registry_agents(path)
-        if isinstance(agent.get("kind"), str) and agent.get("authCardinality") == "single"
+        if isinstance(kind := agent.get("kind"), str) and agent.get("authCardinality") == "single"
     )
 
 
 def registry_multi_source_kinds(*, path: Path = REGISTRY_PATH) -> tuple[str, ...]:
     """Harness kinds registry.json marks ``authCardinality: "multi"`` (additive)."""
     return tuple(
-        agent["kind"]
+        kind
         for agent in _registry_agents(path)
-        if isinstance(agent.get("kind"), str) and agent.get("authCardinality") == "multi"
+        if isinstance(kind := agent.get("kind"), str) and agent.get("authCardinality") == "multi"
     )
 
 

--- a/server/proliferate/server/catalogs/service.py
+++ b/server/proliferate/server/catalogs/service.py
@@ -92,9 +92,7 @@ def registry_harness_kinds(*, path: Path = REGISTRY_PATH) -> tuple[str, ...]:
     the single source of truth. Order follows the registry document.
     """
     return tuple(
-        agent["kind"]
-        for agent in _registry_agents(path)
-        if isinstance(agent.get("kind"), str)
+        agent["kind"] for agent in _registry_agents(path) if isinstance(agent.get("kind"), str)
     )
 
 
@@ -123,8 +121,7 @@ def registry_single_source_kinds(*, path: Path = REGISTRY_PATH) -> tuple[str, ..
     return tuple(
         agent["kind"]
         for agent in _registry_agents(path)
-        if isinstance(agent.get("kind"), str)
-        and agent.get("authCardinality") == "single"
+        if isinstance(agent.get("kind"), str) and agent.get("authCardinality") == "single"
     )
 
 
@@ -133,8 +130,7 @@ def registry_multi_source_kinds(*, path: Path = REGISTRY_PATH) -> tuple[str, ...
     return tuple(
         agent["kind"]
         for agent in _registry_agents(path)
-        if isinstance(agent.get("kind"), str)
-        and agent.get("authCardinality") == "multi"
+        if isinstance(agent.get("kind"), str) and agent.get("authCardinality") == "multi"
     )
 
 

--- a/server/tests/unit/test_agent_registry_mirror_drift.py
+++ b/server/tests/unit/test_agent_registry_mirror_drift.py
@@ -32,9 +32,7 @@ def test_harness_kinds_mirror_matches_registry() -> None:
 
 
 def test_gateway_capable_mirror_matches_registry() -> None:
-    assert set(AGENT_AUTH_GATEWAY_CAPABLE_HARNESS_KINDS) == set(
-        registry_gateway_capable_kinds()
-    )
+    assert set(AGENT_AUTH_GATEWAY_CAPABLE_HARNESS_KINDS) == set(registry_gateway_capable_kinds())
 
 
 def test_single_source_mirror_matches_registry() -> None:

--- a/server/tests/unit/test_agent_registry_mirror_drift.py
+++ b/server/tests/unit/test_agent_registry_mirror_drift.py
@@ -1,0 +1,55 @@
+"""Drift guard: the Python allow-list mirrors equal the registry derivation.
+
+registry.json is the single allow-list authority (agent-auth.md FR-4). The
+hand-tuples in constants/agent_gateway.py and selection_rules.py stay literals
+(so constants/ keeps no runtime registry read, and the store->server import
+boundary enforced by check_server_boundaries.py is untouched), but this test
+fails the build the moment a literal and its registry derivation disagree. The
+registry read helpers live in server/catalogs/service.py, next to the existing
+catalog read machinery.
+"""
+
+from __future__ import annotations
+
+from proliferate.constants.agent_gateway import (
+    AGENT_AUTH_GATEWAY_CAPABLE_HARNESS_KINDS,
+    AGENT_AUTH_HARNESS_KINDS,
+)
+from proliferate.server.catalogs.service import (
+    registry_gateway_capable_kinds,
+    registry_harness_kinds,
+    registry_multi_source_kinds,
+    registry_single_source_kinds,
+)
+from proliferate.server.cloud.agent_gateway.selection_rules import (
+    MULTI_SOURCE_HARNESSES,
+    SINGLE_SOURCE_HARNESSES,
+)
+
+
+def test_harness_kinds_mirror_matches_registry() -> None:
+    assert set(AGENT_AUTH_HARNESS_KINDS) == set(registry_harness_kinds())
+
+
+def test_gateway_capable_mirror_matches_registry() -> None:
+    assert set(AGENT_AUTH_GATEWAY_CAPABLE_HARNESS_KINDS) == set(
+        registry_gateway_capable_kinds()
+    )
+
+
+def test_single_source_mirror_matches_registry() -> None:
+    assert set(SINGLE_SOURCE_HARNESSES) == set(registry_single_source_kinds())
+
+
+def test_multi_source_mirror_matches_registry() -> None:
+    assert set(MULTI_SOURCE_HARNESSES) == set(registry_multi_source_kinds())
+
+
+def test_single_and_multi_partition_every_kind() -> None:
+    # Cardinality is total and disjoint: every declared harness is exactly one
+    # of single/multi, so a new registry agent cannot silently escape both
+    # mirrors.
+    single = set(registry_single_source_kinds())
+    multi = set(registry_multi_source_kinds())
+    assert single.isdisjoint(multi)
+    assert single | multi == set(registry_harness_kinds())

--- a/server/tests/unit/test_litellm_config_access_groups.py
+++ b/server/tests/unit/test_litellm_config_access_groups.py
@@ -18,6 +18,7 @@ from typing import Any
 import yaml
 
 from proliferate.constants.agent_gateway import AGENT_AUTH_GATEWAY_CAPABLE_HARNESS_KINDS
+from proliferate.server.catalogs.service import registry_gateway_capable_kinds
 
 _CONFIG_PATH = Path(__file__).resolve().parents[2] / "litellm" / "config.yaml"
 
@@ -67,6 +68,26 @@ class TestLitellmConfigAccessGroups:
             assert _CURSOR_HARNESS_KIND not in access_groups, (
                 f"{entry['model_name']} must not carry the cursor access group"
             )
+
+    def test_gateway_capable_constant_matches_registry_derivation(self) -> None:
+        # registry.json is the allow-list authority (agent-auth.md FR-4): the
+        # access-group check is anchored to the registry gateway derivation,
+        # not just the Python constant, so a config that drifts from the
+        # registry cannot pass by drifting the constant with it.
+        assert set(AGENT_AUTH_GATEWAY_CAPABLE_HARNESS_KINDS) == set(
+            registry_gateway_capable_kinds()
+        )
+
+    def test_yaml_groups_are_a_subset_of_registry_gateway_capable_kinds(self) -> None:
+        registry_capable = set(registry_gateway_capable_kinds())
+        granted: set[str] = set()
+        for entry in _load_model_list():
+            granted.update(entry["model_info"]["access_groups"])
+        unknown = granted - registry_capable
+        assert not unknown, (
+            f"config.yaml grants access group(s) {unknown} that are not "
+            f"gateway-capable in the registry {sorted(registry_capable)}"
+        )
 
     def test_every_supported_harness_has_at_least_one_model(self) -> None:
         # Every gateway-capable harness_kind (AGENT_AUTH_GATEWAY_CAPABLE_HARNESS_KINDS,

--- a/specs/FEATURE_DOCS/AGENT_AUTH.md
+++ b/specs/FEATURE_DOCS/AGENT_AUTH.md
@@ -92,6 +92,35 @@ Selection laws:
   a vault entry; it names an `env_var_name` when that entry is a bare
   key and must not when the entry is typed (the typed kind carries its
   own env mapping) — enforced in the store, since it spans tables.
+
+### Registry is the allow-list authority (FR-4)
+
+[registry.json](../../catalogs/agents/registry.json) is the single
+declared authority for three allow-lists: the harness-kind set, the
+gateway-capable set (a harness is gateway-capable exactly when its
+`auth.slots[]` contains a slot with id `gateway`; cursor has none), and the
+single-vs-multi cardinality (an explicit per-agent `authCardinality` field,
+`single` or `multi`, because deriving multiplicity from slot count is fragile).
+Every other plane mirrors those sets rather than re-deriving them:
+
+- The Python constants (`AGENT_AUTH_HARNESS_KINDS`,
+  `AGENT_AUTH_GATEWAY_CAPABLE_HARNESS_KINDS`,
+  `SINGLE_SOURCE_HARNESSES`, `MULTI_SOURCE_HARNESSES`) stay literals so
+  `constants/` keeps no runtime registry read and the store to server import
+  boundary is untouched, but a drift test
+  ([test_agent_registry_mirror_drift.py](../../server/tests/unit/test_agent_registry_mirror_drift.py))
+  fails CI the moment a literal and its registry derivation disagree. The
+  LiteLLM access-group contract test is anchored to the same registry
+  derivation, not just the Python constant.
+- The Rust `AgentKind` enum stays a type, but
+  [schema_tests.rs](../../anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema_tests.rs)
+  asserts `AgentKind::all()` equals the registry kind set and that the
+  registry gateway-slot derivation matches `render.rs`'s
+  gateway/`UnsupportedRoute` split (cursor is the only non-gateway kind).
+- The TypeScript client derives the same three sets from the bundled registry
+  copy (`bundled-agent-registry.ts`) instead of re-literalling them, and the
+  harness settings pane reads its per-harness toggles from the bundled catalog
+  copy rather than a hand-copied table.
 - **Org policy gates writes, not launches.**
   `PUT …/selections/{harness}` runs every org the user belongs to
   through `_enforce_org_selection_policy`


### PR DESCRIPTION
## Summary

Rung 5 of the Agent Auth ADR ladder (PRO-214, FR-4), stacked on #1935 (rung 4). `catalogs/agents/registry.json` becomes the declared single authority for the harness allow-lists, with every mirror either flipped to read it or pinned by a CI drift test:

- Registry/schema: explicit `authCardinality: single|multi` per agent (opencode is the only multi); gateway-capability stays derived from the presence of a `gateway` auth slot (cursor has none). JS validator gates the new field and a multi-implies-gateway-slot invariant.
- Python: `AGENT_AUTH_HARNESS_KINDS`, `AGENT_AUTH_GATEWAY_CAPABLE_HARNESS_KINDS`, `SINGLE_SOURCE_HARNESSES`, `MULTI_SOURCE_HARNESSES` stay literals (avoids a store->server import-boundary change) but are now pinned to registry derivation helpers by `test_agent_registry_mirror_drift.py`; the LiteLLM YAML access-group contract test is re-anchored to assert constant == registry derivation AND yaml groups subset of it.
- Rust: `AgentKind` stays a type; new drift tests assert `AgentKind::all()` == registry kinds and that the registry gateway-slot derivation matches the render plane's gateway/`UnsupportedRoute` split.
- TypeScript: full flip — new `bundled-agent-registry.ts` derives kinds/gateway-capable/multi-source from the already-bundled generated registry copy; the hand literals in `harness-auth-sources.ts` are deleted; a vitest guard compares the bundled copy against the source `registry.json` (source-vs-mirror, not a tautology).
- PRO-129 drift surface: the hand-copied `CATALOG_SETTINGS` literal in `HarnessSettingsSection.tsx` (which silently dropped the `cli_flag` mapping) is deleted; the pane now reads settings definitions from the bundled catalog. Rendering is byte-identical for the existing chrome toggle; the pane redesign itself is rung 6.
- PRO-206 data groundwork: the vendored provider registry gains a hand-curated `provider-doc-overlay.json` (anthropic, openai, xai, amazon-bedrock, azure, google: docsUrl + consoleUrl), merged deterministically without network; consumed as data only, rendered in rung 6.

## Testing

- `node scripts/validate-agent-catalog.mjs`: `agent catalog OK: 2026-07-17.9 (5 agents)`; validator self-test 4/4.
- vitest: registry/env-vars 13 passed; harness panes + catalog 51 passed. product-client build (incl. tsc) clean.
- pytest (drift + access-group tests): 11 passed. `check_server_boundaries.py`: passed.
- cargo `-p anyharness-lib --lib`: both new drift tests pass; suite `1998 passed; 1 failed` — the one failure is `route_auth::probe_materialization...scratch_roots`, a pre-existing local-environment failure (PID-liveness + mtime backdating) that fails identically on the base branch and passes in CI; verified unrelated to this diff.
- `check_max_lines.py`, `check_docs.py`: passed.

## Observability

No runtime telemetry changes; enforcement is CI drift tests per specs/GENERATED conventions.

## Docs

`specs/FEATURE_DOCS/AGENT_AUTH.md` gains the registry-authority section.

## Notes

- Lint record deferral: the registry-subset/drift rules ship as normal CI tests; their `lints/` rule records follow once PR #1722 (rung 0) merges. No legacy txt-allowlist entries added.
- Reviewer nits accepted as-is: bundled-registry header comment cites the copy script with an imprecise relative path (matches pre-existing sibling); the doc-URL overlay is merged both at vendor time and runtime (idempotent); the multi-implies-gateway validator invariant encodes today's model and would need revisiting for a future multi non-gateway harness.
- Machine note for the reviewer log: local disk pressure forced a non-incremental cargo run; results quoted above are from that run.

## Open founder questions

None.

Stacked on #1935 -> #1925 -> #1916; merge order bottom-up; merges remain Pablo's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)