### PR TITLE
fix(product): exclude quiet background rows from prompt calibration bucket

### DIFF
--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-row-height-estimate.test.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-row-height-estimate.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   estimateRenderableRowHeight,
   getRowCompositionToken,
+  getRowEstimateBucketKey,
 } from "#product/hooks/chat/ui/transcript-row-height-estimate";
 import type { TurnPresentation } from "#product/domain/chats/transcript/transcript-presentation";
 import type { TranscriptRenderableRow } from "#product/hooks/chat/ui/transcript-row-list-model";
@@ -155,5 +156,41 @@ describe("getRowCompositionToken — invalidation identity", () => {
   it("gives the history-loader row a stable constant token", () => {
     const row: TranscriptRenderableRow = { kind: "history_loader", key: HISTORY_LOADING_ROW_KEY };
     expect(getRowCompositionToken(row)).toBe(getRowCompositionToken({ ...row }));
+  });
+});
+
+describe("getRowEstimateBucketKey — calibration pooling", () => {
+  it("does NOT calibrate the fixed-height quiet background rows (they must not pool into the prompt bucket)", () => {
+    const completionReceipt: TranscriptRenderableRow = {
+      kind: "transcript",
+      key: "completion-receipt:r1",
+      rowIndex: 0,
+      row: {
+        kind: "completion_receipt",
+        key: "completion-receipt:r1",
+        receipt: { anchorTurnId: "t1" } as never,
+      },
+    };
+    const backgroundWork: TranscriptRenderableRow = {
+      kind: "transcript",
+      key: "background-work",
+      rowIndex: 0,
+      row: { kind: "background_work", key: "background-work", runningCount: 2 },
+    };
+
+    // Aligned with the goal-event sibling: a small fixed constant, not worth
+    // calibrating — so null, never the composer-shaped "prompt" bucket.
+    expect(getRowEstimateBucketKey(completionReceipt)).toBeNull();
+    expect(getRowEstimateBucketKey(backgroundWork)).toBeNull();
+  });
+
+  it("still buckets a real composer-shaped prompt row under \"prompt\" (positive control)", () => {
+    const pendingPrompt: TranscriptRenderableRow = {
+      kind: "transcript",
+      key: "pending-prompt:p1",
+      rowIndex: 0,
+      row: { kind: "pending_prompt", key: "pending-prompt:p1" },
+    };
+    expect(getRowEstimateBucketKey(pendingPrompt)).toBe("prompt");
   });
 });

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-row-height-estimate.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-row-height-estimate.ts
@@ -204,7 +204,8 @@ function turnRowBucketKey(
  * are estimated identically before measurement, so the per-session calibration
  * (transcript-row-height-calibration.ts) can pool their real measured heights.
  * Returns null for rows whose height is a small fixed constant not worth
- * calibrating (history loader, goal event) or for the out-of-range probe.
+ * calibrating (history loader, goal event, and the quiet completion-receipt /
+ * background-work footer rows) or for the out-of-range probe.
  */
 export function getRowEstimateBucketKey(
   row: TranscriptRenderableRow | undefined,
@@ -216,6 +217,13 @@ export function getRowEstimateBucketKey(
     return null;
   }
   if (row.row.kind === "goal_event") {
+    return null;
+  }
+  if (row.row.kind === "completion_receipt" || row.row.kind === "background_work") {
+    // Fixed-height quiet rows (bgwork r6): `estimateRenderableRowHeight` gives
+    // them a constant `ESTIMATED_BACKGROUND_WORK_ROW_HEIGHT_PX`, so — like the
+    // goal-event row above — they are not worth calibrating and must not pool
+    // their measured heights into the composer-shaped `"prompt"` bucket.
     return null;
   }
   if (row.row.kind === "turn") {


### PR DESCRIPTION
## What

`getRowEstimateBucketKey` (transcript virtualizer height calibration) special-cases the small fixed-height rows that aren't worth calibrating — `history_loader` and `goal_event` both return `null` — but the two bgwork r6 quiet rows, `completion_receipt` and `background_work`, fell through to the composer-shaped `"prompt"` bucket.

`estimateRenderableRowHeight` already treats them as a fixed constant (`ESTIMATED_BACKGROUND_WORK_ROW_HEIGHT_PX` = 32px, same class as goal-event's 28px), so pooling their measured heights into the `"prompt"` bucket pollutes the per-session prompt-row calibration with a much shorter row — skewing the up-front estimate for real composer-shaped prompt rows.

## Fix

Return `null` for `completion_receipt` and `background_work`, exactly like their `goal_event` sibling one branch above. One-branch change + docstring.

```ts
if (row.row.kind === "completion_receipt" || row.row.kind === "background_work") {
  return null;
}
```

## Test

Added a focused `getRowEstimateBucketKey — calibration pooling` block in the existing test file:
- both quiet kinds return `null` (aligned with goal-event)
- a real `pending_prompt` row still buckets under `"prompt"` (positive control)

Negative control run locally: reverting the branch makes the two new assertions fail (the kinds bucket as `"prompt"`); restoring cures them.

```
 Test Files  1 passed (1)
      Tests  13 passed (13)   # was 11
```
`tsc -p tsconfig.json --noEmit` → 0 errors · `check_frontend_boundaries.py` → passed · `check_max_lines.py` → passed.

## Provenance

F1 finding from f97034e1's #2021 delta verdict (comment 5323392677). Independent micro-PR off current `main`; a fresh reviewer of record follows.