### PR TITLE
fix(product): preserve model picker arrow navigation

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.test.tsx
@@ -371,6 +371,9 @@ it("restores composer focus after Enter selects a searched model", async () => {
 
   openModelOptions(container);
   const search = document.querySelector<HTMLInputElement>('input[placeholder="Search models"]')!;
+  expect(search.getAttribute("autocorrect")).toBe("off");
+  expect(search.getAttribute("spellcheck")).toBe("false");
+  fireEvent.change(search, { target: { value: "a" } });
   fireEvent.keyDown(search, { key: "ArrowDown", code: "ArrowDown" });
   fireEvent.keyDown(search, { key: "Enter", code: "Enter" });
 

--- a/apps/packages/product-client/src/primitives/PopoverSearchField.tsx
+++ b/apps/packages/product-client/src/primitives/PopoverSearchField.tsx
@@ -43,6 +43,8 @@ export function PopoverSearchField({
         onChange={(event) => onChange(event.target.value)}
         placeholder={placeholder}
         autoFocus={autoFocus}
+        autoCorrect="off"
+        spellCheck={false}
         aria-label={ariaLabel}
         onKeyDown={onKeyDown}
         className="h-auto min-w-0 flex-1 border-0 bg-transparent px-0 py-0 text-ui text-foreground shadow-none outline-none placeholder:text-muted-foreground focus:ring-0 disabled:opacity-60"

--- a/apps/packages/product-client/src/primitives/PopoverSearchField.tsx
+++ b/apps/packages/product-client/src/primitives/PopoverSearchField.tsx
@@ -43,8 +43,8 @@ export function PopoverSearchField({
         onChange={(event) => onChange(event.target.value)}
         placeholder={placeholder}
         autoFocus={autoFocus}
-        autoCorrect="off"
         spellCheck={false}
+        autoCorrect="off"
         aria-label={ariaLabel}
         onKeyDown={onKeyDown}
         className="h-auto min-w-0 flex-1 border-0 bg-transparent px-0 py-0 text-ui text-foreground shadow-none outline-none placeholder:text-muted-foreground focus:ring-0 disabled:opacity-60"


### PR DESCRIPTION
## Summary

- Disable native autocorrect and spellcheck for the shared popover search primitive so platform correction UI cannot consume picker navigation keys across model, file, repository, branch, and project searches.
- Extend the model-picker regression coverage to type a query before ArrowDown and Enter.
- The source issue is linked to this PR through the tracker.

## Testing

- Tier 1 DOM and keyboard contract: `pnpm --filter @proliferate/product-client exec vitest run src/components/workspace/chat/input/ComposerModelSelectorControl.test.tsx` (12 passed).
- Type and package integration: `pnpm --filter @proliferate/product-client typecheck`.
- Login first-load budget: `pnpm shared:build && VITE_PROLIFERATE_API_BASE_URL=https://login-budget-fixture.invalid pnpm web:build && node scripts/measure-login-runtime-budget.mjs --no-build` (`501996/502000 B`, passed).
- Manual macOS verification was not run; jsdom cannot exercise the native correction candidate UI, so the regression pins the emitted opt-out attributes and typed-then-arrow behavior.

## Observability

- None. This changes native input hints only and adds no failure path, telemetry, or logging.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] If this PR has support relationships, I linked them through the tracker API. No tracker, report, user, or support IDs or private source data appear in this PR.

## Verification

- `python3 scripts/check_frontend_boundaries.py`
- `git diff --check`
