### PR TITLE
fix(product-client): recover transcript renderer fallback (PRO-301)

### DIFF
--- a/apps/packages/design/src/css/product.css
+++ b/apps/packages/design/src/css/product.css
@@ -211,10 +211,10 @@ body {
 }
 
 @keyframes om-wave {
-  0% { transform: scale(0); opacity: 0; }
-  16% { transform: scale(1); opacity: 1; }
-  44% { transform: scale(1); opacity: 1; }
-  62%, 100% { transform: scale(0); opacity: 0; }
+  0% { opacity: 0; }
+  16% { opacity: 1; }
+  44% { opacity: 1; }
+  62%, 100% { opacity: 0; }
 }
 
 @keyframes om-dot {
@@ -282,7 +282,9 @@ body {
 
 /* Wave sweeps column-major: delay order transposes the grid (col * 3 + row). */
 .dot-cell-loader[data-variant="wave"] .dot-cell-loader__dot {
-  transform: scale(0);
+  /* Opacity keeps the column wave without a permanent transform animation.
+     In WKWebView, that transform makes each frame recompute animation extents
+     across the document and can exhaust a renderer after a full-list fallback. */
   animation: om-wave var(--activity-dot-cell-wave-cycle) var(--ease-standard) infinite;
   animation-delay: calc(var(--activity-dot-cell-wave-step) * (var(--om-c) * 3 + var(--om-r)));
 }

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualTranscriptRowList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualTranscriptRowList.test.tsx
@@ -1,0 +1,116 @@
+/* @vitest-environment jsdom */
+
+import { createRef } from "react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TranscriptVirtualRow } from "#product/domain/chats/transcript/transcript-virtual-rows";
+import { VirtualTranscriptRowList } from "./VirtualTranscriptRowList";
+
+vi.mock("./VirtualizedTranscriptRowList", () => ({
+  VirtualizedTranscriptRowList: ({ onFallback }: { onFallback: (reason: string) => void }) => (
+    <button type="button" data-testid="virtual" onClick={() => onFallback("blank_viewport")}>
+      virtual
+    </button>
+  ),
+}));
+
+vi.mock("./FullTranscriptRowList", () => ({
+  FullTranscriptRowList: ({
+    fallbackReason,
+    rows,
+  }: {
+    fallbackReason: string | null;
+    rows: TranscriptVirtualRow[];
+  }) => (
+    <div data-testid="full" data-fallback-reason={fallbackReason ?? "disabled"}>
+      {rows.length}
+    </div>
+  ),
+}));
+
+const ROWS: TranscriptVirtualRow[] = Array.from({ length: 80 }, (_, index) => ({
+  kind: "pending_prompt",
+  key: `pending-prompt:${index}`,
+}));
+
+function makeProps() {
+  return {
+    rows: ROWS,
+    selectionRootRef: createRef<HTMLDivElement>(),
+    hasOlderHistory: false,
+    isLoadingOlderHistory: false,
+    olderHistoryCursor: null,
+    bottomInsetPx: 0,
+    selectedWorkspaceId: "workspace-1",
+    activeSessionId: "session-1",
+    isSessionBusy: false,
+    lastPromptSubmittedAtMs: null,
+    onLoadOlderHistory: vi.fn(),
+    onScrollSample: vi.fn(),
+    renderRow: (row: TranscriptVirtualRow) => <div>{row.key}</div>,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("VirtualTranscriptRowList", () => {
+  it("retries one transient blank fallback without permanently latching a long transcript full-DOM", () => {
+    const rendered = render(<VirtualTranscriptRowList {...makeProps()} />);
+
+    fireEvent.click(rendered.getByTestId("virtual"));
+    expect(rendered.getByTestId("full").getAttribute("data-fallback-reason"))
+      .toBe("blank_viewport");
+
+    act(() => vi.runAllTimers());
+    expect(rendered.getByTestId("virtual")).toBeTruthy();
+
+    fireEvent.click(rendered.getByTestId("virtual"));
+    expect(rendered.getByTestId("full").getAttribute("data-fallback-reason"))
+      .toBe("blank_viewport");
+
+    act(() => vi.runAllTimers());
+    expect(rendered.getByTestId("full")).toBeTruthy();
+  });
+
+  it("resets the bounded retry when session identity changes", () => {
+    const props = makeProps();
+    const rendered = render(<VirtualTranscriptRowList {...props} />);
+
+    fireEvent.click(rendered.getByTestId("virtual"));
+    act(() => vi.runAllTimers());
+    fireEvent.click(rendered.getByTestId("virtual"));
+    expect(rendered.getByTestId("full")).toBeTruthy();
+
+    rendered.rerender(
+      <VirtualTranscriptRowList
+        {...props}
+        activeSessionId="session-2"
+      />,
+    );
+    expect(rendered.getByTestId("virtual")).toBeTruthy();
+
+    fireEvent.click(rendered.getByTestId("virtual"));
+    expect(rendered.getByTestId("full")).toBeTruthy();
+    act(() => vi.runAllTimers());
+    expect(rendered.getByTestId("virtual")).toBeTruthy();
+  });
+
+  it("keeps the explicit full-render diagnostic mode stable", () => {
+    window.localStorage.setItem("proliferate:transcriptVirtualization", "off");
+
+    const rendered = render(<VirtualTranscriptRowList {...makeProps()} />);
+    expect(rendered.getByTestId("full").getAttribute("data-fallback-reason"))
+      .toBe("disabled");
+
+    act(() => vi.runAllTimers());
+    expect(rendered.getByTestId("full")).toBeTruthy();
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualTranscriptRowList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualTranscriptRowList.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   parseTranscriptVirtualizationMode,
   resolveTranscriptVirtualizationEnabled,
@@ -13,6 +13,11 @@ import { VirtualizedTranscriptRowList } from "./VirtualizedTranscriptRowList";
 
 const LEGACY_ENABLE_VIRTUALIZATION_STORAGE_KEY = "proliferate:enableTranscriptVirtualization";
 const LEGACY_DISABLE_VIRTUALIZATION_STORAGE_KEY = "proliferate:disableTranscriptVirtualization";
+// A confirmed blank range can still be a transient WebKit measurement state.
+// Keep the readable full renderer up briefly, then give a fresh virtualizer one
+// retry. A second failure remains on the safety renderer so a genuinely broken
+// range cannot flash between implementations forever.
+const VIRTUALIZER_FALLBACK_RETRY_DELAY_MS = 1_000;
 
 export function VirtualTranscriptRowList(props: TranscriptRowListBaseProps) {
   const { activeSessionId, selectedWorkspaceId } = props;
@@ -24,9 +29,26 @@ export function VirtualTranscriptRowList(props: TranscriptRowListBaseProps) {
     mode: virtualizationMode,
   });
   const [fallbackReason, setFallbackReason] = useState<string | null>(null);
+  const fallbackCountRef = useRef(0);
   useLayoutEffect(() => {
+    fallbackCountRef.current = 0;
     setFallbackReason(null);
   }, [activeSessionId, selectedWorkspaceId]);
+
+  const handleFallback = useCallback((reason: string) => {
+    fallbackCountRef.current += 1;
+    setFallbackReason(reason);
+  }, []);
+
+  useEffect(() => {
+    if (!virtualizationEnabled || fallbackReason === null || fallbackCountRef.current !== 1) {
+      return;
+    }
+    const retryTimer = window.setTimeout(() => {
+      setFallbackReason(null);
+    }, VIRTUALIZER_FALLBACK_RETRY_DELAY_MS);
+    return () => window.clearTimeout(retryTimer);
+  }, [fallbackReason, virtualizationEnabled]);
 
   if (!virtualizationEnabled || fallbackReason !== null) {
     return (
@@ -41,7 +63,7 @@ export function VirtualTranscriptRowList(props: TranscriptRowListBaseProps) {
   return (
     <VirtualizedTranscriptRowList
       {...props}
-      onFallback={setFallbackReason}
+      onFallback={handleFallback}
       virtualizationMode={virtualizationMode}
     />
   );

--- a/apps/packages/product-client/src/lib/domain/preferences/appearance-css-drift.test.ts
+++ b/apps/packages/product-client/src/lib/domain/preferences/appearance-css-drift.test.ts
@@ -400,20 +400,6 @@ describe("dot-cell activity motion", () => {
       expect(keyframes).toContain("opacity: 0;");
     },
   );
-
-  it("keeps the persistent wave off the transform compositor path", () => {
-    const keyframes = readRule(
-      productCss,
-      /@keyframes om-wave\s*\{([\s\S]*?)\n\}/,
-    );
-    const waveRule = readRule(
-      productCss,
-      /\.dot-cell-loader\[data-variant="wave"\] \.dot-cell-loader__dot\s*\{([\s\S]*?)\}/,
-    );
-
-    expect(keyframes).not.toContain("transform:");
-    expect(waveRule).not.toContain("transform:");
-  });
 });
 
 /**

--- a/apps/packages/product-client/src/lib/domain/preferences/appearance-css-drift.test.ts
+++ b/apps/packages/product-client/src/lib/domain/preferences/appearance-css-drift.test.ts
@@ -400,6 +400,20 @@ describe("dot-cell activity motion", () => {
       expect(keyframes).toContain("opacity: 0;");
     },
   );
+
+  it("keeps the persistent wave off the transform compositor path", () => {
+    const keyframes = readRule(
+      productCss,
+      /@keyframes om-wave\s*\{([\s\S]*?)\n\}/,
+    );
+    const waveRule = readRule(
+      productCss,
+      /\.dot-cell-loader\[data-variant="wave"\] \.dot-cell-loader__dot\s*\{([\s\S]*?)\}/,
+    );
+
+    expect(keyframes).not.toContain("transform:");
+    expect(waveRule).not.toContain("transform:");
+  });
 });
 
 /**

--- a/apps/packages/product-client/src/primitives/__tests__/DotCellLoader.test.tsx
+++ b/apps/packages/product-client/src/primitives/__tests__/DotCellLoader.test.tsx
@@ -1,8 +1,19 @@
 // @vitest-environment jsdom
 
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { DotCellLoader } from "#product/primitives/DotCellLoader";
+
+const productCss = readFileSync(
+  resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    "../../../../design/src/css/product.css",
+  ),
+  "utf8",
+);
 
 afterEach(cleanup);
 
@@ -24,5 +35,19 @@ describe("DotCellLoader", () => {
 
     expect(loader?.getAttribute("data-variant")).toBe("wave");
     expect(loader?.getAttribute("data-size")).toBe("default");
+  });
+
+  it("keeps the persistent wave off the transform compositor path", () => {
+    const keyframes = productCss.match(
+      /@keyframes om-wave\s*\{([\s\S]*?)\n\}/,
+    )?.[1];
+    const waveRule = productCss.match(
+      /\.dot-cell-loader\[data-variant="wave"\] \.dot-cell-loader__dot\s*\{([\s\S]*?)\}/,
+    )?.[1];
+
+    expect(keyframes).toBeDefined();
+    expect(waveRule).toBeDefined();
+    expect(keyframes).not.toContain("transform:");
+    expect(waveRule).not.toContain("transform:");
   });
 });


### PR DESCRIPTION
## Summary

- recover once from a confirmed blank virtualizer fallback instead of permanently latching a long transcript onto the full-DOM renderer
- preserve the full-render escape hatch after a second confirmed failure and preserve explicit virtualization `off`
- remove the dot-cell wave's persistent scale transform while retaining its opacity cadence, keeping WebKit off the sampled transform-extent compositor path
- track the incident in [PRO-301](https://linear.app/proliferate-team/issue/PRO-301/prevent-recurring-desktop-renderer-freeze-after-transcript-fallback)

The affected Desktop 0.4.14 renderer grew to 1.5–2.1 GB and 87–100% CPU while the native shell and runtime remained healthy. A clean native sample repeatedly entered `drawing timer → updateRendering → style/layout → RenderLayerCompositor → computeExtentOfTransformAnimation`.

PR #1775's composer-loop fix is already in 0.4.14. PR #1980 prevents one prepend-specific false blank fallback, but it retains both the permanent full-DOM latch and the transform animation, so it does not close this failure chain.

## Testing

- Component tier: new wrapper regression covers first-failure recovery, second-failure safety latch, per-session retry reset, and explicit full-render mode
- Component/domain tier: 83 focused tests across virtual/full transcript rendering, blank fallback, sidebar status animation, and CSS drift
- Typecheck: `pnpm --filter @proliferate/product-client typecheck`
- Repository checks: component library, frontend boundaries, design attribution, max lines, transcript scroll writer, and frontend structure

## Observability

- No new telemetry or scrubber sources.
- Existing diagnostics behavior is unchanged; PR #1993 separately adds production blank-fallback diagnostics.
- The PR removes the native sampled compositor trigger and bounds the fallback state that amplifies it.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- Focused Vitest: 7 files passed, 83 tests passed
- ProductClient typecheck passed
- Relevant repository checks passed
- Negative controls pin the second-failure escape hatch and forbid reintroducing a persistent transform on the wave treatment
- Manual release validation remains: leave a long transcript selected with an iterating/queued sidebar indicator and confirm WebContent CPU and memory remain bounded