### PR TITLE
fix(product): PRO-100 settle creation config intents once

### DIFF
--- a/apps/packages/product-client/src/domain/sessions/intents/session-intent-model.ts
+++ b/apps/packages/product-client/src/domain/sessions/intents/session-intent-model.ts
@@ -76,6 +76,8 @@ export type SessionConfigIntentApplyState = "applied" | "queued";
 
 export interface SessionUpdateConfigIntent extends SessionIntentBase {
   kind: "update_config";
+  /** Advances when queued-tail coalescing reuses this intent ID for a new choice. */
+  generation: number;
   controlKey: string;
   rawConfigId: string | null;
   value: string;
@@ -189,6 +191,7 @@ export function createUpdateConfigIntent(input: {
     dispatchedAt: null,
     acceptedAt: null,
     reconciledAt: null,
+    generation: 1,
     controlKey: input.controlKey,
     rawConfigId: input.rawConfigId,
     value: input.value,

--- a/apps/packages/product-client/src/domain/sessions/intents/session-intent-model.ts
+++ b/apps/packages/product-client/src/domain/sessions/intents/session-intent-model.ts
@@ -76,7 +76,8 @@ export type SessionConfigIntentApplyState = "applied" | "queued";
 
 export interface SessionUpdateConfigIntent extends SessionIntentBase {
   kind: "update_config";
-  configId: string;
+  controlKey: string;
+  rawConfigId: string | null;
   value: string;
   applyState: SessionConfigIntentApplyState | null;
   persistDefaultPreference: boolean;
@@ -168,7 +169,8 @@ export function createUpdateConfigIntent(input: {
   clientSessionId: string;
   materializedSessionId?: string | null;
   workspaceId?: string | null;
-  configId: string;
+  controlKey: string;
+  rawConfigId: string | null;
   value: string;
   persistDefaultPreference?: boolean;
   now?: string;
@@ -187,7 +189,8 @@ export function createUpdateConfigIntent(input: {
     dispatchedAt: null,
     acceptedAt: null,
     reconciledAt: null,
-    configId: input.configId,
+    controlKey: input.controlKey,
+    rawConfigId: input.rawConfigId,
     value: input.value,
     applyState: null,
     persistDefaultPreference: input.persistDefaultPreference ?? true,

--- a/apps/packages/product-client/src/domain/sessions/intents/session-intent-reconciliation.ts
+++ b/apps/packages/product-client/src/domain/sessions/intents/session-intent-reconciliation.ts
@@ -99,7 +99,7 @@ export function reconcileOutboxFromEnvelopes(
           // reverts (PRO-261). "dispatching" stays reconcilable: that
           // intent's own echo may legitimately beat its HTTP response.
           && (intent.status === "accepted" || intent.status === "dispatching")
-          && getAuthoritativeConfigValue(event.liveConfig, intent.configId) === intent.value
+          && getAuthoritativeConfigValue(event.liveConfig, intent.rawConfigId) === intent.value
         ) {
           nextState = patchPromptOutboxEntry(nextState, intent.intentId, {
             status: "reconciled",

--- a/apps/packages/product-client/src/domain/sessions/intents/session-intent-selectors.ts
+++ b/apps/packages/product-client/src/domain/sessions/intents/session-intent-selectors.ts
@@ -61,7 +61,7 @@ export function pendingConfigChangesForSessionIntents(
     const pendingChange = pendingConfigChangeFromIntent(intent);
     if (pendingChange) {
       pendingConfigChanges ??= {};
-      pendingConfigChanges[intent.configId] = pendingChange;
+      pendingConfigChanges[intent.rawConfigId ?? intent.controlKey] = pendingChange;
     }
   }
   return pendingConfigChanges ?? EMPTY_INTENT_PENDING_CONFIG_CHANGES;
@@ -300,7 +300,10 @@ function pendingConfigChangeFromIntent(
 ): PendingSessionConfigChange | null {
   if (intent.status === "queued" || intent.status === "preparing" || intent.status === "dispatching") {
     return {
-      rawConfigId: intent.configId,
+      // Pending projection may use the semantic key while a launch-only
+      // intent has no authoritative harness target yet. Dispatch never reads
+      // this projection key.
+      rawConfigId: intent.rawConfigId ?? intent.controlKey,
       value: intent.value,
       // Pre-dispatch "queued" is a transient store state, not a turn-blocked
       // change — surfacing it as pending-"queued" flashes the clock glyph on
@@ -320,7 +323,7 @@ function pendingConfigChangeFromIntent(
   // value matches the requested one.
   if (intent.status === "accepted") {
     return {
-      rawConfigId: intent.configId,
+      rawConfigId: intent.rawConfigId ?? intent.controlKey,
       value: intent.value,
       // applyState "queued" is still pending at the backend (mid-turn) → clock.
       // Otherwise the backend already applied it and we are only holding the

--- a/apps/packages/product-client/src/domain/sessions/intents/session-intent-state.ts
+++ b/apps/packages/product-client/src/domain/sessions/intents/session-intent-state.ts
@@ -45,13 +45,13 @@ export function upsertSessionIntent(
 export function findSupersedableTailConfigIntent(
   state: SessionIntentStateShape,
   clientSessionId: string,
-  configId: string,
+  controlKey: string,
 ): SessionUpdateConfigIntent | null {
   const intentIds = state.intentIdsByClientSessionId[clientSessionId] ?? [];
   const tailId = intentIds[intentIds.length - 1];
   const tail = tailId ? state.entriesById[tailId] : undefined;
   return tail?.kind === "update_config"
-    && tail.configId === configId
+    && tail.controlKey === controlKey
     && tail.status === "queued"
     ? tail
     : null;

--- a/apps/packages/product-client/src/domain/sessions/intents/session-intent-state.ts
+++ b/apps/packages/product-client/src/domain/sessions/intents/session-intent-state.ts
@@ -1,9 +1,9 @@
-import {
+import type {
   createUpdateConfigIntent,
-  type PromptOutboxEntry,
-  type SessionIntent,
-  type SessionSendPromptIntent,
-  type SessionUpdateConfigIntent,
+  PromptOutboxEntry,
+  SessionIntent,
+  SessionSendPromptIntent,
+  SessionUpdateConfigIntent,
 } from "./session-intent-model";
 
 export interface SessionIntentStateShape {
@@ -66,43 +66,6 @@ export function findSupersedableTailConfigIntent(
     && tail.status === "queued"
     ? tail
     : null;
-}
-
-export function createOrSupersedeConfigIntent(
-  state: SessionIntentStateShape,
-  input: SessionConfigIntentEnqueueInput,
-  createIntentId: () => string,
-): { intent: SessionUpdateConfigIntent; superseded: boolean } {
-  const controlKey = input.controlKey ?? input.configId;
-  if (!controlKey) {
-    throw new Error("A semantic control key is required for a launch-only config intent");
-  }
-  const supersedable = input.intentId
-    ? null
-    : findSupersedableTailConfigIntent(state, input.clientSessionId, controlKey);
-  const intent = supersedable
-    ? {
-      ...supersedable,
-      generation: supersedable.generation + 1,
-      rawConfigId: input.configId,
-      value: input.value,
-      materializedSessionId: input.materializedSessionId ?? supersedable.materializedSessionId,
-      workspaceId: input.workspaceId ?? supersedable.workspaceId,
-      persistDefaultPreference: input.persistDefaultPreference ?? supersedable.persistDefaultPreference,
-      updatedAt: new Date().toISOString(),
-    }
-    : createUpdateConfigIntent({
-      clientSessionId: input.clientSessionId,
-      materializedSessionId: input.materializedSessionId,
-      workspaceId: input.workspaceId,
-      controlKey,
-      rawConfigId: input.configId,
-      value: input.value,
-      persistDefaultPreference: input.persistDefaultPreference,
-      now: input.now,
-      intentId: input.intentId ?? createIntentId(),
-    });
-  return { intent, superseded: Boolean(supersedable) };
 }
 
 export function patchSessionIntent(

--- a/apps/packages/product-client/src/domain/sessions/intents/session-intent-state.ts
+++ b/apps/packages/product-client/src/domain/sessions/intents/session-intent-state.ts
@@ -1,8 +1,9 @@
-import type {
-  PromptOutboxEntry,
-  SessionIntent,
-  SessionSendPromptIntent,
-  SessionUpdateConfigIntent,
+import {
+  createUpdateConfigIntent,
+  type PromptOutboxEntry,
+  type SessionIntent,
+  type SessionSendPromptIntent,
+  type SessionUpdateConfigIntent,
 } from "./session-intent-model";
 
 export interface SessionIntentStateShape {
@@ -11,6 +12,16 @@ export interface SessionIntentStateShape {
 }
 
 export type PromptOutboxStateShape = SessionIntentStateShape;
+
+export type SessionConfigIntentEnqueueInput = Omit<
+  Parameters<typeof createUpdateConfigIntent>[0],
+  "intentId" | "controlKey" | "rawConfigId"
+> & {
+  intentId?: string;
+} & (
+  | { configId: string; controlKey?: string }
+  | { configId: null; controlKey: string }
+);
 
 export function upsertSessionIntent(
   state: SessionIntentStateShape,
@@ -55,6 +66,43 @@ export function findSupersedableTailConfigIntent(
     && tail.status === "queued"
     ? tail
     : null;
+}
+
+export function createOrSupersedeConfigIntent(
+  state: SessionIntentStateShape,
+  input: SessionConfigIntentEnqueueInput,
+  createIntentId: () => string,
+): { intent: SessionUpdateConfigIntent; superseded: boolean } {
+  const controlKey = input.controlKey ?? input.configId;
+  if (!controlKey) {
+    throw new Error("A semantic control key is required for a launch-only config intent");
+  }
+  const supersedable = input.intentId
+    ? null
+    : findSupersedableTailConfigIntent(state, input.clientSessionId, controlKey);
+  const intent = supersedable
+    ? {
+      ...supersedable,
+      generation: supersedable.generation + 1,
+      rawConfigId: input.configId,
+      value: input.value,
+      materializedSessionId: input.materializedSessionId ?? supersedable.materializedSessionId,
+      workspaceId: input.workspaceId ?? supersedable.workspaceId,
+      persistDefaultPreference: input.persistDefaultPreference ?? supersedable.persistDefaultPreference,
+      updatedAt: new Date().toISOString(),
+    }
+    : createUpdateConfigIntent({
+      clientSessionId: input.clientSessionId,
+      materializedSessionId: input.materializedSessionId,
+      workspaceId: input.workspaceId,
+      controlKey,
+      rawConfigId: input.configId,
+      value: input.value,
+      persistDefaultPreference: input.persistDefaultPreference,
+      now: input.now,
+      intentId: input.intentId ?? createIntentId(),
+    });
+  return { intent, superseded: Boolean(supersedable) };
 }
 
 export function patchSessionIntent(

--- a/apps/packages/product-client/src/domain/sessions/intents/session-intent.test.ts
+++ b/apps/packages/product-client/src/domain/sessions/intents/session-intent.test.ts
@@ -68,7 +68,8 @@ describe("session intents", () => {
     const config = createUpdateConfigIntent({
       intentId: "config-1",
       clientSessionId: "session-1",
-      configId: "reasoning",
+      controlKey: "reasoning",
+      rawConfigId: "reasoning",
       value: "high",
     });
     const secondPrompt = createSendPromptIntent({
@@ -101,14 +102,16 @@ describe("session intents", () => {
     const queued = createUpdateConfigIntent({
       intentId: "config-1",
       clientSessionId: "session-1",
-      configId: "effort",
+      controlKey: "effort",
+      rawConfigId: "reasoning_effort",
       value: "xhigh",
     });
     const acceptedQueued = {
       ...createUpdateConfigIntent({
         intentId: "config-2",
         clientSessionId: "session-1",
-        configId: "mode",
+        controlKey: "mode",
+        rawConfigId: "mode",
         value: "plan",
       }),
       status: "accepted" as const,
@@ -118,7 +121,11 @@ describe("session intents", () => {
     expect(pendingConfigChangesForSessionIntents([queued, acceptedQueued])).toMatchObject({
       // Pre-dispatch queued surfaces as "submitting" (no clock flash);
       // only accepted+applyState:"queued" is genuinely turn-blocked.
-      effort: { rawConfigId: "effort", value: "xhigh", status: "submitting" },
+      reasoning_effort: {
+        rawConfigId: "reasoning_effort",
+        value: "xhigh",
+        status: "submitting",
+      },
       mode: { rawConfigId: "mode", value: "plan", status: "queued" },
     });
   });
@@ -128,7 +135,8 @@ describe("session intents", () => {
       ...createUpdateConfigIntent({
         intentId: "config-applied",
         clientSessionId: "session-1",
-        configId: "mode",
+        controlKey: "mode",
+        rawConfigId: "mode",
         value: "plan",
       }),
       status: "accepted" as const,
@@ -154,7 +162,8 @@ describe("session intents", () => {
       ...createUpdateConfigIntent({
         intentId: "config-default",
         clientSessionId: "session-1",
-        configId: "mode",
+        controlKey: "mode",
+        rawConfigId: "mode",
         value: "default",
       }),
       status: "accepted" as const,
@@ -163,7 +172,8 @@ describe("session intents", () => {
     const latest = createUpdateConfigIntent({
       intentId: "config-plan",
       clientSessionId: "session-1",
-      configId: "mode",
+      controlKey: "mode",
+      rawConfigId: "mode",
       value: "plan",
     });
 
@@ -178,7 +188,8 @@ describe("session intents", () => {
       ...createUpdateConfigIntent({
         intentId: "config-plan",
         clientSessionId: "session-1",
-        configId: "mode",
+        controlKey: "mode",
+        rawConfigId: "mode",
         value: "plan",
       }),
       status: "failed" as const,
@@ -252,7 +263,8 @@ describe("session intents", () => {
       ...createUpdateConfigIntent({
         intentId: "config-failed",
         clientSessionId: "session-1",
-        configId: "mode",
+        controlKey: "mode",
+        rawConfigId: "mode",
         value: "plan",
       }),
       status: "failed",
@@ -260,7 +272,8 @@ describe("session intents", () => {
     state = upsertSessionIntent(state, createUpdateConfigIntent({
       intentId: "config-next",
       clientSessionId: "session-1",
-      configId: "effort",
+      controlKey: "effort",
+      rawConfigId: "reasoning_effort",
       value: "high",
     }));
 
@@ -291,7 +304,8 @@ describe("session intents", () => {
         ...createUpdateConfigIntent({
           intentId: "ignored-config",
           clientSessionId: "session-1",
-          configId: "mode",
+          controlKey: "mode",
+          rawConfigId: "mode",
           value: "plan",
         }),
       },
@@ -349,7 +363,8 @@ describe("session intents", () => {
       ...createUpdateConfigIntent({
         intentId: "config-1",
         clientSessionId: "session-1",
-        configId: "effort",
+        controlKey: "effort",
+        rawConfigId: "reasoning_effort",
         value: "high",
       }),
       status: "accepted",
@@ -387,7 +402,7 @@ describe("session intents", () => {
         timestamp: "2026-05-12T00:00:01Z",
         event: {
           type: "config_option_update",
-          liveConfig: liveConfig("effort", "high"),
+          liveConfig: liveConfig("reasoning_effort", "high"),
         },
         sessionId: "session-1",
       } as SessionEventEnvelope,
@@ -543,7 +558,8 @@ describe("session intents", () => {
       ...createUpdateConfigIntent({
         intentId: "config-session-1",
         clientSessionId: "session-1",
-        configId: "effort",
+        controlKey: "effort",
+        rawConfigId: "reasoning_effort",
         value: "high",
       }),
       status: "accepted",
@@ -553,7 +569,8 @@ describe("session intents", () => {
       ...createUpdateConfigIntent({
         intentId: "config-session-2",
         clientSessionId: "session-2",
-        configId: "effort",
+        controlKey: "effort",
+        rawConfigId: "reasoning_effort",
         value: "high",
       }),
       status: "accepted",
@@ -586,7 +603,7 @@ describe("session intents", () => {
         timestamp: "2026-05-12T00:00:00Z",
         event: {
           type: "config_option_update",
-          liveConfig: liveConfig("effort", "high"),
+          liveConfig: liveConfig("reasoning_effort", "high"),
         },
         sessionId: "session-1",
       } as SessionEventEnvelope,

--- a/apps/packages/product-client/src/domain/sessions/intents/session-intent.test.ts
+++ b/apps/packages/product-client/src/domain/sessions/intents/session-intent.test.ts
@@ -1,7 +1,4 @@
-import type {
-  SessionEventEnvelope,
-  SessionLiveConfigSnapshot,
-} from "@anyharness/sdk";
+import type { SessionEventEnvelope, SessionLiveConfigSnapshot } from "@anyharness/sdk";
 import { createTranscriptState } from "@anyharness/sdk";
 import { describe, expect, it } from "vitest";
 import {
@@ -22,9 +19,7 @@ import {
   upsertSessionIntent,
   type SessionIntentStateShape,
 } from "./session-intent-state";
-import {
-  reconcileOutboxFromEnvelopes,
-} from "./session-intent-reconciliation";
+import { reconcileOutboxFromEnvelopes } from "./session-intent-reconciliation";
 
 describe("session intents", () => {
   it("keeps queue-placed sends out of the transcript while preserving failed sends", () => {
@@ -102,16 +97,14 @@ describe("session intents", () => {
     const queued = createUpdateConfigIntent({
       intentId: "config-1",
       clientSessionId: "session-1",
-      controlKey: "effort",
-      rawConfigId: "reasoning_effort",
+      controlKey: "effort", rawConfigId: "reasoning_effort",
       value: "xhigh",
     });
     const acceptedQueued = {
       ...createUpdateConfigIntent({
         intentId: "config-2",
         clientSessionId: "session-1",
-        controlKey: "mode",
-        rawConfigId: "mode",
+        controlKey: "mode", rawConfigId: "mode",
         value: "plan",
       }),
       status: "accepted" as const,
@@ -135,8 +128,7 @@ describe("session intents", () => {
       ...createUpdateConfigIntent({
         intentId: "config-applied",
         clientSessionId: "session-1",
-        controlKey: "mode",
-        rawConfigId: "mode",
+        controlKey: "mode", rawConfigId: "mode",
         value: "plan",
       }),
       status: "accepted" as const,
@@ -162,8 +154,7 @@ describe("session intents", () => {
       ...createUpdateConfigIntent({
         intentId: "config-default",
         clientSessionId: "session-1",
-        controlKey: "mode",
-        rawConfigId: "mode",
+        controlKey: "mode", rawConfigId: "mode",
         value: "default",
       }),
       status: "accepted" as const,
@@ -172,8 +163,7 @@ describe("session intents", () => {
     const latest = createUpdateConfigIntent({
       intentId: "config-plan",
       clientSessionId: "session-1",
-      controlKey: "mode",
-      rawConfigId: "mode",
+      controlKey: "mode", rawConfigId: "mode",
       value: "plan",
     });
 
@@ -188,8 +178,7 @@ describe("session intents", () => {
       ...createUpdateConfigIntent({
         intentId: "config-plan",
         clientSessionId: "session-1",
-        controlKey: "mode",
-        rawConfigId: "mode",
+        controlKey: "mode", rawConfigId: "mode",
         value: "plan",
       }),
       status: "failed" as const,
@@ -263,8 +252,7 @@ describe("session intents", () => {
       ...createUpdateConfigIntent({
         intentId: "config-failed",
         clientSessionId: "session-1",
-        controlKey: "mode",
-        rawConfigId: "mode",
+        controlKey: "mode", rawConfigId: "mode",
         value: "plan",
       }),
       status: "failed",
@@ -272,8 +260,7 @@ describe("session intents", () => {
     state = upsertSessionIntent(state, createUpdateConfigIntent({
       intentId: "config-next",
       clientSessionId: "session-1",
-      controlKey: "effort",
-      rawConfigId: "reasoning_effort",
+      controlKey: "effort", rawConfigId: "reasoning_effort",
       value: "high",
     }));
 
@@ -304,8 +291,7 @@ describe("session intents", () => {
         ...createUpdateConfigIntent({
           intentId: "ignored-config",
           clientSessionId: "session-1",
-          controlKey: "mode",
-          rawConfigId: "mode",
+          controlKey: "mode", rawConfigId: "mode",
           value: "plan",
         }),
       },
@@ -363,8 +349,7 @@ describe("session intents", () => {
       ...createUpdateConfigIntent({
         intentId: "config-1",
         clientSessionId: "session-1",
-        controlKey: "effort",
-        rawConfigId: "reasoning_effort",
+        controlKey: "effort", rawConfigId: "reasoning_effort",
         value: "high",
       }),
       status: "accepted",
@@ -558,8 +543,7 @@ describe("session intents", () => {
       ...createUpdateConfigIntent({
         intentId: "config-session-1",
         clientSessionId: "session-1",
-        controlKey: "effort",
-        rawConfigId: "reasoning_effort",
+        controlKey: "effort", rawConfigId: "reasoning_effort",
         value: "high",
       }),
       status: "accepted",
@@ -569,8 +553,7 @@ describe("session intents", () => {
       ...createUpdateConfigIntent({
         intentId: "config-session-2",
         clientSessionId: "session-2",
-        controlKey: "effort",
-        rawConfigId: "reasoning_effort",
+        controlKey: "effort", rawConfigId: "reasoning_effort",
         value: "high",
       }),
       status: "accepted",

--- a/apps/packages/product-client/src/domain/sessions/intents/session-intent.test.ts
+++ b/apps/packages/product-client/src/domain/sessions/intents/session-intent.test.ts
@@ -427,7 +427,7 @@ describe("session intents", () => {
       ...createUpdateConfigIntent({
         intentId: "config-1",
         clientSessionId: "session-1",
-        configId: "mode",
+        controlKey: "mode", rawConfigId: "mode",
         value: "plan",
       }),
       status: "accepted" as const,
@@ -441,7 +441,7 @@ describe("session intents", () => {
       state = upsertSessionIntent(state, createUpdateConfigIntent({
         intentId,
         clientSessionId: "session-1",
-        configId: "mode",
+        controlKey: "mode", rawConfigId: "mode",
         value,
       }));
     }

--- a/apps/packages/product-client/src/hooks/chat/facade/use-chat-session-controls.ts
+++ b/apps/packages/product-client/src/hooks/chat/facade/use-chat-session-controls.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from "react";
 import {
   buildLiveSessionControlDescriptors,
   type LiveSessionControlDescriptor,
+  type SupportedLiveControlKey,
 } from "#product/lib/domain/chat/session-controls/session-controls";
 import {
   buildComposerSessionControlGroups,
@@ -24,8 +25,12 @@ export function useChatSessionControls(): {
   const showErrorToast = useToastStore((state) => state.showError);
   const { setActiveSessionConfigOption } = useSessionConfigActions();
 
-  const onSelect = useCallback(function onSelect(rawConfigId: string, value: string) {
-    void setActiveSessionConfigOption(rawConfigId, value).catch((error) => {
+  const onSelect = useCallback(function onSelect(
+    controlKey: SupportedLiveControlKey,
+    rawConfigId: string,
+    value: string,
+  ) {
+    void setActiveSessionConfigOption(rawConfigId, value, { controlKey }).catch((error) => {
       const message = error instanceof Error ? error.message : String(error);
       showErrorToast({
         headline: "Setting not changed",
@@ -34,7 +39,7 @@ export function useChatSessionControls(): {
         // that can say which choice did not take.
         consequence: `The session is still on its previous value, not ${value}.`,
         cause: message,
-        retry: () => onSelect(rawConfigId, value),
+        retry: () => onSelect(controlKey, rawConfigId, value),
       });
     });
   }, [setActiveSessionConfigOption, showErrorToast]);

--- a/apps/packages/product-client/src/hooks/chat/workflows/use-chat-launch-control-actions.ts
+++ b/apps/packages/product-client/src/hooks/chat/workflows/use-chat-launch-control-actions.ts
@@ -23,19 +23,19 @@ export function useChatLaunchControlActions({
       return;
     }
 
-    void setActiveSessionConfigOption(rawConfigId, value).catch(() => {
-      updateDefaultLaunchControlPreference(activeLaunchAgentKind, rawConfigId, value);
+    void setActiveSessionConfigOption(rawConfigId, value, { controlKey }).catch(() => {
+      updateDefaultLaunchControlPreference(activeLaunchAgentKind, controlKey, value);
     });
   }, [activeLaunchAgentKind, setActiveSessionConfigOption]);
 }
 
 function updateDefaultLaunchControlPreference(
   agentKind: string,
-  rawConfigId: string,
+  controlKey: string,
   value: string,
 ): void {
   const state = useUserPreferencesStore.getState();
-  if (rawConfigId === "mode") {
+  if (controlKey === "mode") {
     state.set("defaultSessionModeByAgentKind", {
       ...state.defaultSessionModeByAgentKind,
       [agentKind]: value,
@@ -47,7 +47,7 @@ function updateDefaultLaunchControlPreference(
     ...state.defaultLiveSessionControlValuesByAgentKind,
     [agentKind]: {
       ...state.defaultLiveSessionControlValuesByAgentKind[agentKind],
-      [rawConfigId]: value,
+      [controlKey]: value,
     },
   });
 }

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-intent-config-dispatch.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-intent-config-dispatch.test.ts
@@ -3,6 +3,7 @@ import type {
   SessionLiveConfigSnapshot,
   SetSessionConfigOptionResponse,
 } from "@anyharness/sdk";
+import { AnyHarnessError } from "@anyharness/sdk";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CONFIG_INTENT_DISPATCH_TIMEOUT_MS,
@@ -53,25 +54,48 @@ describe("dispatchConfigIntent", () => {
     vi.useRealTimers();
   });
 
-  it("drops the optimistic intent and reports runtime rejection language", async () => {
+  it("uses the raw id and reports one genuine typed runtime rejection", async () => {
+    putSessionRecord(createEmptySessionRecord("session-1", "codex", {
+      workspaceId: "workspace-1",
+      materializedSessionId: "runtime-session-1",
+      liveConfig: codexLiveConfig("high", "off", 1),
+      modelId: "gpt-5.6-sol",
+    }));
     const intent = useSessionIntentStore.getState().enqueueConfig({
       intentId: "config-plan",
       clientSessionId: "session-1",
       materializedSessionId: "runtime-session-1",
       workspaceId: "workspace-1",
-      configId: "collaboration_mode",
-      value: "plan",
+      configId: "reasoning_effort",
+      controlKey: "effort",
+      value: "max",
     });
     const onFailure = vi.fn();
-    mocks.mutateAsync.mockRejectedValue(new Error("request timed out"));
+    mocks.mutateAsync.mockRejectedValue(new AnyHarnessError({
+      type: "urn:proliferate:anyharness:problem:config-change-rejected",
+      title: "Config change rejected",
+      status: 422,
+      detail: "The runtime rejected the requested config change.",
+    }));
 
     await dispatchConfigIntent(intent, createDeps(onFailure));
 
     expect(useSessionIntentStore.getState().entriesById[intent.intentId]).toMatchObject({
       status: "failed",
-      errorMessage: "request timed out",
+      errorMessage: "The runtime rejected the requested config change.",
     });
-    expect(onFailure).toHaveBeenCalledWith("request timed out");
+    expect(mocks.mutateAsync).toHaveBeenCalledTimes(1);
+    expect(mocks.mutateAsync).toHaveBeenCalledWith(expect.objectContaining({
+      request: { configId: "reasoning_effort", value: "max" },
+    }));
+    expect(onFailure).toHaveBeenCalledTimes(1);
+    expect(onFailure).toHaveBeenCalledWith(
+      "The runtime rejected the requested config change.",
+    );
+    expect(
+      useSessionDirectoryStore.getState().entriesById["session-1"]
+        ?.liveConfig?.normalizedControls.effort?.currentValue,
+    ).toBe("high");
   });
 
   it("times out a stalled request, rolls back once, and ignores its late completion", async () => {

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-intent-config-dispatch.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-intent-config-dispatch.ts
@@ -59,6 +59,14 @@ export async function dispatchConfigIntent(
   // be superseded in place (tail coalescing) after the dispatcher selects it,
   // and the wire payload must carry the superseding value.
   const intent = current;
+  if (!intent.rawConfigId) {
+    useSessionIntentStore.getState().patchIntent(intent.intentId, {
+      status: "stale",
+      errorMessage: null,
+    });
+    return;
+  }
+  const rawConfigId = intent.rawConfigId;
   const dispatchedAt = new Date().toISOString();
   useSessionIntentStore.getState().patchIntent(intent.intentId, {
     status: "dispatching",
@@ -84,7 +92,7 @@ export async function dispatchConfigIntent(
         const response = await deps.setSessionConfigOptionMutation.mutateAsync({
           workspaceId: target.workspaceId,
           sessionId: target.materializedSessionId,
-          request: { configId: intent.configId, value: intent.value },
+          request: { configId: rawConfigId, value: intent.value },
           requestOptions: { signal },
           awaitInvalidations: false,
         });
@@ -108,9 +116,9 @@ export async function dispatchConfigIntent(
         ? responseLiveConfig
         : latestSlot.liveConfig;
       const isModelConfigIntent =
-        intent.configId === "model"
-        || responseLiveConfig?.normalizedControls.model?.rawConfigId === intent.configId
-        || latestSlot.liveConfig?.normalizedControls.model?.rawConfigId === intent.configId;
+        intent.controlKey === "model"
+        || responseLiveConfig?.normalizedControls.model?.rawConfigId === rawConfigId
+        || latestSlot.liveConfig?.normalizedControls.model?.rawConfigId === rawConfigId;
       const nextPatch = {
         agentKind: response.session.agentKind,
         executionSummary: response.session.executionSummary ?? latestSlot.executionSummary ?? null,
@@ -156,7 +164,7 @@ export async function dispatchConfigIntent(
         persistDefaultSessionControlPreference({
           agentKind: response.session.agentKind ?? latestSlot.agentKind,
           liveConfig: effectiveLiveConfig,
-          rawConfigId: intent.configId,
+          rawConfigId,
           requestedValue: intent.value,
           workspaceSurface: deps.getWorkspaceSurface(workspaceId),
         });
@@ -175,10 +183,10 @@ export async function dispatchConfigIntent(
       clientSessionId: intent.clientSessionId,
       workspaceId,
       materializedSessionId: response.session.id,
-      configId: intent.configId,
+      configId: rawConfigId,
       applyState: response.applyState,
     });
-    if (intent.configId === "mode") {
+    if (intent.controlKey === "mode") {
       // UX-latency R12: commit mark, only reached once a superseding dispatch
       // hasn't raced past this one (isCurrentConfigDispatch check above).
       finishRendererFlow({
@@ -196,7 +204,7 @@ export async function dispatchConfigIntent(
       status: "failed",
       errorMessage: message,
     });
-    if (intent.configId === "mode") {
+    if (intent.controlKey === "mode") {
       abandonRendererFlow({
         kind: "mode_switch",
         correlationKey: intent.intentId,

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-intent-dispatcher.test.tsx
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-intent-dispatcher.test.tsx
@@ -162,8 +162,9 @@ describe("useSessionIntentDispatcher", () => {
         clientSessionId: "session-1",
         materializedSessionId: "runtime-session-1",
         workspaceId: "workspace-1",
-        configId: "collaboration_mode",
-        value: "plan",
+        configId: "reasoning_effort",
+        controlKey: "effort",
+        value: "max",
       });
     });
 
@@ -175,7 +176,7 @@ describe("useSessionIntentDispatcher", () => {
     // and the exception is reachable only through Details.
     expect(mocks.showErrorToast).toHaveBeenCalledWith(expect.objectContaining({
       headline: "Setting not changed",
-      consequence: "collaboration_mode is still on its previous value, not plan.",
+      consequence: "effort is still on its previous value, not max.",
       cause: "request timed out",
     }));
     expect(mocks.showToast).not.toHaveBeenCalled();

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-intent-dispatcher.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-intent-dispatcher.ts
@@ -103,7 +103,7 @@ export function useSessionIntentDispatcher(): void {
             // thing left that can say which change did not take.
             showErrorToast({
               headline: "Setting not changed",
-              consequence: `${intent.configId} is still on its previous value, not ${intent.value}.`,
+              consequence: `${intent.controlKey} is still on its previous value, not ${intent.value}.`,
               cause: message,
               retry: () => void dispatchIntent(intent),
             });

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-control-contract.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-control-contract.ts
@@ -34,6 +34,7 @@ export interface LaunchPromptInput extends SessionLatencyFlowOptions {
 }
 
 export interface SessionConfigOptionUpdateOptions {
+  controlKey?: string;
   persistDefaultPreference?: boolean;
 }
 

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-config-intent-ownership.test.tsx
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-config-intent-ownership.test.tsx
@@ -7,39 +7,18 @@ import type {
 } from "@anyharness/sdk";
 import { AnyHarnessError } from "@anyharness/sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  selectNextDispatchableSessionIntent,
-} from "#product/domain/sessions/intents/session-intent-selectors";
-import {
-  sessionIntentsForSession,
-} from "#product/domain/sessions/intents/session-intent-state";
-import {
-  dispatchConfigIntent,
-  type ConfigIntentDispatchDeps,
-} from "#product/hooks/sessions/lifecycle/session-intent-config-dispatch";
-import {
-  materializeExistingSession,
-} from "#product/hooks/sessions/workflows/session-creation-materialization-helpers";
-import {
-  publishCreatedSessionMaterialization,
-} from "#product/hooks/sessions/workflows/session-creation-publication";
-import type {
-  SessionConfigModelRegistry,
-} from "#product/lib/domain/chat/launch/session-config";
-import {
-  configValuesFromIntentSnapshot,
-  planCreationConfigIntentSettlement,
-  snapshotPreMaterializationConfigIntents,
-} from "#product/lib/domain/sessions/creation/config-intent-settlement";
-import {
-  applySessionLaunchDefaults,
-} from "#product/lib/workflows/sessions/session-launch-defaults";
+import { selectNextDispatchableSessionIntent } from "#product/domain/sessions/intents/session-intent-selectors";
+import { sessionIntentsForSession } from "#product/domain/sessions/intents/session-intent-state";
+import { dispatchConfigIntent, type ConfigIntentDispatchDeps } from "#product/hooks/sessions/lifecycle/session-intent-config-dispatch";
+import { materializeExistingSession } from "#product/hooks/sessions/workflows/session-creation-materialization-helpers";
+import { publishCreatedSessionMaterialization } from "#product/hooks/sessions/workflows/session-creation-publication";
+import type { SessionConfigModelRegistry } from "#product/lib/domain/chat/launch/session-config";
+import { configValuesFromIntentSnapshot, planCreationConfigIntentSettlement,
+  snapshotPreMaterializationConfigIntents } from "#product/lib/domain/sessions/creation/config-intent-settlement";
+import { applySessionLaunchDefaults } from "#product/lib/workflows/sessions/session-launch-defaults";
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
 import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
-import {
-  createEmptySessionRecord,
-  putSessionRecord,
-} from "#product/stores/sessions/session-records";
+import { createEmptySessionRecord, putSessionRecord } from "#product/stores/sessions/session-records";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
 const mocks = vi.hoisted(() => ({
@@ -244,7 +223,7 @@ describe("session creation config-intent ownership", () => {
       "unconfirmed-latest": { status: "failed" },
     });
   });
-  it("resolves launch-only targets from an adopted session before binding", () => {
+  it("authoritatively classifies mapped launch intents before adoption binding", async () => {
     const fixture = strictConfigFixture({
       agentKind: "codex",
       applyState: "applied",
@@ -255,21 +234,14 @@ describe("session creation config-intent ownership", () => {
       values: ["high", "max"],
     });
     putProjectedRecord("client-adopted", "workspace-1", "codex", "gpt-5.5");
-    useSessionIntentStore.getState().enqueueConfig({
-      intentId: "adopted-supported",
-      clientSessionId: "client-adopted",
-      workspaceId: "workspace-1",
-      configId: null,
-      controlKey: "effort",
-      value: "max",
-    });
-    useSessionIntentStore.getState().enqueueConfig({
-      intentId: "adopted-unsupported",
-      clientSessionId: "client-adopted",
-      workspaceId: "workspace-1",
-      configId: null,
-      controlKey: "effort",
-      value: "ultra",
+    enqueueEffort("client-adopted", "catalog_reasoning_effort", "ultra", "adopted-unsupported");
+    enqueueEffort("client-adopted", "catalog_reasoning_effort", "max", "adopted-supported");
+    let classifiedBeforeBinding = false;
+    const unsubscribe = useSessionIntentStore.subscribe((state) => {
+      classifiedBeforeBinding ||=
+        state.entriesById["adopted-unsupported"]?.status === "stale"
+        && state.entriesById["adopted-supported"]?.rawConfigId === "reasoning_effort"
+        && state.entriesById["adopted-supported"]?.materializedSessionId === null;
     });
 
     materializeExistingSession({
@@ -281,7 +253,9 @@ describe("session creation config-intent ownership", () => {
       upsertWorkspaceSessionRecord: vi.fn(),
       workspaceId: "workspace-1",
     });
+    unsubscribe();
 
+    expect(classifiedBeforeBinding).toBe(true);
     expect(useSessionIntentStore.getState().entriesById).toMatchObject({
       "adopted-supported": {
         status: "queued",
@@ -294,6 +268,34 @@ describe("session creation config-intent ownership", () => {
         materializedSessionId: "runtime-adopted",
       },
     });
+    const next = selectNextDispatchableSessionIntent(
+      useSessionIntentStore.getState(),
+      "client-adopted",
+    );
+    expect(next).toMatchObject({
+      intentId: "adopted-supported",
+      controlKey: "effort",
+      rawConfigId: "reasoning_effort",
+    });
+
+    const liveMutation = vi.fn().mockResolvedValue(
+      configResponse(fixture.sessionWithValue("max")),
+    );
+    const onFailure = vi.fn();
+    mocks.getSessionClientAndWorkspace.mockResolvedValue({
+      workspaceId: "workspace-1",
+      materializedSessionId: "runtime-adopted",
+    });
+    await dispatchConfigIntent(
+      next as Extract<typeof next, { kind: "update_config" }>,
+      dispatchDeps(liveMutation, onFailure),
+    );
+
+    expect(liveMutation).toHaveBeenCalledTimes(1);
+    expect(liveMutation).toHaveBeenCalledWith(expect.objectContaining({
+      request: { configId: "reasoning_effort", value: "max" },
+    }));
+    expect(onFailure).not.toHaveBeenCalled();
   });
 });
 type ConfigSnapshot = ReturnType<typeof snapshotPreMaterializationConfigIntents>;

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-config-intent-ownership.test.tsx
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-config-intent-ownership.test.tsx
@@ -1,0 +1,598 @@
+import type {
+  AnyHarnessClient,
+  NormalizedSessionControl,
+  Session,
+  SessionLiveConfigSnapshot,
+  SetSessionConfigOptionResponse,
+} from "@anyharness/sdk";
+import { AnyHarnessError } from "@anyharness/sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  selectNextDispatchableSessionIntent,
+} from "#product/domain/sessions/intents/session-intent-selectors";
+import {
+  sessionIntentsForSession,
+} from "#product/domain/sessions/intents/session-intent-state";
+import {
+  dispatchConfigIntent,
+  type ConfigIntentDispatchDeps,
+} from "#product/hooks/sessions/lifecycle/session-intent-config-dispatch";
+import {
+  materializeExistingSession,
+} from "#product/hooks/sessions/workflows/session-creation-materialization-helpers";
+import {
+  publishCreatedSessionMaterialization,
+} from "#product/hooks/sessions/workflows/session-creation-publication";
+import type {
+  SessionConfigModelRegistry,
+} from "#product/lib/domain/chat/launch/session-config";
+import {
+  configValuesFromIntentSnapshot,
+  planCreationConfigIntentSettlement,
+  snapshotPreMaterializationConfigIntents,
+} from "#product/lib/domain/sessions/creation/config-intent-settlement";
+import {
+  applySessionLaunchDefaults,
+} from "#product/lib/workflows/sessions/session-launch-defaults";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
+import {
+  createEmptySessionRecord,
+  putSessionRecord,
+} from "#product/stores/sessions/session-records";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+const mocks = vi.hoisted(() => ({
+  getSessionClientAndWorkspace: vi.fn(),
+}));
+
+vi.mock("#product/lib/access/anyharness/session-runtime", () => ({
+  getSessionClientAndWorkspace: mocks.getSessionClientAndWorkspace,
+}));
+describe("session creation config-intent ownership", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSessionIntentStore.getState().clear();
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+    useSessionSelectionStore.getState().clearSelection();
+  });
+
+  it("settles two sessions from authoritative launch output before publication and dispatches only a newer live intent", async () => {
+    const codex = strictConfigFixture({
+      agentKind: "codex",
+      applyState: "queued",
+      currentValue: "high",
+      modelId: "gpt-5.5",
+      rawConfigId: "reasoning_effort",
+      sessionId: "runtime-codex",
+      values: ["low", "medium", "high", "max", "xhigh"],
+    });
+    const claude = strictConfigFixture({
+      agentKind: "claude",
+      applyState: "applied",
+      currentValue: "low",
+      modelId: "claude-fable-5",
+      rawConfigId: "effort",
+      sessionId: "runtime-claude",
+      values: ["low", "medium", "high"],
+    });
+    putProjectedRecord("client-codex", "workspace-1", "codex", "gpt-5.5");
+    putProjectedRecord("client-claude", "workspace-1", "claude", "claude-fable-5");
+    enqueueEffort("client-codex", "reasoning_effort", "xhigh", "codex-old");
+    enqueueEffort("client-codex", "reasoning_effort", "max", "codex-latest");
+    enqueueEffort("client-claude", "effort", "medium", "claude-old");
+    enqueueEffort("client-claude", "effort", "high", "claude-latest");
+
+    const codexSnapshot = snapshotFor("client-codex");
+    const claudeSnapshot = snapshotFor("client-claude");
+    const [codexResult, claudeResult] = await Promise.all([
+      applyDefaults(codex, codexSnapshot),
+      applyDefaults(claude, claudeSnapshot),
+    ]);
+
+    // This selection happens after creation froze its exact ownership set.
+    // It must survive settlement and become the sole live dispatch candidate.
+    enqueueEffort("client-codex", "reasoning_effort", "xhigh", "codex-newer");
+
+    const publicationOrder: string[] = [];
+    let sawSettlement = false;
+    let sawMaterialization = false;
+    let sawBinding = false;
+    const unsubscribeIntent = useSessionIntentStore.subscribe((state) => {
+      if (
+        !sawSettlement
+        && state.entriesById["codex-old"]?.status === "stale"
+        && state.entriesById["codex-latest"]?.status === "reconciled"
+      ) {
+        sawSettlement = true;
+        publicationOrder.push("settled");
+      }
+      if (
+        !sawBinding
+        && state.entriesById["codex-newer"]?.materializedSessionId === "runtime-codex"
+      ) {
+        sawBinding = true;
+        publicationOrder.push("bound");
+      }
+    });
+    const unsubscribeDirectory = useSessionDirectoryStore.subscribe((state) => {
+      if (
+        !sawMaterialization
+        && state.entriesById["client-codex"]?.materializedSessionId === "runtime-codex"
+      ) {
+        sawMaterialization = true;
+        publicationOrder.push("materialized");
+      }
+    });
+
+    const versionBeforeCodexPublication = useSessionIntentStore.getState().dispatchVersion;
+    publishCreation("client-codex", "workspace-1", codexResult, codexSnapshot);
+    expect(useSessionIntentStore.getState().dispatchVersion)
+      .toBe(versionBeforeCodexPublication + 2);
+    publishCreation("client-claude", "workspace-1", claudeResult, claudeSnapshot);
+    unsubscribeIntent();
+    unsubscribeDirectory();
+
+    expect(publicationOrder).toEqual(["settled", "materialized", "bound"]);
+    expect(codex.requests).toEqual([
+      { configId: "reasoning_effort", value: "max" },
+    ]);
+    expect(claude.requests).toEqual([
+      { configId: "effort", value: "high" },
+    ]);
+    expect(useSessionIntentStore.getState().entriesById).toMatchObject({
+      "codex-old": { status: "stale", rawConfigId: "reasoning_effort" },
+      "codex-latest": { status: "reconciled", rawConfigId: "reasoning_effort" },
+      "codex-newer": { status: "queued", rawConfigId: "reasoning_effort" },
+      "claude-old": { status: "stale", rawConfigId: "effort" },
+      "claude-latest": { status: "reconciled", rawConfigId: "effort" },
+    });
+
+    const intentState = useSessionIntentStore.getState();
+    const codexNext = selectNextDispatchableSessionIntent(intentState, "client-codex");
+    expect(codexNext).toMatchObject({
+      intentId: "codex-newer",
+      controlKey: "effort",
+      rawConfigId: "reasoning_effort",
+    });
+    expect(selectNextDispatchableSessionIntent(intentState, "client-claude")).toBeNull();
+
+    const liveMutation = vi.fn().mockResolvedValue(
+      configResponse(codex.sessionWithValue("xhigh")),
+    );
+    const onFailure = vi.fn();
+    mocks.getSessionClientAndWorkspace.mockResolvedValue({
+      workspaceId: "workspace-1",
+      materializedSessionId: "runtime-codex",
+    });
+    await dispatchConfigIntent(
+      codexNext as Extract<typeof codexNext, { kind: "update_config" }>,
+      dispatchDeps(liveMutation, onFailure),
+    );
+
+    expect(liveMutation).toHaveBeenCalledTimes(1);
+    expect(liveMutation).toHaveBeenCalledWith(expect.objectContaining({
+      request: { configId: "reasoning_effort", value: "xhigh" },
+    }));
+    expect(onFailure).not.toHaveBeenCalled();
+  });
+  it("retires an unsupported creation intent without a request or failure consequence", async () => {
+    const fixture = strictConfigFixture({
+      agentKind: "codex",
+      applyState: "applied",
+      currentValue: "high",
+      exposeControl: false,
+      modelId: "gpt-5.5",
+      rawConfigId: "reasoning_effort",
+      sessionId: "runtime-unsupported",
+      values: ["high", "max"],
+    });
+    putProjectedRecord("client-unsupported", "workspace-1", "codex", "gpt-5.5");
+    useSessionIntentStore.getState().enqueueConfig({
+      intentId: "unsupported-effort",
+      clientSessionId: "client-unsupported",
+      workspaceId: "workspace-1",
+      configId: null,
+      controlKey: "effort",
+      value: "max",
+    });
+    useSessionIntentStore.getState().enqueuePrompt({
+      clientPromptId: "prompt-after-unsupported",
+      clientSessionId: "client-unsupported",
+      workspaceId: "workspace-1",
+      text: "Continue",
+      blocks: [{ type: "text", text: "Continue" }],
+    });
+    const snapshot = snapshotFor("client-unsupported");
+    const result = await applyDefaults(fixture, snapshot);
+
+    publishCreation("client-unsupported", "workspace-1", result, snapshot);
+
+    expect(fixture.requests).toEqual([]);
+    expect(useSessionIntentStore.getState().entriesById["unsupported-effort"])
+      .toMatchObject({ status: "stale", rawConfigId: null });
+    expect(selectNextDispatchableSessionIntent(
+      useSessionIntentStore.getState(),
+      "client-unsupported",
+    )).toMatchObject({ intentId: "prompt-after-unsupported" });
+  });
+  it("fails only the latest applicable creation intent when authority stays unchanged", async () => {
+    const fixture = strictConfigFixture({
+      agentKind: "codex",
+      applyState: "applied",
+      confirmApply: false,
+      currentValue: "high",
+      modelId: "gpt-5.5",
+      rawConfigId: "reasoning_effort",
+      sessionId: "runtime-unconfirmed",
+      values: ["high", "max", "xhigh"],
+    });
+    putProjectedRecord("client-unconfirmed", "workspace-1", "codex", "gpt-5.5");
+    enqueueEffort("client-unconfirmed", "reasoning_effort", "xhigh", "unconfirmed-old");
+    enqueueEffort("client-unconfirmed", "reasoning_effort", "max", "unconfirmed-latest");
+    const snapshot = snapshotFor("client-unconfirmed");
+    const result = await applyDefaults(fixture, snapshot);
+
+    publishCreation("client-unconfirmed", "workspace-1", result, snapshot);
+
+    expect(fixture.requests).toEqual([
+      { configId: "reasoning_effort", value: "max" },
+    ]);
+    expect(useSessionIntentStore.getState().entriesById).toMatchObject({
+      "unconfirmed-old": { status: "stale" },
+      "unconfirmed-latest": { status: "failed" },
+    });
+  });
+  it("resolves launch-only targets from an adopted session before binding", () => {
+    const fixture = strictConfigFixture({
+      agentKind: "codex",
+      applyState: "applied",
+      currentValue: "high",
+      modelId: "gpt-5.5",
+      rawConfigId: "reasoning_effort",
+      sessionId: "runtime-adopted",
+      values: ["high", "max"],
+    });
+    putProjectedRecord("client-adopted", "workspace-1", "codex", "gpt-5.5");
+    useSessionIntentStore.getState().enqueueConfig({
+      intentId: "adopted-supported",
+      clientSessionId: "client-adopted",
+      workspaceId: "workspace-1",
+      configId: null,
+      controlKey: "effort",
+      value: "max",
+    });
+    useSessionIntentStore.getState().enqueueConfig({
+      intentId: "adopted-unsupported",
+      clientSessionId: "client-adopted",
+      workspaceId: "workspace-1",
+      configId: null,
+      controlKey: "effort",
+      value: "ultra",
+    });
+
+    materializeExistingSession({
+      existingProjectedRecord: null,
+      existingSession: fixture.sessionWithValue("high"),
+      fallbackModelId: "gpt-5.5",
+      pendingSessionId: "client-adopted",
+      resolvedModeId: null,
+      upsertWorkspaceSessionRecord: vi.fn(),
+      workspaceId: "workspace-1",
+    });
+
+    expect(useSessionIntentStore.getState().entriesById).toMatchObject({
+      "adopted-supported": {
+        status: "queued",
+        rawConfigId: "reasoning_effort",
+        materializedSessionId: "runtime-adopted",
+      },
+      "adopted-unsupported": {
+        status: "stale",
+        rawConfigId: "reasoning_effort",
+        materializedSessionId: "runtime-adopted",
+      },
+    });
+  });
+});
+type ConfigSnapshot = ReturnType<typeof snapshotPreMaterializationConfigIntents>;
+
+interface StrictConfigFixture {
+  agentKind: string;
+  client: AnyHarnessClient;
+  initialValue: string;
+  modelId: string;
+  requests: Array<{ configId: string; value: string }>;
+  sessionWithValue: (value: string) => Session;
+}
+
+/**
+ * This narrow network double preserves the production config-intent lifecycle:
+ * semantic `effort` remains distinct from the harness raw ID;
+ * lookup is exact; settable and advertised-value checks are enforced; calls
+ * stay ordered; a queued response is not authoritative until a later config
+ * read; and an applied response is confirmed only by authoritative state.
+ * It deliberately defines no semantic-key alias.
+ */
+function strictConfigFixture(input: {
+  agentKind: string;
+  applyState: "applied" | "queued";
+  confirmApply?: boolean;
+  currentValue: string;
+  exposeControl?: boolean;
+  modelId: string;
+  rawConfigId: string;
+  sessionId: string;
+  values: string[];
+}): StrictConfigFixture {
+  const requests: Array<{ configId: string; value: string }> = [];
+  let currentValue = input.currentValue;
+  let queuedValue: string | null = null;
+  const exposeControl = input.exposeControl !== false;
+  const confirmApply = input.confirmApply !== false;
+
+  const sessionWithValue = (value: string): Session => session({
+    agentKind: input.agentKind,
+    liveConfig: liveConfig({
+      currentValue: value,
+      exposeControl,
+      rawConfigId: input.rawConfigId,
+      values: input.values,
+    }),
+    modelId: input.modelId,
+    sessionId: input.sessionId,
+  });
+  const client = {
+    sessions: {
+      setConfigOption: vi.fn(async (sessionId: string, request: {
+        configId: string;
+        value: string;
+      }) => {
+        if (sessionId !== input.sessionId || request.configId !== input.rawConfigId) {
+          throw new AnyHarnessError({
+            type: "urn:proliferate:anyharness:problem:config-option-not-exposed",
+            title: "Config option not exposed",
+            status: 422,
+            detail: `Config option '${request.configId}' is not exposed by the active session.`,
+          });
+        }
+        if (!exposeControl || !input.values.includes(request.value)) {
+          throw new AnyHarnessError({
+            type: "urn:proliferate:anyharness:problem:config-value-unsupported",
+            title: "Config value unsupported",
+            status: 422,
+            detail: `Config value '${request.value}' is not supported.`,
+          });
+        }
+        requests.push(request);
+        if (input.applyState === "queued") {
+          queuedValue = request.value;
+        } else if (confirmApply) {
+          currentValue = request.value;
+        }
+        const responseSession = sessionWithValue(currentValue);
+        return {
+          applyState: input.applyState,
+          session: responseSession,
+          liveConfig: responseSession.liveConfig,
+        };
+      }),
+      getLiveConfig: vi.fn(async () => {
+        if (queuedValue !== null && confirmApply) {
+          currentValue = queuedValue;
+          queuedValue = null;
+        }
+        return { liveConfig: sessionWithValue(currentValue).liveConfig };
+      }),
+    },
+  } as unknown as AnyHarnessClient;
+
+  return {
+    agentKind: input.agentKind,
+    client,
+    initialValue: input.currentValue,
+    modelId: input.modelId,
+    requests,
+    sessionWithValue,
+  };
+}
+
+function snapshotFor(clientSessionId: string): ConfigSnapshot {
+  return snapshotPreMaterializationConfigIntents(
+    sessionIntentsForSession(useSessionIntentStore.getState(), clientSessionId),
+  );
+}
+
+async function applyDefaults(
+  fixture: StrictConfigFixture,
+  snapshot: ConfigSnapshot,
+) {
+  return applySessionLaunchDefaults({
+    client: fixture.client,
+    session: fixture.sessionWithValue(fixture.initialValue),
+    agentKind: fixture.agentKind,
+    modelRegistries: [registry(fixture.agentKind, fixture.modelId)],
+    defaultLiveSessionControlValuesByAgentKind: {
+      [fixture.agentKind]: configValuesFromIntentSnapshot(snapshot),
+    },
+  });
+}
+
+function publishCreation(
+  clientSessionId: string,
+  workspaceId: string,
+  result: Awaited<ReturnType<typeof applySessionLaunchDefaults>>,
+  snapshot: ConfigSnapshot,
+): void {
+  const liveConfigSnapshot = result.liveConfig ?? result.session.liveConfig ?? null;
+  publishCreatedSessionMaterialization({
+    agentKind: result.session.agentKind,
+    configIntentSettlement: planCreationConfigIntentSettlement({
+      snapshot,
+      liveConfig: liveConfigSnapshot,
+    }),
+    fallbackModeId: null,
+    fallbackModelId: result.session.modelId ?? "model",
+    pendingSessionId: clientSessionId,
+    record: {
+      ...createEmptySessionRecord(clientSessionId, result.session.agentKind, {
+        workspaceId,
+        materializedSessionId: result.session.id,
+        modelId: result.session.modelId,
+        requestedModelId: result.session.requestedModelId,
+        liveConfig: liveConfigSnapshot,
+        sessionRelationship: { kind: "root" },
+      }),
+      status: "idle",
+      transcriptHydrated: true,
+    },
+    session: result.session,
+    trackProductEvent: vi.fn(),
+    upsertWorkspaceSessionRecord: vi.fn(),
+    workspaceId,
+    workspaceKind: "local",
+  });
+}
+
+function putProjectedRecord(
+  clientSessionId: string,
+  workspaceId: string,
+  agentKind: string,
+  modelId: string,
+): void {
+  putSessionRecord({
+    ...createEmptySessionRecord(clientSessionId, agentKind, {
+      workspaceId,
+      materializedSessionId: null,
+      modelId,
+      requestedModelId: modelId,
+      sessionRelationship: { kind: "root" },
+    }),
+    status: "starting",
+    transcriptHydrated: true,
+  });
+}
+
+function enqueueEffort(
+  clientSessionId: string,
+  rawConfigId: string,
+  value: string,
+  intentId: string,
+): void {
+  useSessionIntentStore.getState().enqueueConfig({
+    intentId,
+    clientSessionId,
+    workspaceId: "workspace-1",
+    configId: rawConfigId,
+    controlKey: "effort",
+    value,
+  });
+}
+
+function registry(agentKind: string, modelId: string): SessionConfigModelRegistry {
+  return {
+    kind: agentKind,
+    displayName: agentKind,
+    defaultModelId: modelId,
+    models: [{
+      id: modelId,
+      displayName: modelId,
+      isDefault: true,
+      status: "active",
+      sessionDefaultControls: [{
+        key: "effort",
+        label: "Effort",
+        values: ["low", "medium", "high", "max", "xhigh", "ultra"].map(
+          (value) => ({ value, label: value, isDefault: value === "high" }),
+        ),
+      }],
+    }],
+  };
+}
+
+function session(input: {
+  agentKind: string;
+  liveConfig: SessionLiveConfigSnapshot;
+  modelId: string;
+  sessionId: string;
+}): Session {
+  return {
+    id: input.sessionId,
+    workspaceId: "workspace-1",
+    agentKind: input.agentKind,
+    modelId: input.modelId,
+    requestedModelId: input.modelId,
+    modeId: null,
+    requestedModeId: null,
+    status: "idle",
+    title: null,
+    createdAt: "2026-08-15T00:00:00Z",
+    updatedAt: "2026-08-15T00:00:00Z",
+    liveConfig: input.liveConfig,
+    actionCapabilities: { fork: false, targetedFork: false },
+  };
+}
+
+function liveConfig(input: {
+  currentValue: string;
+  exposeControl: boolean;
+  rawConfigId: string;
+  values: string[];
+}): SessionLiveConfigSnapshot {
+  const effort: NormalizedSessionControl | null = input.exposeControl
+    ? {
+        key: "effort",
+        rawConfigId: input.rawConfigId,
+        label: "Effort",
+        currentValue: input.currentValue,
+        settable: true,
+        values: input.values.map((value) => ({ value, label: value })),
+      }
+    : null;
+  return {
+    sourceSeq: 1,
+    rawConfigOptions: effort
+      ? [{
+          id: input.rawConfigId,
+          name: "Effort",
+          type: "select",
+          currentValue: input.currentValue,
+          options: [],
+        }]
+      : [],
+    normalizedControls: {
+      model: null,
+      collaborationMode: null,
+      mode: null,
+      reasoning: null,
+      effort,
+      fastMode: null,
+      extras: [],
+    },
+    updatedAt: "2026-08-15T00:00:00Z",
+  };
+}
+
+function configResponse(session: Session): SetSessionConfigOptionResponse {
+  return {
+    applyState: "applied",
+    session,
+    liveConfig: session.liveConfig,
+  };
+}
+
+function dispatchDeps(
+  mutateAsync: ReturnType<typeof vi.fn>,
+  onFailure: ReturnType<typeof vi.fn>,
+): ConfigIntentDispatchDeps {
+  return {
+    cloudClient: null,
+    getWorkspaceSurface: vi.fn(() => "standard"),
+    setSessionConfigOptionMutation: {
+      mutateAsync,
+    } as unknown as ConfigIntentDispatchDeps["setSessionConfigOptionMutation"],
+    upsertWorkspaceSessionRecord: vi.fn(),
+    onFailure,
+  };
+}

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-config-intent-ownership.test.tsx
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-config-intent-ownership.test.tsx
@@ -41,7 +41,7 @@ describe("session creation config-intent ownership", () => {
     const codex = strictConfigFixture({
       agentKind: "codex",
       applyState: "queued",
-      currentValue: "high",
+      currentValue: "low",
       modelId: "gpt-5.5",
       rawConfigId: "reasoning_effort",
       sessionId: "runtime-codex",
@@ -58,21 +58,20 @@ describe("session creation config-intent ownership", () => {
     });
     putProjectedRecord("client-codex", "workspace-1", "codex", "gpt-5.5");
     putProjectedRecord("client-claude", "workspace-1", "claude", "claude-fable-5");
-    enqueueEffort("client-codex", "reasoning_effort", "xhigh", "codex-old");
-    enqueueEffort("client-codex", "reasoning_effort", "max", "codex-latest");
+    const codexCaptured = enqueueEffort("client-codex", "reasoning_effort", "high");
     enqueueEffort("client-claude", "effort", "medium", "claude-old");
     enqueueEffort("client-claude", "effort", "high", "claude-latest");
 
     const codexSnapshot = snapshotFor("client-codex");
     const claudeSnapshot = snapshotFor("client-claude");
-    const [codexResult, claudeResult] = await Promise.all([
-      applyDefaults(codex, codexSnapshot),
-      applyDefaults(claude, claudeSnapshot),
-    ]);
-
-    // This selection happens after creation froze its exact ownership set.
-    // It must survive settlement and become the sole live dispatch candidate.
-    enqueueEffort("client-codex", "reasoning_effort", "xhigh", "codex-newer");
+    const codexDefaults = applyDefaults(codex, codexSnapshot);
+    const claudeDefaults = applyDefaults(claude, claudeSnapshot);
+    // Launch defaults are pending here. Production tail coalescing reuses the
+    // captured ID, so only its immutable generation can preserve this choice.
+    const codexNewer = enqueueEffort("client-codex", "reasoning_effort", "max");
+    expect(codexNewer.intentId).toBe(codexCaptured.intentId);
+    expect(codexNewer.generation).toBe(codexCaptured.generation + 1);
+    const [codexResult, claudeResult] = await Promise.all([codexDefaults, claudeDefaults]);
 
     const publicationOrder: string[] = [];
     let sawSettlement = false;
@@ -81,15 +80,15 @@ describe("session creation config-intent ownership", () => {
     const unsubscribeIntent = useSessionIntentStore.subscribe((state) => {
       if (
         !sawSettlement
-        && state.entriesById["codex-old"]?.status === "stale"
-        && state.entriesById["codex-latest"]?.status === "reconciled"
+        && state.entriesById["claude-old"]?.status === "stale"
+        && state.entriesById["claude-latest"]?.status === "reconciled"
       ) {
         sawSettlement = true;
         publicationOrder.push("settled");
       }
       if (
         !sawBinding
-        && state.entriesById["codex-newer"]?.materializedSessionId === "runtime-codex"
+        && state.entriesById["claude-latest"]?.materializedSessionId === "runtime-claude"
       ) {
         sawBinding = true;
         publicationOrder.push("bound");
@@ -98,47 +97,48 @@ describe("session creation config-intent ownership", () => {
     const unsubscribeDirectory = useSessionDirectoryStore.subscribe((state) => {
       if (
         !sawMaterialization
-        && state.entriesById["client-codex"]?.materializedSessionId === "runtime-codex"
+        && state.entriesById["client-claude"]?.materializedSessionId === "runtime-claude"
       ) {
         sawMaterialization = true;
         publicationOrder.push("materialized");
       }
     });
 
-    const versionBeforeCodexPublication = useSessionIntentStore.getState().dispatchVersion;
-    publishCreation("client-codex", "workspace-1", codexResult, codexSnapshot);
-    expect(useSessionIntentStore.getState().dispatchVersion)
-      .toBe(versionBeforeCodexPublication + 2);
+    const versionBeforeClaudePublication = useSessionIntentStore.getState().dispatchVersion;
     publishCreation("client-claude", "workspace-1", claudeResult, claudeSnapshot);
+    expect(useSessionIntentStore.getState().dispatchVersion)
+      .toBe(versionBeforeClaudePublication + 2);
+    publishCreation("client-codex", "workspace-1", codexResult, codexSnapshot);
     unsubscribeIntent();
     unsubscribeDirectory();
 
     expect(publicationOrder).toEqual(["settled", "materialized", "bound"]);
     expect(codex.requests).toEqual([
-      { configId: "reasoning_effort", value: "max" },
+      { configId: "reasoning_effort", value: "high" },
     ]);
     expect(claude.requests).toEqual([
       { configId: "effort", value: "high" },
     ]);
     expect(useSessionIntentStore.getState().entriesById).toMatchObject({
-      "codex-old": { status: "stale", rawConfigId: "reasoning_effort" },
-      "codex-latest": { status: "reconciled", rawConfigId: "reasoning_effort" },
-      "codex-newer": { status: "queued", rawConfigId: "reasoning_effort" },
       "claude-old": { status: "stale", rawConfigId: "effort" },
       "claude-latest": { status: "reconciled", rawConfigId: "effort" },
     });
+    expect(useSessionIntentStore.getState().entriesById[codexCaptured.intentId])
+      .toMatchObject({ generation: codexNewer.generation, materializedSessionId: "runtime-codex",
+        rawConfigId: "reasoning_effort", status: "queued", value: "max" });
 
     const intentState = useSessionIntentStore.getState();
     const codexNext = selectNextDispatchableSessionIntent(intentState, "client-codex");
     expect(codexNext).toMatchObject({
-      intentId: "codex-newer",
+      intentId: codexCaptured.intentId,
       controlKey: "effort",
       rawConfigId: "reasoning_effort",
+      value: "max",
     });
     expect(selectNextDispatchableSessionIntent(intentState, "client-claude")).toBeNull();
 
     const liveMutation = vi.fn().mockResolvedValue(
-      configResponse(codex.sessionWithValue("xhigh")),
+      configResponse(codex.sessionWithValue("max")),
     );
     const onFailure = vi.fn();
     mocks.getSessionClientAndWorkspace.mockResolvedValue({
@@ -152,7 +152,7 @@ describe("session creation config-intent ownership", () => {
 
     expect(liveMutation).toHaveBeenCalledTimes(1);
     expect(liveMutation).toHaveBeenCalledWith(expect.objectContaining({
-      request: { configId: "reasoning_effort", value: "xhigh" },
+      request: { configId: "reasoning_effort", value: "max" },
     }));
     expect(onFailure).not.toHaveBeenCalled();
   });
@@ -311,8 +311,8 @@ interface StrictConfigFixture {
 
 /**
  * This narrow network double preserves the production config-intent lifecycle:
- * semantic `effort` remains distinct from the harness raw ID;
- * lookup is exact; settable and advertised-value checks are enforced; calls
+ * semantic `effort` remains distinct from the harness raw ID; tail-coalesced
+ * choices reuse an ID only with a new generation; exact lookup, settable and
  * stay ordered; a queued response is not authoritative until a later config
  * read; and an applied response is confirmed only by authoritative state.
  * It deliberately defines no semantic-key alias.
@@ -480,10 +480,10 @@ function enqueueEffort(
   clientSessionId: string,
   rawConfigId: string,
   value: string,
-  intentId: string,
-): void {
-  useSessionIntentStore.getState().enqueueConfig({
-    intentId,
+  intentId?: string,
+) {
+  return useSessionIntentStore.getState().enqueueConfig({
+    ...(intentId ? { intentId } : {}),
     clientSessionId,
     workspaceId: "workspace-1",
     configId: rawConfigId,

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization-helpers.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization-helpers.ts
@@ -19,6 +19,9 @@ import {
   getSessionRecord,
 } from "#product/stores/sessions/session-records";
 import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
+import {
+  applyAdoptedSessionConfigIntentResolution,
+} from "#product/stores/sessions/session-intent-store-settlement";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import type { SessionRuntimeRecord } from "#product/stores/sessions/session-types";
 
@@ -62,7 +65,7 @@ export function materializeExistingSession({
   const configIntentSnapshot = snapshotPreMaterializationConfigIntents(
     sessionIntentsForSession(intentStore, pendingSessionId),
   );
-  intentStore.applyAdoptedSessionConfigIntentResolution(
+  applyAdoptedSessionConfigIntentResolution(
     planAdoptedSessionConfigIntentResolution({
       snapshot: configIntentSnapshot,
       liveConfig: existingSession.liveConfig ?? null,

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization-helpers.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization-helpers.ts
@@ -1,11 +1,12 @@
 import type { Session } from "@anyharness/sdk";
 import { resolveStatusFromExecutionSummary } from "#product/domain/sessions/activity";
 import {
-  pendingConfigChangesForSessionIntents,
-} from "#product/domain/sessions/intents/session-intent-selectors";
-import {
   sessionIntentsForSession,
 } from "#product/domain/sessions/intents/session-intent-state";
+import {
+  planAdoptedSessionConfigIntentResolution,
+  snapshotPreMaterializationConfigIntents,
+} from "#product/lib/domain/sessions/creation/config-intent-settlement";
 import {
   materializeSessionRecord,
 } from "#product/hooks/sessions/workflows/session-creation-local-state";
@@ -57,8 +58,18 @@ export function materializeExistingSession({
     fallbackTitle: existingProjectedRecord?.title ?? null,
     pendingConfigChanges: {},
   });
+  const intentStore = useSessionIntentStore.getState();
+  const configIntentSnapshot = snapshotPreMaterializationConfigIntents(
+    sessionIntentsForSession(intentStore, pendingSessionId),
+  );
+  intentStore.applyAdoptedSessionConfigIntentResolution(
+    planAdoptedSessionConfigIntentResolution({
+      snapshot: configIntentSnapshot,
+      liveConfig: existingSession.liveConfig ?? null,
+    }),
+  );
   materializeSessionRecord(pendingSessionId, existingSession.id, realRecord);
-  useSessionIntentStore.getState().bindMaterializedSession(
+  intentStore.bindMaterializedSession(
     pendingSessionId,
     existingSession.id,
   );
@@ -82,18 +93,6 @@ export function materializeExistingSession({
     );
   }
   return pendingSessionId;
-}
-
-export function pendingConfigValuesForSession(
-  sessionId: string,
-): Record<string, string> {
-  const pendingConfigChanges = pendingConfigChangesForSessionIntents(
-    sessionIntentsForSession(useSessionIntentStore.getState(), sessionId),
-  );
-  return Object.fromEntries(
-    Object.values(pendingConfigChanges)
-      .map((change) => [change.rawConfigId, change.value] as const),
-  );
 }
 
 export function requeuePromptIntentsBlockedOnMaterialization({

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization-interruption.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization-interruption.ts
@@ -1,6 +1,12 @@
 import {
+  shouldDiscardSupersededSessionCreation,
   subscribeToSessionCreationSupersession,
 } from "#product/hooks/sessions/workflows/session-creation-supersession";
+
+export interface MaterializationLifecycle {
+  discardCreatedSession: (() => Promise<boolean>) | null;
+  retainCreatedSession: (() => void) | null;
+}
 
 /**
  * Races a long materialization request with replace-in-place supersession.
@@ -39,4 +45,39 @@ export async function runInterruptibleSessionCreationStep<T>(input: {
     // The successor rolled back while the external step was in flight. Keep
     // waiting on that same work, but subscribe again for a later replacement.
   }
+}
+
+export async function discardIfSuperseded(
+  sessionId: string,
+  lifecycle: MaterializationLifecycle,
+): Promise<boolean> {
+  if (!await shouldDiscardSupersededSessionCreation(sessionId)) {
+    return false;
+  }
+  const discardCreatedSession = lifecycle.discardCreatedSession;
+  lifecycle.discardCreatedSession = null;
+  if (!discardCreatedSession || await discardCreatedSession()) {
+    lifecycle.retainCreatedSession = null;
+    return true;
+  }
+  // The successor already committed, but this created runtime could not be retired safely. Publish it honestly and stop this older materializer here.
+  const retainCreatedSession = lifecycle.retainCreatedSession;
+  lifecycle.retainCreatedSession = null;
+  retainCreatedSession?.();
+  return true;
+}
+
+export async function discardCreatedRuntimeSession(
+  lifecycle: MaterializationLifecycle,
+): Promise<boolean> {
+  const discardCreatedSession = lifecycle.discardCreatedSession;
+  lifecycle.discardCreatedSession = null;
+  if (!discardCreatedSession || await discardCreatedSession()) {
+    lifecycle.retainCreatedSession = null;
+    return true;
+  }
+  const retainCreatedSession = lifecycle.retainCreatedSession;
+  lifecycle.retainCreatedSession = null;
+  retainCreatedSession?.();
+  return false;
 }

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts
@@ -40,6 +40,7 @@ import {
 import {
   configValuesFromIntentSnapshot,
   planCreationConfigIntentSettlement,
+  rawConfigValuesFromIntentSnapshot,
   resolvePreMaterializationConfigIntentControlKeys,
   snapshotPreMaterializationConfigIntents,
 } from "#product/lib/domain/sessions/creation/config-intent-settlement";
@@ -306,6 +307,7 @@ async function runSessionCreationMaterialization({
       agentKind: options.agentKind,
       modelRegistries,
       defaultLiveSessionControlValuesByAgentKind: liveDefaultsForLaunch,
+      rawLiveSessionControlValues: rawConfigValuesFromIntentSnapshot(configIntentSnapshot),
     }),
     onSuperseded: () => discardIfSuperseded(pendingSessionId, lifecycle),
   });

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts
@@ -33,8 +33,16 @@ import {
 import { buildLatencyRequestOptions } from "#product/hooks/sessions/workflows/session-creation-request-options";
 import {
   materializeExistingSession,
-  pendingConfigValuesForSession,
 } from "#product/hooks/sessions/workflows/session-creation-materialization-helpers";
+import {
+  sessionIntentsForSession,
+} from "#product/domain/sessions/intents/session-intent-state";
+import {
+  configValuesFromIntentSnapshot,
+  planCreationConfigIntentSettlement,
+  snapshotPreMaterializationConfigIntents,
+} from "#product/lib/domain/sessions/creation/config-intent-settlement";
+import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
 import { buildDesktopLaunchModelRegistries } from "#product/lib/domain/agents/cloud-launch-catalog";
 import { resolveSubmitAgentCatalog } from "#product/lib/domain/agents/agent-catalog-submit-gate";
 import type { CreateSessionWithResolvedConfigOptions } from "#product/hooks/sessions/workflows/session-creation-types";
@@ -267,7 +275,6 @@ async function runSessionCreationMaterialization({
     targetSessionId: session.id,
   });
 
-  const queuedConfigValuesBeforeDefaults = pendingConfigValuesForSession(pendingSessionId);
   const catalogStep = await runInterruptibleSessionCreationStep({
     sessionId: pendingSessionId,
     step: resolveSubmitAgentCatalog(ensureCloudAgentCatalog),
@@ -280,10 +287,13 @@ async function runSessionCreationMaterialization({
   const modelRegistries = buildDesktopLaunchModelRegistries(
     cloudLaunchCatalog?.agents ?? [],
   );
+  const configIntentSnapshot = snapshotPreMaterializationConfigIntents(
+    sessionIntentsForSession(useSessionIntentStore.getState(), pendingSessionId),
+  );
   const liveDefaultsForLaunch = mergeLiveDefaultLaunchControls({
     defaults: frozenDefaultLiveSessionControlValuesByAgentKind,
     agentKind: options.agentKind,
-    values: queuedConfigValuesBeforeDefaults,
+    values: configValuesFromIntentSnapshot(configIntentSnapshot),
   });
   const launchDefaultsStep = await runInterruptibleSessionCreationStep({
     sessionId: pendingSessionId,
@@ -308,6 +318,10 @@ async function runSessionCreationMaterialization({
     ...launchedSession,
     liveConfig: launchedLiveConfig,
   };
+  const configIntentSettlement = planCreationConfigIntentSettlement({
+    snapshot: configIntentSnapshot,
+    liveConfig: launchedLiveConfig,
+  });
   if (await discardIfSuperseded(pendingSessionId, lifecycle)) {
     return pendingSessionId;
   }
@@ -345,6 +359,7 @@ async function runSessionCreationMaterialization({
         fallbackModeId: resolvedModeId,
         fallbackModelId: options.modelId,
         launchIntentId: options.launchIntentId,
+        configIntentSettlement,
         pendingSessionId,
         record: realRecord,
         session: launchedSession,

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts
@@ -49,13 +49,15 @@ import type { CreateSessionWithResolvedConfigOptions } from "#product/hooks/sess
 import { resolveDesktopRuntimeUrlForWorkspace } from "#product/hooks/sessions/workflows/session-creation-runtime";
 import { annotateLatencyFlow } from "#product/lib/infra/measurement/measurement-port";
 import { logLatency } from "#product/lib/infra/measurement/measurement-port";
-import {
-  publishSessionCreationIfCurrent,
-  shouldDiscardSupersededSessionCreation,
-} from "#product/hooks/sessions/workflows/session-creation-supersession";
+import { publishSessionCreationIfCurrent } from "#product/hooks/sessions/workflows/session-creation-supersession";
 import { filterReplacedSessionTombstones } from "#product/hooks/sessions/workflows/session-replacement-tombstones";
 import { scheduleCreatedRuntimeSessionCleanup } from "#product/hooks/sessions/workflows/session-created-runtime-cleanup";
-import { runInterruptibleSessionCreationStep } from "#product/hooks/sessions/workflows/session-creation-materialization-interruption";
+import {
+  discardCreatedRuntimeSession,
+  discardIfSuperseded,
+  runInterruptibleSessionCreationStep,
+  type MaterializationLifecycle,
+} from "#product/hooks/sessions/workflows/session-creation-materialization-interruption";
 import {
   publishCreatedSessionMaterialization,
   type TrackChatSessionCreated,
@@ -88,11 +90,6 @@ interface MaterializeSessionCreationInput {
   ) => void;
   workspaceId: string;
   onRuntimeSessionCreated?: (session: Session) => Promise<void> | void;
-}
-
-interface MaterializationLifecycle {
-  discardCreatedSession: (() => Promise<boolean>) | null;
-  retainCreatedSession: (() => void) | null;
 }
 
 export async function materializeSessionCreation(
@@ -377,39 +374,4 @@ async function runSessionCreationMaterialization({
   lifecycle.discardCreatedSession = null;
   lifecycle.retainCreatedSession = null;
   return pendingSessionId;
-}
-
-async function discardIfSuperseded(
-  sessionId: string,
-  lifecycle: MaterializationLifecycle,
-): Promise<boolean> {
-  if (!await shouldDiscardSupersededSessionCreation(sessionId)) {
-    return false;
-  }
-  const discardCreatedSession = lifecycle.discardCreatedSession;
-  lifecycle.discardCreatedSession = null;
-  if (!discardCreatedSession || await discardCreatedSession()) {
-    lifecycle.retainCreatedSession = null;
-    return true;
-  }
-  // The successor already committed, but this created runtime could not be retired safely. Publish it honestly and stop this older materializer here.
-  const retainCreatedSession = lifecycle.retainCreatedSession;
-  lifecycle.retainCreatedSession = null;
-  retainCreatedSession?.();
-  return true;
-}
-
-async function discardCreatedRuntimeSession(
-  lifecycle: MaterializationLifecycle,
-): Promise<boolean> {
-  const discardCreatedSession = lifecycle.discardCreatedSession;
-  lifecycle.discardCreatedSession = null;
-  if (!discardCreatedSession || await discardCreatedSession()) {
-    lifecycle.retainCreatedSession = null;
-    return true;
-  }
-  const retainCreatedSession = lifecycle.retainCreatedSession;
-  lifecycle.retainCreatedSession = null;
-  retainCreatedSession?.();
-  return false;
 }

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts
@@ -40,6 +40,7 @@ import {
 import {
   configValuesFromIntentSnapshot,
   planCreationConfigIntentSettlement,
+  resolvePreMaterializationConfigIntentControlKeys,
   snapshotPreMaterializationConfigIntents,
 } from "#product/lib/domain/sessions/creation/config-intent-settlement";
 import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
@@ -284,9 +285,14 @@ async function runSessionCreationMaterialization({
   const modelRegistries = buildDesktopLaunchModelRegistries(
     cloudLaunchCatalog?.agents ?? [],
   );
-  const configIntentSnapshot = snapshotPreMaterializationConfigIntents(
-    sessionIntentsForSession(useSessionIntentStore.getState(), pendingSessionId),
-  );
+  const configIntentSnapshot = resolvePreMaterializationConfigIntentControlKeys({
+    snapshot: snapshotPreMaterializationConfigIntents(
+      sessionIntentsForSession(useSessionIntentStore.getState(), pendingSessionId),
+    ),
+    launchControls: cloudLaunchCatalog?.agents.find(
+      (agent) => agent.kind === options.agentKind,
+    )?.launchControls ?? [],
+  });
   const liveDefaultsForLaunch = mergeLiveDefaultLaunchControls({
     defaults: frozenDefaultLiveSessionControlValuesByAgentKind,
     agentKind: options.agentKind,

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-publication.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-publication.ts
@@ -12,6 +12,9 @@ import { rememberLastViewedSession } from "#product/stores/preferences/workspace
 import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import type { SessionRuntimeRecord } from "#product/stores/sessions/session-types";
+import type {
+  ConfigIntentSettlementPlan,
+} from "#product/lib/domain/sessions/creation/config-intent-settlement";
 
 export type TrackChatSessionCreated = (
   name: "chat_session_created",
@@ -20,6 +23,7 @@ export type TrackChatSessionCreated = (
 
 export function publishCreatedSessionMaterialization(input: {
   agentKind: string;
+  configIntentSettlement: ConfigIntentSettlementPlan;
   fallbackModeId: string | null;
   fallbackModelId: string;
   launchIntentId?: string | null;
@@ -34,6 +38,9 @@ export function publishCreatedSessionMaterialization(input: {
   workspaceId: string;
   workspaceKind: "cloud" | "local";
 }): void {
+  useSessionIntentStore.getState().applyConfigIntentSettlement(
+    input.configIntentSettlement,
+  );
   materializeSessionRecord(
     input.pendingSessionId,
     input.session.id,

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-publication.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-publication.ts
@@ -10,6 +10,9 @@ import { logLatency } from "#product/lib/infra/measurement/measurement-port";
 import { useChatLaunchIntentStore } from "#product/stores/chat/chat-launch-intent-store";
 import { rememberLastViewedSession } from "#product/stores/preferences/workspace-ui-store";
 import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
+import {
+  applyConfigIntentSettlement,
+} from "#product/stores/sessions/session-intent-store-settlement";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import type { SessionRuntimeRecord } from "#product/stores/sessions/session-types";
 import type {
@@ -38,9 +41,7 @@ export function publishCreatedSessionMaterialization(input: {
   workspaceId: string;
   workspaceKind: "cloud" | "local";
 }): void {
-  useSessionIntentStore.getState().applyConfigIntentSettlement(
-    input.configIntentSettlement,
-  );
+  applyConfigIntentSettlement(input.configIntentSettlement);
   materializeSessionRecord(
     input.pendingSessionId,
     input.session.id,

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-raw-config-intent-ownership.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-raw-config-intent-ownership.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { SessionConfigModelRegistry } from "#product/lib/domain/chat/launch/session-config";
 import {
   configValuesFromIntentSnapshot,
+  rawConfigValuesFromIntentSnapshot,
   resolvePreMaterializationConfigIntentControlKeys,
   type PreMaterializationConfigIntentSnapshot,
 } from "#product/lib/domain/sessions/creation/config-intent-settlement";
@@ -67,6 +68,50 @@ describe("raw-keyed creation config intent ownership", () => {
       controlKey: "effort",
       rawConfigId: "reasoning_effort",
     })]);
+    expect(requests).toEqual([{ configId: "reasoning_effort", value: "high" }]);
+    expect(result.liveConfig?.normalizedControls.effort?.currentValue).toBe("high");
+  });
+
+  it("uses authoritative live config when catalog metadata is unavailable", async () => {
+    const requests: Array<{ configId: string; value: string }> = [];
+    const authoritativeSession = session("low");
+    const initialSession = { ...authoritativeSession, liveConfig: null };
+    const client = {
+      sessions: {
+        setConfigOption: vi.fn(async (_sessionId: string, request: {
+          configId: string;
+          value: string;
+        }) => {
+          requests.push(request);
+          const updatedSession = session(request.value);
+          return {
+            applyState: "applied" as const,
+            session: updatedSession,
+            liveConfig: updatedSession.liveConfig,
+          };
+        }),
+        getLiveConfig: vi.fn(async () => ({ liveConfig: authoritativeSession.liveConfig })),
+      },
+    } as unknown as AnyHarnessClient;
+    const snapshot: PreMaterializationConfigIntentSnapshot = [{
+      intentId: "pending-shell-effort",
+      generation: 1,
+      controlKey: "reasoning_effort",
+      rawConfigId: "reasoning_effort",
+      value: "high",
+      order: 0,
+    }];
+
+    const result = await applySessionLaunchDefaults({
+      client,
+      session: initialSession,
+      agentKind: "codex",
+      modelRegistries: [],
+      defaultLiveSessionControlValuesByAgentKind: {},
+      rawLiveSessionControlValues: rawConfigValuesFromIntentSnapshot(snapshot),
+    });
+
+    expect(client.sessions.getLiveConfig).toHaveBeenCalledWith(initialSession.id);
     expect(requests).toEqual([{ configId: "reasoning_effort", value: "high" }]);
     expect(result.liveConfig?.normalizedControls.effort?.currentValue).toBe("high");
   });

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-raw-config-intent-ownership.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-raw-config-intent-ownership.test.ts
@@ -1,0 +1,154 @@
+import type {
+  AnyHarnessClient,
+  NormalizedSessionControl,
+  Session,
+  SessionLiveConfigSnapshot,
+} from "@anyharness/sdk";
+import { describe, expect, it, vi } from "vitest";
+import type { SessionConfigModelRegistry } from "#product/lib/domain/chat/launch/session-config";
+import {
+  configValuesFromIntentSnapshot,
+  resolvePreMaterializationConfigIntentControlKeys,
+  type PreMaterializationConfigIntentSnapshot,
+} from "#product/lib/domain/sessions/creation/config-intent-settlement";
+import { applySessionLaunchDefaults } from "#product/lib/workflows/sessions/session-launch-defaults";
+
+describe("raw-keyed creation config intent ownership", () => {
+  it("maps a pending-shell raw ID to its catalog semantic key before launch defaults", async () => {
+    const requests: Array<{ configId: string; value: string }> = [];
+    const initialSession = session("low");
+    const client = {
+      sessions: {
+        setConfigOption: vi.fn(async (_sessionId: string, request: {
+          configId: string;
+          value: string;
+        }) => {
+          requests.push(request);
+          const updatedSession = session(request.value);
+          return {
+            applyState: "applied" as const,
+            session: updatedSession,
+            liveConfig: updatedSession.liveConfig,
+          };
+        }),
+        getLiveConfig: vi.fn(async () => ({ liveConfig: initialSession.liveConfig })),
+      },
+    } as unknown as AnyHarnessClient;
+    const rawSnapshot: PreMaterializationConfigIntentSnapshot = [{
+      intentId: "pending-shell-effort",
+      generation: 1,
+      controlKey: "reasoning_effort",
+      rawConfigId: "reasoning_effort",
+      value: "high",
+      order: 0,
+    }];
+    const snapshot = resolvePreMaterializationConfigIntentControlKeys({
+      snapshot: rawSnapshot,
+      launchControls: [{
+        key: "effort",
+        apply: {
+          liveConfigId: "reasoning_effort",
+          queueBeforeMaterialized: true,
+        },
+      }],
+    });
+
+    const result = await applySessionLaunchDefaults({
+      client,
+      session: initialSession,
+      agentKind: "codex",
+      modelRegistries: [registry()],
+      defaultLiveSessionControlValuesByAgentKind: {
+        codex: configValuesFromIntentSnapshot(snapshot),
+      },
+    });
+
+    expect(snapshot).toEqual([expect.objectContaining({
+      controlKey: "effort",
+      rawConfigId: "reasoning_effort",
+    })]);
+    expect(requests).toEqual([{ configId: "reasoning_effort", value: "high" }]);
+    expect(result.liveConfig?.normalizedControls.effort?.currentValue).toBe("high");
+  });
+});
+
+/**
+ * This network-boundary double preserves the production raw/semantic split,
+ * authoritative normalized live config, value applicability, and the exact
+ * raw config ID used by the session launch-default mutation.
+ */
+function session(currentValue: string): Session {
+  return {
+    id: "runtime-pending-shell",
+    workspaceId: "workspace-1",
+    agentKind: "codex",
+    modelId: "gpt-5.5",
+    requestedModelId: "gpt-5.5",
+    status: "idle",
+    title: null,
+    createdAt: "2026-08-17T00:00:00Z",
+    updatedAt: "2026-08-17T00:00:00Z",
+    liveConfig: liveConfig(currentValue),
+  };
+}
+
+function liveConfig(currentValue: string): SessionLiveConfigSnapshot {
+  return {
+    sourceSeq: 1,
+    rawConfigOptions: [{
+      id: "reasoning_effort",
+      label: "Effort",
+      currentValue,
+      settable: true,
+      values: [
+        { value: "low", label: "Low" },
+        { value: "high", label: "High" },
+      ],
+    }],
+    normalizedControls: {
+      model: null,
+      collaborationMode: null,
+      mode: null,
+      reasoning: null,
+      effort: effortControl(currentValue),
+      fastMode: null,
+      extras: [],
+    },
+    updatedAt: "2026-08-17T00:00:00Z",
+  };
+}
+
+function effortControl(currentValue: string): NormalizedSessionControl {
+  return {
+    key: "effort",
+    rawConfigId: "reasoning_effort",
+    label: "Effort",
+    currentValue,
+    settable: true,
+    values: [
+      { value: "low", label: "Low" },
+      { value: "high", label: "High" },
+    ],
+  };
+}
+
+function registry(): SessionConfigModelRegistry {
+  return {
+    kind: "codex",
+    displayName: "Codex",
+    defaultModelId: "gpt-5.5",
+    models: [{
+      id: "gpt-5.5",
+      displayName: "GPT-5.5",
+      isDefault: true,
+      sessionDefaultControls: [{
+        key: "effort",
+        label: "Effort",
+        values: [
+          { value: "low", label: "Low", isDefault: true },
+          { value: "high", label: "High", isDefault: false },
+        ],
+      }],
+    }],
+  };
+}

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-intent-actions.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-intent-actions.ts
@@ -184,7 +184,7 @@ export function useSessionIntentActions() {
       value,
       persistDefaultPreference: options?.persistDefaultPreference !== false,
     });
-    if (configId === "mode") {
+    if (rawConfigId === "mode") {
       // UX-latency R12: keyed by intentId, which enqueueConfig keeps stable
       // across PRO-261 tail coalescing (a burst of switches reuses the same
       // queued intent), so re-begin here restarts the clock to the latest

--- a/apps/packages/product-client/src/hooks/sessions/workflows/use-session-intent-actions.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/use-session-intent-actions.ts
@@ -157,7 +157,7 @@ export function useSessionIntentActions() {
   }, []);
 
   const setActiveSessionConfigOption = useCallback(async (
-    configId: string,
+    rawConfigId: string,
     value: string,
     options?: SessionConfigOptionUpdateOptions,
   ) => {
@@ -179,7 +179,8 @@ export function useSessionIntentActions() {
       clientSessionId: sessionId,
       materializedSessionId: slot.materializedSessionId ?? null,
       workspaceId,
-      configId,
+      configId: rawConfigId,
+      controlKey: options?.controlKey ?? rawConfigId,
       value,
       persistDefaultPreference: options?.persistDefaultPreference !== false,
     });

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/pending-workspace-session-shell.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/pending-workspace-session-shell.ts
@@ -43,15 +43,18 @@ export function ensurePendingWorkspaceSessionShell(input: {
     status: "starting",
     transcriptHydrated: true,
   });
-  for (const [controlKey, value] of Object.entries(initialSession.launchControlValues ?? {})) {
+  for (const [rawConfigId, value] of Object.entries(initialSession.launchControlValues ?? {})) {
     if (value.trim().length === 0) {
       continue;
     }
     useSessionIntentStore.getState().enqueueConfig({
       clientSessionId,
       workspaceId: pendingWorkspaceUiKey,
-      configId: null,
-      controlKey,
+      configId: rawConfigId,
+      // Pending-workspace input is keyed by the harness ID. Settlement
+      // resolves the semantic identity from authoritative live config while
+      // retaining this raw identity for post-materialization dispatch.
+      controlKey: rawConfigId,
       value,
       persistDefaultPreference: false,
     });

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/pending-workspace-session-shell.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/pending-workspace-session-shell.ts
@@ -43,14 +43,15 @@ export function ensurePendingWorkspaceSessionShell(input: {
     status: "starting",
     transcriptHydrated: true,
   });
-  for (const [configId, value] of Object.entries(initialSession.launchControlValues ?? {})) {
+  for (const [controlKey, value] of Object.entries(initialSession.launchControlValues ?? {})) {
     if (value.trim().length === 0) {
       continue;
     }
     useSessionIntentStore.getState().enqueueConfig({
       clientSessionId,
       workspaceId: pendingWorkspaceUiKey,
-      configId,
+      configId: null,
+      controlKey,
       value,
       persistDefaultPreference: false,
     });

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-entry-flow.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-entry-flow.test.ts
@@ -7,6 +7,10 @@ import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-st
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
 import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
 import {
+  getSessionIntentsForSession,
+  useSessionIntentStore,
+} from "#product/stores/sessions/session-intent-store";
+import {
   EMPTY_PENDING_WORKSPACE_REGISTRY,
   type PendingWorkspaceRegistry,
   upsertPendingWorkspaceEntry,
@@ -96,7 +100,10 @@ vi.mock("#product/hooks/chat/derived/use-active-session-config-state", () => ({
 
 vi.mock("#product/lib/infra/measurement/measurement-port", () => ({
   elapsedSince: () => 0,
+  isDebugMeasurementEnabled: () => false,
   logLatency: vi.fn(),
+  now: () => 0,
+  recordStoreActionDebugActivity: vi.fn(),
 }));
 
 describe("useWorkspaceEntryFlow", () => {
@@ -120,6 +127,7 @@ describe("useWorkspaceEntryFlow", () => {
     mocks.harnessState.bumpSessionActivationIntentEpoch.mockReset();
     mocks.harnessState.bumpSessionActivationIntentEpoch.mockReturnValue(1);
     useSessionDirectoryStore.getState().clearEntries();
+    useSessionIntentStore.getState().clear();
     useSessionTranscriptStore.getState().clearEntries();
     useWorkspaceUiStore.setState({
       _hydrated: false,
@@ -193,6 +201,7 @@ describe("useWorkspaceEntryFlow", () => {
         agentKind: "codex",
         modelId: "gpt-5.5",
         modeId: "xhigh",
+        launchControlValues: { reasoning_effort: "high" },
         displayTitle: "gpt-5.5",
       },
     });
@@ -201,6 +210,14 @@ describe("useWorkspaceEntryFlow", () => {
     expect(mocks.enterPendingWorkspaceShell).toHaveBeenCalledWith(entry, {
       initialActiveSessionId: projectedSessionId,
     });
+    expect(getSessionIntentsForSession(projectedSessionId)).toEqual([
+      expect.objectContaining({
+        controlKey: "reasoning_effort",
+        rawConfigId: "reasoning_effort",
+        status: "queued",
+        value: "high",
+      }),
+    ]);
   });
 
   it("materializes projected sessions before clearing finalized pending workspace", async () => {

--- a/apps/packages/product-client/src/lib/domain/chat/models/launch-control-descriptors.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/models/launch-control-descriptors.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { DesktopAgentLaunchControl } from "#product/lib/domain/agents/cloud-launch-catalog";
 import { buildLaunchControlDescriptors } from "#product/lib/domain/chat/models/launch-control-descriptors";
 
@@ -6,6 +6,7 @@ function control(
   key: string,
   label: string,
   defaultValue: string,
+  liveConfigId = key,
 ): DesktopAgentLaunchControl {
   return {
     key,
@@ -28,7 +29,7 @@ function control(
     },
     apply: {
       createField: null,
-      liveConfigId: key,
+      liveConfigId,
       liveSetter: "runtime_control",
       queueBeforeMaterialized: true,
     },
@@ -318,7 +319,7 @@ describe("buildLaunchControlDescriptors", () => {
         {
           kind: "codex",
           launchControls: [
-            control("access_mode", "Mode", "medium"),
+            control("effort", "Effort", "medium", "reasoning_effort"),
           ],
           models: [{ id: "gpt-5.5" }],
         },
@@ -337,9 +338,82 @@ describe("buildLaunchControlDescriptors", () => {
 
     expect(selections).toEqual([{
       agentKind: "codex",
-      controlKey: "mode",
-      rawConfigId: "access_mode",
+      controlKey: "effort",
+      rawConfigId: "reasoning_effort",
       value: "high",
     }]);
+  });
+
+  it("uses the same mapping logic for an aligned semantic and raw id", () => {
+    const onSelect = vi.fn();
+    const [effort] = buildLaunchControlDescriptors({
+      selection: { kind: "claude", modelId: "claude-fable-5" },
+      launchAgents: [{
+        kind: "claude",
+        launchControls: [control("effort", "Effort", "medium", "effort")],
+        models: [{ id: "claude-fable-5" }],
+      }],
+      preferences: {
+        defaultSessionModeByAgentKind: {},
+        defaultLiveSessionControlValuesByAgentKind: {},
+      },
+      pendingConfigChanges: null,
+      onSelect,
+    });
+
+    effort?.onSelect("high");
+
+    expect(effort).toMatchObject({ key: "effort", rawConfigId: "effort" });
+    expect(onSelect).toHaveBeenCalledWith("claude", "effort", "effort", "high");
+  });
+
+  it("omits a launch control without a live mapping", () => {
+    const missingMapping = control("effort", "Effort", "medium", "");
+
+    expect(buildLaunchControlDescriptors({
+      selection: { kind: "codex", modelId: "gpt-5.5" },
+      launchAgents: [{
+        kind: "codex",
+        launchControls: [missingMapping],
+        models: [{ id: "gpt-5.5" }],
+      }],
+      preferences: {
+        defaultSessionModeByAgentKind: {},
+        defaultLiveSessionControlValuesByAgentKind: {},
+      },
+      pendingConfigChanges: null,
+      onSelect: vi.fn(),
+    })).toEqual([]);
+  });
+
+  it("projects a launch-only pending value by semantic key", () => {
+    const [effort] = buildLaunchControlDescriptors({
+      selection: { kind: "codex", modelId: "gpt-5.5" },
+      launchAgents: [{
+        kind: "codex",
+        launchControls: [control("effort", "Effort", "medium", "reasoning_effort")],
+        models: [{ id: "gpt-5.5" }],
+      }],
+      preferences: {
+        defaultSessionModeByAgentKind: {},
+        defaultLiveSessionControlValuesByAgentKind: {},
+      },
+      pendingConfigChanges: {
+        effort: {
+          rawConfigId: "effort",
+          value: "high",
+          status: "submitting",
+          mutationId: Number.NaN,
+        },
+      },
+      onSelect: vi.fn(),
+    });
+
+    expect(effort).toMatchObject({
+      key: "effort",
+      rawConfigId: "reasoning_effort",
+      detail: "High",
+      pendingState: "submitting",
+    });
   });
 });

--- a/apps/packages/product-client/src/lib/domain/chat/models/launch-control-descriptors.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/models/launch-control-descriptors.ts
@@ -107,7 +107,12 @@ function launchControlToDescriptor(input: {
   ) {
     return [];
   }
-  const rawConfigId = input.control.createField === "modeId" ? "mode" : input.control.key;
+  const rawConfigId = input.control.createField === "modeId"
+    ? "mode"
+    : input.control.apply.liveConfigId?.trim();
+  if (!rawConfigId) {
+    return [];
+  }
   // Scope control values to what the selected model actually supports (the
   // agent-level vocabulary is a superset — e.g. gateway/bedrock models reject
   // `auto`; sonnet's effort caps at `max` while opus adds `xhigh`). Fall back
@@ -124,6 +129,9 @@ function launchControlToDescriptor(input: {
   const pendingChange = getPendingSessionConfigChange(
     input.pendingConfigChanges,
     rawConfigId,
+  ) ?? getPendingSessionConfigChange(
+    input.pendingConfigChanges,
+    key,
   );
 
   // Only honour a stored/default preference if the selected model still

--- a/apps/packages/product-client/src/lib/domain/chat/session-controls/session-controls.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/session-controls/session-controls.test.ts
@@ -90,7 +90,30 @@ describe("buildLiveSessionControlDescriptors", () => {
     ]);
 
     controls[0]?.onSelect("low");
-    expect(onSelect).toHaveBeenCalledWith("effort", "low");
+    expect(onSelect).toHaveBeenCalledWith("effort", "effort", "low");
+  });
+
+  it("passes semantic and harness identities separately for an asymmetric live control", () => {
+    const onSelect = vi.fn();
+    const [effort] = buildLiveSessionControlDescriptors(
+      {
+        ...NORMALIZED_CONTROLS,
+        effort: {
+          ...NORMALIZED_CONTROLS.effort!,
+          rawConfigId: "reasoning_effort",
+        },
+      },
+      null,
+      onSelect,
+    );
+
+    effort?.onSelect("medium");
+
+    expect(onSelect).toHaveBeenCalledWith(
+      "effort",
+      "reasoning_effort",
+      "medium",
+    );
   });
 
   it("shows the latest pending value for the same raw config id", () => {

--- a/apps/packages/product-client/src/lib/domain/chat/session-controls/session-controls.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/session-controls/session-controls.ts
@@ -42,7 +42,11 @@ export interface LiveSessionControlDescriptor {
 export function buildLiveSessionControlDescriptors(
   normalized: NormalizedSessionControls | null | undefined,
   pendingConfigChanges: PendingSessionConfigChanges | null | undefined,
-  onSelect: (rawConfigId: string, value: string) => void,
+  onSelect: (
+    controlKey: SupportedLiveControlKey,
+    rawConfigId: string,
+    value: string,
+  ) => void,
 ): LiveSessionControlDescriptor[] {
   if (!normalized) {
     return [];
@@ -72,7 +76,7 @@ export function buildLiveSessionControlDescriptors(
         selected: value.value === displayedState.currentValue,
       })),
       onSelect: (value: string) => {
-        void onSelect(control.rawConfigId, value);
+        void onSelect(key, control.rawConfigId, value);
       },
     };
 

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/config-intent-settlement-state.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/config-intent-settlement-state.ts
@@ -1,0 +1,40 @@
+import type {
+  SessionIntentStateShape,
+} from "#product/domain/sessions/intents/session-intent-state";
+import type {
+  AdoptedSessionConfigIntentResolutionPlan,
+  ConfigIntentSettlementPlan,
+} from "#product/lib/domain/sessions/creation/config-intent-settlement";
+
+export function applyConfigIntentResolutionPlan<T extends SessionIntentStateShape>(
+  state: T,
+  plan: ConfigIntentSettlementPlan | AdoptedSessionConfigIntentResolutionPlan,
+  now = new Date().toISOString(),
+): T {
+  let changed = false;
+  const entriesById = { ...state.entriesById };
+  for (const patch of plan.patches) {
+    const intent = entriesById[patch.intentId];
+    if (
+      !intent
+      || intent.kind !== "update_config"
+      || intent.generation !== patch.generation
+      || intent.status !== "queued"
+      || intent.materializedSessionId !== null
+    ) {
+      continue;
+    }
+    changed = true;
+    entriesById[patch.intentId] = {
+      ...intent,
+      rawConfigId: patch.rawConfigId,
+      status: patch.status,
+      errorMessage: patch.status === "failed"
+        ? "Launch default was not confirmed by authoritative session config."
+        : null,
+      updatedAt: now,
+      reconciledAt: patch.status === "reconciled" ? now : null,
+    };
+  }
+  return changed ? { ...state, entriesById } : state;
+}

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/config-intent-settlement.test.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/config-intent-settlement.test.ts
@@ -1,0 +1,96 @@
+import type {
+  NormalizedSessionControl,
+  SessionLiveConfigSnapshot,
+} from "@anyharness/sdk";
+import { describe, expect, it } from "vitest";
+import {
+  planAdoptedSessionConfigIntentResolution,
+  planCreationConfigIntentSettlement,
+  type PreMaterializationConfigIntentSnapshot,
+} from "#product/lib/domain/sessions/creation/config-intent-settlement";
+
+const SNAPSHOT: PreMaterializationConfigIntentSnapshot = [{
+  intentId: "effort-intent",
+  generation: 1,
+  controlKey: "effort",
+  rawConfigId: "reasoning_effort",
+  value: "high",
+  order: 0,
+}];
+
+describe("config intent settlement", () => {
+  it("preserves queued creation and adoption intents when live config is unavailable", () => {
+    expect(planCreationConfigIntentSettlement({
+      snapshot: SNAPSHOT,
+      liveConfig: null,
+    })).toEqual({ patches: [] });
+    expect(planAdoptedSessionConfigIntentResolution({
+      snapshot: SNAPSHOT,
+      liveConfig: null,
+    })).toEqual({ patches: [] });
+  });
+
+  it("resolves raw-keyed pending-shell input through the authoritative raw ID", () => {
+    const rawKeyedSnapshot: PreMaterializationConfigIntentSnapshot = [{
+      ...SNAPSHOT[0],
+      controlKey: "reasoning_effort",
+    }];
+
+    expect(planCreationConfigIntentSettlement({
+      snapshot: rawKeyedSnapshot,
+      liveConfig: liveConfig(effortControl()),
+    })).toEqual({
+      patches: [{
+        intentId: "effort-intent",
+        generation: 1,
+        rawConfigId: "reasoning_effort",
+        status: "reconciled",
+      }],
+    });
+  });
+
+  it("still retires a value when authoritative config omits its control", () => {
+    expect(planCreationConfigIntentSettlement({
+      snapshot: SNAPSHOT,
+      liveConfig: liveConfig(null),
+    })).toEqual({
+      patches: [{
+        intentId: "effort-intent",
+        generation: 1,
+        rawConfigId: null,
+        status: "stale",
+      }],
+    });
+  });
+});
+
+function effortControl(): NormalizedSessionControl {
+  return {
+    key: "effort",
+    rawConfigId: "reasoning_effort",
+    label: "Effort",
+    currentValue: "high",
+    settable: true,
+    values: [
+      { value: "medium", label: "Medium" },
+      { value: "high", label: "High" },
+    ],
+  };
+}
+
+function liveConfig(effort: NormalizedSessionControl | null): SessionLiveConfigSnapshot {
+  return {
+    sourceSeq: 1,
+    rawConfigOptions: [],
+    normalizedControls: {
+      model: null,
+      collaborationMode: null,
+      mode: null,
+      reasoning: null,
+      effort,
+      fastMode: null,
+      extras: [],
+    },
+    updatedAt: "2026-08-16T00:00:00Z",
+  };
+}

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/config-intent-settlement.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/config-intent-settlement.ts
@@ -3,6 +3,9 @@ import type {
   SessionLiveConfigSnapshot,
 } from "@anyharness/sdk";
 import type {
+  DesktopAgentLaunchControl,
+} from "#product/lib/domain/agents/cloud-launch-catalog";
+import type {
   SessionIntent,
 } from "#product/domain/sessions/intents/session-intent-model";
 
@@ -59,6 +62,28 @@ export function snapshotPreMaterializationConfigIntents(
       value: intent.value,
       order,
     }];
+  });
+}
+
+export function resolvePreMaterializationConfigIntentControlKeys(input: {
+  snapshot: PreMaterializationConfigIntentSnapshot;
+  launchControls: readonly Pick<DesktopAgentLaunchControl, "key" | "apply">[];
+}): PreMaterializationConfigIntentSnapshot {
+  const controlKeyByRawConfigId = new Map<string, string>();
+  for (const control of input.launchControls) {
+    const rawConfigId = control.apply.liveConfigId?.trim();
+    if (rawConfigId) {
+      controlKeyByRawConfigId.set(rawConfigId, control.key);
+    }
+  }
+  return input.snapshot.map((entry) => {
+    const rawConfigId = entry.rawConfigId?.trim();
+    const controlKey = rawConfigId
+      ? controlKeyByRawConfigId.get(rawConfigId)
+      : undefined;
+    return controlKey && controlKey !== entry.controlKey
+      ? { ...entry, controlKey }
+      : entry;
   });
 }
 

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/config-intent-settlement.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/config-intent-settlement.ts
@@ -79,6 +79,10 @@ export function planCreationConfigIntentSettlement(input: {
   snapshot: PreMaterializationConfigIntentSnapshot;
   liveConfig: SessionLiveConfigSnapshot | null;
 }): ConfigIntentSettlementPlan {
+  const liveConfig = input.liveConfig;
+  if (!liveConfig) {
+    return { patches: [] };
+  }
   const entriesByControlKey = new Map<
     string,
     PreMaterializationConfigIntentSnapshotEntry[]
@@ -90,12 +94,12 @@ export function planCreationConfigIntentSettlement(input: {
   }
 
   const patches: Array<ConfigIntentSettlementPatch & { order: number }> = [];
-  for (const [controlKey, entries] of entriesByControlKey) {
+  for (const entries of entriesByControlKey.values()) {
     const latest = entries[entries.length - 1];
     if (!latest) {
       continue;
     }
-    const control = findNormalizedControlBySemanticKey(input.liveConfig, controlKey);
+    const control = findNormalizedControl(liveConfig, latest);
     const rawConfigId = control?.rawConfigId?.trim() || null;
     const applicable = isApplicableControlValue(control, latest.value);
     for (const entry of entries) {
@@ -125,12 +129,13 @@ export function planAdoptedSessionConfigIntentResolution(input: {
   snapshot: PreMaterializationConfigIntentSnapshot;
   liveConfig: SessionLiveConfigSnapshot | null;
 }): AdoptedSessionConfigIntentResolutionPlan {
+  const liveConfig = input.liveConfig;
+  if (!liveConfig) {
+    return { patches: [] };
+  }
   return {
     patches: input.snapshot.flatMap((entry) => {
-      const control = findNormalizedControlBySemanticKey(
-        input.liveConfig,
-        entry.controlKey,
-      );
+      const control = findNormalizedControl(liveConfig, entry);
       const rawConfigId = control?.rawConfigId?.trim() || null;
       return [{
         intentId: entry.intentId,
@@ -207,13 +212,10 @@ export function applyAdoptedSessionConfigIntentResolutionPlan(
   return changed ? { ...state, entriesById } : state;
 }
 
-function findNormalizedControlBySemanticKey(
-  liveConfig: SessionLiveConfigSnapshot | null,
-  controlKey: string,
+function findNormalizedControl(
+  liveConfig: SessionLiveConfigSnapshot,
+  identity: Pick<PreMaterializationConfigIntentSnapshotEntry, "controlKey" | "rawConfigId">,
 ): NormalizedSessionControl | null {
-  if (!liveConfig) {
-    return null;
-  }
   const normalized = liveConfig.normalizedControls;
   const controls: Array<NormalizedSessionControl | null | undefined> = [
     normalized.model,
@@ -224,7 +226,12 @@ function findNormalizedControlBySemanticKey(
     normalized.fastMode,
     ...normalized.extras,
   ];
-  return controls.find((control) => control?.key === controlKey) ?? null;
+  const rawConfigId = identity.rawConfigId?.trim() || null;
+  return controls.find((control) => control?.key === identity.controlKey)
+    ?? (rawConfigId
+      ? controls.find((control) => control?.rawConfigId === rawConfigId)
+      : null)
+    ?? null;
 }
 
 function isApplicableControlValue(

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/config-intent-settlement.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/config-intent-settlement.ts
@@ -11,6 +11,7 @@ import type {
 
 export interface PreMaterializationConfigIntentSnapshotEntry {
   intentId: string;
+  generation: number;
   controlKey: string;
   rawConfigId: string | null;
   value: string;
@@ -22,6 +23,7 @@ export type PreMaterializationConfigIntentSnapshot =
 
 export interface ConfigIntentSettlementPatch {
   intentId: string;
+  generation: number;
   rawConfigId: string | null;
   status: "reconciled" | "stale" | "failed";
 }
@@ -32,6 +34,7 @@ export interface ConfigIntentSettlementPlan {
 
 export interface AdoptedSessionConfigIntentResolutionPatch {
   intentId: string;
+  generation: number;
   rawConfigId: string | null;
   status: "queued" | "stale";
 }
@@ -53,6 +56,7 @@ export function snapshotPreMaterializationConfigIntents(
     }
     return [{
       intentId: intent.intentId,
+      generation: intent.generation,
       controlKey: intent.controlKey,
       rawConfigId: intent.rawConfigId,
       value: intent.value,
@@ -97,6 +101,7 @@ export function planCreationConfigIntentSettlement(input: {
     for (const entry of entries) {
       patches.push({
         intentId: entry.intentId,
+        generation: entry.generation,
         rawConfigId,
         status: !applicable
           ? "stale"
@@ -129,6 +134,7 @@ export function planAdoptedSessionConfigIntentResolution(input: {
       const rawConfigId = control?.rawConfigId?.trim() || null;
       return [{
         intentId: entry.intentId,
+        generation: entry.generation,
         rawConfigId,
         status: isApplicableControlValue(control, entry.value)
           ? "queued" as const
@@ -147,7 +153,13 @@ export function applyConfigIntentSettlementPlan(
   const entriesById = { ...state.entriesById };
   for (const patch of plan.patches) {
     const intent = entriesById[patch.intentId];
-    if (!intent || intent.kind !== "update_config") {
+    if (
+      !intent
+      || intent.kind !== "update_config"
+      || intent.generation !== patch.generation
+      || intent.status !== "queued"
+      || intent.materializedSessionId !== null
+    ) {
       continue;
     }
     changed = true;
@@ -174,7 +186,13 @@ export function applyAdoptedSessionConfigIntentResolutionPlan(
   const entriesById = { ...state.entriesById };
   for (const patch of plan.patches) {
     const intent = entriesById[patch.intentId];
-    if (!intent || intent.kind !== "update_config" || intent.status !== "queued") {
+    if (
+      !intent
+      || intent.kind !== "update_config"
+      || intent.generation !== patch.generation
+      || intent.status !== "queued"
+      || intent.materializedSessionId !== null
+    ) {
       continue;
     }
     changed = true;

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/config-intent-settlement.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/config-intent-settlement.ts
@@ -122,9 +122,6 @@ export function planAdoptedSessionConfigIntentResolution(input: {
 }): AdoptedSessionConfigIntentResolutionPlan {
   return {
     patches: input.snapshot.flatMap((entry) => {
-      if (entry.rawConfigId !== null) {
-        return [];
-      }
       const control = findNormalizedControlBySemanticKey(
         input.liveConfig,
         entry.controlKey,

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/config-intent-settlement.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/config-intent-settlement.ts
@@ -1,0 +1,224 @@
+import type {
+  NormalizedSessionControl,
+  SessionLiveConfigSnapshot,
+} from "@anyharness/sdk";
+import type {
+  SessionIntent,
+} from "#product/domain/sessions/intents/session-intent-model";
+import type {
+  SessionIntentStateShape,
+} from "#product/domain/sessions/intents/session-intent-state";
+
+export interface PreMaterializationConfigIntentSnapshotEntry {
+  intentId: string;
+  controlKey: string;
+  rawConfigId: string | null;
+  value: string;
+  order: number;
+}
+
+export type PreMaterializationConfigIntentSnapshot =
+  PreMaterializationConfigIntentSnapshotEntry[];
+
+export interface ConfigIntentSettlementPatch {
+  intentId: string;
+  rawConfigId: string | null;
+  status: "reconciled" | "stale" | "failed";
+}
+
+export interface ConfigIntentSettlementPlan {
+  patches: ConfigIntentSettlementPatch[];
+}
+
+export interface AdoptedSessionConfigIntentResolutionPatch {
+  intentId: string;
+  rawConfigId: string | null;
+  status: "queued" | "stale";
+}
+
+export interface AdoptedSessionConfigIntentResolutionPlan {
+  patches: AdoptedSessionConfigIntentResolutionPatch[];
+}
+
+export function snapshotPreMaterializationConfigIntents(
+  intents: readonly SessionIntent[],
+): PreMaterializationConfigIntentSnapshot {
+  return intents.flatMap((intent, order) => {
+    if (
+      intent.kind !== "update_config"
+      || intent.status !== "queued"
+      || intent.materializedSessionId !== null
+    ) {
+      return [];
+    }
+    return [{
+      intentId: intent.intentId,
+      controlKey: intent.controlKey,
+      rawConfigId: intent.rawConfigId,
+      value: intent.value,
+      order,
+    }];
+  });
+}
+
+export function configValuesFromIntentSnapshot(
+  snapshot: PreMaterializationConfigIntentSnapshot,
+): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const entry of snapshot) {
+    values[entry.controlKey] = entry.value;
+  }
+  return values;
+}
+
+export function planCreationConfigIntentSettlement(input: {
+  snapshot: PreMaterializationConfigIntentSnapshot;
+  liveConfig: SessionLiveConfigSnapshot | null;
+}): ConfigIntentSettlementPlan {
+  const entriesByControlKey = new Map<
+    string,
+    PreMaterializationConfigIntentSnapshotEntry[]
+  >();
+  for (const entry of input.snapshot) {
+    const entries = entriesByControlKey.get(entry.controlKey) ?? [];
+    entries.push(entry);
+    entriesByControlKey.set(entry.controlKey, entries);
+  }
+
+  const patches: Array<ConfigIntentSettlementPatch & { order: number }> = [];
+  for (const [controlKey, entries] of entriesByControlKey) {
+    const latest = entries[entries.length - 1];
+    if (!latest) {
+      continue;
+    }
+    const control = findNormalizedControlBySemanticKey(input.liveConfig, controlKey);
+    const rawConfigId = control?.rawConfigId?.trim() || null;
+    const applicable = isApplicableControlValue(control, latest.value);
+    for (const entry of entries) {
+      patches.push({
+        intentId: entry.intentId,
+        rawConfigId,
+        status: !applicable
+          ? "stale"
+          : entry.intentId !== latest.intentId
+            ? "stale"
+            : control.currentValue === latest.value
+              ? "reconciled"
+              : "failed",
+        order: entry.order,
+      });
+    }
+  }
+
+  patches.sort((left, right) => left.order - right.order);
+  return {
+    patches: patches.map(({ order: _order, ...patch }) => patch),
+  };
+}
+
+export function planAdoptedSessionConfigIntentResolution(input: {
+  snapshot: PreMaterializationConfigIntentSnapshot;
+  liveConfig: SessionLiveConfigSnapshot | null;
+}): AdoptedSessionConfigIntentResolutionPlan {
+  return {
+    patches: input.snapshot.flatMap((entry) => {
+      if (entry.rawConfigId !== null) {
+        return [];
+      }
+      const control = findNormalizedControlBySemanticKey(
+        input.liveConfig,
+        entry.controlKey,
+      );
+      const rawConfigId = control?.rawConfigId?.trim() || null;
+      return [{
+        intentId: entry.intentId,
+        rawConfigId,
+        status: isApplicableControlValue(control, entry.value)
+          ? "queued" as const
+          : "stale" as const,
+      }];
+    }),
+  };
+}
+
+export function applyConfigIntentSettlementPlan(
+  state: SessionIntentStateShape,
+  plan: ConfigIntentSettlementPlan,
+  now = new Date().toISOString(),
+): SessionIntentStateShape {
+  let changed = false;
+  const entriesById = { ...state.entriesById };
+  for (const patch of plan.patches) {
+    const intent = entriesById[patch.intentId];
+    if (!intent || intent.kind !== "update_config") {
+      continue;
+    }
+    changed = true;
+    entriesById[patch.intentId] = {
+      ...intent,
+      rawConfigId: patch.rawConfigId,
+      status: patch.status,
+      errorMessage: patch.status === "failed"
+        ? "Launch default was not confirmed by authoritative session config."
+        : null,
+      updatedAt: now,
+      reconciledAt: patch.status === "reconciled" ? now : null,
+    };
+  }
+  return changed ? { ...state, entriesById } : state;
+}
+
+export function applyAdoptedSessionConfigIntentResolutionPlan(
+  state: SessionIntentStateShape,
+  plan: AdoptedSessionConfigIntentResolutionPlan,
+  now = new Date().toISOString(),
+): SessionIntentStateShape {
+  let changed = false;
+  const entriesById = { ...state.entriesById };
+  for (const patch of plan.patches) {
+    const intent = entriesById[patch.intentId];
+    if (!intent || intent.kind !== "update_config" || intent.status !== "queued") {
+      continue;
+    }
+    changed = true;
+    entriesById[patch.intentId] = {
+      ...intent,
+      rawConfigId: patch.rawConfigId,
+      status: patch.status,
+      errorMessage: null,
+      updatedAt: now,
+    };
+  }
+  return changed ? { ...state, entriesById } : state;
+}
+
+function findNormalizedControlBySemanticKey(
+  liveConfig: SessionLiveConfigSnapshot | null,
+  controlKey: string,
+): NormalizedSessionControl | null {
+  if (!liveConfig) {
+    return null;
+  }
+  const normalized = liveConfig.normalizedControls;
+  const controls: Array<NormalizedSessionControl | null | undefined> = [
+    normalized.model,
+    normalized.collaborationMode,
+    normalized.mode,
+    normalized.reasoning,
+    normalized.effort,
+    normalized.fastMode,
+    ...normalized.extras,
+  ];
+  return controls.find((control) => control?.key === controlKey) ?? null;
+}
+
+function isApplicableControlValue(
+  control: NormalizedSessionControl | null,
+  value: string,
+): control is NormalizedSessionControl {
+  return Boolean(
+    control?.settable
+    && control.rawConfigId.trim()
+    && control.values.some((candidate) => candidate.value === value),
+  );
+}

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/config-intent-settlement.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/config-intent-settlement.ts
@@ -97,6 +97,19 @@ export function configValuesFromIntentSnapshot(
   return values;
 }
 
+export function rawConfigValuesFromIntentSnapshot(
+  snapshot: PreMaterializationConfigIntentSnapshot,
+): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const entry of snapshot) {
+    const rawConfigId = entry.rawConfigId?.trim();
+    if (rawConfigId) {
+      values[rawConfigId] = entry.value;
+    }
+  }
+  return values;
+}
+
 export function planCreationConfigIntentSettlement(input: {
   snapshot: PreMaterializationConfigIntentSnapshot;
   liveConfig: SessionLiveConfigSnapshot | null;

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/config-intent-settlement.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/config-intent-settlement.ts
@@ -5,9 +5,6 @@ import type {
 import type {
   SessionIntent,
 } from "#product/domain/sessions/intents/session-intent-model";
-import type {
-  SessionIntentStateShape,
-} from "#product/domain/sessions/intents/session-intent-state";
 
 export interface PreMaterializationConfigIntentSnapshotEntry {
   intentId: string;
@@ -147,69 +144,6 @@ export function planAdoptedSessionConfigIntentResolution(input: {
       }];
     }),
   };
-}
-
-export function applyConfigIntentSettlementPlan(
-  state: SessionIntentStateShape,
-  plan: ConfigIntentSettlementPlan,
-  now = new Date().toISOString(),
-): SessionIntentStateShape {
-  let changed = false;
-  const entriesById = { ...state.entriesById };
-  for (const patch of plan.patches) {
-    const intent = entriesById[patch.intentId];
-    if (
-      !intent
-      || intent.kind !== "update_config"
-      || intent.generation !== patch.generation
-      || intent.status !== "queued"
-      || intent.materializedSessionId !== null
-    ) {
-      continue;
-    }
-    changed = true;
-    entriesById[patch.intentId] = {
-      ...intent,
-      rawConfigId: patch.rawConfigId,
-      status: patch.status,
-      errorMessage: patch.status === "failed"
-        ? "Launch default was not confirmed by authoritative session config."
-        : null,
-      updatedAt: now,
-      reconciledAt: patch.status === "reconciled" ? now : null,
-    };
-  }
-  return changed ? { ...state, entriesById } : state;
-}
-
-export function applyAdoptedSessionConfigIntentResolutionPlan(
-  state: SessionIntentStateShape,
-  plan: AdoptedSessionConfigIntentResolutionPlan,
-  now = new Date().toISOString(),
-): SessionIntentStateShape {
-  let changed = false;
-  const entriesById = { ...state.entriesById };
-  for (const patch of plan.patches) {
-    const intent = entriesById[patch.intentId];
-    if (
-      !intent
-      || intent.kind !== "update_config"
-      || intent.generation !== patch.generation
-      || intent.status !== "queued"
-      || intent.materializedSessionId !== null
-    ) {
-      continue;
-    }
-    changed = true;
-    entriesById[patch.intentId] = {
-      ...intent,
-      rawConfigId: patch.rawConfigId,
-      status: patch.status,
-      errorMessage: null,
-      updatedAt: now,
-    };
-  }
-  return changed ? { ...state, entriesById } : state;
 }
 
 function findNormalizedControl(

--- a/apps/packages/product-client/src/lib/workflows/sessions/session-launch-defaults.ts
+++ b/apps/packages/product-client/src/lib/workflows/sessions/session-launch-defaults.ts
@@ -48,6 +48,7 @@ interface ApplySessionLaunchDefaultsInput {
   modelRegistries: readonly SessionConfigModelRegistry[];
   defaultLiveSessionControlValuesByAgentKind:
     DefaultLiveSessionControlValuesByAgentKind;
+  rawLiveSessionControlValues?: Readonly<Record<string, string>>;
 }
 
 interface ApplySessionLaunchDefaultsResult {
@@ -66,9 +67,10 @@ export async function applySessionLaunchDefaults({
   agentKind,
   modelRegistries,
   defaultLiveSessionControlValuesByAgentKind,
+  rawLiveSessionControlValues = {},
 }: ApplySessionLaunchDefaultsInput): Promise<ApplySessionLaunchDefaultsResult> {
   const registry = modelRegistries.find((candidate) => candidate.kind === agentKind);
-  if (!registry) {
+  if (!registry && Object.keys(rawLiveSessionControlValues).length === 0) {
     return {
       session,
       liveConfig: session.liveConfig ?? null,
@@ -84,7 +86,9 @@ export async function applySessionLaunchDefaults({
     };
   }
 
-  const model = resolveSessionModel(registry, workingSession, workingLiveConfig);
+  const model = registry
+    ? resolveSessionModel(registry, workingSession, workingLiveConfig)
+    : null;
   const metadataByKey = buildDefaultControlMetadataByKey(
     model?.sessionDefaultControls ?? [],
   );
@@ -94,7 +98,11 @@ export async function applySessionLaunchDefaults({
     metadataByKey,
     configuredDefaults,
   );
-  if (metadataByKey.size === 0 && !defaults.collaboration_mode?.trim()) {
+  if (
+    metadataByKey.size === 0
+    && !defaults.collaboration_mode?.trim()
+    && Object.keys(rawLiveSessionControlValues).length === 0
+  ) {
     return {
       session: attachLiveConfig(workingSession, workingLiveConfig),
       liveConfig: workingLiveConfig,
@@ -102,20 +110,24 @@ export async function applySessionLaunchDefaults({
   }
 
   for (const controlKey of CONTROL_APPLY_ORDER) {
-    const defaultValue = defaults[controlKey]?.trim();
+    const liveControl = getLiveControl(workingLiveConfig, controlKey);
+    const rawIntentValue = liveControl
+      ? rawLiveSessionControlValues[liveControl.rawConfigId]?.trim()
+      : undefined;
+    const defaultValue = rawIntentValue || defaults[controlKey]?.trim();
     if (!defaultValue) {
       continue;
     }
 
     const metadata = metadataByKey.get(controlKey);
     if (
-      controlKey !== "collaboration_mode"
+      !rawIntentValue
+      && controlKey !== "collaboration_mode"
       && (!metadata || !metadata.values.some((value) => value.value === defaultValue))
     ) {
       continue;
     }
 
-    const liveControl = getLiveControl(workingLiveConfig, controlKey);
     if (
       !liveControl
       || !liveControl.settable

--- a/apps/packages/product-client/src/stores/sessions/session-intent-store-measurement.ts
+++ b/apps/packages/product-client/src/stores/sessions/session-intent-store-measurement.ts
@@ -1,0 +1,48 @@
+import type {
+  SessionIntentStateShape,
+} from "#product/domain/sessions/intents/session-intent-state";
+import {
+  isDebugMeasurementEnabled,
+  now as measurementNow,
+  recordStoreActionDebugActivity,
+} from "#product/lib/infra/measurement/measurement-port";
+
+export function startSessionIntentStoreActionTrace(): number | null {
+  return isDebugMeasurementEnabled() ? measurementNow() : null;
+}
+
+export function recordSessionIntentStoreAction(
+  action: string,
+  before: SessionIntentStateShape,
+  after: SessionIntentStateShape,
+  metadata: Record<string, unknown>,
+  startedAtMs: number | null,
+): void {
+  if (startedAtMs === null) {
+    return;
+  }
+  const clientSessionId = typeof metadata.clientSessionId === "string"
+    ? metadata.clientSessionId
+    : null;
+  recordStoreActionDebugActivity({
+    label: `session-intent-store.${action}`,
+    startedAtMs,
+    metadata: {
+      ...metadata,
+      afterCount: countSessionIntents(after, clientSessionId),
+      beforeCount: countSessionIntents(before, clientSessionId),
+      totalAfterCount: Object.keys(after.entriesById).length,
+      totalBeforeCount: Object.keys(before.entriesById).length,
+    },
+  });
+}
+
+function countSessionIntents(
+  state: SessionIntentStateShape,
+  clientSessionId: string | null,
+): number | null {
+  if (!clientSessionId) {
+    return null;
+  }
+  return state.intentIdsByClientSessionId[clientSessionId]?.length ?? 0;
+}

--- a/apps/packages/product-client/src/stores/sessions/session-intent-store-measurement.ts
+++ b/apps/packages/product-client/src/stores/sessions/session-intent-store-measurement.ts
@@ -15,12 +15,13 @@ export function recordSessionIntentStoreAction(
   action: string,
   before: SessionIntentStateShape,
   after: SessionIntentStateShape,
-  metadata: Record<string, unknown>,
+  createMetadata: () => Record<string, unknown>,
   startedAtMs: number | null,
 ): void {
   if (startedAtMs === null) {
     return;
   }
+  const metadata = createMetadata();
   const clientSessionId = typeof metadata.clientSessionId === "string"
     ? metadata.clientSessionId
     : null;

--- a/apps/packages/product-client/src/stores/sessions/session-intent-store-settlement.ts
+++ b/apps/packages/product-client/src/stores/sessions/session-intent-store-settlement.ts
@@ -1,0 +1,33 @@
+import {
+  applyConfigIntentResolutionPlan,
+} from "#product/lib/domain/sessions/creation/config-intent-settlement-state";
+import type {
+  AdoptedSessionConfigIntentResolutionPlan,
+  ConfigIntentSettlementPlan,
+} from "#product/lib/domain/sessions/creation/config-intent-settlement";
+import {
+  useSessionIntentStore,
+} from "#product/stores/sessions/session-intent-store";
+
+export function applyConfigIntentSettlement(
+  plan: ConfigIntentSettlementPlan,
+): void {
+  applyConfigIntentResolution(plan);
+}
+
+export function applyAdoptedSessionConfigIntentResolution(
+  plan: AdoptedSessionConfigIntentResolutionPlan,
+): void {
+  applyConfigIntentResolution(plan);
+}
+
+function applyConfigIntentResolution(
+  plan: ConfigIntentSettlementPlan | AdoptedSessionConfigIntentResolutionPlan,
+): void {
+  if (plan.patches.length === 0) {
+    return;
+  }
+  useSessionIntentStore.getState().settleConfig(
+    (state) => applyConfigIntentResolutionPlan(state, plan),
+  );
+}

--- a/apps/packages/product-client/src/stores/sessions/session-intent-store.test.ts
+++ b/apps/packages/product-client/src/stores/sessions/session-intent-store.test.ts
@@ -49,29 +49,34 @@ describe("session intent store", () => {
     const first = store.enqueueConfig({
       clientSessionId: "session-1",
       workspaceId: "workspace-1",
-      configId: "mode",
-      value: "plan",
+      controlKey: "effort",
+      configId: "reasoning_effort",
+      value: "high",
     });
     store.enqueueConfig({
       clientSessionId: "session-1",
       workspaceId: "workspace-1",
-      configId: "mode",
-      value: "accept",
+      controlKey: "effort",
+      configId: "reasoning_effort",
+      value: "max",
     });
     const last = store.enqueueConfig({
       clientSessionId: "session-1",
       workspaceId: "workspace-1",
-      configId: "mode",
-      value: "default",
+      controlKey: "effort",
+      configId: "reasoning_effort",
+      value: "high",
     });
 
     const state = useSessionIntentStore.getState();
     expect(state.intentIdsByClientSessionId["session-1"]).toEqual([first.intentId]);
     expect(last.intentId).toBe(first.intentId);
     expect(state.entriesById[first.intentId]).toMatchObject({
-      configId: "mode",
+      controlKey: "effort",
+      generation: first.generation + 2,
+      rawConfigId: "reasoning_effort",
       status: "queued",
-      value: "default",
+      value: "high",
     });
   });
 

--- a/apps/packages/product-client/src/stores/sessions/session-intent-store.ts
+++ b/apps/packages/product-client/src/stores/sessions/session-intent-store.ts
@@ -8,7 +8,6 @@ import {
   createEditPendingPromptIntent,
   createPromptOutboxEntry,
   createResolveInteractionIntent,
-  createUpdateConfigIntent,
   type PromptOutboxCreateInput,
   type PromptOutboxEntry,
   type SessionDeletePendingPromptIntent,
@@ -30,12 +29,13 @@ import {
 } from "#product/domain/sessions/intents/session-intent-reconciliation";
 import {
   bindSessionIntentMaterialization,
-  findSupersedableTailConfigIntent,
+  createOrSupersedeConfigIntent,
   getPromptEntryByPromptId,
   patchSessionIntent,
   removeSessionIntent,
   sessionIntentsForSession,
   upsertSessionIntent,
+  type SessionConfigIntentEnqueueInput,
   type SessionIntentStateShape,
 } from "#product/domain/sessions/intents/session-intent-state";
 import { recordStoreActionDebugActivity } from "#product/lib/infra/measurement/measurement-port";
@@ -73,16 +73,6 @@ interface SessionIntentStoreState extends SessionIntentStateShape {
   clear: () => void;
 }
 
-type SessionConfigIntentEnqueueInput = Omit<
-  Parameters<typeof createUpdateConfigIntent>[0],
-  "intentId" | "controlKey" | "rawConfigId"
-> & {
-  intentId?: string;
-} & (
-  | { configId: string; controlKey?: string }
-  | { configId: null; controlKey: string }
-);
-
 const EMPTY_SESSION_INTENT_STATE: SessionIntentStateShape = {
   entriesById: {},
   intentIdsByClientSessionId: {},
@@ -112,41 +102,11 @@ export const useSessionIntentStore = create<SessionIntentStoreState>((set) => ({
 
   enqueueConfig: (input) => {
     const debugStartedAtMs = startSessionIntentStoreActionTrace();
-    const controlKey = input.controlKey ?? input.configId;
-    if (!controlKey) {
-      throw new Error("A semantic control key is required for a launch-only config intent");
-    }
-    // Same intent id and queue position: the burst reads as one selection
-    // whose value kept changing, and ordering against any later intents is
-    // untouched. Skipped when the caller pins an explicit intentId.
-    const supersedable = input.intentId
-      ? null
-      : findSupersedableTailConfigIntent(
-        useSessionIntentStore.getState(),
-        input.clientSessionId,
-        controlKey,
-      );
-    const intent: SessionUpdateConfigIntent = supersedable
-      ? {
-        ...supersedable,
-        rawConfigId: input.configId,
-        value: input.value,
-        materializedSessionId: input.materializedSessionId ?? supersedable.materializedSessionId,
-        workspaceId: input.workspaceId ?? supersedable.workspaceId,
-        persistDefaultPreference: input.persistDefaultPreference ?? supersedable.persistDefaultPreference,
-        updatedAt: new Date().toISOString(),
-      }
-      : createUpdateConfigIntent({
-        clientSessionId: input.clientSessionId,
-        materializedSessionId: input.materializedSessionId,
-        workspaceId: input.workspaceId,
-        controlKey,
-        rawConfigId: input.configId,
-        value: input.value,
-        persistDefaultPreference: input.persistDefaultPreference,
-        now: input.now,
-        intentId: input.intentId ?? createSessionIntentId("config"),
-      });
+    const { intent, superseded } = createOrSupersedeConfigIntent(
+      useSessionIntentStore.getState(),
+      input,
+      () => createSessionIntentId("config"),
+    );
     set((state) => {
       const next = withDispatchVersion(state, upsertSessionIntent(state, intent));
       recordSessionIntentStoreAction("enqueueConfig", state, next, {
@@ -154,7 +114,7 @@ export const useSessionIntentStore = create<SessionIntentStoreState>((set) => ({
         controlKey: intent.controlKey,
         rawConfigId: intent.rawConfigId,
         intentKind: intent.kind,
-        superseded: Boolean(supersedable),
+        superseded,
         workspaceId: intent.workspaceId,
       }, debugStartedAtMs);
       return next;

--- a/apps/packages/product-client/src/stores/sessions/session-intent-store.ts
+++ b/apps/packages/product-client/src/stores/sessions/session-intent-store.ts
@@ -18,6 +18,12 @@ import {
   type SessionUpdateConfigIntent,
 } from "#product/domain/sessions/intents/session-intent-model";
 import {
+  applyAdoptedSessionConfigIntentResolutionPlan,
+  applyConfigIntentSettlementPlan,
+  type AdoptedSessionConfigIntentResolutionPlan,
+  type ConfigIntentSettlementPlan,
+} from "#product/lib/domain/sessions/creation/config-intent-settlement";
+import {
   pruneEchoedOutboxTombstones,
   pruneEchoedOutboxTombstonesForTranscript,
   reconcileOutboxFromEnvelopes,
@@ -39,9 +45,7 @@ import { now as measurementNow } from "#product/lib/infra/measurement/measuremen
 interface SessionIntentStoreState extends SessionIntentStateShape {
   dispatchVersion: number;
   enqueuePrompt: (input: PromptOutboxCreateInput) => PromptOutboxEntry;
-  enqueueConfig: (input: Omit<Parameters<typeof createUpdateConfigIntent>[0], "intentId"> & {
-    intentId?: string;
-  }) => SessionUpdateConfigIntent;
+  enqueueConfig: (input: SessionConfigIntentEnqueueInput) => SessionUpdateConfigIntent;
   enqueueInteraction: (input: Omit<Parameters<typeof createResolveInteractionIntent>[0], "intentId"> & {
     intentId?: string;
   }) => SessionResolveInteractionIntent;
@@ -54,6 +58,10 @@ interface SessionIntentStoreState extends SessionIntentStateShape {
   patchIntent: (intentId: string, patch: Partial<SessionIntent>) => void;
   removeIntent: (intentId: string) => void;
   bindMaterializedSession: (clientSessionId: string, materializedSessionId: string) => void;
+  applyConfigIntentSettlement: (plan: ConfigIntentSettlementPlan) => void;
+  applyAdoptedSessionConfigIntentResolution: (
+    plan: AdoptedSessionConfigIntentResolutionPlan,
+  ) => void;
   reassignClientSession: (clientSessionId: string, nextClientSessionId: string) => void;
   reconcileFromEnvelopes: (
     clientSessionId: string,
@@ -64,6 +72,16 @@ interface SessionIntentStoreState extends SessionIntentStateShape {
   clearSession: (clientSessionId: string) => void;
   clear: () => void;
 }
+
+type SessionConfigIntentEnqueueInput = Omit<
+  Parameters<typeof createUpdateConfigIntent>[0],
+  "intentId" | "controlKey" | "rawConfigId"
+> & {
+  intentId?: string;
+} & (
+  | { configId: string; controlKey?: string }
+  | { configId: null; controlKey: string }
+);
 
 const EMPTY_SESSION_INTENT_STATE: SessionIntentStateShape = {
   entriesById: {},
@@ -94,6 +112,10 @@ export const useSessionIntentStore = create<SessionIntentStoreState>((set) => ({
 
   enqueueConfig: (input) => {
     const debugStartedAtMs = startSessionIntentStoreActionTrace();
+    const controlKey = input.controlKey ?? input.configId;
+    if (!controlKey) {
+      throw new Error("A semantic control key is required for a launch-only config intent");
+    }
     // Same intent id and queue position: the burst reads as one selection
     // whose value kept changing, and ordering against any later intents is
     // untouched. Skipped when the caller pins an explicit intentId.
@@ -102,11 +124,12 @@ export const useSessionIntentStore = create<SessionIntentStoreState>((set) => ({
       : findSupersedableTailConfigIntent(
         useSessionIntentStore.getState(),
         input.clientSessionId,
-        input.configId,
+        controlKey,
       );
     const intent: SessionUpdateConfigIntent = supersedable
       ? {
         ...supersedable,
+        rawConfigId: input.configId,
         value: input.value,
         materializedSessionId: input.materializedSessionId ?? supersedable.materializedSessionId,
         workspaceId: input.workspaceId ?? supersedable.workspaceId,
@@ -114,14 +137,22 @@ export const useSessionIntentStore = create<SessionIntentStoreState>((set) => ({
         updatedAt: new Date().toISOString(),
       }
       : createUpdateConfigIntent({
-        ...input,
+        clientSessionId: input.clientSessionId,
+        materializedSessionId: input.materializedSessionId,
+        workspaceId: input.workspaceId,
+        controlKey,
+        rawConfigId: input.configId,
+        value: input.value,
+        persistDefaultPreference: input.persistDefaultPreference,
+        now: input.now,
         intentId: input.intentId ?? createSessionIntentId("config"),
       });
     set((state) => {
       const next = withDispatchVersion(state, upsertSessionIntent(state, intent));
       recordSessionIntentStoreAction("enqueueConfig", state, next, {
         clientSessionId: intent.clientSessionId,
-        configId: intent.configId,
+        controlKey: intent.controlKey,
+        rawConfigId: intent.rawConfigId,
         intentKind: intent.kind,
         superseded: Boolean(supersedable),
         workspaceId: intent.workspaceId,
@@ -228,6 +259,44 @@ export const useSessionIntentStore = create<SessionIntentStoreState>((set) => ({
         clientSessionId,
         materializedSessionId,
       }, debugStartedAtMs);
+      return next;
+    });
+  },
+
+  applyConfigIntentSettlement: (plan) => {
+    if (plan.patches.length === 0) {
+      return;
+    }
+    const debugStartedAtMs = startSessionIntentStoreActionTrace();
+    set((state) => {
+      const next = withDispatchVersion(
+        state,
+        applyConfigIntentSettlementPlan(state, plan),
+      );
+      recordSessionIntentStoreAction("applyConfigIntentSettlement", state, next, {
+        patchCount: plan.patches.length,
+      }, debugStartedAtMs);
+      return next;
+    });
+  },
+
+  applyAdoptedSessionConfigIntentResolution: (plan) => {
+    if (plan.patches.length === 0) {
+      return;
+    }
+    const debugStartedAtMs = startSessionIntentStoreActionTrace();
+    set((state) => {
+      const next = withDispatchVersion(
+        state,
+        applyAdoptedSessionConfigIntentResolutionPlan(state, plan),
+      );
+      recordSessionIntentStoreAction(
+        "applyAdoptedSessionConfigIntentResolution",
+        state,
+        next,
+        { patchCount: plan.patches.length },
+        debugStartedAtMs,
+      );
       return next;
     });
   },

--- a/apps/packages/product-client/src/stores/sessions/session-intent-store.ts
+++ b/apps/packages/product-client/src/stores/sessions/session-intent-store.ts
@@ -38,9 +38,10 @@ import {
   type SessionConfigIntentEnqueueInput,
   type SessionIntentStateShape,
 } from "#product/domain/sessions/intents/session-intent-state";
-import { recordStoreActionDebugActivity } from "#product/lib/infra/measurement/measurement-port";
-import { isDebugMeasurementEnabled } from "#product/lib/infra/measurement/measurement-port";
-import { now as measurementNow } from "#product/lib/infra/measurement/measurement-port";
+import {
+  recordSessionIntentStoreAction,
+  startSessionIntentStoreActionTrace,
+} from "#product/stores/sessions/session-intent-store-measurement";
 
 interface SessionIntentStoreState extends SessionIntentStateShape {
   dispatchVersion: number;
@@ -377,44 +378,4 @@ function withDispatchVersion<T extends SessionIntentStoreState>(
 function createSessionIntentId(prefix: string): string {
   nextSessionIntentId += 1;
   return `session-intent:${prefix}:${Date.now()}:${nextSessionIntentId}`;
-}
-
-function startSessionIntentStoreActionTrace(): number | null {
-  return isDebugMeasurementEnabled() ? measurementNow() : null;
-}
-
-function recordSessionIntentStoreAction(
-  action: string,
-  before: SessionIntentStateShape,
-  after: SessionIntentStateShape,
-  metadata: Record<string, unknown>,
-  startedAtMs: number | null,
-): void {
-  if (startedAtMs === null) {
-    return;
-  }
-  const clientSessionId = typeof metadata.clientSessionId === "string"
-    ? metadata.clientSessionId
-    : null;
-  recordStoreActionDebugActivity({
-    label: `session-intent-store.${action}`,
-    startedAtMs,
-    metadata: {
-      ...metadata,
-      afterCount: countSessionIntents(after, clientSessionId),
-      beforeCount: countSessionIntents(before, clientSessionId),
-      totalAfterCount: Object.keys(after.entriesById).length,
-      totalBeforeCount: Object.keys(before.entriesById).length,
-    },
-  });
-}
-
-function countSessionIntents(
-  state: SessionIntentStateShape,
-  clientSessionId: string | null,
-): number | null {
-  if (!clientSessionId) {
-    return null;
-  }
-  return state.intentIdsByClientSessionId[clientSessionId]?.length ?? 0;
 }

--- a/apps/packages/product-client/src/stores/sessions/session-intent-store.ts
+++ b/apps/packages/product-client/src/stores/sessions/session-intent-store.ts
@@ -8,6 +8,7 @@ import {
   createEditPendingPromptIntent,
   createPromptOutboxEntry,
   createResolveInteractionIntent,
+  createUpdateConfigIntent,
   type PromptOutboxCreateInput,
   type PromptOutboxEntry,
   type SessionDeletePendingPromptIntent,
@@ -17,19 +18,13 @@ import {
   type SessionUpdateConfigIntent,
 } from "#product/domain/sessions/intents/session-intent-model";
 import {
-  applyAdoptedSessionConfigIntentResolutionPlan,
-  applyConfigIntentSettlementPlan,
-  type AdoptedSessionConfigIntentResolutionPlan,
-  type ConfigIntentSettlementPlan,
-} from "#product/lib/domain/sessions/creation/config-intent-settlement";
-import {
   pruneEchoedOutboxTombstones,
   pruneEchoedOutboxTombstonesForTranscript,
   reconcileOutboxFromEnvelopes,
 } from "#product/domain/sessions/intents/session-intent-reconciliation";
 import {
   bindSessionIntentMaterialization,
-  createOrSupersedeConfigIntent,
+  findSupersedableTailConfigIntent,
   getPromptEntryByPromptId,
   patchSessionIntent,
   removeSessionIntent,
@@ -59,9 +54,8 @@ interface SessionIntentStoreState extends SessionIntentStateShape {
   patchIntent: (intentId: string, patch: Partial<SessionIntent>) => void;
   removeIntent: (intentId: string) => void;
   bindMaterializedSession: (clientSessionId: string, materializedSessionId: string) => void;
-  applyConfigIntentSettlement: (plan: ConfigIntentSettlementPlan) => void;
-  applyAdoptedSessionConfigIntentResolution: (
-    plan: AdoptedSessionConfigIntentResolutionPlan,
+  settleConfig: (
+    resolve: (state: SessionIntentStateShape) => SessionIntentStateShape,
   ) => void;
   reassignClientSession: (clientSessionId: string, nextClientSessionId: string) => void;
   reconcileFromEnvelopes: (
@@ -90,12 +84,12 @@ export const useSessionIntentStore = create<SessionIntentStoreState>((set) => ({
     const entry = createPromptOutboxEntry(input);
     set((state) => {
       const next = withDispatchVersion(state, upsertSessionIntent(state, entry));
-      recordSessionIntentStoreAction("enqueuePrompt", state, next, {
+      recordSessionIntentStoreAction("enqueuePrompt", state, next, () => ({
         clientSessionId: entry.clientSessionId,
         intentKind: entry.kind,
         placement: entry.placement,
         workspaceId: entry.workspaceId,
-      }, debugStartedAtMs);
+      }), debugStartedAtMs);
       return next;
     });
     return entry;
@@ -103,21 +97,41 @@ export const useSessionIntentStore = create<SessionIntentStoreState>((set) => ({
 
   enqueueConfig: (input) => {
     const debugStartedAtMs = startSessionIntentStoreActionTrace();
-    const { intent, superseded } = createOrSupersedeConfigIntent(
-      useSessionIntentStore.getState(),
-      input,
-      () => createSessionIntentId("config"),
-    );
+    const controlKey = (input.controlKey ?? input.configId) as string;
+    const supersedable = input.intentId
+      ? null
+      : findSupersedableTailConfigIntent(
+        useSessionIntentStore.getState(),
+        input.clientSessionId,
+        controlKey,
+      );
+    const intent: SessionUpdateConfigIntent = supersedable
+      ? {
+        ...supersedable,
+        generation: supersedable.generation + 1,
+        rawConfigId: input.configId,
+        value: input.value,
+        materializedSessionId: input.materializedSessionId ?? supersedable.materializedSessionId,
+        workspaceId: input.workspaceId ?? supersedable.workspaceId,
+        persistDefaultPreference: input.persistDefaultPreference ?? supersedable.persistDefaultPreference,
+        updatedAt: new Date().toISOString(),
+      }
+      : createUpdateConfigIntent({
+        ...input,
+        controlKey,
+        rawConfigId: input.configId,
+        intentId: input.intentId ?? createSessionIntentId("config"),
+      });
     set((state) => {
       const next = withDispatchVersion(state, upsertSessionIntent(state, intent));
-      recordSessionIntentStoreAction("enqueueConfig", state, next, {
+      recordSessionIntentStoreAction("enqueueConfig", state, next, () => ({
         clientSessionId: intent.clientSessionId,
         controlKey: intent.controlKey,
         rawConfigId: intent.rawConfigId,
         intentKind: intent.kind,
-        superseded,
+        superseded: Boolean(supersedable),
         workspaceId: intent.workspaceId,
-      }, debugStartedAtMs);
+      }), debugStartedAtMs);
       return next;
     });
     return intent;
@@ -131,12 +145,12 @@ export const useSessionIntentStore = create<SessionIntentStoreState>((set) => ({
     });
     set((state) => {
       const next = withDispatchVersion(state, upsertSessionIntent(state, intent));
-      recordSessionIntentStoreAction("enqueueInteraction", state, next, {
+      recordSessionIntentStoreAction("enqueueInteraction", state, next, () => ({
         action: intent.action,
         clientSessionId: intent.clientSessionId,
         intentKind: intent.kind,
         workspaceId: intent.workspaceId,
-      }, debugStartedAtMs);
+      }), debugStartedAtMs);
       return next;
     });
     return intent;
@@ -150,12 +164,12 @@ export const useSessionIntentStore = create<SessionIntentStoreState>((set) => ({
     });
     set((state) => {
       const next = withDispatchVersion(state, upsertSessionIntent(state, intent));
-      recordSessionIntentStoreAction("enqueueEditPendingPrompt", state, next, {
+      recordSessionIntentStoreAction("enqueueEditPendingPrompt", state, next, () => ({
         clientSessionId: intent.clientSessionId,
         intentKind: intent.kind,
         seq: intent.seq,
         workspaceId: intent.workspaceId,
-      }, debugStartedAtMs);
+      }), debugStartedAtMs);
       return next;
     });
     return intent;
@@ -169,12 +183,12 @@ export const useSessionIntentStore = create<SessionIntentStoreState>((set) => ({
     });
     set((state) => {
       const next = withDispatchVersion(state, upsertSessionIntent(state, intent));
-      recordSessionIntentStoreAction("enqueueDeletePendingPrompt", state, next, {
+      recordSessionIntentStoreAction("enqueueDeletePendingPrompt", state, next, () => ({
         clientSessionId: intent.clientSessionId,
         intentKind: intent.kind,
         seq: intent.seq,
         workspaceId: intent.workspaceId,
-      }, debugStartedAtMs);
+      }), debugStartedAtMs);
       return next;
     });
     return intent;
@@ -185,12 +199,12 @@ export const useSessionIntentStore = create<SessionIntentStoreState>((set) => ({
     set((state) => {
       const existing = state.entriesById[intentId];
       const next = withDispatchVersion(state, patchSessionIntent(state, intentId, patch));
-      recordSessionIntentStoreAction("patchIntent", state, next, {
+      recordSessionIntentStoreAction("patchIntent", state, next, () => ({
         clientSessionId: existing?.clientSessionId ?? null,
         intentKind: existing?.kind ?? null,
         status: "status" in patch ? patch.status ?? null : null,
         workspaceId: existing?.workspaceId ?? null,
-      }, debugStartedAtMs);
+      }), debugStartedAtMs);
       return next;
     });
   },
@@ -200,11 +214,11 @@ export const useSessionIntentStore = create<SessionIntentStoreState>((set) => ({
     set((state) => {
       const existing = state.entriesById[intentId];
       const next = withDispatchVersion(state, removeSessionIntent(state, intentId));
-      recordSessionIntentStoreAction("removeIntent", state, next, {
+      recordSessionIntentStoreAction("removeIntent", state, next, () => ({
         clientSessionId: existing?.clientSessionId ?? null,
         intentKind: existing?.kind ?? null,
         workspaceId: existing?.workspaceId ?? null,
-      }, debugStartedAtMs);
+      }), debugStartedAtMs);
       return next;
     });
   },
@@ -216,50 +230,16 @@ export const useSessionIntentStore = create<SessionIntentStoreState>((set) => ({
         state,
         bindSessionIntentMaterialization(state, clientSessionId, materializedSessionId),
       );
-      recordSessionIntentStoreAction("bindMaterializedSession", state, next, {
+      recordSessionIntentStoreAction("bindMaterializedSession", state, next, () => ({
         clientSessionId,
         materializedSessionId,
-      }, debugStartedAtMs);
+      }), debugStartedAtMs);
       return next;
     });
   },
 
-  applyConfigIntentSettlement: (plan) => {
-    if (plan.patches.length === 0) {
-      return;
-    }
-    const debugStartedAtMs = startSessionIntentStoreActionTrace();
-    set((state) => {
-      const next = withDispatchVersion(
-        state,
-        applyConfigIntentSettlementPlan(state, plan),
-      );
-      recordSessionIntentStoreAction("applyConfigIntentSettlement", state, next, {
-        patchCount: plan.patches.length,
-      }, debugStartedAtMs);
-      return next;
-    });
-  },
-
-  applyAdoptedSessionConfigIntentResolution: (plan) => {
-    if (plan.patches.length === 0) {
-      return;
-    }
-    const debugStartedAtMs = startSessionIntentStoreActionTrace();
-    set((state) => {
-      const next = withDispatchVersion(
-        state,
-        applyAdoptedSessionConfigIntentResolutionPlan(state, plan),
-      );
-      recordSessionIntentStoreAction(
-        "applyAdoptedSessionConfigIntentResolution",
-        state,
-        next,
-        { patchCount: plan.patches.length },
-        debugStartedAtMs,
-      );
-      return next;
-    });
+  settleConfig: (resolve) => {
+    set((state) => withDispatchVersion(state, resolve(state)));
   },
 
   reassignClientSession: (clientSessionId, nextClientSessionId) => {
@@ -281,10 +261,10 @@ export const useSessionIntentStore = create<SessionIntentStoreState>((set) => ({
         });
       }
       const versionedNext = withDispatchVersion(state, next);
-      recordSessionIntentStoreAction("reassignClientSession", state, versionedNext, {
+      recordSessionIntentStoreAction("reassignClientSession", state, versionedNext, () => ({
         clientSessionId,
         nextClientSessionId,
-      }, debugStartedAtMs);
+      }), debugStartedAtMs);
       return versionedNext;
     });
   },
@@ -300,10 +280,10 @@ export const useSessionIntentStore = create<SessionIntentStoreState>((set) => ({
         ? pruneEchoedOutboxTombstonesForTranscript(reconciled, transcript)
         : reconciled;
       const next = withDispatchVersion(state, pruned);
-      recordSessionIntentStoreAction("reconcileFromEnvelopes", state, next, {
+      recordSessionIntentStoreAction("reconcileFromEnvelopes", state, next, () => ({
         clientSessionId,
         envelopeCount: envelopes.length,
-      }, debugStartedAtMs);
+      }), debugStartedAtMs);
       return next;
     });
   },
@@ -312,7 +292,13 @@ export const useSessionIntentStore = create<SessionIntentStoreState>((set) => ({
     const debugStartedAtMs = startSessionIntentStoreActionTrace();
     set((state) => {
       const next = withDispatchVersion(state, pruneEchoedOutboxTombstones(state));
-      recordSessionIntentStoreAction("pruneEchoedTombstones", state, next, {}, debugStartedAtMs);
+      recordSessionIntentStoreAction(
+        "pruneEchoedTombstones",
+        state,
+        next,
+        () => ({}),
+        debugStartedAtMs,
+      );
       return next;
     });
   },
@@ -329,9 +315,9 @@ export const useSessionIntentStore = create<SessionIntentStoreState>((set) => ({
         next = removeSessionIntent(next, entry.intentId);
       }
       const versionedNext = withDispatchVersion(state, next);
-      recordSessionIntentStoreAction("clearSession", state, versionedNext, {
+      recordSessionIntentStoreAction("clearSession", state, versionedNext, () => ({
         clientSessionId,
-      }, debugStartedAtMs);
+      }), debugStartedAtMs);
       return versionedNext;
     });
   },
@@ -343,7 +329,7 @@ export const useSessionIntentStore = create<SessionIntentStoreState>((set) => ({
         ...EMPTY_SESSION_INTENT_STATE,
         dispatchVersion: state.dispatchVersion + 1,
       };
-      recordSessionIntentStoreAction("clear", state, next, {}, debugStartedAtMs);
+      recordSessionIntentStoreAction("clear", state, next, () => ({}), debugStartedAtMs);
       return next;
     });
   },

--- a/specs/codebase/systems/product/workspaces/pending-shell.md
+++ b/specs/codebase/systems/product/workspaces/pending-shell.md
@@ -557,8 +557,12 @@ projection path.
   config settles only those exact generations before the session is published:
   the latest confirmed value reconciles, superseded values become stale,
   unsupported values become stale, and an applicable unconfirmed latest value
-  fails silently. A newer intent outside the snapshot remains a normal ordered
-  live change.
+  fails silently. If creation returns no live-config snapshot, authority is not
+  yet available: captured intents remain queued and dispatch after binding.
+  Pending-shell inputs retain their raw harness IDs so settlement can resolve a
+  semantic control by raw identity when the producer did not carry that
+  semantic mapping. A newer intent outside the snapshot remains a normal
+  ordered live change.
 - If the projected session has no materialized runtime yet, display labels must
   still use the same label mapping as the final session.
 - Do not mix raw ids and presentation labels. For example, a reasoning setting
@@ -740,8 +744,9 @@ their exact frozen IDs and generations before it materializes or binds the
 session record.
 Compatible existing-session adoption instead resolves launch-only semantic
 keys against that session's authoritative normalized controls before binding;
-applicable records remain ordered live work and unsupported records become
-stale.
+applicable records remain ordered live work, unsupported records become stale,
+and an absent live-config snapshot leaves raw-addressable records queued for
+dispatch after binding.
 
 ### Attachment Conversion
 

--- a/specs/codebase/systems/product/workspaces/pending-shell.md
+++ b/specs/codebase/systems/product/workspaces/pending-shell.md
@@ -308,7 +308,11 @@ Home submit
   -> select real workspace while preserving pending shell
   -> remap projected session to real workspace
   -> create real AnyHarness session for the same client session id
-  -> dispatch ordered session intents
+  -> snapshot queued pre-materialization config intents
+  -> apply each latest applicable config value as a launch default
+  -> settle that exact snapshot from authoritative live config
+  -> publish and bind the materialized session
+  -> dispatch only later ordered session intents
   -> reconcile from transcript/config/interaction stream state
   -> clear pending workspace state after handoff is complete
 ```
@@ -325,8 +329,9 @@ user opens/sends to a new session
   -> write shell tab intent and active session id
   -> enqueue session intents immediately
   -> create real AnyHarness session in the background
+  -> apply and authoritatively settle creation-owned config intents
   -> bind materialized session id
-  -> dispatch and reconcile
+  -> dispatch and reconcile later live intents
 ```
 
 The same model also applies when selecting an existing workspace with remembered
@@ -547,6 +552,12 @@ projection path.
   state match or it would stay stuck. Optimism is therefore held through intent
   `accepted` (so a real switch never reverts to the not-yet-updated value
   mid-flight) and dropped the moment the authoritative value equals it.
+- Session creation snapshots queued pre-materialization config intents before
+  applying launch defaults. The final authoritative live config settles only
+  those exact records before the session is published: the latest confirmed
+  value reconciles, superseded values become stale, unsupported values become
+  stale, and an applicable unconfirmed latest value fails silently. A newer
+  intent outside the snapshot remains a normal ordered live change.
 - If the projected session has no materialized runtime yet, display labels must
   still use the same label mapping as the final session.
 - Do not mix raw ids and presentation labels. For example, a reasoning setting
@@ -680,13 +691,19 @@ Rules:
   values, so an earlier request's echo can match a later click's value, and
   terminating that click before dispatch silently drops it (PRO-261).
 - A session with no materialized AnyHarness id keeps intents queued.
+- Creation temporarily owns the exact pre-materialization config-intent
+  snapshot it consumes. It applies only each semantic control's latest value
+  through the authoritative raw config id, then settles the captured records
+  in one transaction before materialization or binding can expose them to the
+  dispatcher.
 - A config update may unblock later intents after AnyHarness accepts it as
   `applied` or `queued`; runtime config ordering is authoritative after that.
 - A prompt intent renders immediately, dispatches after materialization, and
   reconciles when a renderable user-message echo appears in the transcript.
-- A config intent projects pending config over live config until the stream or
-  API response reconciles it. Normal queued config must not produce rollback
-  toasts.
+- A later live config intent projects pending config over live config until the
+  stream or API response reconciles it. Creation-owned config intents settle
+  from launch output without a live-change toast. Normal queued config must not
+  produce rollback toasts.
 - Interaction response intents are valid only for interactions the UI has
   already seen. If the request is gone by dispatch time, mark the intent stale
   instead of showing a user-visible failure.
@@ -715,6 +732,13 @@ The dispatcher should mark API acceptance quickly enough to unblock later
 intents when AnyHarness owns subsequent ordering internally. It should not wait
 for unrelated UI hydration, history loading, or shell selection completion once
 the materialized session id exists.
+
+Creation-consumed config intents never enter this loop. Publication settles
+their exact frozen IDs before it materializes or binds the session record.
+Compatible existing-session adoption instead resolves launch-only semantic
+keys against that session's authoritative normalized controls before binding;
+applicable records remain ordered live work and unsupported records become
+stale.
 
 ### Attachment Conversion
 
@@ -886,6 +910,10 @@ Minimum coverage by concern:
   closed UUID cannot be resurrected by a stale ledger entry
 - session intents: prompts/config/interaction responses preserve order, render
   immediately where visible, and dispatch only after materialized session id
+- creation-owned config intents: semantic and harness ids stay distinct,
+  rapid selections preserve order, only the latest applicable value is applied,
+  authoritative settlement precedes publication, and a post-snapshot live
+  change dispatches once
 - queued prompt controls: icons reserve immediately while disabled, then enable
   without remounting when local cancel or runtime seq is available
 - latency stability: no infinite Zustand snapshot loops and no render-heavy

--- a/specs/codebase/systems/product/workspaces/pending-shell.md
+++ b/specs/codebase/systems/product/workspaces/pending-shell.md
@@ -559,10 +559,11 @@ projection path.
   unsupported values become stale, and an applicable unconfirmed latest value
   fails silently. If creation returns no live-config snapshot, authority is not
   yet available: captured intents remain queued and dispatch after binding.
-  Pending-shell inputs retain their raw harness IDs so settlement can resolve a
-  semantic control by raw identity when the producer did not carry that
-  semantic mapping. A newer intent outside the snapshot remains a normal
-  ordered live change.
+  Pending-shell inputs retain their raw harness IDs. Authenticated creation
+  resolves the semantic launch key from the agent catalog before applying
+  defaults, and settlement can still resolve by raw identity against
+  authoritative live config. A newer intent outside the snapshot remains a
+  normal ordered live change.
 - If the projected session has no materialized runtime yet, display labels must
   still use the same label mapping as the final session.
 - Do not mix raw ids and presentation labels. For example, a reasoning setting

--- a/specs/codebase/systems/product/workspaces/pending-shell.md
+++ b/specs/codebase/systems/product/workspaces/pending-shell.md
@@ -552,12 +552,13 @@ projection path.
   state match or it would stay stuck. Optimism is therefore held through intent
   `accepted` (so a real switch never reverts to the not-yet-updated value
   mid-flight) and dropped the moment the authoritative value equals it.
-- Session creation snapshots queued pre-materialization config intents before
-  applying launch defaults. The final authoritative live config settles only
-  those exact records before the session is published: the latest confirmed
-  value reconciles, superseded values become stale, unsupported values become
-  stale, and an applicable unconfirmed latest value fails silently. A newer
-  intent outside the snapshot remains a normal ordered live change.
+- Session creation snapshots queued pre-materialization config-intent
+  generations before applying launch defaults. The final authoritative live
+  config settles only those exact generations before the session is published:
+  the latest confirmed value reconciles, superseded values become stale,
+  unsupported values become stale, and an applicable unconfirmed latest value
+  fails silently. A newer intent outside the snapshot remains a normal ordered
+  live change.
 - If the projected session has no materialized runtime yet, display labels must
   still use the same label mapping as the final session.
 - Do not mix raw ids and presentation labels. For example, a reasoning setting
@@ -692,10 +693,11 @@ Rules:
   terminating that click before dispatch silently drops it (PRO-261).
 - A session with no materialized AnyHarness id keeps intents queued.
 - Creation temporarily owns the exact pre-materialization config-intent
-  snapshot it consumes. It applies only each semantic control's latest value
-  through the authoritative raw config id, then settles the captured records
-  in one transaction before materialization or binding can expose them to the
-  dispatcher.
+  generations it snapshots. It applies only each semantic control's latest
+  value through the authoritative raw config id, then settles the captured
+  generations in one transaction before materialization or binding can expose
+  them to the dispatcher. Tail coalescing may reuse a captured intent id for a
+  newer generation; that newer choice remains queued for live dispatch.
 - A config update may unblock later intents after AnyHarness accepts it as
   `applied` or `queued`; runtime config ordering is authoritative after that.
 - A prompt intent renders immediately, dispatches after materialization, and
@@ -734,7 +736,8 @@ for unrelated UI hydration, history loading, or shell selection completion once
 the materialized session id exists.
 
 Creation-consumed config intents never enter this loop. Publication settles
-their exact frozen IDs before it materializes or binds the session record.
+their exact frozen IDs and generations before it materializes or binds the
+session record.
 Compatible existing-session adoption instead resolves launch-only semantic
 keys against that session's authoritative normalized controls before binding;
 applicable records remain ordered live work and unsupported records become
@@ -912,8 +915,9 @@ Minimum coverage by concern:
   immediately where visible, and dispatch only after materialized session id
 - creation-owned config intents: semantic and harness ids stay distinct,
   rapid selections preserve order, only the latest applicable value is applied,
-  authoritative settlement precedes publication, and a post-snapshot live
-  change dispatches once
+  authoritative settlement precedes publication, and a post-snapshot
+  tail-coalesced generation dispatches once even when its intent id or value
+  matches a captured generation
 - queued prompt controls: icons reserve immediately while disabled, then enable
   without remounting when local cancel or runtime seq is available
 - latency stability: no infinite Zustand snapshot loops and no render-heavy


### PR DESCRIPTION
## Summary

- Keeps product-facing launch control keys separate from harness raw config IDs, so semantic controls dispatch through their authoritative raw IDs.
- Settles only the exact pre-materialization intent generation before session publication. A later coalesced choice remains queued and dispatches once after binding.
- Preserves queued creation and adoption intents when live config is unavailable.
- Resolves pending-shell launch input through authenticated catalog metadata, with authoritative runtime live config as the fallback when catalog loading fails.
- Validates existing-session adoption against authoritative controls, preserves one rollback/toast for a genuine live rejection, and documents the pending-shell ownership contract.

## Testing

- `pnpm shared:typecheck` passed on Node 22.
- Focused config-intent, dispatcher, launch-default, materialization, workspace-entry, and store matrix passed: 11 files, 59 tests.
- `python3 scripts/check_docs.py` passed for 226 Markdown files.
- All exact-head GitHub Actions checks passed, including Cargo, ProductClient, intent, production smoke, transcript scroll physics, frontend builds, CodeQL, repository checks, and candidate handoff.
- The production-faithful WebKit prepend-anchor test also passed locally 3/3 on the rebased head.
- Greptile reviewed exact head `4eb1d015314683dc4cd667cef69d61f9d81df927` at 5/5 with zero unresolved threads.
- Branch is rebased on base `29d1f846a1ed39a5a3e1a77295f4774b1edfcc71`.

## Observability

- No new telemetry or log payloads. Creation/adoption settlement remains silent; existing intent status and the existing error toast remain the signal for a genuine live rejection.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] The support relationship was linked through the tracker API. No tracker, report, user, support, or telemetry identifiers or private source data appear in this PR body.

## Verification

- The production-faithful lifecycle fixture preserves semantic/raw identity, exact queue ordering, applicability, authoritative confirmation, generation-sensitive settlement, and typed runtime rejection while faking only the network boundary.
- Coverage proves asymmetric and aligned control mappings, catalog-failure fallback through authoritative live config, creation ownership before publication, independent multi-session settlement, post-snapshot dispatch, unavailable/unsupported/unconfirmed creation outcomes, authoritative adoption, queued-tail/echo behavior, persistence, cleanup, and one genuine typed rejection consequence.