### PR TITLE
feat(product): add queued-message action menu

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/input/PendingPromptList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/PendingPromptList.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 
 import { Profiler } from "react";
-import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   derivePendingPromptQueueRow,
@@ -73,6 +74,21 @@ function renderList(overrides: Partial<PendingPromptListProps> = {}) {
   return { ...render(<PendingPromptList {...props} />), props };
 }
 
+function rowFor(label: string): HTMLElement {
+  return screen.getByText(label).closest("[data-reorder-item]") as HTMLElement;
+}
+
+async function openRowMenu(label: string, user: ReturnType<typeof userEvent.setup>) {
+  const trigger = within(rowFor(label)).getByRole("button", {
+    name: "More queued-message actions",
+  });
+  await user.click(trigger);
+  return {
+    menu: await screen.findByRole("menu"),
+    trigger,
+  };
+}
+
 describe("PendingPromptList", () => {
   afterEach(() => {
     cleanup();
@@ -98,8 +114,9 @@ describe("PendingPromptList", () => {
     expect(props.onReorder).toHaveBeenCalledWith(1, 0);
   });
 
-  it("disables queue actions and drag handles during either queue mutation", () => {
-    renderList({ queueMutationInFlight: true });
+  it("disables queue actions and drag handles during either queue mutation", async () => {
+    const user = userEvent.setup();
+    const { props } = renderList({ queueMutationInFlight: true });
 
     expect(screen.queryByRole("button", { name: "Reorder queued message" })).toBeNull();
     const steerButtons = screen.getAllByRole("button", {
@@ -108,13 +125,130 @@ describe("PendingPromptList", () => {
     expect(steerButtons).toHaveLength(2);
     expect(steerButtons.every((button) => (button as HTMLButtonElement).disabled)).toBe(true);
     expect(
-      screen.getAllByRole("button", { name: "Edit queued message" })
-        .every((button) => (button as HTMLButtonElement).disabled),
-    ).toBe(true);
-    expect(
       screen.getAllByRole("button", { name: "Delete queued message" })
         .every((button) => (button as HTMLButtonElement).disabled),
     ).toBe(true);
+    expect(screen.queryByRole("button", { name: "Edit queued message" })).toBeNull();
+    expect(screen.getAllByRole("button", {
+      name: "More queued-message actions",
+    })).toHaveLength(2);
+
+    const { menu } = await openRowMenu("first", user);
+    const items = within(menu).getAllByRole("menuitem");
+    expect(items.map((item) => item.textContent)).toEqual([
+      "Edit message",
+      "Move up",
+      "Move down",
+    ]);
+    expect(items.every((item) => item.getAttribute("aria-disabled") === "true")).toBe(true);
+
+    await user.click(items[2]!);
+    expect(props.onBeginEdit).not.toHaveBeenCalled();
+    expect(props.onReorder).not.toHaveBeenCalled();
+  });
+
+  it("puts Edit and both move commands in the former Edit slot", async () => {
+    const user = userEvent.setup();
+    const thirdEntry = derivePendingPromptQueueRow({
+      seq: 12,
+      promptId: "third-id",
+      text: "third",
+      contentParts: [],
+      isBeingEdited: false,
+    });
+    const { props } = renderList({ entries: [...ENTRIES, thirdEntry] });
+    const secondRow = rowFor("second");
+    expect(within(secondRow).queryByRole("button", { name: "Edit queued message" })).toBeNull();
+    expect(within(secondRow).getAllByRole("button").map((button) => (
+      button.getAttribute("aria-label")
+    ))).toEqual([
+      "Reorder queued message",
+      "Send next — interrupts the current turn",
+      "More queued-message actions",
+      "Delete queued message",
+    ]);
+
+    let opened = await openRowMenu("second", user);
+    expect(within(opened.menu).getAllByRole("menuitem").map((item) => item.textContent)).toEqual([
+      "Edit message",
+      "Move up",
+      "Move down",
+    ]);
+    await user.click(within(opened.menu).getByRole("menuitem", { name: "Move up" }));
+    expect(props.onReorder).toHaveBeenNthCalledWith(1, 1, 0);
+
+    opened = await openRowMenu("second", user);
+    await user.click(within(opened.menu).getByRole("menuitem", { name: "Move down" }));
+    expect(props.onReorder).toHaveBeenNthCalledWith(2, 1, 2);
+
+    opened = await openRowMenu("second", user);
+    await user.click(within(opened.menu).getByRole("menuitem", { name: "Edit message" }));
+    expect(props.onBeginEdit).toHaveBeenCalledWith(ENTRIES[1]);
+  });
+
+  it("keeps boundary move commands visible and disabled", async () => {
+    const user = userEvent.setup();
+    renderList();
+    let opened = await openRowMenu("first", user);
+    expect(within(opened.menu).getByRole("menuitem", { name: "Move up" })
+      .getAttribute("aria-disabled")).toBe("true");
+    expect(within(opened.menu).getByRole("menuitem", { name: "Move down" })
+      .getAttribute("aria-disabled")).toBeNull();
+
+    await user.keyboard("{Escape}");
+    opened = await openRowMenu("second", user);
+    expect(within(opened.menu).getByRole("menuitem", { name: "Move up" })
+      .getAttribute("aria-disabled")).toBeNull();
+    expect(within(opened.menu).getByRole("menuitem", { name: "Move down" })
+      .getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("keeps a pre-ack Edit item visible with its disabled reason", async () => {
+    const user = userEvent.setup();
+    const preAckEntry = derivePendingPromptQueueRow({
+      seq: -1,
+      promptId: "local-prompt",
+      text: "awaiting acknowledgement",
+      contentParts: [],
+      isBeingEdited: false,
+      localOutboxDeliveryState: "unknown_after_dispatch",
+    });
+    renderList({ entries: [preAckEntry] });
+
+    const { menu } = await openRowMenu("awaiting acknowledgement", user);
+    const editItem = within(menu).getByRole("menuitem", { name: /Edit message/ });
+    expect(editItem.getAttribute("aria-disabled")).toBe("true");
+    expect(within(editItem).getByText("Available once queued")).toBeTruthy();
+    expect(within(menu).queryByRole("menuitem", { name: "Move up" })).toBeNull();
+    expect(within(menu).queryByRole("menuitem", { name: "Move down" })).toBeNull();
+  });
+
+  it("returns focus to the queued-message action trigger after Escape", async () => {
+    const user = userEvent.setup();
+    renderList();
+    const { menu, trigger } = await openRowMenu("first", user);
+
+    await waitFor(() => expect(menu.contains(document.activeElement)).toBe(true));
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("keeps Steer and Delete direct and wired", async () => {
+    const user = userEvent.setup();
+    const { props } = renderList();
+    const firstRow = rowFor("first");
+
+    await user.click(within(firstRow).getByRole("button", {
+      name: "Send next — interrupts the current turn",
+    }));
+    await user.click(within(firstRow).getByRole("button", {
+      name: "Delete queued message",
+    }));
+
+    expect(props.onSteer).toHaveBeenCalledWith(ENTRIES[0]);
+    expect(props.onDelete).toHaveBeenCalledWith(ENTRIES[0]);
   });
 
   it("skips local outbox rows during keyboard reorder", () => {
@@ -190,6 +324,9 @@ describe("PendingPromptList", () => {
     expect(within(aggregate as HTMLElement).queryByRole("button", {
       name: "Edit queued message",
     })).toBeNull();
+    expect(within(aggregate as HTMLElement).queryByRole("button", {
+      name: "More queued-message actions",
+    })).toBeNull();
     const glyphs = aggregate?.querySelectorAll("[data-pending-agent-glyph]") ?? [];
     expect(glyphs).toHaveLength(1);
 
@@ -240,8 +377,12 @@ describe("PendingPromptList", () => {
     expect(screen.getAllByRole("button", { name: "Reorder queued message" })).toHaveLength(2);
     expect(screen.getByText("Review feedback ready").closest("[data-reorder-item]")
       ?.querySelector('[aria-label="Reorder queued message"]')).toBeNull();
+    expect(screen.getByText("Review feedback ready").closest("[data-reorder-item]")
+      ?.querySelector('[aria-label="More queued-message actions"]')).toBeNull();
     expect(document.querySelector("[data-pending-agent-updates]")
       ?.querySelector('[aria-label="Reorder queued message"]')).toBeNull();
+    expect(document.querySelector("[data-pending-agent-updates]")
+      ?.querySelector('[aria-label="More queued-message actions"]')).toBeNull();
   });
 
   it("keeps a durable pending glyph non-clickable when its workspace is unresolved", () => {

--- a/apps/packages/product-client/src/components/workspace/chat/input/PendingPromptList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/PendingPromptList.test.tsx
@@ -213,14 +213,28 @@ describe("PendingPromptList", () => {
       isBeingEdited: false,
       localOutboxDeliveryState: "unknown_after_dispatch",
     });
-    renderList({ entries: [preAckEntry] });
+    const { props } = renderList({ entries: [preAckEntry] });
 
-    const { menu } = await openRowMenu("awaiting acknowledgement", user);
-    const editItem = within(menu).getByRole("menuitem", { name: /Edit message/ });
+    const trigger = within(rowFor("awaiting acknowledgement")).getByRole("button", {
+      name: "More queued-message actions",
+    });
+    trigger.focus();
+    await user.keyboard("{Enter}");
+    const menu = await screen.findByRole("menu");
+    const editItem = within(menu).getByRole("menuitem", {
+      name: "Edit message Available once queued",
+    });
     expect(editItem.getAttribute("aria-disabled")).toBe("true");
     expect(within(editItem).getByText("Available once queued")).toBeTruthy();
     expect(within(menu).queryByRole("menuitem", { name: "Move up" })).toBeNull();
     expect(within(menu).queryByRole("menuitem", { name: "Move down" })).toBeNull();
+
+    await waitFor(() => expect(document.activeElement).toBe(editItem));
+    await user.keyboard("{Enter}");
+
+    expect(props.onBeginEdit).not.toHaveBeenCalled();
+    expect(screen.getByRole("menu")).toBe(menu);
+    expect(document.activeElement).toBe(editItem);
   });
 
   it("returns focus to the queued-message action trigger after Escape", async () => {

--- a/apps/packages/product-client/src/components/workspace/chat/input/PendingPromptList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/PendingPromptList.tsx
@@ -1,7 +1,21 @@
 import { useCallback } from "react";
 import { Button } from "#product/primitives/Button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "#product/primitives/DropdownMenu";
 import { Tooltip } from "#product/primitives/Tooltip";
-import { ArrowUpRight, GripVertical, Pencil, X } from "#product/primitives/icons/core";
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpRight,
+  GripVertical,
+  MoreHorizontal,
+  Pencil,
+  X,
+} from "#product/primitives/icons/core";
 import { ThinkingText } from "#product/primitives/patterns/ThinkingText";
 import { PendingAgentUpdatesRow } from "#product/components/workspace/chat/input/PendingAgentUpdatesRow";
 import { CHAT_STREAMING_STATUS_LABELS } from "#product/copy/chat/chat-copy";
@@ -168,15 +182,17 @@ function PendingPromptRow({
     && sessionMaterialized
     && !entry.isSending
     && !entry.isBeingEdited;
-  const canDragReorder =
+  const isReorderEligible =
     entry.kind === "plain"
-    &&
-    isRuntimeConfirmed
+    && isRuntimeConfirmed
     && sessionMaterialized
-    && runtimeEntryCount > 1
+    && runtimeEntryCount > 1;
+  const canDragReorder =
+    isReorderEligible
     && !queueMutationInFlight;
   const renderEditAction = entry.showEditAction && !entry.isBeingEdited && !entry.isSending;
   const renderDeleteAction = entry.showDeleteAction && (!entry.isSending || entry.canDelete);
+  const renderActionMenu = renderEditAction || isReorderEligible;
 
   const handleBeginEdit = useCallback(() => {
     if (entry.canEdit) {
@@ -202,6 +218,16 @@ function PendingPromptRow({
       onReorder(index, nextReorderIndex);
     }
   }, [index, nextReorderIndex, onReorder, previousReorderIndex]);
+  const handleMoveUp = useCallback(() => {
+    if (!queueMutationInFlight && previousReorderIndex != null) {
+      onReorder(index, previousReorderIndex);
+    }
+  }, [index, onReorder, previousReorderIndex, queueMutationInFlight]);
+  const handleMoveDown = useCallback(() => {
+    if (!queueMutationInFlight && nextReorderIndex != null) {
+      onReorder(index, nextReorderIndex);
+    }
+  }, [index, nextReorderIndex, onReorder, queueMutationInFlight]);
 
   const stateHint = entry.isSending || isSteering
     ? (
@@ -270,20 +296,56 @@ function PendingPromptRow({
               </Button>
             </Tooltip>
           )}
-          {renderEditAction && (
-            <Tooltip content={entry.editDisabledReason ?? "Edit message"}>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                disabled={!entry.canEdit || queueMutationInFlight}
-                onClick={handleBeginEdit}
-                className={ROW_ACTION_CLASSNAME}
-                aria-label="Edit queued message"
-              >
-                <Pencil className="icon-paired" />
-              </Button>
-            </Tooltip>
+          {renderActionMenu && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className={ROW_ACTION_CLASSNAME}
+                  aria-label="More queued-message actions"
+                >
+                  <MoreHorizontal className="icon-paired" aria-hidden />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {renderEditAction && (
+                  <DropdownMenuItem
+                    disabled={!entry.canEdit || queueMutationInFlight}
+                    onSelect={handleBeginEdit}
+                  >
+                    <Pencil className="icon-paired" aria-hidden />
+                    <span className="min-w-0">
+                      <span className="block">Edit message</span>
+                      {!entry.canEdit && entry.editDisabledReason && (
+                        <span className="block text-ui-sm text-muted-foreground">
+                          {entry.editDisabledReason}
+                        </span>
+                      )}
+                    </span>
+                  </DropdownMenuItem>
+                )}
+                {isReorderEligible && (
+                  <>
+                    <DropdownMenuItem
+                      disabled={queueMutationInFlight || previousReorderIndex == null}
+                      onSelect={handleMoveUp}
+                    >
+                      <ArrowUp className="icon-paired" aria-hidden />
+                      Move up
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      disabled={queueMutationInFlight || nextReorderIndex == null}
+                      onSelect={handleMoveDown}
+                    >
+                      <ArrowDown className="icon-paired" aria-hidden />
+                      Move down
+                    </DropdownMenuItem>
+                  </>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
           {renderDeleteAction && (
             <Tooltip content={entry.deleteDisabledReason ?? "Remove from queue"}>

--- a/apps/packages/product-client/src/components/workspace/chat/input/PendingPromptList.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/PendingPromptList.tsx
@@ -193,12 +193,15 @@ function PendingPromptRow({
   const renderEditAction = entry.showEditAction && !entry.isBeingEdited && !entry.isSending;
   const renderDeleteAction = entry.showDeleteAction && (!entry.isSending || entry.canDelete);
   const renderActionMenu = renderEditAction || isReorderEligible;
+  const editActionUnavailable = !entry.canEdit || queueMutationInFlight;
 
-  const handleBeginEdit = useCallback(() => {
-    if (entry.canEdit) {
-      onBeginEdit(entry);
+  const handleBeginEdit = useCallback((event: Event) => {
+    if (editActionUnavailable) {
+      event.preventDefault();
+      return;
     }
-  }, [entry, onBeginEdit]);
+    onBeginEdit(entry);
+  }, [editActionUnavailable, entry, onBeginEdit]);
   const handleDelete = useCallback(() => {
     if (entry.canDelete) {
       onDelete(entry);
@@ -312,16 +315,20 @@ function PendingPromptRow({
               <DropdownMenuContent align="end">
                 {renderEditAction && (
                   <DropdownMenuItem
-                    disabled={!entry.canEdit || queueMutationInFlight}
+                    aria-disabled={editActionUnavailable || undefined}
+                    data-disabled={editActionUnavailable ? "" : undefined}
                     onSelect={handleBeginEdit}
                   >
                     <Pencil className="icon-paired" aria-hidden />
                     <span className="min-w-0">
                       <span className="block">Edit message</span>
                       {!entry.canEdit && entry.editDisabledReason && (
-                        <span className="block text-ui-sm text-muted-foreground">
-                          {entry.editDisabledReason}
-                        </span>
+                        <>
+                          {" "}
+                          <span className="block text-ui-sm text-muted-foreground">
+                            {entry.editDisabledReason}
+                          </span>
+                        </>
                       )}
                     </span>
                   </DropdownMenuItem>

--- a/apps/packages/product-client/src/config/playground.test.ts
+++ b/apps/packages/product-client/src/config/playground.test.ts
@@ -212,27 +212,31 @@ describe("playground scenarios", () => {
     expect(html).toContain("1 update");
     expect(html).not.toContain("Child session:");
     expect(html).not.toContain('aria-label="Delete queued message"');
-    expect(html).not.toContain('aria-label="Edit queued message"');
+    expect(html).not.toContain('aria-label="More queued-message actions"');
     expect(html).not.toContain('aria-label="Reorder queued message"');
   });
 
-  it("keeps queued rows compact and exposes steer, reorder, and edit actions", () => {
+  it("keeps queued rows compact and exposes direct controls plus the action menu", () => {
     const plainHtml = renderToStaticMarkup(renderOutboundSlot("pending-prompts-multi"));
     expect(plainHtml).toContain("line-clamp-2");
     expect(plainHtml).toContain("min-w-0");
     expect(plainHtml).toContain("whitespace-pre-wrap");
     // Head-of-queue entry is dispatching: it shows the shared "Thinking" shimmer
-    // state hint and drops the edit affordance while in flight.
+    // state hint and drops queued-message actions while in flight.
     expect(plainHtml).toContain("Thinking");
-    expect(plainHtml.match(/aria-label="Edit queued message"/g)).toHaveLength(2);
+    expect(plainHtml.match(/aria-label="More queued-message actions"/g)).toHaveLength(2);
     expect(plainHtml.match(/aria-label="Send next — interrupts the current turn"/g))
       .toHaveLength(2);
+    expect(plainHtml.match(/aria-label="Delete queued message"/g)).toHaveLength(2);
     expect(plainHtml.match(/aria-label="Reorder queued message"/g)).toHaveLength(2);
 
     const editingHtml = renderToStaticMarkup(renderOutboundSlot("pending-prompts-editing"));
     expect(editingHtml).toContain("Editing…");
-    expect(editingHtml.match(/aria-label="Edit queued message"/g)).toHaveLength(1);
+    expect(editingHtml.match(/aria-label="More queued-message actions"/g)).toHaveLength(2);
+    expect(editingHtml.match(/aria-label="Send next — interrupts the current turn"/g))
+      .toHaveLength(1);
     expect(editingHtml.match(/aria-label="Delete queued message"/g)).toHaveLength(2);
+    expect(editingHtml.match(/aria-label="Reorder queued message"/g)).toHaveLength(2);
   });
 
   it("keeps queued prompts before active questions and permission approvals", () => {

--- a/specs/codebase/systems/product/chat/composer.md
+++ b/specs/codebase/systems/product/chat/composer.md
@@ -503,6 +503,17 @@ the newest editable queued prompt. Steering promotes the selected prompt to the
 head and interrupts the active turn so normal durable queue drain executes it
 next.
 
+Plain queued-message rows keep Steer and Delete as direct actions. The former
+Edit slot is a keyboard-native action menu, ordered Edit message, Move up, then
+Move down. The menu renders when the row's Edit slot is visible or the plain
+runtime row is reorder-eligible. A pre-ack Edit item remains visible with its
+current disabled reason; boundary Move items also remain visible and disabled.
+Move commands target the nearest eligible plain runtime row and disable while a
+queue mutation is in flight, so local optimistic, agent-update, and review rows
+never acquire no-op reorder actions. Menu dismissal returns focus to its
+trigger. Selecting Edit enters the existing queued-edit workflow, and the
+explicit composer edit banner remains the pointer/touch Cancel path.
+
 ### The todo progress pill (`floatingSlot`)
 
 `TodoProgressPill.tsx` replaced the persistent `TodoTrackerPanel`/`TodoTrackerStrip`


### PR DESCRIPTION
## Summary

- adds a keyboard-native queued-message menu for Edit, Move up, and Move down
- keeps Steer and Delete direct while preserving current plain/agent/review row ownership
- preserves immutable `seq`/CAS ordering, current tray anatomy, and explicit queued-edit cancellation
- updates the canonical composer contract to name the action placement

## Frozen contract

- Vault spec: `/Users/pablohansen/Proliferate Workspace/ADRs/Session Surfaces Recovery/PR Specs/PR 1 - Queued-message action menu.md`
- Revision: `2026-08-19.2-frozen`
- Original implementation base: `8532f52b226413458721b46839fc78b852b69373`
- Final restacked base: `1a6b89c69c9d20295eafd94750f95be31af99ea5`
- Current reviewed head: `f6d8b96a6e812946a32b5a246780a7136a0654f2`

## Proof

- `pnpm --dir apps/packages/product-client exec vitest run src/components/workspace/chat/input/PendingPromptList.test.tsx src/config/playground.test.ts` — 30/30
- final independent review also ran the queue hook suite — 39/39 focused tests across the three suites
- `pnpm --filter @proliferate/product-client typecheck`
- `pnpm --filter @proliferate/product-client build`
- `pnpm --filter @proliferate/web typecheck`
- `pnpm --filter @proliferate/web build`
- `pnpm --filter @proliferate/design build`
- `node scripts/measure-login-runtime-budget.mjs`
- docs, frontend-boundary, component-library, appearance-scaling, strict frontend-structure, theme-contrast, design-attribution, and diff gates

Rendered browser verification covered dark and light themes, the long-label three-row queue, 700 px width with no horizontal overflow, queue + approval, delegated-work wake + approval, the adjacent current goal tray, and keyboard open/navigation/Escape with focus returning to the exact trigger. The current playground has no combined queue + goal fixture, so that adjacent tray was checked independently without expanding the frozen file scope.

The web build emitted only its existing CSS, dynamic-import, and chunk-size warnings. No Rust files changed, so no local Cargo build was run.

## Review

Independent review found and closed two blockers. `SSQ-001` covered the Radix-disabled pre-ack Edit item: the fix keeps it focusable with `aria-disabled`, preserves disabled styling, guards activation without closing or mutating, and adds a keyboard regression. `SSQ-002` updated the owning playground contract from the retired direct Edit icon to exact overflow-trigger counts while retaining direct Steer/Delete, reorder-handle, and no-control-row coverage. Round 3 accepted exact head `f6d8b96a6e812946a32b5a246780a7136a0654f2`; 39/39 focused tests passed and no findings remain.

The first exact-head CI run also hit the repository's known WebKit prepend-anchor failure (`scrollTop` 0 versus >150). The identical assertion failed on three recent `main` runs; the queue slice does not touch transcript scrolling. A current-head replacement run is required to be fully green before merge.

## Accessibility

The sanctioned menu primitive owns arrow navigation, Escape dismissal, typeahead, and focus return. Boundary and in-flight commands stay visible but disabled. Pre-ack Edit exposes “Available once queued” in its accessible name while remaining non-activating. Choosing Edit uses the existing queued-edit focus workflow, and pointer/touch cancellation remains visible.

## Observability

No telemetry or measurement delta. Prompt content remains inside the existing telemetry mask.
