### PR TITLE
fix(desktop): split renderer diagnostics loss reasons by native ingest classification

### DIFF
--- a/apps/desktop/src-tauri/src/commands/diagnostics.rs
+++ b/apps/desktop/src-tauri/src/commands/diagnostics.rs
@@ -281,6 +281,37 @@ fn expand_home_path(path: &str) -> Result<PathBuf, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::diagnostics_collector::supervisor::SupervisorUnavailable;
+
+    #[test]
+    fn renderer_ingest_errors_carry_a_stable_string_per_unavailable_variant() {
+        // The renderer loss classifier parses these strings verbatim
+        // (renderer-diagnostics-native-error.ts); changing one silently
+        // demotes that loss reason to `invoke_failure`.
+        let cases = [
+            (SupervisorUnavailable::Starting, "renderer_ingest_collector_starting"),
+            (
+                SupervisorUnavailable::Unsupported,
+                "renderer_ingest_collector_unsupported",
+            ),
+            (SupervisorUnavailable::Degraded, "renderer_ingest_collector_degraded"),
+            (SupervisorUnavailable::Stopped, "renderer_ingest_collector_stopped"),
+            (SupervisorUnavailable::Replaced, "renderer_ingest_collector_replaced"),
+            (
+                SupervisorUnavailable::ShuttingDown,
+                "renderer_ingest_broker_shutting_down",
+            ),
+            (
+                SupervisorUnavailable::CollectorRejected,
+                "renderer_ingest_collector_rejected",
+            ),
+            (SupervisorUnavailable::Deadline, "renderer_ingest_deadline_exceeded"),
+            (SupervisorUnavailable::Protocol, "renderer_ingest_protocol_error"),
+        ];
+        for (error, expected) in cases {
+            assert_eq!(format!("renderer_ingest_{}", error.classification()), expected);
+        }
+    }
 
     #[test]
     fn renderer_ingest_is_main_window_only_with_a_stable_error() {

--- a/apps/desktop/src/lib/infra/diagnostics/renderer-diagnostics-batcher-limits.ts
+++ b/apps/desktop/src/lib/infra/diagnostics/renderer-diagnostics-batcher-limits.ts
@@ -25,6 +25,21 @@ export const LOSS_REASONS = [
   "invalid_receipt",
   "collector_rejection",
   "acknowledgement_timeout",
+  // Whole-batch invoke rejections, named after the native
+  // `renderer_ingest_*` classification suffixes so bursts can be attributed
+  // to a supervisor state instead of collapsing into `invoke_failure`.
+  // `collector_rejected` is the batch-level twin of the per-record
+  // `collector_rejection` above.
+  "wrong_window",
+  "invalid_batch",
+  "collector_starting",
+  "collector_unsupported",
+  "collector_degraded",
+  "collector_stopped",
+  "collector_replaced",
+  "broker_shutting_down",
+  "collector_rejected",
+  "deadline_exceeded",
 ] as const;
 
 export const SEVERITIES = ["trace", "debug", "info", "warn", "error"] as const;

--- a/apps/desktop/src/lib/infra/diagnostics/renderer-diagnostics-batcher.test.ts
+++ b/apps/desktop/src/lib/infra/diagnostics/renderer-diagnostics-batcher.test.ts
@@ -315,7 +315,7 @@ describe("renderer diagnostics batcher", () => {
     expect(snapshots).toHaveLength(2);
     expect(snapshots[1]).toMatchObject({
       total: 3,
-      byReason: { invalid_input: 1, invoke_failure: 2 },
+      byReason: { invalid_input: 1, collector_stopped: 2 },
     });
   });
 

--- a/apps/desktop/src/lib/infra/diagnostics/renderer-diagnostics-batcher.ts
+++ b/apps/desktop/src/lib/infra/diagnostics/renderer-diagnostics-batcher.ts
@@ -23,7 +23,7 @@ import {
   settleAcknowledgement,
 } from "./renderer-diagnostics-batcher-waiters";
 import { RendererLossLedger } from "./renderer-diagnostics-loss-ledger";
-import { isRendererIngestProtocolError } from "./renderer-diagnostics-native-error";
+import { classifyRendererIngestError } from "./renderer-diagnostics-native-error";
 import type { QueuedRecord } from "./renderer-diagnostics-queue";
 import { RendererRecordQueue } from "./renderer-diagnostics-queue";
 
@@ -251,12 +251,7 @@ export class RendererDiagnosticsBatcher {
       })
       .catch((error: unknown) => {
         this.records.releaseDetached(detached);
-        this.handleInvokeFailure(
-          detached,
-          isRendererIngestProtocolError(error)
-            ? "invalid_receipt"
-            : "invoke_failure",
-        );
+        this.handleInvokeFailure(detached, classifyRendererIngestError(error));
       })
       .finally(() => {
         this.records.releaseDetached(detached);
@@ -300,7 +295,7 @@ export class RendererDiagnosticsBatcher {
 
   private handleInvokeFailure(
     detached: QueuedRecord[],
-    reason: "invoke_failure" | "invalid_receipt",
+    reason: RendererLossReason,
   ): void {
     for (const entry of detached) {
       this.noteLoss(reason, entry.record.severity);

--- a/apps/desktop/src/lib/infra/diagnostics/renderer-diagnostics-native-error.ts
+++ b/apps/desktop/src/lib/infra/diagnostics/renderer-diagnostics-native-error.ts
@@ -1,16 +1,47 @@
-export function isRendererIngestProtocolError(error: unknown): boolean {
-  if (error === "renderer_ingest_protocol_error") {
-    return true;
+// Maps the stable `renderer_ingest_*` rejection strings produced by the
+// native `ingest_renderer_diagnostics` command onto the renderer loss
+// vocabulary. Unknown rejections stay `invoke_failure` so an older or newer
+// native side never breaks loss accounting.
+
+import type { RendererLossReason } from "./renderer-diagnostics-batcher-limits";
+
+const INGEST_ERROR_REASONS = new Map<string, RendererLossReason>([
+  ["renderer_ingest_protocol_error", "invalid_receipt"],
+  ["renderer_ingest_wrong_window", "wrong_window"],
+  ["renderer_ingest_invalid_batch", "invalid_batch"],
+  ["renderer_ingest_collector_starting", "collector_starting"],
+  ["renderer_ingest_collector_unsupported", "collector_unsupported"],
+  ["renderer_ingest_collector_degraded", "collector_degraded"],
+  ["renderer_ingest_collector_stopped", "collector_stopped"],
+  ["renderer_ingest_collector_replaced", "collector_replaced"],
+  ["renderer_ingest_broker_shutting_down", "broker_shutting_down"],
+  ["renderer_ingest_collector_rejected", "collector_rejected"],
+  ["renderer_ingest_deadline_exceeded", "deadline_exceeded"],
+]);
+
+export function classifyRendererIngestError(error: unknown): RendererLossReason {
+  const message = rendererIngestErrorMessage(error);
+  if (message === null) {
+    return "invoke_failure";
+  }
+  return INGEST_ERROR_REASONS.get(message) ?? "invoke_failure";
+}
+
+function rendererIngestErrorMessage(error: unknown): string | null {
+  if (typeof error === "string") {
+    return error;
   }
   if (typeof error !== "object" || error === null) {
-    return false;
+    return null;
   }
   try {
     const descriptor = Object.getOwnPropertyDescriptor(error, "message");
     return descriptor !== undefined
       && "value" in descriptor
-      && descriptor.value === "renderer_ingest_protocol_error";
+      && typeof descriptor.value === "string"
+      ? descriptor.value
+      : null;
   } catch {
-    return false;
+    return null;
   }
 }

--- a/apps/desktop/src/lib/infra/diagnostics/renderer-diagnostics-native-errors.test.ts
+++ b/apps/desktop/src/lib/infra/diagnostics/renderer-diagnostics-native-errors.test.ts
@@ -2,31 +2,38 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { IngestBatchV1 } from "@proliferate/product-client/internal/domain/diagnostics/contract";
 import { RendererDiagnosticsBatcher } from "./renderer-diagnostics-batcher";
+import { LOSS_REASONS } from "./renderer-diagnostics-batcher-limits";
 import {
   rendererDiagnosticTestRecord as record,
 } from "./renderer-diagnostics-batcher-test-support";
 
 const NATIVE_RESULTS = [
-  "renderer_ingest_wrong_window",
-  "renderer_ingest_invalid_batch",
-  "renderer_ingest_collector_starting",
-  "renderer_ingest_collector_unsupported",
-  "renderer_ingest_collector_degraded",
-  "renderer_ingest_collector_stopped",
-  "renderer_ingest_collector_replaced",
-  "renderer_ingest_broker_shutting_down",
-  "renderer_ingest_collector_rejected",
-  "renderer_ingest_deadline_exceeded",
-  "renderer_ingest_protocol_error",
+  ["renderer_ingest_wrong_window", "wrong_window"],
+  ["renderer_ingest_invalid_batch", "invalid_batch"],
+  ["renderer_ingest_collector_starting", "collector_starting"],
+  ["renderer_ingest_collector_unsupported", "collector_unsupported"],
+  ["renderer_ingest_collector_degraded", "collector_degraded"],
+  ["renderer_ingest_collector_stopped", "collector_stopped"],
+  ["renderer_ingest_collector_replaced", "collector_replaced"],
+  ["renderer_ingest_broker_shutting_down", "broker_shutting_down"],
+  ["renderer_ingest_collector_rejected", "collector_rejected"],
+  ["renderer_ingest_deadline_exceeded", "deadline_exceeded"],
+  ["renderer_ingest_protocol_error", "invalid_receipt"],
+] as const;
+
+const UNKNOWN_RESULTS = [
+  "renderer_ingest_from_the_future",
+  "connection reset",
+  "",
 ] as const;
 
 describe("renderer diagnostics native result handling", () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
-  it.each(NATIVE_RESULTS)("handles %s once without retry", async (nativeResult) => {
+  function harness(rejection: unknown) {
     const invoke = vi.fn(async (_batch: IngestBatchV1) => {
-      throw nativeResult;
+      throw rejection;
     });
     const snapshots: Array<{
       byReason: Readonly<Record<string, number>>;
@@ -41,6 +48,11 @@ describe("renderer diagnostics native result handling", () => {
       setTimeout: (callback, delay) => setTimeout(callback, delay),
       clearTimeout: (handle) => clearTimeout(handle),
     });
+    return { invoke, snapshots, queue };
+  }
+
+  it.each(NATIVE_RESULTS)("counts %s as %s once without retry", async (nativeResult, reason) => {
+    const { invoke, snapshots, queue } = harness(nativeResult);
 
     queue.emit(record(1, "warn"), 100);
     await vi.runAllTimersAsync();
@@ -48,11 +60,45 @@ describe("renderer diagnostics native result handling", () => {
 
     expect(invoke).toHaveBeenCalledTimes(1);
     expect(snapshots).toHaveLength(1);
-    const expectedReason = nativeResult === "renderer_ingest_protocol_error"
-      ? "invalid_receipt"
-      : "invoke_failure";
-    expect(snapshots[0].byReason[expectedReason]).toBe(1);
+    expect(snapshots[0].byReason[reason]).toBe(1);
+    expect(snapshots[0].byReason.invoke_failure).toBe(0);
     expect(queue.getPendingStateForTest().lossTotal).toBe(1);
+    vi.clearAllTimers();
+  });
+
+  it.each(NATIVE_RESULTS)("classifies %s carried on an Error message", async (nativeResult, reason) => {
+    const { snapshots, queue } = harness(new Error(nativeResult));
+
+    queue.emit(record(1, "warn"), 100);
+    await vi.runAllTimersAsync();
+    queue.emit(record(2, "warn"), 100);
+
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0].byReason[reason]).toBe(1);
+    vi.clearAllTimers();
+  });
+
+  it.each(UNKNOWN_RESULTS)("counts unknown rejection %j as invoke_failure", async (nativeResult) => {
+    const { snapshots, queue } = harness(nativeResult);
+
+    queue.emit(record(1, "warn"), 100);
+    await vi.runAllTimersAsync();
+    queue.emit(record(2, "warn"), 100);
+
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0].byReason.invoke_failure).toBe(1);
+    vi.clearAllTimers();
+  });
+
+  it("reports the full loss vocabulary, including ingest reasons, in every snapshot", async () => {
+    const { snapshots, queue } = harness("renderer_ingest_collector_stopped");
+
+    queue.emit(record(1, "warn"), 100);
+    await vi.runAllTimersAsync();
+    queue.emit(record(2, "warn"), 100);
+
+    expect(snapshots).toHaveLength(1);
+    expect(Object.keys(snapshots[0].byReason).sort()).toEqual([...LOSS_REASONS].sort());
     vi.clearAllTimers();
   });
 });


### PR DESCRIPTION
## Summary

Slice 4 of the diagnostics-pipeline hardening program (frozen spec: diagnostics-hardening-spec, section "Slice 4").

The renderer diagnostics batcher collapsed every non-protocol `ingest_renderer_diagnostics` invoke rejection to the single loss reason `invoke_failure`, even though the native command already emits a distinct stable string per `SupervisorUnavailable` variant (`renderer_ingest_collector_stopped`, `..._degraded`, `..._deadline_exceeded`, …). Result: all-day `invoke_failure` bursts in the loss ledger that could not be attributed to a supervisor state.

- **Renderer**: `LOSS_REASONS` gains one reason per native `renderer_ingest_*` classification suffix (`wrong_window`, `invalid_batch`, `collector_starting/_unsupported/_degraded/_stopped/_replaced`, `broker_shutting_down`, `collector_rejected` (batch-level twin of the per-record `collector_rejection`), `deadline_exceeded`). `renderer-diagnostics-native-error.ts` is now a classifier (`classifyRendererIngestError`) mapping rejection strings (raw string or `Error#message`) to loss reasons; unknown strings still fall back to `invoke_failure`. `renderer_ingest_protocol_error → invalid_receipt` is unchanged.
- **Native**: the command already carried the classification (`format!("renderer_ingest_{}", error.classification())`), so the native change reduces to a unit test freezing the full string per `SupervisorUnavailable` variant, since the renderer now parses them verbatim.

Wire-freeze: per the frozen spec, `LOSS_REASONS` is renderer-local and `by_reason` ships as a free-form operational map — extending it is safe; Honeycomb just sees new keys.

## Tests

- `apps/desktop`: `pnpm vitest run src/lib/infra/diagnostics` — 11 files, 100 tests passed. New/updated: per-native-string → reason mapping (string and `Error` shapes), unknown-string → `invoke_failure` fallback, loss snapshot `byReason` contains the full extended vocabulary.
- Negative control: with the batcher's classifier call reverted to the old `"invoke_failure"` collapse, `renderer-diagnostics-native-errors.test.ts` fails 22/26.
- Native: `cargo test -p proliferate renderer_ingest` covering the frozen per-variant error strings (run serialized per machine limits; result quoted in PR discussion).

## Spec deviation (raised, not rescoped)

The spec proposed introducing a new native prefix scheme (`renderer_ingest_unavailable_stopped`, …), but `main` already ships distinct per-variant strings under the `renderer_ingest_<classification>` scheme (`renderer_ingest_collector_stopped`, …). I kept the existing shipped strings untouched and matched the renderer vocabulary to them instead of renaming the wire strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)