### PR TITLE
fix(product): map claude fast and codex fast-mode onto the fast_mode launch control

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/projection.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/projection.rs
@@ -294,7 +294,7 @@ pub fn enrich_model(
             provider,
             status: Some(model.status),
             effort: model_effort(model),
-            fast_mode: Some(model.controls.contains_key("fast_mode")),
+            fast_mode: Some(model.supports_fast_mode()),
             modes: model_modes(model),
         }
     } else if let Some(model) = foreign_match {

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema.rs
@@ -319,13 +319,17 @@ pub struct AgentCatalogModel {
 }
 
 impl AgentCatalogModel {
-    /// Whether this model carries a fast-mode control. Harnesses name it
-    /// differently — claude's option is `fast`, codex's is `fast-mode`
+    /// Whether this model carries a toggleable fast-mode control. Harnesses
+    /// name it differently — claude's option is `fast`, codex's is `fast-mode`
     /// (`fast_mode` before the rung-1 fork) — and all mean the same capability.
+    /// A single-value entry is a probe-observed variant dimension (cursor's
+    /// bracket-param `fast`), not a switchable control, so it does not count.
     pub fn supports_fast_mode(&self) -> bool {
-        ["fast_mode", "fast", "fast-mode"]
-            .iter()
-            .any(|key| self.controls.contains_key(*key))
+        ["fast_mode", "fast", "fast-mode"].iter().any(|key| {
+            self.controls
+                .get(*key)
+                .is_some_and(|control| control.values.len() >= 2)
+        })
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema.rs
@@ -318,6 +318,17 @@ pub struct AgentCatalogModel {
     pub provenance: Option<AgentCatalogModelProvenance>,
 }
 
+impl AgentCatalogModel {
+    /// Whether this model carries a fast-mode control. Harnesses name it
+    /// differently — claude's option is `fast`, codex's is `fast-mode`
+    /// (`fast_mode` before the rung-1 fork) — and all mean the same capability.
+    pub fn supports_fast_mode(&self) -> bool {
+        ["fast_mode", "fast", "fast-mode"]
+            .iter()
+            .any(|key| self.controls.contains_key(*key))
+    }
+}
+
 /// Observed-set availability: exactly the auth contexts (incl. `"baseline"`)
 /// whose probe runs contained this model. No monotonicity inference.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema_tests.rs
@@ -378,3 +378,31 @@ fn codex_fast_mode_control_is_mapped_and_reported() {
         );
     }
 }
+
+/// Cursor's `fast` entry is a probe-observed bracket-param variant dimension
+/// with a single value per model — not a switchable control. It must not be
+/// classified as fast-mode capability.
+#[test]
+fn cursor_single_value_fast_is_not_fast_mode_capability() {
+    let catalog = crate::domains::agents::catalog::bundled::bundled_agent_catalog_document();
+    let cursor = catalog
+        .agents
+        .iter()
+        .find(|agent| agent.kind == "cursor")
+        .expect("cursor agent");
+    let carriers: Vec<_> = cursor
+        .session
+        .models
+        .iter()
+        .filter(|model| model.controls.contains_key("fast"))
+        .collect();
+    assert!(!carriers.is_empty(), "cursor models carry a `fast` variant");
+    for model in carriers {
+        assert_eq!(model.controls["fast"].values.len(), 1);
+        assert!(
+            !model.supports_fast_mode(),
+            "{} must not report fast-mode capability",
+            model.id
+        );
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/agents/catalog/schema_tests.rs
@@ -288,3 +288,93 @@ fn registry_gateway_capability_matches_render_assumption() {
         "cursor must never be gateway-capable (render.rs returns UnsupportedRoute)"
     );
 }
+
+/// PRO-318: claude's fast-mode option is `fast`, not codex's `fast_mode`.
+/// The control must carry an apply mapping and every model that declares it
+/// must report the capability, or Opus ships a Fast toggle nothing can apply.
+#[test]
+fn claude_fast_control_is_mapped_and_reported() {
+    let catalog = crate::domains::agents::catalog::bundled::bundled_agent_catalog_document();
+    let claude = catalog
+        .agents
+        .iter()
+        .find(|agent| agent.kind == "claude")
+        .expect("claude agent");
+    let fast = claude
+        .session
+        .controls
+        .iter()
+        .find(|control| control.key == "fast")
+        .expect("claude declares a `fast` control");
+
+    assert_eq!(
+        fast.mapping
+            .as_ref()
+            .and_then(|mapping| mapping.live_config_id.as_deref()),
+        Some("fast"),
+        "the fast control needs a live-apply path or no surface can set it"
+    );
+    for (id, name, description_prefix) in [
+        ("opus", "Opus 5", Some("Opus 5")),
+        ("opus[1m]", "Opus 5 (1M context)", Some("Opus 5")),
+        ("claude-opus-4-8", "Opus 4.8", None),
+    ] {
+        let model = claude
+            .session
+            .models
+            .iter()
+            .find(|model| model.id == id)
+            .unwrap_or_else(|| panic!("missing {name} model"));
+        if let Some(prefix) = description_prefix {
+            assert!(model
+                .description
+                .as_deref()
+                .is_some_and(|value| value.starts_with(prefix)));
+        }
+        assert!(model.supports_fast_mode(), "{name} supports fast mode");
+    }
+}
+
+/// The rung-1 codex fork renamed its fast option `fast_mode` -> `fast-mode`.
+/// The bundled control must stay mapped and the models that declare it must
+/// report the capability, mirroring the claude coverage above.
+#[test]
+fn codex_fast_mode_control_is_mapped_and_reported() {
+    let catalog = crate::domains::agents::catalog::bundled::bundled_agent_catalog_document();
+    let codex = catalog
+        .agents
+        .iter()
+        .find(|agent| agent.kind == "codex")
+        .expect("codex agent");
+    let fast = codex
+        .session
+        .controls
+        .iter()
+        .find(|control| control.key == "fast-mode")
+        .expect("codex declares a `fast-mode` control");
+
+    assert_eq!(
+        fast.mapping
+            .as_ref()
+            .and_then(|mapping| mapping.live_config_id.as_deref()),
+        Some("fast-mode"),
+        "the fast-mode control needs a live-apply path or no surface can set it"
+    );
+    let carriers: Vec<_> = codex
+        .session
+        .models
+        .iter()
+        .filter(|model| model.controls.contains_key("fast-mode"))
+        .collect();
+    assert!(
+        !carriers.is_empty(),
+        "at least one codex model carries fast-mode"
+    );
+    for model in carriers {
+        assert!(
+            model.supports_fast_mode(),
+            "{} supports fast mode",
+            model.id
+        );
+    }
+}

--- a/anyharness/crates/anyharness-lib/src/domains/sessions/service/launch_options.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/sessions/service/launch_options.rs
@@ -175,7 +175,7 @@ impl SessionService {
                             &model.controls,
                             &agent.session.controls,
                         ),
-                        fast_mode: model.controls.contains_key("fast_mode"),
+                        fast_mode: model.supports_fast_mode(),
                         modes: model
                             .controls
                             .get("mode")

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-launch-controls.ts
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-launch-controls.ts
@@ -16,6 +16,7 @@ import type {
   SupportedLiveControlKey,
 } from "#product/lib/domain/chat/session-controls/session-controls";
 import type { HomeNextModelSelection } from "#product/lib/domain/home/home-next-launch";
+import { pickLiveDefaultLaunchControls } from "#product/lib/domain/sessions/creation/launch-controls";
 import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store";
 
 const EMPTY_AGENTS: DesktopAgentLaunchAgent[] = [];
@@ -77,7 +78,9 @@ export function useHomeNextLaunchControls({
         ...preferences.defaultLiveSessionControlValuesByAgentKind,
         [modelSelection.kind]: {
           ...preferences.defaultLiveSessionControlValuesByAgentKind[modelSelection.kind],
-          ...controlOverrides,
+          // Overrides are keyed by raw config id; the descriptor reads the
+          // canonical control key (claude's `fast` is `fast_mode`).
+          ...pickLiveDefaultLaunchControls(controlOverrides),
         },
       },
     };

--- a/apps/packages/product-client/src/lib/domain/agents/cloud-launch-catalog.test.ts
+++ b/apps/packages/product-client/src/lib/domain/agents/cloud-launch-catalog.test.ts
@@ -170,6 +170,63 @@ describe("projectCloudAgentCatalogToDesktopLaunchCatalog", () => {
   });
 });
 
+describe("claude's `fast` control", () => {
+  function claudeCatalog(): Parameters<typeof projectCloudAgentCatalogToDesktopLaunchCatalog>[0] {
+    return {
+      schemaVersion: 2,
+      catalogVersion: "2026-08-18.1",
+      generatedAt: "2026-08-18T00:00:00Z",
+      agents: [{
+        kind: "claude",
+        displayName: "Claude",
+        authContexts: [{ id: "anthropic-oauth" }],
+        session: {
+          controls: [
+            {
+              key: "model",
+              mapping: { createField: "modelId", switchVia: "configOption", liveConfigId: "model" },
+            },
+            { key: "fast", values: ["on", "off"], mapping: { liveConfigId: "fast" } },
+          ],
+          models: [{
+            id: "opus",
+            displayName: "Opus 5",
+            availability: { anyOf: ["anthropic-oauth"] },
+            defaultVisible: true,
+            controls: { fast: { values: ["on", "off"], observedValue: "off" } },
+            status: "active",
+          }],
+          defaults: { "anthropic-oauth": "opus" },
+        },
+      }],
+    };
+  }
+
+  // claude names the control `fast` where codex names it `fast_mode`. Both
+  // must project onto the one desktop `fast_mode` key, or Opus 5 loses its
+  // Fast toggle and its saved launch default.
+  it("projects onto the desktop fast_mode key", () => {
+    const projected = projectCloudAgentCatalogToDesktopLaunchCatalog(claudeCatalog());
+    const agent = projected.agents[0]!;
+
+    expect(agent.launchControls.find((control) => control.key === "fast_mode"))
+      .toMatchObject({ apply: { liveConfigId: "fast" }, values: [
+        { value: "on", label: "On" },
+        { value: "off", label: "Off" },
+      ] });
+    expect(agent.models[0]?.tuningControlValues).toEqual({ fast_mode: ["on", "off"] });
+    expect(agent.models[0]?.sessionDefaultControls).toEqual([{
+      key: "fast_mode",
+      label: "Fast Mode",
+      defaultValue: "off",
+      values: [
+        { value: "on", label: "On", description: null, isDefault: false },
+        { value: "off", label: "Off", description: null, isDefault: true },
+      ],
+    }]);
+  });
+});
+
 describe("mergeRuntimeLaunchOptionsIntoDesktopLaunchAgents", () => {
   it("keeps local/runtime and cloud unattended defaults in parity", () => {
     const base = cloudCatalog();

--- a/apps/packages/product-client/src/lib/domain/agents/cloud-launch-controls.ts
+++ b/apps/packages/product-client/src/lib/domain/agents/cloud-launch-controls.ts
@@ -12,7 +12,7 @@ const SESSION_DEFAULT_CONTROL_KEYS: ReadonlyArray<{
 }> = [
   { key: "reasoning", catalogKeys: ["reasoning"] },
   { key: "effort", catalogKeys: ["effort", "reasoning_effort"] },
-  { key: "fast_mode", catalogKeys: ["fast_mode"] },
+  { key: "fast_mode", catalogKeys: ["fast_mode", "fast", "fast-mode"] },
 ];
 
 /**
@@ -93,6 +93,8 @@ const LAUNCH_CONTROL_KEYS: Readonly<Record<string, string>> = {
   reasoning_effort: "effort",
   effort: "effort",
   fast_mode: "fast_mode",
+  fast: "fast_mode",
+  "fast-mode": "fast_mode",
 };
 
 export function projectCloudControl(

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/launch-controls.test.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/launch-controls.test.ts
@@ -20,6 +20,22 @@ describe("pickLiveDefaultLaunchControls", () => {
     });
   });
 
+  // claude's harness names the option `fast`; the live default it feeds is
+  // still `fast_mode`, so the raw id has to normalize on the way in.
+  it("normalizes claude's raw `fast` id onto fast_mode", () => {
+    expect(pickLiveDefaultLaunchControls({ fast: "on" })).toEqual({ fast_mode: "on" });
+  });
+
+  it("normalizes codex's raw `fast-mode` id onto fast_mode", () => {
+    expect(pickLiveDefaultLaunchControls({ "fast-mode": "on" })).toEqual({ fast_mode: "on" });
+  });
+
+  it("normalizes codex's raw `reasoning_effort` id onto effort", () => {
+    expect(pickLiveDefaultLaunchControls({ reasoning_effort: "high" })).toEqual({
+      effort: "high",
+    });
+  });
+
   it("returns an empty object for missing values", () => {
     expect(pickLiveDefaultLaunchControls(undefined)).toEqual({});
   });

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/launch-controls.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/launch-controls.ts
@@ -8,12 +8,18 @@ export type LiveDefaultLaunchControls = Partial<Record<LiveDefaultLaunchControlI
 
 export type LiveDefaultLaunchControlsByAgent = Record<string, LiveDefaultLaunchControls>;
 
-const LIVE_DEFAULT_LAUNCH_CONTROL_IDS = new Set<string>([
-  "collaboration_mode",
-  "reasoning",
-  "effort",
-  "fast_mode",
-]);
+// Launch-control values arrive keyed by RAW config id (what the harness calls
+// the option), which can differ from the canonical live-default id. Claude
+// calls fast mode `fast`, while Codex calls effort `reasoning_effort`.
+const LIVE_DEFAULT_LAUNCH_CONTROL_ID_BY_RAW_ID: Record<string, LiveDefaultLaunchControlId> = {
+  collaboration_mode: "collaboration_mode",
+  reasoning: "reasoning",
+  reasoning_effort: "effort",
+  effort: "effort",
+  fast_mode: "fast_mode",
+  fast: "fast_mode",
+  "fast-mode": "fast_mode",
+};
 
 export function pickLiveDefaultLaunchControls(
   values: Record<string, string> | undefined,
@@ -22,9 +28,10 @@ export function pickLiveDefaultLaunchControls(
     return {};
   }
   return Object.fromEntries(
-    Object.entries(values).filter(([key, value]) =>
-      LIVE_DEFAULT_LAUNCH_CONTROL_IDS.has(key) && value.trim().length > 0
-    ),
+    Object.entries(values).flatMap(([rawId, value]) => {
+      const id = LIVE_DEFAULT_LAUNCH_CONTROL_ID_BY_RAW_ID[rawId];
+      return id && value.trim().length > 0 ? [[id, value]] : [];
+    }),
   ) as LiveDefaultLaunchControls;
 }
 

--- a/catalogs/agents/catalog.json
+++ b/catalogs/agents/catalog.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "catalogVersion": "2026-08-17.1",
+  "catalogVersion": "2026-08-18.1",
   "probedAgainst": {
     "registryVersion": "2026-08-17.1"
   },
@@ -135,7 +135,10 @@
             "values": [
               "on",
               "off"
-            ]
+            ],
+            "mapping": {
+              "liveConfigId": "fast"
+            }
           }
         ],
         "models": [
@@ -1393,7 +1396,10 @@
             "values": [
               "off",
               "on"
-            ]
+            ],
+            "mapping": {
+              "liveConfigId": "fast-mode"
+            }
           }
         ],
         "models": [

--- a/scripts/agent-catalog/build-catalog.mjs
+++ b/scripts/agent-catalog/build-catalog.mjs
@@ -267,13 +267,19 @@ const CONTROL_MAPPINGS = {
   claude: {
     mode: { createField: "modeId", liveConfigId: "mode" },
     effort: { liveConfigId: "effort" },
-    fast_mode: { liveConfigId: "fast_mode" },
+    // claude names this control `fast` (codex names its own `fast-mode`);
+    // the key must match the probed option id or the control ships unmapped
+    // and no desktop surface can apply it.
+    fast: { liveConfigId: "fast" },
   },
   codex: {
     mode: { createField: "modeId", liveConfigId: "mode" },
     collaboration_mode: { liveConfigId: "collaboration_mode" },
     reasoning_effort: { liveConfigId: "reasoning_effort" },
+    // The rung-1 fork renamed this option from `fast_mode` to `fast-mode`;
+    // both spellings stay mapped so a re-probe against either fork works.
     fast_mode: { liveConfigId: "fast_mode" },
+    "fast-mode": { liveConfigId: "fast-mode" },
   },
   cursor: { mode: { createField: "modeId", liveConfigId: "mode" } },
   opencode: { mode: { createField: "modeId", liveConfigId: "mode" } },

--- a/scripts/agent-catalog/catalog.draft.json
+++ b/scripts/agent-catalog/catalog.draft.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "catalogVersion": "2026-08-17.1",
+  "catalogVersion": "2026-08-18.1",
   "probedAgainst": {
     "registryVersion": "2026-08-17.1"
   },
@@ -135,7 +135,10 @@
             "values": [
               "on",
               "off"
-            ]
+            ],
+            "mapping": {
+              "liveConfigId": "fast"
+            }
           }
         ],
         "models": [
@@ -1393,7 +1396,10 @@
             "values": [
               "off",
               "on"
-            ]
+            ],
+            "mapping": {
+              "liveConfigId": "fast-mode"
+            }
           }
         ],
         "models": [


### PR DESCRIPTION
## Summary

- alias claude's raw `fast` and the rung-1 codex fork's renamed `fast-mode` option onto the product's canonical `fast_mode` launch control
- carry the aliases through catalog generation, the bundled catalog's apply mappings, client launch-control projection, pre-session override normalization, and runtime capability reporting
- re-lands the approach from #2039 (closed) with the codex `reasoning_effort` alias preserved and extended for the `fast-mode` rename that landed with the rung-1 adapter pins (#1988)

## Root cause

Claude exposes its fast-mode option as `fast`, and the rung-1 codex fork (pinned in #1988's catalog regen) renamed codex's from `fast_mode` to `fast-mode`. Every catalog consumer hardcoded the old `fast_mode` spelling:

- `scripts/agent-catalog/build-catalog.mjs` `CONTROL_MAPPINGS` never matched either probed key, so both controls shipped in `catalogs/agents/catalog.json` with no `mapping` — and `projectCloudControl` drops unmapped controls, removing the Fast toggle from the home/pre-session composer for both agents.
- `cloud-launch-controls.ts` and `launch-controls.ts` filtered on the canonical id, so saved Fast defaults and pre-session picks were silently discarded at launch.
- Rust `enrich_model`/`launch_options` reported `fastMode: false` for every claude and codex model.

The in-session toggle kept working because live-config normalization matches the option's label ("Fast mode"), not its id — which made the defect look pre-session-only.

## Validation

- `node scripts/validate-agent-catalog.mjs` — OK (2026-08-18.1, 5 agents)
- `node --test scripts/agent-catalog/build-catalog.test.mjs` — 0 failures
- `cargo test -p anyharness-lib domains::agents::catalog --lib` — 147 passed (incl. new `claude_fast_control_is_mapped_and_reported` and `codex_fast_mode_control_is_mapped_and_reported`)
- focused product-client vitest (launch-controls, cloud-launch-catalog) — 19 passed
- `pnpm --filter @proliferate/product-client typecheck` — passed
- `python3 scripts/check_docs.py` / `check_design_attribution.py` — passed

## Notes

- `catalogs/agents/catalog.json` edited surgically (mapping additions + `catalogVersion` bump to 2026-08-18.1); not regenerated, since `build-catalog.mjs` is not byte-reproducible.
- Complements #2052 (home override round-trip by normalized key) — different hunks, no conflict; the `pickLiveDefaultLaunchControls` normalization here is idempotent over canonical keys.

Fixes PRO-318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)