### PR TITLE
docs(anyharness): Forks rung 1b adapter-migration artifacts + Codex fork-registration patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ apps/packages/product-client/src/generated/
 
 # Local dev symlink into the root workspace node_modules (never committed)
 tests/release/node_modules
+tmp/

--- a/catalogs/agents/adapter-migration/RUNG-1B-NOTES.md
+++ b/catalogs/agents/adapter-migration/RUNG-1B-NOTES.md
@@ -12,6 +12,29 @@ fork repositories (below) and the live catalog pin flip is gated (see §3).
 | Claude | github.com/agentclientprotocol/claude-agent-acp v0.66.0 | `6b405138fc82be947964612fac04e56654827b66` | `proliferate-ai/claude-agent-acp@81a4d52e6bfe8f636d6818c6c48c29be28dca35d` | `v0.66.0-proliferate.1` |
 | Codex | github.com/agentclientprotocol/codex-acp v1.1.14 | `5faefec5d55ded33c54b68ffec93def4f6c547f5` | `proliferate-ai/codex-acp@219738c9dd4205d3c70ab950f5f22cc3b28103c4` | `v1.1.14-proliferate.1` |
 
+### Canonical tag-peel provenance (pin by peeled commit, never tag-object SHA)
+
+Rule: the catalog and any locks pin the **peeled commit**, never a tag-object
+SHA. Resolution tooling MUST peel annotated tags (`refs/tags/<v>^{}`) before
+pinning. Provenance for each canonical ref (`git ls-remote`):
+
+- **codex-acp v1.1.14 — ANNOTATED tag.** Tag object
+  `c82ecc31a5b73014e13a91fa1c3251252ce55f94` peels (`^{}`) to commit
+  `5faefec5d55ded33c54b68ffec93def4f6c547f5`. Pin the peeled commit
+  `5faefec5d55ded33c54b68ffec93def4f6c547f5`, NEVER the tag-object SHA
+  `c82ecc31a5b73014e13a91fa1c3251252ce55f94`.
+  ```
+  $ git ls-remote https://github.com/agentclientprotocol/codex-acp 'refs/tags/v1.1.14' 'refs/tags/v1.1.14^{}'
+  c82ecc31a5b73014e13a91fa1c3251252ce55f94	refs/tags/v1.1.14
+  5faefec5d55ded33c54b68ffec93def4f6c547f5	refs/tags/v1.1.14^{}
+  ```
+- **claude-agent-acp v0.66.0 — LIGHTWEIGHT tag.** No `^{}` deref; the tag ref
+  points directly at commit `6b405138fc82be947964612fac04e56654827b66`.
+  ```
+  $ git ls-remote https://github.com/agentclientprotocol/claude-agent-acp 'refs/tags/v0.66.0' 'refs/tags/v0.66.0^{}'
+  6b405138fc82be947964612fac04e56654827b66	refs/tags/v0.66.0
+  ```
+
 - Claude fork PR: proliferate-ai/claude-agent-acp#50 (draft).
 - Codex fork PR: proliferate-ai/codex-acp#19 (draft, based on a pushed
   `canonical-1.1.14-base` branch because the old Rust `main` shares no history

--- a/catalogs/agents/adapter-migration/RUNG-1B-NOTES.md
+++ b/catalogs/agents/adapter-migration/RUNG-1B-NOTES.md
@@ -1,0 +1,147 @@
+# Forks ADR rung 1b — adapter migration (coordinates, mechanism, gates)
+
+Engineering record for the Forks ADR rung 1 adapter migration (rung 1b
+continuation, coordinates resolved 2026-08-16). This directory carries the
+repo-side artifacts of the migration; the adapter source changes live in the two
+fork repositories (below) and the live catalog pin flip is gated (see §3).
+
+## 1. Resolved coordinates (consumed as git refs, NOT npm)
+
+| Adapter | Canonical source | Canonical ref | Proliferate fork ref | Tag |
+| --- | --- | --- | --- | --- |
+| Claude | github.com/agentclientprotocol/claude-agent-acp v0.66.0 | `6b405138fc82be947964612fac04e56654827b66` | `proliferate-ai/claude-agent-acp@81a4d52e6bfe8f636d6818c6c48c29be28dca35d` | `v0.66.0-proliferate.1` |
+| Codex | github.com/agentclientprotocol/codex-acp v1.1.14 | `5faefec5d55ded33c54b68ffec93def4f6c547f5` | `proliferate-ai/codex-acp@219738c9dd4205d3c70ab950f5f22cc3b28103c4` | `v1.1.14-proliferate.1` |
+
+- Claude fork PR: proliferate-ai/claude-agent-acp#50 (draft).
+- Codex fork PR: proliferate-ai/codex-acp#19 (draft, based on a pushed
+  `canonical-1.1.14-base` branch because the old Rust `main` shares no history
+  with canonical TS — replacement, not rebase, per ADR §4.1(b)).
+
+### What each fork carries (the sanctioned thin deltas)
+
+Claude — canonical 0.66.0 already ships registered `_session/goal` (set/clear),
+`_session/steering`, nested subagent transcripts, and `unstable_forkSession`.
+The legacy 0.59 fork's goal/loop/transcript deltas are **dropped**. Added:
+- **Inclusive fork anchor** on `session/fork` via `_meta.anyharness.upToMessageId`
+  → SDK `resumeSessionAt` (resume up to and including this message uuid). Absent
+  = tip fork; malformed/unresolvable = hard `invalidParams`, never a silent tip
+  fork (ADR §5 cardinal sin). Extends the existing method — no proprietary fork
+  RPC — so it is upstreamable; the runtime bridge `_anyharness/fork/at` maps onto
+  `session/fork` carrying this meta.
+- **Labeled partial `_anyharness/rewindFiles`** — SDK `Query.rewindFiles`,
+  Write/Edit/NotebookEdit scope only, gated on opt-in
+  `_meta.anyharness.enableFileCheckpointing`. NOT complete restore (that is the
+  runtime checkpoint layer, rung 7).
+- Both advertised at initialize `_meta.anyharness`.
+
+Codex — canonical 1.1.14 already registers `_session/goal` (full set) and
+`_session/steering` (→ App Server `turn/steer`); goals + steering are freebies.
+Added: **`session/fork` registration** mapped onto the native App Server
+`thread/fork`, anchored inclusive on `lastTurnId` via `_meta.anyharness.lastTurnId`.
+Per the pinned 0.147.0 schema (`fixtures/contracts/codex-app-server-schema`, PR
+#1982), `lastTurnId` is the ONLY fork anchor — no `beforeTurnId`/`excludeTurns`.
+
+The committed patch `codex-acp-1.1.14+fork-registration.patch` (this directory)
+is the `src/` diff canonical→fork: a review artifact and a patch-package
+install-time fallback if a consumer prefers canonical-npm + patch over the git
+ref.
+
+## 2. Git-ref consumption mechanism
+
+Both forks add a `prepare` build script (`npm run build` / `node build.mjs`) so
+`npm install <git-url>#<sha>` builds `dist/` from source on install — the same
+mechanism the current Claude catalog pin already relies on. The catalog
+`agentProcess.source` becomes `{ kind: "git", repo, gitRef, executableRelpath }`
+for Codex (matching Claude's existing shape), replacing the current
+`{ kind: "npm" }` Codex pin.
+
+Native bytes are pinned **independently**: canonical codex-acp declares
+`@openai/codex ^0.147.0`, so the catalog's `codex.harness.native` must move from
+`rust-v0.144.5` to the 0.147.0 archive (sha256 recorded alongside the pinned
+schema in `fixtures/contracts/codex-app-server-schema/README.md`).
+
+## 3. Catalog pin flip — GATED (not done in this PR)
+
+The pin flip is gated by TWO validators (ADR rung 1 gate):
+- `scripts/validate-agent-catalog.mjs` (JS tripwire), and
+- `cargo test` against `catalogs/agents/catalog.json` (include_str!'d;
+  `anyharness-lib/.../catalog/validation.rs`).
+
+Both enforce `validateSnapshotEvidence`: every agent's committed probe snapshot
+(`scripts/agent-catalog/generated/<kind>.<ctx>.probe.json`) must attest the
+EXACT `harness.agentProcess.version` (for git sources attestation is mandatory)
+and the EXACT `harness.native.version`. Current snapshots attest
+`claude 0.59.0-proliferate.1 / native 2.1.212` and
+`codex 0.18.3-proliferate.1 / native 0.144.5`.
+
+**Blocker:** flipping to `0.66.0-proliferate.1` (native 2.1.212 unchanged) and
+`1.1.14-proliferate.1` (native 0.147.0) fails both validators until the probe
+snapshots are regenerated. Regeneration (`scripts/agent-catalog/build-catalog.mjs`)
+**spawns each adapter and records its live initialize attestation + native CLI
+version**, which requires real Anthropic / OpenAI auth and the ability to boot
+the adapters — neither available in this delegated environment. This is the same
+class of live-auth gate as the ADR's Tier-3 proofs.
+
+To complete the flip (follow-up, on a box with real auth):
+1. `npm install` each fork by its git ref above; confirm `dist/` builds.
+2. Regenerate probe snapshots via `build-catalog.mjs` against real auth for each
+   auth context (anthropic-api/oauth/bedrock; openai-api/oauth/bedrock).
+3. Update `catalog.json` + `catalog.draft.json`: Claude `agentProcess` git
+   ref/version; Codex `agentProcess.source` → git + new native 0.147.0 archive.
+4. `node scripts/validate-agent-catalog.mjs` and the catalog `cargo test` (obey
+   the one-cargo-build-at-a-time machine rule) must both pass.
+5. Revert path: restore the previous catalog pins (all five old artifacts are
+   unchanged and restorable).
+
+## 4. Session adapter-migration markers + dual-read (ADR R9) — DESIGN
+
+Deferred to a dedicated Rust slice (independently reviewable; not landed here to
+avoid an unverifiable Rust change — this environment cannot safely build the
+runtime, and a sibling agent holds the one-cargo-build slot). The contract:
+
+- **Migration marker** on each session recording the `(adapterVersion,
+  nativeVersion)` pair it was created under, stamped at session create/load, so a
+  session created against the pinned pre-migration adapter is distinguishable
+  from a canonical-migrated one at reattach.
+- **Dual-read** of legacy metadata dialects: sessions created by the old Claude
+  (0.59 fork) and old Codex (Rust 0.18.3 fork) adapters must load through an
+  EXPLICIT compatible path OR fail with an actionable, typed incompatibility —
+  never a silent reinterpretation under the new dialect (R9). The goals membrane
+  (rung 6) versions both GoalPort dialects; the session store versions the
+  transcript/metadata read. Durable normalized `session_events` remain readable
+  regardless (runtime-owned).
+- **Test (Tier 2 fixture):** legacy Claude/Codex session metadata blobs loaded
+  under the new adapters assert explicit compatible-load or typed
+  incompatibility; a regression pin proves durable transcripts still render.
+
+## 5. JS ACP SDK 1.3.0 vs pinned Rust ACP client — QUALIFICATION
+
+Both canonical adapters declare **`@agentclientprotocol/sdk@1.3.0`** (Claude:
+exact `1.3.0`; Codex: `^1.3.0`, lockfile resolves 1.3.0). The runtime speaks ACP
+via its pinned **Rust** ACP client. Qualification findings:
+
+- **Stable v1 wire is the contract.** Both adapters register their handlers
+  against `acp.methods.agent.*` (the stable v1 method table). The Rust client
+  targets the same v1 method names; no v2/Draft methods are on the load-bearing
+  path for rung 1 (fork/steer/goal all ride v1 + `_meta` extensions).
+- **`session/fork` is `unstable_`-prefixed in the SDK** (`unstable_forkSession`)
+  but wired to the stable `session/fork` method spelling; the Rust client
+  dispatches by method string, so the prefix is a JS-side naming detail, not a
+  wire difference.
+- **Extension methods** (`_session/steering`, `_session/goal`,
+  `_anyharness/rewindFiles`) are custom `_`-prefixed requests carried over the
+  same JSON-RPC framing; the Rust client's ext-request path handles them by
+  method string. Capability discovery is via initialize `_meta` (never inferred
+  from harness name).
+- **Open qualification item (needs live cross-process spawn):** confirm the Rust
+  client parses SDK 1.3.0's `ForkSessionResponse` / initialize `_meta` shapes
+  end-to-end and that no framing/line-buffer regression exists between the
+  pinned Rust client and SDK 1.3.0's ndjson writer. This is a Tier-3 spawn test,
+  not a known break — the SDK 1.3.0 wire is v1-compatible by inspection.
+
+## Scope note
+
+This PR carries the repo-side migration artifacts and does NOT flip the live
+catalog pin (§3 blocker) or land the Rust session-marker/dual-read slice (§4,
+separate reviewable slice). The two adapter forks are pushed as draft PRs. No
+merges without Pablo's review.

--- a/catalogs/agents/adapter-migration/codex-acp-1.1.14+fork-registration.patch
+++ b/catalogs/agents/adapter-migration/codex-acp-1.1.14+fork-registration.patch
@@ -1,0 +1,276 @@
+diff --git a/src/AcpExtensions.ts b/src/AcpExtensions.ts
+index a469d51..2d3bbed 100644
+--- a/src/AcpExtensions.ts
++++ b/src/AcpExtensions.ts
+@@ -1,6 +1,7 @@
+ import type {
+     ClientContext,
+     ContentBlock,
++    ForkSessionResponse,
+     LoadSessionResponse,
+     NewSessionResponse,
+     ResumeSessionResponse,
+@@ -57,6 +58,10 @@ export type LegacyResumeSessionResponse = ResumeSessionResponse & {
+     models?: LegacySessionModelState | null;
+ }
+ 
++export type LegacyForkSessionResponse = ForkSessionResponse & {
++    models?: LegacySessionModelState | null;
++}
++
+ export type ExtMethodRequest =
+     AuthenticationStatusRequest
+     | AuthenticationLogoutRequest
+diff --git a/src/CodexAcpClient.ts b/src/CodexAcpClient.ts
+index 714d067..1b10222 100644
+--- a/src/CodexAcpClient.ts
++++ b/src/CodexAcpClient.ts
+@@ -9,6 +9,7 @@ import {
+ import type {EmbeddedResourceResource} from "@agentclientprotocol/sdk";
+ import * as acp from "@agentclientprotocol/sdk";
+ import {type McpServer, RequestError} from "@agentclientprotocol/sdk";
++import {forkAnchorLastTurnId} from "./anyharness-fork";
+ import type {
+     ApprovalHandler,
+     CodexAppServerClient,
+@@ -409,6 +410,37 @@ export class CodexAcpClient {
+         }
+     }
+ 
++    /** AnyHarness delta: fork the source thread into a NEW thread via the App
++     *  Server `thread/fork`, anchored (inclusive) on `lastTurnId` when the ACP
++     *  request carries `_meta.anyharness.lastTurnId`; absent = tip fork. Returns
++     *  metadata keyed on the NEW forked thread id (`response.thread.id`), not the
++     *  source. Mirrors {@link resumeSession}. */
++    async forkSession(request: acp.ForkSessionRequest, onSubscribed?: () => void): Promise<SessionMetadata> {
++        const additionalDirectories = readAdditionalDirectories(request.cwd, request.additionalDirectories, request._meta);
++        await this.refreshSkills(request.cwd, additionalDirectories);
++
++        const lastTurnId = forkAnchorLastTurnId(request._meta);
++        const response = await this.codexClient.threadFork({
++            config: await this.createSessionConfig(request.cwd, additionalDirectories, request.mcpServers ?? []),
++            cwd: request.cwd,
++            modelProvider: await this.getResumeModelProvider(),
++            threadId: request.sessionId,
++            ...(lastTurnId !== undefined && { lastTurnId }),
++        });
++        onSubscribed?.();
++        const codexModels = await this.fetchAvailableModels();
++        const currentModelId = this.createModelId(codexModels, response.model, response.reasoningEffort).toString();
++        return {
++            sessionId: response.thread.id,
++            currentModelId: currentModelId,
++            models: codexModels,
++            collaborationMode: this.getCollaborationMode(response.thread.id),
++            modelProvider: response.modelProvider,
++            currentServiceTier: response.serviceTier as ServiceTier ?? null,
++            additionalDirectories,
++        };
++    }
++
+     async loadSession(request: acp.LoadSessionRequest, onSubscribed?: () => void): Promise<SessionMetadataWithThread> {
+         const additionalDirectories = readAdditionalDirectories(request.cwd, request.additionalDirectories, request._meta);
+         await this.refreshSkills(request.cwd, additionalDirectories);
+diff --git a/src/CodexAcpServer.ts b/src/CodexAcpServer.ts
+index 3c321c8..d2cab44 100644
+--- a/src/CodexAcpServer.ts
++++ b/src/CodexAcpServer.ts
+@@ -49,6 +49,7 @@ import {
+     LEGACY_GOAL_CONTROL_METHOD,
+     LEGACY_SET_SESSION_MODEL_METHOD,
+     type LegacyLoadSessionResponse,
++    type LegacyForkSessionResponse,
+     type LegacyNewSessionResponse,
+     type LegacyResumeSessionResponse,
+     type LegacySessionModelState,
+@@ -149,6 +150,12 @@ interface ActivePrompt {
+     complete: () => void;
+ }
+ 
++/** Presence of this object routes {@link CodexAcpServer.getOrCreateSession} to
++ *  the fork path (App Server `thread/fork`) instead of resume/start. The
++ *  inclusive `lastTurnId` anchor itself travels on the request `_meta`
++ *  (`_meta.anyharness.lastTurnId`), read in `CodexAcpClient.forkSession`. */
++type ForkOptions = Record<string, never>;
++
+ export class CodexAcpServer {
+     private static readonly MODEL_NAME_TOKEN_OVERRIDES: Record<string, string> = {
+         gpt: "GPT",
+@@ -238,6 +245,11 @@ export class CodexAcpServer {
+                 },
+                 sessionCapabilities: {
+                     resume: { },
++                    // AnyHarness delta: `session/fork` mapped to App Server
++                    // `thread/fork` (inclusive `lastTurnId` anchor via
++                    // `_meta.anyharness.lastTurnId`). Canonical codex-acp does
++                    // not register fork; absence of this cap means unpatched.
++                    fork: { },
+                     list: { },
+                     close: { },
+                     delete: { },
+@@ -359,9 +371,12 @@ export class CodexAcpServer {
+         }
+     }
+ 
+-    async getOrCreateSession(request: acp.NewSessionRequest | acp.ResumeSessionRequest): Promise<[SessionId, LegacySessionModelState, SessionModeState]> {
++    async getOrCreateSession(
++        request: acp.NewSessionRequest | acp.ResumeSessionRequest | acp.ForkSessionRequest,
++        forkOptions?: ForkOptions,
++    ): Promise<[SessionId, LegacySessionModelState, SessionModeState]> {
+         try {
+-            return await this.tryCreateSession(request);
++            return await this.tryCreateSession(request, forkOptions);
+         } catch (e) {
+             const error = e instanceof Error ? e : new Error(String(e));
+             await this.handleError(error);
+@@ -450,8 +465,14 @@ export class CodexAcpServer {
+         return generation;
+     }
+ 
+-    async tryCreateSession(request: acp.NewSessionRequest | acp.ResumeSessionRequest): Promise<[SessionId, LegacySessionModelState, SessionModeState]> {
+-        const requestedSessionGeneration = "sessionId" in request
++    async tryCreateSession(
++        request: acp.NewSessionRequest | acp.ResumeSessionRequest | acp.ForkSessionRequest,
++        forkOptions?: ForkOptions,
++    ): Promise<[SessionId, LegacySessionModelState, SessionModeState]> {
++        // A fork installs under a NEW thread id (returned by the App Server),
++        // so — like a brand-new session — its session-open generation must be
++        // begun on that new id below (line ~495), NOT on the source id here.
++        const requestedSessionGeneration = "sessionId" in request && !forkOptions
+             ? this.beginSessionOpen(request.sessionId)
+             : null;
+         await this.checkAuthorization();
+@@ -462,7 +483,17 @@ export class CodexAcpServer {
+ 
+         let sessionMetadata: SessionMetadata;
+         let resumeSubscribed = false;
+-        if ("sessionId" in request) {
++        if (forkOptions) {
++            // AnyHarness delta: fork the source thread into a NEW thread. The
++            // returned metadata is keyed on the forked thread id, so the generic
++            // registration tail below installs the new session, not the source.
++            // Generation is begun on the new id (like a new session), so no
++            // source-id session-open cleanup is owed on failure.
++            logger.log(`Fork existing session: ${(request as acp.ForkSessionRequest).sessionId}...`);
++            sessionMetadata = await this.runWithProcessCheck(() =>
++                this.codexAcpClient.forkSession(request as acp.ForkSessionRequest)
++            );
++        } else if ("sessionId" in request) {
+             logger.log(`Resume existing session: ${request.sessionId}...`);
+             try {
+                 sessionMetadata = await this.runWithProcessCheck(() =>
+@@ -618,6 +649,23 @@ export class CodexAcpServer {
+         };
+     }
+ 
++    async unstable_forkSession(params: acp.ForkSessionRequest): Promise<LegacyForkSessionResponse> {
++        logger.log("Forking session...", {sessionId: params.sessionId});
++        const [sessionId, modelState, modeState] = await this.getOrCreateSession(params, {});
++        logger.log("Session forked", {
++            sourceSessionId: params.sessionId,
++            sessionId: sessionId,
++            modelId: modelState.currentModelId,
++            availableModelCount: modelState.availableModels.length,
++        });
++        return {
++            sessionId,
++            models: modelState,
++            modes: modeState,
++            ...this.createSessionConfigOptionsResponse(this.getSessionState(sessionId)),
++        };
++    }
++
+     async listSessions(params: acp.ListSessionsRequest): Promise<acp.ListSessionsResponse> {
+         logger.log("Listing sessions...", {cwd: params.cwd, cursor: params.cursor});
+         await this.checkAuthorization();
+diff --git a/src/CodexAppServerClient.ts b/src/CodexAppServerClient.ts
+index 50a95e4..d62a88b 100644
+--- a/src/CodexAppServerClient.ts
++++ b/src/CodexAppServerClient.ts
+@@ -72,6 +72,8 @@ import type {
+     PermissionsRequestApprovalParams,
+     PermissionsRequestApprovalResponse,
+     ItemCompletedNotification,
++    ThreadForkParams,
++    ThreadForkResponse,
+ } from "./app-server/v2";
+ 
+ export interface ApprovalHandler {
+@@ -530,6 +532,10 @@ export class CodexAppServerClient {
+         return await this.sendRequest({ method: "thread/resume", params: params });
+     }
+ 
++    async threadFork(params: ThreadForkParams): Promise<ThreadForkResponse> {
++        return await this.sendRequest({ method: "thread/fork", params: params });
++    }
++
+     getThreadSettings(threadId: string): ThreadSettings | undefined {
+         return this.threadSettings.get(threadId);
+     }
+diff --git a/src/__tests__/CodexACPAgent/initialize.test.ts b/src/__tests__/CodexACPAgent/initialize.test.ts
+index 7b5bd58..bed1c12 100644
+--- a/src/__tests__/CodexACPAgent/initialize.test.ts
++++ b/src/__tests__/CodexACPAgent/initialize.test.ts
+@@ -49,6 +49,9 @@ describe('CodexACPAgent - initialize', () => {
+                 },
+                 sessionCapabilities: {
+                     resume: {},
++                    // AnyHarness delta: session/fork registered (mapped to App
++                    // Server thread/fork). Canonical codex-acp omits this.
++                    fork: {},
+                     list: {},
+                     close: {},
+                     delete: {},
+diff --git a/src/anyharness-fork.ts b/src/anyharness-fork.ts
+new file mode 100644
+index 0000000..a018a3a
+--- /dev/null
++++ b/src/anyharness-fork.ts
+@@ -0,0 +1,35 @@
++import { RequestError } from "@agentclientprotocol/sdk";
++
++/** The Proliferate ("AnyHarness") thin delta over canonical `codex-acp`:
++ *  registration of the ACP `session/fork` method, mapped onto the native App
++ *  Server `thread/fork` (canonical registers `_session/goal` and
++ *  `_session/steering` already, but NOT `session/fork`).
++ *
++ *  The inclusive fork anchor rides in the `session/fork` request
++ *  `_meta.anyharness.lastTurnId`. Per the pinned App Server schema
++ *  (fixtures/contracts/codex-app-server-schema, native codex 0.147.0),
++ *  `ThreadForkParams.lastTurnId` is the ONLY fork anchor — "last turn id to
++ *  fork through, inclusive; turns after it are omitted; the referenced turn
++ *  cannot be in progress". There is no `beforeTurnId`/`excludeTurns`. The
++ *  runtime resolves the product boundary ("immediately before the selected
++ *  user message") to the preceding turn id and passes it here.
++ *
++ *  Absent anchor → an unanchored (tip) fork. A present-but-malformed anchor is
++ *  a HARD `invalidParams`, never a silent tip fork (Forks ADR §5 cardinal
++ *  sin). */
++export const ANYHARNESS_META_NAMESPACE = "anyharness";
++
++export function forkAnchorLastTurnId(meta: unknown): string | undefined {
++  if (!meta || typeof meta !== "object") return undefined;
++  const ns = (meta as Record<string, unknown>)[ANYHARNESS_META_NAMESPACE];
++  if (!ns || typeof ns !== "object") return undefined;
++  const anchor = (ns as Record<string, unknown>)["lastTurnId"];
++  if (anchor === undefined || anchor === null) return undefined;
++  if (typeof anchor !== "string" || anchor.length === 0) {
++    throw RequestError.invalidParams(
++      undefined,
++      "_meta.anyharness.lastTurnId must be a non-empty string when present",
++    );
++  }
++  return anchor;
++}
+diff --git a/src/index.ts b/src/index.ts
+index 0bddc4e..f6f835b 100644
+--- a/src/index.ts
++++ b/src/index.ts
+@@ -136,6 +136,7 @@ function startAcpServer() {
+         .onRequest(acp.methods.agent.initialize, (ctx) => getAgent().initialize(ctx.params))
+         .onRequest(acp.methods.agent.session.new, (ctx) => getAgent().newSession(ctx.params))
+         .onRequest(acp.methods.agent.session.load, (ctx) => getAgent().loadSession(ctx.params))
++        .onRequest(acp.methods.agent.session.fork, (ctx) => getAgent().unstable_forkSession(ctx.params))
+         .onRequest(acp.methods.agent.session.list, (ctx) => getAgent().listSessions(ctx.params))
+         .onRequest(acp.methods.agent.session.delete, (ctx) => getAgent().deleteSession(ctx.params))
+         .onRequest(acp.methods.agent.session.resume, (ctx) => getAgent().resumeSession(ctx.params))


### PR DESCRIPTION
## Summary

Repo-side artifacts of the **Forks ADR rung 1 adapter migration** (rung 1b continuation, coordinates resolved 2026-08-16). The adapter *source* changes live in two fork-repo draft PRs; this PR carries the coordinates, the Codex fork-registration patch, and the engineering record for the gated/deferred pieces.

Full detail: [`catalogs/agents/adapter-migration/RUNG-1B-NOTES.md`](catalogs/agents/adapter-migration/RUNG-1B-NOTES.md).

## What landed where

**(a) Claude** — rebased onto canonical `claude-agent-acp` v0.66.0 (`6b405138`), legacy 0.59 goal/loop/transcript deltas dropped (superseded by canonical). Added the sanctioned thin delta: inclusive fork anchor (`_meta.anyharness.upToMessageId` → SDK `resumeSessionAt`) + labeled partial `_anyharness/rewindFiles`, both advertised at initialize. Fail-closed on malformed anchors (ADR §5 cardinal sin). → **proliferate-ai/claude-agent-acp#50** (draft, tag `v0.66.0-proliferate.1`, ref `81a4d52e`). Verified: `tsc` clean, `vitest` 707+9 pass (the 4 `acp-agent-settings` failures are pre-existing on pristine canonical — negative-controlled).

**(b) Codex** — replaced the archived Rust fork with canonical TypeScript `codex-acp` v1.1.14 (`5faefec5`); goals + steering are freebies from canonical. Added `session/fork` registration mapped to App Server `thread/fork` (inclusive `lastTurnId` anchor, the only anchor per the pinned 0.147.0 schema). → **proliferate-ai/codex-acp#19** (draft, tag `v1.1.14-proliferate.1`, ref `219738c9`). Verified: `tsc` clean, `node build.mjs` emits `dist/index.js`, `vitest` 349 pass. The `.patch` here is the review artifact + patch-package fallback.

## Gated / deferred (honest scope)

**(c) Catalog pin flip — BLOCKED (not in this PR).** The flip is gated by `scripts/validate-agent-catalog.mjs` AND the catalog `cargo test`, both of which require probe snapshots attesting the exact new adapter+native versions. Regeneration spawns each adapter against **real Anthropic/OpenAI auth** — unavailable in this delegated environment. Step-by-step completion recipe + revert path in the notes §3.

**(d) Session migration markers + dual-read (R9) — DESIGN only.** A Rust slice, deferred as independently reviewable: this environment cannot safely build the runtime (sibling agent holds the one-cargo-build slot, OOM-prone box). Contract in notes §4.

**(e) JS ACP SDK 1.3.0 vs Rust client — QUALIFICATION notes** (§5): both adapters pin `@agentclientprotocol/sdk@1.3.0`; v1 wire is contract-compatible with the Rust client by inspection; one Tier-3 cross-process spawn item remains (not a known break).

## Verification (this PR)
Docs + a patch file only; no code. The two adapter forks carry the executable verification (build/typecheck/unit above).

## Do not merge
Part of the Forks overnight program. No merges without Pablo's review; the two fork PRs and the live catalog flip are separate gated steps.

---

## Merge record (Forks overnight delegation, 2026-08-16) — supersedes the "Do not merge" note above

The note above reflected the state at draft time; it is superseded (not deleted) per the standing merge procedure. Merged by the Forks lead under Pablo's reconfirmed overnight grant (orchestrator-relayed with verbatim receipts); merge of this PR was explicitly pre-authorized by the orchestrator ("merge pre-authorized once rebased+green+post-undraft tally").

Status updates since draft:
- The two fork-repo PRs are MERGED: claude-agent-acp#50 (true merge 99a990c4 onto `canonical-0.66.0-base`) and codex-acp#19 (true merge bb3c8866 onto `canonical-1.1.14-base`); both tags verified at merge time.
- (c) is no longer blocked: probe regeneration ran live under orchestrator-ratified gates; all six contexts (3 codex + 3 claude) attest the exact target pairs. The flip itself rides PR #1988 with its own gates.
- (d) R9 landed as PR #1989 (merged a0d0cd40c).

Gates satisfied for this PR:
- Clean-agent review APPROVE at ba2111d3 lineage; doc-only delta (+23/-0 provenance note) hand-verified with literal diff scope and independently ratified by the orchestrator; rebase onto dfa62c1e8 proven content-identical by range-diff (both commits `=`).
- CI: 25 pass / 2 skip / 0 fail / 0 pending at head 08f25e0e (fresh post-undraft tally quoted in comments at merge time).
- Manual verification: dedicated comment below. Squash-merge per main-repo convention.
