### PR TITLE
fix(product): repo-shape line cap on use-workspace-bootstrap-actions (main red)

### DIFF
--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts
@@ -124,10 +124,9 @@ export function useWorkspaceBootstrapActions() {
     // signal). Superseded/stale exits set this so no false content_stable fires.
     let rendererFlowAbandonReason: string | null = null;
     // UX-latency R14: when set, content_stable is DEFERRED to the transcript
-    // pane (the session whose committed transcript is the real stable signal),
-    // so the finally must neither finish nor abandon the flow — it hands the
-    // mark off. Null => finish/abandon here as before (empty workspace, error,
-    // stale: no transcript to wait for).
+    // pane (its committed transcript is the real stable signal), so the finally
+    // neither finishes nor abandons the flow; it hands the mark off. Null =>
+    // finish/abandon here as before (empty workspace, error, stale).
     let deferContentStableSessionId: string | null = null;
     let sessions: WorkspaceSession[] = [];
     // UX-latency R1 canonical flow marks (intent -> shell -> data -> stable).


### PR DESCRIPTION
Main-tip CI run 31941011855 is red on Repo shape checks: LARGE_FRONTEND_FILE, use-workspace-bootstrap-actions.ts at 401 lines (threshold 400). The UX ladder merges combined to 401 even though every PR was green individually, because a PR base retarget does not re-trigger CI; the first check of the combined tree was the post-merge main run.

Fix: compress the R14 defer-content_stable comment from 5 lines to 4, meaning preserved. Comment-only, zero behavior change.

Local verification at this head, literal output:
- report_frontend_structure.py --strict: LARGE_FRONTEND_FILE: 0 / TOTAL: 0 (exit 0)
- check_max_lines.py: Max-lines check passed (repo max 600, component max 500, server layer maxes enabled).

Unblocks the staging pipeline (repo-shape red blocks staging to prod).