### PR TITLE
fix(anyharness): dev diagnostics producer re-learns the collector from the env file

### DIFF
--- a/anyharness/crates/proliferate-diagnostics-client/src/bridge/activation.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/bridge/activation.rs
@@ -93,12 +93,16 @@ pub struct DesktopDiagnosticsDegradedBootstrap {
 /// records. Given the collector's loopback endpoint and capability in the
 /// environment, this bootstrap talks to the same collector directly.
 ///
-/// It deliberately carries no bridge: this producer never learns of a
-/// collector generation change, so a collector restart ends its delivery until
-/// the runtime is restarted with fresh values. Debug builds only.
+/// It carries no bridge; instead, when the host also published the snippet's
+/// own path ([`DEV_ENV_PATH_ENV`]), the producer keeps re-reading that file
+/// (`producer::dev_refresh`) and re-attaches to the new collector generation
+/// after a restart — a file-backed twin of the fd bridge's `GenerationReady`
+/// path. Without the path (an old app build's 3-line file) a collector restart
+/// still ends delivery until the runtime restarts. Debug builds only.
 #[cfg(debug_assertions)]
 pub struct DevEnvDiagnosticsBootstrap {
     pub(crate) initial_state: InitialCollectorState,
+    pub(crate) env_path: Option<std::path::PathBuf>,
 }
 
 /// Collector ingest endpoint, e.g. `http://127.0.0.1:53421/`.
@@ -119,13 +123,21 @@ pub const DEV_COLLECTOR_BOOT_ID_ENV: &str = "PROLIFERATE_DIAGNOSTICS_BRIDGE_COLL
 #[cfg(debug_assertions)]
 pub const DEV_ENV_PATH_ENV: &str = "PROLIFERATE_DIAGNOSTICS_DEV_ENV_PATH";
 
-/// Fixed: with no bridge there is nothing to advance the generation.
+/// Initial generation for the dev path. With no bridge nothing pushes newer
+/// generations; the file-backed refresh loop advances its own locally owned
+/// counter past this on every re-attach.
 #[cfg(debug_assertions)]
-const DEV_COLLECTOR_GENERATION: u64 = 1;
+pub(crate) const DEV_COLLECTOR_GENERATION: u64 = 1;
 /// Matches the transport's own capability bound; longer values are rejected
 /// there anyway.
 #[cfg(debug_assertions)]
 const DEV_CAPABILITY_MAX_BYTES: usize = 256;
+/// Generous filesystem-path bound for the snippet's self-path line.
+#[cfg(debug_assertions)]
+const DEV_ENV_PATH_MAX_BYTES: usize = 4096;
+/// The whole snippet is four short lines; anything larger is not ours.
+#[cfg(all(unix, debug_assertions))]
+const DEV_ENV_FILE_MAX_BYTES: usize = 8192;
 
 pub(crate) struct FallbackDirectoryHandle {
     #[cfg(unix)]
@@ -210,6 +222,61 @@ fn dev_env_activation() -> DesktopDiagnosticsActivation {
             collector_boot_id,
             client: std::sync::Arc::new(client),
         }),
+        // Optional: absent with an old app build's 3-line snippet, which
+        // freezes the producer on the boot-time generation as before.
+        env_path: bounded_env(DEV_ENV_PATH_ENV, DEV_ENV_PATH_MAX_BYTES)
+            .map(std::path::PathBuf::from),
+    })
+}
+
+/// The three collector values parsed back out of the published snippet.
+#[cfg(all(unix, debug_assertions))]
+pub(crate) struct ParsedDevEnv {
+    pub(crate) endpoint: String,
+    pub(crate) capability: String,
+    pub(crate) collector_boot_id: String,
+}
+
+/// Parses the host-published dev env snippet with the same bounds as
+/// [`dev_env_activation`]. Rejects missing keys and out-of-bound values.
+/// The file is 0600 and the capability is a secret: callers must never log
+/// values, only the endpoint.
+#[cfg(all(unix, debug_assertions))]
+pub(crate) fn parse_dev_env_file(path: &std::path::Path) -> Option<ParsedDevEnv> {
+    use proliferate_diagnostics_protocol::v1::limits::MAX_ID_BYTES;
+
+    let content = std::fs::read_to_string(path).ok()?;
+    if content.len() > DEV_ENV_FILE_MAX_BYTES {
+        return None;
+    }
+    let (mut endpoint, mut capability, mut collector_boot_id) = (None, None, None);
+    for line in content.lines() {
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let slot = match key {
+            DEV_ENDPOINT_ENV => &mut endpoint,
+            DEV_CAPABILITY_ENV => &mut capability,
+            DEV_COLLECTOR_BOOT_ID_ENV => &mut collector_boot_id,
+            _ => continue,
+        };
+        *slot = Some(value.trim().to_owned());
+    }
+    let bounded = |value: &Option<String>, limit: usize| {
+        value
+            .as_deref()
+            .is_some_and(|value| !value.is_empty() && value.len() <= limit)
+    };
+    if !bounded(&endpoint, MAX_ID_BYTES)
+        || !bounded(&capability, DEV_CAPABILITY_MAX_BYTES)
+        || !bounded(&collector_boot_id, MAX_ID_BYTES)
+    {
+        return None;
+    }
+    Some(ParsedDevEnv {
+        endpoint: endpoint?,
+        capability: capability?,
+        collector_boot_id: collector_boot_id?,
     })
 }
 

--- a/anyharness/crates/proliferate-diagnostics-client/src/bridge/activation.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/bridge/activation.rs
@@ -102,6 +102,8 @@ pub struct DesktopDiagnosticsDegradedBootstrap {
 #[cfg(debug_assertions)]
 pub struct DevEnvDiagnosticsBootstrap {
     pub(crate) initial_state: InitialCollectorState,
+    // Only the unix producer runs the refresh task, like the fd bridge.
+    #[cfg_attr(not(unix), allow(dead_code))]
     pub(crate) env_path: Option<std::path::PathBuf>,
 }
 

--- a/anyharness/crates/proliferate-diagnostics-client/src/bridge/activation.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/bridge/activation.rs
@@ -241,7 +241,7 @@ pub(crate) struct ParsedDevEnv {
 
 /// Parses the host-published dev env snippet with the same bounds as
 /// [`dev_env_activation`]. Rejects missing keys and out-of-bound values —
-/// including a torn read of the host's rewrite, which the caller retries.
+/// including content from a non-host writer, which the caller retries.
 /// The file is 0600 and the capability is a secret: callers must never log
 /// values, only the endpoint.
 #[cfg(all(unix, debug_assertions))]

--- a/anyharness/crates/proliferate-diagnostics-client/src/bridge/activation.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/bridge/activation.rs
@@ -240,14 +240,14 @@ pub(crate) struct ParsedDevEnv {
 }
 
 /// Parses the host-published dev env snippet with the same bounds as
-/// [`dev_env_activation`]. Rejects missing keys and out-of-bound values.
+/// [`dev_env_activation`]. Rejects missing keys and out-of-bound values —
+/// including a torn read of the host's rewrite, which the caller retries.
 /// The file is 0600 and the capability is a secret: callers must never log
 /// values, only the endpoint.
 #[cfg(all(unix, debug_assertions))]
-pub(crate) fn parse_dev_env_file(path: &std::path::Path) -> Option<ParsedDevEnv> {
+pub(crate) fn parse_dev_env_snippet(content: &str) -> Option<ParsedDevEnv> {
     use proliferate_diagnostics_protocol::v1::limits::MAX_ID_BYTES;
 
-    let content = std::fs::read_to_string(path).ok()?;
     if content.len() > DEV_ENV_FILE_MAX_BYTES {
         return None;
     }

--- a/anyharness/crates/proliferate-diagnostics-client/src/producer/bridge_runtime.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/producer/bridge_runtime.rs
@@ -332,6 +332,28 @@ fn handle_parent_frame(
     Ok(())
 }
 
+impl ProducerInner {
+    /// Permanent bridge loss: no newer generation can arrive, so the sentinel
+    /// latches unavailable. Queued records retain routing until worker drain.
+    fn mark_bridge_lost(&self) {
+        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+        if matches!(
+            &state.collector,
+            super::CollectorAvailability::Unavailable { generation } if *generation == MAX_SAFE_INTEGER
+        ) {
+            return;
+        }
+        state.collector = super::CollectorAvailability::Unavailable {
+            generation: MAX_SAFE_INTEGER,
+        };
+        if !state.in_flight.is_empty() {
+            state.delivery_fence_eligible = false;
+        }
+        drop(state);
+        self.notify.notify_one();
+    }
+}
+
 fn generation_is_newer(inner: &ProducerInner, generation: u64) -> bool {
     let state = inner
         .state

--- a/anyharness/crates/proliferate-diagnostics-client/src/producer/dev_refresh.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/producer/dev_refresh.rs
@@ -62,11 +62,13 @@ async fn dev_generation_refresh_with_interval(
         if mtime == seen_mtime {
             continue;
         }
-        // seen_mtime latches only after a coherent read: the host's rewrite is
-        // not atomic, so a torn/garbage read at this mtime must be retried on
-        // the next tick rather than locking the rewrite out until a later
-        // distinguishable timestamp — that would reproduce the very outage
-        // this loop exists to fix.
+        // seen_mtime latches only after a coherent read. The host publishes
+        // atomically (temp sibling + rename), but the file can also be
+        // replaced by other writers, and a rename can land within the same
+        // mtime granule as a garbage state we already observed. Latching a
+        // failed read would lock that rewrite out until a later
+        // distinguishable timestamp — reproducing the very outage this loop
+        // exists to fix — so failed reads retry on the next tick instead.
         let Ok(content) = tokio::fs::read_to_string(&path).await else {
             continue;
         };

--- a/anyharness/crates/proliferate-diagnostics-client/src/producer/dev_refresh.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/producer/dev_refresh.rs
@@ -14,16 +14,33 @@ use crate::bridge::activation::{
 };
 use crate::producer::transport::CollectorClient;
 
+#[cfg(test)]
+#[path = "tests_dev_refresh.rs"]
+mod tests;
+
 /// A stat per tick is the steady-state cost; the file only changes when the
 /// collector restarts, so seconds of re-attach latency are fine.
 const DEV_ENV_POLL_INTERVAL: Duration = Duration::from_secs(5);
 
-pub(super) async fn dev_generation_refresh(inner: Arc<ProducerInner>, path: PathBuf) {
+/// Starts the refresh task when the host published the snippet's own path;
+/// an old app build's 3-line snippet keeps the frozen single-generation
+/// behavior.
+pub(super) fn spawn_if_configured(
+    runtime: &tokio::runtime::Handle,
+    inner: &Arc<ProducerInner>,
+    path: Option<PathBuf>,
+) {
+    if let Some(path) = path {
+        runtime.spawn(dev_generation_refresh(Arc::clone(inner), path));
+    }
+}
+
+async fn dev_generation_refresh(inner: Arc<ProducerInner>, path: PathBuf) {
     dev_generation_refresh_with_interval(inner, path, DEV_ENV_POLL_INTERVAL).await;
 }
 
 /// The interval seam exists for tests; production uses the constant above.
-pub(super) async fn dev_generation_refresh_with_interval(
+async fn dev_generation_refresh_with_interval(
     inner: Arc<ProducerInner>,
     path: PathBuf,
     interval: Duration,
@@ -69,5 +86,28 @@ pub(super) async fn dev_generation_refresh_with_interval(
             endpoint = %parsed.endpoint,
             "dev diagnostics re-attached to new collector generation"
         );
+    }
+}
+
+impl ProducerInner {
+    /// Boot id of the current generation, ready or cooling down. `None` while
+    /// unavailable so a re-published snippet for the same (dead) collector can
+    /// still be retried by the dev refresh loop.
+    fn current_collector_boot_id(&self) -> Option<String> {
+        let state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+        match &state.collector {
+            super::CollectorAvailability::Ready(generation)
+            | super::CollectorAvailability::Cooldown { generation, .. } => {
+                Some(generation.collector_boot_id.clone())
+            }
+            super::CollectorAvailability::Unavailable { .. } => None,
+        }
+    }
+
+    fn is_terminal(&self) -> bool {
+        self.state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .terminal
     }
 }

--- a/anyharness/crates/proliferate-diagnostics-client/src/producer/dev_refresh.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/producer/dev_refresh.rs
@@ -1,0 +1,73 @@
+//! Dev-only file-backed twin of the fd bridge's `GenerationReady` path.
+//!
+//! The Desktop host re-publishes the dev diagnostics env snippet whenever a
+//! collector restart brings up a new generation. This task keeps re-reading
+//! that snippet and swaps the producer onto the new collector via
+//! [`ProducerInner::replace_generation`], so an externally launched dev
+//! runtime no longer stays pinned to a dead collector until its own restart.
+
+use std::{path::PathBuf, sync::Arc, time::Duration};
+
+use super::ProducerInner;
+use crate::bridge::activation::{
+    parse_dev_env_file, CollectorGenerationHandle, DEV_COLLECTOR_GENERATION,
+};
+use crate::producer::transport::CollectorClient;
+
+/// A stat per tick is the steady-state cost; the file only changes when the
+/// collector restarts, so seconds of re-attach latency are fine.
+const DEV_ENV_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+pub(super) async fn dev_generation_refresh(inner: Arc<ProducerInner>, path: PathBuf) {
+    dev_generation_refresh_with_interval(inner, path, DEV_ENV_POLL_INTERVAL).await;
+}
+
+/// The interval seam exists for tests; production uses the constant above.
+pub(super) async fn dev_generation_refresh_with_interval(
+    inner: Arc<ProducerInner>,
+    path: PathBuf,
+    interval: Duration,
+) {
+    let mut seen_mtime = None;
+    // Locally owned counter: with no bridge nothing else advances the
+    // generation, so a monotonic bump always supersedes the current one —
+    // including an unavailable latch from boot-id-mismatched receipts.
+    let mut dev_generation = DEV_COLLECTOR_GENERATION;
+    loop {
+        tokio::time::sleep(interval).await;
+        if inner.is_terminal() {
+            return;
+        }
+        let Ok(meta) = tokio::fs::metadata(&path).await else {
+            continue;
+        };
+        let mtime = meta.modified().ok();
+        if mtime == seen_mtime {
+            continue;
+        }
+        seen_mtime = mtime;
+        let Some(parsed) = parse_dev_env_file(&path) else {
+            continue;
+        };
+        if inner.current_collector_boot_id().as_deref() == Some(parsed.collector_boot_id.as_str()) {
+            // Same generation republished (e.g. covering our own boot) —
+            // nothing to do.
+            continue;
+        }
+        let Ok(client) = CollectorClient::new(&parsed.endpoint, parsed.capability) else {
+            continue;
+        };
+        dev_generation = dev_generation.saturating_add(1);
+        inner.replace_generation(CollectorGenerationHandle {
+            generation: dev_generation,
+            collector_boot_id: parsed.collector_boot_id,
+            client: Arc::new(client),
+        });
+        // The capability is a secret: only the endpoint is logged.
+        tracing::info!(
+            target: "anyharness.diagnostics.delivery",
+            endpoint = %parsed.endpoint,
+            "dev diagnostics re-attached to new collector generation"
+        );
+    }
+}

--- a/anyharness/crates/proliferate-diagnostics-client/src/producer/dev_refresh.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/producer/dev_refresh.rs
@@ -10,7 +10,7 @@ use std::{path::PathBuf, sync::Arc, time::Duration};
 
 use super::ProducerInner;
 use crate::bridge::activation::{
-    parse_dev_env_file, CollectorGenerationHandle, DEV_COLLECTOR_GENERATION,
+    parse_dev_env_snippet, CollectorGenerationHandle, DEV_COLLECTOR_GENERATION,
 };
 use crate::producer::transport::CollectorClient;
 
@@ -62,18 +62,27 @@ async fn dev_generation_refresh_with_interval(
         if mtime == seen_mtime {
             continue;
         }
-        seen_mtime = mtime;
-        let Some(parsed) = parse_dev_env_file(&path) else {
+        // seen_mtime latches only after a coherent read: the host's rewrite is
+        // not atomic, so a torn/garbage read at this mtime must be retried on
+        // the next tick rather than locking the rewrite out until a later
+        // distinguishable timestamp — that would reproduce the very outage
+        // this loop exists to fix.
+        let Ok(content) = tokio::fs::read_to_string(&path).await else {
+            continue;
+        };
+        let Some(parsed) = parse_dev_env_snippet(&content) else {
             continue;
         };
         if inner.current_collector_boot_id().as_deref() == Some(parsed.collector_boot_id.as_str()) {
             // Same generation republished (e.g. covering our own boot) —
             // nothing to do.
+            seen_mtime = mtime;
             continue;
         }
         let Ok(client) = CollectorClient::new(&parsed.endpoint, parsed.capability) else {
             continue;
         };
+        seen_mtime = mtime;
         dev_generation = dev_generation.saturating_add(1);
         inner.replace_generation(CollectorGenerationHandle {
             generation: dev_generation,

--- a/anyharness/crates/proliferate-diagnostics-client/src/producer/mod.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/producer/mod.rs
@@ -5,7 +5,7 @@ use std::{
 };
 use tokio::time::Instant as TokioInstant;
 
-use proliferate_diagnostics_protocol::v1::{limits::MAX_SAFE_INTEGER, types::ProducerRecordV1};
+use proliferate_diagnostics_protocol::v1::types::ProducerRecordV1;
 
 use crate::{
     bridge::activation::{BundledDesktopDiagnosticsBootstrap, InitialCollectorState},
@@ -27,9 +27,6 @@ pub(crate) mod status;
 pub(crate) mod transport;
 mod worker;
 
-#[cfg(all(test, unix, debug_assertions))]
-#[path = "tests_dev_refresh.rs"]
-mod tests_dev_refresh;
 #[cfg(all(test, unix))]
 #[path = "tests_delivery_end.rs"]
 mod tests_delivery_end;
@@ -192,8 +189,6 @@ pub(crate) fn install(
             bootstrap.bridge.zip(bootstrap.shutdown),
         ),
         // No inherited descriptors: no bridge thread, no fallback authority.
-        // The file-backed refresh task below stands in for the bridge's
-        // generation updates when the host published the snippet's path.
         #[cfg(debug_assertions)]
         BundledDesktopDiagnosticsBootstrap::DevEnv(dev) => {
             dev_env_path = dev.env_path;
@@ -215,11 +210,7 @@ pub(crate) fn install(
             Some(bootstrap.classification),
         ),
         #[cfg(debug_assertions)]
-        BundledDesktopDiagnosticsBootstrap::DevEnv(dev) => {
-            // The file-backed refresh is unix-only, like the fd bridge.
-            let _ = &dev.env_path;
-            (dev.initial_state, None, None)
-        }
+        BundledDesktopDiagnosticsBootstrap::DevEnv(dev) => (dev.initial_state, None, None),
     };
     if degraded.is_some() {
         eprintln!("[desktop-diagnostics] bundled bootstrap degraded");
@@ -292,12 +283,7 @@ pub(crate) fn install(
         .transpose()
         .map_err(|_| InstallError::WorkerUnavailable)?;
     #[cfg(all(unix, debug_assertions))]
-    if let Some(path) = dev_env_path {
-        runtime.spawn(dev_refresh::dev_generation_refresh(
-            Arc::clone(&inner),
-            path,
-        ));
-    }
+    dev_refresh::spawn_if_configured(&runtime, &inner, dev_env_path);
     let join = runtime.spawn(worker::run(Arc::clone(&inner)));
     let handle = DiagnosticsProducerHandle {
         inner: Arc::clone(&inner),
@@ -444,29 +430,6 @@ impl ProducerInner {
         self.notify.notify_one();
     }
 
-    /// Boot id of the current generation, ready or cooling down. `None` while
-    /// unavailable so a re-published snippet for the same (dead) collector can
-    /// still be retried by the dev refresh loop.
-    #[cfg(all(unix, debug_assertions))]
-    pub(crate) fn current_collector_boot_id(&self) -> Option<String> {
-        let state = self.state.lock().unwrap_or_else(|error| error.into_inner());
-        match &state.collector {
-            CollectorAvailability::Ready(generation)
-            | CollectorAvailability::Cooldown { generation, .. } => {
-                Some(generation.collector_boot_id.clone())
-            }
-            CollectorAvailability::Unavailable { .. } => None,
-        }
-    }
-
-    #[cfg(all(unix, debug_assertions))]
-    pub(crate) fn is_terminal(&self) -> bool {
-        self.state
-            .lock()
-            .unwrap_or_else(|error| error.into_inner())
-            .terminal
-    }
-
     #[cfg(unix)]
     pub(crate) fn mark_generation_unavailable(&self, generation: u64) {
         let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
@@ -501,27 +464,6 @@ impl ProducerInner {
         // The parent signal transfers clock ownership immediately; dispatch
         // pauses until the request supplies the parent's remaining window.
         state.terminal_deadline = None;
-        drop(state);
-        self.notify.notify_one();
-    }
-
-    /// Permanent bridge loss: no newer generation can arrive, so the sentinel
-    /// latches unavailable. Queued records retain routing until worker drain.
-    #[cfg(unix)]
-    pub(crate) fn mark_bridge_lost(&self) {
-        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
-        if matches!(
-            &state.collector,
-            CollectorAvailability::Unavailable { generation } if *generation == MAX_SAFE_INTEGER
-        ) {
-            return;
-        }
-        state.collector = CollectorAvailability::Unavailable {
-            generation: MAX_SAFE_INTEGER,
-        };
-        if !state.in_flight.is_empty() {
-            state.delivery_fence_eligible = false;
-        }
         drop(state);
         self.notify.notify_one();
     }

--- a/anyharness/crates/proliferate-diagnostics-client/src/producer/mod.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/producer/mod.rs
@@ -403,59 +403,6 @@ impl ProducerInner {
     }
 
     #[cfg(unix)]
-    pub(crate) fn replace_generation(
-        &self,
-        generation: crate::bridge::activation::CollectorGenerationHandle,
-    ) {
-        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
-        let current = match &state.collector {
-            CollectorAvailability::Ready(current)
-            | CollectorAvailability::Cooldown {
-                generation: current,
-                ..
-            } => current.generation,
-            CollectorAvailability::Unavailable { generation } => *generation,
-        };
-        if generation.generation <= current {
-            return;
-        }
-        for record in &mut state.queue {
-            record.fallback_reason = Some(FallbackReason::GenerationChanged);
-        }
-        if !state.in_flight.is_empty() {
-            state.delivery_fence_eligible = false;
-        }
-        state.collector = CollectorAvailability::Ready(Arc::new(generation));
-        drop(state);
-        self.notify.notify_one();
-    }
-
-    #[cfg(unix)]
-    pub(crate) fn mark_generation_unavailable(&self, generation: u64) {
-        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
-        let current = match &state.collector {
-            CollectorAvailability::Ready(current)
-            | CollectorAvailability::Cooldown {
-                generation: current,
-                ..
-            } => current.generation,
-            CollectorAvailability::Unavailable { generation } => *generation,
-        };
-        if generation <= current {
-            return;
-        }
-        for record in &mut state.queue {
-            record.fallback_reason = Some(FallbackReason::GenerationChanged);
-        }
-        state.collector = CollectorAvailability::Unavailable { generation };
-        if !state.in_flight.is_empty() {
-            state.delivery_fence_eligible = false;
-        }
-        drop(state);
-        self.notify.notify_one();
-    }
-
-    #[cfg(unix)]
     pub(crate) fn arm_parent_shutdown(&self) {
         let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
         state.terminal = true;

--- a/anyharness/crates/proliferate-diagnostics-client/src/producer/mod.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/producer/mod.rs
@@ -18,6 +18,8 @@ mod admission;
 #[cfg(unix)]
 mod bridge_runtime;
 mod delivery_log;
+#[cfg(all(unix, debug_assertions))]
+mod dev_refresh;
 mod emit;
 mod fallback_runtime;
 pub(crate) mod record;
@@ -25,6 +27,9 @@ pub(crate) mod status;
 pub(crate) mod transport;
 mod worker;
 
+#[cfg(all(test, unix, debug_assertions))]
+#[path = "tests_dev_refresh.rs"]
+mod tests_dev_refresh;
 #[cfg(all(test, unix))]
 #[path = "tests_delivery_end.rs"]
 mod tests_delivery_end;
@@ -166,6 +171,8 @@ pub(crate) fn install(
     release: &str,
     environment: &str,
 ) -> Result<DiagnosticsInstallation, InstallError> {
+    #[cfg(all(unix, debug_assertions))]
+    let mut dev_env_path: Option<std::path::PathBuf> = None;
     #[cfg(unix)]
     let (initial_state, fallback_handle, degraded, platform_channels) = match activation {
         BundledDesktopDiagnosticsBootstrap::Ready(bootstrap) => (
@@ -185,8 +192,13 @@ pub(crate) fn install(
             bootstrap.bridge.zip(bootstrap.shutdown),
         ),
         // No inherited descriptors: no bridge thread, no fallback authority.
+        // The file-backed refresh task below stands in for the bridge's
+        // generation updates when the host published the snippet's path.
         #[cfg(debug_assertions)]
-        BundledDesktopDiagnosticsBootstrap::DevEnv(dev) => (dev.initial_state, None, None, None),
+        BundledDesktopDiagnosticsBootstrap::DevEnv(dev) => {
+            dev_env_path = dev.env_path;
+            (dev.initial_state, None, None, None)
+        }
     };
     #[cfg(not(unix))]
     let (initial_state, fallback_handle, degraded) = match activation {
@@ -203,7 +215,11 @@ pub(crate) fn install(
             Some(bootstrap.classification),
         ),
         #[cfg(debug_assertions)]
-        BundledDesktopDiagnosticsBootstrap::DevEnv(dev) => (dev.initial_state, None, None),
+        BundledDesktopDiagnosticsBootstrap::DevEnv(dev) => {
+            // The file-backed refresh is unix-only, like the fd bridge.
+            let _ = &dev.env_path;
+            (dev.initial_state, None, None)
+        }
     };
     if degraded.is_some() {
         eprintln!("[desktop-diagnostics] bundled bootstrap degraded");
@@ -275,6 +291,13 @@ pub(crate) fn install(
         })
         .transpose()
         .map_err(|_| InstallError::WorkerUnavailable)?;
+    #[cfg(all(unix, debug_assertions))]
+    if let Some(path) = dev_env_path {
+        runtime.spawn(dev_refresh::dev_generation_refresh(
+            Arc::clone(&inner),
+            path,
+        ));
+    }
     let join = runtime.spawn(worker::run(Arc::clone(&inner)));
     let handle = DiagnosticsProducerHandle {
         inner: Arc::clone(&inner),
@@ -391,6 +414,82 @@ impl ProducerInner {
             delivery_fence_eligible: state.delivery_fence_eligible,
             last_failure: state.last_failure,
         }
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn replace_generation(
+        &self,
+        generation: crate::bridge::activation::CollectorGenerationHandle,
+    ) {
+        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+        let current = match &state.collector {
+            CollectorAvailability::Ready(current)
+            | CollectorAvailability::Cooldown {
+                generation: current,
+                ..
+            } => current.generation,
+            CollectorAvailability::Unavailable { generation } => *generation,
+        };
+        if generation.generation <= current {
+            return;
+        }
+        for record in &mut state.queue {
+            record.fallback_reason = Some(FallbackReason::GenerationChanged);
+        }
+        if !state.in_flight.is_empty() {
+            state.delivery_fence_eligible = false;
+        }
+        state.collector = CollectorAvailability::Ready(Arc::new(generation));
+        drop(state);
+        self.notify.notify_one();
+    }
+
+    /// Boot id of the current generation, ready or cooling down. `None` while
+    /// unavailable so a re-published snippet for the same (dead) collector can
+    /// still be retried by the dev refresh loop.
+    #[cfg(all(unix, debug_assertions))]
+    pub(crate) fn current_collector_boot_id(&self) -> Option<String> {
+        let state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+        match &state.collector {
+            CollectorAvailability::Ready(generation)
+            | CollectorAvailability::Cooldown { generation, .. } => {
+                Some(generation.collector_boot_id.clone())
+            }
+            CollectorAvailability::Unavailable { .. } => None,
+        }
+    }
+
+    #[cfg(all(unix, debug_assertions))]
+    pub(crate) fn is_terminal(&self) -> bool {
+        self.state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .terminal
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn mark_generation_unavailable(&self, generation: u64) {
+        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+        let current = match &state.collector {
+            CollectorAvailability::Ready(current)
+            | CollectorAvailability::Cooldown {
+                generation: current,
+                ..
+            } => current.generation,
+            CollectorAvailability::Unavailable { generation } => *generation,
+        };
+        if generation <= current {
+            return;
+        }
+        for record in &mut state.queue {
+            record.fallback_reason = Some(FallbackReason::GenerationChanged);
+        }
+        state.collector = CollectorAvailability::Unavailable { generation };
+        if !state.in_flight.is_empty() {
+            state.delivery_fence_eligible = false;
+        }
+        drop(state);
+        self.notify.notify_one();
     }
 
     #[cfg(unix)]

--- a/anyharness/crates/proliferate-diagnostics-client/src/producer/tests_dev_refresh.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/producer/tests_dev_refresh.rs
@@ -7,8 +7,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use super::{
-    dev_refresh::dev_generation_refresh_with_interval,
+use super::super::{
     status::ProducerCollectorState,
     tests_support::{
         emit, producer, protected, settle, spawn_worker, wait_for, CollectorFixture,
@@ -16,6 +15,7 @@ use super::{
     },
     CollectorAvailability, ProducerInner,
 };
+use super::dev_generation_refresh_with_interval;
 use crate::{
     bridge::activation::{
         parse_dev_env_file, DEV_CAPABILITY_ENV, DEV_COLLECTOR_BOOT_ID_ENV, DEV_ENDPOINT_ENV,

--- a/anyharness/crates/proliferate-diagnostics-client/src/producer/tests_dev_refresh.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/producer/tests_dev_refresh.rs
@@ -1,0 +1,234 @@
+//! File-backed dev generation refresh: parsing bounds and re-attach behavior
+//! against a hand-served loopback collector, no live Desktop host involved.
+
+use std::{
+    path::Path,
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+
+use super::{
+    dev_refresh::dev_generation_refresh_with_interval,
+    status::ProducerCollectorState,
+    tests_support::{
+        emit, producer, protected, settle, spawn_worker, wait_for, CollectorFixture,
+        TEST_CAPABILITY, TEST_COLLECTOR_BOOT,
+    },
+    CollectorAvailability, ProducerInner,
+};
+use crate::{
+    bridge::activation::{
+        parse_dev_env_file, DEV_CAPABILITY_ENV, DEV_COLLECTOR_BOOT_ID_ENV, DEV_ENDPOINT_ENV,
+        DEV_ENV_PATH_ENV,
+    },
+    DiagnosticsComponent, EmitDisposition,
+};
+
+const FRESH_COLLECTOR_BOOT: &str = "collector-boot-0002";
+const TEST_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Writes the snippet exactly as the Desktop host renders it (four lines) and
+/// forces a strictly increasing mtime so the refresh loop's stat cannot miss a
+/// rewrite on filesystems with coarse timestamp granularity.
+fn write_snippet(path: &Path, sequence: u64, endpoint: &str, capability: &str, boot_id: &str) {
+    let snippet = format!(
+        "{DEV_ENDPOINT_ENV}={endpoint}\n{DEV_CAPABILITY_ENV}={capability}\n{DEV_COLLECTOR_BOOT_ID_ENV}={boot_id}\n{DEV_ENV_PATH_ENV}={}\n",
+        path.display(),
+    );
+    write_raw(path, sequence, &snippet);
+}
+
+fn write_raw(path: &Path, sequence: u64, content: &str) {
+    std::fs::write(path, content).expect("write dev env snippet");
+    let file = std::fs::File::options()
+        .write(true)
+        .open(path)
+        .expect("reopen snippet");
+    file.set_modified(SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000 + sequence))
+        .expect("set snippet mtime");
+}
+
+fn ready_snapshot(inner: &ProducerInner) -> Option<(String, u64)> {
+    match inner.snapshot().collector_state {
+        ProducerCollectorState::Ready {
+            collector_boot_id,
+            generation_number,
+        } => Some((collector_boot_id, generation_number)),
+        _ => None,
+    }
+}
+
+#[test]
+fn parse_accepts_the_published_four_line_snippet() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let path = directory.path().join("diagnostics-dev.env");
+    write_snippet(
+        &path,
+        1,
+        "http://127.0.0.1:53421/",
+        TEST_CAPABILITY,
+        TEST_COLLECTOR_BOOT,
+    );
+    let parsed = parse_dev_env_file(&path).expect("valid snippet parses");
+    assert_eq!(parsed.endpoint, "http://127.0.0.1:53421/");
+    assert_eq!(parsed.capability, TEST_CAPABILITY);
+    assert_eq!(parsed.collector_boot_id, TEST_COLLECTOR_BOOT);
+}
+
+#[test]
+fn parse_rejects_missing_keys_out_of_bound_values_and_oversized_files() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let path = directory.path().join("diagnostics-dev.env");
+
+    // Missing capability line.
+    write_raw(
+        &path,
+        1,
+        &format!("{DEV_ENDPOINT_ENV}=http://127.0.0.1:1/\n{DEV_COLLECTOR_BOOT_ID_ENV}=boot\n"),
+    );
+    assert!(parse_dev_env_file(&path).is_none());
+
+    // Boot id past the protocol id bound (128 bytes).
+    write_snippet(
+        &path,
+        2,
+        "http://127.0.0.1:1/",
+        TEST_CAPABILITY,
+        &"b".repeat(129),
+    );
+    assert!(parse_dev_env_file(&path).is_none());
+
+    // Empty value.
+    write_snippet(&path, 3, "", TEST_CAPABILITY, TEST_COLLECTOR_BOOT);
+    assert!(parse_dev_env_file(&path).is_none());
+
+    // A file that is clearly not the four-line snippet.
+    write_raw(&path, 4, &"x".repeat(10_000));
+    assert!(parse_dev_env_file(&path).is_none());
+
+    // Missing file.
+    assert!(parse_dev_env_file(&directory.path().join("absent.env")).is_none());
+}
+
+/// A rewrite carrying a new collector boot id swaps the producer onto the new
+/// endpoint as generation 2, and records dispatch to the new collector.
+#[tokio::test(flavor = "multi_thread")]
+async fn rewrite_with_new_boot_id_reattaches_as_generation_two() {
+    let old = CollectorFixture::accepting(TEST_COLLECTOR_BOOT).await;
+    let fresh = CollectorFixture::accepting(FRESH_COLLECTOR_BOOT).await;
+    let directory = tempfile::tempdir().expect("tempdir");
+    let path = directory.path().join("diagnostics-dev.env");
+    let inner = producer(
+        DiagnosticsComponent::AnyHarness,
+        CollectorAvailability::Ready(Arc::new(old.generation(1))),
+        None,
+    );
+    let refresh = tokio::spawn(dev_generation_refresh_with_interval(
+        Arc::clone(&inner),
+        path.clone(),
+        TEST_POLL_INTERVAL,
+    ));
+
+    write_snippet(
+        &path,
+        1,
+        fresh.endpoint(),
+        TEST_CAPABILITY,
+        FRESH_COLLECTOR_BOOT,
+    );
+    assert!(
+        wait_for(|| { ready_snapshot(&inner) == Some((FRESH_COLLECTOR_BOOT.to_owned(), 2)) }).await,
+        "producer must re-attach to the new boot id as generation 2"
+    );
+
+    // Delivery proof: the swapped-in client points at the fresh endpoint.
+    assert_eq!(
+        emit(&inner, protected("post-restart")),
+        EmitDisposition::Admitted
+    );
+    let worker = spawn_worker(&inner);
+    assert!(
+        wait_for(|| fresh.batch_count() == 1).await,
+        "records must dispatch to the new collector endpoint"
+    );
+    assert_eq!(old.batch_count(), 0);
+    worker.abort();
+    refresh.abort();
+}
+
+/// The host re-publishes the snippet for our own boot too (e.g. app restart
+/// racing us); an unchanged boot id must not churn the generation.
+#[tokio::test(flavor = "multi_thread")]
+async fn rewrite_with_same_boot_id_does_not_swap() {
+    let old = CollectorFixture::accepting(TEST_COLLECTOR_BOOT).await;
+    let directory = tempfile::tempdir().expect("tempdir");
+    let path = directory.path().join("diagnostics-dev.env");
+    let inner = producer(
+        DiagnosticsComponent::AnyHarness,
+        CollectorAvailability::Ready(Arc::new(old.generation(1))),
+        None,
+    );
+    let refresh = tokio::spawn(dev_generation_refresh_with_interval(
+        Arc::clone(&inner),
+        path.clone(),
+        TEST_POLL_INTERVAL,
+    ));
+
+    write_snippet(
+        &path,
+        1,
+        old.endpoint(),
+        TEST_CAPABILITY,
+        TEST_COLLECTOR_BOOT,
+    );
+    settle().await;
+    assert_eq!(
+        ready_snapshot(&inner),
+        Some((TEST_COLLECTOR_BOOT.to_owned(), 1)),
+        "a republished snippet for the same boot id must leave generation 1 in place"
+    );
+    refresh.abort();
+}
+
+/// Garbage never swaps, and the unavailable latch survives it — but a later
+/// valid snippet still supersedes the latch (the outage this fixes).
+#[tokio::test(flavor = "multi_thread")]
+async fn garbage_preserves_latch_and_valid_rewrite_supersedes_it() {
+    let fresh = CollectorFixture::accepting(FRESH_COLLECTOR_BOOT).await;
+    let directory = tempfile::tempdir().expect("tempdir");
+    let path = directory.path().join("diagnostics-dev.env");
+    // Boot-id-mismatched receipts latch the boot generation unusable.
+    let inner = producer(
+        DiagnosticsComponent::AnyHarness,
+        CollectorAvailability::Unavailable { generation: 1 },
+        None,
+    );
+    let refresh = tokio::spawn(dev_generation_refresh_with_interval(
+        Arc::clone(&inner),
+        path.clone(),
+        TEST_POLL_INTERVAL,
+    ));
+
+    write_raw(&path, 1, "not=the\nsnippet\n");
+    settle().await;
+    assert!(
+        matches!(
+            inner.snapshot().collector_state,
+            ProducerCollectorState::Unavailable
+        ),
+        "garbage must not disturb the unavailable latch"
+    );
+
+    write_snippet(
+        &path,
+        2,
+        fresh.endpoint(),
+        TEST_CAPABILITY,
+        FRESH_COLLECTOR_BOOT,
+    );
+    assert!(
+        wait_for(|| { ready_snapshot(&inner) == Some((FRESH_COLLECTOR_BOOT.to_owned(), 2)) }).await,
+        "a valid rewrite must supersede the unavailable latch"
+    );
+    refresh.abort();
+}

--- a/anyharness/crates/proliferate-diagnostics-client/src/producer/tests_dev_refresh.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/producer/tests_dev_refresh.rs
@@ -18,7 +18,7 @@ use super::super::{
 use super::dev_generation_refresh_with_interval;
 use crate::{
     bridge::activation::{
-        parse_dev_env_file, DEV_CAPABILITY_ENV, DEV_COLLECTOR_BOOT_ID_ENV, DEV_ENDPOINT_ENV,
+        parse_dev_env_snippet, DEV_CAPABILITY_ENV, DEV_COLLECTOR_BOOT_ID_ENV, DEV_ENDPOINT_ENV,
         DEV_ENV_PATH_ENV,
     },
     DiagnosticsComponent, EmitDisposition,
@@ -31,11 +31,15 @@ const TEST_POLL_INTERVAL: Duration = Duration::from_millis(10);
 /// forces a strictly increasing mtime so the refresh loop's stat cannot miss a
 /// rewrite on filesystems with coarse timestamp granularity.
 fn write_snippet(path: &Path, sequence: u64, endpoint: &str, capability: &str, boot_id: &str) {
-    let snippet = format!(
+    let snippet = render_snippet(path, endpoint, capability, boot_id);
+    write_raw(path, sequence, &snippet);
+}
+
+fn render_snippet(path: &Path, endpoint: &str, capability: &str, boot_id: &str) -> String {
+    format!(
         "{DEV_ENDPOINT_ENV}={endpoint}\n{DEV_CAPABILITY_ENV}={capability}\n{DEV_COLLECTOR_BOOT_ID_ENV}={boot_id}\n{DEV_ENV_PATH_ENV}={}\n",
         path.display(),
-    );
-    write_raw(path, sequence, &snippet);
+    )
 }
 
 fn write_raw(path: &Path, sequence: u64, content: &str) {
@@ -60,16 +64,14 @@ fn ready_snapshot(inner: &ProducerInner) -> Option<(String, u64)> {
 
 #[test]
 fn parse_accepts_the_published_four_line_snippet() {
-    let directory = tempfile::tempdir().expect("tempdir");
-    let path = directory.path().join("diagnostics-dev.env");
-    write_snippet(
-        &path,
-        1,
+    let path = Path::new("/tmp/app/diagnostics-dev.env");
+    let snippet = render_snippet(
+        path,
         "http://127.0.0.1:53421/",
         TEST_CAPABILITY,
         TEST_COLLECTOR_BOOT,
     );
-    let parsed = parse_dev_env_file(&path).expect("valid snippet parses");
+    let parsed = parse_dev_env_snippet(&snippet).expect("valid snippet parses");
     assert_eq!(parsed.endpoint, "http://127.0.0.1:53421/");
     assert_eq!(parsed.capability, TEST_CAPABILITY);
     assert_eq!(parsed.collector_boot_id, TEST_COLLECTOR_BOOT);
@@ -77,37 +79,35 @@ fn parse_accepts_the_published_four_line_snippet() {
 
 #[test]
 fn parse_rejects_missing_keys_out_of_bound_values_and_oversized_files() {
-    let directory = tempfile::tempdir().expect("tempdir");
-    let path = directory.path().join("diagnostics-dev.env");
+    let path = Path::new("/tmp/app/diagnostics-dev.env");
 
     // Missing capability line.
-    write_raw(
-        &path,
-        1,
-        &format!("{DEV_ENDPOINT_ENV}=http://127.0.0.1:1/\n{DEV_COLLECTOR_BOOT_ID_ENV}=boot\n"),
-    );
-    assert!(parse_dev_env_file(&path).is_none());
+    assert!(parse_dev_env_snippet(&format!(
+        "{DEV_ENDPOINT_ENV}=http://127.0.0.1:1/\n{DEV_COLLECTOR_BOOT_ID_ENV}=boot\n"
+    ))
+    .is_none());
 
     // Boot id past the protocol id bound (128 bytes).
-    write_snippet(
-        &path,
-        2,
+    assert!(parse_dev_env_snippet(&render_snippet(
+        path,
         "http://127.0.0.1:1/",
         TEST_CAPABILITY,
         &"b".repeat(129),
-    );
-    assert!(parse_dev_env_file(&path).is_none());
+    ))
+    .is_none());
 
     // Empty value.
-    write_snippet(&path, 3, "", TEST_CAPABILITY, TEST_COLLECTOR_BOOT);
-    assert!(parse_dev_env_file(&path).is_none());
+    assert!(parse_dev_env_snippet(&render_snippet(
+        path,
+        "",
+        TEST_CAPABILITY,
+        TEST_COLLECTOR_BOOT,
+    ))
+    .is_none());
 
-    // A file that is clearly not the four-line snippet.
-    write_raw(&path, 4, &"x".repeat(10_000));
-    assert!(parse_dev_env_file(&path).is_none());
-
-    // Missing file.
-    assert!(parse_dev_env_file(&directory.path().join("absent.env")).is_none());
+    // Content that is clearly not the four-line snippet.
+    assert!(parse_dev_env_snippet(&"x".repeat(10_000)).is_none());
+    assert!(parse_dev_env_snippet("").is_none());
 }
 
 /// A rewrite carrying a new collector boot id swaps the producer onto the new
@@ -186,6 +186,52 @@ async fn rewrite_with_same_boot_id_does_not_swap() {
         ready_snapshot(&inner),
         Some((TEST_COLLECTOR_BOOT.to_owned(), 1)),
         "a republished snippet for the same boot id must leave generation 1 in place"
+    );
+    refresh.abort();
+}
+
+/// The host's rewrite is not atomic: a poll can catch a torn/garbage read at
+/// some mtime T. The loop must not latch T on a failed parse, or a valid
+/// re-read at the indistinguishable same timestamp would be locked out —
+/// reproducing the outage this slice exists to fix.
+#[tokio::test(flavor = "multi_thread")]
+async fn torn_read_then_valid_content_at_the_same_mtime_still_reattaches() {
+    let old = CollectorFixture::accepting(TEST_COLLECTOR_BOOT).await;
+    let fresh = CollectorFixture::accepting(FRESH_COLLECTOR_BOOT).await;
+    let directory = tempfile::tempdir().expect("tempdir");
+    let path = directory.path().join("diagnostics-dev.env");
+    let inner = producer(
+        DiagnosticsComponent::AnyHarness,
+        CollectorAvailability::Ready(Arc::new(old.generation(1))),
+        None,
+    );
+    let refresh = tokio::spawn(dev_generation_refresh_with_interval(
+        Arc::clone(&inner),
+        path.clone(),
+        TEST_POLL_INTERVAL,
+    ));
+
+    // A torn read: the truncate landed, the content did not.
+    write_raw(&path, 1, "");
+    // Give the loop several ticks to observe the torn state at mtime T.
+    tokio::time::sleep(TEST_POLL_INTERVAL * 5).await;
+    assert_eq!(
+        ready_snapshot(&inner),
+        Some((TEST_COLLECTOR_BOOT.to_owned(), 1)),
+        "a torn read must not swap"
+    );
+
+    // The completed write, indistinguishable by timestamp (same sequence).
+    write_snippet(
+        &path,
+        1,
+        fresh.endpoint(),
+        TEST_CAPABILITY,
+        FRESH_COLLECTOR_BOOT,
+    );
+    assert!(
+        wait_for(|| { ready_snapshot(&inner) == Some((FRESH_COLLECTOR_BOOT.to_owned(), 2)) }).await,
+        "the completed write at the same mtime must still re-attach"
     );
     refresh.abort();
 }

--- a/anyharness/crates/proliferate-diagnostics-client/src/producer/tests_dev_refresh.rs
+++ b/anyharness/crates/proliferate-diagnostics-client/src/producer/tests_dev_refresh.rs
@@ -190,12 +190,13 @@ async fn rewrite_with_same_boot_id_does_not_swap() {
     refresh.abort();
 }
 
-/// The host's rewrite is not atomic: a poll can catch a torn/garbage read at
-/// some mtime T. The loop must not latch T on a failed parse, or a valid
-/// re-read at the indistinguishable same timestamp would be locked out —
-/// reproducing the outage this slice exists to fix.
+/// The host publishes atomically, but an external writer can leave garbage at
+/// some mtime T, and the host's rename can land within the same mtime granule.
+/// The loop must not latch T on a failed parse, or the valid re-read at the
+/// indistinguishable same timestamp would be locked out — reproducing the
+/// outage this slice exists to fix.
 #[tokio::test(flavor = "multi_thread")]
-async fn torn_read_then_valid_content_at_the_same_mtime_still_reattaches() {
+async fn garbage_then_valid_content_at_the_same_mtime_still_reattaches() {
     let old = CollectorFixture::accepting(TEST_COLLECTOR_BOOT).await;
     let fresh = CollectorFixture::accepting(FRESH_COLLECTOR_BOOT).await;
     let directory = tempfile::tempdir().expect("tempdir");
@@ -211,17 +212,17 @@ async fn torn_read_then_valid_content_at_the_same_mtime_still_reattaches() {
         TEST_POLL_INTERVAL,
     ));
 
-    // A torn read: the truncate landed, the content did not.
+    // An external writer left an empty file at mtime T.
     write_raw(&path, 1, "");
-    // Give the loop several ticks to observe the torn state at mtime T.
+    // Give the loop several ticks to observe the garbage state at mtime T.
     tokio::time::sleep(TEST_POLL_INTERVAL * 5).await;
     assert_eq!(
         ready_snapshot(&inner),
         Some((TEST_COLLECTOR_BOOT.to_owned(), 1)),
-        "a torn read must not swap"
+        "an incoherent read must not swap"
     );
 
-    // The completed write, indistinguishable by timestamp (same sequence).
+    // The host's publish, indistinguishable by timestamp (same sequence).
     write_snippet(
         &path,
         1,


### PR DESCRIPTION
Replacement for #1963 (same branch, same reviewed content). #1963 was accidentally closed during its retarget-to-main pass: a scripted rebase hit a conflict and a force-push landed main's tip on the branch before the conflict was resolved; GitHub then refused reopen. Nothing from this slice ever reached main.

This branch is the honest re-cut: the four slice-2b commits rebased --onto main, with the one conflict (producer/mod.rs module declarations: main's delivery_log from #1964 + this slice's dev_refresh) resolved as the union. Review history, receipts, and the slice spec live on #1963.

Local gate at this head: `Max-lines check passed (repo max 600, component max 500, server layer maxes enabled)` — producer/mod.rs at 592/600.

Slice 2b of the diagnostics hardening program: the dev diagnostics producer re-learns the collector coordinates from the env file on every new collector generation (plus torn-read retry at same mtime, and attribution of same-mtime garbage reads to external writers).