### PR TITLE
feat(product): read-only background terminal detail view (bgwork R3)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/activity/LiveTerminalsRosterPanel.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/LiveTerminalsRosterPanel.tsx
@@ -1,86 +1,35 @@
-import { useCallback, useState } from "react";
 import {
   sortProcessesForDisplay,
   type ActivityProcessWire,
 } from "#product/domain/activity/process";
 import { TerminalRosterRow } from "#product/components/workspace/activity/TerminalRosterRow";
 import { RosterPanel } from "#product/primitives/patterns/RosterPanel";
-import { useActiveSessionId } from "#product/hooks/chat/derived/use-active-session-identity";
-import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
-import { useFeedStream } from "#product/hooks/activity/derived/use-feed-stream";
 
 export interface LiveTerminalsRosterPanelProps {
   processes: ActivityProcessWire[];
   nowMs: number;
+  /** Opens the pane's `BackgroundTerminalView` detail seam for this row (rung R3). */
+  onOpen?: (processId: string) => void;
 }
 
 /**
- * The ▸ chip's click-in panel, live-wired: read-only agent-spawned background
- * processes with a click-to-expand live tail sourced from each row's opaque
- * `FeedRef` over `WS /v1/feeds/{feedId}`. Bytes flow only while a row is
- * expanded (lazy FeedService semantics). Presentation of the row header stays
- * in the shared `TerminalRosterRow`; this desktop wrapper owns the SDK feed
- * wiring and expansion state.
+ * The Background work pane's Terminals roster group: a read-only summary of
+ * agent-spawned background processes. Row selection routes to
+ * `BackgroundWorkPane`'s `BackgroundTerminalView` detail seam (Design
+ * Handoff — MODIFIED `TerminalRosterRow`; Delivery Spec — Background Work
+ * Slice 1, rung R3) rather than expanding a live tail inline — the detail
+ * view owns the feed wiring now, so this panel stays a plain, stateless
+ * roster like `AgentsRosterPanel`.
  */
-export function LiveTerminalsRosterPanel({ processes, nowMs }: LiveTerminalsRosterPanelProps) {
-  const activeSessionId = useActiveSessionId();
-  const workspaceId = useSessionDirectoryStore((state) =>
-    activeSessionId ? state.entriesById[activeSessionId]?.workspaceId ?? null : null,
-  );
-  const [expandedId, setExpandedId] = useState<string | null>(null);
-  const toggle = useCallback((processId: string) => {
-    setExpandedId((current) => (current === processId ? null : processId));
-  }, []);
-
+export function LiveTerminalsRosterPanel({ processes, nowMs, onOpen }: LiveTerminalsRosterPanelProps) {
   const sorted = sortProcessesForDisplay(processes);
   return (
     <RosterPanel title="Terminals" empty="No background terminals." data-terminals-roster-panel>
       {sorted.map((process) => (
         <li key={process.id}>
-          <LiveTerminalRow
-            process={process}
-            nowMs={nowMs}
-            workspaceId={workspaceId}
-            expanded={expandedId === process.id}
-            onToggle={toggle}
-          />
+          <TerminalRosterRow process={process} nowMs={nowMs} onOpen={onOpen} />
         </li>
       ))}
     </RosterPanel>
-  );
-}
-
-interface LiveTerminalRowProps {
-  process: ActivityProcessWire;
-  nowMs: number;
-  workspaceId: string | null;
-  expanded: boolean;
-  onToggle: (processId: string) => void;
-}
-
-function LiveTerminalRow({ process, nowMs, workspaceId, expanded, onToggle }: LiveTerminalRowProps) {
-  const feed = process.feed;
-  const { content, connected, error } = useFeedStream(feed, {
-    workspaceId,
-    enabled: expanded && feed !== null,
-  });
-
-  return (
-    <div>
-      <TerminalRosterRow
-        process={process}
-        nowMs={nowMs}
-        onOpen={feed ? onToggle : undefined}
-      />
-      {expanded && feed && (
-        <pre
-          className="mx-1.5 mb-1 max-h-40 overflow-auto whitespace-pre-wrap rounded-md bg-muted/40 px-2 py-1.5 font-mono text-readable-code leading-snug text-muted-foreground"
-          data-terminal-feed
-          data-telemetry-mask
-        >
-          {content || (error ?? (connected ? "Waiting for output…" : "Connecting…"))}
-        </pre>
-      )}
-    </div>
   );
 }

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundTerminalView.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundTerminalView.test.tsx
@@ -1,0 +1,107 @@
+/* @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ActivityProcessWire } from "#product/domain/activity/process";
+import { BackgroundTerminalView } from "./BackgroundTerminalView";
+
+let feedStreamState: { content: string; connected: boolean; error: string | null } = {
+  content: "",
+  connected: false,
+  error: null,
+};
+const useFeedStreamMock = vi.fn(() => feedStreamState);
+
+vi.mock("#product/hooks/chat/derived/use-active-session-identity", () => ({
+  useActiveSessionId: () => "session-1",
+}));
+vi.mock("#product/stores/sessions/session-directory-store", () => ({
+  useSessionDirectoryStore: () => "workspace-1",
+}));
+vi.mock("#product/hooks/activity/derived/use-feed-stream", () => ({
+  useFeedStream: (...args: unknown[]) => useFeedStreamMock(...args),
+}));
+
+function makeProcess(overrides: Partial<ActivityProcessWire> = {}): ActivityProcessWire {
+  return {
+    id: "proc-1",
+    command: "npm run build",
+    cwd: null,
+    status: { status: "running" },
+    pid: null,
+    startedAt: "2026-08-16T00:00:00Z",
+    endedAt: null,
+    feed: { feedId: "feed-1", kind: "terminal_bytes" },
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  feedStreamState = { content: "", connected: false, error: null };
+  useFeedStreamMock.mockClear();
+  cleanup();
+});
+
+describe("BackgroundTerminalView", () => {
+  it("renders the shell prompt line and the command exactly as run", () => {
+    render(
+      <BackgroundTerminalView process={makeProcess()} feed={makeProcess().feed} onBack={() => {}} />,
+    );
+    expect(screen.getByText("$")).toBeTruthy();
+    expect(screen.getAllByText("npm run build").length).toBeGreaterThan(0);
+  });
+
+  it("renders the feed's streamed bytes", () => {
+    feedStreamState = { content: "building…\ndone\n", connected: true, error: null };
+    render(
+      <BackgroundTerminalView process={makeProcess()} feed={makeProcess().feed} onBack={() => {}} />,
+    );
+    expect(screen.getByText(/building…/)).toBeTruthy();
+  });
+
+  it("renders the exact read-only footer copy", () => {
+    render(
+      <BackgroundTerminalView process={makeProcess()} feed={makeProcess().feed} onBack={() => {}} />,
+    );
+    expect(
+      screen.getByText("Read-only mirror of the agent's own output. No input, no resize, no kill."),
+    ).toBeTruthy();
+  });
+
+  it("has no input/textarea/select write affordance anywhere in the view", () => {
+    const { container } = render(
+      <BackgroundTerminalView process={makeProcess()} feed={makeProcess().feed} onBack={() => {}} />,
+    );
+    expect(container.querySelectorAll("input").length).toBe(0);
+    expect(container.querySelectorAll("textarea").length).toBe(0);
+    expect(container.querySelectorAll("select").length).toBe(0);
+  });
+
+  it("fires onBack when the back control is clicked", () => {
+    const onBack = vi.fn();
+    render(
+      <BackgroundTerminalView process={makeProcess()} feed={makeProcess().feed} onBack={onBack} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Back to background work" }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("enables the feed stream only when a feed ref is present", () => {
+    render(
+      <BackgroundTerminalView process={makeProcess()} feed={makeProcess().feed} onBack={() => {}} />,
+    );
+    expect(useFeedStreamMock).toHaveBeenCalledWith(
+      { feedId: "feed-1", kind: "terminal_bytes" },
+      { workspaceId: "workspace-1", enabled: true },
+    );
+  });
+
+  it("disables the feed stream when there is no feed ref", () => {
+    render(
+      <BackgroundTerminalView process={makeProcess({ feed: null })} feed={null} onBack={() => {}} />,
+    );
+    expect(useFeedStreamMock).toHaveBeenCalledWith(
+      null,
+      { workspaceId: "workspace-1", enabled: false },
+    );
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundTerminalView.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundTerminalView.tsx
@@ -1,0 +1,81 @@
+import { ArrowLeft } from "#product/primitives/icons/core";
+import { Terminal as TerminalIcon } from "#product/primitives/icons/workspace";
+import { PaneIconButton } from "#product/primitives/PaneIconButton";
+import { AutoHideScrollArea } from "#product/primitives/patterns/AutoHideScrollArea";
+import type { ActivityProcessWire, FeedRefWire } from "#product/domain/activity/process";
+import { useActiveSessionId } from "#product/hooks/chat/derived/use-active-session-identity";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import { useFeedStream } from "#product/hooks/activity/derived/use-feed-stream";
+
+export interface BackgroundTerminalViewProps {
+  process: ActivityProcessWire;
+  feed: FeedRefWire | null;
+  onBack: () => void;
+}
+
+/**
+ * Read-only detail view for one background process (Design Handoff — NEW
+ * `BackgroundTerminalView`; Delivery Spec — Background Work Slice 1, rung
+ * R3). Header on `TerminalTopBar`'s bar grammar (back + terminal glyph +
+ * title only); body on `TerminalPanel`'s viewport shell, rendering the shell
+ * prompt line, the command exactly as run, then the feed's bytes.
+ *
+ * Explicitly not a terminal: no status strip, no badges, no
+ * `TerminalCommandFloatingAction`, no xterm, no input/resize/kill
+ * affordance of any kind — this mirrors the agent's own output, it does not
+ * let the reader steer it.
+ *
+ * Bytes stream only while this view is mounted: `useFeedStream` is lazy
+ * (connects on mount, tears the socket down on unmount) and the pane only
+ * ever mounts this component while its own selection points at this
+ * process, so there is no separate "enabled" flag to thread through the
+ * frozen `process` / `feed` / `onBack` prop contract.
+ */
+export function BackgroundTerminalView({ process, feed, onBack }: BackgroundTerminalViewProps) {
+  const activeSessionId = useActiveSessionId();
+  const workspaceId = useSessionDirectoryStore((state) =>
+    activeSessionId ? state.entriesById[activeSessionId]?.workspaceId ?? null : null,
+  );
+  const { content, connected, error } = useFeedStream(feed, {
+    workspaceId,
+    enabled: feed !== null,
+  });
+
+  const bodyText = content || (feed ? (error ?? (connected ? "" : "Connecting…")) : "");
+
+  return (
+    <section
+      aria-label="Background work — terminal detail"
+      data-background-terminal-view=""
+      data-process-id={process.id}
+      className="flex h-full min-h-0 flex-col"
+    >
+      <header className="flex h-10 shrink-0 items-center gap-2 border-b border-border bg-sidebar px-2 text-sidebar-foreground">
+        <PaneIconButton label="Back to background work" onClick={onBack}>
+          <ArrowLeft className="icon-compact" />
+        </PaneIconButton>
+        <TerminalIcon
+          className="icon-paired shrink-0 [font-size:var(--text-sidebar-row)]"
+          aria-hidden
+        />
+        <span className="min-w-0 flex-1 truncate text-ui font-medium" title={process.command}>
+          {process.command}
+        </span>
+      </header>
+      <AutoHideScrollArea className="min-h-0 w-full flex-1 bg-sidebar" viewportClassName="p-3">
+        <pre
+          className="m-0 whitespace-pre-wrap font-mono text-readable-code text-sidebar-foreground"
+          data-telemetry-mask
+        >
+          <span className="text-sidebar-muted-foreground">$ </span>
+          <span>{process.command}</span>
+          {"\n"}
+          {bodyText}
+        </pre>
+      </AutoHideScrollArea>
+      <footer className="border-t border-border px-3 py-2 text-ui-sm text-muted-foreground">
+        Read-only mirror of the agent's own output. No input, no resize, no kill.
+      </footer>
+    </section>
+  );
+}

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundTerminalView.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundTerminalView.tsx
@@ -25,11 +25,14 @@ export interface BackgroundTerminalViewProps {
  * affordance of any kind — this mirrors the agent's own output, it does not
  * let the reader steer it.
  *
- * Bytes stream only while this view is mounted: `useFeedStream` is lazy
- * (connects on mount, tears the socket down on unmount) and the pane only
- * ever mounts this component while its own selection points at this
- * process, so there is no separate "enabled" flag to thread through the
- * frozen `process` / `feed` / `onBack` prop contract.
+ * Bytes stream only while a feed ref is actually handed in: `useFeedStream`
+ * is lazy (connects when `feed` is non-null, tears the socket down and
+ * resets to empty content otherwise). The right panel collapses via CSS
+ * (opacity/inert) rather than unmounting — this component stays mounted
+ * while the drawer is closed — so streaming cannot gate on mount alone;
+ * `BackgroundWorkPane` passes `feed={null}` while its own `isOpen` is false
+ * and hands the real `FeedRef` back on reopen, which is why this component's
+ * frozen `process` / `feed` / `onBack` prop contract needs no extra flag.
  */
 export function BackgroundTerminalView({ process, feed, onBack }: BackgroundTerminalViewProps) {
   const activeSessionId = useActiveSessionId();

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.tsx
@@ -22,15 +22,50 @@ vi.mock("#product/hooks/activity/derived/use-background-work-row", () => ({
   useBackgroundWorkRowCounts: () => rowCounts,
 }));
 
-// `LiveTerminalsRosterPanel` and `AgentsRosterPanel` own live feed wiring
-// (`useFeedStream`, `useSessionDirectoryStore`) that is out of scope for
-// this pane's own unit tests — R1/R2 review already exercises them
-// directly. Stubbed here so BackgroundWorkPane's own logic (scope
-// switching, counts, the subagent seam) is what's under test.
+// `LiveTerminalsRosterPanel`, `AgentsRosterPanel` and `BackgroundTerminalView`
+// own live feed wiring (`useFeedStream`, `useSessionDirectoryStore`) that is
+// out of scope for this pane's own unit tests — those components have their
+// own dedicated tests. Stubbed here so BackgroundWorkPane's own logic (scope
+// switching, counts, the terminal + subagent seams) is what's under test.
 vi.mock("#product/components/workspace/activity/LiveTerminalsRosterPanel", () => ({
-  LiveTerminalsRosterPanel: ({ processes }: { processes: ActivityProcessWire[] }) => (
+  LiveTerminalsRosterPanel: ({
+    processes,
+    onOpen,
+  }: {
+    processes: ActivityProcessWire[];
+    onOpen?: (id: string) => void;
+  }) => (
     <div data-testid="live-terminals-roster-panel">
-      {processes.map((process) => process.id).join(",")}
+      <span data-testid="live-terminals-roster-panel-ids">
+        {processes.map((process) => process.id).join(",")}
+      </span>
+      {processes.map((process) => (
+        <div
+          key={process.id}
+          role="button"
+          tabIndex={0}
+          data-testid={`open-process-${process.id}`}
+          onClick={() => onOpen?.(process.id)}
+        >
+          open {process.id}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+vi.mock("#product/components/workspace/activity/background-pane/BackgroundTerminalView", () => ({
+  BackgroundTerminalView: ({
+    process,
+    onBack,
+  }: {
+    process: ActivityProcessWire;
+    feed: unknown;
+    onBack: () => void;
+  }) => (
+    <div data-testid="background-terminal-view" data-process-id={process.id}>
+      <button type="button" onClick={onBack}>
+        Back to background work
+      </button>
     </div>
   ),
 }));
@@ -116,7 +151,7 @@ describe("BackgroundWorkPane", () => {
       agents: [makeAgent({ id: "agent-running" })],
     };
     render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
-    expect(screen.getByTestId("live-terminals-roster-panel").textContent).toBe("proc-running");
+    expect(screen.getByTestId("live-terminals-roster-panel-ids").textContent).toBe("proc-running");
     expect(screen.getByTestId("agents-roster-panel").textContent).toContain("agent-running");
   });
 
@@ -135,7 +170,7 @@ describe("BackgroundWorkPane", () => {
 
     fireEvent.click(screen.getByRole("radio", { name: "Closed (1)" }));
 
-    expect(screen.getByTestId("live-terminals-roster-panel").textContent).toBe("proc-exited");
+    expect(screen.getByTestId("live-terminals-roster-panel-ids").textContent).toBe("proc-exited");
     expect(screen.queryByTestId("agents-roster-panel")).toBeNull();
     expect(
       screen.getByText(
@@ -168,7 +203,7 @@ describe("BackgroundWorkPane", () => {
     expect(container.querySelectorAll("select").length).toBe(0);
   });
 
-  it("opening a subagent replaces the roster with the R3/R4 detail seam, and back returns", () => {
+  it("opening a subagent replaces the roster with the R4 placeholder seam, and back returns", () => {
     sessionActivity = {
       loops: [],
       loopCapabilities: { supported: false, native: false },
@@ -188,6 +223,45 @@ describe("BackgroundWorkPane", () => {
 
     expect(document.querySelector("[data-background-work-subagent-seam]")).toBeNull();
     expect(screen.getByTestId("agents-roster-panel")).toBeTruthy();
+  });
+
+  it("opening a terminal process replaces the roster with the real BackgroundTerminalView, and back returns", () => {
+    sessionActivity = {
+      loops: [],
+      loopCapabilities: { supported: false, native: false },
+      processes: [makeProcess({ id: "proc-77" })],
+      agents: [],
+    };
+    render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+
+    fireEvent.click(screen.getByTestId("open-process-proc-77"));
+
+    const view = screen.getByTestId("background-terminal-view");
+    expect(view.getAttribute("data-process-id")).toBe("proc-77");
+    expect(screen.queryByTestId("live-terminals-roster-panel")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to background work" }));
+
+    expect(screen.queryByTestId("background-terminal-view")).toBeNull();
+    expect(screen.getByTestId("live-terminals-roster-panel")).toBeTruthy();
+  });
+
+  it("opening a terminal process from the Closed scope also resolves the detail view", () => {
+    sessionActivity = {
+      loops: [],
+      loopCapabilities: { supported: false, native: false },
+      processes: [makeProcess({ id: "proc-exited", status: { status: "exited", exitCode: 0 } })],
+      agents: [],
+    };
+    rowCounts = { runningCount: 0, finishedCount: 1 };
+    render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+
+    fireEvent.click(screen.getByRole("radio", { name: "Closed (1)" }));
+    fireEvent.click(screen.getByTestId("open-process-proc-exited"));
+
+    expect(screen.getByTestId("background-terminal-view").getAttribute("data-process-id")).toBe(
+      "proc-exited",
+    );
   });
 
   it("resets to the Running scope when the session id changes", () => {
@@ -224,5 +298,24 @@ describe("BackgroundWorkPane", () => {
     rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-2" isOpen />);
 
     expect(document.querySelector("[data-background-work-subagent-seam]")).toBeNull();
+  });
+
+  it("closes the terminal detail seam when the session id changes", () => {
+    sessionActivity = {
+      loops: [],
+      loopCapabilities: { supported: false, native: false },
+      processes: [makeProcess({ id: "proc-99" })],
+      agents: [],
+    };
+    const { rerender } = render(
+      <BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />,
+    );
+
+    fireEvent.click(screen.getByTestId("open-process-proc-99"));
+    expect(screen.getByTestId("background-terminal-view")).toBeTruthy();
+
+    rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-2" isOpen />);
+
+    expect(screen.queryByTestId("background-terminal-view")).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.tsx
@@ -56,13 +56,18 @@ vi.mock("#product/components/workspace/activity/LiveTerminalsRosterPanel", () =>
 vi.mock("#product/components/workspace/activity/background-pane/BackgroundTerminalView", () => ({
   BackgroundTerminalView: ({
     process,
+    feed,
     onBack,
   }: {
     process: ActivityProcessWire;
-    feed: unknown;
+    feed: { feedId: string } | null;
     onBack: () => void;
   }) => (
-    <div data-testid="background-terminal-view" data-process-id={process.id}>
+    <div
+      data-testid="background-terminal-view"
+      data-process-id={process.id}
+      data-feed-enabled={String(feed !== null)}
+    >
       <button type="button" onClick={onBack}>
         Back to background work
       </button>
@@ -317,5 +322,41 @@ describe("BackgroundWorkPane", () => {
     rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-2" isOpen />);
 
     expect(screen.queryByTestId("background-terminal-view")).toBeNull();
+  });
+
+  it("disables the terminal feed while the right panel is collapsed (mounted, CSS-hidden), and re-enables it on reopen", () => {
+    sessionActivity = {
+      loops: [],
+      loopCapabilities: { supported: false, native: false },
+      processes: [
+        makeProcess({ id: "proc-live", feed: { feedId: "feed-1", kind: "terminal_bytes" } }),
+      ],
+      agents: [],
+    };
+    const { rerender } = render(
+      <BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />,
+    );
+
+    fireEvent.click(screen.getByTestId("open-process-proc-live"));
+    expect(
+      screen.getByTestId("background-terminal-view").getAttribute("data-feed-enabled"),
+    ).toBe("true");
+
+    // The right panel collapses via CSS (opacity/inert), staying mounted —
+    // `isOpen` flipping false is the pane's only signal for that. The
+    // terminal detail seam must keep rendering (no unmount) but stop
+    // streaming.
+    rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen={false} />);
+
+    expect(screen.getByTestId("background-terminal-view")).toBeTruthy();
+    expect(
+      screen.getByTestId("background-terminal-view").getAttribute("data-feed-enabled"),
+    ).toBe("false");
+
+    rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+
+    expect(
+      screen.getByTestId("background-terminal-view").getAttribute("data-feed-enabled"),
+    ).toBe("true");
   });
 });

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.tsx
@@ -5,6 +5,7 @@ import { SegmentedControl, type SegmentedControlItem } from "#product/primitives
 import { RosterPanel } from "#product/primitives/patterns/RosterPanel";
 import { AgentsRosterPanel } from "#product/components/workspace/activity/AgentsRosterPanel";
 import { LiveTerminalsRosterPanel } from "#product/components/workspace/activity/LiveTerminalsRosterPanel";
+import { BackgroundTerminalView } from "#product/components/workspace/activity/background-pane/BackgroundTerminalView";
 import { useSessionActivity } from "#product/hooks/activity/derived/use-session-activity";
 import { useBackgroundWorkRowCounts } from "#product/hooks/activity/derived/use-background-work-row";
 import { isProcessRunning } from "#product/domain/activity/process";
@@ -39,23 +40,25 @@ const CLOSED_SUBAGENTS_EMPTY_COPY =
  * Loops are descoped by founder ruling for this slice — `LoopsPanel` is not
  * re-hosted here and stays untouched at its current call site.
  *
- * Detail views (`BackgroundTerminalView`, `BackgroundSubagentView`) are rungs
- * R3/R4. `LiveTerminalsRosterPanel` keeps its own existing live-tail
- * expand-in-place click (untouched — R1 review already relied on it working).
- * `AgentsRosterPanel`'s `onOpen` stub becomes real here: selecting a
- * subagent row stores its id in pane-local state and swaps the roster body
- * for a minimal placeholder with a back button, clearly marked as the
- * R3/R4 seam `BackgroundSubagentView` fills in.
+ * `BackgroundTerminalView` (rung R3) is wired in below: selecting a terminal
+ * row stores its process id in pane-local state and swaps the roster body
+ * for the real read-only detail view. `BackgroundSubagentView` (rung R4) is
+ * still the placeholder seam below — `AgentsRosterPanel`'s `onOpen` stub
+ * becomes real here: selecting a subagent row stores its id in pane-local
+ * state and swaps the roster body for a minimal placeholder with a back
+ * button, clearly marked as the R4 seam `BackgroundSubagentView` fills in.
  */
 export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: BackgroundWorkPaneProps) {
   const [scope, setScope] = useState<BackgroundWorkScope>("running");
   const [selectedSubagentId, setSelectedSubagentId] = useState<string | null>(null);
+  const [selectedProcessId, setSelectedProcessId] = useState<string | null>(null);
   // Session-scoped by design (handoff — "Out of scope: workspace-level
   // persistence"): switching the active session resets the scope and closes
   // any open detail seam rather than carrying another session's selection.
   useEffect(() => {
     setScope("running");
     setSelectedSubagentId(null);
+    setSelectedProcessId(null);
   }, [sessionId]);
 
   // The roster subscription (`useSessionActivity`) that used to live on
@@ -81,6 +84,29 @@ export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: Backgroun
     { id: "running", label: `Running (${counts.runningCount})` },
     { id: "closed", label: `Closed (${closedCount})` },
   ];
+
+  const selectedProcess = selectedProcessId
+    ? activity.processes.find((process) => process.id === selectedProcessId) ?? null
+    : null;
+  // Processes never leave the roster on their own (unlike subagents, the
+  // Closed scope depends on this), so a selected id should always resolve.
+  // Clearing the stale selection is defensive, not an expected path — done
+  // in an effect rather than during render.
+  useEffect(() => {
+    if (selectedProcessId && !selectedProcess) {
+      setSelectedProcessId(null);
+    }
+  }, [selectedProcessId, selectedProcess]);
+
+  if (selectedProcess) {
+    return (
+      <BackgroundTerminalView
+        process={selectedProcess}
+        feed={selectedProcess.feed}
+        onBack={() => setSelectedProcessId(null)}
+      />
+    );
+  }
 
   if (selectedSubagentId) {
     return (
@@ -116,7 +142,11 @@ export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: Backgroun
         <div className="flex flex-col gap-3">
           {scope === "running" ? (
             <>
-              <LiveTerminalsRosterPanel processes={runningProcesses} nowMs={nowMs} />
+              <LiveTerminalsRosterPanel
+                processes={runningProcesses}
+                nowMs={nowMs}
+                onOpen={setSelectedProcessId}
+              />
               <AgentsRosterPanel
                 agents={activity.agents}
                 nowMs={nowMs}
@@ -125,7 +155,11 @@ export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: Backgroun
             </>
           ) : (
             <>
-              <LiveTerminalsRosterPanel processes={closedProcesses} nowMs={nowMs} />
+              <LiveTerminalsRosterPanel
+                processes={closedProcesses}
+                nowMs={nowMs}
+                onOpen={setSelectedProcessId}
+              />
               {/* Subagents never appear in Closed: they leave the roster the
                   instant they finish (session-activity-architecture rule
                   the Closed scope depends on). `RosterPanel`'s own `empty`
@@ -149,7 +183,7 @@ export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: Backgroun
 }
 
 /**
- * R3/R4 seam: a minimal, clearly-labeled placeholder standing in for
+ * R4 seam: a minimal, clearly-labeled placeholder standing in for
  * `BackgroundSubagentView` (rung R4). Keeps the selected subagent id in
  * pane-local state (owned by the parent) and offers only a back action —
  * no transcript, no composer, nothing to interact with yet.

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.tsx
@@ -102,7 +102,17 @@ export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: Backgroun
     return (
       <BackgroundTerminalView
         process={selectedProcess}
-        feed={selectedProcess.feed}
+        // The right panel collapses via CSS (opacity/inert), not unmount
+        // (`WorkspaceShellRightRail`) — a collapsed-but-still-mounted detail
+        // view must stop streaming rather than keep the socket open
+        // invisibly. `useFeedStream` resets to empty content the instant
+        // `enabled` goes false (no partial-content retention to preserve),
+        // so gating at this seam — rather than adding a second prop to
+        // `BackgroundTerminalView`'s frozen (process, feed, onBack) contract
+        // — is both simplest and matches the acceptance line "feed re-tails
+        // on detail open": reopening hands the real feed back and the view
+        // re-tails from scratch.
+        feed={isOpen ? selectedProcess.feed : null}
         onBack={() => setSelectedProcessId(null)}
       />
     );


### PR DESCRIPTION
## What

New `BackgroundTerminalView` (`apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundTerminalView.tsx`): a read-only detail view for one background process. Header on `TerminalTopBar`'s bar grammar (back `PaneIconButton` + `Terminal` glyph + the command as title); body on `TerminalPanel`'s viewport shell, rendering the shell prompt line, the command exactly as run, then the feed's bytes via the existing `useFeedStream` hook (lazy, plain text, capped buffer); footer copy exactly as specified. Explicitly not: status strip, badge, `TerminalCommandFloatingAction`, xterm, any input affordance.

Wired into `BackgroundWorkPane`'s terminal seam: a new `selectedProcessId` state (mirroring the existing `selectedSubagentId` seam) swaps the roster body for `BackgroundTerminalView` when a Terminals roster row is opened, from either the Running or Closed scope. `LiveTerminalsRosterPanel` drops its own inline expand-in-place state and `useFeedStream` wiring (that responsibility moves to the detail view) and becomes a plain `onOpen`-routing roster, the same shape as `AgentsRosterPanel`.

## Why

Rung R3 of the Background Work delivery spec. Source: Design Handoff — `HANDOFF-background-work.md` (NEW `BackgroundTerminalView`; MODIFIED `BashCommandCall`); Delivery Spec — Background Work Slice 1, rung R3.

## Review round 1 (MINOR, fixed)

**Finding:** `BackgroundTerminalView` gated its feed only on `feed !== null`. The right panel collapses via CSS (`opacity-0`/`inert` on `WorkspaceShellRightRail`) rather than unmounting, so opening a terminal detail then collapsing the drawer left the socket streaming invisibly until `onBack` or a session change.

**Fix:** checked `useFeedStream`'s behavior when `enabled` flips false — it resets to `IDLE` (empty content) immediately rather than retaining partial content, so there's nothing to preserve across a collapse/reopen cycle. Gated at the `BackgroundWorkPane` seam instead of adding a prop: `feed={isOpen ? selectedProcess.feed : null}`. `BackgroundTerminalView`'s frozen `(process, feed, onBack)` prop contract is untouched — this is shape (b) from the two options considered, chosen because content does not survive a disable/re-enable cycle, and it matches the acceptance line "feed re-tails on detail open" (reopening hands back the real `FeedRef` and the view re-tails from scratch). Also corrected a docstring sentence that had gone stale on the (false, once CSS-only collapse is accounted for) premise that the view is only ever mounted while open.

Added a test asserting the feed-enabled signal reaching `BackgroundTerminalView` flips off when `isOpen` goes false with a detail still selected (detail seam stays rendered, not unmounted) and back on on reopen.

## Gap report — `BashCommandCall` MODIFIED not implemented this rung (independently verified correct)

The handoff and delivery spec also ask: for a tool call the activity domain knows as a background process, its transcript row click-opens the pane's terminal view instead of the inline output disclosure (ordinary commands keep the inline panel unchanged).

I traced the correlation this needs end to end and found **none exists in this repo**:

- `anyharness-contract`'s `ActivityProcess` (`anyharness/crates/anyharness-contract/src/v1/activity.rs`) and the wire payload `ActivityProcessWire` (`anyharness-lib`'s `domains/activity/wire.rs`) carry only `id, command, cwd, status, pid, startedAt/startedAtMs, endedAt/endedAtMs, feed` — `id` is the harness's own process/task id, with no field referencing the originating tool call.
- The SDK's `ToolCallItem` (`anyharness/sdk/src/types/reducer.ts`) carries `toolCallId`/`itemId`, with nothing pointing the other way either.
- The one existing tool-call ↔ background-work correlation in this repo, `reducer/background-work.ts`'s `ToolBackgroundWorkMetadata` (`trackerKind: "claude_async_agent"`, `agentId`), is scoped to **async subagent launches** (consumed by `domain/chats/subagents/subagent-launch.ts` for `SubagentLaunchLedger`), not bash processes — there is no equivalent tracker kind for background bash.
- RF's own acceptance debt item ("live probe that `task_started.task_id === BashOutput.backgroundTaskId`") lives entirely in the forked `claude-agent-acp` repo and is explicitly unverified even there (per the Delivery Spec's RF entry).

Per the assignment's explicit instruction to stop and report rather than invent a heuristic here, `BashCommandCall.tsx` is untouched this rung: background-originating and ordinary bash commands render identically today (current behavior preserved). This is the concrete contradiction to resolve — either by exposing a real correlation on the wire (an RF/runtime change) or by a founder ruling to defer this half of R3 — before the click-through can be built without guessing.

## Tests

- `BackgroundTerminalView.test.tsx`: renders the shell prompt line + command + streamed feed content, exact footer copy, asserts no `input`/`textarea`/`select` anywhere, `onBack` fires, `useFeedStream` is called with `enabled: true` only when a feed ref is present (`enabled: false` otherwise).
- `BackgroundWorkPane.test.tsx`: opening a terminal row (Running and Closed scope) swaps in the real `BackgroundTerminalView` with the right process id; back returns to the roster; the seam closes on session-id change; and (review-round addition) the feed-enabled signal flips off/on as `isOpen` toggles false/true while the detail seam stays mounted.

## Gates (current head)

- Affected vitest (`BackgroundTerminalView.test.tsx` + `BackgroundWorkPane.test.tsx`): **19/19 passed**
- Full `product-client` vitest: **1003 files / 7226 tests passed**
- `tsc -p tsconfig.domain.json --noEmit`: 1 error — `TS2741` in `src/domain/workflows/run-view-model.ts:75` (missing `cancelled` key in `RUN_STATUS_TONE`). Confirmed pre-existing on the R2 base (`origin/bgwork/r2-background-work-pane`), unrelated to this diff — attributed, not chased.
- `tsc -p tsconfig.json --noEmit`: same single exogenous error, no new errors.
- `python3 scripts/report_frontend_structure.py --strict`: **0 violations** across all `FE-STRUCT-*`/`FE-SIZE-1` categories.
- `python3 scripts/check_appearance_scaling.py`: **passed**.

Draft PR, stacked on `bgwork/r2-background-work-pane`. Not merging — awaiting review.