### PR TITLE
fix(telemetry): close client vendor privacy leaks

### DIFF
--- a/apps/desktop/src/lib/access/tauri/auth.test.ts
+++ b/apps/desktop/src/lib/access/tauri/auth.test.ts
@@ -25,6 +25,28 @@ const SESSION: StoredAuthSession = {
   display_name: null,
 }
 
+function installMemoryLocalStorage(): void {
+  const values = new Map<string, string>()
+  const storage: Storage = {
+    get length() {
+      return values.size
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key) => {
+      values.delete(key)
+    },
+    setItem: (key, value) => {
+      values.set(key, value)
+    },
+  }
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: storage,
+  })
+}
+
 // reportKeychainFailure dedupes per module instance, so each test loads a
 // fresh copy of the module under test.
 async function loadAuthAccess() {
@@ -42,7 +64,7 @@ describe("tauri auth access", () => {
   beforeEach(() => {
     mocks.invoke.mockReset()
     mocks.trackProductEvent.mockReset()
-    window.localStorage.clear()
+    installMemoryLocalStorage()
   })
 
   it("returns the native session without telemetry when invoke succeeds", async () => {
@@ -59,7 +81,11 @@ describe("tauri auth access", () => {
   it("falls back to localStorage and reports when the keychain read fails", async () => {
     const auth = await loadAuthAccess()
     window.localStorage.setItem("proliferate.auth.session", JSON.stringify(SESSION))
-    mocks.invoke.mockRejectedValue(new Error("keychain access denied"))
+    mocks.invoke.mockRejectedValue(
+      new Error(
+        "permission denied for user@example.com token secret-token at /Users/private/auth",
+      ),
+    )
 
     expect(await auth.getStoredAuthSession()).toEqual(SESSION)
 
@@ -68,9 +94,13 @@ describe("tauri auth access", () => {
       "desktop_keychain_access_failed",
       {
         operation: "get_auth_session",
-        error_message: "keychain access denied",
+        failure_kind: "permission_error",
       },
     )
+    const serializedCalls = JSON.stringify(mocks.trackProductEvent.mock.calls)
+    expect(serializedCalls).not.toContain("user@example.com")
+    expect(serializedCalls).not.toContain("secret-token")
+    expect(serializedCalls).not.toContain("/Users/private/auth")
   })
 
   it("reports each operation at most once per run", async () => {
@@ -111,5 +141,55 @@ describe("tauri auth access", () => {
 
     expect(window.localStorage.getItem("proliferate.auth.session")).toBeNull()
     await flushTelemetry()
+  })
+
+  it("falls back and reports unknown_error when classification throws", async () => {
+    const auth = await loadAuthAccess()
+    window.localStorage.setItem("proliferate.auth.session", JSON.stringify(SESSION))
+    const hostileError = Object.create(null, {
+      name: {
+        get: () => {
+          throw new Error("hostile name getter")
+        },
+      },
+      toString: {
+        value: () => {
+          throw new Error("hostile toString")
+        },
+      },
+    })
+    mocks.invoke.mockRejectedValue(hostileError)
+
+    expect(await auth.getStoredAuthSession()).toEqual(SESSION)
+
+    await flushTelemetry()
+    expect(mocks.trackProductEvent).toHaveBeenCalledWith(
+      "desktop_keychain_access_failed",
+      {
+        operation: "get_auth_session",
+        failure_kind: "unknown_error",
+      },
+    )
+  })
+
+  it("falls back and reports unknown_error for a hostile toString", async () => {
+    const auth = await loadAuthAccess()
+    window.localStorage.setItem("proliferate.auth.session", JSON.stringify(SESSION))
+    mocks.invoke.mockRejectedValue({
+      toString: () => {
+        throw new Error("hostile toString")
+      },
+    })
+
+    expect(await auth.getStoredAuthSession()).toEqual(SESSION)
+
+    await flushTelemetry()
+    expect(mocks.trackProductEvent).toHaveBeenCalledWith(
+      "desktop_keychain_access_failed",
+      {
+        operation: "get_auth_session",
+        failure_kind: "unknown_error",
+      },
+    )
   })
 })

--- a/apps/desktop/src/lib/access/tauri/auth.ts
+++ b/apps/desktop/src/lib/access/tauri/auth.ts
@@ -1,6 +1,10 @@
 import { invoke } from "@tauri-apps/api/core"
 
 import type { KeychainTelemetryOperation } from "@proliferate/product-client/internal/lib/domain/telemetry/events"
+import {
+  classifyTelemetryFailure,
+  type TelemetryFailureKind,
+} from "@proliferate/product-client/internal/lib/domain/telemetry/failures"
 
 export interface StoredAuthSession {
   access_token: string
@@ -37,12 +41,17 @@ function reportKeychainFailure(
 ): void {
   if (reportedKeychainFailures.has(operation)) return
   reportedKeychainFailures.add(operation)
-  const message = error instanceof Error ? error.message : String(error ?? "")
+  let failureKind: TelemetryFailureKind = "unknown_error"
+  try {
+    failureKind = classifyTelemetryFailure(error)
+  } catch {
+    // Classification is diagnostic only and cannot interrupt browser fallback.
+  }
   void import("@/lib/integrations/telemetry/client")
     .then(({ trackProductEvent }) => {
       trackProductEvent("desktop_keychain_access_failed", {
         operation,
-        error_message: message.slice(0, 300),
+        failure_kind: failureKind,
       })
     })
     .catch(() => {})

--- a/apps/desktop/src/lib/integrations/telemetry/client.test.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/client.test.ts
@@ -169,7 +169,7 @@ describe("desktop telemetry client", () => {
     expect(mocks.captureDesktopSentryExceptionMock).not.toHaveBeenCalled();
   });
 
-  it("sends only user id to Sentry while keeping the full user for PostHog", async () => {
+  it("sends only user id to Sentry and PostHog", async () => {
     const client = await loadTelemetryClient();
     const user: AuthUser = {
       id: "user-123",
@@ -185,7 +185,19 @@ describe("desktop telemetry client", () => {
     expect(mocks.setDesktopSentryUserMock).toHaveBeenCalledOnce();
     expect(mocks.setDesktopSentryUserMock).toHaveBeenCalledWith("user-123");
     expect(mocks.identifyDesktopPostHogUserMock).toHaveBeenCalledOnce();
-    expect(mocks.identifyDesktopPostHogUserMock).toHaveBeenCalledWith(user);
+    expect(mocks.identifyDesktopPostHogUserMock).toHaveBeenCalledWith("user-123");
+    expect(
+      JSON.stringify([
+        mocks.setDesktopSentryUserMock.mock.calls,
+        mocks.identifyDesktopPostHogUserMock.mock.calls,
+      ]),
+    ).not.toContain("user@example.com");
+    expect(
+      JSON.stringify([
+        mocks.setDesktopSentryUserMock.mock.calls,
+        mocks.identifyDesktopPostHogUserMock.mock.calls,
+      ]),
+    ).not.toContain("Test User");
   });
 
   it("emits desktop_keychain_access_failed to PostHog", async () => {
@@ -197,12 +209,15 @@ describe("desktop telemetry client", () => {
 
     client.trackProductEvent("desktop_keychain_access_failed", {
       operation: "get_auth_session",
-      error_message: "keychain access denied",
+      failure_kind: "permission_error",
     });
 
     expect(mocks.trackDesktopPostHogEventMock).toHaveBeenCalledWith(
       "desktop_keychain_access_failed",
-      expect.objectContaining({ operation: "get_auth_session" }),
+      {
+        operation: "get_auth_session",
+        failure_kind: "permission_error",
+      },
     );
   });
 });

--- a/apps/desktop/src/lib/integrations/telemetry/client.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/client.ts
@@ -143,7 +143,7 @@ export function setTelemetryUser(user: AuthUser): void {
   }
 
   setDesktopSentryUser(user.id);
-  identifyDesktopPostHogUser(user);
+  identifyDesktopPostHogUser(user.id);
 }
 
 export function clearTelemetryUser(): void {

--- a/apps/desktop/src/lib/integrations/telemetry/posthog.test.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/posthog.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  init: vi.fn(),
+  register: vi.fn(),
+  capture: vi.fn(),
+  identify: vi.fn(),
+  reset: vi.fn(),
+}));
+
+vi.mock("posthog-js", () => ({
+  default: mocks,
+}));
+
+async function loadDesktopPostHog() {
+  vi.resetModules();
+  return import("./posthog");
+}
+
+const ENABLED_CONFIG = {
+  environment: "production",
+  release: "proliferate-desktop@1.2.3+abcdef123456",
+  posthog: {
+    enabled: true,
+    apiKey: "phc_test",
+    apiHost: "https://us.i.posthog.com",
+    sessionRecordingEnabled: false,
+  },
+};
+
+describe("desktop PostHog adapter", () => {
+  beforeEach(() => {
+    mocks.init.mockReset();
+    mocks.register.mockReset();
+    mocks.capture.mockReset();
+    mocks.identify.mockReset();
+    mocks.reset.mockReset();
+  });
+
+  it("identifies with the authenticated user id only", async () => {
+    const adapter = await loadDesktopPostHog();
+    adapter.initializeDesktopPostHog(ENABLED_CONFIG);
+
+    adapter.identifyDesktopPostHogUser("user-123");
+
+    expect(mocks.identify).toHaveBeenCalledOnce();
+    expect(mocks.identify).toHaveBeenCalledWith("user-123");
+    expect(JSON.stringify(mocks.identify.mock.calls)).not.toContain("user@example.com");
+    expect(JSON.stringify(mocks.identify.mock.calls)).not.toContain("Private Person");
+  });
+
+  it("keeps registered context and reset behavior unchanged", async () => {
+    const adapter = await loadDesktopPostHog();
+    adapter.initializeDesktopPostHog(ENABLED_CONFIG);
+
+    expect(mocks.register).toHaveBeenCalledWith({
+      app: "proliferate-desktop",
+      surface: "desktop",
+      environment: "production",
+      release: "proliferate-desktop@1.2.3+abcdef123456",
+    });
+
+    adapter.resetDesktopPostHogUser();
+    expect(mocks.reset).toHaveBeenCalledWith(true);
+  });
+
+  it("keeps identity and reset as no-ops before initialization", async () => {
+    const adapter = await loadDesktopPostHog();
+
+    adapter.identifyDesktopPostHogUser("user-123");
+    adapter.resetDesktopPostHogUser();
+
+    expect(mocks.identify).not.toHaveBeenCalled();
+    expect(mocks.reset).not.toHaveBeenCalled();
+  });
+
+  it("does not initialize without an enabled API key", async () => {
+    const adapter = await loadDesktopPostHog();
+    adapter.initializeDesktopPostHog({
+      ...ENABLED_CONFIG,
+      posthog: { ...ENABLED_CONFIG.posthog, apiKey: "" },
+    });
+
+    expect(mocks.init).not.toHaveBeenCalled();
+    expect(mocks.register).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/lib/integrations/telemetry/posthog.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/posthog.ts
@@ -58,20 +58,10 @@ export function trackDesktopPostHogEvent<E extends keyof DesktopProductEventMap>
   posthog.capture(name, scrubTelemetryData(properties));
 }
 
-export function identifyDesktopPostHogUser(user: {
-  id: string;
-  email: string;
-  display_name: string | null;
-}): void {
+export function identifyDesktopPostHogUser(userId: string): void {
   if (!posthogInitialized) return;
 
-  posthog.identify(
-    user.id,
-    scrubTelemetryData({
-      email: user.email,
-      display_name: user.display_name ?? undefined,
-    }),
-  );
+  posthog.identify(userId);
 }
 
 export function resetDesktopPostHogUser(): void {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -5,6 +5,7 @@
   "main": "index.ts",
   "scripts": {
     "build:shared": "pnpm --filter @proliferate/product-client build",
+    "test": "vitest run",
     "start": "pnpm build:shared && expo start",
     "ios": "pnpm build:shared && expo start --ios",
     "android": "pnpm build:shared && expo start --android",
@@ -49,6 +50,7 @@
     "@expo/ngrok": "^4.1.3",
     "@sentry/expo-upload-sourcemaps": "^8.22.0",
     "@types/react": "~19.2.18",
-    "typescript": "~5.9.2"
+    "typescript": "~5.9.2",
+    "vitest": "^3.2.7"
   }
 }

--- a/apps/mobile/src/lib/integrations/telemetry/posthog.ts
+++ b/apps/mobile/src/lib/integrations/telemetry/posthog.ts
@@ -1,6 +1,5 @@
 import { PostHog } from "posthog-react-native";
 import type { PostHogOptions } from "posthog-react-native";
-import type { AuthUser } from "@proliferate/cloud-sdk";
 import { scrubTelemetryData } from "@proliferate/product-client/internal/domain/telemetry/scrub";
 
 import type { MobileTelemetryConfig } from "./config";
@@ -69,17 +68,9 @@ export function trackMobilePostHogScreenView(screen: MobileTelemetryScreen): voi
   }));
 }
 
-export function identifyMobilePostHogUser(user: AuthUser): void {
+export function identifyMobilePostHogUser(userId: string): void {
   if (!posthogClient) return;
-  const properties: Record<string, string> = { email: user.email };
-  if (user.display_name) {
-    properties.display_name = user.display_name;
-  }
-
-  posthogClient.identify(
-    user.id,
-    scrubTelemetryData(properties),
-  );
+  posthogClient.identify(userId);
 }
 
 export function resetMobilePostHogUser(): void {

--- a/apps/mobile/src/lib/integrations/telemetry/telemetry-privacy.test.ts
+++ b/apps/mobile/src/lib/integrations/telemetry/telemetry-privacy.test.ts
@@ -1,0 +1,305 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type * as SentryTypes from "@sentry/react-native";
+
+const mocks = vi.hoisted(() => ({
+  sentryInit: vi.fn(),
+  sentrySetUser: vi.fn(),
+  sentryWrap: vi.fn((component: unknown) => component),
+  sentryAddBreadcrumb: vi.fn(),
+  sentryWithScope: vi.fn(),
+  sentryCaptureException: vi.fn(),
+  posthogConstructor: vi.fn(),
+  posthogClient: {
+    register: vi.fn(),
+    capture: vi.fn(),
+    identify: vi.fn(),
+    reset: vi.fn(),
+  },
+}));
+
+vi.mock("@sentry/react-native", () => ({
+  init: mocks.sentryInit,
+  setUser: mocks.sentrySetUser,
+  wrap: mocks.sentryWrap,
+  addBreadcrumb: mocks.sentryAddBreadcrumb,
+  withScope: mocks.sentryWithScope,
+  captureException: mocks.sentryCaptureException,
+}));
+
+vi.mock("posthog-react-native", () => ({
+  PostHog: class {
+    constructor(...args: unknown[]) {
+      mocks.posthogConstructor(...args);
+      return mocks.posthogClient;
+    }
+  },
+}));
+
+type SentryInitOptions = Parameters<typeof SentryTypes.init>[0];
+
+const EMAIL_SENTINEL = "private-person@example.com";
+const NAME_SENTINEL = "Private Person";
+const IP_SENTINEL = "203.0.113.42";
+const BODY_SENTINEL = "private-request-body";
+const COOKIE_SENTINEL = "private-cookie";
+const AUTH_SENTINEL = "private-authorization-token";
+const FRAME_SENTINEL = "private-frame-context";
+
+function expectNoPrivateSentinels(value: unknown): void {
+  const serialized = JSON.stringify(value);
+  for (const sentinel of [
+    EMAIL_SENTINEL,
+    NAME_SENTINEL,
+    IP_SENTINEL,
+    BODY_SENTINEL,
+    COOKIE_SENTINEL,
+    AUTH_SENTINEL,
+    FRAME_SENTINEL,
+  ]) {
+    expect(serialized).not.toContain(sentinel);
+  }
+}
+
+async function loadInitializedSentry(): Promise<{
+  adapter: typeof import("./sentry");
+  options: SentryInitOptions;
+}> {
+  vi.resetModules();
+  const adapter = await import("./sentry");
+  adapter.initializeMobileSentry({
+    environment: "production",
+    release: "proliferate-mobile@1.2.3+abcdef123456",
+    sentry: {
+      enabled: true,
+      dsn: "https://public@sentry.example/1",
+      tracesSampleRate: 0.25,
+    },
+  });
+  expect(mocks.sentryInit).toHaveBeenCalledOnce();
+  return {
+    adapter,
+    options: mocks.sentryInit.mock.calls[0]![0] as SentryInitOptions,
+  };
+}
+
+describe("mobile telemetry privacy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("installs and exercises every Sentry privacy callback", async () => {
+    const { adapter, options } = await loadInitializedSentry();
+
+    expect(options.environment).toBe("production");
+    expect(options.release).toBe("proliferate-mobile@1.2.3+abcdef123456");
+    expect(options.sendDefaultPii).toBe(false);
+    expect(options.tracesSampleRate).toBe(0.25);
+    expect(options.replaysSessionSampleRate).toBe(0);
+    expect(options.replaysOnErrorSampleRate).toBe(0);
+    expect(options.attachScreenshot).toBe(false);
+    expect(options.attachViewHierarchy).toBe(false);
+    expect(options.enableNativeCrashHandling).toBe(true);
+
+    const frame = {
+      filename: "src/screens/workspace.tsx",
+      abs_path: "/private/var/mobile/Containers/Data/app/workspace.tsx",
+      function: "renderWorkspace",
+      context_line: FRAME_SENTINEL,
+      pre_context: [FRAME_SENTINEL],
+      post_context: [FRAME_SENTINEL],
+      vars: { private_value: FRAME_SENTINEL },
+    };
+    const event = {
+      environment: "production",
+      release: "proliferate-mobile@1.2.3+abcdef123456",
+      transaction: "/workspace/:workspaceId",
+      user: {
+        id: "user-123",
+        email: EMAIL_SENTINEL,
+        name: NAME_SENTINEL,
+        ip_address: IP_SENTINEL,
+      },
+      request: {
+        data: { private_value: BODY_SENTINEL },
+        cookies: `session=${COOKIE_SENTINEL}`,
+        headers: {
+          authorization: `Bearer ${AUTH_SENTINEL}`,
+          "x-safe-header": "safe-header",
+        },
+        url: `/workspace/123?token=${AUTH_SENTINEL}`,
+      },
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "relative failure",
+            stacktrace: { frames: [{ ...frame }] },
+            raw_stacktrace: { frames: [{ ...frame }] },
+          },
+        ],
+      },
+    };
+
+    const beforeSend = options.beforeSend as (
+      sentryEvent: unknown,
+      hint: unknown,
+    ) => unknown;
+    const scrubbedEvent = beforeSend(event, {});
+    expect(scrubbedEvent).toMatchObject({
+      environment: "production",
+      release: "proliferate-mobile@1.2.3+abcdef123456",
+      transaction: "/workspace/:workspaceId",
+      user: { id: "user-123" },
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "relative failure",
+            stacktrace: {
+              frames: [
+                {
+                  filename: "src/screens/workspace.tsx",
+                  function: "renderWorkspace",
+                },
+              ],
+            },
+            raw_stacktrace: {
+              frames: [
+                {
+                  filename: "src/screens/workspace.tsx",
+                  function: "renderWorkspace",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    expectNoPrivateSentinels(scrubbedEvent);
+
+    const scrubbedFrames = (
+      scrubbedEvent as {
+        exception: {
+          values: Array<{
+            stacktrace: { frames: Array<Record<string, unknown>> };
+            raw_stacktrace: { frames: Array<Record<string, unknown>> };
+          }>;
+        };
+      }
+    ).exception.values[0]!;
+    for (const scrubbedFrame of [
+      scrubbedFrames.stacktrace.frames[0]!,
+      scrubbedFrames.raw_stacktrace.frames[0]!,
+    ]) {
+      expect(scrubbedFrame.context_line).toBeUndefined();
+      expect(scrubbedFrame.pre_context).toBeUndefined();
+      expect(scrubbedFrame.post_context).toBeUndefined();
+      expect(scrubbedFrame.vars).toBeUndefined();
+    }
+
+    const beforeSendTransaction = options.beforeSendTransaction as (
+      transaction: unknown,
+    ) => unknown;
+    const scrubbedTransaction = beforeSendTransaction({
+      environment: "production",
+      release: "proliferate-mobile@1.2.3+abcdef123456",
+      transaction: "/workspace/:workspaceId",
+      user: { id: "user-123", email: EMAIL_SENTINEL, name: NAME_SENTINEL },
+      request: { data: BODY_SENTINEL },
+    });
+    expect(scrubbedTransaction).toMatchObject({
+      environment: "production",
+      release: "proliferate-mobile@1.2.3+abcdef123456",
+      transaction: "/workspace/:workspaceId",
+      user: { id: "user-123" },
+    });
+    expectNoPrivateSentinels(scrubbedTransaction);
+
+    const beforeSendSpan = options.beforeSendSpan as (span: unknown) => unknown;
+    const scrubbedSpan = beforeSendSpan({
+      description: `/workspace/:workspaceId?token=${AUTH_SENTINEL}`,
+      data: { email: EMAIL_SENTINEL, request_body: BODY_SENTINEL },
+      op: "http.client",
+    });
+    expect(scrubbedSpan).toMatchObject({
+      description: "/workspace/:workspaceId",
+      op: "http.client",
+    });
+    expectNoPrivateSentinels(scrubbedSpan);
+
+    const beforeBreadcrumb = options.beforeBreadcrumb as (
+      breadcrumb: unknown,
+      hint: unknown,
+    ) => unknown;
+    const scrubbedBreadcrumb = beforeBreadcrumb(
+      {
+        category: "ui.click",
+        message: `/workspace/:workspaceId?token=${AUTH_SENTINEL}`,
+        data: { email: EMAIL_SENTINEL, token: AUTH_SENTINEL },
+      },
+      {},
+    );
+    expect(scrubbedBreadcrumb).toMatchObject({
+      category: "ui.click",
+      message: "/workspace/:workspaceId",
+    });
+    expectNoPrivateSentinels(scrubbedBreadcrumb);
+
+    adapter.setMobileSentryUser("user-123");
+    expect(mocks.sentrySetUser).toHaveBeenCalledWith({ id: "user-123" });
+    adapter.clearMobileSentryUser();
+    expect(mocks.sentrySetUser).toHaveBeenLastCalledWith(null);
+  });
+
+  it("identifies PostHog with the authenticated user id only", async () => {
+    vi.resetModules();
+    const adapter = await import("./posthog");
+    adapter.initializeMobilePostHog({
+      environment: "production",
+      release: "proliferate-mobile@1.2.3+abcdef123456",
+      posthog: {
+        enabled: true,
+        apiKey: "phc_test",
+        apiHost: "https://us.i.posthog.com",
+        sessionReplayEnabled: false,
+      },
+    });
+
+    expect(mocks.posthogClient.register).toHaveBeenCalledWith({
+      app: "proliferate-mobile",
+      surface: "mobile",
+      environment: "production",
+      release: "proliferate-mobile@1.2.3+abcdef123456",
+    });
+
+    adapter.identifyMobilePostHogUser("user-123");
+    expect(mocks.posthogClient.identify).toHaveBeenCalledOnce();
+    expect(mocks.posthogClient.identify).toHaveBeenCalledWith("user-123");
+    expectNoPrivateSentinels(mocks.posthogClient.identify.mock.calls);
+
+    adapter.resetMobilePostHogUser();
+    expect(mocks.posthogClient.reset).toHaveBeenCalledOnce();
+  });
+
+  it("keeps disabled and uninitialized adapters inert", async () => {
+    vi.resetModules();
+    const sentry = await import("./sentry");
+    sentry.initializeMobileSentry({
+      environment: "production",
+      release: "proliferate-mobile@1.2.3+abcdef123456",
+      sentry: { enabled: true, dsn: null, tracesSampleRate: 0.25 },
+    });
+    sentry.setMobileSentryUser("user-123");
+
+    vi.resetModules();
+    const posthog = await import("./posthog");
+    posthog.identifyMobilePostHogUser("user-123");
+    posthog.resetMobilePostHogUser();
+
+    expect(mocks.sentryInit).not.toHaveBeenCalled();
+    expect(mocks.sentrySetUser).not.toHaveBeenCalled();
+    expect(mocks.posthogConstructor).not.toHaveBeenCalled();
+    expect(mocks.posthogClient.identify).not.toHaveBeenCalled();
+    expect(mocks.posthogClient.reset).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/providers/MobileTelemetryProvider.tsx
+++ b/apps/mobile/src/providers/MobileTelemetryProvider.tsx
@@ -40,7 +40,7 @@ export function MobileTelemetryProvider({ children }: { children: ReactNode }) {
     }
 
     setMobileSentryUser(user.id);
-    identifyMobilePostHogUser(user);
+    identifyMobilePostHogUser(user.id);
     lastIdentityRef.current = user.id;
   }, [authState, user]);
 

--- a/apps/packages/product-client/src/domain/telemetry/scrub.test.ts
+++ b/apps/packages/product-client/src/domain/telemetry/scrub.test.ts
@@ -193,18 +193,25 @@ describe("scrubTelemetryData", () => {
     ).toBe("[redacted-token] [redacted-path]");
   });
 
-  it("can preserve PostHog internal envelope keys while scrubbing user data", () => {
+  it("preserves PostHog envelope identifiers while redacting exact identity keys", () => {
     expect(
       scrubTelemetryData(
         {
           token: "posthog-project-token",
           distinct_id: "user-123",
+          uuid: "event-123",
+          $lib: "web",
           properties: {
             api_key: "secret",
             path: "/home/pablo/project",
           },
           $set: {
             email: "person@example.com",
+            display_name: "Private Person",
+            "display-name": "Private Person",
+            displayName: "Private Person",
+            DISPLAYNAME: "Private Person",
+            name: "Allowed generic name",
           },
         },
         { preservePostHogInternalKeys: true },
@@ -212,12 +219,41 @@ describe("scrubTelemetryData", () => {
     ).toEqual({
       token: "posthog-project-token",
       distinct_id: "user-123",
+      uuid: "event-123",
+      $lib: "web",
       properties: {
         api_key: "[redacted]",
         path: "[redacted]",
       },
       $set: {
-        email: "person@example.com",
+        email: "[redacted]",
+        display_name: "[redacted]",
+        "display-name": "[redacted]",
+        displayName: "[redacted]",
+        DISPLAYNAME: "[redacted]",
+        name: "Allowed generic name",
+      },
+    });
+  });
+
+  it("redacts exact identity keys in ordinary nested objects", () => {
+    expect(
+      scrubTelemetryData({
+        identity: {
+          email: "person@example.com",
+          display_name: "Private Person",
+          "display-name": "Private Person",
+          displayName: "Private Person",
+          name: "Allowed generic name",
+        },
+      }),
+    ).toEqual({
+      identity: {
+        email: "[redacted]",
+        display_name: "[redacted]",
+        "display-name": "[redacted]",
+        displayName: "[redacted]",
+        name: "Allowed generic name",
       },
     });
   });

--- a/apps/packages/product-client/src/domain/telemetry/scrub.ts
+++ b/apps/packages/product-client/src/domain/telemetry/scrub.ts
@@ -24,6 +24,12 @@ const UNINSPECTABLE_VALUE_MARKER = "[redacted]";
 const MAX_SCRUB_DEPTH = 10;
 const MAX_SCRUB_ARRAY_ITEMS = 100;
 const MAX_SCRUB_OBJECT_PROPERTIES = 100;
+const SENSITIVE_IDENTITY_KEYS = new Set([
+  "email",
+  "display_name",
+  "display-name",
+  "displayname",
+]);
 
 export type Scrubbable =
   | string
@@ -79,6 +85,9 @@ function isPostHogInternalKey(key: string): boolean {
 }
 
 function shouldScrubKey(key: string, options: ScrubTelemetryOptions): boolean {
+  if (SENSITIVE_IDENTITY_KEYS.has(key.toLowerCase())) {
+    return true;
+  }
   if (options.preservePostHogInternalKeys && isPostHogInternalKey(key)) {
     return false;
   }

--- a/apps/packages/product-client/src/lib/domain/telemetry/events.ts
+++ b/apps/packages/product-client/src/lib/domain/telemetry/events.ts
@@ -183,7 +183,7 @@ export interface DesktopProductEventMap {
   connectors_pane_viewed: undefined;
   desktop_keychain_access_failed: {
     operation: KeychainTelemetryOperation;
-    error_message: string;
+    failure_kind: TelemetryFailureKind;
   };
   runtime_connection_state_changed: {
     connection_state: RuntimeConnectionTelemetryState;

--- a/apps/web/src/browser/telemetry/telemetry-privacy.test.ts
+++ b/apps/web/src/browser/telemetry/telemetry-privacy.test.ts
@@ -1,0 +1,281 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type * as SentryTypes from "@sentry/react";
+
+const mocks = vi.hoisted(() => ({
+  sentryInit: vi.fn(),
+  sentrySetUser: vi.fn(),
+  sentryCaptureException: vi.fn(),
+  sentrySetTag: vi.fn(),
+  reactErrorHandler: vi.fn(() => vi.fn()),
+  withSentryReactRouterV7Routing: vi.fn((component: unknown) => component),
+  reactRouterV7BrowserTracingIntegration: vi.fn(() => ({ name: "routing" })),
+  posthog: {
+    __loaded: true,
+    init: vi.fn(),
+    register: vi.fn(),
+    capture: vi.fn(),
+    identify: vi.fn(),
+    reset: vi.fn(),
+    get_distinct_id: vi.fn(() => "distinct-123"),
+    get_session_id: vi.fn(() => "session-123"),
+  },
+}));
+
+vi.mock("@sentry/react", () => ({
+  init: mocks.sentryInit,
+  setUser: mocks.sentrySetUser,
+  captureException: mocks.sentryCaptureException,
+  setTag: mocks.sentrySetTag,
+  reactErrorHandler: mocks.reactErrorHandler,
+  withSentryReactRouterV7Routing: mocks.withSentryReactRouterV7Routing,
+  reactRouterV7BrowserTracingIntegration:
+    mocks.reactRouterV7BrowserTracingIntegration,
+}));
+
+vi.mock("posthog-js", () => ({
+  default: mocks.posthog,
+}));
+
+type SentryInitOptions = Parameters<typeof SentryTypes.init>[0];
+type SentryTransaction = Parameters<
+  NonNullable<SentryInitOptions["beforeSendTransaction"]>
+>[0];
+type SentrySpan = Parameters<NonNullable<SentryInitOptions["beforeSendSpan"]>>[0];
+
+const EMAIL_SENTINEL = "private-person@example.com";
+const NAME_SENTINEL = "Private Person";
+const IP_SENTINEL = "203.0.113.42";
+const BODY_SENTINEL = "private-request-body";
+const COOKIE_SENTINEL = "private-cookie";
+const AUTH_SENTINEL = "private-authorization-token";
+const FRAME_SENTINEL = "private-frame-context";
+
+function expectNoPrivateSentinels(value: unknown): void {
+  const serialized = JSON.stringify(value);
+  for (const sentinel of [
+    EMAIL_SENTINEL,
+    NAME_SENTINEL,
+    IP_SENTINEL,
+    BODY_SENTINEL,
+    COOKIE_SENTINEL,
+    AUTH_SENTINEL,
+    FRAME_SENTINEL,
+  ]) {
+    expect(serialized).not.toContain(sentinel);
+  }
+}
+
+async function loadInstalledOptions(): Promise<SentryInitOptions> {
+  vi.resetModules();
+  const { installWebTelemetry } = await import("./install-web-telemetry");
+  installWebTelemetry();
+  expect(mocks.sentryInit).toHaveBeenCalledOnce();
+  return mocks.sentryInit.mock.calls[0]![0] as SentryInitOptions;
+}
+
+describe("web telemetry privacy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.posthog.__loaded = true;
+    vi.stubEnv("VITE_PROLIFERATE_SENTRY_DSN", "https://public@sentry.example/1");
+    vi.stubEnv("VITE_PROLIFERATE_POSTHOG_KEY", "phc_test");
+    vi.stubEnv("VITE_PROLIFERATE_ENVIRONMENT", "production");
+    vi.stubEnv(
+      "VITE_PROLIFERATE_RELEASE",
+      "proliferate-web@1.2.3+abcdef123456",
+    );
+    vi.stubEnv("VITE_PROLIFERATE_SENTRY_TRACES_SAMPLE_RATE", "0.25");
+    vi.stubEnv("VITE_PROLIFERATE_TELEMETRY_DISABLED", "false");
+    vi.stubEnv("VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED", "false");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("installs and exercises every Sentry privacy callback", async () => {
+    const options = await loadInstalledOptions();
+
+    expect(options.environment).toBe("production");
+    expect(options.release).toBe("proliferate-web@1.2.3+abcdef123456");
+    expect(options.sendDefaultPii).toBe(false);
+    expect(options.tracesSampleRate).toBe(0.25);
+    expect(options.replaysSessionSampleRate).toBe(0);
+    expect(options.replaysOnErrorSampleRate).toBe(0);
+    expect(mocks.posthog.register).toHaveBeenCalledWith({
+      app: "proliferate-web",
+      surface: "web",
+      environment: "production",
+      release: "proliferate-web@1.2.3+abcdef123456",
+    });
+
+    const frame = {
+      filename: "src/screens/workspace.tsx",
+      abs_path: "/Users/private/project/src/screens/workspace.tsx",
+      function: "renderWorkspace",
+      context_line: FRAME_SENTINEL,
+      pre_context: [FRAME_SENTINEL],
+      post_context: [FRAME_SENTINEL],
+      vars: { private_value: FRAME_SENTINEL },
+    };
+    const event = {
+      environment: "production",
+      release: "proliferate-web@1.2.3+abcdef123456",
+      transaction: "/workspace/:workspaceId",
+      user: {
+        id: "user-123",
+        email: EMAIL_SENTINEL,
+        name: NAME_SENTINEL,
+        ip_address: IP_SENTINEL,
+      },
+      request: {
+        data: { private_value: BODY_SENTINEL },
+        cookies: `session=${COOKIE_SENTINEL}`,
+        headers: {
+          authorization: `Bearer ${AUTH_SENTINEL}`,
+          "x-safe-header": "safe-header",
+        },
+        url: `/workspace/123?token=${AUTH_SENTINEL}`,
+      },
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "relative failure",
+            stacktrace: { frames: [{ ...frame }] },
+            raw_stacktrace: { frames: [{ ...frame }] },
+          },
+        ],
+      },
+    } as unknown as Parameters<NonNullable<SentryInitOptions["beforeSend"]>>[0];
+
+    const scrubbedEvent = options.beforeSend!(event, {});
+    expect(scrubbedEvent).not.toBeNull();
+    expect(scrubbedEvent).toMatchObject({
+      environment: "production",
+      release: "proliferate-web@1.2.3+abcdef123456",
+      transaction: "/workspace/:workspaceId",
+      user: { id: "user-123" },
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "relative failure",
+            stacktrace: {
+              frames: [
+                {
+                  filename: "src/screens/workspace.tsx",
+                  function: "renderWorkspace",
+                },
+              ],
+            },
+            raw_stacktrace: {
+              frames: [
+                {
+                  filename: "src/screens/workspace.tsx",
+                  function: "renderWorkspace",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    expectNoPrivateSentinels(scrubbedEvent);
+
+    const scrubbedFrames = (
+      scrubbedEvent as unknown as {
+        exception: {
+          values: Array<{
+            stacktrace: { frames: Array<Record<string, unknown>> };
+            raw_stacktrace: { frames: Array<Record<string, unknown>> };
+          }>;
+        };
+      }
+    ).exception.values[0]!;
+    for (const scrubbedFrame of [
+      scrubbedFrames.stacktrace.frames[0]!,
+      scrubbedFrames.raw_stacktrace.frames[0]!,
+    ]) {
+      expect(scrubbedFrame.context_line).toBeUndefined();
+      expect(scrubbedFrame.pre_context).toBeUndefined();
+      expect(scrubbedFrame.post_context).toBeUndefined();
+      expect(scrubbedFrame.vars).toBeUndefined();
+    }
+
+    const transaction = {
+      environment: "production",
+      release: "proliferate-web@1.2.3+abcdef123456",
+      transaction: "/workspace/:workspaceId",
+      user: { id: "user-123", email: EMAIL_SENTINEL, name: NAME_SENTINEL },
+      request: { data: BODY_SENTINEL },
+    } as unknown as SentryTransaction;
+    const scrubbedTransaction = options.beforeSendTransaction!(transaction, {});
+    expect(scrubbedTransaction).toMatchObject({
+      environment: "production",
+      release: "proliferate-web@1.2.3+abcdef123456",
+      transaction: "/workspace/:workspaceId",
+      user: { id: "user-123" },
+    });
+    expectNoPrivateSentinels(scrubbedTransaction);
+
+    const span = {
+      description: `/workspace/:workspaceId?token=${AUTH_SENTINEL}`,
+      data: { email: EMAIL_SENTINEL, request_body: BODY_SENTINEL },
+      op: "http.client",
+    } as unknown as SentrySpan;
+    const scrubbedSpan = options.beforeSendSpan!(span);
+    expect(scrubbedSpan).toMatchObject({
+      description: "/workspace/:workspaceId",
+      op: "http.client",
+    });
+    expectNoPrivateSentinels(scrubbedSpan);
+
+    const scrubbedBreadcrumb = options.beforeBreadcrumb!(
+      {
+        category: "ui.click",
+        message: `/workspace/:workspaceId?token=${AUTH_SENTINEL}`,
+        data: { email: EMAIL_SENTINEL, token: AUTH_SENTINEL },
+      },
+      {},
+    );
+    expect(scrubbedBreadcrumb).toMatchObject({
+      category: "ui.click",
+      message: "/workspace/:workspaceId",
+    });
+    expectNoPrivateSentinels(scrubbedBreadcrumb);
+  });
+
+  it("passes only the authenticated user id to Sentry and PostHog", async () => {
+    vi.resetModules();
+    const { webProductTelemetry } = await import("./web-telemetry");
+
+    webProductTelemetry.setUser({
+      id: "user-123",
+      email: EMAIL_SENTINEL,
+      displayName: NAME_SENTINEL,
+    });
+
+    expect(mocks.sentrySetUser).toHaveBeenCalledWith({ id: "user-123" });
+    expect(mocks.posthog.identify).toHaveBeenCalledWith("user-123");
+    expectNoPrivateSentinels([
+      mocks.sentrySetUser.mock.calls,
+      mocks.posthog.identify.mock.calls,
+    ]);
+
+    webProductTelemetry.setUser(null);
+    expect(mocks.sentrySetUser).toHaveBeenLastCalledWith(null);
+    expect(mocks.posthog.reset).toHaveBeenCalledWith(true);
+  });
+
+  it("keeps telemetry uninitialized when keys are absent", async () => {
+    vi.stubEnv("VITE_PROLIFERATE_SENTRY_DSN", "");
+    vi.stubEnv("VITE_PROLIFERATE_POSTHOG_KEY", "");
+    vi.resetModules();
+    const { installWebTelemetry } = await import("./install-web-telemetry");
+
+    expect(installWebTelemetry()).toEqual({});
+    expect(mocks.sentryInit).not.toHaveBeenCalled();
+    expect(mocks.posthog.init).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/browser/telemetry/web-telemetry.ts
+++ b/apps/web/src/browser/telemetry/web-telemetry.ts
@@ -67,16 +67,9 @@ export const webProductTelemetry: ProductTelemetry = {
 
   setUser(user: ProductAuthUser | null): void {
     if (user) {
-      Sentry.setUser({ id: user.id, email: user.email ?? undefined });
+      Sentry.setUser({ id: user.id });
       if (posthog.__loaded) {
-        const properties: Record<string, string> = {};
-        if (user.email) {
-          properties.email = user.email;
-        }
-        if (user.displayName) {
-          properties.display_name = user.displayName;
-        }
-        posthog.identify(user.id, scrubTelemetryData(properties));
+        posthog.identify(user.id);
       }
       return;
     }

--- a/guides/operating/analytics/posthog.md
+++ b/guides/operating/analytics/posthog.md
@@ -44,7 +44,7 @@ network requests in screenshots.
 4. In the authenticated PostHog UI, filter read-only by the exact release,
    environment, and test account distinct id. Verify:
    - the expected allowlisted Desktop event or Web/Mobile view event arrived;
-   - identity is the user UUID with email and optional display name;
+   - identity is the authenticated user UUID only, with no email or display-name person properties;
    - sign-out produces a new anonymous identity on the next session;
    - no prompt, transcript, repo name, file path, raw URL, terminal text,
      token, or raw error is present.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,6 +352,9 @@ importers:
       typescript:
         specifier: ~5.9.2
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.7
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.13.3)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.23.12)(yaml@2.9.0)
 
   apps/packages/design:
     dependencies:

--- a/specs/codebase/systems/engineering/analytics/posthog.md
+++ b/specs/codebase/systems/engineering/analytics/posthog.md
@@ -10,7 +10,7 @@ initialized by the Server API.
 | --- | --- |
 | Deployment modes | Desktop initializes PostHog only in `hosted_product`. Web and Mobile initialize their adapters when the build has a key and telemetry is not disabled; those are current hosted-product clients. Local-dev and self-managed Desktop do not initialize PostHog. |
 | Source components | Desktop `apps/desktop/src/lib/integrations/telemetry/{client,config,posthog}.ts`; Web `apps/web/src/lib/integrations/telemetry/{config,posthog}.ts`; Mobile `apps/mobile/src/lib/integrations/telemetry/{config,posthog}.ts`. |
-| Identity and data | Distinct id is the authenticated user UUID; identify properties are email and optional display name. Captured data is the fixed event surface below plus scrubbed low-cardinality properties and registered app/surface/environment/release context. |
+| Identity and data | Distinct id is the authenticated user UUID, and identify calls send that UUID only with no email, display name, or other person properties. Captured data is the fixed event surface below plus scrubbed low-cardinality properties and registered app/surface/environment/release context. |
 | Destination | The configured PostHog host, defaulting to `https://us.i.posthog.com`. |
 | Enable, disable, or no-op | A missing API key makes each adapter inert. Web/Mobile also honor their public telemetry-disable setting; Desktop additionally requires hosted-product routing. Replay has a separate false-by-default gate. |
 | Privacy and replay | Autocapture and automatic page views are off. Payload scrubbers remove sensitive values. Replay is off by default; enabled Desktop/Web replay masks inputs and honors block/mask selectors, and Mobile masks text, images, and sandboxed views. |
@@ -44,6 +44,9 @@ cloud_workspace_created
 support_report_submitted
 desktop_keychain_access_failed
 ```
+
+`desktop_keychain_access_failed` carries only the keychain `operation` and a
+closed `failure_kind`; raw error text is never sent.
 
 Other typed product events may become Sentry breadcrumbs when vendor telemetry
 is enabled, but are dropped before PostHog. Sign-out calls `reset(true)`.


### PR DESCRIPTION
## Summary

- Send only the authenticated user UUID through Desktop, Web, and Mobile PostHog identity calls, and through Web Sentry identity.
- Redact exact email and display-name identity keys, including nested PostHog person-property containers, while preserving provider envelope identifiers.
- Replace raw `desktop_keychain_access_failed.error_message` with the existing closed `failure_kind` classification without changing fallback or dedup behavior.
- Exercise the actual Web and Mobile Sentry callbacks installed at each adapter boundary, and give Mobile an owned Vitest command and dependency.
- Update the current PostHog system document and read-only operating procedure for UUID-only identity, absent email/display-name person properties, and the closed keychain event payload.

## Testing

Tier 1 unit, adapter-contract, build, typecheck, and documentation proof:

- `pnpm --filter @proliferate/product-client exec vitest run src/domain/telemetry/scrub.test.ts`
- `pnpm --filter @proliferate/product-client build`
- `pnpm --filter proliferate exec vitest run src/lib/access/tauri/auth.test.ts src/lib/integrations/telemetry/client.test.ts src/lib/integrations/telemetry/posthog.test.ts`
- `pnpm --filter @proliferate/web exec vitest run src/browser/telemetry/telemetry-privacy.test.ts src/browser/telemetry/sentry-event-filter.test.ts`
- `pnpm --filter @proliferate/mobile test`
- `pnpm --filter proliferate exec tsc --noEmit`
- `pnpm --filter @proliferate/web exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @proliferate/mobile exec tsc --noEmit`
- `/opt/homebrew/bin/python3.12 scripts/check_docs.py`
- `rg -nF "identity is the authenticated user UUID only, with no email or display-name person properties;" guides/operating/analytics/posthog.md` — exact match at line 47
- `git grep -n "identity is the user UUID with email and optional display name" HEAD -- guides/operating/analytics/posthog.md` — empty
- `git diff --name-only 1a6b89c69c9d20295eafd94750f95be31af99ea5...HEAD` — exactly 18 permitted files
- `git grep -n error_message HEAD -- apps/desktop/src/lib/access/tauri/auth.ts apps/packages/product-client/src/lib/domain/telemetry/events.ts` — empty

The default Apple `python3` is 3.9.6 and cannot import `tomllib`; the documentation checker passed under the repository baseline Python 3.12 shown above. The frozen lockfile was also verified offline with lifecycle scripts disabled.

## Observability

Negative privacy delta: future client vendor payloads lose email, display name, and raw keychain error prose. Distinct IDs, Sentry user IDs, event names, keychain operation, the new closed failure-kind dimension, app/surface/environment/release registration, reset behavior, gates, sampling, and replay settings remain unchanged. No new event, log, metric, alert, canary, receipt, or provider-side object is added.

This is source-side and mocked-adapter proof only. No provider credentials were read, no live Sentry or PostHog call was made, and no telemetry was emitted. It makes no provider acceptance, deletion, grouping, or display claim.

## Readiness

- [ ] I followed the pull-request procedure for scope, title, labels, body, and readiness.
- Draft only; do not merge or mark ready.

## Verification

- Frozen spec: `/Users/pablohansen/Proliferate Workspace/ADRs/Observability/Control Plane 2026-08-19/run-2026-08-19/specs/CP-S2A Client vendor privacy closure.md`
- Spec revision: `2026-08-19.2`
- Spec SHA-256: `ada52896d211251637e2db60a04188e82aca36ebffc074badb61da032678f847`
- Pinned base: `1a6b89c69c9d20295eafd94750f95be31af99ea5`
- Head: `3f8b84bbb62d0c765bfa3e9f25d5f3483a6df6d9`
- Scope receipt: exactly 18 files, all listed by the refrozen permitted-file contract.
- `CP-S2A-D1`: resolved by founder decision to amend and refreeze; `guides/operating/analytics/posthog.md` now requires authenticated UUID-only identity and verifies email/display-name person properties are absent.
- Final main-drift receipt: `origin/main` advanced through `97658856c5` (#2058) and `12518cb173` (#2056); neither commit touches any CP-S2A permitted file.
- Final open-PR overlap receipt: #2055 overlaps only generated `pnpm-lock.yaml`; no open PR overlaps a client telemetry adapter, scrubber, Sentry initializer, identity caller, event schema, current PostHog document, or PostHog operating guide.
- Test-harness assumption: the Desktop auth unit installs deterministic in-memory `localStorage` because Node 26 exposes an undefined experimental global in jsdom; shipped fallback behavior is unchanged.
- No Cargo/Rust, AnyHarness test wrapper, Docker, provider, credential, or telemetry command was run.
- No scope deviations.