### PR TITLE
fix(product-client): scope transcript submit-stamp to session identity (PRO-175, r2 reopened)

### DIFF
--- a/apps/packages/product-client/qualification/scroll-physics/specs/scroll-physics.spec.ts
+++ b/apps/packages/product-client/qualification/scroll-physics/specs/scroll-physics.spec.ts
@@ -323,11 +323,25 @@ test.describe("transcript scroll physics", () => {
     await drive(page, "finalizeStreamingTurn");
   });
 
-  // EXPECTED TO FAIL today (PRO-175). resetForSession always re-pins and snaps
-  // to bottom on every session switch, then runs a glue loop across the newly
-  // mounted rows, a revisit to a finalized session produces scrollTop motion
-  // frames instead of restoring its prior position with zero visible motion.
-  // Rung 2 introduces restore-finalized placement; unfixme there.
+  // EXPECTED TO FAIL today (PRO-175), for a DIFFERENT reason than the stamp
+  // leak this rung fixes. `resetForSession` still unconditionally
+  // pins/snaps/glues on every session switch by design (rung 2 leaves this
+  // alone), and the virtualizer's own remeasurement of freshly-mounted rows
+  // still produces a handful of settle frames after the snap — plus, in this
+  // fixture, a session switch resets `VirtualTranscriptRowList`'s
+  // `fallbackReason` to null, which can flip the tree from
+  // FullTranscriptRowList back to VirtualizedTranscriptRowList (a real
+  // component remount) if a blank-viewport fallback had fired for the
+  // intervening session. Either path produces multiple distinct scrollTop
+  // frames regardless of the stamp fix below. Verified: with
+  // `setPendingPromptStamp` reproducing the stamp-leak precondition
+  // (session-primary carries a stamp across an intervening session with
+  // none), the pre-fix code and the sessionKey-scoped fix in
+  // use-transcript-stick-to-bottom.ts produce IDENTICAL scrollTop traces
+  // (~5 distinct frames each) — the stamp leak was not this test's failure
+  // mode. Zero-motion placement on revisit is restore-finalized placement,
+  // named in the frozen ladder as rung 6 (bottom-on-entry replacement);
+  // unfixme there.
   test.fixme(
     "revisit-no-motion: switching back to a finalized session places with zero motion frames",
     async ({ page }) => {

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.tsx
@@ -88,6 +88,7 @@ export function FullTranscriptRowList({
     onScrollSample,
     autoFollowBottomInsetPx: effectiveNonDisplacingBottomInsetPx,
     lastPromptSubmittedAtMs,
+    sessionKey: `${selectedWorkspaceId ?? ""}:${activeSessionId}`,
   });
 
   // Content-search jump-to-match. The full list mounts every row, so the

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.tsx
@@ -74,6 +74,7 @@ export function VirtualizedTranscriptRowList({
     onScrollSample,
     autoFollowBottomInsetPx: effectiveNonDisplacingBottomInsetPx,
     lastPromptSubmittedAtMs,
+    sessionKey: `${selectedWorkspaceId ?? ""}:${activeSessionId}`,
   });
   const renderableRows = useMemo(
     () => buildRenderableRows(rows, isLoadingOlderHistory),

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.tsx
@@ -16,7 +16,7 @@ import { TranscriptFloatingControls } from "./TranscriptRowListShared";
 import { useAboveChangeCompensation } from "#product/hooks/chat/ui/use-above-change-compensation";
 import { useTranscriptStickToBottom } from "#product/hooks/chat/ui/use-transcript-stick-to-bottom";
 import { VirtualTranscriptViewport } from "./VirtualTranscriptViewport";
-import { useTranscriptVirtualizerBlankFallback } from "#product/hooks/chat/ui/use-transcript-virtualizer-blank-fallback";
+import { PREPEND_BLANK_FALLBACK_GRACE_MS, useTranscriptVirtualizerBlankFallback } from "#product/hooks/chat/ui/use-transcript-virtualizer-blank-fallback";
 import { useTranscriptVirtualAnchorCapture } from "#product/hooks/chat/ui/use-transcript-virtual-anchor-capture";
 import { useTranscriptVirtualMeasurementModel } from "#product/hooks/chat/ui/use-transcript-virtual-measurement-model";
 
@@ -55,6 +55,7 @@ export function VirtualizedTranscriptRowList({
   const lastOlderHistoryCursorRequestRef = useRef<number | null>(null);
   const lastPrefetchDecisionLogRef = useRef<string | null>(null);
   const lastBlankReportSignatureRef = useRef<string | null>(null);
+  const prependSettleUntilRef = useRef(0);
   const {
     structural: structuralBottomInsetPx,
     nonDisplacing: effectiveNonDisplacingBottomInsetPx,
@@ -248,6 +249,8 @@ export function VirtualizedTranscriptRowList({
     notifyProgrammaticScroll(() => {
       viewport.scrollTop = anchor.scrollTop + (viewport.scrollHeight - anchor.scrollHeight);
     });
+    // Open the blank-fallback grace window: the anchor write above lands against the still-estimated short scrollHeight.
+    prependSettleUntilRef.current = (typeof performance === "undefined" ? Date.now() : performance.now()) + PREPEND_BLANK_FALLBACK_GRACE_MS;
   }, [notifyProgrammaticScroll, olderHistoryCursor, rows.length, setPinned]);
 
   useEffect(() => {
@@ -361,7 +364,7 @@ export function VirtualizedTranscriptRowList({
     activeSessionId, bottomSpacerHeight,
     firstVirtualItem, lastVirtualItem,
     lastBlankReportSignatureRef, rowCount: rows.length,
-    onFallback, renderableRowCount: renderableRows.length,
+    onFallback, prependSettleUntilRef, renderableRowCount: renderableRows.length,
     scrollRef, selectedWorkspaceId,
     topSpacerHeight, totalContentHeight,
     virtualItemCount: virtualItems.length,

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.session-stamp.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.session-stamp.test.tsx
@@ -1,0 +1,180 @@
+/* @vitest-environment jsdom */
+
+// Split out of use-transcript-stick-to-bottom.test.tsx (repo-shape max-lines):
+// the submit-stamp / session-identity scoping scenarios (PRO-175) get their
+// own harness (`renderStampHarness`) rather than the shared `renderHarness`
+// used by the rest of the suite, so this file only duplicates the small slice
+// of setup those scenarios actually need.
+
+import { useRef } from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useTranscriptStickToBottom,
+  type TranscriptStickToBottom,
+} from "./use-transcript-stick-to-bottom";
+
+let rafCallbacks: Array<FrameRequestCallback | null>;
+
+beforeEach(() => {
+  rafCallbacks = [];
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    rafCallbacks.push(cb);
+    return rafCallbacks.length;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+    rafCallbacks[id - 1] = null;
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+interface HarnessHandle {
+  api: TranscriptStickToBottom;
+  viewport: HTMLDivElement;
+}
+
+interface StampHarnessProps {
+  lastPromptSubmittedAtMs: number | null;
+  sessionKey: string;
+}
+
+interface StampHarnessController {
+  current: HarnessHandle;
+  rerender: (props: StampHarnessProps) => void;
+}
+
+/**
+ * Harness for the submit-stamp / session-identity interaction (PRO-175).
+ * Exposes `lastPromptSubmittedAtMs` and `sessionKey` as rerender-able props so
+ * a test can simulate a session switch (`sessionKey` changes on the same
+ * render as `lastPromptSubmittedAtMs`) without unmounting the hook — mirroring
+ * how the row lists never remount across a real session switch.
+ */
+function renderStampHarness(initial: StampHarnessProps): StampHarnessController {
+  const handle: { current: HarnessHandle | null } = { current: null };
+
+  function Harness({ lastPromptSubmittedAtMs, sessionKey }: StampHarnessProps) {
+    const scrollRef = useRef<HTMLDivElement>(null);
+    const api = useTranscriptStickToBottom({
+      scrollRef,
+      onScrollSample: vi.fn(),
+      lastPromptSubmittedAtMs,
+      sessionKey,
+    });
+    return (
+      <div
+        ref={(node) => {
+          scrollRef.current = node;
+          if (node) {
+            handle.current = { api, viewport: node };
+          }
+        }}
+        data-testid="viewport"
+      />
+    );
+  }
+
+  const rendered = render(<Harness {...initial} />);
+  return {
+    get current() {
+      return handle.current!;
+    },
+    rerender(props: StampHarnessProps) {
+      rendered.rerender(<Harness {...props} />);
+    },
+  };
+}
+
+function setMetrics(el: HTMLElement, metrics: { scrollHeight: number; clientHeight: number; scrollTop: number }) {
+  Object.defineProperty(el, "scrollHeight", { value: metrics.scrollHeight, configurable: true });
+  Object.defineProperty(el, "clientHeight", { value: metrics.clientHeight, configurable: true });
+  el.scrollTop = metrics.scrollTop;
+}
+
+/** Mimic AutoHideScrollArea forwarding the viewport's scroll event to the engine. */
+function dispatchScroll(handle: { current: HarnessHandle }) {
+  act(() => {
+    handle.current.api.onViewportScroll(handle.current.viewport);
+  });
+}
+
+/** A user scroll to a position, then the resulting scroll event reaching the engine. */
+function userScroll(handle: { current: HarnessHandle }, scrollTop: number) {
+  handle.current.viewport.scrollTop = scrollTop;
+  dispatchScroll(handle);
+}
+
+describe("useTranscriptStickToBottom", () => {
+  describe("submit-stamp session scoping (PRO-175)", () => {
+    it("re-pins and snaps when the SAME session's stamp genuinely increases", () => {
+      const handle = renderStampHarness({ lastPromptSubmittedAtMs: 100, sessionKey: "workspace:session-a" });
+      const { viewport } = handle.current;
+      setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 400 });
+      userScroll(handle, 400);
+      expect(handle.current.api.isPinnedToBottom).toBe(false);
+
+      // A real new submit in the same session: stamp increases, same sessionKey.
+      act(() => {
+        handle.rerender({ lastPromptSubmittedAtMs: 200, sessionKey: "workspace:session-a" });
+      });
+      expect(handle.current.api.isPinnedToBottom).toBe(true);
+      expect(viewport.scrollTop).toBe(1000);
+    });
+
+    it("does NOT re-pin on a session switch even when the incoming session's stamp is higher than the outgoing session's", () => {
+      // Session A has no stamp; visiting it establishes a null baseline.
+      const handle = renderStampHarness({ lastPromptSubmittedAtMs: null, sessionKey: "workspace:session-a" });
+      const { viewport } = handle.current;
+      setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 400 });
+      userScroll(handle, 400);
+      expect(handle.current.api.isPinnedToBottom).toBe(false);
+
+      // Switch to session B, which carries its OWN pre-existing stamp (e.g. an
+      // old, already-settled submit still tracked as the session's current
+      // stamp — unrelated to this visit). Without session scoping, the stale
+      // `previous == null` comparison would treat this as a fresh submit and
+      // misfire a re-pin/snap/glue with zero new content.
+      act(() => {
+        handle.rerender({ lastPromptSubmittedAtMs: 50, sessionKey: "workspace:session-b" });
+      });
+      expect(handle.current.api.isPinnedToBottom).toBe(false);
+      expect(viewport.scrollTop).toBe(400);
+
+      // A genuinely new submit in session B (stamp increases within the SAME
+      // sessionKey) must still re-pin normally.
+      act(() => {
+        handle.rerender({ lastPromptSubmittedAtMs: 150, sessionKey: "workspace:session-b" });
+      });
+      expect(handle.current.api.isPinnedToBottom).toBe(true);
+      expect(viewport.scrollTop).toBe(1000);
+    });
+
+    it("re-baselines to the incoming session's current stamp so a later switch to a THIRD, unrelated session does not misfire either", () => {
+      // Session A (stamp 500) -> session B (no stamp) -> session C (stamp 10).
+      // C's stamp (10) is lower than A's (500) but the naive "previous == null"
+      // check after visiting B would still misfire without the session-scoped
+      // re-baseline, since B leaves the ref at null.
+      const handle = renderStampHarness({ lastPromptSubmittedAtMs: 500, sessionKey: "workspace:session-a" });
+      const { viewport } = handle.current;
+      setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 400 });
+      userScroll(handle, 400);
+      expect(handle.current.api.isPinnedToBottom).toBe(false);
+
+      act(() => {
+        handle.rerender({ lastPromptSubmittedAtMs: null, sessionKey: "workspace:session-b" });
+      });
+      expect(handle.current.api.isPinnedToBottom).toBe(false);
+
+      act(() => {
+        handle.rerender({ lastPromptSubmittedAtMs: 10, sessionKey: "workspace:session-c" });
+      });
+      expect(handle.current.api.isPinnedToBottom).toBe(false);
+      expect(viewport.scrollTop).toBe(400);
+    });
+  });
+});

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.test.tsx
@@ -85,6 +85,58 @@ function renderHarness(
   };
 }
 
+interface StampHarnessProps {
+  lastPromptSubmittedAtMs: number | null;
+  sessionKey: string;
+}
+
+interface StampHarnessController {
+  current: HarnessHandle;
+  rerender: (props: StampHarnessProps) => void;
+}
+
+/**
+ * Harness for the submit-stamp / session-identity interaction (PRO-175).
+ * Exposes `lastPromptSubmittedAtMs` and `sessionKey` as rerender-able props so
+ * a test can simulate a session switch (`sessionKey` changes on the same
+ * render as `lastPromptSubmittedAtMs`) without unmounting the hook — mirroring
+ * how the row lists never remount across a real session switch.
+ */
+function renderStampHarness(initial: StampHarnessProps): StampHarnessController {
+  const handle: { current: HarnessHandle | null } = { current: null };
+
+  function Harness({ lastPromptSubmittedAtMs, sessionKey }: StampHarnessProps) {
+    const scrollRef = useRef<HTMLDivElement>(null);
+    const api = useTranscriptStickToBottom({
+      scrollRef,
+      onScrollSample: vi.fn(),
+      lastPromptSubmittedAtMs,
+      sessionKey,
+    });
+    return (
+      <div
+        ref={(node) => {
+          scrollRef.current = node;
+          if (node) {
+            handle.current = { api, viewport: node };
+          }
+        }}
+        data-testid="viewport"
+      />
+    );
+  }
+
+  const rendered = render(<Harness {...initial} />);
+  return {
+    get current() {
+      return handle.current!;
+    },
+    rerender(props: StampHarnessProps) {
+      rendered.rerender(<Harness {...props} />);
+    },
+  };
+}
+
 function setMetrics(el: HTMLElement, metrics: { scrollHeight: number; clientHeight: number; scrollTop: number }) {
   Object.defineProperty(el, "scrollHeight", { value: metrics.scrollHeight, configurable: true });
   Object.defineProperty(el, "clientHeight", { value: metrics.clientHeight, configurable: true });
@@ -487,5 +539,73 @@ describe("useTranscriptStickToBottom", () => {
       flushRafRound();
     });
     expect(viewport.scrollTop).toBe(700);
+  });
+
+  describe("submit-stamp session scoping (PRO-175)", () => {
+    it("re-pins and snaps when the SAME session's stamp genuinely increases", () => {
+      const handle = renderStampHarness({ lastPromptSubmittedAtMs: 100, sessionKey: "workspace:session-a" });
+      const { viewport } = handle.current;
+      setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 400 });
+      userScroll(handle, 400);
+      expect(handle.current.api.isPinnedToBottom).toBe(false);
+
+      // A real new submit in the same session: stamp increases, same sessionKey.
+      act(() => {
+        handle.rerender({ lastPromptSubmittedAtMs: 200, sessionKey: "workspace:session-a" });
+      });
+      expect(handle.current.api.isPinnedToBottom).toBe(true);
+      expect(viewport.scrollTop).toBe(1000);
+    });
+
+    it("does NOT re-pin on a session switch even when the incoming session's stamp is higher than the outgoing session's", () => {
+      // Session A has no stamp; visiting it establishes a null baseline.
+      const handle = renderStampHarness({ lastPromptSubmittedAtMs: null, sessionKey: "workspace:session-a" });
+      const { viewport } = handle.current;
+      setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 400 });
+      userScroll(handle, 400);
+      expect(handle.current.api.isPinnedToBottom).toBe(false);
+
+      // Switch to session B, which carries its OWN pre-existing stamp (e.g. an
+      // old, already-settled submit still tracked as the session's current
+      // stamp — unrelated to this visit). Without session scoping, the stale
+      // `previous == null` comparison would treat this as a fresh submit and
+      // misfire a re-pin/snap/glue with zero new content.
+      act(() => {
+        handle.rerender({ lastPromptSubmittedAtMs: 50, sessionKey: "workspace:session-b" });
+      });
+      expect(handle.current.api.isPinnedToBottom).toBe(false);
+      expect(viewport.scrollTop).toBe(400);
+
+      // A genuinely new submit in session B (stamp increases within the SAME
+      // sessionKey) must still re-pin normally.
+      act(() => {
+        handle.rerender({ lastPromptSubmittedAtMs: 150, sessionKey: "workspace:session-b" });
+      });
+      expect(handle.current.api.isPinnedToBottom).toBe(true);
+      expect(viewport.scrollTop).toBe(1000);
+    });
+
+    it("re-baselines to the incoming session's current stamp so a later switch to a THIRD, unrelated session does not misfire either", () => {
+      // Session A (stamp 500) -> session B (no stamp) -> session C (stamp 10).
+      // C's stamp (10) is lower than A's (500) but the naive "previous == null"
+      // check after visiting B would still misfire without the session-scoped
+      // re-baseline, since B leaves the ref at null.
+      const handle = renderStampHarness({ lastPromptSubmittedAtMs: 500, sessionKey: "workspace:session-a" });
+      const { viewport } = handle.current;
+      setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 400 });
+      userScroll(handle, 400);
+      expect(handle.current.api.isPinnedToBottom).toBe(false);
+
+      act(() => {
+        handle.rerender({ lastPromptSubmittedAtMs: null, sessionKey: "workspace:session-b" });
+      });
+      expect(handle.current.api.isPinnedToBottom).toBe(false);
+
+      act(() => {
+        handle.rerender({ lastPromptSubmittedAtMs: 10, sessionKey: "workspace:session-c" });
+      });
+      expect(handle.current.api.isPinnedToBottom).toBe(false);
+      expect(viewport.scrollTop).toBe(400);
+    });
   });
 });

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.test.tsx
@@ -85,58 +85,6 @@ function renderHarness(
   };
 }
 
-interface StampHarnessProps {
-  lastPromptSubmittedAtMs: number | null;
-  sessionKey: string;
-}
-
-interface StampHarnessController {
-  current: HarnessHandle;
-  rerender: (props: StampHarnessProps) => void;
-}
-
-/**
- * Harness for the submit-stamp / session-identity interaction (PRO-175).
- * Exposes `lastPromptSubmittedAtMs` and `sessionKey` as rerender-able props so
- * a test can simulate a session switch (`sessionKey` changes on the same
- * render as `lastPromptSubmittedAtMs`) without unmounting the hook — mirroring
- * how the row lists never remount across a real session switch.
- */
-function renderStampHarness(initial: StampHarnessProps): StampHarnessController {
-  const handle: { current: HarnessHandle | null } = { current: null };
-
-  function Harness({ lastPromptSubmittedAtMs, sessionKey }: StampHarnessProps) {
-    const scrollRef = useRef<HTMLDivElement>(null);
-    const api = useTranscriptStickToBottom({
-      scrollRef,
-      onScrollSample: vi.fn(),
-      lastPromptSubmittedAtMs,
-      sessionKey,
-    });
-    return (
-      <div
-        ref={(node) => {
-          scrollRef.current = node;
-          if (node) {
-            handle.current = { api, viewport: node };
-          }
-        }}
-        data-testid="viewport"
-      />
-    );
-  }
-
-  const rendered = render(<Harness {...initial} />);
-  return {
-    get current() {
-      return handle.current!;
-    },
-    rerender(props: StampHarnessProps) {
-      rendered.rerender(<Harness {...props} />);
-    },
-  };
-}
-
 function setMetrics(el: HTMLElement, metrics: { scrollHeight: number; clientHeight: number; scrollTop: number }) {
   Object.defineProperty(el, "scrollHeight", { value: metrics.scrollHeight, configurable: true });
   Object.defineProperty(el, "clientHeight", { value: metrics.clientHeight, configurable: true });
@@ -540,72 +488,8 @@ describe("useTranscriptStickToBottom", () => {
     });
     expect(viewport.scrollTop).toBe(700);
   });
-
-  describe("submit-stamp session scoping (PRO-175)", () => {
-    it("re-pins and snaps when the SAME session's stamp genuinely increases", () => {
-      const handle = renderStampHarness({ lastPromptSubmittedAtMs: 100, sessionKey: "workspace:session-a" });
-      const { viewport } = handle.current;
-      setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 400 });
-      userScroll(handle, 400);
-      expect(handle.current.api.isPinnedToBottom).toBe(false);
-
-      // A real new submit in the same session: stamp increases, same sessionKey.
-      act(() => {
-        handle.rerender({ lastPromptSubmittedAtMs: 200, sessionKey: "workspace:session-a" });
-      });
-      expect(handle.current.api.isPinnedToBottom).toBe(true);
-      expect(viewport.scrollTop).toBe(1000);
-    });
-
-    it("does NOT re-pin on a session switch even when the incoming session's stamp is higher than the outgoing session's", () => {
-      // Session A has no stamp; visiting it establishes a null baseline.
-      const handle = renderStampHarness({ lastPromptSubmittedAtMs: null, sessionKey: "workspace:session-a" });
-      const { viewport } = handle.current;
-      setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 400 });
-      userScroll(handle, 400);
-      expect(handle.current.api.isPinnedToBottom).toBe(false);
-
-      // Switch to session B, which carries its OWN pre-existing stamp (e.g. an
-      // old, already-settled submit still tracked as the session's current
-      // stamp — unrelated to this visit). Without session scoping, the stale
-      // `previous == null` comparison would treat this as a fresh submit and
-      // misfire a re-pin/snap/glue with zero new content.
-      act(() => {
-        handle.rerender({ lastPromptSubmittedAtMs: 50, sessionKey: "workspace:session-b" });
-      });
-      expect(handle.current.api.isPinnedToBottom).toBe(false);
-      expect(viewport.scrollTop).toBe(400);
-
-      // A genuinely new submit in session B (stamp increases within the SAME
-      // sessionKey) must still re-pin normally.
-      act(() => {
-        handle.rerender({ lastPromptSubmittedAtMs: 150, sessionKey: "workspace:session-b" });
-      });
-      expect(handle.current.api.isPinnedToBottom).toBe(true);
-      expect(viewport.scrollTop).toBe(1000);
-    });
-
-    it("re-baselines to the incoming session's current stamp so a later switch to a THIRD, unrelated session does not misfire either", () => {
-      // Session A (stamp 500) -> session B (no stamp) -> session C (stamp 10).
-      // C's stamp (10) is lower than A's (500) but the naive "previous == null"
-      // check after visiting B would still misfire without the session-scoped
-      // re-baseline, since B leaves the ref at null.
-      const handle = renderStampHarness({ lastPromptSubmittedAtMs: 500, sessionKey: "workspace:session-a" });
-      const { viewport } = handle.current;
-      setMetrics(viewport, { scrollHeight: 1000, clientHeight: 300, scrollTop: 400 });
-      userScroll(handle, 400);
-      expect(handle.current.api.isPinnedToBottom).toBe(false);
-
-      act(() => {
-        handle.rerender({ lastPromptSubmittedAtMs: null, sessionKey: "workspace:session-b" });
-      });
-      expect(handle.current.api.isPinnedToBottom).toBe(false);
-
-      act(() => {
-        handle.rerender({ lastPromptSubmittedAtMs: 10, sessionKey: "workspace:session-c" });
-      });
-      expect(handle.current.api.isPinnedToBottom).toBe(false);
-      expect(viewport.scrollTop).toBe(400);
-    });
-  });
 });
+
+// The submit-stamp / session-identity scoping scenarios (PRO-175) live in
+// ./use-transcript-stick-to-bottom.session-stamp.test.tsx (split out to keep
+// this file under the repo's max-lines threshold).

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
@@ -35,6 +35,16 @@ export interface UseTranscriptStickToBottomOptions {
    * can only lower the stamp and must not re-pin.
    */
   lastPromptSubmittedAtMs?: number | null;
+  /**
+   * Identity of the session/workspace currently mounted (e.g.
+   * `${workspaceId}:${sessionId}`). The row lists never remount across a
+   * session switch, so `lastPromptSubmittedAtMs` alone can't distinguish "a
+   * fresh submit in this session" from "the incoming session's own current
+   * stamp, carried over from a stale prior comparison." A change here
+   * re-baselines the submit-stamp tracking to the incoming session's current
+   * value instead of comparing across the switch.
+   */
+  sessionKey?: string;
 }
 
 export interface TranscriptStickToBottom {
@@ -71,6 +81,7 @@ export function useTranscriptStickToBottom({
   repinThresholdPx = REPIN_BOTTOM_THRESHOLD_PX,
   autoFollowBottomInsetPx = 0,
   lastPromptSubmittedAtMs = null,
+  sessionKey,
 }: UseTranscriptStickToBottomOptions): TranscriptStickToBottom {
   const pinnedRef = useRef(true);
   const [isPinnedToBottom, setIsPinnedToBottom] = useState(true);
@@ -302,10 +313,30 @@ export function useTranscriptStickToBottom({
   // before consumer layout effects, so their pinned snaps read the restored
   // pin. Only a monotonic increase of the submission stamp qualifies — see
   // the option's contract.
+  //
+  // PRO-175: the row lists never remount on a session switch, so this ref
+  // would otherwise carry the PREVIOUS session's stamp across the switch. A
+  // revisited session's own (unrelated, possibly old) stamp then looks like a
+  // fresh increase and fires a spurious re-pin/snap/glue with zero new
+  // content. `sessionKey` scopes the comparison to session identity: a
+  // session-boundary crossing re-baselines the ref to the incoming session's
+  // CURRENT stamp (not null — nulling it would make the very next run see
+  // previous == null and misfire through the other door) and skips the
+  // compare for that render. `resetForSession` still unconditionally
+  // pins/snaps/glues on every switch by design; this only removes the SECOND,
+  // redundant re-pin the stale stamp used to trigger alongside it.
   const lastPromptSubmittedAtRef = useRef(lastPromptSubmittedAtMs);
+  const sessionKeyRef = useRef(sessionKey);
   useLayoutEffect(() => {
+    const previousSessionKey = sessionKeyRef.current;
+    sessionKeyRef.current = sessionKey;
     const previous = lastPromptSubmittedAtRef.current;
     lastPromptSubmittedAtRef.current = lastPromptSubmittedAtMs;
+    if (previousSessionKey !== undefined && previousSessionKey !== sessionKey) {
+      // Session boundary: the ref above is now the new baseline. Do not
+      // compare against the outgoing session's stamp.
+      return;
+    }
     if (
       lastPromptSubmittedAtMs != null
       && (previous == null || lastPromptSubmittedAtMs > previous)
@@ -314,7 +345,7 @@ export function useTranscriptStickToBottom({
       scrollToBottom();
       startGlueLoop();
     }
-  }, [lastPromptSubmittedAtMs, scrollToBottom, setPinned, startGlueLoop]);
+  }, [lastPromptSubmittedAtMs, scrollToBottom, sessionKey, setPinned, startGlueLoop]);
 
   // Session re-entry: snap instantly, then glue for a few frames so the
   // measurement backlog of freshly mounted rows (virtualizer estimates

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
@@ -9,6 +9,7 @@ import {
   TRANSCRIPT_USER_SCROLL_SETTLE_MS,
   type TranscriptScrollSample,
 } from "#product/hooks/chat/ui/transcript-row-list-model";
+import { useTranscriptSubmitStampRepin } from "#product/hooks/chat/ui/use-transcript-submit-stamp-repin";
 import { useTranscriptUserScrollIntent } from "#product/hooks/chat/ui/use-transcript-user-scroll-intent";
 
 function interactionNow(): number {
@@ -301,51 +302,18 @@ export function useTranscriptStickToBottom({
     glueFrameRef.current = requestAnimationFrame(tick);
   }, [scrollRef, scrollToBottom]);
 
-  // A prompt submit is an explicit return-to-bottom intent: re-pin even when
-  // the pin was silently lost earlier (so the sent bubble can never render
-  // clipped behind the dock), snap, and glue across the composer-collapse /
-  // row-measurement settle so the multi-frame geometry change lands as one
-  // silent jump, exactly like session re-entry. Unlike the scroll-to-bottom
-  // button, a submit does NOT consume the manual-only overlay range: the
-  // follow target stays the soft bottom above any dock-slot card, so the
-  // stream never slides under it (a range the user already consumed stays
-  // consumed until they scroll away). Registered after the inset effect above but
-  // before consumer layout effects, so their pinned snaps read the restored
-  // pin. Only a monotonic increase of the submission stamp qualifies — see
-  // the option's contract.
-  //
-  // PRO-175: the row lists never remount on a session switch, so this ref
-  // would otherwise carry the PREVIOUS session's stamp across the switch. A
-  // revisited session's own (unrelated, possibly old) stamp then looks like a
-  // fresh increase and fires a spurious re-pin/snap/glue with zero new
-  // content. `sessionKey` scopes the comparison to session identity: a
-  // session-boundary crossing re-baselines the ref to the incoming session's
-  // CURRENT stamp (not null — nulling it would make the very next run see
-  // previous == null and misfire through the other door) and skips the
-  // compare for that render. `resetForSession` still unconditionally
-  // pins/snaps/glues on every switch by design; this only removes the SECOND,
-  // redundant re-pin the stale stamp used to trigger alongside it.
-  const lastPromptSubmittedAtRef = useRef(lastPromptSubmittedAtMs);
-  const sessionKeyRef = useRef(sessionKey);
-  useLayoutEffect(() => {
-    const previousSessionKey = sessionKeyRef.current;
-    sessionKeyRef.current = sessionKey;
-    const previous = lastPromptSubmittedAtRef.current;
-    lastPromptSubmittedAtRef.current = lastPromptSubmittedAtMs;
-    if (previousSessionKey !== undefined && previousSessionKey !== sessionKey) {
-      // Session boundary: the ref above is now the new baseline. Do not
-      // compare against the outgoing session's stamp.
-      return;
-    }
-    if (
-      lastPromptSubmittedAtMs != null
-      && (previous == null || lastPromptSubmittedAtMs > previous)
-    ) {
-      setPinned(true);
-      scrollToBottom();
-      startGlueLoop();
-    }
-  }, [lastPromptSubmittedAtMs, scrollToBottom, sessionKey, setPinned, startGlueLoop]);
+  // A prompt submit is an explicit return-to-bottom intent (PRO-175 scopes it
+  // to session identity so a session switch can't misfire it) — see
+  // use-transcript-submit-stamp-repin.ts. Registered after the inset effect
+  // above but before consumer layout effects, so their pinned snaps read the
+  // restored pin.
+  useTranscriptSubmitStampRepin({
+    lastPromptSubmittedAtMs,
+    sessionKey,
+    setPinned,
+    scrollToBottom,
+    startGlueLoop,
+  });
 
   // Session re-entry: snap instantly, then glue for a few frames so the
   // measurement backlog of freshly mounted rows (virtualizer estimates

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-submit-stamp-repin.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-submit-stamp-repin.ts
@@ -1,0 +1,80 @@
+import { useLayoutEffect, useRef } from "react";
+
+export interface UseTranscriptSubmitStampRepinOptions {
+  /**
+   * Epoch ms of the newest prompt submission (outbox enqueue or session-level
+   * optimistic prompt). A monotonic increase re-pins: sending is an explicit
+   * return-to-bottom intent. Entries leaving the outbox (delivery, dismissal)
+   * can only lower the stamp and must not re-pin.
+   */
+  lastPromptSubmittedAtMs: number | null | undefined;
+  /**
+   * Identity of the session/workspace currently mounted (e.g.
+   * `${workspaceId}:${sessionId}`). The row lists never remount across a
+   * session switch, so `lastPromptSubmittedAtMs` alone can't distinguish "a
+   * fresh submit in this session" from "the incoming session's own current
+   * stamp, carried over from a stale prior comparison." A change here
+   * re-baselines the submit-stamp tracking to the incoming session's current
+   * value instead of comparing across the switch.
+   */
+  sessionKey: string | undefined;
+  setPinned: (pinned: boolean) => void;
+  scrollToBottom: () => void;
+  startGlueLoop: () => void;
+}
+
+/**
+ * A prompt submit is an explicit return-to-bottom intent: re-pin even when
+ * the pin was silently lost earlier (so the sent bubble can never render
+ * clipped behind the dock), snap, and glue across the composer-collapse /
+ * row-measurement settle so the multi-frame geometry change lands as one
+ * silent jump, exactly like session re-entry. Unlike the scroll-to-bottom
+ * button, a submit does NOT consume the manual-only overlay range: the
+ * follow target stays the soft bottom above any dock-slot card, so the
+ * stream never slides under it (a range the user already consumed stays
+ * consumed until they scroll away). Must be registered after the inset
+ * effect in `useTranscriptStickToBottom` but before consumer layout effects,
+ * so their pinned snaps read the restored pin. Only a monotonic increase of
+ * the submission stamp qualifies — see the option's contract.
+ *
+ * PRO-175: the row lists never remount on a session switch, so this ref
+ * would otherwise carry the PREVIOUS session's stamp across the switch. A
+ * revisited session's own (unrelated, possibly old) stamp then looks like a
+ * fresh increase and fires a spurious re-pin/snap/glue with zero new
+ * content. `sessionKey` scopes the comparison to session identity: a
+ * session-boundary crossing re-baselines the ref to the incoming session's
+ * CURRENT stamp (not null — nulling it would make the very next run see
+ * previous == null and misfire through the other door) and skips the
+ * compare for that render. `resetForSession` still unconditionally
+ * pins/snaps/glues on every switch by design; this only removes the SECOND,
+ * redundant re-pin the stale stamp used to trigger alongside it.
+ */
+export function useTranscriptSubmitStampRepin({
+  lastPromptSubmittedAtMs = null,
+  sessionKey,
+  setPinned,
+  scrollToBottom,
+  startGlueLoop,
+}: UseTranscriptSubmitStampRepinOptions): void {
+  const lastPromptSubmittedAtRef = useRef(lastPromptSubmittedAtMs);
+  const sessionKeyRef = useRef(sessionKey);
+  useLayoutEffect(() => {
+    const previousSessionKey = sessionKeyRef.current;
+    sessionKeyRef.current = sessionKey;
+    const previous = lastPromptSubmittedAtRef.current;
+    lastPromptSubmittedAtRef.current = lastPromptSubmittedAtMs;
+    if (previousSessionKey !== undefined && previousSessionKey !== sessionKey) {
+      // Session boundary: the ref above is now the new baseline. Do not
+      // compare against the outgoing session's stamp.
+      return;
+    }
+    if (
+      lastPromptSubmittedAtMs != null
+      && (previous == null || lastPromptSubmittedAtMs > previous)
+    ) {
+      setPinned(true);
+      scrollToBottom();
+      startGlueLoop();
+    }
+  }, [lastPromptSubmittedAtMs, scrollToBottom, sessionKey, setPinned, startGlueLoop]);
+}

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtualizer-blank-fallback.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtualizer-blank-fallback.test.tsx
@@ -32,13 +32,16 @@ function Harness({
   firstVirtualItem,
   lastVirtualItem,
   onFallback,
+  prependSettleUntil = 0,
 }: {
   firstVirtualItem: { index: number; start: number; end: number } | null;
   lastVirtualItem: { index: number; start: number; end: number } | null;
   onFallback: (reason: string) => void;
+  prependSettleUntil?: number;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const lastBlankReportSignatureRef = useRef<string | null>(null);
+  const prependSettleUntilRef = useRef(prependSettleUntil);
   useTranscriptVirtualizerBlankFallback({
     activeSessionId: "session-1",
     bottomSpacerHeight: 0,
@@ -46,6 +49,7 @@ function Harness({
     lastVirtualItem,
     lastBlankReportSignatureRef,
     onFallback,
+    prependSettleUntilRef,
     renderableRowCount: 100,
     rowCount: 100,
     scrollRef,
@@ -111,6 +115,65 @@ describe("useTranscriptVirtualizerBlankFallback", () => {
     expect(onFallback).not.toHaveBeenCalled();
     expect(frames).toHaveLength(1);
 
+    act(flushFrame);
+    expect(onFallback).toHaveBeenCalledWith("blank_viewport");
+  });
+
+  it("suppresses the blank fallback while an older-history prepend is still settling", () => {
+    // Same DOM-confirmed blank condition that falls back in the test above, but
+    // with a live prepend-settle grace window: the anchored scrollTop legitimately
+    // sits ahead of the still estimate-coordinate mounted range while the freshly
+    // prepended rows measure in, so the remount (which would reset scrollTop to 0)
+    // must be held off until the window lapses.
+    const onFallback = vi.fn();
+    const rendered = render(
+      <Harness
+        firstVirtualItem={{ index: 0, start: 0, end: 100 }}
+        lastVirtualItem={{ index: 1, start: 100, end: 200 }}
+        onFallback={onFallback}
+        prependSettleUntil={performance.now() + 100_000}
+      />,
+    );
+    const viewport = rendered.getByTestId("viewport") as HTMLDivElement;
+    setViewportMetrics(viewport, 2_000);
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function () {
+      const top = this === viewport ? 0 : 1_000;
+      const bottom = this === viewport ? 400 : 1_100;
+      return { top, bottom } as DOMRect;
+    });
+
+    // Far more frames than the two DOM-confirmations the un-graced path needs.
+    for (let i = 0; i < 6; i += 1) {
+      act(flushFrame);
+    }
+    expect(onFallback).not.toHaveBeenCalled();
+    // It keeps watching (re-arms each frame) rather than giving up.
+    expect(frames.length).toBeGreaterThan(0);
+  });
+
+  it("negative control: an already-lapsed prepend grace still falls back on a real blank", () => {
+    // Grace deadline in the past == no active prepend settle: the identical blank
+    // condition must remount exactly as it does with no grace at all, proving the
+    // suppression is scoped to the live settle window and not a blanket disable.
+    const onFallback = vi.fn();
+    const rendered = render(
+      <Harness
+        firstVirtualItem={{ index: 0, start: 0, end: 100 }}
+        lastVirtualItem={{ index: 1, start: 100, end: 200 }}
+        onFallback={onFallback}
+        prependSettleUntil={performance.now() - 1}
+      />,
+    );
+    const viewport = rendered.getByTestId("viewport") as HTMLDivElement;
+    setViewportMetrics(viewport, 2_000);
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function () {
+      const top = this === viewport ? 0 : 1_000;
+      const bottom = this === viewport ? 400 : 1_100;
+      return { top, bottom } as DOMRect;
+    });
+
+    act(flushFrame);
+    act(flushFrame);
     act(flushFrame);
     expect(onFallback).toHaveBeenCalledWith("blank_viewport");
   });

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtualizer-blank-fallback.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-virtualizer-blank-fallback.ts
@@ -5,6 +5,13 @@ import {
 } from "#product/lib/infra/measurement/measurement-port";
 import { recordTranscriptVirtualizerBlank } from "#product/lib/infra/diagnostics/renderer-diagnostic-migrations";
 
+// Bounded window (ms) after an older-history prepend during which the
+// blank-viewport fallback is suppressed while the freshly mounted rows correct
+// estimate -> measured height. A generous upper bound on that reconciliation
+// even on a slow/loaded runner; the anchored scrollTop legitimately sits ahead
+// of the still estimate-coordinate mounted range for that span and must not be
+// misread as a broken virtualizer (a remount resets scrollTop to 0).
+export const PREPEND_BLANK_FALLBACK_GRACE_MS = 3_000;
 const BLANK_VIEWPORT_MIN_SCROLLABLE_PX = 32;
 const BLANK_VIEWPORT_LOGICAL_CONFIRMATION_FRAMES = 2;
 const BLANK_VIEWPORT_DOM_CONFIRMATION_FRAMES = 2;
@@ -23,6 +30,7 @@ export function useTranscriptVirtualizerBlankFallback({
   lastVirtualItem,
   lastBlankReportSignatureRef,
   onFallback,
+  prependSettleUntilRef,
   renderableRowCount,
   rowCount,
   scrollRef,
@@ -37,6 +45,13 @@ export function useTranscriptVirtualizerBlankFallback({
   lastVirtualItem: TranscriptVirtualItemSnapshot | null;
   lastBlankReportSignatureRef: RefObject<string | null>;
   onFallback: (reason: string) => void;
+  /**
+   * Interaction-clock (performance.now) deadline until which a just-applied
+   * older-history prepend is still reconciling its freshly-mounted rows from
+   * estimate to measured height. Blank detection is suppressed until it lapses
+   * (see inspect). 0 (or absent) means no prepend is settling.
+   */
+  prependSettleUntilRef?: RefObject<number>;
   renderableRowCount: number;
   rowCount: number;
   scrollRef: RefObject<HTMLDivElement | null>;
@@ -62,6 +77,29 @@ export function useTranscriptVirtualizerBlankFallback({
       const viewport = scrollRef.current;
       if (!viewport) {
         suspicionRef.current = null;
+        return;
+      }
+
+      // While a just-applied older-history prepend is still reconciling its
+      // freshly-mounted rows from estimate to measured height, the engine
+      // deliberately holds scrollTop at an anchored position that can briefly
+      // sit ahead of the mounted virtual range (the range is in estimate
+      // coordinates until the taller real heights measure in — more pronounced
+      // on a slow/loaded runner and on WebKit, whose measurement delivery lags
+      // the anchor write further). That transient non-overlap is normal prepend
+      // settling, not a broken virtualizer, so it must never trip the blank
+      // remount: the remount unmounts the virtualized list and mounts a fresh
+      // full-DOM list whose new scroll container starts at scrollTop 0, with no
+      // pending anchor to restore — a full loss of the reading position (the CI
+      // webkit prepend "scrollTop 0"). Suppress detection until the bounded
+      // settle window lapses; genuine blankness re-arms the instant it does.
+      // (The reserved-slot / transient-block invariant that would make this a
+      // structural guarantee is rung 10; this is the minimal correct guard for
+      // the prepend anchor path.)
+      const nowMs = typeof performance === "undefined" ? Date.now() : performance.now();
+      if (nowMs < (prependSettleUntilRef?.current ?? 0)) {
+        suspicionRef.current = null;
+        frame = window.requestAnimationFrame(inspect);
         return;
       }
 
@@ -199,6 +237,7 @@ export function useTranscriptVirtualizerBlankFallback({
     lastVirtualItem,
     lastBlankReportSignatureRef,
     onFallback,
+    prependSettleUntilRef,
     renderableRowCount,
     rowCount,
     scrollRef,


### PR DESCRIPTION
Reopens rung 2 of the Chat Scroll ladder (PRO-187). Prior PR #1932 was auto-closed by GitHub when its base branch (rung 1) was deleted on #1928's squash-merge, and such PRs cannot be reopened. Same branch, rebased onto main past the r1 squash; content identical to #1932's reviewed state (review round CLEAN and Manual verification recorded on #1932). Head 653f73b8d. Part of Pablo's granted bottom-up merge of the ladder.