### PR TITLE
feat(integrations): add authorization lifecycle schema

### DIFF
--- a/delivery/integration-lifecycle/delivery-spec-integration-lifecycle-pr1.md
+++ b/delivery/integration-lifecycle/delivery-spec-integration-lifecycle-pr1.md
@@ -1,0 +1,90 @@
+# Delivery specification: integration lifecycle PR1 — additive lifecycle schema
+
+Status: frozen delivery specification.
+Approved design: integration connection lifecycle ADR, decisions 1, 4, and 5;
+high-level sequencing PR1.
+Base revision: integration lifecycle PR0 squash-merged at
+`12518cb173d74bec51ea31c1aa7bd29a976dc74e`.
+
+## Outcome
+
+The database can represent authorization work separately from committed
+connections and can pin the revisions under which a connection was granted.
+This slice is additive and inert: existing endpoints, OAuth callbacks, refresh,
+gateway use, and disconnect keep their current behavior until later slices
+adopt the new records.
+
+## Scope
+
+- Add an immutable `cloud_integration_definition_security_revision` table.
+  Each row captures one definition's security-relevant auth kind, OAuth-client
+  mode, and serialized launch/auth configuration under a monotonic revision.
+- Add lifecycle fields to OAuth clients: monotonic `revision` and
+  `lifecycle_state` (`candidate`, `active`, `retiring`, or `retired`). Preserve
+  all current rows as active revision 1. Replace the old mutable-key uniqueness
+  constraint with revision uniqueness plus a partial unique index allowing at
+  most one active revision per definition, issuer, and redirect URI.
+- Add `cloud_integration_authorization_attempt` with owner, definition,
+  optional current connection, purpose, method, monotonic generation, terminal
+  state, expiry, starting grant/credential versions, pinned definition/client
+  revisions, normalized credential audience, non-secret settings and scope
+  snapshots, staged encrypted credential fields, failure code, and timestamps.
+  Enforce one generation per owner+definition and at most one non-terminal
+  attempt for that pair.
+- Add nullable `attempt_id` to OAuth flows so later code can bind browser work
+  to the domain attempt while the legacy `account_id` path remains valid.
+- Add `grant_version`, `credential_version`, pinned definition/client revision,
+  normalized audience, and effective-scope snapshot to integration accounts.
+  Backfill both new versions from the existing `auth_version`; leave revision
+  pins nullable for the explicit legacy-compatibility window.
+- Add ORM models and store-record projections for the new schema without
+  changing read/write behavior.
+- Add typed server management response models for provider availability,
+  committed connection, current attempt, and one primary plus secondary
+  actions. Do not expose a route or assemble responses in this slice.
+
+## Schema contract
+
+- Attempt purpose: `connect`, `reauthorize`, `rotate`.
+- Attempt method: `oauth2`, `api_key`, `none`.
+- Attempt status: `active`, `exchanging`, `validating`, `succeeded`, `failed`,
+  `cancelled`, `expired`, `superseded`.
+- Non-terminal attempt statuses are `active`, `exchanging`, and `validating`.
+- A staged credential is never plaintext; ciphertext and format are both null
+  or both non-null.
+- Every attempt pins a definition-security revision and non-empty normalized
+  audience. Connect attempts have no account or starting versions; replacement
+  attempts require all three. Non-terminal states have no `closed_at`, while
+  every terminal state has one. Deleting a connection cascades its replacement
+  attempts rather than violating their required account binding.
+- Management primary actions are `connect`, `reconnect`,
+  `open_authorization`, or `none`; secondary actions are `cancel` and
+  `disconnect`.
+- Existing `auth_version`, account statuses, OAuth-flow statuses, API schemas,
+  and foreign-key delete behavior remain unchanged.
+
+## Non-goals
+
+- No attempt creation, stage-and-swap, callback CAS, refresh-version split,
+  per-operation admission, disconnect cutoff, revocation, provider probe, or UI
+  behavior.
+- No destructive migration, legacy placeholder cleanup, SDK regeneration, or
+  production deploy.
+- No new feature flag: absence of call sites keeps the schema dark.
+
+## Acceptance
+
+- A real-Postgres migration upgrade from the prior head preserves representative
+  definitions, OAuth clients, flows, and accounts while producing the expected
+  lifecycle backfill.
+- A downgrade restores the prior schema and preserved legacy values.
+- Database constraints reject duplicate attempt generations, concurrent
+  non-terminal attempts, invalid states, invalid staged-secret pairs, and two
+  active OAuth-client revisions for the same key.
+- ORM metadata and schema assertions include every new table, column, index,
+  constraint, and foreign key.
+- Store-record unit tests prove new persisted fields are projected without
+  exposing or decrypting secret material.
+- Focused unit/integration tests, migration-head validation, server boundary
+  checks, documentation checks, Ruff, mypy on changed modules, and
+  `git diff --check` pass.

--- a/server/alembic/versions/a21c34d56e78_integration_lifecycle_schema.py
+++ b/server/alembic/versions/a21c34d56e78_integration_lifecycle_schema.py
@@ -1,0 +1,408 @@
+"""add integration authorization-attempt and revision schema
+
+Revision ID: a21c34d56e78
+Revises: e7f1a3c9d20b
+Create Date: 2026-08-19 00:00:00.000000
+
+This is an additive compatibility migration. Existing account and OAuth-flow
+behavior continues to use ``auth_version`` and ``account_id`` until later
+lifecycle slices adopt the new records.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a21c34d56e78"
+down_revision: str | Sequence[str] | None = "e7f1a3c9d20b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _timestamps() -> tuple[sa.Column, sa.Column]:
+    return (
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+
+
+def upgrade() -> None:
+    op.create_table(
+        "cloud_integration_definition_security_revision",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            server_default=sa.text("gen_random_uuid()"),
+            primary_key=True,
+        ),
+        sa.Column("definition_id", sa.Uuid(), nullable=False),
+        sa.Column("revision", sa.Integer(), nullable=False),
+        sa.Column("auth_kind", sa.String(length=32), nullable=False),
+        sa.Column("oauth_client_mode", sa.String(length=32), nullable=True),
+        sa.Column("config_json", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "revision > 0",
+            name="ck_cloud_integration_definition_security_revision_positive",
+        ),
+        sa.CheckConstraint(
+            "auth_kind IN ('oauth2', 'api_key', 'none')",
+            name="ck_cloud_integration_definition_security_revision_auth_kind",
+        ),
+        sa.ForeignKeyConstraint(
+            ["definition_id"],
+            ["cloud_integration_definition.id"],
+            name="fk_cloud_integration_definition_security_revision_definition",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint(
+            "definition_id",
+            "revision",
+            name="uq_cloud_integration_definition_security_revision",
+        ),
+    )
+    op.create_index(
+        "ix_cloud_integration_definition_security_revision_definition_id",
+        "cloud_integration_definition_security_revision",
+        ["definition_id"],
+    )
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO cloud_integration_definition_security_revision (
+                id, definition_id, revision, auth_kind, oauth_client_mode,
+                config_json, created_at
+            )
+            SELECT gen_random_uuid(), id, 1, auth_kind, oauth_client_mode,
+                   config_json, created_at
+            FROM cloud_integration_definition
+            """
+        )
+    )
+
+    op.add_column(
+        "cloud_integration_oauth_client",
+        sa.Column("revision", sa.Integer(), server_default="1", nullable=False),
+    )
+    op.add_column(
+        "cloud_integration_oauth_client",
+        sa.Column(
+            "lifecycle_state",
+            sa.String(length=32),
+            server_default="active",
+            nullable=False,
+        ),
+    )
+    op.create_check_constraint(
+        "ck_cloud_integration_oauth_client_revision_positive",
+        "cloud_integration_oauth_client",
+        "revision > 0",
+    )
+    op.create_check_constraint(
+        "ck_cloud_integration_oauth_client_lifecycle_state",
+        "cloud_integration_oauth_client",
+        "lifecycle_state IN ('candidate', 'active', 'retiring', 'retired')",
+    )
+    op.drop_constraint(
+        "uq_cloud_integration_oauth_client_key",
+        "cloud_integration_oauth_client",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "uq_cloud_integration_oauth_client_revision",
+        "cloud_integration_oauth_client",
+        ["issuer", "redirect_uri", "definition_id", "revision"],
+    )
+    op.create_index(
+        "ux_cloud_integration_oauth_client_active",
+        "cloud_integration_oauth_client",
+        ["issuer", "redirect_uri", "definition_id"],
+        unique=True,
+        postgresql_where=sa.text("lifecycle_state = 'active'"),
+    )
+
+    op.add_column(
+        "cloud_integration_account",
+        sa.Column("grant_version", sa.Integer(), server_default="1", nullable=False),
+    )
+    op.add_column(
+        "cloud_integration_account",
+        sa.Column("credential_version", sa.Integer(), server_default="1", nullable=False),
+    )
+    op.add_column(
+        "cloud_integration_account",
+        sa.Column("definition_security_revision_id", sa.Uuid(), nullable=True),
+    )
+    op.add_column(
+        "cloud_integration_account",
+        sa.Column("provider_client_id", sa.Uuid(), nullable=True),
+    )
+    op.add_column(
+        "cloud_integration_account",
+        sa.Column("credential_audience", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "cloud_integration_account",
+        sa.Column("effective_scopes_json", sa.Text(), nullable=True),
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE cloud_integration_account
+            SET grant_version = auth_version,
+                credential_version = auth_version
+            """
+        )
+    )
+    op.create_foreign_key(
+        "fk_cloud_integration_account_definition_security_revision",
+        "cloud_integration_account",
+        "cloud_integration_definition_security_revision",
+        ["definition_security_revision_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        "fk_cloud_integration_account_provider_client",
+        "cloud_integration_account",
+        "cloud_integration_oauth_client",
+        ["provider_client_id"],
+        ["id"],
+    )
+
+    op.create_table(
+        "cloud_integration_authorization_attempt",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            server_default=sa.text("gen_random_uuid()"),
+            primary_key=True,
+        ),
+        sa.Column("owner_user_id", sa.Uuid(), nullable=False),
+        sa.Column("definition_id", sa.Uuid(), nullable=False),
+        sa.Column("account_id", sa.Uuid(), nullable=True),
+        sa.Column("purpose", sa.String(length=32), nullable=False),
+        sa.Column("method", sa.String(length=32), nullable=False),
+        sa.Column("generation", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=32), server_default="active", nullable=False),
+        sa.Column("starting_grant_version", sa.Integer(), nullable=True),
+        sa.Column("starting_credential_version", sa.Integer(), nullable=True),
+        sa.Column("definition_security_revision_id", sa.Uuid(), nullable=False),
+        sa.Column("provider_client_id", sa.Uuid(), nullable=True),
+        sa.Column("credential_audience", sa.Text(), nullable=False),
+        sa.Column("settings_json", sa.Text(), server_default="{}", nullable=False),
+        sa.Column("requested_scopes_json", sa.Text(), server_default="[]", nullable=False),
+        sa.Column("effective_scopes_json", sa.Text(), nullable=True),
+        sa.Column("staged_credential_ciphertext", sa.Text(), nullable=True),
+        sa.Column("staged_credential_format", sa.String(length=64), nullable=True),
+        sa.Column("failure_code", sa.String(length=64), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("closed_at", sa.DateTime(timezone=True), nullable=True),
+        *_timestamps(),
+        sa.CheckConstraint(
+            "purpose IN ('connect', 'reauthorize', 'rotate')",
+            name="ck_cloud_integration_authorization_attempt_purpose",
+        ),
+        sa.CheckConstraint(
+            "method IN ('oauth2', 'api_key', 'none')",
+            name="ck_cloud_integration_authorization_attempt_method",
+        ),
+        sa.CheckConstraint(
+            "status IN ('active', 'exchanging', 'validating', 'succeeded', "
+            "'failed', 'cancelled', 'expired', 'superseded')",
+            name="ck_cloud_integration_authorization_attempt_status",
+        ),
+        sa.CheckConstraint(
+            "generation > 0",
+            name="ck_cloud_integration_authorization_attempt_generation_positive",
+        ),
+        sa.CheckConstraint(
+            "starting_grant_version IS NULL OR starting_grant_version > 0",
+            name="ck_cloud_int_auth_attempt_grant_version_positive",
+        ),
+        sa.CheckConstraint(
+            "starting_credential_version IS NULL OR starting_credential_version > 0",
+            name="ck_cloud_int_auth_attempt_credential_version_positive",
+        ),
+        sa.CheckConstraint(
+            "(staged_credential_ciphertext IS NULL) = (staged_credential_format IS NULL)",
+            name="ck_cloud_integration_authorization_attempt_staged_pair",
+        ),
+        sa.CheckConstraint(
+            "btrim(credential_audience) <> ''",
+            name="ck_cloud_integration_authorization_attempt_audience",
+        ),
+        sa.CheckConstraint(
+            "(purpose = 'connect' AND account_id IS NULL "
+            "AND starting_grant_version IS NULL "
+            "AND starting_credential_version IS NULL) OR "
+            "(purpose IN ('reauthorize', 'rotate') AND account_id IS NOT NULL "
+            "AND starting_grant_version IS NOT NULL "
+            "AND starting_credential_version IS NOT NULL)",
+            name="ck_cloud_int_auth_attempt_starting_connection",
+        ),
+        sa.CheckConstraint(
+            "(status IN ('active', 'exchanging', 'validating') AND closed_at IS NULL) OR "
+            "(status IN ('succeeded', 'failed', 'cancelled', 'expired', 'superseded') "
+            "AND closed_at IS NOT NULL)",
+            name="ck_cloud_int_auth_attempt_terminal_time",
+        ),
+        sa.ForeignKeyConstraint(["owner_user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["definition_id"], ["cloud_integration_definition.id"]),
+        sa.ForeignKeyConstraint(
+            ["account_id"], ["cloud_integration_account.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["definition_security_revision_id"],
+            ["cloud_integration_definition_security_revision.id"],
+        ),
+        sa.ForeignKeyConstraint(["provider_client_id"], ["cloud_integration_oauth_client.id"]),
+        sa.UniqueConstraint(
+            "owner_user_id",
+            "definition_id",
+            "generation",
+            name="uq_cloud_integration_authorization_attempt_generation",
+        ),
+    )
+    op.create_index(
+        "ix_cloud_integration_authorization_attempt_owner_user_id",
+        "cloud_integration_authorization_attempt",
+        ["owner_user_id"],
+    )
+    op.create_index(
+        "ix_cloud_integration_authorization_attempt_definition_id",
+        "cloud_integration_authorization_attempt",
+        ["definition_id"],
+    )
+    op.create_index(
+        "ix_cloud_integration_authorization_attempt_account_id",
+        "cloud_integration_authorization_attempt",
+        ["account_id"],
+    )
+    op.create_index(
+        "ix_cloud_integration_authorization_attempt_expires_at",
+        "cloud_integration_authorization_attempt",
+        ["expires_at"],
+    )
+    op.create_index(
+        "ux_cloud_integration_authorization_attempt_nonterminal",
+        "cloud_integration_authorization_attempt",
+        ["owner_user_id", "definition_id"],
+        unique=True,
+        postgresql_where=sa.text("status IN ('active', 'exchanging', 'validating')"),
+    )
+
+    op.add_column(
+        "cloud_integration_oauth_flow",
+        sa.Column("attempt_id", sa.Uuid(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_cloud_integration_oauth_flow_attempt",
+        "cloud_integration_oauth_flow",
+        "cloud_integration_authorization_attempt",
+        ["attempt_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_index(
+        "ix_cloud_integration_oauth_flow_attempt_id",
+        "cloud_integration_oauth_flow",
+        ["attempt_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_cloud_integration_oauth_flow_attempt_id",
+        table_name="cloud_integration_oauth_flow",
+    )
+    op.drop_constraint(
+        "fk_cloud_integration_oauth_flow_attempt",
+        "cloud_integration_oauth_flow",
+        type_="foreignkey",
+    )
+    op.drop_column("cloud_integration_oauth_flow", "attempt_id")
+
+    op.drop_table("cloud_integration_authorization_attempt")
+
+    op.drop_constraint(
+        "fk_cloud_integration_account_provider_client",
+        "cloud_integration_account",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "fk_cloud_integration_account_definition_security_revision",
+        "cloud_integration_account",
+        type_="foreignkey",
+    )
+    op.drop_column("cloud_integration_account", "effective_scopes_json")
+    op.drop_column("cloud_integration_account", "credential_audience")
+    op.drop_column("cloud_integration_account", "provider_client_id")
+    op.drop_column("cloud_integration_account", "definition_security_revision_id")
+    op.drop_column("cloud_integration_account", "credential_version")
+    op.drop_column("cloud_integration_account", "grant_version")
+
+    op.drop_index(
+        "ux_cloud_integration_oauth_client_active",
+        table_name="cloud_integration_oauth_client",
+    )
+    op.drop_constraint(
+        "uq_cloud_integration_oauth_client_revision",
+        "cloud_integration_oauth_client",
+        type_="unique",
+    )
+    # The old schema can hold only one client per key. Prefer the active
+    # revision, otherwise the highest revision, before restoring that shape.
+    op.execute(
+        sa.text(
+            """
+            DELETE FROM cloud_integration_oauth_client
+            WHERE id IN (
+                SELECT id FROM (
+                    SELECT id,
+                           row_number() OVER (
+                               PARTITION BY issuer, redirect_uri, definition_id
+                               ORDER BY (lifecycle_state = 'active') DESC, revision DESC
+                           ) AS ordinal
+                    FROM cloud_integration_oauth_client
+                ) ranked
+                WHERE ordinal > 1
+            )
+            """
+        )
+    )
+    op.create_unique_constraint(
+        "uq_cloud_integration_oauth_client_key",
+        "cloud_integration_oauth_client",
+        ["issuer", "redirect_uri", "definition_id"],
+    )
+    op.drop_constraint(
+        "ck_cloud_integration_oauth_client_lifecycle_state",
+        "cloud_integration_oauth_client",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_cloud_integration_oauth_client_revision_positive",
+        "cloud_integration_oauth_client",
+        type_="check",
+    )
+    op.drop_column("cloud_integration_oauth_client", "lifecycle_state")
+    op.drop_column("cloud_integration_oauth_client", "revision")
+
+    op.drop_table("cloud_integration_definition_security_revision")

--- a/server/proliferate/db/models/cloud/__init__.py
+++ b/server/proliferate/db/models/cloud/__init__.py
@@ -8,6 +8,7 @@ from . import agent_gateway as agent_gateway  # noqa: F401
 from . import agent_run_config as agent_run_config  # noqa: F401
 from . import github_app as github_app  # noqa: F401
 from . import integration_approvals as integration_approvals  # noqa: F401
+from . import integration_authorization as integration_authorization  # noqa: F401
 from . import integrations as integrations  # noqa: F401
 from . import repositories as repositories  # noqa: F401
 from . import runtime_workers as runtime_workers  # noqa: F401

--- a/server/proliferate/db/models/cloud/integration_authorization.py
+++ b/server/proliferate/db/models/cloud/integration_authorization.py
@@ -1,0 +1,162 @@
+"""Integration authorization-attempt and security-revision models."""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from proliferate.db.models.base import Base
+from proliferate.lib.infra.time.wall_clock import utcnow
+
+
+class CloudIntegrationDefinitionSecurityRevision(Base):
+    """Immutable security-relevant snapshot of an integration definition."""
+
+    __tablename__ = "cloud_integration_definition_security_revision"
+    __table_args__ = (
+        CheckConstraint(
+            "revision > 0",
+            name="ck_cloud_integration_definition_security_revision_positive",
+        ),
+        CheckConstraint(
+            "auth_kind IN ('oauth2', 'api_key', 'none')",
+            name="ck_cloud_integration_definition_security_revision_auth_kind",
+        ),
+        UniqueConstraint(
+            "definition_id",
+            "revision",
+            name="uq_cloud_integration_definition_security_revision",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    definition_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("cloud_integration_definition.id", ondelete="CASCADE"),
+        index=True,
+    )
+    revision: Mapped[int] = mapped_column(Integer)
+    auth_kind: Mapped[str] = mapped_column(String(32))
+    oauth_client_mode: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    config_json: Mapped[str] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+
+
+class CloudIntegrationAuthorizationAttempt(Base):
+    """Temporary credential work; never itself an agent-usable connection."""
+
+    __tablename__ = "cloud_integration_authorization_attempt"
+    __table_args__ = (
+        CheckConstraint(
+            "purpose IN ('connect', 'reauthorize', 'rotate')",
+            name="ck_cloud_integration_authorization_attempt_purpose",
+        ),
+        CheckConstraint(
+            "method IN ('oauth2', 'api_key', 'none')",
+            name="ck_cloud_integration_authorization_attempt_method",
+        ),
+        CheckConstraint(
+            "status IN ('active', 'exchanging', 'validating', 'succeeded', "
+            "'failed', 'cancelled', 'expired', 'superseded')",
+            name="ck_cloud_integration_authorization_attempt_status",
+        ),
+        CheckConstraint(
+            "generation > 0",
+            name="ck_cloud_integration_authorization_attempt_generation_positive",
+        ),
+        CheckConstraint(
+            "starting_grant_version IS NULL OR starting_grant_version > 0",
+            name="ck_cloud_int_auth_attempt_grant_version_positive",
+        ),
+        CheckConstraint(
+            "starting_credential_version IS NULL OR starting_credential_version > 0",
+            name="ck_cloud_int_auth_attempt_credential_version_positive",
+        ),
+        CheckConstraint(
+            "(staged_credential_ciphertext IS NULL) = (staged_credential_format IS NULL)",
+            name="ck_cloud_integration_authorization_attempt_staged_pair",
+        ),
+        CheckConstraint(
+            "btrim(credential_audience) <> ''",
+            name="ck_cloud_integration_authorization_attempt_audience",
+        ),
+        CheckConstraint(
+            "(purpose = 'connect' AND account_id IS NULL "
+            "AND starting_grant_version IS NULL "
+            "AND starting_credential_version IS NULL) OR "
+            "(purpose IN ('reauthorize', 'rotate') AND account_id IS NOT NULL "
+            "AND starting_grant_version IS NOT NULL "
+            "AND starting_credential_version IS NOT NULL)",
+            name="ck_cloud_int_auth_attempt_starting_connection",
+        ),
+        CheckConstraint(
+            "(status IN ('active', 'exchanging', 'validating') AND closed_at IS NULL) OR "
+            "(status IN ('succeeded', 'failed', 'cancelled', 'expired', 'superseded') "
+            "AND closed_at IS NOT NULL)",
+            name="ck_cloud_int_auth_attempt_terminal_time",
+        ),
+        UniqueConstraint(
+            "owner_user_id",
+            "definition_id",
+            "generation",
+            name="uq_cloud_integration_authorization_attempt_generation",
+        ),
+        Index(
+            "ux_cloud_integration_authorization_attempt_nonterminal",
+            "owner_user_id",
+            "definition_id",
+            unique=True,
+            postgresql_where="status IN ('active', 'exchanging', 'validating')",
+        ),
+        Index("ix_cloud_integration_authorization_attempt_expires_at", "expires_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    owner_user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"),
+        index=True,
+    )
+    definition_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("cloud_integration_definition.id"),
+        index=True,
+    )
+    account_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_integration_account.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    purpose: Mapped[str] = mapped_column(String(32))
+    method: Mapped[str] = mapped_column(String(32))
+    generation: Mapped[int] = mapped_column(Integer)
+    status: Mapped[str] = mapped_column(String(32), default="active")
+    starting_grant_version: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    starting_credential_version: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    definition_security_revision_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("cloud_integration_definition_security_revision.id"),
+    )
+    provider_client_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_integration_oauth_client.id"),
+        nullable=True,
+    )
+    credential_audience: Mapped[str] = mapped_column(Text)
+    settings_json: Mapped[str] = mapped_column(Text, default="{}")
+    requested_scopes_json: Mapped[str] = mapped_column(Text, default="[]")
+    effective_scopes_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    staged_credential_ciphertext: Mapped[str | None] = mapped_column(Text, nullable=True)
+    staged_credential_format: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    failure_code: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    closed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, onupdate=utcnow
+    )

--- a/server/proliferate/db/models/cloud/integrations.py
+++ b/server/proliferate/db/models/cloud/integrations.py
@@ -164,6 +164,18 @@ class CloudIntegrationAccount(Base):
     # the real format ('secret-fields-v1' / 'oauth-bundle-v1') with the bundle.
     credential_format: Mapped[str | None] = mapped_column(String(64), nullable=True)
     auth_version: Mapped[int] = mapped_column(Integer, default=1)
+    grant_version: Mapped[int] = mapped_column(Integer, default=1)
+    credential_version: Mapped[int] = mapped_column(Integer, default=1)
+    definition_security_revision_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_integration_definition_security_revision.id"),
+        nullable=True,
+    )
+    provider_client_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_integration_oauth_client.id"),
+        nullable=True,
+    )
+    credential_audience: Mapped[str | None] = mapped_column(Text, nullable=True)
+    effective_scopes_json: Mapped[str | None] = mapped_column(Text, nullable=True)
     settings_json: Mapped[str] = mapped_column(Text, default="{}")
     token_expires_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
@@ -178,11 +190,28 @@ class CloudIntegrationAccount(Base):
 class CloudIntegrationOAuthClient(Base):
     __tablename__ = "cloud_integration_oauth_client"
     __table_args__ = (
+        CheckConstraint(
+            "revision > 0",
+            name="ck_cloud_integration_oauth_client_revision_positive",
+        ),
+        CheckConstraint(
+            "lifecycle_state IN ('candidate', 'active', 'retiring', 'retired')",
+            name="ck_cloud_integration_oauth_client_lifecycle_state",
+        ),
         UniqueConstraint(
             "issuer",
             "redirect_uri",
             "definition_id",
-            name="uq_cloud_integration_oauth_client_key",
+            "revision",
+            name="uq_cloud_integration_oauth_client_revision",
+        ),
+        Index(
+            "ux_cloud_integration_oauth_client_active",
+            "issuer",
+            "redirect_uri",
+            "definition_id",
+            unique=True,
+            postgresql_where="lifecycle_state = 'active'",
         ),
     )
 
@@ -195,6 +224,8 @@ class CloudIntegrationOAuthClient(Base):
     redirect_uri: Mapped[str] = mapped_column(Text)
     resource: Mapped[str | None] = mapped_column(Text, nullable=True)
     client_id: Mapped[str] = mapped_column(String(512))
+    revision: Mapped[int] = mapped_column(Integer, default=1)
+    lifecycle_state: Mapped[str] = mapped_column(String(32), default="active")
     client_secret_ciphertext: Mapped[str | None] = mapped_column(Text, nullable=True)
     client_secret_expires_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
@@ -230,6 +261,11 @@ class CloudIntegrationOAuthFlow(Base):
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     account_id: Mapped[uuid.UUID | None] = mapped_column(
         ForeignKey("cloud_integration_account.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    attempt_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("cloud_integration_authorization_attempt.id", ondelete="CASCADE"),
         index=True,
         nullable=True,
     )

--- a/server/proliferate/db/store/integrations/accounts.py
+++ b/server/proliferate/db/store/integrations/accounts.py
@@ -35,6 +35,12 @@ class IntegrationAccountRecord:
     credential_ciphertext: str | None
     credential_format: str | None
     auth_version: int
+    grant_version: int
+    credential_version: int
+    definition_security_revision_id: UUID | None
+    provider_client_id: UUID | None
+    credential_audience: str | None
+    effective_scopes_json: str | None
     settings_json: str
     token_expires_at: datetime | None
     last_error_code: str | None
@@ -54,6 +60,12 @@ def _record(account: CloudIntegrationAccount) -> IntegrationAccountRecord:
         credential_ciphertext=account.credential_ciphertext,
         credential_format=account.credential_format,
         auth_version=account.auth_version,
+        grant_version=account.grant_version,
+        credential_version=account.credential_version,
+        definition_security_revision_id=account.definition_security_revision_id,
+        provider_client_id=account.provider_client_id,
+        credential_audience=account.credential_audience,
+        effective_scopes_json=account.effective_scopes_json,
         settings_json=account.settings_json,
         token_expires_at=account.token_expires_at,
         last_error_code=account.last_error_code,
@@ -349,6 +361,11 @@ async def set_account_credentials(
     account.status = auth_status
     account.token_expires_at = token_expires_at
     account.auth_version = account.auth_version + 1
+    # Until lifecycle writers adopt the split versions, preserve the exact
+    # legacy revision on both new counters. This prevents drift between the
+    # additive migration and the stage-and-swap cutover.
+    account.grant_version = account.auth_version
+    account.credential_version = account.auth_version
     account.last_error_code = None
     account.updated_at = now
     await db.flush()

--- a/server/proliferate/db/store/integrations/authorization_attempts.py
+++ b/server/proliferate/db/store/integrations/authorization_attempts.py
@@ -1,0 +1,99 @@
+"""Read projections for integration authorization attempts.
+
+Mutation arrives with the stage-and-swap slice. Keeping this store read-only
+here makes the additive schema observable without enabling lifecycle behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.models.cloud.integration_authorization import (
+    CloudIntegrationAuthorizationAttempt,
+)
+
+
+@dataclass(frozen=True)
+class IntegrationAuthorizationAttemptRecord:
+    id: UUID
+    owner_user_id: UUID
+    definition_id: UUID
+    account_id: UUID | None
+    purpose: str
+    method: str
+    generation: int
+    status: str
+    starting_grant_version: int | None
+    starting_credential_version: int | None
+    definition_security_revision_id: UUID
+    provider_client_id: UUID | None
+    credential_audience: str
+    settings_json: str
+    requested_scopes_json: str
+    effective_scopes_json: str | None
+    staged_credential_ciphertext: str | None
+    staged_credential_format: str | None
+    failure_code: str | None
+    expires_at: datetime
+    closed_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+def _record(row: CloudIntegrationAuthorizationAttempt) -> IntegrationAuthorizationAttemptRecord:
+    return IntegrationAuthorizationAttemptRecord(
+        id=row.id,
+        owner_user_id=row.owner_user_id,
+        definition_id=row.definition_id,
+        account_id=row.account_id,
+        purpose=row.purpose,
+        method=row.method,
+        generation=row.generation,
+        status=row.status,
+        starting_grant_version=row.starting_grant_version,
+        starting_credential_version=row.starting_credential_version,
+        definition_security_revision_id=row.definition_security_revision_id,
+        provider_client_id=row.provider_client_id,
+        credential_audience=row.credential_audience,
+        settings_json=row.settings_json,
+        requested_scopes_json=row.requested_scopes_json,
+        effective_scopes_json=row.effective_scopes_json,
+        staged_credential_ciphertext=row.staged_credential_ciphertext,
+        staged_credential_format=row.staged_credential_format,
+        failure_code=row.failure_code,
+        expires_at=row.expires_at,
+        closed_at=row.closed_at,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+async def get_authorization_attempt(
+    db: AsyncSession,
+    attempt_id: UUID,
+) -> IntegrationAuthorizationAttemptRecord | None:
+    row = await db.get(CloudIntegrationAuthorizationAttempt, attempt_id)
+    return _record(row) if row is not None else None
+
+
+async def get_latest_authorization_attempt(
+    db: AsyncSession,
+    *,
+    owner_user_id: UUID,
+    definition_id: UUID,
+) -> IntegrationAuthorizationAttemptRecord | None:
+    row = await db.scalar(
+        select(CloudIntegrationAuthorizationAttempt)
+        .where(
+            CloudIntegrationAuthorizationAttempt.owner_user_id == owner_user_id,
+            CloudIntegrationAuthorizationAttempt.definition_id == definition_id,
+        )
+        .order_by(CloudIntegrationAuthorizationAttempt.generation.desc())
+        .limit(1)
+    )
+    return _record(row) if row is not None else None

--- a/server/proliferate/db/store/integrations/definition_security_revisions.py
+++ b/server/proliferate/db/store/integrations/definition_security_revisions.py
@@ -1,0 +1,67 @@
+"""Read projections for immutable integration-definition security revisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from proliferate.db.models.cloud.integration_authorization import (
+    CloudIntegrationDefinitionSecurityRevision,
+)
+
+
+@dataclass(frozen=True)
+class IntegrationDefinitionSecurityRevisionRecord:
+    id: UUID
+    definition_id: UUID
+    revision: int
+    auth_kind: str
+    oauth_client_mode: str | None
+    config_json: str
+    created_at: datetime
+
+
+def _record(
+    row: CloudIntegrationDefinitionSecurityRevision,
+) -> IntegrationDefinitionSecurityRevisionRecord:
+    return IntegrationDefinitionSecurityRevisionRecord(
+        id=row.id,
+        definition_id=row.definition_id,
+        revision=row.revision,
+        auth_kind=row.auth_kind,
+        oauth_client_mode=row.oauth_client_mode,
+        config_json=row.config_json,
+        created_at=row.created_at,
+    )
+
+
+async def get_definition_security_revision(
+    db: AsyncSession,
+    *,
+    definition_id: UUID,
+    revision: int,
+) -> IntegrationDefinitionSecurityRevisionRecord | None:
+    row = await db.scalar(
+        select(CloudIntegrationDefinitionSecurityRevision).where(
+            CloudIntegrationDefinitionSecurityRevision.definition_id == definition_id,
+            CloudIntegrationDefinitionSecurityRevision.revision == revision,
+        )
+    )
+    return _record(row) if row is not None else None
+
+
+async def get_latest_definition_security_revision(
+    db: AsyncSession,
+    definition_id: UUID,
+) -> IntegrationDefinitionSecurityRevisionRecord | None:
+    row = await db.scalar(
+        select(CloudIntegrationDefinitionSecurityRevision)
+        .where(CloudIntegrationDefinitionSecurityRevision.definition_id == definition_id)
+        .order_by(CloudIntegrationDefinitionSecurityRevision.revision.desc())
+        .limit(1)
+    )
+    return _record(row) if row is not None else None

--- a/server/proliferate/db/store/integrations/oauth_clients.py
+++ b/server/proliferate/db/store/integrations/oauth_clients.py
@@ -25,6 +25,8 @@ class IntegrationOAuthClientRecord:
     redirect_uri: str
     resource: str | None
     client_id: str
+    revision: int
+    lifecycle_state: str
     client_secret_ciphertext: str | None
     client_secret_expires_at: datetime | None
     token_endpoint_auth_method: str | None
@@ -42,6 +44,8 @@ def _record(client: CloudIntegrationOAuthClient) -> IntegrationOAuthClientRecord
         redirect_uri=client.redirect_uri,
         resource=client.resource,
         client_id=client.client_id,
+        revision=client.revision,
+        lifecycle_state=client.lifecycle_state,
         client_secret_ciphertext=client.client_secret_ciphertext,
         client_secret_expires_at=client.client_secret_expires_at,
         token_endpoint_auth_method=client.token_endpoint_auth_method,
@@ -64,6 +68,7 @@ async def get_oauth_client(
                 CloudIntegrationOAuthClient.issuer == issuer,
                 CloudIntegrationOAuthClient.redirect_uri == redirect_uri,
                 CloudIntegrationOAuthClient.definition_id == definition_id,
+                CloudIntegrationOAuthClient.lifecycle_state == "active",
             )
         )
     ).scalar_one_or_none()
@@ -91,6 +96,7 @@ async def upsert_oauth_client(
                 CloudIntegrationOAuthClient.issuer == issuer,
                 CloudIntegrationOAuthClient.redirect_uri == redirect_uri,
                 CloudIntegrationOAuthClient.definition_id == definition_id,
+                CloudIntegrationOAuthClient.lifecycle_state == "active",
             )
             .with_for_update()
         )

--- a/server/proliferate/db/store/integrations/oauth_flows.py
+++ b/server/proliferate/db/store/integrations/oauth_flows.py
@@ -21,6 +21,7 @@ from proliferate.lib.infra.time.wall_clock import utcnow
 class IntegrationOAuthFlowRecord:
     id: UUID
     account_id: UUID | None
+    attempt_id: UUID | None
     owner_user_id: UUID
     definition_id: UUID
     state_hash: str
@@ -48,6 +49,7 @@ def _record(flow: CloudIntegrationOAuthFlow) -> IntegrationOAuthFlowRecord:
     return IntegrationOAuthFlowRecord(
         id=flow.id,
         account_id=flow.account_id,
+        attempt_id=flow.attempt_id,
         owner_user_id=flow.owner_user_id,
         definition_id=flow.definition_id,
         state_hash=flow.state_hash,

--- a/server/proliferate/server/cloud/integrations/models.py
+++ b/server/proliferate/server/cloud/integrations/models.py
@@ -12,6 +12,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
+from typing_extensions import TypedDict
 
 AuthKind = Literal["oauth2", "api_key", "none"]
 Surface = Literal["desktop", "web"]
@@ -130,6 +131,74 @@ class IntegrationHealthItem(_CamelModel):
 
 class IntegrationHealthResponse(_CamelModel):
     items: list[IntegrationHealthItem]
+
+
+# --------------------------------------------------------------------------- #
+# Authoritative management projection (route and assembler land in PR2)
+# --------------------------------------------------------------------------- #
+
+
+IntegrationPrimaryAction = Literal["connect", "reconnect", "open_authorization", "none"]
+IntegrationSecondaryAction = Literal["cancel", "disconnect"]
+IntegrationAttemptPurpose = Literal["connect", "reauthorize", "rotate"]
+IntegrationAttemptStatus = Literal[
+    "active",
+    "exchanging",
+    "validating",
+    "succeeded",
+    "failed",
+    "cancelled",
+    "expired",
+    "superseded",
+]
+
+
+class IntegrationProviderAvailability(TypedDict):
+    available: bool
+    reason: str | None
+
+
+class IntegrationConnectionSummary(TypedDict):
+    accountId: UUID
+    status: str
+    enabled: bool
+    health: str
+    toolCount: int | None
+    tokenExpiresAt: datetime | None
+    lastErrorCode: str | None
+
+
+class IntegrationAuthorizationAttemptSummary(TypedDict):
+    attemptId: UUID
+    purpose: IntegrationAttemptPurpose
+    method: AuthKind
+    generation: int
+    status: IntegrationAttemptStatus
+    authorizationUrl: str | None
+    expiresAt: datetime
+    failureCode: str | None
+
+
+class IntegrationManagementActions(TypedDict):
+    primary: IntegrationPrimaryAction
+    secondary: list[IntegrationSecondaryAction]
+
+
+class IntegrationManagementItem(TypedDict):
+    definitionId: UUID
+    namespace: str
+    displayName: str
+    description: str | None
+    authKind: str
+    connectSchema: IntegrationConnectSchema
+    availability: IntegrationProviderAvailability
+    connection: IntegrationConnectionSummary | None
+    attempt: IntegrationAuthorizationAttemptSummary | None
+    actions: IntegrationManagementActions
+
+
+class IntegrationManagementResponse(TypedDict):
+    items: list[IntegrationManagementItem]
 
 
 # --------------------------------------------------------------------------- #

--- a/server/tests/integration/schema_migration_assertions.py
+++ b/server/tests/integration/schema_migration_assertions.py
@@ -15,7 +15,9 @@ async def assert_current_schema(conn: AsyncConnection, head_revision: str) -> No
         "billing_grant",
         "billing_subject",
         "cloud_integration_account",
+        "cloud_integration_authorization_attempt",
         "cloud_integration_definition",
+        "cloud_integration_definition_security_revision",
         "cloud_integration_gateway_token",
         "cloud_integration_oauth_client",
         "cloud_integration_oauth_flow",
@@ -269,6 +271,207 @@ async def assert_current_schema(conn: AsyncConnection, head_revision: str) -> No
         }
     )
     assert "cloud_integration_account" in tool_cache_foreign_keys
+
+    integration_account_columns = await conn.run_sync(
+        lambda sync_conn: {
+            column["name"]
+            for column in inspect(sync_conn).get_columns("cloud_integration_account")
+        }
+    )
+    assert {
+        "grant_version",
+        "credential_version",
+        "definition_security_revision_id",
+        "provider_client_id",
+        "credential_audience",
+        "effective_scopes_json",
+    } <= integration_account_columns
+    integration_account_foreign_keys = await conn.run_sync(
+        lambda sync_conn: {
+            tuple(foreign_key["constrained_columns"]): foreign_key["referred_table"]
+            for foreign_key in inspect(sync_conn).get_foreign_keys("cloud_integration_account")
+        }
+    )
+    assert integration_account_foreign_keys[("definition_security_revision_id",)] == (
+        "cloud_integration_definition_security_revision"
+    )
+    assert integration_account_foreign_keys[("provider_client_id",)] == (
+        "cloud_integration_oauth_client"
+    )
+
+    oauth_client_columns = await conn.run_sync(
+        lambda sync_conn: {
+            column["name"]
+            for column in inspect(sync_conn).get_columns("cloud_integration_oauth_client")
+        }
+    )
+    assert {"revision", "lifecycle_state"} <= oauth_client_columns
+    oauth_client_checks = await conn.run_sync(
+        lambda sync_conn: {
+            constraint["name"]
+            for constraint in inspect(sync_conn).get_check_constraints(
+                "cloud_integration_oauth_client"
+            )
+        }
+    )
+    assert {
+        "ck_cloud_integration_oauth_client_revision_positive",
+        "ck_cloud_integration_oauth_client_lifecycle_state",
+    } <= oauth_client_checks
+    oauth_client_uniques = await conn.run_sync(
+        lambda sync_conn: {
+            constraint["name"]
+            for constraint in inspect(sync_conn).get_unique_constraints(
+                "cloud_integration_oauth_client"
+            )
+        }
+    )
+    assert "uq_cloud_integration_oauth_client_revision" in oauth_client_uniques
+    oauth_client_indexes = await conn.run_sync(
+        lambda sync_conn: {
+            index["name"]
+            for index in inspect(sync_conn).get_indexes("cloud_integration_oauth_client")
+        }
+    )
+    assert "ux_cloud_integration_oauth_client_active" in oauth_client_indexes
+
+    oauth_flow_columns = await conn.run_sync(
+        lambda sync_conn: {
+            column["name"]
+            for column in inspect(sync_conn).get_columns("cloud_integration_oauth_flow")
+        }
+    )
+    assert "attempt_id" in oauth_flow_columns
+    oauth_flow_foreign_keys = await conn.run_sync(
+        lambda sync_conn: {
+            tuple(foreign_key["constrained_columns"]): foreign_key["referred_table"]
+            for foreign_key in inspect(sync_conn).get_foreign_keys("cloud_integration_oauth_flow")
+        }
+    )
+    assert oauth_flow_foreign_keys[("attempt_id",)] == ("cloud_integration_authorization_attempt")
+
+    attempt_columns = await conn.run_sync(
+        lambda sync_conn: {
+            column["name"]
+            for column in inspect(sync_conn).get_columns("cloud_integration_authorization_attempt")
+        }
+    )
+    assert {
+        "owner_user_id",
+        "definition_id",
+        "account_id",
+        "purpose",
+        "method",
+        "generation",
+        "status",
+        "starting_grant_version",
+        "starting_credential_version",
+        "definition_security_revision_id",
+        "provider_client_id",
+        "credential_audience",
+        "settings_json",
+        "requested_scopes_json",
+        "effective_scopes_json",
+        "staged_credential_ciphertext",
+        "staged_credential_format",
+        "failure_code",
+        "expires_at",
+        "closed_at",
+    } <= attempt_columns
+    attempt_checks = await conn.run_sync(
+        lambda sync_conn: {
+            constraint["name"]
+            for constraint in inspect(sync_conn).get_check_constraints(
+                "cloud_integration_authorization_attempt"
+            )
+        }
+    )
+    assert {
+        "ck_cloud_integration_authorization_attempt_purpose",
+        "ck_cloud_integration_authorization_attempt_method",
+        "ck_cloud_integration_authorization_attempt_status",
+        "ck_cloud_integration_authorization_attempt_generation_positive",
+        "ck_cloud_int_auth_attempt_grant_version_positive",
+        "ck_cloud_int_auth_attempt_credential_version_positive",
+        "ck_cloud_integration_authorization_attempt_staged_pair",
+        "ck_cloud_integration_authorization_attempt_audience",
+        "ck_cloud_int_auth_attempt_starting_connection",
+        "ck_cloud_int_auth_attempt_terminal_time",
+    } <= attempt_checks
+    attempt_uniques = await conn.run_sync(
+        lambda sync_conn: {
+            constraint["name"]
+            for constraint in inspect(sync_conn).get_unique_constraints(
+                "cloud_integration_authorization_attempt"
+            )
+        }
+    )
+    assert "uq_cloud_integration_authorization_attempt_generation" in attempt_uniques
+    attempt_foreign_keys = await conn.run_sync(
+        lambda sync_conn: {
+            tuple(foreign_key["constrained_columns"]): (
+                foreign_key["referred_table"],
+                foreign_key["options"].get("ondelete"),
+            )
+            for foreign_key in inspect(sync_conn).get_foreign_keys(
+                "cloud_integration_authorization_attempt"
+            )
+        }
+    )
+    assert attempt_foreign_keys[("owner_user_id",)] == ("user", "CASCADE")
+    assert attempt_foreign_keys[("definition_id",)][0] == "cloud_integration_definition"
+    assert attempt_foreign_keys[("account_id",)] == (
+        "cloud_integration_account",
+        "CASCADE",
+    )
+    assert attempt_foreign_keys[("definition_security_revision_id",)][0] == (
+        "cloud_integration_definition_security_revision"
+    )
+    assert attempt_foreign_keys[("provider_client_id",)][0] == ("cloud_integration_oauth_client")
+    attempt_indexes = await conn.run_sync(
+        lambda sync_conn: {
+            index["name"]
+            for index in inspect(sync_conn).get_indexes("cloud_integration_authorization_attempt")
+        }
+    )
+    assert "ux_cloud_integration_authorization_attempt_nonterminal" in attempt_indexes
+
+    security_revision_checks = await conn.run_sync(
+        lambda sync_conn: {
+            constraint["name"]
+            for constraint in inspect(sync_conn).get_check_constraints(
+                "cloud_integration_definition_security_revision"
+            )
+        }
+    )
+    assert {
+        "ck_cloud_integration_definition_security_revision_positive",
+        "ck_cloud_integration_definition_security_revision_auth_kind",
+    } <= security_revision_checks
+    security_revision_uniques = await conn.run_sync(
+        lambda sync_conn: {
+            constraint["name"]
+            for constraint in inspect(sync_conn).get_unique_constraints(
+                "cloud_integration_definition_security_revision"
+            )
+        }
+    )
+    assert "uq_cloud_integration_definition_security_revision" in security_revision_uniques
+    security_revision_foreign_keys = await conn.run_sync(
+        lambda sync_conn: {
+            tuple(foreign_key["constrained_columns"]): (
+                foreign_key["referred_table"],
+                foreign_key["options"].get("ondelete"),
+            )
+            for foreign_key in inspect(sync_conn).get_foreign_keys(
+                "cloud_integration_definition_security_revision"
+            )
+        }
+    )
+    assert security_revision_foreign_keys[("definition_id",)] == (
+        "cloud_integration_definition",
+        "CASCADE",
+    )
 
     github_app_installation_columns = await conn.run_sync(
         lambda sync_conn: {

--- a/server/tests/integration/test_cloud_integration_action_approvals_api.py
+++ b/server/tests/integration/test_cloud_integration_action_approvals_api.py
@@ -559,6 +559,8 @@ async def test_account_credential_rotation_invalidates_prior_approval(
         expected_auth_version=context.account_auth_version,
     )
     assert rotated is not None
+    assert rotated.grant_version == rotated.auth_version
+    assert rotated.credential_version == rotated.auth_version
     await db_session.commit()
 
     old_revision = await _consume(context, approval_id=approval_id, arguments=arguments)

--- a/server/tests/integration/test_integration_lifecycle_schema_migration.py
+++ b/server/tests/integration/test_integration_lifecycle_schema_migration.py
@@ -1,0 +1,416 @@
+"""Real-Postgres proof for the additive integration lifecycle schema."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from alembic import command
+from sqlalchemy import inspect, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from proliferate.db.migrations import build_alembic_config
+from tests.postgres import temporary_database
+
+_REVISION = "a21c34d56e78"
+_DOWN_REVISION = "e7f1a3c9d20b"
+
+
+async def _insert_legacy_rows(conn) -> dict[str, uuid.UUID]:  # type: ignore[no-untyped-def]
+    ids = {
+        "user": uuid.uuid4(),
+        "definition": uuid.uuid4(),
+        "account": uuid.uuid4(),
+        "client": uuid.uuid4(),
+        "flow": uuid.uuid4(),
+    }
+    await conn.execute(
+        text(
+            'INSERT INTO "user" '
+            "(id, email, hashed_password, is_active, is_superuser, is_verified, created_at) "
+            "VALUES (:id, :email, 'x', true, false, true, now())"
+        ),
+        {"id": ids["user"], "email": f"lifecycle-{ids['user']}@example.com"},
+    )
+    await conn.execute(
+        text(
+            "INSERT INTO cloud_integration_definition "
+            "(id, source, namespace, display_name, auth_kind, oauth_client_mode, "
+            "config_json, enabled_by_default, created_at, updated_at) "
+            "VALUES (:id, 'seed', 'migration-proof', 'Migration Proof', 'oauth2', "
+            "'dcr', :config_json, true, now(), now())"
+        ),
+        {"id": ids["definition"], "config_json": '{"version":1}'},
+    )
+    await conn.execute(
+        text(
+            "INSERT INTO cloud_integration_account "
+            "(id, definition_id, owner_user_id, owner_scope, enabled, status, auth_kind, "
+            "credential_ciphertext, credential_format, auth_version, settings_json, "
+            "created_at, updated_at) "
+            "VALUES (:id, :definition_id, :owner_user_id, 'personal', true, 'ready', "
+            "'oauth2', 'encrypted-account', 'oauth-bundle-v1', 7, '{}', now(), now())"
+        ),
+        {
+            "id": ids["account"],
+            "definition_id": ids["definition"],
+            "owner_user_id": ids["user"],
+        },
+    )
+    await conn.execute(
+        text(
+            "INSERT INTO cloud_integration_oauth_client "
+            "(id, definition_id, issuer, redirect_uri, resource, client_id, "
+            "client_secret_ciphertext, token_endpoint_auth_method, created_at, updated_at) "
+            "VALUES (:id, :definition_id, 'https://issuer.example', "
+            "'https://api.example/callback', 'https://resource.example', 'legacy-client', "
+            "'encrypted-client', 'client_secret_post', now(), now())"
+        ),
+        {"id": ids["client"], "definition_id": ids["definition"]},
+    )
+    await conn.execute(
+        text(
+            "INSERT INTO cloud_integration_oauth_flow "
+            "(id, account_id, owner_user_id, definition_id, state_hash, "
+            "code_verifier_ciphertext, issuer, resource, client_id, token_endpoint, "
+            "requested_scopes, redirect_uri, authorization_url, callback_surface, "
+            "final_surface, status, expires_at, created_at, updated_at) "
+            "VALUES (:id, :account_id, :owner_user_id, :definition_id, 'state-hash', "
+            "'encrypted-verifier', 'https://issuer.example', 'https://resource.example', "
+            "'legacy-client', 'https://issuer.example/token', '[\"read\"]', "
+            "'https://api.example/callback', 'https://issuer.example/authorize', "
+            "'desktop', 'desktop', 'active', now() + interval '10 minutes', now(), now())"
+        ),
+        {
+            "id": ids["flow"],
+            "account_id": ids["account"],
+            "owner_user_id": ids["user"],
+            "definition_id": ids["definition"],
+        },
+    )
+    return ids
+
+
+async def _assert_rejected(engine, statement: str, params: dict[str, object]) -> None:  # type: ignore[type-arg]
+    with pytest.raises(IntegrityError):
+        async with engine.begin() as conn:
+            await conn.execute(text(statement), params)
+
+
+async def test_lifecycle_schema_backfills_constraints_and_round_trips() -> None:
+    async with temporary_database("integration_lifecycle_schema") as (_name, database_url):
+        config = build_alembic_config(database_url)
+        await asyncio.to_thread(command.upgrade, config, _DOWN_REVISION)
+        engine = create_async_engine(database_url, echo=False)
+        try:
+            async with engine.begin() as conn:
+                ids = await _insert_legacy_rows(conn)
+
+            await asyncio.to_thread(command.upgrade, config, _REVISION)
+
+            async with engine.begin() as conn:
+                account = (
+                    (
+                        await conn.execute(
+                            text(
+                                "SELECT auth_version, grant_version, credential_version, "
+                                "definition_security_revision_id, provider_client_id, "
+                                "credential_audience FROM cloud_integration_account "
+                                "WHERE id = :id"
+                            ),
+                            {"id": ids["account"]},
+                        )
+                    )
+                    .mappings()
+                    .one()
+                )
+                assert dict(account) == {
+                    "auth_version": 7,
+                    "grant_version": 7,
+                    "credential_version": 7,
+                    "definition_security_revision_id": None,
+                    "provider_client_id": None,
+                    "credential_audience": None,
+                }
+                revision = (
+                    (
+                        await conn.execute(
+                            text(
+                                "SELECT revision, auth_kind, oauth_client_mode, config_json "
+                                "FROM cloud_integration_definition_security_revision "
+                                "WHERE definition_id = :definition_id"
+                            ),
+                            {"definition_id": ids["definition"]},
+                        )
+                    )
+                    .mappings()
+                    .one()
+                )
+                assert dict(revision) == {
+                    "revision": 1,
+                    "auth_kind": "oauth2",
+                    "oauth_client_mode": "dcr",
+                    "config_json": '{"version":1}',
+                }
+                client = (
+                    (
+                        await conn.execute(
+                            text(
+                                "SELECT revision, lifecycle_state "
+                                "FROM cloud_integration_oauth_client WHERE id = :id"
+                            ),
+                            {"id": ids["client"]},
+                        )
+                    )
+                    .mappings()
+                    .one()
+                )
+                assert dict(client) == {"revision": 1, "lifecycle_state": "active"}
+                assert (
+                    await conn.scalar(
+                        text("SELECT attempt_id FROM cloud_integration_oauth_flow WHERE id = :id"),
+                        {"id": ids["flow"]},
+                    )
+                    is None
+                )
+
+                security_revision_id = await conn.scalar(
+                    text(
+                        "SELECT id FROM cloud_integration_definition_security_revision "
+                        "WHERE definition_id = :definition_id"
+                    ),
+                    {"definition_id": ids["definition"]},
+                )
+                live_attempt_id = uuid.uuid4()
+                await conn.execute(
+                    text(
+                        "INSERT INTO cloud_integration_authorization_attempt "
+                        "(id, owner_user_id, definition_id, account_id, purpose, method, "
+                        "generation, status, starting_grant_version, "
+                        "starting_credential_version, definition_security_revision_id, "
+                        "provider_client_id, credential_audience, requested_scopes_json, "
+                        "expires_at) "
+                        "VALUES (:id, :owner, :definition, :account, 'reauthorize', 'oauth2', "
+                        "1, 'active', 7, 7, :security_revision, :client, "
+                        "'https://resource.example', '[\"read\"]', now() + interval '10 minutes')"
+                    ),
+                    {
+                        "id": live_attempt_id,
+                        "owner": ids["user"],
+                        "definition": ids["definition"],
+                        "account": ids["account"],
+                        "security_revision": security_revision_id,
+                        "client": ids["client"],
+                    },
+                )
+
+            attempt_insert = (
+                "INSERT INTO cloud_integration_authorization_attempt "
+                "(id, owner_user_id, definition_id, account_id, purpose, method, generation, "
+                "status, starting_grant_version, starting_credential_version, "
+                "definition_security_revision_id, credential_audience, "
+                "staged_credential_ciphertext, staged_credential_format, closed_at, expires_at) "
+                "VALUES (:id, :owner, :definition, :account, :purpose, 'oauth2', :generation, "
+                ":status, :starting_grant, :starting_credential, :security_revision, "
+                ":audience, :staged, :staged_format, :closed_at, "
+                "now() + interval '10 minutes')"
+            )
+            closed_at = datetime.now(UTC)
+            base = {
+                "owner": ids["user"],
+                "definition": ids["definition"],
+                "security_revision": security_revision_id,
+                "account": None,
+                "purpose": "connect",
+                "starting_grant": None,
+                "starting_credential": None,
+                "audience": "https://resource.example",
+                "staged": None,
+                "staged_format": None,
+            }
+            await _assert_rejected(
+                engine,
+                attempt_insert,
+                {
+                    **base,
+                    "id": uuid.uuid4(),
+                    "generation": 1,
+                    "status": "failed",
+                    "closed_at": closed_at,
+                },
+            )
+            await _assert_rejected(
+                engine,
+                attempt_insert,
+                {
+                    **base,
+                    "id": uuid.uuid4(),
+                    "generation": 2,
+                    "status": "active",
+                    "closed_at": None,
+                },
+            )
+            await _assert_rejected(
+                engine,
+                attempt_insert,
+                {
+                    **base,
+                    "id": uuid.uuid4(),
+                    "generation": 2,
+                    "status": "failed",
+                    "staged": "encrypted-without-format",
+                    "closed_at": closed_at,
+                },
+            )
+            await _assert_rejected(
+                engine,
+                attempt_insert,
+                {
+                    **base,
+                    "id": uuid.uuid4(),
+                    "generation": 4,
+                    "status": "failed",
+                    "closed_at": None,
+                },
+            )
+            await _assert_rejected(
+                engine,
+                attempt_insert,
+                {
+                    **base,
+                    "id": uuid.uuid4(),
+                    "generation": 5,
+                    "status": "failed",
+                    "audience": "   ",
+                    "closed_at": closed_at,
+                },
+            )
+            await _assert_rejected(
+                engine,
+                attempt_insert,
+                {
+                    **base,
+                    "id": uuid.uuid4(),
+                    "generation": 6,
+                    "status": "failed",
+                    "account": ids["account"],
+                    "starting_grant": 7,
+                    "starting_credential": 7,
+                    "closed_at": closed_at,
+                },
+            )
+            await _assert_rejected(
+                engine,
+                attempt_insert,
+                {
+                    **base,
+                    "id": uuid.uuid4(),
+                    "generation": 7,
+                    "status": "failed",
+                    "purpose": "reauthorize",
+                    "closed_at": closed_at,
+                },
+            )
+            async with engine.begin() as conn:
+                await conn.execute(
+                    text(
+                        "UPDATE cloud_integration_authorization_attempt "
+                        "SET status = 'failed', closed_at = now() WHERE id = :id"
+                    ),
+                    {"id": live_attempt_id},
+                )
+            await _assert_rejected(
+                engine,
+                attempt_insert,
+                {
+                    **base,
+                    "id": uuid.uuid4(),
+                    "generation": 8,
+                    "status": "active",
+                    "closed_at": closed_at,
+                },
+            )
+            await _assert_rejected(
+                engine,
+                attempt_insert,
+                {
+                    **base,
+                    "id": uuid.uuid4(),
+                    "generation": 3,
+                    "status": "unknown",
+                    "closed_at": closed_at,
+                },
+            )
+            await _assert_rejected(
+                engine,
+                "INSERT INTO cloud_integration_oauth_client "
+                "(id, definition_id, issuer, redirect_uri, client_id, revision, "
+                "lifecycle_state, created_at, updated_at) "
+                "VALUES (:id, :definition, 'https://issuer.example', "
+                "'https://api.example/callback', 'new-client', 2, 'active', now(), now())",
+                {"id": uuid.uuid4(), "definition": ids["definition"]},
+            )
+            async with engine.begin() as conn:
+                await conn.execute(
+                    text(
+                        "INSERT INTO cloud_integration_oauth_client "
+                        "(id, definition_id, issuer, redirect_uri, client_id, revision, "
+                        "lifecycle_state, created_at, updated_at) "
+                        "VALUES (:id, :definition, 'https://issuer.example', "
+                        "'https://api.example/callback', 'retired-client', 2, 'retired', "
+                        "now(), now())"
+                    ),
+                    {"id": uuid.uuid4(), "definition": ids["definition"]},
+                )
+
+            await asyncio.to_thread(command.downgrade, config, _DOWN_REVISION)
+            async with engine.begin() as conn:
+                tables = await conn.run_sync(
+                    lambda sync_conn: set(inspect(sync_conn).get_table_names())
+                )
+                assert "cloud_integration_authorization_attempt" not in tables
+                assert "cloud_integration_definition_security_revision" not in tables
+                account_columns = await conn.run_sync(
+                    lambda sync_conn: {
+                        column["name"]
+                        for column in inspect(sync_conn).get_columns("cloud_integration_account")
+                    }
+                )
+                assert {
+                    "grant_version",
+                    "credential_version",
+                    "definition_security_revision_id",
+                    "provider_client_id",
+                    "credential_audience",
+                    "effective_scopes_json",
+                }.isdisjoint(account_columns)
+                assert (
+                    await conn.scalar(
+                        text("SELECT auth_version FROM cloud_integration_account WHERE id = :id"),
+                        {"id": ids["account"]},
+                    )
+                    == 7
+                )
+                assert (
+                    await conn.scalar(
+                        text(
+                            "SELECT client_id FROM cloud_integration_oauth_client WHERE id = :id"
+                        ),
+                        {"id": ids["client"]},
+                    )
+                    == "legacy-client"
+                )
+                assert (
+                    await conn.scalar(
+                        text("SELECT status FROM cloud_integration_oauth_flow WHERE id = :id"),
+                        {"id": ids["flow"]},
+                    )
+                    == "active"
+                )
+
+            await asyncio.to_thread(command.upgrade, config, "head")
+        finally:
+            await engine.dispose()

--- a/server/tests/unit/test_infra_time.py
+++ b/server/tests/unit/test_infra_time.py
@@ -64,7 +64,14 @@ def test_every_migrated_orm_wall_clock_default_remains_a_deferred_owner_referenc
 
     wall_clock_references, other_references = _split_datetime_default_owners(Base.metadata)
 
-    assert len(wall_clock_references) == 224
+    lifecycle_references = {
+        ("cloud_integration_definition_security_revision", "created_at", "default"),
+        ("cloud_integration_authorization_attempt", "created_at", "default"),
+        ("cloud_integration_authorization_attempt", "updated_at", "default"),
+        ("cloud_integration_authorization_attempt", "updated_at", "onupdate"),
+    }
+    assert lifecycle_references.issubset(wall_clock_references)
+    assert len(wall_clock_references) == 228
     assert other_references == [
         ("cloud_integration_action_approval", "updated_at", "onupdate"),
         ("cloud_integration_action_approval_event", "updated_at", "onupdate"),

--- a/server/tests/unit/test_integration_lifecycle_contracts.py
+++ b/server/tests/unit/test_integration_lifecycle_contracts.py
@@ -1,0 +1,70 @@
+"""Typed contract proof for the server-owned integration management item."""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from proliferate.server.cloud.integrations.models import (
+    IntegrationAuthorizationAttemptSummary,
+    IntegrationConnectSchema,
+    IntegrationManagementActions,
+    IntegrationManagementItem,
+    IntegrationProviderAvailability,
+)
+
+_ITEM_ADAPTER = TypeAdapter(IntegrationManagementItem)
+_ACTIONS_ADAPTER = TypeAdapter(IntegrationManagementActions)
+
+
+def test_management_item_serializes_one_primary_action_without_secret_fields() -> None:
+    attempt_id = uuid4()
+    item = _ITEM_ADAPTER.validate_python(
+        IntegrationManagementItem(
+            definitionId=uuid4(),
+            namespace="linear",
+            displayName="Linear",
+            description=None,
+            authKind="oauth2",
+            connectSchema=IntegrationConnectSchema(),
+            availability=IntegrationProviderAvailability(available=True, reason=None),
+            connection=None,
+            attempt=IntegrationAuthorizationAttemptSummary(
+                attemptId=attempt_id,
+                purpose="connect",
+                method="oauth2",
+                generation=3,
+                status="active",
+                authorizationUrl="https://linear.example/authorize?opaque=1",
+                expiresAt=datetime(2026, 8, 19, 10, tzinfo=UTC),
+                failureCode=None,
+            ),
+            actions=IntegrationManagementActions(
+                primary="open_authorization",
+                secondary=["cancel"],
+            ),
+        )
+    )
+
+    payload = _ITEM_ADAPTER.dump_python(item, mode="json", exclude_none=True)
+
+    assert payload["attempt"]["attemptId"] == str(attempt_id)
+    assert payload["actions"] == {
+        "primary": "open_authorization",
+        "secondary": ["cancel"],
+    }
+    serialized = repr(payload).lower()
+    assert "ciphertext" not in serialized
+    assert "credential" not in serialized
+    assert "verifier" not in serialized
+
+
+def test_disconnect_cannot_be_encoded_as_a_second_primary_action() -> None:
+    with pytest.raises(ValidationError):
+        _ACTIONS_ADAPTER.validate_python(
+            {
+                "primary": "disconnect",
+                "secondary": [],
+            }
+        )

--- a/server/tests/unit/test_integration_lifecycle_store_records.py
+++ b/server/tests/unit/test_integration_lifecycle_store_records.py
@@ -1,0 +1,169 @@
+"""Projection proofs for additive integration lifecycle persistence fields."""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from proliferate.db.models.cloud.integration_authorization import (
+    CloudIntegrationAuthorizationAttempt,
+    CloudIntegrationDefinitionSecurityRevision,
+)
+from proliferate.db.models.cloud.integrations import (
+    CloudIntegrationAccount,
+    CloudIntegrationOAuthClient,
+    CloudIntegrationOAuthFlow,
+)
+from proliferate.db.store.integrations import accounts
+from proliferate.db.store.integrations import authorization_attempts
+from proliferate.db.store.integrations import definition_security_revisions
+from proliferate.db.store.integrations import oauth_clients
+from proliferate.db.store.integrations import oauth_flows
+
+
+def test_account_projection_carries_split_versions_and_security_pins() -> None:
+    now = datetime(2026, 8, 19, tzinfo=UTC)
+    security_revision_id = uuid4()
+    provider_client_id = uuid4()
+    row = CloudIntegrationAccount(
+        id=uuid4(),
+        definition_id=uuid4(),
+        owner_user_id=uuid4(),
+        owner_scope="personal",
+        enabled=True,
+        status="ready",
+        auth_kind="oauth2",
+        credential_ciphertext="encrypted-account-bundle",
+        credential_format="oauth-bundle-v1",
+        auth_version=9,
+        grant_version=4,
+        credential_version=9,
+        definition_security_revision_id=security_revision_id,
+        provider_client_id=provider_client_id,
+        credential_audience="https://resource.example",
+        effective_scopes_json='["read"]',
+        settings_json="{}",
+        token_expires_at=now,
+        last_error_code=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+    record = accounts._record(row)
+
+    assert record.grant_version == 4
+    assert record.credential_version == 9
+    assert record.definition_security_revision_id == security_revision_id
+    assert record.provider_client_id == provider_client_id
+    assert record.credential_audience == "https://resource.example"
+    assert record.effective_scopes_json == '["read"]'
+    assert record.credential_ciphertext == "encrypted-account-bundle"
+
+
+def test_attempt_projection_carries_generation_pins_and_only_ciphertext() -> None:
+    now = datetime(2026, 8, 19, tzinfo=UTC)
+    security_revision_id = uuid4()
+    provider_client_id = uuid4()
+    row = CloudIntegrationAuthorizationAttempt(
+        id=uuid4(),
+        owner_user_id=uuid4(),
+        definition_id=uuid4(),
+        account_id=uuid4(),
+        purpose="reauthorize",
+        method="oauth2",
+        generation=3,
+        status="validating",
+        starting_grant_version=4,
+        starting_credential_version=8,
+        definition_security_revision_id=security_revision_id,
+        provider_client_id=provider_client_id,
+        credential_audience="https://resource.example",
+        settings_json='{"region":"us"}',
+        requested_scopes_json='["read"]',
+        effective_scopes_json='["read"]',
+        staged_credential_ciphertext="encrypted-staged-bundle",
+        staged_credential_format="oauth-bundle-v1",
+        failure_code=None,
+        expires_at=now,
+        closed_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+    record = authorization_attempts._record(row)
+
+    assert record.generation == 3
+    assert record.starting_grant_version == 4
+    assert record.starting_credential_version == 8
+    assert record.definition_security_revision_id == security_revision_id
+    assert record.provider_client_id == provider_client_id
+    assert record.settings_json == '{"region":"us"}'
+    assert record.staged_credential_ciphertext == "encrypted-staged-bundle"
+
+
+def test_revision_client_and_flow_projections_carry_lifecycle_links() -> None:
+    now = datetime(2026, 8, 19, tzinfo=UTC)
+    definition_id = uuid4()
+    attempt_id = uuid4()
+    revision_row = CloudIntegrationDefinitionSecurityRevision(
+        id=uuid4(),
+        definition_id=definition_id,
+        revision=2,
+        auth_kind="oauth2",
+        oauth_client_mode="static",
+        config_json='{"mcp_url":"https://resource.example"}',
+        created_at=now,
+    )
+    client_row = CloudIntegrationOAuthClient(
+        id=uuid4(),
+        definition_id=definition_id,
+        issuer="https://issuer.example",
+        redirect_uri="https://api.example/callback",
+        resource="https://resource.example",
+        client_id="client-id",
+        revision=2,
+        lifecycle_state="retiring",
+        client_secret_ciphertext="encrypted-client-secret",
+        client_secret_expires_at=None,
+        token_endpoint_auth_method="client_secret_post",
+        registration_client_uri=None,
+        registration_access_token_ciphertext=None,
+        created_at=now,
+        updated_at=now,
+    )
+    flow_row = CloudIntegrationOAuthFlow(
+        id=uuid4(),
+        account_id=None,
+        attempt_id=attempt_id,
+        owner_user_id=uuid4(),
+        definition_id=definition_id,
+        state_hash="state-hash",
+        code_verifier_ciphertext="encrypted-verifier",
+        issuer="https://issuer.example",
+        resource="https://resource.example",
+        client_id="client-id",
+        token_endpoint="https://issuer.example/token",
+        requested_scopes='["read"]',
+        redirect_uri="https://api.example/callback",
+        authorization_url="https://issuer.example/authorize",
+        callback_surface="desktop",
+        final_surface="desktop",
+        return_path=None,
+        status="active",
+        expires_at=now,
+        used_at=None,
+        cancelled_at=None,
+        failure_code=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+    revision = definition_security_revisions._record(revision_row)
+    client = oauth_clients._record(client_row)
+    flow = oauth_flows._record(flow_row)
+
+    assert revision.revision == 2
+    assert revision.config_json == '{"mcp_url":"https://resource.example"}'
+    assert client.revision == 2
+    assert client.lifecycle_state == "retiring"
+    assert client.client_secret_ciphertext == "encrypted-client-secret"
+    assert flow.attempt_id == attempt_id
+    assert flow.code_verifier_ciphertext == "encrypted-verifier"


### PR DESCRIPTION
## Summary

- add immutable integration definition security revisions and versioned OAuth client lifecycle state
- add authorization-attempt persistence separate from committed accounts, including generation and nonterminal constraints
- add split grant and credential versions plus pinned security/client/audience/scope fields
- define the authoritative management response contract without activating routes or behavior

## Testing

- 11 focused unit and real-Postgres integration tests, including upgrade/downgrade preservation and constraint proofs
- full Ruff check and format check
- mypy diagnostic ratchet against PR0 merged base: 503 existing diagnostics, no new diagnostics
- Alembic single head: a21c34d56e78
- server boundaries, max-lines, docs integrity, design attribution, and git diff checks

## Observability

No runtime behavior changes in this additive, dark schema slice. Existing integration telemetry and errors are unchanged; later lifecycle slices own attempt transitions and probes.

## Rollout

Additive migration only. Existing rows are backfilled compatibly; no endpoint consumes the new lifecycle records in this slice. Slack remains fail-closed behind the PR0 qualification gate.