### PR TITLE
fix(product): restore the last-viewed session on workspace reopen

### DIFF
--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-activation-guard.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-activation-guard.test.ts
@@ -15,6 +15,7 @@ import { selectSessionWithShellIntentRollback } from "#product/hooks/sessions/wo
 import {
   beginSessionActivationIntent,
   commitActiveSession,
+  commitHotActiveSession,
   invalidateSessionActivationIntent,
   isSessionActivationCurrent,
 } from "#product/hooks/sessions/workflows/session-activation-guard";
@@ -168,7 +169,7 @@ describe("session activation guard", () => {
       .toBeUndefined();
   });
 
-  it("remembers guarded session commits under the selected logical workspace key", () => {
+  it("remembers guarded session commits under both workspace keys", () => {
     selectWorkspace("materialized-workspace", "logical-workspace");
     putSessionRecord(
       createEmptySessionRecord("session-1", "assistant", {
@@ -183,7 +184,31 @@ describe("session activation guard", () => {
     expect(useWorkspaceUiStore.getState().lastViewedSessionByWorkspace["logical-workspace"])
       .toBe("session-1");
     expect(useWorkspaceUiStore.getState().lastViewedSessionByWorkspace["materialized-workspace"])
-      .toBeUndefined();
+      .toBe("session-1");
+  });
+
+  it("remembers guarded hot session commits under both workspace keys", () => {
+    selectWorkspace("materialized-workspace", "logical-workspace");
+    putSessionRecord(
+      createEmptySessionRecord("session-1", "assistant", {
+        workspaceId: "materialized-workspace",
+      }),
+    );
+
+    const guard = beginSessionActivationIntent("materialized-workspace");
+    const outcome = commitHotActiveSession("session-1", guard, {
+      kind: "session_hot_switch",
+      workspaceId: "materialized-workspace",
+      sessionId: "session-1",
+      nonce: guard.workspaceSelectionNonce,
+      operationId: null,
+    });
+
+    expect(outcome.result).toBe("completed");
+    expect(useWorkspaceUiStore.getState().lastViewedSessionByWorkspace["logical-workspace"])
+      .toBe("session-1");
+    expect(useWorkspaceUiStore.getState().lastViewedSessionByWorkspace["materialized-workspace"])
+      .toBe("session-1");
   });
 
   it("guards backend reuse shell selection and rolls back logical shell intent on stale", async () => {

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-activation-guard.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-activation-guard.ts
@@ -165,7 +165,8 @@ function rememberActivatedSession(workspaceId: string, materializedSessionId: st
     useSessionSelectionStore.getState().selectedLogicalWorkspaceId,
     workspaceId,
   ) ?? workspaceId;
-  for (const workspaceKey of new Set([workspaceUiKey, workspaceId])) {
-    rememberLastViewedSession(workspaceKey, materializedSessionId);
+  rememberLastViewedSession(workspaceUiKey, materializedSessionId);
+  if (workspaceUiKey !== workspaceId) {
+    rememberLastViewedSession(workspaceId, materializedSessionId);
   }
 }

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-activation-guard.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-activation-guard.ts
@@ -88,13 +88,7 @@ export function commitActiveSession(
   }
   state.setActiveSessionId(sessionId);
   if (entry.materializedSessionId) {
-    rememberLastViewedSession(
-      resolveWorkspaceUiKey(
-        useSessionSelectionStore.getState().selectedLogicalWorkspaceId,
-        guard.workspaceId,
-      ) ?? guard.workspaceId,
-      entry.materializedSessionId,
-    );
+    rememberActivatedSession(guard.workspaceId, entry.materializedSessionId);
   }
   return {
     result: "completed",
@@ -131,13 +125,7 @@ export function commitHotActiveSession(
     hotPaintGate,
   });
   if (entry.materializedSessionId) {
-    rememberLastViewedSession(
-      resolveWorkspaceUiKey(
-        useSessionSelectionStore.getState().selectedLogicalWorkspaceId,
-        guard.workspaceId,
-      ) ?? guard.workspaceId,
-      entry.materializedSessionId,
-    );
+    rememberActivatedSession(guard.workspaceId, entry.materializedSessionId);
   }
   return {
     result: "completed",
@@ -170,4 +158,14 @@ export function clearActiveSession(
     result: "cleared",
     activeSessionVersion: useSessionSelectionStore.getState().activeSessionVersion,
   };
+}
+
+function rememberActivatedSession(workspaceId: string, materializedSessionId: string): void {
+  const workspaceUiKey = resolveWorkspaceUiKey(
+    useSessionSelectionStore.getState().selectedLogicalWorkspaceId,
+    workspaceId,
+  ) ?? workspaceId;
+  for (const workspaceKey of new Set([workspaceUiKey, workspaceId])) {
+    rememberLastViewedSession(workspaceKey, materializedSessionId);
+  }
 }

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.test.tsx
@@ -141,6 +141,34 @@ describe("useHotWorkspaceReconcileAction transcript hydration", () => {
     expect(rehydrate).toHaveBeenCalledTimes(1);
   });
 
+  it("reconciles a client-keyed slot through its materialized session id", async () => {
+    const clientSessionId = "client-session:r15";
+    removeSessionRecord(clientSessionId);
+    putSessionRecord(createEmptySessionRecord(clientSessionId, "codex", {
+      workspaceId: WORKSPACE_ID,
+      materializedSessionId: SESSION_ID,
+    }));
+    patchSessionRecord(clientSessionId, {
+      streamConnectionState: "open",
+      transcriptHydrated: true,
+    });
+    useSessionIngestStore.getState().applyStreamProgress(clientSessionId, {
+      lastAppliedSeq: 42,
+      lastObservedSeq: 42,
+      gapAfterSeq: null,
+    });
+    const rehydrate = vi.fn(async () => true);
+
+    const reconcile = renderReconcile(rehydrate);
+    const outcome = await reconcile({
+      ...reconcileInput(),
+      sessionId: clientSessionId,
+    });
+
+    expect(outcome).toBe("completed");
+    removeSessionRecord(clientSessionId);
+  });
+
   it("does not trust an open stream whose ingest state reports a gap", async () => {
     patchSessionRecord(SESSION_ID, {
       streamConnectionState: "open",

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.ts
@@ -168,15 +168,18 @@ export function useHotWorkspaceReconcileAction({
         return "stale";
       }
 
-      const sessionMeta = sessions.find((session) =>
-        session.id === sessionId && !session.dismissedAt
-      ) ?? null;
-      if (!sessionMeta) {
-        return "session_missing";
-      }
-
       const currentSlot = getSessionRecord(sessionId);
       if (!currentSlot) {
+        return "session_missing";
+      }
+      // Runtime sessions carry materialized ids while a slot created in this
+      // app run stays keyed by its client session id; compare through the
+      // slot's materialized id or every such session reconciles as missing.
+      const runtimeSessionId = currentSlot.materializedSessionId ?? sessionId;
+      const sessionMeta = sessions.find((session) =>
+        session.id === runtimeSessionId && !session.dismissedAt
+      ) ?? null;
+      if (!sessionMeta) {
         return "session_missing";
       }
       const storeStartedAt = performance.now();

--- a/apps/packages/product-client/src/lib/domain/workspaces/selection/hot-reopen.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/selection/hot-reopen.test.ts
@@ -196,6 +196,71 @@ describe("resolveHotReopenCandidate", () => {
     });
   });
 
+  it("resolves a remembered materialized id to its client-keyed slot", () => {
+    const candidate = resolveHotReopenCandidate({
+      resolvedWorkspaceId: "workspace-1",
+      logicalWorkspace: null,
+      initialActiveSessionId: null,
+      lastViewedSessionByWorkspace: {
+        "workspace-1": "session-real",
+      },
+      sessionSlots: {
+        "client-session:oldest": slot({
+          sessionId: "client-session:oldest",
+          materializedSessionId: "session-oldest",
+          workspaceId: "workspace-1",
+          hydrated: true,
+        }),
+        "client-session:last": slot({
+          sessionId: "client-session:last",
+          materializedSessionId: "session-real",
+          workspaceId: "workspace-1",
+          hydrated: true,
+        }),
+      },
+      isPendingSessionId: () => false,
+    });
+
+    expect(candidate).toEqual({
+      sessionId: "client-session:last",
+      workspaceId: "workspace-1",
+      source: "last_viewed",
+    });
+  });
+
+  it("skips a remembered materialized id whose slot is hidden under its client id", () => {
+    const candidate = resolveHotReopenCandidate({
+      resolvedWorkspaceId: "workspace-1",
+      logicalWorkspace: null,
+      initialActiveSessionId: null,
+      lastViewedSessionByWorkspace: {
+        "workspace-1": "session-real",
+      },
+      sessionSlots: {
+        "client-session:hidden": slot({
+          sessionId: "client-session:hidden",
+          materializedSessionId: "session-real",
+          workspaceId: "workspace-1",
+          hydrated: true,
+        }),
+        "client-session:open": slot({
+          sessionId: "client-session:open",
+          materializedSessionId: "session-open",
+          workspaceId: "workspace-1",
+          hydrated: true,
+        }),
+      },
+      isPendingSessionId: () => false,
+      hiddenSessionIds: new Set(["client-session:hidden"]),
+    });
+
+    expect(candidate).toEqual({
+      sessionId: "client-session:open",
+      workspaceId: "workspace-1",
+      source: "cached_slot",
+    });
+  });
+
   it("falls back to any eligible cached slot", () => {
     const candidate = resolveHotReopenCandidate({
       resolvedWorkspaceId: "workspace-1",
@@ -229,12 +294,14 @@ function logicalWorkspace(): LogicalWorkspace {
 
 function slot(input: {
   sessionId: string;
+  materializedSessionId?: string | null;
   workspaceId: string | null;
   hydrated: boolean;
   transcript?: TranscriptState;
 }): HotReopenSessionSlotSnapshot {
   return {
     sessionId: input.sessionId,
+    materializedSessionId: input.materializedSessionId ?? input.sessionId,
     workspaceId: input.workspaceId,
     transcriptHydrated: input.hydrated,
     events: [],

--- a/apps/packages/product-client/src/lib/domain/workspaces/selection/hot-reopen.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/selection/hot-reopen.ts
@@ -22,11 +22,11 @@ export function hotReopenWorkspaceLookupIds(
   resolvedWorkspaceId: string,
   logicalWorkspace: LogicalWorkspace | null,
 ): string[] {
-  return uniqueStrings([
+  return [...new Set([
     resolvedWorkspaceId,
-    logicalWorkspace?.id ?? null,
+    logicalWorkspace?.id,
     ...(logicalWorkspace ? logicalWorkspaceRelatedIds(logicalWorkspace) : []),
-  ]);
+  ].filter(Boolean))] as string[];
 }
 
 export function isHotReopenEligibleSessionSlot(
@@ -49,6 +49,7 @@ export function resolveHotReopenCandidate(input: {
   isPendingSessionId: (sessionId: string) => boolean;
   hiddenSessionIds?: ReadonlySet<string>;
 }): HotReopenCandidate | null {
+  const hiddenSessionIds = input.hiddenSessionIds;
   // Last-viewed bookkeeping stores materialized session ids (client ids are
   // transient and never persisted), but a session created in this app run
   // keeps its slot keyed by the client session id. Resolve through the slot's
@@ -76,8 +77,12 @@ export function resolveHotReopenCandidate(input: {
     // alias, so check every id the session is known by.
     if (
       source !== "initial_active"
-      && [sessionId, slot?.sessionId, slot?.materializedSessionId]
-        .some((id) => id && input.hiddenSessionIds?.has(id))
+      && slot
+      && hiddenSessionIds
+      && (
+        hiddenSessionIds.has(slot.sessionId)
+        || (slot.materializedSessionId && hiddenSessionIds.has(slot.materializedSessionId))
+      )
     ) {
       return null;
     }
@@ -123,14 +128,4 @@ function isClearlyEmptyFreshSlot(slot: HotReopenSessionSlotSnapshot): boolean {
     && slot.events.length === 0
     && slot.transcript.turnOrder.length === 0
     && !slot.optimisticPrompt;
-}
-
-function uniqueStrings(values: Array<string | null | undefined>): string[] {
-  const result: string[] = [];
-  for (const value of values) {
-    if (value && !result.includes(value)) {
-      result.push(value);
-    }
-  }
-  return result;
 }

--- a/apps/packages/product-client/src/lib/domain/workspaces/selection/hot-reopen.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/selection/hot-reopen.ts
@@ -4,6 +4,7 @@ import { logicalWorkspaceRelatedIds } from "#product/lib/domain/workspaces/cloud
 
 export interface HotReopenSessionSlotSnapshot {
   sessionId: string;
+  materializedSessionId?: string | null;
   workspaceId: string | null;
   transcriptHydrated: boolean;
   events: readonly unknown[];
@@ -48,23 +49,38 @@ export function resolveHotReopenCandidate(input: {
   isPendingSessionId: (sessionId: string) => boolean;
   hiddenSessionIds?: ReadonlySet<string>;
 }): HotReopenCandidate | null {
-  const slotFor = (sessionId: string | null | undefined) =>
-    sessionId ? input.sessionSlots[sessionId] ?? null : null;
+  // Last-viewed bookkeeping stores materialized session ids (client ids are
+  // transient and never persisted), but a session created in this app run
+  // keeps its slot keyed by the client session id. Resolve through the slot's
+  // materialized id so a remembered id still finds its slot; otherwise the
+  // last-viewed candidate silently loses to an arbitrary cached slot.
+  const slotFor = (sessionId: string | null | undefined) => {
+    if (!sessionId) {
+      return null;
+    }
+    return input.sessionSlots[sessionId]
+      ?? Object.values(input.sessionSlots).find(
+        (slot) => slot.materializedSessionId === sessionId,
+      )
+      ?? null;
+  };
   const toCandidate = (
     sessionId: string | null | undefined,
     source: HotReopenCandidate["source"],
   ): HotReopenCandidate | null => {
+    const slot = slotFor(sessionId);
     // Implicit sources must not resurrect a session whose tab the user closed:
     // a hidden session gets no tab, so activating it strands the shell on the
-    // chat-shell surface with the composer armed at an invisible session.
+    // chat-shell surface with the composer armed at an invisible session. The
+    // hidden set holds slot keys while a remembered id may be the materialized
+    // alias, so check every id the session is known by.
     if (
       source !== "initial_active"
-      && sessionId
-      && input.hiddenSessionIds?.has(sessionId)
+      && [sessionId, slot?.sessionId, slot?.materializedSessionId]
+        .some((id) => id && input.hiddenSessionIds?.has(id))
     ) {
       return null;
     }
-    const slot = slotFor(sessionId);
     return isHotReopenEligibleSessionSlot(
       slot,
       input.resolvedWorkspaceId,


### PR DESCRIPTION
## Summary

- Restore the last-viewed session when returning to a workspace during the same app run, including sessions whose runtime slot is keyed by a transient client-session id.
- Preserve valid client-keyed sessions during hot reconciliation by comparing through their materialized session ids.
- Record guarded cold and hot user activations under both logical and materialized workspace keys so the last-clicked session wins over the oldest or last-created tab.
- Add counterfactual regression coverage for alias resolution, hidden-session exclusion, reconcile preservation, and both activation paths.

Founder review required: this PR intentionally updates the guarded session-activation pinning contract from a logical-workspace-only write to a dual logical/materialized workspace write. The behavior change was explicitly approved for this delivery and is pinned by cold and hot activation tests.

## Testing

- Related ProductClient suite: 8 files, 54 tests passed independently in implementation and final code-review sessions.
- Counterfactual proof: restoring the old single-key writer makes exactly the two new guarded cold/hot tests fail; the reviewed implementation passes all 54 related tests.
- ProductClient `tsc --noEmit` passed at the final head.
- Full shared/Web production build passed.
- Login runtime budget passed at JS `501988/502000` gzip-9 bytes and CSS `65823/66250` bytes without changing either cap.
- `python3 scripts/check_max_lines.py` and `git diff --check` passed.
- Real `platypus2` proof: selecting workspace C's middle tab, switching C → D → C, and returning restored that exact session with three stable tabs, one active tab, matching shell/tab identity, and no duplicate or ghost pane.

## Observability

- None. Existing renderer identity attributes and profile/API health checks were sufficient for verification.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker API. No tracker, report, user, or support IDs or private source data appear in this PR.

## Verification

- Final independent code review: ACCEPT, no material findings at the exact pushed head.
- Independent product-proof review: READY FOR FOUNDER PROOF, no proof gaps or behavior defects.
- All feature, repository-shape, frontend, bundle-budget, Cargo, shared-package, and CodeQL checks passed.
- The workflow lifecycle job and provisional intent job both hit the same existing main-tip UI-test defect: a notification toast intercepted `#workflow-builder-input-1-required` until timeout. The failure is outside this six-file ProductClient session-selection diff and reproduced on the isolated main repair PR.
- Final worktree is clean and synchronized with the PR head.
