### PR TITLE
fix(desktop): remove excess page top spacing

### DIFF
--- a/apps/packages/product-client/src/primitives/patterns/PageContentFrame.tsx
+++ b/apps/packages/product-client/src/primitives/patterns/PageContentFrame.tsx
@@ -67,7 +67,9 @@ export function PageContentFrame({
       )}
       <div
         className={twMerge(
-          "mx-auto flex min-h-full w-full min-w-0 flex-col gap-5 px-10 pb-12 pt-14",
+          // Keep the page content just below the shared 46px native drag
+          // strip; pt-14 left an extra 10px of unexplained space here.
+          "mx-auto flex min-h-full w-full min-w-0 flex-col gap-5 px-10 pb-12 pt-12",
           maxWidthClassName,
         )}
       >


### PR DESCRIPTION
## Summary

Reduce the shared full-page content top padding from 56px to 48px so desktop pages sit just below the 46px native drag strip without an unexplained extra band.

## Proof

- `git diff --check`
- Appearance scaling source check passed during commit
- Focused Vitest execution was attempted, but the local dependency graph currently fails before collection with `ERR_REQUIRE_ESM` from `html-encoding-sniffer` requiring `@exodus/bytes`.