### PR TITLE
fix(product): keep sidebar row labels clear of the hover actions

### DIFF
--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/ProductSidebarRepositories.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/ProductSidebarRepositories.test.tsx
@@ -111,6 +111,41 @@ describe("ProductSidebarWorkspaceRow trailing slot", () => {
     expect(screen.getByTestId("running-status").parentElement?.className).toContain("opacity-0");
   });
 
+  it("swaps the trailing cells for the revealed actions instead of covering the label", () => {
+    render(
+      <ProductSidebarWorkspaceRow
+        label="A workspace with a very long name that fills the whole row"
+        trailingStatus={<span data-testid="running-status">Running</span>}
+        hoverAction={<button type="button">Pin workspace</button>}
+      />,
+    );
+
+    const actions = document.querySelector("[data-sidebar-row-actions]");
+    const cells = document.querySelector("[data-sidebar-trailing-cells]");
+    // Same flow row as the cells, not an overlay printed on top of them.
+    expect(actions?.parentElement).toBe(cells?.parentElement);
+    expect(actions?.className).not.toContain("absolute");
+    // Each side owns the width only in the state it is visible in, so the
+    // label re-truncates against whichever is showing.
+    expect(actions?.className).toContain("w-0");
+    expect(actions?.className).toContain("group-hover:w-auto");
+    expect(cells?.className).toContain("group-hover:w-0");
+    expect(cells?.className).toContain("overflow-hidden");
+  });
+
+  it("leaves the trailing cells at full width when the row has no hover actions", () => {
+    render(
+      <ProductSidebarWorkspaceRow
+        label="Quiet workspace"
+        trailingStatus={<span data-testid="running-status">Running</span>}
+      />,
+    );
+
+    const cells = document.querySelector("[data-sidebar-trailing-cells]");
+    expect(cells?.className).not.toContain("group-hover:w-0");
+    expect(document.querySelector("[data-sidebar-row-actions]")).toBeNull();
+  });
+
   it("uses the ordinary trailing slot when there is no symbol to cover", () => {
     render(
       <ProductSidebarWorkspaceRow

--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/ProductSidebarRepositories.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/ProductSidebarRepositories.tsx
@@ -168,11 +168,6 @@ export function ProductSidebarWorkspaceRow({
       className={`${hasSubtitle ? "h-[40px]" : "h-[30px]"} pl-2 pr-1 py-1 text-sidebar-row focus-visible:outline-offset-[-2px] ${className}`}
       {...props}
     >
-      {hoverAction ? (
-        <div className="absolute right-0 top-0 z-10 mr-0.5 flex h-full items-center justify-center pr-0.5 opacity-0 transition-opacity duration-hover group-hover:opacity-100 group-focus-within:opacity-100 has-[[data-state=open]]:opacity-100">
-          {hoverAction}
-        </div>
-      ) : null}
       <div className="flex h-full w-full items-center">
         <div className="flex w-4 shrink-0 items-center justify-center">
           {status ?? (prStatus ? (
@@ -224,8 +219,12 @@ export function ProductSidebarWorkspaceRow({
             {hasTrailingCells ? (
               <div
                 data-sidebar-trailing-cells
-                className={`relative flex items-center justify-end gap-1.5 transition-opacity duration-hover ${hoverAction
-                  ? "group-hover:opacity-0 group-focus-within:opacity-0"
+                // Collapsing to zero width — not just fading — is what hands
+                // the revealed actions the room they need: the two cells and
+                // the actions swap places in the same flow instead of the
+                // actions floating over an already-truncated label.
+                className={`relative flex items-center justify-end gap-1.5 overflow-hidden transition-opacity duration-hover ${hoverAction
+                  ? "group-hover:w-0 group-hover:opacity-0 group-focus-within:w-0 group-focus-within:opacity-0"
                   : ""
                 }`}
               >
@@ -260,6 +259,21 @@ export function ProductSidebarWorkspaceRow({
                     }`}
                   />
                 ) : null}
+              </div>
+            ) : null}
+            {hoverAction ? (
+              // Zero-width at rest so the label keeps the whole row, widening
+              // to its natural size the moment the row is hovered/focused or
+              // an action's menu is open — the label re-truncates against it
+              // rather than being printed under it (the overlay this replaced
+              // was 48px of buttons floating over a 20px cell). The buttons
+              // stay untouchable while collapsed via the row-action
+              // primitive's own reveal contract.
+              <div
+                data-sidebar-row-actions
+                className="flex w-0 shrink-0 items-center justify-end opacity-0 transition-opacity duration-hover group-hover:w-auto group-hover:opacity-100 group-focus-within:w-auto group-focus-within:opacity-100 has-[[data-state=open]]:w-auto has-[[data-state=open]]:opacity-100"
+              >
+                {hoverAction}
               </div>
             ) : null}
           </div>


### PR DESCRIPTION
## Summary

- A workspace row whose title fills the sidebar had the hover-revealed pin printed on top of its last characters: the actions were an absolute overlay pinned to the row's right edge (two 24px buttons) while the label truncated against the 20px trailing cell underneath them.
- The actions now sit in the same flow as the trailing cells, and each side carries width only in the state it is visible in — the cells collapse to zero width as the actions expand to their natural size on hover, focus-within, or an open action menu. The label re-truncates against whichever is showing.
- Net effect: the label keeps the whole row at rest and gives up exactly the room the icons need when they appear. Measured on a row long enough to fill the sidebar: 22px of label-under-icon overlap before, 0px after (6px clear gap).

## Testing

- Component tier: `pnpm vitest run src/components/workspace/shell/sidebar src/primitives/patterns/sidebar` (134 tests). Two new cases in `ProductSidebarRepositories.test.tsx` pin the swap (actions share the cells' flow parent, neither is an overlay, each owns width only in its own state) and pin that a row without hover actions is untouched.
- `npx tsc -p tsconfig.json --noEmit` clean.
- Visual: the production `ProductSidebarWorkspaceRow` mounted against the production stylesheet in a real browser at 3x, hovered, in both Chromium and WebKit (the desktop shell's engine). Before: pin overlapping `…the d…`, label right edge 210px vs pin left edge 188px. After: `Codex Migration for t…` then a 6px gap, then pin and archive; identical in WebKit. Rest state unchanged — the full label still uses the whole row.
- Repo gates: `check_design_attribution`, `check_max_lines`, `check_component_library`, `check_appearance_scaling`, `report_frontend_structure` all pass.

## Observability

- None. Presentation-only change to one row component; no new events, logs, or metrics.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Verification

- Hover any workspace row in the sidebar whose title is long enough to truncate: the title shortens by the width of the revealed controls and the pin/archive glyphs sit in clear space. Move the pointer away and the title returns to the full row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)