### PR TITLE
fix(product-client): reconcile terminal state after hydration failure (PRO-311)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/surface/SessionTranscriptPane.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/surface/SessionTranscriptPane.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import type { ReactNode } from "react";
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { replaySessionHistory } from "#product/lib/domain/sessions/stream/stream-state";
 import { SessionTranscriptPane } from "#product/components/workspace/chat/surface/SessionTranscriptPane";
@@ -26,6 +26,10 @@ import { useSessionDirectoryStore } from "#product/stores/sessions/session-direc
 import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+
+const hydrationMocks = vi.hoisted(() => ({
+  rehydrateSessionSlotFromHistory: vi.fn(),
+}));
 
 // Heavy leaf UI is not under test — the deferred content_stable hand-off is.
 // The mock echoes the two inset props it received as data attributes so
@@ -76,7 +80,7 @@ vi.mock("#product/hooks/ui/debug/use-debug-render-count", () => ({
 // completion explicitly via the flag, so a no-op rehydrate keeps host wiring out.
 vi.mock("#product/hooks/sessions/lifecycle/use-session-history-hydration", () => ({
   useSessionHistoryHydration: () => ({
-    rehydrateSessionSlotFromHistory: vi.fn().mockResolvedValue(true),
+    rehydrateSessionSlotFromHistory: hydrationMocks.rehydrateSessionSlotFromHistory,
   }),
 }));
 vi.mock("#product/hooks/plans/ui/use-plan-handoff-dialog-state", () => ({
@@ -117,6 +121,7 @@ beforeEach(() => {
   emitted = [];
   setRendererDiagnosticsSink({ emit: (input) => emitted.push(input) });
   nowValue = 0;
+  hydrationMocks.rehydrateSessionSlotFromHistory.mockReset().mockResolvedValue(false);
   vi.spyOn(performance, "now").mockImplementation(() => nowValue);
   resetRendererFlowsForTest();
   useSessionDirectoryStore.getState().clearEntries();
@@ -144,7 +149,7 @@ afterEach(() => {
  * path, DEFERS content_stable to this session; selectSession synchronously
  * seeds the empty-but-truthy scaffold via createEmptySessionRecord.
  */
-function beginDeferredColdOpen(): void {
+function beginDeferredColdOpen(options?: { includeTranscriptEntry?: boolean }): void {
   beginRendererFlow({
     kind: "workspace_open",
     correlationKey: WORKSPACE_ID,
@@ -157,9 +162,12 @@ function beginDeferredColdOpen(): void {
   deferWorkspaceOpenContentStable({ sessionId: SESSION_ID, correlationKey: WORKSPACE_ID });
   // Real scaffold: createEmptySessionRecord carries an empty-but-truthy
   // TranscriptState and transcriptHydrated=false.
-  putSessionRecord(
-    createEmptySessionRecord(SESSION_ID, "codex", { workspaceId: WORKSPACE_ID }),
-  );
+  const record = createEmptySessionRecord(SESSION_ID, "codex", { workspaceId: WORKSPACE_ID });
+  if (options?.includeTranscriptEntry === false) {
+    useSessionDirectoryStore.getState().putEntry(record);
+  } else {
+    putSessionRecord(record);
+  }
   useSessionSelectionStore.getState().activateWorkspace({
     logicalWorkspaceId: WORKSPACE_ID,
     workspaceId: WORKSPACE_ID,
@@ -176,12 +184,42 @@ function renderPane() {
 }
 
 describe("SessionTranscriptPane deferred workspace_open content_stable", () => {
+  it("keeps a failed self-hydration uncommitted and retryable", async () => {
+    beginDeferredColdOpen({ includeTranscriptEntry: false });
+    renderPane();
+
+    await waitFor(() => {
+      expect(hydrationMocks.rehydrateSessionSlotFromHistory).toHaveBeenCalledOnce();
+    });
+
+    expect(
+      useSessionDirectoryStore.getState().entriesById[SESSION_ID]?.transcriptHydrated,
+    ).toBe(false);
+    expect(contentStable()).toBeUndefined();
+  });
+
+  it("commits successful self-hydration", async () => {
+    hydrationMocks.rehydrateSessionSlotFromHistory.mockResolvedValueOnce(true);
+    beginDeferredColdOpen({ includeTranscriptEntry: false });
+    renderPane();
+
+    await waitFor(() => {
+      expect(
+        useSessionDirectoryStore.getState().entriesById[SESSION_ID]?.transcriptHydrated,
+      ).toBe(true);
+    });
+
+    expect(contentStable()).toBeDefined();
+  });
+
   it("does NOT finish on the empty scaffold, then finishes once hydration lands", () => {
     beginDeferredColdOpen();
     renderPane();
 
     // Scaffold present (empty-but-truthy transcript) but transcriptHydrated is
-    // still false: content_stable must not fire against the scaffold.
+    // still false: the bootstrap kickoff owns hydration, and content_stable
+    // must not fire against the scaffold.
+    expect(hydrationMocks.rehydrateSessionSlotFromHistory).not.toHaveBeenCalled();
     expect(contentStable()).toBeUndefined();
 
     // Hydration completes 1.5s later — exactly the case that used to be measured.

--- a/apps/packages/product-client/src/components/workspace/chat/surface/SessionTranscriptPane.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/surface/SessionTranscriptPane.tsx
@@ -166,7 +166,10 @@ export function SessionTranscriptPane({
           && state.activeSessionId === activeSessionId
           && state.selectedWorkspaceId === workspaceIdAtStart;
       },
-    }).finally(() => {
+    }).then((hydrated) => {
+      if (!hydrated) {
+        return;
+      }
       const state = useSessionSelectionStore.getState();
       if (
         state.workspaceSelectionNonce === selectionNonce

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MessageList.tsx
@@ -277,6 +277,7 @@ export function MessageList({
       outboxEntry={input.outboxEntry}
       optimisticTrailingStatus={input.optimisticTrailingStatus}
       outboxActions={input.outboxActions}
+      sessionViewState={input.sessionViewState}
       workspaceReceipt={input.row.hostsWorkspaceReceipt ? <WorkspaceCreationReceipt /> : null}
     />
   ), []);

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.test.tsx
@@ -26,11 +26,18 @@ const NOW = "2026-05-20T17:00:00.000Z";
 const TRANSCRIPT = createTranscriptState("session-1");
 
 function TranscriptPendingPromptRow(
-  props: Omit<ComponentProps<typeof TranscriptPendingPromptRowImpl>, "transcript" | "workspaceId">,
+  props: Omit<
+    ComponentProps<typeof TranscriptPendingPromptRowImpl>,
+    "sessionViewState" | "transcript" | "workspaceId"
+  > & {
+    sessionViewState?: ComponentProps<typeof TranscriptPendingPromptRowImpl>["sessionViewState"];
+  },
 ) {
+  const { sessionViewState = "working", ...rest } = props;
   return (
     <TranscriptPendingPromptRowImpl
-      {...props}
+      {...rest}
+      sessionViewState={sessionViewState}
       transcript={TRANSCRIPT}
       workspaceId="workspace-1"
     />
@@ -184,6 +191,35 @@ describe("TranscriptPendingPromptRow", () => {
     expect(container.querySelector("[class~='gap-transcript-turn']")).not.toBeNull();
     expect(container.innerHTML).not.toContain("gap-3.5");
     expect(container.innerHTML).not.toContain("thinking-text");
+  });
+
+  it("does not show Thinking after an accepted prompt reconciles idle", () => {
+    const acceptedAt = new Date().toISOString();
+    const entry = {
+      ...acceptedRunningOutboxEntry(),
+      acceptedAt,
+      dispatchedAt: acceptedAt,
+      updatedAt: acceptedAt,
+    };
+
+    const { container } = render(
+      <TranscriptPendingPromptRow
+        activeSessionId="session-1"
+        rowIndex={0}
+        prompt={createOptimisticPendingPrompt("Finished remotely", "prompt-1", acceptedAt)}
+        outboxEntry={entry}
+        optimisticTrailingStatus={null}
+        outboxActions={{
+          retryPrompt: vi.fn(),
+          dismissPrompt: vi.fn(),
+        }}
+        sessionViewState="idle"
+      />,
+    );
+
+    expect(screen.getByText("Waiting for transcript…")).toBeTruthy();
+    expect(screen.queryByText("Thinking")).toBeNull();
+    expect(container.querySelector("[data-working-status-frame]")).toBeNull();
   });
 
   it("keeps the pending frontier above the fixed assistant footer", () => {

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptPendingPromptRow.tsx
@@ -25,6 +25,7 @@ import {
 import { isReceiptPendingEntry } from "#product/lib/domain/workspaces/creation/creation-receipt";
 import { useAttendedPendingWorkspaceEntry } from "#product/hooks/workspaces/derived/use-pending-workspace-entries";
 import type { PromptOutboxEntry } from "#product/domain/sessions/intents/session-intent-model";
+import type { SessionViewState } from "#product/domain/sessions/activity";
 
 const OUTBOX_ACCEPTED_RUNNING_ECHO_GRACE_MS = 15_000;
 
@@ -42,6 +43,7 @@ export function TranscriptPendingPromptRow({
   outboxEntry,
   optimisticTrailingStatus,
   outboxActions,
+  sessionViewState,
   workspaceReceipt = null,
 }: {
   activeSessionId: string;
@@ -52,6 +54,7 @@ export function TranscriptPendingPromptRow({
   outboxEntry: PromptOutboxEntry | null;
   optimisticTrailingStatus: ReactNode;
   outboxActions: OutboxActionHandlers;
+  sessionViewState: SessionViewState;
   /**
    * The workspace-creation receipt, when this row hosts it (no turn exists
    * yet to host it inline — see `hostsWorkspaceReceipt` on the row model).
@@ -82,7 +85,7 @@ export function TranscriptPendingPromptRow({
   }
 
   const workingStatus = outboxEntry
-    ? <OutboxPromptTrailingStatus entry={outboxEntry} />
+    ? <OutboxPromptTrailingStatus entry={outboxEntry} sessionViewState={sessionViewState} />
     : optimisticTrailingStatus;
   const trailingStatus = workspaceReceipt
     ? (
@@ -158,11 +161,17 @@ function PendingPromptBody({
   );
 }
 
-function OutboxPromptTrailingStatus({ entry }: { entry: PromptOutboxEntry | null }) {
+function OutboxPromptTrailingStatus({
+  entry,
+  sessionViewState,
+}: {
+  entry: PromptOutboxEntry | null;
+  sessionViewState: SessionViewState;
+}) {
   const [nowMs, setNowMs] = useState(() => Date.now());
 
   useEffect(() => {
-    if (entry?.deliveryState !== "accepted_running") {
+    if (entry?.deliveryState !== "accepted_running" || sessionViewState !== "working") {
       return;
     }
     const acceptedAtMs = resolveOutboxAcceptedRunningReferenceMs(entry);
@@ -181,13 +190,15 @@ function OutboxPromptTrailingStatus({ entry }: { entry: PromptOutboxEntry | null
     entry?.createdAt,
     entry?.deliveryState,
     entry?.dispatchedAt,
+    sessionViewState,
   ]);
 
-  return <>{resolveOutboxPromptTrailingStatus(entry, nowMs)}</>;
+  return <>{resolveOutboxPromptTrailingStatus(entry, sessionViewState, nowMs)}</>;
 }
 
 function resolveOutboxPromptTrailingStatus(
   entry: PromptOutboxEntry | null,
+  sessionViewState: SessionViewState,
   nowMs = Date.now(),
 ): ReactNode {
   if (!entry) {
@@ -208,10 +219,16 @@ function resolveOutboxPromptTrailingStatus(
     case "waiting_for_session":
       return resolvePendingPromptTrailingStatus(entry.createdAt, "working", true);
     case "accepted_running":
+      if (sessionViewState === "needs_input") {
+        return resolvePendingPromptTrailingStatus(entry.createdAt, sessionViewState, false);
+      }
+      if (sessionViewState !== "working") {
+        return <OutboxPromptPlainStatus label="Waiting for transcript…" />;
+      }
       if (hasAcceptedRunningOutboxEntryExceededEchoGrace(entry, nowMs)) {
         return <OutboxPromptPlainStatus label="Waiting for transcript…" />;
       }
-      return resolvePendingPromptTrailingStatus(entry.createdAt, "working", true);
+      return resolvePendingPromptTrailingStatus(entry.createdAt, sessionViewState, false);
     default:
       return null;
   }

--- a/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-view-types.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/chat-transcript-view-types.ts
@@ -26,6 +26,7 @@ export interface ChatTranscriptPendingPromptRenderInput {
   outboxEntry: PromptOutboxEntry | null;
   optimisticTrailingStatus: ReactNode;
   outboxActions: ChatTranscriptOutboxActions;
+  sessionViewState: SessionViewState;
 }
 
 export interface ChatTranscriptTurnRowRenderInput {

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-row-renderer.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-row-renderer.test.tsx
@@ -6,6 +6,7 @@ import { createTranscriptState, type TranscriptState } from "@anyharness/sdk";
 import type { ReactNode } from "react";
 import type { TranscriptVirtualRow } from "#product/domain/chats/transcript/transcript-virtual-rows";
 import type { ChatTranscriptTurnRowRenderInput } from "./chat-transcript-view-types";
+import type { SessionViewState } from "#product/domain/sessions/activity";
 import { MemoizedVirtualTranscriptRow } from "#product/components/workspace/chat/transcript/VirtualTranscriptRow";
 import { useChatTranscriptRowRenderer } from "./use-chat-transcript-row-renderer";
 
@@ -127,7 +128,53 @@ describe("useChatTranscriptRowRenderer", () => {
       row,
       rowIndex: 2,
       prompt,
+      sessionViewState: "working",
     }));
+  });
+
+  it("repaints a pending prompt when authoritative session state changes", () => {
+    const transcript = createTranscriptState("session-1");
+    const prompt = {
+      seq: -1,
+      promptId: "prompt-1",
+      text: "Run this",
+      contentParts: [],
+      queuedAt: "2026-08-17T21:59:00Z",
+      promptProvenance: null,
+    };
+    const row = {
+      kind: "pending_prompt" as const,
+      key: "pending-prompt:session-1",
+    };
+    const renderPendingPromptRow = vi.fn(() => null);
+    let sessionViewState: SessionViewState = "working";
+    const { result, rerender } = renderHook(() => useChatTranscriptRowRenderer({
+      activeSessionId: "session-1",
+      latestLiveExplorationBlock: null,
+      latestLiveStatus: null,
+      latestCompletedTurnId: null,
+      latestTurnId: null,
+      optimisticPromptTrailingStatus: null,
+      outboxActions: OUTBOX_ACTIONS,
+      outboxStartedAtByPromptId: OUTBOX_STARTED_AT_BY_PROMPT_ID,
+      renderPendingPromptRow,
+      renderTurnRow: () => null,
+      selectedWorkspaceId: "workspace-1",
+      sessionViewState,
+      transcript,
+      visibleOutboxEntries: [],
+      visibleOptimisticPrompt: prompt,
+    }));
+    const workingRevision = result.current.getRowRenderRevision(row);
+
+    sessionViewState = "idle";
+    rerender();
+
+    expect(result.current.getRowRenderRevision(row)).not.toBe(workingRevision);
+    result.current.renderRow(row, 0);
+    expect(renderPendingPromptRow).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sessionViewState: "idle" }),
+    );
   });
 
   it("keeps historical revisions stable across stream batches and targets live status", () => {

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-row-renderer.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-transcript-row-renderer.ts
@@ -75,6 +75,7 @@ export function useChatTranscriptRowRenderer({
         outboxEntry: target.outboxEntry,
         optimisticTrailingStatus: optimisticPromptTrailingStatus,
         outboxActions,
+        sessionViewState,
       });
     }
 
@@ -147,6 +148,7 @@ export function useChatTranscriptRowRenderer({
     outboxActions,
     renderPendingPromptRow,
     selectedWorkspaceId,
+    sessionViewState,
     transcript.linkCompletionsByCompletionId,
     visibleOptimisticPrompt,
     visibleOutboxEntries,

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-connection-prepare.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-connection-prepare.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { resolveSessionViewState } from "#product/domain/sessions/activity";
+import type { SessionStreamConnectionState } from "#product/lib/domain/sessions/directory/directory-entry";
+import { prepareSessionStreamConnection } from "#product/hooks/sessions/lifecycle/session-stream-connection-prepare";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import {
+  createEmptySessionRecord,
+  getSessionRecord,
+  putSessionRecord,
+} from "#product/stores/sessions/session-records";
+import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
+
+const CLIENT_SESSION_ID = "client-session-1";
+const RUNTIME_SESSION_ID = "runtime-session-1";
+
+describe("prepareSessionStreamConnection", () => {
+  beforeEach(() => {
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+  });
+
+  afterEach(() => {
+    useSessionDirectoryStore.getState().clearEntries();
+    useSessionTranscriptStore.getState().clearEntries();
+  });
+
+  it("reconciles terminal runtime state when initial history hydration fails", async () => {
+    putStaleWorkingShell("disconnected");
+    const rehydrateSessionSlotFromHistory = vi.fn().mockResolvedValue(false);
+    const refreshSessionSlotMeta = vi.fn(async () => {
+      reconcileShellAsIdle();
+    });
+
+    const shouldOpenStream = await prepareSessionStreamConnection(
+      CLIENT_SESSION_ID,
+      {
+        allowColdIdleNoStream: true,
+        hydrateBeforeStream: true,
+        resumeIfActive: true,
+        skipInitialRefresh: true,
+      },
+      {
+        refreshSessionSlotMeta,
+        rehydrateSessionSlotFromHistory,
+      },
+    );
+
+    expect(rehydrateSessionSlotFromHistory).toHaveBeenCalledOnce();
+    expect(refreshSessionSlotMeta).toHaveBeenCalledOnce();
+    expect(shouldOpenStream).toBe(false);
+    expect(getSessionRecord(CLIENT_SESSION_ID)?.transcriptHydrated).toBe(false);
+    expect(resolveSessionViewState(getSessionRecord(CLIENT_SESSION_ID))).toBe("idle");
+  });
+
+  it.each(["connecting", "open"] as const)(
+    "refreshes metadata after failed hydration with an existing %s stream",
+    async (streamConnectionState) => {
+      putStaleWorkingShell(streamConnectionState);
+      const rehydrateSessionSlotFromHistory = vi.fn().mockResolvedValue(false);
+      const refreshSessionSlotMeta = vi.fn(async () => {
+        reconcileShellAsIdle();
+      });
+
+      const shouldOpenStream = await prepareSessionStreamConnection(
+        CLIENT_SESSION_ID,
+        {
+          hydrateBeforeStream: true,
+          skipInitialRefresh: true,
+        },
+        {
+          refreshSessionSlotMeta,
+          rehydrateSessionSlotFromHistory,
+        },
+      );
+
+      expect(refreshSessionSlotMeta).toHaveBeenCalledOnce();
+      expect(shouldOpenStream).toBe(false);
+      expect(getSessionRecord(CLIENT_SESSION_ID)?.transcriptHydrated).toBe(false);
+    },
+  );
+
+  it("preserves the connected fast path after successful hydration", async () => {
+    putStaleWorkingShell("open");
+    const rehydrateSessionSlotFromHistory = vi.fn().mockResolvedValue(true);
+    const refreshSessionSlotMeta = vi.fn();
+
+    const shouldOpenStream = await prepareSessionStreamConnection(
+      CLIENT_SESSION_ID,
+      {
+        hydrateBeforeStream: true,
+        skipInitialRefresh: true,
+      },
+      {
+        refreshSessionSlotMeta,
+        rehydrateSessionSlotFromHistory,
+      },
+    );
+
+    expect(refreshSessionSlotMeta).not.toHaveBeenCalled();
+    expect(shouldOpenStream).toBe(false);
+    expect(getSessionRecord(CLIENT_SESSION_ID)?.transcriptHydrated).toBe(true);
+  });
+});
+
+function putStaleWorkingShell(streamConnectionState: SessionStreamConnectionState): void {
+  const record = createEmptySessionRecord(CLIENT_SESSION_ID, "codex", {
+    workspaceId: "workspace-1",
+    materializedSessionId: RUNTIME_SESSION_ID,
+    executionSummary: {
+      phase: "running",
+      hasLiveHandle: true,
+      pendingInteractions: [],
+      updatedAt: "2026-08-17T21:48:00Z",
+    },
+  });
+  putSessionRecord({
+    ...record,
+    status: "running",
+    streamConnectionState,
+    transcriptHydrated: false,
+    transcript: {
+      ...record.transcript,
+      isStreaming: true,
+    },
+  });
+}
+
+function reconcileShellAsIdle(): void {
+  useSessionDirectoryStore.getState().patchEntry(CLIENT_SESSION_ID, {
+    status: "idle",
+    executionSummary: {
+      phase: "idle",
+      hasLiveHandle: false,
+      pendingInteractions: [],
+      updatedAt: "2026-08-17T21:49:00Z",
+    },
+  });
+}

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-connection-prepare.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-connection-prepare.ts
@@ -29,9 +29,10 @@ export async function prepareSessionStreamConnection(
     return false;
   }
 
+  let initialHistoryHydrationFailed = false;
   if (!initialSlot.transcriptHydrated && options?.hydrateBeforeStream !== false) {
     const hydrateStartedAt = performance.now();
-    await deps.rehydrateSessionSlotFromHistory(sessionId, {
+    const hydrated = await deps.rehydrateSessionSlotFromHistory(sessionId, {
       requestHeaders: options?.requestHeaders,
       measurementOperationId: options?.measurementOperationId,
       isCurrent: options?.isCurrent,
@@ -39,9 +40,12 @@ export async function prepareSessionStreamConnection(
     if (options?.isCurrent && !options.isCurrent()) {
       return false;
     }
-    useSessionDirectoryStore.getState().patchEntry(sessionId, {
-      transcriptHydrated: true,
-    });
+    initialHistoryHydrationFailed = !hydrated;
+    if (hydrated) {
+      useSessionDirectoryStore.getState().patchEntry(sessionId, {
+        transcriptHydrated: true,
+      });
+    }
     recordMeasurementWorkflowStep({
       operationId: options?.measurementOperationId,
       step: "session.stream.initial_history_hydrate",
@@ -61,17 +65,19 @@ export async function prepareSessionStreamConnection(
     return false;
   }
 
+  const streamAlreadyConnected = slot.streamConnectionState === "connecting"
+    || slot.streamConnectionState === "open";
   if (
-    !options?.forceReconnect
-    && (
-      slot.streamConnectionState === "connecting"
-      || slot.streamConnectionState === "open"
-    )
+    !initialHistoryHydrationFailed
+    && !options?.forceReconnect
+    && streamAlreadyConnected
   ) {
     return false;
   }
 
-  if (!options?.skipInitialRefresh) {
+  // A failed bulk replay must not suppress the lightweight summary authority:
+  // it may be the only source that can clear stale working state.
+  if (!options?.skipInitialRefresh || initialHistoryHydrationFailed) {
     const refreshStartedAt = performance.now();
     await deps.refreshSessionSlotMeta(sessionId, {
       resumeIfActive: options?.resumeIfActive ?? true,
@@ -91,6 +97,15 @@ export async function prepareSessionStreamConnection(
 
   const refreshedSlot = getSessionRecord(sessionId);
   if (options?.isCurrent && !options.isCurrent()) {
+    return false;
+  }
+  if (
+    !options?.forceReconnect
+    && (
+      refreshedSlot?.streamConnectionState === "connecting"
+      || refreshedSlot?.streamConnectionState === "open"
+    )
+  ) {
     return false;
   }
   if (shouldSkipColdIdleSessionStream(refreshedSlot, options?.allowColdIdleNoStream)) {

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.test.tsx
@@ -2,6 +2,7 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AnyHarnessResolvedConnection } from "@anyharness/sdk-react";
+import { resolveSessionViewState } from "#product/domain/sessions/activity";
 import { useHotWorkspaceReconcileAction } from "#product/hooks/workspaces/workflows/use-hot-workspace-reconcile-action";
 import type { WorkspaceSession } from "#product/hooks/access/anyharness/sessions/use-workspace-session-cache";
 import { useSessionIngestStore } from "#product/stores/sessions/session-ingest-store";
@@ -27,11 +28,16 @@ const sessionMeta = {
   dismissedAt: null,
 } as unknown as WorkspaceSession;
 
-function renderReconcile(rehydrate: ReturnType<typeof vi.fn>) {
+function renderReconcile(
+  rehydrate: ReturnType<typeof vi.fn>,
+  applySessionSummary = vi.fn(),
+  sessions: WorkspaceSession[] = [sessionMeta],
+) {
   const { result } = renderHook(() =>
     useHotWorkspaceReconcileAction({
+      applySessionSummary,
       cancelDeferredFileTreePrefetch: vi.fn(),
-      loadWorkspaceSessions: vi.fn(async () => [sessionMeta]),
+      loadWorkspaceSessions: vi.fn(async () => sessions),
       prepareFileWorkspace: vi.fn(),
       rehydrateSessionSlotFromHistory: rehydrate,
       scheduleDeferredFileTreePrefetch: vi.fn(),
@@ -120,6 +126,60 @@ describe("useHotWorkspaceReconcileAction transcript hydration", () => {
     expect(outcome).toBe("completed");
     expect(rehydrate).toHaveBeenCalledTimes(2);
     expect(rehydrate.mock.calls[1]?.[1]).toMatchObject({ replace: true });
+    expect(getSessionRecord(SESSION_ID)?.transcriptHydrated).toBe(true);
+  });
+
+  it("keeps failed large-history recovery retryable after applying terminal authority", async () => {
+    const current = getSessionRecord(SESSION_ID)!;
+    patchSessionRecord(SESSION_ID, {
+      status: "running",
+      executionSummary: {
+        phase: "running",
+        hasLiveHandle: true,
+        pendingInteractions: [],
+        updatedAt: "2026-08-17T21:56:47Z",
+      },
+      transcript: {
+        ...current.transcript,
+        isStreaming: true,
+      },
+      transcriptHydrated: false,
+    });
+    const terminalSession = {
+      ...sessionMeta,
+      status: "idle",
+      executionSummary: {
+        phase: "idle",
+        hasLiveHandle: false,
+        pendingInteractions: [],
+        updatedAt: "2026-08-17T21:59:22Z",
+      },
+    } as WorkspaceSession;
+    const applySessionSummary = vi.fn((clientSessionId: string, session: WorkspaceSession) => {
+      patchSessionRecord(clientSessionId, {
+        status: session.status,
+        executionSummary: session.executionSummary,
+      });
+    });
+    const rehydrate = vi.fn(async () => false);
+
+    const reconcile = renderReconcile(
+      rehydrate,
+      applySessionSummary,
+      [terminalSession],
+    );
+    const outcome = await reconcile(reconcileInput());
+
+    expect(outcome).toBe("completed");
+    expect(applySessionSummary).toHaveBeenCalledWith(
+      SESSION_ID,
+      terminalSession,
+      WORKSPACE_ID,
+    );
+    expect(rehydrate).toHaveBeenCalledTimes(2);
+    expect(rehydrate.mock.calls[1]?.[1]).toMatchObject({ replace: true });
+    expect(getSessionRecord(SESSION_ID)?.transcriptHydrated).toBe(false);
+    expect(resolveSessionViewState(getSessionRecord(SESSION_ID))).toBe("idle");
   });
 
   it("never trusts a slot that was not transcript-hydrated, even with a live stream", async () => {

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.ts
@@ -1,7 +1,6 @@
 import type { AnyHarnessRequestOptions } from "@anyharness/sdk";
 import type { AnyHarnessResolvedConnection } from "@anyharness/sdk-react";
 import { useCallback } from "react";
-import { resolveStatusFromExecutionSummary } from "#product/domain/sessions/activity";
 import type { WorkspaceSession } from "#product/hooks/access/anyharness/sessions/use-workspace-session-cache";
 import type { WorkspaceCollections } from "#product/lib/domain/workspaces/cloud/collections";
 import { workspaceFileTreeStateKey } from "#product/lib/domain/workspaces/cloud/collections";
@@ -55,6 +54,11 @@ interface WorkspaceFileAccessInput {
 }
 
 interface UseHotWorkspaceReconcileActionInput {
+  applySessionSummary: (
+    clientSessionId: string,
+    session: WorkspaceSession,
+    workspaceId: string,
+  ) => void;
   cancelDeferredFileTreePrefetch: () => void;
   loadWorkspaceSessions: (input: {
     workspaceConnection: AnyHarnessResolvedConnection;
@@ -81,6 +85,7 @@ interface UseHotWorkspaceReconcileActionInput {
 }
 
 export function useHotWorkspaceReconcileAction({
+  applySessionSummary,
   cancelDeferredFileTreePrefetch,
   loadWorkspaceSessions,
   prepareFileWorkspace,
@@ -183,26 +188,7 @@ export function useHotWorkspaceReconcileAction({
         return "session_missing";
       }
       const storeStartedAt = performance.now();
-      patchSessionRecord(sessionId, {
-        workspaceId,
-        agentKind: sessionMeta.agentKind ?? currentSlot.agentKind,
-        modelId: sessionMeta.modelId ?? currentSlot.modelId ?? null,
-        requestedModelId:
-          sessionMeta.requestedModelId
-          ?? sessionMeta.modelId
-          ?? currentSlot.requestedModelId
-          ?? null,
-        modeId: sessionMeta.modeId ?? currentSlot.modeId ?? null,
-        title: sessionMeta.title ?? currentSlot.title ?? null,
-        liveConfig: sessionMeta.liveConfig ?? currentSlot.liveConfig ?? null,
-        executionSummary: sessionMeta.executionSummary ?? currentSlot.executionSummary ?? null,
-        mcpBindingSummaries: sessionMeta.mcpBindingSummaries ?? currentSlot.mcpBindingSummaries ?? null,
-        status: resolveStatusFromExecutionSummary(
-          sessionMeta.executionSummary ?? currentSlot.executionSummary ?? null,
-          sessionMeta.status ?? currentSlot.status,
-        ),
-        lastPromptAt: sessionMeta.lastPromptAt ?? currentSlot.lastPromptAt ?? null,
-      });
+      applySessionSummary(sessionId, sessionMeta, workspaceId);
       recordMeasurementMetric({
         type: "store",
         category: "session.list",
@@ -253,10 +239,11 @@ export function useHotWorkspaceReconcileAction({
         && slotBeforeHydrate.streamConnectionState === "open"
         && ingestFreshness?.freshness === "current"
         && ingestFreshness.gapAfterSeq === null;
+      let transcriptHydrated = slotBeforeHydrate?.transcriptHydrated === true;
       const lastSeq = slotBeforeHydrate?.transcript.lastSeq ?? 0;
       const hydrateStartedAt = startLatencyTimer();
       if (!slotStreamLive) {
-        const tailHydrated = await rehydrateSessionSlotFromHistory(sessionId, {
+        let hydrationApplied = await rehydrateSessionSlotFromHistory(sessionId, {
           afterSeq: lastSeq,
           requestHeaders,
           measurementOperationId,
@@ -265,8 +252,8 @@ export function useHotWorkspaceReconcileAction({
         if (!isCurrent()) {
           return "stale";
         }
-        if (!tailHydrated) {
-          await rehydrateSessionSlotFromHistory(sessionId, {
+        if (!hydrationApplied) {
+          hydrationApplied = await rehydrateSessionSlotFromHistory(sessionId, {
             replace: true,
             requestHeaders,
             measurementOperationId,
@@ -276,8 +263,11 @@ export function useHotWorkspaceReconcileAction({
         if (!isCurrent()) {
           return "stale";
         }
+        transcriptHydrated ||= hydrationApplied;
       }
-      patchSessionRecord(sessionId, { transcriptHydrated: true });
+      if (transcriptHydrated) {
+        patchSessionRecord(sessionId, { transcriptHydrated: true });
+      }
       recordMeasurementWorkflowStep({
         operationId: measurementOperationId,
         step: "session.select.history_hydrate",
@@ -305,6 +295,7 @@ export function useHotWorkspaceReconcileAction({
       finishOrCancelMeasurementOperation(measurementOperationId, finishReason);
     }
   }, [
+    applySessionSummary,
     cancelDeferredFileTreePrefetch,
     loadWorkspaceSessions,
     prepareFileWorkspace,

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/use-workspace-bootstrap-actions.ts
@@ -78,10 +78,7 @@ export function useWorkspaceBootstrapActions() {
   const lastViewedSessionByWorkspace = useWorkspaceUiStore(
     (state) => state.lastViewedSessionByWorkspace,
   );
-  const {
-    prepareFileWorkspace,
-    prefetchWorkspaceDirectories,
-  } = useWorkspaceFileActions();
+  const { prepareFileWorkspace, prefetchWorkspaceDirectories } = useWorkspaceFileActions();
   const { createEmptySessionWithResolvedConfig } = useSessionCreationActions();
   const { rehydrateSessionSlotFromHistory } = useSessionHistoryHydration();
   const { applySessionSummary } = useSessionSummaryActions();
@@ -93,6 +90,7 @@ export function useWorkspaceBootstrapActions() {
     prefetchWorkspaceDirectories,
   });
   const reconcileHotWorkspace = useHotWorkspaceReconcileAction({
+    applySessionSummary,
     cancelDeferredFileTreePrefetch,
     loadWorkspaceSessions,
     prepareFileWorkspace,


### PR DESCRIPTION
## Summary

- Keep failed history hydration incomplete across stream preparation, pane recovery, and hot-workspace reconciliation so the missing terminal history remains retryable.
- Apply the authoritative runtime session summary before history retry decisions, allowing terminal/idle state to clear stale local working and streaming state even when a large history repeatedly times out.
- Make accepted-running prompt presentation yield to authoritative non-working state: the unconfirmed prompt remains visible as `Waiting for transcript…`, but it can no longer force false `Thinking` UI.

Fixes PRO-311.

## Testing

- Focused regression and adjacent lifecycle suite: 9 files, 57 tests passed.
- Exact-head ProductClient CI: typecheck/build passed; 1,013 test files and 7,315 tests passed.
- Frontend structure, max-lines, boundary, component-library, transcript-scroll-writer, appearance-scaling, and design-attribution checks passed.
- Exact-head login budget passed: JS `501,780 / 502,000` bytes; CSS `65,874 / 66,250` bytes; no asset violations.
- Independent read-only review of pushed SHA `1b0593de2` completed with no blocking findings.

## Observability

- No diagnostic schema or event changes.
- Existing renderer history-rehydrate and metadata-refresh diagnostics remain intact; recovery uses the existing instrumented summary-refresh path.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] The fixing PR is linked through the tracker. No report, user, telemetry, or private source data appears in this PR.

## Verification

- `pnpm --filter @proliferate/product-client exec vitest run src/hooks/sessions/lifecycle/session-stream-connection-prepare.test.ts src/hooks/workspaces/workflows/use-hot-workspace-reconcile-action.test.tsx src/components/workspace/chat/surface/SessionTranscriptPane.test.tsx src/components/workspace/chat/transcript/TranscriptPendingPromptRow.test.tsx src/hooks/chat/ui/use-chat-transcript-row-renderer.test.tsx src/hooks/sessions/lifecycle/use-session-history-hydration.test.tsx src/hooks/sessions/lifecycle/session-history-hydration-helpers.test.ts src/hooks/sessions/lifecycle/session-history-rehydrate-failure.test.ts src/lib/workflows/sessions/hot-session-ingest-manager.test.ts`
- `pnpm --filter @proliferate/product-client typecheck`
- `pnpm --filter @proliferate/product-client test`
- `python3 scripts/report_frontend_structure.py --strict --summary-only`
- `python3 scripts/check_max_lines.py`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_transcript_scroll_writer.py`
- `python3 scripts/check_component_library.py`
- `python3 scripts/check_appearance_scaling.py`
- `uv run --python 3.12 python scripts/check_design_attribution.py`
- `pnpm shared:build && VITE_PROLIFERATE_API_BASE_URL=https://login-budget-fixture.invalid pnpm web:build && node scripts/measure-login-runtime-budget.mjs --no-build`
