### PR TITLE
feat(workflows): title node sessions with their chain index (PRO-277)

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/sessions/store/workflow_links.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/store/workflow_links.rs
@@ -10,18 +10,33 @@ use rusqlite::{params, OptionalExtension};
 use super::SessionStore;
 
 impl SessionStore {
-    /// Link a session to the workflow node it executes.
+    /// Link a session to the workflow node it executes, naming it with the
+    /// node's title when it has none yet. The launch path creates node
+    /// sessions untitled and prompts below the HTTP layer's fallback titling,
+    /// so this link is the one write that names them (PRO-277); riding the
+    /// same statement keeps link and name atomic, and the CASE keeps a user
+    /// rename or any other pre-assigned title authoritative.
     pub fn link_workflow_columns(
         &self,
         session_id: &str,
         workflow_run_id: &str,
         workflow_node_row_id: &str,
+        fallback_title: &str,
     ) -> anyhow::Result<()> {
+        let now = chrono::Utc::now().to_rfc3339();
         self.db.with_conn(|conn| {
             conn.execute(
-                "UPDATE sessions SET workflow_run_id = ?2, workflow_node_row_id = ?3
+                "UPDATE sessions SET workflow_run_id = ?2, workflow_node_row_id = ?3,
+                     title = CASE WHEN title IS NULL OR TRIM(title) = '' THEN ?4 ELSE title END,
+                     updated_at = ?5
                  WHERE id = ?1",
-                params![session_id, workflow_run_id, workflow_node_row_id],
+                params![
+                    session_id,
+                    workflow_run_id,
+                    workflow_node_row_id,
+                    fallback_title,
+                    now
+                ],
             )?;
             Ok(())
         })
@@ -56,5 +71,64 @@ impl SessionStore {
                 _ => None,
             })
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::app::test_support;
+    use crate::domains::sessions::store::SessionStore;
+    use crate::persistence::Db;
+
+    fn seed_session(db: &Db, id: &str, title: Option<&str>) {
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO sessions (
+                    id, workspace_id, agent_kind, native_session_id,
+                    requested_model_id, current_model_id, requested_mode_id, current_mode_id,
+                    title, thinking_level_id, thinking_budget_tokens, status,
+                    created_at, updated_at, last_prompt_at, closed_at, dismissed_at,
+                    mcp_bindings_ciphertext, mcp_binding_summaries_json, system_prompt_append,
+                    origin_json, subagents_enabled
+                ) VALUES (
+                    ?1, 'workspace-1', 'claude', NULL, NULL, NULL, NULL, NULL, ?2, NULL, NULL,
+                    'idle', ?3, ?3, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1
+                )",
+                rusqlite::params![id, title, "2026-03-25T00:00:00Z"],
+            )?;
+            Ok(())
+        })
+        .expect("seed session");
+    }
+
+    #[test]
+    fn linking_names_an_untitled_session_and_keeps_an_assigned_title() {
+        let db = Db::open_in_memory().expect("open db");
+        test_support::seed_workspace_with_repo_root(&db, "workspace-1", "local", "/tmp/workspace");
+        seed_session(&db, "untitled-1", None);
+        seed_session(&db, "named-1", Some("Kept name"));
+        let store = SessionStore::new(db);
+
+        store
+            .link_workflow_columns("untitled-1", "run-1", "row-1", "01 · Plan")
+            .expect("link untitled");
+        store
+            .link_workflow_columns("named-1", "run-1", "row-2", "02 · Ship")
+            .expect("link named");
+
+        let untitled = store.find_by_id("untitled-1").expect("load").expect("exists");
+        assert_eq!(untitled.title.as_deref(), Some("01 · Plan"));
+        let named = store.find_by_id("named-1").expect("load").expect("exists");
+        assert_eq!(named.title.as_deref(), Some("Kept name"));
+        assert_eq!(
+            store.workflow_columns("untitled-1").expect("columns"),
+            Some(("run-1".to_string(), "row-1".to_string()))
+        );
+
+        // Unlink keeps the name: the disposed session survives as evidence.
+        store.clear_workflow_columns("untitled-1").expect("clear");
+        assert_eq!(store.workflow_columns("untitled-1").expect("columns"), None);
+        let cleared = store.find_by_id("untitled-1").expect("load").expect("exists");
+        assert_eq!(cleared.title.as_deref(), Some("01 · Plan"));
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/mod.rs
@@ -28,6 +28,9 @@ mod definition_tests;
 #[path = "materialize_tests.rs"]
 mod materialize_tests;
 #[cfg(test)]
+#[path = "model_tests.rs"]
+mod model_tests;
+#[cfg(test)]
 #[path = "render_tests.rs"]
 mod render_tests;
 #[cfg(test)]

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/model.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/model.rs
@@ -269,6 +269,20 @@ pub struct WorkflowRunNodeRecord {
     pub completed_at: Option<String>,
 }
 
+impl WorkflowRunNodeRecord {
+    /// The node's session title: the graph card's own index line — one-based
+    /// chain position, zero-padded to two digits, "--" for a row with no
+    /// position — so the header tab, the roster, and the card all name the
+    /// node identically (`nodeIndexTitle` in the client's node-card copy).
+    pub fn session_title(&self) -> String {
+        let index_label = match self.chain_index {
+            Some(index) => format!("{:02}", index + 1),
+            None => "--".to_string(),
+        };
+        format!("{index_label} · {}", self.title)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkflowRunDocRecord {
     pub id: String,

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/model_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/model_tests.rs
@@ -1,0 +1,39 @@
+//! `session_title` pins the card's index-line format (one-based, two-digit,
+//! "--" without a chain position) — the string every node session is named
+//! with when the actor links it (PRO-277).
+
+use super::model::{
+    WorkflowNodeKind, WorkflowNodeStatus, WorkflowNodeType, WorkflowRunNodeRecord,
+};
+
+fn node(chain_index: Option<i64>, title: &str) -> WorkflowRunNodeRecord {
+    WorkflowRunNodeRecord {
+        id: "row-1".into(),
+        run_id: "run-1".into(),
+        definition_node_id: None,
+        kind: WorkflowNodeKind::Defined,
+        node_type: WorkflowNodeType::Agent,
+        replaces_node_row_id: None,
+        anchor_node_row_id: None,
+        chain_index,
+        title: title.into(),
+        prompt: "p".into(),
+        status: WorkflowNodeStatus::Running,
+        session_id: None,
+        prompt_id: None,
+        model: None,
+        rendered_envelope: None,
+        failure_code: None,
+        first_turn_finished_at: None,
+        created_at: "now".into(),
+        started_at: None,
+        completed_at: None,
+    }
+}
+
+#[test]
+fn session_titles_mirror_the_card_index_line() {
+    assert_eq!(node(Some(0), "Plan").session_title(), "01 · Plan");
+    assert_eq!(node(Some(2), "Ship").session_title(), "03 · Ship");
+    assert_eq!(node(None, "Side").session_title(), "-- · Side");
+}

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/session_extension.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/session_extension.rs
@@ -362,7 +362,7 @@ mod tests {
         insert_session_row(&session_store, "workspace-1", "session-1", "idle");
         insert_session_row(&session_store, "workspace-1", "session-2", "idle");
         session_store
-            .link_workflow_columns("session-1", "run-x", "node-x")
+            .link_workflow_columns("session-1", "run-x", "node-x", "01 · Node")
             .expect("link workflow columns");
         WorkflowSessionExtension::new(session_store, WorkflowStore::new(db))
     }

--- a/anyharness/crates/anyharness-lib/src/live/workflows/actor.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/actor.rs
@@ -334,9 +334,12 @@ impl WorkflowActor {
         // through the sessions columns, and the extension matches turn reports
         // through them.
         let prompt_id = format!("wf2-{}", node.id);
-        self.deps
-            .session_store
-            .link_workflow_columns(&session.id, &self.run_id, &node.id)?;
+        self.deps.session_store.link_workflow_columns(
+            &session.id,
+            &self.run_id,
+            &node.id,
+            &node.session_title(),
+        )?;
         self.deps
             .store
             .stamp_session(&node.id, &session.id, Some(&prompt_id), Some(agent_kind))?;


### PR DESCRIPTION
## Summary

- Gen-2 workflow node sessions were created untitled, and the workflow actor dispatches prompts below the HTTP layer's fallback titling, so every node session tab in the workspace header read as the bare provider name ("Codex") — indistinguishable in the ⌘⌥1-9 tab index the ticket screenshot shows. The node's identity ("NN · title", its `chainIndex` line) existed only on the right-panel graph card.
- Fix: name the session where the actor already links it. `link_workflow_columns` now carries the node card's own index line — `NN · <node title>` (one-based, zero-padded, `--` for a row with no chain position, matching `nodeIndexTitle` in the client's node-card copy) — in the same UPDATE, so link and name land atomically. The `CASE` keeps a user rename or any pre-assigned title authoritative, and later harness-provided titles already defer to an assigned title.
- The format lives on the model as `WorkflowRunNodeRecord::session_title()`; the actor passes it as the link's fourth argument. No client change needed — tabs, roster, and cmd-k already render `session.title`.

Linear: [PRO-277 — Node sessions should be indexed](https://linear.app/proliferate-team/issue/PRO-277/node-sessions-should-be-indexed)

## Testing

- Store seam (Tier 0/1, real migrations): `linking_names_an_untitled_session_and_keeps_an_assigned_title` in `workflow_links.rs` — untitled session gets the node title, an assigned title survives the link, and unlink keeps the name.
- Format pin: `session_titles_mirror_the_card_index_line` in `domains/workflows/model_tests.rs` (one-based, two-digit, `--` fallback).
- `cargo test -p anyharness-lib workflow` → 163 passed, 0 failed on this branch (lifecycle, actor, transition, store, extension suites included).
- `live/workflows/lifecycle_tests.rs` is intentionally untouched: it sits exactly at its frozen 600-line-checker cap (allowlisted 1070), so the happy-path e2e title assertion is omitted rather than raising the cap; the store-seam test covers the write and the actor's one-line wiring is visible in this diff. Flagging that trade-off explicitly for review.

### Manual verification

1. Run a workflow with 2+ nodes from the Workflows page.
2. Open the run's workspace: node session tabs read `01 · <node title>`, `02 · <node title>` instead of "Codex"/"Claude".
3. Hold ⌘ (~1s) to reveal the tab index: the ⌘⌥1-9 pills sit next to identifiable node names, matching the right-panel node cards.
4. Rename a node session tab, then fail & redo another node: the rename survives; the replacement's fresh session is titled with the same `NN` position.

## Observability

- None — no new logs or telemetry; the title rides an existing store write.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Verification

- `python3 scripts/check_max_lines.py` passes with the checker and allowlist untouched (`actor.rs` at 597/600, no allowlist entry; `lifecycle_tests.rs` byte-identical to main).
- `cargo test -p anyharness-lib workflow` → 163 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
