### PR TITLE
fix(product): harden desktop-worker toast source against unsupported transport (#1997 product-side cure)

### DIFF
--- a/apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.test.tsx
+++ b/apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.test.tsx
@@ -44,7 +44,13 @@ vi.mock("#product/lib/workflows/cloud/ensure-desktop-worker", () => ({
   teardownDesktopWorker: workflowMocks.teardownDesktopWorker,
 }));
 
-const worker = {} as DesktopWorkerBridge;
+// The enrollment hook now re-asserts worker.isSupported() at the toast's
+// source (defense-in-depth), so the harness worker must answer it. Default
+// true keeps the failure-toast tests exercising the real notification path;
+// individual tests flip it to false to pin the unsupported-transport skip.
+const worker = {
+  isSupported: vi.fn<() => boolean>(() => true),
+} as unknown as DesktopWorkerBridge;
 
 // The enrollment guard is module-level state, so each test loads the hook
 // (and the stores it observes) from a fresh module registry. Normalized auth
@@ -112,6 +118,8 @@ describe("useDesktopWorkerEnrollment", () => {
     workflowMocks.teardownDesktopWorker.mockReset();
     workflowMocks.ensureDesktopWorker.mockResolvedValue(true);
     workflowMocks.teardownDesktopWorker.mockResolvedValue(undefined);
+    vi.mocked(worker.isSupported).mockReset();
+    vi.mocked(worker.isSupported).mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -307,6 +315,29 @@ describe("useDesktopWorkerEnrollment", () => {
         ],
       ]);
     });
+    expect(harness.getToastCalls()).toEqual([]);
+  });
+
+  it("suppresses the failure toast at its source when the transport is unsupported", async () => {
+    // Defense-in-depth: even if a failure reaches onFailure while the native
+    // transport is absent (the #1997 tier-2 failure mode), the toast source
+    // must skip silently rather than raise a sticky, pointer-blocking notice.
+    vi.mocked(worker.isSupported).mockReturnValue(false);
+    workflowMocks.ensureDesktopWorker.mockImplementationOnce(async (
+      _organizationId,
+      _worker,
+      deps,
+    ) => {
+      deps.onFailure(
+        new TypeError("Cannot read properties of undefined (reading 'invoke')"),
+      );
+      return false;
+    });
+    const harness = await loadEnrollmentHarness();
+
+    harness.signIn("user-a");
+    await flushEffects();
+    expect(harness.getErrorToastCalls()).toEqual([]);
     expect(harness.getToastCalls()).toEqual([]);
   });
 

--- a/apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.ts
+++ b/apps/packages/product-client/src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.ts
@@ -146,6 +146,19 @@ export function useDesktopWorkerEnrollment(
         if (cancelled || enrolledIdentityKey !== nextIdentityKey) {
           return;
         }
+        // Defense-in-depth at the toast's source. A worker failure raised
+        // while the native transport isn't even present (Desktop web build
+        // without the Tauri shell, intent tests) is an expected environment
+        // shape, not a user-actionable "Integrations unavailable" condition.
+        // ensureDesktopWorker already skips these silently at entry, so this
+        // path is unreachable for that case today; re-asserting it here means
+        // the toast source no longer relies solely on that single entry guard
+        // — any future caller that reaches onFailure without a supported
+        // transport still gets the same silent skip instead of a sticky,
+        // pointer-blocking toast (the #1997 tier-2 failure mode).
+        if (!worker.isSupported()) {
+          return;
+        }
         const notice = desktopWorkerStartupFailureNotice(error);
         if (
           sameFailure(


### PR DESCRIPTION
## What this is

The durable **product-side** hardening of the #1997 integrations-toast tier-2 red, complementing the env-side entry guard already merged in **#2011** (`337114fc8`).

## Root cause recap (verified first-hand against `main`)

In tier-2 intent runs `apps/desktop` boots as a plain Vite web build with no Tauri shell, so `isTauriRuntimeAvailable()` is `false`. Pre-#2011, `ensureDesktopWorker` called `worker.getInstallId()` → unguarded Tauri `invoke()` → `TypeError: Cannot read properties of undefined (reading 'invoke')`. Its `catch` calls `deps.onFailure(error)`, and `useDesktopWorkerEnrollment`'s `onFailure` raises a sticky, no-auto-dismiss **"Integrations unavailable"** toast. That toast region intercepts pointer events, so `#workflow-builder-input-1-required` sat under it and the "Workflow definition lifecycle" spec timed out.

#2011 cured this at the **entry** of `ensureDesktopWorker` (`if (!worker.isSupported()) return;` before any native call).

## The change

One product-side guard **at the toast's emission point** — the top of the `onFailure` callback in `use-desktop-worker-enrollment.ts`:

```ts
if (!worker.isSupported()) {
  return;
}
```

A worker failure raised while the native transport isn't present is an expected environment shape, not a user-actionable condition — so the toast source now skips it silently, mirroring the entry guard's contract.

## Honest scope / reachability note

With #2011's entry guard in place, the unsupported-transport error **cannot reach `onFailure` today** — so for the exact #1997 failure this guard is unreachable and the env guard is the sufficient primary cure. Its value is **defense-in-depth**: the toast source no longer relies *solely* on that single entry guard. Any future caller of `ensureDesktopWorker`'s `onFailure` path (or an `isSupported()` false-positive) that reaches the toast without a supported transport still gets the silent skip instead of the tier-2-breaking sticky toast, rather than re-introducing the regression. No product-side error class that *should* toast is suppressed: genuine startup failures (`isSupported()===true`) are untouched.

The classifier (`desktopWorkerStartupFailureNotice`) was intentionally **not** changed — string-matching the Tauri internals `TypeError` would be fragile; the structural `isSupported()` check is the robust seam the codebase already uses.

## Tests + negative control (executed)

Vitest, product-client package, env-scrubbed shell, node_modules reused read-only from a same-repo checkout (no fresh install, no cargo/rustc, no Docker):

- Added `"suppresses the failure toast at its source when the transport is unsupported"` to `use-desktop-worker-enrollment.test.tsx` — drives `onFailure` with the literal transport `TypeError` while `worker.isSupported()===false`, asserts **no** error toast and **no** info toast.
- Full suite green:
  ```
  ✓ src/hooks/cloud/lifecycle/use-desktop-worker-enrollment.test.tsx (19 tests) 349ms
   Test Files  1 passed (1)
        Tests  19 passed (19)
  ```
- **Negative control** — removed the guard, reran only the new test:
  ```
   FAIL  ...use-desktop-worker-enrollment.test.tsx > suppresses the failure toast at its source when the transport is unsupported
  AssertionError: expected [ [ { …(6) } ] ] to deeply equal []
  + "cause": "Cannot read properties of undefined (reading 'invoke')",
  + "consequence": "Proliferate will keep trying in the background. Retry now, or dismiss this notice.",
  + "headline": "Integrations unavailable",
  + "id": "desktop-worker-startup-failure",
  ```
  i.e. the exact sticky "Integrations unavailable" toast (the #1997 failure mode) fires without the guard. Guard restored; 19/19 green again.

- **tsc**: whole-package `tsc --noEmit -p tsconfig.json` reports **368 errors both with and without this diff** — all pre-existing workspace-package resolution noise (unbuilt `@proliferate/design`/`@anyharness/sdk-react` dist) in the reused-node_modules setup, none in either changed file. This diff introduces **zero** new type errors.

## Not done

No merge, no draft-flip — up for independent review only.
