### PR TITLE
feat(product): redesign the API keys settings page (PRO-132)

### DIFF
--- a/apps/packages/product-client/src/components/settings/panes/agents/api-keys/ApiKeysPane.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/api-keys/ApiKeysPane.test.tsx
@@ -35,8 +35,8 @@ vi.mock("#product/stores/toast/toast-store", () => ({
     selector({ show: showToast }),
 }));
 
-// ConfirmationDialog wraps Radix Dialog (no jsdom polyfills) — stub to plain
-// buttons so the revoke flow is exercisable.
+// ConfirmationDialog and ApiKeyCreatorModal wrap Radix Dialog (no jsdom
+// polyfills) — stub both to plain buttons so their flows are exercisable.
 vi.mock("#product/primitives/patterns/ConfirmationDialog", () => ({
   ConfirmationDialog: ({
     open,
@@ -53,6 +53,32 @@ vi.mock("#product/primitives/patterns/ConfirmationDialog", () => ({
       <div>
         <button type="button" onClick={onConfirm}>{confirmLabel}</button>
         <button type="button" onClick={onClose}>dialog-cancel</button>
+      </div>
+    ) : null,
+}));
+
+vi.mock("#product/components/settings/panes/agent-auth/ApiKeyCreatorModal", () => ({
+  ApiKeyCreatorModal: ({
+    open,
+    heading,
+    onSubmit,
+    onClose,
+  }: {
+    open: boolean;
+    heading: string;
+    onSubmit: (input: { title: string; value: string; envVarName: string }) => void;
+    onClose: () => void;
+  }) =>
+    open ? (
+      <div>
+        <div>{heading}</div>
+        <button
+          type="button"
+          onClick={() => onSubmit({ title: "Personal key", value: "sk-ant-123", envVarName: "" })}
+        >
+          creator-submit
+        </button>
+        <button type="button" onClick={onClose}>creator-cancel</button>
       </div>
     ) : null,
 }));
@@ -95,14 +121,14 @@ describe("ApiKeysPane", () => {
     expect(screen.queryByText("Work key")).not.toBeNull();
     expect(screen.queryByText("sk-...abcd")).not.toBeNull();
     expect(screen.queryByText("Backup")).not.toBeNull();
-    expect(screen.queryByText("2 keys")).not.toBeNull();
   });
 
-  it("labels the empty visual state without changing the existing form focus order", () => {
+  it("shows the empty state with the header Add key action", () => {
     const { container } = render(<ApiKeysPane />);
 
     expect(screen.queryByText(AGENT_API_KEYS_COPY.emptyTitle)).not.toBeNull();
-    expect(screen.queryByRole("button", { name: "Add first key" })).toBeNull();
+    const addButton = screen.getByRole("button", { name: AGENT_API_KEYS_COPY.addAction });
+    expect(addButton.getAttribute("type")).toBe("button");
     expect(container.querySelector('[data-api-keys-state="ready"]')).not.toBeNull();
   });
 
@@ -126,9 +152,7 @@ describe("ApiKeysPane", () => {
     const view = render(<ApiKeysPane />);
 
     const retryButton = screen.getByRole("button", { name: AGENT_API_KEYS_COPY.retryAction });
-    const addButton = screen.getByRole("button", { name: AGENT_API_KEYS_COPY.addAction });
     expect(retryButton.getAttribute("type")).toBe("button");
-    expect(addButton.getAttribute("type")).toBe("submit");
     expect(screen.queryByText(AGENT_API_KEYS_COPY.loadError)).not.toBeNull();
 
     await user.click(retryButton);
@@ -140,7 +164,6 @@ describe("ApiKeysPane", () => {
         name: AGENT_API_KEYS_COPY.retryingAction,
       }) as HTMLButtonElement).disabled,
     ).toBe(true);
-    expect(screen.getByRole("button", { name: AGENT_API_KEYS_COPY.addAction })).toBe(addButton);
 
     state.keys.isError = false;
     state.keys.data = [key()];
@@ -153,7 +176,6 @@ describe("ApiKeysPane", () => {
     expect(screen.queryByText(AGENT_API_KEYS_COPY.loadError)).toBeNull();
     expect(screen.queryByRole("button", { name: AGENT_API_KEYS_COPY.retryAction })).toBeNull();
     expect(screen.queryByText("Work key")).not.toBeNull();
-    expect(screen.getByRole("button", { name: AGENT_API_KEYS_COPY.addAction })).toBe(addButton);
   });
 
   it("keeps failed Retry keyboard-accessible and restores it without duplicate refetch", async () => {
@@ -167,7 +189,7 @@ describe("ApiKeysPane", () => {
     render(<ApiKeysPane />);
 
     const retryButton = screen.getByRole("button", { name: AGENT_API_KEYS_COPY.retryAction });
-    await user.tab();
+    retryButton.focus();
     expect(document.activeElement).toBe(retryButton);
     await user.keyboard("{Enter}");
     await user.keyboard("{Enter}");
@@ -258,21 +280,40 @@ describe("ApiKeysPane", () => {
     expect(refetchKeys).toHaveBeenCalledTimes(1);
   });
 
-  it("creates a key from title + value only", () => {
+  it("creates a key through the Add key modal", () => {
     render(<ApiKeysPane />);
 
-    fireEvent.change(screen.getByLabelText(AGENT_API_KEYS_COPY.titleLabel), {
-      target: { value: "Personal key" },
-    });
-    fireEvent.change(screen.getByLabelText(AGENT_API_KEYS_COPY.valueLabel), {
-      target: { value: "sk-ant-123" },
-    });
+    expect(screen.queryByText(AGENT_API_KEYS_COPY.addModalHeading)).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: AGENT_API_KEYS_COPY.addAction }));
+    expect(screen.queryByText(AGENT_API_KEYS_COPY.addModalHeading)).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "creator-submit" }));
 
     expect(createMutate).toHaveBeenCalledWith(
       { title: "Personal key", value: "sk-ant-123" },
       expect.anything(),
     );
+  });
+
+  it("closes the Add key modal and toasts on success", () => {
+    createMutate.mockImplementation((_input, cbs) => cbs.onSuccess({ title: "Personal key" }));
+    render(<ApiKeysPane />);
+
+    fireEvent.click(screen.getByRole("button", { name: AGENT_API_KEYS_COPY.addAction }));
+    fireEvent.click(screen.getByRole("button", { name: "creator-submit" }));
+
+    expect(screen.queryByText(AGENT_API_KEYS_COPY.addModalHeading)).toBeNull();
+    expect(showToast).toHaveBeenCalledWith("Added API key Personal key.", "info");
+  });
+
+  it("keeps the Add key modal open and toasts on failure", () => {
+    createMutate.mockImplementation((_input, cbs) => cbs.onError(new Error("nope")));
+    render(<ApiKeysPane />);
+
+    fireEvent.click(screen.getByRole("button", { name: AGENT_API_KEYS_COPY.addAction }));
+    fireEvent.click(screen.getByRole("button", { name: "creator-submit" }));
+
+    expect(screen.queryByText(AGENT_API_KEYS_COPY.addModalHeading)).not.toBeNull();
+    expect(showToast).toHaveBeenCalledWith("nope");
   });
 
   it("revokes a key after confirmation", () => {

--- a/apps/packages/product-client/src/components/settings/panes/agents/api-keys/ApiKeysPane.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/api-keys/ApiKeysPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type FormEvent } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { AgentApiKey } from "@proliferate/cloud-sdk";
 import { ProliferateClientError } from "@proliferate/cloud-sdk";
 import {
@@ -6,15 +6,15 @@ import {
   useCreateAgentApiKey,
   useRevokeAgentApiKey,
 } from "@proliferate/cloud-sdk-react";
+import { Plus } from "#product/primitives/icons/core";
 import { Button } from "#product/primitives/Button";
-import { Badge } from "#product/primitives/Badge";
 import { ConfirmationDialog } from "#product/primitives/patterns/ConfirmationDialog";
-import { Input } from "#product/primitives/Input";
-import { Label } from "#product/primitives/Label";
 import { PageHeader } from "#product/primitives/patterns/PageHeader";
+import { SettingsEmptyState } from "#product/primitives/patterns/settings/SettingsEmptyState";
 import { SettingsPageBody } from "#product/primitives/patterns/settings/SettingsPageBody";
 import { SettingsRow } from "#product/primitives/patterns/settings/SettingsRow";
 import { SettingsSection } from "#product/primitives/patterns/settings/SettingsSection";
+import { ApiKeyCreatorModal, type ApiKeyCreatorSubmit } from "#product/components/settings/panes/agent-auth/ApiKeyCreatorModal";
 import { AGENT_API_KEYS_COPY } from "#product/copy/settings/agent-api-keys-copy";
 import { useCloudAvailabilityState } from "#product/hooks/cloud/derived/use-cloud-availability-state";
 import { useToastStore } from "#product/stores/toast/toast-store";
@@ -32,6 +32,11 @@ function revokeConflictHarnesses(error: unknown): string[] | null {
   return null;
 }
 
+function formatCreatedAt(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleDateString();
+}
+
 export function ApiKeysPane() {
   const { cloudActive, authStatus, cloudComputeEnabled } = useCloudAvailabilityState();
   const showToast = useToastStore((state) => state.show);
@@ -40,8 +45,7 @@ export function ApiKeysPane() {
   const createKey = useCreateAgentApiKey();
   const revokeKey = useRevokeAgentApiKey();
 
-  const [title, setTitle] = useState("");
-  const [value, setValue] = useState("");
+  const [addOpen, setAddOpen] = useState(false);
   const [pendingRevoke, setPendingRevoke] = useState<AgentApiKey | null>(null);
   const [isRetrying, setIsRetrying] = useState(false);
   const retryInFlight = useRef(false);
@@ -58,20 +62,13 @@ export function ApiKeysPane() {
   }, []);
 
   const keys = keysQuery.data ?? [];
-  const canSubmit =
-    title.trim().length > 0 && value.trim().length > 0 && !createKey.isPending;
 
-  function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    if (!canSubmit) {
-      return;
-    }
+  function handleCreate(input: ApiKeyCreatorSubmit) {
     createKey.mutate(
-      { title: title.trim(), value: value.trim() },
+      { title: input.title, value: input.value },
       {
         onSuccess: (created) => {
-          setTitle("");
-          setValue("");
+          setAddOpen(false);
           showToast(`Added API key ${created.title}.`, "info");
         },
         onError: (error) => {
@@ -130,9 +127,7 @@ export function ApiKeysPane() {
     // Truthful cause: a signed-in user on a compute-unconfigured deployment
     // gets the operator explanation, not a "sign in" prompt they can't act on
     // (PR2-GATING-01 class). Anonymous users still get the sign-in prompt.
-    const description = authStatus === "authenticated" && !cloudComputeEnabled
-      ? AGENT_API_KEYS_COPY.cloudNotConfigured
-      : AGENT_API_KEYS_COPY.signInRequired;
+    const operatorGated = authStatus === "authenticated" && !cloudComputeEnabled;
     return (
       <SettingsPageBody data-api-keys-pane="" data-api-keys-state="gated">
         <PageHeader
@@ -140,12 +135,15 @@ export function ApiKeysPane() {
           title={AGENT_API_KEYS_COPY.title}
           description={AGENT_API_KEYS_COPY.description}
         />
-        <SettingsSection>
-          <SettingsRow
-            label={AGENT_API_KEYS_COPY.title}
-            description={description}
-          />
-        </SettingsSection>
+        <SettingsEmptyState
+          size="compact"
+          title={operatorGated
+            ? AGENT_API_KEYS_COPY.cloudNotConfiguredTitle
+            : AGENT_API_KEYS_COPY.signInRequiredTitle}
+          description={operatorGated
+            ? AGENT_API_KEYS_COPY.cloudNotConfigured
+            : AGENT_API_KEYS_COPY.signInRequired}
+        />
       </SettingsPageBody>
     );
   }
@@ -162,29 +160,30 @@ export function ApiKeysPane() {
         variant="flat"
         title={AGENT_API_KEYS_COPY.title}
         description={AGENT_API_KEYS_COPY.description}
+        action={
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="gap-1.5"
+            onClick={() => setAddOpen(true)}
+          >
+            <Plus className="icon-paired" />
+            {AGENT_API_KEYS_COPY.addAction}
+          </Button>
+        }
       />
 
-      <SettingsSection
-        title={AGENT_API_KEYS_COPY.keysSection}
-        action={keysQuery.isLoading || keysQuery.isError ? null : (
-          <Badge tone={keys.length > 0 ? "success" : "neutral"}>
-            {keys.length} {keys.length === 1 ? "key" : "keys"}
-          </Badge>
-        )}
-      >
-        {keysQuery.isLoading ? (
-          <SettingsRow
-            label={AGENT_API_KEYS_COPY.keysSection}
-            description={AGENT_API_KEYS_COPY.loading}
-          />
-        ) : keysQuery.isError ? (
-          <SettingsRow
-            label={AGENT_API_KEYS_COPY.keysSection}
-            description={AGENT_API_KEYS_COPY.loadError}
-          >
+      {keysQuery.isLoading ? (
+        <div className="text-ui-sm text-muted-foreground">{AGENT_API_KEYS_COPY.loading}</div>
+      ) : keysQuery.isError ? (
+        <SettingsEmptyState
+          size="compact"
+          title={AGENT_API_KEYS_COPY.loadError}
+          action={
             <Button
               type="button"
-              variant="outline"
+              variant="secondary"
               size="sm"
               loading={isRetrying}
               onClick={handleRetry}
@@ -193,14 +192,17 @@ export function ApiKeysPane() {
                 ? AGENT_API_KEYS_COPY.retryingAction
                 : AGENT_API_KEYS_COPY.retryAction}
             </Button>
-          </SettingsRow>
-        ) : keys.length === 0 ? (
-          <SettingsRow
-            label={AGENT_API_KEYS_COPY.emptyTitle}
-            description={AGENT_API_KEYS_COPY.emptyDescription}
-          />
-        ) : (
-          keys.map((key) => (
+          }
+        />
+      ) : keys.length === 0 ? (
+        <SettingsEmptyState
+          size="compact"
+          title={AGENT_API_KEYS_COPY.emptyTitle}
+          description={AGENT_API_KEYS_COPY.emptyDescription}
+        />
+      ) : (
+        <SettingsSection title={AGENT_API_KEYS_COPY.keysSection}>
+          {keys.map((key) => (
             <SettingsRow
               key={key.id}
               label={
@@ -211,6 +213,7 @@ export function ApiKeysPane() {
                   </span>
                 </span>
               }
+              description={AGENT_API_KEYS_COPY.createdDetail(formatCreatedAt(key.createdAt))}
             >
               <Button
                 type="button"
@@ -221,50 +224,21 @@ export function ApiKeysPane() {
                 {AGENT_API_KEYS_COPY.revokeAction}
               </Button>
             </SettingsRow>
-          ))
-        )}
-      </SettingsSection>
+          ))}
+        </SettingsSection>
+      )}
 
-      <SettingsSection
-        title={AGENT_API_KEYS_COPY.addSection}
-        description={AGENT_API_KEYS_COPY.addSectionDescription}
-      >
-        <form
-          className="flex flex-col gap-2 p-3.5 sm:flex-row"
-          onSubmit={handleSubmit}
-        >
-          <div className="sm:flex-1">
-            <Label htmlFor="agent-api-key-title" className="sr-only">
-              {AGENT_API_KEYS_COPY.titleLabel}
-            </Label>
-            <Input
-              id="agent-api-key-title"
-              aria-label={AGENT_API_KEYS_COPY.titleLabel}
-              placeholder={AGENT_API_KEYS_COPY.titlePlaceholder}
-              value={title}
-              onChange={(event) => setTitle(event.target.value)}
-            />
-          </div>
-          <Input
-            aria-label={AGENT_API_KEYS_COPY.valueLabel}
-            placeholder={AGENT_API_KEYS_COPY.valuePlaceholder}
-            type="password"
-            autoComplete="off"
-            value={value}
-            onChange={(event) => setValue(event.target.value)}
-            className="sm:flex-1"
-          />
-          <Button
-            type="submit"
-            variant="primary"
-            size="md"
-            disabled={!canSubmit}
-            loading={createKey.isPending}
-          >
-            {AGENT_API_KEYS_COPY.addAction}
-          </Button>
-        </form>
-      </SettingsSection>
+      <ApiKeyCreatorModal
+        open={addOpen}
+        onClose={() => setAddOpen(false)}
+        heading={AGENT_API_KEYS_COPY.addModalHeading}
+        description={AGENT_API_KEYS_COPY.addModalDescription}
+        showTitleField
+        submitLabel={AGENT_API_KEYS_COPY.addAction}
+        submitting={createKey.isPending}
+        error={null}
+        onSubmit={handleCreate}
+      />
 
       <ConfirmationDialog
         open={pendingRevoke !== null}

--- a/apps/packages/product-client/src/copy/settings/agent-api-keys-copy.ts
+++ b/apps/packages/product-client/src/copy/settings/agent-api-keys-copy.ts
@@ -8,20 +8,19 @@ export const AGENT_API_KEYS_COPY = {
   retryAction: "Retry",
   retryingAction: "Retrying…",
   emptyTitle: "No API keys yet",
-  emptyDescription: "Add a key below to wire it into a harness later.",
+  emptyDescription: "Add a key to wire it into a harness later.",
+  signInRequiredTitle: "Sign in required",
   signInRequired: "Sign in to Proliferate Cloud to manage your API key vault.",
+  cloudNotConfiguredTitle: "Cloud is not configured",
   // Signed in, but the operator has not configured cloud compute — never a
   // sign-in prompt to someone already signed in (PR2-GATING-01 class).
   cloudNotConfigured:
     "Cloud is not configured on this deployment. An operator must finish configuring it before the API key vault is available.",
-  addSection: "Add key",
-  addSectionDescription:
-    "The value is stored encrypted and never displayed again after saving.",
-  titleLabel: "Title",
-  titlePlaceholder: "Personal Anthropic API key",
-  valueLabel: "Value",
-  valuePlaceholder: "sk-...",
   addAction: "Add key",
+  addModalHeading: "Add API key",
+  addModalDescription:
+    "Save a provider secret to wire into a harness from its Authentication tab.",
+  createdDetail: (date: string) => `Added ${date}`,
   addError: "Could not add the API key.",
   revokeAction: "Revoke",
   revokeTitle: "Revoke API key",

--- a/apps/packages/product-client/src/primitives/__tests__/ModalShell.test.tsx
+++ b/apps/packages/product-client/src/primitives/__tests__/ModalShell.test.tsx
@@ -2,6 +2,7 @@
 
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { ConfirmationDialog } from "#product/primitives/patterns/ConfirmationDialog";
 import { ModalShell } from "#product/primitives/patterns/ModalShell";
 import { useNativeOverlayOpen } from "#product/primitives/overlays/overlay-presence";
 
@@ -63,5 +64,26 @@ describe("ModalShell", () => {
     );
 
     expect(screen.queryByRole("button", { name: "Close" })).toBeNull();
+  });
+});
+
+describe("ConfirmationDialog", () => {
+  it("focuses the confirm action on open so Enter confirms", async () => {
+    render(
+      <ConfirmationDialog
+        open
+        title="Revoke API key"
+        description="Revoke this?"
+        confirmLabel="Revoke key"
+        confirmVariant="destructive"
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    const confirm = screen.getByRole("button", { name: "Revoke key" });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(confirm);
+    });
   });
 });

--- a/apps/packages/product-client/src/primitives/patterns/ConfirmationDialog.tsx
+++ b/apps/packages/product-client/src/primitives/patterns/ConfirmationDialog.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { Button } from "#product/primitives/Button";
 import { ModalShell } from "./ModalShell";
 
@@ -26,11 +27,16 @@ export function ConfirmationDialog({
   onClose,
   onConfirm,
 }: ConfirmationDialogProps) {
+  // The confirm action is the dialog's default button: it takes initial focus,
+  // so Enter confirms on open while Tab → Enter still reaches Cancel.
+  const confirmRef = useRef<HTMLButtonElement>(null);
+
   return (
     <ModalShell
       open={open}
       onClose={onClose}
       disableClose={disableClose}
+      initialFocusRef={confirmRef}
       title={title}
       description={description}
       headerContent={(
@@ -62,6 +68,7 @@ export function ConfirmationDialog({
             {cancelLabel}
           </Button>
           <Button
+            ref={confirmRef}
             type="button"
             variant={confirmVariant}
             size="md"

--- a/apps/packages/product-client/src/primitives/patterns/ModalShell.tsx
+++ b/apps/packages/product-client/src/primitives/patterns/ModalShell.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react";
+import { type ReactNode, type RefObject } from "react";
 import {
   Dialog,
   DialogClose,
@@ -27,6 +27,12 @@ export interface ModalShellProps {
   panelClassName?: string;
   showCloseButton?: boolean;
   telemetryBlocked?: boolean;
+  /**
+   * Element to focus when the dialog opens, instead of Radix's default (the
+   * first tabbable element). Lets a dialog nominate its default action so
+   * Enter activates it on open.
+   */
+  initialFocusRef?: RefObject<HTMLElement | null>;
 }
 
 // NOTE: ModalShell is modal (Radix Dialog): it traps focus and disables
@@ -50,6 +56,7 @@ export function ModalShell({
   panelClassName = "border-border bg-background shadow-modal",
   showCloseButton = true,
   telemetryBlocked = false,
+  initialFocusRef,
 }: ModalShellProps) {
   useNativeOverlayRegistration(open);
 
@@ -67,6 +74,12 @@ export function ModalShell({
         showCloseButton={false}
         data-telemetry-block={telemetryBlocked ? true : undefined}
         {...(description ? {} : { "aria-describedby": undefined })}
+        onOpenAutoFocus={initialFocusRef
+          ? (event) => {
+              event.preventDefault();
+              initialFocusRef.current?.focus();
+            }
+          : undefined}
         onEscapeKeyDown={(event) => {
           // Always shield desktop-global Escape handlers (parity with the old
           // hand-rolled shell, which preventDefault'ed every Escape while open).


### PR DESCRIPTION
## Summary

- Brings the agents **API keys** settings pane (PRO-132, first "Big redesign" child of the PRO-191 settings visual system) onto the canonical settings anatomy used by the sibling secrets panes:
  - The **Add key** action moves into the flat `PageHeader` action slot and creates keys through the shared `ApiKeyCreatorModal` instead of an inline three-field form.
  - Gated (signed out / cloud not configured), load-error, and empty states render as `SettingsEmptyState`; loading matches the integrations pane's quiet line.
  - Key rows keep the mono redacted hint and gain an "Added <date>" meta line; the floating key-count badge is dropped.
- `ConfirmationDialog` now nominates its confirm action as the dialog's **default button** — it takes initial focus through a new `ModalShell` `initialFocusRef` slot, so Return confirms (e.g. Revoke key) while Tab → Return still reaches Cancel and Escape still closes.

## Testing

- Unit (vitest, jsdom): rewrote `ApiKeysPane.test.tsx` for the modal-based anatomy (13 tests: list/empty/loading/error states, retry idempotence, modal create success/failure, revoke + 409 conflict) and added a `ConfirmationDialog` initial-focus test in `ModalShell.test.tsx`. Full settings directory green: 29 files / 222 tests via `pnpm vitest run src/components/settings src/copy`.
- Design gates: `check_appearance_scaling.py`, `check_component_library.py`, `check_frontend_boundaries.py` all pass; `pnpm exec tsc` clean.
- Manual: exercised in a local dev profile (single-org password auth) — sign-in gate, empty state, Add key modal, list rows, Return-to-revoke, and revoke confirmation all verified in the desktop app.

## Observability

- none

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Verification

- `cd apps/packages/product-client && pnpm vitest run src/components/settings src/copy src/primitives/__tests__/ModalShell.test.tsx`
- `cd apps/packages/product-client && pnpm exec tsc -p tsconfig.json --noEmit`
- `python3 scripts/check_appearance_scaling.py && python3 scripts/check_component_library.py && python3 scripts/check_frontend_boundaries.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)