### PR TITLE
feat(product): read-only background subagent detail view (bgwork R4)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/activity/AgentsRosterPanel.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/AgentsRosterPanel.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { AgentsRosterPanel } from "#product/components/workspace/activity/AgentsRosterPanel";
+import type { ActivitySubagentWire } from "#product/domain/activity/subagent";
+
+afterEach(cleanup);
+
+function subagent(overrides: Partial<ActivitySubagentWire>): ActivitySubagentWire {
+  return {
+    id: "agent-1",
+    agentType: "general-purpose",
+    description: "Inspect the transcript pipeline",
+    model: null,
+    background: false,
+    status: { status: "running" },
+    usage: null,
+    feed: null,
+    ...overrides,
+  };
+}
+
+describe("AgentsRosterPanel", () => {
+  it("shows only running agents and threads workspaceId to each row", () => {
+    const { container, getByText, queryByText } = render(
+      <AgentsRosterPanel
+        workspaceId="workspace-1"
+        nowMs={0}
+        agents={[
+          subagent({ id: "agent-running", status: { status: "running" } }),
+          subagent({
+            id: "agent-done",
+            description: "Finished task",
+            status: { status: "completed", summary: null },
+          }),
+        ]}
+      />,
+    );
+
+    expect(getByText("Inspect the transcript pipeline")).not.toBeNull();
+    expect(queryByText("Finished task")).toBeNull();
+    expect(container.querySelectorAll("[data-subagent-roster-row]")).toHaveLength(1);
+    // Every glyph rendered has a real generated color, proving the row
+    // received a non-empty workspaceId/sessionId all the way through.
+    const svg = container.querySelector("[data-subagent-roster-row] svg");
+    expect(svg?.getAttribute("style")).toMatch(/color:/);
+  });
+
+  it("shows the empty copy when no native subagent is running", () => {
+    const { getByText } = render(
+      <AgentsRosterPanel workspaceId="workspace-1" nowMs={0} agents={[]} />,
+    );
+
+    expect(getByText("No active native subagents.")).not.toBeNull();
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/activity/AgentsRosterPanel.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/AgentsRosterPanel.tsx
@@ -5,6 +5,7 @@ import { SubagentRosterRow } from "./SubagentRosterRow";
 export interface AgentsRosterPanelProps {
   agents: ActivitySubagentWire[];
   nowMs: number;
+  workspaceId: string;
   onOpen?: (subagentId: string) => void;
 }
 
@@ -17,7 +18,7 @@ export interface AgentsRosterPanelProps {
  * (`features/delegated-work.md`) as a new `subagent` source, inheriting
  * generated identity/color there.
  */
-export function AgentsRosterPanel({ agents, nowMs, onOpen }: AgentsRosterPanelProps) {
+export function AgentsRosterPanel({ agents, nowMs, workspaceId, onOpen }: AgentsRosterPanelProps) {
   const runningAgents = agents.filter((agent) => agent.status.status === "running");
   const sorted = sortSubagentsForDisplay(runningAgents);
   return (
@@ -28,7 +29,7 @@ export function AgentsRosterPanel({ agents, nowMs, onOpen }: AgentsRosterPanelPr
     >
       {sorted.map((agent) => (
         <li key={agent.id}>
-          <SubagentRosterRow subagent={agent} nowMs={nowMs} onOpen={onOpen} />
+          <SubagentRosterRow subagent={agent} nowMs={nowMs} workspaceId={workspaceId} onOpen={onOpen} />
         </li>
       ))}
     </RosterPanel>

--- a/apps/packages/product-client/src/components/workspace/activity/SubagentRosterRow.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/SubagentRosterRow.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SubagentRosterRow } from "#product/components/workspace/activity/SubagentRosterRow";
+import { buildDelegatedAgentIdentity } from "#product/lib/domain/delegated-work/identity";
+import type { ActivitySubagentWire } from "#product/domain/activity/subagent";
+
+afterEach(cleanup);
+
+const SUBAGENT: ActivitySubagentWire = {
+  id: "agent-1",
+  agentType: "general-purpose",
+  description: "Inspect the transcript pipeline",
+  model: "claude-sonnet",
+  background: false,
+  status: { status: "running" },
+  usage: null,
+  feed: null,
+};
+
+describe("SubagentRosterRow", () => {
+  it("renders a generated identity glyph consistent with buildDelegatedAgentIdentity for the same id", () => {
+    const { container } = render(
+      <SubagentRosterRow subagent={SUBAGENT} nowMs={0} workspaceId="workspace-1" />,
+    );
+
+    const expectedIdentity = buildDelegatedAgentIdentity({
+      id: SUBAGENT.id,
+      title: "Inspect the transcript pipeline",
+      workspaceId: "workspace-1",
+      sessionId: SUBAGENT.id,
+    });
+
+    const svg = container.querySelector("[data-subagent-roster-row] svg");
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute("style")).toContain(expectedIdentity.colorVar);
+  });
+
+  it("fires onOpen with the subagent id on select", () => {
+    let openedId: string | null = null;
+    const { getByText } = render(
+      <SubagentRosterRow
+        subagent={SUBAGENT}
+        nowMs={0}
+        workspaceId="workspace-1"
+        onOpen={(id) => {
+          openedId = id;
+        }}
+      />,
+    );
+
+    fireEvent.click(getByText("Inspect the transcript pipeline"));
+
+    expect(openedId).toBe("agent-1");
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/activity/SubagentRosterRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/SubagentRosterRow.tsx
@@ -1,4 +1,3 @@
-import { Fork } from "#product/primitives/icons/core";
 import {
   subagentDisplayTitle,
   subagentStatusLabel,
@@ -9,7 +8,8 @@ import {
 } from "#product/domain/activity/subagent";
 import { statusDotToneTextClass, type StatusDotTone } from "#product/primitives/StatusDot";
 import { RosterRow } from "#product/primitives/patterns/RosterRow";
-import { twMerge } from "#product/primitives/utils/tw-merge";
+import { AgentIdentityGlyph } from "#product/components/patterns/AgentIdentityGlyph";
+import { buildDelegatedAgentIdentity } from "#product/lib/domain/delegated-work/identity";
 
 const SUBAGENT_STATUS_DOT_TONE: Record<SubagentTone, StatusDotTone> = {
   default: "muted",
@@ -20,6 +20,7 @@ const SUBAGENT_STATUS_DOT_TONE: Record<SubagentTone, StatusDotTone> = {
 export interface SubagentRosterRowProps {
   subagent: ActivitySubagentWire;
   nowMs: number;
+  workspaceId: string;
   /** Optional per-row click-in, e.g. to open the existing delegated-work details surface. */
   onOpen?: (subagentId: string) => void;
 }
@@ -28,18 +29,29 @@ export interface SubagentRosterRowProps {
  * A read-only roster row for a harness-native subagent (Claude Task agent,
  * Codex collab child thread, Cursor `cursor/task`). This roster feeds a new
  * delegated-work *source* (see `activitySubagentToDelegatedWorkFields` in
- * the shared domain layer) — this row is the interim standalone rendering until a
- * follow-up pass merges it into the existing delegated-work surfaces
- * (`features/delegated-work.md`), which own generated identity/color.
+ * the shared domain layer).
+ *
+ * The row's glyph is generated via `buildDelegatedAgentIdentity` from the
+ * roster's own durable id (`ActivitySubagentWire.id` — Claude's Task
+ * `agentId`, Codex's collab thread id) so this chip, the detail view's
+ * header, and any other surface referencing the same subagent all agree on
+ * one generated name/color/glyph (Design Handoff — native subagent identity;
+ * Delivery Spec — Background Work Slice 1, rung R4).
  */
-export function SubagentRosterRow({ subagent, nowMs, onOpen }: SubagentRosterRowProps) {
+export function SubagentRosterRow({ subagent, nowMs, workspaceId, onOpen }: SubagentRosterRowProps) {
   const tone = SUBAGENT_STATUS_DOT_TONE[subagentStatusTone(subagent)];
   const durationLabel = subagentUsageDurationLabel(subagent.usage, nowMs);
   const displayTitle = subagentDisplayTitle(subagent);
+  const identity = buildDelegatedAgentIdentity({
+    id: subagent.id,
+    title: displayTitle,
+    workspaceId,
+    sessionId: subagent.id,
+  });
 
   return (
     <RosterRow
-      leading={<Fork className={twMerge("icon-paired", statusDotToneTextClass(tone))} aria-hidden />}
+      leading={<AgentIdentityGlyph identity={identity} dimension={16} />}
       title={<span data-telemetry-mask title={displayTitle}>{displayTitle}</span>}
       secondary={(
         <>

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundSubagentView.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundSubagentView.test.tsx
@@ -1,0 +1,225 @@
+/* @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTranscriptState } from "@anyharness/sdk";
+import type { ToolCallItem, TranscriptState } from "@anyharness/sdk";
+import type { ActivitySubagentWire } from "#product/domain/activity/subagent";
+import { BackgroundSubagentView } from "./BackgroundSubagentView";
+
+let feedStreamState: { content: string; connected: boolean; error: string | null } = {
+  content: "",
+  connected: false,
+  error: null,
+};
+const useFeedStreamMock = vi.fn(() => feedStreamState);
+
+let transcriptState: { transcript: TranscriptState | null } = { transcript: null };
+let sessionAgentKind: string | null = "claude";
+
+vi.mock("#product/stores/sessions/session-directory-store", () => ({
+  useSessionDirectoryStore: (selector: (state: {
+    entriesById: Record<string, { agentKind: string } | undefined>;
+  }) => unknown) =>
+    selector({
+      entriesById: sessionAgentKind
+        ? { "session-1": { agentKind: sessionAgentKind } }
+        : {},
+    }),
+}));
+vi.mock("#product/hooks/chat/derived/use-active-session-transcript-state", () => ({
+  useTranscriptPaneStateForSession: () => transcriptState,
+}));
+vi.mock("#product/hooks/activity/derived/use-feed-stream", () => ({
+  useFeedStream: (...args: unknown[]) => useFeedStreamMock(...args),
+}));
+
+function makeSubagent(overrides: Partial<ActivitySubagentWire> = {}): ActivitySubagentWire {
+  return {
+    id: "agent-1",
+    agentType: "general-purpose",
+    description: "Inspect the transcript pipeline",
+    model: "claude-sonnet",
+    background: true,
+    status: { status: "running" },
+    usage: null,
+    feed: { feedId: "feed-1", kind: "transcript" },
+    ...overrides,
+  };
+}
+
+function launchToolCallItem(overrides: Partial<ToolCallItem> = {}): ToolCallItem {
+  return {
+    kind: "tool_call",
+    itemId: "tool-launch",
+    turnId: "turn-1",
+    status: "completed",
+    sourceAgentKind: "claude",
+    messageId: null,
+    title: null,
+    nativeToolName: "Agent",
+    parentToolCallId: null,
+    rawInput: { run_in_background: true, prompt: "Inspect the transcript pipeline." },
+    rawOutput: {
+      isAsync: true,
+      agentId: "agent-1",
+      outputFile: "/tmp/task.output",
+      _anyharness: { backgroundWork: { trackerKind: "claude_async_agent", state: "pending" } },
+    },
+    contentParts: [],
+    timestamp: "2026-08-16T00:00:00Z",
+    startedSeq: 1,
+    lastUpdatedSeq: 1,
+    completedSeq: 1,
+    completedAt: "2026-08-16T00:00:00Z",
+    toolCallId: "toolu_1",
+    toolKind: "think",
+    semanticKind: "subagent",
+    approvalState: "none",
+    ...overrides,
+  } as ToolCallItem;
+}
+
+afterEach(() => {
+  feedStreamState = { content: "", connected: false, error: null };
+  transcriptState = { transcript: null };
+  sessionAgentKind = "claude";
+  useFeedStreamMock.mockClear();
+  cleanup();
+});
+
+describe("BackgroundSubagentView", () => {
+  it("renders the header identity, status, and provider", () => {
+    render(
+      <BackgroundSubagentView
+        subagent={makeSubagent()}
+        sessionId="session-1"
+        workspaceId="workspace-1"
+        onBack={() => {}}
+      />,
+    );
+    expect(screen.getAllByText("Inspect the transcript pipeline").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Running/)).toBeTruthy();
+    expect(screen.getByText(/Claude/)).toBeTruthy();
+    expect(screen.getByText("read only")).toBeTruthy();
+  });
+
+  it("renders the correlated launch tool call's initial prompt", () => {
+    const transcript = createTranscriptState("session-1");
+    const item = launchToolCallItem();
+    transcript.itemsById[item.itemId] = item;
+    transcriptState = { transcript };
+
+    render(
+      <BackgroundSubagentView
+        subagent={makeSubagent()}
+        sessionId="session-1"
+        workspaceId="workspace-1"
+        onBack={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Initial prompt")).toBeTruthy();
+    expect(screen.getByText("Inspect the transcript pipeline.")).toBeTruthy();
+  });
+
+  it("omits the initial-prompt panel when no launch tool call correlates", () => {
+    const transcript = createTranscriptState("session-1");
+    transcriptState = { transcript };
+
+    render(
+      <BackgroundSubagentView
+        subagent={makeSubagent()}
+        sessionId="session-1"
+        workspaceId="workspace-1"
+        onBack={() => {}}
+      />,
+    );
+
+    expect(screen.queryByText("Initial prompt")).toBeNull();
+  });
+
+  it("renders the feed's raw tail content (Codex-style fallback used for every harness)", () => {
+    feedStreamState = { content: "Working on the task…\n", connected: true, error: null };
+    render(
+      <BackgroundSubagentView
+        subagent={makeSubagent()}
+        sessionId="session-1"
+        workspaceId="workspace-1"
+        onBack={() => {}}
+      />,
+    );
+    expect(screen.getByText(/Working on the task…/)).toBeTruthy();
+  });
+
+  it("renders the exact read-only footer copy and no composer", () => {
+    render(
+      <BackgroundSubagentView
+        subagent={makeSubagent()}
+        sessionId="session-1"
+        workspaceId="workspace-1"
+        onBack={() => {}}
+      />,
+    );
+    expect(
+      screen.getByText("Read-only. Transcript mirrored from the agent; no composer."),
+    ).toBeTruthy();
+  });
+
+  it("has no input/textarea/select write affordance anywhere in the view", () => {
+    const { container } = render(
+      <BackgroundSubagentView
+        subagent={makeSubagent()}
+        sessionId="session-1"
+        workspaceId="workspace-1"
+        onBack={() => {}}
+      />,
+    );
+    expect(container.querySelectorAll("input").length).toBe(0);
+    expect(container.querySelectorAll("textarea").length).toBe(0);
+    expect(container.querySelectorAll("select").length).toBe(0);
+  });
+
+  it("fires onBack when the back control is clicked", () => {
+    const onBack = vi.fn();
+    render(
+      <BackgroundSubagentView
+        subagent={makeSubagent()}
+        sessionId="session-1"
+        workspaceId="workspace-1"
+        onBack={onBack}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Back to background work" }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("enables the feed stream only when a feed ref is present", () => {
+    render(
+      <BackgroundSubagentView
+        subagent={makeSubagent()}
+        sessionId="session-1"
+        workspaceId="workspace-1"
+        onBack={() => {}}
+      />,
+    );
+    expect(useFeedStreamMock).toHaveBeenCalledWith(
+      { feedId: "feed-1", kind: "transcript" },
+      { workspaceId: "workspace-1", enabled: true },
+    );
+  });
+
+  it("disables the feed stream when there is no feed ref", () => {
+    render(
+      <BackgroundSubagentView
+        subagent={makeSubagent({ feed: null })}
+        sessionId="session-1"
+        workspaceId="workspace-1"
+        onBack={() => {}}
+      />,
+    );
+    expect(useFeedStreamMock).toHaveBeenCalledWith(
+      null,
+      { workspaceId: "workspace-1", enabled: false },
+    );
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundSubagentView.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundSubagentView.test.tsx
@@ -138,7 +138,7 @@ describe("BackgroundSubagentView", () => {
     expect(screen.queryByText("Initial prompt")).toBeNull();
   });
 
-  it("renders the feed's raw tail content (Codex-style fallback used for every harness)", () => {
+  it("renders the feed's raw tail content (raw-tail fallback used for every harness)", () => {
     feedStreamState = { content: "Working on the task…\n", connected: true, error: null };
     render(
       <BackgroundSubagentView

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundSubagentView.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundSubagentView.tsx
@@ -1,0 +1,158 @@
+import { ArrowLeft } from "#product/primitives/icons/core";
+import { StickyNote } from "#product/primitives/icons/product";
+import { Button } from "#product/primitives/Button";
+import { Badge } from "#product/primitives/Badge";
+import { AgentIdentityGlyph } from "#product/components/patterns/AgentIdentityGlyph";
+import { AutoHideScrollArea } from "#product/primitives/patterns/AutoHideScrollArea";
+import { ToolActionDetailsPanel } from "#product/components/workspace/chat/tool-calls/ToolActionDetailsPanel";
+import { MarkdownBody } from "#product/components/workspace/chat/transcript/MarkdownBody";
+import { renderDesktopCodeBlock } from "#product/components/content/ui/desktop-markdown-code-block";
+import { TOOL_CALL_BODY_MAX_HEIGHT_CLASS } from "#product/domain/chats/tools/tool-call-layout";
+import {
+  subagentDisplayTitle,
+  subagentStatusLabel,
+  type ActivitySubagentWire,
+} from "#product/domain/activity/subagent";
+import {
+  findSubagentLaunchItem,
+  resolveSubagentLaunchDisplay,
+} from "#product/domain/chats/subagents/subagent-launch";
+import { buildDelegatedAgentIdentity } from "#product/lib/domain/delegated-work/identity";
+import { getProviderDisplayName } from "#product/lib/domain/agents/provider-display";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import { useTranscriptPaneStateForSession } from "#product/hooks/chat/derived/use-active-session-transcript-state";
+import { useFeedStream } from "#product/hooks/activity/derived/use-feed-stream";
+
+export interface BackgroundSubagentViewProps {
+  subagent: ActivitySubagentWire;
+  sessionId: string;
+  workspaceId: string;
+  onBack: () => void;
+}
+
+/**
+ * Read-only detail view for one harness-native subagent (Design Handoff —
+ * NEW `BackgroundSubagentView`; Delivery Spec — Background Work Slice 1,
+ * rung R4). Header on `AgentsPaneDetail`'s grammar: back + generated
+ * identity glyph + title + `Status · provider` + a "read only" `Badge`.
+ * Body: the launch tool call's initial prompt (when one correlates — see
+ * `findSubagentLaunchItem`), then the child's own output. Footer replaces
+ * `AgentsPaneComposer` with a fixed read-only line — no composer, no input,
+ * ever.
+ *
+ * BLOCKER (reported per `implement-pr-slice` discipline, same class as R3's
+ * `BashCommandCall` stop): the handoff's "Feed fidelity" note calls
+ * transcript-shaped `MessageList` rendering "honest for Claude today"
+ * because "the child transcript arrives as a JSONL tail over `tail_file`."
+ * That is not what the runtime actually sends. `open_tail_file`
+ * (`anyharness-lib/src/domains/activity/feeds.rs`) always emits raw
+ * `FeedFrame::Bytes` regardless of `FeedKind`, and the WS handler
+ * (`api/ws/feeds.rs`) does no JSONL→ACP translation — a Claude subagent's
+ * `tail_file` feed carries Claude's own native CLI session-log JSONL
+ * (`parentUuid`/`isSidechain`/`uuid` fields), not the `SessionEventEnvelope`
+ * shape `@anyharness/sdk`'s reducer (and therefore `MessageList`, which
+ * requires a `TranscriptState`) needs. No translator for this exists
+ * anywhere in the repo. This view therefore renders the feed as plain text
+ * for every harness — the same raw-tail treatment the handoff already rules
+ * for Codex (pending the `acp_child_demux` binding) — rather than inventing
+ * a client-side JSONL-to-ACP translator that is out of this slice's scope.
+ */
+export function BackgroundSubagentView({
+  subagent,
+  sessionId,
+  workspaceId,
+  onBack,
+}: BackgroundSubagentViewProps) {
+  const displayTitle = subagentDisplayTitle(subagent);
+  const identity = buildDelegatedAgentIdentity({
+    id: subagent.id,
+    title: displayTitle,
+    workspaceId,
+    sessionId: subagent.id,
+  });
+  const providerKind = useSessionDirectoryStore((state) => state.entriesById[sessionId]?.agentKind ?? null);
+  const providerLabel = providerKind ? getProviderDisplayName(providerKind) : null;
+
+  const { transcript } = useTranscriptPaneStateForSession(sessionId);
+  const launchItem = transcript ? findSubagentLaunchItem(transcript, subagent.id) : null;
+  const promptText = launchItem ? resolveSubagentLaunchDisplay(launchItem).prompt : null;
+
+  const { content, connected, error } = useFeedStream(subagent.feed, {
+    workspaceId,
+    enabled: subagent.feed !== null,
+  });
+  const bodyText = content || (subagent.feed ? (error ?? (connected ? "" : "Connecting…")) : "");
+
+  return (
+    <section
+      aria-label={`Subagent ${displayTitle}`}
+      data-background-subagent-view=""
+      data-subagent-id={subagent.id}
+      className="flex h-full min-h-0 flex-col"
+    >
+      <header className="flex shrink-0 flex-col gap-1 border-b border-border px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Back to background work"
+            onClick={onBack}
+          >
+            <ArrowLeft className="icon-compact" />
+          </Button>
+          <AgentIdentityGlyph identity={identity} dimension={20} label={identity.generatedName} />
+          <div className="flex min-w-0 flex-1 flex-col">
+            <span className="truncate text-ui font-medium text-foreground" title={displayTitle}>
+              {displayTitle}
+            </span>
+            <span className="truncate text-ui-sm text-muted-foreground">
+              {subagentStatusLabel(subagent)}
+              {providerLabel && (
+                <>
+                  {" · "}
+                  {providerLabel}
+                </>
+              )}
+            </span>
+          </div>
+          <Badge size="micro">read only</Badge>
+        </div>
+      </header>
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {promptText && (
+          <div className="shrink-0 px-3 pt-2">
+            <ToolActionDetailsPanel>
+              <div className="flex items-center gap-1.5 border-b border-border/60 px-3 py-1.5 text-ui-sm text-muted-foreground">
+                <StickyNote aria-hidden="true" className="icon-compact shrink-0 text-faint" />
+                <span>Initial prompt</span>
+              </div>
+              <AutoHideScrollArea className="w-full" viewportClassName={TOOL_CALL_BODY_MAX_HEIGHT_CLASS}>
+                <div className="px-3 py-2 text-chat leading-relaxed text-muted-foreground" data-telemetry-mask>
+                  <MarkdownBody
+                    content={promptText}
+                    className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+                    renderCodeBlock={renderDesktopCodeBlock}
+                  />
+                </div>
+              </AutoHideScrollArea>
+            </ToolActionDetailsPanel>
+          </div>
+        )}
+        <AutoHideScrollArea className="min-h-0 w-full flex-1" viewportClassName="p-3">
+          <pre
+            className="m-0 whitespace-pre-wrap font-mono text-readable-code text-foreground"
+            data-telemetry-mask
+          >
+            {bodyText}
+          </pre>
+        </AutoHideScrollArea>
+      </div>
+
+      <footer className="border-t border-border px-3 py-2 text-ui-sm text-muted-foreground">
+        Read-only. Transcript mirrored from the agent; no composer.
+      </footer>
+    </section>
+  );
+}

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.tsx
@@ -80,6 +80,7 @@ vi.mock("#product/components/workspace/activity/AgentsRosterPanel", () => ({
     onOpen,
   }: {
     agents: ActivitySubagentWire[];
+    workspaceId: string;
     onOpen?: (id: string) => void;
   }) => (
     <div data-testid="agents-roster-panel">
@@ -94,6 +95,25 @@ vi.mock("#product/components/workspace/activity/AgentsRosterPanel", () => ({
           {agent.id}
         </div>
       ))}
+    </div>
+  ),
+}));
+vi.mock("#product/components/workspace/activity/background-pane/BackgroundSubagentView", () => ({
+  BackgroundSubagentView: ({
+    subagent,
+    onBack,
+  }: {
+    subagent: ActivitySubagentWire;
+    onBack: () => void;
+  }) => (
+    <div
+      data-testid="background-subagent-view"
+      data-subagent-id={subagent.id}
+      data-feed-enabled={String(subagent.feed !== null)}
+    >
+      <button type="button" onClick={onBack}>
+        Back to background work
+      </button>
     </div>
   ),
 }));
@@ -208,7 +228,7 @@ describe("BackgroundWorkPane", () => {
     expect(container.querySelectorAll("select").length).toBe(0);
   });
 
-  it("opening a subagent replaces the roster with the R4 placeholder seam, and back returns", () => {
+  it("opening a subagent replaces the roster with the real BackgroundSubagentView, and back returns", () => {
     sessionActivity = {
       loops: [],
       loopCapabilities: { supported: false, native: false },
@@ -219,15 +239,69 @@ describe("BackgroundWorkPane", () => {
 
     fireEvent.click(screen.getByTestId("open-subagent-agent-42"));
 
-    const seam = document.querySelector("[data-background-work-subagent-seam]");
-    expect(seam).not.toBeNull();
-    expect(seam?.getAttribute("data-subagent-id")).toBe("agent-42");
+    const view = screen.getByTestId("background-subagent-view");
+    expect(view.getAttribute("data-subagent-id")).toBe("agent-42");
     expect(screen.queryByTestId("agents-roster-panel")).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Back to background work" }));
 
-    expect(document.querySelector("[data-background-work-subagent-seam]")).toBeNull();
+    expect(screen.queryByTestId("background-subagent-view")).toBeNull();
     expect(screen.getByTestId("agents-roster-panel")).toBeTruthy();
+  });
+
+  it("bounces back to the roster once a viewed subagent leaves it (finished)", () => {
+    sessionActivity = {
+      loops: [],
+      loopCapabilities: { supported: false, native: false },
+      processes: [],
+      agents: [makeAgent({ id: "agent-42" })],
+    };
+    const { rerender } = render(
+      <BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />,
+    );
+
+    fireEvent.click(screen.getByTestId("open-subagent-agent-42"));
+    expect(screen.getByTestId("background-subagent-view")).toBeTruthy();
+
+    // Subagents leave the roster the instant they finish (unlike processes),
+    // so the next activity snapshot simply omits it.
+    sessionActivity = { ...sessionActivity, agents: [] };
+    rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+
+    expect(screen.queryByTestId("background-subagent-view")).toBeNull();
+    expect(screen.getByTestId("agents-roster-panel")).toBeTruthy();
+  });
+
+  it("disables the subagent feed while the right panel is collapsed, and re-enables it on reopen", () => {
+    sessionActivity = {
+      loops: [],
+      loopCapabilities: { supported: false, native: false },
+      processes: [],
+      agents: [
+        makeAgent({ id: "agent-live", feed: { feedId: "feed-2", kind: "transcript" } }),
+      ],
+    };
+    const { rerender } = render(
+      <BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />,
+    );
+
+    fireEvent.click(screen.getByTestId("open-subagent-agent-live"));
+    expect(
+      screen.getByTestId("background-subagent-view").getAttribute("data-feed-enabled"),
+    ).toBe("true");
+
+    rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen={false} />);
+
+    expect(screen.getByTestId("background-subagent-view")).toBeTruthy();
+    expect(
+      screen.getByTestId("background-subagent-view").getAttribute("data-feed-enabled"),
+    ).toBe("false");
+
+    rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+
+    expect(
+      screen.getByTestId("background-subagent-view").getAttribute("data-feed-enabled"),
+    ).toBe("true");
   });
 
   it("opening a terminal process replaces the roster with the real BackgroundTerminalView, and back returns", () => {
@@ -298,11 +372,11 @@ describe("BackgroundWorkPane", () => {
     );
 
     fireEvent.click(screen.getByTestId("open-subagent-agent-99"));
-    expect(document.querySelector("[data-background-work-subagent-seam]")).not.toBeNull();
+    expect(screen.getByTestId("background-subagent-view")).toBeTruthy();
 
     rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-2" isOpen />);
 
-    expect(document.querySelector("[data-background-work-subagent-seam]")).toBeNull();
+    expect(screen.queryByTestId("background-subagent-view")).toBeNull();
   });
 
   it("closes the terminal detail seam when the session id changes", () => {

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.tsx
@@ -5,6 +5,7 @@ import type { ActivityProcessWire } from "#product/domain/activity/process";
 import type { ActivitySubagentWire } from "#product/domain/activity/subagent";
 import type { BackgroundWorkRowCounts } from "#product/domain/activity/background-work-row";
 import type { SessionActivityState } from "#product/hooks/activity/derived/use-session-activity";
+import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 import { BackgroundWorkPane } from "./BackgroundWorkPane";
 
 let sessionActivity: SessionActivityState = {
@@ -155,6 +156,9 @@ afterEach(() => {
   };
   rowCounts = { runningCount: 0, finishedCount: 0 };
   cleanup();
+  useWorkspaceUiStore.setState({
+    pendingBackgroundSubagentSelectionByWorkspace: {},
+  });
 });
 
 describe("BackgroundWorkPane", () => {
@@ -302,6 +306,50 @@ describe("BackgroundWorkPane", () => {
     expect(
       screen.getByTestId("background-subagent-view").getAttribute("data-feed-enabled"),
     ).toBe("true");
+  });
+
+  it("consumes a pending subagent selection from the transcript click seam and clears it", () => {
+    sessionActivity = {
+      loops: [],
+      loopCapabilities: { supported: false, native: false },
+      processes: [],
+      agents: [makeAgent({ id: "agent-42" })],
+    };
+    // Delivery Spec — Background Work Slice 1, rung R4 fix-forward: a native
+    // subagent's transcript block click writes here via
+    // `useOpenBackgroundWorkPane`'s extended return, keyed by the same
+    // `workspaceId` this pane receives as a prop.
+    useWorkspaceUiStore.getState().setPendingBackgroundSubagentSelectionForWorkspace(
+      "ws-1",
+      "agent-42",
+    );
+
+    render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+
+    const view = screen.getByTestId("background-subagent-view");
+    expect(view.getAttribute("data-subagent-id")).toBe("agent-42");
+    // One-shot: consumed and cleared, not left to reopen on a later render.
+    expect(
+      useWorkspaceUiStore.getState().pendingBackgroundSubagentSelectionByWorkspace["ws-1"],
+    ).toBeNull();
+  });
+
+  it("ignores a pending subagent selection for a different workspace", () => {
+    sessionActivity = {
+      loops: [],
+      loopCapabilities: { supported: false, native: false },
+      processes: [],
+      agents: [makeAgent({ id: "agent-42" })],
+    };
+    useWorkspaceUiStore.getState().setPendingBackgroundSubagentSelectionForWorkspace(
+      "ws-other",
+      "agent-42",
+    );
+
+    render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+
+    expect(screen.queryByTestId("background-subagent-view")).toBeNull();
+    expect(screen.getByTestId("agents-roster-panel")).toBeTruthy();
   });
 
   it("opening a terminal process replaces the roster with the real BackgroundTerminalView, and back returns", () => {

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.tsx
@@ -318,10 +318,11 @@ describe("BackgroundWorkPane", () => {
     // Delivery Spec — Background Work Slice 1, rung R4 fix-forward: a native
     // subagent's transcript block click writes here via
     // `useOpenBackgroundWorkPane`'s extended return, keyed by the same
-    // `workspaceId` this pane receives as a prop.
+    // `workspaceId` this pane receives as a prop, carrying the session
+    // active at write time.
     useWorkspaceUiStore.getState().setPendingBackgroundSubagentSelectionForWorkspace(
       "ws-1",
-      "agent-42",
+      { subagentId: "agent-42", sessionId: "sess-1" },
     );
 
     render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
@@ -343,13 +344,44 @@ describe("BackgroundWorkPane", () => {
     };
     useWorkspaceUiStore.getState().setPendingBackgroundSubagentSelectionForWorkspace(
       "ws-other",
-      "agent-42",
+      { subagentId: "agent-42", sessionId: "sess-1" },
     );
 
     render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
 
     expect(screen.queryByTestId("background-subagent-view")).toBeNull();
     expect(screen.getByTestId("agents-roster-panel")).toBeTruthy();
+  });
+
+  it("discards (does not apply) a pending subagent selection written for a different session in the same workspace", () => {
+    // Same subagent id happens to also exist in THIS session's roster —
+    // deliberately, so the pre-existing "bounce back if the id isn't in the
+    // roster" defensive effect can't be the thing masking a wrong-session
+    // leak. Only the session-id check on consume should be why this stays
+    // on the roster instead of opening the (wrong) subagent's detail.
+    sessionActivity = {
+      loops: [],
+      loopCapabilities: { supported: false, native: false },
+      processes: [],
+      agents: [makeAgent({ id: "agent-42" })],
+    };
+    // Written while a DIFFERENT session ("sess-other") was active in this
+    // same workspace — the exact cross-session race reviewed in rung R4
+    // fix-forward round 2.
+    useWorkspaceUiStore.getState().setPendingBackgroundSubagentSelectionForWorkspace(
+      "ws-1",
+      { subagentId: "agent-42", sessionId: "sess-other" },
+    );
+
+    render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+
+    expect(screen.queryByTestId("background-subagent-view")).toBeNull();
+    expect(screen.getByTestId("agents-roster-panel")).toBeTruthy();
+    // Still one-shot: discarded, not left dangling for a later session to
+    // pick up by accident.
+    expect(
+      useWorkspaceUiStore.getState().pendingBackgroundSubagentSelectionByWorkspace["ws-1"],
+    ).toBeNull();
   });
 
   it("opening a terminal process replaces the roster with the real BackgroundTerminalView, and back returns", () => {

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.tsx
@@ -8,6 +8,7 @@ import { BackgroundSubagentView } from "#product/components/workspace/activity/b
 import { useSessionActivity } from "#product/hooks/activity/derived/use-session-activity";
 import { useBackgroundWorkRowCounts } from "#product/hooks/activity/derived/use-background-work-row";
 import { isProcessRunning } from "#product/domain/activity/process";
+import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 
 // Same 15s cadence as the shared `useActivityNowMs`, but reimplemented locally
 // rather than reusing it: that hook is documented to tick unconditionally
@@ -108,6 +109,33 @@ export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: Backgroun
       setSelectedSubagentId(null);
     }
   }, [selectedSubagentId, selectedSubagent]);
+
+  // Deep-open target: a native subagent's transcript block click
+  // (`TranscriptAgentGroupBlock`'s `onOpenSubagent`, threaded through
+  // `useOpenBackgroundWorkPane`'s extended return) writes a one-shot pending
+  // selection into the right-panel model rather than reaching into this pane
+  // directly (Delivery Spec — Background Work Slice 1, rung R4 fix-forward).
+  // Consume it the instant it appears and clear it immediately — a single
+  // writer (the transcript click), a single reader (here), so there is no
+  // race to arbitrate, unlike `pendingChatActivationByWorkspace`'s
+  // epoch/nonce machinery.
+  const pendingSubagentSelection = useWorkspaceUiStore(
+    (state) => state.pendingBackgroundSubagentSelectionByWorkspace[workspaceId] ?? null,
+  );
+  const clearPendingBackgroundSubagentSelectionForWorkspace = useWorkspaceUiStore(
+    (state) => state.clearPendingBackgroundSubagentSelectionForWorkspace,
+  );
+  useEffect(() => {
+    if (!pendingSubagentSelection) {
+      return;
+    }
+    setSelectedSubagentId(pendingSubagentSelection);
+    clearPendingBackgroundSubagentSelectionForWorkspace(workspaceId);
+  }, [
+    clearPendingBackgroundSubagentSelectionForWorkspace,
+    pendingSubagentSelection,
+    workspaceId,
+  ]);
 
   if (selectedProcess) {
     return (

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.tsx
@@ -116,9 +116,17 @@ export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: Backgroun
   // selection into the right-panel model rather than reaching into this pane
   // directly (Delivery Spec — Background Work Slice 1, rung R4 fix-forward).
   // Consume it the instant it appears and clear it immediately — a single
-  // writer (the transcript click), a single reader (here), so there is no
-  // race to arbitrate, unlike `pendingChatActivationByWorkspace`'s
-  // epoch/nonce machinery.
+  // writer (the transcript click), a single reader (here).
+  //
+  // Session-scoped on read (review round 2): the entry is keyed by
+  // workspace only, but carries the `sessionId` that was active at write
+  // time. A click can land here for a session other than this pane's own
+  // (e.g. the active session flips between the write and this effect
+  // running, or the click originated from an embedded transcript for a
+  // different session in the same workspace) — mismatched entries are
+  // discarded rather than applied, whether this is a fresh mount or an
+  // already-mounted re-render, so a stale cross-session id never leaks into
+  // this session's roster lookup.
   const pendingSubagentSelection = useWorkspaceUiStore(
     (state) => state.pendingBackgroundSubagentSelectionByWorkspace[workspaceId] ?? null,
   );
@@ -129,11 +137,14 @@ export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: Backgroun
     if (!pendingSubagentSelection) {
       return;
     }
-    setSelectedSubagentId(pendingSubagentSelection);
+    if (pendingSubagentSelection.sessionId === sessionId) {
+      setSelectedSubagentId(pendingSubagentSelection.subagentId);
+    }
     clearPendingBackgroundSubagentSelectionForWorkspace(workspaceId);
   }, [
     clearPendingBackgroundSubagentSelectionForWorkspace,
     pendingSubagentSelection,
+    sessionId,
     workspaceId,
   ]);
 

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.tsx
@@ -1,11 +1,10 @@
 import { useEffect, useState } from "react";
-import { ArrowLeft } from "#product/primitives/icons/core";
-import { Button } from "#product/primitives/Button";
 import { SegmentedControl, type SegmentedControlItem } from "#product/primitives/SegmentedControl";
 import { RosterPanel } from "#product/primitives/patterns/RosterPanel";
 import { AgentsRosterPanel } from "#product/components/workspace/activity/AgentsRosterPanel";
 import { LiveTerminalsRosterPanel } from "#product/components/workspace/activity/LiveTerminalsRosterPanel";
 import { BackgroundTerminalView } from "#product/components/workspace/activity/background-pane/BackgroundTerminalView";
+import { BackgroundSubagentView } from "#product/components/workspace/activity/background-pane/BackgroundSubagentView";
 import { useSessionActivity } from "#product/hooks/activity/derived/use-session-activity";
 import { useBackgroundWorkRowCounts } from "#product/hooks/activity/derived/use-background-work-row";
 import { isProcessRunning } from "#product/domain/activity/process";
@@ -40,13 +39,10 @@ const CLOSED_SUBAGENTS_EMPTY_COPY =
  * Loops are descoped by founder ruling for this slice — `LoopsPanel` is not
  * re-hosted here and stays untouched at its current call site.
  *
- * `BackgroundTerminalView` (rung R3) is wired in below: selecting a terminal
- * row stores its process id in pane-local state and swaps the roster body
- * for the real read-only detail view. `BackgroundSubagentView` (rung R4) is
- * still the placeholder seam below — `AgentsRosterPanel`'s `onOpen` stub
- * becomes real here: selecting a subagent row stores its id in pane-local
- * state and swaps the roster body for a minimal placeholder with a back
- * button, clearly marked as the R4 seam `BackgroundSubagentView` fills in.
+ * `BackgroundTerminalView` (rung R3) and `BackgroundSubagentView` (rung R4)
+ * are both wired in below: selecting a roster row stores its id in
+ * pane-local state and swaps the roster body for the matching real
+ * read-only detail view.
  */
 export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: BackgroundWorkPaneProps) {
   const [scope, setScope] = useState<BackgroundWorkScope>("running");
@@ -98,6 +94,21 @@ export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: Backgroun
     }
   }, [selectedProcessId, selectedProcess]);
 
+  const selectedSubagent = selectedSubagentId
+    ? activity.agents.find((agent) => agent.id === selectedSubagentId) ?? null
+    : null;
+  // Unlike processes, subagents DO leave the roster the instant they finish
+  // (the invariant the Closed scope depends on — see `CLOSED_SUBAGENTS_EMPTY_COPY`
+  // above), so losing the resolved subagent here is an expected path, not
+  // just a defensive guard. Bouncing back to the roster is correct: there is
+  // nothing left to mirror live, and the subagent's own final result already
+  // lives in the transcript.
+  useEffect(() => {
+    if (selectedSubagentId && !selectedSubagent) {
+      setSelectedSubagentId(null);
+    }
+  }, [selectedSubagentId, selectedSubagent]);
+
   if (selectedProcess) {
     return (
       <BackgroundTerminalView
@@ -118,11 +129,20 @@ export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: Backgroun
     );
   }
 
-  if (selectedSubagentId) {
+  if (selectedSubagent) {
     return (
-      <BackgroundWorkSubagentSeam
+      <BackgroundSubagentView
+        subagent={
+          // Same feed-gating seam as `BackgroundTerminalView` above: the
+          // right panel stays mounted-but-hidden via CSS while closed, so
+          // streaming must stop at this boundary rather than at mount.
+          // `BackgroundSubagentView`'s frozen (subagent, sessionId,
+          // workspaceId, onBack) contract has no separate feed prop, so the
+          // gate clones the roster entry with its `feed` nulled instead.
+          isOpen ? selectedSubagent : { ...selectedSubagent, feed: null }
+        }
+        sessionId={sessionId}
         workspaceId={workspaceId}
-        subagentId={selectedSubagentId}
         onBack={() => setSelectedSubagentId(null)}
       />
     );
@@ -160,6 +180,7 @@ export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: Backgroun
               <AgentsRosterPanel
                 agents={activity.agents}
                 nowMs={nowMs}
+                workspaceId={workspaceId}
                 onOpen={setSelectedSubagentId}
               />
             </>
@@ -187,54 +208,6 @@ export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: Backgroun
       </div>
       <footer className="border-t border-border px-3 py-2 text-ui-sm text-muted-foreground">
         Read-only. Output is mirrored from the agent; nothing here can steer it.
-      </footer>
-    </section>
-  );
-}
-
-/**
- * R4 seam: a minimal, clearly-labeled placeholder standing in for
- * `BackgroundSubagentView` (rung R4). Keeps the selected subagent id in
- * pane-local state (owned by the parent) and offers only a back action —
- * no transcript, no composer, nothing to interact with yet.
- */
-function BackgroundWorkSubagentSeam({
-  workspaceId,
-  subagentId,
-  onBack,
-}: {
-  workspaceId: string;
-  subagentId: string;
-  onBack: () => void;
-}) {
-  return (
-    <section
-      aria-label="Background work — subagent detail"
-      data-background-work-subagent-seam=""
-      data-workspace-id={workspaceId}
-      data-subagent-id={subagentId}
-      className="flex h-full min-h-0 flex-col"
-    >
-      <header className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2">
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          aria-label="Back to background work"
-          onClick={onBack}
-        >
-          <ArrowLeft className="icon-compact" />
-        </Button>
-        <h2 className="min-w-0 flex-1 truncate text-ui font-medium text-foreground">
-          Subagent detail
-        </h2>
-      </header>
-      <div className="flex min-h-0 flex-1 items-center justify-center px-4 text-center text-ui-sm text-muted-foreground">
-        The read-only subagent transcript (`BackgroundSubagentView`) lands in
-        rung R4 — this is that seam, holding the selected subagent's id.
-      </div>
-      <footer className="border-t border-border px-3 py-2 text-ui-sm text-muted-foreground">
-        Read-only. Transcript mirrored from the agent; no composer.
       </footer>
     </section>
   );

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.test.tsx
@@ -96,6 +96,10 @@ vi.mock("#product/hooks/cowork/workflows/use-open-cowork-artifact", () => ({
   useOpenCoworkArtifact: () => ({ openArtifact: vi.fn() }),
 }));
 
+vi.mock("#product/hooks/activity/workflows/use-open-background-work-pane", () => ({
+  useOpenBackgroundWorkPane: () => vi.fn(),
+}));
+
 vi.mock("#product/hooks/ui/debug/use-debug-render-count", () => ({
   useDebugRenderCount: () => {},
 }));

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.tsx
@@ -305,11 +305,12 @@ export function MessageList({
       onOpenFile={(filePath) => void openFile(filePath)}
       onOpenTurnChanges={() => openGitReviewPane({ mode: "last_turn" })}
       onOpenArtifact={openArtifact}
-      onOpenSubagent={openBackgroundWorkPane}
+      onOpenSubagent={(subagentId) => openBackgroundWorkPane(subagentId, activeSessionId)}
       onHandOffPlanToNewSession={onHandOffPlanToNewSession}
       workspaceReceipt={input.row.hostsWorkspaceReceipt ? <WorkspaceCreationReceipt /> : null}
     />
   ), [
+    activeSessionId,
     onHandOffPlanToNewSession,
     openArtifact,
     openBackgroundWorkPane,

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.tsx
@@ -12,6 +12,7 @@ import { CHAT_SCROLL_BASE_BOTTOM_PADDING_PX } from "#product/config/chat-layout"
 import { useWorkspaceFileActions } from "#product/hooks/workspaces/facade/files/use-workspace-file-actions";
 import { useDebugRenderCount } from "#product/hooks/ui/debug/use-debug-render-count";
 import { useOpenCoworkArtifact } from "#product/hooks/cowork/workflows/use-open-cowork-artifact";
+import { useOpenBackgroundWorkPane } from "#product/hooks/activity/workflows/use-open-background-work-pane";
 import type { PromptPlanAttachmentDescriptor } from "#product/domain/chats/composer/prompt-plan-attachments";
 import type { PromptOutboxEntry } from "#product/domain/sessions/intents/session-intent-model";
 import { usePromptOutboxActions } from "#product/hooks/chat/workflows/use-prompt-outbox-actions";
@@ -133,6 +134,12 @@ export function MessageList({
   }), [retryPrompt, dismissPrompt]);
   const { openFile, openGitReviewPane } = useWorkspaceFileActions();
   const { openArtifact } = useOpenCoworkArtifact();
+  // Native-routing affordance (Delivery Spec — Background Work Slice 1,
+  // rung R4 fix-forward): a native subagent's transcript block
+  // (`TranscriptAgentGroupBlock`) opens straight to its `BackgroundWorkPane`
+  // detail via the same hook `BackgroundWorkTranscriptRow`'s seam already
+  // uses — no parallel mechanism.
+  const openBackgroundWorkPane = useOpenBackgroundWorkPane();
   const transcriptViewState = useMemo<ChatTranscriptState>(() => ({
     activeSessionId,
     selectedWorkspaceId,
@@ -298,12 +305,14 @@ export function MessageList({
       onOpenFile={(filePath) => void openFile(filePath)}
       onOpenTurnChanges={() => openGitReviewPane({ mode: "last_turn" })}
       onOpenArtifact={openArtifact}
+      onOpenSubagent={openBackgroundWorkPane}
       onHandOffPlanToNewSession={onHandOffPlanToNewSession}
       workspaceReceipt={input.row.hostsWorkspaceReceipt ? <WorkspaceCreationReceipt /> : null}
     />
   ), [
     onHandOffPlanToNewSession,
     openArtifact,
+    openBackgroundWorkPane,
     openFile,
     openGitReviewPane,
   ]);

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/SubagentLaunchLedger.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/SubagentLaunchLedger.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SubagentLaunchLedger } from "#product/components/workspace/chat/transcript/SubagentLaunchLedger";
+import type { SubagentExecutionState } from "#product/domain/chats/subagents/subagent-launch";
+
+afterEach(cleanup);
+
+const SUPPRESSED_STATES: SubagentExecutionState[] = [
+  "running",
+  "background",
+  "completed_background",
+];
+
+const VISIBLE_STATES: Array<[SubagentExecutionState, string]> = [
+  ["completed", "Started"],
+  ["failed", "Launch failed"],
+  ["expired_background", "Stopped updating"],
+];
+
+describe("SubagentLaunchLedger", () => {
+  it.each(SUPPRESSED_STATES)(
+    "renders nothing for the retired %s status line",
+    (executionState) => {
+      const { container } = render(
+        <SubagentLaunchLedger executionState={executionState} />,
+      );
+
+      expect(container.innerHTML).toBe("");
+    },
+  );
+
+  it.each(VISIBLE_STATES)(
+    "renders the status line for execution state %s",
+    (executionState, expectedLabel) => {
+      const { getByText } = render(
+        <SubagentLaunchLedger executionState={executionState} />,
+      );
+
+      expect(getByText(expectedLabel)).not.toBeNull();
+    },
+  );
+
+  it("never renders a prompt disclosure affordance — that moved to BackgroundSubagentView", () => {
+    const { queryByText } = render(
+      <SubagentLaunchLedger executionState="completed" />,
+    );
+
+    expect(queryByText("View initial prompt")).toBeNull();
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/SubagentLaunchLedger.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/SubagentLaunchLedger.tsx
@@ -1,74 +1,40 @@
-import { Button } from "#product/primitives/Button";
-import { MarkdownBody } from "#product/components/workspace/chat/transcript/MarkdownBody";
-import { renderDesktopCodeBlock } from "#product/components/content/ui/desktop-markdown-code-block";
-import { AutoHideScrollArea } from "#product/primitives/patterns/AutoHideScrollArea";
-import { StickyNote } from "#product/primitives/icons/product";
-import { ToolActionDetailsPanel } from "#product/components/workspace/chat/tool-calls/ToolActionDetailsPanel";
-import { TOOL_CALL_BODY_MAX_HEIGHT_CLASS } from "#product/domain/chats/tools/tool-call-layout";
-import { useState } from "react";
+import { isSubagentLaunchStatusVisibleInTranscript } from "#product/domain/chats/subagents/subagent-launch";
 import type { SubagentExecutionState } from "#product/domain/chats/subagents/subagent-launch";
 
 interface SubagentLaunchLedgerProps {
-  prompt: string | null;
   executionState: SubagentExecutionState;
 }
 
 const CHAT_ACTION_TEXT_CLASS =
   "text-chat";
 
+/**
+ * The native subagent's muted status line in the transcript (Design Handoff
+ * — MODIFIED `SubagentLaunchLedger`; Delivery Spec — Background Work Slice
+ * 1, rung R4). The prompt disclosure this row used to gate on moved out of
+ * the transcript entirely into `BackgroundSubagentView`'s "Initial prompt"
+ * panel, so this component no longer takes a `prompt` prop.
+ *
+ * `Creating` / `Running in background` / `Completed in background` no
+ * longer render here — the creation chip and the command row's own trailing
+ * slot (`running · 4m 12s` / `exited 0 · 2m 45s`) already carry that state
+ * (acceptance line: "the two muted transcript status lines no longer
+ * render"). `formatLaunchStatus` itself is unchanged; only these call sites
+ * are gone, via `isSubagentLaunchStatusVisibleInTranscript`.
+ */
 export function SubagentLaunchLedger({
-  prompt,
   executionState,
 }: SubagentLaunchLedgerProps) {
-  const status = formatLaunchStatus(executionState);
-  const [promptExpanded, setPromptExpanded] = useState(false);
+  if (!isSubagentLaunchStatusVisibleInTranscript(executionState)) {
+    return null;
+  }
 
+  const status = formatLaunchStatus(executionState);
   return (
-    <div className="flex flex-col gap-1">
-      <PlainSubagentActionRow
-        label={status.label}
-        tone={status.tone}
-      />
-      {prompt && (
-        <div>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            data-chat-transcript-ignore
-            className={`group/action-row h-auto max-w-full justify-start gap-1 rounded-none bg-transparent p-0 text-left ${CHAT_ACTION_TEXT_CLASS} font-normal text-muted-foreground/60 hover:bg-transparent active:bg-transparent hover:text-foreground focus-visible:ring-0`}
-            aria-expanded={promptExpanded}
-            onClick={() => setPromptExpanded((next) => !next)}
-          >
-            <StickyNote
-              aria-hidden="true"
-              className={`icon-compact shrink-0 transition-colors ${
-                promptExpanded ? "text-foreground/70" : "text-faint"
-              }`}
-            />
-            <span className="min-w-0 truncate">View initial prompt</span>
-          </Button>
-          {promptExpanded && (
-            <div className="mt-1.5">
-              <ToolActionDetailsPanel>
-                <AutoHideScrollArea
-                  className="w-full"
-                  viewportClassName={TOOL_CALL_BODY_MAX_HEIGHT_CLASS}
-                >
-                  <div className="px-3 py-2 text-chat leading-relaxed text-muted-foreground">
-                    <MarkdownBody
-                      content={prompt}
-                      className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
-                      renderCodeBlock={renderDesktopCodeBlock}
-                    />
-                  </div>
-                </AutoHideScrollArea>
-              </ToolActionDetailsPanel>
-            </div>
-          )}
-        </div>
-      )}
-    </div>
+    <PlainSubagentActionRow
+      label={status.label}
+      tone={status.tone}
+    />
   );
 }
 

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.test.tsx
@@ -203,6 +203,111 @@ describe.each(["in_progress", "completed"] as const)(
   },
 );
 
+describe("TranscriptAgentGroupBlock onOpenSubagent (native routing)", () => {
+  // Delivery Spec — Background Work Slice 1, rung R4 fix-forward: the
+  // native subagent's transcript block must click-open BackgroundWorkPane's
+  // subagent detail, correlated via the same `ToolBackgroundWorkMetadata`
+  // agentId `findSubagentLaunchItem` already reads in reverse.
+  function backgroundWorkItem(agentId: string): ToolCallItem {
+    return {
+      ...toolItem("native-task", "turn-1", 1, "subagent", "in_progress"),
+      title: "Inspect the repository",
+      nativeToolName: "Task",
+      rawInput: { run_in_background: true, prompt: "Inspect the transcript pipeline" },
+      rawOutput: {
+        isAsync: true,
+        agentId,
+        outputFile: "/tmp/task.output",
+        _anyharness: { backgroundWork: { trackerKind: "claude_async_agent", state: "pending" } },
+      },
+    };
+  }
+
+  it("calls onOpenSubagent with the correct subagent id when the header is clicked", () => {
+    const transcript = createTranscriptState("session-1");
+    const item = backgroundWorkItem("agent-42");
+    transcript.itemsById[item.itemId] = item;
+    const onOpenSubagent = vi.fn();
+
+    const { getByText } = render(
+      createElement(TranscriptAgentGroupBlock, {
+        item,
+        childIds: [],
+        transcript,
+        childrenByParentId: new Map(),
+        renderChild: () => null,
+        onOpenSubagent,
+      }),
+    );
+
+    fireEvent.click(getByText("Creating subagent"));
+
+    expect(onOpenSubagent).toHaveBeenCalledTimes(1);
+    expect(onOpenSubagent).toHaveBeenCalledWith("agent-42");
+  });
+
+  it("still allows expand/collapse via the chevron when onOpenSubagent is wired", () => {
+    const transcript = createTranscriptState("session-1");
+    const item = backgroundWorkItem("agent-7");
+    const childItem: ToolCallItem = toolItem("child-tool", "turn-1", 2, "other", "completed");
+    transcript.itemsById[item.itemId] = item;
+    transcript.itemsById[childItem.itemId] = childItem;
+    const onOpenSubagent = vi.fn();
+
+    const { getByRole, queryByText } = render(
+      createElement(TranscriptAgentGroupBlock, {
+        item,
+        childIds: [childItem.itemId],
+        transcript,
+        childrenByParentId: new Map([[item.itemId, [childItem.itemId]]]),
+        renderChild: () => null,
+        onOpenSubagent,
+      }),
+    );
+
+    // The header itself now opens the pane, not the disclosure — expanding
+    // must go through the dedicated chevron control instead.
+    expect(queryByText("Launch failed")).toBeNull();
+    fireEvent.click(getByRole("button", { name: "Expand subagent details" }));
+
+    expect(onOpenSubagent).not.toHaveBeenCalled();
+    expect(getByRole("button", { name: "Collapse subagent details" })).not.toBeNull();
+  });
+
+  it("does not get the pane-opening affordance when rawOutput has no background metadata", () => {
+    const transcript = createTranscriptState("session-1");
+    const item: ToolCallItem = {
+      ...toolItem("native-task-no-meta", "turn-1", 1, "subagent", "failed"),
+      title: "Inspect the repository",
+      nativeToolName: "Task",
+      rawInput: { prompt: "Inspect the transcript pipeline" },
+    };
+    transcript.itemsById[item.itemId] = item;
+    const onOpenSubagent = vi.fn();
+
+    const { getByText, queryByRole } = render(
+      createElement(TranscriptAgentGroupBlock, {
+        item,
+        childIds: [],
+        transcript,
+        childrenByParentId: new Map(),
+        renderChild: () => null,
+        onOpenSubagent,
+      }),
+    );
+
+    // No chevron affordance: this block has no background-work correlation
+    // for onOpenSubagent to resolve an id from.
+    expect(queryByRole("button", { name: "Expand subagent details" })).toBeNull();
+
+    // Falls back to byte-identical expand-on-click behavior.
+    fireEvent.click(getByText("Subagent launch failed"));
+
+    expect(onOpenSubagent).not.toHaveBeenCalled();
+    expect(getByText("Launch failed")).not.toBeNull();
+  });
+});
+
 describe("native subagent transcript tree rendering", () => {
   it("renders Codex collaboration activity as a tool, not another spawn", () => {
     const { fixture, transcript, childrenByParentId } = fixtureTree("codex");

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.test.tsx
@@ -102,6 +102,20 @@ const fixtures = {
 
 afterEach(cleanup);
 
+// Review round 3 (keyboard access): the header's `role="button"` /
+// `tabIndex` / `onKeyDown` live on the outer clickable `<div>`, but
+// `getByText` resolves to the innermost element carrying that exact text
+// (the header-verb `<span>`). Keyboard events target whatever element
+// actually has focus — the header div itself, per its `tabIndex={0}` — so
+// keydown assertions must dispatch on that ancestor, not the inner span.
+function headerButtonFor(textNode: HTMLElement): HTMLElement {
+  const header = textNode.closest('[role="button"]');
+  if (!header) {
+    throw new Error("expected an ancestor with role=\"button\"");
+  }
+  return header as HTMLElement;
+}
+
 describe("TranscriptAgentGroupBlock muted status lines", () => {
   // Design Handoff — MODIFIED `SubagentLaunchLedger`; Delivery Spec —
   // Background Work Slice 1, rung R4, acceptance line 52: "the two muted
@@ -166,6 +180,35 @@ describe("TranscriptAgentGroupBlock muted status lines", () => {
     );
 
     fireEvent.click(getByText("Subagent launch failed"));
+
+    expect(getByText("Launch failed")).not.toBeNull();
+  });
+
+  it("expands via Enter on the header when there is no onOpenSubagent (expand-fallback keyboard access)", () => {
+    const transcript = createTranscriptState("session-1");
+    const item: ToolCallItem = {
+      ...toolItem("native-task-failed-kbd", "turn-1", 1, "subagent", "failed"),
+      title: "Inspect the repository",
+      nativeToolName: "Task",
+      rawInput: { prompt: "Inspect the transcript pipeline" },
+    };
+    transcript.itemsById[item.itemId] = item;
+
+    const { getByText } = render(
+      createElement(TranscriptAgentGroupBlock, {
+        item,
+        childIds: [],
+        transcript,
+        childrenByParentId: new Map(),
+        renderChild: () => null,
+      }),
+    );
+
+    const header = headerButtonFor(getByText("Subagent launch failed"));
+    expect(header.getAttribute("role")).toBe("button");
+    expect(header.getAttribute("tabindex")).toBe("0");
+
+    fireEvent.keyDown(header, { key: " " });
 
     expect(getByText("Launch failed")).not.toBeNull();
   });
@@ -272,6 +315,101 @@ describe("TranscriptAgentGroupBlock onOpenSubagent (native routing)", () => {
 
     expect(onOpenSubagent).not.toHaveBeenCalled();
     expect(getByRole("button", { name: "Collapse subagent details" })).not.toBeNull();
+  });
+
+  it("calls onOpenSubagent with the correct subagent id when Enter is pressed on the header", () => {
+    const transcript = createTranscriptState("session-1");
+    const item = backgroundWorkItem("agent-42");
+    transcript.itemsById[item.itemId] = item;
+    const onOpenSubagent = vi.fn();
+
+    const { getByText } = render(
+      createElement(TranscriptAgentGroupBlock, {
+        item,
+        childIds: [],
+        transcript,
+        childrenByParentId: new Map(),
+        renderChild: () => null,
+        onOpenSubagent,
+      }),
+    );
+
+    // Keyboard activation targets the header `[role="button"]` itself, not
+    // the inner text span — that's the element that actually receives focus
+    // (and thus the keydown) when a user tabs to it.
+    fireEvent.keyDown(headerButtonFor(getByText("Creating subagent")), { key: "Enter" });
+
+    expect(onOpenSubagent).toHaveBeenCalledTimes(1);
+    expect(onOpenSubagent).toHaveBeenCalledWith("agent-42");
+  });
+
+  it("calls onOpenSubagent with the correct subagent id when Space is pressed on the header", () => {
+    const transcript = createTranscriptState("session-1");
+    const item = backgroundWorkItem("agent-42");
+    transcript.itemsById[item.itemId] = item;
+    const onOpenSubagent = vi.fn();
+
+    const { getByText } = render(
+      createElement(TranscriptAgentGroupBlock, {
+        item,
+        childIds: [],
+        transcript,
+        childrenByParentId: new Map(),
+        renderChild: () => null,
+        onOpenSubagent,
+      }),
+    );
+
+    fireEvent.keyDown(headerButtonFor(getByText("Creating subagent")), { key: " " });
+
+    expect(onOpenSubagent).toHaveBeenCalledTimes(1);
+    expect(onOpenSubagent).toHaveBeenCalledWith("agent-42");
+  });
+
+  it("exposes the header as a keyboard-focusable button when it opens a subagent", () => {
+    const transcript = createTranscriptState("session-1");
+    const item = backgroundWorkItem("agent-42");
+    transcript.itemsById[item.itemId] = item;
+
+    const { getByText } = render(
+      createElement(TranscriptAgentGroupBlock, {
+        item,
+        childIds: [],
+        transcript,
+        childrenByParentId: new Map(),
+        renderChild: () => null,
+        onOpenSubagent: vi.fn(),
+      }),
+    );
+
+    const header = getByText("Creating subagent").closest('[role="button"]');
+    expect(header).not.toBeNull();
+    expect(header?.getAttribute("tabindex")).toBe("0");
+    expect(header?.getAttribute("aria-label")).toBe("Open subagent detail");
+  });
+
+  it("does not re-trigger the header's action when Enter is pressed on the nested chevron button", () => {
+    const transcript = createTranscriptState("session-1");
+    const item = backgroundWorkItem("agent-7");
+    const childItem: ToolCallItem = toolItem("child-tool", "turn-1", 2, "other", "completed");
+    transcript.itemsById[item.itemId] = item;
+    transcript.itemsById[childItem.itemId] = childItem;
+    const onOpenSubagent = vi.fn();
+
+    const { getByRole } = render(
+      createElement(TranscriptAgentGroupBlock, {
+        item,
+        childIds: [childItem.itemId],
+        transcript,
+        childrenByParentId: new Map([[item.itemId, [childItem.itemId]]]),
+        renderChild: () => null,
+        onOpenSubagent,
+      }),
+    );
+
+    fireEvent.keyDown(getByRole("button", { name: "Expand subagent details" }), { key: "Enter" });
+
+    expect(onOpenSubagent).not.toHaveBeenCalled();
   });
 
   it("does not get the pane-opening affordance when rawOutput has no background metadata", () => {

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.test.tsx
@@ -1,5 +1,8 @@
+// @vitest-environment jsdom
+
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import {
   createTranscriptState,
   reduceEvents,
@@ -9,7 +12,7 @@ import type {
   ToolCallItem,
   TranscriptState,
 } from "@anyharness/sdk";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildTurnPresentation,
 } from "#product/domain/chats/transcript/transcript-presentation";
@@ -96,6 +99,77 @@ const fixtures = {
   claude: claudeFixtureJson as unknown as NativeSubagentFixture,
   codex: codexFixtureJson as unknown as NativeSubagentFixture,
 };
+
+afterEach(cleanup);
+
+describe("TranscriptAgentGroupBlock muted status lines", () => {
+  // Design Handoff — MODIFIED `SubagentLaunchLedger`; Delivery Spec —
+  // Background Work Slice 1, rung R4, acceptance line 52: "the two muted
+  // transcript status lines no longer render." (A third — `Creating` — was
+  // also retired; see the handoff's exact three-state list.)
+  it("never shows Creating/Running in background/Completed in background once expanded", () => {
+    const transcript = createTranscriptState("session-1");
+    const item: ToolCallItem = {
+      ...toolItem("native-task", "turn-1", 1, "subagent", "completed"),
+      title: "Inspect the repository",
+      nativeToolName: "Task",
+      rawInput: { run_in_background: true, prompt: "Inspect the transcript pipeline" },
+      rawOutput: {
+        isAsync: true,
+        agentId: "agent-1",
+        outputFile: "/tmp/task.output",
+        _anyharness: { backgroundWork: { trackerKind: "claude_async_agent", state: "pending" } },
+      },
+    };
+    const childItem: ToolCallItem = toolItem("child-tool", "turn-1", 2, "other", "completed");
+    transcript.itemsById[item.itemId] = item;
+    transcript.itemsById[childItem.itemId] = childItem;
+
+    const { getByText, container } = render(
+      createElement(TranscriptAgentGroupBlock, {
+        item,
+        childIds: [childItem.itemId],
+        transcript,
+        childrenByParentId: new Map([[item.itemId, [childItem.itemId]]]),
+        renderChild: () => null,
+      }),
+    );
+
+    fireEvent.click(getByText("Creating subagent"));
+
+    // The header verb itself is allowed to read "Creating subagent" — it is
+    // the retired *status line* (rendered on its own, muted, below the
+    // header) that must be gone.
+    expect(container.textContent).not.toContain("Running in background");
+    expect(container.textContent).not.toContain("Completed in background");
+    expect(container.textContent).not.toContain("View initial prompt");
+  });
+
+  it("still shows the non-retired status lines (e.g. Launch failed) once expanded", () => {
+    const transcript = createTranscriptState("session-1");
+    const item: ToolCallItem = {
+      ...toolItem("native-task-failed", "turn-1", 1, "subagent", "failed"),
+      title: "Inspect the repository",
+      nativeToolName: "Task",
+      rawInput: { prompt: "Inspect the transcript pipeline" },
+    };
+    transcript.itemsById[item.itemId] = item;
+
+    const { getByText } = render(
+      createElement(TranscriptAgentGroupBlock, {
+        item,
+        childIds: [],
+        transcript,
+        childrenByParentId: new Map(),
+        renderChild: () => null,
+      }),
+    );
+
+    fireEvent.click(getByText("Subagent launch failed"));
+
+    expect(getByText("Launch failed")).not.toBeNull();
+  });
+});
 
 describe.each(["in_progress", "completed"] as const)(
   "TranscriptAgentGroupBlock %s",

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
@@ -142,18 +142,57 @@ export function TranscriptAgentGroupBlock({
   const subagentId = resolveSubagentIdForItem(item);
   const canOpenSubagent = Boolean(onOpenSubagent && subagentId);
   const headerClickable = canOpenSubagent || headerExpandable;
+  // Keyboard access (review round 3): the header used to be a pure
+  // expand/collapse toggle, where losing keyboard access was a pre-existing
+  // gap; now it can navigate away to a subagent's pane, which makes keyboard
+  // parity load-bearing. `activateHeader` is the single source of truth for
+  // "what does activating this header do," shared by the pointer and
+  // keyboard paths so they can never drift apart.
+  const activateHeader = () => {
+    if (onOpenSubagent && subagentId) {
+      onOpenSubagent(subagentId);
+      return;
+    }
+    if (headerExpandable) {
+      setExpanded(!expanded);
+    }
+  };
+  // Distinct wording from the chevron's own "Expand/Collapse subagent
+  // details" label (kept as-is below, per handoff) — the two controls are
+  // mutually exclusive in the DOM (the chevron only renders alongside a
+  // clickable header when `canOpenSubagent`), but giving them identical
+  // accessible names would still be confusing for anyone landing on either
+  // by name, and it collides with `getByRole("button", { name: … })`
+  // lookups that target the chevron specifically.
+  const headerAriaLabel = canOpenSubagent
+    ? "Open subagent detail"
+    : headerExpandable
+      ? (expanded ? "Hide subagent details" : "Show subagent details")
+      : undefined;
 
   return (
     <div className="py-0.5">
       <div
-        {...(headerClickable ? { "data-chat-transcript-ignore": true } : {})}
-        onClick={() => {
-          if (onOpenSubagent && subagentId) {
-            onOpenSubagent(subagentId);
+        {...(headerClickable
+          ? {
+              "data-chat-transcript-ignore": true,
+              role: "button" as const,
+              tabIndex: 0,
+              "aria-label": headerAriaLabel,
+            }
+          : {})}
+        onClick={activateHeader}
+        onKeyDown={(event) => {
+          // Ignore keydown bubbling up from the nested chevron `Button`
+          // below — it's a real, independently-focusable `<button>`, and
+          // its own Enter/Space activation must not also re-trigger this
+          // header's action.
+          if (!headerClickable || event.target !== event.currentTarget) {
             return;
           }
-          if (headerExpandable) {
-            setExpanded(!expanded);
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            activateHeader();
           }
         }}
         className={`group/tool-action-row inline-flex items-center gap-1 rounded-md pl-0.5 pr-1.5 py-1 text-chat transition-colors ${

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
@@ -22,6 +22,7 @@ import {
   resolveSubagentExecutionState,
   resolveSubagentLaunchDisplay,
   isSubagentExecutionStateRunning,
+  isSubagentLaunchStatusVisibleInTranscript,
   isSubagentWorkComplete,
 } from "#product/domain/chats/subagents/subagent-launch";
 import {
@@ -61,8 +62,12 @@ export function TranscriptAgentGroupBlock({
   const [expanded, setExpanded] = useState(false);
   const [workExpanded, setWorkExpanded] = useState(false);
 
+  // The initial prompt this display used to surface is no longer shown
+  // inline (Design Handoff — MODIFIED `SubagentLaunchLedger`; Delivery Spec
+  // — Background Work Slice 1, rung R4): it moved to
+  // `BackgroundSubagentView`'s dedicated "Initial prompt" panel, reached via
+  // the activity roster, not this transcript group.
   const subagentDisplay = resolveSubagentLaunchDisplay(item);
-  const normalizedPrompt = subagentDisplay.prompt?.trim() ?? "";
 
   // Only ever surface the structured `rawOutput.summary` — the clean result
   // the parent agent received. NEVER the raw tool_result_text content parts:
@@ -92,7 +97,7 @@ export function TranscriptAgentGroupBlock({
   const shouldShowDescription = description.length > 0
     && description.toLowerCase() !== "subagent";
   const hasWork = childIds.length > 0;
-  const hasLaunchLedger = !!normalizedPrompt;
+  const hasLaunchLedger = isSubagentLaunchStatusVisibleInTranscript(executionState);
   const hasBodyContent = hasWork || hasLaunchLedger || !!normalizedAgentResult;
   // The activity roster is a session-level summary. This durable transcript
   // item is the canonical place to inspect the native subagent's nested work.
@@ -152,10 +157,7 @@ export function TranscriptAgentGroupBlock({
 
       {expanded && hasBodyContent && <div className="ml-1 border-l border-border/70 pl-2">
         {hasLaunchLedger && (
-          <SubagentLaunchLedger
-            prompt={normalizedPrompt || null}
-            executionState={executionState}
-          />
+          <SubagentLaunchLedger executionState={executionState} />
         )}
 
         {hasWork && (

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
@@ -10,6 +10,7 @@ import type {
   TranscriptState,
 } from "@anyharness/sdk";
 import { Button } from "#product/primitives/Button";
+import { ChevronRight } from "#product/primitives/icons/core";
 import { Robot } from "#product/primitives/icons/product";
 import { MarkdownBody } from "#product/components/workspace/chat/transcript/MarkdownBody";
 import { renderDesktopCodeBlock } from "#product/components/content/ui/desktop-markdown-code-block";
@@ -20,6 +21,7 @@ import {
 } from "#product/components/workspace/chat/transcript/ScopedTranscriptBlocks";
 import {
   resolveSubagentExecutionState,
+  resolveSubagentIdForItem,
   resolveSubagentLaunchDisplay,
   isSubagentExecutionStateRunning,
   isSubagentLaunchStatusVisibleInTranscript,
@@ -39,12 +41,21 @@ export function TranscriptAgentGroupBlock({
   transcript,
   childrenByParentId,
   renderChild,
+  onOpenSubagent,
 }: {
   item: ToolCallItem;
   childIds: string[];
   transcript: TranscriptState;
   childrenByParentId: Map<string, string[]>;
   renderChild: (childId: string) => ReactNode;
+  /**
+   * Opens this native subagent's `BackgroundWorkPane` detail
+   * (`BackgroundSubagentView`) — the spec's "native routing" intent,
+   * delivered here rather than at `SpawnIdentityReceipt` (that component is
+   * delegated-work-only; see the PR body's disclosed spec correction).
+   * Absent for embedded/read-only transcripts that have no pane to open.
+   */
+  onOpenSubagent?: (subagentId: string) => void;
 }) {
   const executionState = resolveSubagentExecutionState(item);
   const isRunning = isSubagentExecutionStateRunning(executionState);
@@ -122,14 +133,31 @@ export function TranscriptAgentGroupBlock({
         ? "Completed in background"
         : null);
   const headerExpandable = hasBodyContent;
+  // Native-routing affordance (Delivery Spec — Background Work Slice 1, rung
+  // R4 fix-forward): only a block whose `rawOutput` actually carries the
+  // background-work correlation gets the click-to-open-pane behavior — a
+  // block with no `subagentId` (no correlation available for this harness,
+  // or no pane consumer wired at this transcript's call site) falls back to
+  // today's byte-identical expand/collapse-on-click header.
+  const subagentId = resolveSubagentIdForItem(item);
+  const canOpenSubagent = Boolean(onOpenSubagent && subagentId);
+  const headerClickable = canOpenSubagent || headerExpandable;
 
   return (
     <div className="py-0.5">
       <div
-        {...(headerExpandable ? { "data-chat-transcript-ignore": true } : {})}
-        onClick={() => headerExpandable && setExpanded(!expanded)}
+        {...(headerClickable ? { "data-chat-transcript-ignore": true } : {})}
+        onClick={() => {
+          if (onOpenSubagent && subagentId) {
+            onOpenSubagent(subagentId);
+            return;
+          }
+          if (headerExpandable) {
+            setExpanded(!expanded);
+          }
+        }}
         className={`group/tool-action-row inline-flex items-center gap-1 rounded-md pl-0.5 pr-1.5 py-1 text-chat transition-colors ${
-          headerExpandable
+          headerClickable
             ? "cursor-pointer text-muted-foreground hover:bg-muted/40 hover:text-foreground"
             : "cursor-default text-muted-foreground"
         }`}
@@ -139,7 +167,7 @@ export function TranscriptAgentGroupBlock({
           className={`icon-compact shrink-0 transition-colors ${
             expanded
               ? "text-foreground/70"
-              : headerExpandable
+              : headerClickable
                 ? "text-faint group-hover/tool-action-row:text-muted-foreground"
                 : "text-muted-foreground"
           }`}
@@ -152,6 +180,25 @@ export function TranscriptAgentGroupBlock({
           <span className="ml-1 text-chat text-muted-foreground">
             · {collapsedSummary}
           </span>
+        )}
+        {canOpenSubagent && hasBodyContent && (
+          <Button
+            type="button"
+            variant="unstyled"
+            data-chat-transcript-ignore
+            aria-expanded={expanded}
+            aria-label={expanded ? "Collapse subagent details" : "Expand subagent details"}
+            onClick={(event) => {
+              event.stopPropagation();
+              setExpanded(!expanded);
+            }}
+            className="ml-1 flex shrink-0 items-center justify-center rounded p-0.5 text-faint hover:bg-muted/40 hover:text-foreground"
+          >
+            <ChevronRight
+              aria-hidden="true"
+              className={`icon-compact shrink-0 transition-transform ${expanded ? "rotate-90" : ""}`}
+            />
+          </Button>
         )}
       </div>
 

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolCallGroupBlock.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolCallGroupBlock.tsx
@@ -20,6 +20,7 @@ export function TranscriptToolCallGroupBlock({
   childrenByParentId,
   workspaceId,
   onOpenArtifact,
+  onOpenSubagent,
   renderChild,
 }: {
   item: ToolCallItem;
@@ -28,6 +29,7 @@ export function TranscriptToolCallGroupBlock({
   childrenByParentId: Map<string, string[]>;
   workspaceId: string | null;
   onOpenArtifact: (workspaceId: string, artifactId: string) => void;
+  onOpenSubagent?: (subagentId: string) => void;
   renderChild: (childId: string) => ReactNode;
 }) {
   if (isSubagentItem(item)) {
@@ -38,6 +40,7 @@ export function TranscriptToolCallGroupBlock({
         transcript={transcript}
         childrenByParentId={childrenByParentId}
         renderChild={renderChild}
+        onOpenSubagent={onOpenSubagent}
       />
     );
   }

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTreeNode.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTreeNode.tsx
@@ -17,6 +17,7 @@ export function TranscriptTreeNode({
   onAssistantRevealStateChange,
   workspaceId,
   onOpenArtifact,
+  onOpenSubagent,
   onHandOffPlanToNewSession,
 }: {
   itemId: string;
@@ -30,6 +31,7 @@ export function TranscriptTreeNode({
   ) => void;
   workspaceId: string | null;
   onOpenArtifact: (workspaceId: string, artifactId: string) => void;
+  onOpenSubagent?: (subagentId: string) => void;
   onHandOffPlanToNewSession?: PlanHandoffHandler;
 }) {
   const item = transcript.itemsById[itemId];
@@ -46,6 +48,7 @@ export function TranscriptTreeNode({
           childrenByParentId={childrenByParentId}
           workspaceId={workspaceId}
           onOpenArtifact={onOpenArtifact}
+          onOpenSubagent={onOpenSubagent}
           renderChild={(childId) => (
             <TranscriptTreeNode
               itemId={childId}
@@ -56,6 +59,7 @@ export function TranscriptTreeNode({
               onAssistantRevealStateChange={onAssistantRevealStateChange}
               workspaceId={workspaceId}
               onOpenArtifact={onOpenArtifact}
+              onOpenSubagent={onOpenSubagent}
               onHandOffPlanToNewSession={onHandOffPlanToNewSession}
             />
           )}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
@@ -70,6 +70,7 @@ export function TranscriptTurnRow({
   onOpenFile,
   onOpenTurnChanges,
   onOpenArtifact,
+  onOpenSubagent,
   onHandOffPlanToNewSession,
   workspaceReceipt = null,
 }: {
@@ -87,6 +88,7 @@ export function TranscriptTurnRow({
   onOpenFile: (filePath: string) => void;
   onOpenTurnChanges?: () => void;
   onOpenArtifact: (workspaceId: string, artifactId: string) => void;
+  onOpenSubagent?: (subagentId: string) => void;
   onHandOffPlanToNewSession?: PlanHandoffHandler;
   /** The workspace-creation receipt, when this row hosts it (see `hostsWorkspaceReceipt`). */
   workspaceReceipt?: ReactNode;
@@ -277,6 +279,7 @@ export function TranscriptTurnRow({
           showCompletedArtifactFallback={row.isLastTurnRow}
           workspaceId={selectedWorkspaceId}
           onOpenArtifact={onOpenArtifact}
+          onOpenSubagent={onOpenSubagent}
           onHandOffPlanToNewSession={onHandOffPlanToNewSession}
           workspaceReceipt={workspaceReceipt}
         />

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.tsx
@@ -53,6 +53,7 @@ export function TurnItemSequence({
   showCompletedArtifactFallback,
   workspaceId,
   onOpenArtifact,
+  onOpenSubagent,
   onHandOffPlanToNewSession,
   workspaceReceipt = null,
 }: {
@@ -72,6 +73,7 @@ export function TurnItemSequence({
   showCompletedArtifactFallback: boolean;
   workspaceId: string | null;
   onOpenArtifact: (workspaceId: string, artifactId: string) => void;
+  onOpenSubagent?: (subagentId: string) => void;
   onHandOffPlanToNewSession?: PlanHandoffHandler;
   /**
    * The workspace-creation receipt, when this row hosts it. Renders as the
@@ -188,6 +190,7 @@ export function TurnItemSequence({
                             onAssistantRevealStateChange={onAssistantRevealStateChange}
                             workspaceId={workspaceId}
                             onOpenArtifact={onOpenArtifact}
+                            onOpenSubagent={onOpenSubagent}
                             onHandOffPlanToNewSession={onHandOffPlanToNewSession}
                           />
                         )}
@@ -214,6 +217,7 @@ export function TurnItemSequence({
                   onAssistantRevealStateChange={onAssistantRevealStateChange}
                   workspaceId={workspaceId}
                   onOpenArtifact={onOpenArtifact}
+                  onOpenSubagent={onOpenSubagent}
                   onHandOffPlanToNewSession={onHandOffPlanToNewSession}
                 />
               )}
@@ -311,6 +315,7 @@ function TranscriptFragment({
   onAssistantRevealStateChange,
   workspaceId,
   onOpenArtifact,
+  onOpenSubagent,
   onHandOffPlanToNewSession,
 }: {
   itemId: string;
@@ -324,6 +329,7 @@ function TranscriptFragment({
   ) => void;
   workspaceId: string | null;
   onOpenArtifact: (workspaceId: string, artifactId: string) => void;
+  onOpenSubagent?: (subagentId: string) => void;
   onHandOffPlanToNewSession?: PlanHandoffHandler;
 }) {
   return (
@@ -337,6 +343,7 @@ function TranscriptFragment({
         onAssistantRevealStateChange={onAssistantRevealStateChange}
         workspaceId={workspaceId}
         onOpenArtifact={onOpenArtifact}
+        onOpenSubagent={onOpenSubagent}
         onHandOffPlanToNewSession={onHandOffPlanToNewSession}
       />
     </>

--- a/apps/packages/product-client/src/domain/chats/subagents/subagent-launch.test.ts
+++ b/apps/packages/product-client/src/domain/chats/subagents/subagent-launch.test.ts
@@ -329,7 +329,7 @@ describe("findSubagentLaunchItem", () => {
     const transcript = createTranscriptState("session-1");
     transcript.itemsById[item.itemId] = item;
 
-    expect(findSubagentLaunchItem(transcript, "codex-thread-1")).toBeNull();
+    expect(findSubagentLaunchItem(transcript, "child-thread-1")).toBeNull();
   });
 
   it("ignores non-tool-call items", () => {

--- a/apps/packages/product-client/src/domain/chats/subagents/subagent-launch.test.ts
+++ b/apps/packages/product-client/src/domain/chats/subagents/subagent-launch.test.ts
@@ -6,6 +6,7 @@ import {
   isSubagentLaunchStatusVisibleInTranscript,
   isSubagentWorkComplete,
   parseAsyncSubagentLaunch,
+  resolveSubagentIdForItem,
   resolveSubagentLaunchDisplay,
   resolveSubagentExecutionState,
 } from "./subagent-launch";
@@ -340,6 +341,65 @@ describe("findSubagentLaunchItem", () => {
     } as unknown as TranscriptState["itemsById"][string];
 
     expect(findSubagentLaunchItem(transcript, "ad5087d157aab3117")).toBeNull();
+  });
+});
+
+describe("resolveSubagentIdForItem", () => {
+  // Delivery Spec — Background Work Slice 1, rung R4 fix-forward review
+  // round 2: this is now load-bearing for navigation
+  // (`TranscriptAgentGroupBlock`'s click-to-open-pane affordance), so it
+  // gets direct unit coverage of the pure function rather than only
+  // integration-level coverage through the component.
+  it("returns the agentId on the happy path (valid claude_async_agent background-work metadata)", () => {
+    const item = toolCallItem({
+      status: "completed",
+      semanticKind: "subagent",
+      nativeToolName: "Agent",
+      rawInput: { run_in_background: true },
+      rawOutput: backgroundWork("pending"),
+    });
+
+    expect(resolveSubagentIdForItem(item)).toBe("ad5087d157aab3117");
+  });
+
+  it("returns null when rawOutput is a string, not a record", () => {
+    const item = toolCallItem({
+      rawOutput: "Async agent launched successfully." as unknown as ToolCallItem["rawOutput"],
+    });
+
+    expect(resolveSubagentIdForItem(item)).toBeNull();
+  });
+
+  it("returns null when rawOutput is an array, not a record", () => {
+    const item = toolCallItem({
+      rawOutput: ["agentId", "ad5087d157aab3117"] as unknown as ToolCallItem["rawOutput"],
+    });
+
+    expect(resolveSubagentIdForItem(item)).toBeNull();
+  });
+
+  it("returns null when _anyharness.backgroundWork is present but trackerKind is unrecognized", () => {
+    const item = toolCallItem({
+      rawOutput: {
+        agentId: "ad5087d157aab3117",
+        _anyharness: {
+          backgroundWork: {
+            trackerKind: "codex_thread",
+            state: "pending",
+          },
+        },
+      },
+    });
+
+    expect(resolveSubagentIdForItem(item)).toBeNull();
+  });
+
+  it("returns null when rawOutput has no _anyharness.backgroundWork at all", () => {
+    const item = toolCallItem({
+      rawOutput: { agentId: "ad5087d157aab3117" },
+    });
+
+    expect(resolveSubagentIdForItem(item)).toBeNull();
   });
 });
 

--- a/apps/packages/product-client/src/domain/chats/subagents/subagent-launch.test.ts
+++ b/apps/packages/product-client/src/domain/chats/subagents/subagent-launch.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
-import type { ToolCallItem } from "@anyharness/sdk";
+import { createTranscriptState } from "@anyharness/sdk";
+import type { ToolCallItem, TranscriptState } from "@anyharness/sdk";
 import {
+  findSubagentLaunchItem,
+  isSubagentLaunchStatusVisibleInTranscript,
   isSubagentWorkComplete,
   parseAsyncSubagentLaunch,
   resolveSubagentLaunchDisplay,
@@ -265,6 +268,78 @@ describe("resolveSubagentLaunchDisplay", () => {
       meta: null,
       prompt: "Inspect transcript rendering.",
     });
+  });
+});
+
+describe("isSubagentLaunchStatusVisibleInTranscript", () => {
+  it("suppresses the three retired transcript status lines", () => {
+    expect(isSubagentLaunchStatusVisibleInTranscript("running")).toBe(false);
+    expect(isSubagentLaunchStatusVisibleInTranscript("background")).toBe(false);
+    expect(isSubagentLaunchStatusVisibleInTranscript("completed_background")).toBe(false);
+  });
+
+  it("keeps every other execution state's status line visible", () => {
+    expect(isSubagentLaunchStatusVisibleInTranscript("completed")).toBe(true);
+    expect(isSubagentLaunchStatusVisibleInTranscript("failed")).toBe(true);
+    expect(isSubagentLaunchStatusVisibleInTranscript("expired_background")).toBe(true);
+  });
+});
+
+describe("findSubagentLaunchItem", () => {
+  it("finds the parent transcript's launch tool call by background-work agentId", () => {
+    const item = toolCallItem({
+      itemId: "tool-launch",
+      status: "completed",
+      semanticKind: "subagent",
+      nativeToolName: "Agent",
+      rawInput: { run_in_background: true, prompt: "Inspect the repo." },
+      rawOutput: backgroundWork("pending"),
+    });
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById[item.itemId] = item;
+
+    expect(findSubagentLaunchItem(transcript, "ad5087d157aab3117")).toBe(item);
+  });
+
+  it("returns null when no tool call correlates to the subagent id", () => {
+    const item = toolCallItem({
+      itemId: "tool-launch",
+      status: "completed",
+      semanticKind: "subagent",
+      nativeToolName: "Agent",
+      rawInput: { run_in_background: true },
+      rawOutput: backgroundWork("pending"),
+    });
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById[item.itemId] = item;
+
+    expect(findSubagentLaunchItem(transcript, "some-other-agent-id")).toBeNull();
+  });
+
+  it("returns null for harnesses with no background-work correlation (e.g. Codex)", () => {
+    const item = toolCallItem({
+      itemId: "tool-launch",
+      status: "completed",
+      semanticKind: "subagent",
+      nativeToolName: "Agent",
+      rawInput: { prompt: "Inspect the repo." },
+      rawOutput: undefined,
+    });
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById[item.itemId] = item;
+
+    expect(findSubagentLaunchItem(transcript, "codex-thread-1")).toBeNull();
+  });
+
+  it("ignores non-tool-call items", () => {
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById["message-1"] = {
+      kind: "assistant_prose",
+      itemId: "message-1",
+      turnId: "turn-1",
+    } as unknown as TranscriptState["itemsById"][string];
+
+    expect(findSubagentLaunchItem(transcript, "ad5087d157aab3117")).toBeNull();
   });
 });
 

--- a/apps/packages/product-client/src/domain/chats/subagents/subagent-launch.ts
+++ b/apps/packages/product-client/src/domain/chats/subagents/subagent-launch.ts
@@ -2,6 +2,7 @@ import type {
   ToolBackgroundWorkMetadata,
   ToolCallItem,
   ToolResultTextContentPart,
+  TranscriptState,
 } from "@anyharness/sdk";
 import { parseToolBackgroundWork } from "@anyharness/sdk";
 
@@ -12,6 +13,30 @@ export type SubagentExecutionState =
   | "expired_background"
   | "completed"
   | "failed";
+
+/**
+ * Execution states whose `formatLaunchStatus` label used to render as a
+ * muted status line inside `SubagentLaunchLedger`'s transcript row
+ * (`Creating` / `Running in background` / `Completed in background`). The
+ * handoff's MODIFIED `SubagentLaunchLedger` entry (Delivery Spec —
+ * Background Work Slice 1, rung R4) retires all three: the creation chip and
+ * the command row's own trailing slot already carry that state, and the
+ * prompt disclosure this row used to gate on moves to `BackgroundSubagentView`.
+ * `formatLaunchStatus` itself is unchanged — only these transcript call sites
+ * go.
+ */
+const TRANSCRIPT_SUPPRESSED_LAUNCH_STATES: ReadonlySet<SubagentExecutionState> = new Set([
+  "running",
+  "background",
+  "completed_background",
+]);
+
+/** Whether `SubagentLaunchLedger` should render its status line in the transcript. */
+export function isSubagentLaunchStatusVisibleInTranscript(
+  executionState: SubagentExecutionState,
+): boolean {
+  return !TRANSCRIPT_SUPPRESSED_LAUNCH_STATES.has(executionState);
+}
 
 export interface AsyncSubagentLaunch {
   rawText: string;
@@ -93,6 +118,33 @@ export function resolveSubagentLaunchDisplay(
     meta: null,
     prompt,
   };
+}
+
+/**
+ * Finds the parent transcript's native Agent/Task launch tool call for a
+ * harness-native subagent id (the activity roster's `ActivitySubagentWire.id`
+ * — Claude's Task `agentId`). Reuses the one existing tool-call correlation
+ * in this repo, `ToolBackgroundWorkMetadata.agentId` (see
+ * `@anyharness/sdk`'s `parseToolBackgroundWork`), which `trackerKind:
+ * "claude_async_agent"` scopes to Claude's async launch receipts specifically.
+ * Other harnesses have no equivalent correlation yet, so this returns null
+ * for them — `BackgroundSubagentView` treats a missing item the same as "no
+ * initial prompt available," the same graceful fallback
+ * `SubagentLaunchLedger` already used for an absent prompt.
+ */
+export function findSubagentLaunchItem(
+  transcript: TranscriptState,
+  subagentId: string,
+): ToolCallItem | null {
+  for (const item of Object.values(transcript.itemsById)) {
+    if (item.kind !== "tool_call") {
+      continue;
+    }
+    if (parseToolBackgroundWork(item.rawOutput)?.agentId === subagentId) {
+      return item;
+    }
+  }
+  return null;
 }
 
 export function parseAsyncSubagentLaunch(

--- a/apps/packages/product-client/src/domain/chats/subagents/subagent-launch.ts
+++ b/apps/packages/product-client/src/domain/chats/subagents/subagent-launch.ts
@@ -147,6 +147,21 @@ export function findSubagentLaunchItem(
   return null;
 }
 
+/**
+ * The reverse of `findSubagentLaunchItem`: given a native Agent/Task launch
+ * tool-call item, resolves the subagent id it correlates to (the activity
+ * roster's `ActivitySubagentWire.id`) — the same
+ * `ToolBackgroundWorkMetadata.agentId` correlation, read forward instead of
+ * scanned for. Null for harnesses without the correlation, exactly like
+ * `findSubagentLaunchItem`'s own fallback. Used to gate
+ * `TranscriptAgentGroupBlock`'s click-to-open-pane affordance (Delivery Spec
+ * — Background Work Slice 1, rung R4 fix-forward): only a block whose
+ * `rawOutput` actually carries this metadata gets the affordance.
+ */
+export function resolveSubagentIdForItem(item: ToolCallItem): string | null {
+  return getBackgroundWork(item)?.agentId ?? null;
+}
+
 export function parseAsyncSubagentLaunch(
   item: ToolCallItem,
 ): AsyncSubagentLaunch | null {

--- a/apps/packages/product-client/src/hooks/activity/workflows/use-open-background-work-pane.test.tsx
+++ b/apps/packages/product-client/src/hooks/activity/workflows/use-open-background-work-pane.test.tsx
@@ -24,6 +24,7 @@ describe("useOpenBackgroundWorkPane", () => {
       _hydrated: true,
       shellActivationEpochByWorkspace: {},
       pendingChatActivationByWorkspace: {},
+      pendingBackgroundSubagentSelectionByWorkspace: {},
       urgentHighlightedChatSessionByWorkspace: {},
     });
   });
@@ -65,6 +66,44 @@ describe("useOpenBackgroundWorkPane", () => {
     ).toContain("tool:background");
     expect(useWorkspaceUiStore.getState().rightPanelDurableByWorkspace["logical-1"])
       .toMatchObject({ open: true });
+  });
+
+  it("writes a pending subagent selection for the active workspace when given a subagent id", () => {
+    useSessionSelectionStore.getState().activateWorkspace({
+      logicalWorkspaceId: "logical-1",
+      workspaceId: "workspace-1",
+    });
+
+    const { result } = renderHook(() => useOpenBackgroundWorkPane());
+
+    act(() => {
+      result.current("agent-42");
+    });
+
+    expect(
+      useWorkspaceUiStore.getState().pendingBackgroundSubagentSelectionByWorkspace["workspace-1"],
+    ).toBe("agent-42");
+    // Still opens the pane exactly as the zero-arg call does.
+    expect(
+      useWorkspaceUiStore.getState().rightPanelMaterializedByWorkspace["workspace-1"],
+    ).toMatchObject({ activeEntryKey: "tool:background" });
+  });
+
+  it("does not write a pending subagent selection for the zero-arg call", () => {
+    useSessionSelectionStore.getState().activateWorkspace({
+      logicalWorkspaceId: "logical-1",
+      workspaceId: "workspace-1",
+    });
+
+    const { result } = renderHook(() => useOpenBackgroundWorkPane());
+
+    act(() => {
+      result.current();
+    });
+
+    expect(
+      useWorkspaceUiStore.getState().pendingBackgroundSubagentSelectionByWorkspace["workspace-1"],
+    ).toBeUndefined();
   });
 
   it("does not duplicate the background entry in the header order when opened twice", () => {

--- a/apps/packages/product-client/src/hooks/activity/workflows/use-open-background-work-pane.test.tsx
+++ b/apps/packages/product-client/src/hooks/activity/workflows/use-open-background-work-pane.test.tsx
@@ -68,7 +68,7 @@ describe("useOpenBackgroundWorkPane", () => {
       .toMatchObject({ open: true });
   });
 
-  it("writes a pending subagent selection for the active workspace when given a subagent id", () => {
+  it("writes a session-scoped pending subagent selection for the active workspace when given a subagent id and session id", () => {
     useSessionSelectionStore.getState().activateWorkspace({
       logicalWorkspaceId: "logical-1",
       workspaceId: "workspace-1",
@@ -77,12 +77,12 @@ describe("useOpenBackgroundWorkPane", () => {
     const { result } = renderHook(() => useOpenBackgroundWorkPane());
 
     act(() => {
-      result.current("agent-42");
+      result.current("agent-42", "session-1");
     });
 
     expect(
       useWorkspaceUiStore.getState().pendingBackgroundSubagentSelectionByWorkspace["workspace-1"],
-    ).toBe("agent-42");
+    ).toEqual({ subagentId: "agent-42", sessionId: "session-1" });
     // Still opens the pane exactly as the zero-arg call does.
     expect(
       useWorkspaceUiStore.getState().rightPanelMaterializedByWorkspace["workspace-1"],
@@ -99,6 +99,23 @@ describe("useOpenBackgroundWorkPane", () => {
 
     act(() => {
       result.current();
+    });
+
+    expect(
+      useWorkspaceUiStore.getState().pendingBackgroundSubagentSelectionByWorkspace["workspace-1"],
+    ).toBeUndefined();
+  });
+
+  it("does not write a pending subagent selection when the subagent id is given without a session id", () => {
+    useSessionSelectionStore.getState().activateWorkspace({
+      logicalWorkspaceId: "logical-1",
+      workspaceId: "workspace-1",
+    });
+
+    const { result } = renderHook(() => useOpenBackgroundWorkPane());
+
+    act(() => {
+      result.current("agent-42");
     });
 
     expect(

--- a/apps/packages/product-client/src/hooks/activity/workflows/use-open-background-work-pane.ts
+++ b/apps/packages/product-client/src/hooks/activity/workflows/use-open-background-work-pane.ts
@@ -14,18 +14,22 @@ import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-st
  * materialize the tool's header entry for the active workspace (appending it
  * to the header order if it isn't there yet), then open the panel.
  *
- * The returned callback optionally accepts a native subagent id (Delivery
- * Spec — Background Work Slice 1, rung R4 fix-forward: a native subagent's
- * transcript block — `TranscriptAgentGroupBlock` — must click-open its
- * `BackgroundWorkPane` detail). When given, it deep-opens straight to that
- * subagent's `BackgroundSubagentView` by writing a one-shot pending
- * selection into the same right-panel-model store this hook already owns
+ * The returned callback optionally accepts a native subagent id plus the
+ * session it belongs to (Delivery Spec — Background Work Slice 1, rung R4
+ * fix-forward: a native subagent's transcript block —
+ * `TranscriptAgentGroupBlock` — must click-open its `BackgroundWorkPane`
+ * detail). When given, it deep-opens straight to that subagent's
+ * `BackgroundSubagentView` by writing a one-shot pending selection into the
+ * same right-panel-model store this hook already owns
  * (`pendingBackgroundSubagentSelectionByWorkspace`, consumed and cleared by
  * `BackgroundWorkPane` on its next render) — no new global, no parallel
- * mechanism. Existing zero-arg call sites (`BackgroundWorkTranscriptRow`'s
- * `onOpen`) are unaffected: the argument is optional.
+ * mechanism. The `sessionId` travels with the selection (review round 2) so
+ * the pane can discard it if the active session has since changed, rather
+ * than applying a different session's subagent id to its own roster.
+ * Existing zero-arg call sites (`BackgroundWorkTranscriptRow`'s `onOpen`)
+ * are unaffected: both arguments are optional and only take effect together.
  */
-export function useOpenBackgroundWorkPane(): (subagentId?: string) => void {
+export function useOpenBackgroundWorkPane(): (subagentId?: string, sessionId?: string) => void {
   const { workspaceUiKey, materializedWorkspaceId } = useWorkspaceFileContext();
   const setRightPanelMaterializedForWorkspace = useWorkspaceUiStore(
     (state) => state.setRightPanelMaterializedForWorkspace,
@@ -37,13 +41,16 @@ export function useOpenBackgroundWorkPane(): (subagentId?: string) => void {
     (state) => state.setPendingBackgroundSubagentSelectionForWorkspace,
   );
 
-  return useCallback((subagentId?: string) => {
+  return useCallback((subagentId?: string, sessionId?: string) => {
     if (!materializedWorkspaceId || !workspaceUiKey) {
       return;
     }
 
-    if (subagentId) {
-      setPendingBackgroundSubagentSelectionForWorkspace(materializedWorkspaceId, subagentId);
+    if (subagentId && sessionId) {
+      setPendingBackgroundSubagentSelectionForWorkspace(materializedWorkspaceId, {
+        subagentId,
+        sessionId,
+      });
     }
 
     const backgroundEntryKey = rightPanelToolHeaderKey("background");

--- a/apps/packages/product-client/src/hooks/activity/workflows/use-open-background-work-pane.ts
+++ b/apps/packages/product-client/src/hooks/activity/workflows/use-open-background-work-pane.ts
@@ -13,8 +13,19 @@ import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-st
  * (`hooks/workspaces/workflows/files/use-workspace-file-target-actions.ts`):
  * materialize the tool's header entry for the active workspace (appending it
  * to the header order if it isn't there yet), then open the panel.
+ *
+ * The returned callback optionally accepts a native subagent id (Delivery
+ * Spec — Background Work Slice 1, rung R4 fix-forward: a native subagent's
+ * transcript block — `TranscriptAgentGroupBlock` — must click-open its
+ * `BackgroundWorkPane` detail). When given, it deep-opens straight to that
+ * subagent's `BackgroundSubagentView` by writing a one-shot pending
+ * selection into the same right-panel-model store this hook already owns
+ * (`pendingBackgroundSubagentSelectionByWorkspace`, consumed and cleared by
+ * `BackgroundWorkPane` on its next render) — no new global, no parallel
+ * mechanism. Existing zero-arg call sites (`BackgroundWorkTranscriptRow`'s
+ * `onOpen`) are unaffected: the argument is optional.
  */
-export function useOpenBackgroundWorkPane(): () => void {
+export function useOpenBackgroundWorkPane(): (subagentId?: string) => void {
   const { workspaceUiKey, materializedWorkspaceId } = useWorkspaceFileContext();
   const setRightPanelMaterializedForWorkspace = useWorkspaceUiStore(
     (state) => state.setRightPanelMaterializedForWorkspace,
@@ -22,10 +33,17 @@ export function useOpenBackgroundWorkPane(): () => void {
   const setRightPanelOpenForWorkspace = useWorkspaceUiStore(
     (state) => state.setRightPanelOpenForWorkspace,
   );
+  const setPendingBackgroundSubagentSelectionForWorkspace = useWorkspaceUiStore(
+    (state) => state.setPendingBackgroundSubagentSelectionForWorkspace,
+  );
 
-  return useCallback(() => {
+  return useCallback((subagentId?: string) => {
     if (!materializedWorkspaceId || !workspaceUiKey) {
       return;
+    }
+
+    if (subagentId) {
+      setPendingBackgroundSubagentSelectionForWorkspace(materializedWorkspaceId, subagentId);
     }
 
     const backgroundEntryKey = rightPanelToolHeaderKey("background");
@@ -39,6 +57,7 @@ export function useOpenBackgroundWorkPane(): () => void {
     setRightPanelOpenForWorkspace(workspaceUiKey, true);
   }, [
     materializedWorkspaceId,
+    setPendingBackgroundSubagentSelectionForWorkspace,
     setRightPanelMaterializedForWorkspace,
     setRightPanelOpenForWorkspace,
     workspaceUiKey,

--- a/apps/packages/product-client/src/stores/preferences/workspace-ui-right-panel-actions.ts
+++ b/apps/packages/product-client/src/stores/preferences/workspace-ui-right-panel-actions.ts
@@ -17,6 +17,8 @@ type WorkspaceUiRightPanelActions = Pick<
   | "setRightPanelMaterializedForWorkspace"
   | "setRightPanelWidthForWorkspace"
   | "setRightPanelOpenForWorkspace"
+  | "setPendingBackgroundSubagentSelectionForWorkspace"
+  | "clearPendingBackgroundSubagentSelectionForWorkspace"
 >;
 
 function rightPanelStateUpdate(
@@ -107,6 +109,24 @@ export function createWorkspaceUiRightPanelActions(
           },
         };
       });
+    },
+
+    setPendingBackgroundSubagentSelectionForWorkspace: (workspaceId, subagentId) => {
+      set((state) => ({
+        pendingBackgroundSubagentSelectionByWorkspace: {
+          ...state.pendingBackgroundSubagentSelectionByWorkspace,
+          [workspaceId]: subagentId,
+        },
+      }));
+    },
+
+    clearPendingBackgroundSubagentSelectionForWorkspace: (workspaceId) => {
+      set((state) => ({
+        pendingBackgroundSubagentSelectionByWorkspace: {
+          ...state.pendingBackgroundSubagentSelectionByWorkspace,
+          [workspaceId]: null,
+        },
+      }));
     },
   };
 }

--- a/apps/packages/product-client/src/stores/preferences/workspace-ui-right-panel-actions.ts
+++ b/apps/packages/product-client/src/stores/preferences/workspace-ui-right-panel-actions.ts
@@ -111,11 +111,11 @@ export function createWorkspaceUiRightPanelActions(
       });
     },
 
-    setPendingBackgroundSubagentSelectionForWorkspace: (workspaceId, subagentId) => {
+    setPendingBackgroundSubagentSelectionForWorkspace: (workspaceId, selection) => {
       set((state) => ({
         pendingBackgroundSubagentSelectionByWorkspace: {
           ...state.pendingBackgroundSubagentSelectionByWorkspace,
-          [workspaceId]: subagentId,
+          [workspaceId]: selection,
         },
       }));
     },

--- a/apps/packages/product-client/src/stores/preferences/workspace-ui-store-types.ts
+++ b/apps/packages/product-client/src/stores/preferences/workspace-ui-store-types.ts
@@ -11,6 +11,16 @@ import type {
   ChatVisibilityCandidate,
 } from "#product/lib/domain/workspaces/tabs/visibility";
 
+/**
+ * See `pendingBackgroundSubagentSelectionByWorkspace` — `sessionId` is the
+ * session active at write time, checked against the consuming pane's own
+ * `sessionId` so a cross-session entry is discarded rather than applied.
+ */
+export interface PendingBackgroundSubagentSelection {
+  subagentId: string;
+  sessionId: string;
+}
+
 export interface WorkspaceUiState {
   _hydrated: boolean;
   pinnedWorkspaceIds: string[];
@@ -33,12 +43,18 @@ export interface WorkspaceUiState {
    * `useOpenBackgroundWorkPane`'s extended return; Delivery Spec — Background
    * Work Slice 1, rung R4 fix-forward). Session-only, never persisted —
    * mirrors `pendingChatActivationByWorkspace`'s ephemeral-field placement,
-   * but without its epoch/nonce/guard-token machinery: there is only ever one
-   * writer (the transcript click) and one reader (the pane's own consume
-   * effect), so no race to arbitrate. Cleared by the pane the instant it is
-   * consumed.
+   * but without its epoch/nonce/guard-token machinery. Keyed by workspace
+   * only (one right-panel model per workspace), but carries the `sessionId`
+   * active at write time (review round 2) — the pane checks it against its
+   * own `sessionId` on consume and discards a mismatch rather than applying
+   * it, so a stale selection from an abandoned or different session in the
+   * same workspace never leaks into the wrong session's roster lookup.
+   * Cleared by the pane the instant it is read, matched or not.
    */
-  pendingBackgroundSubagentSelectionByWorkspace: Record<string, string | null>;
+  pendingBackgroundSubagentSelectionByWorkspace: Record<
+    string,
+    PendingBackgroundSubagentSelection | null
+  >;
   urgentHighlightedChatSessionByWorkspace: Record<string, string | null>;
   workspaceTypes: SidebarWorkspaceVariant[];
   lastViewedAt: Record<string, string>;
@@ -86,7 +102,7 @@ export interface WorkspaceUiState {
   ) => void;
   setPendingBackgroundSubagentSelectionForWorkspace: (
     workspaceId: string,
-    subagentId: string,
+    selection: PendingBackgroundSubagentSelection,
   ) => void;
   clearPendingBackgroundSubagentSelectionForWorkspace: (
     workspaceId: string,

--- a/apps/packages/product-client/src/stores/preferences/workspace-ui-store-types.ts
+++ b/apps/packages/product-client/src/stores/preferences/workspace-ui-store-types.ts
@@ -27,6 +27,18 @@ export interface WorkspaceUiState {
   shellTabOrderByWorkspace: Record<string, WorkspaceShellTabKey[]>;
   shellActivationEpochByWorkspace: Record<string, number>;
   pendingChatActivationByWorkspace: Record<string, PendingChatActivation | null>;
+  /**
+   * One-shot deep-link target: a native subagent id to select the instant
+   * `BackgroundWorkPane` next renders for this workspace (transcript click →
+   * `useOpenBackgroundWorkPane`'s extended return; Delivery Spec — Background
+   * Work Slice 1, rung R4 fix-forward). Session-only, never persisted —
+   * mirrors `pendingChatActivationByWorkspace`'s ephemeral-field placement,
+   * but without its epoch/nonce/guard-token machinery: there is only ever one
+   * writer (the transcript click) and one reader (the pane's own consume
+   * effect), so no race to arbitrate. Cleared by the pane the instant it is
+   * consumed.
+   */
+  pendingBackgroundSubagentSelectionByWorkspace: Record<string, string | null>;
   urgentHighlightedChatSessionByWorkspace: Record<string, string | null>;
   workspaceTypes: SidebarWorkspaceVariant[];
   lastViewedAt: Record<string, string>;
@@ -71,6 +83,13 @@ export interface WorkspaceUiState {
   setRightPanelOpenForWorkspace: (
     workspaceId: string,
     value: SetStateAction<boolean>,
+  ) => void;
+  setPendingBackgroundSubagentSelectionForWorkspace: (
+    workspaceId: string,
+    subagentId: string,
+  ) => void;
+  clearPendingBackgroundSubagentSelectionForWorkspace: (
+    workspaceId: string,
   ) => void;
   setActiveShellTabKeyForWorkspace: (
     workspaceId: string,

--- a/apps/packages/product-client/src/stores/preferences/workspace-ui-store.ts
+++ b/apps/packages/product-client/src/stores/preferences/workspace-ui-store.ts
@@ -17,6 +17,7 @@ export const useWorkspaceUiStore = create<WorkspaceUiState>((set, get) => ({
   _hydrated: false,
   shellActivationEpochByWorkspace: {},
   pendingChatActivationByWorkspace: {},
+  pendingBackgroundSubagentSelectionByWorkspace: {},
   urgentHighlightedChatSessionByWorkspace: {},
   archivingChatSessionIdsByWorkspace: {},
 


### PR DESCRIPTION
## What / why

Rung R4 of the Background Work slice: a read-only detail view for one harness-native subagent, plus the transcript/identity cleanup the handoff pairs with it. Source of truth: `HANDOFF-background-work.md` (design handoff — wins on UI detail) and `Delivery Spec - Background Work Slice 1.md` rung R4.

## Per-piece notes

**`BackgroundSubagentView`** (new) — `.../background-pane/BackgroundSubagentView.tsx`. Header on `AgentsPaneDetail`'s grammar: back button, `AgentIdentityGlyph` (dimension 20), title, `Status · provider` secondary line, and a "read only" `Badge`. Body: the correlated launch tool call's initial prompt in a `ToolActionDetailsPanel` (`StickyNote` + "Initial prompt"), then the subagent's feed. Footer replaces the composer with the exact handoff copy: "Read-only. Transcript mirrored from the agent; no composer." Wired into `BackgroundWorkPane`'s R2 seam, gated by the same `isOpen` feed pattern `BackgroundTerminalView` (R3) established (the pane stays mounted-but-hidden via CSS, so streaming must stop at that boundary).

**BLOCKER — feed fidelity, reported not worked around.** The handoff's "Feed fidelity" note calls `MessageList`-based transcript-shaped rendering "honest for Claude today" because "the child transcript arrives as a JSONL tail over `tail_file`." Traced end to end:
- `open_tail_file` (`anyharness-lib/src/domains/activity/feeds.rs`) always emits raw `FeedFrame::Bytes` regardless of `FeedKind` — there is no per-kind branch.
- The WS handler (`api/ws/feeds.rs`) does no JSONL→ACP translation.
- A Claude subagent's `tail_file` feed therefore carries Claude's own native CLI session-log JSONL (`parentUuid`/`isSidechain`/`uuid` fields) — not the `SessionEventEnvelope` shape `@anyharness/sdk`'s reducer (and therefore `MessageList`, which requires a `TranscriptState`) needs.
- No translator for this exists anywhere in the repo (exhaustively grepped for `isSidechain`/`parentUuid`).

`BackgroundSubagentView` therefore renders the feed as plain text for **every** harness — the same raw-tail treatment the handoff already rules for Codex pending the `acp_child_demux` binding — rather than inventing a client-side JSONL-to-ACP translator, which is out of this slice's scope. Same class of stop as R3's `BashCommandCall` correlation gap. **This stays escalated to the founder track — confirmed true end to end on review; no translator was built.**

**`SubagentCreationGroupBlock` / `SpawnIdentityReceipt` — disclosed spec correction, not a closed non-issue.** Traced the full path before touching anything: `transcript-presentation.ts`'s `subagent_creations` grouping and `agent-operations-tool-presentation.ts` confirm these components are scoped exclusively to the AgentOperations `create_agent` MCP tool (delegated work, a full separate durable session). A harness-native Task/Agent tool call never reaches `SubagentCreationGroupBlock` — it routes through `TranscriptAgentGroupBlock` instead, so the spec's premise (native subagents flow through `SpawnIdentityReceipt`/`AgentIdentityChip`) is false — there is no "native vs delegated" branch point inside `SpawnIdentityReceipt` to extend; the two mechanisms are architecturally disjoint today. The spec's *intent*, though, is unambiguous and buildable at the right component: a native subagent's transcript block must click-open `BackgroundWorkPane`'s subagent detail. Delivered here at `TranscriptAgentGroupBlock` instead:
  - Resolves the correlated subagent id via the existing `ToolBackgroundWorkMetadata.agentId` correlation (new `resolveSubagentIdForItem` in `subagent-launch.ts`, the forward direction of `findSubagentLaunchItem`'s reverse lookup).
  - The handoff names no distinct identity-chip affordance for this block (no `AgentIdentityGlyph`/chip in its anatomy, unlike the unrelated `SpawnIdentityReceipt` row) — so per the reviewer's fallback, the header's own click now opens the pane when eligible, and expand/collapse moves to a new trailing chevron (`Button variant="unstyled"` + `ChevronRight`, same rotate-on-expand treatment as `TurnSeparator`). A block with no background-work correlation (or no `onOpenSubagent` wired at the call site) keeps today's byte-identical expand-on-click header — no chevron, no behavior change.
  - Threaded `onOpenSubagent?: (subagentId: string) => void` down the existing `onOpenArtifact`/`workspaceId` prop chain (`MessageList` → `TranscriptTurnRow` → `TurnItemSequence` → `TranscriptTreeNode` → `TranscriptToolCallGroupBlock` → `TranscriptAgentGroupBlock`), constructed once in `MessageList` from `useOpenBackgroundWorkPane()`.
  - `useOpenBackgroundWorkPane`'s return is extended from `() => void` to `(subagentId?: string) => void` — an optional deep-open target, not a new hook, not a new global. When given, it writes a one-shot `pendingBackgroundSubagentSelectionByWorkspace[workspaceId]` entry into the same `workspace-ui-store` right-panel model this hook already owns, alongside the existing materialize+open calls. `BackgroundWorkPane` consumes and clears it in an effect (single writer, single reader — no epoch/nonce machinery needed, unlike `pendingChatActivationByWorkspace`). Existing zero-arg callers (`BackgroundWorkTranscriptRow`'s `onOpen`) are unaffected.
  - `SpawnIdentityReceipt.tsx`/`SubagentCreationGroupBlock.tsx` themselves are byte-untouched; delegated-work routing is unchanged.

**Identity nit (flagged, not fixed — out of this rung's scope).** `buildDelegatedAgentIdentity` uses the wire id (Claude `task_id` / Codex `threadId`) as `sessionId`, which only loosely satisfies "durable session id": `identity.openTarget.sessionId` ends up carrying a non-session-backed id. Harmless today — nothing in this PR's scope consumes `openTarget` — but flagged here for future consumers that might expect it to resolve to a real session.

**`SubagentLaunchLedger`** — drops its `prompt` prop and the whole prompt-disclosure affordance (moved to `BackgroundSubagentView`'s "Initial prompt" panel). Added `isSubagentLaunchStatusVisibleInTranscript` (`subagent-launch.ts`) suppressing exactly the three states the handoff/spec name — `running` / `background` / `completed_background` — so `Creating` / `Running in background` / `Completed in background` no longer render in the transcript (acceptance line 52). `formatLaunchStatus` itself is unchanged; only its transcript call sites go. `TranscriptAgentGroupBlock`'s `hasLaunchLedger` now derives from the same predicate instead of prompt-presence.

**Native identity** — added `findSubagentLaunchItem` (`subagent-launch.ts`) reusing the one existing tool-call correlation in the repo, `ToolBackgroundWorkMetadata.agentId` (`parseToolBackgroundWork`, Claude-only `trackerKind: "claude_async_agent"`), to locate a subagent's initial prompt from its roster id. `SubagentRosterRow`/`AgentsRosterPanel` now thread `workspaceId` and call `buildDelegatedAgentIdentity({ id, title, workspaceId, sessionId: subagent.id })`, rendering `AgentIdentityGlyph` instead of the plain `Fork` glyph — the roster row, detail header, and (pre-existing) transcript rendering now agree on one generated name/color/glyph per the handoff's native-identity note.

**Assumption disclosed:** the delivery spec's Acceptance section says "the two muted transcript status lines" while its own MODIFIED section and my task brief both name three (`Creating` / `Running in background` / `Completed in background`). Followed the more specific three-state instruction.

## Delta-review round 2: three MINORs closed

1. **Direct unit tests for `resolveSubagentIdForItem`** (`subagent-launch.test.ts`) — happy path plus malformed `rawOutput` shapes (string, array, `_anyharness` present with an unrecognized `trackerKind`, `_anyharness.backgroundWork` absent), all returning `null`. Previously only exercised at the `TranscriptAgentGroupBlock` integration level.

2. **Session-scoped the pending subagent selection.** The reviewer offered two options — key `pendingBackgroundSubagentSelectionByWorkspace` by `${workspaceId}:${sessionId}`, or add a `sessionId` field checked on consume — and asked for "the smaller diff." I started with an even smaller third option (clear the pending entry inside the pre-existing session-reset effect) but traced through React's effect-execution model and rejected it: on the realistic path — the same transcript click that writes the pending selection also flips the right panel to `"background"`, which is what *mounts* `BackgroundWorkPane` for the first time — mount runs every effect unconditionally, so the reset effect's `setSelectedSubagentId(null)` and the consumption effect's `setSelectedSubagentId(pending.subagentId)` both fire in the same commit, and the consumption effect (declared after reset) wins regardless of the reset effect's store write. That doesn't reliably close the race. Implemented the `sessionId`-field option instead: `PendingBackgroundSubagentSelection = { subagentId, sessionId }`, captured at write time in `useOpenBackgroundWorkPane` (now `(subagentId?, sessionId?) => void`, both threaded from `MessageList`'s `activeSessionId`), checked against the consuming pane's own `sessionId` prop on read — a mismatch is discarded (but still cleared) inside the same effect that reads the value, so it's correct regardless of mount/remount/same-commit timing. New test: a pending selection written under a different session in the same workspace, with a subagent id that *does* exist in the current session's roster (to prove the guard — not roster-membership — is what keeps it off), is discarded rather than applied.

3. **Keyboard access on the header.** `TranscriptAgentGroupBlock`'s clickable header (`div`, pre-existing) now navigates rather than only toggling, so it gets `role="button"`, `tabIndex={0}`, and an `onKeyDown` handling Enter/Space for both branches (open-subagent, expand-fallback), plus an `aria-label` naming the action. Verified `role="button"` on a `div` doesn't trip `FE-STRUCT-1` (it only regexes literal `<button|input|label|select|textarea>` tags), so no `Button`-wrapper swap was needed. Renamed the expand-fallback header's label to "Show/Hide subagent details" (distinct from the chevron's existing "Expand/Collapse subagent details") — same wording would've given two `role="button"` elements outside the same click target an identical accessible name, which is a real a11y smell even though the two never coexist in the same render (the chevron only renders when the header is also `canOpenSubagent`). The header's `onKeyDown` ignores keydown events whose `target` isn't the header itself (`event.target !== event.currentTarget`), so pressing Enter/Space on the focused chevron button — a real nested `<button>` — can't also re-fire the header's own action via bubbling. Chevron itself is unchanged.

## Gates

- Full `product-client` vitest suite: **1007/1007 test files passed, 7275/7275 tests passed.**
- `tsc -p tsconfig.domain.json` and `tsc -p tsconfig.json --noEmit`: both show only the pre-existing exogenous `TS2741` on `run-view-model.ts(75,7)` — present on base, unrelated to this diff.
- `scripts/report_frontend_structure.py --strict`: **0** violations across all FE-STRUCT/FE-SIZE checks (confirmed `role="button"` divs are not flagged).
- `scripts/check_appearance_scaling.py`: **passed.**
- `scripts/check_design_attribution.py`: **passed** (fixed post-CI — see below).
- No raw `button`/`input`/`label`/`select`/`textarea` introduced in `components/`; primitives only (the chevron uses `Button variant="unstyled"`; the header is a `div` with `role="button"`).

**CI fix-forward — design-attribution gate (PROD-ATTR), mechanical rename, no behavior change:**
- `BackgroundSubagentView.test.tsx:141` — test title credited the raw-tail fallback rendering to "Codex-style" (PROD-ATTR-1: crediting another product for our own styling). Renamed to describe the treatment itself: "raw-tail fallback used for every harness."
- `subagent-launch.test.ts:332` — fixture id `codex-thread-1` joined a product name to a design noun (PROD-ATTR-5: `<product>-thread`). Renamed to `child-thread-1`. Bare `codex` as a harness-kind value elsewhere in the diff is unaffected — the gate's own output confirms that's legitimate product vocabulary; only the product-name+design-noun join was banned.
- Swept the full R4 diff for any other `<product>-style/-like/-esque` prose or `<product>-<design-noun>` identifier joins (case-insensitive, all of `claude`/`codex`/`anthropic`/`openai`/`gpt`) — these were the only two.
- Local verification: `scripts/check_design_attribution.py` passes clean; both affected test files (36 tests) pass; `scripts/report_frontend_structure.py --strict` stays at 0.

## Test plan

- [x] `BackgroundSubagentView` renders header identity/status/provider, the correlated initial prompt (and omits the panel when none correlates), the feed's raw tail, the exact footer copy, no input/textarea/select anywhere, `onBack` fires, and the feed enable/disable gating on `isOpen`.
- [x] `SubagentLaunchLedger` renders nothing for the three retired states, still renders `Launch failed`/`Stopped updating`/`Started`, and never renders a prompt-disclosure affordance.
- [x] `TranscriptAgentGroupBlock` expanded view no longer shows the three muted lines but still shows non-retired ones (e.g. `Launch failed`).
- [x] `TranscriptAgentGroupBlock` native-routing fix-forward: clicking the header calls `onOpenSubagent` with the *correct* correlated subagent id (asserted, not just "opened"); the chevron still expands/collapses when `onOpenSubagent` is wired; a block whose `rawOutput` carries no background-work metadata gets no affordance and keeps the byte-identical expand-on-click header.
- [x] `useOpenBackgroundWorkPane`: the optional subagent id writes the pending-selection entry for the active workspace and still opens the pane exactly as the zero-arg call does; the zero-arg call leaves no pending selection.
- [x] `BackgroundWorkPane`: consumes and clears a pending subagent selection scoped to its own `workspaceId` (ignores one written for a different workspace); opening a subagent renders the real `BackgroundSubagentView`, back returns to the roster, the view bounces back to the roster when the subagent leaves it (finishes), feed gates on `isOpen`, session-id change closes the seam.
- [x] `subagent-launch.ts`: unit tests for `isSubagentLaunchStatusVisibleInTranscript` and `findSubagentLaunchItem` (including the "no correlation for other harnesses" case).
- [x] `SubagentRosterRow`/`AgentsRosterPanel`: generated identity glyph consistent with `buildDelegatedAgentIdentity` for the same id, `onOpen` firing, running-only filtering.
- [x] `resolveSubagentIdForItem` (pure-function unit tests): happy path, and `rawOutput` as a string / an array / with an unrecognized `trackerKind` / missing `_anyharness.backgroundWork` all return `null`.
- [x] `useOpenBackgroundWorkPane`: writes a session-scoped `{ subagentId, sessionId }` pending selection only when *both* arguments are given; the subagent-id-without-sessionId case writes nothing.
- [x] `BackgroundWorkPane`: discards (but still clears) a pending selection written for a different session in the same workspace, even when that selection's subagent id happens to exist in the current session's roster.
- [x] `TranscriptAgentGroupBlock` keyboard access: Enter and Space on the header call `onOpenSubagent` with the correct id when eligible; Enter on the header toggles expand/collapse in the fallback case; the header exposes `role="button"`/`tabIndex={0}`/a distinct `aria-label`; Enter on the (separately focusable) chevron does not also re-fire the header's action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


