### PR TITLE
feat(product): draw the run graph as connected nodes in the workflow pane (PRO-278)

### DIFF
--- a/apps/packages/product-client/src/components/workflows/run-view/WorkflowGraphNodeCard.tsx
+++ b/apps/packages/product-client/src/components/workflows/run-view/WorkflowGraphNodeCard.tsx
@@ -47,7 +47,11 @@ function statusDotToneFor(tone: WorkflowNodeTone): StatusDotTone {
 
 export interface WorkflowGraphNodeCardProps {
   vm: WorkflowGraphNodeVM;
-  /** Visually subordinate rendering for a side node anchored under another card: muted fill, indented. Structure, not color. */
+  /**
+   * Visually subordinate rendering for a side node anchored under another
+   * card: muted fill. Placement — the branch-rail indent — belongs to
+   * `WorkflowGraphView`, the container that owns the graph's geometry.
+   */
   secondary?: boolean;
   needsInput?: boolean;
   busy?: boolean;
@@ -155,16 +159,12 @@ export function WorkflowGraphNodeCard({
   return (
     <>
       {/*
-        `className` on `Card` is layout only. The current node's emphasis is
-        carried by its title weight (structure, not color, and not a shadow
-        smuggled through a layout prop): `Card` owns elevation and exposes no
-        shadow axis, so there is nothing sanctioned to pass it through.
+        The current node's emphasis is carried by its title weight (structure,
+        not color, and not a shadow smuggled through a layout prop): `Card`
+        owns elevation and exposes no shadow axis, so there is nothing
+        sanctioned to pass it through.
       */}
-      <Card
-        surface={secondary ? "tint" : "opaque"}
-        className={secondary ? "ml-6" : undefined}
-        footer={controlsFooter}
-      >
+      <Card surface={secondary ? "tint" : "opaque"} footer={controlsFooter}>
         <RosterRow
           density="comfortable"
           leading={<StatusDot tone={statusDotToneFor(tone)} />}

--- a/apps/packages/product-client/src/components/workflows/run-view/WorkflowGraphView.test.tsx
+++ b/apps/packages/product-client/src/components/workflows/run-view/WorkflowGraphView.test.tsx
@@ -165,6 +165,54 @@ describe("WorkflowGraphView", () => {
     expect(chainTitle.closest(".border-l")).toBeNull();
   });
 
+  it("renders a side node under the attempt it anchors to, not after the last attempt", () => {
+    renderView([
+      {
+        chainIndex: 0,
+        attempts: [
+          buildVm({ id: "node-a", chainIndex: 0, title: "First attempt", status: "failed" }),
+          buildVm({ id: "node-b", chainIndex: 0, title: "Second attempt", kind: "replacement" }),
+        ],
+        adhoc: [
+          buildVm({
+            id: "node-side",
+            chainIndex: 0,
+            title: "Side errand",
+            kind: "adhoc",
+            anchorNodeRowId: "node-a",
+          }),
+        ],
+      },
+    ]);
+
+    const side = screen.getByText("01 · Side errand");
+    const secondAttempt = screen.getByText("01 · Second attempt");
+    expect(side.closest(".border-l")).not.toBeNull();
+    expect(
+      side.compareDocumentPosition(secondAttempt) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("still renders a side node whose anchor is not among the slot's attempts", () => {
+    renderView([
+      {
+        chainIndex: 0,
+        attempts: [buildVm({ id: "node-chain", chainIndex: 0, title: "Anchor" })],
+        adhoc: [
+          buildVm({
+            id: "node-side",
+            chainIndex: 0,
+            title: "Orphaned errand",
+            kind: "adhoc",
+            anchorNodeRowId: "node-gone",
+          }),
+        ],
+      },
+    ]);
+
+    expect(screen.getByText("01 · Orphaned errand").closest(".border-l")).not.toBeNull();
+  });
+
   it("passes card callbacks through untouched", () => {
     const { onApprove } = renderView([
       {

--- a/apps/packages/product-client/src/components/workflows/run-view/WorkflowGraphView.test.tsx
+++ b/apps/packages/product-client/src/components/workflows/run-view/WorkflowGraphView.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { WorkflowRunNodeV2 } from "@anyharness/sdk";
+import type {
+  WorkflowGraphNodeVM,
+  WorkflowGraphSlotVM,
+  WorkflowNodeControlSet,
+} from "#product/domain/workflows/run-view-model";
+import { WorkflowGraphView } from "#product/components/workflows/run-view/WorkflowGraphView";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function baseNode(overrides: Partial<WorkflowRunNodeV2> = {}): WorkflowRunNodeV2 {
+  return {
+    id: "node-1",
+    runId: "run-1",
+    definitionNodeId: "def-node-1",
+    kind: "defined",
+    nodeType: "agent",
+    replacesNodeRowId: null,
+    anchorNodeRowId: null,
+    chainIndex: 0,
+    title: "Research the topic",
+    prompt: "Original prompt",
+    status: "completed",
+    sessionId: null,
+    promptId: null,
+    failureCode: null,
+    createdAt: "2026-08-14T12:00:00Z",
+    startedAt: null,
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+function noControls(overrides: Partial<WorkflowNodeControlSet> = {}): WorkflowNodeControlSet {
+  return {
+    approve: false,
+    failRedo: false,
+    flipToAgent: false,
+    flipToHuman: false,
+    addAdhoc: false,
+    ...overrides,
+  };
+}
+
+function buildVm(
+  node: Partial<WorkflowRunNodeV2>,
+  controls: Partial<WorkflowNodeControlSet> = {},
+): WorkflowGraphNodeVM {
+  return {
+    node: baseNode(node),
+    isCurrent: false,
+    tone: "muted",
+    controls: noControls(controls),
+  };
+}
+
+function chainSlot(chainIndex: number, title: string): WorkflowGraphSlotVM {
+  return {
+    chainIndex,
+    attempts: [buildVm({ id: `node-${chainIndex}`, chainIndex, title })],
+    adhoc: [],
+  };
+}
+
+function renderView(slots: WorkflowGraphSlotVM[]) {
+  const onFocusSession = vi.fn();
+  const onApprove = vi.fn();
+  const onFailRedo = vi.fn();
+  const onFlipType = vi.fn();
+  const onAddAdhoc = vi.fn();
+  const { container } = render(
+    <WorkflowGraphView
+      slots={slots}
+      needsInputNodeRowIds={new Set()}
+      busy={false}
+      onFocusSession={onFocusSession}
+      onApprove={onApprove}
+      onFailRedo={onFailRedo}
+      onFlipType={onFlipType}
+      onAddAdhoc={onAddAdhoc}
+    />,
+  );
+  return { container, onFocusSession, onApprove, onFailRedo, onFlipType, onAddAdhoc };
+}
+
+/**
+ * The drawn edge's hairline. The graph is the only place in the view that
+ * draws a `w-px` segment (the cards have none), so counting them counts
+ * edges.
+ */
+function edgesOf(container: HTMLElement): NodeListOf<Element> {
+  return container.querySelectorAll(".w-px.bg-border");
+}
+
+describe("WorkflowGraphView", () => {
+  it("joins consecutive chain slots with drawn edges and draws none before the first", () => {
+    const { container } = renderView([
+      chainSlot(0, "Draft questions"),
+      chainSlot(1, "Answer them"),
+      chainSlot(2, "Propose the design"),
+    ]);
+
+    expect(edgesOf(container).length).toBe(2);
+    // Order: the first rendered element is a card, never an edge.
+    const first = container.firstElementChild?.firstElementChild;
+    expect(first?.getAttribute("aria-hidden")).toBeNull();
+  });
+
+  it("draws no edge around a single slot", () => {
+    const { container } = renderView([chainSlot(0, "Only step")]);
+    expect(edgesOf(container).length).toBe(0);
+  });
+
+  it("marks every drawn edge decorative", () => {
+    const { container } = renderView([chainSlot(0, "One"), chainSlot(1, "Two")]);
+    for (const edge of edgesOf(container)) {
+      expect(edge.closest("[aria-hidden]")).not.toBeNull();
+    }
+  });
+
+  it("keeps a slot's retries inside the slot, with no edge drawn between attempts", () => {
+    const { container } = renderView([
+      {
+        chainIndex: 0,
+        attempts: [
+          buildVm({ id: "node-a", chainIndex: 0, title: "First attempt", status: "failed" }),
+          buildVm({ id: "node-b", chainIndex: 0, title: "Second attempt", kind: "replacement" }),
+        ],
+        adhoc: [],
+      },
+    ]);
+
+    expect(screen.getByText("01 · First attempt")).toBeTruthy();
+    expect(screen.getByText("01 · Second attempt")).toBeTruthy();
+    expect(edgesOf(container).length).toBe(0);
+  });
+
+  it("hangs ad hoc side nodes off a branch rail under their anchor slot", () => {
+    renderView([
+      {
+        chainIndex: 0,
+        attempts: [buildVm({ id: "node-chain", chainIndex: 0, title: "Anchor" })],
+        adhoc: [
+          buildVm({
+            id: "node-side",
+            chainIndex: 0,
+            title: "Side errand",
+            kind: "adhoc",
+            anchorNodeRowId: "node-chain",
+          }),
+        ],
+      },
+    ]);
+
+    const sideTitle = screen.getByText("01 · Side errand");
+    expect(sideTitle.closest(".border-l")).not.toBeNull();
+    const chainTitle = screen.getByText("01 · Anchor");
+    expect(chainTitle.closest(".border-l")).toBeNull();
+  });
+
+  it("passes card callbacks through untouched", () => {
+    const { onApprove } = renderView([
+      {
+        chainIndex: 0,
+        attempts: [
+          buildVm(
+            { id: "node-gate", chainIndex: 0, title: "Approve the design", status: "awaiting_human" },
+            { approve: true },
+          ),
+        ],
+        adhoc: [],
+      },
+    ]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+    expect(onApprove).toHaveBeenCalledWith("node-gate");
+  });
+});

--- a/apps/packages/product-client/src/components/workflows/run-view/WorkflowGraphView.tsx
+++ b/apps/packages/product-client/src/components/workflows/run-view/WorkflowGraphView.tsx
@@ -1,0 +1,93 @@
+import { Fragment } from "react";
+
+import type { WorkflowGraphSlotVM } from "#product/domain/workflows/run-view-model";
+import { ChevronDown } from "#product/primitives/icons/core";
+import { WorkflowGraphNodeCard } from "#product/components/workflows/run-view/WorkflowGraphNodeCard";
+
+export interface WorkflowGraphViewProps {
+  slots: WorkflowGraphSlotVM[];
+  needsInputNodeRowIds: ReadonlySet<string>;
+  busy: boolean;
+  onFocusSession(nodeRowId: string): void;
+  onApprove(nodeRowId: string): void;
+  onFailRedo(nodeRowId: string, prompt?: string): void;
+  onFlipType(nodeRowId: string, nodeType: "agent" | "human_in_loop"): void;
+  onAddAdhoc(anchorNodeRowId: string, prompt: string): void;
+}
+
+/**
+ * The run's chain drawn as a graph rather than a flat stack: consecutive
+ * chain slots are joined by a drawn edge, and a slot's ad hoc side nodes
+ * hang off a branch rail under their anchor, so the pane reads as flow —
+ * this slot feeds the next, that side node belongs to this one — instead of
+ * a list of sibling cards.
+ *
+ * Pure layout. Retries stay inside their slot (a second attempt is the same
+ * chain position, not a chain advance, so no edge is drawn between them),
+ * every card keeps its own controls, and the callbacks pass through
+ * untouched.
+ */
+export function WorkflowGraphView({
+  slots,
+  needsInputNodeRowIds,
+  busy,
+  onFocusSession,
+  onApprove,
+  onFailRedo,
+  onFlipType,
+  onAddAdhoc,
+}: WorkflowGraphViewProps) {
+  const cardHandlers = { onFocusSession, onApprove, onFailRedo, onFlipType, onAddAdhoc };
+  return (
+    <div className="flex flex-col">
+      {slots.map((slot, slotIndex) => (
+        <Fragment key={slot.chainIndex}>
+          {slotIndex > 0 ? <WorkflowGraphEdge /> : null}
+          <div className="flex flex-col gap-1.5">
+            {slot.attempts.map((vm) => (
+              <WorkflowGraphNodeCard
+                key={vm.node.id}
+                vm={vm}
+                needsInput={needsInputNodeRowIds.has(vm.node.id)}
+                busy={busy}
+                {...cardHandlers}
+              />
+            ))}
+            {slot.adhoc.length > 0 ? (
+              <div className="ml-6 flex flex-col gap-1.5 border-l border-border pl-3">
+                {slot.adhoc.map((vm) => (
+                  <WorkflowGraphNodeCard
+                    key={vm.node.id}
+                    vm={vm}
+                    secondary
+                    needsInput={needsInputNodeRowIds.has(vm.node.id)}
+                    busy={busy}
+                    {...cardHandlers}
+                  />
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </Fragment>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * The edge between two consecutive chain slots: a centered hairline segment
+ * (the `w-px bg-border` idiom `TranscriptTurnChrome` draws) flowing into a
+ * small arrowhead. Decorative only, hence `aria-hidden` — order is already
+ * announced by each card's chain-index title. The arrowhead sits at
+ * `icon-tight`, the smallest tier whose scaled stroke still covers a full
+ * device pixel on 1x displays, and takes the border ink the separator-glyph
+ * call sites already use, so the whole edge reads as one drawn line.
+ */
+function WorkflowGraphEdge() {
+  return (
+    <div aria-hidden className="flex flex-col items-center self-center py-0.5">
+      <span className="h-3 w-px bg-border" />
+      <ChevronDown className="icon-tight -mt-1.5 text-border-heavy" />
+    </div>
+  );
+}

--- a/apps/packages/product-client/src/components/workflows/run-view/WorkflowGraphView.tsx
+++ b/apps/packages/product-client/src/components/workflows/run-view/WorkflowGraphView.tsx
@@ -1,6 +1,9 @@
 import { Fragment } from "react";
 
-import type { WorkflowGraphSlotVM } from "#product/domain/workflows/run-view-model";
+import type {
+  WorkflowGraphNodeVM,
+  WorkflowGraphSlotVM,
+} from "#product/domain/workflows/run-view-model";
 import { ChevronDown } from "#product/primitives/icons/core";
 import { WorkflowGraphNodeCard } from "#product/components/workflows/run-view/WorkflowGraphNodeCard";
 
@@ -17,10 +20,10 @@ export interface WorkflowGraphViewProps {
 
 /**
  * The run's chain drawn as a graph rather than a flat stack: consecutive
- * chain slots are joined by a drawn edge, and a slot's ad hoc side nodes
- * hang off a branch rail under their anchor, so the pane reads as flow —
- * this slot feeds the next, that side node belongs to this one — instead of
- * a list of sibling cards.
+ * chain slots are joined by a drawn edge, and every ad hoc side node hangs
+ * off a branch rail directly under the attempt it anchors to, so the pane
+ * reads as flow — this slot feeds the next, that side node belongs to this
+ * attempt — instead of a list of sibling cards.
  *
  * Pure layout. Retries stay inside their slot (a second attempt is the same
  * chain position, not a chain advance, so no edge is drawn between them),
@@ -37,38 +40,99 @@ export function WorkflowGraphView({
   onFlipType,
   onAddAdhoc,
 }: WorkflowGraphViewProps) {
-  const cardHandlers = { onFocusSession, onApprove, onFailRedo, onFlipType, onAddAdhoc };
+  const cardProps = {
+    needsInputNodeRowIds,
+    busy,
+    onFocusSession,
+    onApprove,
+    onFailRedo,
+    onFlipType,
+    onAddAdhoc,
+  };
   return (
     <div className="flex flex-col">
-      {slots.map((slot, slotIndex) => (
-        <Fragment key={slot.chainIndex}>
-          {slotIndex > 0 ? <WorkflowGraphEdge /> : null}
-          <div className="flex flex-col gap-1.5">
-            {slot.attempts.map((vm) => (
-              <WorkflowGraphNodeCard
-                key={vm.node.id}
-                vm={vm}
-                needsInput={needsInputNodeRowIds.has(vm.node.id)}
-                busy={busy}
-                {...cardHandlers}
-              />
-            ))}
-            {slot.adhoc.length > 0 ? (
-              <div className="ml-6 flex flex-col gap-1.5 border-l border-border pl-3">
-                {slot.adhoc.map((vm) => (
+      {slots.map((slot, slotIndex) => {
+        const attemptIds = new Set(slot.attempts.map((vm) => vm.node.id));
+        // A side node's anchor is normally one of this slot's attempt rows; a
+        // projection can still hand back an anchor the slot does not contain,
+        // and those side nodes render on a trailing rail rather than vanish.
+        const orphaned = slot.adhoc.filter(
+          (vm) => vm.node.anchorNodeRowId === null || !attemptIds.has(vm.node.anchorNodeRowId),
+        );
+        return (
+          <Fragment key={slot.chainIndex}>
+            {slotIndex > 0 ? <WorkflowGraphEdge /> : null}
+            <div className="flex flex-col gap-1.5">
+              {slot.attempts.map((vm) => (
+                <Fragment key={vm.node.id}>
                   <WorkflowGraphNodeCard
-                    key={vm.node.id}
                     vm={vm}
-                    secondary
                     needsInput={needsInputNodeRowIds.has(vm.node.id)}
                     busy={busy}
-                    {...cardHandlers}
+                    onFocusSession={onFocusSession}
+                    onApprove={onApprove}
+                    onFailRedo={onFailRedo}
+                    onFlipType={onFlipType}
+                    onAddAdhoc={onAddAdhoc}
                   />
-                ))}
-              </div>
-            ) : null}
-          </div>
-        </Fragment>
+                  <WorkflowGraphBranchRail
+                    vms={slot.adhoc.filter((adhocVm) => adhocVm.node.anchorNodeRowId === vm.node.id)}
+                    {...cardProps}
+                  />
+                </Fragment>
+              ))}
+              <WorkflowGraphBranchRail vms={orphaned} {...cardProps} />
+            </div>
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+}
+
+interface WorkflowGraphBranchRailProps {
+  vms: WorkflowGraphNodeVM[];
+  needsInputNodeRowIds: ReadonlySet<string>;
+  busy: boolean;
+  onFocusSession(nodeRowId: string): void;
+  onApprove(nodeRowId: string): void;
+  onFailRedo(nodeRowId: string, prompt?: string): void;
+  onFlipType(nodeRowId: string, nodeType: "agent" | "human_in_loop"): void;
+  onAddAdhoc(anchorNodeRowId: string, prompt: string): void;
+}
+
+/**
+ * The branch rail a slot's side nodes hang from: rendered directly under the
+ * attempt they anchor to, so a retry's side errand never reads as belonging
+ * to a different attempt. Renders nothing for an empty group — the rail is
+ * the fork's drawing, not a slot fixture.
+ */
+function WorkflowGraphBranchRail({
+  vms,
+  needsInputNodeRowIds,
+  busy,
+  onFocusSession,
+  onApprove,
+  onFailRedo,
+  onFlipType,
+  onAddAdhoc,
+}: WorkflowGraphBranchRailProps) {
+  if (vms.length === 0) return null;
+  return (
+    <div className="ml-6 flex flex-col gap-1.5 border-l border-border pl-3">
+      {vms.map((vm) => (
+        <WorkflowGraphNodeCard
+          key={vm.node.id}
+          vm={vm}
+          secondary
+          needsInput={needsInputNodeRowIds.has(vm.node.id)}
+          busy={busy}
+          onFocusSession={onFocusSession}
+          onApprove={onApprove}
+          onFailRedo={onFailRedo}
+          onFlipType={onFlipType}
+          onAddAdhoc={onAddAdhoc}
+        />
       ))}
     </div>
   );

--- a/apps/packages/product-client/src/components/workflows/run-view/WorkflowPane.tsx
+++ b/apps/packages/product-client/src/components/workflows/run-view/WorkflowPane.tsx
@@ -5,7 +5,7 @@ import { EmptyState } from "#product/primitives/patterns/EmptyState";
 import { NoticeBanner } from "#product/primitives/patterns/NoticeBanner";
 import { PaneHeader } from "#product/components/workspace/pane/PaneHeader";
 import { WorkflowDocsList } from "#product/components/workflows/run-view/WorkflowDocsList";
-import { WorkflowGraphNodeCard } from "#product/components/workflows/run-view/WorkflowGraphNodeCard";
+import { WorkflowGraphView } from "#product/components/workflows/run-view/WorkflowGraphView";
 import { WORKFLOW_RUN_VIEW_COPY } from "#product/copy/workflows/workflow-run-view-copy";
 import { useWorkflowPane } from "#product/hooks/workflows/facade/use-workflow-pane";
 import { useWorkflowDocOpen } from "#product/hooks/workflows/ui/use-workflow-doc-open";
@@ -90,39 +90,16 @@ export function WorkflowPane({ workspaceId }: { workspaceId: string }) {
               <h3 className="px-1 text-ui font-medium text-foreground">
                 {WORKFLOW_RUN_VIEW_COPY.graphSectionTitle}
               </h3>
-              <div className="flex flex-col gap-3">
-                {pane.slots.map((slot) => (
-                  <div key={slot.chainIndex} className="flex flex-col gap-1.5">
-                    {slot.attempts.map((vm) => (
-                      <WorkflowGraphNodeCard
-                        key={vm.node.id}
-                        vm={vm}
-                        needsInput={pane.needsInputNodeRowIds.has(vm.node.id)}
-                        busy={pane.busy}
-                        onFocusSession={pane.actions.focusNodeSession}
-                        onApprove={pane.actions.approve}
-                        onFailRedo={pane.actions.failRedo}
-                        onFlipType={pane.actions.flipType}
-                        onAddAdhoc={pane.actions.addAdhocNode}
-                      />
-                    ))}
-                    {slot.adhoc.map((vm) => (
-                      <WorkflowGraphNodeCard
-                        key={vm.node.id}
-                        vm={vm}
-                        secondary
-                        needsInput={pane.needsInputNodeRowIds.has(vm.node.id)}
-                        busy={pane.busy}
-                        onFocusSession={pane.actions.focusNodeSession}
-                        onApprove={pane.actions.approve}
-                        onFailRedo={pane.actions.failRedo}
-                        onFlipType={pane.actions.flipType}
-                        onAddAdhoc={pane.actions.addAdhocNode}
-                      />
-                    ))}
-                  </div>
-                ))}
-              </div>
+              <WorkflowGraphView
+                slots={pane.slots}
+                needsInputNodeRowIds={pane.needsInputNodeRowIds}
+                busy={pane.busy}
+                onFocusSession={pane.actions.focusNodeSession}
+                onApprove={pane.actions.approve}
+                onFailRedo={pane.actions.failRedo}
+                onFlipType={pane.actions.flipType}
+                onAddAdhoc={pane.actions.addAdhocNode}
+              />
             </section>
 
             <section className="flex flex-col gap-2">


### PR DESCRIPTION
## What

The right-pane Workflow tab rendered the run's steps as a flat stack of free-floating cards, so a run read as a list rather than a flow. This PR introduces `WorkflowGraphView`, which draws the chain as a connected graph in the n8n direction the design calls for:

- Consecutive chain slots are joined by a drawn edge — a centered hairline flowing into a small arrowhead (`w-px bg-border` + `ChevronDown` at `icon-tight`, so the scaled stroke stays a full device pixel on 1x displays).
- Ad hoc side nodes hang off a branch rail (`border-l` elbow) under their anchor slot instead of a bare indent, so the fork is visible.
- Retries stay inside their slot with no edge between attempts — a second attempt is the same chain position, not a chain advance.
- The side-node indent moves from `WorkflowGraphNodeCard` into the rail container: the graph view owns the graph's geometry, the card keeps its subordinate fill.

Pure layout: control eligibility still comes solely from the transition table via `vm.controls`, and all callbacks pass through untouched.

## Why

[PRO-278](https://linear.app/proliferate-team/issue/PRO-278/improve-workflow-graph-in-right-pane) — "Improve workflow graph in right pane. Should be n8n style UI."

Based on `codex/workflows-gen2-pr7-builder-launch` (the gen-2 stack tip) because the run-view pane only exists on that stack.

## Testing

- New `WorkflowGraphView.test.tsx`: edge count between slots (none before the first / around a single slot), edges are decorative (`aria-hidden`), retries draw no intra-slot edge, side nodes render inside the branch rail while chain nodes do not, callbacks pass through.
- `pnpm vitest run src/components/workflows src/domain/workflows src/hooks/workflows` — 283 tests green.
- `pnpm exec tsc --noEmit` green; `check_frontend_boundaries`, `check_appearance_scaling`, `check_component_library`, `report_frontend_structure --strict` all clean.

## Manual test

Run a workflow, open the workspace, switch the right panel to the Workflow tab: steps now render joined by vertical edges with arrowheads; add a side node to see the branch rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)