### PR TITLE
fix(product): restore cancelled workflow run tone

### DIFF
--- a/apps/packages/product-client/src/domain/workflows/run-view-model.test.ts
+++ b/apps/packages/product-client/src/domain/workflows/run-view-model.test.ts
@@ -12,6 +12,7 @@ import {
   workflowNodeIsSideNode,
   workflowNodeStatusTone,
   workflowRunIsActive,
+  workflowRunStatusTone,
   workflowRunTakesSideNode,
 } from "./run-view-model";
 
@@ -129,6 +130,12 @@ describe("workflowRunIsActive", () => {
     expect(
       RUN_STATUSES.map((status) => workflowRunIsActive(run({ status }))),
     ).toEqual([true, true, true, false, false, false]);
+  });
+});
+
+describe("workflowRunStatusTone", () => {
+  it("presents a cancelled run with the neutral tone", () => {
+    expect(workflowRunStatusTone("cancelled")).toBe("neutral");
   });
 });
 

--- a/apps/packages/product-client/src/domain/workflows/run-view-model.ts
+++ b/apps/packages/product-client/src/domain/workflows/run-view-model.ts
@@ -78,6 +78,7 @@ const RUN_STATUS_TONE: Record<WorkflowRunV2["status"], WorkflowRunTone> = {
   interrupted: "warning",
   completed: "success",
   failed: "danger",
+  cancelled: "neutral",
 };
 
 export function workflowRunStatusTone(status: WorkflowRunV2["status"]): WorkflowRunTone {


### PR DESCRIPTION
## Summary

- Restore the total ProductClient run-status tone map after cancelled joined the workflow run status union.
- Present cancelled runs with the established neutral tone.
- Pin the cancelled-to-neutral mapping in the owning domain test.

## Testing

Pre-fix proof reproduced TS2741 at run-view-model.ts: Property cancelled is missing from Record<WorkflowRunStatusV2, WorkflowRunTone>.

Passing proof:
- pnpm exec vitest run src/domain/workflows/run-view-model.test.ts (54 tests)
- pnpm --filter @proliferate/product-client typecheck
- pnpm --filter @proliferate/product-client build
- python3 scripts/check_max_lines.py
- python3 scripts/check_frontend_boundaries.py
- python3 scripts/check_design_attribution.py
- git diff --check efe354aaa985ae1172ff9c8f7948fd2e10489ba6..HEAD

## Observability

None. This restores a pure presentation mapping and adds no failure path, telemetry, logging, or runtime behavior.