### PR TITLE
fix(product-client): restore login first-load budget headroom (lazy lifecycle splits)

### DIFF
--- a/apps/packages/product-client/src/hooks/app/lifecycle/use-app-shortcuts.test.tsx
+++ b/apps/packages/product-client/src/hooks/app/lifecycle/use-app-shortcuts.test.tsx
@@ -13,63 +13,9 @@ import {
 } from "#product/lib/domain/shortcuts/registry";
 import { USER_PREFERENCE_DEFAULTS } from "#product/lib/domain/preferences/user/model";
 import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store";
-import { requestRightPanelTabByIndex } from "#product/lib/workflows/workspaces/right-panel-shortcut-requests";
-import { useSidebarSwitchCursorStore } from "#product/stores/workspaces/sidebar-switch-cursor-store";
-import { WORKSPACE_CURSOR_SETTLE_MS } from "#product/lib/domain/workspaces/sidebar/workspace-switch-cursor-controller";
-
-const navigationMocks = vi.hoisted(() => ({
-  selectWorkspaceFromSurface: vi.fn(),
-}));
-
-const harnessState = vi.hoisted(() => ({
-  selectedWorkspaceId: null as string | null,
-  selectedLogicalWorkspaceId: null as string | null,
-  digitShortcutTargets: [] as string[],
-  traversalShortcutTargets: [] as string[],
-}));
-
-vi.mock("#product/hooks/workspaces/derived/use-sidebar-shortcut-targets", () => ({
-  useSidebarShortcutTargets: () => ({
-    digitTargetIds: harnessState.digitShortcutTargets,
-    traversalTargetIds: harnessState.traversalShortcutTargets,
-  }),
-}));
-
-vi.mock("#product/hooks/workspaces/workflows/use-workspace-navigation-workflow", () => ({
-  useWorkspaceNavigationWorkflow: () => ({
-    selectWorkspaceFromSurface: navigationMocks.selectWorkspaceFromSurface,
-  }),
-}));
-
-vi.mock("#product/stores/sessions/session-selection-store", () => {
-  const readSelection = () => ({
-    selectedWorkspaceId: harnessState.selectedWorkspaceId,
-    selectedLogicalWorkspaceId: harnessState.selectedLogicalWorkspaceId,
-  });
-  const useSessionSelectionStore = (
-    selector: (state: {
-      selectedWorkspaceId: string | null;
-      selectedLogicalWorkspaceId: string | null;
-    }) => unknown,
-  ) => selector(readSelection());
-  // The traversal-cursor effect reads the committed selection imperatively and
-  // subscribes for commit reflection, so the mock exposes the same static
-  // surface the real zustand store does.
-  useSessionSelectionStore.getState = readSelection;
-  useSessionSelectionStore.subscribe = () => () => {};
-  return { useSessionSelectionStore };
-});
-
-vi.mock("#product/lib/workflows/workspaces/right-panel-shortcut-requests", () => ({
-  requestRightPanelTabByIndex: vi.fn(() => true),
-}));
 
 describe("useAppShortcuts", () => {
   beforeEach(() => {
-    harnessState.selectedWorkspaceId = null;
-    harnessState.selectedLogicalWorkspaceId = null;
-    harnessState.digitShortcutTargets = [];
-    harnessState.traversalShortcutTargets = [];
     clearShortcutHandlerRegistryForTests();
     useUserPreferencesStore.setState({
       ...USER_PREFERENCE_DEFAULTS,
@@ -82,59 +28,9 @@ describe("useAppShortcuts", () => {
     cleanup();
     clearShortcutHandlerRegistryForTests();
     document.body.innerHTML = "";
-    useSidebarSwitchCursorStore.getState().setCursor(null);
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
-  });
-
-  describe("held-key workspace traversal", () => {
-    it("previews the cursor on a step and commits the selection once after the settle", () => {
-      harnessState.selectedWorkspaceId = "workspace-1";
-      harnessState.selectedLogicalWorkspaceId = "workspace-1";
-      harnessState.digitShortcutTargets = ["pinned-workspace"];
-      harnessState.traversalShortcutTargets = ["workspace-1", "workspace-2", "workspace-3"];
-      vi.useFakeTimers();
-
-      renderHook(() => useAppShortcuts(commandActions()));
-
-      expect(runShortcutHandler("workspace.next-workspace", { source: "keyboard" })).toBe(true);
-      // The step previews immediately via the cursor, without committing.
-      expect(useSidebarSwitchCursorStore.getState().cursorId).toBe("workspace-2");
-      expect(navigationMocks.selectWorkspaceFromSurface).not.toHaveBeenCalled();
-
-      // The one expensive selection commit fires only after movement settles.
-      act(() => {
-        vi.advanceTimersByTime(WORKSPACE_CURSOR_SETTLE_MS);
-      });
-      expect(navigationMocks.selectWorkspaceFromSurface).toHaveBeenCalledTimes(1);
-      expect(navigationMocks.selectWorkspaceFromSurface).toHaveBeenCalledWith(
-        "workspace-2",
-        "shortcut",
-      );
-    });
-
-    it("cancels an uncommitted preview on Escape without committing", () => {
-      harnessState.selectedWorkspaceId = "workspace-1";
-      harnessState.selectedLogicalWorkspaceId = "workspace-1";
-      harnessState.traversalShortcutTargets = ["workspace-1", "workspace-2", "workspace-3"];
-      vi.useFakeTimers();
-
-      renderHook(() => useAppShortcuts(commandActions()));
-
-      runShortcutHandler("workspace.next-workspace", { source: "keyboard" });
-      expect(useSidebarSwitchCursorStore.getState().cursorId).toBe("workspace-2");
-
-      act(() => {
-        window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
-      });
-      expect(useSidebarSwitchCursorStore.getState().cursorId).toBeNull();
-
-      act(() => {
-        vi.advanceTimersByTime(WORKSPACE_CURSOR_SETTLE_MS);
-      });
-      expect(navigationMocks.selectWorkspaceFromSurface).not.toHaveBeenCalled();
-    });
   });
 
   it("steps window zoom through the registered app shortcuts without changing font sizes", () => {
@@ -164,51 +60,6 @@ describe("useAppShortcuts", () => {
     expect(useUserPreferencesStore.getState().windowZoomId).toBe("zoom120");
     expect(useUserPreferencesStore.getState().uiFontSizeId).toBe("xxxlarge");
     expect(useUserPreferencesStore.getState().readableCodeFontSizeId).toBe("large");
-  });
-
-  it("routes option-number shortcuts to the right panel when right-panel focus is active", () => {
-    harnessState.selectedWorkspaceId = "workspace-1";
-    harnessState.selectedLogicalWorkspaceId = "workspace-1";
-    harnessState.digitShortcutTargets = ["workspace-1", "workspace-2", "workspace-3"];
-    const zone = document.createElement("div");
-    zone.tabIndex = 0;
-    zone.setAttribute("data-focus-zone", "right-panel");
-    document.body.append(zone);
-    zone.focus();
-
-    renderHook(() => useAppShortcuts(commandActions()));
-
-    expect(runShortcutHandler("workspace.by-index", {
-      source: "keyboard",
-      digit: 2,
-    })).toBe(true);
-    expect(requestRightPanelTabByIndex).toHaveBeenCalledWith(2);
-    expect(navigationMocks.selectWorkspaceFromSurface).not.toHaveBeenCalled();
-  });
-
-  it("falls back to workspace selection when a stale right-panel focus request is unhandled", () => {
-    harnessState.selectedWorkspaceId = "workspace-1";
-    harnessState.selectedLogicalWorkspaceId = "workspace-1";
-    harnessState.digitShortcutTargets = ["pin-1", "pin-2", "workspace-1"];
-    harnessState.traversalShortcutTargets = ["workspace-1", "pin-1", "pin-2"];
-    const zone = document.createElement("div");
-    zone.tabIndex = 0;
-    zone.setAttribute("data-focus-zone", "right-panel");
-    document.body.append(zone);
-    zone.focus();
-    vi.mocked(requestRightPanelTabByIndex).mockReturnValueOnce(false);
-
-    renderHook(() => useAppShortcuts(commandActions()));
-
-    expect(runShortcutHandler("workspace.by-index", {
-      source: "keyboard",
-      digit: 2,
-    })).toBe(true);
-    expect(requestRightPanelTabByIndex).toHaveBeenCalledWith(2);
-    expect(navigationMocks.selectWorkspaceFromSurface).toHaveBeenCalledWith(
-      "pin-2",
-      "shortcut",
-    );
   });
 
   it("routes workspace copy shortcuts through app command actions", () => {

--- a/apps/packages/product-client/src/hooks/app/lifecycle/use-app-shortcuts.ts
+++ b/apps/packages/product-client/src/hooks/app/lifecycle/use-app-shortcuts.ts
@@ -1,22 +1,6 @@
-import { useEffect, useRef } from "react";
-
 import { useShortcutHandler } from "#product/hooks/shortcuts/lifecycle/use-shortcut-handler";
 import type { AppCommandActions } from "#product/hooks/app/workflows/app-command-action-types";
-import { useSidebarShortcutTargets } from "#product/hooks/workspaces/derived/use-sidebar-shortcut-targets";
-import { useWorkspaceNavigationWorkflow } from "#product/hooks/workspaces/workflows/use-workspace-navigation-workflow";
-import {
-  focusChatInput,
-  getFocusZone,
-  isRightPanelFocusZone,
-} from "#product/lib/domain/focus-zone";
-import { resolveSidebarShortcutDigitTarget } from "#product/lib/domain/workspaces/sidebar/sidebar-shortcut-targets";
-import {
-  createWorkspaceSwitchCursorController,
-  type WorkspaceSwitchCursorController,
-} from "#product/lib/domain/workspaces/sidebar/workspace-switch-cursor-controller";
-import { requestRightPanelTabByIndex } from "#product/lib/workflows/workspaces/right-panel-shortcut-requests";
-import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
-import { useSidebarSwitchCursorStore } from "#product/stores/workspaces/sidebar-switch-cursor-store";
+import { focusChatInput } from "#product/lib/domain/focus-zone";
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store";
 import { stepWindowZoomId } from "#product/lib/domain/preferences/appearance";
@@ -27,75 +11,15 @@ import {
 } from "#product/lib/infra/dom/dom-select-all";
 
 // Owns global app shortcut registration. App command behavior stays in the
-// workflow actions passed by the caller.
+// workflow actions passed by the caller. The workspace-switch shortcuts
+// (Cmd+1..9, Cmd+Opt+Arrow) live in useWorkspaceSwitchShortcuts instead of
+// here (login runtime-budget fix): they are the only shortcuts that need
+// useWorkspaceNavigationWorkflow's selectWorkspaceFromSurface, which pulls in
+// the workspace-selection / agent-catalog / session-creation graph, and that
+// hook is mounted authenticated-only so the /login first-load chunk never
+// parses it. See AuthenticatedWorkspaceSwitchShortcuts /
+// ProductLifecycleRoot.tsx for the mount point.
 export function useAppShortcuts(actions: AppCommandActions): void {
-  const { digitTargetIds, traversalTargetIds } = useSidebarShortcutTargets();
-  const { selectWorkspaceFromSurface } = useWorkspaceNavigationWorkflow();
-
-  // Held-key workspace traversal (Cmd+Opt+Arrow) previews a lightweight cursor
-  // through the sidebar and commits the one expensive selection only once
-  // movement settles. The controller owns the throttle/settle/coalescing state
-  // machine; refs keep the once-created controller reading current values
-  // without re-subscribing the whole hook to selection changes.
-  const targetIdsRef = useRef(traversalTargetIds);
-  targetIdsRef.current = traversalTargetIds;
-  const selectWorkspaceFromSurfaceRef = useRef(selectWorkspaceFromSurface);
-  selectWorkspaceFromSurfaceRef.current = selectWorkspaceFromSurface;
-
-  const switchCursorControllerRef = useRef<WorkspaceSwitchCursorController | null>(null);
-  if (switchCursorControllerRef.current === null) {
-    switchCursorControllerRef.current = createWorkspaceSwitchCursorController({
-      now: () => performance.now(),
-      setTimer: (fn, ms) => window.setTimeout(fn, ms),
-      clearTimer: (handle) => window.clearTimeout(handle),
-      getTargetIds: () => targetIdsRef.current,
-      getCommittedId: () => {
-        const selection = useSessionSelectionStore.getState();
-        return selection.selectedLogicalWorkspaceId ?? selection.selectedWorkspaceId;
-      },
-      getCursorId: () => useSidebarSwitchCursorStore.getState().cursorId,
-      setCursorId: (cursorId) => useSidebarSwitchCursorStore.getState().setCursor(cursorId),
-      commitSelection: (workspaceId) =>
-        selectWorkspaceFromSurfaceRef.current(workspaceId, "shortcut"),
-    });
-  }
-
-  useEffect(() => {
-    const controller = switchCursorControllerRef.current;
-    if (controller === null) {
-      return undefined;
-    }
-    const readCommitted = (state: {
-      selectedLogicalWorkspaceId: string | null;
-      selectedWorkspaceId: string | null;
-    }) => state.selectedLogicalWorkspaceId ?? state.selectedWorkspaceId;
-    let lastCommitted = readCommitted(useSessionSelectionStore.getState());
-    const unsubscribe = useSessionSelectionStore.subscribe((state) => {
-      const committed = readCommitted(state);
-      if (committed === lastCommitted) {
-        return;
-      }
-      lastCommitted = committed;
-      controller.onCommittedChange(committed);
-    });
-    // Escape cancels an uncommitted preview. Capture-phase and side-effect free
-    // (no preventDefault) so any other Escape handling still runs, and it only
-    // acts while a cursor is actually pending.
-    const handleEscape = (event: KeyboardEvent) => {
-      if (
-        event.key === "Escape" &&
-        useSidebarSwitchCursorStore.getState().cursorId !== null
-      ) {
-        controller.cancel();
-      }
-    };
-    window.addEventListener("keydown", handleEscape, true);
-    return () => {
-      unsubscribe();
-      window.removeEventListener("keydown", handleEscape, true);
-    };
-  }, []);
-
   useShortcutHandler("app.open-settings", () => {
     actions.openSettings.execute("shortcut");
   });
@@ -152,32 +76,6 @@ export function useAppShortcuts(actions: AppCommandActions): void {
 
   useShortcutHandler("app.redo", () => {
     return runRedoCommand();
-  });
-
-  useShortcutHandler("workspace.by-index", ({ digit }) => {
-    if (!digit) {
-      return false;
-    }
-
-    if (isRightPanelFocusZone(getFocusZone())) {
-      const handled = requestRightPanelTabByIndex(digit);
-      if (handled) {
-        return true;
-      }
-    }
-
-    const targetId = resolveSidebarShortcutDigitTarget(digitTargetIds, digit);
-    if (targetId) {
-      selectWorkspaceFromSurface(targetId, "shortcut");
-    }
-  });
-
-  useShortcutHandler("workspace.previous-workspace", () => {
-    switchCursorControllerRef.current?.step(-1);
-  });
-
-  useShortcutHandler("workspace.next-workspace", () => {
-    switchCursorControllerRef.current?.step(1);
   });
 
   useShortcutHandler("workspace.toggle-cowork-threads", () => {

--- a/apps/packages/product-client/src/hooks/app/lifecycle/use-app-shortcuts.ts
+++ b/apps/packages/product-client/src/hooks/app/lifecycle/use-app-shortcuts.ts
@@ -13,12 +13,17 @@ import {
 // Owns global app shortcut registration. App command behavior stays in the
 // workflow actions passed by the caller. The workspace-switch shortcuts
 // (Cmd+1..9, Cmd+Opt+Arrow) live in useWorkspaceSwitchShortcuts instead of
-// here (login runtime-budget fix): they are the only shortcuts that need
-// useWorkspaceNavigationWorkflow's selectWorkspaceFromSurface, which pulls in
-// the workspace-selection / agent-catalog / session-creation graph, and that
-// hook is mounted authenticated-only so the /login first-load chunk never
-// parses it. See AuthenticatedWorkspaceSwitchShortcuts /
-// ProductLifecycleRoot.tsx for the mount point.
+// here (login runtime-budget fix): they were the only unconditional
+// (pre-auth) callers of useSidebarShortcutTargets and the held-key traversal
+// cursor machinery, so moving them to an authenticated-only mount is what
+// keeps that sidebar-projection / cursor-controller code off the /login
+// first-load chunk. (useWorkspaceNavigationWorkflow itself -- and the
+// workspace-selection / agent-catalog / session-creation graph it pulls in --
+// is unrelated to this split: it is still called unconditionally elsewhere,
+// via useAppNavigationCommandActions / useAppNewWorkspaceCommandActions, so
+// it remains in the login chunk regardless.) See
+// AuthenticatedWorkspaceSwitchShortcuts / ProductLifecycleRoot.tsx for the
+// mount point.
 export function useAppShortcuts(actions: AppCommandActions): void {
   useShortcutHandler("app.open-settings", () => {
     actions.openSettings.execute("shortcut");

--- a/apps/packages/product-client/src/hooks/app/lifecycle/use-workspace-switch-shortcuts.test.tsx
+++ b/apps/packages/product-client/src/hooks/app/lifecycle/use-workspace-switch-shortcuts.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useWorkspaceSwitchShortcuts } from "#product/hooks/app/lifecycle/use-workspace-switch-shortcuts";
+import {
+  clearShortcutHandlerRegistryForTests,
+  runShortcutHandler,
+} from "#product/lib/domain/shortcuts/registry";
+import { requestRightPanelTabByIndex } from "#product/lib/workflows/workspaces/right-panel-shortcut-requests";
+import { useSidebarSwitchCursorStore } from "#product/stores/workspaces/sidebar-switch-cursor-store";
+import { WORKSPACE_CURSOR_SETTLE_MS } from "#product/lib/domain/workspaces/sidebar/workspace-switch-cursor-controller";
+
+const navigationMocks = vi.hoisted(() => ({
+  selectWorkspaceFromSurface: vi.fn(),
+}));
+
+const harnessState = vi.hoisted(() => ({
+  selectedWorkspaceId: null as string | null,
+  selectedLogicalWorkspaceId: null as string | null,
+  digitShortcutTargets: [] as string[],
+  traversalShortcutTargets: [] as string[],
+}));
+
+vi.mock("#product/hooks/workspaces/derived/use-sidebar-shortcut-targets", () => ({
+  useSidebarShortcutTargets: () => ({
+    digitTargetIds: harnessState.digitShortcutTargets,
+    traversalTargetIds: harnessState.traversalShortcutTargets,
+  }),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/use-workspace-navigation-workflow", () => ({
+  useWorkspaceNavigationWorkflow: () => ({
+    selectWorkspaceFromSurface: navigationMocks.selectWorkspaceFromSurface,
+  }),
+}));
+
+vi.mock("#product/stores/sessions/session-selection-store", () => {
+  const readSelection = () => ({
+    selectedWorkspaceId: harnessState.selectedWorkspaceId,
+    selectedLogicalWorkspaceId: harnessState.selectedLogicalWorkspaceId,
+  });
+  const useSessionSelectionStore = (
+    selector: (state: {
+      selectedWorkspaceId: string | null;
+      selectedLogicalWorkspaceId: string | null;
+    }) => unknown,
+  ) => selector(readSelection());
+  // The traversal-cursor effect reads the committed selection imperatively and
+  // subscribes for commit reflection, so the mock exposes the same static
+  // surface the real zustand store does.
+  useSessionSelectionStore.getState = readSelection;
+  useSessionSelectionStore.subscribe = () => () => {};
+  return { useSessionSelectionStore };
+});
+
+vi.mock("#product/lib/workflows/workspaces/right-panel-shortcut-requests", () => ({
+  requestRightPanelTabByIndex: vi.fn(() => true),
+}));
+
+describe("useWorkspaceSwitchShortcuts", () => {
+  beforeEach(() => {
+    harnessState.selectedWorkspaceId = null;
+    harnessState.selectedLogicalWorkspaceId = null;
+    harnessState.digitShortcutTargets = [];
+    harnessState.traversalShortcutTargets = [];
+    clearShortcutHandlerRegistryForTests();
+  });
+
+  afterEach(() => {
+    cleanup();
+    clearShortcutHandlerRegistryForTests();
+    document.body.innerHTML = "";
+    useSidebarSwitchCursorStore.getState().setCursor(null);
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  describe("held-key workspace traversal", () => {
+    it("previews the cursor on a step and commits the selection once after the settle", () => {
+      harnessState.selectedWorkspaceId = "workspace-1";
+      harnessState.selectedLogicalWorkspaceId = "workspace-1";
+      harnessState.digitShortcutTargets = ["pinned-workspace"];
+      harnessState.traversalShortcutTargets = ["workspace-1", "workspace-2", "workspace-3"];
+      vi.useFakeTimers();
+
+      renderHook(() => useWorkspaceSwitchShortcuts());
+
+      expect(runShortcutHandler("workspace.next-workspace", { source: "keyboard" })).toBe(true);
+      // The step previews immediately via the cursor, without committing.
+      expect(useSidebarSwitchCursorStore.getState().cursorId).toBe("workspace-2");
+      expect(navigationMocks.selectWorkspaceFromSurface).not.toHaveBeenCalled();
+
+      // The one expensive selection commit fires only after movement settles.
+      act(() => {
+        vi.advanceTimersByTime(WORKSPACE_CURSOR_SETTLE_MS);
+      });
+      expect(navigationMocks.selectWorkspaceFromSurface).toHaveBeenCalledTimes(1);
+      expect(navigationMocks.selectWorkspaceFromSurface).toHaveBeenCalledWith(
+        "workspace-2",
+        "shortcut",
+      );
+    });
+
+    it("cancels an uncommitted preview on Escape without committing", () => {
+      harnessState.selectedWorkspaceId = "workspace-1";
+      harnessState.selectedLogicalWorkspaceId = "workspace-1";
+      harnessState.traversalShortcutTargets = ["workspace-1", "workspace-2", "workspace-3"];
+      vi.useFakeTimers();
+
+      renderHook(() => useWorkspaceSwitchShortcuts());
+
+      runShortcutHandler("workspace.next-workspace", { source: "keyboard" });
+      expect(useSidebarSwitchCursorStore.getState().cursorId).toBe("workspace-2");
+
+      act(() => {
+        window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      });
+      expect(useSidebarSwitchCursorStore.getState().cursorId).toBeNull();
+
+      act(() => {
+        vi.advanceTimersByTime(WORKSPACE_CURSOR_SETTLE_MS);
+      });
+      expect(navigationMocks.selectWorkspaceFromSurface).not.toHaveBeenCalled();
+    });
+  });
+
+  it("routes option-number shortcuts to the right panel when right-panel focus is active", () => {
+    harnessState.selectedWorkspaceId = "workspace-1";
+    harnessState.selectedLogicalWorkspaceId = "workspace-1";
+    harnessState.digitShortcutTargets = ["workspace-1", "workspace-2", "workspace-3"];
+    const zone = document.createElement("div");
+    zone.tabIndex = 0;
+    zone.setAttribute("data-focus-zone", "right-panel");
+    document.body.append(zone);
+    zone.focus();
+
+    renderHook(() => useWorkspaceSwitchShortcuts());
+
+    expect(runShortcutHandler("workspace.by-index", {
+      source: "keyboard",
+      digit: 2,
+    })).toBe(true);
+    expect(requestRightPanelTabByIndex).toHaveBeenCalledWith(2);
+    expect(navigationMocks.selectWorkspaceFromSurface).not.toHaveBeenCalled();
+  });
+
+  it("falls back to workspace selection when a stale right-panel focus request is unhandled", () => {
+    harnessState.selectedWorkspaceId = "workspace-1";
+    harnessState.selectedLogicalWorkspaceId = "workspace-1";
+    harnessState.digitShortcutTargets = ["pin-1", "pin-2", "workspace-1"];
+    harnessState.traversalShortcutTargets = ["workspace-1", "pin-1", "pin-2"];
+    const zone = document.createElement("div");
+    zone.tabIndex = 0;
+    zone.setAttribute("data-focus-zone", "right-panel");
+    document.body.append(zone);
+    zone.focus();
+    vi.mocked(requestRightPanelTabByIndex).mockReturnValueOnce(false);
+
+    renderHook(() => useWorkspaceSwitchShortcuts());
+
+    expect(runShortcutHandler("workspace.by-index", {
+      source: "keyboard",
+      digit: 2,
+    })).toBe(true);
+    expect(requestRightPanelTabByIndex).toHaveBeenCalledWith(2);
+    expect(navigationMocks.selectWorkspaceFromSurface).toHaveBeenCalledWith(
+      "pin-2",
+      "shortcut",
+    );
+  });
+});

--- a/apps/packages/product-client/src/hooks/app/lifecycle/use-workspace-switch-shortcuts.test.tsx
+++ b/apps/packages/product-client/src/hooks/app/lifecycle/use-workspace-switch-shortcuts.test.tsx
@@ -9,7 +9,10 @@ import {
 } from "#product/lib/domain/shortcuts/registry";
 import { requestRightPanelTabByIndex } from "#product/lib/workflows/workspaces/right-panel-shortcut-requests";
 import { useSidebarSwitchCursorStore } from "#product/stores/workspaces/sidebar-switch-cursor-store";
-import { WORKSPACE_CURSOR_SETTLE_MS } from "#product/lib/domain/workspaces/sidebar/workspace-switch-cursor-controller";
+import {
+  WORKSPACE_CURSOR_COMMIT_FALLBACK_MS,
+  WORKSPACE_CURSOR_SETTLE_MS,
+} from "#product/lib/domain/workspaces/sidebar/workspace-switch-cursor-controller";
 
 const navigationMocks = vi.hoisted(() => ({
   selectWorkspaceFromSurface: vi.fn(),
@@ -120,6 +123,30 @@ describe("useWorkspaceSwitchShortcuts", () => {
 
       act(() => {
         vi.advanceTimersByTime(WORKSPACE_CURSOR_SETTLE_MS);
+      });
+      expect(navigationMocks.selectWorkspaceFromSurface).not.toHaveBeenCalled();
+    });
+
+    it("clears pending settle/fallback timers on unmount so a stale commit never fires (auth-flap mid-traversal)", () => {
+      // This owner mounts/unmounts with authStatus (ProductLifecycleRoot only
+      // renders it while authenticated), so an auth flap can unmount it while a
+      // step is still previewing, inside the settle window. Without cleanup the
+      // queued timer would call commitSelection (selectWorkspaceFromSurface)
+      // after unmount, against refs captured before the flap.
+      harnessState.selectedWorkspaceId = "workspace-1";
+      harnessState.selectedLogicalWorkspaceId = "workspace-1";
+      harnessState.traversalShortcutTargets = ["workspace-1", "workspace-2", "workspace-3"];
+      vi.useFakeTimers();
+
+      const { unmount } = renderHook(() => useWorkspaceSwitchShortcuts());
+
+      runShortcutHandler("workspace.next-workspace", { source: "keyboard" });
+      expect(useSidebarSwitchCursorStore.getState().cursorId).toBe("workspace-2");
+
+      unmount();
+
+      act(() => {
+        vi.advanceTimersByTime(WORKSPACE_CURSOR_SETTLE_MS + WORKSPACE_CURSOR_COMMIT_FALLBACK_MS);
       });
       expect(navigationMocks.selectWorkspaceFromSurface).not.toHaveBeenCalled();
     });

--- a/apps/packages/product-client/src/hooks/app/lifecycle/use-workspace-switch-shortcuts.ts
+++ b/apps/packages/product-client/src/hooks/app/lifecycle/use-workspace-switch-shortcuts.ts
@@ -1,0 +1,119 @@
+import { useEffect, useRef } from "react";
+
+import { useShortcutHandler } from "#product/hooks/shortcuts/lifecycle/use-shortcut-handler";
+import { useSidebarShortcutTargets } from "#product/hooks/workspaces/derived/use-sidebar-shortcut-targets";
+import { useWorkspaceNavigationWorkflow } from "#product/hooks/workspaces/workflows/use-workspace-navigation-workflow";
+import { getFocusZone, isRightPanelFocusZone } from "#product/lib/domain/focus-zone";
+import { resolveSidebarShortcutDigitTarget } from "#product/lib/domain/workspaces/sidebar/sidebar-shortcut-targets";
+import {
+  createWorkspaceSwitchCursorController,
+  type WorkspaceSwitchCursorController,
+} from "#product/lib/domain/workspaces/sidebar/workspace-switch-cursor-controller";
+import { requestRightPanelTabByIndex } from "#product/lib/workflows/workspaces/right-panel-shortcut-requests";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+import { useSidebarSwitchCursorStore } from "#product/stores/workspaces/sidebar-switch-cursor-store";
+
+// Split out of use-app-shortcuts.ts (login runtime-budget fix). These three
+// handlers (Cmd+1..9 by sidebar position, Cmd+Opt+Arrow traversal) are the
+// only shortcuts that need useWorkspaceNavigationWorkflow's
+// selectWorkspaceFromSurface, which pulls in workspace selection, the agent
+// catalog, and session-creation machinery -- none of it relevant before a
+// workspace exists, i.e. before auth. Pre-auth these shortcuts were already
+// no-ops (no sidebar targets to select, no committed workspace to step from);
+// mounting this hook only once authenticated (see
+// AuthenticatedWorkspaceSwitchShortcuts / ProductLifecycleRoot.tsx) changes
+// only when the handlers are registered, never what they do.
+export function useWorkspaceSwitchShortcuts(): void {
+  const { digitTargetIds, traversalTargetIds } = useSidebarShortcutTargets();
+  const { selectWorkspaceFromSurface } = useWorkspaceNavigationWorkflow();
+
+  // Held-key workspace traversal (Cmd+Opt+Arrow) previews a lightweight cursor
+  // through the sidebar and commits the one expensive selection only once
+  // movement settles. The controller owns the throttle/settle/coalescing state
+  // machine; refs keep the once-created controller reading current values
+  // without re-subscribing the whole hook to selection changes.
+  const targetIdsRef = useRef(traversalTargetIds);
+  targetIdsRef.current = traversalTargetIds;
+  const selectWorkspaceFromSurfaceRef = useRef(selectWorkspaceFromSurface);
+  selectWorkspaceFromSurfaceRef.current = selectWorkspaceFromSurface;
+
+  const switchCursorControllerRef = useRef<WorkspaceSwitchCursorController | null>(null);
+  if (switchCursorControllerRef.current === null) {
+    switchCursorControllerRef.current = createWorkspaceSwitchCursorController({
+      now: () => performance.now(),
+      setTimer: (fn, ms) => window.setTimeout(fn, ms),
+      clearTimer: (handle) => window.clearTimeout(handle),
+      getTargetIds: () => targetIdsRef.current,
+      getCommittedId: () => {
+        const selection = useSessionSelectionStore.getState();
+        return selection.selectedLogicalWorkspaceId ?? selection.selectedWorkspaceId;
+      },
+      getCursorId: () => useSidebarSwitchCursorStore.getState().cursorId,
+      setCursorId: (cursorId) => useSidebarSwitchCursorStore.getState().setCursor(cursorId),
+      commitSelection: (workspaceId) =>
+        selectWorkspaceFromSurfaceRef.current(workspaceId, "shortcut"),
+    });
+  }
+
+  useEffect(() => {
+    const controller = switchCursorControllerRef.current;
+    if (controller === null) {
+      return undefined;
+    }
+    const readCommitted = (state: {
+      selectedLogicalWorkspaceId: string | null;
+      selectedWorkspaceId: string | null;
+    }) => state.selectedLogicalWorkspaceId ?? state.selectedWorkspaceId;
+    let lastCommitted = readCommitted(useSessionSelectionStore.getState());
+    const unsubscribe = useSessionSelectionStore.subscribe((state) => {
+      const committed = readCommitted(state);
+      if (committed === lastCommitted) {
+        return;
+      }
+      lastCommitted = committed;
+      controller.onCommittedChange(committed);
+    });
+    // Escape cancels an uncommitted preview. Capture-phase and side-effect free
+    // (no preventDefault) so any other Escape handling still runs, and it only
+    // acts while a cursor is actually pending.
+    const handleEscape = (event: KeyboardEvent) => {
+      if (
+        event.key === "Escape" &&
+        useSidebarSwitchCursorStore.getState().cursorId !== null
+      ) {
+        controller.cancel();
+      }
+    };
+    window.addEventListener("keydown", handleEscape, true);
+    return () => {
+      unsubscribe();
+      window.removeEventListener("keydown", handleEscape, true);
+    };
+  }, []);
+
+  useShortcutHandler("workspace.by-index", ({ digit }) => {
+    if (!digit) {
+      return false;
+    }
+
+    if (isRightPanelFocusZone(getFocusZone())) {
+      const handled = requestRightPanelTabByIndex(digit);
+      if (handled) {
+        return true;
+      }
+    }
+
+    const targetId = resolveSidebarShortcutDigitTarget(digitTargetIds, digit);
+    if (targetId) {
+      selectWorkspaceFromSurface(targetId, "shortcut");
+    }
+  });
+
+  useShortcutHandler("workspace.previous-workspace", () => {
+    switchCursorControllerRef.current?.step(-1);
+  });
+
+  useShortcutHandler("workspace.next-workspace", () => {
+    switchCursorControllerRef.current?.step(1);
+  });
+}

--- a/apps/packages/product-client/src/hooks/app/lifecycle/use-workspace-switch-shortcuts.ts
+++ b/apps/packages/product-client/src/hooks/app/lifecycle/use-workspace-switch-shortcuts.ts
@@ -14,15 +14,27 @@ import { useSessionSelectionStore } from "#product/stores/sessions/session-selec
 import { useSidebarSwitchCursorStore } from "#product/stores/workspaces/sidebar-switch-cursor-store";
 
 // Split out of use-app-shortcuts.ts (login runtime-budget fix). These three
-// handlers (Cmd+1..9 by sidebar position, Cmd+Opt+Arrow traversal) are the
-// only shortcuts that need useWorkspaceNavigationWorkflow's
-// selectWorkspaceFromSurface, which pulls in workspace selection, the agent
-// catalog, and session-creation machinery -- none of it relevant before a
-// workspace exists, i.e. before auth. Pre-auth these shortcuts were already
-// no-ops (no sidebar targets to select, no committed workspace to step from);
-// mounting this hook only once authenticated (see
-// AuthenticatedWorkspaceSwitchShortcuts / ProductLifecycleRoot.tsx) changes
-// only when the handlers are registered, never what they do.
+// handlers (Cmd+1..9 by sidebar position, Cmd+Opt+Arrow traversal) were the
+// only unconditional (pre-auth) callers of useSidebarShortcutTargets and of
+// the traversal cursor machinery (workspace-switch-cursor-controller.ts,
+// sidebar-switch-cursor-store.ts) -- useSidebarShortcutTargets's only other
+// caller, MainSidebar.tsx, is already inside the authenticated lazy chunk.
+// Gating this hook behind auth is what removed those modules (sidebar-groups
+// projection, the cursor controller/store) from the /login first-load chunk.
+//
+// NOTE this does NOT remove useWorkspaceNavigationWorkflow (or what it pulls
+// in: useWorkspaceSelection, the bundled agent-catalog JSON, the
+// session-creation graph) from the login chunk -- that hook is still called
+// unconditionally, pre-auth, from useAppNavigationCommandActions and
+// useAppNewWorkspaceCommandActions (both reached via useAppCommandActions at
+// ProductLifecycleRoot.tsx). Getting that graph off /login too is a candidate
+// follow-up, not something this mechanical split attempted.
+//
+// Pre-auth these three shortcuts were already no-ops (no sidebar targets to
+// select, no committed workspace to step from); mounting this hook only once
+// authenticated (see AuthenticatedWorkspaceSwitchShortcuts /
+// ProductLifecycleRoot.tsx) changes only when the handlers are registered,
+// never what they do.
 export function useWorkspaceSwitchShortcuts(): void {
   const { digitTargetIds, traversalTargetIds } = useSidebarShortcutTargets();
   const { selectWorkspaceFromSurface } = useWorkspaceNavigationWorkflow();
@@ -88,6 +100,12 @@ export function useWorkspaceSwitchShortcuts(): void {
     return () => {
       unsubscribe();
       window.removeEventListener("keydown", handleEscape, true);
+      // This owner now mounts/unmounts with authStatus (it did not before this
+      // split), so an in-flight settle/fallback timer can outlive it -- an auth
+      // flap mid-traversal would otherwise let commitSelection fire after
+      // unmount, acting on stale refs. cancel() clears both timers (and any
+      // pending commit/cursor state) so nothing fires post-unmount.
+      controller.cancel();
     };
   }, []);
 

--- a/apps/packages/product-client/src/providers/AuthenticatedWorkspaceSwitchShortcuts.tsx
+++ b/apps/packages/product-client/src/providers/AuthenticatedWorkspaceSwitchShortcuts.tsx
@@ -1,0 +1,15 @@
+import { useWorkspaceSwitchShortcuts } from "#product/hooks/app/lifecycle/use-workspace-switch-shortcuts"
+
+/**
+ * Authenticated-only mount point for useWorkspaceSwitchShortcuts (login
+ * runtime-budget fix). The hook already no-ops when signed out (there is no
+ * sidebar target and no committed workspace to step from), so gating the
+ * owner behind the same auth check that already governs its behavior is a
+ * bundling-only change. It lets the owner be lazy-loaded, which keeps the
+ * workspace-selection / agent-catalog / session-creation graph
+ * useWorkspaceNavigationWorkflow pulls in off the /login first-load path.
+ */
+export function AuthenticatedWorkspaceSwitchShortcuts() {
+  useWorkspaceSwitchShortcuts()
+  return null
+}

--- a/apps/packages/product-client/src/providers/AuthenticatedWorkspaceSwitchShortcuts.tsx
+++ b/apps/packages/product-client/src/providers/AuthenticatedWorkspaceSwitchShortcuts.tsx
@@ -6,8 +6,14 @@ import { useWorkspaceSwitchShortcuts } from "#product/hooks/app/lifecycle/use-wo
  * sidebar target and no committed workspace to step from), so gating the
  * owner behind the same auth check that already governs its behavior is a
  * bundling-only change. It lets the owner be lazy-loaded, which keeps the
- * workspace-selection / agent-catalog / session-creation graph
- * useWorkspaceNavigationWorkflow pulls in off the /login first-load path.
+ * sidebar-shortcut-target projection and the held-key traversal cursor
+ * controller/store off the /login first-load path -- they were only reached
+ * pre-auth through this hook's old home in useAppShortcuts.
+ *
+ * This does NOT gate useWorkspaceNavigationWorkflow's workspace-selection /
+ * agent-catalog / session-creation graph: that hook remains statically,
+ * unconditionally reachable from /login via useAppNavigationCommandActions
+ * and useAppNewWorkspaceCommandActions (see use-app-shortcuts.ts).
  */
 export function AuthenticatedWorkspaceSwitchShortcuts() {
   useWorkspaceSwitchShortcuts()

--- a/apps/packages/product-client/src/providers/ProductLifecycleRoot.test.tsx
+++ b/apps/packages/product-client/src/providers/ProductLifecycleRoot.test.tsx
@@ -83,6 +83,10 @@ vi.mock("#product/providers/AuthenticatedBackgroundLifecycles", () => ({
   ),
 }));
 
+vi.mock("#product/providers/AuthenticatedWorkspaceSwitchShortcuts", () => ({
+  AuthenticatedWorkspaceSwitchShortcuts: () => null,
+}));
+
 // Counted rather than stubbed away: where this hook runs relative to the auth
 // gate is the behaviour under test, not an implementation detail.
 const retentionSweepCount = vi.hoisted(() => ({ value: 0 }));

--- a/apps/packages/product-client/src/providers/ProductLifecycleRoot.test.tsx
+++ b/apps/packages/product-client/src/providers/ProductLifecycleRoot.test.tsx
@@ -83,8 +83,14 @@ vi.mock("#product/providers/AuthenticatedBackgroundLifecycles", () => ({
   ),
 }));
 
-vi.mock("#product/providers/AuthenticatedWorkspaceSwitchShortcuts", () => ({
-  AuthenticatedWorkspaceSwitchShortcuts: () => null,
+// Not mocked as a component (unlike AuthenticatedBackgroundLifecycles above):
+// the real AuthenticatedWorkspaceSwitchShortcuts renders, but its underlying
+// hook is mocked below, matching the stronger AuthenticatedLaunchLifecycles /
+// useHomeDeferredLaunchRunner pattern -- so a regression that drops the
+// `authStatus === "authenticated"` guard around it is actually caught (see
+// "keeps the workspace-switch shortcuts off the signed-out shell..." below).
+vi.mock("#product/hooks/app/lifecycle/use-workspace-switch-shortcuts", () => ({
+  useWorkspaceSwitchShortcuts: vi.fn(),
 }));
 
 // Counted rather than stubbed away: where this hook runs relative to the auth
@@ -107,6 +113,7 @@ vi.mock("#product/providers/DesktopProductLifecycleRoot", () => ({
 import { ProductLifecycleRoot } from "#product/providers/ProductLifecycleRoot";
 import { useAppCommandActionsContext } from "#product/providers/AppCommandActionsProvider";
 import { useHomeDeferredLaunchRunner } from "#product/hooks/home/lifecycle/use-home-deferred-launch-runner";
+import { useWorkspaceSwitchShortcuts } from "#product/hooks/app/lifecycle/use-workspace-switch-shortcuts";
 
 function CommandContextProbe() {
   const actions = useAppCommandActionsContext();
@@ -295,6 +302,39 @@ describe("ProductLifecycleRoot", () => {
     rerender(tree());
 
     await waitFor(() => expect(useHomeDeferredLaunchRunner).toHaveBeenCalled());
+  });
+
+  it("keeps the workspace-switch shortcuts off the signed-out shell and mounts them once authenticated", async () => {
+    // Mirrors "keeps the launch lifecycles off the signed-out shell..." above:
+    // the shortcuts' held-key traversal cursor and sidebar-target projection
+    // only make sense for a signed-in viewer with workspaces, so the owner is
+    // mounted behind the authenticated gate as a lazy chunk, which is what
+    // keeps that code out of the login first-load budget. Asserting the
+    // underlying hook call (rather than mocking the whole component away, as
+    // AuthenticatedBackgroundLifecycles's mock does above) means a regression
+    // that drops the auth gate around <AuthenticatedWorkspaceSwitchShortcuts />
+    // actually fails this test.
+    authStatus.value = "anonymous";
+    const host = makeTestProductHost({
+      auth: { restoreSession: vi.fn().mockResolvedValue(undefined) },
+    });
+    const tree = () => (
+      <ProductHostProvider host={host}>
+        <ProductLifecycleRoot>
+          <div data-testid="app-tree">app</div>
+        </ProductLifecycleRoot>
+      </ProductHostProvider>
+    );
+
+    const { rerender } = render(tree());
+
+    expect(screen.getByTestId("app-tree")).toBeTruthy();
+    expect(useWorkspaceSwitchShortcuts).not.toHaveBeenCalled();
+
+    authStatus.value = "authenticated";
+    rerender(tree());
+
+    await waitFor(() => expect(useWorkspaceSwitchShortcuts).toHaveBeenCalled());
   });
 
   it("keeps a single Desktop lifecycle mount under StrictMode", () => {

--- a/apps/packages/product-client/src/providers/ProductLifecycleRoot.tsx
+++ b/apps/packages/product-client/src/providers/ProductLifecycleRoot.tsx
@@ -87,6 +87,18 @@ const AuthenticatedBackgroundLifecycles = lazy(() =>
   })),
 )
 
+// The workspace-switch shortcuts (Cmd+1..9, Cmd+Opt+Arrow) depend on
+// useWorkspaceNavigationWorkflow's selectWorkspaceFromSurface, which pulls in
+// workspace selection, the agent catalog, and session-creation machinery.
+// Same treatment as the owners above: authenticated-only + lazy, so the login
+// first-load chunk never parses that graph (login runtime JS budget). The
+// shortcuts were already no-ops signed out (no workspace to select).
+const AuthenticatedWorkspaceSwitchShortcuts = lazy(() =>
+  import("#product/providers/AuthenticatedWorkspaceSwitchShortcuts").then((m) => ({
+    default: m.AuthenticatedWorkspaceSwitchShortcuts,
+  })),
+)
+
 const APP_RUNTIME_RENDER_MILESTONES = new Set([1, 2, 3, 5, 10, 25, 50, 100, 250])
 
 let appRuntimeRenderCount = 0
@@ -271,6 +283,11 @@ function ProductLifecycles({ children }: { children: ReactNode }) {
       {authStatus === "authenticated" && (
         <Suspense fallback={null}>
           <AuthenticatedBackgroundLifecycles />
+        </Suspense>
+      )}
+      {authStatus === "authenticated" && (
+        <Suspense fallback={null}>
+          <AuthenticatedWorkspaceSwitchShortcuts />
         </Suspense>
       )}
       {children}

--- a/apps/packages/product-client/src/providers/ProductLifecycleRoot.tsx
+++ b/apps/packages/product-client/src/providers/ProductLifecycleRoot.tsx
@@ -87,12 +87,16 @@ const AuthenticatedBackgroundLifecycles = lazy(() =>
   })),
 )
 
-// The workspace-switch shortcuts (Cmd+1..9, Cmd+Opt+Arrow) depend on
-// useWorkspaceNavigationWorkflow's selectWorkspaceFromSurface, which pulls in
-// workspace selection, the agent catalog, and session-creation machinery.
-// Same treatment as the owners above: authenticated-only + lazy, so the login
-// first-load chunk never parses that graph (login runtime JS budget). The
-// shortcuts were already no-ops signed out (no workspace to select).
+// The workspace-switch shortcuts (Cmd+1..9, Cmd+Opt+Arrow) were the only
+// unconditional (pre-auth) callers of useSidebarShortcutTargets and the
+// held-key traversal cursor controller/store. Same treatment as the owners
+// above: authenticated-only + lazy, so the login first-load chunk never
+// parses the sidebar-shortcut-target projection or the cursor machinery
+// (login runtime JS budget). The shortcuts were already no-ops signed out (no
+// workspace to select). This does NOT gate useWorkspaceNavigationWorkflow's
+// workspace-selection / agent-catalog / session-creation graph, which remains
+// reachable from /login via useAppNavigationCommandActions and
+// useAppNewWorkspaceCommandActions (see use-app-shortcuts.ts).
 const AuthenticatedWorkspaceSwitchShortcuts = lazy(() =>
   import("#product/providers/AuthenticatedWorkspaceSwitchShortcuts").then((m) => ({
     default: m.AuthenticatedWorkspaceSwitchShortcuts,


### PR DESCRIPTION
## Context

Main is currently at a knife edge on the "Login first-load budget (phase-6)" CI gate: `jsBytes` was 500263 B against a hard cap of 502000 B, leaving only ~1.7KB of local headroom, and CI's gzip measurement runs about 0.36% higher than local. Every open frontend PR has been coin-flipping this gate by +/-10 bytes of minifier noise:

- PR #2005 measured 502004 B (+4 over cap)
- PR #1992 measured 502008 B (+8 over cap)
- PR #1993 measured 501999 B (+1 headroom)

This PR frees several KB of headroom mechanically, following the same playbook as PR #1993 (rung 11 of the chat-scroll ladder): find code statically imported by the login-reachable chain that is never needed for first paint of `/login`, and move it behind a lazy chunk.

## What changed and why it is not login-critical

**Correction (post-review):** an earlier version of this description misattributed the savings to gating `useWorkspaceNavigationWorkflow`'s workspace-selection / agent-catalog / session-creation graph off `/login`. That is not what happened, and a fresh reviewer caught it — see below.

`useAppShortcuts`, mounted unconditionally by `ProductLifecycleRoot` (there is no auth gate before it), called `useWorkspaceNavigationWorkflow()` to back three shortcuts (`workspace.by-index`, `workspace.previous-workspace`, `workspace.next-workspace`) and their held-key traversal cursor. `useWorkspaceNavigationWorkflow()` was, and remains, also called unconditionally pre-auth from two other places this PR does not touch — `useAppNavigationCommandActions` and `useAppNewWorkspaceCommandActions`, both reached via `useAppCommandActions()` at `ProductLifecycleRoot.tsx`. Because ES modules load their full body the moment *any* caller imports them, `useWorkspaceNavigationWorkflow` (and everything it pulls in: `useWorkspaceSelection`, the bundled agent-catalog JSON, the session-creation graph) is **still** in the `/login` chunk after this PR, unrelated to this change.

The actual, verified savings mechanism: the three moved shortcuts were the *only* unconditional (pre-auth) callers of `useSidebarShortcutTargets` (which pulls in the sidebar-groups projection) and of the held-key traversal cursor machinery (`workspace-switch-cursor-controller.ts`, `sidebar-switch-cursor-store.ts`). `useSidebarShortcutTargets`'s only other caller, `MainSidebar.tsx`, is already inside the authenticated lazy chunk. Moving those three shortcuts (and the cursor controller they own) behind the same authenticated-only + lazy treatment `ProductLifecycleRoot` already gives `AuthRestartOfferRoot`, `SupportReportQueueRoot`, `AuthenticatedLaunchLifecycles`, and `AuthenticatedBackgroundLifecycles` is what removed the sidebar-target projection and cursor-controller code from the `/login` first-load chunk. The shortcuts were already no-ops signed out (no sidebar targets, no committed workspace to step from), so this changes only when the handlers get registered, never what they do.

Getting `useWorkspaceNavigationWorkflow` itself off `/login` would require the same authenticated-only treatment for `useAppNavigationCommandActions` / `useAppNewWorkspaceCommandActions` — that is a real follow-up candidate for more headroom, but is explicitly out of scope for this mechanical, minimally-reviewable PR.

## Review fixes (round 2, head `b11759689`)

A fresh reviewer found three issues on the first head (`dd6bef225`), all now fixed on this branch:
- **F1** (accuracy): corrected the four code-comment blocks that misattributed the savings mechanism (see above), and this PR description.
- **F2** (test strength): `ProductLifecycleRoot.test.tsx` no longer mocks `AuthenticatedWorkspaceSwitchShortcuts` away as a whole component; it mocks only the underlying `useWorkspaceSwitchShortcuts` hook (matching the stronger `AuthenticatedLaunchLifecycles` pattern) and asserts the hook is not called anonymous / is called once authenticated, so a dropped auth-gate regression is now caught.
- **F3** (latent leak): the traversal cursor's settle/fallback timers were never cleared on unmount. Before this PR the owner never unmounted; after this PR it mounts/unmounts with `authStatus`, so an auth flap mid-traversal could fire a stale commit post-unmount. Fixed by calling the controller's existing `cancel()` from the hook's effect cleanup, with a new test covering unmount mid-settle-window.

## Receipts

- Local measurement (`node scripts/measure-login-runtime-budget.mjs --no-build`), first head (`dd6bef225`): index chunk gzip JS **500263 B -> 495028 B** (a 5235 B / ~5.1KB reduction) against the founder cap of **502000 B**.
- Local re-measurement after the review fixes, current head (`b11759689`): **495020 B** (no regression; the ~8 B delta is the added unmount-cleanup call). Headroom against the cap: ~6980 B.
- CSS unaffected (65702 B, unchanged).
- CI on the first head (`dd6bef225`): "Login first-load budget (phase-6)" passed, CI-measured `JS 496680/502000 B` (headroom 5320 B). CI on the current head is pending re-confirmation.
- No behavior change: existing shortcut tests for the three moved handlers were relocated unmodified in assertions into `use-workspace-switch-shortcuts.test.tsx`; `ProductLifecycleRoot.test.tsx` and the cursor-controller unit tests all pass.

## Status

This PR is staged pending Pablo's ruling on the login-budget-gate phrasing/policy. Keeping as **draft** until then; not to be merged without his review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)