### PR TITLE
fix(product): open home-relative file links

### DIFF
--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.test.tsx
@@ -44,10 +44,12 @@ const viewerMocks = vi.hoisted(() => ({
 const hostMocks = vi.hoisted(() => ({
   desktopAvailable: true,
   writeText: vi.fn(async () => undefined),
+  getHomeDirectory: vi.fn(async () => "/Users/pablo"),
   openTarget: vi.fn(async () => undefined),
   isDirectory: vi.fn(async () => false),
   reveal: vi.fn(async () => undefined),
   files: null as unknown as {
+    getHomeDirectory: ReturnType<typeof vi.fn>;
     isDirectory: ReturnType<typeof vi.fn>;
     openTarget: ReturnType<typeof vi.fn>;
     reveal: ReturnType<typeof vi.fn>;
@@ -55,6 +57,7 @@ const hostMocks = vi.hoisted(() => ({
 }));
 
 hostMocks.files = {
+  getHomeDirectory: hostMocks.getHomeDirectory,
   isDirectory: hostMocks.isDirectory,
   openTarget: hostMocks.openTarget,
   reveal: hostMocks.reveal,
@@ -125,6 +128,7 @@ vi.mock("#product/hooks/workspaces/workflows/files/use-fuzzy-file-resolver", () 
 
 afterEach(() => {
   hostMocks.desktopAvailable = true;
+  hostMocks.getHomeDirectory.mockResolvedValue("/Users/pablo");
   hostMocks.isDirectory.mockResolvedValue(false);
   editorMocks.openInDefaultEditor.mockResolvedValue(true);
   statMocks.kind = "file";
@@ -323,6 +327,35 @@ describe("useFileReferenceActions", () => {
     expect(viewerMocks.openTarget).not.toHaveBeenCalled();
   });
 
+  it("expands a home-relative hidden file before opening it on Desktop", async () => {
+    statMocks.kind = null;
+    let resolveHomeDirectory!: (path: string) => void;
+    hostMocks.getHomeDirectory.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveHomeDirectory = resolve;
+    }));
+    const rawPath = "~/.proliferate-local/dev/profiles/wf2pablo/app/diagnostics-dev.env";
+    const absolutePath = "/Users/pablo/.proliferate-local/dev/profiles/wf2pablo/app/diagnostics-dev.env";
+    const { result } = renderHook(
+      () => useFileReferenceActions({ rawPath }),
+      { wrapper: workspaceWrapper("/repo") },
+    );
+
+    expect(result.current.canOpenPrimary).toBe(true);
+    await act(async () => {
+      const openPromise = result.current.openPrimary();
+      resolveHomeDirectory("/Users/pablo");
+      await expect(openPromise).resolves.toBe("open-external");
+    });
+    await waitFor(() => {
+      expect(result.current.reference.absolutePath).toBe(absolutePath);
+      expect(result.current.pathKind).toBe("file");
+    });
+
+    expect(hostMocks.getHomeDirectory).toHaveBeenCalledTimes(1);
+    expect(hostMocks.isDirectory).toHaveBeenCalledWith(absolutePath);
+    expect(editorMocks.openInDefaultEditor).toHaveBeenCalledWith(absolutePath);
+  });
+
   it("keeps an external file retryable when its Desktop target fails", async () => {
     statMocks.kind = null;
     editorMocks.openInDefaultEditor
@@ -389,6 +422,20 @@ describe("useFileReferenceActions", () => {
     expect(editorMocks.openInDefaultEditor).not.toHaveBeenCalled();
     expect(hostMocks.reveal).not.toHaveBeenCalled();
     expect(viewerMocks.openTarget).not.toHaveBeenCalled();
+  });
+
+  it("keeps a home-relative file unavailable on Web", async () => {
+    hostMocks.desktopAvailable = false;
+    statMocks.kind = null;
+    const { result } = renderHook(
+      () => useFileReferenceActions({ rawPath: "~/.config/proliferate/settings.json" }),
+      { wrapper: workspaceWrapper("/repo") },
+    );
+
+    expect(result.current.canOpenPrimary).toBe(false);
+    expect(result.current.primaryUnavailableReason).toContain("Desktop app");
+    await expect(result.current.openPrimary()).resolves.toBe("unavailable");
+    expect(hostMocks.getHomeDirectory).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.ts
@@ -8,6 +8,7 @@ import {
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { useOpenInDefaultEditor } from "#product/hooks/editor/workflows/use-open-in-default-editor";
 import { useFuzzyFileResolver } from "#product/hooks/workspaces/workflows/files/use-fuzzy-file-resolver";
+import { useHomeRelativeFileReference } from "#product/hooks/workspaces/workflows/files/use-home-relative-file-reference";
 import { useWorkspaceShellActivation } from "#product/hooks/workspaces/workflows/tabs/use-workspace-shell-activation";
 import { useWorkspacePath } from "#product/providers/WorkspacePathProvider";
 import {
@@ -32,6 +33,12 @@ export function useFileReferenceActions({
 }: UseFileReferenceActionsInput) {
   const host = useProductHost();
   const files = host.desktop?.files ?? null;
+  const {
+    homeDirectory,
+    needsHomeDirectory,
+    pending: homeDirectoryPending,
+    resolveHomeDirectory,
+  } = useHomeRelativeFileReference(files, rawPath);
   const openTarget = useWorkspaceViewerTabsStore((state) => state.openTarget);
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
   const selectedLogicalWorkspaceId = useSessionSelectionStore(
@@ -55,8 +62,9 @@ export function useFileReferenceActions({
     rawPath,
     workspaceRoot,
     resolveAbsolute,
+    homeDirectory,
     workspacePathOverride: workspacePath,
-  }), [rawPath, resolveAbsolute, workspacePath, workspaceRoot]);
+  }), [homeDirectory, rawPath, resolveAbsolute, workspacePath, workspaceRoot]);
 
   const statQuery = useStatWorkspaceFileQuery({
     workspaceId: materializedWorkspaceId,
@@ -121,17 +129,20 @@ export function useFileReferenceActions({
   });
   const canResolvePathKind = Boolean(
     (reference.workspacePath && materializedWorkspaceId)
-    || (reference.absolutePath && files),
+    || (reference.absolutePath && files)
+    || (needsHomeDirectory && files),
   );
   const canOpenPrimary = resolvedPrimaryAction !== "unavailable"
     || (pathKind === null && canResolvePathKind);
-  const pathKindPending = externalPathKindPending || statQuery.isFetching;
+  const pathKindPending = homeDirectoryPending || externalPathKindPending || statQuery.isFetching;
   const primaryUnavailableReason = pathKindPending
     ? "Checking whether this path is a file or folder…"
     : primaryOpenFailed
       ? "Could not open this path. Click to retry."
       : pathKind === "directory" && !canReveal
         ? "Reveal in Finder is available in the Desktop app."
+        : needsHomeDirectory && !files
+          ? "Home-relative files are available in the Desktop app."
         : !reference.workspacePath && reference.absolutePath && !files
           ? "External files are available in the Desktop app."
           : pathKind === "file" && !canOpenInSidebar && !canOpenExternal
@@ -199,26 +210,46 @@ export function useFileReferenceActions({
     return client.files.stat(resolved.connection.anyharnessWorkspaceId, path);
   }, [anyHarnessWorkspace, materializedWorkspaceId]);
 
-  const openDefault = useCallback(async () => {
-    if (!reference.absolutePath) {
+  const openDefault = useCallback(async (
+    absolutePath: string | null = reference.absolutePath,
+  ) => {
+    if (!absolutePath) {
       return false;
     }
-    return openInDefaultEditor(reference.absolutePath);
+    return openInDefaultEditor(absolutePath);
   }, [openInDefaultEditor, reference.absolutePath]);
 
-  const reveal = useCallback(async () => {
-    if (!reference.absolutePath) {
+  const reveal = useCallback(async (
+    absolutePath: string | null = reference.absolutePath,
+  ) => {
+    if (!absolutePath) {
       return;
     }
     if (!files) {
       throw new Error("Local file access is not available.");
     }
-    await files.reveal(reference.absolutePath);
+    await files.reveal(absolutePath);
   }, [files, reference.absolutePath]);
 
   const openPrimary = useCallback(async () => {
     let resolvedPathKind = pathKind;
     let resolvedWorkspacePath = reference.workspacePath;
+    let resolvedAbsolutePath = reference.absolutePath;
+    if (!resolvedAbsolutePath && needsHomeDirectory && files) {
+      const resolvedHomeDirectory = await resolveHomeDirectory();
+      if (resolvedHomeDirectory) {
+        resolvedAbsolutePath = resolveFileReference({
+          rawPath,
+          workspaceRoot,
+          resolveAbsolute,
+          homeDirectory: resolvedHomeDirectory,
+          workspacePathOverride: workspacePath,
+        }).absolutePath;
+      } else {
+        setPathResolutionFailed(true);
+        return "unavailable";
+      }
+    }
     if (!resolvedPathKind && reference.workspacePath && materializedWorkspaceId) {
       const result = await statQuery.refetch();
       resolvedPathKind = resolveWorkspaceStatPathKind(result.data);
@@ -243,9 +274,9 @@ export function useFileReferenceActions({
         }
       }
     }
-    if (!resolvedPathKind && reference.absolutePath && files) {
+    if (!resolvedPathKind && resolvedAbsolutePath && files) {
       try {
-        resolvedPathKind = await files.isDirectory(reference.absolutePath)
+        resolvedPathKind = await files.isDirectory(resolvedAbsolutePath)
           ? "directory"
           : "file";
       } catch {
@@ -257,12 +288,12 @@ export function useFileReferenceActions({
     const action = resolveFileReferencePrimaryAction({
       pathKind: resolvedPathKind,
       canOpenViewer: Boolean(resolvedWorkspacePath),
-      canOpenExternal: Boolean(files && reference.absolutePath),
-      canReveal: Boolean(files && reference.absolutePath),
+      canOpenExternal: Boolean(files && resolvedAbsolutePath),
+      canReveal: Boolean(files && resolvedAbsolutePath),
     });
     if (action === "reveal") {
       try {
-        await reveal();
+        await reveal(resolvedAbsolutePath);
       } catch {
         setPrimaryOpenFailed(true);
         return "unavailable";
@@ -289,7 +320,7 @@ export function useFileReferenceActions({
       return action;
     }
     if (action === "open-external") {
-      const opened = await openDefault();
+      const opened = await openDefault(resolvedAbsolutePath);
       if (!opened) {
         setPrimaryOpenFailed(true);
         return "unavailable";
@@ -304,14 +335,20 @@ export function useFileReferenceActions({
     activateViewerTarget,
     fuzzyResolveFilePath,
     materializedWorkspaceId,
+    needsHomeDirectory,
     openDefault,
     openTarget,
     pathKind,
+    rawPath,
     reference.absolutePath,
     reference.workspacePath,
+    resolveAbsolute,
+    resolveHomeDirectory,
     reveal,
     statWorkspacePath,
     statQuery,
+    workspacePath,
+    workspaceRoot,
     workspaceUiKey,
   ]);
 

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-home-relative-file-reference.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-home-relative-file-reference.ts
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useState } from "react";
+import type { DesktopFilesBridge } from "@proliferate/product-client/host/desktop-bridge";
+import { isHomeRelativeFileReference } from "#product/lib/domain/files/path-references";
+
+const cachedHomeDirectoryPromises = new WeakMap<DesktopFilesBridge, Promise<string>>();
+
+function loadHomeDirectory(files: DesktopFilesBridge): Promise<string> {
+  let promise = cachedHomeDirectoryPromises.get(files);
+  if (!promise) {
+    promise = files.getHomeDirectory().then((path) => {
+      const trimmed = path.trim();
+      if (!trimmed) {
+        throw new Error("Desktop home directory is unavailable.");
+      }
+      return trimmed;
+    });
+    cachedHomeDirectoryPromises.set(files, promise);
+    void promise.catch(() => {
+      if (cachedHomeDirectoryPromises.get(files) === promise) {
+        cachedHomeDirectoryPromises.delete(files);
+      }
+    });
+  }
+  return promise;
+}
+
+export function useHomeRelativeFileReference(
+  files: DesktopFilesBridge | null,
+  rawPath: string,
+) {
+  const needsHomeDirectory = isHomeRelativeFileReference(rawPath);
+  const [homeDirectory, setHomeDirectory] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!needsHomeDirectory || !files) {
+      setHomeDirectory(null);
+      setPending(false);
+      return;
+    }
+
+    setHomeDirectory(null);
+    setPending(true);
+    void loadHomeDirectory(files).then(
+      (path) => {
+        if (!cancelled) setHomeDirectory(path);
+      },
+      () => {
+        if (!cancelled) setHomeDirectory(null);
+      },
+    ).finally(() => {
+      if (!cancelled) setPending(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [files, needsHomeDirectory]);
+
+  const resolveHomeDirectory = useCallback(async () => {
+    if (!needsHomeDirectory || !files) {
+      return null;
+    }
+    if (homeDirectory) {
+      return homeDirectory;
+    }
+    try {
+      const path = await loadHomeDirectory(files);
+      setHomeDirectory(path);
+      return path;
+    } catch {
+      return null;
+    }
+  }, [files, homeDirectory, needsHomeDirectory]);
+
+  return {
+    homeDirectory,
+    needsHomeDirectory,
+    pending,
+    resolveHomeDirectory,
+  };
+}

--- a/apps/packages/product-client/src/lib/domain/files/path-references.test.ts
+++ b/apps/packages/product-client/src/lib/domain/files/path-references.test.ts
@@ -95,6 +95,20 @@ describe("resolveFileReference", () => {
     });
   });
 
+  it("expands a home-relative hidden path without treating it as a workspace path", () => {
+    expect(resolveFileReference({
+      rawPath: "~/.proliferate-local/dev/app/diagnostics-dev.env:12",
+      workspaceRoot: "/repo",
+      resolveAbsolute: () => null,
+      homeDirectory: "/Users/pablo/",
+    })).toMatchObject({
+      path: "~/.proliferate-local/dev/app/diagnostics-dev.env",
+      line: 12,
+      absolutePath: "/Users/pablo/.proliferate-local/dev/app/diagnostics-dev.env",
+      workspacePath: null,
+    });
+  });
+
   it("normalizes absolute traversal before deciding workspace membership", () => {
     expect(resolveFileReference({
       rawPath: "/repo/sub/../../tmp/file.txt",

--- a/apps/packages/product-client/src/lib/domain/files/path-references.ts
+++ b/apps/packages/product-client/src/lib/domain/files/path-references.ts
@@ -59,6 +59,7 @@ export function resolveFileReference(args: {
   rawPath: string;
   workspaceRoot: string | null;
   resolveAbsolute: (rawPath: string) => string | null;
+  homeDirectory?: string | null;
   workspacePathOverride?: string | null;
 }): ResolvedFileReference {
   const trimmed = args.rawPath.trim();
@@ -74,9 +75,35 @@ export function resolveFileReference(args: {
     path,
     line,
     column,
-    absolutePath: args.resolveAbsolute(path),
+    absolutePath: resolveAbsoluteFileReferencePath(
+      path,
+      args.homeDirectory,
+      args.resolveAbsolute,
+    ),
     workspacePath,
   };
+}
+
+export function isHomeRelativeFileReference(value: string): boolean {
+  const { path } = splitPathLineSuffix(value.trim());
+  return path === "~" || path.startsWith("~/");
+}
+
+function resolveAbsoluteFileReferencePath(
+  path: string,
+  homeDirectory: string | null | undefined,
+  resolveAbsolute: (rawPath: string) => string | null,
+): string | null {
+  if (!isHomeRelativeFileReference(path)) {
+    return resolveAbsolute(path);
+  }
+  const trimmedHome = homeDirectory?.trim();
+  if (!trimmedHome) {
+    return null;
+  }
+  const homeRoot = trimmedHome === "/" ? "" : trimmedHome.replace(/\/+$/, "");
+  const suffix = path === "~" ? "" : path.slice(1);
+  return `${homeRoot}${suffix}` || "/";
 }
 
 /**

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -140,6 +140,11 @@ Rules:
 
 - Detection happens at render time from raw markdown; do not store parsed file
   references in transcript items.
+- A leading `~/` is an external Desktop file reference, not a workspace-relative
+  path. Resolve it through the Desktop host's home-directory bridge before
+  classifying or opening it; Web keeps the reference unavailable. Hidden path
+  segments such as `~/.config` follow the same rule as any other home-relative
+  path.
 - Once the assistant reveal frontier settles, the final unique Markdown file
   reference also renders as a compact end-resource card after prose. Its
   default subtitle identifies `Document · MD`; hover/focus changes that


### PR DESCRIPTION
## Summary

- Resolve home-relative transcript file references through the existing Desktop home-directory bridge, while keeping the primary action available during the lookup.
- Keep those paths external to the workspace viewer and unavailable on Web, with regression coverage and the transcript contract updated.

## Regression

- A Desktop transcript link to `~/.claude/settings.local.json` remains actionable while `files.getHomeDirectory()` is pending; an immediate click expands it to the absolute home path, classifies it, and opens it through the existing external-file action.
- The same `~/...` reference remains unavailable on Web and is never treated as workspace-relative.

## Testing

- Tier 1: `pnpm --filter @proliferate/product-client test` (1,001 files, 7,218 tests passed in CI).
- Post-rebase regression: `pnpm --filter @proliferate/product-client exec vitest run src/lib/domain/files/path-references.test.ts src/hooks/workspaces/workflows/files/use-file-reference-actions.test.tsx` (2 files, 40 tests passed).
- Static: `pnpm --filter @proliferate/product-client typecheck`.
- Login runtime budget: exact CI rerun command passed at 501,997/502,000 B JS and 65,840/66,250 B CSS.

## Observability

- None. Resolved local paths remain client-local and are not logged or emitted as telemetry.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] If this PR has support relationships, I linked them through the tracker API. No tracker, report, user, or support IDs or private source data appear in this PR.

## Verification

- `python3 scripts/check_docs.py`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_design_attribution.py`
- `python3 scripts/check_appearance_scaling.py`
- `git diff origin/main...HEAD --check`
