### PR TITLE
build(cargo): slim dev-profile debug info (line-tables-only, no deps debug)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,18 @@ edition = "2021"
 license = "AGPL-3.0"
 repository = "https://github.com/proliferate-ai/proliferate"
 
+[profile.dev]
+# Keep file/line backtraces for workspace crates without paying for full
+# variable-level debug info (DWARF). Cuts rlib size, link memory, and disk.
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+# Applies to all non-workspace-member dependencies only (Cargo book,
+# "Overrides": the `"*"` package name overrides settings "for all
+# dependencies (but not any workspace member)"). Dependencies get no debug
+# info at all, since we never step into their source.
+debug = false
+
 [workspace.dependencies]
 # HTTP / async
 axum = { version = "0.8", features = ["ws"] }


### PR DESCRIPTION
## What

Adds two profile settings to the workspace-root Cargo.toml:

```
[profile.dev]
debug = "line-tables-only"

[profile.dev.package."*"]
debug = false
```

Workspace crates (anyharness/crates/*, apps/desktop/src-tauri, apps/desktop/src-tauri-debug) keep file and line backtraces for panics and logs but drop full variable-level DWARF debug info. Third-party dependencies get no debug info at all, since we never step into their source in a debugger.

## Why

Full debug info in the dev profile is the main driver of oversized rlibs, link memory, and disk usage on local builds. anyharness-lib alone produces a debug rlib of roughly 500M today. This machine class is an 18-core/24GB laptop that has already OOM-crashed and swap-died from concurrent Rust builds, and every additional gigabyte spent on unused DWARF sections directly shrinks the headroom before that happens. Cutting debug info to line-tables-only for workspace code and to nothing for dependencies reduces rlib size, the memory the linker needs to hold intermediate objects, and the disk footprint of target/debug, with no loss of the file:line backtraces engineers actually rely on.

## Correctness of the wildcard override

The `[profile.dev.package."*"]` override could in principle be read as applying to every crate, including workspace members, which would be wrong here since we want workspace crates to keep line-tables-only rather than losing debug info entirely. Checked against the Cargo book's Overrides section (https://doc.rust-lang.org/cargo/reference/profiles.html#overrides), which states explicitly: "To override the settings for all dependencies (but not any workspace member), use the `\"*\"` package name." So the wildcard here only ever touches third-party dependencies, and the `[profile.dev]` table's `line-tables-only` setting is what continues to apply to workspace members. No scoping change was needed.

Also checked the repo for any other place that pins `profile.dev` or similar (grepped all *.toml and any .cargo directories); there is none, so this is a clean addition with nothing to reconcile.

## Validation

No Rust build was run for this change, per the current one-build-at-a-time machine constraint. Validated with `cargo metadata --format-version 1`, which parses the manifest and workspace graph without compiling anything, and succeeded (762 packages, 12 workspace members resolved). Also confirmed there is no local Cargo.lock drift caused by this change; a version drift that showed up in Cargo.lock during that metadata run was pre-existing on main (release version bump not yet reflected in the lockfile) and unrelated, so it was reverted before committing to keep this PR to the one-line profile change.

## Note

The first CI run against this branch, and the first local build anyone does after merging, will be cache-cold: rustc will need to recompile every crate under the new profile settings since the debug-info shape is part of the fingerprint. Expect that one build to take the usual full-workspace time; subsequent incremental builds should be smaller and faster to link because of the trimmed debug sections.

## Verified (review round 2, 2026-08-15)

Measured on a clean build of `proliferate-runtime-update-protocol` (main vs this branch): crate rlib -23.4%, object code -31.5%, `__debug_info` -87.4%, `__debug_loc` eliminated, `__debug_line` -3.9% (preserved), and a live `RUST_BACKTRACE=full` panic still resolves exact workspace file:line. Adversarial semantics pass found no defect. Details in the PR comments.

**Merge timing:** this change invalidates every sccache cache key, so the first post-merge build is a full cold recompile. Pre-warm the cache with one build on main after merging, or stagger fleet worktree rebuilds, to avoid concurrent full-graph builds on the 24GB dev machine.
