### PR TITLE
feat(product): chat composer context-doc mention kind (workflows follow-up rung 8)

### DIFF
--- a/apps/packages/product-client/src/components/playground/PlaygroundComposerSurfaces.tsx
+++ b/apps/packages/product-client/src/components/playground/PlaygroundComposerSurfaces.tsx
@@ -221,7 +221,7 @@ function PlaygroundFileMentionComposerSurface({
     <>
       <div className="relative z-popover flex flex-col px-5">
         <ComposerFileMentionSearch
-          results={results}
+          items={results.map((file) => ({ kind: "file", file }))}
           highlightedIndex={0}
           listRef={listRef}
           query="a"

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx
@@ -29,7 +29,7 @@ import {
   useQueuedPromptEdit,
 } from "#product/hooks/chat/ui/use-queued-prompt-edit";
 import { focusChatInput } from "#product/lib/domain/focus-zone";
-import { serializeChatDraftToOutgoingPrompt } from "#product/lib/domain/chat/composer/file-mention-draft-model";
+import { serializeChatDraftToOutgoingPrompt } from "#product/lib/domain/chat/composer/outgoing-prompt";
 import { promptAttachmentSnapshotsToContentParts } from "#product/domain/chats/composer/prompt-attachment-content-parts";
 import { buildPromptWithSelectedResponseContexts } from "#product/domain/chats/transcript/selected-response-context";
 import { useChatInputStore } from "#product/stores/chat/chat-input-store";

--- a/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ChatInput.tsx
@@ -29,7 +29,7 @@ import {
   useQueuedPromptEdit,
 } from "#product/hooks/chat/ui/use-queued-prompt-edit";
 import { focusChatInput } from "#product/lib/domain/focus-zone";
-import { serializeChatDraftToPrompt } from "#product/lib/domain/chat/composer/file-mention-draft-model";
+import { serializeChatDraftToOutgoingPrompt } from "#product/lib/domain/chat/composer/file-mention-draft-model";
 import { promptAttachmentSnapshotsToContentParts } from "#product/domain/chats/composer/prompt-attachment-content-parts";
 import { buildPromptWithSelectedResponseContexts } from "#product/domain/chats/transcript/selected-response-context";
 import { useChatInputStore } from "#product/stores/chat/chat-input-store";
@@ -178,7 +178,7 @@ export function ChatInput({
       });
       // Serialized at submit time (imperative read) so typing keystrokes never
       // re-render this component just to keep promptText fresh.
-      const promptText = serializeChatDraftToPrompt(getDraft());
+      const promptText = serializeChatDraftToOutgoingPrompt(getDraft());
       const selectedResponseContexts = [...getSelectedResponseContexts()];
       const contextualPrompt = buildPromptWithSelectedResponseContexts(
         promptText,

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerCommandEditor.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerCommandEditor.test.tsx
@@ -23,8 +23,15 @@ const slashCommandMock = vi.hoisted(() => ({
   selectedCount: 0,
 }));
 
+type MentionMenuItem =
+  | { kind: "file"; file: { path: string; name: string; parent: string } }
+  | {
+      kind: "contextDoc";
+      doc: { docId: string; runId: string; slug: string; filename: string; runLabel: string | null };
+    };
+
 const fileMentionMock = vi.hoisted(() => ({
-  results: [] as Array<{ path: string; name: string; parent: string }>,
+  items: [] as MentionMenuItem[],
   moveHighlight: vi.fn(),
   selectedCount: 0,
   lastQuery: null as string | null,
@@ -38,13 +45,13 @@ vi.mock("#product/hooks/chat/ui/use-chat-file-mention-menu", () => ({
   }: {
     open: boolean;
     query: string;
-    onSelect: (result: { path: string; name: string; parent: string }) => void;
+    onSelect: (item: MentionMenuItem) => void;
   }) => {
     if (open) {
       fileMentionMock.lastQuery = query;
     }
     return {
-      results: open ? fileMentionMock.results : [],
+      items: open ? fileMentionMock.items : [],
       isLoading: false,
       isError: false,
       isPending: false,
@@ -54,7 +61,7 @@ vi.mock("#product/hooks/chat/ui/use-chat-file-mention-menu", () => ({
       moveHighlight: fileMentionMock.moveHighlight,
       selectHighlighted: () => {
         fileMentionMock.selectedCount += 1;
-        const first = fileMentionMock.results[0];
+        const first = fileMentionMock.items[0];
         if (first) {
           onSelect(first);
         }
@@ -62,10 +69,27 @@ vi.mock("#product/hooks/chat/ui/use-chat-file-mention-menu", () => ({
       setRowRef: vi.fn(),
       handleRowMouseEnter: vi.fn(),
       getRowId: (index: number) => `file-mention-row-${index}`,
-      activeDescendantId: open && fileMentionMock.results.length > 0 ? "file-mention-row-0" : undefined,
+      activeDescendantId: open && fileMentionMock.items.length > 0 ? "file-mention-row-0" : undefined,
     };
   },
 }));
+
+function fileItem(file: { path: string; name: string; parent: string }): MentionMenuItem {
+  return { kind: "file", file };
+}
+
+function docMentionItem(): MentionMenuItem {
+  return {
+    kind: "contextDoc",
+    doc: {
+      docId: "doc-1",
+      runId: "run-01j8",
+      slug: "plan",
+      filename: "01-plan.md",
+      runLabel: "Release checklist",
+    },
+  };
+}
 
 vi.mock("#product/hooks/chat/ui/use-chat-slash-command-menu", () => ({
   useChatSlashCommandMenu: ({
@@ -129,7 +153,7 @@ describe("ComposerCommandEditor", () => {
     slashCommandMock.commands = [];
     slashCommandMock.moveHighlight.mockClear();
     slashCommandMock.selectedCount = 0;
-    fileMentionMock.results = [];
+    fileMentionMock.items = [];
     fileMentionMock.moveHighlight.mockClear();
     fileMentionMock.selectedCount = 0;
     fileMentionMock.lastQuery = null;
@@ -224,8 +248,8 @@ describe("ComposerCommandEditor", () => {
   });
 
   it("opens the file mention menu on an @ token and searches on the typed query", async () => {
-    fileMentionMock.results = [
-      { path: "docs/setup.md", name: "setup.md", parent: "docs" },
+    fileMentionMock.items = [
+      fileItem({ path: "docs/setup.md", name: "setup.md", parent: "docs" }),
     ];
     const { container } = renderEditor({ draft: createTextDraft("Open @set") });
 
@@ -235,8 +259,8 @@ describe("ComposerCommandEditor", () => {
   });
 
   it("wires the file mention menu as a listbox announced from the composer's editable", async () => {
-    fileMentionMock.results = [
-      { path: "docs/setup.md", name: "setup.md", parent: "docs" },
+    fileMentionMock.items = [
+      fileItem({ path: "docs/setup.md", name: "setup.md", parent: "docs" }),
     ];
     const { container, textarea } = renderEditor({ draft: createTextDraft("Open @set") });
 
@@ -271,8 +295,8 @@ describe("ComposerCommandEditor", () => {
   });
 
   it("inserts a selected file mention as a markdown file link", async () => {
-    fileMentionMock.results = [
-      { path: "docs/setup.md", name: "setup.md", parent: "docs" },
+    fileMentionMock.items = [
+      fileItem({ path: "docs/setup.md", name: "setup.md", parent: "docs" }),
     ];
     const onSubmit = vi.fn();
     const onDraftChange = vi.fn();
@@ -292,8 +316,8 @@ describe("ComposerCommandEditor", () => {
   });
 
   it("renders an inserted file mention as a chip rather than raw markdown", async () => {
-    fileMentionMock.results = [
-      { path: "docs/setup.md", name: "setup.md", parent: "docs" },
+    fileMentionMock.items = [
+      fileItem({ path: "docs/setup.md", name: "setup.md", parent: "docs" }),
     ];
     const { textarea } = renderEditor({ draft: createTextDraft("Open @set") });
 
@@ -308,8 +332,8 @@ describe("ComposerCommandEditor", () => {
   });
 
   it("renders an inserted file mention with its file glyph and path", async () => {
-    fileMentionMock.results = [
-      { path: "docs/guides/setup.md", name: "setup.md", parent: "docs/guides" },
+    fileMentionMock.items = [
+      fileItem({ path: "docs/guides/setup.md", name: "setup.md", parent: "docs/guides" }),
     ];
     const { textarea } = renderEditor({ draft: createTextDraft("Open @set") });
 
@@ -332,6 +356,59 @@ describe("ComposerCommandEditor", () => {
     const content = chip.querySelector("[data-composer-file-mention-content]");
     expect(content?.getAttribute("data-composer-file-mention-directory")).toBe("docs/guides");
     expect(chip.textContent).toBe("setup.md");
+  });
+
+  it("inserts a selected context doc serialized to the @doc token", async () => {
+    fileMentionMock.items = [docMentionItem()];
+    const onSubmit = vi.fn();
+    const onDraftChange = vi.fn();
+    const { textarea } = renderEditor({
+      draft: createTextDraft("Open @pla"),
+      onSubmit,
+      onDraftChange,
+    });
+
+    expect(fireEvent.keyDown(textarea, { key: "Enter", repeat: false })).toBe(false);
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(fileMentionMock.selectedCount).toBe(1);
+    await waitFor(() => expect(onDraftChange.mock.calls.some(
+      ([draft]) => serializeChatDraftToPrompt(draft)
+        === "Open [01-plan.md](@doc:run-01j8/01-plan.md) ",
+    )).toBe(true));
+  });
+
+  it("renders an inserted context-doc mention as a chip with the resolved path tooltip", async () => {
+    fileMentionMock.items = [docMentionItem()];
+    const { textarea } = renderEditor({ draft: createTextDraft("Open @pla") });
+
+    fireEvent.keyDown(textarea, { key: "Enter", repeat: false });
+
+    await waitFor(() => {
+      expect(textarea.querySelector("[data-composer-context-doc-mention]")).toBeTruthy();
+    });
+    const chip = textarea.querySelector<HTMLElement>("[data-composer-context-doc-mention]")!;
+    expect(chip.getAttribute("data-composer-context-doc-mention")).toBe("run-01j8/01-plan.md");
+    // The tooltip carries the workspace path the mention resolves to at send
+    // time, not the raw token.
+    expect(chip.title).toBe(".proliferate/context/01-plan.md");
+    const glyph = chip.querySelector("[data-composer-context-doc-mention-glyph]");
+    expect(glyph?.querySelector("svg")).toBeTruthy();
+    expect(glyph?.textContent).toBe("");
+    expect(chip.textContent).toBe("01-plan.md");
+    expect(textarea.textContent).not.toContain("](");
+  });
+
+  it("renders a restored draft's @doc token as a context-doc chip", () => {
+    const { textarea } = renderEditor({
+      draft: createTextDraft("See [01-plan.md](@doc:run-01j8/01-plan.md) please"),
+    });
+
+    const chip = textarea.querySelector<HTMLElement>("[data-composer-context-doc-mention]")!;
+    expect(chip.getAttribute("data-composer-context-doc-mention")).toBe("run-01j8/01-plan.md");
+    expect(chip.textContent).toBe("01-plan.md");
+    // Only the chip's own text may reach the draft's text stream.
+    expect(textarea.textContent).toBe("See 01-plan.md please");
   });
 
   it("renders a workspace file link from restored draft markdown as a chip", () => {
@@ -393,8 +470,8 @@ describe("ComposerCommandEditor", () => {
   });
 
   it("replaces a file trigger after a code block without shifting its range", async () => {
-    fileMentionMock.results = [
-      { path: "docs/setup.md", name: "setup.md", parent: "docs" },
+    fileMentionMock.items = [
+      fileItem({ path: "docs/setup.md", name: "setup.md", parent: "docs" }),
     ];
     const onDraftChange = vi.fn();
     const { textarea } = renderEditor({
@@ -424,8 +501,8 @@ describe("ComposerCommandEditor", () => {
   });
 
   it("replaces a file trigger before a code block without consuming the block", async () => {
-    fileMentionMock.results = [
-      { path: "docs/setup.md", name: "setup.md", parent: "docs" },
+    fileMentionMock.items = [
+      fileItem({ path: "docs/setup.md", name: "setup.md", parent: "docs" }),
     ];
     const onDraftChange = vi.fn();
     const { textarea } = renderEditor({

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerCommandEditor.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerCommandEditor.tsx
@@ -19,7 +19,7 @@ import {
   findComposerMenuTrigger,
   type ComposerMenuTrigger,
 } from "#product/lib/domain/chat/composer/composer-menu-trigger";
-import type { FileMentionResult } from "#product/lib/domain/chat/composer/file-mention-search";
+import type { ChatMentionMenuItem } from "#product/lib/domain/chat/composer/chat-mention-items";
 import type { SessionSlashCommandViewModel } from "#product/lib/domain/chat/composer/session-slash-command-policy";
 import {
   finishOrCancelMeasurementOperation,
@@ -32,6 +32,7 @@ import type { MeasurementOperationId } from "#product/lib/domain/telemetry/debug
 import { ComposerFileMentionSearch } from "#product/components/workspace/chat/input/ComposerFileMentionSearch";
 import { ComposerSlashCommandSearch } from "#product/components/workspace/chat/input/ComposerSlashCommandSearch";
 import { $createComposerFileMentionNode } from "#product/components/workspace/chat/input/ComposerFileMentionNode";
+import { $createComposerContextDocMentionNode } from "#product/components/workspace/chat/input/ComposerContextDocMentionNode";
 import { ComposerRichTextEditor } from "#product/components/workspace/chat/input/ComposerRichTextEditor";
 import {
   getComposerEditorContext,
@@ -153,19 +154,24 @@ export function ComposerCommandEditor({
     editorRef.current.focus();
   }, [replaceEndFor]);
 
-  const handleSelectFileMention = useCallback((result: FileMentionResult) => {
+  const handleSelectMention = useCallback((item: ChatMentionMenuItem) => {
     const activeTrigger = commandTriggerRef.current;
     if (activeTrigger?.kind !== "mention" || !editorRef.current) return;
     // The mention is inserted as a chip node plus a trailing space, not as
     // markdown text: markdown typed in one shot never reaches the shortcut
     // plugin, so building the node here is what makes the draft show a chip
-    // immediately. Serialization back to `[name](path)` is the node's job.
+    // immediately. Serialization back to the mention token is the node's job.
     replaceComposerRangeWithNodes(
       editorRef.current,
       activeTrigger.start,
       replaceEndFor(activeTrigger),
       () => [
-        $createComposerFileMentionNode(result.path, result.name),
+        item.kind === "contextDoc"
+          ? $createComposerContextDocMentionNode(
+              { runId: item.doc.runId, filename: item.doc.filename },
+              item.doc.filename,
+            )
+          : $createComposerFileMentionNode(item.file.path, item.file.name),
         $createTextNode(" "),
       ],
     );
@@ -181,13 +187,13 @@ export function ComposerCommandEditor({
   const mentions = useChatFileMentionMenu({
     open: !!mentionTrigger,
     query: mentionTrigger?.query ?? "",
-    onSelect: handleSelectFileMention,
+    onSelect: handleSelectMention,
   });
   const openMenu = slashTrigger ? search : mentionTrigger ? mentions : null;
   const openMenuItemCount = slashTrigger
     ? search.commands.length
     : mentionTrigger
-      ? mentions.results.length
+      ? mentions.items.length
       : 0;
 
   const handleKeyDown = useCallback((event: ChatComposerKeyboardEvent) => {
@@ -241,7 +247,7 @@ export function ComposerCommandEditor({
     />
   ) : mentionTrigger ? (
     <ComposerFileMentionSearch
-      results={mentions.results}
+      items={mentions.items}
       highlightedIndex={mentions.highlightedIndex}
       listRef={mentions.listRef}
       query={mentionTrigger.query}
@@ -249,7 +255,7 @@ export function ComposerCommandEditor({
       isError={mentions.isError}
       isPending={mentions.isPending}
       runtimeReady={mentions.runtimeReady}
-      onSelect={handleSelectFileMention}
+      onSelect={handleSelectMention}
       onRowMouseEnter={mentions.handleRowMouseEnter}
       setRowRef={mentions.setRowRef}
       getRowId={mentions.getRowId}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerContextDocMentionNode.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerContextDocMentionNode.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { $getRoot, createEditor, type LexicalEditor, type LexicalNode } from "lexical";
+import { $convertFromMarkdownString, $convertToMarkdownString } from "@lexical/markdown";
+import {
+  COMPOSER_INPUT_TRANSFORMERS,
+  COMPOSER_NODES,
+  COMPOSER_OUTPUT_TRANSFORMERS,
+} from "#product/components/workspace/chat/input/ComposerEditorDocument";
+import {
+  $isComposerContextDocMentionNode,
+  ComposerContextDocMentionNode,
+} from "#product/components/workspace/chat/input/ComposerContextDocMentionNode";
+import { $isComposerFileMentionNode } from "#product/components/workspace/chat/input/ComposerFileMentionNode";
+
+function createComposerTestEditor(): LexicalEditor {
+  return createEditor({
+    nodes: COMPOSER_NODES,
+    onError: (error) => {
+      throw error;
+    },
+  });
+}
+
+function importDraft(editor: LexicalEditor, markdown: string): void {
+  editor.update(() => {
+    $convertFromMarkdownString(markdown, COMPOSER_INPUT_TRANSFORMERS);
+  }, { discrete: true });
+}
+
+function exportDraft(editor: LexicalEditor): string {
+  let markdown = "";
+  editor.getEditorState().read(() => {
+    markdown = $convertToMarkdownString(COMPOSER_OUTPUT_TRANSFORMERS);
+  });
+  return markdown;
+}
+
+function firstParagraphChildren(editor: LexicalEditor): LexicalNode[] {
+  let children: LexicalNode[] = [];
+  editor.getEditorState().read(() => {
+    const paragraph = $getRoot().getFirstChild();
+    children = paragraph && "getChildren" in paragraph
+      ? (paragraph as { getChildren(): LexicalNode[] }).getChildren()
+      : [];
+  });
+  return children;
+}
+
+describe("ComposerContextDocMentionNode markdown round-trip", () => {
+  it("round-trips a draft holding a context-doc mention, a file mention, and a web link", () => {
+    const markdown = "Check [01-plan.md](@doc:run-01j8/01-plan.md) against "
+      + "[setup.md](docs/setup.md) and [Docs](https://example.com) now";
+    const editor = createComposerTestEditor();
+
+    importDraft(editor, markdown);
+
+    const children = firstParagraphChildren(editor);
+    const docNodes = children.filter($isComposerContextDocMentionNode);
+    const fileNodes = children.filter($isComposerFileMentionNode);
+    expect(docNodes).toHaveLength(1);
+    expect(fileNodes).toHaveLength(1);
+    editor.getEditorState().read(() => {
+      expect(docNodes[0]?.getRef()).toEqual({ runId: "run-01j8", filename: "01-plan.md" });
+      expect(docNodes[0]?.getTextContent()).toBe("01-plan.md");
+      // The typed web link stays literal text: no link node, no mention chip.
+      expect($getRoot().getTextContent()).toContain("[Docs](https://example.com)");
+    });
+
+    expect(exportDraft(editor)).toBe(markdown);
+  });
+
+  it("never lets the two mention serializations claim each other", () => {
+    const editor = createComposerTestEditor();
+
+    importDraft(editor, "[setup.md](docs/setup.md) then [01-plan.md](@doc:run-01j8/01-plan.md)");
+
+    const children = firstParagraphChildren(editor);
+    const docNodes = children.filter($isComposerContextDocMentionNode);
+    const fileNodes = children.filter($isComposerFileMentionNode);
+    expect(docNodes).toHaveLength(1);
+    expect(fileNodes).toHaveLength(1);
+    editor.getEditorState().read(() => {
+      // The file mention kept its workspace path; the doc mention kept its ref.
+      expect(fileNodes[0]?.getTextContent()).toBe("setup.md");
+      expect(docNodes[0]?.getRef().runId).toBe("run-01j8");
+    });
+  });
+
+  it("leaves a doc-shaped token with an invalid destination as plain text", () => {
+    const editor = createComposerTestEditor();
+
+    importDraft(editor, "See [plan](@doc:no-separator) here");
+
+    const children = firstParagraphChildren(editor);
+    expect(children.some($isComposerContextDocMentionNode)).toBe(false);
+    expect(children.some($isComposerFileMentionNode)).toBe(false);
+    editor.getEditorState().read(() => {
+      expect($getRoot().getTextContent()).toBe("See [plan](@doc:no-separator) here");
+    });
+  });
+
+  it("round-trips the ref through JSON serialization", () => {
+    const editor = createComposerTestEditor();
+    importDraft(editor, "[01-plan.md](@doc:run-01j8/01-plan.md)");
+    let serialized: ReturnType<ComposerContextDocMentionNode["exportJSON"]> | null = null;
+    editor.getEditorState().read(() => {
+      const node = firstDocNode();
+      serialized = node?.exportJSON() ?? null;
+    });
+
+    function firstDocNode(): ComposerContextDocMentionNode | null {
+      const paragraph = $getRoot().getFirstChild();
+      const children = paragraph && "getChildren" in paragraph
+        ? (paragraph as { getChildren(): LexicalNode[] }).getChildren()
+        : [];
+      return children.find($isComposerContextDocMentionNode) ?? null;
+    }
+
+    expect(serialized).toMatchObject({
+      type: "composer-context-doc-mention",
+      runId: "run-01j8",
+      filename: "01-plan.md",
+      text: "01-plan.md",
+    });
+
+    const rehydrated = createComposerTestEditor();
+    rehydrated.update(() => {
+      const node = ComposerContextDocMentionNode.importJSON(serialized!);
+      expect(node.getRef()).toEqual({ runId: "run-01j8", filename: "01-plan.md" });
+      expect(node.getMode()).toBe("token");
+    }, { discrete: true });
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerContextDocMentionNode.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerContextDocMentionNode.tsx
@@ -1,0 +1,235 @@
+import {
+  TextNode,
+  setDOMUnmanaged,
+  type DOMSlot,
+  type EditorConfig,
+  type LexicalEditor,
+  type LexicalNode,
+  type LexicalUpdateJSON,
+  type NodeKey,
+  type SerializedTextNode,
+  type Spread,
+} from "lexical";
+import type { TextMatchTransformer } from "@lexical/markdown";
+import { FILE_ICON_ASSETS } from "#product/components/workspace/files/file-icon-assets";
+import {
+  CONTEXT_DOC_MENTION_LINK_BODY,
+  CONTEXT_DOC_DESTINATION_PREFIX,
+  contextDocMentionWorkspacePath,
+  formatContextDocMentionToken,
+  parseContextDocMentionDestination,
+  type ContextDocMentionRef,
+} from "#product/lib/domain/chat/composer/context-doc-mention";
+
+export type SerializedComposerContextDocMentionNode = Spread<
+  { runId: string; filename: string },
+  SerializedTextNode
+>;
+
+/**
+ * The context-doc chip wears the file-mention chip's anatomy classes (the
+ * inline-flex/gap/glyph-centering rules in product.css key off
+ * `composer-file-mention`) plus its own identity class: the two mentions are
+ * deliberately the same chip *shape* with a different glyph and serialization,
+ * so a doc picked from a run and a file picked from the tree read as siblings.
+ */
+const CONTEXT_DOC_CHIP_CLASS =
+  "composer-context-doc-mention composer-file-mention rounded-sm border border-border/60 bg-muted/45 px-1 py-px text-foreground/90";
+
+const CONTEXT_DOC_GLYPH_CLASS =
+  "composer-file-mention-glyph icon-compact file-reference-icon inline-block shrink-0 select-none [&>svg]:block [&>svg]:size-full";
+const GLYPH_ATTRIBUTE = "data-composer-context-doc-mention-glyph";
+const CONTENT_ATTRIBUTE = "data-composer-context-doc-mention-content";
+
+/**
+ * A workflow context-doc mention chip in the composer.
+ *
+ * Sibling of `ComposerFileMentionNode` and built the same way — a `TextNode`
+ * in token mode, so the caret walks past it, it deletes as one unit, and
+ * markdown export needs no special cases. It differs in what it points at: a
+ * doc registered to one of the workspace's workflow runs, carried as
+ * `(runId, filename)` and serialized to the `@doc:` token rather than a
+ * workspace file link, so the two never cross-parse.
+ */
+export class ComposerContextDocMentionNode extends TextNode {
+  /** The run whose doc registry owns the mentioned doc. */
+  __runId: string;
+  /** The doc's filename inside the run workspace's context directory. */
+  __filename: string;
+
+  static getType(): string {
+    return "composer-context-doc-mention";
+  }
+
+  static clone(node: ComposerContextDocMentionNode): ComposerContextDocMentionNode {
+    return new ComposerContextDocMentionNode(
+      { runId: node.__runId, filename: node.__filename },
+      node.__text,
+      node.__key,
+    );
+  }
+
+  constructor(ref: ContextDocMentionRef, text?: string, key?: NodeKey) {
+    super(text ?? ref.filename, key);
+    this.__runId = ref.runId;
+    this.__filename = ref.filename;
+  }
+
+  afterCloneFrom(prevNode: this): void {
+    super.afterCloneFrom(prevNode);
+    this.__runId = prevNode.__runId;
+    this.__filename = prevNode.__filename;
+  }
+
+  getRef(): ContextDocMentionRef {
+    const latest = this.getLatest();
+    return { runId: latest.__runId, filename: latest.__filename };
+  }
+
+  setRef(ref: ContextDocMentionRef): this {
+    const writable = this.getWritable();
+    writable.__runId = ref.runId;
+    writable.__filename = ref.filename;
+    return writable;
+  }
+
+  createDOM(config: EditorConfig, editor?: LexicalEditor): HTMLElement {
+    const element = super.createDOM(config, editor);
+    element.className = `${element.className} ${CONTEXT_DOC_CHIP_CLASS}`.trim();
+    // Same move as the file chip: `super.createDOM` has already put the text
+    // straight into `element`, so the text is moved into a content element and
+    // the glyph becomes its leading sibling.
+    const document = element.ownerDocument;
+    const content = document.createElement("span");
+    content.setAttribute(CONTENT_ATTRIBUTE, "true");
+    content.append(...Array.from(element.childNodes));
+    element.append(createContextDocGlyph(document), content);
+    applyContextDocRef(element, this.getRefSnapshot());
+    return element;
+  }
+
+  /**
+   * Points reconciliation and selection at the chip's text element, exactly as
+   * the file mention node does; see that node's comment for why the glyph
+   * sibling needs this.
+   */
+  getDOMSlot(element: HTMLElement): DOMSlot<HTMLElement> {
+    const slot = super.getDOMSlot(element);
+    const content = element.querySelector<HTMLElement>(`[${CONTENT_ATTRIBUTE}]`);
+    return content ? slot.withElement(content) : slot;
+  }
+
+  updateDOM(prevNode: this, dom: HTMLElement, config: EditorConfig): boolean {
+    const updated = super.updateDOM(prevNode, dom, config);
+    if (updated) {
+      return true;
+    }
+    if (prevNode.__runId !== this.__runId || prevNode.__filename !== this.__filename) {
+      applyContextDocRef(dom, this.getRefSnapshot());
+    }
+    return false;
+  }
+
+  static importJSON(
+    serializedNode: SerializedComposerContextDocMentionNode,
+  ): ComposerContextDocMentionNode {
+    return $createComposerContextDocMentionNode(
+      { runId: serializedNode.runId, filename: serializedNode.filename },
+      serializedNode.text,
+    ).updateFromJSON(serializedNode);
+  }
+
+  updateFromJSON(
+    serializedNode: LexicalUpdateJSON<SerializedComposerContextDocMentionNode>,
+  ): this {
+    return super
+      .updateFromJSON(serializedNode)
+      .setRef({ runId: serializedNode.runId, filename: serializedNode.filename });
+  }
+
+  exportJSON(): SerializedComposerContextDocMentionNode {
+    const ref = this.getRef();
+    return { ...super.exportJSON(), runId: ref.runId, filename: ref.filename };
+  }
+
+  /** Typing right against a chip must produce ordinary text, never extend it. */
+  canInsertTextBefore(): boolean {
+    return false;
+  }
+
+  canInsertTextAfter(): boolean {
+    return false;
+  }
+
+  /** Ref without `getLatest()`, for use during DOM construction. */
+  private getRefSnapshot(): ContextDocMentionRef {
+    return { runId: this.__runId, filename: this.__filename };
+  }
+}
+
+export function $createComposerContextDocMentionNode(
+  ref: ContextDocMentionRef,
+  label?: string,
+): ComposerContextDocMentionNode {
+  return new ComposerContextDocMentionNode(ref, label).setMode("token");
+}
+
+export function $isComposerContextDocMentionNode(
+  node: LexicalNode | null | undefined,
+): node is ComposerContextDocMentionNode {
+  return node instanceof ComposerContextDocMentionNode;
+}
+
+function createContextDocGlyph(document: Document): HTMLElement {
+  const glyph = document.createElement("span");
+  glyph.setAttribute(GLYPH_ATTRIBUTE, "true");
+  glyph.setAttribute("aria-hidden", "true");
+  glyph.className = CONTEXT_DOC_GLYPH_CLASS;
+  // The generic document mark, not the extension-derived file icon: the chip
+  // says "a context doc of a workflow run", not "a markdown file".
+  glyph.innerHTML = FILE_ICON_ASSETS.document;
+  // Decoration the composer painted, not content Lexical manages; see the file
+  // mention node.
+  setDOMUnmanaged(glyph);
+  return glyph;
+}
+
+/**
+ * Machine-readable identity and the hover tooltip. The tooltip carries the
+ * resolved workspace path — the pointer the mention will send — which is what
+ * a user hovering a chip wants confirmed.
+ */
+function applyContextDocRef(element: HTMLElement, ref: ContextDocMentionRef): void {
+  element.setAttribute("data-composer-context-doc-mention", `${ref.runId}/${ref.filename}`);
+  element.title = contextDocMentionWorkspacePath(ref);
+}
+
+/**
+ * Renders `[label](@doc:<runId>/<filename>)` in the draft as a context-doc
+ * chip, and serializes a chip back to exactly that token. The `@doc:` prefix
+ * requires a `:` in the destination, which the workspace file-link transformer
+ * rejects, so the two transformers can never claim each other's text.
+ */
+export const COMPOSER_CONTEXT_DOC_MENTION_TRANSFORMER: TextMatchTransformer = {
+  dependencies: [ComposerContextDocMentionNode],
+  export: (node) => {
+    if (!$isComposerContextDocMentionNode(node)) {
+      return null;
+    }
+    return formatContextDocMentionToken(node.getTextContent(), node.getRef());
+  },
+  importRegExp: new RegExp(CONTEXT_DOC_MENTION_LINK_BODY),
+  regExp: new RegExp(`${CONTEXT_DOC_MENTION_LINK_BODY}$`),
+  replace: (textNode, match) => {
+    const label = match[1] ?? "";
+    const ref = parseContextDocMentionDestination(
+      `${CONTEXT_DOC_DESTINATION_PREFIX}${match[2] ?? ""}`,
+    );
+    if (!ref) {
+      return;
+    }
+    textNode.replace($createComposerContextDocMentionNode(ref, label));
+  },
+  trigger: ")",
+  type: "text-match",
+};

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerEditorDocument.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerEditorDocument.tsx
@@ -31,6 +31,10 @@ import {
   ComposerFileMentionNode,
 } from "#product/components/workspace/chat/input/ComposerFileMentionNode";
 import {
+  COMPOSER_CONTEXT_DOC_MENTION_TRANSFORMER,
+  ComposerContextDocMentionNode,
+} from "#product/components/workspace/chat/input/ComposerContextDocMentionNode";
+import {
   COMPOSER_CODE_TRANSFORMER,
   isComposerOffsetInsideOpenCodeFence,
 } from "#product/components/workspace/chat/input/ComposerCodeFenceMarkdown";
@@ -50,6 +54,7 @@ export const COMPOSER_NODES = [
   ListItemNode,
   LinkNode,
   ComposerFileMentionNode,
+  ComposerContextDocMentionNode,
 ];
 
 /**
@@ -71,6 +76,10 @@ export const COMPOSER_INPUT_TRANSFORMERS: Transformer[] = [
   BOLD_UNDERSCORE,
   ITALIC_STAR,
   ITALIC_UNDERSCORE,
+  // The context-doc transformer's `@doc:` destination contains a `:`, which the
+  // file transformer's body excludes, so the order of the two mention
+  // transformers carries no meaning — neither can match the other's text.
+  COMPOSER_CONTEXT_DOC_MENTION_TRANSFORMER,
   COMPOSER_FILE_MENTION_TRANSFORMER,
 ];
 

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerFileMentionSearch.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerFileMentionSearch.test.tsx
@@ -4,38 +4,107 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { createRef } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ComposerFileMentionSearch } from "#product/components/workspace/chat/input/ComposerFileMentionSearch";
+import type { ChatMentionMenuItem } from "#product/lib/domain/chat/composer/chat-mention-items";
 
 afterEach(cleanup);
 
-describe("ComposerFileMentionSearch", () => {
-  it("renders long result sets inside the shared scrolling listbox", () => {
-    const results = Array.from({ length: 14 }, (_, index) => ({
+function fileItem(index: number): ChatMentionMenuItem {
+  return {
+    kind: "file",
+    file: {
       path: `src/file-${index}.ts`,
       name: `file-${index}.ts`,
       parent: "src",
-    }));
+    },
+  };
+}
 
-    render(
-      <ComposerFileMentionSearch
-        results={results}
-        highlightedIndex={0}
-        listRef={createRef<HTMLDivElement>()}
-        query="file"
-        isLoading={false}
-        isError={false}
-        isPending={false}
-        runtimeReady
-        onSelect={vi.fn()}
-        onRowMouseEnter={vi.fn()}
-        setRowRef={vi.fn()}
-        getRowId={(index) => `file-result-${index}`}
-      />,
-    );
+function docItem(docId: string, filename: string, runLabel: string | null): ChatMentionMenuItem {
+  return {
+    kind: "contextDoc",
+    doc: { docId, runId: "run-a", slug: filename.replace(/\.md$/, ""), filename, runLabel },
+  };
+}
+
+function renderSearch(items: ChatMentionMenuItem[], onSelect = vi.fn()) {
+  return render(
+    <ComposerFileMentionSearch
+      items={items}
+      highlightedIndex={0}
+      listRef={createRef<HTMLDivElement>()}
+      query="file"
+      isLoading={false}
+      isError={false}
+      isPending={false}
+      runtimeReady
+      onSelect={onSelect}
+      onRowMouseEnter={vi.fn()}
+      setRowRef={vi.fn()}
+      getRowId={(index) => `file-result-${index}`}
+    />,
+  );
+}
+
+describe("ComposerFileMentionSearch", () => {
+  it("renders long result sets inside the shared scrolling listbox", () => {
+    renderSearch(Array.from({ length: 14 }, (_, index) => fileItem(index)));
 
     const listbox = screen.getByRole("listbox", { name: "File mentions" });
     expect(screen.getAllByRole("option")).toHaveLength(14);
     expect(listbox.className).toContain("max-h-[min(320px,40dvh)]");
     expect(listbox.className).toContain("overflow-y-auto");
     expect(screen.getByText("file-13.ts")).toBeTruthy();
+  });
+
+  it("renders a file-only list without group headings", () => {
+    const { container } = renderSearch([fileItem(0), fileItem(1)]);
+
+    expect(container.textContent).not.toContain("Context docs");
+    expect(container.textContent).not.toContain("Files");
+  });
+
+  it("groups a mixed list with docs first and headings at each boundary", () => {
+    renderSearch([
+      docItem("doc-1", "01-plan.md", "Release checklist"),
+      docItem("doc-2", "02-findings.md", null),
+      fileItem(0),
+    ]);
+
+    const listbox = screen.getByRole("listbox", { name: "File mentions" });
+    expect(screen.getByText("Context docs")).toBeTruthy();
+    expect(screen.getByText("Files")).toBeTruthy();
+    const rows = screen.getAllByRole("option");
+    expect(rows).toHaveLength(3);
+    // The doc row shows its filename, its run's label, and resolves its
+    // tooltip to the path the mention will send.
+    expect(rows[0]?.textContent).toContain("01-plan.md");
+    expect(rows[0]?.textContent).toContain("Release checklist");
+    expect(rows[0]?.title).toBe(".proliferate/context/01-plan.md");
+    // A run without a definition title falls back to generic copy.
+    expect(rows[1]?.textContent).toContain("Workflow run");
+    // Headings are painted between rows in document order: docs lead.
+    expect(listbox.textContent?.indexOf("Context docs"))
+      .toBeLessThan(listbox.textContent?.indexOf("Files") ?? -1);
+  });
+
+  it("omits the Files heading when only docs match", () => {
+    renderSearch([docItem("doc-1", "01-plan.md", null)]);
+
+    expect(screen.getByText("Context docs")).toBeTruthy();
+    expect(screen.queryByText("Files")).toBeNull();
+  });
+
+  it("keeps the flat highlight index across both groups", () => {
+    const onSelect = vi.fn();
+    renderSearch(
+      [docItem("doc-1", "01-plan.md", null), fileItem(0)],
+      onSelect,
+    );
+
+    const rows = screen.getAllByRole("option");
+    expect(rows[0]?.id).toBe("file-result-0");
+    expect(rows[1]?.id).toBe("file-result-1");
+    rows[1]?.click();
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ kind: "file" }));
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerFileMentionSearch.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerFileMentionSearch.tsx
@@ -1,14 +1,17 @@
-import type { RefObject } from "react";
+import type { ReactNode, RefObject } from "react";
 import {
+  ComposerInlineMenuGroupLabel,
   ComposerInlineMenuPanel,
   ComposerInlineMenuRow,
 } from "#product/components/workspace/chat/input/ComposerInlineMenu";
 import { PickerEmptyRow } from "#product/primitives/patterns/PickerPopoverContent";
+import { FileText } from "#product/primitives/icons/workspace";
 import { FileTreeEntryIcon } from "#product/components/workspace/files/file-icons";
-import type { FileMentionResult } from "#product/lib/domain/chat/composer/file-mention-search";
+import type { ChatMentionMenuItem } from "#product/lib/domain/chat/composer/chat-mention-items";
+import { contextDocMentionWorkspacePath } from "#product/lib/domain/chat/composer/context-doc-mention";
 
 interface ComposerFileMentionSearchProps {
-  results: readonly FileMentionResult[];
+  items: readonly ChatMentionMenuItem[];
   highlightedIndex: number;
   listRef: RefObject<HTMLDivElement | null>;
   query: string;
@@ -16,7 +19,7 @@ interface ComposerFileMentionSearchProps {
   isError: boolean;
   isPending: boolean;
   runtimeReady: boolean;
-  onSelect: (result: FileMentionResult) => void;
+  onSelect: (item: ChatMentionMenuItem) => void;
   onRowMouseEnter: (index: number) => void;
   setRowRef: (index: number, element: HTMLButtonElement | null) => void;
   getRowId: (index: number) => string;
@@ -24,7 +27,7 @@ interface ComposerFileMentionSearchProps {
 }
 
 export function ComposerFileMentionSearch({
-  results,
+  items,
   highlightedIndex,
   listRef,
   query,
@@ -38,33 +41,43 @@ export function ComposerFileMentionSearch({
   getRowId,
   className,
 }: ComposerFileMentionSearchProps) {
+  // Group labels appear only when both sources contribute rows; the common
+  // file-only menu (context-doc source disabled or empty) stays label-free and
+  // renders exactly as it did before docs existed.
+  const docCount = items.filter((item) => item.kind === "contextDoc").length;
+  const grouped = docCount > 0;
   return (
     <ComposerInlineMenuPanel listRef={listRef} label="File mentions" className={className}>
-      {results.length > 0 ? (
-        results.map((result, index) => (
-          <ComposerInlineMenuRow
-            key={result.path}
-            id={getRowId(index)}
-            index={index}
-            selected={index === highlightedIndex}
-            title={result.path}
-            leading={(
-              <FileTreeEntryIcon
-                name={result.name}
-                path={result.path}
-                kind="file"
-                className="icon-paired shrink-0"
-              />
-            )}
-            primary={<span className="font-control">{result.name}</span>}
-            // The directory is the disambiguator between same-named files, so
-            // it takes the remaining width and truncates rather than the name.
-            secondary={result.parent}
-            onSelect={() => onSelect(result)}
-            onRowMouseEnter={onRowMouseEnter}
-            setRowRef={setRowRef}
-          />
-        ))
+      {items.length > 0 ? (
+        items.map((item, index) => {
+          const row = (
+            <ComposerInlineMenuRow
+              key={mentionItemKey(item)}
+              id={getRowId(index)}
+              index={index}
+              selected={index === highlightedIndex}
+              {...mentionRowContent(item)}
+              onSelect={() => onSelect(item)}
+              onRowMouseEnter={onRowMouseEnter}
+              setRowRef={setRowRef}
+            />
+          );
+          if (!grouped) {
+            return row;
+          }
+          // The merged list is docs-first, so the group boundaries are index 0
+          // and the first file index (= docCount).
+          const heading = index === 0
+            ? "Context docs"
+            : index === docCount
+              ? "Files"
+              : null;
+          return heading ? (
+            <MentionGroup key={`group:${mentionItemKey(item)}`} heading={heading}>
+              {row}
+            </MentionGroup>
+          ) : row;
+        })
       ) : (
         <PickerEmptyRow
           label={mentionStatusMessage({ query, isLoading, isError, isPending, runtimeReady })}
@@ -72,6 +85,50 @@ export function ComposerFileMentionSearch({
       )}
     </ComposerInlineMenuPanel>
   );
+}
+
+function MentionGroup({ heading, children }: { heading: string; children: ReactNode }) {
+  return (
+    <>
+      <ComposerInlineMenuGroupLabel>{heading}</ComposerInlineMenuGroupLabel>
+      {children}
+    </>
+  );
+}
+
+function mentionRowContent(item: ChatMentionMenuItem): {
+  title: string;
+  leading: ReactNode;
+  primary: ReactNode;
+  secondary: ReactNode;
+} {
+  if (item.kind === "contextDoc") {
+    return {
+      title: contextDocMentionWorkspacePath(item.doc),
+      leading: <FileText className="icon-paired shrink-0" />,
+      primary: <span className="font-control">{item.doc.filename}</span>,
+      secondary: item.doc.runLabel ?? "Workflow run",
+    };
+  }
+  return {
+    title: item.file.path,
+    leading: (
+      <FileTreeEntryIcon
+        name={item.file.name}
+        path={item.file.path}
+        kind="file"
+        className="icon-paired shrink-0"
+      />
+    ),
+    primary: <span className="font-control">{item.file.name}</span>,
+    // The directory is the disambiguator between same-named files, so it takes
+    // the remaining width and truncates rather than the name.
+    secondary: item.file.parent,
+  };
+}
+
+function mentionItemKey(item: ChatMentionMenuItem): string {
+  return item.kind === "contextDoc" ? `doc:${item.doc.docId}` : `file:${item.file.path}`;
 }
 
 function mentionStatusMessage({

--- a/apps/packages/product-client/src/config/chat.ts
+++ b/apps/packages/product-client/src/config/chat.ts
@@ -19,6 +19,15 @@ export const HOME_CHAT_COMPOSER_INPUT = {
  */
 export const CHAT_FILE_MENTION_SEARCH_LIMIT = 200;
 
+/**
+ * How many of the workspace's workflow runs the `@` mention menu reads context
+ * docs from, newest-first with active runs prioritized. Bounded because each
+ * run costs one projection fetch when the menu opens; four mirrors the ruled
+ * visible-run cap on the workspace's run rails, so the menu and the pane agree
+ * about which runs are "current".
+ */
+export const CHAT_CONTEXT_DOC_MENTION_RUN_LIMIT = 4;
+
 /** File-picker accept list for the composer's attach (+) button, shared by the
  * chat and home composers. Mirrors the upload kinds prompts accept (images and
  * text-like context files). */

--- a/apps/packages/product-client/src/config/feature-flags.ts
+++ b/apps/packages/product-client/src/config/feature-flags.ts
@@ -15,6 +15,14 @@ export interface FeatureFlags {
    * current panes untouched.
    */
   agentAuthEvidencePanes: boolean;
+  /**
+   * Workflows follow-up rung 8: offer the workspace's workflow-run context
+   * docs as a second candidate source in the composer's `@` mention menu. OFF
+   * leaves the menu file-only; the chip node and its serialization stay
+   * registered either way so an existing draft containing a context-doc
+   * mention still round-trips.
+   */
+  chatContextDocMentions: boolean;
 }
 
 function readEnvFlag(value: string | undefined): boolean {
@@ -24,6 +32,9 @@ function readEnvFlag(value: string | undefined): boolean {
 const DEFAULT_FLAGS: FeatureFlags = {
   agentAuthEvidencePanes: readEnvFlag(
     import.meta.env.VITE_AGENT_AUTH_EVIDENCE_PANES,
+  ),
+  chatContextDocMentions: readEnvFlag(
+    import.meta.env.VITE_CHAT_CONTEXT_DOC_MENTIONS,
   ),
 };
 

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-context-doc-mention-source.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-context-doc-mention-source.test.tsx
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resetFeatureFlagOverridesForTests,
+  setFeatureFlagOverrideForTests,
+} from "#product/config/feature-flags";
+import { useChatContextDocMentionSource } from "#product/hooks/chat/ui/use-chat-context-doc-mention-source";
+
+interface MockRun {
+  id: string;
+  status: string;
+}
+
+interface MockProjection {
+  run: { definitionJson: string };
+  docs: Array<{ id: string; runId: string; slug: string; filename: string }>;
+}
+
+const mocks = vi.hoisted(() => ({
+  runs: [] as MockRun[],
+  runsQueryEnabled: null as boolean | null,
+  projectionsById: {} as Record<string, MockProjection>,
+  requestedRunIds: [] as Array<string | null>,
+}));
+
+vi.mock("@anyharness/sdk-react", () => ({
+  useWorkflowRunsQuery: (_workspaceId: string | null, options: { enabled: boolean }) => {
+    mocks.runsQueryEnabled = options.enabled;
+    return {
+      data: options.enabled ? { runs: mocks.runs } : undefined,
+      isLoading: false,
+    };
+  },
+  useWorkflowRunQuery: (runId: string | null, options: { enabled: boolean }) => {
+    mocks.requestedRunIds.push(options.enabled ? runId : null);
+    return {
+      data: options.enabled && runId ? mocks.projectionsById[runId] : undefined,
+      isLoading: false,
+    };
+  },
+}));
+
+vi.mock("#product/hooks/workspaces/derived/files/use-workspace-file-context", () => ({
+  useWorkspaceFileContext: () => ({ materializedWorkspaceId: "workspace-1" }),
+}));
+
+function run(id: string, status = "completed"): MockRun {
+  return { id, status };
+}
+
+function projection(
+  runId: string,
+  title: string | null,
+  filenames: string[],
+): MockProjection {
+  return {
+    run: { definitionJson: JSON.stringify(title === null ? {} : { title }) },
+    docs: filenames.map((filename, index) => ({
+      id: `${runId}-doc-${index}`,
+      runId,
+      slug: filename.replace(/\.md$/, ""),
+      filename,
+    })),
+  };
+}
+
+describe("useChatContextDocMentionSource", () => {
+  beforeEach(() => {
+    setFeatureFlagOverrideForTests("chatContextDocMentions", true);
+    mocks.runs = [];
+    mocks.runsQueryEnabled = null;
+    mocks.projectionsById = {};
+    mocks.requestedRunIds = [];
+  });
+
+  afterEach(() => {
+    cleanup();
+    resetFeatureFlagOverridesForTests();
+    vi.clearAllMocks();
+  });
+
+  it("yields nothing and disables every query while the flag is off", () => {
+    resetFeatureFlagOverridesForTests();
+    mocks.runs = [run("run-a")];
+    mocks.projectionsById["run-a"] = projection("run-a", "Audit", ["01-plan.md"]);
+
+    const { result } = renderHook(() => useChatContextDocMentionSource({
+      open: true,
+      query: "",
+    }));
+
+    expect(result.current.sourceEnabled).toBe(false);
+    expect(result.current.candidates).toEqual([]);
+    expect(mocks.runsQueryEnabled).toBe(false);
+    expect(mocks.requestedRunIds.every((id) => id === null)).toBe(true);
+  });
+
+  it("disables every query while the menu is closed", () => {
+    mocks.runs = [run("run-a")];
+
+    const { result } = renderHook(() => useChatContextDocMentionSource({
+      open: false,
+      query: "",
+    }));
+
+    expect(result.current.candidates).toEqual([]);
+    expect(mocks.runsQueryEnabled).toBe(false);
+  });
+
+  it("labels candidates with the run's definition title and keeps run order", () => {
+    mocks.runs = [run("run-a"), run("run-b")];
+    mocks.projectionsById["run-a"] = projection("run-a", "Release checklist", ["01-plan.md"]);
+    mocks.projectionsById["run-b"] = projection("run-b", null, ["02-findings.md"]);
+
+    const { result } = renderHook(() => useChatContextDocMentionSource({
+      open: true,
+      query: "",
+    }));
+
+    expect(result.current.candidates).toEqual([
+      {
+        docId: "run-a-doc-0",
+        runId: "run-a",
+        slug: "01-plan",
+        filename: "01-plan.md",
+        runLabel: "Release checklist",
+      },
+      {
+        docId: "run-b-doc-0",
+        runId: "run-b",
+        slug: "02-findings",
+        filename: "02-findings.md",
+        runLabel: null,
+      },
+    ]);
+  });
+
+  it("reads docs from at most four runs, active runs first", () => {
+    mocks.runs = [
+      run("run-1", "completed"),
+      run("run-2", "completed"),
+      run("run-3", "running"),
+      run("run-4", "completed"),
+      run("run-5", "awaiting_human"),
+      run("run-6", "completed"),
+    ];
+    for (const { id } of mocks.runs) {
+      mocks.projectionsById[id] = projection(id, null, [`${id}.md`]);
+    }
+
+    const { result } = renderHook(() => useChatContextDocMentionSource({
+      open: true,
+      query: "",
+    }));
+
+    // Active runs (3, 5) lead in list order, then the newest settled (1, 2);
+    // runs 4 and 6 fall past the cap and are never fetched.
+    expect(mocks.requestedRunIds.filter(Boolean)).toEqual([
+      "run-3", "run-5", "run-1", "run-2",
+    ]);
+    expect(result.current.candidates.map((candidate) => candidate.runId)).toEqual([
+      "run-3", "run-5", "run-1", "run-2",
+    ]);
+  });
+
+  it("narrows candidates by the typed query", () => {
+    mocks.runs = [run("run-a")];
+    mocks.projectionsById["run-a"] = projection("run-a", "Audit", [
+      "01-plan.md",
+      "02-findings.md",
+    ]);
+
+    const { result } = renderHook(() => useChatContextDocMentionSource({
+      open: true,
+      query: "find",
+    }));
+
+    expect(result.current.candidates.map((candidate) => candidate.filename))
+      .toEqual(["02-findings.md"]);
+  });
+});

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-context-doc-mention-source.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-context-doc-mention-source.ts
@@ -1,0 +1,112 @@
+import { useMemo } from "react";
+import { useWorkflowRunQuery, useWorkflowRunsQuery } from "@anyharness/sdk-react";
+import type { WorkflowRunProjectionV2, WorkflowRunV2 } from "@anyharness/sdk";
+import { CHAT_CONTEXT_DOC_MENTION_RUN_LIMIT } from "#product/config/chat";
+import { isFeatureEnabled } from "#product/config/feature-flags";
+import { workflowRunDefinitionTitle } from "#product/domain/workflows/main-view-model";
+import { workflowRunIsActive } from "#product/domain/workflows/run-view-model";
+import { useWorkspaceFileContext } from "#product/hooks/workspaces/derived/files/use-workspace-file-context";
+import {
+  filterContextDocMentionCandidates,
+  type ContextDocMentionCandidate,
+} from "#product/lib/domain/chat/composer/context-doc-mention";
+
+interface UseChatContextDocMentionSourceArgs {
+  open: boolean;
+  query: string;
+}
+
+/**
+ * The `@` menu's second candidate source: the context docs registered to the
+ * workspace's workflow runs.
+ *
+ * Docs ride only on the per-run projection, never on the runs list, so this
+ * hook reads the list and then a bounded number of projections — the
+ * `CHAT_CONTEXT_DOC_MENTION_RUN_LIMIT` newest runs, active runs first (the
+ * same ordering the run rails use). The bound is what lets the projections be
+ * a fixed set of hook calls, and every query is gated on the menu actually
+ * being open, so an unopened composer costs nothing.
+ *
+ * Feature-flagged (`chatContextDocMentions`): OFF disables every query and
+ * yields no candidates, leaving the mention menu file-only.
+ */
+export function useChatContextDocMentionSource({
+  open,
+  query,
+}: UseChatContextDocMentionSourceArgs) {
+  const sourceEnabled = isFeatureEnabled("chatContextDocMentions");
+  const { materializedWorkspaceId } = useWorkspaceFileContext();
+  const queriesEnabled = sourceEnabled && open && materializedWorkspaceId !== null;
+
+  const runsQuery = useWorkflowRunsQuery(materializedWorkspaceId, {
+    enabled: queriesEnabled,
+  });
+  const runs = runsQuery.data?.runs;
+
+  const sourcedRuns = useMemo(
+    () => selectMentionSourceRuns(runs ?? []),
+    [runs],
+  );
+
+  // A fixed set of projection reads, not a loop: the run cap is a constant, so
+  // the hook call count stays constant. Slots beyond the available runs hold
+  // a null id and stay disabled.
+  const projectionQueries = [
+    useWorkflowRunQuery(sourcedRuns[0]?.id ?? null, { enabled: queriesEnabled }),
+    useWorkflowRunQuery(sourcedRuns[1]?.id ?? null, { enabled: queriesEnabled }),
+    useWorkflowRunQuery(sourcedRuns[2]?.id ?? null, { enabled: queriesEnabled }),
+    useWorkflowRunQuery(sourcedRuns[3]?.id ?? null, { enabled: queriesEnabled }),
+  ] as const;
+  const [firstRun, secondRun, thirdRun, fourthRun] = projectionQueries.map(
+    (projectionQuery) => projectionQuery.data,
+  );
+
+  const candidates = useMemo(() => {
+    if (!queriesEnabled) {
+      return [];
+    }
+    const collected: ContextDocMentionCandidate[] = [];
+    for (const projection of [firstRun, secondRun, thirdRun, fourthRun]) {
+      if (projection) {
+        collected.push(...projectionCandidates(projection));
+      }
+    }
+    return filterContextDocMentionCandidates(collected, query);
+  }, [queriesEnabled, query, firstRun, secondRun, thirdRun, fourthRun]);
+
+  return {
+    candidates,
+    sourceEnabled,
+    isLoading: queriesEnabled
+      && (runsQuery.isLoading || projectionQueries.some(
+        (projectionQuery) => projectionQuery.isLoading,
+      )),
+  };
+}
+
+/**
+ * Which runs the menu reads docs from: active runs first, then newest-first —
+ * the list route already returns `created_at DESC`, so a stable partition by
+ * activity preserves recency inside each half.
+ */
+function selectMentionSourceRuns(runs: readonly WorkflowRunV2[]): WorkflowRunV2[] {
+  const active: WorkflowRunV2[] = [];
+  const settled: WorkflowRunV2[] = [];
+  for (const run of runs) {
+    (workflowRunIsActive(run) ? active : settled).push(run);
+  }
+  return [...active, ...settled].slice(0, CHAT_CONTEXT_DOC_MENTION_RUN_LIMIT);
+}
+
+function projectionCandidates(
+  projection: WorkflowRunProjectionV2,
+): ContextDocMentionCandidate[] {
+  const runLabel = workflowRunDefinitionTitle(projection.run.definitionJson);
+  return projection.docs.map((doc) => ({
+    docId: doc.id,
+    runId: doc.runId,
+    slug: doc.slug,
+    filename: doc.filename,
+    runLabel,
+  }));
+}

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-file-mention-menu.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-file-mention-menu.test.tsx
@@ -4,12 +4,14 @@ import { cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CHAT_FILE_MENTION_SEARCH_LIMIT } from "#product/config/chat";
 import { useChatFileMentionMenu } from "#product/hooks/chat/ui/use-chat-file-mention-menu";
+import type { ContextDocMentionCandidate } from "#product/lib/domain/chat/composer/context-doc-mention";
 
 const mocks = vi.hoisted(() => ({
   searchArgs: null as Record<string, unknown> | null,
   searchDebouncedQuery: "cmp",
   searchIsPlaceholderData: false,
   searchResults: [] as Array<{ path: string; name: string }>,
+  contextDocCandidates: [] as ContextDocMentionCandidate[],
 }));
 
 vi.mock("#product/hooks/workspaces/derived/files/use-workspace-file-context", () => ({
@@ -18,6 +20,14 @@ vi.mock("#product/hooks/workspaces/derived/files/use-workspace-file-context", ()
 
 vi.mock("#product/hooks/workspaces/facade/use-selected-cloud-runtime-state", () => ({
   useSelectedCloudRuntimeState: () => ({ state: null }),
+}));
+
+vi.mock("#product/hooks/chat/ui/use-chat-context-doc-mention-source", () => ({
+  useChatContextDocMentionSource: () => ({
+    candidates: mocks.contextDocCandidates,
+    sourceEnabled: mocks.contextDocCandidates.length > 0,
+    isLoading: false,
+  }),
 }));
 
 vi.mock("#product/hooks/workspaces/ui/files/use-workspace-file-search", () => ({
@@ -35,11 +45,16 @@ vi.mock("#product/hooks/workspaces/ui/files/use-workspace-file-search", () => ({
   },
 }));
 
+function docCandidate(docId: string, filename: string): ContextDocMentionCandidate {
+  return { docId, runId: "run-a", slug: filename.replace(/\.md$/, ""), filename, runLabel: null };
+}
+
 describe("useChatFileMentionMenu", () => {
   beforeEach(() => {
     mocks.searchArgs = null;
     mocks.searchDebouncedQuery = "cmp";
     mocks.searchIsPlaceholderData = false;
+    mocks.contextDocCandidates = [];
     mocks.searchResults = Array.from({ length: 200 }, (_, index) => ({
       path: `src/composer-${index}.ts`,
       name: `composer-${index}.ts`,
@@ -64,9 +79,15 @@ describe("useChatFileMentionMenu", () => {
       workspaceId: "workspace-1",
     });
     expect(CHAT_FILE_MENTION_SEARCH_LIMIT).toBe(200);
-    expect(result.current.results).toHaveLength(200);
-    expect(result.current.results[8]?.path).toBe("src/composer-8.ts");
-    expect(result.current.results[199]?.path).toBe("src/composer-199.ts");
+    expect(result.current.items).toHaveLength(200);
+    expect(result.current.items[8]).toMatchObject({
+      kind: "file",
+      file: { path: "src/composer-8.ts" },
+    });
+    expect(result.current.items[199]).toMatchObject({
+      kind: "file",
+      file: { path: "src/composer-199.ts" },
+    });
   });
 
   it("keeps prior-query placeholder rows out of the selectable menu", () => {
@@ -78,7 +99,7 @@ describe("useChatFileMentionMenu", () => {
       onSelect: vi.fn(),
     }));
 
-    expect(result.current.results).toEqual([]);
+    expect(result.current.items).toEqual([]);
     expect(result.current.isPending).toBe(true);
   });
 
@@ -91,7 +112,45 @@ describe("useChatFileMentionMenu", () => {
       onSelect: vi.fn(),
     }));
 
-    expect(result.current.results).toEqual([]);
+    expect(result.current.items).toEqual([]);
     expect(result.current.isPending).toBe(true);
+  });
+
+  it("leads the merged list with context docs and selects across the flat index", () => {
+    mocks.contextDocCandidates = [
+      docCandidate("doc-1", "01-plan.md"),
+      docCandidate("doc-2", "02-findings.md"),
+    ];
+    mocks.searchResults = [{ path: "src/plan.ts", name: "plan.ts" }];
+    const onSelect = vi.fn();
+
+    const { result } = renderHook(() => useChatFileMentionMenu({
+      open: true,
+      query: "cmp",
+      onSelect,
+    }));
+
+    expect(result.current.items.map((item) => item.kind))
+      .toEqual(["contextDoc", "contextDoc", "file"]);
+    result.current.selectHighlighted();
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({
+      kind: "contextDoc",
+      doc: expect.objectContaining({ docId: "doc-1" }),
+    }));
+  });
+
+  it("still offers doc rows while file results wait on the debounce", () => {
+    mocks.searchDebouncedQuery = "old-query";
+    mocks.contextDocCandidates = [
+      docCandidate("doc-1", "01-plan.md"),
+    ];
+
+    const { result } = renderHook(() => useChatFileMentionMenu({
+      open: true,
+      query: "cmp",
+      onSelect: vi.fn(),
+    }));
+
+    expect(result.current.items.map((item) => item.kind)).toEqual(["contextDoc"]);
   });
 });

--- a/apps/packages/product-client/src/hooks/chat/ui/use-chat-file-mention-menu.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-chat-file-mention-menu.ts
@@ -1,27 +1,32 @@
 import { useCallback, useMemo } from "react";
 import { CHAT_FILE_MENTION_SEARCH_LIMIT } from "#product/config/chat";
+import { useChatContextDocMentionSource } from "#product/hooks/chat/ui/use-chat-context-doc-mention-source";
 import { useComposerMenuNavigation } from "#product/hooks/chat/ui/use-composer-menu-navigation";
 import { useSelectedCloudRuntimeState } from "#product/hooks/workspaces/facade/use-selected-cloud-runtime-state";
 import { useWorkspaceFileContext } from "#product/hooks/workspaces/derived/files/use-workspace-file-context";
 import { useWorkspaceFileSearch } from "#product/hooks/workspaces/ui/files/use-workspace-file-search";
 import { parseCloudWorkspaceSyntheticId } from "#product/lib/domain/workspaces/cloud/cloud-ids";
 import {
-  rankFileMentionResults,
-  type FileMentionResult,
-} from "#product/lib/domain/chat/composer/file-mention-search";
+  mergeChatMentionMenuItems,
+  type ChatMentionMenuItem,
+} from "#product/lib/domain/chat/composer/chat-mention-items";
+import { rankFileMentionResults } from "#product/lib/domain/chat/composer/file-mention-search";
 
 interface UseChatFileMentionMenuArgs {
   open: boolean;
   query: string;
-  onSelect: (result: FileMentionResult) => void;
+  onSelect: (item: ChatMentionMenuItem) => void;
 }
 
 /**
- * Workspace file search for the composer's `@` menu.
+ * The composer's `@` mention menu: workspace file search merged with the
+ * workspace's workflow-run context docs.
  *
- * Reuses the same debounced search path as the command palette
+ * File search reuses the same debounced path as the command palette
  * (`useWorkspaceFileSearch` → the runtime's file-search query), so mentions and
- * the palette can never disagree about which files exist.
+ * the palette can never disagree about which files exist. The context-doc
+ * source (`useChatContextDocMentionSource`) is feature-flagged and yields
+ * nothing while the flag is off, leaving the menu file-only.
  */
 export function useChatFileMentionMenu({
   open,
@@ -46,34 +51,46 @@ export function useChatFileMentionMenu({
   const resultsAreCurrent = search.debouncedQuery === search.query
     && !search.isPlaceholderData;
 
-  const results = useMemo(() => (
-    open && resultsAreCurrent
+  const contextDocs = useChatContextDocMentionSource({ open, query });
+
+  const items = useMemo(() => {
+    if (!open) {
+      return [];
+    }
+    const fileResults = resultsAreCurrent
       ? rankFileMentionResults(
           search.results,
           search.debouncedQuery,
           CHAT_FILE_MENTION_SEARCH_LIMIT,
         )
-      : []
-  ), [open, resultsAreCurrent, search.debouncedQuery, search.results]);
+      : [];
+    return mergeChatMentionMenuItems(contextDocs.candidates, fileResults);
+  }, [
+    contextDocs.candidates,
+    open,
+    resultsAreCurrent,
+    search.debouncedQuery,
+    search.results,
+  ]);
 
   const navigation = useComposerMenuNavigation({
     open,
     query,
-    itemCount: results.length,
+    itemCount: items.length,
   });
 
   const selectHighlighted = useCallback(() => {
-    const result = results[navigation.highlightedIndex];
-    if (result) {
-      onSelect(result);
+    const item = items[navigation.highlightedIndex];
+    if (item) {
+      onSelect(item);
     }
-  }, [navigation.highlightedIndex, onSelect, results]);
+  }, [items, navigation.highlightedIndex, onSelect]);
 
   return {
-    results,
+    items,
     isLoading: search.isLoading,
     isError: search.isError,
-    /** True while the current token is waiting for its own result page. */
+    /** True while the current token is waiting for its own file-result page. */
     isPending: open && search.query.length > 0 && (!search.searchEnabled || !resultsAreCurrent),
     runtimeReady,
     highlightedIndex: navigation.highlightedIndex,

--- a/apps/packages/product-client/src/hooks/chat/workflows/use-chat-launch-actions.ts
+++ b/apps/packages/product-client/src/hooks/chat/workflows/use-chat-launch-actions.ts
@@ -25,10 +25,8 @@ import { useUserPreferencesStore } from "#product/stores/preferences/user-prefer
 import { useActiveSessionLaunchState } from "#product/hooks/chat/derived/use-active-session-config-state";
 import { useConfiguredLaunchReadiness } from "#product/hooks/chat/derived/use-configured-launch-readiness";
 import { resolveAvailableLaunchSelection } from "#product/lib/domain/chat/models/launch-selection-defaults";
-import {
-  EMPTY_CHAT_DRAFT,
-  serializeChatDraftToOutgoingPrompt,
-} from "#product/lib/domain/chat/composer/file-mention-draft-model";
+import { EMPTY_CHAT_DRAFT } from "#product/lib/domain/chat/composer/file-mention-draft-model";
+import { serializeChatDraftToOutgoingPrompt } from "#product/lib/domain/chat/composer/outgoing-prompt";
 import { resolveWorkspaceUiKey } from "#product/lib/domain/workspaces/selection/workspace-ui-key";
 import {
   failLatencyFlow,

--- a/apps/packages/product-client/src/hooks/chat/workflows/use-chat-launch-actions.ts
+++ b/apps/packages/product-client/src/hooks/chat/workflows/use-chat-launch-actions.ts
@@ -27,7 +27,7 @@ import { useConfiguredLaunchReadiness } from "#product/hooks/chat/derived/use-co
 import { resolveAvailableLaunchSelection } from "#product/lib/domain/chat/models/launch-selection-defaults";
 import {
   EMPTY_CHAT_DRAFT,
-  serializeChatDraftToPrompt,
+  serializeChatDraftToOutgoingPrompt,
 } from "#product/lib/domain/chat/composer/file-mention-draft-model";
 import { resolveWorkspaceUiKey } from "#product/lib/domain/workspaces/selection/workspace-ui-key";
 import {
@@ -57,7 +57,7 @@ export function useChatLaunchActions(options?: {
   // ChatInput, ~20 hooks) on EVERY keystroke — the draft is only needed when
   // the user actually picks a launch option.
   const getCurrentDraftText = useCallback((): string => {
-    return serializeChatDraftToPrompt(
+    return serializeChatDraftToOutgoingPrompt(
       workspaceUiKey
         ? useChatInputStore.getState().draftByWorkspaceId[workspaceUiKey] ?? EMPTY_CHAT_DRAFT
         : EMPTY_CHAT_DRAFT,

--- a/apps/packages/product-client/src/hooks/chat/workflows/use-chat-prompt-actions.ts
+++ b/apps/packages/product-client/src/hooks/chat/workflows/use-chat-prompt-actions.ts
@@ -21,7 +21,7 @@ import { useConfiguredLaunchReadiness } from "#product/hooks/chat/derived/use-co
 import { resolveAvailableLaunchSelection } from "#product/lib/domain/chat/models/launch-selection-defaults";
 import {
   EMPTY_CHAT_DRAFT,
-  serializeChatDraftToPrompt,
+  serializeChatDraftToOutgoingPrompt,
 } from "#product/lib/domain/chat/composer/file-mention-draft-model";
 import {
   createEmptySessionRecord,
@@ -140,7 +140,7 @@ export function useChatPromptActions(options?: { forceNewSession?: boolean }) {
     const currentDraft = draftKey
       ? useChatInputStore.getState().draftByWorkspaceId[draftKey] ?? EMPTY_CHAT_DRAFT
       : EMPTY_CHAT_DRAFT;
-    const text = input?.text.trim() ?? serializeChatDraftToPrompt(currentDraft).trim();
+    const text = input?.text.trim() ?? serializeChatDraftToOutgoingPrompt(currentDraft).trim();
     const blocks = input?.blocks ?? [{ type: "text" as const, text }];
     const attachmentSnapshots = input?.attachmentSnapshots ?? [];
     const preserveDraft = input?.preserveDraft ?? false;

--- a/apps/packages/product-client/src/hooks/chat/workflows/use-chat-prompt-actions.ts
+++ b/apps/packages/product-client/src/hooks/chat/workflows/use-chat-prompt-actions.ts
@@ -19,10 +19,8 @@ import { useActiveSessionSurfaceSnapshot } from "#product/hooks/chat/derived/use
 import { useChatAvailabilityState } from "#product/hooks/chat/derived/use-chat-availability-state";
 import { useConfiguredLaunchReadiness } from "#product/hooks/chat/derived/use-configured-launch-readiness";
 import { resolveAvailableLaunchSelection } from "#product/lib/domain/chat/models/launch-selection-defaults";
-import {
-  EMPTY_CHAT_DRAFT,
-  serializeChatDraftToOutgoingPrompt,
-} from "#product/lib/domain/chat/composer/file-mention-draft-model";
+import { EMPTY_CHAT_DRAFT } from "#product/lib/domain/chat/composer/file-mention-draft-model";
+import { serializeChatDraftToOutgoingPrompt } from "#product/lib/domain/chat/composer/outgoing-prompt";
 import {
   createEmptySessionRecord,
   putSessionRecord,

--- a/apps/packages/product-client/src/lib/domain/chat/composer/chat-mention-items.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/composer/chat-mention-items.ts
@@ -1,0 +1,29 @@
+import type { ContextDocMentionCandidate } from "#product/lib/domain/chat/composer/context-doc-mention";
+import type { FileMentionResult } from "#product/lib/domain/chat/composer/file-mention-search";
+
+/**
+ * One row of the composer's `@` mention menu, kind-tagged so the menu can
+ * group the sources and the editor can insert the matching chip node.
+ */
+export type ChatMentionMenuItem =
+  | { kind: "file"; file: FileMentionResult }
+  | { kind: "contextDoc"; doc: ContextDocMentionCandidate };
+
+/**
+ * Merges the two candidate sources into one navigable list: context docs
+ * first, then files.
+ *
+ * Docs lead because their set is small, bounded, and — unlike file search,
+ * which needs a query before it returns anything — already answerable on a
+ * bare `@`, so the menu has useful rows the moment it opens. With the doc
+ * source disabled or empty the list is exactly the file list.
+ */
+export function mergeChatMentionMenuItems(
+  contextDocs: readonly ContextDocMentionCandidate[],
+  files: readonly FileMentionResult[],
+): ChatMentionMenuItem[] {
+  return [
+    ...contextDocs.map((doc): ChatMentionMenuItem => ({ kind: "contextDoc", doc })),
+    ...files.map((file): ChatMentionMenuItem => ({ kind: "file", file })),
+  ];
+}

--- a/apps/packages/product-client/src/lib/domain/chat/composer/context-doc-mention.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/composer/context-doc-mention.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import {
+  contextDocMentionWorkspacePath,
+  filterContextDocMentionCandidates,
+  formatContextDocMentionToken,
+  isValidContextDocMentionRef,
+  parseContextDocMentionDestination,
+  resolveContextDocMentionTokens,
+  type ContextDocMentionCandidate,
+} from "#product/lib/domain/chat/composer/context-doc-mention";
+
+const REF = { runId: "run-01j8", filename: "01-plan.md" };
+
+function candidate(overrides: Partial<ContextDocMentionCandidate> = {}): ContextDocMentionCandidate {
+  return {
+    docId: "doc-1",
+    runId: "run-01j8",
+    slug: "plan",
+    filename: "01-plan.md",
+    runLabel: "Release checklist",
+    ...overrides,
+  };
+}
+
+describe("formatContextDocMentionToken", () => {
+  it("serializes to the @doc token with both ref halves in the destination", () => {
+    expect(formatContextDocMentionToken("01-plan.md", REF))
+      .toBe("[01-plan.md](@doc:run-01j8/01-plan.md)");
+  });
+
+  it("escapes markdown-significant characters in the label", () => {
+    expect(formatContextDocMentionToken("[plan]", REF))
+      .toBe("[\\[plan\\]](@doc:run-01j8/01-plan.md)");
+  });
+
+  it("falls back to a plain escaped label when the ref cannot serialize", () => {
+    expect(formatContextDocMentionToken("plan", { runId: "run/../etc", filename: "01-plan.md" }))
+      .toBe("plan");
+  });
+});
+
+describe("parseContextDocMentionDestination", () => {
+  it("round-trips a formatted destination back to its ref", () => {
+    expect(parseContextDocMentionDestination("@doc:run-01j8/01-plan.md")).toEqual(REF);
+  });
+
+  it("splits on the first separator so filenames keep any later slash rejected", () => {
+    // A second slash lands in the filename half, which the segment rule rejects.
+    expect(parseContextDocMentionDestination("@doc:run-01j8/a/b.md")).toBeNull();
+  });
+
+  it.each([
+    ["missing prefix", "run-01j8/01-plan.md"],
+    ["no separator", "@doc:run-01j8"],
+    ["empty run id", "@doc:/01-plan.md"],
+    ["empty filename", "@doc:run-01j8/"],
+    ["traversal run id", "@doc:../01-plan.md"],
+    ["traversal filename", "@doc:run-01j8/.."],
+    ["whitespace in filename", "@doc:run-01j8/01 plan.md"],
+    ["backslash in filename", "@doc:run-01j8/01\\plan.md"],
+    ["control character", "@doc:run-01j8/01\u0007plan.md"],
+    ["bracket in filename", "@doc:run-01j8/01[a].md"],
+  ])("rejects %s", (_reason, destination) => {
+    expect(parseContextDocMentionDestination(destination)).toBeNull();
+  });
+});
+
+describe("isValidContextDocMentionRef", () => {
+  it("accepts real run ids and filenames with hyphens and dots", () => {
+    expect(isValidContextDocMentionRef(REF)).toBe(true);
+  });
+
+  it("rejects dot and dot-dot segments", () => {
+    expect(isValidContextDocMentionRef({ runId: ".", filename: "a.md" })).toBe(false);
+    expect(isValidContextDocMentionRef({ runId: "run-1", filename: ".." })).toBe(false);
+  });
+});
+
+describe("resolveContextDocMentionTokens", () => {
+  it("rewrites a token to a workspace-relative context-dir file link", () => {
+    expect(resolveContextDocMentionTokens("Read [01-plan.md](@doc:run-01j8/01-plan.md) first"))
+      .toBe("Read [01-plan.md](.proliferate/context/01-plan.md) first");
+    expect(contextDocMentionWorkspacePath(REF)).toBe(".proliferate/context/01-plan.md");
+  });
+
+  it("resolves every token and leaves file links and web links untouched", () => {
+    const prompt = "Compare [01-plan.md](@doc:run-a/01-plan.md) with "
+      + "[setup.md](docs/setup.md) and [Docs](https://example.com) then "
+      + "[notes.md](@doc:run-b/notes.md)";
+    expect(resolveContextDocMentionTokens(prompt)).toBe(
+      "Compare [01-plan.md](.proliferate/context/01-plan.md) with "
+      + "[setup.md](docs/setup.md) and [Docs](https://example.com) then "
+      + "[notes.md](.proliferate/context/notes.md)",
+    );
+  });
+
+  it("leaves a token with an unparseable destination untouched", () => {
+    const prose = "See [plan](@doc:no-separator) here";
+    expect(resolveContextDocMentionTokens(prose)).toBe(prose);
+  });
+
+  it("keeps a label that differs from the filename", () => {
+    expect(resolveContextDocMentionTokens("[the plan](@doc:run-01j8/01-plan.md)"))
+      .toBe("[the plan](.proliferate/context/01-plan.md)");
+  });
+});
+
+describe("filterContextDocMentionCandidates", () => {
+  it("returns all valid candidates in given order for an empty query", () => {
+    const docs = [
+      candidate({ docId: "doc-1", filename: "01-plan.md" }),
+      candidate({ docId: "doc-2", filename: "02-findings.md" }),
+    ];
+    expect(filterContextDocMentionCandidates(docs, "")).toEqual(docs);
+  });
+
+  it("matches on filename, slug, and run label case-insensitively", () => {
+    const docs = [
+      candidate({ docId: "doc-1", filename: "01-plan.md", slug: "plan", runLabel: "Release" }),
+      candidate({ docId: "doc-2", filename: "02-findings.md", slug: "findings", runLabel: "Audit" }),
+    ];
+    expect(filterContextDocMentionCandidates(docs, "FIND").map((doc) => doc.docId))
+      .toEqual(["doc-2"]);
+    expect(filterContextDocMentionCandidates(docs, "release").map((doc) => doc.docId))
+      .toEqual(["doc-1"]);
+  });
+
+  it("drops duplicate doc ids and candidates whose ref cannot serialize", () => {
+    const docs = [
+      candidate({ docId: "doc-1" }),
+      candidate({ docId: "doc-1", filename: "duplicate.md" }),
+      candidate({ docId: "doc-2", filename: "has space.md" }),
+    ];
+    expect(filterContextDocMentionCandidates(docs, "")).toEqual([docs[0]]);
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/chat/composer/context-doc-mention.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/composer/context-doc-mention.ts
@@ -1,0 +1,179 @@
+import { formatMarkdownFileLink } from "#product/lib/domain/chat/composer/file-mention-links";
+
+/**
+ * The identity a context-doc mention carries: which run's doc registry the doc
+ * belongs to, and the doc's on-disk filename inside the run workspace's context
+ * directory. Both halves ride in the serialized token so the mention stays
+ * resolvable after the on-disk layout becomes run-scoped.
+ */
+export interface ContextDocMentionRef {
+  runId: string;
+  filename: string;
+}
+
+/**
+ * One row the mention menu can offer from the workspace's workflow runs' doc
+ * registries. `runLabel` is the run's definition title when the frozen
+ * invocation JSON carries one; the menu owns the fallback copy.
+ */
+export interface ContextDocMentionCandidate {
+  docId: string;
+  runId: string;
+  slug: string;
+  filename: string;
+  runLabel: string | null;
+}
+
+/**
+ * The serialized form of a context-doc mention is a markdown-link-shaped token
+ * whose destination wears this prefix: `[label](@doc:<runId>/<filename>)`.
+ *
+ * The prefix is what keeps the two mention serializations disjoint in both
+ * directions. A file mention's destination can never contain a colon (the file
+ * transformer's body excludes `:` to reject URL schemes), so a file link can
+ * never parse as a context-doc token; and this token's destination must open
+ * with the literal prefix, so no workspace path or web URL can parse as one.
+ */
+export const CONTEXT_DOC_DESTINATION_PREFIX = "@doc:";
+
+/**
+ * Matches `[label](@doc:<destination>)`. Shared by the Lexical transformer
+ * (chip round-trip while editing) and the send-time resolver below.
+ */
+export const CONTEXT_DOC_MENTION_LINK_BODY =
+  "\\[([^\\[\\]]+)\\]\\(@doc:([^()\\s]+)\\)";
+
+/**
+ * One path segment: no separators, no traversal, no whitespace, parens, or
+ * control characters. Square brackets are also out: the token's label
+ * pattern cannot represent them (the same limitation the file-link body
+ * carries), so a bracket-bearing segment would serialize to a token that
+ * never re-parses.
+ */
+function isValidSegment(value: string): boolean {
+  return (
+    value.length > 0
+    && value !== "."
+    && value !== ".."
+    && !/[/\\\s()[\]\u0000-\u001f\u007f]/u.test(value)
+  );
+}
+
+export function isValidContextDocMentionRef(ref: ContextDocMentionRef): boolean {
+  return isValidSegment(ref.runId) && isValidSegment(ref.filename);
+}
+
+/** Serializes a mention to its draft token, `[label](@doc:<runId>/<filename>)`. */
+export function formatContextDocMentionToken(
+  label: string,
+  ref: ContextDocMentionRef,
+): string {
+  if (!isValidContextDocMentionRef(ref)) {
+    return escapeMarkdownLabel(label || ref.filename);
+  }
+  const escapedLabel = escapeMarkdownLabel(label || ref.filename);
+  return `[${escapedLabel}](${CONTEXT_DOC_DESTINATION_PREFIX}${ref.runId}/${ref.filename})`;
+}
+
+/** Parses a token destination (`@doc:<runId>/<filename>`) back to its ref. */
+export function parseContextDocMentionDestination(
+  destination: string,
+): ContextDocMentionRef | null {
+  if (!destination.startsWith(CONTEXT_DOC_DESTINATION_PREFIX)) {
+    return null;
+  }
+  const body = destination.slice(CONTEXT_DOC_DESTINATION_PREFIX.length);
+  const separator = body.indexOf("/");
+  if (separator === -1) {
+    return null;
+  }
+  const ref: ContextDocMentionRef = {
+    runId: body.slice(0, separator),
+    filename: body.slice(separator + 1),
+  };
+  return isValidContextDocMentionRef(ref) ? ref : null;
+}
+
+/**
+ * Where the mentioned doc lives on disk, workspace-relative.
+ *
+ * This is the single resolution seam for chat-side context-doc mentions. Today
+ * the runtime materializes every run's docs into the flat
+ * `.proliferate/context/` directory; when the run-scoped layout
+ * (`.proliferate/context/<runId>/`) ships, this function — and only this
+ * function — folds `ref.runId` into the path. The token already carries the
+ * run id for exactly that reason.
+ */
+export function contextDocMentionWorkspacePath(ref: ContextDocMentionRef): string {
+  return `.proliferate/context/${ref.filename}`;
+}
+
+const CONTEXT_DOC_TOKEN_PATTERN = new RegExp(CONTEXT_DOC_MENTION_LINK_BODY, "g");
+
+/**
+ * Send-time resolution: rewrites every context-doc token in an outgoing prompt
+ * to an ordinary workspace-relative markdown file link, the same pointer shape
+ * a file mention sends. The agent dereferences the path with its own read
+ * tools; nothing is inlined. Tokens whose destination does not parse are left
+ * untouched — they are prose, not mentions.
+ */
+export function resolveContextDocMentionTokens(text: string): string {
+  return text.replace(CONTEXT_DOC_TOKEN_PATTERN, (token, label: string, destination: string) => {
+    const ref = parseContextDocMentionDestination(
+      `${CONTEXT_DOC_DESTINATION_PREFIX}${destination}`,
+    );
+    if (!ref) {
+      return token;
+    }
+    return formatMarkdownFileLink(
+      unescapeMarkdown(label),
+      contextDocMentionWorkspacePath(ref),
+    );
+  });
+}
+
+/**
+ * Filters the doc-registry candidates against the typed mention query.
+ *
+ * Candidates arrive newest-run-first from the source hook and stay in that
+ * order; the query narrows rather than re-ranks, because the set is small and
+ * bounded (unlike file search, which ranks a 200-row fuzzy page).
+ */
+export function filterContextDocMentionCandidates(
+  candidates: readonly ContextDocMentionCandidate[],
+  query: string,
+): ContextDocMentionCandidate[] {
+  const needle = query.trim().toLowerCase();
+  const seen = new Set<string>();
+  const filtered: ContextDocMentionCandidate[] = [];
+  for (const candidate of candidates) {
+    if (seen.has(candidate.docId)) {
+      continue;
+    }
+    if (!isValidContextDocMentionRef(candidate)) {
+      continue;
+    }
+    if (needle.length > 0 && !candidateMatches(candidate, needle)) {
+      continue;
+    }
+    seen.add(candidate.docId);
+    filtered.push(candidate);
+  }
+  return filtered;
+}
+
+function candidateMatches(candidate: ContextDocMentionCandidate, needle: string): boolean {
+  return (
+    candidate.filename.toLowerCase().includes(needle)
+    || candidate.slug.toLowerCase().includes(needle)
+    || (candidate.runLabel?.toLowerCase().includes(needle) ?? false)
+  );
+}
+
+function escapeMarkdownLabel(value: string): string {
+  return value.replace(/([\\[\]])/g, "\\$1");
+}
+
+function unescapeMarkdown(value: string): string {
+  return value.replace(/\\(.)/g, "$1");
+}

--- a/apps/packages/product-client/src/lib/domain/chat/composer/file-mention-draft-model.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/composer/file-mention-draft-model.ts
@@ -4,6 +4,7 @@ import {
   normalizeWorkspaceRelativePath,
   workspaceFileBasename,
 } from "#product/lib/domain/chat/composer/file-mention-links";
+import { resolveContextDocMentionTokens } from "#product/lib/domain/chat/composer/context-doc-mention";
 
 export interface ChatComposerDraft {
   nodes: ChatComposerDraftNode[];
@@ -143,6 +144,17 @@ export function serializeChatDraftToPrompt(draft: ChatComposerDraft): string {
     }
     return formatMarkdownFileLink(node.name || workspaceFileBasename(node.path), node.path);
   }).join("");
+}
+
+/**
+ * The prompt actually sent to the agent. `serializeChatDraftToPrompt` is the
+ * draft's own markdown and keeps context-doc mention tokens intact so the
+ * editor round-trips them back into chips; the outgoing form is where those
+ * tokens resolve to the concrete workspace path the agent can read. Send
+ * sites call this, everything that feeds text back into the editor must not.
+ */
+export function serializeChatDraftToOutgoingPrompt(draft: ChatComposerDraft): string {
+  return resolveContextDocMentionTokens(serializeChatDraftToPrompt(draft));
 }
 
 export function cloneChatDraftNode(node: ChatComposerDraftNode): ChatComposerDraftNode {

--- a/apps/packages/product-client/src/lib/domain/chat/composer/file-mention-draft-model.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/composer/file-mention-draft-model.ts
@@ -4,7 +4,6 @@ import {
   normalizeWorkspaceRelativePath,
   workspaceFileBasename,
 } from "#product/lib/domain/chat/composer/file-mention-links";
-import { resolveContextDocMentionTokens } from "#product/lib/domain/chat/composer/context-doc-mention";
 
 export interface ChatComposerDraft {
   nodes: ChatComposerDraftNode[];
@@ -145,18 +144,6 @@ export function serializeChatDraftToPrompt(draft: ChatComposerDraft): string {
     return formatMarkdownFileLink(node.name || workspaceFileBasename(node.path), node.path);
   }).join("");
 }
-
-/**
- * The prompt actually sent to the agent. `serializeChatDraftToPrompt` is the
- * draft's own markdown and keeps context-doc mention tokens intact so the
- * editor round-trips them back into chips; the outgoing form is where those
- * tokens resolve to the concrete workspace path the agent can read. Send
- * sites call this, everything that feeds text back into the editor must not.
- */
-export function serializeChatDraftToOutgoingPrompt(draft: ChatComposerDraft): string {
-  return resolveContextDocMentionTokens(serializeChatDraftToPrompt(draft));
-}
-
 export function cloneChatDraftNode(node: ChatComposerDraftNode): ChatComposerDraftNode {
   return node.type === "text"
     ? { type: "text", text: node.text }

--- a/apps/packages/product-client/src/lib/domain/chat/composer/file-mention-draft.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/composer/file-mention-draft.test.ts
@@ -10,7 +10,6 @@ import {
   createFileMentionNode,
   createTextDraft,
   isChatDraftEmpty,
-  serializeChatDraftToOutgoingPrompt,
   serializeChatDraftToPrompt,
   type ChatComposerDraft,
 } from "#product/lib/domain/chat/composer/file-mention-draft-model";
@@ -174,17 +173,5 @@ describe("chat file mentions", () => {
   it("treats whitespace-only drafts as empty and mentions as content", () => {
     expect(isChatDraftEmpty(createTextDraft(" \n\t"))).toBe(true);
     expect(isChatDraftEmpty({ nodes: [mention("a")] })).toBe(false);
-  });
-
-  it("resolves context-doc tokens only in the outgoing prompt", () => {
-    const draft = createTextDraft(
-      "Read [01-plan.md](@doc:run-01j8/01-plan.md) and [setup.md](docs/setup.md)",
-    );
-    // The draft's own markdown keeps the token so the editor round-trips it
-    // back into a chip; only the outgoing form resolves it to the on-disk path.
-    expect(serializeChatDraftToPrompt(draft))
-      .toBe("Read [01-plan.md](@doc:run-01j8/01-plan.md) and [setup.md](docs/setup.md)");
-    expect(serializeChatDraftToOutgoingPrompt(draft))
-      .toBe("Read [01-plan.md](.proliferate/context/01-plan.md) and [setup.md](docs/setup.md)");
   });
 });

--- a/apps/packages/product-client/src/lib/domain/chat/composer/file-mention-draft.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/composer/file-mention-draft.test.ts
@@ -10,6 +10,7 @@ import {
   createFileMentionNode,
   createTextDraft,
   isChatDraftEmpty,
+  serializeChatDraftToOutgoingPrompt,
   serializeChatDraftToPrompt,
   type ChatComposerDraft,
 } from "#product/lib/domain/chat/composer/file-mention-draft-model";
@@ -173,5 +174,17 @@ describe("chat file mentions", () => {
   it("treats whitespace-only drafts as empty and mentions as content", () => {
     expect(isChatDraftEmpty(createTextDraft(" \n\t"))).toBe(true);
     expect(isChatDraftEmpty({ nodes: [mention("a")] })).toBe(false);
+  });
+
+  it("resolves context-doc tokens only in the outgoing prompt", () => {
+    const draft = createTextDraft(
+      "Read [01-plan.md](@doc:run-01j8/01-plan.md) and [setup.md](docs/setup.md)",
+    );
+    // The draft's own markdown keeps the token so the editor round-trips it
+    // back into a chip; only the outgoing form resolves it to the on-disk path.
+    expect(serializeChatDraftToPrompt(draft))
+      .toBe("Read [01-plan.md](@doc:run-01j8/01-plan.md) and [setup.md](docs/setup.md)");
+    expect(serializeChatDraftToOutgoingPrompt(draft))
+      .toBe("Read [01-plan.md](.proliferate/context/01-plan.md) and [setup.md](docs/setup.md)");
   });
 });

--- a/apps/packages/product-client/src/lib/domain/chat/composer/outgoing-prompt.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/composer/outgoing-prompt.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  createTextDraft,
+  serializeChatDraftToPrompt,
+} from "#product/lib/domain/chat/composer/file-mention-draft-model";
+import { serializeChatDraftToOutgoingPrompt } from "#product/lib/domain/chat/composer/outgoing-prompt";
+
+describe("serializeChatDraftToOutgoingPrompt", () => {
+  it("resolves context-doc tokens only in the outgoing prompt", () => {
+    const draft = createTextDraft(
+      "Read [01-plan.md](@doc:run-01j8/01-plan.md) and [setup.md](docs/setup.md)",
+    );
+    // The draft's own markdown keeps the token so the editor round-trips it
+    // back into a chip; only the outgoing form resolves it to the on-disk path.
+    expect(serializeChatDraftToPrompt(draft))
+      .toBe("Read [01-plan.md](@doc:run-01j8/01-plan.md) and [setup.md](docs/setup.md)");
+    expect(serializeChatDraftToOutgoingPrompt(draft))
+      .toBe("Read [01-plan.md](.proliferate/context/01-plan.md) and [setup.md](docs/setup.md)");
+  });
+
+  it("passes a token-free draft through unchanged", () => {
+    const draft = createTextDraft("plain text with [setup.md](docs/setup.md)");
+    expect(serializeChatDraftToOutgoingPrompt(draft))
+      .toBe(serializeChatDraftToPrompt(draft));
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/chat/composer/outgoing-prompt.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/composer/outgoing-prompt.ts
@@ -1,0 +1,21 @@
+import { resolveContextDocMentionTokens } from "#product/lib/domain/chat/composer/context-doc-mention";
+import {
+  serializeChatDraftToPrompt,
+  type ChatComposerDraft,
+} from "#product/lib/domain/chat/composer/file-mention-draft-model";
+
+/**
+ * The prompt actually sent to the agent. `serializeChatDraftToPrompt` is the
+ * draft's own markdown and keeps context-doc mention tokens intact so the
+ * editor round-trips them back into chips; the outgoing form is where those
+ * tokens resolve to the concrete workspace path the agent can read. Send
+ * sites call this, everything that feeds text back into the editor must not.
+ *
+ * Deliberately NOT part of `file-mention-draft-model`: the draft model rides
+ * in the entry chunk (the chat input store persists drafts at boot), and this
+ * module's context-doc dependency belongs to the lazy workspace surface. The
+ * split is what keeps the login first-load budget untouched.
+ */
+export function serializeChatDraftToOutgoingPrompt(draft: ChatComposerDraft): string {
+  return resolveContextDocMentionTokens(serializeChatDraftToPrompt(draft));
+}

--- a/apps/packages/product-client/src/vite-env.d.ts
+++ b/apps/packages/product-client/src/vite-env.d.ts
@@ -21,6 +21,7 @@ interface ImportMetaEnv {
   readonly VITE_ANYHARNESS_DEV_URL?: string;
   readonly VITE_WORKFLOWS_V2?: string;
   readonly VITE_AGENT_AUTH_EVIDENCE_PANES?: string;
+  readonly VITE_CHAT_CONTEXT_DOC_MENTIONS?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

Rung 8 of the frozen Workflows follow-up ADR: the chat composer's `@` mention menu offers the workspace's workflow-run context docs as a second, feature-flagged candidate source alongside file search.

- New mention kind `contextDoc`: selecting a doc inserts a token-mode Lexical chip (`ComposerContextDocMentionNode`, sibling of the file mention chip) that serializes to `[label](@doc:<runId>/<filename>)`. The `@doc:` destination requires a `:`, which the workspace file-link transformer body excludes, so the two mention serializations can never claim each other's text in either parse direction.
- Candidate source (`useChatContextDocMentionSource`): docs ride only on the per-run projection, so the hook reads the runs list and then a fixed set of four projection queries (`CHAT_CONTEXT_DOC_MENTION_RUN_LIMIT = 4`, mirroring the ruled visible-run cap), active runs first, all gated on the menu being open. Rows are labeled by the run's definition title with `"Workflow run"` fallback copy.
- Send-time resolution: the draft's own markdown keeps the token so the editor round-trips it back into a chip; a new `serializeChatDraftToOutgoingPrompt` (its own module, `lib/domain/chat/composer/outgoing-prompt.ts`) resolves tokens to the doc's workspace-relative path (`.proliferate/context/<filename>`) at the three send sites (`ChatInput`, `use-chat-prompt-actions`, `use-chat-launch-actions`). The mention is a pointer, not content — the agent dereferences the path with its own read tools. The module split is load-bearing for the login first-load budget: `file-mention-draft-model.ts` rides the login entry chunk via the chat input store, so the resolver lives where only the lazy workspace chunk (the three send sites) imports it. After the split, `file-mention-draft-model.ts` is identical to main modulo one removed blank line (`--ignore-blank-lines` clean) and no longer imports `context-doc-mention`. `contextDocMentionWorkspacePath` is the single seam that folds in `<runId>/` when the run-scoped layout (rung 1) merges; the token already carries the run id for that reason.
- Feature flag `chatContextDocMentions` (`VITE_CHAT_CONTEXT_DOC_MENTIONS`, default OFF): OFF disables every query and leaves the menu file-only with byte-identical DOM; the node and transformer stay registered either way so existing drafts holding a doc mention still round-trip. Revert = flag off.
- Menu rendering: docs lead the merged list (bounded set, answerable on a bare `@` before file search has a query); group headings ("Context docs" / "Files") appear only when both sources contribute rows.

Spec deviation flagged to the orchestrator: ADR 4.4 says the mention "resolves to the run-scoped absolute path"; the chat mention contract is hard workspace-relative (ADR 2.7 documents chat mentions as workspace-relative and `normalizeWorkspaceRelativePath` rejects absolute paths), so resolution is workspace-relative. One-function change in `contextDocMentionWorkspacePath` if ruled otherwise.

Per the ladder, docs land in rung 9. Builder-side typed-`@` popup and `@scratch:` are deferred by the ADR.

## TESTING

## Follow-ups (recorded, ruled non-blocking by the orchestrator)

1. The send-time resolver regex is not code-fence aware: a literal `@doc:` token typed inside a fenced code block gets rewritten at send. Optional fence guard as a follow-up.
2. Theoretical cross-parse: a workspace file destination literally beginning `@doc:` would parse as a doc token. Unreachable for realizable paths (the file transformer's destination excludes `:`), recorded for completeness.

At head 52c9afcde (chunk-split fix) — full package suite: "Tests  7420 passed (7420)", `tsc --noEmit` exit 0, and the login budget gate is green on this head's CI round. The negative-control and full-suite literals below were captured at the initial head 3a5861b93; the fix commit only moved `serializeChatDraftToOutgoingPrompt` into `outgoing-prompt.ts` (+ its split-out test with one added pass-through case).

Full package suite (`pnpm exec vitest run` in `apps/packages/product-client`):

```
Test Files  1021 passed (1021)
     Tests  7419 passed (7419)
```

Typecheck: `pnpm exec tsc -p tsconfig.json --noEmit` exit 0 (and the full `typecheck` script with dep builds passes).

New coverage:
- `context-doc-mention.test.ts`: token format/parse/validation (traversal, whitespace, control chars, brackets), send-time resolution incl. adjacency with file links and web links, candidate filtering/dedupe.
- `ComposerContextDocMentionNode.test.tsx`: the ADR-required Tier-1 round-trip — a draft holding a contextDoc token, a file mention, and a literal web link imports to the right node types and exports byte-identical markdown; cross-parse guards; JSON round-trip.
- `use-chat-context-doc-mention-source.test.tsx`: flag off/menu closed disable every query; labels and order; four-run cap with active-first selection; query narrowing.
- Updated `use-chat-file-mention-menu`, `ComposerFileMentionSearch`, `ComposerCommandEditor` suites for the merged item model plus contextDoc insertion/chip/restored-draft cases; `file-mention-draft.test.ts` covers draft-vs-outgoing serialization.

Negative controls (each reverted a slice of the change, showed the guarding tests fail, then restored green — final re-run `Test Files  7 passed (7)` / `Tests  76 passed (76)`):
1. Deregistered `COMPOSER_CONTEXT_DOC_MENTION_TRANSFORMER` → 3 failures, e.g. round-trip `AssertionError: expected [] to have a length of 1 but got +0`.
2. Made `serializeChatDraftToOutgoingPrompt` a no-op → `expected 'Read [01-plan.md](@doc:run-01j8/01-pl…' to be 'Read [01-plan.md](.proliferate/contex…'`.
3. Inverted active-first run selection → `expected [ 'run-1', 'run-2', 'run-4', 'run-6' ] to deeply equal [ 'run-3', 'run-5', 'run-1', 'run-2' ]`.
4. Dropped docs from the merge → `expected [ 'file' ] to deeply equal [ 'contextDoc', 'contextDoc', 'file' ]`.
5. Disabled group headings → `Unable to find an element with the text: Context docs`.
6. Forced contextDoc selection to insert a file node → 2 failures in the insertion/chip tests.

## OBSERVABILITY

No new telemetry. The menu panel already carries `data-telemetry-mask`; the chip contributes only its `data-composer-context-doc-mention` attribute and resolved-path tooltip. The flag is build-time, so rollout state is visible from the build env.

