### PR TITLE
fix(product): round-trip home effort overrides by normalized control key (PRO-321)

### DIFF
--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-launch-controls.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-launch-controls.test.tsx
@@ -40,10 +40,11 @@ vi.mock("#product/stores/preferences/user-preferences-store", () => ({
 describe("useHomeNextLaunchControls", () => {
   afterEach(cleanup);
 
-  // Regression: codex's effort control carries rawConfigId "reasoning_effort"
-  // while overrides are read back through the NORMALIZED control key. Storing
-  // the selection under the raw id made the home stepper snap back to the
-  // default for codex (claude worked only because its raw id IS "effort").
+  // Regression: the "codex" agent kind's effort control carries rawConfigId
+  // "reasoning_effort" while overrides are read back through the NORMALIZED
+  // control key. Storing the selection under the raw id made the home stepper
+  // snap back to the default (kinds whose raw id IS "effort" round-tripped
+  // only by coincidence).
   it("round-trips a codex effort selection through controlOverrides", () => {
     const selections: Record<string, string> = {};
     const { result, rerender } = renderHook(

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-launch-controls.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-launch-controls.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DesktopAgentLaunchCatalog } from "#product/lib/domain/agents/cloud-launch-catalog";
+import { useHomeNextLaunchControls } from "#product/hooks/home/derived/use-home-next-launch-controls";
+
+vi.mock("#product/hooks/access/cloud/agent-catalog/use-cloud-agent-catalog", () => ({
+  useCloudAgentCatalog: () => ({ data: cloudCatalog(), isLoading: false }),
+}));
+
+vi.mock("@anyharness/sdk-react", () => ({
+  useAgentLaunchOptionsQuery: () => ({
+    data: {
+      agents: [{
+        kind: "codex",
+        displayName: "Codex",
+        defaultModelId: "gpt-5.5",
+        models: [{ id: "gpt-5.5", displayName: "GPT-5.5", isDefault: true }],
+      }],
+    },
+    isLoading: false,
+  }),
+}));
+
+vi.mock("#product/hooks/agents/derived/use-agent-catalog", () => ({
+  useAgentCatalog: () => ({
+    agentsByKind: new Map([["codex", { readiness: "ready" }]]),
+  }),
+}));
+
+vi.mock("#product/stores/preferences/user-preferences-store", () => ({
+  useUserPreferencesStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      defaultSessionModeByAgentKind: {},
+      defaultLiveSessionControlValuesByAgentKind: {},
+    }),
+}));
+
+describe("useHomeNextLaunchControls", () => {
+  afterEach(cleanup);
+
+  // Regression: codex's effort control carries rawConfigId "reasoning_effort"
+  // while overrides are read back through the NORMALIZED control key. Storing
+  // the selection under the raw id made the home stepper snap back to the
+  // default for codex (claude worked only because its raw id IS "effort").
+  it("round-trips a codex effort selection through controlOverrides", () => {
+    const selections: Record<string, string> = {};
+    const { result, rerender } = renderHook(
+      ({ overrides }: { overrides: Record<string, string> }) =>
+        useHomeNextLaunchControls({
+          modelSelection: { kind: "codex", modelId: "gpt-5.5" },
+          modeId: null,
+          controlOverrides: overrides,
+          onSelectControl: (controlKey, value) => {
+            selections[controlKey] = value;
+          },
+        }),
+      { initialProps: { overrides: {} } },
+    );
+
+    const effort = result.current.controls.find((control) => control.key === "effort");
+    expect(effort).toBeDefined();
+
+    effort?.onSelect("high");
+    rerender({ overrides: { ...selections } });
+
+    const reselected = result.current.controls.find((control) => control.key === "effort");
+    expect(reselected?.options.find((option) => option.selected)?.value).toBe("high");
+    expect(result.current.launchControlValues.reasoning_effort).toBe("high");
+  });
+});
+
+function cloudCatalog(): DesktopAgentLaunchCatalog {
+  return {
+    schemaVersion: 2,
+    catalogVersion: "test",
+    generatedAt: "2026-08-18T00:00:00Z",
+    defaultAgentKind: "codex",
+    workspaceId: null,
+    agents: [{
+      kind: "codex",
+      displayName: "Codex",
+      description: null,
+      defaultModelId: "gpt-5.5",
+      unattendedModeId: null,
+      models: [{
+        id: "gpt-5.5",
+        displayName: "GPT-5.5",
+        description: null,
+        provider: null,
+        aliases: [],
+        status: "active",
+        isDefault: true,
+        availability: null,
+        sessionDefaultControls: [],
+        modeValues: null,
+        tuningControlValues: { effort: ["low", "medium", "high", "xhigh"] },
+      }],
+      launchControls: [{
+        key: "effort",
+        label: "Effort",
+        description: null,
+        type: "select",
+        category: null,
+        defaultValue: null,
+        createField: null,
+        phase: "live_default",
+        surfaces: { start: true, session: true, automation: true, settings: true },
+        apply: {
+          createField: null,
+          liveConfigId: "reasoning_effort",
+          liveSetter: "runtime_control",
+          queueBeforeMaterialized: true,
+        },
+        missingLiveConfigPolicy: "ignore_default",
+        valueSource: "inline",
+        values: [
+          { value: "low", label: "Low", description: null, isDefault: false, status: null },
+          { value: "medium", label: "Medium", description: null, isDefault: false, status: null },
+          { value: "high", label: "High", description: null, isDefault: false, status: null },
+          { value: "xhigh", label: "Extra High", description: null, isDefault: false, status: null },
+        ],
+        queueWhileMaterializing: true,
+        mutableAfterMaterialized: true,
+      }],
+    }],
+  };
+}

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-launch-controls.ts
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-launch-controls.ts
@@ -91,11 +91,14 @@ export function useHomeNextLaunchControls({
       preferences: effectivePreferences,
       onSelect: (
         _agentKind: string,
-        _controlKey: SupportedLiveControlKey,
-        rawConfigId: string,
+        controlKey: SupportedLiveControlKey,
+        _rawConfigId: string,
         value: string,
       ) => {
-        onSelectControl(rawConfigId, value);
+        // Overrides feed back through defaultLiveSessionControlValuesByAgentKind,
+        // which buildLaunchControlDescriptors reads by NORMALIZED key — raw
+        // catalog ids (codex `reasoning_effort`) would never round-trip.
+        onSelectControl(controlKey, value);
       },
     }),
     [effectivePreferences, launchAgents, modelSelection, onSelectControl],


### PR DESCRIPTION
## Problem

On the home (pre-workspace) composer, clicking the reasoning-effort stepper for **codex** did nothing: the stepper snapped back to the default and the launched session never received the chosen level. Claude was unaffected.

## Root cause

`buildLaunchControlDescriptors` fires `onSelect(agentKind, key, rawConfigId, value)` and reads overrides back through `defaultLiveSessionControlValuesByAgentKind[kind]?.[key]` — keyed by the **normalized** control key (`effort`). But `useHomeNextLaunchControls` forwarded the **rawConfigId** to `onSelectControl`, so HomeNextScreen stored the override under the raw catalog id.

- claude: raw id `effort` == normalized `effort` → round-trips by coincidence
- codex: raw id `reasoning_effort` ≠ normalized `effort` → the lookup misses, selection falls back to default

Same key-mismatch family as PRO-318 (`fast` vs `fast_mode`), one layer down.

## Fix

Forward the normalized control key to `onSelectControl` so the override round-trips. The launch payload is unaffected: `launchControlValues` is derived from the descriptors' selected options (still keyed by rawConfigId via `selectedLaunchControlValues`), and the persisted preference store is already normalized-keyed.

## Testing

- New regression test `use-home-next-launch-controls.test.tsx` drives the full round-trip (click → override → re-render → selected option + `launchControlValues.reasoning_effort`). Verified it **fails without the fix** (selection stays `low`) and passes with it.
- `pnpm typecheck` and the related suites (`src/hooks/home`, `src/lib/domain/chat/models`, `src/lib/domain/agents`, `src/lib/domain/home`): 37 files / 365 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)