### PR TITLE
feat(anyharness): OpenCode targeted-fork HTTP side-door bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4240,7 +4240,7 @@ dependencies = [
 
 [[package]]
 name = "proliferate"
-version = "0.4.14"
+version = "0.4.16"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/live_ports.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/live_ports.rs
@@ -24,9 +24,10 @@ use crate::domains::sessions::store::pending_prompts::PendingPromptWriteError;
 use crate::domains::sessions::store::persisted_payloads::sanitize_session_event_for_sqlite;
 use crate::domains::sessions::store::SessionStore;
 use crate::live::sessions::model::{
-    AttachmentSource, BackgroundWorkDurable, EventPersist, QueueDurable, SessionStateDurable,
-    TerminalTurnOutcome, TerminalTurnPersistenceInput,
+    BackgroundWorkDurable, EventPersist, QueueDurable, SessionStateDurable, TerminalTurnOutcome,
+    TerminalTurnPersistenceInput,
 };
+use crate::live::sessions::model_attachments::AttachmentSource;
 use crate::live::sessions::queue_durable::{
     PendingPromptDeleteOutcome, PendingPromptUpdateOutcome,
 };
@@ -360,6 +361,24 @@ impl SessionStateDurable for SessionStore {
 
     fn repair_unclosed_turns(&self, session_id: &str) -> anyhow::Result<u32> {
         SessionStore::repair_unclosed_turns(self, session_id)
+    }
+
+    fn insert_opencode_message_id(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+        item_id: &str,
+        vendor_message_id: &str,
+        now: &str,
+    ) -> anyhow::Result<()> {
+        SessionStore::insert_opencode_message_id(
+            self,
+            session_id,
+            turn_id,
+            item_id,
+            vendor_message_id,
+            now,
+        )
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork/errors.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork/errors.rs
@@ -1,0 +1,94 @@
+use crate::domains::sessions::model::ForkOperationPhase;
+use crate::domains::sessions::runtime::fork_boundary::ForkTargetError;
+use crate::live::sessions::{ForkSessionCommandError, LiveSessionCommandError};
+
+use super::{ForkSessionError, SessionRuntime, StartSessionError};
+
+impl SessionRuntime {
+    /// Classify a native fork dispatch error. A dropped response / unavailable
+    /// actor is an unknown outcome that BLOCKS blind redispatch (ADR 4.4); a
+    /// definite rejection is a terminal failure.
+    pub(super) fn mark_fork_native_failure(
+        &self,
+        operation_id: &str,
+        error: &LiveSessionCommandError<ForkSessionCommandError>,
+        now: &str,
+    ) {
+        let phase = match error {
+            LiveSessionCommandError::ResponseDropped
+            | LiveSessionCommandError::ActorUnavailable => {
+                ForkOperationPhase::NativeOutcomeUnknown
+            }
+            LiveSessionCommandError::Rejected(_) => ForkOperationPhase::Failed,
+        };
+        self.mark_fork_phase(operation_id, phase, now);
+    }
+}
+
+pub(super) fn map_fork_target_error(error: ForkTargetError) -> ForkSessionError {
+    match error {
+        ForkTargetError::ItemIdRequired => {
+            ForkSessionError::InvalidForkTarget("fork target requires item_id".to_string())
+        }
+        ForkTargetError::TargetNotFound => ForkSessionError::TargetNotFound,
+        ForkTargetError::BoundaryNotCommitted => ForkSessionError::BoundaryNotCommitted,
+    }
+}
+
+pub(super) fn map_start_error_to_fork(error: StartSessionError) -> ForkSessionError {
+    match error {
+        StartSessionError::WorkspaceNotFound => {
+            ForkSessionError::Internal(anyhow::anyhow!("workspace not found for session"))
+        }
+        StartSessionError::WorkspaceDirectoryMissing { path } => {
+            ForkSessionError::WorkspaceDirectoryMissing { path }
+        }
+        StartSessionError::AgentDescriptorNotFound(agent_kind) => {
+            ForkSessionError::Internal(anyhow::anyhow!("agent descriptor not found: {agent_kind}"))
+        }
+        StartSessionError::Closed => ForkSessionError::Invalid("session is closed".to_string()),
+        StartSessionError::MissingDataKey => ForkSessionError::MissingDataKey,
+        StartSessionError::RestartRequired(detail) => ForkSessionError::Invalid(detail),
+        StartSessionError::WorkspaceMcpAttachmentFailed(error) => {
+            ForkSessionError::Internal(anyhow::Error::new(error))
+        }
+        StartSessionError::RouteAuth(error) => ForkSessionError::Invalid(error.to_string()),
+        StartSessionError::AgentNotReady {
+            agent_kind,
+            status,
+            detail,
+        } => ForkSessionError::AgentNotReady {
+            agent_kind,
+            status,
+            detail,
+        },
+        StartSessionError::Internal(error) | StartSessionError::AcpStart(error) => {
+            ForkSessionError::Internal(error)
+        }
+    }
+}
+
+pub(super) fn map_fork_command_error(error: ForkSessionCommandError) -> ForkSessionError {
+    match error {
+        ForkSessionCommandError::Busy => ForkSessionError::Busy,
+        ForkSessionCommandError::Unsupported(detail) => ForkSessionError::Unsupported(detail),
+        ForkSessionCommandError::Failed(detail) => {
+            ForkSessionError::Internal(anyhow::anyhow!(detail))
+        }
+    }
+}
+
+pub(super) fn map_live_fork_command_error(
+    error: LiveSessionCommandError<ForkSessionCommandError>,
+    response_dropped_detail: &str,
+) -> ForkSessionError {
+    match error {
+        LiveSessionCommandError::ActorUnavailable => {
+            ForkSessionError::Internal(anyhow::anyhow!("session actor channel closed"))
+        }
+        LiveSessionCommandError::ResponseDropped => {
+            ForkSessionError::Internal(anyhow::anyhow!(response_dropped_detail.to_string()))
+        }
+        LiveSessionCommandError::Rejected(error) => map_fork_command_error(error),
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork/mod.rs
@@ -8,17 +8,23 @@ use crate::domains::sessions::links::service::SessionLinkService;
 use crate::domains::sessions::model::{
     parse_action_capabilities, ForkOperationPhase, ForkOperationRecord, SessionRecord,
 };
-use crate::domains::sessions::runtime::fork_boundary::{
-    self, ForkTargetError,
-};
+use crate::domains::sessions::runtime::fork_boundary;
 use crate::domains::sessions::store::fork_operations::ForkOperationChildResult;
 use crate::live::sessions::SessionStartupStrategy;
-use crate::live::sessions::{ForkSessionCommandError, LiveSessionCommandError};
+use crate::live::sessions::{ForkSessionCommandResult, LiveSessionCommandError};
+
+use self::errors::{
+    map_fork_target_error, map_live_fork_command_error, map_start_error_to_fork,
+};
+use self::sidedoor::map_live_sidedoor_fork_error;
 
 use super::startup_errors::map_start_session_error_to_anyhow;
 use super::{
     ForkSessionError, ForkSessionOutcome, SessionLifecycleError, SessionRuntime, StartSessionError,
 };
+
+mod errors;
+mod sidedoor;
 
 impl SessionRuntime {
     pub async fn fork_session(
@@ -144,15 +150,23 @@ impl SessionRuntime {
             return Err(ForkSessionError::Busy);
         }
 
-        // Rung 3 target: this is the seam a targeted native dispatch plugs into.
-        // Until a bridge advertises `targeted_fork` the gate above rejects it, so
-        // reaching here with a targeted anchor means a capability was advertised
-        // without a dispatch implementation.
-        if target.is_some() {
-            return Err(ForkSessionError::Unsupported(
-                "targeted fork native dispatch is not wired yet (rung 3)".to_string(),
-            ));
-        }
+        // Rung 3 dispatch: resolve a side-door vendor anchor for a targeted
+        // fork on an adapter that advertises `targeted_fork` (see
+        // `sidedoor::resolve_sidedoor_message_id`); every other targeted case
+        // still errors as unwired.
+        let sidedoor_message_id: Option<String> = self.resolve_sidedoor_message_id(
+            session_id,
+            target.is_some(),
+            &parent,
+            capabilities.targeted_fork,
+            &anchor_turn_id,
+            &anchor_item_id,
+        )?;
+        // The resolved vendor version for side-door provenance (never
+        // hardcoded): the exact `(adapter, native)` pin this session was
+        // stamped under.
+        let sidedoor_native_version =
+            self.resolve_sidedoor_native_version(session_id, &sidedoor_message_id);
 
         // --- Persist the durable operation in `prepared` before any native call ---
         let now = chrono::Utc::now().to_rfc3339();
@@ -201,7 +215,21 @@ impl SessionRuntime {
         // Phase marked before dispatch (ADR 4.4): a lost native outcome parks the
         // record at `native_outcome_unknown` and blocks blind redispatch.
         self.mark_fork_phase(&operation.id, ForkOperationPhase::NativeCallInFlight, &now);
-        let forked = if child_actor_forks {
+        let forked = if let Some(message_id) = sidedoor_message_id.clone() {
+            // Side-door targeted fork: validated + POSTed on the parent actor.
+            // The vendor fork response id becomes the child's durable native
+            // session id; the child starts via the existing load_session path.
+            match handle.sidedoor_targeted_fork(message_id).await {
+                Ok(result) => Some(ForkSessionCommandResult {
+                    native_session_id: result.native_session_id,
+                    supports_close: result.supports_close,
+                }),
+                Err(error) => {
+                    self.mark_fork_sidedoor_failure(&operation.id, &error, &now);
+                    return Err(map_live_sidedoor_fork_error(error));
+                }
+            }
+        } else if child_actor_forks {
             match handle.verify_fork_ready().await {
                 Ok(()) => None,
                 Err(error) => {
@@ -274,14 +302,36 @@ impl SessionRuntime {
         };
         // Provenance resolved once the native call returns; applied atomically
         // with the child + link, advancing the operation to `child_persisted`.
+        // A side-door targeted fork records the vendor message-id anchor
+        // (exclusive: the fork EXCLUDES the target message) and the resolved
+        // vendor version, not the generic tip/targeted native-id anchor.
+        let (
+            resolved_provider_anchor_kind,
+            resolved_provider_anchor_value,
+            resolved_provider_anchor_inclusive,
+            resolved_native_version,
+        ) = match &sidedoor_message_id {
+            Some(message_id) => (
+                "opencode_message_id".to_string(),
+                message_id.clone(),
+                Some(false),
+                sidedoor_native_version.clone(),
+            ),
+            None => (
+                provider_anchor_kind.to_string(),
+                parent_native_session_id.clone(),
+                None,
+                None,
+            ),
+        };
         let child_result = ForkOperationChildResult {
-            provider_anchor_kind: Some(provider_anchor_kind.to_string()),
-            provider_anchor_value: Some(parent_native_session_id.clone()),
-            provider_anchor_inclusive: None,
+            provider_anchor_kind: Some(resolved_provider_anchor_kind),
+            provider_anchor_value: Some(resolved_provider_anchor_value),
+            provider_anchor_inclusive: resolved_provider_anchor_inclusive,
             prefix_terminal_seq: Some(prefix_terminal_seq),
             prefix_digest: Some(prefix_digest.clone()),
             adapter_version: None,
-            native_version: None,
+            native_version: resolved_native_version,
             native_child_session_id: forked
                 .as_ref()
                 .map(|forked| forked.native_session_id.clone()),
@@ -403,25 +453,6 @@ impl SessionRuntime {
         }
     }
 
-    /// Classify a native fork dispatch error. A dropped response / unavailable
-    /// actor is an unknown outcome that BLOCKS blind redispatch (ADR 4.4); a
-    /// definite rejection is a terminal failure.
-    fn mark_fork_native_failure(
-        &self,
-        operation_id: &str,
-        error: &LiveSessionCommandError<ForkSessionCommandError>,
-        now: &str,
-    ) {
-        let phase = match error {
-            LiveSessionCommandError::ResponseDropped
-            | LiveSessionCommandError::ActorUnavailable => {
-                ForkOperationPhase::NativeOutcomeUnknown
-            }
-            LiveSessionCommandError::Rejected(_) => ForkOperationPhase::Failed,
-        };
-        self.mark_fork_phase(operation_id, phase, now);
-    }
-
     /// Reconcile a fork operation that already exists under this idempotency
     /// key: a different canonical payload is an `IDEMPOTENCY_CONFLICT`; the same
     /// payload resumes. Shared by the initial lookup and the insert-time
@@ -510,16 +541,6 @@ pub(crate) fn canonical_fork_request_digest(
     format!("{:x}", hasher.finalize())
 }
 
-fn map_fork_target_error(error: ForkTargetError) -> ForkSessionError {
-    match error {
-        ForkTargetError::ItemIdRequired => {
-            ForkSessionError::InvalidForkTarget("fork target requires item_id".to_string())
-        }
-        ForkTargetError::TargetNotFound => ForkSessionError::TargetNotFound,
-        ForkTargetError::BoundaryNotCommitted => ForkSessionError::BoundaryNotCommitted,
-    }
-}
-
 impl SessionRuntime {
     /// Pre-flight the parent workspace's local checkout before forking. Reuses
     /// the shared `workspace_checkout_missing_path` admission (same predicate as
@@ -561,62 +582,4 @@ pub(super) fn validate_fork_parent(
         ));
     }
     Ok(())
-}
-
-fn map_start_error_to_fork(error: StartSessionError) -> ForkSessionError {
-    match error {
-        StartSessionError::WorkspaceNotFound => {
-            ForkSessionError::Internal(anyhow::anyhow!("workspace not found for session"))
-        }
-        StartSessionError::WorkspaceDirectoryMissing { path } => {
-            ForkSessionError::WorkspaceDirectoryMissing { path }
-        }
-        StartSessionError::AgentDescriptorNotFound(agent_kind) => {
-            ForkSessionError::Internal(anyhow::anyhow!("agent descriptor not found: {agent_kind}"))
-        }
-        StartSessionError::Closed => ForkSessionError::Invalid("session is closed".to_string()),
-        StartSessionError::MissingDataKey => ForkSessionError::MissingDataKey,
-        StartSessionError::RestartRequired(detail) => ForkSessionError::Invalid(detail),
-        StartSessionError::WorkspaceMcpAttachmentFailed(error) => {
-            ForkSessionError::Internal(anyhow::Error::new(error))
-        }
-        StartSessionError::RouteAuth(error) => ForkSessionError::Invalid(error.to_string()),
-        StartSessionError::AgentNotReady {
-            agent_kind,
-            status,
-            detail,
-        } => ForkSessionError::AgentNotReady {
-            agent_kind,
-            status,
-            detail,
-        },
-        StartSessionError::Internal(error) | StartSessionError::AcpStart(error) => {
-            ForkSessionError::Internal(error)
-        }
-    }
-}
-
-fn map_fork_command_error(error: ForkSessionCommandError) -> ForkSessionError {
-    match error {
-        ForkSessionCommandError::Busy => ForkSessionError::Busy,
-        ForkSessionCommandError::Unsupported(detail) => ForkSessionError::Unsupported(detail),
-        ForkSessionCommandError::Failed(detail) => {
-            ForkSessionError::Internal(anyhow::anyhow!(detail))
-        }
-    }
-}
-
-fn map_live_fork_command_error(
-    error: LiveSessionCommandError<ForkSessionCommandError>,
-    response_dropped_detail: &str,
-) -> ForkSessionError {
-    match error {
-        LiveSessionCommandError::ActorUnavailable => {
-            ForkSessionError::Internal(anyhow::anyhow!("session actor channel closed"))
-        }
-        LiveSessionCommandError::ResponseDropped => {
-            ForkSessionError::Internal(anyhow::anyhow!(response_dropped_detail.to_string()))
-        }
-        LiveSessionCommandError::Rejected(error) => map_fork_command_error(error),
-    }
 }

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork/sidedoor.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork/sidedoor.rs
@@ -1,0 +1,110 @@
+use crate::domains::agents::model::AgentKind;
+use crate::domains::sessions::model::{ForkOperationPhase, SessionRecord};
+use crate::live::sessions::{LiveSessionCommandError, SidedoorForkCommandError};
+
+use super::{ForkSessionError, SessionRuntime};
+
+impl SessionRuntime {
+    /// Rung 3 dispatch. A targeted fork on an OpenCode parent that advertises
+    /// `targeted_fork` (the side-door bridge) resolves its
+    /// product anchor to a vendor message id here and dispatches through the
+    /// parent actor's side-door. Every OTHER targeted case keeps the exact
+    /// current error: a targeted anchor with no wired bridge means a
+    /// capability was advertised without a dispatch implementation.
+    pub(super) fn resolve_sidedoor_message_id(
+        &self,
+        session_id: &str,
+        is_targeted: bool,
+        parent: &SessionRecord,
+        targeted_fork_enabled: bool,
+        anchor_turn_id: &Option<String>,
+        anchor_item_id: &Option<String>,
+    ) -> Result<Option<String>, ForkSessionError> {
+        if !is_targeted {
+            return Ok(None);
+        }
+        if parent.agent_kind == AgentKind::OpenCode.as_str() && targeted_fork_enabled {
+            // Translate the resolved (turn_id, item_id) boundary to the
+            // captured vendor message id. Absent ⇒ the stable
+            // TARGET_NOT_FOUND reason: no fallback, no ordinal guessing
+            // (the vendor silently full-copies an unknown id).
+            let turn_id = anchor_turn_id.as_deref().unwrap_or_default();
+            let item_id = anchor_item_id.as_deref().unwrap_or_default();
+            let mapped = self
+                .session_service
+                .store()
+                .find_opencode_message_id(session_id, turn_id, item_id)
+                .map_err(ForkSessionError::Internal)?
+                .ok_or(ForkSessionError::TargetNotFound)?;
+            Ok(Some(mapped))
+        } else {
+            Err(ForkSessionError::Unsupported(
+                "targeted fork native dispatch is not wired yet (rung 3)".to_string(),
+            ))
+        }
+    }
+
+    /// The resolved vendor version for side-door provenance (never hardcoded):
+    /// the exact `(adapter, native)` pin this session was stamped under.
+    pub(super) fn resolve_sidedoor_native_version(
+        &self,
+        session_id: &str,
+        sidedoor_message_id: &Option<String>,
+    ) -> Option<String> {
+        sidedoor_message_id.as_ref().and_then(|_| {
+            self.session_service
+                .store()
+                .find_adapter_marker(session_id)
+                .ok()
+                .flatten()
+                .and_then(|marker| marker.native_version)
+        })
+    }
+
+    /// Classify a side-door fork dispatch error for the phase machine. A
+    /// dropped response / unavailable actor is an unknown outcome that blocks
+    /// blind redispatch; a definite rejection is terminal (ADR 4.4).
+    pub(super) fn mark_fork_sidedoor_failure(
+        &self,
+        operation_id: &str,
+        error: &LiveSessionCommandError<SidedoorForkCommandError>,
+        now: &str,
+    ) {
+        let phase = match error {
+            LiveSessionCommandError::ResponseDropped
+            | LiveSessionCommandError::ActorUnavailable => {
+                ForkOperationPhase::NativeOutcomeUnknown
+            }
+            LiveSessionCommandError::Rejected(_) => ForkOperationPhase::Failed,
+        };
+        self.mark_fork_phase(operation_id, phase, now);
+    }
+}
+
+/// Map a side-door fork dispatch error to the shared fork error taxonomy. The
+/// validation failures resolved on the actor (unknown/non-user id, listing
+/// mismatch) surface as the existing TARGET_NOT_FOUND/INVALID_FORK_TARGET
+/// reasons; a non-Ready side-door is `Unsupported` (never a silent tip fork).
+pub(super) fn map_live_sidedoor_fork_error(
+    error: LiveSessionCommandError<SidedoorForkCommandError>,
+) -> ForkSessionError {
+    match error {
+        LiveSessionCommandError::ActorUnavailable => {
+            ForkSessionError::Internal(anyhow::anyhow!("session actor channel closed"))
+        }
+        LiveSessionCommandError::ResponseDropped => ForkSessionError::Internal(anyhow::anyhow!(
+            "session actor dropped side-door fork response"
+        )),
+        LiveSessionCommandError::Rejected(inner) => match inner {
+            SidedoorForkCommandError::NotReady(detail) => ForkSessionError::Unsupported(detail),
+            SidedoorForkCommandError::TargetNotFound => ForkSessionError::TargetNotFound,
+            SidedoorForkCommandError::InvalidForkTarget(detail) => {
+                ForkSessionError::InvalidForkTarget(detail)
+            }
+            SidedoorForkCommandError::Busy => ForkSessionError::Busy,
+            SidedoorForkCommandError::Failed(detail) => {
+                ForkSessionError::Internal(anyhow::anyhow!(detail))
+            }
+        },
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork_qualification.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork_qualification.rs
@@ -1,0 +1,125 @@
+use std::collections::HashSet;
+use std::sync::OnceLock;
+
+use serde::Deserialize;
+
+/// The targeted-fork side-door qualification registry. An
+/// agent kind only ever advertises `targeted_fork` when a row here says
+/// `qualified: true` for its exact resolved native version -- flipping that
+/// flag is a deliberate, reviewed act after the live two-boundary probe, not
+/// a side effect of shipping the bridge code.
+const BUNDLED_QUALIFICATIONS: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../../catalogs/agents/qualifications/targeted-fork-sidedoor.json"
+));
+
+#[derive(Debug, Clone, Deserialize)]
+struct QualificationEntry {
+    #[serde(rename = "agentKind")]
+    agent_kind: String,
+    #[serde(rename = "nativeVersion")]
+    native_version: String,
+    qualified: bool,
+    #[allow(dead_code)]
+    evidence: String,
+}
+
+static PARSED: OnceLock<Vec<QualificationEntry>> = OnceLock::new();
+
+fn parsed_qualifications() -> &'static [QualificationEntry] {
+    PARSED
+        .get_or_init(|| {
+            parse_qualifications(BUNDLED_QUALIFICATIONS)
+                .expect("bundled targeted-fork-sidedoor qualification registry must be valid")
+        })
+        .as_slice()
+}
+
+/// Parse and validate a qualification registry document. Fails closed (loud
+/// error, never a silent skip) on anything malformed: duplicate
+/// `(agentKind, nativeVersion)` pairs are ambiguous and an unknown/empty
+/// `agentKind` is very likely a typo that would otherwise silently qualify
+/// nothing.
+fn parse_qualifications(raw: &str) -> anyhow::Result<Vec<QualificationEntry>> {
+    let entries: Vec<QualificationEntry> = serde_json::from_str(raw)
+        .map_err(|error| anyhow::anyhow!("targeted-fork-sidedoor registry: invalid JSON: {error}"))?;
+
+    let mut seen: HashSet<(String, String)> = HashSet::new();
+    for entry in &entries {
+        if entry.agent_kind.trim().is_empty() {
+            anyhow::bail!("targeted-fork-sidedoor registry: entry has empty agentKind");
+        }
+        if entry.native_version.trim().is_empty() {
+            anyhow::bail!(
+                "targeted-fork-sidedoor registry: entry for {} has empty nativeVersion",
+                entry.agent_kind
+            );
+        }
+        let key = (entry.agent_kind.clone(), entry.native_version.clone());
+        if !seen.insert(key) {
+            anyhow::bail!(
+                "targeted-fork-sidedoor registry: duplicate entry for agentKind={} nativeVersion={}",
+                entry.agent_kind,
+                entry.native_version
+            );
+        }
+    }
+    Ok(entries)
+}
+
+/// Whether targeted-fork side-door dispatch is qualified for the given agent
+/// kind at the given resolved native version. An unknown `(agent_kind,
+/// native_version)` pair -- including an unknown agent kind entirely -- is
+/// unqualified: fail closed, never assume.
+pub fn sidedoor_fork_qualified(agent_kind: &str, native_version: &str) -> bool {
+    parsed_qualifications()
+        .iter()
+        .any(|entry| entry.agent_kind == agent_kind && entry.native_version == native_version && entry.qualified)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundled_registry_parses_and_matches_opencode_pin() {
+        let entries = parse_qualifications(BUNDLED_QUALIFICATIONS).expect("bundled registry parses");
+        assert!(entries
+            .iter()
+            .any(|entry| entry.agent_kind == "opencode" && entry.native_version == "1.18.3"));
+    }
+
+    #[test]
+    fn unqualified_entry_reports_false() {
+        // The bundled registry ships qualified:false until the live probe
+        // flips it -- this pins that the flag, not just presence, gates.
+        assert!(!sidedoor_fork_qualified("opencode", "1.18.3"));
+    }
+
+    #[test]
+    fn unknown_agent_kind_is_unqualified() {
+        assert!(!sidedoor_fork_qualified("does-not-exist", "1.0.0"));
+    }
+
+    #[test]
+    fn unknown_native_version_is_unqualified() {
+        assert!(!sidedoor_fork_qualified("opencode", "0.0.1"));
+    }
+
+    #[test]
+    fn duplicate_entries_fail_closed() {
+        let raw = r#"[
+            {"agentKind": "opencode", "nativeVersion": "1.18.3", "qualified": false, "evidence": "a"},
+            {"agentKind": "opencode", "nativeVersion": "1.18.3", "qualified": true, "evidence": "b"}
+        ]"#;
+        let error = parse_qualifications(raw).expect_err("duplicate entries must fail to parse");
+        assert!(error.to_string().contains("duplicate entry"));
+    }
+
+    #[test]
+    fn empty_agent_kind_fails_closed() {
+        let raw = r#"[{"agentKind": "", "nativeVersion": "1.0.0", "qualified": true, "evidence": "a"}]"#;
+        let error = parse_qualifications(raw).expect_err("empty agentKind must fail to parse");
+        assert!(error.to_string().contains("empty agentKind"));
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/mod.rs
@@ -30,6 +30,8 @@ mod config;
 mod creation;
 mod fork;
 pub(crate) mod fork_boundary;
+pub(crate) mod fork_qualification;
+pub(crate) mod opencode_sidedoor_client;
 #[cfg(test)]
 mod idempotent_creation_tests;
 mod interactions;

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/opencode_sidedoor_client.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/runtime/opencode_sidedoor_client.rs
@@ -1,0 +1,267 @@
+//! The OpenCode targeted-fork HTTP side-door client.
+//!
+//! Talks directly to the vendor `opencode acp` process's HTTP server on
+//! `127.0.0.1:{port}` with the Basic-auth password minted for this process
+//! (`live::sessions::driver::opencode_sidedoor::SidedoorSpawnConfig`). Every
+//! call is short-timeout: a hung side-door must never stall the fork path,
+//! which has its own caller-side error handling for an unreachable/refused
+//! side-door.
+//!
+//! Vendor contract pinned at tag v1.18.3 (commit
+//! 127bdb30784d508cc556c71a0f32b508a3061517): `GET /session/{id}/message` and
+//! `GET /session/{id}/message/{messageID}` for reads, `POST
+//! /session/{id}/fork` with body `{"messageID": "..."}` to fork. `GET
+//! /session/{id}/message` doubles as the health-check endpoint here (it is
+//! the cheapest call that both requires the target session to exist and
+//! exercises the same auth middleware as fork dispatch).
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, thiserror::Error)]
+pub enum SidedoorClientError {
+    #[error("side-door request failed: {0}")]
+    Request(#[from] reqwest::Error),
+    #[error("side-door returned HTTP {status}")]
+    Status { status: u16 },
+    #[error("side-door response did not parse: {0}")]
+    Parse(String),
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ForkRequestBody<'a> {
+    #[serde(rename = "messageID", skip_serializing_if = "Option::is_none")]
+    message_id: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct VendorSessionInfo {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct VendorMessageInfo {
+    pub id: String,
+    pub role: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct VendorMessageEnvelope {
+    pub info: VendorMessageInfo,
+}
+
+pub struct OpencodeSidedoorClient {
+    base_url: String,
+    username: String,
+    password: String,
+    client: reqwest::Client,
+}
+
+impl OpencodeSidedoorClient {
+    pub fn new(port: u16, password: String) -> anyhow::Result<Self> {
+        let client = reqwest::Client::builder().timeout(REQUEST_TIMEOUT).build()?;
+        Ok(Self {
+            base_url: format!("http://127.0.0.1:{port}"),
+            username: "opencode".to_string(),
+            password,
+            client,
+        })
+    }
+
+    /// Health check: the cheapest authenticated call that exercises the same
+    /// auth middleware as a real fork dispatch. Returns `Ok(true)` on 200,
+    /// `Ok(false)` on any non-2xx (including 401), `Err` when unreachable.
+    pub async fn health_check(&self, session_id: &str) -> Result<bool, SidedoorClientError> {
+        let url = format!(
+            "{}/session/{}/message",
+            self.base_url,
+            urlencode(session_id)
+        );
+        let response = self
+            .client
+            .get(&url)
+            .basic_auth(&self.username, Some(&self.password))
+            .send()
+            .await?;
+        Ok(response.status().is_success())
+    }
+
+    /// Same call as `health_check` but WITHOUT credentials -- used by the
+    /// fail-closed readiness check to confirm the auth middleware actually
+    /// rejects unauthenticated requests.
+    pub async fn health_check_unauthenticated(
+        &self,
+        session_id: &str,
+    ) -> Result<bool, SidedoorClientError> {
+        let url = format!(
+            "{}/session/{}/message",
+            self.base_url,
+            urlencode(session_id)
+        );
+        let response = self.client.get(&url).send().await?;
+        Ok(response.status().is_success())
+    }
+
+    pub async fn get_message(
+        &self,
+        session_id: &str,
+        message_id: &str,
+    ) -> Result<VendorMessageEnvelope, SidedoorClientError> {
+        let url = format!(
+            "{}/session/{}/message/{}",
+            self.base_url,
+            urlencode(session_id),
+            urlencode(message_id)
+        );
+        let response = self
+            .client
+            .get(&url)
+            .basic_auth(&self.username, Some(&self.password))
+            .send()
+            .await?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(SidedoorClientError::Status {
+                status: status.as_u16(),
+            });
+        }
+        response
+            .json()
+            .await
+            .map_err(|error| SidedoorClientError::Parse(error.to_string()))
+    }
+
+    pub async fn list_messages(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<VendorMessageEnvelope>, SidedoorClientError> {
+        let url = format!(
+            "{}/session/{}/message",
+            self.base_url,
+            urlencode(session_id)
+        );
+        let response = self
+            .client
+            .get(&url)
+            .basic_auth(&self.username, Some(&self.password))
+            .send()
+            .await?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(SidedoorClientError::Status {
+                status: status.as_u16(),
+            });
+        }
+        response
+            .json()
+            .await
+            .map_err(|error| SidedoorClientError::Parse(error.to_string()))
+    }
+
+    /// Dispatch the fork. `message_id: None` forks at the tip; `Some(id)`
+    /// forks immediately before that (vendor-EXCLUSIVE) message. Callers in
+    /// this lane must never pass an id that has not first been validated via
+    /// `get_message` + `list_messages` membership (upstream does no existence
+    /// check and will silently full-copy an unrecognized id).
+    pub async fn fork(
+        &self,
+        session_id: &str,
+        message_id: Option<&str>,
+    ) -> Result<VendorSessionInfo, SidedoorClientError> {
+        let url = format!("{}/session/{}/fork", self.base_url, urlencode(session_id));
+        let response = self
+            .client
+            .post(&url)
+            .basic_auth(&self.username, Some(&self.password))
+            .json(&ForkRequestBody { message_id })
+            .send()
+            .await?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(SidedoorClientError::Status {
+                status: status.as_u16(),
+            });
+        }
+        response
+            .json()
+            .await
+            .map_err(|error| SidedoorClientError::Parse(error.to_string()))
+    }
+}
+
+fn urlencode(value: &str) -> String {
+    // Session/message ids are vendor-generated `[A-Za-z0-9_]+` identifiers in
+    // practice; percent-encode conservatively anyway rather than assuming.
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char);
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fork_request_body_serializes_with_message_id() {
+        let body = ForkRequestBody {
+            message_id: Some("msg_abc123"),
+        };
+        let json = serde_json::to_string(&body).unwrap();
+        assert_eq!(json, r#"{"messageID":"msg_abc123"}"#);
+    }
+
+    #[test]
+    fn fork_request_body_omits_message_id_when_none() {
+        let body = ForkRequestBody { message_id: None };
+        let json = serde_json::to_string(&body).unwrap();
+        assert_eq!(json, "{}");
+    }
+
+    #[test]
+    fn urlencode_leaves_typical_ids_untouched() {
+        assert_eq!(urlencode("msg_abcDEF123_-.~"), "msg_abcDEF123_-.~");
+    }
+
+    #[test]
+    fn urlencode_escapes_special_chars() {
+        assert_eq!(urlencode("a/b"), "a%2Fb");
+    }
+
+    const FORK_REQUEST_FIXTURE: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../../fixtures/contracts/opencode-sidedoor/fork-request.json"
+    ));
+    const MESSAGE_LIST_FIXTURE: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../../fixtures/contracts/opencode-sidedoor/message-list-response.json"
+    ));
+
+    #[test]
+    fn fork_request_matches_pinned_fixture_shape() {
+        let body = ForkRequestBody {
+            message_id: Some("msg_01hqrstuvwxyzabcdefghij0"),
+        };
+        let ours: serde_json::Value = serde_json::from_str(&serde_json::to_string(&body).unwrap()).unwrap();
+        let fixture: serde_json::Value = serde_json::from_str(FORK_REQUEST_FIXTURE).unwrap();
+        assert_eq!(ours, fixture);
+    }
+
+    #[test]
+    fn parses_pinned_message_list_fixture() {
+        let messages: Vec<VendorMessageEnvelope> =
+            serde_json::from_str(MESSAGE_LIST_FIXTURE).expect("fixture parses");
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].info.id, "msg_01hqrstuvwxyzabcdefghij0");
+        assert_eq!(messages[0].info.role, "user");
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/store/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/store/mod.rs
@@ -12,6 +12,7 @@ mod links;
 mod live_config;
 pub(crate) mod mobility;
 mod notifications;
+pub(crate) mod opencode_message_ids;
 pub(in crate::domains::sessions) mod pending_prompts;
 pub(crate) mod persisted_payloads;
 pub(crate) mod sessions;

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/store/opencode_message_ids.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/store/opencode_message_ids.rs
@@ -1,0 +1,51 @@
+use rusqlite::{params, OptionalExtension};
+
+use super::SessionStore;
+
+impl SessionStore {
+    /// Record the vendor OpenCode message id observed for a runtime
+    /// `(turn_id, item_id)` user-message identity. First-writer-wins: a later
+    /// call for the same `(session_id, turn_id, item_id)` is a no-op, never an
+    /// overwrite (a replayed echo must never clobber the first-observed id).
+    pub fn insert_opencode_message_id(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+        item_id: &str,
+        vendor_message_id: &str,
+        now: &str,
+    ) -> anyhow::Result<()> {
+        self.db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO opencode_message_ids
+                     (session_id, turn_id, item_id, vendor_message_id, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)
+                 ON CONFLICT(session_id, turn_id, item_id) DO NOTHING",
+                params![session_id, turn_id, item_id, vendor_message_id, now],
+            )?;
+            Ok(())
+        })
+    }
+
+    /// Look up the vendor message id captured for a runtime user-message
+    /// identity. `None` means no echo was ever observed for this
+    /// `(session_id, turn_id, item_id)` -- callers must treat this as
+    /// `TARGET_NOT_FOUND`, never guess or fall back to an ordinal.
+    pub fn find_opencode_message_id(
+        &self,
+        session_id: &str,
+        turn_id: &str,
+        item_id: &str,
+    ) -> anyhow::Result<Option<String>> {
+        self.db.with_conn(|conn| {
+            conn.query_row(
+                "SELECT vendor_message_id
+                   FROM opencode_message_ids
+                  WHERE session_id = ?1 AND turn_id = ?2 AND item_id = ?3",
+                params![session_id, turn_id, item_id],
+                |row| row.get(0),
+            )
+            .optional()
+        })
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/store/tests/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/store/tests/mod.rs
@@ -75,6 +75,7 @@ mod events;
 mod links;
 mod mobility_cursor;
 mod notifications;
+mod opencode_message_ids;
 mod pending_prompt_events;
 mod pending_prompts;
 mod runtime_event_idempotency;

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/store/tests/opencode_message_ids.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/store/tests/opencode_message_ids.rs
@@ -1,0 +1,66 @@
+//! The vendor OpenCode message-id mapping store. Pins the
+//! first-writer-wins contract that the sink→actor capture relies on — a
+//! replayed or duplicated user-message echo must never clobber the first
+//! observed id, and an unmapped identity must translate to `None` (which the
+//! fork dispatch treats as `TARGET_NOT_FOUND`, never an ordinal guess).
+
+use super::SessionStore;
+use crate::persistence::Db;
+
+fn store() -> SessionStore {
+    SessionStore::new(Db::open_in_memory().expect("open db"))
+}
+
+#[test]
+fn first_writer_wins_and_duplicate_echo_is_ignored() {
+    let store = store();
+    store
+        .insert_opencode_message_id("s1", "t1", "i1", "msg_first", "2026-08-17T00:00:00Z")
+        .expect("first insert");
+    // A replayed echo for the same identity must not overwrite the first id.
+    store
+        .insert_opencode_message_id("s1", "t1", "i1", "msg_second", "2026-08-17T00:00:01Z")
+        .expect("duplicate insert is a no-op");
+
+    let found = store
+        .find_opencode_message_id("s1", "t1", "i1")
+        .expect("lookup");
+    assert_eq!(found.as_deref(), Some("msg_first"));
+}
+
+#[test]
+fn distinct_identities_map_independently() {
+    let store = store();
+    store
+        .insert_opencode_message_id("s1", "t1", "i1", "msg_a", "2026-08-17T00:00:00Z")
+        .expect("insert a");
+    store
+        .insert_opencode_message_id("s1", "t2", "i2", "msg_b", "2026-08-17T00:00:00Z")
+        .expect("insert b");
+
+    assert_eq!(
+        store
+            .find_opencode_message_id("s1", "t1", "i1")
+            .expect("lookup a")
+            .as_deref(),
+        Some("msg_a")
+    );
+    assert_eq!(
+        store
+            .find_opencode_message_id("s1", "t2", "i2")
+            .expect("lookup b")
+            .as_deref(),
+        Some("msg_b")
+    );
+}
+
+#[test]
+fn unmapped_identity_is_none() {
+    let store = store();
+    assert_eq!(
+        store
+            .find_opencode_message_id("s1", "t1", "i1")
+            .expect("lookup"),
+        None
+    );
+}

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/capabilities.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/capabilities.rs
@@ -1,0 +1,268 @@
+//! ACP `InitializeResponse` -> `SessionActionCapabilities` parsing, plus the
+//! `_meta.anyharness` GoalPort/LoopPort capability advertisements. Split out
+//! of `startup.rs` (PROD-SIZE-1): this is pure handshake-response parsing,
+//! independent of the actor construction sequence that calls it.
+
+use agent_client_protocol as acp;
+use anyharness_contract::v1::SessionActionCapabilities;
+
+use crate::domains::sessions::model::serialize_action_capabilities;
+use crate::live::sessions::driver::native_session::has_anyharness_targeted_fork_extension;
+use crate::live::sessions::model::SessionStateDurable;
+
+pub(in crate::live::sessions::actor) fn persist_session_action_capabilities(
+    store: &dyn SessionStateDurable,
+    session_id: &str,
+    agent_kind: &str,
+    init_response: &acp::schema::InitializeResponse,
+) {
+    let capabilities = action_capabilities_from_acp(agent_kind, init_response);
+    let Ok(json) = serialize_action_capabilities(capabilities) else {
+        tracing::warn!(
+            session_id,
+            "failed to serialize session action capabilities"
+        );
+        return;
+    };
+    let now = chrono::Utc::now().to_rfc3339();
+    if let Err(error) = store.update_action_capabilities_json(session_id, Some(json), &now) {
+        tracing::warn!(
+            session_id,
+            error = %error,
+            "failed to persist session action capabilities"
+        );
+    }
+}
+
+pub(in crate::live::sessions::actor) fn action_capabilities_from_acp(
+    agent_kind: &str,
+    init_response: &acp::schema::InitializeResponse,
+) -> SessionActionCapabilities {
+    let agent_capabilities = &init_response.agent_capabilities;
+    let fork_capability = agent_capabilities.session_capabilities.fork.as_ref();
+    let fork = agent_capabilities.load_session && fork_capability.is_some();
+    let adapter_targeted_fork_ready = fork
+        && fork_capability
+            .and_then(|capability| capability.meta.as_ref())
+            .map(has_anyharness_targeted_fork_extension)
+            .unwrap_or(false);
+    if adapter_targeted_fork_ready {
+        tracing::debug!(
+            "agent advertises edit-safe targeted fork metadata; public targeted fork remains disabled until runtime target dispatch is implemented"
+        );
+    }
+    let (mut supports_loops, loops_native) =
+        loops_capability_from_init_meta(init_response.meta.as_ref());
+    // Runtime-emulated loops (Codex) never advertise `loops` in `_meta` — the
+    // sidecar has no LoopPort — but the runtime scheduler fully drives them.
+    // Advertise support so the ⟳ loops chip is reachable; `loops_native` stays
+    // false, marking the emulated (non-mirror) path.
+    if !supports_loops && crate::domains::loops::runtime::is_emulated_loop_agent_kind(agent_kind) {
+        supports_loops = true;
+    }
+    SessionActionCapabilities {
+        fork,
+        targeted_fork: false,
+        supports_goals: supports_goals_from_init_meta(init_response.meta.as_ref()),
+        supports_loops,
+        loops_native,
+    }
+}
+
+/// `InitializeResponse._meta.anyharness.goals` — the GoalPort capability
+/// advertisement (wire contract v1). Anything short of an explicit
+/// `{ schemaVersion: 1, goals: { supported: true } }` degrades to
+/// unsupported: stale sidecars must never break.
+fn supports_goals_from_init_meta(meta: Option<&acp::schema::Meta>) -> bool {
+    let Some(anyharness) = meta
+        .and_then(|meta| meta.get("anyharness"))
+        .and_then(|value| value.as_object())
+    else {
+        return false;
+    };
+    if anyharness
+        .get("schemaVersion")
+        .and_then(|value| value.as_u64())
+        != Some(1)
+    {
+        return false;
+    }
+    anyharness
+        .get("goals")
+        .and_then(|goals| goals.get("supported"))
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false)
+}
+
+/// `InitializeResponse._meta.anyharness.loops` — the LoopPort capability
+/// advertisement (wire contract v1: `{ supported, native }`). Same
+/// degrade-to-unsupported rule as goals: anything short of an explicit
+/// `{ schemaVersion: 1, loops: { supported: true } }` reports
+/// `(false, false)` so a stale sidecar never breaks. `native` is only
+/// meaningful when `supported` is true — claude-agent-acp advertises
+/// `native: true` (session crons); codex-acp omits `loops` entirely in v1
+/// (runtime-emulated by `LoopSchedulerExtension`, not the sidecar).
+fn loops_capability_from_init_meta(meta: Option<&acp::schema::Meta>) -> (bool, bool) {
+    let Some(anyharness) = meta
+        .and_then(|meta| meta.get("anyharness"))
+        .and_then(|value| value.as_object())
+    else {
+        return (false, false);
+    };
+    if anyharness
+        .get("schemaVersion")
+        .and_then(|value| value.as_u64())
+        != Some(1)
+    {
+        return (false, false);
+    }
+    let Some(loops) = anyharness.get("loops").and_then(|value| value.as_object()) else {
+        return (false, false);
+    };
+    let supported = loops
+        .get("supported")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+    if !supported {
+        return (false, false);
+    }
+    let native = loops
+        .get("native")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+    (true, native)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    fn init_meta(value: serde_json::Value) -> acp::schema::Meta {
+        let serde_json::Value::Object(map) = value else {
+            panic!("meta fixture must be an object");
+        };
+        acp::schema::Meta::from_iter(map)
+    }
+
+    #[test]
+    fn supports_goals_requires_schema_version_and_supported_flag() {
+        assert!(supports_goals_from_init_meta(Some(&init_meta(
+            serde_json::json!({
+                "anyharness": {
+                    "schemaVersion": 1,
+                    "goals": { "supported": true, "native": true }
+                }
+            })
+        ))));
+        assert!(!supports_goals_from_init_meta(Some(&init_meta(
+            serde_json::json!({
+                "anyharness": {
+                    "schemaVersion": 2,
+                    "goals": { "supported": true }
+                }
+            })
+        ))));
+        assert!(!supports_goals_from_init_meta(Some(&init_meta(
+            serde_json::json!({
+                "anyharness": { "schemaVersion": 1 }
+            })
+        ))));
+        assert!(!supports_goals_from_init_meta(Some(&init_meta(
+            serde_json::json!({
+                "anyharness": {
+                    "schemaVersion": 1,
+                    "goals": { "supported": false }
+                }
+            })
+        ))));
+        assert!(!supports_goals_from_init_meta(None));
+    }
+
+    #[test]
+    fn loops_capability_requires_schema_version_and_supported_flag() {
+        // claude-agent-acp: native loops.
+        assert_eq!(
+            loops_capability_from_init_meta(Some(&init_meta(serde_json::json!({
+                "anyharness": {
+                    "schemaVersion": 1,
+                    "loops": { "supported": true, "native": true }
+                }
+            })))),
+            (true, true)
+        );
+        // codex-acp v1: loops omitted entirely (runtime-emulated, not the
+        // sidecar) — degrades to unsupported.
+        assert_eq!(
+            loops_capability_from_init_meta(Some(&init_meta(serde_json::json!({
+                "anyharness": {
+                    "schemaVersion": 1,
+                    "goals": { "supported": true, "native": true }
+                }
+            })))),
+            (false, false)
+        );
+        // Wrong schema version degrades to unsupported even if the flag is set.
+        assert_eq!(
+            loops_capability_from_init_meta(Some(&init_meta(serde_json::json!({
+                "anyharness": {
+                    "schemaVersion": 2,
+                    "loops": { "supported": true, "native": true }
+                }
+            })))),
+            (false, false)
+        );
+        // Explicitly unsupported.
+        assert_eq!(
+            loops_capability_from_init_meta(Some(&init_meta(serde_json::json!({
+                "anyharness": {
+                    "schemaVersion": 1,
+                    "loops": { "supported": false }
+                }
+            })))),
+            (false, false)
+        );
+        // Supported but not native (a future runtime-emulated-by-sidecar case).
+        assert_eq!(
+            loops_capability_from_init_meta(Some(&init_meta(serde_json::json!({
+                "anyharness": {
+                    "schemaVersion": 1,
+                    "loops": { "supported": true, "native": false }
+                }
+            })))),
+            (true, false)
+        );
+        assert_eq!(loops_capability_from_init_meta(None), (false, false));
+    }
+
+    #[test]
+    fn action_capabilities_from_acp_wires_loops_capability_into_session_capabilities() {
+        let mut init_response =
+            acp::schema::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+        init_response.meta = Some(init_meta(serde_json::json!({
+            "anyharness": {
+                "schemaVersion": 1,
+                "goals": { "supported": true, "native": true },
+                "loops": { "supported": true, "native": true }
+            }
+        })));
+        let capabilities = action_capabilities_from_acp("claude", &init_response);
+        assert!(capabilities.supports_goals);
+        assert!(capabilities.supports_loops);
+        assert!(capabilities.loops_native);
+    }
+
+    #[test]
+    fn action_capabilities_from_acp_advertises_emulated_loops_for_codex() {
+        // codex-acp omits `loops` from `_meta` entirely, but the runtime
+        // emulates loops for it — the capability must still report supported so
+        // the ⟳ loops chip is reachable, with loops_native=false.
+        let init_response = acp::schema::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
+        let capabilities = action_capabilities_from_acp("codex", &init_response);
+        assert!(capabilities.supports_loops);
+        assert!(!capabilities.loops_native);
+
+        // A non-emulated kind with no `loops` meta stays unsupported.
+        let claude = action_capabilities_from_acp("claude", &init_response);
+        assert!(!claude.supports_loops);
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/command.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/command.rs
@@ -65,6 +65,32 @@ pub enum ForkSessionCommandError {
     Failed(String),
 }
 
+/// Result/errors for the OpenCode side-door targeted-fork actor
+/// operation. The parent actor owns the side-door state, validates the vendor
+/// message id (never dispatching unvalidated — the vendor silently full-copies
+/// unknown ids), and POSTs the fork. The child native session id is the vendor
+/// fork response `.id`.
+#[derive(Debug)]
+pub struct SidedoorForkCommandResult {
+    pub native_session_id: String,
+    pub supports_close: bool,
+}
+
+#[derive(Debug)]
+pub enum SidedoorForkCommandError {
+    /// The side-door was not `Ready` at dispatch time — a hard error, never a
+    /// silent tip fork.
+    NotReady(String),
+    /// Pre-validation: the vendor message id is absent, unknown, or not a user
+    /// message. Maps to the `TARGET_NOT_FOUND` family.
+    TargetNotFound,
+    /// Pre-validation: the id resolved but the listing/role contract did not
+    /// hold. Maps to the `INVALID_FORK_TARGET` family.
+    InvalidForkTarget(String),
+    Busy,
+    Failed(String),
+}
+
 #[derive(Clone, PartialEq)]
 pub enum Resolution {
     Selected {
@@ -203,6 +229,14 @@ pub(in crate::live::sessions) enum SessionCommand {
     Fork {
         respond_to: oneshot::Sender<Result<ForkSessionCommandResult, ForkSessionCommandError>>,
     },
+    /// OpenCode side-door targeted fork. Validated and dispatched
+    /// on the parent actor because the side-door (port + password + readiness)
+    /// is process-local actor state.
+    SidedoorTargetedFork {
+        vendor_message_id: String,
+        respond_to:
+            oneshot::Sender<Result<SidedoorForkCommandResult, SidedoorForkCommandError>>,
+    },
     CloseNativeSession {
         native_session_id: String,
         respond_to: oneshot::Sender<anyhow::Result<()>>,
@@ -250,7 +284,10 @@ impl SessionCommand {
     pub(in crate::live::sessions::actor) fn is_fork_lifecycle_command(&self) -> bool {
         matches!(
             self,
-            Self::VerifyForkReady { .. } | Self::Fork { .. } | Self::CloseNativeSession { .. }
+            Self::VerifyForkReady { .. }
+                | Self::Fork { .. }
+                | Self::SidedoorTargetedFork { .. }
+                | Self::CloseNativeSession { .. }
         )
     }
 }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/persist.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/persist.rs
@@ -257,3 +257,40 @@ pub(in crate::live::sessions::actor) fn push_persisted_control(
         current_value.clone(),
     ));
 }
+
+/// Shared startup-stage logging for `emit_live_config_update`/
+/// `restore_persisted_live_config_if_needed` call sites: a failed call logs
+/// both a short warning and the `[workspace-latency]` failure record; success
+/// logs the matching completion record. `stage` names the metric
+/// (`session.actor.<stage>.{failed,completed}`).
+pub(in crate::live::sessions::actor) fn log_config_stage_result<E: std::fmt::Display>(
+    session_id: &str,
+    workspace_id: &str,
+    result: &Result<(), E>,
+    elapsed: std::time::Duration,
+    short_failure_message: &str,
+    stage: &str,
+) {
+    match result {
+        Err(error) => {
+            tracing::warn!(session_id = %session_id, error = %error, "{}", short_failure_message);
+            tracing::warn!(
+                session_id = %session_id,
+                workspace_id = %workspace_id,
+                error = %error,
+                elapsed_ms = elapsed.as_millis(),
+                "[workspace-latency] session.actor.{}.failed",
+                stage
+            );
+        }
+        Ok(()) => {
+            tracing::info!(
+                session_id = %session_id,
+                workspace_id = %workspace_id,
+                elapsed_ms = elapsed.as_millis(),
+                "[workspace-latency] session.actor.{}.completed",
+                stage
+            );
+        }
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/fork/handle.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/fork/handle.rs
@@ -6,10 +6,13 @@ use tokio::sync::oneshot;
 
 use crate::domains::sessions::mcp_bindings::acp::to_acp_servers;
 use crate::domains::sessions::mcp_bindings::model::SessionMcpServer;
+use crate::domains::sessions::runtime::opencode_sidedoor_client::OpencodeSidedoorClient;
 use crate::live::sessions::actor::command::{
-    ForkSessionCommandError, ForkSessionCommandResult, SessionCommand,
+    ForkSessionCommandError, ForkSessionCommandResult, SessionCommand, SidedoorForkCommandError,
+    SidedoorForkCommandResult,
 };
 use crate::live::sessions::actor::state::SessionActor;
+use crate::live::sessions::driver::opencode_sidedoor::SidedoorRuntime;
 use crate::live::sessions::driver::shutdown::close_native_session;
 use crate::live::sessions::handle::LiveSessionHandle;
 use crate::live::sessions::model::QueueDurable;
@@ -40,6 +43,19 @@ impl SessionActor {
                     self.caps.queue.as_ref(),
                     &self.session_id,
                     self.action_capabilities,
+                    self.supports_native_close,
+                )
+                .await;
+                let _ = respond_to.send(result);
+            }
+            SessionCommand::SidedoorTargetedFork {
+                vendor_message_id,
+                respond_to,
+            } => {
+                let result = sidedoor_targeted_fork(
+                    self.sidedoor.as_ref(),
+                    &self.native_session_id,
+                    &vendor_message_id,
                     self.supports_native_close,
                 )
                 .await;
@@ -87,6 +103,66 @@ pub(in crate::live::sessions::actor) async fn fork_native_session(
         .map_err(|error| ForkSessionCommandError::Failed(error.to_string()))?;
     Ok(ForkSessionCommandResult {
         native_session_id: response.session_id.to_string(),
+        supports_close,
+    })
+}
+
+/// The OpenCode side-door targeted-fork actor operation. Runs on
+/// the parent actor because the side-door state (port + password + readiness)
+/// is process-local. Never dispatches an unvalidated id: the vendor does no
+/// existence check and would silently full-copy an unknown id, so this
+/// pre-validates the exact id via `get_message` (must be role "user") AND
+/// `list_messages` membership BEFORE any fork POST.
+pub(in crate::live::sessions::actor) async fn sidedoor_targeted_fork(
+    sidedoor: Option<&SidedoorRuntime>,
+    native_session_id: &str,
+    vendor_message_id: &str,
+    supports_close: bool,
+) -> Result<SidedoorForkCommandResult, SidedoorForkCommandError> {
+    // A non-Ready side-door at dispatch time is a hard error, never a silent
+    // tip fork.
+    let runtime = sidedoor.filter(|runtime| runtime.is_ready()).ok_or_else(|| {
+        SidedoorForkCommandError::NotReady(
+            "OpenCode side-door is not ready for targeted fork dispatch".to_string(),
+        )
+    })?;
+    let client = OpencodeSidedoorClient::new(runtime.config.port, runtime.config.password.clone())
+        .map_err(|error| SidedoorForkCommandError::Failed(error.to_string()))?;
+
+    // Pre-validation gate 1: the id must resolve to a user message.
+    let message = client
+        .get_message(native_session_id, vendor_message_id)
+        .await
+        .map_err(|_| SidedoorForkCommandError::TargetNotFound)?;
+    if message.info.role != "user" {
+        return Err(SidedoorForkCommandError::TargetNotFound);
+    }
+    if message.info.id != vendor_message_id {
+        return Err(SidedoorForkCommandError::InvalidForkTarget(
+            "vendor returned a different message id than requested".to_string(),
+        ));
+    }
+    // Pre-validation gate 2: the id must be present in the message listing.
+    let listing = client
+        .list_messages(native_session_id)
+        .await
+        .map_err(|error| SidedoorForkCommandError::Failed(error.to_string()))?;
+    if !listing
+        .iter()
+        .any(|envelope| envelope.info.id == vendor_message_id)
+    {
+        return Err(SidedoorForkCommandError::InvalidForkTarget(
+            "target message id not present in vendor listing".to_string(),
+        ));
+    }
+
+    // Validated: dispatch the fork POST.
+    let forked = client
+        .fork(native_session_id, Some(vendor_message_id))
+        .await
+        .map_err(|error| SidedoorForkCommandError::Failed(error.to_string()))?;
+    Ok(SidedoorForkCommandResult {
+        native_session_id: forked.id,
         supports_close,
     })
 }
@@ -147,4 +223,368 @@ pub(in crate::live::sessions::actor) fn reject_busy_close_native_child_session(
     let _ = respond_to.send(Err(anyhow::anyhow!(
         "cannot close native child session while parent session is busy"
     )));
+}
+
+#[cfg(test)]
+mod sidedoor_fork_tests {
+    //! Pre-validation matrix and dispatch contract for the
+    //! OpenCode side-door targeted fork, exercised against an in-process fake
+    //! side-door HTTP server (std `TcpListener`). The cardinal sin the vendor
+    //! commits — silently full-copying an unknown message id — means every one
+    //! of these paths MUST hard-error rather than dispatch unvalidated.
+
+    use std::collections::HashMap;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::{Arc, Mutex};
+
+    use super::{sidedoor_targeted_fork, SidedoorForkCommandError};
+    use crate::live::sessions::driver::opencode_sidedoor::{
+        SidedoorRuntime, SidedoorSpawnConfig, SidedoorState,
+    };
+
+    /// Fake side-door behavior. `messages` maps a message id to the role
+    /// `get_message` reports (absent ⇒ 404); `listing` is what
+    /// `list_messages` returns.
+    #[derive(Clone)]
+    struct Scenario {
+        messages: HashMap<String, String>,
+        listing: Vec<String>,
+    }
+
+    /// Spawns a detached fake side-door server on loopback. Returns the bound
+    /// port and a handle to the recorded fork request bodies. The server loops
+    /// forever serving connections; the test process reaps the thread on exit.
+    fn spawn_fake_sidedoor(scenario: Scenario) -> (u16, Arc<Mutex<Vec<String>>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake side-door");
+        let port = listener.local_addr().expect("addr").port();
+        let bodies: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let bodies_for_thread = bodies.clone();
+        std::thread::spawn(move || {
+            let mut child_counter = 0u32;
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let mut buf = Vec::new();
+                let mut chunk = [0u8; 2048];
+                // Read until we have the header terminator, then any body.
+                let header_end = loop {
+                    let read = match stream.read(&mut chunk) {
+                        Ok(0) => break None,
+                        Ok(n) => n,
+                        Err(_) => break None,
+                    };
+                    buf.extend_from_slice(&chunk[..read]);
+                    if let Some(pos) = find_subslice(&buf, b"\r\n\r\n") {
+                        break Some(pos);
+                    }
+                };
+                let Some(header_end) = header_end else { continue };
+                let headers = String::from_utf8_lossy(&buf[..header_end]).to_string();
+                let request_line = headers.lines().next().unwrap_or_default().to_string();
+                let mut parts = request_line.split_whitespace();
+                let method = parts.next().unwrap_or_default().to_string();
+                let path = parts.next().unwrap_or_default().to_string();
+
+                // Read the rest of the body per Content-Length (POST fork).
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        let lower = line.to_ascii_lowercase();
+                        lower
+                            .strip_prefix("content-length:")
+                            .map(|value| value.trim().parse::<usize>().unwrap_or(0))
+                    })
+                    .unwrap_or(0);
+                let mut body = buf[header_end + 4..].to_vec();
+                while body.len() < content_length {
+                    let read = match stream.read(&mut chunk) {
+                        Ok(0) => break,
+                        Ok(n) => n,
+                        Err(_) => break,
+                    };
+                    body.extend_from_slice(&chunk[..read]);
+                }
+
+                let response = route(
+                    &method,
+                    &path,
+                    &body,
+                    &scenario,
+                    &bodies_for_thread,
+                    &mut child_counter,
+                );
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+        (port, bodies)
+    }
+
+    fn route(
+        method: &str,
+        path: &str,
+        body: &[u8],
+        scenario: &Scenario,
+        bodies: &Arc<Mutex<Vec<String>>>,
+        child_counter: &mut u32,
+    ) -> String {
+        // POST /session/{id}/fork
+        if method == "POST" && path.ends_with("/fork") {
+            bodies
+                .lock()
+                .expect("bodies lock")
+                .push(String::from_utf8_lossy(body).to_string());
+            *child_counter += 1;
+            let child_id = format!("child_{child_counter}");
+            return json_ok(&format!("{{\"id\":\"{child_id}\"}}"));
+        }
+        // GET /session/{id}/message  (listing)  — no trailing message id.
+        if method == "GET" && path.ends_with("/message") {
+            let items: Vec<String> = scenario
+                .listing
+                .iter()
+                .map(|id| {
+                    let role = scenario.messages.get(id).cloned().unwrap_or_else(|| "user".to_string());
+                    format!("{{\"info\":{{\"id\":\"{id}\",\"role\":\"{role}\"}}}}")
+                })
+                .collect();
+            return json_ok(&format!("[{}]", items.join(",")));
+        }
+        // GET /session/{id}/message/{messageID}
+        if method == "GET" {
+            if let Some(message_id) = path.rsplit('/').next() {
+                if let Some(role) = scenario.messages.get(message_id) {
+                    return json_ok(&format!(
+                        "{{\"info\":{{\"id\":\"{message_id}\",\"role\":\"{role}\"}}}}"
+                    ));
+                }
+                return not_found();
+            }
+        }
+        not_found()
+    }
+
+    fn json_ok(body: &str) -> String {
+        format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        )
+    }
+
+    fn not_found() -> String {
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".to_string()
+    }
+
+    fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+        haystack
+            .windows(needle.len())
+            .position(|window| window == needle)
+    }
+
+    fn ready_runtime(port: u16) -> SidedoorRuntime {
+        SidedoorRuntime {
+            config: SidedoorSpawnConfig {
+                port,
+                password: "test-password-0000000000000000".to_string(),
+            },
+            state: SidedoorState::Ready { port },
+        }
+    }
+
+    fn user_scenario(id: &str) -> Scenario {
+        let mut messages = HashMap::new();
+        messages.insert(id.to_string(), "user".to_string());
+        Scenario {
+            messages,
+            listing: vec![id.to_string()],
+        }
+    }
+
+    #[tokio::test]
+    async fn happy_path_validates_and_dispatches() {
+        let (port, bodies) = spawn_fake_sidedoor(user_scenario("msg_target"));
+        let runtime = ready_runtime(port);
+        let result =
+            sidedoor_targeted_fork(Some(&runtime), "native_session", "msg_target", true)
+                .await
+                .expect("validated fork dispatches");
+        assert_eq!(result.native_session_id, "child_1");
+        let recorded = bodies.lock().expect("bodies");
+        assert_eq!(recorded.len(), 1);
+        assert!(recorded[0].contains("\"messageID\":\"msg_target\""));
+    }
+
+    #[tokio::test]
+    async fn absent_message_is_target_not_found() {
+        // get_message 404: the id does not exist on the vendor at all.
+        let (port, _bodies) = spawn_fake_sidedoor(Scenario {
+            messages: HashMap::new(),
+            listing: vec![],
+        });
+        let runtime = ready_runtime(port);
+        let error = sidedoor_targeted_fork(Some(&runtime), "native_session", "msg_missing", true)
+            .await
+            .expect_err("absent id must hard-error");
+        assert!(matches!(error, SidedoorForkCommandError::TargetNotFound));
+    }
+
+    #[tokio::test]
+    async fn non_user_role_is_target_not_found() {
+        let mut messages = HashMap::new();
+        messages.insert("msg_assistant".to_string(), "assistant".to_string());
+        let (port, _bodies) = spawn_fake_sidedoor(Scenario {
+            messages,
+            listing: vec!["msg_assistant".to_string()],
+        });
+        let runtime = ready_runtime(port);
+        let error = sidedoor_targeted_fork(Some(&runtime), "native_session", "msg_assistant", true)
+            .await
+            .expect_err("non-user role must hard-error");
+        assert!(matches!(error, SidedoorForkCommandError::TargetNotFound));
+    }
+
+    #[tokio::test]
+    async fn absent_from_listing_is_invalid_fork_target() {
+        // get_message resolves the id as a user message, but the listing omits
+        // it — the membership contract fails, so never dispatch.
+        let mut messages = HashMap::new();
+        messages.insert("msg_ghost".to_string(), "user".to_string());
+        let (port, bodies) = spawn_fake_sidedoor(Scenario {
+            messages,
+            listing: vec![],
+        });
+        let runtime = ready_runtime(port);
+        let error = sidedoor_targeted_fork(Some(&runtime), "native_session", "msg_ghost", true)
+            .await
+            .expect_err("listing mismatch must hard-error");
+        assert!(matches!(
+            error,
+            SidedoorForkCommandError::InvalidForkTarget(_)
+        ));
+        assert!(bodies.lock().expect("bodies").is_empty(), "must not dispatch");
+    }
+
+    #[tokio::test]
+    async fn two_boundaries_produce_distinct_dispatches() {
+        let mut messages = HashMap::new();
+        messages.insert("msg_one".to_string(), "user".to_string());
+        messages.insert("msg_two".to_string(), "user".to_string());
+        let (port, bodies) = spawn_fake_sidedoor(Scenario {
+            messages,
+            listing: vec!["msg_one".to_string(), "msg_two".to_string()],
+        });
+        let runtime = ready_runtime(port);
+        let first = sidedoor_targeted_fork(Some(&runtime), "native_session", "msg_one", true)
+            .await
+            .expect("first fork");
+        let second = sidedoor_targeted_fork(Some(&runtime), "native_session", "msg_two", true)
+            .await
+            .expect("second fork");
+        assert_ne!(first.native_session_id, second.native_session_id);
+        let recorded = bodies.lock().expect("bodies");
+        assert_eq!(recorded.len(), 2);
+        assert!(recorded[0].contains("\"messageID\":\"msg_one\""));
+        assert!(recorded[1].contains("\"messageID\":\"msg_two\""));
+    }
+
+    #[tokio::test]
+    async fn non_ready_side_door_is_hard_error_not_tip_fork() {
+        let runtime = SidedoorRuntime {
+            config: SidedoorSpawnConfig {
+                port: 1,
+                password: "unused".to_string(),
+            },
+            state: SidedoorState::Unavailable,
+        };
+        let error = sidedoor_targeted_fork(Some(&runtime), "native_session", "msg_target", true)
+            .await
+            .expect_err("non-ready side-door must hard-error");
+        assert!(matches!(error, SidedoorForkCommandError::NotReady(_)));
+    }
+
+    #[tokio::test]
+    async fn absent_side_door_is_hard_error() {
+        let error = sidedoor_targeted_fork(None, "native_session", "msg_target", true)
+            .await
+            .expect_err("missing side-door must hard-error");
+        assert!(matches!(error, SidedoorForkCommandError::NotReady(_)));
+    }
+
+    /// The vendor's first silent-failure direction (Q-C4): a messageID sorting
+    /// lexicographically AFTER every real id makes upstream `Session.fork`
+    /// run its ascending copy loop to completion and silently FULL-COPY the
+    /// session. Our exact-membership guard is ordering-blind, so an id the
+    /// vendor never issued is rejected before any POST — the full copy can
+    /// never happen through the bridge.
+    #[tokio::test]
+    async fn unknown_id_sorting_after_all_real_ids_never_dispatches() {
+        let mut messages = HashMap::new();
+        messages.insert("msg_00000000000aaa".to_string(), "user".to_string());
+        messages.insert("msg_00000000000bbb".to_string(), "user".to_string());
+        let (port, bodies) = spawn_fake_sidedoor(Scenario {
+            messages,
+            listing: vec![
+                "msg_00000000000aaa".to_string(),
+                "msg_00000000000bbb".to_string(),
+            ],
+        });
+        let runtime = ready_runtime(port);
+        // Sorts after every real id; upstream would full-copy on this id.
+        let error = sidedoor_targeted_fork(Some(&runtime), "native_session", "msg_zzzzzzzzzzzzzz", true)
+            .await
+            .expect_err("an id sorting after all real ids must hard-error, never full-copy");
+        assert!(matches!(error, SidedoorForkCommandError::TargetNotFound));
+        assert!(
+            bodies.lock().expect("bodies").is_empty(),
+            "the silent full-copy path must never be reached"
+        );
+    }
+
+    /// The vendor's second silent-failure direction (Q-C4, new hazard beyond
+    /// the frozen record): a messageID sorting BEFORE every real id breaks the
+    /// copy loop on the first iteration and silently produces a near-EMPTY
+    /// fork. Same guard, opposite direction — rejected before dispatch.
+    #[tokio::test]
+    async fn unknown_id_sorting_before_all_real_ids_never_dispatches() {
+        let mut messages = HashMap::new();
+        messages.insert("msg_zzzzzzzzzzzaaa".to_string(), "user".to_string());
+        messages.insert("msg_zzzzzzzzzzzbbb".to_string(), "user".to_string());
+        let (port, bodies) = spawn_fake_sidedoor(Scenario {
+            messages,
+            listing: vec![
+                "msg_zzzzzzzzzzzaaa".to_string(),
+                "msg_zzzzzzzzzzzbbb".to_string(),
+            ],
+        });
+        let runtime = ready_runtime(port);
+        // Sorts before every real id; upstream would near-empty-fork on this id.
+        let error = sidedoor_targeted_fork(Some(&runtime), "native_session", "msg_0000000000000", true)
+            .await
+            .expect_err("an id sorting before all real ids must hard-error, never near-empty-fork");
+        assert!(matches!(error, SidedoorForkCommandError::TargetNotFound));
+        assert!(
+            bodies.lock().expect("bodies").is_empty(),
+            "the silent near-empty-fork path must never be reached"
+        );
+    }
+
+    /// A validated dispatch ALWAYS carries an explicit messageID in the fork
+    /// body — the bridge never relies on the vendor's optional-field tip-fork
+    /// default for a targeted fork. The dispatch signature takes `&str`, not
+    /// `Option`, so omission is structurally impossible; this pins the wire
+    /// shape that proves it (an omitted id would be a bodyless `{}` tip fork).
+    #[tokio::test]
+    async fn targeted_dispatch_always_sends_an_explicit_message_id() {
+        let (port, bodies) = spawn_fake_sidedoor(user_scenario("msg_target"));
+        let runtime = ready_runtime(port);
+        sidedoor_targeted_fork(Some(&runtime), "native_session", "msg_target", true)
+            .await
+            .expect("validated fork dispatches");
+        let recorded = bodies.lock().expect("bodies");
+        assert_eq!(recorded.len(), 1);
+        assert!(
+            recorded[0].contains("\"messageID\":\"msg_target\""),
+            "targeted fork body must carry the explicit messageID, never an omitted tip default"
+        );
+    }
 }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/mod.rs
@@ -1,4 +1,5 @@
 mod background_work;
+mod capabilities;
 pub(in crate::live::sessions) mod command;
 mod config;
 mod fork;

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/notifications/dispatch.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/notifications/dispatch.rs
@@ -133,6 +133,32 @@ pub(in crate::live::sessions::actor) async fn apply_actor_update(
             let mut sink = event_sink.lock().await;
             sink.session_info_update(payload);
         }
+        ActorBoundUpdate::OpencodeUserMessageId {
+            turn_id,
+            item_id,
+            vendor_message_id,
+        } => {
+            // Persist the vendor message-id binding only for
+            // opencode — the sink emits the binding meaning-blind for any kind,
+            // the actor (which knows the kind) is the gate. First-writer-wins:
+            // a replayed/duplicate echo is a no-op (ON CONFLICT DO NOTHING).
+            if source_agent_kind == crate::domains::agents::model::AgentKind::OpenCode.as_str() {
+                let now = chrono::Utc::now().to_rfc3339();
+                if let Err(error) = session_store.insert_opencode_message_id(
+                    session_id,
+                    &turn_id,
+                    &item_id,
+                    &vendor_message_id,
+                    &now,
+                ) {
+                    tracing::warn!(
+                        session_id = %session_id,
+                        error = %error,
+                        "failed to persist opencode message-id binding"
+                    );
+                }
+            }
+        }
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
@@ -2,18 +2,21 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use agent_client_protocol as acp;
-use anyharness_contract::v1::{SessionActionCapabilities, SessionExecutionPhase};
+use anyharness_contract::v1::SessionExecutionPhase;
 use tokio::sync::{mpsc, Mutex};
 
-use crate::domains::sessions::model::serialize_action_capabilities;
 use crate::domains::sessions::model::RequestedModeApplyError as ModeApplyError;
 use crate::domains::sessions::prompt::capabilities::capabilities_from_acp;
+use crate::live::sessions::actor::capabilities::{
+    action_capabilities_from_acp, persist_session_action_capabilities,
+};
 use crate::live::sessions::actor::config::apply::restore_persisted_live_config_if_needed;
 use crate::live::sessions::actor::config::handle::{
     apply_requested_mode_preference, apply_requested_model_preference,
 };
 use crate::live::sessions::actor::config::persist::{
     emit_live_config_update, emit_startup_state, load_startup_restore_snapshot,
+    log_config_stage_result,
 };
 use crate::live::sessions::actor::config::types::PersistedSessionConfigState;
 use crate::live::sessions::actor::notifications::replay_filter::ResumeReplayFilter;
@@ -23,14 +26,14 @@ use crate::live::sessions::background_work::{
 };
 use crate::live::sessions::driver::connection::establish_connection;
 use crate::live::sessions::driver::inbound::InboundDoor;
-use crate::live::sessions::driver::native_session::{
-    has_anyharness_targeted_fork_extension, start_native_session,
+use crate::live::sessions::driver::native_session::start_native_session;
+use crate::live::sessions::driver::opencode_sidedoor::{
+    derive_sidedoor_capability, provision_sidedoor_spawn,
 };
 use crate::live::sessions::driver::process::spawn_agent_process;
 use crate::live::sessions::driver::session_lifecycle::initialize_connection;
 use crate::live::sessions::driver::types::NativeSessionStartupDisposition;
 use crate::live::sessions::handle::LiveSessionHandle;
-use crate::live::sessions::model::SessionStateDurable;
 use crate::live::sessions::sink::SessionEventSink;
 use crate::observability::AGENT_STDERR_TRACING_TARGET;
 
@@ -42,7 +45,7 @@ impl SessionActor {
     /// which stay out of the struct (they are threaded through the run loop
     /// as parameters).
     pub(in crate::live::sessions::actor) async fn start(
-        config: SessionActorConfig,
+        mut config: SessionActorConfig,
         ready_tx: std::sync::mpsc::Sender<anyhow::Result<String>>,
         handle: Arc<LiveSessionHandle>,
     ) -> anyhow::Result<(
@@ -56,6 +59,13 @@ impl SessionActor {
         let startup_strategy = config.launch.startup.clone();
         let startup_strategy_label = startup_strategy.as_str();
         let startup_started = Instant::now();
+
+        // See `opencode_sidedoor::provision_sidedoor_spawn`: for OpenCode
+        // only, provisions the HTTP side-door (fresh loopback port +
+        // Basic-auth password) and mutates `config.launch.env` to wire it
+        // into the spawned process.
+        let sidedoor_config =
+            provision_sidedoor_spawn(&source_agent_kind, &mut config.launch.env, &session_id);
 
         let spawned = spawn_agent_process(
             &config.launch.agent,
@@ -160,7 +170,7 @@ impl SessionActor {
             .await?;
             anyhow::Ok((init_response, action_capabilities, native))
         };
-        let (init_response, action_capabilities, native_session) = tokio::select! {
+        let (init_response, mut action_capabilities, native_session) = tokio::select! {
             // Biased so a handshake that completed on the same poll as the
             // exit (agent answered and then died) is reported as the success
             // it was; the exit arm only fires while it is genuinely pending.
@@ -205,6 +215,35 @@ impl SessionActor {
         startup_state.prompt_capabilities =
             capabilities_from_acp(Some(&init_response.agent_capabilities.prompt_capabilities));
 
+        // See `opencode_sidedoor::derive_sidedoor_capability`: with the vendor
+        // server up (native session established), runs the fail-closed
+        // side-door readiness check and derives `targeted_fork` for OpenCode.
+        // Every other kind keeps the hardcoded `false` from
+        // `action_capabilities_from_acp`.
+        let sidedoor = if let Some(config_sd) = sidedoor_config {
+            let native_id = native_session_id.to_string();
+            let resolved_native_version = config
+                .launch
+                .agent
+                .native
+                .as_ref()
+                .and_then(|artifact| artifact.version.clone());
+            Some(
+                derive_sidedoor_capability(
+                    config_sd,
+                    &native_id,
+                    &session_id,
+                    &workspace_id,
+                    resolved_native_version.as_deref(),
+                    &mut action_capabilities,
+                    config.caps.state.as_ref(),
+                )
+                .await,
+            )
+        } else {
+            None
+        };
+
         tracing::info!(
             target: "anyharness.session.established",
             session_id = %session_id,
@@ -231,7 +270,7 @@ impl SessionActor {
             emit_startup_state(&mut sink, &startup_state);
         }
         let initial_live_config_started = Instant::now();
-        if let Err(error) = emit_live_config_update(
+        let result = emit_live_config_update(
             &source_agent_kind,
             &session_id,
             config.caps.state.as_ref(),
@@ -240,24 +279,15 @@ impl SessionActor {
             &mut startup_state,
             chrono::Utc::now().to_rfc3339(),
         )
-        .await
-        {
-            tracing::warn!(session_id = %session_id, error = %error, "failed to persist initial live config snapshot");
-            tracing::warn!(
-                session_id = %session_id,
-                workspace_id = %workspace_id,
-                error = %error,
-                elapsed_ms = initial_live_config_started.elapsed().as_millis(),
-                "[workspace-latency] session.actor.initial_live_config.failed"
-            );
-        } else {
-            tracing::info!(
-                session_id = %session_id,
-                workspace_id = %workspace_id,
-                elapsed_ms = initial_live_config_started.elapsed().as_millis(),
-                "[workspace-latency] session.actor.initial_live_config.completed"
-            );
-        }
+        .await;
+        log_config_stage_result(
+            &session_id,
+            &workspace_id,
+            &result,
+            initial_live_config_started.elapsed(),
+            "failed to persist initial live config snapshot",
+            "initial_live_config",
+        );
         apply_requested_model_preference(
             &conn,
             &native_session_id,
@@ -266,7 +296,7 @@ impl SessionActor {
         )
         .await;
         let restore_live_config_started = Instant::now();
-        if let Err(error) = restore_persisted_live_config_if_needed(
+        let result = restore_persisted_live_config_if_needed(
             &conn,
             &native_session_id,
             &source_agent_kind,
@@ -277,24 +307,15 @@ impl SessionActor {
             &mut startup_state,
             startup_restore_snapshot.as_ref(),
         )
-        .await
-        {
-            tracing::warn!(session_id = %session_id, error = %error, "failed to restore persisted live config");
-            tracing::warn!(
-                session_id = %session_id,
-                workspace_id = %workspace_id,
-                error = %error,
-                elapsed_ms = restore_live_config_started.elapsed().as_millis(),
-                "[workspace-latency] session.actor.restore_live_config.failed"
-            );
-        } else {
-            tracing::info!(
-                session_id = %session_id,
-                workspace_id = %workspace_id,
-                elapsed_ms = restore_live_config_started.elapsed().as_millis(),
-                "[workspace-latency] session.actor.restore_live_config.completed"
-            );
-        }
+        .await;
+        log_config_stage_result(
+            &session_id,
+            &workspace_id,
+            &result,
+            restore_live_config_started.elapsed(),
+            "failed to restore persisted live config",
+            "restore_live_config",
+        );
         if let Err(error) = apply_requested_mode_preference(
             &conn,
             &native_session_id,
@@ -308,7 +329,7 @@ impl SessionActor {
             return Err(error);
         }
         let post_preferences_live_config_started = Instant::now();
-        if let Err(error) = emit_live_config_update(
+        let result = emit_live_config_update(
             &source_agent_kind,
             &session_id,
             config.caps.state.as_ref(),
@@ -317,24 +338,15 @@ impl SessionActor {
             &mut startup_state,
             chrono::Utc::now().to_rfc3339(),
         )
-        .await
-        {
-            tracing::warn!(session_id = %session_id, error = %error, "failed to persist post-preference live config snapshot");
-            tracing::warn!(
-                session_id = %session_id,
-                workspace_id = %workspace_id,
-                error = %error,
-                elapsed_ms = post_preferences_live_config_started.elapsed().as_millis(),
-                "[workspace-latency] session.actor.post_preferences_live_config.failed"
-            );
-        } else {
-            tracing::info!(
-                session_id = %session_id,
-                workspace_id = %workspace_id,
-                elapsed_ms = post_preferences_live_config_started.elapsed().as_millis(),
-                "[workspace-latency] session.actor.post_preferences_live_config.completed"
-            );
-        }
+        .await;
+        log_config_stage_result(
+            &session_id,
+            &workspace_id,
+            &result,
+            post_preferences_live_config_started.elapsed(),
+            "failed to persist post-preference live config snapshot",
+            "post_preferences_live_config",
+        );
 
         let _ = ready_tx.send(Ok(native_session_id.to_string()));
         handle
@@ -379,6 +391,7 @@ impl SessionActor {
             native_session_id,
             action_capabilities,
             supports_native_close,
+            sidedoor,
             conn,
             caps,
             hooks,
@@ -392,259 +405,3 @@ impl SessionActor {
     }
 }
 
-pub(in crate::live::sessions::actor) fn persist_session_action_capabilities(
-    store: &dyn SessionStateDurable,
-    session_id: &str,
-    agent_kind: &str,
-    init_response: &acp::schema::InitializeResponse,
-) {
-    let capabilities = action_capabilities_from_acp(agent_kind, init_response);
-    let Ok(json) = serialize_action_capabilities(capabilities) else {
-        tracing::warn!(
-            session_id,
-            "failed to serialize session action capabilities"
-        );
-        return;
-    };
-    let now = chrono::Utc::now().to_rfc3339();
-    if let Err(error) = store.update_action_capabilities_json(session_id, Some(json), &now) {
-        tracing::warn!(
-            session_id,
-            error = %error,
-            "failed to persist session action capabilities"
-        );
-    }
-}
-
-pub(in crate::live::sessions::actor) fn action_capabilities_from_acp(
-    agent_kind: &str,
-    init_response: &acp::schema::InitializeResponse,
-) -> SessionActionCapabilities {
-    let agent_capabilities = &init_response.agent_capabilities;
-    let fork_capability = agent_capabilities.session_capabilities.fork.as_ref();
-    let fork = agent_capabilities.load_session && fork_capability.is_some();
-    let adapter_targeted_fork_ready = fork
-        && fork_capability
-            .and_then(|capability| capability.meta.as_ref())
-            .map(has_anyharness_targeted_fork_extension)
-            .unwrap_or(false);
-    if adapter_targeted_fork_ready {
-        tracing::debug!(
-            "agent advertises edit-safe targeted fork metadata; public targeted fork remains disabled until runtime target dispatch is implemented"
-        );
-    }
-    let (mut supports_loops, loops_native) =
-        loops_capability_from_init_meta(init_response.meta.as_ref());
-    // Runtime-emulated loops (Codex) never advertise `loops` in `_meta` — the
-    // sidecar has no LoopPort — but the runtime scheduler fully drives them.
-    // Advertise support so the ⟳ loops chip is reachable; `loops_native` stays
-    // false, marking the emulated (non-mirror) path.
-    if !supports_loops && crate::domains::loops::runtime::is_emulated_loop_agent_kind(agent_kind) {
-        supports_loops = true;
-    }
-    SessionActionCapabilities {
-        fork,
-        targeted_fork: false,
-        supports_goals: supports_goals_from_init_meta(init_response.meta.as_ref()),
-        supports_loops,
-        loops_native,
-    }
-}
-
-/// `InitializeResponse._meta.anyharness.goals` — the GoalPort capability
-/// advertisement (wire contract v1). Anything short of an explicit
-/// `{ schemaVersion: 1, goals: { supported: true } }` degrades to
-/// unsupported: stale sidecars must never break.
-fn supports_goals_from_init_meta(meta: Option<&acp::schema::Meta>) -> bool {
-    let Some(anyharness) = meta
-        .and_then(|meta| meta.get("anyharness"))
-        .and_then(|value| value.as_object())
-    else {
-        return false;
-    };
-    if anyharness
-        .get("schemaVersion")
-        .and_then(|value| value.as_u64())
-        != Some(1)
-    {
-        return false;
-    }
-    anyharness
-        .get("goals")
-        .and_then(|goals| goals.get("supported"))
-        .and_then(|value| value.as_bool())
-        .unwrap_or(false)
-}
-
-/// `InitializeResponse._meta.anyharness.loops` — the LoopPort capability
-/// advertisement (wire contract v1: `{ supported, native }`). Same
-/// degrade-to-unsupported rule as goals: anything short of an explicit
-/// `{ schemaVersion: 1, loops: { supported: true } }` reports
-/// `(false, false)` so a stale sidecar never breaks. `native` is only
-/// meaningful when `supported` is true — claude-agent-acp advertises
-/// `native: true` (session crons); codex-acp omits `loops` entirely in v1
-/// (runtime-emulated by `LoopSchedulerExtension`, not the sidecar).
-fn loops_capability_from_init_meta(meta: Option<&acp::schema::Meta>) -> (bool, bool) {
-    let Some(anyharness) = meta
-        .and_then(|meta| meta.get("anyharness"))
-        .and_then(|value| value.as_object())
-    else {
-        return (false, false);
-    };
-    if anyharness
-        .get("schemaVersion")
-        .and_then(|value| value.as_u64())
-        != Some(1)
-    {
-        return (false, false);
-    }
-    let Some(loops) = anyharness.get("loops").and_then(|value| value.as_object()) else {
-        return (false, false);
-    };
-    let supported = loops
-        .get("supported")
-        .and_then(|value| value.as_bool())
-        .unwrap_or(false);
-    if !supported {
-        return (false, false);
-    }
-    let native = loops
-        .get("native")
-        .and_then(|value| value.as_bool())
-        .unwrap_or(false);
-    (true, native)
-}
-
-#[cfg(all(test, unix))]
-mod tests {
-    use super::*;
-
-    fn init_meta(value: serde_json::Value) -> acp::schema::Meta {
-        let serde_json::Value::Object(map) = value else {
-            panic!("meta fixture must be an object");
-        };
-        acp::schema::Meta::from_iter(map)
-    }
-
-    #[test]
-    fn supports_goals_requires_schema_version_and_supported_flag() {
-        assert!(supports_goals_from_init_meta(Some(&init_meta(
-            serde_json::json!({
-                "anyharness": {
-                    "schemaVersion": 1,
-                    "goals": { "supported": true, "native": true }
-                }
-            })
-        ))));
-        assert!(!supports_goals_from_init_meta(Some(&init_meta(
-            serde_json::json!({
-                "anyharness": {
-                    "schemaVersion": 2,
-                    "goals": { "supported": true }
-                }
-            })
-        ))));
-        assert!(!supports_goals_from_init_meta(Some(&init_meta(
-            serde_json::json!({
-                "anyharness": { "schemaVersion": 1 }
-            })
-        ))));
-        assert!(!supports_goals_from_init_meta(Some(&init_meta(
-            serde_json::json!({
-                "anyharness": {
-                    "schemaVersion": 1,
-                    "goals": { "supported": false }
-                }
-            })
-        ))));
-        assert!(!supports_goals_from_init_meta(None));
-    }
-
-    #[test]
-    fn loops_capability_requires_schema_version_and_supported_flag() {
-        // claude-agent-acp: native loops.
-        assert_eq!(
-            loops_capability_from_init_meta(Some(&init_meta(serde_json::json!({
-                "anyharness": {
-                    "schemaVersion": 1,
-                    "loops": { "supported": true, "native": true }
-                }
-            })))),
-            (true, true)
-        );
-        // codex-acp v1: loops omitted entirely (runtime-emulated, not the
-        // sidecar) — degrades to unsupported.
-        assert_eq!(
-            loops_capability_from_init_meta(Some(&init_meta(serde_json::json!({
-                "anyharness": {
-                    "schemaVersion": 1,
-                    "goals": { "supported": true, "native": true }
-                }
-            })))),
-            (false, false)
-        );
-        // Wrong schema version degrades to unsupported even if the flag is set.
-        assert_eq!(
-            loops_capability_from_init_meta(Some(&init_meta(serde_json::json!({
-                "anyharness": {
-                    "schemaVersion": 2,
-                    "loops": { "supported": true, "native": true }
-                }
-            })))),
-            (false, false)
-        );
-        // Explicitly unsupported.
-        assert_eq!(
-            loops_capability_from_init_meta(Some(&init_meta(serde_json::json!({
-                "anyharness": {
-                    "schemaVersion": 1,
-                    "loops": { "supported": false }
-                }
-            })))),
-            (false, false)
-        );
-        // Supported but not native (a future runtime-emulated-by-sidecar case).
-        assert_eq!(
-            loops_capability_from_init_meta(Some(&init_meta(serde_json::json!({
-                "anyharness": {
-                    "schemaVersion": 1,
-                    "loops": { "supported": true, "native": false }
-                }
-            })))),
-            (true, false)
-        );
-        assert_eq!(loops_capability_from_init_meta(None), (false, false));
-    }
-
-    #[test]
-    fn action_capabilities_from_acp_wires_loops_capability_into_session_capabilities() {
-        let mut init_response =
-            acp::schema::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
-        init_response.meta = Some(init_meta(serde_json::json!({
-            "anyharness": {
-                "schemaVersion": 1,
-                "goals": { "supported": true, "native": true },
-                "loops": { "supported": true, "native": true }
-            }
-        })));
-        let capabilities = action_capabilities_from_acp("claude", &init_response);
-        assert!(capabilities.supports_goals);
-        assert!(capabilities.supports_loops);
-        assert!(capabilities.loops_native);
-    }
-
-    #[test]
-    fn action_capabilities_from_acp_advertises_emulated_loops_for_codex() {
-        // codex-acp omits `loops` from `_meta` entirely, but the runtime
-        // emulates loops for it — the capability must still report supported so
-        // the ⟳ loops chip is reachable, with loops_native=false.
-        let init_response = acp::schema::InitializeResponse::new(acp::schema::ProtocolVersion::V1);
-        let capabilities = action_capabilities_from_acp("codex", &init_response);
-        assert!(capabilities.supports_loops);
-        assert!(!capabilities.loops_native);
-
-        // A non-emulated kind with no `loops` meta stays unsupported.
-        let claude = action_capabilities_from_acp("claude", &init_response);
-        assert!(!claude.supports_loops);
-    }
-}

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/state.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/state.rs
@@ -55,6 +55,12 @@ pub(in crate::live::sessions::actor) struct SessionActor {
     pub(in crate::live::sessions::actor) native_session_id: String,
     pub(in crate::live::sessions::actor) action_capabilities: SessionActionCapabilities,
     pub(in crate::live::sessions::actor) supports_native_close: bool,
+    /// Process-local OpenCode side-door state (port + redacted
+    /// password + fail-closed readiness). `None` for every non-OpenCode kind
+    /// and when the side-door could not be provisioned. Never persisted,
+    /// never logged.
+    pub(in crate::live::sessions::actor) sidedoor:
+        Option<crate::live::sessions::driver::opencode_sidedoor::SidedoorRuntime>,
 
     // ── wiring (set at spawn/startup, never reassigned) ──
     pub(in crate::live::sessions::actor) conn: acp::ConnectionTo<acp::Agent>,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/conditional_cancel.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/conditional_cancel.rs
@@ -230,6 +230,7 @@ async fn spawn_harness_with_capabilities(
         native_session_id: NATIVE_SESSION_ID.to_string(),
         action_capabilities: SessionActionCapabilities::default(),
         supports_native_close: false,
+        sidedoor: None,
         conn,
         caps,
         hooks,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/workspace_stop.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/workspace_stop.rs
@@ -33,7 +33,9 @@ use crate::live::sessions::actor::command::{PromptAcceptance, SessionCommand};
 use crate::live::sessions::actor::config::types::PersistedSessionConfigState;
 use crate::live::sessions::actor::notifications::replay_filter::ResumeReplayFilter;
 use crate::live::sessions::actor::state::{SessionActor, SessionStartupState};
-use crate::live::sessions::background_work::{BackgroundWorkOptions, BackgroundWorkRegistry};
+use crate::live::sessions::background_work::{
+    BackgroundWorkOptions, BackgroundWorkRegistry, BackgroundWorkUpdate,
+};
 use crate::live::sessions::driver::inbound::InboundDoor;
 use crate::live::sessions::handle::LiveSessionHandle;
 use crate::live::sessions::model::{SessionHooks, SystemPromptAppends};
@@ -269,7 +271,7 @@ async fn spawn_actor_with_real_child(agent_script: &str) -> RealChildActorHarnes
     )));
 
     let (background_tx, _background_work_rx_unused) =
-        mpsc::unbounded_channel::<crate::live::sessions::background_work::BackgroundWorkUpdate>();
+        mpsc::unbounded_channel::<BackgroundWorkUpdate>();
     let background_work_registry = BackgroundWorkRegistry::new(
         SESSION_ID.to_string(),
         "claude".to_string(),
@@ -334,6 +336,7 @@ async fn spawn_actor_with_real_child(agent_script: &str) -> RealChildActorHarnes
         native_session_id: NATIVE_SESSION_ID.to_string(),
         action_capabilities: SessionActionCapabilities::default(),
         supports_native_close: false,
+        sidedoor: None,
         conn,
         caps,
         hooks: SessionHooks::default(),
@@ -383,9 +386,8 @@ async fn stop_and_await_kills_the_real_process_group_including_a_git_grandchild(
             let agent_pid = actor.child.id().expect("agent pid") as i32;
             let (notification_tx, notification_rx) =
                 mpsc::unbounded_channel::<acp::schema::SessionNotification>();
-            let (background_tx, background_work_rx) = mpsc::unbounded_channel::<
-                crate::live::sessions::background_work::BackgroundWorkUpdate,
-            >();
+            let (background_tx, background_work_rx) =
+                mpsc::unbounded_channel::<BackgroundWorkUpdate>();
             // Swap in fresh receivers wired to nothing but the loop itself -
             // the harness's own unused senders above are dropped, which is
             // fine: the idle loop only needs receivers that never yield
@@ -500,9 +502,8 @@ async fn stop_and_await_kill_escalation_can_leave_the_agents_own_output_torn_mid
 
             let (notification_tx, notification_rx) =
                 mpsc::unbounded_channel::<acp::schema::SessionNotification>();
-            let (background_tx, background_work_rx) = mpsc::unbounded_channel::<
-                crate::live::sessions::background_work::BackgroundWorkUpdate,
-            >();
+            let (background_tx, background_work_rx) =
+                mpsc::unbounded_channel::<BackgroundWorkUpdate>();
             let _ = (notification_tx, background_tx);
 
             // Wait for the third, deliberately-unclosed record to land
@@ -626,9 +627,8 @@ async fn stop_and_await_bounds_an_active_turn_whose_agent_ignores_the_cancel() {
 
             let (notification_tx, notification_rx) =
                 mpsc::unbounded_channel::<acp::schema::SessionNotification>();
-            let (background_tx, background_work_rx) = mpsc::unbounded_channel::<
-                crate::live::sessions::background_work::BackgroundWorkUpdate,
-            >();
+            let (background_tx, background_work_rx) =
+                mpsc::unbounded_channel::<BackgroundWorkUpdate>();
             let _ = (notification_tx, background_tx);
 
             let actor_task = tokio::task::spawn_local(async move {
@@ -768,9 +768,8 @@ async fn a_dropped_stop_future_leaves_the_session_answerable() {
             );
             let (notification_tx, notification_rx) =
                 mpsc::unbounded_channel::<acp::schema::SessionNotification>();
-            let (background_tx, background_work_rx) = mpsc::unbounded_channel::<
-                crate::live::sessions::background_work::BackgroundWorkUpdate,
-            >();
+            let (background_tx, background_work_rx) =
+                mpsc::unbounded_channel::<BackgroundWorkUpdate>();
             let _ = (notification_tx, background_tx);
             assert!(pid_is_alive(agent_pid), "dummy agent must be running");
 

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/active.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/active.rs
@@ -332,6 +332,9 @@ impl SessionActor {
                             Some(SessionCommand::Fork { respond_to }) => {
                                 let _ = respond_to.send(Err(ForkSessionCommandError::Busy));
                             }
+                            Some(SessionCommand::SidedoorTargetedFork { respond_to, .. }) => {
+                                let _ = respond_to.send(Err(crate::live::sessions::SidedoorForkCommandError::Busy));
+                            }
                             Some(SessionCommand::CloseNativeSession { respond_to, .. }) => {
                                 reject_busy_close_native_child_session(respond_to);
                             }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/queue.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/queue.rs
@@ -12,7 +12,7 @@ use crate::live::sessions::actor::command::{
     PromptAcceptError, PromptAcceptance, QueueMutationError, Resolution,
 };
 use crate::live::sessions::actor::state::SessionActor;
-use crate::live::sessions::model::AttachmentSource;
+use crate::live::sessions::model_attachments::AttachmentSource;
 use crate::live::sessions::queue_durable::{
     PendingPromptDeleteOutcome, PendingPromptUpdateOutcome,
 };

--- a/anyharness/crates/anyharness-lib/src/live/sessions/driver/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/driver/mod.rs
@@ -2,6 +2,7 @@ pub(in crate::live::sessions) mod connection;
 pub(in crate::live::sessions) mod frame_tee;
 pub(in crate::live::sessions) mod inbound;
 pub mod native_session;
+pub mod opencode_sidedoor;
 pub mod process;
 pub mod session_lifecycle;
 pub mod shutdown;

--- a/anyharness/crates/anyharness-lib/src/live/sessions/driver/opencode_sidedoor.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/driver/opencode_sidedoor.rs
@@ -1,0 +1,499 @@
+//! The OpenCode targeted-fork HTTP side-door.
+//!
+//! `opencode acp` boots the vendor's full HTTP server as a side effect; when
+//! given `--hostname`/`--port` and `OPENCODE_SERVER_PASSWORD` it is reachable
+//! (with Basic auth) at a loopback address we choose. This module owns the
+//! per-process spawn config (port + password) and the fail-closed readiness
+//! check that decides whether the side-door capability is ever considered on.
+//!
+//! The (port, password) pair is process-local runtime state only: it is never
+//! persisted and never logged. `SidedoorSpawnConfig`'s `Debug` impl redacts
+//! the password so an incidental `{:?}` in a log line cannot leak it.
+
+use std::fmt;
+use std::net::{IpAddr, SocketAddr, TcpListener, TcpStream, UdpSocket};
+use std::time::Duration;
+
+use anyharness_contract::v1::SessionActionCapabilities;
+
+use crate::domains::agents::model::AgentKind;
+use crate::domains::sessions::model::serialize_action_capabilities;
+use crate::domains::sessions::runtime::fork_qualification::sidedoor_fork_qualified;
+use crate::live::sessions::model::LaunchEnv;
+use crate::live::sessions::model::SessionStateDurable;
+
+/// Spawn-time config for the OpenCode side-door: the loopback port the vendor
+/// HTTP server will bind and the Basic-auth password that gates it.
+#[derive(Clone)]
+pub struct SidedoorSpawnConfig {
+    pub port: u16,
+    pub password: String,
+}
+
+impl fmt::Debug for SidedoorSpawnConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SidedoorSpawnConfig")
+            .field("port", &self.port)
+            .field("password", &"<redacted>")
+            .finish()
+    }
+}
+
+impl SidedoorSpawnConfig {
+    /// Pick an ephemeral loopback port (bind-and-drop on 127.0.0.1:0) and mint
+    /// a fresh Basic-auth password. Never reused across processes.
+    pub fn generate() -> anyhow::Result<Self> {
+        let port = pick_ephemeral_port()?;
+        let password = generate_password();
+        Ok(Self { port, password })
+    }
+
+    /// Args to append to the OpenCode `acp` invocation.
+    pub fn spawn_args(&self) -> Vec<String> {
+        vec![
+            "--hostname".to_string(),
+            "127.0.0.1".to_string(),
+            "--port".to_string(),
+            self.port.to_string(),
+        ]
+    }
+
+    /// Env var to set on the spawned process. Kept as a single accessor (not
+    /// a raw field read) so every call site goes through the same redaction
+    /// discipline as the rest of this type.
+    pub fn env_var(&self) -> (&'static str, String) {
+        ("OPENCODE_SERVER_PASSWORD", self.password.clone())
+    }
+}
+
+fn pick_ephemeral_port() -> anyhow::Result<u16> {
+    let listener = TcpListener::bind(("127.0.0.1", 0))?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+    Ok(port)
+}
+
+/// 32 hex chars (two v4 uuids' hyphen-stripped hex, truncated) -- reuses the
+/// `uuid` dependency already vendored rather than adding a `rand` dep.
+fn generate_password() -> String {
+    let a = uuid::Uuid::new_v4().simple().to_string();
+    let b = uuid::Uuid::new_v4().simple().to_string();
+    format!("{a}{b}")[..32].to_string()
+}
+
+/// Outcome of the fail-closed side-door readiness check, recorded in the
+/// actor/driver state. `Refused` and `Unavailable` both keep `targeted_fork`
+/// off; only `Ready` allows the capability to ever be considered.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SidedoorState {
+    Ready { port: u16 },
+    Refused { reason: String },
+    Unavailable,
+}
+
+/// Pure decision logic for the readiness check, factored out of the actual
+/// network calls so it is unit-testable without a live server.
+///
+/// `auth_ok` is `Some(true)` when an authenticated call to the health
+/// endpoint succeeded, `Some(false)` when an UNauthenticated call to the
+/// health endpoint returned 200 (password not enforced -- itself a refusal
+/// condition), and `None` when the endpoint could not be reached at all.
+/// `off_host_reachable` is `Some(true)` when a TCP connect to the discovered
+/// non-loopback local IP succeeded on the side-door port (reachable from
+/// off-host); `None` when no non-loopback interface could be determined
+/// (treated as "no off-host interface" -- a pass, not a failure).
+pub fn decide_sidedoor_state(
+    port: u16,
+    auth_ok: Option<bool>,
+    unauthenticated_rejected: Option<bool>,
+    off_host_reachable: Option<bool>,
+) -> SidedoorState {
+    match auth_ok {
+        None => SidedoorState::Unavailable,
+        Some(false) => SidedoorState::Refused {
+            reason: "side-door health check failed with valid credentials".to_string(),
+        },
+        Some(true) => {
+            if unauthenticated_rejected == Some(false) {
+                return SidedoorState::Refused {
+                    reason: "side-door accepted an unauthenticated request (password not enforced)"
+                        .to_string(),
+                };
+            }
+            if off_host_reachable == Some(true) {
+                return SidedoorState::Refused {
+                    reason: "side-door is reachable from a non-loopback interface".to_string(),
+                };
+            }
+            SidedoorState::Ready { port }
+        }
+    }
+}
+
+/// Process-local side-door runtime state retained on the parent actor: the
+/// spawn config (port + redacted password) and the decided readiness state.
+/// Never persisted, never logged (the config's `Debug` redacts the password).
+#[derive(Debug, Clone)]
+pub struct SidedoorRuntime {
+    pub config: SidedoorSpawnConfig,
+    pub state: SidedoorState,
+}
+
+impl SidedoorRuntime {
+    pub fn is_ready(&self) -> bool {
+        matches!(self.state, SidedoorState::Ready { .. })
+    }
+}
+
+/// Fail-closed readiness probe, run once after the vendor HTTP server is
+/// expected up. Bounded retry (~5s) on the authenticated loopback health check,
+/// then confirms the auth middleware rejects an unauthenticated request and
+/// that the side-door is not reachable from a non-loopback interface. A hung or
+/// unreachable side-door degrades to `Unavailable`; a leaked/misconfigured one
+/// degrades to `Refused`. Only a clean pass yields `Ready`.
+pub async fn probe_sidedoor_readiness(
+    config: &SidedoorSpawnConfig,
+    session_id: &str,
+) -> SidedoorState {
+    use crate::domains::sessions::runtime::opencode_sidedoor_client::OpencodeSidedoorClient;
+
+    let client = match OpencodeSidedoorClient::new(config.port, config.password.clone()) {
+        Ok(client) => client,
+        Err(_) => return SidedoorState::Unavailable,
+    };
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mut auth_ok: Option<bool> = None;
+    loop {
+        match client.health_check(session_id).await {
+            // Authenticated loopback call succeeded: the door is up and our
+            // credentials are honored.
+            Ok(true) => {
+                auth_ok = Some(true);
+                break;
+            }
+            // Reachable but our valid credentials were rejected — a refusal
+            // condition, not a retry: stop probing.
+            Ok(false) => {
+                auth_ok = Some(false);
+                break;
+            }
+            // Not reachable yet; keep retrying until the deadline.
+            Err(_) => {}
+        }
+        if std::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+
+    // The negative controls only matter once the authenticated call worked;
+    // otherwise the decision is already Unavailable/Refused from `auth_ok`.
+    let unauthenticated_rejected = if auth_ok == Some(true) {
+        match client.health_check_unauthenticated(session_id).await {
+            // 200 without credentials means the password is not enforced.
+            Ok(accepted) => Some(!accepted),
+            // Unreachable without credentials counts as rejected.
+            Err(_) => Some(true),
+        }
+    } else {
+        None
+    };
+    let off_host_reachable = if auth_ok == Some(true) {
+        discover_primary_local_ipv4()
+            .and_then(|ip| probe_off_host_reachable(ip, config.port, Duration::from_millis(300)))
+    } else {
+        None
+    };
+
+    decide_sidedoor_state(
+        config.port,
+        auth_ok,
+        unauthenticated_rejected,
+        off_host_reachable,
+    )
+}
+
+/// Discover the primary non-loopback local IPv4 via the UDP-connect trick: no
+/// packet is actually sent (UDP `connect` just binds the route), so this is
+/// cheap and side-effect-free. Returns `None` (never a hard error) when no
+/// such interface exists or can't be determined -- documented as "no
+/// off-host interface" and treated as a pass by the caller.
+pub fn discover_primary_local_ipv4() -> Option<IpAddr> {
+    let socket = UdpSocket::bind("0.0.0.0:0").ok()?;
+    socket.connect("8.8.8.8:80").ok()?;
+    let addr = socket.local_addr().ok()?;
+    let ip = addr.ip();
+    if ip.is_loopback() {
+        None
+    } else {
+        Some(ip)
+    }
+}
+
+/// Attempt a short-timeout TCP connect to `ip:port`. `Some(true)` = reachable,
+/// `Some(false)` = refused/unreachable, matching `decide_sidedoor_state`'s
+/// `off_host_reachable` parameter.
+pub fn probe_off_host_reachable(ip: IpAddr, port: u16, timeout: Duration) -> Option<bool> {
+    let addr = SocketAddr::new(ip, port);
+    Some(TcpStream::connect_timeout(&addr, timeout).is_ok())
+}
+
+/// For OpenCode only, provision the HTTP side-door. Mint a fresh loopback
+/// port + Basic-auth password, point the vendor `acp` server at them
+/// (`--hostname 127.0.0.1 --port <port>` plus `OPENCODE_SERVER_PASSWORD`),
+/// and hand back the config to retain as process-local actor state.
+/// `settings_extra_args` is appended after the descriptor's own launch args
+/// at spawn, and the password rides the session env layer. The (port,
+/// password) pair is never persisted, never logged. `agent_kind` other than
+/// OpenCode always yields `None`.
+pub fn provision_sidedoor_spawn(agent_kind: &str, env: &mut LaunchEnv, session_id: &str) -> Option<SidedoorSpawnConfig> {
+    if agent_kind != AgentKind::OpenCode.as_str() {
+        return None;
+    }
+    match SidedoorSpawnConfig::generate() {
+        Ok(config_sd) => {
+            let (env_key, env_value) = config_sd.env_var();
+            env.session.insert(env_key.to_string(), env_value);
+            env.settings_extra_args.extend(config_sd.spawn_args());
+            Some(config_sd)
+        }
+        Err(error) => {
+            tracing::warn!(
+                session_id = %session_id,
+                error = %error,
+                "failed to provision OpenCode side-door spawn config; targeted fork stays disabled"
+            );
+            None
+        }
+    }
+}
+
+/// With the vendor server up (native session established), run the
+/// fail-closed side-door readiness check and derive `targeted_fork` for
+/// OpenCode. `targeted_fork` = registry-qualified for the resolved vendor
+/// version AND the side-door proved Ready. Because the shipped registry is
+/// `qualified:false`, this leaves `targeted_fork` off today — flipping the
+/// JSON record is the only enable step.
+///
+/// Returns the `SidedoorRuntime` to retain on the actor and mutates
+/// `action_capabilities.targeted_fork` in place; if it flips on, re-persists
+/// the durable capability row (the initial persist ran before readiness).
+pub async fn derive_sidedoor_capability(
+    config_sd: SidedoorSpawnConfig,
+    native_session_id: &str,
+    session_id: &str,
+    workspace_id: &str,
+    resolved_native_version: Option<&str>,
+    action_capabilities: &mut SessionActionCapabilities,
+    store: &dyn SessionStateDurable,
+) -> SidedoorRuntime {
+    let state = probe_sidedoor_readiness(&config_sd, native_session_id).await;
+    if let SidedoorState::Refused { reason } = &state {
+        tracing::warn!(
+            session_id = %session_id,
+            workspace_id = %workspace_id,
+            side_door_state = "refused",
+            reason = %reason,
+            "OpenCode side-door refused; targeted fork stays disabled"
+        );
+    }
+    let ready = matches!(state, SidedoorState::Ready { .. });
+    let qualified = resolved_native_version
+        .map(|version| sidedoor_fork_qualified(AgentKind::OpenCode.as_str(), version))
+        .unwrap_or(false);
+    action_capabilities.targeted_fork = qualified && ready;
+    if action_capabilities.targeted_fork {
+        persist_action_capabilities_value(store, session_id, *action_capabilities);
+    }
+    SidedoorRuntime {
+        config: config_sd,
+        state,
+    }
+}
+
+/// Persist an already-resolved capability set (used by the OpenCode side-door
+/// bridge after the side-door readiness check derives `targeted_fork`, which
+/// the ACP-only initial persist cannot know at handshake time).
+fn persist_action_capabilities_value(
+    store: &dyn SessionStateDurable,
+    session_id: &str,
+    capabilities: SessionActionCapabilities,
+) {
+    let Ok(json) = serialize_action_capabilities(capabilities) else {
+        tracing::warn!(
+            session_id,
+            "failed to serialize session action capabilities"
+        );
+        return;
+    };
+    let now = chrono::Utc::now().to_rfc3339();
+    if let Err(error) = store.update_action_capabilities_json(session_id, Some(json), &now) {
+        tracing::warn!(
+            session_id,
+            error = %error,
+            "failed to persist session action capabilities"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_config_has_valid_port_and_password() {
+        let config = SidedoorSpawnConfig::generate().expect("generate config");
+        assert!(config.port > 0);
+        assert_eq!(config.password.len(), 32);
+        assert!(config.password.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn debug_redacts_password() {
+        let config = SidedoorSpawnConfig {
+            port: 12345,
+            password: "super-secret-value".to_string(),
+        };
+        let debug = format!("{config:?}");
+        assert!(!debug.contains("super-secret-value"));
+        assert!(debug.contains("redacted"));
+    }
+
+    #[test]
+    fn two_generated_passwords_differ() {
+        let a = SidedoorSpawnConfig::generate().unwrap();
+        let b = SidedoorSpawnConfig::generate().unwrap();
+        assert_ne!(a.password, b.password);
+    }
+
+    #[test]
+    fn unreachable_health_check_is_unavailable() {
+        assert_eq!(
+            decide_sidedoor_state(1, None, None, None),
+            SidedoorState::Unavailable
+        );
+    }
+
+    #[test]
+    fn failed_authenticated_call_is_refused() {
+        assert!(matches!(
+            decide_sidedoor_state(1, Some(false), None, None),
+            SidedoorState::Refused { .. }
+        ));
+    }
+
+    #[test]
+    fn unauthenticated_200_is_refused() {
+        assert!(matches!(
+            decide_sidedoor_state(1, Some(true), Some(false), Some(false)),
+            SidedoorState::Refused { .. }
+        ));
+    }
+
+    #[test]
+    fn off_host_reachable_is_refused() {
+        assert!(matches!(
+            decide_sidedoor_state(1, Some(true), Some(true), Some(true)),
+            SidedoorState::Refused { .. }
+        ));
+    }
+
+    #[test]
+    fn no_off_host_interface_and_auth_enforced_is_ready() {
+        assert_eq!(
+            decide_sidedoor_state(4096, Some(true), Some(true), None),
+            SidedoorState::Ready { port: 4096 }
+        );
+    }
+
+    #[test]
+    fn off_host_unreachable_and_auth_enforced_is_ready() {
+        assert_eq!(
+            decide_sidedoor_state(4096, Some(true), Some(true), Some(false)),
+            SidedoorState::Ready { port: 4096 }
+        );
+    }
+}
+
+#[cfg(test)]
+mod readiness_tests {
+    //! Fail-closed readiness against an in-process fake side-door.
+    //! These pin the two leak conditions that must knock the side-door down to
+    //! `Refused` — an unenforced password and off-host reachability — plus the
+    //! clean loopback pass.
+
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    use super::{probe_sidedoor_readiness, SidedoorSpawnConfig, SidedoorState};
+
+    /// Spawns a detached fake side-door health endpoint. `enforce_auth=false`
+    /// models the middleware NO-OP (200 even without credentials); `true`
+    /// returns 401 for an unauthenticated request. Bound at `bind` so the
+    /// off-host reachability probe can be exercised (`0.0.0.0`).
+    fn spawn_health_server(bind: &str, enforce_auth: bool) -> u16 {
+        let listener = TcpListener::bind((bind, 0)).expect("bind fake health server");
+        let port = listener.local_addr().expect("addr").port();
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let mut buf = [0u8; 2048];
+                let read = stream.read(&mut buf).unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..read]);
+                let has_auth = request
+                    .lines()
+                    .any(|line| line.to_ascii_lowercase().starts_with("authorization:"));
+                let ok = !enforce_auth || has_auth;
+                let response = if ok {
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 2\r\nConnection: close\r\n\r\n[]"
+                } else {
+                    "HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                };
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+        port
+    }
+
+    fn config(port: u16) -> SidedoorSpawnConfig {
+        SidedoorSpawnConfig {
+            port,
+            password: "test-password-0000000000000000".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn loopback_enforced_and_not_off_host_is_ready() {
+        let port = spawn_health_server("127.0.0.1", true);
+        let state = probe_sidedoor_readiness(&config(port), "native_session").await;
+        // A server bound to loopback only is never reachable off-host, so with
+        // auth enforced this is the clean Ready pass.
+        assert_eq!(state, SidedoorState::Ready { port });
+    }
+
+    #[tokio::test]
+    async fn unenforced_password_is_refused() {
+        let port = spawn_health_server("127.0.0.1", false);
+        let state = probe_sidedoor_readiness(&config(port), "native_session").await;
+        assert!(
+            matches!(state, SidedoorState::Refused { .. }),
+            "an unauthenticated 200 must refuse: {state:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn off_host_reachable_is_refused() {
+        // Only meaningful when the machine has a non-loopback interface; the
+        // pure decision logic already pins the None (no-interface) case.
+        if super::discover_primary_local_ipv4().is_none() {
+            return;
+        }
+        let port = spawn_health_server("0.0.0.0", true);
+        let state = probe_sidedoor_readiness(&config(port), "native_session").await;
+        assert!(
+            matches!(state, SidedoorState::Refused { .. }),
+            "an off-host-reachable side-door must refuse: {state:?}"
+        );
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/live/sessions/handle.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/handle.rs
@@ -10,7 +10,7 @@ use tokio::sync::{broadcast, mpsc, oneshot, Notify, RwLock};
 pub use crate::live::sessions::actor::command::{
     ConditionalCancelOutcome, ForkSessionCommandError, ForkSessionCommandResult, PromptAcceptError,
     PromptAcceptance, QueueMutationError, Resolution, ResolveInteractionCommandError,
-    SetConfigOptionCommandError,
+    SetConfigOptionCommandError, SidedoorForkCommandError, SidedoorForkCommandResult,
 };
 
 use crate::domains::sessions::prompt::PromptPayload;
@@ -18,7 +18,7 @@ use crate::domains::sessions::runtime_event::{
     RuntimeEventInjectionError, RuntimeEventInjectionResult, RuntimeInjectedSessionEvent,
 };
 use crate::live::sessions::actor::command::SessionCommand;
-
+mod sidedoor;
 #[derive(Debug)]
 pub enum LiveSessionCommandError<E> {
     ActorUnavailable,

--- a/anyharness/crates/anyharness-lib/src/live/sessions/handle/sidedoor.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/handle/sidedoor.rs
@@ -1,0 +1,27 @@
+//! OpenCode side-door targeted-fork dispatch surface on `LiveSessionHandle`.
+//!
+//! A second `impl LiveSessionHandle` block, split out of `handle.rs` into this
+//! child module so the parent stays under the 600-line cap after the rung-3
+//! refold onto main (main independently grew `handle.rs` to the cap edge). As a
+//! descendant module it legitimately reaches the parent's private `send_request`.
+
+use crate::live::sessions::actor::command::{
+    SessionCommand, SidedoorForkCommandError, SidedoorForkCommandResult,
+};
+
+use super::{LiveSessionCommandError, LiveSessionHandle};
+
+impl LiveSessionHandle {
+    /// Dispatch an OpenCode side-door targeted fork on the parent
+    /// actor, which validates the vendor message id and POSTs the fork.
+    pub async fn sidedoor_targeted_fork(
+        &self,
+        vendor_message_id: String,
+    ) -> Result<SidedoorForkCommandResult, LiveSessionCommandError<SidedoorForkCommandError>> {
+        self.send_request(|respond_to| SessionCommand::SidedoorTargetedFork {
+            vendor_message_id,
+            respond_to,
+        })
+        .await
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/live/sessions/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/mod.rs
@@ -4,6 +4,7 @@ mod driver;
 pub mod handle;
 mod manager;
 pub mod model;
+pub mod model_attachments;
 pub mod probe;
 pub mod product_context;
 pub mod queue_durable;
@@ -19,7 +20,8 @@ pub use handle::{
     AgentExtMethodError, ConditionalCancelOutcome, ForkSessionCommandError,
     ForkSessionCommandResult, LiveSessionCommandError, LiveSessionExecutionSnapshot,
     LiveSessionHandle, PromptAcceptError, PromptAcceptance, QueueMutationError, Resolution,
-    ResolveInteractionCommandError, SetConfigOptionCommandError,
+    ResolveInteractionCommandError, SetConfigOptionCommandError, SidedoorForkCommandError,
+    SidedoorForkCommandResult,
 };
 pub use manager::LiveSessionManager;
 pub(crate) use manager::RevealMcpElicitationUrlError;

--- a/anyharness/crates/anyharness-lib/src/live/sessions/model.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/model.rs
@@ -46,12 +46,13 @@ use crate::domains::sessions::extensions::{
 use crate::domains::sessions::mcp_bindings::model::SessionMcpServer;
 use crate::domains::sessions::model::{
     PendingConfigChangeRecord, PendingPromptRecord, PendingPromptReorderOutcome,
-    PromptAttachmentRecord, PromptAttachmentState, SessionBackgroundWorkRecord,
-    SessionBackgroundWorkState, SessionEventRecord, SessionLiveConfigSnapshotRecord, SessionRecord,
+    SessionBackgroundWorkRecord, SessionBackgroundWorkState, SessionEventRecord,
+    SessionLiveConfigSnapshotRecord, SessionRecord,
 };
-use crate::domains::sessions::prompt::{PromptPayload, PromptValidationError, ResolvedParts};
+use crate::domains::sessions::prompt::PromptPayload;
 use crate::live::sessions::actor::command::{Resolution, ResolveInteractionCommandError};
 use crate::live::sessions::actor::turn::types::SessionTurnFinishResult;
+use crate::live::sessions::model_attachments::AttachmentSource;
 use crate::live::sessions::product_context::AgentProductContextResolver;
 use crate::live::sessions::queue_durable::{
     PendingPromptDeleteOutcome, PendingPromptUpdateOutcome,
@@ -310,38 +311,16 @@ pub trait SessionStateDurable: Send + Sync {
     fn delete_pending_config_change(&self, session_id: &str, config_id: &str)
         -> anyhow::Result<()>;
     fn repair_unclosed_turns(&self, session_id: &str) -> anyhow::Result<u32>;
-}
-
-/// Prompt-attachment loading and hygiene as the actor's turn machinery needs
-/// it. `load` is the IO half of the prompt pipeline; the pure render half is
-/// `domains::sessions::prompt::render::render`, which the actor calls itself.
-pub trait AttachmentSource: Send + Sync {
-    /// Load every attachment the payload references: store rows plus stored
-    /// bytes (including the legacy-content fallback). No ACP shapes here —
-    /// rendering them is pure and stays out of the capability.
-    fn load(
+    /// record the vendor OpenCode message id observed for a
+    /// runtime `(turn_id, item_id)` user-message identity (first-writer-wins).
+    fn insert_opencode_message_id(
         &self,
         session_id: &str,
-        payload: &PromptPayload,
-    ) -> Result<ResolvedParts, PromptValidationError>;
-    fn mark_prompt_attachments_state(
-        &self,
-        session_id: &str,
-        attachment_ids: &[String],
-        state: PromptAttachmentState,
+        turn_id: &str,
+        item_id: &str,
+        vendor_message_id: &str,
+        now: &str,
     ) -> anyhow::Result<()>;
-    fn find_prompt_attachment(
-        &self,
-        session_id: &str,
-        attachment_id: &str,
-    ) -> anyhow::Result<Option<PromptAttachmentRecord>>;
-    fn delete_prompt_attachments(
-        &self,
-        session_id: &str,
-        attachment_ids: &[&str],
-    ) -> anyhow::Result<()>;
-    /// Delete the stored attachment file for a (pending) record.
-    fn delete_record(&self, record: &PromptAttachmentRecord) -> anyhow::Result<()>;
 }
 
 /// The never-varies capability set the actor runs against; wired once at

--- a/anyharness/crates/anyharness-lib/src/live/sessions/model_attachments.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/model_attachments.rs
@@ -1,0 +1,38 @@
+//! Prompt-attachment loading and hygiene as the actor's turn machinery needs
+//! it. Split out of `model.rs` (see `guides/domains.md` on module growth): a
+//! separate concern (prompt-attachment loading IO) with a small blast radius.
+
+use crate::domains::sessions::model::{PromptAttachmentRecord, PromptAttachmentState};
+use crate::domains::sessions::prompt::{PromptPayload, PromptValidationError, ResolvedParts};
+
+/// Prompt-attachment loading and hygiene as the actor's turn machinery needs
+/// it. `load` is the IO half of the prompt pipeline; the pure render half is
+/// `domains::sessions::prompt::render::render`, which the actor calls itself.
+pub trait AttachmentSource: Send + Sync {
+    /// Load every attachment the payload references: store rows plus stored
+    /// bytes (including the legacy-content fallback). No ACP shapes here —
+    /// rendering them is pure and stays out of the capability.
+    fn load(
+        &self,
+        session_id: &str,
+        payload: &PromptPayload,
+    ) -> Result<ResolvedParts, PromptValidationError>;
+    fn mark_prompt_attachments_state(
+        &self,
+        session_id: &str,
+        attachment_ids: &[String],
+        state: PromptAttachmentState,
+    ) -> anyhow::Result<()>;
+    fn find_prompt_attachment(
+        &self,
+        session_id: &str,
+        attachment_id: &str,
+    ) -> anyhow::Result<Option<PromptAttachmentRecord>>;
+    fn delete_prompt_attachments(
+        &self,
+        session_id: &str,
+        attachment_ids: &[&str],
+    ) -> anyhow::Result<()>;
+    /// Delete the stored attachment file for a (pending) record.
+    fn delete_record(&self, record: &PromptAttachmentRecord) -> anyhow::Result<()>;
+}

--- a/anyharness/crates/anyharness-lib/src/live/sessions/replay/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/replay/mod.rs
@@ -401,6 +401,14 @@ async fn handle_non_replay_command(
             )));
             None
         }
+        SessionCommand::SidedoorTargetedFork { respond_to, .. } => {
+            let _ = respond_to.send(Err(
+                crate::live::sessions::SidedoorForkCommandError::NotReady(
+                    "replay sessions cannot be forked".to_string(),
+                ),
+            ));
+            None
+        }
         SessionCommand::CloseNativeSession { respond_to, .. } => {
             let _ = respond_to.send(Err(anyhow::anyhow!(
                 "replay sessions have no native child sessions"

--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/ingest.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/ingest.rs
@@ -38,6 +38,15 @@ pub(in crate::live::sessions) enum ActorBoundUpdate {
         title: Option<String>,
         updated_at: Option<String>,
     },
+    /// A vendor OpenCode `messageId` echoed on the active prompt
+    /// turn's user message. The sink stays meaning-blind — it only reports the
+    /// binding; the actor (which knows the agent kind) decides whether to
+    /// persist it (opencode only) via first-writer-wins `insert_opencode_message_id`.
+    OpencodeUserMessageId {
+        turn_id: String,
+        item_id: String,
+        vendor_message_id: String,
+    },
 }
 
 /// What one [`SessionEventSink::ingest`] call produced: the observations to
@@ -226,8 +235,23 @@ impl SessionEventSink {
                     cost: serde_json::to_value(&usage.cost).ok(),
                 });
             }
-            UserMessageChunk(_) => {
+            UserMessageChunk(chunk) => {
                 tracing::trace!("ACP UserMessageChunk echo received (deduplicated)");
+                // The vendor ACP layer echoes its native message
+                // id here. Only bind it when a prompt turn is genuinely open
+                // with a known user item — never misattribute a replayed
+                // history echo (no open turn). The actor persists opencode-only.
+                if let Some(vendor_message_id) =
+                    chunk.message_id.as_ref().map(|id| id.to_string())
+                {
+                    if let Some((turn_id, item_id)) = self.current_user_message_identity() {
+                        outcome.needs_actor = Some(ActorBoundUpdate::OpencodeUserMessageId {
+                            turn_id,
+                            item_id,
+                            vendor_message_id,
+                        });
+                    }
+                }
             }
             #[allow(unreachable_patterns)]
             other => {

--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/mod.rs
@@ -55,6 +55,13 @@ pub struct SessionEventSink {
     store: Arc<dyn EventPersist>,
 
     current_turn_id: Option<String>,
+    /// The `item_id` of the current prompt turn's user-message item, set by
+    /// `begin_turn` and cleared at `turn_ended`. Only a prompt-begun turn has a
+    /// known user item; engine-initiated turns leave this `None`. the OpenCode side-door bridge
+    /// uses it to bind a vendor OpenCode `messageId` echo to the right runtime
+    /// `(turn_id, item_id)` identity, and only ever while a turn is open — a
+    /// replayed history echo (no open turn) is never misattributed.
+    current_user_item_id: Option<String>,
     /// True while the open turn was synthesized for engine-initiated activity
     /// (goal continuation/evaluation) rather than begun by a prompt. Only
     /// such turns may be auto-closed by terminal goal events.
@@ -94,6 +101,7 @@ impl SessionEventSink {
             event_tx,
             store,
             current_turn_id: None,
+            current_user_item_id: None,
             engine_initiated_turn: false,
             engine_turn_has_events: false,
             open_assistant_item: None,
@@ -127,6 +135,7 @@ impl SessionEventSink {
             event_tx,
             store,
             current_turn_id: None,
+            current_user_item_id: None,
             engine_initiated_turn: false,
             engine_turn_has_events: false,
             open_assistant_item: None,
@@ -164,6 +173,18 @@ impl SessionEventSink {
 
     pub fn current_turn_id(&self) -> Option<String> {
         self.current_turn_id.clone()
+    }
+
+    /// The open prompt turn's `(turn_id, item_id)` user-message identity, or
+    /// `None` when no prompt turn is open (engine-initiated turn, or between
+    /// turns). The side-door fork binds a vendor OpenCode `messageId` echo to this.
+    pub(in crate::live::sessions) fn current_user_message_identity(
+        &self,
+    ) -> Option<(String, String)> {
+        match (&self.current_turn_id, &self.current_user_item_id) {
+            (Some(turn_id), Some(item_id)) => Some((turn_id.clone(), item_id.clone())),
+            _ => None,
+        }
     }
 
     pub fn close_open_transcript_items(&mut self) {

--- a/anyharness/crates/anyharness-lib/src/live/sessions/sink/turns.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/sink/turns.rs
@@ -27,6 +27,10 @@ impl SessionEventSink {
         );
 
         let item_id = uuid::Uuid::new_v4().to_string();
+        // Bind the vendor OpenCode `messageId` echo to this
+        // prompt turn's user-message identity. Cleared at `turn_ended`; never
+        // set for engine-initiated turns.
+        self.current_user_item_id = Some(item_id.clone());
         let item = TranscriptItemPayload {
             kind: TranscriptItemKind::UserMessage,
             status: TranscriptItemStatus::Completed,
@@ -91,6 +95,7 @@ impl SessionEventSink {
         // engine-initiated (goal continuation/evaluation) and must open its
         // own turn instead of being glued onto this one.
         self.current_turn_id = None;
+        self.current_user_item_id = None;
         self.engine_initiated_turn = false;
     }
 

--- a/anyharness/crates/anyharness-lib/src/persistence/migrations.rs
+++ b/anyharness/crates/anyharness-lib/src/persistence/migrations.rs
@@ -248,6 +248,10 @@ pub(super) const MIGRATIONS: &[(&str, &str)] = &[
         "0073_pending_prompt_cursor_backfill",
         include_str!("sql/0073_pending_prompt_cursor_backfill.sql"),
     ),
+    (
+        "0074_opencode_message_ids",
+        include_str!("sql/0074_opencode_message_ids.sql"),
+    ),
 ];
 
 pub fn run_migrations(conn: &mut Connection) -> rusqlite::Result<()> {

--- a/anyharness/crates/anyharness-lib/src/persistence/sql/0074_opencode_message_ids.sql
+++ b/anyharness/crates/anyharness-lib/src/persistence/sql/0074_opencode_message_ids.sql
@@ -1,0 +1,20 @@
+-- Forks Lane C (OpenCode targeted-fork side-door): maps our runtime-generated
+-- (turn_id, item_id) user-message identity to the vendor OpenCode message id
+-- observed on the ACP wire (session/update user_message_chunk `messageId`).
+--
+-- The vendor id is required to dispatch a targeted `POST /session/{id}/fork`
+-- side-door call: upstream Session.fork does a raw string comparison against
+-- message ids with no existence check, so dispatching on anything but a
+-- vendor-confirmed id risks a silent full-copy or near-empty fork. This table
+-- is the only place that translation happens.
+--
+-- First-writer-wins: a session/turn/item is captured once, on the first
+-- observed echo, and never overwritten by a later replay of the same chunk.
+CREATE TABLE opencode_message_ids (
+    session_id TEXT NOT NULL,
+    turn_id TEXT NOT NULL,
+    item_id TEXT NOT NULL,
+    vendor_message_id TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (session_id, turn_id, item_id)
+);

--- a/catalogs/agents/qualifications/targeted-fork-sidedoor.json
+++ b/catalogs/agents/qualifications/targeted-fork-sidedoor.json
@@ -1,0 +1,8 @@
+[
+  {
+    "agentKind": "opencode",
+    "nativeVersion": "1.18.3",
+    "qualified": false,
+    "evidence": "Vendor tag v1.18.3 (commit 127bdb30784d508cc556c71a0f32b508a3061517) fork-hazard + side-door bridge wired 2026-08-17; qualified flips to true only when the live side-door qualification probe (two-boundary fork + off-host negative control) has passed for this exact vendor version."
+  }
+]

--- a/fixtures/contracts/opencode-sidedoor/README.md
+++ b/fixtures/contracts/opencode-sidedoor/README.md
@@ -1,0 +1,36 @@
+# OpenCode side-door HTTP contract (pinned ground truth)
+
+Pinned for the OpenCode targeted-fork HTTP side-door bridge: the shapes
+our `OpencodeSidedoorClient` sends/parses against the vendor `opencode acp`
+HTTP server.
+
+## Provenance
+
+| Field | Value |
+| --- | --- |
+| Vendor | `opencode` (agent kind `opencode` in `catalogs/agents/catalog.json`) |
+| Vendor tag | `v1.18.3` |
+| Vendor commit | `127bdb30784d508cc556c71a0f32b508a3061517` |
+| Verification date | 2026-08-17 |
+| Method | Source read of the vendor repo at the pinned tag (`Session.fork`, the `acp` HTTP server bootstrap, and the auth middleware) |
+
+## Files
+
+- `fork-request.json` — body shape for `POST /session/{id}/fork`.
+- `auth-header-example.json` — Basic-auth header shape with a FAKE password
+  (`OPENCODE_SERVER_PASSWORD`, username defaults to `opencode`).
+- `message-list-response.json` — representative `GET /session/{id}/message`
+  response (ascending array of `{info, parts}`).
+- `qualification-registry-entry.json` — shape of one row in
+  `catalogs/agents/qualifications/targeted-fork-sidedoor.json`.
+
+## Vendor hazard (why pre-validation is mandatory)
+
+`Session.fork` walks messages ascending and stops at the first
+`msg.info.id >= messageID` -- a raw string comparison with **no existence
+check**. An unrecognized id sorting after every real id silently full-copies
+the session; one sorting before all real ids silently produces a near-empty
+fork. Fork excludes the target message (exclusive boundary). Our client never
+dispatches a `messageID` that has not been round-tripped through
+`GET /session/{id}/message/{messageID}` (id + role match) AND confirmed
+present in `GET /session/{id}/message` (exact membership).

--- a/fixtures/contracts/opencode-sidedoor/auth-header-example.json
+++ b/fixtures/contracts/opencode-sidedoor/auth-header-example.json
@@ -1,0 +1,5 @@
+{
+  "username": "opencode",
+  "password": "FAKE0000000000000000000000000000",
+  "header": "Authorization: Basic b3BlbmNvZGU6RkFLRTAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw"
+}

--- a/fixtures/contracts/opencode-sidedoor/fork-request.json
+++ b/fixtures/contracts/opencode-sidedoor/fork-request.json
@@ -1,0 +1,3 @@
+{
+  "messageID": "msg_01hqrstuvwxyzabcdefghij0"
+}

--- a/fixtures/contracts/opencode-sidedoor/message-list-response.json
+++ b/fixtures/contracts/opencode-sidedoor/message-list-response.json
@@ -1,0 +1,16 @@
+[
+  {
+    "info": {
+      "id": "msg_01hqrstuvwxyzabcdefghij0",
+      "role": "user"
+    },
+    "parts": []
+  },
+  {
+    "info": {
+      "id": "msg_01hqrstuvwxyzabcdefghij1",
+      "role": "assistant"
+    },
+    "parts": []
+  }
+]

--- a/fixtures/contracts/opencode-sidedoor/qualification-registry-entry.json
+++ b/fixtures/contracts/opencode-sidedoor/qualification-registry-entry.json
@@ -1,0 +1,6 @@
+{
+  "agentKind": "opencode",
+  "nativeVersion": "1.18.3",
+  "qualified": false,
+  "evidence": "short pointer text describing the qualifying evidence"
+}

--- a/lints/anyharness/exceptions.toml
+++ b/lints/anyharness/exceptions.toml
@@ -541,9 +541,9 @@ reason = "1 wire type import below the mapper boundary; target = sessions domain
 
 [[exception]]
 rule = "AH-CONTRACT-1"
-path = "anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork.rs"
+path = "anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork/mod.rs"
 site = "anyharness_contract::v1::ForkSessionTarget"
-reason = "1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x)"
+reason = "1 wire type import below the mapper boundary; target = sessions domain twins (grid plan PR 10.x). Carried forward from runtime/fork.rs when it split into fork/ for the rung-3 side-door dispatch"
 
 [[exception]]
 rule = "AH-CONTRACT-1"

--- a/lints/anyharness/ratchets.toml
+++ b/lints/anyharness/ratchets.toml
@@ -84,23 +84,13 @@ max_lines = 1510
 reason = "existing AnyHarness oversized test file"
 
 [[max_lines]]
-path = "anyharness/crates/anyharness-lib/src/domains/sessions/runtime/fork.rs"
-max_lines = 622
-reason = "Forks ADR rung 2 fork orchestration: access gate, item_id boundary validation, capability gate, canonical-digest idempotency (find-then-insert with a UNIQUE-constraint TOCTOU fallback that reconciles the winner), boundary resolution, durable-operation phase machine, and dispatch/start; split into fork/ per guides/domains.md when rung 3 wires targeted native dispatch"
-
-[[max_lines]]
 path = "anyharness/crates/anyharness-lib/src/domains/sessions/runtime/tests.rs"
 max_lines = 1283
 reason = "existing AnyHarness oversized test file (launch-env tests moved to their owning module) + A9 Scope C resume/fork revoked-credentials regression tests (AgentNotReady at the common live-start seam) + a review-fix pin (unsatisfiable selection reports RouteAuth, not AgentNotReady, on resume) + Forks ADR rung 2 targeted-fork plumbing tests (item-less rejection, fail-closed no-child downgrade guard, idempotency conflict, unknown-outcome redispatch block, same-payload resume shared by the insert-time TOCTOU fallback)"
 
 [[max_lines]]
-path = "anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs"
-max_lines = 650
-reason = "session startup (+goal/loop capability parsing, roster reconcile-on-attach); R3: +1 line initializing the new pending_stop_response field on SessionActor construction; observability PR9: +2 session.established record fields ; +5: pr11b threads the interaction hooks into the event sink at construction"
-
-[[max_lines]]
 path = "anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/workspace_stop.rs"
-max_lines = 841
+max_lines = 840
 reason = "R3 real-process stop suite; every case owns a real agent process and a real ACP duplex, so the per-case setup is genuinely irreducible. +130: the dropped-stop re-entry regression (a stop future abandoned mid-escalation must leave the session answerable)"
 
 [[max_lines]]
@@ -182,11 +172,6 @@ reason = "workflows gen-2 pure transition table: the ADR's ruling rows and their
 path = "anyharness/crates/anyharness-lib/src/domains/workflows/transition_tests.rs"
 max_lines = 1190
 reason = "workflows gen-2 transition suite: one test per ADR table row plus staleness and illegal-command proofs ; +76: PR4 adds ForcedUnload-parking and Ruling L redo-from-running proofs ; +55: fix/wf2-run-cancel adds the cancel transition suite ; +32: fix round 1 adds the running-adhoc disposal proof and parameterizes the terminal-command wall over Completed/Failed/Cancelled"
-
-[[max_lines]]
-path = "anyharness/crates/anyharness-lib/src/live/sessions/model.rs"
-max_lines = 606
-reason = "live-session shared model: actor messages, hooks, capabilities, event persist; split per guides/domains.md on next growth ; +7: pr11b adds the interaction-requested/resolved hook fields to SessionHooks"
 
 [[max_lines]]
 path = "anyharness/crates/anyharness-lib/src/live/workflows/lifecycle_tests.rs"

--- a/specs/GENERATED/anyharness-db-schema.sql
+++ b/specs/GENERATED/anyharness-db-schema.sql
@@ -215,6 +215,16 @@ CREATE TABLE mobility_archive_installs (
     PRIMARY KEY (workspace_id, operation_id)
 );
 
+-- table: opencode_message_ids
+CREATE TABLE opencode_message_ids (
+    session_id TEXT NOT NULL,
+    turn_id TEXT NOT NULL,
+    item_id TEXT NOT NULL,
+    vendor_message_id TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (session_id, turn_id, item_id)
+);
+
 -- table: plan_handoffs
 CREATE TABLE plan_handoffs (
     id TEXT PRIMARY KEY,

--- a/specs/anyharness/sessions.md
+++ b/specs/anyharness/sessions.md
@@ -356,7 +356,12 @@ Fork invariants:
 - raw ACP notifications are not copied into fork children
 - generic ACP fork support (`action_capabilities.fork`) means tip fork only;
   targeted fork requires the separate `action_capabilities.targeted_fork`
-  capability, absent on every adapter until the per-harness bridges land
+  capability. The OpenCode side-door bridge derives `targeted_fork` from the
+  runtime-owned qualification registry (an exact vendor version pin) AND a
+  loopback-only, fail-closed side-door readiness check; it stays off unless the
+  registry qualifies the resolved vendor version and the side-door proves
+  loopback-authenticated and off-host-unreachable. Every other adapter remains
+  absent until its own per-harness bridge lands
 
 ### Fork boundary and the durable operation record
 


### PR DESCRIPTION
## Summary

Forks build-out Lane C (Design ADR C, frozen Forks ADR Q6 guardrails): the OpenCode targeted-fork bridge over the vendor's own HTTP server. All four Q6 guardrails are implemented; the capability ships OFF (registry record `qualified:false`) and flipping the in-repo record is the only enable step, gated on live qualification.

### Refold onto main `703c12e6e` (rebased from reviewed head `6c7aebe2a`)

Refolded after main moved overnight and the PR went CONFLICTING. New head carries the same reviewed content plus minimal conflict resolutions; a delta reviewer is scoped to the conflict hunks via the range-diff receipt comment.

- **Migration renumber:** the store migration was `0072` at review; main took `0072`/`0073` overnight, so it is renumbered to **`0074_opencode_message_ids`** (next free slot). No schema change — only the numeric slot moved.
- **Ratchet: zero new entries (genuine cure, PROD-SIZE-1).** The merge-induced `live/sessions/handle.rs` cap crossing (main grew it to 599 — 1 under cap — overnight; the reviewed 13-line `sidedoor_targeted_fork` wrapper would push the merged file to 612) is cured by the house split pattern, **not** a founder-gated entry: the side-door dispatch surface moves to a new child module `live/sessions/handle/sidedoor.rs` (a second `impl LiveSessionHandle` block that legitimately reaches the parent's private `send_request`), landing `handle.rs` at **599** with **zero new ratchet entries**. This mirrors Lane D's cure of the same file (#2038 — `handle/fork.rs`, 587). Split-driven ratchet removals elsewhere in the refold: `runtime/fork.rs` (→ `fork/`), `actor/startup.rs`, and `sessions/model.rs` all drop below cap.
- **Cargo.lock:** `proliferate = 0.4.16`, matching main's manifest (`apps/desktop/src-tauri/Cargo.toml = 0.4.16`); main's committed lock is stale at `0.4.14`.

### Q-C4 vendor re-verification (done before implementation, per lane order)

Verified against the real sst/opencode `v1.18.3` tag (commit `127bdb30784d508cc556c71a0f32b508a3061517`):
- `POST /session/{id}/fork` body `{"messageID"}` confirmed; `messageID` is optional upstream (omitted = tip fork).
- The silent-degrade hazard is real and mechanistic: `Session.fork` breaks on `msg.info.id >= messageID` (string order, no existence check). An unknown id sorting after all real ids silently FULL-COPIES; one sorting before them silently produces a near-empty fork. Pre-validation therefore requires exact id membership, not plausibility.
- The fork excludes the target message (anchor recorded `inclusive=false`).
- `opencode acp` boots the vendor HTTP server; `--hostname`/`--port` control bind (default 127.0.0.1); auth is HTTP Basic via `OPENCODE_SERVER_PASSWORD` and the middleware is a NO-OP when unset.

### What this PR builds

- **Spawn config**: for OpenCode only, the runtime mints a per-spawn loopback port + random password, appends `--hostname 127.0.0.1 --port <p>`, injects `OPENCODE_SERVER_PASSWORD`. Process-local actor state, never persisted, Debug-redacted.
- **Fail-closed readiness**: authenticated loopback health must pass, an unauthenticated request must be rejected (an unauthenticated 200 is itself a refusal), and a TCP connect to the primary non-loopback interface must fail. Anything else leaves `targeted_fork` off and generic ACP behavior untouched.
- **Boundary translation**: the vendor echoes its native `messageId` on user-message chunks; the sink (meaning-blind) reports the binding for the active prompt turn's user item and the actor persists it for OpenCode into `opencode_message_ids` (migration 0074 after the refold renumber, first-writer-wins). No ordinal guessing exists anywhere.
- **Mandatory pre-validation**: before any fork POST, `get_message` must return the exact id with role `user` AND the id must appear in `list_messages`. Any miss is a hard `TARGET_NOT_FOUND`/`INVALID_FORK_TARGET`; an unmapped boundary is `TARGET_NOT_FOUND`. A resolved target never degrades to a tip fork.
- **Qualification registry**: `catalogs/agents/qualifications/targeted-fork-sidedoor.json`, keyed (agent kind, native version), parsed fail-closed, consulted at capability-persist time with the session's resolved native artifact version (never hardcoded). `targeted_fork = qualified && sidedoor Ready`, OpenCode only; every other adapter keeps the hardcoded false (Lane D owns the general flip).
- **Dispatch**: the rung-3 hard stop now branches for OpenCode-with-capability into a parent-actor side-door operation (OpenCode fork ids are durable; child starts via load_session). Provenance records `opencode_message_id` / the id / `inclusive=false` / resolved native version. The fork_operations phase machine is respected (`native_call_in_flight` before dispatch; dropped responses park at `native_outcome_unknown`).
- **Docs**: the one now-inaccurate clause in `specs/anyharness/sessions.md` amended.

### Testing (specs/TESTING.md)

Tier 1, all against real SQLite or an in-process fake side-door HTTP server (no mock LLM, no fake sandbox):
- Pre-validation matrix: absent id, non-user role, listing-membership mismatch each hard-error without dispatching; happy path dispatches.
- Two-boundary contract: two mapped ids produce two distinct fork POST bodies and distinct child ids.
- Negative controls: unauthenticated-200 ⇒ Refused; off-host-reachable (0.0.0.0 bind) ⇒ Refused; non-Ready/absent side-door at dispatch ⇒ hard error, never a tip fork.
- Store first-writer-wins + unmapped-lookup tests; registry parse fail-closed tests (dup/unknown entries).
- Contract fixtures: `fixtures/contracts/opencode-sidedoor/` pinned to v1.18.3 with provenance README; client tests assert against them.
- Negative control on the cardinal-sin guard: disabling the listing check makes `absent_from_listing_is_invalid_fork_target` fail (`FAILED. 0 passed; 1 failed`), restored green.

Local: `cargo check -p anyharness-lib` clean; `cargo test -p anyharness-lib sidedoor` → `ok. 25 passed; 0 failed`; `... fork` → `ok. 47 passed; 0 failed`; `... opencode_message_ids` → `ok. 3 passed; 0 failed`; `python3 scripts/check_docs.py` → passed (227 files).

### Observability

Structured warn on side-door Refused (reason, never the password); side-door failures surface through the existing fork reason taxonomy (`TARGET_NOT_FOUND`, `INVALID_FORK_TARGET`, `FORK_NATIVE_OUTCOME_UNKNOWN`).

### Security: password residence (verified-absent audit)

The generated `OPENCODE_SERVER_PASSWORD` is redacted in `SidedoorSpawnConfig`'s hand-written `Debug`, and never persisted. Its one un-redacted residence is the generic session env map (`env.session: BTreeMap<String, String>` on `LaunchEnv`, inserted at `driver/opencode_sidedoor.rs`). The safety guarantee here is **not** a missing `Debug` impl — `LaunchEnv` (`live/sessions/model.rs`) *does* `derive(Debug)` and directly owns that map, so a `{:?}` over a bare `LaunchEnv` value would render the password in the clear. The guarantee rests **solely on the grep-verified absence of any such call site**:

- No `{:?}`/`{:#?}` is ever applied to a `LaunchEnv` value or to `env.session` anywhere in the tree — repo-wide grep: **no matches**.
- The only consumer that reads `env.session` is the spawn path (`live/sessions/driver/process.rs`), which iterates the map to set the child process env via `merge_spawn_env` — the result is handed to `Command`, never to a log. Its own log lines emit only `session_id` / `workspace_id` / `agent_kind` / program+cwd paths / timings / `error`.
- Every side-door warn (`driver/opencode_sidedoor.rs`) emits `session_id` / `error` / a Refused-reason string only; no site formats the password.

(For the record: the embedding `SessionLaunch` struct does *not* `derive(Debug)`, but that is incidental — it is not the load-bearing fact, because `LaunchEnv` derives `Debug` on its own and a `{:?}` on a bare `LaunchEnv` value would leak regardless. The guarantee is the absent call site, full stop.) Flagged for whoever next touches these structs; the optional hardening is a hand-written redacted `Debug` for `LaunchEnv` (matching `SidedoorSpawnConfig`), deferred as a follow-up since it moves the head.

### Notes for review

- Capability derivation runs post-readiness in actor startup (not in `action_capabilities_from_acp`) because side-door state is only known after spawn; re-persist only occurs when derived true.
- Readiness adds a bounded (≤5s, typically <200ms) probe to OpenCode session startup only.
- Live two-boundary + off-host qualification probe on the real vendor pin runs as the lane's manual gate; the registry flip to `qualified:true` is deliberately NOT in this PR.
- Known-flake disclosure: an earlier run on `1abbe56a4` showed a panic in `process_kill::tests::census_counts_git_executables_distinctly_from_the_total` (`process_kill_tests.rs:302`) — the program-wide known flake (this test spawns real OS processes and races kill-vs-reap; zero diff vs main here). It cleared on the fresh run for `b55bfeff0`, where "Cargo check & test" passes; the real red on that earlier run was the schema-snapshot mismatch, now fixed by regenerating `anyharness-db-schema.sql` for the store migration (renumbered 0072 -> 0074 in the refold).

### Lane C / Lane D seam boundary

Steps 7 (startup capability flip) and 8 (fork dispatch) sit at two sites that Lane D's charter also touches. To keep C and D from double-landing the same edit, this PR lands **only the OpenCode-scoped arms** ADR C assigns and leaves every generic/cross-adapter path byte-for-byte unchanged:

- **Capability-persist site (`live/sessions/actor/startup.rs`)** — Lane C adds *only* the OpenCode branch: read the qualification registry for `(opencode, resolved_native_version)` and derive `targeted_fork = qualified && sidedoor Ready`. Every non-OpenCode adapter keeps its existing hardcoded `targeted_fork = false`. Lane C does **not** build the general cross-adapter capability-flip mechanism — that stays Lane D.
- **Fork-dispatch site (`runtime/fork/…`)** — Lane C adds *only* the side-door client dispatch branch: OpenCode-with-capability resolves the vendor message id and dispatches through the parent actor's side-door op. The pre-existing rung-3 hard stop is preserved verbatim for every other targeted case. Lane C does **not** restructure the generic fork-dispatch path — that stays Lane D.

Seam: C's changes are additive OpenCode-only branches inside these two sites; D owns the generic mechanism at the same sites. They meet at the branch point and do not overlap, so D and C can both land without colliding. If D lands first, C's arms slot into the generic switch it builds; if C lands first, D generalizes around the OpenCode arm.

### Boundary exception (AH-CONTRACT-1): relocation, not net-new

The exception ledger's own preamble states: *"a net-new entry is an amendment (lints/README.md) and needs founder approval."* The single `ForkSessionTarget` entry moved from `runtime/fork.rs` to `runtime/fork/mod.rs` is **not** net-new — it is the same already-grandfathered wire-type import on the `fork_session` public signature, relocated because the pre-authorized move-only split retired `fork.rs` into `fork/`. The split also eliminated the import from `fork/sidedoor.rs` entirely (the capability is now passed as a plain `bool`), so no exception was added there. Relocation of an existing grandfathered site under a rename/move is legal maintenance per the ledger's content-fingerprint design; the lead has authorized this relocation-not-net-new, surfaced here for founder review at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





