### PR TITLE
fix(product): keep completed history in one transcript row

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.test.tsx
@@ -7,12 +7,17 @@ import { createTranscriptState } from "@anyharness/sdk";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   assistantItem,
+  createLargeInterruptedCompletedTurnFixture,
   terminalItem,
   toolItem,
   turnRecord,
   userItem,
 } from "#product/domain/chats/transcript/transcript-presentation-test-fixtures";
 import { buildTurnPresentation } from "#product/domain/chats/transcript/transcript-presentation";
+import {
+  buildTranscriptRowModel,
+  type TranscriptRow,
+} from "#product/domain/chats/transcript/transcript-row-model";
 import {
   constrainTurnItemSequencePresentation,
   resolveTurnItemFrontierBlockKey,
@@ -121,6 +126,62 @@ describe("CompletedHistorySequence", () => {
     expect(nestedDetailPanel).not.toBeUndefined();
     expect(nestedDetailPanel?.className).toMatch(/(?:^|\s)border(?:\s|$)/);
     expect(nestedDetailPanel?.className).toContain("rounded-lg");
+  });
+
+  it("renders a large interrupted turn with one whole-turn disclosure", async () => {
+    const user = userEvent.setup();
+    const fixture = createLargeInterruptedCompletedTurnFixture();
+    const projectedTurnRows = buildTranscriptRowModel({
+      activeSessionId: fixture.transcript.sessionMeta.sessionId,
+      transcript: fixture.transcript,
+      visibleOptimisticPrompt: null,
+      latestTurnId: fixture.turn.turnId,
+      latestTurnHasAssistantRenderableContent: true,
+    }).filter(
+      (row): row is Extract<TranscriptRow, { kind: "turn" }> => row.kind === "turn",
+    );
+    const completedHistoryRow = projectedTurnRows.find(
+      (row) => row.blockKey === "completed-history",
+    );
+    expect(completedHistoryRow).toBeDefined();
+
+    const { container } = render(
+      <TurnItemSequence
+        turn={fixture.turn}
+        transcript={fixture.transcript}
+        isTurnComplete
+        presentation={completedHistoryRow!.renderPresentation}
+        autoFollowCollapsedActionBlockId={null}
+        tailAssistantProseRootId={completedHistoryRow!.presentation.finalAssistantItemId}
+        completedHistoryLabel={null}
+        animateActivityEntry={false}
+        animateAssistantRevealItemId={null}
+        showCompletedArtifactFallback={false}
+        workspaceId={null}
+        onOpenArtifact={vi.fn()}
+      />,
+    );
+
+    const disclosures = screen.getAllByRole("button", { name: "Worked for 7m 2s" });
+    expect(disclosures).toHaveLength(1);
+    await user.click(disclosures[0]!);
+
+    const completedHistorySequences = container.querySelectorAll(
+      "[data-completed-history-sequence]",
+    );
+    expect(completedHistorySequences).toHaveLength(1);
+    expect(completedHistorySequences[0]?.children).toHaveLength(8);
+    for (const assistantId of fixture.assistantItemIds.slice(0, -1)) {
+      expect(container.querySelectorAll(
+        `[data-rendered-transcript-item="${assistantId}"]`,
+      )).toHaveLength(1);
+    }
+    for (const receiptId of fixture.mutationReceiptItemIds) {
+      const receipt = container.querySelector(
+        `[data-rendered-transcript-item="${receiptId}"]`,
+      );
+      expect(receipt).toBeNull();
+    }
   });
 });
 

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx
@@ -4,6 +4,8 @@ import { createRef } from "react";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TranscriptVirtualRow } from "#product/domain/chats/transcript/transcript-virtual-rows";
+import { createLargeInterruptedCompletedTurnFixture } from "#product/domain/chats/transcript/transcript-presentation-test-fixtures";
+import { buildTranscriptRowModel } from "#product/domain/chats/transcript/transcript-row-model";
 import { VirtualizedTranscriptRowList } from "./VirtualizedTranscriptRowList";
 
 const observedVirtualizerOptions = vi.hoisted(() => [] as Array<{
@@ -47,9 +49,9 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-function makeProps() {
+function makeProps(rows: readonly TranscriptVirtualRow[] = ROWS) {
   return {
-    rows: ROWS,
+    rows,
     selectionRootRef: createRef<HTMLDivElement>(),
     hasOlderHistory: false,
     isLoadingOlderHistory: false,
@@ -112,6 +114,53 @@ describe("VirtualizedTranscriptRowList", () => {
     expect(observedVirtualizerOptions.length).toBeGreaterThan(optionCountBeforeScroll);
     expect(nextOptions?.getItemKey).toBe(firstOptions?.getItemKey);
     expect(nextOptions?.estimateSize).toBe(firstOptions?.estimateSize);
+  });
+
+  it("keeps large interrupted-turn row keys unique across hydration and upward scroll", () => {
+    const fixture = createLargeInterruptedCompletedTurnFixture();
+    const rows = buildTranscriptRowModel({
+      activeSessionId: fixture.transcript.sessionMeta.sessionId,
+      transcript: fixture.transcript,
+      visibleOptimisticPrompt: null,
+      latestTurnId: fixture.turn.turnId,
+      latestTurnHasAssistantRenderableContent: true,
+    });
+    const expectedKeys = rows.map((row) => row.key);
+    const rendered = render(
+      <VirtualizedTranscriptRowList {...makeProps(rows)} />,
+    );
+    const initialOptions = observedVirtualizerOptions.at(-1);
+    const initialGetItemKey = initialOptions?.getItemKey as
+      | ((index: number) => unknown)
+      | undefined;
+    expect(initialGetItemKey).toBeTruthy();
+
+    // This delegates to the real TanStack virtualizer. Its configured accessor
+    // is the index-to-row identity contract used by measurement and scrolling.
+    const initialKeys = rows.map((_, index) => initialGetItemKey!(index));
+    expect(initialKeys).toEqual(expectedKeys);
+    expect(new Set(initialKeys).size).toBe(initialKeys.length);
+
+    const optionCountBeforeScroll = observedVirtualizerOptions.length;
+    const viewport = getViewport(rendered.container);
+    Object.defineProperty(viewport, "clientHeight", { value: 300, configurable: true });
+    Object.defineProperty(viewport, "scrollHeight", { value: 2_000, configurable: true });
+    viewport.scrollTop = 1_200;
+    act(() => {
+      fireEvent.wheel(viewport, { deltaY: -80 });
+      viewport.scrollTop = 1_120;
+      fireEvent.scroll(viewport);
+    });
+
+    const postScrollOptions = observedVirtualizerOptions.at(-1);
+    const postScrollGetItemKey = postScrollOptions?.getItemKey as
+      | ((index: number) => unknown)
+      | undefined;
+    expect(observedVirtualizerOptions.length).toBeGreaterThan(optionCountBeforeScroll);
+    expect(postScrollGetItemKey).toBe(initialGetItemKey);
+    const postScrollKeys = rows.map((_, index) => postScrollGetItemKey!(index));
+    expect(postScrollKeys).toEqual(expectedKeys);
+    expect(new Set(postScrollKeys).size).toBe(postScrollKeys.length);
   });
 
   it("rotates getItemKey only on an ordered-key change, estimateSize also on a session change", () => {

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-presentation-test-fixtures.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-presentation-test-fixtures.ts
@@ -1,4 +1,110 @@
-import type { ContentPart, ToolCallItem, TurnRecord } from "@anyharness/sdk";
+import {
+  createTranscriptState,
+  type ContentPart,
+  type ToolCallItem,
+  type TranscriptState,
+  type TurnRecord,
+} from "@anyharness/sdk";
+
+export const LARGE_INTERRUPTED_TURN_ID = "large-interrupted-turn";
+export const LARGE_INTERRUPTED_TURN_STARTED_AT = "2026-04-04T00:00:00Z";
+export const LARGE_INTERRUPTED_TURN_COMPLETED_AT = "2026-04-04T00:07:02Z";
+
+export interface LargeInterruptedCompletedTurnFixture {
+  transcript: TranscriptState;
+  turn: TurnRecord;
+  itemIds: string[];
+  toolItemIds: string[];
+  assistantItemIds: string[];
+  userItemId: string;
+  completedHistoryItemIds: string[];
+  mutationReceiptItemIds: string[];
+}
+
+/**
+ * Preserves the production invariants for a large completed turn: 152 unique
+ * items (146 tools, five assistant messages, and one user message), with four
+ * history runs separated by Agent Operations mutation receipts. Row output
+ * remains owned by the production projection.
+ */
+export function createLargeInterruptedCompletedTurnFixture(
+): LargeInterruptedCompletedTurnFixture {
+  const transcript = createTranscriptState("large-interrupted-session");
+  const turn: TurnRecord = {
+    turnId: LARGE_INTERRUPTED_TURN_ID,
+    itemOrder: [],
+    startedAt: LARGE_INTERRUPTED_TURN_STARTED_AT,
+    completedAt: LARGE_INTERRUPTED_TURN_COMPLETED_AT,
+    stopReason: "end_turn",
+    fileBadges: [],
+  };
+  transcript.turnOrder.push(turn.turnId);
+  transcript.turnsById[turn.turnId] = turn;
+
+  const itemIds: string[] = [];
+  const toolItemIds: string[] = [];
+  const assistantItemIds: string[] = [];
+  const completedHistoryItemIds: string[] = [];
+  const mutationReceiptItemIds: string[] = [];
+  let startedSeq = 1;
+
+  const appendItem = (item: TranscriptState["itemsById"][string]) => {
+    transcript.itemsById[item.itemId] = item;
+    turn.itemOrder.push(item.itemId);
+    itemIds.push(item.itemId);
+    startedSeq += 1;
+  };
+
+  const userItemId = "large-interrupted-user";
+  appendItem(userItem(userItemId, turn.turnId, startedSeq));
+
+  const historyToolCounts = [36, 36, 36, 35];
+  let historyToolIndex = 0;
+  historyToolCounts.forEach((toolCount, runIndex) => {
+    const assistantId = `large-interrupted-history-assistant-${runIndex + 1}`;
+    appendItem(assistantItem(assistantId, turn.turnId, startedSeq));
+    assistantItemIds.push(assistantId);
+    completedHistoryItemIds.push(assistantId);
+
+    for (let index = 0; index < toolCount; index += 1) {
+      historyToolIndex += 1;
+      const toolId = `large-interrupted-history-tool-${historyToolIndex}`;
+      appendItem(toolItem(toolId, turn.turnId, startedSeq, "file_read"));
+      toolItemIds.push(toolId);
+      completedHistoryItemIds.push(toolId);
+    }
+
+    if (runIndex < historyToolCounts.length - 1) {
+      const receiptId = `large-interrupted-mutation-receipt-${runIndex + 1}`;
+      appendItem({
+        ...toolItem(receiptId, turn.turnId, startedSeq, "other"),
+        title: "Send message",
+        nativeToolName: "mcp__proliferate_workspace__send_message",
+        rawInput: {
+          agentId: `large-interrupted-agent-${runIndex + 1}`,
+          message: `Continue fixture run ${runIndex + 2}`,
+        },
+      });
+      toolItemIds.push(receiptId);
+      mutationReceiptItemIds.push(receiptId);
+    }
+  });
+
+  const finalAssistantId = "large-interrupted-final-assistant";
+  appendItem(assistantItem(finalAssistantId, turn.turnId, startedSeq));
+  assistantItemIds.push(finalAssistantId);
+
+  return {
+    transcript,
+    turn,
+    itemIds,
+    toolItemIds,
+    assistantItemIds,
+    userItemId,
+    completedHistoryItemIds,
+    mutationReceiptItemIds,
+  };
+}
 
 export function range<T>(count: number, prefix: string, build: (id: string, seq: number) => T): T[] {
   return Array.from({ length: count }, (_, idx) => build(`${prefix}-${idx + 1}`, idx + 1));

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-row-model-completed-history.test.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-row-model-completed-history.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { createLargeInterruptedCompletedTurnFixture } from "./transcript-presentation-test-fixtures";
+import {
+  buildTranscriptRowModel,
+  type TranscriptRow,
+} from "./transcript-row-model";
+
+describe("buildTranscriptRowModel completed history", () => {
+  it("projects one canonical completed-history row for a large interrupted turn", () => {
+    const fixture = createLargeInterruptedCompletedTurnFixture();
+    const beforeProjection = JSON.stringify({
+      turn: fixture.turn,
+      items: fixture.itemIds.map((itemId) => fixture.transcript.itemsById[itemId]),
+    });
+    const buildRows = () => buildTranscriptRowModel({
+      activeSessionId: fixture.transcript.sessionMeta.sessionId,
+      transcript: fixture.transcript,
+      visibleOptimisticPrompt: null,
+      latestTurnId: fixture.turn.turnId,
+      latestTurnHasAssistantRenderableContent: true,
+    });
+
+    const rows = buildRows();
+    const turnRows = rows.filter(
+      (row): row is Extract<TranscriptRow, { kind: "turn" }> => row.kind === "turn",
+    );
+    const completedHistoryRows = turnRows.filter(
+      (row) => row.blockKey === "completed-history",
+    );
+    const rowKeys = turnRows.map((row) => row.key);
+    const finalAssistantItemId = fixture.assistantItemIds.at(-1);
+
+    expect([
+      fixture.itemIds.length,
+      new Set(fixture.itemIds).size,
+      fixture.toolItemIds.length,
+      fixture.assistantItemIds.length,
+    ]).toEqual([152, 152, 146, 5]);
+    expect(JSON.stringify({
+      turn: fixture.turn,
+      items: fixture.itemIds.map((itemId) => fixture.transcript.itemsById[itemId]),
+    })).toBe(beforeProjection);
+    expect(turnRows.map((row) => row.blockKey)).toEqual([
+      fixture.userItemId,
+      "completed-history",
+      ...fixture.mutationReceiptItemIds,
+      finalAssistantItemId,
+    ]);
+    expect(completedHistoryRows).toHaveLength(1);
+    expect(completedHistoryRows[0]?.presentation.completedHistoryRootIds)
+      .toEqual(fixture.completedHistoryItemIds);
+    expect(completedHistoryRows[0]?.presentation.completedHistorySummary).toEqual({
+      messages: 4,
+      toolCalls: 143,
+      subagents: 0,
+    });
+    expect(completedHistoryRows[0]?.renderPresentation.displayBlocks).toHaveLength(8);
+    expect(completedHistoryRows[0]?.renderPresentation.displayBlocks.flatMap((block) =>
+      "itemIds" in block ? block.itemIds : [block.itemId]
+    )).toEqual(fixture.completedHistoryItemIds);
+    expect(new Set(rowKeys).size).toBe(rowKeys.length);
+    expect(buildRows().map((row) => row.key)).toEqual(rows.map((row) => row.key));
+  });
+});

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-row-model.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-row-model.ts
@@ -741,36 +741,36 @@ function chunkTurnDisplayBlocks(
 ): TurnDisplayBlockChunk[] {
   const completedHistoryRootIds = new Set(presentation.completedHistoryRootIds);
   const chunks: TurnDisplayBlockChunk[] = [];
-  let completedHistoryBlocks: TurnDisplayBlock[] = [];
-
-  const flushCompletedHistory = () => {
-    if (completedHistoryBlocks.length === 0) {
-      return;
-    }
-    chunks.push({
-      blockKey: TURN_COMPLETED_HISTORY_BLOCK_KEY,
-      blocks: completedHistoryBlocks,
-    });
-    completedHistoryBlocks = [];
-  };
+  const completedHistoryBlocks: TurnDisplayBlock[] = [];
+  let completedHistoryIndex = -1;
 
   for (const block of presentation.displayBlocks) {
     if (
       presentation.completedHistorySummary
       && blockBelongsToCompletedHistory(block, completedHistoryRootIds)
     ) {
+      if (completedHistoryIndex < 0) {
+        completedHistoryIndex = chunks.length;
+      }
       completedHistoryBlocks.push(block);
       continue;
     }
 
-    flushCompletedHistory();
     chunks.push({
       blockKey: getTurnDisplayBlockKey(block),
       blocks: [block],
     });
   }
 
-  flushCompletedHistory();
+  // One completed turn owns one history scope, even when durable receipts
+  // divide its display blocks into several noncontiguous runs.
+  if (completedHistoryBlocks.length > 0) {
+    chunks.splice(completedHistoryIndex, 0, {
+      blockKey: TURN_COMPLETED_HISTORY_BLOCK_KEY,
+      blocks: completedHistoryBlocks,
+    });
+  }
+
   return chunks;
 }
 


### PR DESCRIPTION
## Summary

- project one canonical completed-history row for each completed turn, even when mutation receipts separate the underlying history runs
- preserve receipt rows and the whole-turn duration while giving React and the virtualizer one stable history identity
- cover the 152-item production shape through the presentation, row, renderer, and virtualizer-key paths without retaining private incident identifiers

## Testing

- `pnpm --dir apps/packages/product-client exec vitest run src/domain/chats/transcript/transcript-row-model-completed-history.test.ts src/components/workspace/chat/transcript/TurnItemSequence.test.tsx src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx` — 3 files, 22 tests passed on Node 22
- `pnpm --filter @proliferate/product-client build` — passed
- `pnpm shared:build && VITE_PROLIFERATE_API_BASE_URL=https://login-budget-fixture.invalid pnpm web:build && node scripts/measure-login-runtime-budget.mjs --no-build` — passed at 501,999/502,000 JS gzip bytes
- `python3 scripts/check_max_lines.py` — passed
- `python3 scripts/lint_records.py` — passed
- `python3 -m unittest scripts/test_check_appearance_scaling.py && python3 scripts/check_appearance_scaling.py` — passed
- `git diff --check` — passed

## Observability

- none; this changes deterministic client-side transcript projection and adds no new telemetry

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] Tracker relationship is linked from the tracker. No tracker, report, user, support IDs, or private source data appear in this PR.

## Verification

- the regression fails on the previous implementation because four completed-history rows share one key and each owns the same whole-turn disclosure
- the corrected projection emits one completed-history row, six unique row keys, one `Worked for 7m 2s` disclosure, and stable TanStack `getItemKey` values before and after the scroll update