### PR TITLE
feat(product): background work finish signals (bgwork R5)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.finish-signals.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.finish-signals.test.tsx
@@ -1,0 +1,382 @@
+/* @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BackgroundWorkRowCounts } from "#product/domain/activity/background-work-row";
+import type { SessionActivityState } from "#product/hooks/activity/derived/use-session-activity";
+import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+import {
+  AgentsRosterPanelMock,
+  BackgroundSubagentViewMock,
+  BackgroundTerminalViewMock,
+  LiveTerminalsRosterPanelMock,
+  makeAgent,
+  makeProcess,
+} from "./BackgroundWorkPane.test.fixtures";
+import { BackgroundWorkPane } from "./BackgroundWorkPane";
+
+// R5 finish-signal ladder concerns: pending-selection consumption, feed
+// isOpen-gating, and the NoticeBanner (dirty/mark-viewed interactions). The
+// roster/scopes/seam/detail-routing coverage lives in the sibling
+// `BackgroundWorkPane.test.tsx` — split for PROD-SIZE-1 (repo-wide 600-line
+// cap); see the fixtures module's docstring. No behavior or assertion
+// changed by the split.
+let sessionActivity: SessionActivityState = {
+  loops: [],
+  loopCapabilities: { supported: false, native: false },
+  processes: [],
+  agents: [],
+};
+let rowCounts: BackgroundWorkRowCounts = { runningCount: 0, finishedCount: 0 };
+
+vi.mock("#product/hooks/activity/derived/use-session-activity", () => ({
+  useSessionActivity: () => sessionActivity,
+  // `useBackgroundWorkFinishSignal` (feeding this pane's NoticeBanner rung)
+  // reads the per-session accessor rather than the active-session-only one
+  // (R5 review round 2 — MAJOR fix). This pane is always scoped to the
+  // active session, so mirroring the same fixture here is faithful — the
+  // per-session-vs-active-session distinction itself is covered by
+  // `use-background-work-finish-signal.test.ts` and
+  // `use-background-work-finish-signal-tracking.test.ts`, not here.
+  useSessionActivityForSession: () => sessionActivity,
+}));
+vi.mock("#product/hooks/activity/derived/use-background-work-row", () => ({
+  useBackgroundWorkRowCounts: () => rowCounts,
+}));
+vi.mock("#product/components/workspace/activity/LiveTerminalsRosterPanel", () => ({
+  LiveTerminalsRosterPanel: LiveTerminalsRosterPanelMock,
+}));
+vi.mock("#product/components/workspace/activity/background-pane/BackgroundTerminalView", () => ({
+  BackgroundTerminalView: BackgroundTerminalViewMock,
+}));
+vi.mock("#product/components/workspace/activity/AgentsRosterPanel", () => ({
+  AgentsRosterPanel: AgentsRosterPanelMock,
+}));
+vi.mock("#product/components/workspace/activity/background-pane/BackgroundSubagentView", () => ({
+  BackgroundSubagentView: BackgroundSubagentViewMock,
+}));
+
+afterEach(() => {
+  sessionActivity = {
+    loops: [],
+    loopCapabilities: { supported: false, native: false },
+    processes: [],
+    agents: [],
+  };
+  rowCounts = { runningCount: 0, finishedCount: 0 };
+  cleanup();
+  useWorkspaceUiStore.setState({
+    pendingBackgroundSubagentSelectionByWorkspace: {},
+    backgroundWorkLastViewedAtBySession: {},
+    backgroundWorkLastFinishedSubagentBySession: {},
+  });
+});
+
+describe("BackgroundWorkPane — finish signals", () => {
+  it("disables the subagent feed while the right panel is collapsed, and re-enables it on reopen", () => {
+    sessionActivity = {
+      loops: [],
+      loopCapabilities: { supported: false, native: false },
+      processes: [],
+      agents: [
+        makeAgent({ id: "agent-live", feed: { feedId: "feed-2", kind: "transcript" } }),
+      ],
+    };
+    const { rerender } = render(
+      <BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />,
+    );
+
+    fireEvent.click(screen.getByTestId("open-subagent-agent-live"));
+    expect(
+      screen.getByTestId("background-subagent-view").getAttribute("data-feed-enabled"),
+    ).toBe("true");
+
+    rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen={false} />);
+
+    expect(screen.getByTestId("background-subagent-view")).toBeTruthy();
+    expect(
+      screen.getByTestId("background-subagent-view").getAttribute("data-feed-enabled"),
+    ).toBe("false");
+
+    rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+
+    expect(
+      screen.getByTestId("background-subagent-view").getAttribute("data-feed-enabled"),
+    ).toBe("true");
+  });
+
+  it("consumes a pending subagent selection from the transcript click seam and clears it", () => {
+    sessionActivity = {
+      loops: [],
+      loopCapabilities: { supported: false, native: false },
+      processes: [],
+      agents: [makeAgent({ id: "agent-42" })],
+    };
+    // Delivery Spec — Background Work Slice 1, rung R4 fix-forward: a native
+    // subagent's transcript block click writes here via
+    // `useOpenBackgroundWorkPane`'s extended return, keyed by the same
+    // `workspaceId` this pane receives as a prop, carrying the session
+    // active at write time.
+    useWorkspaceUiStore.getState().setPendingBackgroundSubagentSelectionForWorkspace(
+      "ws-1",
+      { subagentId: "agent-42", sessionId: "sess-1" },
+    );
+
+    render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+
+    const view = screen.getByTestId("background-subagent-view");
+    expect(view.getAttribute("data-subagent-id")).toBe("agent-42");
+    // One-shot: consumed and cleared, not left to reopen on a later render.
+    expect(
+      useWorkspaceUiStore.getState().pendingBackgroundSubagentSelectionByWorkspace["ws-1"],
+    ).toBeNull();
+  });
+
+  it("ignores a pending subagent selection for a different workspace", () => {
+    sessionActivity = {
+      loops: [],
+      loopCapabilities: { supported: false, native: false },
+      processes: [],
+      agents: [makeAgent({ id: "agent-42" })],
+    };
+    useWorkspaceUiStore.getState().setPendingBackgroundSubagentSelectionForWorkspace(
+      "ws-other",
+      { subagentId: "agent-42", sessionId: "sess-1" },
+    );
+
+    render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+
+    expect(screen.queryByTestId("background-subagent-view")).toBeNull();
+    expect(screen.getByTestId("agents-roster-panel")).toBeTruthy();
+  });
+
+  it("discards (does not apply) a pending subagent selection written for a different session in the same workspace", () => {
+    // Same subagent id happens to also exist in THIS session's roster —
+    // deliberately, so the pre-existing "bounce back if the id isn't in the
+    // roster" defensive effect can't be the thing masking a wrong-session
+    // leak. Only the session-id check on consume should be why this stays
+    // on the roster instead of opening the (wrong) subagent's detail.
+    sessionActivity = {
+      loops: [],
+      loopCapabilities: { supported: false, native: false },
+      processes: [],
+      agents: [makeAgent({ id: "agent-42" })],
+    };
+    // Written while a DIFFERENT session ("sess-other") was active in this
+    // same workspace — the exact cross-session race reviewed in rung R4
+    // fix-forward round 2.
+    useWorkspaceUiStore.getState().setPendingBackgroundSubagentSelectionForWorkspace(
+      "ws-1",
+      { subagentId: "agent-42", sessionId: "sess-other" },
+    );
+
+    render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+
+    expect(screen.queryByTestId("background-subagent-view")).toBeNull();
+    expect(screen.getByTestId("agents-roster-panel")).toBeTruthy();
+    // Still one-shot: discarded, not left dangling for a later session to
+    // pick up by accident.
+    expect(
+      useWorkspaceUiStore.getState().pendingBackgroundSubagentSelectionByWorkspace["ws-1"],
+    ).toBeNull();
+  });
+
+  it("disables the terminal feed while the right panel is collapsed (mounted, CSS-hidden), and re-enables it on reopen", () => {
+    sessionActivity = {
+      loops: [],
+      loopCapabilities: { supported: false, native: false },
+      processes: [
+        makeProcess({ id: "proc-live", feed: { feedId: "feed-1", kind: "terminal_bytes" } }),
+      ],
+      agents: [],
+    };
+    const { rerender } = render(
+      <BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />,
+    );
+
+    fireEvent.click(screen.getByTestId("open-process-proc-live"));
+    expect(
+      screen.getByTestId("background-terminal-view").getAttribute("data-feed-enabled"),
+    ).toBe("true");
+
+    // The right panel collapses via CSS (opacity/inert), staying mounted —
+    // `isOpen` flipping false is the pane's only signal for that. The
+    // terminal detail seam must keep rendering (no unmount) but stop
+    // streaming.
+    rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen={false} />);
+
+    expect(screen.getByTestId("background-terminal-view")).toBeTruthy();
+    expect(
+      screen.getByTestId("background-terminal-view").getAttribute("data-feed-enabled"),
+    ).toBe("false");
+
+    rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+
+    expect(
+      screen.getByTestId("background-terminal-view").getAttribute("data-feed-enabled"),
+    ).toBe("true");
+  });
+
+  describe("finish-signal ladder rung 2 — NoticeBanner", () => {
+    it("names a finished process, offers View, and View opens its terminal detail", () => {
+      sessionActivity = {
+        loops: [],
+        loopCapabilities: { supported: false, native: false },
+        processes: [
+          makeProcess({
+            id: "proc-done",
+            command: "npm run build",
+            status: { status: "exited", exitCode: 0 },
+            endedAt: "2026-08-17T00:00:05Z",
+          }),
+        ],
+        agents: [],
+      };
+      render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+
+      const notice = document.querySelector("[data-background-work-notice]");
+      expect(notice).not.toBeNull();
+      expect(notice?.textContent).toContain("npm run build");
+
+      fireEvent.click(screen.getByRole("button", { name: "View" }));
+
+      expect(screen.getByTestId("background-terminal-view").getAttribute("data-process-id")).toBe(
+        "proc-done",
+      );
+    });
+
+    it("names a finished subagent with no View action (finished subagents have already left the live roster)", () => {
+      useWorkspaceUiStore.getState().recordBackgroundWorkFinishedSubagentForSession(
+        "sess-1",
+        makeAgent({ id: "agent-done", description: "Explore ACP lifecycle", status: { status: "completed", summary: null } }),
+        Date.now(),
+      );
+      render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+
+      const notice = document.querySelector("[data-background-work-notice]");
+      expect(notice).not.toBeNull();
+      expect(notice?.textContent).toContain("Explore ACP lifecycle");
+      expect(screen.queryByRole("button", { name: "View" })).toBeNull();
+    });
+
+    it("does not show the notice while the pane is collapsed (mounted, isOpen=false)", () => {
+      sessionActivity = {
+        loops: [],
+        loopCapabilities: { supported: false, native: false },
+        processes: [
+          makeProcess({
+            id: "proc-done",
+            status: { status: "exited", exitCode: 0 },
+            endedAt: "2026-08-17T00:00:05Z",
+          }),
+        ],
+        agents: [],
+      };
+      render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen={false} />);
+
+      expect(document.querySelector("[data-background-work-notice]")).toBeNull();
+    });
+
+    it("does not show the notice for work that had already finished before the pane was last viewed", () => {
+      useWorkspaceUiStore.getState().markBackgroundWorkViewedForSession("sess-1", Date.parse("2026-08-17T00:00:10Z"));
+      sessionActivity = {
+        loops: [],
+        loopCapabilities: { supported: false, native: false },
+        processes: [
+          makeProcess({
+            id: "proc-stale",
+            status: { status: "exited", exitCode: 0 },
+            endedAt: "2026-08-17T00:00:05Z",
+          }),
+        ],
+        agents: [],
+      };
+      render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+
+      expect(document.querySelector("[data-background-work-notice]")).toBeNull();
+    });
+
+    it("hides the notice while its matching detail view is open, and shows it again on Back (documented minimal dismissal)", () => {
+      sessionActivity = {
+        loops: [],
+        loopCapabilities: { supported: false, native: false },
+        processes: [
+          makeProcess({
+            id: "proc-done",
+            status: { status: "exited", exitCode: 0 },
+            endedAt: "2026-08-17T00:00:05Z",
+          }),
+        ],
+        agents: [],
+      };
+      render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+      expect(document.querySelector("[data-background-work-notice]")).not.toBeNull();
+
+      // The process is exited, so it only lists under the Closed scope; the
+      // banner's own View action (unlike the roster row) works from
+      // whichever scope happens to be showing.
+      fireEvent.click(screen.getByRole("button", { name: "View" }));
+      expect(document.querySelector("[data-background-work-notice]")).toBeNull();
+
+      fireEvent.click(screen.getByRole("button", { name: "Back to background work" }));
+      expect(document.querySelector("[data-background-work-notice]")).not.toBeNull();
+    });
+
+    it("does not flicker away on its own re-renders while the pane stays open (frozen-at-mount baseline)", () => {
+      sessionActivity = {
+        loops: [],
+        loopCapabilities: { supported: false, native: false },
+        processes: [
+          makeProcess({
+            id: "proc-done",
+            status: { status: "exited", exitCode: 0 },
+            endedAt: "2026-08-17T00:00:05Z",
+          }),
+        ],
+        agents: [],
+      };
+      const { rerender } = render(
+        <BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />,
+      );
+      expect(document.querySelector("[data-background-work-notice]")).not.toBeNull();
+
+      // The mark-viewed-on-mount effect has by now advanced the LIVE
+      // `backgroundWorkLastViewedAtBySession["sess-1"]` past this signal's
+      // `atMs` — re-rendering with unchanged props must not read that live
+      // value, or the banner would vanish on its own the instant after it
+      // appeared.
+      rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+      expect(document.querySelector("[data-background-work-notice]")).not.toBeNull();
+    });
+
+    it("does not leak a stale finished signal or baseline into a freshly switched-to session", () => {
+      sessionActivity = {
+        loops: [],
+        loopCapabilities: { supported: false, native: false },
+        processes: [
+          makeProcess({
+            id: "proc-done",
+            status: { status: "exited", exitCode: 0 },
+            endedAt: "2026-08-17T00:00:05Z",
+          }),
+        ],
+        agents: [],
+      };
+      const { rerender } = render(
+        <BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />,
+      );
+      expect(document.querySelector("[data-background-work-notice]")).not.toBeNull();
+
+      // A real session switch also switches the roster `useSessionActivity`
+      // reports — the new session has its own (here: empty) activity, not
+      // sess-1's finished process.
+      sessionActivity = {
+        loops: [],
+        loopCapabilities: { supported: false, native: false },
+        processes: [],
+        agents: [],
+      };
+      rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-2" isOpen />);
+      expect(document.querySelector("[data-background-work-notice]")).toBeNull();
+    });
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.fixtures.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.fixtures.tsx
@@ -11,6 +11,12 @@
  * lines. No behavior or assertion changed by the split — every test moved
  * verbatim into one of the two files above, and this module holds only the
  * value builders and component stand-ins both files need identically.
+ *
+ * The `.test.` mid-name segment is LOAD-BEARING, not stylistic: it must
+ * contain the literal substring `.test.` so `report_frontend_structure.py`'s
+ * `should_skip` exempts the raw `<button>` mocks in here, while NOT ending in
+ * `.test.tsx` so vitest's include glob does not collect it as an (empty)
+ * suite. Renaming it either way silently breaks one of those two gates.
  */
 import type { ActivityProcessWire } from "#product/domain/activity/process";
 import type { ActivitySubagentWire } from "#product/domain/activity/subagent";

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.fixtures.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.fixtures.tsx
@@ -1,0 +1,145 @@
+/**
+ * Shared, mechanical test fixtures for `BackgroundWorkPane`'s two split
+ * test files:
+ *  - `BackgroundWorkPane.test.tsx` — roster/scopes/seam/detail-routing.
+ *  - `BackgroundWorkPane.finish-signals.test.tsx` — the R5 finish-signal
+ *    ladder concerns: the NoticeBanner, pending-selection consumption, and
+ *    feed isOpen-gating.
+ *
+ * Split for PROD-SIZE-1 (the repo-wide 600-line cap, `scripts/check_max_lines.py`):
+ * R2-R5 review rounds accumulated coverage onto one file until it hit 690
+ * lines. No behavior or assertion changed by the split — every test moved
+ * verbatim into one of the two files above, and this module holds only the
+ * value builders and component stand-ins both files need identically.
+ */
+import type { ActivityProcessWire } from "#product/domain/activity/process";
+import type { ActivitySubagentWire } from "#product/domain/activity/subagent";
+
+export function makeProcess(overrides: Partial<ActivityProcessWire>): ActivityProcessWire {
+  return {
+    id: "proc-1",
+    command: "npm test",
+    cwd: null,
+    status: { status: "running" },
+    pid: null,
+    startedAt: "2026-08-16T00:00:00Z",
+    endedAt: null,
+    feed: null,
+    ...overrides,
+  };
+}
+
+export function makeAgent(overrides: Partial<ActivitySubagentWire>): ActivitySubagentWire {
+  return {
+    id: "agent-1",
+    agentType: "claude-subagent",
+    description: "Native subagent",
+    model: null,
+    background: true,
+    status: { status: "running" },
+    usage: null,
+    feed: null,
+    ...overrides,
+  };
+}
+
+// `LiveTerminalsRosterPanel`, `AgentsRosterPanel`, `BackgroundTerminalView`
+// and `BackgroundSubagentView` own live feed wiring (`useFeedStream`,
+// `useSessionDirectoryStore`) that is out of scope for BackgroundWorkPane's
+// own unit tests — those components have their own dedicated tests. Stubbed
+// here so BackgroundWorkPane's own logic (scope switching, counts, the
+// terminal + subagent seams, the finish-signal banner) is what's under test
+// in both split files.
+export function LiveTerminalsRosterPanelMock({
+  processes,
+  onOpen,
+}: {
+  processes: ActivityProcessWire[];
+  onOpen?: (id: string) => void;
+}) {
+  return (
+    <div data-testid="live-terminals-roster-panel">
+      <span data-testid="live-terminals-roster-panel-ids">
+        {processes.map((process) => process.id).join(",")}
+      </span>
+      {processes.map((process) => (
+        <div
+          key={process.id}
+          role="button"
+          tabIndex={0}
+          data-testid={`open-process-${process.id}`}
+          onClick={() => onOpen?.(process.id)}
+        >
+          open {process.id}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function BackgroundTerminalViewMock({
+  process,
+  feed,
+  onBack,
+}: {
+  process: ActivityProcessWire;
+  feed: { feedId: string } | null;
+  onBack: () => void;
+}) {
+  return (
+    <div
+      data-testid="background-terminal-view"
+      data-process-id={process.id}
+      data-feed-enabled={String(feed !== null)}
+    >
+      <button type="button" onClick={onBack}>
+        Back to background work
+      </button>
+    </div>
+  );
+}
+
+export function AgentsRosterPanelMock({
+  agents,
+  onOpen,
+}: {
+  agents: ActivitySubagentWire[];
+  workspaceId: string;
+  onOpen?: (id: string) => void;
+}) {
+  return (
+    <div data-testid="agents-roster-panel">
+      {agents.map((agent) => (
+        <div
+          key={agent.id}
+          role="button"
+          tabIndex={0}
+          data-testid={`open-subagent-${agent.id}`}
+          onClick={() => onOpen?.(agent.id)}
+        >
+          {agent.id}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function BackgroundSubagentViewMock({
+  subagent,
+  onBack,
+}: {
+  subagent: ActivitySubagentWire;
+  onBack: () => void;
+}) {
+  return (
+    <div
+      data-testid="background-subagent-view"
+      data-subagent-id={subagent.id}
+      data-feed-enabled={String(subagent.feed !== null)}
+    >
+      <button type="button" onClick={onBack}>
+        Back to background work
+      </button>
+    </div>
+  );
+}

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.tsx
@@ -18,6 +18,14 @@ let rowCounts: BackgroundWorkRowCounts = { runningCount: 0, finishedCount: 0 };
 
 vi.mock("#product/hooks/activity/derived/use-session-activity", () => ({
   useSessionActivity: () => sessionActivity,
+  // `useBackgroundWorkFinishSignal` (feeding this pane's NoticeBanner rung)
+  // reads the per-session accessor rather than the active-session-only one
+  // (R5 review round 2 — MAJOR fix). This pane is always scoped to the
+  // active session, so mirroring the same fixture here is faithful — the
+  // per-session-vs-active-session distinction itself is covered by
+  // `use-background-work-finish-signal.test.ts` and
+  // `use-background-work-finish-signal-tracking.test.ts`, not here.
+  useSessionActivityForSession: () => sessionActivity,
 }));
 vi.mock("#product/hooks/activity/derived/use-background-work-row", () => ({
   useBackgroundWorkRowCounts: () => rowCounts,

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.tsx
@@ -1,13 +1,24 @@
 /* @vitest-environment jsdom */
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ActivityProcessWire } from "#product/domain/activity/process";
-import type { ActivitySubagentWire } from "#product/domain/activity/subagent";
 import type { BackgroundWorkRowCounts } from "#product/domain/activity/background-work-row";
 import type { SessionActivityState } from "#product/hooks/activity/derived/use-session-activity";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+import {
+  AgentsRosterPanelMock,
+  BackgroundSubagentViewMock,
+  BackgroundTerminalViewMock,
+  LiveTerminalsRosterPanelMock,
+  makeAgent,
+  makeProcess,
+} from "./BackgroundWorkPane.test.fixtures";
 import { BackgroundWorkPane } from "./BackgroundWorkPane";
 
+// Roster/scopes/seam/detail-routing coverage. The R5 finish-signal ladder
+// concerns (NoticeBanner, pending-selection consumption, feed isOpen-gating)
+// live in the sibling `BackgroundWorkPane.finish-signals.test.tsx` — split
+// for PROD-SIZE-1 (repo-wide 600-line cap); see the fixtures module's
+// docstring.
 let sessionActivity: SessionActivityState = {
   loops: [],
   loopCapabilities: { supported: false, native: false },
@@ -30,130 +41,18 @@ vi.mock("#product/hooks/activity/derived/use-session-activity", () => ({
 vi.mock("#product/hooks/activity/derived/use-background-work-row", () => ({
   useBackgroundWorkRowCounts: () => rowCounts,
 }));
-
-// `LiveTerminalsRosterPanel`, `AgentsRosterPanel` and `BackgroundTerminalView`
-// own live feed wiring (`useFeedStream`, `useSessionDirectoryStore`) that is
-// out of scope for this pane's own unit tests — those components have their
-// own dedicated tests. Stubbed here so BackgroundWorkPane's own logic (scope
-// switching, counts, the terminal + subagent seams) is what's under test.
 vi.mock("#product/components/workspace/activity/LiveTerminalsRosterPanel", () => ({
-  LiveTerminalsRosterPanel: ({
-    processes,
-    onOpen,
-  }: {
-    processes: ActivityProcessWire[];
-    onOpen?: (id: string) => void;
-  }) => (
-    <div data-testid="live-terminals-roster-panel">
-      <span data-testid="live-terminals-roster-panel-ids">
-        {processes.map((process) => process.id).join(",")}
-      </span>
-      {processes.map((process) => (
-        <div
-          key={process.id}
-          role="button"
-          tabIndex={0}
-          data-testid={`open-process-${process.id}`}
-          onClick={() => onOpen?.(process.id)}
-        >
-          open {process.id}
-        </div>
-      ))}
-    </div>
-  ),
+  LiveTerminalsRosterPanel: LiveTerminalsRosterPanelMock,
 }));
 vi.mock("#product/components/workspace/activity/background-pane/BackgroundTerminalView", () => ({
-  BackgroundTerminalView: ({
-    process,
-    feed,
-    onBack,
-  }: {
-    process: ActivityProcessWire;
-    feed: { feedId: string } | null;
-    onBack: () => void;
-  }) => (
-    <div
-      data-testid="background-terminal-view"
-      data-process-id={process.id}
-      data-feed-enabled={String(feed !== null)}
-    >
-      <button type="button" onClick={onBack}>
-        Back to background work
-      </button>
-    </div>
-  ),
+  BackgroundTerminalView: BackgroundTerminalViewMock,
 }));
 vi.mock("#product/components/workspace/activity/AgentsRosterPanel", () => ({
-  AgentsRosterPanel: ({
-    agents,
-    onOpen,
-  }: {
-    agents: ActivitySubagentWire[];
-    workspaceId: string;
-    onOpen?: (id: string) => void;
-  }) => (
-    <div data-testid="agents-roster-panel">
-      {agents.map((agent) => (
-        <div
-          key={agent.id}
-          role="button"
-          tabIndex={0}
-          data-testid={`open-subagent-${agent.id}`}
-          onClick={() => onOpen?.(agent.id)}
-        >
-          {agent.id}
-        </div>
-      ))}
-    </div>
-  ),
+  AgentsRosterPanel: AgentsRosterPanelMock,
 }));
 vi.mock("#product/components/workspace/activity/background-pane/BackgroundSubagentView", () => ({
-  BackgroundSubagentView: ({
-    subagent,
-    onBack,
-  }: {
-    subagent: ActivitySubagentWire;
-    onBack: () => void;
-  }) => (
-    <div
-      data-testid="background-subagent-view"
-      data-subagent-id={subagent.id}
-      data-feed-enabled={String(subagent.feed !== null)}
-    >
-      <button type="button" onClick={onBack}>
-        Back to background work
-      </button>
-    </div>
-  ),
+  BackgroundSubagentView: BackgroundSubagentViewMock,
 }));
-
-function makeProcess(overrides: Partial<ActivityProcessWire>): ActivityProcessWire {
-  return {
-    id: "proc-1",
-    command: "npm test",
-    cwd: null,
-    status: { status: "running" },
-    pid: null,
-    startedAt: "2026-08-16T00:00:00Z",
-    endedAt: null,
-    feed: null,
-    ...overrides,
-  };
-}
-
-function makeAgent(overrides: Partial<ActivitySubagentWire>): ActivitySubagentWire {
-  return {
-    id: "agent-1",
-    agentType: "claude-subagent",
-    description: "Native subagent",
-    model: null,
-    background: true,
-    status: { status: "running" },
-    usage: null,
-    feed: null,
-    ...overrides,
-  };
-}
 
 afterEach(() => {
   sessionActivity = {
@@ -286,114 +185,6 @@ describe("BackgroundWorkPane", () => {
     expect(screen.getByTestId("agents-roster-panel")).toBeTruthy();
   });
 
-  it("disables the subagent feed while the right panel is collapsed, and re-enables it on reopen", () => {
-    sessionActivity = {
-      loops: [],
-      loopCapabilities: { supported: false, native: false },
-      processes: [],
-      agents: [
-        makeAgent({ id: "agent-live", feed: { feedId: "feed-2", kind: "transcript" } }),
-      ],
-    };
-    const { rerender } = render(
-      <BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />,
-    );
-
-    fireEvent.click(screen.getByTestId("open-subagent-agent-live"));
-    expect(
-      screen.getByTestId("background-subagent-view").getAttribute("data-feed-enabled"),
-    ).toBe("true");
-
-    rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen={false} />);
-
-    expect(screen.getByTestId("background-subagent-view")).toBeTruthy();
-    expect(
-      screen.getByTestId("background-subagent-view").getAttribute("data-feed-enabled"),
-    ).toBe("false");
-
-    rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
-
-    expect(
-      screen.getByTestId("background-subagent-view").getAttribute("data-feed-enabled"),
-    ).toBe("true");
-  });
-
-  it("consumes a pending subagent selection from the transcript click seam and clears it", () => {
-    sessionActivity = {
-      loops: [],
-      loopCapabilities: { supported: false, native: false },
-      processes: [],
-      agents: [makeAgent({ id: "agent-42" })],
-    };
-    // Delivery Spec — Background Work Slice 1, rung R4 fix-forward: a native
-    // subagent's transcript block click writes here via
-    // `useOpenBackgroundWorkPane`'s extended return, keyed by the same
-    // `workspaceId` this pane receives as a prop, carrying the session
-    // active at write time.
-    useWorkspaceUiStore.getState().setPendingBackgroundSubagentSelectionForWorkspace(
-      "ws-1",
-      { subagentId: "agent-42", sessionId: "sess-1" },
-    );
-
-    render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
-
-    const view = screen.getByTestId("background-subagent-view");
-    expect(view.getAttribute("data-subagent-id")).toBe("agent-42");
-    // One-shot: consumed and cleared, not left to reopen on a later render.
-    expect(
-      useWorkspaceUiStore.getState().pendingBackgroundSubagentSelectionByWorkspace["ws-1"],
-    ).toBeNull();
-  });
-
-  it("ignores a pending subagent selection for a different workspace", () => {
-    sessionActivity = {
-      loops: [],
-      loopCapabilities: { supported: false, native: false },
-      processes: [],
-      agents: [makeAgent({ id: "agent-42" })],
-    };
-    useWorkspaceUiStore.getState().setPendingBackgroundSubagentSelectionForWorkspace(
-      "ws-other",
-      { subagentId: "agent-42", sessionId: "sess-1" },
-    );
-
-    render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
-
-    expect(screen.queryByTestId("background-subagent-view")).toBeNull();
-    expect(screen.getByTestId("agents-roster-panel")).toBeTruthy();
-  });
-
-  it("discards (does not apply) a pending subagent selection written for a different session in the same workspace", () => {
-    // Same subagent id happens to also exist in THIS session's roster —
-    // deliberately, so the pre-existing "bounce back if the id isn't in the
-    // roster" defensive effect can't be the thing masking a wrong-session
-    // leak. Only the session-id check on consume should be why this stays
-    // on the roster instead of opening the (wrong) subagent's detail.
-    sessionActivity = {
-      loops: [],
-      loopCapabilities: { supported: false, native: false },
-      processes: [],
-      agents: [makeAgent({ id: "agent-42" })],
-    };
-    // Written while a DIFFERENT session ("sess-other") was active in this
-    // same workspace — the exact cross-session race reviewed in rung R4
-    // fix-forward round 2.
-    useWorkspaceUiStore.getState().setPendingBackgroundSubagentSelectionForWorkspace(
-      "ws-1",
-      { subagentId: "agent-42", sessionId: "sess-other" },
-    );
-
-    render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
-
-    expect(screen.queryByTestId("background-subagent-view")).toBeNull();
-    expect(screen.getByTestId("agents-roster-panel")).toBeTruthy();
-    // Still one-shot: discarded, not left dangling for a later session to
-    // pick up by accident.
-    expect(
-      useWorkspaceUiStore.getState().pendingBackgroundSubagentSelectionByWorkspace["ws-1"],
-    ).toBeNull();
-  });
-
   it("opening a terminal process replaces the roster with the real BackgroundTerminalView, and back returns", () => {
     sessionActivity = {
       loops: [],
@@ -486,205 +277,5 @@ describe("BackgroundWorkPane", () => {
     rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-2" isOpen />);
 
     expect(screen.queryByTestId("background-terminal-view")).toBeNull();
-  });
-
-  it("disables the terminal feed while the right panel is collapsed (mounted, CSS-hidden), and re-enables it on reopen", () => {
-    sessionActivity = {
-      loops: [],
-      loopCapabilities: { supported: false, native: false },
-      processes: [
-        makeProcess({ id: "proc-live", feed: { feedId: "feed-1", kind: "terminal_bytes" } }),
-      ],
-      agents: [],
-    };
-    const { rerender } = render(
-      <BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />,
-    );
-
-    fireEvent.click(screen.getByTestId("open-process-proc-live"));
-    expect(
-      screen.getByTestId("background-terminal-view").getAttribute("data-feed-enabled"),
-    ).toBe("true");
-
-    // The right panel collapses via CSS (opacity/inert), staying mounted —
-    // `isOpen` flipping false is the pane's only signal for that. The
-    // terminal detail seam must keep rendering (no unmount) but stop
-    // streaming.
-    rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen={false} />);
-
-    expect(screen.getByTestId("background-terminal-view")).toBeTruthy();
-    expect(
-      screen.getByTestId("background-terminal-view").getAttribute("data-feed-enabled"),
-    ).toBe("false");
-
-    rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
-
-    expect(
-      screen.getByTestId("background-terminal-view").getAttribute("data-feed-enabled"),
-    ).toBe("true");
-  });
-
-  describe("finish-signal ladder rung 2 — NoticeBanner", () => {
-    it("names a finished process, offers View, and View opens its terminal detail", () => {
-      sessionActivity = {
-        loops: [],
-        loopCapabilities: { supported: false, native: false },
-        processes: [
-          makeProcess({
-            id: "proc-done",
-            command: "npm run build",
-            status: { status: "exited", exitCode: 0 },
-            endedAt: "2026-08-17T00:00:05Z",
-          }),
-        ],
-        agents: [],
-      };
-      render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
-
-      const notice = document.querySelector("[data-background-work-notice]");
-      expect(notice).not.toBeNull();
-      expect(notice?.textContent).toContain("npm run build");
-
-      fireEvent.click(screen.getByRole("button", { name: "View" }));
-
-      expect(screen.getByTestId("background-terminal-view").getAttribute("data-process-id")).toBe(
-        "proc-done",
-      );
-    });
-
-    it("names a finished subagent with no View action (finished subagents have already left the live roster)", () => {
-      useWorkspaceUiStore.getState().recordBackgroundWorkFinishedSubagentForSession(
-        "sess-1",
-        makeAgent({ id: "agent-done", description: "Explore ACP lifecycle", status: { status: "completed", summary: null } }),
-        Date.now(),
-      );
-      render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
-
-      const notice = document.querySelector("[data-background-work-notice]");
-      expect(notice).not.toBeNull();
-      expect(notice?.textContent).toContain("Explore ACP lifecycle");
-      expect(screen.queryByRole("button", { name: "View" })).toBeNull();
-    });
-
-    it("does not show the notice while the pane is collapsed (mounted, isOpen=false)", () => {
-      sessionActivity = {
-        loops: [],
-        loopCapabilities: { supported: false, native: false },
-        processes: [
-          makeProcess({
-            id: "proc-done",
-            status: { status: "exited", exitCode: 0 },
-            endedAt: "2026-08-17T00:00:05Z",
-          }),
-        ],
-        agents: [],
-      };
-      render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen={false} />);
-
-      expect(document.querySelector("[data-background-work-notice]")).toBeNull();
-    });
-
-    it("does not show the notice for work that had already finished before the pane was last viewed", () => {
-      useWorkspaceUiStore.getState().markBackgroundWorkViewedForSession("sess-1", Date.parse("2026-08-17T00:00:10Z"));
-      sessionActivity = {
-        loops: [],
-        loopCapabilities: { supported: false, native: false },
-        processes: [
-          makeProcess({
-            id: "proc-stale",
-            status: { status: "exited", exitCode: 0 },
-            endedAt: "2026-08-17T00:00:05Z",
-          }),
-        ],
-        agents: [],
-      };
-      render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
-
-      expect(document.querySelector("[data-background-work-notice]")).toBeNull();
-    });
-
-    it("hides the notice while its matching detail view is open, and shows it again on Back (documented minimal dismissal)", () => {
-      sessionActivity = {
-        loops: [],
-        loopCapabilities: { supported: false, native: false },
-        processes: [
-          makeProcess({
-            id: "proc-done",
-            status: { status: "exited", exitCode: 0 },
-            endedAt: "2026-08-17T00:00:05Z",
-          }),
-        ],
-        agents: [],
-      };
-      render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
-      expect(document.querySelector("[data-background-work-notice]")).not.toBeNull();
-
-      // The process is exited, so it only lists under the Closed scope; the
-      // banner's own View action (unlike the roster row) works from
-      // whichever scope happens to be showing.
-      fireEvent.click(screen.getByRole("button", { name: "View" }));
-      expect(document.querySelector("[data-background-work-notice]")).toBeNull();
-
-      fireEvent.click(screen.getByRole("button", { name: "Back to background work" }));
-      expect(document.querySelector("[data-background-work-notice]")).not.toBeNull();
-    });
-
-    it("does not flicker away on its own re-renders while the pane stays open (frozen-at-mount baseline)", () => {
-      sessionActivity = {
-        loops: [],
-        loopCapabilities: { supported: false, native: false },
-        processes: [
-          makeProcess({
-            id: "proc-done",
-            status: { status: "exited", exitCode: 0 },
-            endedAt: "2026-08-17T00:00:05Z",
-          }),
-        ],
-        agents: [],
-      };
-      const { rerender } = render(
-        <BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />,
-      );
-      expect(document.querySelector("[data-background-work-notice]")).not.toBeNull();
-
-      // The mark-viewed-on-mount effect has by now advanced the LIVE
-      // `backgroundWorkLastViewedAtBySession["sess-1"]` past this signal's
-      // `atMs` — re-rendering with unchanged props must not read that live
-      // value, or the banner would vanish on its own the instant after it
-      // appeared.
-      rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
-      expect(document.querySelector("[data-background-work-notice]")).not.toBeNull();
-    });
-
-    it("does not leak a stale finished signal or baseline into a freshly switched-to session", () => {
-      sessionActivity = {
-        loops: [],
-        loopCapabilities: { supported: false, native: false },
-        processes: [
-          makeProcess({
-            id: "proc-done",
-            status: { status: "exited", exitCode: 0 },
-            endedAt: "2026-08-17T00:00:05Z",
-          }),
-        ],
-        agents: [],
-      };
-      const { rerender } = render(
-        <BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />,
-      );
-      expect(document.querySelector("[data-background-work-notice]")).not.toBeNull();
-
-      // A real session switch also switches the roster `useSessionActivity`
-      // reports — the new session has its own (here: empty) activity, not
-      // sess-1's finished process.
-      sessionActivity = {
-        loops: [],
-        loopCapabilities: { supported: false, native: false },
-        processes: [],
-        agents: [],
-      };
-      rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-2" isOpen />);
-      expect(document.querySelector("[data-background-work-notice]")).toBeNull();
-    });
   });
 });

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.tsx
@@ -158,6 +158,8 @@ afterEach(() => {
   cleanup();
   useWorkspaceUiStore.setState({
     pendingBackgroundSubagentSelectionByWorkspace: {},
+    backgroundWorkLastViewedAtBySession: {},
+    backgroundWorkLastFinishedSubagentBySession: {},
   });
 });
 
@@ -512,5 +514,169 @@ describe("BackgroundWorkPane", () => {
     expect(
       screen.getByTestId("background-terminal-view").getAttribute("data-feed-enabled"),
     ).toBe("true");
+  });
+
+  describe("finish-signal ladder rung 2 — NoticeBanner", () => {
+    it("names a finished process, offers View, and View opens its terminal detail", () => {
+      sessionActivity = {
+        loops: [],
+        loopCapabilities: { supported: false, native: false },
+        processes: [
+          makeProcess({
+            id: "proc-done",
+            command: "npm run build",
+            status: { status: "exited", exitCode: 0 },
+            endedAt: "2026-08-17T00:00:05Z",
+          }),
+        ],
+        agents: [],
+      };
+      render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+
+      const notice = document.querySelector("[data-background-work-notice]");
+      expect(notice).not.toBeNull();
+      expect(notice?.textContent).toContain("npm run build");
+
+      fireEvent.click(screen.getByRole("button", { name: "View" }));
+
+      expect(screen.getByTestId("background-terminal-view").getAttribute("data-process-id")).toBe(
+        "proc-done",
+      );
+    });
+
+    it("names a finished subagent with no View action (finished subagents have already left the live roster)", () => {
+      useWorkspaceUiStore.getState().recordBackgroundWorkFinishedSubagentForSession(
+        "sess-1",
+        makeAgent({ id: "agent-done", description: "Explore ACP lifecycle", status: { status: "completed", summary: null } }),
+        Date.now(),
+      );
+      render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+
+      const notice = document.querySelector("[data-background-work-notice]");
+      expect(notice).not.toBeNull();
+      expect(notice?.textContent).toContain("Explore ACP lifecycle");
+      expect(screen.queryByRole("button", { name: "View" })).toBeNull();
+    });
+
+    it("does not show the notice while the pane is collapsed (mounted, isOpen=false)", () => {
+      sessionActivity = {
+        loops: [],
+        loopCapabilities: { supported: false, native: false },
+        processes: [
+          makeProcess({
+            id: "proc-done",
+            status: { status: "exited", exitCode: 0 },
+            endedAt: "2026-08-17T00:00:05Z",
+          }),
+        ],
+        agents: [],
+      };
+      render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen={false} />);
+
+      expect(document.querySelector("[data-background-work-notice]")).toBeNull();
+    });
+
+    it("does not show the notice for work that had already finished before the pane was last viewed", () => {
+      useWorkspaceUiStore.getState().markBackgroundWorkViewedForSession("sess-1", Date.parse("2026-08-17T00:00:10Z"));
+      sessionActivity = {
+        loops: [],
+        loopCapabilities: { supported: false, native: false },
+        processes: [
+          makeProcess({
+            id: "proc-stale",
+            status: { status: "exited", exitCode: 0 },
+            endedAt: "2026-08-17T00:00:05Z",
+          }),
+        ],
+        agents: [],
+      };
+      render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+
+      expect(document.querySelector("[data-background-work-notice]")).toBeNull();
+    });
+
+    it("hides the notice while its matching detail view is open, and shows it again on Back (documented minimal dismissal)", () => {
+      sessionActivity = {
+        loops: [],
+        loopCapabilities: { supported: false, native: false },
+        processes: [
+          makeProcess({
+            id: "proc-done",
+            status: { status: "exited", exitCode: 0 },
+            endedAt: "2026-08-17T00:00:05Z",
+          }),
+        ],
+        agents: [],
+      };
+      render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+      expect(document.querySelector("[data-background-work-notice]")).not.toBeNull();
+
+      // The process is exited, so it only lists under the Closed scope; the
+      // banner's own View action (unlike the roster row) works from
+      // whichever scope happens to be showing.
+      fireEvent.click(screen.getByRole("button", { name: "View" }));
+      expect(document.querySelector("[data-background-work-notice]")).toBeNull();
+
+      fireEvent.click(screen.getByRole("button", { name: "Back to background work" }));
+      expect(document.querySelector("[data-background-work-notice]")).not.toBeNull();
+    });
+
+    it("does not flicker away on its own re-renders while the pane stays open (frozen-at-mount baseline)", () => {
+      sessionActivity = {
+        loops: [],
+        loopCapabilities: { supported: false, native: false },
+        processes: [
+          makeProcess({
+            id: "proc-done",
+            status: { status: "exited", exitCode: 0 },
+            endedAt: "2026-08-17T00:00:05Z",
+          }),
+        ],
+        agents: [],
+      };
+      const { rerender } = render(
+        <BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />,
+      );
+      expect(document.querySelector("[data-background-work-notice]")).not.toBeNull();
+
+      // The mark-viewed-on-mount effect has by now advanced the LIVE
+      // `backgroundWorkLastViewedAtBySession["sess-1"]` past this signal's
+      // `atMs` — re-rendering with unchanged props must not read that live
+      // value, or the banner would vanish on its own the instant after it
+      // appeared.
+      rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
+      expect(document.querySelector("[data-background-work-notice]")).not.toBeNull();
+    });
+
+    it("does not leak a stale finished signal or baseline into a freshly switched-to session", () => {
+      sessionActivity = {
+        loops: [],
+        loopCapabilities: { supported: false, native: false },
+        processes: [
+          makeProcess({
+            id: "proc-done",
+            status: { status: "exited", exitCode: 0 },
+            endedAt: "2026-08-17T00:00:05Z",
+          }),
+        ],
+        agents: [],
+      };
+      const { rerender } = render(
+        <BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />,
+      );
+      expect(document.querySelector("[data-background-work-notice]")).not.toBeNull();
+
+      // A real session switch also switches the roster `useSessionActivity`
+      // reports — the new session has its own (here: empty) activity, not
+      // sess-1's finished process.
+      sessionActivity = {
+        loops: [],
+        loopCapabilities: { supported: false, native: false },
+        processes: [],
+        agents: [],
+      };
+      rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-2" isOpen />);
+      expect(document.querySelector("[data-background-work-notice]")).toBeNull();
+    });
   });
 });

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.tsx
@@ -1,13 +1,19 @@
 import { useEffect, useState } from "react";
 import { SegmentedControl, type SegmentedControlItem } from "#product/primitives/SegmentedControl";
 import { RosterPanel } from "#product/primitives/patterns/RosterPanel";
+import { NoticeBanner } from "#product/primitives/patterns/NoticeBanner";
+import { Button } from "#product/primitives/Button";
+import { CircleCheck } from "#product/primitives/icons/status";
 import { AgentsRosterPanel } from "#product/components/workspace/activity/AgentsRosterPanel";
 import { LiveTerminalsRosterPanel } from "#product/components/workspace/activity/LiveTerminalsRosterPanel";
 import { BackgroundTerminalView } from "#product/components/workspace/activity/background-pane/BackgroundTerminalView";
 import { BackgroundSubagentView } from "#product/components/workspace/activity/background-pane/BackgroundSubagentView";
 import { useSessionActivity } from "#product/hooks/activity/derived/use-session-activity";
 import { useBackgroundWorkRowCounts } from "#product/hooks/activity/derived/use-background-work-row";
-import { isProcessRunning } from "#product/domain/activity/process";
+import { useBackgroundWorkFinishSignal } from "#product/hooks/activity/derived/use-background-work-finish-signal";
+import { deriveBackgroundWorkDirty } from "#product/domain/activity/background-work-finish-signal";
+import { isProcessRunning, processStatusLabel } from "#product/domain/activity/process";
+import { subagentDisplayTitle, subagentStatusLabel } from "#product/domain/activity/subagent";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 
 // Same 15s cadence as the shared `useActivityNowMs`, but reimplemented locally
@@ -49,6 +55,17 @@ export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: Backgroun
   const [scope, setScope] = useState<BackgroundWorkScope>("running");
   const [selectedSubagentId, setSelectedSubagentId] = useState<string | null>(null);
   const [selectedProcessId, setSelectedProcessId] = useState<string | null>(null);
+  // The finish-signal ladder rung 2 (`NoticeBanner`) baseline — see the note
+  // where this is consumed below for why it must be a snapshot rather than a
+  // live store read. Reset alongside everything else in the per-session
+  // effect just below rather than relying solely on a lazy `useState`
+  // initializer: the real call site remounts this component on session
+  // switch (`RightPanelContent` — `key={activeSessionId}`), but this
+  // component's own reset should not silently depend on every caller doing
+  // that.
+  const [lastViewedAtMsBeforeThisMount, setLastViewedAtMsBeforeThisMount] = useState<number | null>(
+    () => useWorkspaceUiStore.getState().backgroundWorkLastViewedAtBySession[sessionId] ?? null,
+  );
   // Session-scoped by design (handoff — "Out of scope: workspace-level
   // persistence"): switching the active session resets the scope and closes
   // any open detail seam rather than carrying another session's selection.
@@ -56,6 +73,9 @@ export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: Backgroun
     setScope("running");
     setSelectedSubagentId(null);
     setSelectedProcessId(null);
+    setLastViewedAtMsBeforeThisMount(
+      useWorkspaceUiStore.getState().backgroundWorkLastViewedAtBySession[sessionId] ?? null,
+    );
   }, [sessionId]);
 
   // The roster subscription (`useSessionActivity`) that used to live on
@@ -148,6 +168,47 @@ export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: Backgroun
     workspaceId,
   ]);
 
+  // Finish-signal ladder rung 2 (`NoticeBanner`, Design Handoff —
+  // "When one finishes: Pane notice"): visible only while this pane is both
+  // mounted AND actually open (not CSS-collapsed via `WorkspaceShellRightRail`),
+  // and only above the roster — the process/subagent detail views below are
+  // a full swap of this component's return, so opening either one already
+  // removes the banner with no extra state ("clears when the user opens
+  // the named detail").
+  //
+  // The "frozen at mount" baseline is deliberate: the mark-viewed effect
+  // right below keeps nudging the LIVE `lastViewedAtMs` forward for as
+  // long as the pane stays mounted (so the tab dot never re-lights for a
+  // finish this pane already showed live) — comparing the banner's own
+  // visibility against that same live value would make it flip false on
+  // the very next render after appearing. Comparing against a value
+  // snapshotted once per session (see `lastViewedAtMsBeforeThisMount`
+  // above), avoids that self-erasing race.
+  //
+  // Minimal dismissal semantics (handoff is silent on the exact rule):
+  // the banner is hidden for as long as either detail view is open (a full
+  // swap of this return), and reappears if the user presses Back to the
+  // roster within the SAME session (same baseline) — nothing tracks "the
+  // user already saw this one" beyond that. It fully, permanently clears
+  // only on tab-away (unmount) or a session switch (fresh baseline).
+  const finishSignalState = useBackgroundWorkFinishSignal(sessionId);
+  const markBackgroundWorkViewedForSession = useWorkspaceUiStore(
+    (state) => state.markBackgroundWorkViewedForSession,
+  );
+  // "Clears on select" (handoff, verbatim) — mounting this pane IS
+  // selecting the Background work tab, independent of whether the whole
+  // right rail happens to be CSS-collapsed at that instant, so this runs
+  // unconditionally rather than gating on `isOpen`.
+  useEffect(() => {
+    markBackgroundWorkViewedForSession(sessionId, finishSignalState.signal?.atMs);
+  }, [sessionId, finishSignalState.signal?.atMs, markBackgroundWorkViewedForSession]);
+
+  const showBackgroundWorkNotice = isOpen && deriveBackgroundWorkDirty({
+    latestFinishAtMs: finishSignalState.signal?.atMs ?? null,
+    lastViewedAtMs: lastViewedAtMsBeforeThisMount,
+  });
+  const noticeSignal = showBackgroundWorkNotice ? finishSignalState.signal : null;
+
   if (selectedProcess) {
     return (
       <BackgroundTerminalView
@@ -207,6 +268,41 @@ export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: Backgroun
           onChange={setScope}
         />
       </header>
+      {noticeSignal ? (
+        <div className="shrink-0 px-3 pt-2" data-background-work-notice="">
+          {noticeSignal.kind === "process" ? (
+            <NoticeBanner
+              tone="neutral"
+              icon={<CircleCheck className="text-success" />}
+              action={
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setSelectedProcessId(noticeSignal.process.id)}
+                >
+                  View
+                </Button>
+              }
+            >
+              {noticeSignal.process.command} — {processStatusLabel(noticeSignal.process)}
+            </NoticeBanner>
+          ) : (
+            // No View action here — see the "subagent-View-action"
+            // contradiction in the R5 PR body. `BackgroundWorkPane.test.tsx`
+            // pins the roster-bounce-back behavior for any selected subagent
+            // id the live roster can't resolve, and a finished native
+            // subagent has, by definition, already left that live roster
+            // (locked design, `chips.ts`) — there is no live detail seam
+            // left to open. The banner still names what finished.
+            <NoticeBanner
+              tone="neutral"
+              icon={<CircleCheck className="text-success" />}
+            >
+              {subagentDisplayTitle(noticeSignal.subagent)} — {subagentStatusLabel(noticeSignal.subagent)}
+            </NoticeBanner>
+          )}
+        </div>
+      ) : null}
       <div className="min-h-0 flex-1 overflow-y-auto px-1 py-2">
         <div className="flex flex-col gap-3">
           {scope === "running" ? (

--- a/apps/packages/product-client/src/components/workspace/chat/surface/SessionTranscriptPane.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/surface/SessionTranscriptPane.tsx
@@ -7,6 +7,7 @@ import { BackgroundWorkTranscriptRow } from "#product/components/workspace/activ
 import { ConnectedPlanHandoffDialog } from "#product/components/workspace/chat/plans/ConnectedPlanHandoffDialog";
 import { usePlanHandoffDialogState } from "#product/hooks/plans/ui/use-plan-handoff-dialog-state";
 import { useBackgroundWorkRowCounts } from "#product/hooks/activity/derived/use-background-work-row";
+import { useBackgroundWorkFinishSignalTracking } from "#product/hooks/activity/lifecycle/use-background-work-finish-signal-tracking";
 import { useOpenBackgroundWorkPane } from "#product/hooks/activity/workflows/use-open-background-work-pane";
 import { useResizeObserverHeight } from "#product/hooks/ui/layout/use-resize-observer-height";
 import { useSessionHistoryHydration } from "#product/hooks/sessions/lifecycle/use-session-history-hydration";
@@ -88,6 +89,14 @@ export function SessionTranscriptPane({
   const [olderHistoryLoadingSessionId, setOlderHistoryLoadingSessionId] = useState<string | null>(null);
   const immediatePaneState = useActiveTranscriptPaneState();
   const workspaceReceiptKey = useWorkspaceCreationReceiptKey();
+  // Finish-signal ladder (rung R5): the only place that observes a native
+  // subagent disappearing from the roster, which is the only way to ever
+  // learn it finished (session-activity-architecture — subagents leave the
+  // roster the instant they finish; processes never leave it, so they need
+  // no equivalent tracking here). Keyed on the IMMEDIATE session id, not the
+  // deferred one below — a finish must never be missed just because the
+  // heavier transcript render is still catching up to a session switch.
+  useBackgroundWorkFinishSignalTracking(immediatePaneState.activeSessionId);
   // STARVATION GUARD: only the session IDENTITY is deferred — never the
   // transcript content. Deferring the whole pane state meant every stream
   // batch restarted the in-flight deferred render; once per-batch renders got

--- a/apps/packages/product-client/src/components/workspace/delegated-work/agents-pane/AgentsPaneShell.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/delegated-work/agents-pane/AgentsPaneShell.test.tsx
@@ -72,6 +72,7 @@ describe("Agents right-panel shell", () => {
       <RightPanelHeaderEntryList
         entries={[{ key: "tool:agents", kind: "tool", tool: "agents" }]}
         activeEntryKey="tool:agents"
+        backgroundWorkDirty={false}
         unreadByTerminal={{}}
         buffersByPath={{}}
         tabModes={{}}

--- a/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelFrame.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelFrame.tsx
@@ -30,6 +30,8 @@ interface RightPanelFrameProps {
   activeTerminalId: string | null;
   activeViewerTarget: ViewerTarget | null;
   entries: readonly RightPanelHeaderEntry[];
+  /** Finish-signal ladder rung 1 — the Background work entry's unread dot. */
+  backgroundWorkDirty: boolean;
   unreadByTerminal: Record<string, boolean>;
   buffersByPath: Record<string, WorkspaceFileBuffer>;
   tabModes: Record<string, FileViewerMode>;
@@ -67,6 +69,7 @@ export function RightPanelFrame({
   activeTerminalId,
   activeViewerTarget,
   entries,
+  backgroundWorkDirty,
   unreadByTerminal,
   buffersByPath,
   tabModes,
@@ -102,6 +105,7 @@ export function RightPanelFrame({
       <RightPanelHeaderTabs
         entries={entries}
         activeEntryKey={activeEntryKey}
+        backgroundWorkDirty={backgroundWorkDirty}
         unreadByTerminal={unreadByTerminal}
         buffersByPath={buffersByPath}
         tabModes={tabModes}

--- a/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelHeaderEntryList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelHeaderEntryList.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RightPanelHeaderEntry } from "#product/lib/domain/workspaces/shell/right-panel-header-entry";
+import { rightPanelToolHeaderKey } from "#product/lib/domain/workspaces/shell/right-panel-model";
+import type { RightPanelHeaderDragController } from "#product/hooks/workspaces/ui/use-right-panel-header-drag";
+import { RightPanelHeaderEntryList } from "#product/components/workspace/shell/right-panel/RightPanelHeaderEntryList";
+
+afterEach(cleanup);
+
+// Minimal stub — this component only reads drag state per entry key and
+// fires a handful of callbacks; none of them are exercised by the
+// `dirty && !isActive` gate under test.
+function makeDrag(): RightPanelHeaderDragController {
+  return {
+    draggedHeaderKey: null,
+    showEndDropIndicator: false,
+    getEntryDragState: () => ({ isDragging: false, dragOffsetX: 0, showDropIndicator: false }),
+    registerHeaderEntryNode: vi.fn(),
+    handleHeaderPointerDown: vi.fn(),
+    handleHeaderPointerMove: vi.fn(),
+    finishHeaderPointerDrag: vi.fn(),
+    cancelHeaderPointerDrag: vi.fn(),
+    shouldSuppressHeaderClick: () => false,
+  };
+}
+
+function renderEntryList(props: {
+  entries: readonly RightPanelHeaderEntry[];
+  activeEntryKey: string;
+  backgroundWorkDirty: boolean;
+}) {
+  return render(
+    <RightPanelHeaderEntryList
+      entries={props.entries}
+      activeEntryKey={props.activeEntryKey}
+      backgroundWorkDirty={props.backgroundWorkDirty}
+      unreadByTerminal={{}}
+      buffersByPath={{}}
+      tabModes={{}}
+      isWorkspaceReady
+      drag={makeDrag()}
+      shortcutRevealVisible={false}
+      onActivateEntry={() => true}
+      onCloseTerminal={vi.fn()}
+      onCloseViewerTarget={vi.fn()}
+      onRenameTerminal={vi.fn()}
+    />,
+  );
+}
+
+function dotFor(entryLabel: string): Element | null {
+  const tab = screen.getByRole("tab", { name: entryLabel });
+  return tab.querySelector(".rounded-full");
+}
+
+describe("RightPanelHeaderEntryList — background work dot gate", () => {
+  // Manifest rule (see the inline comment in RightPanelHeaderEntryList.tsx):
+  // "never render [the dirty dot] on the active entry" — belt-and-suspenders
+  // alongside the store-level clear-on-select. Dedicated component-level
+  // coverage per R5 review round 2 MINOR #5 (previously only exercised
+  // indirectly, if at all, through the tracker/derive-signal unit tests).
+  it("does not render the dot on the Background work entry while it is active, even when dirty", () => {
+    const entries: RightPanelHeaderEntry[] = [
+      { kind: "tool", key: rightPanelToolHeaderKey("background"), tool: "background" },
+    ];
+    renderEntryList({
+      entries,
+      activeEntryKey: rightPanelToolHeaderKey("background"),
+      backgroundWorkDirty: true,
+    });
+
+    expect(dotFor("Background work")).toBeNull();
+  });
+
+  it("renders the dot on the Background work entry when dirty and inactive", () => {
+    const entries: RightPanelHeaderEntry[] = [
+      { kind: "tool", key: rightPanelToolHeaderKey("background"), tool: "background" },
+      { kind: "tool", key: rightPanelToolHeaderKey("scratch"), tool: "scratch" },
+    ];
+    renderEntryList({
+      entries,
+      // Some OTHER entry is active — Background work is not.
+      activeEntryKey: rightPanelToolHeaderKey("scratch"),
+      backgroundWorkDirty: true,
+    });
+
+    const dot = dotFor("Background work");
+    expect(dot?.className).toContain("bg-current");
+  });
+
+  it("never marks a non-background tool entry dirty, regardless of backgroundWorkDirty or active state", () => {
+    const entries: RightPanelHeaderEntry[] = [
+      { kind: "tool", key: rightPanelToolHeaderKey("background"), tool: "background" },
+      { kind: "tool", key: rightPanelToolHeaderKey("scratch"), tool: "scratch" },
+      { kind: "tool", key: rightPanelToolHeaderKey("git"), tool: "git" },
+    ];
+    renderEntryList({
+      entries,
+      // Background work itself is active, so its own dot is suppressed by
+      // the active gate anyway — the point of this test is the OTHER tools.
+      activeEntryKey: rightPanelToolHeaderKey("background"),
+      backgroundWorkDirty: true,
+    });
+
+    expect(dotFor("Scratch")).toBeNull();
+    expect(dotFor("Changes")).toBeNull();
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelHeaderEntryList.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelHeaderEntryList.tsx
@@ -60,6 +60,8 @@ const PANEL_TOOLS: Record<RightPanelTool, ToolConfig> = {
 interface RightPanelHeaderEntryListProps {
   entries: readonly RightPanelHeaderEntry[];
   activeEntryKey: RightPanelHeaderEntryKey;
+  /** Finish-signal ladder rung 1 — the Background work entry's unread dot. */
+  backgroundWorkDirty: boolean;
   unreadByTerminal: Record<string, boolean>;
   buffersByPath: Record<string, WorkspaceFileBuffer>;
   tabModes: Record<string, FileViewerMode>;
@@ -75,6 +77,7 @@ interface RightPanelHeaderEntryListProps {
 export function RightPanelHeaderEntryList({
   entries,
   activeEntryKey,
+  backgroundWorkDirty,
   unreadByTerminal,
   buffersByPath,
   tabModes,
@@ -103,6 +106,12 @@ export function RightPanelHeaderEntryList({
         if (entry.kind === "tool") {
           const panelTool = PANEL_TOOLS[entry.tool];
           const Icon = panelTool.icon;
+          // Finish-signal ladder rung 1: the Background work tool is the
+          // only one with an unread signal today. Guarded on `!isActive`
+          // here too (belt-and-suspenders alongside the store-level
+          // clear-on-select) — the manifest's rule for every `dirty` entry
+          // is "never render it on the active entry."
+          const dirty = entry.tool === "background" && backgroundWorkDirty && !isActive;
           return (
             <RightPanelHeaderEntryDropZone
               key={entry.key}
@@ -120,6 +129,7 @@ export function RightPanelHeaderEntryList({
                 label={panelTool.label}
                 icon={<Icon className="icon-control" />}
                 active={isActive}
+                dirty={dirty}
                 tabIndexFloor={tabIndexFloor}
                 controls={`tabpanel-workspace-right-panel-${entry.tool}`}
                 data-reorderable="true"

--- a/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelHeaderTabs.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/right-panel/RightPanelHeaderTabs.tsx
@@ -18,6 +18,8 @@ import { useShortcutRevealVisible } from "#product/providers/ShortcutRevealProvi
 interface RightPanelHeaderTabsProps {
   entries: readonly RightPanelHeaderEntry[];
   activeEntryKey: RightPanelHeaderEntryKey;
+  /** Finish-signal ladder rung 1 — the Background work entry's unread dot. */
+  backgroundWorkDirty: boolean;
   unreadByTerminal: Record<string, boolean>;
   buffersByPath: Record<string, WorkspaceFileBuffer>;
   tabModes: Record<string, FileViewerMode>;
@@ -39,6 +41,7 @@ interface RightPanelHeaderTabsProps {
 export function RightPanelHeaderTabs({
   entries,
   activeEntryKey,
+  backgroundWorkDirty,
   unreadByTerminal,
   buffersByPath,
   tabModes,
@@ -92,6 +95,7 @@ export function RightPanelHeaderTabs({
                 <RightPanelHeaderEntryList
                   entries={entries}
                   activeEntryKey={activeEntryKey}
+                  backgroundWorkDirty={backgroundWorkDirty}
                   unreadByTerminal={unreadByTerminal}
                   buffersByPath={buffersByPath}
                   tabModes={tabModes}

--- a/apps/packages/product-client/src/domain/activity/background-work-finish-signal.test.ts
+++ b/apps/packages/product-client/src/domain/activity/background-work-finish-signal.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import type { ActivityProcessWire } from "./process";
+import type { ActivitySubagentWire } from "./subagent";
+import {
+  deriveBackgroundWorkDirty,
+  deriveLatestBackgroundWorkFinishSignal,
+} from "./background-work-finish-signal";
+
+function process(overrides: Partial<ActivityProcessWire>): ActivityProcessWire {
+  return {
+    id: "proc-1",
+    command: "npm run build",
+    cwd: null,
+    status: { status: "running" },
+    pid: null,
+    startedAt: "2026-08-17T00:00:00.000Z",
+    endedAt: null,
+    feed: null,
+    ...overrides,
+  };
+}
+
+function subagent(overrides: Partial<ActivitySubagentWire>): ActivitySubagentWire {
+  return {
+    id: "agent-1",
+    agentType: "task",
+    description: "Explore ACP session lifecycle",
+    model: null,
+    background: true,
+    status: { status: "running" },
+    usage: null,
+    feed: null,
+    ...overrides,
+  };
+}
+
+describe("deriveLatestBackgroundWorkFinishSignal", () => {
+  it("returns null when nothing has finished", () => {
+    const signal = deriveLatestBackgroundWorkFinishSignal({
+      processes: [process({ status: { status: "running" } })],
+      cachedFinishedSubagent: null,
+    });
+    expect(signal).toBeNull();
+  });
+
+  it("reads a process finish straight off the live roster (no cache needed)", () => {
+    const exited = process({
+      id: "proc-exited",
+      status: { status: "exited", exitCode: 0 },
+      endedAt: "2026-08-17T00:05:00.000Z",
+    });
+    const signal = deriveLatestBackgroundWorkFinishSignal({
+      processes: [process({ status: { status: "running" } }), exited],
+      cachedFinishedSubagent: null,
+    });
+    expect(signal).toEqual({
+      kind: "process",
+      process: exited,
+      atMs: Date.parse("2026-08-17T00:05:00.000Z"),
+    });
+  });
+
+  it("falls back to the cached subagent finish when no process has finished", () => {
+    const cachedSubagent = subagent({ id: "agent-42" });
+    const signal = deriveLatestBackgroundWorkFinishSignal({
+      processes: [],
+      cachedFinishedSubagent: { subagent: cachedSubagent, atMs: 1000 },
+    });
+    expect(signal).toEqual({ kind: "subagent", subagent: cachedSubagent, atMs: 1000 });
+  });
+
+  it("picks whichever of the two sources finished most recently", () => {
+    const olderProcess = process({
+      id: "proc-older",
+      status: { status: "exited", exitCode: 0 },
+      endedAt: "2026-08-17T00:00:00.000Z",
+    });
+    const newerProcess = process({
+      id: "proc-newer",
+      status: { status: "exited", exitCode: 0 },
+      endedAt: "2026-08-17T00:10:00.000Z",
+    });
+    const cachedSubagent = subagent({ id: "agent-mid" });
+
+    const subagentWins = deriveLatestBackgroundWorkFinishSignal({
+      processes: [olderProcess],
+      cachedFinishedSubagent: { subagent: cachedSubagent, atMs: Date.parse("2026-08-17T00:05:00.000Z") },
+    });
+    expect(subagentWins).toEqual({
+      kind: "subagent",
+      subagent: cachedSubagent,
+      atMs: Date.parse("2026-08-17T00:05:00.000Z"),
+    });
+
+    const processWins = deriveLatestBackgroundWorkFinishSignal({
+      processes: [newerProcess],
+      cachedFinishedSubagent: { subagent: cachedSubagent, atMs: Date.parse("2026-08-17T00:05:00.000Z") },
+    });
+    expect(processWins).toEqual({
+      kind: "process",
+      process: newerProcess,
+      atMs: Date.parse("2026-08-17T00:10:00.000Z"),
+    });
+  });
+
+  it("ignores a process with a malformed endedAt rather than throwing", () => {
+    const malformed = process({
+      id: "proc-malformed",
+      status: { status: "exited", exitCode: 0 },
+      endedAt: "not-a-date",
+    });
+    const signal = deriveLatestBackgroundWorkFinishSignal({
+      processes: [malformed],
+      cachedFinishedSubagent: null,
+    });
+    expect(signal).toBeNull();
+  });
+});
+
+describe("deriveBackgroundWorkDirty", () => {
+  it("is never dirty when nothing has finished", () => {
+    expect(deriveBackgroundWorkDirty({ latestFinishAtMs: null, lastViewedAtMs: null })).toBe(false);
+    expect(deriveBackgroundWorkDirty({ latestFinishAtMs: null, lastViewedAtMs: 500 })).toBe(false);
+  });
+
+  it("is dirty the first time anything finishes, before the pane has ever been viewed", () => {
+    expect(deriveBackgroundWorkDirty({ latestFinishAtMs: 100, lastViewedAtMs: null })).toBe(true);
+  });
+
+  it("is dirty only when the finish is newer than the last view", () => {
+    expect(deriveBackgroundWorkDirty({ latestFinishAtMs: 100, lastViewedAtMs: 50 })).toBe(true);
+    expect(deriveBackgroundWorkDirty({ latestFinishAtMs: 50, lastViewedAtMs: 100 })).toBe(false);
+    expect(deriveBackgroundWorkDirty({ latestFinishAtMs: 100, lastViewedAtMs: 100 })).toBe(false);
+  });
+
+});
+
+describe("negative control — counts never derive from tool-call status", () => {
+  // Acceptance: "session/cancel during background work: indicator keeps
+  // counting until the roster steps down (counts never derive from
+  // tool-call status)." `session/cancel` never touches `ActivityProcessWire`
+  // — the process keeps reporting `status: "running"` until the harness
+  // itself reports it exited. Prove the signal (and therefore the dirty
+  // dot) stays un-finished across a "cancel" that the roster never saw.
+  it("a still-running process reports no finish signal even after its tool call would have been cancelled", () => {
+    // The tool call itself is irrelevant to this derivation by
+    // construction — it never appears as an input — but the roster state
+    // a `session/cancel` leaves behind is exactly this: `status: "running"`
+    // survives the cancel because the process keeps executing in the
+    // background.
+    const stillRunningAfterCancel = process({ id: "proc-cancelled-call", status: { status: "running" } });
+    const signal = deriveLatestBackgroundWorkFinishSignal({
+      processes: [stillRunningAfterCancel],
+      cachedFinishedSubagent: null,
+    });
+    expect(signal).toBeNull();
+    expect(deriveBackgroundWorkDirty({ latestFinishAtMs: signal?.atMs ?? null, lastViewedAtMs: null }))
+      .toBe(false);
+  });
+
+  it("only flips once the roster itself reports the process exited, independent of when the call was cancelled", () => {
+    const nowExited = process({
+      id: "proc-cancelled-call",
+      status: { status: "exited", exitCode: 0 },
+      endedAt: "2026-08-17T00:05:00.000Z",
+    });
+    const signal = deriveLatestBackgroundWorkFinishSignal({
+      processes: [nowExited],
+      cachedFinishedSubagent: null,
+    });
+    expect(signal?.kind).toBe("process");
+    expect(deriveBackgroundWorkDirty({ latestFinishAtMs: signal?.atMs ?? null, lastViewedAtMs: null }))
+      .toBe(true);
+  });
+});

--- a/apps/packages/product-client/src/domain/activity/background-work-finish-signal.test.ts
+++ b/apps/packages/product-client/src/domain/activity/background-work-finish-signal.test.ts
@@ -39,6 +39,7 @@ describe("deriveLatestBackgroundWorkFinishSignal", () => {
     const signal = deriveLatestBackgroundWorkFinishSignal({
       processes: [process({ status: { status: "running" } })],
       cachedFinishedSubagent: null,
+      lastViewedAtMs: null,
     });
     expect(signal).toBeNull();
   });
@@ -52,6 +53,7 @@ describe("deriveLatestBackgroundWorkFinishSignal", () => {
     const signal = deriveLatestBackgroundWorkFinishSignal({
       processes: [process({ status: { status: "running" } }), exited],
       cachedFinishedSubagent: null,
+      lastViewedAtMs: null,
     });
     expect(signal).toEqual({
       kind: "process",
@@ -64,43 +66,10 @@ describe("deriveLatestBackgroundWorkFinishSignal", () => {
     const cachedSubagent = subagent({ id: "agent-42" });
     const signal = deriveLatestBackgroundWorkFinishSignal({
       processes: [],
-      cachedFinishedSubagent: { subagent: cachedSubagent, atMs: 1000 },
+      cachedFinishedSubagent: { subagent: cachedSubagent, detectedAtMs: 1000 },
+      lastViewedAtMs: null,
     });
     expect(signal).toEqual({ kind: "subagent", subagent: cachedSubagent, atMs: 1000 });
-  });
-
-  it("picks whichever of the two sources finished most recently", () => {
-    const olderProcess = process({
-      id: "proc-older",
-      status: { status: "exited", exitCode: 0 },
-      endedAt: "2026-08-17T00:00:00.000Z",
-    });
-    const newerProcess = process({
-      id: "proc-newer",
-      status: { status: "exited", exitCode: 0 },
-      endedAt: "2026-08-17T00:10:00.000Z",
-    });
-    const cachedSubagent = subagent({ id: "agent-mid" });
-
-    const subagentWins = deriveLatestBackgroundWorkFinishSignal({
-      processes: [olderProcess],
-      cachedFinishedSubagent: { subagent: cachedSubagent, atMs: Date.parse("2026-08-17T00:05:00.000Z") },
-    });
-    expect(subagentWins).toEqual({
-      kind: "subagent",
-      subagent: cachedSubagent,
-      atMs: Date.parse("2026-08-17T00:05:00.000Z"),
-    });
-
-    const processWins = deriveLatestBackgroundWorkFinishSignal({
-      processes: [newerProcess],
-      cachedFinishedSubagent: { subagent: cachedSubagent, atMs: Date.parse("2026-08-17T00:05:00.000Z") },
-    });
-    expect(processWins).toEqual({
-      kind: "process",
-      process: newerProcess,
-      atMs: Date.parse("2026-08-17T00:10:00.000Z"),
-    });
   });
 
   it("ignores a process with a malformed endedAt rather than throwing", () => {
@@ -112,8 +81,110 @@ describe("deriveLatestBackgroundWorkFinishSignal", () => {
     const signal = deriveLatestBackgroundWorkFinishSignal({
       processes: [malformed],
       cachedFinishedSubagent: null,
+      lastViewedAtMs: null,
     });
     expect(signal).toBeNull();
+  });
+
+  // MINOR #4 (R5 review round 2) — non-suppression regression: a still-
+  // running process sitting alongside a just-finished subagent must not
+  // suppress the subagent's signal. Pinned by a real snapshot, not by
+  // reading the code.
+  it("does not suppress a finished subagent's signal just because another process is still running", () => {
+    const stillRunning = process({ id: "proc-running", status: { status: "running" } });
+    const cachedSubagent = subagent({ id: "agent-done", status: { status: "completed", summary: null } });
+    const signal = deriveLatestBackgroundWorkFinishSignal({
+      processes: [stillRunning],
+      cachedFinishedSubagent: { subagent: cachedSubagent, detectedAtMs: 5000 },
+      lastViewedAtMs: null,
+    });
+    expect(signal).toEqual({ kind: "subagent", subagent: cachedSubagent, atMs: 5000 });
+  });
+
+  describe("deterministic tiebreak (R5 review round 2 — MAJOR)", () => {
+    // A cached subagent's `detectedAtMs` is only when THIS client noticed
+    // the disappearance, not the subagent's real finish time — it can lag
+    // arbitrarily behind a process's real, server-stamped `endedAt`. The
+    // rule: an unseen process ALWAYS wins over an unseen subagent
+    // detection, even when the raw detection timestamp is numerically
+    // later, because trusting the later-but-unknown timestamp is exactly
+    // the wrong-name bug this tiebreak exists to prevent.
+    it("prefers an unseen process over an unseen subagent detection even when the detection's raw timestamp is later", () => {
+      const process1 = process({
+        id: "proc-real",
+        status: { status: "exited", exitCode: 0 },
+        endedAt: "2026-08-17T00:05:00.000Z", // real: 00:05
+      });
+      const cachedSubagent = subagent({ id: "agent-late-detect" });
+      const lastViewedAtMs = Date.parse("2026-08-17T00:00:00.000Z"); // both are unseen
+
+      const signal = deriveLatestBackgroundWorkFinishSignal({
+        processes: [process1],
+        // Detected at 00:20 — numerically LATER than the process's real
+        // 00:05 endedAt — yet the process must still win.
+        cachedFinishedSubagent: {
+          subagent: cachedSubagent,
+          detectedAtMs: Date.parse("2026-08-17T00:20:00.000Z"),
+        },
+        lastViewedAtMs,
+      });
+
+      expect(signal).toEqual({
+        kind: "process",
+        process: process1,
+        atMs: Date.parse("2026-08-17T00:05:00.000Z"),
+      });
+    });
+
+    it("falls back to the unseen subagent detection only when no process is unseen", () => {
+      const alreadySeenProcess = process({
+        id: "proc-seen",
+        status: { status: "exited", exitCode: 0 },
+        endedAt: "2026-08-17T00:00:00.000Z", // before lastViewedAtMs — seen already
+      });
+      const cachedSubagent = subagent({ id: "agent-unseen" });
+      const lastViewedAtMs = Date.parse("2026-08-17T00:10:00.000Z");
+
+      const signal = deriveLatestBackgroundWorkFinishSignal({
+        processes: [alreadySeenProcess],
+        cachedFinishedSubagent: {
+          subagent: cachedSubagent,
+          detectedAtMs: Date.parse("2026-08-17T00:20:00.000Z"), // unseen
+        },
+        lastViewedAtMs,
+      });
+
+      expect(signal).toEqual({
+        kind: "subagent",
+        subagent: cachedSubagent,
+        atMs: Date.parse("2026-08-17T00:20:00.000Z"),
+      });
+    });
+
+    it("prefers the real process time over the unknown subagent detection even when NEITHER is unseen (inert case, hidden by dirty=false)", () => {
+      const seenProcess = process({
+        id: "proc-seen",
+        status: { status: "exited", exitCode: 0 },
+        endedAt: "2026-08-17T00:00:00.000Z",
+      });
+      const cachedSubagent = subagent({ id: "agent-seen" });
+      const lastViewedAtMs = Date.parse("2026-08-17T00:30:00.000Z"); // after both
+
+      const signal = deriveLatestBackgroundWorkFinishSignal({
+        processes: [seenProcess],
+        cachedFinishedSubagent: {
+          subagent: cachedSubagent,
+          detectedAtMs: Date.parse("2026-08-17T00:10:00.000Z"),
+        },
+        lastViewedAtMs,
+      });
+
+      expect(signal?.kind).toBe("process");
+      // Confirm it really is inert: nothing here is dirty, so no caller
+      // would ever render this signal regardless of which kind it picked.
+      expect(deriveBackgroundWorkDirty({ latestFinishAtMs: signal?.atMs ?? null, lastViewedAtMs }))
+        .toBe(false);
+    });
   });
 });
 
@@ -152,6 +223,7 @@ describe("negative control — counts never derive from tool-call status", () =>
     const signal = deriveLatestBackgroundWorkFinishSignal({
       processes: [stillRunningAfterCancel],
       cachedFinishedSubagent: null,
+      lastViewedAtMs: null,
     });
     expect(signal).toBeNull();
     expect(deriveBackgroundWorkDirty({ latestFinishAtMs: signal?.atMs ?? null, lastViewedAtMs: null }))
@@ -167,6 +239,7 @@ describe("negative control — counts never derive from tool-call status", () =>
     const signal = deriveLatestBackgroundWorkFinishSignal({
       processes: [nowExited],
       cachedFinishedSubagent: null,
+      lastViewedAtMs: null,
     });
     expect(signal?.kind).toBe("process");
     expect(deriveBackgroundWorkDirty({ latestFinishAtMs: signal?.atMs ?? null, lastViewedAtMs: null }))

--- a/apps/packages/product-client/src/domain/activity/background-work-finish-signal.ts
+++ b/apps/packages/product-client/src/domain/activity/background-work-finish-signal.ts
@@ -1,0 +1,101 @@
+/**
+ * Finish-signal ladder (rungs 1-3): the pane's tab dot and its in-pane
+ * `NoticeBanner` both need to know "what was the most recent piece of
+ * background work to finish, and is it newer than the last time this was
+ * viewed" (Design Handoff — HANDOFF-background-work.md, "Finish signals are
+ * a ladder"; Delivery Spec — Background Work Slice 1, rung R5).
+ *
+ * Processes never leave the roster (session-activity-architecture), so their
+ * `endedAt` is read straight off the live roster — no separate tracking
+ * needed. Native subagents DO leave the roster the instant they finish, so
+ * the only record of a subagent's finish is whatever
+ * `useBackgroundWorkFinishSignalTracking` observed at the moment it
+ * disappeared; that observation is cached by session in the workspace UI
+ * store and read back in here as `cachedFinishedSubagent`.
+ */
+
+import type { ActivityProcessWire } from "./process";
+import { isProcessRunning } from "./process";
+import type { ActivitySubagentWire } from "./subagent";
+
+export type BackgroundWorkFinishSignal =
+  | { kind: "process"; process: ActivityProcessWire; atMs: number }
+  | { kind: "subagent"; subagent: ActivitySubagentWire; atMs: number };
+
+export interface CachedFinishedSubagent {
+  subagent: ActivitySubagentWire;
+  atMs: number;
+}
+
+function latestExitedProcess(
+  processes: readonly ActivityProcessWire[],
+): { process: ActivityProcessWire; atMs: number } | null {
+  let best: { process: ActivityProcessWire; atMs: number } | null = null;
+  for (const process of processes) {
+    if (isProcessRunning(process) || !process.endedAt) {
+      continue;
+    }
+    const atMs = Date.parse(process.endedAt);
+    if (!Number.isFinite(atMs)) {
+      continue;
+    }
+    if (!best || atMs > best.atMs) {
+      best = { process, atMs };
+    }
+  }
+  return best;
+}
+
+/**
+ * The most recent piece of background work to finish for the active
+ * session, whichever of the two sources is newer. Counts (and therefore this
+ * signal) never derive from tool-call status — same rule as
+ * `deriveBackgroundWorkRowCounts`.
+ */
+export function deriveLatestBackgroundWorkFinishSignal({
+  processes,
+  cachedFinishedSubagent,
+}: {
+  processes: readonly ActivityProcessWire[];
+  cachedFinishedSubagent: CachedFinishedSubagent | null;
+}): BackgroundWorkFinishSignal | null {
+  const processSignal = latestExitedProcess(processes);
+  const subagentSignal: BackgroundWorkFinishSignal | null = cachedFinishedSubagent
+    ? {
+      kind: "subagent",
+      subagent: cachedFinishedSubagent.subagent,
+      atMs: cachedFinishedSubagent.atMs,
+    }
+    : null;
+
+  if (processSignal && subagentSignal) {
+    return processSignal.atMs >= subagentSignal.atMs
+      ? { kind: "process", process: processSignal.process, atMs: processSignal.atMs }
+      : subagentSignal;
+  }
+  if (processSignal) {
+    return { kind: "process", process: processSignal.process, atMs: processSignal.atMs };
+  }
+  return subagentSignal;
+}
+
+/**
+ * A pure timestamp comparison: dirty the instant something has finished
+ * later than the last time it was viewed. `lastViewedAtMs === null` means
+ * never viewed — anything finished at all counts as unseen.
+ */
+export function deriveBackgroundWorkDirty({
+  latestFinishAtMs,
+  lastViewedAtMs,
+}: {
+  latestFinishAtMs: number | null;
+  lastViewedAtMs: number | null;
+}): boolean {
+  if (latestFinishAtMs === null) {
+    return false;
+  }
+  if (lastViewedAtMs === null) {
+    return true;
+  }
+  return latestFinishAtMs > lastViewedAtMs;
+}

--- a/apps/packages/product-client/src/domain/activity/background-work-finish-signal.ts
+++ b/apps/packages/product-client/src/domain/activity/background-work-finish-signal.ts
@@ -6,12 +6,23 @@
  * a ladder"; Delivery Spec — Background Work Slice 1, rung R5).
  *
  * Processes never leave the roster (session-activity-architecture), so their
- * `endedAt` is read straight off the live roster — no separate tracking
- * needed. Native subagents DO leave the roster the instant they finish, so
- * the only record of a subagent's finish is whatever
+ * `endedAt` is read straight off the live roster — a REAL, server-stamped
+ * time. Native subagents DO leave the roster the instant they finish, so the
+ * only record of a subagent's finish is whatever
  * `useBackgroundWorkFinishSignalTracking` observed at the moment it
  * disappeared; that observation is cached by session in the workspace UI
  * store and read back in here as `cachedFinishedSubagent`.
+ *
+ * That cached observation's `detectedAtMs` is deliberately NOT treated as
+ * the subagent's real finish time (R5 review round 2 — MAJOR): it is only
+ * the moment this client happened to notice the disappearance, which can
+ * lag arbitrarily behind the true finish whenever the tracker wasn't
+ * actively watching that session (see `useSessionActivityForSession`'s
+ * docstring on cold sessions). Ranking a real, known `endedAt` against an
+ * unknown detection time is handled by an explicit, deterministic tiebreak
+ * below rather than a raw `atMs` comparison, which would let a late
+ * detection falsely "outrank" — and get named in the banner over — a
+ * process that really did finish more recently.
  */
 
 import type { ActivityProcessWire } from "./process";
@@ -24,7 +35,13 @@ export type BackgroundWorkFinishSignal =
 
 export interface CachedFinishedSubagent {
   subagent: ActivitySubagentWire;
-  atMs: number;
+  /**
+   * When THIS CLIENT noticed the subagent had vanished from the roster —
+   * not the subagent's real finish time, which is unknowable client-side.
+   * Named distinctly from `atMs` (used elsewhere in this module for real
+   * times) so a future edit can't casually treat it as one.
+   */
+  detectedAtMs: number;
 }
 
 function latestExitedProcess(
@@ -46,33 +63,63 @@ function latestExitedProcess(
   return best;
 }
 
+function isUnseen(atMs: number, lastViewedAtMs: number | null): boolean {
+  return lastViewedAtMs === null || atMs > lastViewedAtMs;
+}
+
 /**
- * The most recent piece of background work to finish for the active
- * session, whichever of the two sources is newer. Counts (and therefore this
+ * The single piece of background work to surface for the active session —
+ * the dot's dirty source and the banner's name. Counts (and therefore this
  * signal) never derive from tool-call status — same rule as
  * `deriveBackgroundWorkRowCounts`.
+ *
+ * Deterministic tiebreak (R5 review round 2 — MAJOR, see module docstring):
+ * a process's real, unseen `endedAt` always wins over an unseen subagent
+ * detection, never the reverse — an unknown-time detection must not outrank
+ * a known-time finish. Only when there is no unseen process does an unseen
+ * subagent detection surface at all.
+ *
+ * Residual, disclosed gap: if a subagent's TRUE finish was actually the
+ * more recent event but its session was cold long enough that detection
+ * lagged behind an unseen process's real `endedAt`, this still names the
+ * process. We cannot safely compare a real time against an unknown one, and
+ * arbitrarily preferring the known-real side is the safe-by-construction
+ * choice — the alternative (trusting the detection time) is the routine
+ * wrong-name bug this rewrite removes. This residual case is rare (requires
+ * BOTH items unseen AND the subagent's session having gone cold) and
+ * under-states rather than over-states freshness.
  */
 export function deriveLatestBackgroundWorkFinishSignal({
   processes,
   cachedFinishedSubagent,
+  lastViewedAtMs,
 }: {
   processes: readonly ActivityProcessWire[];
   cachedFinishedSubagent: CachedFinishedSubagent | null;
+  lastViewedAtMs: number | null;
 }): BackgroundWorkFinishSignal | null {
   const processSignal = latestExitedProcess(processes);
   const subagentSignal: BackgroundWorkFinishSignal | null = cachedFinishedSubagent
     ? {
       kind: "subagent",
       subagent: cachedFinishedSubagent.subagent,
-      atMs: cachedFinishedSubagent.atMs,
+      atMs: cachedFinishedSubagent.detectedAtMs,
     }
     : null;
 
-  if (processSignal && subagentSignal) {
-    return processSignal.atMs >= subagentSignal.atMs
-      ? { kind: "process", process: processSignal.process, atMs: processSignal.atMs }
-      : subagentSignal;
+  const processUnseen = processSignal !== null && isUnseen(processSignal.atMs, lastViewedAtMs);
+  if (processUnseen) {
+    return { kind: "process", process: processSignal.process, atMs: processSignal.atMs };
   }
+
+  const subagentUnseen = subagentSignal !== null && isUnseen(subagentSignal.atMs, lastViewedAtMs);
+  if (subagentUnseen) {
+    return subagentSignal;
+  }
+
+  // Nothing unseen — `deriveBackgroundWorkDirty` below will report false
+  // for whichever of these is returned, so no caller renders it. Prefer the
+  // real time over the unknown one for the same reason as above.
   if (processSignal) {
     return { kind: "process", process: processSignal.process, atMs: processSignal.atMs };
   }

--- a/apps/packages/product-client/src/domain/activity/background-work-row.test.ts
+++ b/apps/packages/product-client/src/domain/activity/background-work-row.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { ActivityChipDescriptor } from "./chips";
+import { deriveActivityChips } from "./chips";
 import { deriveBackgroundWorkRowCounts } from "./background-work-row";
+import { isProcessRunning, type ActivityProcessWire } from "./process";
+import type { ActivitySubagentWire } from "./subagent";
 
 function chip(overrides: Partial<ActivityChipDescriptor>): ActivityChipDescriptor {
   return {
@@ -58,5 +61,119 @@ describe("deriveBackgroundWorkRowCounts", () => {
       chip({ kind: "terminals", count: 2, liveCount: 1, label: "2 terminals (1 running)" }),
     ]);
     expect(after).toEqual(before);
+  });
+});
+
+// R5 verification — Delivery Spec, Background Work Slice 1, acceptance line
+// "wake turn renders the receipt and the roster + counts step down." These
+// go through the real `deriveActivityChips` too (not a hand-built
+// `ActivityChipDescriptor`), and reuse the exact filters
+// `BackgroundWorkPane` renders the roster with (`isProcessRunning`), so a
+// count and a roster row can never silently disagree — both are pure
+// functions of the same `{ loops, processes, agents }` snapshot.
+describe("R5 — roster + counts step down together, and only from the roster", () => {
+  function process(overrides: Partial<ActivityProcessWire> = {}): ActivityProcessWire {
+    return {
+      id: "proc-1",
+      command: "npm run dev",
+      cwd: null,
+      status: { status: "running" },
+      pid: null,
+      startedAt: "2026-08-17T00:00:00.000Z",
+      endedAt: null,
+      feed: null,
+      ...overrides,
+    };
+  }
+
+  function agent(overrides: Partial<ActivitySubagentWire> = {}): ActivitySubagentWire {
+    return {
+      id: "task-1",
+      agentType: null,
+      description: null,
+      model: null,
+      background: true,
+      status: { status: "running" },
+      usage: null,
+      feed: null,
+      ...overrides,
+    };
+  }
+
+  it("a subagent finishing drops out of the roster and its count in the same step", () => {
+    const before = { loops: [], processes: [], agents: [agent({ id: "a1" })] };
+    const beforeCounts = deriveBackgroundWorkRowCounts(deriveActivityChips(before));
+    expect(beforeCounts.runningCount).toBe(1);
+    expect(before.agents.filter((a) => a.status.status === "running")).toHaveLength(1);
+
+    // Native subagents leave the roster instantly on finish (locked design,
+    // `chips.ts`) — there is no "completed" entry left behind to filter out,
+    // the array itself shrinks.
+    const after = { loops: [], processes: [], agents: [] };
+    const afterCounts = deriveBackgroundWorkRowCounts(deriveActivityChips(after));
+    expect(afterCounts.runningCount).toBe(0);
+    expect(after.agents).toHaveLength(0);
+  });
+
+  it("a process finishing flips it to Closed scope — it stays in the roster, never leaves", () => {
+    const running = process({ id: "proc-a", status: { status: "running" } });
+    const before = { loops: [], processes: [running], agents: [] };
+    const beforeCounts = deriveBackgroundWorkRowCounts(deriveActivityChips(before));
+    expect(beforeCounts.runningCount).toBe(1);
+    expect(beforeCounts.finishedCount).toBe(0);
+    expect(before.processes.filter(isProcessRunning)).toHaveLength(1);
+    expect(before.processes.filter((p) => !isProcessRunning(p))).toHaveLength(0);
+
+    const exited = { ...running, status: { status: "exited" as const, exitCode: 0 }, endedAt: "2026-08-17T00:01:00.000Z" };
+    const after = { loops: [], processes: [exited], agents: [] };
+    const afterCounts = deriveBackgroundWorkRowCounts(deriveActivityChips(after));
+    expect(afterCounts.runningCount).toBe(0);
+    expect(afterCounts.finishedCount).toBe(1);
+    // Same process id, still present — the Closed scope's `closedProcesses`
+    // filter (`BackgroundWorkPane`) is what now picks it up, not a roster
+    // removal like the subagent case above.
+    expect(after.processes).toHaveLength(1);
+    expect(after.processes.filter(isProcessRunning)).toHaveLength(0);
+    expect(after.processes.filter((p) => !isProcessRunning(p))).toHaveLength(1);
+    expect(after.processes[0]?.id).toBe("proc-a");
+  });
+
+  // NEGATIVE CONTROL — HANDOFF "Decisions that stuck": "`session/cancel`
+  // does not stop background work, so the indicator survives cancellation
+  // and keeps counting until the roster says otherwise." `session/cancel`
+  // acts on the parent turn, never on this snapshot — there is no
+  // tool-call/cancel field anywhere in `{ loops, processes, agents }` for
+  // either derivation to read. Modeled here as the realistic shape of that
+  // moment: the subagent/process the cancelled turn was waiting on are
+  // themselves untouched (still running), so the exact same snapshot must
+  // still count them as running — cancelling the turn is not, by itself,
+  // a roster event.
+  it("cancelling the parent turn does not move the count — only the roster finishing the work does", () => {
+    const duringCancel = {
+      loops: [],
+      processes: [process({ id: "proc-a", status: { status: "running" } })],
+      agents: [agent({ id: "a1", status: { status: "running" } })],
+    };
+    const counts = deriveBackgroundWorkRowCounts(deriveActivityChips(duringCancel));
+    expect(counts.runningCount).toBe(2);
+
+    // The cancelled turn ends, but the roster it left running is
+    // unchanged — re-deriving from the identical snapshot must be
+    // idempotent, not a fresh "0" just because a turn ended.
+    const afterCancelledTurnEnds = deriveBackgroundWorkRowCounts(deriveActivityChips(duringCancel));
+    expect(afterCancelledTurnEnds).toEqual(counts);
+
+    // Only once the roster itself reports the work finished does the count
+    // move.
+    const finished = {
+      loops: [],
+      processes: [
+        { ...duringCancel.processes[0]!, status: { status: "exited" as const, exitCode: 0 }, endedAt: "2026-08-17T00:02:00.000Z" },
+      ],
+      agents: [],
+    };
+    const finishedCounts = deriveBackgroundWorkRowCounts(deriveActivityChips(finished));
+    expect(finishedCounts.runningCount).toBe(0);
+    expect(finishedCounts.finishedCount).toBe(1);
   });
 });

--- a/apps/packages/product-client/src/hooks/activity/derived/use-background-work-finish-signal.test.ts
+++ b/apps/packages/product-client/src/hooks/activity/derived/use-background-work-finish-signal.test.ts
@@ -15,8 +15,14 @@ let sessionActivity: SessionActivityState = {
   agents: [],
 };
 
+// Keyed by session id so a test can prove the hook reads exactly the
+// session it was ASKED about rather than falling back to some other
+// globally-active session — the R5 review round 2 MAJOR this rewrite fixes.
+let sessionActivityBySessionId: Record<string, SessionActivityState> = {};
+
 vi.mock("#product/hooks/activity/derived/use-session-activity", () => ({
-  useSessionActivity: () => sessionActivity,
+  useSessionActivityForSession: (sessionId: string | null) =>
+    (sessionId ? sessionActivityBySessionId[sessionId] : undefined) ?? sessionActivity,
 }));
 
 function makeProcess(overrides: Partial<ActivityProcessWire>): ActivityProcessWire {
@@ -54,6 +60,7 @@ afterEach(() => {
     processes: [],
     agents: [],
   };
+  sessionActivityBySessionId = {};
   cleanup();
   useWorkspaceUiStore.setState({
     backgroundWorkLastFinishedSubagentBySession: {},
@@ -110,7 +117,7 @@ describe("useBackgroundWorkFinishSignal", () => {
     const agent = makeAgent({ id: "agent-42" });
     useWorkspaceUiStore.setState({
       backgroundWorkLastFinishedSubagentBySession: {
-        "sess-1": { subagent: agent, atMs: 1_000 },
+        "sess-1": { subagent: agent, detectedAtMs: 1_000 },
       },
     });
     const { result } = renderHook(() => useBackgroundWorkFinishSignal("sess-1"));
@@ -122,10 +129,37 @@ describe("useBackgroundWorkFinishSignal", () => {
     const agent = makeAgent({ id: "agent-42" });
     useWorkspaceUiStore.setState({
       backgroundWorkLastFinishedSubagentBySession: {
-        "sess-other": { subagent: agent, atMs: 1_000 },
+        "sess-other": { subagent: agent, detectedAtMs: 1_000 },
       },
     });
     const { result } = renderHook(() => useBackgroundWorkFinishSignal("sess-1"));
     expect(result.current).toEqual({ signal: null, dirty: false });
+  });
+
+  // R5 review round 2 — MAJOR: this hook must read the roster for the
+  // `sessionId` it was CALLED with, not whatever session happens to be
+  // globally active elsewhere. The mock's `sessionActivityBySessionId` map
+  // gives each session id a genuinely distinct roster, so this fails under
+  // the old "always reads the active session" implementation and passes
+  // only once the read is truly per-session.
+  it("reads the roster for the requested sessionId, not a different session's roster", () => {
+    const exitedInSessionOne = makeProcess({
+      id: "proc-in-sess-1",
+      status: { status: "exited", exitCode: 0 },
+      endedAt: "2026-08-17T00:05:00.000Z",
+    });
+    sessionActivityBySessionId = {
+      "sess-1": { ...sessionActivity, processes: [exitedInSessionOne] },
+      "sess-2": { ...sessionActivity, processes: [] },
+    };
+
+    const forSessionOne = renderHook(() => useBackgroundWorkFinishSignal("sess-1"));
+    expect(forSessionOne.result.current.signal?.kind).toBe("process");
+    expect((forSessionOne.result.current.signal as { atMs: number } | null)?.atMs).toBe(
+      Date.parse("2026-08-17T00:05:00.000Z"),
+    );
+
+    const forSessionTwo = renderHook(() => useBackgroundWorkFinishSignal("sess-2"));
+    expect(forSessionTwo.result.current).toEqual({ signal: null, dirty: false });
   });
 });

--- a/apps/packages/product-client/src/hooks/activity/derived/use-background-work-finish-signal.test.ts
+++ b/apps/packages/product-client/src/hooks/activity/derived/use-background-work-finish-signal.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ActivityProcessWire } from "#product/domain/activity/process";
+import type { ActivitySubagentWire } from "#product/domain/activity/subagent";
+import type { SessionActivityState } from "#product/hooks/activity/derived/use-session-activity";
+import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+import { useBackgroundWorkFinishSignal } from "./use-background-work-finish-signal";
+
+let sessionActivity: SessionActivityState = {
+  loops: [],
+  loopCapabilities: { supported: false, native: false },
+  processes: [],
+  agents: [],
+};
+
+vi.mock("#product/hooks/activity/derived/use-session-activity", () => ({
+  useSessionActivity: () => sessionActivity,
+}));
+
+function makeProcess(overrides: Partial<ActivityProcessWire>): ActivityProcessWire {
+  return {
+    id: "proc-1",
+    command: "npm run build",
+    cwd: null,
+    status: { status: "running" },
+    pid: null,
+    startedAt: "2026-08-17T00:00:00.000Z",
+    endedAt: null,
+    feed: null,
+    ...overrides,
+  };
+}
+
+function makeAgent(overrides: Partial<ActivitySubagentWire>): ActivitySubagentWire {
+  return {
+    id: "agent-1",
+    agentType: "claude-subagent",
+    description: "Explore ACP session lifecycle",
+    model: null,
+    background: true,
+    status: { status: "running" },
+    usage: null,
+    feed: null,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  sessionActivity = {
+    loops: [],
+    loopCapabilities: { supported: false, native: false },
+    processes: [],
+    agents: [],
+  };
+  cleanup();
+  useWorkspaceUiStore.setState({
+    backgroundWorkLastFinishedSubagentBySession: {},
+    backgroundWorkLastViewedAtBySession: {},
+  });
+});
+
+describe("useBackgroundWorkFinishSignal", () => {
+  it("returns no signal and is never dirty with no session", () => {
+    const { result } = renderHook(() => useBackgroundWorkFinishSignal(null));
+    expect(result.current).toEqual({ signal: null, dirty: false });
+  });
+
+  it("returns no signal and is never dirty while nothing has finished", () => {
+    sessionActivity = {
+      ...sessionActivity,
+      processes: [makeProcess({ status: { status: "running" } })],
+    };
+    const { result } = renderHook(() => useBackgroundWorkFinishSignal("sess-1"));
+    expect(result.current).toEqual({ signal: null, dirty: false });
+  });
+
+  it("is dirty when a process finished and the pane was never viewed", () => {
+    const exited = makeProcess({
+      status: { status: "exited", exitCode: 0 },
+      endedAt: "2026-08-17T00:05:00.000Z",
+    });
+    sessionActivity = { ...sessionActivity, processes: [exited] };
+    const { result } = renderHook(() => useBackgroundWorkFinishSignal("sess-1"));
+    expect(result.current.dirty).toBe(true);
+    expect(result.current.signal).toEqual({
+      kind: "process",
+      process: exited,
+      atMs: Date.parse("2026-08-17T00:05:00.000Z"),
+    });
+  });
+
+  it("is not dirty once the recorded last-viewed time is after the finish", () => {
+    const exited = makeProcess({
+      status: { status: "exited", exitCode: 0 },
+      endedAt: "2026-08-17T00:05:00.000Z",
+    });
+    sessionActivity = { ...sessionActivity, processes: [exited] };
+    useWorkspaceUiStore.setState({
+      backgroundWorkLastViewedAtBySession: {
+        "sess-1": Date.parse("2026-08-17T00:10:00.000Z"),
+      },
+    });
+    const { result } = renderHook(() => useBackgroundWorkFinishSignal("sess-1"));
+    expect(result.current.dirty).toBe(false);
+  });
+
+  it("reads a cached finished subagent from the store when no process has finished", () => {
+    const agent = makeAgent({ id: "agent-42" });
+    useWorkspaceUiStore.setState({
+      backgroundWorkLastFinishedSubagentBySession: {
+        "sess-1": { subagent: agent, atMs: 1_000 },
+      },
+    });
+    const { result } = renderHook(() => useBackgroundWorkFinishSignal("sess-1"));
+    expect(result.current.signal).toEqual({ kind: "subagent", subagent: agent, atMs: 1_000 });
+    expect(result.current.dirty).toBe(true);
+  });
+
+  it("scopes the cached subagent and last-viewed lookups per session — a different session's finish stays invisible", () => {
+    const agent = makeAgent({ id: "agent-42" });
+    useWorkspaceUiStore.setState({
+      backgroundWorkLastFinishedSubagentBySession: {
+        "sess-other": { subagent: agent, atMs: 1_000 },
+      },
+    });
+    const { result } = renderHook(() => useBackgroundWorkFinishSignal("sess-1"));
+    expect(result.current).toEqual({ signal: null, dirty: false });
+  });
+});

--- a/apps/packages/product-client/src/hooks/activity/derived/use-background-work-finish-signal.ts
+++ b/apps/packages/product-client/src/hooks/activity/derived/use-background-work-finish-signal.ts
@@ -4,7 +4,7 @@ import {
   deriveLatestBackgroundWorkFinishSignal,
   type BackgroundWorkFinishSignal,
 } from "#product/domain/activity/background-work-finish-signal";
-import { useSessionActivity } from "#product/hooks/activity/derived/use-session-activity";
+import { useSessionActivityForSession } from "#product/hooks/activity/derived/use-session-activity";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 
 export interface BackgroundWorkFinishSignalState {
@@ -22,25 +22,24 @@ export interface BackgroundWorkFinishSignalState {
 const NO_SIGNAL: BackgroundWorkFinishSignalState = { signal: null, dirty: false };
 
 /**
- * Read-side of the finish-signal ladder for `sessionId`. Combines the live
- * roster (`useSessionActivity` — processes never leave it, so their
- * `endedAt` is read straight off it) with the cached subagent-finish
- * observation `useBackgroundWorkFinishSignalTracking` writes (subagents DO
- * leave the roster the instant they finish).
+ * Read-side of the finish-signal ladder for `sessionId`. Combines the
+ * roster (`useSessionActivityForSession(sessionId)` — processes never leave
+ * it, so their `endedAt` is read straight off it) with the cached
+ * subagent-finish observation `useBackgroundWorkFinishSignalTracking`
+ * writes (subagents DO leave the roster the instant they finish).
  *
- * `sessionId` is an explicit parameter rather than re-derived internally via
- * `useActiveSessionId()` — every call site already has its own session
- * identity (a prop, or a locally-computed active id with its own
- * deferred/session-switch semantics), and this hook must agree with THAT
- * one rather than risk racing a second, independently-read source during a
- * session switch. `useSessionActivity()` itself still only ever reports the
- * globally active session's roster (there is no per-session variant), which
- * is fine here: every caller only ever passes the session it also renders.
+ * `sessionId` is an explicit parameter, and — R5 review round 2 (MAJOR) —
+ * reads the roster via `useSessionActivityForSession(sessionId)` rather
+ * than the active-session-only `useSessionActivity()`: every call site
+ * already has its own session identity (a prop, or a locally-computed
+ * active id with its own deferred/session-switch semantics), and this hook
+ * must agree with THAT one, not silently swap in whatever session happens
+ * to be globally active on a given render.
  */
 export function useBackgroundWorkFinishSignal(
   sessionId: string | null,
 ): BackgroundWorkFinishSignalState {
-  const activity = useSessionActivity();
+  const activity = useSessionActivityForSession(sessionId);
   const cachedFinishedSubagent = useWorkspaceUiStore((state) =>
     sessionId ? state.backgroundWorkLastFinishedSubagentBySession[sessionId] ?? null : null
   );
@@ -55,6 +54,7 @@ export function useBackgroundWorkFinishSignal(
     const signal = deriveLatestBackgroundWorkFinishSignal({
       processes: activity.processes,
       cachedFinishedSubagent,
+      lastViewedAtMs,
     });
     const dirty = deriveBackgroundWorkDirty({
       latestFinishAtMs: signal?.atMs ?? null,

--- a/apps/packages/product-client/src/hooks/activity/derived/use-background-work-finish-signal.ts
+++ b/apps/packages/product-client/src/hooks/activity/derived/use-background-work-finish-signal.ts
@@ -1,0 +1,65 @@
+import { useMemo } from "react";
+import {
+  deriveBackgroundWorkDirty,
+  deriveLatestBackgroundWorkFinishSignal,
+  type BackgroundWorkFinishSignal,
+} from "#product/domain/activity/background-work-finish-signal";
+import { useSessionActivity } from "#product/hooks/activity/derived/use-session-activity";
+import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+
+export interface BackgroundWorkFinishSignalState {
+  /** The most recent piece of background work to finish, or null. */
+  signal: BackgroundWorkFinishSignal | null;
+  /**
+   * Whether `signal` is newer than the last time this session's Background
+   * work pane was actually open — the source `PanelHeaderEntry`'s `dirty`
+   * prop reads (Design Handoff — "Finish signals are a ladder"; Delivery
+   * Spec — Background Work Slice 1, rung R5).
+   */
+  dirty: boolean;
+}
+
+const NO_SIGNAL: BackgroundWorkFinishSignalState = { signal: null, dirty: false };
+
+/**
+ * Read-side of the finish-signal ladder for `sessionId`. Combines the live
+ * roster (`useSessionActivity` — processes never leave it, so their
+ * `endedAt` is read straight off it) with the cached subagent-finish
+ * observation `useBackgroundWorkFinishSignalTracking` writes (subagents DO
+ * leave the roster the instant they finish).
+ *
+ * `sessionId` is an explicit parameter rather than re-derived internally via
+ * `useActiveSessionId()` — every call site already has its own session
+ * identity (a prop, or a locally-computed active id with its own
+ * deferred/session-switch semantics), and this hook must agree with THAT
+ * one rather than risk racing a second, independently-read source during a
+ * session switch. `useSessionActivity()` itself still only ever reports the
+ * globally active session's roster (there is no per-session variant), which
+ * is fine here: every caller only ever passes the session it also renders.
+ */
+export function useBackgroundWorkFinishSignal(
+  sessionId: string | null,
+): BackgroundWorkFinishSignalState {
+  const activity = useSessionActivity();
+  const cachedFinishedSubagent = useWorkspaceUiStore((state) =>
+    sessionId ? state.backgroundWorkLastFinishedSubagentBySession[sessionId] ?? null : null
+  );
+  const lastViewedAtMs = useWorkspaceUiStore((state) =>
+    sessionId ? state.backgroundWorkLastViewedAtBySession[sessionId] ?? null : null
+  );
+
+  return useMemo(() => {
+    if (!sessionId) {
+      return NO_SIGNAL;
+    }
+    const signal = deriveLatestBackgroundWorkFinishSignal({
+      processes: activity.processes,
+      cachedFinishedSubagent,
+    });
+    const dirty = deriveBackgroundWorkDirty({
+      latestFinishAtMs: signal?.atMs ?? null,
+      lastViewedAtMs,
+    });
+    return { signal, dirty };
+  }, [sessionId, activity.processes, cachedFinishedSubagent, lastViewedAtMs]);
+}

--- a/apps/packages/product-client/src/hooks/activity/derived/use-session-activity.ts
+++ b/apps/packages/product-client/src/hooks/activity/derived/use-session-activity.ts
@@ -33,11 +33,48 @@ const EMPTY_ACTIVITY: SessionActivityState = {
  * stream events — confirmed native/mirror state only, never optimistic. In dev
  * builds `VITE_PROLIFERATE_ACTIVITY_FIXTURE=<key>` overrides with a fixture
  * (keys in lib/domain/chat/__fixtures__/playground/activity-fixtures.ts).
+ *
+ * Thin wrapper over `useSessionActivityForSession` bound to
+ * `useActiveSessionId()` — see that function for any caller that needs a
+ * SPECIFIC session's slice rather than "whichever session happens to be
+ * active right now."
  */
 export function useSessionActivity(): SessionActivityState {
   const activeSessionId = useActiveSessionId();
+  return useSessionActivityForSession(activeSessionId);
+}
+
+/**
+ * The SAME mirrored activity as `useSessionActivity`, but for an explicit
+ * `sessionId` rather than whatever `useActiveSessionId()` currently reports.
+ *
+ * This matters for the finish-signal ladder (R5 review round 2 — MAJOR):
+ * `useSessionActivity()` is hardwired to the active session, so a caller
+ * that passes its OWN `sessionId` prop straight into `useSessionActivity()`
+ * silently gets the ACTIVE session's roster instead whenever the two
+ * diverge (e.g. a tracker mounted for session A keeps rendering with
+ * `sessionId="A"` for one tick after the user has already switched to
+ * session B — `useActiveSessionId()` inside `useSessionActivity()` would
+ * report B). Every `entriesById[sessionId]` slot in
+ * `useSessionDirectoryStore` genuinely exists per session (seeded from that
+ * session's own `Session.activity` and folded by ITS OWN stream events), so
+ * reading it by explicit id here is a real per-session subscription, not an
+ * approximation.
+ *
+ * The slot's OWN liveness is a separate, honest constraint of the client's
+ * hot-session data model (`lib/domain/sessions/hot-session-policy.ts`): a
+ * session keeps folding stream deltas while it is the active session, an
+ * open tab, or has an in-flight turn — a session with no open tab and no
+ * live turn (its foreground turn ended, even though a detached background
+ * process/subagent continues) goes cold, and this slot then holds whatever
+ * it last knew until that session becomes hot again. That is compatible
+ * with ruled D6 (the finish signal is per-session): a cold session's dot
+ * only needs to be correct once that session is actually viewed again,
+ * which is exactly the moment its slot would resync.
+ */
+export function useSessionActivityForSession(sessionId: string | null): SessionActivityState {
   const slot = useSessionDirectoryStore(useShallow((state) => {
-    const entry = activeSessionId ? state.entriesById[activeSessionId] ?? null : null;
+    const entry = sessionId ? state.entriesById[sessionId] ?? null : null;
     if (!entry) {
       return null;
     }

--- a/apps/packages/product-client/src/hooks/activity/lifecycle/use-background-work-finish-signal-tracking.test.ts
+++ b/apps/packages/product-client/src/hooks/activity/lifecycle/use-background-work-finish-signal-tracking.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ActivitySubagentWire } from "#product/domain/activity/subagent";
+import type { SessionActivityState } from "#product/hooks/activity/derived/use-session-activity";
+import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+import { useBackgroundWorkFinishSignalTracking } from "./use-background-work-finish-signal-tracking";
+
+let sessionActivity: SessionActivityState = {
+  loops: [],
+  loopCapabilities: { supported: false, native: false },
+  processes: [],
+  agents: [],
+};
+
+vi.mock("#product/hooks/activity/derived/use-session-activity", () => ({
+  useSessionActivity: () => sessionActivity,
+}));
+
+function makeAgent(overrides: Partial<ActivitySubagentWire>): ActivitySubagentWire {
+  return {
+    id: "agent-1",
+    agentType: "claude-subagent",
+    description: "Explore ACP session lifecycle",
+    model: null,
+    background: true,
+    status: { status: "running" },
+    usage: null,
+    feed: null,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  sessionActivity = {
+    loops: [],
+    loopCapabilities: { supported: false, native: false },
+    processes: [],
+    agents: [],
+  };
+  cleanup();
+  useWorkspaceUiStore.setState({ backgroundWorkLastFinishedSubagentBySession: {} });
+});
+
+describe("useBackgroundWorkFinishSignalTracking", () => {
+  it("records nothing while every subagent stays running", () => {
+    sessionActivity = { ...sessionActivity, agents: [makeAgent({ id: "agent-42" })] };
+    const { rerender } = renderHook(
+      ({ sessionId }) => useBackgroundWorkFinishSignalTracking(sessionId),
+      { initialProps: { sessionId: "sess-1" as string | null } },
+    );
+
+    rerender({ sessionId: "sess-1" });
+
+    expect(
+      useWorkspaceUiStore.getState().backgroundWorkLastFinishedSubagentBySession["sess-1"] ?? null,
+    ).toBeNull();
+  });
+
+  it("caches the last-seen snapshot when a running subagent disappears from the roster", () => {
+    const agent = makeAgent({ id: "agent-42" });
+    sessionActivity = { ...sessionActivity, agents: [agent] };
+    const { rerender } = renderHook(
+      ({ sessionId }) => useBackgroundWorkFinishSignalTracking(sessionId),
+      { initialProps: { sessionId: "sess-1" as string | null } },
+    );
+
+    // Subagents leave the roster the instant they finish — the next
+    // snapshot simply omits it.
+    sessionActivity = { ...sessionActivity, agents: [] };
+    rerender({ sessionId: "sess-1" });
+
+    const cached = useWorkspaceUiStore.getState()
+      .backgroundWorkLastFinishedSubagentBySession["sess-1"];
+    expect(cached?.subagent).toEqual(agent);
+    expect(cached?.atMs).toBeGreaterThan(0);
+  });
+
+  it("caches the real final status when the wire briefly exposes it before removal", () => {
+    const running = makeAgent({ id: "agent-42", status: { status: "running" } });
+    sessionActivity = { ...sessionActivity, agents: [running] };
+    const { rerender } = renderHook(
+      ({ sessionId }) => useBackgroundWorkFinishSignalTracking(sessionId),
+      { initialProps: { sessionId: "sess-1" as string | null } },
+    );
+
+    const completed = makeAgent({
+      id: "agent-42",
+      status: { status: "completed", summary: "Done" },
+    });
+    sessionActivity = { ...sessionActivity, agents: [completed] };
+    rerender({ sessionId: "sess-1" });
+
+    const cached = useWorkspaceUiStore.getState()
+      .backgroundWorkLastFinishedSubagentBySession["sess-1"];
+    expect(cached?.subagent).toEqual(completed);
+  });
+
+  it("does not re-count a subagent that already finished on an earlier pass", () => {
+    const agent = makeAgent({ id: "agent-42" });
+    sessionActivity = { ...sessionActivity, agents: [agent] };
+    const { rerender } = renderHook(
+      ({ sessionId }) => useBackgroundWorkFinishSignalTracking(sessionId),
+      { initialProps: { sessionId: "sess-1" as string | null } },
+    );
+
+    sessionActivity = { ...sessionActivity, agents: [] };
+    rerender({ sessionId: "sess-1" });
+    const firstAtMs = useWorkspaceUiStore.getState()
+      .backgroundWorkLastFinishedSubagentBySession["sess-1"]?.atMs;
+
+    // Nothing new happens on a later pass — the cached record must not move.
+    rerender({ sessionId: "sess-1" });
+    const secondAtMs = useWorkspaceUiStore.getState()
+      .backgroundWorkLastFinishedSubagentBySession["sess-1"]?.atMs;
+    expect(secondAtMs).toBe(firstAtMs);
+  });
+
+  it("keys the cache per session rather than mixing sessions on switch", () => {
+    const agentOne = makeAgent({ id: "agent-1" });
+    sessionActivity = { ...sessionActivity, agents: [agentOne] };
+    const { rerender } = renderHook(
+      ({ sessionId }) => useBackgroundWorkFinishSignalTracking(sessionId),
+      { initialProps: { sessionId: "sess-1" as string | null } },
+    );
+
+    // Switch to a different session with a different subagent — no finish
+    // for session 1 has happened, so nothing should be recorded for it, and
+    // session 2 starts its own clean baseline (no false finish just from
+    // switching).
+    const agentTwo = makeAgent({ id: "agent-2" });
+    sessionActivity = { ...sessionActivity, agents: [agentTwo] };
+    rerender({ sessionId: "sess-2" });
+
+    expect(
+      useWorkspaceUiStore.getState().backgroundWorkLastFinishedSubagentBySession["sess-1"] ?? null,
+    ).toBeNull();
+    expect(
+      useWorkspaceUiStore.getState().backgroundWorkLastFinishedSubagentBySession["sess-2"] ?? null,
+    ).toBeNull();
+
+    sessionActivity = { ...sessionActivity, agents: [] };
+    rerender({ sessionId: "sess-2" });
+
+    expect(
+      useWorkspaceUiStore.getState().backgroundWorkLastFinishedSubagentBySession["sess-1"] ?? null,
+    ).toBeNull();
+    expect(
+      useWorkspaceUiStore.getState().backgroundWorkLastFinishedSubagentBySession["sess-2"]?.subagent,
+    ).toEqual(agentTwo);
+  });
+});

--- a/apps/packages/product-client/src/hooks/activity/lifecycle/use-background-work-finish-signal-tracking.test.ts
+++ b/apps/packages/product-client/src/hooks/activity/lifecycle/use-background-work-finish-signal-tracking.test.ts
@@ -2,20 +2,42 @@
 
 import { cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ActivityProcessWire } from "#product/domain/activity/process";
 import type { ActivitySubagentWire } from "#product/domain/activity/subagent";
 import type { SessionActivityState } from "#product/hooks/activity/derived/use-session-activity";
+import { deriveLatestBackgroundWorkFinishSignal } from "#product/domain/activity/background-work-finish-signal";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 import { useBackgroundWorkFinishSignalTracking } from "./use-background-work-finish-signal-tracking";
 
-let sessionActivity: SessionActivityState = {
-  loops: [],
-  loopCapabilities: { supported: false, native: false },
-  processes: [],
-  agents: [],
-};
+function emptyActivity(): SessionActivityState {
+  return {
+    loops: [],
+    loopCapabilities: { supported: false, native: false },
+    processes: [],
+    agents: [],
+  };
+}
+
+// Keyed by session id — NOT a single shared variable switched in lockstep
+// with whatever `sessionId` prop the test happens to pass. That lockstep
+// shape is exactly what let the R5 review round 2 MAJOR (the hook silently
+// reading the globally-active session instead of its own `sessionId`
+// parameter) slip past the original tests: a mock that always returns
+// "whatever session the prop currently says" can't tell the two
+// implementations apart. This map lets a session's OWN data diverge from
+// whichever `sessionId` the hook is CALLED with, so a test can genuinely
+// simulate "this session's roster changed while a DIFFERENT session was
+// being tracked."
+let sessionActivityBySessionId: Record<string, SessionActivityState> = {};
 
 vi.mock("#product/hooks/activity/derived/use-session-activity", () => ({
-  useSessionActivity: () => sessionActivity,
+  useSessionActivityForSession: (sessionId: string | null) =>
+    (sessionId ? sessionActivityBySessionId[sessionId] : undefined) ?? {
+      loops: [],
+      loopCapabilities: { supported: false, native: false },
+      processes: [],
+      agents: [],
+    },
 }));
 
 function makeAgent(overrides: Partial<ActivitySubagentWire>): ActivitySubagentWire {
@@ -32,20 +54,29 @@ function makeAgent(overrides: Partial<ActivitySubagentWire>): ActivitySubagentWi
   };
 }
 
-afterEach(() => {
-  sessionActivity = {
-    loops: [],
-    loopCapabilities: { supported: false, native: false },
-    processes: [],
-    agents: [],
+function makeProcess(overrides: Partial<ActivityProcessWire>): ActivityProcessWire {
+  return {
+    id: "proc-1",
+    command: "npm run build",
+    cwd: null,
+    status: { status: "running" },
+    pid: null,
+    startedAt: "2026-08-17T00:00:00.000Z",
+    endedAt: null,
+    feed: null,
+    ...overrides,
   };
+}
+
+afterEach(() => {
+  sessionActivityBySessionId = {};
   cleanup();
   useWorkspaceUiStore.setState({ backgroundWorkLastFinishedSubagentBySession: {} });
 });
 
 describe("useBackgroundWorkFinishSignalTracking", () => {
   it("records nothing while every subagent stays running", () => {
-    sessionActivity = { ...sessionActivity, agents: [makeAgent({ id: "agent-42" })] };
+    sessionActivityBySessionId["sess-1"] = { ...emptyActivity(), agents: [makeAgent({ id: "agent-42" })] };
     const { rerender } = renderHook(
       ({ sessionId }) => useBackgroundWorkFinishSignalTracking(sessionId),
       { initialProps: { sessionId: "sess-1" as string | null } },
@@ -58,9 +89,9 @@ describe("useBackgroundWorkFinishSignalTracking", () => {
     ).toBeNull();
   });
 
-  it("caches the last-seen snapshot when a running subagent disappears from the roster", () => {
+  it("caches the last-seen snapshot when a running subagent disappears from the roster while actively tracked", () => {
     const agent = makeAgent({ id: "agent-42" });
-    sessionActivity = { ...sessionActivity, agents: [agent] };
+    sessionActivityBySessionId["sess-1"] = { ...emptyActivity(), agents: [agent] };
     const { rerender } = renderHook(
       ({ sessionId }) => useBackgroundWorkFinishSignalTracking(sessionId),
       { initialProps: { sessionId: "sess-1" as string | null } },
@@ -68,18 +99,18 @@ describe("useBackgroundWorkFinishSignalTracking", () => {
 
     // Subagents leave the roster the instant they finish — the next
     // snapshot simply omits it.
-    sessionActivity = { ...sessionActivity, agents: [] };
+    sessionActivityBySessionId["sess-1"] = { ...emptyActivity(), agents: [] };
     rerender({ sessionId: "sess-1" });
 
     const cached = useWorkspaceUiStore.getState()
       .backgroundWorkLastFinishedSubagentBySession["sess-1"];
     expect(cached?.subagent).toEqual(agent);
-    expect(cached?.atMs).toBeGreaterThan(0);
+    expect(cached?.detectedAtMs).toBeGreaterThan(0);
   });
 
   it("caches the real final status when the wire briefly exposes it before removal", () => {
     const running = makeAgent({ id: "agent-42", status: { status: "running" } });
-    sessionActivity = { ...sessionActivity, agents: [running] };
+    sessionActivityBySessionId["sess-1"] = { ...emptyActivity(), agents: [running] };
     const { rerender } = renderHook(
       ({ sessionId }) => useBackgroundWorkFinishSignalTracking(sessionId),
       { initialProps: { sessionId: "sess-1" as string | null } },
@@ -89,7 +120,7 @@ describe("useBackgroundWorkFinishSignalTracking", () => {
       id: "agent-42",
       status: { status: "completed", summary: "Done" },
     });
-    sessionActivity = { ...sessionActivity, agents: [completed] };
+    sessionActivityBySessionId["sess-1"] = { ...emptyActivity(), agents: [completed] };
     rerender({ sessionId: "sess-1" });
 
     const cached = useWorkspaceUiStore.getState()
@@ -99,27 +130,27 @@ describe("useBackgroundWorkFinishSignalTracking", () => {
 
   it("does not re-count a subagent that already finished on an earlier pass", () => {
     const agent = makeAgent({ id: "agent-42" });
-    sessionActivity = { ...sessionActivity, agents: [agent] };
+    sessionActivityBySessionId["sess-1"] = { ...emptyActivity(), agents: [agent] };
     const { rerender } = renderHook(
       ({ sessionId }) => useBackgroundWorkFinishSignalTracking(sessionId),
       { initialProps: { sessionId: "sess-1" as string | null } },
     );
 
-    sessionActivity = { ...sessionActivity, agents: [] };
+    sessionActivityBySessionId["sess-1"] = { ...emptyActivity(), agents: [] };
     rerender({ sessionId: "sess-1" });
-    const firstAtMs = useWorkspaceUiStore.getState()
-      .backgroundWorkLastFinishedSubagentBySession["sess-1"]?.atMs;
+    const firstDetectedAtMs = useWorkspaceUiStore.getState()
+      .backgroundWorkLastFinishedSubagentBySession["sess-1"]?.detectedAtMs;
 
     // Nothing new happens on a later pass — the cached record must not move.
     rerender({ sessionId: "sess-1" });
-    const secondAtMs = useWorkspaceUiStore.getState()
-      .backgroundWorkLastFinishedSubagentBySession["sess-1"]?.atMs;
-    expect(secondAtMs).toBe(firstAtMs);
+    const secondDetectedAtMs = useWorkspaceUiStore.getState()
+      .backgroundWorkLastFinishedSubagentBySession["sess-1"]?.detectedAtMs;
+    expect(secondDetectedAtMs).toBe(firstDetectedAtMs);
   });
 
   it("keys the cache per session rather than mixing sessions on switch", () => {
     const agentOne = makeAgent({ id: "agent-1" });
-    sessionActivity = { ...sessionActivity, agents: [agentOne] };
+    sessionActivityBySessionId["sess-1"] = { ...emptyActivity(), agents: [agentOne] };
     const { rerender } = renderHook(
       ({ sessionId }) => useBackgroundWorkFinishSignalTracking(sessionId),
       { initialProps: { sessionId: "sess-1" as string | null } },
@@ -130,7 +161,7 @@ describe("useBackgroundWorkFinishSignalTracking", () => {
     // session 2 starts its own clean baseline (no false finish just from
     // switching).
     const agentTwo = makeAgent({ id: "agent-2" });
-    sessionActivity = { ...sessionActivity, agents: [agentTwo] };
+    sessionActivityBySessionId["sess-2"] = { ...emptyActivity(), agents: [agentTwo] };
     rerender({ sessionId: "sess-2" });
 
     expect(
@@ -140,7 +171,7 @@ describe("useBackgroundWorkFinishSignalTracking", () => {
       useWorkspaceUiStore.getState().backgroundWorkLastFinishedSubagentBySession["sess-2"] ?? null,
     ).toBeNull();
 
-    sessionActivity = { ...sessionActivity, agents: [] };
+    sessionActivityBySessionId["sess-2"] = { ...emptyActivity(), agents: [] };
     rerender({ sessionId: "sess-2" });
 
     expect(
@@ -149,5 +180,72 @@ describe("useBackgroundWorkFinishSignalTracking", () => {
     expect(
       useWorkspaceUiStore.getState().backgroundWorkLastFinishedSubagentBySession["sess-2"]?.subagent,
     ).toEqual(agentTwo);
+  });
+
+  // R5 review round 2 — finding #3 (MAJOR follow-through): a subagent
+  // finishes in session A while the tracker is mounted for a DIFFERENT
+  // session B (this hook is only ever mounted once, for whichever session
+  // is currently rendered — see the module docstring). Session A's own
+  // slice changes independently in the mock's per-session map WHILE B is
+  // being tracked, simulating exactly the case the review flagged. Detection
+  // is deferred to switch-back by construction (disclosed in the module
+  // docstring), so this proves: (1) nothing is recorded for A while B is
+  // active, (2) switching back to A correctly detects the vanish using
+  // whatever A last looked like before the switch away, and (3) the
+  // resulting (necessarily late) detection timestamp still does NOT outrank
+  // a process with a real, later `endedAt` once fed through the actual
+  // ranking function — i.e. the wrong-name bug is closed end-to-end, not
+  // just at the isolated domain-function level.
+  it("detects a subagent that finished while its session was inactive, on switch-back — and a real process endedAt still outranks the late detection", () => {
+    const agent = makeAgent({ id: "agent-in-session-a" });
+    sessionActivityBySessionId["session-a"] = { ...emptyActivity(), agents: [agent] };
+    sessionActivityBySessionId["session-b"] = emptyActivity();
+
+    const { rerender } = renderHook(
+      ({ sessionId }) => useBackgroundWorkFinishSignalTracking(sessionId),
+      { initialProps: { sessionId: "session-a" as string | null } },
+    );
+
+    // The user switches to session B. The tracker now only watches B.
+    rerender({ sessionId: "session-b" });
+    expect(
+      useWorkspaceUiStore.getState().backgroundWorkLastFinishedSubagentBySession["session-a"] ?? null,
+    ).toBeNull();
+
+    // While the user is on B, session A's subagent finishes for real —
+    // nobody is watching, so nothing is recorded yet.
+    sessionActivityBySessionId["session-a"] = { ...emptyActivity(), agents: [] };
+    rerender({ sessionId: "session-b" });
+    expect(
+      useWorkspaceUiStore.getState().backgroundWorkLastFinishedSubagentBySession["session-a"] ?? null,
+    ).toBeNull();
+
+    // The user switches back to A. The tracker resumes watching it, diffs
+    // against the stale (running) snapshot from before the switch away, and
+    // finally detects the vanish.
+    rerender({ sessionId: "session-a" });
+    const cached = useWorkspaceUiStore.getState()
+      .backgroundWorkLastFinishedSubagentBySession["session-a"];
+    expect(cached?.subagent).toEqual(agent);
+    expect(cached?.detectedAtMs).toBeGreaterThan(0);
+
+    // Feed the (necessarily late) detection through the real ranking
+    // function alongside a process that really did finish more recently in
+    // wall-clock terms — the process must win.
+    const realProcess = makeProcess({
+      id: "proc-real",
+      status: { status: "exited", exitCode: 0 },
+      endedAt: new Date(cached!.detectedAtMs + 1_000).toISOString(),
+    });
+    const signal = deriveLatestBackgroundWorkFinishSignal({
+      processes: [realProcess],
+      cachedFinishedSubagent: { subagent: cached!.subagent, detectedAtMs: cached!.detectedAtMs },
+      lastViewedAtMs: null,
+    });
+    expect(signal).toEqual({
+      kind: "process",
+      process: realProcess,
+      atMs: Date.parse(realProcess.endedAt!),
+    });
   });
 });

--- a/apps/packages/product-client/src/hooks/activity/lifecycle/use-background-work-finish-signal-tracking.ts
+++ b/apps/packages/product-client/src/hooks/activity/lifecycle/use-background-work-finish-signal-tracking.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { ActivitySubagentWire } from "#product/domain/activity/subagent";
-import { useSessionActivity } from "#product/hooks/activity/derived/use-session-activity";
+import { useSessionActivityForSession } from "#product/hooks/activity/derived/use-session-activity";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 
 /**
@@ -14,17 +14,51 @@ import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-st
  * Mount this once, somewhere that stays mounted for the whole time a
  * session is active regardless of which right-panel tool tab is showing
  * (`SessionTranscriptPane` — the transcript surface, not `BackgroundWorkPane`,
- * which unmounts whenever a different tool is selected). The roster data
- * itself lives in the session directory store and keeps folding forward
- * from SSE independent of any UI being mounted; this hook only needs to be
- * present to OBSERVE the transition and cache it.
+ * which unmounts whenever a different tool is selected).
  *
- * `sessionId` is an explicit parameter — see the note on
- * `useBackgroundWorkFinishSignal` for why this does not re-derive it via
- * `useActiveSessionId()` internally.
+ * `sessionId` is an explicit parameter, read via
+ * `useSessionActivityForSession(sessionId)` rather than the active-session-
+ * only `useSessionActivity()` (R5 review round 2 — MAJOR: the previous
+ * version silently ignored this parameter and always read whatever session
+ * was globally active, which is a real API-contract bug even though it
+ * happened to be a no-op today — see below). This makes the hook honor its
+ * own signature: give it any `sessionId` and it tracks exactly that
+ * session's roster, regardless of what else is active.
+ *
+ * Two things this hook does NOT do, disclosed rather than silently patched
+ * over:
+ *
+ * 1. **It is mounted once, for whichever session `SessionTranscriptPane` is
+ *    currently rendering — always the active session in practice**
+ *    (`SessionTranscriptPane` passes `immediatePaneState.activeSessionId`,
+ *    which is itself derived from `useActiveSessionId()`). A subagent that
+ *    finishes in a DIFFERENT session while the user is looking at this one
+ *    is therefore not observed until the user switches to it — at which
+ *    point this hook starts tracking it and correctly detects anything that
+ *    vanished while away (comparing against whatever it last recorded for
+ *    that session, however old). This is not a client-data-availability gap
+ *    — `useSessionActivityForSession` genuinely reads a per-session slice,
+ *    and `lib/domain/sessions/hot-session-policy.ts` keeps several
+ *    non-active sessions' slices live (open tabs, sessions with an
+ *    in-flight turn, cross-workspace running sessions) — it is a mount-
+ *    cardinality choice: exactly one tracker, tied to the one session whose
+ *    Background work pane could ever actually be shown. Extending this to
+ *    watch every hot session concurrently would need a tracker instance per
+ *    hot session and has no UI payoff today, because rung 1/2 of the ladder
+ *    (`use-right-panel-controller.ts`'s dot, `BackgroundWorkPane`'s banner)
+ *    are ALSO both scoped to `useActiveSessionId()` only — there is no
+ *    right-panel surface that renders a non-active session's dot or banner
+ *    for this multi-tracker mode to feed. Compatible with ruled D6 (the
+ *    signal is per-session, no workspace-level persistence): a session's
+ *    signal only has to be correct once that session is the one being
+ *    viewed, which is exactly when this hook is watching it.
+ * 2. **The cached `detectedAtMs` is NOT the subagent's real finish time** —
+ *    see `domain/activity/background-work-finish-signal.ts`'s module
+ *    docstring for how ranking against a process's real `endedAt` avoids
+ *    letting a stale detection outrank a genuinely more recent finish.
  */
 export function useBackgroundWorkFinishSignalTracking(sessionId: string | null): void {
-  const activity = useSessionActivity();
+  const activity = useSessionActivityForSession(sessionId);
   const recordBackgroundWorkFinishedSubagentForSession = useWorkspaceUiStore(
     (state) => state.recordBackgroundWorkFinishedSubagentForSession,
   );
@@ -49,11 +83,13 @@ export function useBackgroundWorkFinishSignalTracking(sessionId: string | null):
         const currentAgent = currentById.get(id);
         if (!currentAgent) {
           // Vanished entirely — the last-seen (running) snapshot is the only
-          // record that will ever exist.
+          // record that will ever exist. `Date.now()` here is a DETECTION
+          // time, not a finish time — see the module docstring above.
           recordBackgroundWorkFinishedSubagentForSession(sessionId, previousAgent, Date.now());
         } else if (currentAgent.status.status !== "running") {
           // Still present for this one tick with its real final status —
-          // cache THAT instead of the stale running snapshot.
+          // cache THAT instead of the stale running snapshot. Still a
+          // detection time, not a finish time.
           recordBackgroundWorkFinishedSubagentForSession(sessionId, currentAgent, Date.now());
         }
       }

--- a/apps/packages/product-client/src/hooks/activity/lifecycle/use-background-work-finish-signal-tracking.ts
+++ b/apps/packages/product-client/src/hooks/activity/lifecycle/use-background-work-finish-signal-tracking.ts
@@ -1,0 +1,64 @@
+import { useEffect, useRef } from "react";
+import type { ActivitySubagentWire } from "#product/domain/activity/subagent";
+import { useSessionActivity } from "#product/hooks/activity/derived/use-session-activity";
+import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
+
+/**
+ * Write side of the finish-signal ladder's subagent tracking. Native
+ * subagents leave the roster the instant they finish (locked design,
+ * `domain/activity/chips.ts`), so the ONLY way to ever learn a subagent
+ * finished is to notice it disappearing between two roster snapshots — there
+ * is nothing to re-derive later from a durable field, unlike a process's
+ * `endedAt`.
+ *
+ * Mount this once, somewhere that stays mounted for the whole time a
+ * session is active regardless of which right-panel tool tab is showing
+ * (`SessionTranscriptPane` — the transcript surface, not `BackgroundWorkPane`,
+ * which unmounts whenever a different tool is selected). The roster data
+ * itself lives in the session directory store and keeps folding forward
+ * from SSE independent of any UI being mounted; this hook only needs to be
+ * present to OBSERVE the transition and cache it.
+ *
+ * `sessionId` is an explicit parameter — see the note on
+ * `useBackgroundWorkFinishSignal` for why this does not re-derive it via
+ * `useActiveSessionId()` internally.
+ */
+export function useBackgroundWorkFinishSignalTracking(sessionId: string | null): void {
+  const activity = useSessionActivity();
+  const recordBackgroundWorkFinishedSubagentForSession = useWorkspaceUiStore(
+    (state) => state.recordBackgroundWorkFinishedSubagentForSession,
+  );
+  const previousAgentsBySessionRef = useRef<Map<string, Map<string, ActivitySubagentWire>>>(
+    new Map(),
+  );
+
+  useEffect(() => {
+    if (!sessionId) {
+      return;
+    }
+
+    const currentById = new Map(activity.agents.map((agent) => [agent.id, agent] as const));
+    const previousById = previousAgentsBySessionRef.current.get(sessionId);
+
+    if (previousById) {
+      for (const [id, previousAgent] of previousById) {
+        if (previousAgent.status.status !== "running") {
+          // Already accounted for on an earlier pass.
+          continue;
+        }
+        const currentAgent = currentById.get(id);
+        if (!currentAgent) {
+          // Vanished entirely — the last-seen (running) snapshot is the only
+          // record that will ever exist.
+          recordBackgroundWorkFinishedSubagentForSession(sessionId, previousAgent, Date.now());
+        } else if (currentAgent.status.status !== "running") {
+          // Still present for this one tick with its real final status —
+          // cache THAT instead of the stale running snapshot.
+          recordBackgroundWorkFinishedSubagentForSession(sessionId, currentAgent, Date.now());
+        }
+      }
+    }
+
+    previousAgentsBySessionRef.current.set(sessionId, currentById);
+  }, [sessionId, activity.agents, recordBackgroundWorkFinishedSubagentForSession]);
+}

--- a/apps/packages/product-client/src/hooks/workspaces/facade/use-right-panel-controller.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/facade/use-right-panel-controller.ts
@@ -7,6 +7,8 @@ import {
 import type { TerminalRecord } from "@anyharness/sdk";
 import { useTerminalsQuery, useWorkflowRunsQuery } from "@anyharness/sdk-react";
 import { isWorkflowsV2Enabled } from "#product/lib/domain/capabilities/workflows-v2";
+import { useBackgroundWorkFinishSignal } from "#product/hooks/activity/derived/use-background-work-finish-signal";
+import { useActiveSessionId } from "#product/hooks/chat/derived/use-active-session-identity";
 import { useWorkflowAutoAdvanceWatch } from "#product/hooks/workflows/lifecycle/use-workflow-auto-advance-toast";
 import { useRightPanelHeaderEntries } from "#product/hooks/workspaces/derived/use-right-panel-header-entries";
 import {
@@ -99,6 +101,12 @@ export function useRightPanelController({
   // controller (mounted for as long as the workspace shell) rather than off the
   // pane behind the tool switch.
   useWorkflowAutoAdvanceWatch({ workspaceId, enabled: shouldRenderContent });
+  // Finish-signal ladder rung 1 (`PanelHeaderEntry` dirty dot): read
+  // independent of which tool is actually active — the header strip renders
+  // regardless, and `BackgroundWorkPane` itself only mounts while its own
+  // tool is selected, so the dot's own read must not depend on that.
+  const activeSessionId = useActiveSessionId();
+  const backgroundWorkFinishSignal = useBackgroundWorkFinishSignal(activeSessionId);
   const {
     activeTool,
     activeTerminalId,
@@ -193,6 +201,10 @@ export function useRightPanelController({
     activeTerminalId,
     activeViewerTarget,
     entries: headerEntries,
+    // Never rendered on the active entry — enforced at the render site
+    // (`RightPanelHeaderEntryList`), matching the manifest's "never set it
+    // on the active entry" rule for every other tab kind's `dirty`.
+    backgroundWorkDirty: backgroundWorkFinishSignal.dirty,
     unreadByTerminal,
     buffersByPath,
     tabModes,

--- a/apps/packages/product-client/src/stores/preferences/workspace-ui-right-panel-actions.ts
+++ b/apps/packages/product-client/src/stores/preferences/workspace-ui-right-panel-actions.ts
@@ -19,6 +19,8 @@ type WorkspaceUiRightPanelActions = Pick<
   | "setRightPanelOpenForWorkspace"
   | "setPendingBackgroundSubagentSelectionForWorkspace"
   | "clearPendingBackgroundSubagentSelectionForWorkspace"
+  | "markBackgroundWorkViewedForSession"
+  | "recordBackgroundWorkFinishedSubagentForSession"
 >;
 
 function rightPanelStateUpdate(
@@ -127,6 +129,39 @@ export function createWorkspaceUiRightPanelActions(
           [workspaceId]: null,
         },
       }));
+    },
+
+    // Finish-signal ladder rung 1 — "clears on select": `BackgroundWorkPane`
+    // calls this the instant it is actually open (not merely mounted), and
+    // again on every new finish observed while it stays open, so the dot
+    // never re-lights for work the pane already showed live.
+    markBackgroundWorkViewedForSession: (sessionId, atMs) => {
+      set((state) => ({
+        backgroundWorkLastViewedAtBySession: {
+          ...state.backgroundWorkLastViewedAtBySession,
+          [sessionId]: atMs ?? Date.now(),
+        },
+      }));
+    },
+
+    // Finish-signal ladder rungs 1-2 — the durable record `chips.ts`'s
+    // "subagents leave the roster on finish" comment forward-references:
+    // the only place a finished-and-vanished subagent's last snapshot
+    // survives. Monotonic per session — a later observation never regresses
+    // an already-recorded finish.
+    recordBackgroundWorkFinishedSubagentForSession: (sessionId, subagent, atMs) => {
+      set((state) => {
+        const current = state.backgroundWorkLastFinishedSubagentBySession[sessionId];
+        if (current && current.atMs >= atMs) {
+          return state;
+        }
+        return {
+          backgroundWorkLastFinishedSubagentBySession: {
+            ...state.backgroundWorkLastFinishedSubagentBySession,
+            [sessionId]: { subagent, atMs },
+          },
+        };
+      });
     },
   };
 }

--- a/apps/packages/product-client/src/stores/preferences/workspace-ui-right-panel-actions.ts
+++ b/apps/packages/product-client/src/stores/preferences/workspace-ui-right-panel-actions.ts
@@ -149,16 +149,16 @@ export function createWorkspaceUiRightPanelActions(
     // the only place a finished-and-vanished subagent's last snapshot
     // survives. Monotonic per session — a later observation never regresses
     // an already-recorded finish.
-    recordBackgroundWorkFinishedSubagentForSession: (sessionId, subagent, atMs) => {
+    recordBackgroundWorkFinishedSubagentForSession: (sessionId, subagent, detectedAtMs) => {
       set((state) => {
         const current = state.backgroundWorkLastFinishedSubagentBySession[sessionId];
-        if (current && current.atMs >= atMs) {
+        if (current && current.detectedAtMs >= detectedAtMs) {
           return state;
         }
         return {
           backgroundWorkLastFinishedSubagentBySession: {
             ...state.backgroundWorkLastFinishedSubagentBySession,
-            [sessionId]: { subagent, atMs },
+            [sessionId]: { subagent, detectedAtMs },
           },
         };
       });

--- a/apps/packages/product-client/src/stores/preferences/workspace-ui-store-types.ts
+++ b/apps/packages/product-client/src/stores/preferences/workspace-ui-store-types.ts
@@ -71,13 +71,15 @@ export interface WorkspaceUiState {
    * finish that will ever exist. Subagents leave the roster the instant
    * they finish, so `useBackgroundWorkFinishSignalTracking` caches the last
    * snapshot it observed (running, or already flipped if the wire ever
-   * shows that before removal) plus the epoch-ms moment it noticed the
-   * disappearance. Session-scoped, never persisted — same ephemeral
-   * placement as `pendingBackgroundSubagentSelectionByWorkspace` above.
+   * shows that before removal) plus `detectedAtMs`: the epoch-ms moment it
+   * noticed the disappearance, deliberately NOT the subagent's real finish
+   * time (which is unknowable client-side — R5 review round 2). Session-
+   * scoped, never persisted — same ephemeral placement as
+   * `pendingBackgroundSubagentSelectionByWorkspace` above.
    */
   backgroundWorkLastFinishedSubagentBySession: Record<
     string,
-    { subagent: ActivitySubagentWire; atMs: number } | null
+    { subagent: ActivitySubagentWire; detectedAtMs: number } | null
   >;
   urgentHighlightedChatSessionByWorkspace: Record<string, string | null>;
   workspaceTypes: SidebarWorkspaceVariant[];
@@ -135,7 +137,7 @@ export interface WorkspaceUiState {
   recordBackgroundWorkFinishedSubagentForSession: (
     sessionId: string,
     subagent: ActivitySubagentWire,
-    atMs: number,
+    detectedAtMs: number,
   ) => void;
   setActiveShellTabKeyForWorkspace: (
     workspaceId: string,

--- a/apps/packages/product-client/src/stores/preferences/workspace-ui-store-types.ts
+++ b/apps/packages/product-client/src/stores/preferences/workspace-ui-store-types.ts
@@ -1,4 +1,5 @@
 import type { SetStateAction } from "react";
+import type { ActivitySubagentWire } from "#product/domain/activity/subagent";
 import type { PersistedWorkspaceUiState } from "#product/lib/domain/preferences/workspace-ui/model";
 import type { PersistedWorkspaceGitStatusSnapshot } from "#product/lib/domain/workspaces/git-status/workspace-git-status-model";
 import type { RightPanelDurableState, RightPanelMaterializedState, RightPanelWorkspaceState } from "#product/lib/domain/workspaces/shell/right-panel-model";
@@ -55,6 +56,29 @@ export interface WorkspaceUiState {
     string,
     PendingBackgroundSubagentSelection | null
   >;
+  /**
+   * Finish-signal ladder rung 1 (`PanelHeaderEntry` dirty dot) — the epoch-ms
+   * timestamp the Background work pane was last actually open for this
+   * session. Session-scoped, never persisted (D6 rules out workspace-level
+   * persistence for this slice): a reload starts every session back at
+   * "never viewed", which only matters for work that already finished
+   * before the reload — live roster state itself survives via the session
+   * GET seed + SSE fold, unaffected by this being ephemeral.
+   */
+  backgroundWorkLastViewedAtBySession: Record<string, number>;
+  /**
+   * Finish-signal ladder rungs 1-2 — the only record of a native subagent's
+   * finish that will ever exist. Subagents leave the roster the instant
+   * they finish, so `useBackgroundWorkFinishSignalTracking` caches the last
+   * snapshot it observed (running, or already flipped if the wire ever
+   * shows that before removal) plus the epoch-ms moment it noticed the
+   * disappearance. Session-scoped, never persisted — same ephemeral
+   * placement as `pendingBackgroundSubagentSelectionByWorkspace` above.
+   */
+  backgroundWorkLastFinishedSubagentBySession: Record<
+    string,
+    { subagent: ActivitySubagentWire; atMs: number } | null
+  >;
   urgentHighlightedChatSessionByWorkspace: Record<string, string | null>;
   workspaceTypes: SidebarWorkspaceVariant[];
   lastViewedAt: Record<string, string>;
@@ -106,6 +130,12 @@ export interface WorkspaceUiState {
   ) => void;
   clearPendingBackgroundSubagentSelectionForWorkspace: (
     workspaceId: string,
+  ) => void;
+  markBackgroundWorkViewedForSession: (sessionId: string, atMs?: number) => void;
+  recordBackgroundWorkFinishedSubagentForSession: (
+    sessionId: string,
+    subagent: ActivitySubagentWire,
+    atMs: number,
   ) => void;
   setActiveShellTabKeyForWorkspace: (
     workspaceId: string,

--- a/apps/packages/product-client/src/stores/preferences/workspace-ui-store.ts
+++ b/apps/packages/product-client/src/stores/preferences/workspace-ui-store.ts
@@ -18,6 +18,8 @@ export const useWorkspaceUiStore = create<WorkspaceUiState>((set, get) => ({
   shellActivationEpochByWorkspace: {},
   pendingChatActivationByWorkspace: {},
   pendingBackgroundSubagentSelectionByWorkspace: {},
+  backgroundWorkLastViewedAtBySession: {},
+  backgroundWorkLastFinishedSubagentBySession: {},
   urgentHighlightedChatSessionByWorkspace: {},
   archivingChatSessionIdsByWorkspace: {},
 


### PR DESCRIPTION
## What

Final repo-side rung of the Background Work slice — the finish-signal ladder from `HANDOFF-background-work.md` ("Finish signals are a ladder"): tab dot (quietest) → in-pane `NoticeBanner` → wake receipt + new turn (already shipped, existing `AgentOriginPromptReceipt`).

**1. `PanelHeaderEntry` dirty dot** (handoff — "clears on select... never render `dirty` on an `active` entry"; Delivery Spec rung R5)
- New domain module `domain/activity/background-work-finish-signal.ts`: `deriveLatestBackgroundWorkFinishSignal` (reads a process's `endedAt` straight off the live roster — processes never leave it; combines with a cached subagent-finish observation) and `deriveBackgroundWorkDirty` (pure timestamp comparison).
- New hook `hooks/activity/derived/use-background-work-finish-signal.ts` (read side) and `hooks/activity/lifecycle/use-background-work-finish-signal-tracking.ts` (write side — a ref-diffing observer, since native subagents vanish from the roster instantly on finish with no durable timestamp; mounted in `SessionTranscriptPane` so it's never missed regardless of which right-panel tool tab is active).
- New session-scoped, non-persisted store state: `backgroundWorkLastViewedAtBySession`, `backgroundWorkLastFinishedSubagentBySession` (same ephemeral placement as R4's `pendingBackgroundSubagentSelectionByWorkspace`).
- Threaded `backgroundWorkDirty` through `use-right-panel-controller` → `RightPanelFrame` → `RightPanelHeaderTabs` → `RightPanelHeaderEntryList`, with a defensive `!isActive` guard at the render site alongside the store-level clear-on-select.

**2. `NoticeBanner` in-pane notice** (handoff — "Pane open; `NoticeBanner` above the roster names what finished, with a View action")
- `BackgroundWorkPane` now renders a `NoticeBanner` (`tone="neutral"`, `CircleCheck` in `text-success`) above the roster while open and a finish is unseen.
- Process finishes: View action (ghost `Button`) opens the real `BackgroundTerminalView` — processes stay live in the roster.
- Subagent finishes: **no View action** — see Contradiction below.
- Dismissal (handoff silent on the exact rule, resolved minimally): banner hides while either detail view is open (a full swap of the pane's return) or the pane unmounts/switches session; it reappears on Back within the same session mount. Uses a "frozen at mount" baseline to avoid self-erasing against the live mark-viewed-on-select effect that also lights rung 1.

**3. Wake receipts vs roster step-down — verification only**
`AgentOriginPromptReceipt` already renders the wake turn; nothing there needed changes. Added domain-level tests (`background-work-row.test.ts`) proving counts and the roster step down together (both are pure functions of the same `{ loops, processes, agents }` snapshot — a count and a roster row can never disagree), that a finished process flips to Closed scope rather than leaving, and a negative control that `session/cancel` does not move the count (re-deriving from an identical snapshot is idempotent; only the roster itself finishing the work moves it).

**4. Indicator settled state**
No changes — `BackgroundWorkTranscriptRow` already ships the `CircleCheck` glyph swap, `"{n} background task{s} finished"` copy, and no-motion static swap from R1, verified still passing.

## Contradiction (stop-and-report, per R3/R4 precedent)

The handoff/delivery-spec ask the `NoticeBanner`'s View action to work symmetrically for both process and subagent finishes. `BackgroundWorkPane.test.tsx` pins (via an explicit, already-passing R4 test — "bounces back to the roster once a viewed subagent leaves it (finished)") that any selected subagent id the live roster can't resolve bounces back to the roster. A finished native subagent has, by definition, always already left that live roster (locked design, `chips.ts`) — there is no live detail seam a View click could ever land on without immediately bouncing back out. Rather than override that tested R4 decision, the subagent branch of the banner omits the View action and only names what finished. Flagging for founder review rather than silently reworking pinned R4 behavior.

## Disclosed, licensed as-is (NIT, review round 2)

The banner can fire for a stale finish on a session's very first-ever open (before any `markBackgroundWorkViewedForSession` has ever run for it). This is licensed by the handoff's "Pane open" condition — the banner's job is "tell me about anything I haven't seen in this pane," and on a first-ever open nothing has been seen yet. Left as-is by direction; disclosed rather than silently patched.

## Review round 2 — fixes applied

Coordinator review returned 1 MAJOR, 4 MINOR, 1 NIT (NIT addressed above). Rebased onto `origin/bgwork/r4-background-subagent-view@0d38ccad7` (mechanical design-attribution rename, unaffected by this diff) before fixing.

**MAJOR — `use-background-work-finish-signal-tracking.ts` ignored its own `sessionId` parameter.**
The tracker (and its sibling read hook) called `useSessionActivity()`, which is hardwired to `useActiveSessionId()` and silently ignores the explicit `sessionId` argument — a real API-contract bug, and one that could stamp a wrong-session finish with a fabricated `Date.now()` that outranks a process's real `endedAt`.

Investigated whether a per-session slice exists client-side for inactive sessions: it does. `session-directory-store.ts`'s `entriesById[sessionId]` is genuinely keyed per session (not active-only), and `lib/domain/sessions/hot-session-policy.ts` keeps several classes of inactive sessions' slices live (open tabs, sessions with an in-flight turn, cross-workspace running sessions) via `use-hot-session-ingest.ts`. So the fix is the "real fix" path, not the fallback: added `useSessionActivityForSession(sessionId)` to `use-session-activity.ts`, reading the per-session store slice directly, and switched both the tracker and the read hook to use it. `useSessionActivity()` itself is now a thin wrapper (`useSessionActivityForSession(useActiveSessionId())`) — its existing call sites (`BackgroundWorkPane`, `use-background-work-row.ts`, `use-workspace-status-model.ts`) are behaviorally unchanged.

This closes the API-contract bug but not the full multi-session concurrent-tracking case, disclosed rather than silently absorbed: this hook is mounted exactly once, for whichever session `SessionTranscriptPane` is currently rendering (always the active session today). A subagent finishing in a background session is detected on switch-back, not live — but this is a mount-cardinality choice, not a data-availability limit (the data is live; nothing consumes it live), because rung 1/2 of the ladder (the dot, the banner) are themselves both scoped to `useActiveSessionId()` only — there is no right-panel surface that could render a non-active session's signal even if the tracker watched it concurrently. Compatible with ruled D6 (per-session signal, no workspace-level persistence): a session's signal only needs to be correct once that session is the one being viewed.

Also fixed the ranking-safety half regardless of data hotness, since a subagent's finish is never independently timestamped: `background-work-finish-signal.ts` now tracks `detectedAtMs` (when the client noticed) as distinct from a process's real `endedAt`, and applies a deterministic tiebreak — an unseen process always outranks an unseen subagent detection, even when the raw detection timestamp is numerically later. Documented residual gap: if a subagent's session went cold long enough that detection lagged behind an unseen process's real, later `endedAt`, this still names the process — rare (needs both unseen AND the subagent's session cold) and understates rather than overstates freshness.

Rewrote the tracker/read-hook tests: the old mock was a single module-level variable reassigned in lockstep with whichever `sessionId` prop a test happened to pass — structurally unable to distinguish per-session from active-session-only visibility (it would pass under either implementation). Replaced with a `sessionActivityBySessionId` map so a session's own data can diverge from whatever session id the hook is currently called with, plus a dedicated test: a subagent finishes in session A while the tracker watches session B, then switches back to A — asserting the finish is detected on switch-back AND, fed through the real ranking function alongside a process with a real, later `endedAt`, the process still wins.

**MINORs:**
- `background-work-finish-signal.test.ts`: added the running-process + just-finished-subagent regression test (non-suppression, pinned by a snapshot assertion, not by reading the code).
- `RightPanelHeaderEntryList.test.tsx` (new): dedicated component-level test for the `dirty && !isActive` gate — dirty+active → no dot, dirty+inactive → dot, non-background tool entries never dirty regardless of `backgroundWorkDirty`.
- Acceptance "wake turn renders the receipt": already covered pre-existing, cited rather than duplicated — `AgentOriginPromptReceipt.test.tsx`'s `it.each(["completed","failed","cancelled"])("renders a resolved wake outcome %s on the right", ...)` renders the component with `wakeProvenance()` (`type: "subagentWake"`) and asserts the receipt DOM + outcome text. No new test added; this machinery predates R5's diff.

Fallout from the store field rename (`atMs` → `detectedAtMs`, to keep detection-time vs finish-time visible at the type level): `BackgroundWorkPane.test.tsx`'s module mock of `use-session-activity` needed `useSessionActivityForSession` added alongside `useSessionActivity` — fixed.

## Gates (review round 2, re-run after all fixes)

- Full `product-client` vitest: **1011 files / 7314 tests passed**, 0 failed.
- `tsc -p tsconfig.domain.json` and `tsc -p tsconfig.json --noEmit`: **1 error each**, both the pre-existing exogenous `src/domain/workflows/run-view-model.ts(75,7)` TS2741 — no new errors.
- `scripts/report_frontend_structure.py --strict`: **0** violations across all categories.
- `scripts/check_appearance_scaling.py`: **passed**.
- `scripts/check_design_attribution.py`: **passed** (0 hits).
- No raw `button`/`input`/`label`/`select`/`textarea` introduced.

## Files (review round 2 delta)

- Modified: `domain/activity/background-work-finish-signal.ts(+.test.ts)`, `hooks/activity/derived/use-session-activity.ts`, `hooks/activity/derived/use-background-work-finish-signal.ts(+.test.ts)`, `hooks/activity/lifecycle/use-background-work-finish-signal-tracking.ts(+.test.ts)`, `stores/preferences/workspace-ui-store-types.ts`, `stores/preferences/workspace-ui-right-panel-actions.ts`, `BackgroundWorkPane.test.tsx` (mock fallout fix)
- New: `RightPanelHeaderEntryList.test.tsx`

Base: `bgwork/r4-background-subagent-view` @ `0d38ccad7` (rebased from `4430513d6`, verified unmoved since). Draft, no merge, no auto-merge.


## CI red fix — PROD-SIZE-1 file split (post review-round-2)

CI's "Repo shape checks" job flagged `BackgroundWorkPane.test.tsx` at 690 lines against the repo-wide 600-line cap (`scripts/check_max_lines.py`, PROD-SIZE-1) — accumulated R2-R5 review-round additions; R4's head was under the cap. Net-new size exceptions are founder-gated, so split rather than exempted.

Mechanical split, no product code touched, no assertions added/removed/weakened:
- `BackgroundWorkPane.test.tsx` (281 lines) — roster/scopes/seam/detail-routing, 12 tests.
- `BackgroundWorkPane.finish-signals.test.tsx` (new, 382 lines) — the R5-era finish-signal ladder concerns: NoticeBanner, pending-selection consumption, feed isOpen-gating, 12 tests.
- `BackgroundWorkPane.test.fixtures.tsx` (new, 145 lines) — shared mock components (`LiveTerminalsRosterPanelMock`, `BackgroundTerminalViewMock`, `AgentsRosterPanelMock`, `BackgroundSubagentViewMock`) and value builders (`makeProcess`, `makeAgent`) both files import into their own `vi.mock(...)` calls, so neither re-declares them. Named with a literal `.test.` segment (not `.test-fixtures`) so `report_frontend_structure.py`'s `should_skip` recognizes it as test-only scaffolding (exempting its mock JSX from the shipped-component raw-DOM-control rule, FE-STRUCT-1) and so vitest's `*.test.tsx` include glob does not collect it as a test suite itself.

Test count preserved exactly: 24 tests before (1 file), 24 tests after (12 + 12 across 2 files).

Gates re-run clean after the split:
- `python3 scripts/check_max_lines.py`: **passed** (was failing on this file at 690/600).
- Full `product-client` vitest: **1012 files / 7314 tests passed** (was 1011/7314 before the split — file count +1 from the new sibling test file, total test count unchanged).
- `tsc -p tsconfig.domain.json` / `tsc -p tsconfig.json --noEmit`: 1 error each, both the same pre-existing exogenous `run-view-model.ts(75,7)` TS2741.
- `scripts/report_frontend_structure.py --strict`: **0** violations.
- `scripts/check_appearance_scaling.py`: **passed**.
- `scripts/check_design_attribution.py`: **passed**.

New head: `6c60ade04`.
