### PR TITLE
bgwork r6: inline completion receipts + running-only indicator

### DIFF
--- a/apps/packages/product-client/src/components/workspace/activity/BackgroundCompletionReceipt.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/BackgroundCompletionReceipt.test.tsx
@@ -1,0 +1,126 @@
+/* @vitest-environment jsdom */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BackgroundCompletionReceipt } from "./BackgroundCompletionReceipt";
+import type {
+  SubagentCompletionReceipt,
+  TerminalCompletionReceipt,
+} from "#product/domain/activity/background-completion-receipt";
+
+afterEach(() => {
+  cleanup();
+});
+
+function terminalReceipt(
+  overrides: Partial<TerminalCompletionReceipt> = {},
+): TerminalCompletionReceipt {
+  return {
+    kind: "terminal",
+    key: "terminal:proc-1",
+    processId: "proc-1",
+    command: "pytest -q tests/e2e",
+    exitCode: 0,
+    atMs: 1_000,
+    anchorTurnId: null,
+    ...overrides,
+  };
+}
+
+function subagentReceipt(
+  overrides: Partial<SubagentCompletionReceipt> = {},
+): SubagentCompletionReceipt {
+  return {
+    kind: "subagent",
+    key: "subagent:task-1",
+    subagentId: "task-1",
+    title: "audit the roster",
+    outcome: "completed",
+    atMs: 1_000,
+    anchorTurnId: null,
+    ...overrides,
+  };
+}
+
+describe("BackgroundCompletionReceipt — terminal", () => {
+  it("renders the design markup: exited-code verb + mono command button on the incoming rail", () => {
+    const { container } = render(
+      <BackgroundCompletionReceipt receipt={terminalReceipt()} workspaceId="ws-1" onOpen={() => {}} />,
+    );
+    const rail = container.querySelector('[data-background-completion-receipt="terminal"]');
+    expect(rail).toBeTruthy();
+    const receipt = container.querySelector('[data-agent-message-receipt][data-direction="incoming"]');
+    expect(receipt).toBeTruthy();
+    expect(screen.getByText("exited 0 ·")).toBeTruthy();
+    const button = screen.getByRole("button", { name: "Open terminal pytest -q tests/e2e" });
+    expect(button.className).toContain("font-mono");
+    expect(button.textContent).toBe("pytest -q tests/e2e");
+  });
+
+  it("shows a nonzero exit code in the verb", () => {
+    render(
+      <BackgroundCompletionReceipt
+        receipt={terminalReceipt({ exitCode: 130 })}
+        workspaceId="ws-1"
+        onOpen={() => {}}
+      />,
+    );
+    expect(screen.getByText("exited 130 ·")).toBeTruthy();
+  });
+
+  it("fires onOpen when the command button is clicked (terminal deep-open)", () => {
+    const onOpen = vi.fn();
+    render(
+      <BackgroundCompletionReceipt receipt={terminalReceipt()} workspaceId="ws-1" onOpen={onOpen} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Open terminal pytest -q tests/e2e" }));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("BackgroundCompletionReceipt — subagent", () => {
+  it("renders 'finished ·' + an identity chip keyed by the wire agent id", () => {
+    const { container } = render(
+      <BackgroundCompletionReceipt receipt={subagentReceipt()} workspaceId="ws-1" onOpen={() => {}} />,
+    );
+    expect(container.querySelector('[data-background-completion-receipt="subagent"]')).toBeTruthy();
+    expect(screen.getByText("finished ·")).toBeTruthy();
+    expect(container.querySelector("[data-agent-identity-chip]")).toBeTruthy();
+    expect(screen.getByText("audit the roster")).toBeTruthy();
+  });
+
+  it("renders 'failed ·' for a failed subagent", () => {
+    render(
+      <BackgroundCompletionReceipt
+        receipt={subagentReceipt({ outcome: "failed" })}
+        workspaceId="ws-1"
+        onOpen={() => {}}
+      />,
+    );
+    expect(screen.getByText("failed ·")).toBeTruthy();
+  });
+
+  it("fires onOpen when the identity chip is clicked (subagent deep-open)", () => {
+    const onOpen = vi.fn();
+    render(
+      <BackgroundCompletionReceipt receipt={subagentReceipt()} workspaceId="ws-1" onOpen={onOpen} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Open/ }));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  // Identity-less fallback: a receipt whose subagent id cannot mint a durable
+  // identity (no session id) degrades to the plain title-fallback span, never a
+  // broken chip button.
+  it("falls back to a plain title span when no durable identity can be minted", () => {
+    const { container } = render(
+      <BackgroundCompletionReceipt
+        receipt={subagentReceipt({ subagentId: "" })}
+        workspaceId="ws-1"
+        onOpen={() => {}}
+      />,
+    );
+    expect(container.querySelector("[data-agent-identity-chip]")).toBeNull();
+    expect(container.querySelector("[data-agent-message-fallback]")).toBeTruthy();
+    expect(screen.getByText("audit the roster")).toBeTruthy();
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/activity/BackgroundCompletionReceipt.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/BackgroundCompletionReceipt.tsx
@@ -1,0 +1,86 @@
+import { AgentMessageReceipt } from "#product/components/workspace/chat/transcript/AgentMessageReceipt";
+import { Button } from "#product/primitives/Button";
+import { buildDelegatedAgentIdentity } from "#product/lib/domain/delegated-work/identity";
+import {
+  subagentReceiptVerb,
+  terminalReceiptVerb,
+  type BackgroundCompletionReceipt as BackgroundCompletionReceiptModel,
+} from "#product/domain/activity/background-completion-receipt";
+
+/**
+ * One inline background-work completion receipt in the transcript tail (bgwork
+ * r6). Right-aligned on the incoming rail, per the design artifact ("Chat -
+ * Background Work Indicator").
+ *
+ * - Terminal: `exited {code} ·` + a mono command button that deep-opens the
+ *   Background work pane's `BackgroundTerminalView` for that process.
+ * - Subagent: `finished ·` (or `failed ·`) + the durable `AgentIdentityChip`
+ *   (reused via `AgentMessageReceipt`), keyed by the subagent's wire agent id.
+ *
+ * Both share `AgentMessageReceipt`'s markup (`data-agent-message-receipt`,
+ * incoming direction) so the receipts read identically to the transcript's
+ * existing agent receipts; the terminal variant swaps the chip for a command
+ * button since a background terminal has no agent identity.
+ */
+export function BackgroundCompletionReceipt({
+  receipt,
+  workspaceId,
+  onOpen,
+}: {
+  receipt: BackgroundCompletionReceiptModel;
+  workspaceId: string | null;
+  onOpen: () => void;
+}) {
+  if (receipt.kind === "subagent") {
+    const identity = buildDelegatedAgentIdentity({
+      id: receipt.subagentId,
+      title: receipt.title,
+      workspaceId,
+      sessionId: receipt.subagentId,
+    });
+    return (
+      <div
+        className="flex justify-end"
+        data-agent-origin-prompt
+        data-background-completion-receipt="subagent"
+      >
+        <AgentMessageReceipt
+          direction="incoming"
+          identity={identity}
+          fallbackLabel={receipt.title}
+          verb={subagentReceiptVerb(receipt.outcome)}
+          onOpen={onOpen}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex justify-end"
+      data-agent-origin-prompt
+      data-background-completion-receipt="terminal"
+    >
+      <div
+        data-agent-message-receipt
+        data-direction="incoming"
+        className="flex max-w-[85%] items-center self-end text-right text-chat leading-8"
+      >
+        <span className="relative top-px align-middle text-muted-foreground">
+          {terminalReceiptVerb(receipt.exitCode)}
+        </span>
+        <Button
+          type="button"
+          variant="unstyled"
+          size="unstyled"
+          data-chat-transcript-ignore
+          className="ms-1.5 inline-block min-w-0 max-w-72 shrink cursor-pointer truncate font-mono font-medium text-foreground/80 hover:underline"
+          aria-label={`Open terminal ${receipt.command}`}
+          onClick={onOpen}
+        >
+          {receipt.command}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/packages/product-client/src/components/workspace/activity/BackgroundWorkTranscriptRow.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/BackgroundWorkTranscriptRow.test.tsx
@@ -11,54 +11,38 @@ const PROLIFERATE_MARK_SELECTOR = 'svg[viewBox="300 300 200 200"]';
 const CIRCLE_CHECK_SELECTOR = 'svg[viewBox="0 0 24 24"]';
 
 describe("BackgroundWorkTranscriptRow", () => {
-  it("renders nothing when nothing is running and nothing finished", () => {
+  // Founder ruling (bgwork r6): the row counts RUNNING work only and is not
+  // rendered at count 0. Completed tasks leave the count; the row disappears
+  // at 0. There is no settled/finished display state — completed work is
+  // announced solely by the inline `BackgroundCompletionReceipt` rows.
+  it("renders nothing when nothing is running", () => {
     const { container } = render(
-      <BackgroundWorkTranscriptRow runningCount={0} finishedCount={0} onOpen={() => {}} />,
+      <BackgroundWorkTranscriptRow runningCount={0} onOpen={() => {}} />,
     );
     expect(container.firstChild).toBeNull();
   });
 
   it("renders the singular running copy", () => {
-    render(<BackgroundWorkTranscriptRow runningCount={1} finishedCount={0} onOpen={() => {}} />);
+    render(<BackgroundWorkTranscriptRow runningCount={1} onOpen={() => {}} />);
     expect(screen.getByText("1 background task")).toBeTruthy();
   });
 
   it("renders the plural running copy", () => {
-    render(<BackgroundWorkTranscriptRow runningCount={3} finishedCount={0} onOpen={() => {}} />);
+    render(<BackgroundWorkTranscriptRow runningCount={3} onOpen={() => {}} />);
     expect(screen.getByText("3 background tasks")).toBeTruthy();
   });
 
-  it("renders the static Proliferate mark while running, not CircleCheck", () => {
+  it("renders the static Proliferate mark while running, never CircleCheck", () => {
     const { container } = render(
-      <BackgroundWorkTranscriptRow runningCount={2} finishedCount={0} onOpen={() => {}} />,
+      <BackgroundWorkTranscriptRow runningCount={2} onOpen={() => {}} />,
     );
     expect(container.querySelector(PROLIFERATE_MARK_SELECTOR)).toBeTruthy();
     expect(container.querySelector(CIRCLE_CHECK_SELECTOR)).toBeNull();
   });
 
-  it("renders the settled copy, pluralized, once the running count is zero", () => {
-    render(<BackgroundWorkTranscriptRow runningCount={0} finishedCount={2} onOpen={() => {}} />);
-    expect(screen.getByText("2 background tasks finished")).toBeTruthy();
-  });
-
-  it("renders the singular settled copy", () => {
-    render(<BackgroundWorkTranscriptRow runningCount={0} finishedCount={1} onOpen={() => {}} />);
-    expect(screen.getByText("1 background task finished")).toBeTruthy();
-  });
-
-  it("swaps the glyph to CircleCheck once settled, and rests at text-faint", () => {
+  it("rests at text-muted-foreground and shares one hover treatment between glyph and label", () => {
     const { container } = render(
-      <BackgroundWorkTranscriptRow runningCount={0} finishedCount={1} onOpen={() => {}} />,
-    );
-    expect(container.querySelector(CIRCLE_CHECK_SELECTOR)).toBeTruthy();
-    expect(container.querySelector(PROLIFERATE_MARK_SELECTOR)).toBeNull();
-    const label = screen.getByText("1 background task finished");
-    expect(label.className.split(" ")).toContain("text-faint");
-  });
-
-  it("shares one hover treatment between the glyph wrapper and the label", () => {
-    const { container } = render(
-      <BackgroundWorkTranscriptRow runningCount={1} finishedCount={0} onOpen={() => {}} />,
+      <BackgroundWorkTranscriptRow runningCount={1} onOpen={() => {}} />,
     );
     const label = screen.getByText("1 background task");
     const glyphWrapper = container.querySelector(PROLIFERATE_MARK_SELECTOR)?.parentElement;
@@ -71,24 +55,36 @@ describe("BackgroundWorkTranscriptRow", () => {
     expect(label.className.split(" ")).toContain("text-muted-foreground");
   });
 
-  it("carries no motion class in the running state", () => {
+  it("carries no motion class", () => {
     const { container } = render(
-      <BackgroundWorkTranscriptRow runningCount={1} finishedCount={0} onOpen={() => {}} />,
-    );
-    expect(container.innerHTML).not.toMatch(/animate-|motion-safe:/);
-  });
-
-  it("carries no motion class in the settled state", () => {
-    const { container } = render(
-      <BackgroundWorkTranscriptRow runningCount={0} finishedCount={1} onOpen={() => {}} />,
+      <BackgroundWorkTranscriptRow runningCount={1} onOpen={() => {}} />,
     );
     expect(container.innerHTML).not.toMatch(/animate-|motion-safe:/);
   });
 
   it("fires onOpen when clicked", () => {
     const onOpen = vi.fn();
-    render(<BackgroundWorkTranscriptRow runningCount={1} finishedCount={0} onOpen={onOpen} />);
+    render(<BackgroundWorkTranscriptRow runningCount={1} onOpen={onOpen} />);
     fireEvent.click(screen.getByRole("button", { name: "1 background task" }));
     expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  // NEGATIVE CONTROL: the removed settled state is gone in every arrangement —
+  // no "finished" copy, no CircleCheck glyph, and no `text-faint` settled tone,
+  // whether running is positive or zero.
+  it("never renders the removed settled state (no finished copy, no CircleCheck, no text-faint)", () => {
+    const running = render(
+      <BackgroundWorkTranscriptRow runningCount={2} onOpen={() => {}} />,
+    );
+    expect(running.container.textContent).not.toMatch(/finished/i);
+    expect(running.container.querySelector(CIRCLE_CHECK_SELECTOR)).toBeNull();
+    expect(running.container.innerHTML).not.toContain("text-faint");
+    cleanup();
+
+    // At zero running, the row is absent entirely — the old code would have
+    // shown "N background tasks finished" here.
+    const zero = render(<BackgroundWorkTranscriptRow runningCount={0} onOpen={() => {}} />);
+    expect(zero.container.firstChild).toBeNull();
+    expect(screen.queryByText(/finished/i)).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/components/workspace/activity/BackgroundWorkTranscriptRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/BackgroundWorkTranscriptRow.tsx
@@ -1,19 +1,11 @@
 import type { ReactNode } from "react";
 import { ProliferateIcon } from "#product/primitives/icons/proliferate-icons";
-import { CircleCheck } from "#product/primitives/icons/status";
 import { Button } from "#product/primitives/Button";
-import { twMerge } from "#product/primitives/utils/tw-merge";
 
 export interface BackgroundWorkTranscriptRowProps {
   /** Still-live processes + running native subagents. */
   runningCount: number;
-  /** Finished work still worth reporting once nothing is running. */
-  finishedCount: number;
-  /**
-   * Opens the Background work pane. R1 ships only this row; the pane itself
-   * lands in R2, so callers wire a no-op seam until then — see the
-   * `onOpen={backgroundWorkPaneSeam}` call site.
-   */
+  /** Opens the Background work pane. */
   onOpen: () => void;
 }
 
@@ -23,38 +15,33 @@ function pluralizeTask(count: number): string {
 
 /**
  * The quiet line at the end of the transcript reporting live background work
- * (running bash processes + running native subagents — loops are descoped)
- * and opening the Background work pane on click (Design Handoff —
- * HANDOFF-background-work.md, NEW `BackgroundWorkTranscriptRow`; Delivery
- * Spec — Background Work Slice 1, rung R1). Replaces the docked
- * `ActivityChips` breakdown with one aggregate line — no "running", no
- * "2 terminals, 1 subagent" tail.
+ * (running bash processes + running native subagents — loops are descoped) and
+ * opening the Background work pane on click (Design Handoff —
+ * HANDOFF-background-work.md, NEW `BackgroundWorkTranscriptRow`; Delivery Spec
+ * — Background Work Slice 1, rung R1).
  *
- * No motion in either state: a spinner and the `ProliferateLivingMark`
- * breathing treatment were both tried and rejected. The glyph is static and
- * swaps to `CircleCheck` once settled; the mark and the label always share
- * one hover treatment.
+ * Founder ruling (2026-08-17, bgwork r6): this row counts RUNNING work only,
+ * and is NOT rendered at count 0. Completed tasks leave the count; the row
+ * disappears at 0. There is no settled/finished display state — completed work
+ * is announced solely by the inline `BackgroundCompletionReceipt` rows. The
+ * earlier "N background tasks finished" + `CircleCheck` swap is removed
+ * entirely.
+ *
+ * No motion: a spinner and the `ProliferateLivingMark` breathing treatment were
+ * both tried and rejected. The glyph is static; the mark and the label always
+ * share one hover treatment.
  */
 export function BackgroundWorkTranscriptRow({
   runningCount,
-  finishedCount,
   onOpen,
 }: BackgroundWorkTranscriptRowProps): ReactNode {
-  const running = runningCount > 0;
-  if (!running && finishedCount <= 0) {
+  if (runningCount <= 0) {
     return null;
   }
 
-  const label = running
-    ? pluralizeTask(runningCount)
-    : `${pluralizeTask(finishedCount)} finished`;
-
-  // Settled state rests at `text-faint` instead of `text-muted-foreground`;
-  // both states share the same hover treatment (mark + label light together).
-  const toneClassName = twMerge(
-    running ? "text-muted-foreground" : "text-faint",
-    "transition-colors duration-hover group-hover:text-foreground",
-  );
+  const label = pluralizeTask(runningCount);
+  const toneClassName =
+    "text-muted-foreground transition-colors duration-hover group-hover:text-foreground";
 
   return (
     <Button
@@ -65,11 +52,7 @@ export function BackgroundWorkTranscriptRow({
       className="group flex w-fit items-center gap-2 rounded-md text-chat"
     >
       <span className={toneClassName}>
-        {running ? (
-          <ProliferateIcon className="icon-paired [font-size:var(--text-chat)]" aria-hidden />
-        ) : (
-          <CircleCheck className="icon-paired [font-size:var(--text-chat)]" aria-hidden />
-        )}
+        <ProliferateIcon className="icon-paired [font-size:var(--text-chat)]" aria-hidden />
       </span>
       <span className={toneClassName}>{label}</span>
     </Button>

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.finish-signals.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.finish-signals.test.tsx
@@ -15,11 +15,11 @@ import {
 import { BackgroundWorkPane } from "./BackgroundWorkPane";
 
 // R5 finish-signal ladder concerns: pending-selection consumption, feed
-// isOpen-gating, and the NoticeBanner (dirty/mark-viewed interactions). The
-// roster/scopes/seam/detail-routing coverage lives in the sibling
-// `BackgroundWorkPane.test.tsx` — split for PROD-SIZE-1 (repo-wide 600-line
-// cap); see the fixtures module's docstring. No behavior or assertion
-// changed by the split.
+// isOpen-gating, and the mark-viewed write that clears the tab dirty-dot (the
+// in-pane NoticeBanner was removed in bgwork r6 round 2 — see the negative
+// controls below). The roster/scopes/seam/detail-routing coverage lives in the
+// sibling `BackgroundWorkPane.test.tsx` — split for PROD-SIZE-1 (repo-wide
+// 600-line cap); see the fixtures module's docstring.
 let sessionActivity: SessionActivityState = {
   loops: [],
   loopCapabilities: { supported: false, native: false },
@@ -30,7 +30,7 @@ let rowCounts: BackgroundWorkRowCounts = { runningCount: 0, finishedCount: 0 };
 
 vi.mock("#product/hooks/activity/derived/use-session-activity", () => ({
   useSessionActivity: () => sessionActivity,
-  // `useBackgroundWorkFinishSignal` (feeding this pane's NoticeBanner rung)
+  // `useBackgroundWorkFinishSignal` (feeding this pane's mark-viewed write)
   // reads the per-session accessor rather than the active-session-only one
   // (R5 review round 2 — MAJOR fix). This pane is always scoped to the
   // active session, so mirroring the same fixture here is faithful — the
@@ -216,8 +216,13 @@ describe("BackgroundWorkPane — finish signals", () => {
     ).toBe("true");
   });
 
-  describe("finish-signal ladder rung 2 — NoticeBanner", () => {
-    it("names a finished process, offers View, and View opens its terminal detail", () => {
+  // Founder ruling (bgwork r6 round 2): "we don't want the checkmark + box at
+  // the top of background work." The in-pane NoticeBanner was removed entirely
+  // — completions now read solely as inline transcript receipts. What survives
+  // is the tab dirty-dot's mark-viewed write (R5's dot stays). These are the
+  // negative controls for that removal.
+  describe("finish-signal ladder rung 2 — in-pane NoticeBanner removed", () => {
+    it("does NOT render an in-pane notice banner when a process finishes (the exact scenario that used to show it)", () => {
       sessionActivity = {
         loops: [],
         loopCapabilities: { supported: false, native: false },
@@ -233,18 +238,13 @@ describe("BackgroundWorkPane — finish signals", () => {
       };
       render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
 
-      const notice = document.querySelector("[data-background-work-notice]");
-      expect(notice).not.toBeNull();
-      expect(notice?.textContent).toContain("npm run build");
-
-      fireEvent.click(screen.getByRole("button", { name: "View" }));
-
-      expect(screen.getByTestId("background-terminal-view").getAttribute("data-process-id")).toBe(
-        "proc-done",
-      );
+      expect(document.querySelector("[data-background-work-notice]")).toBeNull();
+      // The banner's "View" action is gone with it (the Closed-scope roster
+      // row keeps its own separate open affordance, tested elsewhere).
+      expect(screen.queryByRole("button", { name: "View" })).toBeNull();
     });
 
-    it("names a finished subagent with no View action (finished subagents have already left the live roster)", () => {
+    it("does NOT render an in-pane notice banner when a native subagent finishes either", () => {
       useWorkspaceUiStore.getState().recordBackgroundWorkFinishedSubagentForSession(
         "sess-1",
         makeAgent({ id: "agent-done", description: "Explore ACP lifecycle", status: { status: "completed", summary: null } }),
@@ -252,50 +252,10 @@ describe("BackgroundWorkPane — finish signals", () => {
       );
       render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
 
-      const notice = document.querySelector("[data-background-work-notice]");
-      expect(notice).not.toBeNull();
-      expect(notice?.textContent).toContain("Explore ACP lifecycle");
-      expect(screen.queryByRole("button", { name: "View" })).toBeNull();
-    });
-
-    it("does not show the notice while the pane is collapsed (mounted, isOpen=false)", () => {
-      sessionActivity = {
-        loops: [],
-        loopCapabilities: { supported: false, native: false },
-        processes: [
-          makeProcess({
-            id: "proc-done",
-            status: { status: "exited", exitCode: 0 },
-            endedAt: "2026-08-17T00:00:05Z",
-          }),
-        ],
-        agents: [],
-      };
-      render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen={false} />);
-
       expect(document.querySelector("[data-background-work-notice]")).toBeNull();
     });
 
-    it("does not show the notice for work that had already finished before the pane was last viewed", () => {
-      useWorkspaceUiStore.getState().markBackgroundWorkViewedForSession("sess-1", Date.parse("2026-08-17T00:00:10Z"));
-      sessionActivity = {
-        loops: [],
-        loopCapabilities: { supported: false, native: false },
-        processes: [
-          makeProcess({
-            id: "proc-stale",
-            status: { status: "exited", exitCode: 0 },
-            endedAt: "2026-08-17T00:00:05Z",
-          }),
-        ],
-        agents: [],
-      };
-      render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
-
-      expect(document.querySelector("[data-background-work-notice]")).toBeNull();
-    });
-
-    it("hides the notice while its matching detail view is open, and shows it again on Back (documented minimal dismissal)", () => {
+    it("still marks the latest finish viewed on mount so the tab dirty-dot clears (R5 dot behavior retained)", () => {
       sessionActivity = {
         loops: [],
         loopCapabilities: { supported: false, native: false },
@@ -309,74 +269,12 @@ describe("BackgroundWorkPane — finish signals", () => {
         agents: [],
       };
       render(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
-      expect(document.querySelector("[data-background-work-notice]")).not.toBeNull();
 
-      // The process is exited, so it only lists under the Closed scope; the
-      // banner's own View action (unlike the roster row) works from
-      // whichever scope happens to be showing.
-      fireEvent.click(screen.getByRole("button", { name: "View" }));
-      expect(document.querySelector("[data-background-work-notice]")).toBeNull();
-
-      fireEvent.click(screen.getByRole("button", { name: "Back to background work" }));
-      expect(document.querySelector("[data-background-work-notice]")).not.toBeNull();
-    });
-
-    it("does not flicker away on its own re-renders while the pane stays open (frozen-at-mount baseline)", () => {
-      sessionActivity = {
-        loops: [],
-        loopCapabilities: { supported: false, native: false },
-        processes: [
-          makeProcess({
-            id: "proc-done",
-            status: { status: "exited", exitCode: 0 },
-            endedAt: "2026-08-17T00:00:05Z",
-          }),
-        ],
-        agents: [],
-      };
-      const { rerender } = render(
-        <BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />,
-      );
-      expect(document.querySelector("[data-background-work-notice]")).not.toBeNull();
-
-      // The mark-viewed-on-mount effect has by now advanced the LIVE
-      // `backgroundWorkLastViewedAtBySession["sess-1"]` past this signal's
-      // `atMs` — re-rendering with unchanged props must not read that live
-      // value, or the banner would vanish on its own the instant after it
-      // appeared.
-      rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />);
-      expect(document.querySelector("[data-background-work-notice]")).not.toBeNull();
-    });
-
-    it("does not leak a stale finished signal or baseline into a freshly switched-to session", () => {
-      sessionActivity = {
-        loops: [],
-        loopCapabilities: { supported: false, native: false },
-        processes: [
-          makeProcess({
-            id: "proc-done",
-            status: { status: "exited", exitCode: 0 },
-            endedAt: "2026-08-17T00:00:05Z",
-          }),
-        ],
-        agents: [],
-      };
-      const { rerender } = render(
-        <BackgroundWorkPane workspaceId="ws-1" sessionId="sess-1" isOpen />,
-      );
-      expect(document.querySelector("[data-background-work-notice]")).not.toBeNull();
-
-      // A real session switch also switches the roster `useSessionActivity`
-      // reports — the new session has its own (here: empty) activity, not
-      // sess-1's finished process.
-      sessionActivity = {
-        loops: [],
-        loopCapabilities: { supported: false, native: false },
-        processes: [],
-        agents: [],
-      };
-      rerender(<BackgroundWorkPane workspaceId="ws-1" sessionId="sess-2" isOpen />);
-      expect(document.querySelector("[data-background-work-notice]")).toBeNull();
+      // The mark-viewed effect advanced the live baseline to this finish's
+      // atMs — the tab dot the pane's mount is meant to clear.
+      expect(
+        useWorkspaceUiStore.getState().backgroundWorkLastViewedAtBySession["sess-1"],
+      ).toBe(Date.parse("2026-08-17T00:00:05Z"));
     });
   });
 });

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.test.tsx
@@ -15,10 +15,10 @@ import {
 import { BackgroundWorkPane } from "./BackgroundWorkPane";
 
 // Roster/scopes/seam/detail-routing coverage. The R5 finish-signal ladder
-// concerns (NoticeBanner, pending-selection consumption, feed isOpen-gating)
-// live in the sibling `BackgroundWorkPane.finish-signals.test.tsx` — split
-// for PROD-SIZE-1 (repo-wide 600-line cap); see the fixtures module's
-// docstring.
+// concerns (the removed in-pane NoticeBanner's negative controls,
+// pending-selection consumption, feed isOpen-gating) live in the sibling
+// `BackgroundWorkPane.finish-signals.test.tsx` — split for PROD-SIZE-1
+// (repo-wide 600-line cap); see the fixtures module's docstring.
 let sessionActivity: SessionActivityState = {
   loops: [],
   loopCapabilities: { supported: false, native: false },
@@ -29,7 +29,7 @@ let rowCounts: BackgroundWorkRowCounts = { runningCount: 0, finishedCount: 0 };
 
 vi.mock("#product/hooks/activity/derived/use-session-activity", () => ({
   useSessionActivity: () => sessionActivity,
-  // `useBackgroundWorkFinishSignal` (feeding this pane's NoticeBanner rung)
+  // `useBackgroundWorkFinishSignal` (feeding this pane's mark-viewed write)
   // reads the per-session accessor rather than the active-session-only one
   // (R5 review round 2 — MAJOR fix). This pane is always scoped to the
   // active session, so mirroring the same fixture here is faithful — the

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundWorkPane.tsx
@@ -1,9 +1,6 @@
 import { useEffect, useState } from "react";
 import { SegmentedControl, type SegmentedControlItem } from "#product/primitives/SegmentedControl";
 import { RosterPanel } from "#product/primitives/patterns/RosterPanel";
-import { NoticeBanner } from "#product/primitives/patterns/NoticeBanner";
-import { Button } from "#product/primitives/Button";
-import { CircleCheck } from "#product/primitives/icons/status";
 import { AgentsRosterPanel } from "#product/components/workspace/activity/AgentsRosterPanel";
 import { LiveTerminalsRosterPanel } from "#product/components/workspace/activity/LiveTerminalsRosterPanel";
 import { BackgroundTerminalView } from "#product/components/workspace/activity/background-pane/BackgroundTerminalView";
@@ -11,9 +8,7 @@ import { BackgroundSubagentView } from "#product/components/workspace/activity/b
 import { useSessionActivity } from "#product/hooks/activity/derived/use-session-activity";
 import { useBackgroundWorkRowCounts } from "#product/hooks/activity/derived/use-background-work-row";
 import { useBackgroundWorkFinishSignal } from "#product/hooks/activity/derived/use-background-work-finish-signal";
-import { deriveBackgroundWorkDirty } from "#product/domain/activity/background-work-finish-signal";
-import { isProcessRunning, processStatusLabel } from "#product/domain/activity/process";
-import { subagentDisplayTitle, subagentStatusLabel } from "#product/domain/activity/subagent";
+import { isProcessRunning } from "#product/domain/activity/process";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 
 // Same 15s cadence as the shared `useActivityNowMs`, but reimplemented locally
@@ -55,17 +50,6 @@ export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: Backgroun
   const [scope, setScope] = useState<BackgroundWorkScope>("running");
   const [selectedSubagentId, setSelectedSubagentId] = useState<string | null>(null);
   const [selectedProcessId, setSelectedProcessId] = useState<string | null>(null);
-  // The finish-signal ladder rung 2 (`NoticeBanner`) baseline — see the note
-  // where this is consumed below for why it must be a snapshot rather than a
-  // live store read. Reset alongside everything else in the per-session
-  // effect just below rather than relying solely on a lazy `useState`
-  // initializer: the real call site remounts this component on session
-  // switch (`RightPanelContent` — `key={activeSessionId}`), but this
-  // component's own reset should not silently depend on every caller doing
-  // that.
-  const [lastViewedAtMsBeforeThisMount, setLastViewedAtMsBeforeThisMount] = useState<number | null>(
-    () => useWorkspaceUiStore.getState().backgroundWorkLastViewedAtBySession[sessionId] ?? null,
-  );
   // Session-scoped by design (handoff — "Out of scope: workspace-level
   // persistence"): switching the active session resets the scope and closes
   // any open detail seam rather than carrying another session's selection.
@@ -73,9 +57,6 @@ export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: Backgroun
     setScope("running");
     setSelectedSubagentId(null);
     setSelectedProcessId(null);
-    setLastViewedAtMsBeforeThisMount(
-      useWorkspaceUiStore.getState().backgroundWorkLastViewedAtBySession[sessionId] ?? null,
-    );
   }, [sessionId]);
 
   // The roster subscription (`useSessionActivity`) that used to live on
@@ -168,46 +149,51 @@ export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: Backgroun
     workspaceId,
   ]);
 
-  // Finish-signal ladder rung 2 (`NoticeBanner`, Design Handoff —
-  // "When one finishes: Pane notice"): visible only while this pane is both
-  // mounted AND actually open (not CSS-collapsed via `WorkspaceShellRightRail`),
-  // and only above the roster — the process/subagent detail views below are
-  // a full swap of this component's return, so opening either one already
-  // removes the banner with no extra state ("clears when the user opens
-  // the named detail").
-  //
-  // The "frozen at mount" baseline is deliberate: the mark-viewed effect
-  // right below keeps nudging the LIVE `lastViewedAtMs` forward for as
-  // long as the pane stays mounted (so the tab dot never re-lights for a
-  // finish this pane already showed live) — comparing the banner's own
-  // visibility against that same live value would make it flip false on
-  // the very next render after appearing. Comparing against a value
-  // snapshotted once per session (see `lastViewedAtMsBeforeThisMount`
-  // above), avoids that self-erasing race.
-  //
-  // Minimal dismissal semantics (handoff is silent on the exact rule):
-  // the banner is hidden for as long as either detail view is open (a full
-  // swap of this return), and reappears if the user presses Back to the
-  // roster within the SAME session (same baseline) — nothing tracks "the
-  // user already saw this one" beyond that. It fully, permanently clears
-  // only on tab-away (unmount) or a session switch (fresh baseline).
+  // Terminal deep-open target (bgwork r6): a background terminal's completion
+  // receipt (`BackgroundCompletionReceipt`) opens straight to its
+  // `BackgroundTerminalView` through `useOpenBackgroundTerminalDetail`, which
+  // writes a one-shot pending process selection into the same right-panel
+  // model. Same single-writer/single-reader, session-checked consume-and-clear
+  // discipline as the subagent selection above — a process id from a different
+  // session in this workspace is discarded rather than applied to this
+  // session's roster lookup.
+  const pendingProcessSelection = useWorkspaceUiStore(
+    (state) => state.pendingBackgroundProcessSelectionByWorkspace[workspaceId] ?? null,
+  );
+  const clearPendingBackgroundProcessSelectionForWorkspace = useWorkspaceUiStore(
+    (state) => state.clearPendingBackgroundProcessSelectionForWorkspace,
+  );
+  useEffect(() => {
+    if (!pendingProcessSelection) {
+      return;
+    }
+    if (pendingProcessSelection.sessionId === sessionId) {
+      setSelectedProcessId(pendingProcessSelection.processId);
+    }
+    clearPendingBackgroundProcessSelectionForWorkspace(workspaceId);
+  }, [
+    clearPendingBackgroundProcessSelectionForWorkspace,
+    pendingProcessSelection,
+    sessionId,
+    workspaceId,
+  ]);
+
+  // Finish-signal ladder rung 2, tab dirty-dot half (Design Handoff — "When
+  // one finishes"): the in-pane NoticeBanner was removed on founder ruling
+  // (bgwork r6 round 2 — "we don't want the checkmark + box at the top of
+  // background work"; completions now read solely as inline transcript
+  // receipts). What stays is the mark-viewed write that clears the tab's
+  // dirty dot: mounting this pane IS selecting the Background work tab, so —
+  // "clears on select" (handoff, verbatim) — the latest finish is marked
+  // viewed unconditionally (not gated on `isOpen`, independent of whether the
+  // right rail is CSS-collapsed at that instant).
   const finishSignalState = useBackgroundWorkFinishSignal(sessionId);
   const markBackgroundWorkViewedForSession = useWorkspaceUiStore(
     (state) => state.markBackgroundWorkViewedForSession,
   );
-  // "Clears on select" (handoff, verbatim) — mounting this pane IS
-  // selecting the Background work tab, independent of whether the whole
-  // right rail happens to be CSS-collapsed at that instant, so this runs
-  // unconditionally rather than gating on `isOpen`.
   useEffect(() => {
     markBackgroundWorkViewedForSession(sessionId, finishSignalState.signal?.atMs);
   }, [sessionId, finishSignalState.signal?.atMs, markBackgroundWorkViewedForSession]);
-
-  const showBackgroundWorkNotice = isOpen && deriveBackgroundWorkDirty({
-    latestFinishAtMs: finishSignalState.signal?.atMs ?? null,
-    lastViewedAtMs: lastViewedAtMsBeforeThisMount,
-  });
-  const noticeSignal = showBackgroundWorkNotice ? finishSignalState.signal : null;
 
   if (selectedProcess) {
     return (
@@ -268,41 +254,6 @@ export function BackgroundWorkPane({ workspaceId, sessionId, isOpen }: Backgroun
           onChange={setScope}
         />
       </header>
-      {noticeSignal ? (
-        <div className="shrink-0 px-3 pt-2" data-background-work-notice="">
-          {noticeSignal.kind === "process" ? (
-            <NoticeBanner
-              tone="neutral"
-              icon={<CircleCheck className="text-success" />}
-              action={
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setSelectedProcessId(noticeSignal.process.id)}
-                >
-                  View
-                </Button>
-              }
-            >
-              {noticeSignal.process.command} — {processStatusLabel(noticeSignal.process)}
-            </NoticeBanner>
-          ) : (
-            // No View action here — see the "subagent-View-action"
-            // contradiction in the R5 PR body. `BackgroundWorkPane.test.tsx`
-            // pins the roster-bounce-back behavior for any selected subagent
-            // id the live roster can't resolve, and a finished native
-            // subagent has, by definition, already left that live roster
-            // (locked design, `chips.ts`) — there is no live detail seam
-            // left to open. The banner still names what finished.
-            <NoticeBanner
-              tone="neutral"
-              icon={<CircleCheck className="text-success" />}
-            >
-              {subagentDisplayTitle(noticeSignal.subagent)} — {subagentStatusLabel(noticeSignal.subagent)}
-            </NoticeBanner>
-          )}
-        </div>
-      ) : null}
       <div className="min-h-0 flex-1 overflow-y-auto px-1 py-2">
         <div className="flex flex-col gap-3">
           {scope === "running" ? (

--- a/apps/packages/product-client/src/components/workspace/chat/surface/SessionTranscriptPane.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/surface/SessionTranscriptPane.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import type { ReactNode } from "react";
-import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { replaySessionHistory } from "#product/lib/domain/sessions/stream/stream-state";
 import { SessionTranscriptPane } from "#product/components/workspace/chat/surface/SessionTranscriptPane";
@@ -31,37 +31,27 @@ const hydrationMocks = vi.hoisted(() => ({
   rehydrateSessionSlotFromHistory: vi.fn(),
 }));
 
-// Heavy leaf UI is not under test — the deferred content_stable hand-off is.
-// The mock echoes the two inset props it received as data attributes so
-// dock-reactivity (the background-work row staying live-reactive to
-// bottomInsetPx/nonDisplacingBottomInsetPx) can be asserted without needing
-// the real virtualized transcript. It also exposes two plain buttons that
-// invoke `onIsPinnedToBottomChange`, standing in for the REAL stick-to-bottom
-// engine's reported pin state — this suite doesn't mount the real virtualized
-// row list, so it can't fire a genuine scroll event.
+// Heavy leaf UI is not under test — the deferred content_stable hand-off is,
+// plus (bgwork r6 round 2) the pane's remaining background-work responsibility:
+// forwarding the live running count and completion receipts down as MessageList
+// props. The row and receipts are now real in-scroll transcript rows rendered
+// INSIDE MessageList (covered by the transcript-row-model + MessageList tests),
+// so the pane no longer floats a band or augments the inset to reserve one. The
+// mock echoes the props it receives as data attributes.
 vi.mock("#product/components/workspace/chat/transcript/MessageList", () => ({
   MessageList: (props: {
     bottomInsetPx: number;
     nonDisplacingBottomInsetPx: number;
-    onIsPinnedToBottomChange?: (isPinnedToBottom: boolean) => void;
+    backgroundWorkRunningCount?: number;
+    completionReceipts?: readonly { key: string }[];
   }) => (
-    <>
-      <div
-        data-testid="message-list"
-        data-bottom-inset-px={props.bottomInsetPx}
-        data-non-displacing-bottom-inset-px={props.nonDisplacingBottomInsetPx}
-      />
-      <button
-        type="button"
-        data-testid="simulate-scroll-away"
-        onClick={() => props.onIsPinnedToBottomChange?.(false)}
-      />
-      <button
-        type="button"
-        data-testid="simulate-scroll-to-bottom"
-        onClick={() => props.onIsPinnedToBottomChange?.(true)}
-      />
-    </>
+    <div
+      data-testid="message-list"
+      data-bottom-inset-px={props.bottomInsetPx}
+      data-non-displacing-bottom-inset-px={props.nonDisplacingBottomInsetPx}
+      data-background-work-running-count={props.backgroundWorkRunningCount ?? 0}
+      data-completion-receipt-count={props.completionReceipts?.length ?? 0}
+    />
   ),
 }));
 vi.mock("#product/components/workspace/chat/plans/ConnectedPlanHandoffDialog", () => ({
@@ -96,17 +86,12 @@ vi.mock("#product/hooks/workspaces/derived/use-workspace-creation-receipt", () =
   useWorkspaceCreationReceiptKey: () => null,
 }));
 const backgroundWorkMocks = vi.hoisted(() => ({
-  openBackgroundWorkPane: vi.fn(),
   rowCounts: { runningCount: 0, finishedCount: 0 },
 }));
-// Requires ProductHostProvider (`useWorkspaceFileContext` -> `useWorkspaces`)
-// via real host wiring that is out of scope for this diagnostics-timing
-// suite; the mechanism itself is covered by
-// use-open-background-work-pane.test.tsx. Here we only need to assert the
-// transcript row's `onOpen` is wired to whatever this hook returns.
-vi.mock("#product/hooks/activity/workflows/use-open-background-work-pane", () => ({
-  useOpenBackgroundWorkPane: () => backgroundWorkMocks.openBackgroundWorkPane,
-}));
+// The pane's only remaining background-work read is the live running count it
+// forwards to MessageList; the open-pane actions moved down to MessageList
+// alongside the rows themselves (covered by use-open-background-work-pane.test
+// and the MessageList render path).
 vi.mock("#product/hooks/activity/derived/use-background-work-row", () => ({
   useBackgroundWorkRowCounts: () => backgroundWorkMocks.rowCounts,
 }));
@@ -129,7 +114,6 @@ beforeEach(() => {
   useSessionTranscriptStore.getState().clearEntries();
   useSessionSelectionStore.getState().deselectWorkspacePreservingSessions();
   backgroundWorkMocks.rowCounts = { runningCount: 0, finishedCount: 0 };
-  backgroundWorkMocks.openBackgroundWorkPane.mockClear();
 });
 
 afterEach(() => {
@@ -256,174 +240,50 @@ describe("SessionTranscriptPane deferred workspace_open content_stable", () => {
   });
 });
 
-describe("SessionTranscriptPane background-work row (carried R1 items)", () => {
-  it("passes the live, unclamped bottomInsetPx/nonDisplacingBottomInsetPx through to MessageList even while the row is visible (carried item 1: dock-reactivity)", () => {
+describe("SessionTranscriptPane background-work wiring (in-flow rows, bgwork r6 round 2)", () => {
+  it("passes the live, unclamped bottomInsetPx/nonDisplacingBottomInsetPx straight through to MessageList — the running-count row is now an in-scroll transcript row, so the pane no longer augments the inset to reserve a floating band", () => {
     backgroundWorkMocks.rowCounts = { runningCount: 2, finishedCount: 0 };
     beginDeferredColdOpen();
     render(<SessionTranscriptPane bottomInsetPx={64} nonDisplacingBottomInsetPx={8} />);
 
     const messageList = screen.getByTestId("message-list");
+    // Unaugmented: exactly the props it was handed (round-2 supersedes the R2
+    // inset-reserve that used to add the measured row height here).
     expect(messageList.getAttribute("data-bottom-inset-px")).toBe("64");
     expect(messageList.getAttribute("data-non-displacing-bottom-inset-px")).toBe("8");
-    expect(screen.getByText("2 background tasks")).toBeTruthy();
   });
 
-  it("still passes the same inset values through when there is no background work", () => {
-    backgroundWorkMocks.rowCounts = { runningCount: 0, finishedCount: 0 };
-    beginDeferredColdOpen();
-    render(<SessionTranscriptPane bottomInsetPx={64} nonDisplacingBottomInsetPx={8} />);
-
-    const messageList = screen.getByTestId("message-list");
-    expect(messageList.getAttribute("data-bottom-inset-px")).toBe("64");
-    expect(messageList.getAttribute("data-non-displacing-bottom-inset-px")).toBe("8");
-    expect(screen.queryByText(/background task/)).toBeNull();
-  });
-
-  it("wires the transcript row's onOpen to the background-work-pane open action (carried R1 seam, R2 wiring)", () => {
-    backgroundWorkMocks.rowCounts = { runningCount: 1, finishedCount: 0 };
+  it("threads the live running count down to MessageList, which renders the tail footer row in-flow", () => {
+    backgroundWorkMocks.rowCounts = { runningCount: 2, finishedCount: 0 };
     beginDeferredColdOpen();
     render(<SessionTranscriptPane bottomInsetPx={0} nonDisplacingBottomInsetPx={0} />);
 
-    fireEvent.click(screen.getByText("1 background task"));
-
-    expect(backgroundWorkMocks.openBackgroundWorkPane).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByTestId("message-list").getAttribute("data-background-work-running-count"),
+    ).toBe("2");
   });
 
-  // The row is real content sitting ABOVE MessageList's own reserved
-  // end-padding, not a scrim inside it — its own height must be reserved
-  // too, or it paints over the last turn's tail. jsdom's
-  // `getBoundingClientRect` returns all-zero rects by default, so this test
-  // spies it to a fixed, nonzero row height to exercise the real
-  // measure -> augment -> anchor wiring (the actual pixel geometry is proven
-  // end-to-end by the throwaway Playwright fixture, not by this unit test).
-  it("reserves the row's own measured height on top of the live bottomInsetPx, and anchors the row at the raw bottomInsetPx regardless of nonDisplacing", () => {
-    backgroundWorkMocks.rowCounts = { runningCount: 1, finishedCount: 0 };
-    const rectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
-      height: 32,
-      width: 0,
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      x: 0,
-      y: 0,
-      toJSON: () => ({}),
-    } as DOMRect);
-    try {
-      beginDeferredColdOpen();
-      render(<SessionTranscriptPane bottomInsetPx={64} nonDisplacingBottomInsetPx={8} />);
-
-      const messageList = screen.getByTestId("message-list");
-      // Augmented total fed to MessageList = 64 + 32 (row height).
-      expect(messageList.getAttribute("data-bottom-inset-px")).toBe("96");
-      expect(messageList.getAttribute("data-non-displacing-bottom-inset-px")).toBe("8");
-
-      const rowAnchor = screen.getByTestId("background-work-row-anchor");
-      // Anchored at the raw bottomInsetPx (64), NOT `bottomInsetPx -
-      // nonDisplacing` (56) — the last real row's distance from the
-      // viewport's bottom is `bottomInsetPx`, constant regardless of the
-      // nonDisplacing/structural split, because the composer's scrim overlay
-      // (`VirtualTranscriptViewport`'s `top-full` sibling div) extends the
-      // scrollable region by exactly `nonDisplacing` past the shrunk
-      // `structural` paddingEnd. Anchoring at the structural share alone
-      // (56) would reopen an 8px gap — confirmed via Playwright measurement
-      // (see the throwaway fixture in the PR description).
-      expect(rowAnchor.style.bottom).toBe("64px");
-    } finally {
-      rectSpy.mockRestore();
-    }
-  });
-
-  it("does not augment MessageList's bottomInsetPx when there is no background work, even if a stale row height was measured earlier", () => {
+  it("passes the same plain inset through and a zero running count when there is no background work — no floating band, no reserved padding", () => {
     backgroundWorkMocks.rowCounts = { runningCount: 0, finishedCount: 0 };
     beginDeferredColdOpen();
     render(<SessionTranscriptPane bottomInsetPx={64} nonDisplacingBottomInsetPx={8} />);
 
     const messageList = screen.getByTestId("message-list");
     expect(messageList.getAttribute("data-bottom-inset-px")).toBe("64");
+    expect(messageList.getAttribute("data-non-displacing-bottom-inset-px")).toBe("8");
+    expect(messageList.getAttribute("data-background-work-running-count")).toBe("0");
+    // Negative control: the retired R1/R2 floating band anchor is gone — the
+    // pane no longer renders any background-work element of its own.
     expect(screen.queryByTestId("background-work-row-anchor")).toBeNull();
   });
 
-  // A floating row that stays visible while the user has scrolled away from
-  // the bottom would paint over arbitrary mid-transcript content, so the row
-  // must hide the instant the transcript is no longer pinned to bottom,
-  // reusing the SAME `isPinnedToBottom` signal the stick-to-bottom engine
-  // already computes (reported here via the mocked MessageList's
-  // `onIsPinnedToBottomChange`, standing in for a real scroll). The reserve
-  // stays constant across pin flips; only the row's render reacts to pin —
-  // shrinking `paddingEnd` on unpin isn't covered by the stick-to-bottom
-  // engine's non-user-scroll guard (keyed only on `autoFollowBottomInsetPx`,
-  // not this row's height), so a live shrink could strand the viewport at
-  // zero distance-from-bottom but unpinned. The reserved band is below the
-  // fold and invisible while unpinned regardless, so there is no visible
-  // cost to keeping it constant for as long as background work exists.
-  it("hides the row (but keeps the reserved inset) the instant the transcript scrolls away from the bottom, then restores the row on return to bottom", () => {
-    backgroundWorkMocks.rowCounts = { runningCount: 1, finishedCount: 0 };
-    const rectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
-      height: 32,
-      width: 0,
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      x: 0,
-      y: 0,
-      toJSON: () => ({}),
-    } as DOMRect);
-    try {
-      beginDeferredColdOpen();
-      render(<SessionTranscriptPane bottomInsetPx={64} nonDisplacingBottomInsetPx={8} />);
+  it("forwards the session's completion receipts (empty with no observed completions) as a MessageList prop rather than rendering them itself", () => {
+    backgroundWorkMocks.rowCounts = { runningCount: 0, finishedCount: 0 };
+    beginDeferredColdOpen();
+    render(<SessionTranscriptPane bottomInsetPx={0} nonDisplacingBottomInsetPx={0} />);
 
-      // Pinned by default: row present, inset augmented by its measured height.
-      expect(screen.getByTestId("background-work-row-anchor")).toBeTruthy();
-      expect(screen.getByTestId("message-list").getAttribute("data-bottom-inset-px")).toBe("96");
-
-      // Scrolled away: only the row disappears — the reserve stays augmented
-      // (it's below the fold, invisible while unpinned, and must not shrink
-      // paddingEnd mid-scroll purely from unpinning).
-      fireEvent.click(screen.getByTestId("simulate-scroll-away"));
-      expect(screen.queryByTestId("background-work-row-anchor")).toBeNull();
-      expect(screen.getByTestId("message-list").getAttribute("data-bottom-inset-px")).toBe("96");
-
-      // Back to bottom: the row reappears; the inset was never disturbed.
-      fireEvent.click(screen.getByTestId("simulate-scroll-to-bottom"));
-      expect(screen.getByTestId("background-work-row-anchor")).toBeTruthy();
-      expect(screen.getByTestId("message-list").getAttribute("data-bottom-inset-px")).toBe("96");
-    } finally {
-      rectSpy.mockRestore();
-    }
-  });
-
-  it("drops the reserved inset to the plain bottomInsetPx only when background work itself ends, even while unpinned", () => {
-    backgroundWorkMocks.rowCounts = { runningCount: 1, finishedCount: 0 };
-    const rectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
-      height: 32,
-      width: 0,
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      x: 0,
-      y: 0,
-      toJSON: () => ({}),
-    } as DOMRect);
-    try {
-      beginDeferredColdOpen();
-      const { rerender } = render(
-        <SessionTranscriptPane bottomInsetPx={64} nonDisplacingBottomInsetPx={8} />,
-      );
-
-      fireEvent.click(screen.getByTestId("simulate-scroll-away"));
-      expect(screen.getByTestId("message-list").getAttribute("data-bottom-inset-px")).toBe("96");
-
-      // Background work itself ends (independent of pin state): the reserve
-      // must drop back to the plain bottomInsetPx — no ghost band.
-      backgroundWorkMocks.rowCounts = { runningCount: 0, finishedCount: 0 };
-      rerender(<SessionTranscriptPane bottomInsetPx={64} nonDisplacingBottomInsetPx={8} />);
-      expect(screen.getByTestId("message-list").getAttribute("data-bottom-inset-px")).toBe("64");
-      expect(screen.queryByTestId("background-work-row-anchor")).toBeNull();
-    } finally {
-      rectSpy.mockRestore();
-    }
+    expect(
+      screen.getByTestId("message-list").getAttribute("data-completion-receipt-count"),
+    ).toBe("0");
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/surface/SessionTranscriptPane.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/surface/SessionTranscriptPane.tsx
@@ -3,22 +3,16 @@ import { DebugProfiler } from "#product/components/diagnostics/DebugProfiler";
 import { useActiveTranscriptPaneState } from "#product/hooks/chat/derived/use-active-session-transcript-state";
 import { useDebugRenderCount } from "#product/hooks/ui/debug/use-debug-render-count";
 import { MessageList } from "#product/components/workspace/chat/transcript/MessageList";
-import { BackgroundWorkTranscriptRow } from "#product/components/workspace/activity/BackgroundWorkTranscriptRow";
 import { ConnectedPlanHandoffDialog } from "#product/components/workspace/chat/plans/ConnectedPlanHandoffDialog";
 import { usePlanHandoffDialogState } from "#product/hooks/plans/ui/use-plan-handoff-dialog-state";
 import { useBackgroundWorkRowCounts } from "#product/hooks/activity/derived/use-background-work-row";
+import { useBackgroundCompletionReceipts } from "#product/hooks/activity/derived/use-background-completion-receipts";
 import { useBackgroundWorkFinishSignalTracking } from "#product/hooks/activity/lifecycle/use-background-work-finish-signal-tracking";
-import { useOpenBackgroundWorkPane } from "#product/hooks/activity/workflows/use-open-background-work-pane";
-import { useResizeObserverHeight } from "#product/hooks/ui/layout/use-resize-observer-height";
 import { useSessionHistoryHydration } from "#product/hooks/sessions/lifecycle/use-session-history-hydration";
 import { useTranscriptSessionNavigationActions } from "#product/hooks/chat/workflows/use-transcript-session-navigation-actions";
 import { useWorkspaceCreationReceiptKey } from "#product/hooks/workspaces/derived/use-workspace-creation-receipt";
 import { TranscriptSwitchingPlaceholder } from "#product/components/workspace/chat/surface/TranscriptSwitchingPlaceholder";
 import type { GoalTranscriptEvent } from "#product/domain/activity/goal-transcript-events";
-import {
-  CHAT_COLUMN_CLASSNAME,
-  CHAT_SURFACE_GUTTER_CLASSNAME,
-} from "#product/config/chat-layout";
 import { logLatency } from "#product/lib/infra/measurement/measurement-port";
 import { finishDeferredWorkspaceOpenForSession } from "#product/lib/infra/diagnostics/renderer-flow-timing";
 import {
@@ -46,49 +40,28 @@ export function SessionTranscriptPane({
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
   const handoff = usePlanHandoffDialogState();
   const backgroundWorkRowCounts = useBackgroundWorkRowCounts();
-  const hasBackgroundWork = backgroundWorkRowCounts.runningCount > 0
-    || backgroundWorkRowCounts.finishedCount > 0;
-  const openBackgroundWorkPane = useOpenBackgroundWorkPane();
-  // Review fix (bgwork R2 round 2): the row is a real content element sitting
-  // ABOVE MessageList's own reserved end-padding, not decoration inside it —
-  // so its own height must ALSO be reserved, or it paints over the last
-  // turn's tail (see the comment at the row's render site below for the
-  // full geometry). Measure it live rather than hardcoding a row height:
-  // the row's rendered height moves with the appearance-scaling multiplier.
-  const { ref: backgroundWorkRowRef, height: backgroundWorkRowHeightPx } =
-    useResizeObserverHeight<HTMLDivElement>();
-  // Review fix (bgwork R2 round 3): round 2 fixed the AT-BOTTOM overlap but
-  // left the row floating over arbitrary mid-transcript content once the
-  // user scrolled away — it is `position: absolute` in a static wrapper, so
-  // it never tracked scroll. The handoff's own semantics settle this: the row
-  // is a line at the END of the transcript, so scrolling away from the end
-  // should hide it, exactly like the floating "scroll to bottom" button it
-  // sits beside. Reuse that SAME signal (`useTranscriptStickToBottom`'s
-  // `isPinnedToBottom`, already threaded out through
-  // MessageList/ChatTranscriptView/the row lists as
-  // `onIsPinnedToBottomChange` — no parallel scroll listener) rather than
-  // inventing a second one. Starts `true`: the engine itself defaults pinned
-  // and re-pins on session entry, so a fresh mount is at the bottom until
-  // proven otherwise.
-  const [isPinnedToBottom, setIsPinnedToBottom] = useState(true);
-  const isBackgroundWorkRowVisible = hasBackgroundWork && isPinnedToBottom;
-  // The reserve keys on `hasBackgroundWork`, not on the row's visibility:
-  // shrinking `paddingEnd` on unpin isn't covered by
-  // `use-transcript-stick-to-bottom`'s non-user-scroll guard (keyed only on
-  // `autoFollowBottomInsetPx`), so the clamp-driven scroll event would strand
-  // the viewport at bottom-but-unpinned with auto-follow off. The band is
-  // below the fold while unpinned, so the constant reserve has no visible
-  // cost. Accepted residual: if `hasBackgroundWork` itself flips false while
-  // the user is parked unpinned within this reserved band, the same
-  // uncovered structural shrink can still occur — a pre-existing guard gap
-  // shared with any composer-driven inset change, out of this rung's scope.
-  const messageListBottomInsetPx = hasBackgroundWork
-    ? bottomInsetPx + backgroundWorkRowHeightPx
-    : bottomInsetPx;
   const { rehydrateSessionSlotFromHistory } = useSessionHistoryHydration();
   const [olderHistoryLoadingSessionId, setOlderHistoryLoadingSessionId] = useState<string | null>(null);
   const immediatePaneState = useActiveTranscriptPaneState();
   const workspaceReceiptKey = useWorkspaceCreationReceiptKey();
+  // Inline completion receipts (bgwork r6, in-flow placement r6 round 2):
+  // synthesized from the active session's activity fold — a terminal that exits
+  // or a native subagent that finishes yields a right-aligned receipt that
+  // MessageList interleaves into the transcript row sequence (as a real
+  // in-scroll row), anchored to the turn that was latest when it was observed
+  // so it reads in stream order before the wake turn. Keyed on the IMMEDIATE
+  // session id, same as the finish-signal tracking below, so a completion is
+  // never missed while the heavier transcript render catches up to a session
+  // switch; the anchor turn is likewise read off the immediate transcript.
+  const immediateLatestTurnId = immediatePaneState.transcript
+    ? immediatePaneState.transcript.turnOrder[
+      immediatePaneState.transcript.turnOrder.length - 1
+    ] ?? null
+    : null;
+  const completionReceipts = useBackgroundCompletionReceipts(
+    immediatePaneState.activeSessionId,
+    immediateLatestTurnId,
+  );
   // Finish-signal ladder (rung R5): the only place that observes a native
   // subagent disappearing from the roster, which is the only way to ever
   // learn it finished (session-activity-architecture — subagents leave the
@@ -116,16 +89,6 @@ export function SessionTranscriptPane({
   const activeSessionId = transcriptDeferred
     ? null
     : immediatePaneState.activeSessionId;
-  // Insurance for the session-switch window: `SessionTranscriptPane` itself
-  // is not remounted per session (no `key`), so a stale `isPinnedToBottom`
-  // from the PREVIOUS session's scrolled-up state could otherwise hide the
-  // row for one frame in a brand-new, pinned-by-default session before the
-  // row list's own reset-for-session effect reports back. `MessageList`'s
-  // own reset already re-pins internally; this just keeps this pane's
-  // gating state from lagging it.
-  useEffect(() => {
-    setIsPinnedToBottom(true);
-  }, [activeSessionId]);
   const optimisticPrompt = transcriptDeferred
     ? null
     : immediatePaneState.optimisticPrompt;
@@ -284,71 +247,13 @@ export function SessionTranscriptPane({
 
   return (
     <DebugProfiler id="session-transcript-pane">
-      {/* `relative` anchor for the background-work row below: R1 fed
-          MessageList a clamped `bottomInsetPx={0}` while this row was
-          visible so an external flex-sibling-plus-spacer partition could
-          place the row without double-reserving the composer's clearance —
-          that clamp severed the live composer-dock height from MessageList's
-          own re-pin effect (`VirtualizedTranscriptRowList`'s
-          `useLayoutEffect` re-pins on `totalContentHeight`, which is derived
-          from the SAME `bottomInsetPx` via the virtualizer's `paddingEnd`),
-          so a dock card growing while idle+pinned could clip the last turn
-          until the next unrelated resize (carried R1 item 1).
-          Fix round 1: stop clamping — MessageList gets the real, live
-          `bottomInsetPx`/`nonDisplacingBottomInsetPx` exactly as it does on
-          every other session, restoring that reactivity for free (no
-          separate "force a re-pin" hook needed: the existing effect already
-          keys off this same prop's downstream value). Review round 2 caught
-          that round 1's row placement painted OVER the last turn's tail
-          instead of clearing it: `bottomInsetPx` splits into a `structural`
-          share (real, reserved-as-blank scroll space — the virtualizer's
-          `paddingEnd`) and a `nonDisplacing` share (the composer's own
-          translucent overlap zone, which is DELIBERATELY allowed to sit over
-          the last turn's tail — see `useChatDockInset`'s
-          `composerSurfaceOffsetTopPx`). Anchoring the row at the full
-          `bottomInsetPx` placed its entire box inside the content-occupied
-          range (everything above `structural`), regardless of
-          `nonDisplacing` — the row is real, distinct content, not a scrim,
-          so it may not share that overlap allowance.
-          Fix round 2: feed MessageList `bottomInsetPx` PLUS the row's own
-          live-measured height while it is visible — reserving one extra
-          band the exact size of the row, immediately above where content
-          used to stop. Round 2 anchored the row at `bottom:
-          structuralBottomInsetPx` (`bottomInsetPx - nonDisplacing`),
-          reasoning the row must not share the composer's overlap allowance.
-          That reasoning about the ALLOWANCE was right but the ARITHMETIC was
-          wrong: `VirtualTranscriptViewport` renders the nonDisplacing scrim
-          as a sibling overlay (`top-full`, i.e. positioned at the content
-          div's OWN bottom edge) that EXTENDS the scrollable region by exactly
-          `nonDisplacing` past the shrunk `structural` paddingEnd — so the
-          last real row's distance from the viewport's bottom edge, once
-          pinned, is `structural + nonDisplacing`, i.e. the CONSTANT
-          `bottomInsetPx` regardless of the split (confirmed via fresh
-          Playwright measurement: anchoring at `structuralBottomInsetPx`
-          reopened a gap of exactly `nonDisplacingBottomInsetPx`, e.g. 24px
-          with a 24px composer scrim, while the round-2 fixture's own "dock
-          card" scenario never actually varied `nonDisplacingBottomInsetPx`
-          off zero, so it never exercised the split and never caught this).
-          Fix round 3 (renumbered; corrects round 2's anchor arithmetic
-          above): anchor at the plain `bottom: bottomInsetPx` — the row's box
-          then exactly fills the newly-reserved band regardless of how much
-          of `bottomInsetPx` is `nonDisplacing`: its bottom edge sits
-          precisely where content used to end (a fixed `bottomInsetPx` above
-          the viewport's bottom, composer scrim or not) and its top edge is
-          exactly where content now ends post-augmentation.
-          The row is `position: absolute` in this static-height wrapper, so
-          scrolled away from bottom it would float over arbitrary
-          mid-transcript content — hence gated on `isBackgroundWorkRowVisible`
-          (`hasBackgroundWork && isPinnedToBottom`), with `isPinnedToBottom`
-          reported upward via `onIsPinnedToBottomChange`, the SAME state the
-          stick-to-bottom engine already computes for the in-list
-          scroll-to-bottom button (no second scroll listener). See
-          `messageListBottomInsetPx` above for why the reserve itself does
-          NOT share this gate.
-          This still does not achieve the handoff's literal "last row of the
-          transcript column" in-scroll placement (an actual virtualized row)
-          — that remains out of this rung's scope; see the PR body. */}
-      <div className="relative flex min-h-0 flex-1 flex-col">
+      {/* Background-work completion receipts and the running-count footer are
+          real in-scroll transcript rows (bgwork r6 round 2, superseding R1's
+          dock-anchored floating band): MessageList interleaves each receipt
+          after its anchor turn and appends the footer at the tail, so both
+          scroll with content and need no external reserve, anchor arithmetic,
+          or pinned-to-bottom visibility gating. */}
+      <div className="flex min-h-0 flex-1 flex-col">
         <MessageList
           activeSessionId={activeSessionId}
           selectedWorkspaceId={selectedWorkspaceId}
@@ -357,36 +262,19 @@ export function SessionTranscriptPane({
           outboxEntries={outboxEntries}
           transcript={transcript}
           goalEvents={goalEvents}
+          completionReceipts={completionReceipts}
+          backgroundWorkRunningCount={backgroundWorkRowCounts.runningCount}
           sessionViewState={sessionViewState}
           hasOlderHistory={hasOlderHistory}
           isLoadingOlderHistory={isLoadingOlderHistory}
           olderHistoryCursor={oldestLoadedEventSeq}
-          bottomInsetPx={messageListBottomInsetPx}
+          bottomInsetPx={bottomInsetPx}
           nonDisplacingBottomInsetPx={nonDisplacingBottomInsetPx}
           onLoadOlderHistory={loadOlderHistory}
-          onIsPinnedToBottomChange={setIsPinnedToBottom}
           onHandOffPlanToNewSession={handoff.open}
           onOpenSession={openTranscriptSession}
           canOpenSession={canOpenTranscriptSession}
         />
-        {isBackgroundWorkRowVisible && (
-          <div
-            ref={backgroundWorkRowRef}
-            data-testid="background-work-row-anchor"
-            className={`absolute inset-x-0 ${CHAT_SURFACE_GUTTER_CLASSNAME}`}
-            style={{ bottom: bottomInsetPx }}
-          >
-            <div
-              className={`${CHAT_COLUMN_CLASSNAME} pt-transcript-turn-tight pb-2`}
-            >
-              <BackgroundWorkTranscriptRow
-                runningCount={backgroundWorkRowCounts.runningCount}
-                finishedCount={backgroundWorkRowCounts.finishedCount}
-                onOpen={openBackgroundWorkPane}
-              />
-            </div>
-          </div>
-        )}
       </div>
       {handoff.plan && (
         <ConnectedPlanHandoffDialog

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/ChatTranscriptView.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/ChatTranscriptView.tsx
@@ -31,6 +31,8 @@ export function ChatTranscriptView({
   renderPendingPromptTrailingStatus,
   renderTurnTrailingStatus,
   renderGoalEventRow,
+  renderCompletionReceiptRow,
+  renderBackgroundWorkRow,
   contentSearch,
   scrollHandleRef,
 }: ChatTranscriptViewProps) {
@@ -66,6 +68,8 @@ export function ChatTranscriptView({
     renderPendingPromptRow,
     renderTurnRow,
     renderGoalEventRow,
+    renderCompletionReceiptRow,
+    renderBackgroundWorkRow,
     selectedWorkspaceId: model.selectedWorkspaceId,
     sessionViewState: model.sessionViewState,
     transcript: model.transcript,

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.test.tsx
@@ -98,6 +98,7 @@ vi.mock("#product/hooks/cowork/workflows/use-open-cowork-artifact", () => ({
 
 vi.mock("#product/hooks/activity/workflows/use-open-background-work-pane", () => ({
   useOpenBackgroundWorkPane: () => vi.fn(),
+  useOpenBackgroundTerminalDetail: () => vi.fn(),
 }));
 
 vi.mock("#product/hooks/ui/debug/use-debug-render-count", () => ({

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.tsx
@@ -12,7 +12,10 @@ import { CHAT_SCROLL_BASE_BOTTOM_PADDING_PX } from "#product/config/chat-layout"
 import { useWorkspaceFileActions } from "#product/hooks/workspaces/facade/files/use-workspace-file-actions";
 import { useDebugRenderCount } from "#product/hooks/ui/debug/use-debug-render-count";
 import { useOpenCoworkArtifact } from "#product/hooks/cowork/workflows/use-open-cowork-artifact";
-import { useOpenBackgroundWorkPane } from "#product/hooks/activity/workflows/use-open-background-work-pane";
+import {
+  useOpenBackgroundTerminalDetail,
+  useOpenBackgroundWorkPane,
+} from "#product/hooks/activity/workflows/use-open-background-work-pane";
 import type { PromptPlanAttachmentDescriptor } from "#product/domain/chats/composer/prompt-plan-attachments";
 import type { PromptOutboxEntry } from "#product/domain/sessions/intents/session-intent-model";
 import { usePromptOutboxActions } from "#product/hooks/chat/workflows/use-prompt-outbox-actions";
@@ -24,10 +27,13 @@ import type {
 } from "@anyharness/sdk";
 import type { SessionViewState } from "#product/domain/sessions/activity";
 import type { GoalTranscriptEvent } from "#product/domain/activity/goal-transcript-events";
+import type { BackgroundCompletionReceipt } from "#product/domain/activity/background-completion-receipt";
 import {
   ChatTranscriptView,
 } from "#product/components/workspace/chat/transcript/ChatTranscriptView";
 import type {
+  ChatTranscriptBackgroundWorkRenderInput,
+  ChatTranscriptCompletionReceiptRenderInput,
   ChatTranscriptGoalEventRenderInput,
   ChatTranscriptPendingPromptRenderInput,
   ChatTranscriptPendingStatusInput,
@@ -35,6 +41,8 @@ import type {
   ChatTranscriptTurnRowRenderInput,
   ChatTranscriptTurnStatusInput,
 } from "#product/hooks/chat/ui/chat-transcript-view-types";
+import { BackgroundCompletionReceipt as BackgroundCompletionReceiptRow } from "#product/components/workspace/activity/BackgroundCompletionReceipt";
+import { BackgroundWorkTranscriptRow } from "#product/components/workspace/activity/BackgroundWorkTranscriptRow";
 import { useContentSearchStore } from "#product/stores/search/content-search-store";
 import { useChatTranscriptContentSearch } from "#product/hooks/chat/lifecycle/use-chat-transcript-content-search";
 import {
@@ -61,6 +69,7 @@ import { useTranscriptScrollSample } from "#product/hooks/chat/ui/use-transcript
 
 const EMPTY_OUTBOX_ENTRIES: readonly PromptOutboxEntry[] = [];
 const EMPTY_GOAL_EVENTS: readonly GoalTranscriptEvent[] = [];
+const EMPTY_COMPLETION_RECEIPTS: readonly BackgroundCompletionReceipt[] = [];
 type PlanHandoffHandler = (plan: PromptPlanAttachmentDescriptor) => void;
 
 // INPUT-PRIORITY (the "typing must never be laggy" rule): WHILE THE USER IS
@@ -82,6 +91,14 @@ interface MessageListProps {
   sessionViewState: SessionViewState;
   goalEvents?: readonly GoalTranscriptEvent[];
   workspaceReceiptKey?: string | null;
+  /**
+   * Inline background-work completion receipts, interleaved into the row
+   * sequence by anchor turn (bgwork r6 round 2). The host pane synthesizes
+   * these from the immediate session's activity fold.
+   */
+  completionReceipts?: readonly BackgroundCompletionReceipt[];
+  /** Live background-work count driving the quiet tail footer row. */
+  backgroundWorkRunningCount?: number;
   hasOlderHistory?: boolean;
   isLoadingOlderHistory?: boolean;
   olderHistoryCursor?: number | null;
@@ -111,6 +128,8 @@ export function MessageList({
   sessionViewState,
   goalEvents = EMPTY_GOAL_EVENTS,
   workspaceReceiptKey = null,
+  completionReceipts = EMPTY_COMPLETION_RECEIPTS,
+  backgroundWorkRunningCount = 0,
   hasOlderHistory = false,
   isLoadingOlderHistory = false,
   olderHistoryCursor = null,
@@ -140,6 +159,10 @@ export function MessageList({
   // detail via the same hook `BackgroundWorkTranscriptRow`'s seam already
   // uses — no parallel mechanism.
   const openBackgroundWorkPane = useOpenBackgroundWorkPane();
+  // Terminal receipts deep-open the Background work pane straight to their
+  // process's `BackgroundTerminalView` (bgwork r6); subagent receipts and the
+  // footer row reuse `openBackgroundWorkPane`.
+  const openBackgroundTerminalDetail = useOpenBackgroundTerminalDetail();
   const transcriptViewState = useMemo<ChatTranscriptState>(() => ({
     activeSessionId,
     selectedWorkspaceId,
@@ -149,6 +172,8 @@ export function MessageList({
     sessionViewState,
     goalEvents,
     workspaceReceiptKey,
+    completionReceipts,
+    backgroundWorkRunningCount,
     history: {
       hasOlderHistory,
       isLoadingOlderHistory,
@@ -161,7 +186,9 @@ export function MessageList({
     },
   }), [
     activeSessionId,
+    backgroundWorkRunningCount,
     bottomInsetPx,
+    completionReceipts,
     nonDisplacingBottomInsetPx,
     goalEvents,
     hasOlderHistory,
@@ -320,6 +347,34 @@ export function MessageList({
   const renderGoalEventRow = useCallback((input: ChatTranscriptGoalEventRenderInput) => (
     <GoalTranscriptEventRow event={input.event} />
   ), []);
+  const renderCompletionReceiptRow = useCallback(
+    (input: ChatTranscriptCompletionReceiptRenderInput) => {
+      const { receipt } = input;
+      return (
+        <BackgroundCompletionReceiptRow
+          receipt={receipt}
+          workspaceId={selectedWorkspaceId}
+          onOpen={() => {
+            if (receipt.kind === "terminal") {
+              openBackgroundTerminalDetail(receipt.processId, activeSessionId);
+            } else {
+              openBackgroundWorkPane(receipt.subagentId, activeSessionId);
+            }
+          }}
+        />
+      );
+    },
+    [activeSessionId, openBackgroundTerminalDetail, openBackgroundWorkPane, selectedWorkspaceId],
+  );
+  const renderBackgroundWorkRow = useCallback(
+    (input: ChatTranscriptBackgroundWorkRenderInput) => (
+      <BackgroundWorkTranscriptRow
+        runningCount={input.runningCount}
+        onOpen={() => openBackgroundWorkPane()}
+      />
+    ),
+    [openBackgroundWorkPane],
+  );
   // Stable renderer identities — required for DeferredChatTranscriptView's
   // memo to bail out on urgent (typing) passes.
   const renderPendingPromptTrailingStatusRow = useCallback(
@@ -367,6 +422,8 @@ export function MessageList({
                     renderPendingPromptRow={renderPendingPromptRow}
                     renderTurnRow={renderTurnRow}
                     renderGoalEventRow={renderGoalEventRow}
+                    renderCompletionReceiptRow={renderCompletionReceiptRow}
+                    renderBackgroundWorkRow={renderBackgroundWorkRow}
                     renderPendingPromptTrailingStatus={renderPendingPromptTrailingStatusRow}
                     renderTurnTrailingStatus={renderTurnTrailingStatusRow}
                     contentSearch={contentSearchPaint}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.test.tsx
@@ -92,6 +92,7 @@ describe("frontier status box", () => {
     hasTrailingStatus: false,
     rowIsLastTurnRow: true,
     isLatestTurnInProgress: true,
+    turnIsActivelyStreaming: true,
     assistantRevealComplete: true,
   };
 
@@ -114,6 +115,37 @@ describe("frontier status box", () => {
       assistantRevealComplete: false,
       hasTrailingStatus: true,
     })).toBe("hidden");
+  });
+
+  it("hides the reserve on a dropped-tail wake turn once the session goes idle (R5)", () => {
+    // The runtime drops the wake turn's completion tail, so isLatestTurnInProgress
+    // stays true forever; only genuine stream liveness may reserve the band. An
+    // idle session (turnIsActivelyStreaming false) must resolve "hidden" so no
+    // dead ~44-56px gap sits between the settled prose and the timestamp footer.
+    expect(resolveTurnFrontierStatusMode({
+      ...base,
+      turnIsActivelyStreaming: false,
+    })).toBe("hidden");
+  });
+
+  it("keeps the reserve while the latest turn is genuinely streaming (working)", () => {
+    // isLatestTurnInProgress AND turnIsActivelyStreaming both true: unchanged
+    // anti-jitter reserve through the whole live turn.
+    expect(resolveTurnFrontierStatusMode({
+      ...base,
+      isLatestTurnInProgress: true,
+      turnIsActivelyStreaming: true,
+    })).toBe("reserved");
+  });
+
+  it("shows a real trailing status regardless of liveness (e.g. a needs_input pause)", () => {
+    // A permission-pause turn is not actively streaming, but its interaction
+    // indicator is a trailing status, so "status" wins before the reserve branch.
+    expect(resolveTurnFrontierStatusMode({
+      ...base,
+      hasTrailingStatus: true,
+      turnIsActivelyStreaming: false,
+    })).toBe("status");
   });
 });
 

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
@@ -22,6 +22,7 @@ import { hostsSynthesizedReceiptDisclosure } from "#product/components/workspace
 import {
   findTailAssistantProseRootId,
   getAssistantProseContent,
+  resolveTurnAssistantFooterModeForRow,
   resolveTurnPromptTiming,
 } from "#product/domain/chats/transcript/transcript-rendering";
 import {
@@ -39,7 +40,6 @@ import {
 } from "#product/domain/chats/transcript/turn-stopped-presentation";
 import {
   resolveTranscriptTurnDiffPanelKind,
-  resolveTurnAssistantFooterMode,
   resolveTurnFrontierStatusMode,
   shouldRenderAssistantEndResource,
   shouldRenderStandaloneStoppedNotice,
@@ -182,16 +182,26 @@ export function TranscriptTurnRow({
   // The end-of-turn diff panel is completion-only and renders BELOW the final
   // prose, directly above that footer — it appears in the same paint as the
   // footer swap, so nothing shifts under a live stream.
-  const assistantFooterMode = resolveTurnAssistantFooterMode({
+  // The runtime drops the completion tail (item_completed + turn_ended) for
+  // injected wake turns, so the footer cannot rely on turn/item completion
+  // stamps. The session's own view state is the authority for "still live":
+  // only the latest turn of a session that is actively "working" is genuinely
+  // streaming. A reloaded or idle session leaves this false, so a dropped-tail
+  // wake message becomes copyable.
+  const turnIsActivelyStreaming = isLatestTurn && sessionViewState === "working";
+  const assistantFooterMode = resolveTurnAssistantFooterModeForRow({
     rowIsLastTurnRow: row.isLastTurnRow,
-    turnCompleted: !!turn.completedAt,
-    hasAssistantCopyContent: !!tailAssistantCopyContent,
+    turn,
+    transcript,
+    presentation,
     assistantRevealComplete,
+    turnIsActivelyStreaming,
   });
   const frontierStatusMode = resolveTurnFrontierStatusMode({
     hasTrailingStatus: trailingStatus !== null && trailingStatus !== undefined,
     rowIsLastTurnRow: row.isLastTurnRow,
     isLatestTurnInProgress,
+    turnIsActivelyStreaming,
     assistantRevealComplete,
   });
   const revertPatchesMutation = useRevertGitPatchesMutation({ workspaceId: selectedWorkspaceId });

--- a/apps/packages/product-client/src/domain/activity/background-completion-receipt.test.ts
+++ b/apps/packages/product-client/src/domain/activity/background-completion-receipt.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import type { ActivityProcessWire } from "./process";
+import type { ActivitySubagentWire } from "./subagent";
+import {
+  deriveNewCompletionReceipts,
+  subagentReceiptKey,
+  subagentReceiptVerb,
+  terminalReceiptKey,
+  terminalReceiptVerb,
+} from "./background-completion-receipt";
+
+function process(overrides: Partial<ActivityProcessWire> = {}): ActivityProcessWire {
+  return {
+    id: "proc-1",
+    command: "pytest -q tests/e2e",
+    cwd: null,
+    status: { status: "running" },
+    pid: null,
+    startedAt: "2026-08-17T00:00:00.000Z",
+    endedAt: null,
+    feed: null,
+    ...overrides,
+  };
+}
+
+function agent(overrides: Partial<ActivitySubagentWire> = {}): ActivitySubagentWire {
+  return {
+    id: "task-1",
+    agentType: "general",
+    description: "audit the roster",
+    model: null,
+    background: true,
+    status: { status: "running" },
+    usage: null,
+    feed: null,
+    ...overrides,
+  };
+}
+
+const NOW = 1_000;
+
+describe("terminalReceiptVerb / subagentReceiptVerb", () => {
+  it("renders the exit code in the terminal verb, matching the design artifact", () => {
+    expect(terminalReceiptVerb(0)).toBe("exited 0 ·");
+    expect(terminalReceiptVerb(130)).toBe("exited 130 ·");
+    expect(terminalReceiptVerb(null)).toBe("exited ·");
+  });
+
+  it("uses finished/failed for the subagent verb", () => {
+    expect(subagentReceiptVerb("completed")).toBe("finished ·");
+    expect(subagentReceiptVerb("failed")).toBe("failed ·");
+  });
+});
+
+describe("deriveNewCompletionReceipts", () => {
+  it("emits a terminal receipt when a running process exits", () => {
+    const exited = process({
+      status: { status: "exited", exitCode: 0 },
+      endedAt: "2026-08-17T00:01:00.000Z",
+    });
+    const receipts = deriveNewCompletionReceipts({
+      previousRunningProcessIds: new Set(["proc-1"]),
+      previousRunningAgentsById: new Map(),
+      processes: [exited],
+      agents: [],
+      alreadyReceiptedKeys: new Set(),
+      anchorTurnId: "turn-1",
+      nowMs: NOW,
+    });
+    expect(receipts).toEqual([
+      {
+        kind: "terminal",
+        key: terminalReceiptKey("proc-1"),
+        processId: "proc-1",
+        command: "pytest -q tests/e2e",
+        exitCode: 0,
+        atMs: Date.parse("2026-08-17T00:01:00.000Z"),
+        anchorTurnId: "turn-1",
+      },
+    ]);
+  });
+
+  it("emits a subagent receipt when a running subagent vanishes from the roster", () => {
+    const previous = agent({ id: "task-1" });
+    const receipts = deriveNewCompletionReceipts({
+      previousRunningProcessIds: new Set(),
+      previousRunningAgentsById: new Map([["task-1", previous]]),
+      processes: [],
+      agents: [],
+      alreadyReceiptedKeys: new Set(),
+      anchorTurnId: "turn-1",
+      nowMs: NOW,
+    });
+    expect(receipts).toEqual([
+      {
+        kind: "subagent",
+        key: subagentReceiptKey("task-1"),
+        subagentId: "task-1",
+        title: "audit the roster",
+        outcome: "completed",
+        atMs: NOW,
+        anchorTurnId: "turn-1",
+      },
+    ]);
+  });
+
+  // The anchor turn stamped in is the one that was latest when the completion
+  // was folded — the row model interleaves the receipt right after it so it
+  // reads before the wake turn (bgwork r6 round 2).
+  it("stamps each receipt with the anchor turn passed in", () => {
+    const exited = process({ status: { status: "exited", exitCode: 0 } });
+    const [receipt] = deriveNewCompletionReceipts({
+      previousRunningProcessIds: new Set(["proc-1"]),
+      previousRunningAgentsById: new Map(),
+      processes: [exited],
+      agents: [],
+      alreadyReceiptedKeys: new Set(),
+      anchorTurnId: "turn-agent-42",
+      nowMs: NOW,
+    });
+    expect(receipt.anchorTurnId).toBe("turn-agent-42");
+  });
+
+  it("stamps a null anchor when no turn exists yet", () => {
+    const exited = process({ status: { status: "exited", exitCode: 0 } });
+    const [receipt] = deriveNewCompletionReceipts({
+      previousRunningProcessIds: new Set(["proc-1"]),
+      previousRunningAgentsById: new Map(),
+      processes: [exited],
+      agents: [],
+      alreadyReceiptedKeys: new Set(),
+      anchorTurnId: null,
+      nowMs: NOW,
+    });
+    expect(receipt.anchorTurnId).toBeNull();
+  });
+
+  it("prefers the final-status snapshot when the subagent lingers one tick as failed", () => {
+    const previous = agent({ id: "task-1", status: { status: "running" } });
+    const current = agent({ id: "task-1", status: { status: "failed" } });
+    const receipts = deriveNewCompletionReceipts({
+      previousRunningProcessIds: new Set(),
+      previousRunningAgentsById: new Map([["task-1", previous]]),
+      processes: [],
+      agents: [current],
+      alreadyReceiptedKeys: new Set(),
+      anchorTurnId: "turn-1",
+      nowMs: NOW,
+    });
+    expect(receipts).toHaveLength(1);
+    expect(receipts[0]).toMatchObject({ kind: "subagent", outcome: "failed" });
+  });
+
+  it("does NOT receipt a subagent that is still running", () => {
+    const previous = agent({ id: "task-1" });
+    const receipts = deriveNewCompletionReceipts({
+      previousRunningProcessIds: new Set(),
+      previousRunningAgentsById: new Map([["task-1", previous]]),
+      processes: [],
+      agents: [agent({ id: "task-1", status: { status: "running" } })],
+      alreadyReceiptedKeys: new Set(),
+      anchorTurnId: "turn-1",
+      nowMs: NOW,
+    });
+    expect(receipts).toEqual([]);
+  });
+
+  // NEGATIVE CONTROL: work already finished at first sighting (never seen
+  // running by this hook — e.g. the roster seed on mount) is NOT receipted.
+  // Receipts announce completions observed while watching, never a backlog.
+  it("does NOT receipt an exited process it never saw running (roster-seed backlog)", () => {
+    const exited = process({
+      status: { status: "exited", exitCode: 0 },
+      endedAt: "2026-08-17T00:01:00.000Z",
+    });
+    const receipts = deriveNewCompletionReceipts({
+      previousRunningProcessIds: new Set(), // never observed running
+      previousRunningAgentsById: new Map(),
+      processes: [exited],
+      agents: [],
+      alreadyReceiptedKeys: new Set(),
+      anchorTurnId: "turn-1",
+      nowMs: NOW,
+    });
+    expect(receipts).toEqual([]);
+  });
+
+  it("does NOT re-emit a completion already receipted on an earlier tick", () => {
+    const exited = process({
+      status: { status: "exited", exitCode: 0 },
+      endedAt: "2026-08-17T00:01:00.000Z",
+    });
+    const receipts = deriveNewCompletionReceipts({
+      previousRunningProcessIds: new Set(["proc-1"]),
+      previousRunningAgentsById: new Map(),
+      processes: [exited],
+      agents: [],
+      alreadyReceiptedKeys: new Set([terminalReceiptKey("proc-1")]),
+      anchorTurnId: "turn-1",
+      nowMs: NOW,
+    });
+    expect(receipts).toEqual([]);
+  });
+});

--- a/apps/packages/product-client/src/domain/activity/background-completion-receipt.ts
+++ b/apps/packages/product-client/src/domain/activity/background-completion-receipt.ts
@@ -1,0 +1,167 @@
+/**
+ * Inline background-work completion receipts (bgwork r6). When a background
+ * terminal exits or a native subagent finishes, the transcript shows a
+ * right-aligned receipt row at the tail (Design Handoff — "Chat - Background
+ * Work Indicator"; Delivery Spec — Background Work Slice 1, rung R6).
+ *
+ * ARCHITECTURE (path b — synthesized from the activity fold):
+ * The runtime carries NO identifying provenance for native BACKGROUND
+ * completions. Background terminals inject no session wake prompt at all
+ * (`anyharness-lib/.../terminals/command_runs` only writes shell-prompt
+ * bytes, never a `PromptProvenance`), and native roster subagents leave the
+ * roster the instant they finish with no durable transcript record — the only
+ * evidence is a roster departure (`use-background-work-finish-signal-tracking`,
+ * rung R5). The `subagentWake`/`linkWake` provenance the transcript's
+ * `AgentOriginPromptReceipt` already renders is for delegated/linked SESSIONS
+ * (cowork/review/agent-parent), a different mechanism — not "background work."
+ *
+ * So receipts are synthesized from fold transitions: a process last seen
+ * running that is now exited, or a native subagent last seen running that is
+ * now finished-in-place or vanished. These are appended at the transcript tail
+ * at fold time; they do not survive reload (known lane defect D1: activity
+ * rendering is fold-only — the durable wire signal is the wire rung's job).
+ */
+
+import type { ActivityProcessWire } from "./process";
+import { isProcessRunning } from "./process";
+import type { ActivitySubagentWire } from "./subagent";
+import { subagentDisplayTitle } from "./subagent";
+
+/**
+ * The transcript turn that was latest at the moment this completion was
+ * observed (bgwork r6 round 2). Receipts interleave into the transcript row
+ * sequence AFTER this turn's rows (see `bucketCompletionReceiptRows`), so a
+ * background finish reads in stream order — agent turn → receipt → wake turn —
+ * rather than piling up detached at the tail. `null` when no turn existed yet.
+ */
+interface CompletionReceiptAnchor {
+  anchorTurnId: string | null;
+}
+
+export interface TerminalCompletionReceipt extends CompletionReceiptAnchor {
+  kind: "terminal";
+  /** Stable de-dupe/react key. */
+  key: string;
+  processId: string;
+  command: string;
+  exitCode: number | null;
+  /** Real, server-stamped `endedAt` when present; else the detection time. */
+  atMs: number;
+}
+
+export interface SubagentCompletionReceipt extends CompletionReceiptAnchor {
+  kind: "subagent";
+  key: string;
+  subagentId: string;
+  title: string;
+  outcome: "completed" | "failed";
+  /** Detection time — a finished subagent has no real, knowable finish time client-side (R5). */
+  atMs: number;
+}
+
+export type BackgroundCompletionReceipt =
+  | TerminalCompletionReceipt
+  | SubagentCompletionReceipt;
+
+/** Matches the design artifact's "exited 0 ·" verb; drops the code when the harness reports none. */
+export function terminalReceiptVerb(exitCode: number | null): string {
+  return exitCode === null ? "exited ·" : `exited ${exitCode} ·`;
+}
+
+/** Founder markup uses "finished ·"; a failed subagent reads "failed ·", matching `formatAgentMessageReceiptVerb`. */
+export function subagentReceiptVerb(outcome: "completed" | "failed"): string {
+  return outcome === "failed" ? "failed ·" : "finished ·";
+}
+
+export function terminalReceiptKey(processId: string): string {
+  return `terminal:${processId}`;
+}
+
+export function subagentReceiptKey(subagentId: string): string {
+  return `subagent:${subagentId}`;
+}
+
+/**
+ * Pure transition diff: given the ids/entries last seen RUNNING and the
+ * current roster, return receipts for work that has JUST finished — a running
+ * process now exited, or a running subagent now finished-in-place (its final
+ * status still on the roster for one tick) or vanished entirely.
+ *
+ * Only transitions from a previously-observed running state produce a receipt.
+ * Work already finished at first sighting (roster seed on mount) is NOT
+ * receipted — receipts announce completions that happen while watching, never
+ * a backlog. `alreadyReceiptedKeys` guards against re-emitting the same
+ * completion across ticks.
+ */
+export function deriveNewCompletionReceipts({
+  previousRunningProcessIds,
+  previousRunningAgentsById,
+  processes,
+  agents,
+  alreadyReceiptedKeys,
+  anchorTurnId,
+  nowMs,
+}: {
+  previousRunningProcessIds: ReadonlySet<string>;
+  previousRunningAgentsById: ReadonlyMap<string, ActivitySubagentWire>;
+  processes: readonly ActivityProcessWire[];
+  agents: readonly ActivitySubagentWire[];
+  alreadyReceiptedKeys: ReadonlySet<string>;
+  /**
+   * The transcript's latest turn id at observation time, stamped onto every
+   * receipt this call produces so the row model can interleave it right after
+   * that turn (bgwork r6 round 2). Pass `null` when no turn exists yet.
+   */
+  anchorTurnId: string | null;
+  nowMs: number;
+}): BackgroundCompletionReceipt[] {
+  const receipts: BackgroundCompletionReceipt[] = [];
+  const currentAgentsById = new Map(agents.map((agent) => [agent.id, agent] as const));
+
+  for (const process of processes) {
+    if (isProcessRunning(process)) {
+      continue;
+    }
+    if (!previousRunningProcessIds.has(process.id)) {
+      continue;
+    }
+    const key = terminalReceiptKey(process.id);
+    if (alreadyReceiptedKeys.has(key)) {
+      continue;
+    }
+    receipts.push({
+      kind: "terminal",
+      key,
+      processId: process.id,
+      command: process.command,
+      exitCode: process.status.status === "exited" ? process.status.exitCode : null,
+      atMs: process.endedAt ? Date.parse(process.endedAt) || nowMs : nowMs,
+      anchorTurnId,
+    });
+  }
+
+  for (const [id, previousAgent] of previousRunningAgentsById) {
+    const key = subagentReceiptKey(id);
+    if (alreadyReceiptedKeys.has(key)) {
+      continue;
+    }
+    const currentAgent = currentAgentsById.get(id);
+    if (currentAgent && currentAgent.status.status === "running") {
+      continue;
+    }
+    // Prefer the current (final-status) snapshot when the roster still holds it
+    // for one tick; otherwise the last-seen running snapshot is all that exists.
+    const finished = currentAgent ?? previousAgent;
+    receipts.push({
+      kind: "subagent",
+      key,
+      subagentId: id,
+      title: subagentDisplayTitle(finished),
+      outcome: finished.status.status === "failed" ? "failed" : "completed",
+      atMs: nowMs,
+      anchorTurnId,
+    });
+  }
+
+  return receipts;
+}

--- a/apps/packages/product-client/src/domain/chats/transcript/chat-transcript-state.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/chat-transcript-state.ts
@@ -5,6 +5,7 @@ import type {
 import type { SessionViewState } from "../../sessions/activity";
 import type { PromptOutboxEntry } from "../../sessions/intents/session-intent-model";
 import type { GoalTranscriptEvent } from "../../activity/goal-transcript-events";
+import type { BackgroundCompletionReceipt } from "../../activity/background-completion-receipt";
 
 export type {
   PendingPromptEntry,
@@ -34,6 +35,18 @@ export interface ChatTranscriptState {
    * while older history pages remain unloaded.
    */
   workspaceReceiptKey?: string | null;
+  /**
+   * Inline background-work completion receipts (bgwork r6 round 2), interleaved
+   * into the row sequence after each receipt's anchor turn. Client-side
+   * composition like `goalEvents`; set only by the main chat surface.
+   */
+  completionReceipts?: readonly BackgroundCompletionReceipt[];
+  /**
+   * Count of still-running background work; drives the quiet `background_work`
+   * footer row at the transcript tail (bgwork r6 round 2). 0/undefined renders
+   * no row.
+   */
+  backgroundWorkRunningCount?: number;
 }
 
 export interface ChatTranscriptHistoryState {

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-interleave-rows.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-interleave-rows.ts
@@ -1,0 +1,308 @@
+import type { TranscriptState, TurnRecord } from "@anyharness/sdk";
+import type { GoalTranscriptEvent } from "../../activity/goal-transcript-events";
+import type { BackgroundCompletionReceipt } from "../../activity/background-completion-receipt";
+import type { TranscriptRow } from "./transcript-row-model";
+
+/**
+ * Row-interleaving helpers for `buildTranscriptRowModel` (split out for
+ * PROD-SIZE-1). Two auxiliary row kinds are woven into the turn sequence
+ * client-side:
+ *   - Goal lifecycle rows (`goal_event`) interleave MID-turn by seq.
+ *   - Background completion receipts (`completion_receipt`) anchor to a turn's
+ *     END by `anchorTurnId` (bgwork r6 round 2).
+ * Both are pure functions over the transcript; the model builder buckets, then
+ * splices, the results.
+ */
+
+export type GoalEventRow = Extract<TranscriptRow, { kind: "goal_event" }>;
+export type CompletionReceiptRow = Extract<TranscriptRow, { kind: "completion_receipt" }>;
+
+export const EMPTY_GOAL_ROWS: readonly GoalEventRow[] = [];
+
+export function buildGoalEventRowKey(eventId: string): `goal-event:${string}` {
+  return `goal-event:${eventId}`;
+}
+
+export interface GoalEventRowBuckets {
+  beforeFirstTurn: GoalEventRow[];
+  byTurnId: Map<string, GoalEventRow[]>;
+}
+
+/**
+ * Buckets goal lifecycle rows against the transcript's turns purely by seq
+ * (both the goal event and every item ride the same global per-session
+ * sequence space).
+ *
+ * A turn "hosts" an event when the turn's earliest item `startedSeq` is at
+ * or before the event's seq and no later turn's earliest item is too — i.e.
+ * the last turn that had already started by that seq. Events earlier than
+ * every turn's start (including when there are no turns yet) lead the row
+ * list.
+ *
+ * All goal events for a given turn are collected together; the caller
+ * (`interleaveGoalRowsBySeq`) will position them by seq within the turn's
+ * item sequence.
+ */
+export function bucketGoalEventRows(
+  goalEvents: readonly GoalTranscriptEvent[],
+  transcript: TranscriptState,
+): GoalEventRowBuckets {
+  const beforeFirstTurn: GoalEventRow[] = [];
+  const byTurnId = new Map<string, GoalEventRow[]>();
+  if (goalEvents.length === 0) {
+    return { beforeFirstTurn, byTurnId };
+  }
+
+  const orderedTurnRanges = transcript.turnOrder
+    .map((turnId) => ({ turnId, range: turnItemSeqRange(transcript, turnId) }))
+    .filter((entry): entry is { turnId: string; range: TurnItemSeqRange } =>
+      entry.range !== null
+    );
+
+  const sortedEvents = [...goalEvents].sort((left, right) => left.seq - right.seq);
+  for (const event of sortedEvents) {
+    const row: GoalEventRow = {
+      kind: "goal_event",
+      key: buildGoalEventRowKey(event.id),
+      event,
+    };
+
+    let host: { turnId: string; range: TurnItemSeqRange } | null = null;
+    for (const candidate of orderedTurnRanges) {
+      if (candidate.range.minSeq > event.seq) {
+        break;
+      }
+      host = candidate;
+    }
+
+    if (host === null) {
+      beforeFirstTurn.push(row);
+      continue;
+    }
+
+    const bucket = byTurnId.get(host.turnId);
+    if (bucket) {
+      bucket.push(row);
+    } else {
+      byTurnId.set(host.turnId, [row]);
+    }
+  }
+
+  return { beforeFirstTurn, byTurnId };
+}
+
+export function buildCompletionReceiptRowKey(
+  receiptKey: string,
+): `completion-receipt:${string}` {
+  return `completion-receipt:${receiptKey}`;
+}
+
+export interface CompletionReceiptRowBuckets {
+  beforeFirstTurn: CompletionReceiptRow[];
+  byTurnId: Map<string, CompletionReceiptRow[]>;
+  afterAllTurns: CompletionReceiptRow[];
+}
+
+/**
+ * Buckets completion receipts against the transcript's turns by each receipt's
+ * `anchorTurnId` — the turn that was latest when the completion was folded.
+ * Unlike goal events (interleaved mid-turn by seq), receipts render only at a
+ * turn's END, so this is a plain by-turn assignment, not a seq scan:
+ *   - `anchorTurnId === null` (no turn existed yet) → lead the list.
+ *   - anchor turn still loaded → after that turn's rows.
+ *   - anchor turn no longer loaded (aged out of history) → after all turns.
+ * Receipts keep their arrival order within each bucket.
+ */
+export function bucketCompletionReceiptRows(
+  receipts: readonly BackgroundCompletionReceipt[],
+  transcript: TranscriptState,
+): CompletionReceiptRowBuckets {
+  const beforeFirstTurn: CompletionReceiptRow[] = [];
+  const byTurnId = new Map<string, CompletionReceiptRow[]>();
+  const afterAllTurns: CompletionReceiptRow[] = [];
+  for (const receipt of receipts) {
+    const row: CompletionReceiptRow = {
+      kind: "completion_receipt",
+      key: buildCompletionReceiptRowKey(receipt.key),
+      receipt,
+    };
+    if (receipt.anchorTurnId === null) {
+      beforeFirstTurn.push(row);
+    } else if (transcript.turnsById[receipt.anchorTurnId]) {
+      const bucket = byTurnId.get(receipt.anchorTurnId);
+      if (bucket) {
+        bucket.push(row);
+      } else {
+        byTurnId.set(receipt.anchorTurnId, [row]);
+      }
+    } else {
+      afterAllTurns.push(row);
+    }
+  }
+  return { beforeFirstTurn, byTurnId, afterAllTurns };
+}
+
+interface TurnItemSeqRange {
+  minSeq: number;
+  maxSeq: number;
+}
+
+function turnItemSeqRange(transcript: TranscriptState, turnId: string): TurnItemSeqRange | null {
+  const turn = transcript.turnsById[turnId];
+  if (!turn) {
+    return null;
+  }
+  let minSeq: number | null = null;
+  let maxSeq: number | null = null;
+  for (const itemId of turn.itemOrder) {
+    const item = transcript.itemsById[itemId];
+    if (!item) {
+      continue;
+    }
+    if (minSeq === null || item.startedSeq < minSeq) {
+      minSeq = item.startedSeq;
+    }
+    if (maxSeq === null || item.startedSeq > maxSeq) {
+      maxSeq = item.startedSeq;
+    }
+  }
+  return minSeq === null || maxSeq === null ? null : { minSeq, maxSeq };
+}
+
+/**
+ * Interleaves goal event rows by seq among a turn's rows, positioning each
+ * goal event at its true chronological location within the turn's content.
+ *
+ * Strategy:
+ * - Collect all items from all turn rows with their seq values.
+ * - For each goal event, find its insertion point: after the last item whose
+ *   startedSeq < event.seq, which determines which turn row it should follow.
+ * - Special case: if the turn has a leading user-message row split, goal
+ *   events whose seq falls before all assistant content still render after
+ *   the user message row (preserving the "goal set right after user prompt" UX).
+ */
+export function interleaveGoalRowsBySeq(
+  turnRows: readonly Extract<TranscriptRow, { kind: "turn" }>[],
+  goalRows: readonly GoalEventRow[],
+  _turn: TurnRecord,
+  transcript: TranscriptState,
+): TranscriptRow[] {
+  if (goalRows.length === 0) {
+    return [...turnRows];
+  }
+
+  // Build a list of all items across all rows, tracking which row each item belongs to.
+  interface ItemEntry {
+    seq: number;
+    rowIndex: number;
+  }
+  const items: ItemEntry[] = [];
+
+  for (let rowIndex = 0; rowIndex < turnRows.length; rowIndex += 1) {
+    const turnRow = turnRows[rowIndex];
+    for (const block of turnRow.renderPresentation.displayBlocks) {
+      if (block.kind === "item") {
+        const item = transcript.itemsById[block.itemId];
+        if (item) {
+          items.push({ seq: item.startedSeq, rowIndex });
+        }
+      } else if (
+        block.kind === "collapsed_actions"
+        || block.kind === "inline_tools"
+        || block.kind === "subagent_creations"
+      ) {
+        for (const itemId of block.itemIds) {
+          const item = transcript.itemsById[itemId];
+          if (item) {
+            items.push({ seq: item.startedSeq, rowIndex });
+          }
+        }
+      }
+    }
+  }
+
+  // Sort items by seq to enable binary-search-like positioning.
+  items.sort((a, b) => a.seq - b.seq);
+
+  // Determine if the first row is a leading user-message split.
+  const hasLeadingSplit = turnRows.length > 1 && turnRows[0].isFirstTurnRow && !turnRows[0].isLastTurnRow;
+
+  // Sort goal rows by seq to maintain order.
+  const sortedGoalRows = [...goalRows].sort((a, b) => a.event.seq - b.event.seq);
+
+  // For each goal event, determine which row it should be inserted after.
+  // A goal at seq N should appear:
+  // - AFTER the row containing the last item with seq < N, AND
+  // - BEFORE the row containing the first item with seq >= N
+  // This ensures goals render at their chronological position, even if that
+  // position is mid-way through a row's content (the row will have been split
+  // to enable this).
+  const goalInsertionPoints = new Map<number, GoalEventRow[]>(); // rowIndex -> goals to insert after
+
+  for (const goalRow of sortedGoalRows) {
+    const goalSeq = goalRow.event.seq;
+
+    // Find the row containing the last item with seq < goalSeq.
+    // If the next item (seq >= goalSeq) is in a DIFFERENT row, insert after
+    // the current row. Otherwise, the goal falls mid-row, and the row should
+    // have been split — but if not, we insert before that row.
+    let lastItemBefore: ItemEntry | null = null;
+    let firstItemAtOrAfter: ItemEntry | null = null;
+
+    for (const item of items) {
+      if (item.seq < goalSeq) {
+        lastItemBefore = item;
+      } else if (item.seq >= goalSeq && firstItemAtOrAfter === null) {
+        firstItemAtOrAfter = item;
+        break;
+      }
+    }
+
+    let targetRowIndex: number;
+    if (lastItemBefore === null) {
+      // Goal precedes all items. Insert after the leading split row if it
+      // exists, otherwise before all rows.
+      targetRowIndex = hasLeadingSplit ? 0 : -1;
+    } else if (firstItemAtOrAfter === null) {
+      // Goal follows all items. Insert after the row containing the last item.
+      targetRowIndex = lastItemBefore.rowIndex;
+    } else if (lastItemBefore.rowIndex !== firstItemAtOrAfter.rowIndex) {
+      // Goal falls between two different rows. This is the clean case: insert
+      // after lastItemBefore's row, which places it before firstItemAtOrAfter's row.
+      targetRowIndex = lastItemBefore.rowIndex;
+    } else {
+      // Goal falls mid-row: the row contains both the last item <= goalSeq
+      // and the first item > goalSeq. Insert the goal AFTER this row, since
+      // we can't split it finer than the user/content boundary.
+      targetRowIndex = lastItemBefore.rowIndex;
+    }
+
+    const existing = goalInsertionPoints.get(targetRowIndex);
+    if (existing) {
+      existing.push(goalRow);
+    } else {
+      goalInsertionPoints.set(targetRowIndex, [goalRow]);
+    }
+  }
+
+  // Assemble the result by interleaving turn rows with goal rows.
+  const result: TranscriptRow[] = [];
+
+  // Insert any goals that should come before all rows.
+  const beforeAllGoals = goalInsertionPoints.get(-1);
+  if (beforeAllGoals) {
+    result.push(...beforeAllGoals);
+  }
+
+  for (let rowIndex = 0; rowIndex < turnRows.length; rowIndex += 1) {
+    result.push(turnRows[rowIndex]);
+
+    // Insert any goals that should come after this row.
+    const afterThisRowGoals = goalInsertionPoints.get(rowIndex);
+    if (afterThisRowGoals) {
+      result.push(...afterThisRowGoals);
+    }
+  }
+
+  return result;
+}

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-rendering.test.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-rendering.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createTranscriptState } from "@anyharness/sdk";
+import { createTranscriptState, type TranscriptState } from "@anyharness/sdk";
 import {
   assistantItem,
   terminalItem,
@@ -11,8 +11,11 @@ import {
   collectToolCallIdsWithProposedPlan,
   findTrailingLiveExplorationBlock,
   findTrailingLiveWorkBlock,
+  resolveTurnAssistantFooterModeForRow,
   turnHasActiveToolWork,
 } from "./transcript-rendering";
+import { buildTranscriptRowModel } from "./transcript-row-model";
+import type { BackgroundCompletionReceipt } from "../../activity/background-completion-receipt";
 
 describe("transcript rendering helpers", () => {
   it("preserves the proposed-plan index identity when unrelated prose changes", () => {
@@ -154,3 +157,263 @@ describe("transcript rendering helpers", () => {
     expect(turnHasActiveToolWork(turn, transcript)).toBe(true);
   });
 });
+
+// Regression: bgwork r6 rounds 3 + 4. A runtime-injected wake turn (the
+// background-work finish signal, e.g. "Terminal … finished — exit code 0")
+// never receives its completion tail. Round 3 handled the case where the tail
+// message item finalized (status "completed") but the TurnRecord.completedAt
+// stamp was missing. Round 4 handles the REAL durable shape observed on the
+// wire (GET /v1/sessions/{id}/events): the runtime drops both item_completed
+// AND turn_ended, so the tail assistant message item stays status "in_progress"
+// (isStreaming true) forever — every completion-stamp / item-status gate is
+// false. Completion is instead derived from session liveness: once the turn is
+// no longer the session's actively-streaming turn (idle, reloaded, or
+// interrupted), its message is copyable. Interleaved completion_receipt /
+// background_work rows stay transparent to this.
+describe("resolveTurnAssistantFooterModeForRow — footer completion without a turn_ended stamp", () => {
+  it("round 3: restores copy when the tail message item settled but the TurnRecord never got completedAt", () => {
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = { msg: assistantItem("msg", "turn-1", 1) };
+    const turn = turnRecord(["msg"], null);
+
+    expect(resolveTurnAssistantFooterModeForRow({
+      rowIsLastTurnRow: true,
+      turn,
+      transcript,
+      presentation: buildTurnPresentation(turn, transcript),
+      assistantRevealComplete: true,
+      turnIsActivelyStreaming: false,
+    })).toBe("copy");
+  });
+
+  it("round 4: restores copy on a dropped-tail wake turn whose message item is stuck in_progress once the session is idle", () => {
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = { msg: streamingProseItem("msg", "turn-1") };
+    const turn = turnRecord(["msg"], null);
+
+    expect(resolveTurnAssistantFooterModeForRow({
+      rowIsLastTurnRow: true,
+      turn,
+      transcript,
+      presentation: buildTurnPresentation(turn, transcript),
+      assistantRevealComplete: true,
+      turnIsActivelyStreaming: false,
+    })).toBe("copy");
+  });
+
+  it("round 4 control: keeps the reserved footer for the same in_progress-tail shape while the turn IS the actively-streaming turn", () => {
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = { msg: streamingProseItem("msg", "turn-1") };
+    const turn = turnRecord(["msg"], null);
+
+    expect(resolveTurnAssistantFooterModeForRow({
+      rowIsLastTurnRow: true,
+      turn,
+      transcript,
+      presentation: buildTurnPresentation(turn, transcript),
+      assistantRevealComplete: true,
+      turnIsActivelyStreaming: true,
+    })).toBe("reserved");
+  });
+
+  it("keeps the reserved footer when prose closed but a tool is still running (session working)", () => {
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = {
+      msg: assistantItem("msg", "turn-1", 1),
+      tool: toolItem("tool", "turn-1", 2, "other", "in_progress"),
+    };
+    const turn = turnRecord(["msg", "tool"], null);
+
+    expect(resolveTurnAssistantFooterModeForRow({
+      rowIsLastTurnRow: true,
+      turn,
+      transcript,
+      presentation: buildTurnPresentation(turn, transcript),
+      assistantRevealComplete: true,
+      turnIsActivelyStreaming: true,
+    })).toBe("reserved");
+  });
+
+  it("L1: keeps the reserved footer in a prose-finished-but-turn-still-active gap (before the next tool_call)", () => {
+    // The tail prose item has settled (status "completed", isStreaming false)
+    // and no tool is active YET — structurally identical to a settled wake turn
+    // under item-status inputs, but the turn is still the live one, so the
+    // liveness gate must keep it reserved (no mid-turn copy flash).
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = { msg: assistantItem("msg", "turn-1", 1) };
+    const turn = turnRecord(["msg"], null);
+
+    expect(resolveTurnAssistantFooterModeForRow({
+      rowIsLastTurnRow: true,
+      turn,
+      transcript,
+      presentation: buildTurnPresentation(turn, transcript),
+      assistantRevealComplete: true,
+      turnIsActivelyStreaming: true,
+    })).toBe("reserved");
+  });
+
+  it("keeps the reserved footer until the assistant reveal completes", () => {
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = { msg: assistantItem("msg", "turn-1", 1) };
+    const turn = turnRecord(["msg"], null);
+
+    expect(resolveTurnAssistantFooterModeForRow({
+      rowIsLastTurnRow: true,
+      turn,
+      transcript,
+      presentation: buildTurnPresentation(turn, transcript),
+      assistantRevealComplete: false,
+      turnIsActivelyStreaming: false,
+    })).toBe("reserved");
+  });
+
+  it("leaves stamped turns unchanged (negative control): completed turn still shows copy", () => {
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = { msg: assistantItem("msg", "turn-1", 1) };
+    const turn = turnRecord(["msg"], "2026-04-04T00:00:01Z");
+
+    expect(resolveTurnAssistantFooterModeForRow({
+      rowIsLastTurnRow: true,
+      turn,
+      transcript,
+      presentation: buildTurnPresentation(turn, transcript),
+      assistantRevealComplete: true,
+      turnIsActivelyStreaming: false,
+    })).toBe("copy");
+  });
+
+  it("emits no footer on a non-final turn row", () => {
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = { msg: assistantItem("msg", "turn-1", 1) };
+    const turn = turnRecord(["msg"], null);
+
+    expect(resolveTurnAssistantFooterModeForRow({
+      rowIsLastTurnRow: false,
+      turn,
+      transcript,
+      presentation: buildTurnPresentation(turn, transcript),
+      assistantRevealComplete: true,
+      turnIsActivelyStreaming: false,
+    })).toBe("none");
+  });
+
+  it("(a) keeps the wake message's copy footer with a receipt interleaved after the preceding turn", () => {
+    const transcript = createTranscriptState("session-1");
+    addProseTurn(transcript, "turn-a", { completed: true });
+    addProseTurn(transcript, "turn-b", { completed: false, tailStreaming: true });
+
+    const rows = buildTranscriptRowModel({
+      activeSessionId: "session-1",
+      transcript,
+      visibleOptimisticPrompt: null,
+      latestTurnId: "turn-b",
+      latestTurnHasAssistantRenderableContent: true,
+      completionReceipts: [terminalReceiptFor("turn-a")],
+    });
+
+    expect(rows.map((row) => row.kind)).toEqual(["turn", "completion_receipt", "turn"]);
+    expect(footerModeForTurnRow(rows, transcript, "turn-b")).toBe("copy");
+  });
+
+  it("(b) keeps the wake message's copy footer with the background_work row at the tail", () => {
+    const transcript = createTranscriptState("session-1");
+    addProseTurn(transcript, "turn-a", { completed: true });
+    addProseTurn(transcript, "turn-b", { completed: false, tailStreaming: true });
+
+    const rows = buildTranscriptRowModel({
+      activeSessionId: "session-1",
+      transcript,
+      visibleOptimisticPrompt: null,
+      latestTurnId: "turn-b",
+      latestTurnHasAssistantRenderableContent: true,
+      backgroundWorkRunningCount: 2,
+    });
+
+    expect(rows.at(-1)?.kind).toBe("background_work");
+    expect(footerModeForTurnRow(rows, transcript, "turn-b")).toBe("copy");
+  });
+
+  it("(c) keeps the wake message's copy footer with both a receipt and the tail footer", () => {
+    const transcript = createTranscriptState("session-1");
+    addProseTurn(transcript, "turn-a", { completed: true });
+    addProseTurn(transcript, "turn-b", { completed: false, tailStreaming: true });
+
+    const rows = buildTranscriptRowModel({
+      activeSessionId: "session-1",
+      transcript,
+      visibleOptimisticPrompt: null,
+      latestTurnId: "turn-b",
+      latestTurnHasAssistantRenderableContent: true,
+      completionReceipts: [terminalReceiptFor("turn-a")],
+      backgroundWorkRunningCount: 1,
+    });
+
+    expect(rows.map((row) => row.kind)).toEqual([
+      "turn",
+      "completion_receipt",
+      "turn",
+      "background_work",
+    ]);
+    expect(footerModeForTurnRow(rows, transcript, "turn-b")).toBe("copy");
+  });
+});
+
+// The wake turn is not the session's active turn (idle / reloaded), so the
+// row-model integration cases resolve with turnIsActivelyStreaming: false.
+function footerModeForTurnRow(
+  rows: ReturnType<typeof buildTranscriptRowModel>,
+  transcript: TranscriptState,
+  turnId: string,
+): "none" | "reserved" | "copy" {
+  const row = rows.find((candidate) => candidate.kind === "turn" && candidate.turnId === turnId);
+  if (!row || row.kind !== "turn") {
+    throw new Error(`turn row ${turnId} not found`);
+  }
+  return resolveTurnAssistantFooterModeForRow({
+    rowIsLastTurnRow: row.isLastTurnRow,
+    turn: transcript.turnsById[turnId],
+    transcript,
+    presentation: row.presentation,
+    assistantRevealComplete: true,
+    turnIsActivelyStreaming: false,
+  });
+}
+
+// The verbatim durable shape from the wire: item_started(in_progress) +
+// item_delta with no item_completed, so the assistant message stays streaming.
+function streamingProseItem(itemId: string, turnId: string) {
+  return { ...assistantItem(itemId, turnId, 1), status: "in_progress" as const, isStreaming: true };
+}
+
+function addProseTurn(
+  transcript: TranscriptState,
+  turnId: string,
+  opts: { completed: boolean; tailStreaming?: boolean },
+): void {
+  const proseId = `${turnId}-prose`;
+  transcript.turnOrder.push(turnId);
+  transcript.turnsById[turnId] = {
+    turnId,
+    itemOrder: [proseId],
+    startedAt: "2026-01-01T00:00:00.000Z",
+    completedAt: opts.completed ? "2026-01-01T00:00:01.000Z" : null,
+    stopReason: opts.completed ? "end_turn" : null,
+    fileBadges: [],
+  };
+  transcript.itemsById[proseId] = opts.tailStreaming
+    ? streamingProseItem(proseId, turnId)
+    : assistantItem(proseId, turnId, transcript.turnOrder.length);
+}
+
+function terminalReceiptFor(anchorTurnId: string | null): BackgroundCompletionReceipt {
+  return {
+    kind: "terminal",
+    key: "terminal:p1",
+    processId: "p1",
+    command: "echo hi",
+    exitCode: 0,
+    atMs: 1,
+    anchorTurnId,
+  };
+}

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-rendering.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-rendering.ts
@@ -12,6 +12,7 @@ import {
   type TurnDisplayBlock,
   type TurnPresentation,
 } from "./transcript-presentation";
+import { resolveTurnAssistantFooterMode } from "./turn-row-presentation";
 import type { PromptOutboxEntry } from "../../sessions/intents/session-intent-model";
 
 const EMPTY_OUTBOX_STARTED_AT_BY_PROMPT_ID = new Map<string, string>();
@@ -78,6 +79,76 @@ export function getAssistantProseContent(
   }
   const item = transcript.itemsById[itemId];
   return item?.kind === "assistant_prose" && item.text ? item.text : null;
+}
+
+/**
+ * Resolve the assistant copy/timestamp footer mode for one turn row, sourcing
+ * "is this turn done?" from stream/session liveness and the tail assistant
+ * MESSAGE rather than only the turn envelope's completion stamp.
+ *
+ * A runtime-injected wake turn (the background-work finish signal, e.g.
+ * "Terminal … finished — exit code 0") never receives the completion tail: the
+ * runtime drops both `item_completed` and `turn_ended`, so `TurnRecord`'s
+ * `completedAt` stays null AND the tail assistant message item stays status
+ * "in_progress" (isStreaming true) forever in the durable record. The bare
+ * `!!turn.completedAt` gate — and a tail-item-status gate — therefore leave
+ * that final message stuck on the empty "reserved" footer: no copy button, no
+ * timestamp, durable across reload. Interleaved `completion_receipt` /
+ * `background_work` rows are transparent to this: the affordance belongs to the
+ * last real MESSAGE row of a turn regardless of the activity rows the row model
+ * places before or after it.
+ *
+ * Two OR'd completion signals:
+ *   1. `turn.completedAt` — a real `turn_ended` stamp (normal turns; the left
+ *      branch always wins when present).
+ *   2. `messageSettledOffLiveStream` — there is copyable tail prose and this
+ *      turn is NOT the session's actively-streaming turn. This is the signal
+ *      that survives the dropped completion tail: on reload there is no live
+ *      stream, and once the agent stops the session leaves the "working" view
+ *      state, so a message whose item is stuck "in_progress" is nonetheless
+ *      copyable. An interrupted turn matches too — desired for the affordance.
+ *
+ * Completion is deliberately NOT sourced from the tail item's own status: the
+ * runtime drops `item_completed` for wake turns, so the item stays
+ * "in_progress" forever, and a per-item-settle gate also flashes `copy` in the
+ * mid-turn gap between a prose block finishing and the next tool_call arriving
+ * (a still-live turn indistinguishable from a settled one). Keying on
+ * `turnIsActivelyStreaming` (isLatestTurn AND the session view state is
+ * "working") instead keeps that gap — and every genuinely live turn — in
+ * "reserved", with the reveal guard (`assistantRevealComplete`) holding the
+ * empty footer through the reveal.
+ */
+export function resolveTurnAssistantFooterModeForRow({
+  rowIsLastTurnRow,
+  turn,
+  transcript,
+  presentation,
+  assistantRevealComplete,
+  turnIsActivelyStreaming,
+}: {
+  rowIsLastTurnRow: boolean;
+  turn: TurnRecord;
+  transcript: TranscriptState;
+  presentation: TurnPresentation;
+  assistantRevealComplete: boolean;
+  turnIsActivelyStreaming: boolean;
+}): "none" | "reserved" | "copy" {
+  const tailAssistantProseRootId = findTailAssistantProseRootId(
+    presentation,
+    transcript,
+  );
+  const tailAssistantProseContent = getAssistantProseContent(
+    tailAssistantProseRootId,
+    transcript,
+  );
+  const messageSettledOffLiveStream = !!tailAssistantProseContent
+    && !turnIsActivelyStreaming;
+  return resolveTurnAssistantFooterMode({
+    rowIsLastTurnRow,
+    turnCompleted: !!turn.completedAt || messageSettledOffLiveStream,
+    hasAssistantCopyContent: !!tailAssistantProseContent,
+    assistantRevealComplete,
+  });
 }
 
 export function collectToolCallIdsWithProposedPlan(

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-row-model.background-work.test.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-row-model.background-work.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import { createTranscriptState, type PendingPromptEntry, type TranscriptState } from "@anyharness/sdk";
+import {
+  buildTranscriptRowModel,
+  type TranscriptRow,
+} from "./transcript-row-model";
+import type { BackgroundCompletionReceipt } from "../../activity/background-completion-receipt";
+
+// Split from transcript-row-model.test.ts for PROD-SIZE-1 (repo-wide 600-line
+// cap). Covers the bgwork r6 round-2 in-scroll rows: inline completion receipts
+// anchored to a turn's END and the running-count footer at the tail. The
+// interleaving helpers under test live in `transcript-interleave-rows.ts`.
+
+describe("buildTranscriptRowModel — background-work rows (bgwork r6 round 2)", () => {
+  function build(overrides: {
+    transcript: TranscriptState;
+    latestTurnId: string | null;
+    completionReceipts?: readonly BackgroundCompletionReceipt[];
+    backgroundWorkRunningCount?: number;
+    visibleOptimisticPrompt?: PendingPromptEntry | null;
+  }): TranscriptRow[] {
+    return buildTranscriptRowModel({
+      activeSessionId: "session-1",
+      transcript: overrides.transcript,
+      visibleOptimisticPrompt: overrides.visibleOptimisticPrompt ?? null,
+      latestTurnId: overrides.latestTurnId,
+      latestTurnHasAssistantRenderableContent: true,
+      completionReceipts: overrides.completionReceipts,
+      backgroundWorkRunningCount: overrides.backgroundWorkRunningCount,
+    });
+  }
+
+  it("interleaves a completion receipt right after its anchor turn, before the later (wake) turn", () => {
+    const transcript = createTranscriptState("session-1");
+    addTurn(transcript, "turn-a", true);
+    addTurn(transcript, "turn-b", true);
+
+    const rows = build({
+      transcript,
+      latestTurnId: "turn-b",
+      completionReceipts: [terminalReceiptFor("turn-a")],
+    });
+
+    expect(rows.map((row) => row.kind)).toEqual(["turn", "completion_receipt", "turn"]);
+    expect(rows[0]).toEqual(expect.objectContaining({ turnId: "turn-a" }));
+    expect(rows[1]).toEqual(expect.objectContaining({
+      kind: "completion_receipt",
+      key: "completion-receipt:terminal:p1",
+    }));
+    expect(rows[2]).toEqual(expect.objectContaining({ turnId: "turn-b" }));
+  });
+
+  it("leads the row list with a receipt whose anchor turn never existed (null anchor)", () => {
+    const transcript = createTranscriptState("session-1");
+    addTurn(transcript, "turn-a", true);
+
+    const rows = build({
+      transcript,
+      latestTurnId: "turn-a",
+      completionReceipts: [terminalReceiptFor(null)],
+    });
+
+    expect(rows.map((row) => row.kind)).toEqual(["completion_receipt", "turn"]);
+  });
+
+  it("places a receipt whose anchor turn is no longer loaded after all turns", () => {
+    const transcript = createTranscriptState("session-1");
+    addTurn(transcript, "turn-a", true);
+
+    const rows = build({
+      transcript,
+      latestTurnId: "turn-a",
+      completionReceipts: [terminalReceiptFor("turn-gone")],
+    });
+
+    expect(rows.map((row) => row.kind)).toEqual(["turn", "completion_receipt"]);
+  });
+
+  it("keeps multiple receipts anchored to the same turn in arrival order", () => {
+    const transcript = createTranscriptState("session-1");
+    addTurn(transcript, "turn-a", true);
+
+    const rows = build({
+      transcript,
+      latestTurnId: "turn-a",
+      completionReceipts: [
+        terminalReceiptFor("turn-a", "terminal:p1"),
+        terminalReceiptFor("turn-a", "terminal:p2"),
+      ],
+    });
+
+    expect(rows.map((row) => row.key)).toEqual([
+      "turn:turn-a:block:content",
+      "completion-receipt:terminal:p1",
+      "completion-receipt:terminal:p2",
+    ]);
+  });
+
+  it("appends the running-count footer row at the very tail while runningCount > 0", () => {
+    const transcript = createTranscriptState("session-1");
+    addTurn(transcript, "turn-a", true);
+
+    const rows = build({ transcript, latestTurnId: "turn-a", backgroundWorkRunningCount: 3 });
+
+    expect(rows.at(-1)).toEqual({
+      kind: "background_work",
+      key: "background-work",
+      runningCount: 3,
+    });
+  });
+
+  it("renders NO footer row at runningCount 0", () => {
+    const transcript = createTranscriptState("session-1");
+    addTurn(transcript, "turn-a", true);
+
+    const rows = build({ transcript, latestTurnId: "turn-a", backgroundWorkRunningCount: 0 });
+
+    expect(rows.some((row) => row.kind === "background_work")).toBe(false);
+  });
+
+  it("orders agent turn -> receipt -> footer at the tail (receipt above the still-running footer)", () => {
+    const transcript = createTranscriptState("session-1");
+    addTurn(transcript, "turn-a", true);
+
+    const rows = build({
+      transcript,
+      latestTurnId: "turn-a",
+      completionReceipts: [terminalReceiptFor("turn-a")],
+      backgroundWorkRunningCount: 1,
+    });
+
+    expect(rows.map((row) => row.kind)).toEqual(["turn", "completion_receipt", "background_work"]);
+  });
+
+  it("places the footer row after a pending-prompt row (absolute tail)", () => {
+    const transcript = createTranscriptState("session-1");
+    addTurn(transcript, "turn-a", true);
+
+    const rows = build({
+      transcript,
+      latestTurnId: "turn-a",
+      visibleOptimisticPrompt: pendingPrompt(),
+      backgroundWorkRunningCount: 1,
+    });
+
+    expect(rows.map((row) => row.kind)).toEqual(["turn", "pending_prompt", "background_work"]);
+  });
+});
+
+function terminalReceiptFor(
+  anchorTurnId: string | null,
+  key = "terminal:p1",
+): BackgroundCompletionReceipt {
+  return {
+    kind: "terminal",
+    key,
+    processId: key.replace("terminal:", ""),
+    command: "echo hi",
+    exitCode: 0,
+    atMs: 1,
+    anchorTurnId,
+  };
+}
+
+function addTurn(
+  transcript: TranscriptState,
+  turnId: string,
+  completed: boolean,
+) {
+  transcript.turnOrder.push(turnId);
+  transcript.turnsById[turnId] = {
+    turnId,
+    itemOrder: [],
+    startedAt: "2026-01-01T00:00:00.000Z",
+    completedAt: completed ? "2026-01-01T00:00:01.000Z" : null,
+    stopReason: completed ? "stop" : null,
+    fileBadges: [],
+  };
+}
+
+function pendingPrompt(): PendingPromptEntry {
+  return {
+    seq: 1,
+    promptId: "prompt-1",
+    text: "hello",
+    contentParts: [],
+    queuedAt: "2026-01-01T00:00:00.000Z",
+    promptProvenance: null,
+  };
+}

--- a/apps/packages/product-client/src/domain/chats/transcript/transcript-row-model.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/transcript-row-model.ts
@@ -11,11 +11,18 @@ import {
 } from "./transcript-presentation";
 import type { PromptOutboxEntry } from "../../sessions/intents/session-intent-model";
 import type { GoalTranscriptEvent } from "../../activity/goal-transcript-events";
+import type { BackgroundCompletionReceipt } from "../../activity/background-completion-receipt";
 import {
   createTranscriptTurnRowCacheKey,
   isTranscriptTurnRowCacheHit,
   type TranscriptTurnRowCacheKey,
 } from "./transcript-row-cache-key";
+import {
+  EMPTY_GOAL_ROWS,
+  bucketCompletionReceiptRows,
+  bucketGoalEventRows,
+  interleaveGoalRowsBySeq,
+} from "./transcript-interleave-rows";
 
 export const TURN_CONTENT_BLOCK_KEY = "content";
 export const TURN_COMPLETED_HISTORY_BLOCK_KEY = "completed-history";
@@ -64,6 +71,31 @@ export type TranscriptRow =
     kind: "goal_event";
     key: `goal-event:${string}`;
     event: GoalTranscriptEvent;
+  }
+  | {
+    /**
+     * An inline background-work completion receipt (a terminal that exited or a
+     * native subagent that finished), synthesized client-side from the activity
+     * fold — see `background-completion-receipt.ts`. Interleaved into the row
+     * sequence right after the turn that was latest when the completion was
+     * observed (`receipt.anchorTurnId`), so it reads in stream order: agent
+     * turn → receipt → wake turn (bgwork r6 round 2, superseding the r6
+     * floating tail band).
+     */
+    kind: "completion_receipt";
+    key: `completion-receipt:${string}`;
+    receipt: BackgroundCompletionReceipt;
+  }
+  | {
+    /**
+     * The quiet running-background-work footer row. A true in-scroll row at the
+     * transcript tail (bgwork r6 round 2, superseding R1's dock-anchored
+     * placement) — present only while `runningCount > 0`, scrolling with
+     * content like any other row.
+     */
+    kind: "background_work";
+    key: "background-work";
+    runningCount: number;
   };
 
 export interface BuildTranscriptRowModelInput {
@@ -113,6 +145,22 @@ export interface BuildTranscriptRowModelInput {
    * it when the full history is loaded (no older pages above).
    */
   workspaceReceiptKey?: string | null;
+  /**
+   * Inline background-work completion receipts (bgwork r6 round 2). Each is
+   * interleaved right after its `anchorTurnId` turn — the turn that was latest
+   * when the completion was folded — so the receipt reads in stream order
+   * before any later (wake) turn. Client-side composition only, like
+   * `goalEvents`; ephemeral (fold-only, does not survive reload — lane defect
+   * D1). Empty/omitted for surfaces that render no background work.
+   */
+  completionReceipts?: readonly BackgroundCompletionReceipt[];
+  /**
+   * Count of still-running background work (live terminals + running native
+   * subagents). When > 0, a single quiet `background_work` footer row renders
+   * at the very tail of the transcript; at 0 no row renders (bgwork r6 round
+   * 2). Client-side derived, like the receipts above.
+   */
+  backgroundWorkRunningCount?: number;
 }
 
 export interface TranscriptRowModelCache {
@@ -138,10 +186,13 @@ export function buildTranscriptRowModel({
   latestTurnHasAssistantRenderableContent,
   goalEvents = EMPTY_GOAL_EVENTS,
   workspaceReceiptKey = null,
+  completionReceipts = EMPTY_COMPLETION_RECEIPTS,
+  backgroundWorkRunningCount = 0,
 }: BuildTranscriptRowModelInput, cache?: TranscriptRowModelCache): TranscriptRow[] {
   const rows: TranscriptRow[] = [];
   const seenTurnIds = new Set<string>();
   const goalRows = bucketGoalEventRows(goalEvents, transcript);
+  const receiptRows = bucketCompletionReceiptRows(completionReceipts, transcript);
 
   // The receipt reads as one of the first turn's tool calls: it hosts on
   // whichever row of that turn will render the completed-history "Worked for
@@ -154,6 +205,9 @@ export function buildTranscriptRowModel({
   let turnHostedWorkspaceReceipt = false;
 
   rows.push(...goalRows.beforeFirstTurn);
+  // Receipts whose anchor turn never existed (observed before any turn) lead
+  // the list, after any start-anchored goal rows.
+  rows.push(...receiptRows.beforeFirstTurn);
 
   for (const turnId of transcript.turnOrder) {
     const turn = transcript.turnsById[turnId];
@@ -194,10 +248,23 @@ export function buildTranscriptRowModel({
       transcript,
     );
     rows.push(...interleavedRows);
+    // Completion receipts anchored to this turn render at its END (after all
+    // of the turn's own rows), so a later turn — the wake reply — falls after
+    // them: agent turn → receipt → wake turn.
+    const turnReceiptRows = receiptRows.byTurnId.get(turnId);
+    if (turnReceiptRows) {
+      rows.push(...turnReceiptRows);
+    }
     if (hostsWorkspaceReceipt) {
       turnHostedWorkspaceReceipt = true;
     }
   }
+
+  // Receipts whose anchor turn is no longer loaded (e.g. it aged out above the
+  // history window) fall in after the last rendered turn rather than leading
+  // the transcript — a rare edge, and receipts do not survive reload anyway
+  // (lane defect D1).
+  rows.push(...receiptRows.afterAllTurns);
 
   let lastPromptRowIndex = -1;
   if (visibleOptimisticPrompt) {
@@ -229,6 +296,17 @@ export function buildTranscriptRowModel({
     }
   }
 
+  // The running-work footer is always the absolute last row while any work is
+  // live — an in-scroll row at the tail (bgwork r6 round 2), below the last
+  // turn, any completion receipts, and any pending-prompt echo.
+  if (backgroundWorkRunningCount > 0) {
+    rows.push({
+      kind: "background_work",
+      key: "background-work",
+      runningCount: backgroundWorkRunningCount,
+    });
+  }
+
   if (cache) {
     for (const turnId of cache.turnRowsById.keys()) {
       if (!seenTurnIds.has(turnId)) {
@@ -241,246 +319,7 @@ export function buildTranscriptRowModel({
 }
 
 const EMPTY_GOAL_EVENTS: readonly GoalTranscriptEvent[] = [];
-const EMPTY_GOAL_ROWS: readonly GoalEventRow[] = [];
-
-type GoalEventRow = Extract<TranscriptRow, { kind: "goal_event" }>;
-
-export function buildGoalEventRowKey(eventId: string): `goal-event:${string}` {
-  return `goal-event:${eventId}`;
-}
-
-interface GoalEventRowBuckets {
-  beforeFirstTurn: GoalEventRow[];
-  byTurnId: Map<string, GoalEventRow[]>;
-}
-
-/**
- * Buckets goal lifecycle rows against the transcript's turns purely by seq
- * (both the goal event and every item ride the same global per-session
- * sequence space).
- *
- * A turn "hosts" an event when the turn's earliest item `startedSeq` is at
- * or before the event's seq and no later turn's earliest item is too — i.e.
- * the last turn that had already started by that seq. Events earlier than
- * every turn's start (including when there are no turns yet) lead the row
- * list.
- *
- * All goal events for a given turn are collected together; the caller
- * (`interleaveGoalRowsBySeq`) will position them by seq within the turn's
- * item sequence.
- */
-function bucketGoalEventRows(
-  goalEvents: readonly GoalTranscriptEvent[],
-  transcript: TranscriptState,
-): GoalEventRowBuckets {
-  const beforeFirstTurn: GoalEventRow[] = [];
-  const byTurnId = new Map<string, GoalEventRow[]>();
-  if (goalEvents.length === 0) {
-    return { beforeFirstTurn, byTurnId };
-  }
-
-  const orderedTurnRanges = transcript.turnOrder
-    .map((turnId) => ({ turnId, range: turnItemSeqRange(transcript, turnId) }))
-    .filter((entry): entry is { turnId: string; range: TurnItemSeqRange } =>
-      entry.range !== null
-    );
-
-  const sortedEvents = [...goalEvents].sort((left, right) => left.seq - right.seq);
-  for (const event of sortedEvents) {
-    const row: GoalEventRow = {
-      kind: "goal_event",
-      key: buildGoalEventRowKey(event.id),
-      event,
-    };
-
-    let host: { turnId: string; range: TurnItemSeqRange } | null = null;
-    for (const candidate of orderedTurnRanges) {
-      if (candidate.range.minSeq > event.seq) {
-        break;
-      }
-      host = candidate;
-    }
-
-    if (host === null) {
-      beforeFirstTurn.push(row);
-      continue;
-    }
-
-    const bucket = byTurnId.get(host.turnId);
-    if (bucket) {
-      bucket.push(row);
-    } else {
-      byTurnId.set(host.turnId, [row]);
-    }
-  }
-
-  return { beforeFirstTurn, byTurnId };
-}
-
-interface TurnItemSeqRange {
-  minSeq: number;
-  maxSeq: number;
-}
-
-function turnItemSeqRange(transcript: TranscriptState, turnId: string): TurnItemSeqRange | null {
-  const turn = transcript.turnsById[turnId];
-  if (!turn) {
-    return null;
-  }
-  let minSeq: number | null = null;
-  let maxSeq: number | null = null;
-  for (const itemId of turn.itemOrder) {
-    const item = transcript.itemsById[itemId];
-    if (!item) {
-      continue;
-    }
-    if (minSeq === null || item.startedSeq < minSeq) {
-      minSeq = item.startedSeq;
-    }
-    if (maxSeq === null || item.startedSeq > maxSeq) {
-      maxSeq = item.startedSeq;
-    }
-  }
-  return minSeq === null || maxSeq === null ? null : { minSeq, maxSeq };
-}
-
-/**
- * Interleaves goal event rows by seq among a turn's rows, positioning each
- * goal event at its true chronological location within the turn's content.
- *
- * Strategy:
- * - Collect all items from all turn rows with their seq values.
- * - For each goal event, find its insertion point: after the last item whose
- *   startedSeq < event.seq, which determines which turn row it should follow.
- * - Special case: if the turn has a leading user-message row split, goal
- *   events whose seq falls before all assistant content still render after
- *   the user message row (preserving the "goal set right after user prompt" UX).
- */
-function interleaveGoalRowsBySeq(
-  turnRows: readonly Extract<TranscriptRow, { kind: "turn" }>[],
-  goalRows: readonly GoalEventRow[],
-  _turn: TurnRecord,
-  transcript: TranscriptState,
-): TranscriptRow[] {
-  if (goalRows.length === 0) {
-    return [...turnRows];
-  }
-
-  // Build a list of all items across all rows, tracking which row each item belongs to.
-  interface ItemEntry {
-    seq: number;
-    rowIndex: number;
-  }
-  const items: ItemEntry[] = [];
-
-  for (let rowIndex = 0; rowIndex < turnRows.length; rowIndex += 1) {
-    const turnRow = turnRows[rowIndex];
-    for (const block of turnRow.renderPresentation.displayBlocks) {
-      if (block.kind === "item") {
-        const item = transcript.itemsById[block.itemId];
-        if (item) {
-          items.push({ seq: item.startedSeq, rowIndex });
-        }
-      } else if (
-        block.kind === "collapsed_actions"
-        || block.kind === "inline_tools"
-        || block.kind === "subagent_creations"
-      ) {
-        for (const itemId of block.itemIds) {
-          const item = transcript.itemsById[itemId];
-          if (item) {
-            items.push({ seq: item.startedSeq, rowIndex });
-          }
-        }
-      }
-    }
-  }
-
-  // Sort items by seq to enable binary-search-like positioning.
-  items.sort((a, b) => a.seq - b.seq);
-
-  // Determine if the first row is a leading user-message split.
-  const hasLeadingSplit = turnRows.length > 1 && turnRows[0].isFirstTurnRow && !turnRows[0].isLastTurnRow;
-
-  // Sort goal rows by seq to maintain order.
-  const sortedGoalRows = [...goalRows].sort((a, b) => a.event.seq - b.event.seq);
-
-  // For each goal event, determine which row it should be inserted after.
-  // A goal at seq N should appear:
-  // - AFTER the row containing the last item with seq < N, AND
-  // - BEFORE the row containing the first item with seq >= N
-  // This ensures goals render at their chronological position, even if that
-  // position is mid-way through a row's content (the row will have been split
-  // to enable this).
-  const goalInsertionPoints = new Map<number, GoalEventRow[]>(); // rowIndex -> goals to insert after
-
-  for (const goalRow of sortedGoalRows) {
-    const goalSeq = goalRow.event.seq;
-
-    // Find the row containing the last item with seq < goalSeq.
-    // If the next item (seq >= goalSeq) is in a DIFFERENT row, insert after
-    // the current row. Otherwise, the goal falls mid-row, and the row should
-    // have been split — but if not, we insert before that row.
-    let lastItemBefore: ItemEntry | null = null;
-    let firstItemAtOrAfter: ItemEntry | null = null;
-
-    for (const item of items) {
-      if (item.seq < goalSeq) {
-        lastItemBefore = item;
-      } else if (item.seq >= goalSeq && firstItemAtOrAfter === null) {
-        firstItemAtOrAfter = item;
-        break;
-      }
-    }
-
-    let targetRowIndex: number;
-    if (lastItemBefore === null) {
-      // Goal precedes all items. Insert after the leading split row if it
-      // exists, otherwise before all rows.
-      targetRowIndex = hasLeadingSplit ? 0 : -1;
-    } else if (firstItemAtOrAfter === null) {
-      // Goal follows all items. Insert after the row containing the last item.
-      targetRowIndex = lastItemBefore.rowIndex;
-    } else if (lastItemBefore.rowIndex !== firstItemAtOrAfter.rowIndex) {
-      // Goal falls between two different rows. This is the clean case: insert
-      // after lastItemBefore's row, which places it before firstItemAtOrAfter's row.
-      targetRowIndex = lastItemBefore.rowIndex;
-    } else {
-      // Goal falls mid-row: the row contains both the last item <= goalSeq
-      // and the first item > goalSeq. Insert the goal AFTER this row, since
-      // we can't split it finer than the user/content boundary.
-      targetRowIndex = lastItemBefore.rowIndex;
-    }
-
-    const existing = goalInsertionPoints.get(targetRowIndex);
-    if (existing) {
-      existing.push(goalRow);
-    } else {
-      goalInsertionPoints.set(targetRowIndex, [goalRow]);
-    }
-  }
-
-  // Assemble the result by interleaving turn rows with goal rows.
-  const result: TranscriptRow[] = [];
-
-  // Insert any goals that should come before all rows.
-  const beforeAllGoals = goalInsertionPoints.get(-1);
-  if (beforeAllGoals) {
-    result.push(...beforeAllGoals);
-  }
-
-  for (let rowIndex = 0; rowIndex < turnRows.length; rowIndex += 1) {
-    result.push(turnRows[rowIndex]);
-
-    // Insert any goals that should come after this row.
-    const afterThisRowGoals = goalInsertionPoints.get(rowIndex);
-    if (afterThisRowGoals) {
-      result.push(...afterThisRowGoals);
-    }
-  }
-
-  return result;
-}
+const EMPTY_COMPLETION_RECEIPTS: readonly BackgroundCompletionReceipt[] = [];
 
 /**
  * Selects the row that hosts the workspace-creation receipt among a turn's

--- a/apps/packages/product-client/src/domain/chats/transcript/turn-row-presentation.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/turn-row-presentation.ts
@@ -42,16 +42,31 @@ export function resolveTurnAssistantFooterMode({
  * moved the transcript bottom by the slot + column gap every time. During an
  * assistant prose reveal the streaming answer owns the frontier, so the box
  * hides entirely — same single settle as before.
+ *
+ * The empty reserve is keyed on genuine stream liveness (`turnIsActivelyStreaming`,
+ * from the session view state), NOT on the turn-completion stamp. The runtime
+ * drops the completion tail for injected background-work wake turns (defect D3),
+ * so `isLatestTurnInProgress` (`isLatestTurn && !turn.completedAt`) stays true
+ * forever in the live view and would otherwise leave a dead ~44-56px reserve
+ * band between the settled wake prose and its timestamp footer. Mirrors the
+ * round-4 footer fix: an idle session with a dropped-tail latest turn resolves
+ * "hidden". A genuine trailing status still wins ("status") whenever present, so
+ * a permission pause (needs_input) that carries an interaction indicator is
+ * unaffected; a needs_input turn with no trailing status resolves "hidden"
+ * rather than a dead reserve, staying coherent with the footer, which treats
+ * the same non-"working" turn as settled/copyable.
  */
 export function resolveTurnFrontierStatusMode({
   hasTrailingStatus,
   rowIsLastTurnRow,
   isLatestTurnInProgress,
+  turnIsActivelyStreaming,
   assistantRevealComplete,
 }: {
   hasTrailingStatus: boolean;
   rowIsLastTurnRow: boolean;
   isLatestTurnInProgress: boolean;
+  turnIsActivelyStreaming: boolean;
   assistantRevealComplete: boolean;
 }): "status" | "reserved" | "hidden" {
   if (!assistantRevealComplete) {
@@ -60,7 +75,9 @@ export function resolveTurnFrontierStatusMode({
   if (hasTrailingStatus) {
     return "status";
   }
-  return rowIsLastTurnRow && isLatestTurnInProgress ? "reserved" : "hidden";
+  return rowIsLastTurnRow && isLatestTurnInProgress && turnIsActivelyStreaming
+    ? "reserved"
+    : "hidden";
 }
 
 export function shouldRenderStandaloneStoppedNotice(

--- a/apps/packages/product-client/src/hooks/activity/derived/use-background-completion-receipts.test.ts
+++ b/apps/packages/product-client/src/hooks/activity/derived/use-background-completion-receipts.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ActivityProcessWire } from "#product/domain/activity/process";
+import type { ActivitySubagentWire } from "#product/domain/activity/subagent";
+import type { SessionActivityState } from "#product/hooks/activity/derived/use-session-activity";
+import { useBackgroundCompletionReceipts } from "./use-background-completion-receipts";
+
+function emptyActivity(): SessionActivityState {
+  return {
+    loops: [],
+    loopCapabilities: { supported: false, native: false },
+    processes: [],
+    agents: [],
+  };
+}
+
+// Per-session slice, same shape as use-background-work-finish-signal-tracking's
+// test mock — lets a session's own roster diverge from the id the hook is
+// called with.
+let sessionActivityBySessionId: Record<string, SessionActivityState> = {};
+
+vi.mock("#product/hooks/activity/derived/use-session-activity", () => ({
+  useSessionActivityForSession: (sessionId: string | null) =>
+    (sessionId ? sessionActivityBySessionId[sessionId] : undefined) ?? {
+      loops: [],
+      loopCapabilities: { supported: false, native: false },
+      processes: [],
+      agents: [],
+    },
+}));
+
+function makeProcess(overrides: Partial<ActivityProcessWire>): ActivityProcessWire {
+  return {
+    id: "proc-1",
+    command: "pytest -q tests/e2e",
+    cwd: null,
+    status: { status: "running" },
+    pid: null,
+    startedAt: "2026-08-17T00:00:00.000Z",
+    endedAt: null,
+    feed: null,
+    ...overrides,
+  };
+}
+
+function makeAgent(overrides: Partial<ActivitySubagentWire>): ActivitySubagentWire {
+  return {
+    id: "task-1",
+    agentType: "general",
+    description: "audit the roster",
+    model: null,
+    background: true,
+    status: { status: "running" },
+    usage: null,
+    feed: null,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  sessionActivityBySessionId = {};
+  cleanup();
+});
+
+describe("useBackgroundCompletionReceipts", () => {
+  it("appends a terminal receipt when a running process exits", () => {
+    sessionActivityBySessionId["s1"] = {
+      ...emptyActivity(),
+      processes: [makeProcess({ id: "p1", status: { status: "running" } })],
+    };
+    const { result, rerender } = renderHook(
+      ({ sessionId, anchorTurnId }) => useBackgroundCompletionReceipts(sessionId, anchorTurnId),
+      { initialProps: { sessionId: "s1" as string | null, anchorTurnId: "turn-1" as string | null } },
+    );
+    expect(result.current).toEqual([]);
+
+    sessionActivityBySessionId["s1"] = {
+      ...emptyActivity(),
+      processes: [
+        makeProcess({
+          id: "p1",
+          status: { status: "exited", exitCode: 0 },
+          endedAt: "2026-08-17T00:01:00.000Z",
+        }),
+      ],
+    };
+    rerender({ sessionId: "s1", anchorTurnId: "turn-1" });
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toMatchObject({
+      kind: "terminal",
+      processId: "p1",
+      command: "pytest -q tests/e2e",
+      exitCode: 0,
+    });
+  });
+
+  it("stamps the receipt with the anchor turn latest at observation, and does not restamp when a later (wake) turn arrives", () => {
+    sessionActivityBySessionId["s1"] = {
+      ...emptyActivity(),
+      processes: [makeProcess({ id: "p1", status: { status: "running" } })],
+    };
+    const { result, rerender } = renderHook(
+      ({ sessionId, anchorTurnId }) => useBackgroundCompletionReceipts(sessionId, anchorTurnId),
+      { initialProps: { sessionId: "s1" as string | null, anchorTurnId: "turn-agent" as string | null } },
+    );
+
+    sessionActivityBySessionId["s1"] = {
+      ...emptyActivity(),
+      processes: [
+        makeProcess({ id: "p1", status: { status: "exited", exitCode: 0 }, endedAt: "2026-08-17T00:01:00.000Z" }),
+      ],
+    };
+    // The process exits while "turn-agent" is the latest turn.
+    rerender({ sessionId: "s1", anchorTurnId: "turn-agent" });
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].anchorTurnId).toBe("turn-agent");
+
+    // The wake turn now streams in and becomes the latest turn — the already
+    // emitted receipt keeps its original anchor rather than jumping after the
+    // wake turn.
+    rerender({ sessionId: "s1", anchorTurnId: "turn-wake" });
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].anchorTurnId).toBe("turn-agent");
+  });
+
+  it("appends a subagent receipt when a running subagent vanishes, and does not double-append", () => {
+    sessionActivityBySessionId["s1"] = { ...emptyActivity(), agents: [makeAgent({ id: "a1" })] };
+    const { result, rerender } = renderHook(
+      ({ sessionId, anchorTurnId }) => useBackgroundCompletionReceipts(sessionId, anchorTurnId),
+      { initialProps: { sessionId: "s1" as string | null, anchorTurnId: "turn-1" as string | null } },
+    );
+    expect(result.current).toEqual([]);
+
+    sessionActivityBySessionId["s1"] = { ...emptyActivity(), agents: [] };
+    rerender({ sessionId: "s1", anchorTurnId: "turn-1" });
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toMatchObject({ kind: "subagent", subagentId: "a1", outcome: "completed" });
+
+    // A later idle pass must not re-emit the same completion.
+    rerender({ sessionId: "s1", anchorTurnId: "turn-1" });
+    expect(result.current).toHaveLength(1);
+  });
+
+  it("does NOT receipt work already finished at mount (roster-seed backlog)", () => {
+    sessionActivityBySessionId["s1"] = {
+      ...emptyActivity(),
+      processes: [
+        makeProcess({
+          id: "seed",
+          status: { status: "exited", exitCode: 0 },
+          endedAt: "2026-08-17T00:00:30.000Z",
+        }),
+      ],
+    };
+    const { result } = renderHook(
+      ({ sessionId, anchorTurnId }) => useBackgroundCompletionReceipts(sessionId, anchorTurnId),
+      { initialProps: { sessionId: "s1" as string | null, anchorTurnId: "turn-1" as string | null } },
+    );
+    expect(result.current).toEqual([]);
+  });
+
+  it("resets its accumulation on session switch rather than carrying receipts across sessions", () => {
+    sessionActivityBySessionId["s1"] = {
+      ...emptyActivity(),
+      processes: [makeProcess({ id: "p1", status: { status: "running" } })],
+    };
+    const { result, rerender } = renderHook(
+      ({ sessionId, anchorTurnId }) => useBackgroundCompletionReceipts(sessionId, anchorTurnId),
+      { initialProps: { sessionId: "s1" as string | null, anchorTurnId: "turn-1" as string | null } },
+    );
+
+    sessionActivityBySessionId["s1"] = {
+      ...emptyActivity(),
+      processes: [
+        makeProcess({ id: "p1", status: { status: "exited", exitCode: 0 }, endedAt: "2026-08-17T00:01:00.000Z" }),
+      ],
+    };
+    rerender({ sessionId: "s1", anchorTurnId: "turn-1" });
+    expect(result.current).toHaveLength(1);
+
+    sessionActivityBySessionId["s2"] = emptyActivity();
+    rerender({ sessionId: "s2", anchorTurnId: null });
+    expect(result.current).toEqual([]);
+  });
+});

--- a/apps/packages/product-client/src/hooks/activity/derived/use-background-completion-receipts.ts
+++ b/apps/packages/product-client/src/hooks/activity/derived/use-background-completion-receipts.ts
@@ -1,0 +1,97 @@
+import { useEffect, useRef, useState } from "react";
+import type { ActivitySubagentWire } from "#product/domain/activity/subagent";
+import { isProcessRunning } from "#product/domain/activity/process";
+import {
+  deriveNewCompletionReceipts,
+  type BackgroundCompletionReceipt,
+} from "#product/domain/activity/background-completion-receipt";
+import { useSessionActivityForSession } from "#product/hooks/activity/derived/use-session-activity";
+
+interface ReceiptAccumulator {
+  sessionId: string | null;
+  runningProcessIds: Set<string>;
+  runningAgentsById: Map<string, ActivitySubagentWire>;
+  receiptedKeys: Set<string>;
+}
+
+function emptyAccumulator(sessionId: string | null): ReceiptAccumulator {
+  return {
+    sessionId,
+    runningProcessIds: new Set(),
+    runningAgentsById: new Map(),
+    receiptedKeys: new Set(),
+  };
+}
+
+/**
+ * Accumulates inline completion receipts for a session by watching its
+ * activity fold (bgwork r6). Mirrors `useBackgroundWorkFinishSignalTracking`'s
+ * transition-detection shape: it reads the SAME per-session roster slice
+ * (`useSessionActivityForSession`), remembers what it last saw running, and
+ * appends a receipt the moment a process exits or a native subagent finishes.
+ *
+ * The accumulation is deliberately ephemeral (path b, disclosed defect D1):
+ * receipts only cover completions observed while this hook is mounted for the
+ * session — work already finished at mount (roster seed) is baselined, not
+ * receipted, and nothing survives a reload. The wire fix that would make these
+ * durable and correctly ordered is flagged for the wire rung.
+ *
+ * Switching `sessionId` resets the accumulator to that session's own baseline
+ * rather than carrying receipts across sessions (this hook's host,
+ * `SessionTranscriptPane`, is not remounted per session).
+ */
+export function useBackgroundCompletionReceipts(
+  sessionId: string | null,
+  anchorTurnId: string | null,
+): BackgroundCompletionReceipt[] {
+  const activity = useSessionActivityForSession(sessionId);
+  const [receipts, setReceipts] = useState<BackgroundCompletionReceipt[]>([]);
+  const accumulatorRef = useRef<ReceiptAccumulator>(emptyAccumulator(sessionId));
+  // Read at observation time only, never a re-run trigger: a receipt is
+  // stamped with whatever turn was latest when its completion was folded, so
+  // the row model can interleave it right after that turn (bgwork r6 round 2).
+  // The transcript growing a later (e.g. wake) turn must NOT restamp an
+  // already-emitted receipt, hence a ref rather than an effect dependency.
+  const anchorTurnIdRef = useRef(anchorTurnId);
+  anchorTurnIdRef.current = anchorTurnId;
+
+  useEffect(() => {
+    let accumulator = accumulatorRef.current;
+    if (accumulator.sessionId !== sessionId) {
+      accumulator = emptyAccumulator(sessionId);
+      accumulatorRef.current = accumulator;
+      setReceipts([]);
+    }
+
+    if (!sessionId) {
+      return;
+    }
+
+    const newReceipts = deriveNewCompletionReceipts({
+      previousRunningProcessIds: accumulator.runningProcessIds,
+      previousRunningAgentsById: accumulator.runningAgentsById,
+      processes: activity.processes,
+      agents: activity.agents,
+      alreadyReceiptedKeys: accumulator.receiptedKeys,
+      anchorTurnId: anchorTurnIdRef.current,
+      nowMs: Date.now(),
+    });
+    if (newReceipts.length > 0) {
+      for (const receipt of newReceipts) {
+        accumulator.receiptedKeys.add(receipt.key);
+      }
+      setReceipts((previous) => [...previous, ...newReceipts]);
+    }
+
+    accumulator.runningProcessIds = new Set(
+      activity.processes.filter(isProcessRunning).map((process) => process.id),
+    );
+    accumulator.runningAgentsById = new Map(
+      activity.agents
+        .filter((agent) => agent.status.status === "running")
+        .map((agent) => [agent.id, agent] as const),
+    );
+  }, [sessionId, activity.processes, activity.agents]);
+
+  return receipts;
+}

--- a/apps/packages/product-client/src/hooks/activity/workflows/use-open-background-work-pane.test.tsx
+++ b/apps/packages/product-client/src/hooks/activity/workflows/use-open-background-work-pane.test.tsx
@@ -5,7 +5,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WORKSPACE_UI_DEFAULTS } from "#product/lib/domain/preferences/workspace-ui/model";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
-import { useOpenBackgroundWorkPane } from "./use-open-background-work-pane";
+import {
+  useOpenBackgroundTerminalDetail,
+  useOpenBackgroundWorkPane,
+} from "./use-open-background-work-pane";
 
 const mocks = vi.hoisted(() => ({
   useWorkspaces: vi.fn(),
@@ -139,5 +142,83 @@ describe("useOpenBackgroundWorkPane", () => {
     const headerOrder = useWorkspaceUiStore.getState()
       .rightPanelMaterializedByWorkspace["workspace-1"]?.headerOrder ?? [];
     expect(headerOrder.filter((key) => key === "tool:background")).toHaveLength(1);
+  });
+});
+
+describe("useOpenBackgroundTerminalDetail (bgwork r6)", () => {
+  beforeEach(() => {
+    useSessionSelectionStore.getState().clearSelection();
+    mocks.useWorkspaces.mockReturnValue({ data: undefined });
+    useWorkspaceUiStore.setState({
+      ...WORKSPACE_UI_DEFAULTS,
+      _hydrated: true,
+      shellActivationEpochByWorkspace: {},
+      pendingChatActivationByWorkspace: {},
+      pendingBackgroundSubagentSelectionByWorkspace: {},
+      pendingBackgroundProcessSelectionByWorkspace: {},
+      rightPanelMaterializedByWorkspace: {},
+      rightPanelDurableByWorkspace: {},
+      urgentHighlightedChatSessionByWorkspace: {},
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    useSessionSelectionStore.getState().clearSelection();
+  });
+
+  it("writes a session-scoped pending process selection and opens the pane", () => {
+    useSessionSelectionStore.getState().activateWorkspace({
+      logicalWorkspaceId: "logical-1",
+      workspaceId: "workspace-1",
+    });
+
+    const { result } = renderHook(() => useOpenBackgroundTerminalDetail());
+
+    act(() => {
+      result.current("proc-7", "session-1");
+    });
+
+    expect(
+      useWorkspaceUiStore.getState().pendingBackgroundProcessSelectionByWorkspace["workspace-1"],
+    ).toEqual({ processId: "proc-7", sessionId: "session-1" });
+    expect(
+      useWorkspaceUiStore.getState().rightPanelMaterializedByWorkspace["workspace-1"],
+    ).toMatchObject({ activeEntryKey: "tool:background" });
+  });
+
+  it("does not write a pending process selection for the bare (pane-only) call", () => {
+    useSessionSelectionStore.getState().activateWorkspace({
+      logicalWorkspaceId: "logical-1",
+      workspaceId: "workspace-1",
+    });
+
+    const { result } = renderHook(() => useOpenBackgroundTerminalDetail());
+
+    act(() => {
+      result.current();
+    });
+
+    expect(
+      useWorkspaceUiStore.getState().pendingBackgroundProcessSelectionByWorkspace["workspace-1"],
+    ).toBeUndefined();
+    // Still opens the pane.
+    expect(
+      useWorkspaceUiStore.getState().rightPanelMaterializedByWorkspace["workspace-1"],
+    ).toMatchObject({ activeEntryKey: "tool:background" });
+  });
+
+  it("does nothing when no workspace is selected", () => {
+    const { result } = renderHook(() => useOpenBackgroundTerminalDetail());
+
+    act(() => {
+      result.current("proc-7", "session-1");
+    });
+
+    expect(useWorkspaceUiStore.getState().rightPanelMaterializedByWorkspace).toEqual({});
+    expect(
+      useWorkspaceUiStore.getState().pendingBackgroundProcessSelectionByWorkspace,
+    ).toEqual({});
   });
 });

--- a/apps/packages/product-client/src/hooks/activity/workflows/use-open-background-work-pane.ts
+++ b/apps/packages/product-client/src/hooks/activity/workflows/use-open-background-work-pane.ts
@@ -29,7 +29,14 @@ import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-st
  * Existing zero-arg call sites (`BackgroundWorkTranscriptRow`'s `onOpen`)
  * are unaffected: both arguments are optional and only take effect together.
  */
-export function useOpenBackgroundWorkPane(): (subagentId?: string, sessionId?: string) => void {
+interface BackgroundWorkPaneOpener {
+  /** The workspace a pending selection must be keyed under, or null when none is active. */
+  materializedWorkspaceId: string | null;
+  /** Materialize the `background` tool entry and open the right panel. No-op with no active workspace. */
+  openPane: () => void;
+}
+
+function useBackgroundWorkPaneOpener(): BackgroundWorkPaneOpener {
   const { workspaceUiKey, materializedWorkspaceId } = useWorkspaceFileContext();
   const setRightPanelMaterializedForWorkspace = useWorkspaceUiStore(
     (state) => state.setRightPanelMaterializedForWorkspace,
@@ -37,22 +44,11 @@ export function useOpenBackgroundWorkPane(): (subagentId?: string, sessionId?: s
   const setRightPanelOpenForWorkspace = useWorkspaceUiStore(
     (state) => state.setRightPanelOpenForWorkspace,
   );
-  const setPendingBackgroundSubagentSelectionForWorkspace = useWorkspaceUiStore(
-    (state) => state.setPendingBackgroundSubagentSelectionForWorkspace,
-  );
 
-  return useCallback((subagentId?: string, sessionId?: string) => {
+  const openPane = useCallback(() => {
     if (!materializedWorkspaceId || !workspaceUiKey) {
       return;
     }
-
-    if (subagentId && sessionId) {
-      setPendingBackgroundSubagentSelectionForWorkspace(materializedWorkspaceId, {
-        subagentId,
-        sessionId,
-      });
-    }
-
     const backgroundEntryKey = rightPanelToolHeaderKey("background");
     setRightPanelMaterializedForWorkspace(materializedWorkspaceId, (previous) => ({
       ...previous,
@@ -64,9 +60,53 @@ export function useOpenBackgroundWorkPane(): (subagentId?: string, sessionId?: s
     setRightPanelOpenForWorkspace(workspaceUiKey, true);
   }, [
     materializedWorkspaceId,
-    setPendingBackgroundSubagentSelectionForWorkspace,
     setRightPanelMaterializedForWorkspace,
     setRightPanelOpenForWorkspace,
     workspaceUiKey,
   ]);
+
+  return { materializedWorkspaceId, openPane };
+}
+
+export function useOpenBackgroundWorkPane(): (subagentId?: string, sessionId?: string) => void {
+  const { materializedWorkspaceId, openPane } = useBackgroundWorkPaneOpener();
+  const setPendingBackgroundSubagentSelectionForWorkspace = useWorkspaceUiStore(
+    (state) => state.setPendingBackgroundSubagentSelectionForWorkspace,
+  );
+
+  return useCallback((subagentId?: string, sessionId?: string) => {
+    if (materializedWorkspaceId && subagentId && sessionId) {
+      setPendingBackgroundSubagentSelectionForWorkspace(materializedWorkspaceId, {
+        subagentId,
+        sessionId,
+      });
+    }
+    openPane();
+  }, [materializedWorkspaceId, openPane, setPendingBackgroundSubagentSelectionForWorkspace]);
+}
+
+/**
+ * Terminal counterpart of `useOpenBackgroundWorkPane` (bgwork r6): deep-opens
+ * the Background work pane straight to one process's `BackgroundTerminalView`.
+ * A background terminal's completion receipt (`BackgroundCompletionReceipt`)
+ * wires its command button here. Same one-shot, session-scoped selection
+ * mechanism as the subagent path — the pane consumes and clears it on its next
+ * render, discarding a cross-session entry. The `processId`/`sessionId` pair
+ * only takes effect together; a bare call just opens the pane on its roster.
+ */
+export function useOpenBackgroundTerminalDetail(): (processId?: string, sessionId?: string) => void {
+  const { materializedWorkspaceId, openPane } = useBackgroundWorkPaneOpener();
+  const setPendingBackgroundProcessSelectionForWorkspace = useWorkspaceUiStore(
+    (state) => state.setPendingBackgroundProcessSelectionForWorkspace,
+  );
+
+  return useCallback((processId?: string, sessionId?: string) => {
+    if (materializedWorkspaceId && processId && sessionId) {
+      setPendingBackgroundProcessSelectionForWorkspace(materializedWorkspaceId, {
+        processId,
+        sessionId,
+      });
+    }
+    openPane();
+  }, [materializedWorkspaceId, openPane, setPendingBackgroundProcessSelectionForWorkspace]);
 }

--- a/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-view-types.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-view-types.ts
@@ -10,6 +10,7 @@ import type { SessionViewState } from "#product/domain/sessions/activity";
 import type { TranscriptVirtualRow } from "#product/domain/chats/transcript/transcript-virtual-rows";
 import type { TurnDisplayBlock } from "#product/domain/chats/transcript/transcript-presentation";
 import type { GoalTranscriptEvent } from "#product/domain/activity/goal-transcript-events";
+import type { BackgroundCompletionReceipt } from "#product/domain/activity/background-completion-receipt";
 
 export interface ChatTranscriptOutboxActions {
   retryPrompt: (clientPromptId: string) => void;
@@ -61,6 +62,18 @@ export interface ChatTranscriptGoalEventRenderInput {
   event: GoalTranscriptEvent;
 }
 
+export interface ChatTranscriptCompletionReceiptRenderInput {
+  row: Extract<TranscriptVirtualRow, { kind: "completion_receipt" }>;
+  rowIndex: number;
+  receipt: BackgroundCompletionReceipt;
+}
+
+export interface ChatTranscriptBackgroundWorkRenderInput {
+  row: Extract<TranscriptVirtualRow, { kind: "background_work" }>;
+  rowIndex: number;
+  runningCount: number;
+}
+
 /** Active chat content-search state driving the prose paint layer. */
 export interface ChatTranscriptContentSearch {
   query: string;
@@ -87,6 +100,13 @@ export interface ChatTranscriptViewProps {
   renderTurnTrailingStatus?: (input: ChatTranscriptTurnStatusInput) => ReactNode;
   /** Omitted surfaces (e.g. the cloud preview transcript) render no goal rows. */
   renderGoalEventRow?: (input: ChatTranscriptGoalEventRenderInput) => ReactNode;
+  /**
+   * Renders an inline background-work completion receipt row (bgwork r6 round
+   * 2). Omitted surfaces render no receipts even if the state carries them.
+   */
+  renderCompletionReceiptRow?: (input: ChatTranscriptCompletionReceiptRenderInput) => ReactNode;
+  /** Renders the quiet running-background-work footer row (bgwork r6 round 2). */
+  renderBackgroundWorkRow?: (input: ChatTranscriptBackgroundWorkRenderInput) => ReactNode;
   /**
    * Chat content search. When set (search open on the chat surface), the
    * transcript prose is highlighted for `query`. Null/undefined disables the

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-row-height-estimate.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-row-height-estimate.ts
@@ -49,6 +49,9 @@ import type { TranscriptRenderableRow } from "#product/hooks/chat/ui/transcript-
 const ESTIMATED_TURN_HEIGHT_PX = 360;
 const ESTIMATED_HISTORY_LOADING_ROW_HEIGHT_PX = 32;
 const ESTIMATED_GOAL_EVENT_ROW_HEIGHT_PX = 28;
+// Background-work rows (a completion receipt, or the running-count footer) are
+// likewise single-line quiet rows, not turn content (bgwork r6 round 2).
+const ESTIMATED_BACKGROUND_WORK_ROW_HEIGHT_PX = 32;
 
 const ESTIMATED_SINGLE_BLOCK_TURN_HEIGHT_PX = 120;
 const ESTIMATED_SHORT_MULTI_BLOCK_TURN_HEIGHT_PX = 220;
@@ -142,6 +145,9 @@ export function estimateRenderableRowHeight(
   }
   if (row.row.kind === "goal_event") {
     return ESTIMATED_GOAL_EVENT_ROW_HEIGHT_PX;
+  }
+  if (row.row.kind === "completion_receipt" || row.row.kind === "background_work") {
+    return ESTIMATED_BACKGROUND_WORK_ROW_HEIGHT_PX;
   }
   if (row.row.kind === "turn") {
     return estimateTurnRowHeight(row.row.blockKey, row.row.renderPresentation.displayBlocks);
@@ -248,6 +254,11 @@ export function getRowCompositionToken(
   }
   if (row.row.kind === "outbox_prompt") {
     return `outbox:${row.row.clientPromptId}:${row.row.hostsWorkspaceReceipt ?? false}`;
+  }
+  if (row.row.kind === "completion_receipt" || row.row.kind === "background_work") {
+    // Single-line quiet rows (bgwork r6): no composition variants that change
+    // their height shape, so the kind itself is a stable token.
+    return row.row.kind;
   }
   return `pending:${row.row.hostsWorkspaceReceipt ?? false}`;
 }

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-row-renderer.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-row-renderer.test.tsx
@@ -299,4 +299,78 @@ describe("useChatTranscriptRowRenderer", () => {
     expect(rendered.getByTestId("integrated-latest-row").textContent).toBe("working:Renamed");
     expect(renderTurnRow).toHaveBeenCalledTimes(3);
   });
+
+  const COMPLETION_RECEIPT_ROW = {
+    kind: "completion_receipt",
+    key: "completion-receipt:terminal:p1",
+    receipt: {
+      kind: "terminal",
+      key: "terminal:p1",
+      processId: "p1",
+      command: "echo hi",
+      exitCode: 0,
+      atMs: 1,
+      anchorTurnId: "turn-a",
+    },
+  } as TranscriptVirtualRow;
+  const BACKGROUND_WORK_ROW = {
+    kind: "background_work",
+    key: "background-work",
+    runningCount: 2,
+  } as TranscriptVirtualRow;
+
+  function baseRendererInput(overrides: {
+    renderCompletionReceiptRow?: (input: unknown) => ReactNode;
+    renderBackgroundWorkRow?: (input: unknown) => ReactNode;
+  }) {
+    return {
+      activeSessionId: "session-1",
+      latestLiveExplorationBlock: null,
+      latestLiveStatus: null,
+      latestCompletedTurnId: null,
+      latestTurnId: "latest",
+      optimisticPromptTrailingStatus: null,
+      outboxActions: OUTBOX_ACTIONS,
+      outboxStartedAtByPromptId: OUTBOX_STARTED_AT_BY_PROMPT_ID,
+      renderPendingPromptRow: () => null,
+      renderTurnRow: () => null,
+      selectedWorkspaceId: "workspace-1",
+      sessionViewState: "working" as const,
+      transcript: createTranscriptState("session-1"),
+      visibleOutboxEntries: [],
+      visibleOptimisticPrompt: null,
+      ...overrides,
+    };
+  }
+
+  it("dispatches completion_receipt and background_work rows to their render callbacks (bgwork r6 round 2)", () => {
+    const renderCompletionReceiptRow = vi.fn(() => <span>receipt</span>);
+    const renderBackgroundWorkRow = vi.fn(() => <span>footer</span>);
+    const { result } = renderHook(() =>
+      useChatTranscriptRowRenderer(
+        baseRendererInput({ renderCompletionReceiptRow, renderBackgroundWorkRow }),
+      ),
+    );
+
+    result.current.renderRow(COMPLETION_RECEIPT_ROW, 3);
+    result.current.renderRow(BACKGROUND_WORK_ROW, 4);
+
+    expect(renderCompletionReceiptRow).toHaveBeenCalledWith(expect.objectContaining({
+      row: COMPLETION_RECEIPT_ROW,
+      rowIndex: 3,
+      receipt: expect.objectContaining({ kind: "terminal", processId: "p1" }),
+    }));
+    expect(renderBackgroundWorkRow).toHaveBeenCalledWith(expect.objectContaining({
+      row: BACKGROUND_WORK_ROW,
+      rowIndex: 4,
+      runningCount: 2,
+    }));
+  });
+
+  it("renders null for background-work rows when the surface omits the callbacks (e.g. cloud preview)", () => {
+    const { result } = renderHook(() => useChatTranscriptRowRenderer(baseRendererInput({})));
+
+    expect(result.current.renderRow(COMPLETION_RECEIPT_ROW, 0)).toBeNull();
+    expect(result.current.renderRow(BACKGROUND_WORK_ROW, 0)).toBeNull();
+  });
 });

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-row-renderer.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-row-renderer.ts
@@ -8,6 +8,8 @@ import type { SessionViewState } from "#product/domain/sessions/activity";
 import type { TranscriptVirtualRow } from "#product/domain/chats/transcript/transcript-virtual-rows";
 import type { TurnDisplayBlock } from "#product/domain/chats/transcript/transcript-presentation";
 import type {
+  ChatTranscriptBackgroundWorkRenderInput,
+  ChatTranscriptCompletionReceiptRenderInput,
   ChatTranscriptGoalEventRenderInput,
   ChatTranscriptOutboxActions,
   ChatTranscriptPendingPromptRenderInput,
@@ -32,6 +34,8 @@ export function useChatTranscriptRowRenderer({
   renderPendingPromptRow,
   renderTurnRow,
   renderGoalEventRow,
+  renderCompletionReceiptRow,
+  renderBackgroundWorkRow,
   selectedWorkspaceId,
   sessionViewState,
   transcript,
@@ -49,6 +53,8 @@ export function useChatTranscriptRowRenderer({
   renderPendingPromptRow: (input: ChatTranscriptPendingPromptRenderInput) => ReactNode;
   renderTurnRow: (input: ChatTranscriptTurnRowRenderInput) => ReactNode;
   renderGoalEventRow?: (input: ChatTranscriptGoalEventRenderInput) => ReactNode;
+  renderCompletionReceiptRow?: (input: ChatTranscriptCompletionReceiptRenderInput) => ReactNode;
+  renderBackgroundWorkRow?: (input: ChatTranscriptBackgroundWorkRenderInput) => ReactNode;
   selectedWorkspaceId: string | null;
   sessionViewState: SessionViewState;
   transcript: TranscriptState;
@@ -83,6 +89,14 @@ export function useChatTranscriptRowRenderer({
       return renderGoalEventRow?.({ row, rowIndex, event: row.event }) ?? null;
     }
 
+    if (row.kind === "completion_receipt") {
+      return renderCompletionReceiptRow?.({ row, rowIndex, receipt: row.receipt }) ?? null;
+    }
+
+    if (row.kind === "background_work") {
+      return renderBackgroundWorkRow?.({ row, rowIndex, runningCount: row.runningCount }) ?? null;
+    }
+
     const turn = transcript.turnsById[row.turnId];
     if (!turn) {
       return null;
@@ -113,6 +127,8 @@ export function useChatTranscriptRowRenderer({
     renderPendingPromptRow,
     renderTurnRow,
     renderGoalEventRow,
+    renderCompletionReceiptRow,
+    renderBackgroundWorkRow,
     selectedWorkspaceId,
     sessionViewState,
     transcript,
@@ -154,6 +170,12 @@ export function useChatTranscriptRowRenderer({
     visibleOutboxEntries,
   ]);
   const goalEventRenderRevision = useMemo(() => ({}), [renderGoalEventRow]);
+  // Both background-work rows carry their state in the row model itself (a new
+  // row object is minted whenever the receipt list or running count changes),
+  // so a renderer-identity revision is all these need — the memo's own
+  // `prev.row === next.row` check drives the re-render.
+  const completionReceiptRenderRevision = useMemo(() => ({}), [renderCompletionReceiptRow]);
+  const backgroundWorkRenderRevision = useMemo(() => ({}), [renderBackgroundWorkRow]);
 
   const getRowRenderRevision = useCallback((row: TranscriptVirtualRow): object => {
     if (row.kind === "pending_prompt" || row.kind === "outbox_prompt") {
@@ -161,6 +183,12 @@ export function useChatTranscriptRowRenderer({
     }
     if (row.kind === "goal_event") {
       return goalEventRenderRevision;
+    }
+    if (row.kind === "completion_receipt") {
+      return completionReceiptRenderRevision;
+    }
+    if (row.kind === "background_work") {
+      return backgroundWorkRenderRevision;
     }
     if (row.turnId === latestTurnId) {
       return latestTurnRenderRevision;
@@ -170,6 +198,8 @@ export function useChatTranscriptRowRenderer({
     }
     return turnRenderRevision;
   }, [
+    backgroundWorkRenderRevision,
+    completionReceiptRenderRevision,
     goalEventRenderRevision,
     latestCompletedTurnId,
     latestCompletedTurnRenderRevision,

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-view-model.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-view-model.ts
@@ -18,6 +18,7 @@ import {
 import type { TranscriptVirtualRow } from "#product/domain/chats/transcript/transcript-virtual-rows";
 import type { TurnDisplayBlock } from "#product/domain/chats/transcript/transcript-presentation";
 import type { GoalTranscriptEvent } from "#product/domain/activity/goal-transcript-events";
+import type { BackgroundCompletionReceipt } from "#product/domain/activity/background-completion-receipt";
 import type {
   ChatTranscriptPendingStatusInput,
   ChatTranscriptTurnStatusInput,
@@ -32,6 +33,7 @@ import { latestCompletedTurn } from "#product/domain/chats/transcript/last-turn-
 const noop = () => {};
 const EMPTY_OUTBOX_ENTRIES: readonly PromptOutboxEntry[] = [];
 const EMPTY_GOAL_EVENTS: readonly GoalTranscriptEvent[] = [];
+const EMPTY_COMPLETION_RECEIPTS: readonly BackgroundCompletionReceipt[] = [];
 
 export interface ChatTranscriptViewModel {
   activeSessionId: string;
@@ -79,6 +81,8 @@ export function useChatTranscriptViewModel({
     layout,
     goalEvents = EMPTY_GOAL_EVENTS,
     workspaceReceiptKey = null,
+    completionReceipts = EMPTY_COMPLETION_RECEIPTS,
+    backgroundWorkRunningCount = 0,
   } = state;
   const hasOlderHistory = history?.hasOlderHistory ?? false;
   const isLoadingOlderHistory = history?.isLoadingOlderHistory ?? false;
@@ -158,6 +162,8 @@ export function useChatTranscriptViewModel({
     // remain unloaded the top of the loaded window isn't the top of the
     // transcript, so the row must not render there.
     workspaceReceiptKey: hasOlderHistory ? null : workspaceReceiptKey,
+    completionReceipts,
+    backgroundWorkRunningCount,
   });
   const visibleTurnIds = useMemo(
     () => collectVisibleTurnIds(virtualRows),

--- a/apps/packages/product-client/src/hooks/chat/ui/use-shared-transcript-row-model.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-shared-transcript-row-model.ts
@@ -10,6 +10,7 @@ import {
 } from "#product/domain/chats/transcript/transcript-row-model";
 import type { TranscriptVirtualRow } from "#product/domain/chats/transcript/transcript-virtual-rows";
 import type { GoalTranscriptEvent } from "#product/domain/activity/goal-transcript-events";
+import type { BackgroundCompletionReceipt } from "#product/domain/activity/background-completion-receipt";
 
 export function useSharedTranscriptRowModel(input: {
   activeSessionId: string;
@@ -20,6 +21,8 @@ export function useSharedTranscriptRowModel(input: {
   latestTurnHasAssistantRenderableContent: boolean;
   goalEvents?: readonly GoalTranscriptEvent[];
   workspaceReceiptKey?: string | null;
+  completionReceipts?: readonly BackgroundCompletionReceipt[];
+  backgroundWorkRunningCount?: number;
 }): readonly TranscriptVirtualRow[] {
   const cacheRef = useRef(createTranscriptRowModelCache());
 
@@ -34,6 +37,8 @@ export function useSharedTranscriptRowModel(input: {
       input.visibleOutboxEntries,
       input.goalEvents,
       input.workspaceReceiptKey,
+      input.completionReceipts,
+      input.backgroundWorkRunningCount,
     ],
   );
 }

--- a/apps/packages/product-client/src/stores/preferences/workspace-ui-right-panel-actions.ts
+++ b/apps/packages/product-client/src/stores/preferences/workspace-ui-right-panel-actions.ts
@@ -19,6 +19,8 @@ type WorkspaceUiRightPanelActions = Pick<
   | "setRightPanelOpenForWorkspace"
   | "setPendingBackgroundSubagentSelectionForWorkspace"
   | "clearPendingBackgroundSubagentSelectionForWorkspace"
+  | "setPendingBackgroundProcessSelectionForWorkspace"
+  | "clearPendingBackgroundProcessSelectionForWorkspace"
   | "markBackgroundWorkViewedForSession"
   | "recordBackgroundWorkFinishedSubagentForSession"
 >;
@@ -126,6 +128,24 @@ export function createWorkspaceUiRightPanelActions(
       set((state) => ({
         pendingBackgroundSubagentSelectionByWorkspace: {
           ...state.pendingBackgroundSubagentSelectionByWorkspace,
+          [workspaceId]: null,
+        },
+      }));
+    },
+
+    setPendingBackgroundProcessSelectionForWorkspace: (workspaceId, selection) => {
+      set((state) => ({
+        pendingBackgroundProcessSelectionByWorkspace: {
+          ...state.pendingBackgroundProcessSelectionByWorkspace,
+          [workspaceId]: selection,
+        },
+      }));
+    },
+
+    clearPendingBackgroundProcessSelectionForWorkspace: (workspaceId) => {
+      set((state) => ({
+        pendingBackgroundProcessSelectionByWorkspace: {
+          ...state.pendingBackgroundProcessSelectionByWorkspace,
           [workspaceId]: null,
         },
       }));

--- a/apps/packages/product-client/src/stores/preferences/workspace-ui-store-types.ts
+++ b/apps/packages/product-client/src/stores/preferences/workspace-ui-store-types.ts
@@ -22,6 +22,18 @@ export interface PendingBackgroundSubagentSelection {
   sessionId: string;
 }
 
+/**
+ * Terminal counterpart of `PendingBackgroundSubagentSelection` (bgwork r6): a
+ * background terminal's completion receipt deep-opens straight to its
+ * `BackgroundTerminalView`. Same session-scoping contract — `sessionId` is the
+ * session active at write time, checked against the consuming pane's own
+ * `sessionId` so a cross-session entry is discarded rather than applied.
+ */
+export interface PendingBackgroundProcessSelection {
+  processId: string;
+  sessionId: string;
+}
+
 export interface WorkspaceUiState {
   _hydrated: boolean;
   pinnedWorkspaceIds: string[];
@@ -55,6 +67,17 @@ export interface WorkspaceUiState {
   pendingBackgroundSubagentSelectionByWorkspace: Record<
     string,
     PendingBackgroundSubagentSelection | null
+  >;
+  /**
+   * One-shot deep-link target for a background terminal's completion receipt
+   * (bgwork r6) — a process id to select the instant `BackgroundWorkPane` next
+   * renders for this workspace. Same ephemeral, workspace-keyed, session-
+   * checked contract as `pendingBackgroundSubagentSelectionByWorkspace` above;
+   * cleared by the pane the instant it is read, matched or not.
+   */
+  pendingBackgroundProcessSelectionByWorkspace: Record<
+    string,
+    PendingBackgroundProcessSelection | null
   >;
   /**
    * Finish-signal ladder rung 1 (`PanelHeaderEntry` dirty dot) — the epoch-ms
@@ -131,6 +154,13 @@ export interface WorkspaceUiState {
     selection: PendingBackgroundSubagentSelection,
   ) => void;
   clearPendingBackgroundSubagentSelectionForWorkspace: (
+    workspaceId: string,
+  ) => void;
+  setPendingBackgroundProcessSelectionForWorkspace: (
+    workspaceId: string,
+    selection: PendingBackgroundProcessSelection,
+  ) => void;
+  clearPendingBackgroundProcessSelectionForWorkspace: (
     workspaceId: string,
   ) => void;
   markBackgroundWorkViewedForSession: (sessionId: string, atMs?: number) => void;

--- a/apps/packages/product-client/src/stores/preferences/workspace-ui-store.ts
+++ b/apps/packages/product-client/src/stores/preferences/workspace-ui-store.ts
@@ -18,6 +18,7 @@ export const useWorkspaceUiStore = create<WorkspaceUiState>((set, get) => ({
   shellActivationEpochByWorkspace: {},
   pendingChatActivationByWorkspace: {},
   pendingBackgroundSubagentSelectionByWorkspace: {},
+  pendingBackgroundProcessSelectionByWorkspace: {},
   backgroundWorkLastViewedAtBySession: {},
   backgroundWorkLastFinishedSubagentBySession: {},
   urgentHighlightedChatSessionByWorkspace: {},

--- a/lints/frontend/ratchets.toml
+++ b/lints/frontend/ratchets.toml
@@ -53,8 +53,8 @@ reason = "relocated existing oversized domain test; +workspace-creation-receipt 
 
 [[max_lines]]
 path = "apps/packages/product-client/src/domain/chats/transcript/transcript-row-model.ts"
-max_lines = 1017
-reason = "relocated existing oversized domain source; receipt folded into first turn's Worked-for group; the standalone workspace_receipt row kind is deleted — before any turn exists the receipt instead hosts via hostsWorkspaceReceipt on the last pending/outbox prompt row (composer-dock-receipt placement fix)"
+max_lines = 856
+reason = "relocated existing oversized domain source; receipt folded into first turn's Worked-for group; the standalone workspace_receipt row kind is deleted — before any turn exists the receipt instead hosts via hostsWorkspaceReceipt on the last pending/outbox prompt row (composer-dock-receipt placement fix); goal-event + completion-receipt row interleaving helpers extracted to transcript-interleave-rows.ts (bgwork r6 round 2), shrinking this file below its prior ratchet"
 
 [[max_lines]]
 path = "apps/packages/product-client/src/domain/sessions/activity.test.ts"
@@ -197,6 +197,11 @@ reason = "terminal/feed stream registry (+open/close/error records woven into th
 path = "apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.tsx"
 max_lines = 405
 reason = "Background Work R2: reports the stick-to-bottom engine's own isPinnedToBottom state upward via a new onIsPinnedToBottomChange callback prop, so the background-work transcript row can hide itself when the user scrolls away from bottom instead of floating over mid-transcript content; split deferred. Bumped 403->405 by the current-main merge: the chat-scroll refold's single-writer / frame-pipeline landing (PRO-187) plus r2's pin-state wiring net two more lines in this host."
+
+[[frontend_structure]]
+path = "apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.tsx"
+max_lines = 442
+reason = "Background Work R6: in-scroll background_work + completion_receipt row orchestration (interleave placement, receipt hosting, pane wiring) grew the transcript list host past 400; extraction pending"
 
 # FE-CHATSCROLL-1 sanctioned scroll-position writers, read by
 # scripts/check_transcript_scroll_writer.py. File-level allowlist: any non-test


### PR DESCRIPTION
## What

Two founder-ruled changes (2026-08-17) in `apps/packages/product-client`, amending the frozen handoff:

**1. Inline completion receipts in the transcript.** When a background terminal exits or a native subagent finishes, a right-aligned receipt row appears at the transcript tail, on the incoming rail, per the authoritative design markup ("Chat - Background Work Indicator"):
- Terminal: `exited {code} ·` + a mono command button that deep-opens the Background work pane's `BackgroundTerminalView` for that process.
- Subagent: `finished ·` (or `failed ·`) + the durable `AgentIdentityChip` (identity via `buildDelegatedAgentIdentity`, keyed by the subagent's wire agent id), whose on-open deep-opens the pane's subagent detail.

**2. Tail indicator is running-only.** `BackgroundWorkTranscriptRow` now counts RUNNING work only and is not rendered at count 0. The settled/finished display state ("N background tasks finished" + `CircleCheck` swap, `text-faint` tone) is removed entirely, including its tests.

## Founder ruling (quoted)

> the `{n} background task{s}` row counts RUNNING work only, and the row is NOT RENDERED at count 0. Remove the settled/finished display state ... entirely ... Completed work is announced solely by the new inline receipts.
> completed tasks leave the count; the row disappears at 0.

## Architecture path: **(b) — synthesized from the activity fold**

The wire carries **no** identifying provenance for native BACKGROUND completions, so the preferred path (a) — rendering receipts from a wake-prompt transcript envelope — is not available for this feature. Evidence:

- **Terminals inject no session wake prompt at all.** The terminals domain only writes shell-prompt bytes, never a `PromptProvenance` (`anyharness/crates/anyharness-lib/src/live/terminals/command_runs/*` — `stream_format.rs` `workspace_prompt`/`terminal_command_preface`; no `with_provenance`/wake anywhere under `command_runs`). `PromptProvenance` (`.../sessions/prompt/provenance.rs:23-66`, mirrored in the SDK at `anyharness/sdk/src/generated/openapi.ts:4139-4169`) has **no** process/terminal variant — only `agentSession | subagentWake | linkWake | reviewFeedback | system`. A terminal exit therefore has nothing on the wire to reconstruct "exited 0 · pytest -q tests/e2e" or to deep-link the process.
- **Native roster subagents leave no durable transcript record.** They leave the roster the instant they finish; the only evidence is a roster departure observed between two snapshots — see `use-background-work-finish-signal-tracking.ts:60-99` (R5) and its store field docstring (`workspace-ui-store-types.ts`: "the only record ... that will ever exist"). If a `subagentWake` transcript wake existed for these, R5 would not need to cache the disappearance.
- The `subagentWake`/`linkWake` provenance that `AgentOriginPromptReceipt` already renders is for delegated/linked **sessions** (cowork/review/agent-parent) via completion deliveries (`.../sessions/subagents/transcript.rs:71`, `.../store/completion_deliveries/*`) — a different mechanism, not "background work."

So receipts are synthesized from fold transitions (a running process now exited; a running subagent now finished-in-place or vanished), pure-derived in `domain/activity/background-completion-receipt.ts` and accumulated per-session in `hooks/activity/derived/use-background-completion-receipts.ts` (mirroring R5's transition-detection shape and reading the same `useSessionActivityForSession` slice).

## Honest limitations (disclosed)

- **Synthesized receipts do not survive reload / are not interleaved at the exact historical scroll position** (known lane defect D1: activity rendering is fold-only). They cover completions observed while the hook is mounted; work already finished at mount (roster seed) is baselined, not receipted. Placement is now a true in-scroll virtualized row (see **Round 2** below, superseding the r6 tail band). The durable, correctly-ordered wire signal is flagged for the wire rung.
- **CONTRADICTION RAISED — subagent receipt "opens the pane's subagent detail":** a finished native subagent has, by the locked roster-departure invariant, already left the live roster, and `BackgroundWorkPane` resolves `selectedSubagent` from `activity.agents` — so it bounces back to the roster (documented at `BackgroundWorkPane.tsx`, the "subagent-View-action" note). R4b renders a *live* subagent's tail as a transcript; it does **not** reconstruct a roster-absent one. The receipt chip's on-open still deep-opens the pane (best-effort: it resolves during the one-tick finished-in-place window, else shows the roster), but a durable finished-subagent detail is blocked on the same wire/durability work as D1. Raising rather than silently rescoping.

## Deep-open plumbing

Added an analogous terminal selection to the R4 subagent one: `pendingBackgroundProcessSelectionByWorkspace` + `set/clearPendingBackgroundProcessSelectionForWorkspace` (`workspace-ui-store*`), consumed+cleared by `BackgroundWorkPane` with the same session-checked discipline, driven by a new `useOpenBackgroundTerminalDetail` hook (shares the pane-open helper with `useOpenBackgroundWorkPane`; the existing subagent signature is unchanged).

## Tests (literal `pnpm exec vitest run`)

Consolidated run of every touched/owned spec + the full background-work suite list: **18 files, 153 passed, 0 failed.** Includes: receipt rendering both kinds + click-through wiring + identity-less fallback (`BackgroundCompletionReceipt.test.tsx`), pure transition derivation + roster-seed negative control + no-double-emit (`background-completion-receipt.test.ts`), accumulation + session-switch reset (`use-background-completion-receipts.test.ts`), terminal deep-open (`use-open-background-work-pane.test.tsx`), indicator hide-at-0 + **negative control that the removed settled-state copy/CircleCheck/`text-faint` are gone** (`BackgroundWorkTranscriptRow.test.tsx`).

`tsc -p tsconfig.json --noEmit`: only the pre-existing exogenous `TS2741` in `src/domain/workflows/run-view-model.ts` (from main; not touched, does not affect vitest). Design-attribution gate: passed. New domain module 147 lines (< 404); all new files < 600.

---

## Round 2 — founder amendments (2026-08-17)

The founder live-tested the r6 build and ruled three amendments, committed **on top** of the r6 work (no history rewrite).

### FIX 1 — running-count row is a true in-scroll transcript row (supersedes R1's dock placement)

> the pinned-to-bottom footer "reads as **fading in weirdly**" — make it a true in-scroll transcript row that sits statically **below** the agent's last message in content flow and scrolls **with** content.

`BackgroundWorkTranscriptRow` is now a virtualized `background_work` row emitted by `buildTranscriptRowModel` at the absolute transcript tail while `runningCount > 0`, gone at 0. This **supersedes R1's dock-anchored, visibility-gated placement**. Removed as now-dead: the pinned-to-bottom `isPinnedToBottom` gating + reset effect, the floating absolute band JSX + geometry comment, and the **R2 MessageList bottom-inset reserve machinery** (`hasBackgroundWork` inset threading through `SessionTranscriptPane` to `MessageList`); `bottomInsetPx` is now passed plainly. **Kept:** the `MessageList` bottom-inset prop itself (still used for the unrelated composer-dock reserve).

### FIX 2 — receipts interleave in reading order at the fold-observation point

> receipts render in reading order, interleaved into the transcript item sequence — agent turn → receipt → wake turn; the "exited N · command" receipt appears in the (right-aligned) message slot, **not** as an element after/below the message list.

Each receipt now carries an `anchorTurnId` (the turn that was latest when the completion was folded, captured via ref at observation time so a later wake turn never restamps it). `buildTranscriptRowModel` buckets receipts by that anchor and splices a `completion_receipt` row at the **end** of its anchor turn, so a later (wake) turn falls after it. Receipts are real in-scroll transcript rows rendered inside `MessageList`, not appended after it. Modeled on the existing goal-event interleaving precedent (turn-END anchoring rather than mid-turn seq).

### FIX 3 — remove the in-pane NoticeBanner

> we don't want the **checkmark + box at the top of background work**.

Removed the `NoticeBanner` (CircleCheck + View box) from the top of `BackgroundWorkPane` and its dead wiring (`showBackgroundWorkNotice`/`noticeSignal`, the `lastViewedAtMsBeforeThisMount` state). **Kept** R5's tab dirty-dot: `useBackgroundWorkFinishSignal` + the mark-viewed effect still fire. A negative control asserts the banner no longer renders on process/subagent finish.

### Size (PROD-SIZE-1, no ratchet raise)

Split along real seams rather than ratcheting up: goal-event + completion-receipt row interleaving helpers extracted to **`transcript-interleave-rows.ts`** (row-model 1143 to 856 lines; its ratchet **tightened** 1017 to 856), and the background-work row tests moved to **`transcript-row-model.background-work.test.ts`** (main test back to 1363). Full `check_max_lines.py` and `check_design_attribution.py`: **pass**.

### Round-2 tests (literal `vitest run`)

Full touched-surface re-run (`src/domain/chats/transcript src/components/workspace/chat src/hooks/chat/ui src/components/workspace/activity src/hooks/activity src/domain/activity`): **155 files, 1158 passed, 0 failed.** `tsc -p tsconfig.json --noEmit`: only the same pre-existing exogenous `TS2741` in `src/domain/workflows/run-view-model.ts` (from main; not touched).

Round-2 head: `d66ed0579`.

## Round 3 — wake-turn copy affordance regression

Founder repro (served preview, run `bn30h453a`): after a background command exits, the FINAL agent message — the runtime-injected **wake turn** ("Terminal … finished — exit code 0") — showed no copy button and no timestamp on hover; the footer `<div data-turn-assistant-footer>` mounted but was empty. Durable across a fresh reload.

### Actual root cause (not the interleaving)

The interleaved `completion_receipt` / `background_work` rows were a red herring — the preceding turns kept their footers; only the wake turn regressed. `completedAt` is written **only** by the `turn_ended` event (sdk `reducer/transcript.ts`), and a runtime-injected wake turn never receives one, so its `TurnRecord.completedAt` stays `null` forever. The footer gate `resolveTurnAssistantFooterMode` required `turnCompleted = !!turn.completedAt`, so the fully-settled final message fell through to the empty **"reserved"** mode. On reload the assistant-reveal mount floor makes `assistantRevealComplete` true, so `completedAt` was the sole false input — matching the durable, both-affordances-gone symptom exactly.

### Fix

New `resolveTurnAssistantFooterModeForRow` (in `transcript-rendering.ts`) sources "is this turn done?" from the tail assistant **message**, not only the turn envelope: a turn is footer-complete when `!!turn.completedAt` **OR** its tail prose item has stopped streaming and no tool work is still active (`turnHasActiveToolWork`). Affordances belong to the last real message row regardless of interleaved activity rows. `TranscriptTurnRow` calls it in place of the raw `!!turn.completedAt` gate. Frontier/diff/goal-marker chrome (which keys on the completion stamp via `latestCompletedTurnId`) is deliberately untouched — the wake turn gets its hover copy + timestamp back without being promoted to the "session complete" persistent marker.

### Tests (literal `vitest run`)

`transcript-rendering.test.ts` grew 9 → **17** tests: the wake-turn copy restore, plus negative controls (streaming prose, prose-closed-while-tool-runs, reveal-incomplete, stamped turn unchanged, non-final row → none), plus (a) receipt interleaved after the preceding turn, (b) `background_work` row at the tail, (c) both — each asserting the wake turn row still resolves to `copy`. Suite run: `transcript-rendering.test.ts` **17**, `transcript-row-model.test.ts` **43**, `transcript-row-model.background-work.test.ts` **8** — 68 passed, 0 failed. Negative control: reverting the `|| tailMessageSettled` branch fails exactly the 4 fix-dependent tests and leaves every control green. `check_max_lines.py`, `check_design_attribution.py`, `check_frontend_boundaries.py`: **pass** (touched files 309/365/367 lines, under caps, no ratchet entries). Same pre-existing exogenous `TS2741` in `run-view-model.ts` (from main; not touched).

Round-3 head: `4f8f00a51`.

## Round 4 — the runtime drops the wake turn's entire completion tail

Round 3 shipped, but the wake-turn footer was STILL empty on the live stack. Pulling the durable event stream (`GET /v1/sessions/{id}/events`) showed why: for a runtime-injected wake turn the runtime emits `turn_started` → `item_started(assistant_message, in_progress)` → `item_delta("… completed with exit code 0.")` → terminal `usage_update`(s), then the stream ends. There is **no `item_completed` and no `turn_ended`**. So in the durable record the tail assistant message item stays status `in_progress` (isStreaming true) forever — round 3's tail-item-settled gate is false, and so is the `completedAt` stamp. Both round-3 branches lose on real data.

### Fix — source completion from session liveness

`resolveTurnAssistantFooterModeForRow` no longer reads the tail item's status at all. A turn with copyable tail prose is footer-complete when it is **not the session's actively-streaming turn** — `turnIsActivelyStreaming = isLatestTurn && sessionViewState === "working"`, negated. `sessionViewState` is the runtime-derived run state (`resolveSessionViewState`): on reload there is no live stream and `isSessionEffectivelyStreaming` returns false for an idle+ended session, so the stuck-`in_progress` wake message becomes copyable even though the reducer's replayed `transcript.isStreaming` is stale-true. Interrupted turns match too. Genuinely live turns keep `turnIsActivelyStreaming` true and stay `reserved`, with the reveal guard holding the empty footer through the reveal.

Two OR'd signals remain: `!!turn.completedAt` (normal stamped turns, unchanged) OR `hasTailProse && !turnIsActivelyStreaming`.

### Reviewer findings folded in

- **L1** (mid-turn `copy` flash in the gap between a prose block finishing and the next `tool_call`): closed by the same liveness gate — that gap is still the live turn, so it stays `reserved`. New test asserts it.
- **L2** (one-frame stale-receipt flash at the tail on session switch; receipts reset in an async effect): display-only, left as **known-cosmetic** to keep this diff focused. The durable fix for the missing completion tail is **runtime-side** (emit `item_completed` + `turn_ended` for injected wake turns) — recorded here as a **known runtime defect** next to the provenance wire-rung note. No Rust touched.

### Tests (verbatim `vitest run`)

```
 ✓ src/domain/chats/transcript/transcript-rendering.test.ts (19 tests) 6ms
 ✓ src/domain/chats/transcript/transcript-row-model.test.ts (43 tests) 13ms
 ✓ src/domain/chats/transcript/transcript-row-model.background-work.test.ts (8 tests)
 ✓ src/components/workspace/chat/transcript/TranscriptTurnRow.test.tsx (16 tests) 3ms
 ✓ src/components/workspace/chat/transcript/TranscriptTurnChrome.test.tsx (23 tests) 43ms
 Test Files  5 passed (5)
      Tests  109 passed (109)
```

Negative controls: reverting `|| messageSettledOffLiveStream` fails exactly the round-4 dropped-tail test + interleaving (a)/(b)/(c); dropping the `!turnIsActivelyStreaming` gate fails exactly the three live-turn controls (round-4 active control, tool-running, L1). `check_max_lines.py`, `check_design_attribution.py`, `check_frontend_boundaries.py`: **pass** (touched files 322/419/375 lines, under caps, no ratchet entries). Same pre-existing exogenous `TS2741` in `run-view-model.ts` (from main; not touched).

Round-4 head: `1fb98411e`.

## Round 4b — FE-SIZE-1 ratchet for MessageList.tsx

CI's "Repo shape checks" job (`report_frontend_structure.py --strict --summary-only`, now added to the standard local gate set) flagged `MessageList.tsx` at 442 lines, over the 400-line FE-SIZE-1 soft threshold — grown by r6's in-scroll row work. Recorded the sanctioned `[[frontend_structure]]` ratchet entry (observed 442 + reason) in `lints/frontend/ratchets.toml`, in the same PR that grew it, rather than splitting a host that just cleared four review rounds (the alternative, and not the founder-gated `exceptions.toml` path).

```
  FE-SIZE-1: 0
  TOTAL: 0
```

`check_max_lines.py` still passes (the file is in `[[frontend_structure]]` only, not `[[max_lines]]` — no collision). The second repo-wide FE-SIZE-1 hit, `TranscriptToolCallItemBlock.tsx` at 402, is r8/#2022's and does not appear on this branch.

Round-4b head: `79127061f`.

## Round 5 — frontier reserve leaves a dead band under settled wake turns

Pablo's final pre-merge blocker, same stream-liveness family as round 4. After a background-command wake message settles and the session goes idle, the final wake turn showed a dead ~44-56px band between the last prose and the timestamp footer. `resolveTurnFrontierStatusMode` reserved an empty fixed-height frontier-status box whenever `rowIsLastTurnRow && isLatestTurnInProgress`; because the runtime drops the wake turn's completion tail (defect D3), `isLatestTurnInProgress` (`isLatestTurn && !turn.completedAt`) stays true forever in the live view, so the `h-6` box plus its two 16px column gaps rendered as the gap. On reload the durable store has the tail, `completedAt` is set, and the gap vanishes — hence live-only.

### Fix — same doctrine as the round-4 footer

The reserve now also requires genuine stream liveness: `resolveTurnFrontierStatusMode` takes `turnIsActivelyStreaming` (`isLatestTurn && sessionViewState === "working"`, already computed in `TranscriptTurnRow`) and the reserve branch is `rowIsLastTurnRow && isLatestTurnInProgress && turnIsActivelyStreaming`. That flips exactly one truth-table cell — an idle session with a dropped-tail latest turn now resolves `"hidden"` instead of `"reserved"`. Genuinely streaming turns keep the anti-jitter reserve unchanged.

**needs_input decision:** a real trailing status still wins `"status"` before the reserve branch, so a permission pause that carries its interaction indicator (the normal case) is unaffected. A `needs_input` turn with a null trailing status resolves `"hidden"` rather than a dead reserve — coherent with the round-4 footer, which already treats the same non-`"working"` turn as settled/copyable (showing copy), so the frontier must not simultaneously claim the turn is still working.

### Tests (verbatim `vitest run`)

```
 ✓ src/components/workspace/chat/transcript/TranscriptTurnRow.test.tsx (19 tests)
```
(+3 frontier cases: dropped-tail wake + idle → `hidden`; genuinely streaming/working → `reserved`; trailing status present → `status` regardless.) Sibling regression run — `TranscriptTurnChrome.test.tsx` (23), `transcript-rendering.test.ts` (19), `transcript-row-model.test.ts` (43), `transcript-row-model.background-work.test.ts` (8) — **93 passed**. Negative control: reverting the `&& turnIsActivelyStreaming` gate fails exactly the R5 test and leaves the streaming/trailing-status controls green.

Gates (from the scratch worktree): `check_max_lines.py`, `check_design_attribution.py`, `check_frontend_boundaries.py`, `report_frontend_structure.py --strict --summary-only` (**FE-SIZE-1: 0, TOTAL: 0**) all pass. (`report_frontend_structure` added to the standard local gate set.)

New head: `209c23663`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




