### PR TITLE
docs(product): as-built target doc for UX Latency + Transitions ladder

### DIFF
--- a/specs/codebase/systems/product/README.md
+++ b/specs/codebase/systems/product/README.md
@@ -23,6 +23,7 @@ restating folder rules or low-level reusable contracts.
 | Agents | The agent-systems overview map (distribution, auth, gateway, model catalog), plus delegated-work UX and cowork artifact lifecycle. | [agents/README.md](agents/README.md) |
 | Settings and appearance | Settings/admin information architecture, Appearance scaling, billing/account/team/config surfaces, filtering, origins, and admin-facing state. | [settings/README.md](settings/README.md) |
 | Support reporting | Currently shipped private support capture. | [support/README.md](support/README.md) |
+| UX Latency + Transitions | Loading-treatment state machine and tokens, the chat pane's hero loading mark, sidebar row activation transition, and held-key workspace switching. | [ux-latency-transitions.md](ux-latency-transitions.md) (Status: target) |
 | Web/Desktop client unification | Shared client ownership, thin Desktop/Web hosts, capability policy, and migration governance. | [clients/web-desktop-unification/README.md](clients/web-desktop-unification/README.md) |
 
 ## Outline Coverage

--- a/specs/codebase/systems/product/chat/README.md
+++ b/specs/codebase/systems/product/chat/README.md
@@ -11,6 +11,7 @@ Start with the product task you intend to change:
 | Change tab ordering, restoration, or projected-shell mechanics | [Workspaces](../workspaces/README.md) |
 | Change model identity, availability, or selection action classification | [Model Catalog](../../../../FEATURE_DOCS/MODELS.md) |
 | Change session actors, live config, process retirement, or relaunch | [AnyHarness sessions](../../../../anyharness/sessions.md) |
+| Change the workspace-status/session-loading wait treatment | [UX Latency + Transitions](../ux-latency-transitions.md) (Status: target) |
 | Decide where frontend source belongs | [Frontend structure](../../../../frontend/README.md) |
 
 Each focused document owns its listed product behavior and links to its

--- a/specs/codebase/systems/product/ux-latency-transitions.md
+++ b/specs/codebase/systems/product/ux-latency-transitions.md
@@ -26,9 +26,12 @@ Fences, one owner per concern:
 - **Session selection** ([workspaces/session-selection.md](workspaces/session-selection.md))
   owns which session is visible inside an already-open workspace; this
   document owns switching which workspace is open.
-- **Chat lifecycle** ([chat/lifecycle.md](chat/lifecycle.md)) owns the
-  `mode.kind` state machine the chat pane dispatches on; this document owns
-  what renders while a `workspace-status`/`session-loading` mode is active.
+- The `mode.kind` union the chat pane dispatches on (`workspace-status`,
+  `session-loading`, `session-transcript`) is defined in
+  [chat-surface.ts](../../../../apps/packages/product-client/src/lib/domain/chat/surface/chat-surface.ts),
+  already on `main`; no spec owns that state machine today. This document
+  owns only what renders while a `workspace-status`/`session-loading` mode
+  is active, not the state machine itself.
 
 ## Loading treatments
 

--- a/specs/codebase/systems/product/ux-latency-transitions.md
+++ b/specs/codebase/systems/product/ux-latency-transitions.md
@@ -1,0 +1,235 @@
+# UX Latency + Transitions
+
+Status: target. This document describes the accepted destination for
+perceived-latency behavior and loading/transition treatments across the
+product client. The body is written in the ideal state. Every difference
+from `main` today is listed in [Current gaps](#current-gaps); the list
+shrinks as the delivery ladder's PRs merge, and the label comes off when it
+is empty.
+
+Frozen delivery base: `6b5aa59896c9cdb90850db8fd9b9fea05971ffc2`.
+
+Owns the perceived-latency contract from the UX Latency + Transitions ADR:
+the loading-treatment state machine and its tokens, the chat pane's hero
+loading mark, the sidebar's held-key workspace traversal, and the sidebar
+row activation transition. Renderer instrumentation for these flows
+(`renderer.flow.*`, `renderer.loading.*` marks) is described where it is
+emitted, not re-derived here.
+
+Fences, one owner per concern:
+
+- **This document owns the interaction/perception contract; [DESIGN_SYSTEM.md](../../../DESIGN_SYSTEM.md)
+  owns the token values and component tier placement.** Once the ladder
+  merges, the token and sanctioned-index entries below move into
+  DESIGN_SYSTEM.md's current material and this document stops repeating
+  them.
+- **Session selection** ([workspaces/session-selection.md](workspaces/session-selection.md))
+  owns which session is visible inside an already-open workspace; this
+  document owns switching which workspace is open.
+- **Chat lifecycle** ([chat/lifecycle.md](chat/lifecycle.md)) owns the
+  `mode.kind` state machine the chat pane dispatches on; this document owns
+  what renders while a `workspace-status`/`session-loading` mode is active.
+
+## Loading treatments
+
+A `LoadingBoundary` primitive (`apps/packages/product-client/src/primitives/LoadingBoundary.tsx`,
+not yet on `main`, see [Current gaps](#current-gaps))
+is the single owner of the loading-treatment state machine. Callers pass a
+discriminated `pending | empty | ready` state and a treatment slot; the
+boundary never hand-rolls a `content-fade-in` + `animation-delay` show-delay
+per call site.
+
+| Value | ms | Role |
+| --- | --- | --- |
+| `loading.showDelayMs` | 200 | No loading treatment mounts until a wait has lasted this long, so a resolution faster than 200ms never flashes a treatment at all. |
+| `loading.minDisplayMs` | 300 | A mounted treatment stays at least this long before yielding to resolved or empty content, so a just-appeared treatment cannot flash back out. |
+| `loading.heroMinDisplayMs` | 420 | The chat loading hero's mark-specific floor (below), longer than the generic floor because the hero is a larger, more prominent mark. |
+
+Doctrine, all load-bearing:
+
+- The state is discriminated, never a boolean. `empty` is a resolved outcome
+  and may only render after data lands; while `pending` the boundary shows
+  the treatment or nothing, never the empty slot.
+- The one sanctioned reveal is `content-fade-in` at `--duration-enter`;
+  reduced motion disables the fade so content appears instantly.
+- Skeletons are a carve-out, not a default: sanctioned only for the sidebar
+  workspace list and the repo picker rows, both routed through
+  `LoadingBoundary` as the treatment slot. Every other loading surface is
+  Class C (stable shell, no skeleton).
+
+### Chat loading hero (R16)
+
+The chat pane's `workspace-status`/`session-loading` wait state
+([ChatLoadingHero.tsx](../../../../apps/packages/product-client/src/components/workspace/chat/surface/ChatLoadingHero.tsx))
+renders a `DotCellLoader` in its `hero` size tier, mark-only: no caption or
+workspace-name copy. The surrounding container carries `role="status"` and
+`aria-label="Loading conversation"`; the mark itself is `aria-hidden`, so
+assistive tech gets one status announcement instead of narrating a
+decorative animation. `ThinkingText` (the `awaiting-first-turn` substep)
+stays outside this treatment, since it is agent-activity feedback inside
+otherwise-ready content, not a wait state.
+
+`hero` is a new `DotCellLoaderSize` tier
+([DotCellLoader.tsx](../../../../apps/packages/product-client/src/primitives/DotCellLoader.tsx)),
+styled via `.dot-cell-loader[data-size="hero"]` in
+[product.css](../../../../apps/packages/design/src/css/product.css) with its
+own `--dot-cell-size`/`--dot-cell-gap` pair, smaller and tighter than the
+default tier.
+
+Because `ChatLoadingHero` hardcodes `state="pending"` for its whole life
+(the parent `ChatView` mounts it only while a wait mode is active and
+unmounts it synchronously on resolve), `LoadingBoundary`'s own min-display
+and fade-out machinery never fires from inside it — that machinery only
+engages on a local transition away from `pending`, and this component never
+makes one. Resolution here is `ChatView` switching `mode.kind` and tearing
+this component down, not a state change this component owns.
+
+`ChatLoadingHero` instead reports the instant its treatment becomes visible
+through an `onTreatmentShown` callback. `useChatLoadingHeroExit`
+(`apps/packages/product-client/src/hooks/chat/ui/use-chat-loading-hero-exit.ts`,
+not yet on `main`, see [Current gaps](#current-gaps))
+owns the exit choreography from that instant: it holds a `holding` phase for
+`loading.heroMinDisplayMs` (420ms) past the shown timestamp even if
+`mode.kind` flips away sooner, then a `fading` phase for `duration.exitMs`
+(120ms), then returns to `idle`. `ChatView` keeps a frozen
+`ChatLoadingHeroExitOverlay` mounted for the `holding`/`fading` phases on top
+of whatever real content `mode.kind` has already switched to underneath, so
+a fast resolve never cuts the mark off mid-mount. A wait that never crosses
+the 200ms show-delay has no shown timestamp, so `phase` stays `idle` and the
+mode switch takes effect immediately, unchanged from before R16.
+
+A workspace that has already bootstrapped in this browser session never
+mounts the hero mark at all
+(`hasWorkspaceBootstrappedInSession`), so revisiting an already-settled
+workspace does not re-show a loading treatment for it.
+
+## Sidebar row activation transition (R17)
+
+`SidebarRowSurface`
+([SidebarRowSurface.tsx](../../../../apps/packages/product-client/src/primitives/patterns/sidebar/SidebarRowSurface.tsx))
+excludes `background-color` from its transitioned properties while a row is
+**activating**, and includes it while **deactivating**:
+
+- Activating a row paints its selected background solid on the first
+  available frame instead of fading in.
+- Deactivating a row keeps the fade, so hover/deselect still reads soft.
+
+This asymmetry exists because a rapid sidebar sweep (holding the
+next/prev-workspace shortcut) pins the main thread with a long task per
+switch, so the browser only manages to paint a handful of frames across the
+whole sweep. At roughly 5fps, every painted frame catches a still-fading-in
+background at near-zero alpha, and the highlight never reads as visible
+until the sweep stops. There is no frame budget a settle-by-one-frame trick
+can buy back here: a settle deferral (delaying which value drives the class
+by one `requestAnimationFrame`) fixes a *different* bug (a same-row net-zero
+flip across commits faster than a paint, which otherwise suppresses the
+transition entirely) but makes the frame-starved sweep worse, since the
+deferral's own callback can be starved for the same reason. Excluding
+`background-color` from the activating transition sidesteps the starvation
+instead of racing it: activation has nothing left to finish painting, so it
+is correct even at 5fps.
+
+## Sidebar workspace switching (R19)
+
+Held-key workspace traversal (`Cmd+Opt+Left/Right`,
+`workspace.previous-workspace` / `workspace.next-workspace`) is a two-phase
+switch: a cheap preview cursor during traversal, one expensive selection
+commit after it settles.
+
+```text
+useAppShortcuts (React glue: refs to current target ids / commit action)
+  └── createWorkspaceSwitchCursorController   pure state machine, no React/DOM
+        step(direction)                        throttled cursor advance
+        onCommittedChange(committedId)          reconciles/cancels vs. an external commit
+        cancel()                                Escape / abandon
+  └── useSidebarSwitchCursorStore (zustand)    { cursorId }
+        └── WorkspaceItem                       displayedActive selector
+```
+
+- `workspace-switch-cursor-controller.ts` (`apps/packages/product-client/src/lib/domain/workspaces/sidebar/workspace-switch-cursor-controller.ts`,
+  not yet on `main`, see [Current gaps](#current-gaps))
+  is free of React, DOM, and any concrete timer or store; `useAppShortcuts`
+  injects `now`/`setTimer`/`clearTimer` and store accessors so the throttle,
+  settle, and commit-reflection edges are unit-testable with fake timers.
+- **Throttle.** A step is accepted only after `WORKSPACE_CURSOR_STEP_MIN_MS`
+  (60ms) since the last accepted step; a repeat inside that window is
+  dropped, never queued, so releasing a held key never replays a backlog.
+- **Settle.** Every accepted step (including a dropped repeat) re-arms a
+  `WORKSPACE_CURSOR_SETTLE_MS` (180ms) quiet timer; only when that timer
+  fires uninterrupted does the controller commit the previewed workspace as
+  the real selection.
+- **Commit reflection / fallback.** After calling `commitSelection`, the
+  controller tracks the id it expects the committed-selection store to
+  reflect. `WORKSPACE_CURSOR_COMMIT_FALLBACK_MS` (2000ms) bounds how long it
+  waits before clearing the cursor unconditionally, covering a commit that
+  fails (error toast path) or is superseded.
+- **Click-beats-pending-commit.** If the committed-selection store changes
+  to something other than the controller's own pending commit while a
+  commit is in flight, or changes at all while only a preview (no commit) is
+  in flight, the controller treats it as an external actor (a mouse click on
+  another row) winning and abandons its own preview.
+- **Escape cancels.** A capture-phase, non-`preventDefault` listener cancels
+  an in-progress preview on `Escape`, without interfering with any other
+  `Escape` handling.
+- **Vanished-id guard.** If the previewed row's id is no longer in the
+  current sidebar traversal order when the settle timer fires (the target
+  list changed mid-traversal), the controller drops the preview instead of
+  committing a stale id.
+
+`WorkspaceItem`
+([WorkspaceItem.tsx](../../../../apps/packages/product-client/src/components/workspace/shell/sidebar/WorkspaceItem.tsx))
+reads a per-row selector that folds its own id and the committed `active`
+prop into one `displayedActive` boolean: while a cursor is set, the cursor
+position drives the highlight and the committed selection's highlight is
+suppressed, so exactly one row reads active during traversal and a cursor
+step re-renders only the two rows whose displayed state flips.
+
+Test-only: `vitest.config.ts` maps the public
+`@proliferate/product-client/internal/*` subpath to source, alongside the
+existing `@proliferate/product-client/host/*` mapping, so a test whose graph
+reaches product-client's diagnostics port through that subpath runs against
+source instead of requiring a package build first. It carries no runtime
+behavior; it exists only so the test lane keeps the same "tests run against
+source, never dist" rule the file already states for the `host/*` subpath.
+
+### React-query stabilization (R19 companion)
+
+Two shell-wide query-hook fixes reduce the switch-triggered wide re-render
+this two-phase switch exists to keep off the traversal path:
+
+- `getProliferateApiOrigin`
+  ([proliferate-api.ts](../../../../apps/packages/product-client/src/lib/infra/proliferate-api.ts))
+  memoizes the last resolved origin instead of constructing a fresh `new
+  URL(...)` on every render across the many query hooks that call it.
+- `useRepoPrStatuses`
+  ([use-repo-pr-statuses.ts](../../../../apps/packages/product-client/src/hooks/workspaces/cache/use-repo-pr-statuses.ts))
+  memoizes its per-repo query descriptors and its `combine` callback, so a
+  shell re-render no longer rebuilds every query option object and forces
+  react-query observer churn when the inputs are unchanged.
+
+## Current gaps
+
+Deltas between this document and `main` today, each struck by its follow-up
+PR:
+
+- [ ] **Ladder not merged.** None of R1-R19 is on `main` yet. The full PR
+      chain: #1917, #1920, #1926, #1930 (R1-R4), #1913, #1918, #1924, #1914
+      (R5-R8), #1923 (R9), #1927 (R10), #1929 (R11), #1970 (R13),
+      #1968 (R14), #1969 (R15), and the R16/R17/R19 PRs delivering the
+      chat loading hero, the sidebar activation transition, and the
+      two-phase switch described above. All are CI-green and reviewed;
+      none merged as of this writing.
+- [ ] **R19 leg 3 (deferred pane) left out, by design, not by gap.** The
+      ADR's two-phase switch originally scoped a third leg: deferring the
+      expensive pane mount itself during a rapid sweep, on top of the
+      preview-cursor leg documented above. Leg 1 (the preview cursor) already
+      makes every intermediate workspace during a sweep vanish before its
+      pane would ever mount, so a separate deferred-pane mechanism would be
+      unmeasured machinery protecting against a case leg 1 already
+      eliminates. This is a closed scope decision, not an open item; it is
+      listed here only so a reader does not go looking for a third leg.
+- [ ] **T4 booted-app latency measurement stays open.** #1970 delivers the
+      `composer_submit`/`mode_switch` instrumentation marks; the booted-app
+      measurement run validating the ADR's latency budgets against real
+      traces has not happened (no-app-boot constraint during the ladder's
+      build). Tracked as R12 in the ADR, not by this document.

--- a/specs/codebase/systems/product/ux-latency-transitions.md
+++ b/specs/codebase/systems/product/ux-latency-transitions.md
@@ -73,15 +73,17 @@ otherwise-ready content, not a wait state.
 ([DotCellLoader.tsx](../../../../apps/packages/product-client/src/primitives/DotCellLoader.tsx)),
 styled via `.dot-cell-loader[data-size="hero"]` in
 [product.css](../../../../apps/packages/design/src/css/product.css) with its
-own `--dot-cell-size`/`--dot-cell-gap` pair, smaller and tighter than the
-default tier.
+own `--dot-cell-size`/`--dot-cell-gap` pair: `0.375rem`/`0.25rem` (6px dots,
+4px gap), against the default tier's `0.1875rem`/`0.125rem` (3px dots, 2px
+gap) and the `compact` tier's `0.15625rem`/`0.09375rem`. The 3x3 grid this
+produces is 26px square, the largest of the three tiers.
 
 Because `ChatLoadingHero` hardcodes `state="pending"` for its whole life
 (the parent `ChatView` mounts it only while a wait mode is active and
 unmounts it synchronously on resolve), `LoadingBoundary`'s own min-display
-and fade-out machinery never fires from inside it — that machinery only
-engages on a local transition away from `pending`, and this component never
-makes one. Resolution here is `ChatView` switching `mode.kind` and tearing
+and fade-out machinery never fires from inside it, because that machinery
+only engages on a local transition away from `pending`, and this component
+never makes one. Resolution here is `ChatView` switching `mode.kind` and tearing
 this component down, not a state change this component owns.
 
 `ChatLoadingHero` instead reports the instant its treatment becomes visible

--- a/specs/codebase/systems/product/workspaces/README.md
+++ b/specs/codebase/systems/product/workspaces/README.md
@@ -10,6 +10,6 @@
 - [Session Selection](session-selection.md) — active-session restoration, the
   visible-session tab invariant, and bounded empty-workspace recovery.
 - [Terminals](terminals.md) — current user-facing terminal behavior.
-- [UX Latency + Transitions](../ux-latency-transitions.md) (Status: target)
-  — held-key sidebar workspace switching, the sidebar row activation
+- [UX Latency + Transitions](../ux-latency-transitions.md) (Status: target):
+  held-key sidebar workspace switching, the sidebar row activation
   transition, and the chat loading hero.

--- a/specs/codebase/systems/product/workspaces/README.md
+++ b/specs/codebase/systems/product/workspaces/README.md
@@ -10,3 +10,6 @@
 - [Session Selection](session-selection.md) — active-session restoration, the
   visible-session tab invariant, and bounded empty-workspace recovery.
 - [Terminals](terminals.md) — current user-facing terminal behavior.
+- [UX Latency + Transitions](../ux-latency-transitions.md) (Status: target)
+  — held-key sidebar workspace switching, the sidebar row activation
+  transition, and the chat loading hero.


### PR DESCRIPTION
## Summary

- Adds `specs/codebase/systems/product/ux-latency-transitions.md`, a `Status: target` system doc covering the loading-treatment state machine and tokens (`loading.showDelayMs`/`minDisplayMs`/`heroMinDisplayMs`), the chat pane's DotCellLoader hero mark and its exit choreography (R16), the sidebar row's asymmetric activation transition (R17), and the two-phase held-key workspace switch plus its react-query stabilization companion (R19).
- Cross-links the new doc from the product systems index, chat, and workspaces READMEs, following the "one owner per concern, everyone else links" rule in `specs/README.md`.
- Notes the test-only `@proliferate/product-client/internal/*` vitest source alias in the R19 section (mirrors the existing `host/*` mapping, no runtime behavior).
- Records two deliberate scope decisions in Current gaps: R19's originally-scoped "leg 3" deferred-pane mechanism was left out because leg 1 (the preview cursor) already makes every intermediate workspace vanish before its pane would mount, so a separate mechanism would be unmeasured machinery; and the booted-app T4 latency measurement run stays open as a separate, already-tracked item (R12 in the ADR).

## Not yet merged: depends on the UX Latency + Transitions ladder

This doc describes destination behavior, not current `main` behavior. Its Current gaps section names the full dependency chain, none of which is merged as of this writing (all CI-green and reviewed): #1917, #1920, #1926, #1930 (R1-R4), #1913, #1918, #1924, #1914 (R5-R8), #1923 (R9), #1927 (R10), #1929 (R11), #1970 (R13, perceived-latency measurement marks), #1968 (R14, switch critical path), #1969 (R15, streaming continuity), and the R16 (DotCellLoader hero tier), R17 (sidebar activation transition), and R19 (two-phase switch) PRs. The `Status: target` label comes off in a follow-up docs PR once the ladder lands on main.

## Test plan

- [x] `python3 scripts/check_docs.py` passes (222 Markdown files, all link targets resolve)
- [x] Manual read-through against each source branch's actual diff (R16/R17/R19 branches) to keep every claim, constant, and file path accurate to what will land
- [ ] Re-verify link targets once the ladder merges and flip `Status: target` off in a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
