### PR TITLE
fix(desktop): classify local path inspection

### DIFF
--- a/apps/desktop/src-tauri/src/commands/shell.rs
+++ b/apps/desktop/src-tauri/src/commands/shell.rs
@@ -1,5 +1,6 @@
 use crate::editors;
 use std::io::Write;
+use std::path::Path;
 use std::process::Command;
 use std::process::Stdio;
 
@@ -13,9 +14,56 @@ pub fn open_in_editor(path: String, editor: String) -> Result<(), String> {
     editors::open_path_in_editor(&path, &editor)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PathInspection {
+    File,
+    Directory,
+    Missing,
+    Unavailable {
+        reason: PathInspectionUnavailableReason,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PathInspectionUnavailableReason {
+    InvalidPath,
+    PermissionDenied,
+    UnsupportedType,
+    IoError,
+}
+
 #[tauri::command]
-pub fn path_is_directory(path: String) -> bool {
-    std::fs::metadata(&path).map(|m| m.is_dir()).unwrap_or(false)
+pub fn inspect_path(path: String) -> PathInspection {
+    if path.is_empty() || path.contains('\0') || !Path::new(&path).is_absolute() {
+        return PathInspection::Unavailable {
+            reason: PathInspectionUnavailableReason::InvalidPath,
+        };
+    }
+
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_file() => PathInspection::File,
+        Ok(metadata) if metadata.is_dir() => PathInspection::Directory,
+        Ok(_) => PathInspection::Unavailable {
+            reason: PathInspectionUnavailableReason::UnsupportedType,
+        },
+        Err(error) => classify_path_inspection_error(error.kind()),
+    }
+}
+
+fn classify_path_inspection_error(kind: std::io::ErrorKind) -> PathInspection {
+    match kind {
+        std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory => {
+            PathInspection::Missing
+        }
+        std::io::ErrorKind::PermissionDenied => PathInspection::Unavailable {
+            reason: PathInspectionUnavailableReason::PermissionDenied,
+        },
+        _ => PathInspection::Unavailable {
+            reason: PathInspectionUnavailableReason::IoError,
+        },
+    }
 }
 
 #[tauri::command]
@@ -140,4 +188,188 @@ fn write_to_clipboard_command(program: &str, args: &[&str], value: &str) -> Resu
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod path_inspection_tests {
+    use super::{
+        classify_path_inspection_error, inspect_path, PathInspection,
+        PathInspectionUnavailableReason,
+    };
+    use serde_json::json;
+    use std::fs;
+    use std::io::ErrorKind;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new(label: &str) -> Self {
+            let sequence = NEXT_TEST_DIRECTORY.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "proliferate-path-inspection-{}-{label}-{sequence}",
+                std::process::id()
+            ));
+            fs::create_dir(&path).expect("create path-inspection test directory");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn path_inspection_serializes_the_exact_tagged_union() {
+        let values = [
+            (PathInspection::File, json!({"kind": "file"})),
+            (
+                PathInspection::Directory,
+                json!({"kind": "directory"}),
+            ),
+            (PathInspection::Missing, json!({"kind": "missing"})),
+            (
+                PathInspection::Unavailable {
+                    reason: PathInspectionUnavailableReason::InvalidPath,
+                },
+                json!({"kind": "unavailable", "reason": "invalid_path"}),
+            ),
+            (
+                PathInspection::Unavailable {
+                    reason: PathInspectionUnavailableReason::PermissionDenied,
+                },
+                json!({"kind": "unavailable", "reason": "permission_denied"}),
+            ),
+            (
+                PathInspection::Unavailable {
+                    reason: PathInspectionUnavailableReason::UnsupportedType,
+                },
+                json!({"kind": "unavailable", "reason": "unsupported_type"}),
+            ),
+            (
+                PathInspection::Unavailable {
+                    reason: PathInspectionUnavailableReason::IoError,
+                },
+                json!({"kind": "unavailable", "reason": "io_error"}),
+            ),
+        ];
+
+        for (value, expected) in values {
+            assert_eq!(serde_json::to_value(value).expect("serialize inspection"), expected);
+        }
+    }
+
+    #[test]
+    fn path_inspection_rejects_empty_relative_and_nul_bearing_input() {
+        let expected = PathInspection::Unavailable {
+            reason: PathInspectionUnavailableReason::InvalidPath,
+        };
+        assert_eq!(inspect_path(String::new()), expected);
+        assert_eq!(inspect_path("relative/file.txt".to_string()), expected);
+        assert_eq!(inspect_path("/tmp/bad\0path".to_string()), expected);
+    }
+
+    #[test]
+    fn path_inspection_classifies_file_directory_missing_and_not_a_directory() {
+        let directory = TestDirectory::new("basic");
+        let file = directory.path().join("file.txt");
+        fs::write(&file, b"content").expect("write test file");
+
+        assert_eq!(
+            inspect_path(file.to_string_lossy().into_owned()),
+            PathInspection::File
+        );
+        assert_eq!(
+            inspect_path(directory.path().to_string_lossy().into_owned()),
+            PathInspection::Directory
+        );
+        assert_eq!(
+            inspect_path(
+                directory
+                    .path()
+                    .join("missing.txt")
+                    .to_string_lossy()
+                    .into_owned()
+            ),
+            PathInspection::Missing
+        );
+        assert_eq!(
+            inspect_path(file.join("child").to_string_lossy().into_owned()),
+            PathInspection::Missing
+        );
+    }
+
+    #[test]
+    fn path_inspection_classifies_permission_and_unexpected_io_errors() {
+        assert_eq!(
+            classify_path_inspection_error(ErrorKind::PermissionDenied),
+            PathInspection::Unavailable {
+                reason: PathInspectionUnavailableReason::PermissionDenied,
+            }
+        );
+        assert_eq!(
+            classify_path_inspection_error(ErrorKind::TimedOut),
+            PathInspection::Unavailable {
+                reason: PathInspectionUnavailableReason::IoError,
+            }
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn path_inspection_follows_file_and_directory_links_and_reports_dangling_links() {
+        use std::os::unix::fs::symlink;
+
+        let directory = TestDirectory::new("links");
+        let file = directory.path().join("file.txt");
+        let child_directory = directory.path().join("child");
+        fs::write(&file, b"content").expect("write link target");
+        fs::create_dir(&child_directory).expect("create directory link target");
+
+        let file_link = directory.path().join("file-link");
+        let directory_link = directory.path().join("directory-link");
+        let dangling_link = directory.path().join("dangling-link");
+        symlink(&file, &file_link).expect("create file link");
+        symlink(&child_directory, &directory_link).expect("create directory link");
+        symlink(directory.path().join("absent"), &dangling_link).expect("create dangling link");
+
+        assert_eq!(
+            inspect_path(file_link.to_string_lossy().into_owned()),
+            PathInspection::File
+        );
+        assert_eq!(
+            inspect_path(directory_link.to_string_lossy().into_owned()),
+            PathInspection::Directory
+        );
+        assert_eq!(
+            inspect_path(dangling_link.to_string_lossy().into_owned()),
+            PathInspection::Missing
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn path_inspection_rejects_unsupported_unix_objects() {
+        use std::os::unix::net::UnixListener;
+
+        let directory = TestDirectory::new("unsupported");
+        let socket_path = directory.path().join("socket");
+        let _listener = UnixListener::bind(&socket_path).expect("bind test socket");
+
+        assert_eq!(
+            inspect_path(socket_path.to_string_lossy().into_owned()),
+            PathInspection::Unavailable {
+                reason: PathInspectionUnavailableReason::UnsupportedType,
+            }
+        );
+    }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -298,7 +298,7 @@ pub fn run() {
             shell::pick_folder,
             shell::copy_text,
             shell::list_available_editors,
-            shell::path_is_directory,
+            shell::inspect_path,
             shell::open_in_editor,
             shell::reveal_in_finder,
             shell::open_in_terminal,

--- a/apps/desktop/src/lib/access/tauri/desktop-bridge-path-inspection.test.ts
+++ b/apps/desktop/src/lib/access/tauri/desktop-bridge-path-inspection.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+
+const inspectPath = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/access/tauri/shell", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@/lib/access/tauri/shell")>(),
+  inspectPath,
+}));
+
+import { desktopBridge } from "@/lib/access/tauri/desktop-bridge";
+
+describe("desktopBridge path inspection", () => {
+  it.each([
+    { kind: "file" },
+    { kind: "directory" },
+    { kind: "missing" },
+    { kind: "unavailable", reason: "invalid_path" },
+    { kind: "unavailable", reason: "permission_denied" },
+    { kind: "unavailable", reason: "unsupported_type" },
+    { kind: "unavailable", reason: "io_error" },
+  ] as const)("preserves the typed payload %#", async (inspection) => {
+    inspectPath.mockResolvedValue(inspection);
+
+    await expect(desktopBridge.files.inspectPath("/repo/item")).resolves.toBe(inspection);
+  });
+
+  it("preserves the invoke rejection", async () => {
+    const rejection = new Error("invoke rejected");
+    inspectPath.mockRejectedValue(rejection);
+
+    await expect(desktopBridge.files.inspectPath("/repo/item")).rejects.toBe(rejection);
+  });
+});

--- a/apps/desktop/src/lib/access/tauri/desktop-bridge.test.ts
+++ b/apps/desktop/src/lib/access/tauri/desktop-bridge.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => ({
   restartRuntime: vi.fn(),
   pickFolder: vi.fn(),
   getHomeDir: vi.fn(),
-  pathIsDirectory: vi.fn(),
+  inspectPath: vi.fn(),
   listAvailableEditors: vi.fn(),
   listOpenTargets: vi.fn(),
   openTarget: vi.fn(),
@@ -55,7 +55,7 @@ vi.mock("@/lib/access/tauri/runtime", () => ({
 vi.mock("@/lib/access/tauri/shell", () => ({
   pickFolder: mocks.pickFolder,
   getHomeDir: mocks.getHomeDir,
-  pathIsDirectory: mocks.pathIsDirectory,
+  inspectPath: mocks.inspectPath,
   listAvailableEditors: mocks.listAvailableEditors,
   listOpenTargets: mocks.listOpenTargets,
   openTarget: mocks.openTarget,
@@ -188,7 +188,7 @@ describe("files", () => {
   it("normalizes a selected directory and delegates the other shell wrappers", async () => {
     mocks.pickFolder.mockResolvedValue("/repo");
     mocks.getHomeDir.mockResolvedValue("/home/dev");
-    mocks.pathIsDirectory.mockResolvedValue(true);
+    mocks.inspectPath.mockResolvedValue({ kind: "directory" });
     mocks.revealInFinder.mockResolvedValue(undefined);
     mocks.openInTerminal.mockResolvedValue(undefined);
 
@@ -197,8 +197,10 @@ describe("files", () => {
       path: "/repo",
     });
     await expect(desktopBridge.files.getHomeDirectory()).resolves.toBe("/home/dev");
-    await expect(desktopBridge.files.isDirectory("/repo")).resolves.toBe(true);
-    expect(mocks.pathIsDirectory).toHaveBeenCalledWith("/repo");
+    await expect(desktopBridge.files.inspectPath("/repo")).resolves.toEqual({
+      kind: "directory",
+    });
+    expect(mocks.inspectPath).toHaveBeenCalledWith("/repo");
 
     await desktopBridge.files.reveal("/repo");
     expect(mocks.revealInFinder).toHaveBeenCalledWith("/repo");
@@ -244,6 +246,7 @@ describe("files", () => {
     await desktopBridge.files.openTarget("cursor", "/repo");
     expect(mocks.openTarget).toHaveBeenCalledWith("cursor", "/repo");
   });
+
 });
 
 describe("nativeUi", () => {

--- a/apps/desktop/src/lib/access/tauri/desktop-bridge.ts
+++ b/apps/desktop/src/lib/access/tauri/desktop-bridge.ts
@@ -19,11 +19,11 @@ import type {
 import { getRuntimeInfo, restartRuntime } from "./runtime";
 import {
   getHomeDir,
+  inspectPath,
   listAvailableEditors,
   listOpenTargets,
   openInTerminal,
   openTarget,
-  pathIsDirectory,
   pickFolder,
   revealInFinder,
 } from "./shell";
@@ -133,7 +133,7 @@ export const desktopBridge: DesktopBridge = {
       }
     },
     getHomeDirectory: getHomeDir,
-    isDirectory: pathIsDirectory,
+    inspectPath,
     getDragPasteboardChangeCount,
     readDroppedPaths: readDragDropPaths,
     listAvailableEditors,

--- a/apps/desktop/src/lib/access/tauri/shell.test.ts
+++ b/apps/desktop/src/lib/access/tauri/shell.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  homeDir: vi.fn(),
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+}));
+
+vi.mock("@tauri-apps/api/path", () => ({
+  homeDir: mocks.homeDir,
+}));
+
+async function loadShell() {
+  vi.resetModules();
+  return import("./shell");
+}
+
+beforeEach(() => {
+  mocks.homeDir.mockReset();
+  mocks.invoke.mockReset();
+});
+
+describe("inspectPath", () => {
+  it.each([
+    { kind: "file" },
+    { kind: "directory" },
+    { kind: "missing" },
+    { kind: "unavailable", reason: "invalid_path" },
+    { kind: "unavailable", reason: "permission_denied" },
+    { kind: "unavailable", reason: "unsupported_type" },
+    { kind: "unavailable", reason: "io_error" },
+  ] as const)("preserves the validated native payload $kind $reason", async (payload) => {
+    const shell = await loadShell();
+    mocks.invoke.mockResolvedValue(payload);
+
+    await expect(shell.inspectPath("/private/repo/file.txt")).resolves.toBe(payload);
+    expect(mocks.invoke).toHaveBeenCalledExactlyOnceWith("inspect_path", {
+      path: "/private/repo/file.txt",
+    });
+  });
+
+  it.each([
+    null,
+    [],
+    "file",
+    { kind: "other" },
+    { kind: "unavailable" },
+    { kind: "unavailable", reason: "other" },
+    { kind: "file", path: "/private/secret" },
+    { kind: "unavailable", reason: "io_error", path: "/private/secret" },
+  ])("rejects malformed payload %# with one fixed path-free error", async (payload) => {
+    const shell = await loadShell();
+    mocks.invoke.mockResolvedValue(payload);
+
+    let rejection: unknown;
+    try {
+      await shell.inspectPath("/private/secret");
+    } catch (error) {
+      rejection = error;
+    }
+
+    expect(rejection).toBeInstanceOf(Error);
+    expect((rejection as Error).message).toBe("Invalid inspect_path response.");
+  });
+
+  it("preserves invoke rejection", async () => {
+    const shell = await loadShell();
+    const transportError = new Error("native transport unavailable");
+    mocks.invoke.mockRejectedValue(transportError);
+
+    await expect(shell.inspectPath("/private/repo/file.txt")).rejects.toBe(transportError);
+  });
+});
+
+describe("getHomeDir", () => {
+  it("caches only a successful native home lookup", async () => {
+    const shell = await loadShell();
+    mocks.homeDir.mockResolvedValue("/Users/example");
+
+    await expect(shell.getHomeDir()).resolves.toBe("/Users/example");
+    await expect(shell.getHomeDir()).resolves.toBe("/Users/example");
+    expect(mocks.homeDir).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps native rejection and never substitutes /tmp", async () => {
+    const shell = await loadShell();
+    const lookupError = new Error("home lookup failed");
+    mocks.homeDir.mockRejectedValue(lookupError);
+
+    await expect(shell.getHomeDir()).rejects.toBe(lookupError);
+    await expect(shell.getHomeDir()).rejects.toBe(lookupError);
+    expect(mocks.homeDir).toHaveBeenCalledTimes(2);
+    expect(mocks.invoke).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/lib/access/tauri/shell.ts
+++ b/apps/desktop/src/lib/access/tauri/shell.ts
@@ -5,6 +5,10 @@ import type {
   OpenTarget,
   PathKind,
 } from "@proliferate/product-client/internal/lib/domain/open-targets/model";
+import type {
+  DesktopPathInspection,
+  DesktopPathInspectionUnavailableReason,
+} from "@proliferate/product-client/host/desktop-bridge";
 
 export type {
   EditorIconId,
@@ -34,17 +38,43 @@ export async function revealInFinder(path: string): Promise<void> {
   return invoke("reveal_in_finder", { path });
 }
 
-/**
- * True when the absolute path exists and is a directory. Returns false on
- * any failure (missing path, non-Tauri host) so callers can fall back to
- * file behavior.
- */
-export async function pathIsDirectory(path: string): Promise<boolean> {
-  try {
-    return await invoke<boolean>("path_is_directory", { path });
-  } catch {
+const INSPECT_PATH_PROTOCOL_ERROR = "Invalid inspect_path response.";
+const INSPECTION_UNAVAILABLE_REASONS = new Set<DesktopPathInspectionUnavailableReason>([
+  "invalid_path",
+  "permission_denied",
+  "unsupported_type",
+  "io_error",
+]);
+
+export async function inspectPath(path: string): Promise<DesktopPathInspection> {
+  const payload = await invoke<unknown>("inspect_path", { path });
+  if (!isDesktopPathInspection(payload)) {
+    throw new Error(INSPECT_PATH_PROTOCOL_ERROR);
+  }
+  return payload;
+}
+
+function isDesktopPathInspection(value: unknown): value is DesktopPathInspection {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
     return false;
   }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (
+    (record.kind === "file" || record.kind === "directory" || record.kind === "missing")
+    && keys.length === 1
+    && keys[0] === "kind"
+  ) {
+    return true;
+  }
+  return record.kind === "unavailable"
+    && keys.length === 2
+    && keys.includes("kind")
+    && keys.includes("reason")
+    && typeof record.reason === "string"
+    && INSPECTION_UNAVAILABLE_REASONS.has(
+      record.reason as DesktopPathInspectionUnavailableReason,
+    );
 }
 
 export async function openInTerminal(path: string): Promise<void> {
@@ -196,11 +226,6 @@ let _cachedHome: string | null = null;
 
 export async function getHomeDir(): Promise<string> {
   if (_cachedHome) return _cachedHome;
-  try {
-    _cachedHome = await tauriHomeDir();
-    return _cachedHome;
-  } catch {
-    // Fallback outside Tauri (dev browser)
-    return "/tmp";
-  }
+  _cachedHome = await tauriHomeDir();
+  return _cachedHome;
 }

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnDocumentReferenceCard.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnDocumentReferenceCard.test.tsx
@@ -4,15 +4,19 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TurnDocumentReferenceCard } from "#product/components/workspace/chat/transcript/TurnDocumentReferenceCard";
 
-const { openPrimary } = vi.hoisted(() => ({ openPrimary: vi.fn() }));
+const fileActionMocks = vi.hoisted(() => ({
+  canOpenPrimary: true,
+  openPrimary: vi.fn(),
+}));
 
 vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", () => ({
-  useFileReferenceActions: () => ({ openPrimary }),
+  useFileReferenceActions: () => fileActionMocks,
 }));
 
 afterEach(() => {
   cleanup();
-  openPrimary.mockReset();
+  fileActionMocks.canOpenPrimary = true;
+  fileActionMocks.openPrimary.mockReset();
 });
 
 describe("TurnDocumentReferenceCard", () => {
@@ -38,6 +42,27 @@ describe("TurnDocumentReferenceCard", () => {
     expect(screen.getByText("Open preview")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Open preview for decision.md" }));
-    expect(openPrimary).toHaveBeenCalledOnce();
+    expect(fileActionMocks.openPrimary).toHaveBeenCalledOnce();
+  });
+
+  it("disables the unavailable primary action and guards its handler", () => {
+    fileActionMocks.canOpenPrimary = false;
+    render(
+      <TurnDocumentReferenceCard
+        resource={{
+          rawPath: "/repo/specs/missing.md",
+          path: "/repo/specs/missing.md",
+          displayName: "missing.md",
+          typeLabel: "Document · MD",
+        }}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "Open preview for missing.md",
+    });
+    expect((trigger as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(trigger);
+    expect(fileActionMocks.openPrimary).not.toHaveBeenCalled();
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnDocumentReferenceCard.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnDocumentReferenceCard.tsx
@@ -24,7 +24,12 @@ export function TurnDocumentReferenceCard({
         type="button"
         variant="unstyled"
         size="unstyled"
-        onClick={() => void fileActions.openPrimary()}
+        disabled={!fileActions.canOpenPrimary}
+        onClick={() => {
+          if (fileActions.canOpenPrimary) {
+            void fileActions.openPrimary();
+          }
+        }}
         className="turn-document-reference-trigger flex w-full min-w-0 items-center justify-start gap-2.5 rounded-none px-3 py-3 text-left focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
         aria-label={`Open preview for ${resource.displayName}`}
       >

--- a/apps/packages/product-client/src/hooks/editor/workflows/use-open-in-default-editor.test.tsx
+++ b/apps/packages/product-client/src/hooks/editor/workflows/use-open-in-default-editor.test.tsx
@@ -33,6 +33,86 @@ afterEach(() => {
 });
 
 describe("useOpenInDefaultEditor", () => {
+  it("does not discover targets while the path kind is null", async () => {
+    const listOpenTargets = vi.fn(async () => []);
+    mocks.files = {
+      listOpenTargets,
+      openTarget: vi.fn(async () => undefined),
+    };
+
+    const { result } = renderHook(() => useOpenInDefaultEditor(null));
+
+    expect(result.current.targets).toEqual([]);
+    expect(result.current.defaultTarget).toBeNull();
+    expect(result.current.ready).toBe(false);
+    await act(async () => Promise.resolve());
+    expect(listOpenTargets).not.toHaveBeenCalled();
+  });
+
+  it("discovers targets for each committed file and directory kind", async () => {
+    const fileTarget: OpenTarget = {
+      id: "file-editor",
+      label: "File editor",
+      kind: "editor",
+      iconId: "cursor",
+    };
+    const directoryTarget: OpenTarget = {
+      id: "finder",
+      label: "Finder",
+      kind: "finder",
+      iconId: "finder",
+    };
+    const listOpenTargets = vi.fn(async (kind: "file" | "directory") => (
+      kind === "file" ? [fileTarget] : [directoryTarget]
+    ));
+    mocks.files = {
+      listOpenTargets,
+      openTarget: vi.fn(async () => undefined),
+    };
+
+    const { result, rerender } = renderHook(
+      ({ kind }: { kind: "file" | "directory" | null }) => useOpenInDefaultEditor(kind),
+      { initialProps: { kind: null } },
+    );
+    expect(listOpenTargets).not.toHaveBeenCalled();
+
+    rerender({ kind: "file" });
+    await waitFor(() => expect(result.current.targets).toEqual([fileTarget]));
+    expect(listOpenTargets).toHaveBeenLastCalledWith("file");
+
+    rerender({ kind: "directory" });
+    expect(result.current.ready).toBe(false);
+    expect(result.current.targets).toEqual([]);
+    await waitFor(() => expect(result.current.targets).toEqual([directoryTarget]));
+    expect(listOpenTargets).toHaveBeenLastCalledWith("directory");
+  });
+
+  it("uses the imperative kind when render state has not committed", async () => {
+    const target: OpenTarget = {
+      id: "finder",
+      label: "Finder",
+      kind: "finder",
+      iconId: "finder",
+    };
+    const listOpenTargets = vi.fn(async () => [target]);
+    const openTarget = vi.fn(async () => undefined);
+    mocks.files = { listOpenTargets, openTarget };
+
+    const { result } = renderHook(() => useOpenInDefaultEditor(null));
+
+    await act(async () => {
+      await expect(
+        result.current.openInDefaultEditor("/tmp/folder", "directory"),
+      ).resolves.toBe(true);
+    });
+
+    expect(listOpenTargets).toHaveBeenCalledExactlyOnceWith("directory");
+    expect(openTarget).toHaveBeenCalledWith("finder", "/tmp/folder");
+    expect(result.current.targets).toEqual([]);
+    expect(result.current.defaultTarget).toBeNull();
+    expect(result.current.ready).toBe(false);
+  });
+
   it("retries target discovery after a transient bridge failure", async () => {
     const target: OpenTarget = {
       id: "cursor",
@@ -62,7 +142,10 @@ describe("useOpenInDefaultEditor", () => {
 
     let opened = false;
     await act(async () => {
-      opened = await result.current.openInDefaultEditor("/tmp/outside.txt:12:3");
+      opened = await result.current.openInDefaultEditor(
+        "/tmp/outside.txt:12:3",
+        "file",
+      );
     });
 
     expect(opened).toBe(true);

--- a/apps/packages/product-client/src/hooks/editor/workflows/use-open-in-default-editor.ts
+++ b/apps/packages/product-client/src/hooks/editor/workflows/use-open-in-default-editor.ts
@@ -40,7 +40,10 @@ function loadTargets(files: DesktopFilesBridge, pathKind: PathKind): Promise<Ope
 
 interface UseOpenInDefaultEditorResult {
   /** Open a path in the preferred external target and report whether it launched. */
-  openInDefaultEditor: (absolutePath: string) => Promise<boolean>;
+  openInDefaultEditor: (
+    absolutePath: string,
+    imperativePathKind: PathKind,
+  ) => Promise<boolean>;
   /** Open a path in a specific shell target. */
   openTarget: (targetId: string, absolutePath: string) => Promise<void>;
   /** Reveal a path in Finder. */
@@ -67,13 +70,26 @@ interface UseOpenInDefaultEditorResult {
  *  - Strips any `:line[:col]` suffix before invoking the shell command,
  *    because Desktop open-target commands take a plain path.
  */
-export function useOpenInDefaultEditor(pathKind: PathKind = "file"): UseOpenInDefaultEditorResult {
+interface LoadedTargets {
+  files: DesktopFilesBridge | null;
+  pathKind: PathKind;
+  targets: OpenTarget[];
+}
+
+export function useOpenInDefaultEditor(
+  pathKind: PathKind | null,
+): UseOpenInDefaultEditorResult {
   const host = useProductHost();
   const files = host.desktop?.files ?? null;
-  const [targets, setTargets] = useState<OpenTarget[] | null>(null);
+  const [loadedTargets, setLoadedTargets] = useState<LoadedTargets | null>(null);
   const defaultOpenInTargetId = useUserPreferencesStore(
     (state) => state.defaultOpenInTargetId,
   );
+  const targets = pathKind !== null
+    && loadedTargets?.files === files
+    && loadedTargets.pathKind === pathKind
+    ? loadedTargets.targets
+    : null;
   const availableTargets = targets ?? EMPTY_OPEN_TARGETS;
   const defaultTarget = useMemo(
     () => resolvePreferredOpenTarget(openableTargets(availableTargets), { defaultOpenInTargetId }),
@@ -82,20 +98,26 @@ export function useOpenInDefaultEditor(pathKind: PathKind = "file"): UseOpenInDe
 
   useEffect(() => {
     let cancelled = false;
-    if (!files) {
-      setTargets([]);
+    if (pathKind === null) {
+      setLoadedTargets(null);
       return;
     }
-    setTargets(null);
+    if (!files) {
+      setLoadedTargets({ files, pathKind, targets: [] });
+      return;
+    }
+    setLoadedTargets((current) => (
+      current?.files === files && current.pathKind === pathKind ? current : null
+    ));
     void loadTargets(files, pathKind).then(
       (loaded) => {
-        if (!cancelled) setTargets(loaded);
+        if (!cancelled) setLoadedTargets({ files, pathKind, targets: loaded });
       },
       () => {
         // Keep the unresolved state so an explicit open action retries target
         // discovery instead of treating a transient bridge failure as an
         // authoritative empty target list.
-        if (!cancelled) setTargets(null);
+        if (!cancelled) setLoadedTargets(null);
       },
     );
     return () => {
@@ -104,15 +126,18 @@ export function useOpenInDefaultEditor(pathKind: PathKind = "file"): UseOpenInDe
   }, [files, pathKind]);
 
   const openInDefaultEditor = useCallback(
-    async (absolutePath: string) => {
+    async (absolutePath: string, imperativePathKind: PathKind) => {
       if (!files) {
         throw new Error("Local file access is not available.");
       }
-      let list = targets;
+      let list = loadedTargets?.files === files
+        && loadedTargets.pathKind === imperativePathKind
+        ? loadedTargets.targets
+        : null;
       if (list === null) {
         try {
-          list = await loadTargets(files, pathKind);
-          setTargets(list);
+          list = await loadTargets(files, imperativePathKind);
+          setLoadedTargets({ files, pathKind: imperativePathKind, targets: list });
         } catch {
           return false;
         }
@@ -127,7 +152,7 @@ export function useOpenInDefaultEditor(pathKind: PathKind = "file"): UseOpenInDe
         return false;
       }
     },
-    [files, pathKind, targets, defaultOpenInTargetId],
+    [files, loadedTargets, defaultOpenInTargetId],
   );
 
   const copyPath = useCallback(async (path: string) => {
@@ -157,7 +182,7 @@ export function useOpenInDefaultEditor(pathKind: PathKind = "file"): UseOpenInDe
     copyPath,
     targets: availableTargets,
     defaultTarget,
-    ready: targets !== null,
+    ready: pathKind !== null && targets !== null,
   };
 }
 

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-desktop-file-reference-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-desktop-file-reference-actions.ts
@@ -1,0 +1,102 @@
+import { useCallback, useMemo, useRef } from "react";
+import type {
+  DesktopFilesBridge,
+  OpenTarget,
+} from "@proliferate/product-client/host/desktop-bridge";
+import type {
+  FileReferencePathKind,
+  ResolvedFileReference,
+} from "#product/lib/domain/files/path-references";
+import type { DesktopPathInspectionState } from "#product/hooks/workspaces/workflows/files/use-desktop-path-inspection";
+
+interface UseDesktopFileReferenceActionsInput {
+  files: DesktopFilesBridge | null;
+  reference: Pick<ResolvedFileReference, "absolutePath" | "workspacePath">;
+  pathKind: FileReferencePathKind | null;
+  desktopInspectionState: DesktopPathInspectionState;
+  routeRevision: object;
+  targets: readonly OpenTarget[];
+  openInDefaultEditor: (
+    absolutePath: string,
+    imperativePathKind: FileReferencePathKind,
+  ) => Promise<boolean>;
+}
+
+export function useDesktopFileReferenceActions({
+  files,
+  reference,
+  pathKind,
+  desktopInspectionState,
+  routeRevision,
+  targets,
+  openInDefaultEditor,
+}: UseDesktopFileReferenceActionsInput) {
+  const currentRouteRevisionRef = useRef(routeRevision);
+  currentRouteRevisionRef.current = routeRevision;
+  const openTargets = useMemo(
+    () => targets.filter((target) => target.kind !== "copy"),
+    [targets],
+  );
+
+  const currentNativePathKind = useCallback((
+    absolutePath: string,
+  ): FileReferencePathKind | null => {
+    if (
+      currentRouteRevisionRef.current !== routeRevision
+      || absolutePath !== reference.absolutePath
+      || !files
+      || pathKind === null
+    ) {
+      return null;
+    }
+    if (reference.workspacePath) {
+      return pathKind;
+    }
+    return desktopInspectionState.status === "settled"
+      && desktopInspectionState.inspection.kind === pathKind
+      ? pathKind
+      : null;
+  }, [
+    desktopInspectionState,
+    files,
+    pathKind,
+    reference.absolutePath,
+    reference.workspacePath,
+    routeRevision,
+  ]);
+
+  const openDefault = useCallback(async (
+    absolutePath: string | null = reference.absolutePath,
+  ) => {
+    if (!absolutePath) {
+      return false;
+    }
+    const imperativePathKind = currentNativePathKind(absolutePath);
+    if (!imperativePathKind) {
+      return false;
+    }
+    return openInDefaultEditor(absolutePath, imperativePathKind);
+  }, [currentNativePathKind, openInDefaultEditor, reference.absolutePath]);
+
+  const reveal = useCallback(async (
+    absolutePath: string | null = reference.absolutePath,
+  ) => {
+    if (!absolutePath || currentNativePathKind(absolutePath) !== "directory" || !files) {
+      return;
+    }
+    await files.reveal(absolutePath);
+  }, [currentNativePathKind, files, reference.absolutePath]);
+
+  const openWithTarget = useCallback(async (targetId: string) => {
+    if (
+      !reference.absolutePath
+      || currentNativePathKind(reference.absolutePath) === null
+      || !files
+    ) {
+      return;
+    }
+    await files.openTarget(targetId, reference.absolutePath);
+  }, [currentNativePathKind, files, reference.absolutePath]);
+
+  return { openDefault, openTargets, openWithTarget, reveal };
+}

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-desktop-path-inspection.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-desktop-path-inspection.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  DesktopFilesBridge,
+  DesktopPathInspection,
+} from "@proliferate/product-client/host/desktop-bridge";
+import {
+  resolveInspectionPathKind,
+  resolveInspectionUnavailableCopy,
+  useDesktopPathInspection,
+} from "#product/hooks/workspaces/workflows/files/use-desktop-path-inspection";
+
+function filesBridge(
+  inspectPath: (path: string) => Promise<DesktopPathInspection>,
+): DesktopFilesBridge {
+  return { inspectPath } as DesktopFilesBridge;
+}
+
+describe("useDesktopPathInspection", () => {
+  it("shares the pending effect attempt with an imperative inspection", async () => {
+    let resolveInspection!: (inspection: DesktopPathInspection) => void;
+    const inspectPath = vi.fn(() => new Promise<DesktopPathInspection>((resolve) => {
+      resolveInspection = resolve;
+    }));
+    const files = filesBridge(inspectPath);
+    const routeRevision = {};
+    const { result } = renderHook(() => useDesktopPathInspection({
+      candidatePath: "/tmp/pending.txt",
+      files,
+      routeRevision,
+    }));
+
+    await waitFor(() => expect(inspectPath).toHaveBeenCalledTimes(1));
+    expect(result.current.state).toEqual({ status: "pending" });
+
+    const imperative = result.current.ensureInspection("/tmp/pending.txt");
+    expect(inspectPath).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolveInspection({ kind: "file" });
+      await expect(imperative).resolves.toEqual({ kind: "file" });
+    });
+
+    expect(result.current.state).toEqual({
+      status: "settled",
+      inspection: { kind: "file" },
+    });
+    await expect(result.current.ensureInspection("/tmp/pending.txt"))
+      .resolves.toEqual({ kind: "file" });
+    expect(inspectPath).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a rejected attempt terminal for its candidate revision", async () => {
+    const inspectPath = vi.fn(async () => {
+      throw new Error("transport failed");
+    });
+    const files = filesBridge(inspectPath);
+    const routeRevision = {};
+    const { result } = renderHook(() => useDesktopPathInspection({
+      candidatePath: "/tmp/rejected.txt",
+      files,
+      routeRevision,
+    }));
+
+    await waitFor(() => expect(result.current.state).toEqual({ status: "rejected" }));
+    await expect(result.current.ensureInspection("/tmp/rejected.txt")).resolves.toBeNull();
+    expect(inspectPath).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores stale completion after the candidate revision changes", async () => {
+    let resolveFirst!: (inspection: DesktopPathInspection) => void;
+    const inspectPath = vi.fn()
+      .mockImplementationOnce(() => new Promise<DesktopPathInspection>((resolve) => {
+        resolveFirst = resolve;
+      }))
+      .mockResolvedValueOnce({ kind: "directory" });
+    const files = filesBridge(inspectPath);
+    const firstRevision = {};
+    const secondRevision = {};
+    const { result, rerender } = renderHook(
+      ({ candidatePath, routeRevision }) => useDesktopPathInspection({
+        candidatePath,
+        files,
+        routeRevision,
+      }),
+      {
+        initialProps: {
+          candidatePath: "/tmp/first.txt",
+          routeRevision: firstRevision,
+        },
+      },
+    );
+
+    await waitFor(() => expect(inspectPath).toHaveBeenCalledTimes(1));
+    const staleAttempt = result.current.ensureInspection("/tmp/first.txt");
+    rerender({ candidatePath: "/tmp/second", routeRevision: secondRevision });
+    await waitFor(() => expect(result.current.state).toEqual({
+      status: "settled",
+      inspection: { kind: "directory" },
+    }));
+
+    await act(async () => {
+      resolveFirst({ kind: "file" });
+      await Promise.resolve();
+    });
+    await expect(staleAttempt).resolves.toBeNull();
+    expect(result.current.state).toEqual({
+      status: "settled",
+      inspection: { kind: "directory" },
+    });
+    expect(inspectPath).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores completion after unmount for an imperative waiter", async () => {
+    let resolveInspection!: (inspection: DesktopPathInspection) => void;
+    const inspectPath = vi.fn(() => new Promise<DesktopPathInspection>((resolve) => {
+      resolveInspection = resolve;
+    }));
+    const files = filesBridge(inspectPath);
+    const routeRevision = {};
+    const { result, unmount } = renderHook(() => useDesktopPathInspection({
+      candidatePath: "/tmp/unmounted.txt",
+      files,
+      routeRevision,
+    }));
+
+    await waitFor(() => expect(inspectPath).toHaveBeenCalledTimes(1));
+    const imperative = result.current.ensureInspection("/tmp/unmounted.txt");
+    unmount();
+    resolveInspection({ kind: "file" });
+
+    await expect(imperative).resolves.toBeNull();
+    expect(inspectPath).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("desktop inspection projections", () => {
+  it.each([
+    [{ status: "idle" }, null, "Checking whether this path is a file or folder…"],
+    [{ status: "pending" }, null, "Checking whether this path is a file or folder…"],
+    [{ status: "settled", inspection: { kind: "file" } }, "file", null],
+    [{ status: "settled", inspection: { kind: "directory" } }, "directory", null],
+    [{ status: "settled", inspection: { kind: "missing" } }, null, "This path was not found."],
+    [{ status: "rejected" }, null, "This path is unavailable."],
+  ] as const)("projects bounded state %#", (state, pathKind, copy) => {
+    expect(resolveInspectionPathKind(state)).toBe(pathKind);
+    expect(resolveInspectionUnavailableCopy(state)).toBe(copy);
+  });
+});

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-desktop-path-inspection.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-desktop-path-inspection.ts
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type {
+  DesktopFilesBridge,
+  DesktopPathInspection,
+} from "@proliferate/product-client/host/desktop-bridge";
+import type { FileReferencePathKind } from "#product/lib/domain/files/path-references";
+
+export type DesktopPathInspectionState =
+  | { status: "idle" }
+  | { status: "pending" }
+  | { status: "settled"; inspection: DesktopPathInspection }
+  | { status: "rejected" };
+
+interface DesktopPathInspectionAttempt {
+  routeRevision: object;
+  files: DesktopFilesBridge;
+  path: string;
+  state: DesktopPathInspectionState;
+  promise: Promise<DesktopPathInspection | null> | null;
+}
+
+interface DesktopPathInspectionSnapshot {
+  routeRevision: object;
+  files: DesktopFilesBridge;
+  path: string;
+  state: DesktopPathInspectionState;
+}
+
+export const IDLE_DESKTOP_PATH_INSPECTION: DesktopPathInspectionState = {
+  status: "idle",
+};
+
+export function resolveInspectionPathKind(
+  state: DesktopPathInspectionState,
+): FileReferencePathKind | null {
+  if (state.status !== "settled") {
+    return null;
+  }
+  return state.inspection.kind === "file" || state.inspection.kind === "directory"
+    ? state.inspection.kind
+    : null;
+}
+
+export function resolveInspectionUnavailableCopy(
+  state: DesktopPathInspectionState,
+): string | null {
+  if (state.status === "idle" || state.status === "pending") {
+    return "Checking whether this path is a file or folder…";
+  }
+  if (state.status === "rejected") {
+    return "This path is unavailable.";
+  }
+  if (state.inspection.kind === "missing") {
+    return "This path was not found.";
+  }
+  if (state.inspection.kind !== "unavailable") {
+    return null;
+  }
+  switch (state.inspection.reason) {
+    case "invalid_path":
+      return "This path is invalid.";
+    case "permission_denied":
+      return "Permission denied for this path.";
+    case "unsupported_type":
+      return "This path type is not supported.";
+    case "io_error":
+      return "This path is unavailable.";
+  }
+}
+
+export function useDesktopPathInspection({
+  candidatePath,
+  files,
+  routeRevision,
+}: {
+  candidatePath: string | null;
+  files: DesktopFilesBridge | null;
+  routeRevision: object;
+}) {
+  const currentRouteRevisionRef = useRef(routeRevision);
+  currentRouteRevisionRef.current = routeRevision;
+  const mountedRef = useRef(true);
+  const attemptRef = useRef<DesktopPathInspectionAttempt | null>(null);
+  const [snapshot, setSnapshot] = useState<DesktopPathInspectionSnapshot | null>(null);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const publish = useCallback((
+    attempt: DesktopPathInspectionAttempt,
+    state: DesktopPathInspectionState,
+  ): boolean => {
+    attempt.state = state;
+    if (
+      !mountedRef.current
+      || attemptRef.current !== attempt
+      || currentRouteRevisionRef.current !== attempt.routeRevision
+    ) {
+      return false;
+    }
+    setSnapshot({
+      routeRevision: attempt.routeRevision,
+      files: attempt.files,
+      path: attempt.path,
+      state,
+    });
+    return true;
+  }, []);
+
+  const ensureInspection = useCallback((
+    path: string,
+  ): Promise<DesktopPathInspection | null> => {
+    if (!files || currentRouteRevisionRef.current !== routeRevision) {
+      return Promise.resolve(null);
+    }
+
+    let attempt = attemptRef.current;
+    if (
+      !attempt
+      || attempt.routeRevision !== routeRevision
+      || attempt.files !== files
+      || attempt.path !== path
+    ) {
+      attempt = {
+        routeRevision,
+        files,
+        path,
+        state: IDLE_DESKTOP_PATH_INSPECTION,
+        promise: null,
+      };
+      attemptRef.current = attempt;
+    }
+
+    if (attempt.state.status === "settled") {
+      return Promise.resolve(attempt.state.inspection);
+    }
+    if (attempt.state.status === "rejected") {
+      return Promise.resolve(null);
+    }
+    if (attempt.promise) {
+      return attempt.promise;
+    }
+
+    publish(attempt, { status: "pending" });
+    const activeAttempt = attempt;
+    const promise = Promise.resolve().then(() => files.inspectPath(path)).then(
+      (inspection) => {
+        const isCurrent = publish(activeAttempt, { status: "settled", inspection });
+        activeAttempt.promise = null;
+        return isCurrent ? inspection : null;
+      },
+      () => {
+        publish(activeAttempt, { status: "rejected" });
+        activeAttempt.promise = null;
+        return null;
+      },
+    );
+    activeAttempt.promise = promise;
+    return promise;
+  }, [files, publish, routeRevision]);
+
+  const state = candidatePath
+    && files
+    && snapshot?.routeRevision === routeRevision
+    && snapshot.files === files
+    && snapshot.path === candidatePath
+    ? snapshot.state
+    : IDLE_DESKTOP_PATH_INSPECTION;
+
+  useEffect(() => {
+    if (files && candidatePath) {
+      void ensureInspection(candidatePath);
+    }
+  }, [candidatePath, ensureInspection, files]);
+
+  return { ensureInspection, state };
+}

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.test.tsx
@@ -46,11 +46,11 @@ const hostMocks = vi.hoisted(() => ({
   writeText: vi.fn(async () => undefined),
   getHomeDirectory: vi.fn(async () => "/Users/pablo"),
   openTarget: vi.fn(async () => undefined),
-  isDirectory: vi.fn(async () => false),
+  inspectPath: vi.fn(async () => ({ kind: "file" as const })),
   reveal: vi.fn(async () => undefined),
   files: null as unknown as {
     getHomeDirectory: ReturnType<typeof vi.fn>;
-    isDirectory: ReturnType<typeof vi.fn>;
+    inspectPath: ReturnType<typeof vi.fn>;
     openTarget: ReturnType<typeof vi.fn>;
     reveal: ReturnType<typeof vi.fn>;
   },
@@ -58,7 +58,7 @@ const hostMocks = vi.hoisted(() => ({
 
 hostMocks.files = {
   getHomeDirectory: hostMocks.getHomeDirectory,
-  isDirectory: hostMocks.isDirectory,
+  inspectPath: hostMocks.inspectPath,
   openTarget: hostMocks.openTarget,
   reveal: hostMocks.reveal,
 };
@@ -129,7 +129,7 @@ vi.mock("#product/hooks/workspaces/workflows/files/use-fuzzy-file-resolver", () 
 afterEach(() => {
   hostMocks.desktopAvailable = true;
   hostMocks.getHomeDirectory.mockResolvedValue("/Users/pablo");
-  hostMocks.isDirectory.mockResolvedValue(false);
+  hostMocks.inspectPath.mockResolvedValue({ kind: "file" });
   editorMocks.openInDefaultEditor.mockResolvedValue(true);
   statMocks.kind = "file";
   statMocks.sizeBytes = undefined;
@@ -143,6 +143,12 @@ afterEach(() => {
     sizeBytes: 1,
   }));
   vi.clearAllMocks();
+  hostMocks.files = {
+    getHomeDirectory: hostMocks.getHomeDirectory,
+    inspectPath: hostMocks.inspectPath,
+    openTarget: hostMocks.openTarget,
+    reveal: hostMocks.reveal,
+  };
 });
 
 describe("useFileReferenceActions", () => {
@@ -161,7 +167,7 @@ describe("useFileReferenceActions", () => {
 
     expect(viewerMocks.openTarget).toHaveBeenCalledWith({ kind: "file", path: expectedPath });
     expect(hostMocks.reveal).not.toHaveBeenCalled();
-    expect(hostMocks.isDirectory).not.toHaveBeenCalled();
+    expect(hostMocks.inspectPath).not.toHaveBeenCalled();
     expect(editorMocks.openInDefaultEditor).not.toHaveBeenCalled();
   });
 
@@ -199,7 +205,7 @@ describe("useFileReferenceActions", () => {
 
   it("resolves and reveals an external directory on Desktop", async () => {
     statMocks.kind = null;
-    hostMocks.isDirectory.mockResolvedValue(true);
+    hostMocks.inspectPath.mockResolvedValue({ kind: "directory" });
     const { result } = renderHook(
       () => useFileReferenceActions({ rawPath: "/Users/pablo/landing" }),
       { wrapper: workspaceWrapper("/repo") },
@@ -213,6 +219,85 @@ describe("useFileReferenceActions", () => {
     expect(viewerMocks.openTarget).not.toHaveBeenCalled();
   });
 
+  it("keeps pending actions inert while the imperative primary shares the inspection", async () => {
+    statMocks.kind = null;
+    let resolveInspection!: (inspection: { kind: "file" }) => void;
+    hostMocks.inspectPath.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveInspection = resolve;
+    }));
+    const { result } = renderHook(
+      () => useFileReferenceActions({ rawPath: "/tmp/pending.txt" }),
+      { wrapper: workspaceWrapper("/repo") },
+    );
+
+    await waitFor(() => expect(hostMocks.inspectPath).toHaveBeenCalledTimes(1));
+    expect(result.current.pathKindPending).toBe(true);
+    expect(result.current.canOpenPrimary).toBe(false);
+    expect(result.current.openTargets).toEqual([]);
+    expect(result.current.defaultOpenTarget).toBeNull();
+    await expect(result.current.openDefault()).resolves.toBe(false);
+    await result.current.openWithTarget("cursor");
+    await result.current.reveal();
+    expect(hostMocks.openTarget).not.toHaveBeenCalled();
+    expect(hostMocks.reveal).not.toHaveBeenCalled();
+
+    const primary = result.current.openPrimary();
+    expect(hostMocks.inspectPath).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolveInspection({ kind: "file" });
+      await expect(primary).resolves.toBe("open-external");
+    });
+    expect(hostMocks.inspectPath).toHaveBeenCalledTimes(1);
+    expect(editorMocks.openInDefaultEditor)
+      .toHaveBeenCalledWith("/tmp/pending.txt", "file");
+  });
+
+  it.each([
+    [{ kind: "missing" }, "This path was not found."],
+    [{ kind: "unavailable", reason: "invalid_path" }, "This path is invalid."],
+    [
+      { kind: "unavailable", reason: "permission_denied" },
+      "Permission denied for this path.",
+    ],
+    [
+      { kind: "unavailable", reason: "unsupported_type" },
+      "This path type is not supported.",
+    ],
+    [{ kind: "unavailable", reason: "io_error" }, "This path is unavailable."],
+  ] as const)(
+    "keeps a settled refusal inert: %#",
+    async (inspection, expectedCopy) => {
+      statMocks.kind = null;
+      hostMocks.inspectPath.mockResolvedValue(inspection);
+      const rawPath = "/tmp/refused.txt";
+      const { result } = renderHook(
+        () => useFileReferenceActions({ rawPath }),
+        { wrapper: workspaceWrapper("/repo") },
+      );
+
+      await waitFor(() => expect(result.current.pathKindPending).toBe(false));
+      expect(result.current.pathKind).toBeNull();
+      expect(result.current.canOpenExternal).toBe(false);
+      expect(result.current.canReveal).toBe(false);
+      expect(result.current.canOpenPrimary).toBe(false);
+      expect(result.current.openTargets).toEqual([]);
+      expect(result.current.defaultOpenTarget).toBeNull();
+      expect(result.current.primaryUnavailableReason).toBe(expectedCopy);
+
+      await expect(result.current.openDefault()).resolves.toBe(false);
+      await result.current.openWithTarget("cursor");
+      await result.current.reveal();
+      await expect(result.current.openPrimary()).resolves.toBe("unavailable");
+      await result.current.copyPath();
+
+      expect(hostMocks.inspectPath).toHaveBeenCalledTimes(1);
+      expect(hostMocks.openTarget).not.toHaveBeenCalled();
+      expect(hostMocks.reveal).not.toHaveBeenCalled();
+      expect(editorMocks.openInDefaultEditor).not.toHaveBeenCalled();
+      expect(hostMocks.writeText).toHaveBeenCalledWith(rawPath);
+    },
+  );
+
   it("keeps a Web directory unavailable without invoking a native action", async () => {
     hostMocks.desktopAvailable = false;
     statMocks.kind = "directory";
@@ -222,9 +307,9 @@ describe("useFileReferenceActions", () => {
     );
 
     expect(result.current.canOpenPrimary).toBe(false);
-    expect(result.current.primaryUnavailableReason).toContain("Desktop app");
+    expect(result.current.primaryUnavailableReason).toBe("This path is unavailable.");
     await expect(result.current.openPrimary()).resolves.toBe("unavailable");
-    expect(hostMocks.isDirectory).not.toHaveBeenCalled();
+    expect(hostMocks.inspectPath).not.toHaveBeenCalled();
     expect(hostMocks.reveal).not.toHaveBeenCalled();
     expect(viewerMocks.openTarget).not.toHaveBeenCalled();
   });
@@ -288,7 +373,7 @@ describe("useFileReferenceActions", () => {
 
     await waitFor(() => {
       expect(result.current.primaryUnavailableReason)
-        .toBe("Could not resolve this path. Click to retry.");
+        .toBe("This path was not found.");
     });
     expect(result.current.canOpenPrimary).toBe(true);
     expect(viewerMocks.openTarget).not.toHaveBeenCalled();
@@ -321,10 +406,41 @@ describe("useFileReferenceActions", () => {
 
     await waitFor(() => expect(result.current.pathKind).toBe("file"));
     expect(result.current.canOpenPrimary).toBe(true);
+    expect(result.current.canOpenExternal).toBe(true);
+    expect(result.current.canReveal).toBe(false);
     await expect(result.current.openPrimary()).resolves.toBe("open-external");
-    expect(editorMocks.openInDefaultEditor).toHaveBeenCalledWith("/tmp/outside.txt");
+    await result.current.openWithTarget("cursor");
+    await result.current.reveal();
+    expect(editorMocks.openInDefaultEditor).toHaveBeenCalledWith("/tmp/outside.txt", "file");
+    expect(hostMocks.openTarget).toHaveBeenCalledWith("cursor", "/tmp/outside.txt");
     expect(hostMocks.reveal).not.toHaveBeenCalled();
     expect(viewerMocks.openTarget).not.toHaveBeenCalled();
+  });
+
+  it("keeps a rejected home lookup unavailable without a /tmp fallback", async () => {
+    statMocks.kind = null;
+    hostMocks.getHomeDirectory.mockRejectedValue(new Error("home unavailable"));
+    const { result } = renderHook(
+      () => useFileReferenceActions({ rawPath: "~/.config/secret.txt" }),
+      { wrapper: workspaceWrapper("/repo") },
+    );
+
+    await waitFor(() => expect(result.current.pathKindPending).toBe(false));
+    expect(result.current.reference.absolutePath).toBeNull();
+    expect(result.current.pathKind).toBeNull();
+    expect(result.current.canOpenPrimary).toBe(false);
+    expect(result.current.primaryUnavailableReason).toBe("This path is unavailable.");
+
+    await expect(result.current.openPrimary()).resolves.toBe("unavailable");
+    await expect(result.current.openPrimary()).resolves.toBe("unavailable");
+    expect(hostMocks.getHomeDirectory).toHaveBeenCalledTimes(1);
+    expect(hostMocks.inspectPath).not.toHaveBeenCalled();
+    expect(hostMocks.openTarget).not.toHaveBeenCalled();
+    expect(hostMocks.reveal).not.toHaveBeenCalled();
+    expect(editorMocks.openInDefaultEditor).not.toHaveBeenCalled();
+    expect(hostMocks.inspectPath).not.toHaveBeenCalledWith(
+      expect.stringContaining("/tmp"),
+    );
   });
 
   it("expands a home-relative hidden file before opening it on Desktop", async () => {
@@ -340,7 +456,7 @@ describe("useFileReferenceActions", () => {
       { wrapper: workspaceWrapper("/repo") },
     );
 
-    expect(result.current.canOpenPrimary).toBe(true);
+    expect(result.current.canOpenPrimary).toBe(false);
     await act(async () => {
       const openPromise = result.current.openPrimary();
       resolveHomeDirectory("/Users/pablo");
@@ -352,8 +468,8 @@ describe("useFileReferenceActions", () => {
     });
 
     expect(hostMocks.getHomeDirectory).toHaveBeenCalledTimes(1);
-    expect(hostMocks.isDirectory).toHaveBeenCalledWith(absolutePath);
-    expect(editorMocks.openInDefaultEditor).toHaveBeenCalledWith(absolutePath);
+    expect(hostMocks.inspectPath).toHaveBeenCalledWith(absolutePath);
+    expect(editorMocks.openInDefaultEditor).toHaveBeenCalledWith(absolutePath, "file");
   });
 
   it("keeps an external file retryable when its Desktop target fails", async () => {
@@ -384,29 +500,35 @@ describe("useFileReferenceActions", () => {
       expect(result.current.primaryUnavailableReason).toBeNull();
     });
     expect(editorMocks.openInDefaultEditor).toHaveBeenCalledTimes(2);
+    expect(hostMocks.inspectPath).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps external path resolution retryable when the Desktop bridge rejects", async () => {
+  it("keeps a rejected Desktop inspection terminal for the candidate revision", async () => {
     statMocks.kind = null;
-    hostMocks.isDirectory.mockRejectedValue(new Error("bridge unavailable"));
+    hostMocks.inspectPath.mockRejectedValue(new Error("bridge unavailable"));
     const { result } = renderHook(
       () => useFileReferenceActions({ rawPath: "/tmp/outside.txt" }),
       { wrapper: workspaceWrapper("/repo") },
     );
 
     await waitFor(() => {
-      expect(hostMocks.isDirectory).toHaveBeenCalled();
+      expect(hostMocks.inspectPath).toHaveBeenCalled();
       expect(result.current.pathKindPending).toBe(false);
     });
+    expect(result.current.canOpenPrimary).toBe(false);
     await act(async () => {
       await expect(result.current.openPrimary()).resolves.toBe("unavailable");
+      await expect(result.current.openPrimary()).resolves.toBe("unavailable");
+      await expect(result.current.openDefault()).resolves.toBe(false);
+      await result.current.openWithTarget("cursor");
+      await result.current.reveal();
     });
 
-    await waitFor(() => {
-      expect(result.current.primaryUnavailableReason)
-        .toBe("Could not resolve this path. Click to retry.");
-    });
-    expect(result.current.canOpenPrimary).toBe(true);
+    expect(result.current.primaryUnavailableReason).toBe("This path is unavailable.");
+    expect(hostMocks.inspectPath).toHaveBeenCalledTimes(1);
+    expect(hostMocks.openTarget).not.toHaveBeenCalled();
+    expect(hostMocks.reveal).not.toHaveBeenCalled();
+    expect(editorMocks.openInDefaultEditor).not.toHaveBeenCalled();
   });
 
   it("keeps an external file unavailable on Web", async () => {
@@ -418,6 +540,8 @@ describe("useFileReferenceActions", () => {
     );
 
     expect(result.current.canOpenPrimary).toBe(false);
+    expect(result.current.pathKindPending).toBe(false);
+    expect(result.current.primaryUnavailableReason).toBe("This path is unavailable.");
     await expect(result.current.openPrimary()).resolves.toBe("unavailable");
     expect(editorMocks.openInDefaultEditor).not.toHaveBeenCalled();
     expect(hostMocks.reveal).not.toHaveBeenCalled();
@@ -433,7 +557,7 @@ describe("useFileReferenceActions", () => {
     );
 
     expect(result.current.canOpenPrimary).toBe(false);
-    expect(result.current.primaryUnavailableReason).toContain("Desktop app");
+    expect(result.current.primaryUnavailableReason).toBe("This path is unavailable.");
     await expect(result.current.openPrimary()).resolves.toBe("unavailable");
     expect(hostMocks.getHomeDirectory).not.toHaveBeenCalled();
   });

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.ts
@@ -12,6 +12,7 @@ import {
   resolveInspectionUnavailableCopy,
   useDesktopPathInspection,
 } from "#product/hooks/workspaces/workflows/files/use-desktop-path-inspection";
+import { useDesktopFileReferenceActions } from "#product/hooks/workspaces/workflows/files/use-desktop-file-reference-actions";
 import { useFuzzyFileResolver } from "#product/hooks/workspaces/workflows/files/use-fuzzy-file-resolver";
 import { useHomeRelativeFileReference } from "#product/hooks/workspaces/workflows/files/use-home-relative-file-reference";
 import { useWorkspaceShellActivation } from "#product/hooks/workspaces/workflows/tabs/use-workspace-shell-activation";
@@ -20,7 +21,6 @@ import {
   resolveFileReference,
   resolveFileReferencePrimaryAction,
   resolveWorkspaceStatPathKind,
-  type FileReferencePathKind,
 } from "#product/lib/domain/files/path-references";
 import { resolveSelectedWorkspaceIdentity } from "#product/lib/domain/workspaces/selection/workspace-ui-key";
 import { fileViewerTarget } from "#product/lib/domain/workspaces/viewer/viewer-target";
@@ -113,6 +113,15 @@ export function useFileReferenceActions({
     openInDefaultEditor,
     targets,
   } = useOpenInDefaultEditor(pathKind);
+  const { openDefault, openTargets, openWithTarget, reveal } = useDesktopFileReferenceActions({
+    files,
+    reference,
+    pathKind,
+    desktopInspectionState,
+    routeRevision,
+    targets,
+    openInDefaultEditor,
+  });
 
   const canOpenInSidebar = pathKind === "file" && Boolean(reference.workspacePath);
   const canOpenExternal = Boolean(files && reference.absolutePath && pathKind);
@@ -168,11 +177,6 @@ export function useFileReferenceActions({
                     : pathKind === null
                       ? "This path is unavailable."
                       : null);
-  const openTargets = useMemo(
-    () => targets.filter((target) => target.kind !== "copy"),
-    [targets],
-  );
-
   const copyPath = useCallback(async () => {
     await host.clipboard.writeText(reference.absolutePath ?? reference.path);
   }, [host.clipboard, reference.absolutePath, reference.path]);
@@ -225,58 +229,6 @@ export function useFileReferenceActions({
     const client = getAnyHarnessClient(resolved.connection);
     return client.files.stat(resolved.connection.anyharnessWorkspaceId, path);
   }, [anyHarnessWorkspace, materializedWorkspaceId]);
-
-  const currentNativePathKind = useCallback((
-    absolutePath: string,
-  ): FileReferencePathKind | null => {
-    if (
-      currentRouteRevisionRef.current !== routeRevision
-      || absolutePath !== reference.absolutePath
-      || !files
-      || pathKind === null
-    ) {
-      return null;
-    }
-    if (reference.workspacePath) {
-      return pathKind;
-    }
-    return desktopInspectionState.status === "settled"
-      && desktopInspectionState.inspection.kind === pathKind
-      ? pathKind
-      : null;
-  }, [
-    desktopInspectionState,
-    files,
-    pathKind,
-    reference.absolutePath,
-    reference.workspacePath,
-    routeRevision,
-  ]);
-
-  const openDefault = useCallback(async (
-    absolutePath: string | null = reference.absolutePath,
-  ) => {
-    if (!absolutePath) {
-      return false;
-    }
-    const imperativePathKind = currentNativePathKind(absolutePath);
-    if (!imperativePathKind) {
-      return false;
-    }
-    return openInDefaultEditor(absolutePath, imperativePathKind);
-  }, [currentNativePathKind, openInDefaultEditor, reference.absolutePath]);
-
-  const reveal = useCallback(async (
-    absolutePath: string | null = reference.absolutePath,
-  ) => {
-    if (!absolutePath || currentNativePathKind(absolutePath) !== "directory") {
-      return;
-    }
-    if (!files) {
-      return;
-    }
-    await files.reveal(absolutePath);
-  }, [currentNativePathKind, files, reference.absolutePath]);
 
   const openPrimary = useCallback(async () => {
     let resolvedPathKind = pathKind;
@@ -423,19 +375,6 @@ export function useFileReferenceActions({
     workspaceRoot,
     workspaceUiKey,
   ]);
-
-  const openWithTarget = useCallback(async (targetId: string) => {
-    if (
-      !reference.absolutePath
-      || currentNativePathKind(reference.absolutePath) === null
-    ) {
-      return;
-    }
-    if (!files) {
-      return;
-    }
-    await files.openTarget(targetId, reference.absolutePath);
-  }, [currentNativePathKind, files, reference.absolutePath]);
 
   return {
     reference,

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   getAnyHarnessClient,
   resolveWorkspaceConnectionFromContext,
@@ -7,6 +7,11 @@ import {
 } from "@anyharness/sdk-react";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { useOpenInDefaultEditor } from "#product/hooks/editor/workflows/use-open-in-default-editor";
+import {
+  resolveInspectionPathKind,
+  resolveInspectionUnavailableCopy,
+  useDesktopPathInspection,
+} from "#product/hooks/workspaces/workflows/files/use-desktop-path-inspection";
 import { useFuzzyFileResolver } from "#product/hooks/workspaces/workflows/files/use-fuzzy-file-resolver";
 import { useHomeRelativeFileReference } from "#product/hooks/workspaces/workflows/files/use-home-relative-file-reference";
 import { useWorkspaceShellActivation } from "#product/hooks/workspaces/workflows/tabs/use-workspace-shell-activation";
@@ -37,6 +42,7 @@ export function useFileReferenceActions({
     homeDirectory,
     needsHomeDirectory,
     pending: homeDirectoryPending,
+    rejected: homeDirectoryRejected,
     resolveHomeDirectory,
   } = useHomeRelativeFileReference(files, rawPath);
   const openTarget = useWorkspaceViewerTabsStore((state) => state.openTarget);
@@ -71,11 +77,30 @@ export function useFileReferenceActions({
     path: reference.workspacePath,
     enabled: Boolean(materializedWorkspaceId && reference.workspacePath),
   });
-  const [externalPathKind, setExternalPathKind] = useState<FileReferencePathKind | null>(null);
-  const [externalPathKindPending, setExternalPathKindPending] = useState(false);
+  const routeRevision = useMemo(() => ({}), [
+    files,
+    rawPath,
+    resolveAbsolute,
+    workspacePath,
+    workspaceRoot,
+  ]);
+  const currentRouteRevisionRef = useRef(routeRevision);
+  currentRouteRevisionRef.current = routeRevision;
   const [pathResolutionFailed, setPathResolutionFailed] = useState(false);
   const [primaryOpenFailed, setPrimaryOpenFailed] = useState(false);
+
+  const desktopCandidatePath = reference.workspacePath ? null : reference.absolutePath;
+  const {
+    ensureInspection: ensureDesktopPathInspection,
+    state: desktopInspectionState,
+  } = useDesktopPathInspection({
+    candidatePath: desktopCandidatePath,
+    files,
+    routeRevision,
+  });
+
   const workspacePathKind = resolveWorkspaceStatPathKind(statQuery.data);
+  const externalPathKind = resolveInspectionPathKind(desktopInspectionState);
   const pathKind = reference.workspacePath ? workspacePathKind : externalPathKind;
 
   useEffect(() => {
@@ -83,75 +108,66 @@ export function useFileReferenceActions({
     setPrimaryOpenFailed(false);
   }, [materializedWorkspaceId, reference.absolutePath, reference.workspacePath]);
 
-  useEffect(() => {
-    let cancelled = false;
-    if (reference.workspacePath || !reference.absolutePath || !files) {
-      setExternalPathKind(null);
-      setExternalPathKindPending(false);
-      return;
-    }
-
-    setExternalPathKind(null);
-    setExternalPathKindPending(true);
-    void files.isDirectory(reference.absolutePath).then((isDirectory) => {
-      if (!cancelled) {
-        setExternalPathKind(isDirectory ? "directory" : "file");
-      }
-    }).catch(() => {
-      if (!cancelled) {
-        setExternalPathKind(null);
-      }
-    }).finally(() => {
-      if (!cancelled) {
-        setExternalPathKindPending(false);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [files, reference.absolutePath, reference.workspacePath]);
-
   const {
     defaultTarget: defaultOpenTarget,
     openInDefaultEditor,
     targets,
-  } = useOpenInDefaultEditor(pathKind ?? "file");
+  } = useOpenInDefaultEditor(pathKind);
 
   const canOpenInSidebar = pathKind === "file" && Boolean(reference.workspacePath);
   const canOpenExternal = Boolean(files && reference.absolutePath && pathKind);
-  const canReveal = Boolean(files && reference.absolutePath);
+  const canReveal = Boolean(
+    files
+    && reference.absolutePath
+    && pathKind === "directory",
+  );
   const resolvedPrimaryAction = resolveFileReferencePrimaryAction({
     pathKind,
     canOpenViewer: canOpenInSidebar,
     canOpenExternal,
     canReveal,
   });
-  const canResolvePathKind = Boolean(
-    (reference.workspacePath && materializedWorkspaceId)
-    || (reference.absolutePath && files)
-    || (needsHomeDirectory && files),
-  );
   const canOpenPrimary = resolvedPrimaryAction !== "unavailable"
-    || (pathKind === null && canResolvePathKind);
-  const pathKindPending = homeDirectoryPending || externalPathKindPending || statQuery.isFetching;
+    || Boolean(reference.workspacePath && materializedWorkspaceId && pathKind === null);
+  const desktopInspectionPending = Boolean(
+    files
+    && desktopCandidatePath
+    && (desktopInspectionState.status === "idle"
+      || desktopInspectionState.status === "pending"),
+  );
+  const homeResolutionPending = Boolean(
+    needsHomeDirectory
+    && files
+    && !homeDirectory
+    && !homeDirectoryRejected,
+  );
+  const pathKindPending = homeDirectoryPending
+    || homeResolutionPending
+    || desktopInspectionPending
+    || statQuery.isFetching;
+  const desktopInspectionUnavailableReason = files && desktopCandidatePath
+    ? resolveInspectionUnavailableCopy(desktopInspectionState)
+    : null;
   const primaryUnavailableReason = pathKindPending
     ? "Checking whether this path is a file or folder…"
     : primaryOpenFailed
       ? "Could not open this path. Click to retry."
-      : pathKind === "directory" && !canReveal
-        ? "Reveal in Finder is available in the Desktop app."
-        : needsHomeDirectory && !files
-          ? "Home-relative files are available in the Desktop app."
-        : !reference.workspacePath && reference.absolutePath && !files
-          ? "External files are available in the Desktop app."
-          : pathKind === "file" && !canOpenInSidebar && !canOpenExternal
-            ? "External files are available in the Desktop app."
-            : pathKind === null && pathResolutionFailed
-              ? "Could not resolve this path. Click to retry."
-              : pathKind === null
-                ? "Resolve this path in the workspace."
-                : null;
+      : desktopInspectionUnavailableReason
+        ?? (homeDirectoryRejected
+          ? "This path is unavailable."
+          : pathKind === "directory" && !canReveal
+            ? "This path is unavailable."
+            : needsHomeDirectory && !files
+              ? "This path is unavailable."
+              : !reference.workspacePath && reference.absolutePath && !files
+                ? "This path is unavailable."
+                : pathKind === "file" && !canOpenInSidebar && !canOpenExternal
+                  ? "This path is unavailable."
+                  : pathKind === null && pathResolutionFailed
+                    ? "This path was not found."
+                    : pathKind === null
+                      ? "This path is unavailable."
+                      : null);
   const openTargets = useMemo(
     () => targets.filter((target) => target.kind !== "copy"),
     [targets],
@@ -210,26 +226,57 @@ export function useFileReferenceActions({
     return client.files.stat(resolved.connection.anyharnessWorkspaceId, path);
   }, [anyHarnessWorkspace, materializedWorkspaceId]);
 
+  const currentNativePathKind = useCallback((
+    absolutePath: string,
+  ): FileReferencePathKind | null => {
+    if (
+      currentRouteRevisionRef.current !== routeRevision
+      || absolutePath !== reference.absolutePath
+      || !files
+      || pathKind === null
+    ) {
+      return null;
+    }
+    if (reference.workspacePath) {
+      return pathKind;
+    }
+    return desktopInspectionState.status === "settled"
+      && desktopInspectionState.inspection.kind === pathKind
+      ? pathKind
+      : null;
+  }, [
+    desktopInspectionState,
+    files,
+    pathKind,
+    reference.absolutePath,
+    reference.workspacePath,
+    routeRevision,
+  ]);
+
   const openDefault = useCallback(async (
     absolutePath: string | null = reference.absolutePath,
   ) => {
     if (!absolutePath) {
       return false;
     }
-    return openInDefaultEditor(absolutePath);
-  }, [openInDefaultEditor, reference.absolutePath]);
+    const imperativePathKind = currentNativePathKind(absolutePath);
+    if (!imperativePathKind) {
+      return false;
+    }
+    return openInDefaultEditor(absolutePath, imperativePathKind);
+  }, [currentNativePathKind, openInDefaultEditor, reference.absolutePath]);
 
   const reveal = useCallback(async (
     absolutePath: string | null = reference.absolutePath,
   ) => {
-    if (!absolutePath) {
+    if (!absolutePath || currentNativePathKind(absolutePath) !== "directory") {
       return;
     }
     if (!files) {
-      throw new Error("Local file access is not available.");
+      return;
     }
     await files.reveal(absolutePath);
-  }, [files, reference.absolutePath]);
+  }, [currentNativePathKind, files, reference.absolutePath]);
 
   const openPrimary = useCallback(async () => {
     let resolvedPathKind = pathKind;
@@ -237,6 +284,9 @@ export function useFileReferenceActions({
     let resolvedAbsolutePath = reference.absolutePath;
     if (!resolvedAbsolutePath && needsHomeDirectory && files) {
       const resolvedHomeDirectory = await resolveHomeDirectory();
+      if (currentRouteRevisionRef.current !== routeRevision) {
+        return "unavailable";
+      }
       if (resolvedHomeDirectory) {
         resolvedAbsolutePath = resolveFileReference({
           rawPath,
@@ -274,15 +324,21 @@ export function useFileReferenceActions({
         }
       }
     }
-    if (!resolvedPathKind && resolvedAbsolutePath && files) {
-      try {
-        resolvedPathKind = await files.isDirectory(resolvedAbsolutePath)
-          ? "directory"
-          : "file";
-      } catch {
-        setPathResolutionFailed(true);
+    if (!resolvedWorkspacePath && resolvedAbsolutePath && files) {
+      const inspection = await ensureDesktopPathInspection(resolvedAbsolutePath);
+      if (currentRouteRevisionRef.current !== routeRevision) {
         return "unavailable";
       }
+      resolvedPathKind = inspection?.kind === "file" || inspection?.kind === "directory"
+        ? inspection.kind
+        : null;
+      if (!resolvedPathKind) {
+        return "unavailable";
+      }
+    }
+
+    if (currentRouteRevisionRef.current !== routeRevision) {
+      return "unavailable";
     }
 
     const action = resolveFileReferencePrimaryAction({
@@ -293,7 +349,15 @@ export function useFileReferenceActions({
     });
     if (action === "reveal") {
       try {
-        await reveal(resolvedAbsolutePath);
+        if (
+          !files
+          || !resolvedAbsolutePath
+          || resolvedPathKind !== "directory"
+          || currentRouteRevisionRef.current !== routeRevision
+        ) {
+          return "unavailable";
+        }
+        await files.reveal(resolvedAbsolutePath);
       } catch {
         setPrimaryOpenFailed(true);
         return "unavailable";
@@ -320,7 +384,14 @@ export function useFileReferenceActions({
       return action;
     }
     if (action === "open-external") {
-      const opened = await openDefault(resolvedAbsolutePath);
+      if (
+        !resolvedAbsolutePath
+        || !resolvedPathKind
+        || currentRouteRevisionRef.current !== routeRevision
+      ) {
+        return "unavailable";
+      }
+      const opened = await openInDefaultEditor(resolvedAbsolutePath, resolvedPathKind);
       if (!opened) {
         setPrimaryOpenFailed(true);
         return "unavailable";
@@ -334,9 +405,10 @@ export function useFileReferenceActions({
     files,
     activateViewerTarget,
     fuzzyResolveFilePath,
+    ensureDesktopPathInspection,
     materializedWorkspaceId,
     needsHomeDirectory,
-    openDefault,
+    openInDefaultEditor,
     openTarget,
     pathKind,
     rawPath,
@@ -344,7 +416,7 @@ export function useFileReferenceActions({
     reference.workspacePath,
     resolveAbsolute,
     resolveHomeDirectory,
-    reveal,
+    routeRevision,
     statWorkspacePath,
     statQuery,
     workspacePath,
@@ -353,14 +425,17 @@ export function useFileReferenceActions({
   ]);
 
   const openWithTarget = useCallback(async (targetId: string) => {
-    if (!reference.absolutePath) {
+    if (
+      !reference.absolutePath
+      || currentNativePathKind(reference.absolutePath) === null
+    ) {
       return;
     }
     if (!files) {
-      throw new Error("Local file access is not available.");
+      return;
     }
     await files.openTarget(targetId, reference.absolutePath);
-  }, [files, reference.absolutePath]);
+  }, [currentNativePathKind, files, reference.absolutePath]);
 
   return {
     reference,

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-home-relative-file-reference.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-home-relative-file-reference.ts
@@ -31,23 +31,32 @@ export function useHomeRelativeFileReference(
   const needsHomeDirectory = isHomeRelativeFileReference(rawPath);
   const [homeDirectory, setHomeDirectory] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
+  const [rejected, setRejected] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     if (!needsHomeDirectory || !files) {
       setHomeDirectory(null);
       setPending(false);
+      setRejected(false);
       return;
     }
 
     setHomeDirectory(null);
     setPending(true);
+    setRejected(false);
     void loadHomeDirectory(files).then(
       (path) => {
-        if (!cancelled) setHomeDirectory(path);
+        if (!cancelled) {
+          setHomeDirectory(path);
+          setRejected(false);
+        }
       },
       () => {
-        if (!cancelled) setHomeDirectory(null);
+        if (!cancelled) {
+          setHomeDirectory(null);
+          setRejected(true);
+        }
       },
     ).finally(() => {
       if (!cancelled) setPending(false);
@@ -61,22 +70,28 @@ export function useHomeRelativeFileReference(
     if (!needsHomeDirectory || !files) {
       return null;
     }
+    if (rejected) {
+      return null;
+    }
     if (homeDirectory) {
       return homeDirectory;
     }
     try {
       const path = await loadHomeDirectory(files);
       setHomeDirectory(path);
+      setRejected(false);
       return path;
     } catch {
+      setRejected(true);
       return null;
     }
-  }, [files, homeDirectory, needsHomeDirectory]);
+  }, [files, homeDirectory, needsHomeDirectory, rejected]);
 
   return {
     homeDirectory,
     needsHomeDirectory,
     pending,
+    rejected,
     resolveHomeDirectory,
   };
 }

--- a/apps/packages/product-client/src/host/desktop-bridge.ts
+++ b/apps/packages/product-client/src/host/desktop-bridge.ts
@@ -87,6 +87,21 @@ export type DirectoryPickerUnavailableReason =
   | "native_host_required"
   | "picker_failed";
 
+export type DesktopPathInspectionUnavailableReason =
+  | "invalid_path"
+  | "permission_denied"
+  | "unsupported_type"
+  | "io_error";
+
+export type DesktopPathInspection =
+  | { kind: "file" }
+  | { kind: "directory" }
+  | { kind: "missing" }
+  | {
+      kind: "unavailable";
+      reason: DesktopPathInspectionUnavailableReason;
+    };
+
 
 /** A directory-picker outcome with cancellation kept distinct from a missing
  * or failed native transport. Product workflows decide how to present the
@@ -103,7 +118,7 @@ export type DirectoryPickerResult =
 export interface DesktopFilesBridge {
   pickDirectory(): Promise<DirectoryPickerResult>;
   getHomeDirectory(): Promise<string>;
-  isDirectory(path: string): Promise<boolean>;
+  inspectPath(path: string): Promise<DesktopPathInspection>;
 
   /**
    * The drag pasteboard's current change count, captured while a drag is over

--- a/specs/FEATURE_DOCS/DESKTOP_HOST.md
+++ b/specs/FEATURE_DOCS/DESKTOP_HOST.md
@@ -95,6 +95,20 @@ deployment selection, links, storage, clipboard, telemetry, and Cloud behavior
 use their normal ProductHost groups rather than being duplicated in the
 Desktop bridge.
 
+Desktop-local path inspection is one narrow typed bridge operation. The host
+accepts an absolute candidate and returns exactly `file`, `directory`,
+`missing`, or `unavailable` with the bounded reason `invalid_path`,
+`permission_denied`, `unsupported_type`, or `io_error`. The renderer adapter
+validates that exact path-free union from an unknown native payload; malformed
+payloads reject with fixed protocol copy, and native transport failures remain
+rejections. Inspection follows the final filesystem link and reports metadata
+at that moment. It neither establishes that a reference belongs to the local
+machine nor guarantees that a later open will succeed.
+
+Home-directory lookup is also fail closed. Desktop caches a successful native
+lookup, but rejection remains rejection; there is no development or browser
+fallback path.
+
 The initial DesktopBridge may implement methods for the known inventoried
 consumers before those call sites migrate, as Desktop Host Adoption did. New
 methods beyond that inventory remain demand-driven: add one only when an

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -144,12 +144,15 @@ Rules:
   path. Resolve it through the Desktop host's home-directory bridge before
   classifying or opening it; Web keeps the reference unavailable. Hidden path
   segments such as `~/.config` follow the same rule as any other home-relative
-  path.
+  path. A rejected home lookup remains unavailable and never substitutes
+  `/tmp` for inspection, target discovery, open, or reveal.
 - Once the assistant reveal frontier settles, the final unique Markdown file
   reference also renders as a compact end-resource card after prose. Its
   default subtitle identifies `Document · MD`; hover/focus changes that
   subtitle to `Open preview`. It remains completion chrome: never expose it
-  while transport text is still buffered or its final opacity is settling.
+  while transport text is still buffered or its final opacity is settling. Its
+  trigger consumes the file-reference action's `canOpenPrimary` capability and
+  stays disabled, with a guarded handler, until that capability is true.
 - While prose is streaming, a trailing incomplete local-file link is closed
   only in the Markdown render copy so its file mention appears as soon as the
   destination begins. Never persist the synthetic delimiter or expose the raw

--- a/specs/codebase/systems/product/workspaces/files.md
+++ b/specs/codebase/systems/product/workspaces/files.md
@@ -141,6 +141,30 @@ server read cache; they exist only for local editing and conflict metadata.
 Scratch content belongs to Tauri app-data access hooks. It is a local external
 resource, not Zustand state and not an AnyHarness file resource.
 
+## Desktop-local Path Capabilities
+
+Values already routed to the Desktop filesystem pass through
+`DesktopFilesBridge.inspectPath`; inspection itself does not establish local
+provenance. Product state keeps `idle`, `pending`, `settled`, and `rejected`
+distinct for each candidate revision. The render effect and an imperative
+primary action share one attempt, a candidate change makes an older completion
+stale, and a settled refusal or rejected transport is terminal for that
+revision.
+
+Only a settled `file` or `directory` result establishes a path kind and enables
+matching open/reveal capabilities. Missing, invalid, denied, unsupported,
+unexpected-I/O, malformed-payload, idle, pending, and rejected states keep the
+kind null, expose no open targets, and cause every native handler to no-op after
+rechecking current state. Copy path remains available because it performs no
+filesystem operation. Target discovery takes `file | directory | null`; null
+does not default to file or start discovery, while an imperative open supplies
+the already-inspected kind explicitly.
+
+Inspection refusal does not advertise or perform a retry. A native open or
+reveal attempted after a settled file/directory may fail separately; only that
+operation failure keeps retry copy, and retrying it reuses the settled
+inspection.
+
 ## Right Panel Tools
 
 The durable Scratch tool id is `scratch`. New right-panel state defaults to

--- a/specs/desktop-native.md
+++ b/specs/desktop-native.md
@@ -434,6 +434,25 @@ terminal to teardown fallback; remove the locator; close fallback. Windows'
 direct-exit updater command enters this same coordinator before installation,
 preserving its existing fail-closed Worker behavior.
 
+## Desktop Path Inspection
+
+`commands/shell.rs::inspect_path` is the native metadata boundary for a path
+that product code has already routed to Desktop. It accepts only a non-empty,
+NUL-free, platform-absolute path and intentionally uses `std::fs::metadata` so
+the final link is followed. Its serialized response is path-free:
+
+- regular file/link-to-file: `{"kind":"file"}`
+- directory/link-to-directory: `{"kind":"directory"}`
+- missing, `NotADirectory`, or dangling link: `{"kind":"missing"}`
+- invalid input, denied metadata, unsupported object type, or other I/O:
+  `{"kind":"unavailable","reason":"<bounded_reason>"}`
+
+The bounded reasons are `invalid_path`, `permission_denied`,
+`unsupported_type`, and `io_error`. Expected outcomes do not use a native
+string-error channel, and the command does not log the input, link target, or
+OS error. Inspection and the later OS open are separate operations; the
+same-user race between them is accepted.
+
 ## Failure Modes
 
 | Failure | Handling |


### PR DESCRIPTION
## Summary

- Replace Desktop's boolean path probe with a validated, path-free `file` / `directory` / `missing` / bounded-unavailable inspection contract.
- Fail closed across home expansion, editor target discovery, transcript actions, open, and reveal; only a settled exact kind grants a native capability.
- Share one stale-safe inspection attempt between effect and imperative callers, and document the native/host/Product ownership boundary.
- Keep Desktop-native open/reveal/target guards in a focused hook so the main file-reference action hook remains below the frontend structure ratchet.
- Runtime-authority dependency #2066 is merged; this branch is restacked directly on current `main`, which contains that squash merge.

## Testing

- Tier 1 native contract: `CARGO_BUILD_JOBS=1 cargo test -p proliferate path_inspection --lib` — 6 passed, exit 0, with empty machine-wide cargo/rustc checks before and after.
- Tier 1 Product behavior: focused Vitest across desktop inspection state, file-reference actions, exact-kind editor discovery, and transcript card — 40 passed.
- Tier 1 Desktop bridge: focused Vitest across shell, general bridge, and split path-inspection bridge suites — 54 passed.
- `pnpm --filter @proliferate/product-client typecheck`
- `pnpm --filter proliferate exec tsc --noEmit`
- `python3 scripts/check_docs.py`
- `python3 scripts/check_design_attribution.py`
- `python3 scripts/check_max_lines.py`
- `python3 scripts/report_frontend_structure.py --strict --summary-only`
- `git diff --check`

## Observability

- None. Expected native failures are bounded enums; malformed payloads and unavailable UI copy remain fixed and path-free. No analytics, Sentry capture, or raw path/error logging was added.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- Independently reviewed against frozen Slice 01B r5: ACCEPT, with no blocking or decision findings; r4/r5 are structural/restack bookkeeping with no contract change.
- The review follow-up to name the split bridge/state tests is incorporated in the frozen proof and this evidence.
- The current-main restack onto `06fe0d00c4` (containing #2066 merge `2e0b907b97`) preserves both commits exactly in a 2/2 range diff.
- `01B-CI-B01` resolved: the head-caused FE-SIZE-1 violation was fixed by a behavior-preserving native-action seam; strict structure is 0 violations, focused Product behavior remains 40/40, and Product typecheck passes.
- Settled missing/unavailable results and rejected inspection transport are intentionally terminal for one candidate revision under `specs/codebase/systems/product/workspaces/files.md`; candidate, route, or bridge revisions reset the state. The focused action test pins a single inspection after refusal so render/click retries cannot repeatedly probe native paths.
