### PR TITLE
fix(product): inputs-first workflow trigger dialog with collapsed location (PRO-275)

### DIFF
--- a/apps/packages/product-client/src/components/workflows/trigger/WorkflowTriggerDialog.test.tsx
+++ b/apps/packages/product-client/src/components/workflows/trigger/WorkflowTriggerDialog.test.tsx
@@ -68,17 +68,32 @@ describe("WorkflowTriggerDialog", () => {
 
     // Negative control: the optional input stays empty for the whole test, so
     // an enabled Confirm proves only the required one gates.
-    fireEvent.change(screen.getByLabelText("issue"), { target: { value: "PRO-174" } });
-    expect(screen.getByLabelText("notes")).toHaveProperty("value", "");
+    fireEvent.change(screen.getByLabelText("Issue"), { target: { value: "PRO-174" } });
+    expect(screen.getByLabelText("Notes")).toHaveProperty("value", "");
     expect(confirm()).toHaveProperty("disabled", false);
 
-    fireEvent.change(screen.getByLabelText("issue"), { target: { value: "   " } });
+    fireEvent.change(screen.getByLabelText("Issue"), { target: { value: "   " } });
     expect(confirm()).toHaveProperty("disabled", true);
   });
 
-  it("defaults placement to a new worktree", () => {
+  it("shows the authored workflow description under the title", () => {
+    renderDialog({ ...definitionRecord(), description: "Triage one issue end to end." });
+
+    expect(screen.getByText("Triage one issue end to end.")).toBeTruthy();
+  });
+
+  it("collapses a usable saved repository to a summary until Change is clicked", () => {
     renderDialog();
 
+    // The saved default (root-1) is listed, so the location reads as one line
+    // and neither control is rendered.
+    expect(screen.getByText(/Runs in/).textContent).toBe("Runs in proliferate · New worktree");
+    expect(screen.queryByLabelText("Repository")).toBeNull();
+    expect(screen.queryByRole("radio", { name: "New worktree" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Change" }));
+
+    expect(screen.getByLabelText("Repository")).toBeTruthy();
     expect(screen.getByRole("radio", { name: "New worktree" }).getAttribute("aria-checked"))
       .toBe("true");
     expect(screen.getByRole("radio", { name: "Repo root" }).getAttribute("aria-checked"))
@@ -88,10 +103,10 @@ describe("WorkflowTriggerDialog", () => {
   it("submits an argument for every declared input, blank optionals included", () => {
     renderDialog();
 
-    fireEvent.change(screen.getByLabelText("issue"), { target: { value: " PRO-174 " } });
+    fireEvent.change(screen.getByLabelText("Issue"), { target: { value: " PRO-174 " } });
     // `notes` is left blank on purpose: a prompt that reads `@input:notes`
     // cannot launch unless the argument is present, so it must arrive as "".
-    expect(screen.getByLabelText("notes")).toHaveProperty("value", "");
+    expect(screen.getByLabelText("Notes")).toHaveProperty("value", "");
     fireEvent.click(screen.getByRole("button", { name: "Start run" }));
 
     expect(triggerActions.triggerRun).toHaveBeenCalledWith({
@@ -107,7 +122,8 @@ describe("WorkflowTriggerDialog", () => {
       defaultRepoConfigId: null,
     });
 
-    fireEvent.change(screen.getByLabelText("issue"), { target: { value: "PRO-174" } });
+    // No saved default: the location controls are open from the start.
+    fireEvent.change(screen.getByLabelText("Issue"), { target: { value: "PRO-174" } });
     fireEvent.change(screen.getByLabelText("Repository"), { target: { value: "root-2" } });
     fireEvent.click(screen.getByRole("radio", { name: "Repo root" }));
     fireEvent.click(screen.getByRole("button", { name: "Start run" }));
@@ -122,6 +138,7 @@ describe("WorkflowTriggerDialog", () => {
   it("offers the listed repo roots, falling back to the folder name", () => {
     renderDialog();
 
+    fireEvent.click(screen.getByRole("button", { name: "Change" }));
     const options = Array.from(
       screen.getByLabelText("Repository").querySelectorAll("option"),
     ).map((option) => [option.getAttribute("value"), option.textContent]);
@@ -138,7 +155,9 @@ describe("WorkflowTriggerDialog", () => {
       defaultRepoConfigId: "repo-config-9",
     });
 
-    fireEvent.change(screen.getByLabelText("issue"), { target: { value: "PRO-174" } });
+    // An unavailable saved default forces the controls open — a summary line
+    // could not explain why the run is blocked.
+    fireEvent.change(screen.getByLabelText("Issue"), { target: { value: "PRO-174" } });
     expect(screen.getByText("Saved repository unavailable (repo-config-9)")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Start run" })).toHaveProperty("disabled", true);
 

--- a/apps/packages/product-client/src/components/workflows/trigger/WorkflowTriggerDialog.test.tsx
+++ b/apps/packages/product-client/src/components/workflows/trigger/WorkflowTriggerDialog.test.tsx
@@ -166,6 +166,35 @@ describe("WorkflowTriggerDialog", () => {
     expect(screen.getByRole("button", { name: "Start run" })).toHaveProperty("disabled", false);
   });
 
+  it("submits on Enter through the native form, honouring the disabled gate", () => {
+    renderDialog();
+    const form = () => {
+      const found = document.getElementById("workflow-trigger-form");
+      if (!(found instanceof HTMLFormElement)) {
+        throw new Error("trigger form not rendered");
+      }
+      return found;
+    };
+
+    // The footer button lives outside the form and joins it by id — the
+    // association implicit submission depends on.
+    expect(screen.getByRole("button", { name: "Start run" }).getAttribute("form"))
+      .toBe("workflow-trigger-form");
+
+    // Required input missing: the submit handler's own guard must hold even
+    // if a submission event gets through.
+    fireEvent.submit(form());
+    expect(triggerActions.triggerRun).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText("Issue"), { target: { value: "PRO-174" } });
+    fireEvent.submit(form());
+    expect(triggerActions.triggerRun).toHaveBeenCalledWith({
+      workflowDefinitionId: "wf-1",
+      arguments: { issue: "PRO-174", notes: "" },
+      placement: { repoConfigId: "root-1", mode: "worktree" },
+    });
+  });
+
   it("renders the trigger error inline", () => {
     triggerActions.error = "The workflow request could not be completed.";
     renderDialog();

--- a/apps/packages/product-client/src/components/workflows/trigger/WorkflowTriggerDialog.tsx
+++ b/apps/packages/product-client/src/components/workflows/trigger/WorkflowTriggerDialog.tsx
@@ -34,18 +34,27 @@ export interface WorkflowTriggerDialogProps {
   authCacheScope: string;
 }
 
+const TRIGGER_FORM_ID = "workflow-trigger-form";
+
 interface TriggerFormState {
   key: string;
   values: Record<string, string>;
   repoConfigId: string;
   mode: WorkflowPlacementModeV2;
+  /** The person asked to see the location controls despite a usable default. */
+  locationOpen: boolean;
 }
 
 /**
- * The gen-2 "run this workflow" dialog: one field per declared input, where
- * the run should be placed, and a Confirm that hands the whole thing to the
- * trigger courier. It composes existing primitives only — the modal frame,
- * the field controls, and the placement segment all belong to the library.
+ * The gen-2 "run this workflow" dialog, inputs first: one field per declared
+ * input and a Start run that hands the whole thing to the trigger courier.
+ * The location half (repository + placement) collapses to a one-line summary
+ * whenever the definition's saved default repository is usable, so the common
+ * case reads as "fill the inputs, go" — the controls only surface when there
+ * is a real choice to make (no saved default, the saved default is not a
+ * listed repo root, or an explicit "Change"). It composes existing primitives
+ * only — the modal frame, the field controls, and the placement segment all
+ * belong to the library.
  */
 export function WorkflowTriggerDialog({
   definitionRecord,
@@ -86,6 +95,17 @@ export function WorkflowTriggerDialog({
   // rejects a repo-root id it does not own.
   const savedRepositoryUnavailable = form.repoConfigId.length > 0
     && !repositories.some((repository) => repository.id === form.repoConfigId);
+  const savedRepositoryLabel = repositories.find(
+    (repository) => repository.id === form.repoConfigId,
+  )?.label;
+  // No saved default means the person must pick before anything can run, so
+  // the controls show immediately; an unavailable saved default only forces
+  // them open once the list has actually loaded, so a collapsed summary does
+  // not flash open while the roots are still on the wire.
+  const mustChooseLocation = form.repoConfigId.length === 0
+    || (!repoRootsQuery.isLoading && savedRepositoryUnavailable);
+  const locationExpanded = form.locationOpen || mustChooseLocation;
+
   const requiredInputsSupplied = inputs.every(
     (input) => !input.required || form.values[input.name]?.trim(),
   );
@@ -102,14 +122,17 @@ export function WorkflowTriggerDialog({
     });
   };
 
+  const description = definitionRecord.description.trim();
+
   return (
     <ModalShell
       open={open}
       onClose={() => onOpenChange(false)}
       disableClose={triggering}
       title={definitionRecord.title}
-      description={WORKFLOW_TRIGGER_COPY.description}
+      description={description.length > 0 ? description : undefined}
       sizeClassName="max-w-lg"
+      telemetryBlocked
       footer={(
         <>
           <Button
@@ -122,19 +145,28 @@ export function WorkflowTriggerDialog({
             {WORKFLOW_TRIGGER_COPY.cancelLabel}
           </Button>
           <Button
-            type="button"
+            type="submit"
+            form={TRIGGER_FORM_ID}
             variant="primary"
             size="md"
             loading={triggering}
             disabled={confirmDisabled}
-            onClick={submit}
           >
             {WORKFLOW_TRIGGER_COPY.confirmLabel}
           </Button>
         </>
       )}
     >
-      <div className="space-y-4">
+      <form
+        id={TRIGGER_FORM_ID}
+        className="space-y-4"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!confirmDisabled) {
+            submit();
+          }
+        }}
+      >
         {error ? <NoticeBanner tone="destructive">{error}</NoticeBanner> : null}
         {repoRootsQuery.isError ? (
           <NoticeBanner tone="warning">
@@ -147,76 +179,113 @@ export function WorkflowTriggerDialog({
             {WORKFLOW_TRIGGER_COPY.inputsEmpty}
           </p>
         ) : (
-          <div className="space-y-3">
-            {inputs.map((input) => {
-              const fieldId = `workflow-trigger-input-${input.name}`;
-              const help = inputHelpText(input);
-              return (
-                <div key={input.name}>
-                  <Label htmlFor={fieldId}>{input.name}</Label>
-                  <Input
-                    id={fieldId}
-                    value={form.values[input.name] ?? ""}
-                    required={input.required}
-                    disabled={triggering}
-                    onChange={(event) => setFormState({
-                      ...form,
-                      values: {
-                        ...form.values,
-                        [input.name]: event.currentTarget.value,
-                      },
-                    })}
-                  />
-                  {help ? (
-                    <p className="mt-1 text-ui-sm text-muted-foreground">{help}</p>
-                  ) : null}
-                </div>
-              );
-            })}
-          </div>
+          inputs.map((input, index) => {
+            const fieldId = `workflow-trigger-input-${input.name}`;
+            const help = inputHelpText(input);
+            return (
+              <div key={input.name} className="space-y-1.5">
+                <Label htmlFor={fieldId} className="text-ui font-medium text-foreground">
+                  {workflowInputDisplayName(input.name)}
+                </Label>
+                <Input
+                  id={fieldId}
+                  value={form.values[input.name] ?? ""}
+                  required={input.required}
+                  disabled={triggering}
+                  autoFocus={index === 0}
+                  autoComplete="off"
+                  spellCheck={false}
+                  onChange={(event) => setFormState({
+                    ...form,
+                    values: {
+                      ...form.values,
+                      [input.name]: event.currentTarget.value,
+                    },
+                  })}
+                />
+                {help ? (
+                  <p className="text-ui-sm text-muted-foreground">{help}</p>
+                ) : null}
+              </div>
+            );
+          })
         )}
 
-        <div>
-          <Label htmlFor="workflow-trigger-repository">
-            {WORKFLOW_TRIGGER_COPY.repositoryLabel}
-          </Label>
-          <Select
-            id="workflow-trigger-repository"
-            value={form.repoConfigId}
-            disabled={triggering || repoRootsQuery.isLoading}
-            onChange={(event) => setFormState({
-              ...form,
-              repoConfigId: event.currentTarget.value,
-            })}
-          >
-            <option value="">{WORKFLOW_TRIGGER_COPY.repositoryPlaceholder}</option>
-            {savedRepositoryUnavailable ? (
-              <option value={form.repoConfigId}>
-                {WORKFLOW_TRIGGER_COPY.repositoryUnavailable(form.repoConfigId)}
-              </option>
-            ) : null}
-            {repositories.map((repository) => (
-              <option key={repository.id} value={repository.id}>{repository.label}</option>
-            ))}
-          </Select>
-        </div>
-
-        <div>
-          <Label>{WORKFLOW_TRIGGER_COPY.placementLabel}</Label>
-          <SegmentedControl<WorkflowPlacementModeV2>
-            ariaLabel={WORKFLOW_TRIGGER_COPY.placementLabel}
-            value={form.mode}
-            items={[
-              { id: "worktree", label: WORKFLOW_TRIGGER_COPY.placementWorktree, disabled: triggering },
-              { id: "repo_root", label: WORKFLOW_TRIGGER_COPY.placementRepoRoot, disabled: triggering },
-            ]}
-            onChange={(mode) => setFormState({ ...form, mode })}
-          />
-          <p className="mt-1 text-ui-sm text-muted-foreground">
-            {WORKFLOW_TRIGGER_COPY.placementHelp}
-          </p>
-        </div>
-      </div>
+        {locationExpanded ? (
+          <>
+            <div className="space-y-1.5">
+              <Label
+                htmlFor="workflow-trigger-repository"
+                className="text-ui font-medium text-foreground"
+              >
+                {WORKFLOW_TRIGGER_COPY.repositoryLabel}
+              </Label>
+              <Select
+                id="workflow-trigger-repository"
+                value={form.repoConfigId}
+                disabled={triggering || repoRootsQuery.isLoading}
+                // `locationOpen` pins the controls: without it, picking a
+                // listed root would clear `mustChooseLocation` and collapse
+                // the section mid-interaction.
+                onChange={(event) => setFormState({
+                  ...form,
+                  repoConfigId: event.currentTarget.value,
+                  locationOpen: true,
+                })}
+              >
+                <option value="">{WORKFLOW_TRIGGER_COPY.repositoryPlaceholder}</option>
+                {savedRepositoryUnavailable ? (
+                  <option value={form.repoConfigId}>
+                    {WORKFLOW_TRIGGER_COPY.repositoryUnavailable(form.repoConfigId)}
+                  </option>
+                ) : null}
+                {repositories.map((repository) => (
+                  <option key={repository.id} value={repository.id}>{repository.label}</option>
+                ))}
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label className="text-ui font-medium text-foreground">
+                {WORKFLOW_TRIGGER_COPY.placementLabel}
+              </Label>
+              <SegmentedControl<WorkflowPlacementModeV2>
+                ariaLabel={WORKFLOW_TRIGGER_COPY.placementLabel}
+                value={form.mode}
+                items={[
+                  { id: "worktree", label: WORKFLOW_TRIGGER_COPY.placementWorktree, disabled: triggering },
+                  { id: "repo_root", label: WORKFLOW_TRIGGER_COPY.placementRepoRoot, disabled: triggering },
+                ]}
+                onChange={(mode) => setFormState({ ...form, mode, locationOpen: true })}
+              />
+              <p className="text-ui-sm text-muted-foreground">
+                {WORKFLOW_TRIGGER_COPY.placementHelp}
+              </p>
+            </div>
+          </>
+        ) : (
+          <div className="flex items-center gap-2">
+            <p className="min-w-0 truncate text-ui-sm text-muted-foreground">
+              {WORKFLOW_TRIGGER_COPY.locationSummaryPrefix}{" "}
+              <span className="font-medium text-foreground">
+                {savedRepositoryLabel ?? "…"}
+              </span>
+              {" · "}
+              {form.mode === "worktree"
+                ? WORKFLOW_TRIGGER_COPY.placementWorktree
+                : WORKFLOW_TRIGGER_COPY.placementRepoRoot}
+            </p>
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={triggering}
+              onClick={() => setFormState({ ...form, locationOpen: true })}
+              className="inline h-auto shrink-0 px-0 py-0 text-ui-sm text-muted-foreground underline underline-offset-4 hover:bg-transparent hover:text-foreground"
+            >
+              {WORKFLOW_TRIGGER_COPY.changeLocationLabel}
+            </Button>
+          </div>
+        )}
+      </form>
     </ModalShell>
   );
 }
@@ -232,7 +301,21 @@ function freshTriggerForm(
     ),
     repoConfigId: definitionRecord.defaultRepoConfigId ?? "",
     mode: "worktree",
+    locationOpen: false,
   };
+}
+
+/**
+ * Presentation only: input names are prompt identifiers (`@input:pr_number`),
+ * shown as field labels with separators spaced out and the first letter
+ * raised. The submitted argument keys stay the declared names untouched.
+ */
+function workflowInputDisplayName(name: string): string {
+  const spaced = name.replace(/[_-]+/gu, " ").trim();
+  if (spaced.length === 0) {
+    return name;
+  }
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
 }
 
 function inputHelpText(input: WorkflowInputV2): string | null {

--- a/apps/packages/product-client/src/copy/workflows/workflow-trigger-copy.ts
+++ b/apps/packages/product-client/src/copy/workflows/workflow-trigger-copy.ts
@@ -5,7 +5,6 @@
  * authored text, not presentation logic.
  */
 export const WORKFLOW_TRIGGER_COPY = {
-  description: "Fill in this workflow's inputs and choose where the run works.",
   inputsEmpty: "This workflow takes no inputs.",
   optionalHint: "Optional",
   repositoryLabel: "Repository",
@@ -19,6 +18,8 @@ export const WORKFLOW_TRIGGER_COPY = {
   placementRepoRoot: "Repo root",
   placementHelp:
     "A new worktree keeps this run isolated. Repo root runs in the existing checkout.",
+  locationSummaryPrefix: "Runs in",
+  changeLocationLabel: "Change",
   cancelLabel: "Cancel",
   confirmLabel: "Start run",
 } as const;


### PR DESCRIPTION
## Summary

- Reworks the gen-2 start-run dialog (`WorkflowTriggerDialog`) per [PRO-275](https://linear.app/proliferate-team/issue/PRO-275/improve-general-uiux-for-starting-workflow): minimize the popup to essentially the inputs, and improve the UI generally.
- Inputs are now the hero: humanized field labels (`pr_number` → "Pr number") in the house strong-label treatment (ApiKeyCreatorModal idiom), first field autofocused, and a real `<form>` so Enter starts the run.
- Repository + Placement collapse into a one-line summary — "Runs in *repo* · New worktree — Change" — whenever the definition's saved default repository is listed by the runtime. The controls render expanded only when a real choice is required: no saved default, the saved default is not a listed repo root (with the existing unavailable-option warning), or the user clicks Change. Interacting with the controls pins them open so picking a listed root can't collapse the section mid-interaction.
- The generic subtitle ("Fill in this workflow's inputs…") is replaced by the workflow's own authored description when present; nothing otherwise. The modal now sets `telemetryBlocked` like the other authored-content dialogs, so run-input values don't leak into capture.
- Contract untouched: argument collection (blank optionals included), `placement: { repoConfigId, mode }`, `#workflow-trigger-input-*` / `#workflow-trigger-repository` ids, radio names, and Start run gating are unchanged.

Stacked on `codex/workflows-gen2-pr7-builder-launch` (the gen-2 integration tip), same as #1906 — the dialog only exists on this stack.

## Testing

- Tier 1: `WorkflowTriggerDialog.test.tsx` updated and extended (8 tests) — collapsed-summary default + Change reveal, auto-expand when the saved default is unlisted, authored-description rendering, plus the pre-existing gating/argument/placement suites. Full `src/components/workflows` + `src/hooks/workflows` vitest run green (137 tests). `tsc -p tsconfig.json --noEmit` clean.
- Tier 2: `tests/intent/specs/workflow-trigger-seam.spec.ts` needs no changes — its seeded definition has `defaultRepoConfigId: null`, which renders the location controls expanded from first paint, and it addresses fields by id.

## Observability

- None. The existing launch diagnostics in `use-workflow-trigger-actions.ts` are unchanged.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Verification

- To verify manually: Workflows page → Run on a definition with a saved default repository → dialog shows inputs plus the one-line location summary; Change reveals Repository/Placement. Run on a definition without a default → controls are expanded immediately and Start run stays disabled until a repository is picked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)