### PR TITLE
fix(workflows): render the per-node envelope preamble as structured markdown (PRO-276)

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/workflows/render.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/render.rs
@@ -101,37 +101,45 @@ fn argument_text(value: &serde_json::Value) -> String {
 
 /// The fixed context-doc preamble, varied only by node type (advance
 /// semantics differ). Logged per node via the stored envelope; keep changes
-/// deliberate — this text is what every workflow agent is told.
+/// deliberate — this text is what every workflow agent is told. It is
+/// markdown on purpose: the transcript renders it, so structure the agent
+/// parses is the same structure the human reads (single newlines would
+/// collapse into one run-on paragraph).
 fn preamble(node_type: WorkflowNodeType, context_dir: &Path, docs: &[WorkflowRunDocRecord]) -> String {
-    let mut text = String::new();
-    text.push_str(
-        "You are one node in a multi-step workflow. Shared context documents for this \
-         run live in one flat folder:\n",
-    );
-    text.push_str(&format!("  {}\n", context_dir.display()));
-    text.push_str(
-        "Files are named NN-slug.md, where NN is the position of the workflow step that \
-         produces the document. Read them freely for context and write to the ones your \
-         step produces. Keep documents legible plain markdown: someone who has never seen \
-         this workflow should understand what happened from the documents alone. Prefer \
-         evidence over prose. Do not add frontmatter or machine metadata.\n",
+    let mut text = format!(
+        "You are one node in a multi-step workflow.\n\
+         \n\
+         ## Shared context documents\n\
+         \n\
+         Shared documents for this run live in one flat folder:\n\
+         \n\
+         {}\n\
+         \n\
+         - Files are named NN-slug.md, where NN is the position of the workflow step \
+         that produces the document.\n\
+         - Read them freely for context and write to the ones your step produces.\n\
+         - Keep documents legible plain markdown: someone who has never seen this \
+         workflow should understand what happened from the documents alone.\n\
+         - Prefer evidence over prose. Do not add frontmatter or machine metadata.\n",
+        context_dir.display()
     );
     if !docs.is_empty() {
-        text.push_str("This run's documents:\n");
+        text.push_str("\nThis run's documents:\n\n");
         for doc in docs {
-            text.push_str(&format!("  - {}\n", context_dir.join(&doc.filename).display()));
+            text.push_str(&format!("- {}\n", context_dir.join(&doc.filename).display()));
         }
     }
-    match node_type {
-        WorkflowNodeType::Agent => text.push_str(
+    text.push_str("\n## Your step\n\n");
+    text.push_str(match node_type {
+        WorkflowNodeType::Agent => {
             "Your step completes when this turn ends. Finish the job in this turn; never \
              stop to ask questions. Do only this step's work — do not proceed into later \
-             steps' work.",
-        ),
-        WorkflowNodeType::HumanInLoop => text.push_str(
+             steps' work."
+        }
+        WorkflowNodeType::HumanInLoop => {
             "A human reviews your work before the workflow advances. Ending with open \
-             questions or partial work is fine — surface what the reviewer should look at.",
-        ),
-    }
+             questions or partial work is fine — surface what the reviewer should look at."
+        }
+    });
     text
 }

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/render_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/render_tests.rs
@@ -93,8 +93,12 @@ fn agent_preamble_teaches_conventions_and_the_completion_contract() {
     let preamble = &envelope.instruction_blocks[0];
     assert!(preamble.contains("/ws/.proliferate/context"));
     assert!(preamble.contains("NN-slug.md"));
-    assert!(preamble.contains("/ws/.proliferate/context/00-plan-doc.md"));
-    assert!(preamble.contains("/ws/.proliferate/context/notes.md"));
+    // The preamble is markdown the transcript renders: pinned section
+    // headings and one bullet line per registered doc.
+    assert!(preamble.contains("\n## Shared context documents\n"));
+    assert!(preamble.contains("\n## Your step\n"));
+    assert!(preamble.contains("\n- /ws/.proliferate/context/00-plan-doc.md\n"));
+    assert!(preamble.contains("\n- /ws/.proliferate/context/notes.md\n"));
     assert!(preamble.contains("never stop to ask questions"));
     assert!(preamble.contains("do not proceed into later steps' work"));
     // Ruling D: the preamble never rides system_prompt_append — that channel


### PR DESCRIPTION
## Summary

Re-lands the PRO-276 fix (originally #1947, rolled back with the other workflow PRs in #1996). The per-node workflow envelope preamble was single-newline prose, which the transcript's markdown renderer collapses into one run-on paragraph — illegible for the human and unstructured for the agent.

Reworks it into pinned markdown sections with the same semantic content:
- `## Shared context documents` — the flat context folder, naming convention, and doc conventions as a bullet list
- `This run's documents` — one bullet per registered doc (was indented `  - `)
- `## Your step` — the per-node-type completion contract (Agent vs Human-in-loop), verbatim

## Testing

- `cargo test -p anyharness-lib --lib -- workflows` — 160 passed, 0 failed
- Render tests pin the new section headings and bullet-per-doc structure; the `never stop to ask questions` / Human-in-loop fragments are preserved verbatim (also pinned in lifecycle_tests.rs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)