### PR TITLE
feat(product): take transcript hydration off the workspace-switch critical path (R14)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/surface/SessionTranscriptPane.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/surface/SessionTranscriptPane.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { replaySessionHistory } from "#product/lib/domain/sessions/stream/stream-state";
+import { SessionTranscriptPane } from "#product/components/workspace/chat/surface/SessionTranscriptPane";
+import {
+  beginRendererFlow,
+  deferWorkspaceOpenContentStable,
+  markRendererFlowDataReady,
+  markRendererFlowShellCommitted,
+  resetRendererFlowsForTest,
+} from "#product/lib/infra/diagnostics/renderer-flow-timing";
+import {
+  resetRendererDiagnosticsSinkForTest,
+  setRendererDiagnosticsSink,
+  type RendererDiagnosticInput,
+} from "#product/lib/infra/diagnostics/renderer-diagnostics-port";
+import {
+  createEmptySessionRecord,
+  patchSessionRecord,
+  putSessionRecord,
+} from "#product/stores/sessions/session-records";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+
+// Heavy leaf UI is not under test — the deferred content_stable hand-off is.
+vi.mock("#product/components/workspace/chat/transcript/MessageList", () => ({
+  MessageList: () => <div data-testid="message-list" />,
+}));
+vi.mock("#product/components/workspace/chat/plans/ConnectedPlanHandoffDialog", () => ({
+  ConnectedPlanHandoffDialog: () => null,
+}));
+vi.mock("#product/components/workspace/chat/surface/TranscriptSwitchingPlaceholder", () => ({
+  TranscriptSwitchingPlaceholder: () => <div data-testid="placeholder" />,
+}));
+vi.mock("#product/components/diagnostics/DebugProfiler", () => ({
+  DebugProfiler: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock("#product/hooks/ui/debug/use-debug-render-count", () => ({
+  useDebugRenderCount: () => {},
+}));
+// The pane self-hydration path is exercised elsewhere; here we drive hydration
+// completion explicitly via the flag, so a no-op rehydrate keeps host wiring out.
+vi.mock("#product/hooks/sessions/lifecycle/use-session-history-hydration", () => ({
+  useSessionHistoryHydration: () => ({
+    rehydrateSessionSlotFromHistory: vi.fn().mockResolvedValue(true),
+  }),
+}));
+vi.mock("#product/hooks/plans/ui/use-plan-handoff-dialog-state", () => ({
+  usePlanHandoffDialogState: () => ({ plan: null, open: vi.fn(), close: vi.fn() }),
+}));
+vi.mock("#product/hooks/chat/workflows/use-transcript-session-navigation-actions", () => ({
+  useTranscriptSessionNavigationActions: () => ({
+    canOpenTranscriptSession: false,
+    openTranscriptSession: vi.fn(),
+  }),
+}));
+vi.mock("#product/hooks/workspaces/derived/use-workspace-creation-receipt", () => ({
+  useWorkspaceCreationReceiptKey: () => null,
+}));
+
+const WORKSPACE_ID = "workspace-1";
+const SESSION_ID = "session-1";
+
+let emitted: RendererDiagnosticInput[];
+let nowValue: number;
+
+beforeEach(() => {
+  emitted = [];
+  setRendererDiagnosticsSink({ emit: (input) => emitted.push(input) });
+  nowValue = 0;
+  vi.spyOn(performance, "now").mockImplementation(() => nowValue);
+  resetRendererFlowsForTest();
+  useSessionDirectoryStore.getState().clearEntries();
+  useSessionIntentStore.getState().clear();
+  useSessionTranscriptStore.getState().clearEntries();
+  useSessionSelectionStore.getState().deselectWorkspacePreservingSessions();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  resetRendererFlowsForTest();
+  resetRendererDiagnosticsSinkForTest();
+  useSessionDirectoryStore.getState().clearEntries();
+  useSessionIntentStore.getState().clear();
+  useSessionTranscriptStore.getState().clearEntries();
+  useSessionSelectionStore.getState().deselectWorkspacePreservingSessions();
+});
+
+/**
+ * Simulates the real cold workspace-open: the bootstrap begins the
+ * workspace_open flow and, because transcript hydration is off its critical
+ * path, DEFERS content_stable to this session; selectSession synchronously
+ * seeds the empty-but-truthy scaffold via createEmptySessionRecord.
+ */
+function beginDeferredColdOpen(): void {
+  beginRendererFlow({
+    kind: "workspace_open",
+    correlationKey: WORKSPACE_ID,
+    correlation: { workspaceId: WORKSPACE_ID },
+  });
+  nowValue = 10;
+  markRendererFlowShellCommitted({ kind: "workspace_open", correlationKey: WORKSPACE_ID });
+  nowValue = 35;
+  markRendererFlowDataReady({ kind: "workspace_open", correlationKey: WORKSPACE_ID });
+  deferWorkspaceOpenContentStable({ sessionId: SESSION_ID, correlationKey: WORKSPACE_ID });
+  // Real scaffold: createEmptySessionRecord carries an empty-but-truthy
+  // TranscriptState and transcriptHydrated=false.
+  putSessionRecord(
+    createEmptySessionRecord(SESSION_ID, "codex", { workspaceId: WORKSPACE_ID }),
+  );
+  useSessionSelectionStore.getState().activateWorkspace({
+    logicalWorkspaceId: WORKSPACE_ID,
+    workspaceId: WORKSPACE_ID,
+    initialActiveSessionId: SESSION_ID,
+  });
+}
+
+function contentStable(): RendererDiagnosticInput | undefined {
+  return emitted.find((entry) => entry.name === "renderer.flow.content_stable");
+}
+
+function renderPane() {
+  return render(<SessionTranscriptPane bottomInsetPx={0} nonDisplacingBottomInsetPx={0} />);
+}
+
+describe("SessionTranscriptPane deferred workspace_open content_stable", () => {
+  it("does NOT finish on the empty scaffold, then finishes once hydration lands", () => {
+    beginDeferredColdOpen();
+    renderPane();
+
+    // Scaffold present (empty-but-truthy transcript) but transcriptHydrated is
+    // still false: content_stable must not fire against the scaffold.
+    expect(contentStable()).toBeUndefined();
+
+    // Hydration completes 1.5s later — exactly the case that used to be measured.
+    nowValue = 1_535;
+    act(() => {
+      const initial = replaySessionHistory(SESSION_ID, []);
+      patchSessionRecord(SESSION_ID, {
+        events: initial.events,
+        transcript: initial.transcript,
+        transcriptHydrated: true,
+      });
+    });
+
+    const stable = contentStable();
+    expect(stable).toBeDefined();
+    // Honest measurement: data_to_stable reflects the real hydration wait
+    // (1535 - 35 = 1500), not ~0 against the scaffold.
+    expect(stable?.fields?.data_to_stable_ms?.value).toBe(1_500);
+  });
+
+  it("counts a hydrated-empty session (zero messages) as stable", () => {
+    beginDeferredColdOpen();
+    renderPane();
+    expect(contentStable()).toBeUndefined();
+
+    // New workspace, zero messages: transcript stays the empty scaffold, only
+    // the hydrated flag flips. This must still finish the flow.
+    nowValue = 200;
+    act(() => {
+      patchSessionRecord(SESSION_ID, { transcriptHydrated: true });
+    });
+
+    expect(contentStable()).toBeDefined();
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/surface/SessionTranscriptPane.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/surface/SessionTranscriptPane.tsx
@@ -128,19 +128,34 @@ export function SessionTranscriptPane({
   // UX-latency R14: honest workspace_open content_stable. The bootstrap no
   // longer finishes that flow at its own completion — transcript hydration is
   // off its critical path. It DEFERS the mark to here: once the selected
-  // session's transcript is actually committed (non-null transcript, deferred
-  // id caught up so MessageList is rendering), we finish the flow. This is the
-  // first moment the user can truly see the transcript. finishDeferred… no-ops
-  // when there is no deferred workspace_open flow for this session (a plain
-  // in-workspace switch), so it is safe to run on every committed transcript.
+  // session's transcript is actually HYDRATED, we finish the flow. This is the
+  // first moment the user can truly see the real transcript. finishDeferred…
+  // no-ops when there is no deferred workspace_open flow for this session (a
+  // plain in-workspace switch), so it is safe to run on every hydration.
+  //
+  // The gate is the directory entry's `transcriptHydrated` flag, NOT object
+  // presence of `transcript`. On cold open selectSession synchronously seeds
+  // createEmptySessionRecord with an empty-but-truthy TranscriptState scaffold;
+  // gating on `transcript` would fire content_stable ~0ms against that scaffold
+  // (lying: data_to_stable_ms would read ~0 for the exact case that used to
+  // measure 1.2–1.8s) and the real content would pop in AFTER we reported
+  // stable. Both hydration call sites (this pane's self-hydration and the
+  // bootstrap kickoff) patch transcriptHydrated=true only once history has been
+  // fetched and applied, so a hydrated-empty session (new workspace, zero
+  // messages) still counts as stable while the scaffold-empty state does not.
+  const transcriptHydrated = useSessionDirectoryStore((state) =>
+    activeSessionId
+      ? state.entriesById[activeSessionId]?.transcriptHydrated ?? false
+      : false
+  );
   useEffect(() => {
-    if (transcriptDeferred || !activeSessionId || !transcript) {
+    if (transcriptDeferred || !activeSessionId || !transcriptHydrated) {
       return;
     }
     finishDeferredWorkspaceOpenForSession(activeSessionId, {
       content_stable_source: "transcript_committed",
     });
-  }, [activeSessionId, transcript, transcriptDeferred]);
+  }, [activeSessionId, transcriptHydrated, transcriptDeferred]);
 
   const loadOlderHistory = useCallback(() => {
     if (!activeSessionId || !selectedWorkspaceId || !hasOlderHistory || isLoadingOlderHistory) {

--- a/apps/packages/product-client/src/components/workspace/chat/surface/SessionTranscriptPane.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/surface/SessionTranscriptPane.tsx
@@ -11,6 +11,7 @@ import { useWorkspaceCreationReceiptKey } from "#product/hooks/workspaces/derive
 import { TranscriptSwitchingPlaceholder } from "#product/components/workspace/chat/surface/TranscriptSwitchingPlaceholder";
 import type { GoalTranscriptEvent } from "#product/domain/activity/goal-transcript-events";
 import { logLatency } from "#product/lib/infra/measurement/measurement-port";
+import { finishDeferredWorkspaceOpenForSession } from "#product/lib/infra/diagnostics/renderer-flow-timing";
 import {
   ensureSessionTranscriptEntry,
   patchSessionRecord,
@@ -123,6 +124,23 @@ export function SessionTranscriptPane({
     selectedWorkspaceId,
     transcript,
   ]);
+
+  // UX-latency R14: honest workspace_open content_stable. The bootstrap no
+  // longer finishes that flow at its own completion — transcript hydration is
+  // off its critical path. It DEFERS the mark to here: once the selected
+  // session's transcript is actually committed (non-null transcript, deferred
+  // id caught up so MessageList is rendering), we finish the flow. This is the
+  // first moment the user can truly see the transcript. finishDeferred… no-ops
+  // when there is no deferred workspace_open flow for this session (a plain
+  // in-workspace switch), so it is safe to run on every committed transcript.
+  useEffect(() => {
+    if (transcriptDeferred || !activeSessionId || !transcript) {
+      return;
+    }
+    finishDeferredWorkspaceOpenForSession(activeSessionId, {
+      content_stable_source: "transcript_committed",
+    });
+  }, [activeSessionId, transcript, transcriptDeferred]);
 
   const loadOlderHistory = useCallback(() => {
     if (!activeSessionId || !selectedWorkspaceId || !hasOlderHistory || isLoadingOlderHistory) {

--- a/apps/packages/product-client/src/hooks/access/anyharness/workspaces/use-workspace-bootstrap-cache.test.ts
+++ b/apps/packages/product-client/src/hooks/access/anyharness/workspaces/use-workspace-bootstrap-cache.test.ts
@@ -22,6 +22,10 @@ import {
 import {
   resetSessionReplacementDismissalsForTests,
 } from "#product/hooks/sessions/workflows/session-replacement-dismissals";
+import {
+  resetWorkspaceSessionsWarmPinsForTest,
+  warmWorkspaceSessionsPinCountForTest,
+} from "#product/hooks/access/anyharness/workspaces/workspace-session-directory-keepalive";
 
 const mocks = vi.hoisted(() => ({
   dismissSession: vi.fn(async () => undefined),
@@ -48,6 +52,7 @@ beforeEach(() => {
   mocks.writeSessionReplacementTombstones.mockReturnValue(true);
   resetReplacedSessionTombstonesForTests();
   resetSessionReplacementDismissalsForTests();
+  resetWorkspaceSessionsWarmPinsForTest();
 });
 
 describe("replacement tombstone reconciliation", () => {
@@ -85,7 +90,14 @@ describe("replacement tombstone reconciliation", () => {
     expect(isReplacedSessionTombstoned("workspace-1", "client-old")).toBe(true);
   });
 
-  it("filters staged replacements from cache hits without reconciling them", async () => {
+  it("filters staged replacements from the warm first-paint serve without destructively reconciling them", async () => {
+    // R14: a warm serve now kicks a background revalidation (founder ruling:
+    // not stale-tolerant). It must still NOT destructively reconcile a STAGED
+    // (uncommitted) replacement — dismissSession must never fire for it.
+    mocks.listWorkspaceSessions.mockResolvedValueOnce([
+      { id: "runtime-old" },
+      { id: "runtime-new" },
+    ]);
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
@@ -103,9 +115,74 @@ describe("replacement tombstone reconciliation", () => {
       workspaceId: "workspace-1",
     });
 
+    // First-paint serve is the warm, filtered cache — returned synchronously
+    // without blocking on the network.
     expect(sessions).toEqual([{ id: "runtime-new", workspaceId: "workspace-1" }]);
-    expect(mocks.listWorkspaceSessions).not.toHaveBeenCalled();
+    // A staged replacement is never dismissed, even by the background fetch.
+    await vi.waitFor(() =>
+      expect(mocks.listWorkspaceSessions).toHaveBeenCalledTimes(1),
+    );
     expect(mocks.dismissSession).not.toHaveBeenCalled();
+  });
+
+  it("keeps the sessions query warm and reports a hit after a fresh load", async () => {
+    mocks.listWorkspaceSessions.mockResolvedValueOnce([{ id: "s1" }]);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = createWrapper(queryClient, "http://runtime.test");
+    const { result } = renderHook(() => useWorkspaceBootstrapCache(), { wrapper });
+
+    expect(result.current.getWorkspaceSessionsCacheDecision("workspace-1")).toBe("miss");
+    await result.current.loadWorkspaceSessions({
+      workspaceConnection: {} as never,
+      workspaceId: "workspace-1",
+    });
+
+    // The query was pinned warm (bounded LRU) and now reports a truthful hit.
+    expect(warmWorkspaceSessionsPinCountForTest()).toBeGreaterThan(0);
+    expect(result.current.getWorkspaceSessionsCacheDecision("workspace-1")).toBe("hit");
+  });
+
+  it("revalidates a warm serve in the background and updates the cache", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const queryKey = anyHarnessSessionsKey(CACHE_SCOPE_KEY, "workspace-1");
+    queryClient.setQueryData(queryKey, [{ id: "stale-1", workspaceId: "workspace-1" }]);
+    mocks.listWorkspaceSessions.mockResolvedValueOnce([{ id: "fresh-1" }]);
+    const wrapper = createWrapper(queryClient, "http://runtime.test");
+    const { result } = renderHook(() => useWorkspaceBootstrapCache(), { wrapper });
+
+    const served = await result.current.loadWorkspaceSessions({
+      workspaceConnection: {} as never,
+      workspaceId: "workspace-1",
+    });
+    // Warm value served for first paint.
+    expect(served).toEqual([{ id: "stale-1", workspaceId: "workspace-1" }]);
+    // Background revalidation fetched and seeded the fresh list.
+    await vi.waitFor(() => {
+      expect(queryClient.getQueryData(queryKey)).toEqual([
+        { id: "fresh-1", workspaceId: "workspace-1" },
+      ]);
+    });
+  });
+
+  it("invalidates a warm entry when a replaced-session tombstone commits", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const queryKey = anyHarnessSessionsKey(CACHE_SCOPE_KEY, "workspace-1");
+    queryClient.setQueryData(queryKey, [{ id: "runtime-old", workspaceId: "workspace-1" }]);
+    const wrapper = createWrapper(queryClient, "http://runtime.test");
+    const { result } = renderHook(() => useWorkspaceBootstrapCache(), { wrapper });
+    expect(result.current.getWorkspaceSessionsCacheDecision("workspace-1")).toBe("hit");
+
+    commitReplacedSessionTombstone("workspace-1", "runtime-old");
+
+    await vi.waitFor(() =>
+      expect(result.current.getWorkspaceSessionsCacheDecision("workspace-1")).toBe("stale"),
+    );
   });
 
   it("does not cache a forced response after its selection ownership becomes stale", async () => {

--- a/apps/packages/product-client/src/hooks/access/anyharness/workspaces/use-workspace-bootstrap-cache.ts
+++ b/apps/packages/product-client/src/hooks/access/anyharness/workspaces/use-workspace-bootstrap-cache.ts
@@ -5,7 +5,7 @@ import {
   useAnyHarnessCacheScopeKey,
 } from "@anyharness/sdk-react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import {
   dismissSession,
   listWorkspaceSessions,
@@ -20,6 +20,12 @@ import {
 import {
   runTrackedReplacementDismissal,
 } from "#product/hooks/sessions/workflows/session-replacement-dismissals";
+import {
+  addReplacedSessionTombstoneCommitListener,
+} from "#product/hooks/sessions/workflows/session-replacement-tombstones";
+import {
+  pinWorkspaceSessionsQueryWarm,
+} from "#product/hooks/access/anyharness/workspaces/workspace-session-directory-keepalive";
 
 export type CacheDecision = "hit" | "stale" | "miss";
 
@@ -144,6 +150,19 @@ export function useWorkspaceBootstrapCache() {
   const queryClient = useQueryClient();
   const cacheScopeKey = useAnyHarnessCacheScopeKey();
 
+  // UX-latency R14: keep warm-pinned session-directory entries truthful. When a
+  // replaced session's tombstone durably commits, invalidate the affected
+  // workspace's sessions query so a warm entry cannot keep showing a retired
+  // session; default refetchType lets any live list observer revalidate
+  // immediately (founder ruling: not stale-tolerant, fetch immediately).
+  useEffect(() => {
+    return addReplacedSessionTombstoneCommitListener((workspaceId) => {
+      void queryClient.invalidateQueries({
+        queryKey: anyHarnessSessionsKey(cacheScopeKey, workspaceId),
+      });
+    });
+  }, [cacheScopeKey, queryClient]);
+
   const getWorkspaceSessionsCacheDecision = useCallback((
     workspaceId: string,
   ): CacheDecision => {
@@ -162,6 +181,28 @@ export function useWorkspaceBootstrapCache() {
     input: LoadWorkspaceSessionsInput,
   ): Promise<WorkspaceSession[]> => {
     const queryKey = anyHarnessSessionsKey(cacheScopeKey, input.workspaceId);
+    // UX-latency R14: pin this workspace's session query warm (bounded LRU) so
+    // an intra-run revisit finds it in cache instead of a cold miss.
+    pinWorkspaceSessionsQueryWarm(queryClient, queryKey);
+    const fetchAndSeed = async (): Promise<WorkspaceSession[]> => {
+      // Bootstrap/reconcile own workspace activation. Fetch directly instead of
+      // joining a possibly hung automatic session-list query triggered by
+      // selectedWorkspaceId subscribers, then seed React Query for those
+      // surfaces.
+      const sessions = await fetchWorkspaceSessionsWithConnection({
+        workspaceConnection: input.workspaceConnection,
+        workspaceId: input.workspaceId,
+        requestOptions: input.requestOptions,
+        timeoutMs: input.timeoutMs,
+        isResultOwned: input.isCurrent,
+      });
+      if (input.isCurrent?.() === false) {
+        return sessions;
+      }
+      queryClient.setQueryData(queryKey, sessions);
+      return sessions;
+    };
+
     const cacheState = queryClient.getQueryState(queryKey);
     const cachedSessions = queryClient.getQueryData<WorkspaceSession[]>(queryKey);
     if (
@@ -170,27 +211,19 @@ export function useWorkspaceBootstrapCache() {
       && cacheState?.dataUpdatedAt
       && !cacheState.isInvalidated
     ) {
-      // Cache hits are not authoritative and must never reconcile staged
-      // suppression into destructive cleanup. They still need filtering so an
-      // intentionally retained rollback record cannot be reselected/reingested.
+      // Warm serve for first paint. Founder ruling: NOT stale-tolerant SWR —
+      // kick an immediate background revalidation so the list stays genuinely
+      // up to date, but return the warm list without blocking first paint on
+      // the network. Cache hits are not authoritative and must never reconcile
+      // staged suppression into destructive cleanup, so the synchronous serve
+      // only filters (an intentionally retained rollback record must not be
+      // reselected/reingested); the background fetch does the authoritative
+      // reconcile.
+      void fetchAndSeed().catch(() => undefined);
       return filterReplacedSessionTombstones(input.workspaceId, cachedSessions) ?? [];
     }
 
-    // Bootstrap/reconcile own workspace activation. Fetch directly instead of
-    // joining a possibly hung automatic session-list query triggered by
-    // selectedWorkspaceId subscribers, then seed React Query for those surfaces.
-    const sessions = await fetchWorkspaceSessionsWithConnection({
-      workspaceConnection: input.workspaceConnection,
-      workspaceId: input.workspaceId,
-      requestOptions: input.requestOptions,
-      timeoutMs: input.timeoutMs,
-      isResultOwned: input.isCurrent,
-    });
-    if (input.isCurrent?.() === false) {
-      return sessions;
-    }
-    queryClient.setQueryData(queryKey, sessions);
-    return sessions;
+    return fetchAndSeed();
   }, [cacheScopeKey, queryClient]);
 
   return {

--- a/apps/packages/product-client/src/hooks/access/anyharness/workspaces/use-workspace-bootstrap-cache.ts
+++ b/apps/packages/product-client/src/hooks/access/anyharness/workspaces/use-workspace-bootstrap-cache.ts
@@ -22,7 +22,7 @@ import {
 } from "#product/hooks/sessions/workflows/session-replacement-dismissals";
 import {
   addReplacedSessionTombstoneCommitListener,
-} from "#product/hooks/sessions/workflows/session-replacement-tombstones";
+} from "#product/hooks/sessions/workflows/session-replacement-tombstone-listeners";
 import {
   pinWorkspaceSessionsQueryWarm,
 } from "#product/hooks/access/anyharness/workspaces/workspace-session-directory-keepalive";

--- a/apps/packages/product-client/src/hooks/access/anyharness/workspaces/workspace-session-directory-keepalive.test.ts
+++ b/apps/packages/product-client/src/hooks/access/anyharness/workspaces/workspace-session-directory-keepalive.test.ts
@@ -1,0 +1,62 @@
+import { QueryClient } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  MAX_WARM_WORKSPACE_SESSION_QUERIES,
+  pinWorkspaceSessionsQueryWarm,
+  resetWorkspaceSessionsWarmPinsForTest,
+  warmWorkspaceSessionsPinCountForTest,
+} from "#product/hooks/access/anyharness/workspaces/workspace-session-directory-keepalive";
+
+function key(workspaceId: string): string[] {
+  return ["sessions", workspaceId];
+}
+
+let queryClient: QueryClient;
+
+beforeEach(() => {
+  resetWorkspaceSessionsWarmPinsForTest();
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+});
+
+afterEach(() => {
+  resetWorkspaceSessionsWarmPinsForTest();
+  queryClient.clear();
+});
+
+describe("workspace session directory keep-alive", () => {
+  it("pins a seeded query so it survives garbage collection after seeding", () => {
+    queryClient.setQueryData(key("ws-1"), [{ id: "s1" }]);
+    pinWorkspaceSessionsQueryWarm(queryClient, key("ws-1"));
+
+    // gcTime is 0, so an unpinned query would be collected once observerless.
+    expect(queryClient.getQueryCache().find({ queryKey: key("ws-1") })).toBeDefined();
+    expect(warmWorkspaceSessionsPinCountForTest()).toBe(1);
+  });
+
+  it("bounds warm pins to the LRU limit, evicting least-recently-pinned", () => {
+    for (let i = 0; i < MAX_WARM_WORKSPACE_SESSION_QUERIES + 3; i += 1) {
+      queryClient.setQueryData(key(`ws-${i}`), [{ id: `s${i}` }]);
+      pinWorkspaceSessionsQueryWarm(queryClient, key(`ws-${i}`));
+    }
+    expect(warmWorkspaceSessionsPinCountForTest()).toBe(MAX_WARM_WORKSPACE_SESSION_QUERIES);
+  });
+
+  it("re-pinning refreshes recency instead of creating a second observer", () => {
+    for (let i = 0; i < MAX_WARM_WORKSPACE_SESSION_QUERIES; i += 1) {
+      queryClient.setQueryData(key(`ws-${i}`), [{ id: `s${i}` }]);
+      pinWorkspaceSessionsQueryWarm(queryClient, key(`ws-${i}`));
+    }
+    // Touch the oldest so it becomes most-recent.
+    pinWorkspaceSessionsQueryWarm(queryClient, key("ws-0"));
+    // Add one more: the now-oldest (ws-1) is evicted, ws-0 survives.
+    queryClient.setQueryData(key("ws-new"), [{ id: "sn" }]);
+    pinWorkspaceSessionsQueryWarm(queryClient, key("ws-new"));
+
+    expect(warmWorkspaceSessionsPinCountForTest()).toBe(MAX_WARM_WORKSPACE_SESSION_QUERIES);
+    // ws-0 was re-pinned so it must still be observed (not garbage-collected).
+    expect(queryClient.getQueryCache().find({ queryKey: key("ws-0") })?.getObserversCount())
+      .toBeGreaterThan(0);
+    expect(queryClient.getQueryCache().find({ queryKey: key("ws-1") })?.getObserversCount() ?? 0)
+      .toBe(0);
+  });
+});

--- a/apps/packages/product-client/src/hooks/access/anyharness/workspaces/workspace-session-directory-keepalive.ts
+++ b/apps/packages/product-client/src/hooks/access/anyharness/workspaces/workspace-session-directory-keepalive.ts
@@ -1,0 +1,98 @@
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
+import { QueryObserver } from "@tanstack/react-query";
+
+/**
+ * UX-latency R14: bounded keep-alive for the workspace session-directory query.
+ *
+ * MEASURED PROBLEM: the anyHarnessSessionsKey react-query entry is seeded with
+ * setQueryData, loses its last observer the moment the user navigates away, and
+ * is garbage-collected — so every revisit was a cold cache MISS (14 miss / 3 hit
+ * live), each paying a full session-list network round trip on the
+ * workspace-switch critical path.
+ *
+ * FIX: pin the last N visited workspace session queries with a disabled
+ * QueryObserver. A query with at least one observer is never garbage-collected,
+ * so an intra-run revisit finds the entry warm and getWorkspaceSessionsCacheDecision
+ * truthfully reports "hit". The pin is DISABLED (enabled: false) so it never
+ * fetches on its own — the bootstrap still owns fetching/revalidation. This is
+ * NOT stale-tolerant SWR: the warm entry is served for first paint and the
+ * bootstrap revalidates immediately (see loadWorkspaceSessions).
+ *
+ * MEMORY BOUND: an LRU of exactly MAX_WARM_WORKSPACE_SESSION_QUERIES pins. When a
+ * new workspace is pinned past the bound, the least-recently-pinned observer is
+ * destroyed, which drops its subscription and lets that query resume the normal
+ * gcTime countdown — so at most N session-list payloads are retained.
+ */
+
+export const MAX_WARM_WORKSPACE_SESSION_QUERIES = 5;
+
+interface WarmPin {
+  observer: QueryObserver;
+  unsubscribe: () => void;
+}
+
+// Insertion order in a Map is LRU order: re-pinning deletes+reinserts to move an
+// entry to the most-recently-used end.
+const warmPins = new Map<string, WarmPin>();
+
+function pinCacheKey(queryKey: QueryKey): string {
+  return JSON.stringify(queryKey);
+}
+
+function destroyPin(pin: WarmPin): void {
+  pin.unsubscribe();
+  pin.observer.destroy();
+}
+
+/**
+ * Keep `queryKey` warm (not garbage-collected) as one of the most-recently
+ * visited N workspace session queries. Idempotent per key; re-pinning refreshes
+ * LRU recency without creating a second observer.
+ */
+export function pinWorkspaceSessionsQueryWarm(
+  queryClient: QueryClient,
+  queryKey: QueryKey,
+): void {
+  const cacheKey = pinCacheKey(queryKey);
+  const existing = warmPins.get(cacheKey);
+  if (existing) {
+    warmPins.delete(cacheKey);
+    warmPins.set(cacheKey, existing);
+    return;
+  }
+
+  const observer = new QueryObserver(queryClient, {
+    queryKey,
+    // Never fetch from the pin itself; it exists only to retain the entry. The
+    // bootstrap remains the single owner of fetching and revalidation.
+    enabled: false,
+    // Do not let the pin mark data stale or schedule background refetches.
+    staleTime: Number.POSITIVE_INFINITY,
+    notifyOnChangeProps: [],
+  });
+  const unsubscribe = observer.subscribe(() => {});
+  warmPins.set(cacheKey, { observer, unsubscribe });
+
+  while (warmPins.size > MAX_WARM_WORKSPACE_SESSION_QUERIES) {
+    const oldestKey = warmPins.keys().next().value as string | undefined;
+    if (oldestKey === undefined) {
+      break;
+    }
+    const oldestPin = warmPins.get(oldestKey);
+    warmPins.delete(oldestKey);
+    if (oldestPin) {
+      destroyPin(oldestPin);
+    }
+  }
+}
+
+export function resetWorkspaceSessionsWarmPinsForTest(): void {
+  for (const pin of warmPins.values()) {
+    destroyPin(pin);
+  }
+  warmPins.clear();
+}
+
+export function warmWorkspaceSessionsPinCountForTest(): number {
+  return warmPins.size;
+}

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-history-hydration-dedupe.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-history-hydration-dedupe.ts
@@ -1,0 +1,56 @@
+/**
+ * UX-latency R14: in-flight dedupe for full session-open (non-incremental)
+ * hydrations, keyed by session id.
+ *
+ * Two callers can now race for the same session's transcript — the
+ * workspace-open bootstrap fires a fire-and-forget kickoff (hydration moved off
+ * the critical path) and SessionTranscriptPane's self-hydration effect fires
+ * independently. Without dedupe both would fetch AND both would apply history
+ * to the stores and emit the session_open flow marks twice. Sharing the whole
+ * operation (fetch + replay + store + marks) guarantees exactly one fetch and
+ * one apply; the second caller receives the first caller's result.
+ *
+ * Only full opens dedupe — incremental append/prepend fetches (afterSeq/
+ * beforeSeq) target different ranges and must not share.
+ *
+ * Extracted from use-session-history-hydration.ts to keep that hook under the
+ * frontend-structure line threshold.
+ */
+const inFlightSessionOpenHydrations = new Map<string, Promise<boolean>>();
+
+interface SessionOpenDedupeOptions {
+  afterSeq?: number;
+  beforeSeq?: number;
+}
+
+/**
+ * Runs `run` under the session-open dedupe when the options describe a full
+ * open; otherwise runs it directly (incremental fetches are never shared).
+ */
+export function dedupeSessionOpenHydration(
+  sessionId: string,
+  options: SessionOpenDedupeOptions | undefined,
+  run: () => Promise<boolean>,
+): Promise<boolean> {
+  const isSessionOpenHydration =
+    (options?.afterSeq ?? null) === null && (options?.beforeSeq ?? null) === null;
+  if (!isSessionOpenHydration) {
+    return run();
+  }
+  const inFlight = inFlightSessionOpenHydrations.get(sessionId);
+  if (inFlight) {
+    return inFlight;
+  }
+  const promise = run();
+  inFlightSessionOpenHydrations.set(sessionId, promise);
+  void promise.finally(() => {
+    if (inFlightSessionOpenHydrations.get(sessionId) === promise) {
+      inFlightSessionOpenHydrations.delete(sessionId);
+    }
+  });
+  return promise;
+}
+
+export function resetSessionHistoryHydrationInFlightForTest(): void {
+  inFlightSessionOpenHydrations.clear();
+}

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-history-hydration-helpers.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-history-hydration-helpers.ts
@@ -10,6 +10,7 @@ import {
   recordMeasurementMetric,
   recordMeasurementWorkflowStep,
 } from "#product/lib/infra/measurement/measurement-port";
+import { fetchSessionHistory } from "#product/lib/access/anyharness/session-runtime";
 import { recordSessionHistoryRehydrateFailure } from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations";
 import { safeRendererErrorName } from "#product/lib/infra/diagnostics/renderer-diagnostic-values";
 import type {
@@ -37,6 +38,45 @@ export const SESSION_APPLY_MEASUREMENT_SURFACES: readonly MeasurementSurface[] =
   "chat-composer-dock",
 ];
 export const SESSION_HISTORY_APPLY_MAX_DURATION_MS = 30_000;
+
+type FetchSessionHistoryArgs = Parameters<typeof fetchSessionHistory>[1];
+
+/**
+ * Assembles the `fetchSessionHistory` request options. Only the fields the
+ * caller actually supplied are included so a bare open still sends just the
+ * connection handles.
+ */
+export function buildSessionHistoryFetchArgs(params: {
+  afterSeq?: number;
+  beforeSeq?: number;
+  limit?: number;
+  turnLimit?: number;
+  requestHeaders?: HeadersInit;
+  measurementOperationId?: MeasurementOperationId | null;
+  timeoutMs?: number;
+  ssh: NonNullable<FetchSessionHistoryArgs>["ssh"];
+  cloudClient: NonNullable<FetchSessionHistoryArgs>["cloudClient"];
+}): FetchSessionHistoryArgs {
+  const { afterSeq, beforeSeq, limit, turnLimit, requestHeaders } = params;
+  const { measurementOperationId, timeoutMs, ssh, cloudClient } = params;
+  if (
+    afterSeq == null && beforeSeq == null && limit == null && turnLimit == null
+    && !requestHeaders && !measurementOperationId && timeoutMs == null
+  ) {
+    return { ssh, cloudClient };
+  }
+  return {
+    ...(afterSeq != null ? { afterSeq } : {}),
+    ...(beforeSeq != null ? { beforeSeq } : {}),
+    ...(limit != null ? { limit } : {}),
+    ...(turnLimit != null ? { turnLimit } : {}),
+    ...(requestHeaders ? { requestHeaders } : {}),
+    ...(measurementOperationId ? { measurementOperationId } : {}),
+    ...(timeoutMs != null ? { timeoutMs } : {}),
+    ssh,
+    cloudClient,
+  };
+}
 
 export function isSessionHistoryTimeoutAbort(error: unknown): boolean {
   return error instanceof Error

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-history-hydration.test.tsx
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-history-hydration.test.tsx
@@ -4,10 +4,10 @@ import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEventEnvelope } from "@anyharness/sdk";
 import { replaySessionHistory } from "#product/lib/domain/sessions/stream/stream-state";
+import { useSessionHistoryHydration } from "#product/hooks/sessions/lifecycle/use-session-history-hydration";
 import {
   resetSessionHistoryHydrationInFlightForTest,
-  useSessionHistoryHydration,
-} from "#product/hooks/sessions/lifecycle/use-session-history-hydration";
+} from "#product/hooks/sessions/lifecycle/session-history-hydration-dedupe";
 import {
   createEmptySessionRecord,
   getSessionRecord,

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-history-hydration.test.tsx
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-history-hydration.test.tsx
@@ -4,7 +4,10 @@ import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEventEnvelope } from "@anyharness/sdk";
 import { replaySessionHistory } from "#product/lib/domain/sessions/stream/stream-state";
-import { useSessionHistoryHydration } from "#product/hooks/sessions/lifecycle/use-session-history-hydration";
+import {
+  resetSessionHistoryHydrationInFlightForTest,
+  useSessionHistoryHydration,
+} from "#product/hooks/sessions/lifecycle/use-session-history-hydration";
 import {
   createEmptySessionRecord,
   getSessionRecord,
@@ -36,6 +39,7 @@ vi.mock("#product/hooks/sessions/lifecycle/use-session-history-subagent-authorit
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resetSessionHistoryHydrationInFlightForTest();
   useSessionDirectoryStore.getState().clearEntries();
   useSessionIntentStore.getState().clear();
   useSessionTranscriptStore.getState().clearEntries();
@@ -92,6 +96,60 @@ describe("useSessionHistoryHydration subagent authority", () => {
     expect(retryResult).toBe(true);
     expect(mocks.reconcileHydratedSubagents).toHaveBeenCalledTimes(2);
     expect(mocks.reconcileHydratedSubagents.mock.calls[1]?.[0].transcript.lastSeq).toBe(2);
+  });
+});
+
+describe("useSessionHistoryHydration session-open dedupe", () => {
+  it("collapses two concurrent full hydrations of a session into one fetch", async () => {
+    putSessionRecord(createEmptySessionRecord("session-1", "codex", {
+      workspaceId: "workspace-1",
+    }));
+    let resolveFetch!: (events: SessionEventEnvelope[]) => void;
+    mocks.fetchSessionHistory.mockReturnValueOnce(
+      new Promise<SessionEventEnvelope[]>((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+    mocks.reconcileHydratedSubagents.mockResolvedValue(true);
+    const rendered = renderHook(() => useSessionHistoryHydration());
+
+    let results: [boolean, boolean] = [false, false];
+    await act(async () => {
+      // Bootstrap kickoff and the transcript pane both hydrate the same session
+      // while the first fetch is still in flight.
+      const first = rendered.result.current.rehydrateSessionSlotFromHistory(
+        "session-1",
+        { replace: true },
+      );
+      const second = rendered.result.current.rehydrateSessionSlotFromHistory(
+        "session-1",
+        { replace: true },
+      );
+      resolveFetch([turnStarted(1), turnEnded(2)]);
+      results = await Promise.all([first, second]);
+    });
+
+    expect(mocks.fetchSessionHistory).toHaveBeenCalledTimes(1);
+    expect(results).toEqual([true, true]);
+  });
+
+  it("does not dedupe incremental (afterSeq/beforeSeq) fetches", async () => {
+    const initial = replaySessionHistory("session-1", [turnStarted(1)]);
+    putSessionRecord({
+      ...createEmptySessionRecord("session-1", "codex", { workspaceId: "workspace-1" }),
+      events: initial.events,
+      transcript: initial.transcript,
+    });
+    mocks.fetchSessionHistory.mockResolvedValue([turnEnded(2)]);
+    mocks.reconcileHydratedSubagents.mockResolvedValue(true);
+    const rendered = renderHook(() => useSessionHistoryHydration());
+
+    await act(async () => {
+      await rendered.result.current.rehydrateSessionSlotFromHistory("session-1", { afterSeq: 1 });
+      await rendered.result.current.rehydrateSessionSlotFromHistory("session-1", { afterSeq: 1 });
+    });
+
+    expect(mocks.fetchSessionHistory).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-history-hydration.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-history-hydration.ts
@@ -22,6 +22,7 @@ import { fetchSessionHistory } from "#product/lib/access/anyharness/session-runt
 import { getSessionRecord } from "#product/stores/sessions/session-records";
 import {
   applyHistoryStateToStores,
+  buildSessionHistoryFetchArgs,
   finishStandaloneApplyOperation,
   recordHistoryApplyStepMetrics,
   recordHistoryStateCounts,
@@ -31,6 +32,7 @@ import {
   SESSION_HISTORY_APPLY_MAX_DURATION_MS,
 } from "#product/hooks/sessions/lifecycle/session-history-hydration-helpers";
 import { useSessionHistorySubagentAuthority } from "#product/hooks/sessions/lifecycle/use-session-history-subagent-authority";
+import { dedupeSessionOpenHydration } from "#product/hooks/sessions/lifecycle/session-history-hydration-dedupe";
 import {
   beginRendererFlow,
   finishRendererFlow,
@@ -44,25 +46,6 @@ import {
   buildSessionOpenShellCommittedParams,
   markSessionOpenFlowAbandoned,
 } from "#product/hooks/sessions/lifecycle/session-open-flow-marks";
-
-/**
- * UX-latency R14: in-flight dedupe for full session-open (non-incremental)
- * hydrations, keyed by session id. Two callers can now race for the same
- * session's transcript — the workspace-open bootstrap fires a fire-and-forget
- * kickoff (hydration moved off the critical path) and SessionTranscriptPane's
- * self-hydration effect fires independently. Without dedupe both would fetch
- * AND both would apply history to the stores and emit the session_open flow
- * marks twice. Sharing the whole operation (fetch + replay + store + marks)
- * guarantees exactly one fetch and one apply; the second caller receives the
- * first caller's result. Only full opens dedupe here — incremental
- * append/prepend fetches (afterSeq/beforeSeq) target different ranges and must
- * not share.
- */
-const inFlightSessionOpenHydrations = new Map<string, Promise<boolean>>();
-
-export function resetSessionHistoryHydrationInFlightForTest(): void {
-  inFlightSessionOpenHydrations.clear();
-}
 
 export interface SessionHistoryHydrationOptions {
   afterSeq?: number;
@@ -136,29 +119,17 @@ export function useSessionHistoryHydration() {
       const fetchStartedAt = performance.now();
       const events = await fetchSessionHistory(
         sessionId,
-        afterSeq != null
-          || beforeSeq != null
-          || options?.limit != null
-          || options?.turnLimit != null
-          || options?.requestHeaders
-          || requestMeasurementOperationId
-          || options?.timeoutMs != null
-          ? {
-            ...(afterSeq != null ? { afterSeq } : {}),
-            ...(beforeSeq != null ? { beforeSeq } : {}),
-            ...(options?.limit != null ? { limit: options.limit } : {}),
-            ...(options?.turnLimit != null ? { turnLimit: options.turnLimit } : {}),
-            ...(options?.requestHeaders
-              ? { requestHeaders: options.requestHeaders }
-              : {}),
-            ...(requestMeasurementOperationId
-              ? { measurementOperationId: requestMeasurementOperationId }
-              : {}),
-            ...(options?.timeoutMs != null ? { timeoutMs: options.timeoutMs } : {}),
-            ssh,
-            cloudClient,
-          }
-          : { ssh, cloudClient },
+        buildSessionHistoryFetchArgs({
+          afterSeq,
+          beforeSeq,
+          limit: options?.limit,
+          turnLimit: options?.turnLimit,
+          requestHeaders: options?.requestHeaders,
+          measurementOperationId: requestMeasurementOperationId,
+          timeoutMs: options?.timeoutMs,
+          ssh,
+          cloudClient,
+        }),
       );
       for (const operationId of historyApplyOperationIds) {
         recordMeasurementWorkflowStep({
@@ -412,29 +383,16 @@ export function useSessionHistoryHydration() {
     }
   }, [cloudClient, reconcileHydratedSubagents, ssh]);
 
+  // UX-latency R14: full session-open hydrations dedupe by session id so the
+  // bootstrap kickoff and the transcript pane share one fetch + apply.
   const rehydrateSessionSlotFromHistory = useCallback((
     sessionId: string,
     options?: SessionHistoryHydrationOptions,
-  ): Promise<boolean> => {
-    // Only full session-open hydrations dedupe (see inFlightSessionOpenHydrations).
-    const isSessionOpenHydration =
-      (options?.afterSeq ?? null) === null && (options?.beforeSeq ?? null) === null;
-    if (!isSessionOpenHydration) {
-      return runHydration(sessionId, options);
-    }
-    const inFlight = inFlightSessionOpenHydrations.get(sessionId);
-    if (inFlight) {
-      return inFlight;
-    }
-    const promise = runHydration(sessionId, options);
-    inFlightSessionOpenHydrations.set(sessionId, promise);
-    void promise.finally(() => {
-      if (inFlightSessionOpenHydrations.get(sessionId) === promise) {
-        inFlightSessionOpenHydrations.delete(sessionId);
-      }
-    });
-    return promise;
-  }, [runHydration]);
+  ): Promise<boolean> => dedupeSessionOpenHydration(
+    sessionId,
+    options,
+    () => runHydration(sessionId, options),
+  ), [runHydration]);
 
   return {
     rehydrateSessionSlotFromHistory,

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-history-hydration.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-history-hydration.ts
@@ -45,6 +45,25 @@ import {
   markSessionOpenFlowAbandoned,
 } from "#product/hooks/sessions/lifecycle/session-open-flow-marks";
 
+/**
+ * UX-latency R14: in-flight dedupe for full session-open (non-incremental)
+ * hydrations, keyed by session id. Two callers can now race for the same
+ * session's transcript — the workspace-open bootstrap fires a fire-and-forget
+ * kickoff (hydration moved off the critical path) and SessionTranscriptPane's
+ * self-hydration effect fires independently. Without dedupe both would fetch
+ * AND both would apply history to the stores and emit the session_open flow
+ * marks twice. Sharing the whole operation (fetch + replay + store + marks)
+ * guarantees exactly one fetch and one apply; the second caller receives the
+ * first caller's result. Only full opens dedupe here — incremental
+ * append/prepend fetches (afterSeq/beforeSeq) target different ranges and must
+ * not share.
+ */
+const inFlightSessionOpenHydrations = new Map<string, Promise<boolean>>();
+
+export function resetSessionHistoryHydrationInFlightForTest(): void {
+  inFlightSessionOpenHydrations.clear();
+}
+
 export interface SessionHistoryHydrationOptions {
   afterSeq?: number;
   beforeSeq?: number;
@@ -67,7 +86,7 @@ export function useSessionHistoryHydration() {
   const cloudClient = host.cloud.client;
   const reconcileHydratedSubagents = useSessionHistorySubagentAuthority();
 
-  const rehydrateSessionSlotFromHistory = useCallback(async (
+  const runHydration = useCallback(async (
     sessionId: string,
     options?: SessionHistoryHydrationOptions,
   ): Promise<boolean> => {
@@ -392,6 +411,30 @@ export function useSessionHistoryHydration() {
       return false;
     }
   }, [cloudClient, reconcileHydratedSubagents, ssh]);
+
+  const rehydrateSessionSlotFromHistory = useCallback((
+    sessionId: string,
+    options?: SessionHistoryHydrationOptions,
+  ): Promise<boolean> => {
+    // Only full session-open hydrations dedupe (see inFlightSessionOpenHydrations).
+    const isSessionOpenHydration =
+      (options?.afterSeq ?? null) === null && (options?.beforeSeq ?? null) === null;
+    if (!isSessionOpenHydration) {
+      return runHydration(sessionId, options);
+    }
+    const inFlight = inFlightSessionOpenHydrations.get(sessionId);
+    if (inFlight) {
+      return inFlight;
+    }
+    const promise = runHydration(sessionId, options);
+    inFlightSessionOpenHydrations.set(sessionId, promise);
+    void promise.finally(() => {
+      if (inFlightSessionOpenHydrations.get(sessionId) === promise) {
+        inFlightSessionOpenHydrations.delete(sessionId);
+      }
+    });
+    return promise;
+  }, [runHydration]);
 
   return {
     rehydrateSessionSlotFromHistory,

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-tombstone-listeners.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-tombstone-listeners.ts
@@ -1,0 +1,34 @@
+/**
+ * UX-latency R14: listeners notified when a replaced-session tombstone durably
+ * commits, so warm-kept session-directory query entries can be invalidated and
+ * refreshed. Before R14 the sessions query was garbage-collected on navigate
+ * away, so a stale warm entry could never outlive a replacement; now that the
+ * last N visited entries are pinned (workspace-session-directory-keepalive.ts),
+ * a committed replacement must invalidate the pinned entry so it can never keep
+ * showing a retired session.
+ *
+ * Kept in its own module so session-replacement-tombstones.ts stays under the
+ * frontend-structure line threshold.
+ */
+type ReplacedSessionTombstoneCommitListener = (workspaceId: string) => void;
+
+const tombstoneCommitListeners = new Set<ReplacedSessionTombstoneCommitListener>();
+
+export function addReplacedSessionTombstoneCommitListener(
+  listener: ReplacedSessionTombstoneCommitListener,
+): () => void {
+  tombstoneCommitListeners.add(listener);
+  return () => {
+    tombstoneCommitListeners.delete(listener);
+  };
+}
+
+export function notifyReplacedSessionTombstoneCommitted(workspaceId: string): void {
+  for (const listener of tombstoneCommitListeners) {
+    listener(workspaceId);
+  }
+}
+
+export function clearReplacedSessionTombstoneCommitListeners(): void {
+  tombstoneCommitListeners.clear();
+}

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-tombstones.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-tombstones.ts
@@ -32,6 +32,31 @@ const retiredSuppressionByWorkspaceId = new Map<string, WorkspaceTombstones>();
 const retiredClientAliasesByWorkspaceId = new Map<string, Set<string>>();
 let latestCommittedGeneration = 0;
 
+// UX-latency R14: notify listeners when a replaced-session tombstone durably
+// commits, so warm-kept session-directory query entries can be invalidated and
+// refreshed. Before R14 the sessions query was garbage-collected on navigate
+// away, so a stale warm entry could never outlive a replacement; now that we
+// pin the last N visited entries (workspace-session-directory-keepalive.ts), a
+// committed replacement must invalidate the pinned entry so it can never keep
+// showing a retired session.
+type ReplacedSessionTombstoneCommitListener = (workspaceId: string) => void;
+const tombstoneCommitListeners = new Set<ReplacedSessionTombstoneCommitListener>();
+
+export function addReplacedSessionTombstoneCommitListener(
+  listener: ReplacedSessionTombstoneCommitListener,
+): () => void {
+  tombstoneCommitListeners.add(listener);
+  return () => {
+    tombstoneCommitListeners.delete(listener);
+  };
+}
+
+function notifyReplacedSessionTombstoneCommitted(workspaceId: string): void {
+  for (const listener of tombstoneCommitListeners) {
+    listener(workspaceId);
+  }
+}
+
 export function stageReplacedClientSessionAlias(
   workspaceId: string,
   sessionId: string,
@@ -103,6 +128,7 @@ export function commitReplacedSessionTombstone(
   removeEntry(stagedByWorkspaceId, workspaceId, runtimeSessionId);
   replaceTombstoneSource(committedByWorkspaceId, nextCommitted);
   latestCommittedGeneration = commitGeneration;
+  notifyReplacedSessionTombstoneCommitted(workspaceId);
   return true;
 }
 
@@ -283,6 +309,7 @@ export function resetReplacedSessionTombstonesForTests(): void {
   retiredSuppressionByWorkspaceId.clear();
   retiredClientAliasesByWorkspaceId.clear();
   latestCommittedGeneration = 0;
+  tombstoneCommitListeners.clear();
   persistCommittedTombstones();
 }
 

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-tombstones.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-tombstones.ts
@@ -2,6 +2,10 @@ import {
   type PersistedSessionReplacementTombstones,
   writeSessionReplacementTombstones,
 } from "#product/lib/access/persistence/session-replacement-tombstones-storage";
+import {
+  clearReplacedSessionTombstoneCommitListeners,
+  notifyReplacedSessionTombstoneCommitted,
+} from "#product/hooks/sessions/workflows/session-replacement-tombstone-listeners";
 
 type SessionIdentity = { id: string };
 
@@ -31,31 +35,6 @@ const committedByWorkspaceId = new Map<string, WorkspaceTombstones>();
 const retiredSuppressionByWorkspaceId = new Map<string, WorkspaceTombstones>();
 const retiredClientAliasesByWorkspaceId = new Map<string, Set<string>>();
 let latestCommittedGeneration = 0;
-
-// UX-latency R14: notify listeners when a replaced-session tombstone durably
-// commits, so warm-kept session-directory query entries can be invalidated and
-// refreshed. Before R14 the sessions query was garbage-collected on navigate
-// away, so a stale warm entry could never outlive a replacement; now that we
-// pin the last N visited entries (workspace-session-directory-keepalive.ts), a
-// committed replacement must invalidate the pinned entry so it can never keep
-// showing a retired session.
-type ReplacedSessionTombstoneCommitListener = (workspaceId: string) => void;
-const tombstoneCommitListeners = new Set<ReplacedSessionTombstoneCommitListener>();
-
-export function addReplacedSessionTombstoneCommitListener(
-  listener: ReplacedSessionTombstoneCommitListener,
-): () => void {
-  tombstoneCommitListeners.add(listener);
-  return () => {
-    tombstoneCommitListeners.delete(listener);
-  };
-}
-
-function notifyReplacedSessionTombstoneCommitted(workspaceId: string): void {
-  for (const listener of tombstoneCommitListeners) {
-    listener(workspaceId);
-  }
-}
 
 export function stageReplacedClientSessionAlias(
   workspaceId: string,
@@ -309,7 +288,7 @@ export function resetReplacedSessionTombstonesForTests(): void {
   retiredSuppressionByWorkspaceId.clear();
   retiredClientAliasesByWorkspaceId.clear();
   latestCommittedGeneration = 0;
-  tombstoneCommitListeners.clear();
+  clearReplacedSessionTombstoneCommitListeners();
   persistCommittedTombstones();
 }
 

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts
@@ -17,13 +17,11 @@ import {
   startLatencyTimer,
 } from "#product/lib/infra/measurement/measurement-port";
 import {
-  abandonRendererFlow,
   beginRendererFlow,
-  deferWorkspaceOpenContentStable,
-  finishRendererFlow,
   markRendererFlowDataReady,
   markRendererFlowShellCommitted,
 } from "#product/lib/infra/diagnostics/renderer-flow-timing";
+import { finishWorkspaceOpenRendererFlow } from "#product/hooks/workspaces/workflows/workspace-open-flow-finish";
 import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store";
 import {
   clearLastViewedSession,
@@ -368,24 +366,13 @@ export function useWorkspaceBootstrapActions() {
       }
       return { sessions };
     } finally {
-      if (rendererFlowAbandonReason !== null) {
-        abandonRendererFlow({
-          kind: "workspace_open",
-          correlationKey: workspaceId,
-          reason: rendererFlowAbandonReason,
-        });
-      } else if (deferContentStableSessionId !== null) {
-        // Transcript hydration moved off the critical path (R14): the pane
-        // finishes this flow when the selected session's transcript commits.
-        // Emitting content_stable here would lie — the transcript is not yet
-        // on screen. Never emit a stable mark before the user can see it.
-        deferWorkspaceOpenContentStable({
-          sessionId: deferContentStableSessionId,
-          correlationKey: workspaceId,
-        });
-      } else {
-        finishRendererFlow({ kind: "workspace_open", correlationKey: workspaceId });
-      }
+      // UX-latency R14: abandon, defer content_stable to the transcript pane, or
+      // finish now (empty workspace). See finishWorkspaceOpenRendererFlow.
+      finishWorkspaceOpenRendererFlow({
+        workspaceId,
+        abandonReason: rendererFlowAbandonReason,
+        deferContentStableSessionId,
+      });
     }
   }, [
     applySessionSummary,

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts
@@ -19,6 +19,7 @@ import {
 import {
   abandonRendererFlow,
   beginRendererFlow,
+  deferWorkspaceOpenContentStable,
   finishRendererFlow,
   markRendererFlowDataReady,
   markRendererFlowShellCommitted,
@@ -124,6 +125,12 @@ export function useWorkspaceBootstrapActions() {
     // abandon (the truthful replacement for the old cancelLatencyFlow staleness
     // signal). Superseded/stale exits set this so no false content_stable fires.
     let rendererFlowAbandonReason: string | null = null;
+    // UX-latency R14: when set, content_stable is DEFERRED to the transcript
+    // pane (the session whose committed transcript is the real stable signal),
+    // so the finally must neither finish nor abandon the flow — it hands the
+    // mark off. Null => finish/abandon here as before (empty workspace, error,
+    // stale: no transcript to wait for).
+    let deferContentStableSessionId: string | null = null;
     let sessions: WorkspaceSession[] = [];
     // UX-latency R1 canonical flow marks (intent -> shell -> data -> stable).
     // COVERAGE LIMIT (honest): this intent mark fires here, after the caller
@@ -330,6 +337,9 @@ export function useWorkspaceBootstrapActions() {
           setActiveSessionId: (sessionId) =>
             useSessionSelectionStore.getState().setActiveSessionId(sessionId),
         });
+        if (rememberedBootstrap.contentStableSessionId) {
+          deferContentStableSessionId = rememberedBootstrap.contentStableSessionId;
+        }
         if (rememberedBootstrap.shouldReturn) {
           return { sessions };
         }
@@ -358,14 +368,23 @@ export function useWorkspaceBootstrapActions() {
       }
       return { sessions };
     } finally {
-      if (rendererFlowAbandonReason === null) {
-        finishRendererFlow({ kind: "workspace_open", correlationKey: workspaceId });
-      } else {
+      if (rendererFlowAbandonReason !== null) {
         abandonRendererFlow({
           kind: "workspace_open",
           correlationKey: workspaceId,
           reason: rendererFlowAbandonReason,
         });
+      } else if (deferContentStableSessionId !== null) {
+        // Transcript hydration moved off the critical path (R14): the pane
+        // finishes this flow when the selected session's transcript commits.
+        // Emitting content_stable here would lie — the transcript is not yet
+        // on screen. Never emit a stable mark before the user can see it.
+        deferWorkspaceOpenContentStable({
+          sessionId: deferContentStableSessionId,
+          correlationKey: workspaceId,
+        });
+      } else {
+        finishRendererFlow({ kind: "workspace_open", correlationKey: workspaceId });
       }
     }
   }, [

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/workspace-bootstrap-remembered-session.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/workspace-bootstrap-remembered-session.test.ts
@@ -102,4 +102,46 @@ describe("handleRememberedWorkspaceSessionBootstrap", () => {
     expect(setActiveSessionId).not.toHaveBeenCalledWith(null);
     expect(removeSessionRecord).toHaveBeenCalledWith(setupSessionId);
   });
+
+  it("finishes without awaiting transcript hydration and hands the content_stable session to the pane", async () => {
+    // R14: session selection stays on the critical path; the history fetch does
+    // not. This resolves even though rehydration never settles.
+    vi.mocked(selectSessionWithShellIntentRollback).mockResolvedValueOnce(undefined);
+    let hydrationSettled = false;
+    const rehydrateSessionSlotFromHistory = vi.fn(
+      () => new Promise<boolean>(() => {
+        // Deliberately never resolves within the test.
+        hydrationSettled = true;
+      }),
+    );
+    const patchSessionRecord = vi.fn();
+
+    const result = await handleRememberedWorkspaceSessionBootstrap({
+      lastViewedSessionByWorkspace: { "logical-workspace-1": "session-1" },
+      latencyFlowId: null,
+      logicalWorkspaceId: "logical-workspace-1",
+      measurementOperationId: null,
+      sessions: [session("session-1")],
+      startedAt: performance.now(),
+      workspaceId: "workspace-1",
+      isCurrent: () => true,
+    }, {
+      clearLastViewedSession: vi.fn(),
+      getActiveSessionId: () => null,
+      getSessionRecord: vi.fn(),
+      patchSessionRecord,
+      rehydrateSessionSlotFromHistory: rehydrateSessionSlotFromHistory as never,
+      removeSessionRecord: vi.fn(),
+      selectSession: vi.fn() as never,
+      setActiveSessionId: vi.fn(),
+    });
+
+    expect(result.shouldReturn).toBe(false);
+    expect(result.contentStableSessionId).toBe("session-1");
+    // Hydration was kicked off (fire-and-forget) but never awaited: the record
+    // is not patched hydrated synchronously, since the fetch has not resolved.
+    expect(rehydrateSessionSlotFromHistory).toHaveBeenCalledTimes(1);
+    expect(hydrationSettled).toBe(true);
+    expect(patchSessionRecord).not.toHaveBeenCalled();
+  });
 });

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/workspace-bootstrap-remembered-session.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/workspace-bootstrap-remembered-session.ts
@@ -8,7 +8,6 @@ import {
 import {
   elapsedMs,
   logLatency,
-  startLatencyTimer,
 } from "#product/lib/infra/measurement/measurement-port";
 import {
   recordMeasurementWorkflowStep,
@@ -44,7 +43,7 @@ export async function handleRememberedWorkspaceSessionBootstrap(
     selectSession: ReturnType<typeof useSessionSelectionActions>["selectSession"];
     setActiveSessionId: (sessionId: string | null) => void;
   },
-): Promise<{ shouldReturn: boolean }> {
+): Promise<{ shouldReturn: boolean; contentStableSessionId?: string }> {
   const rememberedSession = resolveLastViewedSessionForWorkspace(
     input.lastViewedSessionByWorkspace,
     input.logicalWorkspaceId,
@@ -113,23 +112,31 @@ export async function handleRememberedWorkspaceSessionBootstrap(
     step: "workspace.bootstrap.session_select",
     startedAt: sessionSelectStartedAt,
   });
-  const hydrateStartedAt = startLatencyTimer();
-  await deps.rehydrateSessionSlotFromHistory(targetSession.id, {
+  // UX-latency R14: transcript hydration is OFF the workspace-switch critical
+  // path. Session selection above stays on it, but the history fetch does not:
+  // we kick rehydration fire-and-forget (never awaited) so bootstrap can finish
+  // the non-transcript work immediately. SessionTranscriptPane's own
+  // self-hydration effect owns the transcript for the selected session; the
+  // in-flight dedupe in use-session-history-hydration collapses this kickoff and
+  // the pane's fetch into a single request. This kickoff exists so hydration
+  // starts the instant the session is selected (even before the pane mounts) and
+  // so transcriptHydrated is set on the record even if this fetch wins the race
+  // and the pane's effect returns early.
+  void Promise.resolve(deps.rehydrateSessionSlotFromHistory(targetSession.id, {
     replace: true,
     requestHeaders: input.requestHeaders,
     measurementOperationId: input.measurementOperationId,
     isCurrent: () =>
       input.isCurrent()
       && deps.getActiveSessionId() === targetSession.id,
-  });
-  if (!input.isCurrent()) {
-    return { shouldReturn: true };
-  }
-  deps.patchSessionRecord(targetSession.id, { transcriptHydrated: true });
-  recordMeasurementWorkflowStep({
-    operationId: input.measurementOperationId,
-    step: "session.select.history_hydrate",
-    startedAt: hydrateStartedAt,
+  })).then((hydrated) => {
+    if (
+      hydrated
+      && input.isCurrent()
+      && deps.getActiveSessionId() === targetSession.id
+    ) {
+      deps.patchSessionRecord(targetSession.id, { transcriptHydrated: true });
+    }
   });
   logLatency("workspace.select.success", {
     workspaceId: input.workspaceId,
@@ -137,5 +144,8 @@ export async function handleRememberedWorkspaceSessionBootstrap(
     sessionCount: input.sessions.length,
     totalElapsedMs: elapsedMs(input.startedAt),
   });
-  return { shouldReturn: false };
+  // The bootstrap must NOT finish content_stable at its own completion now that
+  // the transcript is hydrated off the critical path. Hand the mark to the
+  // transcript pane, which fires it when this session's transcript commits.
+  return { shouldReturn: false, contentStableSessionId: targetSession.id };
 }

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/workspace-open-flow-finish.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/workspace-open-flow-finish.ts
@@ -1,0 +1,40 @@
+import {
+  abandonRendererFlow,
+  deferWorkspaceOpenContentStable,
+  finishRendererFlow,
+} from "#product/lib/infra/diagnostics/renderer-flow-timing";
+
+/**
+ * Resolves the terminal outcome of a `workspace_open` renderer flow at the end
+ * of bootstrapWorkspace (UX-latency R14). Exactly one of three things happens:
+ *
+ *  - abandonReason set          -> abandon (stale / error): no content_stable.
+ *  - deferContentStableSessionId -> HAND OFF: transcript hydration moved off the
+ *    critical path, so the pane finishes the flow when the selected session's
+ *    transcript commits. Emitting content_stable here would lie — never emit a
+ *    stable mark before the user can see the transcript.
+ *  - neither                    -> finish now (empty workspace: nothing to wait
+ *    for, the shell's empty state IS the stable content).
+ */
+export function finishWorkspaceOpenRendererFlow(input: {
+  workspaceId: string;
+  abandonReason: string | null;
+  deferContentStableSessionId: string | null;
+}): void {
+  if (input.abandonReason !== null) {
+    abandonRendererFlow({
+      kind: "workspace_open",
+      correlationKey: input.workspaceId,
+      reason: input.abandonReason,
+    });
+    return;
+  }
+  if (input.deferContentStableSessionId !== null) {
+    deferWorkspaceOpenContentStable({
+      sessionId: input.deferContentStableSessionId,
+      correlationKey: input.workspaceId,
+    });
+    return;
+  }
+  finishRendererFlow({ kind: "workspace_open", correlationKey: input.workspaceId });
+}

--- a/apps/packages/product-client/src/lib/infra/diagnostics/renderer-flow-timing-wiring.test.ts
+++ b/apps/packages/product-client/src/lib/infra/diagnostics/renderer-flow-timing-wiring.test.ts
@@ -26,8 +26,16 @@ const FLOW_ENTRY_FILES: Record<
       "beginRendererFlow",
       "markRendererFlowShellCommitted",
       "markRendererFlowDataReady",
-      "finishRendererFlow",
+      // UX-latency R14: the finish decision (finish now / defer content_stable to
+      // the transcript pane / abandon) is extracted to workspace-open-flow-finish.ts
+      // to keep this hook under the frontend-structure line threshold; the actual
+      // finishRendererFlow call is asserted on that module below.
+      "finishWorkspaceOpenRendererFlow",
     ],
+  },
+  workspace_open_finish: {
+    file: "src/hooks/workspaces/workflows/workspace-open-flow-finish.ts",
+    requiredMarks: ["finishRendererFlow"],
   },
   session_open: {
     file: "src/hooks/sessions/lifecycle/use-session-history-hydration.ts",

--- a/apps/packages/product-client/src/lib/infra/diagnostics/renderer-flow-timing.test.ts
+++ b/apps/packages/product-client/src/lib/infra/diagnostics/renderer-flow-timing.test.ts
@@ -5,6 +5,8 @@ import {
   type RendererFlowKind,
   abandonRendererFlow,
   beginRendererFlow,
+  deferWorkspaceOpenContentStable,
+  finishDeferredWorkspaceOpenForSession,
   finishRendererFlow,
   markRendererFlowDataReady,
   markRendererFlowShellCommitted,
@@ -176,5 +178,57 @@ describe("renderer flow timing", () => {
       finishRendererFlow({ kind: "workspace_open", correlationKey: "missing" }),
     ).not.toThrow();
     expect(emitted).toHaveLength(0);
+  });
+
+  // UX-latency R14: content_stable hand-off to the transcript pane.
+  describe("deferred workspace_open content_stable", () => {
+    it("finishes only when the transcript pane commits the deferred session", () => {
+      beginRendererFlow({ kind: "workspace_open", correlationKey: "ws-1", correlation: { workspaceId: "ws-1" } });
+      nowValue = 5;
+      markRendererFlowShellCommitted({ kind: "workspace_open", correlationKey: "ws-1" });
+      nowValue = 40;
+      markRendererFlowDataReady({ kind: "workspace_open", correlationKey: "ws-1" });
+      // Bootstrap defers: content_stable must NOT fire at bootstrap completion.
+      deferWorkspaceOpenContentStable({ sessionId: "session-a", correlationKey: "ws-1" });
+      expect(emitted.some((e) => e.name === "renderer.flow.content_stable")).toBe(false);
+
+      // A different session committing does not resolve this flow.
+      finishDeferredWorkspaceOpenForSession("session-other");
+      expect(emitted.some((e) => e.name === "renderer.flow.content_stable")).toBe(false);
+
+      // The deferred session's transcript commits -> honest content_stable.
+      nowValue = 100;
+      finishDeferredWorkspaceOpenForSession("session-a", { content_stable_source: "transcript_committed" });
+      const stable = fieldsOf("renderer.flow.content_stable");
+      expect(stable.flow_kind).toBe("workspace_open");
+      expect(stable.data_to_stable_ms).toBe(60);
+      expect(stable.content_stable_source).toBe("transcript_committed");
+      expect(stable.budget_metric).toBe(RENDERER_FLOW_BUDGETS.workspace_open.metric);
+    });
+
+    it("no-ops for a session with no deferred workspace_open flow", () => {
+      finishDeferredWorkspaceOpenForSession("plain-switch");
+      expect(emitted).toHaveLength(0);
+    });
+
+    it("finishes a deferred session at most once", () => {
+      beginRendererFlow({ kind: "workspace_open", correlationKey: "ws-1" });
+      deferWorkspaceOpenContentStable({ sessionId: "session-a", correlationKey: "ws-1" });
+      finishDeferredWorkspaceOpenForSession("session-a");
+      finishDeferredWorkspaceOpenForSession("session-a");
+      expect(emitted.filter((e) => e.name === "renderer.flow.content_stable")).toHaveLength(1);
+    });
+
+    it("drops a prior deferral for the same flow when the settled session changes", () => {
+      beginRendererFlow({ kind: "workspace_open", correlationKey: "ws-1" });
+      deferWorkspaceOpenContentStable({ sessionId: "session-a", correlationKey: "ws-1" });
+      // Selection settled on a different session for the same workspace flow.
+      deferWorkspaceOpenContentStable({ sessionId: "session-b", correlationKey: "ws-1" });
+      // The superseded session must not resolve the flow.
+      finishDeferredWorkspaceOpenForSession("session-a");
+      expect(emitted.some((e) => e.name === "renderer.flow.content_stable")).toBe(false);
+      finishDeferredWorkspaceOpenForSession("session-b");
+      expect(emitted.filter((e) => e.name === "renderer.flow.content_stable")).toHaveLength(1);
+    });
   });
 });

--- a/apps/packages/product-client/src/lib/infra/diagnostics/renderer-flow-timing.ts
+++ b/apps/packages/product-client/src/lib/infra/diagnostics/renderer-flow-timing.ts
@@ -315,6 +315,63 @@ export function abandonRendererFlow(input: {
   });
 }
 
+/**
+ * UX-latency R14: content_stable hand-off for workspace_open.
+ *
+ * The workspace-open flow no longer awaits transcript hydration on its critical
+ * path (that fetch moved to SessionTranscriptPane's self-hydration). So the
+ * bootstrap can no longer honestly finish the flow at its own completion — the
+ * transcript is not yet on screen. Instead the bootstrap DEFERS content_stable:
+ * it records the target session id whose committed transcript is the real
+ * "user can see it" signal, and the transcript pane finishes the flow when it
+ * actually commits that session's transcript.
+ *
+ * The founder's rule: never emit a stable mark before the user can see the
+ * transcript. A deferred flow that never commits (selection superseded before
+ * the pane mounts) simply ages out via pruneStaleFlows — no false milestone.
+ *
+ * The registry maps a session id -> the workspace_open flow correlation key the
+ * bootstrap opened for it. The bootstrap owns this mapping (it knows both the
+ * correlationKey it began the flow with AND the session it selected), so the
+ * pane never has to reconstruct the correlation key from workspace ids that may
+ * differ from the selected/materialized id.
+ */
+const deferredWorkspaceOpenBySession = new Map<string, string>();
+
+export function deferWorkspaceOpenContentStable(input: {
+  sessionId: string;
+  correlationKey: string;
+}): void {
+  // A single workspace_open flow settles on exactly one session. Drop any prior
+  // deferral pointing at the same flow so a superseded session can't leak an
+  // entry that never resolves.
+  for (const [sessionId, correlationKey] of deferredWorkspaceOpenBySession) {
+    if (correlationKey === input.correlationKey && sessionId !== input.sessionId) {
+      deferredWorkspaceOpenBySession.delete(sessionId);
+    }
+  }
+  deferredWorkspaceOpenBySession.set(input.sessionId, input.correlationKey);
+}
+
+/**
+ * Finish a deferred workspace_open flow because the transcript pane committed
+ * the session's transcript (the real content_stable signal). No-ops when the
+ * session has no deferred workspace_open flow (a plain in-workspace session
+ * switch, or an already-finished flow), so it is safe to call on every commit.
+ */
+export function finishDeferredWorkspaceOpenForSession(
+  sessionId: string,
+  detail?: RendererFlowDetail,
+): void {
+  const correlationKey = deferredWorkspaceOpenBySession.get(sessionId);
+  if (correlationKey === undefined) {
+    return;
+  }
+  deferredWorkspaceOpenBySession.delete(sessionId);
+  finishRendererFlow({ kind: "workspace_open", correlationKey, detail });
+}
+
 export function resetRendererFlowsForTest(): void {
   activeFlows.clear();
+  deferredWorkspaceOpenBySession.clear();
 }

--- a/scripts/frontend_structure_allowlist.txt
+++ b/scripts/frontend_structure_allowlist.txt
@@ -30,7 +30,7 @@ apps/packages/product-client/src/components/content/ui/diff/ChatDiffViewer.tsx 5
 apps/packages/product-client/src/components/content/ui/diff/SplitDiffViewer.tsx 465 split diff viewer pending row-renderer split
 apps/packages/product-client/src/components/content/ui/diff/UnifiedDiffViewer.tsx 414 unified diff viewer pending row-renderer split
 apps/packages/product-client/src/components/workspace/repo-setup/CloudRepoActionDialogHost.tsx 433 shared ordered-readiness continuation host for Cloud registration and retry-stable local clone; split by intent owner on next growth
-apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-tombstones.ts 408 async ProductStorage hydration added to the in-memory tombstone model
+apps/packages/product-client/src/hooks/sessions/workflows/session-replacement-tombstones.ts 414 async ProductStorage hydration added to the in-memory tombstone model; R14 tombstone-commit listener notify wiring
 apps/packages/product-client/src/hooks/sessions/workflows/use-session-creation-actions.ts 460 session creation orchestrator (+lazy materialization and durable empty-create lifecycle, frozen-input replay, and acknowledgement seam); split deferred
 apps/packages/product-client/src/lib/infra/measurement/measurement-port.ts 734 product-owned measurement port barrel (R1 ruling) mirroring the retained measurement surface through a swappable no-op sink; split deferred
 apps/packages/product-client/src/host/product-host.ts 420 WDU slice 04 (G2/G4): host contract grew from getAnonymousInstallId + getSandboxGatewayAccessToken and their doc contracts


### PR DESCRIPTION
## Problem (measured live tonight, `renderer.flow` marks)

Workspace-switch critical path ran ~1.5s against a ~200ms floor:

- `intent_to_shell` 0–3ms (fine)
- `shell_to_data` 240–780ms — session-directory fetch, `session_list_cache` **miss on every revisit** (14 miss / 3 hit)
- `data_to_stable` 800–2300ms heavy vs 15–239ms light — dominated by `bootstrapWorkspace` awaiting a **full network transcript-history fetch** before emitting `content_stable`

Root causes (already diagnosed, not re-derived):
1. The remembered-session branch serially awaited `selectSessionWithShellIntentRollback` then `rehydrateSessionSlotFromHistory(..., {replace:true})` before the `finally` emitted `content_stable`. `SessionTranscriptPane` already self-hydrates, so the bootstrap-side await was largely redundant.
2. The `anyHarnessSessionsKey` react-query entry is seeded with `setQueryData`, loses its last observer on navigate-away, and is garbage-collected → every revisit is a cold miss.

## Changes

**1. Transcript hydration off the critical path.** `handleRememberedWorkspaceSessionBootstrap` now fires `rehydrateSessionSlotFromHistory` **fire-and-forget** (never awaited). Session selection stays on the critical path; only the history fetch moves off. `SessionTranscriptPane`'s existing self-hydration effect owns the transcript.

**2. In-flight dedupe.** `use-session-history-hydration` now shares one full-open (`replace`, no `afterSeq`/`beforeSeq`) hydration per session id across concurrent callers — the bootstrap kickoff and the pane effect collapse into a single fetch **and** a single apply (store writes + `session_open` flow marks fire once). Incremental append/prepend fetches are not deduped.

**3. Honest `content_stable`.** With hydration off the bootstrap path, emitting `content_stable` at bootstrap completion would lie — the transcript isn't on screen yet. The bootstrap now **defers** the mark (records the selected session id via `deferWorkspaceOpenContentStable`), and `SessionTranscriptPane` finishes the `workspace_open` flow (`finishDeferredWorkspaceOpenForSession`) when the selected session's transcript actually commits (non-null transcript + `useDeferredValue` caught up = `MessageList` rendering). Empty-workspace / error / stale paths still finish/abandon at bootstrap as before (no transcript to wait for). Marks stay additive/revertible; `budget_metric`/`budget_threshold_ms` unchanged.

> Honest-mark rationale: the founder's rule is never emit a stable mark before the user can see the transcript. A deferred flow that never commits (selection superseded before the pane mounts) simply ages out via `pruneStaleFlows` — no false milestone.

**4. Warm, truthful session directory.** Founder ruling: NOT stale-tolerant SWR — keep the list genuinely up to date and fetch immediately.
- (a) Bounded LRU keep-alive (`workspace-session-directory-keepalive.ts`, last N=5 visited queries) pins each session query with a disabled `QueryObserver` so an intra-run revisit is a warm **hit** instead of a GC'd miss; memory-bounded by evicting the least-recently-pinned observer past the bound.
- (b) Warm serve for first paint **plus an immediate background revalidation** (`void fetchAndSeed()`), so the list stays truthful without blocking first paint on the network.
- (c) Invalidate on replaced-session tombstone commit: `commitReplacedSessionTombstone` now notifies a listener that the bootstrap-cache hook uses to `invalidateQueries` the affected workspace, so a warm/pinned entry can never keep showing a retired session.
- `session_list_cache` hit/miss stays truthful: keep-alive means a revisit finds `dataUpdatedAt` → `hit`; invalidation → `stale`.

## R9 / R10 collision notes

Both are unmerged and cut from a different base; not absorbed here.
- **#1923 (R9 staleness-abort)** threads an `AbortSignal` through `loadWorkspaceSessionDirectory`/`loadWorkspaceSessions`. This PR edits the same `loadWorkspaceSessions` body (warm serve → background revalidate + pin). Both touch the cache-decision/warm branch; a rebase will need to route R9's signal through the new `fetchAndSeed` helper.
- **#1927 (R10 catalog parallelization)** adds `prefetchAgentCatalog` at `runWorkspaceSelection` entry. No overlap with these files beyond proximity in the selection workflow.

## Testing

Test list derived from `git diff --stat` vs base. Full `@proliferate/product-client` vitest suite run: **6992 passing**; the only 8 failures are pre-existing and unrelated — `src/hooks/access/tauri/updater-dev-mock.test.ts` (`window.localStorage` undefined; the node env is started without `--localstorage-file`), untouched by this PR and failing identically in isolation on the base tree.

New/updated unit tests (no widget mocks):
- `renderer-flow-timing.test.ts`: deferral finishes only when the deferred session commits; no-op for a non-deferred session; finishes at most once; drops a prior deferral when the settled session changes.
- `use-session-history-hydration.test.tsx`: two concurrent full hydrations → one fetch; incremental fetches are not deduped.
- `workspace-bootstrap-remembered-session.test.ts`: bootstrap resolves without awaiting hydration and returns `contentStableSessionId`; hydration is not awaited (record not patched synchronously).
- `use-workspace-bootstrap-cache.test.ts`: keep-alive pin + truthful `hit` after load; warm serve + background revalidation updates the cache; tombstone-commit invalidation → `stale`; staged replacement still never destructively reconciled on the warm serve.
- `workspace-session-directory-keepalive.test.ts`: pin survives GC; LRU bound; re-pin refreshes recency.

**Negative controls (mandatory) — performed for every behavioral test:** for each, I temporarily reverted the code change, confirmed the specific test failed, then restored the change and confirmed green. Done for: the dedupe wrapper, the `deferWorkspaceOpenContentStable` registration, the keep-alive pin call, the warm-serve background revalidation, the tombstone-commit invalidation notify, the LRU eviction bound, and the `contentStableSessionId` hand-off.

Typecheck clean (`tsc -p tsconfig.json --noEmit`). No Rust built (frontend-only change).

## Repo-shape / frontend-structure

To keep the three touched hooks under the ~400-line frontend-structure threshold, cohesive helpers were extracted into new modules: `session-history-hydration-dedupe.ts`, `workspace-open-flow-finish.ts`, `session-replacement-tombstone-listeners.ts`, plus `buildSessionHistoryFetchArgs` moved into `session-history-hydration-helpers.ts`. `use-session-history-hydration.ts` and `use-workspace-bootstrap-actions.ts` now land at exactly 400 lines (pass).

`session-replacement-tombstones.ts` was **already allowlisted at 408**; the R14 tombstone-commit listener wiring grew it to 414, so its existing allowlist entry was bumped 408 → 414 (marginal grow of a pre-existing entry; no new allowlist entries added). `python3 scripts/report_frontend_structure.py --strict` reports `LARGE_FRONTEND_FILE: 0`.

## Review fixes (round 1 — REQUEST_CHANGES)

**HIGH — content_stable could fire on the empty scaffold.** The deferred-finish effect in `SessionTranscriptPane.tsx` gated on `transcript` object presence, but cold workspace-open synchronously seeds `createEmptySessionRecord` with an empty-but-truthy `TranscriptState`, so `finishDeferredWorkspaceOpenForSession` fired ~0ms and `data_to_stable_ms` read ~0 for the exact case that used to measure 1.2–1.8s — content popped in AFTER the flow reported stable. Fix: gate on the directory entry's `transcriptHydrated` flag (read reactively), which both hydration call sites (this pane's self-hydration and the bootstrap kickoff) patch only after history is fetched and applied. A hydrated-empty session (new workspace, zero messages) still counts as stable; a scaffold-empty session does not.

**LOW — end-to-end coverage.** Added `SessionTranscriptPane.test.tsx` driving the real `createEmptySessionRecord` scaffold + `activateWorkspace` selection with a genuinely deferred `workspace_open` flow: asserts the flow does NOT finish while only the scaffold exists, DOES finish once hydration flips the flag (with `data_to_stable_ms` = 1500, not ~0), and a hydrated-empty variant still finishes. Negative control: reverting the gate to `transcript` presence makes both `toBeUndefined()` assertions fail (content_stable fires immediately, `data_to_stable_ms` = 25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


