### PR TITLE
fix(product): restore the composer caret when WebKit drops the DOM selection (PRO-294)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
@@ -24,6 +24,7 @@ import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext
 import { ComposerCaretPlugin } from "#product/components/workspace/chat/input/ComposerCaretPlugin";
 import { ComposerFencedCodePlugin } from "#product/components/workspace/chat/input/ComposerFencedCodePlugin";
 import { ComposerFormatGuardPlugin } from "#product/components/workspace/chat/input/ComposerFormatGuardPlugin";
+import { ComposerSelectionRecoveryPlugin } from "#product/components/workspace/chat/input/ComposerSelectionRecoveryPlugin";
 import {
   COMPOSER_INPUT_TRANSFORMERS,
   COMPOSER_NODES,
@@ -178,6 +179,7 @@ export function ComposerRichTextEditor({
       <ComposerMarkdownShortcutPlugin transformers={INPUT_TRANSFORMERS} />
       <ComposerFencedCodePlugin />
       <ComposerFormatGuardPlugin />
+      <ComposerSelectionRecoveryPlugin />
       <ComposerBehaviorPlugin
         canSubmit={canSubmit}
         onSubmit={onSubmit}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerSelectionRecoveryPlugin.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerSelectionRecoveryPlugin.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { $getRoot, type LexicalEditor } from "lexical";
+import { ComposerRichTextEditor } from "#product/components/workspace/chat/input/ComposerRichTextEditor";
+
+let originalRangeRectDescriptor: PropertyDescriptor | undefined;
+
+afterEach(() => {
+  cleanup();
+  if (originalRangeRectDescriptor === undefined) {
+    Reflect.deleteProperty(Range.prototype, "getBoundingClientRect");
+  } else {
+    Object.defineProperty(
+      Range.prototype,
+      "getBoundingClientRect",
+      originalRangeRectDescriptor,
+    );
+  }
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  originalRangeRectDescriptor = Object.getOwnPropertyDescriptor(
+    Range.prototype,
+    "getBoundingClientRect",
+  );
+  // jsdom Ranges have no layout; Lexical's post-commit scroll-into-view reads
+  // the caret range's rect.
+  Object.defineProperty(Range.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({
+      bottom: 0, height: 0, left: 0, right: 0, toJSON: () => ({}),
+      top: 0, width: 0, x: 0, y: 0,
+    }),
+  });
+  vi.stubGlobal("DragEvent", class DragEvent extends Event {});
+  vi.stubGlobal("ClipboardEvent", class ClipboardEvent extends Event {});
+  vi.spyOn(window, "scrollBy").mockImplementation(() => {});
+});
+
+// WebKit clears the document selection while the composer keeps DOM focus
+// (native attach-file dialog, cancelled external drags) and then emits no
+// beforeinput for any keystroke, so typing dies under a live-looking caret
+// (PRO-294). The recovery plugin must re-seat the editor state's selection in
+// the DOM on the first input-producing keystroke.
+describe("ComposerSelectionRecoveryPlugin", () => {
+  it("restores the DOM selection on a printable keystroke after it was cleared", async () => {
+    const harness = renderEditor("draft");
+    await harness.ready();
+
+    act(() => {
+      harness.root.focus();
+      harness.editor.update(() => {
+        $getRoot().getAllTextNodes()[0]!.select(3, 3);
+      }, { discrete: true });
+    });
+    act(() => {
+      document.getSelection()!.removeAllRanges();
+    });
+    expect(document.getSelection()!.rangeCount).toBe(0);
+    expect(document.activeElement).toBe(harness.root);
+
+    act(() => {
+      fireEvent.keyDown(harness.root, { key: "x" });
+    });
+
+    const selection = document.getSelection()!;
+    expect(selection.rangeCount).toBe(1);
+    expect(
+      harness.root.contains(selection.getRangeAt(0).startContainer),
+    ).toBe(true);
+  });
+
+  it("leaves modifier chords alone so a transcript selection can still be copied", async () => {
+    const harness = renderEditor("draft");
+    await harness.ready();
+
+    act(() => {
+      harness.root.focus();
+      harness.editor.update(() => {
+        $getRoot().getAllTextNodes()[0]!.select(3, 3);
+      }, { discrete: true });
+    });
+    act(() => {
+      document.getSelection()!.removeAllRanges();
+    });
+
+    act(() => {
+      fireEvent.keyDown(harness.root, { key: "c", metaKey: true });
+    });
+
+    expect(document.getSelection()!.rangeCount).toBe(0);
+  });
+
+  it("does not touch a selection that already sits inside the editor", async () => {
+    const harness = renderEditor("draft");
+    await harness.ready();
+
+    act(() => {
+      harness.root.focus();
+      harness.editor.update(() => {
+        $getRoot().getAllTextNodes()[0]!.select(2, 2);
+      }, { discrete: true });
+    });
+    const before = describeSelection();
+
+    act(() => {
+      fireEvent.keyDown(harness.root, { key: "x" });
+    });
+
+    expect(describeSelection()).toEqual(before);
+  });
+});
+
+function describeSelection() {
+  const selection = document.getSelection()!;
+  if (selection.rangeCount === 0) return null;
+  const range = selection.getRangeAt(0);
+  return { node: range.startContainer, offset: range.startOffset };
+}
+
+function renderEditor(value: string) {
+  let editor: LexicalEditor | null = null;
+  const rendered = render(
+    <ComposerRichTextEditor
+      value={value}
+      onChange={vi.fn()}
+      canSubmit
+      onSubmit={vi.fn()}
+      placeholder="Message"
+      disabled={false}
+      editorRef={(next) => {
+        editor = next;
+      }}
+    />,
+  );
+  const root = rendered.container.querySelector<HTMLElement>(
+    "[data-chat-composer-editor]",
+  )!;
+  return {
+    get editor() {
+      return editor!;
+    },
+    root,
+    ready: () => waitFor(() => expect(editor).toBeTruthy()),
+  };
+}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerSelectionRecoveryPlugin.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerSelectionRecoveryPlugin.tsx
@@ -1,0 +1,63 @@
+import { useEffect } from "react";
+import { $getRoot, $getSelection, $isRangeSelection } from "lexical";
+import { createDOMRange } from "@lexical/selection";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+
+/**
+ * WebKit can clear the document selection while the composer keeps DOM focus —
+ * closing the native attach-file dialog and cancelled external drags both do
+ * it. A focused contenteditable with no DOM range emits no beforeinput at all
+ * in WebKit, so every keystroke dies while the caret still looks live
+ * (PRO-294). Chromium reseats a selection on its own; WebKit never does, and
+ * because focus never left, no blur/focus cycle runs that would repair it.
+ * Rebuild the DOM selection from the editor state's last selection on the
+ * first keystroke that should produce input. Modifier chords stay untouched
+ * so a ⌘C over a transcript selection made while the composer holds focus
+ * still copies that selection.
+ */
+export function ComposerSelectionRecoveryPlugin() {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey) return;
+      if (event.key.length !== 1 && event.key !== "Backspace" && event.key !== "Delete") return;
+      if (editor.isComposing() || !editor.isEditable()) return;
+      const root = editor.getRootElement();
+      if (root === null || root.ownerDocument.activeElement !== root) return;
+      const domSelection = root.ownerDocument.defaultView?.getSelection() ?? null;
+      if (domSelection === null) return;
+      if (
+        domSelection.rangeCount > 0
+        && root.contains(domSelection.getRangeAt(0).startContainer)
+      ) return;
+      const range = editor.getEditorState().read(() => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) return null;
+        return createDOMRange(
+          editor,
+          selection.anchor.getNode(),
+          selection.anchor.offset,
+          selection.focus.getNode(),
+          selection.focus.offset,
+        );
+      });
+      if (range !== null) {
+        // Applying the range fires selectionchange, which syncs Lexical the
+        // same way a user click would; the keystroke's own beforeinput then
+        // lands on the restored caret.
+        domSelection.removeAllRanges();
+        domSelection.addRange(range);
+        return;
+      }
+      editor.update(() => { $getRoot().selectEnd(); });
+    };
+
+    return editor.registerRootListener((rootElement, previousRootElement) => {
+      previousRootElement?.removeEventListener("keydown", handleKeyDown);
+      rootElement?.addEventListener("keydown", handleKeyDown);
+    });
+  }, [editor]);
+
+  return null;
+}


### PR DESCRIPTION
## What

Attaching an image in the composer could leave typing completely dead while the caret still looked live. Root cause: WebKit clears the document selection while the composer keeps DOM focus — closing the native attach-file dialog and cancelled external drags both do it. A focused contenteditable with **no DOM range emits no beforeinput at all** in WebKit, so every keystroke is silently dropped. Meanwhile the composer's replacement caret keeps painting from Lexical's (stale) state selection, so the editor looks focused and ready. Because focus never left the editor, no blur/focus cycle ever runs that would reseat a selection — the state is sticky. Chromium reseats a selection on its own, which is why this only bites the desktop app (WKWebView).

Fix: a `ComposerSelectionRecoveryPlugin` mounted in `ComposerRichTextEditor`. On the first input-producing keystroke (printable keys, Backspace, Delete — never modifier chords, so ⌘C over a transcript selection still copies it), if the editor root holds focus but the document selection has no range inside it, rebuild the DOM range from the editor state's last selection (`createDOMRange`) and apply it. The keystroke's own beforeinput then lands on the restored caret — the first key already types.

## Why this shape

- Verified in real engines against the production composer wiring (surface paste-capture, attachment controller, preview list, focus-zone pointer capture): WebKit reproduces the exact reported state (focused editor, `contenteditable=true`, `rangeCount: 0`, phantom caret painting, keystrokes dropped) and the plugin heals it — typed text lands at the exact stale caret position. Chromium behavior is byte-identical before/after (its native recovery wins before the plugin ever sees a cleared selection; instrumented restore count is 0 there).
- Recovery at the editor level covers every native trigger of the selection clear rather than patching one attach path.

## Ticket

https://linear.app/proliferate-team/issue/PRO-294/sometimes-attaching-an-image-makes-typing-disabled

## How to test manually

1. In the desktop app, focus the composer in a session (caret blinking).
2. Attach an image via the **+** control (native file dialog) — and/or drag an image (e.g. the macOS screenshot floating thumbnail) over the composer and drop it.
3. Type immediately without clicking anywhere. Before this fix, when WebKit dropped the selection, nothing typed while the caret stayed visible; now the first keystroke lands at the caret.
4. Sanity: select transcript text while the composer has focus and press ⌘C — the transcript selection still copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)