### PR TITLE
fix(product): streaming continuity across workspace switches (R15)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptContexts.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptContexts.tsx
@@ -1,6 +1,8 @@
 import {
   createContext,
   useContext,
+  useEffect,
+  useRef,
   type ReactNode,
 } from "react";
 import type { TranscriptOpenSessionRole } from "#product/domain/chats/transcript/transcript-open-target";
@@ -10,7 +12,25 @@ export type TranscriptOpenSessionHandler = (
   role?: TranscriptOpenSessionRole,
 ) => void;
 
+/**
+ * Whether the transcript pane's initial paint for the current session has
+ * committed. Rows that mount as part of that first paint treat their existing
+ * content as finalized history (ADR Q15 restore-finalized); rows that first
+ * appear inside an established pane carry content that arrived while the
+ * viewer was watching, so it may animate. The object is mutated in place —
+ * consumers read it once at their own mount and must not subscribe to it.
+ */
+export interface TranscriptPaneLifecycle {
+  initialPaintComplete: boolean;
+}
+
+// No provider (isolated renders, tests, playground) behaves like a pane-initial
+// paint: mount-time content paints finalized, the safe direction under Q15.
+const DEFAULT_PANE_LIFECYCLE: TranscriptPaneLifecycle = { initialPaintComplete: false };
+
 const TranscriptSessionIdContext = createContext<string | null>(null);
+const TranscriptPaneLifecycleContext =
+  createContext<TranscriptPaneLifecycle>(DEFAULT_PANE_LIFECYCLE);
 const TranscriptOpenSessionContext = createContext<TranscriptOpenSessionHandler | null>(null);
 const TranscriptCanOpenSessionContext = createContext<
   ((sessionId: string, role?: TranscriptOpenSessionRole) => boolean) | null
@@ -27,15 +47,41 @@ export function TranscriptContextProviders({
   canOpenSession?: (sessionId: string, role?: TranscriptOpenSessionRole) => boolean;
   children: ReactNode;
 }) {
+  // Reset in render (not an effect) on session change: the swapped session's
+  // rows first-render in the same commit and must already see a fresh
+  // pane-initial lifecycle, before any effect can run.
+  const paneLifecycleRef = useRef<{
+    sessionId: string;
+    lifecycle: TranscriptPaneLifecycle;
+  }>({ sessionId, lifecycle: { initialPaintComplete: false } });
+  if (paneLifecycleRef.current.sessionId !== sessionId) {
+    paneLifecycleRef.current = {
+      sessionId,
+      lifecycle: { initialPaintComplete: false },
+    };
+  }
+  const paneLifecycle = paneLifecycleRef.current.lifecycle;
+  // Runs after every commit; the first commit for this session's tree flips
+  // the flag, so rows mounted in that commit read false and later ones true.
+  useEffect(() => {
+    paneLifecycle.initialPaintComplete = true;
+  });
+
   return (
     <TranscriptSessionIdContext.Provider value={sessionId}>
-      <TranscriptOpenSessionContext.Provider value={onOpenSession ?? null}>
-        <TranscriptCanOpenSessionContext.Provider value={canOpenSession ?? null}>
-          {children}
-        </TranscriptCanOpenSessionContext.Provider>
-      </TranscriptOpenSessionContext.Provider>
+      <TranscriptPaneLifecycleContext.Provider value={paneLifecycle}>
+        <TranscriptOpenSessionContext.Provider value={onOpenSession ?? null}>
+          <TranscriptCanOpenSessionContext.Provider value={canOpenSession ?? null}>
+            {children}
+          </TranscriptCanOpenSessionContext.Provider>
+        </TranscriptOpenSessionContext.Provider>
+      </TranscriptPaneLifecycleContext.Provider>
     </TranscriptSessionIdContext.Provider>
   );
+}
+
+export function useTranscriptPaneLifecycle(): TranscriptPaneLifecycle {
+  return useContext(TranscriptPaneLifecycleContext);
 }
 
 export function useTranscriptSessionId(): string | null {

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
@@ -16,6 +16,7 @@ import {
 } from "#product/components/workspace/chat/transcript/TranscriptTurnChrome";
 import { goalMetMarkerLabel } from "#product/domain/activity/goal";
 import { useSessionGoal } from "#product/hooks/activity/derived/use-session-goal";
+import { useTranscriptPaneLifecycle } from "#product/components/workspace/chat/transcript/TranscriptContexts";
 import { TurnItemSequence } from "#product/components/workspace/chat/transcript/TurnItemSequence";
 import { hostsSynthesizedReceiptDisclosure } from "#product/components/workspace/chat/transcript/TurnWorkspaceReceiptSlot";
 import {
@@ -108,6 +109,7 @@ export function TranscriptTurnRow({
     ? transcript.itemsById[tailAssistantProseRootId]
     : null;
   const tailAssistantTextLength = tailAssistantCopyContent?.length ?? 0;
+  const paneLifecycle = useTranscriptPaneLifecycle();
   const {
     animateAssistantRevealItemId,
     assistantRevealComplete,
@@ -118,6 +120,7 @@ export function TranscriptTurnRow({
     targetLength: tailAssistantTextLength,
     turnCompletedAt: turn.completedAt,
     turnId: turn.turnId,
+    paneEstablishedAtMount: paneLifecycle.initialPaintComplete,
   });
   const visualTurnCompleted = !!turn.completedAt && assistantRevealComplete;
   const assistantEndResource = useMemo(

--- a/apps/packages/product-client/src/hooks/chat/ui/use-assistant-reveal-frontier.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-assistant-reveal-frontier.test.tsx
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
-import { renderHook } from "@testing-library/react";
+import { render, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { useAssistantRevealFrontier } from "#product/hooks/chat/ui/use-assistant-reveal-frontier";
+import {
+  TranscriptContextProviders,
+  useTranscriptPaneLifecycle,
+} from "#product/components/workspace/chat/transcript/TranscriptContexts";
 import {
   clearAssistantRevealProgressForTests,
   getAssistantRevealProgress,
@@ -68,6 +72,92 @@ describe("useAssistantRevealFrontier mount floor", () => {
 
     expect(result.current.animateAssistantRevealItemId).toBe("item-2");
     expect(getAssistantRevealProgress("item-2")).toBeNull();
+  });
+
+  it("paces a fresh row that mounts inside an established pane", () => {
+    // A new turn whose first store flush coalesced the turn with its opening
+    // prose mounts a row already carrying content. The viewer watched it
+    // arrive, so it must animate from zero — no mount floor.
+    const { result } = renderHook(useAssistantRevealFrontier, {
+      initialProps: {
+        ...baseProps,
+        itemId: "item-3",
+        targetLength: 30,
+        paneEstablishedAtMount: true,
+      },
+    });
+
+    expect(result.current.animateAssistantRevealItemId).toBe("item-3");
+    expect(getAssistantRevealProgress("item-3")).toBeNull();
+  });
+
+  it("finalizes mount-time content only for rows in the pane's initial paint", () => {
+    // End-to-end through the real provider: a probe row mounted in the pane's
+    // first commit is floored; a probe row mounted afterwards paces.
+    const frontierByItemId = new Map<string, string | null>();
+    function ProbeRow({ itemId }: { itemId: string }) {
+      const paneLifecycle = useTranscriptPaneLifecycle();
+      const { animateAssistantRevealItemId } = useAssistantRevealFrontier({
+        ...baseProps,
+        itemId,
+        targetLength: 50,
+        paneEstablishedAtMount: paneLifecycle.initialPaintComplete,
+      });
+      frontierByItemId.set(itemId, animateAssistantRevealItemId);
+      return null;
+    }
+    function Pane({ showLateRow }: { showLateRow: boolean }) {
+      return (
+        <TranscriptContextProviders sessionId="session-1">
+          <ProbeRow itemId="initial-row" />
+          {showLateRow ? <ProbeRow itemId="late-row" /> : null}
+        </TranscriptContextProviders>
+      );
+    }
+
+    const view = render(<Pane showLateRow={false} />);
+    expect(frontierByItemId.get("initial-row")).toBeNull();
+    expect(getAssistantRevealProgress("initial-row")).toMatchObject({
+      complete: true,
+      visibleLength: 50,
+    });
+
+    view.rerender(<Pane showLateRow />);
+    expect(frontierByItemId.get("late-row")).toBe("late-row");
+    expect(getAssistantRevealProgress("late-row")).toBeNull();
+  });
+
+  it("re-floors rows when the pane swaps to another session", () => {
+    const frontierByItemId = new Map<string, string | null>();
+    function ProbeRow({ itemId }: { itemId: string }) {
+      const paneLifecycle = useTranscriptPaneLifecycle();
+      const { animateAssistantRevealItemId } = useAssistantRevealFrontier({
+        ...baseProps,
+        itemId,
+        targetLength: 50,
+        paneEstablishedAtMount: paneLifecycle.initialPaintComplete,
+      });
+      frontierByItemId.set(itemId, animateAssistantRevealItemId);
+      return null;
+    }
+    function Pane({ sessionId, itemId }: { sessionId: string; itemId: string }) {
+      return (
+        <TranscriptContextProviders sessionId={sessionId}>
+          <ProbeRow key={sessionId} itemId={itemId} />
+        </TranscriptContextProviders>
+      );
+    }
+
+    const view = render(<Pane sessionId="session-1" itemId="row-a" />);
+    view.rerender(<Pane sessionId="session-2" itemId="row-b" />);
+
+    // The swapped-in session's row mounts in that session's initial paint and
+    // must be floored, even though the provider instance stayed mounted.
+    expect(frontierByItemId.get("row-b")).toBeNull();
+    expect(getAssistantRevealProgress("row-b")).toMatchObject({
+      complete: true,
+      visibleLength: 50,
+    });
   });
 
   it("does not re-arm the reveal for a completed turn remounted later", () => {

--- a/apps/packages/product-client/src/hooks/chat/ui/use-assistant-reveal-frontier.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-assistant-reveal-frontier.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAssistantRevealFrontier } from "#product/hooks/chat/ui/use-assistant-reveal-frontier";
+import {
+  clearAssistantRevealProgressForTests,
+  getAssistantRevealProgress,
+  recordAssistantRevealProgress,
+} from "#product/hooks/chat/ui/assistant-reveal-progress";
+
+const baseProps = {
+  itemId: "item-1",
+  isLatestTurn: true,
+  targetLength: 100,
+  turnCompletedAt: null,
+  turnId: "turn-1",
+};
+
+describe("useAssistantRevealFrontier mount floor", () => {
+  beforeEach(() => {
+    clearAssistantRevealProgressForTests();
+  });
+
+  it("treats content present at mount as finalized instead of replaying it", () => {
+    // Stale progress left behind by a row that unmounted mid-stream while the
+    // transcript kept ingesting deltas (backgrounded workspace).
+    recordAssistantRevealProgress("item-1", {
+      complete: false,
+      phase: "active",
+      visibleLength: 5,
+      targetLength: 40,
+      isStreaming: true,
+    });
+
+    const { result } = renderHook(useAssistantRevealFrontier, {
+      initialProps: baseProps,
+    });
+
+    expect(result.current.animateAssistantRevealItemId).toBeNull();
+    expect(result.current.assistantRevealComplete).toBe(true);
+    expect(getAssistantRevealProgress("item-1")).toMatchObject({
+      complete: true,
+      visibleLength: 100,
+    });
+  });
+
+  it("animates only deltas that arrive after mount", () => {
+    const { result, rerender } = renderHook(useAssistantRevealFrontier, {
+      initialProps: baseProps,
+    });
+    expect(result.current.animateAssistantRevealItemId).toBeNull();
+
+    rerender({ ...baseProps, targetLength: 140 });
+
+    expect(result.current.animateAssistantRevealItemId).toBe("item-1");
+    expect(result.current.assistantRevealComplete).toBe(false);
+    // The floor still marks everything up to the mount-time length as revealed.
+    expect(getAssistantRevealProgress("item-1")?.visibleLength).toBe(100);
+  });
+
+  it("still paces an item that first appears after mount", () => {
+    const { result, rerender } = renderHook(useAssistantRevealFrontier, {
+      initialProps: { ...baseProps, itemId: null, targetLength: 0 },
+    });
+    expect(result.current.animateAssistantRevealItemId).toBeNull();
+
+    rerender({ ...baseProps, itemId: "item-2", targetLength: 30 });
+
+    expect(result.current.animateAssistantRevealItemId).toBe("item-2");
+    expect(getAssistantRevealProgress("item-2")).toBeNull();
+  });
+
+  it("does not re-arm the reveal for a completed turn remounted later", () => {
+    const { result } = renderHook(useAssistantRevealFrontier, {
+      initialProps: {
+        ...baseProps,
+        turnCompletedAt: new Date().toISOString(),
+      },
+    });
+
+    expect(result.current.animateAssistantRevealItemId).toBeNull();
+    expect(result.current.assistantRevealComplete).toBe(true);
+  });
+});

--- a/apps/packages/product-client/src/hooks/chat/ui/use-assistant-reveal-frontier.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-assistant-reveal-frontier.ts
@@ -19,12 +19,22 @@ export function useAssistantRevealFrontier({
   targetLength,
   turnCompletedAt,
   turnId,
+  paneEstablishedAtMount = false,
 }: {
   itemId: string | null;
   isLatestTurn: boolean;
   targetLength: number;
   turnCompletedAt: string | null | undefined;
   turnId: string;
+  /**
+   * True when the transcript pane had already completed its initial paint by
+   * the time this row first rendered (see TranscriptPaneLifecycle). A row
+   * mounting inside an established pane carries content that arrived while
+   * the viewer was watching — e.g. a new turn whose first store flush
+   * coalesced the turn with its opening prose — so it must pace, not be
+   * finalized by the mount floor.
+   */
+  paneEstablishedAtMount?: boolean;
 }) {
   const revealOriginRef = useRef({
     turnId,
@@ -37,16 +47,28 @@ export function useAssistantRevealFrontier({
   }
 
   // Streaming continuity (Chat Scroll ADR Q15): text that already exists when
-  // this row first renders is finalized history for this viewer — only deltas
-  // that arrive while the row is mounted may animate. Raising the shared
-  // reveal floor before child rows mount keeps a stream that kept ingesting
-  // while its workspace was backgrounded from re-playing on return. Items that
-  // appear on later renders start at floor zero, so a fresh live chunk still
-  // paces in through the frontier.
+  // this row first renders AS PART OF THE PANE'S INITIAL PAINT is finalized
+  // history for this viewer — only deltas that arrive while the viewer is
+  // watching may animate. Raising the shared reveal floor keeps a stream that
+  // kept ingesting while its workspace was backgrounded from re-playing on
+  // return. Two carve-outs preserve arrival-vs-viewer semantics: items that
+  // appear on later renders of a mounted row, and rows that first mount inside
+  // an established pane (paneEstablishedAtMount), both start at floor zero so
+  // a fresh live chunk still paces in through the frontier.
+  //
+  // The floor is written during render, deliberately: it must exist before
+  // this render's children (TranscriptItemBlock → AssistantMessage) mount and
+  // read the cache to seed their visible content — an effect would run after
+  // that first paint, too late to stop a one-frame replay. The write is safe
+  // where render purity normally forbids side effects because it is
+  // idempotent and monotonic: StrictMode's double-invoke finds the floor
+  // already at targetLength and skips, and an abandoned concurrent render can
+  // only have raised the floor toward "more content finalized", which a retry
+  // re-derives from the current targetLength.
   const appliedMountRevealFloorRef = useRef(false);
   if (!appliedMountRevealFloorRef.current) {
     appliedMountRevealFloorRef.current = true;
-    if (itemId !== null && targetLength > 0) {
+    if (itemId !== null && targetLength > 0 && !paneEstablishedAtMount) {
       const cachedAtMount = getAssistantRevealProgress(itemId);
       if (
         !cachedAtMount

--- a/apps/packages/product-client/src/hooks/chat/ui/use-assistant-reveal-frontier.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-assistant-reveal-frontier.ts
@@ -1,6 +1,9 @@
 import { useCallback, useRef, useState } from "react";
 import type { AssistantMessageRevealState } from "#product/lib/domain/chat/transcript/assistant-message-reveal";
-import { getAssistantRevealProgress } from "#product/hooks/chat/ui/assistant-reveal-progress";
+import {
+  getAssistantRevealProgress,
+  recordAssistantRevealProgress,
+} from "#product/hooks/chat/ui/assistant-reveal-progress";
 import { logDevAssistantRevealState } from "#product/hooks/chat/ui/dev-assistant-reveal-log";
 
 type AssistantRevealClaim = {
@@ -31,6 +34,34 @@ export function useAssistantRevealFrontier({
     revealOriginRef.current = { turnId, wasLive: !turnCompletedAt };
   } else if (!turnCompletedAt) {
     revealOriginRef.current.wasLive = true;
+  }
+
+  // Streaming continuity (Chat Scroll ADR Q15): text that already exists when
+  // this row first renders is finalized history for this viewer — only deltas
+  // that arrive while the row is mounted may animate. Raising the shared
+  // reveal floor before child rows mount keeps a stream that kept ingesting
+  // while its workspace was backgrounded from re-playing on return. Items that
+  // appear on later renders start at floor zero, so a fresh live chunk still
+  // paces in through the frontier.
+  const appliedMountRevealFloorRef = useRef(false);
+  if (!appliedMountRevealFloorRef.current) {
+    appliedMountRevealFloorRef.current = true;
+    if (itemId !== null && targetLength > 0) {
+      const cachedAtMount = getAssistantRevealProgress(itemId);
+      if (
+        !cachedAtMount
+        || cachedAtMount.visibleLength < targetLength
+        || !cachedAtMount.complete
+      ) {
+        recordAssistantRevealProgress(itemId, {
+          complete: true,
+          phase: "idle",
+          visibleLength: Math.max(targetLength, cachedAtMount?.visibleLength ?? 0),
+          targetLength,
+          isStreaming: false,
+        });
+      }
+    }
   }
 
   const [assistantRevealClaim, setAssistantRevealClaim] =

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/use-hot-session-ingest.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/use-hot-session-ingest.ts
@@ -3,6 +3,7 @@ import { useShallow } from "zustand/react/shallow";
 import {
   resolveHotSessionTargets,
 } from "#product/lib/domain/sessions/hot-session-policy";
+import { resolveSessionViewState } from "#product/domain/sessions/activity";
 import {
   reconcileHotSessions,
   type HotSessionIngestManagerDeps,
@@ -45,15 +46,50 @@ export function useHotSessionIngest(): void {
       ? state.sessionIdsByWorkspaceId[selectedWorkspaceId] ?? EMPTY_SESSION_IDS
       : EMPTY_SESSION_IDS
   );
+  // Streaming continuity (ADR Q15): sessions with in-flight work in other
+  // workspaces stay hot so their store slots keep ingesting deltas while
+  // backgrounded. The pending-prompt check catches a prompt sent immediately
+  // before switching away, before the directory reflects the run.
+  const pendingPromptSessionIds = useSessionTranscriptStore(useShallow((state) =>
+    Object.entries(state.entriesById)
+      .filter(([, entry]) =>
+        !!entry
+        && (!!entry.optimisticPrompt || entry.transcript.pendingPrompts.length > 0))
+      .map(([sessionId]) => sessionId)
+      .sort()
+  ));
+  const workingSessionIds = useSessionDirectoryStore(useShallow((state) =>
+    Object.entries(state.entriesById)
+      .filter(([, entry]) =>
+        !!entry?.workspaceId
+        && resolveSessionViewState({
+          status: entry.status,
+          executionSummary: entry.executionSummary,
+          streamConnectionState: entry.streamConnectionState,
+          transcript: {
+            isStreaming: entry.activity.isStreaming,
+            pendingInteractions: entry.activity.pendingInteractions,
+          },
+        }) === "working")
+      .map(([sessionId]) => sessionId)
+      .sort()
+  ));
+  const backgroundSessionIds = useMemo(() =>
+    uniqueSessionIds([...workingSessionIds, ...pendingPromptSessionIds]), [
+    pendingPromptSessionIds,
+    workingSessionIds,
+  ]);
   const relevantSessionIds = useMemo(() =>
     uniqueSessionIds([
       activeSessionId,
       ...visibleChatSessionIds,
       ...workspaceSessionIds,
+      ...backgroundSessionIds,
     ]), [
     activeSessionId,
     visibleChatSessionIds,
     workspaceSessionIds,
+    backgroundSessionIds,
   ]);
   const directoryEntriesById = useSessionDirectoryStore(useShallow((state) =>
     Object.fromEntries(
@@ -74,6 +110,7 @@ export function useHotSessionIngest(): void {
   ));
   const targets = useMemo(() => resolveHotSessionTargets({
     activeSessionId,
+    backgroundSessionIds,
     directoryEntriesById,
     promptActivityBySessionId,
     selectedWorkspaceId,
@@ -81,6 +118,7 @@ export function useHotSessionIngest(): void {
     workspaceSessionIds,
   }), [
     activeSessionId,
+    backgroundSessionIds,
     directoryEntriesById,
     promptActivityBySessionId,
     selectedWorkspaceId,

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.test.tsx
@@ -122,6 +122,25 @@ describe("useHotWorkspaceReconcileAction transcript hydration", () => {
     expect(rehydrate.mock.calls[1]?.[1]).toMatchObject({ replace: true });
   });
 
+  it("never trusts a slot that was not transcript-hydrated, even with a live stream", async () => {
+    patchSessionRecord(SESSION_ID, {
+      streamConnectionState: "open",
+      transcriptHydrated: false,
+    });
+    useSessionIngestStore.getState().applyStreamProgress(SESSION_ID, {
+      lastAppliedSeq: 42,
+      lastObservedSeq: 42,
+      gapAfterSeq: null,
+    });
+    const rehydrate = vi.fn(async () => true);
+
+    const reconcile = renderReconcile(rehydrate);
+    const outcome = await reconcile(reconcileInput());
+
+    expect(outcome).toBe("completed");
+    expect(rehydrate).toHaveBeenCalledTimes(1);
+  });
+
   it("does not trust an open stream whose ingest state reports a gap", async () => {
     patchSessionRecord(SESSION_ID, {
       streamConnectionState: "open",

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AnyHarnessResolvedConnection } from "@anyharness/sdk-react";
+import { useHotWorkspaceReconcileAction } from "#product/hooks/workspaces/workflows/use-hot-workspace-reconcile-action";
+import type { WorkspaceSession } from "#product/hooks/access/anyharness/sessions/use-workspace-session-cache";
+import { useSessionIngestStore } from "#product/stores/sessions/session-ingest-store";
+import {
+  createEmptySessionRecord,
+  getSessionRecord,
+  patchSessionRecord,
+  putSessionRecord,
+  removeSessionRecord,
+} from "#product/stores/sessions/session-records";
+
+const SESSION_ID = "session-r15";
+const WORKSPACE_ID = "workspace-r15";
+
+const workspaceConnection = {
+  anyharnessWorkspaceId: "anyharness-workspace-r15",
+  runtimeUrl: "http://localhost:9999",
+  authToken: null,
+} as AnyHarnessResolvedConnection;
+
+const sessionMeta = {
+  id: SESSION_ID,
+  dismissedAt: null,
+} as unknown as WorkspaceSession;
+
+function renderReconcile(rehydrate: ReturnType<typeof vi.fn>) {
+  const { result } = renderHook(() =>
+    useHotWorkspaceReconcileAction({
+      cancelDeferredFileTreePrefetch: vi.fn(),
+      loadWorkspaceSessions: vi.fn(async () => [sessionMeta]),
+      prepareFileWorkspace: vi.fn(),
+      rehydrateSessionSlotFromHistory: rehydrate,
+      scheduleDeferredFileTreePrefetch: vi.fn(),
+      workspaceCollections: undefined,
+    })
+  );
+  return result.current;
+}
+
+function reconcileInput() {
+  return {
+    workspaceId: WORKSPACE_ID,
+    logicalWorkspaceId: WORKSPACE_ID,
+    workspaceConnection,
+    sessionId: SESSION_ID,
+    selectionNonce: 1,
+    isCurrent: () => true,
+  };
+}
+
+describe("useHotWorkspaceReconcileAction transcript hydration", () => {
+  beforeEach(() => {
+    removeSessionRecord(SESSION_ID);
+    useSessionIngestStore.getState().clear();
+    putSessionRecord(createEmptySessionRecord(SESSION_ID, "codex", {
+      workspaceId: WORKSPACE_ID,
+      materializedSessionId: SESSION_ID,
+    }));
+  });
+
+  it("performs zero history fetches when the slot stream stayed live without a gap", async () => {
+    patchSessionRecord(SESSION_ID, {
+      streamConnectionState: "open",
+      transcriptHydrated: true,
+    });
+    useSessionIngestStore.getState().applyStreamProgress(SESSION_ID, {
+      lastAppliedSeq: 42,
+      lastObservedSeq: 42,
+      gapAfterSeq: null,
+    });
+    const rehydrate = vi.fn(async () => true);
+
+    const reconcile = renderReconcile(rehydrate);
+    const outcome = await reconcile(reconcileInput());
+
+    expect(outcome).toBe("completed");
+    expect(rehydrate).not.toHaveBeenCalled();
+    expect(getSessionRecord(SESSION_ID)?.transcriptHydrated).toBe(true);
+  });
+
+  it("repairs a real gap with exactly one incremental history fetch", async () => {
+    patchSessionRecord(SESSION_ID, {
+      streamConnectionState: "disconnected",
+      transcriptHydrated: true,
+    });
+    useSessionIngestStore.getState().markStale(SESSION_ID, {
+      gapAfterSeq: 7,
+    });
+    const rehydrate = vi.fn(async () => true);
+
+    const reconcile = renderReconcile(rehydrate);
+    const outcome = await reconcile(reconcileInput());
+
+    expect(outcome).toBe("completed");
+    expect(rehydrate).toHaveBeenCalledTimes(1);
+    expect(rehydrate).toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.objectContaining({ afterSeq: expect.any(Number) }),
+    );
+    expect(rehydrate.mock.calls[0]?.[1]).not.toMatchObject({ replace: true });
+  });
+
+  it("falls back to a full replace only when the tail cannot apply contiguously", async () => {
+    patchSessionRecord(SESSION_ID, {
+      streamConnectionState: "disconnected",
+      transcriptHydrated: true,
+    });
+    const rehydrate = vi.fn(async (
+      _sessionId: string,
+      options?: { replace?: boolean },
+    ) => options?.replace === true);
+
+    const reconcile = renderReconcile(rehydrate);
+    const outcome = await reconcile(reconcileInput());
+
+    expect(outcome).toBe("completed");
+    expect(rehydrate).toHaveBeenCalledTimes(2);
+    expect(rehydrate.mock.calls[1]?.[1]).toMatchObject({ replace: true });
+  });
+
+  it("does not trust an open stream whose ingest state reports a gap", async () => {
+    patchSessionRecord(SESSION_ID, {
+      streamConnectionState: "open",
+      transcriptHydrated: true,
+    });
+    useSessionIngestStore.getState().applyStreamProgress(SESSION_ID, {
+      lastAppliedSeq: 42,
+      lastObservedSeq: 50,
+      gapAfterSeq: 42,
+    });
+    const rehydrate = vi.fn(async () => true);
+
+    const reconcile = renderReconcile(rehydrate);
+    await reconcile(reconcileInput());
+
+    expect(rehydrate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.ts
@@ -28,6 +28,7 @@ import {
   getSessionRecord,
   patchSessionRecord,
 } from "#product/stores/sessions/session-records";
+import { useSessionIngestStore } from "#product/stores/sessions/session-ingest-store";
 import { recordHotWorkspaceReconcileFailure } from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations";
 import { safeRendererErrorName } from "#product/lib/infra/diagnostics/renderer-diagnostic-values";
 
@@ -236,34 +237,49 @@ export function useHotWorkspaceReconcileAction({
         isCurrent,
       });
 
+      // Streaming continuity (ADR Q15): a slot whose hot stream stayed open
+      // and contiguous while the workspace was backgrounded already holds the
+      // full transcript, so the store is trusted as-is. History is fetched
+      // only to repair a real gap (closed stream, missed sequence), and the
+      // full replace stays a last resort for a non-contiguous tail.
       const slotBeforeHydrate = getSessionRecord(sessionId);
+      const ingestFreshness = useSessionIngestStore
+        .getState()
+        .freshnessByClientSessionId[sessionId];
+      const slotStreamLive = slotBeforeHydrate?.transcriptHydrated === true
+        && slotBeforeHydrate.streamConnectionState === "open"
+        && ingestFreshness?.freshness === "current"
+        && ingestFreshness.gapAfterSeq === null;
       const lastSeq = slotBeforeHydrate?.transcript.lastSeq ?? 0;
       const hydrateStartedAt = startLatencyTimer();
-      const tailHydrated = await rehydrateSessionSlotFromHistory(sessionId, {
-        afterSeq: lastSeq,
-        requestHeaders,
-        measurementOperationId,
-        isCurrent,
-      });
-      if (!isCurrent()) {
-        return "stale";
-      }
-      if (!tailHydrated) {
-        await rehydrateSessionSlotFromHistory(sessionId, {
-          replace: true,
+      if (!slotStreamLive) {
+        const tailHydrated = await rehydrateSessionSlotFromHistory(sessionId, {
+          afterSeq: lastSeq,
           requestHeaders,
           measurementOperationId,
           isCurrent,
         });
-      }
-      if (!isCurrent()) {
-        return "stale";
+        if (!isCurrent()) {
+          return "stale";
+        }
+        if (!tailHydrated) {
+          await rehydrateSessionSlotFromHistory(sessionId, {
+            replace: true,
+            requestHeaders,
+            measurementOperationId,
+            isCurrent,
+          });
+        }
+        if (!isCurrent()) {
+          return "stale";
+        }
       }
       patchSessionRecord(sessionId, { transcriptHydrated: true });
       recordMeasurementWorkflowStep({
         operationId: measurementOperationId,
         step: "session.select.history_hydrate",
         startedAt: hydrateStartedAt,
+        outcome: slotStreamLive ? "skipped" : undefined,
       });
 
       markWorkspaceBootstrappedInSession(workspaceId);

--- a/apps/packages/product-client/src/lib/domain/sessions/hot-session-policy.test.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/hot-session-policy.test.ts
@@ -68,6 +68,102 @@ describe("resolveHotSessionTargets", () => {
     expect(targets.map((target) => target.clientSessionId)).toEqual(["c", "a"]);
   });
 
+  it("keeps a running session in a backgrounded workspace hot", () => {
+    const state = fixtures(["selected"]);
+    state.directory["background-running"] = backgroundEntry("background-running", {
+      status: "running",
+    });
+    state.directory["background-idle"] = backgroundEntry("background-idle", {
+      status: "idle",
+    });
+    state.promptActivity["background-running"] = 0;
+    state.promptActivity["background-idle"] = 0;
+
+    const targets = resolveHotSessionTargets({
+      activeSessionId: "selected",
+      backgroundSessionIds: ["background-running", "background-idle"],
+      directoryEntriesById: state.directory,
+      promptActivityBySessionId: state.promptActivity,
+      selectedWorkspaceId: "workspace-1",
+      visibleChatSessionIds: ["selected"],
+      workspaceSessionIds: ["selected"],
+    });
+
+    expect(targets.map((target) => [target.clientSessionId, target.reason])).toEqual([
+      ["selected", "selected"],
+      ["background-running", "background_running"],
+    ]);
+  });
+
+  it("keeps a backgrounded session with a queued prompt hot", () => {
+    const state = fixtures(["selected"]);
+    state.directory["background-queued"] = backgroundEntry("background-queued", {
+      status: "idle",
+    });
+    state.promptActivity["background-queued"] = 1;
+
+    const targets = resolveHotSessionTargets({
+      activeSessionId: "selected",
+      backgroundSessionIds: ["background-queued"],
+      directoryEntriesById: state.directory,
+      promptActivityBySessionId: state.promptActivity,
+      selectedWorkspaceId: "workspace-1",
+      visibleChatSessionIds: ["selected"],
+      workspaceSessionIds: ["selected"],
+    });
+
+    expect(targets.map((target) => [target.clientSessionId, target.reason])).toEqual([
+      ["selected", "selected"],
+      ["background-queued", "background_running"],
+    ]);
+  });
+
+  it("keeps background running sessions hot with no workspace selected", () => {
+    const state = fixtures([]);
+    state.directory["background-running"] = backgroundEntry("background-running", {
+      status: "running",
+    });
+    state.promptActivity["background-running"] = 0;
+
+    const targets = resolveHotSessionTargets({
+      activeSessionId: null,
+      backgroundSessionIds: ["background-running"],
+      directoryEntriesById: state.directory,
+      promptActivityBySessionId: state.promptActivity,
+      selectedWorkspaceId: null,
+      visibleChatSessionIds: [],
+      workspaceSessionIds: [],
+    });
+
+    expect(targets.map((target) => [target.clientSessionId, target.reason])).toEqual([
+      ["background-running", "background_running"],
+    ]);
+  });
+
+  it("drops background sessions before selected-workspace targets under the cap", () => {
+    const state = fixtures(["selected", "visible"]);
+    state.directory["background-running"] = backgroundEntry("background-running", {
+      status: "running",
+    });
+    state.promptActivity["background-running"] = 0;
+
+    const targets = resolveHotSessionTargets({
+      activeSessionId: "selected",
+      backgroundSessionIds: ["background-running"],
+      directoryEntriesById: state.directory,
+      maxHotSessionStreams: 2,
+      promptActivityBySessionId: state.promptActivity,
+      selectedWorkspaceId: "workspace-1",
+      visibleChatSessionIds: ["selected", "visible"],
+      workspaceSessionIds: ["selected", "visible"],
+    });
+
+    expect(targets.map((target) => target.clientSessionId)).toEqual([
+      "selected",
+      "visible",
+    ]);
+  });
+
   it("keeps projected targets hot but non-streamable", () => {
     const state = fixtures(["projected"], { materialized: false });
 
@@ -88,6 +184,23 @@ describe("resolveHotSessionTargets", () => {
     }]);
   });
 });
+
+function backgroundEntry(
+  sessionId: string,
+  options: { status: HotSessionDirectoryEntry["status"] },
+): HotSessionDirectoryEntry {
+  return {
+    materializedSessionId: sessionId,
+    workspaceId: "workspace-2",
+    status: options.status,
+    executionSummary: null,
+    streamConnectionState: "disconnected",
+    activity: {
+      isStreaming: false,
+      pendingInteractions: [],
+    },
+  };
+}
 
 function fixtures(
   sessionIds: string[],

--- a/apps/packages/product-client/src/lib/domain/sessions/hot-session-policy.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/hot-session-policy.ts
@@ -156,6 +156,9 @@ export function resolveHotSessionTargets(
     }
   }
 
+  // Cap contract: reasons win strictly by priority; within a priority tier the
+  // lexicographic session-id tiebreak is arbitrary but stable, so repeated
+  // resolutions over the same inputs never churn which sessions hold streams.
   return Array.from(candidates.values())
     .sort((a, b) => a.priority - b.priority || a.clientSessionId.localeCompare(b.clientSessionId))
     .slice(0, maxHotSessionStreams);

--- a/apps/packages/product-client/src/lib/domain/sessions/hot-session-policy.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/hot-session-policy.ts
@@ -12,7 +12,8 @@ export type HotSessionReason =
   | "queued_prompt"
   | "needs_input"
   | "running"
-  | "open_tab";
+  | "open_tab"
+  | "background_running";
 
 export interface HotSessionTarget {
   clientSessionId: string;
@@ -40,6 +41,12 @@ export interface ResolveHotSessionTargetsInput {
   activeSessionId: string | null;
   visibleChatSessionIds: readonly string[];
   workspaceSessionIds: readonly string[];
+  /**
+   * Sessions outside the selected workspace that may have in-flight work.
+   * Running ones stay hot so their store slots keep ingesting stream deltas
+   * while the workspace is backgrounded (streaming continuity, ADR Q15).
+   */
+  backgroundSessionIds?: readonly string[];
   directoryEntriesById: Record<string, HotSessionDirectoryEntry | undefined>;
   promptActivityBySessionId: Record<string, number | undefined>;
   maxHotSessionStreams?: number;
@@ -51,15 +58,12 @@ const PRIORITY_BY_REASON: Record<HotSessionReason, number> = {
   needs_input: 2,
   running: 3,
   open_tab: 4,
+  background_running: 5,
 };
 
 export function resolveHotSessionTargets(
   input: ResolveHotSessionTargetsInput,
 ): HotSessionTarget[] {
-  if (!input.selectedWorkspaceId) {
-    return [];
-  }
-
   const candidates = new Map<string, HotSessionTarget>();
   const maxHotSessionStreams = input.maxHotSessionStreams ?? MAX_HOT_SESSION_STREAMS;
 
@@ -69,7 +73,11 @@ export function resolveHotSessionTargets(
     }
     const entry = input.directoryEntriesById[sessionId];
     const workspaceId = entry?.workspaceId ?? null;
-    if (!entry || !workspaceId || workspaceId !== input.selectedWorkspaceId) {
+    if (!entry || !workspaceId) {
+      return;
+    }
+    const inSelectedWorkspace = workspaceId === input.selectedWorkspaceId;
+    if (reason === "background_running" ? inSelectedWorkspace : !inSelectedWorkspace) {
       return;
     }
 
@@ -89,23 +97,51 @@ export function resolveHotSessionTargets(
     });
   };
 
-  maybeAdd(input.activeSessionId, "selected");
+  if (input.selectedWorkspaceId) {
+    maybeAdd(input.activeSessionId, "selected");
 
-  const visibleSet = new Set(input.visibleChatSessionIds);
-  for (const sessionId of input.visibleChatSessionIds) {
-    maybeAdd(sessionId, "open_tab");
+    const visibleSet = new Set(input.visibleChatSessionIds);
+    for (const sessionId of input.visibleChatSessionIds) {
+      maybeAdd(sessionId, "open_tab");
+    }
+
+    for (const sessionId of input.workspaceSessionIds) {
+      const entry = input.directoryEntriesById[sessionId];
+      if (!entry || entry.workspaceId !== input.selectedWorkspaceId) {
+        continue;
+      }
+
+      if ((input.promptActivityBySessionId[sessionId] ?? 0) > 0) {
+        maybeAdd(sessionId, "queued_prompt");
+      }
+
+      const viewState = resolveSessionViewState({
+        status: entry.status,
+        executionSummary: entry.executionSummary,
+        streamConnectionState: entry.streamConnectionState,
+        transcript: {
+          isStreaming: entry.activity.isStreaming,
+          pendingInteractions: entry.activity.pendingInteractions,
+        },
+      });
+      if (viewState === "needs_input") {
+        maybeAdd(sessionId, "needs_input");
+      } else if (viewState === "working") {
+        maybeAdd(sessionId, "running");
+      } else if (visibleSet.has(sessionId)) {
+        maybeAdd(sessionId, "open_tab");
+      }
+    }
   }
 
-  for (const sessionId of input.workspaceSessionIds) {
+  // Backgrounded sessions stay hot only while they have in-flight work, so
+  // idle slots never hold a stream open just because their workspace was once
+  // visited. Selected-workspace reasons sort ahead of these under the cap.
+  for (const sessionId of input.backgroundSessionIds ?? []) {
     const entry = input.directoryEntriesById[sessionId];
-    if (!entry || entry.workspaceId !== input.selectedWorkspaceId) {
+    if (!entry) {
       continue;
     }
-
-    if ((input.promptActivityBySessionId[sessionId] ?? 0) > 0) {
-      maybeAdd(sessionId, "queued_prompt");
-    }
-
     const viewState = resolveSessionViewState({
       status: entry.status,
       executionSummary: entry.executionSummary,
@@ -115,12 +151,8 @@ export function resolveHotSessionTargets(
         pendingInteractions: entry.activity.pendingInteractions,
       },
     });
-    if (viewState === "needs_input") {
-      maybeAdd(sessionId, "needs_input");
-    } else if (viewState === "working") {
-      maybeAdd(sessionId, "running");
-    } else if (visibleSet.has(sessionId)) {
-      maybeAdd(sessionId, "open_tab");
+    if (viewState === "working" || (input.promptActivityBySessionId[sessionId] ?? 0) > 0) {
+      maybeAdd(sessionId, "background_running");
     }
   }
 

--- a/apps/packages/product-client/src/lib/workflows/sessions/hot-session-ingest-manager.test.ts
+++ b/apps/packages/product-client/src/lib/workflows/sessions/hot-session-ingest-manager.test.ts
@@ -98,6 +98,26 @@ describe("hot-session-ingest-manager", () => {
     expect(deps.ensureSessionStreamConnected).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps a live stream open when its target is demoted to background_running", async () => {
+    putSessionRecord(createEmptySessionRecord("session-a", "codex", {
+      workspaceId: "workspace-1",
+    }));
+    const deps = depsWithEnsure(async () => {
+      patchSessionRecord("session-a", { streamConnectionState: "open" });
+    });
+
+    reconcileHotSessions([target("session-a", "selected")], deps);
+    await Promise.resolve();
+
+    reconcileHotSessions([target("session-a", "background_running")], deps);
+    await Promise.resolve();
+
+    expect(deps.closeSessionSlotStream).not.toHaveBeenCalled();
+    expect(deps.ensureSessionStreamConnected).toHaveBeenCalledTimes(1);
+    expect(useSessionIngestStore.getState().freshnessByClientSessionId["session-a"]?.freshness)
+      .toBe("current");
+  });
+
   it("hydrates an existing open-tab stream when it becomes selected", async () => {
     putSessionRecord(createEmptySessionRecord("session-a", "codex", {
       workspaceId: "workspace-1",


### PR DESCRIPTION
Implements R15 of the UX Latency ladder: after sending a message, switching workspace, and switching back, the stream no longer visibly "restarts" and re-plays. Ruled behavior (Chat Scroll ADR Q15, restore-finalized / bottom-streaming): everything already received paints instantly as finalized at the bottom; only tokens arriving after remount animate.

**Base: stacked on `ux-latency/r14-switch-critical-path`** (the branch appeared on origin before push, as instructed; originally developed against `ux-latency/r4-skeleton-retirement` and rebased cleanly — no file overlap with R14).

## Phase 1 — verified mechanism

**(a) Deltas do NOT keep applying while backgrounded.** The hot-session policy scopes live streams to the selected workspace: `resolveHotSessionTargets` returns nothing for other workspaces (`lib/domain/sessions/hot-session-policy.ts:59-73` pre-change), and `reconcileHotSessions` closes every stream that drops out of the target set (`lib/workflows/sessions/hot-session-ingest-manager.ts:71-75` → `closeHotStream` → `closeSessionSlotStream`). The transcript slot itself is NOT evicted — it stays cached, frozen at its `transcript.lastSeq`, marked `cold` in the ingest store. Events are retained server-side: reconnects resume with `afterSeq = slot.transcript.lastSeq` (`hooks/sessions/lifecycle/session-stream-connection-open.ts:75,162-163`), and the ingest store tracks contiguity via `lastAppliedSeq`/`gapAfterSeq` (`stores/sessions/session-ingest-store.ts:106-123,153-173`). This differs from the founder's mental model (store kept ingesting) but does not change the ruled design — it just means R15 must supply the store continuity too.

**(b) The visible re-stream has two ingredients.** On return, `useHotWorkspaceReconcileAction` tail-hydrates with `afterSeq` and falls back to `rehydrateSessionSlotFromHistory({replace:true})` when the tail can't apply contiguously (`hooks/workspaces/workflows/use-hot-workspace-reconcile-action.ts:242-258` pre-change). Independently, the reveal animation replays: the reveal-progress cache (`hooks/chat/ui/assistant-reveal-progress.ts`) is only updated from a mounted row's effect, so it freezes when the pane unmounts; on remount `useAssistantRevealFrontier` sees `targetLength > stale cached visibleLength` and re-arms the reveal (`hooks/chat/ui/use-assistant-reveal-frontier.ts:38-49`), and `AssistantMessageContent` seeds from the stale prefix (`lib/domain/chat/transcript/assistant-message-reveal.ts` `initialVisibleContent`) and typewriters through the entire backlog at 360 chars/s. Verdict: the animation replay is the dominant visible symptom; the replace-fallback is the secondary data-level one.

## The three changes

1. **Store continuity while away** — `hot-session-policy.ts` adds a `background_running` target reason (lowest priority, inside the existing `MAX_HOT_SESSION_STREAMS = 12` cap, so selected-workspace targets always win): sessions outside the selected workspace stay hot only while they have in-flight work (view state `working`, or a pending/optimistic prompt so a send-then-switch race is covered). `use-hot-session-ingest.ts` feeds those candidates from the directory + transcript stores. Idle sessions never hold a stream, so slots don't grow unbounded. Existing manager behavior keeps a live stream open on selected→background demotion (no `closeHotStream`, verified by test), and `prepareSessionStreamConnection` already no-ops on an open stream, so the return-promotion doesn't reconnect.

2. **Trust the store on return (gap-repair, not unconditional replace)** — `use-hot-workspace-reconcile-action.ts` now skips history entirely when the slot is trustworthy: `transcriptHydrated && streamConnectionState === "open" && ingest freshness === "current" && gapAfterSeq === null` → zero fetches. On a real gap (closed stream, stale/gapped ingest state) it performs exactly one incremental `afterSeq` repair fetch; the full `{replace:true}` remains only as the fallback for a non-contiguous tail. Coordination with R14: R14 took the blocking `rehydrateSessionSlotFromHistory({replace:true})` off the workspace_open bootstrap critical path and added hydration dedupe; R15 defines what replaces it on the hot-reopen reconcile — trust-the-live-slot with gap-repair. No shared files between the two diffs.

3. **Render-as-finalized at mount** — `useAssistantRevealFrontier` records a mount-time reveal floor into the shared reveal-progress cache on the row's first render: content that already exists when the viewer first sees the item is marked fully revealed/complete, so nothing pre-mount can animate — only deltas arriving after mount hold the frontier and pace in. Items that first appear on a later render (a fresh live chunk in a new turn) start at floor zero, preserving the deliberate "never snap a large delivery" pacing that `AssistantMessage.test.tsx` locks in. This also retires the remount replay of recently-completed turns (`isRecentAssistantCompletion` path), which is the same defect class under Q15. Scroll ownership untouched — restore-finalized/bottom-streaming still owns initial position; this hands off at a single instant paint.

## Test evidence

Suites derived from `git diff --stat` vs base; full `pnpm --filter @proliferate/product-client test` run after `pnpm --filter @proliferate/product-client build`: **968 files / 7013 tests passed** on the rebased tree.

- `hot-session-policy.test.ts` (+4): background running kept hot; queued-prompt background kept hot; background running kept hot with no workspace selected; background dropped before selected-workspace targets under the cap.
- `hot-session-ingest-manager.test.ts` (+1): live stream stays open (no `closeSessionSlotStream`, no reconnect) when the target demotes selected→`background_running` — this is the "deltas keep applying while backgrounded" invariant at the manager level, using the real target/ingest-store machinery.
- `use-hot-workspace-reconcile-action.test.tsx` (new): return without gap performs **zero** history fetches (fetch-spy assertion); gap triggers **exactly one** `afterSeq` repair fetch and no replace; replace fires only when the tail can't apply; an open stream with a reported `gapAfterSeq` is not trusted. Uses the real session-record and ingest stores, no widget mocks.
- `use-assistant-reveal-frontier.test.tsx` (new): stale in-flight cache + grown content at mount → no reveal re-arm, floor raised to mount length; post-mount delta → reveal arms; item appearing after mount still paces from zero; completed turn remounted later doesn't re-arm.
- Existing `AssistantMessage.test.tsx` (14 tests) passes unchanged — mount pacing, remount-resume via `initialVisibleLength`, scroll-pause, and settle behavior are all preserved.

**Negative controls** (each production file reverted to base, its tests run, then restored):
- `hot-session-policy.ts` reverted → 3/8 policy tests fail (the three background-target tests).
- `use-hot-workspace-reconcile-action.ts` reverted → "performs zero history fetches" fails (unconditional hydrate observed).
- `use-assistant-reveal-frontier.ts` reverted → 3/4 frontier tests fail (mount replay re-arms).
The manager test addition documents pre-existing manager behavior that the new policy output now relies on, so it has no matching revert (the manager itself is unchanged).

## What now happens on return

While away, the running session's stream stays open and deltas keep landing in its store slot (freshness stays `current`). On return, the reconcile sees a live gap-free slot and fetches nothing; the pane mounts, the reveal floor finalizes everything already in the store in one instant paint at the bottom, and only tokens that arrive after that mount animate. If the connection did gap while away, one `afterSeq` repair fetch fills the tail (replace only if non-contiguous) — and either way nothing pre-mount animates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Adversarial review (dedicated agent, opus)

No blockers. Findings and dispositions:
- **Trust-path race on promotion (major-efficacy, accepted):** selecting a backgrounded running session flips its target `background_running → selected`, and the manager's `connectHotTarget` calls `markWarming` before its no-op reconnect resolves back to `current` (the stream stays open; `prepareSessionStreamConnection` early-returns). If the reconcile reads freshness inside that window it degrades to the single `afterSeq` repair — still zero replace, still no replay. The measurement step records `session.select.history_hydrate outcome:"skipped"` when the zero-fetch path fires, so the hit rate is observable at runtime (T4 debt covers the booted-app check).
- **Silent-stall window (accepted trade-off):** an "open + current + no gap" stream that silently stalled server-side would be trusted without the old unconditional `afterSeq` backstop. This is the ruled semantics (trust the store unless there is a real gap); stall detection belongs to the stream layer.
- **Foreground virtualizer remount mid-stream now paints finalized** instead of resuming the typewriter — consistent with the ADR's mount semantics (animation is arrival-vs-viewer), noted as intentional behavior change.
- **Render-phase write to the reveal cache** (mount floor) is idempotent and safe under StrictMode double-render; flagged as a latent hazard if the transcript ever renders under startTransition/Suspense.
- **Minor follow-ups:** the pending-prompt hot-candidate selector scans the transcript store per delta (O(sessions·log) with a `useShallow`-stable result — fine at current session counts); pending-prompt candidates require a directory entry, so a brand-new session with only an optimistic prompt relies on being the active session (it is, in the send-then-switch flow).

**Rebase note:** originally opened against a mid-work R14 snapshot (454069ecd), which failed the shared-frontend `renderer-flow-timing-wiring` guard in the CI merge (R14 later moved the workspace_open `finishRendererFlow` out of the bootstrap and updated that guard in its own tree). Rebased onto the green R14 head (ab52584aa) once #1968 settled — clean rebase, no conflicts, wiring guard + full suite (7014 tests) green, force-pushed with lease. No bootstrap-side `finishRendererFlow` was re-added.

## Second review round (independent adversarial review — APPROVE, no blockers)

Four follow-ups addressed in 402a38932:

1. **Coalesced-first-flush edge (real edge, fixed + pinned):** the mount floor used to apply on any row first render with `itemId && targetLength > 0`. A genuinely NEW assistant message whose first flush coalesced turn-start with its opening deltas mounts a fresh row already carrying prose inside an established pane — and was finalized with no animation ever, violating arrival-vs-viewer. Fix: a `TranscriptPaneLifecycle` context (in `TranscriptContexts.tsx`) tracks `initialPaintComplete` per pane — reset in the render phase on session change (so a swapped session's rows see a fresh lifecycle in the same commit), flipped true by a no-deps effect after each commit. `TranscriptTurnRow` passes it to the frontier hook as `paneEstablishedAtMount`; the floor now applies only when the row mounts as part of the pane's initial paint. The hook takes a parameter rather than reading the context itself to keep hooks/chat/ui free of component imports. Default with no provider = pane-initial (floor applies), the Q15-safe direction for tests/playground. Pinned by three new tests: fresh hook instance with `itemId` + `targetLength > 0` mounted after the pane is established → paces from zero, cache not floored; pane-initial variant through the real `TranscriptContextProviders` → floored/finalized while a late-mounted probe row in the same pane paces; session swap on a live provider → the swapped-in row is floored again.
2. **`transcriptHydrated=false` never trusted (test added):** reconcile test now pins that a slot with an open stream, `current` freshness, and no gap is still rehydrated when `transcriptHydrated` is false.
3. **Cap tiebreak comment:** `hot-session-policy.ts` documents that the lexicographic session-id tiebreak is arbitrary-but-stable and states the cap contract (priority wins strictly; stability prevents stream churn across resolutions). No behavior change.
4. **Render-phase cache write comment expanded:** states why render-time is required (the floor must exist before this render's children — TranscriptItemBlock → AssistantMessage — mount and seed from the cache; an effect runs after first paint, too late to stop a one-frame replay) and the StrictMode/concurrent-safety argument (idempotent + monotonic; double-invoke finds the floor at targetLength and skips; an abandoned render only raised the floor toward "more finalized" and a retry re-derives it).

**Negative controls (round 2):** floor gate reverted to ignore `paneEstablishedAtMount` → exactly the 2 gate-dependent frontier tests fail; `transcriptHydrated` dropped from the reconcile trust condition → exactly the new never-trusted test fails; both restored. Full suite after `pnpm --filter @proliferate/product-client build`: **968 files / 7018 tests passed**.

## Performance dependency (R18 renderer diagnosis)

R18's renderer diagnosis found that each kept-open background stream is an independent roughly-60Hz flush source, and today every flush triggers an app-wide O(all-sessions) directory recompute: executionSummary identity churn defeats the directory store's reference-equality guard. Until the planned directory-scoping rung lands (stabilize executionSummary identity plus per-workspace-scoped activity subscriptions), this PR's up-to-12 background streams multiply that recompute roughly linearly in stream count, which raises the sustained renderer CPU floor on high-workspace-count profiles. Recommendation: land the directory-scoping rung first, or accept a temporarily raised floor on 40-workspace-scale profiles. No code change to this PR; its semantics and trust predicate are unaffected.

## Base pickup (R14 content_stable fix)

R14's honesty-bug fix landed as an append-only commit on `ux-latency/r14-switch-critical-path` (19e16b111, gating deferred content_stable on transcriptHydrated instead of scaffold). Picked up via a plain merge (3d13a5a94) rather than a rebase so the reviewed hardening commit 402a38932 keeps its SHA; regular push, no history rewrite. Zero conflicts (the fix touches only SessionTranscriptPane, no overlap with R15 files). After dist rebuild: R15 suites plus the new SessionTranscriptPane gating test pass (5 files / 32 tests), full suite **969 files / 7020 tests passed**.
