### PR TITLE
docs(workflows): consolidated gen-2 follow-up feature doc (rung 9)

### DIFF
--- a/specs/FEATURE_DOCS/WORKFLOWS.md
+++ b/specs/FEATURE_DOCS/WORKFLOWS.md
@@ -78,9 +78,23 @@ migration.
 
 ## Gen-2 follow-up: existing-workspace placement and parallel nodes
 
-This section is current operating truth for the two additive capabilities the Follow-up Workflows ADR bolted onto the merged gen-2 engine: running a workflow run inside a workspace the user already owns (Feature A), and fanning one node out to N parallel sessions that each carry their own authored prompt (Feature B). They compose into the motivating case, a reviewer panel (a correctness, security, and perf reviewer) running as one parallel node in an existing PR worktree.
+This section is current operating truth for the two additive capabilities the
+Follow-up Workflows ADR bolted onto the merged gen-2 engine: running a workflow
+run inside a workspace the user already owns (Feature A), and fanning one node
+out to N parallel sessions that each carry their own authored prompt (Feature
+B). They compose into the motivating case, a reviewer panel (a correctness,
+security, and perf reviewer) running as one parallel node in an existing PR
+worktree.
 
-It owns only the follow-up delta. The gen-2 base engine it extends (the per-run actor behind `WorkflowManager`, the pure transition table, the node/session model, the client-delivered invocation snapshot) is still documented by the delivery specs under [`../../delivery/workflows-gen2/`](../../delivery/workflows-gen2/) until the full gen-1 rewrite lands; this section never restates that base, it names the seam it changed. Workspace materialization for a fresh worktree stays owned by [Workspace Placement](#workspace-placement); this section owns only the third placement mode that adopts an existing workspace instead.
+It owns only the follow-up delta. The gen-2 base engine it extends (the per-run
+actor behind `WorkflowManager`, the pure transition table, the node/session
+model, the client-delivered invocation snapshot) is still documented by the
+delivery specs under
+[`../../delivery/workflows-gen2/`](../../delivery/workflows-gen2/) until the
+full gen-1 rewrite lands; this section never restates that base, it names the
+seam it changed. Workspace materialization for a fresh worktree stays owned by
+[Workspace Placement](#workspace-placement); this section owns only the third
+placement mode that adopts an existing workspace instead.
 
 The follow-up shipped as a linear ladder of rungs, each stacked on the prior:
 
@@ -94,7 +108,10 @@ The follow-up shipped as a linear ladder of rungs, each stacked on the prior:
 | 6 | Per-leg redo | [`transition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/transition.rs), [`store.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/store.rs) |
 | 7 | The ledger on the wire (projection, SDK, run view) | [`projection.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/projection.rs), [`workflow-runs-v2.ts`](../../anyharness/sdk/src/types/workflow-runs-v2.ts), [`run-view-model.ts`](../../apps/packages/product-client/src/domain/workflows/run-view-model.ts) |
 
-Read with the [gen-2 delivery specs](../../delivery/workflows-gen2/) for the base engine, [Workspace Placement](#workspace-placement) for fresh-worktree materialization, and [`../TESTING/README.md`](../TESTING/README.md) for the test tiers cited below.
+Read with the [gen-2 delivery specs](../../delivery/workflows-gen2/) for the base
+engine, [Workspace Placement](#workspace-placement) for fresh-worktree
+materialization, and [`../TESTING/README.md`](../TESTING/README.md) for the test
+tiers cited below.
 
 ### Code map
 
@@ -126,9 +143,16 @@ apps/packages/product-client/src/
 
 ### Run-scoped context docs (rung 1)
 
-> **A run owns its own context directory.** Context docs live under `.proliferate/context/<runId>/NN-slug.md`, not the old flat `.proliferate/context/NN-slug.md`, so two runs sharing one workspace never collide on the chain-index filename. The run-scoped path is minted once by `run_context_dir_relative(run_id)` ([`render.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/render.rs)).
+> **A run owns its own context directory.** Context docs live under
+> `.proliferate/context/<runId>/NN-slug.md`, not the old flat
+> `.proliferate/context/NN-slug.md`, so two runs sharing one workspace never
+> collide on the chain-index filename. The run-scoped path is minted once by
+> `run_context_dir_relative(run_id)`
+> ([`render.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/render.rs)).
 
-The ADR budgeted three consumers of the path constant; the as-built change has five, because the client and a release scenario also construct the path (ADR erratum #1). All five agree on the run subfolder:
+The ADR budgeted three consumers of the path constant; the as-built change has
+five, because the client and a release scenario also construct the path (ADR
+erratum #1). All five agree on the run subfolder:
 
 | Consumer | Role |
 | --- | --- |
@@ -138,11 +162,13 @@ The ADR budgeted three consumers of the path constant; the as-built change has f
 | [`use-workflow-doc-open.ts`](../../apps/packages/product-client/src/hooks/workflows/ui/use-workflow-doc-open.ts) | opens a doc by building `<dir>/<runId>/<filename>` from the DTO's existing `runId`, no contract change |
 | [`t3-wf-1.ts`](../../tests/release/src/scenarios/t3-wf-1.ts) | the Tier-3 release scenario asserts the on-disk run-scoped path |
 
-Migration is nil: context docs are ephemeral, gitignored run-workspace files; old flat-path runs are terminal by the time this ships.
+Migration is nil: context docs are ephemeral, gitignored run-workspace files;
+old flat-path runs are terminal by the time this ships.
 
 ### Existing-workspace placement (rung 2, ruling F-A1)
 
-A run's placement is one of three modes on `PlacementMode` ([`definition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/definition.rs)):
+A run's placement is one of three modes on `PlacementMode`
+([`definition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/definition.rs)):
 
 | Mode | Workspace | Compensation on failure |
 | --- | --- | --- |
@@ -150,13 +176,35 @@ A run's placement is one of three modes on `PlacementMode` ([`definition.rs`](..
 | `RepoRoot` | reuses the repo root's workspace | leaves the reused workspace |
 | `ExistingWorkspace` | adopts a `workspaceId` the caller names | no-op; never touches an adopted workspace |
 
-`ExistingWorkspace` carries a required `workspaceId` (validated at [`definition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/definition.rs); `workspaceId` is rejected for any other mode). Adoption skips `ensure_workflow_workspace` entirely and validates that the named workspace exists, is repo-backed, and is alive; it records the run-to-workspace association on `workflow_runs.workspace_id` alone and never rewrites the workspace's creator context.
+`ExistingWorkspace` carries a required `workspaceId` (validated at
+[`definition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/definition.rs);
+`workspaceId` is rejected for any other mode). Adoption skips
+`ensure_workflow_workspace` entirely and validates that the named workspace
+exists, is repo-backed, and is alive; it records the run-to-workspace
+association on `workflow_runs.workspace_id` alone and never rewrites the
+workspace's creator context.
 
-> **Occupancy is re-scoped, not relaxed.** `enforces_exclusive_occupancy()` keeps the one-live-run law for `Worktree` and `RepoRoot`, and admits N concurrent runs only under `ExistingWorkspace`, where the user explicitly chose to stack work onto a workspace they own ([`definition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/definition.rs)). Both enforcement halves, the route pre-check and the store's in-transaction re-check, apply exactly this predicate, so the race protection survives the re-scoping.
+> **Occupancy is re-scoped, not relaxed.** `enforces_exclusive_occupancy()`
+> keeps the one-live-run law for `Worktree` and `RepoRoot`, and admits N
+> concurrent runs only under `ExistingWorkspace`, where the user explicitly
+> chose to stack work onto a workspace they own
+> ([`definition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/definition.rs)).
+> Both enforcement halves, the route pre-check and the store's in-transaction
+> re-check, apply exactly this predicate, so the race protection survives the
+> re-scoping.
 
-> **Concurrent runs share one working tree with no write isolation.** Sessions of concurrent runs, and the workspace's own chat sessions, coexist on one git index and working tree; coordinating write-heavy concurrent workflows is the caller's decision. The run-accept OpenAPI description states this doctrine verbatim ([`workflow_runs.rs`](../../anyharness/crates/anyharness-lib/src/api/http/workflow_runs.rs)).
+> **Concurrent runs share one working tree with no write isolation.** Sessions
+> of concurrent runs, and the workspace's own chat sessions, coexist on one git
+> index and working tree; coordinating write-heavy concurrent workflows is the
+> caller's decision. The run-accept OpenAPI description states this doctrine
+> verbatim
+> ([`workflow_runs.rs`](../../anyharness/crates/anyharness-lib/src/api/http/workflow_runs.rs)).
 
-Repository-binding is deliberately not a placement constraint: the definition's `repo_root_id` versus the adopted workspace's is left **unchecked** (ADR erratum #2, ruled "it doesn't matter"), so cross-repo adoption is acceptable. The in-code comment at the adoption block is the durable record of that intent ([`workflow_runs.rs`](../../anyharness/crates/anyharness-lib/src/api/http/workflow_runs.rs)).
+Repository-binding is deliberately not a placement constraint: the definition's
+`repo_root_id` versus the adopted workspace's is left **unchecked** (ADR
+erratum #2, ruled "it doesn't matter"), so cross-repo adoption is acceptable.
+The in-code comment at the adoption block is the durable record of that intent
+([`workflow_runs.rs`](../../anyharness/crates/anyharness-lib/src/api/http/workflow_runs.rs)).
 
 Stable placement errors:
 
@@ -166,17 +214,31 @@ Stable placement errors:
 | `existing_workspace` names an unknown workspace | `404 WORKFLOW_WORKSPACE_NOT_FOUND` |
 | Named workspace is not repo-backed / not alive | `409 WORKFLOW_WORKSPACE_NOT_ELIGIBLE` |
 
-The as-built codes carry the `WORKFLOW_` prefix; the ADR's drafted names (`WORKSPACE_NOT_FOUND` / `WORKSPACE_NOT_ELIGIBLE`) were namespaced at implementation time and are the same errors.
+The as-built codes carry the `WORKFLOW_` prefix; the ADR's drafted names
+(`WORKSPACE_NOT_FOUND` / `WORKSPACE_NOT_ELIGIBLE`) were namespaced at
+implementation time and are the same errors.
 
 ### Concurrent-run UI (rung 3, ruling F-A2)
 
-> **At most four run rails render at once, and no waiting run is ever hidden silently.** The workspace pane shows one interactive rail per concurrent run, newest-first with active runs prioritized, capped at four; the rest sit behind a paging overflow line, and any run that hits a gate, needs human review, or fails is surfaced rather than merely reachable ([`WorkflowPane.tsx`](../../apps/packages/product-client/src/components/workflows/run-view/WorkflowPane.tsx)).
+> **At most four run rails render at once, and no waiting run is ever hidden
+> silently.** The workspace pane shows one interactive rail per concurrent run,
+> newest-first with active runs prioritized, capped at four; the rest sit behind
+> a paging overflow line, and any run that hits a gate, needs human review, or
+> fails is surfaced rather than merely reachable
+> ([`WorkflowPane.tsx`](../../apps/packages/product-client/src/components/workflows/run-view/WorkflowPane.tsx)).
 
-The cap resolves a collision with the `unvirtualizedLongLists` census lint: each rail is a heavy interactive panel, so virtualization was rejected on the merits and a bounded list was chosen over a founder-gated census exception (ADR erratum #3). The single-run pane renders byte-identically to before the feature.
+The cap resolves a collision with the `unvirtualizedLongLists` census lint: each
+rail is a heavy interactive panel, so virtualization was rejected on the merits
+and a bounded list was chosen over a founder-gated census exception (ADR erratum
+#3). The single-run pane renders byte-identically to before the feature.
 
 ### Parallel nodes: the fan-in ledger (rung 4, rulings F1 and F3)
 
-The question the ledger answers is "which of a parallel node's N sessions have already finished," and it must be answerable from SQLite after a crash, never from actor memory. The durable answer is one row per leg in `workflow_run_node_sessions` ([`0076_workflow_run_node_sessions.sql`](../../anyharness/crates/anyharness-lib/src/persistence/sql/0076_workflow_run_node_sessions.sql)):
+The question the ledger answers is "which of a parallel node's N sessions have
+already finished," and it must be answerable from SQLite after a crash, never
+from actor memory. The durable answer is one row per leg in
+`workflow_run_node_sessions`
+([`0076_workflow_run_node_sessions.sql`](../../anyharness/crates/anyharness-lib/src/persistence/sql/0076_workflow_run_node_sessions.sql)):
 
 ```text
 node_row_id  TEXT  -> workflow_run_nodes(id) ON DELETE CASCADE
@@ -189,23 +251,64 @@ completed_at TEXT
 UNIQUE (node_row_id, leg_index)
 ```
 
-The node row's scalar `session_id` stays the representative (leg 0) session for back-compat. The migration is numbered 0076 (0075 is reserved for `workspace_checkpoints`), and until the grammar could express N > 1 legs, exactly one row existed per node (leg 0), so every real definition behaved identically to the pre-ledger engine ([`migrations.rs`](../../anyharness/crates/anyharness-lib/src/persistence/migrations.rs)).
+The node row's scalar `session_id` stays the representative (leg 0) session for
+back-compat. The migration is numbered 0076 (0075 is reserved for
+`workspace_checkpoints`), and until the grammar could express N > 1 legs,
+exactly one row existed per node (leg 0), so every real definition behaved
+identically to the pre-ledger engine
+([`migrations.rs`](../../anyharness/crates/anyharness-lib/src/persistence/migrations.rs)).
 
-`TurnFinished` grew a `session_id` so every finish names the leg that produced it; the 1:1 node-row shortcut is never relied on for N > 1.
+`TurnFinished` grew a `session_id` so every finish names the leg that produced
+it; the 1:1 node-row shortcut is never relied on for N > 1.
 
-> **A parallel node waits for every leg and fails iff any leg failed (F1).** Each terminal turn arm records the leg's outcome to its ledger row and holds; the aggregation branch fires only on the last outstanding leg. `RunState` carries the loaded ledger slice (`legs_total` / `legs_done`) so the pure transition table can answer completion without touching the store ([`transition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/transition.rs)). The existing harness caps (`MaxTokens` / `MaxTurnRequests`, which arrive as `HarnessCap`) bound one hung leg from holding the node open forever; a per-node timeout is a deferred exit, not built.
+> **A parallel node waits for every leg and fails iff any leg failed (F1).**
+> Each terminal turn arm records the leg's outcome to its ledger row and holds;
+> the aggregation branch fires only on the last outstanding leg. `RunState`
+> carries the loaded ledger slice (`legs_total` / `legs_done`) so the pure
+> transition table can answer completion without touching the store
+> ([`transition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/transition.rs)).
+> The existing harness caps (`MaxTokens` / `MaxTurnRequests`, which arrive as
+> `HarnessCap`) bound one hung leg from holding the node open forever; a
+> per-node timeout is a deferred exit, not built.
 
-> **The undo window stamps at node completion, not first-of-N (F3).** For a parallel node the `first_turn_finished_at` stamp is written inside the transition that flips the node to completed, not by the per-report `note_first_turn_finished` call, so the window cannot close while N-1 legs are still running; for a one-leg node first equals last and the behavior is unchanged ([`store.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/store.rs)).
+> **The undo window stamps at node completion, not first-of-N (F3).** For a
+> parallel node the `first_turn_finished_at` stamp is written inside the
+> transition that flips the node to completed, not by the per-report
+> `note_first_turn_finished` call, so the window cannot close while N-1 legs are
+> still running; for a one-leg node first equals last and the behavior is
+> unchanged ([`store.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/store.rs)).
 
-A run-terminal Cancel stamps **every** running ledger leg terminal, adhoc rows included, via `cancel_all_run_legs_tx`, so no leg is left dangling when a run is cancelled ([`store.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/store.rs)).
+A run-terminal Cancel stamps **every** running ledger leg terminal, adhoc rows
+included, via `cancel_all_run_legs_tx`, so no leg is left dangling when a run is
+cancelled ([`store.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/store.rs)).
 
 ### Parallel nodes: per-leg prompts and fan-out (rung 5, rulings F5 and F6)
 
-Ruling F5 reversed the drafted "one prompt fanned N times": a node is an ordered list of authored leg prompts, one per session, so heterogeneous panels are v1 scope. The chain stays linear at node level; legs have no edges, ordering, or inter-leg dependencies.
+Ruling F5 reversed the drafted "one prompt fanned N times": a node is an ordered
+list of authored leg prompts, one per session, so heterogeneous panels are v1
+scope. The chain stays linear at node level; legs have no edges, ordering, or
+inter-leg dependencies.
 
-> **A node's `legs` is either absent (today's 1:1 node/session) or a 2..=8 list, and `legs[0].prompt` equals the node's scalar `prompt`.** Leg 0 is the representative session and `leg_index` addresses `legs[i]` uniformly, so every consumer of the scalar prompt stays correct without knowing legs exist (`MAX_NODE_LEGS = 8`, [`definition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/definition.rs)). The invariant is pinned on all three grammar planes: runtime ([`definition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/definition.rs)), control plane ([`models_v2.py`](../../server/proliferate/server/workflows/models_v2.py), a `min_length=2, max_length=8` list with a `prompt == legs[0].prompt` validator), and the client draft ([`workflow-builder-draft.ts`](../../apps/packages/product-client/src/lib/domain/workflows/workflow-builder-draft.ts)).
+> **A node's `legs` is either absent (today's 1:1 node/session) or a 2..=8
+> list, and `legs[0].prompt` equals the node's scalar `prompt`.** Leg 0 is the
+> representative session and `leg_index` addresses `legs[i]` uniformly, so every
+> consumer of the scalar prompt stays correct without knowing legs exist
+> (`MAX_NODE_LEGS = 8`,
+> [`definition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/definition.rs)).
+> The invariant is pinned on all three grammar planes: runtime
+> ([`definition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/definition.rs)),
+> control plane
+> ([`models_v2.py`](../../server/proliferate/server/workflows/models_v2.py), a
+> `min_length=2, max_length=8` list with a `prompt == legs[0].prompt`
+> validator), and the client draft
+> ([`workflow-builder-draft.ts`](../../apps/packages/product-client/src/lib/domain/workflows/workflow-builder-draft.ts)).
 
-Fan-out (`launch_legs` in [`launch.rs`](../../anyharness/crates/anyharness-lib/src/live/workflows/launch.rs)) renders one envelope per authored prompt against the shared doc set and inputs, mints one session per leg, and inserts N ledger rows keyed by `leg_index` in the same transaction that stamps the representative session; any failure compensates every session already minted so no half-born leg lingers.
+Fan-out (`launch_legs` in
+[`launch.rs`](../../anyharness/crates/anyharness-lib/src/live/workflows/launch.rs))
+renders one envelope per authored prompt against the shared doc set and inputs,
+mints one session per leg, and inserts N ledger rows keyed by `leg_index` in the
+same transaction that stamps the representative session; any failure compensates
+every session already minted so no half-born leg lingers.
 
 ```mermaid
 flowchart TD
@@ -218,41 +321,101 @@ flowchart TD
     A -->|no| C["aggregate: fail iff any leg failed, else complete"]
 ```
 
-> **Crash-resume re-fans-out all N legs (F6).** The boot fence parks a running node node-granularly and disposes nothing; `ResumeNode` then truncates the node's ledger and relaunches every leg from the frozen definition, using the same fan-out vocabulary as whole-node redo ([`transition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/transition.rs)). This is deliberately asymmetric with per-leg redo: crash-resume re-runs everything, only manual redo can target one leg.
+> **Crash-resume re-fans-out all N legs (F6).** The boot fence parks a running
+> node node-granularly and disposes nothing; `ResumeNode` then truncates the
+> node's ledger and relaunches every leg from the frozen definition, using the
+> same fan-out vocabulary as whole-node redo
+> ([`transition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/transition.rs)).
+> This is deliberately asymmetric with per-leg redo: crash-resume re-runs
+> everything, only manual redo can target one leg.
 
-The builder authors leg prompts through `addLeg` / `removeLeg` / `updateLeg` ([`workflow-builder-draft.ts`](../../apps/packages/product-client/src/lib/domain/workflows/workflow-builder-draft.ts)): `addLeg` seeds a 2-leg fan-out from the current prompt (leg 0 mirrors it, leg 1 blank) and grows up to eight; `removeLeg` back down to one leg collapses `legs` away entirely and keeps the survivor's text as the scalar prompt; editing leg 0 mirrors into `node.prompt` to hold the invariant. Per-leg prompt typing coalesces into one undo entry per leg under the coalesce key `node:<id>:leg:<index>`, so a burst of keystrokes is one Cmd+Z, not many.
+The builder authors leg prompts through `addLeg` / `removeLeg` / `updateLeg`
+([`workflow-builder-draft.ts`](../../apps/packages/product-client/src/lib/domain/workflows/workflow-builder-draft.ts)):
+`addLeg` seeds a 2-leg fan-out from the current prompt (leg 0 mirrors it, leg 1
+blank) and grows up to eight; `removeLeg` back down to one leg collapses `legs`
+away entirely and keeps the survivor's text as the scalar prompt; editing leg 0
+mirrors into `node.prompt` to hold the invariant. Per-leg prompt typing coalesces
+into one undo entry per leg under the coalesce key `node:<id>:leg:<index>`, so a
+burst of keystrokes is one Cmd+Z, not many.
 
 ### Per-leg redo (rung 6, ruling F2)
 
-Ruling F2 reversed whole-node-only redo: the fail-redo verb accepts an optional leg identifier.
+Ruling F2 reversed whole-node-only redo: the fail-redo verb accepts an optional
+leg identifier.
 
-- **Leg-targeted** redo is the `RedoLeg` transition ([`transition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/transition.rs)): it disposes exactly that leg's session, replaces that one ledger row (fresh row, same `leg_index`, superseded row kept terminal for audit), and relaunches only that leg's prompt through the `DisposeSessionThenStartLeg` side effect ([`store.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/store.rs)). `relaunch_leg` reads the addressed leg's prompt from the frozen definition ([`launch.rs`](../../anyharness/crates/anyharness-lib/src/live/workflows/launch.rs)); sibling legs are untouched and the node stays held until the redone leg reaches the aggregation branch.
-- **Untargeted** redo is the bulk case: a whole-node redo of a running parallel node disposes **all** live legs (`DisposeSessionsThenStartLegs`), resets the ledger, and relaunches every leg.
+- **Leg-targeted** redo is the `RedoLeg` transition
+  ([`transition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/transition.rs)):
+  it disposes exactly that leg's session, replaces that one ledger row (fresh
+  row, same `leg_index`, superseded row kept terminal for audit), and relaunches
+  only that leg's prompt through the `DisposeSessionThenStartLeg` side effect
+  ([`store.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/store.rs)).
+  `relaunch_leg` reads the addressed leg's prompt from the frozen definition
+  ([`launch.rs`](../../anyharness/crates/anyharness-lib/src/live/workflows/launch.rs));
+  sibling legs are untouched and the node stays held until the redone leg
+  reaches the aggregation branch.
+- **Untargeted** redo is the bulk case: a whole-node redo of a running parallel
+  node disposes **all** live legs (`DisposeSessionsThenStartLegs`), resets the
+  ledger, and relaunches every leg.
 
-Only failed or terminal legs are redoable while the node is held; redo of a still-running leg is rejected with a stable 409. A single leg's relaunch failure stamps only its own ledger row terminal (and disposes its own running siblings under the whole-node shape), never a sibling's row ([`store.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/store.rs)).
+Only failed or terminal legs are redoable while the node is held; redo of a
+still-running leg is rejected with a stable 409. A single leg's relaunch failure
+stamps only its own ledger row terminal (and disposes its own running siblings
+under the whole-node shape), never a sibling's row
+([`store.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/store.rs)).
 
 ### The ledger on the wire (rung 7, ruling F4)
 
-The fan-in ledger surfaces to clients as an additive, read-only rollup. The run projection carries `NodeView.sessions`, always emitted (an empty array for a node that has not launched a leg), with the scalar `session_id` kept as the representative for back-compat ([`projection.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/projection.rs)). The SDK types are `WorkflowLegStatusV2` and the per-node `sessions` list on the node type ([`workflow-runs-v2.ts`](../../anyharness/sdk/src/types/workflow-runs-v2.ts)); the generated OpenAPI artifacts were regenerated to match.
+The fan-in ledger surfaces to clients as an additive, read-only rollup. The run
+projection carries `NodeView.sessions`, always emitted (an empty array for a node
+that has not launched a leg), with the scalar `session_id` kept as the
+representative for back-compat
+([`projection.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/projection.rs)).
+The SDK types are `WorkflowLegStatusV2` and the per-node `sessions` list on the
+node type
+([`workflow-runs-v2.ts`](../../anyharness/sdk/src/types/workflow-runs-v2.ts));
+the generated OpenAPI artifacts were regenerated to match.
 
-The client computes the rollup with `workflowNodeLegRollup` ([`run-view-model.ts`](../../apps/packages/product-client/src/domain/workflows/run-view-model.ts)) and renders a "N/M done" progress row with per-leg status on the node card ([`WorkflowGraphNodeCard.tsx`](../../apps/packages/product-client/src/components/workflows/run-view/WorkflowGraphNodeCard.tsx)). A one-leg node returns no rollup, so "1/1 done" never shows.
+The client computes the rollup with `workflowNodeLegRollup`
+([`run-view-model.ts`](../../apps/packages/product-client/src/domain/workflows/run-view-model.ts))
+and renders a "N/M done" progress row with per-leg status on the node card
+([`WorkflowGraphNodeCard.tsx`](../../apps/packages/product-client/src/components/workflows/run-view/WorkflowGraphNodeCard.tsx)).
+A one-leg node returns no rollup, so "1/1 done" never shows.
 
-> **The ledger required a runtime projection field, not a client/SDK-only change.** The frozen ladder called rung 7 "client/SDK-only," but the SDK `sessions` list is generated from the Rust `NodeView.sessions` projection, so a small additive Rust field was unavoidable (wire erratum). The change is still additive and back-compatible; only the "revert is client-only" note was inaccurate.
+> **The ledger required a runtime projection field, not a client/SDK-only
+> change.** The frozen ladder called rung 7 "client/SDK-only," but the SDK
+> `sessions` list is generated from the Rust `NodeView.sessions` projection, so
+> a small additive Rust field was unavoidable (wire erratum). The change is
+> still additive and back-compatible; only the "revert is client-only" note was
+> inaccurate.
 
 ### Errata against the frozen ladder
 
-The as-built chain matches the frozen ADR except for the errata the ADR itself records (five context-doc consumers not three; `repo_root_id` unchecked; the run-rail cap at four) and two implementation notes:
+The as-built chain matches the frozen ADR except for the errata the ADR itself
+records (five context-doc consumers not three; `repo_root_id` unchecked; the
+run-rail cap at four) and two implementation notes:
 
-- **Stable error names carry the `WORKFLOW_` prefix** where the ADR drafted the bare `WORKSPACE_NOT_FOUND` / `WORKSPACE_NOT_ELIGIBLE`. Same errors, namespaced.
-- **Rung 7 needed a Rust projection field** despite the ladder's "client/SDK-only" label (see the wire erratum above).
+- **Stable error names carry the `WORKFLOW_` prefix** where the ADR drafted the
+  bare `WORKSPACE_NOT_FOUND` / `WORKSPACE_NOT_ELIGIBLE`. Same errors, namespaced.
+- **Rung 7 needed a Rust projection field** despite the ladder's "client/SDK-only"
+  label (see the wire erratum above).
 
 Neither changes the settled architecture.
 
 ### Current gaps
 
-- **Fan-out leg sessions are untitled.** Only the single-session launch path titles a session "NN Node <id>" (`node_session_title` is called from `link_start_and_dispatch`, not from the per-leg `launch_legs` dispatch loop, [`launch.rs`](../../anyharness/crates/anyharness-lib/src/live/workflows/launch.rs)). A fan-out leg's session shows no chain-index title yet.
-- **Per-leg prompt editing on redo is not included.** `RedoLeg` relaunches the addressed leg from the frozen definition's stored prompt; there is no way to edit a leg's prompt as part of a redo. This was left as a parked founder question.
-- **Chat-side context-doc mentions (rung 8) ship off this chain.** The composer `contextDoc` mention kind is delivered separately (PR #2037) and is not part of the rung 1..7 stack this document is based on, so it is described in that PR's spec, not linked here.
+- **Fan-out leg sessions are untitled.** Only the single-session launch path
+  titles a session "NN Node <id>" (`node_session_title` is called from
+  `link_start_and_dispatch`, not from the per-leg `launch_legs` dispatch loop,
+  [`launch.rs`](../../anyharness/crates/anyharness-lib/src/live/workflows/launch.rs)).
+  A fan-out leg's session shows no chain-index title yet.
+- **Per-leg prompt editing on redo is not included.** `RedoLeg` relaunches the
+  addressed leg from the frozen definition's stored prompt; there is no way to
+  edit a leg's prompt as part of a redo. This was left as a parked founder
+  question.
+- **Chat-side context-doc mentions (rung 8) ship off this chain.** The composer
+  `contextDoc` mention kind is delivered separately (PR #2037) and is not part
+  of the rung 1..7 stack this document is based on, so it is described in that
+  PR's spec, not linked here.
 
 ### Failure and observability
 
@@ -265,7 +428,12 @@ Neither changes the settled architecture.
 | Crash mid-parallel-node | boot fence parks the node; resume truncates the ledger and re-fans-out all N (F6) | automatic on restart |
 | Run cancelled mid-fan-out | every running ledger leg stamped terminal (`cancel_all_run_legs_tx`) | terminal |
 
-Counters the ADR names for these paths (`workflow.placement.conflict`, `workflow.parallel.leg_finish`, `workflow.parallel.node_complete`, `workflow.parallel.redo`, `workflow.resume.refanout`) and the `legs_total`/`legs_done` projection let dashboards read fan-in state without log archaeology; see [`../OBSERVABILITY.md`](../OBSERVABILITY.md) for the per-PR observability standard.
+Counters the ADR names for these paths (`workflow.placement.conflict`,
+`workflow.parallel.leg_finish`, `workflow.parallel.node_complete`,
+`workflow.parallel.redo`, `workflow.resume.refanout`) and the
+`legs_total`/`legs_done` projection let dashboards read fan-in state without log
+archaeology; see [`../OBSERVABILITY.md`](../OBSERVABILITY.md) for the per-PR
+observability standard.
 
 ## Overview
 

--- a/specs/FEATURE_DOCS/WORKFLOWS.md
+++ b/specs/FEATURE_DOCS/WORKFLOWS.md
@@ -10,9 +10,12 @@
 > a client-delivered invocation snapshot — is documented by the delivery
 > specs (`delivery/workflows-gen2/delivery-spec-workflows-gen2-pr1.md`
 > and successors) until this
-> document is rewritten at the end of that ladder. Only the workspace
-> placement section below still describes live code
-> (`domains/workspaces/workflow_placement.rs`).
+> document is rewritten at the end of that ladder. Three sections here already
+> describe live gen-2 code, not the superseded gen-1 vertical: "Current gen-2
+> authoring experience" (the builder), "Gen-2 follow-up: existing-workspace
+> placement and parallel nodes" (the follow-up ADR's rungs), and the "Workspace
+> Placement" section (`domains/workspaces/workflow_placement.rs`). The remaining
+> gen-1 sections stay for the record until the full rewrite.
 >
 > Superseded by name: this document's repeated prohibition on a runtime-side
 > workflow actor/manager/scheduler ("no workflow actor", "no scheduler", the
@@ -72,6 +75,197 @@ This current behavior explicitly supersedes the older PR7 delivery-spec rules
 that treated graph editing as a non-goal and rebuilt edges from array order.
 There is no schema, API, database, runtime, or run-pane change in this UI
 migration.
+
+## Gen-2 follow-up: existing-workspace placement and parallel nodes
+
+This section is current operating truth for the two additive capabilities the Follow-up Workflows ADR bolted onto the merged gen-2 engine: running a workflow run inside a workspace the user already owns (Feature A), and fanning one node out to N parallel sessions that each carry their own authored prompt (Feature B). They compose into the motivating case, a reviewer panel (a correctness, security, and perf reviewer) running as one parallel node in an existing PR worktree.
+
+It owns only the follow-up delta. The gen-2 base engine it extends (the per-run actor behind `WorkflowManager`, the pure transition table, the node/session model, the client-delivered invocation snapshot) is still documented by the delivery specs under [`../../delivery/workflows-gen2/`](../../delivery/workflows-gen2/) until the full gen-1 rewrite lands; this section never restates that base, it names the seam it changed. Workspace materialization for a fresh worktree stays owned by [Workspace Placement](#workspace-placement); this section owns only the third placement mode that adopts an existing workspace instead.
+
+The follow-up shipped as a linear ladder of rungs, each stacked on the prior:
+
+| Rung | Capability | Primary home |
+| --- | --- | --- |
+| 1 | Run-scoped context docs under `.proliferate/context/<runId>/` | [`render.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/render.rs) |
+| 2 | `ExistingWorkspace` placement + re-scoped occupancy | [`definition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/definition.rs), [`workflow_runs.rs`](../../anyharness/crates/anyharness-lib/src/api/http/workflow_runs.rs) |
+| 3 | One run rail per concurrent run, capped at four | [`WorkflowPane.tsx`](../../apps/packages/product-client/src/components/workflows/run-view/WorkflowPane.tsx) |
+| 4 | Fan-in ledger + wait-for-all aggregation | [`0076_workflow_run_node_sessions.sql`](../../anyharness/crates/anyharness-lib/src/persistence/sql/0076_workflow_run_node_sessions.sql), [`transition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/transition.rs) |
+| 5 | Per-leg authored prompts + N-way fan-out | [`definition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/definition.rs), [`launch.rs`](../../anyharness/crates/anyharness-lib/src/live/workflows/launch.rs), [`models_v2.py`](../../server/proliferate/server/workflows/models_v2.py) |
+| 6 | Per-leg redo | [`transition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/transition.rs), [`store.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/store.rs) |
+| 7 | The ledger on the wire (projection, SDK, run view) | [`projection.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/projection.rs), [`workflow-runs-v2.ts`](../../anyharness/sdk/src/types/workflow-runs-v2.ts), [`run-view-model.ts`](../../apps/packages/product-client/src/domain/workflows/run-view-model.ts) |
+
+Read with the [gen-2 delivery specs](../../delivery/workflows-gen2/) for the base engine, [Workspace Placement](#workspace-placement) for fresh-worktree materialization, and [`../TESTING/README.md`](../TESTING/README.md) for the test tiers cited below.
+
+### Code map
+
+```text
+anyharness/crates/anyharness-lib/src/
+  domains/workflows/
+    render.rs           run_context_dir_relative(run_id); envelope + preamble render
+    materialize.rs      writes each doc under the run-scoped context dir
+    definition.rs       PlacementMode, occupancy predicate, DefinitionLeg, MAX_NODE_LEGS
+    store.rs            ResolvedSideEffect fan-out shapes; leg ledger writes; cancel-all
+    transition.rs       TurnFinished.session_id; F1 aggregation; RedoLeg; ResumeNode
+    projection.rs       NodeView.sessions + NodeSessionView (the wire rollup)
+  live/workflows/
+    actor.rs            the launch/redo/resume driver; single-leg path stays inline
+    launch.rs           launch_legs fan-out, relaunch_leg per-leg redo, session titling
+  persistence/
+    sql/0076_workflow_run_node_sessions.sql   the fan-in ledger table
+    migrations.rs       registers 0076 (0075 is reserved for workspace_checkpoints)
+  api/http/workflow_runs.rs                    placement DTO threading + stable errors
+anyharness/sdk/src/types/workflow-runs-v2.ts   WorkflowLegStatusV2, NodeView.sessions
+server/proliferate/server/workflows/models_v2.py  the legs list on the CP grammar plane
+apps/packages/product-client/src/
+  lib/domain/workflows/workflow-builder-draft.ts   addLeg/removeLeg/updateLeg + coalescing
+  domain/workflows/run-view-model.ts               workflowNodeLegRollup
+  components/workflows/run-view/WorkflowPane.tsx    concurrent-run rails, cap of four
+  components/workflows/run-view/WorkflowGraphNodeCard.tsx  the "N/M done" row
+  hooks/workflows/ui/use-workflow-doc-open.ts      builds the run-scoped doc path client-side
+```
+
+### Run-scoped context docs (rung 1)
+
+> **A run owns its own context directory.** Context docs live under `.proliferate/context/<runId>/NN-slug.md`, not the old flat `.proliferate/context/NN-slug.md`, so two runs sharing one workspace never collide on the chain-index filename. The run-scoped path is minted once by `run_context_dir_relative(run_id)` ([`render.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/render.rs)).
+
+The ADR budgeted three consumers of the path constant; the as-built change has five, because the client and a release scenario also construct the path (ADR erratum #1). All five agree on the run subfolder:
+
+| Consumer | Role |
+| --- | --- |
+| [`render.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/render.rs) | owns `CONTEXT_DIR_RELATIVE` and `run_context_dir_relative`; resolves `@doc:` references and the preamble listing from the run-scoped dir |
+| [`materialize.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/materialize.rs) | creates the run dir and writes each doc into it before the first node's session starts |
+| [`actor.rs`](../../anyharness/crates/anyharness-lib/src/live/workflows/actor.rs) | drives the launch path that renders envelopes against the resolved dir |
+| [`use-workflow-doc-open.ts`](../../apps/packages/product-client/src/hooks/workflows/ui/use-workflow-doc-open.ts) | opens a doc by building `<dir>/<runId>/<filename>` from the DTO's existing `runId`, no contract change |
+| [`t3-wf-1.ts`](../../tests/release/src/scenarios/t3-wf-1.ts) | the Tier-3 release scenario asserts the on-disk run-scoped path |
+
+Migration is nil: context docs are ephemeral, gitignored run-workspace files; old flat-path runs are terminal by the time this ships.
+
+### Existing-workspace placement (rung 2, ruling F-A1)
+
+A run's placement is one of three modes on `PlacementMode` ([`definition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/definition.rs)):
+
+| Mode | Workspace | Compensation on failure |
+| --- | --- | --- |
+| `Worktree` | mints a fresh git worktree | destroys the worktree it created |
+| `RepoRoot` | reuses the repo root's workspace | leaves the reused workspace |
+| `ExistingWorkspace` | adopts a `workspaceId` the caller names | no-op; never touches an adopted workspace |
+
+`ExistingWorkspace` carries a required `workspaceId` (validated at [`definition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/definition.rs); `workspaceId` is rejected for any other mode). Adoption skips `ensure_workflow_workspace` entirely and validates that the named workspace exists, is repo-backed, and is alive; it records the run-to-workspace association on `workflow_runs.workspace_id` alone and never rewrites the workspace's creator context.
+
+> **Occupancy is re-scoped, not relaxed.** `enforces_exclusive_occupancy()` keeps the one-live-run law for `Worktree` and `RepoRoot`, and admits N concurrent runs only under `ExistingWorkspace`, where the user explicitly chose to stack work onto a workspace they own ([`definition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/definition.rs)). Both enforcement halves, the route pre-check and the store's in-transaction re-check, apply exactly this predicate, so the race protection survives the re-scoping.
+
+> **Concurrent runs share one working tree with no write isolation.** Sessions of concurrent runs, and the workspace's own chat sessions, coexist on one git index and working tree; coordinating write-heavy concurrent workflows is the caller's decision. The run-accept OpenAPI description states this doctrine verbatim ([`workflow_runs.rs`](../../anyharness/crates/anyharness-lib/src/api/http/workflow_runs.rs)).
+
+Repository-binding is deliberately not a placement constraint: the definition's `repo_root_id` versus the adopted workspace's is left **unchecked** (ADR erratum #2, ruled "it doesn't matter"), so cross-repo adoption is acceptable. The in-code comment at the adoption block is the durable record of that intent ([`workflow_runs.rs`](../../anyharness/crates/anyharness-lib/src/api/http/workflow_runs.rs)).
+
+Stable placement errors:
+
+| Condition | Status + code |
+| --- | --- |
+| Occupancy conflict under the exclusive modes | `409 WORKFLOW_PLACEMENT_CONFLICT` |
+| `existing_workspace` names an unknown workspace | `404 WORKFLOW_WORKSPACE_NOT_FOUND` |
+| Named workspace is not repo-backed / not alive | `409 WORKFLOW_WORKSPACE_NOT_ELIGIBLE` |
+
+The as-built codes carry the `WORKFLOW_` prefix; the ADR's drafted names (`WORKSPACE_NOT_FOUND` / `WORKSPACE_NOT_ELIGIBLE`) were namespaced at implementation time and are the same errors.
+
+### Concurrent-run UI (rung 3, ruling F-A2)
+
+> **At most four run rails render at once, and no waiting run is ever hidden silently.** The workspace pane shows one interactive rail per concurrent run, newest-first with active runs prioritized, capped at four; the rest sit behind a paging overflow line, and any run that hits a gate, needs human review, or fails is surfaced rather than merely reachable ([`WorkflowPane.tsx`](../../apps/packages/product-client/src/components/workflows/run-view/WorkflowPane.tsx)).
+
+The cap resolves a collision with the `unvirtualizedLongLists` census lint: each rail is a heavy interactive panel, so virtualization was rejected on the merits and a bounded list was chosen over a founder-gated census exception (ADR erratum #3). The single-run pane renders byte-identically to before the feature.
+
+### Parallel nodes: the fan-in ledger (rung 4, rulings F1 and F3)
+
+The question the ledger answers is "which of a parallel node's N sessions have already finished," and it must be answerable from SQLite after a crash, never from actor memory. The durable answer is one row per leg in `workflow_run_node_sessions` ([`0076_workflow_run_node_sessions.sql`](../../anyharness/crates/anyharness-lib/src/persistence/sql/0076_workflow_run_node_sessions.sql)):
+
+```text
+node_row_id  TEXT  -> workflow_run_nodes(id) ON DELETE CASCADE
+leg_index    INTEGER            the durable prompt-to-leg linkage (addresses legs[leg_index])
+session_id   TEXT               the leg's session, null until minted
+status       TEXT               running | done | cancelled | forced_unload
+                                | node_launch_failed | turn_error | refusal
+                                | empty_turn | harness_cap
+completed_at TEXT
+UNIQUE (node_row_id, leg_index)
+```
+
+The node row's scalar `session_id` stays the representative (leg 0) session for back-compat. The migration is numbered 0076 (0075 is reserved for `workspace_checkpoints`), and until the grammar could express N > 1 legs, exactly one row existed per node (leg 0), so every real definition behaved identically to the pre-ledger engine ([`migrations.rs`](../../anyharness/crates/anyharness-lib/src/persistence/migrations.rs)).
+
+`TurnFinished` grew a `session_id` so every finish names the leg that produced it; the 1:1 node-row shortcut is never relied on for N > 1.
+
+> **A parallel node waits for every leg and fails iff any leg failed (F1).** Each terminal turn arm records the leg's outcome to its ledger row and holds; the aggregation branch fires only on the last outstanding leg. `RunState` carries the loaded ledger slice (`legs_total` / `legs_done`) so the pure transition table can answer completion without touching the store ([`transition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/transition.rs)). The existing harness caps (`MaxTokens` / `MaxTurnRequests`, which arrive as `HarnessCap`) bound one hung leg from holding the node open forever; a per-node timeout is a deferred exit, not built.
+
+> **The undo window stamps at node completion, not first-of-N (F3).** For a parallel node the `first_turn_finished_at` stamp is written inside the transition that flips the node to completed, not by the per-report `note_first_turn_finished` call, so the window cannot close while N-1 legs are still running; for a one-leg node first equals last and the behavior is unchanged ([`store.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/store.rs)).
+
+A run-terminal Cancel stamps **every** running ledger leg terminal, adhoc rows included, via `cancel_all_run_legs_tx`, so no leg is left dangling when a run is cancelled ([`store.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/store.rs)).
+
+### Parallel nodes: per-leg prompts and fan-out (rung 5, rulings F5 and F6)
+
+Ruling F5 reversed the drafted "one prompt fanned N times": a node is an ordered list of authored leg prompts, one per session, so heterogeneous panels are v1 scope. The chain stays linear at node level; legs have no edges, ordering, or inter-leg dependencies.
+
+> **A node's `legs` is either absent (today's 1:1 node/session) or a 2..=8 list, and `legs[0].prompt` equals the node's scalar `prompt`.** Leg 0 is the representative session and `leg_index` addresses `legs[i]` uniformly, so every consumer of the scalar prompt stays correct without knowing legs exist (`MAX_NODE_LEGS = 8`, [`definition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/definition.rs)). The invariant is pinned on all three grammar planes: runtime ([`definition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/definition.rs)), control plane ([`models_v2.py`](../../server/proliferate/server/workflows/models_v2.py), a `min_length=2, max_length=8` list with a `prompt == legs[0].prompt` validator), and the client draft ([`workflow-builder-draft.ts`](../../apps/packages/product-client/src/lib/domain/workflows/workflow-builder-draft.ts)).
+
+Fan-out (`launch_legs` in [`launch.rs`](../../anyharness/crates/anyharness-lib/src/live/workflows/launch.rs)) renders one envelope per authored prompt against the shared doc set and inputs, mints one session per leg, and inserts N ledger rows keyed by `leg_index` in the same transaction that stamps the representative session; any failure compensates every session already minted so no half-born leg lingers.
+
+```mermaid
+flowchart TD
+    L["launch_legs (node with N leg prompts)"] --> R["render one envelope per prompt<br/>(shared docs + inputs)"]
+    R --> M["mint N sessions, insert N ledger rows<br/>keyed by leg_index, stamp leg 0 representative"]
+    M --> D["start + dispatch each leg"]
+    D --> F["each TurnFinished carries session_id<br/>-> record leg outcome to its ledger row, hold"]
+    F --> A{"any leg outstanding?"}
+    A -->|yes| H["hold"]
+    A -->|no| C["aggregate: fail iff any leg failed, else complete"]
+```
+
+> **Crash-resume re-fans-out all N legs (F6).** The boot fence parks a running node node-granularly and disposes nothing; `ResumeNode` then truncates the node's ledger and relaunches every leg from the frozen definition, using the same fan-out vocabulary as whole-node redo ([`transition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/transition.rs)). This is deliberately asymmetric with per-leg redo: crash-resume re-runs everything, only manual redo can target one leg.
+
+The builder authors leg prompts through `addLeg` / `removeLeg` / `updateLeg` ([`workflow-builder-draft.ts`](../../apps/packages/product-client/src/lib/domain/workflows/workflow-builder-draft.ts)): `addLeg` seeds a 2-leg fan-out from the current prompt (leg 0 mirrors it, leg 1 blank) and grows up to eight; `removeLeg` back down to one leg collapses `legs` away entirely and keeps the survivor's text as the scalar prompt; editing leg 0 mirrors into `node.prompt` to hold the invariant. Per-leg prompt typing coalesces into one undo entry per leg under the coalesce key `node:<id>:leg:<index>`, so a burst of keystrokes is one Cmd+Z, not many.
+
+### Per-leg redo (rung 6, ruling F2)
+
+Ruling F2 reversed whole-node-only redo: the fail-redo verb accepts an optional leg identifier.
+
+- **Leg-targeted** redo is the `RedoLeg` transition ([`transition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/transition.rs)): it disposes exactly that leg's session, replaces that one ledger row (fresh row, same `leg_index`, superseded row kept terminal for audit), and relaunches only that leg's prompt through the `DisposeSessionThenStartLeg` side effect ([`store.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/store.rs)). `relaunch_leg` reads the addressed leg's prompt from the frozen definition ([`launch.rs`](../../anyharness/crates/anyharness-lib/src/live/workflows/launch.rs)); sibling legs are untouched and the node stays held until the redone leg reaches the aggregation branch.
+- **Untargeted** redo is the bulk case: a whole-node redo of a running parallel node disposes **all** live legs (`DisposeSessionsThenStartLegs`), resets the ledger, and relaunches every leg.
+
+Only failed or terminal legs are redoable while the node is held; redo of a still-running leg is rejected with a stable 409. A single leg's relaunch failure stamps only its own ledger row terminal (and disposes its own running siblings under the whole-node shape), never a sibling's row ([`store.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/store.rs)).
+
+### The ledger on the wire (rung 7, ruling F4)
+
+The fan-in ledger surfaces to clients as an additive, read-only rollup. The run projection carries `NodeView.sessions`, always emitted (an empty array for a node that has not launched a leg), with the scalar `session_id` kept as the representative for back-compat ([`projection.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/projection.rs)). The SDK types are `WorkflowLegStatusV2` and the per-node `sessions` list on the node type ([`workflow-runs-v2.ts`](../../anyharness/sdk/src/types/workflow-runs-v2.ts)); the generated OpenAPI artifacts were regenerated to match.
+
+The client computes the rollup with `workflowNodeLegRollup` ([`run-view-model.ts`](../../apps/packages/product-client/src/domain/workflows/run-view-model.ts)) and renders a "N/M done" progress row with per-leg status on the node card ([`WorkflowGraphNodeCard.tsx`](../../apps/packages/product-client/src/components/workflows/run-view/WorkflowGraphNodeCard.tsx)). A one-leg node returns no rollup, so "1/1 done" never shows.
+
+> **The ledger required a runtime projection field, not a client/SDK-only change.** The frozen ladder called rung 7 "client/SDK-only," but the SDK `sessions` list is generated from the Rust `NodeView.sessions` projection, so a small additive Rust field was unavoidable (wire erratum). The change is still additive and back-compatible; only the "revert is client-only" note was inaccurate.
+
+### Errata against the frozen ladder
+
+The as-built chain matches the frozen ADR except for the errata the ADR itself records (five context-doc consumers not three; `repo_root_id` unchecked; the run-rail cap at four) and two implementation notes:
+
+- **Stable error names carry the `WORKFLOW_` prefix** where the ADR drafted the bare `WORKSPACE_NOT_FOUND` / `WORKSPACE_NOT_ELIGIBLE`. Same errors, namespaced.
+- **Rung 7 needed a Rust projection field** despite the ladder's "client/SDK-only" label (see the wire erratum above).
+
+Neither changes the settled architecture.
+
+### Current gaps
+
+- **Fan-out leg sessions are untitled.** Only the single-session launch path titles a session "NN Node <id>" (`node_session_title` is called from `link_start_and_dispatch`, not from the per-leg `launch_legs` dispatch loop, [`launch.rs`](../../anyharness/crates/anyharness-lib/src/live/workflows/launch.rs)). A fan-out leg's session shows no chain-index title yet.
+- **Per-leg prompt editing on redo is not included.** `RedoLeg` relaunches the addressed leg from the frozen definition's stored prompt; there is no way to edit a leg's prompt as part of a redo. This was left as a parked founder question.
+- **Chat-side context-doc mentions (rung 8) ship off this chain.** The composer `contextDoc` mention kind is delivered separately (PR #2037) and is not part of the rung 1..7 stack this document is based on, so it is described in that PR's spec, not linked here.
+
+### Failure and observability
+
+| Condition | Result | Recovery |
+| --- | --- | --- |
+| Occupancy conflict under an exclusive mode | `409 WORKFLOW_PLACEMENT_CONFLICT`, zero rows inserted | caller retries against a free workspace or uses `existing_workspace` |
+| `existing_workspace` names an unknown / ineligible workspace | `404 WORKFLOW_WORKSPACE_NOT_FOUND` / `409 WORKFLOW_WORKSPACE_NOT_ELIGIBLE` | caller names a live, repo-backed workspace |
+| A leg fails | node holds until all legs finish, then fails (F1) | per-leg redo re-runs only the failed leg (F2) |
+| Redo of a still-running leg | stable `409` | wait for the leg to reach a terminal state |
+| Crash mid-parallel-node | boot fence parks the node; resume truncates the ledger and re-fans-out all N (F6) | automatic on restart |
+| Run cancelled mid-fan-out | every running ledger leg stamped terminal (`cancel_all_run_legs_tx`) | terminal |
+
+Counters the ADR names for these paths (`workflow.placement.conflict`, `workflow.parallel.leg_finish`, `workflow.parallel.node_complete`, `workflow.parallel.redo`, `workflow.resume.refanout`) and the `legs_total`/`legs_done` projection let dashboards read fan-in state without log archaeology; see [`../OBSERVABILITY.md`](../OBSERVABILITY.md) for the per-PR observability standard.
 
 ## Overview
 

--- a/specs/FEATURE_DOCS/WORKFLOWS.md
+++ b/specs/FEATURE_DOCS/WORKFLOWS.md
@@ -264,8 +264,9 @@ it; the 1:1 node-row shortcut is never relied on for N > 1.
 > **A parallel node waits for every leg and fails iff any leg failed (F1).**
 > Each terminal turn arm records the leg's outcome to its ledger row and holds;
 > the aggregation branch fires only on the last outstanding leg. `RunState`
-> carries the loaded ledger slice (`legs_total` / `legs_done`) so the pure
-> transition table can answer completion without touching the store
+> carries the loaded ledger slice (`node_legs`, read per node via `legs_of()`;
+> the ADR calls these `legs_total` / `legs_done`) so the pure transition table
+> can answer completion without touching the store
 > ([`transition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/transition.rs)).
 > The existing harness caps (`MaxTokens` / `MaxTurnRequests`, which arrive as
 > `HarnessCap`) bound one hung leg from holding the node open forever; a
@@ -345,23 +346,32 @@ leg identifier.
 
 - **Leg-targeted** redo is the `RedoLeg` transition
   ([`transition.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/transition.rs)):
-  it disposes exactly that leg's session, replaces that one ledger row (fresh
-  row, same `leg_index`, superseded row kept terminal for audit), and relaunches
-  only that leg's prompt through the `DisposeSessionThenStartLeg` side effect
-  ([`store.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/store.rs)).
+  it resets that one ledger row in place back to running (`reset_leg_running_tx`
+  keeps the row's `leg_index` and its `session_id` until the relaunch re-stamps a
+  fresh one), disposes that leg's live session when the leg is still running, and
+  relaunches only that leg's prompt through the `DisposeSessionThenStartLeg`
+  side effect
+  ([`store/node_sessions.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/store/node_sessions.rs)).
   `relaunch_leg` reads the addressed leg's prompt from the frozen definition
   ([`launch.rs`](../../anyharness/crates/anyharness-lib/src/live/workflows/launch.rs));
-  sibling legs are untouched and the node stays held until the redone leg
-  reaches the aggregation branch.
-- **Untargeted** redo is the bulk case: a whole-node redo of a running parallel
-  node disposes **all** live legs (`DisposeSessionsThenStartLegs`), resets the
-  ledger, and relaunches every leg.
+  sibling rows are untouched and the node stays held until the redone leg reaches
+  the aggregation branch.
+- **Untargeted** (whole-node) redo is the bulk case: it disposes all live legs
+  and replaces the node row itself (`replaces_node_row_id`,
+  [`store.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/store.rs)),
+  re-fanning-out every leg on the fresh node row.
 
-Only failed or terminal legs are redoable while the node is held; redo of a
-still-running leg is rejected with a stable 409. A single leg's relaunch failure
-stamps only its own ledger row terminal (and disposes its own running siblings
-under the whole-node shape), never a sibling's row
-([`store.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/store.rs)).
+Per-leg redo applies at a pause (failed, needs_attention, or awaiting_human) or
+to a running chain node; there is no 409 for a still-running leg, whose live
+session is disposed and relaunched. A per-leg redo aimed at a one-leg node, or an
+out-of-range leg index, is rejected as an illegal command.
+
+When a single-leg relaunch itself fails, the failure status lands only on the
+addressed leg's row; its still-running siblings are stamped cancelled (not
+failed) and their sessions disposed, and already-terminal siblings keep their
+status and completion receipts
+([`store/node_sessions.rs`](../../anyharness/crates/anyharness-lib/src/domains/workflows/store/node_sessions.rs),
+`fail_leg_and_cancel_running_siblings_tx`).
 
 ### The ledger on the wire (rung 7, ruling F4)
 
@@ -424,16 +434,20 @@ Neither changes the settled architecture.
 | Occupancy conflict under an exclusive mode | `409 WORKFLOW_PLACEMENT_CONFLICT`, zero rows inserted | caller retries against a free workspace or uses `existing_workspace` |
 | `existing_workspace` names an unknown / ineligible workspace | `404 WORKFLOW_WORKSPACE_NOT_FOUND` / `409 WORKFLOW_WORKSPACE_NOT_ELIGIBLE` | caller names a live, repo-backed workspace |
 | A leg fails | node holds until all legs finish, then fails (F1) | per-leg redo re-runs only the failed leg (F2) |
-| Redo of a still-running leg | stable `409` | wait for the leg to reach a terminal state |
+| Per-leg redo of a running leg | that leg's live session is disposed and its ledger row reset to running, then relaunched (`RedoLeg`); siblings untouched | node re-aggregates when the redone leg finishes |
+| Per-leg redo of a one-leg node or an out-of-range leg index | rejected as an illegal command | use whole-node redo instead |
 | Crash mid-parallel-node | boot fence parks the node; resume truncates the ledger and re-fans-out all N (F6) | automatic on restart |
 | Run cancelled mid-fan-out | every running ledger leg stamped terminal (`cancel_all_run_legs_tx`) | terminal |
 
-Counters the ADR names for these paths (`workflow.placement.conflict`,
-`workflow.parallel.leg_finish`, `workflow.parallel.node_complete`,
-`workflow.parallel.redo`, `workflow.resume.refanout`) and the
-`legs_total`/`legs_done` projection let dashboards read fan-in state without log
-archaeology; see [`../OBSERVABILITY.md`](../OBSERVABILITY.md) for the per-PR
-observability standard.
+No dedicated metrics ship with this program: the workflows domain emits none of
+the counters the ADR sketched, and there is no `legs_total`/`legs_done` gauge. A
+placement conflict surfaces as the `409 WORKFLOW_PLACEMENT_CONFLICT` and a
+correlation-only log line
+([`workflow_runs.rs`](../../anyharness/crates/anyharness-lib/src/api/http/workflow_runs.rs)),
+and fan-in state is read off the projection's per-leg `NodeView.sessions` list
+rather than a metric (the client derives `total`/`finished` from it, see rung 7).
+See [`../OBSERVABILITY.md`](../OBSERVABILITY.md) for the per-PR observability
+standard a follow-up would meet if metrics are added.
 
 ## Overview
 


### PR DESCRIPTION
## Rung 9 (final): docs and records

Lands the canonical documentation for the Workflows follow-up program, per the
frozen ADR's rung-9 scope ("canonical workflow docs updated ... the consolidated
feature doc"). Documents the two additive capabilities as built across rungs
1-7 on this stacked chain, in a new "Gen-2 follow-up: existing-workspace
placement and parallel nodes" section of the single canonical workflow doc
(`specs/FEATURE_DOCS/WORKFLOWS.md`).

Covered, each with verified code links:

- Run-scoped context docs under `.proliferate/context/<runId>/` (rung 1), with the five as-built consumers (ADR erratum #1).
- `ExistingWorkspace` placement, the re-scoped occupancy law, adoption without provenance rewrite, no-op compensation, stable error taxonomy, and the shared-working-tree doctrine sentence (rung 2). `repo_root_id` left unchecked (erratum #2).
- The concurrent-run rail cap of four with overflow + reachability (rung 3, erratum #3).
- The `workflow_run_node_sessions` fan-in ledger (migration 0076), wait-for-all/fail-iff-any aggregation (F1), the undo-window relocation (F3), and cancel stamping every running leg (rung 4).
- Per-leg authored prompts (2..=8, `legs[0].prompt == prompt`) across all three grammar planes, N-way fan-out, crash-resume re-fan-out (F6), and the builder leg authoring + per-leg undo coalescing (rung 5).
- Per-leg redo (`RedoLeg`, `DisposeSessionThenStartLeg`), whole-node redo disposing all live legs, and single-leg-failure isolation (rung 6).
- The ledger on the wire: `NodeView.sessions`, `WorkflowLegStatusV2`, the client `workflowNodeLegRollup` and "N/M done" node-card row (rung 7).

Records the deviations against the frozen ladder as errata (WORKFLOW_-prefixed
error names; the rung-7 change needed a small additive Rust projection field
despite the "client/SDK-only" label) and the known open gaps (fan-out leg
sessions are untitled; per-leg prompt editing on redo is not included; rung-8
chat context-doc mentions ship off this chain in #2037).

No new lint/enforcement record was warranted: the program satisfied existing
lint families (max-lines ratchets, the census lint via the rail cap, PROD-DOCS)
and introduced no new rule family.

## Scope and validation

- Docs-only. Single file touched: `specs/FEATURE_DOCS/WORKFLOWS.md` (+197 / -3), plus a stale-banner correction noting the live gen-2 sections.
- `python3 scripts/check_docs.py` passes (230 markdown files); `python3 -m unittest scripts/test_check_docs.py` passes (20 tests).
- No cargo/rustc/make/docker run (docs need none).
- Rebased onto the re-parented base `wf-followup/r7-leg-rollup` (cd4944db6); `git diff cd4944db6..HEAD` shows only this doc.

Base: `wf-followup/r7-leg-rollup`. Draft; Pablo merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
