### PR TITLE
fix(product): consolidate completed transcript history

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.test.tsx
@@ -7,12 +7,17 @@ import { createTranscriptState } from "@anyharness/sdk";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   assistantItem,
+  createPro292CompletedTurnFixture,
   terminalItem,
   toolItem,
   turnRecord,
   userItem,
 } from "#product/domain/chats/transcript/transcript-presentation-test-fixtures";
 import { buildTurnPresentation } from "#product/domain/chats/transcript/transcript-presentation";
+import {
+  buildTranscriptRowModel,
+  type TranscriptRow,
+} from "#product/domain/chats/transcript/transcript-row-model";
 import {
   constrainTurnItemSequencePresentation,
   resolveTurnItemFrontierBlockKey,
@@ -104,6 +109,64 @@ describe("CompletedHistorySequence", () => {
     expect(nestedDetailPanel).not.toBeUndefined();
     expect(nestedDetailPanel?.className).toMatch(/(?:^|\s)border(?:\s|$)/);
     expect(nestedDetailPanel?.className).toContain("rounded-md");
+  });
+
+  it("hydrates the PRO-292 projected rows with one whole-turn disclosure", async () => {
+    const user = userEvent.setup();
+    const fixture = createPro292CompletedTurnFixture();
+    const projectedTurnItems = buildTranscriptRowModel({
+      activeSessionId: fixture.transcript.sessionMeta.sessionId,
+      transcript: fixture.transcript,
+      visibleOptimisticPrompt: null,
+      latestTurnId: fixture.turn.turnId,
+      latestTurnHasAssistantRenderableContent: true,
+    }).filter(
+      (row): row is Extract<TranscriptRow, { kind: "turn" }> => row.kind === "turn",
+    );
+
+    const { container } = render(
+      <>
+        {projectedTurnItems.map((row) => (
+          <TurnItemSequence
+            key={row.key}
+            turn={fixture.turn}
+            transcript={fixture.transcript}
+            isTurnComplete
+            presentation={row.renderPresentation}
+            autoFollowCollapsedActionBlockId={null}
+            tailAssistantProseRootId={row.presentation.finalAssistantItemId}
+            completedHistoryLabel={null}
+            animateActivityEntry={false}
+            animateAssistantRevealItemId={null}
+            showCompletedArtifactFallback={false}
+            workspaceId={null}
+            onOpenArtifact={vi.fn()}
+          />
+        ))}
+      </>,
+    );
+
+    const disclosures = screen.getAllByRole("button", { name: "Worked for 7m 2s" });
+    expect(disclosures).toHaveLength(1);
+    await user.click(disclosures[0]!);
+
+    const completedHistorySequences = container.querySelectorAll(
+      "[data-completed-history-sequence]",
+    );
+    expect(completedHistorySequences).toHaveLength(1);
+    expect(completedHistorySequences[0]?.children).toHaveLength(8);
+    for (const assistantId of fixture.assistantItemIds.slice(0, -1)) {
+      expect(container.querySelectorAll(
+        `[data-rendered-transcript-item="${assistantId}"]`,
+      )).toHaveLength(1);
+    }
+    for (const receiptId of fixture.mutationReceiptItemIds) {
+      const receipt = container.querySelector(
+        `[data-rendered-transcript-item="${receiptId}"]`,
+      );
+      expect(receipt).not.toBeNull();
+      expect(completedHistorySequences[0]?.contains(receipt)).toBe(false);
+    }
   });
 });
 

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx
@@ -4,6 +4,8 @@ import { createRef } from "react";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TranscriptVirtualRow } from "#product/domain/chats/transcript/transcript-virtual-rows";
+import { createPro292CompletedTurnFixture } from "#product/domain/chats/transcript/transcript-presentation-test-fixtures";
+import { buildTranscriptRowModel } from "#product/domain/chats/transcript/transcript-row-model";
 import { VirtualizedTranscriptRowList } from "./VirtualizedTranscriptRowList";
 
 const observedVirtualizerOptions = vi.hoisted(() => [] as Array<{
@@ -47,9 +49,9 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-function makeProps() {
+function makeProps(rows: readonly TranscriptVirtualRow[] = ROWS) {
   return {
-    rows: ROWS,
+    rows,
     selectionRootRef: createRef<HTMLDivElement>(),
     hasOlderHistory: false,
     isLoadingOlderHistory: false,
@@ -112,6 +114,54 @@ describe("VirtualizedTranscriptRowList", () => {
     expect(observedVirtualizerOptions.length).toBeGreaterThan(optionCountBeforeScroll);
     expect(nextOptions?.getItemKey).toBe(firstOptions?.getItemKey);
     expect(nextOptions?.estimateSize).toBe(firstOptions?.estimateSize);
+  });
+
+  it("keeps PRO-292 production row keys unique across hydration and upward scroll", () => {
+    const fixture = createPro292CompletedTurnFixture();
+    const rows = buildTranscriptRowModel({
+      activeSessionId: fixture.transcript.sessionMeta.sessionId,
+      transcript: fixture.transcript,
+      visibleOptimisticPrompt: null,
+      latestTurnId: fixture.turn.turnId,
+      latestTurnHasAssistantRenderableContent: true,
+    });
+    const expectedKeys = rows.map((row) => row.key);
+    const rendered = render(
+      <VirtualizedTranscriptRowList {...makeProps(rows)} />,
+    );
+    const initialOptions = observedVirtualizerOptions.at(-1);
+    const initialGetItemKey = initialOptions?.getItemKey as
+      | ((index: number) => unknown)
+      | undefined;
+    expect(initialGetItemKey).toBeTruthy();
+
+    // The wrapper delegates to the real TanStack virtualizer. Evaluating its
+    // configured accessor for every production row preserves the ordered
+    // index-to-row mapping that measurement and scroll identity consume.
+    const initialKeys = rows.map((_, index) => initialGetItemKey!(index));
+    expect(initialKeys).toEqual(expectedKeys);
+    expect(new Set(initialKeys).size).toBe(initialKeys.length);
+
+    const optionCountBeforeScroll = observedVirtualizerOptions.length;
+    const viewport = getViewport(rendered.container);
+    Object.defineProperty(viewport, "clientHeight", { value: 300, configurable: true });
+    Object.defineProperty(viewport, "scrollHeight", { value: 2_000, configurable: true });
+    viewport.scrollTop = 1_200;
+    act(() => {
+      fireEvent.wheel(viewport, { deltaY: -80 });
+      viewport.scrollTop = 1_120;
+      fireEvent.scroll(viewport);
+    });
+
+    const postScrollOptions = observedVirtualizerOptions.at(-1);
+    const postScrollGetItemKey = postScrollOptions?.getItemKey as
+      | ((index: number) => unknown)
+      | undefined;
+    expect(observedVirtualizerOptions.length).toBeGreaterThan(optionCountBeforeScroll);
+    expect(postScrollGetItemKey).toBe(initialGetItemKey);
+    const postScrollKeys = rows.map((_, index) => postScrollGetItemKey!(index));
+    expect(postScrollKeys).toEqual(expectedKeys);
+    expect(new Set(postScrollKeys).size).toBe(postScrollKeys.length);
   });
 
   it("rotates measurement accessors only when ordered row composition changes", () => {

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-presentation-test-fixtures.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-presentation-test-fixtures.ts
@@ -1,7 +1,175 @@
-import type { ContentPart, ToolCallItem, TurnRecord } from "@anyharness/sdk";
+import {
+  createTranscriptState,
+  type ContentPart,
+  type ToolCallItem,
+  type TranscriptState,
+  type TurnRecord,
+} from "@anyharness/sdk";
+import { buildTurnPresentation, type TurnDisplayBlock } from "./transcript-presentation";
+import { buildTranscriptRowModel, type TranscriptRow } from "./transcript-row-model";
+export const PRO_292_TURN_ID = "e9298357-b2a2-411f-b9c4-7bde31ee4087";
+export const PRO_292_TURN_STARTED_AT = "2026-08-15T22:09:57.836816Z";
+export const PRO_292_TURN_COMPLETED_AT = "2026-08-15T22:17:00.016779Z";
+
+export interface Pro292CompletedTurnFixture {
+  transcript: TranscriptState;
+  turn: TurnRecord;
+  itemIds: string[];
+  toolItemIds: string[];
+  assistantItemIds: string[];
+  userItemId: string;
+  completedHistoryItemIds: string[];
+  mutationReceiptItemIds: string[];
+}
+
+/**
+ * Reproduces the durable PRO-292 turn shape through production presentation
+ * classification: 152 unique items (146 tools, five assistant messages, and
+ * one user message), with four history runs separated by Agent Operations
+ * mutation receipts. Row output is intentionally left to the production
+ * transcript projection.
+ */
+export function createPro292CompletedTurnFixture(): Pro292CompletedTurnFixture {
+  const transcript = createTranscriptState("pro-292-session");
+  const turn: TurnRecord = {
+    turnId: PRO_292_TURN_ID,
+    itemOrder: [],
+    startedAt: PRO_292_TURN_STARTED_AT,
+    completedAt: PRO_292_TURN_COMPLETED_AT,
+    stopReason: "end_turn",
+    fileBadges: [],
+  };
+  transcript.turnOrder.push(turn.turnId);
+  transcript.turnsById[turn.turnId] = turn;
+
+  const itemIds: string[] = [];
+  const toolItemIds: string[] = [];
+  const assistantItemIds: string[] = [];
+  const completedHistoryItemIds: string[] = [];
+  const mutationReceiptItemIds: string[] = [];
+  let startedSeq = 8_454;
+
+  const appendItem = (item: TranscriptState["itemsById"][string]) => {
+    transcript.itemsById[item.itemId] = item;
+    turn.itemOrder.push(item.itemId);
+    itemIds.push(item.itemId);
+    startedSeq += 1;
+  };
+
+  const userItemId = "pro-292-user";
+  appendItem(userItem(userItemId, turn.turnId, startedSeq));
+
+  const historyToolCounts = [36, 36, 36, 35];
+  let historyToolIndex = 0;
+  historyToolCounts.forEach((toolCount, runIndex) => {
+    const assistantId = `pro-292-history-assistant-${runIndex + 1}`;
+    appendItem(assistantItem(assistantId, turn.turnId, startedSeq));
+    assistantItemIds.push(assistantId);
+    completedHistoryItemIds.push(assistantId);
+
+    for (let index = 0; index < toolCount; index += 1) {
+      historyToolIndex += 1;
+      const toolId = `pro-292-history-tool-${historyToolIndex}`;
+      appendItem(toolItem(toolId, turn.turnId, startedSeq, "file_read"));
+      toolItemIds.push(toolId);
+      completedHistoryItemIds.push(toolId);
+    }
+
+    if (runIndex < historyToolCounts.length - 1) {
+      const receiptId = `pro-292-mutation-receipt-${runIndex + 1}`;
+      appendItem({
+        ...toolItem(receiptId, turn.turnId, startedSeq, "other"),
+        title: "Send message",
+        nativeToolName: "mcp__proliferate_workspace__send_message",
+        rawInput: {
+          agentId: `pro-292-agent-${runIndex + 1}`,
+          message: `Continue fixture run ${runIndex + 2}`,
+        },
+      });
+      toolItemIds.push(receiptId);
+      mutationReceiptItemIds.push(receiptId);
+    }
+  });
+
+  const finalAssistantId = "pro-292-final-assistant";
+  appendItem(assistantItem(finalAssistantId, turn.turnId, startedSeq));
+  assistantItemIds.push(finalAssistantId);
+
+  return {
+    transcript,
+    turn,
+    itemIds,
+    toolItemIds,
+    assistantItemIds,
+    userItemId,
+    completedHistoryItemIds,
+    mutationReceiptItemIds,
+  };
+}
+export function buildPro292RowModelProof() {
+  const fixture = createPro292CompletedTurnFixture();
+  const serializedTurn = () => JSON.stringify({ turn: fixture.turn,
+    items: fixture.itemIds.map((itemId) => fixture.transcript.itemsById[itemId]) });
+  const beforeProjection = serializedTurn();
+  const presentation = buildTurnPresentation(fixture.turn, fixture.transcript);
+  const completedHistoryRootIds = new Set(presentation.completedHistoryRootIds);
+  const belongsToCompletedHistory = (block: TurnDisplayBlock) =>
+    displayBlockItemIds(block).every((itemId) => completedHistoryRootIds.has(itemId));
+  const expectedHistoryBlocks = presentation.displayBlocks.filter(belongsToCompletedHistory);
+  const expectedNonHistoryBlocks = presentation.displayBlocks
+    .filter((block) => !belongsToCompletedHistory(block));
+  const buildRows = (completedFixture: Pro292CompletedTurnFixture) =>
+    buildTranscriptRowModel({
+      activeSessionId: completedFixture.transcript.sessionMeta.sessionId,
+      transcript: completedFixture.transcript, visibleOptimisticPrompt: null,
+      latestTurnId: completedFixture.turn.turnId,
+      latestTurnHasAssistantRenderableContent: true,
+    });
+  const turnRows = buildRows(fixture).filter((row): row is Extract<
+    TranscriptRow, { kind: "turn" }> => row.kind === "turn");
+  const completedHistoryRows = turnRows
+    .filter((row) => row.blockKey === "completed-history");
+  const rowKeys = turnRows.map((row) => row.key);
+  const expectedRowKeys = [
+    `turn:${PRO_292_TURN_ID}:block:${fixture.userItemId}`,
+    `turn:${PRO_292_TURN_ID}:block:completed-history`,
+    ...fixture.mutationReceiptItemIds.map((itemId) => `turn:${PRO_292_TURN_ID}:block:${itemId}`),
+    `turn:${PRO_292_TURN_ID}:block:pro-292-final-assistant`,
+  ];
+  const projectedNonHistoryBlocks = turnRows
+    .filter((row) => row.blockKey !== "completed-history")
+    .flatMap((row) => row.renderPresentation.displayBlocks);
+  const rebuiltKeys = buildRows(createPro292CompletedTurnFixture()).map((row) => row.key);
+  return {
+    counts: [fixture.itemIds.length, new Set(fixture.itemIds).size,
+      fixture.toolItemIds.length, fixture.assistantItemIds.length,
+      fixture.itemIds.filter((itemId) => fixture.transcript.itemsById[itemId]?.kind
+        === "user_message").length, expectedHistoryBlocks.length],
+    completedHistory: [completedHistoryRows.length,
+      completedHistoryRows[0]?.renderPresentation.displayBlocks.length ?? 0],
+    invariants: [
+      fixture.turn.turnId === PRO_292_TURN_ID,
+      serializedTurn() === beforeProjection,
+      JSON.stringify(presentation.completedHistoryRootIds) === JSON.stringify(fixture.completedHistoryItemIds),
+      JSON.stringify(completedHistoryRows[0]?.renderPresentation.displayBlocks) === JSON.stringify(expectedHistoryBlocks),
+      JSON.stringify(projectedNonHistoryBlocks) === JSON.stringify(expectedNonHistoryBlocks),
+      JSON.stringify(rowKeys) === JSON.stringify(expectedRowKeys),
+      new Set(rowKeys).size === rowKeys.length,
+      JSON.stringify(rebuiltKeys) === JSON.stringify(rowKeys),
+    ],
+  };
+}
 
 export function range<T>(count: number, prefix: string, build: (id: string, seq: number) => T): T[] {
   return Array.from({ length: count }, (_, idx) => build(`${prefix}-${idx + 1}`, idx + 1));
+}
+
+function displayBlockItemIds(block: TurnDisplayBlock): string[] {
+  if (block.kind === "collapsed_actions" || block.kind === "inline_tools"
+    || block.kind === "subagent_creations") {
+    return block.itemIds;
+  }
+  return [block.itemId];
 }
 
 export function turnRecord(itemOrder: string[], completedAt: string | null = null): TurnRecord {

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-row-model.test.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-row-model.test.ts
@@ -6,17 +6,12 @@ import {
   type TranscriptRow,
 } from "./transcript-row-model";
 import { createPromptOutboxEntry } from "../../sessions/intents/session-intent-model";
-import {
-  resolveVirtualBottomDistance,
-} from "./transcript-virtual-rows";
+import { resolveVirtualBottomDistance } from "./transcript-virtual-rows";
 import {
   parseTranscriptVirtualizationMode,
   resolveTranscriptVirtualizationEnabled,
 } from "./transcript-virtualization-config";
-import {
-  terminalItem,
-  thoughtItem,
-} from "./transcript-presentation-test-fixtures";
+import { buildPro292RowModelProof, terminalItem, thoughtItem } from "./transcript-presentation-test-fixtures";
 import type { GoalTranscriptEvent } from "../../activity/goal-transcript-events";
 
 describe("buildTranscriptRowModel", () => {
@@ -177,6 +172,11 @@ describe("buildTranscriptRowModel", () => {
       isFirstTurnRow: false,
       isLastTurnRow: true,
     }));
+  });
+
+  it("projects one canonical completed-history row for the PRO-292 large turn", () => {
+    expect(buildPro292RowModelProof()).toEqual({ counts: [152, 152, 146, 5, 1, 8],
+      completedHistory: [1, 8], invariants: Array(8).fill(true) });
   });
 
   it("keeps large in-progress turns in one row so live action phases do not remount", () => {

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-row-model.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-row-model.ts
@@ -740,37 +740,37 @@ function chunkTurnDisplayBlocks(
   presentation: TurnPresentation,
 ): TurnDisplayBlockChunk[] {
   const completedHistoryRootIds = new Set(presentation.completedHistoryRootIds);
+  // One completed turn owns one history scope, even when durable receipts
+  // divide its display blocks into several noncontiguous runs.
+  const completedHistoryBlocks = presentation.completedHistorySummary
+    ? presentation.displayBlocks.filter((block) =>
+      blockBelongsToCompletedHistory(block, completedHistoryRootIds)
+    )
+    : [];
   const chunks: TurnDisplayBlockChunk[] = [];
-  let completedHistoryBlocks: TurnDisplayBlock[] = [];
-
-  const flushCompletedHistory = () => {
-    if (completedHistoryBlocks.length === 0) {
-      return;
-    }
-    chunks.push({
-      blockKey: TURN_COMPLETED_HISTORY_BLOCK_KEY,
-      blocks: completedHistoryBlocks,
-    });
-    completedHistoryBlocks = [];
-  };
+  let emittedCompletedHistory = false;
 
   for (const block of presentation.displayBlocks) {
     if (
       presentation.completedHistorySummary
       && blockBelongsToCompletedHistory(block, completedHistoryRootIds)
     ) {
-      completedHistoryBlocks.push(block);
+      if (!emittedCompletedHistory) {
+        chunks.push({
+          blockKey: TURN_COMPLETED_HISTORY_BLOCK_KEY,
+          blocks: completedHistoryBlocks,
+        });
+        emittedCompletedHistory = true;
+      }
       continue;
     }
 
-    flushCompletedHistory();
     chunks.push({
       blockKey: getTurnDisplayBlockKey(block),
       blocks: [block],
     });
   }
 
-  flushCompletedHistory();
   return chunks;
 }
 


### PR DESCRIPTION
## Summary

- Consolidate every completed-history block for one completed turn into one canonical transcript row at the first history position.
- Preserve mutation-receipt and final-prose ordering while restoring one stable, unique completed-history row key.
- Add production-projection regressions for the verified 152-item turn shape, hydrated disclosure rendering, and virtualizer key stability after scroll.

## Testing

Tier 1:
- `pnpm --filter @proliferate/product-client exec vitest run src/domain/chats/transcript/transcript-row-model.test.ts src/components/workspace/chat/transcript/TurnItemSequence.test.tsx src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx` — 3 files, 65 tests passed.
- `pnpm --filter @proliferate/product-client build` — passed.
- `pnpm --filter @proliferate/product-client typecheck` — passed.
- Repository shape, frontend boundary, appearance, design-attribution, toast-copy, component-library, documentation, and diff checks passed.

Production-path comparison:
- The identical reduced 152-item fixture on fresh current main emitted four completed-history rows, four `Worked for 7m 2s` disclosures, and duplicate row keys.
- This branch emitted one canonical completed-history row, one disclosure, and unique stable initial/post-scroll keys.

## Observability

None. This restores deterministic client projection behavior and adds no failure path, event, or telemetry field.

## Docs

None; behavior is restored to the existing transcript specification.

## Readiness

- [ ] I followed the pull-request procedure for scope, title, labels, body, and readiness.
- Draft only; do not merge or mark ready until independent review and founder product proof.

## Support and attribution

- [x] The support relationship was linked through the tracker API. No tracker or private-source identifier appears in this PR.

## Verification

- Head: `1e745eaaba76b65974194e2c7d996f5eeb27812a`
- Frozen five-file scope only.
