### PR TITLE
fix(product): keep the sidebar selection highlight always animating

### DIFF
--- a/apps/packages/product-client/src/primitives/patterns/sidebar/SidebarRowSurface.test.tsx
+++ b/apps/packages/product-client/src/primitives/patterns/sidebar/SidebarRowSurface.test.tsx
@@ -1,42 +1,44 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
 import { SidebarRowSurface } from "#product/primitives/patterns/sidebar/SidebarRowSurface";
 
 afterEach(cleanup);
 
-function flushFrame() {
-  act(() => {
-    vi.advanceTimersToNextFrame();
-  });
-}
-
 describe("SidebarRowSurface", () => {
-  it("always settles into bg-selected, even after many rapid re-selections in the same tick", () => {
-    vi.useFakeTimers();
+  it("applies bg-selected on the very next render, even after many rapid re-selections in the same tick", () => {
     const { container, rerender } = render(<SidebarRowSurface active={false}>Row</SidebarRowSurface>);
     const row = () => container.firstElementChild as HTMLElement;
 
     expect(row().className).not.toContain("bg-selected");
 
-    // Simulate many workspace switches landing faster than a paint: active
-    // flips true/false/true repeatedly before any frame is settled.
+    // Simulate a fast sweep: many switches land in quick succession, with no
+    // paint (and thus no animation frame) guaranteed between any of them.
     for (let i = 0; i < 20; i += 1) {
       rerender(<SidebarRowSurface active={i % 2 === 0}>Row</SidebarRowSurface>);
     }
     rerender(<SidebarRowSurface active>Row</SidebarRowSurface>);
 
-    // data-active reflects the true logical state immediately.
+    // The highlight must be visible on this render already: waiting on a
+    // frame (rAF-style deferral) is exactly what breaks under main-thread
+    // saturation, since the deferred frame may never come in time.
     expect(row().getAttribute("data-active")).toBe("true");
-
-    // The visual class hasn't jumped yet: it settles one animation frame
-    // behind so the browser always paints a real, distinct "before" frame.
-    expect(row().className).not.toContain("bg-selected");
-
-    flushFrame();
-
     expect(row().className).toContain("bg-selected");
-    vi.useRealTimers();
+  });
+
+  it("excludes background-color from the transition set while active, so activation paints instantly", () => {
+    const { container } = render(<SidebarRowSurface active>Row</SidebarRowSurface>);
+    const row = container.firstElementChild as HTMLElement;
+
+    expect(row.className).toContain("transition-[color,opacity]");
+    expect(row.className).not.toContain("transition-[background-color,color,opacity]");
+  });
+
+  it("keeps background-color in the transition set while inactive, so deselect/hover still fades", () => {
+    const { container } = render(<SidebarRowSurface active={false}>Row</SidebarRowSurface>);
+    const row = container.firstElementChild as HTMLElement;
+
+    expect(row.className).toContain("transition-[background-color,color,opacity]");
   });
 });

--- a/apps/packages/product-client/src/primitives/patterns/sidebar/SidebarRowSurface.test.tsx
+++ b/apps/packages/product-client/src/primitives/patterns/sidebar/SidebarRowSurface.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SidebarRowSurface } from "#product/primitives/patterns/sidebar/SidebarRowSurface";
+
+afterEach(cleanup);
+
+function flushFrame() {
+  act(() => {
+    vi.advanceTimersToNextFrame();
+  });
+}
+
+describe("SidebarRowSurface", () => {
+  it("always settles into bg-selected, even after many rapid re-selections in the same tick", () => {
+    vi.useFakeTimers();
+    const { container, rerender } = render(<SidebarRowSurface active={false}>Row</SidebarRowSurface>);
+    const row = () => container.firstElementChild as HTMLElement;
+
+    expect(row().className).not.toContain("bg-selected");
+
+    // Simulate many workspace switches landing faster than a paint: active
+    // flips true/false/true repeatedly before any frame is settled.
+    for (let i = 0; i < 20; i += 1) {
+      rerender(<SidebarRowSurface active={i % 2 === 0}>Row</SidebarRowSurface>);
+    }
+    rerender(<SidebarRowSurface active>Row</SidebarRowSurface>);
+
+    // data-active reflects the true logical state immediately.
+    expect(row().getAttribute("data-active")).toBe("true");
+
+    // The visual class hasn't jumped yet: it settles one animation frame
+    // behind so the browser always paints a real, distinct "before" frame.
+    expect(row().className).not.toContain("bg-selected");
+
+    flushFrame();
+
+    expect(row().className).toContain("bg-selected");
+    vi.useRealTimers();
+  });
+});

--- a/apps/packages/product-client/src/primitives/patterns/sidebar/SidebarRowSurface.tsx
+++ b/apps/packages/product-client/src/primitives/patterns/sidebar/SidebarRowSurface.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef, useState } from "react";
 import type { ButtonHTMLAttributes, HTMLAttributes, KeyboardEvent, ReactNode } from "react";
 
 import { twMerge } from "#product/primitives/utils/tw-merge";
@@ -11,34 +10,6 @@ interface SidebarRowSurfaceProps extends Omit<HTMLAttributes<HTMLElement>, "onCl
   onPress?: () => void;
 }
 
-/**
- * Rapid successive selections can flip `active` true/false/true across several
- * React commits that land faster than the browser paints a frame in between,
- * so the transition's start and end styles are identical at the next paint
- * and it silently never runs. Settling the value one animation frame behind
- * `active` guarantees the previous state is actually painted before we ever
- * commit the flip to the new one, so the transition always has two distinct
- * frames to animate between.
- */
-function useSettledActive(active: boolean): boolean {
-  const [settled, setSettled] = useState(active);
-  const frameRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    if (active === settled) {
-      return undefined;
-    }
-    frameRef.current = requestAnimationFrame(() => setSettled(active));
-    return () => {
-      if (frameRef.current !== null) {
-        cancelAnimationFrame(frameRef.current);
-      }
-    };
-  }, [active, settled]);
-
-  return settled;
-}
-
 export function SidebarRowSurface({
   children,
   as = "div",
@@ -48,22 +19,39 @@ export function SidebarRowSurface({
   className = "",
   ...props
 }: SidebarRowSurfaceProps) {
-  const settledActive = useSettledActive(active);
   const interactive = typeof onPress === "function" && !disabled;
   // Hover sits one step below the selected row so a committed selection reads
   // stronger than a transient hover (previously both used the same accent, so
   // hovering any row looked identical to the active one).
-  const stateClass = settledActive
+  const stateClass = active
     ? "bg-selected text-sidebar-foreground"
     : disabled
       ? "text-sidebar-muted-foreground"
       : "text-sidebar-foreground hover:bg-hover active:bg-active";
 
+  // A rapid sweep through many rows (e.g. holding a next/prev-workspace
+  // shortcut) pins the main thread with a long task per switch, so the
+  // browser only manages a handful of paints across the whole sweep. At
+  // ~5fps every painted frame catches a still-fading-in bg-selected at
+  // ~0 alpha (duration-hover is 120ms) -- the highlight never becomes
+  // visible until the sweep stops and a fade finally gets enough frames to
+  // finish. There is no frame budget a settle/defer trick can buy back here:
+  // an earlier version of this file deferred the active class by one
+  // rAF to fix a *different* bug (same-row net-zero flips suppressing the
+  // transition entirely), but under this frame-starved path that deferral
+  // made things worse -- its own rAF callback could be starved for the same
+  // reason, delaying the highlight even further. Instead, activating a row
+  // never transitions background-color at all: it paints solid on the very
+  // first available frame, so it's visible even at 5fps. Deactivating a row
+  // is unaffected by the starvation (it doesn't need to be seen instantly)
+  // and keeps the fade so hover/deselect still feels soft.
+  const colorTransition = active ? "transition-[color,opacity]" : "transition-[background-color,color,opacity]";
+
   // Sidebar row geometry (retune): 30px rows, 10px radius (--radius-lg).
   // twMerge so a caller-provided size token (text-sidebar-nav etc.) actually
   // replaces a baseline size instead of fighting it on stylesheet order.
   const rowClassName = twMerge(
-    `group relative flex w-full min-w-0 items-center rounded-lg text-left font-control transition-[background-color,color,opacity] duration-hover ${
+    `group relative flex w-full min-w-0 items-center rounded-lg text-left font-control ${colorTransition} duration-hover ${
       interactive ? "cursor-pointer select-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-sidebar-ring" : ""
     } ${
       disabled ? "cursor-not-allowed opacity-60" : ""

--- a/apps/packages/product-client/src/primitives/patterns/sidebar/SidebarRowSurface.tsx
+++ b/apps/packages/product-client/src/primitives/patterns/sidebar/SidebarRowSurface.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import type { ButtonHTMLAttributes, HTMLAttributes, KeyboardEvent, ReactNode } from "react";
 
 import { twMerge } from "#product/primitives/utils/tw-merge";
@@ -10,6 +11,34 @@ interface SidebarRowSurfaceProps extends Omit<HTMLAttributes<HTMLElement>, "onCl
   onPress?: () => void;
 }
 
+/**
+ * Rapid successive selections can flip `active` true/false/true across several
+ * React commits that land faster than the browser paints a frame in between,
+ * so the transition's start and end styles are identical at the next paint
+ * and it silently never runs. Settling the value one animation frame behind
+ * `active` guarantees the previous state is actually painted before we ever
+ * commit the flip to the new one, so the transition always has two distinct
+ * frames to animate between.
+ */
+function useSettledActive(active: boolean): boolean {
+  const [settled, setSettled] = useState(active);
+  const frameRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (active === settled) {
+      return undefined;
+    }
+    frameRef.current = requestAnimationFrame(() => setSettled(active));
+    return () => {
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current);
+      }
+    };
+  }, [active, settled]);
+
+  return settled;
+}
+
 export function SidebarRowSurface({
   children,
   as = "div",
@@ -19,11 +48,12 @@ export function SidebarRowSurface({
   className = "",
   ...props
 }: SidebarRowSurfaceProps) {
+  const settledActive = useSettledActive(active);
   const interactive = typeof onPress === "function" && !disabled;
   // Hover sits one step below the selected row so a committed selection reads
   // stronger than a transient hover (previously both used the same accent, so
   // hovering any row looked identical to the active one).
-  const stateClass = active
+  const stateClass = settledActive
     ? "bg-selected text-sidebar-foreground"
     : disabled
       ? "text-sidebar-muted-foreground"


### PR DESCRIPTION
## Finding 1: transition never plays on rapid re-selection (fixed in the first commit)

The workspace row highlight lives in `apps/packages/product-client/src/primitives/patterns/sidebar/SidebarRowSurface.tsx`. It applies a plain CSS transition (`transition-[background-color,color,opacity] duration-hover`), with the active/inactive class swapped via a boolean `active` prop, on a row keyed stably on `item.id` (no remount, no keyframe animation, no reduced-motion/instant flag involved for this path, all ruled out by direct code inspection).

The row's `active` boolean is recomputed fresh every render from the selection store (no stale memoization). Each click synchronously updates the store and produces its own React commit. The bug is not a React batching or stale-prop issue: it is the browser's rendering pipeline coalescing rapid same-frame style mutations. When workspace switches land faster than a paint, the same row's `active` value can flip true/false/true across several commits before the browser ever paints an intermediate frame. CSS transitions only animate between the style actually painted in the last frame and the style computed in the next painted frame; any values written and overwritten in between are invisible to the transition engine. If the row that ends up finally selected nets out to the same value it last had a real paint for (true -> true across the skipped window), no transition fires even though `data-active`/`bg-selected` land correctly in the DOM.

First fix: settle the class-driving value one animation frame behind `active` via a `useSettledActive` hook, guaranteeing a real, previously-painted "before" frame exists for the transition to animate from.

## Finding 2: no highlight at all during a fast Cmd+Opt+Arrow sweep (fixed in the second commit)

Live-testing a build with the first fix still reproduced a related but distinct symptom: sweeping through workspaces very quickly shows no sidebar highlight at all until movement stops.

Measured root cause: every workspace switch runs a 130-200ms main-thread long task. During a fast sweep the browser only manages a handful of paints across the whole sequence (roughly 5fps, frame gaps of 130-240ms). The row highlight (`bg-selected` at 3.2% alpha) fades in over `duration-hover` (120ms). At roughly 5fps, every painted frame catches that fade at close to zero alpha, so the highlight never becomes visible until the sweep stops and a fade finally gets enough frames to finish. No transition-triggering fix can help here because there are no frames to animate across.

Worse, the `useSettledActive` rAF-based settle from finding 1 made this failure mode worse rather than better: its own animation-frame callback is starved by the exact same main-thread saturation, so under a fast sweep the highlight application itself could be delayed indefinitely (matching the reported "no highlight until movement stops"), not merely fail to animate.

Second fix: removed `useSettledActive` (it no longer has a role: see below) and instead exclude `background-color` from the transition set while a row is active, keeping it in the set while inactive. Activating a row now paints `bg-selected` solid on the very first available frame regardless of frame rate, so it is visible even at 5fps. Deactivating a row is unaffected by the starvation (it does not need to be seen instantly) and keeps the fade, so hover/deselect still feels soft. Keyed on the immediate `active` prop, not a settled value, since the whole point is for activation to require zero frames.

Why `useSettledActive` was removed rather than kept alongside: it existed only to guarantee an intermediate painted frame so a *transition* could play across it. With `background-color` no longer transitioning while active, there is no transition left for it to guarantee frames for on the activation path, and keeping it would reintroduce the exact starvation risk that caused finding 2. Deactivation was never reported as broken and keeps its transition unmodified, so nothing else needed the settle either.

No new duration/token was introduced; the existing `duration-hover` cadence token and reduced-motion handling in the design package are untouched. The R18 workstream separately owns the underlying ~150ms per-switch main-thread long task; this PR does not attempt to reduce it, only to make the highlight correct regardless of how many frames are available.

## Test evidence

`apps/packages/product-client/src/primitives/patterns/sidebar/SidebarRowSurface.test.tsx`:
- simulates 20+ rapid re-selections landing in the same tick and asserts the row shows `bg-selected` on the very next render (no waiting on a frame)
- asserts an active row's className excludes `background-color` from its transition set
- asserts an inactive row's className includes `background-color` in its transition set

```
 Test Files  4 passed (4)
      Tests  44 passed (44)
 (SidebarRowSurface.test.tsx: 3, MainSidebar.cloud-gating.test.tsx: 2, WorkspaceItem.test.tsx: 15, MainSidebar.test.tsx: 24)
```

Negative control (finding 2): reverted the conditional transition to the unconditional `transition-[background-color,color,opacity]` and reran; the new transition-set test failed as expected:

```
 x SidebarRowSurface > excludes background-color from the transition set while active, so activation paints instantly
   AssertionError: expected '...' to contain 'transition-[color,opacity]'
```

Restored the fix and confirmed all 44 tests green again before pushing.

Negative control (finding 1, from the first commit): reverted the settle indirection so the class read `active` directly; the regression test failed as expected (`expected ... not to contain 'bg-selected'`). Restored and confirmed green.

## Test plan
- [x] `SidebarRowSurface.test.tsx` (3 tests, both findings covered, both negative controls verified)
- [x] `MainSidebar.test.tsx`, `MainSidebar.cloud-gating.test.tsx`, `WorkspaceItem.test.tsx` all green