### PR TITLE
chore(lints): tighten stale actor.rs max-lines ratchet to observed 603

### DIFF
--- a/lints/anyharness/ratchets.toml
+++ b/lints/anyharness/ratchets.toml
@@ -190,8 +190,8 @@ reason = "workflows gen-2 transition suite: one test per ADR table row plus stal
 
 [[max_lines]]
 path = "anyharness/crates/anyharness-lib/src/live/workflows/actor.rs"
-max_lines = 606
-reason = "fix/wf2-run-cancel's Cancel command threads through the actor's transition-apply loop (+9 lines) alongside the gen-2 ADR's existing side-effect dispatch; grows the file past the repo-wide 600 cap for the first time"
+max_lines = 603
+reason = "fix/wf2-run-cancel's Cancel command threads through the actor's transition-apply loop alongside the gen-2 ADR's existing side-effect dispatch; grows the file past the repo-wide 600 cap for the first time (603 on main after #1996's revert landed under #1906's 606-line branch context)"
 
 [[max_lines]]
 path = "anyharness/crates/anyharness-lib/src/live/sessions/model.rs"


### PR DESCRIPTION
## What
Main-tip CI is red on Repo shape checks (run 31980320224, 23:51Z): the max-lines ratchet for `anyharness/crates/anyharness-lib/src/live/workflows/actor.rs` says 606 but main observes 603 (checker: "Stale max-lines ratchet entries — shrink or delete"). This tightens the entry to 603. One line, no source changes.

## Why it happened
Merge-union regression, same class as this morning's #1968 incident: #1906's branch context had actor.rs at 606 lines and its lints rescue honestly recorded 606; main had meanwhile taken #1996's workflow revert, so the squashed union landed at 603. Both sides green alone; per-PR gates cannot see the union by construction.

## Verification
- `wc -l` at origin/main (773551737): 603.
- Checker semantics: entries must not exceed observed; 603 > repo cap 600 so the entry stays (tightened), not deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)