### PR TITLE
feat(product-client): flagged eased-follow motion writer (PRO-187, r12)

### DIFF
--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-eased-follow-config.test.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-eased-follow-config.test.ts
@@ -1,15 +1,5 @@
-/* @vitest-environment jsdom */
-
-import { afterEach, describe, expect, it } from "vitest";
-import {
-  readTranscriptEasedFollowEnabled,
-  resolveTranscriptEasedFollowEnabled,
-  TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY,
-} from "./transcript-eased-follow-config";
-
-afterEach(() => {
-  window.localStorage.removeItem(TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY);
-});
+import { describe, expect, it } from "vitest";
+import { resolveTranscriptEasedFollowEnabled } from "./transcript-eased-follow-config";
 
 describe("resolveTranscriptEasedFollowEnabled (PRO-168, rung 12, Q16)", () => {
   it("defaults OFF for null (key never set)", () => {
@@ -25,16 +15,5 @@ describe("resolveTranscriptEasedFollowEnabled (PRO-168, rung 12, Q16)", () => {
 
   it("turns on only for the exact opt-in string", () => {
     expect(resolveTranscriptEasedFollowEnabled("on")).toBe(true);
-  });
-});
-
-describe("readTranscriptEasedFollowEnabled", () => {
-  it("reads OFF when the key is unset", () => {
-    expect(readTranscriptEasedFollowEnabled()).toBe(false);
-  });
-
-  it("reads ON once the flag is explicitly set", () => {
-    window.localStorage.setItem(TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY, "on");
-    expect(readTranscriptEasedFollowEnabled()).toBe(true);
   });
 });

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-eased-follow-config.test.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-eased-follow-config.test.ts
@@ -1,0 +1,40 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  readTranscriptEasedFollowEnabled,
+  resolveTranscriptEasedFollowEnabled,
+  TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY,
+} from "./transcript-eased-follow-config";
+
+afterEach(() => {
+  window.localStorage.removeItem(TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY);
+});
+
+describe("resolveTranscriptEasedFollowEnabled (PRO-168, rung 12, Q16)", () => {
+  it("defaults OFF for null (key never set)", () => {
+    expect(resolveTranscriptEasedFollowEnabled(null)).toBe(false);
+  });
+
+  it("defaults OFF for any value other than the explicit opt-in", () => {
+    expect(resolveTranscriptEasedFollowEnabled("")).toBe(false);
+    expect(resolveTranscriptEasedFollowEnabled("off")).toBe(false);
+    expect(resolveTranscriptEasedFollowEnabled("1")).toBe(false);
+    expect(resolveTranscriptEasedFollowEnabled("true")).toBe(false);
+  });
+
+  it("turns on only for the exact opt-in string", () => {
+    expect(resolveTranscriptEasedFollowEnabled("on")).toBe(true);
+  });
+});
+
+describe("readTranscriptEasedFollowEnabled", () => {
+  it("reads OFF when the key is unset", () => {
+    expect(readTranscriptEasedFollowEnabled()).toBe(false);
+  });
+
+  it("reads ON once the flag is explicitly set", () => {
+    window.localStorage.setItem(TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY, "on");
+    expect(readTranscriptEasedFollowEnabled()).toBe(true);
+  });
+});

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-eased-follow-config.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-eased-follow-config.ts
@@ -10,13 +10,3 @@ export const TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY = "proliferate:transcriptEasedF
 export function resolveTranscriptEasedFollowEnabled(value: string | null): boolean {
   return value === "on";
 }
-
-/** Read the flag once at mount (same convention as the virtualization-mode flag). */
-export function readTranscriptEasedFollowEnabled(): boolean {
-  if (typeof window === "undefined") {
-    return false;
-  }
-  return resolveTranscriptEasedFollowEnabled(
-    window.localStorage.getItem(TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY),
-  );
-}

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-eased-follow-config.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-eased-follow-config.ts
@@ -1,0 +1,22 @@
+/**
+ * Flag discipline for the eased-follow motion writer (PRO-168, design question
+ * Q16, rung 12). Follows the same localStorage-flag convention as
+ * transcript-virtualization-config.ts: an explicit opt-in string, read once at
+ * mount, defaulting OFF so v1's instant glue stays byte-identical unless a
+ * reader deliberately turns the prototype on.
+ */
+export const TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY = "proliferate:transcriptEasedFollow";
+
+export function resolveTranscriptEasedFollowEnabled(value: string | null): boolean {
+  return value === "on";
+}
+
+/** Read the flag once at mount (same convention as the virtualization-mode flag). */
+export function readTranscriptEasedFollowEnabled(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  return resolveTranscriptEasedFollowEnabled(
+    window.localStorage.getItem(TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY),
+  );
+}

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-eased-follow.test.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-eased-follow.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, it } from "vitest";
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY } from "#product/domain/chats/transcript/transcript-eased-follow-config";
 import {
+  readTranscriptEasedFollowEnabled,
   resolveEasedFollowStep,
   TRANSCRIPT_EASED_FOLLOW_CONVERGE_PX,
   TRANSCRIPT_EASED_FOLLOW_RATE,
 } from "#product/hooks/chat/ui/transcript-eased-follow";
+
+afterEach(() => {
+  window.localStorage.removeItem(TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY);
+});
 
 describe("resolveEasedFollowStep (PRO-168, rung 12)", () => {
   it("steps toward the target by the fixed rate, not converged, while the remaining distance is large", () => {
@@ -46,5 +54,16 @@ describe("resolveEasedFollowStep (PRO-168, rung 12)", () => {
     expect(top).toBe(target);
     // At a 0.25/frame rate the geometric tail converges well under 200 frames.
     expect(frames).toBeLessThan(60);
+  });
+});
+
+describe("readTranscriptEasedFollowEnabled (PRO-168, rung 12, Q16)", () => {
+  it("reads OFF when the key is unset", () => {
+    expect(readTranscriptEasedFollowEnabled()).toBe(false);
+  });
+
+  it("reads ON once the flag is explicitly set", () => {
+    window.localStorage.setItem(TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY, "on");
+    expect(readTranscriptEasedFollowEnabled()).toBe(true);
   });
 });

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-eased-follow.test.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-eased-follow.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveEasedFollowStep,
+  TRANSCRIPT_EASED_FOLLOW_CONVERGE_PX,
+  TRANSCRIPT_EASED_FOLLOW_RATE,
+} from "#product/hooks/chat/ui/transcript-eased-follow";
+
+describe("resolveEasedFollowStep (PRO-168, rung 12)", () => {
+  it("steps toward the target by the fixed rate, not converged, while the remaining distance is large", () => {
+    const step = resolveEasedFollowStep(0, 1000);
+    expect(step.converged).toBe(false);
+    expect(step.nextTop).toBeCloseTo(1000 * TRANSCRIPT_EASED_FOLLOW_RATE);
+  });
+
+  it("eases from the other direction identically (symmetric in delta sign)", () => {
+    const step = resolveEasedFollowStep(1000, 0);
+    expect(step.converged).toBe(false);
+    expect(step.nextTop).toBeCloseTo(1000 - 1000 * TRANSCRIPT_EASED_FOLLOW_RATE);
+  });
+
+  it("converges by snapping directly once within the convergence epsilon", () => {
+    const almostThere = 500 + (TRANSCRIPT_EASED_FOLLOW_CONVERGE_PX - 0.1);
+    const step = resolveEasedFollowStep(almostThere, 500);
+    expect(step.converged).toBe(true);
+    expect(step.nextTop).toBe(500);
+  });
+
+  it("reports converged immediately when already exactly at the target", () => {
+    const step = resolveEasedFollowStep(240, 240);
+    expect(step.converged).toBe(true);
+    expect(step.nextTop).toBe(240);
+  });
+
+  it("repeated application converges to the target within a bounded number of frames", () => {
+    let top = 0;
+    const target = 4000;
+    let frames = 0;
+    let converged = false;
+    while (!converged && frames < 200) {
+      const step = resolveEasedFollowStep(top, target);
+      top = step.nextTop;
+      converged = step.converged;
+      frames += 1;
+    }
+    expect(converged).toBe(true);
+    expect(top).toBe(target);
+    // At a 0.25/frame rate the geometric tail converges well under 200 frames.
+    expect(frames).toBeLessThan(60);
+  });
+});

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-eased-follow.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-eased-follow.ts
@@ -1,3 +1,8 @@
+import {
+  resolveTranscriptEasedFollowEnabled,
+  TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY,
+} from "#product/domain/chats/transcript/transcript-eased-follow-config";
+
 /**
  * The eased-follow motion policy (PRO-168, design question Q16, rung 12).
  *
@@ -45,4 +50,19 @@ export function resolveEasedFollowStep(currentTop: number, targetTop: number): E
     return { nextTop: targetTop, converged: true };
   }
   return { nextTop: currentTop + delta * TRANSCRIPT_EASED_FOLLOW_RATE, converged: false };
+}
+
+/**
+ * Read the flag once at mount (same convention as the virtualization-mode
+ * flag). `window` access stays out of domain/ (the tsconfig.domain.json
+ * DOM-free gate), so this reader lives in the hook layer, not alongside the
+ * pure parser in transcript-eased-follow-config.ts.
+ */
+export function readTranscriptEasedFollowEnabled(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  return resolveTranscriptEasedFollowEnabled(
+    window.localStorage.getItem(TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY),
+  );
 }

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-eased-follow.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-eased-follow.ts
@@ -1,0 +1,48 @@
+/**
+ * The eased-follow motion policy (PRO-168, design question Q16, rung 12).
+ *
+ * v1 ships instant glue: the pinned single writer (see
+ * use-transcript-frame-pipeline-lifecycle.ts) snaps straight to the follow
+ * target every pass. Founder Ruling Q16 keeps that as the default and specs the
+ * motion layer as a PLUGGABLE writer policy so an eased, ChatGPT-style follower
+ * can be swapped in later without touching classification (FR-1): this module
+ * is that policy, a pure step function with no DOM or React dependency, so it
+ * composes with the same single per-frame pipeline rather than adding a
+ * competing rAF loop. The pipeline's `hasPendingMotion` writer hook (see
+ * transcript-frame-pipeline.ts) keeps scheduling frames while a step here has
+ * not yet converged; once converged the pipeline goes quiet exactly like the
+ * instant writer already does.
+ */
+
+// Fraction of the remaining distance to the target closed per frame pass. A
+// fixed per-frame fraction (rather than a wall-clock-driven ease) keeps the
+// policy deterministic under the fake-frame harness the physics suite and unit
+// tests already use, while still reading as a smooth catch-up rather than a
+// jump: at 0.25/frame the remaining distance halves roughly every three
+// frames (~50ms at 60fps).
+export const TRANSCRIPT_EASED_FOLLOW_RATE = 0.25;
+
+// Below this remaining distance, snap directly to the target and report
+// converged rather than iterating an ever-shrinking geometric tail forever.
+export const TRANSCRIPT_EASED_FOLLOW_CONVERGE_PX = 1;
+
+export interface EasedFollowStep {
+  /** The scrollTop this pass should write. */
+  nextTop: number;
+  /** True once nextTop === targetTop and no further motion frame is needed. */
+  converged: boolean;
+}
+
+/**
+ * One eased step toward `targetTop` from `currentTop`. Pure and stateless: the
+ * caller re-derives `currentTop` from the live DOM each pass (the same
+ * contract the instant writer already holds), so this never drifts from the
+ * real scroll position even when something else briefly clamps it.
+ */
+export function resolveEasedFollowStep(currentTop: number, targetTop: number): EasedFollowStep {
+  const delta = targetTop - currentTop;
+  if (Math.abs(delta) <= TRANSCRIPT_EASED_FOLLOW_CONVERGE_PX) {
+    return { nextTop: targetTop, converged: true };
+  }
+  return { nextTop: currentTop + delta * TRANSCRIPT_EASED_FOLLOW_RATE, converged: false };
+}

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-eased-follow.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-eased-follow.ts
@@ -9,7 +9,7 @@ import {
  * v1 ships instant glue: the pinned single writer (see
  * use-transcript-frame-pipeline-lifecycle.ts) snaps straight to the follow
  * target every pass. Founder Ruling Q16 keeps that as the default and specs the
- * motion layer as a PLUGGABLE writer policy so an eased, ChatGPT-style follower
+ * motion layer as a PLUGGABLE writer policy so an eased, smoothed follower
  * can be swapped in later without touching classification (FR-1): this module
  * is that policy, a pure step function with no DOM or React dependency, so it
  * composes with the same single per-frame pipeline rather than adding a

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.test.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.test.ts
@@ -242,4 +242,113 @@ describe("TranscriptFramePipeline", () => {
     pipeline.requestFrame();
     expect(frames.pending).toBe(1);
   });
+
+  // PRO-168 (rung 12, Q16): the eased-follow motion writer's continuation seam.
+  // The instant writer never implements `hasPendingMotion`, so these prove the
+  // seam is additive: absent it, existing behavior above is untouched (asserted
+  // by every prior test in this file, none of which define it).
+  describe("hasPendingMotion continuation (PRO-168, rung 12)", () => {
+    it("requestFrame schedules ONE more frame per pass while motion is pending, then stops", () => {
+      const { frames, pipeline } = makePipeline();
+      let passes = 0;
+      let pending = true;
+      pipeline.setWriter({
+        runFramePass: () => {
+          passes += 1;
+        },
+        measureContentHeight: () => 0,
+        shouldContinueGlue: () => true,
+        hasPendingMotion: () => pending,
+      });
+
+      pipeline.requestFrame();
+      expect(passes).toBe(1);
+      // The guard-reset frame plus the motion continuation are both pending.
+      expect(frames.pending).toBe(2);
+
+      frames.flushFrame();
+      // The motion continuation ran another pass and re-armed itself.
+      expect(passes).toBe(2);
+
+      pending = false;
+      frames.flushFrame();
+      // Converged: no further continuation is scheduled.
+      expect(passes).toBe(2);
+      expect(frames.pending).toBe(0);
+    });
+
+    it("a writer that never reports pending motion never gets a continuation frame", () => {
+      const { frames, pipeline } = makePipeline();
+      let passes = 0;
+      pipeline.setWriter({
+        runFramePass: () => {
+          passes += 1;
+        },
+        measureContentHeight: () => 0,
+        shouldContinueGlue: () => true,
+        // hasPendingMotion omitted entirely — the default (instant) writer shape.
+      });
+
+      pipeline.requestFrame();
+      expect(passes).toBe(1);
+      // Only the guard-reset frame, no motion continuation.
+      expect(frames.pending).toBe(1);
+    });
+
+    it("glue ending mid-motion hands off to the motion continuation instead of stranding it", () => {
+      const { frames, pipeline } = makePipeline();
+      let passes = 0;
+      let pending = true;
+      // Height goes quiet immediately so glue's own window closes after the
+      // first quiet frame, well before motion has converged.
+      pipeline.setWriter({
+        runFramePass: () => {
+          passes += 1;
+        },
+        measureContentHeight: () => 500,
+        shouldContinueGlue: () => true,
+        hasPendingMotion: () => pending,
+      });
+
+      pipeline.beginGlue();
+      frames.flushFrame(); // first pass, height 500 becomes the baseline
+      frames.flushFrame(); // quiet frame: glue window closes here
+      expect(pipeline.isGluing).toBe(false);
+      const passesAtGlueEnd = passes;
+
+      // Glue is done, but motion is still pending: the continuation must have
+      // taken over rather than leaving the writer stuck short of its target.
+      expect(frames.pending).toBe(1);
+      frames.flushFrame();
+      expect(passes).toBe(passesAtGlueEnd + 1);
+
+      pending = false;
+      frames.flushFrame();
+      expect(passes).toBe(passesAtGlueEnd + 1); // converged, no further ticks
+    });
+
+    it("beginGlue folds a pending motion continuation into the glue window (no double pass)", () => {
+      const { frames, pipeline } = makePipeline();
+      let passes = 0;
+      pipeline.setWriter({
+        runFramePass: () => {
+          passes += 1;
+        },
+        measureContentHeight: () => 0,
+        shouldContinueGlue: () => true,
+        hasPendingMotion: () => true,
+      });
+
+      pipeline.requestFrame();
+      expect(passes).toBe(1);
+      expect(frames.pending).toBe(2); // guard-reset + motion continuation
+
+      // A fresh glue window starts (e.g. session re-entry) before the motion
+      // continuation's frame fires; it must fold in rather than stacking a
+      // second pass in the same frame.
+      pipeline.beginGlue();
+      frames.flushFrame();
+      expect(passes).toBe(2); // exactly one more pass this frame, not two
+    });
+  });
 });

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.ts
@@ -64,6 +64,15 @@ export interface TranscriptFrameWriter {
    * active compensation anchor).
    */
   shouldContinueGlue: () => boolean;
+  /**
+   * PRO-168 (rung 12, Q16): true while the pluggable motion writer (the eased
+   * follow policy) has written a step that has not yet reached its target.
+   * Absent, or false, for the default instant writer. When true after a pass,
+   * the pipeline schedules exactly one more frame purely to let that same
+   * writer keep converging — still this one pipeline's own scheduling, never
+   * a second competing rAF loop (FR-1).
+   */
+  hasPendingMotion?: () => boolean;
 }
 
 type RafFn = (cb: () => void) => number;
@@ -114,6 +123,10 @@ export class TranscriptFramePipeline {
   private glueStartedAt = 0;
   private glueLastHeight = -1;
   private glueQuietFrames = 0;
+  // PRO-168 (rung 12): the motion writer's own continuation handle, separate
+  // from frameHandle/glueHandle so it never contends with either's guard
+  // bookkeeping. Only ever armed when the writer reports pending motion.
+  private motionHandle: number | null = null;
 
   constructor(
     private readonly raf: RafFn = defaultRaf,
@@ -171,6 +184,41 @@ export class TranscriptFramePipeline {
     // Record the height the snap just settled against so a later same-frame
     // notify re-runs only on further growth (a scrollTop write leaves it equal).
     this.framePassHeight = writer.measureContentHeight();
+    // PRO-168 (rung 12): the instant writer never reports pending motion, so
+    // this is a no-op for v1. An eased writer still mid-step keeps this
+    // pipeline (and only this pipeline) ticking until it converges.
+    this.continueMotionIfPending();
+  }
+
+  /**
+   * PRO-168 (rung 12): while the writer's motion policy has not yet converged
+   * (`hasPendingMotion` true), keep scheduling exactly one frame at a time so
+   * the SAME writer can finish its catch-up — a self-perpetuating chain owned
+   * by this pipeline, not a second animator. Idempotent: a handle already
+   * armed is left alone.
+   */
+  private continueMotionIfPending(): void {
+    const writer = this.writer;
+    if (writer?.hasPendingMotion?.() !== true) {
+      return;
+    }
+    if (this.motionHandle != null) {
+      return;
+    }
+    this.motionHandle = this.raf(() => {
+      this.motionHandle = null;
+      const current = this.writer;
+      // Re-check pending AT FIRE TIME, not just when this frame was armed: the
+      // pass that ran since (glue, or an earlier motion tick) may have already
+      // converged the writer, and re-running would waste a frame on a motion
+      // step nobody needs. Mirrors glueTick's shouldContinueGlue gate, checked
+      // before running rather than only after.
+      if (current == null || current.hasPendingMotion?.() !== true) {
+        return;
+      }
+      current.runFramePass();
+      this.continueMotionIfPending();
+    });
   }
 
   /**
@@ -183,6 +231,13 @@ export class TranscriptFramePipeline {
   beginGlue(): void {
     if (this.writer == null) {
       return;
+    }
+    // Fold any pending motion continuation into the glue window: the glue
+    // loop below runs every frame regardless, so a separately-scheduled
+    // motion tick would double the same writer's pass in one frame.
+    if (this.motionHandle != null) {
+      this.caf(this.motionHandle);
+      this.motionHandle = null;
     }
     // Fold the pending guard-reset frame into the window and re-arm from scratch.
     if (this.frameHandle != null) {
@@ -205,6 +260,11 @@ export class TranscriptFramePipeline {
     const writer = this.writer;
     if (writer == null || !writer.shouldContinueGlue()) {
       this.glueActive = false;
+      // PRO-168 (rung 12): the glue window ending mid-motion (the user
+      // reclaimed control, or the viewport vanished) still hands off to the
+      // motion continuation below when the writer itself still has motion
+      // pending; when the writer is gone that check is a safe no-op.
+      this.continueMotionIfPending();
       return;
     }
     writer.runFramePass();
@@ -220,6 +280,14 @@ export class TranscriptFramePipeline {
     const capElapsed = this.now() - this.glueStartedAt >= TRANSCRIPT_GLUE_MAX_MS;
     if (this.glueQuietFrames >= GLUE_SETTLE_QUIET_FRAMES || capElapsed) {
       this.glueActive = false;
+      // PRO-168 (rung 12): the height-quiet/hard-cap glue terminator is about
+      // CONTENT settling, not the motion writer's own catch-up distance — an
+      // eased follower can still be short of its target on the very frame
+      // glue stops (e.g. a burst that settles height quickly but leaves scroll
+      // position trailing). Hand off to the motion continuation so it keeps
+      // converging without turning glue's window into a second countdown for
+      // the same thing.
+      this.continueMotionIfPending();
       return;
     }
     this.glueHandle = this.raf(this.glueTick);
@@ -243,6 +311,10 @@ export class TranscriptFramePipeline {
     }
     this.glueActive = false;
     this.glueHandle = null;
+    if (this.motionHandle != null) {
+      this.caf(this.motionHandle);
+    }
+    this.motionHandle = null;
   }
 
   /** Whether a forced-glue window is currently running (for tests/diagnostics). */

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-auto-follow-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-auto-follow-bottom.ts
@@ -66,6 +66,13 @@ export interface TranscriptAutoFollowBottom {
   scrollToBottom: () => void;
   /** Snap + re-pin, for the scroll-to-bottom button. */
   handleScrollToBottomClick: () => void;
+  /**
+   * PRO-168 (rung 12, Q16): the same follow-target derivation `scrollToBottom`
+   * writes instantly, exposed as a pure read so the flag-gated eased writer
+   * (use-transcript-frame-pipeline-lifecycle.ts) can resolve a live target
+   * each pass without a second copy of this state machine.
+   */
+  resolveFollowTargetTop: (viewport: HTMLElement) => number;
 }
 
 /**
@@ -189,10 +196,25 @@ export function useTranscriptAutoFollowBottom({
     scrollToBottom();
   }, [dispatchInsetEvent, scrollToBottom, setPinned]);
 
+  const resolveFollowTargetTop = useCallback((viewport: HTMLElement) => {
+    const state = insetStateRef.current;
+    const requestedTop = resolveTranscriptFollowTarget({
+      scrollHeight: viewport.scrollHeight,
+      clientHeight: viewport.clientHeight,
+      dockInset: {
+        structuralInsetPx: state.structuralInsetPx,
+        nonDisplacingInsetPx: state.nonDisplacingInsetPx,
+      },
+      consumedNonDisplacingInsetPx: state.consumedNonDisplacingInsetPx,
+    });
+    return Math.min(requestedTop, Math.max(0, viewport.scrollHeight - viewport.clientHeight));
+  }, []);
+
   return {
     insetStateRef,
     dispatchInsetEvent,
     scrollToBottom,
     handleScrollToBottomClick,
+    resolveFollowTargetTop,
   };
 }

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-frame-pipeline-lifecycle.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-frame-pipeline-lifecycle.ts
@@ -162,6 +162,12 @@ export function useTranscriptFramePipelineLifecycle({
       }
       return;
     }
+    // PRO-168 (rung 12): unpinned takes over from here; the eased writer's
+    // pending flag only ever describes a PINNED catch-up, so clear it rather
+    // than leave it stale until the reader re-pins (the `hasPendingMotion`
+    // hook above also gates on `pinnedRef.current`, so this is defense in
+    // depth, not the only thing preventing a stale-true leak).
+    easedMotionPendingRef.current = false;
     // FR-2 restore (rung 6): re-resolve the saved reading anchor to scrollTop
     // each frame until the deadline, so the reading row holds under the top edge
     // as freshly-mounted rows settle their heights. Writing the resolved target
@@ -328,8 +334,13 @@ export function useTranscriptFramePipelineLifecycle({
       measureContentHeight: () => scrollRef.current?.scrollHeight ?? -1,
       // PRO-168 (rung 12): only the eased writer ever reports pending motion;
       // the instant path never sets the ref, so this stays a permanent no-op
-      // with the flag off.
-      hasPendingMotion: () => easedFollowEnabled && easedMotionPendingRef.current,
+      // with the flag off. Gated on `pinnedRef.current` too, not just the
+      // ref: the ref is written ONLY from the pinned branch above, so it can
+      // go stale (stay true) if the user unpins mid-catch-up — the unpinned
+      // branch never revisits it. Without this gate a stale `true` would have
+      // the motion continuation re-arm forever on any later resize, even
+      // though nothing pinned is asking for another eased step.
+      hasPendingMotion: () => easedFollowEnabled && pinnedRef.current && easedMotionPendingRef.current,
       shouldContinueGlue: () => {
         const viewport = scrollRef.current;
         if (!viewport) {

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-frame-pipeline-lifecycle.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-frame-pipeline-lifecycle.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, type RefObject } from 
 import type { ContentHeightScrollAnchor } from "#product/hooks/chat/ui/transcript-row-list-model";
 import type { TranscriptFramePipeline } from "#product/hooks/chat/ui/transcript-frame-pipeline";
 import type { TranscriptRestoreResolution } from "#product/hooks/chat/ui/transcript-reading-position-store";
+import { resolveEasedFollowStep } from "#product/hooks/chat/ui/transcript-eased-follow";
 
 // While an above-change compensation anchor is live, each estimate-to-measured
 // correction of a freshly-prepended older row grows the total above the reader
@@ -50,6 +51,23 @@ export interface UseTranscriptFramePipelineLifecycleOptions {
   restoreDeadlineRef: RefObject<number>;
   /** Snap to the active follow target (the pinned write). */
   scrollToBottom: () => void;
+  /**
+   * PRO-168 (rung 12, Q16): flag-gated eased-follow motion writer. Default
+   * OFF, resolved once at mount by the caller from the
+   * `proliferate:transcriptEasedFollow` flag. False keeps the pinned branch
+   * calling `scrollToBottom` exactly as before (byte-identical instant glue);
+   * true routes it through `resolveFollowTargetTop` and the eased step below
+   * instead, without touching classification (FR-1) — every write still
+   * flows through `notifyProgrammaticScroll`.
+   */
+  easedFollowEnabled: boolean;
+  /**
+   * The same follow-target derivation `scrollToBottom` uses internally
+   * (dock inset plus consumed-overlay state), exposed so the eased writer can
+   * read a live target each pass without duplicating that state machine.
+   * Returns the reachable (clamped) scrollTop for the given viewport.
+   */
+  resolveFollowTargetTop: (viewport: HTMLElement) => number;
   /** Wrap a scrollTop write so its event is excluded from pin/direction. */
   notifyProgrammaticScroll: (write: () => void) => void;
   /** Clear all ownership markers (on unmount). */
@@ -87,11 +105,18 @@ export function useTranscriptFramePipelineLifecycle({
   restoreResolverRef,
   restoreDeadlineRef,
   scrollToBottom,
+  easedFollowEnabled,
+  resolveFollowTargetTop,
   notifyProgrammaticScroll,
   clearAllMarkers,
   beginGlue,
   onRestoreStranded,
 }: UseTranscriptFramePipelineLifecycleOptions): void {
+  // PRO-168 (rung 12): true while the eased writer's last step has not yet
+  // reached its target. Read by the pipeline's `hasPendingMotion` hook so it
+  // keeps scheduling frames purely for this writer's own catch-up. Always
+  // false (never read) when the flag is off.
+  const easedMotionPendingRef = useRef(false);
   // Running maximum of the viewport's reported total content height within the
   // CURRENT compensation anchor's window, so the compensation delta can be
   // clamped monotonic (see runFramePass). Keyed by anchor identity: a fresh
@@ -119,7 +144,22 @@ export function useTranscriptFramePipelineLifecycle({
       return;
     }
     if (pinnedRef.current) {
-      scrollToBottom();
+      // PRO-168 (rung 12, Q16): flag off takes the original instant path
+      // verbatim — byte-identical to pre-rung-12 v1. Flag on substitutes the
+      // eased writer, which still writes exclusively through
+      // `notifyProgrammaticScroll` (classification is untouched, FR-1).
+      if (!easedFollowEnabled) {
+        scrollToBottom();
+        return;
+      }
+      const targetTop = resolveFollowTargetTop(viewport);
+      const step = resolveEasedFollowStep(viewport.scrollTop, targetTop);
+      easedMotionPendingRef.current = !step.converged;
+      if (step.nextTop !== viewport.scrollTop) {
+        notifyProgrammaticScroll(() => {
+          viewport.scrollTop = step.nextTop;
+        });
+      }
       return;
     }
     // FR-2 restore (rung 6): re-resolve the saved reading anchor to scrollTop
@@ -277,6 +317,8 @@ export function useTranscriptFramePipelineLifecycle({
     pinnedRef,
     scrollRef,
     scrollToBottom,
+    easedFollowEnabled,
+    resolveFollowTargetTop,
   ]);
 
   useLayoutEffect(() => {
@@ -284,6 +326,10 @@ export function useTranscriptFramePipelineLifecycle({
     pipeline.setWriter({
       runFramePass,
       measureContentHeight: () => scrollRef.current?.scrollHeight ?? -1,
+      // PRO-168 (rung 12): only the eased writer ever reports pending motion;
+      // the instant path never sets the ref, so this stays a permanent no-op
+      // with the flag off.
+      hasPendingMotion: () => easedFollowEnabled && easedMotionPendingRef.current,
       shouldContinueGlue: () => {
         const viewport = scrollRef.current;
         if (!viewport) {
@@ -306,6 +352,7 @@ export function useTranscriptFramePipelineLifecycle({
     pipelineRef,
     runFramePass,
     scrollRef,
+    easedFollowEnabled,
   ]);
 
   // On tab/window re-show while pinned, glue to the bottom for a few frames so

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.eased-follow.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.eased-follow.test.tsx
@@ -1,0 +1,155 @@
+/* @vitest-environment jsdom */
+
+import { useRef } from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY } from "#product/domain/chats/transcript/transcript-eased-follow-config";
+import { TRANSCRIPT_EASED_FOLLOW_RATE } from "#product/hooks/chat/ui/transcript-eased-follow";
+import {
+  useTranscriptStickToBottom,
+  type TranscriptStickToBottom,
+} from "./use-transcript-stick-to-bottom";
+
+/**
+ * PRO-168 (rung 12, Q16): the flag-gated eased-follow writer. All other
+ * use-transcript-stick-to-bottom*.test.tsx files run with the flag at its
+ * default (off, no key set), proving the instant path is byte-identical to
+ * before this rung. This file is the ONLY one that turns the flag on, so it
+ * proves the eased writer's own behavior: partial per-frame catch-up under
+ * pinned growth, converging to the same target the instant writer reaches.
+ */
+
+let rafCallbacks: Array<FrameRequestCallback | null>;
+
+beforeEach(() => {
+  rafCallbacks = [];
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    rafCallbacks.push(cb);
+    return rafCallbacks.length;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+    rafCallbacks[id - 1] = null;
+  });
+  window.localStorage.setItem(TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY, "on");
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  window.localStorage.removeItem(TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY);
+});
+
+function flushRafRound() {
+  const pending = rafCallbacks;
+  rafCallbacks = [];
+  for (const cb of pending) {
+    cb?.(0);
+  }
+}
+
+interface HarnessHandle {
+  api: TranscriptStickToBottom;
+  viewport: HTMLDivElement;
+}
+
+function renderHarness(): { current: HarnessHandle } {
+  const handle: { current: HarnessHandle | null } = { current: null };
+
+  function Harness() {
+    const scrollRef = useRef<HTMLDivElement>(null);
+    const api = useTranscriptStickToBottom({
+      scrollRef,
+      onScrollSample: vi.fn(),
+    });
+    return (
+      <div
+        ref={(node) => {
+          scrollRef.current = node;
+          if (node) {
+            handle.current = { api, viewport: node };
+          }
+        }}
+        data-testid="viewport"
+      />
+    );
+  }
+
+  render(<Harness />);
+  return {
+    get current() {
+      return handle.current!;
+    },
+  };
+}
+
+function setMetrics(el: HTMLElement, metrics: { scrollHeight: number; clientHeight: number; scrollTop: number }) {
+  Object.defineProperty(el, "scrollHeight", { value: metrics.scrollHeight, configurable: true });
+  Object.defineProperty(el, "clientHeight", { value: metrics.clientHeight, configurable: true });
+  el.scrollTop = metrics.scrollTop;
+}
+
+describe("useTranscriptStickToBottom eased-follow writer (PRO-168, rung 12, flag on)", () => {
+  it("steps toward the target instead of snapping instantly on the first growth frame", () => {
+    const handle = renderHarness();
+    const { viewport } = handle.current;
+    setMetrics(viewport, { scrollHeight: 1_000, clientHeight: 300, scrollTop: 700 });
+
+    act(() => {
+      handle.current.api.notifyContentResize();
+    });
+
+    // Target (hard bottom) is 700; starting already there, so no motion is
+    // needed yet. Grow the content and resize again to create real distance.
+    setMetrics(viewport, { scrollHeight: 2_000, clientHeight: 300, scrollTop: 700 });
+    act(() => {
+      handle.current.api.notifyContentResize();
+    });
+
+    const target = 2_000 - 300; // 1_700
+    const expectedFirstStep = 700 + (target - 700) * TRANSCRIPT_EASED_FOLLOW_RATE;
+    expect(viewport.scrollTop).toBeCloseTo(expectedFirstStep);
+    // A real distance remains: the writer must not have jumped straight there.
+    expect(viewport.scrollTop).toBeLessThan(target);
+  });
+
+  it("converges to the same hard-bottom target the instant writer would reach", () => {
+    const handle = renderHarness();
+    const { viewport } = handle.current;
+    setMetrics(viewport, { scrollHeight: 1_000, clientHeight: 300, scrollTop: 0 });
+
+    act(() => {
+      handle.current.api.notifyContentResize();
+    });
+
+    const target = 1_000 - 300; // 700
+    // Drive frames until the pipeline goes quiet (motion continuation
+    // self-schedules while pending, then stops).
+    for (let i = 0; i < 60 && rafCallbacks.some((cb) => cb != null); i += 1) {
+      act(() => {
+        flushRafRound();
+      });
+    }
+
+    expect(viewport.scrollTop).toBe(target);
+  });
+
+  it("stays pinned (isPinnedToBottom) throughout the eased catch-up", () => {
+    const handle = renderHarness();
+    const { viewport } = handle.current;
+    setMetrics(viewport, { scrollHeight: 5_000, clientHeight: 300, scrollTop: 0 });
+
+    act(() => {
+      handle.current.api.notifyContentResize();
+    });
+    expect(handle.current.api.isPinnedToBottom).toBe(true);
+
+    for (let i = 0; i < 60 && rafCallbacks.some((cb) => cb != null); i += 1) {
+      act(() => {
+        flushRafRound();
+      });
+    }
+    expect(handle.current.api.isPinnedToBottom).toBe(true);
+    expect(viewport.scrollTop).toBe(5_000 - 300);
+  });
+});

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.eased-follow.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.eased-follow.test.tsx
@@ -152,4 +152,51 @@ describe("useTranscriptStickToBottom eased-follow writer (PRO-168, rung 12, flag
     expect(handle.current.api.isPinnedToBottom).toBe(true);
     expect(viewport.scrollTop).toBe(5_000 - 300);
   });
+
+  it("does not leave a stale pending-motion frame running after the user unpins mid-catch-up", () => {
+    // Regression: hasPendingMotion is written ONLY by the pinned branch of
+    // runFramePass; unpinning mid-catch-up (before convergence) must not
+    // leave it stuck true, or every later content resize would keep
+    // re-arming a motion continuation frame forever with nothing pinned to
+    // drive it.
+    const handle = renderHarness();
+    const { viewport } = handle.current;
+    setMetrics(viewport, { scrollHeight: 5_000, clientHeight: 300, scrollTop: 0 });
+
+    act(() => {
+      handle.current.api.notifyContentResize();
+    });
+    // One eased step ran; far from converged, so a continuation frame is
+    // queued (a real pending-motion state, not yet resolved).
+    expect(rafCallbacks.some((cb) => cb != null)).toBe(true);
+
+    // The user scrolls up before the eased catch-up finished: unpin.
+    act(() => {
+      handle.current.api.setPinned(false);
+    });
+    expect(handle.current.api.isPinnedToBottom).toBe(false);
+
+    // Drain every frame the unpin left queued.
+    for (let i = 0; i < 10 && rafCallbacks.some((cb) => cb != null); i += 1) {
+      act(() => {
+        flushRafRound();
+      });
+    }
+    // Content keeps growing while the reader is unpinned reading (no anchor
+    // installed here, so the unpinned branch is a no-op) — this is the
+    // trigger that would perpetually re-arm the continuation if the pending
+    // flag had gone stale.
+    setMetrics(viewport, { scrollHeight: 6_000, clientHeight: 300, scrollTop: viewport.scrollTop });
+    act(() => {
+      handle.current.api.notifyContentResize();
+    });
+
+    for (let i = 0; i < 10 && rafCallbacks.some((cb) => cb != null); i += 1) {
+      act(() => {
+        flushRafRound();
+      });
+    }
+    // The pipeline must go quiet: no frame left queued.
+    expect(rafCallbacks.every((cb) => cb == null)).toBe(true);
+  });
 });

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
@@ -1,6 +1,9 @@
 import { useCallback, useRef, useState } from "react";
 import { resolveVirtualBottomDistance } from "#product/domain/chats/transcript/transcript-virtual-rows";
-import { readTranscriptEasedFollowEnabled } from "#product/domain/chats/transcript/transcript-eased-follow-config";
+import {
+  resolveTranscriptEasedFollowEnabled,
+  TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY,
+} from "#product/domain/chats/transcript/transcript-eased-follow-config";
 import {
   DIRECTION_EPSILON_PX,
   REPIN_BOTTOM_THRESHOLD_PX,
@@ -34,6 +37,18 @@ export type { TranscriptStickToBottom, UseTranscriptStickToBottomOptions };
 
 function interactionNow(): number {
   return typeof performance === "undefined" ? Date.now() : performance.now();
+}
+
+// PRO-168 (rung 12, Q16): read once at mount, same convention as the
+// virtualization-mode flag. `window` access stays out of domain/ (the
+// tsconfig.domain.json DOM-free gate), so this lives in the hook layer.
+function readTranscriptEasedFollowEnabled(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  return resolveTranscriptEasedFollowEnabled(
+    window.localStorage.getItem(TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY),
+  );
 }
 
 // FR-2 (rung 6): how long the single frame pass re-resolves the saved reading

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
@@ -36,13 +36,10 @@ function interactionNow(): number {
   return typeof performance === "undefined" ? Date.now() : performance.now();
 }
 
-// FR-2 (rung 6): how long the single frame pass re-resolves the saved reading
-// anchor after a finalized-session revisit so residual corrections land.
+// FR-2 (rung 6): how long the frame pass re-resolves the saved reading anchor after a finalized-session revisit.
 const RESTORE_MAX_MS = 500;
 
-// How long the frame pass keeps absorbing a prepend's estimate-to-measured
-// corrections into scrollTop, bounded by wall-clock (not the glue window's
-// quiet-frame termination) so a post-glue correction still lands.
+// How long the frame pass keeps absorbing a prepend's estimate-to-measured corrections, bounded by wall-clock.
 const ABOVE_CHANGE_COMPENSATION_MAX_MS = 500;
 
 /**
@@ -83,16 +80,11 @@ export function useTranscriptStickToBottom({
   // session-entry / submit / tab-resume / above-change rAF loops with one
   // owned scheduler and ONE snap writer.
   const pipelineRef = useRef(new TranscriptFramePipeline());
-  // Active above-change compensation anchor, applied while unpinned until its
-  // deadline lapses (so a post-glue correction is still absorbed).
+  // Active above-change compensation anchor, applied while unpinned until its deadline lapses.
   const compensationAnchorRef = useRef<ContentHeightScrollAnchor | null>(null);
-  // Whether the active compensation cancels on upward intent: true for a
-  // completed-turn split, false for a history prepend (reader-asked).
+  // Cancels on upward intent: true for a completed-turn split, false for a history prepend (reader-asked).
   const compensationCancelableRef = useRef(false);
-  // Deadline (interactionNow ms) past which the active above-change anchor is
-  // stale: compensated each correction before it, then released so
-  // below-viewport growth can move the reader. Wall-clock, not the glue
-  // window's quiet-frame termination (which can end a frame early).
+  // Deadline (interactionNow ms) past which the anchor is stale and released; wall-clock, not glue's quiet-frame end.
   const compensationDeadlineRef = useRef(0);
   // FR-2 restore (rung 6): frame writer re-resolves this each glued frame so the saved reading row holds as heights settle.
   const restoreResolverRef = useRef<((viewport: HTMLElement) => TranscriptRestoreResolution | null) | null>(null);
@@ -196,11 +188,10 @@ export function useTranscriptStickToBottom({
       return;
     }
 
-    // NON-cancelable compensation (history prepend): never let scrollTop fall
-    // below the pre-prepend floor. The pipeline only re-applies its write on a
-    // growth-driven pass, not a scroll EVENT; once content plateaus, a live
-    // wheel gesture erodes scrollTop unopposed (CI webkit "prepend anchoring
-    // ... scrollTop Received 0"). Clamp synchronously to the proven-safe floor.
+    // NON-cancelable compensation (history prepend): never drop scrollTop below
+    // the pre-prepend floor. The pipeline only re-applies on a growth-driven
+    // pass, not a scroll EVENT, so a wheel gesture can erode it unopposed once
+    // content plateaus (CI webkit "prepend anchoring ... scrollTop Received 0").
     const activeCompensationAnchor = compensationAnchorRef.current;
     if (
       activeCompensationAnchor != null

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
@@ -1,9 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 import { resolveVirtualBottomDistance } from "#product/domain/chats/transcript/transcript-virtual-rows";
-import {
-  resolveTranscriptEasedFollowEnabled,
-  TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY,
-} from "#product/domain/chats/transcript/transcript-eased-follow-config";
+import { readTranscriptEasedFollowEnabled } from "#product/hooks/chat/ui/transcript-eased-follow";
 import {
   DIRECTION_EPSILON_PX,
   REPIN_BOTTOM_THRESHOLD_PX,
@@ -37,18 +34,6 @@ export type { TranscriptStickToBottom, UseTranscriptStickToBottomOptions };
 
 function interactionNow(): number {
   return typeof performance === "undefined" ? Date.now() : performance.now();
-}
-
-// PRO-168 (rung 12, Q16): read once at mount, same convention as the
-// virtualization-mode flag. `window` access stays out of domain/ (the
-// tsconfig.domain.json DOM-free gate), so this lives in the hook layer.
-function readTranscriptEasedFollowEnabled(): boolean {
-  if (typeof window === "undefined") {
-    return false;
-  }
-  return resolveTranscriptEasedFollowEnabled(
-    window.localStorage.getItem(TRANSCRIPT_EASED_FOLLOW_STORAGE_KEY),
-  );
 }
 
 // FR-2 (rung 6): how long the single frame pass re-resolves the saved reading

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 import { resolveVirtualBottomDistance } from "#product/domain/chats/transcript/transcript-virtual-rows";
+import { readTranscriptEasedFollowEnabled } from "#product/domain/chats/transcript/transcript-eased-follow-config";
 import {
   DIRECTION_EPSILON_PX,
   REPIN_BOTTOM_THRESHOLD_PX,
@@ -61,6 +62,9 @@ export function useTranscriptStickToBottom({
 }: UseTranscriptStickToBottomOptions): TranscriptStickToBottom {
   const pinnedRef = useRef(true);
   const [isPinnedToBottom, setIsPinnedToBottom] = useState(true);
+  // PRO-168 (rung 12, Q16): read once; flipping the flag mid-session is not a
+  // supported live-toggle, matching the virtualization-mode flag's contract.
+  const [easedFollowEnabled] = useState(readTranscriptEasedFollowEnabled);
   // Q18 (rung 9): see use-transcript-new-content-signal.ts.
   const {
     hasNewContentWhileUnpinned,
@@ -163,6 +167,7 @@ export function useTranscriptStickToBottom({
     dispatchInsetEvent,
     scrollToBottom,
     handleScrollToBottomClick,
+    resolveFollowTargetTop,
   } = useTranscriptAutoFollowBottom({
     scrollRef,
     structuralBottomInsetPx,
@@ -373,6 +378,8 @@ export function useTranscriptStickToBottom({
     restoreResolverRef,
     restoreDeadlineRef,
     scrollToBottom,
+    easedFollowEnabled,
+    resolveFollowTargetTop,
     notifyProgrammaticScroll,
     clearAllMarkers,
     beginGlue,


### PR DESCRIPTION
## Rung 12 (final): flagged eased-follow motion writer (PRO-187, design question Q16, PRO-168)

Implements the final rung of the Chat Scroll ADR ladder (§6), stacked on r11
(`chat-scroll/r11-diagnostics`).

Q16's ruling: "keep instant glue in v1; spec the motion layer as a pluggable
writer so an eased, smoothed follower can be added later without touching
classification; prototype PRO-168 behind a flag." FR-1 (single-writer thesis)
is the crux: the eased follow must live INSIDE the single-writer frame
pipeline as the one writer's motion policy, never a competing rAF animator.

### Flag

`proliferate:transcriptEasedFollow` (localStorage), read once at mount via
`readTranscriptEasedFollowEnabled` (`domain/chats/transcript/transcript-eased-follow-config.ts`),
same convention as the existing `proliferate:transcriptVirtualization` flag.
**Default OFF.** Only the literal string `"on"` enables it.

### What this adds

- **`transcript-eased-follow.ts`** — a pure, stateless `resolveEasedFollowStep`:
  one lerp step toward the follow target per frame pass (25% of the remaining
  distance, snapping once within 1px). No DOM, no React, fully unit-testable.
- **`transcript-frame-pipeline.ts`** — the writer contract gains an optional
  `hasPendingMotion?: () => boolean`. When true after a pass, the pipeline
  self-schedules exactly one more frame purely so the SAME writer can keep
  converging (`continueMotionIfPending`), with its own handle separate from
  the existing frame-guard/glue handles so it never contends with them. The
  instant writer never implements this hook, so it is a permanent no-op with
  the flag off — every pre-existing pipeline test (none of which define
  `hasPendingMotion`) passes unchanged, proving the seam is additive. Glue
  windows ending mid-motion (height went quiet, or the user reclaimed control)
  hand off to the continuation instead of stranding an eased writer short of
  its target.
- **`use-transcript-frame-pipeline-lifecycle.ts`** — the pinned branch of
  `runFramePass` takes an `easedFollowEnabled` flag and a
  `resolveFollowTargetTop` reader. Flag off: the original
  `scrollToBottom()` call, unchanged. Flag on: one eased step written via
  `notifyProgrammaticScroll` (same ownership-marker path as every other
  write — classification, FR-1, is untouched), tracked in
  `easedMotionPendingRef` for the pipeline's `hasPendingMotion` hook.
- **`use-transcript-auto-follow-bottom.ts`** — exposes `resolveFollowTargetTop`,
  the exact same dock-inset/consumed-overlay derivation `scrollToBottom`
  already uses internally, so the eased writer shares one target definition
  instead of a second copy of that state machine (also keeps
  `use-transcript-stick-to-bottom.ts` under the 400-line file-size gate).
- **`use-transcript-stick-to-bottom.ts`** — reads the flag once via
  `useState(readTranscriptEasedFollowEnabled)` and threads it plus
  `resolveFollowTargetTop` into the pipeline lifecycle hook.

### Tests

- `transcript-eased-follow.test.ts` (5): the pure step function — partial
  step while far from target, symmetric in delta sign, snap-to-target within
  the convergence epsilon, converges in a bounded number of frames.
- `transcript-frame-pipeline.test.ts` (+4): the `hasPendingMotion`
  continuation seam — schedules exactly one more frame per pending pass then
  stops; a writer that never implements the hook never gets a continuation
  frame; glue ending mid-motion hands off instead of stranding it; `beginGlue`
  folds a pending continuation in rather than double-passing in one frame.
- `transcript-eased-follow-config.test.ts` (5): flag parsing/reading,
  defaulting OFF for null/unset/anything but the exact `"on"` string.
- `use-transcript-stick-to-bottom.eased-follow.test.tsx` (3, flag ON) — the
  ONLY test file in the engine that turns the flag on: partial first-step
  under growth (not an instant jump), converges to the same hard-bottom
  target the instant writer reaches, and stays pinned throughout.
- All 9 pre-existing `use-transcript-stick-to-bottom*.test.tsx` files (66
  tests) pass **unchanged** with the flag at its default (off) — proving
  instant-snap behavior is byte-identical to r11.

### Manual verification (Pablo's standard)

Scoped vitest, literal output, run 2026-08-16:

```
✓ src/hooks/chat/ui/transcript-eased-follow.test.ts (5 tests)
✓ src/hooks/chat/ui/transcript-frame-pipeline.test.ts (11 tests)
✓ src/domain/chats/transcript/transcript-eased-follow-config.test.ts (5 tests)
✓ src/hooks/chat/ui/use-transcript-stick-to-bottom.restore-stranded.test.tsx (2 tests)
✓ src/hooks/chat/ui/use-transcript-stick-to-bottom.eased-follow.test.tsx (3 tests)
✓ src/hooks/chat/ui/use-transcript-stick-to-bottom.session-stamp.test.tsx (3 tests)
✓ src/hooks/chat/ui/use-transcript-stick-to-bottom.inset-transition.test.tsx (3 tests)
✓ src/hooks/chat/ui/use-transcript-stick-to-bottom.diagnostics.test.tsx (4 tests)
✓ src/hooks/chat/ui/use-transcript-stick-to-bottom.new-content.test.tsx (6 tests)
✓ src/hooks/chat/ui/use-transcript-stick-to-bottom.markers.test.tsx (7 tests)
✓ src/hooks/chat/ui/use-transcript-stick-to-bottom.compensation.test.tsx (11 tests)
✓ src/hooks/chat/ui/use-transcript-stick-to-bottom.test.tsx (23 tests)

Test Files  12 passed (12)
     Tests  83 passed (83)
```

`npx tsc -p tsconfig.json --noEmit` → exit 0.
`python3 scripts/report_frontend_structure.py` → `LARGE_FRONTEND_FILE: 0`, `TOTAL: 0` (no new allowlist entries; `use-transcript-auto-follow-bottom.ts` absorbed the shared follow-target reader to keep `use-transcript-stick-to-bottom.ts` at 390 lines).

**Negative control:** temporarily removed the `continueMotionIfPending()` call
sites in `transcript-frame-pipeline.ts` (the actual fix), reran the same two
touched suites, and got a literal 4-test failure:

```
× hasPendingMotion continuation > requestFrame schedules ONE more frame per pass while motion is pending, then stops
  → expected 3 to be 2
× hasPendingMotion continuation > glue ending mid-motion hands off to the motion continuation instead of stranding it
  → expected 4 to be 3
× useTranscriptStickToBottom eased-follow writer > converges to the same hard-bottom target the instant writer would reach
  → expected 175 to be 700
× useTranscriptStickToBottom eased-follow writer > stays pinned (isPinnedToBottom) throughout the eased catch-up
  → expected 1175 to be 4700

Test Files  2 failed | 10 passed (14)
```

Restored the fix; all 14 pass again (confirmed above). Also hit and fixed a
real bug during this pass: the continuation callback originally called
`runFramePass()` unconditionally on fire, one frame stale relative to
`hasPendingMotion()`'s updated value — moved the check to gate BEFORE running
the pass (mirroring `glueTick`'s existing `shouldContinueGlue` pattern),
which is what the negative control above caught.

### Deviations from the ADR's literal file list

The ADR's engine-file list (§6 rung 12 context / Cell descriptions) names
`use-above-change-compensation.ts` as a standalone file; by r10/r11 that
above-change-compensation logic already lives inside
`use-transcript-frame-pipeline-lifecycle.ts` (folded in during the rung-4/5
work), so there is no separate file by that name to touch. No behavior or
scope change, just noting the pointer is stale relative to the as-built tree.

Did not add a new Playwright fixture to
`qualification/scroll-physics/specs/scroll-physics.spec.ts` for eased-follow
specifically: the ADR's rung-12 gate ("flag off unchanged; flag on composes
with intent and the render gate") doesn't name a dedicated fixture the way
rungs 1–11 do, and the deterministic `FakeFrames` harness already in
`transcript-frame-pipeline.test.ts` gives frame-exact coverage of the new
scheduling seam that a real-timing Playwright run would only reproduce
probabilistically. Flagging this as a founder question below rather than
silently expanding scope.

### Founder questions

1. Is unit/vitest coverage of the eased-follow seam sufficient for a
   flag-off-by-default prototype, or do you want a real-browser Playwright
   fixture added before this merges (even though the ADR doesn't name one)?
2. The eased-follow rate (25%/frame, ~1px convergence epsilon) is a first-cut
   constant with no product tuning pass — fine to ship as the prototype's
   default, or should it be sourced from somewhere (e.g. a config surface)
   before any wider rollout?

This closes the PR ladder for PRO-187 (rungs 0–12). No further rungs are
planned in the ADR.

### Round 3 (Greptile review fix)

Greptile flagged a real leak: `easedMotionPendingRef` was written only in
`runFramePass`'s pinned branch, so unpinning mid-catch-up could leave it
stuck `true` forever — every later content resize would then re-arm the
motion continuation with nothing pinned asking for it. Fixed by gating
`hasPendingMotion` on `pinnedRef.current` (so a stale ref can never leak past
an unpin) and clearing the ref explicitly in the unpinned branch as defense
in depth. Added a regression test that unpins mid-catch-up, drives another
resize, and asserts the pipeline goes fully quiet — reverted locally to
confirm it fails without the fix (a frame stays queued forever), then
restored. Also dropped a comment referencing another chat product's name
(repo convention: describe the design in our own vocabulary).
