### PR TITLE
fix(product): cover the cancelled run status in RUN_STATUS_TONE

### DIFF
--- a/apps/packages/product-client/src/domain/workflows/run-view-model.ts
+++ b/apps/packages/product-client/src/domain/workflows/run-view-model.ts
@@ -78,6 +78,9 @@ const RUN_STATUS_TONE: Record<WorkflowRunV2["status"], WorkflowRunTone> = {
   interrupted: "warning",
   completed: "success",
   failed: "danger",
+  // Terminal-inert, same reasoning as NODE_STATUS_TONE's `cancelled`: a
+  // deliberate stop, not an error; matches the unknown-status fallback.
+  cancelled: "neutral",
 };
 
 export function workflowRunStatusTone(status: WorkflowRunV2["status"]): WorkflowRunTone {


### PR DESCRIPTION
Main is latently red: #1906 (23:23Z) added `cancelled` to `WorkflowRunStatusV2`, and #1972 (00:28Z) landed `run-view-model.ts` with a total `RUN_STATUS_TONE` map authored before that — the merges crossed, so `tsc -p tsconfig.domain.json` fails with TS2741 ("Property 'cancelled' is missing") in every job that builds the product-client domain (first seen on PR #1725's Self-Host Smoke after a branch update; main's own smoke at efe354aaa skipped the build as docs-only).

One-line fix: add `cancelled: "neutral"` to the map, mirroring `NODE_STATUS_TONE`'s existing `cancelled: "muted"` entry. `workflowRunStatusTone` already falls back to `neutral` for unknown statuses, so runtime behavior is unchanged — this only restores the total-declaration typecheck.

Found during the open-PR backlog review lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)