### PR TITLE
feat(workflows): run-scoped context docs — .proliferate/context/<runId>/ (follow-up ADR rung 1)

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/http/workflow_runs.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/workflow_runs.rs
@@ -400,9 +400,11 @@ pub async fn put_workflow_run(
         let doc_count = planned_docs.len();
         let templates = snapshot.definition.doc_templates.clone();
         let workspace_path = placed.workspace.path.clone();
+        let materialize_run_id = run_id.clone();
         let materialized = run_blocking("workflow_run_materialize", move || {
             materialize_planned_context(
                 std::path::Path::new(&workspace_path),
+                &materialize_run_id,
                 &planned_docs,
                 &templates,
             )

--- a/anyharness/crates/anyharness-lib/src/api/workflow_runs_placement_route_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/workflow_runs_placement_route_tests.rs
@@ -41,7 +41,7 @@ async fn repo_root_mode_reuses_the_workspace_and_enforces_one_live_run() {
     // Context docs materialized into the user's checkout.
     assert!(fixture
         .repo_dir()
-        .join(".proliferate/context/00-notes.md")
+        .join(format!(".proliferate/context/{first_run}/00-notes.md"))
         .is_file());
 
     // The one-live-run law: a second run cannot land in the workspace while

--- a/anyharness/crates/anyharness-lib/src/api/workflow_runs_route_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/api/workflow_runs_route_tests.rs
@@ -301,7 +301,7 @@ async fn put_places_a_run_idempotently_and_the_wire_shape_holds() {
     let managed_root = canonical_managed_worktrees_root(&fixture.runtime_home).expect("root");
     let workspace_root = managed_root.join(format!("workflows/{run_id}"));
     assert!(workspace_root.is_dir(), "run worktree materialized");
-    let seeded = workspace_root.join(".proliferate/context/00-notes.md");
+    let seeded = workspace_root.join(format!(".proliferate/context/{run_id}/00-notes.md"));
     assert_eq!(
         std::fs::read_to_string(&seeded).expect("seeded doc"),
         "# Notes\n"

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/materialize.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/materialize.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 
 use super::definition::{DocTemplate, InvocationSnapshot};
 use super::model::WorkflowRunDocRecord;
-use super::render::CONTEXT_DIR_RELATIVE;
+use super::render::run_context_dir_relative;
 use super::store::doc_filename;
 use crate::domains::workspaces::exclude::{ensure_proliferate_excluded, ExcludeOutcome};
 
@@ -46,12 +46,13 @@ pub fn plan_context_docs(snapshot: &InvocationSnapshot, chain: &[String]) -> Vec
 }
 
 /// Materialize the context folder for one run from its registry rows: create
-/// `<workspace>/.proliferate/context/`, seed each row's file from its
-/// template body, and ensure the clone's shared `/.proliferate/` exclude
+/// `<workspace>/.proliferate/context/<run_id>/`, seed each row's file from
+/// its template body, and ensure the clone's shared `/.proliferate/` exclude
 /// entry. Idempotent, and run-local edits win: an existing file is never
 /// overwritten.
 pub fn materialize_context(
     workspace_root: &Path,
+    run_id: &str,
     docs: &[WorkflowRunDocRecord],
     templates: &[DocTemplate],
 ) -> anyhow::Result<PathBuf> {
@@ -62,17 +63,18 @@ pub fn materialize_context(
             filename: doc.filename.clone(),
         })
         .collect();
-    materialize_planned_context(workspace_root, &planned, templates)
+    materialize_planned_context(workspace_root, run_id, &planned, templates)
 }
 
 /// The record-free half of [`materialize_context`], for the PUT path's
 /// disk-before-rows ordering.
 pub fn materialize_planned_context(
     workspace_root: &Path,
+    run_id: &str,
     docs: &[PlannedContextDoc],
     templates: &[DocTemplate],
 ) -> anyhow::Result<PathBuf> {
-    let context_dir = workspace_root.join(CONTEXT_DIR_RELATIVE);
+    let context_dir = workspace_root.join(run_context_dir_relative(run_id));
     std::fs::create_dir_all(&context_dir)
         .map_err(|error| anyhow::anyhow!("create {}: {error}", context_dir.display()))?;
 

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/materialize_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/materialize_tests.rs
@@ -102,8 +102,8 @@ fn materialize_seeds_docs_and_writes_the_exclude_entry_once() {
     let docs = vec![doc("plan-doc", "00-plan-doc.md"), doc("notes", "notes.md")];
     let templates = vec![template("plan-doc", "# Plan\n"), template("notes", "")];
 
-    let context_dir = materialize_context(&root, &docs, &templates).expect("materialize");
-    assert_eq!(context_dir, root.join(".proliferate/context"));
+    let context_dir = materialize_context(&root, "run-1", &docs, &templates).expect("materialize");
+    assert_eq!(context_dir, root.join(".proliferate/context/run-1"));
     assert_eq!(
         std::fs::read_to_string(context_dir.join("00-plan-doc.md")).expect("seeded"),
         "# Plan\n"
@@ -125,7 +125,7 @@ fn materialize_seeds_docs_and_writes_the_exclude_entry_once() {
 
     // Negative control for idempotence: a second materialization must not
     // duplicate the entry or clobber files.
-    materialize_context(&root, &docs, &templates).expect("re-materialize");
+    materialize_context(&root, "run-1", &docs, &templates).expect("re-materialize");
     let exclude = read_exclude(&root);
     assert_eq!(
         exclude
@@ -158,11 +158,11 @@ fn run_local_edits_survive_rematerialization() {
     let docs = vec![doc("plan-doc", "00-plan-doc.md")];
     let templates = vec![template("plan-doc", "# Plan\n")];
 
-    let context_dir = materialize_context(&root, &docs, &templates).expect("materialize");
+    let context_dir = materialize_context(&root, "run-1", &docs, &templates).expect("materialize");
     let path = context_dir.join("00-plan-doc.md");
     std::fs::write(&path, "# Plan\n\nthe agent wrote this\n").expect("edit");
 
-    materialize_context(&root, &docs, &templates).expect("re-materialize");
+    materialize_context(&root, "run-1", &docs, &templates).expect("re-materialize");
     assert_eq!(
         std::fs::read_to_string(&path).expect("read"),
         "# Plan\n\nthe agent wrote this\n",
@@ -183,7 +183,7 @@ fn worktree_workspaces_write_the_entry_into_the_common_git_dir() {
 
     let docs = vec![doc("notes", "notes.md")];
     let templates = vec![template("notes", "")];
-    materialize_context(&worktree, &docs, &templates).expect("materialize in worktree");
+    materialize_context(&worktree, "run-1", &docs, &templates).expect("materialize in worktree");
 
     // The entry lands in the MAIN clone's info/exclude (the common dir), not
     // in the worktree's private gitdir.
@@ -222,7 +222,7 @@ fn non_git_workspaces_materialize_without_an_exclude_entry() {
     let outcome = ensure_proliferate_excluded(&root).expect("exclude probe");
     let docs = vec![doc("notes", "notes.md")];
     let templates = vec![template("notes", "seeded\n")];
-    let context_dir = materialize_context(&root, &docs, &templates).expect("materialize");
+    let context_dir = materialize_context(&root, "run-1", &docs, &templates).expect("materialize");
     assert_eq!(
         std::fs::read_to_string(context_dir.join("notes.md")).expect("read"),
         "seeded\n"
@@ -243,7 +243,7 @@ fn template_bodies_seed_byte_for_byte_verbatim() {
     let body = "# Plan\n@input:ticket and @doc:plan-doc stay literal, so do {braces} and $vars\n\u{201C}smart quotes\u{201D} too\n";
     let docs = vec![doc("plan-doc", "00-plan-doc.md")];
     let templates = vec![template("plan-doc", body)];
-    let context_dir = materialize_context(&root, &docs, &templates).expect("materialize");
+    let context_dir = materialize_context(&root, "run-1", &docs, &templates).expect("materialize");
     assert_eq!(
         std::fs::read(context_dir.join("00-plan-doc.md")).expect("read"),
         body.as_bytes(),
@@ -259,7 +259,7 @@ fn doc_rows_without_templates_seed_empty_files() {
     let root = tmp.path().join("repo");
     init_repo(&root);
     let docs = vec![doc("scratch", "scratch.md")];
-    let context_dir = materialize_context(&root, &docs, &[]).expect("materialize");
+    let context_dir = materialize_context(&root, "run-1", &docs, &[]).expect("materialize");
     assert_eq!(
         std::fs::read_to_string(context_dir.join("scratch.md")).expect("read"),
         ""
@@ -328,4 +328,33 @@ fn exclude_entry_appends_below_existing_content() {
     );
     let content = read_exclude(&root);
     assert_eq!(content, format!("*.tmp\n{PROLIFERATE_EXCLUDE_ENTRY}\n"));
+}
+
+/// R3: two runs sharing one workspace never collide on doc paths — each
+/// run's docs live under its own run-scoped directory. Negative control for
+/// the old flat layout: identical filenames across runs stay disjoint files.
+#[test]
+fn concurrent_runs_materialize_into_disjoint_run_scoped_dirs() {
+    let tmp = TempDir::new("test");
+    let root = tmp.path().join("repo");
+    init_repo(&root);
+    let docs = vec![doc("plan-doc", "00-plan-doc.md")];
+
+    let dir_a = materialize_context(&root, "run-a", &docs, &[template("plan-doc", "a\n")])
+        .expect("materialize run a");
+    let dir_b = materialize_context(&root, "run-b", &docs, &[template("plan-doc", "b\n")])
+        .expect("materialize run b");
+
+    assert_ne!(dir_a, dir_b, "run-scoped dirs must be disjoint");
+    assert_eq!(dir_a, root.join(".proliferate/context/run-a"));
+    assert_eq!(dir_b, root.join(".proliferate/context/run-b"));
+    assert_eq!(
+        std::fs::read_to_string(dir_a.join("00-plan-doc.md")).expect("run a doc"),
+        "a\n",
+        "run b's seed must not clobber run a's identically named doc"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir_b.join("00-plan-doc.md")).expect("run b doc"),
+        "b\n"
+    );
 }

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/render.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/render.rs
@@ -25,7 +25,9 @@ use super::model::{RenderedEnvelope, WorkflowNodeType, WorkflowRunDocRecord};
 use crate::domains::sessions::model::SESSION_TITLE_MAX_CHARS;
 use crate::domains::sessions::prompt::render::SYSTEM_INSTRUCTION_WRAPPER;
 
-/// Workspace-relative home of a run's context docs.
+/// Workspace-relative parent of every run's context docs. Each run gets its
+/// own subfolder ([`run_context_dir_relative`]); nothing writes into this
+/// directory directly.
 pub const CONTEXT_DIR_RELATIVE: &str = ".proliferate/context";
 
 /// The node-session title law: `NN Title`, NN = the node's chain position,
@@ -62,6 +64,14 @@ pub fn node_session_title(chain_index: Option<i64>, node_title: &str) -> String 
     clipped
 }
 
+/// Workspace-relative home of ONE run's context docs
+/// (`.proliferate/context/<run_id>/`). Run-scoping keeps concurrent runs
+/// sharing a workspace from colliding on `NN-slug.md` names, which are only
+/// unique within a run's chain.
+pub fn run_context_dir_relative(run_id: &str) -> std::path::PathBuf {
+    Path::new(CONTEXT_DIR_RELATIVE).join(run_id)
+}
+
 #[derive(Debug, Clone)]
 pub struct RenderInputs<'a> {
     pub node_type: WorkflowNodeType,
@@ -77,8 +87,8 @@ pub struct RenderInputs<'a> {
     /// The run's doc registry rows — resolution reads rows, never the
     /// definition, so run-local registrations stay authoritative.
     pub docs: &'a [WorkflowRunDocRecord],
-    /// Absolute path of the run workspace's context dir
-    /// (`<workspace>/.proliferate/context`).
+    /// Absolute path of this run's context dir
+    /// (`<workspace>/.proliferate/context/<run_id>`).
     pub context_dir: &'a Path,
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/render_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/render_tests.rs
@@ -282,3 +282,35 @@ fn node_session_title_clips_to_the_session_title_cap() {
     assert!(title.starts_with("01 x"));
     assert!(title.ends_with('\u{2026}'));
 }
+
+/// R3 invariant: rendered against a run-scoped context dir (the layout the
+/// engine actually resolves — `run_context_dir_relative`), every doc path in
+/// the first message AND every path in the preamble carries the run id, so
+/// concurrent runs' sessions can never be pointed at each other's docs.
+#[test]
+fn rendered_prompt_and_preamble_paths_are_run_scoped() {
+    let docs = vec![doc("plan-doc", "00-plan-doc.md"), doc("notes", "notes.md")];
+    let context_dir = Path::new("/ws").join(super::render::run_context_dir_relative("run-1"));
+    let envelope = render_envelope(&RenderInputs {
+        node_type: WorkflowNodeType::Agent,
+        prompt: "update @doc:plan-doc and @doc:notes",
+        mode: ResolveMode::Strict,
+        arguments: &arguments(&[]),
+        docs: &docs,
+        context_dir: &context_dir,
+    })
+    .expect("render");
+    assert_eq!(
+        envelope.first_message,
+        "update /ws/.proliferate/context/run-1/00-plan-doc.md and /ws/.proliferate/context/run-1/notes.md"
+    );
+    let preamble = &envelope.instruction_blocks[0];
+    for line in preamble.lines().filter(|line| line.contains(".proliferate/context")) {
+        assert!(
+            line.contains("/.proliferate/context/run-1"),
+            "every preamble context path must be run-scoped, got: {line}"
+        );
+    }
+    assert!(preamble.contains("/ws/.proliferate/context/run-1/00-plan-doc.md"));
+    assert!(preamble.contains("/ws/.proliferate/context/run-1/notes.md"));
+}

--- a/anyharness/crates/anyharness-lib/src/live/workflows/actor.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/actor.rs
@@ -22,7 +22,7 @@ use crate::domains::workflows::model::{
 };
 use crate::domains::workflows::projection::RunProjection;
 use crate::domains::workflows::render::{
-    node_session_title, render_envelope, RenderInputs, CONTEXT_DIR_RELATIVE,
+    node_session_title, render_envelope, run_context_dir_relative, RenderInputs,
 };
 use crate::domains::workflows::store::{emit_decision_events, ResolvedSideEffect, WorkflowStore};
 use crate::domains::workflows::transition::{
@@ -453,7 +453,7 @@ impl WorkflowActor {
         let arguments: serde_json::Map<String, serde_json::Value> =
             serde_json::from_str(&state.run.arguments_json)?;
         let docs = self.deps.store.list_docs(&self.run_id)?;
-        let context_dir = Path::new(&workspace.path).join(CONTEXT_DIR_RELATIVE);
+        let context_dir = Path::new(&workspace.path).join(run_context_dir_relative(&self.run_id));
         render_envelope(&RenderInputs {
             node_type: node.node_type,
             prompt: &node.prompt,

--- a/anyharness/crates/anyharness-lib/src/live/workflows/lifecycle_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/lifecycle_tests.rs
@@ -156,12 +156,8 @@ fn create_run_rows(
             definition_json,
         })
         .expect("create run rows");
-    materialize_context(
-        workspace_root,
-        &created.docs,
-        &snapshot.definition.doc_templates,
-    )
-    .expect("materialize context");
+    materialize_context(workspace_root, run_id, &created.docs, &snapshot.definition.doc_templates)
+        .expect("materialize context");
     created
 }
 
@@ -319,7 +315,7 @@ async fn happy_path_resolves_references_teaches_the_preamble_and_completes() {
     // Both sessions received the resolved first message, in chain order.
     let doc_path = fixture
         .workspace_root
-        .join(".proliferate/context/00-plan-doc.md");
+        .join(".proliferate/context/run-happy/00-plan-doc.md");
     let doc_path = doc_path.to_string_lossy();
     assert_eq!(
         prompt_texts(&fixture.script.request_log),

--- a/apps/packages/product-client/src/hooks/workflows/ui/use-workflow-doc-open.test.tsx
+++ b/apps/packages/product-client/src/hooks/workflows/ui/use-workflow-doc-open.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import type { WorkflowRunDocV2 } from "@anyharness/sdk";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useWorkflowDocOpen } from "#product/hooks/workflows/ui/use-workflow-doc-open";
+import { fileViewerTarget } from "#product/lib/domain/workspaces/viewer/viewer-target";
+
+const mocks = vi.hoisted(() => ({
+  activateViewerTarget: vi.fn(),
+  openTarget: vi.fn(),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/tabs/use-workspace-shell-activation", () => ({
+  useWorkspaceShellActivation: () => ({
+    activateViewerTarget: mocks.activateViewerTarget,
+  }),
+}));
+
+vi.mock("#product/stores/editor/workspace-viewer-tabs-store", () => ({
+  useWorkspaceViewerTabsStore: (
+    selector: (state: { openTarget: typeof mocks.openTarget }) => unknown,
+  ) => selector({ openTarget: mocks.openTarget }),
+}));
+
+vi.mock("#product/stores/sessions/session-selection-store", () => ({
+  useSessionSelectionStore: (
+    selector: (state: { selectedLogicalWorkspaceId: string }) => unknown,
+  ) => selector({ selectedLogicalWorkspaceId: "logical-workspace-1" }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useWorkflowDocOpen", () => {
+  it("opens and activates the exact run-scoped context-doc path", () => {
+    const doc: WorkflowRunDocV2 = {
+      id: "doc-1",
+      runId: "run-1",
+      slug: "research-findings",
+      filename: "03-research-findings.md",
+      producingNodeRowId: "node-1",
+      seededFromTemplate: false,
+      createdAt: "2026-08-01T00:00:00.000Z",
+      updatedAt: "2026-08-01T00:00:00.000Z",
+    };
+    const scopedTarget = fileViewerTarget(
+      ".proliferate/context/run-1/03-research-findings.md",
+    );
+    const flatTarget = fileViewerTarget(".proliferate/context/03-research-findings.md");
+    const { result } = renderHook(() => useWorkflowDocOpen("workspace-1"));
+
+    act(() => result.current(doc));
+
+    expect(mocks.openTarget).toHaveBeenCalledWith(scopedTarget);
+    expect(mocks.openTarget).not.toHaveBeenCalledWith(flatTarget);
+    expect(mocks.activateViewerTarget).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      shellWorkspaceId: "logical-workspace-1",
+      target: scopedTarget,
+      mode: "open-or-focus",
+    });
+  });
+});

--- a/apps/packages/product-client/src/hooks/workflows/ui/use-workflow-doc-open.ts
+++ b/apps/packages/product-client/src/hooks/workflows/ui/use-workflow-doc-open.ts
@@ -6,7 +6,10 @@ import { fileViewerTarget } from "#product/lib/domain/workspaces/viewer/viewer-t
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useWorkspaceViewerTabsStore } from "#product/stores/editor/workspace-viewer-tabs-store";
 
-/** Workflow run context docs are real files the runtime writes under this workspace-relative directory. */
+/**
+ * Workflow run context docs are real files the runtime writes under this
+ * workspace-relative directory, one subfolder per run (`<dir>/<runId>/`).
+ */
 const WORKFLOW_CONTEXT_DOCS_DIRECTORY = ".proliferate/context";
 
 /**
@@ -36,7 +39,7 @@ export function useWorkflowDocOpen(workspaceId: string): (doc: WorkflowRunDocV2)
   );
 
   return useCallback((doc: WorkflowRunDocV2) => {
-    const path = `${WORKFLOW_CONTEXT_DOCS_DIRECTORY}/${doc.filename}`;
+    const path = `${WORKFLOW_CONTEXT_DOCS_DIRECTORY}/${doc.runId}/${doc.filename}`;
     const target = fileViewerTarget(path);
     openTarget(target);
 

--- a/lints/anyharness/ratchets.toml
+++ b/lints/anyharness/ratchets.toml
@@ -175,5 +175,5 @@ reason = "workflows gen-2 transition suite: one test per ADR table row plus stal
 
 [[max_lines]]
 path = "anyharness/crates/anyharness-lib/src/live/workflows/lifecycle_tests.rs"
-max_lines = 1070
+max_lines = 1066
 reason = "workflows gen-2 engine lifecycle suite: scripted-ACP agents drive real runs through the manager/actor (happy path, gate approve, flip, redo, undo, boot fence) with zero mocks of our machinery"

--- a/specs/TESTING/scenarios.md
+++ b/specs/TESTING/scenarios.md
@@ -761,7 +761,7 @@ Assert: the PUT materializes a workspace and starts node 1; the research
 node's underlying session prompt carries the runtime's wrapped preamble
 around the raw node prompt (assert the wrapper's presence, not its exact
 text); the findings doc materializes as a real file under
-`.proliferate/context/` in the workspace; the run parks at
+`.proliferate/context/<run_id>/` in the workspace; the run parks at
 `run.status=awaiting_human` with the gate node `awaiting_human` and HOLDS —
 no auto-advance; approving the gate advances the run to `completed`; every
 command (PUT, GET, approve) returns the full projection

--- a/tests/release/src/scenarios/t3-wf-1.ts
+++ b/tests/release/src/scenarios/t3-wf-1.ts
@@ -56,7 +56,7 @@ import type { PlannedCellV1 } from "../runner/result.js";
  *    placement}` materializes a workspace and starts node 1.
  * 2. The agent node's session prompt honors the runtime's wrapped preamble
  *    (assert the wrapper's presence, not its exact text).
- * 3. The findings doc materializes as a REAL file under `.proliferate/context/`
+ * 3. The findings doc materializes as a REAL file under `.proliferate/context/<run_id>/`
  *    in the materialized workspace.
  * 4. The run parks at the human gate: `run.status === "awaiting_human"`, the
  *    gate node is `awaiting_human`, and it HOLDS — no auto-advance.
@@ -89,7 +89,7 @@ export const t3Wf1: MatrixScenarioDefinition = {
     },
     {
       description:
-        `[${cell.cell_id}] the findings doc materializes as a real file under .proliferate/context/ in the ` +
+        `[${cell.cell_id}] the findings doc materializes as a real file under .proliferate/context/<run_id>/ in the ` +
         "materialized workspace",
     },
     {
@@ -383,7 +383,7 @@ async function runResearchAndReviewJourney(
     const workspaces = await runtime.listWorkspaces();
     const workspace = workspaces.find((candidate) => candidate.id === projection.run.workspaceId);
     assert.ok(workspace, "T3-WF-1: the materialized workspace must still be resolvable by id");
-    const docPath = path.join(workspace!.path, ".proliferate", "context", findingsDoc!.filename);
+    const docPath = path.join(workspace!.path, ".proliferate", "context", runId, findingsDoc!.filename);
     const docContent = await readFile(docPath, "utf8");
     assert.ok(docContent.trim().length > 0, `T3-WF-1: the findings doc must be a real, non-empty file at ${docPath}`);
 


### PR DESCRIPTION
## Summary

Rung 1 of the frozen Workflows Follow-up ADR moves workflow context documents from the flat `.proliferate/context/` directory to `.proliferate/context/<runId>/`. Concurrent runs that share a workspace can no longer collide on identical `NN-slug.md` filenames.

## Implementation

- Adds one run-scoped path helper and threads the run ID through planned materialization, PUT acceptance, actor envelope rendering, prompt references, and preamble rendering.
- Updates the ProductClient doc opener to target `.proliferate/context/<runId>/<filename>`.
- Updates the T3 reference scenario and testing record to the run-scoped layout.
- Preserves the parent `.proliferate/context/` git-exclude entry.
- Adds a focused ProductClient regression test that pins both viewer-open calls to the scoped path and rejects the obsolete flat target.

## Testing

- `CARGO_BUILD_JOBS=1 cargo test -p anyharness-lib workflows --lib` — 166 passed, 0 failed.
- `pnpm --filter @proliferate/product-client exec vitest run src/hooks/workflows/ui/use-workflow-doc-open.test.tsx src/lib/access/cloud/workflow-surface-boundary.test.ts --maxWorkers=1` — 3 passed.
- `pnpm --filter @proliferate/release-e2e exec tsx --test src/scenarios/t3-wf-1.test.ts` — 8 passed.
- `pnpm --filter @proliferate/product-client typecheck` — passed.
- `python3 scripts/check_frontend_boundaries.py` — passed.
- `python3 scripts/check_design_attribution.py` — passed.
- `python3 scripts/check_max_lines.py` — passed.
- `python3 scripts/check_docs.py` — passed.
- `git diff --check` — passed.

### TESTING

The path/render invariants are Tier 1. The workflow-domain suite covers materialization, rendering, store, transition, and lifecycle behavior, including the two-run collision negative control. T3 remains planned release coverage; its plan-level assertions are pinned here.

### OBSERVABILITY

No telemetry, log schema, span identity, or error-code behavior changes. Filesystem paths and document contents are not newly emitted.

## Migration

No schema migration or backfill. Context documents are ephemeral, gitignored workspace files. Historical flat files are neither moved nor deleted; newly materialized/current projections use the run-scoped layout.

## Review and reconciliation

- Frozen contract: Workflows Follow-up ADR, 2026-08-17, rung 1 plus erratum 1.
- Original reviewed head: `feed196bf117893c17a6c6338a653e2e7b93f521`.
- Current base: `3b9c1c395282b96cffd793970cd4f7f1a941309c`.
- Current head: `9d90be8f0538e8123b01753de2bca461e2e95008`.
- The two implementation commits are range-diff identical to the reviewed source.
- Independent review finding `WF-R1-001` required focused ProductClient coverage; fixed and delta-reviewed clean in the third commit.
