### PR TITLE
docs(lints): Update Flow lint records — AH-UPDFLOW launcher promotion + catalog immutability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Check managed Workflow legacy-plane boundary
         run: python3 scripts/check_workflow_managed_boundaries.py
 
+      - name: Check Update Flow lints
+        run: python3 scripts/check_update_flow_lints.py
+
       - name: Check documentation integrity
         run: |
           python3 -m unittest scripts/test_check_docs.py

--- a/lints/anyharness/exceptions.toml
+++ b/lints/anyharness/exceptions.toml
@@ -1068,3 +1068,15 @@ rule = "AH-STORE-4"
 path = "anyharness/crates/anyharness-lib/src/live/workflows/mod.rs"
 site = "mod lifecycle_tests::crate::domains::workspaces::store::WorkspaceStore"
 reason = "the WorkflowManager constructs actors and heals the boot fence from the same three stores the actor uses; same gen-2 ADR ruling and same capability-trait target as actor.rs"
+
+[[exception]]
+rule = "AH-UPDFLOW-001"
+path = "anyharness/crates/anyharness-lib/src/domains/agents/installer/npm.rs"
+site = "install_managed_npm_package::generate_launcher_script"
+reason = "pre-Update-Flow legacy direct write to the live launcher path; the Update Flow ADR rung that moves this call site onto the staged-write-then-activate_launcher promotion (or generate_launcher_script_atomic) is landing on open PRs #1922/#1931/#1940, not yet merged onto this branch"
+
+[[exception]]
+rule = "AH-UPDFLOW-001"
+path = "anyharness/crates/anyharness-lib/src/domains/agents/installer/agent_process.rs"
+site = "regenerate_agent_process_launcher::generate_launcher_script"
+reason = "pre-Update-Flow legacy direct write to the live launcher path; the Update Flow ADR rung that moves this call site onto the staged-write-then-activate_launcher promotion (or generate_launcher_script_atomic) is landing on open PRs #1922/#1931/#1940, not yet merged onto this branch"

--- a/lints/anyharness/exceptions.toml
+++ b/lints/anyharness/exceptions.toml
@@ -1068,15 +1068,3 @@ rule = "AH-STORE-4"
 path = "anyharness/crates/anyharness-lib/src/live/workflows/mod.rs"
 site = "mod lifecycle_tests::crate::domains::workspaces::store::WorkspaceStore"
 reason = "the WorkflowManager constructs actors and heals the boot fence from the same three stores the actor uses; same gen-2 ADR ruling and same capability-trait target as actor.rs"
-
-[[exception]]
-rule = "AH-UPDFLOW-001"
-path = "anyharness/crates/anyharness-lib/src/domains/agents/installer/npm.rs"
-site = "install_managed_npm_package::generate_launcher_script"
-reason = "pre-Update-Flow legacy direct write to the live launcher path; the Update Flow ADR rung that moves this call site onto the staged-write-then-activate_launcher promotion (or generate_launcher_script_atomic) is landing on open PRs #1922/#1931/#1940, not yet merged onto this branch"
-
-[[exception]]
-rule = "AH-UPDFLOW-001"
-path = "anyharness/crates/anyharness-lib/src/domains/agents/installer/agent_process.rs"
-site = "regenerate_agent_process_launcher::generate_launcher_script"
-reason = "pre-Update-Flow legacy direct write to the live launcher path; the Update Flow ADR rung that moves this call site onto the staged-write-then-activate_launcher promotion (or generate_launcher_script_atomic) is landing on open PRs #1922/#1931/#1940, not yet merged onto this branch"

--- a/lints/anyharness/updflow.toml
+++ b/lints/anyharness/updflow.toml
@@ -21,7 +21,7 @@ owner = "anyharness"
 status = "holds"
 enforced_by = "scripts/check_update_flow_lints.py"
 mode = "lint"
-scope = "anyharness/crates/anyharness-lib/src/**"
+scope = "anyharness/crates/**"
 
 rule = """The non-atomic `generate_launcher_script` writer may only be called from inside integrations/agent_cli/launcher.rs itself, or from a call site whose enclosing function also promotes the written file through `ArchiveTreeActivation::activate_launcher` (a staged-write-then-journaled-promote, never a direct live write)."""
 alternative = """Call `generate_launcher_script_atomic`, or write to a staged sibling path and promote it through the same `ArchiveTreeActivation` the surrounding install already uses — never call the bare writer against a live launcher path."""

--- a/lints/anyharness/updflow.toml
+++ b/lints/anyharness/updflow.toml
@@ -1,0 +1,49 @@
+# Update Flow (AH-UPDFLOW) — invariants from the Update Flow ADR
+# implementation (rungs 1-2/5: managed-launcher atomic promotion, the
+# process-lifetime catalog). Family segment reserved per the ID-allocation
+# convention in lints/README.md: `UPDFLOW` mints AH-UPDFLOW-001+, distinct
+# from every other family minting in parallel tonight.
+#
+# Both rules are scoped to the whole anyharness/crates/** tree rather than a
+# single crate: AH-UPDFLOW-002's allowed call sites straddle the
+# anyharness-lib and anyharness crates (AppState construction lives in
+# anyharness-lib, the install-agents command lives in anyharness). If the
+# rungs that introduce the scoped modules have not landed on a given
+# checkout, the checker treats the absent files as vacuously clean — see
+# scripts/check_update_flow_lints.py's module docstring.
+#
+# Enforced by scripts/check_update_flow_lints.py.
+
+[[rule]]
+id = "AH-UPDFLOW-001"
+title = "managed launcher files are never written live"
+owner = "anyharness"
+status = "holds"
+enforced_by = "scripts/check_update_flow_lints.py"
+mode = "lint"
+scope = "anyharness/crates/anyharness-lib/src/**"
+
+rule = """The non-atomic `generate_launcher_script` writer may only be called from inside integrations/agent_cli/launcher.rs itself, or from a call site whose enclosing function also promotes the written file through `ArchiveTreeActivation::activate_launcher` (a staged-write-then-journaled-promote, never a direct live write)."""
+alternative = """Call `generate_launcher_script_atomic`, or write to a staged sibling path and promote it through the same `ArchiveTreeActivation` the surrounding install already uses — never call the bare writer against a live launcher path."""
+why = """A managed launcher a session may be executing right now must never see a non-atomic write land on its live path; Update Flow FR-3/R2.5 requires every regeneration to go through rename-based promotion so a running session keeps its old inode."""
+
+[rule.example]
+bad = """`generate_launcher_script(&live_launcher_path, ..)` called directly against the live path with no promotion step"""
+good = """`generate_launcher_script_atomic(&launcher_path, ..)`, or `generate_launcher_script(&staged, ..)` followed by `activation.activate_launcher(&staged)` in the same function"""
+
+[[rule]]
+id = "AH-UPDFLOW-002"
+title = "the active agent catalog is constructed once per process"
+owner = "anyharness"
+status = "law"
+enforced_by = "scripts/check_update_flow_lints.py"
+mode = "lint"
+scope = "anyharness/crates/**/src/**"
+
+rule = """`CatalogSyncService::from_bundled` / `from_staged_or_bundled` / `from_bundled_and_staged_via_env` may only be called from AppState construction (app/mod.rs), the install-agents command (commands/install_agents.rs), or `#[cfg(test)]` code."""
+alternative = """Take the already-constructed `CatalogSyncService` (or the `AgentCatalogService` built over it) as a dependency instead of constructing a fresh one."""
+why = """The active catalog is immutable for the process lifetime (FR-1, encodes the invariant Pablo's 796ff1f08 deletion reversed); a second construction site is a second, divergent in-memory catalog."""
+
+[rule.example]
+bad = """a domain service calling `CatalogSyncService::from_bundled()` to get "a" catalog instead of taking one"""
+good = """the constructor call stays in app/mod.rs's AppState wiring or commands/install_agents.rs; everything else takes a shared handle"""

--- a/scripts/check_update_flow_lints.py
+++ b/scripts/check_update_flow_lints.py
@@ -74,6 +74,38 @@ def _relative(path: Path) -> str:
     return str(path.relative_to(REPO_ROOT))
 
 
+def _code_portion(line: str) -> str:
+    """The line with `//` comments and string-literal bodies removed.
+
+    Keeps the matchers from firing on prose that merely NAMES a banned call
+    (doc comments, log/format strings). Deliberately naive — no multi-line
+    strings or nested block comments — because rule matches inside those are
+    already adversarial-only, and this checker targets rustfmt-shaped code.
+    """
+    out: list[str] = []
+    in_str = False
+    i = 0
+    while i < len(line):
+        ch = line[i]
+        if in_str:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_str = False
+            i += 1
+            continue
+        if ch == '"':
+            in_str = True
+            i += 1
+            continue
+        if ch == "/" and line[i : i + 2] == "//":
+            break
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
 def _brace_delta(line: str) -> int:
     # Good enough for this repo's formatting: braces inside string/char
     # literals in the lines we care about (fn signatures, call sites) are not
@@ -160,7 +192,7 @@ def check_launcher_writes() -> tuple[list[str], list[str]]:
             continue
         lines = text.splitlines()
         for idx, line in enumerate(lines):
-            if not LAUNCHER_CALL_RE.search(line):
+            if not LAUNCHER_CALL_RE.search(_code_portion(line)):
                 continue
             lineno = idx + 1
             fn_start, fn_end = _enclosing_fn_range(lines, lineno)
@@ -203,7 +235,7 @@ def check_catalog_construction() -> list[str]:
             continue  # whole file is test-only (declared behind #[cfg(test)])
         cfg_test_ranges = _cfg_test_ranges(lines)
         for idx, line in enumerate(lines):
-            match = CATALOG_CTOR_RE.search(line)
+            match = CATALOG_CTOR_RE.search(_code_portion(line))
             if not match:
                 continue
             lineno = idx + 1

--- a/scripts/check_update_flow_lints.py
+++ b/scripts/check_update_flow_lints.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Enforce AH-UPDFLOW-1/2: the Update Flow ADR's mechanical invariants.
+
+The rule statements and rationales are canonical in
+lints/anyharness/updflow.toml (see lints/README.md); this module is only the
+detection engine, and every diagnostic is rendered from the record.
+
+AH-UPDFLOW-001 — the non-atomic `generate_launcher_script` writer must never
+land a launcher file directly on a live path. It is legal (a) inside
+integrations/agent_cli/launcher.rs, where it is the atomic writer's staged
+half, or (b) at any other call site whose *enclosing function* also promotes
+the written file through `ArchiveTreeActivation::activate_launcher` — the
+staged-write-then-journaled-promote pattern used by the npm and pinned
+installers. Anything else is a violation.
+
+AH-UPDFLOW-002 — the catalog-construction constructors may only be called
+from AppState wiring (app/mod.rs), the install-agents command
+(commands/install_agents.rs), or `#[cfg(test)]` code.
+
+Rungs 1-2/5 of the Update Flow ADR implementation had not merged onto every
+checkout this checker might run against when these records were authored.
+Rather than hard-require the scoped modules to exist, every scan below walks
+whatever `.rs` files are actually present under `anyharness/crates/**/src`
+and simply finds zero matches when a referenced module is absent — the
+checker is vacuously clean on such a tree, not skipped and not failing.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import lint_records  # noqa: E402  (path shim must precede the import)
+
+CRATES_ROOT = REPO_ROOT / "anyharness" / "crates"
+
+RULE_001 = "AH-UPDFLOW-001"
+RULE_002 = "AH-UPDFLOW-002"
+
+LAUNCHER_FILE_SUFFIX = "integrations/agent_cli/launcher.rs"
+ALLOWED_CATALOG_CTOR_SUFFIXES = (
+    "anyharness-lib/src/app/mod.rs",
+    "anyharness/src/commands/install_agents.rs",
+)
+
+# The bare (non-atomic) writer, never the `_atomic` variant: the trailing
+# `(` distinguishes `generate_launcher_script(` from
+# `generate_launcher_script_atomic(`.
+LAUNCHER_CALL_RE = re.compile(r"\bgenerate_launcher_script\(")
+ACTIVATE_LAUNCHER_RE = re.compile(r"\bactivate_launcher\(")
+CATALOG_CTOR_RE = re.compile(
+    r"\bCatalogSyncService::"
+    r"(from_bundled|from_staged_or_bundled|from_bundled_and_staged_via_env)\b"
+)
+
+FN_SIGNATURE_RE = re.compile(r"^\s*(pub(\([^)]*\))?\s+)?(async\s+)?fn\s+\w+")
+CFG_TEST_RE = re.compile(r"^\s*#\[cfg\(test\)\]\s*$")
+TEST_FILE_RE = re.compile(r"(^|_)tests\.rs$")
+
+
+def _iter_rs_files():
+    if not CRATES_ROOT.is_dir():
+        return
+    for path in sorted(CRATES_ROOT.rglob("*.rs")):
+        yield path
+
+
+def _relative(path: Path) -> str:
+    return str(path.relative_to(REPO_ROOT))
+
+
+def _brace_delta(line: str) -> int:
+    # Good enough for this repo's formatting: braces inside string/char
+    # literals in the lines we care about (fn signatures, call sites) are not
+    # a real hazard here, so a raw count is fine rather than a real lexer.
+    return line.count("{") - line.count("}")
+
+
+def _enclosing_fn_range(lines: list[str], lineno: int) -> tuple[int, int]:
+    """Return the 1-indexed [start, end] line range of the fn enclosing lineno.
+
+    Falls back to (1, len(lines)) — the whole file — if no `fn` signature is
+    found above, which only widens the search for `activate_launcher(` and
+    therefore never hides a real violation.
+    """
+    start = None
+    for idx in range(lineno - 1, -1, -1):
+        if FN_SIGNATURE_RE.match(lines[idx]):
+            start = idx
+            break
+    if start is None:
+        return 1, len(lines)
+    depth = 0
+    seen_open = False
+    for idx in range(start, len(lines)):
+        depth += _brace_delta(lines[idx])
+        if "{" in lines[idx]:
+            seen_open = True
+        if seen_open and depth <= 0:
+            return start + 1, idx + 1
+    return start + 1, len(lines)
+
+
+def _cfg_test_ranges(lines: list[str]) -> list[tuple[int, int]]:
+    """1-indexed [start, end] ranges of every `#[cfg(test)]`-gated item."""
+    ranges: list[tuple[int, int]] = []
+    idx = 0
+    n = len(lines)
+    while idx < n:
+        if CFG_TEST_RE.match(lines[idx]):
+            item_start = idx + 1
+            while item_start < n and not lines[item_start].strip():
+                item_start += 1
+            if item_start < n:
+                depth = 0
+                seen_open = False
+                end = item_start
+                for j in range(item_start, n):
+                    depth += _brace_delta(lines[j])
+                    if "{" in lines[j]:
+                        seen_open = True
+                    end = j
+                    if seen_open and depth <= 0:
+                        break
+                else:
+                    end = n - 1
+                ranges.append((idx + 1, end + 1))
+                idx = end + 1
+                continue
+        idx += 1
+    return ranges
+
+
+def _line_in_ranges(lineno: int, ranges: list[tuple[int, int]]) -> bool:
+    return any(start <= lineno <= end for start, end in ranges)
+
+
+def _enclosing_fn_name(lines: list[str], fn_start: int) -> str:
+    match = re.search(r"fn\s+(\w+)", lines[fn_start - 1])
+    return match.group(1) if match else "<module>"
+
+
+def check_launcher_writes() -> tuple[list[str], list[str]]:
+    """Return (failures, stale-exception-entries) for AH-UPDFLOW-001."""
+    rule = RULES.rule(RULE_001)
+    ledger = RULES.exception_sites(RULE_001)
+    observed: set[tuple[str, str]] = set()
+    failures: list[str] = []
+    for path in _iter_rs_files():
+        rel = _relative(path)
+        if rel.endswith(LAUNCHER_FILE_SUFFIX):
+            continue
+        text = path.read_text(encoding="utf-8")
+        if "generate_launcher_script(" not in text:
+            continue
+        lines = text.splitlines()
+        for idx, line in enumerate(lines):
+            if not LAUNCHER_CALL_RE.search(line):
+                continue
+            lineno = idx + 1
+            fn_start, fn_end = _enclosing_fn_range(lines, lineno)
+            enclosing_text = "\n".join(lines[fn_start - 1 : fn_end])
+            if ACTIVATE_LAUNCHER_RE.search(enclosing_text):
+                continue  # staged-write-then-promote: legal
+            site = f"{_enclosing_fn_name(lines, fn_start)}::generate_launcher_script"
+            key = (rel, site)
+            observed.add(key)
+            if key in ledger:
+                continue  # grandfathered legacy direct-write site
+            location = f"{rel}:{lineno}"
+            failures.append(
+                lint_records.render_diagnostic(
+                    rule,
+                    location,
+                    detail="generate_launcher_script(..) with no activate_launcher promotion in the enclosing function",
+                )
+            )
+    stale = [
+        f"{path}: [{RULE_001}] site '{site}' no longer violates the rule — "
+        f"delete this entry from lints/anyharness/exceptions.toml"
+        for path, site in sorted(ledger - observed)
+    ]
+    return failures, stale
+
+
+def check_catalog_construction() -> list[str]:
+    rule = RULES.rule(RULE_002)
+    failures: list[str] = []
+    for path in _iter_rs_files():
+        rel = _relative(path)
+        if rel.endswith(ALLOWED_CATALOG_CTOR_SUFFIXES):
+            continue
+        text = path.read_text(encoding="utf-8")
+        if "CatalogSyncService::" not in text:
+            continue
+        lines = text.splitlines()
+        if TEST_FILE_RE.search(path.name):
+            continue  # whole file is test-only (declared behind #[cfg(test)])
+        cfg_test_ranges = _cfg_test_ranges(lines)
+        for idx, line in enumerate(lines):
+            match = CATALOG_CTOR_RE.search(line)
+            if not match:
+                continue
+            lineno = idx + 1
+            if _line_in_ranges(lineno, cfg_test_ranges):
+                continue
+            location = f"{rel}:{lineno}"
+            failures.append(
+                lint_records.render_diagnostic(
+                    rule, location, detail=f"CatalogSyncService::{match.group(1)}(..) outside the allowed construction sites"
+                )
+            )
+    return failures
+
+
+RULES = lint_records.load("anyharness")
+
+
+def main() -> int:
+    launcher_failures, stale = check_launcher_writes()
+    failures = launcher_failures + check_catalog_construction()
+    if failures:
+        print("Update Flow lint violations:")
+        for failure in failures:
+            print(failure)
+            print()
+    if stale:
+        print("Stale AH-UPDFLOW-001 exception entries:")
+        for entry in stale:
+            print(f"  {entry}")
+        print()
+    if failures or stale:
+        return 1
+    print("Update Flow lint check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Update Flow ADR lint records, stacked on `docs-v1/d6-lints` (#1722) per the ladder's rung-0 instruction. Retarget after #1722 merges; never merge before it.

## What changed

- **`AH-UPDFLOW-001` — managed launcher files are never written live** (`status = "holds"`): the non-atomic `generate_launcher_script` writer is legal only inside `launcher.rs` itself or where the enclosing function promotes through `ArchiveTreeActivation::activate_launcher`. Two real pre-Update-Flow violations exist on this branch's tree (`npm.rs::install_managed_npm_package`, `agent_process.rs::regenerate_agent_process_launcher`) — ledgered as exceptions citing PRs #1922/#1931 as the fix in flight, not laundered into a false `law`.
- **`AH-UPDFLOW-002` — the active agent catalog is constructed once per process** (`status = "law"`): `CatalogSyncService` constructors confined to `app/mod.rs`, `commands/install_agents.rs`, and `#[cfg(test)]`. Encodes the FR-1 immutability invariant (preserving 796ff1f08's intent). Zero violations verified.
- **Checker**: `scripts/check_update_flow_lints.py` (loads its rules via `lint_records.py`, brace-scoped enclosing-function analysis for the 001 co-occurrence check, `#[cfg(test)]` range detection for 002, absent scope files = vacuously clean since the rungs land on separate PRs). Wired into the `repo-shape` CI job alongside the other record checkers — no dangling `enforced_by`. No ratchet tables (nothing reads one).
- Family segment `UPDFLOW` reserved per the ID-allocation convention; renumbering at integration is expected if another ladder collides.

## Testing

- `python3 scripts/check_update_flow_lints.py` → `Update Flow lint check passed.` (re-verified by the coordinator post-commit)
- Negative control: synthetic violating call sites injected for BOTH rules were flagged, then removed — the rules detect, they aren't vacuous.
- `python3 scripts/lint_records.py` → `lint records OK — 190 rules (anyharness: 46, ...), 242 exception sites`
- `python3 -m unittest scripts/test_lint_records.py` → `Ran 19 tests ... OK`
- `python3 scripts/check_docs.py` → `Documentation integrity check passed (215 Markdown files).`

## Open founder questions

None — the AH-UPDFLOW-001 exceptions self-retire when #1931 merges (the ledger entries cite it); a follow-up commit on this branch should delete them at that point.
