### PR TITLE
feat(product-client): scroll diagnostics via renderer pipe (PRO-187, r11, reopened)

### DIFF
--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-reading-position-store.test.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-reading-position-store.test.ts
@@ -163,7 +163,7 @@ describe("transcript-reading-position-store", () => {
         (write) => write(),
       );
       expect(placed).toBe(true);
-      expect(setPinned).toHaveBeenCalledWith(false);
+      expect(setPinned).toHaveBeenCalledWith(false, "session_reset");
       expect(refs.viewport.scrollTop).toBe(450);
       expect(refs.restoreResolverRef.current).toBe(plan.kind === "restore" ? plan.resolveTargetTop : null);
       expect(refs.restoreDeadlineRef.current).toBe(1234);

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-reading-position-store.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-reading-position-store.ts
@@ -19,7 +19,7 @@
 // "estimates cannot skew the restore" guarantee.
 
 import type { MutableRefObject, RefObject } from "react";
-import type { TranscriptPinTransitionCause } from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations";
+import type { TranscriptPinTransitionCause } from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations-transcript";
 
 // The working set of concurrently open sessions in one runtime is small; this
 // caps the retained set so a very long-lived tab that visits thousands of

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-reading-position-store.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-reading-position-store.ts
@@ -19,6 +19,7 @@
 // "estimates cannot skew the restore" guarantee.
 
 import type { MutableRefObject, RefObject } from "react";
+import type { TranscriptPinTransitionCause } from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations";
 
 // The working set of concurrently open sessions in one runtime is small; this
 // caps the retained set so a very long-lived tab that visits thousands of
@@ -196,7 +197,7 @@ export function beginSessionRestorePlacement(
     >;
     restoreDeadlineRef: MutableRefObject<number>;
   },
-  setPinned: (pinned: boolean) => void,
+  setPinned: (pinned: boolean, cause?: TranscriptPinTransitionCause) => void,
   notifyProgrammaticScroll: (write: () => void) => void,
 ): boolean {
   if (plan.kind !== "restore") {
@@ -209,7 +210,7 @@ export function beginSessionRestorePlacement(
   if (initialTop == null) {
     return false;
   }
-  setPinned(false);
+  setPinned(false, "session_reset");
   refs.restoreResolverRef.current = plan.resolveTargetTop;
   refs.restoreDeadlineRef.current = deadlineMs;
   const viewportEl = viewport;

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-auto-follow-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-auto-follow-bottom.ts
@@ -11,6 +11,7 @@ import {
   PROGRAMMATIC_MATCH_TOL_PX,
 } from "#product/hooks/chat/ui/transcript-row-list-model";
 import { resolveTranscriptFollowTarget } from "#product/hooks/chat/ui/transcript-follow-target";
+import type { TranscriptPinTransitionCause } from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations";
 import {
   initialTranscriptInsetState,
   reduceTranscriptInset,
@@ -38,7 +39,7 @@ export interface UseTranscriptAutoFollowBottomOptions {
   nonDisplacingBottomInsetPx: number;
   /** Live pin state. */
   pinnedRef: RefObject<boolean>;
-  setPinned: (pinned: boolean) => void;
+  setPinned: (pinned: boolean, cause?: TranscriptPinTransitionCause) => void;
   /** Owned by the caller: last observed scrollTop, used for direction detection. */
   lastScrollTopRef: MutableRefObject<number>;
   /** Record a write as our own, not the user's, before its scroll event arrives. */
@@ -184,7 +185,7 @@ export function useTranscriptAutoFollowBottom({
 
   const handleScrollToBottomClick = useCallback(() => {
     dispatchInsetEvent({ type: "consume_full" });
-    setPinned(true);
+    setPinned(true, "button_click");
     scrollToBottom();
   }, [dispatchInsetEvent, scrollToBottom, setPinned]);
 

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-auto-follow-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-auto-follow-bottom.ts
@@ -11,7 +11,7 @@ import {
   PROGRAMMATIC_MATCH_TOL_PX,
 } from "#product/hooks/chat/ui/transcript-row-list-model";
 import { resolveTranscriptFollowTarget } from "#product/hooks/chat/ui/transcript-follow-target";
-import type { TranscriptPinTransitionCause } from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations";
+import type { TranscriptPinTransitionCause } from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations-transcript";
 import {
   initialTranscriptInsetState,
   reduceTranscriptInset,

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom-types.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom-types.ts
@@ -4,6 +4,7 @@ import type {
   TranscriptScrollSample,
 } from "#product/hooks/chat/ui/transcript-row-list-model";
 import type { TranscriptSessionRestorePlan } from "#product/hooks/chat/ui/transcript-reading-position-store";
+import type { TranscriptPinTransitionCause } from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations";
 
 /**
  * Split out of use-transcript-stick-to-bottom.ts (capped near 400 lines,
@@ -66,8 +67,13 @@ export interface TranscriptStickToBottom {
   handleScrollToBottomClick: () => void;
   /** Wrap ANY external scrollTop/scrollToOffset write so its scroll event is excluded from pin/direction. */
   notifyProgrammaticScroll: (write: () => void) => void;
-  /** Force the pin state (history prepend / anchor restore intentionally unpin to hold the user's position). */
-  setPinned: (pinned: boolean) => void;
+  /**
+   * Force the pin state (history prepend / anchor restore intentionally unpin
+   * to hold the user's position). `cause` is diagnostics-only (rung 11,
+   * PRO-187): it labels the resulting `renderer.transcript.pin_transition`
+   * record and never changes behavior.
+   */
+  setPinned: (pinned: boolean, cause?: TranscriptPinTransitionCause) => void;
   /**
    * Reset tracking for a session switch and place the viewport before first
    * paint: bottom-pin a streaming session, or restore a finalized session to its

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom-types.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom-types.ts
@@ -4,7 +4,7 @@ import type {
   TranscriptScrollSample,
 } from "#product/hooks/chat/ui/transcript-row-list-model";
 import type { TranscriptSessionRestorePlan } from "#product/hooks/chat/ui/transcript-reading-position-store";
-import type { TranscriptPinTransitionCause } from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations";
+import type { TranscriptPinTransitionCause } from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations-transcript";
 
 /**
  * Split out of use-transcript-stick-to-bottom.ts (capped near 400 lines,

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.diagnostics.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.diagnostics.test.tsx
@@ -1,0 +1,167 @@
+/* @vitest-environment jsdom */
+
+// Rung 11 (PRO-187, requirement R10 / design question Q8): pin-state
+// transitions and programmatic-versus-user classification must reach the
+// renderer diagnostics so a production scroll bug reproduces from logs
+// alone. This file asserts ONLY the diagnostics wiring (observation-only,
+// same choke points the engine already uses); the pin/classification
+// BEHAVIOR itself stays covered by the pre-existing marker/session-stamp/
+// compensation suites, which all still pass unchanged (no new writer, no
+// behavior change).
+
+import { useRef } from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useTranscriptStickToBottom,
+  type TranscriptStickToBottom,
+} from "./use-transcript-stick-to-bottom";
+import {
+  resetRendererDiagnosticsSinkForTest,
+  setRendererDiagnosticsSink,
+} from "#product/lib/infra/diagnostics/renderer-diagnostics-port";
+
+let rafCallbacks: Array<FrameRequestCallback | null>;
+
+beforeEach(() => {
+  rafCallbacks = [];
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    rafCallbacks.push(cb);
+    return rafCallbacks.length;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+    rafCallbacks[id - 1] = null;
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  resetRendererDiagnosticsSinkForTest();
+});
+
+interface HarnessHandle {
+  api: TranscriptStickToBottom;
+  viewport: HTMLDivElement;
+}
+
+function renderHarness(sessionKey?: string): { current: HarnessHandle } {
+  const handle: { current: HarnessHandle | null } = { current: null };
+
+  function Harness() {
+    const scrollRef = useRef<HTMLDivElement>(null);
+    const api = useTranscriptStickToBottom({
+      scrollRef,
+      onScrollSample: vi.fn(),
+      sessionKey,
+    });
+    return (
+      <div
+        ref={(node) => {
+          scrollRef.current = node;
+          if (node) {
+            handle.current = { api, viewport: node };
+          }
+        }}
+        data-testid="viewport"
+      />
+    );
+  }
+
+  render(<Harness />);
+  return {
+    get current() {
+      return handle.current!;
+    },
+  };
+}
+
+function setMetrics(el: HTMLElement, metrics: { scrollHeight: number; clientHeight: number; scrollTop: number }) {
+  Object.defineProperty(el, "scrollHeight", { value: metrics.scrollHeight, configurable: true });
+  Object.defineProperty(el, "clientHeight", { value: metrics.clientHeight, configurable: true });
+  el.scrollTop = metrics.scrollTop;
+}
+
+function pinTransitionCalls(emit: ReturnType<typeof vi.fn>) {
+  return emit.mock.calls
+    .map(([input]: [{ name: string; correlation?: { sessionId?: string }; fields?: Record<string, { value: unknown }> }]) => input)
+    .filter((input) => input.name === "renderer.transcript.pin_transition");
+}
+
+describe("useTranscriptStickToBottom diagnostics (rung 11, PRO-187)", () => {
+  it("records the user-scroll-intent direction before the resulting pin transition, both correlated to the session", () => {
+    const emit = vi.fn();
+    setRendererDiagnosticsSink({ emit });
+    const handle = renderHarness("session-42");
+    const { viewport } = handle.current;
+    setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 700 });
+
+    act(() => {
+      handle.current.api.notifyUserScrollIntent(-1);
+    });
+
+    const names = emit.mock.calls.map(([input]) => input.name);
+    expect(names).toContain("renderer.transcript.user_scroll_intent");
+    expect(names).toContain("renderer.transcript.pin_transition");
+    // Intent recorded strictly before the pin flip it causes, matching the
+    // false-unpin / swallowed-scroll detections in ADR section 5.
+    expect(names.indexOf("renderer.transcript.user_scroll_intent"))
+      .toBeLessThan(names.indexOf("renderer.transcript.pin_transition"));
+
+    const transitions = pinTransitionCalls(emit);
+    expect(transitions[0]).toEqual(expect.objectContaining({
+      correlation: { sessionId: "session-42" },
+      fields: expect.objectContaining({
+        pinned: { privacy: "operational", value: false },
+        cause: { privacy: "operational", value: "user_intent_unpin" },
+      }),
+    }));
+  });
+
+  it("does not record a pin transition for a no-op setPinned call (state unchanged)", () => {
+    const emit = vi.fn();
+    setRendererDiagnosticsSink({ emit });
+    const handle = renderHarness("session-1");
+
+    // Already pinned by default; re-pinning via the button click is a no-op
+    // transition and must not spam a transition record.
+    act(() => {
+      handle.current.api.handleScrollToBottomClick();
+    });
+
+    expect(pinTransitionCalls(emit)).toHaveLength(0);
+  });
+
+  it("labels a button-click re-pin distinctly from a leave-band unpin", () => {
+    const emit = vi.fn();
+    setRendererDiagnosticsSink({ emit });
+    const handle = renderHarness("session-1");
+    const { viewport } = handle.current;
+    setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 700 });
+
+    act(() => {
+      handle.current.api.notifyUserScrollIntent(-1);
+    });
+    act(() => {
+      handle.current.api.handleScrollToBottomClick();
+    });
+
+    const transitions = pinTransitionCalls(emit);
+    const causes = transitions.map((input) => input.fields?.cause.value);
+    expect(causes).toEqual(["user_intent_unpin", "button_click"]);
+  });
+
+  it("falls back to an 'unknown' correlation when no sessionKey is supplied", () => {
+    const emit = vi.fn();
+    setRendererDiagnosticsSink({ emit });
+    const handle = renderHarness();
+
+    act(() => {
+      handle.current.api.notifyUserScrollIntent(-1);
+    });
+
+    const transitions = pinTransitionCalls(emit);
+    expect(transitions[0].correlation).toEqual({ sessionId: "unknown" });
+  });
+});

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
@@ -39,11 +39,9 @@ function interactionNow(): number {
 // anchor after a finalized-session revisit so residual corrections land.
 const RESTORE_MAX_MS = 500;
 
-// How long after a prepend the frame pass keeps absorbing freshly-mounted rows'
-// estimate-to-measured corrections into scrollTop (reading row stays fixed).
-// Corrections arrive over several frames via the ResizeObserver, so compensation
-// is bounded by this deadline (not the glue window's quiet-frame termination);
-// after it, below-viewport growth is free to move the reader again.
+// How long the frame pass keeps absorbing a prepend's estimate-to-measured
+// corrections into scrollTop, bounded by wall-clock (not the glue window's
+// quiet-frame termination) so a post-glue correction still lands.
 const ABOVE_CHANGE_COMPENSATION_MAX_MS = 500;
 
 /**
@@ -72,39 +70,33 @@ export function useTranscriptStickToBottom({
   } = useTranscriptNewContentSignal();
   const lastScrollTopRef = useRef(0);
   // Last observed content height: lets a scroll event tell a genuine user
-  // displacement (same-size content) apart from our snap lagging a growing stream
-  // (content just grew). Only the former unpins. See onViewportScroll.
+  // displacement apart from our own snap lagging a growing stream. See onViewportScroll.
   const lastContentHeightRef = useRef(0);
   // Ownership markers: the PRIMARY signal telling our own writes apart from a
   // user scroll. See transcript-scroll-ownership.ts.
   const ownershipMarkersRef = useRef(new TranscriptScrollOwnershipMarkers());
   // One per-frame mutate-then-snap pipeline (rung 4 / PRO-187): replaces the
-  // session-entry / submit / tab-resume / above-change rAF loops with one owned
-  // scheduler and ONE snap writer.
+  // session-entry / submit / tab-resume / above-change rAF loops with one
+  // owned scheduler and ONE snap writer.
   const pipelineRef = useRef(new TranscriptFramePipeline());
-  // Active above-change compensation anchor, applied by the single frame writer
-  // while unpinned until its deadline lapses (the deadline, not the glue window,
-  // bounds it so a post-glue correction is still absorbed).
+  // Active above-change compensation anchor, applied while unpinned until its
+  // deadline lapses (so a post-glue correction is still absorbed).
   const compensationAnchorRef = useRef<ContentHeightScrollAnchor | null>(null);
-  // Whether the active compensation cancels on upward user intent: true for a
-  // completed-turn split (autonomous); false for a history prepend (reader-asked).
+  // Whether the active compensation cancels on upward intent: true for a
+  // completed-turn split, false for a history prepend (reader-asked).
   const compensationCancelableRef = useRef(false);
   // Deadline (interactionNow ms) past which the active above-change anchor is
-  // stale: the frame pass compensates each correction before it, then stops so
-  // below-viewport growth can move the reader. Bounds compensation by wall-clock
-  // instead of the glue window's quiet-frame termination (which ends a frame
-  // early on a slow runner and loses the last correction).
+  // stale: compensated each correction before it, then released so
+  // below-viewport growth can move the reader. Wall-clock, not the glue
+  // window's quiet-frame termination (which can end a frame early).
   const compensationDeadlineRef = useRef(0);
   // FR-2 restore (rung 6): frame writer re-resolves this each glued frame so the saved reading row holds as heights settle.
   const restoreResolverRef = useRef<((viewport: HTMLElement) => TranscriptRestoreResolution | null) | null>(null);
   const restoreDeadlineRef = useRef(0);
   const userScrollIntentUntilRef = useRef(0);
 
-  // Rung 11 (PRO-187, R10 / Q8): `cause` is observation-only — it labels which
-  // of the engine's own transitions fired for the diagnostics record below and
-  // never changes what setPinned does. Defaults to "unspecified" so call sites
-  // this rung did not touch (there are none left un-instrumented, but future
-  // callers passing only one arg) still emit a record rather than a silent one.
+  // Rung 11: `cause` is observation-only for the diagnostics record below;
+  // it never changes what setPinned does. Defaults to "unspecified".
   const setPinned = useCallback((next: boolean, cause: TranscriptPinTransitionCause = "unspecified") => {
     if (next) {
       // Re-pinning (any path: repin band, submit, button click) means the
@@ -150,16 +142,12 @@ export function useTranscriptStickToBottom({
     userScrollIntentUntilRef.current = interactionNow() + TRANSCRIPT_USER_SCROLL_SETTLE_MS;
     // The reader is driving: end any in-flight FR-2 restore (rung 6).
     restoreResolverRef.current = null;
-    // Rung 11: the input-intent record itself, so a production log can tell
-    // "no intent recorded before this pin flip" (false unpin) apart from
-    // "intent recorded but pin state never moved" (swallowed user scroll) —
-    // see the failure-mode detections in section 5 of the ADR.
+    // Rung 11: records intent so a prod log can tell false-unpin apart from a swallowed user scroll (ADR §5).
     recordTranscriptUserScrollIntent({ sessionId: sessionKey ?? "unknown", direction });
     if (direction < 0) {
-      // Upward intent cancels only a CANCELABLE above-change compensation (a
-      // completed-turn split): the gesture wins, no per-frame re-anchor. A history
-      // PREPEND is NON-cancelable (reader asked for it by scrolling up) so it holds.
-      // See use-transcript-stick-to-bottom.compensation.test.tsx.
+      // Upward intent cancels only a CANCELABLE compensation (completed-turn
+      // split); a history PREPEND is NON-cancelable and holds regardless. See
+      // use-transcript-stick-to-bottom.compensation.test.tsx.
       if (compensationCancelableRef.current) {
         compensationAnchorRef.current = null;
       }
@@ -203,13 +191,11 @@ export function useTranscriptStickToBottom({
       return;
     }
 
-    // A NON-cancelable compensation (history prepend) must never let scrollTop
-    // fall below where the reader stood pre-prepend. The frame pipeline only
-    // re-applies its write on a growth-driven pass, never on a scroll EVENT; a
-    // physical wheel gesture moves scrollTop natively between passes, and once
-    // content plateaus nothing schedules another pass to counter it (CI webkit
-    // "prepend anchoring ... scrollTop Received 0"). Clamp synchronously here
-    // to the anchor's pre-prepend floor, already proven safe.
+    // NON-cancelable compensation (history prepend): never let scrollTop fall
+    // below the pre-prepend floor. The pipeline only re-applies its write on a
+    // growth-driven pass, not a scroll EVENT; once content plateaus, a live
+    // wheel gesture erodes scrollTop unopposed (CI webkit "prepend anchoring
+    // ... scrollTop Received 0"). Clamp synchronously to the proven-safe floor.
     const activeCompensationAnchor = compensationAnchorRef.current;
     if (
       activeCompensationAnchor != null

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
@@ -23,6 +23,11 @@ import type {
   TranscriptStickToBottom,
   UseTranscriptStickToBottomOptions,
 } from "#product/hooks/chat/ui/use-transcript-stick-to-bottom-types";
+import {
+  recordTranscriptPinTransition,
+  recordTranscriptUserScrollIntent,
+  type TranscriptPinTransitionCause,
+} from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations";
 
 export type { TranscriptStickToBottom, UseTranscriptStickToBottomOptions };
 
@@ -95,7 +100,12 @@ export function useTranscriptStickToBottom({
   const restoreDeadlineRef = useRef(0);
   const userScrollIntentUntilRef = useRef(0);
 
-  const setPinned = useCallback((next: boolean) => {
+  // Rung 11 (PRO-187, R10 / Q8): `cause` is observation-only — it labels which
+  // of the engine's own transitions fired for the diagnostics record below and
+  // never changes what setPinned does. Defaults to "unspecified" so call sites
+  // this rung did not touch (there are none left un-instrumented, but future
+  // callers passing only one arg) still emit a record rather than a silent one.
+  const setPinned = useCallback((next: boolean, cause: TranscriptPinTransitionCause = "unspecified") => {
     if (next) {
       // Re-pinning (any path: repin band, submit, button click) means the
       // reader is at the bottom seeing the new content, so the announcement
@@ -107,7 +117,8 @@ export function useTranscriptStickToBottom({
     }
     pinnedRef.current = next;
     setIsPinnedToBottom(next);
-  }, [clearNewContentSignal]);
+    recordTranscriptPinTransition({ sessionId: sessionKey ?? "unknown", pinned: next, cause });
+  }, [clearNewContentSignal, sessionKey]);
 
   const clearAllMarkers = useCallback(() => {
     ownershipMarkersRef.current.clear();
@@ -139,6 +150,11 @@ export function useTranscriptStickToBottom({
     userScrollIntentUntilRef.current = interactionNow() + TRANSCRIPT_USER_SCROLL_SETTLE_MS;
     // The reader is driving: end any in-flight FR-2 restore (rung 6).
     restoreResolverRef.current = null;
+    // Rung 11: the input-intent record itself, so a production log can tell
+    // "no intent recorded before this pin flip" (false unpin) apart from
+    // "intent recorded but pin state never moved" (swallowed user scroll) —
+    // see the failure-mode detections in section 5 of the ADR.
+    recordTranscriptUserScrollIntent({ sessionId: sessionKey ?? "unknown", direction });
     if (direction < 0) {
       // Upward intent cancels only a CANCELABLE above-change compensation (a
       // completed-turn split): the gesture wins, no per-frame re-anchor. A history
@@ -147,11 +163,11 @@ export function useTranscriptStickToBottom({
       if (compensationCancelableRef.current) {
         compensationAnchorRef.current = null;
       }
-      setPinned(false);
+      setPinned(false, "user_intent_unpin");
     }
     // Claim the frame at input time so it can't race a stream/reveal animation frame.
     onScrollSample({ programmatic: false, userInitiated: true });
-  }, [onScrollSample, setPinned]);
+  }, [onScrollSample, sessionKey, setPinned]);
 
   // Owns the consumed-inset machine, follow-target math, and scroll-to-bottom
   // callbacks. See use-transcript-auto-follow-bottom.ts.
@@ -237,12 +253,12 @@ export function useTranscriptStickToBottom({
       // content max, not the reader; clearing it would kill the frame writer's
       // re-resolution. A real takeover clears via notifyUserScrollIntent.
       dispatchInsetEvent({ type: "leave_band" });
-      setPinned(false);
+      setPinned(false, "leave_band");
     } else if (decision.pin === true) {
       if (decision.consumeInset === "full") {
         dispatchInsetEvent({ type: "consume_full" });
       }
-      setPinned(true);
+      setPinned(true, "repin_band");
     }
     // decision.pin === "hold": our own resize lag — leave pin and inset as they
     // are so a lagging follow is never misread as the user leaving.
@@ -342,7 +358,7 @@ export function useTranscriptStickToBottom({
       notifyProgrammaticScroll,
     );
     if (!restored) {
-      setPinned(true);
+      setPinned(true, "session_reset");
       scrollToBottom();
     }
     beginGlue();
@@ -356,7 +372,7 @@ export function useTranscriptStickToBottom({
   // never mounted the saved row gives up on the coarse estimate and bottom-pins
   // instead — the conservative FR-2 default, same as a vanished saved row.
   const notifyRestoreStranded = useCallback(() => {
-    setPinned(true);
+    setPinned(true, "restore_stranded");
     scrollToBottom();
   }, [scrollToBottom, setPinned]);
 

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
@@ -27,7 +27,7 @@ import {
   recordTranscriptPinTransition,
   recordTranscriptUserScrollIntent,
   type TranscriptPinTransitionCause,
-} from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations";
+} from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations-transcript";
 
 export type { TranscriptStickToBottom, UseTranscriptStickToBottomOptions };
 

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-submit-stamp-repin.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-submit-stamp-repin.ts
@@ -1,5 +1,5 @@
 import { useLayoutEffect, useRef } from "react";
-import type { TranscriptPinTransitionCause } from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations";
+import type { TranscriptPinTransitionCause } from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations-transcript";
 
 export interface UseTranscriptSubmitStampRepinOptions {
   /**

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-submit-stamp-repin.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-submit-stamp-repin.ts
@@ -1,4 +1,5 @@
 import { useLayoutEffect, useRef } from "react";
+import type { TranscriptPinTransitionCause } from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations";
 
 export interface UseTranscriptSubmitStampRepinOptions {
   /**
@@ -18,7 +19,7 @@ export interface UseTranscriptSubmitStampRepinOptions {
    * value instead of comparing across the switch.
    */
   sessionKey: string | undefined;
-  setPinned: (pinned: boolean) => void;
+  setPinned: (pinned: boolean, cause?: TranscriptPinTransitionCause) => void;
   scrollToBottom: () => void;
   beginGlue: () => void;
   /**
@@ -81,7 +82,7 @@ export function useTranscriptSubmitStampRepin({
       && (previous == null || lastPromptSubmittedAtMs > previous)
     ) {
       onSubmitRepin();
-      setPinned(true);
+      setPinned(true, "submit_repin");
       scrollToBottom();
       beginGlue();
     }

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtualizer-blank-fallback.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtualizer-blank-fallback.test.tsx
@@ -4,6 +4,10 @@ import { useRef } from "react";
 import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useTranscriptVirtualizerBlankFallback } from "./use-transcript-virtualizer-blank-fallback";
+import {
+  resetRendererDiagnosticsSinkForTest,
+  setRendererDiagnosticsSink,
+} from "#product/lib/infra/diagnostics/renderer-diagnostics-port";
 
 let frames: FrameRequestCallback[];
 
@@ -21,6 +25,7 @@ afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+  resetRendererDiagnosticsSinkForTest();
 });
 
 function flushFrame() {
@@ -176,6 +181,39 @@ describe("useTranscriptVirtualizerBlankFallback", () => {
     act(flushFrame);
     act(flushFrame);
     expect(onFallback).toHaveBeenCalledWith("blank_viewport");
+  });
+
+  // Rung 11 (PRO-187, Q8): the founder ruling requires the blank-fallback
+  // diagnostic to reach telemetry beyond dev-only console. isMainThreadMeasurementEnabled()
+  // defaults false here (the same as a production build with the debug flag
+  // off), so this proves the record is no longer gated behind it.
+  it("emits the blank-viewport diagnostic even when main-thread measurement is disabled", () => {
+    const emit = vi.fn();
+    setRendererDiagnosticsSink({ emit });
+    const onFallback = vi.fn();
+    const rendered = render(
+      <Harness
+        firstVirtualItem={{ index: 0, start: 0, end: 100 }}
+        lastVirtualItem={{ index: 1, start: 100, end: 200 }}
+        onFallback={onFallback}
+      />,
+    );
+    const viewport = rendered.getByTestId("viewport") as HTMLDivElement;
+    setViewportMetrics(viewport, 2_000);
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function () {
+      const top = this === viewport ? 0 : 1_000;
+      const bottom = this === viewport ? 400 : 1_100;
+      return { top, bottom } as DOMRect;
+    });
+
+    act(flushFrame);
+    act(flushFrame);
+    act(flushFrame);
+
+    expect(onFallback).toHaveBeenCalledWith("blank_viewport");
+    expect(emit.mock.calls.map(([input]) => input.name)).toContain(
+      "renderer.transcript.virtualizer_blank",
+    );
   });
 
   it("does not fall back when a suspicious blank recovers before DOM confirmation", () => {

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtualizer-blank-fallback.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtualizer-blank-fallback.ts
@@ -3,7 +3,7 @@ import {
   hashMeasurementScope,
   isMainThreadMeasurementEnabled,
 } from "#product/lib/infra/measurement/measurement-port";
-import { recordTranscriptVirtualizerBlank } from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations";
+import { recordTranscriptVirtualizerBlank } from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations-transcript";
 
 // Founder Ruling 3(c), rung 10 (PRO-187): this used to be an INDEPENDENT fixed
 // 3s timer, started the instant a prepend fired regardless of whether the

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtualizer-blank-fallback.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtualizer-blank-fallback.ts
@@ -217,16 +217,24 @@ export function useTranscriptVirtualizerBlankFallback({
       }
       lastBlankReportSignatureRef.current = signature;
 
+      // Rung 11 (PRO-187, Q8): a production occurrence is a bug per the
+      // founder ruling ("keep it as a safety net, but emit a diagnostic event
+      // on trigger, beyond dev-only console, and treat any production
+      // occurrence as a bug"), so the diagnostic record fires unconditionally
+      // — the DEV gate stays only in front of the verbose console dump below,
+      // which is a developer aid, not the telemetry signal itself. The record
+      // is observation-only: onFallback still fires the same full-render swap
+      // whether or not any sink is installed.
+      recordTranscriptVirtualizerBlank({
+        sessionId: activeSessionId,
+        workspaceId: selectedWorkspaceId,
+        rowCount,
+        renderableRowCount,
+        virtualItemCount,
+        firstVirtualItemIndex,
+        lastVirtualItemIndex,
+      });
       if (import.meta.env.DEV && isMainThreadMeasurementEnabled()) {
-        recordTranscriptVirtualizerBlank({
-          sessionId: activeSessionId,
-          workspaceId: selectedWorkspaceId,
-          rowCount,
-          renderableRowCount,
-          virtualItemCount,
-          firstVirtualItemIndex,
-          lastVirtualItemIndex,
-        });
         console.error("[transcript-virtualizer] blank viewport detected; falling back to full render", {
           activeSessionHash: hashMeasurementScope(activeSessionId),
           selectedWorkspaceHash: selectedWorkspaceId ? hashMeasurementScope(selectedWorkspaceId) : null,

--- a/apps/packages/product-client/src/lib/infra/diagnostics/renderer-diagnostic-migrations-transcript.ts
+++ b/apps/packages/product-client/src/lib/infra/diagnostics/renderer-diagnostic-migrations-transcript.ts
@@ -1,0 +1,104 @@
+import {
+  diagnosticField,
+  recordRendererDiagnostic,
+} from "#product/lib/infra/diagnostics/renderer-diagnostics-port";
+
+// Transcript-only diagnostic records, split out of renderer-diagnostic-migrations.ts
+// (PRO-187, login runtime-budget fix). These are only imported by the
+// chat/transcript UI hooks, which mount inside the AuthenticatedProductClient
+// lazy chunk, never from the always-mounted login path. Keeping them in a
+// separate module lets the bundler split them out of the /login bundle
+// instead of dragging them along with recordTurnEnded and friends, which
+// use-turn-end-diagnostics.ts pulls in from renderer-diagnostic-migrations.ts
+// unconditionally via ProductLifecycleRoot.
+
+export function recordTranscriptVirtualizerBlank(input: {
+  sessionId: string;
+  workspaceId: string | null;
+  rowCount: number;
+  renderableRowCount: number;
+  virtualItemCount: number;
+  firstVirtualItemIndex: number | null;
+  lastVirtualItemIndex: number | null;
+}): void {
+  recordRendererDiagnostic({
+    name: "renderer.transcript.virtualizer_blank",
+    severity: "error",
+    kind: "message",
+    privacy: "operational",
+    correlation: {
+      sessionId: input.sessionId,
+      ...(input.workspaceId === null ? {} : { workspaceId: input.workspaceId }),
+    },
+    fields: {
+      row_count: diagnosticField(input.rowCount, "operational"),
+      renderable_row_count: diagnosticField(input.renderableRowCount, "operational"),
+      virtual_item_count: diagnosticField(input.virtualItemCount, "operational"),
+      first_virtual_item_index: diagnosticField(
+        input.firstVirtualItemIndex ?? -1,
+        "operational",
+      ),
+      last_virtual_item_index: diagnosticField(
+        input.lastVirtualItemIndex ?? -1,
+        "operational",
+      ),
+    },
+    errorClassification: "virtualizer_blank",
+  });
+}
+
+// Rung 11 (PRO-187, requirement R10 / design question Q8): Cell 10's jank note
+// was that pin-state transitions and classification outcomes were sampled for
+// perf only, never persisted as debuggable events, so a production scroll bug
+// could only be reproduced by hand. These two records are the fix: together
+// they let a scripted bug reproduce from logs alone (rung 11's gate) —
+// `renderer.transcript.user_scroll_intent` is the input-intent signal, and
+// `renderer.transcript.pin_transition` is the resulting (or missing) pin-state
+// change, each carrying the cause the engine already attributes internally.
+// Observation-only: recording a transition never influences it, and both
+// records reuse the SAME choke points (`setPinned`, `notifyUserScrollIntent`)
+// the engine already uses for its own bookkeeping, so there is no new scroll
+// writer and negligible overhead beyond the existing call.
+export type TranscriptPinTransitionCause =
+  | "user_intent_unpin"
+  | "leave_band"
+  | "repin_band"
+  | "submit_repin"
+  | "button_click"
+  | "session_reset"
+  | "restore_stranded"
+  | "unspecified";
+
+export function recordTranscriptPinTransition(input: {
+  sessionId: string;
+  pinned: boolean;
+  cause: TranscriptPinTransitionCause;
+}): void {
+  recordRendererDiagnostic({
+    name: "renderer.transcript.pin_transition",
+    severity: "debug",
+    kind: "message",
+    privacy: "operational",
+    correlation: { sessionId: input.sessionId },
+    fields: {
+      pinned: diagnosticField(input.pinned, "operational"),
+      cause: diagnosticField(input.cause, "operational"),
+    },
+  });
+}
+
+export function recordTranscriptUserScrollIntent(input: {
+  sessionId: string;
+  direction: -1 | 1;
+}): void {
+  recordRendererDiagnostic({
+    name: "renderer.transcript.user_scroll_intent",
+    severity: "debug",
+    kind: "message",
+    privacy: "operational",
+    correlation: { sessionId: input.sessionId },
+    fields: {
+      direction: diagnosticField(input.direction, "operational"),
+    },
+  });
+}

--- a/apps/packages/product-client/src/lib/infra/diagnostics/renderer-diagnostic-migrations.test.ts
+++ b/apps/packages/product-client/src/lib/infra/diagnostics/renderer-diagnostic-migrations.test.ts
@@ -5,6 +5,8 @@ import {
   recordHotWorkspaceReconcileFailure,
   recordSessionHistoryRehydrateFailure,
   recordSessionMetadataRefreshFailure,
+  recordTranscriptPinTransition,
+  recordTranscriptUserScrollIntent,
   recordTranscriptVirtualizerBlank,
 } from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations";
 import {
@@ -83,5 +85,38 @@ describe("fixed ProductClient renderer diagnostic migrations", () => {
       { sessionId: "session-1", operationId: "" },
       { sessionId: "session-1", operationId: "" },
     ]);
+  });
+
+  // Rung 11 (PRO-187, R10 / Q8): the two records that let a scripted scroll
+  // bug reproduce from logs alone — see the engine call sites in
+  // use-transcript-stick-to-bottom.ts.
+  it("records a pin transition with its cause and a user-scroll-intent direction", () => {
+    const emit = vi.fn();
+    setRendererDiagnosticsSink({ emit });
+
+    recordTranscriptPinTransition({
+      sessionId: "session-1",
+      pinned: false,
+      cause: "leave_band",
+    });
+    recordTranscriptUserScrollIntent({ sessionId: "session-1", direction: -1 });
+
+    expect(emit.mock.calls.map(([input]) => input.name)).toEqual([
+      "renderer.transcript.pin_transition",
+      "renderer.transcript.user_scroll_intent",
+    ]);
+    expect(emit.mock.calls[0][0]).toEqual(expect.objectContaining({
+      correlation: { sessionId: "session-1" },
+      fields: expect.objectContaining({
+        pinned: { privacy: "operational", value: false },
+        cause: { privacy: "operational", value: "leave_band" },
+      }),
+    }));
+    expect(emit.mock.calls[1][0]).toEqual(expect.objectContaining({
+      correlation: { sessionId: "session-1" },
+      fields: expect.objectContaining({
+        direction: { privacy: "operational", value: -1 },
+      }),
+    }));
   });
 });

--- a/apps/packages/product-client/src/lib/infra/diagnostics/renderer-diagnostic-migrations.test.ts
+++ b/apps/packages/product-client/src/lib/infra/diagnostics/renderer-diagnostic-migrations.test.ts
@@ -5,10 +5,12 @@ import {
   recordHotWorkspaceReconcileFailure,
   recordSessionHistoryRehydrateFailure,
   recordSessionMetadataRefreshFailure,
+} from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations";
+import {
   recordTranscriptPinTransition,
   recordTranscriptUserScrollIntent,
   recordTranscriptVirtualizerBlank,
-} from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations";
+} from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations-transcript";
 import {
   resetRendererDiagnosticsSinkForTest,
   setRendererDiagnosticsSink,

--- a/apps/packages/product-client/src/lib/infra/diagnostics/renderer-diagnostic-migrations.ts
+++ b/apps/packages/product-client/src/lib/infra/diagnostics/renderer-diagnostic-migrations.ts
@@ -148,96 +148,14 @@ export function recordSessionErrorBanner(input: {
   });
 }
 
-export function recordTranscriptVirtualizerBlank(input: {
-  sessionId: string;
-  workspaceId: string | null;
-  rowCount: number;
-  renderableRowCount: number;
-  virtualItemCount: number;
-  firstVirtualItemIndex: number | null;
-  lastVirtualItemIndex: number | null;
-}): void {
-  recordRendererDiagnostic({
-    name: "renderer.transcript.virtualizer_blank",
-    severity: "error",
-    kind: "message",
-    privacy: "operational",
-    correlation: {
-      sessionId: input.sessionId,
-      ...(input.workspaceId === null ? {} : { workspaceId: input.workspaceId }),
-    },
-    fields: {
-      row_count: diagnosticField(input.rowCount, "operational"),
-      renderable_row_count: diagnosticField(input.renderableRowCount, "operational"),
-      virtual_item_count: diagnosticField(input.virtualItemCount, "operational"),
-      first_virtual_item_index: diagnosticField(
-        input.firstVirtualItemIndex ?? -1,
-        "operational",
-      ),
-      last_virtual_item_index: diagnosticField(
-        input.lastVirtualItemIndex ?? -1,
-        "operational",
-      ),
-    },
-    errorClassification: "virtualizer_blank",
-  });
-}
-
-// Rung 11 (PRO-187, requirement R10 / design question Q8): Cell 10's jank note
-// was that pin-state transitions and classification outcomes were sampled for
-// perf only, never persisted as debuggable events, so a production scroll bug
-// could only be reproduced by hand. These two records are the fix: together
-// they let a scripted bug reproduce from logs alone (rung 11's gate) —
-// `renderer.transcript.user_scroll_intent` is the input-intent signal, and
-// `renderer.transcript.pin_transition` is the resulting (or missing) pin-state
-// change, each carrying the cause the engine already attributes internally.
-// Observation-only: recording a transition never influences it, and both
-// records reuse the SAME choke points (`setPinned`, `notifyUserScrollIntent`)
-// the engine already uses for its own bookkeeping, so there is no new scroll
-// writer and negligible overhead beyond the existing call.
-export type TranscriptPinTransitionCause =
-  | "user_intent_unpin"
-  | "leave_band"
-  | "repin_band"
-  | "submit_repin"
-  | "button_click"
-  | "session_reset"
-  | "restore_stranded"
-  | "unspecified";
-
-export function recordTranscriptPinTransition(input: {
-  sessionId: string;
-  pinned: boolean;
-  cause: TranscriptPinTransitionCause;
-}): void {
-  recordRendererDiagnostic({
-    name: "renderer.transcript.pin_transition",
-    severity: "debug",
-    kind: "message",
-    privacy: "operational",
-    correlation: { sessionId: input.sessionId },
-    fields: {
-      pinned: diagnosticField(input.pinned, "operational"),
-      cause: diagnosticField(input.cause, "operational"),
-    },
-  });
-}
-
-export function recordTranscriptUserScrollIntent(input: {
-  sessionId: string;
-  direction: -1 | 1;
-}): void {
-  recordRendererDiagnostic({
-    name: "renderer.transcript.user_scroll_intent",
-    severity: "debug",
-    kind: "message",
-    privacy: "operational",
-    correlation: { sessionId: input.sessionId },
-    fields: {
-      direction: diagnosticField(input.direction, "operational"),
-    },
-  });
-}
+// Transcript-only diagnostic records (blank-fallback, pin-transition,
+// user-scroll-intent) live in ./renderer-diagnostic-migrations-transcript
+// instead of here. That file is only reachable from the chat/transcript UI
+// hooks (mounted after auth, inside the AuthenticatedProductClient lazy
+// chunk); this file's exports are also reached from `use-turn-end-diagnostics`,
+// which `ProductLifecycleRoot` mounts unconditionally, so anything added here
+// travels into the /login bundle. See renderer-diagnostic-migrations-transcript.ts
+// for the split rationale (PRO-187, login runtime-budget fix).
 
 export function recordHotWorkspaceReconcileFailure(input: {
   operationId: string | null;

--- a/apps/packages/product-client/src/lib/infra/diagnostics/renderer-diagnostic-migrations.ts
+++ b/apps/packages/product-client/src/lib/infra/diagnostics/renderer-diagnostic-migrations.ts
@@ -183,6 +183,62 @@ export function recordTranscriptVirtualizerBlank(input: {
   });
 }
 
+// Rung 11 (PRO-187, requirement R10 / design question Q8): Cell 10's jank note
+// was that pin-state transitions and classification outcomes were sampled for
+// perf only, never persisted as debuggable events, so a production scroll bug
+// could only be reproduced by hand. These two records are the fix: together
+// they let a scripted bug reproduce from logs alone (rung 11's gate) —
+// `renderer.transcript.user_scroll_intent` is the input-intent signal, and
+// `renderer.transcript.pin_transition` is the resulting (or missing) pin-state
+// change, each carrying the cause the engine already attributes internally.
+// Observation-only: recording a transition never influences it, and both
+// records reuse the SAME choke points (`setPinned`, `notifyUserScrollIntent`)
+// the engine already uses for its own bookkeeping, so there is no new scroll
+// writer and negligible overhead beyond the existing call.
+export type TranscriptPinTransitionCause =
+  | "user_intent_unpin"
+  | "leave_band"
+  | "repin_band"
+  | "submit_repin"
+  | "button_click"
+  | "session_reset"
+  | "restore_stranded"
+  | "unspecified";
+
+export function recordTranscriptPinTransition(input: {
+  sessionId: string;
+  pinned: boolean;
+  cause: TranscriptPinTransitionCause;
+}): void {
+  recordRendererDiagnostic({
+    name: "renderer.transcript.pin_transition",
+    severity: "debug",
+    kind: "message",
+    privacy: "operational",
+    correlation: { sessionId: input.sessionId },
+    fields: {
+      pinned: diagnosticField(input.pinned, "operational"),
+      cause: diagnosticField(input.cause, "operational"),
+    },
+  });
+}
+
+export function recordTranscriptUserScrollIntent(input: {
+  sessionId: string;
+  direction: -1 | 1;
+}): void {
+  recordRendererDiagnostic({
+    name: "renderer.transcript.user_scroll_intent",
+    severity: "debug",
+    kind: "message",
+    privacy: "operational",
+    correlation: { sessionId: input.sessionId },
+    fields: {
+      direction: diagnosticField(input.direction, "operational"),
+    },
+  });
+}
+
 export function recordHotWorkspaceReconcileFailure(input: {
   operationId: string | null;
   workspaceId: string;


### PR DESCRIPTION
Reopens rung 11 of the Chat Scroll ladder (PRO-187). The prior PR #1984 was irreversibly auto-marked MERGED by GitHub when a tooling agent briefly pushed this branch's commits onto the base ref (immediately force-restored; verified nothing reached main: r11 head is not an ancestor of origin/main). Same branch, same content, same head as #1984's final state.

Scope (unchanged from #1984): observation-only scroll diagnostics through the existing renderer-diagnostics-port pipe.
- recordTranscriptPinTransition with an 8-variant cause taxonomy, recordTranscriptUserScrollIntent (src/lib/infra/diagnostics/renderer-diagnostic-migrations.ts)
- setPinned/notifyUserScrollIntent instrumented in use-transcript-stick-to-bottom.ts with an optional cause param threaded through button-click, submit-repin, and restore call sites
- blank-viewport fallback diagnostic un-gated from import.meta.env.DEV so it reaches production telemetry (Q8)

History: #1984 was CI-green (18/18) and adversarially reviewed CLEAN at head 11cfa279a (review: #1984 issuecomment-5307172323, manual verification: issuecomment-5306898383); current head ee976c831 is that content rebased onto the r10 Q13 assertion fix (7e627c22f), which asserts the unexplained scrollTop drop (drop minus scrollHeight shrink) from frame-aligned traces.

Known lane flake under investigation: [webkit] prepend anchoring (Expected > 150 / Received 0) recurs bimodally across the stack on slow runners; evidence archived, tracked separately.

Not to be merged without Pablo's review (standing rule; merges bottom-up on #1722).