### PR TITLE
fix(diagnostics): collector death certificates + loud delivery-end warning (slice 3)

### DIFF
--- a/anyharness/crates/proliferate-diagnostics-client/src/producer/delivery_log.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/producer/delivery_log.rs
@@ -1,0 +1,107 @@
+//! Collector-generation availability transitions and their loud logging. The
+//! 2026-08-15 outage counted loss for 10.5h without one line in the runtime's
+//! own log; every latch into `Unavailable` now says so out loud, and every
+//! re-attach answers it.
+
+use super::AdmissionState;
+#[cfg(unix)]
+use super::{CollectorAvailability, ProducerInner};
+#[cfg(unix)]
+use crate::fallback::FallbackReason;
+#[cfg(unix)]
+use std::sync::Arc;
+
+#[cfg(unix)]
+impl ProducerInner {
+    pub(crate) fn replace_generation(
+        &self,
+        generation: crate::bridge::activation::CollectorGenerationHandle,
+    ) {
+        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+        let current = match &state.collector {
+            CollectorAvailability::Ready(current)
+            | CollectorAvailability::Cooldown {
+                generation: current,
+                ..
+            } => current.generation,
+            CollectorAvailability::Unavailable { generation } => *generation,
+        };
+        if generation.generation <= current {
+            return;
+        }
+        for record in &mut state.queue {
+            record.fallback_reason = Some(FallbackReason::GenerationChanged);
+        }
+        if !state.in_flight.is_empty() {
+            state.delivery_fence_eligible = false;
+        }
+        let generation_number = generation.generation;
+        state.collector = CollectorAvailability::Ready(Arc::new(generation));
+        drop(state);
+        info_delivery_reattached(generation_number);
+        self.notify.notify_one();
+    }
+
+    pub(crate) fn mark_generation_unavailable(&self, generation: u64) {
+        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+        let current = match &state.collector {
+            CollectorAvailability::Ready(current)
+            | CollectorAvailability::Cooldown {
+                generation: current,
+                ..
+            } => current.generation,
+            CollectorAvailability::Unavailable { generation } => *generation,
+        };
+        if generation <= current {
+            return;
+        }
+        for record in &mut state.queue {
+            record.fallback_reason = Some(FallbackReason::GenerationChanged);
+        }
+        state.collector = CollectorAvailability::Unavailable { generation };
+        if !state.in_flight.is_empty() {
+            state.delivery_fence_eligible = false;
+        }
+        let warn = state.note_delivery_ended(generation);
+        drop(state);
+        if warn {
+            warn_delivery_ended(generation);
+        }
+        self.notify.notify_one();
+    }
+}
+
+impl AdmissionState {
+    /// One-shot per generation: several sites can observe the same dead
+    /// generation (a bridge notice, a boot-mismatched receipt, retries), but
+    /// the loud delivery-end warning fires once.
+    pub(crate) fn note_delivery_ended(&mut self, generation: u64) -> bool {
+        if self.delivery_end_warned_generation == Some(generation) {
+            return false;
+        }
+        self.delivery_end_warned_generation = Some(generation);
+        true
+    }
+}
+
+/// WARN is re-ingested by the tracing layer, which is acceptable: the caller
+/// guards with `note_delivery_ended` and the pipe being described is already
+/// dead. Callers emit outside the admission-state lock.
+pub(crate) fn warn_delivery_ended(generation: u64) {
+    tracing::warn!(
+        target: "anyharness.diagnostics.delivery",
+        generation,
+        "diagnostics delivery ended: collector generation gone; records count as loss until re-attach"
+    );
+}
+
+/// The canonical re-attach line answering `warn_delivery_ended`; call sites
+/// must not log their own copy.
+#[cfg(unix)]
+pub(crate) fn info_delivery_reattached(generation: u64) {
+    tracing::info!(
+        target: "anyharness.diagnostics.delivery",
+        generation,
+        "diagnostics delivery re-attached: collector generation ready"
+    );
+}

--- a/anyharness/crates/proliferate-diagnostics-client/src/producer/mod.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/producer/mod.rs
@@ -25,6 +25,9 @@ pub(crate) mod transport;
 mod worker;
 
 #[cfg(all(test, unix))]
+#[path = "tests_delivery_end.rs"]
+mod tests_delivery_end;
+#[cfg(all(test, unix))]
 #[path = "tests_fallback_deadline.rs"]
 mod tests_fallback_deadline;
 #[cfg(test)]
@@ -135,6 +138,33 @@ pub(crate) struct AdmissionState {
     pending_loss_total: u64,
     pending_loss_range: PendingLossRange,
     open_loss_snapshot: Option<LossSnapshot>,
+    delivery_end_warned_generation: Option<u64>,
+}
+
+impl AdmissionState {
+    /// One-shot per generation: several sites can observe the same dead
+    /// generation (a bridge notice, a boot-mismatched receipt, retries), but
+    /// the loud delivery-end warning fires once.
+    pub(crate) fn note_delivery_ended(&mut self, generation: u64) -> bool {
+        if self.delivery_end_warned_generation == Some(generation) {
+            return false;
+        }
+        self.delivery_end_warned_generation = Some(generation);
+        true
+    }
+}
+
+/// The 2026-08-15 outage counted loss for 10.5h without one line in the
+/// runtime's own log; every latch into `Unavailable` now says so out loud.
+/// WARN is re-ingested by the tracing layer, which is acceptable: the caller
+/// guards with `note_delivery_ended` and the pipe being described is already
+/// dead.
+pub(crate) fn warn_delivery_ended(generation: u64) {
+    tracing::warn!(
+        target: "anyharness.diagnostics.delivery",
+        generation,
+        "diagnostics delivery ended: collector generation gone; records count as loss until re-attach"
+    );
 }
 
 pub(crate) enum CollectorAvailability {
@@ -251,6 +281,7 @@ pub(crate) fn install(
             pending_loss_total: 0,
             pending_loss_range: PendingLossRange::Empty,
             open_loss_snapshot: None,
+            delivery_end_warned_generation: None,
         }),
         fallback: Arc::new(fallback_runtime::FallbackController::new(fallback)),
         notify: tokio::sync::Notify::new(),
@@ -410,8 +441,16 @@ impl ProducerInner {
         if !state.in_flight.is_empty() {
             state.delivery_fence_eligible = false;
         }
+        let generation_number = generation.generation;
         state.collector = CollectorAvailability::Ready(Arc::new(generation));
         drop(state);
+        // The canonical re-attach line, mirroring `warn_delivery_ended`; call
+        // sites must not log their own copy.
+        tracing::info!(
+            target: "anyharness.diagnostics.delivery",
+            generation = generation_number,
+            "diagnostics delivery re-attached: collector generation ready"
+        );
         self.notify.notify_one();
     }
 
@@ -436,7 +475,11 @@ impl ProducerInner {
         if !state.in_flight.is_empty() {
             state.delivery_fence_eligible = false;
         }
+        let warn = state.note_delivery_ended(generation);
         drop(state);
+        if warn {
+            warn_delivery_ended(generation);
+        }
         self.notify.notify_one();
     }
 

--- a/anyharness/crates/proliferate-diagnostics-client/src/producer/mod.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/producer/mod.rs
@@ -17,6 +17,7 @@ use crate::{
 mod admission;
 #[cfg(unix)]
 mod bridge_runtime;
+mod delivery_log;
 mod emit;
 mod fallback_runtime;
 pub(crate) mod record;
@@ -139,32 +140,6 @@ pub(crate) struct AdmissionState {
     pending_loss_range: PendingLossRange,
     open_loss_snapshot: Option<LossSnapshot>,
     delivery_end_warned_generation: Option<u64>,
-}
-
-impl AdmissionState {
-    /// One-shot per generation: several sites can observe the same dead
-    /// generation (a bridge notice, a boot-mismatched receipt, retries), but
-    /// the loud delivery-end warning fires once.
-    pub(crate) fn note_delivery_ended(&mut self, generation: u64) -> bool {
-        if self.delivery_end_warned_generation == Some(generation) {
-            return false;
-        }
-        self.delivery_end_warned_generation = Some(generation);
-        true
-    }
-}
-
-/// The 2026-08-15 outage counted loss for 10.5h without one line in the
-/// runtime's own log; every latch into `Unavailable` now says so out loud.
-/// WARN is re-ingested by the tracing layer, which is acceptable: the caller
-/// guards with `note_delivery_ended` and the pipe being described is already
-/// dead.
-pub(crate) fn warn_delivery_ended(generation: u64) {
-    tracing::warn!(
-        target: "anyharness.diagnostics.delivery",
-        generation,
-        "diagnostics delivery ended: collector generation gone; records count as loss until re-attach"
-    );
 }
 
 pub(crate) enum CollectorAvailability {
@@ -416,71 +391,6 @@ impl ProducerInner {
             delivery_fence_eligible: state.delivery_fence_eligible,
             last_failure: state.last_failure,
         }
-    }
-
-    #[cfg(unix)]
-    pub(crate) fn replace_generation(
-        &self,
-        generation: crate::bridge::activation::CollectorGenerationHandle,
-    ) {
-        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
-        let current = match &state.collector {
-            CollectorAvailability::Ready(current)
-            | CollectorAvailability::Cooldown {
-                generation: current,
-                ..
-            } => current.generation,
-            CollectorAvailability::Unavailable { generation } => *generation,
-        };
-        if generation.generation <= current {
-            return;
-        }
-        for record in &mut state.queue {
-            record.fallback_reason = Some(FallbackReason::GenerationChanged);
-        }
-        if !state.in_flight.is_empty() {
-            state.delivery_fence_eligible = false;
-        }
-        let generation_number = generation.generation;
-        state.collector = CollectorAvailability::Ready(Arc::new(generation));
-        drop(state);
-        // The canonical re-attach line, mirroring `warn_delivery_ended`; call
-        // sites must not log their own copy.
-        tracing::info!(
-            target: "anyharness.diagnostics.delivery",
-            generation = generation_number,
-            "diagnostics delivery re-attached: collector generation ready"
-        );
-        self.notify.notify_one();
-    }
-
-    #[cfg(unix)]
-    pub(crate) fn mark_generation_unavailable(&self, generation: u64) {
-        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
-        let current = match &state.collector {
-            CollectorAvailability::Ready(current)
-            | CollectorAvailability::Cooldown {
-                generation: current,
-                ..
-            } => current.generation,
-            CollectorAvailability::Unavailable { generation } => *generation,
-        };
-        if generation <= current {
-            return;
-        }
-        for record in &mut state.queue {
-            record.fallback_reason = Some(FallbackReason::GenerationChanged);
-        }
-        state.collector = CollectorAvailability::Unavailable { generation };
-        if !state.in_flight.is_empty() {
-            state.delivery_fence_eligible = false;
-        }
-        let warn = state.note_delivery_ended(generation);
-        drop(state);
-        if warn {
-            warn_delivery_ended(generation);
-        }
-        self.notify.notify_one();
     }
 
     #[cfg(unix)]

--- a/anyharness/crates/proliferate-diagnostics-client/src/producer/tests_delivery_end.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/producer/tests_delivery_end.rs
@@ -1,0 +1,129 @@
+//! Loud delivery-end proofs: every latch into `Unavailable` logs exactly one
+//! warning per dead generation, and re-attach logs its matching info line.
+
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+use tracing::instrument::WithSubscriber;
+use tracing_subscriber::layer::SubscriberExt;
+
+use super::tests_support::{
+    accepted_receipt, emit, producer, protected, unavailable_producer, wait_for, with_state,
+    CollectorFixture, FixtureResponse, TEST_COLLECTOR_BOOT,
+};
+use super::CollectorAvailability;
+use crate::{DiagnosticsComponent, EmitDisposition};
+
+const DELIVERY_TARGET: &str = "anyharness.diagnostics.delivery";
+
+#[derive(Clone, Default)]
+struct DeliveryEventCounter {
+    warns: Arc<AtomicUsize>,
+    infos: Arc<AtomicUsize>,
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for DeliveryEventCounter {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _context: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        if event.metadata().target() != DELIVERY_TARGET {
+            return;
+        }
+        match *event.metadata().level() {
+            tracing::Level::WARN => self.warns.fetch_add(1, Ordering::SeqCst),
+            tracing::Level::INFO => self.infos.fetch_add(1, Ordering::SeqCst),
+            _ => 0,
+        };
+    }
+}
+
+#[test]
+fn note_delivery_ended_is_one_shot_per_generation() {
+    let inner = unavailable_producer();
+    with_state(&inner, |state| {
+        assert!(state.note_delivery_ended(3));
+        assert!(!state.note_delivery_ended(3));
+        assert!(state.note_delivery_ended(4));
+    });
+}
+
+#[test]
+fn generation_unavailable_warns_exactly_once_per_generation() {
+    let inner = unavailable_producer();
+    let counter = DeliveryEventCounter::default();
+    let subscriber = tracing_subscriber::registry().with(counter.clone());
+    tracing::subscriber::with_default(subscriber, || {
+        inner.mark_generation_unavailable(5);
+        inner.mark_generation_unavailable(5);
+        assert_eq!(
+            counter.warns.load(Ordering::SeqCst),
+            1,
+            "a repeated notice for a dead generation must stay silent"
+        );
+        inner.mark_generation_unavailable(7);
+        assert_eq!(counter.warns.load(Ordering::SeqCst), 2);
+    });
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn replacement_logs_the_canonical_reattach_info_line() {
+    let fresh = CollectorFixture::accepting(TEST_COLLECTOR_BOOT).await;
+    let inner = unavailable_producer();
+    let counter = DeliveryEventCounter::default();
+    let subscriber = tracing_subscriber::registry().with(counter.clone());
+    tracing::subscriber::with_default(subscriber, || {
+        inner.replace_generation(fresh.generation(1));
+    });
+    assert_eq!(counter.infos.load(Ordering::SeqCst), 1);
+    assert!(matches!(
+        with_state(&inner, |state| match &state.collector {
+            CollectorAvailability::Ready(generation) => Some(generation.generation),
+            _ => None,
+        }),
+        Some(1)
+    ));
+}
+
+/// The real worker, transport, and receipt validation run against a scripted
+/// collector whose receipts carry a foreign boot id. The latch that made the
+/// 2026-08-15 outage silent must now warn, exactly once.
+#[tokio::test(flavor = "multi_thread")]
+async fn boot_mismatched_receipt_latch_warns_exactly_once() {
+    let fixture = CollectorFixture::start(TEST_COLLECTOR_BOOT, |_, batch| {
+        FixtureResponse::Receipt(accepted_receipt("collector-boot-9999", batch.records.len()))
+    })
+    .await;
+    let inner = producer(
+        DiagnosticsComponent::AnyHarness,
+        CollectorAvailability::Ready(Arc::new(fixture.generation(1))),
+        None,
+    );
+    assert_eq!(
+        emit(&inner, protected("dispatched-to-foreign-boot")),
+        EmitDisposition::Admitted
+    );
+    let counter = DeliveryEventCounter::default();
+    let subscriber = tracing_subscriber::registry().with(counter.clone());
+    let worker = tokio::spawn(super::worker::run(Arc::clone(&inner)).with_subscriber(subscriber));
+    assert!(
+        wait_for(|| with_state(&inner, |state| matches!(
+            state.collector,
+            CollectorAvailability::Unavailable { generation: 1 }
+        )))
+        .await,
+        "the boot-mismatched receipt must latch the generation unusable"
+    );
+    assert!(
+        wait_for(|| counter.warns.load(Ordering::SeqCst) == 1).await,
+        "the latch must announce the end of delivery"
+    );
+    assert!(
+        !with_state(&inner, |state| state.note_delivery_ended(1)),
+        "the per-generation guard is spent after the single warning"
+    );
+    worker.abort();
+}

--- a/anyharness/crates/proliferate-diagnostics-client/src/producer/tests_support.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/producer/tests_support.rs
@@ -103,6 +103,7 @@ pub(super) fn producer(
             pending_loss_total: 0,
             pending_loss_range: PendingLossRange::Empty,
             open_loss_snapshot: None,
+            delivery_end_warned_generation: None,
         }),
         fallback: Arc::new(super::fallback_runtime::FallbackController::new(fallback)),
         notify: tokio::sync::Notify::new(),

--- a/anyharness/crates/proliferate-diagnostics-client/src/producer/worker.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/producer/worker.rs
@@ -333,6 +333,7 @@ async fn finish_ingest(
     result: Result<proliferate_diagnostics_protocol::v1::types::IngestReceiptV1, TransportFailure>,
 ) {
     let mut fallback = None;
+    let mut delivery_ended_generation = None;
     {
         let mut state = inner
             .state
@@ -388,6 +389,9 @@ async fn finish_ingest(
                         state.collector = CollectorAvailability::Unavailable {
                             generation: generation_identity.generation,
                         };
+                        if state.note_delivery_ended(generation_identity.generation) {
+                            delivery_ended_generation = Some(generation_identity.generation);
+                        }
                         for record in &mut records {
                             record.fallback_reason = Some(FallbackReason::DeliveryUnknown);
                         }
@@ -468,6 +472,9 @@ async fn finish_ingest(
                 }
             }
         }
+    }
+    if let Some(generation) = delivery_ended_generation {
+        super::warn_delivery_ended(generation);
     }
     if let Some((records, deadline)) = fallback {
         route_fallback(inner, records, deadline).await;

--- a/anyharness/crates/proliferate-diagnostics-client/src/producer/worker.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/producer/worker.rs
@@ -474,7 +474,7 @@ async fn finish_ingest(
         }
     }
     if let Some(generation) = delivery_ended_generation {
-        super::warn_delivery_ended(generation);
+        super::delivery_log::warn_delivery_ended(generation);
     }
     if let Some((records, deadline)) = fallback {
         route_fallback(inner, records, deadline).await;

--- a/apps/desktop/src-tauri/src/diagnostics_collector/producer.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/producer.rs
@@ -284,6 +284,22 @@ impl TauriDiagnosticsProducer {
     }
 
     #[cfg(test)]
+    pub(crate) fn lifecycle_snapshot(&self, name: &str) -> Vec<ProducerRecordV1> {
+        self.inner
+            .state
+            .lock()
+            .map(|state| {
+                state
+                    .queued
+                    .iter()
+                    .filter(|queued| queued.record.name == name)
+                    .map(|queued| queued.record.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    #[cfg(test)]
     pub(crate) fn support_lifecycle_snapshot(&self) -> Vec<ProducerRecordV1> {
         self.inner
             .state

--- a/apps/desktop/src-tauri/src/diagnostics_collector/producer/lifecycle.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/producer/lifecycle.rs
@@ -45,6 +45,15 @@ impl LifecycleOperation {
     fn operation_id(&self) -> &str {
         &self.operation_id
     }
+
+    /// Attaches arguments learned after the operation began (e.g. an exit
+    /// status observed at terminal time). They ride the terminal record only.
+    pub(crate) fn append_arguments(
+        &mut self,
+        arguments: impl IntoIterator<Item = TypedArgumentV1>,
+    ) {
+        self.arguments.extend(arguments);
+    }
 }
 
 impl LifecycleOperation {
@@ -107,6 +116,30 @@ impl LifecycleOperation {
 impl TauriDiagnosticsProducer {
     pub(crate) fn begin_lifecycle(&self, name: &'static str) -> LifecycleOperation {
         self.begin_lifecycle_with_correlation(name, LifecycleCorrelation::default())
+    }
+
+    pub(crate) fn begin_lifecycle_with_arguments(
+        &self,
+        name: &'static str,
+        arguments: Vec<TypedArgumentV1>,
+    ) -> LifecycleOperation {
+        if !PR3_LIFECYCLE_NAMES.contains(&name) {
+            return LifecycleOperation::new(
+                self.clone(),
+                name,
+                uuid::Uuid::new_v4().to_string(),
+                LifecycleCorrelation::default(),
+                arguments,
+                &PR3_CLASSIFICATIONS,
+                true,
+            );
+        }
+        self.begin_admitted_lifecycle(
+            name,
+            LifecycleCorrelation::default(),
+            arguments,
+            &PR3_CLASSIFICATIONS,
+        )
     }
 
     pub(crate) fn begin_lifecycle_with_correlation(

--- a/apps/desktop/src-tauri/src/diagnostics_collector/supervisor.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/supervisor.rs
@@ -221,6 +221,8 @@ impl fmt::Debug for DiagnosticsCollectorSupervisor {
     }
 }
 
+#[path = "supervisor/death_certificate.rs"]
+mod death_certificate;
 #[path = "supervisor/initialization.rs"]
 mod initialization;
 #[path = "supervisor/lifecycle.rs"]

--- a/apps/desktop/src-tauri/src/diagnostics_collector/supervisor/death_certificate.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/supervisor/death_certificate.rs
@@ -1,0 +1,105 @@
+use proliferate_diagnostics_protocol::v1::types::{
+    ArgumentValueV1, PrivacyClassificationV1, TypedArgumentV1,
+};
+
+use crate::diagnostics_collector::producer::lifecycle::LifecycleOperation;
+
+use super::DiagnosticsCollectorSupervisor;
+
+/// Death certificate for a failed collector generation: what the monitor (or
+/// the stop path) observed at the moment the child was declared gone. The
+/// exit status is present only when the child was actually seen exited;
+/// inspection failures, health losses, and latched classifications carry none.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct CollectorDeathCertificate {
+    trigger: &'static str,
+    exit_status: Option<std::process::ExitStatus>,
+}
+
+impl CollectorDeathCertificate {
+    pub(super) fn new(
+        trigger: &'static str,
+        exit_status: Option<std::process::ExitStatus>,
+    ) -> Self {
+        Self {
+            trigger,
+            exit_status,
+        }
+    }
+
+    pub(super) fn arguments(&self, restart_count: u64) -> Vec<TypedArgumentV1> {
+        let mut arguments = vec![
+            operational_argument("trigger", ArgumentValueV1::String(self.trigger.to_owned())),
+            operational_argument(
+                "restart_count",
+                ArgumentValueV1::Integer(i64::try_from(restart_count).unwrap_or(i64::MAX)),
+            ),
+        ];
+        if let Some(status) = self.exit_status {
+            if let Some(code) = status.code() {
+                arguments.push(operational_argument(
+                    "exit_code",
+                    ArgumentValueV1::Integer(i64::from(code)),
+                ));
+            }
+            #[cfg(unix)]
+            {
+                use std::os::unix::process::ExitStatusExt;
+                if let Some(signal) = status.signal() {
+                    arguments.push(operational_argument(
+                        "signal",
+                        ArgumentValueV1::Integer(i64::from(signal)),
+                    ));
+                }
+            }
+        }
+        arguments
+    }
+}
+
+fn operational_argument(name: &str, value: ArgumentValueV1) -> TypedArgumentV1 {
+    TypedArgumentV1 {
+        name: name.to_owned(),
+        privacy: PrivacyClassificationV1::Operational,
+        value,
+    }
+}
+
+impl DiagnosticsCollectorSupervisor {
+    /// Begins a `desktop.collector.restart` operation, attaching the death
+    /// certificate when one exists. `accept_restart_budget` already counted
+    /// this attempt, so the certificate's restart_count matches the Ready
+    /// state this attempt would publish.
+    pub(super) fn begin_restart_lifecycle(
+        &self,
+        certificate: Option<CollectorDeathCertificate>,
+    ) -> LifecycleOperation {
+        match certificate {
+            Some(certificate) => {
+                let restart_count = self
+                    .inner
+                    .lock()
+                    .map(|inner| inner.restart_count)
+                    .unwrap_or_default();
+                self.producer.begin_lifecycle_with_arguments(
+                    "desktop.collector.restart",
+                    certificate.arguments(restart_count),
+                )
+            }
+            None => self.producer.begin_lifecycle("desktop.collector.restart"),
+        }
+    }
+
+    /// The certificate arguments for a child observed exited on the stop path.
+    pub(super) fn child_exited_arguments(
+        &self,
+        status: std::process::ExitStatus,
+    ) -> Vec<TypedArgumentV1> {
+        let restart_count = self
+            .inner
+            .lock()
+            .map(|inner| inner.restart_count)
+            .unwrap_or_default();
+        CollectorDeathCertificate::new("child_exited", Some(status)).arguments(restart_count)
+    }
+}

--- a/apps/desktop/src-tauri/src/diagnostics_collector/supervisor/initialization.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/supervisor/initialization.rs
@@ -167,7 +167,7 @@ impl DiagnosticsCollectorSupervisor {
                 };
                 start_operation.terminal(outcome, Some(classification));
                 self.publish_degraded(classification, false);
-                if retryable(error.kind) && self.restart_burst_locked().await {
+                if retryable(error.kind) && self.restart_burst_locked(None).await {
                     self.resolve_startup(StartupBarrierResult::Ready);
                     self.spawn_monitor();
                     StartupBarrierResult::Ready

--- a/apps/desktop/src-tauri/src/diagnostics_collector/supervisor/lifecycle.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/supervisor/lifecycle.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use proliferate_diagnostics_protocol::v1::limits::CURRENT_SCHEMA_VERSION;
-use proliferate_diagnostics_protocol::v1::types::{HealthStatusV1, TerminalOutcomeV1};
+use proliferate_diagnostics_protocol::v1::types::{
+    ArgumentValueV1, HealthStatusV1, PrivacyClassificationV1, TerminalOutcomeV1, TypedArgumentV1,
+};
 
 use super::{
     accept_restart_budget_at, classification_for_launch_error, reset_restart_budget_after_health,
@@ -13,6 +15,65 @@ use super::{
     SupervisorUnavailable, AUTOMATIC_RESTART_DELAYS, HEALTH_FAILURE_THRESHOLD,
     PRODUCER_DRAIN_TIMEOUT, STEADY_HEALTH_INTERVAL,
 };
+
+/// Death certificate for a failed collector generation: what the monitor (or
+/// the stop path) observed at the moment the child was declared gone. The
+/// exit status is present only when the child was actually seen exited;
+/// inspection failures, health losses, and latched classifications carry none.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct CollectorDeathCertificate {
+    trigger: &'static str,
+    exit_status: Option<std::process::ExitStatus>,
+}
+
+impl CollectorDeathCertificate {
+    pub(super) fn new(
+        trigger: &'static str,
+        exit_status: Option<std::process::ExitStatus>,
+    ) -> Self {
+        Self {
+            trigger,
+            exit_status,
+        }
+    }
+
+    pub(super) fn arguments(&self, restart_count: u64) -> Vec<TypedArgumentV1> {
+        let mut arguments = vec![
+            operational_argument("trigger", ArgumentValueV1::String(self.trigger.to_owned())),
+            operational_argument(
+                "restart_count",
+                ArgumentValueV1::Integer(i64::try_from(restart_count).unwrap_or(i64::MAX)),
+            ),
+        ];
+        if let Some(status) = self.exit_status {
+            if let Some(code) = status.code() {
+                arguments.push(operational_argument(
+                    "exit_code",
+                    ArgumentValueV1::Integer(i64::from(code)),
+                ));
+            }
+            #[cfg(unix)]
+            {
+                use std::os::unix::process::ExitStatusExt;
+                if let Some(signal) = status.signal() {
+                    arguments.push(operational_argument(
+                        "signal",
+                        ArgumentValueV1::Integer(i64::from(signal)),
+                    ));
+                }
+            }
+        }
+        arguments
+    }
+}
+
+fn operational_argument(name: &str, value: ArgumentValueV1) -> TypedArgumentV1 {
+    TypedArgumentV1 {
+        name: name.to_owned(),
+        privacy: PrivacyClassificationV1::Operational,
+        value,
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum SteadyHealthAssessment {
@@ -68,7 +129,7 @@ impl DiagnosticsCollectorSupervisor {
 
     pub(crate) async fn stop_collector(&self) -> Result<(), SupervisorUnavailable> {
         let _decision = self.decisions.lock().await;
-        let stop_operation = self.producer.begin_lifecycle("desktop.collector.stop");
+        let mut stop_operation = self.producer.begin_lifecycle("desktop.collector.stop");
         let _ = self.producer.drain(PRODUCER_DRAIN_TIMEOUT).await;
         let (mut process, retained_launch) = {
             let mut inner = self
@@ -124,9 +185,18 @@ impl DiagnosticsCollectorSupervisor {
             };
         }
         match process.observe_exit() {
-            Ok(Some(_)) => {
+            Ok(Some(status)) => {
                 process.finish_reaped();
                 self.invalidate_generation();
+                let restart_count = self
+                    .inner
+                    .lock()
+                    .map(|inner| inner.restart_count)
+                    .unwrap_or_default();
+                stop_operation.append_arguments(
+                    CollectorDeathCertificate::new("child_exited", Some(status))
+                        .arguments(restart_count),
+                );
                 stop_operation.terminal(TerminalOutcomeV1::Failed, Some("child_exited"));
                 self.publish_state(DesktopDiagnosticsSupervisorStateV1::Stopped { orderly: false });
                 return Ok(());
@@ -171,7 +241,10 @@ impl DiagnosticsCollectorSupervisor {
         }
     }
 
-    pub(super) async fn restart_burst_locked(self: &Arc<Self>) -> bool {
+    pub(super) async fn restart_burst_locked(
+        self: &Arc<Self>,
+        certificate: Option<CollectorDeathCertificate>,
+    ) -> bool {
         for (index, delay) in AUTOMATIC_RESTART_DELAYS.iter().copied().enumerate() {
             if self.shutdown_armed.load(Ordering::Acquire) {
                 self.publish_degraded("shutdown_armed", false);
@@ -186,7 +259,23 @@ impl DiagnosticsCollectorSupervisor {
                 self.publish_degraded("restart_exhausted", true);
                 return false;
             }
-            let restart_operation = self.producer.begin_lifecycle("desktop.collector.restart");
+            let restart_operation = match certificate {
+                Some(certificate) => {
+                    // `accept_restart_budget` already counted this attempt, so
+                    // the certificate's restart_count matches the Ready state
+                    // this attempt would publish.
+                    let restart_count = self
+                        .inner
+                        .lock()
+                        .map(|inner| inner.restart_count)
+                        .unwrap_or_default();
+                    self.producer.begin_lifecycle_with_arguments(
+                        "desktop.collector.restart",
+                        certificate.arguments(restart_count),
+                    )
+                }
+                None => self.producer.begin_lifecycle("desktop.collector.restart"),
+            };
             self.publish_starting(CollectorLaunchKindV1::AutomaticRestart, (index + 1) as u8);
             let launcher = match &self.launcher {
                 Ok(launcher) => launcher,
@@ -267,12 +356,13 @@ impl DiagnosticsCollectorSupervisor {
                 return;
             };
             match child_state {
-                Ok(Some(_)) => {
-                    self.fail_generation(generation, "child_exited", true).await;
+                Ok(Some(status)) => {
+                    self.fail_generation(generation, "child_exited", true, Some(status))
+                        .await;
                     return;
                 }
                 Err(_) => {
-                    self.fail_generation(generation, "child_inspection_failed", false)
+                    self.fail_generation(generation, "child_inspection_failed", false, None)
                         .await;
                     return;
                 }
@@ -304,13 +394,13 @@ impl DiagnosticsCollectorSupervisor {
                 SteadyHealthAssessment::TransientFailure => {
                     failed_probes = failed_probes.saturating_add(1);
                     if failed_probes >= HEALTH_FAILURE_THRESHOLD {
-                        self.fail_generation(generation, "health_unavailable", true)
+                        self.fail_generation(generation, "health_unavailable", true, None)
                             .await;
                         return;
                     }
                 }
                 SteadyHealthAssessment::LatchedFailure(classification) => {
-                    self.fail_generation(generation, classification, false)
+                    self.fail_generation(generation, classification, false, None)
                         .await;
                     return;
                 }
@@ -323,6 +413,7 @@ impl DiagnosticsCollectorSupervisor {
         generation: u64,
         classification: &'static str,
         may_retry: bool,
+        mut exit_status: Option<std::process::ExitStatus>,
     ) {
         let _decision = self.decisions.lock().await;
         if !self.generation_is_current(generation) || self.shutdown_armed.load(Ordering::Acquire) {
@@ -336,7 +427,12 @@ impl DiagnosticsCollectorSupervisor {
             .and_then(|mut inner| inner.process.take());
         if let Some(mut process) = process {
             match process.observe_exit() {
-                Ok(Some(_)) => process.finish_reaped(),
+                Ok(Some(status)) => {
+                    // A health-triggered failure can find the child exited by
+                    // now; the reap observation still belongs on the record.
+                    exit_status = exit_status.or(Some(status));
+                    process.finish_reaped();
+                }
                 Ok(None) => {
                     if process.terminate_and_reap().await.is_err() {
                         if let Ok(mut inner) = self.inner.lock() {
@@ -355,7 +451,14 @@ impl DiagnosticsCollectorSupervisor {
                 }
             }
         }
-        if may_retry && self.restart_burst_locked().await {
+        if may_retry
+            && self
+                .restart_burst_locked(Some(CollectorDeathCertificate::new(
+                    classification,
+                    exit_status,
+                )))
+                .await
+        {
             self.spawn_monitor();
         }
     }

--- a/apps/desktop/src-tauri/src/diagnostics_collector/supervisor/lifecycle.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/supervisor/lifecycle.rs
@@ -3,10 +3,9 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use proliferate_diagnostics_protocol::v1::limits::CURRENT_SCHEMA_VERSION;
-use proliferate_diagnostics_protocol::v1::types::{
-    ArgumentValueV1, HealthStatusV1, PrivacyClassificationV1, TerminalOutcomeV1, TypedArgumentV1,
-};
+use proliferate_diagnostics_protocol::v1::types::{HealthStatusV1, TerminalOutcomeV1};
 
+use super::death_certificate::CollectorDeathCertificate;
 use super::{
     accept_restart_budget_at, classification_for_launch_error, reset_restart_budget_after_health,
     retryable, CollectorClientError, CollectorLaunchError, CollectorLaunchErrorKind,
@@ -15,65 +14,6 @@ use super::{
     SupervisorUnavailable, AUTOMATIC_RESTART_DELAYS, HEALTH_FAILURE_THRESHOLD,
     PRODUCER_DRAIN_TIMEOUT, STEADY_HEALTH_INTERVAL,
 };
-
-/// Death certificate for a failed collector generation: what the monitor (or
-/// the stop path) observed at the moment the child was declared gone. The
-/// exit status is present only when the child was actually seen exited;
-/// inspection failures, health losses, and latched classifications carry none.
-#[derive(Debug, Clone, Copy)]
-pub(super) struct CollectorDeathCertificate {
-    trigger: &'static str,
-    exit_status: Option<std::process::ExitStatus>,
-}
-
-impl CollectorDeathCertificate {
-    pub(super) fn new(
-        trigger: &'static str,
-        exit_status: Option<std::process::ExitStatus>,
-    ) -> Self {
-        Self {
-            trigger,
-            exit_status,
-        }
-    }
-
-    pub(super) fn arguments(&self, restart_count: u64) -> Vec<TypedArgumentV1> {
-        let mut arguments = vec![
-            operational_argument("trigger", ArgumentValueV1::String(self.trigger.to_owned())),
-            operational_argument(
-                "restart_count",
-                ArgumentValueV1::Integer(i64::try_from(restart_count).unwrap_or(i64::MAX)),
-            ),
-        ];
-        if let Some(status) = self.exit_status {
-            if let Some(code) = status.code() {
-                arguments.push(operational_argument(
-                    "exit_code",
-                    ArgumentValueV1::Integer(i64::from(code)),
-                ));
-            }
-            #[cfg(unix)]
-            {
-                use std::os::unix::process::ExitStatusExt;
-                if let Some(signal) = status.signal() {
-                    arguments.push(operational_argument(
-                        "signal",
-                        ArgumentValueV1::Integer(i64::from(signal)),
-                    ));
-                }
-            }
-        }
-        arguments
-    }
-}
-
-fn operational_argument(name: &str, value: ArgumentValueV1) -> TypedArgumentV1 {
-    TypedArgumentV1 {
-        name: name.to_owned(),
-        privacy: PrivacyClassificationV1::Operational,
-        value,
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum SteadyHealthAssessment {
@@ -188,15 +128,7 @@ impl DiagnosticsCollectorSupervisor {
             Ok(Some(status)) => {
                 process.finish_reaped();
                 self.invalidate_generation();
-                let restart_count = self
-                    .inner
-                    .lock()
-                    .map(|inner| inner.restart_count)
-                    .unwrap_or_default();
-                stop_operation.append_arguments(
-                    CollectorDeathCertificate::new("child_exited", Some(status))
-                        .arguments(restart_count),
-                );
+                stop_operation.append_arguments(self.child_exited_arguments(status));
                 stop_operation.terminal(TerminalOutcomeV1::Failed, Some("child_exited"));
                 self.publish_state(DesktopDiagnosticsSupervisorStateV1::Stopped { orderly: false });
                 return Ok(());
@@ -259,23 +191,7 @@ impl DiagnosticsCollectorSupervisor {
                 self.publish_degraded("restart_exhausted", true);
                 return false;
             }
-            let restart_operation = match certificate {
-                Some(certificate) => {
-                    // `accept_restart_budget` already counted this attempt, so
-                    // the certificate's restart_count matches the Ready state
-                    // this attempt would publish.
-                    let restart_count = self
-                        .inner
-                        .lock()
-                        .map(|inner| inner.restart_count)
-                        .unwrap_or_default();
-                    self.producer.begin_lifecycle_with_arguments(
-                        "desktop.collector.restart",
-                        certificate.arguments(restart_count),
-                    )
-                }
-                None => self.producer.begin_lifecycle("desktop.collector.restart"),
-            };
+            let restart_operation = self.begin_restart_lifecycle(certificate);
             self.publish_starting(CollectorLaunchKindV1::AutomaticRestart, (index + 1) as u8);
             let launcher = match &self.launcher {
                 Ok(launcher) => launcher,

--- a/apps/desktop/src-tauri/src/diagnostics_collector/supervisor_recovery_tests.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/supervisor_recovery_tests.rs
@@ -1,10 +1,19 @@
 use super::*;
 use crate::diagnostics_collector::test_binary::built_collector_binary;
 use proliferate_diagnostics_protocol::v1::types::{
-    ComponentV1, LifecyclePhaseV1, ProducerRecordV1, RecordClassV1, RecordsFilterV1,
+    ArgumentValueV1, ComponentV1, LifecyclePhaseV1, ProducerRecordV1, RecordClassV1,
+    RecordsFilterV1,
 };
 use std::io::Read;
 use std::path::PathBuf;
+
+fn argument(record: &ProducerRecordV1, name: &str) -> Option<ArgumentValueV1> {
+    record
+        .arguments
+        .iter()
+        .find(|argument| argument.name == name)
+        .map(|argument| argument.value.clone())
+}
 
 fn lifecycle_query(name: &str) -> RecordsQueryV1 {
     RecordsQueryV1 {
@@ -150,8 +159,131 @@ async fn killed_collector_restarts_with_new_generation_capability_and_query() {
         page.records[0].record.operation_id,
         page.records[1].record.operation_id
     );
+    // The death certificate rides both phases: a killed child restarts with
+    // the signal that took it, the trigger, and the attempt count on record.
+    for stored in &page.records {
+        assert_eq!(
+            argument(&stored.record, "trigger"),
+            Some(ArgumentValueV1::String("child_exited".to_owned()))
+        );
+        assert_eq!(
+            argument(&stored.record, "restart_count"),
+            Some(ArgumentValueV1::Integer(1))
+        );
+        assert_eq!(
+            argument(&stored.record, "signal"),
+            Some(ArgumentValueV1::Integer(i64::from(libc::SIGKILL)))
+        );
+        assert_eq!(argument(&stored.record, "exit_code"), None);
+    }
 
     stop_fixture(root, fallback, producer, supervisor).await;
+}
+
+#[tokio::test]
+async fn stop_of_an_already_exited_child_records_the_death_certificate() {
+    let (root, fallback, producer, supervisor) = running_supervisor("collector-stop-exited").await;
+    supervisor.arm_shutdown();
+    supervisor
+        .kill_current_process_for_test()
+        .expect("kill owned collector");
+    // SIGKILL delivery is asynchronous; the child must be observably exited
+    // before the stop path inspects it.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    supervisor
+        .stop_collector()
+        .await
+        .expect("stop over exited child");
+
+    let terminal: Vec<ProducerRecordV1> = producer
+        .lifecycle_snapshot("desktop.collector.stop")
+        .into_iter()
+        .filter(|record| {
+            record
+                .lifecycle
+                .as_ref()
+                .is_some_and(|lifecycle| lifecycle.phase == LifecyclePhaseV1::Terminal)
+        })
+        .collect();
+    assert_eq!(terminal.len(), 1);
+    let record = &terminal[0];
+    assert_eq!(record.error_classification.as_deref(), Some("child_exited"));
+    assert_eq!(
+        argument(record, "trigger"),
+        Some(ArgumentValueV1::String("child_exited".to_owned()))
+    );
+    assert_eq!(
+        argument(record, "signal"),
+        Some(ArgumentValueV1::Integer(i64::from(libc::SIGKILL)))
+    );
+    assert_eq!(argument(record, "exit_code"), None);
+    assert_eq!(
+        argument(record, "restart_count"),
+        Some(ArgumentValueV1::Integer(0))
+    );
+
+    producer.close();
+    fallback.close().expect("fallback close");
+    std::fs::remove_dir_all(root).expect("fixture cleanup");
+}
+
+#[cfg(unix)]
+#[test]
+fn death_certificate_distinguishes_clean_exit_from_signal() {
+    use std::os::unix::process::ExitStatusExt;
+
+    let clean = super::lifecycle::CollectorDeathCertificate::new(
+        "child_exited",
+        Some(std::process::ExitStatus::from_raw(0)),
+    );
+    let clean_record = certificate_record(clean);
+    assert_eq!(
+        argument(&clean_record, "exit_code"),
+        Some(ArgumentValueV1::Integer(0))
+    );
+    assert_eq!(argument(&clean_record, "signal"), None);
+
+    let signalled = super::lifecycle::CollectorDeathCertificate::new(
+        "child_exited",
+        Some(std::process::ExitStatus::from_raw(libc::SIGKILL)),
+    );
+    let signalled_record = certificate_record(signalled);
+    assert_eq!(argument(&signalled_record, "exit_code"), None);
+    assert_eq!(
+        argument(&signalled_record, "signal"),
+        Some(ArgumentValueV1::Integer(i64::from(libc::SIGKILL)))
+    );
+
+    let uninspected = super::lifecycle::CollectorDeathCertificate::new("health_unavailable", None);
+    let uninspected_record = certificate_record(uninspected);
+    assert_eq!(
+        argument(&uninspected_record, "trigger"),
+        Some(ArgumentValueV1::String("health_unavailable".to_owned()))
+    );
+    assert_eq!(argument(&uninspected_record, "exit_code"), None);
+    assert_eq!(argument(&uninspected_record, "signal"), None);
+}
+
+/// Runs a certificate through the real producer admission path so the
+/// arguments asserted on are the ones a stored record would carry.
+fn certificate_record(
+    certificate: super::lifecycle::CollectorDeathCertificate,
+) -> ProducerRecordV1 {
+    let root = std::env::temp_dir().join(format!("certificate-args-{}", uuid::Uuid::new_v4()));
+    let fallback = FallbackDiagnosticsWriter::open_for_test(root.join("desktop-native.log"))
+        .expect("fallback");
+    let producer = TauriDiagnosticsProducer::new(fallback.clone(), "test".into(), "test".into());
+    let operation = producer
+        .begin_lifecycle_with_arguments("desktop.collector.restart", certificate.arguments(1));
+    drop(operation);
+    let record = producer
+        .lifecycle_snapshot("desktop.collector.restart")
+        .into_iter()
+        .next()
+        .expect("admitted certificate record");
+    fallback.close().expect("fallback close");
+    std::fs::remove_dir_all(root).expect("fixture cleanup");
+    record
 }
 
 #[tokio::test]

--- a/apps/desktop/src-tauri/src/diagnostics_collector/supervisor_recovery_tests.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/supervisor_recovery_tests.rs
@@ -232,7 +232,7 @@ async fn stop_of_an_already_exited_child_records_the_death_certificate() {
 fn death_certificate_distinguishes_clean_exit_from_signal() {
     use std::os::unix::process::ExitStatusExt;
 
-    let clean = super::lifecycle::CollectorDeathCertificate::new(
+    let clean = super::death_certificate::CollectorDeathCertificate::new(
         "child_exited",
         Some(std::process::ExitStatus::from_raw(0)),
     );
@@ -243,7 +243,7 @@ fn death_certificate_distinguishes_clean_exit_from_signal() {
     );
     assert_eq!(argument(&clean_record, "signal"), None);
 
-    let signalled = super::lifecycle::CollectorDeathCertificate::new(
+    let signalled = super::death_certificate::CollectorDeathCertificate::new(
         "child_exited",
         Some(std::process::ExitStatus::from_raw(libc::SIGKILL)),
     );
@@ -254,7 +254,7 @@ fn death_certificate_distinguishes_clean_exit_from_signal() {
         Some(ArgumentValueV1::Integer(i64::from(libc::SIGKILL)))
     );
 
-    let uninspected = super::lifecycle::CollectorDeathCertificate::new("health_unavailable", None);
+    let uninspected = super::death_certificate::CollectorDeathCertificate::new("health_unavailable", None);
     let uninspected_record = certificate_record(uninspected);
     assert_eq!(
         argument(&uninspected_record, "trigger"),
@@ -267,7 +267,7 @@ fn death_certificate_distinguishes_clean_exit_from_signal() {
 /// Runs a certificate through the real producer admission path so the
 /// arguments asserted on are the ones a stored record would carry.
 fn certificate_record(
-    certificate: super::lifecycle::CollectorDeathCertificate,
+    certificate: super::death_certificate::CollectorDeathCertificate,
 ) -> ProducerRecordV1 {
     let root = std::env::temp_dir().join(format!("certificate-args-{}", uuid::Uuid::new_v4()));
     let fallback = FallbackDiagnosticsWriter::open_for_test(root.join("desktop-native.log"))


### PR DESCRIPTION
## What

Slice 3 of the diagnostics-pipeline hardening program (frozen spec: diagnostics-hardening 2026-08-15; root cause: the wf2pablo dev runtime's producer counted loss silently for 10.5h after a collector death).

**Desktop supervisor (death certificates).** The monitor observed the child's `ExitStatus` and threw it away. Now `fail_generation` carries the observed status (refining it at reap time if the child died between the trigger and the take), and every `desktop.collector.restart` lifecycle record carries typed arguments: `trigger` (`child_exited` | `child_inspection_failed` | `health_unavailable` | latched classification), `exit_code` (i64, if any), `signal` (i64, unix, if any), and `restart_count`. The terminal `desktop.collector.stop` `child_exited` path attaches the same certificate. `begin_lifecycle` gains an arguments-accepting variant; launch-time restart bursts (no dead child) pass no certificate and are unchanged.

**Diagnostics client (loud delivery end).** The two latches into `CollectorAvailability::Unavailable` — `mark_generation_unavailable` (bridge notice) and the boot-id-mismatched receipt in the worker — now emit a one-shot-per-generation `WARN` on `anyharness.diagnostics.delivery` ("diagnostics delivery ended: collector generation gone; records count as loss until re-attach"), guarded by a per-generation flag in `AdmissionState`. `replace_generation` logs the canonical matching info line (call sites must not double-log; slice 2b consumes this). The WARN self-ingestion noted in the spec is accepted: one-shot, and the pipe is dead at that point.

## Tests

- `cargo test -p proliferate-diagnostics-client --lib` → **197 passed, 0 failed**, including new `tests_delivery_end`: one-shot flag semantics, exactly-one-WARN per generation death (captured via a counting tracing layer), the canonical re-attach info line, and a real-worker boot-mismatched-receipt latch warning exactly once.
- `cargo test -p proliferate --lib diagnostics_collector` → **205 passed, 0 failed**, including: extended `killed_collector_restarts_...` asserting the restart records carry `trigger=child_exited`, `signal=SIGKILL`, no `exit_code`, `restart_count=1`; new stop-path test for an already-exited child; unit test distinguishing clean exit (`exit_code=0`, no `signal`) from signal death and from an uninspected (`health_unavailable`) certificate, run through real producer admission.

**Negative controls** (each fix reverted temporarily, test observed failing, fix restored):
- warn suppressed in `mark_generation_unavailable` → `generation_unavailable_warns_exactly_once_per_generation` FAILED
- warn suppressed at the worker boot-mismatch latch → `boot_mismatched_receipt_latch_warns_exactly_once` FAILED
- certificate dropped from `fail_generation` → `killed_collector_restarts_with_new_generation_capability_and_query` FAILED

Pre-existing, unrelated: `cargo clippy -p proliferate` fails on `diagnostics/support_snapshot/assembly/accounting.rs` (`overly_complex_bool_expr`, from #1818); three tests are flaky under parallel runs and pass in isolation — `bridge::activation::close_if_open...`, `child_bridge::...status_timeout...`, and `process_kill::tests::census_counts_git_executables_distinctly_from_the_total` (anyharness-lib; failed once in CI, re-run solo 5/5 green — the census counts machine-wide processes and is perturbed by concurrent tests spawning git). All untouched by this diff.

## Repo shape fix (review round 1)

producer/mod.rs (641) and supervisor/lifecycle.rs (674) breached the 600-line cap. The slice's client-side additions (plus the two generation-transition methods that own the logging) now live in `producer/delivery_log.rs`, deliberately avoiding the mod.rs regions slice 2b (#1963) reshuffles; the desktop certificate type and the supervisor's certificate-assembly helpers live in `supervisor/death_certificate.rs`. `scripts/check_max_lines.py` passes locally; all three negative controls were re-run after the move and still fail with the fix reverted.

## Spec notes

One observation raised (not rescoped): the transport `Authentication|Rejected|Protocol` failure latch in `worker.rs` also flips a generation to `Unavailable` but is not named by the spec, so it does not warn in this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
