### PR TITLE
fix(product): workflow-lane merge fallout — main tsc break + line-clamp previews

### DIFF
--- a/apps/packages/product-client/src/components/workflows/run-view/WorkflowGraphView.tsx
+++ b/apps/packages/product-client/src/components/workflows/run-view/WorkflowGraphView.tsx
@@ -125,7 +125,7 @@ export function WorkflowGraphView({
                 {WORKFLOW_NODE_CARD_COPY.needsInputBadge}
               </Badge>
             ) : vm.node.prompt.trim().length > 0 ? (
-              <span className="line-clamp-2 w-full text-ui-sm text-muted-foreground">
+              <span className="line-clamp-2 w-full whitespace-normal text-ui-sm text-muted-foreground">
                 {vm.node.prompt}
               </span>
             ) : null}

--- a/tests/intent/specs/workflow-definitions.spec.ts
+++ b/tests/intent/specs/workflow-definitions.spec.ts
@@ -93,6 +93,22 @@ test("creates, reloads, reopens, edits, and deletes a durable gen-2 definition",
   // it waits for the claim to be visible on the read-only signal directly
   // rather than racing a UI-driven sign-in against it.
   await awaitInstanceClaimVisible();
+  // This environment provisions no integrations, so the capability-liveness
+  // toast ("Integrations unavailable") re-raises for the whole session and its
+  // bottom-right card intercepts clicks aimed at the inspector's lower inputs.
+  // Dismiss it whenever it surfaces instead of racing individual clicks.
+  await page.addLocatorHandler(
+    page.getByText("Integrations unavailable", { exact: true }),
+    async () => {
+      // ToastBody's close affordance is aria-labelled "Close"; scope to the
+      // notifications region so no dialog close button can match instead.
+      await page
+        .getByRole("region", { name: /Notifications/ })
+        .getByRole("button", { name: "Close", exact: true })
+        .first()
+        .click();
+    },
+  );
   await signInThroughUi(page);
 
   await page.goto(`${webBaseUrl()}/workflows`);


### PR DESCRIPTION
Fast-follow to the #1906 + #1972 merges. Two independent one-liners:

**1. Main is currently RED — `cancelled` tone missing (commit `0e4177a9d`).** #1906 added the `cancelled` status to `WorkflowRunStatusV2`; #1972's `run-view-model.ts` predates it, so its total `RUN_STATUS_TONE: Record<WorkflowRunStatusV2, WorkflowRunTone>` map fails `tsc` repo-wide on main:

```
src/domain/workflows/run-view-model.ts(75,7): error TS2741: Property 'cancelled' is missing in type '{ running: "info"; awaiting_human: "info"; interrupted: "warning"; completed: "success"; failed: "danger"; }' but required in type 'Record<WorkflowRunStatusV2, WorkflowRunTone>'.
```

Fix: `cancelled: "neutral"` — matching run-presentation.ts's existing `cancelled: ["Cancelled", "neutral"]` convention and the map's own `?? "neutral"` fallback. Negative control: reverting the line locally reproduces the exact TS2741 above; with it, `tsc -p tsconfig.domain.json` is clean and `run-view-model.test.ts` passes 53/53.

**2. line-clamp previews collapse under Button's `whitespace-nowrap` (commit `1d4b743b1`).** The FE-STRUCT-1 Button conversion in #1972 (`1deae734f`) wrapped the workflow cards in the `Button` primitive, whose base class includes `whitespace-nowrap`; `white-space` is CSS-inherited, so the `line-clamp-2` prompt/subtitle spans collapse to one clipped line. Flagged by #1972's delta review; the fix was pushed to that branch 4 minutes after merge, so it never landed — this is the identical cherry-pick. Adds `whitespace-normal` to the three spans (WorkflowBuilderChainCanvas.tsx ×2, WorkflowGraphView.tsx ×1). Scoped vitest: WorkflowGraphView + WorkflowGraphNodeCard, 24/24 pass.

The 12 CI failures on the first push here were main's breakage (item 1) plus a setup-terraform 429 download flake — not this PR's diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**3. e2e unblock (commit `a572a22f8`).** Adds a `page.addLocatorHandler` to `tests/intent/specs/workflow-definitions.spec.ts` auto-dismissing the persistent "Integrations unavailable" toast (#1997 capability-liveness) that intercepts inspector clicks in CI's integration-less env — this was failing the tier-2 lifecycle lane for every PR.
