### PR TITLE
fix(product): keep Changes actions reachable

### DIFF
--- a/apps/packages/product-client/src/components/content/ui/diff/ChatDiffViewer.test.tsx
+++ b/apps/packages/product-client/src/components/content/ui/diff/ChatDiffViewer.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { createElement, type ReactElement } from "react";
-import { cleanup, render } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProductHost } from "@proliferate/product-client/host/product-host";
 import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
 import { ChatDiffViewer } from "#product/components/content/ui/diff/ChatDiffViewer";
@@ -35,6 +35,19 @@ index 1111111..2222222 100644
 -export const oldName = "old";
 +export const newName = "new";
  export const done = true;`;
+
+const MULTI_HUNK_PATCH = `diff --git a/src/example.ts b/src/example.ts
+index 1111111..2222222 100644
+--- a/src/example.ts
++++ b/src/example.ts
+@@ -1,2 +1,2 @@
+-export const first = "old";
++export const first = "new";
+ export const firstDone = true;
+@@ -10,2 +10,2 @@
+-export const second = "old";
++export const second = "new";
+ export const secondDone = true;`;
 
 describe("ChatDiffViewer content search registration", () => {
   beforeEach(() => {
@@ -76,5 +89,128 @@ describe("ChatDiffViewer content search registration", () => {
 
     const unit = useContentSearchStore.getState().unitsById["chat-diff:test"];
     expect(unit?.surface).toBe("chat");
+  });
+});
+
+describe("ChatDiffViewer hunk actions", () => {
+  beforeEach(() => {
+    resetContentSearchStore();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("mounts wrap-off actions before hover with scrollport placement and focus reveal", () => {
+    const onRevert = vi.fn();
+    const onStageOrUnstage = vi.fn();
+    const view = renderWithHost(
+      <ChatDiffViewer
+        parsed={parsePatch(PATCH)}
+        tokens={null}
+        wrapLongLines={false}
+        hunkActions={{
+          mode: "unstaged",
+          disabled: false,
+          onRevert,
+          onStageOrUnstage,
+        }}
+      />,
+    );
+
+    const revert = screen.getByRole("button", { name: "Revert hunk" });
+    const stage = screen.getByRole("button", { name: "Stage hunk" });
+    const pill = revert.closest("div");
+    const firstRow = revert.closest("[data-line-index]");
+
+    expect(pill?.className).toContain("sticky right-2 ms-auto shrink-0");
+    expect(pill?.className).toContain("opacity-0 pointer-events-none");
+    expect(pill?.className).toContain("group-focus-within/hunk:opacity-100");
+    expect(firstRow?.className).toContain("group/hunk");
+    expect(firstRow?.className).toContain("pr-2");
+    expect(firstRow?.className).not.toContain("pr-3");
+    expect(view.container.querySelector("pre")?.tabIndex).toBe(0);
+
+    fireEvent.click(revert);
+    fireEvent.click(stage);
+    expect(onRevert).toHaveBeenCalledWith(0);
+    expect(onStageOrUnstage).toHaveBeenCalledWith(0);
+  });
+
+  it("keeps wrap-on staged actions at the line end", () => {
+    const onStageOrUnstage = vi.fn();
+    renderWithHost(
+      <ChatDiffViewer
+        parsed={parsePatch(PATCH)}
+        tokens={null}
+        wrapLongLines
+        hunkActions={{
+          mode: "staged",
+          disabled: false,
+          onRevert: vi.fn(),
+          onStageOrUnstage,
+        }}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Revert hunk" })).toBeNull();
+    const unstage = screen.getByRole("button", { name: "Unstage hunk" });
+    expect(unstage.closest("div")?.className).toContain("absolute right-2 top-0");
+    expect(unstage.closest("div")?.className).not.toContain("sticky");
+    expect(unstage.closest("[data-line-index]")?.className).toContain("pr-3");
+
+    fireEvent.click(unstage);
+    expect(onStageOrUnstage).toHaveBeenCalledWith(0);
+  });
+
+  it("orders actions by hunk and keeps disabled mutations disabled", () => {
+    const actions = {
+      mode: "unstaged" as const,
+      disabled: true,
+      onRevert: vi.fn(),
+      onStageOrUnstage: vi.fn(),
+    };
+    const view = renderWithHost(
+      <ChatDiffViewer
+        parsed={parsePatch(MULTI_HUNK_PATCH)}
+        tokens={null}
+        wrapLongLines={false}
+        hunkActions={actions}
+      />,
+    );
+
+    const actionLabels = Array.from(
+      view.container.querySelectorAll<HTMLButtonElement>('button[aria-label$="hunk"]'),
+      (button) => button.getAttribute("aria-label"),
+    );
+    expect(actionLabels).toEqual([
+      "Revert hunk",
+      "Stage hunk",
+      "Revert hunk",
+      "Stage hunk",
+    ]);
+    expect(screen.getAllByRole("button", { name: "Revert hunk" }).every(
+      (button) => (button as HTMLButtonElement).disabled,
+    )).toBe(true);
+    expect(screen.getAllByRole("button", { name: "Stage hunk" }).every(
+      (button) => (button as HTMLButtonElement).disabled,
+    )).toBe(true);
+  });
+
+  it("does not mount hunk buttons without mutation actions", () => {
+    const view = renderWithHost(
+      <ChatDiffViewer
+        parsed={parsePatch(PATCH)}
+        tokens={null}
+        wrapLongLines={false}
+        hunkActions={null}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Revert hunk" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Stage hunk" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Unstage hunk" })).toBeNull();
+    expect(view.container.querySelector("[data-content] [data-line-index]")?.className)
+      .toContain("pr-3");
   });
 });

--- a/apps/packages/product-client/src/components/content/ui/diff/ChatDiffViewer.tsx
+++ b/apps/packages/product-client/src/components/content/ui/diff/ChatDiffViewer.tsx
@@ -106,6 +106,7 @@ function ChatContentLine({
   const lineType = getChatLineType(line);
   const lineNumber = getChatLineNumber(line);
   const altLineNumber = line.type === "context" ? line.oldLineNum : undefined;
+  const rightPaddingClass = pill && !wrapLongLines ? "pr-2" : "pr-3";
 
   return (
     <div
@@ -118,11 +119,11 @@ function ChatContentLine({
           ? () => onHunkHover(hunkIndex)
           : undefined
       }
-      className={`diff-content-cell relative min-h-[var(--diffs-line-height)] pr-3 pl-2 ${
+      className={`diff-content-cell relative min-h-[var(--diffs-line-height)] ${rightPaddingClass} pl-2 ${
         wrapLongLines
           ? "block min-w-0 whitespace-pre-wrap break-words py-[calc((var(--diffs-line-height)-1em)/2)]"
           : "flex min-w-max items-center whitespace-pre"
-      }`}
+      } ${pill ? "group/hunk" : ""}`}
     >
       <DiffLineContent
         line={line}
@@ -244,11 +245,7 @@ function ChatContentColumn({
     >
       {rows.map((row) => {
         if (row.kind === "line") {
-          const showPill = Boolean(
-            hunkActions
-            && row.isHunkFirstRow
-            && hoveredHunkIndex === row.hunkIndex,
-          );
+          const showPill = Boolean(hunkActions && row.isHunkFirstRow);
           return (
             <ChatContentLine
               key={row.key}
@@ -266,7 +263,8 @@ function ChatContentColumn({
                   disabled={hunkActions.disabled}
                   onRevert={() => hunkActions.onRevert(row.hunkIndex)}
                   onStageOrUnstage={() => hunkActions.onStageOrUnstage(row.hunkIndex)}
-                  reveal="visible"
+                  placement={wrapLongLines ? "line-end" : "scrollport-end"}
+                  reveal={hoveredHunkIndex === row.hunkIndex ? "visible" : "group-hover"}
                 />
               ) : undefined}
             />

--- a/apps/packages/product-client/src/components/content/ui/diff/HunkActionPill.tsx
+++ b/apps/packages/product-client/src/components/content/ui/diff/HunkActionPill.tsx
@@ -8,6 +8,7 @@ interface HunkActionPillProps {
   disabled: boolean;
   onRevert: () => void;
   onStageOrUnstage: () => void;
+  placement?: "line-end" | "scrollport-end";
   /**
    * How the pill reveals itself:
    * - "group-hover" (default): invisible until an ancestor `.group/hunk` is hovered.
@@ -25,6 +26,7 @@ export function HunkActionPill({
   disabled,
   onRevert,
   onStageOrUnstage,
+  placement = "line-end",
   reveal = "group-hover",
 }: HunkActionPillProps) {
   const isUnstaged = mode === "unstaged";
@@ -32,10 +34,13 @@ export function HunkActionPill({
     reveal === "group-hover"
       ? "opacity-0 pointer-events-none group-hover/hunk:opacity-100 group-hover/hunk:pointer-events-auto group-focus-within/hunk:opacity-100 group-focus-within/hunk:pointer-events-auto"
       : "opacity-100";
+  const placementClasses = placement === "scrollport-end"
+    ? "sticky right-2 ms-auto shrink-0"
+    : "absolute right-2 top-0";
 
   return (
     <div
-      className={`absolute right-2 top-0 z-10 flex items-center gap-0.5 rounded-md border border-border/50 bg-[var(--diff-view-surface)] px-0.5 py-0.5 shadow-popover transition-opacity duration-hover ${revealClasses}`}
+      className={`${placementClasses} z-10 flex items-center gap-0.5 rounded-md border border-border/50 bg-[var(--diff-view-surface)] px-0.5 py-0.5 shadow-popover transition-opacity duration-hover ${revealClasses}`}
     >
       {isUnstaged && (
         <Tooltip content="Revert hunk">

--- a/apps/packages/product-client/src/components/workspace/git/GitPanel.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/git/GitPanel.test.tsx
@@ -288,7 +288,7 @@ describe("GitPanel", () => {
     ))).toBe(true);
   });
 
-  it("shows the branch target selector only in branch review mode", () => {
+  it("keeps all branch controls in the named two-row narrow layout only in branch mode", () => {
     const baseProps = {
       visibleChangedCount: 1,
       additions: 1,
@@ -323,7 +323,15 @@ describe("GitPanel", () => {
     );
 
     expect(unstagedHtml).not.toContain("origin/main");
+    expect(unstagedHtml).toContain("[container-name:review-header]");
+    expect(unstagedHtml).not.toContain("@max-[28rem]/review-header:flex-col");
     expect(branchHtml).toContain("origin/main");
+    expect(branchHtml).toContain("[container-name:review-header]");
+    expect(branchHtml).toContain("@max-[28rem]/review-header:flex-col");
+    expect(branchHtml).toContain("@max-[28rem]/review-header:grid-cols-2");
+    expect(branchHtml).toContain("Collapse all diffs");
+    expect(branchHtml).toContain("Jump to file");
+    expect(branchHtml).toContain("Git review options");
   });
 
   it("renders the active changes filter as plain text until hover or open", () => {

--- a/apps/packages/product-client/src/components/workspace/git/GitPanelHeader.tsx
+++ b/apps/packages/product-client/src/components/workspace/git/GitPanelHeader.tsx
@@ -66,46 +66,66 @@ export function GitPanelHeader({
       // naming a container, only querying one.
       className="z-20 flex shrink-0 flex-col [container-name:review-header] [container-type:inline-size] border-b border-border/70 bg-sidebar-background px-2 py-1 text-sidebar-muted-foreground"
     >
-      <div className="flex min-h-7 min-w-0 items-center gap-1">
-        <GitReviewBaseSelector
-          activeMode={changesFilter}
-          changedCount={visibleChangedCount}
-          onSelect={onFilterChange}
-        />
-        {showTargetSelector && (
-          <GitReviewTargetSelector
-            mode={changesFilter}
-            baseRef={baseRef}
-            branchRefs={branchRefs}
-            isRuntimeReady={isRuntimeReady}
-            onSelect={onBaseRefChange}
+      <div
+        className={`flex min-h-7 min-w-0 items-center gap-1 ${
+          showTargetSelector
+            ? "@max-[28rem]/review-header:flex-col @max-[28rem]/review-header:items-stretch @max-[28rem]/review-header:gap-0"
+            : ""
+        }`}
+      >
+        {showTargetSelector ? (
+          <div className="contents @max-[28rem]/review-header:grid @max-[28rem]/review-header:min-w-0 @max-[28rem]/review-header:w-full @max-[28rem]/review-header:grid-cols-2 @max-[28rem]/review-header:gap-1 @max-[28rem]/review-header:[&>button]:w-full @max-[28rem]/review-header:[&>button]:max-w-none">
+            <GitReviewBaseSelector
+              activeMode={changesFilter}
+              changedCount={visibleChangedCount}
+              onSelect={onFilterChange}
+            />
+            <GitReviewTargetSelector
+              mode={changesFilter}
+              baseRef={baseRef}
+              branchRefs={branchRefs}
+              isRuntimeReady={isRuntimeReady}
+              onSelect={onBaseRefChange}
+            />
+          </div>
+        ) : (
+          <GitReviewBaseSelector
+            activeMode={changesFilter}
+            changedCount={visibleChangedCount}
+            onSelect={onFilterChange}
           />
         )}
-        <GitPanelAggregateStats additions={additions} deletions={deletions} />
-        <div className="ms-auto flex shrink-0 items-center gap-px">
-          <PaneIconButton
-            label={allFilesCollapsed ? "Expand all diffs" : "Collapse all diffs"}
-            aria-pressed={allFilesCollapsed}
-            onClick={onToggleAllFiles}
-          >
-            {allFilesCollapsed
-              ? <ExpandAll className="icon-paired" />
-              : <CollapseAll className="icon-paired" />}
-          </PaneIconButton>
-          <GitReviewJumpToFileMenu
-            reviewEntries={reviewEntries}
-            onFocusFile={onFocusFile}
-          />
-          <GitReviewOptionsMenu
-            allFilesCollapsed={allFilesCollapsed}
-            wrapLongLines={wrapLongLines}
-            layout={layout}
-            isRuntimeReady={isRuntimeReady}
-            onToggleAllFiles={onToggleAllFiles}
-            onToggleWrap={onToggleWrap}
-            onToggleLayout={onToggleLayout}
-            onRefresh={onRefresh}
-          />
+        <div
+          className={showTargetSelector
+            ? "contents @max-[28rem]/review-header:flex @max-[28rem]/review-header:min-h-7 @max-[28rem]/review-header:w-full @max-[28rem]/review-header:min-w-0 @max-[28rem]/review-header:items-center"
+            : "contents"}
+        >
+          <GitPanelAggregateStats additions={additions} deletions={deletions} />
+          <div className="ms-auto flex shrink-0 items-center gap-px">
+            <PaneIconButton
+              label={allFilesCollapsed ? "Expand all diffs" : "Collapse all diffs"}
+              aria-pressed={allFilesCollapsed}
+              onClick={onToggleAllFiles}
+            >
+              {allFilesCollapsed
+                ? <ExpandAll className="icon-paired" />
+                : <CollapseAll className="icon-paired" />}
+            </PaneIconButton>
+            <GitReviewJumpToFileMenu
+              reviewEntries={reviewEntries}
+              onFocusFile={onFocusFile}
+            />
+            <GitReviewOptionsMenu
+              allFilesCollapsed={allFilesCollapsed}
+              wrapLongLines={wrapLongLines}
+              layout={layout}
+              isRuntimeReady={isRuntimeReady}
+              onToggleAllFiles={onToggleAllFiles}
+              onToggleWrap={onToggleWrap}
+              onToggleLayout={onToggleLayout}
+              onRefresh={onRefresh}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/specs/codebase/systems/product/workspaces/files.md
+++ b/specs/codebase/systems/product/workspaces/files.md
@@ -43,6 +43,13 @@ In the review document, unchanged diff lines sit on the plain pane background
 strips with rounded ends — both scoped by `[data-git-review-document]` in
 design `product.css`.
 
+At or below the Changes header's 28rem named-container boundary, branch mode
+uses a selector row above the aggregate statistics and unchanged action
+cluster; the other targets retain one row. In unified wrap-off diffs, each
+actionable hunk's existing pill stays at the review scrollport's right edge and
+remains in keyboard order while visually hidden, revealing on focus as well as
+pointer hover. Wrap-on and split diff placement remain unchanged.
+
 Commit, publish, and pull-request dialogs may summarize change counts and
 staging state, but they do not duplicate the changed-file roster. Detailed
 paths and diff review remain in Changes, reached through Review changes.


### PR DESCRIPTION
## Summary

- Reflow the branch-mode Changes header into two contained rows at the named 28rem pane boundary while preserving wide and non-branch layouts.
- Keep unified wrap-off hunk actions pinned to the visible scrollport edge and mounted in keyboard order, with existing hover/focus reveal and callbacks.
- Preserve Git semantics, wrap-on/split behavior, empty states, and the current-diff cache contract.
- Stack on #2071; this PR must not merge ahead of its base.

## Testing

- Focused ProductClient suites: 20/20.
- `pnpm --filter @proliferate/product-client typecheck`
- `python3 scripts/report_frontend_structure.py --strict --summary-only`
- `python3 scripts/check_frontend_boundaries.py`
- `python3 scripts/check_component_library.py`
- `python3 scripts/check_appearance_scaling.py`
- `python3 scripts/check_max_lines.py`
- `python3 scripts/check_design_attribution.py`
- `python3 scripts/check_docs.py`
- `git diff --check`
- Production-component browser matrix covers 480/380/320 dark and 320 light headers, wrap-off left/mid/max scroll, native keyboard actions, wrap-on, sticky headers, no-current/clean states, and file-header containment.

## Observability

- None: this changes layout, mounting, and focus reveal for existing controls only. No event, log, identifier, failure path, or replay surface is added.

## Readiness

- [x] I followed the pull-request procedure for scope, title, labels, body, and readiness.

## Verification

- Independent review accepted the frozen contract after the max-scroll sticky-inset finding was repaired.
- No Rust or Docker work was required.