### PR TITLE
fix(anyharness): let live sessions outlast product MCP capability-token TTL

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/http/product_mcp.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/product_mcp.rs
@@ -9,10 +9,12 @@ use serde_json::Value;
 use super::access::assert_workspace_mutable;
 use super::error::ApiError;
 use crate::app::AppState;
+use crate::integrations::mcp::capability_token::McpCapabilityTokenValidation;
 use crate::integrations::mcp::product_server::{
     ProductMcpAuthHeader, ProductMcpContextError, ProductMcpDispatchError,
     ProductMcpEndpointOperation, ProductMcpRequestContext, PRODUCT_MCP_TOKEN_HEADER_NAME,
 };
+use crate::observability::PRODUCT_MCP_AUTH_REJECTED_TRACING_TARGET;
 
 pub async fn get_product_mcp_endpoint(
     State(_state): State<AppState>,
@@ -53,20 +55,68 @@ pub async fn dispatch_product_mcp(
     let definition = server.definition();
     let request = ProductMcpRequestContext::new(workspace_id, session_id, definition.id);
     let endpoint_operation = ProductMcpEndpointOperation::from_request_body(&body);
-    let auth_header = read_auth_header(&headers).ok_or_else(|| {
-        ApiError::unauthorized(
-            "Missing product MCP capability token.",
+    let Some(auth_header) = read_auth_header(&headers) else {
+        return Err(reject_capability(
+            &request,
+            product_mcp_slug,
+            "missing",
+            "Product MCP capability token missing: the request did not carry the \
+             x-anyharness-product-mcp-token header this endpoint requires.",
             definition.unauthorized_code,
-        )
-    })?;
+        ));
+    };
     let validation = server
         .validate_capability_token(auth_header, &request)
         .map_err(|error| ApiError::internal(error.to_string()))?;
-    if !validation.is_valid() {
-        return Err(ApiError::unauthorized(
-            "Invalid product MCP capability token.",
-            definition.unauthorized_code,
-        ));
+    match validation {
+        McpCapabilityTokenValidation::Valid => {}
+        // The token is delivered as a static header for the life of the
+        // session, so a session that outlives the TTL arrives here on every
+        // call. The signature already proved the runtime minted this exact
+        // scope; the sessions domain, not the timestamp, decides whether the
+        // capability is still alive.
+        McpCapabilityTokenValidation::Expired => {
+            let session_open = state
+                .session_service
+                .session_open_for_capability(session_id, workspace_id)
+                .map_err(|error| ApiError::internal(error.to_string()))?;
+            if !session_open {
+                return Err(reject_capability(
+                    &request,
+                    product_mcp_slug,
+                    "expired",
+                    "Product MCP capability token expired and its session is no longer open. \
+                     Start or resume the session to mint a fresh token.",
+                    definition.unauthorized_code,
+                ));
+            }
+            tracing::debug!(
+                session_id = %request.session_id,
+                workspace_id = %request.workspace_id,
+                slug = product_mcp_slug,
+                "product MCP capability token past TTL accepted for open session"
+            );
+        }
+        McpCapabilityTokenValidation::InvalidSignature => {
+            return Err(reject_capability(
+                &request,
+                product_mcp_slug,
+                "invalid-signature",
+                "Product MCP capability token is not valid for this runtime: the token is \
+                 malformed or its signature does not verify.",
+                definition.unauthorized_code,
+            ));
+        }
+        McpCapabilityTokenValidation::ScopeMismatch => {
+            return Err(reject_capability(
+                &request,
+                product_mcp_slug,
+                "scope-mismatch",
+                "Product MCP capability token is not scoped to this workspace, session, and \
+                 product endpoint.",
+                definition.unauthorized_code,
+            ));
+        }
     }
 
     let _lease = match server.endpoint_operation_kind(endpoint_operation) {
@@ -90,6 +140,31 @@ pub async fn dispatch_product_mcp(
         Some(payload) => Ok((StatusCode::OK, Json(payload)).into_response()),
         None => Ok(StatusCode::NO_CONTENT.into_response()),
     }
+}
+
+/// Reject a capability header with the one observable trace of the failure.
+///
+/// The status is 403, not 401, on purpose: MCP clients treat 401 as an OAuth
+/// challenge and run authorization-server discovery against the runtime root,
+/// which fails with an unrelated parse error that masks the real cause. A 403
+/// body passes through to the client verbatim, so the detail names the cause.
+/// The event carries identifiers and the reason — never the token.
+fn reject_capability(
+    request: &ProductMcpRequestContext,
+    slug: &str,
+    reason: &'static str,
+    detail: &'static str,
+    unauthorized_code: &str,
+) -> ApiError {
+    tracing::warn!(
+        target: PRODUCT_MCP_AUTH_REJECTED_TRACING_TARGET,
+        session_id = %request.session_id,
+        workspace_id = %request.workspace_id,
+        slug,
+        reason,
+        "product MCP capability token rejected"
+    );
+    ApiError::forbidden(detail, unauthorized_code)
 }
 
 fn map_dispatch_error(error: ProductMcpDispatchError, request_invalid_code: &str) -> ApiError {

--- a/anyharness/crates/anyharness-lib/src/app/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/app/tests.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 
 mod completion_delivery_crash_tests;
+mod product_mcp_auth_tests;
 
 fn run_git(path: &Path, args: &[&str]) {
     let output = Command::new("git")

--- a/anyharness/crates/anyharness-lib/src/app/tests/product_mcp_auth_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/app/tests/product_mcp_auth_tests.rs
@@ -1,0 +1,214 @@
+//! Dispatch-level tests for product MCP capability auth: expired tokens defer
+//! to session liveness, every rejection is a 403 naming the real cause.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use serde_json::json;
+
+use super::init_seed_repository;
+use crate::app::{test_support, AppState};
+use crate::{
+    api::http::product_mcp::dispatch_product_mcp,
+    domains::{agents::installer::seed::AgentSeedStore, sessions::store::SessionStore},
+    integrations::mcp::capability_token::{
+        McpCapabilityTokenIssuer, McpCapabilityTokenSignature, ProductMcpCapabilityScope,
+    },
+    integrations::mcp::product_server::PRODUCT_MCP_TOKEN_HEADER_NAME,
+    persistence::Db,
+};
+
+/// AppState over an in-memory db with one seeded workspace and one session in
+/// the given status, ready for product MCP dispatch against the Workspace
+/// endpoint. Returns the runtime home so the caller can mint tokens against
+/// the same secret file and clean up.
+fn product_mcp_dispatch_fixture(label: &str, session_status: &str) -> (AppState, PathBuf, PathBuf) {
+    let runtime_home = PathBuf::from(format!("/tmp/anyharness-{label}-{}", uuid::Uuid::new_v4()));
+    let repository_path = init_seed_repository(&PathBuf::from(format!(
+        "/tmp/anyharness-{label}-repo-{}",
+        uuid::Uuid::new_v4()
+    )));
+    let state = AppState::new(
+        runtime_home.clone(),
+        "http://127.0.0.1:8457".to_string(),
+        Db::open_in_memory().expect("expected in-memory db"),
+        false,
+        AgentSeedStore::not_configured_dev(),
+    )
+    .expect("expected app state");
+    test_support::seed_workspace_with_repo_root(
+        &state.db,
+        "workspace-1",
+        "local",
+        &repository_path.to_string_lossy(),
+    );
+    test_support::insert_session_row(
+        &SessionStore::new(state.db.clone()),
+        "workspace-1",
+        "session-1",
+        session_status,
+    );
+    (state, runtime_home, repository_path)
+}
+
+/// An authentic Workspace-scope token whose embedded expiry is already in the
+/// past: same secret file the served endpoint loads, negative TTL.
+fn mint_expired_workspace_token(runtime_home: &Path) -> String {
+    McpCapabilityTokenIssuer::new(
+        runtime_home.to_path_buf(),
+        "workspace-mcp-token.key",
+        McpCapabilityTokenSignature::HmacSha256,
+        -60,
+    )
+    .mint_product_mcp_token(ProductMcpCapabilityScope {
+        workspace_id: "workspace-1",
+        session_id: "session-1",
+        product_mcp_id: crate::domains::agent_operations::mcp::definition::ID,
+    })
+    .expect("mint expired workspace token")
+}
+
+fn product_mcp_token_headers(token: &str) -> axum::http::HeaderMap {
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        axum::http::HeaderName::from_static(PRODUCT_MCP_TOKEN_HEADER_NAME),
+        axum::http::HeaderValue::from_str(token).expect("header value"),
+    );
+    headers
+}
+
+fn tools_list_body() -> serde_json::Value {
+    json!({ "jsonrpc": "2.0", "id": 1, "method": "tools/list" })
+}
+
+// Regression for the 12h-TTL session death: tokens are minted once at launch
+// and delivered as a static header, so any session older than the TTL used to
+// lose every product MCP tool. A session that is still open must keep working
+// on the strength of durable session state alone.
+#[tokio::test(flavor = "current_thread")]
+async fn expired_capability_token_keeps_serving_an_open_session() {
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("expected env mutex");
+    let _guard = test_support::set_bearer_token_env(None);
+    let _data_key_guard = test_support::set_data_key_env(None);
+    let (state, runtime_home, repository_path) =
+        product_mcp_dispatch_fixture("expired-open", "idle");
+    let token = mint_expired_workspace_token(&runtime_home);
+
+    let response = dispatch_product_mcp(
+        &state,
+        "workspace-1",
+        "session-1",
+        "workspace",
+        product_mcp_token_headers(&token),
+        tools_list_body(),
+    )
+    .await
+    .expect("expired token with an open session must still dispatch");
+
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+    let _ = fs::remove_dir_all(runtime_home);
+    let _ = fs::remove_dir_all(repository_path);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn expired_capability_token_is_forbidden_once_the_session_closes() {
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("expected env mutex");
+    let _guard = test_support::set_bearer_token_env(None);
+    let _data_key_guard = test_support::set_data_key_env(None);
+    let (state, runtime_home, repository_path) =
+        product_mcp_dispatch_fixture("expired-closed", "closed");
+    let token = mint_expired_workspace_token(&runtime_home);
+
+    let error = dispatch_product_mcp(
+        &state,
+        "workspace-1",
+        "session-1",
+        "workspace",
+        product_mcp_token_headers(&token),
+        tools_list_body(),
+    )
+    .await
+    .err()
+    .expect("expired token with a closed session must be rejected");
+
+    // 403 and a cause-naming detail: 401 would send MCP clients into OAuth
+    // discovery and mask the real failure behind a parse error.
+    assert_eq!(error.status(), axum::http::StatusCode::FORBIDDEN);
+    assert!(error
+        .detail()
+        .is_some_and(|detail| detail.contains("expired")));
+    assert_eq!(error.code(), Some("WORKSPACE_MCP_UNAUTHORIZED"));
+    let _ = fs::remove_dir_all(runtime_home);
+    let _ = fs::remove_dir_all(repository_path);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn missing_capability_token_is_forbidden_with_named_cause() {
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("expected env mutex");
+    let _guard = test_support::set_bearer_token_env(None);
+    let _data_key_guard = test_support::set_data_key_env(None);
+    let (state, runtime_home, repository_path) =
+        product_mcp_dispatch_fixture("missing-token", "idle");
+
+    let error = dispatch_product_mcp(
+        &state,
+        "workspace-1",
+        "session-1",
+        "workspace",
+        axum::http::HeaderMap::new(),
+        tools_list_body(),
+    )
+    .await
+    .err()
+    .expect("missing token must be rejected");
+
+    assert_eq!(error.status(), axum::http::StatusCode::FORBIDDEN);
+    assert!(error
+        .detail()
+        .is_some_and(|detail| detail.contains("x-anyharness-product-mcp-token")));
+    assert_eq!(error.code(), Some("WORKSPACE_MCP_UNAUTHORIZED"));
+    let _ = fs::remove_dir_all(runtime_home);
+    let _ = fs::remove_dir_all(repository_path);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn garbage_capability_token_is_forbidden_even_for_an_open_session() {
+    let _lock = test_support::ENV_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("expected env mutex");
+    let _guard = test_support::set_bearer_token_env(None);
+    let _data_key_guard = test_support::set_data_key_env(None);
+    let (state, runtime_home, repository_path) =
+        product_mcp_dispatch_fixture("garbage-token", "idle");
+
+    let error = dispatch_product_mcp(
+        &state,
+        "workspace-1",
+        "session-1",
+        "workspace",
+        product_mcp_token_headers("not-a-real-token"),
+        tools_list_body(),
+    )
+    .await
+    .err()
+    .expect("garbage token must be rejected even though the session is open");
+
+    assert_eq!(error.status(), axum::http::StatusCode::FORBIDDEN);
+    assert!(error
+        .detail()
+        .is_some_and(|detail| detail.contains("malformed or its signature")));
+    assert_eq!(error.code(), Some("WORKSPACE_MCP_UNAUTHORIZED"));
+    let _ = fs::remove_dir_all(runtime_home);
+    let _ = fs::remove_dir_all(repository_path);
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/auth.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/auth.rs
@@ -1,8 +1,10 @@
 use std::path::PathBuf;
 
-use crate::integrations::mcp::capability_token::McpCapabilityTokenSignature;
+use crate::integrations::mcp::capability_token::{
+    McpCapabilityTokenSignature, McpCapabilityTokenValidation,
+};
 use crate::integrations::mcp::product_server::{
-    ProductMcpAuth, ProductMcpAuthHeader, ProductMcpRequestContext, ProductMcpTokenValidation,
+    ProductMcpAuth, ProductMcpAuthHeader, ProductMcpRequestContext,
 };
 
 const SECRET_FILE_NAME: &str = "workspace-mcp-token.key";
@@ -36,7 +38,7 @@ impl WorkspaceMcpAuth {
         &self,
         header: ProductMcpAuthHeader<'_>,
         request: &ProductMcpRequestContext,
-    ) -> anyhow::Result<ProductMcpTokenValidation> {
+    ) -> anyhow::Result<McpCapabilityTokenValidation> {
         self.inner.validate_capability_header(header, request)
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/mod.rs
@@ -15,9 +15,10 @@ use serde_json::Value;
 use self::auth::WorkspaceMcpAuth;
 use self::context::WorkspaceMcpContext;
 use crate::domains::agent_operations::runtime::AgentOperations;
+use crate::integrations::mcp::capability_token::McpCapabilityTokenValidation;
 use crate::integrations::mcp::product_server::{
     ProductMcpAuthHeader, ProductMcpContextError, ProductMcpDefinition, ProductMcpRequestContext,
-    ProductMcpServer, ProductMcpTokenValidation,
+    ProductMcpServer,
 };
 use crate::integrations::mcp::tools::McpToolOutput;
 
@@ -44,7 +45,7 @@ impl ProductMcpServer for WorkspaceProductMcpServer {
         &self,
         header: ProductMcpAuthHeader<'_>,
         request: &ProductMcpRequestContext,
-    ) -> anyhow::Result<ProductMcpTokenValidation> {
+    ) -> anyhow::Result<McpCapabilityTokenValidation> {
         self.auth.validate_capability_header(header, request)
     }
 

--- a/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agent_operations/mcp/tests.rs
@@ -26,9 +26,9 @@ use crate::domains::workspaces::options::{
     CreateWorkspaceFromOptionsInput, CreateWorkspaceFromOptionsResult, WorkspaceCreationOptions,
     WorkspaceOptionsError,
 };
+use crate::integrations::mcp::capability_token::McpCapabilityTokenValidation;
 use crate::integrations::mcp::product_server::{
     dispatch_product_mcp_request, ProductMcpAuthHeader, ProductMcpRequestContext, ProductMcpServer,
-    ProductMcpTokenValidation,
 };
 
 #[path = "tests/tool_contract.rs"]
@@ -304,7 +304,7 @@ async fn authenticated_dispatch(
             &request_context,
         )
         .expect("validate Workspace capability token");
-    if validation != ProductMcpTokenValidation::Valid {
+    if validation != McpCapabilityTokenValidation::Valid {
         return Err(AuthenticatedDispatchError::InvalidCapability);
     }
     Ok(dispatch_product_mcp_request(server, request_context, body)

--- a/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/auth.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/auth.rs
@@ -1,8 +1,10 @@
 use std::path::PathBuf;
 
-use crate::integrations::mcp::capability_token::McpCapabilityTokenSignature;
+use crate::integrations::mcp::capability_token::{
+    McpCapabilityTokenSignature, McpCapabilityTokenValidation,
+};
 use crate::integrations::mcp::product_server::{
-    ProductMcpAuth, ProductMcpAuthHeader, ProductMcpRequestContext, ProductMcpTokenValidation,
+    ProductMcpAuth, ProductMcpAuthHeader, ProductMcpRequestContext,
 };
 
 pub(crate) const SECRET_FILE_NAME: &str = "cowork-mcp-token.key";
@@ -36,7 +38,7 @@ impl CoworkMcpAuth {
         &self,
         header: ProductMcpAuthHeader<'_>,
         request: &ProductMcpRequestContext,
-    ) -> anyhow::Result<ProductMcpTokenValidation> {
+    ) -> anyhow::Result<McpCapabilityTokenValidation> {
         self.inner.validate_capability_header(header, request)
     }
 }
@@ -71,7 +73,7 @@ mod tests {
                 &request,
             )
             .expect("validate product token"),
-            ProductMcpTokenValidation::Valid,
+            McpCapabilityTokenValidation::Valid,
         );
 
         let wrong_scope = ProductMcpRequestContext::new("workspace-1", "session-1", "subagents");
@@ -83,7 +85,7 @@ mod tests {
                 &wrong_scope,
             )
             .expect("reject wrong scope"),
-            ProductMcpTokenValidation::Invalid,
+            McpCapabilityTokenValidation::ScopeMismatch,
         );
 
         let _ = std::fs::remove_dir_all(home);

--- a/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/mod.rs
@@ -18,9 +18,10 @@ use self::auth::CoworkMcpAuth;
 use self::context::CoworkMcpContext;
 use crate::domains::cowork::artifacts::CoworkArtifactRuntime;
 use crate::domains::cowork::runtime::CoworkRuntime;
+use crate::integrations::mcp::capability_token::McpCapabilityTokenValidation;
 use crate::integrations::mcp::product_server::{
     ProductMcpAuthHeader, ProductMcpContextError, ProductMcpDefinition, ProductMcpRequestContext,
-    ProductMcpServer, ProductMcpTokenValidation,
+    ProductMcpServer,
 };
 
 #[derive(Clone)]
@@ -56,7 +57,7 @@ impl ProductMcpServer for CoworkProductMcpServer {
         &self,
         header: ProductMcpAuthHeader<'_>,
         request: &ProductMcpRequestContext,
-    ) -> anyhow::Result<ProductMcpTokenValidation> {
+    ) -> anyhow::Result<McpCapabilityTokenValidation> {
         self.auth.validate_capability_header(header, request)
     }
 

--- a/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/tools_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/cowork/mcp/tools_tests.rs
@@ -8,10 +8,10 @@ use crate::domains::sessions::mcp_bindings::product_registry::{
     ProductMcpEndpointHandler, ProductMcpEndpointHandlerAdapter,
 };
 use crate::domains::workspaces::operation_gate::WorkspaceOperationKind;
+use crate::integrations::mcp::capability_token::McpCapabilityTokenValidation;
 use crate::integrations::mcp::product_server::{
     ProductMcpAuthHeader, ProductMcpContextError, ProductMcpDefinition,
     ProductMcpEndpointOperation, ProductMcpRequestContext, ProductMcpServer,
-    ProductMcpTokenValidation,
 };
 
 struct TestProductMcpServer;
@@ -28,8 +28,8 @@ impl ProductMcpServer for TestProductMcpServer {
         &self,
         _header: ProductMcpAuthHeader<'_>,
         _request: &ProductMcpRequestContext,
-    ) -> anyhow::Result<ProductMcpTokenValidation> {
-        Ok(ProductMcpTokenValidation::Valid)
+    ) -> anyhow::Result<McpCapabilityTokenValidation> {
+        Ok(McpCapabilityTokenValidation::Valid)
     }
 
     fn resolve_context(

--- a/anyharness/crates/anyharness-lib/src/domains/reviews/mcp/auth.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/reviews/mcp/auth.rs
@@ -1,8 +1,10 @@
 use std::path::PathBuf;
 
-use crate::integrations::mcp::capability_token::McpCapabilityTokenSignature;
+use crate::integrations::mcp::capability_token::{
+    McpCapabilityTokenSignature, McpCapabilityTokenValidation,
+};
 use crate::integrations::mcp::product_server::{
-    ProductMcpAuth, ProductMcpAuthHeader, ProductMcpRequestContext, ProductMcpTokenValidation,
+    ProductMcpAuth, ProductMcpAuthHeader, ProductMcpRequestContext,
 };
 
 const SECRET_FILE_NAME: &str = "review-mcp-token.key";
@@ -36,7 +38,7 @@ impl ReviewMcpAuth {
         &self,
         header: ProductMcpAuthHeader<'_>,
         request: &ProductMcpRequestContext,
-    ) -> anyhow::Result<ProductMcpTokenValidation> {
+    ) -> anyhow::Result<McpCapabilityTokenValidation> {
         self.inner.validate_capability_header(header, request)
     }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/reviews/mcp/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/reviews/mcp/mod.rs
@@ -12,9 +12,10 @@ use serde_json::Value;
 use self::auth::ReviewMcpAuth;
 use self::context::ReviewMcpContext;
 use crate::domains::reviews::runtime::ReviewRuntime;
+use crate::integrations::mcp::capability_token::McpCapabilityTokenValidation;
 use crate::integrations::mcp::product_server::{
     ProductMcpAuthHeader, ProductMcpContextError, ProductMcpDefinition, ProductMcpRequestContext,
-    ProductMcpServer, ProductMcpTokenValidation,
+    ProductMcpServer,
 };
 
 #[derive(Clone)]
@@ -41,7 +42,7 @@ impl ProductMcpServer for ReviewProductMcpServer {
         &self,
         header: ProductMcpAuthHeader<'_>,
         request: &ProductMcpRequestContext,
-    ) -> anyhow::Result<ProductMcpTokenValidation> {
+    ) -> anyhow::Result<McpCapabilityTokenValidation> {
         self.auth.validate_capability_header(header, request)
     }
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/mcp_bindings/product_registry.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/mcp_bindings/product_registry.rs
@@ -5,10 +5,11 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::domains::workspaces::operation_gate::WorkspaceOperationKind;
+use crate::integrations::mcp::capability_token::McpCapabilityTokenValidation;
 use crate::integrations::mcp::product_server::{
     dispatch_product_mcp_request, ProductMcpAuthHeader, ProductMcpDefinition,
     ProductMcpDispatchError, ProductMcpEndpointOperation, ProductMcpRequestContext,
-    ProductMcpServer, ProductMcpTokenValidation,
+    ProductMcpServer,
 };
 
 #[async_trait]
@@ -24,7 +25,7 @@ pub trait ProductMcpEndpointHandler: Send + Sync {
         &self,
         header: ProductMcpAuthHeader<'_>,
         request: &ProductMcpRequestContext,
-    ) -> anyhow::Result<ProductMcpTokenValidation>;
+    ) -> anyhow::Result<McpCapabilityTokenValidation>;
 
     async fn dispatch(
         &self,
@@ -94,7 +95,7 @@ where
         &self,
         header: ProductMcpAuthHeader<'_>,
         request: &ProductMcpRequestContext,
-    ) -> anyhow::Result<ProductMcpTokenValidation> {
+    ) -> anyhow::Result<McpCapabilityTokenValidation> {
         self.server.validate_capability_token(header, request)
     }
 
@@ -238,8 +239,8 @@ mod tests {
             &self,
             _header: ProductMcpAuthHeader<'_>,
             _request: &ProductMcpRequestContext,
-        ) -> anyhow::Result<ProductMcpTokenValidation> {
-            Ok(ProductMcpTokenValidation::Valid)
+        ) -> anyhow::Result<McpCapabilityTokenValidation> {
+            Ok(McpCapabilityTokenValidation::Valid)
         }
 
         fn resolve_context(
@@ -281,8 +282,8 @@ mod tests {
             &self,
             _header: ProductMcpAuthHeader<'_>,
             _request: &ProductMcpRequestContext,
-        ) -> anyhow::Result<ProductMcpTokenValidation> {
-            Ok(ProductMcpTokenValidation::Valid)
+        ) -> anyhow::Result<McpCapabilityTokenValidation> {
+            Ok(McpCapabilityTokenValidation::Valid)
         }
 
         async fn dispatch(

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/service/capability.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/service/capability.rs
@@ -1,0 +1,102 @@
+use super::SessionService;
+use crate::domains::sessions::model::SessionRecord;
+
+impl SessionService {
+    /// Whether a session may keep exercising a capability minted at its
+    /// launch: the row still exists, belongs to the workspace, and has not
+    /// been closed.
+    ///
+    /// Product MCP capability tokens are delivered as a static header for the
+    /// life of the session, so a session that outlives the token TTL would
+    /// otherwise lose its product tools mid-flight. The token's expiry is
+    /// defense-in-depth; this durable rule is the actual lifetime bound.
+    /// Dismissal is hiding, not termination, so a dismissed session keeps its
+    /// capability until it closes.
+    pub fn session_open_for_capability(
+        &self,
+        session_id: &str,
+        workspace_id: &str,
+    ) -> anyhow::Result<bool> {
+        Ok(self
+            .session_store
+            .find_by_id(session_id)?
+            .is_some_and(|record| session_record_open_for_capability(&record, workspace_id)))
+    }
+}
+
+fn session_record_open_for_capability(record: &SessionRecord, workspace_id: &str) -> bool {
+    record.workspace_id == workspace_id && record.status != "closed" && record.closed_at.is_none()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domains::sessions::model::SessionMcpBindingPolicy;
+
+    fn record(workspace_id: &str, status: &str, closed_at: Option<&str>) -> SessionRecord {
+        SessionRecord {
+            id: "session-1".to_string(),
+            workspace_id: workspace_id.to_string(),
+            agent_kind: "claude".to_string(),
+            native_session_id: None,
+            agent_auth_contexts: None,
+            requested_model_id: None,
+            current_model_id: None,
+            requested_mode_id: None,
+            current_mode_id: None,
+            title: None,
+            thinking_level_id: None,
+            thinking_budget_tokens: None,
+            status: status.to_string(),
+            created_at: "2026-08-16T00:00:00Z".to_string(),
+            updated_at: "2026-08-16T00:00:00Z".to_string(),
+            last_prompt_at: None,
+            closed_at: closed_at.map(str::to_string),
+            dismissed_at: None,
+            mcp_bindings_ciphertext: None,
+            mcp_binding_summaries_json: None,
+            mcp_binding_policy: SessionMcpBindingPolicy::InheritWorkspace,
+            system_prompt_append: None,
+            subagents_enabled: false,
+            action_capabilities_json: None,
+            origin: None,
+        }
+    }
+
+    #[test]
+    fn open_statuses_keep_the_capability() {
+        for status in ["starting", "idle", "running", "completed", "errored"] {
+            assert!(
+                session_record_open_for_capability(&record("workspace-1", status, None), "workspace-1"),
+                "status {status:?} should keep the capability",
+            );
+        }
+    }
+
+    #[test]
+    fn closed_sessions_lose_the_capability() {
+        assert!(!session_record_open_for_capability(
+            &record("workspace-1", "closed", None),
+            "workspace-1"
+        ));
+        assert!(!session_record_open_for_capability(
+            &record("workspace-1", "idle", Some("2026-08-16T01:00:00Z")),
+            "workspace-1"
+        ));
+    }
+
+    #[test]
+    fn foreign_workspace_rows_do_not_grant_the_capability() {
+        assert!(!session_record_open_for_capability(
+            &record("workspace-2", "idle", None),
+            "workspace-1"
+        ));
+    }
+
+    #[test]
+    fn dismissed_sessions_keep_the_capability_until_closed() {
+        let mut dismissed = record("workspace-1", "idle", None);
+        dismissed.dismissed_at = Some("2026-08-16T01:00:00Z".to_string());
+        assert!(session_record_open_for_capability(&dismissed, "workspace-1"));
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/service/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/service/mod.rs
@@ -9,6 +9,7 @@ use crate::domains::agents::model_snapshot::universe::ObservedUniverseSource;
 use crate::domains::workspaces::store::WorkspaceStore;
 
 pub(crate) mod attachments;
+mod capability;
 mod config;
 mod create;
 #[cfg(test)]

--- a/anyharness/crates/anyharness-lib/src/integrations/mcp/capability_token.rs
+++ b/anyharness/crates/anyharness-lib/src/integrations/mcp/capability_token.rs
@@ -46,6 +46,29 @@ pub struct ProductMcpCapabilityScope<'a> {
     pub product_mcp_id: &'a str,
 }
 
+/// Why a capability token was or was not accepted.
+///
+/// `Expired` is deliberately distinct from the invalid shapes: an expired
+/// token still proves the runtime minted it for exactly this scope, so the
+/// caller may consult durable session state before rejecting. The invalid
+/// shapes prove nothing and must always reject.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpCapabilityTokenValidation {
+    Valid,
+    /// Signature and scope verified; the embedded expiry is in the past.
+    Expired,
+    /// Missing parts, undecodable payload, or signature mismatch.
+    InvalidSignature,
+    /// Authentic token bound to a different workspace, session, or product.
+    ScopeMismatch,
+}
+
+impl McpCapabilityTokenValidation {
+    pub fn is_valid(self) -> bool {
+        matches!(self, Self::Valid)
+    }
+}
+
 #[derive(Clone)]
 pub struct McpCapabilityTokenIssuer {
     secret_path: PathBuf,
@@ -152,44 +175,55 @@ impl McpCapabilityTokenIssuer {
         &self,
         token: &str,
         scope: ProductMcpCapabilityScope<'_>,
-    ) -> anyhow::Result<bool> {
+    ) -> anyhow::Result<McpCapabilityTokenValidation> {
+        self.validate_product_mcp_token_at(token, scope, chrono::Utc::now().timestamp())
+    }
+
+    /// Validation against an injected clock (epoch seconds), so expiry
+    /// branches are testable without sleeping past a real TTL.
+    pub fn validate_product_mcp_token_at(
+        &self,
+        token: &str,
+        scope: ProductMcpCapabilityScope<'_>,
+        now_epoch_seconds: i64,
+    ) -> anyhow::Result<McpCapabilityTokenValidation> {
         let secret = self.load_or_create_secret()?;
         let mut parts = token.split('.');
         let Some(payload_encoded) = parts.next() else {
-            return Ok(false);
+            return Ok(McpCapabilityTokenValidation::InvalidSignature);
         };
         let Some(signature_encoded) = parts.next() else {
-            return Ok(false);
+            return Ok(McpCapabilityTokenValidation::InvalidSignature);
         };
         if parts.next().is_some() {
-            return Ok(false);
+            return Ok(McpCapabilityTokenValidation::InvalidSignature);
         }
 
         let expected = self.sign(&secret, payload_encoded.as_bytes());
         let Ok(provided) = URL_SAFE_NO_PAD.decode(signature_encoded) else {
-            return Ok(false);
+            return Ok(McpCapabilityTokenValidation::InvalidSignature);
         };
         if expected.as_slice().ct_eq(provided.as_slice()).unwrap_u8() != 1 {
-            return Ok(false);
+            return Ok(McpCapabilityTokenValidation::InvalidSignature);
         }
 
         let Ok(payload_json) = URL_SAFE_NO_PAD.decode(payload_encoded) else {
-            return Ok(false);
+            return Ok(McpCapabilityTokenValidation::InvalidSignature);
         };
         let Ok(payload) = serde_json::from_slice::<ProductCapabilityTokenPayload>(&payload_json)
         else {
-            return Ok(false);
+            return Ok(McpCapabilityTokenValidation::InvalidSignature);
         };
         if payload.workspace_id != scope.workspace_id
             || payload.session_id != scope.session_id
             || payload.product_mcp_id != scope.product_mcp_id
         {
-            return Ok(false);
+            return Ok(McpCapabilityTokenValidation::ScopeMismatch);
         }
-        if payload.exp < chrono::Utc::now().timestamp() {
-            return Ok(false);
+        if payload.exp < now_epoch_seconds {
+            return Ok(McpCapabilityTokenValidation::Expired);
         }
-        Ok(true)
+        Ok(McpCapabilityTokenValidation::Valid)
     }
 
     fn load_or_create_secret(&self) -> anyhow::Result<Vec<u8>> {
@@ -324,29 +358,108 @@ mod tests {
             })
             .unwrap();
 
-        assert!(issuer
-            .validate_product_mcp_token(
-                &token,
-                ProductMcpCapabilityScope {
-                    workspace_id: "workspace-1",
-                    session_id: "session-1",
-                    product_mcp_id: "reviews",
-                },
-            )
-            .unwrap());
-        assert!(!issuer
-            .validate_product_mcp_token(
-                &token,
-                ProductMcpCapabilityScope {
-                    workspace_id: "workspace-1",
-                    session_id: "session-1",
-                    product_mcp_id: "subagents",
-                },
-            )
-            .unwrap());
+        assert_eq!(
+            issuer
+                .validate_product_mcp_token(
+                    &token,
+                    ProductMcpCapabilityScope {
+                        workspace_id: "workspace-1",
+                        session_id: "session-1",
+                        product_mcp_id: "reviews",
+                    },
+                )
+                .unwrap(),
+            McpCapabilityTokenValidation::Valid,
+        );
+        assert_eq!(
+            issuer
+                .validate_product_mcp_token(
+                    &token,
+                    ProductMcpCapabilityScope {
+                        workspace_id: "workspace-1",
+                        session_id: "session-1",
+                        product_mcp_id: "subagents",
+                    },
+                )
+                .unwrap(),
+            McpCapabilityTokenValidation::ScopeMismatch,
+        );
         assert!(!issuer
             .validate_workspace_session_token(&token, "workspace-1", "session-1")
             .unwrap());
+
+        let _ = std::fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn product_token_expiry_is_judged_against_the_injected_clock() {
+        let home = runtime_home("product-clock");
+        let ttl_seconds = 60 * 60 * 12;
+        let issuer = McpCapabilityTokenIssuer::new(
+            home.clone(),
+            "product-clock.key",
+            McpCapabilityTokenSignature::HmacSha256,
+            ttl_seconds,
+        );
+        let scope = ProductMcpCapabilityScope {
+            workspace_id: "workspace-1",
+            session_id: "session-1",
+            product_mcp_id: "workspace",
+        };
+
+        let minted_at = chrono::Utc::now().timestamp();
+        let token = issuer.mint_product_mcp_token(scope.clone()).unwrap();
+
+        assert_eq!(
+            issuer
+                .validate_product_mcp_token_at(&token, scope.clone(), minted_at + ttl_seconds - 60)
+                .unwrap(),
+            McpCapabilityTokenValidation::Valid,
+        );
+        // Thirty hours in: the fixed TTL is long past, and the verdict says
+        // exactly that instead of collapsing into a generic rejection.
+        assert_eq!(
+            issuer
+                .validate_product_mcp_token_at(&token, scope, minted_at + 60 * 60 * 30)
+                .unwrap(),
+            McpCapabilityTokenValidation::Expired,
+        );
+
+        let _ = std::fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn tampered_product_tokens_are_invalid_not_expired() {
+        let home = runtime_home("product-tamper");
+        let issuer = McpCapabilityTokenIssuer::new(
+            home.clone(),
+            "product-tamper.key",
+            McpCapabilityTokenSignature::HmacSha256,
+            60,
+        );
+        let scope = ProductMcpCapabilityScope {
+            workspace_id: "workspace-1",
+            session_id: "session-1",
+            product_mcp_id: "workspace",
+        };
+        let token = issuer.mint_product_mcp_token(scope.clone()).unwrap();
+        let (payload, signature) = token.split_once('.').unwrap();
+
+        for tampered in [
+            String::new(),
+            "payload-only".to_string(),
+            format!("{token}.extra"),
+            format!("{payload}.not-base64!"),
+            format!("{payload}A.{signature}"),
+        ] {
+            assert_eq!(
+                issuer
+                    .validate_product_mcp_token(&tampered, scope.clone())
+                    .unwrap(),
+                McpCapabilityTokenValidation::InvalidSignature,
+                "token {tampered:?} should be invalid",
+            );
+        }
 
         let _ = std::fs::remove_dir_all(home);
     }

--- a/anyharness/crates/anyharness-lib/src/integrations/mcp/product_server/auth.rs
+++ b/anyharness/crates/anyharness-lib/src/integrations/mcp/product_server/auth.rs
@@ -1,12 +1,15 @@
 use std::path::PathBuf;
 
 use crate::integrations::mcp::capability_token::{
-    McpCapabilityTokenIssuer, McpCapabilityTokenSignature, ProductMcpCapabilityScope,
+    McpCapabilityTokenIssuer, McpCapabilityTokenSignature, McpCapabilityTokenValidation,
+    ProductMcpCapabilityScope,
 };
-use crate::integrations::mcp::product_server::{
-    ProductMcpAuthHeader, ProductMcpRequestContext, ProductMcpTokenValidation,
-};
+use crate::integrations::mcp::product_server::{ProductMcpAuthHeader, ProductMcpRequestContext};
 
+/// Defense-in-depth only, not the session-lifetime bound. A token past this
+/// TTL still proves its scope; the HTTP dispatch layer then consults durable
+/// session state and keeps serving a session that is still open. The TTL
+/// exists so a token whose session row is gone entirely stops working.
 const TOKEN_TTL_SECONDS: i64 = 60 * 60 * 12;
 
 #[derive(Clone)]
@@ -50,8 +53,8 @@ impl ProductMcpAuth {
         &self,
         header: ProductMcpAuthHeader<'_>,
         request: &ProductMcpRequestContext,
-    ) -> anyhow::Result<ProductMcpTokenValidation> {
-        let valid = match header {
+    ) -> anyhow::Result<McpCapabilityTokenValidation> {
+        match header {
             ProductMcpAuthHeader::Product { value } => {
                 self.product_issuer.validate_product_mcp_token(
                     value,
@@ -60,14 +63,9 @@ impl ProductMcpAuth {
                         session_id: &request.session_id,
                         product_mcp_id: &request.product_mcp_id,
                     },
-                )?
+                )
             }
-        };
-        Ok(if valid {
-            ProductMcpTokenValidation::Valid
-        } else {
-            ProductMcpTokenValidation::Invalid
-        })
+        }
     }
 }
 
@@ -106,7 +104,7 @@ mod tests {
                 &request,
             )
             .expect("validate product header"),
-            ProductMcpTokenValidation::Valid,
+            McpCapabilityTokenValidation::Valid,
         );
 
         let wrong_scope_request =
@@ -119,7 +117,47 @@ mod tests {
                 &wrong_scope_request,
             )
             .expect("reject wrong scope"),
-            ProductMcpTokenValidation::Invalid,
+            McpCapabilityTokenValidation::ScopeMismatch,
+        );
+
+        let _ = std::fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn expired_tokens_report_expired_not_invalid() {
+        let home = runtime_home("expired");
+        let auth = ProductMcpAuth::new(
+            home.clone(),
+            "test-product.key",
+            McpCapabilityTokenSignature::HmacSha256,
+            "reviews",
+        );
+        // Same secret file and product id, negative TTL: an authentic token
+        // that is already past its expiry the moment it is minted.
+        let expired_issuer = McpCapabilityTokenIssuer::new(
+            home.clone(),
+            "test-product.key",
+            McpCapabilityTokenSignature::HmacSha256,
+            -60,
+        );
+        let expired_token = expired_issuer
+            .mint_product_mcp_token(ProductMcpCapabilityScope {
+                workspace_id: "workspace-1",
+                session_id: "session-1",
+                product_mcp_id: "reviews",
+            })
+            .expect("mint expired product token");
+        let request = ProductMcpRequestContext::new("workspace-1", "session-1", "reviews");
+
+        assert_eq!(
+            auth.validate_capability_header(
+                ProductMcpAuthHeader::Product {
+                    value: &expired_token,
+                },
+                &request,
+            )
+            .expect("validate expired header"),
+            McpCapabilityTokenValidation::Expired,
         );
 
         let _ = std::fs::remove_dir_all(home);

--- a/anyharness/crates/anyharness-lib/src/integrations/mcp/product_server/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/integrations/mcp/product_server/mod.rs
@@ -9,6 +9,6 @@ pub use endpoint::ProductMcpEndpointOperation;
 pub use server::{
     dispatch_product_mcp_request, initialize_response, ProductMcpAuthHeader,
     ProductMcpContextError, ProductMcpDispatchError, ProductMcpRequestContext, ProductMcpServer,
-    ProductMcpTokenValidation, JSON_RPC_INVALID_PARAMS, JSON_RPC_INVALID_REQUEST,
-    JSON_RPC_METHOD_NOT_FOUND, JSON_RPC_PARSE_ERROR, PRODUCT_MCP_TOKEN_HEADER_NAME,
+    JSON_RPC_INVALID_PARAMS, JSON_RPC_INVALID_REQUEST, JSON_RPC_METHOD_NOT_FOUND,
+    JSON_RPC_PARSE_ERROR, PRODUCT_MCP_TOKEN_HEADER_NAME,
 };

--- a/anyharness/crates/anyharness-lib/src/integrations/mcp/product_server/server.rs
+++ b/anyharness/crates/anyharness-lib/src/integrations/mcp/product_server/server.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use serde_json::{json, Value};
 
 use super::definition::ProductMcpDefinition;
+use crate::integrations::mcp::capability_token::McpCapabilityTokenValidation;
 use crate::integrations::mcp::json_rpc::{
     jsonrpc_error, jsonrpc_result, CallToolParams, InitializeParams, JsonRpcRequest,
 };
@@ -74,18 +75,6 @@ pub enum ProductMcpAuthHeader<'a> {
     Product { value: &'a str },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ProductMcpTokenValidation {
-    Valid,
-    Invalid,
-}
-
-impl ProductMcpTokenValidation {
-    pub fn is_valid(self) -> bool {
-        matches!(self, Self::Valid)
-    }
-}
-
 // ── Initialize response ──────────────────────────────────────────────────────
 
 pub fn initialize_response(
@@ -119,7 +108,7 @@ pub trait ProductMcpServer: Send + Sync {
         &self,
         header: ProductMcpAuthHeader<'_>,
         request: &ProductMcpRequestContext,
-    ) -> anyhow::Result<ProductMcpTokenValidation>;
+    ) -> anyhow::Result<McpCapabilityTokenValidation>;
 
     fn resolve_context(
         &self,
@@ -274,8 +263,8 @@ mod tests {
             &self,
             _header: ProductMcpAuthHeader<'_>,
             _request: &ProductMcpRequestContext,
-        ) -> anyhow::Result<ProductMcpTokenValidation> {
-            Ok(ProductMcpTokenValidation::Valid)
+        ) -> anyhow::Result<McpCapabilityTokenValidation> {
+            Ok(McpCapabilityTokenValidation::Valid)
         }
 
         fn resolve_context(
@@ -361,8 +350,8 @@ mod tests {
             &self,
             _header: ProductMcpAuthHeader<'_>,
             _request: &ProductMcpRequestContext,
-        ) -> anyhow::Result<ProductMcpTokenValidation> {
-            Ok(ProductMcpTokenValidation::Valid)
+        ) -> anyhow::Result<McpCapabilityTokenValidation> {
+            Ok(McpCapabilityTokenValidation::Valid)
         }
 
         fn resolve_context(

--- a/anyharness/crates/anyharness-lib/src/observability/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/observability/mod.rs
@@ -14,6 +14,14 @@ pub const AGENT_STDERR_TRACING_TARGET: &str = "anyharness.agent_stderr";
 /// changing ordinary runtime error grouping.
 pub const RUNTIME_INCIDENT_TRACING_TARGET: &str = "anyharness.runtime_incident";
 
+/// Every product MCP capability-token rejection, with the session, workspace,
+/// endpoint slug, and rejection reason as fields — and never the token itself.
+///
+/// Keep this target stable: expired-token incidents surface at the agent as a
+/// generic client failure, so this event is the one server-side trace that a
+/// session's product tools died of auth rather than of the tool call.
+pub const PRODUCT_MCP_AUTH_REJECTED_TRACING_TARGET: &str = "anyharness.product_mcp_auth_rejected";
+
 /// The gen-2 workflow engine's named events (the Workflows ADR observability
 /// table). Each target maps to one named diagnostics event in telemetry
 /// setup; keep both sides stable so dashboards survive refactors.

--- a/anyharness/crates/anyharness/src/telemetry.rs
+++ b/anyharness/crates/anyharness/src/telemetry.rs
@@ -3,7 +3,8 @@ use std::{borrow::Cow, path::PathBuf, sync::Arc, time::Duration};
 use anyharness_lib::{
     app::default_runtime_home,
     observability::{
-        AGENT_STDERR_TRACING_TARGET, RUNTIME_INCIDENT_TRACING_TARGET,
+        AGENT_STDERR_TRACING_TARGET, PRODUCT_MCP_AUTH_REJECTED_TRACING_TARGET,
+        RUNTIME_INCIDENT_TRACING_TARGET,
         WORKFLOW_BOOT_FENCE_TRACING_TARGET, WORKFLOW_INTERJECTION_HELD_TRACING_TARGET,
         WORKFLOW_INVARIANT_VIOLATION_TRACING_TARGET,
         WORKFLOW_NODE_INTERACTION_REQUESTED_TRACING_TARGET,
@@ -378,6 +379,10 @@ fn anyharness_target_mappings() -> TargetMappingConfig {
         TargetMapping::span_event(
             RUNTIME_INCIDENT_TRACING_TARGET,
             "anyharness.runtime.incident",
+        ),
+        TargetMapping::span_event(
+            PRODUCT_MCP_AUTH_REJECTED_TRACING_TARGET,
+            "anyharness.product_mcp.auth.rejected",
         ),
         TargetMapping::span_event(
             WORKFLOW_RUN_STARTED_TRACING_TARGET,

--- a/anyharness/crates/anyharness/src/telemetry/tests.rs
+++ b/anyharness/crates/anyharness/src/telemetry/tests.rs
@@ -12,7 +12,10 @@ use crate::{
     cli::Commands,
     commands::{install_agents::InstallAgentsArgs, serve::ServeArgs},
 };
-use anyharness_lib::observability::{AGENT_STDERR_TRACING_TARGET, RUNTIME_INCIDENT_TRACING_TARGET};
+use anyharness_lib::observability::{
+    AGENT_STDERR_TRACING_TARGET, PRODUCT_MCP_AUTH_REJECTED_TRACING_TARGET,
+    RUNTIME_INCIDENT_TRACING_TARGET,
+};
 use proliferate_diagnostics_client::ResolvedRecordName;
 use proliferate_diagnostics_protocol::v1::types::{DetailedKindV1, StandardStreamV1};
 
@@ -453,7 +456,7 @@ fn install_command_log_path_lands_under_runtime_home_logs() {
 #[test]
 fn anyharness_targets_resolve_to_record_names_by_table_then_pass_through() {
     let mappings = anyharness_target_mappings();
-    let cases: [(&str, ResolvedRecordName<'_>); 7] = [
+    let cases: [(&str, ResolvedRecordName<'_>); 8] = [
         (
             AGENT_STDERR_TRACING_TARGET,
             ResolvedRecordName::Mapped {
@@ -466,6 +469,14 @@ fn anyharness_targets_resolve_to_record_names_by_table_then_pass_through() {
             RUNTIME_INCIDENT_TRACING_TARGET,
             ResolvedRecordName::Mapped {
                 name: "anyharness.runtime.incident",
+                kind: DetailedKindV1::SpanEvent,
+                stream: None,
+            },
+        ),
+        (
+            PRODUCT_MCP_AUTH_REJECTED_TRACING_TARGET,
+            ResolvedRecordName::Mapped {
+                name: "anyharness.product_mcp.auth.rejected",
                 kind: DetailedKindV1::SpanEvent,
                 stream: None,
             },

--- a/specs/codebase/platforms/product/agent-features/servers.md
+++ b/specs/codebase/platforms/product/agent-features/servers.md
@@ -269,7 +269,11 @@ artifact_namespace
 
 Runtime bearer auth proves the HTTP caller can access protected AnyHarness
 routes. The product MCP capability token proves the MCP call was minted for a
-specific workspace/session/product capability.
+specific workspace/session/product capability. The token's expiry is
+defense-in-depth only: because the header is static for the life of the
+session, the shared endpoint accepts an expired-but-authentic token while the
+bound session is still open, and rejects with `403` plus a cause-naming body
+(never `401`, which triggers MCP client OAuth discovery) once it is not.
 
 ### `context.rs`
 

--- a/specs/codebase/platforms/product/mcp-runtime.md
+++ b/specs/codebase/platforms/product/mcp-runtime.md
@@ -215,6 +215,20 @@ POST -> validate capability header
         return JSON-RPC response or no-content response
 ```
 
+Capability validation returns a verdict, not a boolean. The token's embedded
+TTL is defense-in-depth, not the session-lifetime bound: the header is static
+for the life of the session, so an expired-but-authentic token defers to the
+sessions domain (`SessionService::session_open_for_capability`) and keeps
+serving while the session row exists, matches the workspace, and is not
+closed. Missing, malformed, mis-scoped, and expired-with-closed-session
+tokens are rejected with `403` and a cause-naming RFC 7807 body — never
+`401`, which MCP clients treat as an OAuth challenge and answer with
+authorization-server discovery that masks the real cause. Every rejection
+emits the named `anyharness.product_mcp.auth.rejected` tracing event with
+the session, workspace, endpoint slug, and reason
+(`missing | expired | invalid-signature | scope-mismatch`), and never the
+token value.
+
 Target shared owner for transport scaffolding:
 
 ```text


### PR DESCRIPTION
## Summary

Product MCP capability tokens (workspace/cowork/reviews tools) are minted once at session launch, delivered to the agent as a **static header** baked into the session's MCP config, and expired after a fixed 12h TTL. Nothing ever re-minted them, so any session older than 12h lost every product MCP tool — and the failure surfaced as garbage: the 401 sent the MCP client into OAuth discovery against the runtime root, and axum's empty 404 for the missing well-known routes became `HTTP 404: Invalid OAuth error response: JSON Parse error: Unexpected EOF`. The 401s also logged nothing server-side. (Live incident: orchestrator session `554b8edc`, launched 02:13Z, token expired 14:13Z, dead from 14:24Z onward.)

Three fixes, one family:

1. **Sessions no longer outlive their tokens.** Token validation now returns a reasoned verdict (`Valid | Expired | InvalidSignature | ScopeMismatch`) instead of a boolean. An **expired-but-authentic** token — signature and workspace/session/product scope verified — defers to the sessions domain: `SessionService::session_open_for_capability` accepts it while the session row exists, matches the workspace, and is not closed. A session that is alive and prompting at hour 30 keeps working; the moment it closes (or its row is deleted), the expired token dies.
2. **Error masking killed.** Every capability rejection is now **403** with a cause-naming RFC 7807 body, never 401. Missing header, malformed/bad-signature, scope mismatch, and expired-with-closed-session each get a distinct `detail` naming the real cause.
3. **Auth failures are observable.** Every rejection emits the named tracing event `anyharness.product_mcp.auth.rejected` (target `anyharness.product_mcp_auth_rejected`, mapped in telemetry setup per the #1849/#1850 named-event lineage) with `session_id`, `workspace_id`, `slug`, and `reason ∈ {missing, expired, invalid-signature, scope-mismatch}` — and never the token value. Expired-but-live grace acceptances additionally log at debug.

### Why session-liveness (and not the other candidates)

- **Re-mint + re-inject on resume/reconfigure**: cannot help a session that never resumes — the observed incident is a continuously-running session crossing the TTL mid-flight; refreshing the binding requires a session reconfigure the client never performs. Highest complexity, still leaves the exact observed gap.
- **Lifetime-scaled TTL + revoke-on-close**: any fixed TTL re-creates the same cliff further out, and revocation needs a new revocation store. The sessions table already *is* the revocation store — which is what this PR uses.
- **Chosen — validate against session liveness, exp as defense-in-depth**: the token already cryptographically binds workspace+session+product (HMAC-SHA256, constant-time compare, unchanged), and the domain layer re-verifies session↔workspace on every call (`verify_caller_workspace`). The honest freshness question is "is the bound session still open", answered from durable state on the expired path only; the fresh-token fast path is unchanged.

**Leaked-token threat model.** The server binds loopback-only, and the signing key lives at `<runtime_home>/secrets/workspace-mcp-token.key` (0600). Any local attacker positioned to steal a token can read the key and mint arbitrary tokens, so token theft adds no marginal capability. Today a stolen token replays for up to 12h regardless of session state; after this change an expired token dies with its session, and a fresh one still expires within 12h if the session row vanishes. Strictly narrower. A "recently active" recency gate was considered and rejected: it defends nothing in this threat model and would kill tools mid-turn for sessions idling through long builds. Dismissal is hiding, not termination, so dismissed sessions keep their capability until closed.

### Client-side proof for the 401→403 switch

From the shipped Claude Code binary (v2.1.212, MCP transport `send()`, extracted via `strings`):

```js
if (!n.ok) {
  let o = await n.text().catch(() => null);
  if (n.status === 401 && this._authProvider) {
    let { resourceMetadataUrl: i, scope: s } = uzt(n);
    ...OAuth discovery / authorization flow...
  }
  throw Error(`Error POSTing to endpoint (HTTP ${n.status}): ${o}`);
}
```

Only `401` diverts into OAuth discovery (the masking path). Any other status throws with the response body verbatim, so the client-visible error becomes e.g. `Error POSTing to endpoint (HTTP 403): {"title":"Forbidden","status":403,"detail":"Product MCP capability token expired and its session is no longer open. Start or resume the session to mint a fresh token.","code":"WORKSPACE_MCP_UNAUTHORIZED"}` — the real cause, named.

## Testing

Tier 1 (unit/integration in-crate) per specs/TESTING.md — the behavior is a pure server-side auth rule, fully exercisable against real `AppState` + in-memory SQLite and the real Workspace MCP endpoint registry; no sandbox or live agent needed.

- **Regression (a session older than the TTL still validates):** `app::tests::product_mcp_auth_tests::expired_capability_token_keeps_serving_an_open_session` — real `AppState`, seeded workspace + `idle` session, token minted with the same secret file but already-past expiry (negative TTL injected via the issuer constructor — no sleeps), `tools/list` dispatch returns 200.
- Closed-session rejection: `expired_capability_token_is_forbidden_once_the_session_closes` (403, detail contains "expired", code `WORKSPACE_MCP_UNAUTHORIZED`).
- Missing header: `missing_capability_token_is_forbidden_with_named_cause` (403, detail names the header).
- Garbage token with an OPEN session: `garbage_capability_token_is_forbidden_even_for_an_open_session` (liveness never rescues an unauthentic token).
- Verdict-level units: injected-clock expiry (`product_token_expiry_is_judged_against_the_injected_clock`: valid at TTL−60s, expired at hour 30), tamper matrix (`tampered_product_tokens_are_invalid_not_expired`), scope mismatch, expired-vs-invalid separation at the auth wrapper (`expired_tokens_report_expired_not_invalid`), and the pure liveness predicate (open statuses / closed / foreign workspace / dismissed).
- Telemetry mapping: `anyharness_targets_resolve_to_record_names_by_table_then_pass_through` extended with the new target.

Results (local, macOS, scrubbed of leaked `PROLIFERATE_*`/`ANYHARNESS_*` env):

- `cargo test -p anyharness-lib` → `2094 passed; 1 failed` — the one failure is `route_auth::...::the_sweep_removes_only_abandoned_and_old_scratch_roots`, **pre-existing on this machine**: it fails identically at pristine `origin/main` (`caf288f57`, verified by checkout + rerun) and is untouched by this diff (mtime-sweep behavior, passes on Linux CI). The dispatch tests were subsequently moved to `app/tests/product_mcp_auth_tests.rs` to stay under the PROD-SIZE-1 line cap; all 4 re-verified green at the final head.
- `cargo test -p anyharness` → `33 passed; 0 failed`.

Negative controls (each fix reverted, watched fail, restored):

1. Expired arm hard-rejects (liveness ignored) → `expired_capability_token_keeps_serving_an_open_session` **fails**.
2. `forbidden` flipped back to `unauthorized` → all three 403 assertions **fail**.
3. Telemetry `TargetMapping` removed → mapping test **fails**.

## Observability

New named event per the runtime named-event lineage: constant `PRODUCT_MCP_AUTH_REJECTED_TRACING_TARGET` (`anyharness.product_mcp_auth_rejected`) in `observability/mod.rs`, mapped to diagnostics record `anyharness.product_mcp.auth.rejected` in `telemetry.rs`, emitted at `warn` on every capability rejection with `session_id`, `workspace_id`, `slug`, `reason`. Token values never appear in any log call (secret-log check passes). One grep now answers what took hours of forensics tonight.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- `python3 scripts/check_docs.py` → passed (226 files); `check_design_attribution.py`, `check_agent_auth_secret_logs.py` → passed.
- Touched files are rustfmt-clean (`rustfmt --check` per file).
- Follow-ups recorded, not expanded here: `mint_workspace_session_token`/`validate_workspace_session_token` and the `LegacySha256Dot` signature variant have no production callers outside `capability_token.rs` (dead-code candidates); the runtime could additionally serve minimal OAuth well-known metadata for clients that still probe it.
