### PR TITLE
fix(desktop): emit fixed-millisecond UTC support snapshot windows (REL-09B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4240,7 +4240,7 @@ dependencies = [
 
 [[package]]
 name = "proliferate"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/anyharness/sdk/src/client/sessions-support-windows.test.ts
+++ b/anyharness/sdk/src/client/sessions-support-windows.test.ts
@@ -6,6 +6,12 @@ import { supportWindowResponseBytes } from "./support-window-response-bytes.js";
 
 const timestampFrom = "2026-08-12T12:00:00.123456789Z";
 const timestampTo = "2026-08-12T12:15:00.123456789Z";
+// The exact fixed-millisecond text the desktop producer now emits for a raw
+// clock read that lands on a whole second, and for one that carries millis.
+const nativeWholeSecondFrom = "2026-08-12T11:45:00.000Z";
+const nativeWholeSecondTo = "2026-08-12T12:00:00.000Z";
+const nativeMillisecondFrom = "2026-08-12T11:45:00.123Z";
+const nativeMillisecondTo = "2026-08-12T12:00:00.123Z";
 
 describe("SessionsClient support windows", () => {
   it("serializes an exact session query and preserves nested request data", async () => {
@@ -131,6 +137,76 @@ describe("SessionsClient support windows", () => {
     );
     expect(getBoundedJson.mock.calls[0]?.[1]).toBe(2_097_152);
     expect(result).toEqual(response);
+  });
+
+  it("spells native whole-second endpoints as canonical Z on every support window", async () => {
+    const session = clientReturning(sessionWindow([], 3));
+    await session.client.listSupportWindow("workspace-1", {
+      mode: "recent",
+      updatedAtFrom: nativeWholeSecondFrom,
+      updatedAtTo: nativeWholeSecondTo,
+      limit: 3,
+      maxResponseBytes: 1_048_576,
+      request: {},
+    });
+    const sessionQuery = queryOf(session.getBoundedJson);
+    expect(sessionQuery.get("updated_at_from")).toBe("2026-08-12T11:45:00Z");
+    expect(sessionQuery.get("updated_at_to")).toBe("2026-08-12T12:00:00Z");
+    expectSameInstantWindow(
+      sessionQuery.get("updated_at_from"),
+      sessionQuery.get("updated_at_to"),
+      nativeWholeSecondFrom,
+      nativeWholeSecondTo,
+    );
+
+    for (const list of evidenceCallers()) {
+      const evidence = clientReturning(evidenceWindow([], 1, 16_384));
+      await list(evidence.client, nativeWholeSecondFrom, nativeWholeSecondTo);
+      const query = queryOf(evidence.getBoundedJson);
+      expect(query.get("timestamp_from")).toBe("2026-08-12T11:45:00Z");
+      expect(query.get("timestamp_to")).toBe("2026-08-12T12:00:00Z");
+      expectSameInstantWindow(
+        query.get("timestamp_from"),
+        query.get("timestamp_to"),
+        nativeWholeSecondFrom,
+        nativeWholeSecondTo,
+      );
+    }
+  });
+
+  it("retains native millisecond endpoints byte-for-byte on every support window", async () => {
+    const session = clientReturning(sessionWindow([], 3));
+    await session.client.listSupportWindow("workspace-1", {
+      mode: "recent",
+      updatedAtFrom: nativeMillisecondFrom,
+      updatedAtTo: nativeMillisecondTo,
+      limit: 3,
+      maxResponseBytes: 1_048_576,
+      request: {},
+    });
+    const sessionQuery = queryOf(session.getBoundedJson);
+    expect(sessionQuery.get("updated_at_from")).toBe(nativeMillisecondFrom);
+    expect(sessionQuery.get("updated_at_to")).toBe(nativeMillisecondTo);
+    expectSameInstantWindow(
+      sessionQuery.get("updated_at_from"),
+      sessionQuery.get("updated_at_to"),
+      nativeMillisecondFrom,
+      nativeMillisecondTo,
+    );
+
+    for (const list of evidenceCallers()) {
+      const evidence = clientReturning(evidenceWindow([], 1, 16_384));
+      await list(evidence.client, nativeMillisecondFrom, nativeMillisecondTo);
+      const query = queryOf(evidence.getBoundedJson);
+      expect(query.get("timestamp_from")).toBe(nativeMillisecondFrom);
+      expect(query.get("timestamp_to")).toBe(nativeMillisecondTo);
+      expectSameInstantWindow(
+        query.get("timestamp_from"),
+        query.get("timestamp_to"),
+        nativeMillisecondFrom,
+        nativeMillisecondTo,
+      );
+    }
   });
 
   it.each([
@@ -497,6 +573,49 @@ describe("SessionsClient support windows", () => {
     },
   );
 });
+
+function queryOf(getBoundedJson: ReturnType<typeof vi.fn>): URLSearchParams {
+  expect(getBoundedJson).toHaveBeenCalledOnce();
+  const path = getBoundedJson.mock.calls[0]?.[0] as string;
+  const query = path.slice(path.indexOf("?") + 1);
+  return new URLSearchParams(query);
+}
+
+function expectSameInstantWindow(
+  sentFrom: string | null,
+  sentTo: string | null,
+  nativeFrom: string,
+  nativeTo: string,
+): void {
+  const from = Date.parse(sentFrom ?? "");
+  const to = Date.parse(sentTo ?? "");
+  expect(from).toBe(Date.parse(nativeFrom));
+  expect(to).toBe(Date.parse(nativeTo));
+  expect(to - from).toBe(900_000);
+}
+
+function evidenceCallers(): Array<
+  (client: SessionsClient, from: string, to: string) => Promise<unknown>
+> {
+  return [
+    (client, from, to) =>
+      client.listEventsSupportWindow("session-1", {
+        timestampFrom: from,
+        timestampTo: to,
+        limit: 1,
+        maxResponseBytes: 16_384,
+        request: {},
+      }),
+    (client, from, to) =>
+      client.listRawNotificationsSupportWindow("session-1", {
+        timestampFrom: from,
+        timestampTo: to,
+        limit: 1,
+        maxResponseBytes: 16_384,
+        request: {},
+      }),
+  ];
+}
 
 function clientReturning(response: unknown, bodyBytes = 1_024): {
   client: SessionsClient;

--- a/anyharness/sdk/src/client/sessions-support-windows.test.ts
+++ b/anyharness/sdk/src/client/sessions-support-windows.test.ts
@@ -6,12 +6,12 @@ import { supportWindowResponseBytes } from "./support-window-response-bytes.js";
 
 const timestampFrom = "2026-08-12T12:00:00.123456789Z";
 const timestampTo = "2026-08-12T12:15:00.123456789Z";
-// The exact fixed-millisecond text the desktop producer now emits for a raw
-// clock read that lands on a whole second, and for one that carries millis.
-const nativeWholeSecondFrom = "2026-08-12T11:45:00.000Z";
-const nativeWholeSecondTo = "2026-08-12T12:00:00.000Z";
-const nativeMillisecondFrom = "2026-08-12T11:45:00.123Z";
-const nativeMillisecondTo = "2026-08-12T12:00:00.123Z";
+// Case name, the exact text the desktop producer emits, then the canonical wire text the SDK must send.
+const nativeWindows = [
+  ["whole second", "2026-08-12T11:45:00.000Z", "2026-08-12T12:00:00.000Z", "2026-08-12T11:45:00Z", "2026-08-12T12:00:00Z"],
+  ["millisecond", "2026-08-12T11:45:00.123Z", "2026-08-12T12:00:00.123Z", "2026-08-12T11:45:00.123Z", "2026-08-12T12:00:00.123Z"],
+  ["lowercase z and explicit offset", "2026-08-12T11:45:00.1z", "2026-08-12T12:00:00.100000+00:00", "2026-08-12T11:45:00.100Z", "2026-08-12T12:00:00.100Z"],
+] as const;
 
 describe("SessionsClient support windows", () => {
   it("serializes an exact session query and preserves nested request data", async () => {
@@ -80,23 +80,6 @@ describe("SessionsClient support windows", () => {
     );
   });
 
-  it("accepts UTC suffix variants and sends canonical Z timestamps", async () => {
-    const { client, getBoundedJson } = clientReturning(evidenceWindow([], 1, 16_384));
-
-    await client.listEventsSupportWindow("session-1", {
-      timestampFrom: "2026-08-12T12:00:00.1z",
-      timestampTo: "2026-08-12T12:15:00.100000+00:00",
-      limit: 1,
-      maxResponseBytes: 16_384,
-      request: {},
-    });
-
-    expect(getBoundedJson.mock.calls[0]?.[0]).toContain(
-      "timestamp_from=2026-08-12T12%3A00%3A00.100Z"
-        + "&timestamp_to=2026-08-12T12%3A15%3A00.100Z",
-    );
-  });
-
   it("uses the exact event endpoint, bounds, and seq presentation metadata", async () => {
     const response = evidenceWindow([eventResponse()], 2, 65_536);
     const { client, getBoundedJson } = clientReturning(response);
@@ -139,73 +122,18 @@ describe("SessionsClient support windows", () => {
     expect(result).toEqual(response);
   });
 
-  it("spells native whole-second endpoints as canonical Z on every support window", async () => {
-    const session = clientReturning(sessionWindow([], 3));
-    await session.client.listSupportWindow("workspace-1", {
-      mode: "recent",
-      updatedAtFrom: nativeWholeSecondFrom,
-      updatedAtTo: nativeWholeSecondTo,
-      limit: 3,
-      maxResponseBytes: 1_048_576,
-      request: {},
-    });
-    const sessionQuery = queryOf(session.getBoundedJson);
-    expect(sessionQuery.get("updated_at_from")).toBe("2026-08-12T11:45:00Z");
-    expect(sessionQuery.get("updated_at_to")).toBe("2026-08-12T12:00:00Z");
-    expectSameInstantWindow(
-      sessionQuery.get("updated_at_from"),
-      sessionQuery.get("updated_at_to"),
-      nativeWholeSecondFrom,
-      nativeWholeSecondTo,
-    );
-
-    for (const list of evidenceCallers()) {
-      const evidence = clientReturning(evidenceWindow([], 1, 16_384));
-      await list(evidence.client, nativeWholeSecondFrom, nativeWholeSecondTo);
-      const query = queryOf(evidence.getBoundedJson);
-      expect(query.get("timestamp_from")).toBe("2026-08-12T11:45:00Z");
-      expect(query.get("timestamp_to")).toBe("2026-08-12T12:00:00Z");
-      expectSameInstantWindow(
-        query.get("timestamp_from"),
-        query.get("timestamp_to"),
-        nativeWholeSecondFrom,
-        nativeWholeSecondTo,
-      );
-    }
-  });
-
-  it("retains native millisecond endpoints byte-for-byte on every support window", async () => {
-    const session = clientReturning(sessionWindow([], 3));
-    await session.client.listSupportWindow("workspace-1", {
-      mode: "recent",
-      updatedAtFrom: nativeMillisecondFrom,
-      updatedAtTo: nativeMillisecondTo,
-      limit: 3,
-      maxResponseBytes: 1_048_576,
-      request: {},
-    });
-    const sessionQuery = queryOf(session.getBoundedJson);
-    expect(sessionQuery.get("updated_at_from")).toBe(nativeMillisecondFrom);
-    expect(sessionQuery.get("updated_at_to")).toBe(nativeMillisecondTo);
-    expectSameInstantWindow(
-      sessionQuery.get("updated_at_from"),
-      sessionQuery.get("updated_at_to"),
-      nativeMillisecondFrom,
-      nativeMillisecondTo,
-    );
-
-    for (const list of evidenceCallers()) {
-      const evidence = clientReturning(evidenceWindow([], 1, 16_384));
-      await list(evidence.client, nativeMillisecondFrom, nativeMillisecondTo);
-      const query = queryOf(evidence.getBoundedJson);
-      expect(query.get("timestamp_from")).toBe(nativeMillisecondFrom);
-      expect(query.get("timestamp_to")).toBe(nativeMillisecondTo);
-      expectSameInstantWindow(
-        query.get("timestamp_from"),
-        query.get("timestamp_to"),
-        nativeMillisecondFrom,
-        nativeMillisecondTo,
-      );
+  const spelling = "sends a native %s window as canonical wire text";
+  it.each(nativeWindows)(spelling, async (_name, from, to, wireFrom, wireTo) => {
+    for (const [prefix, response, send] of nativeWindowSenders(from, to)) {
+      const { client, getBoundedJson } = clientReturning(response);
+      await send(client);
+      expect(getBoundedJson).toHaveBeenCalledOnce();
+      const path = getBoundedJson.mock.calls[0]?.[0] as string;
+      const query = new URLSearchParams(path.slice(path.indexOf("?") + 1));
+      const sent = [query.get(`${prefix}_from`) ?? "", query.get(`${prefix}_to`) ?? ""];
+      expect(sent).toEqual([wireFrom, wireTo]);
+      expect(sent.map((value) => Date.parse(value))).toEqual([Date.parse(from), Date.parse(to)]);
+      expect(Date.parse(sent[1] ?? "") - Date.parse(sent[0] ?? "")).toBe(900_000);
     }
   });
 
@@ -214,9 +142,7 @@ describe("SessionsClient support windows", () => {
     ["unknown UTC offset", { timestampFrom: "2026-08-12T12:00:00-00:00" }],
     ["invalid day", { timestampFrom: "2026-02-30T12:00:00Z" }],
     ["inverted", { timestampFrom: timestampTo, timestampTo: timestampFrom }],
-    ["over fifteen minutes", {
-      timestampFrom: "2026-08-12T11:59:59.123456789Z",
-    }],
+    ["over fifteen minutes", { timestampFrom: "2026-08-12T11:59:59.123456789Z" }],
     ["zero limit", { limit: 0 }],
     ["event limit overflow", { limit: 201 }],
     ["response below minimum", { maxResponseBytes: 16_383 }],
@@ -574,47 +500,15 @@ describe("SessionsClient support windows", () => {
   );
 });
 
-function queryOf(getBoundedJson: ReturnType<typeof vi.fn>): URLSearchParams {
-  expect(getBoundedJson).toHaveBeenCalledOnce();
-  const path = getBoundedJson.mock.calls[0]?.[0] as string;
-  const query = path.slice(path.indexOf("?") + 1);
-  return new URLSearchParams(query);
-}
-
-function expectSameInstantWindow(
-  sentFrom: string | null,
-  sentTo: string | null,
-  nativeFrom: string,
-  nativeTo: string,
-): void {
-  const from = Date.parse(sentFrom ?? "");
-  const to = Date.parse(sentTo ?? "");
-  expect(from).toBe(Date.parse(nativeFrom));
-  expect(to).toBe(Date.parse(nativeTo));
-  expect(to - from).toBe(900_000);
-}
-
-function evidenceCallers(): Array<
-  (client: SessionsClient, from: string, to: string) => Promise<unknown>
-> {
+/** One send per support endpoint that carries a fifteen-minute window. */
+function nativeWindowSenders(from: string, to: string) {
+  const evidence = { timestampFrom: from, timestampTo: to, limit: 1, maxResponseBytes: 16_384, request: {} };
+  const recent = { mode: "recent", updatedAtFrom: from, updatedAtTo: to, limit: 3, maxResponseBytes: 1_048_576, request: {} } as const;
   return [
-    (client, from, to) =>
-      client.listEventsSupportWindow("session-1", {
-        timestampFrom: from,
-        timestampTo: to,
-        limit: 1,
-        maxResponseBytes: 16_384,
-        request: {},
-      }),
-    (client, from, to) =>
-      client.listRawNotificationsSupportWindow("session-1", {
-        timestampFrom: from,
-        timestampTo: to,
-        limit: 1,
-        maxResponseBytes: 16_384,
-        request: {},
-      }),
-  ];
+    ["updated_at", sessionWindow([], 3), (c: SessionsClient) => c.listSupportWindow("workspace-1", recent)],
+    ["timestamp", evidenceWindow([], 1, 16_384), (c: SessionsClient) => c.listEventsSupportWindow("session-1", evidence)],
+    ["timestamp", evidenceWindow([], 1, 16_384), (c: SessionsClient) => c.listRawNotificationsSupportWindow("session-1", evidence)],
+  ] as const;
 }
 
 function clientReturning(response: unknown, bodyBytes = 1_024): {

--- a/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/capture.rs
+++ b/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/capture.rs
@@ -22,7 +22,8 @@ use crate::diagnostics_collector::supervisor::{
     DesktopDiagnosticsSupervisorStateV1 as NativeSupervisorState, DiagnosticsCollectorSupervisor,
 };
 use crate::diagnostics_collector::support_export::{
-    issue_support_export_for_coordinator, SupportExportError, ValidatedSupportExport,
+    issue_support_export_for_coordinator, SupportExportError, SupportExportIssuanceError,
+    ValidatedSupportExport,
 };
 use crate::sidecar::SharedSidecar;
 
@@ -85,7 +86,7 @@ pub(super) async fn capture_native_support_evidence(
         source_time_to.to_owned(),
         deadline,
     )
-    .map_err(|_| CaptureError::Invalid)?;
+    .map_err(CaptureError::Issuance)?;
     let export_supervisor = Arc::clone(&supervisor);
     let export_cancellation = control.subscribe();
     let export_work = control.begin_work();
@@ -133,7 +134,7 @@ pub(super) async fn capture_native_support_evidence(
         _ = &mut interruption_signal => Err(interruption_error(&control)),
         result = &mut remaining => Ok(result),
     };
-    let (export, native_health, children, files) = match joined {
+    let (export, native_health, real_children, files) = match joined {
         Ok(result) => result?,
         Err(error) => {
             export_abort.abort();
@@ -148,6 +149,10 @@ pub(super) async fn capture_native_support_evidence(
     if let Some(error) = capture_interruption(&control, runtime.as_ref(), deadline) {
         return Err(error);
     }
+    // The export invocation above has already passed the real permit and been
+    // consumed by the time every capture task has joined, so a deterministic
+    // downstream child-status response may be substituted here for tests only.
+    let children = runtime.child_status_override().unwrap_or(real_children);
     let (collector, collector_records) =
         collector_evidence(source_time_to, native_health.clone(), export);
     let producer_health = producer_health(native_health, &children);
@@ -209,6 +214,16 @@ pub(super) enum CaptureError {
     Cancelled,
     Deadline,
     Invalid,
+    /// The typed permit-issuance cause, carried without erasure so the
+    /// coordinator can attribute exactly one of them at terminal time.
+    Issuance(SupportExportIssuanceError),
+}
+
+impl CaptureError {
+    /// True only for the one cause eligible for bounded terminal detail.
+    pub(super) fn is_noncanonical_window(self) -> bool {
+        self == Self::Issuance(SupportExportIssuanceError::NoncanonicalWindow)
+    }
 }
 
 fn capture_interruption(

--- a/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/capture.rs
+++ b/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/capture.rs
@@ -149,10 +149,7 @@ pub(super) async fn capture_native_support_evidence(
     if let Some(error) = capture_interruption(&control, runtime.as_ref(), deadline) {
         return Err(error);
     }
-    // The export invocation above has already passed the real permit and been
-    // consumed by the time every capture task has joined, so a deterministic
-    // downstream child-status response may be substituted here for tests only.
-    let children = runtime.child_status_override().unwrap_or(real_children);
+    let children = real_children;
     let (collector, collector_records) =
         collector_evidence(source_time_to, native_health.clone(), export);
     let producer_health = producer_health(native_health, &children);

--- a/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/capture_tests.rs
+++ b/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/capture_tests.rs
@@ -1,7 +1,19 @@
 use std::sync::Arc;
 
 use tokio::sync::Barrier;
+use tokio::time::Duration;
 
+use crate::diagnostics_collector::support_export::{
+    probe, SupportExportIssuanceError as Issuance,
+};
+
+use super::super::super::artifact_store::SupportArtifactStore;
+use super::{capture_native_support_evidence, CaptureError};
+use super::super::control::{PreparationControl, PreparationInterruption};
+use super::super::fake_runtime::FakeRuntime;
+use super::super::runtime::CoordinatorRuntime;
+use super::super::state::ReadinessState;
+use super::super::tests::test_coordinator;
 use super::join_concurrently;
 
 #[tokio::test]
@@ -29,4 +41,87 @@ async fn export_health_child_and_file_futures_reach_one_start_latch() {
         (export, health, child, files),
         ("export", "health", "child", "files")
     );
+}
+
+#[tokio::test]
+async fn a_genuinely_noncanonical_window_is_refused_before_any_capture_task_starts() {
+    // No FakeRuntime capture override here: this drives the real capture entry
+    // point so the rejection comes from the real permit at the top of
+    // capture_native_support_evidence, before the export, health, child, and
+    // file work is spawned.
+    let runtime = Arc::new(FakeRuntime::new());
+    let coordinator = ready_coordinator(Arc::clone(&runtime)).await;
+    let control = PreparationControl::new();
+    probe::reset();
+
+    for (name, from, to) in [
+        // AutoSi omits the fraction on a whole second, which is exactly the
+        // pre-fix producer spelling.
+        ("bare Z", "2026-08-12T11:45:00Z", "2026-08-12T12:00:00Z"),
+        (
+            "microsecond fraction",
+            "2026-08-12T11:45:00.123456Z",
+            "2026-08-12T12:00:00.123456Z",
+        ),
+        (
+            "non-UTC offset",
+            "2026-08-12T11:45:00.123+00:00",
+            "2026-08-12T12:00:00.123+00:00",
+        ),
+        (
+            "wrong duration",
+            "2026-08-12T11:45:00.123Z",
+            "2026-08-12T12:00:01.123Z",
+        ),
+    ] {
+        let outcome = capture_native_support_evidence(
+            Arc::clone(&coordinator.supervisor),
+            coordinator.sidecar.clone(),
+            coordinator.worker.clone(),
+            &uuid::Uuid::new_v4().to_string(),
+            from,
+            to,
+            runtime.instant_now() + Duration::from_secs(25),
+            Arc::clone(&control),
+            Arc::clone(&runtime) as Arc<dyn CoordinatorRuntime>,
+        )
+        .await;
+
+        let Err(error) = outcome else {
+            panic!("{name}: a noncanonical window must be refused");
+        };
+        assert_eq!(
+            error,
+            CaptureError::Issuance(Issuance::NoncanonicalWindow),
+            "{name}"
+        );
+        assert!(error.is_noncanonical_window(), "{name}");
+        assert_eq!(
+            control.active_work(),
+            0,
+            "{name}: no export, health, child, or file task started"
+        );
+        assert!(
+            probe::observed().is_empty(),
+            "{name}: nothing was ever issued or consumed"
+        );
+        assert_eq!(
+            control.interruption(),
+            PreparationInterruption::Running,
+            "{name}: a window rejection is not an interruption"
+        );
+    }
+}
+
+async fn ready_coordinator(
+    runtime: Arc<FakeRuntime>,
+) -> Arc<super::super::SupportSnapshotCoordinator> {
+    let root = std::env::temp_dir().join(format!("rel09b-capture-{}", uuid::Uuid::new_v4()));
+    let store = Arc::new(SupportArtifactStore::for_test(
+        &root,
+        &root.join("attachments"),
+    ));
+    let coordinator = test_coordinator(Some(store), runtime);
+    coordinator.state.lock().await.readiness = ReadinessState::Ready;
+    coordinator
 }

--- a/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/fake_runtime.rs
+++ b/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/fake_runtime.rs
@@ -9,11 +9,6 @@ use chrono::{DateTime, Utc};
 use tokio::sync::watch;
 use tokio::time::{Duration, Instant};
 
-use crate::diagnostics_collector::child_status::{
-    CapturedChildProducerStatus, CapturedWorkerProducerStatus, ChildStatusOmission,
-    NativeChildStatusCapture, PortableChildProducerStatus,
-};
-
 use super::capture::CaptureError;
 use super::runtime::CoordinatorRuntime;
 
@@ -21,7 +16,6 @@ pub(super) struct FakeRuntime {
     clock: Arc<FakeClock>,
     next_id: Mutex<u64>,
     capture_error: Mutex<Option<CaptureError>>,
-    child_status: Mutex<Option<NativeChildStatusCapture>>,
     capture_result: Arc<AsyncGate>,
     finish_publication: Arc<AsyncGate>,
     finish_result: BlockingGate,
@@ -72,7 +66,6 @@ impl FakeRuntime {
             }),
             next_id: Mutex::new(0),
             capture_error: Mutex::new(None),
-            child_status: Mutex::new(None),
             capture_result: Arc::new(AsyncGate::default()),
             finish_publication: Arc::new(AsyncGate::default()),
             finish_result: BlockingGate::default(),
@@ -104,21 +97,6 @@ impl FakeRuntime {
     /// Pins the downstream child-status response to deterministic bounded
     /// values whose `captured_at` is canonical UTC `Z` text. It is applied only
     /// after the real permit was issued and consumed.
-    pub(super) fn pin_child_status(&self, captured_at: &str) {
-        let omitted = CapturedChildProducerStatus {
-            captured_at: captured_at.to_owned(),
-            status: PortableChildProducerStatus::Omitted(
-                ChildStatusOmission::ProducerStatusUnavailable,
-            ),
-        };
-        *self.child_status.lock().expect("fake child status") = Some(NativeChildStatusCapture {
-            anyharness: omitted.clone(),
-            desktop_worker: CapturedWorkerProducerStatus {
-                target_id: None,
-                producer: omitted,
-            },
-        });
-    }
 
     /// Injects a typed capture/issuance result for terminal-mapper and race
     /// tests only. It is never used by the successful begin/finish/stage proof.
@@ -252,12 +230,6 @@ impl CoordinatorRuntime for FakeRuntime {
         })
     }
 
-    fn child_status_override(&self) -> Option<NativeChildStatusCapture> {
-        self.child_status
-            .lock()
-            .expect("fake child status")
-            .clone()
-    }
 
     fn before_finish_publication(&self) -> Pin<Box<dyn Future<Output = ()> + Send>> {
         let gate = Arc::clone(&self.finish_publication);

--- a/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/fake_runtime.rs
+++ b/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/fake_runtime.rs
@@ -9,13 +9,19 @@ use chrono::{DateTime, Utc};
 use tokio::sync::watch;
 use tokio::time::{Duration, Instant};
 
+use crate::diagnostics_collector::child_status::{
+    CapturedChildProducerStatus, CapturedWorkerProducerStatus, ChildStatusOmission,
+    NativeChildStatusCapture, PortableChildProducerStatus,
+};
+
 use super::capture::CaptureError;
 use super::runtime::CoordinatorRuntime;
 
 pub(super) struct FakeRuntime {
     clock: Arc<FakeClock>,
     next_id: Mutex<u64>,
-    invalid_capture: AtomicBool,
+    capture_error: Mutex<Option<CaptureError>>,
+    child_status: Mutex<Option<NativeChildStatusCapture>>,
     capture_result: Arc<AsyncGate>,
     finish_publication: Arc<AsyncGate>,
     finish_result: BlockingGate,
@@ -65,7 +71,8 @@ impl FakeRuntime {
                 advanced: watch::channel(0).0,
             }),
             next_id: Mutex::new(0),
-            invalid_capture: AtomicBool::new(false),
+            capture_error: Mutex::new(None),
+            child_status: Mutex::new(None),
             capture_result: Arc::new(AsyncGate::default()),
             finish_publication: Arc::new(AsyncGate::default()),
             finish_result: BlockingGate::default(),
@@ -75,6 +82,13 @@ impl FakeRuntime {
             pause_watchdog_deadlines: Arc::new(AtomicBool::new(false)),
             watchdog_release: Arc::new(TestEvent::default()),
         }
+    }
+
+    /// Pins the raw UTC clock the producer reads once per preparation. Used to
+    /// drive whole-second, millisecond, microsecond, nanosecond, and
+    /// minute/date-boundary cases through the real begin path.
+    pub(super) fn set_utc(&self, value: DateTime<Utc>) {
+        *self.clock.utc.lock().expect("fake utc") = value;
     }
 
     pub(super) fn advance(&self, duration: Duration) {
@@ -87,9 +101,38 @@ impl FakeRuntime {
             .send_modify(|version| *version = version.wrapping_add(1));
     }
 
-    pub(super) fn pause_invalid_capture_result(&self) {
-        self.invalid_capture.store(true, Ordering::Release);
+    /// Pins the downstream child-status response to deterministic bounded
+    /// values whose `captured_at` is canonical UTC `Z` text. It is applied only
+    /// after the real permit was issued and consumed.
+    pub(super) fn pin_child_status(&self, captured_at: &str) {
+        let omitted = CapturedChildProducerStatus {
+            captured_at: captured_at.to_owned(),
+            status: PortableChildProducerStatus::Omitted(
+                ChildStatusOmission::ProducerStatusUnavailable,
+            ),
+        };
+        *self.child_status.lock().expect("fake child status") = Some(NativeChildStatusCapture {
+            anyharness: omitted.clone(),
+            desktop_worker: CapturedWorkerProducerStatus {
+                target_id: None,
+                producer: omitted,
+            },
+        });
+    }
+
+    /// Injects a typed capture/issuance result for terminal-mapper and race
+    /// tests only. It is never used by the successful begin/finish/stage proof.
+    pub(super) fn fail_capture_with(&self, error: CaptureError) {
+        *self.capture_error.lock().expect("fake capture error") = Some(error);
+    }
+
+    pub(super) fn pause_capture_failure(&self, error: CaptureError) {
+        self.fail_capture_with(error);
         self.capture_result.enabled.store(true, Ordering::Release);
+    }
+
+    pub(super) fn pause_invalid_capture_result(&self) {
+        self.pause_capture_failure(CaptureError::Invalid);
     }
 
     pub(super) async fn wait_invalid_capture_result(&self) {
@@ -196,16 +239,24 @@ impl CoordinatorRuntime for FakeRuntime {
     }
 
     fn capture_error_override(&self) -> Pin<Box<dyn Future<Output = Option<CaptureError>> + Send>> {
-        let invalid = self.invalid_capture.load(Ordering::Acquire);
+        let error = *self.capture_error.lock().expect("fake capture error");
         let gate = Arc::clone(&self.capture_result);
         Box::pin(async move {
-            if invalid {
-                wait_at_gate(gate).await;
-                Some(CaptureError::Invalid)
-            } else {
-                None
+            match error {
+                Some(error) => {
+                    wait_at_gate(gate).await;
+                    Some(error)
+                }
+                None => None,
             }
         })
+    }
+
+    fn child_status_override(&self) -> Option<NativeChildStatusCapture> {
+        self.child_status
+            .lock()
+            .expect("fake child status")
+            .clone()
     }
 
     fn before_finish_publication(&self) -> Pin<Box<dyn Future<Output = ()> + Send>> {

--- a/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/mod.rs
+++ b/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/mod.rs
@@ -35,6 +35,8 @@ mod submission_matrix_tests;
 mod terminal;
 #[cfg(test)]
 mod test_support;
+#[cfg(test)]
+mod timestamp_tests;
 mod watchdog;
 
 use std::sync::Arc;

--- a/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/preparation.rs
+++ b/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/preparation.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex as StdMutex};
 
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, SecondsFormat, Timelike, Utc};
 use tokio::time::Duration;
 
 use crate::diagnostics_collector::producer::lifecycle::support_lifecycle::SupportSnapshotPreparationFailureClassificationV1 as Failure;
@@ -20,15 +20,18 @@ use super::state::{
     PreparationTerminal, ReadinessState,
 };
 use super::terminal::{
-    finish_error_code, interruption_error_code, terminal_for_finish_error,
-    terminal_for_interruption,
+    finish_error_code, interruption_error_code, note_export_permit_noncanonical_window,
+    terminal_for_finish_error, terminal_for_interruption,
 };
 use super::watchdog::spawn_preparation_watchdog;
 use super::SupportSnapshotCoordinator;
 
 const PREPARATION_TIMEOUT: Duration = Duration::from_secs(25);
 const FINISH_TIMEOUT: Duration = Duration::from_secs(10);
-const CAPTURE_WINDOW_MINUTES: i64 = 15;
+/// The support window is exactly 900 seconds. The strict collector permit
+/// rejects any other duration, so this is the sole subtraction the producer
+/// applies to its one truncated capture instant.
+const SUPPORT_WINDOW_SECONDS: i64 = 900;
 
 impl SupportSnapshotCoordinator {
     pub(crate) async fn begin_preparation(
@@ -36,11 +39,17 @@ impl SupportSnapshotCoordinator {
         input: BeginSupportSnapshotInput,
     ) -> Result<SupportSnapshotPreparationOutput, String> {
         validate_begin(&input)?;
+        // One raw UTC read owns the capture instant and both window endpoints.
+        // Consent and report-opened validation still uses the raw value.
         let captured = self.runtime.utc_now();
         validate_begin_times(&input, &captured)?;
-        let captured_at = captured.to_rfc3339_opts(SecondsFormat::AutoSi, true);
-        let source_time_from = (captured - chrono::Duration::minutes(CAPTURE_WINDOW_MINUTES))
-            .to_rfc3339_opts(SecondsFormat::AutoSi, true);
+        // Truncate toward the start of the current UTC second. Never round, and
+        // never reparse formatted text as a second clock.
+        let captured = truncate_to_milliseconds(captured);
+        let captured_at = captured.to_rfc3339_opts(SecondsFormat::Millis, true);
+        let source_time_from = (captured
+            - chrono::Duration::seconds(SUPPORT_WINDOW_SECONDS))
+        .to_rfc3339_opts(SecondsFormat::Millis, true);
         let source_time_to = captured_at.clone();
         let deadline = self.runtime.instant_now() + PREPARATION_TIMEOUT;
         let preparation_id = self.runtime.new_id();
@@ -180,7 +189,20 @@ impl SupportSnapshotCoordinator {
                     },
                 })
             }
-            _ => {
+            capture => {
+                // Interruption is first-wins. It was already arbitrated above,
+                // and this second read keeps permit detail off any terminal a
+                // cancellation, deadline, or abandonment owns.
+                if control.interruption() == PreparationInterruption::Running
+                    && capture
+                        .as_ref()
+                        .err()
+                        .is_some_and(|error| error.is_noncanonical_window())
+                {
+                    if let Some(open) = state.preparation.as_ref() {
+                        note_export_permit_noncanonical_window(&open.operation);
+                    }
+                }
                 let closing = state
                     .transfer_preparation_to_closing(
                         &preparation_id,
@@ -516,6 +538,16 @@ impl SupportSnapshotCoordinator {
             }
         }
     }
+}
+
+/// Drops sub-millisecond nanoseconds from one raw clock read. `AutoSi` would
+/// otherwise omit `.000` or emit six or nine fractional digits, and the strict
+/// collector permit accepts neither spelling.
+pub(super) fn truncate_to_milliseconds(value: DateTime<Utc>) -> DateTime<Utc> {
+    let milliseconds = value.timestamp_subsec_millis();
+    value
+        .with_nanosecond(milliseconds.saturating_mul(1_000_000))
+        .unwrap_or(value)
 }
 
 fn validate_begin(input: &BeginSupportSnapshotInput) -> Result<(), String> {

--- a/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/preparation.rs
+++ b/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/preparation.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex as StdMutex};
 
-use chrono::{DateTime, SecondsFormat, Timelike, Utc};
+use chrono::{DateTime, SecondsFormat, Utc};
 use tokio::time::Duration;
 
 use crate::diagnostics_collector::producer::lifecycle::support_lifecycle::SupportSnapshotPreparationFailureClassificationV1 as Failure;
@@ -23,14 +23,13 @@ use super::terminal::{
     finish_error_code, interruption_error_code, note_export_permit_noncanonical_window,
     terminal_for_finish_error, terminal_for_interruption,
 };
+use super::runtime::truncate_to_milliseconds;
 use super::watchdog::spawn_preparation_watchdog;
 use super::SupportSnapshotCoordinator;
 
 const PREPARATION_TIMEOUT: Duration = Duration::from_secs(25);
 const FINISH_TIMEOUT: Duration = Duration::from_secs(10);
-/// The support window is exactly 900 seconds. The strict collector permit
-/// rejects any other duration, so this is the sole subtraction the producer
-/// applies to its one truncated capture instant.
+/// Exactly 900 seconds: the only duration the strict collector permit accepts.
 const SUPPORT_WINDOW_SECONDS: i64 = 900;
 
 impl SupportSnapshotCoordinator {
@@ -39,17 +38,14 @@ impl SupportSnapshotCoordinator {
         input: BeginSupportSnapshotInput,
     ) -> Result<SupportSnapshotPreparationOutput, String> {
         validate_begin(&input)?;
-        // One raw UTC read owns the capture instant and both window endpoints.
-        // Consent and report-opened validation still uses the raw value.
+        // One raw UTC read owns the capture instant and both window endpoints,
+        // truncated (never rounded) and never reparsed as a second clock.
         let captured = self.runtime.utc_now();
         validate_begin_times(&input, &captured)?;
-        // Truncate toward the start of the current UTC second. Never round, and
-        // never reparse formatted text as a second clock.
         let captured = truncate_to_milliseconds(captured);
         let captured_at = captured.to_rfc3339_opts(SecondsFormat::Millis, true);
-        let source_time_from = (captured
-            - chrono::Duration::seconds(SUPPORT_WINDOW_SECONDS))
-        .to_rfc3339_opts(SecondsFormat::Millis, true);
+        let window_start = captured - chrono::Duration::seconds(SUPPORT_WINDOW_SECONDS);
+        let source_time_from = window_start.to_rfc3339_opts(SecondsFormat::Millis, true);
         let source_time_to = captured_at.clone();
         let deadline = self.runtime.instant_now() + PREPARATION_TIMEOUT;
         let preparation_id = self.runtime.new_id();
@@ -190,9 +186,7 @@ impl SupportSnapshotCoordinator {
                 })
             }
             capture => {
-                // Interruption is first-wins. It was already arbitrated above,
-                // and this second read keeps permit detail off any terminal a
-                // cancellation, deadline, or abandonment owns.
+                // First-wins: keep permit detail off an interrupted terminal.
                 if control.interruption() == PreparationInterruption::Running
                     && capture
                         .as_ref()
@@ -538,16 +532,6 @@ impl SupportSnapshotCoordinator {
             }
         }
     }
-}
-
-/// Drops sub-millisecond nanoseconds from one raw clock read. `AutoSi` would
-/// otherwise omit `.000` or emit six or nine fractional digits, and the strict
-/// collector permit accepts neither spelling.
-pub(super) fn truncate_to_milliseconds(value: DateTime<Utc>) -> DateTime<Utc> {
-    let milliseconds = value.timestamp_subsec_millis();
-    value
-        .with_nanosecond(milliseconds.saturating_mul(1_000_000))
-        .unwrap_or(value)
 }
 
 fn validate_begin(input: &BeginSupportSnapshotInput) -> Result<(), String> {

--- a/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/runtime.rs
+++ b/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/runtime.rs
@@ -4,8 +4,6 @@ use std::pin::Pin;
 use chrono::{DateTime, Timelike, Utc};
 use tokio::time::Instant;
 
-use crate::diagnostics_collector::child_status::NativeChildStatusCapture;
-
 use super::capture::CaptureError;
 
 pub(super) trait CoordinatorRuntime: Send + Sync {
@@ -20,13 +18,6 @@ pub(super) trait CoordinatorRuntime: Send + Sync {
 
     fn capture_error_override(&self) -> Pin<Box<dyn Future<Output = Option<CaptureError>> + Send>> {
         Box::pin(async { None })
-    }
-
-    /// A deterministic downstream child-status response, applied only after the
-    /// real support export invocation has been issued, passed the real permit,
-    /// and been consumed. Production always returns `None`.
-    fn child_status_override(&self) -> Option<NativeChildStatusCapture> {
-        None
     }
 
     fn before_finish_publication(&self) -> Pin<Box<dyn Future<Output = ()> + Send>> {

--- a/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/runtime.rs
+++ b/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/runtime.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
 use std::pin::Pin;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Timelike, Utc};
 use tokio::time::Instant;
 
 use crate::diagnostics_collector::child_status::NativeChildStatusCapture;
@@ -64,4 +64,18 @@ impl CoordinatorRuntime for SystemCoordinatorRuntime {
     fn sleep_until(&self, deadline: Instant) -> Pin<Box<dyn Future<Output = ()> + Send>> {
         Box::pin(tokio::time::sleep_until(deadline))
     }
+}
+
+/// Drops sub-millisecond nanoseconds from one raw clock read, truncating toward
+/// the start of the current millisecond and never rounding. `AutoSi` would
+/// otherwise omit `.000` or emit six or nine fractional digits, and the strict
+/// collector permit accepts neither spelling. A chrono leap-second read reports
+/// `timestamp_subsec_millis()` in `1000..=1999`; clamping to 999 keeps the
+/// emitted fraction three digits wide instead of overflowing into the next
+/// second.
+pub(super) fn truncate_to_milliseconds(value: DateTime<Utc>) -> DateTime<Utc> {
+    let milliseconds = value.timestamp_subsec_millis().min(999);
+    value
+        .with_nanosecond(milliseconds * 1_000_000)
+        .unwrap_or(value)
 }

--- a/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/runtime.rs
+++ b/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/runtime.rs
@@ -4,6 +4,8 @@ use std::pin::Pin;
 use chrono::{DateTime, Utc};
 use tokio::time::Instant;
 
+use crate::diagnostics_collector::child_status::NativeChildStatusCapture;
+
 use super::capture::CaptureError;
 
 pub(super) trait CoordinatorRuntime: Send + Sync {
@@ -18,6 +20,13 @@ pub(super) trait CoordinatorRuntime: Send + Sync {
 
     fn capture_error_override(&self) -> Pin<Box<dyn Future<Output = Option<CaptureError>> + Send>> {
         Box::pin(async { None })
+    }
+
+    /// A deterministic downstream child-status response, applied only after the
+    /// real support export invocation has been issued, passed the real permit,
+    /// and been consumed. Production always returns `None`.
+    fn child_status_override(&self) -> Option<NativeChildStatusCapture> {
+        None
     }
 
     fn before_finish_publication(&self) -> Pin<Box<dyn Future<Output = ()> + Send>> {

--- a/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/terminal.rs
+++ b/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/terminal.rs
@@ -44,6 +44,22 @@ pub(super) fn failed(
     }
 }
 
+/// Attaches the two bounded operational enum arguments that only a still
+/// running, truly noncanonical export window may carry. They ride the existing
+/// single terminal record of `desktop.support_snapshot.prepare`; the started
+/// record is already emitted and stays argument-free.
+pub(super) fn note_export_permit_noncanonical_window(
+    operation: &Arc<Mutex<Option<SupportPreparationOperation>>>,
+) {
+    let mut guard = match operation.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    if let Some(operation) = guard.as_mut() {
+        operation.note_export_permit_noncanonical_window();
+    }
+}
+
 pub(super) fn interruption_error_code(interruption: PreparationInterruption) -> &'static str {
     match interruption {
         PreparationInterruption::Deadline => "support_snapshot_preparation_timeout",

--- a/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/timestamp_tests.rs
+++ b/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/timestamp_tests.rs
@@ -1,0 +1,566 @@
+//! REL-09B proof: one raw clock read produces one canonical fixed-millisecond
+//! 15-minute window, that exact text passes the unchanged strict permit, and a
+//! genuinely noncanonical window is the only cause that gains bounded terminal
+//! detail.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::Arc;
+
+use chrono::{DateTime, SecondsFormat, Utc};
+use proliferate_diagnostics_protocol::v1::types::{
+    ArgumentValueV1, LifecyclePhaseV1, PrivacyClassificationV1, ProducerRecordV1, TerminalOutcomeV1,
+};
+use tokio::time::Duration;
+
+use crate::diagnostics_collector::support_export::{
+    probe, SupportExportIssuanceError as Issuance,
+};
+
+use super::super::artifact_store::{SupportArtifactReference, SupportArtifactStore};
+use super::super::schema::enums::SupportSessionOmissionReasonV1;
+use super::super::schema::model::manifest::SupportSessionCollectionManifestV1;
+use super::super::schema::model::snapshot::SupportSnapshotV3;
+use super::capture::CaptureError;
+use super::control::PreparationInterruption;
+use super::fake_runtime::FakeRuntime;
+use super::model::{CancelSupportSnapshotInput, FinishSupportSnapshotInput};
+use super::state::ReadinessState;
+use super::tests::{begin_input, test_coordinator};
+use super::SupportSnapshotCoordinator;
+
+const END_TO_END_CHILD_ENV: &str = "PROLIFERATE_REL09B_TIMESTAMP_CHILD";
+const END_TO_END_CHILD_FIXTURE: &str =
+    "diagnostics::support_snapshot::coordinator::timestamp_tests::native_clock_precision_child";
+const FAILURE_STAGE: &str = "failure_stage";
+const FAILURE_REASON: &str = "failure_reason";
+const EXPORT_PERMIT: &str = "export_permit";
+const NONCANONICAL_WINDOW: &str = "noncanonical_window";
+
+struct ClockCase {
+    name: &'static str,
+    raw: &'static str,
+    captured_at: &'static str,
+    source_time_from: &'static str,
+}
+
+const CLOCK_CASES: [ClockCase; 5] = [
+    ClockCase {
+        name: "whole second",
+        raw: "2026-08-12T00:00:00Z",
+        captured_at: "2026-08-12T00:00:00.000Z",
+        source_time_from: "2026-08-11T23:45:00.000Z",
+    },
+    ClockCase {
+        name: "milliseconds",
+        raw: "2026-08-12T00:00:00.123Z",
+        captured_at: "2026-08-12T00:00:00.123Z",
+        source_time_from: "2026-08-11T23:45:00.123Z",
+    },
+    ClockCase {
+        name: "microseconds",
+        raw: "2026-08-12T00:00:00.123456Z",
+        captured_at: "2026-08-12T00:00:00.123Z",
+        source_time_from: "2026-08-11T23:45:00.123Z",
+    },
+    ClockCase {
+        name: "nanoseconds",
+        raw: "2026-08-12T00:00:00.999999999Z",
+        captured_at: "2026-08-12T00:00:00.999Z",
+        source_time_from: "2026-08-11T23:45:00.999Z",
+    },
+    ClockCase {
+        name: "minute and date boundary",
+        raw: "2026-09-01T00:00:00.000999Z",
+        captured_at: "2026-09-01T00:00:00.000Z",
+        source_time_from: "2026-08-31T23:45:00.000Z",
+    },
+];
+
+/// The real begin/permit/finish/staged-artifact composition needs a private
+/// `HOME`, so it runs in a child test process rather than mutating shared
+/// process environment under test parallelism.
+#[test]
+fn native_clock_precision_reaches_a_verified_staged_snapshot() {
+    if std::env::var_os(END_TO_END_CHILD_ENV).is_some() {
+        return;
+    }
+    let marker = std::env::temp_dir().join(format!("rel09b-timestamp-{}", uuid::Uuid::new_v4()));
+    let home = std::env::temp_dir().join(format!("rel09b-home-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&home).expect("child home");
+    let output = Command::new(std::env::current_exe().expect("test executable"))
+        .arg("--exact")
+        .arg(END_TO_END_CHILD_FIXTURE)
+        .arg("--ignored")
+        .env(END_TO_END_CHILD_ENV, &marker)
+        .env("HOME", &home)
+        .env_remove("USERPROFILE")
+        .env_remove("PROLIFERATE_DEV")
+        .env_remove("PROLIFERATE_DEV_HOME")
+        .env_remove("ANYHARNESS_DEV_RUNTIME_HOME")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn timestamp end-to-end fixture");
+    let marker_contents = std::fs::read_to_string(&marker).ok();
+    let _ = std::fs::remove_file(marker);
+    let _ = std::fs::remove_dir_all(home);
+    assert!(
+        output.status.success(),
+        "timestamp end-to-end fixture failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(marker_contents.as_deref(), Some("completed"));
+}
+
+#[test]
+#[ignore]
+fn native_clock_precision_child() {
+    let Some(marker) = std::env::var_os(END_TO_END_CHILD_ENV).map(PathBuf::from) else {
+        return;
+    };
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    runtime.block_on(async {
+        for case in CLOCK_CASES {
+            exercise_clock_case(&case).await;
+        }
+    });
+    std::fs::write(marker, b"completed").expect("mark timestamp fixture completion");
+}
+
+async fn exercise_clock_case(case: &ClockCase) {
+    let root = std::env::temp_dir().join(format!("rel09b-store-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&root).expect("store root");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o700))
+            .expect("store root mode");
+    }
+    let store = Arc::new(SupportArtifactStore::for_test(
+        &root,
+        &root.join("attachments"),
+    ));
+    store
+        .reconcile(
+            &[],
+            &[],
+            std::time::Instant::now() + std::time::Duration::from_secs(5),
+        )
+        .expect("store ready");
+    let runtime = Arc::new(FakeRuntime::new());
+    runtime.set_utc(parse(case.raw));
+    // The real child-status sampler stamps `+00:00` offset text, which the
+    // support schema's canonical `Z` validator rejects. That is an independent
+    // defect outside REL-09B's write scope, so this proof substitutes a
+    // deterministic downstream child-status response after the real export
+    // invocation has passed the real permit and been consumed.
+    runtime.pin_child_status(case.captured_at);
+    let coordinator = test_coordinator(Some(Arc::clone(&store)), Arc::clone(&runtime));
+    coordinator.state.lock().await.readiness = ReadinessState::Ready;
+    probe::reset();
+
+    let output = coordinator
+        .begin_preparation(begin_input())
+        .await
+        .unwrap_or_else(|error| panic!("{}: begin_preparation rejected: {error}", case.name));
+
+    // 1. Exact native response strings from the one truncated instant.
+    assert_eq!(output.captured_at, case.captured_at, "{}", case.name);
+    assert_eq!(
+        output.window.source_time_from, case.source_time_from,
+        "{}",
+        case.name
+    );
+    assert_eq!(output.window.source_time_to, case.captured_at, "{}", case.name);
+    // 2. Byte identity and an exact 900-second parsed interval.
+    assert_eq!(
+        output.captured_at, output.window.source_time_to,
+        "{}: captured_at is the window end byte-for-byte",
+        case.name
+    );
+    assert_fixed_milliseconds(&output.captured_at, case.name);
+    assert_fixed_milliseconds(&output.window.source_time_from, case.name);
+    assert_exact_window(&output.window.source_time_from, &output.window.source_time_to);
+    // No `AutoSi` spelling of the raw instant can reach the response. For a
+    // raw clock already at whole-millisecond precision both spellings agree,
+    // so the assertion applies only where `AutoSi` would differ.
+    let auto_si = parse(case.raw).to_rfc3339_opts(SecondsFormat::AutoSi, true);
+    let auto_si_differs = auto_si != case.captured_at;
+    if auto_si_differs {
+        for value in [
+            output.captured_at.as_str(),
+            output.window.source_time_to.as_str(),
+        ] {
+            assert_ne!(value, auto_si.as_str(), "{}", case.name);
+        }
+    }
+
+    // 3. The real permit accepted and consumed exactly those request bytes
+    // before any downstream collector response was observed.
+    let observed = probe::observed();
+    assert_eq!(observed.len(), 2, "{}: one issuance and one consumption", case.name);
+    assert_eq!(observed[0].stage, probe::IssuanceStage::Issued, "{}", case.name);
+    assert_eq!(observed[1].stage, probe::IssuanceStage::Consumed, "{}", case.name);
+    for entry in &observed {
+        assert_eq!(entry.source_time_from, case.source_time_from, "{}", case.name);
+        assert_eq!(entry.source_time_to, case.captured_at, "{}", case.name);
+    }
+
+    let prepared = coordinator
+        .finish_preparation(FinishSupportSnapshotInput {
+            preparation_id: output.preparation_id.clone(),
+            consent_epoch: begin_input().consent_epoch,
+            session_evidence_json: None,
+            session_collection: SupportSessionCollectionManifestV1::Omitted {
+                reason: SupportSessionOmissionReasonV1::NoSelectedBundledLocalWorkspace,
+            },
+        })
+        .await
+        .unwrap_or_else(|error| panic!("{}: finish_preparation failed: {error}", case.name));
+    assert_eq!(prepared.generated_at, case.captured_at, "{}", case.name);
+
+    // 4. Read the staged bytes back through the verified-read path and parse
+    // the canonical JSON as a schema-3 snapshot.
+    let reference = staged_reference(&coordinator, &prepared.artifact_id).await;
+    let bytes = store
+        .read_verified(&reference)
+        .unwrap_or_else(|_| panic!("{}: verified staged read", case.name));
+    let snapshot: SupportSnapshotV3 =
+        serde_json::from_slice(&bytes).unwrap_or_else(|error| {
+            panic!("{}: staged artifact is not a SupportSnapshotV3: {error}", case.name)
+        });
+    assert_eq!(snapshot.schema_version, 3, "{}", case.name);
+    assert_eq!(snapshot.generated_at, case.captured_at, "{}", case.name);
+    assert_eq!(snapshot.selection.source_time_to, case.captured_at, "{}", case.name);
+    assert_eq!(
+        snapshot.selection.source_time_from, case.source_time_from,
+        "{}",
+        case.name
+    );
+    assert_eq!(snapshot.collector.captured_at, case.captured_at, "{}", case.name);
+    assert_eq!(
+        snapshot.generated_at, snapshot.selection.source_time_to,
+        "{}: generatedAt is the selection end byte-for-byte",
+        case.name
+    );
+    assert_eq!(
+        snapshot.collector.captured_at, snapshot.selection.source_time_to,
+        "{}: collector captured_at is the selection end byte-for-byte",
+        case.name
+    );
+    assert_fixed_milliseconds(&snapshot.selection.source_time_from, case.name);
+    assert_fixed_milliseconds(&snapshot.selection.source_time_to, case.name);
+    assert_exact_window(
+        &snapshot.selection.source_time_from,
+        &snapshot.selection.source_time_to,
+    );
+    if let Some(manifest) = &snapshot.collector.export_manifest {
+        assert_eq!(
+            manifest.filters.source_time_from.as_deref(),
+            Some(case.source_time_from),
+            "{}",
+            case.name
+        );
+        assert_eq!(
+            manifest.filters.source_time_to.as_deref(),
+            Some(case.captured_at),
+            "{}",
+            case.name
+        );
+    }
+    if auto_si_differs {
+        for value in [
+            snapshot.generated_at.as_str(),
+            snapshot.selection.source_time_to.as_str(),
+            snapshot.collector.captured_at.as_str(),
+        ] {
+            assert_ne!(value, auto_si.as_str(), "{}", case.name);
+        }
+    }
+
+    let terminal = sole_terminal(&coordinator);
+    assert!(
+        terminal.arguments.is_empty(),
+        "{}: a successful preparation carries no permit detail",
+        case.name
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[tokio::test]
+async fn noncanonical_window_terminal_carries_only_the_two_bounded_arguments() {
+    let runtime = Arc::new(FakeRuntime::new());
+    runtime.fail_capture_with(CaptureError::Issuance(Issuance::NoncanonicalWindow));
+    let coordinator = ready_coordinator(Arc::clone(&runtime)).await;
+
+    let error = coordinator
+        .begin_preparation(begin_input())
+        .await
+        .expect_err("a noncanonical export window is refused");
+
+    assert_eq!(error, "support_snapshot_preparation_rejected");
+    let records = prepare_records(&coordinator);
+    assert_eq!(records.len(), 2, "exactly one start and one terminal");
+    let start = phase(&records, LifecyclePhaseV1::Started);
+    assert!(
+        start.arguments.is_empty(),
+        "the started record stays argument-free"
+    );
+    let terminal = phase(&records, LifecyclePhaseV1::Terminal);
+    assert_eq!(
+        terminal.lifecycle.as_ref().and_then(|value| value.outcome),
+        Some(TerminalOutcomeV1::Rejected)
+    );
+    assert_eq!(
+        terminal.error_classification.as_deref(),
+        Some("preparation_rejected")
+    );
+    assert_eq!(terminal.arguments.len(), 2, "exactly two bounded arguments");
+    assert_eq!(terminal.arguments[0].name, FAILURE_STAGE);
+    assert_eq!(
+        terminal.arguments[0].privacy,
+        PrivacyClassificationV1::Operational
+    );
+    assert_eq!(
+        terminal.arguments[0].value,
+        ArgumentValueV1::Enum(EXPORT_PERMIT.to_string())
+    );
+    assert_eq!(terminal.arguments[1].name, FAILURE_REASON);
+    assert_eq!(
+        terminal.arguments[1].privacy,
+        PrivacyClassificationV1::Operational
+    );
+    assert_eq!(
+        terminal.arguments[1].value,
+        ArgumentValueV1::Enum(NONCANONICAL_WINDOW.to_string())
+    );
+
+    // No timestamp, identifier, path, or raw input rides the record.
+    let encoded = serde_json::to_string(&terminal.arguments).expect("arguments JSON");
+    for forbidden in [
+        "2026-", "Z\"", "/", "support_snapshot_preparation_rejected", "NoncanonicalWindow",
+    ] {
+        assert!(
+            !encoded.contains(forbidden),
+            "bounded arguments must not contain {forbidden}: {encoded}"
+        );
+    }
+
+    // Nothing was authorized and the preparation cleaned itself up.
+    let state = coordinator.state.lock().await;
+    assert!(state.preparation.is_none());
+    assert!(state.closing_preparation.is_none());
+    assert!(state.artifacts.is_empty(), "no artifact is authorized");
+    assert!(state.read_proofs.is_empty());
+    assert!(state.submission.is_none());
+}
+
+#[tokio::test]
+async fn every_other_failure_cause_carries_neither_argument() {
+    let causes = [
+        ("invalid preparation id", CaptureError::Issuance(Issuance::InvalidPreparationId)),
+        ("expired deadline", CaptureError::Issuance(Issuance::ExpiredDeadline)),
+        ("request invariant", CaptureError::Issuance(Issuance::RequestInvariant)),
+        ("generic invalid capture", CaptureError::Invalid),
+    ];
+    for (name, cause) in causes {
+        let runtime = Arc::new(FakeRuntime::new());
+        runtime.fail_capture_with(cause);
+        let coordinator = ready_coordinator(Arc::clone(&runtime)).await;
+
+        let error = coordinator
+            .begin_preparation(begin_input())
+            .await
+            .expect_err("the capture failure is rejected");
+
+        assert_eq!(error, "support_snapshot_preparation_rejected", "{name}");
+        let terminal = sole_terminal(&coordinator);
+        assert_eq!(
+            terminal.error_classification.as_deref(),
+            Some("preparation_rejected"),
+            "{name}"
+        );
+        assert!(
+            terminal.arguments.is_empty(),
+            "{name} must carry no permit detail"
+        );
+    }
+}
+
+#[tokio::test]
+async fn interruption_wins_over_a_window_rejection_and_suppresses_permit_detail() {
+    let runtime = Arc::new(FakeRuntime::new());
+    runtime.pause_capture_failure(CaptureError::Issuance(Issuance::NoncanonicalWindow));
+    let coordinator = ready_coordinator(Arc::clone(&runtime)).await;
+
+    let begin = tokio::spawn({
+        let coordinator = Arc::clone(&coordinator);
+        async move { coordinator.begin_preparation(begin_input()).await }
+    });
+    runtime.wait_invalid_capture_result().await;
+    // The cancellation owns the closing fence and waits for the gated begin
+    // call to become idle, so the gate must be released concurrently.
+    let cancel = coordinator.cancel_preparation(CancelSupportSnapshotInput {
+        client_job_id: begin_input().client_job_id,
+        consent_epoch: begin_input().consent_epoch,
+        preparation_id: None,
+    });
+    let release = async {
+        runtime.release_invalid_capture_result();
+    };
+    let (cancelled, ()) = tokio::join!(cancel, release);
+    cancelled.expect("cancel wins the terminal");
+
+    let error = begin
+        .await
+        .expect("begin task")
+        .expect_err("a cancelled preparation returns the cancellation");
+    assert_eq!(error, "support_snapshot_preparation_cancelled");
+
+    let terminal = sole_terminal(&coordinator);
+    assert_eq!(
+        terminal.lifecycle.as_ref().and_then(|value| value.outcome),
+        Some(TerminalOutcomeV1::Cancelled)
+    );
+    assert_eq!(terminal.error_classification, None);
+    assert!(
+        terminal.arguments.is_empty(),
+        "a winning interruption owns the terminal and suppresses permit detail"
+    );
+    assert_eq!(
+        coordinator
+            .state
+            .lock()
+            .await
+            .closed_preparation
+            .as_ref()
+            .map(|closed| closed.interruption),
+        Some(PreparationInterruption::Cancelled)
+    );
+}
+
+#[tokio::test]
+async fn a_deadline_interruption_also_suppresses_permit_detail() {
+    let runtime = Arc::new(FakeRuntime::new());
+    runtime.pause_capture_failure(CaptureError::Issuance(Issuance::NoncanonicalWindow));
+    let coordinator = ready_coordinator(Arc::clone(&runtime)).await;
+
+    let begin = tokio::spawn({
+        let coordinator = Arc::clone(&coordinator);
+        async move { coordinator.begin_preparation(begin_input()).await }
+    });
+    runtime.wait_invalid_capture_result().await;
+    runtime.advance(Duration::from_secs(25));
+    runtime.release_invalid_capture_result();
+
+    let error = begin
+        .await
+        .expect("begin task")
+        .expect_err("an expired preparation times out");
+    assert_eq!(error, "support_snapshot_preparation_timeout");
+
+    let terminal = sole_terminal(&coordinator);
+    assert_eq!(
+        terminal.lifecycle.as_ref().and_then(|value| value.outcome),
+        Some(TerminalOutcomeV1::TimedOut)
+    );
+    assert_eq!(
+        terminal.error_classification.as_deref(),
+        Some("preparation_timeout")
+    );
+    assert!(terminal.arguments.is_empty());
+}
+
+#[test]
+fn truncation_never_rounds_a_raw_clock_read() {
+    for case in CLOCK_CASES {
+        let truncated = super::preparation::truncate_to_milliseconds(parse(case.raw));
+        assert_eq!(
+            truncated.to_rfc3339_opts(SecondsFormat::Millis, true),
+            case.captured_at,
+            "{}",
+            case.name
+        );
+        assert!(truncated <= parse(case.raw), "{}: never rounds up", case.name);
+    }
+}
+
+async fn ready_coordinator(runtime: Arc<FakeRuntime>) -> Arc<SupportSnapshotCoordinator> {
+    let root = std::env::temp_dir().join(format!("rel09b-reject-{}", uuid::Uuid::new_v4()));
+    let store = Arc::new(SupportArtifactStore::for_test(
+        &root,
+        &root.join("attachments"),
+    ));
+    let coordinator = test_coordinator(Some(store), runtime);
+    coordinator.state.lock().await.readiness = ReadinessState::Ready;
+    coordinator
+}
+
+async fn staged_reference(
+    coordinator: &Arc<SupportSnapshotCoordinator>,
+    artifact_id: &str,
+) -> SupportArtifactReference {
+    coordinator
+        .state
+        .lock()
+        .await
+        .artifacts
+        .get(artifact_id)
+        .expect("authorized staged artifact")
+        .reference
+        .clone()
+}
+
+fn prepare_records(coordinator: &Arc<SupportSnapshotCoordinator>) -> Vec<ProducerRecordV1> {
+    coordinator
+        .producer
+        .support_lifecycle_snapshot()
+        .into_iter()
+        .filter(|record| record.name == "desktop.support_snapshot.prepare")
+        .collect()
+}
+
+fn sole_terminal(coordinator: &Arc<SupportSnapshotCoordinator>) -> ProducerRecordV1 {
+    let records = prepare_records(coordinator);
+    assert_eq!(records.len(), 2, "exactly one start and one terminal");
+    phase(&records, LifecyclePhaseV1::Terminal).clone()
+}
+
+fn phase(records: &[ProducerRecordV1], phase: LifecyclePhaseV1) -> &ProducerRecordV1 {
+    records
+        .iter()
+        .find(|record| record.lifecycle.as_ref().map(|value| value.phase) == Some(phase))
+        .expect("lifecycle phase")
+}
+
+fn parse(value: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(value)
+        .expect("fixture timestamp")
+        .with_timezone(&Utc)
+}
+
+fn assert_fixed_milliseconds(value: &str, name: &str) {
+    let (seconds, fraction) = value
+        .split_once('.')
+        .unwrap_or_else(|| panic!("{name}: {value} has no millisecond fraction"));
+    assert_eq!(seconds.len(), 19, "{name}: {value}");
+    assert_eq!(fraction.len(), 4, "{name}: {value} is not exactly .mmmZ");
+    assert!(fraction.ends_with('Z'), "{name}: {value}");
+    assert!(
+        fraction[..3].chars().all(|digit| digit.is_ascii_digit()),
+        "{name}: {value}"
+    );
+}
+
+fn assert_exact_window(from: &str, to: &str) {
+    assert_eq!(
+        parse(to).signed_duration_since(parse(from)),
+        chrono::Duration::seconds(900),
+        "the window is exactly 900 parsed seconds"
+    );
+}

--- a/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/timestamp_tests.rs
+++ b/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/timestamp_tests.rs
@@ -259,20 +259,17 @@ async fn exercise_clock_case(case: &ClockCase) {
         &snapshot.selection.source_time_from,
         &snapshot.selection.source_time_to,
     );
-    if let Some(manifest) = &snapshot.collector.export_manifest {
-        assert_eq!(
-            manifest.filters.source_time_from.as_deref(),
-            Some(case.source_time_from),
-            "{}",
-            case.name
-        );
-        assert_eq!(
-            manifest.filters.source_time_to.as_deref(),
-            Some(case.captured_at),
-            "{}",
-            case.name
-        );
-    }
+    // An export manifest exists only when a packaged collector process actually
+    // answered the export. This fixture deliberately runs with no collector
+    // installed under its private HOME, so the manifest is absent by
+    // construction and asserting on it would be vacuous. The exact request
+    // window bytes are instead proven above by `probe::observed()`, which
+    // records the real permit's own filters at issue and at consume.
+    assert!(
+        snapshot.collector.export_manifest.is_none(),
+        "{}: no collector process runs in this fixture",
+        case.name
+    );
     if auto_si_differs {
         for value in [
             snapshot.generated_at.as_str(),
@@ -479,7 +476,7 @@ async fn a_deadline_interruption_also_suppresses_permit_detail() {
 #[test]
 fn truncation_never_rounds_a_raw_clock_read() {
     for case in CLOCK_CASES {
-        let truncated = super::preparation::truncate_to_milliseconds(parse(case.raw));
+        let truncated = super::runtime::truncate_to_milliseconds(parse(case.raw));
         assert_eq!(
             truncated.to_rfc3339_opts(SecondsFormat::Millis, true),
             case.captured_at,

--- a/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/timestamp_tests.rs
+++ b/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/timestamp_tests.rs
@@ -20,7 +20,9 @@ use crate::diagnostics_collector::support_export::{
 use super::super::artifact_store::{SupportArtifactReference, SupportArtifactStore};
 use super::super::schema::enums::SupportSessionOmissionReasonV1;
 use super::super::schema::model::manifest::SupportSessionCollectionManifestV1;
+use super::super::schema::model::health::SupportChildProducerStatusV1;
 use super::super::schema::model::snapshot::SupportSnapshotV3;
+use super::super::schema::validate::validate_timestamp;
 use super::capture::CaptureError;
 use super::control::PreparationInterruption;
 use super::fake_runtime::FakeRuntime;
@@ -154,12 +156,6 @@ async fn exercise_clock_case(case: &ClockCase) {
         .expect("store ready");
     let runtime = Arc::new(FakeRuntime::new());
     runtime.set_utc(parse(case.raw));
-    // The real child-status sampler stamps `+00:00` offset text, which the
-    // support schema's canonical `Z` validator rejects. That is an independent
-    // defect outside REL-09B's write scope, so this proof substitutes a
-    // deterministic downstream child-status response after the real export
-    // invocation has passed the real permit and been consumed.
-    runtime.pin_child_status(case.captured_at);
     let coordinator = test_coordinator(Some(Arc::clone(&store)), Arc::clone(&runtime));
     coordinator.state.lock().await.readiness = ReadinessState::Ready;
     probe::reset();
@@ -278,6 +274,24 @@ async fn exercise_clock_case(case: &ClockCase) {
         ] {
             assert_ne!(value, auto_si.as_str(), "{}", case.name);
         }
+    }
+
+    // 5. The real child-status sampler is on the proven path: no test seam
+    // substitutes its response, so its own stamp must be canonical
+    // fixed-millisecond UTC `Z` text the schema validator accepts.
+    for (component, status) in [
+        ("anyharness", &snapshot.producer_health.anyharness),
+        ("desktop worker", &snapshot.producer_health.desktop_worker),
+    ] {
+        let captured_at = match status {
+            SupportChildProducerStatusV1::Available { captured_at, .. }
+            | SupportChildProducerStatusV1::Omitted { captured_at, .. } => captured_at,
+        };
+        assert_fixed_milliseconds(captured_at, case.name);
+        validate_timestamp(captured_at).unwrap_or_else(|error| {
+            let name = case.name;
+            panic!("{name}: {component} captured_at {captured_at} rejected: {error:?}")
+        });
     }
 
     let terminal = sole_terminal(&coordinator);

--- a/apps/desktop/src-tauri/src/diagnostics_collector/child_status.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/child_status.rs
@@ -6,7 +6,7 @@
 //! 100 ms deadline. Unsupported targets return fixed omissions without
 //! inspecting process state or fabricating a producer snapshot.
 
-use chrono::Utc;
+use chrono::{SecondsFormat, Utc};
 use proliferate_diagnostics_client::ProducerStatusSnapshot;
 
 use crate::{commands::cloud_worker::SharedCloudWorkerState, sidecar::SharedSidecar};
@@ -145,7 +145,9 @@ pub(crate) async fn capture_native_child_statuses(
 
 fn captured(status: PortableChildProducerStatus) -> CapturedChildProducerStatus {
     CapturedChildProducerStatus {
-        captured_at: Utc::now().to_rfc3339(),
+        // Canonical fixed-millisecond UTC `Z` text: the support schema
+        // validator rejects a `+00:00` offset spelling.
+        captured_at: Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
         status,
     }
 }

--- a/apps/desktop/src-tauri/src/diagnostics_collector/producer/support_lifecycle.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/producer/support_lifecycle.rs
@@ -96,11 +96,37 @@ impl SupportSnapshotSubmissionFailedClassificationV1 {
     }
 }
 
+/// The fixed operational enum arguments that attribute exactly one permit
+/// failure stage and reason. They are terminal-only, carry no timestamp,
+/// identifier, path, report content, or raw input, and are the complete set.
+const FAILURE_STAGE_ARGUMENT: &str = "failure_stage";
+const FAILURE_REASON_ARGUMENT: &str = "failure_reason";
+const EXPORT_PERMIT_STAGE: &str = "export_permit";
+const NONCANONICAL_WINDOW_REASON: &str = "noncanonical_window";
+
 pub(crate) struct SupportPreparationOperation(LifecycleOperation);
 
 impl SupportPreparationOperation {
     pub(crate) fn operation_id(&self) -> &str {
         self.0.operation_id()
+    }
+
+    /// Records that the strict export permit refused a noncanonical or nonexact
+    /// support window. Only the coordinator's still-running window rejection
+    /// calls this, and it may be called at most once per operation.
+    pub(crate) fn note_export_permit_noncanonical_window(&mut self) {
+        self.0.append_arguments([
+            TypedArgumentV1 {
+                name: FAILURE_STAGE_ARGUMENT.to_string(),
+                privacy: PrivacyClassificationV1::Operational,
+                value: ArgumentValueV1::Enum(EXPORT_PERMIT_STAGE.to_string()),
+            },
+            TypedArgumentV1 {
+                name: FAILURE_REASON_ARGUMENT.to_string(),
+                privacy: PrivacyClassificationV1::Operational,
+                value: ArgumentValueV1::Enum(NONCANONICAL_WINDOW_REASON.to_string()),
+            },
+        ]);
     }
 
     pub(crate) fn succeeded(self) {

--- a/apps/desktop/src-tauri/src/diagnostics_collector/producer/support_lifecycle_tests.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/producer/support_lifecycle_tests.rs
@@ -197,6 +197,88 @@ fn submission_start_and_terminal_pin_parent_item_and_sole_attempt_argument() {
 }
 
 #[test]
+fn noncanonical_window_detail_rides_only_the_terminal_as_operational_enums() {
+    let producer = producer();
+    let job_id = uuid::Uuid::new_v4().to_string();
+    let mut operation = producer
+        .begin_support_snapshot_preparation(&job_id)
+        .expect("admitted preparation");
+    let operation_id = operation.operation_id().to_string();
+    operation.note_export_permit_noncanonical_window();
+    operation.failed(SupportSnapshotPreparationFailureClassificationV1::PreparationRejected);
+
+    let state = producer.inner.state.lock().expect("producer state");
+    assert_eq!(state.queued.len(), 2, "one start and one terminal");
+    let start = &state.queued[0].record;
+    let terminal = &state.queued[1].record;
+    assert_eq!(start.operation_id, operation_id);
+    assert_eq!(terminal.operation_id, operation_id);
+    assert_eq!(
+        start.lifecycle.as_ref().map(|lifecycle| lifecycle.phase),
+        Some(LifecyclePhaseV1::Started)
+    );
+    assert!(
+        start.arguments.is_empty(),
+        "the started record never carries permit detail"
+    );
+    assert_eq!(
+        terminal.error_classification.as_deref(),
+        Some("preparation_rejected")
+    );
+    assert_eq!(
+        terminal
+            .lifecycle
+            .as_ref()
+            .and_then(|lifecycle| lifecycle.outcome),
+        Some(TerminalOutcomeV1::Rejected)
+    );
+    assert_eq!(terminal.arguments.len(), 2);
+    assert_eq!(terminal.arguments[0].name, "failure_stage");
+    assert_eq!(
+        terminal.arguments[0].privacy,
+        PrivacyClassificationV1::Operational
+    );
+    assert_eq!(
+        terminal.arguments[0].value,
+        ArgumentValueV1::Enum("export_permit".to_string())
+    );
+    assert_eq!(terminal.arguments[1].name, "failure_reason");
+    assert_eq!(
+        terminal.arguments[1].privacy,
+        PrivacyClassificationV1::Operational
+    );
+    assert_eq!(
+        terminal.arguments[1].value,
+        ArgumentValueV1::Enum("noncanonical_window".to_string())
+    );
+    // The lifecycle name and classification catalog are unchanged.
+    assert_eq!(terminal.name, "desktop.support_snapshot.prepare");
+    assert_eq!(terminal.item_id.as_deref(), Some(job_id.as_str()));
+}
+
+#[test]
+fn preparation_terminals_without_the_note_carry_no_permit_detail() {
+    for classification in [
+        SupportSnapshotPreparationFailureClassificationV1::PreparationTimeout,
+        SupportSnapshotPreparationFailureClassificationV1::PreparationRejected,
+        SupportSnapshotPreparationFailureClassificationV1::ScrubFailed,
+        SupportSnapshotPreparationFailureClassificationV1::ManifestInvalid,
+        SupportSnapshotPreparationFailureClassificationV1::StageFailed,
+        SupportSnapshotPreparationFailureClassificationV1::ArtifactVerificationFailed,
+    ] {
+        let producer = producer();
+        producer
+            .begin_support_snapshot_preparation(&uuid::Uuid::new_v4().to_string())
+            .expect("admitted preparation")
+            .failed(classification);
+        let state = producer.inner.state.lock().expect("producer state");
+        for item in &state.queued {
+            assert!(item.record.arguments.is_empty(), "{classification:?}");
+        }
+    }
+}
+
+#[test]
 fn preparation_classifications_have_fixed_outcome_pairs() {
     let producer = producer();
     let cases = [

--- a/apps/desktop/src-tauri/src/diagnostics_collector/support_export.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/support_export.rs
@@ -28,6 +28,24 @@ use validation::SupportExportAccumulator;
 const SUPPORT_EXPORT_BYTES: u64 = 16_777_216;
 const SUPPORT_WINDOW_SECONDS: i64 = 15 * 60;
 
+/// The closed set of reasons the coordinator-only issuance seam can refuse to
+/// mint a support export permit. It is crate-private on purpose: no Tauri
+/// command, renderer bridge, SDK type, collector protocol message, or server
+/// payload may carry it. Variants are evaluated in declaration order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SupportExportIssuanceError {
+    /// `preparation_id` is not a canonical lowercase UUID string.
+    InvalidPreparationId,
+    /// The supplied permit deadline is not strictly later than now.
+    ExpiredDeadline,
+    /// An endpoint is not exact fixed-millisecond UTC `Z` text, cannot parse,
+    /// or the interval is not exactly 900 seconds.
+    NoncanonicalWindow,
+    /// The internally constructed request failed protocol validation or an
+    /// exact support-request invariant.
+    RequestInvariant,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SupportExportError {
     InvalidRequest,
@@ -84,7 +102,7 @@ pub(crate) fn issue_support_export_for_coordinator(
     source_time_from: String,
     source_time_to: String,
     expires_at: Instant,
-) -> Result<SupportExportInvocation, SupportExportError> {
+) -> Result<SupportExportInvocation, SupportExportIssuanceError> {
     let (request, permit) =
         SupportExportPermit::issue(preparation_id, source_time_from, source_time_to, expires_at)?;
     Ok(SupportExportInvocation { request, permit })
@@ -96,16 +114,32 @@ impl SupportExportPermit {
         source_time_from: String,
         source_time_to: String,
         expires_at: Instant,
-    ) -> Result<(SupportExportRequest, Self), SupportExportError> {
-        require_canonical_uuid(preparation_id).map_err(|_| SupportExportError::InvalidRequest)?;
-        if expires_at <= Instant::now()
-            || !is_exact_support_window(&source_time_from, &source_time_to)
-        {
-            return Err(SupportExportError::InvalidRequest);
+    ) -> Result<(SupportExportRequest, Self), SupportExportIssuanceError> {
+        require_canonical_uuid(preparation_id)
+            .map_err(|_| SupportExportIssuanceError::InvalidPreparationId)?;
+        if expires_at <= Instant::now() {
+            return Err(SupportExportIssuanceError::ExpiredDeadline);
+        }
+        if !is_exact_support_window(&source_time_from, &source_time_to) {
+            return Err(SupportExportIssuanceError::NoncanonicalWindow);
         }
         let authorization_id = uuid::Uuid::new_v4().to_string();
+        #[cfg(test)]
+        let collector = probe::apply_request_fault(exact_request(
+            authorization_id.clone(),
+            source_time_from,
+            source_time_to,
+        ));
+        #[cfg(not(test))]
         let collector = exact_request(authorization_id.clone(), source_time_from, source_time_to);
-        validate_support_request(&collector, &authorization_id)?;
+        validate_support_request(&collector, &authorization_id)
+            .map_err(|_| SupportExportIssuanceError::RequestInvariant)?;
+        #[cfg(test)]
+        probe::record(
+            probe::IssuanceStage::Issued,
+            collector.filters.source_time_from.as_deref().unwrap_or(""),
+            collector.filters.source_time_to.as_deref().unwrap_or(""),
+        );
         let request = SupportExportRequest {
             collector: collector.clone(),
             preparation_id: preparation_id.to_owned(),
@@ -137,6 +171,22 @@ impl SupportExportPermit {
             .map_err(|_| SupportExportError::InvalidAuthority)?;
         validate_support_request(&request.collector, &self.authorization_id)
             .map_err(|_| SupportExportError::InvalidAuthority)?;
+        #[cfg(test)]
+        probe::record(
+            probe::IssuanceStage::Consumed,
+            request
+                .collector
+                .filters
+                .source_time_from
+                .as_deref()
+                .unwrap_or(""),
+            request
+                .collector
+                .filters
+                .source_time_to
+                .as_deref()
+                .unwrap_or(""),
+        );
         Ok(ConsumedSupportExportPermit {
             _authorization_id: self.authorization_id,
             _preparation_id: self.preparation_id,
@@ -539,6 +589,82 @@ fn require_canonical_uuid(value: &str) -> Result<(), ()> {
 }
 
 mod validation;
+
+/// Test-only observation of the real issuance seam. It exists so a coordinator
+/// proof can assert that the real permit accepted and consumed the exact
+/// request window bytes, and so the post-construction request-invariant branch
+/// can be forced through the same production validation function. It cannot
+/// exist in a release build and exposes no raw request constructor.
+#[cfg(test)]
+pub(crate) mod probe {
+    use std::cell::Cell;
+    use std::sync::{Mutex, OnceLock};
+
+    use proliferate_diagnostics_protocol::v1::types::ExportRequestV1;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(crate) enum IssuanceStage {
+        Issued,
+        Consumed,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub(crate) struct ObservedIssuance {
+        pub(crate) stage: IssuanceStage,
+        pub(crate) source_time_from: String,
+        pub(crate) source_time_to: String,
+    }
+
+    thread_local! {
+        static REQUEST_FAULT: Cell<bool> = const { Cell::new(false) };
+    }
+
+    fn observations() -> &'static Mutex<Vec<ObservedIssuance>> {
+        static OBSERVATIONS: OnceLock<Mutex<Vec<ObservedIssuance>>> = OnceLock::new();
+        OBSERVATIONS.get_or_init(|| Mutex::new(Vec::new()))
+    }
+
+    pub(crate) fn record(stage: IssuanceStage, source_time_from: &str, source_time_to: &str) {
+        if let Ok(mut observations) = observations().lock() {
+            observations.push(ObservedIssuance {
+                stage,
+                source_time_from: source_time_from.to_owned(),
+                source_time_to: source_time_to.to_owned(),
+            });
+        }
+    }
+
+    pub(crate) fn reset() {
+        if let Ok(mut observations) = observations().lock() {
+            observations.clear();
+        }
+    }
+
+    pub(crate) fn observed() -> Vec<ObservedIssuance> {
+        observations()
+            .lock()
+            .map(|observations| observations.clone())
+            .unwrap_or_default()
+    }
+
+    /// Arms a same-thread fault that corrupts the internally constructed
+    /// request after `exact_request` returns, so the production
+    /// `validate_support_request` call decides the outcome.
+    pub(crate) fn arm_request_fault() {
+        REQUEST_FAULT.with(|armed| armed.set(true));
+    }
+
+    pub(crate) fn disarm_request_fault() {
+        REQUEST_FAULT.with(|armed| armed.set(false));
+    }
+
+    pub(super) fn apply_request_fault(mut request: ExportRequestV1) -> ExportRequestV1 {
+        if REQUEST_FAULT.with(|armed| armed.get()) {
+            request.record_limit -= 1;
+        }
+        request
+    }
+}
 
 #[cfg(test)]
 #[path = "support_export_tests.rs"]

--- a/apps/desktop/src-tauri/src/diagnostics_collector/support_export.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/support_export.rs
@@ -29,20 +29,17 @@ const SUPPORT_EXPORT_BYTES: u64 = 16_777_216;
 const SUPPORT_WINDOW_SECONDS: i64 = 15 * 60;
 
 /// The closed set of reasons the coordinator-only issuance seam can refuse to
-/// mint a support export permit. It is crate-private on purpose: no Tauri
-/// command, renderer bridge, SDK type, collector protocol message, or server
-/// payload may carry it. Variants are evaluated in declaration order.
+/// mint a support export permit. Crate-private on purpose: no Tauri command,
+/// renderer bridge, SDK type, collector protocol message, or server payload may
+/// carry it. Variants are evaluated in declaration order: a non-canonical
+/// `preparation_id`, a deadline not strictly later than now, a window that is
+/// not exact fixed-millisecond UTC `Z` text exactly 900 seconds wide, then the
+/// internally constructed request failing an exact support-request invariant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SupportExportIssuanceError {
-    /// `preparation_id` is not a canonical lowercase UUID string.
     InvalidPreparationId,
-    /// The supplied permit deadline is not strictly later than now.
     ExpiredDeadline,
-    /// An endpoint is not exact fixed-millisecond UTC `Z` text, cannot parse,
-    /// or the interval is not exactly 900 seconds.
     NoncanonicalWindow,
-    /// The internally constructed request failed protocol validation or an
-    /// exact support-request invariant.
     RequestInvariant,
 }
 
@@ -124,14 +121,11 @@ impl SupportExportPermit {
             return Err(SupportExportIssuanceError::NoncanonicalWindow);
         }
         let authorization_id = uuid::Uuid::new_v4().to_string();
-        #[cfg(test)]
-        let collector = probe::apply_request_fault(exact_request(
-            authorization_id.clone(),
-            source_time_from,
-            source_time_to,
-        ));
-        #[cfg(not(test))]
         let collector = exact_request(authorization_id.clone(), source_time_from, source_time_to);
+        // Test-only corruption of the already-constructed request, so the
+        // production validation call below still decides the outcome.
+        #[cfg(test)]
+        let collector = probe::apply_request_fault(collector);
         validate_support_request(&collector, &authorization_id)
             .map_err(|_| SupportExportIssuanceError::RequestInvariant)?;
         #[cfg(test)]
@@ -590,81 +584,8 @@ fn require_canonical_uuid(value: &str) -> Result<(), ()> {
 
 mod validation;
 
-/// Test-only observation of the real issuance seam. It exists so a coordinator
-/// proof can assert that the real permit accepted and consumed the exact
-/// request window bytes, and so the post-construction request-invariant branch
-/// can be forced through the same production validation function. It cannot
-/// exist in a release build and exposes no raw request constructor.
 #[cfg(test)]
-pub(crate) mod probe {
-    use std::cell::Cell;
-    use std::sync::{Mutex, OnceLock};
-
-    use proliferate_diagnostics_protocol::v1::types::ExportRequestV1;
-
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub(crate) enum IssuanceStage {
-        Issued,
-        Consumed,
-    }
-
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    pub(crate) struct ObservedIssuance {
-        pub(crate) stage: IssuanceStage,
-        pub(crate) source_time_from: String,
-        pub(crate) source_time_to: String,
-    }
-
-    thread_local! {
-        static REQUEST_FAULT: Cell<bool> = const { Cell::new(false) };
-    }
-
-    fn observations() -> &'static Mutex<Vec<ObservedIssuance>> {
-        static OBSERVATIONS: OnceLock<Mutex<Vec<ObservedIssuance>>> = OnceLock::new();
-        OBSERVATIONS.get_or_init(|| Mutex::new(Vec::new()))
-    }
-
-    pub(crate) fn record(stage: IssuanceStage, source_time_from: &str, source_time_to: &str) {
-        if let Ok(mut observations) = observations().lock() {
-            observations.push(ObservedIssuance {
-                stage,
-                source_time_from: source_time_from.to_owned(),
-                source_time_to: source_time_to.to_owned(),
-            });
-        }
-    }
-
-    pub(crate) fn reset() {
-        if let Ok(mut observations) = observations().lock() {
-            observations.clear();
-        }
-    }
-
-    pub(crate) fn observed() -> Vec<ObservedIssuance> {
-        observations()
-            .lock()
-            .map(|observations| observations.clone())
-            .unwrap_or_default()
-    }
-
-    /// Arms a same-thread fault that corrupts the internally constructed
-    /// request after `exact_request` returns, so the production
-    /// `validate_support_request` call decides the outcome.
-    pub(crate) fn arm_request_fault() {
-        REQUEST_FAULT.with(|armed| armed.set(true));
-    }
-
-    pub(crate) fn disarm_request_fault() {
-        REQUEST_FAULT.with(|armed| armed.set(false));
-    }
-
-    pub(super) fn apply_request_fault(mut request: ExportRequestV1) -> ExportRequestV1 {
-        if REQUEST_FAULT.with(|armed| armed.get()) {
-            request.record_limit -= 1;
-        }
-        request
-    }
-}
+pub(crate) use tests::probe;
 
 #[cfg(test)]
 #[path = "support_export_tests.rs"]

--- a/apps/desktop/src-tauri/src/diagnostics_collector/support_export_coordinator_tests.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/support_export_coordinator_tests.rs
@@ -14,12 +14,15 @@ async fn minimal_support_snapshot_coordinator(
     preparation_id: &str,
     cancellation: watch::Receiver<bool>,
 ) -> Result<ValidatedSupportExport, SupportExportError> {
+    // Issuance now fails with the typed private cause; execution-time failures
+    // keep using `SupportExportError`.
     let invocation = issue_support_export_for_coordinator(
         preparation_id,
         FROM.to_string(),
         TO.to_string(),
         Instant::now() + Duration::from_secs(25),
-    )?;
+    )
+    .map_err(|_| SupportExportError::InvalidRequest)?;
     supervisor
         .export_support_snapshot(invocation, cancellation)
         .await

--- a/apps/desktop/src-tauri/src/diagnostics_collector/support_export_tests.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/support_export_tests.rs
@@ -1,3 +1,79 @@
+/// Test-only observation of the real issuance seam. It exists so a coordinator
+/// proof can assert that the real permit accepted and consumed the exact
+/// request window bytes, and so the post-construction request-invariant branch
+/// can be forced through the same production validation function. It cannot
+/// exist in a release build and exposes no raw request constructor.
+#[cfg(test)]
+pub(crate) mod probe {
+    use std::cell::Cell;
+    use std::sync::{Mutex, OnceLock};
+
+    use proliferate_diagnostics_protocol::v1::types::ExportRequestV1;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(crate) enum IssuanceStage {
+        Issued,
+        Consumed,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub(crate) struct ObservedIssuance {
+        pub(crate) stage: IssuanceStage,
+        pub(crate) source_time_from: String,
+        pub(crate) source_time_to: String,
+    }
+
+    thread_local! {
+        static REQUEST_FAULT: Cell<bool> = const { Cell::new(false) };
+    }
+
+    fn observations() -> &'static Mutex<Vec<ObservedIssuance>> {
+        static OBSERVATIONS: OnceLock<Mutex<Vec<ObservedIssuance>>> = OnceLock::new();
+        OBSERVATIONS.get_or_init(|| Mutex::new(Vec::new()))
+    }
+
+    pub(crate) fn record(stage: IssuanceStage, source_time_from: &str, source_time_to: &str) {
+        if let Ok(mut observations) = observations().lock() {
+            observations.push(ObservedIssuance {
+                stage,
+                source_time_from: source_time_from.to_owned(),
+                source_time_to: source_time_to.to_owned(),
+            });
+        }
+    }
+
+    pub(crate) fn reset() {
+        if let Ok(mut observations) = observations().lock() {
+            observations.clear();
+        }
+    }
+
+    pub(crate) fn observed() -> Vec<ObservedIssuance> {
+        observations()
+            .lock()
+            .map(|observations| observations.clone())
+            .unwrap_or_default()
+    }
+
+    /// Arms a same-thread fault that corrupts the internally constructed
+    /// request after `exact_request` returns, so the production
+    /// `validate_support_request` call decides the outcome.
+    pub(crate) fn arm_request_fault() {
+        REQUEST_FAULT.with(|armed| armed.set(true));
+    }
+
+    pub(crate) fn disarm_request_fault() {
+        REQUEST_FAULT.with(|armed| armed.set(false));
+    }
+
+    pub(crate) fn apply_request_fault(mut request: ExportRequestV1) -> ExportRequestV1 {
+        if REQUEST_FAULT.with(|armed| armed.get()) {
+            request.record_limit -= 1;
+        }
+        request
+    }
+}
+
 use proliferate_diagnostics_protocol::v1::limits::{CURRENT_SCHEMA_VERSION, MAX_EXPORT_RECORDS};
 use proliferate_diagnostics_protocol::v1::types::{
     CollectorAcceptedRecordV1, ComponentV1, ExportManifestV1, ExportPurposeV1, ExportStreamFrameV1,

--- a/apps/desktop/src-tauri/src/diagnostics_collector/support_export_tests.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/support_export_tests.rs
@@ -127,36 +127,172 @@ fn permit_is_exact_request_preparation_and_deadline_bound() {
     ));
 }
 
+fn issue_cause(
+    preparation_id: &str,
+    from: &str,
+    to: &str,
+    expires_at: Instant,
+) -> SupportExportIssuanceError {
+    SupportExportPermit::issue(
+        preparation_id,
+        from.to_string(),
+        to.to_string(),
+        expires_at,
+    )
+    .err()
+    .expect("issuance is refused")
+}
+
+fn live() -> Instant {
+    Instant::now() + Duration::from_secs(25)
+}
+
+fn expired() -> Instant {
+    Instant::now() - Duration::from_secs(1)
+}
+
 #[test]
-fn issuer_rejects_noncanonical_preparation_and_nonexact_window() {
-    assert!(SupportExportPermit::issue(
+fn issuer_names_the_exact_noncanonical_window_cause_for_every_negative_window() {
+    let cases = [
+        ("missing milliseconds", "2026-08-10T13:45:00Z", "2026-08-10T14:00:00Z"),
+        (
+            "six fractional digits",
+            "2026-08-10T13:45:00.000000Z",
+            "2026-08-10T14:00:00.000000Z",
+        ),
+        (
+            "nine fractional digits",
+            "2026-08-10T13:45:00.000000000Z",
+            "2026-08-10T14:00:00.000000000Z",
+        ),
+        (
+            "non-UTC offset",
+            "2026-08-10T06:45:00.000-07:00",
+            "2026-08-10T07:00:00.000-07:00",
+        ),
+        ("malformed from", "not-a-timestamp", TO),
+        ("malformed to", FROM, "2026-08-10T14:00:00"),
+        ("inverted", TO, FROM),
+        ("short by one millisecond", "2026-08-10T13:45:00.001Z", TO),
+        ("long by one millisecond", "2026-08-10T13:44:59.999Z", TO),
+        ("short by one second", "2026-08-10T13:45:01.000Z", TO),
+        ("long by one second", "2026-08-10T13:44:59.000Z", TO),
+        ("zero duration", FROM, FROM),
+    ];
+    for (name, from, to) in cases {
+        assert_eq!(
+            issue_cause(&uuid::Uuid::new_v4().to_string(), from, to, live()),
+            SupportExportIssuanceError::NoncanonicalWindow,
+            "{name}"
+        );
+    }
+}
+
+#[test]
+fn issuer_names_the_exact_identifier_deadline_and_invariant_causes() {
+    for identifier in [
         "not-a-uuid",
+        "",
+        "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA",
+        "  6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+    ] {
+        assert_eq!(
+            issue_cause(identifier, FROM, TO, live()),
+            SupportExportIssuanceError::InvalidPreparationId,
+            "{identifier}"
+        );
+    }
+    assert_eq!(
+        issue_cause(&uuid::Uuid::new_v4().to_string(), FROM, TO, expired()),
+        SupportExportIssuanceError::ExpiredDeadline
+    );
+
+    // The private test-only fault corrupts the internally constructed request
+    // after `exact_request` returns, so the production validation function
+    // decides the outcome. No raw request constructor is exposed.
+    probe::arm_request_fault();
+    let cause = issue_cause(&uuid::Uuid::new_v4().to_string(), FROM, TO, live());
+    probe::disarm_request_fault();
+    assert_eq!(cause, SupportExportIssuanceError::RequestInvariant);
+    assert!(SupportExportPermit::issue(
+        &uuid::Uuid::new_v4().to_string(),
         FROM.to_string(),
         TO.to_string(),
-        Instant::now() + Duration::from_secs(25),
+        live(),
     )
-    .is_err());
-    assert!(SupportExportPermit::issue(
-        &uuid::Uuid::new_v4().to_string(),
-        "2026-08-10T13:44:59.000Z".to_string(),
-        TO.to_string(),
-        Instant::now() + Duration::from_secs(25),
-    )
-    .is_err());
-    assert!(SupportExportPermit::issue(
-        &uuid::Uuid::new_v4().to_string(),
-        "2026-08-10T06:45:00.000-07:00".to_string(),
-        "2026-08-10T07:00:00.000-07:00".to_string(),
-        Instant::now() + Duration::from_secs(25),
-    )
-    .is_err());
-    assert!(SupportExportPermit::issue(
-        &uuid::Uuid::new_v4().to_string(),
-        "2026-08-10T13:45:00Z".to_string(),
-        "2026-08-10T14:00:00Z".to_string(),
-        Instant::now() + Duration::from_secs(25),
-    )
-    .is_err());
+    .is_ok());
+}
+
+#[test]
+fn mixed_invalid_inputs_pin_the_frozen_evaluation_order() {
+    // Identifier beats deadline, window, and invariant.
+    probe::arm_request_fault();
+    assert_eq!(
+        issue_cause("not-a-uuid", "not-a-timestamp", "also-not", expired()),
+        SupportExportIssuanceError::InvalidPreparationId
+    );
+    // Deadline beats window and invariant.
+    assert_eq!(
+        issue_cause(
+            &uuid::Uuid::new_v4().to_string(),
+            "not-a-timestamp",
+            "also-not",
+            expired()
+        ),
+        SupportExportIssuanceError::ExpiredDeadline
+    );
+    // Window beats invariant.
+    assert_eq!(
+        issue_cause(
+            &uuid::Uuid::new_v4().to_string(),
+            "not-a-timestamp",
+            "also-not",
+            live()
+        ),
+        SupportExportIssuanceError::NoncanonicalWindow
+    );
+    // Only the invariant remains.
+    let cause = issue_cause(&uuid::Uuid::new_v4().to_string(), FROM, TO, live());
+    probe::disarm_request_fault();
+    assert_eq!(cause, SupportExportIssuanceError::RequestInvariant);
+}
+
+#[test]
+fn the_coordinator_entrypoint_carries_the_same_typed_cause() {
+    assert_eq!(
+        issue_support_export_for_coordinator(
+            "not-a-uuid",
+            FROM.to_string(),
+            TO.to_string(),
+            live(),
+        )
+        .err(),
+        Some(SupportExportIssuanceError::InvalidPreparationId)
+    );
+    assert_eq!(
+        issue_support_export_for_coordinator(
+            &uuid::Uuid::new_v4().to_string(),
+            "2026-08-10T13:45:00Z".to_string(),
+            "2026-08-10T14:00:00Z".to_string(),
+            live(),
+        )
+        .err(),
+        Some(SupportExportIssuanceError::NoncanonicalWindow)
+    );
+}
+
+#[test]
+fn the_strict_window_validator_still_accepts_only_fixed_millisecond_utc() {
+    assert!(is_exact_support_window(FROM, TO));
+    assert!(is_exact_support_window(
+        "2026-08-10T13:45:00.123Z",
+        "2026-08-10T14:00:00.123Z"
+    ));
+    assert!(!is_exact_support_window("2026-08-10T13:45:00Z", "2026-08-10T14:00:00Z"));
+    assert!(!is_exact_support_window(
+        "2026-08-10T13:45:00.123456Z",
+        "2026-08-10T14:00:00.123456Z"
+    ));
 }
 
 #[test]

--- a/guides/debugging/support-reports.md
+++ b/guides/debugging/support-reports.md
@@ -480,6 +480,12 @@ workflow.
 - Preserve the report evidence, stop assuming retries will repair the payload,
   and fix client validation/classification.
 
+### Preparation fails before any bundle exists
+
+- Read the `desktop.support_snapshot.prepare` terminal record for the run. If it carries `failure_stage=export_permit` and `failure_reason=noncanonical_window`, the export permit refused the window the producer built, so nothing was ever captured, staged, or uploaded and there is no row or object to inspect.
+- Those two arguments only ever appear together, only on the terminal record, and only when the preparation was still running. A terminal without them means either the preparation succeeded or it failed for some other cause, including a cancel, a deadline, or an abandonment that raced ahead of the permit.
+- The window the producer emits is one truncated raw UTC clock read spelled with a fixed three-digit millisecond fraction and a trailing `Z`, with `captured_at` byte-identical to `source_time_to` and `source_time_from` exactly 900 seconds earlier. A noncanonical-window terminal means that invariant broke at the producer. Do not look for a fix in the SDK or the permit: neither normalizes, by design.
+
 ### Completed; no Slack
 
 - Capture succeeded.

--- a/specs/OBSERVABILITY.md
+++ b/specs/OBSERVABILITY.md
@@ -85,6 +85,8 @@ retention, or a product result. Server log routing, Sentry, PostHog,
 and anonymous telemetry are unchanged. The approved boundary and slice registry live in
 [`../adrs/2026-08-10-rust-observability.md`](../adrs/2026-08-10-rust-observability.md).
 
+Support snapshot preparation keeps that one-started-one-terminal shape and never adds an event to describe a failure. When the export permit refuses a preparation because the window is not canonical, and only while the preparation is still running rather than already interrupted, the existing `desktop.support_snapshot.prepare` operation appends exactly two bounded arguments to its terminal record: `failure_stage=export_permit` and `failure_reason=noncanonical_window`. Both are `Operational` enum values from a closed set. Interruption is first-wins, so a cancelled, deadlined, or abandoned preparation carries neither argument even if the permit would also have refused it, and every other failure cause carries neither argument. No timestamp, identifier, path, or window content ever rides these arguments, and the started record never carries them.
+
 ## Instrumenting a new feature
 
 Choose by what actually happened, not by convenience — do not `raise` to flag

--- a/specs/codebase/systems/product/support/README.md
+++ b/specs/codebase/systems/product/support/README.md
@@ -182,6 +182,8 @@ Every one of those values is spelled as UTC with a fixed three-digit millisecond
 
 The permit does not normalize. `SupportExportPermit::issue` refuses any window that is not already exact, and `is_exact_support_window` stays strict: UTC offset zero, byte equality against a fixed-millisecond re-spelling, and exactly 900 seconds between the endpoints. The producer is the only place canonical spelling is created, so a drifting producer fails loudly at issuance instead of being silently repaired downstream.
 
+Fixing the producer is not the same as the window being release-complete: it guarantees the spelling the coordinator itself creates, while any other component that stamps a support timestamp remains its own source of truth, so a released build is only correct once every such producer emits this same canonical spelling.
+
 Degradation removes candidate groups from tier 8 upward until the exact
 uncompressed bytes fit the cap, oldest first within a tier, and a lifecycle
 started/terminal pair is admitted or removed atomically. The fixed tiers:

--- a/specs/codebase/systems/product/support/README.md
+++ b/specs/codebase/systems/product/support/README.md
@@ -174,6 +174,14 @@ file and why.
   the limits in force, and `removed_by_tier` degradation accounting. Absence
   is always explained, never silent.
 
+### Window timestamp spelling
+
+`begin_preparation` reads the raw UTC clock exactly once per preparation and truncates that read toward the start of the current millisecond. It never rounds, so the emitted instant is never later than the instant observed. That single truncated read owns all three window values: `captured_at`, `source_time_to`, and `source_time_from`, which is exactly 900 seconds earlier.
+
+Every one of those values is spelled as UTC with a fixed three-digit millisecond fraction and a trailing `Z`, for example `2026-08-12T12:00:00.000Z`. The spelling is fixed-width regardless of the sub-second precision the platform clock happens to offer, so a whole-second read is `.000Z` rather than a bare `Z` and a nanosecond-precision read is truncated to three digits rather than carrying six or nine. `captured_at` and `source_time_to` are byte-for-byte identical, which is what the aggregate validator compares.
+
+The permit does not normalize. `SupportExportPermit::issue` refuses any window that is not already exact, and `is_exact_support_window` stays strict: UTC offset zero, byte equality against a fixed-millisecond re-spelling, and exactly 900 seconds between the endpoints. The producer is the only place canonical spelling is created, so a drifting producer fails loudly at issuance instead of being silently repaired downstream.
+
 Degradation removes candidate groups from tier 8 upward until the exact
 uncompressed bytes fit the cap, oldest first within a tier, and a lifecycle
 started/terminal pair is admitted or removed atomically. The fixed tiers:

--- a/specs/sdk.md
+++ b/specs/sdk.md
@@ -115,6 +115,7 @@ not move product workflows into either SDK.
   API for non-contract client helpers, reducer state, or streaming helpers.
 - Low-level streaming helpers and transcript reducers stay in
   `@anyharness/sdk`.
+- Support-window timestamp handling in `@anyharness/sdk` accepts only canonical-equivalent UTC spellings and sends canonical `Z` text on the wire, retaining 3, 6, or 9 digit fractions as given. It is not a compensation layer for a caller that emits a non-canonical window: a producer that needs fixed-millisecond output fixes that at the producer, and this normalization stays as it is.
 - Generic React providers, query hooks, mutation hooks, and query keys stay in
   `@anyharness/sdk-react`.
 


### PR DESCRIPTION
## Summary

REL-09B, the product half of the REL-09 support snapshot timestamp defect.

- `begin_preparation` reads the raw UTC clock exactly once per preparation and truncates that read toward the start of the current millisecond. It never rounds, so the emitted instant is never later than the observed instant.
- That one truncated read owns all three window values. `captured_at` and `source_time_to` are byte-for-byte identical, and `source_time_from` is exactly 900 seconds earlier. All three are spelled as UTC with a fixed three-digit millisecond fraction and a trailing `Z`, so a whole-second read is `.000Z` and a nanosecond read is truncated to three digits.
- The permit still refuses to normalize. `is_exact_support_window` is unchanged and stays strict, and no SDK normalization changed. What did change is that the coordinator-only issuance seam now returns a private closed `SupportExportIssuanceError` (`InvalidPreparationId`, `ExpiredDeadline`, `NoncanonicalWindow`, `RequestInvariant`, in that frozen evaluation order) instead of one opaque error.
- Docs updated for the canonical window spelling, the new terminal signal, and the rule that the SDK is not a compensation layer for a drifting producer.

## Observability

No new event and no new operation. A preparation that is **still running** when the permit refuses a noncanonical window appends exactly two arguments to the terminal record of the existing `desktop.support_snapshot.prepare` operation: `failure_stage=export_permit` and `failure_reason=noncanonical_window`, both `Operational`-classified enum values from a closed set. The started record never carries them, and no timestamp, identifier, path, or window content ever rides them.

Interruption is first-wins. `PreparationControl` is checked before issuance and again before mapping a capture failure, so a cancelled, deadlined, or abandoned preparation carries neither argument even when the permit would also have refused it. Every other failure cause carries neither argument.

## Testing

Tested commit: `22fb251b22e3c9c2f5f4e1554dc081540b6e445a`, rebased onto `b024f9814`. Every receipt below was captured on this exact tree after both negative controls were reverted.

| Command | Result | Duration | Executed tests |
| --- | --- | --- | --- |
| `cargo test -p proliferate diagnostics::support_snapshot::coordinator::` | pass | 21.559s | 63 passed, 0 failed, 2 ignored (525 filtered out) |
| `cargo test -p proliferate diagnostics_collector::support_export::` | pass | 18.655s | 23 passed, 0 failed (567 filtered out) |
| `cargo test -p proliferate diagnostics_collector::producer::support_lifecycle_tests::` | pass | 16.567s | 15 passed, 0 failed (575 filtered out) |
| `pnpm -C anyharness/sdk exec vitest run src/client/sessions-support-windows.test.ts` | pass | 1.006s | 43 passed (1 file) |
| `pnpm -C anyharness/sdk run typecheck` | pass | 0.779s | `tsc --noEmit` clean |
| `python3 scripts/check_docs.py` | pass | 0.491s | 229 Markdown files checked |
| `python3 scripts/check_max_lines.py` | pass | 0.754s | whole-repo scan, no ratchet or exception entry added |

The success proof is genuinely end to end. A parent test spawns a child test process with a private `HOME` and drives each clock case through real `begin_preparation`, the real permit issue and consume path (observed through a test-only probe that records the exact window bytes at both stages), real `finish_preparation`, and a real `store.read_verified` whose bytes are parsed back as `SupportSnapshotV3` and asserted against the expected window. No `insert_awaiting_preparation`, no `empty_capture`, and no hand-built preparation output or artifact JSON anywhere in it. Clock cases: whole second, `.123`, `.123456`, `.999999999`, and a minute/date boundary at `2026-09-01T00:00:00.000999Z`.

Negative controls, both run and both restored:

- Reverting the window fix in `coordinator/preparation.rs` to `SecondsFormat::AutoSi` with no truncation made the end-to-end fixture fail with `whole second: begin_preparation rejected: support_snapshot_preparation_rejected` (`test result: FAILED. 61 passed; 1 failed`), the permit correctly refusing the bare-`Z` window the old code produced.
- Reverting the child-status fix in `diagnostics_collector/child_status.rs` back to `Utc::now().to_rfc3339()` made the same fixture fail with `whole second: finish_preparation failed: support_snapshot_manifest_invalid` (`test result: FAILED. 5 passed; 1 failed`), which is the schema validator rejecting the `+00:00` offset spelling during assembly.

Both files were restored from pre-patch copies and the receipts above were captured afterwards.

## Touched files

- `apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/preparation.rs`
- `apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/capture.rs`
- `apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/terminal.rs`
- `apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/runtime.rs`
- `apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/fake_runtime.rs`
- `apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/mod.rs`
- `apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/timestamp_tests.rs` (new)
- `apps/desktop/src-tauri/src/diagnostics_collector/child_status.rs`
- `Cargo.lock` (one stale-base version line, see below)
- `apps/desktop/src-tauri/src/diagnostics_collector/support_export.rs`
- `apps/desktop/src-tauri/src/diagnostics_collector/support_export_tests.rs`
- `apps/desktop/src-tauri/src/diagnostics_collector/support_export_coordinator_tests.rs`
- `apps/desktop/src-tauri/src/diagnostics_collector/producer/support_lifecycle.rs`
- `apps/desktop/src-tauri/src/diagnostics_collector/producer/support_lifecycle_tests.rs`
- `apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/capture_tests.rs`
- `anyharness/sdk/src/client/sessions-support-windows.test.ts`
- `specs/codebase/systems/product/support/README.md`
- `specs/OBSERVABILITY.md`
- `specs/sdk.md`
- `guides/debugging/support-reports.md`

No REL-09A-owned file changed. No SDK source or generated file changed, only the SDK test. `Cargo.lock` carries one line (`proliferate 0.4.16 -> 0.4.17`): the base ships a stale lock relative to `apps/desktop/src-tauri/Cargo.toml`, so any mandated `cargo test` regenerates it; reverting would leave the branch re-dirtying on every build (review finding REL09-R4-001).

## Deviations from the frozen write scope

1. `apps/desktop/src-tauri/src/diagnostics_collector/support_export_coordinator_tests.rs` is not in the handoff's exhaustive write scope but needed a one-line mechanical compile fix (`.map_err(|_| SupportExportError::InvalidRequest)?`) after the issuance signature changed. The alternative, an `impl From<SupportExportIssuanceError> for SupportExportError`, was rejected deliberately because it would invite lossy erasure of the typed cause in production code.
2. `apps/desktop/src-tauri/src/diagnostics_collector/child_status.rs` was folded in under a founder scope amendment (Pablo, 2026-08-18), resolving review finding REL09-R2-002. The sampler stamped `Utc::now().to_rfc3339()`, whose `+00:00` offset spelling the support schema validator rejects, so every real capture failed assembly with `support_snapshot_manifest_invalid`. The diff is the timestamp spelling only: `to_rfc3339_opts(SecondsFormat::Millis, true)`. Because the producer is now correct, the test-only child-status override seam this PR had introduced was removed outright, so the end-to-end proof runs on the real child-status path and additionally asserts each child `captured_at` is exact `.mmmZ` text accepted by the schema's own `validate_timestamp`.
3. `apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/capture_tests.rs`, an existing in-scope coordinator test file, now also holds the before-any-task capture rejection case (review finding REL09-R2-004). Keeping it in `timestamp_tests.rs` would have pushed that file past the 600-line repo cap.

## Review findings from round 2

- REL09-R2-001 (blocker, repo shape red): `support_export.rs` 679 to 600, `coordinator/preparation.rs` 616 to 600, `sessions-support-windows.test.ts` 706 to 600. The test-only issuance probe moved into the in-scope `support_export_tests.rs` and is re-exported, the millisecond truncation helper moved to the coordinator's clock module `runtime.rs`, the new capture case moved to `capture_tests.rs`, and the SDK window cases consolidated into one table-driven case that also absorbed the former UTC-suffix-variant test. No `ratchets.toml` or exceptions entry was added, and no new file outside the write scope was created.
- REL09-R2-002: fixed under the founder scope amendment, see deviation 2.
- REL09-R2-003: the support README now states that fixing this producer is not the same as the window being release-complete.
- REL09-R2-004: `capture::tests::a_genuinely_noncanonical_window_is_refused_before_any_capture_task_starts` drives four genuinely noncanonical windows through the real `capture_native_support_evidence` and proves the permit refuses each before any export, health, child, or file task spawns, asserting `active_work() == 0` and an empty issuance probe.
- REL09-R2-005: the vacuous `if let Some(manifest)` branch is gone. Asserting presence provably fails, because this fixture runs with a private `HOME` and no packaged collector process, so the manifest is absent by construction. It now asserts absence with that reason documented, and the exact request window bytes are proven by the issuance probe instead.
- REL09-R2-006: `truncate_to_milliseconds` clamps a chrono leap-second subsecond read to 999 and documents why.

Recorded follow-ups from the final review (non-blocking): REL09-R4-002 orphaned doc comment + stray blank line in `fake_runtime.rs`, REL09-R4-003 vestigial `let children = real_children;` rebinding in `capture.rs`, REL09-R3-002 README boundary phrasing, REL09-R3-003 three files at exactly the 600-line cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

