### PR TITLE
feat(workflows): per-leg authored prompts with N-way fan-out (F5+F6, rung 5)

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/workflow_runs_openapi.rs
+++ b/anyharness/crates/anyharness-lib/src/api/workflow_runs_openapi.rs
@@ -34,6 +34,7 @@ use utoipa::OpenApi;
         crate::domains::workflows::model::WorkflowNodeType,
         crate::domains::workflows::definition::WorkflowDefinition,
         crate::domains::workflows::definition::DefinitionNode,
+        crate::domains::workflows::definition::DefinitionLeg,
         crate::domains::workflows::definition::NodeModel,
         crate::domains::workflows::definition::DefinitionEdge,
         crate::domains::workflows::definition::DefinitionInput,

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/definition.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/definition.rs
@@ -22,6 +22,11 @@ use super::model::WorkflowNodeType;
 
 pub const DEFINITION_SCHEMA_VERSION: u32 = 2;
 
+/// The most parallel leg prompts one node may fan out to (ruling F5). A node
+/// with `legs` present must carry 2..=`MAX_NODE_LEGS`; a single-leg node is
+/// expressed the old way (no `legs`), so `legs` of length 0 or 1 is invalid.
+pub const MAX_NODE_LEGS: usize = 8;
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct WorkflowDefinition {
@@ -48,6 +53,33 @@ pub struct DefinitionNode {
     pub prompt: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<NodeModel>,
+    /// Parallel leg prompts (ruling F5). Absent means today's 1:1 node/session
+    /// behavior exactly (and serializes byte-identically). Present means a
+    /// parallel node: 2..=`MAX_NODE_LEGS` legs, each with its own authored
+    /// prompt, `legs[0].prompt` equal to `prompt` so leg 0 is the
+    /// representative session and `leg_index` addresses `legs[i]` uniformly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legs: Option<Vec<DefinitionLeg>>,
+}
+
+impl DefinitionNode {
+    /// The authored prompt of every leg in order — the multi-leg list when
+    /// present, else the single node prompt. Leg 0 is always the node prompt
+    /// (validation pins `legs[0].prompt == prompt`).
+    pub fn leg_prompts(&self) -> Vec<&str> {
+        match &self.legs {
+            Some(legs) if legs.len() > 1 => legs.iter().map(|leg| leg.prompt.as_str()).collect(),
+            _ => vec![self.prompt.as_str()],
+        }
+    }
+}
+
+/// One parallel leg's authored prompt (ruling F5). Legs have no edges,
+/// ordering, or inter-leg dependencies — the chain stays linear at node level.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DefinitionLeg {
+    pub prompt: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
@@ -217,27 +249,54 @@ impl WorkflowDefinition {
 
         let chain = self.linear_chain(&node_ids)?;
 
-        for node in &self.nodes {
-            let references = parse_references(&node.prompt)
-                .map_err(|error| invalid(format!("node '{}': {}", node.id, error.detail)))?;
+        // Reference-grammar validation for one prompt, labelled by its owner
+        // (the node, or `node 'x' leg i` for a fan-out leg) so a bad reference
+        // inside a leg names the leg (ruling F5).
+        let validate_refs = |prompt: &str, label: &str| -> Result<(), DefinitionValidationError> {
+            let references = parse_references(prompt)
+                .map_err(|error| invalid(format!("{label}: {}", error.detail)))?;
             for reference in references {
                 match reference {
-                    PromptReference::Input(name) => {
-                        if !input_names.contains(name.as_str()) {
-                            return Err(invalid(format!(
-                                "node '{}' references undeclared @input:{name}",
-                                node.id
-                            )));
-                        }
+                    PromptReference::Input(name) if !input_names.contains(name.as_str()) => {
+                        return Err(invalid(format!("{label} references undeclared @input:{name}")));
                     }
-                    PromptReference::Doc(slug) => {
-                        if !doc_slugs.contains(slug.as_str()) {
-                            return Err(invalid(format!(
-                                "node '{}' references unknown @doc:{slug}",
-                                node.id
-                            )));
-                        }
+                    PromptReference::Doc(slug) if !doc_slugs.contains(slug.as_str()) => {
+                        return Err(invalid(format!("{label} references unknown @doc:{slug}")));
                     }
+                    _ => {}
+                }
+            }
+            Ok(())
+        };
+
+        for node in &self.nodes {
+            validate_refs(&node.prompt, &format!("node '{}'", node.id))?;
+            // Ruling F5: a parallel node carries 2..=MAX_NODE_LEGS legs, leg 0's
+            // prompt equals the node prompt (so every old consumer of
+            // node.prompt stays correct), and every leg prompt is non-blank and
+            // reference-grammar valid. `linear_chain` above is untouched: legs
+            // are inside the node, not edges.
+            if let Some(legs) = &node.legs {
+                if !(2..=MAX_NODE_LEGS).contains(&legs.len()) {
+                    return Err(invalid(format!(
+                        "node '{}' has {} legs; a parallel node needs 2..={MAX_NODE_LEGS} \
+                         (a single-leg node omits `legs`)",
+                        node.id,
+                        legs.len()
+                    )));
+                }
+                if legs[0].prompt != node.prompt {
+                    return Err(invalid(format!(
+                        "node '{}' prompt must equal legs[0].prompt (leg 0 is the \
+                         representative session)",
+                        node.id
+                    )));
+                }
+                for (index, leg) in legs.iter().enumerate() {
+                    if leg.prompt.trim().is_empty() {
+                        return Err(invalid(format!("node '{}' leg {index} has a blank prompt", node.id)));
+                    }
+                    validate_refs(&leg.prompt, &format!("node '{}' leg {index}", node.id))?;
                 }
             }
         }

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/definition_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/definition_tests.rs
@@ -2,9 +2,9 @@
 //! invocation-snapshot revalidation, with a negative control per rule.
 
 use super::definition::{
-    parse_references, DefinitionEdge, DefinitionInput, DefinitionNode, DocTemplate,
+    parse_references, DefinitionEdge, DefinitionInput, DefinitionLeg, DefinitionNode, DocTemplate,
     InvocationPlacement, InvocationSnapshot, PlacementMode, PromptReference, WorkflowDefinition,
-    DEFINITION_SCHEMA_VERSION,
+    DEFINITION_SCHEMA_VERSION, MAX_NODE_LEGS,
 };
 use super::model::WorkflowNodeType;
 
@@ -15,6 +15,7 @@ fn node(id: &str, prompt: &str) -> DefinitionNode {
         title: format!("Node {id}"),
         prompt: prompt.into(),
         model: None,
+        legs: None,
     }
 }
 
@@ -426,4 +427,116 @@ fn snapshot_pins_the_workspace_id_to_the_existing_workspace_mode() {
             error.detail
         );
     }
+}
+
+// --- Ruling F5: parallel-node leg prompts ---
+
+/// A single Agent node carrying `prompts` as its leg list; `prompt` (leg 0)
+/// mirrors `prompts[0]` so the representative invariant holds by construction.
+fn legged(prompts: &[&str]) -> WorkflowDefinition {
+    WorkflowDefinition {
+        schema_version: DEFINITION_SCHEMA_VERSION,
+        nodes: vec![DefinitionNode {
+            id: "panel".into(),
+            node_type: WorkflowNodeType::Agent,
+            title: "Panel".into(),
+            prompt: prompts[0].into(),
+            model: None,
+            legs: Some(prompts.iter().map(|p| DefinitionLeg { prompt: (*p).into() }).collect()),
+        }],
+        edges: vec![],
+        inputs: vec![],
+        doc_templates: vec![],
+    }
+}
+
+#[test]
+fn a_valid_two_leg_node_passes_and_exposes_both_prompts() {
+    let definition = legged(&["correctness review", "security review"]);
+    assert_eq!(definition.validate().unwrap(), vec!["panel".to_string()]);
+    assert_eq!(
+        definition.nodes[0].leg_prompts(),
+        vec!["correctness review", "security review"]
+    );
+}
+
+#[test]
+fn legs_cap_at_max_node_legs() {
+    let prompts: Vec<String> = (0..MAX_NODE_LEGS).map(|i| format!("leg {i}")).collect();
+    let refs: Vec<&str> = prompts.iter().map(String::as_str).collect();
+    assert!(legged(&refs).validate().is_ok(), "8 legs is the cap and valid");
+
+    let too_many: Vec<String> = (0..MAX_NODE_LEGS + 1).map(|i| format!("leg {i}")).collect();
+    let refs: Vec<&str> = too_many.iter().map(String::as_str).collect();
+    assert!(legged(&refs).validate().is_err(), "9 legs exceeds the cap");
+}
+
+#[test]
+fn a_single_leg_list_is_rejected() {
+    // A one-leg node is expressed the old way (no `legs`); a length-1 list is
+    // a validation error, not today's behavior.
+    assert!(legged(&["only one"]).validate().is_err());
+}
+
+#[test]
+fn an_empty_leg_list_is_rejected() {
+    let mut definition = legged(&["a", "b"]);
+    definition.nodes[0].legs = Some(vec![]);
+    assert!(definition.validate().is_err());
+}
+
+#[test]
+fn a_blank_leg_prompt_is_rejected() {
+    let mut definition = legged(&["real prompt", "   "]);
+    let error = definition.validate().unwrap_err();
+    assert!(error.detail.contains("leg 1"), "{}", error.detail);
+    // And leg 0 blank when it equals a blank node prompt:
+    definition.nodes[0].prompt = "   ".into();
+    definition.nodes[0].legs = Some(vec![
+        DefinitionLeg { prompt: "   ".into() },
+        DefinitionLeg { prompt: "real".into() },
+    ]);
+    assert!(definition.validate().is_err());
+}
+
+#[test]
+fn node_prompt_must_equal_leg_zero() {
+    let mut definition = legged(&["representative", "sibling"]);
+    definition.nodes[0].prompt = "drifted from leg 0".into();
+    let error = definition.validate().unwrap_err();
+    assert!(error.detail.contains("legs[0]"), "{}", error.detail);
+}
+
+#[test]
+fn a_reference_error_inside_a_leg_names_the_leg() {
+    // Leg 1 references an undeclared input; the error must carry the leg index
+    // (the prompt-to-leg cardinal sin surfaces at authoring, per F5).
+    let mut definition = legged(&["fine", "look at @input:missing"]);
+    definition.inputs = vec![];
+    let error = definition.validate().unwrap_err();
+    assert!(error.detail.contains("leg 1"), "{}", error.detail);
+    assert!(error.detail.contains("missing"), "{}", error.detail);
+}
+
+#[test]
+fn a_valid_leg_reference_resolves_against_declared_inputs_and_docs() {
+    let mut definition = legged(&["plan @input:ticket", "review @doc:plan-doc"]);
+    definition.inputs = vec![DefinitionInput {
+        name: "ticket".into(),
+        description: None,
+        required: false,
+    }];
+    definition.doc_templates = vec![DocTemplate {
+        slug: "plan-doc".into(),
+        producing_node_id: "panel".into(),
+        body: String::new(),
+    }];
+    assert!(definition.validate().is_ok());
+}
+
+#[test]
+fn an_unknown_field_inside_a_leg_is_rejected() {
+    // deny_unknown_fields on DefinitionLeg: a stray key fails deserialization.
+    let json = r#"{"prompt":"do it","weight":3}"#;
+    assert!(serde_json::from_str::<DefinitionLeg>(json).is_err());
 }

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/render_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/render_tests.rs
@@ -314,3 +314,56 @@ fn rendered_prompt_and_preamble_paths_are_run_scoped() {
     assert!(preamble.contains("/ws/.proliferate/context/run-1/00-plan-doc.md"));
     assert!(preamble.contains("/ws/.proliferate/context/run-1/notes.md"));
 }
+
+// --- Ruling F5: the prompt-to-leg invariant (R4) ---
+
+/// Rendering leg i's selected prompt lands legs[i] — and no sibling leg — into
+/// that leg's envelope. The selection under test is `DefinitionNode::leg_prompts`
+/// (the same one the actor's fan-out consumes); its negative control is to make
+/// it return leg 0's prompt for every leg, which trips `leg {i} selection` here.
+#[test]
+fn each_leg_envelope_carries_only_its_own_leg_prompt() {
+    use super::definition::{DefinitionLeg, DefinitionNode};
+
+    let authored = ["CORRECTNESS-REVIEW", "SECURITY-REVIEW", "PERF-REVIEW"];
+    let node = DefinitionNode {
+        id: "panel".into(),
+        node_type: WorkflowNodeType::Agent,
+        title: "Panel".into(),
+        prompt: authored[0].into(),
+        model: None,
+        legs: Some(
+            authored
+                .iter()
+                .map(|p| DefinitionLeg { prompt: (*p).into() })
+                .collect(),
+        ),
+    };
+    let selected = node.leg_prompts();
+    assert_eq!(selected.len(), authored.len());
+    let no_args = arguments(&[]);
+    for (i, prompt) in selected.iter().enumerate() {
+        assert_eq!(*prompt, authored[i], "leg {i} selection must be legs[i].prompt");
+        let envelope = render_envelope(&RenderInputs {
+            node_type: WorkflowNodeType::Agent,
+            prompt,
+            mode: ResolveMode::Strict,
+            arguments: &no_args,
+            docs: &[],
+            context_dir: Path::new("/ws/.proliferate/context/run-1"),
+        })
+        .expect("render leg");
+        assert!(
+            envelope.first_message.contains(authored[i]),
+            "leg {i} envelope must contain its own prompt"
+        );
+        for (j, sibling) in authored.iter().enumerate() {
+            if i != j {
+                assert!(
+                    !envelope.first_message.contains(sibling),
+                    "leg {i} envelope must not contain leg {j}'s prompt"
+                );
+            }
+        }
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/store.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/store.rs
@@ -12,7 +12,7 @@ mod node_sessions;
 use rusqlite::{params, Connection, OptionalExtension};
 use uuid::Uuid;
 
-use super::definition::InvocationSnapshot;
+use super::definition::{InvocationSnapshot, WorkflowDefinition};
 use super::model::{
     RenderedEnvelope, WorkflowNodeFailureCode, WorkflowNodeKind, WorkflowNodeStatus,
     WorkflowNodeType, WorkflowRunDocRecord, WorkflowRunNodeRecord, WorkflowRunRecord,
@@ -72,6 +72,13 @@ pub struct CreatedRun {
 pub enum ResolvedSideEffect {
     None,
     StartNode { node_row_id: String },
+    /// Fan-out (ruling F5): launch one session per authored leg prompt of a
+    /// parallel node. The actor loops the node's legs; a one-leg node never
+    /// produces this (it stays `StartNode`, byte-identical to today). Rung 6
+    /// extends this family with `DisposeSessionThenStartLeg` (per-leg redo) and
+    /// `DisposeSessionsThenStartLegs` (whole-node redo), which dispose then
+    /// re-enter this same launch path.
+    StartNodeLegs { node_row_id: String },
     DisposeSession { session_id: String },
     /// Ruling L's compound effect: a redo of a RUNNING node first disposes
     /// the session it took over from, then starts the minted replacement.
@@ -95,6 +102,45 @@ pub struct AppliedTransition {
 
 fn now() -> String {
     chrono::Utc::now().to_rfc3339()
+}
+
+/// The launch side effect for a node about to start: `StartNodeLegs` for a
+/// parallel node (its definition leg list has > 1 entry, ruling F5), else the
+/// unchanged singular `StartNode` — so a one-leg node produces exactly today's
+/// effect (the gate). Reads the frozen definition off the run; only defined
+/// chain rows fan out (adhoc/replacement rows carry a single prompt), and any
+/// parse miss falls back to the single-leg effect.
+pub fn start_side_effect(state: &RunState, node_row_id: &str) -> ResolvedSideEffect {
+    if node_leg_count(state, node_row_id) > 1 {
+        ResolvedSideEffect::StartNodeLegs {
+            node_row_id: node_row_id.to_string(),
+        }
+    } else {
+        ResolvedSideEffect::StartNode {
+            node_row_id: node_row_id.to_string(),
+        }
+    }
+}
+
+/// How many legs the node about to launch fans out to (1 for every one-leg
+/// node, i.e. every definition without a `legs` list).
+pub fn node_leg_count(state: &RunState, node_row_id: &str) -> usize {
+    let Some(node) = state.node(node_row_id) else {
+        return 1;
+    };
+    let Some(def_node_id) = node.definition_node_id.as_deref() else {
+        return 1;
+    };
+    let Ok(definition) = serde_json::from_str::<WorkflowDefinition>(&state.run.definition_json)
+    else {
+        return 1;
+    };
+    definition
+        .nodes
+        .iter()
+        .find(|candidate| candidate.id == def_node_id)
+        .map(|candidate| candidate.leg_prompts().len())
+        .unwrap_or(1)
 }
 
 /// The one-live-run law refused an insert (Ruling B, journaled as an ADR
@@ -333,9 +379,9 @@ impl WorkflowStore {
                             ..RunUpdate::default()
                         },
                     )?;
-                    side_effect = ResolvedSideEffect::StartNode {
-                        node_row_id: next_node_row_id.clone(),
-                    };
+                    // Fan-out (ruling F5): a parallel next node launches all its
+                    // legs; a one-leg node produces the unchanged StartNode.
+                    side_effect = start_side_effect(&state, next_node_row_id);
                 }
                 Transition::CompleteRun {
                     completed_node_row_id,
@@ -523,6 +569,12 @@ impl WorkflowStore {
                          WHERE id = ?1",
                         params![node_row_id, timestamp],
                     )?;
+                    // Ruling F6: resume re-fans-out ALL legs on a fresh
+                    // generation, so the node's ledger rows are truncated here
+                    // before the relaunch re-inserts leg 0..N. A one-leg node's
+                    // single row is deleted then re-inserted by the launch upsert
+                    // — end state unchanged.
+                    node_sessions::truncate_legs_tx(tx, node_row_id)?;
                     update_run(
                         tx,
                         run_id,
@@ -533,9 +585,7 @@ impl WorkflowStore {
                             ..RunUpdate::default()
                         },
                     )?;
-                    side_effect = ResolvedSideEffect::StartNode {
-                        node_row_id: node_row_id.clone(),
-                    };
+                    side_effect = start_side_effect(&state, node_row_id);
                 }
                 Transition::AddAdhoc { adhoc } => {
                     let new_id = insert_new_node(tx, run_id, adhoc, &timestamp)?;
@@ -699,6 +749,52 @@ impl WorkflowStore {
             agent_kind = agent_kind.unwrap_or("unknown"),
             chain_index = chain_index.unwrap_or(-1),
             "workflow node launched",
+        );
+        Ok(())
+    }
+
+    /// The fan-out stamp (ruling F5): in ONE transaction, stamp the node's
+    /// scalar/representative session (leg 0) and prompt_id and insert every
+    /// leg's ledger row keyed by `leg_index` — the durable prompt-to-leg
+    /// linkage. `legs` must be `(leg_index, session_id)` in leg order with a
+    /// row for leg 0; the representative is `legs[0]`. Emits one
+    /// `workflow.node.launched` for the representative, matching `stamp_session`.
+    pub fn stamp_fanout(
+        &self,
+        node_row_id: &str,
+        prompt_id: Option<&str>,
+        agent_kind: Option<&str>,
+        legs: &[(i64, String)],
+    ) -> anyhow::Result<()> {
+        let representative = legs
+            .iter()
+            .find(|(leg_index, _)| *leg_index == 0)
+            .map(|(_, session_id)| session_id.clone())
+            .ok_or_else(|| anyhow::anyhow!("fan-out stamp needs a leg 0 (representative)"))?;
+        let (run_id, chain_index) = self.db.with_tx_anyhow(|tx| {
+            tx.execute(
+                "UPDATE workflow_run_nodes SET session_id = ?2, prompt_id = ?3 WHERE id = ?1",
+                params![node_row_id, representative, prompt_id],
+            )?;
+            for (leg_index, session_id) in legs {
+                node_sessions::upsert_leg_at_tx(tx, node_row_id, *leg_index, session_id)?;
+            }
+            let (run_id, chain_index): (String, Option<i64>) = tx.query_row(
+                "SELECT run_id, chain_index FROM workflow_run_nodes WHERE id = ?1",
+                params![node_row_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )?;
+            Ok((run_id, chain_index))
+        })?;
+        tracing::info!(
+            target: WORKFLOW_NODE_LAUNCHED_TRACING_TARGET,
+            run_id = %run_id,
+            node_row_id = %node_row_id,
+            session_id = %representative,
+            agent_kind = agent_kind.unwrap_or("unknown"),
+            chain_index = chain_index.unwrap_or(-1),
+            legs = legs.len(),
+            "workflow parallel node launched",
         );
         Ok(())
     }

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/store.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/store.rs
@@ -663,8 +663,13 @@ impl WorkflowStore {
             if let Transition::Cancel { .. } = transition {
                 node_sessions::cancel_all_run_legs_tx(tx, run_id, &timestamp)?;
             } else if let Some((leg_node, leg_status)) = node_sessions::finished_leg_of(transition) {
-                let session = turn_session(event)
-                    .or_else(|| state.node(leg_node).and_then(|node| node.session_id.clone()));
+                // A launch failure has no turn session and strands every
+                // freshly stamped leg, so its stamp goes keyless (whole node).
+                let session = match event {
+                    WorkflowEvent::NodeLaunchFailed { .. } => None,
+                    _ => turn_session(event)
+                        .or_else(|| state.node(leg_node).and_then(|node| node.session_id.clone())),
+                };
                 node_sessions::mark_leg_terminal_tx(
                     tx,
                     leg_node,

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/store/node_sessions.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/store/node_sessions.rs
@@ -38,13 +38,39 @@ pub(super) fn upsert_leg_tx(
     node_row_id: &str,
     session_id: &str,
 ) -> rusqlite::Result<()> {
+    upsert_leg_at_tx(tx, node_row_id, 0, session_id)
+}
+
+/// The fan-out primitive (ruling F5): insert (or reset) the row at `leg_index`,
+/// the durable prompt-to-leg linkage — `leg_index` addresses `legs[leg_index]`
+/// in the definition. Leg 0 is the representative; legs 1..N are the parallel
+/// siblings the actor mints one session each for.
+pub(super) fn upsert_leg_at_tx(
+    tx: &Connection,
+    node_row_id: &str,
+    leg_index: i64,
+    session_id: &str,
+) -> rusqlite::Result<()> {
     tx.execute(
         "INSERT INTO workflow_run_node_sessions
             (node_row_id, leg_index, session_id, status, completed_at)
-         VALUES (?1, 0, ?2, 'running', NULL)
+         VALUES (?1, ?2, ?3, 'running', NULL)
          ON CONFLICT(node_row_id, leg_index) DO UPDATE SET
             session_id = excluded.session_id, status = 'running', completed_at = NULL",
-        params![node_row_id, session_id],
+        params![node_row_id, leg_index, session_id],
+    )?;
+    Ok(())
+}
+
+/// Truncate every ledger row of a node (ruling F6): boot-fence resume
+/// re-fans-out ALL legs from the definition on a fresh generation, so the old
+/// rows are cleared before the relaunch re-inserts leg 0..N. A one-leg node has
+/// exactly one row, so this is the delete half of the reset the upsert did
+/// before — observable end state unchanged.
+pub(super) fn truncate_legs_tx(tx: &Connection, node_row_id: &str) -> rusqlite::Result<()> {
+    tx.execute(
+        "DELETE FROM workflow_run_node_sessions WHERE node_row_id = ?1",
+        params![node_row_id],
     )?;
     Ok(())
 }

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/store_fanin_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/store_fanin_tests.rs
@@ -383,3 +383,46 @@ fn resume_truncates_the_ledger_and_re_fans_out() {
         }
     );
 }
+
+#[test]
+fn a_failed_fan_out_launch_terminalizes_every_leg_it_stamped() {
+    let store = test_store();
+    let created = store
+        .create_run_with_first_node(parallel_params("run-p", 3))
+        .expect("create");
+    let node_id = created.first_node_row_id.clone();
+    let legs = vec![
+        (0i64, "sess-0".to_string()),
+        (1, "sess-1".to_string()),
+        (2, "sess-2".to_string()),
+    ];
+    store
+        .stamp_fanout(&node_id, Some("wf2-panel"), Some("claude"), &legs)
+        .expect("stamp fanout");
+    let state = store.load_run_state("run-p").expect("load").expect("run");
+
+    let failed = apply(
+        &store,
+        "run-p",
+        &state,
+        &WorkflowEvent::NodeLaunchFailed {
+            node_row_id: node_id.clone(),
+        },
+    );
+
+    // Rung-5 review finding: the representative fallback stamped only leg 0,
+    // stranding legs 1..N at 'running' against compensated sessions. The
+    // launch-failure stamp covers every row the fan-out inserted.
+    let mut rows = failed.legs_of(&node_id);
+    rows.sort_by_key(|leg| leg.leg_index);
+    assert_eq!(rows.len(), 3);
+    for leg in rows {
+        assert_eq!(
+            leg.status,
+            WorkflowLegStatus::Failed(super::model::WorkflowNodeFailureCode::NodeLaunchFailed),
+            "leg {}",
+            leg.leg_index
+        );
+        assert!(leg.completed_at.is_some(), "leg {}", leg.leg_index);
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/store_fanin_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/store_fanin_tests.rs
@@ -8,11 +8,13 @@
 use crate::persistence::Db;
 
 use super::definition::{
-    DefinitionNode, InvocationPlacement, InvocationSnapshot, PlacementMode, WorkflowDefinition,
-    DEFINITION_SCHEMA_VERSION,
+    DefinitionLeg, DefinitionNode, InvocationPlacement, InvocationSnapshot, PlacementMode,
+    WorkflowDefinition, DEFINITION_SCHEMA_VERSION,
 };
 use super::model::{WorkflowLegStatus, WorkflowNodeType, WorkflowRunStatus};
-use super::store::{NewRunParams, WorkflowStore};
+use super::store::{
+    node_leg_count, start_side_effect, NewRunParams, ResolvedSideEffect, WorkflowStore,
+};
 use super::transition::{
     next, Decision, RunState, TurnFinished, TurnStopReason, WorkflowCommand, WorkflowEvent,
 };
@@ -56,6 +58,7 @@ fn params(run_id: &str) -> NewRunParams {
             title: "Only".into(),
             prompt: "do the thing".into(),
             model: None,
+            legs: None,
         }],
         edges: vec![],
         inputs: vec![],
@@ -225,4 +228,158 @@ fn cancel_marks_every_running_leg_in_the_run_cancelled() {
         assert_eq!(legs[0].status, WorkflowLegStatus::Cancelled, "node {node_id}");
         assert!(legs[0].completed_at.is_some(), "node {node_id}");
     }
+}
+// --- Ruling F5/F6: fan-out at the store seam ---
+
+/// A single Agent node fanned out to `n` distinguishable leg prompts. Leg 0's
+/// prompt mirrors the node prompt (the representative invariant).
+fn parallel_params(run_id: &str, n: usize) -> NewRunParams {
+    let prompts: Vec<String> = (0..n).map(|i| format!("leg {i} work")).collect();
+    let definition = WorkflowDefinition {
+        schema_version: DEFINITION_SCHEMA_VERSION,
+        nodes: vec![DefinitionNode {
+            id: "panel".into(),
+            node_type: WorkflowNodeType::Agent,
+            title: "Panel".into(),
+            prompt: prompts[0].clone(),
+            model: None,
+            legs: Some(
+                prompts
+                    .iter()
+                    .map(|p| DefinitionLeg { prompt: p.clone() })
+                    .collect(),
+            ),
+        }],
+        edges: vec![],
+        inputs: vec![],
+        doc_templates: vec![],
+    };
+    let snapshot = InvocationSnapshot {
+        schema_version: DEFINITION_SCHEMA_VERSION,
+        workflow_definition_id: "wd-p".into(),
+        definition,
+        arguments: serde_json::Map::new(),
+        placement: InvocationPlacement {
+            repo_config_id: "rc-1".into(),
+            mode: PlacementMode::Worktree,
+            workspace_id: None,
+        },
+    };
+    let definition_json = serde_json::to_string(&snapshot.definition).expect("serialize");
+    NewRunParams {
+        run_id: run_id.into(),
+        invocation_id: format!("inv-{run_id}"),
+        workspace_id: "workspace-1".into(),
+        snapshot,
+        definition_json,
+    }
+}
+
+#[test]
+fn a_multi_leg_node_resolves_to_the_fan_out_start_effect() {
+    let store = test_store();
+    let created = store
+        .create_run_with_first_node(parallel_params("run-p", 3))
+        .expect("create");
+    let node_id = created.first_node_row_id.clone();
+    let state = &created.state;
+    assert_eq!(node_leg_count(state, &node_id), 3);
+    assert_eq!(
+        start_side_effect(state, &node_id),
+        ResolvedSideEffect::StartNodeLegs {
+            node_row_id: node_id.clone()
+        }
+    );
+}
+
+#[test]
+fn a_one_leg_node_keeps_the_singular_start_effect() {
+    let store = test_store();
+    let created = store
+        .create_run_with_first_node(params("run-1"))
+        .expect("create");
+    let node_id = created.first_node_row_id.clone();
+    assert_eq!(node_leg_count(&created.state, &node_id), 1);
+    assert_eq!(
+        start_side_effect(&created.state, &node_id),
+        ResolvedSideEffect::StartNode {
+            node_row_id: node_id
+        }
+    );
+}
+
+#[test]
+fn stamp_fanout_writes_one_ledger_row_per_leg() {
+    let store = test_store();
+    let created = store
+        .create_run_with_first_node(parallel_params("run-p", 3))
+        .expect("create");
+    let node_id = created.first_node_row_id.clone();
+    let legs = vec![
+        (0i64, "sess-0".to_string()),
+        (1, "sess-1".to_string()),
+        (2, "sess-2".to_string()),
+    ];
+    store
+        .stamp_fanout(&node_id, Some("wf2-panel"), Some("claude"), &legs)
+        .expect("stamp fanout");
+    let state = store.load_run_state("run-p").expect("load").expect("run");
+    let mut rows = state.legs_of(&node_id);
+    rows.sort_by_key(|leg| leg.leg_index);
+    assert_eq!(rows.len(), 3);
+    for (index, leg) in rows.iter().enumerate() {
+        assert_eq!(leg.leg_index, index as i64);
+        assert_eq!(leg.session_id.as_deref(), Some(format!("sess-{index}").as_str()));
+        assert_eq!(leg.status, WorkflowLegStatus::Running);
+    }
+    // Leg 0 is the representative stamped onto the node's scalar column.
+    assert_eq!(
+        state.node(&node_id).unwrap().session_id.as_deref(),
+        Some("sess-0")
+    );
+}
+
+#[test]
+fn resume_truncates_the_ledger_and_re_fans_out() {
+    let store = test_store();
+    let created = store
+        .create_run_with_first_node(parallel_params("run-p", 3))
+        .expect("create");
+    let node_id = created.first_node_row_id.clone();
+    let legs = vec![
+        (0i64, "sess-0".to_string()),
+        (1, "sess-1".to_string()),
+        (2, "sess-2".to_string()),
+    ];
+    store
+        .stamp_fanout(&node_id, Some("wf2-panel"), Some("claude"), &legs)
+        .expect("stamp fanout");
+
+    // Park the run (boot fence) then resume it.
+    let state = store.load_run_state("run-p").expect("load").expect("run");
+    let fenced = apply(
+        &store,
+        "run-p",
+        &state,
+        &WorkflowEvent::BootFence {
+            code: super::model::WorkflowInterruptionCode::RuntimeRestarted,
+        },
+    );
+    let resume_event = WorkflowEvent::Command(WorkflowCommand::Resume);
+    let transition = match next(&fenced, &resume_event) {
+        Decision::Transition(transition) => transition,
+        other => panic!("expected resume transition, got {other:?}"),
+    };
+    let applied = store
+        .apply_transition("run-p", &transition, &resume_event)
+        .expect("apply resume");
+    // Ruling F6: the ledger is truncated (a fresh generation) and the fan-out
+    // start effect is emitted; the actor re-inserts leg 0..N on relaunch.
+    assert!(applied.state.legs_of(&node_id).is_empty());
+    assert_eq!(
+        applied.side_effect,
+        ResolvedSideEffect::StartNodeLegs {
+            node_row_id: node_id
+        }
+    );
 }

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/store_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/store_tests.rs
@@ -64,6 +64,7 @@ fn snapshot() -> InvocationSnapshot {
                 title: "Plan".into(),
                 prompt: "Plan the work for @input:ticket, write @doc:plan-doc".into(),
                 model: None,
+                legs: None,
             },
             DefinitionNode {
                 id: "review".into(),
@@ -71,6 +72,7 @@ fn snapshot() -> InvocationSnapshot {
                 title: "Review".into(),
                 prompt: "Summarize @doc:plan-doc for review".into(),
                 model: None,
+                legs: None,
             },
             DefinitionNode {
                 id: "ship".into(),
@@ -78,6 +80,7 @@ fn snapshot() -> InvocationSnapshot {
                 title: "Ship".into(),
                 prompt: "Implement per @doc:plan-doc".into(),
                 model: None,
+                legs: None,
             },
         ],
         edges: vec![

--- a/anyharness/crates/anyharness-lib/src/live/workflows/actor.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/actor.rs
@@ -25,6 +25,7 @@ use crate::domains::workflows::render::{
     node_session_title, render_envelope, run_context_dir_relative, RenderInputs,
 };
 use crate::domains::workflows::store::{emit_decision_events, ResolvedSideEffect, WorkflowStore};
+use super::launch::{launch_legs, launch_model};
 use crate::domains::workflows::transition::{
     next, Decision, IllegalTransition, RunState, TurnFinished, WorkflowCommand, WorkflowEvent,
 };
@@ -175,7 +176,10 @@ impl WorkflowActor {
                     self.dispose_session(&session_id).await;
                     effect = ResolvedSideEffect::StartNode { node_row_id };
                 }
-                ResolvedSideEffect::StartNode { node_row_id } => {
+                // Both share `launch_node`, which fans out (F5) or single-launches
+                // by leg count; a one-leg node behaves exactly as before.
+                ResolvedSideEffect::StartNode { node_row_id }
+                | ResolvedSideEffect::StartNodeLegs { node_row_id } => {
                     match self.launch_node(state, &node_row_id).await {
                         Ok(()) => break,
                         Err(error) => {
@@ -270,6 +274,17 @@ impl WorkflowActor {
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("node row {node_row_id} not in run state"))?;
         let definition: WorkflowDefinition = serde_json::from_str(&state.run.definition_json)?;
+
+        // Ruling F5: a parallel node fans out all N legs; one leg falls through.
+        if crate::domains::workflows::store::node_leg_count(state, node_row_id) > 1 {
+            let run = &state.run;
+            launch_legs(&self.deps, &self.run_id, &node, &definition,
+                &run.workspace_id, &run.arguments_json).await?;
+            if let Some(fresh) = self.deps.store.load_run_state(&self.run_id)? {
+                *state = fresh;
+            }
+            return Ok(());
+        }
 
         let envelope = match &node.rendered_envelope {
             Some(envelope) => envelope.clone(),
@@ -500,25 +515,5 @@ impl WorkflowActor {
                 "undo-advance session unlink failed",
             );
         }
-    }
-}
-
-/// Launch config precedence: the node row's own pick wins (adhoc, and
-/// adhoc-redo inheritance per Ruling K.1); a defined/replacement row resolves
-/// through the frozen definition by its `definition_node_id`; otherwise the
-/// boring app default.
-pub(super) fn launch_model(
-    node: &WorkflowRunNodeRecord,
-    definition: &WorkflowDefinition,
-) -> (String, Option<String>, Option<String>) {
-    let model = node.model.clone().or_else(|| {
-        node.definition_node_id
-            .as_deref()
-            .and_then(|id| definition.nodes.iter().find(|node| node.id == id))
-            .and_then(|node| node.model.clone())
-    });
-    match model {
-        Some(model) => (model.agent_kind, model.model_id, model.mode_id),
-        None => (DEFAULT_WORKFLOW_AGENT_KIND.to_string(), None, None),
     }
 }

--- a/anyharness/crates/anyharness-lib/src/live/workflows/launch.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/launch.rs
@@ -1,0 +1,240 @@
+//! Parallel-node fan-out (ruling F5): the actor's launch path for a node whose
+//! definition carries N authored leg prompts. One rendered envelope per leg
+//! (same doc set and inputs, distinct prompt), N minted sessions, N ledger rows
+//! keyed by `leg_index` in the transaction that stamps the representative (leg
+//! 0). Split out of `actor.rs` so that seam stays under its size ratchet; the
+//! one-leg launch path stays inline in the actor, byte-identical to before.
+
+use std::path::Path;
+
+use crate::domains::sessions::model::SessionRecord;
+use crate::domains::sessions::runtime::{InternalSessionCreateInput, TextPromptDispatchError};
+use crate::domains::workflows::definition::{ResolveMode, WorkflowDefinition};
+use crate::domains::workflows::model::{RenderedEnvelope, WorkflowNodeKind, WorkflowRunNodeRecord};
+use crate::domains::workflows::render::{render_envelope, run_context_dir_relative, RenderInputs};
+use crate::origin::OriginContext;
+
+use super::actor::{WorkflowActorDeps, DEFAULT_WORKFLOW_AGENT_KIND};
+
+/// Launch config precedence, shared with the single-leg path: the node row's
+/// own pick wins (adhoc, and adhoc-redo inheritance per Ruling K.1); a
+/// defined/replacement row resolves through the frozen definition by its
+/// `definition_node_id`; otherwise the boring app default.
+pub(super) fn launch_model(
+    node: &WorkflowRunNodeRecord,
+    definition: &WorkflowDefinition,
+) -> (String, Option<String>, Option<String>) {
+    let model = node.model.clone().or_else(|| {
+        node.definition_node_id
+            .as_deref()
+            .and_then(|id| definition.nodes.iter().find(|node| node.id == id))
+            .and_then(|node| node.model.clone())
+    });
+    match model {
+        Some(model) => (model.agent_kind, model.model_id, model.mode_id),
+        None => (DEFAULT_WORKFLOW_AGENT_KIND.to_string(), None, None),
+    }
+}
+
+/// The authored leg prompts of a defined parallel node, in leg order. Leg 0 is
+/// the node prompt (validation pins `legs[0].prompt == prompt`), so this is the
+/// prompt-to-leg selection the invariant test exercises.
+pub(super) fn leg_prompts(node: &WorkflowRunNodeRecord, definition: &WorkflowDefinition) -> Vec<String> {
+    node.definition_node_id
+        .as_deref()
+        .filter(|_| node.kind == WorkflowNodeKind::Defined)
+        .and_then(|id| definition.nodes.iter().find(|candidate| candidate.id == id))
+        .map(|candidate| {
+            candidate
+                .leg_prompts()
+                .into_iter()
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_else(|| vec![node.prompt.clone()])
+}
+
+/// Render leg `prompt`'s envelope against the shared doc set and inputs. Same
+/// path as the single-leg render; only the prompt differs per leg.
+fn render_leg(
+    deps: &WorkflowActorDeps,
+    run_id: &str,
+    node: &WorkflowRunNodeRecord,
+    workspace_path: &str,
+    arguments: &serde_json::Map<String, serde_json::Value>,
+    prompt: &str,
+) -> anyhow::Result<RenderedEnvelope> {
+    let docs = deps.store.list_docs(run_id)?;
+    let context_dir = Path::new(workspace_path).join(run_context_dir_relative(run_id));
+    render_envelope(&RenderInputs {
+        node_type: node.node_type,
+        prompt,
+        // Ruling E: a defined node's leg prompts were validated before the
+        // snapshot froze and render strict.
+        mode: if node.kind == WorkflowNodeKind::Defined {
+            ResolveMode::Strict
+        } else {
+            ResolveMode::Lenient
+        },
+        arguments,
+        docs: &docs,
+        context_dir: &context_dir,
+    })
+    .map_err(|error| anyhow::anyhow!("leg envelope render failed: {error}"))
+}
+
+/// Fan a node out to one session per authored leg prompt (ruling F5). Mints N
+/// sessions and links their workflow columns, then in one transaction stamps
+/// the representative session (leg 0) and inserts N ledger rows keyed by
+/// leg_index, then starts and dispatches each leg's envelope. Any failure
+/// compensates every session already minted so no half-born leg lingers, and
+/// bubbles up so the actor feeds `NodeLaunchFailed` through the table.
+pub(super) async fn launch_legs(
+    deps: &WorkflowActorDeps,
+    run_id: &str,
+    node: &WorkflowRunNodeRecord,
+    definition: &WorkflowDefinition,
+    workspace_id: &str,
+    arguments_json: &str,
+) -> anyhow::Result<()> {
+    let prompts = leg_prompts(node, definition);
+    let (agent_kind, model_id, mode_id) = launch_model(node, definition);
+    let workspace = deps
+        .workspace_store
+        .find_by_id(workspace_id)?
+        .ok_or_else(|| anyhow::anyhow!("workspace {workspace_id} not found for fan-out render"))?;
+    let arguments: serde_json::Map<String, serde_json::Value> =
+        serde_json::from_str(arguments_json)?;
+
+    // Render + mint + link every leg first; the representative is leg 0.
+    let mut legs: Vec<(i64, SessionRecord, RenderedEnvelope)> = Vec::with_capacity(prompts.len());
+    for (index, prompt) in prompts.iter().enumerate() {
+        let envelope = match render_leg(deps, run_id, node, &workspace.path, &arguments, prompt) {
+            Ok(envelope) => envelope,
+            Err(error) => {
+                compensate_all(deps, &legs).await;
+                return Err(error);
+            }
+        };
+        let input = InternalSessionCreateInput {
+            workspace_id: workspace.id.clone(),
+            agent_kind: agent_kind.clone(),
+            model_id: model_id.clone(),
+            mode_id: mode_id.clone(),
+            origin: OriginContext::system_local_runtime(),
+            preselected_session_id: None,
+        };
+        let session_runtime = deps.session_runtime.clone();
+        let session = match tokio::task::spawn_blocking(move || {
+            session_runtime.create_persisted_internal_session(input)
+        })
+        .await
+        {
+            Ok(Ok(session)) => session,
+            Ok(Err(error)) => {
+                compensate_all(deps, &legs).await;
+                return Err(anyhow::anyhow!("leg session create failed: {error:?}"));
+            }
+            Err(join) => {
+                compensate_all(deps, &legs).await;
+                return Err(anyhow::anyhow!("leg session create join failed: {join}"));
+            }
+        };
+        if let Err(error) = deps
+            .session_store
+            .link_workflow_columns(&session.id, run_id, &node.id)
+        {
+            deps.session_runtime
+                .compensate_new_agent_session(&session.id)
+                .await
+                .ok();
+            compensate_all(deps, &legs).await;
+            return Err(error);
+        }
+        legs.push((index as i64, session, envelope));
+    }
+
+    // One transaction: representative stamp + N ledger rows (ruling F5).
+    let ledger: Vec<(i64, String)> = legs
+        .iter()
+        .map(|(index, session, _)| (*index, session.id.clone()))
+        .collect();
+    let rep_envelope = legs.first().map(|(_, _, envelope)| envelope.clone());
+    let rep_prompt_id = format!("wf2-{}", node.id);
+    if let Err(error) = deps
+        .store
+        .stamp_fanout(&node.id, Some(&rep_prompt_id), Some(&agent_kind), &ledger)
+    {
+        compensate_all(deps, &legs).await;
+        return Err(error);
+    }
+    if let Some(envelope) = &rep_envelope {
+        deps.store.store_rendered_envelope(&node.id, envelope).ok();
+    }
+
+    // Start + dispatch each leg; leg 0 keeps the representative prompt id.
+    for (index, session, envelope) in &legs {
+        let prompt_id = if *index == 0 {
+            rep_prompt_id.clone()
+        } else {
+            format!("wf2-{}-l{}", node.id, index)
+        };
+        if let Err(error) = start_and_dispatch(deps, run_id, node, session, envelope, prompt_id).await
+        {
+            compensate_all(deps, &legs).await;
+            return Err(error);
+        }
+    }
+    Ok(())
+}
+
+/// Start one leg's session and dispatch its wrapped envelope in-band (Ruling
+/// D). A lost acknowledgement leaves the leg running (the fence resolves it);
+/// a hard dispatch error bubbles.
+async fn start_and_dispatch(
+    deps: &WorkflowActorDeps,
+    run_id: &str,
+    node: &WorkflowRunNodeRecord,
+    session: &SessionRecord,
+    envelope: &RenderedEnvelope,
+    prompt_id: String,
+) -> anyhow::Result<()> {
+    deps.session_runtime
+        .start_persisted_session(session)
+        .await
+        .map_err(|error| anyhow::anyhow!("leg session start failed: {error:?}"))?;
+    let mut texts = envelope.instruction_blocks.clone();
+    texts.push(envelope.first_message.clone());
+    match deps
+        .session_runtime
+        .send_text_blocks_prompt_with_id(&session.id, texts, prompt_id)
+        .await
+    {
+        Ok(_) => Ok(()),
+        Err(TextPromptDispatchError::AcknowledgementLost) => {
+            tracing::warn!(
+                run_id = %run_id,
+                node_row_id = %node.id,
+                session_id = %session.id,
+                "workflow leg envelope acknowledgement lost; leaving the leg running",
+            );
+            Ok(())
+        }
+        Err(TextPromptDispatchError::Dispatch(error)) => {
+            Err(anyhow::anyhow!("leg envelope dispatch failed: {error:?}"))
+        }
+    }
+}
+
+/// Best-effort compensation of every already-minted leg session on a failed
+/// fan-out — the rows already tell the truth, so a cleanup miss only leaves a
+/// closable session behind.
+async fn compensate_all(deps: &WorkflowActorDeps, legs: &[(i64, SessionRecord, RenderedEnvelope)]) {
+    for (_, session, _) in legs {
+        deps.session_runtime
+            .compensate_new_agent_session(&session.id)
+            .await
+            .ok();
+        deps.session_store.clear_workflow_columns(&session.id).ok();
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/live/workflows/launch_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/launch_tests.rs
@@ -7,7 +7,8 @@
 //! test reuses that suite's scripted-agent fixture — real actor, real
 //! sessions, no mocks of our machinery.
 
-use super::actor::{launch_model, DEFAULT_WORKFLOW_AGENT_KIND};
+use super::actor::DEFAULT_WORKFLOW_AGENT_KIND;
+use super::launch::launch_model;
 use super::lifecycle_tests::{agent_node, chain, fixture, node_by_def};
 use crate::domains::workflows::definition::{
     DefinitionNode, NodeModel, WorkflowDefinition, DEFINITION_SCHEMA_VERSION,
@@ -55,6 +56,7 @@ fn definition_with_model(model: Option<NodeModel>) -> WorkflowDefinition {
             title: "Plan".into(),
             prompt: "plan".into(),
             model,
+            legs: None,
         }],
         edges: Vec::new(),
         inputs: Vec::new(),

--- a/anyharness/crates/anyharness-lib/src/live/workflows/lifecycle_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/lifecycle_tests.rs
@@ -39,6 +39,7 @@ pub(super) fn agent_node(id: &str, prompt: &str) -> DefinitionNode {
         title: format!("Node {id}"),
         prompt: prompt.into(),
         model: None,
+        legs: None,
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/live/workflows/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/mod.rs
@@ -5,6 +5,7 @@
 //! rebuilt from them on first touch.
 
 mod actor;
+mod launch;
 #[cfg(test)]
 mod launch_tests;
 #[cfg(test)]

--- a/anyharness/sdk/generated/openapi.json
+++ b/anyharness/sdk/generated/openapi.json
@@ -10987,6 +10987,19 @@
         },
         "additionalProperties": false
       },
+      "DefinitionLeg": {
+        "type": "object",
+        "description": "One parallel leg's authored prompt (ruling F5). Legs have no edges,\nordering, or inter-leg dependencies — the chain stays linear at node level.",
+        "required": [
+          "prompt"
+        ],
+        "properties": {
+          "prompt": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
       "DefinitionNode": {
         "type": "object",
         "required": [
@@ -10998,6 +11011,16 @@
         "properties": {
           "id": {
             "type": "string"
+          },
+          "legs": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/DefinitionLeg"
+            },
+            "description": "Parallel leg prompts (ruling F5). Absent means today's 1:1 node/session\nbehavior exactly (and serializes byte-identically). Present means a\nparallel node: 2..=`MAX_NODE_LEGS` legs, each with its own authored\nprompt, `legs[0].prompt` equal to `prompt` so leg 0 is the\nrepresentative session and `leg_index` addresses `legs[i]` uniformly."
           },
           "model": {
             "oneOf": [

--- a/anyharness/sdk/src/generated/openapi.ts
+++ b/anyharness/sdk/src/generated/openapi.ts
@@ -2945,8 +2945,23 @@ export interface components {
             name: string;
             required?: boolean;
         };
+        /**
+         * @description One parallel leg's authored prompt (ruling F5). Legs have no edges,
+         *     ordering, or inter-leg dependencies — the chain stays linear at node level.
+         */
+        DefinitionLeg: {
+            prompt: string;
+        };
         DefinitionNode: {
             id: string;
+            /**
+             * @description Parallel leg prompts (ruling F5). Absent means today's 1:1 node/session
+             *     behavior exactly (and serializes byte-identically). Present means a
+             *     parallel node: 2..=`MAX_NODE_LEGS` legs, each with its own authored
+             *     prompt, `legs[0].prompt` equal to `prompt` so leg 0 is the
+             *     representative session and `leg_index` addresses `legs[i]` uniformly.
+             */
+            legs?: components["schemas"]["DefinitionLeg"][] | null;
             model?: null | components["schemas"]["NodeModel"];
             prompt: string;
             title: string;

--- a/apps/packages/product-client/src/components/workflows/builder-v2/WorkflowBuilderInspector.tsx
+++ b/apps/packages/product-client/src/components/workflows/builder-v2/WorkflowBuilderInspector.tsx
@@ -89,6 +89,9 @@ export function WorkflowBuilderInspector({
           onRemove={() => actions.removeNode(selectedNode.id)}
           onMoveUp={() => actions.moveNodeUp(selectedNode.id)}
           onMoveDown={() => actions.moveNodeDown(selectedNode.id)}
+          onAddLeg={() => actions.addLeg(selectedNode.id)}
+          onRemoveLeg={(legIndex) => actions.removeLeg(selectedNode.id, legIndex)}
+          onUpdateLeg={(legIndex, prompt) => actions.updateLeg(selectedNode.id, legIndex, prompt)}
         />
       ) : null}
 

--- a/apps/packages/product-client/src/components/workflows/builder-v2/WorkflowBuilderNodeCard.tsx
+++ b/apps/packages/product-client/src/components/workflows/builder-v2/WorkflowBuilderNodeCard.tsx
@@ -1,4 +1,4 @@
-import type { WorkflowNodeV2 } from "@proliferate/cloud-sdk";
+import type { WorkflowNodeV2WithLegs as WorkflowNodeV2 } from "#product/domain/workflows/definition-v2";
 import { WORKFLOW_BUILDER_COPY } from "#product/copy/workflows/workflow-builder-copy";
 import {
   workflowBuilderModelOptions,
@@ -30,6 +30,10 @@ export interface WorkflowBuilderNodeCardProps {
   onRemove: () => void;
   onMoveUp: () => void;
   onMoveDown: () => void;
+  /** Ruling F5: adds one parallel leg (2..8 legs total). */
+  onAddLeg: () => void;
+  onRemoveLeg: (legIndex: number) => void;
+  onUpdateLeg: (legIndex: number, prompt: string) => void;
 }
 
 /**
@@ -49,12 +53,20 @@ export function WorkflowBuilderNodeCard({
   onRemove,
   onMoveUp,
   onMoveDown,
+  onAddLeg,
+  onRemoveLeg,
+  onUpdateLeg,
 }: WorkflowBuilderNodeCardProps) {
   const fieldPrefix = `workflow-builder-node-${node.id}`;
-  const promptInvalid = issues.some((issue) =>
-    issue.code === "unknown_input_ref"
-    || issue.code === "unknown_doc_ref"
-    || issue.code === "malformed_reference");
+  const legs = node.legs;
+  const promptIssueCodes = new Set(["unknown_input_ref", "unknown_doc_ref", "malformed_reference"]);
+  const promptInvalid = !legs
+    && issues.some((issue) => promptIssueCodes.has(issue.code) && issue.index === undefined);
+  const legInvalid = (legIndex: number) =>
+    issues.some((issue) =>
+      (promptIssueCodes.has(issue.code) || issue.code === "blank_leg_prompt"
+        || (issue.code === "leg_prompt_mismatch" && legIndex === 0))
+      && issue.index === legIndex);
   // Ids are minted, never typed, so the only way to reach an id error is to
   // open a definition authored elsewhere. The badge IS the id's field, so the
   // error is marked on it rather than only in the card's issue list.
@@ -155,15 +167,67 @@ export function WorkflowBuilderNodeCard({
       />
 
       <div className="mt-3">
-        <WorkflowBuilderPromptField
-          fieldId={`${fieldPrefix}-prompt`}
-          value={node.prompt}
-          disabled={disabled}
-          inputNames={inputNames}
-          docSlugs={docSlugs}
-          invalid={promptInvalid}
-          onChange={(prompt) => onChange({ prompt })}
-        />
+        {legs ? (
+          <div className="space-y-3">
+            {legs.map((leg, legIndex) => (
+              <div key={legIndex}>
+                <div className="flex items-center justify-between">
+                  <Label htmlFor={`${fieldPrefix}-leg-${legIndex}-prompt`}>
+                    {WORKFLOW_BUILDER_COPY.legPromptLabel(legIndex + 1)}
+                  </Label>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label={WORKFLOW_BUILDER_COPY.removeLegLabel(legIndex + 1)}
+                    disabled={disabled}
+                    onClick={() => onRemoveLeg(legIndex)}
+                  >
+                    <Trash className="icon-paired" aria-hidden />
+                  </Button>
+                </div>
+                <WorkflowBuilderPromptField
+                  fieldId={`${fieldPrefix}-leg-${legIndex}-prompt`}
+                  value={leg.prompt}
+                  disabled={disabled}
+                  inputNames={inputNames}
+                  docSlugs={docSlugs}
+                  invalid={legInvalid(legIndex)}
+                  onChange={(prompt) => onUpdateLeg(legIndex, prompt)}
+                />
+              </div>
+            ))}
+            <Button
+              type="button"
+              variant="outline"
+              disabled={disabled || legs.length >= 8}
+              onClick={onAddLeg}
+            >
+              {WORKFLOW_BUILDER_COPY.addLegLabel}
+            </Button>
+          </div>
+        ) : (
+          <div>
+            <WorkflowBuilderPromptField
+              fieldId={`${fieldPrefix}-prompt`}
+              value={node.prompt}
+              disabled={disabled}
+              inputNames={inputNames}
+              docSlugs={docSlugs}
+              invalid={promptInvalid}
+              onChange={(prompt) => onChange({ prompt })}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              className="mt-2"
+              disabled={disabled}
+              onClick={onAddLeg}
+            >
+              {WORKFLOW_BUILDER_COPY.addParallelLegsLabel}
+            </Button>
+          </div>
+        )}
       </div>
 
       {issues.length > 0 ? (

--- a/apps/packages/product-client/src/copy/workflows/workflow-builder-copy.ts
+++ b/apps/packages/product-client/src/copy/workflows/workflow-builder-copy.ts
@@ -101,6 +101,11 @@ export const WORKFLOW_BUILDER_COPY = {
   malformedReferenceHint: (raw: string, reason: string) =>
     `${raw} is not a valid reference: ${reason}`,
 
+  legPromptLabel: (legIndex: number) => `Leg ${legIndex} prompt`,
+  removeLegLabel: (legIndex: number) => `Remove leg ${legIndex}`,
+  addLegLabel: "Add leg",
+  addParallelLegsLabel: "Run in parallel",
+
   inputsHeading: "Inputs",
   inputsDescription: "Values supplied when a run starts. Prompts read them as @input:name.",
   inputsEmpty: "This workflow takes no inputs.",

--- a/apps/packages/product-client/src/domain/workflows/definition-v2.test.ts
+++ b/apps/packages/product-client/src/domain/workflows/definition-v2.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { WorkflowDefinitionV2, WorkflowNodeV2 } from "@proliferate/cloud-sdk";
 import v2FullFixture from "../../../../../../fixtures/contracts/workflow-definition/v2-full.json";
-import { definitionHeadId, orderedNodes, validateDefinitionV2 } from "./definition-v2";
+import {
+  definitionHeadId,
+  orderedNodes,
+  validateDefinitionV2,
+  type WorkflowDefinitionV2WithLegs,
+} from "./definition-v2";
 
 // Structural validation. The reference-grammar cases live in
 // `definition-v2-references.test.ts`.
@@ -432,5 +437,88 @@ describe("definitionHeadId", () => {
       { from: "b", to: "a" },
     ]))).toBeNull();
     expect(definitionHeadId(graph([], []))).toBeNull();
+  });
+});
+
+describe("validateDefinitionV2: node legs (ruling F5)", () => {
+  function legsDef(
+    legs: { prompt: string }[] | undefined,
+    promptOverride?: string,
+  ): WorkflowDefinitionV2WithLegs {
+    return {
+      schemaVersion: 2,
+      nodes: [
+        {
+          id: "a",
+          type: "agent",
+          title: "Review",
+          prompt: promptOverride ?? legs?.[0]?.prompt ?? "Solo prompt",
+          ...(legs ? { legs } : {}),
+        },
+      ],
+      edges: [],
+      inputs: [],
+      docTemplates: [],
+    };
+  }
+
+  it("accepts a node with no legs (today's behavior, unchanged)", () => {
+    expect(validateDefinitionV2(legsDef(undefined))).toEqual([]);
+  });
+
+  it("accepts a valid 2-leg node whose prompt equals legs[0].prompt", () => {
+    const def = legsDef([{ prompt: "Correctness review" }, { prompt: "Security review" }]);
+    expect(validateDefinitionV2(def)).toEqual([]);
+  });
+
+  it("rejects a single-leg list", () => {
+    const def = legsDef([{ prompt: "Solo prompt" }]);
+    const issues = validateDefinitionV2(def);
+    expect(issues.some((issue) => issue.code === "invalid_leg_count")).toBe(true);
+  });
+
+  it("rejects 9 legs", () => {
+    const legs = Array.from({ length: 9 }, (_, i) => ({ prompt: `Leg ${i}` }));
+    const def = legsDef(legs, "Leg 0");
+    const issues = validateDefinitionV2(def);
+    expect(issues.some((issue) => issue.code === "invalid_leg_count")).toBe(true);
+  });
+
+  it("rejects a blank leg prompt", () => {
+    const def = legsDef([{ prompt: "Leg 0" }, { prompt: "   " }], "Leg 0");
+    const issues = validateDefinitionV2(def);
+    expect(issues.some((issue) => issue.code === "blank_leg_prompt" && issue.index === 1))
+      .toBe(true);
+  });
+
+  it("rejects a prompt/legs[0] mismatch", () => {
+    const def = legsDef([{ prompt: "Leg 0" }, { prompt: "Leg 1" }], "Not leg 0");
+    const issues = validateDefinitionV2(def);
+    expect(issues.some((issue) => issue.code === "leg_prompt_mismatch")).toBe(true);
+  });
+
+  it("scans each leg's prompt for @input:/@doc: references independently", () => {
+    const def: WorkflowDefinitionV2WithLegs = {
+      schemaVersion: 2,
+      nodes: [
+        {
+          id: "a",
+          type: "agent",
+          title: "Review",
+          prompt: "Research @input:topic",
+          legs: [
+            { prompt: "Research @input:topic" },
+            { prompt: "Research @input:missing" },
+          ],
+        },
+      ],
+      edges: [],
+      inputs: [{ name: "topic", description: "", required: true }],
+      docTemplates: [],
+    };
+    const issues = validateDefinitionV2(def);
+    const unknownRefIssue = issues.find((issue) => issue.code === "unknown_input_ref");
+    expect(unknownRefIssue).toBeDefined();
+    expect(unknownRefIssue?.index).toBe(1);
   });
 });

--- a/apps/packages/product-client/src/domain/workflows/definition-v2.ts
+++ b/apps/packages/product-client/src/domain/workflows/definition-v2.ts
@@ -35,6 +35,32 @@ export type {
   PromptToken,
 } from "./definition-v2-references";
 
+/**
+ * One parallel leg of a node's fan-out (ruling F5, frozen wire shape, all
+ * three grammar planes): its own authored prompt, its own session at run
+ * time. Not part of the `@proliferate/cloud-sdk` `WorkflowNodeV2` type yet —
+ * see `WorkflowNodeV2WithLegs` below.
+ */
+export interface WorkflowNodeLegV2 {
+  prompt: string;
+}
+
+/**
+ * `WorkflowNodeV2` widened with the optional `legs` field. The SDK type
+ * (`cloud/sdk/src/types/workflows-v2.ts`) does not carry `legs` yet — that
+ * package is out of scope for this change (a parallel effort owns
+ * anyharness/sdk and cloud/sdk types) — so this local extension is the
+ * product-client-side stand-in until the SDK is regenerated/updated to match
+ * the frozen wire shape. Everywhere in this domain that needs to read or
+ * write `legs` should use this type (or `WorkflowDefinitionV2WithLegs`)
+ * instead of the bare SDK type.
+ */
+export type WorkflowNodeV2WithLegs = WorkflowNodeV2 & { legs?: WorkflowNodeLegV2[] };
+
+export type WorkflowDefinitionV2WithLegs = Omit<WorkflowDefinitionV2, "nodes"> & {
+  nodes: WorkflowNodeV2WithLegs[];
+};
+
 export type DefinitionV2IssueCode =
   | "not_linear"
   | "invalid_node_id"
@@ -46,7 +72,10 @@ export type DefinitionV2IssueCode =
   | "unknown_doc_ref"
   | "unknown_producing_node"
   | "empty_nodes"
-  | "dangling_edge";
+  | "dangling_edge"
+  | "invalid_leg_count"
+  | "blank_leg_prompt"
+  | "leg_prompt_mismatch";
 
 export interface DefinitionV2Issue {
   code: DefinitionV2IssueCode;
@@ -77,7 +106,7 @@ export interface DefinitionV2Issue {
  * Declared input names and doc slugs are grammar-checked by the control plane's
  * wire models, not here — this validator sees whatever the builder holds.
  */
-export function validateDefinitionV2(def: WorkflowDefinitionV2): DefinitionV2Issue[] {
+export function validateDefinitionV2(def: WorkflowDefinitionV2WithLegs): DefinitionV2Issue[] {
   const issues: DefinitionV2Issue[] = [];
   // `edges` is required on the wire (the runtime rejects a definition without
   // it); `inputs`/`docTemplates` may be omitted, and omitted means "none".
@@ -186,36 +215,84 @@ export function validateDefinitionV2(def: WorkflowDefinitionV2): DefinitionV2Iss
   const inputNames = new Set(inputs.map((input) => input.name));
   const docSlugs = new Set(docTemplates.map((doc) => doc.slug));
   for (const node of def.nodes) {
-    const refs = collectPromptReferences(node.prompt);
-    for (const malformed of refs.malformed) {
+    // Ruling F5: a node's `legs` (when present) are the authored prompts; the
+    // scalar `node.prompt` is required to equal `legs[0].prompt`, so scanning
+    // both would double-report the same references for leg 0. Scan legs
+    // instead of the scalar prompt whenever legs are present.
+    const prompts = node.legs && node.legs.length > 0
+      ? node.legs.map((leg) => leg.prompt)
+      : [node.prompt];
+    prompts.forEach((prompt, legIndex) => {
+      const refs = collectPromptReferences(prompt);
+      for (const malformed of refs.malformed) {
+        issues.push({
+          code: "malformed_reference",
+          message:
+            `Node “${node.id}” prompt has a malformed reference “${malformed.raw}”: ` +
+            `${describeMalformedReference(malformed)}.`,
+          nodeId: node.id,
+          ref: malformed.raw,
+          ...(node.legs ? { index: legIndex } : {}),
+        });
+      }
+      for (const name of refs.inputs) {
+        if (!inputNames.has(name)) {
+          issues.push({
+            code: "unknown_input_ref",
+            message: `Node “${node.id}” prompt references unknown input “@input:${name}”.`,
+            nodeId: node.id,
+            ref: name,
+            ...(node.legs ? { index: legIndex } : {}),
+          });
+        }
+      }
+      for (const slug of refs.docs) {
+        if (!docSlugs.has(slug)) {
+          issues.push({
+            code: "unknown_doc_ref",
+            message: `Node “${node.id}” prompt references unknown doc template “@doc:${slug}”.`,
+            nodeId: node.id,
+            ref: slug,
+            ...(node.legs ? { index: legIndex } : {}),
+          });
+        }
+      }
+    });
+  }
+
+  for (const node of def.nodes) {
+    if (node.legs === undefined) {
+      continue;
+    }
+    if (node.legs.length < 2 || node.legs.length > 8) {
       issues.push({
-        code: "malformed_reference",
+        code: "invalid_leg_count",
         message:
-          `Node “${node.id}” prompt has a malformed reference “${malformed.raw}”: ` +
-          `${describeMalformedReference(malformed)}.`,
+          `Node “${node.id}” has ${node.legs.length} legs; a parallel node must have between ` +
+          "2 and 8 legs (a single leg is expressed without `legs` at all).",
         nodeId: node.id,
-        ref: malformed.raw,
       });
+      continue;
     }
-    for (const name of refs.inputs) {
-      if (!inputNames.has(name)) {
+    node.legs.forEach((leg, index) => {
+      if (!leg.prompt.trim()) {
         issues.push({
-          code: "unknown_input_ref",
-          message: `Node “${node.id}” prompt references unknown input “@input:${name}”.`,
+          code: "blank_leg_prompt",
+          message: `Node “${node.id}” leg ${index + 1} prompt is required.`,
           nodeId: node.id,
-          ref: name,
+          index,
         });
       }
-    }
-    for (const slug of refs.docs) {
-      if (!docSlugs.has(slug)) {
-        issues.push({
-          code: "unknown_doc_ref",
-          message: `Node “${node.id}” prompt references unknown doc template “@doc:${slug}”.`,
-          nodeId: node.id,
-          ref: slug,
-        });
-      }
+    });
+    if (node.legs[0] && node.legs[0].prompt !== node.prompt) {
+      issues.push({
+        code: "leg_prompt_mismatch",
+        message:
+          `Node “${node.id}” prompt must equal its first leg's prompt ` +
+          "(leg 0 is the representative session).",
+        nodeId: node.id,
+        index: 0,
+      });
     }
   }
 
@@ -229,7 +306,7 @@ export function validateDefinitionV2(def: WorkflowDefinitionV2): DefinitionV2Iss
  * convention; this module follows `validateDefinitionV2`'s own
  * return-a-value, no-exceptions style rather than introduce one).
  */
-export function orderedNodes(def: WorkflowDefinitionV2): WorkflowNodeV2[] {
+export function orderedNodes(def: WorkflowDefinitionV2WithLegs): WorkflowNodeV2WithLegs[] {
   if (validateDefinitionV2(def).length > 0) {
     return [];
   }
@@ -262,7 +339,7 @@ export function definitionHeadId(def: WorkflowDefinitionV2): string | null {
  * covering all of them (branch, merge, cycle, or disconnected components).
  * A single node with zero edges is a valid (length-1) chain.
  */
-function computeLinearOrder(def: WorkflowDefinitionV2): string[] | null {
+function computeLinearOrder(def: WorkflowDefinitionV2WithLegs): string[] | null {
   const presentIds = new Set(def.nodes.map((node) => node.id));
   if (presentIds.size === 0) {
     return [];

--- a/apps/packages/product-client/src/hooks/workflows/facade/use-workflow-builder.test.tsx
+++ b/apps/packages/product-client/src/hooks/workflows/facade/use-workflow-builder.test.tsx
@@ -321,6 +321,45 @@ describe("useWorkflowBuilder draft edits", () => {
     expect(result.current.draft.defaultRepoConfigId).toBe("");
     vi.useRealTimers();
   });
+
+  it("coalesces adjacent typing in one leg's editor into a single undo entry", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-17T12:00:00Z"));
+    const { result } = renderBuilder();
+    act(() => result.current.actions.addLeg("step-1"));
+    act(() => {
+      result.current.actions.updateLeg("step-1", 1, "d");
+      result.current.actions.updateLeg("step-1", 1, "dig");
+    });
+    expect(result.current.draft.nodes[0].legs?.[1]?.prompt).toBe("dig");
+    // One undo unwinds the whole typing burst, not one keystroke of it...
+    act(() => result.current.undo());
+    expect(result.current.draft.nodes[0].legs?.[1]?.prompt).toBe("");
+    // ...and the next lands on the structural addLeg entry underneath.
+    act(() => result.current.undo());
+    expect(result.current.draft.nodes[0].legs).toBeUndefined();
+    vi.useRealTimers();
+  });
+
+  it("keeps each leg's typing in its own undo entry", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-17T12:00:00Z"));
+    const { result } = renderBuilder();
+    const scalarPrompt = result.current.draft.nodes[0].prompt;
+    act(() => result.current.actions.addLeg("step-1"));
+    act(() => {
+      result.current.actions.updateLeg("step-1", 1, "dig");
+      result.current.actions.updateLeg("step-1", 0, "lead");
+    });
+    expect(result.current.draft.nodes[0].legs?.map((leg) => leg.prompt)).toEqual(["lead", "dig"]);
+    // Different leg, different key: leg 0's edit undoes alone, leg 1 keeps its text.
+    act(() => result.current.undo());
+    expect(result.current.draft.nodes[0].legs?.map((leg) => leg.prompt))
+      .toEqual([scalarPrompt, "dig"]);
+    // Leg 0 mirrors into the scalar prompt (ruling F5), so that unwound too.
+    expect(result.current.draft.nodes[0].prompt).toBe(scalarPrompt);
+    vi.useRealTimers();
+  });
 });
 
 function definitionWithPrompt(prompt: string): WorkflowDefinitionV2 {

--- a/apps/packages/product-client/src/lib/domain/workflows/workflow-builder-draft-legs.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workflows/workflow-builder-draft-legs.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  blankWorkflowBuilderDraft,
+  draftToDefinition,
+  workflowBuilderActions,
+  type WorkflowBuilderDraft,
+} from "./workflow-builder-draft";
+
+/**
+ * Round-trip serialization for ruling F5's per-leg prompts (rung 5 of the
+ * Follow-up Workflows ADR): absent `legs` stays byte-identical, 2..8 legs
+ * serialize exactly as the frozen wire shape, and removing legs back down to
+ * one collapses the node to today's shape (`legs` omitted, never length 1).
+ */
+describe("workflow-builder-draft: node legs round-trip (ruling F5)", () => {
+  function draftWithEditor(): {
+    getDraft: () => WorkflowBuilderDraft;
+    actions: ReturnType<typeof workflowBuilderActions>;
+  } {
+    let draft = blankWorkflowBuilderDraft();
+    const actions = workflowBuilderActions((edit) => {
+      draft = edit(draft);
+    });
+    return { getDraft: () => draft, actions };
+  }
+
+  it("absent legs round-trips with no `legs` key at all", () => {
+    const { getDraft } = draftWithEditor();
+    const definition = draftToDefinition(getDraft());
+    expect(definition.nodes[0]).not.toHaveProperty("legs");
+    expect(JSON.stringify(definition.nodes[0])).not.toContain("legs");
+  });
+
+  it("adding a leg fans out to 2, and the node's prompt mirrors leg 0", () => {
+    const { getDraft, actions } = draftWithEditor();
+    actions.updateNode("step-1", { prompt: "Solo prompt" });
+    actions.addLeg("step-1");
+    const definition = draftToDefinition(getDraft());
+    const node = definition.nodes[0];
+    expect(node.legs).toEqual([{ prompt: "Solo prompt" }, { prompt: "" }]);
+    expect(node.prompt).toBe("Solo prompt");
+  });
+
+  it("2-leg node round-trips exactly as the wire shape after editing both legs", () => {
+    const { getDraft, actions } = draftWithEditor();
+    actions.addLeg("step-1");
+    actions.updateLeg("step-1", 0, "Correctness review");
+    actions.updateLeg("step-1", 1, "Security review");
+    const definition = draftToDefinition(getDraft());
+    const node = definition.nodes[0];
+    expect(node.prompt).toBe("Correctness review");
+    expect(node.legs).toEqual([
+      { prompt: "Correctness review" },
+      { prompt: "Security review" },
+    ]);
+  });
+
+  it("growing to 8 legs then back down to 1 collapses `legs` away entirely", () => {
+    const { getDraft, actions } = draftWithEditor();
+    for (let i = 0; i < 7; i += 1) {
+      actions.addLeg("step-1");
+    }
+    expect(getDraft().nodes[0].legs).toHaveLength(8);
+    // Adding a 9th is a no-op: legs never grow past 8.
+    actions.addLeg("step-1");
+    expect(getDraft().nodes[0].legs).toHaveLength(8);
+
+    for (let i = 0; i < 7; i += 1) {
+      actions.removeLeg("step-1", 1);
+    }
+    const definition = draftToDefinition(getDraft());
+    const node = definition.nodes[0];
+    expect(node).not.toHaveProperty("legs");
+  });
+
+  // Negative control: a hand-built definition with a length-1 `legs` array is
+  // exactly the shape rung 5's validator rejects (`invalid_leg_count`) and
+  // the collapse logic above exists to prevent producing. Asserting it here
+  // pins that this test suite would in fact fail if the collapse regressed.
+  it("negative control: a length-1 legs array is not the round-trip's output", () => {
+    const { getDraft, actions } = draftWithEditor();
+    actions.addLeg("step-1");
+    actions.removeLeg("step-1", 1);
+    const definition = draftToDefinition(getDraft());
+    const node = definition.nodes[0];
+    expect(node.legs).toBeUndefined();
+    // The shape a regression would produce instead:
+    expect(node.legs).not.toEqual([{ prompt: "" }]);
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/workflows/workflow-builder-draft.ts
+++ b/apps/packages/product-client/src/lib/domain/workflows/workflow-builder-draft.ts
@@ -1,14 +1,25 @@
 import type {
   WorkflowDefinitionRecordV2,
-  WorkflowDefinitionV2,
   WorkflowDocTemplateV2,
   WorkflowEdgeV2,
   WorkflowInputV2,
-  WorkflowNodeV2,
 } from "@proliferate/cloud-sdk";
 import type { WorkflowStarterTemplateV2 } from "#product/config/workflows/starter-templates";
-import { definitionHeadId, validateDefinitionV2 } from "#product/domain/workflows/definition-v2";
+import {
+  definitionHeadId,
+  validateDefinitionV2,
+  type WorkflowDefinitionV2WithLegs,
+  type WorkflowNodeLegV2,
+  type WorkflowNodeV2WithLegs,
+} from "#product/domain/workflows/definition-v2";
 import { normalizeDocSlugInput } from "#product/lib/domain/workflows/workflow-builder-validation";
+
+// `WorkflowNodeV2` alias kept local so the rest of this module (and its
+// re-exports) reads the widened, legs-aware shape everywhere a node type is
+// named. The bare SDK type has no `legs` field yet (see the comment on
+// `WorkflowNodeV2WithLegs`).
+type WorkflowNodeV2 = WorkflowNodeV2WithLegs;
+type WorkflowDefinitionV2 = WorkflowDefinitionV2WithLegs;
 
 /**
  * The gen-2 builder's draft shape and every pure operation on it: seeding,
@@ -60,6 +71,25 @@ export interface WorkflowBuilderActions {
   removeDocTemplate: (index: number) => void;
   updateDocTemplate: (index: number, patch: Partial<WorkflowDocTemplateV2>) => void;
   replaceDefinition: (definition: WorkflowDefinitionV2) => void;
+  /**
+   * Adds one parallel leg to a node (ruling F5). A node with no `legs` gains
+   * a 2-leg fan-out seeded from its current prompt (leg 0 mirrors it, leg 1
+   * starts blank); a node already fanned out gains one more leg, up to 8.
+   */
+  addLeg: (nodeId: string) => void;
+  /**
+   * Removes one leg. Removing down to a single leg collapses the node back
+   * to today's shape entirely: `legs` is omitted (never serialized at
+   * length 1), and the node's scalar `prompt` keeps the surviving leg's text.
+   */
+  removeLeg: (nodeId: string, legIndex: number) => void;
+  /**
+   * Edits one leg's prompt. Leg 0's editor IS the node's existing prompt
+   * field, so writing leg 0 also mirrors into `node.prompt` (ruling F5's
+   * `prompt === legs[0].prompt` invariant), keeping every existing consumer
+   * of the scalar prompt correct without them knowing legs exist.
+   */
+  updateLeg: (nodeId: string, legIndex: number, prompt: string) => void;
 }
 
 /** Applies one draft-to-draft edit; the hook supplies the state writer. */
@@ -154,6 +184,7 @@ export function serializeDraft(draft: WorkflowBuilderDraft): string {
       node.model?.agentKind ?? null,
       node.model?.modelId ?? null,
       node.model?.modeId ?? null,
+      node.legs ? node.legs.map((leg) => leg.prompt) : null,
     ]),
     edges: draft.edges.map((edge) => [edge.from, edge.to]),
     inputConnectedTo: draft.inputConnectedTo,
@@ -198,6 +229,53 @@ export function workflowBuilderActions(
     }), typeof patch.title === "string" || typeof patch.prompt === "string"
       ? { coalesceKey: `node:${nodeId}:${typeof patch.prompt === "string" ? "prompt" : "title"}` }
       : undefined),
+    addLeg: (nodeId) => editDraft((draft) => ({
+      ...draft,
+      nodes: draft.nodes.map((node) => {
+        if (node.id !== nodeId) {
+          return node;
+        }
+        const existingLegs = node.legs ?? [{ prompt: node.prompt }];
+        if (existingLegs.length >= 8) {
+          return node;
+        }
+        return { ...node, legs: [...existingLegs, { prompt: "" }] };
+      }),
+    })),
+    removeLeg: (nodeId, legIndex) => editDraft((draft) => ({
+      ...draft,
+      nodes: draft.nodes.map((node) => {
+        if (node.id !== nodeId || !node.legs) {
+          return node;
+        }
+        const nextLegs = node.legs.filter((_, index) => index !== legIndex);
+        if (nextLegs.length <= 1) {
+          // Collapse back to today's single-prompt shape: `legs` is omitted
+          // entirely (never serialized at length 1), keeping the surviving
+          // leg's text as the node's scalar prompt.
+          const { legs: _legs, ...rest } = node;
+          return { ...rest, prompt: nextLegs[0]?.prompt ?? node.prompt };
+        }
+        return { ...node, legs: nextLegs };
+      }),
+    })),
+    updateLeg: (nodeId, legIndex, prompt) => editDraft((draft) => ({
+      ...draft,
+      nodes: draft.nodes.map((node) => {
+        if (node.id !== nodeId || !node.legs) {
+          return node;
+        }
+        const nextLegs: WorkflowNodeLegV2[] = node.legs.map((leg, index) =>
+          index === legIndex ? { ...leg, prompt } : leg
+        );
+        // Leg 0's editor IS the node's prompt field: mirror it into the
+        // scalar `prompt` so ruling F5's invariant (`prompt === legs[0].prompt`)
+        // holds on every edit, not just at save time.
+        return legIndex === 0
+          ? { ...node, prompt, legs: nextLegs }
+          : { ...node, legs: nextLegs };
+      }),
+    })),
     moveNodeUp: (nodeId) => editDraft((draft) => ({
       ...draft,
       nodes: moveNode(draft.nodes, nodeId, -1),
@@ -310,6 +388,7 @@ function draftPartsFromDefinition(definition: WorkflowDefinitionV2): {
     nodes: nodes.map((node) => ({
       ...node,
       ...(node.model ? { model: { ...node.model } } : {}),
+      ...(node.legs ? { legs: node.legs.map((leg) => ({ ...leg })) } : {}),
     })),
     edges: definition.edges.map((edge) => ({ ...edge })),
     inputConnectedTo: validateDefinitionV2(definition).length === 0

--- a/apps/packages/product-client/src/lib/domain/workflows/workflow-builder-draft.ts
+++ b/apps/packages/product-client/src/lib/domain/workflows/workflow-builder-draft.ts
@@ -275,7 +275,7 @@ export function workflowBuilderActions(
           ? { ...node, prompt, legs: nextLegs }
           : { ...node, legs: nextLegs };
       }),
-    })),
+    }), { coalesceKey: `node:${nodeId}:leg:${legIndex}` }),
     moveNodeUp: (nodeId) => editDraft((draft) => ({
       ...draft,
       nodes: moveNode(draft.nodes, nodeId, -1),

--- a/cloud/sdk/src/generated/openapi.ts
+++ b/cloud/sdk/src/generated/openapi.ts
@@ -7475,6 +7475,16 @@ export interface components {
              */
             createdAt: string;
         };
+        /**
+         * WorkflowNodeLegV2
+         * @description One parallel leg of a node's fan-out (ruling F5): its own authored
+         *     prompt, its own session at run time. No edges, no ordering, no inter-leg
+         *     dependencies — a leg is not a node.
+         */
+        WorkflowNodeLegV2: {
+            /** Prompt */
+            prompt: string;
+        };
         /** WorkflowNodeModelConfigV2 */
         WorkflowNodeModelConfigV2: {
             /** Agentkind */
@@ -7498,6 +7508,8 @@ export interface components {
             /** Prompt */
             prompt: string;
             model?: components["schemas"]["WorkflowNodeModelConfigV2"] | null;
+            /** Legs */
+            legs?: components["schemas"]["WorkflowNodeLegV2"][] | null;
         };
         /** WorkflowPromptStep */
         WorkflowPromptStep: {

--- a/cloud/sdk/src/types/workflows-v2.ts
+++ b/cloud/sdk/src/types/workflows-v2.ts
@@ -15,12 +15,23 @@ export interface WorkflowNodeModelV2 {
   modeId?: string | null;
 }
 
+/** One parallel leg's authored prompt (ruling F5). */
+export interface WorkflowNodeLegV2 {
+  prompt: string;
+}
+
 export interface WorkflowNodeV2 {
   id: string;
   type: WorkflowNodeTypeV2;
   title: string;
   prompt: string;
   model?: WorkflowNodeModelV2 | null;
+  /**
+   * Parallel legs (ruling F5). Present only with 2..8 entries; `prompt` always
+   * equals `legs[0].prompt` (leg 0 is the representative session). Absent =
+   * a single-leg node, today's behavior exactly.
+   */
+  legs?: WorkflowNodeLegV2[];
 }
 
 export interface WorkflowEdgeV2 {

--- a/lints/anyharness/ratchets.toml
+++ b/lints/anyharness/ratchets.toml
@@ -154,14 +154,19 @@ max_lines = 601
 reason = "scripted-ACP prompt/queue race suite over the real actor ; +2: workflows gen-2 PR4 teaches the scripted agent program a refusal stop-reason branch"
 
 [[max_lines]]
+path = "anyharness/crates/anyharness-lib/src/domains/workflows/definition.rs"
+max_lines = 650
+reason = "workflows gen-2 definition DSL + validator (linear-chain, reference grammar, invocation revalidation) ; +59: wf-followup R5 adds the DefinitionLeg grammar type, the node `legs` list + leg_prompts() accessor, and the per-leg validation (2..=MAX_NODE_LEGS, non-blank, prompt==legs[0], per-leg reference-grammar with leg index in the error) for ruling F5 fan-out"
+
+[[max_lines]]
 path = "anyharness/crates/anyharness-lib/src/domains/workflows/store.rs"
-max_lines = 1318
-reason = "workflows gen-2 durable store: run/node/doc writes, apply_transition and projections share one SQLite seam; split into store/ on next growth per guides/domains.md ; +62: PR3 adds the docs-registry register/read seam and rendered-envelope persistence ; +32: PR4 adds the Ruling L DisposeThenStart side effect, the node model column, and queue-aware hold event emission ; +115: PR5a adds the courier PUT upsert (Ruling B one-live-run refusal, key-sorted definition JSON note) and the node_membership 404 discriminator read ; +11: pr11 adds the failure_code classification to the named transition event ; +20: pr11b splits the queued-interjection Hold out of the stale-notification target ; +25: fix/wf2-run-cancel adds the run-cancel command ; +25: fix round 1 widens Cancel's disposal to every running row (chain + adhoc), NULLs the disposed node's session_id, and clears interruption_code on cancel ; -62 net: wf-followup R4 fan-in wires the ledger (stamp/load/mark, F3 stamp relocation) but relocates the four row-mappers to store_rows.rs, netting the seam smaller ; +3: R4 CI fix relocates node_sessions under store/ per AH-STORE-3, adding the child-module decl and its note"
+max_lines = 1419
+reason = "workflows gen-2 durable store: run/node/doc writes, apply_transition and projections share one SQLite seam; split into store/ on next growth per guides/domains.md ; +62: PR3 adds the docs-registry register/read seam and rendered-envelope persistence ; +32: PR4 adds the Ruling L DisposeThenStart side effect, the node model column, and queue-aware hold event emission ; +115: PR5a adds the courier PUT upsert (Ruling B one-live-run refusal, key-sorted definition JSON note) and the node_membership 404 discriminator read ; +11: pr11 adds the failure_code classification to the named transition event ; +20: pr11b splits the queued-interjection Hold out of the stale-notification target ; +25: fix/wf2-run-cancel adds the run-cancel command ; +25: fix round 1 widens Cancel's disposal to every running row (chain + adhoc), NULLs the disposed node's session_id, and clears interruption_code on cancel ; -62 net: wf-followup R4 fan-in wires the ledger (stamp/load/mark, F3 stamp relocation) but relocates the four row-mappers to store_rows.rs, netting the seam smaller ; +3: R4 CI fix relocates node_sessions under store/ per AH-STORE-3, adding the child-module decl and its note ; +96: wf-followup R5 fan-out adds the StartNodeLegs side effect, the start_side_effect/node_leg_count leg-count resolver, and stamp_fanout (representative + N ledger rows in one commit, ruling F5) ; +5: R5 review fix stamps every leg keyless on NodeLaunchFailed"
 
 [[max_lines]]
 path = "anyharness/crates/anyharness-lib/src/domains/workflows/store_tests.rs"
-max_lines = 1677
-reason = "workflows gen-2 store suite over real migrations (idempotent create, transition application, projections, boot fence, docs registry) ; +139: PR3 adds docs-registry and rendered-envelope round-trip proofs ; +31: PR5a adds one-live-run refusal and membership-discriminator proofs ; +79: pr11 adds the subscriber-capture proof for the named transition event ; +89: pr11b adds the shared capture harness plus interjection-held and node_launched join-key proofs ; +117: fix/wf2-run-cancel adds the cancel command store suite ; +98: fix round 1 adds the running-adhoc double-disposal proof and the interruption_code-cleared-on-cancel proof"
+max_lines = 1680
+reason = "workflows gen-2 store suite over real migrations (idempotent create, transition application, projections, boot fence, docs registry) ; +139: PR3 adds docs-registry and rendered-envelope round-trip proofs ; +31: PR5a adds one-live-run refusal and membership-discriminator proofs ; +79: pr11 adds the subscriber-capture proof for the named transition event ; +89: pr11b adds the shared capture harness plus interjection-held and node_launched join-key proofs ; +117: fix/wf2-run-cancel adds the cancel command store suite ; +98: fix round 1 adds the running-adhoc double-disposal proof and the interruption_code-cleared-on-cancel proof ; +3: wf-followup R5 threads the DefinitionNode `legs` field (None) through the three chain-node fixtures for ruling F5"
 
 [[max_lines]]
 path = "anyharness/crates/anyharness-lib/src/domains/workflows/transition.rs"
@@ -175,5 +180,5 @@ reason = "workflows gen-2 transition suite: one test per ADR table row plus stal
 
 [[max_lines]]
 path = "anyharness/crates/anyharness-lib/src/live/workflows/lifecycle_tests.rs"
-max_lines = 1066
-reason = "workflows gen-2 engine lifecycle suite: scripted-ACP agents drive real runs through the manager/actor (happy path, gate approve, flip, redo, undo, boot fence) with zero mocks of our machinery"
+max_lines = 1067
+reason = "workflows gen-2 engine lifecycle suite: scripted-ACP agents drive real runs through the manager/actor (happy path, gate approve, flip, redo, undo, boot fence) with zero mocks of our machinery ; +1: wf-followup R5 threads the DefinitionNode `legs` field (None) through the agent_node fixture for ruling F5"

--- a/server/proliferate/server/workflows/models_v2.py
+++ b/server/proliferate/server/workflows/models_v2.py
@@ -67,12 +67,34 @@ class WorkflowNodeModelConfigV2(WorkflowDefinitionWireModel):
     ) = None
 
 
+class WorkflowNodeLegV2(WorkflowDefinitionWireModel):
+    """One parallel leg of a node's fan-out (ruling F5): its own authored
+    prompt, its own session at run time. No edges, no ordering, no inter-leg
+    dependencies — a leg is not a node."""
+
+    prompt: Annotated[str, StringConstraints(min_length=1, max_length=100_000)]
+
+    @field_validator("prompt")
+    @classmethod
+    def prompt_must_not_be_blank(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("Leg prompt is required.")
+        return value
+
+
 class WorkflowNodeV2(WorkflowDefinitionWireModel):
     id: Annotated[str, NODE_ID_CONSTRAINTS]
     type: Literal["agent", "human_in_loop"]
     title: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=255)]
     prompt: Annotated[str, StringConstraints(min_length=1, max_length=100_000)]
     model: WorkflowNodeModelConfigV2 | None = None
+    # Ruling F5 (REVERSED from the drafted recommendation): a node fans out to
+    # N parallel legs, each carrying its own authored prompt. Absent = today's
+    # 1-session-per-node behavior, byte-identical. When present: 2..8 legs
+    # (a single-leg node is expressed the old way, without `legs` at all), and
+    # `prompt` MUST equal `legs[0].prompt` (leg 0 is the representative
+    # session, keeping every existing consumer of the scalar `prompt` correct).
+    legs: list[WorkflowNodeLegV2] | None = Field(default=None, min_length=2, max_length=8)
 
     @field_validator("prompt")
     @classmethod
@@ -80,6 +102,14 @@ class WorkflowNodeV2(WorkflowDefinitionWireModel):
         if not value.strip():
             raise ValueError("Prompt is required.")
         return value
+
+    @model_validator(mode="after")
+    def prompt_must_equal_first_leg_prompt(self) -> "WorkflowNodeV2":
+        if self.legs is not None and self.prompt != self.legs[0].prompt:
+            raise ValueError(
+                "Node prompt must equal legs[0].prompt (leg 0 is the representative session)."
+            )
+        return self
 
 
 class WorkflowEdgeV2(WorkflowDefinitionWireModel):

--- a/server/proliferate/server/workflows/models_v2.py
+++ b/server/proliferate/server/workflows/models_v2.py
@@ -104,7 +104,7 @@ class WorkflowNodeV2(WorkflowDefinitionWireModel):
         return value
 
     @model_validator(mode="after")
-    def prompt_must_equal_first_leg_prompt(self) -> "WorkflowNodeV2":
+    def prompt_must_equal_first_leg_prompt(self) -> WorkflowNodeV2:
         if self.legs is not None and self.prompt != self.legs[0].prompt:
             raise ValueError(
                 "Node prompt must equal legs[0].prompt (leg 0 is the representative session)."

--- a/server/tests/unit/test_workflow_definition_v2_validation.py
+++ b/server/tests/unit/test_workflow_definition_v2_validation.py
@@ -22,6 +22,7 @@ from proliferate.server.workflows.models_v2 import (
     WorkflowDefinitionDocumentV2,
     WorkflowDefinitionResponseV2,
     WorkflowInvocationResponseV2,
+    WorkflowNodeV2,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -173,6 +174,67 @@ def test_valid_refs_fixture_validates_clean() -> None:
     assert isinstance(definition, dict)
     document = WorkflowDefinitionDocumentV2.model_validate(definition)
     assert validate_definition_v2_document(document) is None
+
+
+def _node_kwargs(prompt: str = "Run.", **overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {"id": "n_a", "type": "agent", "title": "T", "prompt": prompt}
+    base.update(overrides)
+    return base
+
+
+def test_node_legs_absent_is_unchanged() -> None:
+    node = WorkflowNodeV2.model_validate(_node_kwargs())
+    assert node.legs is None
+    assert node.prompt == "Run."
+
+
+def test_node_legs_valid_two_legs() -> None:
+    node = WorkflowNodeV2.model_validate(
+        _node_kwargs(
+            prompt="Reviewer A prompt.",
+            legs=[{"prompt": "Reviewer A prompt."}, {"prompt": "Reviewer B prompt."}],
+        )
+    )
+    assert node.legs is not None
+    assert len(node.legs) == 2
+    assert node.legs[0].prompt == node.prompt
+
+
+def test_node_legs_reject_single_leg_list() -> None:
+    with pytest.raises(ValidationError):
+        WorkflowNodeV2.model_validate(
+            _node_kwargs(legs=[{"prompt": "Run."}]),
+        )
+
+
+def test_node_legs_reject_nine_legs() -> None:
+    with pytest.raises(ValidationError):
+        WorkflowNodeV2.model_validate(
+            _node_kwargs(
+                prompt="Leg 0",
+                legs=[{"prompt": f"Leg {i}"} for i in range(9)],
+            ),
+        )
+
+
+def test_node_legs_reject_blank_leg() -> None:
+    with pytest.raises(ValidationError):
+        WorkflowNodeV2.model_validate(
+            _node_kwargs(
+                prompt="Leg 0",
+                legs=[{"prompt": "Leg 0"}, {"prompt": "   "}],
+            ),
+        )
+
+
+def test_node_legs_reject_prompt_mismatch() -> None:
+    with pytest.raises(ValidationError):
+        WorkflowNodeV2.model_validate(
+            _node_kwargs(
+                prompt="Not leg 0's prompt",
+                legs=[{"prompt": "Leg 0"}, {"prompt": "Leg 1"}],
+            ),
+        )
 
 
 def test_wellformed_references_still_distinguish_undeclared() -> None:

--- a/specs/TESTING/scenarios.md
+++ b/specs/TESTING/scenarios.md
@@ -767,6 +767,34 @@ no auto-advance; approving the gate advances the run to `completed`; every
 command (PUT, GET, approve) returns the full projection
 `{run, nodes[], docs[]}`.
 
+### T3-WF-PARALLEL-1: heterogeneous parallel node fan-out with crash and resume
+Authored against the frozen Workflows gen-2 ADR contract, modeled exactly on
+T3-WF-1 (same "frozen, not-yet-executed" framing — the `/v1/workflow-runs/*`
+routes are a parallel lane not in this chain's base; see
+`tests/release/src/scenarios/t3-wf-parallel-1.ts`'s module docstring). Two
+wire shapes are rung-forward and flagged for reconciliation on restack: the
+definition node's `legs` list (this rung 5's grammar, ruling F5) and the
+run projection's additive per-node `sessions` rollup (rung 7, ruling F4).
+The definition is one `agent` node ("review") fanned out to three authored
+leg prompts — a correctness reviewer, a security reviewer, and a perf
+reviewer (the panel use case); leg 0's prompt equals the node prompt (the
+representative invariant). Model resolution reuses T3-CHAT-1's picker against
+the fixed harness `claude`.
+Steps: `PUT /v1/workflow-runs/{run_id}` with the frozen invocation (definition
+carrying `legs`) → the node mints one session per leg → two legs finish → the
+runtime is killed with one leg still live (an out-of-band supervisor step) →
+restart → resume.
+Assert: the PUT materializes a workspace and starts one session per leg (three
+distinct sessions); each leg's underlying session prompt carries only that
+leg's authored prompt inside the wrapped preamble — the prompt-to-leg mapping
+invariant (R4), never a sibling leg's prompt; after restart the boot fence
+parks the parallel node `needs_attention`; resume re-fans-out all three legs on
+a fresh generation (ruling F6) with three fresh sessions and no pre-crash
+orphan session; all legs finishing aggregates the node exactly once (ruling
+F1: all done, fail iff any failed) and the run reaches `completed`; every
+command (PUT, GET) returns the full projection `{run, nodes[], docs[]}` plus
+the parallel node's per-leg `sessions` rollup.
+
 ---
 
 ## Tier 4 — upgrade path

--- a/tests/release/src/scenarios/registry.ts
+++ b/tests/release/src/scenarios/registry.ts
@@ -17,6 +17,7 @@ import { t3Bill2 } from "./t3-bill-2.js";
 import { t3Bill3 } from "./t3-bill-3.js";
 import { t3Bill4 } from "./t3-bill-4.js";
 import { t3Wf1 } from "./t3-wf-1.js";
+import { t3WfParallel1 } from "./t3-wf-parallel-1.js";
 import { t4Cloud1 } from "./upgrade/t4-cloud-1.js";
 import { t4Runtime1 } from "./upgrade/t4-runtime-1.js";
 import { t4Desktop1 } from "./upgrade/t4-desktop-1.js";
@@ -80,6 +81,7 @@ export const SCENARIOS: readonly ScenarioDefinition[] = [
   t3Bill3,
   t3Bill4,
   t3Wf1,
+  t3WfParallel1,
   t3Sh2,
   t3Sh3,
   t3Sh4,

--- a/tests/release/src/scenarios/t3-wf-parallel-1.ts
+++ b/tests/release/src/scenarios/t3-wf-parallel-1.ts
@@ -1,0 +1,451 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+
+import type { MatrixScenarioDefinition, ScenarioCellOutcome, ScenarioCellSpec } from "./types.js";
+import { catalogHarnesses, withGatewayProbedCandidates } from "./t3-chat-1.js";
+import { assertWrappedPreamble, type WorkflowRunProjectionV2 } from "./t3-wf-1.js";
+import { DEFAULT_GITHUB_TEST_REPO, DEFAULT_LOCAL_RUNTIME_URL } from "../config/env-manifest.js";
+import { ensureLocalClone } from "../fixtures/git.js";
+import { ApiClient } from "../fixtures/http.js";
+import { LocalRuntimeClient, type SessionEventEnvelope } from "../fixtures/local-runtime.js";
+import type { PlannedCellV1 } from "../runner/result.js";
+
+/**
+ * T3-WF-PARALLEL-1 — a heterogeneous parallel node (ruling F5) plus crash and
+ * resume (ruling F6). specs/TESTING/scenarios.md#T3-WF-PARALLEL-1
+ *
+ * ── Frozen contract, not yet backed by a runtime ────────────────────────────
+ * Modeled EXACTLY on `t3-wf-1.ts` (read its module docstring): every wire
+ * shape is mirrored structurally from the frozen Workflows gen-2 ADR contract
+ * (`anyharness/sdk/src/types/workflow-runs-v2.ts`), `tests/release` carries no
+ * dependency on `@anyharness/sdk`, and the `/v1/workflow-runs/*` routes are a
+ * parallel lane not in this PR's base. This scenario is authored and
+ * registered against the frozen contract only and is NEVER executed here (no
+ * cargo/rustc build, no runtime boot, no live run) — the colocated `.test.ts`
+ * plans the cell and asserts its shape without running the journey. Two shapes
+ * below are rung-forward, flagged for reconciliation on the next restack:
+ *   - `legs` on a definition node (this rung 5's grammar, ruling F5); and
+ *   - the additive per-node `sessions` rollup on the run projection (rung 7,
+ *     ruling F4). Rung 5 durably links each leg by `leg_index` in the fan-in
+ *     ledger; the run projection surfaces that as the per-leg `sessions` list
+ *     only once rung 7 lands. Until then the rollup read below is the intended
+ *     shape, not a shipped one — drift is a finding, not silently absorbed.
+ *
+ * ── The journey ──────────────────────────────────────────────────────────
+ * One `agent` node ("review") fanned out to THREE authored leg prompts — a
+ * correctness reviewer, a security reviewer, and a perf reviewer (the panel
+ * use case). The run:
+ *   1. `PUT /v1/workflow-runs/{run_id}` materializes a workspace and starts the
+ *      parallel node, minting one session PER leg (three distinct sessions).
+ *   2. Each leg's underlying session prompt carries THAT leg's authored prompt
+ *      inside the wrapped preamble — the prompt-to-leg mapping invariant (R4):
+ *      the correctness session never carries the security or perf prompt, and
+ *      so on. This is the cardinal sin of ruling F5 asserted end to end.
+ *   3. Two legs finish; the runtime is killed mid-node with one leg still live.
+ *   4. On restart the boot fence parks the node; resume re-fans-out ALL three
+ *      legs on a fresh generation (ruling F6): three fresh sessions, a
+ *      truncated-then-rebuilt ledger, no orphan session from before the crash.
+ *   5. All three legs finish; the node aggregates once (ruling F1: all done)
+ *      and the run reaches `completed`.
+ * Model resolution reuses T3-CHAT-1's catalog-driven cheapest-Anthropic picker
+ * against the fixed harness `claude`, exactly as T3-WF-1 does.
+ */
+const T3_WF_PARALLEL_1_HARNESS = "claude";
+
+const LEG_PROMPTS = {
+  correctness:
+    "CORRECTNESS-REVIEW: read the diff and report only logic and correctness " +
+    "defects — off-by-one, wrong branch, broken invariant — with file:line evidence.",
+  security:
+    "SECURITY-REVIEW: read the diff and report only security defects — injection, " +
+    "auth bypass, unsafe deserialization, secret exposure — with file:line evidence.",
+  perf:
+    "PERF-REVIEW: read the diff and report only performance defects — N+1 queries, " +
+    "needless allocation, quadratic loops — with file:line evidence.",
+} as const;
+
+export const t3WfParallel1: MatrixScenarioDefinition = {
+  id: "T3-WF-PARALLEL-1",
+  title: "heterogeneous parallel node fan-out with crash and resume",
+  registryFlowRef: "specs/TESTING/scenarios.md#T3-WF-PARALLEL-1",
+  lanes: ["local"],
+  requiredEnv: [],
+  kind: "matrix",
+  expandCells: (): ScenarioCellSpec[] => [{ dimensions: { harness: T3_WF_PARALLEL_1_HARNESS } }],
+  planCell: (_ctx, cell) => [
+    {
+      description:
+        `[${cell.cell_id}] PUT /v1/workflow-runs/{run_id} with a parallel node (three authored leg ` +
+        "prompts) materializes a workspace and starts one session per leg (three distinct sessions)",
+    },
+    {
+      description:
+        `[${cell.cell_id}] each leg's underlying session prompt carries only that leg's authored prompt ` +
+        "inside the wrapped preamble — the prompt-to-leg mapping invariant (R4), no sibling leg's prompt",
+    },
+    {
+      description:
+        `[${cell.cell_id}] two legs finish, the runtime is killed with one leg still live, and on restart ` +
+        "the boot fence parks the node",
+    },
+    {
+      description:
+        `[${cell.cell_id}] resume re-fans-out all three legs on a fresh generation (ruling F6): three ` +
+        "fresh sessions, a truncated-then-rebuilt ledger, and no orphan session from before the crash",
+    },
+    {
+      description:
+        `[${cell.cell_id}] all three legs finish, the node aggregates once (ruling F1: all done), and the ` +
+        "run reaches completed",
+    },
+    {
+      description:
+        `[${cell.cell_id}] every command (PUT, GET) returns the full projection {run, nodes[], docs[]} and ` +
+        "the parallel node's per-leg sessions rollup (rung 7 shape, reconciled on restack)",
+    },
+  ],
+  runCells: async (_ctx, cells): Promise<ScenarioCellOutcome[]> => {
+    assert.equal(cells.length, 1, "T3-WF-PARALLEL-1: exactly one cell is planned (single panel journey)");
+    const [cell] = cells;
+    const runtimeUrl = process.env.RELEASE_E2E_LOCAL_RUNTIME_URL ?? DEFAULT_LOCAL_RUNTIME_URL;
+    const runtime = new LocalRuntimeClient({ baseUrl: runtimeUrl });
+    const workflowClient = new ApiClient({ baseUrl: runtimeUrl });
+    try {
+      return [await runParallelPanelJourney(runtime, workflowClient, cell)];
+    } catch (error) {
+      return [
+        {
+          cellId: cell.cell_id,
+          status: "failed",
+          reason: { code: "scenario_failure", message: error instanceof Error ? error.message : String(error) },
+        },
+      ];
+    }
+  },
+};
+
+/**
+ * The rung-5/7 fan-out wire shapes, mirrored structurally (see the module
+ * docstring). A definition node gains an optional `legs` list; the run
+ * projection's node gains an additive read-only `sessions` rollup, one entry
+ * per leg keyed by `legIndex` (the durable prompt-to-leg linkage the ledger
+ * carries). Both are declared here rather than imported for the same
+ * dependency-free reasons T3-WF-1 declares its base shapes.
+ */
+interface WorkflowNodeModelV2 {
+  agentKind: string;
+  modelId?: string | null;
+  modeId?: string | null;
+}
+
+interface WorkflowSnapshotLegV2 {
+  prompt: string;
+}
+
+interface WorkflowSnapshotNodeV2 {
+  id: string;
+  type: "agent" | "human_in_loop";
+  title: string;
+  prompt: string;
+  model?: WorkflowNodeModelV2 | null;
+  legs?: WorkflowSnapshotLegV2[] | null;
+}
+
+interface WorkflowSnapshotDefinitionV2 {
+  schemaVersion: 2;
+  nodes: WorkflowSnapshotNodeV2[];
+  edges?: { from: string; to: string }[];
+  inputs?: { name: string; description?: string; required: boolean }[];
+  docTemplates?: { slug: string; producingNodeId: string; body: string }[];
+}
+
+interface WorkflowInvocationJsonV2 {
+  schemaVersion: 2;
+  workflowDefinitionId: string;
+  definition: WorkflowSnapshotDefinitionV2;
+  arguments: Record<string, string | number | boolean>;
+  placement: { repoConfigId: string; mode: "worktree" | "repo_root" };
+}
+
+/** Rung 7's additive per-leg rollup (ruling F4), mirrored structurally. */
+interface WorkflowRunNodeLegV2 {
+  legIndex: number;
+  sessionId: string | null;
+  status: string;
+}
+
+/**
+ * A three-leg heterogeneous review panel. Leg 0's prompt equals the node
+ * prompt (the representative invariant the validator enforces), so a rung-4
+ * one-leg consumer of `node.prompt` still sees a valid prompt.
+ */
+function reviewPanelDefinition(model: WorkflowNodeModelV2): WorkflowSnapshotDefinitionV2 {
+  return {
+    schemaVersion: 2,
+    nodes: [
+      {
+        id: "review",
+        type: "agent",
+        title: "Review panel",
+        prompt: LEG_PROMPTS.correctness,
+        model,
+        legs: [
+          { prompt: LEG_PROMPTS.correctness },
+          { prompt: LEG_PROMPTS.security },
+          { prompt: LEG_PROMPTS.perf },
+        ],
+      },
+    ],
+    edges: [],
+    inputs: [],
+    docTemplates: [],
+  };
+}
+
+/**
+ * The real journey (never invoked by the colocated `.test.ts`): PUT the frozen
+ * parallel invocation, assert three distinct leg sessions and the per-leg
+ * prompt mapping, kill the runtime with one leg live, restart, assert the
+ * re-fan-out on resume, and assert the run completes once all legs finish.
+ */
+async function runParallelPanelJourney(
+  runtime: LocalRuntimeClient,
+  workflowClient: ApiClient,
+  cell: PlannedCellV1,
+): Promise<ScenarioCellOutcome> {
+  const choices = await catalogHarnesses([T3_WF_PARALLEL_1_HARNESS]);
+  const choice = choices.get(T3_WF_PARALLEL_1_HARNESS);
+  if (!choice) {
+    return {
+      cellId: cell.cell_id,
+      status: "blocked",
+      reason: {
+        code: "scenario_blocked",
+        message: `T3-WF-PARALLEL-1: no Anthropic-family model found for "${T3_WF_PARALLEL_1_HARNESS}" in catalogs/agents/catalog.json`,
+      },
+    };
+  }
+  const candidates = await withGatewayProbedCandidates(runtime, T3_WF_PARALLEL_1_HARNESS, choice.modelCandidates);
+  const modelId = candidates[0];
+  assert.ok(modelId, "T3-WF-PARALLEL-1: at least one candidate model must be resolvable from the catalog");
+
+  const githubTestRepo = process.env.RELEASE_E2E_GITHUB_TEST_REPO ?? DEFAULT_GITHUB_TEST_REPO;
+  const repoPath = await ensureLocalClone(githubTestRepo);
+
+  // Mint a real repo-root id exactly as T3-WF-1 does: register a repo root with
+  // a throwaway workspace, delete the scratch workspace, and let the run PUT
+  // materialize the real workspace.
+  const { repoRoot, workspace: scratchWorkspace } = await runtime.createLocalWorkspace(repoPath);
+  await runtime.deleteWorkspace(scratchWorkspace.id).catch(() => undefined);
+
+  const runId = randomUUID();
+  const definition = reviewPanelDefinition({ agentKind: T3_WF_PARALLEL_1_HARNESS, modelId });
+  const invocation: WorkflowInvocationJsonV2 = {
+    schemaVersion: 2,
+    workflowDefinitionId: randomUUID(),
+    definition,
+    arguments: {},
+    placement: { repoConfigId: repoRoot.id, mode: "repo_root" },
+  };
+
+  let materializedWorkspaceId: string | undefined;
+  try {
+    // 1) PUT materializes a workspace and fans the node out to three sessions.
+    let projection = await workflowClient.put<WorkflowRunProjectionV2>(`/v1/workflow-runs/${runId}`, invocation);
+    assertFullProjection(projection, "PUT /v1/workflow-runs/{run_id}");
+    materializedWorkspaceId = projection.run.workspaceId;
+    assert.ok(materializedWorkspaceId, "T3-WF-PARALLEL-1: the PUT response must materialize a workspace");
+
+    const reviewNode = projection.nodes.find((node) => node.definitionNodeId === "review");
+    assert.ok(reviewNode, "T3-WF-PARALLEL-1: the projection must carry the defined review node");
+    assert.equal(reviewNode!.nodeType, "agent", "T3-WF-PARALLEL-1: the review node must be an agent node");
+
+    // 2) Poll until all three legs have attached a real session, then assert
+    //    the prompt-to-leg mapping (R4): each leg's session carries only its
+    //    own authored prompt inside the wrapped preamble.
+    const legs = await pollForLegSessions(workflowClient, runId, reviewNode!.id, 3, { timeoutMs: 30_000 });
+    assert.equal(legs.length, 3, "T3-WF-PARALLEL-1: the parallel node must mint one session per leg (three)");
+    const orderedPrompts = [LEG_PROMPTS.correctness, LEG_PROMPTS.security, LEG_PROMPTS.perf];
+    const sessionIds = new Set<string>();
+    for (const leg of legs) {
+      assert.ok(leg.sessionId, `T3-WF-PARALLEL-1: leg ${leg.legIndex} must attach a real session id`);
+      sessionIds.add(leg.sessionId!);
+      const events = await runtime.getEvents(leg.sessionId!);
+      const sentPrompt = findFirstUserPromptText(events);
+      assert.ok(sentPrompt, `T3-WF-PARALLEL-1: leg ${leg.legIndex}'s session must record the prompt actually sent`);
+      const own = orderedPrompts[leg.legIndex];
+      assertWrappedPreamble(sentPrompt!, own);
+      for (const [index, sibling] of orderedPrompts.entries()) {
+        if (index !== leg.legIndex) {
+          assert.ok(
+            !sentPrompt!.includes(sibling),
+            `T3-WF-PARALLEL-1: leg ${leg.legIndex}'s prompt must not carry leg ${index}'s authored prompt (R4)`,
+          );
+        }
+      }
+    }
+    assert.equal(sessionIds.size, 3, "T3-WF-PARALLEL-1: the three leg sessions must be distinct");
+
+    // 3) Let two legs finish, then crash the runtime with one leg still live.
+    //    The runtime kill+restart is performed OUT OF BAND by the release
+    //    runner's process supervisor (the same seam the T4 upgrade scenarios
+    //    use — there is no LocalRuntimeClient kill method, deliberately), so
+    //    this authored journey marks the boundary and then asserts the
+    //    post-restart state through the HTTP surface only.
+    await pollRunProjection(
+      workflowClient,
+      runId,
+      (candidate) => legsDoneCount(candidate, reviewNode!.id) >= 2,
+      { timeoutMs: 180_000 },
+    );
+    await crashAndRestartRuntimeOutOfBand();
+
+    // 4) After restart the boot fence has parked the node; resume re-fans-out
+    //    all three legs on a fresh generation.
+    projection = await pollRunProjection(
+      workflowClient,
+      runId,
+      (candidate) => candidate.run.status === "interrupted",
+      { timeoutMs: 60_000 },
+    );
+    assertFullProjection(projection, "GET /v1/workflow-runs/{run_id} (post-restart)");
+    const fencedNode = projection.nodes.find((node) => node.definitionNodeId === "review");
+    assert.equal(
+      fencedNode?.status,
+      "needs_attention",
+      "T3-WF-PARALLEL-1: the boot fence must park the parallel node needs_attention (ruling K)",
+    );
+    const resumed = await workflowClient.post<WorkflowRunProjectionV2>(`/v1/workflow-runs/${runId}/resume`, {});
+    assertFullProjection(resumed, "POST .../resume");
+    const refanned = await pollForLegSessions(workflowClient, runId, reviewNode!.id, 3, { timeoutMs: 30_000 });
+    assert.equal(refanned.length, 3, "T3-WF-PARALLEL-1: resume must re-fan-out all three legs (ruling F6)");
+    for (const leg of refanned) {
+      assert.ok(leg.sessionId, `T3-WF-PARALLEL-1: resumed leg ${leg.legIndex} must attach a fresh session`);
+      assert.ok(
+        !sessionIds.has(leg.sessionId!),
+        `T3-WF-PARALLEL-1: resumed leg ${leg.legIndex}'s session must be fresh, not a pre-crash orphan`,
+      );
+    }
+
+    // 5) All legs finish; the node aggregates once and the run completes.
+    const finalProjection = await pollRunProjection(
+      workflowClient,
+      runId,
+      (candidate) => candidate.run.status === "completed" || candidate.run.status === "failed",
+      { timeoutMs: 180_000 },
+    );
+    assert.equal(
+      finalProjection.run.status,
+      "completed",
+      `T3-WF-PARALLEL-1: all legs done must complete the run (got ${finalProjection.run.status}, ` +
+        `failureCode=${finalProjection.run.failureCode})`,
+    );
+    const finalNode = finalProjection.nodes.find((node) => node.definitionNodeId === "review");
+    assert.equal(finalNode?.status, "completed", "T3-WF-PARALLEL-1: the parallel node must complete once (ruling F1)");
+
+    return { cellId: cell.cell_id, status: "green" };
+  } finally {
+    if (materializedWorkspaceId) {
+      await runtime.deleteWorkspace(materializedWorkspaceId).catch(() => undefined);
+    }
+  }
+}
+
+function assertFullProjection(projection: WorkflowRunProjectionV2, whichCommand: string): void {
+  assert.ok(
+    projection && typeof projection === "object" && typeof projection.run?.id === "string",
+    `T3-WF-PARALLEL-1: ${whichCommand} must return the full projection's run`,
+  );
+  assert.ok(Array.isArray(projection.nodes), `T3-WF-PARALLEL-1: ${whichCommand} must return the full projection's nodes[]`);
+  assert.ok(Array.isArray(projection.docs), `T3-WF-PARALLEL-1: ${whichCommand} must return the full projection's docs[]`);
+}
+
+/**
+ * The parallel node's per-leg rollup (rung 7 shape, ruling F4). Read off the
+ * node projection structurally; until rung 7 lands, this is the intended
+ * shape to reconcile against the real SDK type on restack.
+ */
+function legsOf(projection: WorkflowRunProjectionV2, nodeRowId: string): WorkflowRunNodeLegV2[] {
+  const node = projection.nodes.find((candidate) => candidate.id === nodeRowId) as
+    | (WorkflowRunProjectionV2["nodes"][number] & { sessions?: WorkflowRunNodeLegV2[] })
+    | undefined;
+  return node?.sessions ?? [];
+}
+
+function legsDoneCount(projection: WorkflowRunProjectionV2, nodeRowId: string): number {
+  return legsOf(projection, nodeRowId).filter((leg) => leg.status === "done").length;
+}
+
+async function pollForLegSessions(
+  client: ApiClient,
+  runId: string,
+  nodeRowId: string,
+  expected: number,
+  options: { timeoutMs: number; pollMs?: number },
+): Promise<WorkflowRunNodeLegV2[]> {
+  const projection = await pollRunProjection(
+    client,
+    runId,
+    (candidate) => legsOf(candidate, nodeRowId).filter((leg) => leg.sessionId != null).length >= expected,
+    options,
+  );
+  return legsOf(projection, nodeRowId)
+    .filter((leg) => leg.sessionId != null)
+    .sort((a, b) => a.legIndex - b.legIndex);
+}
+
+async function pollRunProjection(
+  client: ApiClient,
+  runId: string,
+  until: (projection: WorkflowRunProjectionV2) => boolean,
+  options: { timeoutMs: number; pollMs?: number },
+): Promise<WorkflowRunProjectionV2> {
+  const pollMs = options.pollMs ?? 2000;
+  const deadline = Date.now() + options.timeoutMs;
+  let last = await client.get<WorkflowRunProjectionV2>(`/v1/workflow-runs/${runId}`);
+  while (!until(last) && Date.now() < deadline) {
+    await sleep(pollMs);
+    last = await client.get<WorkflowRunProjectionV2>(`/v1/workflow-runs/${runId}`);
+  }
+  return last;
+}
+
+/**
+ * Mirrors T3-WF-1's `findFirstUserPromptText` (the fixture does not export it):
+ * the first user-message text in a session's event log — the prompt actually
+ * sent to the harness, used for the per-leg prompt-to-leg assertion.
+ */
+function findFirstUserPromptText(events: SessionEventEnvelope[]): string | undefined {
+  for (const entry of events) {
+    const event = entry.event as {
+      type: string;
+      item?: { kind?: string; contentParts?: Array<{ type: string; text?: string }> };
+    };
+    if (event.type === "item_completed" && event.item?.kind === "user_message") {
+      const text = event.item.contentParts?.find((part) => part.type === "text")?.text;
+      if (text) {
+        return text;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The crash/resume boundary (ruling F6). A real runtime kill+restart is a
+ * process-supervisor operation the release runner owns out of band — there is
+ * no LocalRuntimeClient method for it, by design — so this authored,
+ * never-executed journey marks the boundary explicitly. When this scenario is
+ * wired for real on the next restack, replace this with the runner's
+ * supervisor hook (the same one the T4 upgrade scenarios drive).
+ */
+async function crashAndRestartRuntimeOutOfBand(): Promise<void> {
+  throw new Error(
+    "T3-WF-PARALLEL-1: runtime crash+restart is an out-of-band supervisor step; " +
+      "this scenario is authored against the frozen contract and not executed in this PR",
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Rung 5 of the Workflows follow-up ladder (frozen ADR, rulings F5 + F6): a node may carry 2..=8 per-leg authored prompts and fans out one session per leg; crash-resume truncates the ledger and re-fans-out all N.

## Grammar (all three planes)
- Runtime: `DefinitionLeg` (camelCase, `deny_unknown_fields`), `DefinitionNode.legs: Option<Vec<DefinitionLeg>>` — absent serializes byte-identically to today; 2..=8 enforced, `legs[0].prompt` must equal `node.prompt`, every leg non-blank with per-leg reference validation naming the leg index. Chain stays linear at node level; legs have no edges.
- Control plane: `WorkflowNodeLegV2` in `models_v2.py` (min_length=2, max_length=8, mirror validator).
- Client: `definition-v2.ts` per-leg reference scan (issue codes `invalid_leg_count` / `blank_leg_prompt` / `leg_prompt_mismatch`), builder draft add/remove/update-leg with leg 0 mirroring the node prompt and collapse-to-absent, builder UI leg authoring.

## Engine
- `ResolvedSideEffect::StartNodeLegs`; one-leg nodes keep `StartNode` byte-identically.
- `launch_legs` (new `live/workflows/launch.rs`): render one envelope per leg, mint N sessions, `stamp_fanout` writes the representative scalar stamp + N ledger rows in one commit, start+dispatch each, compensate all on any failure.
- F6 resume: `ResumeNode` truncates the ledger (`truncate_legs_tx`) and re-emits the fan-out effect.
- Tier-3 scenario `t3-wf-parallel-1.ts` authored and registered (heterogeneous 3-leg panel, prompt-to-leg assertion, crash boundary, re-fan-out assertions).

## Evidence (literals)
- `cargo test -p anyharness-lib workflow` → "test result: ok. 212 passed; 0 failed" (prior rung-4 gate was 196; +16 new).
- Negative control (prompt-to-leg invariant): pinned `leg_prompts()` to repeat leg 0's prompt → exactly `each_leg_envelope_carries_only_its_own_leg_prompt` fails; restored → "ok. 1 passed; 0 failed".
- Run-terminal Cancel control (rung-4 carry, first compile of its round-2 test in this stack): pinned the round-1 only-current-node stamp → exactly `cancel_marks_every_running_leg_in_the_run_cancelled` fails; restored → 2/2 pass.
- Control plane: `server/tests/unit/test_workflow_definition_v2_validation.py` → "42 passed".
- Client: workflows builder/domain suites → "Test Files 5 passed (5), Tests 75 passed (75)".
- `scripts/check_max_lines.py` → "Max-lines check passed"; `check_frontend_boundaries.py` → "Frontend boundary check passed."
- Committed OpenAPI artifacts regenerated (`DefinitionLeg` present in `components.schemas`).

## Fix log (burst disclosures)
- The rung was implemented under a machine-wide cargo hold (file-edits-only); on release, first compile surfaced one error: `actor.rs` used `launch_model` after its move to `launch.rs` without importing it (E0425). Fixed in the same burst (one-line import), disclosed here per the honesty-debt order.

## Notes
- The per-leg `sessions` rollup the t3 scenario reads is rung-7 shape — flagged for reconciliation there.
- Per-leg redo (`RedoLeg`, `DisposeSessionThenStartLeg`) is rung 6 and builds on the side-effect vocabulary added here.

## Review fixes on this rung
1. [BLOCKING finding, reviewer of record] A mid-fan-out launch failure stranded every freshly stamped leg at `running` against compensated, disposed sessions — `NodeLaunchFailed` carries no turn session and the representative fallback stamped leg 0 only. Fixed in 3be8505a2: the launch-failure stamp goes keyless and covers every row the fan-out inserted. Regression test `a_failed_fan_out_launch_terminalizes_every_leg_it_stamped` (3 legs, all land `Failed(NodeLaunchFailed)` + `completed_at`); negative control (fallback restored) fails at exactly "leg 1". Full suite after fix: "test result: ok. 213 passed; 0 failed". store.rs ratchet entry amended 1411→1416 within this rung's own new-content entry (+5, reason string updated).
2. [Non-blocking] Commit-message/body contradiction on OpenAPI artifacts reconciled: the "knowingly stale" sentence predated the release burst and has been removed from the feat commit message via reword — the committed artifacts in this PR are current (DefinitionLeg present in both generated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

