### PR TITLE
fix(product): prevent dismissed Home probe flash

### DIFF
--- a/apps/packages/product-client/src/hooks/home/facade/use-home-screen.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/facade/use-home-screen.test.tsx
@@ -1,0 +1,296 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type {
+  ErrorContext,
+  ProductStorage,
+} from "@proliferate/product-client/host/product-host";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useHomeScreen } from "#product/hooks/home/facade/use-home-screen";
+import type { ProductStorageContext } from "#product/lib/infra/persistence/product-storage";
+
+const HOME_MODEL_PROBE_DISMISSED_STORAGE_KEY =
+  "proliferate.home.modelProbeCardDismissed";
+
+const mocks = vi.hoisted(() => ({
+  storageContext: null as ProductStorageContext | null,
+  readyAgents: [{ kind: "claude" }, { kind: "codex" }],
+  agentsLoading: false,
+  isReconciling: true,
+  readIsStaleCallbacks: [] as Array<() => boolean>,
+  navigate: vi.fn(),
+  openAddRepoFlow: vi.fn(),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mocks.navigate,
+}));
+
+vi.mock("@proliferate/cloud-sdk-react", () => ({
+  useRepositories: () => ({
+    data: { repositories: [] },
+    isPending: false,
+  }),
+}));
+
+vi.mock("#product/hooks/agents/derived/use-agent-catalog", () => ({
+  useAgentCatalog: () => ({
+    readyAgents: mocks.readyAgents,
+    isLoading: mocks.agentsLoading,
+    isReconciling: mocks.isReconciling,
+  }),
+}));
+
+vi.mock("#product/hooks/agents/lifecycle/use-auth-setup-onboarding-step", () => ({
+  useAuthSetupOnboardingStep: () => "hidden",
+}));
+
+vi.mock("#product/hooks/agents/lifecycle/use-auth-setup-onboarding-evidence", () => ({
+  useAuthSetupOnboardingEvidence: () => null,
+}));
+
+vi.mock("#product/hooks/cloud/derived/use-cloud-availability-state", () => ({
+  useCloudAvailabilityState: () => ({ cloudActive: false }),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/use-add-repo", () => ({
+  useAddRepo: () => ({ isAddingRepo: false }),
+}));
+
+vi.mock("#product/stores/ui/add-repo-flow-store", () => ({
+  useAddRepoFlowStore: (selector: (state: { openFlow: () => void }) => unknown) =>
+    selector({ openFlow: mocks.openAddRepoFlow }),
+}));
+
+vi.mock("#product/hooks/workspaces/derived/use-standard-repo-projection", () => ({
+  useStandardRepoProjection: () => ({
+    localWorkspaces: [],
+    repoRoots: [],
+    isLoading: false,
+  }),
+}));
+
+vi.mock("#product/stores/preferences/user-preferences-store", () => ({
+  useUserPreferencesStore: (
+    selector: (state: { defaultChatAgentKind: string }) => unknown,
+  ) => selector({ defaultChatAgentKind: "claude" }),
+}));
+
+vi.mock("#product/stores/preferences/workspace-ui-store", () => ({
+  useWorkspaceUiStore: (
+    selector: (state: { hiddenRepoRootIds: string[] }) => unknown,
+  ) => selector({ hiddenRepoRootIds: [] }),
+}));
+
+vi.mock("#product/hooks/persistence/facade/use-product-storage-context", () => ({
+  useProductStorageContext: () => {
+    if (!mocks.storageContext) {
+      throw new Error("Test storage context was not installed");
+    }
+    return mocks.storageContext;
+  },
+}));
+
+vi.mock(
+  "#product/lib/infra/persistence/product-storage",
+  async (importOriginal) => {
+    const actual = await importOriginal<
+      typeof import("#product/lib/infra/persistence/product-storage")
+    >();
+    return {
+      ...actual,
+      readPersistedString: vi.fn(
+        (...args: Parameters<typeof actual.readPersistedString>) => {
+          const options = args[2];
+          if (options?.isStale) {
+            mocks.readIsStaleCallbacks.push(options.isStale);
+          }
+          return actual.readPersistedString(...args);
+        },
+      ),
+    };
+  },
+);
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function installStorage(args: {
+  getItem: ProductStorage["getItem"];
+  setItem?: ProductStorage["setItem"];
+}) {
+  const captureException = vi.fn<
+    (error: unknown, context?: ErrorContext) => void
+  >();
+  const storage: ProductStorage = {
+    getItem: vi.fn(args.getItem),
+    setItem: vi.fn(args.setItem ?? (async () => {})),
+    removeItem: vi.fn(async () => {}),
+  };
+  mocks.storageContext = { storage, captureException };
+  return { storage, captureException };
+}
+
+async function resolveDeferredRead(
+  deferred: Deferred<string | null>,
+  value: string | null,
+) {
+  await act(async () => {
+    deferred.resolve(value);
+    await deferred.promise;
+  });
+}
+
+describe("useHomeScreen model-probe dismissal hydration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.readyAgents = [{ kind: "claude" }, { kind: "codex" }];
+    mocks.agentsLoading = false;
+    mocks.isReconciling = true;
+    mocks.readIsStaleCallbacks.length = 0;
+    mocks.storageContext = null;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("withholds the probe inputs until a deferred sentinel read settles", async () => {
+    const read = createDeferred<string | null>();
+    mocks.agentsLoading = true;
+    const { storage } = installStorage({ getItem: () => read.promise });
+    const { result } = renderHook(() => useHomeScreen());
+
+    expect(result.current.modelProbeInputs).toBeUndefined();
+    expect(storage.getItem).toHaveBeenCalledWith(
+      HOME_MODEL_PROBE_DISMISSED_STORAGE_KEY,
+    );
+
+    await resolveDeferredRead(read, "1");
+
+    expect(result.current.modelProbeInputs).toEqual({
+      dismissed: true,
+      agentsLoading: true,
+      isReconciling: true,
+      harnessKinds: ["claude", "codex"],
+    });
+  });
+
+  it.each([
+    { label: "a missing value", raw: null },
+    { label: "an empty value", raw: "" },
+    { label: "an unrecognized value", raw: "0" },
+  ])("settles $label to visible", async ({ raw }) => {
+    installStorage({ getItem: async () => raw });
+    const { result } = renderHook(() => useHomeScreen());
+
+    await waitFor(() => {
+      expect(result.current.modelProbeInputs?.dismissed).toBe(false);
+    });
+  });
+
+  it("settles a captured read rejection to visible", async () => {
+    const readError = new Error("storage read failed");
+    const { captureException } = installStorage({
+      getItem: async () => Promise.reject(readError),
+    });
+    const { result } = renderHook(() => useHomeScreen());
+
+    await waitFor(() => {
+      expect(result.current.modelProbeInputs?.dismissed).toBe(false);
+    });
+    expect(captureException).toHaveBeenCalledWith(
+      readError,
+      expect.objectContaining({
+        tags: {
+          domain: "product_storage",
+          action: "read",
+          key: HOME_MODEL_PROBE_DISMISSED_STORAGE_KEY,
+        },
+      }),
+    );
+  });
+
+  it.each([
+    { label: "a late missing value", lateValue: null },
+    { label: "a late sentinel", lateValue: "1" },
+  ])("keeps a current dismissal after $label", async ({ lateValue }) => {
+    const read = createDeferred<string | null>();
+    const { storage } = installStorage({ getItem: () => read.promise });
+    const { result } = renderHook(() => useHomeScreen());
+
+    act(() => {
+      result.current.dismissModelProbeCard();
+    });
+
+    expect(result.current.modelProbeInputs?.dismissed).toBe(true);
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+    expect(storage.setItem).toHaveBeenCalledWith(
+      HOME_MODEL_PROBE_DISMISSED_STORAGE_KEY,
+      "1",
+    );
+
+    await resolveDeferredRead(read, lateValue);
+
+    expect(result.current.modelProbeInputs?.dismissed).toBe(true);
+  });
+
+  it("marks an unmounted read stale so its late value is ignored", async () => {
+    const read = createDeferred<string | null>();
+    const { captureException } = installStorage({ getItem: () => read.promise });
+    const { result, unmount } = renderHook(() => useHomeScreen());
+
+    expect(result.current.modelProbeInputs).toBeUndefined();
+    expect(mocks.readIsStaleCallbacks).toHaveLength(1);
+    expect(mocks.readIsStaleCallbacks[0]?.()).toBe(false);
+
+    unmount();
+    expect(mocks.readIsStaleCallbacks[0]?.()).toBe(true);
+
+    await resolveDeferredRead(read, "1");
+
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it("keeps the dismissed UI state when the best-effort write rejects", async () => {
+    const writeError = new Error("storage write failed");
+    const { captureException } = installStorage({
+      getItem: async () => null,
+      setItem: async () => Promise.reject(writeError),
+    });
+    const { result } = renderHook(() => useHomeScreen());
+
+    await waitFor(() => {
+      expect(result.current.modelProbeInputs?.dismissed).toBe(false);
+    });
+
+    act(() => {
+      result.current.dismissModelProbeCard();
+    });
+
+    expect(result.current.modelProbeInputs?.dismissed).toBe(true);
+    await waitFor(() => {
+      expect(captureException).toHaveBeenCalledWith(
+        writeError,
+        expect.objectContaining({
+          tags: {
+            domain: "product_storage",
+            action: "write",
+            key: HOME_MODEL_PROBE_DISMISSED_STORAGE_KEY,
+          },
+        }),
+      );
+    });
+    expect(result.current.modelProbeInputs?.dismissed).toBe(true);
+  });
+});

--- a/apps/packages/product-client/src/hooks/home/facade/use-home-screen.ts
+++ b/apps/packages/product-client/src/hooks/home/facade/use-home-screen.ts
@@ -22,12 +22,13 @@ import { useUserPreferencesStore } from "#product/stores/preferences/user-prefer
 import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-store";
 import { useProductStorageContext } from "#product/hooks/persistence/facade/use-product-storage-context";
 import {
-  readPersistedStringValue,
+  readPersistedString,
   writePersistedString,
 } from "#product/lib/infra/persistence/product-storage";
 
 const HOME_MODEL_PROBE_DISMISSED_STORAGE_KEY =
   "proliferate.home.modelProbeCardDismissed";
+type HomeModelProbeDismissalState = "loading" | "visible" | "dismissed";
 
 // Owns the Home screen facade consumed by the component. Does not own Home Next launch flow.
 export function useHomeScreen() {
@@ -40,24 +41,28 @@ export function useHomeScreen() {
     isLoading: agentsLoading,
     isReconciling,
   } = useAgentCatalog();
-  const [modelProbeDismissed, setModelProbeDismissed] = useState<boolean>(false);
+  const [modelProbeDismissalState, setModelProbeDismissalState] =
+    useState<HomeModelProbeDismissalState>("loading");
   useEffect(() => {
     let cancelled = false;
     // Bare "1" sentinel string (never JSON): read raw to preserve the existing
     // dismissal with zero migration. A late read after unmount is discarded.
-    void readPersistedStringValue(storage, HOME_MODEL_PROBE_DISMISSED_STORAGE_KEY).then(
-      (value) => {
-        if (!cancelled && value === "1") {
-          setModelProbeDismissed(true);
-        }
-      },
-    );
+    void readPersistedString(storage, HOME_MODEL_PROBE_DISMISSED_STORAGE_KEY, {
+      isStale: () => cancelled,
+    }).then((result) => {
+      if (result.status === "settled") {
+        const hydratedState = result.value === "1" ? "dismissed" : "visible";
+        setModelProbeDismissalState((current) =>
+          current === "loading" ? hydratedState : current
+        );
+      }
+    });
     return () => {
       cancelled = true;
     };
   }, [storage]);
   const dismissModelProbeCard = useCallback(() => {
-    setModelProbeDismissed(true);
+    setModelProbeDismissalState("dismissed");
     void writePersistedString(storage, HOME_MODEL_PROBE_DISMISSED_STORAGE_KEY, "1");
   }, [storage]);
   const { cloudActive } = useCloudAvailabilityState();
@@ -162,12 +167,14 @@ export function useHomeScreen() {
     // Model-probe card inputs (UX spec §10). The model count itself lives with
     // the home model-selection state, so the screen combines these with its
     // model groups via resolveHomeModelProbeCardState.
-    modelProbeInputs: {
-      dismissed: modelProbeDismissed,
-      agentsLoading,
-      isReconciling,
-      harnessKinds: readyHarnessKinds,
-    },
+    modelProbeInputs: modelProbeDismissalState === "loading"
+      ? undefined
+      : {
+        dismissed: modelProbeDismissalState === "dismissed",
+        agentsLoading,
+        isReconciling,
+        harnessKinds: readyHarnessKinds,
+      },
     dismissModelProbeCard,
   };
 }

--- a/specs/FEATURE_DOCS/MODELS.md
+++ b/specs/FEATURE_DOCS/MODELS.md
@@ -537,6 +537,25 @@ this platform:
 - **The list is auto-collapsed by default.** It is reference material, not
   the reason a user opened the pane.
 
+### Home probe-card dismissal
+
+Home persists dismissal of its model-probe card under the raw-string key
+`proliferate.home.modelProbeCardDismissed`, with exact value `"1"` as the only
+dismissed sentinel. The facade owns an explicit per-mount hydration state:
+`loading`, `visible`, or `dismissed`. While it is `loading`, the facade omits
+the probe inputs entirely, so cached agent and model data cannot mount the card
+before the persisted choice is known. An exact sentinel settles to
+`dismissed`; a missing value, any other raw value, or a captured read failure
+settles to `visible`.
+
+Hydration may transition only a still-loading state. A current user dismissal
+moves the state synchronously to `dismissed` before the existing best-effort
+sentinel write, and a late read cannot overwrite it. Reads use the mounted
+host's storage context and its staleness guard, so an unmounted result is
+ignored. Read and write failures retain the persistence layer's existing
+captured, non-blocking behavior: a failed read still settles to visible, and a
+failed write never rolls the in-memory dismissal back.
+
 ### Probing during a degraded apply
 
 An apply can land while gateway enrollment sync is incomplete, in which case


### PR DESCRIPTION
## Summary

- withholds Home's model-probe inputs until the persisted dismissal sentinel has settled
- keeps exact raw `"1"` dismissals authoritative from the first committed Home render
- settles missing, unknown, and failed reads visible while preventing a current dismissal from being overwritten by a late result
- preserves the existing probe resolver, card behavior, storage key, and best-effort write semantics
- documents the hydration contract in the Models feature specification

## Frozen contract

- Vault spec: `/Users/pablohansen/Proliferate Workspace/ADRs/Session Surfaces Recovery/PR Specs/PR 2 - Home model-probe dismissal hydration.md`
- Revision: `2026-08-19.2-frozen`
- Original implementation base: `12518cb173d74bec51ea31c1aa7bd29a976dc74e`
- Final no-overlap restack base: `bfb8f64659b81cf2716b0ec006c8f469da0b3395`
- Current reviewed head: `ac462201e89872e6e1d5becec5f5819c01ad700e`

## Testing

- focused Home facade, screen, onboarding-card, and domain tests — 61/61
- ProductClient typecheck and build
- Web typecheck and build
- Desktop renderer build
- frontend boundaries and strict frontend structure — zero violations
- docs and design-attribution checks
- `git diff --check`
- login runtime budget — JS `491795/502000`, CSS `65853/66250`, zero eager font/image/audio assets

The first package-script test command ignored its selector and began the broad ProductClient suite; it was stopped promptly for machine-pressure safety and is not claimed. The intended focused suites were rerun directly and passed. The full ProductClient suite remains CI-owned. No stable rendered state or interaction changed, so this non-visual hydration fix does not add a Tier-2 or screenshot fixture. No Rust files changed, so no local Cargo build was run.

## Review

Independent review accepted the exact three-file implementation with no findings. The reviewer independently reproduced 61/61 focused tests, ProductClient typecheck, the relevant static/docs gates, and the diff check. After `main` advanced through server-only PR #2059, `git range-diff` reported an exact `=` restack; the reviewer accepted final head `ac462201e89872e6e1d5becec5f5819c01ad700e` on base `bfb8f64659b81cf2716b0ec006c8f469da0b3395`.

## Observability

None. Existing persistence helpers continue to capture read/write failures through the injected telemetry path. No prompt, repository, model, user, or storage value is added to events, logs, attributes, or diagnostics.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Verification

- Persisted `"1"` never exposes probe inputs during hydration.
- Missing, unknown, and rejected reads settle visible.
- Dismiss-during-pending wins over late missing and sentinel results.
- Unmounted reads are stale; write failure never rolls the UI state back.
- Settled agent-loading, reconciliation, and harness-kind inputs retain their prior shape.
