### PR TITLE
fix(product): route file locators by authority

### DIFF
--- a/anyharness/sdk-react/src/hooks/files.test.tsx
+++ b/anyharness/sdk-react/src/hooks/files.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AnyHarnessRuntime } from "../context/AnyHarnessRuntime.js";
+import { AnyHarnessWorkspace } from "../context/AnyHarnessWorkspace.js";
+import { useStatWorkspaceFileQuery } from "./files.js";
+
+const mocks = vi.hoisted(() => ({
+  stat: vi.fn(),
+}));
+
+vi.mock("../lib/client-cache.js", () => ({
+  getAnyHarnessClient: () => ({
+    files: {
+      stat: mocks.stat,
+    },
+  }),
+}));
+
+describe("workspace file stat query", () => {
+  afterEach(() => {
+    cleanup();
+    mocks.stat.mockReset();
+  });
+
+  it("stats the workspace root when the path is empty", async () => {
+    mocks.stat.mockResolvedValue({
+      path: "",
+      kind: "directory",
+    });
+    const queryClient = createQueryClient();
+
+    const { result } = renderHook(
+      () => useStatWorkspaceFileQuery({ path: "" }),
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mocks.stat).toHaveBeenCalledOnce();
+    expect(mocks.stat).toHaveBeenCalledWith(
+      "anyharness-workspace-1",
+      "",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("does not stat when the path is null", async () => {
+    const queryClient = createQueryClient();
+
+    const { result } = renderHook(
+      () => useStatWorkspaceFileQuery({ path: null }),
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    await waitFor(() => expect(result.current.fetchStatus).toBe("idle"));
+    expect(mocks.stat).not.toHaveBeenCalled();
+  });
+});
+
+function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <AnyHarnessRuntime runtimeUrl="http://runtime-files.test">
+          <AnyHarnessWorkspace
+            workspaceId="workspace-1"
+            resolveConnection={async () => ({
+              runtimeUrl: "http://runtime-files.test",
+              anyharnessWorkspaceId: "anyharness-workspace-1",
+            })}
+          >
+            {children}
+          </AnyHarnessWorkspace>
+        </AnyHarnessRuntime>
+      </QueryClientProvider>
+    );
+  };
+}

--- a/anyharness/sdk-react/src/hooks/files.ts
+++ b/anyharness/sdk-react/src/hooks/files.ts
@@ -164,7 +164,9 @@ export function useStatWorkspaceFileQuery(options: {
   const workspace = useAnyHarnessWorkspaceContext();
   const cacheScopeKey = useAnyHarnessCacheScopeKey();
   const workspaceId = options.workspaceId ?? workspace.workspaceId;
-  const enabled = (options.enabled ?? true) && !!workspaceId && !!options.path;
+  const enabled = (options.enabled ?? true)
+    && !!workspaceId
+    && options.path !== null;
   const queryKey = anyHarnessWorkspaceFileStatKey(cacheScopeKey, workspaceId, options.path);
   useReportAnyHarnessCacheDecision({
     category: "file.stat",

--- a/anyharness/sdk/src/reducer/__tests__/file-change-path-presence.test.ts
+++ b/anyharness/sdk/src/reducer/__tests__/file-change-path-presence.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { reduceEvents } from "../../index.js";
+import type {
+  ContentPart,
+  SessionEventEnvelope,
+  ToolCallItem,
+} from "../../index.js";
+
+describe("file-change path presence", () => {
+  it("keeps identity stable when a workspace path becomes empty", () => {
+    const state = reduceFileChangeSnapshots(
+      [fileChange({ path: "/wire/src/app.ts", workspacePath: "src/app.ts" })],
+      [fileChange({ path: "/wire/src/app.ts", workspacePath: "" })],
+    );
+
+    const fileChanges = changes(state.itemsById["tool-1"] as ToolCallItem);
+    expect(fileChanges).toHaveLength(1);
+    expect(fileChanges[0]).toMatchObject({
+      path: "/wire/src/app.ts",
+      workspacePath: "",
+    });
+  });
+
+  it("keeps identity stable when a new workspace path becomes whitespace", () => {
+    const state = reduceFileChangeSnapshots(
+      [fileChange({
+        operation: "move",
+        path: "/wire/src/old.ts",
+        workspacePath: "src/old.ts",
+        newPath: "/wire/src/new.ts",
+        newWorkspacePath: "src/new.ts",
+      })],
+      [fileChange({
+        operation: "move",
+        path: "/wire/src/old.ts",
+        workspacePath: "src/old.ts",
+        newPath: "/wire/src/new.ts",
+        newWorkspacePath: "  ",
+      })],
+    );
+
+    const fileChanges = changes(state.itemsById["tool-1"] as ToolCallItem);
+    expect(fileChanges).toHaveLength(1);
+    expect(fileChanges[0]).toMatchObject({
+      newPath: "/wire/src/new.ts",
+      newWorkspacePath: "  ",
+    });
+  });
+
+  it("keeps different raw wire paths distinct despite shared structured paths", () => {
+    const state = reduceFileChangeSnapshots(
+      [fileChange({ path: "/wire/src/first.ts", workspacePath: "src/shared.ts" })],
+      [fileChange({ path: "/wire/src/second.ts", workspacePath: "src/shared.ts" })],
+    );
+
+    const fileChanges = changes(state.itemsById["tool-1"] as ToolCallItem);
+    expect(fileChanges).toHaveLength(2);
+    expect(fileChanges.map((part) => part.path)).toEqual(expect.arrayContaining([
+      "/wire/src/first.ts",
+      "/wire/src/second.ts",
+    ]));
+  });
+});
+
+type FileChange = Extract<ContentPart, { type: "file_change" }>;
+
+function fileChange(
+  fields: Pick<FileChange, "path"> & Partial<Omit<FileChange, "type" | "path">>,
+): FileChange {
+  return { type: "file_change", operation: "edit", ...fields };
+}
+
+function changes(item: ToolCallItem): FileChange[] {
+  return item.contentParts.filter((part): part is FileChange => part.type === "file_change");
+}
+
+function reduceFileChangeSnapshots(initial: FileChange[], next: FileChange[]) {
+  const toolCallPart: Extract<ContentPart, { type: "tool_call" }> = {
+    type: "tool_call",
+    toolCallId: "tool-1",
+    title: "Edit file",
+    toolKind: "edit",
+  };
+  const events: SessionEventEnvelope[] = [
+    {
+      sessionId: "session-1",
+      seq: 1,
+      timestamp: "2026-04-04T00:00:01Z",
+      turnId: "turn-1",
+      event: { type: "turn_started" },
+    },
+    {
+      sessionId: "session-1",
+      seq: 2,
+      timestamp: "2026-04-04T00:00:02Z",
+      turnId: "turn-1",
+      itemId: "tool-1",
+      event: {
+        type: "item_started",
+        item: {
+          kind: "tool_invocation",
+          status: "in_progress",
+          sourceAgentKind: "claude",
+          toolCallId: "tool-1",
+          title: "Edit file",
+          contentParts: [toolCallPart, ...initial],
+        },
+      },
+    },
+    {
+      sessionId: "session-1",
+      seq: 3,
+      timestamp: "2026-04-04T00:00:03Z",
+      turnId: "turn-1",
+      itemId: "tool-1",
+      event: {
+        type: "item_delta",
+        delta: { replaceContentParts: [toolCallPart, ...next] },
+      },
+    },
+  ];
+  return reduceEvents(events, "session-1");
+}

--- a/anyharness/sdk/src/reducer/file-change-path-presence.ts
+++ b/anyharness/sdk/src/reducer/file-change-path-presence.ts
@@ -1,0 +1,14 @@
+import type { FileChangeContentPart } from "../types/events.js";
+
+/** Streaming identity is stable while structured locator metadata is refined. */
+export function fileChangeIdentity(part: FileChangeContentPart): string {
+  return `${part.path}\u0000${part.newPath ?? ""}`;
+}
+
+/** Every supplied string is authoritative, including empty and whitespace. */
+export function chooseWorkspacePathString(
+  next: string | null | undefined,
+  previous: string | null | undefined,
+): string | null {
+  return typeof next === "string" ? next : previous ?? null;
+}

--- a/anyharness/sdk/src/reducer/transcript.ts
+++ b/anyharness/sdk/src/reducer/transcript.ts
@@ -25,6 +25,10 @@ import type {
 } from "../types/reducer.js";
 import { reducePendingPrompts } from "./pending-prompts.js";
 import {
+  chooseWorkspacePathString,
+  fileChangeIdentity,
+} from "./file-change-path-presence.js";
+import {
   ensureMutableContextItem as ensureMutableKnownItem,
   ensureMutableContextTurn,
   reduceTranscriptEventBatch,
@@ -36,7 +40,6 @@ import {
 } from "./transcript-reduction-context.js";
 
 export type { ReduceOptions } from "./transcript-reduction-context.js";
-
 export function createTranscriptState(sessionId: string): TranscriptState {
   return {
     sessionMeta: {
@@ -1185,12 +1188,6 @@ function mergeFileChangeParts(
   return [...merged, ...remainingCurrent];
 }
 
-function fileChangeIdentity(part: FileChangeContentPart): string {
-  const currentPath = part.workspacePath ?? part.path;
-  const nextPath = part.newWorkspacePath ?? part.newPath ?? "";
-  return `${currentPath}\u0000${nextPath}`;
-}
-
 function mergeFileChangePart(
   previous: FileChangeContentPart,
   next: FileChangeContentPart,
@@ -1206,10 +1203,13 @@ function mergeFileChangePart(
     type: "file_change",
     operation: next.operation,
     path: chooseString(next.path, previous.path),
-    workspacePath: chooseNullableString(next.workspacePath, previous.workspacePath),
+    workspacePath: chooseWorkspacePathString(
+      next.workspacePath,
+      previous.workspacePath,
+    ),
     basename: chooseNullableString(next.basename, previous.basename),
     newPath: chooseNullableString(next.newPath, previous.newPath),
-    newWorkspacePath: chooseNullableString(
+    newWorkspacePath: chooseWorkspacePathString(
       next.newWorkspacePath,
       previous.newWorkspacePath,
     ),

--- a/apps/packages/product-client/package.json
+++ b/apps/packages/product-client/package.json
@@ -55,8 +55,11 @@
     "typecheck": "node scripts/copy-product-client-assets.mjs && pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @anyharness/sdk build && tsc -p tsconfig.domain.json && pnpm --filter @anyharness/sdk-react build && pnpm --filter @proliferate/cloud-sdk-react build && pnpm --filter @proliferate/design build && tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "build:scroll-physics-fixture": "vite build --config qualification/scroll-physics/vite.config.ts",
+    "build:file-viewer-fixture": "vite build --config qualification/file-viewer/vite.config.ts",
     "build:workflow-canvas-fixture": "vite build --config qualification/workflow-canvas/vite.config.ts",
+    "typecheck:file-viewer": "tsc --noEmit -p qualification/file-viewer/tsconfig.json",
     "typecheck:workflow-canvas": "tsc --noEmit -p qualification/workflow-canvas/tsconfig.json",
+    "test:file-viewer": "pnpm --workspace-root shared:build && pnpm run build:file-viewer-fixture && playwright test --config qualification/file-viewer/playwright.config.ts",
     "test:workflow-canvas": "pnpm run build:workflow-canvas-fixture && playwright test --config qualification/workflow-canvas/playwright.config.ts",
     "typecheck:scroll-physics": "tsc --noEmit -p qualification/scroll-physics/tsconfig.json",
     "test:scroll-physics": "pnpm run build:scroll-physics-fixture && playwright test --config qualification/scroll-physics/playwright.config.ts"

--- a/apps/packages/product-client/qualification/file-viewer/.gitignore
+++ b/apps/packages/product-client/qualification/file-viewer/.gitignore
@@ -1,0 +1,2 @@
+dist/
+test-results/

--- a/apps/packages/product-client/qualification/file-viewer/index.html
+++ b/apps/packages/product-client/qualification/file-viewer/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" data-mode="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>File Reference Routing Fixture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/packages/product-client/qualification/file-viewer/playwright.config.ts
+++ b/apps/packages/product-client/qualification/file-viewer/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from "@playwright/test";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = fileURLToPath(new URL("../../", import.meta.url));
+const fixtureDir = fileURLToPath(new URL(".", import.meta.url));
+
+export default defineConfig({
+  testDir: "./specs",
+  outputDir: `${fixtureDir}/test-results`,
+  workers: 1,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  reporter: process.env.CI ? [["list"], ["github"]] : [["list"]],
+  use: {
+    baseURL: "http://127.0.0.1:5180",
+    headless: true,
+    trace: "retain-on-failure",
+    viewport: { width: 960, height: 720 },
+    colorScheme: "dark",
+    locale: "en-US",
+    timezoneId: "UTC",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: "pnpm exec vite preview --config qualification/file-viewer/vite.config.ts",
+    cwd: packageRoot,
+    url: "http://127.0.0.1:5180",
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+});

--- a/apps/packages/product-client/qualification/file-viewer/specs/file-reference-routing.spec.ts
+++ b/apps/packages/product-client/qualification/file-viewer/specs/file-reference-routing.spec.ts
@@ -1,0 +1,220 @@
+import { expect, test, type Page } from "@playwright/test";
+
+interface FixtureSnapshot {
+  counters: {
+    clipboard: number;
+    discovery: number;
+    home: number;
+    inspection: number;
+    nativeMenu: number;
+    open: number;
+    reveal: number;
+  };
+  clipboardValues: string[];
+  nativeMenuItems: Array<{
+    kind: "action" | "separator" | "submenu";
+    id?: string;
+    label?: string;
+    enabled?: boolean;
+  }>;
+  openedPaths: Array<{ targetId: string; path: string }>;
+  revealedPaths: string[];
+}
+
+const WORKSPACE_ROUTES = [
+  {
+    name: "Desktop with local provenance",
+    path: "/playground/files?host=desktop&origin=local&case=workspace-file",
+    localDesktop: true,
+  },
+  {
+    name: "Desktop with remote provenance",
+    path: "/playground/files?host=desktop&origin=remote&case=workspace-file",
+    localDesktop: false,
+  },
+  {
+    name: "Web with local provenance",
+    path: "/playground/files?host=web&origin=local&case=workspace-file",
+    localDesktop: false,
+  },
+  {
+    name: "Web with remote provenance",
+    path: "/playground/files?host=web&origin=remote&case=workspace-file",
+    localDesktop: false,
+  },
+] as const;
+
+for (const route of WORKSPACE_ROUTES) {
+  test(`${route.name} opens the settled workspace file in the viewer`, async ({ page }) => {
+    const externalRequests = await openFixture(page, route.path);
+    const badge = page.locator('button[data-file-reference-badge="chip"]');
+    await expect(badge).toBeVisible();
+
+    if (route.localDesktop) {
+      await expect.poll(async () => (await fixtureSnapshot(page)).counters.discovery).toBe(1);
+    }
+
+    await badge.click();
+    await expect(page.locator("[data-file-viewer-frame]")).toBeVisible();
+    await expect(page.locator('[data-file-reference-viewer="active"]')).toBeVisible();
+
+    if (route.localDesktop) {
+      await badge.click({ button: "right" });
+      const openExternal = page.getByRole("menuitem", { name: "Open in Fixture Editor" });
+      await expect(openExternal).toBeVisible();
+      await openExternal.click();
+      await expect.poll(async () => (await fixtureSnapshot(page)).counters.open).toBe(1);
+
+      const snapshot = await fixtureSnapshot(page);
+      expect(snapshot.counters.home).toBe(0);
+      expect(snapshot.counters.inspection).toBe(0);
+      expect(snapshot.counters.reveal).toBe(0);
+      expect(snapshot.openedPaths).toEqual([
+        { targetId: "fixture-editor", path: "/fixture-workspace/src/example.ts" },
+      ]);
+    } else {
+      expectNativePathCalls(await fixtureSnapshot(page)).toEqual({
+        discovery: 0,
+        home: 0,
+        inspection: 0,
+        open: 0,
+        reveal: 0,
+      });
+    }
+
+    expect(externalRequests).toEqual([]);
+  });
+}
+
+test("local Desktop opens an authority-proven Desktop file natively", async ({ page }) => {
+  const externalRequests = await openFixture(
+    page,
+    "/playground/files?host=desktop&origin=local&case=desktop-file",
+  );
+  const badge = page.locator('button[data-file-reference-badge="chip"]');
+  await expect(badge).toBeVisible();
+  await expect.poll(async () => (await fixtureSnapshot(page)).counters.inspection).toBe(1);
+  await expect.poll(async () => (await fixtureSnapshot(page)).counters.discovery).toBe(1);
+
+  await badge.click();
+  await expect.poll(async () => (await fixtureSnapshot(page)).counters.open).toBe(1);
+  await expect(page.locator("[data-file-viewer-frame]")).toHaveCount(0);
+
+  const snapshot = await fixtureSnapshot(page);
+  expect(snapshot.counters.home).toBe(0);
+  expect(snapshot.counters.reveal).toBe(0);
+  expect(snapshot.openedPaths).toEqual([
+    { targetId: "fixture-editor", path: "/outside/reference.txt" },
+  ]);
+  expect(externalRequests).toEqual([]);
+});
+
+test("remote Desktop unavailable reference exposes exactly Copy path", async ({ page }) => {
+  const externalRequests = await openFixture(
+    page,
+    "/playground/files?host=desktop&origin=remote&case=unavailable",
+  );
+  const badge = page.locator('[data-file-reference-badge="chip"]');
+  await expect(badge).toBeVisible();
+  await expect(badge).toHaveAttribute("data-file-reference-unavailable", "true");
+
+  await badge.click({ button: "right" });
+  const menu = page.locator('[data-slot="popover-content"]');
+  const menuItems = menu.getByRole("menuitem");
+  await expect(menuItems).toHaveCount(1);
+  await expect(menuItems.first()).toBeEnabled();
+  await expect(menuItems.first()).toHaveText("Copy path");
+  await expect(menu.locator(":scope > div > .h-px")).toHaveCount(0);
+
+  await expect.poll(async () => (await fixtureSnapshot(page)).counters.nativeMenu).toBe(1);
+  let snapshot = await fixtureSnapshot(page);
+  expect(snapshot.nativeMenuItems).toEqual([
+    {
+      kind: "action",
+      id: "copy-path",
+      label: "Copy path",
+      enabled: true,
+    },
+  ]);
+  expectNativePathCalls(snapshot).toEqual({
+    discovery: 0,
+    home: 0,
+    inspection: 0,
+    open: 0,
+    reveal: 0,
+  });
+
+  await menuItems.first().click();
+  snapshot = await fixtureSnapshot(page);
+  expect(snapshot.counters.clipboard).toBe(1);
+  expect(snapshot.clipboardValues).toEqual(["/outside/reference.txt"]);
+  expect(externalRequests).toEqual([]);
+});
+
+for (const inertCase of ["empty", "whitespace"] as const) {
+  test(`${inertCase} reference exposes no DOM or native menu`, async ({ page }) => {
+    const externalRequests = await openFixture(
+      page,
+      `/playground/files?host=desktop&origin=local&case=${inertCase}`,
+    );
+    const badge = page.locator('[data-file-reference-badge="chip"]');
+    await expect(badge).toBeVisible();
+    await expect(badge).toHaveAttribute("data-file-reference-unavailable", "true");
+    await badge.click({ button: "right" });
+
+    await expect(page.locator('[data-slot="popover-content"]')).toHaveCount(0);
+    const snapshot = await fixtureSnapshot(page);
+    expect(snapshot.counters).toEqual({
+      clipboard: 0,
+      discovery: 0,
+      home: 0,
+      inspection: 0,
+      nativeMenu: 0,
+      open: 0,
+      reveal: 0,
+    });
+    expect(snapshot.clipboardValues).toEqual([]);
+    expect(snapshot.nativeMenuItems).toEqual([]);
+    expect(externalRequests).toEqual([]);
+  });
+}
+
+async function openFixture(page: Page, path: string): Promise<string[]> {
+  const externalRequests: string[] = [];
+  await page.route("**/*", async (route) => {
+    const url = new URL(route.request().url());
+    if (url.hostname === "127.0.0.1") {
+      await route.continue();
+      return;
+    }
+    externalRequests.push(url.href);
+    await route.abort("blockedbyclient");
+  });
+  await page.clock.setFixedTime(new Date("2026-08-19T12:00:00.000Z"));
+  await page.emulateMedia({ reducedMotion: "reduce", colorScheme: "dark" });
+  await page.goto(path);
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+  });
+  await expect(page.locator("[data-file-reference-routing-fixture]")).toBeVisible();
+  return externalRequests;
+}
+
+async function fixtureSnapshot(page: Page): Promise<FixtureSnapshot> {
+  return page.evaluate(() => {
+    const fixtureWindow = window as typeof window & {
+      __fileReferenceRoutingFixture: { snapshot(): FixtureSnapshot };
+    };
+    return fixtureWindow.__fileReferenceRoutingFixture.snapshot();
+  });
+}
+
+function expectNativePathCalls(snapshot: FixtureSnapshot) {
+  return expect({
+    discovery: snapshot.counters.discovery,
+    home: snapshot.counters.home,
+    inspection: snapshot.counters.inspection,
+    open: snapshot.counters.open,
+    reveal: snapshot.counters.reveal,
+  });
+}

--- a/apps/packages/product-client/qualification/file-viewer/src/main.tsx
+++ b/apps/packages/product-client/qualification/file-viewer/src/main.tsx
@@ -1,0 +1,377 @@
+import "@proliferate/design/product.css";
+
+import { AnyHarnessRuntime, AnyHarnessWorkspace } from "@anyharness/sdk-react";
+import type { Workspace } from "@anyharness/sdk";
+import type {
+  DesktopBridge,
+  DesktopFilesBridge,
+  DesktopNativeUiBridge,
+  NativeMenuItem,
+  OpenTarget,
+} from "@proliferate/product-client/host/desktop-bridge";
+import type { ProductHost } from "@proliferate/product-client/host/product-host";
+import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import ReactDOM from "react-dom/client";
+import { FileViewerPlaygroundPage } from "#product/pages/FileViewerPlaygroundPage";
+import type { ProductResolvedWorkspaceConnection } from "#product/lib/access/anyharness/resolve-workspace-connection";
+import { ProductWorkspaceConnectionProvider } from "#product/providers/ProductWorkspaceConnectionProvider";
+import { WorkspacePathProvider } from "#product/providers/WorkspacePathProvider";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+import { useWorkspaceViewerTabsStore } from "#product/stores/editor/workspace-viewer-tabs-store";
+
+type FixtureHost = "desktop" | "web";
+type FixtureOrigin = "local" | "remote";
+
+interface FixtureCounters {
+  clipboard: number;
+  discovery: number;
+  home: number;
+  inspection: number;
+  nativeMenu: number;
+  open: number;
+  reveal: number;
+}
+
+interface NativeMenuItemSnapshot {
+  kind: "action" | "separator" | "submenu";
+  id?: string;
+  label?: string;
+  enabled?: boolean;
+  items?: NativeMenuItemSnapshot[];
+}
+
+interface FileReferenceRoutingFixtureSnapshot {
+  counters: FixtureCounters;
+  clipboardValues: string[];
+  nativeMenuItems: NativeMenuItemSnapshot[];
+  openedPaths: Array<{ targetId: string; path: string }>;
+  revealedPaths: string[];
+}
+
+interface FileReferenceRoutingFixture {
+  snapshot(): FileReferenceRoutingFixtureSnapshot;
+}
+
+declare global {
+  interface Window {
+    __fileReferenceRoutingFixture: FileReferenceRoutingFixture;
+  }
+}
+
+const FIXTURE_WORKSPACE_ID = "fixture-workspace";
+const FIXTURE_RUNTIME_WORKSPACE_ID = "fixture-runtime-workspace";
+const FIXTURE_RUNTIME_URL = "https://file-reference-routing.invalid";
+const FIXTURE_WORKSPACE_ROOT = "/fixture-workspace";
+const FIXED_TIME = "2026-08-19T12:00:00.000Z";
+
+const params = new URLSearchParams(window.location.search);
+const fixtureHost: FixtureHost = params.get("host") === "web" ? "web" : "desktop";
+const fixtureOrigin: FixtureOrigin = params.get("origin") === "remote" ? "remote" : "local";
+
+const counters: FixtureCounters = {
+  clipboard: 0,
+  discovery: 0,
+  home: 0,
+  inspection: 0,
+  nativeMenu: 0,
+  open: 0,
+  reveal: 0,
+};
+const clipboardValues: string[] = [];
+const openedPaths: Array<{ targetId: string; path: string }> = [];
+const revealedPaths: string[] = [];
+let nativeMenuItems: NativeMenuItemSnapshot[] = [];
+
+const editorTarget: OpenTarget = {
+  id: "fixture-editor",
+  label: "Fixture Editor",
+  kind: "editor",
+  iconId: "vscode",
+};
+
+const files: DesktopFilesBridge = {
+  pickDirectory: async () => ({ kind: "cancelled" }),
+  getHomeDirectory: async () => {
+    counters.home += 1;
+    return "/Users/fixture";
+  },
+  inspectPath: async () => {
+    counters.inspection += 1;
+    return { kind: "file" };
+  },
+  getDragPasteboardChangeCount: async () => -1,
+  readDroppedPaths: async () => ({ changeCount: -1, entries: [] }),
+  listAvailableEditors: async () => [],
+  listOpenTargets: async () => {
+    counters.discovery += 1;
+    return [editorTarget];
+  },
+  openTarget: async (targetId, path) => {
+    counters.open += 1;
+    openedPaths.push({ targetId, path });
+  },
+  reveal: async (path) => {
+    counters.reveal += 1;
+    revealedPaths.push(path);
+  },
+  openTerminal: async () => {},
+};
+
+const nativeUi = {
+  showContextMenu: async (items: NativeMenuItem[]) => {
+    counters.nativeMenu += 1;
+    nativeMenuItems = items.map(snapshotNativeMenuItem);
+    // Exercise the shipped DOM fallback from the same context-menu event.
+    return false;
+  },
+  subscribeMenuCommands: () => () => {},
+  setRunningAgentCount: async () => {},
+  setWorkspaceActivity: async () => {},
+  setZoom: async () => {},
+  applyMacosWindowChrome: async () => {},
+  isMainWebviewAvailable: () => false,
+  revealCurrentWindow: async () => {},
+} satisfies DesktopNativeUiBridge;
+
+const desktop = fixtureHost === "desktop"
+  ? ({ files, nativeUi } as unknown as DesktopBridge)
+  : null;
+
+const host: ProductHost = {
+  surface: fixtureHost,
+  deployment: { apiBaseUrl: "https://file-reference-routing-cloud.invalid" },
+  auth: {
+    authRequired: false,
+    state: { status: "anonymous", methods: [] },
+    restoreSession: async () => {},
+    startLogin: async () => ({ provider: "fixture", source: "qualification" }),
+    finishLogin: async () => {},
+    cancelLogin: async () => {},
+    logout: async () => ({ provider: "fixture" }),
+  },
+  cloud: {
+    client: null,
+    getSandboxGatewayAccessToken: async () => {
+      throw new Error("File-reference qualification has no Cloud transport.");
+    },
+  },
+  storage: {
+    getItem: async () => null,
+    setItem: async () => {},
+    removeItem: async () => {},
+  },
+  links: {
+    openExternal: async () => {},
+    buildReturnUrl: () => "https://file-reference-routing.invalid/callback",
+    observeInboundEntries: () => () => {},
+  },
+  clipboard: {
+    writeText: async (value) => {
+      counters.clipboard += 1;
+      clipboardValues.push(value);
+    },
+  },
+  telemetry: {
+    track: () => {},
+    captureException: () => {},
+    setUser: () => {},
+    setTag: () => {},
+    routeChanged: () => {},
+    getSupportContext: () => ({ clientReleaseId: "file-reference-routing-qualification" }),
+    getAnonymousInstallId: async () => "file-reference-routing-qualification",
+  },
+  desktop,
+};
+
+const productConnection: ProductResolvedWorkspaceConnection = {
+  connection: {
+    runtimeUrl: FIXTURE_RUNTIME_URL,
+    anyharnessWorkspaceId: FIXTURE_RUNTIME_WORKSPACE_ID,
+    runtimeGeneration: 1,
+    runtimeAccessKind: fixtureOrigin === "local" ? "direct" : "proliferate-gateway",
+    ...(fixtureOrigin === "remote" ? { webSocketAuthTransport: "protocol" as const } : {}),
+  },
+  filesystemOrigin: fixtureOrigin === "local" ? "desktop-local" : "remote",
+};
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+      staleTime: Infinity,
+    },
+  },
+});
+
+const workspace: Workspace = {
+  id: FIXTURE_RUNTIME_WORKSPACE_ID,
+  kind: "local",
+  availability: "available",
+  lifecycleState: "active",
+  surface: "standard",
+  path: FIXTURE_WORKSPACE_ROOT,
+  repoRootId: "fixture-repo-root",
+  createdAt: FIXED_TIME,
+  updatedAt: FIXED_TIME,
+};
+
+const fixtureFetch: typeof globalThis.fetch = async (input) => {
+  const rawUrl = typeof input === "string"
+    ? input
+    : input instanceof URL
+      ? input.href
+      : input.url;
+  const url = new URL(rawUrl);
+  if (url.origin !== FIXTURE_RUNTIME_URL) {
+    throw new Error(`External network is forbidden in file-reference qualification: ${url.origin}`);
+  }
+
+  if (url.pathname.endsWith(`/v1/workspaces/${FIXTURE_RUNTIME_WORKSPACE_ID}`)) {
+    return jsonResponse(workspace);
+  }
+  if (url.pathname.endsWith("/files/stat")) {
+    const path = url.searchParams.get("path") ?? "";
+    return jsonResponse({
+      kind: path === "" ? "directory" : "file",
+      path,
+      isText: path !== "",
+      sizeBytes: path === "" ? null : 62,
+      modifiedAt: FIXED_TIME,
+    });
+  }
+  if (url.pathname.endsWith("/files/file")) {
+    const path = url.searchParams.get("path") ?? "src/example.ts";
+    return jsonResponse({
+      content: "export const fixture = 'file reference routing';\n",
+      encoding: "utf-8",
+      isText: true,
+      kind: "file",
+      modifiedAt: FIXED_TIME,
+      path,
+      sizeBytes: 49,
+      tooLarge: false,
+      versionToken: "fixture-v1",
+    });
+  }
+  if (url.pathname.endsWith("/git/status")) {
+    return jsonResponse({
+      actions: {
+        canCommit: false,
+        canCreateBranchWorkspace: false,
+        canCreateDraftPullRequest: false,
+        canCreatePullRequest: false,
+        canPush: false,
+        pushLabel: "Push",
+      },
+      ahead: 0,
+      behind: 0,
+      clean: true,
+      conflicted: false,
+      currentBranch: "main",
+      detached: false,
+      files: [],
+      headOid: "0000000000000000000000000000000000000000",
+      operation: "none",
+      repoRootPath: FIXTURE_WORKSPACE_ROOT,
+      summary: {
+        additions: 0,
+        changedFiles: 0,
+        conflictedFiles: 0,
+        deletions: 0,
+        includedFiles: 0,
+      },
+      workspaceId: FIXTURE_RUNTIME_WORKSPACE_ID,
+      workspacePath: FIXTURE_WORKSPACE_ROOT,
+    });
+  }
+  if (url.pathname.endsWith("/files/search")) {
+    return jsonResponse({ results: [] });
+  }
+
+  throw new Error(`Unscripted AnyHarness request: ${url.pathname}${url.search}`);
+};
+
+window.fetch = fixtureFetch;
+window.__fileReferenceRoutingFixture = {
+  snapshot: () => ({
+    counters: { ...counters },
+    clipboardValues: [...clipboardValues],
+    nativeMenuItems: structuredClone(nativeMenuItems),
+    openedPaths: openedPaths.map((entry) => ({ ...entry })),
+    revealedPaths: [...revealedPaths],
+  }),
+};
+document.documentElement.dataset.proliferateClient = fixtureHost;
+
+useSessionSelectionStore.setState({
+  _hydrated: true,
+  selectedLogicalWorkspaceId: FIXTURE_WORKSPACE_ID,
+  selectedWorkspaceId: FIXTURE_WORKSPACE_ID,
+});
+useWorkspaceViewerTabsStore.getState().prepareWorkspace({
+  workspaceUiKey: FIXTURE_WORKSPACE_ID,
+  materializedWorkspaceId: FIXTURE_WORKSPACE_ID,
+});
+
+const resolveProductConnection = async (): Promise<ProductResolvedWorkspaceConnection> => (
+  productConnection
+);
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <ProductHostProvider host={host}>
+        <AnyHarnessRuntime
+          runtimeUrl={FIXTURE_RUNTIME_URL}
+          cacheScopeKey="file-reference-routing-qualification"
+          fetch={fixtureFetch}
+        >
+          <ProductWorkspaceConnectionProvider resolveConnection={resolveProductConnection}>
+            <AnyHarnessWorkspace
+              workspaceId={FIXTURE_WORKSPACE_ID}
+              resolveConnection={async () => productConnection.connection}
+            >
+              <WorkspacePathProvider>
+                <Routes>
+                  <Route path="/playground/files" element={<FileViewerPlaygroundPage />} />
+                </Routes>
+              </WorkspacePathProvider>
+            </AnyHarnessWorkspace>
+          </ProductWorkspaceConnectionProvider>
+        </AnyHarnessRuntime>
+      </ProductHostProvider>
+    </QueryClientProvider>
+  </BrowserRouter>,
+);
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function snapshotNativeMenuItem(item: NativeMenuItem): NativeMenuItemSnapshot {
+  if (item.kind === "separator") {
+    return { kind: "separator" };
+  }
+  if (item.kind === "submenu") {
+    return {
+      kind: "submenu",
+      label: item.label,
+      enabled: item.enabled !== false,
+      items: item.items.map(snapshotNativeMenuItem),
+    };
+  }
+  return {
+    kind: "action",
+    id: item.id,
+    label: item.label,
+    enabled: item.enabled !== false,
+  };
+}

--- a/apps/packages/product-client/qualification/file-viewer/tsconfig.json
+++ b/apps/packages/product-client/qualification/file-viewer/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "types": ["vite/client"],
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src", "specs", "vite.config.ts", "playwright.config.ts"]
+}

--- a/apps/packages/product-client/qualification/file-viewer/vite.config.ts
+++ b/apps/packages/product-client/qualification/file-viewer/vite.config.ts
@@ -1,0 +1,15 @@
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { fileURLToPath, URL } from "node:url";
+import { defineConfig } from "vite";
+
+// Qualification-only host for the shipped file-reference and viewer build.
+// Package-private #product imports resolve through ProductClient's dist map.
+const root = fileURLToPath(new URL(".", import.meta.url));
+
+export default defineConfig({
+  root,
+  plugins: [react(), tailwindcss()],
+  server: { host: "127.0.0.1", port: 5180, strictPort: true, hmr: false },
+  preview: { host: "127.0.0.1", port: 5180, strictPort: true },
+});

--- a/apps/packages/product-client/src/App.tsx
+++ b/apps/packages/product-client/src/App.tsx
@@ -120,6 +120,14 @@ const CrashRecoveryPlaygroundPage = import.meta.env.DEV
     )
   : null
 
+const FileViewerPlaygroundPage = import.meta.env.DEV
+  ? lazy(() =>
+      import("#product/pages/FileViewerPlaygroundPage").then((m) => ({
+        default: m.FileViewerPlaygroundPage,
+      })),
+    )
+  : null
+
 interface AppProps {
   // Host-supplied routes component (Desktop/Web pass their Sentry-instrumented
   // InstrumentedRoutes; the browser fixture passes plain React Router Routes).
@@ -281,6 +289,16 @@ export function App({ RoutesComponent }: AppProps) {
               }
             />
           )}
+          {import.meta.env.DEV && FileViewerPlaygroundPage && (
+            <Route
+              path="/playground/files"
+              element={
+                <Suspense fallback={null}>
+                  <FileViewerPlaygroundPage />
+                </Suspense>
+              }
+            />
+          )}
           <Route path="*" element={<Navigate to="/" replace />} />
         </RoutesComponent>
         <SupportModalHost />
@@ -338,4 +356,3 @@ function AppMinDesktopVersionGate() {
     </Suspense>
   )
 }
-

--- a/apps/packages/product-client/src/components/content/ui/FilePathLink.tsx
+++ b/apps/packages/product-client/src/components/content/ui/FilePathLink.tsx
@@ -15,11 +15,9 @@ interface FilePathLinkProps {
  * Inline file-path link rendered in chat markdown and tool-call output.
  *
  * Behavior:
- *  - Click -> open workspace files in the right-sidebar viewer and external
- *    Desktop files in the configured external target.
- *  - Actionable references expose external targets, copy, and reveal through
- *    the context menu.
- *  - An unavailable path is plain text with no file-reference controls.
+ *  - Actionable references expose their authority-shaped primary and menu actions.
+ *  - A nonempty unavailable reference exposes Copy path only.
+ *  - An empty or whitespace reference exposes no controls.
  *
  * Style: local file/doc link in `text-link-foreground`, no pill,
  * no border, underline on hover only.

--- a/apps/packages/product-client/src/components/playground/FileViewerPlayground.tsx
+++ b/apps/packages/product-client/src/components/playground/FileViewerPlayground.tsx
@@ -1,0 +1,86 @@
+import { FileReferenceBadge } from "#product/components/workspace/file-references/FileReferenceBadge";
+import { FileEditorView } from "#product/components/workspace/files/FileEditorView";
+import {
+  parseViewerTargetKey,
+  viewerTargetKey,
+} from "#product/lib/domain/workspaces/viewer/viewer-target";
+import { useWorkspaceViewerTabsStore } from "#product/stores/editor/workspace-viewer-tabs-store";
+import { useSearchParams } from "react-router-dom";
+
+type FileViewerPlaygroundCase =
+  | "workspace-file"
+  | "desktop-file"
+  | "unavailable"
+  | "empty"
+  | "whitespace";
+
+interface FileReferenceScenario {
+  caseName: FileViewerPlaygroundCase;
+  rawPath: string;
+  workspacePath?: string;
+}
+
+const WORKSPACE_FILE_PATH = "src/example.ts";
+
+/**
+ * Deterministic file-reference route used by the browser qualification host.
+ * It composes the shipped badge and viewer; the host owns all fixed transport
+ * data and bridge counters.
+ */
+export function FileViewerPlayground() {
+  const [params] = useSearchParams();
+  const scenario = resolveScenario(params.get("case"));
+  const activeTargetKey = useWorkspaceViewerTabsStore((state) => state.activeTargetKey);
+  const activeTarget = activeTargetKey ? parseViewerTargetKey(activeTargetKey) : null;
+  const activeFileTarget = activeTarget?.kind === "file" ? activeTarget : null;
+
+  return (
+    <main
+      data-telemetry-block
+      data-file-reference-routing-fixture
+      data-fixture-case={scenario.caseName}
+      className="flex h-screen min-h-0 min-w-0 flex-col bg-background text-foreground"
+    >
+      <div className="flex shrink-0 items-center gap-3 border-b border-border bg-sidebar px-4 py-3">
+        <span className="text-ui-sm text-muted-foreground">File reference</span>
+        <FileReferenceBadge
+          rawPath={scenario.rawPath}
+          workspacePath={scenario.workspacePath}
+          variant="chip"
+        />
+      </div>
+      <section
+        aria-label="File viewer"
+        data-file-reference-viewer={activeFileTarget ? "active" : "idle"}
+        className="min-h-0 min-w-0 flex-1"
+      >
+        {activeFileTarget ? (
+          <FileEditorView
+            filePath={activeFileTarget.path}
+            targetKey={viewerTargetKey(activeFileTarget)}
+          />
+        ) : null}
+      </section>
+    </main>
+  );
+}
+
+function resolveScenario(value: string | null): FileReferenceScenario {
+  switch (value) {
+    case "desktop-file":
+      return { caseName: value, rawPath: "/outside/reference.txt" };
+    case "unavailable":
+      return { caseName: value, rawPath: "/outside/reference.txt" };
+    case "empty":
+      return { caseName: value, rawPath: "" };
+    case "whitespace":
+      return { caseName: value, rawPath: "   " };
+    case "workspace-file":
+    default:
+      return {
+        caseName: "workspace-file",
+        rawPath: WORKSPACE_FILE_PATH,
+        workspacePath: WORKSPACE_FILE_PATH,
+      };
+  }
+}

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRowPrimitives.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRowPrimitives.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ActionFileLink } from "#product/components/workspace/chat/tool-calls/CollapsedActionRowPrimitives";
+
+const badgeInputs = vi.hoisted(() => ([] as Array<Record<string, unknown>>));
+
+vi.mock("#product/components/workspace/file-references/FileReferenceBadge", () => ({
+  FileReferenceBadge: (props: Record<string, unknown>) => {
+    badgeInputs.push(props);
+    return <span data-mocked-file-reference />;
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+  badgeInputs.length = 0;
+});
+
+describe("ActionFileLink", () => {
+  it("preserves an explicit blank structured path without replacing the raw path", () => {
+    render(
+      <ActionFileLink
+        rawPath="src/raw.ts"
+        workspacePath=""
+        displayName="raw.ts"
+      />,
+    );
+    expect(badgeInputs).toContainEqual(expect.objectContaining({
+      rawPath: "src/raw.ts",
+      workspacePath: "",
+      label: "raw.ts",
+    }));
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRowPrimitives.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRowPrimitives.tsx
@@ -99,12 +99,12 @@ export function ActionDisclosureRow({
 }
 
 export function ActionFileLink({
-  pathLabel,
+  rawPath,
   workspacePath,
   displayName,
 }: {
-  pathLabel: string;
-  /** A known workspace-relative path, or absent to infer from pathLabel. */
+  rawPath: string;
+  /** An explicitly supplied workspace-relative path; absent to classify rawPath. */
   workspacePath: string | null | undefined;
   displayName: string;
 }) {
@@ -112,7 +112,7 @@ export function ActionFileLink({
     // Keep FileReferenceBadge's semantic link color: the surrounding activity
     // row is intentionally muted, but this child is an actionable file target.
     <FileReferenceBadge
-      rawPath={pathLabel}
+      rawPath={rawPath}
       label={displayName}
       workspacePath={workspacePath}
       variant="inline"

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRows.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRows.test.tsx
@@ -40,15 +40,29 @@ const {
 vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", () => ({
   useFileReferenceActions: (args: { rawPath: string; workspacePath?: string | null }) => {
     fileReferenceActionsCalls.push(args);
+    const resolvedWorkspacePath = typeof args.workspacePath === "string"
+      ? args.workspacePath
+      : args.rawPath;
+    const locator = resolvedWorkspacePath.trim()
+      ? {
+          authority: "workspace" as const,
+          workspacePath: resolvedWorkspacePath,
+          localCompanionPath: `/repo/${resolvedWorkspacePath}`,
+        }
+      : { authority: "unavailable" as const, reason: "invalid" as const };
     return {
       reference: {
         rawPath: args.rawPath,
-        path: args.rawPath,
+        parsedPath: args.rawPath,
+        displayPath: args.rawPath || "File",
         line: null,
         column: null,
-        absolutePath: `/repo/${args.rawPath}`,
-        workspacePath: args.rawPath,
+        locator,
       },
+      accessState: resolvedWorkspacePath.trim()
+        ? { status: "settled", locator, kind: "file" }
+        : { status: "unavailable", reason: "invalid" },
+      nativePathKind: null,
       openTargets: [],
       defaultOpenTarget: null,
       pathKind: "file",
@@ -58,7 +72,8 @@ vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", 
       canOpenPrimary: fileReferenceActionState.canOpenPrimary,
       canReveal: true,
       primaryUnavailableReason: null,
-      copyPath: vi.fn(),
+      copyPath: args.rawPath || null,
+      copyCurrentPath: vi.fn(),
       openInSidebar: vi.fn(),
       openDefault: vi.fn(),
       openPrimary: openPrimaryMock,
@@ -155,8 +170,7 @@ describe("CollapsedActionRows read rows", () => {
 
     const call = fileReferenceActionsCalls.find((entry) => entry.rawPath === "src/deep/notes.md");
     expect(call).toBeTruthy();
-    // undefined (not null) so the resolver may infer a workspace-relative path
-    // and the click can open the in-app viewer.
+    // The raw-input fallback has no structured channel.
     expect(call?.workspacePath).toBeUndefined();
 
     fireEvent.click(screen.getByText("notes.md"));
@@ -209,7 +223,7 @@ describe("CollapsedActionRows read rows", () => {
     const call = fileReferenceActionsCalls.find(
       (entry) => entry.rawPath === "src/legacy/read.ts",
     );
-    expect(call?.workspacePath).toBeUndefined();
+    expect(call?.workspacePath).toBeNull();
 
     fireEvent.click(screen.getByText("read.ts"));
     expect(openPrimaryMock).toHaveBeenCalledTimes(1);
@@ -236,6 +250,25 @@ describe("CollapsedActionRows read rows", () => {
 
     const call = fileReferenceActionsCalls.find((entry) => entry.rawPath === "/etc/hosts");
     expect(call).toBeTruthy();
-    expect(call?.workspacePath).toBeUndefined();
+    expect(call?.workspacePath).toBeNull();
+  });
+
+  it("preserves an explicitly blank structured path beside the raw wire path", () => {
+    const transcript = createTranscriptState("session-1");
+    const read = toolItem("read", "turn-1", 1, "file_read");
+    const part = read.contentParts[0];
+    if (part?.type === "file_read") {
+      part.path = "src/visible.ts";
+      part.basename = "visible.ts";
+      part.workspacePath = "";
+    }
+    transcript.itemsById = { read };
+    render(<CollapsedActions itemIds={["read"]} transcript={transcript} />);
+    fireEvent.click(screen.getByRole("button", { name: /Read/i }));
+
+    expect(fileReferenceActionsCalls).toContainEqual({
+      rawPath: "src/visible.ts",
+      workspacePath: "",
+    });
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRows.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActionRows.tsx
@@ -110,16 +110,18 @@ function ReadRows({ item }: { item: ToolCallItem }) {
   const fileReads = item.contentParts.filter(
     (part): part is FileReadContentPart => part.type === "file_read",
   );
-  // The SDK collapses an omitted workspacePath and an explicit null to the same
-  // value. Preserve a non-empty normalized path, but otherwise let the shared
-  // resolver classify the raw path against the current workspace root.
+  // Keep raw wire syntax separate from structured workspace metadata. Any
+  // structured string, including an invalid blank one, remains authoritative.
+  const fallbackTarget = deriveReadPathTarget(item);
   const targets = fileReads.length > 0
     ? fileReads.map((part) => ({
-      rawPath: part.workspacePath || part.path,
-      workspacePath: part.workspacePath || undefined,
-      displayName: part.basename || basename(part.workspacePath || part.path),
+      rawPath: part.path,
+      pathLabel: part.workspacePath?.trim() ? part.workspacePath : part.path,
+      workspacePath: part.workspacePath,
+      displayName: part.basename
+        || basename(part.workspacePath?.trim() ? part.workspacePath : part.path),
     }))
-    : [{ ...deriveReadPathTarget(item), workspacePath: undefined }];
+    : [{ ...fallbackTarget, pathLabel: fallbackTarget.rawPath ?? "", workspacePath: undefined }];
 
   return (
     <>
@@ -129,7 +131,8 @@ function ReadRows({ item }: { item: ToolCallItem }) {
             key={`${item.itemId}-read-${idx}`}
             icon={<CollapsedActionIcon kind="read" />}
             verb={verb}
-            pathLabel={target.rawPath}
+            rawPath={target.rawPath}
+            pathLabel={target.pathLabel}
             workspacePath={target.workspacePath}
             displayName={target.displayName}
             failed={failed}
@@ -150,6 +153,7 @@ function ReadRows({ item }: { item: ToolCallItem }) {
 function FileActionRow({
   icon,
   verb,
+  rawPath,
   pathLabel,
   workspacePath,
   displayName,
@@ -157,8 +161,9 @@ function FileActionRow({
 }: {
   icon: ReactNode;
   verb: string;
+  rawPath: string;
   pathLabel: string;
-  /** A known workspace-relative path, or absent to infer from pathLabel. */
+  /** An explicitly supplied workspace-relative path; absent to classify rawPath. */
   workspacePath: string | null | undefined;
   displayName: string;
   failed: boolean;
@@ -174,7 +179,7 @@ function FileActionRow({
       <span className="inline-flex min-w-0 items-center gap-1">
         <span className="shrink-0 text-inherit">{verb}</span>
         <ActionFileLink
-          pathLabel={pathLabel}
+          rawPath={rawPath}
           workspacePath={workspacePath}
           displayName={displayName}
         />
@@ -230,6 +235,7 @@ function ParsedCommandRows({
             key={`${item.itemId}-parsed-${idx}`}
             icon={<CollapsedActionIcon kind="read" />}
             verb={item.status === "in_progress" ? "Reading" : "Read"}
+            rawPath={command.path}
             pathLabel={command.path}
             workspacePath={undefined}
             displayName={command.name ?? basename(command.path)}

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedActions.test.tsx
@@ -40,23 +40,36 @@ function openActions(button: HTMLElement) {
 
 vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", () => ({
   useFileReferenceActions: (args: { rawPath: string; workspacePath?: string | null }) => {
+    const workspacePath = typeof args.workspacePath === "string"
+      ? args.workspacePath
+      : args.rawPath;
+    const locator = {
+      authority: "workspace" as const,
+      workspacePath,
+      localCompanionPath: `/repo/${workspacePath}`,
+    };
     return {
       reference: {
         rawPath: args.rawPath,
-        path: args.rawPath,
+        parsedPath: args.rawPath,
+        displayPath: args.rawPath,
         line: null,
         column: null,
-        absolutePath: `/repo/${args.rawPath}`,
-        workspacePath: args.rawPath,
+        locator,
       },
+      accessState: { status: "settled" as const, locator, kind: "file" as const },
+      nativePathKind: null,
       openTargets: [],
       defaultOpenTarget: null,
+      pathKind: "file" as const,
+      pathKindPending: false,
       canOpenPrimary: true,
       canOpenInSidebar: true,
-      canOpenExternal: true,
-      canReveal: true,
-      pathKind: "file",
-      copyPath: vi.fn(),
+      canOpenExternal: false,
+      canReveal: false,
+      primaryUnavailableReason: null,
+      copyPath: `/repo/${workspacePath}`,
+      copyCurrentPath: vi.fn(async () => undefined),
       openInSidebar: vi.fn(),
       openDefault: vi.fn(),
       openPrimary: vi.fn(),

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.test.tsx
@@ -148,4 +148,36 @@ describe("CollapsedEditActionRows", () => {
       workspacePath: "",
     });
   });
+
+  it("routes a move outside the workspace to its destination, not the source", () => {
+    const item = editItem();
+    const part = item.contentParts[0];
+    if (part?.type === "file_change") {
+      part.path = "src/a.ts";
+      part.workspacePath = "src/a.ts";
+      part.newPath = "/tmp/a.ts";
+      part.newWorkspacePath = null;
+    }
+    render(<EditRows item={item} />);
+    expect(fileReferenceActionsCalls).toContainEqual({
+      rawPath: "/tmp/a.ts",
+      workspacePath: null,
+    });
+  });
+
+  it("keeps workspacePath for a plain edit with no newPath", () => {
+    const item = editItem();
+    const part = item.contentParts[0];
+    if (part?.type === "file_change") {
+      part.path = "src/a.ts";
+      part.workspacePath = "src/a.ts";
+      part.newPath = null;
+      part.newWorkspacePath = null;
+    }
+    render(<EditRows item={item} />);
+    expect(fileReferenceActionsCalls).toContainEqual({
+      rawPath: "src/a.ts",
+      workspacePath: "src/a.ts",
+    });
+  });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.test.tsx
@@ -23,8 +23,9 @@ function render(ui: ReactElement) {
   return testingRender(ui, { wrapper: WebProductHostWrapper });
 }
 
-const { openPrimaryMock, fileReferenceOpenState } = vi.hoisted(() => ({
+const { openPrimaryMock, fileReferenceOpenState, fileReferenceActionsCalls } = vi.hoisted(() => ({
   openPrimaryMock: vi.fn(),
+  fileReferenceActionsCalls: [] as Array<{ rawPath: string; workspacePath?: string | null }>,
   fileReferenceOpenState: {
     canOpenPrimary: true,
     canOpenInSidebar: true,
@@ -35,25 +36,38 @@ const { openPrimaryMock, fileReferenceOpenState } = vi.hoisted(() => ({
 }));
 
 vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", () => ({
-  useFileReferenceActions: (args: { rawPath: string; workspacePath?: string | null }) => ({
-    reference: {
+  useFileReferenceActions: (args: { rawPath: string; workspacePath?: string | null }) => {
+    fileReferenceActionsCalls.push(args);
+    const locator = {
+      authority: "workspace" as const,
+      workspacePath: typeof args.workspacePath === "string" ? args.workspacePath : args.rawPath,
+      localCompanionPath: null,
+    };
+    return {
+      reference: {
       rawPath: args.rawPath,
-      path: args.rawPath,
+      parsedPath: args.rawPath,
+      displayPath: args.rawPath || "File",
       line: null,
       column: null,
-      absolutePath: `/repo/${args.rawPath}`,
-      workspacePath: args.rawPath,
-    },
-    openTargets: [],
-    defaultOpenTarget: null,
-    ...fileReferenceOpenState,
-    copyPath: vi.fn(),
-    openInSidebar: vi.fn(),
-    openDefault: vi.fn(),
-    openPrimary: openPrimaryMock,
-    openWithTarget: vi.fn(),
-    reveal: vi.fn(),
-  }),
+      locator,
+      },
+      accessState: { status: "settled", locator, kind: "file" },
+      nativePathKind: null,
+      openTargets: [],
+      defaultOpenTarget: null,
+      pathKindPending: false,
+      primaryUnavailableReason: null,
+      copyPath: args.rawPath || null,
+      copyCurrentPath: vi.fn(),
+      ...fileReferenceOpenState,
+      openInSidebar: vi.fn(),
+      openDefault: vi.fn(),
+      openPrimary: openPrimaryMock,
+      openWithTarget: vi.fn(),
+      reveal: vi.fn(),
+    };
+  },
 }));
 
 afterEach(() => {
@@ -64,6 +78,7 @@ afterEach(() => {
   fileReferenceOpenState.canOpenExternal = true;
   fileReferenceOpenState.canReveal = true;
   fileReferenceOpenState.pathKind = "file";
+  fileReferenceActionsCalls.length = 0;
 });
 
 function editItem({ patch = false }: { patch?: boolean } = {}) {
@@ -116,5 +131,21 @@ describe("CollapsedEditActionRows", () => {
     expect(screen.getByRole("menuitem", { name: "Copy path" })).toBeTruthy();
     expect(openPrimaryMock).not.toHaveBeenCalled();
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("preserves a blank new structured path beside the raw new path", () => {
+    const item = editItem();
+    const part = item.contentParts[0];
+    if (part?.type === "file_change") {
+      part.path = "old/raw.ts";
+      part.workspacePath = "old/workspace.ts";
+      part.newPath = "new/raw.ts";
+      part.newWorkspacePath = "";
+    }
+    render(<EditRows item={item} />);
+    expect(fileReferenceActionsCalls).toContainEqual({
+      rawPath: "new/raw.ts",
+      workspacePath: "",
+    });
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.tsx
@@ -58,8 +58,11 @@ function EditActionRow({
 }) {
   const [expanded, setExpanded] = useState(false);
   const rawPath = part.newPath ?? part.path;
-  const workspacePath = typeof part.newWorkspacePath === "string"
-    ? part.newWorkspacePath
+  // A move whose destination lives outside the workspace has no structured
+  // path of its own; falling back to the source workspacePath would silently
+  // route file-reference actions to the pre-move location.
+  const workspacePath = part.newPath != null
+    ? (typeof part.newWorkspacePath === "string" ? part.newWorkspacePath : null)
     : part.workspacePath;
   const pathLabel = firstNonblankPath(
     part.newWorkspacePath,

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.tsx
@@ -57,14 +57,22 @@ function EditActionRow({
   contentSearchUnitId: string;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const pathLabel = part.newWorkspacePath ?? part.workspacePath ?? part.newPath ?? part.path;
+  const rawPath = part.newPath ?? part.path;
+  const workspacePath = typeof part.newWorkspacePath === "string"
+    ? part.newWorkspacePath
+    : part.workspacePath;
+  const pathLabel = firstNonblankPath(
+    part.newWorkspacePath,
+    part.newPath,
+    part.workspacePath,
+    part.path,
+  );
   const displayName = part.newBasename ?? part.basename ?? basename(pathLabel);
   const additions = part.additions ?? 0;
   const deletions = part.deletions ?? 0;
-  const workspacePath = part.newWorkspacePath ?? part.workspacePath ?? null;
   const patch = part.patch?.trim() ? part.patch : null;
   const canExpand = Boolean(patch);
-  const fileActions = useFileReferenceActions({ rawPath: pathLabel, workspacePath });
+  const fileActions = useFileReferenceActions({ rawPath, workspacePath });
   const nativeContextMenu = useFileReferenceNativeContextMenu(fileActions);
   const canOpenFile = fileActions.canOpenPrimary;
   const displayPolicy = patch
@@ -206,4 +214,8 @@ function formatFailedEditActionTitle(operation: FileChangeContentPart["operation
     default:
       return "Failed editing";
   }
+}
+
+function firstNonblankPath(...paths: Array<string | null | undefined>): string {
+  return paths.find((candidate) => candidate?.trim()) ?? "";
 }

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileChangeCall.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileChangeCall.test.tsx
@@ -9,10 +9,13 @@ import { makeTestProductHost } from "#product/test/product-host-fixtures";
 // useProductHost().clipboard for its copy control, so a bare { desktop: null }
 // cast (no clipboard) crashes; makeTestProductHost supplies every capability.
 const webTestHost = makeTestProductHost({ desktop: null });
-const fileReferenceActionState = vi.hoisted(() => ({
+const { fileReferenceActionState, fileReferenceActionsCalls } = vi.hoisted(() => ({
+  fileReferenceActionsCalls: [] as Array<{ rawPath: string; workspacePath?: string | null }>,
+  fileReferenceActionState: {
   canOpenInSidebar: true,
   canOpenExternal: true,
   canOpenPrimary: true,
+  },
 }));
 
 function renderToStaticMarkup(ui: ReactElement) {
@@ -22,32 +25,49 @@ function renderToStaticMarkup(ui: ReactElement) {
 }
 
 vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", () => ({
-  useFileReferenceActions: ({ rawPath }: { rawPath: string }) => ({
-    reference: {
-      rawPath,
-      path: rawPath,
+  useFileReferenceActions: (args: { rawPath: string; workspacePath?: string | null }) => {
+    fileReferenceActionsCalls.push(args);
+    const locator = {
+      authority: "workspace" as const,
+      workspacePath: typeof args.workspacePath === "string" ? args.workspacePath : args.rawPath,
+      localCompanionPath: null,
+    };
+    return {
+      reference: {
+      rawPath: args.rawPath,
+      parsedPath: args.rawPath,
+      displayPath: args.rawPath || "File",
       line: null,
       column: null,
-      absolutePath: `/repo/${rawPath}`,
-      workspacePath: rawPath,
-    },
-    openTargets: [],
-    canOpenInSidebar: fileReferenceActionState.canOpenInSidebar,
-    canOpenExternal: fileReferenceActionState.canOpenExternal,
-    canOpenPrimary: fileReferenceActionState.canOpenPrimary,
-    copyPath: vi.fn(),
-    openInSidebar: vi.fn(),
-    openDefault: vi.fn(),
-    openPrimary: vi.fn(),
-    openWithTarget: vi.fn(),
-    reveal: vi.fn(),
-  }),
+      locator,
+      },
+      accessState: { status: "settled", locator, kind: "file" },
+      nativePathKind: null,
+      openTargets: [],
+      defaultOpenTarget: null,
+      pathKind: "file",
+      pathKindPending: false,
+      canReveal: false,
+      primaryUnavailableReason: null,
+      copyPath: args.rawPath || null,
+      copyCurrentPath: vi.fn(),
+      canOpenInSidebar: fileReferenceActionState.canOpenInSidebar,
+      canOpenExternal: fileReferenceActionState.canOpenExternal,
+      canOpenPrimary: fileReferenceActionState.canOpenPrimary,
+      openInSidebar: vi.fn(),
+      openDefault: vi.fn(),
+      openPrimary: vi.fn(),
+      openWithTarget: vi.fn(),
+      reveal: vi.fn(),
+    };
+  },
 }));
 
 afterEach(() => {
   fileReferenceActionState.canOpenInSidebar = true;
   fileReferenceActionState.canOpenExternal = true;
   fileReferenceActionState.canOpenPrimary = true;
+  fileReferenceActionsCalls.length = 0;
 });
 
 describe("FileChangeCall", () => {
@@ -138,5 +158,23 @@ describe("FileChangeCall", () => {
     );
 
     expect(html).toContain("select-text [direction:rtl]");
+  });
+
+  it("keeps raw and explicitly blank structured destination paths separate", () => {
+    renderToStaticMarkup(
+      <FileChangeCall
+        operation="move"
+        path="old/raw.ts"
+        workspacePath="old/workspace.ts"
+        newPath="new/raw.ts"
+        newWorkspacePath=""
+        status="completed"
+      />,
+    );
+
+    expect(fileReferenceActionsCalls).toContainEqual({
+      rawPath: "new/raw.ts",
+      workspacePath: "",
+    });
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileChangeCall.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileChangeCall.test.tsx
@@ -177,4 +177,42 @@ describe("FileChangeCall", () => {
       workspacePath: "",
     });
   });
+
+  it("routes a move outside the workspace to its destination, not the source", () => {
+    renderToStaticMarkup(
+      <FileChangeCall
+        operation="move"
+        path="src/a.ts"
+        workspacePath="src/a.ts"
+        newPath="/tmp/a.ts"
+        newWorkspacePath={null}
+        status="completed"
+      />,
+    );
+
+    // The component's own primary file-reference actions (used for open/copy)
+    // are established before any child chip renders, so this is always the
+    // first call recorded — child label chips make their own independent
+    // calls that must not be mistaken for the parent's.
+    expect(fileReferenceActionsCalls[0]).toEqual({
+      rawPath: "/tmp/a.ts",
+      workspacePath: null,
+    });
+  });
+
+  it("keeps workspacePath for a plain edit with no newPath", () => {
+    renderToStaticMarkup(
+      <FileChangeCall
+        operation="edit"
+        path="src/a.ts"
+        workspacePath="src/a.ts"
+        status="completed"
+      />,
+    );
+
+    expect(fileReferenceActionsCalls[0]).toEqual({
+      rawPath: "src/a.ts",
+      workspacePath: "src/a.ts",
+    });
+  });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileChangeCall.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileChangeCall.tsx
@@ -55,10 +55,19 @@ export function FileChangeCall({
 }: FileChangeCallProps) {
   const hasDiff = !!patch;
   const actionLabel = getOperationLabel(operation, status);
-  const displayPath = newWorkspacePath || workspacePath || newPath || path;
+  const rawReferencePath = newPath ?? path;
+  const structuredWorkspacePath = typeof newWorkspacePath === "string"
+    ? newWorkspacePath
+    : workspacePath;
+  const displayPath = firstNonblankPath(
+    newWorkspacePath,
+    newPath,
+    workspacePath,
+    path,
+  );
   const fileReferenceActions = useFileReferenceActions({
-    rawPath: displayPath,
-    workspacePath: newWorkspacePath || workspacePath,
+    rawPath: rawReferencePath,
+    workspacePath: structuredWorkspacePath,
   });
   const handleOpenFile = useCallback(() => {
     void fileReferenceActions.openPrimary();
@@ -201,17 +210,19 @@ function buildLabel(
 ): ReactNode {
   const resolvedBasename = basename || extractBasename(path);
   const resolvedNewBasename = newBasename || (newPath ? extractBasename(newPath) : null);
+  const hasMoveDestination = typeof newPath === "string"
+    || typeof newWorkspacePath === "string"
+    || resolvedNewBasename !== null;
 
   const primaryChip = (
     <ToolFileChip
       basename={resolvedBasename}
-      pathLabel={workspacePath ?? path}
+      rawPath={path}
       workspacePath={workspacePath}
     />
   );
 
-  if (operation === "move" && (newPath || newWorkspacePath || resolvedNewBasename)) {
-    const nextPathLabel = newWorkspacePath ?? newPath ?? path;
+  if (operation === "move" && hasMoveDestination) {
     return (
       <div className="flex min-w-0 items-center gap-2">
         <span className="shrink-0 text-inherit">{actionLabel}</span>
@@ -219,7 +230,7 @@ function buildLabel(
         <ArrowRight className="icon-compact shrink-0 text-muted-foreground" />
         <ToolFileChip
           basename={resolvedNewBasename ?? resolvedBasename}
-          pathLabel={nextPathLabel}
+          rawPath={newPath ?? path}
           workspacePath={newWorkspacePath}
         />
       </div>
@@ -249,6 +260,10 @@ function buildStatsHint(
 function extractBasename(path: string): string {
   const segments = path.split(/[\\/]/).filter(Boolean);
   return segments[segments.length - 1] ?? path;
+}
+
+function firstNonblankPath(...paths: Array<string | null | undefined>): string {
+  return paths.find((candidate) => candidate?.trim()) ?? "";
 }
 
 function getOperationIcon(operation: FileChangeOperation) {

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileChangeCall.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileChangeCall.tsx
@@ -56,8 +56,11 @@ export function FileChangeCall({
   const hasDiff = !!patch;
   const actionLabel = getOperationLabel(operation, status);
   const rawReferencePath = newPath ?? path;
-  const structuredWorkspacePath = typeof newWorkspacePath === "string"
-    ? newWorkspacePath
+  // A move whose destination lives outside the workspace has no structured
+  // path of its own; falling back to the source workspacePath would silently
+  // route file-reference actions to the pre-move location.
+  const structuredWorkspacePath = newPath != null
+    ? (typeof newWorkspacePath === "string" ? newWorkspacePath : null)
     : workspacePath;
   const displayPath = firstNonblankPath(
     newWorkspacePath,

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileReadCall.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileReadCall.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FileReadCall } from "#product/components/workspace/chat/tool-calls/FileReadCall";
+
+const chipInputs = vi.hoisted(() => ([] as Array<Record<string, unknown>>));
+
+vi.mock("#product/components/workspace/chat/tool-calls/ToolFileChip", () => ({
+  ToolFileChip: (props: Record<string, unknown>) => {
+    chipInputs.push(props);
+    return <span data-mocked-file-chip />;
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+  chipInputs.length = 0;
+});
+
+describe("FileReadCall", () => {
+  it("keeps the raw wire path when a structured blank path is supplied", () => {
+    render(
+      <FileReadCall
+        path="src/raw/visible.ts"
+        workspacePath=""
+        basename="visible.ts"
+      />,
+    );
+    expect(chipInputs).toContainEqual(expect.objectContaining({
+      rawPath: "src/raw/visible.ts",
+      workspacePath: "",
+      basename: "visible.ts",
+    }));
+  });
+
+  it("preserves null as absent structured metadata", () => {
+    render(<FileReadCall path="src/raw.ts" workspacePath={null} />);
+    expect(chipInputs).toContainEqual(expect.objectContaining({
+      rawPath: "src/raw.ts",
+      workspacePath: null,
+    }));
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileReadCall.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileReadCall.tsx
@@ -59,7 +59,7 @@ export function FileReadCall({
       </span>
       <ToolFileChip
         basename={resolvedBasename}
-        pathLabel={workspacePath || path}
+        rawPath={path}
         workspacePath={workspacePath}
       />
       {scopeLabel && <span className="truncate text-ui-sm text-faint">{scopeLabel}</span>}

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolFileChip.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolFileChip.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ToolFileChip } from "#product/components/workspace/chat/tool-calls/ToolFileChip";
+
+const badgeInputs = vi.hoisted(() => ([] as Array<Record<string, unknown>>));
+
+vi.mock("#product/components/workspace/file-references/FileReferenceBadge", () => ({
+  FileReferenceBadge: (props: Record<string, unknown>) => {
+    badgeInputs.push(props);
+    return <span data-mocked-file-reference />;
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+  badgeInputs.length = 0;
+});
+
+describe("ToolFileChip", () => {
+  it("forwards raw and structured paths through separate channels", () => {
+    render(
+      <ToolFileChip
+        basename="visible.ts"
+        rawPath="src/raw/visible.ts"
+        workspacePath=""
+      />,
+    );
+
+    expect(badgeInputs).toContainEqual(expect.objectContaining({
+      rawPath: "src/raw/visible.ts",
+      workspacePath: "",
+      basename: "visible.ts",
+      label: "visible.ts",
+      variant: "chip",
+    }));
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolFileChip.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/ToolFileChip.tsx
@@ -2,10 +2,11 @@ import { FileReferenceBadge } from "#product/components/workspace/file-reference
 
 interface ToolFileChipProps {
   basename: string;
-  pathLabel: string;
+  /** Raw wire path; never replaced by normalized workspace metadata. */
+  rawPath: string;
   /**
-   * Known workspace-relative path. Missing nullable metadata is inferred from
-   * pathLabel by the shared file-reference resolver.
+   * Supplied structured workspace paths are authoritative; otherwise the
+   * shared file-reference resolver classifies `rawPath`.
    */
   workspacePath: string | null | undefined;
 }
@@ -18,19 +19,19 @@ interface ToolFileChipProps {
  *    target for an external file.
  *  - Actionable references expose external targets, copy, and reveal through
  *    the context menu.
- *  - An unavailable path is non-interactive text.
+ *  - A nonempty unavailable path has Copy path only; an empty path has no controls.
  *
  * Visual is intentionally a chip (border + background + file icon) so tool
  * results stay scannable; markdown prose uses the flat `FilePathLink` instead.
  */
 export function ToolFileChip({
   basename,
-  pathLabel,
+  rawPath,
   workspacePath,
 }: ToolFileChipProps) {
   return (
     <FileReferenceBadge
-      rawPath={pathLabel}
+      rawPath={rawPath}
       basename={basename}
       label={basename}
       workspacePath={workspacePath}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptToolCallItemBlock.test.tsx
@@ -94,25 +94,25 @@ vi.mock("#product/stores/sessions/session-directory-store", () => {
 });
 
 vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", () => ({
-  useFileReferenceActions: ({ rawPath }: { rawPath: string }) => ({
-    reference: {
-      rawPath,
-      path: rawPath,
-      line: null,
-      column: null,
-      absolutePath: `/repo/${rawPath}`,
-      workspacePath: rawPath,
-    },
-    openTargets: [],
-    canOpenInSidebar: true,
-    canOpenExternal: true,
-    copyPath: vi.fn(),
-    openInSidebar: vi.fn(),
-    openDefault: vi.fn(),
-    openPrimary: vi.fn(),
-    openWithTarget: vi.fn(),
-    reveal: vi.fn(),
-  }),
+  useFileReferenceActions: ({ rawPath }: { rawPath: string }) => {
+    const locator = { authority: "workspace" as const, workspacePath: rawPath,
+      localCompanionPath: `/repo/${rawPath}`,
+    };
+    return {
+      reference: { rawPath, parsedPath: rawPath, displayPath: rawPath, line: null, column: null,
+        locator },
+      accessState: { status: "settled" as const, locator, kind: "file" as const },
+      nativePathKind: null, openTargets: [], defaultOpenTarget: null,
+      pathKind: "file" as const, pathKindPending: false,
+      canOpenInSidebar: true, canOpenExternal: false,
+      canOpenPrimary: true, canReveal: false,
+      primaryUnavailableReason: null,
+      copyPath: `/repo/${rawPath}`,
+      copyCurrentPath: vi.fn(async () => undefined),
+      openInSidebar: vi.fn(), openDefault: vi.fn(), openPrimary: vi.fn(),
+      openWithTarget: vi.fn(), reveal: vi.fn(),
+    };
+  },
 }));
 
 describe("TranscriptToolCallItemBlock", () => {

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TurnDocumentReferenceCard.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TurnDocumentReferenceCard.test.tsx
@@ -7,16 +7,21 @@ import { TurnDocumentReferenceCard } from "#product/components/workspace/chat/tr
 const fileActionMocks = vi.hoisted(() => ({
   canOpenPrimary: true,
   openPrimary: vi.fn(),
+  inputs: [] as Array<{ rawPath: string }>,
 }));
 
 vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", () => ({
-  useFileReferenceActions: () => fileActionMocks,
+  useFileReferenceActions: (input: { rawPath: string }) => {
+    fileActionMocks.inputs.push(input);
+    return fileActionMocks;
+  },
 }));
 
 afterEach(() => {
   cleanup();
   fileActionMocks.canOpenPrimary = true;
   fileActionMocks.openPrimary.mockReset();
+  fileActionMocks.inputs.length = 0;
 });
 
 describe("TurnDocumentReferenceCard", () => {
@@ -40,6 +45,9 @@ describe("TurnDocumentReferenceCard", () => {
     expect(screen.getByText("decision.md")).toBeTruthy();
     expect(screen.getByText("Document · MD")).toBeTruthy();
     expect(screen.getByText("Open preview")).toBeTruthy();
+    expect(fileActionMocks.inputs).toContainEqual({
+      rawPath: "/repo/specs/decision.md:42",
+    });
 
     fireEvent.click(screen.getByRole("button", { name: "Open preview for decision.md" }));
     expect(fileActionMocks.openPrimary).toHaveBeenCalledOnce();

--- a/apps/packages/product-client/src/components/workspace/cowork/CoworkWorkspaceShell.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/cowork/CoworkWorkspaceShell.test.tsx
@@ -117,10 +117,6 @@ vi.mock("#product/stores/sessions/session-selection-store", () => ({
     selector(sessionSelectionState),
 }));
 
-vi.mock("#product/providers/WorkspacePathProvider", () => ({
-  WorkspacePathProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
-}));
-
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
@@ -137,7 +133,6 @@ describe("CoworkWorkspaceShell", () => {
     const { rerender } = render(
       <CoworkWorkspaceShell
         workspaceId="workspace-cowork"
-        workspacePath="/tmp/workspace-cowork"
       />,
     );
 
@@ -147,7 +142,6 @@ describe("CoworkWorkspaceShell", () => {
     rerender(
       <CoworkWorkspaceShell
         workspaceId="workspace-cowork"
-        workspacePath="/tmp/workspace-cowork"
       />,
     );
     expect(document.getElementById("cowork-sidebar")?.className).not.toContain("border-r");
@@ -157,7 +151,6 @@ describe("CoworkWorkspaceShell", () => {
     render(
       <CoworkWorkspaceShell
         workspaceId="workspace-cowork"
-        workspacePath="/tmp/workspace-cowork"
       />,
     );
 
@@ -173,7 +166,6 @@ describe("CoworkWorkspaceShell", () => {
     const { container } = render(
       <CoworkWorkspaceShell
         workspaceId="workspace-cowork"
-        workspacePath="/tmp/workspace-cowork"
       />,
     );
 
@@ -198,7 +190,6 @@ describe("CoworkWorkspaceShell", () => {
       const { queryByTestId, unmount } = render(
         <CoworkWorkspaceShell
           workspaceId="workspace-cowork"
-          workspacePath="/tmp/workspace-cowork"
         />,
       );
 

--- a/apps/packages/product-client/src/components/workspace/cowork/CoworkWorkspaceShell.tsx
+++ b/apps/packages/product-client/src/components/workspace/cowork/CoworkWorkspaceShell.tsx
@@ -20,18 +20,15 @@ import { useWorkspaceUiStore } from "#product/stores/preferences/workspace-ui-st
 import { useCoworkUiStore } from "#product/stores/cowork/cowork-ui-store";
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
-import { WorkspacePathProvider } from "#product/providers/WorkspacePathProvider";
 
 interface CoworkWorkspaceShellProps {
   workspaceId: string | null;
-  workspacePath: string | null;
   visible?: boolean;
   fallbackTitle?: string | null;
 }
 
 export function CoworkWorkspaceShell({
   workspaceId,
-  workspacePath,
   visible = true,
   fallbackTitle,
 }: CoworkWorkspaceShellProps) {
@@ -114,11 +111,10 @@ export function CoworkWorkspaceShell({
   });
 
   return (
-    <WorkspacePathProvider workspacePath={workspacePath}>
-      <div
-        className={`h-screen flex overflow-hidden ${chromeClasses.root}`}
-        data-telemetry-block
-      >
+    <div
+      className={`h-screen flex overflow-hidden ${chromeClasses.root}`}
+      data-telemetry-block
+    >
         <div
           id="cowork-sidebar"
           className={`flex shrink-0 flex-col overflow-hidden bg-sidebar ${
@@ -223,7 +219,6 @@ export function CoworkWorkspaceShell({
             </div>
           </div>
         </div>
-      </div>
-    </WorkspacePathProvider>
+    </div>
   );
 }

--- a/apps/packages/product-client/src/components/workspace/file-references/FileReferenceBadge.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/file-references/FileReferenceBadge.test.tsx
@@ -1,52 +1,65 @@
 // @vitest-environment jsdom
 
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
-import { makeTestProductHost } from "#product/test/product-host-fixtures";
 import { FileReferenceBadge } from "#product/components/workspace/file-references/FileReferenceBadge";
+import { makeTestProductHost } from "#product/test/product-host-fixtures";
 
-// FileReferenceBadge picks a glyph by combining `actions.pathKind` with
-// `getFileVisual` (the single extension->visual table) and only falls back to
-// the generic external-mention glyph when the name is genuinely unclassifiable
-// AND the reference is an external (non-workspace) path. That combination —
-// not `getFileVisual` or the label helpers individually, which already have
-// their own direct tests — is what this file exercises.
-
-type MockActionsState = {
-  pathKind: "file" | "directory" | null;
-  pathKindPending: boolean;
-  workspacePath: string | null;
-  absolutePath: string | null;
-  canOpenPrimary: boolean;
-  primaryUnavailableReason: string | null;
-};
-
-const state: MockActionsState = {
-  pathKind: "file",
+const actionMocks = vi.hoisted(() => ({
+  authority: "workspace" as "workspace" | "desktop" | "unavailable",
+  pathKind: "file" as "file" | "directory" | null,
   pathKindPending: false,
-  workspacePath: "src/App.tsx",
-  absolutePath: "/repo/src/App.tsx",
   canOpenPrimary: true,
-  primaryUnavailableReason: null,
-};
+  copyPath: "/repo/src/App.tsx" as string | null,
+  primaryUnavailableReason: null as string | null,
+  openPrimary: vi.fn(),
+  copyCurrentPath: vi.fn(async () => undefined),
+}));
 
 vi.mock("#product/hooks/workspaces/workflows/files/use-file-reference-actions", () => ({
-  useFileReferenceActions: ({ rawPath }: { rawPath: string }) => ({
-    reference: {
-      rawPath,
-      path: rawPath,
-      line: null,
-      column: null,
-      absolutePath: state.absolutePath,
-      workspacePath: state.workspacePath,
-    },
-    pathKind: state.pathKind,
-    pathKindPending: state.pathKindPending,
-    canOpenPrimary: state.canOpenPrimary,
-    primaryUnavailableReason: state.primaryUnavailableReason,
-    openPrimary: vi.fn(),
-  }),
+  useFileReferenceActions: ({ rawPath }: { rawPath: string }) => {
+    const parsedPath = rawPath.trim();
+    const locator = actionMocks.authority === "workspace"
+      ? {
+          authority: "workspace" as const,
+          workspacePath: parsedPath,
+          localCompanionPath: `/repo/${parsedPath}`,
+        }
+      : actionMocks.authority === "desktop"
+        ? { authority: "desktop" as const, absolutePath: parsedPath, syntax: "absolute" as const }
+        : { authority: "unavailable" as const, reason: parsedPath ? "invalid" as const : "empty" as const };
+    return {
+      reference: {
+        rawPath,
+        parsedPath,
+        displayPath: parsedPath || "File",
+        line: null,
+        column: null,
+        locator,
+      },
+      accessState: actionMocks.canOpenPrimary
+        ? { status: "settled", locator, kind: actionMocks.pathKind }
+        : { status: "unavailable", reason: "invalid" },
+      nativePathKind: null,
+      openTargets: [],
+      defaultOpenTarget: null,
+      pathKind: actionMocks.pathKind,
+      pathKindPending: actionMocks.pathKindPending,
+      canOpenInSidebar: actionMocks.canOpenPrimary,
+      canOpenExternal: false,
+      canOpenPrimary: actionMocks.canOpenPrimary,
+      canReveal: false,
+      primaryUnavailableReason: actionMocks.primaryUnavailableReason,
+      copyPath: actionMocks.copyPath,
+      copyCurrentPath: actionMocks.copyCurrentPath,
+      openInSidebar: vi.fn(),
+      openDefault: vi.fn(),
+      openPrimary: actionMocks.openPrimary,
+      openWithTarget: vi.fn(),
+      reveal: vi.fn(),
+    };
+  },
 }));
 
 vi.mock("#product/hooks/workspaces/ui/files/use-file-reference-native-context-menu", () => ({
@@ -54,6 +67,96 @@ vi.mock("#product/hooks/workspaces/ui/files/use-file-reference-native-context-me
 }));
 
 const webTestHost = makeTestProductHost({ desktop: null });
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  actionMocks.authority = "workspace";
+  actionMocks.pathKind = "file";
+  actionMocks.pathKindPending = false;
+  actionMocks.canOpenPrimary = true;
+  actionMocks.copyPath = "/repo/src/App.tsx";
+  actionMocks.primaryUnavailableReason = null;
+});
+
+describe("FileReferenceBadge glyph selection", () => {
+  it("uses classified file glyphs for workspace and Desktop references", () => {
+    const workspace = renderBadge("src/App.tsx");
+    expect(usesExternalMentionGlyph(workspace.container)).toBe(false);
+    workspace.unmount();
+
+    actionMocks.authority = "desktop";
+    const desktop = renderBadge("/Users/pablo/README.md");
+    expect(usesExternalMentionGlyph(desktop.container)).toBe(false);
+  });
+
+  it("uses the mention glyph only for an unclassified Desktop file", () => {
+    actionMocks.authority = "desktop";
+    const { container } = renderBadge("/Users/pablo/some-notes");
+    expect(usesExternalMentionGlyph(container)).toBe(true);
+  });
+
+  it("never uses the Desktop mention glyph for a workspace path", () => {
+    const { container } = renderBadge("notes/some-notes");
+    expect(usesExternalMentionGlyph(container)).toBe(false);
+  });
+
+  it("does not classify a directory by its filename-looking extension", () => {
+    actionMocks.authority = "desktop";
+    actionMocks.pathKind = "directory";
+    const { container } = renderBadge("/Users/pablo/README.md");
+    expect(usesExternalMentionGlyph(container)).toBe(true);
+  });
+
+  it("uses an explicit basename for glyph selection", () => {
+    actionMocks.authority = "desktop";
+    const { container } = renderBadge("/Users/pablo/scratch-file", "logo.svg");
+    expect(usesExternalMentionGlyph(container)).toBe(false);
+  });
+});
+
+describe("FileReferenceBadge interaction semantics", () => {
+  it("renders and invokes an available primary action", () => {
+    const { container } = renderBadge("src/App.tsx");
+    const reference = container.querySelector("[data-file-reference-badge='inline']");
+    expect(reference?.tagName).toBe("BUTTON");
+    expect(reference?.className).toContain("text-link-foreground");
+    fireEvent.click(reference!);
+    expect(actionMocks.openPrimary).toHaveBeenCalledOnce();
+  });
+
+  it("renders a nonempty unavailable reference as inert text with Copy path only", () => {
+    actionMocks.authority = "unavailable";
+    actionMocks.pathKind = null;
+    actionMocks.canOpenPrimary = false;
+    actionMocks.copyPath = "missing.ts";
+    const { container } = renderBadge("missing.ts");
+    const reference = container.querySelector("[data-file-reference-badge='inline']");
+    expect(reference?.tagName).toBe("SPAN");
+    expect(reference?.className).not.toContain("text-link-foreground");
+
+    fireEvent.contextMenu(reference!);
+    expect(screen.getAllByRole("menuitem")).toHaveLength(1);
+    expect(screen.getByRole("menuitem", { name: "Copy path" })).toBeTruthy();
+    expect(screen.queryByText("Open externally")).toBeNull();
+    expect(screen.queryByText("Reveal in Finder")).toBeNull();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy path" }));
+    expect(actionMocks.copyCurrentPath).toHaveBeenCalledOnce();
+  });
+
+  it.each(["", "   "])("exposes no menu or primary control for %j", (rawPath) => {
+    actionMocks.authority = "unavailable";
+    actionMocks.pathKind = null;
+    actionMocks.canOpenPrimary = false;
+    actionMocks.copyPath = null;
+    const { container } = renderBadge(rawPath);
+    const reference = container.querySelector("[data-file-reference-badge='inline']");
+    expect(reference?.tagName).toBe("SPAN");
+    fireEvent.contextMenu(reference!);
+    expect(screen.queryByRole("menuitem")).toBeNull();
+    expect(actionMocks.copyCurrentPath).not.toHaveBeenCalled();
+  });
+});
 
 function renderBadge(rawPath: string, basename?: string) {
   return render(
@@ -63,118 +166,6 @@ function renderBadge(rawPath: string, basename?: string) {
   );
 }
 
-function glyphSpan(container: HTMLElement) {
-  return container.querySelector("[data-file-reference-badge] span[aria-hidden='true']");
-}
-
 function usesExternalMentionGlyph(container: HTMLElement) {
   return container.querySelector("[data-external-path-reference-icon='true']") !== null;
 }
-
-afterEach(() => {
-  cleanup();
-  state.pathKind = "file";
-  state.pathKindPending = false;
-  state.workspacePath = "src/App.tsx";
-  state.absolutePath = "/repo/src/App.tsx";
-  state.canOpenPrimary = true;
-  state.primaryUnavailableReason = null;
-});
-
-describe("FileReferenceBadge glyph selection", () => {
-  it("shows the real file-type glyph for a workspace file with a classified extension", () => {
-    const { container } = renderBadge("src/App.tsx");
-    expect(usesExternalMentionGlyph(container)).toBe(false);
-    expect(glyphSpan(container)).toBeTruthy();
-  });
-
-  it("shows the markdown glyph for an external reference to a classified extension", () => {
-    state.workspacePath = null;
-    state.absolutePath = "/Users/pablo/notes/README.md";
-    const { container } = renderBadge("/Users/pablo/notes/README.md");
-    // The whole point of the file-type-glyph fix: an out-of-workspace
-    // reference to a recognizable extension gets its real glyph, not the
-    // generic mention icon.
-    expect(usesExternalMentionGlyph(container)).toBe(false);
-  });
-
-  it("falls back to the generic mention glyph for an external reference with no classified extension", () => {
-    state.workspacePath = null;
-    state.absolutePath = "/Users/pablo/notes/some-notes";
-    const { container } = renderBadge("/Users/pablo/notes/some-notes");
-    expect(usesExternalMentionGlyph(container)).toBe(true);
-  });
-
-  it("never falls back to the mention glyph for a workspace reference, even with no classified extension", () => {
-    // useExternalInlineIcon requires !reference.workspacePath, so a reference
-    // resolved inside the workspace always renders FileTreeEntryIcon (which
-    // itself resolves to the "default" file glyph) instead of the mention icon.
-    state.workspacePath = "notes/some-notes";
-    state.absolutePath = "/repo/notes/some-notes";
-    const { container } = renderBadge("notes/some-notes");
-    expect(usesExternalMentionGlyph(container)).toBe(false);
-  });
-
-  it("treats a directory as unclassified even when its name looks like a recognized file", () => {
-    // hasFileTypeGlyph is gated on pathKind !== "directory": a directory
-    // named like a markdown file must not pick up the markdown glyph.
-    state.pathKind = "directory";
-    state.workspacePath = null;
-    state.absolutePath = "/Users/pablo/notes/README.md";
-    const { container } = renderBadge("/Users/pablo/notes/README.md");
-    expect(usesExternalMentionGlyph(container)).toBe(true);
-  });
-
-  it("shows a classified glyph for a still-resolving external reference (pending stat does not block the extension lookup)", () => {
-    // hasFileTypeGlyph is computed off resolvedBasename/iconPath, not off
-    // pathKindPending, so a reference whose workspace stat hasn't resolved
-    // yet still gets the markdown glyph rather than waiting or showing the
-    // mention icon in the meantime.
-    state.pathKind = null;
-    state.pathKindPending = true;
-    state.workspacePath = null;
-    state.absolutePath = "/Users/pablo/notes/README.md";
-    const { container } = renderBadge("/Users/pablo/notes/README.md");
-    expect(usesExternalMentionGlyph(container)).toBe(false);
-  });
-
-  it("uses an explicit basename override for glyph selection instead of the raw path", () => {
-    state.workspacePath = null;
-    state.absolutePath = "/Users/pablo/tmp/scratch-file";
-    const { container } = renderBadge("/Users/pablo/tmp/scratch-file", "logo.svg");
-    expect(usesExternalMentionGlyph(container)).toBe(false);
-  });
-});
-
-describe("FileReferenceBadge interaction semantics", () => {
-  it("renders an actionable inline reference as a blue button", () => {
-    const { container } = renderBadge("src/App.tsx");
-    const reference = container.querySelector("[data-file-reference-badge='inline']");
-
-    expect(reference?.tagName).toBe("BUTTON");
-    expect(reference?.getAttribute("aria-disabled")).toBeNull();
-    expect(reference?.className).toContain("text-link-foreground");
-    expect(reference?.className).not.toContain("cursor-not-allowed");
-  });
-
-  it("keeps a retry reason on an actionable reference", () => {
-    state.primaryUnavailableReason = "Could not resolve this path. Click to retry.";
-    const { container } = renderBadge("src/App.tsx");
-    const reference = container.querySelector("[data-file-reference-badge='inline']");
-
-    expect(reference?.getAttribute("title"))
-      .toBe("Could not resolve this path. Click to retry.");
-  });
-
-  it("renders an unavailable reference as plain text instead of a disabled link", () => {
-    state.canOpenPrimary = false;
-    const { container } = renderBadge("/tmp/unavailable.txt");
-    const reference = container.querySelector("[data-file-reference-badge='inline']");
-
-    expect(reference?.tagName).toBe("SPAN");
-    expect(reference?.getAttribute("aria-disabled")).toBeNull();
-    expect(reference?.className).not.toContain("text-link-foreground");
-    expect(reference?.className).not.toContain("cursor-not-allowed");
-    expect(reference?.className).toContain("cursor-default");
-  });
-});

--- a/apps/packages/product-client/src/components/workspace/file-references/FileReferenceBadge.tsx
+++ b/apps/packages/product-client/src/components/workspace/file-references/FileReferenceBadge.tsx
@@ -43,9 +43,14 @@ export function FileReferenceBadge({
 }: FileReferenceBadgeProps) {
   const actions = useFileReferenceActions({ rawPath, workspacePath });
   const { onContextMenuCapture } = useFileReferenceNativeContextMenu(actions);
+  const workspaceLocator = actions.reference.locator.authority === "workspace"
+    ? actions.reference.locator
+    : null;
   const resolvedBasename = basename
-    ?? fileReferenceBasename(actions.reference.workspacePath ?? actions.reference.path);
-  const iconPath = actions.reference.workspacePath ?? actions.reference.path;
+    ?? fileReferenceBasename(actions.reference.displayPath);
+  const iconPath = workspaceLocator && workspaceLocator.workspacePath !== ""
+    ? workspaceLocator.workspacePath
+    : actions.reference.displayPath;
   const displayLabel = label
     ?? (variant === "chip"
       ? resolvedBasename
@@ -61,8 +66,7 @@ export function FileReferenceBadge({
     && getFileVisual(resolvedBasename, iconPath, "file").kind !== "default";
   const useExternalInlineIcon =
     variant === "inline"
-    && !actions.reference.workspacePath
-    && Boolean(actions.reference.absolutePath)
+    && actions.reference.locator.authority === "desktop"
     && !hasFileTypeGlyph;
   const iconShellClassName = variant === "inline"
     ? "relative mr-[3px] inline-block h-[1lh] w-3.5 shrink-0 align-bottom"
@@ -110,7 +114,7 @@ export function FileReferenceBadge({
     </>
   );
   if (!actions.canOpenPrimary) {
-    return (
+    const unavailableTrigger = (
       <span
         data-chat-transcript-ignore
         data-file-reference-badge={variant}
@@ -118,10 +122,22 @@ export function FileReferenceBadge({
         data-path-kind={actions.pathKind ?? "unknown"}
         aria-busy={actions.pathKindPending || undefined}
         title={actions.primaryUnavailableReason ?? rawPath}
+        onContextMenuCapture={actions.copyPath === null ? undefined : onContextMenuCapture}
         className={resolveUnavailableBadgeClassName(variant, className)}
       >
         {contents}
       </span>
+    );
+    if (actions.copyPath === null) return unavailableTrigger;
+    return (
+      <PopoverButton
+        trigger={unavailableTrigger}
+        triggerMode="contextMenu"
+        stopPropagation={stopPropagation}
+        className={FILE_REFERENCE_MENU_CLASS}
+      >
+        {(close) => <FileReferenceMenuContent actions={actions} close={close} />}
+      </PopoverButton>
     );
   }
 

--- a/apps/packages/product-client/src/components/workspace/file-references/FileReferenceMenu.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/file-references/FileReferenceMenu.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FileReferenceMenuContent } from "#product/components/workspace/file-references/FileReferenceMenu";
+
+type MenuActions = ComponentProps<typeof FileReferenceMenuContent>["actions"];
+
+afterEach(cleanup);
+
+describe("FileReferenceMenuContent", () => {
+  it("renders exactly one enabled Copy path item for a nonempty unavailable reference", () => {
+    const actions = makeActions({
+      accessState: { status: "unavailable", reason: "invalid" },
+      copyPath: "invalid:path",
+    });
+    const close = vi.fn();
+    const { container } = render(<FileReferenceMenuContent actions={actions} close={close} />);
+
+    const items = screen.getAllByRole("menuitem");
+    expect(items).toHaveLength(1);
+    expect(items[0].textContent).toBe("Copy path");
+    expect(items[0].getAttribute("aria-disabled")).not.toBe("true");
+    expect(Array.from(container.querySelectorAll("div")).some(
+      (element) => element.className.includes("bg-border/70"),
+    )).toBe(false);
+
+    fireEvent.click(items[0]);
+    expect(actions.copyCurrentPath).toHaveBeenCalledOnce();
+    expect(actions.openDefault).not.toHaveBeenCalled();
+    expect(actions.reveal).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("renders no menu model when copyPath is null", () => {
+    const actions = makeActions({
+      accessState: { status: "unavailable", reason: "empty" },
+      copyPath: null,
+    });
+    const { container } = render(<FileReferenceMenuContent actions={actions} close={vi.fn()} />);
+    expect(container.innerHTML).toBe("");
+    expect(screen.queryByRole("menuitem")).toBeNull();
+  });
+
+  it("renders a remote workspace file as viewer plus Copy path", () => {
+    const locator = {
+      authority: "workspace" as const,
+      workspacePath: "src/App.tsx",
+      localCompanionPath: null,
+    };
+    const actions = makeActions({
+      accessState: { status: "settled", locator, kind: "file" },
+      pathKind: "file",
+      canOpenInSidebar: true,
+      copyPath: "src/App.tsx",
+    });
+    const { container } = render(
+      <FileReferenceMenuContent actions={actions} close={vi.fn()} />,
+    );
+
+    expect(screen.getAllByRole("menuitem").map((item) => item.textContent)).toEqual([
+      "Open in viewer",
+      "Copy path",
+    ]);
+    expect(separatorCount(container)).toBe(1);
+    expect(screen.queryByText("Open externally")).toBeNull();
+    expect(screen.queryByText("Reveal in Finder")).toBeNull();
+  });
+
+  it("renders a remote workspace directory as exactly Copy path", () => {
+    const locator = {
+      authority: "workspace" as const,
+      workspacePath: "",
+      localCompanionPath: null,
+    };
+    const actions = makeActions({
+      accessState: { status: "settled", locator, kind: "directory" },
+      pathKind: "directory",
+      copyPath: ".",
+    });
+    const { container } = render(
+      <FileReferenceMenuContent actions={actions} close={vi.fn()} />,
+    );
+
+    expect(screen.getAllByRole("menuitem").map((item) => item.textContent)).toEqual([
+      "Copy path",
+    ]);
+    expect(separatorCount(container)).toBe(0);
+  });
+
+  it("renders an ordinary local workspace directory as Copy path plus reveal", () => {
+    const locator = {
+      authority: "workspace" as const,
+      workspacePath: "",
+      localCompanionPath: "/repo",
+    };
+    const actions = makeActions({
+      accessState: { status: "settled", locator, kind: "directory" },
+      pathKind: "directory",
+      canReveal: true,
+      copyPath: "/repo",
+    });
+    const { container } = render(
+      <FileReferenceMenuContent actions={actions} close={vi.fn()} />,
+    );
+    const items = screen.getAllByRole("menuitem");
+
+    expect(items.map((item) => item.textContent)).toEqual([
+      "Copy path",
+      "Reveal folder in Finder",
+    ]);
+    expect(separatorCount(container)).toBe(0);
+    fireEvent.click(items[0]);
+    fireEvent.click(items[1]);
+    expect(actions.copyCurrentPath).toHaveBeenCalledOnce();
+    expect(actions.reveal).toHaveBeenCalledOnce();
+    expect(actions.openDefault).not.toHaveBeenCalled();
+    expect(actions.openWithTarget).not.toHaveBeenCalled();
+  });
+});
+
+function makeActions(overrides: Partial<MenuActions>): MenuActions {
+  const locator = { authority: "unavailable" as const, reason: "invalid" as const };
+  return {
+    reference: {
+      rawPath: "invalid:path",
+      parsedPath: "invalid:path",
+      displayPath: "invalid:path",
+      line: null,
+      column: null,
+      locator,
+    },
+    accessState: { status: "unavailable", reason: "invalid" },
+    nativePathKind: null,
+    openTargets: [],
+    defaultOpenTarget: null,
+    pathKind: null,
+    pathKindPending: false,
+    canOpenInSidebar: false,
+    canOpenExternal: false,
+    canOpenPrimary: false,
+    canReveal: false,
+    primaryUnavailableReason: "This path is invalid.",
+    copyPath: "invalid:path",
+    copyCurrentPath: vi.fn(async () => undefined),
+    openInSidebar: vi.fn(async () => undefined),
+    openDefault: vi.fn(async () => false),
+    openPrimary: vi.fn(async () => "unavailable" as const),
+    openWithTarget: vi.fn(async () => undefined),
+    reveal: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+function separatorCount(container: HTMLElement): number {
+  return Array.from(container.querySelectorAll("div")).filter(
+    (element) => element.className.includes("bg-border/70"),
+  ).length;
+}

--- a/apps/packages/product-client/src/components/workspace/file-references/FileReferenceMenu.tsx
+++ b/apps/packages/product-client/src/components/workspace/file-references/FileReferenceMenu.tsx
@@ -1,5 +1,6 @@
 import { FilePathContextMenuContent } from "#product/components/workspace/open-target/FilePathContextMenuContent";
 import { POPOVER_FRAME_CLASS } from "#product/primitives/PopoverButton";
+import { PopoverMenuItem } from "#product/primitives/PopoverMenuItem";
 import type { useFileReferenceActions } from "#product/hooks/workspaces/workflows/files/use-file-reference-actions";
 
 type FileReferenceActions = ReturnType<typeof useFileReferenceActions>;
@@ -14,6 +15,23 @@ export function FileReferenceMenuContent({
   actions: FileReferenceActions;
   close: () => void;
 }) {
+  if (actions.accessState.status !== "settled") {
+    if (actions.copyPath === null) return null;
+    return (
+      <div className="relative flex flex-col gap-px">
+        <PopoverMenuItem
+          density="compact"
+          role="menuitem"
+          data-chat-transcript-ignore
+          label="Copy path"
+          onClick={() => {
+            void actions.copyCurrentPath();
+            close();
+          }}
+        />
+      </div>
+    );
+  }
   const openTargets = filterFileReferenceOpenTargets(actions.openTargets);
 
   return (
@@ -28,9 +46,10 @@ export function FileReferenceMenuContent({
       onOpenInViewer={() => void actions.openInSidebar()}
       onOpenDefault={() => void actions.openDefault()}
       onOpenTarget={(targetId) => void actions.openWithTarget(targetId)}
-      onCopyPath={() => void actions.copyPath()}
+      onCopyPath={() => void actions.copyCurrentPath()}
       onRevealInFinder={() => void actions.reveal()}
       ignoreChatTranscript
+      hideUnavailableActions
     />
   );
 }

--- a/apps/packages/product-client/src/components/workspace/files/FileEditorView.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/FileEditorView.tsx
@@ -70,7 +70,7 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
     void writeText(read?.content ?? "");
   };
   const copyPath = () => {
-    void fileActions.copyPath();
+    void fileActions.copyCurrentPath();
   };
   const openExternal = () => {
     void fileActions.openDefault();

--- a/apps/packages/product-client/src/components/workspace/files/tree/FileTreeOverlay.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/tree/FileTreeOverlay.test.tsx
@@ -101,7 +101,7 @@ describe("FileTreeOverlay", () => {
     });
     queryMocks.root.data = { entries: rootEntries };
     queryMocks.stat.set("apps-link", {
-      data: { kind: "symlink" },
+      data: { kind: "directory" },
       isFetching: false,
       refetch: vi.fn(),
     });
@@ -143,12 +143,12 @@ describe("FileTreeOverlay", () => {
     queryMocks.stat.set("folder-link", {
       data: undefined,
       isFetching: false,
-      refetch: vi.fn(async () => ({ data: { kind: "symlink" } })),
+      refetch: vi.fn(async () => ({ data: { kind: "directory" } })),
     });
     queryMocks.stat.set("file-link.ts", {
       data: undefined,
       isFetching: false,
-      refetch: vi.fn(async () => ({ data: { kind: "symlink", sizeBytes: 0 } })),
+      refetch: vi.fn(async () => ({ data: { kind: "file", sizeBytes: 0 } })),
     });
     const onOpenFile = vi.fn();
     renderOverlay({ selectedPath: "", onOpenFile });

--- a/apps/packages/product-client/src/components/workspace/files/viewer/FileViewerFrame.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/viewer/FileViewerFrame.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { WorkspacePathContextValue } from "#product/providers/WorkspacePathProvider";
+
+const mocks = vi.hoisted(() => ({
+  workspacePath: {
+    materializedWorkspaceId: "workspace-1",
+    filesystemOrigin: { status: "settled", origin: "desktop-local" },
+    workspaceRoot: { status: "settled", path: "/workspaces/my-repo" },
+  } as WorkspacePathContextValue,
+  setSurfaceAvailability: vi.fn(),
+}));
+
+vi.mock("#product/providers/WorkspacePathProvider", () => ({
+  useWorkspacePath: () => mocks.workspacePath,
+}));
+
+vi.mock("#product/stores/search/content-search-store", () => ({
+  useContentSearchStore: (
+    selector: (state: { setSurfaceAvailability: typeof mocks.setSurfaceAvailability }) => unknown,
+  ) => selector({ setSurfaceAvailability: mocks.setSurfaceAvailability }),
+}));
+
+vi.mock("#product/hooks/workspaces/ui/files/use-file-viewer-native-menu", () => ({
+  useFileViewerNativeMenu: () => ({ showNativeMenu: vi.fn(async () => true) }),
+  useFileViewerNativeContextMenu: () => ({ onContextMenuCapture: vi.fn() }),
+}));
+
+import { FileViewerFrame } from "#product/components/workspace/files/viewer/FileViewerFrame";
+
+const noop = () => {};
+
+function renderFrame() {
+  return render(
+    <FileViewerFrame
+      filePath="src/index.tsx"
+      canRenderRichPreview={false}
+      wordWrap={false}
+      richPreviewEnabled={false}
+      canCopyContent
+      canFindInFile={false}
+      canOpenExternal={false}
+      onToggleWordWrap={noop}
+      onToggleRichPreview={noop}
+      onCopyContent={noop}
+      onCopyPath={noop}
+      onOpenExternal={noop}
+      onOpenContentSearch={noop}
+      browserOpen={false}
+      onToggleBrowser={noop}
+      onBrowsePath={noop}
+    >
+      <div>file content</div>
+    </FileViewerFrame>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  mocks.workspacePath = {
+    materializedWorkspaceId: "workspace-1",
+    filesystemOrigin: { status: "settled", origin: "desktop-local" },
+    workspaceRoot: { status: "settled", path: "/workspaces/my-repo" },
+  };
+});
+
+describe("FileViewerFrame breadcrumbs", () => {
+  it("derives the workspace crumb from a settled normalized runtime root", () => {
+    renderFrame();
+
+    const breadcrumbs = within(screen.getByRole("navigation", { name: "File path" }));
+    expect(breadcrumbs.getByText("my-repo")).toBeTruthy();
+    expect(breadcrumbs.getByText("src")).toBeTruthy();
+    expect(breadcrumbs.getByText("index.tsx")).toBeTruthy();
+  });
+
+  it.each(["pending", "unavailable"] as const)(
+    "does not invent a workspace crumb while the root is %s",
+    (status) => {
+      mocks.workspacePath = {
+        ...mocks.workspacePath,
+        workspaceRoot: { status, path: null },
+      };
+      renderFrame();
+
+      const breadcrumbs = screen.getByRole("navigation", { name: "File path" });
+      expect(within(breadcrumbs).queryByText("my-repo")).toBeNull();
+      expect(breadcrumbs.querySelectorAll("li")).toHaveLength(2);
+    },
+  );
+
+  it("treats filesystem root as having no nonblank workspace-name segment", () => {
+    mocks.workspacePath = {
+      ...mocks.workspacePath,
+      workspaceRoot: { status: "settled", path: "/" },
+    };
+    renderFrame();
+
+    const breadcrumbs = screen.getByRole("navigation", { name: "File path" });
+    expect(breadcrumbs.querySelectorAll("li")).toHaveLength(2);
+    expect(within(breadcrumbs).getByText("src")).toBeTruthy();
+    expect(within(breadcrumbs).getByText("index.tsx")).toBeTruthy();
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/files/viewer/FileViewerFrame.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/viewer/FileViewerFrame.tsx
@@ -184,9 +184,9 @@ function FileBreadcrumbs({
   filePath: string;
   onBrowsePath: (path: string) => void;
 }) {
-  const { workspacePath } = useWorkspacePath();
-  const workspaceName = workspacePath
-    ? workspacePath.split("/").filter(Boolean).pop()
+  const { workspaceRoot } = useWorkspacePath();
+  const workspaceName = workspaceRoot.status === "settled"
+    ? workspaceRoot.path.split("/").filter(Boolean).pop() ?? null
     : null;
   const parts = filePath.split("/").filter(Boolean);
   const crumbs = workspaceName ? [workspaceName, ...parts] : parts;

--- a/apps/packages/product-client/src/components/workspace/open-target/FilePathContextMenuContent.tsx
+++ b/apps/packages/product-client/src/components/workspace/open-target/FilePathContextMenuContent.tsx
@@ -32,6 +32,7 @@ export function FilePathContextMenuContent({
   onCopyPath,
   onRevealInFinder,
   ignoreChatTranscript = false,
+  hideUnavailableActions = false,
 }: {
   pathKind: FileReferencePathKind | null;
   canOpenInViewer: boolean;
@@ -46,15 +47,27 @@ export function FilePathContextMenuContent({
   onCopyPath: () => void;
   onRevealInFinder: () => void;
   ignoreChatTranscript?: boolean;
+  /** Omit unavailable rows and separators for capability-shaped menus. */
+  hideUnavailableActions?: boolean;
 }) {
   const [openWithActive, setOpenWithActive] = useState(false);
   const transcriptProps = ignoreChatTranscript
     ? { "data-chat-transcript-ignore": true }
     : {};
+  const showViewer = pathKind !== "directory"
+    && (!hideUnavailableActions || canOpenInViewer);
+  const showExternal = !hideUnavailableActions || canOpenExternal;
+  const showTargets = targets.length > 0
+    && (!hideUnavailableActions || canOpenExternal);
+  const showReveal = !hideUnavailableActions || canReveal;
+  const showActionSeparator = !hideUnavailableActions
+    || showViewer
+    || showExternal
+    || showTargets;
 
   return (
     <div className="relative flex flex-col gap-px">
-      {pathKind !== "directory" && (
+      {showViewer && (
         <PopoverMenuItem
           {...FILE_PATH_MENU_ITEM_PROPS}
           {...transcriptProps}
@@ -67,18 +80,20 @@ export function FilePathContextMenuContent({
           }}
         />
       )}
-      <PopoverMenuItem
-        {...FILE_PATH_MENU_ITEM_PROPS}
-        {...transcriptProps}
-        icon={<OpenMenuTargetIcon target={defaultTarget ?? null} />}
-        label={defaultTarget ? `Open in ${defaultTarget.label}` : "Open externally"}
-        disabled={!canOpenExternal}
-        onClick={() => {
-          onOpenDefault();
-          close();
-        }}
-      />
-      {targets.length > 0 && (
+      {showExternal && (
+        <PopoverMenuItem
+          {...FILE_PATH_MENU_ITEM_PROPS}
+          {...transcriptProps}
+          icon={<OpenMenuTargetIcon target={defaultTarget ?? null} />}
+          label={defaultTarget ? `Open in ${defaultTarget.label}` : "Open externally"}
+          disabled={!canOpenExternal}
+          onClick={() => {
+            onOpenDefault();
+            close();
+          }}
+        />
+      )}
+      {showTargets && (
         <div
           className="relative"
           onMouseEnter={() => setOpenWithActive(true)}
@@ -118,7 +133,7 @@ export function FilePathContextMenuContent({
           )}
         </div>
       )}
-      <div className="my-1 h-px bg-border/70" />
+      {showActionSeparator && <div className="my-1 h-px bg-border/70" />}
       <PopoverMenuItem
         {...FILE_PATH_MENU_ITEM_PROPS}
         {...transcriptProps}
@@ -128,16 +143,18 @@ export function FilePathContextMenuContent({
           close();
         }}
       />
-      <PopoverMenuItem
-        {...FILE_PATH_MENU_ITEM_PROPS}
-        {...transcriptProps}
-        label={pathKind === "directory" ? "Reveal folder in Finder" : "Reveal in Finder"}
-        disabled={!canReveal}
-        onClick={() => {
-          onRevealInFinder();
-          close();
-        }}
-      />
+      {showReveal && (
+        <PopoverMenuItem
+          {...FILE_PATH_MENU_ITEM_PROPS}
+          {...transcriptProps}
+          label={pathKind === "directory" ? "Reveal folder in Finder" : "Reveal in Finder"}
+          disabled={!canReveal}
+          onClick={() => {
+            onRevealInFinder();
+            close();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/apps/packages/product-client/src/components/workspace/shell/screen/MainScreen.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/MainScreen.tsx
@@ -44,7 +44,6 @@ export const MainScreen = memo(function MainScreen({ visible = true }: { visible
     return (
       <CoworkWorkspaceShell
         workspaceId={coworkWorkspace?.id ?? null}
-        workspacePath={coworkWorkspace?.path ?? null}
         visible={visible}
         fallbackTitle={pendingWorkspaceEntry?.source === "cowork-created"
           ? pendingWorkspaceEntry.displayName

--- a/apps/packages/product-client/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/screen/StandardWorkspaceShell.tsx
@@ -38,7 +38,6 @@ import { useWorkspaceActivityAcknowledgement } from "#product/hooks/workspaces/l
 import {
   resolveStandardWorkspaceChromeClasses,
 } from "#product/lib/domain/preferences/workspace-chrome";
-import { WorkspacePathProvider } from "#product/providers/WorkspacePathProvider";
 import { useRepoPreferencesStore } from "#product/stores/preferences/repo-preferences-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useAttendedPendingWorkspaceEntry } from "#product/hooks/workspaces/derived/use-pending-workspace-entries";
@@ -219,10 +218,9 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
   return (
     <DebugProfiler id="workspace-shell">
       <WorkspaceShellActionsProvider value={shellActions}>
-        <WorkspacePathProvider workspacePath={selectedWorkspace?.path ?? pendingWorkspacePath}>
-          <WorkspaceHeaderTabsViewModelProvider
-            enabled={hasWorkspaceShell && !hasLaunchIntentOnlyShell}
-          >
+        <WorkspaceHeaderTabsViewModelProvider
+          enabled={hasWorkspaceShell && !hasLaunchIntentOnlyShell}
+        >
             {hasWorkspaceShell && !hasLaunchIntentOnlyShell ? (
               <WorkspaceShellShortcuts enabled={visible} />
             ) : null}
@@ -288,7 +286,7 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
                         {hasWorkspaceShell && !hasLaunchIntentOnlyShell && (
                           <GlobalHeader
                             selectedWorkspace={selectedWorkspace}
-                            workspacePath={selectedWorkspace?.path ?? pendingWorkspacePath}
+                            displayWorkspacePath={selectedWorkspace?.path ?? pendingWorkspacePath}
                             runDisabled={!runCommand.canRun}
                             runLoading={runCommand.isLaunching}
                             runLabel={runCommand.runLabel}
@@ -379,8 +377,7 @@ export function StandardWorkspaceShell({ visible = true }: { visible?: boolean }
 
               {hasWorkspaceShell && !hasLaunchIntentOnlyShell ? <ContentSearchPill /> : null}
             </div>
-          </WorkspaceHeaderTabsViewModelProvider>
-        </WorkspacePathProvider>
+        </WorkspaceHeaderTabsViewModelProvider>
       </WorkspaceShellActionsProvider>
     </DebugProfiler>
   );

--- a/apps/packages/product-client/src/components/workspace/shell/topbar/GlobalHeader.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/topbar/GlobalHeader.test.tsx
@@ -1,152 +1,313 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { OpenTarget } from "@proliferate/product-client/host/desktop-bridge";
-
+import type {
+  DesktopBridge,
+  DesktopFilesBridge,
+  OpenTarget,
+} from "@proliferate/product-client/host/desktop-bridge";
+import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
+import type { ProductHost } from "@proliferate/product-client/host/product-host";
 import { GlobalHeader } from "#product/components/workspace/shell/topbar/GlobalHeader";
+import { makeTestProductHost } from "#product/test/product-host-fixtures";
 
-const mocks = vi.hoisted(() => ({
-  files: null as null | {
-    listOpenTargets: ReturnType<typeof vi.fn>;
-    openTarget: ReturnType<typeof vi.fn>;
+const pathMocks = vi.hoisted(() => ({
+  value: {
+    materializedWorkspaceId: "workspace-1" as string | null,
+    filesystemOrigin: { status: "settled" as string, origin: "desktop-local" as string | null },
+    workspaceRoot: { status: "settled" as string, path: "/repo" as string | null },
   },
-  clipboardWriteText: vi.fn().mockResolvedValue(undefined),
-  preferredTargetId: "",
 }));
 
-vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
-  useProductHost: () => ({
-    clipboard: { writeText: mocks.clipboardWriteText },
-    desktop: mocks.files ? { files: mocks.files } : null,
+const statMocks = vi.hoisted(() => ({
+  calls: vi.fn(),
+  data: { kind: "directory" as "file" | "directory" | "symlink" } as
+    | { kind: "file" | "directory" | "symlink" }
+    | undefined,
+  error: null as unknown,
+  isPending: false,
+}));
+
+const shellMocks = vi.hoisted(() => ({
+  splitOnClick: null as (() => void) | null,
+  splitOnTargetClick: null as ((target: OpenTarget) => void) | null,
+  splitTargets: [] as OpenTarget[],
+}));
+
+vi.mock("#product/providers/WorkspacePathProvider", () => ({
+  useWorkspacePath: () => pathMocks.value,
+}));
+
+vi.mock("@anyharness/sdk-react", () => ({
+  useStatWorkspaceFileQuery: (input: unknown) => {
+    statMocks.calls(input);
+    return {
+      data: statMocks.data,
+      error: statMocks.error,
+      isPending: statMocks.isPending,
+      isFetching: false,
+    };
+  },
+}));
+
+vi.mock("#product/hooks/access/anyharness/files/use-workspace-file-lookup", () => ({
+  useWorkspaceFileLookup: () => ({ statFile: vi.fn() }),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/files/use-fuzzy-file-resolver", () => ({
+  useFuzzyFileResolver: () => vi.fn(async () => ({ status: "no-match" })),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/tabs/use-workspace-shell-activation", () => ({
+  useWorkspaceShellActivation: () => ({ activateViewerTarget: vi.fn() }),
+}));
+
+vi.mock("#product/stores/editor/workspace-viewer-tabs-store", () => ({
+  useWorkspaceViewerTabsStore: (selector: (state: { openTarget: () => void }) => unknown) =>
+    selector({ openTarget: vi.fn() }),
+}));
+
+vi.mock("#product/stores/sessions/session-selection-store", () => ({
+  useSessionSelectionStore: (
+    selector: (state: {
+      selectedWorkspaceId: string;
+      selectedLogicalWorkspaceId: string;
+    }) => unknown,
+  ) => selector({
+    selectedWorkspaceId: "workspace-1",
+    selectedLogicalWorkspaceId: "workspace-1",
   }),
 }));
 
 vi.mock("#product/stores/preferences/user-preferences-store", () => ({
   useUserPreferencesStore: (selector: (state: { defaultOpenInTargetId: string }) => unknown) =>
-    selector({ defaultOpenInTargetId: mocks.preferredTargetId }),
+    selector({ defaultOpenInTargetId: "cursor" }),
 }));
 
-vi.mock("#product/components/workspace/shell/topbar/HeaderTabs", () => ({
-  HeaderTabs: () => null,
-}));
-
+vi.mock("#product/components/workspace/shell/topbar/HeaderTabs", () => ({ HeaderTabs: () => null }));
 vi.mock("#product/components/workspace/shell/topbar/WorkspaceActionsMenuContainer", () => ({
   WorkspaceActionsMenuContainer: () => null,
 }));
-
 vi.mock("#product/components/diagnostics/DebugProfiler", () => ({
   DebugProfiler: ({ children }: { children: ReactNode }) => children,
 }));
-
+vi.mock("#product/hooks/ui/debug/use-debug-render-count", () => ({
+  useDebugRenderCount: () => undefined,
+}));
 vi.mock("#product/components/workspace/open-target/SplitButton", () => ({
   SplitButton: ({
     onClick,
     onTargetClick,
-    targets,
+    targets = [],
   }: {
     onClick?: () => void;
     onTargetClick?: (target: OpenTarget) => void;
     targets?: OpenTarget[];
-  }) => (
-    <>
-      <button type="button" onClick={onClick}>Open native target</button>
-      {targets?.map((target) => (
-        <button
-          key={target.id}
-          type="button"
-          onClick={() => onTargetClick?.(target)}
-        >
-          {target.label}
-        </button>
-      ))}
-    </>
-  ),
+  }) => {
+    shellMocks.splitOnClick = onClick ?? null;
+    shellMocks.splitOnTargetClick = onTargetClick ?? null;
+    shellMocks.splitTargets = targets;
+    return (
+      <>
+        <button type="button" onClick={onClick}>Open native target</button>
+        {targets.map((target) => (
+          <button key={target.id} type="button" onClick={() => onTargetClick?.(target)}>
+            {target.label}
+          </button>
+        ))}
+      </>
+    );
+  },
 }));
-
-vi.mock("#product/hooks/ui/debug/use-debug-render-count", () => ({
-  useDebugRenderCount: () => undefined,
-}));
-
-function renderHeader() {
-  return render(
-    <GlobalHeader
-      selectedWorkspace={undefined}
-      workspacePath="/repo"
-      onRun={vi.fn()}
-    />,
-  );
-}
 
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
-  mocks.files = null;
-  mocks.preferredTargetId = "";
+  pathMocks.value = {
+    materializedWorkspaceId: "workspace-1",
+    filesystemOrigin: { status: "settled", origin: "desktop-local" },
+    workspaceRoot: { status: "settled", path: "/repo" },
+  };
+  statMocks.data = { kind: "directory" };
+  statMocks.error = null;
+  statMocks.isPending = false;
+  shellMocks.splitOnClick = null;
+  shellMocks.splitOnTargetClick = null;
+  shellMocks.splitTargets = [];
 });
 
 describe("GlobalHeader", () => {
-  it("applies the larger semantic workspace-title scale to the workspace name", () => {
-    renderHeader();
+  it("keeps the inventory path display-only while using the authority-proven root", async () => {
+    const fixture = desktopFixture();
+    renderHeader(fixture.host, "/inventory/lookalike");
 
-    const title = screen.getByTitle("repo");
-    expect(title.style.fontSize).toBe("var(--text-workspace-title)");
-    expect(title.style.lineHeight).toBe("var(--text-workspace-title--line-height)");
-    expect(title.className.split(" ")).not.toContain("text-ui");
-    expect(title.className.split(" ")).not.toContain("text-sidebar-nav");
-  });
-
-  it("derives left and right action dwell from the animated shell widths", () => {
-    renderHeader();
-
-    const title = screen.getByTitle("repo");
-    expect(title.parentElement?.style.paddingLeft).toBe(
-      "max(8px, calc(var(--workspace-left-header-dwell) - var(--workspace-left-width)))",
-    );
-    expect(screen.getByRole("button", { name: "Run workspace command" }).parentElement?.style.paddingRight)
-      .toBe("max(0px, calc(36px - var(--workspace-right-width)))");
-  });
-
-  it("does not offer a native open action without a Desktop file bridge", () => {
-    renderHeader();
-
-    expect(screen.queryByRole("button", { name: "Open native target" })).toBeNull();
-  });
-
-  it("offers the native open action when the Desktop file bridge is available", () => {
-    mocks.files = {
-      listOpenTargets: vi.fn().mockResolvedValue([]),
-      openTarget: vi.fn().mockResolvedValue(undefined),
-    };
-
-    renderHeader();
-
-    expect(screen.getByRole("button", { name: "Open native target" })).toBeTruthy();
-  });
-
-  it("routes both preferred and menu copy targets through the shared clipboard", async () => {
-    const copyTarget: OpenTarget = {
-      id: "copy-path",
-      label: "Copy path",
-      kind: "copy",
-    };
-    mocks.preferredTargetId = copyTarget.id;
-    mocks.files = {
-      listOpenTargets: vi.fn().mockResolvedValue([copyTarget]),
-      openTarget: vi.fn().mockResolvedValue(undefined),
-    };
-
-    renderHeader();
-    const menuCopyButton = await screen.findByRole("button", { name: "Copy path" });
+    expect(screen.getByTitle("lookalike").style.fontSize).toBe("var(--text-workspace-title)");
+    expect(statMocks.calls).toHaveBeenLastCalledWith(expect.objectContaining({ path: "" }));
+    await waitFor(() => expect(fixture.listOpenTargets).toHaveBeenCalledWith("directory"));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Open native target" })).toBeTruthy());
 
     fireEvent.click(screen.getByRole("button", { name: "Open native target" }));
-    fireEvent.click(menuCopyButton);
-
-    await waitFor(() => {
-      expect(mocks.clipboardWriteText).toHaveBeenCalledTimes(2);
-    });
-    expect(mocks.clipboardWriteText).toHaveBeenNthCalledWith(1, "/repo");
-    expect(mocks.clipboardWriteText).toHaveBeenNthCalledWith(2, "/repo");
-    expect(mocks.files.openTarget).not.toHaveBeenCalled();
+    await waitFor(() => expect(fixture.openTarget).toHaveBeenCalledWith("cursor", "/repo"));
+    fireEvent.click(screen.getByRole("button", { name: "Copy path" }));
+    await waitFor(() => expect(fixture.copy).toHaveBeenCalledWith("/repo"));
+    expect(fixture.openTarget).not.toHaveBeenCalledWith(expect.anything(), "/inventory/lookalike");
   });
+
+  it("falls back to authority-proven root reveal when no open target exists", async () => {
+    const fixture = desktopFixture([]);
+    renderHeader(fixture.host);
+    await waitFor(() => expect(fixture.listOpenTargets).toHaveBeenCalledOnce());
+    fireEvent.click(screen.getByRole("button", { name: "Open native target" }));
+    await waitFor(() => expect(fixture.reveal).toHaveBeenCalledWith("/repo"));
+  });
+
+  it.each([
+    ["remote", { status: "settled", origin: "remote" }, { status: "settled", path: "/repo" }, "directory", true],
+    ["SSH target", { status: "settled", origin: "remote" }, { status: "settled", path: "/repo" }, "directory", true],
+    ["origin pending", { status: "pending", origin: null }, { status: "settled", path: "/repo" }, "directory", true],
+    ["origin rejected", { status: "rejected", origin: null }, { status: "settled", path: "/repo" }, "directory", true],
+    ["root pending", { status: "settled", origin: "desktop-local" }, { status: "pending", path: null }, "directory", true],
+    ["root unavailable", { status: "settled", origin: "desktop-local" }, { status: "unavailable", path: null }, "directory", true],
+    ["Web local", { status: "settled", origin: "desktop-local" }, { status: "settled", path: "/repo" }, "directory", false],
+    ["Web remote", { status: "settled", origin: "remote" }, { status: "settled", path: "/repo" }, "directory", false],
+    ["non-directory", { status: "settled", origin: "desktop-local" }, { status: "settled", path: "/repo" }, "file", true],
+    ["unexpected kind", { status: "settled", origin: "desktop-local" }, { status: "settled", path: "/repo" }, "symlink", true],
+  ] as const)("offers no native root action for %s", async (_label, origin, root, kind, desktop) => {
+    pathMocks.value = {
+      materializedWorkspaceId: "workspace-1",
+      filesystemOrigin: origin,
+      workspaceRoot: root,
+    };
+    statMocks.data = { kind };
+    const fixture = desktopFixture();
+    renderHeader(desktop ? fixture.host : makeTestProductHost(), "/inventory/local-looking");
+    await act(async () => Promise.resolve());
+
+    expect(screen.queryByRole("button", { name: "Open native target" })).toBeNull();
+    expect(fixture.listOpenTargets).not.toHaveBeenCalled();
+    expect(fixture.openTarget).not.toHaveBeenCalled();
+    expect(fixture.reveal).not.toHaveBeenCalled();
+    expect(fixture.copy).not.toHaveBeenCalled();
+  });
+
+  it("keeps the root action hidden while exact stat is pending or refused", async () => {
+    const fixture = desktopFixture();
+    statMocks.data = undefined;
+    statMocks.isPending = true;
+    const view = renderHeader(fixture.host);
+    expect(screen.queryByRole("button", { name: "Open native target" })).toBeNull();
+    expect(fixture.listOpenTargets).not.toHaveBeenCalled();
+
+    statMocks.isPending = false;
+    statMocks.error = new Error("refused");
+    view.rerender(headerTree(fixture.host));
+    await act(async () => Promise.resolve());
+    expect(screen.queryByRole("button", { name: "Open native target" })).toBeNull();
+    expect(fixture.listOpenTargets).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when local root callbacks become stale", async () => {
+    const fixture = desktopFixture();
+    const view = renderHeader(fixture.host);
+    await waitFor(() => expect(fixture.listOpenTargets).toHaveBeenCalledOnce());
+    const staleDefault = shellMocks.splitOnClick!;
+    const staleTarget = shellMocks.splitOnTargetClick!;
+    const staleCopyTarget = shellMocks.splitTargets.find((target) => target.kind === "copy")!;
+    const staleEditorTarget = shellMocks.splitTargets.find((target) => target.kind === "editor")!;
+    fixture.openTarget.mockClear();
+    fixture.reveal.mockClear();
+    fixture.copy.mockClear();
+
+    pathMocks.value = {
+      ...pathMocks.value,
+      workspaceRoot: { status: "settled", path: "/different" },
+    };
+    view.rerender(headerTree(fixture.host));
+    await act(async () => {
+      staleDefault();
+      staleTarget(staleCopyTarget);
+      staleTarget(staleEditorTarget);
+      await Promise.resolve();
+    });
+
+    expect(fixture.openTarget).not.toHaveBeenCalled();
+    expect(fixture.reveal).not.toHaveBeenCalled();
+    expect(fixture.copy).not.toHaveBeenCalled();
+  });
+
+  it.each(["selection", "origin", "bridge", "kind"] as const)(
+    "fails closed when a callback predates a %s change",
+    async (change) => {
+      const fixture = desktopFixture();
+      const view = renderHeader(fixture.host);
+      await waitFor(() => expect(fixture.listOpenTargets).toHaveBeenCalledOnce());
+      const staleDefault = shellMocks.splitOnClick!;
+      const staleTarget = shellMocks.splitOnTargetClick!;
+      const editorTarget = shellMocks.splitTargets.find((target) => target.kind === "editor")!;
+      fixture.openTarget.mockClear();
+      fixture.reveal.mockClear();
+
+      let nextHost = fixture.host;
+      if (change === "selection") {
+        pathMocks.value = { ...pathMocks.value, materializedWorkspaceId: "workspace-2" };
+      } else if (change === "origin") {
+        pathMocks.value = {
+          ...pathMocks.value,
+          filesystemOrigin: { status: "settled", origin: "remote" },
+        };
+      } else if (change === "bridge") {
+        nextHost = desktopFixture().host;
+      } else {
+        statMocks.data = { kind: "file" };
+      }
+      view.rerender(headerTree(nextHost));
+      await act(async () => {
+        staleDefault();
+        staleTarget(editorTarget);
+        await Promise.resolve();
+      });
+
+      expect(fixture.openTarget).not.toHaveBeenCalled();
+      expect(fixture.reveal).not.toHaveBeenCalled();
+    },
+  );
 });
+
+function renderHeader(host: ProductHost, displayWorkspacePath = "/repo") {
+  return render(headerTree(host, displayWorkspacePath));
+}
+
+function headerTree(host: ProductHost, displayWorkspacePath = "/repo") {
+  return (
+    <ProductHostProvider host={host}>
+      <GlobalHeader
+        selectedWorkspace={undefined}
+        displayWorkspacePath={displayWorkspacePath}
+        onRun={vi.fn()}
+      />
+    </ProductHostProvider>
+  );
+}
+
+function desktopFixture(targets: OpenTarget[] = [
+  { id: "cursor", label: "Cursor", kind: "editor", iconId: "cursor" },
+]) {
+  const listOpenTargets = vi.fn(async () => targets);
+  const openTarget = vi.fn(async () => undefined);
+  const reveal = vi.fn(async () => undefined);
+  const copy = vi.fn(async () => undefined);
+  const files = {
+    listOpenTargets,
+    openTarget,
+    reveal,
+    getHomeDirectory: vi.fn(async () => "/Users/pablo"),
+    inspectPath: vi.fn(async () => ({ kind: "directory" as const })),
+  } as unknown as DesktopFilesBridge;
+  const host = makeTestProductHost({
+    desktop: { files } as unknown as DesktopBridge,
+    overrides: { clipboard: { writeText: copy } },
+  });
+  return { host, listOpenTargets, openTarget, reveal, copy };
+}

--- a/apps/packages/product-client/src/components/workspace/shell/topbar/GlobalHeader.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/topbar/GlobalHeader.tsx
@@ -1,32 +1,30 @@
-import {
-  memo,
-  useState,
-  useCallback,
-  useEffect,
-} from "react";
-import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store";
-import { resolvePreferredOpenTarget } from "#product/lib/domain/chat/composer/preference-resolvers";
-import { HeaderTabs } from "#product/components/workspace/shell/topbar/HeaderTabs";
-import { WorkspaceActionsMenuContainer } from "#product/components/workspace/shell/topbar/WorkspaceActionsMenuContainer";
-import { Button } from "#product/primitives/Button";
+import { memo, useCallback, useMemo, useRef } from "react";
+import type { Workspace } from "@anyharness/sdk";
+import type { OpenTarget } from "@proliferate/product-client/host/desktop-bridge";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { DebugProfiler } from "#product/components/diagnostics/DebugProfiler";
 import { SplitButton } from "#product/components/workspace/open-target/SplitButton";
-import {
-  type OpenTarget,
-} from "@proliferate/product-client/host/desktop-bridge";
-import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
-import { FilePen } from "#product/primitives/icons/workspace";
-import { Play } from "#product/primitives/icons/core";
-import type { Workspace } from "@anyharness/sdk";
+import { HeaderTabs } from "#product/components/workspace/shell/topbar/HeaderTabs";
+import { WorkspaceActionsMenuContainer } from "#product/components/workspace/shell/topbar/WorkspaceActionsMenuContainer";
 import { useDebugRenderCount } from "#product/hooks/ui/debug/use-debug-render-count";
+import { useFileReferenceActions } from "#product/hooks/workspaces/workflows/files/use-file-reference-actions";
 import { workspaceHeaderTitle } from "#product/lib/domain/workspaces/display/workspace-display";
-import { useToastStore } from "#product/stores/toast/toast-store";
+import { Button } from "#product/primitives/Button";
+import { Play } from "#product/primitives/icons/core";
+import { FilePen } from "#product/primitives/icons/workspace";
+import { useWorkspacePath } from "#product/providers/WorkspacePathProvider";
 
 const HEADER_RUN_BUTTON_CLASS = "workspace-shell-action-button font-medium";
+const COPY_PATH_TARGET: OpenTarget = {
+  id: "copy-path",
+  label: "Copy path",
+  kind: "copy",
+};
 
 interface GlobalHeaderProps {
   selectedWorkspace: Workspace | undefined;
-  workspacePath?: string | null;
+  /** Inventory/pending path used only to derive the visible workspace title. */
+  displayWorkspacePath?: string | null;
   runDisabled?: boolean;
   runLoading?: boolean;
   runLabel?: string;
@@ -36,7 +34,7 @@ interface GlobalHeaderProps {
 
 export const GlobalHeader = memo(function GlobalHeader({
   selectedWorkspace,
-  workspacePath: workspacePathProp,
+  displayWorkspacePath,
   runDisabled = false,
   runLoading = false,
   runLabel = "Run",
@@ -44,56 +42,86 @@ export const GlobalHeader = memo(function GlobalHeader({
   onRun,
 }: GlobalHeaderProps) {
   useDebugRenderCount("global-header");
-  const [targets, setTargets] = useState<OpenTarget[]>([]);
   const host = useProductHost();
-  const files = host.desktop?.files ?? null;
-  const defaultOpenInTargetId = useUserPreferencesStore((s) => s.defaultOpenInTargetId);
-  const preferredTarget = resolvePreferredOpenTarget(targets, { defaultOpenInTargetId });
-  const workspacePath = workspacePathProp ?? selectedWorkspace?.path;
-  const title = workspaceHeaderTitle(selectedWorkspace, workspacePath);
-
-  useEffect(() => {
-    if (!files) {
-      setTargets([]);
-      return;
-    }
-    void files.listOpenTargets("directory").then(setTargets);
-  }, [files]);
-
-  const showToast = useToastStore((s) => s.show);
-
-  const openTarget = useCallback(
-    (targetId: string, label: string) => {
-      if (!workspacePath || !files) return;
-      // The Rust side re-resolves the app at click time, so an editor can
-      // vanish between listing and clicking — don't swallow that.
-      files.openTarget(targetId, workspacePath).catch(() => {
-        showToast(`Couldn't open workspace in ${label}`);
-      });
-    },
-    [files, showToast, workspacePath],
+  const workspacePathState = useWorkspacePath();
+  const rootActions = useFileReferenceActions({
+    rawPath: ".",
+    workspacePath: ".",
+    nativeCapabilityKind: "directory",
+  });
+  const rootLocator = rootActions.accessState.status === "settled"
+    && rootActions.accessState.locator.authority === "workspace"
+    ? rootActions.accessState.locator
+    : null;
+  const rootCapabilityAvailable = rootActions.accessState.status === "settled"
+    && rootActions.accessState.kind === "directory"
+    && rootLocator?.workspacePath === ""
+    && rootLocator.localCompanionPath !== null
+    && rootActions.nativePathKind === "directory";
+  const targets = useMemo(
+    () => rootCapabilityAvailable
+      ? [...rootActions.openTargets, COPY_PATH_TARGET]
+      : [],
+    [rootActions.openTargets, rootCapabilityAvailable],
   );
+  const preferredTarget = rootActions.defaultOpenTarget;
+
+  const capabilityRevision = useMemo(() => ({}), [
+    host.desktop?.files,
+    rootActions.nativePathKind,
+    rootActions.openDefault,
+    rootLocator?.localCompanionPath,
+    rootLocator?.workspacePath,
+    rootCapabilityAvailable,
+    workspacePathState.filesystemOrigin.origin,
+    workspacePathState.filesystemOrigin.status,
+    workspacePathState.materializedWorkspaceId,
+    workspacePathState.workspaceRoot.path,
+    workspacePathState.workspaceRoot.status,
+  ]);
+  const capabilityRef = useRef({
+    actions: rootActions,
+    available: rootCapabilityAvailable,
+    revision: capabilityRevision,
+    targets,
+    preferredTarget,
+  });
+  capabilityRef.current = {
+    actions: rootActions,
+    available: rootCapabilityAvailable,
+    revision: capabilityRevision,
+    targets,
+    preferredTarget,
+  };
 
   const handleDefaultOpen = useCallback(() => {
-    if (!workspacePath) return;
-    if (preferredTarget?.kind === "copy") {
-      void host.clipboard.writeText(workspacePath);
+    const current = capabilityRef.current;
+    if (!current.available || current.revision !== capabilityRevision) return;
+    if (current.preferredTarget) {
+      void current.actions.openDefault();
       return;
     }
-    openTarget(preferredTarget?.id ?? "finder", preferredTarget?.label ?? "Finder");
-  }, [host.clipboard, openTarget, workspacePath, preferredTarget]);
+    void current.actions.reveal();
+  }, [capabilityRevision]);
 
-  const handleTargetClick = useCallback(
-    (target: OpenTarget) => {
-      if (!workspacePath) return;
-      if (target.kind === "copy") {
-        void host.clipboard.writeText(workspacePath);
-        return;
-      }
-      openTarget(target.id, target.label);
-    },
-    [host.clipboard, openTarget, workspacePath],
-  );
+  const handleTargetClick = useCallback((target: OpenTarget) => {
+    const current = capabilityRef.current;
+    if (
+      !current.available
+      || current.revision !== capabilityRevision
+      || !current.targets.some((candidate) => candidate.id === target.id)
+    ) return;
+    if (target.kind === "copy") {
+      void current.actions.copyCurrentPath();
+      return;
+    }
+    void current.actions.openWithTarget(target.id);
+  }, [capabilityRevision]);
+
+  // This inventory-derived value is deliberately display-only. Filesystem
+  // actions above use the authority-proven runtime root capability instead.
+  const titlePath = displayWorkspacePath ?? selectedWorkspace?.path;
+  const title = workspaceHeaderTitle(selectedWorkspace, titlePath);
 
   return (
     <DebugProfiler id="global-header">
@@ -116,7 +144,6 @@ export const GlobalHeader = memo(function GlobalHeader({
         </div>
 
         <WorkspaceActionsMenuContainer />
-
         <div className="flex h-full min-w-0 flex-1 items-stretch overflow-hidden">
           <HeaderTabs />
         </div>
@@ -141,10 +168,10 @@ export const GlobalHeader = memo(function GlobalHeader({
               <Play className="icon-paired" />
               <span>{runLabel}</span>
             </Button>
-            {workspacePath && files && (
+            {rootCapabilityAvailable && (
               <SplitButton
                 icon={<FilePen className="icon-paired" />}
-                label={preferredTarget?.label ?? "Open"}
+                label={preferredTarget?.label ?? "Reveal in Finder"}
                 showLabel={false}
                 onClick={handleDefaultOpen}
                 targets={targets}

--- a/apps/packages/product-client/src/hooks/access/anyharness/files/use-workspace-file-lookup.test.tsx
+++ b/apps/packages/product-client/src/hooks/access/anyharness/files/use-workspace-file-lookup.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useWorkspaceFileLookup } from "#product/hooks/access/anyharness/files/use-workspace-file-lookup";
+import { createAppQueryClient } from "#product/lib/infra/query/query-client";
+
+const mocks = vi.hoisted(() => ({
+  search: vi.fn(),
+  stat: vi.fn(),
+}));
+
+vi.mock("@anyharness/sdk-react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@anyharness/sdk-react")>();
+  return {
+    ...actual,
+    getAnyHarnessClient: () => ({ files: { search: mocks.search, stat: mocks.stat } }),
+    resolveWorkspaceConnectionFromContext: vi.fn(async (_context, workspaceId: string) => ({
+      workspaceId,
+      connection: {
+        runtimeUrl: "http://runtime.test",
+        anyharnessWorkspaceId: `runtime-${workspaceId}`,
+      },
+    })),
+    useAnyHarnessCacheScopeKey: () => "account-1",
+    useAnyHarnessWorkspaceContext: () => ({
+      workspaceId: "workspace-1",
+      resolveConnection: vi.fn(),
+    }),
+  };
+});
+
+describe("useWorkspaceFileLookup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses SDK query keys and the 200-result search bound", async () => {
+    mocks.search.mockResolvedValueOnce({ results: [] });
+    mocks.stat.mockResolvedValueOnce({ path: "src/App.tsx", kind: "file", sizeBytes: 1 });
+    const queryClient = createAppQueryClient({ captureException: vi.fn() });
+    const { result } = renderHook(() => useWorkspaceFileLookup(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    });
+
+    await act(async () => {
+      await result.current.searchFiles({ materializedWorkspaceId: "workspace-1", query: "App.tsx" });
+      await result.current.statFile({ materializedWorkspaceId: "workspace-1", path: "src/App.tsx" });
+    });
+
+    expect(mocks.search).toHaveBeenCalledWith("runtime-workspace-1", "App.tsx", 200);
+    expect(mocks.stat).toHaveBeenCalledWith("runtime-workspace-1", "src/App.tsx");
+    expect(queryClient.getQueryCache().getAll().map((query) => query.queryKey)).toContainEqual([
+      "anyharness",
+      "account-1",
+      "workspace",
+      "workspace-1",
+      "file-search",
+      "App.tsx",
+      200,
+    ]);
+  });
+
+  it("overrides the production retry default for each failed transport stage", async () => {
+    mocks.search.mockRejectedValue(new Error("search failed"));
+    mocks.stat.mockRejectedValue(new Error("stat failed"));
+    const queryClient = createAppQueryClient({ captureException: vi.fn() });
+    const { result } = renderHook(() => useWorkspaceFileLookup(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    });
+
+    await expect(result.current.searchFiles({
+      materializedWorkspaceId: "workspace-1",
+      query: "missing.ts",
+    })).rejects.toThrow("search failed");
+    await expect(result.current.statFile({
+      materializedWorkspaceId: "workspace-1",
+      path: "missing.ts",
+    })).rejects.toThrow("stat failed");
+
+    expect(mocks.search).toHaveBeenCalledTimes(1);
+    expect(mocks.stat).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/packages/product-client/src/hooks/access/anyharness/files/use-workspace-file-lookup.ts
+++ b/apps/packages/product-client/src/hooks/access/anyharness/files/use-workspace-file-lookup.ts
@@ -1,0 +1,69 @@
+import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  anyHarnessWorkspaceFileSearchKey,
+  anyHarnessWorkspaceFileStatKey,
+  getAnyHarnessClient,
+  resolveWorkspaceConnectionFromContext,
+  useAnyHarnessCacheScopeKey,
+  useAnyHarnessWorkspaceContext,
+} from "@anyharness/sdk-react";
+
+const FUZZY_SEARCH_LIMIT = 200;
+
+/** Imperative, cache-owned runtime file lookup used by bounded reference recovery. */
+export function useWorkspaceFileLookup() {
+  const queryClient = useQueryClient();
+  const workspace = useAnyHarnessWorkspaceContext();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
+
+  const searchFiles = useCallback(async ({
+    materializedWorkspaceId,
+    query,
+  }: {
+    materializedWorkspaceId: string;
+    query: string;
+  }) => queryClient.fetchQuery({
+    queryKey: anyHarnessWorkspaceFileSearchKey(
+      cacheScopeKey,
+      materializedWorkspaceId,
+      query,
+      FUZZY_SEARCH_LIMIT,
+    ),
+    retry: false,
+    queryFn: async () => {
+      const { connection } = await resolveWorkspaceConnectionFromContext(
+        workspace,
+        materializedWorkspaceId,
+      );
+      return getAnyHarnessClient(connection).files.search(
+        connection.anyharnessWorkspaceId,
+        query,
+        FUZZY_SEARCH_LIMIT,
+      );
+    },
+  }), [cacheScopeKey, queryClient, workspace]);
+
+  const statFile = useCallback(async ({
+    materializedWorkspaceId,
+    path,
+  }: {
+    materializedWorkspaceId: string;
+    path: string;
+  }) => queryClient.fetchQuery({
+    queryKey: anyHarnessWorkspaceFileStatKey(cacheScopeKey, materializedWorkspaceId, path),
+    retry: false,
+    queryFn: async () => {
+      const { connection } = await resolveWorkspaceConnectionFromContext(
+        workspace,
+        materializedWorkspaceId,
+      );
+      return getAnyHarnessClient(connection).files.stat(
+        connection.anyharnessWorkspaceId,
+        path,
+      );
+    },
+  }), [cacheScopeKey, queryClient, workspace]);
+
+  return { searchFiles, statFile };
+}

--- a/apps/packages/product-client/src/hooks/terminals/lifecycle/use-terminal-stream-controller.test.tsx
+++ b/apps/packages/product-client/src/hooks/terminals/lifecycle/use-terminal-stream-controller.test.tsx
@@ -91,10 +91,14 @@ vi.mock("#product/hooks/workspaces/derived/use-workspace-runtime-block", () => (
 
 vi.mock("#product/lib/access/anyharness/resolve-workspace-connection", () => ({
   resolveWorkspaceConnection: vi.fn(async () => ({
-    runtimeUrl: "http://runtime.test",
-    authToken: mockState.token,
-    anyharnessWorkspaceId: "anyharness-workspace-1",
-    runtimeGeneration: mockState.runtimeGeneration,
+    connection: {
+      runtimeUrl: "http://runtime.test",
+      authToken: mockState.token,
+      anyharnessWorkspaceId: "anyharness-workspace-1",
+      runtimeGeneration: mockState.runtimeGeneration,
+      runtimeAccessKind: "direct",
+    },
+    filesystemOrigin: "desktop-local",
   })),
 }));
 

--- a/apps/packages/product-client/src/hooks/terminals/workflows/use-terminal-workspace-connection.test.tsx
+++ b/apps/packages/product-client/src/hooks/terminals/workflows/use-terminal-workspace-connection.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  selectedCloudRuntime: {
+    workspaceId: null as string | null,
+    state: null as { phase: string } | null,
+    connectionInfo: null as Record<string, unknown> | null,
+  },
+  resolveWorkspaceConnection: vi.fn(),
+  invalidateCloudWorkspaceConnection: vi.fn(),
+  getWorkspaceRuntimeBlockReason: vi.fn(),
+  withFreshCloudSandboxGatewayAccessToken: vi.fn(async (connection: unknown) => connection),
+}));
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => ({ desktop: null, cloud: { client: null } }),
+}));
+
+vi.mock("#product/hooks/access/cloud/use-cloud-workspace-connection-cache", () => ({
+  useCloudWorkspaceConnectionCache: () => ({
+    invalidateCloudWorkspaceConnection: mocks.invalidateCloudWorkspaceConnection,
+  }),
+}));
+
+vi.mock("#product/hooks/workspaces/derived/use-workspace-runtime-block", () => ({
+  useWorkspaceRuntimeBlock: () => ({
+    selectedCloudRuntime: mocks.selectedCloudRuntime,
+    getWorkspaceRuntimeBlockReason: mocks.getWorkspaceRuntimeBlockReason,
+  }),
+}));
+
+vi.mock("#product/lib/access/anyharness/resolve-workspace-connection", () => ({
+  resolveWorkspaceConnection: mocks.resolveWorkspaceConnection,
+}));
+
+vi.mock("#product/lib/access/cloud/cloud-sandbox-gateway", async (importOriginal) => {
+  const original = await importOriginal<
+    typeof import("#product/lib/access/cloud/cloud-sandbox-gateway")
+  >();
+  return {
+    ...original,
+    withFreshCloudSandboxGatewayAccessToken:
+      mocks.withFreshCloudSandboxGatewayAccessToken,
+  };
+});
+
+import { useTerminalWorkspaceConnection } from "#product/hooks/terminals/workflows/use-terminal-workspace-connection";
+import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.selectedCloudRuntime.workspaceId = null;
+  mocks.selectedCloudRuntime.state = null;
+  mocks.selectedCloudRuntime.connectionInfo = null;
+  useHarnessConnectionStore.setState({
+    runtimeUrl: "http://local.runtime.test",
+    connectionState: "healthy",
+    error: null,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useTerminalWorkspaceConnection", () => {
+  it("preserves all cached Cloud gateway connection metadata", async () => {
+    mocks.selectedCloudRuntime.workspaceId = "cloud:cloud-1";
+    mocks.selectedCloudRuntime.state = { phase: "ready" };
+    mocks.selectedCloudRuntime.connectionInfo = {
+      runtimeUrl: "https://gateway.runtime.test",
+      accessToken: "cloud-token",
+      anyharnessWorkspaceId: "runtime-workspace",
+      runtimeGeneration: 12,
+      runtimeAccessKind: "proliferate-gateway",
+      webSocketAuthTransport: "protocol",
+    };
+    const { result } = renderHook(() => useTerminalWorkspaceConnection());
+
+    await expect(result.current.resolveTerminalWorkspaceConnection("cloud:cloud-1"))
+      .resolves.toEqual({
+        runtimeUrl: "https://gateway.runtime.test",
+        authToken: "cloud-token",
+        anyharnessWorkspaceId: "runtime-workspace",
+        runtimeGeneration: 12,
+        runtimeAccessKind: "proliferate-gateway",
+        webSocketAuthTransport: "protocol",
+      });
+    expect(mocks.resolveWorkspaceConnection).not.toHaveBeenCalled();
+  });
+
+  it("unwraps the Product envelope on the normal terminal path", async () => {
+    const connection = {
+      runtimeUrl: "http://local.runtime.test",
+      anyharnessWorkspaceId: "workspace-local",
+      runtimeGeneration: 0,
+      runtimeAccessKind: "direct" as const,
+    };
+    mocks.resolveWorkspaceConnection.mockResolvedValue({
+      connection,
+      filesystemOrigin: "desktop-local",
+    });
+    const { result } = renderHook(() => useTerminalWorkspaceConnection());
+
+    await expect(result.current.resolveTerminalWorkspaceConnection("workspace-local"))
+      .resolves.toEqual(connection);
+  });
+});

--- a/apps/packages/product-client/src/hooks/terminals/workflows/use-terminal-workspace-connection.ts
+++ b/apps/packages/product-client/src/hooks/terminals/workflows/use-terminal-workspace-connection.ts
@@ -4,7 +4,7 @@ import { useCloudWorkspaceConnectionCache } from "#product/hooks/access/cloud/us
 import { useWorkspaceRuntimeBlock } from "#product/hooks/workspaces/derived/use-workspace-runtime-block";
 import {
   resolveWorkspaceConnection,
-  type AnyHarnessDesktopResolvedConnection,
+  type ProductAnyHarnessResolvedConnection,
 } from "#product/lib/access/anyharness/resolve-workspace-connection";
 import { parseCloudWorkspaceSyntheticId } from "#product/lib/domain/workspaces/cloud/cloud-ids";
 import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
@@ -14,7 +14,7 @@ export interface TerminalWorkspaceConnectionController {
   getWorkspaceRuntimeBlockReason(workspaceId: string): string | null;
   resolveTerminalWorkspaceConnection(
     workspaceId: string,
-  ): Promise<AnyHarnessDesktopResolvedConnection>;
+  ): Promise<ProductAnyHarnessResolvedConnection>;
   triggerSelectedCloudReconnect(workspaceId: string): void;
 }
 
@@ -29,7 +29,7 @@ export function useTerminalWorkspaceConnection(): TerminalWorkspaceConnectionCon
 
   const resolveTerminalWorkspaceConnection = useCallback(async (
     workspaceId: string,
-  ): Promise<AnyHarnessDesktopResolvedConnection> => {
+  ): Promise<ProductAnyHarnessResolvedConnection> => {
     if (
       selectedCloudRuntime.workspaceId === workspaceId
       && selectedCloudRuntime.state?.phase === "ready"
@@ -43,11 +43,12 @@ export function useTerminalWorkspaceConnection(): TerminalWorkspaceConnectionCon
         authToken: connectionInfo.accessToken,
         webSocketAuthTransport: connectionInfo.webSocketAuthTransport,
         anyharnessWorkspaceId: connectionInfo.anyharnessWorkspaceId ?? "",
-        runtimeGeneration: connectionInfo.runtimeGeneration,
+        runtimeGeneration: connectionInfo.runtimeGeneration ?? 0,
+        runtimeAccessKind: "proliferate-gateway",
       };
     }
 
-    return resolveWorkspaceConnection(runtimeUrl, workspaceId, ssh, cloudClient);
+    return (await resolveWorkspaceConnection(runtimeUrl, workspaceId, ssh, cloudClient)).connection;
   }, [
     runtimeUrl,
     ssh,

--- a/apps/packages/product-client/src/hooks/workspaces/cache/use-resolve-workspace-connection.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/cache/use-resolve-workspace-connection.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  resolveWorkspaceConnection: vi.fn(),
+  withFreshCloudSandboxGatewayAccessToken: vi.fn(async (connection: unknown) => connection),
+}));
+
+vi.mock("#product/lib/access/anyharness/resolve-workspace-connection", () => ({
+  resolveWorkspaceConnection: mocks.resolveWorkspaceConnection,
+}));
+
+vi.mock("#product/lib/access/cloud/cloud-sandbox-gateway", async (importOriginal) => {
+  const original = await importOriginal<
+    typeof import("#product/lib/access/cloud/cloud-sandbox-gateway")
+  >();
+  return {
+    ...original,
+    withFreshCloudSandboxGatewayAccessToken:
+      mocks.withFreshCloudSandboxGatewayAccessToken,
+  };
+});
+
+import { useResolveWorkspaceConnection } from "#product/hooks/workspaces/cache/use-resolve-workspace-connection";
+
+function wrapper(queryClient: QueryClient) {
+  return function QueryWrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const input = {
+  ssh: null,
+  cloudClient: null,
+  runtimeUrl: "http://local.runtime.test",
+  authStatus: "anonymous",
+  authUserId: null,
+  cacheScopeKey: "test-scope",
+  selectedWorkspaceId: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useResolveWorkspaceConnection", () => {
+  it("returns the Product envelope from the normal resolver unchanged", async () => {
+    const queryClient = new QueryClient();
+    const expected = {
+      connection: {
+        runtimeUrl: "http://local.runtime.test",
+        anyharnessWorkspaceId: "workspace-local",
+        runtimeGeneration: 4,
+        runtimeAccessKind: "direct" as const,
+      },
+      filesystemOrigin: "desktop-local" as const,
+    };
+    mocks.resolveWorkspaceConnection.mockResolvedValue(expected);
+    const { result } = renderHook(
+      () => useResolveWorkspaceConnection(input),
+      { wrapper: wrapper(queryClient) },
+    );
+
+    await expect(result.current("workspace-local")).resolves.toEqual(expected);
+    expect(mocks.resolveWorkspaceConnection).toHaveBeenCalledWith(
+      "http://local.runtime.test",
+      "workspace-local",
+      null,
+      null,
+    );
+  });
+
+  it("treats only a successful cached Cloud gateway resolution as remote authority", async () => {
+    const queryClient = new QueryClient();
+    vi.spyOn(queryClient, "fetchQuery").mockResolvedValue({
+      runtimeUrl: "https://gateway.runtime.test",
+      accessToken: "cloud-token",
+      anyharnessWorkspaceId: "runtime-workspace",
+      runtimeGeneration: 9,
+      webSocketAuthTransport: "protocol",
+    });
+    const { result } = renderHook(
+      () => useResolveWorkspaceConnection(input),
+      { wrapper: wrapper(queryClient) },
+    );
+
+    await expect(result.current("cloud:cloud-1")).resolves.toEqual({
+      connection: {
+        runtimeUrl: "https://gateway.runtime.test",
+        authToken: "cloud-token",
+        anyharnessWorkspaceId: "runtime-workspace",
+        runtimeGeneration: 9,
+        runtimeAccessKind: "proliferate-gateway",
+        webSocketAuthTransport: "protocol",
+      },
+      filesystemOrigin: "remote",
+    });
+    expect(mocks.resolveWorkspaceConnection).not.toHaveBeenCalled();
+  });
+
+  it("rejects a failed cached Cloud fetch instead of synthesizing provenance", async () => {
+    const queryClient = new QueryClient();
+    vi.spyOn(queryClient, "fetchQuery").mockRejectedValue(new Error("connection unavailable"));
+    const { result } = renderHook(
+      () => useResolveWorkspaceConnection(input),
+      { wrapper: wrapper(queryClient) },
+    );
+
+    await expect(result.current("cloud:cloud-1")).rejects.toThrow("connection unavailable");
+    expect(mocks.resolveWorkspaceConnection).not.toHaveBeenCalled();
+  });
+});

--- a/apps/packages/product-client/src/hooks/workspaces/cache/use-resolve-workspace-connection.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/cache/use-resolve-workspace-connection.ts
@@ -1,5 +1,5 @@
 import { anyHarnessCoworkStatusKey } from "@anyharness/sdk-react";
-import type { CoworkStatus, TerminalWebSocketAuthTransport } from "@anyharness/sdk";
+import type { CoworkStatus } from "@anyharness/sdk";
 import type { DesktopSshBridge } from "@proliferate/product-client/host/desktop-bridge";
 import type { ProliferateCloudClient } from "@proliferate/cloud-sdk";
 import type { QueryClient } from "@tanstack/react-query";
@@ -7,7 +7,10 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import type { CloudMobilityWorkspaceSummary } from "@proliferate/cloud-sdk/types";
 import { cloudWorkspaceConnectionQueryOptions } from "#product/hooks/access/cloud/use-cloud-workspace-connection";
-import { resolveWorkspaceConnection } from "#product/lib/access/anyharness/resolve-workspace-connection";
+import {
+  resolveWorkspaceConnection,
+  type ProductResolvedWorkspaceConnection,
+} from "#product/lib/access/anyharness/resolve-workspace-connection";
 import { buildLogicalWorkspaces } from "#product/lib/domain/workspaces/cloud/logical-workspaces";
 import { findLogicalWorkspace } from "#product/lib/domain/workspaces/cloud/logical-workspace-lookup";
 import {
@@ -47,7 +50,7 @@ async function resolveWorkspaceConnectionWithCache(
   workspaceId: string,
   ssh: DesktopSshBridge | null,
   cloudClient: ProliferateCloudClient | null,
-) {
+): Promise<ProductResolvedWorkspaceConnection> {
   const cloudWorkspaceId = parseCloudWorkspaceSyntheticId(workspaceId);
   if (!cloudWorkspaceId) {
     return resolveWorkspaceConnection(runtimeUrl, workspaceId, ssh, cloudClient);
@@ -57,14 +60,16 @@ async function resolveWorkspaceConnectionWithCache(
     cloudWorkspaceConnectionQueryOptions(cloudWorkspaceId, cloudClient),
   );
   const connection = await withFreshCloudSandboxGatewayAccessToken(cachedConnection);
-  const webSocketAuthTransport = (
-    connection as { webSocketAuthTransport?: TerminalWebSocketAuthTransport }
-  ).webSocketAuthTransport;
   return {
-    runtimeUrl: connection.runtimeUrl,
-    authToken: connection.accessToken ?? undefined,
-    anyharnessWorkspaceId: connection.anyharnessWorkspaceId ?? "",
-    webSocketAuthTransport,
+    connection: {
+      runtimeUrl: connection.runtimeUrl,
+      authToken: connection.accessToken ?? undefined,
+      anyharnessWorkspaceId: connection.anyharnessWorkspaceId ?? "",
+      runtimeGeneration: connection.runtimeGeneration ?? 0,
+      runtimeAccessKind: "proliferate-gateway",
+      webSocketAuthTransport: "protocol",
+    },
+    filesystemOrigin: "remote",
   };
 }
 
@@ -77,7 +82,7 @@ export function useResolveWorkspaceConnection({
   cacheScopeKey,
   selectedWorkspaceId,
 }: ResolveWorkspaceConnectionInput): (workspaceId: string) => Promise<
-  Awaited<ReturnType<typeof resolveWorkspaceConnectionWithCache>>
+  ProductResolvedWorkspaceConnection
 > {
   const queryClient = useQueryClient();
   return useCallback(

--- a/apps/packages/product-client/src/hooks/workspaces/ui/files/use-file-reference-native-context-menu.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/files/use-file-reference-native-context-menu.test.ts
@@ -2,40 +2,29 @@ import { describe, expect, it, vi } from "vitest";
 import type { OpenTarget } from "@proliferate/product-client/host/desktop-bridge";
 import { buildFileReferenceNativeContextMenuItems } from "#product/hooks/workspaces/ui/files/use-file-reference-native-context-menu";
 
-describe("buildFileReferenceNativeContextMenuItems", () => {
-  it("models the native file reference menu with app icons and an Open with submenu", () => {
-    const onOpenDefault = vi.fn();
-    const onOpenInSidebar = vi.fn();
-    const onOpenTarget = vi.fn();
-    const onCopyPath = vi.fn();
-    const onReveal = vi.fn();
-    const targets: OpenTarget[] = [
-      { id: "cursor", label: "Cursor", kind: "editor", iconId: "cursor" },
-      { id: "zed", label: "Zed", kind: "editor", iconId: "zed" },
-      { id: "terminal", label: "Terminal", kind: "terminal", iconId: "terminal" },
-      { id: "copy-path", label: "Copy path", kind: "copy" },
-    ];
+const targets: OpenTarget[] = [
+  { id: "cursor", label: "Cursor", kind: "editor", iconId: "cursor" },
+  { id: "terminal", label: "Terminal", kind: "terminal", iconId: "terminal" },
+  { id: "copy-path", label: "Copy path", kind: "copy" },
+];
 
+describe("buildFileReferenceNativeContextMenuItems", () => {
+  it("models only current eligible settled actions", () => {
+    const actions = callbacks();
     const items = buildFileReferenceNativeContextMenuItems({
+      ...actions,
+      accessState: { status: "settled" },
       openTargets: targets,
       defaultOpenTarget: targets[0],
       pathKind: "file",
       canOpenInSidebar: true,
       canOpenExternal: true,
       canReveal: true,
-      copyPath: onCopyPath,
-      openInSidebar: onOpenInSidebar,
-      openDefault: onOpenDefault,
-      openWithTarget: onOpenTarget,
-      reveal: onReveal,
+      copyPath: "/repo/src/App.tsx",
     });
 
     expect(items).toMatchObject([
-      {
-        id: "open-viewer",
-        label: "Open in viewer",
-        enabled: true,
-      },
+      { id: "open-viewer", label: "Open in viewer", enabled: true },
       {
         id: "open-default",
         label: "Open in Cursor",
@@ -46,81 +35,155 @@ describe("buildFileReferenceNativeContextMenuItems", () => {
         kind: "submenu",
         submenuId: "open-with",
         label: "Open with",
-        enabled: true,
         items: [
-          {
-            id: "open-with:cursor",
-            label: "Cursor",
-            icon: { kind: "resource", path: "app-icons/cursor.png" },
-          },
-          {
-            id: "open-with:zed",
-            label: "Zed",
-            icon: { kind: "resource", path: "app-icons/zed.png" },
-          },
-          {
-            id: "open-with:terminal",
-            label: "Terminal",
-            icon: { kind: "resource", path: "app-icons/terminal.png" },
-          },
+          { id: "open-with:cursor", label: "Cursor" },
+          { id: "open-with:terminal", label: "Terminal" },
         ],
       },
       { kind: "separator" },
-      {
-        id: "copy-path",
-        label: "Copy path",
-      },
-      {
-        id: "reveal-in-finder",
-        label: "Reveal in Finder",
-      },
+      { id: "copy-path", label: "Copy path", enabled: true },
+      { id: "reveal-in-finder", label: "Reveal in Finder", enabled: true },
     ]);
 
-    if ("id" in items[0]) items[0].onSelect?.();
-    if ("id" in items[1]) items[1].onSelect?.();
+    select(items[0]);
+    select(items[1]);
     const submenu = items[2];
     if ("kind" in submenu && submenu.kind === "submenu") {
-      const firstChild = submenu.items[0];
-      const thirdChild = submenu.items[2];
-      if ("id" in firstChild) firstChild.onSelect?.();
-      if ("id" in thirdChild) thirdChild.onSelect?.();
+      select(submenu.items[0]);
+      select(submenu.items[1]);
     }
-    if ("id" in items[4]) items[4].onSelect?.();
-    if ("id" in items[5]) items[5].onSelect?.();
-
-    expect(onOpenInSidebar).toHaveBeenCalledTimes(1);
-    expect(onOpenDefault).toHaveBeenCalledTimes(1);
-    expect(onOpenTarget).toHaveBeenNthCalledWith(1, "cursor");
-    expect(onOpenTarget).toHaveBeenNthCalledWith(2, "terminal");
-    expect(onCopyPath).toHaveBeenCalledTimes(1);
-    expect(onReveal).toHaveBeenCalledTimes(1);
+    select(items[4]);
+    select(items[5]);
+    expect(actions.openInSidebar).toHaveBeenCalledOnce();
+    expect(actions.openDefault).toHaveBeenCalledOnce();
+    expect(actions.openWithTarget).toHaveBeenNthCalledWith(1, "cursor");
+    expect(actions.openWithTarget).toHaveBeenNthCalledWith(2, "terminal");
+    expect(actions.copyCurrentPath).toHaveBeenCalledOnce();
+    expect(actions.reveal).toHaveBeenCalledOnce();
   });
 
-  it("omits the viewer action for folders and keeps Finder capability explicit", () => {
+  it("returns exactly Copy path for any non-settled nonempty reference", () => {
+    const actions = callbacks();
+    for (const status of ["pending", "exact-missing", "recovering", "unavailable"]) {
+      const items = buildFileReferenceNativeContextMenuItems({
+        ...actions,
+        accessState: { status },
+        openTargets: targets,
+        defaultOpenTarget: targets[0],
+        pathKind: null,
+        canOpenInSidebar: false,
+        canOpenExternal: false,
+        canReveal: false,
+        copyPath: "missing.ts",
+      });
+      expect(items).toMatchObject([
+        { id: "copy-path", label: "Copy path", enabled: true },
+      ]);
+      expect(items).toHaveLength(1);
+      select(items[0]);
+    }
+    expect(actions.copyCurrentPath).toHaveBeenCalledTimes(4);
+    expect(actions.openDefault).not.toHaveBeenCalled();
+    expect(actions.reveal).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty model when the current copy path is null", () => {
+    const actions = callbacks();
+    expect(buildFileReferenceNativeContextMenuItems({
+      ...actions,
+      accessState: { status: "unavailable" },
+      openTargets: targets,
+      defaultOpenTarget: targets[0],
+      pathKind: null,
+      canOpenInSidebar: false,
+      canOpenExternal: false,
+      canReveal: false,
+      copyPath: null,
+    })).toEqual([]);
+  });
+
+  it("renders a remote workspace file as viewer plus Copy path", () => {
+    const actions = callbacks();
     const items = buildFileReferenceNativeContextMenuItems({
+      ...actions,
+      accessState: { status: "settled" },
+      openTargets: [],
+      defaultOpenTarget: null,
+      pathKind: "file",
+      canOpenInSidebar: true,
+      canOpenExternal: false,
+      canReveal: false,
+      copyPath: "src/App.tsx",
+    });
+    expect(items).toMatchObject([
+      { id: "open-viewer", label: "Open in viewer", enabled: true },
+      { kind: "separator" },
+      { id: "copy-path", label: "Copy path", enabled: true },
+    ]);
+    expect(items).toHaveLength(3);
+    select(items[0]);
+    select(items[2]);
+    expect(actions.openInSidebar).toHaveBeenCalledOnce();
+    expect(actions.copyCurrentPath).toHaveBeenCalledOnce();
+    expect(actions.openDefault).not.toHaveBeenCalled();
+    expect(actions.reveal).not.toHaveBeenCalled();
+  });
+
+  it("renders a remote settled directory as exactly Copy path", () => {
+    const items = buildFileReferenceNativeContextMenuItems({
+      ...callbacks(),
+      accessState: { status: "settled" },
       openTargets: [],
       defaultOpenTarget: null,
       pathKind: "directory",
       canOpenInSidebar: false,
       canOpenExternal: false,
       canReveal: false,
-      copyPath: vi.fn(),
-      openInSidebar: vi.fn(),
-      openDefault: vi.fn(),
-      openWithTarget: vi.fn(),
-      reveal: vi.fn(),
+      copyPath: ".",
     });
-
     expect(items).toMatchObject([
-      { id: "open-default", label: "Open externally", enabled: false },
-      { kind: "separator" },
-      { id: "copy-path", label: "Copy path" },
-      {
-        id: "reveal-in-finder",
-        label: "Reveal folder in Finder",
-        enabled: false,
-      },
+      { id: "copy-path", label: "Copy path", enabled: true },
     ]);
-    expect(items).not.toContainEqual(expect.objectContaining({ id: "open-viewer" }));
+    expect(items).toHaveLength(1);
+  });
+
+  it("renders an ordinary local workspace directory as Copy path plus reveal", () => {
+    const actions = callbacks();
+    const items = buildFileReferenceNativeContextMenuItems({
+      ...actions,
+      accessState: { status: "settled" },
+      openTargets: [],
+      defaultOpenTarget: null,
+      pathKind: "directory",
+      canOpenInSidebar: false,
+      canOpenExternal: false,
+      canReveal: true,
+      copyPath: "/repo",
+    });
+    expect(items).toMatchObject([
+      { id: "copy-path", label: "Copy path", enabled: true },
+      { id: "reveal-in-finder", label: "Reveal folder in Finder", enabled: true },
+    ]);
+    expect(items).toHaveLength(2);
+    select(items[0]);
+    select(items[1]);
+    expect(actions.copyCurrentPath).toHaveBeenCalledOnce();
+    expect(actions.reveal).toHaveBeenCalledOnce();
+    expect(actions.openDefault).not.toHaveBeenCalled();
+    expect(actions.openWithTarget).not.toHaveBeenCalled();
   });
 });
+
+function callbacks() {
+  return {
+    copyCurrentPath: vi.fn(),
+    openInSidebar: vi.fn(),
+    openDefault: vi.fn(),
+    openWithTarget: vi.fn(),
+    reveal: vi.fn(),
+  };
+}
+
+function select(item: ReturnType<typeof buildFileReferenceNativeContextMenuItems>[number]) {
+  if ("id" in item) item.onSelect?.();
+}

--- a/apps/packages/product-client/src/hooks/workspaces/ui/files/use-file-reference-native-context-menu.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/files/use-file-reference-native-context-menu.ts
@@ -8,13 +8,15 @@ import type {
 import type { FileReferencePathKind } from "#product/lib/domain/files/path-references";
 
 interface FileReferenceNativeContextMenuActions {
+  accessState: { status: string };
   openTargets: OpenTarget[];
   defaultOpenTarget?: OpenTarget | null;
   pathKind: FileReferencePathKind | null;
   canOpenInSidebar: boolean;
   canOpenExternal: boolean;
   canReveal: boolean;
-  copyPath: () => void;
+  copyPath: string | null;
+  copyCurrentPath: () => void;
   openInSidebar: () => void;
   openDefault: () => void;
   openWithTarget: (targetId: string) => void;
@@ -30,6 +32,7 @@ export function useFileReferenceNativeContextMenu(
 }
 
 export function buildFileReferenceNativeContextMenuItems({
+  accessState,
   openTargets,
   defaultOpenTarget,
   pathKind,
@@ -37,62 +40,70 @@ export function buildFileReferenceNativeContextMenuItems({
   canOpenExternal,
   canReveal,
   copyPath,
+  copyCurrentPath,
   openInSidebar,
   openDefault,
   openWithTarget,
   reveal,
 }: FileReferenceNativeContextMenuActions): NativeMenuItem[] {
+  if (copyPath === null) return [];
+  const copyItem: NativeMenuItem = {
+    id: "copy-path",
+    label: "Copy path",
+    enabled: true,
+    onSelect: copyCurrentPath,
+  };
+  if (accessState.status !== "settled") return [copyItem];
+
   const targets = filterFileReferenceOpenTargets(openTargets);
   const items: NativeMenuItem[] = [];
 
-  if (pathKind !== "directory") {
+  if (pathKind !== "directory" && canOpenInSidebar) {
     items.push({
       id: "open-viewer",
       label: "Open in viewer",
-      enabled: canOpenInSidebar,
+      enabled: true,
       icon: { kind: "native", name: "document" },
       onSelect: openInSidebar,
     });
   }
 
-  items.push({
-    id: "open-default",
-    label: defaultOpenTarget ? `Open in ${defaultOpenTarget.label}` : "Open externally",
-    enabled: canOpenExternal,
-    icon: nativeMenuIconForOpenTarget(defaultOpenTarget) ?? { kind: "native", name: "open" },
-    onSelect: openDefault,
-  });
+  if (canOpenExternal) {
+    items.push({
+      id: "open-default",
+      label: defaultOpenTarget ? `Open in ${defaultOpenTarget.label}` : "Open externally",
+      enabled: true,
+      icon: nativeMenuIconForOpenTarget(defaultOpenTarget) ?? { kind: "native", name: "open" },
+      onSelect: openDefault,
+    });
+  }
 
-  if (targets.length > 0) {
+  if (canOpenExternal && targets.length > 0) {
     items.push({
       kind: "submenu",
       submenuId: "open-with",
       label: "Open with",
-      enabled: canOpenExternal,
+      enabled: true,
       items: targets.map((target): NativeMenuItem => ({
         id: `open-with:${target.id}`,
         label: target.label,
-        enabled: canOpenExternal,
+        enabled: true,
         icon: nativeMenuIconForOpenTarget(target),
         onSelect: () => openWithTarget(target.id),
       })),
     });
   }
 
-  items.push(
-    { kind: "separator" },
-    {
-      id: "copy-path",
-      label: "Copy path",
-      onSelect: copyPath,
-    },
-    {
+  if (items.length > 0) items.push({ kind: "separator" });
+  items.push(copyItem);
+  if (canReveal) {
+    items.push({
       id: "reveal-in-finder",
       label: pathKind === "directory" ? "Reveal folder in Finder" : "Reveal in Finder",
-      enabled: canReveal,
+      enabled: true,
       onSelect: reveal,
-    },
-  );
+    });
+  }
 
   return items;
 }

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/file-reference-access-state.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/file-reference-access-state.ts
@@ -1,0 +1,180 @@
+import { AnyHarnessError } from "@anyharness/sdk";
+import type { NativeFileReferenceCapability } from "#product/hooks/workspaces/workflows/files/use-desktop-file-reference-actions";
+import {
+  resolveInspectionPathKind,
+  type DesktopPathInspectionState,
+} from "#product/hooks/workspaces/workflows/files/use-desktop-path-inspection";
+import {
+  resolveWorkspaceStatPathKind,
+  type FileReferencePathKind,
+  type FileReferenceUnavailableLocatorReason,
+  type ResolvedFileLocator,
+} from "#product/lib/domain/files/path-references";
+
+export type FileReferenceUnavailableReason =
+  | FileReferenceUnavailableLocatorReason
+  | "not_found"
+  | "permission_denied"
+  | "outside_workspace"
+  | "unsupported_type"
+  | "unexpected_kind"
+  | "ambiguous_match"
+  | "runtime_unavailable"
+  | "io_error";
+
+export type AccessibleFileLocator = Exclude<
+  ResolvedFileLocator,
+  { authority: "unavailable" }
+>;
+
+export type FileReferenceAccessState =
+  | { status: "pending"; locator: AccessibleFileLocator }
+  | { status: "settled"; locator: AccessibleFileLocator; kind: FileReferencePathKind }
+  | {
+      status: "exact-missing";
+      locator: Extract<AccessibleFileLocator, { authority: "workspace" }>;
+      fuzzyAttempted: false;
+    }
+  | {
+      status: "recovering";
+      locator: Extract<AccessibleFileLocator, { authority: "workspace" }>;
+    }
+  | { status: "unavailable"; reason: FileReferenceUnavailableReason };
+
+export type FileReferenceRecoveryState =
+  | { recoveryRevision: object; status: "recovering" }
+  | {
+      recoveryRevision: object;
+      status: "settled";
+      locator: Extract<AccessibleFileLocator, { authority: "workspace" }>;
+    }
+  | {
+      recoveryRevision: object;
+      status: "terminal";
+      reason: FileReferenceUnavailableReason;
+    }
+  | null;
+
+export function resolveFileReferenceAccessState(args: {
+  locator: ResolvedFileLocator;
+  materializedWorkspaceId: string | null;
+  statData: { kind: "file" | "directory" | "symlink" } | undefined;
+  statError: unknown;
+  statPending: boolean;
+  desktopInspectionState: DesktopPathInspectionState;
+  recovery: FileReferenceRecoveryState;
+}): FileReferenceAccessState {
+  if (args.locator.authority === "unavailable") {
+    return { status: "unavailable", reason: args.locator.reason };
+  }
+  if (args.locator.authority === "desktop") {
+    const kind = resolveInspectionPathKind(args.desktopInspectionState);
+    if (kind) return { status: "settled", locator: args.locator, kind };
+    if (args.desktopInspectionState.status === "settled") {
+      const inspection = args.desktopInspectionState.inspection;
+      if (inspection.kind === "missing") {
+        return { status: "unavailable", reason: "not_found" };
+      }
+      if (inspection.kind === "unavailable") {
+        return { status: "unavailable", reason: inspectionReason(inspection.reason) };
+      }
+    }
+    return args.desktopInspectionState.status === "rejected"
+      ? { status: "unavailable", reason: "io_error" }
+      : { status: "pending", locator: args.locator };
+  }
+  if (!args.materializedWorkspaceId) {
+    return { status: "unavailable", reason: "runtime_unavailable" };
+  }
+  if (args.recovery?.status === "recovering") {
+    return { status: "recovering", locator: args.locator };
+  }
+  if (args.recovery?.status === "terminal") {
+    return { status: "unavailable", reason: args.recovery.reason };
+  }
+  if (args.recovery?.status === "settled") {
+    return { status: "settled", locator: args.recovery.locator, kind: "file" };
+  }
+  const kind = resolveWorkspaceStatPathKind(args.statData);
+  if (kind) return { status: "settled", locator: args.locator, kind };
+  if (args.statData?.kind === "symlink") {
+    return { status: "unavailable", reason: "unexpected_kind" };
+  }
+  if (args.statError) {
+    if (isExactFileMissing(args.statError) && args.locator.workspacePath !== "") {
+      return { status: "exact-missing", locator: args.locator, fuzzyAttempted: false };
+    }
+    return { status: "unavailable", reason: fileReferenceAccessReason(args.statError) };
+  }
+  return args.statPending
+    ? { status: "pending", locator: args.locator }
+    : { status: "unavailable", reason: "runtime_unavailable" };
+}
+
+export function resolveNativeFileReferenceCapability(
+  state: FileReferenceAccessState,
+  routeRevision: object,
+): NativeFileReferenceCapability | null {
+  if (state.status !== "settled") return null;
+  if (state.locator.authority === "desktop") {
+    return {
+      source: "desktop",
+      absolutePath: state.locator.absolutePath,
+      kind: state.kind,
+      routeRevision,
+    };
+  }
+  if (!state.locator.localCompanionPath) return null;
+  return {
+    source: "workspace-companion",
+    absolutePath: state.locator.localCompanionPath,
+    kind: state.kind,
+    routeRevision,
+  };
+}
+
+export function isExactFileMissing(error: unknown): boolean {
+  return error instanceof AnyHarnessError && error.problem.code === "FILE_NOT_FOUND";
+}
+
+export function fileReferenceAccessReason(error: unknown): FileReferenceUnavailableReason {
+  if (!(error instanceof AnyHarnessError)) return "runtime_unavailable";
+  switch (error.problem.code) {
+    case "FILE_NOT_FOUND": return "not_found";
+    case "FILE_PERMISSION_DENIED": return "permission_denied";
+    case "PATH_OUTSIDE_WORKSPACE": return "outside_workspace";
+    case "INVALID_FILE_PATH": return "invalid";
+    case "NOT_A_DIRECTORY": return "unexpected_kind";
+    default: return error.problem.status >= 500 ? "io_error" : "runtime_unavailable";
+  }
+}
+
+export function fileReferenceUnavailableCopy(
+  state: FileReferenceAccessState,
+): string | null {
+  if (state.status === "pending" || state.status === "recovering") {
+    return "Checking whether this path is a file or folder…";
+  }
+  if (state.status === "exact-missing") {
+    return "This path was not found. Search for a match.";
+  }
+  if (state.status !== "unavailable") return null;
+  if (state.reason === "not_found") return "This path was not found.";
+  if (state.reason === "permission_denied") return "Permission denied for this path.";
+  if (state.reason === "invalid") return "This path is invalid.";
+  if (state.reason === "unsupported_type" || state.reason === "unexpected_kind") {
+    return "This path type is not supported.";
+  }
+  return "This path is unavailable.";
+}
+
+function inspectionReason(
+  reason: "invalid_path" | "permission_denied" | "unsupported_type" | "io_error",
+): FileReferenceUnavailableReason {
+  switch (reason) {
+    case "invalid_path": return "invalid";
+    case "permission_denied": return "permission_denied";
+    case "unsupported_type": return "unsupported_type";
+    case "io_error": return "io_error";
+  }
+}

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-desktop-file-reference-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-desktop-file-reference-actions.ts
@@ -3,17 +3,19 @@ import type {
   DesktopFilesBridge,
   OpenTarget,
 } from "@proliferate/product-client/host/desktop-bridge";
-import type {
-  FileReferencePathKind,
-  ResolvedFileReference,
-} from "#product/lib/domain/files/path-references";
-import type { DesktopPathInspectionState } from "#product/hooks/workspaces/workflows/files/use-desktop-path-inspection";
+import type { FileReferencePathKind } from "#product/lib/domain/files/path-references";
+
+export interface NativeFileReferenceCapability {
+  source: "desktop" | "workspace-companion";
+  absolutePath: string;
+  kind: FileReferencePathKind;
+  routeRevision: object;
+}
 
 interface UseDesktopFileReferenceActionsInput {
   files: DesktopFilesBridge | null;
-  reference: Pick<ResolvedFileReference, "absolutePath" | "workspacePath">;
-  pathKind: FileReferencePathKind | null;
-  desktopInspectionState: DesktopPathInspectionState;
+  capability: NativeFileReferenceCapability | null;
+  externalOpenCapability: NativeFileReferenceCapability | null;
   routeRevision: object;
   targets: readonly OpenTarget[];
   openInDefaultEditor: (
@@ -22,81 +24,74 @@ interface UseDesktopFileReferenceActionsInput {
   ) => Promise<boolean>;
 }
 
+/** Invocation-time native capability checks shared by DOM and native menus. */
 export function useDesktopFileReferenceActions({
   files,
-  reference,
-  pathKind,
-  desktopInspectionState,
+  capability,
+  externalOpenCapability,
   routeRevision,
   targets,
   openInDefaultEditor,
 }: UseDesktopFileReferenceActionsInput) {
-  const currentRouteRevisionRef = useRef(routeRevision);
-  currentRouteRevisionRef.current = routeRevision;
+  const currentRef = useRef({ files, capability, externalOpenCapability, targets });
+  currentRef.current = { files, capability, externalOpenCapability, targets };
   const openTargets = useMemo(
-    () => targets.filter((target) => target.kind !== "copy"),
-    [targets],
+    () => externalOpenCapability
+      ? targets.filter((target) => target.kind !== "copy")
+      : [],
+    [externalOpenCapability, targets],
   );
 
-  const currentNativePathKind = useCallback((
-    absolutePath: string,
-  ): FileReferencePathKind | null => {
+  const currentNativePathKind = useCallback((): FileReferencePathKind | null => {
+    const current = currentRef.current;
     if (
-      currentRouteRevisionRef.current !== routeRevision
-      || absolutePath !== reference.absolutePath
-      || !files
-      || pathKind === null
+      !current.files
+      || !current.capability
+      || current.capability.routeRevision !== routeRevision
+      || current.capability.routeRevision !== capability?.routeRevision
     ) {
       return null;
     }
-    if (reference.workspacePath) {
-      return pathKind;
-    }
-    return desktopInspectionState.status === "settled"
-      && desktopInspectionState.inspection.kind === pathKind
-      ? pathKind
-      : null;
-  }, [
-    desktopInspectionState,
-    files,
-    pathKind,
-    reference.absolutePath,
-    reference.workspacePath,
-    routeRevision,
-  ]);
+    return current.capability.kind;
+  }, [capability?.routeRevision, routeRevision]);
 
-  const openDefault = useCallback(async (
-    absolutePath: string | null = reference.absolutePath,
-  ) => {
-    if (!absolutePath) {
-      return false;
+  const currentExternalOpenCapability = useCallback(() => {
+    const current = currentRef.current;
+    if (
+      !current.files
+      || !current.externalOpenCapability
+      || current.externalOpenCapability.routeRevision !== routeRevision
+      || current.externalOpenCapability.routeRevision !== externalOpenCapability?.routeRevision
+    ) {
+      return null;
     }
-    const imperativePathKind = currentNativePathKind(absolutePath);
-    if (!imperativePathKind) {
-      return false;
-    }
-    return openInDefaultEditor(absolutePath, imperativePathKind);
-  }, [currentNativePathKind, openInDefaultEditor, reference.absolutePath]);
+    return current.externalOpenCapability;
+  }, [externalOpenCapability?.routeRevision, routeRevision]);
 
-  const reveal = useCallback(async (
-    absolutePath: string | null = reference.absolutePath,
-  ) => {
-    if (!absolutePath || currentNativePathKind(absolutePath) !== "directory" || !files) {
-      return;
-    }
-    await files.reveal(absolutePath);
-  }, [currentNativePathKind, files, reference.absolutePath]);
+  const openDefault = useCallback(async () => {
+    const current = currentExternalOpenCapability();
+    if (!current) return false;
+    return openInDefaultEditor(current.absolutePath, current.kind);
+  }, [currentExternalOpenCapability, openInDefaultEditor]);
+
+  const reveal = useCallback(async () => {
+    const current = currentRef.current;
+    if (!current.files || !current.capability || !currentNativePathKind()) return;
+    await current.files.reveal(current.capability.absolutePath);
+  }, [currentNativePathKind]);
 
   const openWithTarget = useCallback(async (targetId: string) => {
+    const current = currentRef.current;
+    const openCapability = currentExternalOpenCapability();
     if (
-      !reference.absolutePath
-      || currentNativePathKind(reference.absolutePath) === null
-      || !files
+      !current.files
+      || !openCapability
+      || !current.targets.some((target) => target.kind !== "copy" && target.id === targetId)
     ) {
       return;
     }
-    await files.openTarget(targetId, reference.absolutePath);
-  }, [currentNativePathKind, files, reference.absolutePath]);
+    await current.files.openTarget(targetId, openCapability.absolutePath);
+  }, [currentExternalOpenCapability]);
 
-  return { openDefault, openTargets, openWithTarget, reveal };
+  return { currentNativePathKind, openDefault, openTargets, openWithTarget, reveal };
 }

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.test.tsx
@@ -1,39 +1,43 @@
 // @vitest-environment jsdom
 
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { AnyHarnessError } from "@anyharness/sdk";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ReactNode } from "react";
-import { WorkspacePathProvider } from "#product/providers/WorkspacePathProvider";
 import { useFileReferenceActions } from "#product/hooks/workspaces/workflows/files/use-file-reference-actions";
 
-const editorMocks = vi.hoisted(() => ({
-  openInDefaultEditor: vi.fn(async () => true),
+const pathMocks = vi.hoisted(() => ({
+  value: {
+    materializedWorkspaceId: "workspace-1" as string | null,
+    filesystemOrigin: { status: "settled" as const, origin: "desktop-local" as const },
+    workspaceRoot: { status: "settled" as const, path: "/repo" as string | null },
+  },
+}));
+
+const selectionMocks = vi.hoisted(() => ({
+  selectedWorkspaceId: "workspace-1",
+  selectedLogicalWorkspaceId: "workspace-1",
 }));
 
 const statMocks = vi.hoisted(() => ({
-  kind: "file" as "file" | "directory" | "symlink" | null,
-  sizeBytes: undefined as number | undefined,
+  calls: vi.fn(),
+  data: { kind: "file" as "file" | "directory" | "symlink" },
+  error: null as unknown,
+  isPending: false,
   isFetching: false,
-  error: null as Error | null,
-  refetch: vi.fn(async (): Promise<{
-    data?: { kind: "file" | "directory" | "symlink"; sizeBytes?: number };
-  }> => ({ data: { kind: "file" } })),
 }));
 
 const fuzzyMocks = vi.hoisted(() => ({
-  resolve: vi.fn(async (): Promise<string | null> => null),
+  resolve: vi.fn(async () => ({ status: "no-match" as const })),
 }));
 
-const anyHarnessMocks = vi.hoisted(() => ({
-  stat: vi.fn(async (_workspaceId: string, path: string) => ({
-    path,
-    kind: "file" as const,
-    sizeBytes: 1,
-  })),
-  resolveWorkspaceConnection: vi.fn(async () => ({
-    runtimeUrl: "http://runtime.test",
-    anyharnessWorkspaceId: "runtime-workspace-1",
-  })),
+const lookupMocks = vi.hoisted(() => ({
+  statFile: vi.fn(async ({ path }: { path: string }) => ({ path, kind: "file" as const })),
+}));
+
+const editorMocks = vi.hoisted(() => ({
+  kinds: vi.fn(),
+  openInDefaultEditor: vi.fn(async () => true),
+  targets: [{ id: "cursor", label: "Cursor", kind: "editor" as const }],
 }));
 
 const viewerMocks = vi.hoisted(() => ({
@@ -41,55 +45,49 @@ const viewerMocks = vi.hoisted(() => ({
   activateViewerTarget: vi.fn(),
 }));
 
-const hostMocks = vi.hoisted(() => ({
+const bridgeMocks = vi.hoisted(() => ({
   desktopAvailable: true,
   writeText: vi.fn(async () => undefined),
   getHomeDirectory: vi.fn(async () => "/Users/pablo"),
-  openTarget: vi.fn(async () => undefined),
   inspectPath: vi.fn(async () => ({ kind: "file" as const })),
+  openTarget: vi.fn(async () => undefined),
   reveal: vi.fn(async () => undefined),
-  files: null as unknown as {
-    getHomeDirectory: ReturnType<typeof vi.fn>;
-    inspectPath: ReturnType<typeof vi.fn>;
-    openTarget: ReturnType<typeof vi.fn>;
-    reveal: ReturnType<typeof vi.fn>;
-  },
+  files: null as unknown as Record<string, unknown>,
 }));
 
-hostMocks.files = {
-  getHomeDirectory: hostMocks.getHomeDirectory,
-  inspectPath: hostMocks.inspectPath,
-  openTarget: hostMocks.openTarget,
-  reveal: hostMocks.reveal,
-};
-
-vi.mock("#product/hooks/editor/workflows/use-open-in-default-editor", () => ({
-  useOpenInDefaultEditor: () => ({
-    defaultTarget: null,
-    openInDefaultEditor: editorMocks.openInDefaultEditor,
-    targets: [],
-  }),
+vi.mock("#product/providers/WorkspacePathProvider", () => ({
+  useWorkspacePath: () => pathMocks.value,
 }));
 
 vi.mock("@anyharness/sdk-react", () => ({
-  getAnyHarnessClient: () => ({ files: { stat: anyHarnessMocks.stat } }),
-  resolveWorkspaceConnectionFromContext: async () => ({
-    workspaceId: "workspace-1",
-    connection: {
-      runtimeUrl: "http://runtime.test",
-      anyharnessWorkspaceId: "runtime-workspace-1",
-    },
-  }),
-  useAnyHarnessWorkspaceContext: () => ({
-    workspaceId: "workspace-1",
-    resolveConnection: anyHarnessMocks.resolveWorkspaceConnection,
-  }),
-  useStatWorkspaceFileQuery: () => ({
-    data: statMocks.kind ? { kind: statMocks.kind, sizeBytes: statMocks.sizeBytes } : undefined,
-    isFetching: statMocks.isFetching,
-    error: statMocks.error,
-    refetch: statMocks.refetch,
-  }),
+  useStatWorkspaceFileQuery: (input: unknown) => {
+    statMocks.calls(input);
+    return {
+      data: statMocks.data,
+      error: statMocks.error,
+      isPending: statMocks.isPending,
+      isFetching: statMocks.isFetching,
+    };
+  },
+}));
+
+vi.mock("#product/hooks/access/anyharness/files/use-workspace-file-lookup", () => ({
+  useWorkspaceFileLookup: () => ({ statFile: lookupMocks.statFile }),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/files/use-fuzzy-file-resolver", () => ({
+  useFuzzyFileResolver: () => fuzzyMocks.resolve,
+}));
+
+vi.mock("#product/hooks/editor/workflows/use-open-in-default-editor", () => ({
+  useOpenInDefaultEditor: (kind: "file" | "directory" | null) => {
+    editorMocks.kinds(kind);
+    return {
+      defaultTarget: kind ? editorMocks.targets[0] : null,
+      openInDefaultEditor: editorMocks.openInDefaultEditor,
+      targets: kind ? editorMocks.targets : [],
+    };
+  },
 }));
 
 vi.mock("#product/hooks/workspaces/workflows/tabs/use-workspace-shell-activation", () => ({
@@ -99,476 +97,504 @@ vi.mock("#product/hooks/workspaces/workflows/tabs/use-workspace-shell-activation
 }));
 
 vi.mock("#product/stores/editor/workspace-viewer-tabs-store", () => ({
-  useWorkspaceViewerTabsStore: (selector: (state: { openTarget: typeof viewerMocks.openTarget }) => unknown) =>
-    selector({ openTarget: viewerMocks.openTarget }),
+  useWorkspaceViewerTabsStore: (
+    selector: (state: { openTarget: typeof viewerMocks.openTarget }) => unknown,
+  ) => selector({ openTarget: viewerMocks.openTarget }),
 }));
 
 vi.mock("#product/stores/sessions/session-selection-store", () => ({
-  useSessionSelectionStore: (selector: (state: {
-    selectedWorkspaceId: string;
-    selectedLogicalWorkspaceId: string;
-  }) => unknown) => selector({
-    selectedWorkspaceId: "workspace-1",
-    selectedLogicalWorkspaceId: "workspace-1",
-  }),
+  useSessionSelectionStore: (
+    selector: (state: {
+      selectedWorkspaceId: string;
+      selectedLogicalWorkspaceId: string;
+    }) => unknown,
+  ) => selector(selectionMocks),
 }));
 
 vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
   useProductHost: () => ({
-    clipboard: { writeText: hostMocks.writeText },
-    desktop: hostMocks.desktopAvailable ? {
-      files: hostMocks.files,
-    } : null,
+    clipboard: { writeText: bridgeMocks.writeText },
+    desktop: bridgeMocks.desktopAvailable ? { files: bridgeMocks.files } : null,
   }),
 }));
 
-vi.mock("#product/hooks/workspaces/workflows/files/use-fuzzy-file-resolver", () => ({
-  useFuzzyFileResolver: () => fuzzyMocks.resolve,
-}));
-
 afterEach(() => {
-  hostMocks.desktopAvailable = true;
-  hostMocks.getHomeDirectory.mockResolvedValue("/Users/pablo");
-  hostMocks.inspectPath.mockResolvedValue({ kind: "file" });
-  editorMocks.openInDefaultEditor.mockResolvedValue(true);
-  statMocks.kind = "file";
-  statMocks.sizeBytes = undefined;
-  statMocks.isFetching = false;
-  statMocks.error = null;
-  statMocks.refetch.mockResolvedValue({ data: { kind: "file" } });
-  fuzzyMocks.resolve.mockResolvedValue(null);
-  anyHarnessMocks.stat.mockImplementation(async (_workspaceId, path) => ({
-    path,
-    kind: "file",
-    sizeBytes: 1,
-  }));
+  cleanup();
   vi.clearAllMocks();
-  hostMocks.files = {
-    getHomeDirectory: hostMocks.getHomeDirectory,
-    inspectPath: hostMocks.inspectPath,
-    openTarget: hostMocks.openTarget,
-    reveal: hostMocks.reveal,
+  pathMocks.value = {
+    materializedWorkspaceId: "workspace-1",
+    filesystemOrigin: { status: "settled", origin: "desktop-local" },
+    workspaceRoot: { status: "settled", path: "/repo" },
+  };
+  selectionMocks.selectedWorkspaceId = "workspace-1";
+  selectionMocks.selectedLogicalWorkspaceId = "workspace-1";
+  statMocks.data = { kind: "file" };
+  statMocks.error = null;
+  statMocks.isPending = false;
+  statMocks.isFetching = false;
+  fuzzyMocks.resolve.mockResolvedValue({ status: "no-match" });
+  lookupMocks.statFile.mockImplementation(async ({ path }) => ({ path, kind: "file" }));
+  editorMocks.openInDefaultEditor.mockResolvedValue(true);
+  bridgeMocks.desktopAvailable = true;
+  bridgeMocks.getHomeDirectory.mockResolvedValue("/Users/pablo");
+  bridgeMocks.inspectPath.mockResolvedValue({ kind: "file" });
+  bridgeMocks.files = {
+    getHomeDirectory: bridgeMocks.getHomeDirectory,
+    inspectPath: bridgeMocks.inspectPath,
+    openTarget: bridgeMocks.openTarget,
+    reveal: bridgeMocks.reveal,
   };
 });
 
 describe("useFileReferenceActions", () => {
   it.each([
-    ["relative", "src/App.tsx", "src/App.tsx"],
-    ["absolute", "/repo/src/App.tsx", "src/App.tsx"],
-  ])("opens a resolved %s file in the workspace viewer", async (_label, rawPath, expectedPath) => {
-    const { result } = renderHook(
-      () => useFileReferenceActions({ rawPath }),
-      { wrapper: workspaceWrapper("/repo") },
-    );
+    ["src/App.tsx", "src/App.tsx"],
+    ["/repo/src/App.tsx", "src/App.tsx"],
+  ])("stats and opens workspace file %s only in the viewer", async (rawPath, expectedPath) => {
+    const { result } = renderHook(() => useFileReferenceActions({ rawPath }));
 
-    await act(async () => {
-      await result.current.openPrimary();
-    });
-
-    expect(viewerMocks.openTarget).toHaveBeenCalledWith({ kind: "file", path: expectedPath });
-    expect(hostMocks.reveal).not.toHaveBeenCalled();
-    expect(hostMocks.inspectPath).not.toHaveBeenCalled();
-    expect(editorMocks.openInDefaultEditor).not.toHaveBeenCalled();
-  });
-
-  it("infers a workspace file when nullable path metadata is missing", async () => {
-    const { result } = renderHook(
-      () => useFileReferenceActions({
-        rawPath: "src/App.tsx",
-        workspacePath: null,
-      }),
-      { wrapper: workspaceWrapper("/repo") },
-    );
-
-    expect(result.current.reference.workspacePath).toBe("src/App.tsx");
     await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
-    expect(viewerMocks.openTarget).toHaveBeenCalledWith({
-      kind: "file",
-      path: "src/App.tsx",
-    });
-  });
 
-  it("reveals a workspace directory in Finder instead of opening it as a file", async () => {
-    statMocks.kind = "directory";
-    const { result } = renderHook(
-      () => useFileReferenceActions({ rawPath: "apps/packages" }),
-      { wrapper: workspaceWrapper("/repo") },
-    );
-
-    await act(async () => {
-      await result.current.openPrimary();
-    });
-
-    expect(hostMocks.reveal).toHaveBeenCalledWith("/repo/apps/packages");
-    expect(viewerMocks.openTarget).not.toHaveBeenCalled();
-  });
-
-  it("resolves and reveals an external directory on Desktop", async () => {
-    statMocks.kind = null;
-    hostMocks.inspectPath.mockResolvedValue({ kind: "directory" });
-    const { result } = renderHook(
-      () => useFileReferenceActions({ rawPath: "/Users/pablo/landing" }),
-      { wrapper: workspaceWrapper("/repo") },
-    );
-
-    await act(async () => {
-      await result.current.openPrimary();
-    });
-
-    expect(hostMocks.reveal).toHaveBeenCalledWith("/Users/pablo/landing");
-    expect(viewerMocks.openTarget).not.toHaveBeenCalled();
-  });
-
-  it("keeps pending actions inert while the imperative primary shares the inspection", async () => {
-    statMocks.kind = null;
-    let resolveInspection!: (inspection: { kind: "file" }) => void;
-    hostMocks.inspectPath.mockImplementationOnce(() => new Promise((resolve) => {
-      resolveInspection = resolve;
+    expect(statMocks.calls).toHaveBeenLastCalledWith(expect.objectContaining({
+      workspaceId: "workspace-1",
+      path: expectedPath,
+      enabled: true,
     }));
-    const { result } = renderHook(
-      () => useFileReferenceActions({ rawPath: "/tmp/pending.txt" }),
-      { wrapper: workspaceWrapper("/repo") },
-    );
+    expect(viewerMocks.openTarget).toHaveBeenCalledWith({ kind: "file", path: expectedPath });
+    expect(bridgeMocks.inspectPath).not.toHaveBeenCalled();
+    expect(bridgeMocks.openTarget).not.toHaveBeenCalled();
+    expect(bridgeMocks.reveal).not.toHaveBeenCalled();
+  });
 
-    await waitFor(() => expect(hostMocks.inspectPath).toHaveBeenCalledTimes(1));
-    expect(result.current.pathKindPending).toBe(true);
+  it("stats root as an empty workspace path and exposes reveal only as a secondary action", async () => {
+    statMocks.data = { kind: "directory" };
+    const { result } = renderHook(() => useFileReferenceActions({
+      rawPath: ".",
+      workspacePath: ".",
+    }));
+
+    expect(statMocks.calls).toHaveBeenLastCalledWith(expect.objectContaining({ path: "" }));
+    expect(result.current.reference.locator).toEqual({
+      authority: "workspace",
+      workspacePath: "",
+      localCompanionPath: "/repo",
+    });
     expect(result.current.canOpenPrimary).toBe(false);
+    expect(result.current.canOpenExternal).toBe(false);
+    expect(result.current.canReveal).toBe(true);
     expect(result.current.openTargets).toEqual([]);
-    expect(result.current.defaultOpenTarget).toBeNull();
+    expect(editorMocks.kinds).toHaveBeenLastCalledWith(null);
+    await expect(result.current.openPrimary()).resolves.toBe("unavailable");
     await expect(result.current.openDefault()).resolves.toBe(false);
     await result.current.openWithTarget("cursor");
     await result.current.reveal();
-    expect(hostMocks.openTarget).not.toHaveBeenCalled();
-    expect(hostMocks.reveal).not.toHaveBeenCalled();
+    expect(bridgeMocks.reveal).toHaveBeenCalledWith("/repo");
+    expect(editorMocks.openInDefaultEditor).not.toHaveBeenCalled();
+    expect(bridgeMocks.openTarget).not.toHaveBeenCalled();
+    expect(viewerMocks.openTarget).not.toHaveBeenCalled();
+  });
 
-    const primary = result.current.openPrimary();
-    expect(hostMocks.inspectPath).toHaveBeenCalledTimes(1);
-    await act(async () => {
-      resolveInspection({ kind: "file" });
-      await expect(primary).resolves.toBe("open-external");
-    });
-    expect(hostMocks.inspectPath).toHaveBeenCalledTimes(1);
-    expect(editorMocks.openInDefaultEditor)
-      .toHaveBeenCalledWith("/tmp/pending.txt", "file");
+  it("allows explicit header-owned workspace root target discovery", () => {
+    statMocks.data = { kind: "directory" };
+    const { result } = renderHook(() => useFileReferenceActions({
+      rawPath: ".",
+      workspacePath: ".",
+      nativeCapabilityKind: "directory",
+    }));
+
+    expect(result.current.canOpenExternal).toBe(true);
+    expect(result.current.canReveal).toBe(true);
+    expect(result.current.openTargets).toEqual(editorMocks.targets);
+    expect(editorMocks.kinds).toHaveBeenLastCalledWith("directory");
+  });
+
+  it("opens a remote workspace file while forbidding every native operation", async () => {
+    pathMocks.value = {
+      ...pathMocks.value,
+      filesystemOrigin: { status: "settled", origin: "remote" },
+    };
+    const { result } = renderHook(() => useFileReferenceActions({ rawPath: "README.md" }));
+
+    expect(result.current.nativePathKind).toBeNull();
+    await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
+    await result.current.openDefault();
+    await result.current.openWithTarget("cursor");
+    await result.current.reveal();
+    expect(viewerMocks.openTarget).toHaveBeenCalledOnce();
+    expect(bridgeMocks.getHomeDirectory).not.toHaveBeenCalled();
+    expect(bridgeMocks.inspectPath).not.toHaveBeenCalled();
+    expect(bridgeMocks.openTarget).not.toHaveBeenCalled();
+    expect(bridgeMocks.reveal).not.toHaveBeenCalled();
   });
 
   it.each([
-    [{ kind: "missing" }, "This path was not found."],
-    [{ kind: "unavailable", reason: "invalid_path" }, "This path is invalid."],
-    [
-      { kind: "unavailable", reason: "permission_denied" },
-      "Permission denied for this path.",
-    ],
-    [
-      { kind: "unavailable", reason: "unsupported_type" },
-      "This path type is not supported.",
-    ],
-    [{ kind: "unavailable", reason: "io_error" }, "This path is unavailable."],
-  ] as const)(
-    "keeps a settled refusal inert: %#",
-    async (inspection, expectedCopy) => {
-      statMocks.kind = null;
-      hostMocks.inspectPath.mockResolvedValue(inspection);
-      const rawPath = "/tmp/refused.txt";
-      const { result } = renderHook(
-        () => useFileReferenceActions({ rawPath }),
-        { wrapper: workspaceWrapper("/repo") },
-      );
+    ["remote", { status: "settled", origin: "remote" }],
+    ["pending", { status: "pending", origin: null }],
+    ["rejected", { status: "rejected", origin: null }],
+  ] as const)("rejects an outside absolute path with %s origin before native access", async (_label, origin) => {
+    pathMocks.value = { ...pathMocks.value, filesystemOrigin: origin };
+    const { result } = renderHook(() => useFileReferenceActions({ rawPath: "/tmp/outside" }));
 
-      await waitFor(() => expect(result.current.pathKindPending).toBe(false));
-      expect(result.current.pathKind).toBeNull();
-      expect(result.current.canOpenExternal).toBe(false);
-      expect(result.current.canReveal).toBe(false);
+    expect(result.current.accessState.status).toBe("unavailable");
+    expect(statMocks.calls).toHaveBeenLastCalledWith(expect.objectContaining({ enabled: false }));
+    expect(bridgeMocks.inspectPath).not.toHaveBeenCalled();
+    expect(editorMocks.kinds).toHaveBeenLastCalledWith(null);
+  });
+
+  it.each(["file:///tmp/a", "//server/a", "\\\\server\\a", "#fragment", "C:/a", "~user/a", "a/../b"])(
+    "keeps rejected syntax %s inert",
+    async (rawPath) => {
+      const { result } = renderHook(() => useFileReferenceActions({ rawPath }));
       expect(result.current.canOpenPrimary).toBe(false);
-      expect(result.current.openTargets).toEqual([]);
-      expect(result.current.defaultOpenTarget).toBeNull();
-      expect(result.current.primaryUnavailableReason).toBe(expectedCopy);
-
-      await expect(result.current.openDefault()).resolves.toBe(false);
-      await result.current.openWithTarget("cursor");
-      await result.current.reveal();
-      await expect(result.current.openPrimary()).resolves.toBe("unavailable");
-      await result.current.copyPath();
-
-      expect(hostMocks.inspectPath).toHaveBeenCalledTimes(1);
-      expect(hostMocks.openTarget).not.toHaveBeenCalled();
-      expect(hostMocks.reveal).not.toHaveBeenCalled();
-      expect(editorMocks.openInDefaultEditor).not.toHaveBeenCalled();
-      expect(hostMocks.writeText).toHaveBeenCalledWith(rawPath);
+      await result.current.openPrimary();
+      expect(statMocks.calls).toHaveBeenLastCalledWith(expect.objectContaining({ enabled: false }));
+      expect(fuzzyMocks.resolve).not.toHaveBeenCalled();
+      expect(bridgeMocks.getHomeDirectory).not.toHaveBeenCalled();
+      expect(bridgeMocks.inspectPath).not.toHaveBeenCalled();
+      expect(bridgeMocks.openTarget).not.toHaveBeenCalled();
+      expect(bridgeMocks.reveal).not.toHaveBeenCalled();
     },
   );
 
-  it("keeps a Web directory unavailable without invoking a native action", async () => {
-    hostMocks.desktopAvailable = false;
-    statMocks.kind = "directory";
-    const { result } = renderHook(
-      () => useFileReferenceActions({ rawPath: "apps/packages" }),
-      { wrapper: workspaceWrapper("/repo") },
-    );
-
-    expect(result.current.canOpenPrimary).toBe(false);
-    expect(result.current.primaryUnavailableReason).toBe("This path is unavailable.");
-    await expect(result.current.openPrimary()).resolves.toBe("unavailable");
-    expect(hostMocks.inspectPath).not.toHaveBeenCalled();
-    expect(hostMocks.reveal).not.toHaveBeenCalled();
-    expect(viewerMocks.openTarget).not.toHaveBeenCalled();
+  it.each(["", "   "])("keeps supplied structured value %j authoritative and inert", async (workspacePath) => {
+    const { result } = renderHook(() => useFileReferenceActions({
+      rawPath: "src/visible.ts",
+      workspacePath,
+    }));
+    expect(result.current.reference.displayPath).toBe("src/visible.ts");
+    expect(result.current.reference.locator).toEqual({ authority: "unavailable", reason: "invalid" });
+    expect(statMocks.calls).toHaveBeenLastCalledWith(expect.objectContaining({ enabled: false }));
+    expect(bridgeMocks.getHomeDirectory).not.toHaveBeenCalled();
+    expect(bridgeMocks.inspectPath).not.toHaveBeenCalled();
   });
 
-  it("still opens a resolved workspace file in the viewer on Web", async () => {
-    hostMocks.desktopAvailable = false;
-    const { result } = renderHook(
-      () => useFileReferenceActions({ rawPath: "README.md" }),
-      { wrapper: workspaceWrapper("/repo") },
-    );
+  it("inspects and opens an authority-proven Desktop file", async () => {
+    const { result } = renderHook(() => useFileReferenceActions({ rawPath: "/tmp/outside.txt" }));
+    await waitFor(() => expect(result.current.accessState.status).toBe("settled"));
 
-    await act(async () => {
-      await result.current.openPrimary();
-    });
+    expect(result.current.nativePathKind).toBe("file");
+    await expect(result.current.openPrimary()).resolves.toBe("open-external");
+    await result.current.openWithTarget("cursor");
+    await result.current.openWithTarget("removed-target");
 
-    expect(viewerMocks.openTarget).toHaveBeenCalledWith({ kind: "file", path: "README.md" });
-    expect(hostMocks.reveal).not.toHaveBeenCalled();
+    expect(bridgeMocks.inspectPath).toHaveBeenCalledWith("/tmp/outside.txt");
+    expect(editorMocks.openInDefaultEditor).toHaveBeenCalledWith("/tmp/outside.txt", "file");
+    expect(bridgeMocks.openTarget).toHaveBeenCalledTimes(1);
+    expect(bridgeMocks.openTarget).toHaveBeenCalledWith("cursor", "/tmp/outside.txt");
   });
 
-  it("opens the uniquely corrected viewer target after an exact stat miss", async () => {
-    statMocks.kind = null;
-    statMocks.error = new Error("not found");
-    statMocks.refetch.mockResolvedValue({ data: undefined });
-    fuzzyMocks.resolve.mockResolvedValue("apps/product/src/App.tsx");
-    const { result } = renderHook(
-      () => useFileReferenceActions({ rawPath: "src/App.tsx" }),
-      { wrapper: workspaceWrapper("/repo") },
+  it("uses reveal as the Desktop directory primary action", async () => {
+    bridgeMocks.inspectPath.mockResolvedValue({ kind: "directory" });
+    const { result } = renderHook(() => useFileReferenceActions({ rawPath: "/tmp/folder" }));
+    await waitFor(() => expect(result.current.nativePathKind).toBe("directory"));
+
+    expect(result.current.canOpenExternal).toBe(true);
+    expect(result.current.openTargets).toEqual(editorMocks.targets);
+    await expect(result.current.openPrimary()).resolves.toBe("reveal");
+    await result.current.openWithTarget("cursor");
+    expect(bridgeMocks.reveal).toHaveBeenCalledWith("/tmp/folder");
+    expect(bridgeMocks.openTarget).toHaveBeenCalledWith("cursor", "/tmp/folder");
+    expect(editorMocks.openInDefaultEditor).not.toHaveBeenCalled();
+  });
+
+  it("expands a gated home reference and rejects an invalid native home without inspection", async () => {
+    const { result, rerender } = renderHook(
+      ({ rawPath }) => useFileReferenceActions({ rawPath }),
+      { initialProps: { rawPath: "~/notes/file.md" } },
     );
+    await waitFor(() => expect(result.current.nativePathKind).toBe("file"));
+    expect(bridgeMocks.inspectPath).toHaveBeenCalledWith("/Users/pablo/notes/file.md");
 
-    await act(async () => {
-      await result.current.openPrimary();
+    bridgeMocks.files = {
+      ...bridgeMocks.files,
+      getHomeDirectory: vi.fn(async () => "relative-home"),
+    };
+    rerender({ rawPath: "~/other.md" });
+    await waitFor(() => expect(result.current.pathKindPending).toBe(false));
+    expect(result.current.reference.locator).toEqual({
+      authority: "unavailable",
+      reason: "home_unavailable",
     });
+    expect(bridgeMocks.inspectPath).toHaveBeenCalledTimes(1);
+  });
 
-    expect(fuzzyMocks.resolve).toHaveBeenCalledWith({
-      workspacePath: "src/App.tsx",
+  it("offers one bounded recovery only for an exact typed missing error", async () => {
+    statMocks.data = undefined as never;
+    statMocks.error = problem("FILE_NOT_FOUND", 404);
+    fuzzyMocks.resolve.mockResolvedValue({
+      status: "match",
+      workspacePath: "Apps/Web/SRC/App.tsx",
+    });
+    const { result } = renderHook(() => useFileReferenceActions({ rawPath: "src/App.tsx" }));
+
+    expect(result.current.accessState.status).toBe("exact-missing");
+    await act(async () => {
+      await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
+    });
+    await waitFor(() => expect(result.current.accessState.status).toBe("settled"));
+    await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
+
+    expect(fuzzyMocks.resolve).toHaveBeenCalledTimes(1);
+    expect(lookupMocks.statFile).toHaveBeenCalledTimes(1);
+    expect(lookupMocks.statFile).toHaveBeenCalledWith({
       materializedWorkspaceId: "workspace-1",
+      path: "Apps/Web/SRC/App.tsx",
     });
-    expect(anyHarnessMocks.stat).toHaveBeenCalledWith(
-      "runtime-workspace-1",
-      "apps/product/src/App.tsx",
-    );
-    expect(viewerMocks.openTarget).toHaveBeenCalledWith({
-      kind: "file",
-      path: "apps/product/src/App.tsx",
-    });
-  });
-
-  it("keeps primary opening retryable after exact stat and correction both fail", async () => {
-    statMocks.kind = null;
-    statMocks.error = new Error("not found");
-    statMocks.refetch.mockResolvedValue({ data: undefined });
-    const { result } = renderHook(
-      () => useFileReferenceActions({ rawPath: "missing/App.tsx" }),
-      { wrapper: workspaceWrapper("/repo") },
-    );
-
-    expect(result.current.canOpenPrimary).toBe(true);
-    await act(async () => {
-      await expect(result.current.openPrimary()).resolves.toBe("unavailable");
-    });
-
-    await waitFor(() => {
-      expect(result.current.primaryUnavailableReason)
-        .toBe("This path was not found.");
-    });
-    expect(result.current.canOpenPrimary).toBe(true);
-    expect(viewerMocks.openTarget).not.toHaveBeenCalled();
+    expect(viewerMocks.openTarget).toHaveBeenCalledTimes(2);
   });
 
   it.each([
-    ["file", 0, true],
-    ["directory", undefined, false],
-  ])("resolves a workspace symlink to its %s target on Web", async (_target, sizeBytes, opensViewer) => {
-    hostMocks.desktopAvailable = false;
-    statMocks.kind = "symlink";
-    statMocks.sizeBytes = sizeBytes;
-    const { result } = renderHook(
-      () => useFileReferenceActions({ rawPath: "linked-entry" }),
-      { wrapper: workspaceWrapper("/repo") },
-    );
+    [{ status: "no-match" }, "not_found"],
+    [{ status: "ambiguous" }, "ambiguous_match"],
+    [{ status: "search-error" }, "runtime_unavailable"],
+  ] as const)("makes %s recovery terminal and non-repeatable", async (outcome, reason) => {
+    statMocks.data = undefined as never;
+    statMocks.error = problem("FILE_NOT_FOUND", 404);
+    fuzzyMocks.resolve.mockResolvedValue(outcome);
+    const { result } = renderHook(() => useFileReferenceActions({ rawPath: "missing.ts" }));
 
-    await expect(result.current.openPrimary()).resolves.toBe(
-      opensViewer ? "open-viewer" : "unavailable",
-    );
-    expect(viewerMocks.openTarget).toHaveBeenCalledTimes(opensViewer ? 1 : 0);
+    await act(async () => {
+      await expect(result.current.openPrimary()).resolves.toBe("unavailable");
+    });
+    await waitFor(() => expect(result.current.accessState).toEqual({ status: "unavailable", reason }));
+    await expect(result.current.openPrimary()).resolves.toBe("unavailable");
+    expect(fuzzyMocks.resolve).toHaveBeenCalledTimes(1);
+    expect(lookupMocks.statFile).not.toHaveBeenCalled();
   });
 
-  it("opens an external file with the configured Desktop target", async () => {
-    statMocks.kind = null;
-    const { result } = renderHook(
-      () => useFileReferenceActions({ rawPath: "/tmp/outside.txt" }),
-      { wrapper: workspaceWrapper("/repo") },
-    );
+  it("does not recover a missing lookalike or any stable nonmissing runtime refusal", () => {
+    for (const error of [
+      Object.assign(new Error("missing"), { problem: { code: "FILE_NOT_FOUND" } }),
+      problem("PATH_OUTSIDE_WORKSPACE", 400),
+      problem("INVALID_FILE_PATH", 400),
+      problem("FILE_PERMISSION_DENIED", 403),
+      problem("NOT_A_DIRECTORY", 400),
+      problem("UNEXPECTED", 500),
+    ]) {
+      statMocks.data = undefined as never;
+      statMocks.error = error;
+      const { result, unmount } = renderHook(() => useFileReferenceActions({ rawPath: "missing.ts" }));
+      expect(result.current.accessState.status).toBe("unavailable");
+      expect(result.current.canOpenPrimary).toBe(false);
+      unmount();
+    }
+    expect(fuzzyMocks.resolve).not.toHaveBeenCalled();
+  });
 
-    await waitFor(() => expect(result.current.pathKind).toBe("file"));
-    expect(result.current.canOpenPrimary).toBe(true);
-    expect(result.current.canOpenExternal).toBe(true);
-    expect(result.current.canReveal).toBe(false);
-    await expect(result.current.openPrimary()).resolves.toBe("open-external");
-    await result.current.openWithTarget("cursor");
-    await result.current.reveal();
-    expect(editorMocks.openInDefaultEditor).toHaveBeenCalledWith("/tmp/outside.txt", "file");
-    expect(hostMocks.openTarget).toHaveBeenCalledWith("cursor", "/tmp/outside.txt");
-    expect(hostMocks.reveal).not.toHaveBeenCalled();
+  it.each([
+    ["directory", { kind: "directory" }, "unsupported_type"],
+    ["refusal", problem("FILE_PERMISSION_DENIED", 403), "permission_denied"],
+    ["transport", new Error("offline"), "runtime_unavailable"],
+  ] as const)("makes a corrected %s terminal", async (_label, corrected, reason) => {
+    statMocks.data = undefined as never;
+    statMocks.error = problem("FILE_NOT_FOUND", 404);
+    fuzzyMocks.resolve.mockResolvedValue({ status: "match", workspacePath: "actual.ts" });
+    if (corrected instanceof Error) lookupMocks.statFile.mockRejectedValue(corrected);
+    else lookupMocks.statFile.mockResolvedValue({ path: "actual.ts", ...corrected });
+    const { result } = renderHook(() => useFileReferenceActions({ rawPath: "missing.ts" }));
+
+    await act(async () => void await result.current.openPrimary());
+    await waitFor(() => expect(result.current.accessState).toEqual({ status: "unavailable", reason }));
+    await result.current.openPrimary();
+    expect(fuzzyMocks.resolve).toHaveBeenCalledTimes(1);
+    expect(lookupMocks.statFile).toHaveBeenCalledTimes(1);
     expect(viewerMocks.openTarget).not.toHaveBeenCalled();
   });
 
-  it("keeps a rejected home lookup unavailable without a /tmp fallback", async () => {
-    statMocks.kind = null;
-    hostMocks.getHomeDirectory.mockRejectedValue(new Error("home unavailable"));
-    const { result } = renderHook(
-      () => useFileReferenceActions({ rawPath: "~/.config/secret.txt" }),
-      { wrapper: workspaceWrapper("/repo") },
+  it("resets consumed recovery when locator identity changes", async () => {
+    statMocks.data = undefined as never;
+    statMocks.error = problem("FILE_NOT_FOUND", 404);
+    const { result, rerender } = renderHook(
+      ({ rawPath }) => useFileReferenceActions({ rawPath }),
+      { initialProps: { rawPath: "one.ts" } },
     );
+    await consumeMissingRecovery(result);
+    await result.current.openPrimary();
+    expect(fuzzyMocks.resolve).toHaveBeenCalledTimes(1);
 
-    await waitFor(() => expect(result.current.pathKindPending).toBe(false));
-    expect(result.current.reference.absolutePath).toBeNull();
-    expect(result.current.pathKind).toBeNull();
+    rerender({ rawPath: "two.ts" });
+    expect(result.current.accessState.status).toBe("exact-missing");
+    await act(async () => void await result.current.openPrimary());
+    expect(fuzzyMocks.resolve).toHaveBeenCalledTimes(2);
+  });
+
+  it("resets consumed recovery when the materialized workspace changes", async () => {
+    statMocks.data = undefined as never;
+    statMocks.error = problem("FILE_NOT_FOUND", 404);
+    const { result, rerender } = renderHook(() => (
+      useFileReferenceActions({ rawPath: "missing.ts" })
+    ));
+    await consumeMissingRecovery(result);
+
+    selectionMocks.selectedWorkspaceId = "workspace-2";
+    selectionMocks.selectedLogicalWorkspaceId = "workspace-2";
+    rerender();
+    expect(result.current.accessState.status).toBe("exact-missing");
+    await act(async () => void await result.current.openPrimary());
+    expect(fuzzyMocks.resolve).toHaveBeenCalledTimes(2);
+    expect(fuzzyMocks.resolve).toHaveBeenLastCalledWith({
+      materializedWorkspaceId: "workspace-2",
+      workspacePath: "missing.ts",
+    });
+  });
+
+  it("resets consumed recovery when runtime-root state or path changes", async () => {
+    statMocks.data = undefined as never;
+    statMocks.error = problem("FILE_NOT_FOUND", 404);
+    pathMocks.value = {
+      ...pathMocks.value,
+      filesystemOrigin: { status: "settled", origin: "remote" },
+      workspaceRoot: { status: "pending", path: null },
+    };
+    const { result, rerender } = renderHook(() => (
+      useFileReferenceActions({ rawPath: "missing.ts" })
+    ));
+    await consumeMissingRecovery(result);
+
+    pathMocks.value = {
+      ...pathMocks.value,
+      workspaceRoot: { status: "settled", path: "/repo" },
+    };
+    rerender();
+    expect(result.current.accessState.status).toBe("exact-missing");
+    await act(async () => void await result.current.openPrimary());
+    pathMocks.value = {
+      ...pathMocks.value,
+      workspaceRoot: { status: "settled", path: "/other" },
+    };
+    rerender();
+    expect(result.current.accessState.status).toBe("exact-missing");
+    await act(async () => void await result.current.openPrimary());
+
+    expect(fuzzyMocks.resolve).toHaveBeenCalledTimes(3);
+  });
+
+  it("resets consumed recovery when filesystem-origin state or value changes", async () => {
+    statMocks.data = undefined as never;
+    statMocks.error = problem("FILE_NOT_FOUND", 404);
+    pathMocks.value = {
+      ...pathMocks.value,
+      filesystemOrigin: { status: "pending", origin: null },
+      workspaceRoot: { status: "unavailable", path: null },
+    };
+    const { result, rerender } = renderHook(() => (
+      useFileReferenceActions({ rawPath: "missing.ts" })
+    ));
+    await consumeMissingRecovery(result);
+
+    pathMocks.value = {
+      ...pathMocks.value,
+      filesystemOrigin: { status: "rejected", origin: null },
+    };
+    rerender();
+    expect(result.current.accessState.status).toBe("exact-missing");
+    await act(async () => void await result.current.openPrimary());
+
+    pathMocks.value = {
+      ...pathMocks.value,
+      filesystemOrigin: { status: "settled", origin: "remote" },
+    };
+    rerender();
+    expect(result.current.accessState.status).toBe("exact-missing");
+    await act(async () => void await result.current.openPrimary());
+
+    pathMocks.value = {
+      ...pathMocks.value,
+      filesystemOrigin: { status: "settled", origin: "desktop-local" },
+    };
+    rerender();
+    expect(result.current.accessState.status).toBe("exact-missing");
+    await act(async () => void await result.current.openPrimary());
+
+    expect(fuzzyMocks.resolve).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not reset consumed recovery for rerenders, bridge replacement, or native kind", async () => {
+    statMocks.data = undefined as never;
+    statMocks.error = problem("FILE_NOT_FOUND", 404);
+    const { result, rerender } = renderHook(
+      ({ nativeCapabilityKind, renderKey }: {
+        nativeCapabilityKind?: "file" | "directory";
+        renderKey: number;
+      }) => {
+        void renderKey;
+        return useFileReferenceActions({ rawPath: "missing.ts", nativeCapabilityKind });
+      },
+      { initialProps: { nativeCapabilityKind: undefined, renderKey: 0 } },
+    );
+    await consumeMissingRecovery(result);
+
+    rerender({ nativeCapabilityKind: undefined, renderKey: 1 });
+    await result.current.openPrimary();
+    bridgeMocks.files = { ...bridgeMocks.files };
+    rerender({ nativeCapabilityKind: undefined, renderKey: 2 });
+    await result.current.openPrimary();
+    rerender({ nativeCapabilityKind: "directory", renderKey: 3 });
+    await result.current.openPrimary();
+
+    expect(result.current.accessState).toEqual({ status: "unavailable", reason: "not_found" });
+    expect(fuzzyMocks.resolve).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats an unexpected symlink kind as terminal without size inference", () => {
+    statMocks.data = { kind: "symlink" };
+    const { result } = renderHook(() => useFileReferenceActions({ rawPath: "linked" }));
+    expect(result.current.accessState).toEqual({ status: "unavailable", reason: "unexpected_kind" });
     expect(result.current.canOpenPrimary).toBe(false);
-    expect(result.current.primaryUnavailableReason).toBe("This path is unavailable.");
+  });
 
-    await expect(result.current.openPrimary()).resolves.toBe("unavailable");
-    await expect(result.current.openPrimary()).resolves.toBe("unavailable");
-    expect(hostMocks.getHomeDirectory).toHaveBeenCalledTimes(1);
-    expect(hostMocks.inspectPath).not.toHaveBeenCalled();
-    expect(hostMocks.openTarget).not.toHaveBeenCalled();
-    expect(hostMocks.reveal).not.toHaveBeenCalled();
+  it("uses a stable current-copy handler and no-ops a captured callback after the path becomes empty", async () => {
+    const { result, rerender } = renderHook(
+      ({ rawPath }) => useFileReferenceActions({ rawPath }),
+      { initialProps: { rawPath: "src/App.tsx" } },
+    );
+    const captured = result.current.copyCurrentPath;
+    await captured();
+    expect(bridgeMocks.writeText).toHaveBeenCalledWith("/repo/src/App.tsx");
+
+    rerender({ rawPath: "   " });
+    expect(result.current.copyPath).toBeNull();
+    await captured();
+    expect(bridgeMocks.writeText).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed for stale native callbacks after provenance changes", async () => {
+    const { result, rerender } = renderHook(() => useFileReferenceActions({ rawPath: "/tmp/a" }));
+    await waitFor(() => expect(result.current.nativePathKind).toBe("file"));
+    const staleOpen = result.current.openDefault;
+    const staleTarget = result.current.openWithTarget;
+    const staleReveal = result.current.reveal;
+
+    pathMocks.value = {
+      ...pathMocks.value,
+      filesystemOrigin: { status: "settled", origin: "remote" },
+    };
+    rerender();
+    await staleOpen();
+    await staleTarget("cursor");
+    await staleReveal();
+
     expect(editorMocks.openInDefaultEditor).not.toHaveBeenCalled();
-    expect(hostMocks.inspectPath).not.toHaveBeenCalledWith(
-      expect.stringContaining("/tmp"),
-    );
-  });
-
-  it("expands a home-relative hidden file before opening it on Desktop", async () => {
-    statMocks.kind = null;
-    let resolveHomeDirectory!: (path: string) => void;
-    hostMocks.getHomeDirectory.mockImplementationOnce(() => new Promise((resolve) => {
-      resolveHomeDirectory = resolve;
-    }));
-    const rawPath = "~/.proliferate-local/dev/profiles/wf2pablo/app/diagnostics-dev.env";
-    const absolutePath = "/Users/pablo/.proliferate-local/dev/profiles/wf2pablo/app/diagnostics-dev.env";
-    const { result } = renderHook(
-      () => useFileReferenceActions({ rawPath }),
-      { wrapper: workspaceWrapper("/repo") },
-    );
-
-    expect(result.current.canOpenPrimary).toBe(false);
-    await act(async () => {
-      const openPromise = result.current.openPrimary();
-      resolveHomeDirectory("/Users/pablo");
-      await expect(openPromise).resolves.toBe("open-external");
-    });
-    await waitFor(() => {
-      expect(result.current.reference.absolutePath).toBe(absolutePath);
-      expect(result.current.pathKind).toBe("file");
-    });
-
-    expect(hostMocks.getHomeDirectory).toHaveBeenCalledTimes(1);
-    expect(hostMocks.inspectPath).toHaveBeenCalledWith(absolutePath);
-    expect(editorMocks.openInDefaultEditor).toHaveBeenCalledWith(absolutePath, "file");
-  });
-
-  it("keeps an external file retryable when its Desktop target fails", async () => {
-    statMocks.kind = null;
-    editorMocks.openInDefaultEditor
-      .mockResolvedValueOnce(false)
-      .mockResolvedValueOnce(true);
-    const { result } = renderHook(
-      () => useFileReferenceActions({ rawPath: "/tmp/outside.txt" }),
-      { wrapper: workspaceWrapper("/repo") },
-    );
-
-    await waitFor(() => expect(result.current.pathKind).toBe("file"));
-    await act(async () => {
-      await expect(result.current.openPrimary()).resolves.toBe("unavailable");
-    });
-
-    await waitFor(() => {
-      expect(result.current.primaryUnavailableReason)
-        .toBe("Could not open this path. Click to retry.");
-    });
-    expect(result.current.canOpenPrimary).toBe(true);
-
-    await act(async () => {
-      await expect(result.current.openPrimary()).resolves.toBe("open-external");
-    });
-    await waitFor(() => {
-      expect(result.current.primaryUnavailableReason).toBeNull();
-    });
-    expect(editorMocks.openInDefaultEditor).toHaveBeenCalledTimes(2);
-    expect(hostMocks.inspectPath).toHaveBeenCalledTimes(1);
-  });
-
-  it("keeps a rejected Desktop inspection terminal for the candidate revision", async () => {
-    statMocks.kind = null;
-    hostMocks.inspectPath.mockRejectedValue(new Error("bridge unavailable"));
-    const { result } = renderHook(
-      () => useFileReferenceActions({ rawPath: "/tmp/outside.txt" }),
-      { wrapper: workspaceWrapper("/repo") },
-    );
-
-    await waitFor(() => {
-      expect(hostMocks.inspectPath).toHaveBeenCalled();
-      expect(result.current.pathKindPending).toBe(false);
-    });
-    expect(result.current.canOpenPrimary).toBe(false);
-    await act(async () => {
-      await expect(result.current.openPrimary()).resolves.toBe("unavailable");
-      await expect(result.current.openPrimary()).resolves.toBe("unavailable");
-      await expect(result.current.openDefault()).resolves.toBe(false);
-      await result.current.openWithTarget("cursor");
-      await result.current.reveal();
-    });
-
-    expect(result.current.primaryUnavailableReason).toBe("This path is unavailable.");
-    expect(hostMocks.inspectPath).toHaveBeenCalledTimes(1);
-    expect(hostMocks.openTarget).not.toHaveBeenCalled();
-    expect(hostMocks.reveal).not.toHaveBeenCalled();
-    expect(editorMocks.openInDefaultEditor).not.toHaveBeenCalled();
-  });
-
-  it("keeps an external file unavailable on Web", async () => {
-    hostMocks.desktopAvailable = false;
-    statMocks.kind = null;
-    const { result } = renderHook(
-      () => useFileReferenceActions({ rawPath: "/tmp/outside.txt" }),
-      { wrapper: workspaceWrapper("/repo") },
-    );
-
-    expect(result.current.canOpenPrimary).toBe(false);
-    expect(result.current.pathKindPending).toBe(false);
-    expect(result.current.primaryUnavailableReason).toBe("This path is unavailable.");
-    await expect(result.current.openPrimary()).resolves.toBe("unavailable");
-    expect(editorMocks.openInDefaultEditor).not.toHaveBeenCalled();
-    expect(hostMocks.reveal).not.toHaveBeenCalled();
-    expect(viewerMocks.openTarget).not.toHaveBeenCalled();
-  });
-
-  it("keeps a home-relative file unavailable on Web", async () => {
-    hostMocks.desktopAvailable = false;
-    statMocks.kind = null;
-    const { result } = renderHook(
-      () => useFileReferenceActions({ rawPath: "~/.config/proliferate/settings.json" }),
-      { wrapper: workspaceWrapper("/repo") },
-    );
-
-    expect(result.current.canOpenPrimary).toBe(false);
-    expect(result.current.primaryUnavailableReason).toBe("This path is unavailable.");
-    await expect(result.current.openPrimary()).resolves.toBe("unavailable");
-    expect(hostMocks.getHomeDirectory).not.toHaveBeenCalled();
+    expect(bridgeMocks.openTarget).not.toHaveBeenCalled();
+    expect(bridgeMocks.reveal).not.toHaveBeenCalled();
   });
 });
 
-function workspaceWrapper(workspacePath: string | null) {
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return (
-      <WorkspacePathProvider workspacePath={workspacePath}>
-        {children}
-      </WorkspacePathProvider>
-    );
-  };
+function problem(code: string, status: number): AnyHarnessError {
+  return new AnyHarnessError({
+    type: "about:blank",
+    title: "File request failed",
+    status,
+    code,
+  });
+}
+
+async function consumeMissingRecovery(result: {
+  readonly current: ReturnType<typeof useFileReferenceActions>;
+}) {
+  await act(async () => void await result.current.openPrimary());
+  await waitFor(() => expect(result.current.accessState).toEqual({
+    status: "unavailable",
+    reason: "not_found",
+  }));
 }

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.ts
@@ -1,397 +1,365 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  getAnyHarnessClient,
-  resolveWorkspaceConnectionFromContext,
-  useAnyHarnessWorkspaceContext,
-  useStatWorkspaceFileQuery,
-} from "@anyharness/sdk-react";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { useStatWorkspaceFileQuery } from "@anyharness/sdk-react";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
 import { useOpenInDefaultEditor } from "#product/hooks/editor/workflows/use-open-in-default-editor";
+import { useWorkspaceFileLookup } from "#product/hooks/access/anyharness/files/use-workspace-file-lookup";
 import {
-  resolveInspectionPathKind,
-  resolveInspectionUnavailableCopy,
-  useDesktopPathInspection,
-} from "#product/hooks/workspaces/workflows/files/use-desktop-path-inspection";
-import { useDesktopFileReferenceActions } from "#product/hooks/workspaces/workflows/files/use-desktop-file-reference-actions";
+  useDesktopFileReferenceActions,
+} from "#product/hooks/workspaces/workflows/files/use-desktop-file-reference-actions";
+import { useDesktopPathInspection } from "#product/hooks/workspaces/workflows/files/use-desktop-path-inspection";
+import {
+  fileReferenceAccessReason,
+  fileReferenceUnavailableCopy,
+  resolveFileReferenceAccessState,
+  resolveNativeFileReferenceCapability,
+  type AccessibleFileLocator,
+  type FileReferenceRecoveryState,
+} from "#product/hooks/workspaces/workflows/files/file-reference-access-state";
 import { useFuzzyFileResolver } from "#product/hooks/workspaces/workflows/files/use-fuzzy-file-resolver";
 import { useHomeRelativeFileReference } from "#product/hooks/workspaces/workflows/files/use-home-relative-file-reference";
 import { useWorkspaceShellActivation } from "#product/hooks/workspaces/workflows/tabs/use-workspace-shell-activation";
-import { useWorkspacePath } from "#product/providers/WorkspacePathProvider";
 import {
+  fileReferenceCopyPath,
+  isHomeRelativeFileReference,
   resolveFileReference,
-  resolveFileReferencePrimaryAction,
   resolveWorkspaceStatPathKind,
+  type FileReferencePrimaryAction,
 } from "#product/lib/domain/files/path-references";
 import { resolveSelectedWorkspaceIdentity } from "#product/lib/domain/workspaces/selection/workspace-ui-key";
 import { fileViewerTarget } from "#product/lib/domain/workspaces/viewer/viewer-target";
+import { useWorkspacePath } from "#product/providers/WorkspacePathProvider";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useWorkspaceViewerTabsStore } from "#product/stores/editor/workspace-viewer-tabs-store";
 
 interface UseFileReferenceActionsInput {
   rawPath: string;
   workspacePath?: string | null;
+  /** Narrow native discovery for callers whose UI owns one exact path kind. */
+  nativeCapabilityKind?: "file" | "directory";
 }
 
 export function useFileReferenceActions({
   rawPath,
   workspacePath,
+  nativeCapabilityKind,
 }: UseFileReferenceActionsInput) {
   const host = useProductHost();
   const files = host.desktop?.files ?? null;
-  const {
-    homeDirectory,
-    needsHomeDirectory,
-    pending: homeDirectoryPending,
-    rejected: homeDirectoryRejected,
-    resolveHomeDirectory,
-  } = useHomeRelativeFileReference(files, rawPath);
   const openTarget = useWorkspaceViewerTabsStore((state) => state.openTarget);
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
   const selectedLogicalWorkspaceId = useSessionSelectionStore(
     (state) => state.selectedLogicalWorkspaceId,
   );
   const { activateViewerTarget } = useWorkspaceShellActivation();
-  const selectedWorkspaceIdentity = useMemo(
-    () => resolveSelectedWorkspaceIdentity({
-      selectedLogicalWorkspaceId,
-      materializedWorkspaceId: selectedWorkspaceId,
-    }),
-    [selectedLogicalWorkspaceId, selectedWorkspaceId],
-  );
-  const materializedWorkspaceId = selectedWorkspaceIdentity.materializedWorkspaceId;
-  const workspaceUiKey = selectedWorkspaceIdentity.workspaceUiKey;
-  const { workspacePath: workspaceRoot, resolveAbsolute } = useWorkspacePath();
-  const anyHarnessWorkspace = useAnyHarnessWorkspaceContext();
-  const fuzzyResolveFilePath = useFuzzyFileResolver();
+  const identity = useMemo(() => resolveSelectedWorkspaceIdentity({
+    selectedLogicalWorkspaceId,
+    materializedWorkspaceId: selectedWorkspaceId,
+  }), [selectedLogicalWorkspaceId, selectedWorkspaceId]);
+  const materializedWorkspaceId = identity.materializedWorkspaceId;
+  const workspaceUiKey = identity.workspaceUiKey;
+  const { filesystemOrigin, workspaceRoot } = useWorkspacePath();
 
+  const unresolvedReference = useMemo(() => resolveFileReference({
+    rawPath,
+    workspacePathOverride: workspacePath,
+    workspaceRoot,
+    filesystemOrigin,
+    desktopBridgeAvailable: files !== null,
+  }), [files, filesystemOrigin, rawPath, workspacePath, workspaceRoot]);
+  const homeCandidate = typeof workspacePath !== "string"
+    && isHomeRelativeFileReference(rawPath)
+    && unresolvedReference.locator.authority === "unavailable"
+    && unresolvedReference.locator.reason === "home_unavailable"
+    ? unresolvedReference.parsedPath
+    : null;
+  const home = useHomeRelativeFileReference({ files, candidatePath: homeCandidate });
   const reference = useMemo(() => resolveFileReference({
     rawPath,
-    workspaceRoot,
-    resolveAbsolute,
-    homeDirectory,
     workspacePathOverride: workspacePath,
-  }), [homeDirectory, rawPath, resolveAbsolute, workspacePath, workspaceRoot]);
+    workspaceRoot,
+    filesystemOrigin,
+    desktopBridgeAvailable: files !== null,
+    homeDirectory: home.homeDirectory,
+  }), [files, filesystemOrigin, home.homeDirectory, rawPath, workspacePath, workspaceRoot]);
 
-  const statQuery = useStatWorkspaceFileQuery({
-    workspaceId: materializedWorkspaceId,
-    path: reference.workspacePath,
-    enabled: Boolean(materializedWorkspaceId && reference.workspacePath),
-  });
   const routeRevision = useMemo(() => ({}), [
     files,
-    rawPath,
-    resolveAbsolute,
-    workspacePath,
-    workspaceRoot,
+    filesystemOrigin.origin,
+    filesystemOrigin.status,
+    materializedWorkspaceId,
+    nativeCapabilityKind,
+    reference.locator,
+    workspaceRoot.path,
+    workspaceRoot.status,
+  ]);
+  const recoveryLocatorWorkspacePath = reference.locator.authority === "workspace"
+    ? reference.locator.workspacePath
+    : null;
+  const recoveryLocatorCompanionPath = reference.locator.authority === "workspace"
+    ? reference.locator.localCompanionPath
+    : null;
+  const recoveryLocatorAbsolutePath = reference.locator.authority === "desktop"
+    ? reference.locator.absolutePath
+    : null;
+  const recoveryLocatorUnavailableReason = reference.locator.authority === "unavailable"
+    ? reference.locator.reason
+    : null;
+  const recoveryRevision = useMemo(() => ({}), [
+    filesystemOrigin.origin,
+    filesystemOrigin.status,
+    materializedWorkspaceId,
+    recoveryLocatorAbsolutePath,
+    recoveryLocatorCompanionPath,
+    recoveryLocatorUnavailableReason,
+    recoveryLocatorWorkspacePath,
+    reference.locator.authority,
+    workspaceRoot.path,
+    workspaceRoot.status,
   ]);
   const currentRouteRevisionRef = useRef(routeRevision);
   currentRouteRevisionRef.current = routeRevision;
-  const [pathResolutionFailed, setPathResolutionFailed] = useState(false);
-  const [primaryOpenFailed, setPrimaryOpenFailed] = useState(false);
-
-  const desktopCandidatePath = reference.workspacePath ? null : reference.absolutePath;
-  const {
-    ensureInspection: ensureDesktopPathInspection,
-    state: desktopInspectionState,
-  } = useDesktopPathInspection({
+  const currentRecoveryRevisionRef = useRef(recoveryRevision);
+  currentRecoveryRevisionRef.current = recoveryRevision;
+  const workspaceLocator = reference.locator.authority === "workspace"
+    ? reference.locator
+    : null;
+  const statQuery = useStatWorkspaceFileQuery({
+    workspaceId: materializedWorkspaceId,
+    path: workspaceLocator?.workspacePath ?? null,
+    enabled: workspaceLocator !== null && materializedWorkspaceId !== null,
+  });
+  const desktopCandidatePath = reference.locator.authority === "desktop"
+    ? reference.locator.absolutePath
+    : null;
+  const desktopInspection = useDesktopPathInspection({
     candidatePath: desktopCandidatePath,
     files,
     routeRevision,
   });
-
-  const workspacePathKind = resolveWorkspaceStatPathKind(statQuery.data);
-  const externalPathKind = resolveInspectionPathKind(desktopInspectionState);
-  const pathKind = reference.workspacePath ? workspacePathKind : externalPathKind;
-
-  useEffect(() => {
-    setPathResolutionFailed(false);
-    setPrimaryOpenFailed(false);
-  }, [materializedWorkspaceId, reference.absolutePath, reference.workspacePath]);
-
-  const {
-    defaultTarget: defaultOpenTarget,
-    openInDefaultEditor,
-    targets,
-  } = useOpenInDefaultEditor(pathKind);
-  const { openDefault, openTargets, openWithTarget, reveal } = useDesktopFileReferenceActions({
+  const [recoveryState, setRecoveryState] = useState<FileReferenceRecoveryState>(null);
+  const recoveryRef = useRef<FileReferenceRecoveryState>(recoveryState);
+  recoveryRef.current = recoveryState;
+  const setRecovery = useCallback((next: FileReferenceRecoveryState) => {
+    recoveryRef.current = next;
+    setRecoveryState(next);
+  }, []);
+  const activeRecovery = recoveryState?.recoveryRevision === recoveryRevision
+    ? recoveryState
+    : null;
+  const accessState = resolveFileReferenceAccessState({
+    locator: reference.locator,
+    materializedWorkspaceId,
+    statData: statQuery.data,
+    statError: statQuery.error,
+    statPending: statQuery.isPending || statQuery.isFetching,
+    desktopInspectionState: desktopInspection.state,
+    recovery: activeRecovery,
+  });
+  const pathKind = accessState.status === "settled" ? accessState.kind : null;
+  const resolvedNativeCapability = resolveNativeFileReferenceCapability(accessState, routeRevision);
+  const nativeCapability = resolvedNativeCapability
+    && (!nativeCapabilityKind || resolvedNativeCapability.kind === nativeCapabilityKind)
+    ? resolvedNativeCapability
+    : null;
+  const externalOpenCapability = nativeCapability
+    && (
+      nativeCapability.source === "desktop"
+      || nativeCapability.kind === "file"
+      || nativeCapabilityKind === "directory"
+    )
+    ? nativeCapability
+    : null;
+  const nativePathKind = nativeCapability?.kind ?? null;
+  const { defaultTarget: defaultOpenTarget, openInDefaultEditor, targets } =
+    useOpenInDefaultEditor(externalOpenCapability?.kind ?? null);
+  const nativeActions = useDesktopFileReferenceActions({
     files,
-    reference,
-    pathKind,
-    desktopInspectionState,
+    capability: nativeCapability,
+    externalOpenCapability,
     routeRevision,
     targets,
     openInDefaultEditor,
   });
+  const fuzzyResolve = useFuzzyFileResolver();
+  const { statFile } = useWorkspaceFileLookup();
+  const [failedPrimaryRoute, setFailedPrimaryRoute] = useState<object | null>(null);
 
-  const canOpenInSidebar = pathKind === "file" && Boolean(reference.workspacePath);
-  const canOpenExternal = Boolean(files && reference.absolutePath && pathKind);
-  const canReveal = Boolean(
-    files
-    && reference.absolutePath
-    && pathKind === "directory",
-  );
-  const resolvedPrimaryAction = resolveFileReferencePrimaryAction({
-    pathKind,
-    canOpenViewer: canOpenInSidebar,
-    canOpenExternal,
-    canReveal,
+  const latestRef = useRef({
+    accessState,
+    materializedWorkspaceId,
+    recoveryRevision,
+    reference,
+    routeRevision,
+    workspaceUiKey,
   });
-  const canOpenPrimary = resolvedPrimaryAction !== "unavailable"
-    || Boolean(reference.workspacePath && materializedWorkspaceId && pathKind === null);
-  const desktopInspectionPending = Boolean(
-    files
-    && desktopCandidatePath
-    && (desktopInspectionState.status === "idle"
-      || desktopInspectionState.status === "pending"),
-  );
-  const homeResolutionPending = Boolean(
-    needsHomeDirectory
-    && files
-    && !homeDirectory
-    && !homeDirectoryRejected,
-  );
-  const pathKindPending = homeDirectoryPending
-    || homeResolutionPending
-    || desktopInspectionPending
-    || statQuery.isFetching;
-  const desktopInspectionUnavailableReason = files && desktopCandidatePath
-    ? resolveInspectionUnavailableCopy(desktopInspectionState)
-    : null;
-  const primaryUnavailableReason = pathKindPending
-    ? "Checking whether this path is a file or folder…"
-    : primaryOpenFailed
-      ? "Could not open this path. Click to retry."
-      : desktopInspectionUnavailableReason
-        ?? (homeDirectoryRejected
-          ? "This path is unavailable."
-          : pathKind === "directory" && !canReveal
-            ? "This path is unavailable."
-            : needsHomeDirectory && !files
-              ? "This path is unavailable."
-              : !reference.workspacePath && reference.absolutePath && !files
-                ? "This path is unavailable."
-                : pathKind === "file" && !canOpenInSidebar && !canOpenExternal
-                  ? "This path is unavailable."
-                  : pathKind === null && pathResolutionFailed
-                    ? "This path was not found."
-                    : pathKind === null
-                      ? "This path is unavailable."
-                      : null);
-  const copyPath = useCallback(async () => {
-    await host.clipboard.writeText(reference.absolutePath ?? reference.path);
-  }, [host.clipboard, reference.absolutePath, reference.path]);
+  latestRef.current = {
+    accessState,
+    materializedWorkspaceId,
+    recoveryRevision,
+    reference,
+    routeRevision,
+    workspaceUiKey,
+  };
+  const copyPath = fileReferenceCopyPath(reference);
+  const copyPathRef = useRef(copyPath);
+  copyPathRef.current = copyPath;
+  const clipboardRef = useRef(host.clipboard);
+  clipboardRef.current = host.clipboard;
+  const copyCurrentPath = useCallback(async () => {
+    const current = copyPathRef.current;
+    if (current === null) return;
+    await clipboardRef.current.writeText(current);
+  }, []);
+
+  const openViewer = useCallback((path: string, snapshot: typeof latestRef.current) => {
+    if (
+      currentRouteRevisionRef.current !== snapshot.routeRevision
+      || !snapshot.materializedWorkspaceId
+    ) return false;
+    const target = fileViewerTarget(path);
+    openTarget(target);
+    activateViewerTarget({
+      workspaceId: snapshot.materializedWorkspaceId,
+      shellWorkspaceId: snapshot.workspaceUiKey,
+      target,
+      mode: "open-or-focus",
+    });
+    return true;
+  }, [activateViewerTarget, openTarget]);
 
   const openInSidebar = useCallback(async () => {
-    if (!reference.workspacePath) {
-      return;
-    }
-    const openViewer = (path: string) => {
-      const target = fileViewerTarget(path);
-      openTarget(target);
-      if (materializedWorkspaceId) {
-        activateViewerTarget({
-          workspaceId: materializedWorkspaceId,
-          shellWorkspaceId: workspaceUiKey,
-          target,
-          mode: "open-or-focus",
-        });
-      }
-    };
-    // Open optimistically so the common (correct-path) case has zero latency.
-    // Then, best-effort and non-blocking, correct a partial/abbreviated path
-    // and re-open if it actually pointed elsewhere (the viewer would otherwise
-    // just show "file not found").
-    openViewer(reference.workspacePath);
-    const corrected = await fuzzyResolveFilePath({
-      workspacePath: reference.workspacePath,
-      materializedWorkspaceId,
+    const snapshot = latestRef.current;
+    if (
+      snapshot.routeRevision !== routeRevision
+      || snapshot.accessState.status !== "settled"
+      || snapshot.accessState.kind !== "file"
+      || snapshot.accessState.locator.authority !== "workspace"
+    ) return;
+    openViewer(snapshot.accessState.locator.workspacePath, snapshot);
+  }, [openViewer, routeRevision]);
+
+  const recoverMissing = useCallback(async (
+    locator: Extract<AccessibleFileLocator, { authority: "workspace" }>,
+    snapshot: typeof latestRef.current,
+  ): Promise<FileReferencePrimaryAction> => {
+    if (!snapshot.materializedWorkspaceId || locator.workspacePath === "") return "unavailable";
+    setRecovery({ recoveryRevision: snapshot.recoveryRevision, status: "recovering" });
+    const outcome = await fuzzyResolve({
+      workspacePath: locator.workspacePath,
+      materializedWorkspaceId: snapshot.materializedWorkspaceId,
     });
-    if (corrected && corrected !== reference.workspacePath) {
-      openViewer(corrected);
-    }
-  }, [
-    activateViewerTarget,
-    fuzzyResolveFilePath,
-    openTarget,
-    reference.workspacePath,
-    materializedWorkspaceId,
-    workspaceUiKey,
-  ]);
-
-  const statWorkspacePath = useCallback(async (path: string) => {
-    if (!materializedWorkspaceId) {
-      return null;
-    }
-    const resolved = await resolveWorkspaceConnectionFromContext(
-      anyHarnessWorkspace,
-      materializedWorkspaceId,
-    );
-    const client = getAnyHarnessClient(resolved.connection);
-    return client.files.stat(resolved.connection.anyharnessWorkspaceId, path);
-  }, [anyHarnessWorkspace, materializedWorkspaceId]);
-
-  const openPrimary = useCallback(async () => {
-    let resolvedPathKind = pathKind;
-    let resolvedWorkspacePath = reference.workspacePath;
-    let resolvedAbsolutePath = reference.absolutePath;
-    if (!resolvedAbsolutePath && needsHomeDirectory && files) {
-      const resolvedHomeDirectory = await resolveHomeDirectory();
-      if (currentRouteRevisionRef.current !== routeRevision) {
-        return "unavailable";
-      }
-      if (resolvedHomeDirectory) {
-        resolvedAbsolutePath = resolveFileReference({
-          rawPath,
-          workspaceRoot,
-          resolveAbsolute,
-          homeDirectory: resolvedHomeDirectory,
-          workspacePathOverride: workspacePath,
-        }).absolutePath;
-      } else {
-        setPathResolutionFailed(true);
-        return "unavailable";
-      }
-    }
-    if (!resolvedPathKind && reference.workspacePath && materializedWorkspaceId) {
-      const result = await statQuery.refetch();
-      resolvedPathKind = resolveWorkspaceStatPathKind(result.data);
-      if (!resolvedPathKind) {
-        const corrected = await fuzzyResolveFilePath({
-          workspacePath: reference.workspacePath,
-          materializedWorkspaceId,
-        });
-        if (corrected) {
-          try {
-            const correctedStat = await statWorkspacePath(corrected);
-            resolvedPathKind = resolveWorkspaceStatPathKind(correctedStat ?? undefined);
-            resolvedWorkspacePath = resolvedPathKind ? corrected : null;
-          } catch {
-            resolvedPathKind = null;
-            resolvedWorkspacePath = null;
-          }
-        }
-        if (!resolvedPathKind || !resolvedWorkspacePath) {
-          setPathResolutionFailed(true);
-          return "unavailable";
-        }
-      }
-    }
-    if (!resolvedWorkspacePath && resolvedAbsolutePath && files) {
-      const inspection = await ensureDesktopPathInspection(resolvedAbsolutePath);
-      if (currentRouteRevisionRef.current !== routeRevision) {
-        return "unavailable";
-      }
-      resolvedPathKind = inspection?.kind === "file" || inspection?.kind === "directory"
-        ? inspection.kind
-        : null;
-      if (!resolvedPathKind) {
-        return "unavailable";
-      }
-    }
-
-    if (currentRouteRevisionRef.current !== routeRevision) {
+    if (currentRecoveryRevisionRef.current !== snapshot.recoveryRevision) return "unavailable";
+    if (outcome.status !== "match") {
+      setRecovery({
+        recoveryRevision: snapshot.recoveryRevision,
+        status: "terminal",
+        reason: outcome.status === "ambiguous"
+          ? "ambiguous_match"
+          : outcome.status === "search-error" ? "runtime_unavailable" : "not_found",
+      });
       return "unavailable";
     }
+    try {
+      const correctedStat = await statFile({
+        materializedWorkspaceId: snapshot.materializedWorkspaceId,
+        path: outcome.workspacePath,
+      });
+      if (currentRecoveryRevisionRef.current !== snapshot.recoveryRevision) return "unavailable";
+      const correctedKind = resolveWorkspaceStatPathKind(correctedStat);
+      if (correctedKind !== "file") {
+        setRecovery({
+          recoveryRevision: snapshot.recoveryRevision,
+          status: "terminal",
+          reason: "unsupported_type",
+        });
+        return "unavailable";
+      }
+      const corrected = resolveFileReference({
+        rawPath: snapshot.reference.rawPath,
+        workspacePathOverride: outcome.workspacePath,
+        workspaceRoot,
+        filesystemOrigin,
+        desktopBridgeAvailable: files !== null,
+      }).locator;
+      if (corrected.authority !== "workspace") {
+        setRecovery({
+          recoveryRevision: snapshot.recoveryRevision,
+          status: "terminal",
+          reason: "unexpected_kind",
+        });
+        return "unavailable";
+      }
+      setRecovery({
+        recoveryRevision: snapshot.recoveryRevision,
+        status: "settled",
+        locator: corrected,
+      });
+      return openViewer(corrected.workspacePath, snapshot) ? "open-viewer" : "unavailable";
+    } catch (error) {
+      setRecovery({
+        recoveryRevision: snapshot.recoveryRevision,
+        status: "terminal",
+        reason: fileReferenceAccessReason(error),
+      });
+      return "unavailable";
+    }
+  }, [files, filesystemOrigin, fuzzyResolve, openViewer, setRecovery, statFile, workspaceRoot]);
 
-    const action = resolveFileReferencePrimaryAction({
-      pathKind: resolvedPathKind,
-      canOpenViewer: Boolean(resolvedWorkspacePath),
-      canOpenExternal: Boolean(files && resolvedAbsolutePath),
-      canReveal: Boolean(files && resolvedAbsolutePath),
-    });
-    if (action === "reveal") {
-      try {
-        if (
-          !files
-          || !resolvedAbsolutePath
-          || resolvedPathKind !== "directory"
-          || currentRouteRevisionRef.current !== routeRevision
-        ) {
-          return "unavailable";
-        }
-        await files.reveal(resolvedAbsolutePath);
-      } catch {
-        setPrimaryOpenFailed(true);
+  const openPrimary = useCallback(async (): Promise<FileReferencePrimaryAction> => {
+    const snapshot = latestRef.current;
+    if (snapshot.routeRevision !== routeRevision) return "unavailable";
+    const state = snapshot.accessState;
+    if (state.status === "exact-missing") {
+      if (recoveryRef.current?.recoveryRevision === snapshot.recoveryRevision) {
         return "unavailable";
       }
-      setPathResolutionFailed(false);
-      setPrimaryOpenFailed(false);
-      return action;
+      return recoverMissing(state.locator, snapshot);
     }
-    if (action === "open-viewer") {
-      if (resolvedWorkspacePath) {
-        const target = fileViewerTarget(resolvedWorkspacePath);
-        openTarget(target);
-        if (materializedWorkspaceId) {
-          activateViewerTarget({
-            workspaceId: materializedWorkspaceId,
-            shellWorkspaceId: workspaceUiKey,
-            target,
-            mode: "open-or-focus",
-          });
-        }
-      }
-      setPathResolutionFailed(false);
-      setPrimaryOpenFailed(false);
-      return action;
+    if (state.status !== "settled") return "unavailable";
+    if (state.locator.authority === "workspace") {
+      if (state.kind !== "file") return "unavailable";
+      return openViewer(state.locator.workspacePath, snapshot) ? "open-viewer" : "unavailable";
     }
-    if (action === "open-external") {
-      if (
-        !resolvedAbsolutePath
-        || !resolvedPathKind
-        || currentRouteRevisionRef.current !== routeRevision
-      ) {
-        return "unavailable";
-      }
-      const opened = await openInDefaultEditor(resolvedAbsolutePath, resolvedPathKind);
-      if (!opened) {
-        setPrimaryOpenFailed(true);
-        return "unavailable";
-      }
-      setPathResolutionFailed(false);
-      setPrimaryOpenFailed(false);
-      return action;
+    if (state.kind === "directory") {
+      await nativeActions.reveal();
+      return "reveal";
     }
-    return action;
-  }, [
-    files,
-    activateViewerTarget,
-    fuzzyResolveFilePath,
-    ensureDesktopPathInspection,
-    materializedWorkspaceId,
-    needsHomeDirectory,
-    openInDefaultEditor,
-    openTarget,
-    pathKind,
-    rawPath,
-    reference.absolutePath,
-    reference.workspacePath,
-    resolveAbsolute,
-    resolveHomeDirectory,
-    routeRevision,
-    statWorkspacePath,
-    statQuery,
-    workspacePath,
-    workspaceRoot,
-    workspaceUiKey,
-  ]);
+    const opened = await nativeActions.openDefault();
+    setFailedPrimaryRoute(opened ? null : routeRevision);
+    return opened ? "open-external" : "unavailable";
+  }, [nativeActions, openViewer, recoverMissing, routeRevision]);
+
+  const canOpenInSidebar = accessState.status === "settled"
+    && accessState.kind === "file"
+    && accessState.locator.authority === "workspace";
+  const canOpenPrimary = canOpenInSidebar
+    || (accessState.status === "settled" && accessState.locator.authority === "desktop")
+    || accessState.status === "exact-missing";
+  const pathKindPending = home.pending
+    || accessState.status === "pending"
+    || accessState.status === "recovering";
 
   return {
     reference,
-    openTargets,
+    accessState,
+    nativePathKind,
+    openTargets: nativeActions.openTargets,
     defaultOpenTarget,
     pathKind,
     pathKindPending,
     canOpenInSidebar,
-    canOpenExternal,
+    canOpenExternal: externalOpenCapability !== null,
     canOpenPrimary,
-    canReveal,
-    primaryUnavailableReason,
+    canReveal: nativeCapability !== null,
+    primaryUnavailableReason: failedPrimaryRoute === routeRevision
+      ? "Could not open this path. Click to retry."
+      : fileReferenceUnavailableCopy(accessState),
     copyPath,
+    copyCurrentPath,
     openInSidebar,
-    openDefault,
+    openDefault: nativeActions.openDefault,
     openPrimary,
-    openWithTarget,
-    reveal,
+    openWithTarget: nativeActions.openWithTarget,
+    reveal: nativeActions.reveal,
   };
 }

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-fuzzy-file-resolver.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-fuzzy-file-resolver.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fuzzyOutcome,
+  useFuzzyFileResolver,
+} from "#product/hooks/workspaces/workflows/files/use-fuzzy-file-resolver";
+
+const mocks = vi.hoisted(() => ({ searchFiles: vi.fn() }));
+
+vi.mock("#product/hooks/access/anyharness/files/use-workspace-file-lookup", () => ({
+  useWorkspaceFileLookup: () => ({ searchFiles: mocks.searchFiles, statFile: vi.fn() }),
+}));
+
+describe("fuzzyOutcome", () => {
+  it("includes exact matches and retains runtime casing", () => {
+    expect(fuzzyOutcome("src/app.ts", ["src/App.ts"])).toEqual({
+      status: "match",
+      workspacePath: "src/App.ts",
+    });
+  });
+
+  it("distinguishes zero and ambiguous suffix matches", () => {
+    expect(fuzzyOutcome("src/app.ts", [])).toEqual({ status: "no-match" });
+    expect(fuzzyOutcome("src/app.ts", ["a/src/App.ts", "b/src/app.ts"]))
+      .toEqual({ status: "ambiguous" });
+  });
+});
+
+describe("useFuzzyFileResolver", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("runs one basename search through the access hook", async () => {
+    mocks.searchFiles.mockResolvedValueOnce({ results: [{ path: "apps/web/src/App.tsx" }] });
+    const { result } = renderHook(() => useFuzzyFileResolver());
+
+    await expect(result.current({
+      workspacePath: "src/app.tsx",
+      materializedWorkspaceId: "workspace-1",
+    })).resolves.toEqual({ status: "match", workspacePath: "apps/web/src/App.tsx" });
+    expect(mocks.searchFiles).toHaveBeenCalledTimes(1);
+    expect(mocks.searchFiles).toHaveBeenCalledWith({
+      materializedWorkspaceId: "workspace-1",
+      query: "app.tsx",
+    });
+  });
+
+  it("returns an explicit search error without retrying", async () => {
+    mocks.searchFiles.mockRejectedValueOnce(new Error("offline"));
+    const { result } = renderHook(() => useFuzzyFileResolver());
+    await expect(result.current({
+      workspacePath: "src/App.tsx",
+      materializedWorkspaceId: "workspace-1",
+    })).resolves.toEqual({ status: "search-error" });
+    expect(mocks.searchFiles).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-fuzzy-file-resolver.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-fuzzy-file-resolver.ts
@@ -1,57 +1,50 @@
 import { useCallback } from "react";
-import {
-  resolveWorkspaceConnectionFromContext,
-  useAnyHarnessWorkspaceContext,
-} from "@anyharness/sdk-react";
-import { searchWorkspaceFiles } from "#product/lib/access/anyharness/workspace-file-transport";
-import { splitPathLineSuffix } from "#product/lib/domain/files/path-detection";
-import { pickFuzzyPathMatch } from "#product/lib/domain/files/path-references";
+import { useWorkspaceFileLookup } from "#product/hooks/access/anyharness/files/use-workspace-file-lookup";
+import { fileReferenceBasename } from "#product/lib/domain/files/path-references";
 
-/**
- * Backstop for slightly-wrong file references: when a workspace path does not
- * resolve to a real file (e.g. an agent dropped leading directories, producing
- * `content/ui/MarkdownRenderer.tsx` instead of the full path), search by
- * basename and return the unique workspace file whose path ends with the given
- * suffix. Best-effort — returns null when the path already exists, the match is
- * ambiguous, or the search fails. Runs lazily on open, never per render.
- */
+export type FuzzyFileResolutionOutcome =
+  | { status: "match"; workspacePath: string }
+  | { status: "no-match" }
+  | { status: "ambiguous" }
+  | { status: "search-error" };
+
+/** One bounded basename search; corrected stat remains owned by the action hook. */
 export function useFuzzyFileResolver() {
-  const workspace = useAnyHarnessWorkspaceContext();
-  return useCallback(
-    async (input: {
-      workspacePath: string;
-      materializedWorkspaceId: string | null;
-    }): Promise<string | null> => {
-      if (!input.materializedWorkspaceId) {
-        return null;
-      }
-      const targetPath = splitPathLineSuffix(input.workspacePath).path;
-      const basename = targetPath.split("/").filter(Boolean).pop();
-      if (!basename) {
-        return null;
-      }
-      try {
-        const { connection } = await resolveWorkspaceConnectionFromContext(
-          workspace,
-          input.materializedWorkspaceId,
-        );
-        // High limit (server caps at 200): a basename can match many files, and
-        // truncating the real one out would defeat the "already exists" guard
-        // and risk correcting a valid path to the wrong file.
-        const response = await searchWorkspaceFiles(
-          connection,
-          connection.anyharnessWorkspaceId,
-          basename,
-          200,
-        );
-        return pickFuzzyPathMatch(
-          targetPath,
-          (response.results ?? []).map((result) => result.path),
-        );
-      } catch {
-        return null;
-      }
-    },
-    [workspace],
-  );
+  const { searchFiles } = useWorkspaceFileLookup();
+
+  return useCallback(async ({
+    workspacePath,
+    materializedWorkspaceId,
+  }: {
+    workspacePath: string;
+    materializedWorkspaceId: string;
+  }): Promise<FuzzyFileResolutionOutcome> => {
+    const basename = fileReferenceBasename(workspacePath);
+    if (!basename || !workspacePath) return { status: "no-match" };
+
+    try {
+      const response = await searchFiles({ materializedWorkspaceId, query: basename });
+      return fuzzyOutcome(
+        workspacePath,
+        (response.results ?? []).map((result) => result.path),
+      );
+    } catch {
+      return { status: "search-error" };
+    }
+  }, [searchFiles]);
+}
+
+export function fuzzyOutcome(
+  requestedPath: string,
+  candidates: readonly string[],
+): FuzzyFileResolutionOutcome {
+  const requested = requestedPath.toLowerCase();
+  const suffix = `/${requested}`;
+  const matches = candidates.filter((candidate) => {
+    const normalized = candidate.toLowerCase();
+    return normalized === requested || normalized.endsWith(suffix);
+  });
+  if (matches.length === 0) return { status: "no-match" };
+  if (matches.length > 1) return { status: "ambiguous" };
+  return { status: "match", workspacePath: matches[0] };
 }

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-home-relative-file-reference.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-home-relative-file-reference.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { DesktopFilesBridge } from "@proliferate/product-client/host/desktop-bridge";
+import { useHomeRelativeFileReference } from "#product/hooks/workspaces/workflows/files/use-home-relative-file-reference";
+
+function bridge(getHomeDirectory = vi.fn(async () => "/Users/pablo/")) {
+  return { getHomeDirectory } as unknown as DesktopFilesBridge;
+}
+
+describe("useHomeRelativeFileReference", () => {
+  it("normalizes a valid native home for an authority-gated candidate", async () => {
+    const files = bridge();
+    const { result } = renderHook(() => useHomeRelativeFileReference({
+      files,
+      candidatePath: "~/.config/file",
+    }));
+    await waitFor(() => expect(result.current.homeDirectory).toBe("/Users/pablo"));
+    expect(files.getHomeDirectory).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["", "relative", "/bad/../home", "/bad\0home"])(
+    "rejects and does not cache invalid native home %s",
+    async (nativeHome) => {
+      const getHomeDirectory = vi.fn(async () => nativeHome);
+      const files = bridge(getHomeDirectory);
+      const { result } = renderHook(() => useHomeRelativeFileReference({
+        files,
+        candidatePath: "~/file",
+      }));
+      await waitFor(() => expect(result.current.rejected).toBe(true));
+      await act(async () => {
+        await expect(result.current.resolveHomeDirectory()).resolves.toBeNull();
+      });
+      expect(getHomeDirectory).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("performs zero lookup when the caller supplies no authority-gated candidate", () => {
+    const files = bridge();
+    const { result } = renderHook(() => useHomeRelativeFileReference({
+      files,
+      candidatePath: null,
+    }));
+    expect(result.current).toMatchObject({ homeDirectory: null, pending: false, rejected: false });
+    expect(files.getHomeDirectory).not.toHaveBeenCalled();
+  });
+
+  it("drops a stale completion after candidate and bridge change", async () => {
+    let resolveOld!: (path: string) => void;
+    const oldFiles = bridge(vi.fn(() => new Promise<string>((resolve) => {
+      resolveOld = resolve;
+    })));
+    const newFiles = bridge(vi.fn(async () => "/Users/new"));
+    const { result, rerender } = renderHook(
+      ({ files, candidatePath }) => useHomeRelativeFileReference({ files, candidatePath }),
+      { initialProps: { files: oldFiles, candidatePath: "~/old" as string | null } },
+    );
+    await waitFor(() => expect(oldFiles.getHomeDirectory).toHaveBeenCalledTimes(1));
+    rerender({ files: newFiles, candidatePath: "~/new" });
+    await waitFor(() => expect(result.current.homeDirectory).toBe("/Users/new"));
+    await act(async () => resolveOld("/Users/old"));
+    expect(result.current.homeDirectory).toBe("/Users/new");
+  });
+});

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-home-relative-file-reference.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-home-relative-file-reference.ts
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { DesktopFilesBridge } from "@proliferate/product-client/host/desktop-bridge";
-import { isHomeRelativeFileReference } from "#product/lib/domain/files/path-references";
+import { normalizeRuntimeWorkspaceRoot } from "#product/lib/domain/files/path-references";
 
 const cachedHomeDirectoryPromises = new WeakMap<DesktopFilesBridge, Promise<string>>();
 
@@ -8,11 +8,9 @@ function loadHomeDirectory(files: DesktopFilesBridge): Promise<string> {
   let promise = cachedHomeDirectoryPromises.get(files);
   if (!promise) {
     promise = files.getHomeDirectory().then((path) => {
-      const trimmed = path.trim();
-      if (!trimmed) {
-        throw new Error("Desktop home directory is unavailable.");
-      }
-      return trimmed;
+      const normalized = normalizeRuntimeWorkspaceRoot(path);
+      if (!normalized) throw new Error("Desktop home directory is unavailable.");
+      return normalized;
     });
     cachedHomeDirectoryPromises.set(files, promise);
     void promise.catch(() => {
@@ -24,74 +22,104 @@ function loadHomeDirectory(files: DesktopFilesBridge): Promise<string> {
   return promise;
 }
 
-export function useHomeRelativeFileReference(
-  files: DesktopFilesBridge | null,
-  rawPath: string,
-) {
-  const needsHomeDirectory = isHomeRelativeFileReference(rawPath);
-  const [homeDirectory, setHomeDirectory] = useState<string | null>(null);
-  const [pending, setPending] = useState(false);
-  const [rejected, setRejected] = useState(false);
+interface HomeResolution {
+  files: DesktopFilesBridge;
+  candidatePath: string;
+  homeDirectory: string | null;
+  pending: boolean;
+  rejected: boolean;
+}
+
+/** Resolve only an already authority-gated home-relative candidate. */
+export function useHomeRelativeFileReference({
+  files,
+  candidatePath,
+}: {
+  files: DesktopFilesBridge | null;
+  candidatePath: string | null;
+}) {
+  const routeRef = useRef({ files, candidatePath });
+  routeRef.current = { files, candidatePath };
+  const [resolution, setResolution] = useState<HomeResolution | null>(null);
+  const current = files
+    && candidatePath
+    && resolution?.files === files
+    && resolution.candidatePath === candidatePath
+    ? resolution
+    : null;
 
   useEffect(() => {
     let cancelled = false;
-    if (!needsHomeDirectory || !files) {
-      setHomeDirectory(null);
-      setPending(false);
-      setRejected(false);
+    if (!candidatePath || !files) {
+      setResolution(null);
       return;
     }
 
-    setHomeDirectory(null);
-    setPending(true);
-    setRejected(false);
+    const pending: HomeResolution = {
+      files,
+      candidatePath,
+      homeDirectory: null,
+      pending: true,
+      rejected: false,
+    };
+    setResolution(pending);
     void loadHomeDirectory(files).then(
-      (path) => {
-        if (!cancelled) {
-          setHomeDirectory(path);
-          setRejected(false);
-        }
+      (homeDirectory) => {
+        if (!cancelled) setResolution({ ...pending, homeDirectory, pending: false });
       },
       () => {
-        if (!cancelled) {
-          setHomeDirectory(null);
-          setRejected(true);
-        }
+        if (!cancelled) setResolution({ ...pending, pending: false, rejected: true });
       },
-    ).finally(() => {
-      if (!cancelled) setPending(false);
-    });
+    );
     return () => {
       cancelled = true;
     };
-  }, [files, needsHomeDirectory]);
+  }, [candidatePath, files]);
 
   const resolveHomeDirectory = useCallback(async () => {
-    if (!needsHomeDirectory || !files) {
-      return null;
-    }
-    if (rejected) {
-      return null;
-    }
-    if (homeDirectory) {
-      return homeDirectory;
-    }
+    const route = routeRef.current;
+    if (!route.candidatePath || !route.files) return null;
+    const active = resolution?.files === route.files
+      && resolution.candidatePath === route.candidatePath
+      ? resolution
+      : null;
+    if (active?.rejected) return null;
+    if (active?.homeDirectory) return active.homeDirectory;
     try {
-      const path = await loadHomeDirectory(files);
-      setHomeDirectory(path);
-      setRejected(false);
-      return path;
+      const homeDirectory = await loadHomeDirectory(route.files);
+      if (
+        routeRef.current.files !== route.files
+        || routeRef.current.candidatePath !== route.candidatePath
+      ) return null;
+      setResolution({
+        files: route.files,
+        candidatePath: route.candidatePath,
+        homeDirectory,
+        pending: false,
+        rejected: false,
+      });
+      return homeDirectory;
     } catch {
-      setRejected(true);
+      if (
+        routeRef.current.files === route.files
+        && routeRef.current.candidatePath === route.candidatePath
+      ) {
+        setResolution({
+          files: route.files,
+          candidatePath: route.candidatePath,
+          homeDirectory: null,
+          pending: false,
+          rejected: true,
+        });
+      }
       return null;
     }
-  }, [files, homeDirectory, needsHomeDirectory, rejected]);
+  }, [resolution]);
 
   return {
-    homeDirectory,
-    needsHomeDirectory,
-    pending,
-    rejected,
+    homeDirectory: current?.homeDirectory ?? null,
+    pending: Boolean(files && candidatePath && (!current || current.pending)),
+    rejected: current?.rejected ?? false,
     resolveHomeDirectory,
   };
 }

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/selection/connection.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/selection/connection.test.ts
@@ -75,8 +75,13 @@ describe("resolveSelectionConnection", () => {
     } satisfies DesktopRuntimeBridge;
     mocks.ensureRuntimeReady.mockResolvedValue("http://runtime.test");
     mocks.resolveWorkspaceConnection.mockResolvedValue({
-      runtimeUrl: "http://runtime.test",
-      anyharnessWorkspaceId: "workspace-runtime",
+      connection: {
+        runtimeUrl: "http://runtime.test",
+        anyharnessWorkspaceId: "workspace-runtime",
+        runtimeGeneration: 0,
+        runtimeAccessKind: "direct",
+      },
+      filesystemOrigin: "desktop-local",
     });
 
     const result = await resolveSelectionConnection(
@@ -93,6 +98,12 @@ describe("resolveSelectionConnection", () => {
       null,
     );
     expect(result.runtimeUrl).toBe("http://runtime.test");
+    expect(result.workspaceConnection).toEqual({
+      runtimeUrl: "http://runtime.test",
+      anyharnessWorkspaceId: "workspace-runtime",
+      runtimeGeneration: 0,
+      runtimeAccessKind: "direct",
+    });
   });
 
   it("does not discover a local runtime for an SSH target workspace", async () => {
@@ -103,11 +114,15 @@ describe("resolveSelectionConnection", () => {
       ensureTunnel: vi.fn(),
     } satisfies DesktopSshBridge;
     mocks.resolveWorkspaceConnection.mockResolvedValue({
-      runtimeUrl: "https://target.test",
-      anyharnessWorkspaceId: "workspace-runtime",
+      connection: {
+        runtimeUrl: "https://target.test",
+        anyharnessWorkspaceId: "workspace-runtime",
+        runtimeGeneration: 0,
+      },
+      filesystemOrigin: "remote",
     });
 
-    await resolveSelectionConnection(
+    const result = await resolveSelectionConnection(
       deps(null, vi.fn(), ssh),
       context("target:target-1:workspace-runtime"),
       { kind: "local" },
@@ -120,6 +135,11 @@ describe("resolveSelectionConnection", () => {
       ssh,
       null,
     );
+    expect(result.workspaceConnection).toEqual({
+      runtimeUrl: "https://target.test",
+      anyharnessWorkspaceId: "workspace-runtime",
+      runtimeGeneration: 0,
+    });
   });
 
   it("does not discover a local runtime for a Cloud workspace", async () => {
@@ -127,6 +147,8 @@ describe("resolveSelectionConnection", () => {
       runtimeUrl: "https://cloud.test",
       accessToken: "cloud-token",
       anyharnessWorkspaceId: "workspace-runtime",
+      runtimeGeneration: 8,
+      webSocketAuthTransport: "protocol",
     });
 
     const result = await resolveSelectionConnection(
@@ -141,6 +163,9 @@ describe("resolveSelectionConnection", () => {
       runtimeUrl: "https://cloud.test",
       authToken: "cloud-token",
       anyharnessWorkspaceId: "workspace-runtime",
+      runtimeGeneration: 8,
+      runtimeAccessKind: "proliferate-gateway",
+      webSocketAuthTransport: "protocol",
     });
   });
 });

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/selection/connection.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/selection/connection.ts
@@ -35,12 +35,20 @@ export async function resolveSelectionConnection(
 
   const connectionStartedAt = startLatencyTimer();
   const workspaceConnection = cloudReadiness.kind === "local"
-    ? await resolveWorkspaceConnection(desktopRuntimeUrl, localWorkspaceId, deps.ssh ?? null, deps.cloudClient)
+    ? (await resolveWorkspaceConnection(
+      desktopRuntimeUrl,
+      localWorkspaceId,
+      deps.ssh ?? null,
+      deps.cloudClient,
+    )).connection
     : await deps.cache.refreshCloudWorkspaceConnection(cloudReadiness.cloudWorkspaceId)
       .then((connection) => ({
         runtimeUrl: connection.runtimeUrl,
         authToken: connection.accessToken ?? undefined,
         anyharnessWorkspaceId: connection.anyharnessWorkspaceId ?? "",
+        runtimeGeneration: connection.runtimeGeneration,
+        runtimeAccessKind: "proliferate-gateway" as const,
+        webSocketAuthTransport: connection.webSocketAuthTransport,
       }));
   logLatency("workspace.select.connection_resolved", {
     workspaceId: context.workspaceId,

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-hot-workspace-reopen.test.ts
@@ -29,6 +29,7 @@ describe("runHotWorkspaceReopen", () => {
       workspaceConnection: {
         runtimeUrl: "http://runtime.test",
         anyharnessWorkspaceId: "workspace-1",
+        runtimeGeneration: 0,
       },
     });
     useSessionSelectionStore.setState({

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-workspace-selection-catalog-parallelization.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-workspace-selection-catalog-parallelization.test.ts
@@ -50,6 +50,7 @@ describe("runWorkspaceSelection agent-catalog parallelization", () => {
       workspaceConnection: {
         runtimeUrl: "http://runtime.test",
         anyharnessWorkspaceId: "ah-workspace",
+        runtimeGeneration: 0,
       },
     });
   });
@@ -63,6 +64,7 @@ describe("runWorkspaceSelection agent-catalog parallelization", () => {
         workspaceConnection: {
           runtimeUrl: "http://runtime.test",
           anyharnessWorkspaceId: "ah-workspace",
+          runtimeGeneration: 0,
         },
       };
     });

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-workspace-selection-staleness-abort.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-workspace-selection-staleness-abort.test.ts
@@ -66,6 +66,7 @@ describe("runWorkspaceSelection staleness abort", () => {
       workspaceConnection: {
         runtimeUrl: "http://runtime.test",
         anyharnessWorkspaceId: "ah-workspace",
+        runtimeGeneration: 0,
       },
     });
 

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-workspace-selection.test.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/selection/run-workspace-selection.test.ts
@@ -129,6 +129,7 @@ describe("runWorkspaceSelection", () => {
       workspaceConnection: {
         runtimeUrl: "http://runtime.test",
         anyharnessWorkspaceId: "ah-fresh-local",
+        runtimeGeneration: 0,
       },
     });
     const knownWorkspace = {
@@ -276,6 +277,7 @@ describe("runWorkspaceSelection", () => {
       workspaceConnection: {
         runtimeUrl: "http://runtime.test",
         anyharnessWorkspaceId: "ah-workspace-1",
+        runtimeGeneration: 0,
       },
     });
     useWorkspaceUiStore.setState({
@@ -319,6 +321,7 @@ describe("runWorkspaceSelection", () => {
       workspaceConnection: {
         runtimeUrl: "http://runtime.test",
         anyharnessWorkspaceId: "ah-workspace-1",
+        runtimeGeneration: 0,
       },
     });
     const staleSlotId = buildLocalSlotLogicalWorkspaceId("workspace-1");
@@ -358,6 +361,7 @@ describe("runWorkspaceSelection", () => {
       workspaceConnection: {
         runtimeUrl: "http://runtime.test",
         anyharnessWorkspaceId: "ah-workspace-1",
+        runtimeGeneration: 0,
       },
     });
     useWorkspaceUiStore.setState({
@@ -397,6 +401,7 @@ describe("runWorkspaceSelection", () => {
       workspaceConnection: {
         runtimeUrl: "http://runtime.test",
         anyharnessWorkspaceId: "ah-workspace-1",
+        runtimeGeneration: 0,
       },
     });
 
@@ -428,6 +433,7 @@ describe("runWorkspaceSelection", () => {
       workspaceConnection: {
         runtimeUrl: "http://runtime.test",
         anyharnessWorkspaceId: "ah-workspace-1",
+        runtimeGeneration: 0,
       },
     });
     const bootstrapWorkspace = vi.fn().mockResolvedValue({ sessions: [] });
@@ -466,6 +472,7 @@ describe("runWorkspaceSelection", () => {
       workspaceConnection: {
         runtimeUrl: "http://runtime.test",
         anyharnessWorkspaceId: "ah-workspace-1",
+        runtimeGeneration: 0,
       },
     });
     const pendingEntry = {

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/selection/types.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/selection/types.ts
@@ -8,6 +8,9 @@ import type { WorkspaceSession } from "#product/hooks/access/anyharness/sessions
 import type { LogicalWorkspace } from "#product/lib/domain/workspaces/cloud/logical-workspace-model";
 import type { CloudSandboxGatewayUrlSource } from "#product/lib/access/cloud/cloud-sandbox-gateway";
 import type { ClearSelectionOptions } from "#product/stores/sessions/session-selection-store";
+import type {
+  ProductAnyHarnessResolvedConnection,
+} from "#product/lib/access/anyharness/resolve-workspace-connection";
 
 export interface WorkspaceSelectionOptions {
   force?: boolean;
@@ -69,6 +72,8 @@ export interface WorkspaceSelectionDeps {
       runtimeUrl: string;
       accessToken?: string | null;
       anyharnessWorkspaceId?: string | null;
+      runtimeGeneration: number;
+      webSocketAuthTransport?: "protocol";
     }>;
   };
   /**
@@ -124,6 +129,6 @@ export type ReadyCloudReadinessResult = Extract<
 
 export interface WorkspaceConnectionResult {
   runtimeUrl: string;
-  workspaceConnection: AnyHarnessResolvedConnection;
+  workspaceConnection: ProductAnyHarnessResolvedConnection;
   materializedWorkspaceId?: string | null;
 }

--- a/apps/packages/product-client/src/lib/access/anyharness/resolve-workspace-connection.test.ts
+++ b/apps/packages/product-client/src/lib/access/anyharness/resolve-workspace-connection.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  resolveRuntimeTargetForWorkspace: vi.fn(),
+}));
+
+vi.mock("#product/lib/access/anyharness/runtime-target", () => ({
+  resolveRuntimeTargetForWorkspace: mocks.resolveRuntimeTargetForWorkspace,
+}));
+
+import { resolveWorkspaceConnection } from "#product/lib/access/anyharness/resolve-workspace-connection";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("resolveWorkspaceConnection", () => {
+  it.each([
+    {
+      location: "local" as const,
+      expectedOrigin: "desktop-local" as const,
+      runtimeAccessKind: "direct" as const,
+      webSocketAuthTransport: undefined,
+    },
+    {
+      location: "cloud" as const,
+      expectedOrigin: "remote" as const,
+      runtimeAccessKind: "proliferate-gateway" as const,
+      webSocketAuthTransport: "protocol" as const,
+    },
+    {
+      location: "target" as const,
+      expectedOrigin: "remote" as const,
+      runtimeAccessKind: undefined,
+      webSocketAuthTransport: undefined,
+    },
+  ])("maps $location provenance without narrowing connection metadata", async ({
+    location,
+    expectedOrigin,
+    runtimeAccessKind,
+    webSocketAuthTransport,
+  }) => {
+    mocks.resolveRuntimeTargetForWorkspace.mockResolvedValue({
+      location,
+      baseUrl: `https://${location}.runtime.test`,
+      authToken: `${location}-token`,
+      anyharnessWorkspaceId: `${location}-workspace`,
+      runtimeGeneration: 7,
+      runtimeAccessKind,
+      webSocketAuthTransport,
+    });
+
+    await expect(resolveWorkspaceConnection(
+      "http://local.runtime.test",
+      `${location}-selected`,
+      null,
+      null,
+    )).resolves.toEqual({
+      connection: {
+        runtimeUrl: `https://${location}.runtime.test`,
+        authToken: `${location}-token`,
+        anyharnessWorkspaceId: `${location}-workspace`,
+        runtimeGeneration: 7,
+        runtimeAccessKind,
+        webSocketAuthTransport,
+      },
+      filesystemOrigin: expectedOrigin,
+    });
+  });
+});

--- a/apps/packages/product-client/src/lib/access/anyharness/resolve-workspace-connection.ts
+++ b/apps/packages/product-client/src/lib/access/anyharness/resolve-workspace-connection.ts
@@ -2,18 +2,24 @@ import type { AnyHarnessResolvedConnection } from "@anyharness/sdk-react";
 import type { DesktopSshBridge } from "@proliferate/product-client/host/desktop-bridge";
 import type { CloudSandboxGatewayUrlSource } from "#product/lib/access/cloud/cloud-sandbox-gateway";
 import { resolveRuntimeTargetForWorkspace } from "#product/lib/access/anyharness/runtime-target";
+import type { WorkspaceFilesystemOrigin } from "#product/lib/domain/files/path-references";
 
-export type AnyHarnessDesktopResolvedConnection = AnyHarnessResolvedConnection & {
-  runtimeGeneration?: number;
+export type ProductAnyHarnessResolvedConnection = AnyHarnessResolvedConnection & {
+  runtimeGeneration: number;
   runtimeAccessKind?: "direct" | "proliferate-gateway";
 };
+
+export interface ProductResolvedWorkspaceConnection {
+  connection: ProductAnyHarnessResolvedConnection;
+  filesystemOrigin: WorkspaceFilesystemOrigin;
+}
 
 export async function resolveWorkspaceConnection(
   runtimeUrl: string,
   workspaceId: string,
   ssh: DesktopSshBridge | null,
   cloudClient: CloudSandboxGatewayUrlSource | null,
-): Promise<AnyHarnessDesktopResolvedConnection> {
+): Promise<ProductResolvedWorkspaceConnection> {
   const target = await resolveRuntimeTargetForWorkspace(
     runtimeUrl,
     workspaceId,
@@ -21,11 +27,14 @@ export async function resolveWorkspaceConnection(
     cloudClient,
   );
   return {
-    runtimeUrl: target.baseUrl,
-    authToken: target.authToken,
-    webSocketAuthTransport: target.webSocketAuthTransport,
-    anyharnessWorkspaceId: target.anyharnessWorkspaceId,
-    runtimeGeneration: target.runtimeGeneration,
-    runtimeAccessKind: target.runtimeAccessKind,
+    connection: {
+      runtimeUrl: target.baseUrl,
+      authToken: target.authToken,
+      webSocketAuthTransport: target.webSocketAuthTransport,
+      anyharnessWorkspaceId: target.anyharnessWorkspaceId,
+      runtimeGeneration: target.runtimeGeneration,
+      runtimeAccessKind: target.runtimeAccessKind,
+    },
+    filesystemOrigin: target.location === "local" ? "desktop-local" : "remote",
   };
 }

--- a/apps/packages/product-client/src/lib/access/anyharness/runtime-target.test.ts
+++ b/apps/packages/product-client/src/lib/access/anyharness/runtime-target.test.ts
@@ -55,8 +55,10 @@ describe("resolveRuntimeTargetForWorkspace", () => {
       location: "target",
       baseUrl: "http://127.0.0.1:43210",
       anyharnessWorkspaceId: "workspace-7",
+      runtimeGeneration: 0,
       targetId: "target-1",
     });
+    expect(target).not.toHaveProperty("runtimeAccessKind");
   });
 
   it("fails closed for a target without a Desktop SSH bridge", async () => {
@@ -71,16 +73,19 @@ describe("resolveRuntimeTargetForWorkspace", () => {
   it("does not use SSH when resolving a local workspace", async () => {
     const ssh = makeSshBridge();
 
-    await expect(resolveRuntimeTargetForWorkspace(
+    const target = await resolveRuntimeTargetForWorkspace(
       "http://runtime.test",
       "workspace-local",
       ssh,
       null,
-    )).resolves.toMatchObject({
+    );
+    expect(target).toMatchObject({
       location: "local",
       baseUrl: "http://runtime.test",
       anyharnessWorkspaceId: "workspace-local",
+      runtimeGeneration: 0,
     });
+    expect(target).not.toHaveProperty("runtimeAccessKind");
     expect(ssh.getProfile).not.toHaveBeenCalled();
     expect(ssh.ensureTunnel).not.toHaveBeenCalled();
   });

--- a/apps/packages/product-client/src/lib/domain/files/path-references.test.ts
+++ b/apps/packages/product-client/src/lib/domain/files/path-references.test.ts
@@ -1,236 +1,228 @@
 import { describe, expect, it } from "vitest";
 import {
-  fileReferenceBasename,
+  fileReferenceCopyPath,
   inlineFileReferenceLabel,
+  normalizeRuntimeWorkspaceRoot,
   pickFuzzyPathMatch,
   resolveFileReference,
-  resolveFileReferencePrimaryAction,
+  resolveWorkspaceStatPathKind,
+  type RuntimeWorkspaceRootState,
+  type WorkspaceFilesystemOriginState,
 } from "#product/lib/domain/files/path-references";
 
-describe("pickFuzzyPathMatch", () => {
-  const tree = [
-    "apps/desktop/src/components/content/ui/MarkdownRenderer.tsx",
-    "apps/desktop/src/components/content/ui/FilePathLink.tsx",
-    "apps/desktop/src/lib/index.ts",
-    "server/src/lib/index.ts",
-  ];
+const ROOT: RuntimeWorkspaceRootState = { status: "settled", path: "/repo" };
+const LOCAL: WorkspaceFilesystemOriginState = {
+  status: "settled",
+  origin: "desktop-local",
+};
+const REMOTE: WorkspaceFilesystemOriginState = { status: "settled", origin: "remote" };
 
-  it("corrects a partial path to the unique suffix match", () => {
-    expect(pickFuzzyPathMatch("content/ui/MarkdownRenderer.tsx", tree))
-      .toBe("apps/desktop/src/components/content/ui/MarkdownRenderer.tsx");
+function resolve(overrides: Partial<Parameters<typeof resolveFileReference>[0]> = {}) {
+  return resolveFileReference({
+    rawPath: "src/App.tsx",
+    workspaceRoot: ROOT,
+    filesystemOrigin: LOCAL,
+    desktopBridgeAvailable: true,
+    ...overrides,
   });
-
-  it("returns null when the path already exists (exact match present)", () => {
-    expect(pickFuzzyPathMatch("apps/desktop/src/lib/index.ts", tree)).toBeNull();
-  });
-
-  it("returns null when the suffix is ambiguous", () => {
-    expect(pickFuzzyPathMatch("lib/index.ts", tree)).toBeNull();
-  });
-
-  it("returns null when nothing matches", () => {
-    expect(pickFuzzyPathMatch("nope/Missing.tsx", tree)).toBeNull();
-  });
-
-  it("matches case-insensitively but returns the real casing", () => {
-    expect(pickFuzzyPathMatch("content/ui/markdownrenderer.tsx", tree))
-      .toBe("apps/desktop/src/components/content/ui/MarkdownRenderer.tsx");
-  });
-});
+}
 
 describe("resolveFileReference", () => {
-  const resolveAbsolute = (path: string) => path.startsWith("/")
-    ? path
-    : `/repo/${path.startsWith("./") ? path.slice(2) : path}`;
-
-  it("resolves relative paths for sidebar opening while preserving absolute paths", () => {
-    expect(resolveFileReference({
-      rawPath: "./src/App.tsx:12",
-      workspaceRoot: "/repo",
-      resolveAbsolute,
-    })).toMatchObject({
-      path: "./src/App.tsx",
-      line: 12,
-      column: null,
-      absolutePath: "/repo/src/App.tsx",
-      workspacePath: "src/App.tsx",
+  it.each([
+    [".", ""],
+    ["./", ""],
+    ["./src/App.tsx:12:4", "src/App.tsx"],
+    ["src/./App.tsx", "src/App.tsx"],
+    ["/repo", ""],
+    ["/repo/", ""],
+    ["/repo/src/App.tsx", "src/App.tsx"],
+  ])("projects %s into workspace path %s", (rawPath, workspacePath) => {
+    expect(resolve({ rawPath })).toMatchObject({
+      displayPath: workspacePath || ".",
+      locator: {
+        authority: "workspace",
+        workspacePath,
+        localCompanionPath: workspacePath ? `/repo/${workspacePath}` : "/repo",
+      },
     });
   });
 
-  it("infers a relative workspace path when nullable metadata was omitted on the wire", () => {
-    expect(resolveFileReference({
-      rawPath: "src/App.tsx",
-      workspaceRoot: "/repo",
-      resolveAbsolute,
-      workspacePathOverride: null,
-    })).toMatchObject({
-      absolutePath: "/repo/src/App.tsx",
-      workspacePath: "src/App.tsx",
-    });
-  });
-
-  it("maps absolute paths under the workspace back to workspace-relative paths", () => {
-    expect(resolveFileReference({
-      rawPath: "/repo/src/App.tsx:12:4",
-      workspaceRoot: "/repo",
-      resolveAbsolute,
-    })).toMatchObject({
-      path: "/repo/src/App.tsx",
+  it("keeps line and column out of normalized and copied paths", () => {
+    const reference = resolve({ rawPath: " src/App.tsx:12:4 " });
+    expect(reference).toMatchObject({
+      parsedPath: "src/App.tsx",
+      displayPath: "src/App.tsx",
       line: 12,
       column: 4,
-      absolutePath: "/repo/src/App.tsx",
+    });
+    expect(fileReferenceCopyPath(reference)).toBe("/repo/src/App.tsx");
+  });
+
+  it("uses runtime root and provenance only for native companion capability", () => {
+    expect(resolve({ filesystemOrigin: REMOTE }).locator).toEqual({
+      authority: "workspace",
       workspacePath: "src/App.tsx",
+      localCompanionPath: null,
+    });
+    expect(resolve({ desktopBridgeAvailable: false }).locator).toEqual({
+      authority: "workspace",
+      workspacePath: "src/App.tsx",
+      localCompanionPath: null,
+    });
+    expect(resolve({ workspaceRoot: { status: "pending", path: null } }).locator).toEqual({
+      authority: "workspace",
+      workspacePath: "src/App.tsx",
+      localCompanionPath: null,
     });
   });
 
-  it("does not open external absolute paths in the workspace sidebar", () => {
-    expect(resolveFileReference({
-      rawPath: "/tmp/file.txt",
-      workspaceRoot: "/repo",
-      resolveAbsolute,
-      workspacePathOverride: null,
-    })).toMatchObject({
-      absolutePath: "/tmp/file.txt",
-      workspacePath: null,
-    });
-  });
-
-  it("expands a home-relative hidden path without treating it as a workspace path", () => {
-    expect(resolveFileReference({
-      rawPath: "~/.proliferate-local/dev/app/diagnostics-dev.env:12",
-      workspaceRoot: "/repo",
-      resolveAbsolute: () => null,
-      homeDirectory: "/Users/pablo/",
-    })).toMatchObject({
-      path: "~/.proliferate-local/dev/app/diagnostics-dev.env",
-      line: 12,
-      absolutePath: "/Users/pablo/.proliferate-local/dev/app/diagnostics-dev.env",
-      workspacePath: null,
-    });
-  });
-
-  it("normalizes absolute traversal before deciding workspace membership", () => {
-    expect(resolveFileReference({
-      rawPath: "/repo/sub/../../tmp/file.txt",
-      workspaceRoot: "/repo",
-      resolveAbsolute,
-      workspacePathOverride: null,
-    })).toMatchObject({
-      workspacePath: null,
-    });
-
-    expect(resolveFileReference({
-      rawPath: "/repo/src/../App.tsx",
-      workspaceRoot: "/repo",
-      resolveAbsolute,
-      workspacePathOverride: null,
-    })).toMatchObject({
-      workspacePath: "App.tsx",
-    });
-  });
-
-  it("rejects a relative path that escapes the workspace after normalization", () => {
-    expect(resolveFileReference({
-      rawPath: "src/../../tmp/file.txt",
-      workspaceRoot: "/repo",
-      resolveAbsolute,
-      workspacePathOverride: null,
-    })).toMatchObject({
-      workspacePath: null,
-    });
-  });
-});
-
-describe("resolveFileReferencePrimaryAction", () => {
   it.each([
-    [{
-      pathKind: "file" as const,
-      canOpenViewer: true,
-      canOpenExternal: true,
-      canReveal: true,
-    }, "open-viewer"],
-    [{
-      pathKind: "file" as const,
-      canOpenViewer: false,
-      canOpenExternal: true,
-      canReveal: true,
-    }, "open-external"],
-    [{
-      pathKind: "file" as const,
-      canOpenViewer: false,
-      canOpenExternal: false,
-      canReveal: true,
-    }, "unavailable"],
-    [{
-      pathKind: "directory" as const,
-      canOpenViewer: true,
-      canOpenExternal: true,
-      canReveal: true,
-    }, "reveal"],
-    [{
-      pathKind: "directory" as const,
-      canOpenViewer: true,
-      canOpenExternal: true,
-      canReveal: false,
-    }, "unavailable"],
-    [{
-      pathKind: null,
-      canOpenViewer: true,
-      canOpenExternal: true,
-      canReveal: true,
-    }, "unavailable"],
-  ])("routes %o to %s", (input, expected) => {
-    expect(resolveFileReferencePrimaryAction(input)).toBe(expected);
+    [REMOTE, true, "remote_filesystem"],
+    [{ status: "pending", origin: null } as const, true, "filesystem_origin_unavailable"],
+    [{ status: "rejected", origin: null } as const, true, "filesystem_origin_unavailable"],
+    [LOCAL, false, "native_host_required"],
+  ])("gates an external absolute path for %#", (filesystemOrigin, bridge, reason) => {
+    expect(resolve({
+      rawPath: "/tmp/file.txt",
+      filesystemOrigin,
+      desktopBridgeAvailable: bridge,
+    }).locator).toEqual({ authority: "unavailable", reason });
+  });
+
+  it("classifies authority-proven absolute and home-relative Desktop paths", () => {
+    expect(resolve({ rawPath: "/tmp/file.txt" }).locator).toEqual({
+      authority: "desktop",
+      absolutePath: "/tmp/file.txt",
+      syntax: "absolute",
+    });
+    expect(resolve({ rawPath: "~/.config/file", homeDirectory: "/Users/pablo/" }).locator)
+      .toEqual({
+        authority: "desktop",
+        absolutePath: "/Users/pablo/.config/file",
+        syntax: "home-relative",
+      });
+  });
+
+  it.each([undefined, null, "", "relative", "/bad/../home", "/bad\0home"])(
+    "fails closed for invalid native home %s",
+    (homeDirectory) => {
+      expect(resolve({ rawPath: "~/file", homeDirectory }).locator).toEqual({
+        authority: "unavailable",
+        reason: "home_unavailable",
+      });
+    },
+  );
+
+  it("does not reclassify a home expansion under the workspace", () => {
+    expect(resolve({ rawPath: "~/src/App.tsx", homeDirectory: "/repo" }).locator).toEqual({
+      authority: "desktop",
+      absolutePath: "/repo/src/App.tsx",
+      syntax: "home-relative",
+    });
+  });
+
+  it.each([
+    "https://example.com/file",
+    "file:/repo/a",
+    "mailto:a@b.test",
+    "//server/share",
+    "\\\\server\\share",
+    "\\rooted",
+    "#fragment",
+    "C:/repo/a",
+    "C:\\repo\\a",
+    "~user/file",
+    "~\\file",
+    "bad\0path",
+  ])("rejects raw unsupported syntax %s", (rawPath) => {
+    expect(resolve({ rawPath }).locator).toEqual({ authority: "unavailable", reason: "invalid" });
+  });
+
+  it.each(["../secret", "src/../secret", "/repo/src/../secret"])(
+    "rejects every traversal segment in %s",
+    (rawPath) => {
+      expect(resolve({ rawPath }).locator).toEqual({
+        authority: "unavailable",
+        reason: "traversal",
+      });
+    },
+  );
+
+  it("keeps absolute references unavailable while the runtime root is unknown", () => {
+    expect(resolve({
+      rawPath: "/repo/src/App.tsx",
+      workspaceRoot: { status: "unavailable", path: null },
+    }).locator).toEqual({ authority: "unavailable", reason: "workspace_root_unavailable" });
+  });
+
+  it("treats a supplied structured value as authoritative, including invalid strings", () => {
+    expect(resolve({
+      rawPath: "/tmp/file.txt",
+      workspacePathOverride: "src/App.tsx",
+    }).locator).toMatchObject({ authority: "workspace", workspacePath: "src/App.tsx" });
+    for (const workspacePathOverride of ["", "   ", "/repo/a", "~/a", "file:a", "#a"]) {
+      expect(resolve({ rawPath: "src/fallback.ts", workspacePathOverride }).locator)
+        .toEqual({ authority: "unavailable", reason: "invalid" });
+    }
+    expect(resolve({ rawPath: "src/fallback.ts", workspacePathOverride: "a/../b" }).locator)
+      .toEqual({ authority: "unavailable", reason: "traversal" });
+  });
+
+  it("maps structured dot paths to workspace root", () => {
+    expect(resolve({ rawPath: "/tmp/not-used", workspacePathOverride: "./" }).locator)
+      .toMatchObject({ authority: "workspace", workspacePath: "" });
+  });
+
+  it("uses neutral display and null copy data only for an empty reference", () => {
+    const empty = resolve({ rawPath: "  " });
+    expect(empty).toMatchObject({
+      parsedPath: "",
+      displayPath: "File",
+      locator: { authority: "unavailable", reason: "empty" },
+    });
+    expect(fileReferenceCopyPath(empty)).toBeNull();
+    expect(fileReferenceCopyPath(resolve({ rawPath: "../secret" }))).toBe("../secret");
+  });
+
+  it("supports / as an authoritative runtime root", () => {
+    const reference = resolve({
+      rawPath: "/src/App.tsx",
+      workspaceRoot: { status: "settled", path: "/" },
+    });
+    expect(reference.locator).toEqual({
+      authority: "workspace",
+      workspacePath: "src/App.tsx",
+      localCompanionPath: "/src/App.tsx",
+    });
   });
 });
 
-describe("inlineFileReferenceLabel", () => {
-  const resolveAbsolute = (path: string) => path;
-
-  it("renders a markdown link's path:line destination as basename plus line", () => {
-    const reference = resolveFileReference({
-      rawPath: "/Users/x/proliferate/docs/FORMATTING.md:7",
-      workspaceRoot: null,
-      resolveAbsolute,
-    });
-
-    expect(inlineFileReferenceLabel(reference)).toBe("FORMATTING.md (line 7)");
+describe("path helpers", () => {
+  it.each([
+    ["/", "/"],
+    ["/repo/./src/", "/repo/src"],
+    ["relative", null],
+    ["/repo/../tmp", null],
+    ["//server/share", null],
+  ])("normalizes runtime root %s", (input, expected) => {
+    expect(normalizeRuntimeWorkspaceRoot(input)).toBe(expected);
   });
 
-  it("prefers the workspace-relative basename when the reference is inside the workspace", () => {
-    const reference = resolveFileReference({
-      rawPath: "/repo/apps/web/src/App.tsx:42:8",
-      workspaceRoot: "/repo",
-      resolveAbsolute,
-    });
-
-    expect(inlineFileReferenceLabel(reference)).toBe("App.tsx (line 42)");
+  it("returns the unique fuzzy suffix including an exact candidate", () => {
+    expect(pickFuzzyPathMatch("src/app.ts", ["Src/App.ts"])).toBe("Src/App.ts");
+    expect(pickFuzzyPathMatch("src/app.ts", ["a/src/App.ts"])).toBe("a/src/App.ts");
+    expect(pickFuzzyPathMatch("src/app.ts", ["a/src/App.ts", "b/src/App.ts"])).toBeNull();
   });
 
-  it("keeps the path when there is no line to anchor on", () => {
-    const reference = resolveFileReference({
-      rawPath: "apps/web/src/App.tsx",
-      workspaceRoot: "/repo",
-      resolveAbsolute,
-    });
-
-    expect(inlineFileReferenceLabel(reference)).toBe("apps/web/src/App.tsx");
+  it("does not infer a symlink kind from size", () => {
+    expect(resolveWorkspaceStatPathKind({ kind: "file" })).toBe("file");
+    expect(resolveWorkspaceStatPathKind({ kind: "directory" })).toBe("directory");
+    expect(resolveWorkspaceStatPathKind({ kind: "symlink" })).toBeNull();
   });
 
-  it("tolerates a bare basename reference", () => {
-    expect(inlineFileReferenceLabel({
-      path: "FORMATTING.md",
-      workspacePath: null,
-      line: 7,
-    })).toBe("FORMATTING.md (line 7)");
-  });
-});
-
-describe("fileReferenceBasename", () => {
-  it("takes the last segment of posix and windows paths", () => {
-    expect(fileReferenceBasename("a/b/c.md")).toBe("c.md");
-    expect(fileReferenceBasename("a\\b\\c.md")).toBe("c.md");
-    expect(fileReferenceBasename("c.md")).toBe("c.md");
-    expect(fileReferenceBasename("a/b/")).toBe("b");
+  it("renders root and line labels from display paths", () => {
+    expect(inlineFileReferenceLabel({ displayPath: ".", line: null })).toBe(".");
+    expect(inlineFileReferenceLabel({ displayPath: "src/App.tsx", line: 4 }))
+      .toBe("App.tsx (line 4)");
   });
 });

--- a/apps/packages/product-client/src/lib/domain/files/path-references.ts
+++ b/apps/packages/product-client/src/lib/domain/files/path-references.ts
@@ -1,12 +1,50 @@
 import { splitPathLineSuffix } from "#product/lib/domain/files/path-detection";
 
+export type WorkspaceFilesystemOrigin = "desktop-local" | "remote";
+
+export type WorkspaceFilesystemOriginState =
+  | { status: "pending"; origin: null }
+  | { status: "settled"; origin: WorkspaceFilesystemOrigin }
+  | { status: "rejected"; origin: null };
+
+export type RuntimeWorkspaceRootState =
+  | { status: "pending"; path: null }
+  | { status: "settled"; path: string }
+  | { status: "unavailable"; path: null };
+
+export type FileReferenceUnavailableLocatorReason =
+  | "empty"
+  | "invalid"
+  | "traversal"
+  | "native_host_required"
+  | "remote_filesystem"
+  | "home_unavailable"
+  | "filesystem_origin_unavailable"
+  | "workspace_root_unavailable";
+
+export type ResolvedFileLocator =
+  | {
+      authority: "workspace";
+      workspacePath: string;
+      localCompanionPath: string | null;
+    }
+  | {
+      authority: "desktop";
+      absolutePath: string;
+      syntax: "absolute" | "home-relative";
+    }
+  | {
+      authority: "unavailable";
+      reason: FileReferenceUnavailableLocatorReason;
+    };
+
 export interface ResolvedFileReference {
   rawPath: string;
-  path: string;
+  parsedPath: string;
+  displayPath: string;
   line: number | null;
   column: number | null;
-  absolutePath: string | null;
-  workspacePath: string | null;
+  locator: ResolvedFileLocator;
 }
 
 export type FileReferencePathKind = "file" | "directory";
@@ -16,27 +54,38 @@ export type FileReferencePrimaryAction =
   | "reveal"
   | "unavailable";
 
-export function resolveWorkspaceStatPathKind(stat: {
-  kind: "file" | "directory" | "symlink";
-  sizeBytes?: number | null;
-} | undefined): FileReferencePathKind | null {
-  if (!stat) {
-    return null;
-  }
-  if (stat.kind !== "symlink") {
-    return stat.kind;
-  }
-  // AnyHarness stats symlinks after following the target: file targets carry
-  // a byte size (including zero), while directory targets do not.
-  return typeof stat.sizeBytes === "number" ? "file" : "directory";
+interface ResolveFileReferenceInput {
+  rawPath: string;
+  workspacePathOverride?: string | null;
+  workspaceRoot: RuntimeWorkspaceRootState;
+  filesystemOrigin: WorkspaceFilesystemOriginState;
+  desktopBridgeAvailable: boolean;
+  homeDirectory?: string | null;
 }
 
-/**
- * Keep primary file-reference behavior host-independent and fail closed while
- * the path kind is unknown. A directory must never be routed through the file
- * viewer, and an external file must use the configured external open target
- * rather than silently falling back to Finder.
- */
+/** Classify one rendered reference into exactly one filesystem authority. */
+export function resolveFileReference(args: ResolveFileReferenceInput): ResolvedFileReference {
+  const { path: parsedPath, line, column } = splitPathLineSuffix(args.rawPath.trim());
+  const locator = typeof args.workspacePathOverride === "string"
+    ? classifyStructuredWorkspacePath(args.workspacePathOverride, args)
+    : classifyRawPath(parsedPath, args);
+
+  return {
+    rawPath: args.rawPath,
+    parsedPath,
+    displayPath: displayPathForLocator(locator, parsedPath),
+    line,
+    column,
+    locator,
+  };
+}
+
+export function resolveWorkspaceStatPathKind(stat: {
+  kind: "file" | "directory" | "symlink";
+} | undefined): FileReferencePathKind | null {
+  return stat?.kind === "file" || stat?.kind === "directory" ? stat.kind : null;
+}
+
 export function resolveFileReferencePrimaryAction(args: {
   pathKind: FileReferencePathKind | null;
   canOpenViewer: boolean;
@@ -44,9 +93,7 @@ export function resolveFileReferencePrimaryAction(args: {
   canReveal: boolean;
 }): FileReferencePrimaryAction {
   if (args.pathKind === "file") {
-    if (args.canOpenViewer) {
-      return "open-viewer";
-    }
+    if (args.canOpenViewer) return "open-viewer";
     return args.canOpenExternal ? "open-external" : "unavailable";
   }
   if (args.pathKind === "directory") {
@@ -55,74 +102,37 @@ export function resolveFileReferencePrimaryAction(args: {
   return "unavailable";
 }
 
-export function resolveFileReference(args: {
-  rawPath: string;
-  workspaceRoot: string | null;
-  resolveAbsolute: (rawPath: string) => string | null;
-  homeDirectory?: string | null;
-  workspacePathOverride?: string | null;
-}): ResolvedFileReference {
-  const trimmed = args.rawPath.trim();
-  const { path, line, column } = splitPathLineSuffix(trimmed);
-  // The SDK normalizes both an omitted wire field and an explicit null to
-  // `null`, so absence cannot safely mean "authoritatively external" here.
-  // Use a non-empty override when supplied; otherwise classify the raw path.
-  const workspacePath = normalizeWorkspacePathOverride(args.workspacePathOverride)
-    ?? resolveWorkspacePathFromReference(path, args.workspaceRoot);
-
-  return {
-    rawPath: args.rawPath,
-    path,
-    line,
-    column,
-    absolutePath: resolveAbsoluteFileReferencePath(
-      path,
-      args.homeDirectory,
-      args.resolveAbsolute,
-    ),
-    workspacePath,
-  };
-}
-
 export function isHomeRelativeFileReference(value: string): boolean {
   const { path } = splitPathLineSuffix(value.trim());
   return path === "~" || path.startsWith("~/");
 }
 
-function resolveAbsoluteFileReferencePath(
-  path: string,
-  homeDirectory: string | null | undefined,
-  resolveAbsolute: (rawPath: string) => string | null,
-): string | null {
-  if (!isHomeRelativeFileReference(path)) {
-    return resolveAbsolute(path);
-  }
-  const trimmedHome = homeDirectory?.trim();
-  if (!trimmedHome) {
-    return null;
-  }
-  const homeRoot = trimmedHome === "/" ? "" : trimmedHome.replace(/\/+$/, "");
-  const suffix = path === "~" ? "" : path.slice(1);
-  return `${homeRoot}${suffix}` || "/";
+export function normalizeRuntimeWorkspaceRoot(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!isSupportedAbsolutePath(trimmed) || hasTraversalSegment(trimmed)) return null;
+  return normalizeLexicalPath(trimmed, true);
 }
 
-/**
- * Best-effort correction for a workspace file path that does not resolve to a
- * real file (e.g. an agent dropped leading directories): given candidate paths
- * from a basename search, return the single candidate whose path equals or ends
- * with the target path. Returns null when the target already appears among the
- * candidates (it exists), or when the suffix match is absent or ambiguous.
- */
+export function fileReferenceCopyPath(reference: ResolvedFileReference): string | null {
+  switch (reference.locator.authority) {
+    case "workspace":
+      return reference.locator.localCompanionPath
+        ?? (reference.locator.workspacePath || ".");
+    case "desktop":
+      return reference.locator.absolutePath;
+    case "unavailable":
+      return reference.parsedPath.trim() || null;
+  }
+}
+
+/** Return the one suffix match, including an exact match, with runtime casing. */
 export function pickFuzzyPathMatch(
   targetPath: string,
   candidatePaths: readonly string[],
 ): string | null {
-  // Compare case-insensitively (the workspace search is case-insensitive, and
-  // a ref may differ in case from the real file) but return the real casing.
   const target = targetPath.toLowerCase();
-  if (!target || candidatePaths.some((candidate) => candidate.toLowerCase() === target)) {
-    return null;
-  }
+  if (!target) return null;
   const suffix = `/${target}`;
   const matches = candidatePaths.filter((candidate) => {
     const lower = candidate.toLowerCase();
@@ -131,24 +141,11 @@ export function pickFuzzyPathMatch(
   return matches.length === 1 ? matches[0] : null;
 }
 
-/**
- * Human-readable label for an inline file reference.
- *
- * A line-anchored reference reads as `basename (line N)`: the raw `path:line`
- * form (and the absolute directory chain in front of it) is machine syntax, and
- * what matters about a jump target is the file and the line. References without
- * a line keep their path — with no line to anchor on, the path is what
- * identifies the file. Either way this is display only; the reference's raw
- * path stays the click target and the tooltip.
- */
 export function inlineFileReferenceLabel(
-  reference: Pick<ResolvedFileReference, "path" | "workspacePath" | "line">,
+  reference: Pick<ResolvedFileReference, "displayPath" | "line">,
 ): string {
-  const path = reference.workspacePath ?? reference.path;
-  if (reference.line === null) {
-    return path;
-  }
-  return `${fileReferenceBasename(path)} (line ${reference.line})`;
+  if (reference.line === null) return reference.displayPath;
+  return `${fileReferenceBasename(reference.displayPath)} (line ${reference.line})`;
 }
 
 export function fileReferenceBasename(path: string): string {
@@ -156,88 +153,166 @@ export function fileReferenceBasename(path: string): string {
   return segments[segments.length - 1] ?? path;
 }
 
-function normalizeWorkspacePathOverride(path: string | null | undefined): string | null {
-  if (!path) {
-    return null;
+function classifyStructuredWorkspacePath(
+  suppliedPath: string,
+  args: ResolveFileReferenceInput,
+): ResolvedFileLocator {
+  const validation = validateWorkspacePath(suppliedPath);
+  if (validation.kind === "invalid") {
+    return { authority: "unavailable", reason: validation.reason };
   }
-  const trimmed = stripRelativePrefix(path.trim());
-  if (trimmed === "~" || trimmed.startsWith("~/")) {
-    return null;
-  }
-  const normalized = normalizeLexicalPath(trimmed);
-  return normalized && !normalized.startsWith("/") ? normalized : null;
+  return workspaceLocator(validation.path, args);
 }
 
-function resolveWorkspacePathFromReference(
-  path: string,
-  workspaceRoot: string | null,
-): string | null {
+function classifyRawPath(
+  parsedPath: string,
+  args: ResolveFileReferenceInput,
+): ResolvedFileLocator {
+  const trimmed = parsedPath.trim();
+  if (!trimmed) return { authority: "unavailable", reason: "empty" };
+  if (containsNul(trimmed) || hasUnsupportedPrefix(trimmed)) {
+    return { authority: "unavailable", reason: "invalid" };
+  }
+  if (hasTraversalSegment(trimmed)) {
+    return { authority: "unavailable", reason: "traversal" };
+  }
+  if (isHomeRelativeFileReference(trimmed)) return classifyHomeRelativePath(trimmed, args);
+  if (trimmed.startsWith("/")) return classifyAbsolutePath(trimmed, args);
+
+  const normalized = normalizeLexicalPath(trimmed, false);
+  return workspaceLocator(normalized ?? "", args);
+}
+
+function classifyAbsolutePath(
+  absolutePath: string,
+  args: ResolveFileReferenceInput,
+): ResolvedFileLocator {
+  if (args.workspaceRoot.status !== "settled") {
+    return { authority: "unavailable", reason: "workspace_root_unavailable" };
+  }
+  const normalizedRoot = normalizeRuntimeWorkspaceRoot(args.workspaceRoot.path);
+  const normalizedPath = normalizeRuntimeWorkspaceRoot(absolutePath);
+  if (!normalizedRoot || !normalizedPath) {
+    return { authority: "unavailable", reason: "workspace_root_unavailable" };
+  }
+
+  const workspacePath = workspacePathBelowRoot(normalizedPath, normalizedRoot);
+  if (workspacePath !== null) return workspaceLocator(workspacePath, args);
+
+  const originRefusal = nativeAuthorityRefusal(args);
+  if (originRefusal) return originRefusal;
+  return { authority: "desktop", absolutePath: normalizedPath, syntax: "absolute" };
+}
+
+function classifyHomeRelativePath(
+  homePath: string,
+  args: ResolveFileReferenceInput,
+): ResolvedFileLocator {
+  const originRefusal = nativeAuthorityRefusal(args);
+  if (originRefusal) return originRefusal;
+
+  const homeDirectory = normalizeRuntimeWorkspaceRoot(args.homeDirectory);
+  if (!homeDirectory) {
+    return { authority: "unavailable", reason: "home_unavailable" };
+  }
+  const suffix = homePath === "~" ? "" : homePath.slice(2);
+  const absolutePath = suffix ? lexicalJoin(homeDirectory, suffix) : homeDirectory;
+  return { authority: "desktop", absolutePath, syntax: "home-relative" };
+}
+
+function nativeAuthorityRefusal(
+  args: ResolveFileReferenceInput,
+): Extract<ResolvedFileLocator, { authority: "unavailable" }> | null {
+  if (args.filesystemOrigin.status !== "settled") {
+    return { authority: "unavailable", reason: "filesystem_origin_unavailable" };
+  }
+  if (args.filesystemOrigin.origin === "remote") {
+    return { authority: "unavailable", reason: "remote_filesystem" };
+  }
+  if (!args.desktopBridgeAvailable) {
+    return { authority: "unavailable", reason: "native_host_required" };
+  }
+  return null;
+}
+
+function workspaceLocator(
+  workspacePath: string,
+  args: ResolveFileReferenceInput,
+): Extract<ResolvedFileLocator, { authority: "workspace" }> {
+  let localCompanionPath: string | null = null;
+  if (
+    args.filesystemOrigin.status === "settled"
+    && args.filesystemOrigin.origin === "desktop-local"
+    && args.desktopBridgeAvailable
+    && args.workspaceRoot.status === "settled"
+  ) {
+    const root = normalizeRuntimeWorkspaceRoot(args.workspaceRoot.path);
+    if (root) localCompanionPath = workspacePath ? lexicalJoin(root, workspacePath) : root;
+  }
+  return { authority: "workspace", workspacePath, localCompanionPath };
+}
+
+function validateWorkspacePath(path: string):
+  | { kind: "valid"; path: string }
+  | { kind: "invalid"; reason: "invalid" | "traversal" } {
   const trimmed = path.trim();
-  if (!trimmed) {
-    return null;
+  if (
+    !trimmed
+    || containsNul(trimmed)
+    || hasUnsupportedPrefix(trimmed)
+    || trimmed.startsWith("/")
+    || isHomeRelativeFileReference(trimmed)
+  ) {
+    return { kind: "invalid", reason: "invalid" };
   }
-
-  if (trimmed === "~" || trimmed.startsWith("~/")) {
-    return null;
+  if (hasTraversalSegment(trimmed)) {
+    return { kind: "invalid", reason: "traversal" };
   }
-
-  const normalizedPath = normalizeLexicalPath(trimmed);
-  if (!normalizedPath) {
-    return null;
-  }
-
-  const normalizedRoot = normalizeRoot(workspaceRoot);
-  if (normalizedPath.startsWith("/")) {
-    if (!normalizedRoot) {
-      return null;
-    }
-    if (normalizedPath === normalizedRoot) {
-      return null;
-    }
-    const prefix = normalizedRoot === "/" ? "/" : `${normalizedRoot}/`;
-    return normalizedPath.startsWith(prefix)
-      ? normalizedPath.slice(prefix.length)
-      : null;
-  }
-
-  return normalizedPath;
+  return { kind: "valid", path: normalizeLexicalPath(trimmed, false) ?? "" };
 }
 
-function stripRelativePrefix(path: string): string {
-  let next = path;
-  while (next.startsWith("./")) {
-    next = next.slice(2);
-  }
-  return next;
+function displayPathForLocator(locator: ResolvedFileLocator, parsedPath: string): string {
+  if (locator.authority === "workspace") return locator.workspacePath || ".";
+  if (locator.authority === "desktop") return locator.absolutePath;
+  return parsedPath.trim() || "File";
 }
 
-function normalizeRoot(root: string | null): string | null {
-  if (!root) {
-    return null;
-  }
-  const normalized = normalizeLexicalPath(root.trim());
-  return normalized?.startsWith("/") ? normalized : null;
+function hasUnsupportedPrefix(path: string): boolean {
+  return /^[A-Za-z][A-Za-z0-9+.-]*:/.test(path)
+    || path.startsWith("//")
+    || path.startsWith("\\")
+    || path.startsWith("#")
+    || (/^~/.test(path) && path !== "~" && !path.startsWith("~/"));
 }
 
-function normalizeLexicalPath(path: string): string | null {
-  const absolute = path.startsWith("/");
-  const segments: string[] = [];
-  for (const segment of path.split("/")) {
-    if (!segment || segment === ".") {
-      continue;
-    }
-    if (segment === "..") {
-      if (segments.length === 0) {
-        return null;
-      }
-      segments.pop();
-      continue;
-    }
-    segments.push(segment);
-  }
+function hasTraversalSegment(path: string): boolean {
+  return path.split("/").some((segment) => segment === "..");
+}
 
-  if (segments.length === 0) {
-    return absolute ? "/" : null;
-  }
+function containsNul(path: string): boolean {
+  return path.includes("\0");
+}
+
+function isSupportedAbsolutePath(path: string): boolean {
+  return path.startsWith("/")
+    && !path.startsWith("//")
+    && !containsNul(path)
+    && !hasUnsupportedPrefix(path);
+}
+
+function normalizeLexicalPath(path: string, absolute: boolean): string | null {
+  const segments = path.split("/").filter((segment) => segment && segment !== ".");
+  if (segments.length === 0) return absolute ? "/" : null;
   return `${absolute ? "/" : ""}${segments.join("/")}`;
+}
+
+function workspacePathBelowRoot(path: string, root: string): string | null {
+  if (path === root) return "";
+  const prefix = root === "/" ? "/" : `${root}/`;
+  return path.startsWith(prefix) ? path.slice(prefix.length) : null;
+}
+
+function lexicalJoin(root: string, child: string): string {
+  if (!child) return root;
+  return root === "/" ? `/${child}` : `${root}/${child}`;
 }

--- a/apps/packages/product-client/src/pages/FileViewerPlaygroundPage.tsx
+++ b/apps/packages/product-client/src/pages/FileViewerPlaygroundPage.tsx
@@ -1,0 +1,5 @@
+import { FileViewerPlayground } from "#product/components/playground/FileViewerPlayground";
+
+export function FileViewerPlaygroundPage() {
+  return <FileViewerPlayground />;
+}

--- a/apps/packages/product-client/src/providers/ProductProviderRoot.test.tsx
+++ b/apps/packages/product-client/src/providers/ProductProviderRoot.test.tsx
@@ -1,12 +1,17 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, render } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   runtimeProps: [] as Array<{ runtimeUrl: string | null }>,
   resolveConnection: vi.fn(),
+  workspaceProps: [] as Array<{
+    workspaceId: string | null;
+    resolveConnection: (workspaceId: string) => Promise<unknown>;
+  }>,
+  workspacePathProviderMounts: 0,
 }));
 
 vi.mock("@anyharness/sdk-react", () => ({
@@ -20,7 +25,18 @@ vi.mock("@anyharness/sdk-react", () => ({
     mocks.runtimeProps.push({ runtimeUrl });
     return children;
   },
-  AnyHarnessWorkspace: ({ children }: { children: ReactNode }) => children,
+  AnyHarnessWorkspace: ({
+    children,
+    workspaceId,
+    resolveConnection,
+  }: {
+    children: ReactNode;
+    workspaceId: string | null;
+    resolveConnection: (workspaceId: string) => Promise<unknown>;
+  }) => {
+    mocks.workspaceProps.push({ workspaceId, resolveConnection });
+    return <div data-testid="anyharness-workspace">{children}</div>;
+  },
 }));
 
 vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
@@ -48,12 +64,34 @@ vi.mock("#product/providers/TelemetryProvider", () => ({
   TelemetryProvider: ({ children }: { children: ReactNode }) => children,
 }));
 
+vi.mock("#product/providers/WorkspacePathProvider", () => ({
+  WorkspacePathProvider: ({ children }: { children: ReactNode }) => {
+    mocks.workspacePathProviderMounts += 1;
+    return <div data-testid="workspace-path-provider">{children}</div>;
+  },
+}));
+
 import { ProductProviderRoot } from "#product/providers/ProductProviderRoot";
+import {
+  useProductWorkspaceConnectionResolver,
+  type ProductWorkspaceConnectionResolver,
+} from "#product/providers/ProductWorkspaceConnectionProvider";
 import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 
+let observedProductResolver: ProductWorkspaceConnectionResolver | null = null;
+
+function ProductConnectionProbe() {
+  observedProductResolver = useProductWorkspaceConnectionResolver();
+  return <div data-testid="product-child" />;
+}
+
 beforeEach(() => {
   mocks.runtimeProps.length = 0;
+  mocks.workspaceProps.length = 0;
+  mocks.workspacePathProviderMounts = 0;
+  mocks.resolveConnection.mockReset();
+  observedProductResolver = null;
   useHarnessConnectionStore.setState({
     runtimeUrl: "http://127.0.0.1:9001",
     connectionState: "connecting",
@@ -89,5 +127,41 @@ describe("ProductProviderRoot", () => {
       useHarnessConnectionStore.setState({ connectionState: "failed" });
     });
     expect(mocks.runtimeProps[mocks.runtimeProps.length - 1]?.runtimeUrl).toBeNull();
+  });
+
+  it("mounts one path provider inside the SDK workspace and narrows only the SDK adapter", async () => {
+    const productEnvelope = {
+      connection: {
+        runtimeUrl: "http://runtime.test",
+        anyharnessWorkspaceId: "runtime-workspace",
+        runtimeGeneration: 5,
+        runtimeAccessKind: "direct",
+      },
+      filesystemOrigin: "desktop-local",
+    };
+    mocks.resolveConnection.mockResolvedValue(productEnvelope);
+    useSessionSelectionStore.setState({
+      selectedWorkspaceId: "workspace-materialized",
+      selectedLogicalWorkspaceId: "logical:workspace",
+    });
+
+    render(
+      <ProductProviderRoot>
+        <ProductConnectionProbe />
+      </ProductProviderRoot>,
+    );
+
+    const sdkWorkspace = screen.getByTestId("anyharness-workspace");
+    const pathProvider = screen.getByTestId("workspace-path-provider");
+    expect(sdkWorkspace.contains(pathProvider)).toBe(true);
+    expect(pathProvider.contains(screen.getByTestId("product-child"))).toBe(true);
+    expect(mocks.workspacePathProviderMounts).toBe(1);
+    expect(mocks.workspaceProps.at(-1)?.workspaceId).toBe("logical:workspace");
+
+    await expect(mocks.workspaceProps.at(-1)?.resolveConnection("workspace-materialized"))
+      .resolves.toEqual(productEnvelope.connection);
+    await expect(observedProductResolver?.("workspace-materialized"))
+      .resolves.toEqual(productEnvelope);
+    expect(mocks.resolveConnection).toHaveBeenCalledWith("workspace-materialized");
   });
 });

--- a/apps/packages/product-client/src/providers/ProductProviderRoot.tsx
+++ b/apps/packages/product-client/src/providers/ProductProviderRoot.tsx
@@ -3,7 +3,7 @@ import {
   AnyHarnessWorkspace,
 } from "@anyharness/sdk-react";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
-import { useMemo, type ReactNode } from "react";
+import { useCallback, useMemo, type ReactNode } from "react";
 import { useLocation } from "react-router-dom";
 import { resolveRouteScopedWorkspaceProviderId } from "#product/lib/domain/workspaces/selection/workspace-provider-scope";
 import { useResolveWorkspaceConnection } from "#product/hooks/workspaces/cache/use-resolve-workspace-connection";
@@ -13,6 +13,10 @@ import type { AuthClientStatus } from "#product/lib/domain/auth/auth-state-mappi
 import { buildAnyHarnessCacheScopeKey } from "#product/lib/domain/auth/anyharness-cache-scope";
 import { useCloudWorkspaceMaterializationCacheBoundary } from "#product/hooks/workspaces/cache/use-cloud-workspace-materialization-cache-boundary";
 import { TelemetryProvider } from "#product/providers/TelemetryProvider";
+import {
+  ProductWorkspaceConnectionProvider,
+} from "#product/providers/ProductWorkspaceConnectionProvider";
+import { WorkspacePathProvider } from "#product/providers/WorkspacePathProvider";
 
 /**
  * Product-owned provider root. Wraps the AnyHarness/workspace product scope and
@@ -58,7 +62,7 @@ function WorkspaceProviders({ children }: { children: ReactNode }) {
     selectedLogicalWorkspaceId,
     selectedWorkspaceId,
   });
-  const resolveConnection = useResolveWorkspaceConnection({
+  const resolveProductConnection = useResolveWorkspaceConnection({
     ssh,
     cloudClient,
     runtimeUrl,
@@ -67,16 +71,23 @@ function WorkspaceProviders({ children }: { children: ReactNode }) {
     cacheScopeKey,
     selectedWorkspaceId,
   });
+  const resolveAnyHarnessConnection = useCallback(async (workspaceId: string) => (
+    await resolveProductConnection(workspaceId)
+  ).connection, [resolveProductConnection]);
 
   return (
     <AnyHarnessRuntime runtimeUrl={readyRuntimeUrl || null} cacheScopeKey={cacheScopeKey}>
       <CloudWorkspaceMaterializationCacheBoundary>
-        <AnyHarnessWorkspace
-          workspaceId={providerWorkspaceId}
-          resolveConnection={resolveConnection}
+        <ProductWorkspaceConnectionProvider
+          resolveConnection={resolveProductConnection}
         >
-          {children}
-        </AnyHarnessWorkspace>
+          <AnyHarnessWorkspace
+            workspaceId={providerWorkspaceId}
+            resolveConnection={resolveAnyHarnessConnection}
+          >
+            <WorkspacePathProvider>{children}</WorkspacePathProvider>
+          </AnyHarnessWorkspace>
+        </ProductWorkspaceConnectionProvider>
       </CloudWorkspaceMaterializationCacheBoundary>
     </AnyHarnessRuntime>
   );

--- a/apps/packages/product-client/src/providers/ProductWorkspaceConnectionProvider.tsx
+++ b/apps/packages/product-client/src/providers/ProductWorkspaceConnectionProvider.tsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, type ReactNode } from "react";
+import type {
+  ProductResolvedWorkspaceConnection,
+} from "#product/lib/access/anyharness/resolve-workspace-connection";
+
+export type ProductWorkspaceConnectionResolver = (
+  workspaceId: string,
+) => Promise<ProductResolvedWorkspaceConnection>;
+
+const ProductWorkspaceConnectionContext = createContext<
+  ProductWorkspaceConnectionResolver | null
+>(null);
+
+export function ProductWorkspaceConnectionProvider({
+  resolveConnection,
+  children,
+}: {
+  resolveConnection: ProductWorkspaceConnectionResolver;
+  children: ReactNode;
+}) {
+  return (
+    <ProductWorkspaceConnectionContext.Provider value={resolveConnection}>
+      {children}
+    </ProductWorkspaceConnectionContext.Provider>
+  );
+}
+
+export function useProductWorkspaceConnectionResolver(): ProductWorkspaceConnectionResolver {
+  const resolveConnection = useContext(ProductWorkspaceConnectionContext);
+  if (!resolveConnection) {
+    throw new Error(
+      "useProductWorkspaceConnectionResolver must be used inside ProductWorkspaceConnectionProvider",
+    );
+  }
+  return resolveConnection;
+}

--- a/apps/packages/product-client/src/providers/WorkspacePathProvider.test.tsx
+++ b/apps/packages/product-client/src/providers/WorkspacePathProvider.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProductResolvedWorkspaceConnection } from "#product/lib/access/anyharness/resolve-workspace-connection";
+
+const mocks = vi.hoisted(() => ({
+  query: {
+    data: undefined as { path?: string | null } | undefined,
+    isPending: true,
+    isError: false,
+  },
+  queryOptions: [] as Array<{ workspaceId: string | null; enabled: boolean }>,
+}));
+
+vi.mock("@anyharness/sdk-react", () => ({
+  useWorkspaceQuery: (options: { workspaceId: string | null; enabled: boolean }) => {
+    mocks.queryOptions.push(options);
+    return mocks.query;
+  },
+}));
+
+import {
+  ProductWorkspaceConnectionProvider,
+  type ProductWorkspaceConnectionResolver,
+} from "#product/providers/ProductWorkspaceConnectionProvider";
+import {
+  useWorkspacePath,
+  WorkspacePathProvider,
+} from "#product/providers/WorkspacePathProvider";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+
+function StateProbe() {
+  return <pre data-testid="state">{JSON.stringify(useWorkspacePath())}</pre>;
+}
+
+function renderProvider(resolveConnection: ProductWorkspaceConnectionResolver) {
+  return render(
+    <ProductWorkspaceConnectionProvider resolveConnection={resolveConnection}>
+      <WorkspacePathProvider>
+        <StateProbe />
+      </WorkspacePathProvider>
+    </ProductWorkspaceConnectionProvider>,
+  );
+}
+
+function state(): ReturnType<typeof useWorkspacePath> {
+  return JSON.parse(screen.getByTestId("state").textContent ?? "null");
+}
+
+function resolved(
+  filesystemOrigin: ProductResolvedWorkspaceConnection["filesystemOrigin"],
+): ProductResolvedWorkspaceConnection {
+  return {
+    connection: {
+      runtimeUrl: "https://runtime.test",
+      anyharnessWorkspaceId: "runtime-workspace",
+      runtimeGeneration: 1,
+    },
+    filesystemOrigin,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.query.data = undefined;
+  mocks.query.isPending = true;
+  mocks.query.isError = false;
+  mocks.queryOptions.length = 0;
+  useSessionSelectionStore.setState({
+    selectedWorkspaceId: null,
+    selectedLogicalWorkspaceId: null,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("WorkspacePathProvider", () => {
+  it("keeps null selection pending without resolving or querying", () => {
+    const resolveConnection = vi.fn<ProductWorkspaceConnectionResolver>();
+    renderProvider(resolveConnection);
+
+    expect(state()).toEqual({
+      materializedWorkspaceId: null,
+      filesystemOrigin: { status: "pending", origin: null },
+      workspaceRoot: { status: "pending", path: null },
+    });
+    expect(resolveConnection).not.toHaveBeenCalled();
+    expect(mocks.queryOptions.at(-1)).toEqual({ workspaceId: null, enabled: false });
+  });
+
+  it.each([
+    ["desktop-local" as const, "/workspaces/local/", "/workspaces/local"],
+    ["remote" as const, "/workspaces/cloud", "/workspaces/cloud"],
+  ])("settles %s provenance and a normalized runtime root", async (
+    filesystemOrigin,
+    runtimePath,
+    expectedPath,
+  ) => {
+    useSessionSelectionStore.setState({
+      selectedWorkspaceId: "workspace-materialized",
+      selectedLogicalWorkspaceId: "logical:workspace",
+    });
+    mocks.query.data = { path: runtimePath };
+    mocks.query.isPending = false;
+    const resolveConnection = vi.fn<ProductWorkspaceConnectionResolver>()
+      .mockResolvedValue(resolved(filesystemOrigin));
+    renderProvider(resolveConnection);
+
+    await waitFor(() => expect(state().filesystemOrigin).toEqual({
+      status: "settled",
+      origin: filesystemOrigin,
+    }));
+    expect(state()).toMatchObject({
+      materializedWorkspaceId: "workspace-materialized",
+      workspaceRoot: { status: "settled", path: expectedPath },
+    });
+    expect(resolveConnection).toHaveBeenCalledWith("workspace-materialized");
+    expect(mocks.queryOptions.at(-1)).toEqual({
+      workspaceId: "workspace-materialized",
+      enabled: true,
+    });
+  });
+
+  it.each([undefined, null, "relative/root", "/root/../escape", "/bad\0root"])(
+    "marks invalid runtime root %s unavailable",
+    async (runtimePath) => {
+      useSessionSelectionStore.setState({ selectedWorkspaceId: "workspace-1" });
+      mocks.query.data = { path: runtimePath };
+      mocks.query.isPending = false;
+      const resolveConnection = vi.fn<ProductWorkspaceConnectionResolver>()
+        .mockResolvedValue(resolved("desktop-local"));
+      renderProvider(resolveConnection);
+
+      await waitFor(() => expect(state().filesystemOrigin.status).toBe("settled"));
+      expect(state().workspaceRoot).toEqual({ status: "unavailable", path: null });
+    },
+  );
+
+  it("marks a rejected provenance resolution unknown without exposing its error", async () => {
+    useSessionSelectionStore.setState({ selectedWorkspaceId: "cloud:cloud-1" });
+    mocks.query.isPending = false;
+    mocks.query.isError = true;
+    const resolveConnection = vi.fn<ProductWorkspaceConnectionResolver>()
+      .mockRejectedValue(new Error("secret path /private/workspace"));
+    renderProvider(resolveConnection);
+
+    await waitFor(() => expect(state().filesystemOrigin).toEqual({
+      status: "rejected",
+      origin: null,
+    }));
+    expect(state().workspaceRoot).toEqual({ status: "unavailable", path: null });
+    expect(screen.getByTestId("state").textContent).not.toContain("secret path");
+  });
+
+  it("resets on selection change and ignores a stale completion", async () => {
+    let resolveFirst!: (value: ProductResolvedWorkspaceConnection) => void;
+    let resolveSecond!: (value: ProductResolvedWorkspaceConnection) => void;
+    const first = new Promise<ProductResolvedWorkspaceConnection>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const second = new Promise<ProductResolvedWorkspaceConnection>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const resolveConnection = vi.fn<ProductWorkspaceConnectionResolver>((workspaceId) => (
+      workspaceId === "workspace-1" ? first : second
+    ));
+    useSessionSelectionStore.setState({ selectedWorkspaceId: "workspace-1" });
+    renderProvider(resolveConnection);
+    await waitFor(() => expect(resolveConnection).toHaveBeenCalledWith("workspace-1"));
+
+    act(() => {
+      useSessionSelectionStore.setState({
+        selectedWorkspaceId: "workspace-2",
+        selectedLogicalWorkspaceId: "logical:workspace-2",
+      });
+    });
+    expect(state()).toMatchObject({
+      materializedWorkspaceId: "workspace-2",
+      filesystemOrigin: { status: "pending", origin: null },
+    });
+    await waitFor(() => expect(resolveConnection).toHaveBeenCalledWith("workspace-2"));
+
+    await act(async () => {
+      resolveFirst(resolved("desktop-local"));
+      await first;
+    });
+    expect(state().filesystemOrigin).toEqual({ status: "pending", origin: null });
+
+    await act(async () => {
+      resolveSecond(resolved("remote"));
+      await second;
+    });
+    expect(state().filesystemOrigin).toEqual({ status: "settled", origin: "remote" });
+  });
+});

--- a/apps/packages/product-client/src/providers/WorkspacePathProvider.tsx
+++ b/apps/packages/product-client/src/providers/WorkspacePathProvider.tsx
@@ -1,59 +1,125 @@
-import { createContext, useContext, useMemo, type ReactNode } from "react";
+import { useWorkspaceQuery } from "@anyharness/sdk-react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  normalizeRuntimeWorkspaceRoot,
+  type RuntimeWorkspaceRootState,
+  type WorkspaceFilesystemOriginState,
+} from "#product/lib/domain/files/path-references";
+import { resolveSelectedWorkspaceIdentity } from "#product/lib/domain/workspaces/selection/workspace-ui-key";
+import { useProductWorkspaceConnectionResolver } from "#product/providers/ProductWorkspaceConnectionProvider";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 
-interface WorkspacePathContextValue {
-  /** Absolute filesystem root of the active workspace, or null if none. */
-  workspacePath: string | null;
-  /**
-   * Resolve a raw path string (relative or absolute) to an absolute path on
-   * disk, or `null` if no workspace is active and the input is relative.
-   *
-   * - Absolute paths (`/…`) are returned unchanged.
-   * - `~/…` is left unresolved (callers that need home expansion should do
-   *   it themselves; we don't import the Tauri home helper here to keep this
-   *   provider sync + workspace-agnostic).
-   * - Relative paths are joined to `workspacePath`.
-   * - An optional `:line` or `:line:col` suffix is preserved on the result.
-   */
-  resolveAbsolute: (rawPath: string) => string | null;
+export interface WorkspacePathContextValue {
+  materializedWorkspaceId: string | null;
+  filesystemOrigin: WorkspaceFilesystemOriginState;
+  workspaceRoot: RuntimeWorkspaceRootState;
 }
 
+const PENDING_FILESYSTEM_ORIGIN: WorkspaceFilesystemOriginState = {
+  status: "pending",
+  origin: null,
+};
+const PENDING_WORKSPACE_ROOT: RuntimeWorkspaceRootState = {
+  status: "pending",
+  path: null,
+};
+
 const WorkspacePathContext = createContext<WorkspacePathContextValue>({
-  workspacePath: null,
-  resolveAbsolute: () => null,
+  materializedWorkspaceId: null,
+  filesystemOrigin: PENDING_FILESYSTEM_ORIGIN,
+  workspaceRoot: PENDING_WORKSPACE_ROOT,
 });
 
-export function WorkspacePathProvider({
-  workspacePath,
-  children,
-}: {
-  workspacePath: string | null;
-  children: ReactNode;
-}) {
-  const value = useMemo<WorkspacePathContextValue>(() => {
-    return {
-      workspacePath,
-      resolveAbsolute: (rawPath: string) => {
-        const trimmed = rawPath.trim();
-        if (trimmed.length === 0) return null;
+interface OriginResolution {
+  materializedWorkspaceId: string | null;
+  state: WorkspaceFilesystemOriginState;
+}
 
-        // Absolute — return as-is.
-        if (trimmed.startsWith("/")) return trimmed;
+export function WorkspacePathProvider({ children }: { children: ReactNode }) {
+  const resolveConnection = useProductWorkspaceConnectionResolver();
+  const selectedWorkspaceId = useSessionSelectionStore(
+    (state) => state.selectedWorkspaceId,
+  );
+  const selectedLogicalWorkspaceId = useSessionSelectionStore(
+    (state) => state.selectedLogicalWorkspaceId,
+  );
+  const { materializedWorkspaceId } = resolveSelectedWorkspaceIdentity({
+    selectedLogicalWorkspaceId,
+    materializedWorkspaceId: selectedWorkspaceId,
+  });
+  const workspaceQuery = useWorkspaceQuery({
+    workspaceId: materializedWorkspaceId,
+    enabled: materializedWorkspaceId !== null,
+  });
+  const [originResolution, setOriginResolution] = useState<OriginResolution>({
+    materializedWorkspaceId: null,
+    state: PENDING_FILESYSTEM_ORIGIN,
+  });
 
-        // ~ paths — leave for caller / shell layer to expand.
-        if (trimmed.startsWith("~/") || trimmed === "~") return null;
+  useEffect(() => {
+    let current = true;
+    setOriginResolution({
+      materializedWorkspaceId,
+      state: PENDING_FILESYSTEM_ORIGIN,
+    });
+    if (materializedWorkspaceId === null) {
+      return () => {
+        current = false;
+      };
+    }
 
-        // Relative — needs an active workspace.
-        if (!workspacePath) return null;
-
-        // Strip leading "./".
-        const cleaned = trimmed.startsWith("./") ? trimmed.slice(2) : trimmed;
-        const root = workspacePath.endsWith("/")
-          ? workspacePath.slice(0, -1)
-          : workspacePath;
-        return `${root}/${cleaned}`;
+    void resolveConnection(materializedWorkspaceId).then(
+      (resolved) => {
+        if (!current) return;
+        setOriginResolution({
+          materializedWorkspaceId,
+          state: {
+            status: "settled",
+            origin: resolved.filesystemOrigin,
+          },
+        });
       },
+      () => {
+        if (!current) return;
+        setOriginResolution({
+          materializedWorkspaceId,
+          state: { status: "rejected", origin: null },
+        });
+      },
+    );
+
+    return () => {
+      current = false;
     };
-  }, [workspacePath]);
+  }, [materializedWorkspaceId, resolveConnection]);
+
+  const filesystemOrigin = originResolution.materializedWorkspaceId === materializedWorkspaceId
+    ? originResolution.state
+    : PENDING_FILESYSTEM_ORIGIN;
+  const workspaceRoot = useMemo<RuntimeWorkspaceRootState>(() => {
+    if (materializedWorkspaceId === null || workspaceQuery.isPending) {
+      return PENDING_WORKSPACE_ROOT;
+    }
+    if (workspaceQuery.isError) {
+      return { status: "unavailable", path: null };
+    }
+    const path = normalizeRuntimeWorkspaceRoot(workspaceQuery.data?.path);
+    return path === null
+      ? { status: "unavailable", path: null }
+      : { status: "settled", path };
+  }, [materializedWorkspaceId, workspaceQuery.data?.path, workspaceQuery.isError, workspaceQuery.isPending]);
+  const value = useMemo<WorkspacePathContextValue>(() => ({
+    materializedWorkspaceId,
+    filesystemOrigin,
+    workspaceRoot,
+  }), [filesystemOrigin, materializedWorkspaceId, workspaceRoot]);
 
   return (
     <WorkspacePathContext.Provider value={value}>

--- a/lints/frontend/exceptions.toml
+++ b/lints/frontend/exceptions.toml
@@ -35,12 +35,6 @@
 
 [[exception]]
 rule = "FE-ACCESS-2"
-path = "apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.ts"
-site = "getAnyHarnessClient"
-reason = "workflow imports raw AnyHarness client"
-
-[[exception]]
-rule = "FE-ACCESS-2"
 path = "apps/packages/product-client/src/hooks/workspaces/workflows/use-materialization-health-pass.ts"
 site = "getAnyHarnessClient"
 reason = "workflow imports raw AnyHarness client"

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -140,6 +140,15 @@ Rules:
 
 - Detection happens at render time from raw markdown; do not store parsed file
   references in transcript items.
+- File-read and file-change callers keep raw wire paths separate from structured
+  workspace-path metadata. Any structured string, including empty or
+  whitespace, is supplied and authoritative; `null`/`undefined` alone permits
+  raw classification. Human-readable labels may fall back to a nonblank raw
+  path without changing that access decision.
+- Streaming file-change identity uses only the raw `path` and `newPath`
+  channels. A later supplied `workspacePath` or `newWorkspacePath` string is
+  merged verbatim, so structured refinement—including an invalid blank
+  value—updates one logical part instead of splitting it.
 - A leading `~/` is an external Desktop file reference, not a workspace-relative
   path. Resolve it through the Desktop host's home-directory bridge before
   classifying or opening it; Web keeps the reference unavailable. Hidden path
@@ -152,7 +161,9 @@ Rules:
   subtitle to `Open preview`. It remains completion chrome: never expose it
   while transport text is still buffered or its final opacity is settling. Its
   trigger consumes the file-reference action's `canOpenPrimary` capability and
-  stays disabled, with a guarded handler, until that capability is true.
+  stays disabled, with a guarded handler, until that capability is true. It
+  forwards the resource's raw path through the same canonical locator hook and
+  never opens an optimistic preview before exact access settles.
 - While prose is streaming, a trailing incomplete local-file link is closed
   only in the Markdown render copy so its file mention appears as soon as the
   destination begins. Never persist the synthetic delimiter or expose the raw

--- a/specs/codebase/systems/product/workspaces/files.md
+++ b/specs/codebase/systems/product/workspaces/files.md
@@ -141,7 +141,42 @@ server read cache; they exist only for local editing and conflict metadata.
 Scratch content belongs to Tauri app-data access hooks. It is a local external
 resource, not Zustand state and not an AnyHarness file resource.
 
-## Desktop-local Path Capabilities
+## File Locator And Desktop-local Capabilities
+
+Every rendered file reference is classified once as a workspace locator, a
+Desktop locator, or an unavailable locator before any stat, search, home
+lookup, inspection, target discovery, open, or reveal operation. A locator
+never carries nullable workspace and absolute authorities at the same time.
+
+Workspace filesystem provenance comes from the resolved runtime target:
+`local` maps to `desktop-local`, while Cloud and SSH-target runtimes map to
+`remote`. A successfully fetched cached Cloud gateway is also authoritative
+remote evidence. Host surface, workspace-id spelling, inventory rows, and
+equal-looking roots are not provenance. Resolution pending and rejection stay
+explicit unknown states and never grant native access.
+
+The single `WorkspacePathProvider` under `AnyHarnessWorkspace` resolves both
+that provenance and the runtime-reported workspace root for the exact
+materialized workspace id. Only a normalized supported absolute runtime root
+is settled. Inventory and pending-entry paths may label the header, but they
+must not construct filesystem capabilities.
+
+Relative references and supplied valid workspace paths remain workspace
+locators while provenance/root are pending. Workspace root is represented by
+the empty runtime stat path and displayed/copied as `.` unless a proven local
+companion exists. Absolute paths project into the workspace only against a
+settled root. Paths outside it and home-relative paths become Desktop locators
+only with settled `desktop-local` provenance and a Desktop files bridge.
+Unsupported prefixes, NUL, and any `..` segment fail before all I/O. A supplied
+structured workspace-path string is authoritative even when empty or
+whitespace; only `null`/`undefined` permits raw-path classification.
+
+Workspace access begins with exact stat, including `""` for root. Only the
+typed AnyHarness `FILE_NOT_FOUND` for a non-root path offers one bounded fuzzy
+activation: one no-retry basename search, one corrected stat, and no repeated
+recovery after a terminal result. Exact/corrected directories do not become a
+primary browse action in this slice. Unexpected symlink kinds are refused;
+the runtime must report the safely resolved `file` or `directory` kind.
 
 Values already routed to the Desktop filesystem pass through
 `DesktopFilesBridge.inspectPath`; inspection itself does not establish local
@@ -155,8 +190,11 @@ Only a settled `file` or `directory` result establishes a path kind and enables
 matching open/reveal capabilities. Missing, invalid, denied, unsupported,
 unexpected-I/O, malformed-payload, idle, pending, and rejected states keep the
 kind null, expose no open targets, and cause every native handler to no-op after
-rechecking current state. Copy path remains available because it performs no
-filesystem operation. Target discovery takes `file | directory | null`; null
+rechecking current route, bridge, kind, and target membership. A nonempty
+unavailable reference exposes exactly Copy path; an empty/whitespace reference
+has no menu and no clipboard write. Copy handlers read the current locator at
+invocation so captured callbacks cannot copy a later empty reference. Target
+discovery takes `file | directory | null`; null
 does not default to file or start discovery, while an imperative open supplies
 the already-inspected kind explicitly.
 

--- a/specs/sdk.md
+++ b/specs/sdk.md
@@ -118,6 +118,10 @@ not move product workflows into either SDK.
 - Support-window timestamp handling in `@anyharness/sdk` accepts only canonical-equivalent UTC spellings and sends canonical `Z` text on the wire, retaining 3, 6, or 9 digit fractions as given. It is not a compensation layer for a caller that emits a non-canonical window: a producer that needs fixed-millisecond output fixes that at the producer, and this normalization stays as it is.
 - Generic React providers, query hooks, mutation hooks, and query keys stay in
   `@anyharness/sdk-react`.
+- `useStatWorkspaceFileQuery` treats `path: ""` as an enabled workspace-root
+  stat and treats only `path: null` as disabled (subject to workspace id and
+  caller `enabled`). `useReadWorkspaceFileQuery` keeps its nonempty-path gate;
+  workspace root is not a readable file.
 
 ## 3. Ownership Model
 


### PR DESCRIPTION
## Summary

- classify workspace-relative, workspace-absolute, Desktop absolute/home-relative, and unavailable references through one provenance-aware locator contract
- preserve runtime origin/root metadata through Product connection flows, fail closed for remote/Web/unknown native access, and bound exact-missing fuzzy recovery to one attempt
- route transcript references, viewer breadcrumbs, workspace-root actions, DOM/native menus, and copy behavior through current capability checks
- preserve streamed file-change identity independently of mutable structured paths and add a deterministic file-routing qualification fixture

## Testing

- focused Product suites: baseline 59/59 provenance/root, 107/107 locator/access, 64/64 caller/menu/header/viewer, plus 14/14 caller recheck
- SDK React 2/2 and SDK reducer 37/37
- post-review focused repair batch 73/73; independent round-two review rerun 65/65
- stale action mocks and symlink-stat fixtures were repaired with focused 46/46 plus independent acceptance
- dependency-correct exact head `ccae4636fc43776f553624716bc8adf409de5c1d` passed its single fresh hosted matrix 25/25, including ProductClient, Cargo, login, workflow lifecycle, and Chromium/WebKit scroll physics
- baseline `pnpm shared:build`, file-viewer fixture typecheck, deterministic Playwright route matrix 8/8, typechecks, frontend boundaries, strict structure, appearance scaling, component library, design attribution, max-lines, docs, and diff checks passed
- no local Cargo, Rust build, or Docker

## Observability

- none: no new events or telemetry fields; existing sanitized query telemetry remains unchanged

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Verification

- Frozen 01D r5 implemented and independently accepted; `01D-R1-B01`–`B03`, `01D-R2-F01`, and hosted fixture findings `2077-CI-B01`–`B03` are closed
- shared hosted-apt prerequisite #2080 merged 26/26 green and exact-head reviewed as `36ffc263077df8ec5ea6fb775af4f3e0b2932ec5`
- accepted Product commits were replayed onto that exact main as `e1c0d23731ba715a4e3b9c1cf207af8eafa2748e` and `ccae4636fc43776f553624716bc8adf409de5c1d`
- stable patch IDs remain exactly `b54e0d81cbd02abffaff710d8c07483e0206b1f8` and `71745f9e34890234c1df32b70d2bb33aecd38ae0`; `git range-diff` marks both commits identical
- Product paths have zero overlap with intervening main work; rebased tree `d9dbed0307dfb6f56f382d1cba7da8972eb6391d` exactly equals the clean precomputed merge tree

## Merge hold release

The prior external hold referenced the shared WebKit prepend regression (`scroll-physics.spec.ts:750`) reproduced on Session #2072 and Sandbox #2069. That defect is a pre-existing main-branch issue owned by the dedicated shared-scroll lane; it is not caused, touched, or masked by this PR, and this PR's own exact-head hosted matrix (run 32281910434) passed 25/25 with no retry, including Chromium/WebKit scroll physics. Under the 2026-08-19 stack-completion directive, the hold is released for this PR only; the shared-scroll fix remains owned by its dedicated lane and still gates #2069/#2072.

Post-hold delta: one fresh exact-head independent review (no P0) surfaced two P1 defects — moved-file references whose destination lies outside the workspace routed open/copy actions to the source path. Fixed in `4816b0a1c8` (findings 2077-R4-B01/B02) with negative-controlled focused tests; fix independently re-verified. P2 notes (SDK reducer null-vs-absent workspacePath clearing; fuzzy-search 200-hit truncation ambiguity) are recorded as ledger follow-ups.
