### PR TITLE
fix(product): preserve transcript position through prepend

### DIFF
--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.test.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.test.ts
@@ -243,6 +243,26 @@ describe("TranscriptFramePipeline", () => {
     expect(frames.pending).toBe(1);
   });
 
+  it("coalesces repeated beginGlue calls before a frame into one writer pass", () => {
+    const { frames, pipeline } = makePipeline();
+    let passes = 0;
+    pipeline.setWriter({
+      runFramePass: () => {
+        passes += 1;
+      },
+      measureContentHeight: () => 500,
+      shouldContinueGlue: () => true,
+    });
+
+    pipeline.beginGlue();
+    pipeline.beginGlue();
+    pipeline.beginGlue();
+
+    expect(frames.pending).toBe(1);
+    frames.flushFrame();
+    expect(passes).toBe(1);
+  });
+
   // PRO-168 (rung 12, Q16): the eased-follow motion writer's continuation seam.
   // The instant writer never implements `hasPendingMotion`, so these prove the
   // seam is additive: absent it, existing behavior above is untouched (asserted

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.test.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.test.ts
@@ -13,6 +13,7 @@ import {
  */
 class FakeFrames {
   time = 0;
+  cancelled: number[] = [];
   private seq = 0;
   private queue: Array<{ handle: number; cb: () => void }> = [];
 
@@ -23,6 +24,7 @@ class FakeFrames {
   };
 
   caf = (handle: number): void => {
+    this.cancelled.push(handle);
     this.queue = this.queue.filter((entry) => entry.handle !== handle);
   };
 
@@ -30,6 +32,10 @@ class FakeFrames {
 
   get pending(): number {
     return this.queue.length;
+  }
+
+  get pendingHandles(): number[] {
+    return this.queue.map(({ handle }) => handle);
   }
 
   /** Fire every frame queued as of now (a snapshot), advancing the clock once. */
@@ -243,7 +249,7 @@ describe("TranscriptFramePipeline", () => {
     expect(frames.pending).toBe(1);
   });
 
-  it("coalesces repeated beginGlue calls before a frame into one writer pass", () => {
+  it("ensureGlue preserves the first pending handle through rapid position events", () => {
     const { frames, pipeline } = makePipeline();
     let passes = 0;
     pipeline.setWriter({
@@ -254,13 +260,31 @@ describe("TranscriptFramePipeline", () => {
       shouldContinueGlue: () => true,
     });
 
-    pipeline.beginGlue();
-    pipeline.beginGlue();
-    pipeline.beginGlue();
+    pipeline.ensureGlue();
+    const [firstHandle] = frames.pendingHandles;
+    pipeline.ensureGlue();
+    pipeline.ensureGlue();
+    pipeline.ensureGlue();
 
-    expect(frames.pending).toBe(1);
+    expect(frames.pendingHandles).toEqual([firstHandle]);
+    expect(frames.cancelled).toEqual([]);
     frames.flushFrame();
     expect(passes).toBe(1);
+  });
+
+  it("beginGlue still restarts a fresh owner window", () => {
+    const { frames, pipeline } = makePipeline();
+    pipeline.setWriter({
+      runFramePass: () => undefined,
+      measureContentHeight: () => 500,
+      shouldContinueGlue: () => true,
+    });
+    pipeline.beginGlue();
+    const [firstHandle] = frames.pendingHandles;
+    pipeline.beginGlue();
+    expect(frames.cancelled).toEqual([firstHandle]);
+    expect(frames.pendingHandles).not.toContain(firstHandle);
+    expect(frames.pending).toBe(1);
   });
 
   // PRO-168 (rung 12, Q16): the eased-follow motion writer's continuation seam.

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.trailing-edge.test.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.trailing-edge.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { TranscriptFramePipeline } from "#product/hooks/chat/ui/transcript-frame-pipeline";
+
+class FakeFrames {
+  cancelled: number[] = [];
+  private nextHandle = 0;
+  private queue: Array<{ handle: number; callback: () => void }> = [];
+
+  raf = (callback: () => void): number => {
+    const handle = (this.nextHandle += 1);
+    this.queue.push({ handle, callback });
+    return handle;
+  };
+
+  caf = (handle: number): void => {
+    this.cancelled.push(handle);
+    this.queue = this.queue.filter((entry) => entry.handle !== handle);
+  };
+
+  flushFrame(): void {
+    const batch = this.queue;
+    this.queue = [];
+    for (const entry of batch) {
+      entry.callback();
+    }
+  }
+
+  get pending(): number {
+    return this.queue.length;
+  }
+
+  get pendingHandles(): number[] {
+    return this.queue.map(({ handle }) => handle);
+  }
+}
+
+describe("TranscriptFramePipeline trailing-edge ensure", () => {
+  it("runs one trailing pass when erosion is delivered during the quiet-ending pass", () => {
+    const frames = new FakeFrames();
+    const pipeline = new TranscriptFramePipeline(frames.raf, frames.caf, () => 0);
+    const settledSeat = 1_831;
+    let scrollTop = 0;
+    let passes = 0;
+
+    pipeline.setWriter({
+      runFramePass: () => {
+        passes += 1;
+        scrollTop = settledSeat;
+        if (passes <= 2) {
+          // Model WebKit eroding the just-written seat and delivering the native
+          // position event reentrantly while this glue pass is still active.
+          scrollTop = 0;
+          pipeline.ensureGlue();
+          if (passes === 2) {
+            pipeline.ensureGlue();
+            pipeline.ensureGlue();
+          }
+        }
+      },
+      measureContentHeight: () => 6_908,
+      shouldContinueGlue: () => true,
+    });
+
+    pipeline.beginGlue();
+    const [leadingHandle] = frames.pendingHandles;
+
+    frames.flushFrame();
+    expect(scrollTop).toBe(0);
+    expect(passes).toBe(1);
+    expect(frames.cancelled).not.toContain(leadingHandle);
+
+    frames.flushFrame();
+    expect(scrollTop).toBe(0);
+    expect(passes).toBe(2);
+    expect(frames.cancelled).toEqual([]);
+
+    // Erosion has stopped. The request delivered during the quiet-ending pass
+    // is still owed one coalesced writer pass, which must persist the full seat.
+    frames.flushFrame();
+    expect(scrollTop).toBe(settledSeat);
+    expect(passes).toBe(3);
+    expect(frames.pending).toBe(0);
+  });
+});

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.ts
@@ -256,6 +256,14 @@ export class TranscriptFramePipeline {
     this.glueHandle = this.raf(this.glueTick);
   }
 
+  /** Preserve an active glue window, or start one when no window is scheduled. */
+  ensureGlue(): void {
+    if (this.glueActive) {
+      return;
+    }
+    this.beginGlue();
+  }
+
   private glueTick = (): void => {
     const writer = this.writer;
     if (writer == null || !writer.shouldContinueGlue()) {

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.ts
@@ -123,6 +123,10 @@ export class TranscriptFramePipeline {
   private glueStartedAt = 0;
   private glueLastHeight = -1;
   private glueQuietFrames = 0;
+  // Ensures delivered during a running pass are owed one coalesced trailing
+  // pass; requests already present when a pass starts are satisfied by it.
+  private glueDemandGeneration = 0;
+  private glueServedGeneration = 0;
   // PRO-168 (rung 12): the motion writer's own continuation handle, separate
   // from frameHandle/glueHandle so it never contends with either's guard
   // bookkeeping. Only ever armed when the writer reports pending motion.
@@ -253,12 +257,14 @@ export class TranscriptFramePipeline {
     this.glueStartedAt = this.now();
     this.glueLastHeight = -1;
     this.glueQuietFrames = 0;
+    this.glueServedGeneration = this.glueDemandGeneration;
     this.glueHandle = this.raf(this.glueTick);
   }
 
   /** Preserve an active glue window, or start one when no window is scheduled. */
   ensureGlue(): void {
     if (this.glueActive) {
+      this.glueDemandGeneration += 1;
       return;
     }
     this.beginGlue();
@@ -275,7 +281,9 @@ export class TranscriptFramePipeline {
       this.continueMotionIfPending();
       return;
     }
+    const passGeneration = this.glueDemandGeneration;
     writer.runFramePass();
+    this.glueServedGeneration = passGeneration;
 
     const height = writer.measureContentHeight();
     if (height === this.glueLastHeight) {
@@ -286,7 +294,11 @@ export class TranscriptFramePipeline {
     }
 
     const capElapsed = this.now() - this.glueStartedAt >= TRANSCRIPT_GLUE_MAX_MS;
-    if (this.glueQuietFrames >= GLUE_SETTLE_QUIET_FRAMES || capElapsed) {
+    const trailingEnsurePending = this.glueServedGeneration !== this.glueDemandGeneration;
+    if (
+      (this.glueQuietFrames >= GLUE_SETTLE_QUIET_FRAMES || capElapsed)
+      && !trailingEnsurePending
+    ) {
       this.glueActive = false;
       // PRO-168 (rung 12): the height-quiet/hard-cap glue terminator is about
       // CONTENT settling, not the motion writer's own catch-up distance — an
@@ -323,6 +335,7 @@ export class TranscriptFramePipeline {
       this.caf(this.motionHandle);
     }
     this.motionHandle = null;
+    this.glueServedGeneration = this.glueDemandGeneration;
   }
 
   /** Whether a forced-glue window is currently running (for tests/diagnostics). */

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.compensation.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.compensation.test.tsx
@@ -563,7 +563,7 @@ describe("above-change compensation cancels on upward user intent (PRO-187, r4)"
   // compensation specifically: the reader asked for this by scrolling up, so
   // it must hold regardless of continued upward scrolling — unlike the
   // cancelable completed-turn-split case exercised above.
-  it("clamps a non-cancelable compensation forward against a native scroll event that would erode it below the anchor floor", () => {
+  it("restores the full settled seat after native scroll events erode a non-cancelable compensation", () => {
     const handle = renderHarness();
     const { viewport, api } = handle.current;
     setContentHeight(viewport, 5_552);
@@ -576,19 +576,23 @@ describe("above-change compensation cancels on upward user intent (PRO-187, r4)"
     act(() => { flushRafRound(); });
     act(() => { flushRafRound(); });
 
-    // Content has already settled at its final measured height (no further
-    // growth event will ever fire) while a still-in-flight wheelToTop gesture
-    // keeps writing scrollTop down natively, event by event, toward 0.
+    // Content settles and the lifecycle writer establishes the full running-max
+    // seat: 464 + (6908 - 5552) = 1820.
     setContentHeight(viewport, 6_908);
+    act(() => { api.notifyContentResize(); });
+    expect(viewport.scrollTop).toBe(1_820);
+
+    // A still-in-flight wheelToTop gesture keeps writing scrollTop down natively,
+    // event by event, after height has gone quiet.
     for (const nativeScrollTop of [300, 120, 40, 0]) {
       viewport.scrollTop = nativeScrollTop;
       act(() => { api.onViewportScroll(viewport); });
     }
+    act(() => { flushRafRound(); });
 
-    // NEGATIVE CONTROL: remove the forward-clamp guard in onViewportScroll
-    // (use-transcript-stick-to-bottom.ts) and this regresses to 0 — the exact
-    // CI failure (`expect(after.scrollTop).toBeGreaterThan(150)` receiving 0).
-    expect(viewport.scrollTop).toBe(464);
+    // The single lifecycle writer restores the whole seat, not only the captured
+    // pre-prepend floor.
+    expect(viewport.scrollTop).toBe(1_820);
     expect(viewport.scrollTop).toBeGreaterThan(150);
   });
 });

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.markers.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.markers.test.tsx
@@ -342,4 +342,74 @@ describe("useTranscriptStickToBottom ownership markers (PRO-187)", () => {
     dispatchScroll(handle);
     expect(handle.current.api.isPinnedToBottom).toBe(true);
   });
+
+  it("reconciles the settled prepend seat after a matching marker and trailing input cancellation", () => {
+    const handle = renderHarness();
+    const { viewport, api } = handle.current;
+    setMetrics(viewport, { scrollHeight: 5_552, clientHeight: 400, scrollTop: 475 });
+
+    let scrollTop = 475;
+    const scrollTopWrites: number[] = [];
+    Object.defineProperty(viewport, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (next: number) => {
+        scrollTop = next;
+        scrollTopWrites.push(next);
+      },
+    });
+
+    act(() => {
+      api.setPinned(false);
+      api.startAboveChangeCompensation({ rowCount: 5, scrollHeight: 5_552, scrollTop: 475 }, false);
+    });
+    setMetrics(viewport, { scrollHeight: 6_908, clientHeight: 400, scrollTop: 475 });
+    act(() => { flushRafRound(); });
+    expect(viewport.scrollTop).toBe(1_831);
+
+    // Deliver the zero-valued marker before its watchdog, then model the
+    // trailing input listener attempting to cancel the queued reconciliation.
+    act(() => {
+      api.notifyProgrammaticScroll(() => {
+        viewport.scrollTop = 0;
+      });
+    });
+    scrollTopWrites.length = 0;
+    act(() => {
+      api.onViewportScroll(viewport);
+      api.cancelFramePipeline();
+    });
+    act(() => { flushRafRound(); });
+
+    expect(viewport.scrollTop).toBe(1_831);
+    expect(handle.current.api.isPinnedToBottom).toBe(false);
+    expect(scrollTopWrites).toEqual([1_831]);
+  });
+
+  it("lets upward intent clear a cancelable anchor through the same marker sequence", () => {
+    const handle = renderHarness();
+    const { viewport, api } = handle.current;
+    setMetrics(viewport, { scrollHeight: 5_552, clientHeight: 400, scrollTop: 475 });
+
+    act(() => {
+      api.setPinned(false);
+      api.startAboveChangeCompensation({ rowCount: 5, scrollHeight: 5_552, scrollTop: 475 }, true);
+    });
+    setMetrics(viewport, { scrollHeight: 6_908, clientHeight: 400, scrollTop: 475 });
+    act(() => { flushRafRound(); });
+    expect(viewport.scrollTop).toBe(1_831);
+
+    act(() => {
+      api.notifyUserScrollIntent(-1);
+      api.notifyProgrammaticScroll(() => {
+        viewport.scrollTop = 0;
+      });
+      api.onViewportScroll(viewport);
+      api.cancelFramePipeline();
+    });
+    act(() => { flushRafRound(); });
+
+    expect(viewport.scrollTop).toBe(0);
+    expect(handle.current.api.isPinnedToBottom).toBe(false);
+  });
 });

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
@@ -181,27 +181,20 @@ export function useTranscriptStickToBottom({
     const previousTop = lastScrollTopRef.current;
     lastScrollTopRef.current = top;
 
+    // A live NON-cancelable history prepend remains invariant after height settles.
+    // Re-arm before marker precedence; WebKit momentum can keep eroding through its marker.
+    const hasLiveNonCancelableCompensation = (
+      compensationAnchorRef.current != null
+      && !compensationCancelableRef.current
+      && interactionNow() < compensationDeadlineRef.current
+    );
+    if (hasLiveNonCancelableCompensation) {
+      pipelineRef.current.beginGlue();
+    }
+
     // Classification ladder. PRIMARY: a live ownership marker (queued, so a burst
     // of glue writes keeps attribution) owns this event — clear and return.
     if (ownershipMarkersRef.current.matchByValue(top)) {
-      onScrollSample({ programmatic: true });
-      return;
-    }
-
-    // NON-cancelable compensation (history prepend): never drop scrollTop below
-    // the pre-prepend floor. The pipeline only re-applies on a growth-driven
-    // pass, not a scroll EVENT, so a wheel gesture can erode it unopposed once
-    // content plateaus (CI webkit "prepend anchoring ... scrollTop Received 0").
-    const activeCompensationAnchor = compensationAnchorRef.current;
-    if (
-      activeCompensationAnchor != null
-      && !compensationCancelableRef.current
-      && interactionNow() < compensationDeadlineRef.current
-      && top < activeCompensationAnchor.scrollTop
-    ) {
-      notifyProgrammaticScroll(() => {
-        viewport.scrollTop = activeCompensationAnchor.scrollTop;
-      });
       onScrollSample({ programmatic: true });
       return;
     }
@@ -255,7 +248,6 @@ export function useTranscriptStickToBottom({
     compensationCancelableRef,
     compensationDeadlineRef,
     dispatchInsetEvent,
-    notifyProgrammaticScroll,
     onScrollSample,
     pinnedRef,
     repinThresholdPx,
@@ -284,6 +276,16 @@ export function useTranscriptStickToBottom({
   }, [notifyContentGrew, scrollRef]);
 
   const cancelFramePipeline = useCallback(() => {
+    // A trailing input listener may run after onViewportScroll re-armed the
+    // prepend reconciliation above. Preserve that one queued pass while the
+    // non-cancelable anchor is live; every other owner remains cancelable.
+    if (
+      compensationAnchorRef.current != null
+      && !compensationCancelableRef.current
+      && interactionNow() < compensationDeadlineRef.current
+    ) {
+      return;
+    }
     pipelineRef.current.cancel();
   }, []);
 

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
@@ -189,7 +189,7 @@ export function useTranscriptStickToBottom({
       && interactionNow() < compensationDeadlineRef.current
     );
     if (hasLiveNonCancelableCompensation) {
-      pipelineRef.current.beginGlue();
+      pipelineRef.current.ensureGlue();
     }
 
     // Classification ladder. PRIMARY: a live ownership marker (queued, so a burst

--- a/lints/frontend/ratchets.toml
+++ b/lints/frontend/ratchets.toml
@@ -215,10 +215,6 @@ path = "apps/packages/product-client/src/hooks/chat/ui/use-transcript-frame-pipe
 reason = "rung 4 frame-pipeline refactor: session re-entry / submit re-pin / tab-resume anchor restore, now driven through TranscriptFramePipeline instead of N independent rAF loops"
 
 [[transcript_scroll_writer]]
-path = "apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts"
-reason = "rung 10: NON-cancelable above-change compensation floor — never drops scrollTop below the live compensation anchor during a history prepend, restoring a direct write alongside the frame-pipeline's own writer"
-
-[[transcript_scroll_writer]]
 path = "apps/packages/product-client/src/components/workspace/chat/transcript/FullTranscriptRowList.tsx"
 reason = "transcript row list: engine-owned virtual-anchor scrollTop restore across height changes"
 


### PR DESCRIPTION
## Summary

- Preserve the reader position when Linux WebKit momentum continues during an older-history prepend.
- Route reconciliation through the existing single frame-pipeline writer and remove the duplicate direct scroll writer.
- Preserve the leading glue frame under rapid position events, then drain one coalesced trailing demand when an event arrives during the current or height-quiet terminating pass.
- Keep fresh-owner `beginGlue()` restart semantics unchanged.
- This is the standalone scroll-owner prerequisite for the identical required-context failure observed on #2062, #2069, and #2073.

## Testing

- Tier 1: focused Vitest owners, 35/35 passed.
- Tier 1: shared frontend build, ProductClient typecheck, scroll-fixture typecheck, transcript writer checker, strict frontend structure, boundaries, max-lines, docs, design attribution, and diff hygiene passed.
- Tier 2: unchanged exact prepend Playwright case passed in Chromium and WebKit, 2/2.
- Tier 2: unchanged full scroll-physics suite passed, 33 passed / 1 intentional WebKit skip / 0 failed.
- v1 negative control on current main: expected settled seat 1831, received 0.
- v1.1 scheduler negative control on published head `6fa15e7944`: the regression failed because `ensureGlue` was absent; companion proof shows repeated `beginGlue()` cancels and replaces the pending handle.
- v1.2 trailing-edge negative control on published head `c46d8e1ccb`: after the first and quiet-terminating passes each seated then suffered reentrant erosion, the scheduler stopped at 0 instead of draining the owed pass to 1831.

## Observability

- None. The repair adds no telemetry or geometry logging. Existing renderer diagnostics remain unchanged.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Verification

- Frozen contract: `CS-PREPEND-v1.2`, exact PR base `4390327f55c5c3d6ffde343ea1f5158f304c43b7`.
- Current-main drift audit: remote main `e0a74d6c8ec0f5392db3651ff4423442547749fb`; zero path or semantic overlap; guarded merge tree is clean.
- Hosted v1 disproof: run `32255271740`, job `96075397603`, artifact `9366161651` failed only WebKit at `scrollTop=0`; every other check passed.
- Hosted v1.1 disproof: run `32257422106`, job `96082285192`, artifact `9367009151` again failed only WebKit at `scrollTop=0`; 32 pass / 1 intentional skip / 1 fail. No retry was used.
- Durable CI review: https://github.com/proliferate-ai/proliferate/pull/2076#pullrequestreview-4972435237.
- Independent v1.1 review accepted exact pre-commit diff `b559bc43b064c089f16c1265f65e3268d4c817d5f749feea58d61831ead90c3a`; hosted CI then disproved its sufficiency.
- Independent v1.2 architecture and implementation reviews accepted the exact incremental diff `822a486962d6b34f91ac085f023d013f913be356b095622aadddc70150065268` with no findings.
- Current head: `8947eb9ff0af62f247821102884ac90a2f77a1aa`. Production scope remains limited to the existing hook and pipeline owners; browser fixture, thresholds, retries, projects, packages, lockfile, lifecycle deadlines and math, and Changes heads are untouched.
