### PR TITLE
fix(support): record Slack notification receipts truthfully

### DIFF
--- a/server/proliferate/server/support/notifications.py
+++ b/server/proliferate/server/support/notifications.py
@@ -79,7 +79,7 @@ async def notify_support_report(
     urgent: bool = False,
     notify_me: bool = False,
     correlation: dict[str, object] | None,
-) -> None:
+) -> bool:
     webhook_url = settings.support_slack_webhook_url.strip()
     if not webhook_url:
         # Fail loudly: a completed report that no one gets pinged about is a
@@ -92,7 +92,7 @@ async def notify_support_report(
             report_id,
             extra={"support_report_id": report_id, "urgent": urgent},
         )
-        return
+        return False
 
     plan = build_support_report_plan(
         sender_name=sender_display_name or sender_email,
@@ -136,6 +136,8 @@ async def notify_support_report(
             exc_info=True,
             extra={"support_report_id": report_id, "urgent": urgent},
         )
+        return False
+    return True
 
 
 def _support_report_internal_url(report_id: str) -> str | None:

--- a/server/proliferate/server/support/service.py
+++ b/server/proliferate/server/support/service.py
@@ -490,7 +490,7 @@ async def _complete_db_backed_report(
         },
     )
     if should_notify:
-        await notify_support_report(
+        delivered = await notify_support_report(
             sender_email=sender_email,
             sender_display_name=sender_display_name,
             report_id=completed_report.id,
@@ -505,7 +505,8 @@ async def _complete_db_backed_report(
             notify_me=completed_report.notify_me,
             correlation=support_report_correlation_record(completed_report),
         )
-        await support_reports.mark_report_slack_notified(db, report_id=completed_report.id)
+        if delivered:
+            await support_reports.mark_report_slack_notified(db, report_id=completed_report.id)
     return SupportReportCompleteResponse(reportId=report.id)
 
 

--- a/server/tests/integration/test_support_report_capture.py
+++ b/server/tests/integration/test_support_report_capture.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from uuid import uuid4
 
 import pytest
@@ -10,6 +11,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from proliferate.config import settings
 from proliferate.db.models.auth import User
 from proliferate.db.store import support_reports
+from proliferate.integrations.slack.errors import SlackWebhookError
+from proliferate.server.support import notifications as support_notifications
 from proliferate.server.support import service
 from proliferate.server.support.errors import SupportReportUploadInvalid
 from proliferate.server.support.models import (
@@ -22,6 +25,13 @@ from proliferate.server.support.models import (
 def _storage(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "support_report_s3_bucket", "private-support-bucket")
     monkeypatch.setattr(settings, "support_report_s3_region", "")
+    monkeypatch.setattr(settings, "support_slack_webhook_url", "")
+    monkeypatch.setattr(logging.getLogger("proliferate"), "propagate", True)
+    monkeypatch.setattr(
+        logging.getLogger(support_notifications.__name__),
+        "disabled",
+        False,
+    )
 
     async def _fake_put_json_object(**_: object) -> None:
         return None
@@ -148,6 +158,170 @@ async def _create_and_complete(
         body=SupportReportCompleteRequest(),
     )
     return response.report_id
+
+
+async def _complete_report(
+    db_session: AsyncSession,
+    user: User,
+    report_id: str,
+) -> None:
+    response = await service.complete_support_report_upload(
+        db=db_session,
+        sender_user_id=user.id,
+        sender_email=user.email,
+        sender_display_name=None,
+        report_id=report_id,
+        body=SupportReportCompleteRequest(),
+    )
+    assert response.report_id == report_id
+
+
+async def test_completion_records_slack_receipt_after_delivery_succeeds(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = await _user(db_session)
+    created = await service.create_support_report(
+        db=db_session,
+        sender_user_id=user.id,
+        sender_email=user.email,
+        sender_display_name=None,
+        body=_create_body(),
+    )
+    calls: list[str] = []
+
+    async def _fake_post_incoming_webhook(
+        *,
+        webhook_url: str,
+        text: str,
+        blocks: list[dict[str, object]] | None = None,
+    ) -> None:
+        del text, blocks
+        calls.append(webhook_url)
+        stored_before_success = await support_reports.get_report_by_id(
+            db_session, created.report_id
+        )
+        assert stored_before_success is not None
+        assert stored_before_success.status == "completed"
+        assert stored_before_success.slack_notified_at is None
+
+    monkeypatch.setattr(settings, "support_slack_webhook_url", "https://slack.test/report")
+    monkeypatch.setattr(
+        support_notifications,
+        "post_incoming_webhook",
+        _fake_post_incoming_webhook,
+    )
+
+    await _complete_report(db_session, user, created.report_id)
+    stored = await support_reports.get_report_by_id(db_session, created.report_id)
+    assert stored is not None
+    assert stored.status == "completed"
+    assert stored.slack_notified_at is not None
+    first_receipt = stored.slack_notified_at
+    assert calls == ["https://slack.test/report"]
+
+    await _complete_report(db_session, user, created.report_id)
+    stored_after_duplicate = await support_reports.get_report_by_id(db_session, created.report_id)
+    assert stored_after_duplicate is not None
+    assert stored_after_duplicate.slack_notified_at == first_receipt
+    assert calls == ["https://slack.test/report"]
+
+
+async def test_completion_leaves_slack_receipt_null_when_webhook_is_missing(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    user = await _user(db_session)
+    created = await service.create_support_report(
+        db=db_session,
+        sender_user_id=user.id,
+        sender_email=user.email,
+        sender_display_name=None,
+        body=_create_body(),
+    )
+    calls: list[str] = []
+
+    async def _fake_post_incoming_webhook(**_: object) -> None:
+        calls.append("called")
+
+    monkeypatch.setattr(settings, "support_slack_webhook_url", "  ")
+    monkeypatch.setattr(
+        support_notifications,
+        "post_incoming_webhook",
+        _fake_post_incoming_webhook,
+    )
+
+    with caplog.at_level(logging.ERROR, logger=support_notifications.__name__):
+        await _complete_report(db_session, user, created.report_id)
+        await _complete_report(db_session, user, created.report_id)
+
+    stored = await support_reports.get_report_by_id(db_session, created.report_id)
+    assert stored is not None
+    assert stored.status == "completed"
+    assert stored.slack_notified_at is None
+    assert calls == []
+    records = [
+        record for record in caplog.records if record.name == support_notifications.__name__
+    ]
+    assert len(records) == 1
+    assert records[0].levelno == logging.ERROR
+    assert records[0].getMessage() == (
+        f"Support report {created.report_id} completed but SUPPORT_SLACK_WEBHOOK_URL "
+        "is unset — no Slack notification sent. Set the webhook secret in this environment."
+    )
+
+
+async def test_completion_leaves_slack_receipt_null_when_delivery_fails(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    user = await _user(db_session)
+    created = await service.create_support_report(
+        db=db_session,
+        sender_user_id=user.id,
+        sender_email=user.email,
+        sender_display_name=None,
+        body=_create_body(),
+    )
+    calls: list[str] = []
+
+    async def _fake_post_incoming_webhook(
+        *,
+        webhook_url: str,
+        text: str,
+        blocks: list[dict[str, object]] | None = None,
+    ) -> None:
+        del text, blocks
+        calls.append(webhook_url)
+        raise SlackWebhookError("provider unavailable")
+
+    monkeypatch.setattr(settings, "support_slack_webhook_url", "https://slack.test/report")
+    monkeypatch.setattr(
+        support_notifications,
+        "post_incoming_webhook",
+        _fake_post_incoming_webhook,
+    )
+
+    with caplog.at_level(logging.ERROR, logger=support_notifications.__name__):
+        await _complete_report(db_session, user, created.report_id)
+        await _complete_report(db_session, user, created.report_id)
+
+    stored = await support_reports.get_report_by_id(db_session, created.report_id)
+    assert stored is not None
+    assert stored.status == "completed"
+    assert stored.slack_notified_at is None
+    assert calls == ["https://slack.test/report"]
+    records = [
+        record for record in caplog.records if record.name == support_notifications.__name__
+    ]
+    assert len(records) == 1
+    assert records[0].levelno == logging.ERROR
+    assert records[0].getMessage() == (
+        f"Support report {created.report_id} Slack notification failed to deliver: "
+        "provider unavailable"
+    )
 
 
 async def test_enforcement_accepts_legacy_absent_release(


### PR DESCRIPTION
## Summary

- Make `notify_support_report` return whether the Slack webhook await completed successfully.
- Write `slack_notified_at` only after confirmed delivery while keeping report completion successful for missing configuration and handled provider failures.
- Pin configured success, missing configuration, provider failure, and duplicate-completion/no-retry behavior against real Postgres with a fake Slack seam.

## Tests

- PASS — `(cd server && uv run --python 3.12 --frozen --extra dev pytest -q tests/integration/test_support_report_capture.py)` with CI-local `JWT_SECRET` and `CLOUD_SECRET_KEY` exported: 10 passed.
- PASS — `make lint-server`
- PASS — `make check-server-boundaries`
- PASS — `git diff --check`

## Observability delta

Durable receipt state is now truthful: missing configuration or handled Slack delivery failure leaves `slack_notified_at` null. The existing missing-configuration and provider-failure ERROR logs, levels, exception context, and bounded support-report fields are unchanged. No success log, event, metric, Sentry call, payload detail, or customer-content field was added.

## Frozen specification

- Path: `/Users/pablohansen/Proliferate Workspace/ADRs/Observability/Control Plane 2026-08-19/run-2026-08-19/specs/CP-S1 Support notification receipt truth.md`
- SHA-256: `549ea31012d68f8bd4a1b1f393f706de1f1a5372eda3c0400cd3106a2249ac0b`
- Frozen base: `1a6b89c69c9d20295eafd94750f95be31af99ea5`
- Head: `205d7c75e8b0cbf1b6074ba797df4d8de4b3b882`

## Live-provider proof

Not run, by design. No live Slack, S3, support-report, credential, or network action is part of this merge proof.
