### PR TITLE
feat(agent-auth): evidence-rendered agent panes and catalog (rung 6)

### DIFF
--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsFilterRow.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsFilterRow.tsx
@@ -1,0 +1,57 @@
+import { Search, X } from "#product/primitives/icons/core";
+import { Button } from "#product/primitives/Button";
+import { Input } from "#product/primitives/Input";
+
+interface HarnessAllModelsFilterRowProps {
+  filterText: string;
+  filteredCount: number;
+  totalCount: number;
+  onChange: (value: string) => void;
+  onClear: () => void;
+}
+
+/**
+ * The All Models filter row (extracted from HarnessAllModelsSection to keep that
+ * file under the frontend size threshold).
+ *
+ * Canonical picker-search treatment (PopoverSearchField recipe): muted magnifier
+ * + borderless transparent input — no boxed field — with a hairline divider
+ * between the row and the table below. py-[7px] matches PopoverSearchField's own
+ * filter-row height exactly, so the two recipes stay pixel-identical rather than
+ * drifting to the nearest space-scale step.
+ */
+export function HarnessAllModelsFilterRow({
+  filterText,
+  filteredCount,
+  totalCount,
+  onChange,
+  onClear,
+}: HarnessAllModelsFilterRowProps) {
+  return (
+    <div className="flex items-center gap-2 border-b border-border px-2.5 py-[7px]">
+      <Search className="icon-paired shrink-0 text-muted-foreground/75" />
+      <Input
+        aria-label="Filter models"
+        placeholder="Filter models..."
+        value={filterText}
+        className="h-auto min-w-0 flex-1 border-0 bg-transparent px-0 py-0 text-ui shadow-none focus:ring-0"
+        onChange={(event) => onChange(event.target.value)}
+      />
+      {filterText ? (
+        <span className="flex shrink-0 items-center gap-1.5 text-ui-sm text-muted-foreground">
+          {filteredCount} of {totalCount}
+          <Button
+            variant="unstyled"
+            size="unstyled"
+            type="button"
+            aria-label="Clear filter"
+            className="rounded p-0.5 hover:bg-hover active:bg-active"
+            onClick={onClear}
+          >
+            <X className="icon-compact" />
+          </Button>
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
@@ -29,6 +29,14 @@ import {
   formatSnapshotAge,
   resolveComposedObservation,
 } from "#product/lib/domain/settings/model-snapshot-observation";
+import { useShallow } from "zustand/react/shallow";
+import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store";
+import {
+  isModelVisibleByPreference,
+  resolveCatalogDefaultOptIn,
+  withUpdatedModelVisibilityOverride,
+} from "#product/lib/domain/chat/models/model-visibility";
+import { isFeatureEnabled } from "#product/config/feature-flags";
 
 interface HarnessAllModelsSectionProps {
   harnessKind: string;
@@ -64,6 +72,18 @@ export function HarnessAllModelsSection({
   const { cloudActive } = useCloudAvailabilityState();
   const showToast = useToastStore((state) => state.show);
   const isLocal = surface === "local";
+
+  // Flag-ON (ADR agent-auth rung 6): model enable/disable is a per-user
+  // per-harness VISIBILITY preference applied at render over the observed list,
+  // on every surface. The picker already reads the same preference
+  // (model-visibility.ts), so hiding here hides everywhere. The flag-ON UI no
+  // longer writes the server agent_catalog_override table (dormant cloud arm;
+  // deletion deferred to a follow-up).
+  const evidenceOn = isFeatureEnabled("agentAuthEvidencePanes");
+  const visibilityOverrides = useUserPreferencesStore(
+    useShallow((state) => state.chatModelVisibilityOverridesByAgentKind),
+  );
+  const setPreference = useUserPreferencesStore((state) => state.set);
 
   // Cloud (machineless) branch: the layered read off the context-free route —
   // one composed observation per (owner, harness), the cloud sandbox's
@@ -128,8 +148,15 @@ export function HarnessAllModelsSection({
     effort: model.effort,
     modes: model.modes,
     fastMode: model.fastMode,
-    enabled: model.enabled,
-    toggleDisabled: isLocal || upsertOverride.isPending,
+    enabled: evidenceOn
+      ? isModelVisibleByPreference(
+          harnessKind,
+          model.id,
+          resolveCatalogDefaultOptIn(),
+          visibilityOverrides,
+        )
+      : model.enabled,
+    toggleDisabled: evidenceOn ? false : isLocal || upsertOverride.isPending,
   }));
 
   if (!isLocal && !cloudActive) {
@@ -160,6 +187,19 @@ export function HarnessAllModelsSection({
   }
 
   function handleToggle(modelId: string, enabled: boolean) {
+    if (evidenceOn) {
+      setPreference(
+        "chatModelVisibilityOverridesByAgentKind",
+        withUpdatedModelVisibilityOverride(
+          visibilityOverrides,
+          harnessKind,
+          modelId,
+          enabled,
+          resolveCatalogDefaultOptIn(),
+        ),
+      );
+      return;
+    }
     if (isLocal) {
       return;
     }

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
@@ -9,12 +9,11 @@ import {
   useModelSnapshotStatusQuery,
   useRefreshModelSnapshotMutation,
 } from "@anyharness/sdk-react";
-import { ChevronRight, Search, X } from "#product/primitives/icons/core";
+import { ChevronRight } from "#product/primitives/icons/core";
 import { RefreshCw } from "#product/primitives/icons/platform";
 import { AnimatedCollapsibleContent } from "#product/primitives/AnimatedCollapsibleContent";
-import { Button } from "#product/primitives/Button";
 import { IconButton } from "#product/primitives/IconButton";
-import { Input } from "#product/primitives/Input";
+import { HarnessAllModelsFilterRow } from "#product/components/settings/panes/agents/harness/HarnessAllModelsFilterRow";
 import { ModelTable, type ModelTableRow } from "#product/components/settings/panes/agents/harness/ModelTable";
 import { HARNESS_PANE_COPY } from "#product/copy/settings/harness-pane";
 import { SettingsSection } from "#product/primitives/patterns/settings/SettingsSection";
@@ -349,37 +348,13 @@ export function HarnessAllModelsSection({
         ) : null}
 
         {rows.length > 0 ? (
-          // Canonical picker-search treatment (PopoverSearchField recipe): muted
-          // magnifier + borderless transparent input — no boxed field — with a
-          // hairline divider between the row and the table below. py-[7px]
-          // matches PopoverSearchField's own filter-row height exactly, so the
-          // two recipes stay pixel-identical rather than drifting to the
-          // nearest space-scale step.
-          <div className="flex items-center gap-2 border-b border-border px-2.5 py-[7px]">
-            <Search className="icon-paired shrink-0 text-muted-foreground/75" />
-            <Input
-              aria-label="Filter models"
-              placeholder="Filter models..."
-              value={filterText}
-              className="h-auto min-w-0 flex-1 border-0 bg-transparent px-0 py-0 text-ui shadow-none focus:ring-0"
-              onChange={(event) => setFilterText(event.target.value)}
-            />
-            {filterText ? (
-              <span className="flex shrink-0 items-center gap-1.5 text-ui-sm text-muted-foreground">
-                {filteredRows.length} of {rows.length}
-                <Button
-                  variant="unstyled"
-                  size="unstyled"
-                  type="button"
-                  aria-label="Clear filter"
-                  className="rounded p-0.5 hover:bg-hover active:bg-active"
-                  onClick={() => setFilterText("")}
-                >
-                  <X className="icon-compact" />
-                </Button>
-              </span>
-            ) : null}
-          </div>
+          <HarnessAllModelsFilterRow
+            filterText={filterText}
+            filteredCount={filteredRows.length}
+            totalCount={rows.length}
+            onChange={setFilterText}
+            onClear={() => setFilterText("")}
+          />
         ) : null}
 
         {isLoading ? (

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthEvidenceBadge.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthEvidenceBadge.test.tsx
@@ -65,6 +65,22 @@ describe("HarnessAuthEvidenceBadge", () => {
     }
   });
 
+  it("renders an unknown future display non-green without crashing", () => {
+    const future = "some_future_state" as AgentAuthDisplay;
+    render(
+      <HarnessAuthEvidenceBadge
+        authState={stateFor(future, { evidenceAgeSeconds: 60 })}
+        refreshing={false}
+        onRefresh={() => {}}
+      />,
+    );
+    const badge = document.querySelector("[data-harness-display]");
+    expect(badge?.getAttribute("data-harness-display")).toBe(future);
+    // Neutral tone, never the success (green) treatment; no faked evidence age.
+    expect((badge?.className ?? "").includes("success")).toBe(false);
+    expect(screen.queryByText(/verified/)).toBeNull();
+  });
+
   it("shows the evidence age on a green badge", () => {
     render(
       <HarnessAuthEvidenceBadge

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthEvidenceBadge.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthEvidenceBadge.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  HarnessAuthEvidenceBadge,
+  HarnessAuthEvidenceSummary,
+} from "#product/components/settings/panes/agents/harness/HarnessAuthEvidenceBadge";
+import type {
+  AgentAuthDisplay,
+  AgentAuthState,
+} from "#product/lib/domain/settings/agent-auth-evidence";
+
+afterEach(cleanup);
+
+function stateFor(
+  display: AgentAuthDisplay,
+  extra: Partial<AgentAuthState> = {},
+): AgentAuthState {
+  return {
+    display,
+    nextAction: "none",
+    facts: {
+      installed: true,
+      expired: false,
+      misconfigured: false,
+      unsupportedRoute: false,
+      probe: { phase: "idle", observationNonempty: false },
+    },
+    ...extra,
+  } as AgentAuthState;
+}
+
+const ALL_DISPLAYS: AgentAuthDisplay[] = [
+  "not_installed",
+  "unsupported",
+  "misconfigured",
+  "expired",
+  "unavailable",
+  "probing",
+  "usable",
+  "authenticated",
+  "selected",
+  "installed",
+];
+
+describe("HarnessAuthEvidenceBadge", () => {
+  it("renders each display's state name and marks green ONLY for usable/authenticated", () => {
+    for (const display of ALL_DISPLAYS) {
+      const { unmount } = render(
+        <HarnessAuthEvidenceBadge
+          authState={stateFor(display)}
+          refreshing={false}
+          onRefresh={() => {}}
+        />,
+      );
+      const badge = document.querySelector("[data-harness-display]");
+      expect(badge?.getAttribute("data-harness-display")).toBe(display);
+      // The success tone is the only green; assert via the Badge's own class.
+      const isGreen = display === "usable" || display === "authenticated";
+      // Badge success tone renders text-success; other tones do not.
+      const html = badge?.className ?? "";
+      expect(html.includes("success")).toBe(isGreen);
+      unmount();
+    }
+  });
+
+  it("shows the evidence age on a green badge", () => {
+    render(
+      <HarnessAuthEvidenceBadge
+        authState={stateFor("usable", { evidenceAgeSeconds: 120 })}
+        refreshing={false}
+        onRefresh={() => {}}
+      />,
+    );
+    expect(screen.getByText("verified 2m ago")).toBeTruthy();
+  });
+
+  it("never shows an evidence age on a non-green badge", () => {
+    render(
+      <HarnessAuthEvidenceBadge
+        authState={stateFor("installed", { evidenceAgeSeconds: 30 })}
+        refreshing={false}
+        onRefresh={() => {}}
+      />,
+    );
+    expect(screen.queryByText(/verified/)).toBeNull();
+  });
+});
+
+describe("HarnessAuthEvidenceSummary", () => {
+  it("renders the next-action affordance", () => {
+    render(
+      <HarnessAuthEvidenceSummary
+        authState={stateFor("installed", { nextAction: "log_in_or_paste_key" })}
+      />,
+    );
+    expect(screen.getByText("Log in or paste a key")).toBeTruthy();
+  });
+
+  it("renders the probe backoff with its next-attempt countdown", () => {
+    const now = Date.parse("2026-08-15T00:00:00Z");
+    render(
+      <HarnessAuthEvidenceSummary
+        now={now}
+        authState={stateFor("probing", {
+          facts: {
+            installed: true,
+            expired: false,
+            misconfigured: false,
+            unsupportedRoute: false,
+            probe: {
+              phase: "backoff",
+              observationNonempty: false,
+              nextAttemptAt: "2026-08-15T00:02:00Z",
+              lastFailureDetail: "429 rate limited",
+            },
+          },
+        } as Partial<AgentAuthState>)}
+      />,
+    );
+    expect(screen.getByText(/Next attempt in 2m/)).toBeTruthy();
+    expect(screen.getByText(/429 rate limited/)).toBeTruthy();
+  });
+
+  it("renders a retry affordance for a cancelled handoff", () => {
+    const onRetry = vi.fn();
+    render(
+      <HarnessAuthEvidenceSummary
+        onRetryHandoff={onRetry}
+        authState={stateFor("installed", {
+          facts: {
+            installed: true,
+            expired: false,
+            misconfigured: false,
+            unsupportedRoute: false,
+            probe: { phase: "idle", observationNonempty: false },
+            handoff: "cancelled",
+          },
+        } as Partial<AgentAuthState>)}
+      />,
+    );
+    expect(screen.getByText("Sign-in cancelled")).toBeTruthy();
+    screen.getByText("Retry").click();
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it("renders nothing extra when the runtime filled no probe/handoff slots", () => {
+    const { container } = render(
+      <HarnessAuthEvidenceSummary authState={stateFor("usable")} />,
+    );
+    // nextAction none + idle probe + null handoff => empty summary wrapper.
+    expect(container.querySelector("[data-harness-probe-phase]")).toBeNull();
+    expect(container.querySelector("[data-harness-handoff]")).toBeNull();
+  });
+});

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthEvidenceBadge.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthEvidenceBadge.tsx
@@ -1,5 +1,6 @@
 import { RefreshCw } from "#product/primitives/icons/platform";
 import { Badge } from "#product/primitives/Badge";
+import { Button } from "#product/primitives/Button";
 import { IconButton } from "#product/primitives/IconButton";
 import {
   evidenceAgeLine,
@@ -137,13 +138,15 @@ export function HarnessAuthEvidenceSummary({
           ) : null}
           {handoff.label}
           {handoff.retryable && onRetryHandoff ? (
-            <button
+            <Button
               type="button"
+              variant="unstyled"
+              size="unstyled"
               className="text-foreground underline underline-offset-2"
               onClick={onRetryHandoff}
             >
               Retry
-            </button>
+            </Button>
           ) : null}
         </p>
       ) : null}

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthEvidenceBadge.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthEvidenceBadge.tsx
@@ -1,0 +1,152 @@
+import { RefreshCw } from "#product/primitives/icons/platform";
+import { Badge } from "#product/primitives/Badge";
+import { IconButton } from "#product/primitives/IconButton";
+import {
+  evidenceAgeLine,
+  labelForDisplay,
+  labelForNextAction,
+  presentHandoff,
+  toneForDisplay,
+  type AgentAuthState,
+} from "#product/lib/domain/settings/agent-auth-evidence";
+
+/**
+ * The evidence-backed status badge (ADR agent-auth rung 6). Renders EXCLUSIVELY
+ * from the runtime's derived `authState`: the display name sets the label and
+ * tone, green (success) is reachable ONLY for `usable`/`authenticated` because
+ * `toneForDisplay` says so and those are the runtime's evidence-backed
+ * terminals, and a green badge carries its evidence age ("verified 2m ago").
+ * There is no local derivation and no readiness fallback — the two behaviors
+ * that produced PRO-252's false greens.
+ */
+export function HarnessAuthEvidenceBadge({
+  authState,
+  refreshing,
+  onRefresh,
+  "data-harness-status": dataHarnessStatus,
+}: {
+  authState: AgentAuthState;
+  refreshing: boolean;
+  onRefresh: () => void;
+  "data-harness-status"?: string;
+}) {
+  const tone = toneForDisplay(authState.display);
+  const ageLine = evidenceAgeLine(authState);
+  return (
+    <>
+      <Badge
+        tone={tone}
+        data-harness-status={dataHarnessStatus}
+        data-harness-display={authState.display}
+      >
+        <span
+          aria-hidden
+          className="icon-status mr-1.5 inline-block shrink-0 rounded-full bg-current"
+        />
+        {labelForDisplay(authState.display)}
+        {ageLine ? (
+          <span className="ml-1.5 font-normal opacity-70">{ageLine}</span>
+        ) : null}
+      </Badge>
+      <IconButton
+        aria-label="Refresh status"
+        title="Refresh status"
+        disabled={refreshing}
+        onClick={onRefresh}
+      >
+        <RefreshCw className={`icon-paired ${refreshing ? "animate-spin" : ""}`} />
+      </IconButton>
+    </>
+  );
+}
+
+/** Coarse remaining-time label until an ISO `nextAttemptAt`, or null if past. */
+function formatCountdown(nextAttemptAt: string, now: number): string | null {
+  const target = Date.parse(nextAttemptAt);
+  if (Number.isNaN(target)) return null;
+  const remaining = Math.round((target - now) / 1000);
+  if (remaining <= 0) return null;
+  if (remaining < 60) return `${remaining}s`;
+  return `${Math.round(remaining / 60)}m`;
+}
+
+/**
+ * The lead the flag-ON pane opens with (ADR agent-auth rung 6): the derived
+ * state said in a sentence plus the single next action, then the probe
+ * lifecycle (probing spinner, backoff with its `next_attempt_at` countdown and
+ * last-failure detail) and the login handoff when present. All read straight
+ * off `authState`; nothing here is re-derived. Shows nothing extra when the
+ * runtime has not filled those slots.
+ */
+export function HarnessAuthEvidenceSummary({
+  authState,
+  now = Date.now(),
+  onRetryHandoff,
+}: {
+  authState: AgentAuthState;
+  now?: number;
+  onRetryHandoff?: () => void;
+}) {
+  const nextAction = labelForNextAction(authState.nextAction);
+  const probe = authState.facts.probe;
+  const handoff = authState.facts.handoff
+    ? presentHandoff(authState.facts.handoff)
+    : null;
+  const countdown =
+    probe.phase === "backoff" && probe.nextAttemptAt
+      ? formatCountdown(probe.nextAttemptAt, now)
+      : null;
+
+  return (
+    <div className="space-y-2 pb-1" data-harness-evidence-summary>
+      {nextAction ? (
+        <p className="text-ui-sm text-muted-foreground">
+          <span className="text-foreground">Next:</span> {nextAction}
+        </p>
+      ) : null}
+
+      {probe.phase === "running" || probe.phase === "queued" ? (
+        <p
+          className="flex items-center gap-2 text-ui-sm text-muted-foreground"
+          data-harness-probe-phase={probe.phase}
+        >
+          <RefreshCw className="icon-paired animate-spin" />
+          {probe.phase === "running" ? "Probing models…" : "Probe queued…"}
+        </p>
+      ) : null}
+
+      {probe.phase === "backoff" ? (
+        <p
+          className="text-ui-sm text-muted-foreground"
+          data-harness-probe-phase="backoff"
+        >
+          {countdown
+            ? `Probe failed. Next attempt in ${countdown}.`
+            : "Probe failed. Retrying shortly."}
+          {probe.lastFailureDetail ? ` ${probe.lastFailureDetail}` : ""}
+        </p>
+      ) : null}
+
+      {handoff ? (
+        <p
+          className="flex items-center gap-2 text-ui-sm text-muted-foreground"
+          data-harness-handoff={authState.facts.handoff ?? undefined}
+        >
+          {handoff.inFlight ? (
+            <RefreshCw className="icon-paired animate-spin" />
+          ) : null}
+          {handoff.label}
+          {handoff.retryable && onRetryHandoff ? (
+            <button
+              type="button"
+              className="text-foreground underline underline-offset-2"
+              onClick={onRetryHandoff}
+            >
+              Retry
+            </button>
+          ) : null}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthSection.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAuthSection.tsx
@@ -19,6 +19,11 @@ import {
   deriveAuthStatus,
   HarnessAuthStatusAction,
 } from "#product/components/settings/panes/agents/harness/HarnessAuthStatusBadge";
+import {
+  HarnessAuthEvidenceBadge,
+  HarnessAuthEvidenceSummary,
+} from "#product/components/settings/panes/agents/harness/HarnessAuthEvidenceBadge";
+import { isFeatureEnabled } from "#product/config/feature-flags";
 
 export type { AuthMethod };
 
@@ -158,13 +163,27 @@ function HarnessAuthMethods({
     : null;
   const cardCount = gatewayCapable ? 3 : 2;
 
+  // Flag-ON path (ADR agent-auth rung 6): render the runtime's DERIVED
+  // authState verbatim — evidence-backed badge + next-action/probe/handoff
+  // lead — instead of the legacy locally-derived status. Falls back to the old
+  // badge only when the flag is off or the runtime carries no derived state.
+  const evidenceOn = isFeatureEnabled("agentAuthEvidencePanes");
+  const authState = evidenceOn ? editor.localAgent?.authState ?? null : null;
+
   return (
     <SettingsSection
       title={HARNESS_PANE_COPY.authenticationTitle}
       description={HARNESS_PANE_COPY.authenticationDescription(displayName, surface)}
       titleWeight="emphasized"
       surface="plain"
-      action={(
+      action={authState ? (
+        <HarnessAuthEvidenceBadge
+          authState={authState}
+          refreshing={refreshing}
+          onRefresh={handleRefresh}
+          data-harness-status={selectedMethod === "cli" ? "native" : selectedMethod}
+        />
+      ) : (
         <HarnessAuthStatusAction
           status={status}
           refreshing={refreshing}
@@ -173,6 +192,7 @@ function HarnessAuthMethods({
         />
       )}
     >
+      {authState ? <HarnessAuthEvidenceSummary authState={authState} /> : null}
       {editor.harnessDisallowed ? (
         <p className="pb-2 text-ui-sm text-muted-foreground">{POLICY_TOOLTIP}.</p>
       ) : null}

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessProvidersSection.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessProvidersSection.tsx
@@ -14,6 +14,11 @@ import {
   deriveProvidersStatus,
   HarnessAuthStatusAction,
 } from "#product/components/settings/panes/agents/harness/HarnessAuthStatusBadge";
+import {
+  HarnessAuthEvidenceBadge,
+  HarnessAuthEvidenceSummary,
+} from "#product/components/settings/panes/agents/harness/HarnessAuthEvidenceBadge";
+import { isFeatureEnabled } from "#product/config/feature-flags";
 
 // Lazy: the modal pulls in the vendored provider-logo asset map (170+ marks),
 // which must never reach the login-path chunk (login JS budget gate,
@@ -86,6 +91,14 @@ export function HarnessProvidersSection({
 
   const status = deriveProvidersStatus();
   const refreshing = editor.apiKeysQuery.isFetching || editor.selectionsQuery.isFetching;
+  // Flag-ON (ADR agent-auth rung 6): opencode's badge reads the runtime's
+  // derived authState, killing deriveProvidersStatus's unconditional green.
+  const evidenceOn = isFeatureEnabled("agentAuthEvidencePanes");
+  const authState = evidenceOn ? editor.localAgent?.authState ?? null : null;
+  function handleRefresh() {
+    void editor.apiKeysQuery.refetch();
+    void editor.selectionsQuery.refetch();
+  }
 
   // §5's two writes: a vault api_key entry, then one selection row whose
   // env_var_name is the provider's key-shaped registry env var and whose
@@ -149,14 +162,18 @@ export function HarnessProvidersSection({
       description={HARNESS_PANE_COPY.providersDescription}
       titleWeight="emphasized"
       surface="plain"
-      action={(
+      action={authState ? (
+        <HarnessAuthEvidenceBadge
+          authState={authState}
+          refreshing={refreshing}
+          onRefresh={handleRefresh}
+          data-harness-status="api_key"
+        />
+      ) : (
         <HarnessAuthStatusAction
           status={status}
           refreshing={refreshing}
-          onRefresh={() => {
-            void editor.apiKeysQuery.refetch();
-            void editor.selectionsQuery.refetch();
-          }}
+          onRefresh={handleRefresh}
           data-harness-status="api_key"
         />
       )}
@@ -164,6 +181,7 @@ export function HarnessProvidersSection({
       data-harness-auth-delivery={editor.deliveryPending ? "pending" : "applied"}
       data-harness-selected-route={selectedRoute}
     >
+      {authState ? <HarnessAuthEvidenceSummary authState={authState} /> : null}
       <div className="space-y-4">
         <div className="flex items-center gap-3">
           {configured.length > 0 ? (

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/ProviderPickerModal.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/ProviderPickerModal.test.tsx
@@ -4,6 +4,12 @@ import type { ReactNode } from "react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ProviderPickerModal } from "#product/components/settings/panes/agents/harness/ProviderPickerModal";
+import { productHostWrapper, makeTestProductHost } from "#product/test/product-host-test-utils";
+
+// ProviderRow reads the host's openExternal for the PRO-206 doc/console links,
+// so these renders need a ProductHostProvider above them.
+const providerModalHost = makeTestProductHost();
+const providerModalWrapper = productHostWrapper(providerModalHost);
 
 // ModalShell wraps Radix Dialog (no jsdom polyfills) — stub to a passthrough
 // that renders its body when open.
@@ -63,6 +69,7 @@ function renderModal(props: Partial<Parameters<typeof ProviderPickerModal>[0]> =
       onRemove={vi.fn()}
       {...props}
     />,
+    { wrapper: providerModalWrapper },
   );
 }
 
@@ -81,7 +88,9 @@ function renderModalControlled(
     onRemove: vi.fn(),
     ...props,
   };
-  const view = render(<ProviderPickerModal {...baseProps} />);
+  const view = render(<ProviderPickerModal {...baseProps} />, {
+    wrapper: providerModalWrapper,
+  });
   return {
     baseProps,
     rerender: (next: Parameters<typeof ProviderPickerModal>[0]) =>

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/ProviderRow.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/ProviderRow.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ProviderRow } from "#product/components/settings/panes/agents/harness/ProviderRow";
+import type { ProviderRegistryEntry } from "#product/config/harness-env-vars";
+import {
+  productHostWrapper,
+  makeTestProductHost,
+} from "#product/test/product-host-test-utils";
+
+afterEach(cleanup);
+
+const anthropic: ProviderRegistryEntry = {
+  id: "anthropic",
+  displayName: "Anthropic",
+  envVarNames: ["ANTHROPIC_API_KEY"],
+  docsUrl: "https://docs.anthropic.com/",
+  consoleUrl: "https://console.anthropic.com/",
+};
+
+const noLinks: ProviderRegistryEntry = {
+  id: "obscure",
+  displayName: "Obscure Cloud",
+  envVarNames: ["OBSCURE_API_KEY"],
+};
+
+function renderRow(provider: ProviderRegistryEntry) {
+  const host = makeTestProductHost();
+  const openExternal = vi.spyOn(host.links, "openExternal").mockResolvedValue();
+  render(
+    <ProviderRow
+      provider={provider}
+      expanded
+      configured={false}
+      redactedHint={null}
+      secret=""
+      submitting={false}
+      error={null}
+      onToggle={() => {}}
+      onSecretChange={() => {}}
+      onConfirm={() => {}}
+      onRemove={() => {}}
+    />,
+    { wrapper: productHostWrapper(host) },
+  );
+  return { openExternal };
+}
+
+describe("ProviderRow doc/console links (PRO-206)", () => {
+  it("renders console and docs links and opens them externally", () => {
+    const { openExternal } = renderRow(anthropic);
+    fireEvent.click(screen.getByText("Get an API key"));
+    expect(openExternal).toHaveBeenCalledWith("https://console.anthropic.com/");
+    fireEvent.click(screen.getByText("Docs"));
+    expect(openExternal).toHaveBeenCalledWith("https://docs.anthropic.com/");
+  });
+
+  it("falls back to plain guidance when the provider has no curated URLs", () => {
+    renderRow(noLinks);
+    expect(screen.getByText("Get an API key")).toBeTruthy();
+    expect(screen.queryByText("Docs")).toBeNull();
+  });
+});

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/ProviderRow.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/ProviderRow.tsx
@@ -1,7 +1,9 @@
 import { ChevronRight } from "#product/primitives/icons/core";
+import { ArrowUpRight } from "#product/primitives/icons/core";
 import { Button } from "#product/primitives/Button";
 import { IconTile } from "#product/primitives/IconTile";
 import { Input } from "#product/primitives/Input";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { HARNESS_PANE_COPY } from "#product/copy/settings/harness-pane";
 import {
   getProviderSecretEnvVar,
@@ -68,6 +70,7 @@ export function ProviderRow({
   onRemove: () => void;
 }) {
   const envVarName = getProviderSecretEnvVar(provider);
+  const { links } = useProductHost();
   return (
     // Disclosure is deferred here (frozen spec §4.3 pattern): the modal keeps
     // only ONE row's form mounted at a time and several tests assert true
@@ -121,11 +124,42 @@ export function ProviderRow({
               </Button>
             </div>
           ) : null}
-          {/* Plain guidance until a per-provider console-URL registry exists —
-              no arrow/link styling on a non-interactive element. */}
-          <p className="text-ui-sm text-muted-foreground">
-            {HARNESS_PANE_COPY.getApiKey}
-          </p>
+          {/* PRO-206: the hand-curated doc/console overlay (rung 5) now carries
+              per-provider links for the featured tier. Render them as external
+              links via the host's openExternal affordance when present; fall
+              back to plain guidance for providers with no curated URLs. */}
+          {provider.consoleUrl || provider.docsUrl ? (
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-ui-sm">
+              {provider.consoleUrl ? (
+                <button
+                  type="button"
+                  className="flex items-center gap-1 text-foreground hover:underline"
+                  onClick={() => {
+                    void links.openExternal(provider.consoleUrl as string);
+                  }}
+                >
+                  {HARNESS_PANE_COPY.providerConsoleLink}
+                  <ArrowUpRight className="icon-compact" />
+                </button>
+              ) : null}
+              {provider.docsUrl ? (
+                <button
+                  type="button"
+                  className="flex items-center gap-1 text-muted-foreground hover:underline"
+                  onClick={() => {
+                    void links.openExternal(provider.docsUrl as string);
+                  }}
+                >
+                  {HARNESS_PANE_COPY.providerDocsLink}
+                  <ArrowUpRight className="icon-compact" />
+                </button>
+              ) : null}
+            </div>
+          ) : (
+            <p className="text-ui-sm text-muted-foreground">
+              {HARNESS_PANE_COPY.getApiKey}
+            </p>
+          )}
           <form
             className="flex items-center gap-2"
             onSubmit={(event) => {

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/ProviderRow.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/ProviderRow.tsx
@@ -131,8 +131,10 @@ export function ProviderRow({
           {provider.consoleUrl || provider.docsUrl ? (
             <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-ui-sm">
               {provider.consoleUrl ? (
-                <button
+                <Button
                   type="button"
+                  variant="unstyled"
+                  size="unstyled"
                   className="flex items-center gap-1 text-foreground hover:underline"
                   onClick={() => {
                     void links.openExternal(provider.consoleUrl as string);
@@ -140,11 +142,13 @@ export function ProviderRow({
                 >
                   {HARNESS_PANE_COPY.providerConsoleLink}
                   <ArrowUpRight className="icon-compact" />
-                </button>
+                </Button>
               ) : null}
               {provider.docsUrl ? (
-                <button
+                <Button
                   type="button"
+                  variant="unstyled"
+                  size="unstyled"
                   className="flex items-center gap-1 text-muted-foreground hover:underline"
                   onClick={() => {
                     void links.openExternal(provider.docsUrl as string);
@@ -152,7 +156,7 @@ export function ProviderRow({
                 >
                   {HARNESS_PANE_COPY.providerDocsLink}
                   <ArrowUpRight className="icon-compact" />
-                </button>
+                </Button>
               ) : null}
             </div>
           ) : (

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/harness-models-visibility.test.ts
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/harness-models-visibility.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  isModelVisibleByPreference,
+  resolveCatalogDefaultOptIn,
+  withUpdatedModelVisibilityOverride,
+} from "#product/lib/domain/chat/models/model-visibility";
+import type { ChatModelVisibilityOverridesByAgentKind } from "#product/lib/domain/preferences/user/session-defaults";
+
+// The exact (harnessKind, modelId) -> hidden application the flag-ON
+// HarnessAllModelsSection routes through instead of writing the server
+// agent_catalog_override table (ADR agent-auth rung 6, FR-4/C16).
+describe("harness models visibility preference", () => {
+  const defaultOptIn = resolveCatalogDefaultOptIn();
+
+  it("shows models by default and hides only those with a false override", () => {
+    let overrides: ChatModelVisibilityOverridesByAgentKind = {};
+    expect(
+      isModelVisibleByPreference("claude", "opus[1m]", defaultOptIn, overrides),
+    ).toBe(true);
+
+    // Toggling a model off writes a per-harness per-model override.
+    overrides = withUpdatedModelVisibilityOverride(
+      overrides,
+      "claude",
+      "opus[1m]",
+      false,
+      defaultOptIn,
+    );
+    expect(overrides).toEqual({ claude: { "opus[1m]": false } });
+    expect(
+      isModelVisibleByPreference("claude", "opus[1m]", defaultOptIn, overrides),
+    ).toBe(false);
+    // A sibling model on the same harness stays visible.
+    expect(
+      isModelVisibleByPreference("claude", "haiku", defaultOptIn, overrides),
+    ).toBe(true);
+  });
+
+  it("re-showing a hidden model drops the override rather than storing true", () => {
+    const overrides = withUpdatedModelVisibilityOverride(
+      { claude: { "opus[1m]": false } },
+      "claude",
+      "opus[1m]",
+      true,
+      defaultOptIn,
+    );
+    expect(overrides).toEqual({});
+  });
+});

--- a/apps/packages/product-client/src/config/feature-flags.ts
+++ b/apps/packages/product-client/src/config/feature-flags.ts
@@ -1,0 +1,47 @@
+// Build-time product feature flags. Each flag defaults OFF and is turned on by
+// a `VITE_*` env value of "1"/"true" at build time. Tests set an in-memory
+// override via `setFeatureFlagOverrideForTests` rather than mutating env.
+//
+// The flags themselves are static per build (env is read once), so there is no
+// runtime toggle surface and no store — a component reads `isFeatureEnabled`
+// directly. When a flag graduates, delete its entry here and the branch that
+// reads it.
+
+export interface FeatureFlags {
+  /**
+   * ADR agent-auth rung 6: render the harness auth panes from the runtime's
+   * derived `authState` (evidence-backed badge, next-action lead, visibility
+   * preferences) instead of the legacy locally-derived badge. OFF leaves the
+   * current panes untouched.
+   */
+  agentAuthEvidencePanes: boolean;
+}
+
+function readEnvFlag(value: string | undefined): boolean {
+  return value === "1" || value === "true";
+}
+
+const DEFAULT_FLAGS: FeatureFlags = {
+  agentAuthEvidencePanes: readEnvFlag(
+    import.meta.env.VITE_AGENT_AUTH_EVIDENCE_PANES,
+  ),
+};
+
+const overrides: Partial<FeatureFlags> = {};
+
+export function isFeatureEnabled(flag: keyof FeatureFlags): boolean {
+  return overrides[flag] ?? DEFAULT_FLAGS[flag];
+}
+
+export function setFeatureFlagOverrideForTests(
+  flag: keyof FeatureFlags,
+  value: boolean,
+): void {
+  overrides[flag] = value;
+}
+
+export function resetFeatureFlagOverridesForTests(): void {
+  for (const key of Object.keys(overrides) as (keyof FeatureFlags)[]) {
+    delete overrides[key];
+  }
+}

--- a/apps/packages/product-client/src/copy/settings/harness-pane.ts
+++ b/apps/packages/product-client/src/copy/settings/harness-pane.ts
@@ -85,6 +85,9 @@ export const HARNESS_PANE_COPY = {
   allModelsFreshRefreshedAgo: (ago: string) =>
     ago === "just now" ? "refreshed just now" : `refreshed ${ago} ago`,
   getApiKey: "Get an API key",
+  // PRO-206 — external links from the curated provider doc/console overlay.
+  providerConsoleLink: "Get an API key",
+  providerDocsLink: "Docs",
   // Method card labels.
   methodGateway: "Proliferate gateway",
   methodGatewayDescription: "Use managed model access.",

--- a/apps/packages/product-client/src/lib/domain/settings/agent-auth-evidence.test.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/agent-auth-evidence.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  evidenceAgeLine,
+  isEvidenceGreen,
+  labelForDisplay,
+  labelForNextAction,
+  presentHandoff,
+  toneForDisplay,
+  type AgentAuthDisplay,
+  type AgentAuthState,
+} from "#product/lib/domain/settings/agent-auth-evidence";
+
+const ALL_DISPLAYS: AgentAuthDisplay[] = [
+  "not_installed",
+  "unsupported",
+  "misconfigured",
+  "expired",
+  "unavailable",
+  "probing",
+  "usable",
+  "authenticated",
+  "selected",
+  "installed",
+];
+
+function stateFor(
+  display: AgentAuthDisplay,
+  extra: Partial<AgentAuthState> = {},
+): AgentAuthState {
+  return {
+    display,
+    nextAction: "none",
+    facts: {
+      installed: true,
+      expired: false,
+      misconfigured: false,
+      unsupportedRoute: false,
+      probe: { phase: "idle", observationNonempty: false },
+    },
+    ...extra,
+  } as AgentAuthState;
+}
+
+describe("agent-auth-evidence", () => {
+  it("marks green ONLY for usable and authenticated", () => {
+    for (const display of ALL_DISPLAYS) {
+      const green = isEvidenceGreen(display);
+      const success = toneForDisplay(display) === "success";
+      expect(green).toBe(display === "usable" || display === "authenticated");
+      expect(success).toBe(green);
+    }
+  });
+
+  it("labels every display value", () => {
+    for (const display of ALL_DISPLAYS) {
+      expect(labelForDisplay(display)).toBeTruthy();
+    }
+  });
+
+  it("shows evidence age only on a green display that carries one", () => {
+    expect(
+      evidenceAgeLine(stateFor("usable", { evidenceAgeSeconds: 120 })),
+    ).toBe("verified 2m ago");
+    expect(
+      evidenceAgeLine(stateFor("authenticated", { evidenceAgeSeconds: 5 })),
+    ).toBe("verified 5s ago");
+    // Green but no age -> no faked freshness.
+    expect(evidenceAgeLine(stateFor("usable"))).toBeNull();
+    // Non-green never shows an age even if one leaked through.
+    expect(
+      evidenceAgeLine(stateFor("installed", { evidenceAgeSeconds: 30 })),
+    ).toBeNull();
+  });
+
+  it("maps each next action to an affordance (none -> null)", () => {
+    expect(labelForNextAction("none")).toBeNull();
+    expect(labelForNextAction("install")).toBe("Install");
+    expect(labelForNextAction("log_in_or_paste_key")).toBe("Log in or paste a key");
+    expect(labelForNextAction("choose_source")).toBe("Choose a source");
+    expect(labelForNextAction("top_up_or_retry")).toBe("Top up or retry");
+    expect(labelForNextAction("wait_for_probe")).toBe("Waiting for probe");
+    expect(labelForNextAction("fix_config")).toBe("Fix configuration");
+  });
+
+  it("presents handoff states with in-flight and retry affordances", () => {
+    expect(presentHandoff("awaiting_browser").inFlight).toBe(true);
+    expect(presentHandoff("initiated").inFlight).toBe(true);
+    expect(presentHandoff("completed").inFlight).toBe(false);
+    expect(presentHandoff("cancelled").retryable).toBe(true);
+    expect(presentHandoff("timed_out").retryable).toBe(true);
+    expect(presentHandoff("completed").retryable).toBe(false);
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/settings/agent-auth-evidence.test.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/agent-auth-evidence.test.ts
@@ -82,6 +82,17 @@ describe("agent-auth-evidence", () => {
     expect(labelForNextAction("fix_config")).toBe("Fix configuration");
   });
 
+  it("treats an unknown future display as non-green with a neutral fallback tone", () => {
+    const future = "some_future_state" as AgentAuthDisplay;
+    expect(isEvidenceGreen(future)).toBe(false);
+    expect(toneForDisplay(future)).toBe("neutral");
+    // A green-only evidence line must not appear for an unknown display even
+    // if it somehow carried an age.
+    expect(
+      evidenceAgeLine(stateFor(future, { evidenceAgeSeconds: 60 })),
+    ).toBeNull();
+  });
+
   it("presents handoff states with in-flight and retry affordances", () => {
     expect(presentHandoff("awaiting_browser").inFlight).toBe(true);
     expect(presentHandoff("initiated").inFlight).toBe(true);

--- a/apps/packages/product-client/src/lib/domain/settings/agent-auth-evidence.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/agent-auth-evidence.ts
@@ -1,0 +1,144 @@
+import type { AgentSummary } from "@anyharness/sdk";
+
+// Presentation of the runtime's DERIVED agent-auth state (agent-auth.md "The
+// canonical evidence model"). Everything here is a projection of the already
+// derived `AgentSummary.authState` — no fact is re-folded, no fallback ladder
+// is consulted. The runtime owns the derivation; the UI only names it.
+
+export type AgentAuthState = NonNullable<AgentSummary["authState"]>;
+export type AgentAuthDisplay = AgentAuthState["display"];
+export type AgentAuthNextAction = AgentAuthState["nextAction"];
+export type AgentAuthHandoff = NonNullable<
+  NonNullable<AgentAuthState["facts"]>["handoff"]
+>;
+export type AgentAuthProbeLifecycle = NonNullable<
+  AgentAuthState["facts"]
+>["probe"];
+
+/**
+ * The two green terminals. Reachable ONLY on dated evidence (agent-auth.md: a
+ * display in {authenticated, usable} names a probe observation, a key-scoped
+ * gateway check, or an acknowledged route, each with a non-null evidence age).
+ * The badge trusts the runtime's derivation rather than re-checking that here —
+ * but the tone table is the one place we assert "green means evidence".
+ */
+export function isEvidenceGreen(display: AgentAuthDisplay): boolean {
+  return display === "usable" || display === "authenticated";
+}
+
+export type AuthEvidenceTone = "success" | "warning" | "destructive" | "neutral";
+
+export function toneForDisplay(display: AgentAuthDisplay): AuthEvidenceTone {
+  switch (display) {
+    case "usable":
+    case "authenticated":
+      return "success";
+    case "misconfigured":
+    case "expired":
+      return "destructive";
+    case "unavailable":
+    case "probing":
+    case "selected":
+      return "warning";
+    case "not_installed":
+    case "unsupported":
+    case "installed":
+      return "neutral";
+  }
+}
+
+export function labelForDisplay(display: AgentAuthDisplay): string {
+  switch (display) {
+    case "not_installed":
+      return "Not installed";
+    case "unsupported":
+      return "Unsupported";
+    case "misconfigured":
+      return "Misconfigured";
+    case "expired":
+      return "Expired";
+    case "unavailable":
+      return "Unavailable";
+    case "probing":
+      return "Probing";
+    case "usable":
+      return "Usable";
+    case "authenticated":
+      return "Authenticated";
+    case "selected":
+      return "Selected";
+    case "installed":
+      return "Installed";
+  }
+}
+
+/** The next-action affordance label, or null when no action is offered. */
+export function labelForNextAction(action: AgentAuthNextAction): string | null {
+  switch (action) {
+    case "none":
+      return null;
+    case "install":
+      return "Install";
+    case "fix_config":
+      return "Fix configuration";
+    case "log_in_or_paste_key":
+      return "Log in or paste a key";
+    case "top_up_or_retry":
+      return "Top up or retry";
+    case "wait":
+      return "Waiting";
+    case "wait_for_probe":
+      return "Waiting for probe";
+    case "choose_source":
+      return "Choose a source";
+  }
+}
+
+/** Coarse relative age ("2m", "3h", "5d") from a whole-second count. */
+export function formatEvidenceAge(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds));
+  if (s < 60) return `${s}s`;
+  const minutes = Math.floor(s / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+/**
+ * The evidence line shown on a green badge, e.g. "verified 2m ago". Returns
+ * null when the display is not green or no evidence age is present — the badge
+ * never fakes freshness it does not hold.
+ */
+export function evidenceAgeLine(state: AgentAuthState): string | null {
+  if (!isEvidenceGreen(state.display)) return null;
+  const age = state.evidenceAgeSeconds;
+  if (age == null) return null;
+  return `verified ${formatEvidenceAge(age)} ago`;
+}
+
+export interface HandoffPresentation {
+  label: string;
+  /** True while the browser round-trip is still open (spinner). */
+  inFlight: boolean;
+  /** True for terminal failures that offer a retry. */
+  retryable: boolean;
+}
+
+export function presentHandoff(
+  handoff: AgentAuthHandoff,
+): HandoffPresentation {
+  switch (handoff) {
+    case "initiated":
+      return { label: "Sign-in started", inFlight: true, retryable: false };
+    case "awaiting_browser":
+      return { label: "Waiting for your browser", inFlight: true, retryable: false };
+    case "completed":
+      return { label: "Sign-in complete", inFlight: false, retryable: false };
+    case "cancelled":
+      return { label: "Sign-in cancelled", inFlight: false, retryable: true };
+    case "timed_out":
+      return { label: "Sign-in timed out", inFlight: false, retryable: true };
+  }
+}

--- a/apps/packages/product-client/src/lib/domain/settings/agent-auth-evidence.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/agent-auth-evidence.ts
@@ -44,6 +44,11 @@ export function toneForDisplay(display: AgentAuthDisplay): AuthEvidenceTone {
     case "unsupported":
     case "installed":
       return "neutral";
+    default:
+      // Forward-compat: an unknown display from a newer runtime is never green.
+      // Keeping this arm neutral (not success) is the invariant a reviewer must
+      // hold if the display union grows.
+      return "neutral";
   }
 }
 

--- a/apps/packages/product-client/src/vite-env.d.ts
+++ b/apps/packages/product-client/src/vite-env.d.ts
@@ -20,6 +20,7 @@ interface ImportMetaEnv {
   readonly VITE_PLAYGROUND_REPLAY_WORKSPACE_PATH?: string;
   readonly VITE_ANYHARNESS_DEV_URL?: string;
   readonly VITE_WORKFLOWS_V2?: string;
+  readonly VITE_AGENT_AUTH_EVIDENCE_PANES?: string;
 }
 
 interface ImportMeta {

--- a/specs/FEATURE_DOCS/AGENT_AUTH.md
+++ b/specs/FEATURE_DOCS/AGENT_AUTH.md
@@ -875,6 +875,38 @@ Rationale: never lie about what was observed, and do not invent a special
 no-probe state for a window that lasts seconds. A pending badge next to
 real data beats an empty pane next to no explanation.
 
+### Evidence panes (rung 6, flag-gated)
+
+The panes above render the runtime's DERIVED `authState` rather than
+re-deriving status in the client, behind the build-time flag
+`agentAuthEvidencePanes` (env `VITE_AGENT_AUTH_EVIDENCE_PANES`, default off).
+With the flag off the legacy locally-derived badge is untouched. With it on:
+
+- **The status badge is the derivation, verbatim.** The badge reads
+  `authState.display` for its label and tone and shows green ONLY for
+  `usable`/`authenticated`, each carrying its evidence age ("verified 2m
+  ago"). There is no local fallback and no readiness-based green, so the
+  false greens the legacy badge produced (opencode's unconditional success,
+  the `readiness === "ready"` fallback, enrollment `synced`) cannot occur.
+- **The pane leads with the next action.** `authState.nextAction` names the
+  one thing to do next (install, log in or paste a key, choose a source, top
+  up or retry, fix config, wait). The probe lifecycle renders inline: a
+  spinner while running or queued, and a backoff line with the
+  `next_attempt_at` countdown and last-failure detail. The login handoff
+  states (`initiated`, `awaiting-browser`, `completed`, `cancelled`,
+  `timed-out`) render from `facts.handoff` when present, with an in-flight
+  indicator and a retry affordance on the terminal failures. Handoff is
+  wired to render from the typed field ahead of the runtime adapters that
+  emit it, so nothing shows until those land.
+
+**Model visibility is a per-user preference.** With the flag on, enabling or
+disabling a model in the pane's model list is a per-user per-harness
+visibility preference keyed `(harnessKind, modelId)`, applied at render over
+the observed list on every surface (the launch picker reads the same
+preference). The flag-on UI no longer writes the server
+`agent_catalog_override` table; that table and its endpoints stay in place
+for the dormant cloud arm and their removal is a follow-up.
+
 ### Open verification items
 
 Cells this document specifies but does not yet claim as verified. Each is a


### PR DESCRIPTION
## Summary

Rung 6 of the Agent Auth ADR ladder (PRO-214), stacked on #1939 (rung 5). Flag-gated UI switch to the FR-1 evidence model: panes render the runtime derivation and never re-derive.

- Feature flag `agentAuthEvidencePanes` (env `VITE_AGENT_AUTH_EVIDENCE_PANES`, default OFF). Flag off = every legacy path byte-preserved.
- PRO-252 false greens killed on the flag-ON path: new `HarnessAuthEvidenceBadge` renders exclusively from `authState` (display, nextAction, evidenceAgeSeconds). Green is reachable only for `usable`/`authenticated` and always shows the evidence age ("verified 2m ago"). The three legacy false-green sources (opencode's unconditional success, the readiness fallback, enrollment syncStatus-as-green) are bypassed; unknown future display values render non-green with a pinned forward-compat test.
- PRO-130 pane refresh: the auth section leads with the derived state + next action (install / log in / paste key / choose source / top up / wait with next-attempt countdown / fix config) and shows the probe lifecycle (running/queued, backoff with `nextAttemptAt` and last failure detail). Existing atoms only; no new glyphs; no ownership border treatments.
- FR-4/C16 visibility toggles: model enable/disable becomes the existing `chatModelVisibilityOverridesByAgentKind` per-user preference applied at render on all surfaces (pane and picker share the store), and the flag-ON UI stops writing `agent_catalog_override`. The dormant server table/endpoints stay; deletion is a noted follow-up.
- PRO-206: opencode provider rows render curated docsUrl/consoleUrl links (rung-5 overlay) through the host `links.openExternal` affordance. Deliberately flag-independent: it is a pure additive link replacing a placeholder; flagged here for review.
- B19: the pane renders `facts.handoff` (initiated / awaiting-browser / completed / cancelled / timed-out) null-safe; the runtime does not emit handoff yet, so this is render-ready ahead of the adapter wire-up.
- PRO-129 verdict: the frontend write/read path is sound after rung 5's bundled-catalog flip (put invalidates both selection and state roots; pane re-reads applied settings). The remaining unverified piece is the runtime's catalog-key to `--chrome` cli_flag mapping at launch (Rust, untouched here).

## Testing

- Targeted vitest: 5 files, 35 tests passed (badge renders every display value with green only for usable/authenticated; next-action mapping; visibility application; doc links; handoff states; unknown-display forward-compat). Full harness pane regression suite: 9 files, 91 tests passed.
- product-client typecheck + build clean (`check-theme: ok`, dist mirrored for desktop).
- `check_docs.py`, `check_design_attribution.py`, `check_max_lines.py`: all passed.

## Observability

None added this rung; the `agent_auth_green_without_evidence_total` counter remains a follow-up alongside the flag-default flip.

## Docs

`specs/FEATURE_DOCS/AGENT_AUTH.md` UI section updated (flag, evidence panes, visibility preference).

## Notes

- Review verdict CLEAN (nits): flag-flip silently ignores previously-set server-side model overrides (no migration; users re-hide via the preference) — see Open founder questions; the handoff Retry affordance is honestly inert until the runtime emits handoff; with an old runtime (no `authState`) the flag-ON path falls back to the legacy badge, so the flag only fully bites against a rung-2+ runtime.
- The backoff countdown is render-static (no ticking timer) by design.

## Open founder questions

- Flag rollout: when `agentAuthEvidencePanes` flips on, previously-set `agent_catalog_override` hides are ignored rather than migrated into the visibility preference. Migration is a small follow-up if you want continuity; the safest reversible choice (no data mutation) was taken here.

Stacked on #1939 -> #1935 -> #1925 -> #1916; merge order bottom-up; merges remain Pablo's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)