### PR TITLE
fix(product): keep current diff evidence coherent

### DIFF
--- a/anyharness/sdk-react/src/hooks/files.test.tsx
+++ b/anyharness/sdk-react/src/hooks/files.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AnyHarnessRuntime } from "../context/AnyHarnessRuntime.js";
+import { AnyHarnessWorkspace } from "../context/AnyHarnessWorkspace.js";
+import { readGitCacheForceEpoch } from "../lib/git-cache-generation.js";
+import { useWriteWorkspaceFileMutation } from "./files.js";
+import { useGitCacheForceEpoch, useGitDiffQuery } from "./git.js";
+
+const CACHE_SCOPE_KEY = "files:test";
+const mocks = vi.hoisted(() => ({ getDiff: vi.fn(), write: vi.fn() }));
+
+vi.mock("../lib/client-cache.js", () => ({
+  getAnyHarnessClient: () => ({
+    files: { write: mocks.write },
+    git: { getDiff: mocks.getDiff },
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+  mocks.getDiff.mockReset();
+  mocks.write.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("sdk-react file mutation Git coherence", () => {
+  it("advances the force epoch only after successful invalidations settle", async () => {
+    mocks.write.mockResolvedValue({ path: "src/app.ts" });
+    const queryClient = createQueryClient();
+    const invalidation = deferred<void>();
+    vi.spyOn(queryClient, "invalidateQueries").mockReturnValue(invalidation.promise);
+    const { result } = renderHook(() => useWriteWorkspaceFileMutation(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let mutation!: Promise<unknown>;
+    act(() => {
+      mutation = result.current.mutateAsync({ path: "src/app.ts", content: "next" });
+    });
+    await waitFor(() => expect(mocks.write).toHaveBeenCalledTimes(1));
+    expect(readGitCacheForceEpoch(queryClient, CACHE_SCOPE_KEY, "workspace-1")).toBe(0);
+
+    invalidation.resolve();
+    await act(() => mutation);
+    expect(readGitCacheForceEpoch(queryClient, CACHE_SCOPE_KEY, "workspace-1")).toBe(1);
+  });
+
+  it("moves a same-numstat diff to the file-write epoch without restoring old data", async () => {
+    const second = deferred<ReturnType<typeof gitDiff>>();
+    mocks.getDiff
+      .mockResolvedValueOnce(gitDiff("generation one"))
+      .mockReturnValueOnce(second.promise);
+    mocks.write.mockResolvedValue({ path: "src/app.ts" });
+    const queryClient = createQueryClient();
+    const { result } = renderHook(() => {
+      const forceEpoch = useGitCacheForceEpoch();
+      return {
+        diff: useGitDiffQuery({
+          path: "src/app.ts",
+          cacheGeneration: `epoch-${forceEpoch}`,
+        }),
+        write: useWriteWorkspaceFileMutation(),
+      };
+    }, { wrapper: createWrapper(queryClient) });
+    await waitFor(() => expect(result.current.diff.data?.patch).toContain("generation one"));
+
+    await act(() => result.current.write.mutateAsync({
+      path: "src/app.ts",
+      content: "next",
+    }));
+    await waitFor(() => expect(mocks.getDiff).toHaveBeenCalledTimes(2));
+    expect(result.current.diff.data).toBeUndefined();
+    expect(result.current.diff.isFetching).toBe(true);
+
+    act(() => second.resolve(gitDiff("generation two")));
+    await waitFor(() => expect(result.current.diff.data?.patch).toContain("generation two"));
+    expect(mocks.getDiff).toHaveBeenCalledTimes(2);
+  });
+});
+
+function gitDiff(label: string) {
+  return {
+    path: "src/app.ts",
+    scope: "working_tree" as const,
+    binary: false,
+    truncated: false,
+    additions: 1,
+    deletions: 1,
+    patch: `@@ -1 +1 @@\n-before\n+${label}`,
+  };
+}
+
+function createQueryClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <AnyHarnessRuntime runtimeUrl="http://runtime-files.test" cacheScopeKey={CACHE_SCOPE_KEY}>
+          <AnyHarnessWorkspace
+            workspaceId="workspace-1"
+            resolveConnection={async () => ({
+              runtimeUrl: "http://runtime-files.test",
+              anyharnessWorkspaceId: "anyharness-workspace-1",
+            })}
+          >
+            {children}
+          </AnyHarnessWorkspace>
+        </AnyHarnessRuntime>
+      </QueryClientProvider>
+    );
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}

--- a/anyharness/sdk-react/src/hooks/files.ts
+++ b/anyharness/sdk-react/src/hooks/files.ts
@@ -16,12 +16,15 @@ import {
 import { useAnyHarnessCacheScopeKey } from "../context/AnyHarnessRuntime.js";
 import { getAnyHarnessClient } from "../lib/client-cache.js";
 import {
+  advanceGitCacheForceEpoch,
+  invalidateGitDiffCache,
+} from "../lib/git-cache-generation.js";
+import {
   type AnyHarnessQueryTimingOptions,
   useReportAnyHarnessCacheDecision,
 } from "../lib/timing-options.js";
 import { requestOptionsWithSignal } from "../lib/request-options.js";
 import {
-  anyHarnessGitDiffScopeKey,
   anyHarnessGitStatusKey,
   anyHarnessWorkspaceFileKey,
   anyHarnessWorkspaceFileSearchKey,
@@ -218,10 +221,9 @@ export function useWriteWorkspaceFileMutation(options?: { workspaceId?: string |
         queryClient.invalidateQueries({
           queryKey: anyHarnessGitStatusKey(cacheScopeKey, workspaceId),
         }),
-        queryClient.invalidateQueries({
-          queryKey: anyHarnessGitDiffScopeKey(cacheScopeKey, workspaceId),
-        }),
+        invalidateGitDiffCache(queryClient, cacheScopeKey, workspaceId),
       ]);
+      advanceGitCacheForceEpoch(queryClient, cacheScopeKey, workspaceId);
     },
   });
 }
@@ -274,9 +276,7 @@ export function useRenameWorkspaceEntryMutation(options?: { workspaceId?: string
         queryClient.invalidateQueries({
           queryKey: anyHarnessGitStatusKey(cacheScopeKey, workspaceId),
         }),
-        queryClient.invalidateQueries({
-          queryKey: anyHarnessGitDiffScopeKey(cacheScopeKey, workspaceId),
-        }),
+        invalidateGitDiffCache(queryClient, cacheScopeKey, workspaceId),
       ];
       if (response.entry.kind === "directory") {
         invalidations.push(
@@ -286,6 +286,7 @@ export function useRenameWorkspaceEntryMutation(options?: { workspaceId?: string
         );
       }
       await Promise.all(invalidations);
+      advanceGitCacheForceEpoch(queryClient, cacheScopeKey, workspaceId);
     },
   });
 }
@@ -320,9 +321,7 @@ export function useDeleteWorkspaceEntryMutation(options?: { workspaceId?: string
         queryClient.invalidateQueries({
           queryKey: anyHarnessGitStatusKey(cacheScopeKey, workspaceId),
         }),
-        queryClient.invalidateQueries({
-          queryKey: anyHarnessGitDiffScopeKey(cacheScopeKey, workspaceId),
-        }),
+        invalidateGitDiffCache(queryClient, cacheScopeKey, workspaceId),
       ];
       if (response.kind === "directory") {
         invalidations.push(
@@ -332,6 +331,7 @@ export function useDeleteWorkspaceEntryMutation(options?: { workspaceId?: string
         );
       }
       await Promise.all(invalidations);
+      advanceGitCacheForceEpoch(queryClient, cacheScopeKey, workspaceId);
     },
   });
 }
@@ -381,11 +381,12 @@ function useCreateWorkspaceEntryMutation(
             })
           : Promise.resolve(),
         kind === "file"
-          ? queryClient.invalidateQueries({
-              queryKey: anyHarnessGitDiffScopeKey(cacheScopeKey, workspaceId),
-            })
+          ? invalidateGitDiffCache(queryClient, cacheScopeKey, workspaceId)
           : Promise.resolve(),
       ]);
+      if (kind === "file") {
+        advanceGitCacheForceEpoch(queryClient, cacheScopeKey, workspaceId);
+      }
     },
   });
 }

--- a/anyharness/sdk-react/src/hooks/git.test.tsx
+++ b/anyharness/sdk-react/src/hooks/git.test.tsx
@@ -1,12 +1,19 @@
 // @vitest-environment jsdom
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AnyHarnessRuntime } from "../context/AnyHarnessRuntime.js";
 import { AnyHarnessWorkspace } from "../context/AnyHarnessWorkspace.js";
 import {
+  invalidateGitDiffCache,
+  readGitCacheForceEpoch,
+} from "../lib/git-cache-generation.js";
+import {
+  useGitCacheForceEpoch,
+  useStagePatchMutation,
+  useUnstagePatchMutation,
   useGitBaseWorktreeDiffFilesQuery,
   useGitBranchDiffFilesQuery,
   useGitDiffQuery,
@@ -18,6 +25,8 @@ const mocks = vi.hoisted(() => ({
   listBranchDiffFiles: vi.fn(),
   listBaseWorktreeDiffFiles: vi.fn(),
   revertPatches: vi.fn(),
+  stagePatch: vi.fn(),
+  unstagePatch: vi.fn(),
 }));
 
 vi.mock("../lib/client-cache.js", () => ({
@@ -27,6 +36,8 @@ vi.mock("../lib/client-cache.js", () => ({
       listBranchDiffFiles: mocks.listBranchDiffFiles,
       listBaseWorktreeDiffFiles: mocks.listBaseWorktreeDiffFiles,
       revertPatches: mocks.revertPatches,
+      stagePatch: mocks.stagePatch,
+      unstagePatch: mocks.unstagePatch,
     },
   }),
 }));
@@ -38,6 +49,8 @@ describe("sdk-react git timing hooks", () => {
     mocks.listBranchDiffFiles.mockReset();
     mocks.listBaseWorktreeDiffFiles.mockReset();
     mocks.revertPatches.mockReset();
+    mocks.stagePatch.mockReset();
+    mocks.unstagePatch.mockReset();
     vi.restoreAllMocks();
   });
 
@@ -101,6 +114,7 @@ describe("sdk-react git timing hooks", () => {
 
     const { result } = renderHook(() => useGitBranchDiffFilesQuery({
       baseRef: "origin/private",
+      cacheGeneration: "refresh-2",
       requestOptions: {
         measurementOperationId: "mop_branch",
         headers: { "x-trace": "trace-2" },
@@ -123,6 +137,8 @@ describe("sdk-react git timing hooks", () => {
     const queryKeys = queryClient.getQueryCache().getAll().map((query) => query.queryKey);
     expect(JSON.stringify(queryKeys)).not.toContain("mop_branch");
     expect(JSON.stringify(queryKeys)).not.toContain("x-trace");
+    expect(queryKeys.some((key) => key.at(-1) === "refresh-2")).toBe(true);
+    expect(mocks.listBranchDiffFiles.mock.calls[0]?.[1]).not.toHaveProperty("cacheGeneration");
     expect(onCacheDecision).toHaveBeenCalledWith({
       category: "git.branch_diff_files",
       decision: "miss",
@@ -143,6 +159,7 @@ describe("sdk-react git timing hooks", () => {
 
     const { result } = renderHook(() => useGitBaseWorktreeDiffFilesQuery({
       baseRef: "origin/private",
+      cacheGeneration: "turn-2",
       requestOptions: {
         measurementOperationId: "mop_base_worktree",
         headers: { "x-trace": "trace-3" },
@@ -165,6 +182,9 @@ describe("sdk-react git timing hooks", () => {
     const queryKeys = queryClient.getQueryCache().getAll().map((query) => query.queryKey);
     expect(JSON.stringify(queryKeys)).not.toContain("mop_base_worktree");
     expect(JSON.stringify(queryKeys)).not.toContain("x-trace");
+    expect(queryKeys.some((key) => key.at(-1) === "turn-2")).toBe(true);
+    expect(mocks.listBaseWorktreeDiffFiles.mock.calls[0]?.[1])
+      .not.toHaveProperty("cacheGeneration");
     expect(onCacheDecision).toHaveBeenCalledWith({
       category: "git.base_worktree_diff_files",
       decision: "miss",
@@ -188,6 +208,133 @@ describe("sdk-react git timing hooks", () => {
       source: "react_query",
     }));
     expect(mocks.getDiff).not.toHaveBeenCalled();
+  });
+
+  it("drops prior-generation diff data until the new generation resolves", async () => {
+    const first = gitDiff("generation-1");
+    const second = deferred<ReturnType<typeof gitDiff>>();
+    mocks.getDiff.mockResolvedValueOnce(first).mockReturnValueOnce(second.promise);
+    const queryClient = createQueryClient();
+
+    const { result, rerender } = renderHook(
+      ({ cacheGeneration }) => useGitDiffQuery({
+        path: "src/app.ts",
+        cacheGeneration,
+      }),
+      {
+        initialProps: { cacheGeneration: "generation-1" },
+        wrapper: createWrapper(queryClient, "http://runtime-generation.test"),
+      },
+    );
+    await waitFor(() => expect(result.current.data?.patch).toContain("generation-1"));
+
+    rerender({ cacheGeneration: "generation-2" });
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isFetching).toBe(true);
+    await waitFor(() => expect(mocks.getDiff).toHaveBeenCalledTimes(2));
+
+    act(() => second.resolve(gitDiff("generation-2")));
+    await waitFor(() => expect(result.current.data?.patch).toContain("generation-2"));
+    rerender({ cacheGeneration: "generation-2" });
+    expect(mocks.getDiff).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a deferred generation empty until it is enabled, then fetches once", async () => {
+    mocks.getDiff
+      .mockResolvedValueOnce(gitDiff("generation-1"))
+      .mockResolvedValueOnce(gitDiff("generation-2"));
+    const queryClient = createQueryClient();
+    const { result, rerender } = renderHook(
+      ({ cacheGeneration, enabled }) => useGitDiffQuery({
+        path: "src/deferred.ts",
+        cacheGeneration,
+        enabled,
+      }),
+      {
+        initialProps: { cacheGeneration: "generation-1", enabled: true },
+        wrapper: createWrapper(queryClient, "http://runtime-deferred.test"),
+      },
+    );
+    await waitFor(() => expect(result.current.data?.patch).toContain("generation-1"));
+
+    rerender({ cacheGeneration: "generation-2", enabled: false });
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isFetching).toBe(false);
+    expect(mocks.getDiff).toHaveBeenCalledTimes(1);
+
+    rerender({ cacheGeneration: "generation-2", enabled: true });
+    await waitFor(() => expect(result.current.data?.patch).toContain("generation-2"));
+    expect(mocks.getDiff).toHaveBeenCalledTimes(2);
+  });
+
+  it("refetches every active generationless diff family without refetching generated keys", async () => {
+    mocks.getDiff.mockImplementation(async (_workspaceId: string, path: string) => (
+      gitDiff(path === "src/center.ts" ? "center one" : "changes one")
+    ));
+    mocks.listBranchDiffFiles.mockResolvedValue(gitFileList("branch one"));
+    mocks.listBaseWorktreeDiffFiles.mockResolvedValue(gitFileList("base worktree one"));
+    const runtimeUrl = "http://runtime-unversioned.test";
+    const queryClient = createQueryClient();
+    const { result } = renderHook(() => ({
+      center: useGitDiffQuery({ path: "src/center.ts" }),
+      changes: useGitDiffQuery({
+        path: "src/changes.ts",
+        cacheGeneration: "generation-1",
+      }),
+      branch: useGitBranchDiffFilesQuery({ baseRef: "origin/main" }),
+      generatedBranch: useGitBranchDiffFilesQuery({
+        baseRef: "origin/main",
+        cacheGeneration: "generation-1",
+      }),
+      baseWorktree: useGitBaseWorktreeDiffFilesQuery({ baseRef: "origin/main" }),
+      generatedBaseWorktree: useGitBaseWorktreeDiffFilesQuery({
+        baseRef: "origin/main",
+        cacheGeneration: "generation-1",
+      }),
+    }), { wrapper: createWrapper(queryClient, runtimeUrl) });
+    await waitFor(() => {
+      expect(result.current.center.data?.patch).toContain("center one");
+      expect(result.current.changes.data?.patch).toContain("changes one");
+      expect(result.current.branch.data?.headOid).toBe("branch one");
+      expect(result.current.generatedBranch.data?.headOid).toBe("branch one");
+      expect(result.current.baseWorktree.data?.headOid).toBe("base worktree one");
+      expect(result.current.generatedBaseWorktree.data?.headOid).toBe("base worktree one");
+    });
+    for (const [, options] of mocks.listBranchDiffFiles.mock.calls) {
+      expect(options).not.toHaveProperty("cacheGeneration");
+    }
+    for (const [, options] of mocks.listBaseWorktreeDiffFiles.mock.calls) {
+      expect(options).not.toHaveProperty("cacheGeneration");
+    }
+
+    mocks.getDiff.mockClear();
+    mocks.getDiff.mockImplementation(async (_workspaceId: string, path: string) => (
+      gitDiff(path === "src/center.ts" ? "center two" : "changes two")
+    ));
+    mocks.listBranchDiffFiles.mockClear();
+    mocks.listBranchDiffFiles.mockResolvedValue(gitFileList("branch two"));
+    mocks.listBaseWorktreeDiffFiles.mockClear();
+    mocks.listBaseWorktreeDiffFiles.mockResolvedValue(gitFileList("base worktree two"));
+    await act(() => invalidateGitDiffCache(queryClient, runtimeUrl, "workspace-1"));
+
+    await waitFor(() => {
+      expect(result.current.center.data?.patch).toContain("center two");
+      expect(result.current.branch.data?.headOid).toBe("branch two");
+      expect(result.current.baseWorktree.data?.headOid).toBe("base worktree two");
+    });
+    expect(result.current.changes.data?.patch).toContain("changes one");
+    expect(result.current.changes.isStale).toBe(true);
+    expect(result.current.generatedBranch.data?.headOid).toBe("branch one");
+    expect(result.current.generatedBranch.isStale).toBe(true);
+    expect(result.current.generatedBaseWorktree.data?.headOid).toBe("base worktree one");
+    expect(result.current.generatedBaseWorktree.isStale).toBe(true);
+    expect(mocks.getDiff).toHaveBeenCalledTimes(1);
+    expect(mocks.getDiff.mock.calls[0]?.[1]).toBe("src/center.ts");
+    expect(mocks.listBranchDiffFiles).toHaveBeenCalledTimes(1);
+    expect(mocks.listBaseWorktreeDiffFiles).toHaveBeenCalledTimes(1);
+    expect(mocks.listBranchDiffFiles.mock.calls[0]?.[1]).not.toHaveProperty("cacheGeneration");
+    expect(mocks.listBaseWorktreeDiffFiles.mock.calls[0]?.[1])
+      .not.toHaveProperty("cacheGeneration");
   });
 
   it("keeps caller-provided request signals when merging query signals", async () => {
@@ -260,7 +407,96 @@ describe("sdk-react git timing hooks", () => {
       },
     );
   });
+
+  it("advances the force epoch after successful stage, unstage, and revert invalidations", async () => {
+    mocks.stagePatch.mockResolvedValue(undefined);
+    mocks.unstagePatch.mockResolvedValue(undefined);
+    mocks.revertPatches.mockResolvedValue({
+      revertedPaths: ["README.md"],
+      headOidBefore: "head-1",
+      headOidAfter: "head-2",
+    });
+    const queryClient = createQueryClient();
+    const { result } = renderHook(() => ({
+      stage: useStagePatchMutation(),
+      unstage: useUnstagePatchMutation(),
+      revert: useRevertGitPatchesMutation(),
+    }), { wrapper: createWrapper(queryClient, "http://runtime-mutations.test") });
+
+    await act(() => result.current.stage.mutateAsync("stage patch"));
+    expect(readGitCacheForceEpoch(queryClient, "http://runtime-mutations.test", "workspace-1"))
+      .toBe(1);
+    await act(() => result.current.unstage.mutateAsync("unstage patch"));
+    expect(readGitCacheForceEpoch(queryClient, "http://runtime-mutations.test", "workspace-1"))
+      .toBe(2);
+    await act(() => result.current.revert.mutateAsync({ entries: [{
+      path: "README.md",
+      operation: "edit",
+      patch: "@@ patch @@",
+    }] }));
+    expect(readGitCacheForceEpoch(queryClient, "http://runtime-mutations.test", "workspace-1"))
+      .toBe(3);
+  });
+
+  it("moves a staged same-numstat diff to the new epoch without reactivating old data", async () => {
+    const second = deferred<ReturnType<typeof gitDiff>>();
+    mocks.getDiff
+      .mockResolvedValueOnce(gitDiff("generation one"))
+      .mockReturnValueOnce(second.promise);
+    mocks.stagePatch.mockResolvedValue(undefined);
+    const queryClient = createQueryClient();
+    const { result } = renderHook(() => {
+      const forceEpoch = useGitCacheForceEpoch();
+      return {
+        diff: useGitDiffQuery({
+          path: "src/staged.ts",
+          cacheGeneration: `epoch-${forceEpoch}`,
+        }),
+        stage: useStagePatchMutation(),
+      };
+    }, { wrapper: createWrapper(queryClient, "http://runtime-stage-generation.test") });
+    await waitFor(() => expect(result.current.diff.data?.patch).toContain("generation one"));
+
+    await act(() => result.current.stage.mutateAsync("stage patch"));
+    await waitFor(() => expect(mocks.getDiff).toHaveBeenCalledTimes(2));
+    expect(result.current.diff.data).toBeUndefined();
+    expect(result.current.diff.isFetching).toBe(true);
+
+    act(() => second.resolve(gitDiff("generation two")));
+    await waitFor(() => expect(result.current.diff.data?.patch).toContain("generation two"));
+    expect(mocks.getDiff).toHaveBeenCalledTimes(2);
+  });
 });
+
+function gitDiff(label: string) {
+  return {
+    path: "src/app.ts",
+    scope: "working_tree" as const,
+    binary: false,
+    truncated: false,
+    additions: 1,
+    deletions: 1,
+    patch: `@@ -1 +1 @@\n-before\n+${label}`,
+  };
+}
+
+function gitFileList(label: string) {
+  return {
+    baseRef: "origin/main",
+    resolvedBaseOid: "base",
+    mergeBaseOid: "merge",
+    headOid: label,
+    files: [],
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
 
 function createQueryClient(): QueryClient {
   return new QueryClient({

--- a/anyharness/sdk-react/src/hooks/git.ts
+++ b/anyharness/sdk-react/src/hooks/git.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
 import type {
   CommitRequest,
   GitDiffOptions,
@@ -14,6 +15,11 @@ import {
 import { useAnyHarnessCacheScopeKey } from "../context/AnyHarnessRuntime.js";
 import { getAnyHarnessClient } from "../lib/client-cache.js";
 import {
+  advanceGitCacheForceEpoch,
+  invalidateGitDiffCache,
+  readGitCacheForceEpoch,
+} from "../lib/git-cache-generation.js";
+import {
   type AnyHarnessQueryTimingOptions,
   useReportAnyHarnessCacheDecision,
 } from "../lib/timing-options.js";
@@ -23,7 +29,7 @@ import {
   anyHarnessGitBaseWorktreeDiffFilesKey,
   anyHarnessGitBranchDiffFilesKey,
   anyHarnessGitDiffKey,
-  anyHarnessGitDiffScopeKey,
+  anyHarnessGitForceEpochKey,
   anyHarnessGitStatusKey,
   anyHarnessPullRequestKey,
 } from "../lib/query-keys.js";
@@ -33,6 +39,7 @@ interface WorkspaceQueryOptions {
   enabled?: boolean;
   refetchInterval?: number | false;
   refetchIntervalInBackground?: boolean;
+  staleTime?: number;
 }
 
 type TimedWorkspaceQueryOptions = WorkspaceQueryOptions & AnyHarnessQueryTimingOptions;
@@ -43,17 +50,20 @@ type TimedGitDiffQueryOptions = {
   scope?: GitDiffOptions["scope"];
   baseRef?: string | null;
   oldPath?: string | null;
+  cacheGeneration?: string | number | null;
   enabled?: boolean;
 } & AnyHarnessQueryTimingOptions;
 
 type TimedBranchDiffFilesQueryOptions =
   & WorkspaceQueryOptions
   & ListBranchDiffFilesOptions
+  & { cacheGeneration?: string | number | null }
   & AnyHarnessQueryTimingOptions;
 
 type TimedBaseWorktreeDiffFilesQueryOptions =
   & WorkspaceQueryOptions
   & ListBaseWorktreeDiffFilesOptions
+  & { cacheGeneration?: string | number | null }
   & AnyHarnessQueryTimingOptions;
 
 async function invalidateWorkspaceGit(
@@ -68,13 +78,40 @@ async function invalidateWorkspaceGit(
     queryClient.invalidateQueries({
       queryKey: anyHarnessGitBranchesKey(cacheScopeKey, workspaceId),
     }),
-    queryClient.invalidateQueries({
-      queryKey: anyHarnessGitDiffScopeKey(cacheScopeKey, workspaceId),
-    }),
+    invalidateGitDiffCache(queryClient, cacheScopeKey, workspaceId),
     queryClient.invalidateQueries({
       queryKey: anyHarnessPullRequestKey(cacheScopeKey, workspaceId),
     }),
   ]);
+  advanceGitCacheForceEpoch(queryClient, cacheScopeKey, workspaceId);
+}
+
+export function useGitCacheForceEpoch(options?: { workspaceId?: string | null }): number {
+  const workspace = useAnyHarnessWorkspaceContext();
+  const queryClient = useQueryClient();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
+  const workspaceId = options?.workspaceId ?? workspace.workspaceId;
+  const query = useQuery({
+    queryKey: anyHarnessGitForceEpochKey(cacheScopeKey, workspaceId),
+    queryFn: () => readGitCacheForceEpoch(queryClient, cacheScopeKey, workspaceId),
+    initialData: () => readGitCacheForceEpoch(queryClient, cacheScopeKey, workspaceId),
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+  return query.data;
+}
+
+export function useAdvanceGitCacheForceEpoch(
+  options?: { workspaceId?: string | null },
+): () => number {
+  const workspace = useAnyHarnessWorkspaceContext();
+  const queryClient = useQueryClient();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
+  const workspaceId = options?.workspaceId ?? workspace.workspaceId;
+  return useCallback(
+    () => advanceGitCacheForceEpoch(queryClient, cacheScopeKey, workspaceId),
+    [cacheScopeKey, queryClient, workspaceId],
+  );
 }
 
 export function useGitStatusQuery(options?: TimedWorkspaceQueryOptions) {
@@ -93,6 +130,7 @@ export function useGitStatusQuery(options?: TimedWorkspaceQueryOptions) {
   return useQuery({
     queryKey,
     enabled,
+    staleTime: options?.staleTime,
     refetchInterval: options?.refetchInterval,
     refetchIntervalInBackground: options?.refetchIntervalInBackground,
     queryFn: async ({ signal }) => {
@@ -118,6 +156,7 @@ export function useGitDiffQuery(options: TimedGitDiffQueryOptions) {
     options.scope,
     options.baseRef,
     options.oldPath,
+    options.cacheGeneration,
   );
   useReportAnyHarnessCacheDecision({
     category: "git.diff",
@@ -129,6 +168,9 @@ export function useGitDiffQuery(options: TimedGitDiffQueryOptions) {
   return useQuery({
     queryKey,
     enabled,
+    staleTime: options.cacheGeneration === null || options.cacheGeneration === undefined
+      ? undefined
+      : Infinity,
     queryFn: async ({ signal }) => {
       const resolved = await resolveWorkspaceConnectionFromContext(workspace, workspaceId);
       const client = getAnyHarnessClient(resolved.connection);
@@ -149,7 +191,12 @@ export function useGitBranchDiffFilesQuery(
   const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
   const enabled = (options?.enabled ?? true) && !!workspaceId;
-  const queryKey = anyHarnessGitBranchDiffFilesKey(cacheScopeKey, workspaceId, options?.baseRef);
+  const queryKey = anyHarnessGitBranchDiffFilesKey(
+    cacheScopeKey,
+    workspaceId,
+    options?.baseRef,
+    options?.cacheGeneration,
+  );
   useReportAnyHarnessCacheDecision({
     category: "git.branch_diff_files",
     enabled,
@@ -160,6 +207,7 @@ export function useGitBranchDiffFilesQuery(
   return useQuery({
     queryKey,
     enabled,
+    staleTime: options?.staleTime,
     refetchInterval: options?.refetchInterval,
     refetchIntervalInBackground: options?.refetchIntervalInBackground,
     queryFn: async ({ signal }) => {
@@ -180,7 +228,12 @@ export function useGitBaseWorktreeDiffFilesQuery(
   const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options?.workspaceId ?? workspace.workspaceId;
   const enabled = (options?.enabled ?? true) && !!workspaceId;
-  const queryKey = anyHarnessGitBaseWorktreeDiffFilesKey(cacheScopeKey, workspaceId, options?.baseRef);
+  const queryKey = anyHarnessGitBaseWorktreeDiffFilesKey(
+    cacheScopeKey,
+    workspaceId,
+    options?.baseRef,
+    options?.cacheGeneration,
+  );
   useReportAnyHarnessCacheDecision({
     category: "git.base_worktree_diff_files",
     enabled,
@@ -191,6 +244,7 @@ export function useGitBaseWorktreeDiffFilesQuery(
   return useQuery({
     queryKey,
     enabled,
+    staleTime: options?.staleTime,
     refetchInterval: options?.refetchInterval,
     refetchIntervalInBackground: options?.refetchIntervalInBackground,
     queryFn: async ({ signal }) => {

--- a/anyharness/sdk-react/src/index.ts
+++ b/anyharness/sdk-react/src/index.ts
@@ -66,6 +66,7 @@ export {
   anyHarnessPlanKey,
   anyHarnessPlanDocumentKey,
   anyHarnessGitStatusKey,
+  anyHarnessGitForceEpochKey,
   anyHarnessGitDiffScopeKey,
   anyHarnessGitDiffKey,
   anyHarnessGitBranchDiffFilesKey,
@@ -85,6 +86,11 @@ export {
   anyHarnessTerminalsKey,
   anyHarnessWorkspaceQueryKeyRoots,
 } from "./lib/query-keys.js";
+
+export {
+  advanceGitCacheForceEpoch,
+  readGitCacheForceEpoch,
+} from "./lib/git-cache-generation.js";
 
 export {
   anyHarnessWorkflowRunsScopeKey,
@@ -235,6 +241,8 @@ export {
 } from "./hooks/reviews.js";
 export {
   useGitStatusQuery,
+  useGitCacheForceEpoch,
+  useAdvanceGitCacheForceEpoch,
   useGitDiffQuery,
   useGitBranchDiffFilesQuery,
   useGitBaseWorktreeDiffFilesQuery,

--- a/anyharness/sdk-react/src/lib/git-cache-generation.ts
+++ b/anyharness/sdk-react/src/lib/git-cache-generation.ts
@@ -1,0 +1,61 @@
+import type { QueryClient } from "@tanstack/react-query";
+import {
+  anyHarnessGitDiffScopeKey,
+  anyHarnessGitForceEpochKey,
+} from "./query-keys.js";
+
+export async function invalidateGitDiffCache(
+  queryClient: QueryClient,
+  cacheScopeKey: string,
+  workspaceId: string | null | undefined,
+): Promise<void> {
+  const diffScopeKey = anyHarnessGitDiffScopeKey(cacheScopeKey, workspaceId);
+  await queryClient.invalidateQueries({
+    queryKey: diffScopeKey,
+    refetchType: "none",
+  });
+  await queryClient.refetchQueries({
+    queryKey: diffScopeKey,
+    type: "active",
+    // Generationless list keys add kind/baseRef and per-file keys add
+    // scope/base/oldPath/path. Generated consumers add one more segment and
+    // move to their new key when the force epoch advances, so refetch only the
+    // active callers that intentionally retain the pre-generation identity.
+    predicate: (query) => {
+      const suffixLength = query.queryKey.length - diffScopeKey.length;
+      return suffixLength === 2 || suffixLength === 4;
+    },
+  });
+}
+
+export function readGitCacheForceEpoch(
+  queryClient: QueryClient,
+  cacheScopeKey: string,
+  workspaceId: string | null | undefined,
+): number {
+  if (!workspaceId) {
+    return 0;
+  }
+  return queryClient.getQueryData<number>(
+    anyHarnessGitForceEpochKey(cacheScopeKey, workspaceId),
+  ) ?? 0;
+}
+
+export function advanceGitCacheForceEpoch(
+  queryClient: QueryClient,
+  cacheScopeKey: string,
+  workspaceId: string | null | undefined,
+): number {
+  if (!workspaceId) {
+    return 0;
+  }
+  let nextEpoch = 0;
+  queryClient.setQueryData<number>(
+    anyHarnessGitForceEpochKey(cacheScopeKey, workspaceId),
+    (currentEpoch) => {
+      nextEpoch = (currentEpoch ?? 0) + 1;
+      return nextEpoch;
+    },
+  );
+  return nextEpoch;
+}

--- a/anyharness/sdk-react/src/lib/query-keys.test.ts
+++ b/anyharness/sdk-react/src/lib/query-keys.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   anyHarnessGitBaseWorktreeDiffFilesKey,
+  anyHarnessGitBranchDiffFilesKey,
   anyHarnessGitDiffKey,
   anyHarnessRuntimeHealthKey,
   anyHarnessSessionEventsKey,
@@ -84,6 +85,56 @@ describe("sdk-react query keys", () => {
       "origin/main",
       "src/old-app.ts",
       "src/app.ts",
+    ]);
+  });
+
+  it("adds cache generations as an optional trailing Git identity", () => {
+    const baseDiffKey = anyHarnessGitDiffKey(
+      "http://runtime.test",
+      "workspace-1",
+      "src/app.ts",
+      "base_worktree",
+      "origin/main",
+      null,
+    );
+    expect(anyHarnessGitDiffKey(
+      "http://runtime.test",
+      "workspace-1",
+      "src/app.ts",
+      "base_worktree",
+      "origin/main",
+      null,
+      "generation-2",
+    )).toEqual([...baseDiffKey, "generation-2"]);
+    expect(anyHarnessGitBranchDiffFilesKey(
+      "http://runtime.test",
+      "workspace-1",
+      "origin/main",
+      "refresh-2",
+    )).toEqual([
+      "anyharness",
+      "http://runtime.test",
+      "workspace",
+      "workspace-1",
+      "git-diff",
+      "branch-files",
+      "origin/main",
+      "refresh-2",
+    ]);
+    expect(anyHarnessGitBaseWorktreeDiffFilesKey(
+      "http://runtime.test",
+      "workspace-1",
+      "origin/main",
+      "turn-2",
+    )).toEqual([
+      "anyharness",
+      "http://runtime.test",
+      "workspace",
+      "workspace-1",
+      "git-diff",
+      "base-worktree-files",
+      "origin/main",
+      "turn-2",
     ]);
   });
 

--- a/anyharness/sdk-react/src/lib/query-keys.ts
+++ b/anyharness/sdk-react/src/lib/query-keys.ts
@@ -380,6 +380,13 @@ export function anyHarnessGitStatusKey(
   return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "git-status"] as const;
 }
 
+export function anyHarnessGitForceEpochKey(
+  cacheScopeKey: string | null | undefined,
+  workspaceId: string | null | undefined,
+) {
+  return [...anyHarnessWorkspaceKey(cacheScopeKey, workspaceId), "git-force-epoch"] as const;
+}
+
 export function anyHarnessGitDiffKey(
   cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
@@ -387,14 +394,16 @@ export function anyHarnessGitDiffKey(
   scope: string | null | undefined = "working_tree",
   baseRef: string | null | undefined = null,
   oldPath: string | null | undefined = null,
+  cacheGeneration: string | number | null | undefined = null,
 ) {
-  return [
+  const key = [
     ...anyHarnessGitDiffScopeKey(cacheScopeKey, workspaceId),
     normalizeGitDiffScope(scope),
     normalizeNullableGitArg(baseRef),
     normalizeNullableGitArg(oldPath),
     path ?? null,
   ] as const;
+  return appendCacheGeneration(key, cacheGeneration);
 }
 
 export function anyHarnessGitDiffScopeKey(
@@ -408,24 +417,37 @@ export function anyHarnessGitBranchDiffFilesKey(
   cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
   baseRef: string | null | undefined = null,
+  cacheGeneration: string | number | null | undefined = null,
 ) {
-  return [
+  const key = [
     ...anyHarnessGitDiffScopeKey(cacheScopeKey, workspaceId),
     "branch-files",
     normalizeNullableGitArg(baseRef),
   ] as const;
+  return appendCacheGeneration(key, cacheGeneration);
 }
 
 export function anyHarnessGitBaseWorktreeDiffFilesKey(
   cacheScopeKey: string | null | undefined,
   workspaceId: string | null | undefined,
   baseRef: string | null | undefined = null,
+  cacheGeneration: string | number | null | undefined = null,
 ) {
-  return [
+  const key = [
     ...anyHarnessGitDiffScopeKey(cacheScopeKey, workspaceId),
     "base-worktree-files",
     normalizeNullableGitArg(baseRef),
   ] as const;
+  return appendCacheGeneration(key, cacheGeneration);
+}
+
+function appendCacheGeneration<T extends readonly unknown[]>(
+  key: T,
+  cacheGeneration: string | number | null | undefined,
+) {
+  return cacheGeneration === null || cacheGeneration === undefined
+    ? key
+    : [...key, cacheGeneration] as const;
 }
 
 function normalizeGitDiffScope(scope: string | null | undefined) {

--- a/apps/packages/product-client/src/components/content/ui/DiffViewer.tsx
+++ b/apps/packages/product-client/src/components/content/ui/DiffViewer.tsx
@@ -2,11 +2,12 @@ import type { CSSProperties } from "react";
 import { DebugProfiler } from "#product/components/diagnostics/DebugProfiler";
 import { ChatDiffViewer } from "#product/components/content/ui/diff/ChatDiffViewer";
 import { SplitDiffViewer } from "#product/components/content/ui/diff/SplitDiffViewer";
-import { UnifiedDiffViewer, type UnifiedDiffHunkActions } from "#product/components/content/ui/diff/UnifiedDiffViewer";
+import { UnifiedDiffViewer } from "#product/components/content/ui/diff/UnifiedDiffViewer";
 import { useDiffHighlight } from "#product/hooks/ui/highlighting/use-diff-highlight";
 import type { MeasurementOperationId } from "#product/lib/domain/telemetry/debug-measurement-catalog";
 import { useChatDiffPreferencesStore } from "#product/stores/chat/chat-diff-preferences-store";
 import type { ContentSearchSurface } from "#product/stores/search/content-search-store";
+import type { UnifiedDiffHunkActions } from "#product/lib/domain/files/hunk-patch";
 
 interface DiffViewerProps {
   patch: string;

--- a/apps/packages/product-client/src/components/content/ui/diff/ChatDiffViewer.tsx
+++ b/apps/packages/product-client/src/components/content/ui/diff/ChatDiffViewer.tsx
@@ -15,7 +15,7 @@ import {
 } from "#product/components/content/ui/diff/DiffContextExpander";
 import { ChatDiffLineWrapContextMenu } from "#product/components/content/ui/diff/ChatDiffLineWrapContextMenu";
 import { HunkActionPill } from "#product/components/content/ui/diff/HunkActionPill";
-import type { UnifiedDiffHunkActions } from "#product/components/content/ui/diff/UnifiedDiffViewer";
+import type { UnifiedDiffHunkActions } from "#product/lib/domain/files/hunk-patch";
 import { useResolvedMode } from "#product/hooks/theme/derived/use-resolved-mode";
 import { Button } from "#product/primitives/Button";
 import {

--- a/apps/packages/product-client/src/components/content/ui/diff/HunkActionPill.tsx
+++ b/apps/packages/product-client/src/components/content/ui/diff/HunkActionPill.tsx
@@ -1,8 +1,7 @@
 import { Minus, Plus, Undo } from "#product/primitives/icons/core";
 import { Button } from "#product/primitives/Button";
 import { Tooltip } from "#product/primitives/Tooltip";
-
-export type HunkActionMode = "unstaged" | "staged";
+import type { HunkActionMode } from "#product/lib/domain/files/hunk-patch";
 
 interface HunkActionPillProps {
   mode: HunkActionMode;

--- a/apps/packages/product-client/src/components/content/ui/diff/UnifiedDiffViewer.tsx
+++ b/apps/packages/product-client/src/components/content/ui/diff/UnifiedDiffViewer.tsx
@@ -7,7 +7,7 @@ import {
   DiffGapInfoRow,
   type ExpandDirection,
 } from "#product/components/content/ui/diff/DiffContextExpander";
-import { HunkActionPill, type HunkActionMode } from "#product/components/content/ui/diff/HunkActionPill";
+import { HunkActionPill } from "#product/components/content/ui/diff/HunkActionPill";
 import type {
   CollapsedContext,
   DiffHunk,
@@ -21,6 +21,10 @@ import {
   useGapExpansion,
 } from "#product/hooks/ui/diff/use-gap-expansion";
 import type { HighlightedToken } from "#product/lib/infra/editor/highlighting";
+import type {
+  HunkActionMode,
+  UnifiedDiffHunkActions,
+} from "#product/lib/domain/files/hunk-patch";
 
 function getLineType(type: DiffLine["type"]): string {
   if (type === "added") return "change-addition";
@@ -220,13 +224,6 @@ function ExpandedGapLines({
       ))}
     </>
   );
-}
-
-export interface UnifiedDiffHunkActions {
-  mode: HunkActionMode;
-  disabled: boolean;
-  onRevert: (hunkIndex: number) => void;
-  onStageOrUnstage: (hunkIndex: number) => void;
 }
 
 export function UnifiedDiffViewer({

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnDiffFileCard.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnDiffFileCard.tsx
@@ -18,9 +18,10 @@ interface TurnDiffFileCardProps {
   turnId: string;
   workspaceId: string | null;
   baseRef: string | null;
+  cacheGeneration: string;
   isRuntimeReady: boolean;
   runtimeBlockedReason: string | null;
-  metadataLoading: boolean;
+  metadataPending: boolean;
   metadataErrorMessage: string | null;
   fallbackAdditions: number;
   fallbackDeletions: number;
@@ -35,9 +36,10 @@ export function TurnDiffFileCard({
   turnId,
   workspaceId,
   baseRef,
+  cacheGeneration,
   isRuntimeReady,
   runtimeBlockedReason,
-  metadataLoading,
+  metadataPending,
   metadataErrorMessage,
   fallbackAdditions,
   fallbackDeletions,
@@ -48,16 +50,19 @@ export function TurnDiffFileCard({
   const {
     currentDiff,
     metadataPolicy,
-    diffQuery,
     diffErrorMessage,
     additions,
     deletions,
     patch,
     patchPolicy,
+    diffData,
+    diffPending,
   } = useTurnCurrentFilePatch({
     file,
     workspaceId,
     baseRef,
+    cacheGeneration,
+    metadataPending,
     enabled: isRuntimeReady && isExpanded,
   });
   // Turn diffs use scope=base_worktree (worktree vs merge-base), so the
@@ -67,7 +72,7 @@ export function TurnDiffFileCard({
     path: file.path,
     enabled: isRuntimeReady && Boolean(currentDiff),
   });
-  const liveDiffData = currentDiff ? diffQuery.data : null;
+  const liveDiffData = currentDiff ? diffData : null;
   const emptyDiffState = formatEmptyDiffState({
     binary: Boolean(liveDiffData?.binary || currentDiff?.binary),
     truncated: Boolean(liveDiffData?.truncated && !patch),
@@ -100,18 +105,18 @@ export function TurnDiffFileCard({
           title="Diff unavailable"
           description={runtimeBlockedReason ?? "The workspace runtime is not ready."}
         />
-      ) : metadataLoading && !currentDiff ? (
-        <TurnDiffInlineState
-          icon={<RefreshCw className="icon-paired animate-spin" />}
-          title="Loading diff"
-          description="Fetching the latest file patch."
-        />
-      ) : metadataErrorMessage && !currentDiff ? (
+      ) : metadataErrorMessage ? (
         <TurnDiffInlineState
           icon={<CircleAlert className="icon-paired" />}
           title="Diff unavailable"
           description={metadataErrorMessage}
           onOpenFile={onOpenFile}
+        />
+      ) : metadataPending ? (
+        <TurnDiffInlineState
+          icon={<RefreshCw className="icon-paired animate-spin" />}
+          title="Loading diff"
+          description="Fetching the latest file patch."
         />
       ) : !currentDiff ? (
         recordedPatch && recordedPolicy ? (
@@ -142,7 +147,7 @@ export function TurnDiffFileCard({
           title={metadataPolicy?.placeholderTitle ?? "Too large to render inline"}
           description={metadataPolicy?.placeholderDescription ?? "Open the file to inspect this change."}
         />
-      ) : diffQuery.isLoading ? (
+      ) : diffPending ? (
         <TurnDiffInlineState
           icon={<RefreshCw className="icon-paired animate-spin" />}
           title="Loading diff"

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnDiffPanel.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnDiffPanel.tsx
@@ -124,9 +124,10 @@ export function TurnDiffPanel({
               turnId={turn.turnId}
               workspaceId={currentDiffs.activeWorkspaceId}
               baseRef={currentDiffs.baseRef}
+              cacheGeneration={currentDiffs.cacheGeneration}
               isRuntimeReady={currentDiffs.isRuntimeReady}
               runtimeBlockedReason={currentDiffs.runtimeBlockedReason}
-              metadataLoading={currentDiffs.isLoading}
+              metadataPending={currentDiffs.metadataPending}
               metadataErrorMessage={currentDiffs.errorMessage}
               fallbackAdditions={fileStats.get(file.key)?.additions ?? 0}
               fallbackDeletions={fileStats.get(file.key)?.deletions ?? 0}

--- a/apps/packages/product-client/src/components/workspace/git/CurrentDiffGenerationCoherence.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/git/CurrentDiffGenerationCoherence.test.tsx
@@ -1,0 +1,468 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider, useQueryClient } from "@tanstack/react-query";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  AnyHarnessRuntime,
+  AnyHarnessWorkspace,
+  anyHarnessGitDiffKey,
+  useAdvanceGitCacheForceEpoch,
+  useGitCacheForceEpoch,
+} from "@anyharness/sdk-react";
+import type { ProductHost } from "@proliferate/product-client/host/product-host";
+import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
+import { TurnDiffFileCard } from "#product/components/workspace/chat/transcript/TurnDiffFileCard";
+import { GitReviewFileRow } from "#product/components/workspace/git/GitReviewFileRow";
+import type { GitPanelReviewFile } from "#product/lib/domain/workspaces/changes/git-panel-diff";
+import {
+  buildChangesCacheGeneration,
+  buildChangesMetadataFingerprint,
+} from "#product/lib/domain/workspaces/changes/changes-cache-generation";
+import { refreshGitPanelMetadata } from "#product/lib/workflows/workspaces/changes/refresh-git-panel-metadata";
+import { useSessionStreamCache } from "#product/hooks/sessions/cache/use-session-stream-cache";
+import { observeChangesMetadata } from "#product/hooks/workspaces/cache/changes-cache-observation";
+
+const CACHE_SCOPE_KEY = "generation:test";
+const RUNTIME_URL = "http://runtime-generation.test";
+const webTestHost = { desktop: null } as ProductHost;
+const mocks = vi.hoisted(() => ({ getDiff: vi.fn() }));
+
+vi.mock("../../../../../../../anyharness/sdk-react/src/lib/client-cache.js", () => ({
+  getAnyHarnessClient: () => ({ git: { getDiff: mocks.getDiff } }),
+}));
+
+vi.mock("#product/hooks/auth/facade/use-product-auth", () => ({
+  useProductAuthUserId: () => "test-user",
+}));
+
+afterEach(() => {
+  cleanup();
+  mocks.getDiff.mockReset();
+});
+
+describe("current diff generation coherence", () => {
+  it("replaces sidebar evidence without presenting prior data or errors", async () => {
+    const background = deferred<ReturnType<typeof diffResponse>>();
+    const second = deferred<ReturnType<typeof diffResponse>>();
+    mocks.getDiff
+      .mockResolvedValueOnce(diffResponse("generation one", {
+        additions: 99,
+        deletions: 88,
+        binary: true,
+        truncated: true,
+      }))
+      .mockReturnValueOnce(background.promise)
+      .mockReturnValueOnce(second.promise);
+    const queryClient = createQueryClient();
+    const firstFile = reviewFile("src/sidebar.ts", 3, 2);
+    const view = renderWithProviders(
+      sidebarRow(firstFile, "generation-1"),
+      queryClient,
+    );
+    await waitFor(() => expect(view.container.textContent).toContain("generation one"));
+    expect(view.container.textContent).toContain("99");
+    expect(view.container.textContent).toContain("88");
+    expect(view.container.textContent).toContain("Diff truncated because it is too large");
+
+    const firstKey = anyHarnessGitDiffKey(
+      CACHE_SCOPE_KEY,
+      "workspace-1",
+      firstFile.path,
+      "unstaged",
+      null,
+      null,
+      "generation-1",
+    );
+    const firstQuery = queryClient.getQueryCache().find({ queryKey: firstKey, exact: true });
+    act(() => {
+      void queryClient.invalidateQueries({
+        queryKey: firstKey,
+        exact: true,
+      });
+    });
+    await waitFor(() => expect(mocks.getDiff).toHaveBeenCalledTimes(2));
+    expect(screen.getByText("Loading diff")).toBeTruthy();
+    expect(view.container.textContent).not.toContain("generation one");
+    act(() => background.resolve(diffResponse("generation one", {
+      additions: 99,
+      deletions: 88,
+      binary: true,
+      truncated: true,
+    })));
+    await waitFor(() => expect(view.container.textContent).toContain("generation one"));
+
+    act(() => {
+      firstQuery?.setState({
+        data: {
+          ...diffResponse("generation one", { additions: 99, deletions: 88, binary: true }),
+          patch: null,
+        },
+        dataUpdatedAt: Date.now(),
+        error: null,
+        fetchStatus: "idle",
+        isInvalidated: false,
+        status: "success",
+      });
+    });
+    await waitFor(() => expect(screen.getByText("Binary file changed")).toBeTruthy());
+    act(() => {
+      firstQuery?.setState({
+        error: new Error("generation one error"),
+        errorUpdatedAt: Date.now(),
+        fetchStatus: "idle",
+        status: "error",
+      });
+    });
+    await waitFor(() => expect(screen.getByText("generation one error")).toBeTruthy());
+
+    const secondFile = reviewFile("src/sidebar.ts", 7, 6);
+    view.rerender(providers(
+      sidebarRow(secondFile, "generation-2"),
+      queryClient,
+    ));
+    await waitFor(() => expect(mocks.getDiff).toHaveBeenCalledTimes(3));
+    expect(screen.getByText("Loading diff")).toBeTruthy();
+    expect(view.container.textContent).not.toContain("generation one");
+    expect(view.container.textContent).not.toContain("generation one error");
+    expect(view.container.textContent).not.toContain("99");
+    expect(view.container.textContent).not.toContain("88");
+    expect(view.container.textContent).not.toContain("Binary file changed");
+    expect(view.container.textContent).not.toContain("Diff truncated because it is too large");
+
+    act(() => second.resolve(diffResponse("generation two", {
+      additions: 8,
+      deletions: 5,
+    })));
+    await waitFor(() => expect(view.container.textContent).toContain("generation two"));
+    expect(mocks.getDiff).toHaveBeenCalledTimes(3);
+    expect(view.container.textContent?.match(/generation two/g)).toHaveLength(1);
+  });
+
+  it("keeps deferred and policy-blocked sidebar generations free of prior data", async () => {
+    mocks.getDiff.mockResolvedValueOnce(diffResponse("old sidebar"));
+    const queryClient = createQueryClient();
+    const firstFile = reviewFile("src/deferred.ts", 1, 1);
+    const view = renderWithProviders(sidebarRow(firstFile, "generation-1"), queryClient);
+    await waitFor(() => expect(view.container.textContent).toContain("old sidebar"));
+
+    const nextFile = reviewFile("src/deferred.ts", 4, 3);
+    view.rerender(providers(
+      sidebarRow(nextFile, "generation-2", { fetchDiff: false }),
+      queryClient,
+    ));
+    expect(screen.getByText("Waiting to load diff")).toBeTruthy();
+    expect(view.container.textContent).not.toContain("old sidebar");
+    expect(mocks.getDiff).toHaveBeenCalledTimes(1);
+
+    view.rerender(providers(
+      sidebarRow(nextFile, "generation-3", { collapsed: true }),
+      queryClient,
+    ));
+    expect(view.container.textContent).not.toContain("old sidebar");
+    expect(mocks.getDiff).toHaveBeenCalledTimes(1);
+
+    const blockedFile = reviewFile("src/deferred.ts", 5_001, 0);
+    view.rerender(providers(
+      sidebarRow(blockedFile, "generation-4"),
+      queryClient,
+    ));
+    expect(screen.getByText("Too large to render inline")).toBeTruthy();
+    expect(view.container.textContent).not.toContain("old sidebar");
+    expect(mocks.getDiff).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a transcript-collapsed generation empty, then fetches once on expansion", async () => {
+    const second = deferred<ReturnType<typeof diffResponse>>();
+    mocks.getDiff
+      .mockResolvedValueOnce(diffResponse("old transcript"))
+      .mockReturnValueOnce(second.promise);
+    const queryClient = createQueryClient();
+    const firstFile = reviewFile("src/transcript.ts", 2, 1);
+    const view = renderWithProviders(
+      turnCard(firstFile, "generation-1", true),
+      queryClient,
+    );
+    await waitFor(() => expect(view.container.textContent).toContain("old transcript"));
+
+    const secondFile = reviewFile("src/transcript.ts", 5, 3);
+    view.rerender(providers(
+      turnCard(secondFile, "generation-2", false),
+      queryClient,
+    ));
+    expect(view.container.textContent).not.toContain("old transcript");
+    expect(mocks.getDiff).toHaveBeenCalledTimes(1);
+
+    view.rerender(providers(
+      turnCard(secondFile, "generation-2", true),
+      queryClient,
+    ));
+    await waitFor(() => expect(mocks.getDiff).toHaveBeenCalledTimes(2));
+    expect(screen.getByText("Loading diff")).toBeTruthy();
+    expect(view.container.textContent).not.toContain("old transcript");
+
+    act(() => second.resolve(diffResponse("new transcript", {
+      additions: 6,
+      deletions: 4,
+    })));
+    await waitFor(() => expect(view.container.textContent).toContain("new transcript"));
+    expect(mocks.getDiff).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["manual", "stream"] as const)(
+    "moves identical-numstat evidence across the %s force boundary",
+    async (boundary) => {
+      const second = deferred<ReturnType<typeof diffResponse>>();
+      mocks.getDiff
+        .mockResolvedValueOnce(diffResponse("generation one"))
+        .mockReturnValueOnce(second.promise);
+      const queryClient = createQueryClient();
+      const view = renderWithProviders(<ForceBoundarySidebar boundary={boundary} />, queryClient);
+      await waitFor(() => expect(view.container.textContent).toContain("generation one"));
+
+      fireEvent.click(screen.getByRole("button", { name: `Advance ${boundary} boundary` }));
+      await waitFor(() => expect(mocks.getDiff).toHaveBeenCalledTimes(2));
+      expect(screen.getByText("Loading diff")).toBeTruthy();
+      expect(view.container.textContent).not.toContain("generation one");
+
+      act(() => second.resolve(diffResponse("generation two")));
+      await waitFor(() => expect(view.container.textContent).toContain("generation two"));
+      expect(mocks.getDiff).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("treats M1 to M2 to M1 as three observations without rotating unchanged polls", async () => {
+    const second = deferred<ReturnType<typeof diffResponse>>();
+    const third = deferred<ReturnType<typeof diffResponse>>();
+    mocks.getDiff
+      .mockResolvedValueOnce(diffResponse("first M1"))
+      .mockReturnValueOnce(second.promise)
+      .mockReturnValueOnce(third.promise);
+    const queryClient = createQueryClient();
+    const m1 = reviewFile("src/aba.ts", 2, 1);
+    const m2: GitPanelReviewFile = {
+      ...m1,
+      currentDiff: { ...m1.currentDiff!, status: "added" },
+    };
+    const view = renderWithProviders(
+      <ObservedMetadataSidebar file={m1} />,
+      queryClient,
+    );
+    await waitFor(() => expect(view.container.textContent).toContain("first M1"));
+
+    view.rerender(providers(
+      <ObservedMetadataSidebar file={{ ...m1, currentDiff: { ...m1.currentDiff! } }} />,
+      queryClient,
+    ));
+    expect(mocks.getDiff).toHaveBeenCalledTimes(1);
+
+    view.rerender(providers(<ObservedMetadataSidebar file={m2} />, queryClient));
+    await waitFor(() => expect(mocks.getDiff).toHaveBeenCalledTimes(2));
+    expect(screen.getByText("Loading diff")).toBeTruthy();
+    expect(view.container.textContent).not.toContain("first M1");
+    act(() => second.resolve(diffResponse("observed M2")));
+    await waitFor(() => expect(view.container.textContent).toContain("observed M2"));
+
+    view.rerender(providers(
+      <ObservedMetadataSidebar file={{ ...m1, currentDiff: { ...m1.currentDiff! } }} />,
+      queryClient,
+    ));
+    await waitFor(() => expect(mocks.getDiff).toHaveBeenCalledTimes(3));
+    expect(screen.getByText("Loading diff")).toBeTruthy();
+    expect(view.container.textContent).not.toContain("first M1");
+    expect(view.container.textContent).not.toContain("observed M2");
+    act(() => third.resolve(diffResponse("final M1")));
+    await waitFor(() => expect(view.container.textContent).toContain("final M1"));
+    expect(queryClient.getQueryCache().getAll().filter((query) => (
+      query.queryKey.includes("src/aba.ts")
+    ))).toHaveLength(3);
+
+    view.unmount();
+    const remount = renderWithProviders(<ObservedMetadataSidebar file={m1} />, queryClient);
+    expect(remount.container.textContent).toContain("final M1");
+    expect(remount.container.textContent).not.toContain("first M1");
+    expect(mocks.getDiff).toHaveBeenCalledTimes(3);
+  });
+});
+
+function ObservedMetadataSidebar({ file }: { file: GitPanelReviewFile }) {
+  const queryClient = useQueryClient();
+  const semanticFingerprint = buildChangesMetadataFingerprint({ files: [file.currentDiff!] });
+  const observationToken = observeChangesMetadata({
+    queryClient,
+    scopeKey: "observed-metadata-sidebar:workspace-1",
+    forceEpoch: 0,
+    semanticFingerprint,
+  });
+  const cacheGeneration = buildChangesCacheGeneration({
+    kind: "working_tree",
+    semanticFingerprint,
+    observationToken,
+    forceEpoch: 0,
+  });
+  return sidebarRow(file, cacheGeneration);
+}
+
+function ForceBoundarySidebar({ boundary }: { boundary: "manual" | "stream" }) {
+  const queryClient = useQueryClient();
+  const forceEpoch = useGitCacheForceEpoch({ workspaceId: "workspace-1" });
+  const advanceForceEpoch = useAdvanceGitCacheForceEpoch({ workspaceId: "workspace-1" });
+  const streamCache = useSessionStreamCache();
+  const file = reviewFile("src/boundary.ts", 2, 1);
+  const semanticFingerprint = buildChangesMetadataFingerprint({ files: [file.currentDiff!] });
+  const observationToken = observeChangesMetadata({
+    queryClient,
+    scopeKey: "force-boundary-sidebar:workspace-1",
+    forceEpoch,
+    semanticFingerprint,
+  });
+  const cacheGeneration = buildChangesCacheGeneration({
+    kind: "working_tree",
+    semanticFingerprint,
+    observationToken,
+    forceEpoch,
+  });
+  const advanceBoundary = () => {
+    if (boundary === "manual") {
+      void refreshGitPanelMetadata({
+        refreshes: [async () => ({ isError: false })],
+        advanceForceEpoch,
+      });
+      return;
+    }
+    streamCache.invalidateGitStatus({ workspaceId: "workspace-1" });
+  };
+
+  return (
+    <>
+      <button type="button" onClick={advanceBoundary}>
+        Advance {boundary} boundary
+      </button>
+      {sidebarRow(file, cacheGeneration)}
+    </>
+  );
+}
+
+function sidebarRow(
+  file: GitPanelReviewFile,
+  cacheGeneration: string,
+  overrides: { fetchDiff?: boolean; collapsed?: boolean } = {},
+) {
+  return (
+    <GitReviewFileRow
+      id={`review-${file.path}`}
+      workspaceId="workspace-1"
+      sectionScope="unstaged"
+      file={file}
+      baseRef={null}
+      cacheGeneration={cacheGeneration}
+      metadataPending={false}
+      layout="unified"
+      wrapLongLines={false}
+      collapsed={overrides.collapsed ?? false}
+      isRuntimeReady
+      fetchDiff={overrides.fetchDiff ?? true}
+      onToggleCollapsed={() => {}}
+      onDiffFetchSettled={() => {}}
+      openFile={async () => undefined}
+      contentSearchOrderKey={0}
+    />
+  );
+}
+
+function turnCard(file: GitPanelReviewFile, cacheGeneration: string, isExpanded: boolean) {
+  return (
+    <TurnDiffFileCard
+      file={file}
+      fileCount={2}
+      turnId="turn-1"
+      workspaceId="workspace-1"
+      baseRef="origin/main"
+      cacheGeneration={cacheGeneration}
+      isRuntimeReady
+      runtimeBlockedReason={null}
+      metadataPending={false}
+      metadataErrorMessage={null}
+      fallbackAdditions={file.currentDiff?.additions ?? 0}
+      fallbackDeletions={file.currentDiff?.deletions ?? 0}
+      isExpanded={isExpanded}
+      onToggleExpand={() => {}}
+      onOpenFile={() => {}}
+    />
+  );
+}
+
+function reviewFile(path: string, additions: number, deletions: number): GitPanelReviewFile {
+  return {
+    key: `:${path}:modified`,
+    path,
+    oldPath: null,
+    displayPath: path,
+    currentDiff: {
+      key: `:${path}:modified`,
+      path,
+      oldPath: null,
+      displayPath: path,
+      status: "modified",
+      includedState: "excluded",
+      additions,
+      deletions,
+      binary: false,
+    },
+  };
+}
+
+function diffResponse(
+  label: string,
+  overrides: Partial<{
+    additions: number;
+    deletions: number;
+    binary: boolean;
+    truncated: boolean;
+  }> = {},
+) {
+  return {
+    path: "src/file.ts",
+    scope: "working_tree" as const,
+    additions: overrides.additions ?? 2,
+    deletions: overrides.deletions ?? 1,
+    binary: overrides.binary ?? false,
+    truncated: overrides.truncated ?? false,
+    patch: `@@ -1 +1 @@\n-before\n+${label}`,
+  };
+}
+
+function createQueryClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function renderWithProviders(ui: ReactElement, queryClient: QueryClient) {
+  return render(providers(ui, queryClient));
+}
+
+function providers(ui: ReactElement, queryClient: QueryClient) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AnyHarnessRuntime runtimeUrl={RUNTIME_URL} cacheScopeKey={CACHE_SCOPE_KEY}>
+        <AnyHarnessWorkspace
+          workspaceId="workspace-1"
+          resolveConnection={async () => ({
+            runtimeUrl: RUNTIME_URL,
+            anyharnessWorkspaceId: "workspace-1",
+          })}
+        >
+          <ProductHostProvider host={webTestHost}>{ui}</ProductHostProvider>
+        </AnyHarnessWorkspace>
+      </AnyHarnessRuntime>
+    </QueryClientProvider>
+  );
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}

--- a/apps/packages/product-client/src/components/workspace/git/GitPanel.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/git/GitPanel.test.tsx
@@ -1,6 +1,9 @@
+// @vitest-environment jsdom
+
 import { createElement, type ReactElement } from "react";
 import { renderToStaticMarkup as renderReactToStaticMarkup } from "react-dom/server";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render as renderDom, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProductHost } from "@proliferate/product-client/host/product-host";
 import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
 import { GitPanel } from "./GitPanel";
@@ -20,11 +23,14 @@ function renderToStaticMarkup(ui: ReactElement) {
 const mockGitPanelState = vi.hoisted(() => vi.fn());
 const gitDiffQuery = vi.hoisted(() => ({
   calls: [] as unknown[],
+  resolve: null as ((options: unknown) => unknown) | null,
   state: {
     data: null as unknown,
     error: null as unknown,
     isError: false,
     isLoading: false,
+    isFetching: false,
+    isStale: false,
   },
 }));
 
@@ -34,7 +40,7 @@ vi.mock("@anyharness/sdk-react", () => ({
   }),
   useGitDiffQuery: (options: unknown) => {
     gitDiffQuery.calls.push(options);
-    return gitDiffQuery.state;
+    return gitDiffQuery.resolve?.(options) ?? gitDiffQuery.state;
   },
   useStageGitPathsMutation: () => ({
     mutateAsync: vi.fn(),
@@ -76,7 +82,7 @@ vi.mock("#product/hooks/workspaces/derived/files/use-workspace-file-context", ()
   }),
 }));
 
-vi.mock("#product/hooks/workspaces/derived/use-git-panel-state", () => ({
+vi.mock("#product/hooks/workspaces/cache/use-git-panel-state", () => ({
   useGitPanelState: () => mockGitPanelState(),
 }));
 
@@ -96,6 +102,8 @@ function createGitPanelState(overrides = {}) {
     activeWorkspaceId: "workspace-1",
     baseRef: "main",
     branchRefs: [],
+    cacheGeneration: "generation-1",
+    metadataPending: false,
     sections: [{
       scope: "unstaged",
       label: "Unstaged",
@@ -117,9 +125,12 @@ function createGitPanelState(overrides = {}) {
 }
 
 describe("GitPanel", () => {
+  afterEach(cleanup);
+
   beforeEach(() => {
     mockGitPanelState.mockReturnValue(createGitPanelState());
     gitDiffQuery.calls = [];
+    gitDiffQuery.resolve = null;
     gitDiffQuery.state = {
       data: {
         patch: [
@@ -135,6 +146,8 @@ describe("GitPanel", () => {
       error: null,
       isError: false,
       isLoading: false,
+      isFetching: false,
+      isStale: false,
     };
   });
 
@@ -165,6 +178,114 @@ describe("GitPanel", () => {
       path: "apps/desktop/src/components/workspace/git/GitPanel.tsx",
       enabled: true,
     });
+  });
+
+  it("admits only five file diffs on the first generation render", () => {
+    const files = Array.from({ length: 6 }, (_, index) => {
+      const path = `src/file-${index}.ts`;
+      const currentDiff = {
+        key: `:${path}:modified`,
+        path,
+        oldPath: null,
+        displayPath: path,
+        status: "modified",
+        includedState: "excluded",
+        additions: 1,
+        deletions: 0,
+        binary: false,
+      };
+      return { ...currentDiff, currentDiff };
+    });
+    mockGitPanelState.mockReturnValue(createGitPanelState({
+      cacheGeneration: "generation-2",
+      sections: [{ scope: "unstaged", label: "Unstaged", files }],
+      visibleChangedCount: files.length,
+    }));
+    gitDiffQuery.state = {
+      data: null,
+      error: null,
+      isError: false,
+      isLoading: true,
+      isFetching: true,
+      isStale: true,
+    };
+
+    renderToStaticMarkup(createElement(GitPanel));
+
+    expect(gitDiffQuery.calls).toHaveLength(6);
+    expect(gitDiffQuery.calls.filter((call) => (
+      call as { enabled?: boolean }
+    ).enabled)).toHaveLength(5);
+    expect(gitDiffQuery.calls.every((call) => (
+      call as { cacheGeneration?: string }
+    ).cacheGeneration === "generation-2")).toBe(true);
+  });
+
+  it("drops prior settled rows before the first render of a new generation", async () => {
+    const files = Array.from({ length: 6 }, (_, index) => {
+      const path = `src/generation-file-${index}.ts`;
+      const currentDiff = {
+        key: `:${path}:modified`,
+        path,
+        oldPath: null,
+        displayPath: path,
+        status: "modified",
+        includedState: "excluded",
+        additions: 1,
+        deletions: 0,
+        binary: false,
+      };
+      return { ...currentDiff, currentDiff };
+    });
+    let panelState = createGitPanelState({
+      cacheGeneration: "generation-1",
+      sections: [{ scope: "unstaged", label: "Unstaged", files }],
+      visibleChangedCount: files.length,
+    });
+    mockGitPanelState.mockImplementation(() => panelState);
+    gitDiffQuery.resolve = (options) => (
+      (options as { enabled?: boolean }).enabled
+        ? gitDiffQuery.state
+        : {
+            ...gitDiffQuery.state,
+            data: null,
+            isLoading: false,
+          }
+    );
+    const view = renderDom(
+      <ProductHostProvider host={webTestHost}><GitPanel /></ProductHostProvider>,
+    );
+    await waitFor(() => expect(gitDiffQuery.calls.some((call) => (
+      (call as { path?: string; enabled?: boolean }).path === files[5]?.path
+      && (call as { enabled?: boolean }).enabled
+    ))).toBe(true));
+
+    panelState = createGitPanelState({
+      cacheGeneration: "generation-2",
+      sections: [{ scope: "unstaged", label: "Unstaged", files }],
+      visibleChangedCount: files.length,
+    });
+    gitDiffQuery.resolve = () => ({
+      data: null,
+      error: null,
+      isError: false,
+      isLoading: true,
+      isFetching: true,
+      isStale: true,
+    });
+    gitDiffQuery.calls = [];
+    view.rerender(
+      <ProductHostProvider host={webTestHost}><GitPanel /></ProductHostProvider>,
+    );
+
+    const firstGenerationRender = gitDiffQuery.calls.slice(0, files.length);
+    expect(firstGenerationRender).toHaveLength(files.length);
+    expect(firstGenerationRender.filter((call) => (
+      (call as { enabled?: boolean }).enabled
+    ))).toHaveLength(5);
+    expect(firstGenerationRender.every((call) => (
+      (call as { cacheGeneration?: string }).cacheGeneration === "generation-2"
+    ))).toBe(true);
   });
 
   it("shows the branch target selector only in branch review mode", () => {

--- a/apps/packages/product-client/src/components/workspace/git/GitPanel.tsx
+++ b/apps/packages/product-client/src/components/workspace/git/GitPanel.tsx
@@ -7,7 +7,7 @@ import { formatGitPanelUndoError } from "./GitPanelReviewChrome";
 import { useDiffReviewMeasurement } from "#product/hooks/workspaces/ui/files/use-diff-review-measurement";
 import { useWorkspaceFileActions } from "#product/hooks/workspaces/facade/files/use-workspace-file-actions";
 import { useWorkspaceFileContext } from "#product/hooks/workspaces/derived/files/use-workspace-file-context";
-import { useGitPanelState } from "#product/hooks/workspaces/derived/use-git-panel-state";
+import { useGitPanelState } from "#product/hooks/workspaces/cache/use-git-panel-state";
 import { type GitPanelMode } from "#product/lib/domain/workspaces/changes/git-panel-diff";
 import {
   resolveDiffDisplayPolicy,
@@ -81,7 +81,10 @@ function GitPanelContent({
   const [wrapLongLines, setWrapLongLines] = useState(false);
   // Files render expanded by default; this set only holds explicit collapses.
   const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(new Set());
-  const [settledDiffFetchKeys, setSettledDiffFetchKeys] = useState<Set<string>>(new Set());
+  const [settledDiffFetchState, setSettledDiffFetchState] = useState<{
+    scopeKey: string | null;
+    settled: ReadonlySet<string>;
+  }>(() => ({ scopeKey: null, settled: new Set() }));
   const [undoneTurnIds, setUndoneTurnIds] = useState<ReadonlySet<string>>(() => new Set());
   const fileContext = useWorkspaceFileContext();
   const modeRequest = useGitPanelUiStore((state) =>
@@ -94,6 +97,8 @@ function GitPanelContent({
     activeWorkspaceId,
     baseRef,
     branchRefs = [],
+    cacheGeneration,
+    metadataPending,
     sections,
     visibleChangedCount,
     isRuntimeReady,
@@ -150,13 +155,14 @@ function GitPanelContent({
       activeWorkspaceId,
       baseRef,
       mode: changesFilter,
+      cacheGeneration,
       reviewEntries,
     }),
-    [activeWorkspaceId, baseRef, changesFilter, reviewEntries],
+    [activeWorkspaceId, baseRef, cacheGeneration, changesFilter, reviewEntries],
   );
-  useEffect(() => {
-    setSettledDiffFetchKeys(new Set());
-  }, [diffFetchScopeKey]);
+  const settledDiffFetchKeys = settledDiffFetchState.scopeKey === diffFetchScopeKey
+    ? settledDiffFetchState.settled
+    : new Set<string>();
   const permittedDiffFetchKeys = useMemo<ReadonlySet<string>>(() => {
     return resolvePermittedGitPanelDiffFetchKeys({
       reviewEntries,
@@ -206,15 +212,20 @@ function GitPanelContent({
   }, []);
 
   const markDiffFetchSettled = useCallback((key: string) => {
-    setSettledDiffFetchKeys((current) => {
-      if (current.has(key)) {
-        return current;
+    setSettledDiffFetchState((current) => {
+      const settled = current.scopeKey === diffFetchScopeKey
+        ? current.settled
+        : new Set<string>();
+      if (settled.has(key)) {
+        return current.scopeKey === diffFetchScopeKey
+          ? current
+          : { scopeKey: diffFetchScopeKey, settled };
       }
-      const next = new Set(current);
+      const next = new Set(settled);
       next.add(key);
-      return next;
+      return { scopeKey: diffFetchScopeKey, settled: next };
     });
-  }, []);
+  }, [diffFetchScopeKey]);
 
   const focusReviewFile = useCallback((entry: GitReviewFileEntry) => {
     setCollapsedFiles((current) => {
@@ -308,6 +319,8 @@ function GitPanelContent({
         <GitPanelReviewBody
           changesFilter={changesFilter}
           baseRef={baseRef}
+          cacheGeneration={cacheGeneration}
+          metadataPending={metadataPending}
           isLoading={isLoading}
           errorMessage={errorMessage}
           runtimeBlockedReason={runtimeBlockedReason}

--- a/apps/packages/product-client/src/components/workspace/git/GitPanelReviewBody.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/git/GitPanelReviewBody.test.tsx
@@ -21,6 +21,8 @@ function renderBody(overrides: Partial<Parameters<typeof GitPanelReviewBody>[0]>
     <GitPanelReviewBody
       changesFilter="working_tree_composite"
       baseRef={null}
+      cacheGeneration="generation-1"
+      metadataPending={false}
       isLoading={false}
       errorMessage={null}
       runtimeBlockedReason={null}
@@ -77,6 +79,8 @@ describe("GitPanelReviewBody loading vs empty split (Rung 4 / Q19)", () => {
       <GitPanelReviewBody
         changesFilter="working_tree_composite"
         baseRef={null}
+        cacheGeneration="generation-1"
+        metadataPending={false}
         isLoading={false}
         errorMessage={null}
         runtimeBlockedReason={null}

--- a/apps/packages/product-client/src/components/workspace/git/GitPanelReviewBody.tsx
+++ b/apps/packages/product-client/src/components/workspace/git/GitPanelReviewBody.tsx
@@ -21,6 +21,8 @@ import { useContentSearchStore } from "#product/stores/search/content-search-sto
 interface GitPanelReviewBodyProps {
   changesFilter: GitPanelMode;
   baseRef: string | null;
+  cacheGeneration: string;
+  metadataPending: boolean;
   isLoading: boolean;
   errorMessage: string | null;
   runtimeBlockedReason: string | null;
@@ -48,6 +50,8 @@ interface GitPanelReviewBodyProps {
 export function GitPanelReviewBody({
   changesFilter,
   baseRef,
+  cacheGeneration,
+  metadataPending,
   isLoading,
   errorMessage,
   runtimeBlockedReason,
@@ -145,6 +149,8 @@ export function GitPanelReviewBody({
                 sections={sections}
                 activeWorkspaceId={activeWorkspaceId}
                 baseRef={baseRef}
+                cacheGeneration={cacheGeneration}
+                metadataPending={metadataPending}
                 layout={layout}
                 wrapLongLines={wrapLongLines}
                 collapsedFiles={collapsedFiles}

--- a/apps/packages/product-client/src/components/workspace/git/GitPanelReviewSections.tsx
+++ b/apps/packages/product-client/src/components/workspace/git/GitPanelReviewSections.tsx
@@ -12,6 +12,8 @@ interface GitPanelReviewSectionsProps {
   sections: readonly GitPanelSection[];
   activeWorkspaceId: string | null;
   baseRef: string | null;
+  cacheGeneration: string;
+  metadataPending: boolean;
   layout: "unified" | "split";
   wrapLongLines: boolean;
   collapsedFiles: ReadonlySet<string>;
@@ -35,6 +37,8 @@ export function GitPanelReviewSections({
   sections,
   activeWorkspaceId,
   baseRef,
+  cacheGeneration,
+  metadataPending,
   layout,
   wrapLongLines,
   collapsedFiles,
@@ -63,6 +67,8 @@ export function GitPanelReviewSections({
               sectionScope={section.scope}
               file={file}
               baseRef={baseRef}
+              cacheGeneration={cacheGeneration}
+              metadataPending={metadataPending}
               layout={layout}
               wrapLongLines={wrapLongLines}
               collapsed={collapsedFiles.has(entry.key)}

--- a/apps/packages/product-client/src/components/workspace/git/GitReviewFileRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/git/GitReviewFileRow.tsx
@@ -1,13 +1,9 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import {
   type AnyHarnessQueryTimingOptions,
   useGitDiffQuery,
-  useRevertGitPatchesMutation,
-  useStagePatchMutation,
-  useUnstagePatchMutation,
 } from "@anyharness/sdk-react";
 import { DiffViewer } from "#product/components/content/ui/DiffViewer";
-import type { UnifiedDiffHunkActions } from "#product/components/content/ui/diff/UnifiedDiffViewer";
 import { CircleAlert } from "#product/primitives/icons/status";
 import { FileIcon } from "#product/primitives/icons/workspace";
 import { RefreshCw } from "#product/primitives/icons/platform";
@@ -18,9 +14,8 @@ import {
 } from "#product/components/workspace/git/GitReviewInlineState";
 import { GitReviewFileSectionShell } from "#product/components/workspace/git/GitReviewFileSectionShell";
 import { useLazyDiffFileLines } from "#product/hooks/ui/diff/use-lazy-diff-file-lines";
+import { useGitReviewHunkActions } from "#product/hooks/workspaces/workflows/files/use-git-review-hunk-actions";
 import type { MeasurementOperationId } from "#product/lib/domain/telemetry/debug-measurement-catalog";
-import { extractHunkPatch, isHunkActionEligible } from "#product/lib/domain/files/hunk-patch";
-import { useToastStore } from "#product/stores/toast/toast-store";
 import {
   DIFF_ROW_VIRTUALIZATION_LINE_THRESHOLD,
   resolveDiffDisplayPolicy,
@@ -43,6 +38,8 @@ export function GitReviewFileRow({
   sectionScope,
   file,
   baseRef,
+  cacheGeneration,
+  metadataPending,
   layout,
   wrapLongLines,
   collapsed,
@@ -61,6 +58,8 @@ export function GitReviewFileRow({
   sectionScope: GitPanelReviewScope;
   file: GitPanelReviewFile;
   baseRef: string | null;
+  cacheGeneration: string;
+  metadataPending: boolean;
   layout: "unified" | "split";
   wrapLongLines: boolean;
   collapsed: boolean;
@@ -78,15 +77,6 @@ export function GitReviewFileRow({
   const currentDiff = file.currentDiff;
   const isBranchMode = sectionScope === "branch";
   const isLastTurnMode = sectionScope === "last_turn";
-  const shouldUnstage = sectionScope === "staged";
-
-  // Hunk-level mutation hooks (lightweight — share the same query client)
-  const revertMutation = useRevertGitPatchesMutation({ workspaceId });
-  const stagePatchMutation = useStagePatchMutation({ workspaceId });
-  const unstagePatchMutation = useUnstagePatchMutation({ workspaceId });
-  const showToast = useToastStore((state) => state.show);
-  const hunkMutationInFlight =
-    revertMutation.isPending || stagePatchMutation.isPending || unstagePatchMutation.isPending;
   // Gap expansion reads the worktree file, which only matches the diff's
   // NEW side for worktree-target scopes: `unstaged` (worktree vs index) and
   // `last_turn`/`base_worktree` (worktree vs merge-base). `staged` diffs
@@ -114,16 +104,31 @@ export function GitReviewFileRow({
     scope: isLastTurnMode ? "base_worktree" : sectionScope,
     baseRef: isBranchMode || isLastTurnMode ? baseRef : null,
     oldPath: isBranchMode || isLastTurnMode ? file.oldPath : null,
+    cacheGeneration,
     enabled:
       isRuntimeReady
+      && !metadataPending
       && !collapsed
       && fetchDiff
       && Boolean(currentDiff)
       && Boolean(metadataPolicy?.canFetchInline),
     ...(diffTimingOptions ?? {}),
   });
-  const evidence = resolveGitPanelReviewEvidence(file, diffQuery.data);
-  const diffErrorMessage = currentDiff && diffQuery.isError
+  const currentDiffData = currentDiff
+    && !metadataPending
+    && !diffQuery.isFetching
+    && !diffQuery.isStale
+      ? diffQuery.data ?? null
+      : null;
+  const diffEvidencePending = metadataPending
+    || diffQuery.isLoading
+    || diffQuery.isFetching
+    || Boolean(!diffQuery.isError && diffQuery.isStale && diffQuery.data);
+  const evidence = resolveGitPanelReviewEvidence(file, currentDiffData);
+  const diffErrorMessage = currentDiff
+    && !metadataPending
+    && !diffQuery.isFetching
+    && diffQuery.isError
     ? formatDiffErrorMessage(diffQuery.error)
     : null;
   const { additions, deletions } = evidence;
@@ -157,8 +162,8 @@ export function GitReviewFileRow({
     && metadataPolicy?.canFetchInline
     && !fetchDiff
     && !patch
-    && !diffQuery.data
-    && !diffQuery.isError,
+    && !currentDiffData
+    && !diffErrorMessage,
   );
   // Opt large diffs into per-row content-visibility virtualization (the
   // [data-diff-row-virtualization] rule in design product.css): the diff
@@ -174,73 +179,34 @@ export function GitReviewFileRow({
     truncated: evidence.truncated && !patch,
   });
 
-  // Hunk-level actions: only for working-tree scopes (unstaged/staged) in
-  // unified layout, and only when the patch is complete and the file is not
-  // binary/rename/copy. Branch and last-turn diffs are excluded — their hunks
-  // are not guaranteed to apply against the current worktree/index.
-  const hunkActionsEnabled = Boolean(
-    patch
-    && !isBranchMode
-    && !isLastTurnMode
-    && layout === "unified"
-    && !evidence.truncated
-    && isHunkActionEligible(patch, file.oldPath)
-    && isRuntimeReady,
-  );
-
-  const handleHunkRevert = useCallback(
-    (hunkIndex: number) => {
-      if (!patch) return;
-      const result = extractHunkPatch({ patch, hunkIndex, filePath: file.path, oldPath: file.oldPath });
-      if (result) {
-        revertMutation
-          .mutateAsync({
-            entries: [{
-              path: file.path,
-              operation: "edit",
-              patch: result.patch,
-            }],
-          })
-          .catch((error: unknown) => {
-            showToast(formatHunkActionError(error, "Could not revert this change."));
-          });
-      }
-    },
-    [patch, file.path, file.oldPath, revertMutation, showToast],
-  );
-
-  const handleHunkStageOrUnstage = useCallback(
-    (hunkIndex: number) => {
-      if (!patch) return;
-      const result = extractHunkPatch({ patch, hunkIndex, filePath: file.path, oldPath: file.oldPath });
-      if (!result) return;
-      if (shouldUnstage) {
-        unstagePatchMutation.mutateAsync(result.patch).catch((error: unknown) => {
-          showToast(formatHunkActionError(error, "Could not unstage this change."));
-        });
-      } else {
-        stagePatchMutation.mutateAsync(result.patch).catch((error: unknown) => {
-          showToast(formatHunkActionError(error, "Could not stage this change."));
-        });
-      }
-    },
-    [patch, file.path, file.oldPath, shouldUnstage, stagePatchMutation, unstagePatchMutation, showToast],
-  );
-
-  const hunkActions: UnifiedDiffHunkActions | null = hunkActionsEnabled
-    ? {
-        mode: shouldUnstage ? "staged" : "unstaged",
-        disabled: !isRuntimeReady || hunkMutationInFlight,
-        onRevert: handleHunkRevert,
-        onStageOrUnstage: handleHunkStageOrUnstage,
-      }
-    : null;
+  const hunkActions = useGitReviewHunkActions({
+    workspaceId,
+    sectionScope,
+    file,
+    layout,
+    patch,
+    truncated: evidence.truncated,
+    isRuntimeReady,
+  });
 
   useEffect(() => {
-    if (currentDiff && (diffQuery.data || diffQuery.isError)) {
+    if (
+      currentDiff
+      && !metadataPending
+      && !diffQuery.isFetching
+      && (diffQuery.isError || (!diffQuery.isStale && diffQuery.data))
+    ) {
       onDiffFetchSettled();
     }
-  }, [currentDiff, diffQuery.data, diffQuery.isError, onDiffFetchSettled]);
+  }, [
+    currentDiff,
+    diffQuery.data,
+    diffQuery.isError,
+    diffQuery.isFetching,
+    diffQuery.isStale,
+    metadataPending,
+    onDiffFetchSettled,
+  ]);
 
   if (
     currentDiff
@@ -249,7 +215,7 @@ export function GitReviewFileRow({
     && fetchDiff
     && metadataPolicy?.canFetchInline
     && !patch
-    && !diffQuery.isLoading
+    && !diffEvidencePending
     && !diffErrorMessage
     && !emptyDiffState
   ) {
@@ -322,7 +288,7 @@ export function GitReviewFileRow({
             title="Waiting to load diff"
             description="This file will load when review capacity is available."
           />
-        ) : diffQuery.isLoading ? (
+        ) : diffEvidencePending ? (
           <GitReviewInlineEmptyState
             icon={<RefreshCw className="icon-paired animate-spin" />}
             title="Loading diff"
@@ -388,11 +354,4 @@ function formatDiffErrorMessage(error: unknown): string {
     return error;
   }
   return "Failed to load diff";
-}
-
-function formatHunkActionError(error: unknown, fallback: string): string {
-  if (error instanceof Error && error.message.trim()) {
-    return error.message;
-  }
-  return fallback;
 }

--- a/apps/packages/product-client/src/components/workspace/git/RecordedLastTurnDiffs.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/git/RecordedLastTurnDiffs.test.tsx
@@ -58,6 +58,7 @@ vi.mock("#product/hooks/chat/cache/use-turn-current-file-diffs", () => ({
       currentDiff: input.file.currentDiff,
       metadataPolicy: null,
       diffQuery: gitDiffQuery.state,
+      diffData: input.file.currentDiff ? gitDiffQuery.state.data : null,
       diffErrorMessage: "stale query error",
       additions: 99,
       deletions: 88,
@@ -177,9 +178,10 @@ describe("recorded Last turn diff continuity", () => {
         turnId="turn-1"
         workspaceId="workspace-1"
         baseRef="origin/main"
+        cacheGeneration="generation-1"
         isRuntimeReady
         runtimeBlockedReason={null}
-        metadataLoading={false}
+        metadataPending={false}
         metadataErrorMessage={null}
         fallbackAdditions={5_001}
         fallbackDeletions={0}
@@ -246,10 +248,12 @@ function currentDiffState(files: GitPanelReviewFile[]) {
   return {
     activeWorkspaceId: "workspace-1",
     baseRef: "origin/main",
+    cacheGeneration: "generation-1",
     files,
     isRuntimeReady: true,
     runtimeBlockedReason: null,
     isLoading: false,
+    metadataPending: false,
     errorMessage: null,
   };
 }
@@ -307,6 +311,8 @@ function reviewRow(
       sectionScope="last_turn"
       file={file}
       baseRef="origin/main"
+      cacheGeneration="generation-1"
+      metadataPending={false}
       layout="unified"
       wrapLongLines={false}
       collapsed={false}

--- a/apps/packages/product-client/src/hooks/chat/cache/use-turn-current-file-diffs.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/cache/use-turn-current-file-diffs.test.tsx
@@ -14,6 +14,8 @@ const staleDiffQuery = vi.hoisted(() => ({
   error: new Error("stale query error"),
   isError: true,
   isLoading: false,
+  isFetching: false,
+  isStale: false,
 }));
 
 vi.mock("@anyharness/sdk-react", async (importOriginal) => ({
@@ -25,14 +27,19 @@ describe("useTurnCurrentFilePatch", () => {
   it("clears stale live-query evidence after the current diff disappears", () => {
     const file = reviewFile();
     const { result, rerender } = renderHook(
-      ({ currentFile }: { currentFile: GitPanelReviewFile }) =>
+      ({ currentFile, metadataPending }: {
+        currentFile: GitPanelReviewFile;
+        metadataPending: boolean;
+      }) =>
         useTurnCurrentFilePatch({
           file: currentFile,
           workspaceId: "workspace-1",
           baseRef: "origin/main",
+          cacheGeneration: "generation-1",
+          metadataPending,
           enabled: true,
         }),
-      { initialProps: { currentFile: file } },
+      { initialProps: { currentFile: file, metadataPending: false } },
     );
 
     expect(result.current).toMatchObject({
@@ -43,7 +50,18 @@ describe("useTurnCurrentFilePatch", () => {
     });
     expect(result.current.patchPolicy).not.toBeNull();
 
-    rerender({ currentFile: { ...file, currentDiff: null } });
+    rerender({ currentFile: file, metadataPending: true });
+
+    expect(result.current).toMatchObject({
+      additions: 5,
+      deletions: 2,
+      patch: null,
+      diffData: null,
+      diffErrorMessage: null,
+    });
+    expect(result.current.patchPolicy).toMatchObject({ patchLineCount: 0 });
+
+    rerender({ currentFile: { ...file, currentDiff: null }, metadataPending: false });
 
     expect(result.current).toMatchObject({
       currentDiff: null,

--- a/apps/packages/product-client/src/hooks/chat/cache/use-turn-current-file-diffs.ts
+++ b/apps/packages/product-client/src/hooks/chat/cache/use-turn-current-file-diffs.ts
@@ -6,10 +6,12 @@ import type {
 } from "@anyharness/sdk";
 import {
   useGitBaseWorktreeDiffFilesQuery,
+  useGitCacheForceEpoch,
   useGitDiffQuery,
   useGitStatusQuery,
 } from "@anyharness/sdk-react";
 import { useMemo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useIsHotPaintGatePendingForWorkspace } from "#product/hooks/workspaces/derived/use-hot-paint-gate";
 import { useWorkspaceRuntimeBlock } from "#product/hooks/workspaces/derived/use-workspace-runtime-block";
 import { useWorkspaces } from "#product/hooks/workspaces/cache/use-workspaces";
@@ -25,6 +27,12 @@ import { resolveGitPanelWorkspaceContext } from "#product/lib/domain/workspaces/
 import { useRepoPreferencesStore } from "#product/stores/preferences/repo-preferences-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { collectTurnTouchedFiles } from "#product/domain/chats/transcript/last-turn-file-changes";
+import {
+  buildChangesCacheGeneration,
+  buildChangesMetadataFingerprint,
+  buildChangesMetadataListCacheGeneration,
+} from "#product/lib/domain/workspaces/changes/changes-cache-generation";
+import { observeChangesMetadata } from "#product/hooks/workspaces/cache/changes-cache-observation";
 
 const EMPTY_STATUS_FILES: GitChangedFile[] = [];
 const EMPTY_BRANCH_FILES: GitDiffFile[] = [];
@@ -42,9 +50,11 @@ export function useTurnCurrentFileDiffs({
   transcript: TranscriptState;
   workspaceId: string | null;
 }) {
+  const queryClient = useQueryClient();
   const selectedLogicalWorkspaceId = useSessionSelectionStore(
     (state) => state.selectedLogicalWorkspaceId,
   );
+  const forceEpoch = useGitCacheForceEpoch({ workspaceId });
   const runtimeBlockWorkspaceId = gitPanelRuntimeBlockWorkspaceId(
     workspaceId,
     selectedLogicalWorkspaceId,
@@ -76,6 +86,7 @@ export function useTurnCurrentFileDiffs({
   const gitStatusQuery = useGitStatusQuery({
     workspaceId,
     enabled: isRuntimeReady && !hotPaintPending && touchedFiles.length > 0,
+    staleTime: Infinity,
   });
   const baseRef = resolveGitPanelBaseRef({
     repoPreferenceDefaultBranch: savedDefaultBranch,
@@ -86,6 +97,11 @@ export function useTurnCurrentFileDiffs({
   const baseWorktreeFilesQuery = useGitBaseWorktreeDiffFilesQuery({
     workspaceId,
     baseRef: activeBaseRef,
+    cacheGeneration: buildChangesMetadataListCacheGeneration({
+      forceEpoch,
+      completedTurnId: turn.turnId,
+    }),
+    staleTime: Infinity,
     enabled:
       isRuntimeReady
       && !hotPaintPending
@@ -104,14 +120,42 @@ export function useTurnCurrentFileDiffs({
     [baseWorktreeFiles, touchedFiles],
   );
   const error = baseWorktreeFilesQuery.error ?? gitStatusQuery.error;
+  const semanticFingerprint = useMemo(
+    () => buildChangesMetadataFingerprint(baseWorktreeFilesQuery.data),
+    [baseWorktreeFilesQuery.data],
+  );
+  const observationToken = observeChangesMetadata({
+    queryClient,
+    scopeKey: `turn-current-diffs:${workspaceId ?? ""}:${turn.turnId}`,
+    forceEpoch,
+    semanticFingerprint,
+  });
+  const cacheGeneration = useMemo(
+    () => buildChangesCacheGeneration({
+      kind: "last_turn",
+      semanticFingerprint,
+      observationToken,
+      forceEpoch,
+      completedTurnId: turn.turnId,
+    }),
+    [forceEpoch, observationToken, semanticFingerprint, turn.turnId],
+  );
+  const metadataPending = gitStatusQuery.isFetching
+    || gitStatusQuery.isStale
+    || gitStatusQuery.isError
+    || baseWorktreeFilesQuery.isFetching
+    || baseWorktreeFilesQuery.isStale
+    || baseWorktreeFilesQuery.isError;
 
   return {
     activeWorkspaceId: workspaceId,
     baseRef: activeBaseRef,
+    cacheGeneration,
     files: sections[0]?.files ?? [],
     isRuntimeReady,
     runtimeBlockedReason,
     isLoading: baseWorktreeFilesQuery.isLoading || gitStatusQuery.isLoading,
+    metadataPending,
     errorMessage: error instanceof Error ? error.message : null,
   };
 }
@@ -120,11 +164,15 @@ export function useTurnCurrentFilePatch({
   file,
   workspaceId,
   baseRef,
+  cacheGeneration,
+  metadataPending,
   enabled,
 }: {
   file: GitPanelReviewFile;
   workspaceId: string | null;
   baseRef: string | null;
+  cacheGeneration: string;
+  metadataPending: boolean;
   enabled: boolean;
 }) {
   const currentDiff = file.currentDiff;
@@ -144,14 +192,26 @@ export function useTurnCurrentFilePatch({
     scope: "base_worktree",
     baseRef,
     oldPath: file.oldPath,
+    cacheGeneration,
     enabled:
       enabled
+      && !metadataPending
       && Boolean(currentDiff)
       && Boolean(metadataPolicy?.canFetchInline),
   });
-  const additions = currentDiff ? diffQuery.data?.additions ?? currentDiff.additions : 0;
-  const deletions = currentDiff ? diffQuery.data?.deletions ?? currentDiff.deletions : 0;
-  const patch = currentDiff ? diffQuery.data?.patch ?? null : null;
+  const diffData = currentDiff
+    && !metadataPending
+    && !diffQuery.isFetching
+    && !diffQuery.isStale
+      ? diffQuery.data ?? null
+      : null;
+  const diffPending = metadataPending
+    || diffQuery.isLoading
+    || diffQuery.isFetching
+    || Boolean(!diffQuery.isError && diffQuery.isStale && diffQuery.data);
+  const additions = currentDiff ? diffData?.additions ?? currentDiff.additions : 0;
+  const deletions = currentDiff ? diffData?.deletions ?? currentDiff.deletions : 0;
+  const patch = currentDiff ? diffData?.patch ?? null : null;
   const patchPolicy = useMemo(
     () => patch
       ? resolveDiffDisplayPolicy({
@@ -168,7 +228,12 @@ export function useTurnCurrentFilePatch({
     currentDiff,
     metadataPolicy,
     diffQuery,
-    diffErrorMessage: currentDiff && diffQuery.isError
+    diffData,
+    diffPending,
+    diffErrorMessage: currentDiff
+      && !metadataPending
+      && !diffQuery.isFetching
+      && diffQuery.isError
       ? formatDiffErrorMessage(diffQuery.error)
       : null,
     additions,

--- a/apps/packages/product-client/src/hooks/sessions/cache/use-session-stream-cache.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/cache/use-session-stream-cache.test.ts
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 
 import { createElement, type ReactNode } from "react";
-import { act, cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   AnyHarnessRuntime,
   anyHarnessCoworkManagedWorkspacesKey,
   anyHarnessGitStatusKey,
+  readGitCacheForceEpoch,
   anyHarnessRuntimeKey,
   anyHarnessSessionReviewsKey,
   anyHarnessSessionSubagentsKey,
@@ -55,8 +56,8 @@ describe("useSessionStreamCache", () => {
     ]);
   });
 
-  it("preserves the other stream-triggered invalidation keys", () => {
-    const { invalidateQueries, result } = renderStreamCache();
+  it("preserves invalidation keys and advances Git evidence after status settles", async () => {
+    const { invalidateQueries, queryClient, result } = renderStreamCache();
 
     act(() => {
       result.current.invalidateWorkspaceCollections(RUNTIME_URL);
@@ -98,6 +99,9 @@ describe("useSessionStreamCache", () => {
         queryKey: anyHarnessGitStatusKey(CACHE_SCOPE_KEY, "workspace-1"),
       },
     ]);
+    await waitFor(() => expect(
+      readGitCacheForceEpoch(queryClient, CACHE_SCOPE_KEY, "workspace-1"),
+    ).toBe(1));
   });
 });
 
@@ -118,5 +122,5 @@ function renderStreamCache() {
     }),
   );
   const { result } = renderHook(() => useSessionStreamCache(), { wrapper });
-  return { invalidateQueries, result };
+  return { invalidateQueries, queryClient, result };
 }

--- a/apps/packages/product-client/src/hooks/sessions/cache/use-session-stream-cache.ts
+++ b/apps/packages/product-client/src/hooks/sessions/cache/use-session-stream-cache.ts
@@ -1,4 +1,5 @@
 import {
+  advanceGitCacheForceEpoch,
   anyHarnessCoworkManagedWorkspacesKey,
   anyHarnessRuntimeKey,
   anyHarnessGitStatusKey,
@@ -93,7 +94,10 @@ export function useSessionStreamCache(): SessionStreamCache {
     invalidateGitStatus({ workspaceId }) {
       void queryClient.invalidateQueries({
         queryKey: anyHarnessGitStatusKey(cacheScopeKey, workspaceId),
-      });
+      }).then(
+        () => advanceGitCacheForceEpoch(queryClient, cacheScopeKey, workspaceId),
+        () => undefined,
+      );
     },
     refreshPrStatuses({ runtimeUrl, workspaceId }) {
       // Resolve the workspace's repo root from the cached collections; a

--- a/apps/packages/product-client/src/hooks/workspaces/cache/changes-cache-observation.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/cache/changes-cache-observation.test.ts
@@ -1,0 +1,53 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+import { observeChangesMetadata } from "./changes-cache-observation";
+import { buildChangesMetadataFingerprint } from "#product/lib/domain/workspaces/changes/changes-cache-generation";
+
+describe("observeChangesMetadata", () => {
+  it("distinguishes an ABA sequence while unchanged query updates and remount reads stay stable", () => {
+    const queryClient = new QueryClient();
+    const metadataKey = ["metadata", "workspace-1"] as const;
+    const m1 = metadata("modified");
+    const m2 = metadata("added");
+
+    queryClient.setQueryData(metadataKey, m1);
+    const firstM1 = observeCurrent(queryClient, metadataKey);
+    queryClient.setQueryData(metadataKey, { ...m1, files: [...m1.files] });
+    const unchangedPoll = observeCurrent(queryClient, metadataKey);
+    queryClient.setQueryData(metadataKey, m2);
+    const observedM2 = observeCurrent(queryClient, metadataKey);
+    queryClient.setQueryData(metadataKey, { ...m1, files: [...m1.files] });
+    const finalM1 = observeCurrent(queryClient, metadataKey);
+
+    expect([firstM1, unchangedPoll, observedM2, finalM1]).toEqual([0, 0, 1, 2]);
+    expect(observeCurrent(queryClient, metadataKey)).toBe(finalM1);
+  });
+});
+
+function observeCurrent(
+  queryClient: QueryClient,
+  metadataKey: readonly unknown[],
+): number {
+  return observeChangesMetadata({
+    queryClient,
+    scopeKey: "git-panel:workspace-1:working-tree",
+    forceEpoch: 0,
+    semanticFingerprint: buildChangesMetadataFingerprint(
+      queryClient.getQueryData<ReturnType<typeof metadata>>(metadataKey),
+    ),
+  });
+}
+
+function metadata(status: string) {
+  return {
+    files: [{
+      path: "src/app.ts",
+      oldPath: null,
+      status,
+      includedState: "excluded",
+      additions: 1,
+      deletions: 1,
+      binary: false,
+    }],
+  };
+}

--- a/apps/packages/product-client/src/hooks/workspaces/cache/changes-cache-observation.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/cache/changes-cache-observation.ts
@@ -1,0 +1,49 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+interface ChangesMetadataObservation {
+  forceEpoch: number;
+  semanticFingerprint: string;
+  token: number;
+}
+
+const observationsByQueryClient = new WeakMap<
+  QueryClient,
+  Map<string, ChangesMetadataObservation>
+>();
+
+export function observeChangesMetadata({
+  queryClient,
+  scopeKey,
+  forceEpoch,
+  semanticFingerprint,
+}: {
+  queryClient: QueryClient;
+  scopeKey: string;
+  forceEpoch: number;
+  semanticFingerprint: string;
+}): number {
+  let observations = observationsByQueryClient.get(queryClient);
+  if (!observations) {
+    observations = new Map();
+    observationsByQueryClient.set(queryClient, observations);
+  }
+  const current = observations.get(scopeKey);
+  if (!current || current.forceEpoch !== forceEpoch) {
+    observations.set(scopeKey, {
+      forceEpoch,
+      semanticFingerprint,
+      token: 0,
+    });
+    return 0;
+  }
+  if (current.semanticFingerprint === semanticFingerprint) {
+    return current.token;
+  }
+  const next = {
+    forceEpoch,
+    semanticFingerprint,
+    token: current.token + 1,
+  };
+  observations.set(scopeKey, next);
+  return next.token;
+}

--- a/apps/packages/product-client/src/hooks/workspaces/cache/use-git-panel-state.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/cache/use-git-panel-state.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useGitPanelState } from "#product/hooks/workspaces/cache/use-git-panel-state";
+
+const sdk = vi.hoisted(() => ({
+  advanceForceEpoch: vi.fn(() => 1),
+  status: queryState({
+    files: [{
+      path: "src/app.ts",
+      oldPath: null,
+      status: "modified",
+      includedState: "excluded",
+      additions: 1,
+      deletions: 1,
+      binary: false,
+    }],
+    suggestedBaseBranch: "origin/main",
+  }),
+  branches: queryState([]),
+  branchFiles: queryState({
+    baseRef: "origin/main",
+    resolvedBaseOid: "base",
+    mergeBaseOid: "merge",
+    headOid: "head",
+    files: [],
+  }),
+  baseWorktreeFiles: queryState({
+    baseRef: "origin/main",
+    resolvedBaseOid: "base",
+    mergeBaseOid: "merge",
+    headOid: "head",
+    files: [],
+  }),
+}));
+
+vi.mock("@anyharness/sdk-react", () => ({
+  useGitCacheForceEpoch: () => 0,
+  useAdvanceGitCacheForceEpoch: () => sdk.advanceForceEpoch,
+  useGitStatusQuery: () => sdk.status,
+  useGitBranchesQuery: () => sdk.branches,
+  useGitBranchDiffFilesQuery: () => sdk.branchFiles,
+  useGitBaseWorktreeDiffFilesQuery: () => sdk.baseWorktreeFiles,
+}));
+
+vi.mock("#product/hooks/workspaces/derived/use-hot-paint-gate", () => ({
+  useIsHotPaintGatePendingForWorkspace: () => false,
+}));
+
+vi.mock("#product/hooks/workspaces/derived/use-workspace-runtime-block", () => ({
+  useWorkspaceRuntimeBlock: () => ({ getWorkspaceRuntimeBlockReason: () => null }),
+}));
+
+vi.mock("#product/hooks/workspaces/cache/use-workspaces", () => ({
+  useWorkspaces: () => ({ data: undefined }),
+}));
+
+vi.mock("#product/stores/preferences/repo-preferences-store", () => ({
+  useRepoPreferencesStore: (
+    selector: (state: { repoConfigs: Record<string, never> }) => unknown,
+  ) => selector({ repoConfigs: {} }),
+}));
+
+vi.mock("#product/stores/sessions/session-selection-store", () => ({
+  useSessionSelectionStore: (
+    selector: (state: {
+      selectedWorkspaceId: string;
+      selectedLogicalWorkspaceId: null;
+      activeSessionId: null;
+    }) => unknown,
+  ) => selector({
+    selectedWorkspaceId: "workspace-1",
+    selectedLogicalWorkspaceId: null,
+    activeSessionId: null,
+  }),
+}));
+
+vi.mock("#product/stores/sessions/session-transcript-store", () => ({
+  useSessionTranscriptStore: (
+    selector: (state: { entriesById: Record<string, never> }) => unknown,
+  ) => selector({ entriesById: {} }),
+}));
+
+afterEach(cleanup);
+
+describe("useGitPanelState refresh coherence", () => {
+  beforeEach(() => {
+    sdk.advanceForceEpoch.mockClear();
+    sdk.status.data = workingTreeMetadata("modified");
+    for (const query of [sdk.status, sdk.branches, sdk.branchFiles, sdk.baseWorktreeFiles]) {
+      query.error = null;
+      query.isError = false;
+      query.refetch.mockReset().mockResolvedValue({ isError: false });
+    }
+  });
+
+  it("returns and renders a branch-list refresh failure without advancing the epoch", async () => {
+    const refreshError = new Error("Could not refresh branches");
+    sdk.branches.error = refreshError;
+    sdk.branches.isError = true;
+    sdk.branches.refetch.mockResolvedValue({ isError: true });
+    const queryClient = new QueryClient();
+    const { result } = renderHook(() => useGitPanelState("branch"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.errorMessage).toBe(refreshError.message);
+    let refreshed: boolean | undefined;
+    await act(async () => {
+      refreshed = await result.current.refetch();
+    });
+    expect(refreshed).toBe(false);
+    expect(sdk.status.refetch).toHaveBeenCalledTimes(1);
+    expect(sdk.branches.refetch).toHaveBeenCalledTimes(1);
+    expect(sdk.branchFiles.refetch).toHaveBeenCalledTimes(1);
+    expect(sdk.advanceForceEpoch).not.toHaveBeenCalled();
+  });
+
+  it("keeps unchanged polls stable and assigns a third generation to M1 after M1-M2-M1", () => {
+    const queryClient = new QueryClient();
+    const wrapper = createWrapper(queryClient);
+    sdk.status.data = workingTreeMetadata("modified");
+    const view = renderHook(() => useGitPanelState("working_tree_composite"), { wrapper });
+    const firstM1 = view.result.current.cacheGeneration;
+
+    sdk.status.data = {
+      ...sdk.status.data,
+      files: sdk.status.data.files.map((file) => ({ ...file })),
+    };
+    view.rerender();
+    expect(view.result.current.cacheGeneration).toBe(firstM1);
+
+    sdk.status.data = workingTreeMetadata("added");
+    view.rerender();
+    const observedM2 = view.result.current.cacheGeneration;
+    expect(observedM2).not.toBe(firstM1);
+
+    sdk.status.data = workingTreeMetadata("modified");
+    view.rerender();
+    const finalM1 = view.result.current.cacheGeneration;
+    expect(finalM1).not.toBe(firstM1);
+    expect(finalM1).not.toBe(observedM2);
+
+    view.unmount();
+    const remount = renderHook(() => useGitPanelState("working_tree_composite"), { wrapper });
+    expect(remount.result.current.cacheGeneration).toBe(finalM1);
+  });
+});
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function workingTreeMetadata(status: string) {
+  return {
+    files: [{
+      path: "src/app.ts",
+      oldPath: null,
+      status,
+      includedState: "excluded",
+      additions: 1,
+      deletions: 1,
+      binary: false,
+    }],
+    suggestedBaseBranch: "origin/main",
+  };
+}
+
+function queryState<T>(data: T) {
+  return {
+    data,
+    error: null as Error | null,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    isStale: false,
+    refetch: vi.fn(async () => ({ isError: false })),
+  };
+}

--- a/apps/packages/product-client/src/hooks/workspaces/cache/use-git-panel-state.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/cache/use-git-panel-state.ts
@@ -1,12 +1,15 @@
 import type { GitChangedFile, GitDiffFile } from "@anyharness/sdk";
 import {
   type AnyHarnessQueryTimingOptions,
+  useAdvanceGitCacheForceEpoch,
   useGitBaseWorktreeDiffFilesQuery,
   useGitBranchDiffFilesQuery,
   useGitBranchesQuery,
+  useGitCacheForceEpoch,
   useGitStatusQuery,
 } from "@anyharness/sdk-react";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useIsHotPaintGatePendingForWorkspace } from "#product/hooks/workspaces/derived/use-hot-paint-gate";
 import { useWorkspaceRuntimeBlock } from "#product/hooks/workspaces/derived/use-workspace-runtime-block";
 import { useWorkspaces } from "#product/hooks/workspaces/cache/use-workspaces";
@@ -26,6 +29,13 @@ import { useSessionSelectionStore } from "#product/stores/sessions/session-selec
 import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
 import { collectLatestCompletedTurnTouchedFiles } from "#product/domain/chats/transcript/last-turn-file-changes";
 import { collectTurnFileRevertPatchEntries } from "#product/domain/chats/transcript/turn-file-patches";
+import {
+  buildChangesCacheGeneration,
+  buildChangesMetadataFingerprint,
+  buildChangesMetadataListCacheGeneration,
+} from "#product/lib/domain/workspaces/changes/changes-cache-generation";
+import { refreshGitPanelMetadata } from "#product/lib/workflows/workspaces/changes/refresh-git-panel-metadata";
+import { observeChangesMetadata } from "#product/hooks/workspaces/cache/changes-cache-observation";
 
 const EMPTY_STATUS_FILES: GitChangedFile[] = [];
 const EMPTY_BRANCH_FILES: GitDiffFile[] = [];
@@ -37,8 +47,8 @@ interface GitPanelStateOptions {
   branchDiffFilesTimingOptions?: AnyHarnessQueryTimingOptions;
 }
 
-// Owns read-only Git panel state for changed-file surfaces. Git mutations stay
-// in the component/action hooks that own the user intent.
+// Owns the composed Git panel cache, including its explicit refresh boundary.
+// Git mutations stay in the access hooks that own the user intent.
 export function useGitPanelState(
   mode: GitPanelMode,
   options?: GitPanelStateOptions,
@@ -52,6 +62,9 @@ export function useGitPanelState(
     activeSessionId ? state.entriesById[activeSessionId]?.transcript ?? null : null
   );
   const activeWorkspaceId = selectedWorkspaceId;
+  const queryClient = useQueryClient();
+  const forceEpoch = useGitCacheForceEpoch({ workspaceId: activeWorkspaceId });
+  const advanceForceEpoch = useAdvanceGitCacheForceEpoch({ workspaceId: activeWorkspaceId });
   const runtimeBlockWorkspaceId = gitPanelRuntimeBlockWorkspaceId(
     selectedWorkspaceId,
     selectedLogicalWorkspaceId,
@@ -80,6 +93,7 @@ export function useGitPanelState(
   const gitStatusQuery = useGitStatusQuery({
     workspaceId: activeWorkspaceId,
     enabled: isRuntimeReady && !hotPaintPending,
+    staleTime: Infinity,
     ...(options?.statusTimingOptions ?? {}),
   });
 
@@ -92,12 +106,6 @@ export function useGitPanelState(
     ?? baseRef
     ?? DEFAULT_REVIEW_BASE_REF;
 
-  const branchFilesQuery = useGitBranchDiffFilesQuery({
-    workspaceId: activeWorkspaceId,
-    baseRef: activeBaseRef,
-    enabled: isRuntimeReady && !hotPaintPending && mode === "branch",
-    ...(options?.branchDiffFilesTimingOptions ?? {}),
-  });
   const lastTurnTouched = useMemo(
     () => collectLatestCompletedTurnTouchedFiles(activeTranscript),
     [activeTranscript],
@@ -108,9 +116,22 @@ export function useGitPanelState(
       : { entries: [], blockedReason: null },
     [activeTranscript, lastTurnTouched.turn],
   );
+  const branchFilesQuery = useGitBranchDiffFilesQuery({
+    workspaceId: activeWorkspaceId,
+    baseRef: activeBaseRef,
+    cacheGeneration: buildChangesMetadataListCacheGeneration({ forceEpoch }),
+    staleTime: Infinity,
+    enabled: isRuntimeReady && !hotPaintPending && mode === "branch",
+    ...(options?.branchDiffFilesTimingOptions ?? {}),
+  });
   const baseWorktreeFilesQuery = useGitBaseWorktreeDiffFilesQuery({
     workspaceId: activeWorkspaceId,
     baseRef: activeBaseRef,
+    cacheGeneration: buildChangesMetadataListCacheGeneration({
+      forceEpoch,
+      completedTurnId: lastTurnTouched.turn?.turnId ?? null,
+    }),
+    staleTime: Infinity,
     enabled: isRuntimeReady
       && !hotPaintPending
       && mode === "last_turn"
@@ -146,6 +167,50 @@ export function useGitPanelState(
     [baseWorktreeFiles, branchFiles, lastTurnTouched.files, mode, statusFiles],
   );
   const branchRefs = branchesQuery.data ?? [];
+  const evidenceKind = mode === "branch"
+    ? "branch"
+    : mode === "last_turn"
+      ? "last_turn"
+      : "working_tree";
+  const generationMetadata = mode === "branch"
+    ? branchFilesQuery.data
+    : mode === "last_turn"
+      ? baseWorktreeFilesQuery.data
+      : gitStatusQuery.data;
+  const semanticFingerprint = useMemo(
+    () => buildChangesMetadataFingerprint(generationMetadata),
+    [generationMetadata],
+  );
+  const observationToken = observeChangesMetadata({
+    queryClient,
+    scopeKey: `git-panel:${activeWorkspaceId ?? ""}:${evidenceKind}`,
+    forceEpoch,
+    semanticFingerprint,
+  });
+  const cacheGeneration = useMemo(() => {
+    return buildChangesCacheGeneration({
+      kind: evidenceKind,
+      semanticFingerprint,
+      observationToken,
+      forceEpoch,
+      completedTurnId: evidenceKind === "last_turn"
+        ? lastTurnTouched.turn?.turnId ?? null
+        : null,
+    });
+  }, [
+    evidenceKind,
+    forceEpoch,
+    lastTurnTouched.turn?.turnId,
+    observationToken,
+    semanticFingerprint,
+  ]);
+  const metadataPending = mode === "branch"
+    ? branchFilesQuery.isFetching || branchFilesQuery.isStale || branchFilesQuery.isError
+    : mode === "last_turn"
+      ? baseWorktreeFilesQuery.isFetching
+        || baseWorktreeFilesQuery.isStale
+        || baseWorktreeFilesQuery.isError
+      : gitStatusQuery.isFetching || gitStatusQuery.isStale || gitStatusQuery.isError;
 
   const totalChangedCount = mode === "branch" || mode === "last_turn"
     ? sections.reduce((count, section) => count + section.files.length, 0)
@@ -157,11 +222,32 @@ export function useGitPanelState(
       ? baseWorktreeFilesQuery.isLoading
       : gitStatusQuery.isLoading;
   const error = mode === "branch"
-    ? branchFilesQuery.error ?? gitStatusQuery.error
+    ? branchFilesQuery.error ?? gitStatusQuery.error ?? branchesQuery.error
     : mode === "last_turn"
-      ? baseWorktreeFilesQuery.error ?? gitStatusQuery.error
-      : gitStatusQuery.error;
+      ? baseWorktreeFilesQuery.error ?? gitStatusQuery.error ?? branchesQuery.error
+      : gitStatusQuery.error ?? branchesQuery.error;
   const errorMessage = error instanceof Error ? error.message : null;
+  const refetch = useCallback(async () => {
+    const refreshes: Array<() => Promise<{ isError: boolean }>> = [
+      () => gitStatusQuery.refetch(),
+      () => branchesQuery.refetch(),
+    ];
+    if (mode === "branch") {
+      refreshes.push(() => branchFilesQuery.refetch());
+    }
+    if (mode === "last_turn" && lastTurnTouched.files.length > 0) {
+      refreshes.push(() => baseWorktreeFilesQuery.refetch());
+    }
+    return refreshGitPanelMetadata({ refreshes, advanceForceEpoch });
+  }, [
+    advanceForceEpoch,
+    baseWorktreeFilesQuery.refetch,
+    branchFilesQuery.refetch,
+    branchesQuery.refetch,
+    gitStatusQuery.refetch,
+    lastTurnTouched.files.length,
+    mode,
+  ]);
 
   return {
     activeWorkspaceId,
@@ -175,22 +261,15 @@ export function useGitPanelState(
       ? sections.reduce((count, section) => count + section.files.length, 0)
       : files.length,
     activeFilterLabel,
+    cacheGeneration,
+    metadataPending,
     lastTurn: lastTurnTouched.turn,
     lastTurnRevertPatches,
     isRuntimeReady,
     runtimeBlockedReason,
     isLoading: loading,
     errorMessage,
-    refetch: async () => {
-      await gitStatusQuery.refetch();
-      await branchesQuery.refetch();
-      if (mode === "branch") {
-        await branchFilesQuery.refetch();
-      }
-      if (mode === "last_turn" && lastTurnTouched.files.length > 0) {
-        await baseWorktreeFilesQuery.refetch();
-      }
-    },
+    refetch,
   };
 }
 

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-git-review-hunk-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-git-review-hunk-actions.ts
@@ -1,0 +1,109 @@
+import { useCallback } from "react";
+import {
+  useRevertGitPatchesMutation,
+  useStagePatchMutation,
+  useUnstagePatchMutation,
+} from "@anyharness/sdk-react";
+import {
+  extractHunkPatch,
+  isHunkActionEligible,
+  type UnifiedDiffHunkActions,
+} from "#product/lib/domain/files/hunk-patch";
+import type {
+  GitPanelReviewFile,
+  GitPanelReviewScope,
+} from "#product/lib/domain/workspaces/changes/git-panel-diff";
+import { useToastStore } from "#product/stores/toast/toast-store";
+
+export function useGitReviewHunkActions({
+  workspaceId,
+  sectionScope,
+  file,
+  layout,
+  patch,
+  truncated,
+  isRuntimeReady,
+}: {
+  workspaceId: string | null;
+  sectionScope: GitPanelReviewScope;
+  file: GitPanelReviewFile;
+  layout: "unified" | "split";
+  patch: string | null;
+  truncated: boolean;
+  isRuntimeReady: boolean;
+}): UnifiedDiffHunkActions | null {
+  const revertMutation = useRevertGitPatchesMutation({ workspaceId });
+  const stagePatchMutation = useStagePatchMutation({ workspaceId });
+  const unstagePatchMutation = useUnstagePatchMutation({ workspaceId });
+  const showToast = useToastStore((state) => state.show);
+  const shouldUnstage = sectionScope === "staged";
+  const actionsEnabled = Boolean(
+    patch
+    && sectionScope !== "branch"
+    && sectionScope !== "last_turn"
+    && layout === "unified"
+    && !truncated
+    && isHunkActionEligible(patch, file.oldPath)
+    && isRuntimeReady,
+  );
+  const mutationInFlight =
+    revertMutation.isPending || stagePatchMutation.isPending || unstagePatchMutation.isPending;
+
+  const handleRevert = useCallback((hunkIndex: number) => {
+    if (!patch) return;
+    const result = extractHunkPatch({
+      patch,
+      hunkIndex,
+      filePath: file.path,
+      oldPath: file.oldPath,
+    });
+    if (!result) return;
+    revertMutation.mutateAsync({
+      entries: [{ path: file.path, operation: "edit", patch: result.patch }],
+    }).catch((error: unknown) => {
+      showToast(formatHunkActionError(error, "Could not revert this change."));
+    });
+  }, [file.oldPath, file.path, patch, revertMutation, showToast]);
+
+  const handleStageOrUnstage = useCallback((hunkIndex: number) => {
+    if (!patch) return;
+    const result = extractHunkPatch({
+      patch,
+      hunkIndex,
+      filePath: file.path,
+      oldPath: file.oldPath,
+    });
+    if (!result) return;
+    const mutation = shouldUnstage ? unstagePatchMutation : stagePatchMutation;
+    mutation.mutateAsync(result.patch).catch((error: unknown) => {
+      showToast(formatHunkActionError(
+        error,
+        shouldUnstage ? "Could not unstage this change." : "Could not stage this change.",
+      ));
+    });
+  }, [
+    file.oldPath,
+    file.path,
+    patch,
+    shouldUnstage,
+    showToast,
+    stagePatchMutation,
+    unstagePatchMutation,
+  ]);
+
+  return actionsEnabled
+    ? {
+        mode: shouldUnstage ? "staged" : "unstaged",
+        disabled: !isRuntimeReady || mutationInFlight,
+        onRevert: handleRevert,
+        onStageOrUnstage: handleStageOrUnstage,
+      }
+    : null;
+}
+
+function formatHunkActionError(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+  return fallback;
+}

--- a/apps/packages/product-client/src/lib/domain/files/hunk-patch.ts
+++ b/apps/packages/product-client/src/lib/domain/files/hunk-patch.ts
@@ -9,6 +9,15 @@
 // never contains the literal `@/` substring the frontend-boundary scanner flags.
 const HUNK_RANGE_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @[@]/;
 
+export type HunkActionMode = "unstaged" | "staged";
+
+export interface UnifiedDiffHunkActions {
+  mode: HunkActionMode;
+  disabled: boolean;
+  onRevert: (hunkIndex: number) => void;
+  onStageOrUnstage: (hunkIndex: number) => void;
+}
+
 export interface HunkPatchOptions {
   /** The full patch text as returned by the diff endpoint */
   patch: string;

--- a/apps/packages/product-client/src/lib/domain/workspaces/changes/changes-cache-generation.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/changes/changes-cache-generation.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildChangesCacheGeneration,
+  buildChangesMetadataFingerprint,
+  buildChangesMetadataListCacheGeneration,
+  type ChangesMetadataPayload,
+} from "./changes-cache-generation";
+
+const METADATA: ChangesMetadataPayload = {
+  baseRef: "origin/main",
+  resolvedBaseOid: "base-1",
+  mergeBaseOid: "merge-1",
+  headOid: "head-1",
+  files: [
+    {
+      path: "src/b.ts",
+      oldPath: null,
+      status: "modified",
+      includedState: "partial",
+      additions: 2,
+      deletions: 1,
+      binary: false,
+    },
+    {
+      path: "src/a.ts",
+      oldPath: "src/old-a.ts",
+      status: "renamed",
+      includedState: "included",
+      additions: 3,
+      deletions: 4,
+      binary: true,
+    },
+  ],
+};
+
+describe("changes cache generation", () => {
+  it("fingerprints semantic metadata independently of file order", () => {
+    const fingerprint = buildChangesMetadataFingerprint(METADATA);
+    expect(fingerprint).toBe(
+      buildChangesMetadataFingerprint({ ...METADATA, files: [...METADATA.files].reverse() }),
+    );
+    expect(fingerprint).not.toContain("src/a.ts");
+    expect(fingerprint).not.toContain("origin/main");
+  });
+
+  it("keeps opaque fingerprints compact, stable, and distinct across a collision sample", () => {
+    const fingerprint = buildChangesMetadataFingerprint(METADATA);
+    expect(fingerprint).toMatch(/^changes-metadata-v1:[0-9a-z]+:[0-9a-f]{32}$/);
+    expect(buildChangesMetadataFingerprint(METADATA)).toBe(fingerprint);
+    const sample = Array.from({ length: 256 }, (_, index) => (
+      buildChangesMetadataFingerprint(withFirstFile({ path: `src/sample-${index}.ts` }))
+    ));
+    expect(new Set(sample).size).toBe(sample.length);
+  });
+
+  it.each([
+    ["path", withFirstFile({ path: "src/other.ts" })],
+    ["old path", withFirstFile({ oldPath: "src/old.ts" })],
+    ["status", withFirstFile({ status: "added" })],
+    ["included state", withFirstFile({ includedState: "excluded" })],
+    ["additions", withFirstFile({ additions: 9 })],
+    ["deletions", withFirstFile({ deletions: 9 })],
+    ["binary state", withFirstFile({ binary: true })],
+    ["base ref", { ...METADATA, baseRef: "origin/release" }],
+    ["head oid", { ...METADATA, headOid: "head-2" }],
+    ["base oid", { ...METADATA, resolvedBaseOid: "base-2" }],
+    ["merge-base oid", { ...METADATA, mergeBaseOid: "merge-2" }],
+  ])("changes when %s changes", (_label, metadata) => {
+    expect(buildChangesMetadataFingerprint(metadata)).not.toBe(
+      buildChangesMetadataFingerprint(METADATA),
+    );
+  });
+
+  it("composes metadata, observation, force epoch, evidence kind, and Last turn identity", () => {
+    const semanticFingerprint = buildChangesMetadataFingerprint(METADATA);
+    const generation = buildChangesCacheGeneration({
+      kind: "last_turn",
+      semanticFingerprint,
+      observationToken: 1,
+      forceEpoch: 1,
+      completedTurnId: "turn-1",
+    });
+    expect(generation).not.toContain("turn-1");
+    expect(generation).not.toContain("src/a.ts");
+    expect(buildChangesCacheGeneration({
+      kind: "last_turn",
+      semanticFingerprint,
+      observationToken: 1,
+      forceEpoch: 2,
+      completedTurnId: "turn-1",
+    })).not.toBe(generation);
+    expect(buildChangesCacheGeneration({
+      kind: "last_turn",
+      semanticFingerprint,
+      observationToken: 1,
+      forceEpoch: 1,
+      completedTurnId: "turn-2",
+    })).not.toBe(generation);
+    expect(buildChangesCacheGeneration({
+      kind: "branch",
+      semanticFingerprint,
+      observationToken: 1,
+      forceEpoch: 1,
+      completedTurnId: "turn-1",
+    })).not.toBe(generation);
+    expect(buildChangesCacheGeneration({
+      kind: "last_turn",
+      semanticFingerprint,
+      observationToken: 2,
+      forceEpoch: 1,
+      completedTurnId: "turn-1",
+    })).not.toBe(generation);
+  });
+
+  it("separates metadata-list identities at force and turn boundaries", () => {
+    const first = buildChangesMetadataListCacheGeneration({
+      forceEpoch: 1,
+      completedTurnId: "turn-1",
+    });
+    expect(first).not.toContain("turn-1");
+    expect(first).not.toBe(buildChangesMetadataListCacheGeneration({
+      forceEpoch: 1,
+      completedTurnId: "turn-2",
+    }));
+    expect(buildChangesMetadataListCacheGeneration({ forceEpoch: 1 })).not.toBe(
+      buildChangesMetadataListCacheGeneration({ forceEpoch: 2 }),
+    );
+  });
+});
+
+function withFirstFile(
+  change: Partial<ChangesMetadataPayload["files"][number]>,
+): ChangesMetadataPayload {
+  return {
+    ...METADATA,
+    files: [
+      { ...METADATA.files[0]!, ...change },
+      METADATA.files[1]!,
+    ],
+  };
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/changes/changes-cache-generation.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/changes/changes-cache-generation.ts
@@ -1,0 +1,133 @@
+export interface ChangesMetadataFile {
+  path: string;
+  oldPath?: string | null;
+  status: string;
+  includedState?: string | null;
+  additions: number;
+  deletions: number;
+  binary: boolean;
+}
+
+export interface ChangesMetadataPayload {
+  files: readonly ChangesMetadataFile[];
+  baseRef?: string | null;
+  resolvedBaseOid?: string | null;
+  mergeBaseOid?: string | null;
+  headOid?: string | null;
+}
+
+export type ChangesEvidenceKind = "working_tree" | "branch" | "last_turn";
+
+export function buildChangesMetadataFingerprint(
+  metadata: ChangesMetadataPayload | null | undefined,
+): string {
+  const files = (metadata?.files ?? [])
+    .map((file) => {
+      const canonicalFile = {
+        path: file.path,
+        oldPath: file.oldPath ?? null,
+        status: file.status,
+        includedState: file.includedState ?? null,
+        additions: file.additions,
+        deletions: file.deletions,
+        binary: file.binary,
+      };
+      return {
+        file: canonicalFile,
+        sortKey: stableFileIdentity(canonicalFile),
+      };
+    })
+    .sort((left, right) => compareStableIdentity(left.sortKey, right.sortKey))
+    .map((entry) => entry.file);
+  return buildOpaqueFingerprint("changes-metadata-v1", {
+    files,
+    baseRef: metadata?.baseRef ?? null,
+    resolvedBaseOid: metadata?.resolvedBaseOid ?? null,
+    mergeBaseOid: metadata?.mergeBaseOid ?? null,
+    headOid: metadata?.headOid ?? null,
+  });
+}
+
+export function buildChangesCacheGeneration({
+  kind,
+  semanticFingerprint,
+  observationToken,
+  forceEpoch,
+  completedTurnId = null,
+}: {
+  kind: ChangesEvidenceKind;
+  semanticFingerprint: string;
+  observationToken: number;
+  forceEpoch: number;
+  completedTurnId?: string | null;
+}): string {
+  return buildOpaqueFingerprint("changes-cache-v1", [
+    kind,
+    semanticFingerprint,
+    observationToken,
+    forceEpoch,
+    kind === "last_turn" ? completedTurnId : null,
+  ]);
+}
+
+export function buildChangesMetadataListCacheGeneration({
+  forceEpoch,
+  completedTurnId = null,
+}: {
+  forceEpoch: number;
+  completedTurnId?: string | null;
+}): string {
+  return buildOpaqueFingerprint(
+    "changes-metadata-list-v1",
+    [forceEpoch, completedTurnId],
+  );
+}
+
+function stableFileIdentity(file: {
+  path: string;
+  oldPath: string | null;
+  status: string;
+  includedState: string | null;
+  additions: number;
+  deletions: number;
+  binary: boolean;
+}): string {
+  return JSON.stringify([
+    file.path,
+    file.oldPath,
+    file.status,
+    file.includedState,
+    file.additions,
+    file.deletions,
+    file.binary,
+  ]);
+}
+
+function compareStableIdentity(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function buildOpaqueFingerprint(namespace: string, value: unknown): string {
+  const canonical = JSON.stringify(value);
+  const hashes = [
+    hashFingerprintPart(canonical, 0x811c9dc5),
+    hashFingerprintPart(canonical, 0x9e3779b9),
+    hashFingerprintPart(canonical, 0x85ebca6b),
+    hashFingerprintPart(canonical, 0xc2b2ae35),
+  ];
+  return `${namespace}:${canonical.length.toString(36)}:${hashes.join("")}`;
+}
+
+function hashFingerprintPart(value: string, seed: number): string {
+  let hash = seed;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  hash ^= hash >>> 16;
+  hash = Math.imul(hash, 0x85ebca6b);
+  hash ^= hash >>> 13;
+  hash = Math.imul(hash, 0xc2b2ae35);
+  hash ^= hash >>> 16;
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}

--- a/apps/packages/product-client/src/lib/domain/workspaces/changes/git-panel-review-model.test.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/changes/git-panel-review-model.test.ts
@@ -4,9 +4,12 @@ import type {
   GitPanelSection,
 } from "#product/lib/domain/workspaces/changes/git-panel-diff";
 import {
+  buildGitPanelDiffFetchScopeKey,
   resolveGitPanelReviewEvidence,
+  resolvePermittedGitPanelDiffFetchKeys,
   summarizeGitPanelSectionStats,
 } from "#product/lib/domain/workspaces/changes/git-panel-review-model";
+import { gitReviewEntryForFile } from "#product/lib/domain/workspaces/changes/git-review-entries";
 
 describe("git panel review evidence", () => {
   it("keeps current evidence authoritative over recorded fallback", () => {
@@ -106,6 +109,62 @@ describe("git panel review evidence", () => {
       additions: 7,
       deletions: 4,
     });
+  });
+});
+
+describe("git panel diff scheduling", () => {
+  it("includes the evidence generation in the synchronous fetch scope", () => {
+    const args = {
+      activeWorkspaceId: "workspace-1",
+      baseRef: "origin/main",
+      mode: "branch" as const,
+      reviewEntries: [gitReviewEntryForFile("branch", reviewFile({
+        currentAdditions: 1,
+      }))],
+    };
+    expect(buildGitPanelDiffFetchScopeKey({ ...args, cacheGeneration: "generation-1" }))
+      .not.toBe(buildGitPanelDiffFetchScopeKey({ ...args, cacheGeneration: "generation-2" }));
+  });
+
+  it("admits at most five current-generation rows in document order", () => {
+    const reviewEntries = Array.from({ length: 6 }, (_, index) =>
+      gitReviewEntryForFile("unstaged", reviewFile({
+        path: `src/file-${index}.ts`,
+        currentAdditions: 1,
+      }))
+    );
+    const permitted = resolvePermittedGitPanelDiffFetchKeys({
+      reviewEntries,
+      visibleSectionScopes: new Set(["unstaged"]),
+      effectiveCollapsedFiles: new Set(),
+      settledDiffFetchKeys: new Set(),
+    });
+    expect([...permitted]).toEqual(reviewEntries.slice(0, 5).map((entry) => entry.key));
+  });
+
+  it("does not spend capacity on collapsed, missing, or policy-blocked rows", () => {
+    const collapsed = gitReviewEntryForFile("unstaged", reviewFile({
+      path: "src/collapsed.ts",
+      currentAdditions: 1,
+    }));
+    const missing = gitReviewEntryForFile("unstaged", reviewFile({
+      path: "src/missing.ts",
+      currentAdditions: null,
+    }));
+    const blocked = gitReviewEntryForFile("unstaged", reviewFile({
+      path: "src/blocked.ts",
+      currentAdditions: 5_001,
+    }));
+    const eligible = gitReviewEntryForFile("unstaged", reviewFile({
+      path: "src/eligible.ts",
+      currentAdditions: 1,
+    }));
+    expect([...resolvePermittedGitPanelDiffFetchKeys({
+      reviewEntries: [collapsed, missing, blocked, eligible],
+      visibleSectionScopes: new Set(["unstaged"]),
+      effectiveCollapsedFiles: new Set([collapsed.key]),
+      settledDiffFetchKeys: new Set(),
+    })]).toEqual([eligible.key]);
   });
 });
 

--- a/apps/packages/product-client/src/lib/domain/workspaces/changes/git-panel-review-model.ts
+++ b/apps/packages/product-client/src/lib/domain/workspaces/changes/git-panel-review-model.ts
@@ -87,12 +87,14 @@ export function buildGitPanelDiffFetchScopeKey(args: {
   activeWorkspaceId: string | null;
   baseRef: string | null;
   mode: GitPanelMode;
+  cacheGeneration: string;
   reviewEntries: readonly GitReviewFileEntry[];
 }): string {
   return [
     args.activeWorkspaceId ?? "",
     args.baseRef ?? "",
     args.mode,
+    args.cacheGeneration,
     args.reviewEntries.map((entry) => entry.key).join("\n"),
   ].join("\u001f");
 }

--- a/apps/packages/product-client/src/lib/infra/query/query-client.test.ts
+++ b/apps/packages/product-client/src/lib/infra/query/query-client.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createAppQueryClient,
   hashAppQueryKey,
+  hashAppQueryKeyForTelemetry,
   shouldCaptureAppMutationError,
   shouldCaptureAppQueryError,
 } from "#product/lib/infra/query/query-client";
@@ -29,6 +30,37 @@ describe("hashAppQueryKey", () => {
     const event = new Event("click");
 
     expect(hashAppQueryKey(["event", event])).toBe('["event","[Event]"]');
+  });
+
+  it.each([
+    ["file", [
+      "anyharness",
+      "secret-cache-scope",
+      "workspace",
+      "secret-workspace-id",
+      "git-diff",
+      "base_worktree",
+      "origin/secret-branch",
+      "src/old-secret.ts",
+      "src/current-secret.ts",
+      "changes-cache-v1:secret-generation",
+    ]],
+    ["branch-files", [
+      "anyharness",
+      "secret-cache-scope",
+      "workspace",
+      "secret-workspace-id",
+      "git-diff",
+      "branch-files",
+      "origin/secret-branch",
+      "changes-metadata-list-v1:secret-generation",
+    ]],
+  ])("redacts %s Git diff identity from telemetry hashes", (kind, queryKey) => {
+    const telemetryHash = hashAppQueryKeyForTelemetry(queryKey);
+    expect(telemetryHash).toBe(
+      `["anyharness","workspace","git-diff","${kind}","[redacted]"]`,
+    );
+    expect(telemetryHash).not.toContain("secret");
   });
 });
 
@@ -145,6 +177,37 @@ describe("createAppQueryClient query telemetry", () => {
         query_hash: hashAppQueryKey(queryKey),
       },
     });
+  });
+
+  it("captures Git diff failures without query paths or generations", async () => {
+    const captureException = vi.fn();
+    const client = createAppQueryClient({ captureException });
+    const queryKey = [
+      "anyharness",
+      "secret-cache-scope",
+      "workspace",
+      "secret-workspace-id",
+      "git-diff",
+      "base_worktree",
+      "origin/secret-branch",
+      "src/old-secret.ts",
+      "src/current-secret.ts",
+      "changes-cache-v1:secret-generation",
+    ];
+    const error = new TypeError("Failed to fetch");
+
+    await runFailingQuery(client, queryKey, error);
+
+    expect(captureException).toHaveBeenCalledExactlyOnceWith(error, {
+      tags: {
+        action: "query_error",
+        domain: "react_query",
+      },
+      extras: {
+        query_hash: '["anyharness","workspace","git-diff","file","[redacted]"]',
+      },
+    });
+    expect(JSON.stringify(captureException.mock.calls)).not.toContain("secret");
   });
 
   it("captures the Cowork lifecycle code when its status is 5xx", async () => {

--- a/apps/packages/product-client/src/lib/infra/query/query-client.ts
+++ b/apps/packages/product-client/src/lib/infra/query/query-client.ts
@@ -112,6 +112,26 @@ export function hashAppQueryKey(queryKey: unknown): string {
   }
 }
 
+export function hashAppQueryKeyForTelemetry(queryKey: unknown): string {
+  return hashAppQueryKey(redactSensitiveQueryKeyForTelemetry(queryKey));
+}
+
+function redactSensitiveQueryKeyForTelemetry(queryKey: unknown): unknown {
+  if (
+    Array.isArray(queryKey)
+    && queryKey[0] === "anyharness"
+    && queryKey[2] === "workspace"
+    && queryKey[4] === "git-diff"
+  ) {
+    const kind = queryKey[5] === "branch-files"
+      || queryKey[5] === "base-worktree-files"
+      ? queryKey[5]
+      : "file";
+    return ["anyharness", "workspace", "git-diff", kind, "[redacted]"];
+  }
+  return queryKey;
+}
+
 export function shouldCaptureAppQueryError(error: unknown): boolean {
   return !hasAnyHarnessRuntimeIncidentReceipt(error)
     && !isCancelledError(error)
@@ -142,7 +162,7 @@ export function createAppQueryClient({
             domain: "react_query",
           },
           extras: {
-            query_hash: query.queryHash,
+            query_hash: hashAppQueryKeyForTelemetry(query.queryKey),
           },
         });
       },

--- a/apps/packages/product-client/src/lib/workflows/workspaces/changes/refresh-git-panel-metadata.test.ts
+++ b/apps/packages/product-client/src/lib/workflows/workspaces/changes/refresh-git-panel-metadata.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { refreshGitPanelMetadata } from "./refresh-git-panel-metadata";
+
+describe("refreshGitPanelMetadata", () => {
+  it("advances the force epoch only after every metadata refresh succeeds", async () => {
+    const first = deferred<{ isError: boolean }>();
+    const second = deferred<{ isError: boolean }>();
+    const advanceForceEpoch = vi.fn(() => 1);
+    const refresh = refreshGitPanelMetadata({
+      refreshes: [() => first.promise, () => second.promise],
+      advanceForceEpoch,
+    });
+
+    first.resolve({ isError: false });
+    await Promise.resolve();
+    expect(advanceForceEpoch).not.toHaveBeenCalled();
+    second.resolve({ isError: false });
+
+    await expect(refresh).resolves.toBe(true);
+    expect(advanceForceEpoch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains the prior epoch when any metadata refresh fails", async () => {
+    const advanceForceEpoch = vi.fn(() => 1);
+    await expect(refreshGitPanelMetadata({
+      refreshes: [
+        async () => ({ isError: false }),
+        async () => ({ isError: true }),
+      ],
+      advanceForceEpoch,
+    })).resolves.toBe(false);
+    expect(advanceForceEpoch).not.toHaveBeenCalled();
+  });
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}

--- a/apps/packages/product-client/src/lib/workflows/workspaces/changes/refresh-git-panel-metadata.ts
+++ b/apps/packages/product-client/src/lib/workflows/workspaces/changes/refresh-git-panel-metadata.ts
@@ -1,0 +1,14 @@
+export async function refreshGitPanelMetadata({
+  refreshes,
+  advanceForceEpoch,
+}: {
+  refreshes: ReadonlyArray<() => Promise<{ isError: boolean }>>;
+  advanceForceEpoch: () => number;
+}): Promise<boolean> {
+  const results = await Promise.all(refreshes.map((refresh) => refresh()));
+  if (results.some((result) => result.isError)) {
+    return false;
+  }
+  advanceForceEpoch();
+  return true;
+}

--- a/specs/codebase/systems/product/workspaces/files.md
+++ b/specs/codebase/systems/product/workspaces/files.md
@@ -124,6 +124,26 @@ Remote filesystem and git data belongs to SDK-react/TanStack Query:
 - branch changed files
 - diff bodies
 
+Per-file diff cache identity includes an optional evidence generation owned by
+SDK React. Changes composes that generation from a stable semantic fingerprint
+of the authoritative file-list metadata, an observation token, a
+workspace-scoped force epoch, and the completed-turn id for Last turn. The
+observation token advances on each semantic metadata transition, including a
+return to an earlier fingerprint, and persists across owner remounts while the
+Query Client remains alive. Raw query timestamps are not evidence identity:
+active-session status polling must not create a new diff generation on every
+unchanged response. The force epoch advances only after a known boundary
+settles successfully: completed-turn/error metadata invalidation, Manual
+Refresh, or an existing Git/file mutation invalidation. Branch and
+base-worktree file-list keys include the corresponding force/turn identity;
+the generation never becomes a runtime request parameter. Invalidating Git
+diff state preserves active refetches for generationless per-file, branch-list,
+and base-worktree-list consumers while generated consumers move to their new
+identity. Generation values are compact opaque hashes rather than raw roster
+metadata, and Product query error telemetry reduces Git diff keys to a redacted
+structural kind so paths, refs, workspace identity, and generation values never
+enter `query_hash`.
+
 Zustand stores only local UI/editor state:
 
 - `workspace-viewer-tabs-store.ts`: open targets, active target, per-target
@@ -200,6 +220,17 @@ remains visible with `No current diff` and Open file. Cached live-query status,
 statistics, and binary badges stay suppressed; truthful transcript-recorded
 statistics may still appear. Changes aggregate totals and jump-to-file entries
 prefer current statistics and then recorded statistics.
+
+Current diff data is presentable only when it belongs to the current semantic
+generation and its query is settled. A generation transition, background
+refetch, or invalidated query hides the prior patch, query statistics,
+binary/truncation flags, error, and patch-derived display policy. Active rows
+use the existing Loading state, concurrency-deferred rows use Waiting, and
+collapsed or inline-policy-blocked rows remain disabled without inheriting
+prior data. The five-query scheduler scopes its settled set synchronously to
+the same generation so a transition cannot admit previously settled rows.
+Same-numstat external edits with no observable metadata change remain
+undetectable until one of the known force boundaries above.
 
 Last-turn undo is transcript-backed and all-or-nothing. The UI only builds undo
 requests from top-level visible `file_change` parts that include complete patch


### PR DESCRIPTION
## Summary

- Version Changes diff and file-list cache evidence across semantic metadata transitions, completed turns, explicit refreshes, and successful Git/file mutations.
- Keep prior-generation patches, statistics, policy, errors, and hunk actions hidden while current evidence is pending, while preserving the five-query scheduler and generationless consumers.
- Redact Git diff query identity from error telemetry and document the cache contract.
- Stack on #2062; this PR must not merge ahead of its base.

## Testing

- SDK React focused suites: 21/21.
- ProductClient changed and adjacent suites: 131/131.
- `pnpm --filter @anyharness/sdk-react typecheck`
- `pnpm --filter @proliferate/product-client typecheck`
- `python3 scripts/report_frontend_structure.py --strict --summary-only`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_max_lines.py`
- `python3 scripts/check_design_attribution.py`
- `python3 scripts/check_docs.py`
- `git diff --check`
- Fixture-backed live ProductClient proof covers sidebar and transcript D1 → truthful pending state without D1 → D2, collapsed request suppression, and the five-query admission limit.

## Observability

- None: no new telemetry event or logging. Existing cache-decision timing is preserved; Git diff error query hashes are structurally redacted so cache scope, workspace, refs, paths, and generations are not recorded.

## Readiness

- [x] I followed the pull-request procedure for scope, title, labels, body, and readiness.

## Verification

- Independent review accepted the frozen contract after the ABA and generationless-list regressions were repaired.
- No Rust or Docker work was required.