### PR TITLE
docs(lints): agent-auth rule records, AGENTAUTH ID block, B20 secret-log checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,11 @@ jobs:
           python3 -m unittest scripts/test_check_toast_copy.py
           python3 scripts/check_toast_copy.py
 
+      - name: Check agent-auth secret logs
+        run: |
+          python3 -m unittest scripts/test_check_agent_auth_secret_logs.py
+          python3 scripts/check_agent_auth_secret_logs.py
+
       - name: Check frontend structure drift
         run: python3 scripts/report_frontend_structure.py --strict --summary-only
 

--- a/lints/anyharness/agent_auth.toml
+++ b/lints/anyharness/agent_auth.toml
@@ -1,0 +1,68 @@
+# Agent-auth AnyHarness rules (AH-AGENTAUTH-*). Reserved family segment:
+# AGENTAUTH (see lints/README.md "Rule ID allocation"). The Rust render plane's
+# share of the Agent Auth ADR: FR-4 registry authority on the Rust mirror, and
+# the FR-1 evidence-only-green auth-state invariant.
+
+# FR-4 (2, Rust): the Rust catalog/auth-context projection is derived from the
+# bundled registry, not hand-authored — the registry schema/version and the
+# gateway auth context are asserted against the registry. A real, CI-wired Rust
+# test (`cargo test --workspace`, ci.yml), so the record points at it directly.
+[[rule]]
+id = "AH-AGENTAUTH-001"
+title = "The Rust auth-context projection is derived from the bundled registry"
+owner = "anyharness"
+status = "law"
+enforced_by = "anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema_tests.rs"
+mode = "test"
+scope = "anyharness/crates/anyharness-lib/src/domains/agents/catalog/**, anyharness/crates/anyharness-lib/src/domains/agents/registry/**"
+
+rule = """The Rust auth contexts and their route/gateway signals must be
+projected from the bundled agent registry (registry version and the
+gateway-engaged context are asserted against the registry), never mirrored by
+hand into Rust literals that can drift from `catalogs/agents/registry.json`."""
+alternative = """Change the registry and let the projection follow it; assert
+new auth-context shape against the registry in the catalog schema tests rather
+than pinning a hand-written Rust constant."""
+why = """FR-4 makes the registry the one authority for gateway capability. The
+Rust plane is a consumer, so its auth-context projection is a mirror that must
+stay pinned to the registry or the runtime authorizes routes the authority never
+granted. (Agent Auth ADR FR-4.)"""
+
+[rule.example]
+bad = "a hardcoded Rust list of gateway-capable kinds independent of the registry"
+good = "auth contexts projected from the bundled registry and asserted against it"
+
+# FR-1: an auth source is reported green only with probe evidence. Enforcement
+# is the Rust auth_state invariant unit tests on the FR-1 code ladder. Recorded
+# as intentionally deferred: the record convention's automated enforcers are
+# scripts/ checkers or CI-wired test files present on this branch, and the FR-1
+# auth_state invariant tests are not materialized on this foundation branch. A
+# thin lint-lane wrapper would need the cargo build (too heavy for the lint
+# lane) and would duplicate the invariant divergently, so this is tracked debt.
+[[rule]]
+id = "AH-AGENTAUTH-002"
+title = "An auth source is reported green only with probe evidence"
+owner = "anyharness"
+status = "leaks"
+gap = "#1916"
+enforced_by = "review"
+mode = "review"
+scope = "anyharness/crates/anyharness-lib/src/domains/agents/route_auth/**"
+
+rule = """A rendered auth state must not present a source as verified/green
+optimistically: a green status requires positive probe evidence for that source;
+absent evidence the state is unknown/unverified, never green."""
+alternative = """Gate the green status on a successful probe result; render
+unknown/unverified until evidence lands, and let the status regress to unknown —
+never silently stay green — when evidence is absent."""
+why = """FR-1's evidence-only-green rule keeps the auth surface from claiming a
+credential works before anything proved it does. The invariant is enforced by
+the Rust auth_state unit tests on the FR-1 code ladder; that enforcement is not
+present on this lint-records foundation branch, and a cargo-driven lint-lane
+wrapper is too heavy and would duplicate the invariant, so the gap is tracked
+rather than pretended closed. (Reconcile the gap ref to the FR-1 rung PR at
+integration.)"""
+
+[rule.example]
+bad = "rendering a source green before any probe has confirmed the credential"
+good = "green only after a successful probe; unknown/unverified until then"

--- a/lints/frontend/agent_auth.toml
+++ b/lints/frontend/agent_auth.toml
@@ -1,0 +1,32 @@
+# Agent-auth frontend rules (FE-AGENTAUTH-*). Reserved family segment: AGENTAUTH
+# (see lints/README.md "Rule ID allocation"). The product-client mirror's share
+# of the Agent Auth ADR FR-4 registry-authority invariant.
+
+# FR-4 (2, TS): the product-client's gateway-capable set must not drift from the
+# registry. The vitest mirror-drift guard lands with the FR-4 code ladder; it is
+# not wired on this foundation branch, so the record is honest tracked debt.
+[[rule]]
+id = "FE-AGENTAUTH-001"
+title = "The product-client gateway-capable set mirrors the registry"
+owner = "frontend"
+status = "leaks"
+gap = "#1939"
+enforced_by = "review"
+mode = "review"
+scope = "apps/packages/product-client/src/**"
+
+rule = """The product-client's notion of which harness kinds are gateway-capable
+must be derived from / pinned to the agent registry
+(`catalogs/agents/registry.json`), never a separately hand-maintained TS list
+that can disagree with the authority."""
+alternative = """Source the gateway-capable set from the shared registry-derived
+contract and assert it against the registry in a product-client vitest, rather
+than hardcoding the kinds in the UI."""
+why = """FR-4 makes the registry the one authority with every language binding a
+checked mirror. The TS mirror-drift vitest guard lands with the FR-4 code ladder
+(#1939); until it is wired on this branch the TS mirror is unenforced, so this is
+tracked debt rather than a silent law."""
+
+[rule.example]
+bad = "a TS const GATEWAY_CAPABLE = [\"claude\", ...] maintained independently"
+good = "the gateway-capable set derived from the registry contract under a vitest"

--- a/lints/product/agent_auth.toml
+++ b/lints/product/agent_auth.toml
@@ -1,0 +1,33 @@
+# Agent-auth cross-surface rules (PROD-AGENTAUTH-*). Reserved family segment:
+# AGENTAUTH (see lints/README.md "Rule ID allocation"). This file holds the one
+# rule that spans owners — the secret-log ban covers both the server cloud
+# gateway and the AnyHarness render/snapshot planes, so it lives with the
+# cross-owner records. The B20 custody item from the Agent Auth ADR.
+
+[[rule]]
+id = "PROD-AGENTAUTH-001"
+title = "Agent-auth secrets never reach a log call"
+owner = "product"
+status = "law"
+enforced_by = "scripts/check_agent_auth_secret_logs.py"
+mode = "lint"
+scope = "server/proliferate/server/cloud/agent_gateway/**, anyharness/crates/anyharness-lib/src/domains/agents/route_auth/**, anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/**"
+
+rule = """A structured-log or tracing call in the agent-auth surfaces must not
+contain a live secret identifier — the provider env-var secret names
+(PROLIFERATE_GATEWAY_KEY, ANTHROPIC_AUTH_TOKEN, XAI_API_KEY, CURSOR_API_KEY,
+OPENAI_API_KEY) or the raw secret bindings `virtual_key` and
+`value_ciphertext`."""
+alternative = """Log the opaque handle (`virtual_key_id`), a redacted hint, or a
+boolean presence flag instead of the secret. A reviewed redaction site that must
+name the binding carries an inline `agent-auth:allow-secret-log` pragma inside
+the call."""
+why = """These surfaces move minted gateway keys and decrypted provider
+credentials through their hot paths; a single credential written to a log ships
+to the collector and is leaked irreversibly the moment the line runs. `_id`
+handles and ciphertext references are safe; the raw key and plaintext are not.
+(Agent Auth ADR custody item B20.)"""
+
+[rule.example]
+bad = "logger.info(\"minted gateway key %s\", virtual_key)"
+good = "logger.info(\"minted gateway key %s\", virtual_key_id)"

--- a/lints/product/agent_auth.toml
+++ b/lints/product/agent_auth.toml
@@ -11,22 +11,27 @@ owner = "product"
 status = "law"
 enforced_by = "scripts/check_agent_auth_secret_logs.py"
 mode = "lint"
-scope = "server/proliferate/server/cloud/agent_gateway/**, anyharness/crates/anyharness-lib/src/domains/agents/route_auth/**, anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/**"
+scope = "server/proliferate/server/cloud/agent_gateway/**, server/proliferate/db/store/agent_gateway/**, server/proliferate/db/models/cloud/**, server/proliferate/lib/infra/encryption/**, anyharness/crates/anyharness-lib/src/domains/agents/route_auth/**, anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot/**"
 
 rule = """A structured-log or tracing call in the agent-auth surfaces must not
-contain a live secret identifier — the provider env-var secret names
-(PROLIFERATE_GATEWAY_KEY, ANTHROPIC_AUTH_TOKEN, XAI_API_KEY, CURSOR_API_KEY,
-OPENAI_API_KEY) or the raw secret bindings `virtual_key` and
-`value_ciphertext`."""
-alternative = """Log the opaque handle (`virtual_key_id`), a redacted hint, or a
-boolean presence flag instead of the secret. A reviewed redaction site that must
-name the binding carries an inline `agent-auth:allow-secret-log` pragma inside
-the call."""
+contain a live secret identifier. Three shapes are banned: the provider env-var
+secret names (PROLIFERATE_GATEWAY_KEY, ANTHROPIC_AUTH_TOKEN, XAI_API_KEY,
+CURSOR_API_KEY, OPENAI_API_KEY); the raw secret bindings `virtual_key`,
+`value_ciphertext`, and `api_key`; and attribute access of a secret field —
+`<receiver>.key`, `.token`, or `.api_key` — which is how the minted key actually
+flows (`minted.key`)."""
+alternative = """Log the opaque handle (`virtual_key_id`, `.token_id`), a
+redacted hint, or a boolean presence flag instead of the secret. A reviewed
+redaction site that must name the binding carries an inline
+`agent-auth:allow-secret-log` pragma inside the call."""
 why = """These surfaces move minted gateway keys and decrypted provider
 credentials through their hot paths; a single credential written to a log ships
-to the collector and is leaked irreversibly the moment the line runs. `_id`
-handles and ciphertext references are safe; the raw key and plaintext are not.
-(Agent Auth ADR custody item B20.)"""
+to the collector and is leaked irreversibly the moment the line runs. The check
+is deliberately narrow: `_id`/`.token_id` handles, `virtual_key_ciphertext`
+column names, and `.keys()` iteration stay silent, and bare `token`/`value`
+words are not flagged — only the named secret bindings and the
+`.key`/`.token`/`.api_key` attribute form are. (Agent Auth ADR custody item
+B20.)"""
 
 [rule.example]
 bad = "logger.info(\"minted gateway key %s\", virtual_key)"

--- a/lints/server/agent_auth.toml
+++ b/lints/server/agent_auth.toml
@@ -1,0 +1,65 @@
+# Agent-auth server rules (SRV-AGENTAUTH-*). Reserved family segment: AGENTAUTH
+# (see lints/README.md "Rule ID allocation"). FR-4 registry-authority invariants
+# on the server plane. Enforcement lands with the Agent Auth code ladder; these
+# records are authored on the lint-records foundation and reconcile with it at
+# integration.
+
+# FR-4 (1a): the deployed LiteLLM config's access groups are exactly the
+# gateway-capable harness kinds. A pure static check of a reviewed YAML file, so
+# it is a real, CI-wired test (server-ci.yml runs `pytest tests/unit`), and the
+# record points at that test directly (mode = "test").
+[[rule]]
+id = "SRV-AGENTAUTH-001"
+title = "LiteLLM config access groups are exactly the gateway-capable harness kinds"
+owner = "server"
+status = "law"
+enforced_by = "server/tests/unit/test_litellm_config_access_groups.py"
+mode = "test"
+scope = "server/litellm/config.yaml"
+
+rule = """Every `model_list` entry in `server/litellm/config.yaml` must carry a
+`model_info.access_groups` list whose names are exactly harness_kind identifiers
+drawn from `AGENT_AUTH_GATEWAY_CAPABLE_HARNESS_KINDS`; `cursor` — which has no
+gateway recipe — must never appear in any entry's access groups."""
+alternative = """Name the access group with the harness_kind that owns the
+gateway route, and leave native-only harnesses (cursor) out of the config's
+access groups entirely."""
+why = """The one deployed config is the authority for which harness may reach
+which model through the gateway. An access group that is not a gateway-capable
+kind, or a cursor group, grants a route the registry says does not exist. (Agent
+Auth ADR FR-4, agents-impl-plan.md §4 B1.)"""
+
+[rule.example]
+bad = "a config.yaml model_list entry with access_groups = [\"cursor\"]"
+good = "access_groups naming only claude/codex/opencode/grok, per the constant"
+
+# FR-4 (1b): the Python gateway-capable constant is the registry's derivation,
+# not an independent hand-maintained list. The cross-source drift guard
+# (test_agent_registry_mirror_drift.py) lands with the FR-4 code ladder; on this
+# foundation branch there is no checker for it, so the record is honest debt.
+[[rule]]
+id = "SRV-AGENTAUTH-002"
+title = "The Python gateway-capable constant is the registry's derivation"
+owner = "server"
+status = "leaks"
+gap = "#1939"
+enforced_by = "review"
+mode = "review"
+scope = "server/proliferate/constants/agent_gateway.py, catalogs/agents/registry.json"
+
+rule = """`AGENT_AUTH_GATEWAY_CAPABLE_HARNESS_KINDS` must equal the set of
+gateway-capable harness kinds derived from the agent registry
+(`catalogs/agents/registry.json`), not a separately edited list — the registry
+is the single authority and the Python constant is its mirror."""
+alternative = """When a harness gains or loses a gateway recipe, change the
+registry; regenerate/verify the Python mirror against it rather than editing the
+constant by hand."""
+why = """FR-4 makes the registry the one authority for gateway capability, with
+every language binding a checked mirror. The drift guard that asserts the Python
+mirror against the registry derivation lands with the FR-4 code ladder (#1939);
+until it is wired on this branch the invariant is unenforced, so this is tracked
+debt rather than a silent law."""
+
+[rule.example]
+bad = "editing AGENT_AUTH_GATEWAY_CAPABLE_HARNESS_KINDS without touching the registry"
+good = "the registry declares gateway capability; the constant mirrors it under a drift test"

--- a/scripts/check_agent_auth_secret_logs.py
+++ b/scripts/check_agent_auth_secret_logs.py
@@ -37,7 +37,10 @@ one:
     keyword args. Bare ``token``/``value`` words are deliberately NOT matched —
     they are far too common (``value.keys()``, plain ``token`` counters) to flag
     without absurd noise; only the attribute form and the ``value_ciphertext``
-    binding are caught.
+    binding are caught. As a lexical guard it also stays silent on
+    non-idiomatic forms (``minted["key"]`` subscripts, ``getattr(minted,
+    "key")``, spaced or line-split attribute access); none appear in the real
+    code, and review remains the backstop for those shapes.
 
 An intentional, reviewed redaction site marks itself with an inline pragma
 ``agent-auth:allow-secret-log`` inside the call; that one call is exempt. The

--- a/scripts/check_agent_auth_secret_logs.py
+++ b/scripts/check_agent_auth_secret_logs.py
@@ -20,7 +20,24 @@ one:
     ``CURSOR_API_KEY``, ``OPENAI_API_KEY``) — logging the name is how the value
     next to it slips in;
   - the raw secret variable names ``virtual_key`` (the minted key itself, as
-    opposed to the safe ``virtual_key_id`` handle) and ``value_ciphertext``.
+    opposed to the safe ``virtual_key_id`` handle), ``value_ciphertext``, and the
+    bare ``api_key`` binding;
+  - ATTRIBUTE ACCESS of a secret field — ``<receiver>.key`` / ``.token`` /
+    ``.api_key`` — because the live minted key actually flows as
+    ``minted.key`` (``MintedVirtualKey``), not through a ``virtual_key`` local.
+    A word-boundary at the tail keeps this narrow and free of the obvious
+    false positives: ``.keys()`` iteration is NOT ``.key`` (the ``s`` blocks the
+    boundary), and the safe ``.token_id`` handle is NOT ``.token`` (the ``_``
+    blocks the boundary), exactly as ``virtual_key_id`` is safe from
+    ``virtual_key``. An audit of every ``.key``/``.token``/``.api_key`` access and
+    every log call under the scanned roots on both this branch and the live
+    ``r4-gateway-verification`` gateway code found ZERO legitimate secret-field
+    attribute access inside a log call, so no receiver-name allowlist is needed;
+    the only real ``minted.key`` sites are non-log ``upsert_enrollment_key``
+    keyword args. Bare ``token``/``value`` words are deliberately NOT matched —
+    they are far too common (``value.keys()``, plain ``token`` counters) to flag
+    without absurd noise; only the attribute form and the ``value_ciphertext``
+    binding are caught.
 
 An intentional, reviewed redaction site marks itself with an inline pragma
 ``agent-auth:allow-secret-log`` inside the call; that one call is exempt. The
@@ -51,9 +68,14 @@ OWNED_RULE_IDS = frozenset(
     rule.id for rule in RULES.rules.values() if rule.enforced_by == CHECKER
 )
 
-# (root, suffixes) — Python cloud gateway surface, Rust render + snapshot planes.
+# (root, suffixes) — Python cloud gateway surface, the ciphertext/plaintext
+# custody planes (store + models + encryption, where ``value_ciphertext`` and
+# the decrypt paths actually live), and the Rust render + snapshot planes.
 SCANNED_ROOTS: list[tuple[str, frozenset[str]]] = [
     ("server/proliferate/server/cloud/agent_gateway", frozenset({".py"})),
+    ("server/proliferate/db/store/agent_gateway", frozenset({".py"})),
+    ("server/proliferate/db/models/cloud", frozenset({".py"})),
+    ("server/proliferate/lib/infra/encryption", frozenset({".py"})),
     (
         "anyharness/crates/anyharness-lib/src/domains/agents/route_auth",
         frozenset({".rs"}),
@@ -77,7 +99,9 @@ LOG_OPENER = re.compile(
 
 # The secret identifiers. `virtual_key_id` is a safe opaque handle, so the raw
 # `virtual_key` is matched on a word boundary alone — the boundary cannot fall
-# between `key` and `_id`, so the handle is never a hit.
+# between `key` and `_id`, so the handle is never a hit. The attribute form
+# `<receiver>.(key|token|api_key)` catches the live `minted.key` flow; the tail
+# `\b` keeps `.keys()` (the `s`) and the safe `.token_id` handle (the `_`) out.
 SECRET_IDENTIFIER = re.compile(
     r"(?:"
     r"PROLIFERATE_GATEWAY_KEY"
@@ -87,6 +111,8 @@ SECRET_IDENTIFIER = re.compile(
     r"|OPENAI_API_KEY"
     r"|\bvalue_ciphertext\b"
     r"|\bvirtual_key\b"
+    r"|\bapi_key\b"
+    r"|\b\w+\.(?:key|token|api_key)\b"
     r")"
 )
 

--- a/scripts/check_agent_auth_secret_logs.py
+++ b/scripts/check_agent_auth_secret_logs.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+
+"""Keep agent-auth secrets out of structured-log call sites.
+
+The agent-auth surfaces move real provider secrets and minted gateway keys
+through their hot paths: the cloud enrollment/migration/topup flows in
+``server/proliferate/server/cloud/agent_gateway`` and the AnyHarness render and
+model-snapshot planes under ``route_auth`` / ``model_snapshot``. A single
+``logger.info("minted %s", virtual_key)`` or ``tracing::warn!(%value_ciphertext,
+...)`` writes a live credential into logs that ship to a collector — an
+irreversible leak the moment it runs.
+
+This guard makes that shape unwritable. It reads every logging / tracing call
+site in those surfaces (not all code — only the log call, extracted by balanced
+parentheses) and fails on any of the known secret identifiers appearing inside
+one:
+
+  - the provider env-var secret NAMES a rendered source binds
+    (``PROLIFERATE_GATEWAY_KEY``, ``ANTHROPIC_AUTH_TOKEN``, ``XAI_API_KEY``,
+    ``CURSOR_API_KEY``, ``OPENAI_API_KEY``) — logging the name is how the value
+    next to it slips in;
+  - the raw secret variable names ``virtual_key`` (the minted key itself, as
+    opposed to the safe ``virtual_key_id`` handle) and ``value_ciphertext``.
+
+An intentional, reviewed redaction site marks itself with an inline pragma
+``agent-auth:allow-secret-log`` inside the call; that one call is exempt. The
+rule is ``PROD-AGENTAUTH-001``; the record under
+``lints/product/agent_auth.toml`` is canonical and every diagnostic is rendered
+from it via ``scripts/lint_records.py``.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    # Run as `python3 scripts/check_agent_auth_secret_logs.py` from the repo
+    # root; sys.path[0] is scripts/, and the shared loader lives one level up.
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import lint_records  # noqa: E402  (path shim must precede the import)
+
+CHECKER = "scripts/check_agent_auth_secret_logs.py"
+RULE_ID = "PROD-AGENTAUTH-001"
+RULES = lint_records.load("product")
+OWNED_RULE_IDS = frozenset(
+    rule.id for rule in RULES.rules.values() if rule.enforced_by == CHECKER
+)
+
+# (root, suffixes) — Python cloud gateway surface, Rust render + snapshot planes.
+SCANNED_ROOTS: list[tuple[str, frozenset[str]]] = [
+    ("server/proliferate/server/cloud/agent_gateway", frozenset({".py"})),
+    (
+        "anyharness/crates/anyharness-lib/src/domains/agents/route_auth",
+        frozenset({".rs"}),
+    ),
+    (
+        "anyharness/crates/anyharness-lib/src/domains/agents/model_snapshot",
+        frozenset({".rs"}),
+    ),
+]
+
+SKIPPED_DIR_NAMES = {"node_modules", "dist", "build", "target", "__pycache__"}
+
+# The log-call openers, each ending at the opening paren. Python's `logger.info(`
+# family, and Rust's `tracing::warn!(` plus the bare `warn!(` re-exported macro.
+LOG_OPENER = re.compile(
+    r"(?:"
+    r"\b(?:log|logger|logging)\.(?:debug|info|warning|warn|error|exception|critical|log)\s*\("
+    r"|(?:tracing::)?(?:debug|info|warn|error|trace)!\s*\("
+    r")"
+)
+
+# The secret identifiers. `virtual_key_id` is a safe opaque handle, so the raw
+# `virtual_key` is matched on a word boundary alone — the boundary cannot fall
+# between `key` and `_id`, so the handle is never a hit.
+SECRET_IDENTIFIER = re.compile(
+    r"(?:"
+    r"PROLIFERATE_GATEWAY_KEY"
+    r"|ANTHROPIC_AUTH_TOKEN"
+    r"|XAI_API_KEY"
+    r"|CURSOR_API_KEY"
+    r"|OPENAI_API_KEY"
+    r"|\bvalue_ciphertext\b"
+    r"|\bvirtual_key\b"
+    r")"
+)
+
+# A reviewed redaction site opts out by carrying this marker inside the call.
+ALLOW_PRAGMA = "agent-auth:allow-secret-log"
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One secret-in-log violation, reported through its record."""
+
+    lineno: int
+    identifier: str
+    snippet: str
+    path: Path | None = None
+
+    @property
+    def relative_path(self) -> str:
+        if self.path is None:
+            return "<unknown>"
+        try:
+            return str(self.path.relative_to(REPO_ROOT))
+        except ValueError:
+            return str(self.path)
+
+    def format(self) -> str:
+        return lint_records.render_diagnostic(
+            RULES.rule(RULE_ID),
+            f"{self.relative_path}:{self.lineno}",
+            f"secret identifier {self.identifier!r} inside a log call: {self.snippet!r}",
+        )
+
+
+def _call_span(text: str, open_paren: int) -> tuple[int, str]:
+    """Return (end_index, call_text) for the balanced parens from `open_paren`.
+
+    `open_paren` indexes the `(`. Scans forward counting parens so a nested
+    call — an f-string with `redact(key)` in it — does not truncate the span.
+    String literals are honored so a `)` inside a quoted message never closes
+    the call early. Returns the index just past the matching `)`.
+    """
+    depth = 0
+    quote: str | None = None
+    i = open_paren
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if quote is not None:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+        elif ch in "\"'`":
+            quote = ch
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return i + 1, text[open_paren : i + 1]
+        i += 1
+    # Unbalanced (truncated file / macro); take the rest so a real hit inside is
+    # still seen rather than silently dropped.
+    return n, text[open_paren:n]
+
+
+def scan_file(path: Path) -> list[Finding]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return []
+
+    findings: list[Finding] = []
+    for opener in LOG_OPENER.finditer(text):
+        open_paren = opener.end() - 1
+        end, call_text = _call_span(text, open_paren)
+        # The reviewed-site pragma may sit inside the call or in a trailing
+        # comment on the line the call closes on, so widen the exempt window to
+        # the end of that closing line.
+        line_end = text.find("\n", end)
+        pragma_region = call_text + (text[end : line_end if line_end != -1 else len(text)])
+        if ALLOW_PRAGMA in pragma_region:
+            continue
+        secret = SECRET_IDENTIFIER.search(call_text)
+        if secret is None:
+            continue
+        lineno = text.count("\n", 0, opener.start()) + 1
+        snippet = " ".join(call_text.split())
+        if len(snippet) > 160:
+            snippet = snippet[:157] + "..."
+        findings.append(Finding(lineno, secret.group(0), snippet, path))
+    return sorted(findings, key=lambda finding: finding.lineno)
+
+
+def iter_source_files() -> list[Path]:
+    files: list[Path] = []
+    for root, suffixes in SCANNED_ROOTS:
+        base = REPO_ROOT / root
+        if not base.exists():
+            continue
+        for path in base.rglob("*"):
+            if path.suffix not in suffixes or not path.is_file():
+                continue
+            if any(part in SKIPPED_DIR_NAMES for part in path.parts):
+                continue
+            files.append(path)
+    return files
+
+
+def main() -> int:
+    violations: list[Finding] = []
+    for path in sorted(iter_source_files()):
+        violations.extend(scan_file(path))
+
+    if not violations:
+        print("Agent-auth secret-log check passed.")
+        return 0
+
+    print("A live agent-auth secret must never reach a log call:")
+    for violation in violations:
+        print(violation.format())
+        print()
+    print(
+        "\nLog the opaque handle (virtual_key_id), a redacted hint, or a boolean —"
+        "\nnever the minted key, the ciphertext, or a provider secret env var. A"
+        "\nreviewed redaction site may carry an inline `agent-auth:allow-secret-log`."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_check_agent_auth_secret_logs.py
+++ b/scripts/test_check_agent_auth_secret_logs.py
@@ -69,6 +69,20 @@ class SecretInLogRejected(unittest.TestCase):
     def test_rust_bare_macro(self) -> None:
         self.assertTrue(hit('error!("leaked {}", value_ciphertext);', suffix=".rs"))
 
+    def test_minted_key_attribute_access(self) -> None:
+        # The live secret flows as `minted.key` (MintedVirtualKey), not a
+        # `virtual_key` local — the checker must catch the attribute form.
+        self.assertTrue(hit('logger.info("minted gateway key %s", minted.key)'))
+
+    def test_secret_attribute_in_extra_dict(self) -> None:
+        self.assertTrue(hit('logger.info("done", extra={"vkey": minted.key})'))
+
+    def test_bare_api_key_binding(self) -> None:
+        self.assertTrue(hit('logger.info("provider api_key=%s", api_key)'))
+
+    def test_token_attribute_access(self) -> None:
+        self.assertTrue(hit('logger.info("delivering %s", credential.token)'))
+
 
 class SafeSitesAccepted(unittest.TestCase):
     def test_opaque_handle_is_safe(self) -> None:
@@ -88,6 +102,19 @@ class SafeSitesAccepted(unittest.TestCase):
     def test_paren_inside_string_does_not_truncate_the_call(self) -> None:
         # The `)` in the message must not close the call before the secret arg.
         self.assertTrue(hit('logger.info("done (ok) %s", virtual_key)'))
+
+    def test_keys_iteration_is_not_key_attribute(self) -> None:
+        # `.keys()` is a dict iteration, not a `.key` secret access — the tail
+        # word-boundary keeps it silent.
+        self.assertFalse(hit('logger.info("fields %s", list(payload.keys()))'))
+
+    def test_token_id_handle_is_safe(self) -> None:
+        # `.token_id` is the opaque handle, not the raw `.token`.
+        self.assertFalse(hit('logger.info("minted %s", minted.token_id)'))
+
+    def test_virtual_key_ciphertext_column_is_safe(self) -> None:
+        # The stored-ciphertext column name is not the raw `virtual_key`.
+        self.assertFalse(hit('logger.info("row %s", row.virtual_key_ciphertext)'))
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_agent_auth_secret_logs.py
+++ b/scripts/test_check_agent_auth_secret_logs.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+"""The accept cases carry the weight: an opaque `virtual_key_id` handle, a
+redacted hint, and non-log code that mentions a secret are all normal and must
+stay silent. What is banned is narrow — a live secret binding inside a log or
+tracing call — so a guard that flagged every mention of `virtual_key` would ban
+the safe handle along with the raw key."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import check_agent_auth_secret_logs as checker
+from scripts.check_agent_auth_secret_logs import scan_file
+
+
+def scanned(source: str, suffix: str = ".py") -> list[checker.Finding]:
+    with tempfile.NamedTemporaryFile("w", suffix=suffix, delete=False) as handle:
+        handle.write(source)
+        path = Path(handle.name)
+    try:
+        return scan_file(path)
+    finally:
+        path.unlink()
+
+
+def hit(source: str, suffix: str = ".py") -> bool:
+    return bool(scanned(source, suffix))
+
+
+class RecordCoverageTest(unittest.TestCase):
+    def test_checker_owns_exactly_its_record(self) -> None:
+        self.assertEqual(checker.OWNED_RULE_IDS, frozenset({checker.RULE_ID}))
+
+    def test_diagnostic_cites_the_rule_and_the_record(self) -> None:
+        diagnostic = scanned('logger.info("minted %s", virtual_key)')[0].format()
+        self.assertIn("PROD-AGENTAUTH-001", diagnostic)
+        self.assertIn("lints/product/agent_auth.toml", diagnostic)
+
+
+class SecretInLogRejected(unittest.TestCase):
+    def test_raw_virtual_key_python(self) -> None:
+        self.assertTrue(hit('logger.info("minted %s", virtual_key)'))
+
+    def test_value_ciphertext_python(self) -> None:
+        self.assertTrue(hit('logger.warning("stored %s", value_ciphertext)'))
+
+    def test_provider_env_secret_name(self) -> None:
+        self.assertTrue(hit('logger.debug("set ANTHROPIC_AUTH_TOKEN=%s", token)'))
+
+    def test_wrapped_call_across_lines(self) -> None:
+        self.assertTrue(
+            hit(
+                "logger.info(\n"
+                '    "rotated key for team %s: %s",\n'
+                "    team_id,\n"
+                "    virtual_key,\n"
+                ")"
+            )
+        )
+
+    def test_rust_tracing_macro(self) -> None:
+        self.assertTrue(
+            hit('tracing::warn!(%virtual_key, "delivering gateway key");', suffix=".rs")
+        )
+
+    def test_rust_bare_macro(self) -> None:
+        self.assertTrue(hit('error!("leaked {}", value_ciphertext);', suffix=".rs"))
+
+
+class SafeSitesAccepted(unittest.TestCase):
+    def test_opaque_handle_is_safe(self) -> None:
+        self.assertFalse(hit('logger.info("minted %s", virtual_key_id)'))
+
+    def test_secret_outside_a_log_call_is_ignored(self) -> None:
+        self.assertFalse(hit("stored = encrypt(virtual_key)"))
+
+    def test_ciphertext_id_reference_is_safe(self) -> None:
+        self.assertFalse(hit('logger.info("wrote %s", value_ciphertext_id)'))
+
+    def test_allow_pragma_exempts_a_reviewed_site(self) -> None:
+        self.assertFalse(
+            hit('logger.debug("redacted %s", redact(virtual_key))  # agent-auth:allow-secret-log')
+        )
+
+    def test_paren_inside_string_does_not_truncate_the_call(self) -> None:
+        # The `)` in the message must not close the call before the secret arg.
+        self.assertTrue(hit('logger.info("done (ok) %s", virtual_key)'))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/proliferate/server/cloud/agent_gateway/usage_import.py
+++ b/server/proliferate/server/cloud/agent_gateway/usage_import.py
@@ -244,6 +244,10 @@ async def run_usage_import(
                 "LiteLLM spend row has an unresolved virtual key",
                 extra={
                     "litellm_request_id": entry.request_id,
+                    # A 12-char prefix of LiteLLM's stored key identifier (the
+                    # value used as virtual_key_id below), truncated for manual
+                    # review — a redacted hint, not the raw secret.
+                    # agent-auth:allow-secret-log
                     "api_key_hint": entry.api_key[:12] if entry.api_key else None,
                 },
             )


### PR DESCRIPTION
## Summary

Agent Auth lint records stacked on the docs-v1/d6-lints foundation (#1722), per the lint-record authoring unlock. Reserves the `AGENTAUTH` family segment for this effort's rule IDs.

- **`PROD-AGENTAUTH-001` (B20 secret-log rule)** — new CI-wired checker `scripts/check_agent_auth_secret_logs.py`: scans logging/tracing call sites in agent-auth surfaces (agent_gateway, route_auth, model_snapshot) for known secret identifiers (provider env-var names, `virtual_key`, `value_ciphertext`) using balanced-paren call-body extraction; inline `agent-auth:allow-secret-log` opts out reviewed redaction sites. Wired into the ci.yml lint lane next to the toast-copy check, with a 20-test self-test mirroring `test_check_toast_copy.py`.
- **`SRV-AGENTAUTH-001`** (`mode = "test"`) — YAML access groups subset of registry gateway-capable kinds, enforced by the existing CI-wired `server/tests/unit/test_litellm_config_access_groups.py`.
- **`AH-AGENTAUTH-001`** (`mode = "test"`) — registry/catalog schema invariants, enforced by the existing `catalog/schema_tests.rs` in the cargo CI lane.
- **`SRV-AGENTAUTH-002`, `FE-AGENTAUTH-001`, `AH-AGENTAUTH-002`** — recorded as `leaks`/review debt: their real enforcers (registry mirror drift tests, FR-1 evidence invariant tests) live on the agent-auth code ladder (#1939 / #1916) and are not on this foundation branch; a dangling `enforced_by` would fail the loader. Gap refs to be reconciled to exact rung PRs at integration.

## Founder-attention flags

1. First use of `mode = "test"` records in the repo (loader supports it; no prior precedent — all existing records are lint/review).
2. Three rules are intentionally review-debt until the code-ladder rungs merge; the records name the gaps explicitly rather than pointing at not-yet-existing files.
3. Adversarial review round 2 extended the checker to attribute-access secrets (`minted.key`, `.token`, bare `api_key`) and the credential-custody roots (`db/store/agent_gateway`, `db/models/cloud`, `lib/infra/encryption`). That surfaced ONE sanctioned redacted-hint site, `server/proliferate/server/cloud/agent_gateway/usage_import.py` (`api_key_hint: entry.api_key[:12]` in a `logger.warning`), now carrying the rule's first inline `agent-auth:allow-secret-log` pragma: a +4-line production-source touch on a lints PR, and a net-new (call-scoped, in-code, not ledger) exception. Flagging per constitution.

## Evidence

```
python3 scripts/lint_records.py
lint records OK — 194 rules (anyharness: 46, frontend: 41, product: 60, server: 47), 240 exception sites

python3 scripts/check_agent_auth_secret_logs.py
Agent-auth secret-log check passed.

python3 -m unittest (lint_records + secret-log self-tests)
Ran 32 tests ... OK

scripts/check_max_lines.py / check_docs.py: pass (215 Markdown files).
```

Testing: checker self-test covers reject/accept/wrapped-call/pragma/paren-in-string cases. Observability: n/a (static lint tooling).

Part of the Agent Auth ADR ladder (#1916 → #1943). Do not merge before #1722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
