### PR TITLE
feat(product): transcript-shaped claude subagent detail via client-side session-log translator (bgwork R4b)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundSubagentView.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundSubagentView.test.tsx
@@ -16,6 +16,8 @@ const useFeedStreamMock = vi.fn(() => feedStreamState);
 let transcriptState: { transcript: TranscriptState | null } = { transcript: null };
 let sessionAgentKind: string | null = "claude";
 
+const messageListPropsSpy = vi.fn();
+
 vi.mock("#product/stores/sessions/session-directory-store", () => ({
   useSessionDirectoryStore: (selector: (state: {
     entriesById: Record<string, { agentKind: string } | undefined>;
@@ -31,6 +33,30 @@ vi.mock("#product/hooks/chat/derived/use-active-session-transcript-state", () =>
 }));
 vi.mock("#product/hooks/activity/derived/use-feed-stream", () => ({
   useFeedStream: (...args: unknown[]) => useFeedStreamMock(...args),
+}));
+// Mirrors AgentsPaneDetail.test.tsx's convention: MessageList's own row
+// rendering is its own test's responsibility. Here we assert on the
+// `transcript` prop it receives, which is where BackgroundSubagentView's
+// translation wiring actually lives.
+vi.mock("#product/components/workspace/chat/transcript/MessageList", () => ({
+  MessageList: (props: { transcript: TranscriptState; sessionViewState: string; activeSessionId: string }) => {
+    messageListPropsSpy(props);
+    return (
+      <div data-testid="message-list">
+        {props.transcript.turnOrder.flatMap((turnId) =>
+          (props.transcript.turnsById[turnId]?.itemOrder ?? []).map((itemId) => {
+            const item = props.transcript.itemsById[itemId];
+            const text = item && "text" in item ? item.text : null;
+            return (
+              <div key={itemId} data-testid="transcript-row" data-item-kind={item?.kind}>
+                {text}
+              </div>
+            );
+          }),
+        )}
+      </div>
+    );
+  },
 }));
 
 function makeSubagent(overrides: Partial<ActivitySubagentWire> = {}): ActivitySubagentWire {
@@ -79,11 +105,43 @@ function launchToolCallItem(overrides: Partial<ToolCallItem> = {}): ToolCallItem
   } as ToolCallItem;
 }
 
+/** A synthetic, fully fictional Claude-CLI session-log JSONL tail — one
+ * user prompt and one assistant text reply — used to exercise the real
+ * `claude-session-log` translator end to end. */
+function syntheticClaudeSessionLogJsonl(): string {
+  const userLine = {
+    type: "user",
+    uuid: "line-u1",
+    parentUuid: null,
+    isSidechain: false,
+    timestamp: "2026-08-17T00:00:00.000Z",
+    sessionId: "child-session-1",
+    message: { role: "user", content: "Summarize the fixture directory." },
+  };
+  const assistantLine = {
+    type: "assistant",
+    uuid: "line-a1",
+    parentUuid: "line-u1",
+    isSidechain: false,
+    timestamp: "2026-08-17T00:00:01.000Z",
+    sessionId: "child-session-1",
+    message: {
+      role: "assistant",
+      id: "msg-a1",
+      model: "claude-test",
+      content: [{ type: "text", text: "It holds three example fixtures." }],
+      stop_reason: "end_turn",
+    },
+  };
+  return `${JSON.stringify(userLine)}\n${JSON.stringify(assistantLine)}\n`;
+}
+
 afterEach(() => {
   feedStreamState = { content: "", connected: false, error: null };
   transcriptState = { transcript: null };
   sessionAgentKind = "claude";
   useFeedStreamMock.mockClear();
+  messageListPropsSpy.mockClear();
   cleanup();
 });
 
@@ -136,19 +194,6 @@ describe("BackgroundSubagentView", () => {
     );
 
     expect(screen.queryByText("Initial prompt")).toBeNull();
-  });
-
-  it("renders the feed's raw tail content (raw-tail fallback used for every harness)", () => {
-    feedStreamState = { content: "Working on the task…\n", connected: true, error: null };
-    render(
-      <BackgroundSubagentView
-        subagent={makeSubagent()}
-        sessionId="session-1"
-        workspaceId="workspace-1"
-        onBack={() => {}}
-      />,
-    );
-    expect(screen.getByText(/Working on the task…/)).toBeTruthy();
   });
 
   it("renders the exact read-only footer copy and no composer", () => {
@@ -221,5 +266,83 @@ describe("BackgroundSubagentView", () => {
       null,
       { workspaceId: "workspace-1", enabled: false },
     );
+  });
+
+  describe("transcript-shaped rendering (rung R4b)", () => {
+    it("claude: maps the tail_file JSONL into a TranscriptState and hands it to MessageList", () => {
+      feedStreamState = { content: syntheticClaudeSessionLogJsonl(), connected: true, error: null };
+      sessionAgentKind = "claude";
+
+      render(
+        <BackgroundSubagentView
+          subagent={makeSubagent()}
+          sessionId="session-1"
+          workspaceId="workspace-1"
+          onBack={() => {}}
+        />,
+      );
+
+      expect(screen.getByTestId("message-list")).toBeTruthy();
+      expect(screen.getByText("Summarize the fixture directory.")).toBeTruthy();
+      expect(screen.getByText("It holds three example fixtures.")).toBeTruthy();
+      expect(messageListPropsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionViewState: "idle", activeSessionId: "agent-1" }),
+      );
+      const passedTranscript = messageListPropsSpy.mock.calls[0]?.[0]?.transcript as TranscriptState;
+      expect(passedTranscript.turnOrder.length).toBeGreaterThan(0);
+    });
+
+    it("codex: the identical JSONL text renders as raw tail, never through MessageList (negative control on the provider gate)", () => {
+      feedStreamState = { content: syntheticClaudeSessionLogJsonl(), connected: true, error: null };
+      sessionAgentKind = "codex";
+
+      render(
+        <BackgroundSubagentView
+          subagent={makeSubagent()}
+          sessionId="session-1"
+          workspaceId="workspace-1"
+          onBack={() => {}}
+        />,
+      );
+
+      expect(screen.queryByTestId("message-list")).toBeNull();
+      expect(messageListPropsSpy).not.toHaveBeenCalled();
+      expect(screen.getByText(/Summarize the fixture directory\./)).toBeTruthy();
+    });
+
+    it("claude with a malformed feed degrades to the raw-tail view rather than an empty transcript (no crash)", () => {
+      feedStreamState = { content: "not json at all, just a log line\n", connected: true, error: null };
+      sessionAgentKind = "claude";
+
+      render(
+        <BackgroundSubagentView
+          subagent={makeSubagent()}
+          sessionId="session-1"
+          workspaceId="workspace-1"
+          onBack={() => {}}
+        />,
+      );
+
+      expect(screen.queryByTestId("message-list")).toBeNull();
+      expect(messageListPropsSpy).not.toHaveBeenCalled();
+      expect(screen.getByText(/not json at all, just a log line/)).toBeTruthy();
+    });
+
+    it("claude with no feed content yet shows the connecting/raw-tail state, not an empty MessageList", () => {
+      feedStreamState = { content: "", connected: false, error: null };
+      sessionAgentKind = "claude";
+
+      render(
+        <BackgroundSubagentView
+          subagent={makeSubagent()}
+          sessionId="session-1"
+          workspaceId="workspace-1"
+          onBack={() => {}}
+        />,
+      );
+
+      expect(screen.queryByTestId("message-list")).toBeNull();
+      expect(screen.getByText("Connecting…")).toBeTruthy();
+    });
   });
 });

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundSubagentView.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundSubagentView.tsx
@@ -6,6 +6,7 @@ import { AgentIdentityGlyph } from "#product/components/patterns/AgentIdentityGl
 import { AutoHideScrollArea } from "#product/primitives/patterns/AutoHideScrollArea";
 import { ToolActionDetailsPanel } from "#product/components/workspace/chat/tool-calls/ToolActionDetailsPanel";
 import { MarkdownBody } from "#product/components/workspace/chat/transcript/MarkdownBody";
+import { MessageList } from "#product/components/workspace/chat/transcript/MessageList";
 import { renderDesktopCodeBlock } from "#product/components/content/ui/desktop-markdown-code-block";
 import { TOOL_CALL_BODY_MAX_HEIGHT_CLASS } from "#product/domain/chats/tools/tool-call-layout";
 import {
@@ -22,6 +23,10 @@ import { getProviderDisplayName } from "#product/lib/domain/agents/provider-disp
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
 import { useTranscriptPaneStateForSession } from "#product/hooks/chat/derived/use-active-session-transcript-state";
 import { useFeedStream } from "#product/hooks/activity/derived/use-feed-stream";
+import { useClaudeSessionLogTranscript } from "#product/hooks/activity/derived/use-claude-session-log-transcript";
+
+/** The one harness whose `tail_file` feed this view can translate into a transcript today (see `domain/activity/claude-session-log.ts`). */
+const TRANSCRIPT_SHAPED_PROVIDER_KIND = "claude";
 
 export interface BackgroundSubagentViewProps {
   subagent: ActivitySubagentWire;
@@ -33,29 +38,30 @@ export interface BackgroundSubagentViewProps {
 /**
  * Read-only detail view for one harness-native subagent (Design Handoff —
  * NEW `BackgroundSubagentView`; Delivery Spec — Background Work Slice 1,
- * rung R4). Header on `AgentsPaneDetail`'s grammar: back + generated
+ * rung R4/R4b). Header on `AgentsPaneDetail`'s grammar: back + generated
  * identity glyph + title + `Status · provider` + a "read only" `Badge`.
  * Body: the launch tool call's initial prompt (when one correlates — see
  * `findSubagentLaunchItem`), then the child's own output. Footer replaces
  * `AgentsPaneComposer` with a fixed read-only line — no composer, no input,
  * ever.
  *
- * BLOCKER (reported per `implement-pr-slice` discipline, same class as R3's
- * `BashCommandCall` stop): the handoff's "Feed fidelity" note calls
- * transcript-shaped `MessageList` rendering "honest for Claude today"
- * because "the child transcript arrives as a JSONL tail over `tail_file`."
- * That is not what the runtime actually sends. `open_tail_file`
+ * Feed fidelity (rung R4b, resolving R4's reported blocker): a claude
+ * subagent's `tail_file` feed carries Claude's own native CLI session-log
+ * JSONL, not an ACP `SessionEventEnvelope` stream — `open_tail_file`
  * (`anyharness-lib/src/domains/activity/feeds.rs`) always emits raw
- * `FeedFrame::Bytes` regardless of `FeedKind`, and the WS handler
- * (`api/ws/feeds.rs`) does no JSONL→ACP translation — a Claude subagent's
- * `tail_file` feed carries Claude's own native CLI session-log JSONL
- * (`parentUuid`/`isSidechain`/`uuid` fields), not the `SessionEventEnvelope`
- * shape `@anyharness/sdk`'s reducer (and therefore `MessageList`, which
- * requires a `TranscriptState`) needs. No translator for this exists
- * anywhere in the repo. This view therefore renders the feed as plain text
- * for every harness — the same raw-tail treatment the handoff already rules
- * for Codex (pending the `acp_child_demux` binding) — rather than inventing
- * a client-side JSONL-to-ACP translator that is out of this slice's scope.
+ * `FeedFrame::Bytes`, and no runtime/fork change backs this PR. So the
+ * translation happens entirely client-side:
+ * `domain/activity/claude-session-log.ts` maps the accumulated buffer
+ * into a `TranscriptState` (reusing `@anyharness/sdk`'s own reducer), and
+ * this view renders it with the literal component the handoff names —
+ * `MessageList` with `sessionViewState="idle"` — fed directly via its
+ * `transcript` prop with a synthetic `activeSessionId`/`sessionId`; no
+ * session-store entry is needed because `MessageList` (via
+ * `ChatTranscriptView`) only *reads* the `transcript` prop it is given and
+ * uses the session id as an opaque context/routing key, never to look
+ * itself up in a store. Codex (and any harness whose mapped subset comes up
+ * empty — degrades honestly rather than rendering a confident but empty
+ * transcript) keeps the raw-tail `<pre>` treatment this view has always had.
  */
 export function BackgroundSubagentView({
   subagent,
@@ -82,6 +88,14 @@ export function BackgroundSubagentView({
     enabled: subagent.feed !== null,
   });
   const bodyText = content || (subagent.feed ? (error ?? (connected ? "" : "Connecting…")) : "");
+
+  // Transcript-shaped rendering (rung R4b): only claude's tail_file bytes have
+  // a translator (domain/activity/claude-session-log.ts). Every other harness,
+  // and a claude buffer whose mapped subset comes up empty (no complete lines
+  // yet, or nothing but skipped/malformed ones), keeps the raw-tail fallback.
+  const isClaudeSubagent = providerKind === TRANSCRIPT_SHAPED_PROVIDER_KIND;
+  const claudeTranscript = useClaudeSessionLogTranscript(content, subagent.id);
+  const showTranscriptView = isClaudeSubagent && claudeTranscript.transcript.turnOrder.length > 0;
 
   return (
     <section
@@ -140,14 +154,25 @@ export function BackgroundSubagentView({
             </ToolActionDetailsPanel>
           </div>
         )}
-        <AutoHideScrollArea className="min-h-0 w-full flex-1" viewportClassName="p-3">
-          <pre
-            className="m-0 whitespace-pre-wrap font-mono text-readable-code text-foreground"
-            data-telemetry-mask
-          >
-            {bodyText}
-          </pre>
-        </AutoHideScrollArea>
+        {showTranscriptView ? (
+          <MessageList
+            activeSessionId={subagent.id}
+            selectedWorkspaceId={workspaceId}
+            optimisticPrompt={null}
+            transcript={claudeTranscript.transcript}
+            sessionViewState="idle"
+            contentSearchEnabled={false}
+          />
+        ) : (
+          <AutoHideScrollArea className="min-h-0 w-full flex-1" viewportClassName="p-3">
+            <pre
+              className="m-0 whitespace-pre-wrap font-mono text-readable-code text-foreground"
+              data-telemetry-mask
+            >
+              {bodyText}
+            </pre>
+          </AutoHideScrollArea>
+        )}
       </div>
 
       <footer className="border-t border-border px-3 py-2 text-ui-sm text-muted-foreground">

--- a/apps/packages/product-client/src/domain/activity/claude-session-log-envelopes.ts
+++ b/apps/packages/product-client/src/domain/activity/claude-session-log-envelopes.ts
@@ -1,0 +1,212 @@
+/**
+ * Envelope construction for `claude-session-log.ts`: turns one parsed
+ * user/assistant log line's content blocks into the `SessionEventEnvelope`s
+ * `@anyharness/sdk`'s reducer expects. Split out of the main module purely
+ * for size (FE-SIZE-1) — see that module's doc comment for the mapping this
+ * belongs to and the honest subset it implements.
+ */
+import type { SessionEventEnvelope, StopReason } from "@anyharness/sdk";
+
+export const SOURCE_AGENT_KIND = "claude";
+
+export interface PendingToolUse {
+  turnId: string;
+  nativeToolName: string;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function extractUserText(content: unknown): string {
+  if (typeof content === "string") {
+    return content.trim();
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .filter(isRecord)
+    .filter((block) => block.type === "text" && typeof block.text === "string")
+    .map((block) => (block.text as string))
+    .join("\n\n")
+    .trim();
+}
+
+export function mapStopReason(rawStopReason: unknown): StopReason {
+  if (rawStopReason === "max_tokens") {
+    return "max_tokens";
+  }
+  if (rawStopReason === "refusal") {
+    return "refusal";
+  }
+  return "end_turn";
+}
+
+function extractToolResultText(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return content
+      .filter(isRecord)
+      .map((block) => (typeof block.text === "string" ? block.text : ""))
+      .filter((text) => text.length > 0)
+      .join("\n");
+  }
+  return "";
+}
+
+export interface EmitUserLineArgs {
+  content: unknown;
+  timestamp: string;
+  pendingToolUses: Map<string, PendingToolUse>;
+  nextSeq: () => number;
+  sessionId: string;
+  envelopes: SessionEventEnvelope[];
+}
+
+/**
+ * Resolves this user line's `tool_result` blocks against open tool uses,
+ * emitting an `item_completed` envelope for each match. Returns the count of
+ * `tool_result` blocks whose `tool_use_id` matched nothing pending (an
+ * orphan — expected at the front of a capped/truncated tail).
+ */
+export function emitUserLine(args: EmitUserLineArgs): number {
+  const { content, timestamp, pendingToolUses, nextSeq, sessionId, envelopes } = args;
+  if (!Array.isArray(content)) {
+    return 0;
+  }
+  let orphanCount = 0;
+  for (const block of content) {
+    if (!isRecord(block) || block.type !== "tool_result") {
+      continue;
+    }
+    const toolUseId = typeof block.tool_use_id === "string" ? block.tool_use_id : null;
+    const pending = toolUseId ? pendingToolUses.get(toolUseId) : undefined;
+    if (!toolUseId || !pending) {
+      orphanCount += 1;
+      continue;
+    }
+    pendingToolUses.delete(toolUseId);
+    envelopes.push({
+      seq: nextSeq(),
+      sessionId,
+      timestamp,
+      turnId: pending.turnId,
+      itemId: toolUseId,
+      event: {
+        type: "item_completed",
+        item: {
+          kind: "tool_invocation",
+          sourceAgentKind: SOURCE_AGENT_KIND,
+          status: block.is_error === true ? "failed" : "completed",
+          nativeToolName: pending.nativeToolName,
+          rawOutput: extractToolResultText(block.content),
+          contentParts: [],
+        },
+      },
+    });
+  }
+  return orphanCount;
+}
+
+export interface EmitAssistantLineArgs {
+  content: unknown;
+  timestamp: string;
+  uuid: string;
+  turnId: string;
+  pendingToolUses: Map<string, PendingToolUse>;
+  nextSeq: () => number;
+  sessionId: string;
+  envelopes: SessionEventEnvelope[];
+}
+
+/** Maps one assistant line's content blocks (text/thinking/tool_use) into item envelopes. */
+export function emitAssistantLine(args: EmitAssistantLineArgs): void {
+  const { content, timestamp, uuid, turnId, pendingToolUses, nextSeq, sessionId, envelopes } = args;
+  const blocks = Array.isArray(content)
+    ? content
+    : typeof content === "string" && content.length > 0
+      ? [{ type: "text", text: content }]
+      : [];
+
+  blocks.forEach((block, blockIndex) => {
+    if (!isRecord(block)) {
+      return;
+    }
+    if (block.type === "text" && typeof block.text === "string" && block.text.length > 0) {
+      envelopes.push({
+        seq: nextSeq(),
+        sessionId,
+        timestamp,
+        turnId,
+        itemId: `${uuid}:text:${blockIndex}`,
+        event: {
+          type: "item_completed",
+          item: {
+            kind: "assistant_message",
+            sourceAgentKind: SOURCE_AGENT_KIND,
+            status: "completed",
+            contentParts: [{ type: "text", text: block.text }],
+          },
+        },
+      });
+      return;
+    }
+    if (block.type === "thinking" && typeof block.thinking === "string" && block.thinking.length > 0) {
+      envelopes.push({
+        seq: nextSeq(),
+        sessionId,
+        timestamp,
+        turnId,
+        itemId: `${uuid}:thinking:${blockIndex}`,
+        event: {
+          type: "item_completed",
+          item: {
+            kind: "reasoning",
+            sourceAgentKind: SOURCE_AGENT_KIND,
+            status: "completed",
+            contentParts: [{ type: "reasoning", text: block.thinking, visibility: "private" }],
+          },
+        },
+      });
+      return;
+    }
+    if (
+      block.type === "tool_use"
+      && typeof block.id === "string"
+      && typeof block.name === "string"
+    ) {
+      const toolUseId = block.id;
+      const nativeToolName = block.name;
+      pendingToolUses.set(toolUseId, { turnId, nativeToolName });
+      envelopes.push({
+        seq: nextSeq(),
+        sessionId,
+        timestamp,
+        turnId,
+        itemId: toolUseId,
+        event: {
+          type: "item_started",
+          item: {
+            kind: "tool_invocation",
+            sourceAgentKind: SOURCE_AGENT_KIND,
+            status: "in_progress",
+            nativeToolName,
+            rawInput: block.input,
+            contentParts: [{
+              type: "tool_call",
+              toolCallId: toolUseId,
+              title: nativeToolName,
+              nativeToolName,
+            }],
+          },
+        },
+      });
+    }
+    // Other block types (image, redacted_thinking, server_tool_use, …) are
+    // outside the honest subset and are dropped without affecting the
+    // line-level skipped count — the line itself IS in the mapped subset.
+  });
+}

--- a/apps/packages/product-client/src/domain/activity/claude-session-log.test.ts
+++ b/apps/packages/product-client/src/domain/activity/claude-session-log.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+import type { AssistantProseItem, ToolCallItem, UserMessageItem } from "@anyharness/sdk";
+import { claudeSessionLogToTranscriptState } from "./claude-session-log";
+
+const SESSION_ID = "synthetic-child-session";
+
+function jsonLine(obj: unknown): string {
+  return `${JSON.stringify(obj)}\n`;
+}
+
+function userTextLine(uuid: string, text: string, timestamp = "2026-08-17T00:00:00.000Z") {
+  return {
+    type: "user",
+    uuid,
+    parentUuid: null,
+    isSidechain: false,
+    timestamp,
+    sessionId: SESSION_ID,
+    message: { role: "user", content: text },
+  };
+}
+
+function assistantLine(
+  uuid: string,
+  content: unknown[],
+  timestamp = "2026-08-17T00:00:01.000Z",
+  stopReason: string | null = "end_turn",
+) {
+  return {
+    type: "assistant",
+    uuid,
+    parentUuid: null,
+    isSidechain: false,
+    timestamp,
+    sessionId: SESSION_ID,
+    message: {
+      role: "assistant",
+      id: `msg-${uuid}`,
+      model: "claude-test",
+      content,
+      stop_reason: stopReason,
+    },
+  };
+}
+
+function toolResultLine(
+  uuid: string,
+  toolUseId: string,
+  content: unknown,
+  isError = false,
+  timestamp = "2026-08-17T00:00:02.000Z",
+) {
+  return {
+    type: "user",
+    uuid,
+    parentUuid: null,
+    isSidechain: false,
+    timestamp,
+    sessionId: SESSION_ID,
+    message: {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: toolUseId, content, is_error: isError }],
+    },
+  };
+}
+
+describe("claudeSessionLogToTranscriptState", () => {
+  it("returns an empty transcript for an empty buffer", () => {
+    const result = claudeSessionLogToTranscriptState("", SESSION_ID);
+    expect(result.transcript.turnOrder).toEqual([]);
+    expect(result.skippedLineCount).toBe(0);
+    expect(result.pendingPartialLine).toBe("");
+  });
+
+  it("maps a happy-path exchange: user prompt, assistant text + tool call, tool result, final text", () => {
+    const buffer = [
+      jsonLine(userTextLine("u1", "List the files in this repo.")),
+      jsonLine(assistantLine("a1", [
+        { type: "text", text: "I'll list them now." },
+        { type: "tool_use", id: "toolu_1", name: "Bash", input: { command: "ls" } },
+      ], "2026-08-17T00:00:01.000Z", "tool_use")),
+      jsonLine(toolResultLine("u2", "toolu_1", "file-a\nfile-b")),
+      jsonLine(assistantLine("a2", [
+        { type: "text", text: "Found two files." },
+      ])),
+    ].join("");
+
+    const { transcript, skippedLineCount, pendingPartialLine } =
+      claudeSessionLogToTranscriptState(buffer, SESSION_ID);
+
+    expect(skippedLineCount).toBe(0);
+    expect(pendingPartialLine).toBe("");
+    expect(transcript.turnOrder).toEqual(["turn-1"]);
+
+    const turn = transcript.turnsById["turn-1"];
+    expect(turn).toBeDefined();
+    expect(turn?.itemOrder).toEqual(["u1:msg", "a1:text:0", "toolu_1", "a2:text:0"]);
+
+    const userItem = transcript.itemsById["u1:msg"] as UserMessageItem;
+    expect(userItem.kind).toBe("user_message");
+    expect(userItem.text).toBe("List the files in this repo.");
+
+    const prose = transcript.itemsById["a1:text:0"] as AssistantProseItem;
+    expect(prose.kind).toBe("assistant_prose");
+    expect(prose.text).toBe("I'll list them now.");
+
+    const toolCall = transcript.itemsById["toolu_1"] as ToolCallItem;
+    expect(toolCall.kind).toBe("tool_call");
+    expect(toolCall.status).toBe("completed");
+    expect(toolCall.nativeToolName).toBe("Bash");
+    expect(toolCall.semanticKind).toBe("terminal");
+    expect(toolCall.rawInput).toEqual({ command: "ls" });
+    expect(toolCall.rawOutput).toBe("file-a\nfile-b");
+
+    const finalProse = transcript.itemsById["a2:text:0"] as AssistantProseItem;
+    expect(finalProse.text).toBe("Found two files.");
+  });
+
+  it("holds back a trailing line with no newline, then includes it once the newline arrives", () => {
+    const complete = jsonLine(userTextLine("u1", "First prompt."));
+    const partial = JSON.stringify(assistantLine("a1", [{ type: "text", text: "Partial reply" }]));
+
+    const midStream = claudeSessionLogToTranscriptState(complete + partial, SESSION_ID);
+    expect(midStream.pendingPartialLine).toBe(partial);
+    expect(midStream.transcript.turnOrder).toEqual(["turn-1"]);
+    expect(Object.keys(midStream.transcript.itemsById)).toEqual(["u1:msg"]);
+
+    const completed = claudeSessionLogToTranscriptState(`${complete}${partial}\n`, SESSION_ID);
+    expect(completed.pendingPartialLine).toBe("");
+    expect(completed.transcript.itemsById["a1:text:0"]).toBeDefined();
+  });
+
+  it("skips a malformed JSON line without throwing and counts it", () => {
+    const buffer = [
+      jsonLine(userTextLine("u1", "Hello.")),
+      "{not valid json at all\n",
+      jsonLine(assistantLine("a1", [{ type: "text", text: "Hi." }])),
+    ].join("");
+
+    expect(() => claudeSessionLogToTranscriptState(buffer, SESSION_ID)).not.toThrow();
+    const result = claudeSessionLogToTranscriptState(buffer, SESSION_ID);
+    expect(result.skippedLineCount).toBe(1);
+    expect(result.transcript.turnOrder).toEqual(["turn-1"]);
+  });
+
+  it("skips top-level line types outside the mapped subset, and counts them", () => {
+    const buffer = [
+      jsonLine({ type: "system", uuid: "s1", timestamp: "2026-08-17T00:00:00.000Z", subtype: "info" }),
+      jsonLine({ type: "summary", leafUuid: "u1", summary: "A recap" }),
+      jsonLine(userTextLine("u1", "Hello.")),
+    ].join("");
+
+    const result = claudeSessionLogToTranscriptState(buffer, SESSION_ID);
+    expect(result.skippedLineCount).toBe(2);
+    expect(result.transcript.turnOrder).toEqual(["turn-1"]);
+  });
+
+  it("skips isSidechain lines (nested subagent noise), and counts them", () => {
+    const sidechainLine = {
+      ...userTextLine("side-1", "Nested subagent prompt."),
+      isSidechain: true,
+    };
+    const buffer = [jsonLine(sidechainLine), jsonLine(userTextLine("u1", "Top-level prompt."))].join("");
+
+    const result = claudeSessionLogToTranscriptState(buffer, SESSION_ID);
+    expect(result.skippedLineCount).toBe(1);
+    expect(result.transcript.turnOrder).toEqual(["turn-1"]);
+    const turn = result.transcript.turnsById["turn-1"];
+    expect(turn?.itemOrder).toEqual(["u1:msg"]);
+  });
+
+  it("leaves a tool_use with no matching tool_result as an in-progress tool call", () => {
+    const buffer = [
+      jsonLine(userTextLine("u1", "Run a background command.")),
+      jsonLine(assistantLine("a1", [
+        { type: "tool_use", id: "toolu_running", name: "Bash", input: { command: "sleep 100" } },
+      ])),
+    ].join("");
+
+    const result = claudeSessionLogToTranscriptState(buffer, SESSION_ID);
+    const toolCall = result.transcript.itemsById.toolu_running as ToolCallItem;
+    expect(toolCall.status).toBe("in_progress");
+    expect(toolCall.rawOutput).toBeUndefined();
+  });
+
+  it("counts an orphaned tool_result (its tool_use is outside the buffer) without crashing", () => {
+    const buffer = [
+      jsonLine(userTextLine("u1", "Prompt after a truncated tail.")),
+      jsonLine(toolResultLine("u0", "toolu_never_seen", "some output")),
+    ].join("");
+
+    expect(() => claudeSessionLogToTranscriptState(buffer, SESSION_ID)).not.toThrow();
+    const result = claudeSessionLogToTranscriptState(buffer, SESSION_ID);
+    expect(result.skippedLineCount).toBe(1);
+    expect(result.transcript.itemsById.toolu_never_seen).toBeUndefined();
+  });
+
+  it("marks a failed tool result via is_error", () => {
+    const buffer = [
+      jsonLine(userTextLine("u1", "Run something that fails.")),
+      jsonLine(assistantLine("a1", [
+        { type: "tool_use", id: "toolu_fail", name: "Bash", input: { command: "false" } },
+      ])),
+      jsonLine(toolResultLine("u2", "toolu_fail", "command not found", true)),
+    ].join("");
+
+    const result = claudeSessionLogToTranscriptState(buffer, SESSION_ID);
+    const toolCall = result.transcript.itemsById.toolu_fail as ToolCallItem;
+    expect(toolCall.status).toBe("failed");
+    expect(toolCall.rawOutput).toBe("command not found");
+  });
+
+  it("maps a thinking block to a thought item", () => {
+    const buffer = [
+      jsonLine(userTextLine("u1", "Think it through.")),
+      jsonLine(assistantLine("a1", [
+        { type: "thinking", thinking: "Let me consider the options.", signature: "sig" },
+        { type: "text", text: "Here is my answer." },
+      ])),
+    ].join("");
+
+    const result = claudeSessionLogToTranscriptState(buffer, SESSION_ID);
+    const thought = result.transcript.itemsById["a1:thinking:0"];
+    expect(thought?.kind).toBe("thought");
+  });
+});

--- a/apps/packages/product-client/src/domain/activity/claude-session-log.ts
+++ b/apps/packages/product-client/src/domain/activity/claude-session-log.ts
@@ -1,0 +1,213 @@
+/**
+ * Client-side, read-only translator from a Claude-CLI native session-log
+ * JSONL tail (the bytes `open_tail_file` mirrors verbatim over a
+ * subagent's `tail_file` feed — see
+ * `anyharness-lib/src/domains/activity/feeds.rs`) into a `TranscriptState`
+ * so `BackgroundSubagentView` can render a background claude subagent's
+ * child transcript the same way any other transcript renders (Delivery Spec
+ * — Background Work Slice 1, rung R4b; handoff's "Feed fidelity" note).
+ *
+ * No runtime or fork change backs this: the wire never translates Claude's
+ * native log into ACP `SessionEventEnvelope`s for a background child, so
+ * this module does it entirely in the client, from whatever bytes have
+ * streamed in so far. It is a **pure, stateless recompute**: call it again
+ * with the fuller buffer as more bytes arrive (`useClaudeSessionLogTranscript`
+ * memoizes on the buffer text) rather than a stateful incremental parser
+ * that retains a cursor — the feed buffer is already capped at 256KB
+ * (`feed-content-buffer.ts`), so reparsing it whole on every chunk is cheap
+ * and, unlike hidden parser state, can never desync from what is on screen.
+ *
+ * Honest subset mapped (everything else is skipped and counted, never
+ * thrown): top-level `user` and `assistant` log lines; `text` and
+ * `thinking` content blocks; `tool_use` blocks paired with their
+ * `tool_result` by id. Skipped and counted: malformed JSON, any other
+ * top-level `type` (`system`, `summary`, `queue-operation`, …), lines
+ * flagged `isSidechain` (a *nested* Task-tool subagent inside this child —
+ * one level of native-subagent nesting is out of this slice's scope, same
+ * boundary the handoff draws for the top-level view), and a `tool_result`
+ * whose `tool_use_id` never matched a `tool_use` seen in this buffer (an
+ * orphan — expected at the front of a capped/truncated tail). The buffer's
+ * trailing line is always held back and returned as `pendingPartialLine`:
+ * `tail_file` streams raw bytes with no line-complete guarantee, and a
+ * `\n`-free tail is indistinguishable from a write in flight.
+ *
+ * Reuses `@anyharness/sdk`'s own reducer (`reduceEvents`) rather than
+ * hand-building `TranscriptState` — the same convergence point
+ * `envelope-to-state.ts` already uses for the main transcript — so turn
+ * bookkeeping, tool semantic-kind classification (native tool names like
+ * `Bash`/`Task`/`Grep` are handled for free by the reducer's own
+ * `nativeToolName` heuristics), and content-part shapes stay identical to a
+ * live session's. Turns close (`turn_ended`) only when the next turn opens;
+ * the buffer's final turn is left open, honestly reflecting that a
+ * background child may still be writing to it. Envelope construction for
+ * one parsed line's content blocks lives in `claude-session-log-envelopes.ts`
+ * (split out purely for file size, FE-SIZE-1).
+ */
+import { reduceEvents, type SessionEventEnvelope, type StopReason, type TranscriptState } from "@anyharness/sdk";
+import {
+  emitAssistantLine,
+  emitUserLine,
+  extractUserText,
+  isRecord,
+  mapStopReason,
+  type PendingToolUse,
+} from "./claude-session-log-envelopes";
+
+export interface ClaudeSessionLogTranscript {
+  transcript: TranscriptState;
+  /** Complete lines that were not part of the honest mapped subset (see module doc). */
+  skippedLineCount: number;
+  /** The buffer's held-back trailing line (may be empty). */
+  pendingPartialLine: string;
+}
+
+interface ParsedLogLine {
+  type: string;
+  uuid: string;
+  timestamp: string;
+  isSidechain: boolean;
+  message: Record<string, unknown> | null;
+}
+
+/**
+ * Maps the accumulated `tail_file` buffer for one claude subagent into a
+ * `TranscriptState`. Called fresh on every buffer growth (see module doc);
+ * always terminates, never throws.
+ */
+export function claudeSessionLogToTranscriptState(
+  buffer: string,
+  sessionId: string,
+): ClaudeSessionLogTranscript {
+  const { completeLines, pendingPartialLine } = splitCompleteLines(buffer);
+
+  const envelopes: SessionEventEnvelope[] = [];
+  const pendingToolUses = new Map<string, PendingToolUse>();
+  let skippedLineCount = 0;
+  let seq = 0;
+  let turnSeq = 0;
+  let currentTurnId: string | null = null;
+  let currentTurnStopReason: StopReason = "end_turn";
+
+  const nextSeq = () => {
+    seq += 1;
+    return seq;
+  };
+  const closeCurrentTurn = (ts: string) => {
+    if (!currentTurnId) {
+      return;
+    }
+    envelopes.push({
+      seq: nextSeq(),
+      sessionId,
+      timestamp: ts,
+      turnId: currentTurnId,
+      itemId: null,
+      event: { type: "turn_ended", stopReason: currentTurnStopReason },
+    });
+  };
+
+  completeLines.forEach((rawLine, lineIndex) => {
+    const parsed = parseLogLine(rawLine, lineIndex);
+    if (!parsed) {
+      skippedLineCount += 1;
+      return;
+    }
+    if (parsed.isSidechain || (parsed.type !== "user" && parsed.type !== "assistant")) {
+      skippedLineCount += 1;
+      return;
+    }
+    if (!parsed.message) {
+      skippedLineCount += 1;
+      return;
+    }
+
+    if (parsed.type === "user") {
+      skippedLineCount += emitUserLine({
+        content: parsed.message.content,
+        timestamp: parsed.timestamp,
+        pendingToolUses,
+        nextSeq,
+        sessionId,
+        envelopes,
+      });
+      const text = extractUserText(parsed.message.content);
+      if (text) {
+        closeCurrentTurn(parsed.timestamp);
+        turnSeq += 1;
+        currentTurnId = `turn-${turnSeq}`;
+        currentTurnStopReason = "end_turn";
+        envelopes.push({
+          seq: nextSeq(),
+          sessionId,
+          timestamp: parsed.timestamp,
+          turnId: currentTurnId,
+          itemId: `${parsed.uuid}:msg`,
+          event: {
+            type: "item_completed",
+            item: {
+              kind: "user_message",
+              sourceAgentKind: "claude",
+              status: "completed",
+              contentParts: [{ type: "text", text }],
+            },
+          },
+        });
+      }
+      return;
+    }
+
+    // Assistant line.
+    if (!currentTurnId) {
+      turnSeq += 1;
+      currentTurnId = `turn-${turnSeq}`;
+      currentTurnStopReason = "end_turn";
+    }
+    emitAssistantLine({
+      content: parsed.message.content,
+      timestamp: parsed.timestamp,
+      uuid: parsed.uuid,
+      turnId: currentTurnId,
+      pendingToolUses,
+      nextSeq,
+      sessionId,
+      envelopes,
+    });
+    currentTurnStopReason = mapStopReason(parsed.message.stop_reason);
+  });
+
+  const transcript = reduceEvents(envelopes, sessionId);
+  return { transcript, skippedLineCount, pendingPartialLine };
+}
+
+/** Splits on `\n`, always holding back the trailing (possibly-partial) line. */
+function splitCompleteLines(
+  buffer: string,
+): { completeLines: string[]; pendingPartialLine: string } {
+  if (buffer.length === 0) {
+    return { completeLines: [], pendingPartialLine: "" };
+  }
+  const parts = buffer.split("\n");
+  const pendingPartialLine = parts[parts.length - 1] ?? "";
+  const completeLines = parts.slice(0, -1).filter((line) => line.trim().length > 0);
+  return { completeLines, pendingPartialLine };
+}
+
+function parseLogLine(rawLine: string, lineIndex: number): ParsedLogLine | null {
+  let obj: unknown;
+  try {
+    obj = JSON.parse(rawLine);
+  } catch {
+    return null;
+  }
+  if (!isRecord(obj) || typeof obj.type !== "string") {
+    return null;
+  }
+  const message = isRecord(obj.message) ? obj.message : null;
+  return {
+    type: obj.type,
+    uuid: typeof obj.uuid === "string" && obj.uuid.length > 0 ? obj.uuid : `line-${lineIndex}`,
+    timestamp: typeof obj.timestamp === "string" ? obj.timestamp : "",
+    isSidechain: obj.isSidechain === true,
+    message,
+  };
+}

--- a/apps/packages/product-client/src/hooks/activity/derived/use-claude-session-log-transcript.ts
+++ b/apps/packages/product-client/src/hooks/activity/derived/use-claude-session-log-transcript.ts
@@ -1,0 +1,24 @@
+import { useMemo } from "react";
+import {
+  claudeSessionLogToTranscriptState,
+  type ClaudeSessionLogTranscript,
+} from "#product/domain/activity/claude-session-log";
+
+/**
+ * Memoized client-side translation of a claude subagent's accumulated
+ * `tail_file` buffer into a `TranscriptState` (see
+ * `domain/activity/claude-session-log.ts` for the mapped subset and the
+ * "recompute on buffer growth" rationale). `sessionId` is a synthetic key —
+ * this transcript has no session-store entry — used only to stamp
+ * `TranscriptState.sessionMeta.sessionId` and thread `TranscriptContexts`'
+ * pane-lifecycle bookkeeping.
+ */
+export function useClaudeSessionLogTranscript(
+  buffer: string,
+  sessionId: string,
+): ClaudeSessionLogTranscript {
+  return useMemo(
+    () => claudeSessionLogToTranscriptState(buffer, sessionId),
+    [buffer, sessionId],
+  );
+}


### PR DESCRIPTION
## Summary

Rung R4b of the Background Work slice (Delivery Spec — Background Work Slice 1, line 19; stack position 6, branched off `bgwork/r5-finish-signals` @ `4fdd503db4cfb1119ed7c88e2aee79fc3e1151bd`). Resolves the blocker R4's `BackgroundSubagentView` reported: the handoff's "Feed fidelity" note calls transcript-shaped rendering "honest for Claude today" because the child transcript "arrives as a JSONL tail over `tail_file`" — but no translator from that native Claude-CLI JSONL to the SDK's `TranscriptState`/`SessionEventEnvelope` shape existed anywhere in the repo. This PR adds one, entirely client-side, and wires it into the view. **Zero runtime/fork changes** — everything here is `apps/packages/product-client`.

- `domain/activity/claude-session-log.ts` (+ `claude-session-log-envelopes.ts`, split out purely for FE-SIZE-1): a pure, stateless, per-call recompute that maps the accumulated `tail_file` buffer into a `TranscriptState`. It never throws: malformed JSON lines are skipped and counted, unsupported top-level line types (`system`, `summary`, `queue-operation`, …) are skipped and counted, `isSidechain` lines (a nested Task-tool subagent *inside* this child — out of this slice's scope) are skipped and counted, the buffer's trailing line is always held back (`tail_file` has no line-complete guarantee), and an orphaned `tool_result` (its `tool_use_id` outside the buffer, e.g. a capped/truncated tail) is dropped and counted rather than crashing.
  - Reuses `@anyharness/sdk`'s own reducer (`reduceEvents`) instead of hand-building `TranscriptState` — the same convergence point `domain/chats/transcript/envelope-to-state.ts` already uses for the main transcript. This means turn bookkeeping, and tool semantic-kind classification (`Bash` → terminal, `Task`/`Agent` → subagent, `Grep`/`Glob`/`Ls` → search, via the reducer's existing `nativeToolName` heuristics) come for free and stay identical to a live session's rendering. `Read`/`Edit`/`Write` fall back to the generic "other" tool-call treatment (no file-diff-preview content-part synthesis) — a deliberate scope limit, not a bug.
- `hooks/activity/derived/use-claude-session-log-transcript.ts`: a one-line `useMemo` wrapper next to `use-feed-stream.ts`, per the reviewer's sketch.
- `BackgroundSubagentView.tsx`: claude subagents (checked via `session-directory-store`'s `agentKind === "claude"`) whose mapped transcript is non-empty render through `MessageList` with `sessionViewState="idle"` — **the literal component the handoff names**, fed directly via its `transcript` prop with a synthetic `activeSessionId`. Every other harness, and a claude buffer whose mapped subset comes up empty (no complete lines yet, or nothing but skipped/malformed content), keeps the existing raw-tail `<pre>` fallback. The R3/R4 `isOpen` feed-gating seam is untouched.

## Rendering-path investigation (per the mission's item 2)

Investigated whether `MessageList` can render a synthetic, store-less transcript before assuming store surgery was needed. It can: `MessageList`'s own props (`AgentsPaneDetail.tsx`) show it takes `transcript: TranscriptState` **directly as a prop** — it does not derive transcript content from a session store via `activeSessionId`. The session id is only used as an opaque key: `TranscriptContexts.tsx`'s `TranscriptContextProviders` stores it in a `createContext` purely for pane-lifecycle bookkeeping (never a store lookup), and `useOpenBackgroundWorkPane` (the one thing wired to `activeSessionId` inside `MessageList`, for a nested subagent chip click) safely no-ops on an id with no matching roster entry. So **no deviation from the handoff was needed** — the view renders through the literal `MessageList`/`sessionViewState="idle"` path, with `contentSearchEnabled={false}` (same as `AgentsPaneDetail`'s embedded-transcript convention).

## Assumptions / scope limits (disclosed, reversible)

- `isSidechain` lines (grandchild native subagents nested inside this child) are skipped and counted, not recursively mapped — matches the one-level-of-nesting scope boundary the handoff already draws for the top-level view.
- Turn `stopReason` is best-effort-mapped from Claude's own `message.stop_reason` (`max_tokens`/`refusal` pass through, everything else defaults to `end_turn`); the buffer's *final*, possibly still-open turn is left without a `turn_ended`, honestly reflecting that a background child may still be writing to it.
- `Read`/`Edit`/`Write` tool calls render generically ("other" semantic kind) rather than with rich file-diff previews — building `file_read`/`file_change` content-part synthesis from Claude's native tool schemas is real additional scope, deferred.
- A nested `Task`/`Agent` tool-call chip inside the mapped transcript is inert if clicked (writes a pending selection keyed to a synthetic subagent id that matches no roster entry) — no crash, just a no-op; documented here rather than built out, since grandchild-subagent click-through is out of scope.
- Malformed/empty claude feed content degrades to the raw-tail view rather than a confident-but-empty transcript — a deliberate, tested choice.

## Tests

- `domain/activity/claude-session-log.test.ts` (10 tests, all new): empty buffer; happy-path exchange (user text → assistant text + tool_use → tool_result → final text) with full turn/item/semantic-kind assertions; partial trailing line held back then completed across two calls; malformed JSON line skipped + counted, never throws; unsupported top-level types skipped + counted; `isSidechain` lines skipped + counted; orphaned tool_result skipped + counted, never throws; unresolved tool_use stays `in_progress`; `is_error` tool_result maps to `failed`; `thinking` block maps to a `thought` item.
- `BackgroundSubagentView.test.tsx` (12 tests, 8 pre-existing + 4 new): claude with valid synthetic JSONL → `MessageList` receives a real, non-empty `TranscriptState` and the mapped text renders; **negative control** — the identical JSONL text fed to a `codex` subagent never reaches `MessageList` and renders the raw tail instead (proves the gate is on provider, not "any parseable JSON"); claude with malformed feed content degrades to the raw-tail view without crashing; claude with no feed content yet shows the pre-existing "Connecting…" state. Manually verified the negative-control test actually catches a regression by reverting the provider gate locally (`isClaudeSubagent = true`) — 1 test failed as expected, then restored.

## Gates (literal tallies)

- Affected suite: `pnpm vitest run src/domain/activity/claude-session-log.test.ts src/components/workspace/activity/background-pane/BackgroundSubagentView.test.tsx` → **2 files / 22 tests passed**.
- Full product-client suite: `pnpm vitest run` → **1013 files / 7327 tests passed**.
- `tsc -p tsconfig.domain.json` → 1 error, the known exogenous `run-view-model.ts(75,7)` TS2741 (attributed, not chased; present before this PR).
- `tsc -p tsconfig.json --noEmit` → same single exogenous error, nothing else.
- `python3 scripts/report_frontend_structure.py --strict` → **0 violations** (FE-SIZE-1 initially flagged the new domain module at 404 lines; split into `claude-session-log.ts` (213) + `claude-session-log-envelopes.ts` (212) rather than take a ratchet exception).
- `python3 scripts/check_appearance_scaling.py` → passed.
- `python3 scripts/check_design_attribution.py` → passed.
- `python3 scripts/check_max_lines.py` → passed (repo max 600, component max 500).

## specs/TESTING.md and specs/OBSERVABILITY.md

Tier 1 (pure logic, no state) for the translator; Tier 1/component-level for the view's provider-gated branch — both merge-gating, no real LLM/sandbox involved, consistent with the tier model. No telemetry/observability surface changed — this is pure client-side rendering of bytes the runtime already streams unchanged.

Draft PR, no merge — per lane convention, merges are Pablo's call only.