### PR TITLE
fix(test): PRO-104 control-row count floor is 7 post-cull

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInputControlRow.layout.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInputControlRow.layout.test.tsx
@@ -186,10 +186,11 @@ describe("composer control row layout at the right-rail clamp floor", () => {
       });
 
       // Every control rendered: model, mode, reasoning, fast mode, goal,
-      // integrations, attach, workspace status, send. A sparse row would
-      // make the no-overlap assertions vacuous.
+      // integrations, attach, workspace status, send (the cloud control left
+      // with the PRO-10 cull). A sparse row would make the no-overlap
+      // assertions vacuous.
       for (const pane of PANES) {
-        expect(result[pane.id]?.buttonCount, pane.id).toBeGreaterThanOrEqual(8);
+        expect(result[pane.id]?.buttonCount, pane.id).toBeGreaterThanOrEqual(7);
       }
 
       expect(result["floor-icon-mode"].overlaps).toEqual([]);


### PR DESCRIPTION
One-line CI unbreak: #1816's anti-vacuity floor pinned >=8 composer controls; the PRO-10 cull (merged today) removed the cloud control, so floor-icon-mode renders 7. Lowers the guard to 7 and notes why. Unblocks the release train (main CI red on 89349486c only from this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)