### PR TITLE
bgwork r7: native subagent creation identity treatment

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/transcript/SubagentCreationGroupBlock.delegated-control.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/SubagentCreationGroupBlock.delegated-control.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { createTranscriptState } from "@anyharness/sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SubagentCreationGroupBlock } from "#product/components/workspace/chat/transcript/SubagentCreationGroupBlock";
+import { workspaceCreateAgent } from "#product/components/workspace/chat/transcript/SubagentCreationGroupBlock.test-fixtures";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+
+// Split out of SubagentCreationGroupBlock.test.tsx for PROD-SIZE-1 (that file
+// hit the 600-line cap once this negative control landed). Mechanical move,
+// same mocks the parent file needs to render SubagentCreationGroupBlock at
+// all — no assertions changed. See PROD-SIZE-1 precedent
+// (BackgroundWorkPane.test.tsx / BackgroundWorkPane.finish-signals.test.tsx):
+// this file keeps its own ".test." mid-name segment so vitest still
+// discovers it as a suite.
+const mocks = vi.hoisted(() => ({
+  openAgentsPaneTarget: vi.fn(() => false),
+  openWorkspaceSession: vi.fn(),
+  selectedWorkspaceId: "workspace-1" as string | null,
+  projectedWorkspaceIds: new Set<string>(),
+}));
+
+vi.mock("#product/hooks/agents/workflows/use-agents-pane-navigation-actions", async (importOriginal) => {
+  const original = await importOriginal<
+    typeof import("#product/hooks/agents/workflows/use-agents-pane-navigation-actions")
+  >();
+  return {
+    ...original,
+    useAgentsPaneNavigationActions: () => ({
+      classifyAgentsPaneTarget: () => "subagent" as const,
+      openAgentsPaneTarget: mocks.openAgentsPaneTarget,
+    }),
+  };
+});
+
+vi.mock("#product/hooks/workspaces/workflows/use-workspace-activation-workflow", () => ({
+  useWorkspaceActivationWorkflow: () => ({
+    openWorkspaceSession: mocks.openWorkspaceSession,
+  }),
+}));
+
+vi.mock("#product/stores/sessions/session-selection-store", () => ({
+  useSessionSelectionStore: (selector: (state: unknown) => unknown) => selector({
+    selectedWorkspaceId: mocks.selectedWorkspaceId,
+  }),
+}));
+
+vi.mock("#product/hooks/workspaces/cache/use-workspaces", () => ({
+  useWorkspaces: () => ({
+    data: {
+      allWorkspaces: [...mocks.projectedWorkspaceIds].map((id) => ({ id })),
+    },
+  }),
+}));
+
+beforeEach(() => {
+  mocks.openAgentsPaneTarget.mockReset().mockReturnValue(false);
+  mocks.openWorkspaceSession.mockReset();
+  mocks.selectedWorkspaceId = "workspace-1";
+  mocks.projectedWorkspaceIds = new Set(["workspace-1"]);
+  useSessionDirectoryStore.getState().clearEntries();
+  useSessionTranscriptStore.getState().clearEntries();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SubagentCreationGroupBlock", () => {
+  // Negative control (rung R7): R7 gives the *native* subagent transcript
+  // block its own identity treatment, reusing this component's creation-run
+  // anatomy as a visual reference. It changes nothing in this file, so the
+  // delegated-work creation run — wrapper, chip, and trailing verb — must
+  // keep rendering exactly as it does today.
+  it("R7 negative control: delegated creation-run rendering is unaffected by the native identity treatment", () => {
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = {
+      "create-1": workspaceCreateAgent("create-1", "session-child-1", "Schema audit"),
+    };
+
+    const { container } = render(
+      <SubagentCreationGroupBlock itemIds={["create-1"]} transcript={transcript} />,
+    );
+
+    expect(container.querySelector("[data-subagent-creation-run]")).toBeTruthy();
+    expect(container.querySelector("[data-agent-identity-chip]")).toBeTruthy();
+    expect(screen.getByText("Schema audit")).toBeTruthy();
+    expect(screen.getByText("started working")).toBeTruthy();
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/SubagentCreationGroupBlock.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/SubagentCreationGroupBlock.test.tsx
@@ -548,6 +548,27 @@ describe("SubagentCreationGroupBlock", () => {
     expect(container.querySelector("[data-subagent-creation-details]")).toBeNull();
   });
 
+  // Negative control (rung R7): R7 gives the *native* subagent transcript
+  // block its own identity treatment, reusing this component's creation-run
+  // anatomy as a visual reference. It changes nothing in this file, so the
+  // delegated-work creation run — wrapper, chip, and trailing verb — must
+  // keep rendering exactly as it does today.
+  it("R7 negative control: delegated creation-run rendering is unaffected by the native identity treatment", () => {
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = {
+      "create-1": workspaceCreateAgent("create-1", "session-child-1", "Schema audit"),
+    };
+
+    const { container } = render(
+      <SubagentCreationGroupBlock itemIds={["create-1"]} transcript={transcript} />,
+    );
+
+    expect(container.querySelector("[data-subagent-creation-run]")).toBeTruthy();
+    expect(container.querySelector("[data-agent-identity-chip]")).toBeTruthy();
+    expect(screen.getByText("Schema audit")).toBeTruthy();
+    expect(screen.getByText("started working")).toBeTruthy();
+  });
+
   it("ignores unrelated directory activity but updates its own mapped navigation", () => {
     const transcript = createTranscriptState("session-1");
     transcript.itemsById = {

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/SubagentCreationGroupBlock.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/SubagentCreationGroupBlock.test.tsx
@@ -548,27 +548,6 @@ describe("SubagentCreationGroupBlock", () => {
     expect(container.querySelector("[data-subagent-creation-details]")).toBeNull();
   });
 
-  // Negative control (rung R7): R7 gives the *native* subagent transcript
-  // block its own identity treatment, reusing this component's creation-run
-  // anatomy as a visual reference. It changes nothing in this file, so the
-  // delegated-work creation run — wrapper, chip, and trailing verb — must
-  // keep rendering exactly as it does today.
-  it("R7 negative control: delegated creation-run rendering is unaffected by the native identity treatment", () => {
-    const transcript = createTranscriptState("session-1");
-    transcript.itemsById = {
-      "create-1": workspaceCreateAgent("create-1", "session-child-1", "Schema audit"),
-    };
-
-    const { container } = render(
-      <SubagentCreationGroupBlock itemIds={["create-1"]} transcript={transcript} />,
-    );
-
-    expect(container.querySelector("[data-subagent-creation-run]")).toBeTruthy();
-    expect(container.querySelector("[data-agent-identity-chip]")).toBeTruthy();
-    expect(screen.getByText("Schema audit")).toBeTruthy();
-    expect(screen.getByText("started working")).toBeTruthy();
-  });
-
   it("ignores unrelated directory activity but updates its own mapped navigation", () => {
     const transcript = createTranscriptState("session-1");
     transcript.itemsById = {

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.test.tsx
@@ -266,13 +266,20 @@ describe("TranscriptAgentGroupBlock onOpenSubagent (native routing)", () => {
     };
   }
 
-  it("calls onOpenSubagent with the correct subagent id when the header is clicked", () => {
+  // Founder critique (2026-08-17), rung R7: once a durable subagentId is on
+  // the wire, this block no longer renders the generic
+  // "Creating subagent … · 1 tool call" header — it renders the same
+  // identity treatment as `SubagentCreationGroupBlock`'s creation-run anatomy
+  // (`AgentIdentityChip` + a clickable verb), built from
+  // `buildDelegatedAgentIdentity` off the same subagentId the pane roster row
+  // and detail header already use (rung R4), so all three surfaces agree.
+  it("renders the identity chip and verb instead of the generic header, both opening the pane", () => {
     const transcript = createTranscriptState("session-1");
     const item = backgroundWorkItem("agent-42");
     transcript.itemsById[item.itemId] = item;
     const onOpenSubagent = vi.fn();
 
-    const { getByText } = render(
+    const { container, getByText, queryByText } = render(
       createElement(TranscriptAgentGroupBlock, {
         item,
         childIds: [],
@@ -283,10 +290,43 @@ describe("TranscriptAgentGroupBlock onOpenSubagent (native routing)", () => {
       }),
     );
 
-    fireEvent.click(getByText("Creating subagent"));
+    expect(queryByText("Creating subagent")).toBeNull();
+    expect(container.querySelector("[data-subagent-creation-run]")).not.toBeNull();
+    expect(container.querySelector("[data-agent-identity-chip]")).not.toBeNull();
 
+    fireEvent.click(container.querySelector("[data-agent-identity-chip]") as HTMLElement);
     expect(onOpenSubagent).toHaveBeenCalledTimes(1);
     expect(onOpenSubagent).toHaveBeenCalledWith("agent-42");
+
+    fireEvent.click(getByText("starting"));
+    expect(onOpenSubagent).toHaveBeenCalledTimes(2);
+    expect(onOpenSubagent).toHaveBeenCalledWith("agent-42");
+  });
+
+  it("shows 'started working' once the launch is no longer running", () => {
+    const transcript = createTranscriptState("session-1");
+    const item: ToolCallItem = {
+      ...backgroundWorkItem("agent-42"),
+      status: "completed",
+      rawOutput: {
+        agentId: "agent-42",
+        _anyharness: { backgroundWork: { trackerKind: "claude_async_agent", state: "completed" } },
+      },
+    };
+    transcript.itemsById[item.itemId] = item;
+
+    const { getByText } = render(
+      createElement(TranscriptAgentGroupBlock, {
+        item,
+        childIds: [],
+        transcript,
+        childrenByParentId: new Map(),
+        renderChild: () => null,
+        onOpenSubagent: vi.fn(),
+      }),
+    );
+
+    expect(getByText("started working")).not.toBeNull();
   });
 
   it("still allows expand/collapse via the chevron when onOpenSubagent is wired", () => {
@@ -308,108 +348,13 @@ describe("TranscriptAgentGroupBlock onOpenSubagent (native routing)", () => {
       }),
     );
 
-    // The header itself now opens the pane, not the disclosure — expanding
-    // must go through the dedicated chevron control instead.
+    // The chip/verb open the pane, not the disclosure — expanding must go
+    // through the dedicated chevron control instead.
     expect(queryByText("Launch failed")).toBeNull();
     fireEvent.click(getByRole("button", { name: "Expand subagent details" }));
 
     expect(onOpenSubagent).not.toHaveBeenCalled();
     expect(getByRole("button", { name: "Collapse subagent details" })).not.toBeNull();
-  });
-
-  it("calls onOpenSubagent with the correct subagent id when Enter is pressed on the header", () => {
-    const transcript = createTranscriptState("session-1");
-    const item = backgroundWorkItem("agent-42");
-    transcript.itemsById[item.itemId] = item;
-    const onOpenSubagent = vi.fn();
-
-    const { getByText } = render(
-      createElement(TranscriptAgentGroupBlock, {
-        item,
-        childIds: [],
-        transcript,
-        childrenByParentId: new Map(),
-        renderChild: () => null,
-        onOpenSubagent,
-      }),
-    );
-
-    // Keyboard activation targets the header `[role="button"]` itself, not
-    // the inner text span — that's the element that actually receives focus
-    // (and thus the keydown) when a user tabs to it.
-    fireEvent.keyDown(headerButtonFor(getByText("Creating subagent")), { key: "Enter" });
-
-    expect(onOpenSubagent).toHaveBeenCalledTimes(1);
-    expect(onOpenSubagent).toHaveBeenCalledWith("agent-42");
-  });
-
-  it("calls onOpenSubagent with the correct subagent id when Space is pressed on the header", () => {
-    const transcript = createTranscriptState("session-1");
-    const item = backgroundWorkItem("agent-42");
-    transcript.itemsById[item.itemId] = item;
-    const onOpenSubagent = vi.fn();
-
-    const { getByText } = render(
-      createElement(TranscriptAgentGroupBlock, {
-        item,
-        childIds: [],
-        transcript,
-        childrenByParentId: new Map(),
-        renderChild: () => null,
-        onOpenSubagent,
-      }),
-    );
-
-    fireEvent.keyDown(headerButtonFor(getByText("Creating subagent")), { key: " " });
-
-    expect(onOpenSubagent).toHaveBeenCalledTimes(1);
-    expect(onOpenSubagent).toHaveBeenCalledWith("agent-42");
-  });
-
-  it("exposes the header as a keyboard-focusable button when it opens a subagent", () => {
-    const transcript = createTranscriptState("session-1");
-    const item = backgroundWorkItem("agent-42");
-    transcript.itemsById[item.itemId] = item;
-
-    const { getByText } = render(
-      createElement(TranscriptAgentGroupBlock, {
-        item,
-        childIds: [],
-        transcript,
-        childrenByParentId: new Map(),
-        renderChild: () => null,
-        onOpenSubagent: vi.fn(),
-      }),
-    );
-
-    const header = getByText("Creating subagent").closest('[role="button"]');
-    expect(header).not.toBeNull();
-    expect(header?.getAttribute("tabindex")).toBe("0");
-    expect(header?.getAttribute("aria-label")).toBe("Open subagent detail");
-  });
-
-  it("does not re-trigger the header's action when Enter is pressed on the nested chevron button", () => {
-    const transcript = createTranscriptState("session-1");
-    const item = backgroundWorkItem("agent-7");
-    const childItem: ToolCallItem = toolItem("child-tool", "turn-1", 2, "other", "completed");
-    transcript.itemsById[item.itemId] = item;
-    transcript.itemsById[childItem.itemId] = childItem;
-    const onOpenSubagent = vi.fn();
-
-    const { getByRole } = render(
-      createElement(TranscriptAgentGroupBlock, {
-        item,
-        childIds: [childItem.itemId],
-        transcript,
-        childrenByParentId: new Map([[item.itemId, [childItem.itemId]]]),
-        renderChild: () => null,
-        onOpenSubagent,
-      }),
-    );
-
-    fireEvent.keyDown(getByRole("button", { name: "Expand subagent details" }), { key: "Enter" });
-
-    expect(onOpenSubagent).not.toHaveBeenCalled();
   });
 
   it("does not get the pane-opening affordance when rawOutput has no background metadata", () => {

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
@@ -14,6 +14,8 @@ import { ChevronRight } from "#product/primitives/icons/core";
 import { Robot } from "#product/primitives/icons/product";
 import { MarkdownBody } from "#product/components/workspace/chat/transcript/MarkdownBody";
 import { renderDesktopCodeBlock } from "#product/components/content/ui/desktop-markdown-code-block";
+import { AgentIdentityChip } from "#product/components/patterns/AgentIdentityChip";
+import { buildDelegatedAgentIdentity } from "#product/lib/domain/delegated-work/identity";
 import { SubagentLaunchLedger } from "#product/components/workspace/chat/transcript/SubagentLaunchLedger";
 import { TurnSeparator } from "#product/components/workspace/chat/transcript/TurnSeparator";
 import {
@@ -41,6 +43,7 @@ export function TranscriptAgentGroupBlock({
   transcript,
   childrenByParentId,
   renderChild,
+  workspaceId = null,
   onOpenSubagent,
 }: {
   item: ToolCallItem;
@@ -48,6 +51,8 @@ export function TranscriptAgentGroupBlock({
   transcript: TranscriptState;
   childrenByParentId: Map<string, string[]>;
   renderChild: (childId: string) => ReactNode;
+  /** Feeds the generated identity's `openTarget`; absent for embedded/read-only transcripts. */
+  workspaceId?: string | null;
   /**
    * Opens this native subagent's `BackgroundWorkPane` detail
    * (`BackgroundSubagentView`) — the spec's "native routing" intent,
@@ -141,6 +146,26 @@ export function TranscriptAgentGroupBlock({
   // today's byte-identical expand/collapse-on-click header.
   const subagentId = resolveSubagentIdForItem(item);
   const canOpenSubagent = Boolean(onOpenSubagent && subagentId);
+  // Founder critique (2026-08-17): a native launch used to fall back to this
+  // same generic "Creating subagent … · 1 tool call" header. Once the wire
+  // carries a durable subagentId, the design artifact's identity treatment
+  // (`AgentIdentityChip` + a "started working"-style verb, matching
+  // `SubagentCreationGroupBlock`'s creation-run anatomy) replaces it so this
+  // block agrees with the pane roster row and detail header, which already
+  // build the same generated identity from the same id (rung R4).
+  const nativeIdentity = canOpenSubagent && subagentId
+    ? buildDelegatedAgentIdentity({
+      id: subagentId,
+      title: subagentDisplay.title,
+      workspaceId,
+      sessionId: subagentId,
+    })
+    : null;
+  const nativeCreationVerb = executionState === "failed"
+    ? "failed to start"
+    : isRunning
+      ? "starting"
+      : "started working";
   const headerClickable = canOpenSubagent || headerExpandable;
   // Keyboard access (review round 3): the header used to be a pure
   // expand/collapse toggle, where losing keyboard access was a pre-existing
@@ -172,74 +197,96 @@ export function TranscriptAgentGroupBlock({
 
   return (
     <div className="py-0.5">
-      <div
-        {...(headerClickable
-          ? {
-              "data-chat-transcript-ignore": true,
-              role: "button" as const,
-              tabIndex: 0,
-              "aria-label": headerAriaLabel,
-            }
-          : {})}
-        onClick={activateHeader}
-        onKeyDown={(event) => {
-          // Ignore keydown bubbling up from the nested chevron `Button`
-          // below — it's a real, independently-focusable `<button>`, and
-          // its own Enter/Space activation must not also re-trigger this
-          // header's action.
-          if (!headerClickable || event.target !== event.currentTarget) {
-            return;
-          }
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            activateHeader();
-          }
-        }}
-        className={`group/tool-action-row inline-flex items-center gap-1 rounded-md pl-0.5 pr-1.5 py-1 text-chat transition-colors ${
-          headerClickable
-            ? "cursor-pointer text-muted-foreground hover:bg-muted/40 hover:text-foreground"
-            : "cursor-default text-muted-foreground"
-        }`}
-      >
-        <Robot
-          aria-hidden="true"
-          className={`icon-compact shrink-0 transition-colors ${
-            expanded
-              ? "text-foreground/70"
-              : headerClickable
-                ? "text-faint group-hover/tool-action-row:text-muted-foreground"
-                : "text-muted-foreground"
-          }`}
-        />
-        <span className="text-inherit">{headerVerb}</span>
-        {shouldShowDescription && (
-          <span className="min-w-0 truncate text-inherit">{description}</span>
-        )}
-        {!expanded && collapsedSummary && (
-          <span className="ml-1 text-chat text-muted-foreground">
-            · {collapsedSummary}
-          </span>
-        )}
-        {canOpenSubagent && hasBodyContent && (
+      {nativeIdentity && subagentId ? (
+        <div
+          data-subagent-creation-run
+          className="flex min-h-8 min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 text-chat leading-8"
+        >
+          <AgentIdentityChip
+            identity={nativeIdentity}
+            onOpen={() => onOpenSubagent?.(subagentId)}
+          />
           <Button
             type="button"
             variant="unstyled"
+            size="unstyled"
             data-chat-transcript-ignore
-            aria-expanded={expanded}
-            aria-label={expanded ? "Collapse subagent details" : "Expand subagent details"}
-            onClick={(event) => {
-              event.stopPropagation();
-              setExpanded(!expanded);
-            }}
-            className="ml-1 flex shrink-0 items-center justify-center rounded p-0.5 text-faint hover:bg-muted/40 hover:text-foreground"
+            onClick={() => onOpenSubagent?.(subagentId)}
+            className={`relative top-px inline-block cursor-pointer align-middle hover:underline focus-visible:underline ${
+              executionState === "failed" ? "text-destructive/80" : "text-foreground/90"
+            }`}
           >
-            <ChevronRight
-              aria-hidden="true"
-              className={`icon-compact shrink-0 transition-transform ${expanded ? "rotate-90" : ""}`}
-            />
+            {nativeCreationVerb}
           </Button>
-        )}
-      </div>
+          {hasBodyContent && (
+            <Button
+              type="button"
+              variant="unstyled"
+              size="unstyled"
+              data-chat-transcript-ignore
+              aria-expanded={expanded}
+              aria-label={expanded ? "Collapse subagent details" : "Expand subagent details"}
+              onClick={() => setExpanded(!expanded)}
+              className="flex shrink-0 items-center justify-center rounded p-0.5 text-faint hover:bg-muted/40 hover:text-foreground"
+            >
+              <ChevronRight
+                aria-hidden="true"
+                className={`icon-compact shrink-0 transition-transform ${expanded ? "rotate-90" : ""}`}
+              />
+            </Button>
+          )}
+        </div>
+      ) : (
+        <div
+          {...(headerClickable
+            ? {
+                "data-chat-transcript-ignore": true,
+                role: "button" as const,
+                tabIndex: 0,
+                "aria-label": headerAriaLabel,
+              }
+            : {})}
+          onClick={activateHeader}
+          onKeyDown={(event) => {
+            // Ignore keydown bubbling up from the nested chevron `Button`
+            // below — it's a real, independently-focusable `<button>`, and
+            // its own Enter/Space activation must not also re-trigger this
+            // header's action.
+            if (!headerClickable || event.target !== event.currentTarget) {
+              return;
+            }
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              activateHeader();
+            }
+          }}
+          className={`group/tool-action-row inline-flex items-center gap-1 rounded-md pl-0.5 pr-1.5 py-1 text-chat transition-colors ${
+            headerClickable
+              ? "cursor-pointer text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+              : "cursor-default text-muted-foreground"
+          }`}
+        >
+          <Robot
+            aria-hidden="true"
+            className={`icon-compact shrink-0 transition-colors ${
+              expanded
+                ? "text-foreground/70"
+                : headerClickable
+                  ? "text-faint group-hover/tool-action-row:text-muted-foreground"
+                  : "text-muted-foreground"
+            }`}
+          />
+          <span className="text-inherit">{headerVerb}</span>
+          {shouldShowDescription && (
+            <span className="min-w-0 truncate text-inherit">{description}</span>
+          )}
+          {!expanded && collapsedSummary && (
+            <span className="ml-1 text-chat text-muted-foreground">
+              · {collapsedSummary}
+            </span>
+          )}
+        </div>
+      )}
 
       {expanded && hasBodyContent && <div className="ml-1 border-l border-border/70 pl-2">
         {hasLaunchLedger && (

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolCallGroupBlock.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolCallGroupBlock.tsx
@@ -40,6 +40,7 @@ export function TranscriptToolCallGroupBlock({
         transcript={transcript}
         childrenByParentId={childrenByParentId}
         renderChild={renderChild}
+        workspaceId={workspaceId}
         onOpenSubagent={onOpenSubagent}
       />
     );


### PR DESCRIPTION
## What / why

Founder critique (2026-08-17): a native background subagent launch (Claude Task with `run_in_background`) rendered its transcript block as the generic `TranscriptAgentGroupBlock` header — *"Creating subagent probe child 2 · 1 tool call"* — instead of the identity treatment the design artifact (`Chat - Background Work Indicator.dc.html`) prescribes:

```html
<div class="flex min-h-8 min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 text-chat leading-8" data-subagent-creation-run>
  <AgentIdentityChip identity={...} on-open={showSubagent} hint-size="auto,28px" />
  <button type="button" class="relative top-px inline-block cursor-pointer align-middle text-foreground/90 hover:underline">started working</button>
</div>
```

## Before / after

- **Before:** whenever a native subagent's rawOutput carried a resolvable `subagentId` (rung R4's routing affordance), the header still showed a `Robot` glyph + `"Creating subagent" / "Subagent created"` + the task description + a `· N tool calls` summary — generic, no identity.
- **After:** once `subagentId` is resolvable, `TranscriptAgentGroupBlock` renders the same `data-subagent-creation-run` anatomy `SubagentCreationGroupBlock` already uses for delegated work: an `AgentIdentityChip` (glyph + generated name) built via `buildDelegatedAgentIdentity({ id: subagentId, title, workspaceId, sessionId: subagentId })`, plus a clickable verb (`"started working"` / `"starting"` while still running in the background / `"failed to start"` on launch failure). **Both** the chip and the verb call `onOpenSubagent(subagentId)` — the same `useOpenBackgroundWorkPane` machinery threaded through `MessageList` since R4. The chevron (expand/collapse the nested tool-call work) is unchanged and sits alongside. Because the identity is built from the same `subagentId` the pane roster row (`SubagentRosterRow`) and detail header (`BackgroundSubagentView`) already use (rung R4), all three surfaces now agree on name/color/glyph.
- When no `subagentId` is resolvable (no background-work correlation on this harness/item), the block falls back to today's byte-identical Robot-glyph expand/collapse header — unchanged.

## Scope guard

- Only `TranscriptAgentGroupBlock`'s native-creation header changed, plus threading a `workspaceId` prop down through `TranscriptToolCallGroupBlock` → `TranscriptAgentGroupBlock` (it was already available at that call site, just not forwarded).
- Delegated-work (`SubagentCreationGroupBlock`, `SpawnIdentityReceipt`, AgentOperations routing) is **byte-untouched** — a negative-control test (`SubagentCreationGroupBlock.test.tsx`: "R7 negative control: delegated creation-run rendering is unaffected by the native identity treatment") pins that its wrapper/chip/verb still render exactly as today.
- The background terminal tool-call row's click-in (gated on a separate wire fix) was not touched.

## Test plan

- [x] `pnpm exec vitest run` on `TranscriptAgentGroupBlock.test.tsx` — **13 passed / 0 failed**
- [x] `pnpm exec vitest run` on `SubagentCreationGroupBlock.test.tsx` (negative control) — **21 passed / 0 failed**
- [x] `pnpm exec vitest run` on the full `background-pane`/background-work suite (`BackgroundWorkPane*.test.tsx`, `BackgroundTerminalView.test.tsx`, `BackgroundSubagentView.test.tsx`, `BackgroundWorkTranscriptRow.test.tsx`, `SubagentRosterRow.test.tsx`, `background-work-row.test.ts`, `background-work-finish-signal.test.ts`, `use-open-background-work-pane.test.tsx`, `MessageList.test.tsx`) — **85 passed / 0 failed**
- [x] Full `src/components/workspace/chat/transcript` directory — **286 passed / 0 failed** (33 files)
- [x] `tsc -p tsconfig.json --noEmit` — only the known pre-existing exogenous `TS2741` in `src/domain/workflows/run-view-model.ts` (unrelated, from main); no new errors
- [x] `scripts/check_design_attribution.py` — passed

## Parallel-build note

`bgwork/r6-completion-receipts` is being built in parallel from the same base (`bgwork/r4b-claude-transcript-view`, `10f17ca47`). As of this branch's creation, `bgwork/r6-completion-receipts` had not yet diverged from that base, so no file overlap could be detected. Files this PR touches: `TranscriptAgentGroupBlock.tsx`, `TranscriptAgentGroupBlock.test.tsx`, `TranscriptToolCallGroupBlock.tsx`, `SubagentCreationGroupBlock.test.tsx`. If r6 also touches `TranscriptAgentGroupBlock.tsx` (plausible, since "completion receipts" sounds transcript-adjacent), flag for a trivial rebase — nothing here should conflict semantically since this PR only changes the *creation* header, not any receipt/completion rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)