### PR TITLE
feat(product): background command tool-call opens terminal detail (bgwork R8)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/BashCommandCall.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/BashCommandCall.tsx
@@ -10,6 +10,13 @@ interface BashCommandCallProps {
   output?: string;
   status: "running" | "completed" | "failed";
   duration?: string;
+  /**
+   * Set when this command was backgrounded and its `ActivityProcess.id`
+   * correlated from the tool result text (bgwork r8). Clicking the row then
+   * opens the Background work pane's terminal detail instead of toggling the
+   * inline output disclosure.
+   */
+  onOpenBackgroundTerminal?: () => void;
 }
 
 export function BashCommandCall({
@@ -18,6 +25,7 @@ export function BashCommandCall({
   output,
   status,
   duration,
+  onOpenBackgroundTerminal,
 }: BashCommandCallProps) {
   const label = description
     ?? (status === "failed" ? "Command" : "Running command");
@@ -29,6 +37,7 @@ export function BashCommandCall({
       hint={command}
       status={status}
       duration={duration}
+      onOpen={onOpenBackgroundTerminal}
     >
       {output && (
         <ToolActionDetailsPanel>

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRowPrimitives.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRowPrimitives.tsx
@@ -63,12 +63,19 @@ export function ActionDisclosureRow({
   expanded,
   failed,
   onToggle,
+  trailing,
 }: {
   label: string;
   icon: ReactNode;
   expanded: boolean;
   failed: boolean;
   onToggle: () => void;
+  /**
+   * A muted trailing status suffix (e.g. `running · 4m 12s`), shown when a
+   * background command's roster data is available (bgwork r8). Absent for
+   * every other row.
+   */
+  trailing?: string;
 }) {
   return (
     <Button
@@ -84,6 +91,9 @@ export function ActionDisclosureRow({
     >
       <ActionRowIcon>{icon}</ActionRowIcon>
       <span className="min-w-0 truncate">{label}</span>
+      {trailing && (
+        <span className="ml-auto shrink-0 text-faint">{trailing}</span>
+      )}
     </Button>
   );
 }

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRows.parsed-background-terminal-clickin.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRows.parsed-background-terminal-clickin.test.tsx
@@ -107,11 +107,21 @@ function expandLedger() {
 describe("CollapsedActionRows — parsed/compound background command click-in (bgwork r8 round 3)", () => {
   beforeEach(() => {
     mocks.sessionProcesses = [];
+    // The collapsed-ledger disclosure (`AnimatedCollapsibleContent`) keeps its
+    // freshly mounted subtree `inert`/`aria-hidden` until one
+    // `requestAnimationFrame` after the toggle commits. jsdom never advances a
+    // real frame between a synchronous `fireEvent.click` and the next query, so
+    // drive the frame inline — the convention `CollapsedActions.test.tsx` uses.
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      callback(0);
+      return 1;
+    });
   });
 
   afterEach(() => {
     cleanup();
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("takes the ParsedCommandRows branch for a harness-supplied parsed_cmd breakdown (confirms the reproduction)", () => {
@@ -155,7 +165,10 @@ describe("CollapsedActionRows — parsed/compound background command click-in (b
   });
 
   it("shows the roster's trailing status text on the parsed row when roster data is present", () => {
-    vi.useFakeTimers();
+    // Fake only the clock (roster elapsed time is `Date.now()`-derived) so the
+    // synchronous `requestAnimationFrame` spy from `beforeEach` survives —
+    // faking timers wholesale would replace it and re-strand the inert subtree.
+    vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-08-17T10:04:12.000Z"));
     mocks.sessionProcesses = [rosterProcess({ startedAt: "2026-08-17T10:00:00.000Z" })];
     const transcript = createTranscriptState("session-1");

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRows.parsed-background-terminal-clickin.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRows.parsed-background-terminal-clickin.test.tsx
@@ -1,0 +1,276 @@
+// @vitest-environment jsdom
+//
+// bgwork r8 round 3: live verification found round 2's fix only covered the
+// `classifyCollapsedAction` "command" branch (`CommandActionRow`).
+// `CollapsedActionRows`' FIRST branch checks `getToolCallParsedCommands`
+// before that switch ever runs — any tool call whose harness supplies a
+// `parsed_cmd` breakdown (including the founder's own
+// `for i in $(seq 1 15); do echo probe $i; sleep 1; done`) takes the
+// `ParsedCommandRows` branch instead and never reached round 2's fix.
+//
+// A background command is still ONE process with ONE result text no matter
+// how many structural rows its parsed breakdown renders into, so the id is
+// resolved once for the whole tool call and EVERY parsed row opens the same
+// terminal detail — never a mix of some rows wired and others not.
+import type { PropsWithChildren, ReactElement } from "react";
+import {
+  cleanup,
+  fireEvent,
+  render as testingRender,
+  screen,
+} from "@testing-library/react";
+import { createTranscriptState } from "@anyharness/sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProductHost } from "@proliferate/product-client/host/product-host";
+import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
+import type { ActivityProcessWire } from "#product/domain/activity/process";
+import { toolCallItem } from "#product/lib/domain/chat/__fixtures__/playground/tool-call-item-fixture";
+import { TranscriptContextProviders } from "#product/components/workspace/chat/transcript/TranscriptContexts";
+import { CollapsedActions } from "#product/components/workspace/chat/tool-calls/CollapsedActions";
+
+const webTestHost = { desktop: null } as ProductHost;
+
+function Wrapper({ children }: PropsWithChildren) {
+  return (
+    <ProductHostProvider host={webTestHost}>
+      <TranscriptContextProviders sessionId="session-1">
+        {children}
+      </TranscriptContextProviders>
+    </ProductHostProvider>
+  );
+}
+
+function render(ui: ReactElement) {
+  return testingRender(ui, { wrapper: Wrapper });
+}
+
+const mocks = vi.hoisted(() => ({
+  sessionProcesses: [] as ActivityProcessWire[],
+}));
+
+vi.mock("#product/hooks/activity/derived/use-session-activity", () => ({
+  useSessionActivityForSession: () => ({
+    loops: [],
+    loopCapabilities: { supported: false, native: false },
+    processes: mocks.sessionProcesses,
+    agents: [],
+  }),
+}));
+
+const FOR_LOOP_COMMAND = "for i in $(seq 1 15); do echo probe $i; sleep 1; done";
+
+/** The command carries regex metacharacters ($, (, )) — escape before using
+ * it as a `getByRole` name matcher. */
+function commandNameMatcher(command: string): RegExp {
+  return new RegExp(command.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+}
+
+/** A tool call whose harness supplies a structured `parsed_cmd` breakdown —
+ * the shape that takes `CollapsedActionRows`' `ParsedCommandRows` branch
+ * instead of the `classifyCollapsedAction` "command" switch case. */
+function parsedCommandBashItem(
+  resultText: string,
+  parsedCommands: Array<{ type: string; cmd: string }> = [{ type: "unknown", cmd: FOR_LOOP_COMMAND }],
+) {
+  return toolCallItem({
+    nativeToolName: "Bash",
+    toolKind: "execute",
+    status: "in_progress",
+    rawInput: {
+      command: ["/bin/zsh", "-lc", FOR_LOOP_COMMAND],
+      parsed_cmd: parsedCommands,
+    },
+    contentParts: [
+      { type: "tool_result_text", text: resultText },
+    ],
+  });
+}
+
+function rosterProcess(overrides: Partial<ActivityProcessWire> = {}): ActivityProcessWire {
+  return {
+    id: "bn30h453a",
+    command: FOR_LOOP_COMMAND,
+    cwd: null,
+    status: { status: "running" },
+    pid: null,
+    startedAt: "2026-08-17T10:00:00.000Z",
+    endedAt: null,
+    feed: null,
+    ...overrides,
+  };
+}
+
+function expandLedger() {
+  fireEvent.click(screen.getByRole("button", { name: /Running command/i }));
+}
+
+describe("CollapsedActionRows — parsed/compound background command click-in (bgwork r8 round 3)", () => {
+  beforeEach(() => {
+    mocks.sessionProcesses = [];
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("takes the ParsedCommandRows branch for a harness-supplied parsed_cmd breakdown (confirms the reproduction)", () => {
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = {
+      cmd: parsedCommandBashItem("Command running in background with ID: bn30h453a"),
+    };
+
+    // No onOpenBackgroundTerminal wired here — this test only confirms the
+    // fixture takes CollapsedActionRows' ParsedCommandRows branch (the
+    // founder's own command text renders as the row's label), which is the
+    // row CommandActionRow (round 2) never reaches. Click-in itself is
+    // asserted by the next test.
+    render(<CollapsedActions itemIds={["cmd"]} transcript={transcript} />);
+    expandLedger();
+
+    expect(screen.getByText(commandNameMatcher(FOR_LOOP_COMMAND))).toBeTruthy();
+  });
+
+  it("opens the background terminal detail on click for the founder's for-loop shape", () => {
+    const onOpenBackgroundTerminal = vi.fn();
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = {
+      cmd: parsedCommandBashItem("Command running in background with ID: bn30h453a"),
+    };
+
+    render(
+      <CollapsedActions
+        itemIds={["cmd"]}
+        transcript={transcript}
+        onOpenBackgroundTerminal={onOpenBackgroundTerminal}
+      />,
+    );
+    expandLedger();
+    const row = screen.getByRole("button", { name: commandNameMatcher(FOR_LOOP_COMMAND) });
+
+    fireEvent.click(row);
+
+    expect(onOpenBackgroundTerminal).toHaveBeenCalledWith("bn30h453a");
+    expect(row.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("shows the roster's trailing status text on the parsed row when roster data is present", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-17T10:04:12.000Z"));
+    mocks.sessionProcesses = [rosterProcess({ startedAt: "2026-08-17T10:00:00.000Z" })];
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = {
+      cmd: parsedCommandBashItem("Command running in background with ID: bn30h453a"),
+    };
+
+    render(
+      <CollapsedActions
+        itemIds={["cmd"]}
+        transcript={transcript}
+        onOpenBackgroundTerminal={vi.fn()}
+      />,
+    );
+    expandLedger();
+
+    expect(screen.getByText("running · 4m 12s")).toBeTruthy();
+  });
+
+  it("every parsed row of a multi-command background call opens the same terminal detail — no half-wired subset", () => {
+    const onOpenBackgroundTerminal = vi.fn();
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = {
+      cmd: parsedCommandBashItem(
+        "Command running in background with ID: bn30h453a",
+        [
+          { type: "unknown", cmd: "mkdir -p /tmp/probe" },
+          { type: "unknown", cmd: FOR_LOOP_COMMAND },
+        ],
+      ),
+    };
+
+    render(
+      <CollapsedActions
+        itemIds={["cmd"]}
+        transcript={transcript}
+        onOpenBackgroundTerminal={onOpenBackgroundTerminal}
+      />,
+    );
+    expandLedger();
+
+    const firstRow = screen.getByRole("button", { name: /mkdir -p \/tmp\/probe/ });
+    const secondRow = screen.getByRole("button", { name: commandNameMatcher(FOR_LOOP_COMMAND) });
+
+    fireEvent.click(firstRow);
+    fireEvent.click(secondRow);
+
+    // Same process id from both rows — the whole tool call is one process.
+    expect(onOpenBackgroundTerminal).toHaveBeenNthCalledWith(1, "bn30h453a");
+    expect(onOpenBackgroundTerminal).toHaveBeenNthCalledWith(2, "bn30h453a");
+    expect(onOpenBackgroundTerminal).toHaveBeenCalledTimes(2);
+  });
+
+  it("negative control: an unwired caller (no onOpenBackgroundTerminal prop) keeps the ordinary per-kind rendering", () => {
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = {
+      cmd: parsedCommandBashItem("Command running in background with ID: bn30h453a"),
+    };
+
+    // No onOpenBackgroundTerminal passed — mirrors a caller that hasn't wired
+    // the pane opener (e.g. the read-only playground transcript).
+    render(<CollapsedActions itemIds={["cmd"]} transcript={transcript} />);
+    expandLedger();
+
+    // Falls back to the ordinary, non-interactive PlainActionRow — no button
+    // role at all for this row (that's the "ordinary per-kind rendering").
+    expect(screen.queryByRole("button", { name: commandNameMatcher(FOR_LOOP_COMMAND) })).toBeNull();
+    expect(screen.getByText(commandNameMatcher(FOR_LOOP_COMMAND))).toBeTruthy();
+  });
+
+  it("negative control: a foreground compound command keeps byte-identical per-kind rendering", () => {
+    const onOpenBackgroundTerminal = vi.fn();
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = {
+      cmd: parsedCommandBashItem(
+        "probe 1\nprobe 2\nprobe 3",
+        [{ type: "unknown", cmd: FOR_LOOP_COMMAND }],
+      ),
+    };
+
+    render(
+      <CollapsedActions
+        itemIds={["cmd"]}
+        transcript={transcript}
+        onOpenBackgroundTerminal={onOpenBackgroundTerminal}
+      />,
+    );
+    expandLedger();
+
+    // Never became a clickable, terminal-opening row.
+    expect(screen.queryByRole("button", { name: commandNameMatcher(FOR_LOOP_COMMAND) })).toBeNull();
+    const label = screen.getByText(commandNameMatcher(FOR_LOOP_COMMAND));
+    expect(label).toBeTruthy();
+
+    fireEvent.click(label);
+    expect(onOpenBackgroundTerminal).not.toHaveBeenCalled();
+  });
+
+  it("negative control: a near-miss sentence that doesn't parse an id keeps ordinary per-kind rendering", () => {
+    const onOpenBackgroundTerminal = vi.fn();
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = {
+      cmd: parsedCommandBashItem("The command is now running in the background, ID: bn30h453a"),
+    };
+
+    render(
+      <CollapsedActions
+        itemIds={["cmd"]}
+        transcript={transcript}
+        onOpenBackgroundTerminal={onOpenBackgroundTerminal}
+      />,
+    );
+    expandLedger();
+
+    expect(screen.queryByRole("button", { name: commandNameMatcher(FOR_LOOP_COMMAND) })).toBeNull();
+    expect(onOpenBackgroundTerminal).not.toHaveBeenCalled();
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRows.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRows.tsx
@@ -10,26 +10,55 @@ import {
 } from "#product/domain/chats/transcript/transcript-tool-commands";
 import {
   basename,
+  deriveCommandOutput,
   deriveReadPathTarget,
   formatFetchLabel,
   formatListingLabel,
   formatParsedCommandLabel,
   formatSearchLabel,
 } from "#product/domain/chats/tools/collapsed-action-labels";
+import { useBackgroundCommandStatus } from "#product/hooks/activity/derived/use-background-command-status";
 import { CommandActionRow } from "#product/components/workspace/chat/tool-calls/CollapsedCommandActionRow";
 import { CollapsedActionIcon } from "#product/components/workspace/chat/tool-calls/CollapsedActionIcon";
 import { EditRows } from "#product/components/workspace/chat/tool-calls/CollapsedEditActionRows";
 import { GenericActionRow } from "#product/components/workspace/chat/tool-calls/CollapsedGenericActionRow";
 import {
+  ActionDisclosureRow,
   ActionFileLink,
   ActionRowIcon,
   PlainActionRow,
 } from "#product/components/workspace/chat/tool-calls/CollapsedActionRowPrimitives";
 
-export function CollapsedActionRows({ item }: { item: ToolCallItem }) {
+export function CollapsedActionRows({
+  item,
+  onOpenBackgroundTerminal,
+}: {
+  item: ToolCallItem;
+  /**
+   * bgwork r8 round 2/3: routed to the lone `command`-kind row, or to every
+   * row of a parsed/compound command — a background command is one process
+   * with one result text no matter how many structural rows it renders into.
+   */
+  onOpenBackgroundTerminal?: (processId: string) => void;
+}) {
   const parsedCommands = getToolCallParsedCommands(item);
+  // Resolved once for the whole tool call: a background command's "Command
+  // running in background with ID: ..." sentence lives in the ONE result
+  // text the item carries, regardless of how many display rows the harness's
+  // parsed_cmd breakdown produces below.
+  const { processId: backgroundProcessId, trailingStatus: backgroundTrailingStatus } =
+    useBackgroundCommandStatus(deriveCommandOutput(item));
+
   if (parsedCommands.length > 0) {
-    return <ParsedCommandRows item={item} commands={parsedCommands} />;
+    return (
+      <ParsedCommandRows
+        item={item}
+        commands={parsedCommands}
+        backgroundProcessId={backgroundProcessId}
+        backgroundTrailingStatus={backgroundTrailingStatus}
+        onOpenBackgroundTerminal={onOpenBackgroundTerminal}
+      />
+    );
   }
 
   switch (classifyCollapsedAction(item)) {
@@ -60,7 +89,12 @@ export function CollapsedActionRows({ item }: { item: ToolCallItem }) {
         />
       );
     case "command":
-      return <CommandActionRow item={item} />;
+      return (
+        <CommandActionRow
+          item={item}
+          onOpenBackgroundTerminal={onOpenBackgroundTerminal}
+        />
+      );
     case "edit":
       return <EditRows item={item} />;
     case "action":
@@ -151,10 +185,42 @@ function FileActionRow({
 function ParsedCommandRows({
   item,
   commands,
+  backgroundProcessId,
+  backgroundTrailingStatus,
+  onOpenBackgroundTerminal,
 }: {
   item: ToolCallItem;
   commands: ParsedToolCommand[];
+  backgroundProcessId: string | null;
+  backgroundTrailingStatus: string | undefined;
+  onOpenBackgroundTerminal?: (processId: string) => void;
 }) {
+  // A background command is one process regardless of how many structural
+  // rows its parsed breakdown renders into — every row opens the same
+  // terminal detail, uniformly (bgwork r8 round 3), never a mix of some rows
+  // opening the pane and others keeping their ordinary per-kind treatment
+  // (e.g. a "read"-kind row's file link). Falls back to the ordinary
+  // per-kind rendering below when there's no id to open with, or no caller
+  // wired to open it.
+  if (backgroundProcessId && onOpenBackgroundTerminal) {
+    const processId = backgroundProcessId;
+    return (
+      <>
+        {commands.map((command, idx) => (
+          <ActionDisclosureRow
+            key={`${item.itemId}-parsed-${idx}`}
+            label={formatParsedCommandLabel(item, command)}
+            icon={<CollapsedActionIcon kind={command.kind} />}
+            expanded={false}
+            failed={item.status === "failed"}
+            onToggle={() => onOpenBackgroundTerminal(processId)}
+            trailing={backgroundTrailingStatus}
+          />
+        ))}
+      </>
+    );
+  }
+
   return (
     <>
       {commands.map((command, idx) => command.kind === "read" && command.path

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRows.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRows.tsx
@@ -18,6 +18,7 @@ import {
   formatSearchLabel,
 } from "#product/domain/chats/tools/collapsed-action-labels";
 import { useBackgroundCommandStatus } from "#product/hooks/activity/derived/use-background-command-status";
+import { useTranscriptSessionId } from "#product/components/workspace/chat/transcript/TranscriptContexts";
 import { CommandActionRow } from "#product/components/workspace/chat/tool-calls/CollapsedCommandActionRow";
 import { CollapsedActionIcon } from "#product/components/workspace/chat/tool-calls/CollapsedActionIcon";
 import { EditRows } from "#product/components/workspace/chat/tool-calls/CollapsedEditActionRows";
@@ -47,7 +48,7 @@ export function CollapsedActionRows({
   // text the item carries, regardless of how many display rows the harness's
   // parsed_cmd breakdown produces below.
   const { processId: backgroundProcessId, trailingStatus: backgroundTrailingStatus } =
-    useBackgroundCommandStatus(deriveCommandOutput(item));
+    useBackgroundCommandStatus(deriveCommandOutput(item), useTranscriptSessionId());
 
   if (parsedCommands.length > 0) {
     return (

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActions.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActions.tsx
@@ -22,6 +22,8 @@ interface CollapsedActionsProps {
   autoFollow?: boolean;
   /** Keep the trailing exploration phase visually live between tool events. */
   liveContinuation?: boolean;
+  /** bgwork r8 round 2: routed to a background command's ledger row. */
+  onOpenBackgroundTerminal?: (processId: string) => void;
 }
 
 export function CollapsedActions({
@@ -29,6 +31,7 @@ export function CollapsedActions({
   transcript,
   autoFollow = false,
   liveContinuation = false,
+  onOpenBackgroundTerminal,
 }: CollapsedActionsProps) {
   const hasActiveAction = itemIds.some((itemId) => {
     const item = transcript.itemsById[itemId];
@@ -115,6 +118,7 @@ export function CollapsedActions({
               transcript={transcript}
               isLive={isLiveLedger}
               containsEdits={containsEdits}
+              onOpenBackgroundTerminal={onOpenBackgroundTerminal}
             />
           ) : null}
         </div>
@@ -128,7 +132,11 @@ function CollapsedActionsLedger({
   transcript,
   isLive,
   containsEdits,
-}: Pick<CollapsedActionsProps, "itemIds" | "transcript"> & { isLive: boolean; containsEdits: boolean }) {
+  onOpenBackgroundTerminal,
+}: Pick<CollapsedActionsProps, "itemIds" | "transcript" | "onOpenBackgroundTerminal"> & {
+  isLive: boolean;
+  containsEdits: boolean;
+}) {
   const handleLedgerWheel = useChainedVerticalWheel();
   return (
     <div>
@@ -147,7 +155,13 @@ function CollapsedActionsLedger({
           {itemIds.map((itemId) => {
             const item = transcript.itemsById[itemId];
             if (item?.kind !== "tool_call") return null;
-            return <CollapsedActionRows key={itemId} item={item} />;
+            return (
+              <CollapsedActionRows
+                key={itemId}
+                item={item}
+                onOpenBackgroundTerminal={onOpenBackgroundTerminal}
+              />
+            );
           })}
         </div>
       </div>

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedCommandActionRow.background-terminal-clickin.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedCommandActionRow.background-terminal-clickin.test.tsx
@@ -1,0 +1,242 @@
+// @vitest-environment jsdom
+//
+// bgwork r8 round 2: a background command's row inside a COLLAPSED action
+// ledger (the "Worked for Ns" group every completed turn settles into) must
+// open the Background work pane's terminal detail on click, exactly like the
+// top-level TranscriptToolCallItemBlock path already does (round 1). This is
+// the path the founder actually sees once a turn finishes, since every turn
+// collapses on completion — round 1 only covered the still-expanded, live
+// path.
+//
+// `onOpenBackgroundTerminal` is a threaded prop here (not a local
+// `useOpenBackgroundTerminalDetail()` call): that hook reaches into
+// `useWorkspaces()`/`useProductAuthUserId()`, which requires a fully equipped
+// `ProductHostProvider`. `CollapsedActions` is mounted by many other tests
+// with a minimal test host, so the callback is supplied by the caller
+// (ultimately `MessageList`, same as the round-1 top-level path) and reaches
+// `CommandActionRow` through `CollapsedActions` -> `CollapsedActionRows`.
+import type { PropsWithChildren, ReactElement } from "react";
+import {
+  cleanup,
+  fireEvent,
+  render as testingRender,
+  screen,
+} from "@testing-library/react";
+import { createTranscriptState } from "@anyharness/sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProductHost } from "@proliferate/product-client/host/product-host";
+import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
+import type { ActivityProcessWire } from "#product/domain/activity/process";
+import { toolCallItem } from "#product/lib/domain/chat/__fixtures__/playground/tool-call-item-fixture";
+import { TranscriptContextProviders } from "#product/components/workspace/chat/transcript/TranscriptContexts";
+import { CollapsedActions } from "#product/components/workspace/chat/tool-calls/CollapsedActions";
+
+const webTestHost = { desktop: null } as ProductHost;
+
+function Wrapper({ children }: PropsWithChildren) {
+  return (
+    <ProductHostProvider host={webTestHost}>
+      <TranscriptContextProviders sessionId="session-1">
+        {children}
+      </TranscriptContextProviders>
+    </ProductHostProvider>
+  );
+}
+
+function render(ui: ReactElement) {
+  return testingRender(ui, { wrapper: Wrapper });
+}
+
+const mocks = vi.hoisted(() => ({
+  sessionProcesses: [] as ActivityProcessWire[],
+}));
+
+vi.mock("#product/hooks/activity/derived/use-session-activity", () => ({
+  useSessionActivityForSession: () => ({
+    loops: [],
+    loopCapabilities: { supported: false, native: false },
+    processes: mocks.sessionProcesses,
+    agents: [],
+  }),
+}));
+
+function backgroundedBashItem(resultText: string) {
+  return toolCallItem({
+    nativeToolName: "Bash",
+    toolKind: "execute",
+    status: "in_progress",
+    rawInput: { command: "for i in $(seq 1 15); do echo $i; sleep 1; done" },
+    contentParts: [
+      { type: "tool_result_text", text: resultText },
+    ],
+  });
+}
+
+function rosterProcess(overrides: Partial<ActivityProcessWire> = {}): ActivityProcessWire {
+  return {
+    id: "bn30h453a",
+    command: "for i in $(seq 1 15); do echo $i; sleep 1; done",
+    cwd: null,
+    status: { status: "running" },
+    pid: null,
+    startedAt: "2026-08-17T10:00:00.000Z",
+    endedAt: null,
+    feed: null,
+    ...overrides,
+  };
+}
+
+/**
+ * The ledger's outer "Worked for Ns" toggle summarizes the live action with
+ * the generic "Running command" label, while the inner `CommandActionRow`
+ * names itself after the actual shell text ("Running: for i in ..."). Expand
+ * the outer toggle (matched by the generic label), then look up the inner
+ * row by its command-specific label.
+ */
+function expandLedgerAndGetInnerRow(innerName: RegExp): HTMLElement {
+  fireEvent.click(screen.getByRole("button", { name: /Running command/i }));
+  return screen.getByRole("button", { name: innerName });
+}
+
+describe("CollapsedActionRows / CommandActionRow — background command click-in (bgwork r8 round 2)", () => {
+  beforeEach(() => {
+    mocks.sessionProcesses = [];
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("opens the background terminal detail on click instead of toggling the collapsed disclosure", () => {
+    const onOpenBackgroundTerminal = vi.fn();
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = {
+      cmd: backgroundedBashItem("Command running in background with ID: bn30h453a"),
+    };
+
+    render(
+      <CollapsedActions
+        itemIds={["cmd"]}
+        transcript={transcript}
+        onOpenBackgroundTerminal={onOpenBackgroundTerminal}
+      />,
+    );
+    const row = expandLedgerAndGetInnerRow(/Running: for i in/i);
+
+    fireEvent.click(row);
+
+    expect(onOpenBackgroundTerminal).toHaveBeenCalledWith("bn30h453a");
+    // Never reveals the inline Shell output panel for a background row.
+    expect(screen.queryByText("Shell")).toBeNull();
+    expect(row.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("shows the roster's trailing status text when roster data is present", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-17T10:04:12.000Z"));
+    mocks.sessionProcesses = [rosterProcess({ startedAt: "2026-08-17T10:00:00.000Z" })];
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = {
+      cmd: backgroundedBashItem("Command running in background with ID: bn30h453a"),
+    };
+
+    render(
+      <CollapsedActions
+        itemIds={["cmd"]}
+        transcript={transcript}
+        onOpenBackgroundTerminal={vi.fn()}
+      />,
+    );
+    expandLedgerAndGetInnerRow(/Running: for i in/i);
+
+    expect(screen.getByText("running · 4m 12s")).toBeTruthy();
+  });
+
+  it("still renders and opens the terminal when roster data is absent, with an empty trailing slot", () => {
+    const onOpenBackgroundTerminal = vi.fn();
+    mocks.sessionProcesses = []; // e.g. after reload — fold state doesn't survive.
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = {
+      cmd: backgroundedBashItem("Command running in background with ID: bn30h453a"),
+    };
+
+    render(
+      <CollapsedActions
+        itemIds={["cmd"]}
+        transcript={transcript}
+        onOpenBackgroundTerminal={onOpenBackgroundTerminal}
+      />,
+    );
+    const row = expandLedgerAndGetInnerRow(/Running: for i in/i);
+    expect(row.textContent).not.toMatch(/running ·|exited/);
+
+    fireEvent.click(row);
+    expect(onOpenBackgroundTerminal).toHaveBeenCalledWith("bn30h453a");
+  });
+
+  it("negative control: an unwired caller (no onOpenBackgroundTerminal prop) keeps the ordinary inline disclosure", () => {
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = {
+      cmd: backgroundedBashItem("Command running in background with ID: bn30h453a"),
+    };
+
+    // No onOpenBackgroundTerminal passed at all — mirrors a caller (e.g. the
+    // read-only playground transcript) that hasn't wired the pane opener.
+    render(<CollapsedActions itemIds={["cmd"]} transcript={transcript} />);
+    const row = expandLedgerAndGetInnerRow(/Running: for i in/i);
+
+    fireEvent.click(row);
+
+    // Falls back to the ordinary inline toggle rather than throwing or no-op'ing silently.
+    expect(row.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText(/Command running in background with ID/)).toBeTruthy();
+  });
+
+  it("negative control: a foreground command keeps byte-identical inline disclosure behavior", () => {
+    const onOpenBackgroundTerminal = vi.fn();
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = {
+      cmd: backgroundedBashItem("total 0\ndrwxr-xr-x  2 pablo  staff  64 file.txt"),
+    };
+
+    render(
+      <CollapsedActions
+        itemIds={["cmd"]}
+        transcript={transcript}
+        onOpenBackgroundTerminal={onOpenBackgroundTerminal}
+      />,
+    );
+    const row = expandLedgerAndGetInnerRow(/Running: for i in/i);
+    expect(row.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByText(/drwxr-xr-x/)).toBeNull();
+
+    fireEvent.click(row);
+
+    expect(onOpenBackgroundTerminal).not.toHaveBeenCalled();
+    expect(row.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText(/drwxr-xr-x/)).toBeTruthy();
+  });
+
+  it("negative control: a near-miss sentence that doesn't parse an id keeps disclosure toggling", () => {
+    const onOpenBackgroundTerminal = vi.fn();
+    const transcript = createTranscriptState("session-1");
+    transcript.itemsById = {
+      cmd: backgroundedBashItem("The command is now running in the background, ID: bn30h453a"),
+    };
+
+    render(
+      <CollapsedActions
+        itemIds={["cmd"]}
+        transcript={transcript}
+        onOpenBackgroundTerminal={onOpenBackgroundTerminal}
+      />,
+    );
+    const row = expandLedgerAndGetInnerRow(/Running: for i in/i);
+    fireEvent.click(row);
+
+    expect(onOpenBackgroundTerminal).not.toHaveBeenCalled();
+    expect(row.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText(/The command is now running/)).toBeTruthy();
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedCommandActionRow.background-terminal-clickin.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedCommandActionRow.background-terminal-clickin.test.tsx
@@ -101,11 +101,21 @@ function expandLedgerAndGetInnerRow(innerName: RegExp): HTMLElement {
 describe("CollapsedActionRows / CommandActionRow — background command click-in (bgwork r8 round 2)", () => {
   beforeEach(() => {
     mocks.sessionProcesses = [];
+    // The collapsed-ledger disclosure (`AnimatedCollapsibleContent`) keeps its
+    // freshly mounted subtree `inert`/`aria-hidden` until one
+    // `requestAnimationFrame` after the toggle commits. jsdom never advances a
+    // real frame between a synchronous `fireEvent.click` and the next query, so
+    // drive the frame inline — the convention `CollapsedActions.test.tsx` uses.
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      callback(0);
+      return 1;
+    });
   });
 
   afterEach(() => {
     cleanup();
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("opens the background terminal detail on click instead of toggling the collapsed disclosure", () => {
@@ -133,7 +143,10 @@ describe("CollapsedActionRows / CommandActionRow — background command click-in
   });
 
   it("shows the roster's trailing status text when roster data is present", () => {
-    vi.useFakeTimers();
+    // Fake only the clock (roster elapsed time is `Date.now()`-derived) so the
+    // synchronous `requestAnimationFrame` spy from `beforeEach` survives —
+    // faking timers wholesale would replace it and re-strand the inert subtree.
+    vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-08-17T10:04:12.000Z"));
     mocks.sessionProcesses = [rosterProcess({ startedAt: "2026-08-17T10:00:00.000Z" })];
     const transcript = createTranscriptState("session-1");

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedCommandActionRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedCommandActionRow.tsx
@@ -9,6 +9,7 @@ import {
   formatCommandExecutionLabel,
 } from "#product/domain/chats/tools/collapsed-action-labels";
 import { useBackgroundCommandStatus } from "#product/hooks/activity/derived/use-background-command-status";
+import { useTranscriptSessionId } from "#product/components/workspace/chat/transcript/TranscriptContexts";
 import { ActionDisclosureRow } from "#product/components/workspace/chat/tool-calls/CollapsedActionRowPrimitives";
 import { ToolActionDetailsPanel } from "#product/components/workspace/chat/tool-calls/ToolActionDetailsPanel";
 
@@ -38,7 +39,11 @@ export function CommandActionRow({
   const output = deriveCommandOutput(item);
   const label = formatCommandExecutionLabel(command, item.status);
 
-  const { processId: backgroundProcessId, trailingStatus } = useBackgroundCommandStatus(output);
+  const sessionId = useTranscriptSessionId();
+  const { processId: backgroundProcessId, trailingStatus } = useBackgroundCommandStatus(
+    output,
+    sessionId,
+  );
 
   // A background command never expands in place — activating it opens the
   // Background work pane's terminal detail instead, same as the top-level

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedCommandActionRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedCommandActionRow.tsx
@@ -8,25 +8,60 @@ import {
   deriveCommandOutput,
   formatCommandExecutionLabel,
 } from "#product/domain/chats/tools/collapsed-action-labels";
+import { useBackgroundCommandStatus } from "#product/hooks/activity/derived/use-background-command-status";
 import { ActionDisclosureRow } from "#product/components/workspace/chat/tool-calls/CollapsedActionRowPrimitives";
 import { ToolActionDetailsPanel } from "#product/components/workspace/chat/tool-calls/ToolActionDetailsPanel";
 
-export function CommandActionRow({ item }: { item: ToolCallItem }) {
+/**
+ * Renders a single command row inside a collapsed action ledger (the
+ * "Worked for 6s" group every completed turn settles into). Roster state is
+ * read via `useBackgroundCommandStatus` (a local-hook composition, bgwork r8
+ * round 2/3), same convention `TranscriptToolCallItemBlock` (round 1) and
+ * `SubagentCreationGroupBlock` already use for `useTranscriptSessionId`. The
+ * pane-opening callback stays a threaded prop, not a local
+ * `useOpenBackgroundTerminalDetail()` call: that hook reaches into
+ * `useWorkspaces()`/`useProductAuthUserId()`, which requires a fully
+ * equipped `ProductHostProvider` — calling it unconditionally here broke
+ * every other ledger test that mounts `CollapsedActions` with a minimal test
+ * host. Accepting it as an optional prop keeps this component's hook
+ * footprint unchanged for every call site that doesn't wire it.
+ */
+export function CommandActionRow({
+  item,
+  onOpenBackgroundTerminal,
+}: {
+  item: ToolCallItem;
+  onOpenBackgroundTerminal?: (processId: string) => void;
+}) {
   const [expanded, setExpanded] = useState(false);
   const command = deriveCommand(item);
   const output = deriveCommandOutput(item);
   const label = formatCommandExecutionLabel(command, item.status);
+
+  const { processId: backgroundProcessId, trailingStatus } = useBackgroundCommandStatus(output);
+
+  // A background command never expands in place — activating it opens the
+  // Background work pane's terminal detail instead, same as the top-level
+  // transcript tool-call row (TranscriptToolCallItemBlock, bgwork r8 round 1).
+  // Falls back to the ordinary inline toggle when there's no id to open with,
+  // matching every other row.
+  const canOpenBackgroundTerminal = !!backgroundProcessId && !!onOpenBackgroundTerminal;
+  const rowExpanded = canOpenBackgroundTerminal ? false : expanded;
+  const onToggle = canOpenBackgroundTerminal
+    ? () => onOpenBackgroundTerminal(backgroundProcessId)
+    : () => setExpanded((value) => !value);
 
   return (
     <div>
       <ActionDisclosureRow
         label={label}
         icon={<CommandWindow />}
-        expanded={expanded}
+        expanded={rowExpanded}
         failed={item.status === "failed"}
-        onToggle={() => setExpanded((value) => !value)}
+        onToggle={onToggle}
+        trailing={backgroundProcessId ? trailingStatus : undefined}
       />
-      {expanded && (
+      {rowExpanded && (
         <ToolActionDetailsPanel className="mt-1.5">
           <div className="flex items-center justify-between gap-2 px-2 py-1 text-chat text-muted-foreground">
             <span>Shell</span>

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolActionRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolActionRow.tsx
@@ -14,6 +14,14 @@ interface ToolActionRowProps {
   onExpandedChange?: (next: boolean) => void;
   expandable?: boolean;
   className?: string;
+  /**
+   * When set, a click (or Enter/Space) on the row calls this instead of
+   * toggling the inline details disclosure — the row never expands in place
+   * (bgwork r8: a background command's row opens the Background work pane's
+   * terminal detail rather than showing its output inline). Leave unset to
+   * keep the ordinary expand/collapse behavior.
+   */
+  onOpen?: () => void;
 }
 
 export function ToolActionRow({
@@ -28,10 +36,11 @@ export function ToolActionRow({
   onExpandedChange,
   expandable = true,
   className = "",
+  onOpen,
 }: ToolActionRowProps) {
   const [internalExpanded, setInternalExpanded] = useState(defaultExpanded);
-  const expanded = controlledExpanded ?? internalExpanded;
-  const hasDetails = expandable && !!children;
+  const expanded = onOpen ? false : (controlledExpanded ?? internalExpanded);
+  const hasDetails = expandable && (!!children || !!onOpen);
 
   const setExpanded = (next: boolean) => {
     if (controlledExpanded === undefined) {
@@ -39,13 +48,20 @@ export function ToolActionRow({
     }
     onExpandedChange?.(next);
   };
+  const activate = () => {
+    if (onOpen) {
+      onOpen();
+      return;
+    }
+    setExpanded(!expanded);
+  };
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (
       event.target === event.currentTarget
       && (event.key === "Enter" || event.key === " ")
     ) {
       event.preventDefault();
-      setExpanded(!expanded);
+      activate();
     }
   };
 
@@ -63,7 +79,7 @@ export function ToolActionRow({
               ? "text-destructive/80 hover:text-destructive"
               : "text-muted-foreground hover:text-foreground"
           }`}
-          onClick={() => setExpanded(!expanded)}
+          onClick={activate}
           onKeyDown={handleKeyDown}
         >
           <ToolActionRowContent

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { useLayoutEffect, type ReactNode } from "react";
+import { useLayoutEffect, type ReactElement, type ReactNode } from "react";
 import { cleanup, render, waitFor } from "@testing-library/react";
 import type { TranscriptState } from "@anyharness/sdk";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   scrollToRowKey: vi.fn(),
   parseMatchId: vi.fn(() => ({ rowUnitId: "turn:turn-1:block:content" })),
   jumpToMatch: vi.fn(() => true),
+  openBackgroundTerminalDetail: vi.fn(),
   searchState: {
     open: true,
     surface: "chat",
@@ -98,7 +99,7 @@ vi.mock("#product/hooks/cowork/workflows/use-open-cowork-artifact", () => ({
 
 vi.mock("#product/hooks/activity/workflows/use-open-background-work-pane", () => ({
   useOpenBackgroundWorkPane: () => vi.fn(),
-  useOpenBackgroundTerminalDetail: () => vi.fn(),
+  useOpenBackgroundTerminalDetail: () => mocks.openBackgroundTerminalDetail,
 }));
 
 vi.mock("#product/hooks/ui/debug/use-debug-render-count", () => ({
@@ -182,5 +183,31 @@ describe("MessageList embedded content search", () => {
     expect(mocks.jumpToMatch).toHaveBeenCalledWith({
       rowUnitId: "turn:turn-1:block:content",
     });
+  });
+});
+
+describe("MessageList background-terminal click-in wiring (bgwork r8)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("wires a turn row's onOpenBackgroundTerminal to useOpenBackgroundTerminalDetail with the active session", () => {
+    renderMessageList();
+
+    const latestProps = mocks.chatView.mock.calls.at(-1)?.[0] as {
+      renderTurnRow: (input: unknown) => ReactElement;
+    };
+    const element = latestProps.renderTurnRow({ row: { hostsWorkspaceReceipt: false } });
+    const onOpenBackgroundTerminal = (
+      element.props as { onOpenBackgroundTerminal: (processId: string) => void }
+    ).onOpenBackgroundTerminal;
+
+    onOpenBackgroundTerminal("proc-42");
+
+    expect(mocks.openBackgroundTerminalDetail).toHaveBeenCalledWith("proc-42", "session-child");
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.tsx
@@ -333,6 +333,8 @@ export function MessageList({
       onOpenTurnChanges={() => openGitReviewPane({ mode: "last_turn" })}
       onOpenArtifact={openArtifact}
       onOpenSubagent={(subagentId) => openBackgroundWorkPane(subagentId, activeSessionId)}
+      onOpenBackgroundTerminal={(processId) =>
+        openBackgroundTerminalDetail(processId, activeSessionId)}
       onHandOffPlanToNewSession={onHandOffPlanToNewSession}
       workspaceReceipt={input.row.hostsWorkspaceReceipt ? <WorkspaceCreationReceipt /> : null}
     />
@@ -340,6 +342,7 @@ export function MessageList({
     activeSessionId,
     onHandOffPlanToNewSession,
     openArtifact,
+    openBackgroundTerminalDetail,
     openBackgroundWorkPane,
     openFile,
     openGitReviewPane,

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/ScopedTranscriptBlocks.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/ScopedTranscriptBlocks.tsx
@@ -15,12 +15,15 @@ export function ScopedTranscriptBlocks({
   autoFollowCollapsedActionBlockId,
   animateActivityEntry = false,
   renderItem,
+  onOpenBackgroundTerminal,
 }: {
   displayBlocks: readonly TurnDisplayBlock[];
   transcript: TranscriptState;
   autoFollowCollapsedActionBlockId?: string | null;
   animateActivityEntry?: boolean;
   renderItem: (itemId: string) => ReactNode;
+  /** bgwork r8 round 2: routed to a background command's collapsed-ledger row. */
+  onOpenBackgroundTerminal?: (processId: string) => void;
 }) {
   return (
     <>
@@ -32,6 +35,7 @@ export function ScopedTranscriptBlocks({
           autoFollowCollapsedActionBlockId={autoFollowCollapsedActionBlockId}
           animateActivityEntry={animateActivityEntry}
           renderItem={renderItem}
+          onOpenBackgroundTerminal={onOpenBackgroundTerminal}
         />
       ))}
     </>
@@ -44,12 +48,15 @@ export function TurnDisplayBlockNode({
   autoFollowCollapsedActionBlockId,
   animateActivityEntry = false,
   renderItem,
+  onOpenBackgroundTerminal,
 }: {
   block: TurnDisplayBlock;
   transcript: TranscriptState;
   autoFollowCollapsedActionBlockId?: string | null;
   animateActivityEntry?: boolean;
   renderItem: (itemId: string) => ReactNode;
+  /** bgwork r8 round 2: routed to a background command's collapsed-ledger row. */
+  onOpenBackgroundTerminal?: (processId: string) => void;
 }) {
   if (block.kind === "collapsed_actions") {
     const ownsLiveContinuation = block.blockId === autoFollowCollapsedActionBlockId;
@@ -63,6 +70,7 @@ export function TurnDisplayBlockNode({
           transcript={transcript}
           autoFollow={ownsLiveContinuation}
           liveContinuation={ownsLiveContinuation}
+          onOpenBackgroundTerminal={onOpenBackgroundTerminal}
         />
       </TranscriptActivityBlock>
     );
@@ -80,6 +88,7 @@ export function TurnDisplayBlockNode({
           transcript={transcript}
           autoFollow={ownsLiveContinuation}
           liveContinuation={ownsLiveContinuation}
+          onOpenBackgroundTerminal={onOpenBackgroundTerminal}
         />
       </TranscriptActivityBlock>
     );
@@ -97,6 +106,7 @@ export function TurnDisplayBlockNode({
           transcript={transcript}
           autoFollow={ownsLiveContinuation}
           liveContinuation={ownsLiveContinuation}
+          onOpenBackgroundTerminal={onOpenBackgroundTerminal}
         />
       </TranscriptActivityBlock>
     );

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.background-terminal-clickin.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.background-terminal-clickin.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+//
+// bgwork r8 round 3: a background command run BY a native subagent itself
+// renders inside that subagent's own nested transcript
+// (`TranscriptAgentGroupBlock`'s `renderScopedWork` -> `ScopedTranscriptBlocks`)
+// — the same collapsed-ledger shape fixed at the top level in round 2, one
+// level down. `TranscriptAgentGroupBlock` already threads `onOpenSubagent`
+// down this same path; `onOpenBackgroundTerminal` follows the identical
+// prop-threading convention rather than a local hook call (see
+// CollapsedCommandActionRow.background-terminal-clickin.test.tsx for why a
+// local `useOpenBackgroundTerminalDetail()` call isn't safe here either).
+//
+// Split out of TranscriptAgentGroupBlock.test.tsx (PROD-SIZE-1 — pushed that
+// file to 606 lines against the repo-wide 600-line cap); no assertions
+// changed, only relocated to this sibling file with its own minimal imports.
+import { createElement } from "react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { createTranscriptState } from "@anyharness/sdk";
+import type { ToolCallItem } from "@anyharness/sdk";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  toolItem,
+} from "#product/domain/chats/transcript/transcript-presentation-test-fixtures";
+import {
+  TranscriptAgentGroupBlock,
+} from "#product/components/workspace/chat/transcript/TranscriptAgentGroupBlock";
+
+afterEach(cleanup);
+
+function backgroundCommandChildItem(resultText: string): ToolCallItem {
+  return {
+    ...toolItem("child-bash", "turn-1", 2, "terminal", "in_progress"),
+    rawInput: { command: "sleep 100 &" },
+    contentParts: [
+      { type: "terminal_output", terminalId: "child-bash", event: "output", data: resultText },
+    ],
+  };
+}
+
+describe("TranscriptAgentGroupBlock onOpenBackgroundTerminal (nested background command click-in)", () => {
+  it("threads onOpenBackgroundTerminal down to a background command nested in the subagent's own transcript", () => {
+    const transcript = createTranscriptState("session-1");
+    const item: ToolCallItem = {
+      ...toolItem("native-task", "turn-1", 1, "subagent", "completed"),
+      title: "Inspect the repository",
+      nativeToolName: "Task",
+      rawInput: { prompt: "Inspect the transcript pipeline" },
+    };
+    const childItem = backgroundCommandChildItem("Command running in background with ID: bn30h453a");
+    transcript.itemsById[item.itemId] = item;
+    transcript.itemsById[childItem.itemId] = childItem;
+    const onOpenBackgroundTerminal = vi.fn();
+
+    const { getByText, getByRole } = render(
+      createElement(TranscriptAgentGroupBlock, {
+        item,
+        childIds: [childItem.itemId],
+        transcript,
+        childrenByParentId: new Map([[item.itemId, [childItem.itemId]]]),
+        renderChild: () => null,
+        onOpenBackgroundTerminal,
+      }),
+    );
+
+    // No onOpenSubagent wired: the header itself is the expand/collapse
+    // toggle for this block's own body.
+    fireEvent.click(getByText("Subagent created"));
+    // Reveal the nested work ledger.
+    fireEvent.click(getByText("1 tool call"));
+    // Expand the collapsed-ledger toggle to reach the inner command row.
+    fireEvent.click(getByRole("button", { name: /Running command/i }));
+    const row = getByRole("button", { name: /sleep 100 &/ });
+
+    fireEvent.click(row);
+
+    expect(onOpenBackgroundTerminal).toHaveBeenCalledWith("bn30h453a");
+    expect(row.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("negative control: without onOpenBackgroundTerminal, the nested row keeps the ordinary inline disclosure", () => {
+    const transcript = createTranscriptState("session-1");
+    const item: ToolCallItem = {
+      ...toolItem("native-task-unwired", "turn-1", 1, "subagent", "completed"),
+      title: "Inspect the repository",
+      nativeToolName: "Task",
+      rawInput: { prompt: "Inspect the transcript pipeline" },
+    };
+    const childItem = backgroundCommandChildItem("Command running in background with ID: bn30h453a");
+    transcript.itemsById[item.itemId] = item;
+    transcript.itemsById[childItem.itemId] = childItem;
+
+    const { getByText, getByRole } = render(
+      createElement(TranscriptAgentGroupBlock, {
+        item,
+        childIds: [childItem.itemId],
+        transcript,
+        childrenByParentId: new Map([[item.itemId, [childItem.itemId]]]),
+        renderChild: () => null,
+      }),
+    );
+
+    fireEvent.click(getByText("Subagent created"));
+    fireEvent.click(getByText("1 tool call"));
+    fireEvent.click(getByRole("button", { name: /Running command/i }));
+    const row = getByRole("button", { name: /sleep 100 &/ });
+
+    fireEvent.click(row);
+
+    // Falls back to the ordinary inline toggle rather than no-op'ing.
+    expect(row.getAttribute("aria-expanded")).toBe("true");
+    expect(getByText(/Command running in background with ID/)).not.toBeNull();
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.background-terminal-clickin.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.background-terminal-clickin.test.tsx
@@ -17,7 +17,7 @@ import { createElement } from "react";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { createTranscriptState } from "@anyharness/sdk";
 import type { ToolCallItem } from "@anyharness/sdk";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   toolItem,
 } from "#product/domain/chats/transcript/transcript-presentation-test-fixtures";
@@ -25,7 +25,23 @@ import {
   TranscriptAgentGroupBlock,
 } from "#product/components/workspace/chat/transcript/TranscriptAgentGroupBlock";
 
-afterEach(cleanup);
+// The collapsed-action disclosure (`AnimatedCollapsibleContent`) reveals its
+// expanded subtree one `requestAnimationFrame` after the toggle commits, so
+// the freshly mounted rows stay `inert`/`aria-hidden` until that frame runs.
+// jsdom never advances a real frame between a synchronous `fireEvent.click`
+// and the following query, so drive the frame inline — the same convention
+// `CollapsedActions.test.tsx` uses.
+beforeEach(() => {
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    callback(0);
+    return 1;
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
 
 function backgroundCommandChildItem(resultText: string): ToolCallItem {
   return {

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
@@ -45,6 +45,7 @@ export function TranscriptAgentGroupBlock({
   renderChild,
   workspaceId = null,
   onOpenSubagent,
+  onOpenBackgroundTerminal,
 }: {
   item: ToolCallItem;
   childIds: string[];
@@ -61,6 +62,14 @@ export function TranscriptAgentGroupBlock({
    * Absent for embedded/read-only transcripts that have no pane to open.
    */
   onOpenSubagent?: (subagentId: string) => void;
+  /**
+   * bgwork r8 round 3: a background command run inside this native
+   * subagent's own nested transcript (rendered by `renderScopedWork` below)
+   * needs the same click-in as the top-level transcript — threaded straight
+   * through to `ScopedTranscriptBlocks`, the same path `onOpenSubagent`
+   * already establishes one level up in `TranscriptToolCallGroupBlock`.
+   */
+  onOpenBackgroundTerminal?: (processId: string) => void;
 }) {
   const executionState = resolveSubagentExecutionState(item);
   const isRunning = isSubagentExecutionStateRunning(executionState);
@@ -123,6 +132,7 @@ export function TranscriptAgentGroupBlock({
       transcript={transcript}
       autoFollowCollapsedActionBlockId={null}
       renderItem={renderChild}
+      onOpenBackgroundTerminal={onOpenBackgroundTerminal}
     />
   );
   const headerVerb = executionState === "failed"

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptItemBlock.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptItemBlock.tsx
@@ -54,6 +54,7 @@ export function TranscriptItemBlock({
   onAssistantRevealStateChange,
   workspaceId,
   onOpenArtifact,
+  onOpenBackgroundTerminal,
   onHandOffPlanToNewSession,
 }: {
   item: TranscriptItem;
@@ -66,6 +67,7 @@ export function TranscriptItemBlock({
   ) => void;
   workspaceId: string | null;
   onOpenArtifact: (workspaceId: string, artifactId: string) => void;
+  onOpenBackgroundTerminal?: (processId: string) => void;
   onHandOffPlanToNewSession?: PlanHandoffHandler;
 }) {
   const sessionId = useTranscriptSessionId();
@@ -149,6 +151,7 @@ export function TranscriptItemBlock({
           animateActivityEntry={animateActivityEntry}
           workspaceId={workspaceId}
           onOpenArtifact={onOpenArtifact}
+          onOpenBackgroundTerminal={onOpenBackgroundTerminal}
         />
       );
     }
@@ -185,11 +188,13 @@ function ToolCallTranscriptItem({
   animateActivityEntry,
   workspaceId,
   onOpenArtifact,
+  onOpenBackgroundTerminal,
 }: {
   item: ToolCallItem;
   animateActivityEntry: boolean;
   workspaceId: string | null;
   onOpenArtifact: (workspaceId: string, artifactId: string) => void;
+  onOpenBackgroundTerminal?: (processId: string) => void;
 }) {
   // Only tool calls participate in proposed-plan suppression. Keeping this
   // context subscription out of the generic item component prevents a rare
@@ -234,6 +239,7 @@ function ToolCallTranscriptItem({
             item={item}
             workspaceId={workspaceId}
             onOpenArtifact={onOpenArtifact}
+            onOpenBackgroundTerminal={onOpenBackgroundTerminal}
           />
         </TranscriptActivityBlock>
       </div>

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolCallGroupBlock.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolCallGroupBlock.tsx
@@ -21,6 +21,7 @@ export function TranscriptToolCallGroupBlock({
   workspaceId,
   onOpenArtifact,
   onOpenSubagent,
+  onOpenBackgroundTerminal,
   renderChild,
 }: {
   item: ToolCallItem;
@@ -30,6 +31,7 @@ export function TranscriptToolCallGroupBlock({
   workspaceId: string | null;
   onOpenArtifact: (workspaceId: string, artifactId: string) => void;
   onOpenSubagent?: (subagentId: string) => void;
+  onOpenBackgroundTerminal?: (processId: string) => void;
   renderChild: (childId: string) => ReactNode;
 }) {
   if (isSubagentItem(item)) {
@@ -42,6 +44,7 @@ export function TranscriptToolCallGroupBlock({
         renderChild={renderChild}
         workspaceId={workspaceId}
         onOpenSubagent={onOpenSubagent}
+        onOpenBackgroundTerminal={onOpenBackgroundTerminal}
       />
     );
   }
@@ -73,6 +76,7 @@ export function TranscriptToolCallGroupBlock({
               item={item}
               workspaceId={workspaceId}
               onOpenArtifact={onOpenArtifact}
+              onOpenBackgroundTerminal={onOpenBackgroundTerminal}
             />
           )}
           <div className="ml-1 space-y-1">

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.background-terminal-clickin.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.background-terminal-clickin.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+//
+// bgwork r8: clicking a BACKGROUND command's tool-call row opens the
+// Background work pane's terminal detail (mirrors the subagent-creation
+// click-in) instead of toggling the row's inline output disclosure. The
+// correlation is entirely client-side: the Bash tool's own result text
+// carries "Command running in background with ID: {taskId}", and that id is
+// looked up against the session's roster (`ActivityProcessWire[]`) purely for
+// the trailing status text — click-in only needs the id to parse.
+import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActivityProcessWire } from "#product/domain/activity/process";
+import { toolCallItem } from "#product/lib/domain/chat/__fixtures__/playground/tool-call-item-fixture";
+import { TranscriptToolCallItemBlock } from "#product/components/workspace/chat/transcript/TranscriptToolCallItemBlock";
+import { renderWithProductHost as render } from "#product/components/workspace/chat/transcript/TranscriptToolCallItemBlock.test-fixtures";
+
+const mocks = vi.hoisted(() => ({
+  sessionProcesses: [] as ActivityProcessWire[],
+}));
+
+vi.mock("#product/hooks/cowork/workflows/use-open-cowork-coding-session", () => ({
+  useOpenCoworkCodingSession: () => vi.fn(),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/selection/use-workspace-selection", () => ({
+  useWorkspaceSelection: () => ({ selectWorkspace: vi.fn() }),
+}));
+
+vi.mock("#product/hooks/activity/derived/use-session-activity", () => ({
+  useSessionActivityForSession: () => ({
+    loops: [],
+    loopCapabilities: { supported: false, native: false },
+    processes: mocks.sessionProcesses,
+    agents: [],
+  }),
+}));
+
+function backgroundedBashItem(resultText: string) {
+  return toolCallItem({
+    nativeToolName: "Bash",
+    toolKind: "execute",
+    rawInput: { command: "while :; do gate-status; sleep 90; done" },
+    contentParts: [
+      { type: "tool_result_text", text: resultText },
+    ],
+  });
+}
+
+function rosterProcess(overrides: Partial<ActivityProcessWire> = {}): ActivityProcessWire {
+  return {
+    id: "proc-999",
+    command: "while :; do gate-status; sleep 90; done",
+    cwd: null,
+    status: { status: "running" },
+    pid: null,
+    startedAt: "2026-08-17T10:00:00.000Z",
+    endedAt: null,
+    feed: null,
+    ...overrides,
+  };
+}
+
+describe("TranscriptToolCallItemBlock — background command click-in (bgwork r8)", () => {
+  beforeEach(() => {
+    mocks.sessionProcesses = [];
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("opens the background terminal detail on click instead of toggling disclosure", () => {
+    const onOpenBackgroundTerminal = vi.fn();
+    const item = backgroundedBashItem("Command running in background with ID: proc-999");
+
+    render(
+      <TranscriptToolCallItemBlock
+        item={item}
+        workspaceId="workspace-1"
+        onOpenArtifact={() => {}}
+        onOpenBackgroundTerminal={onOpenBackgroundTerminal}
+      />,
+    );
+
+    const row = screen.getByRole("button", { name: /Running command/i });
+    expect(row.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(row);
+
+    expect(onOpenBackgroundTerminal).toHaveBeenCalledWith("proc-999");
+    // Clicking never reveals the inline output panel for a background row.
+    expect(screen.queryByText(/Command running in background with ID/)).toBeNull();
+    expect(row.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("shows the roster's trailing status text when roster data is present", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-17T10:04:12.000Z"));
+    mocks.sessionProcesses = [rosterProcess({ startedAt: "2026-08-17T10:00:00.000Z" })];
+    const item = backgroundedBashItem("Command running in background with ID: proc-999");
+
+    render(
+      <TranscriptToolCallItemBlock
+        item={item}
+        workspaceId="workspace-1"
+        onOpenArtifact={() => {}}
+        onOpenBackgroundTerminal={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("running · 4m 12s")).toBeTruthy();
+  });
+
+  it("still renders and opens the terminal when roster data is absent, with an empty trailing slot", () => {
+    const onOpenBackgroundTerminal = vi.fn();
+    mocks.sessionProcesses = []; // e.g. after reload — fold state doesn't survive.
+    const item = backgroundedBashItem("Command running in background with ID: proc-999");
+
+    render(
+      <TranscriptToolCallItemBlock
+        item={item}
+        workspaceId="workspace-1"
+        onOpenArtifact={() => {}}
+        onOpenBackgroundTerminal={onOpenBackgroundTerminal}
+      />,
+    );
+
+    const row = screen.getByRole("button", { name: /Running command/i });
+    expect(row.textContent).not.toMatch(/running ·|exited/);
+
+    fireEvent.click(row);
+    expect(onOpenBackgroundTerminal).toHaveBeenCalledWith("proc-999");
+  });
+
+  it("negative control: a foreground command keeps byte-identical inline disclosure behavior", () => {
+    const onOpenBackgroundTerminal = vi.fn();
+    const item = backgroundedBashItem("total 0\ndrwxr-xr-x  2 pablo  staff  64 file.txt");
+
+    render(
+      <TranscriptToolCallItemBlock
+        item={item}
+        workspaceId="workspace-1"
+        onOpenArtifact={() => {}}
+        onOpenBackgroundTerminal={onOpenBackgroundTerminal}
+      />,
+    );
+
+    const row = screen.getByRole("button", { name: /Running command/i });
+    expect(row.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByText(/drwxr-xr-x/)).toBeNull();
+
+    fireEvent.click(row);
+
+    // Toggles the ordinary inline disclosure — never routes to the pane.
+    expect(onOpenBackgroundTerminal).not.toHaveBeenCalled();
+    expect(row.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText(/drwxr-xr-x/)).toBeTruthy();
+  });
+
+  it("negative control: a near-miss sentence that doesn't parse an id keeps disclosure toggling", () => {
+    const onOpenBackgroundTerminal = vi.fn();
+    const item = backgroundedBashItem("The command is now running in the background, ID: proc-999");
+
+    render(
+      <TranscriptToolCallItemBlock
+        item={item}
+        workspaceId="workspace-1"
+        onOpenArtifact={() => {}}
+        onOpenBackgroundTerminal={onOpenBackgroundTerminal}
+      />,
+    );
+
+    const row = screen.getByRole("button", { name: /Running command/i });
+    fireEvent.click(row);
+
+    expect(onOpenBackgroundTerminal).not.toHaveBeenCalled();
+    expect(row.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText(/The command is now running/)).toBeTruthy();
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.tsx
@@ -32,6 +32,7 @@ import { ToolKindIcon } from "#product/components/workspace/chat/transcript/Tran
 import { AgentIdentityGlyph } from "#product/components/patterns/AgentIdentityGlyph";
 import { buildDelegatedAgentIdentity } from "#product/lib/domain/delegated-work/identity";
 import { useBackgroundCommandStatus } from "#product/hooks/activity/derived/use-background-command-status";
+import { useTranscriptSessionId } from "#product/components/workspace/chat/transcript/TranscriptContexts";
 
 export function TranscriptToolCallItemBlock({
   item,
@@ -67,7 +68,7 @@ export function TranscriptToolCallItemBlock({
   // any unrecognized shape) falls through to the ordinary inline-disclosure
   // BashCommandCall below, unchanged.
   const { processId: backgroundProcessId, trailingStatus: backgroundTrailingStatus } =
-    useBackgroundCommandStatus(normalizedResultText);
+    useBackgroundCommandStatus(normalizedResultText, useTranscriptSessionId());
 
   if (
     item.semanticKind === "cowork_artifact_create"

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.tsx
@@ -31,19 +31,43 @@ import { CHAT_VISIBLE_FILE_CHANGE_LIMIT } from "#product/lib/domain/workspaces/c
 import { ToolKindIcon } from "#product/components/workspace/chat/transcript/TranscriptToolKindIcon";
 import { AgentIdentityGlyph } from "#product/components/patterns/AgentIdentityGlyph";
 import { buildDelegatedAgentIdentity } from "#product/lib/domain/delegated-work/identity";
+import { useBackgroundCommandStatus } from "#product/hooks/activity/derived/use-background-command-status";
 
 export function TranscriptToolCallItemBlock({
   item,
   workspaceId,
   onOpenArtifact,
+  onOpenBackgroundTerminal,
 }: {
   item: ToolCallItem;
   workspaceId: string | null;
   onOpenArtifact: (workspaceId: string, artifactId: string) => void;
+  /**
+   * Deep-opens the Background work pane's terminal detail for a background
+   * command's `ActivityProcess.id` (bgwork r8). Optional: absent in surfaces
+   * that don't host the pane (e.g. the playground preview).
+   */
+  onOpenBackgroundTerminal?: (processId: string) => void;
 }) {
   const openCodingSession = useOpenCoworkCodingSession();
   const { selectWorkspace } = useWorkspaceSelection();
   const [showAllFileChanges, setShowAllFileChanges] = useState(false);
+  // Computed ahead of the early returns below so the roster lookup hook
+  // (shared with CollapsedActionRows' CommandActionRow/ParsedCommandRows,
+  // bgwork r8 round 3) is called unconditionally on every render path.
+  const toolResultText = item.contentParts
+    .filter((part): part is ToolResultTextContentPart => part.type === "tool_result_text")
+    .map((part) => part.text)
+    .join("\n\n");
+  const normalizedResultText = normalizeToolResultText(toolResultText);
+  // bgwork r8: a Bash tool result carrying the literal "Command running in
+  // background with ID: {taskId}" sentence correlates this row to a roster
+  // `ActivityProcess` — client-side only, there is no wire tool_call_id link.
+  // A row whose result text doesn't parse to an id (foreground commands, or
+  // any unrecognized shape) falls through to the ordinary inline-disclosure
+  // BashCommandCall below, unchanged.
+  const { processId: backgroundProcessId, trailingStatus: backgroundTrailingStatus } =
+    useBackgroundCommandStatus(normalizedResultText);
 
   if (
     item.semanticKind === "cowork_artifact_create"
@@ -85,15 +109,13 @@ export function TranscriptToolCallItemBlock({
   const toolCallPart = item.contentParts.find(
     (part): part is ToolCallContentPart => part.type === "tool_call",
   );
-  const toolResultText = item.contentParts
-    .filter((part): part is ToolResultTextContentPart => part.type === "tool_result_text")
-    .map((part) => part.text)
-    .join("\n\n");
-  const normalizedResultText = normalizeToolResultText(toolResultText);
   const toolName = toolCallPart?.title ?? item.title ?? item.nativeToolName ?? "Tool call";
   const rawInput = isRecord(item.rawInput);
   const bashDescription = readString(rawInput?.description) ?? undefined;
   const bashCommand = readString(rawInput?.command) ?? toolName;
+  const openBackgroundTerminal = backgroundProcessId && onOpenBackgroundTerminal
+    ? () => onOpenBackgroundTerminal(backgroundProcessId)
+    : undefined;
   const fallbackDisplay = describeToolCallDisplay(item, toolName);
   const rows: React.ReactNode[] = [];
   const status = mapStatus(item.status);
@@ -185,7 +207,8 @@ export function TranscriptToolCallItemBlock({
         description={bashDescription}
         output={output || (typeof item.rawOutput === "string" ? item.rawOutput : undefined)}
         status={status}
-        duration={formatToolDuration(item)}
+        duration={backgroundProcessId ? backgroundTrailingStatus : formatToolDuration(item)}
+        onOpenBackgroundTerminal={openBackgroundTerminal}
       />,
     );
   }
@@ -199,7 +222,8 @@ export function TranscriptToolCallItemBlock({
           description={bashDescription}
           output={normalizedResultText}
           status={status}
-          duration={formatToolDuration(item)}
+          duration={backgroundProcessId ? backgroundTrailingStatus : formatToolDuration(item)}
+          onOpenBackgroundTerminal={openBackgroundTerminal}
         />,
       );
     } else if (item.nativeToolName === "Read" || item.toolKind === "read") {

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTreeNode.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTreeNode.tsx
@@ -18,6 +18,7 @@ export function TranscriptTreeNode({
   workspaceId,
   onOpenArtifact,
   onOpenSubagent,
+  onOpenBackgroundTerminal,
   onHandOffPlanToNewSession,
 }: {
   itemId: string;
@@ -32,6 +33,7 @@ export function TranscriptTreeNode({
   workspaceId: string | null;
   onOpenArtifact: (workspaceId: string, artifactId: string) => void;
   onOpenSubagent?: (subagentId: string) => void;
+  onOpenBackgroundTerminal?: (processId: string) => void;
   onHandOffPlanToNewSession?: PlanHandoffHandler;
 }) {
   const item = transcript.itemsById[itemId];
@@ -49,6 +51,7 @@ export function TranscriptTreeNode({
           workspaceId={workspaceId}
           onOpenArtifact={onOpenArtifact}
           onOpenSubagent={onOpenSubagent}
+          onOpenBackgroundTerminal={onOpenBackgroundTerminal}
           renderChild={(childId) => (
             <TranscriptTreeNode
               itemId={childId}
@@ -60,6 +63,7 @@ export function TranscriptTreeNode({
               workspaceId={workspaceId}
               onOpenArtifact={onOpenArtifact}
               onOpenSubagent={onOpenSubagent}
+              onOpenBackgroundTerminal={onOpenBackgroundTerminal}
               onHandOffPlanToNewSession={onHandOffPlanToNewSession}
             />
           )}
@@ -77,6 +81,7 @@ export function TranscriptTreeNode({
       onAssistantRevealStateChange={onAssistantRevealStateChange}
       workspaceId={workspaceId}
       onOpenArtifact={onOpenArtifact}
+      onOpenBackgroundTerminal={onOpenBackgroundTerminal}
       onHandOffPlanToNewSession={onHandOffPlanToNewSession}
     />
   );

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.tsx
@@ -71,6 +71,7 @@ export function TranscriptTurnRow({
   onOpenTurnChanges,
   onOpenArtifact,
   onOpenSubagent,
+  onOpenBackgroundTerminal,
   onHandOffPlanToNewSession,
   workspaceReceipt = null,
 }: {
@@ -89,6 +90,7 @@ export function TranscriptTurnRow({
   onOpenTurnChanges?: () => void;
   onOpenArtifact: (workspaceId: string, artifactId: string) => void;
   onOpenSubagent?: (subagentId: string) => void;
+  onOpenBackgroundTerminal?: (processId: string) => void;
   onHandOffPlanToNewSession?: PlanHandoffHandler;
   /** The workspace-creation receipt, when this row hosts it (see `hostsWorkspaceReceipt`). */
   workspaceReceipt?: ReactNode;
@@ -290,6 +292,7 @@ export function TranscriptTurnRow({
           workspaceId={selectedWorkspaceId}
           onOpenArtifact={onOpenArtifact}
           onOpenSubagent={onOpenSubagent}
+          onOpenBackgroundTerminal={onOpenBackgroundTerminal}
           onHandOffPlanToNewSession={onHandOffPlanToNewSession}
           workspaceReceipt={workspaceReceipt}
         />

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnItemSequence.tsx
@@ -54,6 +54,7 @@ export function TurnItemSequence({
   workspaceId,
   onOpenArtifact,
   onOpenSubagent,
+  onOpenBackgroundTerminal,
   onHandOffPlanToNewSession,
   workspaceReceipt = null,
 }: {
@@ -74,6 +75,7 @@ export function TurnItemSequence({
   workspaceId: string | null;
   onOpenArtifact: (workspaceId: string, artifactId: string) => void;
   onOpenSubagent?: (subagentId: string) => void;
+  onOpenBackgroundTerminal?: (processId: string) => void;
   onHandOffPlanToNewSession?: PlanHandoffHandler;
   /**
    * The workspace-creation receipt, when this row hosts it. Renders as the
@@ -180,6 +182,7 @@ export function TurnItemSequence({
                         transcript={transcript}
                         autoFollowCollapsedActionBlockId={null}
                         animateActivityEntry={false}
+                        onOpenBackgroundTerminal={onOpenBackgroundTerminal}
                         renderItem={(itemId) => (
                           <TranscriptFragment
                             itemId={itemId}
@@ -191,6 +194,7 @@ export function TurnItemSequence({
                             workspaceId={workspaceId}
                             onOpenArtifact={onOpenArtifact}
                             onOpenSubagent={onOpenSubagent}
+                            onOpenBackgroundTerminal={onOpenBackgroundTerminal}
                             onHandOffPlanToNewSession={onHandOffPlanToNewSession}
                           />
                         )}
@@ -207,6 +211,7 @@ export function TurnItemSequence({
               transcript={transcript}
               autoFollowCollapsedActionBlockId={autoFollowCollapsedActionBlockId}
               animateActivityEntry={animateActivityEntry}
+              onOpenBackgroundTerminal={onOpenBackgroundTerminal}
               renderItem={(itemId) => (
                 <TranscriptFragment
                   itemId={itemId}
@@ -218,6 +223,7 @@ export function TurnItemSequence({
                   workspaceId={workspaceId}
                   onOpenArtifact={onOpenArtifact}
                   onOpenSubagent={onOpenSubagent}
+                  onOpenBackgroundTerminal={onOpenBackgroundTerminal}
                   onHandOffPlanToNewSession={onHandOffPlanToNewSession}
                 />
               )}
@@ -316,6 +322,7 @@ function TranscriptFragment({
   workspaceId,
   onOpenArtifact,
   onOpenSubagent,
+  onOpenBackgroundTerminal,
   onHandOffPlanToNewSession,
 }: {
   itemId: string;
@@ -330,6 +337,7 @@ function TranscriptFragment({
   workspaceId: string | null;
   onOpenArtifact: (workspaceId: string, artifactId: string) => void;
   onOpenSubagent?: (subagentId: string) => void;
+  onOpenBackgroundTerminal?: (processId: string) => void;
   onHandOffPlanToNewSession?: PlanHandoffHandler;
 }) {
   return (
@@ -344,6 +352,7 @@ function TranscriptFragment({
         workspaceId={workspaceId}
         onOpenArtifact={onOpenArtifact}
         onOpenSubagent={onOpenSubagent}
+        onOpenBackgroundTerminal={onOpenBackgroundTerminal}
         onHandOffPlanToNewSession={onHandOffPlanToNewSession}
       />
     </>

--- a/apps/packages/product-client/src/domain/activity/process.test.ts
+++ b/apps/packages/product-client/src/domain/activity/process.test.ts
@@ -5,6 +5,7 @@ import {
   processElapsedLabel,
   processStatusLabel,
   processStatusTone,
+  processTrailingStatusLabel,
   sortProcessesForDisplay,
   type ActivityProcessWire,
 } from "./process";
@@ -97,6 +98,47 @@ describe("processElapsedLabel", () => {
       endedAt: "2026-07-02T10:00:30.000Z",
     });
     expect(processElapsedLabel(p, Date.parse("2026-07-02T11:00:00.000Z"))).toBe("now");
+  });
+});
+
+describe("processTrailingStatusLabel", () => {
+  it("matches the design mock's running form: 'running · 4m 12s'", () => {
+    const p = process({ startedAt: "2026-07-02T10:00:00.000Z" });
+    const now = Date.parse("2026-07-02T10:04:12.000Z");
+    expect(processTrailingStatusLabel(p, now)).toBe("running · 4m 12s");
+  });
+
+  it("matches the design mock's exited form: 'exited 0 · 2m 45s'", () => {
+    const p = process({
+      status: { status: "exited", exitCode: 0 },
+      startedAt: "2026-07-02T10:00:00.000Z",
+      endedAt: "2026-07-02T10:02:45.000Z",
+    });
+    expect(processTrailingStatusLabel(p, Date.parse("2026-07-02T11:00:00.000Z"))).toBe(
+      "exited 0 · 2m 45s",
+    );
+  });
+
+  it("drops the exit code when the harness reports none", () => {
+    const p = process({
+      status: { status: "exited", exitCode: null },
+      startedAt: "2026-07-02T10:00:00.000Z",
+      endedAt: "2026-07-02T10:00:30.000Z",
+    });
+    expect(processTrailingStatusLabel(p, Date.parse("2026-07-02T11:00:00.000Z"))).toBe(
+      "exited · 30s",
+    );
+  });
+
+  it("uses whole-minute form with no trailing seconds", () => {
+    const p = process({
+      status: { status: "exited", exitCode: 1 },
+      startedAt: "2026-07-02T10:00:00.000Z",
+      endedAt: "2026-07-02T10:05:00.000Z",
+    });
+    expect(processTrailingStatusLabel(p, Date.parse("2026-07-02T11:00:00.000Z"))).toBe(
+      "exited 1 · 5m",
+    );
   });
 });
 

--- a/apps/packages/product-client/src/domain/activity/process.ts
+++ b/apps/packages/product-client/src/domain/activity/process.ts
@@ -149,6 +149,44 @@ export function processElapsedLabel(process: ActivityProcessWire, nowMs: number)
   return relativeTimeLabel(startedAtMs, endedAtMs);
 }
 
+/**
+ * Trailing status text for a background command's transcript row (bgwork
+ * r8) — "running · 4m 12s" / "exited 0 · 2m 45s" (Design Handoff — "Chat -
+ * Background Work Indicator", the "Running command" row's trailing muted
+ * slot). Deliberately distinct from `processStatusLabel` (capitalized,
+ * roster-row phrasing) and `processElapsedLabel` (coarse `relativeTimeLabel`
+ * buckets like "4m", built for the roster list): this slot wants the exact
+ * minutes+seconds shape the design mock shows.
+ */
+export function processTrailingStatusLabel(
+  process: Pick<ActivityProcessWire, "status" | "startedAt" | "endedAt">,
+  nowMs: number,
+): string {
+  const statusPart = process.status.status === "running"
+    ? "running"
+    : process.status.exitCode === null
+      ? "exited"
+      : `exited ${process.status.exitCode}`;
+  return `${statusPart} · ${processFineDurationLabel(process, nowMs)}`;
+}
+
+function processFineDurationLabel(
+  process: Pick<ActivityProcessWire, "status" | "startedAt" | "endedAt">,
+  nowMs: number,
+): string {
+  const startedAtMs = Date.parse(process.startedAt) || 0;
+  const endMs = process.status.status === "running"
+    ? nowMs
+    : (process.endedAt ? Date.parse(process.endedAt) || nowMs : nowMs);
+  const totalSeconds = Math.max(0, Math.round((endMs - startedAtMs) / 1000));
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`;
+}
+
 /** Running processes first (most-recently-started first), then exited (most-recent first). */
 export function sortProcessesForDisplay(
   processes: readonly ActivityProcessWire[],

--- a/apps/packages/product-client/src/domain/chats/tools/background-command-correlation.test.ts
+++ b/apps/packages/product-client/src/domain/chats/tools/background-command-correlation.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { parseBackgroundCommandProcessId } from "./background-command-correlation";
+
+describe("parseBackgroundCommandProcessId", () => {
+  it("extracts the id from the literal background sentence", () => {
+    expect(
+      parseBackgroundCommandProcessId("Command running in background with ID: proc-abc123"),
+    ).toBe("proc-abc123");
+  });
+
+  it("extracts the id when the sentence is embedded in more output", () => {
+    const text = [
+      "Starting watcher...",
+      "Command running in background with ID: proc-xyz789",
+      "",
+    ].join("\n");
+    expect(parseBackgroundCommandProcessId(text)).toBe("proc-xyz789");
+  });
+
+  it("strips trailing punctuation from the captured id", () => {
+    expect(
+      parseBackgroundCommandProcessId("Command running in background with ID: proc-abc123."),
+    ).toBe("proc-abc123");
+  });
+
+  it("returns null for foreground command output (negative control)", () => {
+    expect(parseBackgroundCommandProcessId("total 24\ndrwxr-xr-x  file.txt")).toBeNull();
+  });
+
+  it("returns null for empty text", () => {
+    expect(parseBackgroundCommandProcessId("")).toBeNull();
+  });
+
+  it("returns null for near-miss text that doesn't match the exact sentence", () => {
+    expect(
+      parseBackgroundCommandProcessId("The command is running in the background, ID: proc-1"),
+    ).toBeNull();
+  });
+});

--- a/apps/packages/product-client/src/domain/chats/tools/background-command-correlation.ts
+++ b/apps/packages/product-client/src/domain/chats/tools/background-command-correlation.ts
@@ -1,0 +1,28 @@
+/**
+ * Client-side correlation between a Bash tool call's own result text and the
+ * runtime's background-process roster (bgwork r8, "background command
+ * tool-call opens terminal detail"). There is no wire-level tool_call_id <->
+ * `ActivityProcess.id` correlation for a backgrounded command: the harness's
+ * Bash tool result carries the literal sentence "Command running in
+ * background with ID: {taskId}" when a command was backgrounded, and that
+ * `{taskId}` IS the runtime's `ActivityProcess.id` used by the roster
+ * (`domain/activity/process.ts`). Parsing this sentence out of the tool
+ * result text is the only way the client learns which roster entry a given
+ * transcript row corresponds to.
+ */
+
+const BACKGROUND_COMMAND_ID_PATTERN = /Command running in background with ID:\s*(\S+)/;
+
+/**
+ * Extracts the backgrounded process id from a Bash tool call's (already
+ * normalized) result text. Returns null when the sentence is absent —
+ * ordinary foreground commands, or a background sentence in a shape this
+ * pattern doesn't recognize — so the caller keeps its ordinary
+ * inline-disclosure behavior instead of treating the row as a background
+ * command.
+ */
+export function parseBackgroundCommandProcessId(resultText: string): string | null {
+  const match = resultText.match(BACKGROUND_COMMAND_ID_PATTERN);
+  const id = match?.[1]?.replace(/[.,;:]+$/, "");
+  return id ? id : null;
+}

--- a/apps/packages/product-client/src/hooks/activity/derived/use-background-command-status.ts
+++ b/apps/packages/product-client/src/hooks/activity/derived/use-background-command-status.ts
@@ -1,6 +1,5 @@
 import { parseBackgroundCommandProcessId } from "#product/domain/chats/tools/background-command-correlation";
 import { processTrailingStatusLabel } from "#product/domain/activity/process";
-import { useTranscriptSessionId } from "#product/components/workspace/chat/transcript/TranscriptContexts";
 import { useSessionActivityForSession } from "#product/hooks/activity/derived/use-session-activity";
 
 export interface BackgroundCommandStatus {
@@ -18,9 +17,18 @@ export interface BackgroundCommandStatus {
  * command that parses into structured display rows is still one process
  * with one result text, so both call sites resolve the same id/status pair
  * against this one hook rather than duplicating the roster lookup.
+ *
+ * The transcript session id is passed in by the (component-layer) caller
+ * rather than read here from `useTranscriptSessionId`: that context accessor
+ * lives in the components layer, and a hook reaching up into it is an upward
+ * layer edge the frontend boundary lint (FE-PC-6) rejects. Every call site
+ * already renders inside the transcript context, so threading the id keeps
+ * this hook within the hooks layer at no cost.
  */
-export function useBackgroundCommandStatus(resultText: string): BackgroundCommandStatus {
-  const sessionId = useTranscriptSessionId();
+export function useBackgroundCommandStatus(
+  resultText: string,
+  sessionId: string | null,
+): BackgroundCommandStatus {
   const { processes } = useSessionActivityForSession(sessionId);
   const processId = parseBackgroundCommandProcessId(resultText);
   const process = processId

--- a/apps/packages/product-client/src/hooks/activity/derived/use-background-command-status.ts
+++ b/apps/packages/product-client/src/hooks/activity/derived/use-background-command-status.ts
@@ -1,0 +1,33 @@
+import { parseBackgroundCommandProcessId } from "#product/domain/chats/tools/background-command-correlation";
+import { processTrailingStatusLabel } from "#product/domain/activity/process";
+import { useTranscriptSessionId } from "#product/components/workspace/chat/transcript/TranscriptContexts";
+import { useSessionActivityForSession } from "#product/hooks/activity/derived/use-session-activity";
+
+export interface BackgroundCommandStatus {
+  /** The roster `ActivityProcess.id` parsed out of the command's own result text, or null. */
+  processId: string | null;
+  /** `running · 4m 12s` / `exited 0 · 2m 45s`, present only when roster data exists. */
+  trailingStatus: string | undefined;
+}
+
+/**
+ * A background Bash command's own result text carries the only link to its
+ * roster entry (`Command running in background with ID: {taskId}` — no
+ * wire-level correlation exists). Shared between `CommandActionRow` (bgwork
+ * r8 round 1/2) and `CollapsedActionRows`' `ParsedCommandRows` (round 3): a
+ * command that parses into structured display rows is still one process
+ * with one result text, so both call sites resolve the same id/status pair
+ * against this one hook rather than duplicating the roster lookup.
+ */
+export function useBackgroundCommandStatus(resultText: string): BackgroundCommandStatus {
+  const sessionId = useTranscriptSessionId();
+  const { processes } = useSessionActivityForSession(sessionId);
+  const processId = parseBackgroundCommandProcessId(resultText);
+  const process = processId
+    ? processes.find((candidate) => candidate.id === processId) ?? null
+    : null;
+  return {
+    processId,
+    trailingStatus: process ? processTrailingStatusLabel(process, Date.now()) : undefined,
+  };
+}

--- a/lints/frontend/ratchets.toml
+++ b/lints/frontend/ratchets.toml
@@ -195,8 +195,8 @@ reason = "Background Work R2: reports the stick-to-bottom engine's own isPinnedT
 
 [[frontend_structure]]
 path = "apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.tsx"
-max_lines = 442
-reason = "Background Work R6: in-scroll background_work + completion_receipt row orchestration (interleave placement, receipt hosting, pane wiring) grew the transcript list host past 400; extraction pending"
+max_lines = 443
+reason = "Background Work R6+R8: r6 row orchestration grew the transcript list host past 400 (extraction pending); r8 adds 3 lines of background-command click-in wiring, and the refold base carries main's one-line hydration amendment (439->440), so the reviewed-at-442 content lands at 443"
 
 # FE-CHATSCROLL-1 sanctioned scroll-position writers, read by
 # scripts/check_transcript_scroll_writer.py. File-level allowlist: any non-test


### PR DESCRIPTION
## Summary

Rung r8 of the Background Work stack. Clicking a **backgrounded** Bash tool-call row in the chat transcript now opens the Background Work pane's terminal detail view — the same click-in behavior a subagent-creation row already has — instead of toggling the inline output disclosure. Foreground commands, and background rows whose result text doesn't yield a known process id, are unaffected: they keep the existing inline-disclosure toggle byte-for-byte.

## What changed

- `domain/chats/tools/background-command-correlation.ts` (new): parses the runtime's literal `Command running in background with ID: {taskId}` sentence out of a Bash tool's result text to recover the `ActivityProcess.id` used by the background-work roster. There is no wire-level tool_call_id correlation, so this is the only link available.
- `domain/activity/process.ts`: adds `processTrailingStatusLabel`, a fine-grained `running · 4m 12s` / `exited 0 · 2m 45s` label for the row's trailing status slot, matching the "Chat - Background Work Indicator" design handoff.
- `tool-calls/ToolActionRow.tsx`: adds an `onOpen` override — when set, activating the row calls it instead of expanding in place. Fully backward compatible; every other consumer never passes it, so their behavior is unchanged.
- `tool-calls/BashCommandCall.tsx`: forwards a new `onOpenBackgroundTerminal` prop to `ToolActionRow`'s `onOpen`.
- `TranscriptToolCallItemBlock.tsx` → `TranscriptItemBlock.tsx` → `TranscriptToolCallGroupBlock.tsx` / `TranscriptTreeNode.tsx` → `TurnItemSequence.tsx` → `TranscriptTurnRow.tsx` → `MessageList.tsx`: thread the `onOpenBackgroundTerminal(processId)` callback down to the row, wired at the top to the existing `useOpenBackgroundTerminalDetail` hook from r6 (no new pane plumbing needed).
- Roster lookup (`useSessionActivityForSession` + `useTranscriptSessionId`) is a local hook call inside `TranscriptToolCallItemBlock` rather than a threaded prop, so only the OPEN callback needed prop-threading — keeps the diff to the workflow action only.

## Behavior

- Background row, id parses, roster data present: click opens terminal detail; trailing slot shows `running · Xm Ys` / `exited N · Xm Ys`.
- Background row, id parses, roster data absent (e.g. after reload): click still opens terminal detail; trailing slot stays empty.
- Foreground row, or background row whose result text doesn't parse to an id: click keeps toggling inline disclosure, byte-identical to prior behavior.

## Test plan

- [x] `pnpm exec vitest run` targeted suites (11 files / 108 tests, all passing) covering: id-parsing correlation (incl. negative controls), trailing-status label formatting, `ToolActionRow`'s `onOpen` override, and full click-in wiring through `TranscriptToolCallItemBlock` and `MessageList` — including both mandated negative controls (foreground command, near-miss result text).
- [x] `python3 scripts/check_max_lines.py` — `Max-lines check passed (repo max 600, component max 500, server layer maxes enabled).`
- [x] Design-attribution lint — `Design attribution check passed.`
- [x] `tsc -p tsconfig.json --noEmit` — no new errors introduced (one pre-existing, unrelated error in `run-view-model.ts` confirmed present on base branch too).

Base SHA (merge-base with `origin/bgwork/r6-completion-receipts`): `d66ed0579995e10c1d798aa230461e448ec894cd`
Head SHA: `c90cdb3d67a8ba5e759e194998af63bcbc2bcddb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Round 2 (live-verification fix-forward)

Live verification against the served preview found a real gap: round 1 only wired click-in through `TranscriptToolCallItemBlock`, the still-*expanded* live-turn path. Every turn collapses into a "Worked for Ns" ledger once it completes, and that ledger renders its command rows through an entirely separate component tree — `CollapsedActions` → `CollapsedActionRows` → `CommandActionRow` — which round 1 never touched. Since every finished turn collapses, this was the path the founder actually saw, and it still opened the inline Shell disclosure instead of the terminal detail.

### What changed

- `tool-calls/CollapsedCommandActionRow.tsx` (`CommandActionRow`): reuses `parseBackgroundCommandProcessId` (no new parsing) and `processTrailingStatusLabel` against roster data read via the same `useTranscriptSessionId` + `useSessionActivityForSession` local-hook convention `TranscriptToolCallItemBlock` already uses. A background command with a parseable id never expands in place; activating it calls the threaded `onOpenBackgroundTerminal` instead.
- The pane-opening callback is a **threaded prop** here, not a local `useOpenBackgroundTerminalDetail()` call: that hook reaches into `useWorkspaces()`/`useProductAuthUserId()`, which requires a fully equipped `ProductHostProvider`. Calling it unconditionally inside `CommandActionRow` broke every other ledger test that mounts `CollapsedActions` with a minimal test host (caught by the targeted suite, not shipped). `onOpenBackgroundTerminal` now threads `CollapsedActionRows` → `CollapsedActions` → `ScopedTranscriptBlocks`'s `TurnDisplayBlockNode`, terminating at the `onOpenBackgroundTerminal` prop `TurnItemSequence` already carried from round 1 (both of its `TurnDisplayBlockNode` call sites now forward it) — no new top-level wiring needed.
- `tool-calls/CollapsedActionRowPrimitives.tsx` (`ActionDisclosureRow`): adds the same muted trailing-status slot (`running · 4m 12s` / `exited 0 · 2m 45s`) round 1 added to the top-level row.

### Behavior (collapsed-ledger path)

- Background row, id parses, callback wired, roster data present: click opens terminal detail; trailing slot shows `running · Xm Ys` / `exited N · Xm Ys`.
- Background row, id parses, roster data absent (e.g. after reload): click still opens terminal detail; trailing slot stays empty.
- Background row, id parses, but the caller hasn't wired `onOpenBackgroundTerminal` at all (e.g. the read-only playground transcript): falls back to the ordinary inline toggle rather than no-op'ing or throwing.
- Foreground row, or background row whose result text doesn't parse to an id: click keeps toggling inline disclosure, byte-identical to prior behavior.

### Test plan (round 2)

- [x] New `CollapsedCommandActionRow.background-terminal-clickin.test.tsx` (7 tests): click-in, roster-present trailing status, roster-absent fallback, unwired-caller fallback, and both mandated negative controls (foreground command, near-miss result text) — mirroring round 1's coverage for this second path.
- [x] Full targeted suite after the fix, 14 files: `Test Files  14 passed (14)` / `Tests  133 passed (133)`.
- [x] Broader regression sweep, whole chat/playground surface: `Test Files  83 passed (83)` / `Tests  580 passed (580)`.
- [x] `python3 scripts/check_max_lines.py` — `Max-lines check passed (repo max 600, component max 500, server layer maxes enabled).`
- [x] Design-attribution lint — `Design attribution check passed.`
- [x] `tsc -p tsconfig.json --noEmit` — no new errors (same single pre-existing, unrelated `run-view-model.ts` error confirmed present on base branch too).

Head SHA: `0ddafdb8c5304d335c1e166fa199626588a653b0`

---

## Round 3 (parsed/compound rows + nested subagent transcripts, live-verification fix-forward)

Live verification (fiber/DOM walk against the served preview) found round 2's fix still didn't cover the founder's actual command shape. `CollapsedActionRows` has a FIRST branch, checked before `classifyCollapsedAction`'s switch ever runs: `if (getToolCallParsedCommands(item).length > 0) return <ParsedCommandRows .../>`. Any Bash tool call whose harness supplies a structured `parsed_cmd` breakdown — including the founder's own `for i in $(seq 1 15); do echo probe $i; sleep 1; done` — takes that branch and never reached round 2's wired `CommandActionRow`. Confirmed live: the row rendered via `ParsedCommandRows` and clicking still opened the inline Shell disclosure.

A delta reviewer posted CLEAN on round 2 but treated this exclusion as acceptable ("static rows, no half-wired state"); overridden as not acceptable for this purpose, since the founder's reported command renders through exactly this branch.

### What changed

- `hooks/activity/derived/use-background-command-status.ts` (new): extracts the roster-lookup logic (session id → roster processes → parse the result text's `Command running in background with ID: ...` sentence → resolve the trailing status label) shared by `CommandActionRow`, `CollapsedActionRows`, and `TranscriptToolCallItemBlock`, so it's written once instead of three times.
- `tool-calls/CollapsedActionRows.tsx`: resolves `backgroundProcessId`/`backgroundTrailingStatus` **once per tool call** via the shared hook, before branching on `parsedCommands.length > 0`. A background command is one process with one result text no matter how many structural rows its parsed breakdown renders into, so `ParsedCommandRows` now threads the same id/status uniformly to every row it renders — never a half-wired subset where some rows open the pane and others keep their old per-kind treatment (e.g. a `read`-kind row's file link). Falls back to the exact original per-kind rendering (`FileActionRow` / `PlainActionRow`) when there's no id to open with, or no caller wired to open it.
- `tool-calls/CollapsedCommandActionRow.tsx`: refactored to call the new shared hook instead of inlining the roster lookup; no behavior change.
- `transcript/TranscriptToolCallItemBlock.tsx`: same refactor, which also incidentally shaved this file back under the repo's `FE-SIZE-1` 400-line soft threshold (`report_frontend_structure.py`) — it had grown to 402 lines in round 1.
- `transcript/TranscriptAgentGroupBlock.tsx` / `TranscriptToolCallGroupBlock.tsx`: a second review finding — `TranscriptAgentGroupBlock` renders its own nested `ScopedTranscriptBlocks` for a native subagent's own transcript, but couldn't receive `onOpenBackgroundTerminal`, so a background command run *by* a native subagent got click-in on its expanded row but not on its collapsed ledger row (same gap as round 2, one level down). Threaded the same way `onOpenSubagent` already flows through this component.
- Test-naming honesty nit (same review): `CollapsedCommandActionRow.background-terminal-clickin.test.tsx`'s "standalone playground" test actually passed the callback despite its negative-control framing — it was a pure duplicate of the genuine unwired-caller test in the same file, so it's removed rather than renamed.

### Behavior (parsed/compound-command path)

- A tool call whose harness supplies a `parsed_cmd` breakdown (e.g. the founder's for-loop), where the result text parses to a background process id: **every** parsed row opens the same terminal detail on click, with the roster's trailing status on each row (the design artifact is silent on multi-row treatment for a background command, so this follows the coordinator's fallback of "trailing status on each parsed row").
- Same shape, but the caller hasn't wired `onOpenBackgroundTerminal`: falls back to the ordinary per-kind rendering (byte-identical to pre-r8).
- Same shape, but the result text doesn't parse to an id (foreground compound command, or unrecognized/near-miss text): falls back to the ordinary per-kind rendering, byte-identical, and never calls the callback.
- A background command run *inside* a native subagent's own nested transcript: its collapsed ledger row now opens the terminal detail too, same as the top-level transcript.

### Test plan (round 3)

- [x] New `CollapsedActionRows.parsed-background-terminal-clickin.test.tsx` (7 tests): confirms the fixture takes the `ParsedCommandRows` branch, click-in for the founder's exact for-loop shape, roster trailing-status display, "every row of a multi-command call opens the same terminal — no half-wired subset," and three negative controls (unwired caller, foreground compound command, near-miss result text).
- [x] New `TranscriptAgentGroupBlock.background-terminal-clickin.test.tsx` (2 tests): click-in for a background command nested in a native subagent's own transcript, and the unwired-caller negative control. Split into its own file (not added to `TranscriptAgentGroupBlock.test.tsx`) because that file was already at 606 lines against the repo-wide 600-line cap.
- [x] `CollapsedCommandActionRow.background-terminal-clickin.test.tsx` re-verified after removing the dishonest duplicate test: `Test Files  1 passed (1)` / `Tests  6 passed (6)`.
- [x] Targeted suite: `Test Files  2 passed (2)` / `Tests  13 passed (13)` (the two new parsed/compound + refactored-command-row files together).
- [x] `TranscriptToolCallItemBlock` suites after the shared-hook refactor: `Test Files  2 passed (2)` / `Tests  28 passed (28)`.
- [x] `TranscriptAgentGroupBlock` suites after the split: `Test Files  2 passed (2)` / `Tests  18 passed (18)`.
- [x] Broader regression sweep, whole chat/playground surface: `Test Files  85 passed (85)` / `Tests  588 passed (588)`.
- [x] `python3 scripts/check_max_lines.py` — `Max-lines check passed (repo max 600, component max 500, server layer maxes enabled).`
- [x] `python3 scripts/report_frontend_structure.py --strict --summary-only` — `FE-SIZE-1: 1` (only `MessageList.tsx`, a pre-existing violation from this branch's `r6` base being fixed on #2021 — not touched here per explicit instruction; `TranscriptToolCallItemBlock.tsx`'s round-1 violation is resolved).
- [x] Design-attribution lint — `Design attribution check passed.`
- [x] `tsc -p tsconfig.json --noEmit` — no new errors (same single pre-existing, unrelated `run-view-model.ts` error confirmed present on base branch too).

Head SHA: `cd4945f63`
