### PR TITLE
fix(anyharness): run install-agents installer off the async runtime (tokio blocking-drop crash)

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/mod.rs
@@ -6,6 +6,7 @@ mod lock;
 pub(crate) mod managed_npm;
 pub mod manifest;
 mod npm;
+pub mod off_runtime;
 mod pinned;
 pub mod progress;
 pub mod reconcile;

--- a/anyharness/crates/anyharness-lib/src/domains/agents/installer/off_runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/installer/off_runtime.rs
@@ -1,0 +1,72 @@
+//! Async/sync boundary for the CLI installer.
+//!
+//! The installer downloads artifacts with `reqwest::blocking` (see
+//! [`super::downloads`]), which builds and then drops its own Tokio runtime. A
+//! Tokio runtime cannot be dropped from within a runtime worker thread — doing
+//! so panics with *"Cannot drop a runtime in a context where blocking is not
+//! allowed"* (`tokio .../runtime/blocking/shutdown.rs`).
+//!
+//! `anyharness install-agents` runs under `#[tokio::main]`, so calling the
+//! synchronous installer directly on the async runtime hits exactly that panic
+//! the first time an artifact actually has to be fetched over HTTP. It stayed
+//! latent until a native pin bump forced a re-download (the codex
+//! `rust-v0.144.5 → rust-v0.147.0` move in the Forks ADR rung-1 catalog flip).
+//!
+//! The fix is to hop the synchronous installer onto a dedicated blocking thread
+//! via [`tokio::task::spawn_blocking`] before it touches `reqwest::blocking`.
+//! Blocking-pool threads are not runtime workers, so the nested blocking
+//! runtime is created and dropped cleanly there.
+
+use anyhow::Result;
+
+/// Run the synchronous installer closure off the async runtime.
+///
+/// Safe to call from within `#[tokio::main]`: the closure executes on a
+/// blocking-pool thread, so any `reqwest::blocking` client it builds (and
+/// drops) does not violate Tokio's no-runtime-drop-in-async-context rule.
+pub async fn run_installer_off_runtime<F>(f: F) -> Result<()>
+where
+    F: FnOnce() -> Result<()> + Send + 'static,
+{
+    match tokio::task::spawn_blocking(f).await {
+        Ok(inner) => inner,
+        Err(join_error) => {
+            Err(anyhow::anyhow!("install-agents worker thread panicked: {join_error}"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression pin for the `install-agents` crash.
+    ///
+    /// Building a `reqwest::blocking` client is the exact operation that
+    /// panicked under `anyharness install-agents` (frame `ClientBuilder::build`
+    /// → `download_binary_inner`, `downloads.rs:60`): the blocking client spins
+    /// and drops its own runtime, which aborts when done on a Tokio worker
+    /// thread. Running that build through [`run_installer_off_runtime`] inside
+    /// a Tokio runtime must NOT panic.
+    ///
+    /// Negative control (manual): replace the `run_installer_off_runtime(...)`
+    /// call below with a direct `reqwest::blocking::Client::builder().build()`
+    /// and this test panics with *"Cannot drop a runtime in a context where
+    /// blocking is not allowed"* at `tokio .../blocking/shutdown.rs` — i.e. the
+    /// pre-fix behavior.
+    #[tokio::test]
+    async fn blocking_reqwest_build_survives_off_runtime() {
+        let outcome = run_installer_off_runtime(|| {
+            reqwest::blocking::Client::builder()
+                .build()
+                .map(|_client| ())
+                .map_err(|error| anyhow::anyhow!("reqwest blocking client build failed: {error}"))
+        })
+        .await;
+
+        assert!(
+            outcome.is_ok(),
+            "off-runtime installer boundary must not panic building a blocking client: {outcome:?}"
+        );
+    }
+}

--- a/anyharness/crates/anyharness/src/main.rs
+++ b/anyharness/crates/anyharness/src/main.rs
@@ -17,7 +17,16 @@ async fn main() -> Result<()> {
 
     let result = match args.command {
         cli::Commands::Serve(serve_args) => commands::serve::run(serve_args).await,
-        cli::Commands::InstallAgents(install_args) => commands::install_agents::run(install_args),
+        // `install_agents::run` is synchronous and fetches artifacts via
+        // `reqwest::blocking`, which drops its own runtime. Under `#[tokio::main]`
+        // that must happen off the async runtime or it panics ("cannot drop a
+        // runtime in a context where blocking is not allowed").
+        cli::Commands::InstallAgents(install_args) => {
+            anyharness_lib::domains::agents::installer::off_runtime::run_installer_off_runtime(
+                move || commands::install_agents::run(install_args),
+            )
+            .await
+        }
         cli::Commands::PrintOpenapi => commands::print_openapi::run(),
         cli::Commands::CatalogProbe(probe_args) => commands::catalog_probe::run(probe_args).await,
     };


### PR DESCRIPTION
## Problem
`anyharness install-agents` runs under `#[tokio::main]`, but `install_agents::run` is **synchronous** and fetches artifacts with `reqwest::blocking` (`anyharness-lib/.../installer/downloads.rs:60`). `reqwest::blocking` builds and then drops its own Tokio runtime; dropping a runtime inside a Tokio worker thread panics:

```
thread 'main' panicked at tokio-1.50.0/src/runtime/blocking/shutdown.rs:51:21:
Cannot drop a runtime in a context where blocking is not allowed. This happens
when a runtime is dropped from within an asynchronous context.
  reqwest::blocking::client::ClientBuilder::build
  download_binary_inner   installer/downloads.rs:60
  download_and_extract_archive_verified   downloads.rs:202
  install_binary_or_archive_from_pin   pinned.rs:69
```

It stayed latent until an artifact actually had to be fetched over HTTP. It surfaced during the Forks ADR rung-1 catalog flip: the codex native pin bump `rust-v0.144.5 → rust-v0.147.0` forces an archive re-download, which is the first thing to exercise the `reqwest::blocking` path in a while.

## Fix
Minimal, at the async/sync boundary — do **not** rewrite `downloads.rs` to async (the blocking downloader is fine when not dropped inside Tokio). New helper `installer::off_runtime::run_installer_off_runtime` hops the synchronous installer onto a blocking-pool thread via `tokio::task::spawn_blocking`; `main.rs` calls it for the `InstallAgents` command. Blocking-pool threads are not runtime workers, so the nested blocking runtime is created and dropped cleanly.

## Test (literal)
Regression pin — building a `reqwest::blocking` client (the exact panicking op) through the helper inside a `#[tokio::test]` must not panic:
```
running 1 test
test domains::agents::installer::off_runtime::tests::blocking_reqwest_build_survives_off_runtime ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2066 filtered out
```
**Negative control** (verified: temporarily bypassed the helper, calling `reqwest::blocking::Client::builder().build()` directly on the async runtime, then restored):
```
thread '...::blocking_reqwest_build_survives_off_runtime' panicked at
tokio-1.50.0/src/runtime/blocking/shutdown.rs:51:21:
Cannot drop a runtime in a context where blocking is not allowed. ...
test ...::blocking_reqwest_build_survives_off_runtime ... FAILED
test result: FAILED. 0 passed; 1 failed
```
The test reproduces the exact install-agents crash and passes only with the fix.

## Blast radius (orchestrator-mandated)
Traced every caller that can reach the `reqwest::blocking` construction at `downloads.rs:60`. The blocking downloader is reached only through the **synchronous** chain `downloads::{download_binary_verified, download_and_extract_archive_verified, …}` → `pinned::install_{binary_or_archive,agent_process}_from_pin` → `service::install_agent_with_pins{,_and_progress}` / `reconcile::reconcile_agent_with_progress`. It only constructs the client when an artifact must actually be **downloaded** (missing/version-drifted pin), which is why it stayed latent — a bake/install where the pinned version is already present never enters it.

**In-process runtime / desktop / server paths are ALL already off-runtime — UNAFFECTED.** Every live surface that installs or reconciles agents already hops through `spawn_blocking` before touching the sync installer:
```
# HTTP install: POST /v1/agents/{kind}/install
api/router.rs:69        .route("/agents/{kind}/install", post(agents::install_agent))
api/http/agents.rs:121  .install_agent(&kind, install_request(req))   # async handler
runtime.rs:198          let install_result = tokio::task::spawn_blocking(move || {
runtime.rs:199              installer::install_agent_with_pins( ... )   # ← wrapped

# Runtime-startup + HTTP-triggered reconcile
reconcile/execution.rs:311  let result = match tokio::task::spawn_blocking(move || {
reconcile/execution.rs:366      reconcile_agent_with_progress( ... )     # ← wrapped

# Startup seed hydration
runtime.rs:390          let _ = tokio::task::spawn_blocking(move || {
                            installer::seed::hydrate_configured_agent_seed( ... )
```
The desktop app runs the in-process runtime (`serve`) and reaches installs only through those wrapped paths; it never shells out to the `install-agents` subcommand (grep of app/tauri dirs: no matches).

**The one exposed path was the `install-agents` CLI subcommand** — pre-fix, `main.rs` called the synchronous `install_agents::run` directly under `#[tokio::main]` with no `spawn_blocking` hop. That is what this PR fixes.

**This CLI subcommand IS a production path, so this is a latent prod (bake-pipeline) panic, not merely a probe blocker.** `anyharness install-agents` is the bake-time agent installer for **cloud sandbox templates** and build tooling:
```
scripts/build-template.mjs:372            /home/user/anyharness install-agents --runtime-home ${...} ${agentArgs}
tests/release/.../managed-cloud/template.ts:340   /home/user/anyharness install-agents --runtime-home ${...} ${agentArgs}
scripts/build-agent-seed.mjs:46           "install-agents",
scripts/setup-agent-runtime-suite.mjs:151 "install-agents",
scripts/smoke-cloud-template.mjs:200      /home/user/anyharness install-agents --agent claude --agent codex
anyharness/tests/src/harness/runtime-harness.ts:102  "install-agents",
```
**Consequence for Pablo's visibility:** on the **next native bump** (exactly the codex `rust-v0.144.5 → rust-v0.147.0` and claude `2.1.212 → 2.1.233` moves in this ADR flip), a cloud-template rebuild that must re-download a native artifact would panic at **bake time**, failing the template build — a fleet-wide break of cloud-workspace template provisioning. It manifests at image-bake / CI time (and in the catalog-probe pipeline), **not** as a live end-user runtime crash, because the live paths above are already wrapped. This reclassifies the fix from probe-unblocker to a real prod bug.

## Scope / sequencing
Ladder work under the Forks ADR rung-1 program. The catalog pin-flip PR (#1988) depends on this fix's **binary behavior** (probes run from a worktree build) but NOT on its merge — the two PRs are independent and this one merges on its own gates. Draft; clean-agent review before merge. Local `cargo test` above; the CI cargo lane is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Merge record (Forks overnight delegation, 2026-08-16)

Merged by the Forks lead under Pablo's reconfirmed overnight grant. Orchestrator ruling: this fix is a HARD RELEASE GATE — the production release rebakes cloud templates with the new natives, which is exactly the panic path documented in the blast-radius section; the release agent does not start until this is on main. Gates satisfied:
- **Clean-agent review**: dedicated fresh reviewer — APPROVE at head 4c24d6bc1, zero blocking findings; fix boundary, spawn_blocking semantics, panic propagation, network-free regression test, and every blast-radius claim independently verified against origin/main.
- **CI**: full suite green including the authoritative Rust gate ("Cargo check & test — pass, 10m41s"); fresh post-undraft literal tally quoted in comments at merge time.
- **Manual verification**: dedicated comment below. Squash-merge per main-repo convention.
- Post-#1722 note: this PR touches no lint-record-allowlisted surfaces (fix + test in anyharness crates only).
