### PR TITLE
fix(integrations): gate Slack OAuth on distribution qualification

### DIFF
--- a/delivery/integration-lifecycle/delivery-spec-integration-lifecycle-pr0.md
+++ b/delivery/integration-lifecycle/delivery-spec-integration-lifecycle-pr0.md
@@ -1,0 +1,46 @@
+# Delivery specification: integration lifecycle PR0 — Slack qualification gate
+
+Status: frozen delivery specification.
+Approved design: integration connection lifecycle ADR proposal, decision 4 and
+high-level sequencing PR0.
+Base revision: `8532f52b226413458721b46839fc78b852b69373`.
+
+## Outcome
+
+Customer Slack OAuth cannot start merely because static credentials are
+configured. A separate, default-off deployment qualification flag proves that
+the exact Slack app has completed distribution review and canary qualification.
+When that proof is absent, OAuth start fails closed before provider discovery,
+OAuth-client persistence, or browser handoff.
+
+## Scope
+
+- Add `CLOUD_MCP_SLACK_DISTRIBUTION_READY`, default `false`, to server settings
+  and the supported environment-variable catalog.
+- Require both `CLOUD_MCP_SLACK_ENABLED` and the new qualification flag before
+  resolving the static Slack OAuth client.
+- Return the stable provider error code `integration_provider_unavailable` when
+  distribution qualification is absent. Preserve
+  `missing_static_oauth_client` for incomplete/invalid client configuration
+  after qualification.
+- Keep existing connected-account runtime use unchanged; this slice gates only
+  new OAuth starts and reauthorization starts.
+
+## Non-goals
+
+- No lifecycle schema, management projection, UI, probe scheduler, or existing
+  connection migration.
+- No Slack Marketplace submission, environment mutation, or production deploy.
+- No provider network call in tests.
+
+## Acceptance
+
+- Default settings leave Slack distribution unqualified.
+- Static Slack client resolution fails with
+  `integration_provider_unavailable` and performs no client-store read/write
+  while unqualified.
+- Qualified, fully configured Slack resolution preserves existing behavior.
+- Qualified but incomplete configuration preserves
+  `missing_static_oauth_client`.
+- Focused unit/integration tests, server boundary checks, documentation checks,
+  and migration-head validation pass.

--- a/server/deploy/.env.production.example
+++ b/server/deploy/.env.production.example
@@ -148,6 +148,9 @@ INSTANCE_SUPPORT_URL=
 CLOUD_MCP_ENABLED=true
 CLOUD_MCP_OAUTH_CALLBACK_BASE_URL=
 CLOUD_MCP_SLACK_ENABLED=false
+# Set true only after the exact configured Slack app is Marketplace-qualified
+# and its release canary has passed.
+CLOUD_MCP_SLACK_DISTRIBUTION_READY=false
 CLOUD_MCP_SLACK_CLIENT_ID=
 CLOUD_MCP_SLACK_CLIENT_SECRET=
 CLOUD_MCP_SLACK_TOKEN_ENDPOINT_AUTH_METHOD=client_secret_post

--- a/server/proliferate/config.py
+++ b/server/proliferate/config.py
@@ -394,6 +394,9 @@ class Settings(BaseSettings):
     cloud_mcp_oauth_callback_base_url: str = ""
     cloud_mcp_oauth_callback_fallback_base_url: str = "http://localhost:8000"
     cloud_mcp_slack_enabled: bool = False
+    # Operator-owned release qualification for the exact static Slack app.
+    # Credentials alone never prove Marketplace distribution eligibility.
+    cloud_mcp_slack_distribution_ready: bool = False
     cloud_mcp_slack_client_id: str = ""
     cloud_mcp_slack_client_secret: str = ""
     cloud_mcp_slack_token_endpoint_auth_method: str = "client_secret_post"

--- a/server/proliferate/config.py
+++ b/server/proliferate/config.py
@@ -394,8 +394,6 @@ class Settings(BaseSettings):
     cloud_mcp_oauth_callback_base_url: str = ""
     cloud_mcp_oauth_callback_fallback_base_url: str = "http://localhost:8000"
     cloud_mcp_slack_enabled: bool = False
-    # Operator-owned release qualification for the exact static Slack app.
-    # Credentials alone never prove Marketplace distribution eligibility.
     cloud_mcp_slack_distribution_ready: bool = False
     cloud_mcp_slack_client_id: str = ""
     cloud_mcp_slack_client_secret: str = ""
@@ -403,9 +401,8 @@ class Settings(BaseSettings):
     cloud_mcp_google_workspace_enabled: bool = False
     cloud_mcp_google_workspace_oauth_client_id: str = ""
     cloud_mcp_google_workspace_oauth_client_secret: str = ""
-    # Agent LLM gateway (LiteLLM proxy)
-    # Publisher lane (Update Flow ADR, FR-1): when set, the server advertises
-    # these on GET /meta so a desktop shell or cloud worker launches its
+    # Agent LLM gateway publisher lane (Update Flow ADR, FR-1): advertise these on
+    # GET /meta so a desktop shell or cloud worker launches its
     # runtime sidecar with ANYHARNESS_CATALOG_ARTIFACT_BASE_URL/_CHANNEL
     # populated. Absent (default) => `agentCatalog` is null and every runtime
     # this deployment launches stays on the compiled-in floor, by design.

--- a/server/proliferate/server/cloud/integrations/oauth/clients.py
+++ b/server/proliferate/server/cloud/integrations/oauth/clients.py
@@ -28,7 +28,6 @@ from proliferate.integrations.integration_oauth import (
 from proliferate.lib.infra.encryption.fernet import decrypt_text, encrypt_text
 
 # Static-client auth methods this deployment can drive.
-# Static-client auth methods this deployment can drive.
 SUPPORTED_STATIC_OAUTH_TOKEN_ENDPOINT_AUTH_METHODS = {
     "none",
     "client_secret_post",
@@ -62,6 +61,33 @@ def _static_oauth_client_config(namespace: str) -> _StaticOAuthClientConfig | No
         client_secret=client_secret,
         token_endpoint_auth_method=auth_method,
     )
+
+
+def validate_oauth_provider_start_readiness(
+    definition: IntegrationDefinitionRecord,
+) -> None:
+    """Fail closed before discovery when a static provider is not qualified.
+
+    Slack Marketplace/distribution eligibility is independent of possessing a
+    client id and secret.  Keep the release qualification as a distinct,
+    default-off gate so a stale deployment secret can never advertise a usable
+    authorization path on its own.
+    """
+    if definition.oauth_client_mode != "static" or definition.namespace != "slack":
+        return
+    if (
+        not app_settings.cloud_mcp_slack_enabled
+        or not app_settings.cloud_mcp_slack_distribution_ready
+    ):
+        raise IntegrationOAuthProviderError(
+            "integration_provider_unavailable",
+            "Slack OAuth distribution is not qualified for this deployment.",
+        )
+    if _static_oauth_client_config(definition.namespace) is None:
+        raise IntegrationOAuthProviderError(
+            "missing_static_oauth_client",
+            "This deployment is missing static OAuth client configuration.",
+        )
 
 
 # --------------------------------------------------------------------------- #
@@ -122,6 +148,7 @@ async def _get_static_client(
     redirect_uri: str,
     resource: str,
 ) -> IntegrationOAuthClientRecord:
+    validate_oauth_provider_start_readiness(definition)
     config = _static_oauth_client_config(definition.namespace)
     if config is None:
         raise IntegrationOAuthProviderError(

--- a/server/proliferate/server/cloud/integrations/oauth/service.py
+++ b/server/proliferate/server/cloud/integrations/oauth/service.py
@@ -58,7 +58,10 @@ from proliferate.lib.infra.encryption.fernet import decrypt_text, encrypt_text
 from proliferate.lib.infra.encryption.json import encrypt_json
 from proliferate.server.cloud.errors import CloudApiError
 from proliferate.server.cloud.integrations.config import parse_definition_config, render_mcp_url
-from proliferate.server.cloud.integrations.oauth.clients import resolve_oauth_client
+from proliferate.server.cloud.integrations.oauth.clients import (
+    resolve_oauth_client,
+    validate_oauth_provider_start_readiness,
+)
 from proliferate.server.cloud.integrations.oauth.scope_policy import (
     OAuthScopePolicyError,
     validate_callback_oauth_scopes,
@@ -302,6 +305,9 @@ async def start_oauth_flow(
         raise CloudApiError("invalid_payload", str(exc), status_code=400) from exc
 
     try:
+        # Static provider qualification is deployment state, not something
+        # provider discovery can infer. Refuse before any external request.
+        validate_oauth_provider_start_readiness(definition)
         protected = await discover_protected_resource_metadata(server_url)
         requested_scope = _resolve_requested_oauth_scope(
             challenged_scope=protected.challenged_scope,

--- a/server/tests/integration/test_cloud_integrations_api.py
+++ b/server/tests/integration/test_cloud_integrations_api.py
@@ -292,6 +292,11 @@ class TestAuthenticateIntegration:
         monkeypatch.setattr(oauth_clients.app_settings, "cloud_mcp_slack_enabled", True)
         monkeypatch.setattr(
             oauth_clients.app_settings,
+            "cloud_mcp_slack_distribution_ready",
+            True,
+        )
+        monkeypatch.setattr(
+            oauth_clients.app_settings,
             "cloud_mcp_slack_client_id",
             "slack-client-id",
         )
@@ -369,6 +374,22 @@ class TestAuthenticateIntegration:
                 challenged_scope="search:read.public chat:write",
             )
 
+        monkeypatch.setattr(oauth_clients.app_settings, "cloud_mcp_slack_enabled", True)
+        monkeypatch.setattr(
+            oauth_clients.app_settings,
+            "cloud_mcp_slack_distribution_ready",
+            True,
+        )
+        monkeypatch.setattr(
+            oauth_clients.app_settings,
+            "cloud_mcp_slack_client_id",
+            "slack-client-id",
+        )
+        monkeypatch.setattr(
+            oauth_clients.app_settings,
+            "cloud_mcp_slack_client_secret",
+            "slack-client-secret",
+        )
         monkeypatch.setattr(oauth_service, "discover_protected_resource_metadata", _fake_protected)
 
         response = await client.post(

--- a/server/tests/integration/test_integration_oauth_scope_policy.py
+++ b/server/tests/integration/test_integration_oauth_scope_policy.py
@@ -55,6 +55,11 @@ async def _start_slack_flow(
     assert definition is not None
 
     monkeypatch.setattr(oauth_clients.app_settings, "cloud_mcp_slack_enabled", True)
+    monkeypatch.setattr(
+        oauth_clients.app_settings,
+        "cloud_mcp_slack_distribution_ready",
+        True,
+    )
     monkeypatch.setattr(oauth_clients.app_settings, "cloud_mcp_slack_client_id", "slack-client")
     monkeypatch.setattr(
         oauth_clients.app_settings,

--- a/server/tests/unit/test_cloud_integration_oauth_clients.py
+++ b/server/tests/unit/test_cloud_integration_oauth_clients.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.store.integrations.definitions import IntegrationDefinitionRecord
+from proliferate.integrations.integration_oauth import IntegrationOAuthProviderError
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.integrations.config import serialize_definition_config
+from proliferate.server.cloud.integrations.oauth import clients
+from proliferate.server.cloud.integrations.oauth import service as oauth_service
+from proliferate.server.cloud.integrations.seeds import SEED_DEFINITIONS
+
+
+def _definition(*, namespace: str = "slack", mode: str = "static") -> IntegrationDefinitionRecord:
+    config = next(seed.config for seed in SEED_DEFINITIONS if seed.namespace == namespace)
+    return cast(
+        IntegrationDefinitionRecord,
+        SimpleNamespace(
+            namespace=namespace,
+            oauth_client_mode=mode,
+            auth_kind="oauth2",
+            config_json=serialize_definition_config(config),
+        ),
+    )
+
+
+def _configure_valid_slack(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(clients.app_settings, "cloud_mcp_slack_enabled", True)
+    monkeypatch.setattr(clients.app_settings, "cloud_mcp_slack_distribution_ready", True)
+    monkeypatch.setattr(clients.app_settings, "cloud_mcp_slack_client_id", "slack-client")
+    monkeypatch.setattr(clients.app_settings, "cloud_mcp_slack_client_secret", "slack-secret")
+    monkeypatch.setattr(
+        clients.app_settings,
+        "cloud_mcp_slack_token_endpoint_auth_method",
+        "client_secret_post",
+    )
+
+
+@pytest.mark.parametrize(
+    ("enabled", "distribution_ready"),
+    [(False, False), (False, True), (True, False)],
+)
+def test_slack_start_requires_enabled_and_distribution_qualification(
+    monkeypatch: pytest.MonkeyPatch,
+    enabled: bool,
+    distribution_ready: bool,
+) -> None:
+    _configure_valid_slack(monkeypatch)
+    monkeypatch.setattr(clients.app_settings, "cloud_mcp_slack_enabled", enabled)
+    monkeypatch.setattr(
+        clients.app_settings,
+        "cloud_mcp_slack_distribution_ready",
+        distribution_ready,
+    )
+
+    with pytest.raises(IntegrationOAuthProviderError) as exc_info:
+        clients.validate_oauth_provider_start_readiness(_definition())
+
+    assert exc_info.value.code == "integration_provider_unavailable"
+
+
+def test_qualified_slack_requires_complete_static_client_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_valid_slack(monkeypatch)
+    monkeypatch.setattr(clients.app_settings, "cloud_mcp_slack_client_secret", "")
+
+    with pytest.raises(IntegrationOAuthProviderError) as exc_info:
+        clients.validate_oauth_provider_start_readiness(_definition())
+
+    assert exc_info.value.code == "missing_static_oauth_client"
+
+
+def test_qualified_slack_with_complete_config_is_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_valid_slack(monkeypatch)
+
+    clients.validate_oauth_provider_start_readiness(_definition())
+
+
+def test_non_static_provider_does_not_use_slack_distribution_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(clients.app_settings, "cloud_mcp_slack_enabled", False)
+    monkeypatch.setattr(clients.app_settings, "cloud_mcp_slack_distribution_ready", False)
+
+    clients.validate_oauth_provider_start_readiness(_definition(namespace="linear", mode="dcr"))
+
+
+@pytest.mark.asyncio
+async def test_unqualified_slack_start_fails_before_provider_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_valid_slack(monkeypatch)
+    monkeypatch.setattr(clients.app_settings, "cloud_mcp_slack_distribution_ready", False)
+    discovery_called = False
+
+    async def _unexpected_discovery(_server_url: str) -> None:
+        nonlocal discovery_called
+        discovery_called = True
+        raise AssertionError("provider discovery must not run")
+
+    monkeypatch.setattr(
+        oauth_service,
+        "discover_protected_resource_metadata",
+        _unexpected_discovery,
+    )
+
+    with pytest.raises(CloudApiError) as exc_info:
+        await oauth_service.start_oauth_flow(
+            cast(AsyncSession, object()),
+            user_id=uuid4(),
+            definition=_definition(),
+            account_id=None,
+            settings={},
+        )
+
+    assert exc_info.value.code == "integration_provider_unavailable"
+    assert discovery_called is False

--- a/specs/developing/reference/env-vars.yaml
+++ b/specs/developing/reference/env-vars.yaml
@@ -660,7 +660,13 @@
 - name: CLOUD_MCP_SLACK_ENABLED
   secret: false
   default: "false"
-  description: Shows the Slack MCP connector when static Slack OAuth config is also present
+  description: Allows Slack MCP OAuth only when static config and the independent distribution-qualification gate are also present
+  tags: [local-dev, self-hosted, production]
+
+- name: CLOUD_MCP_SLACK_DISTRIBUTION_READY
+  secret: false
+  default: "false"
+  description: Operator qualification that the exact configured Slack app is Marketplace-eligible and has passed its release canary; credentials alone never set this
   tags: [local-dev, self-hosted, production]
 
 - name: CLOUD_MCP_SLACK_CLIENT_ID


### PR DESCRIPTION
## Summary
- add a separate, default-off Slack distribution qualification gate
- reject unqualified Slack OAuth before provider discovery or client persistence
- document the deployment input and preserve qualified static-client behavior

## Proof
- `DEBUG=true uv run pytest -q tests/unit/test_cloud_integration_oauth_clients.py tests/unit/test_cloud_integration_oauth.py` (13 passed)
- `DEBUG=true uv run pytest -q tests/integration/test_cloud_integrations_api.py tests/integration/test_integration_oauth_scope_policy.py` (19 passed)
- `uv run ruff check ...` (changed Python files; passed)
- `uv run mypy proliferate/server/cloud/integrations/oauth/clients.py`
- `server/.venv/bin/python scripts/check_server_boundaries.py`
- `server/.venv/bin/python scripts/check_docs.py`
- `DEBUG=true uv run alembic heads` (single head `e7f1a3c9d20b`)

## Safety
- no production configuration was changed or deployed
- existing connected-account runtime use is unchanged
- Slack remains fail-closed unless an operator explicitly qualifies the exact app