### PR TITLE
fix(product): settle first-run auth adoption

### DIFF
--- a/apps/packages/product-client/src/hooks/agents/derived/use-agent-catalog.ts
+++ b/apps/packages/product-client/src/hooks/agents/derived/use-agent-catalog.ts
@@ -32,11 +32,20 @@ export function useAgentCatalog() {
     ),
     reconcileSnapshot: reconcileQuery.data ?? null,
     reconcileStatus: reconcileQuery.data?.status ?? "idle",
+    reconcileIsError: reconcileQuery.isError,
+    reconcileError: reconcileQuery.error,
     reconcileDataUpdatedAt: reconcileQuery.dataUpdatedAt,
     isReconciling: reconcileQuery.data?.status === "queued"
       || reconcileQuery.data?.status === "running",
     hasAgents: agents.length > 0,
-  }), [agents, reconcileQuery.data, reconcileQuery.dataUpdatedAt, reconcileResults]);
+  }), [
+    agents,
+    reconcileQuery.data,
+    reconcileQuery.dataUpdatedAt,
+    reconcileQuery.error,
+    reconcileQuery.isError,
+    reconcileResults,
+  ]);
 
   return {
     ...agentsQuery,

--- a/apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.test.tsx
+++ b/apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.test.tsx
@@ -236,6 +236,140 @@ describe("useFirstRunAuthAdoption", () => {
   });
 
   it.each([
+    [
+      "pending selections do not mask a capabilities failure",
+      () => {
+        state.selections.data = undefined;
+        state.capabilities.data = undefined;
+        state.capabilities.isError = true;
+        state.capabilities.error = new TypeError("capabilities payload");
+      },
+      "capabilities_query",
+    ],
+    [
+      "pending Cloud inputs do not mask a reconcile query failure",
+      () => {
+        state.selections.data = undefined;
+        state.capabilities.data = undefined;
+        state.reconcileIsError = true;
+        state.reconcileError = new TypeError("reconcile payload");
+      },
+      "reconcile_query",
+    ],
+    [
+      "pending capabilities do not mask a failed reconcile job",
+      () => {
+        state.capabilities.data = undefined;
+        state.reconcileStatus = "failed";
+      },
+      "reconcile_job",
+    ],
+    [
+      "a connecting runtime does not mask an independent Cloud failure",
+      () => {
+        state.connectionState = "connecting";
+        state.capabilities.data = undefined;
+        state.capabilities.isError = true;
+        state.capabilities.error = new TypeError("capabilities payload");
+      },
+      "capabilities_query",
+    ],
+    [
+      "a connecting runtime does not mask an independent reconcile failure",
+      () => {
+        state.connectionState = "connecting";
+        state.reconcileIsError = true;
+        state.reconcileError = new TypeError("reconcile payload");
+      },
+      "reconcile_query",
+    ],
+  ] as const)("settles crossed state: %s", async (_name, configure, expectedStage) => {
+    configure();
+    renderHook(() => useFirstRunAuthAdoption());
+    await waitForDecision();
+
+    expect(useAuthSetupOnboardingStore.getState().adoptedHarnessKinds).toEqual([]);
+    expect(diagnosticValues(diagnostics[0]!).failure_stage).toBe(expectedStage);
+    expect(mocks.refetchAgents).not.toHaveBeenCalled();
+  });
+
+  it("uses deterministic terminal precedence when several failures coexist", async () => {
+    state.connectionState = "failed";
+    state.selections.data = undefined;
+    state.selections.isError = true;
+    state.selections.error = new TypeError("selections payload");
+    state.capabilities.data = undefined;
+    state.capabilities.isError = true;
+    state.capabilities.error = new TypeError("capabilities payload");
+    state.reconcileIsError = true;
+    state.reconcileError = new TypeError("reconcile payload");
+    state.reconcileStatus = "failed";
+
+    renderHook(() => useFirstRunAuthAdoption());
+    await waitForDecision();
+
+    expect(diagnosticValues(diagnostics[0]!)).toEqual({
+      failure_stage: "runtime_connection",
+    });
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    [
+      "selections before capabilities and reconcile",
+      () => {
+        state.selections.data = undefined;
+        state.selections.isError = true;
+        state.selections.error = new TypeError("selections payload");
+        state.capabilities.data = undefined;
+        state.capabilities.isError = true;
+        state.capabilities.error = new TypeError("capabilities payload");
+        state.reconcileIsError = true;
+        state.reconcileError = new TypeError("reconcile payload");
+      },
+      "selections_query",
+    ],
+    [
+      "capabilities before reconcile when selections are usable",
+      () => {
+        state.selections.isError = true;
+        state.selections.error = new TypeError("background selections payload");
+        state.capabilities.data = undefined;
+        state.capabilities.isError = true;
+        state.capabilities.error = new TypeError("capabilities payload");
+        state.reconcileIsError = true;
+        state.reconcileError = new TypeError("reconcile payload");
+      },
+      "capabilities_query",
+    ],
+  ] as const)("orders terminal stages: %s", async (_name, configure, expectedStage) => {
+    configure();
+    renderHook(() => useFirstRunAuthAdoption());
+    await waitForDecision();
+
+    expect(diagnosticValues(diagnostics[0]!).failure_stage).toBe(expectedStage);
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it("does not retry after a crossed pending-plus-terminal state recovers", async () => {
+    state.selections.data = undefined;
+    state.reconcileStatus = "failed";
+    const { rerender } = renderHook(() => useFirstRunAuthAdoption());
+    await waitForDecision();
+
+    expect(diagnosticValues(diagnostics[0]!).failure_stage).toBe("reconcile_job");
+
+    state.selections.data = [];
+    state.reconcileStatus = "completed";
+    rerender();
+    await flushAdoption();
+
+    expect(mocks.refetchAgents).not.toHaveBeenCalled();
+    expect(mocks.putMutate).not.toHaveBeenCalled();
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it.each([
     ["selections", "selections_query"],
     ["capabilities", "capabilities_query"],
   ] as const)(

--- a/apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.test.tsx
+++ b/apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.test.tsx
@@ -13,54 +13,93 @@ import {
 
 const state = vi.hoisted(() => ({
   cloudActive: true,
+  isDesktop: true,
+  connectionState: "healthy" as "connecting" | "healthy" | "failed",
   capabilities: {
     data: { gatewayEnabled: true } as { gatewayEnabled: boolean } | undefined,
+    isError: false,
+    error: null as unknown,
   },
   selections: {
     data: [] as Array<Record<string, unknown>> | undefined,
+    isError: false,
+    error: null as unknown,
   },
-  agents: [] as AgentSummary[],
-  agentsLoading: false,
   reconcileSnapshot: {} as Record<string, unknown> | null,
   reconcileStatus: "completed" as string,
+  reconcileIsError: false,
+  reconcileError: null as unknown,
+  freshAgents: [] as AgentSummary[],
 }));
-const putMutate = vi.hoisted(() => vi.fn());
+
+const mocks = vi.hoisted(() => ({
+  capabilitiesEnabled: vi.fn(),
+  selectionsEnabled: vi.fn(),
+  refetchAgents: vi.fn(),
+  planner: vi.fn(),
+  putMutate: vi.fn(),
+}));
+
 let diagnostics: RendererDiagnosticInput[] = [];
 
 vi.mock("@proliferate/cloud-sdk-react", () => ({
-  useAgentGatewayCapabilities: () => state.capabilities,
-  useAuthSelections: () => state.selections,
-  usePutAuthSelections: () => ({ mutate: putMutate, isPending: false }),
+  useAgentGatewayCapabilities: (enabled: boolean) => {
+    mocks.capabilitiesEnabled(enabled);
+    return state.capabilities;
+  },
+  useAuthSelections: (_surface: unknown, enabled: boolean) => {
+    mocks.selectionsEnabled(enabled);
+    return state.selections;
+  },
+  usePutAuthSelections: () => ({ mutate: mocks.putMutate, isPending: false }),
 }));
 
 vi.mock("#product/hooks/cloud/derived/use-cloud-availability-state", () => ({
   useCloudAvailabilityState: () => ({ cloudActive: state.cloudActive }),
 }));
 
+vi.mock("#product/host/ProductHostProvider", () => ({
+  useProductHost: () => ({ desktop: state.isDesktop ? {} : null }),
+}));
+
+vi.mock("#product/stores/sessions/harness-connection-store", () => ({
+  useHarnessConnectionStore: (
+    selector: (value: { connectionState: typeof state.connectionState }) => unknown,
+  ) => selector({ connectionState: state.connectionState }),
+}));
+
 vi.mock("#product/hooks/agents/derived/use-agent-catalog", () => ({
   useAgentCatalog: () => ({
-    agents: state.agents,
-    isLoading: state.agentsLoading,
+    refetch: mocks.refetchAgents,
     reconcileSnapshot: state.reconcileSnapshot,
     reconcileStatus: state.reconcileStatus,
+    reconcileIsError: state.reconcileIsError,
+    reconcileError: state.reconcileError,
   }),
+}));
+
+vi.mock("#product/lib/domain/agents/auth-onboarding", () => ({
+  planFirstRunAuthAdoption: mocks.planner,
 }));
 
 function agent(overrides: Partial<AgentSummary> = {}): AgentSummary {
   return {
     kind: "claude",
     displayName: "Claude Code",
-    credentialState: "ready",
+    credentialState: "login_required",
     installState: "installed",
-    readiness: "ready",
+    readiness: "credentials_required",
     supportsLogin: true,
     ...overrides,
   } as AgentSummary;
 }
 
-const GATEWAY_BODY = { sources: [{ sourceKind: "gateway", enabled: true }] };
+function diagnosticValues(input: RendererDiagnosticInput) {
+  return Object.fromEntries(
+    Object.entries(input.fields ?? {}).map(([key, field]) => [key, field.value]),
+  );
+}
 
-/** The planner is dynamically imported (login-chunk split); let it settle. */
 async function flushAdoption() {
   await act(async () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -68,7 +107,6 @@ async function flushAdoption() {
   });
 }
 
-/** The decision ran (possibly adopting nothing) once the store has recorded it. */
 async function waitForDecision() {
   await waitFor(() => {
     expect(useAuthSetupOnboardingStore.getState().adoptedHarnessKinds).not.toBeNull();
@@ -78,177 +116,277 @@ async function waitForDecision() {
 beforeEach(() => {
   diagnostics = [];
   setRendererDiagnosticsSink({ emit: (input) => diagnostics.push(input) });
+  vi.spyOn(Date, "now").mockReturnValue(1_723_456_789);
+  mocks.refetchAgents.mockReset();
+  mocks.planner.mockReset();
+  mocks.putMutate.mockReset();
+
+  state.cloudActive = true;
+  state.isDesktop = true;
+  state.connectionState = "healthy";
+  state.capabilities.data = { gatewayEnabled: true };
+  state.capabilities.isError = false;
+  state.capabilities.error = null;
+  state.selections.data = [];
+  state.selections.isError = false;
+  state.selections.error = null;
+  state.reconcileSnapshot = {};
+  state.reconcileStatus = "completed";
+  state.reconcileIsError = false;
+  state.reconcileError = null;
+  state.freshAgents = [agent()];
+
+  mocks.refetchAgents.mockImplementation(async () => ({
+    data: state.freshAgents,
+    isError: false,
+    error: null,
+  }));
+  mocks.planner.mockImplementation((input: {
+    agents: AgentSummary[];
+    selectionCount: number;
+    gatewayEnabled: boolean;
+  }) => (
+    input.selectionCount === 0 && input.gatewayEnabled
+      ? input.agents.map((item) => ({ harnessKind: item.kind, surface: "local" }))
+      : []
+  ));
 });
 
 afterEach(() => {
   resetRendererDiagnosticsSinkForTest();
   cleanup();
+  vi.restoreAllMocks();
   vi.clearAllMocks();
   useAuthSetupOnboardingStore.getState().resetForTests();
-  state.cloudActive = true;
-  state.capabilities.data = { gatewayEnabled: true };
-  state.selections.data = [];
-  state.agents = [];
-  state.agentsLoading = false;
-  state.reconcileSnapshot = {};
-  state.reconcileStatus = "completed";
 });
 
 describe("useFirstRunAuthAdoption", () => {
-  it("writes nothing when native creds are detected (native is implicit)", async () => {
-    state.agents = [
-      agent({ kind: "claude" }),
-      agent({ kind: "codex", credentialState: "login_required" }),
-    ];
-
-    renderHook(() => useFirstRunAuthAdoption());
-    await waitForDecision();
-
-    expect(putMutate).not.toHaveBeenCalled();
-  });
-
-  it("is a no-op when selections already exist", async () => {
-    state.agents = [agent({ kind: "claude", credentialState: "login_required" })];
-    state.selections.data = [
-      { harnessKind: "claude", surface: "local", sourceKind: "gateway", enabled: true },
-    ];
-
-    renderHook(() => useFirstRunAuthAdoption());
-    await waitForDecision();
-
-    expect(putMutate).not.toHaveBeenCalled();
-  });
-
-  it("preselects the gateway when nothing is detected and the gateway is enabled", async () => {
-    state.agents = [agent({ kind: "claude", credentialState: "login_required" })];
-
-    renderHook(() => useFirstRunAuthAdoption());
-
-    await waitFor(() => expect(putMutate).toHaveBeenCalledTimes(1));
-    expect(putMutate).toHaveBeenCalledWith(
-      { harnessKind: "claude", surface: "local", body: GATEWAY_BODY },
-      expect.anything(),
-    );
-  });
-
-  it("records a failed first-run adoption through the renderer sink", async () => {
-    state.agents = [agent({ kind: "claude", credentialState: "login_required" })];
-    renderHook(() => useFirstRunAuthAdoption());
-    await waitFor(() => expect(putMutate).toHaveBeenCalledTimes(1));
-
-    const options = putMutate.mock.calls[0]?.[1] as { onError(error: unknown): void };
-    options.onError(new TypeError("adoption failed"));
-
-    expect(diagnostics).toContainEqual(expect.objectContaining({
-      name: "renderer.agent_auth.first_run_adoption_failed",
-      errorClassification: "first_run_adoption_failed",
-    }));
-  });
-
-  it("does nothing when nothing is detected and the gateway is disabled", async () => {
-    state.agents = [agent({ kind: "claude", credentialState: "login_required" })];
-    state.capabilities.data = { gatewayEnabled: false };
-
-    renderHook(() => useFirstRunAuthAdoption());
-    await waitForDecision();
-
-    expect(putMutate).not.toHaveBeenCalled();
-  });
-
-  it("waits for selections to load and then runs only once", async () => {
-    state.agents = [agent({ kind: "claude", credentialState: "login_required" })];
-    state.selections.data = undefined;
+  it("settles active Web as a silent no-op with both Cloud queries disabled", async () => {
+    state.isDesktop = false;
+    state.connectionState = "failed";
 
     const { rerender } = renderHook(() => useFirstRunAuthAdoption());
-    await flushAdoption();
-    expect(putMutate).not.toHaveBeenCalled();
+    await waitForDecision();
 
-    state.selections.data = [];
-    rerender();
-    await waitFor(() => expect(putMutate).toHaveBeenCalledTimes(1));
+    expect(mocks.capabilitiesEnabled).toHaveBeenLastCalledWith(false);
+    expect(mocks.selectionsEnabled).toHaveBeenLastCalledWith(false);
+    expect(useAuthSetupOnboardingStore.getState()).toMatchObject({
+      adoptedHarnessKinds: [],
+      adoptionStartedAt: 1_723_456_789,
+    });
+    expect(mocks.refetchAgents).not.toHaveBeenCalled();
+    expect(mocks.planner).not.toHaveBeenCalled();
+    expect(mocks.putMutate).not.toHaveBeenCalled();
+    expect(diagnostics).toEqual([]);
 
+    vi.mocked(Date.now).mockReturnValue(1_723_456_790);
     rerender();
     await flushAdoption();
-    expect(putMutate).toHaveBeenCalledTimes(1);
+    expect(useAuthSetupOnboardingStore.getState().adoptionStartedAt)
+      .toBe(1_723_456_789);
   });
 
-  it("waits for reconcile hydration to settle before deciding", async () => {
-    // Mid-hydration: the reconcile job is still running, so the one-shot
-    // decision must not fire off a stale snapshot.
-    state.reconcileStatus = "running";
-    state.agents = [agent({ kind: "claude", credentialState: "login_required" })];
-
-    const { rerender } = renderHook(() => useFirstRunAuthAdoption());
-    await flushAdoption();
-    expect(putMutate).not.toHaveBeenCalled();
-
-    state.reconcileStatus = "completed";
-    state.agents = [agent({ kind: "claude", credentialState: "login_required" })];
-    rerender();
-
-    await waitFor(() => expect(putMutate).toHaveBeenCalledTimes(1));
-    expect(putMutate).toHaveBeenCalledWith(
-      { harnessKind: "claude", surface: "local", body: GATEWAY_BODY },
-      expect.anything(),
-    );
-  });
-
-  it("waits until a reconcile snapshot exists before deciding", async () => {
-    state.reconcileSnapshot = null;
-    state.agents = [agent({ kind: "claude", credentialState: "login_required" })];
-
-    const { rerender } = renderHook(() => useFirstRunAuthAdoption());
-    await flushAdoption();
-    expect(putMutate).not.toHaveBeenCalled();
-
-    state.reconcileSnapshot = {};
-    rerender();
-    await waitFor(() => expect(putMutate).toHaveBeenCalledTimes(1));
-  });
-
-  it("does nothing while cloud is inactive", async () => {
+  it("keeps inactive Cloud pending and can adopt after active Desktop transition", async () => {
     state.cloudActive = false;
-    state.agents = [agent({ kind: "claude", credentialState: "login_required" })];
-
-    renderHook(() => useFirstRunAuthAdoption());
+    const { rerender } = renderHook(() => useFirstRunAuthAdoption());
     await flushAdoption();
 
-    expect(putMutate).not.toHaveBeenCalled();
+    expect(mocks.capabilitiesEnabled).toHaveBeenLastCalledWith(false);
+    expect(mocks.selectionsEnabled).toHaveBeenLastCalledWith(false);
+    expect(useAuthSetupOnboardingStore.getState().adoptedHarnessKinds).toBeNull();
+    expect(mocks.refetchAgents).not.toHaveBeenCalled();
+
+    state.cloudActive = true;
+    rerender();
+    await waitFor(() => expect(mocks.putMutate).toHaveBeenCalledTimes(1));
+
+    expect(mocks.capabilitiesEnabled).toHaveBeenLastCalledWith(true);
+    expect(mocks.selectionsEnabled).toHaveBeenLastCalledWith(true);
   });
 
-  // Ack-gated onboarding step (agent-auth.md, Proof C7): the "setting up"
-  // step reads the adoption decision from the auth-setup store.
-  it("records the adopted harness kinds for the onboarding step", async () => {
-    state.agents = [
-      agent({ kind: "claude", credentialState: "login_required" }),
-      agent({ kind: "codex", credentialState: "login_required" }),
-    ];
+  it("waits while the Desktop runtime is connecting", async () => {
+    state.connectionState = "connecting";
+    const { rerender } = renderHook(() => useFirstRunAuthAdoption());
+    await flushAdoption();
 
-    renderHook(() => useFirstRunAuthAdoption());
-    await waitForDecision();
+    expect(useAuthSetupOnboardingStore.getState().adoptedHarnessKinds).toBeNull();
+    expect(mocks.refetchAgents).not.toHaveBeenCalled();
 
-    const store = useAuthSetupOnboardingStore.getState();
-    expect(store.adoptedHarnessKinds).toEqual(["claude", "codex"]);
-    expect(store.adoptionStartedAt).not.toBeNull();
+    state.connectionState = "healthy";
+    rerender();
+    await waitFor(() => expect(mocks.refetchAgents).toHaveBeenCalledTimes(1));
   });
 
-  it("records an empty adoption (native creds detected) so the step stays hidden", async () => {
-    state.agents = [agent({ kind: "claude" })];
-
-    renderHook(() => useFirstRunAuthAdoption());
+  it("settles a failed Desktop runtime once and does not retry after recovery", async () => {
+    state.connectionState = "failed";
+    const { rerender } = renderHook(() => useFirstRunAuthAdoption());
     await waitForDecision();
 
-    expect(putMutate).not.toHaveBeenCalled();
     expect(useAuthSetupOnboardingStore.getState().adoptedHarnessKinds).toEqual([]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnosticValues(diagnostics[0]!)).toEqual({
+      failure_stage: "runtime_connection",
+    });
+
+    state.connectionState = "healthy";
+    rerender();
+    await flushAdoption();
+    expect(mocks.refetchAgents).not.toHaveBeenCalled();
+    expect(diagnostics).toHaveLength(1);
   });
 
-  it("records nothing while the decision has not run (cloud inactive)", async () => {
-    state.cloudActive = false;
-    state.agents = [agent({ kind: "claude", credentialState: "login_required" })];
+  it.each([
+    ["selections", "selections_query"],
+    ["capabilities", "capabilities_query"],
+  ] as const)(
+    "waits for pending %s and settles a terminal no-data error",
+    async (queryName, expectedStage) => {
+      const query = state[queryName];
+      query.data = undefined;
+      const { rerender } = renderHook(() => useFirstRunAuthAdoption());
+      await flushAdoption();
 
+      expect(useAuthSetupOnboardingStore.getState().adoptedHarnessKinds).toBeNull();
+      expect(mocks.refetchAgents).not.toHaveBeenCalled();
+
+      const error = new TypeError("private provider response");
+      query.isError = true;
+      query.error = error;
+      rerender();
+      await waitForDecision();
+
+      expect(useAuthSetupOnboardingStore.getState().adoptedHarnessKinds).toEqual([]);
+      expect(diagnosticValues(diagnostics[0]!)).toEqual({
+        failure_stage: expectedStage,
+        error_name: "TypeError",
+      });
+      expect(JSON.stringify(diagnostics[0])).not.toContain("private provider response");
+    },
+  );
+
+  it("uses cached selections and capabilities despite background errors", async () => {
+    state.selections.isError = true;
+    state.selections.error = new Error("stale selections refresh failed");
+    state.capabilities.isError = true;
+    state.capabilities.error = new Error("stale capabilities refresh failed");
+
+    renderHook(() => useFirstRunAuthAdoption());
+    await waitFor(() => expect(mocks.refetchAgents).toHaveBeenCalledTimes(1));
+
+    expect(mocks.putMutate).toHaveBeenCalledTimes(1);
+    expect(diagnostics).toEqual([]);
+  });
+
+  it("keeps a missing reconcile snapshot pending", async () => {
+    state.reconcileSnapshot = null;
     renderHook(() => useFirstRunAuthAdoption());
     await flushAdoption();
 
     expect(useAuthSetupOnboardingStore.getState().adoptedHarnessKinds).toBeNull();
+    expect(mocks.refetchAgents).not.toHaveBeenCalled();
+  });
+
+  it.each(["idle", "queued", "running"])(
+    "keeps reconcile %s pending",
+    async (status) => {
+      state.reconcileStatus = status;
+      renderHook(() => useFirstRunAuthAdoption());
+      await flushAdoption();
+
+      expect(useAuthSetupOnboardingStore.getState().adoptedHarnessKinds).toBeNull();
+      expect(mocks.refetchAgents).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    Object.assign(new Error("missing endpoint"), { name: "AnyHarnessError", status: 404 }),
+    Object.assign(new Error("transport response"), { name: "NetworkError" }),
+  ])("settles reconcile query errors without exposing their payload", async (error) => {
+    state.reconcileIsError = true;
+    state.reconcileError = error;
+    renderHook(() => useFirstRunAuthAdoption());
+    await waitForDecision();
+
+    expect(useAuthSetupOnboardingStore.getState().adoptedHarnessKinds).toEqual([]);
+    expect(diagnosticValues(diagnostics[0]!)).toEqual({
+      failure_stage: "reconcile_query",
+      error_name: error.name,
+    });
+    expect(JSON.stringify(diagnostics[0])).not.toContain(error.message);
+    expect(mocks.refetchAgents).not.toHaveBeenCalled();
+  });
+
+  it("settles a failed reconcile job without copying job results", async () => {
+    state.reconcileStatus = "failed";
+    state.reconcileSnapshot = {
+      message: "private runtime path /Users/example/repo",
+      results: [{ detail: "provider payload" }],
+    };
+    renderHook(() => useFirstRunAuthAdoption());
+    await waitForDecision();
+
+    expect(diagnosticValues(diagnostics[0]!)).toEqual({
+      failure_stage: "reconcile_job",
+    });
+    expect(JSON.stringify(diagnostics[0])).not.toContain("private runtime path");
+    expect(JSON.stringify(diagnostics[0])).not.toContain("provider payload");
+  });
+
+  it("uses completed reconcile to refetch once and pass settled Cloud inputs", async () => {
+    state.selections.data = [{ harnessKind: "codex" }];
+    state.capabilities.data = { gatewayEnabled: false };
+    state.freshAgents = [agent({ kind: "codex" })];
+
+    const { rerender } = renderHook(() => useFirstRunAuthAdoption());
+    await waitForDecision();
+
+    expect(mocks.refetchAgents).toHaveBeenCalledTimes(1);
+    expect(mocks.refetchAgents).toHaveBeenCalledWith({ cancelRefetch: false });
+    expect(mocks.planner).toHaveBeenCalledWith({
+      agents: state.freshAgents,
+      selectionCount: 1,
+      gatewayEnabled: false,
+    });
+    expect(useAuthSetupOnboardingStore.getState().adoptedHarnessKinds).toEqual([]);
+    expect(mocks.putMutate).not.toHaveBeenCalled();
+
+    rerender();
+    await flushAdoption();
+    expect(mocks.refetchAgents).toHaveBeenCalledTimes(1);
+  });
+
+  it("records adopted kinds and preserves planner write order", async () => {
+    state.freshAgents = [agent({ kind: "claude" }), agent({ kind: "codex" })];
+
+    renderHook(() => useFirstRunAuthAdoption());
+    await waitFor(() => expect(mocks.putMutate).toHaveBeenCalledTimes(2));
+
+    expect(useAuthSetupOnboardingStore.getState().adoptedHarnessKinds)
+      .toEqual(["claude", "codex"]);
+    expect(mocks.putMutate.mock.calls.map(([input]) => input.harnessKind))
+      .toEqual(["claude", "codex"]);
+    expect(useAuthSetupOnboardingStore.getState().adoptionStartedAt)
+      .toBe(1_723_456_789);
+  });
+
+  it("keeps selection-write diagnostics bounded to stage, safe name, and harness", async () => {
+    renderHook(() => useFirstRunAuthAdoption());
+    await waitFor(() => expect(mocks.putMutate).toHaveBeenCalledTimes(1));
+
+    const options = mocks.putMutate.mock.calls[0]?.[1] as {
+      onError(error: unknown): void;
+    };
+    const error = Object.assign(new TypeError("secret response body"), {
+      payload: { token: "do-not-ship" },
+    });
+    options.onError(error);
+
+    expect(diagnosticValues(diagnostics[0]!)).toEqual({
+      failure_stage: "selection_write",
+      error_name: "TypeError",
+      harness_kind: "claude",
+    });
+    expect(JSON.stringify(diagnostics[0])).not.toContain("secret response body");
+    expect(JSON.stringify(diagnostics[0])).not.toContain("do-not-ship");
   });
 });

--- a/apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.test.tsx
+++ b/apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.test.tsx
@@ -264,25 +264,6 @@ describe("useFirstRunAuthAdoption", () => {
       },
       "reconcile_job",
     ],
-    [
-      "a connecting runtime does not mask an independent Cloud failure",
-      () => {
-        state.connectionState = "connecting";
-        state.capabilities.data = undefined;
-        state.capabilities.isError = true;
-        state.capabilities.error = new TypeError("capabilities payload");
-      },
-      "capabilities_query",
-    ],
-    [
-      "a connecting runtime does not mask an independent reconcile failure",
-      () => {
-        state.connectionState = "connecting";
-        state.reconcileIsError = true;
-        state.reconcileError = new TypeError("reconcile payload");
-      },
-      "reconcile_query",
-    ],
   ] as const)("settles crossed state: %s", async (_name, configure, expectedStage) => {
     configure();
     renderHook(() => useFirstRunAuthAdoption());
@@ -292,6 +273,58 @@ describe("useFirstRunAuthAdoption", () => {
     expect(diagnosticValues(diagnostics[0]!).failure_stage).toBe(expectedStage);
     expect(mocks.refetchAgents).not.toHaveBeenCalled();
   });
+
+  it.each([
+    [
+      "capabilities failure",
+      () => {
+        state.capabilities.data = undefined;
+        state.capabilities.isError = true;
+        state.capabilities.error = new TypeError("capabilities payload");
+      },
+      "capabilities_query",
+    ],
+    [
+      "reconcile failure",
+      () => {
+        state.reconcileIsError = true;
+        state.reconcileError = new TypeError("reconcile payload");
+      },
+      "reconcile_query",
+    ],
+    [
+      "failed reconcile job",
+      () => {
+        state.reconcileStatus = "failed";
+      },
+      "reconcile_job",
+    ],
+  ] as const)(
+    "keeps a connecting runtime pending despite %s, then settles once healthy",
+    async (_name, configure, expectedStage) => {
+      state.connectionState = "connecting";
+      configure();
+      const { rerender } = renderHook(() => useFirstRunAuthAdoption());
+      await flushAdoption();
+
+      expect(useAuthSetupOnboardingStore.getState().adoptedHarnessKinds).toBeNull();
+      expect(diagnostics).toEqual([]);
+      expect(mocks.refetchAgents).not.toHaveBeenCalled();
+
+      state.connectionState = "healthy";
+      rerender();
+      await waitForDecision();
+
+      expect(useAuthSetupOnboardingStore.getState().adoptedHarnessKinds).toEqual([]);
+      expect(diagnosticValues(diagnostics[0]!).failure_stage).toBe(expectedStage);
+      expect(diagnostics).toHaveLength(1);
+      expect(mocks.refetchAgents).not.toHaveBeenCalled();
+
+      rerender();
+      await flushAdoption();
+      expect(diagnostics).toHaveLength(1);
+    },
+  );
 
   it("uses deterministic terminal precedence when several failures coexist", async () => {
     state.connectionState = "failed";

--- a/apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.ts
+++ b/apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.ts
@@ -75,16 +75,20 @@ export function useFirstRunAuthAdoption() {
       );
     };
 
-    const selections = selectionsQuery.data;
-    const gatewayEnabled = capabilitiesQuery.data?.gatewayEnabled;
-
-    // Arbitrate every already-known terminal before returning for an earlier
-    // pending prerequisite. Precedence is stable and ownership-ordered:
-    // runtime, selections, capabilities, reconcile query, reconcile job.
     if (connectionState === "failed") {
       settleFailure("runtime_connection");
       return;
     }
+    if (connectionState === "connecting") {
+      return;
+    }
+
+    const selections = selectionsQuery.data;
+    const gatewayEnabled = capabilitiesQuery.data?.gatewayEnabled;
+
+    // With a healthy runtime, arbitrate every already-known peer terminal
+    // before returning for an earlier pending prerequisite. Precedence is
+    // selections, capabilities, reconcile query, then reconcile job.
     if (selections === undefined && selectionsQuery.isError) {
       settleFailure("selections_query", selectionsQuery.error);
       return;
@@ -105,8 +109,7 @@ export function useFirstRunAuthAdoption() {
     // Once every known terminal has had a chance to settle the one shot, any
     // still-pending prerequisite blocks only the successful adoption path.
     if (
-      connectionState === "connecting"
-      || selections === undefined
+      selections === undefined
       || gatewayEnabled === undefined
       || reconcileSnapshot === null
     ) {

--- a/apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.ts
+++ b/apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.ts
@@ -6,12 +6,14 @@ import {
 } from "@proliferate/cloud-sdk-react";
 import { useAgentCatalog } from "#product/hooks/agents/derived/use-agent-catalog";
 import { useCloudAvailabilityState } from "#product/hooks/cloud/derived/use-cloud-availability-state";
-import { useAuthSetupOnboardingStore } from "#product/stores/agents/auth-setup-onboarding-store";
+import { useProductHost } from "#product/host/ProductHostProvider";
 import {
-  diagnosticField,
-  recordRendererDiagnostic,
-} from "#product/lib/infra/diagnostics/renderer-diagnostics-port";
-import { safeRendererErrorName } from "#product/lib/infra/diagnostics/renderer-diagnostic-values";
+  runFirstRunAuthAdoption,
+  settleFirstRunAuthAdoptionFailure,
+} from "#product/lib/workflows/agents/first-run-auth-adoption";
+import { useAuthSetupOnboardingStore } from "#product/stores/agents/auth-setup-onboarding-store";
+import { recordRendererDiagnostic } from "#product/lib/infra/diagnostics/renderer-diagnostics-port";
+import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
 
 /**
  * First-run adoption of the managed gateway into auth selections (spec §9).
@@ -24,13 +26,17 @@ import { safeRendererErrorName } from "#product/lib/infra/diagnostics/renderer-d
  */
 export function useFirstRunAuthAdoption() {
   const { cloudActive } = useCloudAvailabilityState();
-  const capabilitiesQuery = useAgentGatewayCapabilities(cloudActive);
-  const selectionsQuery = useAuthSelections(null, cloudActive);
+  const isDesktop = useProductHost().desktop !== null;
+  const connectionState = useHarnessConnectionStore((state) => state.connectionState);
+  const workflowQueriesEnabled = cloudActive && isDesktop;
+  const capabilitiesQuery = useAgentGatewayCapabilities(workflowQueriesEnabled);
+  const selectionsQuery = useAuthSelections(null, workflowQueriesEnabled);
   const {
-    agents,
-    isLoading: agentsLoading,
+    refetch: refetchAgents,
     reconcileSnapshot,
     reconcileStatus,
+    reconcileIsError,
+    reconcileError,
   } = useAgentCatalog();
   const putSelections = usePutAuthSelections();
   const recordAdoption = useAuthSetupOnboardingStore(
@@ -38,90 +44,130 @@ export function useFirstRunAuthAdoption() {
   );
   const attemptedRef = useRef(false);
 
-  const selections = selectionsQuery.data;
-  const gatewayEnabled = capabilitiesQuery.data?.gatewayEnabled;
   const putMutate = putSelections.mutate;
-
-  // The runtime hydrates the bundled seed then runs an installed-only reconcile
-  // at startup; agent credential/install states are only trustworthy once that
-  // pass has SETTLED. Deciding from a mid-hydration snapshot permanently misses
-  // native creds for harnesses that hydrate after the (one-shot) decision.
-  const reconcileActive =
-    reconcileStatus === "queued" || reconcileStatus === "running";
-  const readinessSettled = reconcileSnapshot !== null && !reconcileActive;
 
   useEffect(() => {
     if (attemptedRef.current || !cloudActive) {
       return;
     }
-    // Wait until every input has settled before deciding anything.
-    if (selections === undefined || gatewayEnabled === undefined) {
+
+    // Local auth adoption does not apply on Web. Settle without using any
+    // local-runtime result so downstream readiness can distinguish no-op from
+    // a still-pending Desktop decision.
+    if (!isDesktop) {
+      attemptedRef.current = true;
+      recordAdoption([], Date.now());
       return;
     }
-    if (agentsLoading || agents.length === 0) {
+
+    const settleFailure = (
+      stage: Parameters<typeof settleFirstRunAuthAdoptionFailure>[0]["stage"],
+      error?: unknown,
+    ) => {
+      attemptedRef.current = true;
+      settleFirstRunAuthAdoptionFailure(
+        { stage, ...(error === undefined ? {} : { error }) },
+        {
+          now: Date.now,
+          recordAdoption,
+          recordDiagnostic: recordRendererDiagnostic,
+        },
+      );
+    };
+
+    if (connectionState === "connecting") {
       return;
     }
-    if (!readinessSettled) {
+    if (connectionState === "failed") {
+      settleFailure("runtime_connection");
+      return;
+    }
+
+    const selections = selectionsQuery.data;
+    if (selections === undefined) {
+      if (selectionsQuery.isError) {
+        settleFailure("selections_query", selectionsQuery.error);
+      }
+      return;
+    }
+    const gatewayEnabled = capabilitiesQuery.data?.gatewayEnabled;
+    if (gatewayEnabled === undefined) {
+      if (capabilitiesQuery.isError) {
+        settleFailure("capabilities_query", capabilitiesQuery.error);
+      }
+      return;
+    }
+
+    if (reconcileIsError) {
+      settleFailure("reconcile_query", reconcileError);
+      return;
+    }
+    if (reconcileSnapshot === null) {
+      return;
+    }
+    if (reconcileStatus === "failed") {
+      settleFailure("reconcile_job");
+      return;
+    }
+    // `idle` is the startup service's pre-admission state, not a settled scan.
+    // queued/running are likewise pending. Only completed authorizes the fresh
+    // post-reconcile read and one-shot adoption workflow.
+    if (reconcileStatus !== "completed") {
       return;
     }
 
     attemptedRef.current = true;
-    void (async () => {
-      // Lazy: the adoption planner only ever runs for an authenticated,
-      // cloud-active user, so it (and the catalog-shape helpers it pulls in)
-      // stays out of the login first-load chunk (login runtime JS budget).
-      const { planFirstRunAuthAdoption } = await import(
-        "#product/lib/domain/agents/auth-onboarding"
-      );
-      const actions = planFirstRunAuthAdoption({
-        agents,
+    void runFirstRunAuthAdoption(
+      {
         selectionCount: selections.length,
         gatewayEnabled,
-      });
-      // Ack-gated onboarding step (agent-auth.md, Proof C7): record what was
-      // adopted (possibly nothing) so the "setting up" step knows which
-      // selections' `applied` flags to await — and whether to show at all.
-      recordAdoption(
-        actions.map((action) => action.harnessKind),
-        Date.now(),
-      );
-      for (const action of actions) {
-        putMutate(
-          {
-            harnessKind: action.harnessKind,
-            surface: action.surface,
-            body: { sources: [{ sourceKind: "gateway", enabled: true }] },
-          },
-          {
-            onError: (error) => {
-              recordRendererDiagnostic({
-                name: "renderer.agent_auth.first_run_adoption_failed",
-                severity: "warn",
-                kind: "message",
-                privacy: "operational",
-                fields: {
-                  harness_kind: diagnosticField(action.harnessKind, "operational"),
-                  error_name: diagnosticField(safeRendererErrorName(error), "operational"),
-                },
-                errorClassification: "first_run_adoption_failed",
-              });
-              console.warn(
-                `[agent-auth] first-run adoption failed for ${action.harnessKind}`,
-                error,
-              );
+      },
+      {
+        now: Date.now,
+        recordAdoption,
+        recordDiagnostic: recordRendererDiagnostic,
+        readFreshAgents: async () => {
+          const result = await refetchAgents({ cancelRefetch: false });
+          return result.isError
+            ? { kind: "failure", error: result.error }
+            : { kind: "success", agents: result.data ?? [] };
+        },
+        // Lazy: the planner stays out of the login first-load chunk and is
+        // loaded only after authenticated Desktop reconciliation completes.
+        loadPlanner: async () => {
+          const { planFirstRunAuthAdoption } = await import(
+            "#product/lib/domain/agents/auth-onboarding"
+          );
+          return planFirstRunAuthAdoption;
+        },
+        writeSelection: (action, onError) => {
+          putMutate(
+            {
+              harnessKind: action.harnessKind,
+              surface: action.surface,
+              body: { sources: [{ sourceKind: "gateway", enabled: true }] },
             },
-          },
-        );
-      }
-    })();
+            { onError },
+          );
+        },
+      },
+    );
   }, [
-    agents,
-    agentsLoading,
+    capabilitiesQuery.data,
+    capabilitiesQuery.error,
+    capabilitiesQuery.isError,
     cloudActive,
-    gatewayEnabled,
-    readinessSettled,
+    connectionState,
+    isDesktop,
+    reconcileError,
+    reconcileIsError,
+    reconcileSnapshot,
+    reconcileStatus,
     recordAdoption,
-    selections,
+    refetchAgents,
+    selectionsQuery.data,
+    selectionsQuery.error,
+    selectionsQuery.isError,
     putMutate,
   ]);
 }

--- a/apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.ts
+++ b/apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.ts
@@ -75,38 +75,41 @@ export function useFirstRunAuthAdoption() {
       );
     };
 
-    if (connectionState === "connecting") {
-      return;
-    }
+    const selections = selectionsQuery.data;
+    const gatewayEnabled = capabilitiesQuery.data?.gatewayEnabled;
+
+    // Arbitrate every already-known terminal before returning for an earlier
+    // pending prerequisite. Precedence is stable and ownership-ordered:
+    // runtime, selections, capabilities, reconcile query, reconcile job.
     if (connectionState === "failed") {
       settleFailure("runtime_connection");
       return;
     }
-
-    const selections = selectionsQuery.data;
-    if (selections === undefined) {
-      if (selectionsQuery.isError) {
-        settleFailure("selections_query", selectionsQuery.error);
-      }
+    if (selections === undefined && selectionsQuery.isError) {
+      settleFailure("selections_query", selectionsQuery.error);
       return;
     }
-    const gatewayEnabled = capabilitiesQuery.data?.gatewayEnabled;
-    if (gatewayEnabled === undefined) {
-      if (capabilitiesQuery.isError) {
-        settleFailure("capabilities_query", capabilitiesQuery.error);
-      }
+    if (gatewayEnabled === undefined && capabilitiesQuery.isError) {
+      settleFailure("capabilities_query", capabilitiesQuery.error);
       return;
     }
-
     if (reconcileIsError) {
       settleFailure("reconcile_query", reconcileError);
       return;
     }
-    if (reconcileSnapshot === null) {
-      return;
-    }
     if (reconcileStatus === "failed") {
       settleFailure("reconcile_job");
+      return;
+    }
+
+    // Once every known terminal has had a chance to settle the one shot, any
+    // still-pending prerequisite blocks only the successful adoption path.
+    if (
+      connectionState === "connecting"
+      || selections === undefined
+      || gatewayEnabled === undefined
+      || reconcileSnapshot === null
+    ) {
       return;
     }
     // `idle` is the startup service's pre-admission state, not a settled scan.

--- a/apps/packages/product-client/src/lib/workflows/agents/first-run-auth-adoption.test.ts
+++ b/apps/packages/product-client/src/lib/workflows/agents/first-run-auth-adoption.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentSummary } from "@anyharness/sdk";
+import {
+  runFirstRunAuthAdoption,
+  settleFirstRunAuthAdoptionFailure,
+  type FreshAgentCatalogResult,
+  type RunFirstRunAuthAdoptionDeps,
+} from "#product/lib/workflows/agents/first-run-auth-adoption";
+import type { RendererDiagnosticInput } from "#product/lib/infra/diagnostics/renderer-diagnostics-port";
+
+const SETTLED_AT = 1_723_456_789;
+
+function agent(kind: string): AgentSummary {
+  return {
+    kind,
+    displayName: kind,
+    credentialState: "login_required",
+    installState: "installed",
+    readiness: "credentials_required",
+    supportsLogin: true,
+  } as AgentSummary;
+}
+
+function createDeps(
+  overrides: Partial<RunFirstRunAuthAdoptionDeps> = {},
+): RunFirstRunAuthAdoptionDeps {
+  return {
+    now: vi.fn(() => SETTLED_AT),
+    recordAdoption: vi.fn(),
+    recordDiagnostic: vi.fn(),
+    readFreshAgents: vi.fn(async () => ({
+      kind: "success" as const,
+      agents: [],
+    })),
+    loadPlanner: vi.fn(async () => () => []),
+    writeSelection: vi.fn(),
+    ...overrides,
+  };
+}
+
+function diagnosticValues(input: RendererDiagnosticInput) {
+  return Object.fromEntries(
+    Object.entries(input.fields ?? {}).map(([key, field]) => [key, field.value]),
+  );
+}
+
+describe("runFirstRunAuthAdoption", () => {
+  it("does nothing before the fresh catalog read resolves", async () => {
+    let resolveFresh!: (result: FreshAgentCatalogResult) => void;
+    const deps = createDeps({
+      readFreshAgents: vi.fn(() => new Promise((resolve) => {
+        resolveFresh = resolve;
+      })),
+    });
+
+    const run = runFirstRunAuthAdoption(
+      { selectionCount: 0, gatewayEnabled: true },
+      deps,
+    );
+    await Promise.resolve();
+
+    expect(deps.recordAdoption).not.toHaveBeenCalled();
+    expect(deps.recordDiagnostic).not.toHaveBeenCalled();
+    expect(deps.loadPlanner).not.toHaveBeenCalled();
+    expect(deps.writeSelection).not.toHaveBeenCalled();
+
+    resolveFresh({ kind: "success", agents: [] });
+    await run;
+  });
+
+  it("plans only from the freshly resolved catalog", async () => {
+    const freshAgents = [agent("codex")];
+    const planner = vi.fn(() => [
+      { harnessKind: "codex", surface: "local" as const },
+    ]);
+    const deps = createDeps({
+      readFreshAgents: vi.fn(async () => ({
+        kind: "success" as const,
+        agents: freshAgents,
+      })),
+      loadPlanner: vi.fn(async () => planner),
+    });
+
+    await runFirstRunAuthAdoption(
+      { selectionCount: 0, gatewayEnabled: true },
+      deps,
+    );
+
+    expect(planner).toHaveBeenCalledWith({
+      agents: freshAgents,
+      selectionCount: 0,
+      gatewayEnabled: true,
+    });
+    expect(deps.recordAdoption).toHaveBeenCalledWith(["codex"], SETTLED_AT);
+  });
+
+  it("settles a successful fresh empty catalog without a diagnostic or write", async () => {
+    const deps = createDeps();
+
+    await runFirstRunAuthAdoption(
+      { selectionCount: 0, gatewayEnabled: true },
+      deps,
+    );
+
+    expect(deps.recordAdoption).toHaveBeenCalledWith([], SETTLED_AT);
+    expect(deps.recordDiagnostic).not.toHaveBeenCalled();
+    expect(deps.writeSelection).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "typed result",
+      async (): Promise<FreshAgentCatalogResult> => ({
+        kind: "failure",
+        error: new TypeError("secret result"),
+      }),
+    ],
+    ["rejection", async () => { throw new TypeError("secret rejection"); }],
+  ] as const)("settles and diagnoses a fresh-catalog %s", async (_label, readFreshAgents) => {
+    const deps = createDeps({ readFreshAgents: vi.fn(readFreshAgents) });
+
+    await runFirstRunAuthAdoption(
+      { selectionCount: 0, gatewayEnabled: true },
+      deps,
+    );
+
+    expect(deps.recordAdoption).toHaveBeenCalledWith([], SETTLED_AT);
+    expect(deps.recordAdoption).toHaveBeenCalledTimes(1);
+    expect(deps.loadPlanner).not.toHaveBeenCalled();
+    const diagnostic = vi.mocked(deps.recordDiagnostic).mock.calls[0]![0];
+    expect(diagnosticValues(diagnostic)).toEqual({
+      failure_stage: "agent_catalog_query",
+      error_name: "TypeError",
+    });
+    expect(JSON.stringify(diagnostic)).not.toContain("secret");
+  });
+
+  it("settles and diagnoses a lazy planner loader rejection", async () => {
+    const deps = createDeps({
+      loadPlanner: vi.fn(async () => {
+        throw new SyntaxError("private chunk URL");
+      }),
+    });
+
+    await runFirstRunAuthAdoption(
+      { selectionCount: 0, gatewayEnabled: true },
+      deps,
+    );
+
+    expect(deps.recordAdoption).toHaveBeenCalledWith([], SETTLED_AT);
+    const diagnostic = vi.mocked(deps.recordDiagnostic).mock.calls[0]![0];
+    expect(diagnosticValues(diagnostic)).toEqual({
+      failure_stage: "planner_import",
+      error_name: "SyntaxError",
+    });
+    expect(JSON.stringify(diagnostic)).not.toContain("private chunk URL");
+  });
+
+  it("settles and diagnoses a loaded planner throw", async () => {
+    const deps = createDeps({
+      loadPlanner: vi.fn(async () => () => {
+        throw new RangeError("private planner payload");
+      }),
+    });
+
+    await runFirstRunAuthAdoption(
+      { selectionCount: 0, gatewayEnabled: true },
+      deps,
+    );
+
+    expect(deps.recordAdoption).toHaveBeenCalledWith([], SETTLED_AT);
+    const diagnostic = vi.mocked(deps.recordDiagnostic).mock.calls[0]![0];
+    expect(diagnosticValues(diagnostic)).toEqual({
+      failure_stage: "planner",
+      error_name: "RangeError",
+    });
+    expect(JSON.stringify(diagnostic)).not.toContain("private planner payload");
+  });
+
+  it("records a successful empty plan without a failure diagnostic", async () => {
+    const deps = createDeps({
+      readFreshAgents: vi.fn(async () => ({
+        kind: "success" as const,
+        agents: [agent("claude")],
+      })),
+      loadPlanner: vi.fn(async () => () => []),
+    });
+
+    await runFirstRunAuthAdoption(
+      { selectionCount: 0, gatewayEnabled: false },
+      deps,
+    );
+
+    expect(deps.recordAdoption).toHaveBeenCalledWith([], SETTLED_AT);
+    expect(deps.recordDiagnostic).not.toHaveBeenCalled();
+    expect(deps.writeSelection).not.toHaveBeenCalled();
+  });
+
+  it("records once before dispatching multiple writes in planner order", async () => {
+    const calls: string[] = [];
+    const recordAdoption = vi.fn((kinds: readonly string[]) => {
+      calls.push(`record:${kinds.join(",")}`);
+    });
+    const writeSelection = vi.fn((action: { harnessKind: string }) => {
+      calls.push(`write:${action.harnessKind}`);
+    });
+    const deps = createDeps({
+      recordAdoption,
+      readFreshAgents: vi.fn(async () => ({
+        kind: "success" as const,
+        agents: [agent("claude"), agent("codex")],
+      })),
+      loadPlanner: vi.fn(async () => () => [
+        { harnessKind: "claude", surface: "local" as const },
+        { harnessKind: "codex", surface: "local" as const },
+      ]),
+      writeSelection,
+    });
+
+    await runFirstRunAuthAdoption(
+      { selectionCount: 0, gatewayEnabled: true },
+      deps,
+    );
+
+    expect(recordAdoption).toHaveBeenCalledTimes(1);
+    expect(recordAdoption).toHaveBeenCalledWith(["claude", "codex"], SETTLED_AT);
+    expect(calls).toEqual([
+      "record:claude,codex",
+      "write:claude",
+      "write:codex",
+    ]);
+  });
+
+  it("bounds a selection-write diagnostic to its fixed fields", async () => {
+    let onError!: (error: unknown) => void;
+    const deps = createDeps({
+      readFreshAgents: vi.fn(async () => ({
+        kind: "success" as const,
+        agents: [agent("claude")],
+      })),
+      loadPlanner: vi.fn(async () => () => [
+        { harnessKind: "claude", surface: "local" as const },
+      ]),
+      writeSelection: vi.fn((_action, callback) => {
+        onError = callback;
+      }),
+    });
+
+    await runFirstRunAuthAdoption(
+      { selectionCount: 0, gatewayEnabled: true },
+      deps,
+    );
+    onError(Object.assign(new TypeError("raw response"), {
+      payload: { token: "secret-token" },
+    }));
+
+    const diagnostic = vi.mocked(deps.recordDiagnostic).mock.calls[0]![0];
+    expect(diagnosticValues(diagnostic)).toEqual({
+      failure_stage: "selection_write",
+      error_name: "TypeError",
+      harness_kind: "claude",
+    });
+    expect(JSON.stringify(diagnostic)).not.toContain("raw response");
+    expect(JSON.stringify(diagnostic)).not.toContain("secret-token");
+  });
+});
+
+describe("settleFirstRunAuthAdoptionFailure", () => {
+  it("records the empty settlement before diagnostics and omits non-write harness ids", () => {
+    const calls: string[] = [];
+    const recordDiagnostic = vi.fn((input: RendererDiagnosticInput) => {
+      calls.push("diagnostic");
+      expect(diagnosticValues(input)).toEqual({
+        failure_stage: "reconcile_job",
+      });
+    });
+
+    settleFirstRunAuthAdoptionFailure(
+      {
+        stage: "reconcile_job",
+        harnessKind: "must-not-ship",
+      },
+      {
+        now: () => SETTLED_AT,
+        recordAdoption: (kinds, settledAt) => {
+          calls.push("settlement");
+          expect(kinds).toEqual([]);
+          expect(settledAt).toBe(SETTLED_AT);
+        },
+        recordDiagnostic,
+      },
+    );
+
+    expect(calls).toEqual(["settlement", "diagnostic"]);
+  });
+});

--- a/apps/packages/product-client/src/lib/workflows/agents/first-run-auth-adoption.ts
+++ b/apps/packages/product-client/src/lib/workflows/agents/first-run-auth-adoption.ts
@@ -1,0 +1,157 @@
+import type { AgentSummary } from "@anyharness/sdk";
+import type {
+  AuthAdoptionAction,
+  FirstRunAuthAdoptionInput,
+} from "#product/lib/domain/agents/auth-onboarding";
+import {
+  diagnosticField,
+  type RendererDiagnosticField,
+  type RendererDiagnosticInput,
+} from "#product/lib/infra/diagnostics/renderer-diagnostics-port";
+import { safeRendererErrorName } from "#product/lib/infra/diagnostics/renderer-diagnostic-values";
+
+export type FirstRunAuthAdoptionFailureStage =
+  | "runtime_connection"
+  | "selections_query"
+  | "capabilities_query"
+  | "reconcile_query"
+  | "reconcile_job"
+  | "agent_catalog_query"
+  | "planner_import"
+  | "planner"
+  | "selection_write";
+
+export type FreshAgentCatalogResult =
+  | { kind: "success"; agents: AgentSummary[] }
+  | { kind: "failure"; error: unknown };
+
+type FirstRunAuthAdoptionPlanner = (
+  input: FirstRunAuthAdoptionInput,
+) => AuthAdoptionAction[];
+
+export interface FirstRunAuthAdoptionSettlementDeps {
+  now(): number;
+  recordAdoption(harnessKinds: readonly string[], settledAt: number): void;
+  recordDiagnostic(input: RendererDiagnosticInput): void;
+}
+
+export interface RunFirstRunAuthAdoptionDeps
+  extends FirstRunAuthAdoptionSettlementDeps {
+  readFreshAgents(): Promise<FreshAgentCatalogResult>;
+  loadPlanner(): Promise<FirstRunAuthAdoptionPlanner>;
+  writeSelection(
+    action: AuthAdoptionAction,
+    onError: (error: unknown) => void,
+  ): void;
+}
+
+export interface FirstRunAuthAdoptionFailure {
+  stage: FirstRunAuthAdoptionFailureStage;
+  error?: unknown;
+  harnessKind?: string;
+}
+
+function firstRunAdoptionFailureDiagnostic(
+  failure: FirstRunAuthAdoptionFailure,
+): RendererDiagnosticInput {
+  const fields: Record<string, RendererDiagnosticField> = {
+    failure_stage: diagnosticField(failure.stage, "operational"),
+  };
+  if (failure.error !== undefined && failure.error !== null) {
+    fields.error_name = diagnosticField(
+      safeRendererErrorName(failure.error),
+      "operational",
+    );
+  }
+  if (failure.stage === "selection_write" && failure.harnessKind !== undefined) {
+    fields.harness_kind = diagnosticField(failure.harnessKind, "operational");
+  }
+  return {
+    name: "renderer.agent_auth.first_run_adoption_failed",
+    severity: "warn",
+    kind: "message",
+    privacy: "operational",
+    fields,
+    errorClassification: "first_run_adoption_failed",
+  };
+}
+
+function recordFirstRunAdoptionFailure(
+  failure: FirstRunAuthAdoptionFailure,
+  recordDiagnostic: FirstRunAuthAdoptionSettlementDeps["recordDiagnostic"],
+): void {
+  recordDiagnostic(firstRunAdoptionFailureDiagnostic(failure));
+}
+
+/** Settle a terminal pre-plan failure before emitting its best-effort diagnostic. */
+export function settleFirstRunAuthAdoptionFailure(
+  failure: FirstRunAuthAdoptionFailure,
+  deps: FirstRunAuthAdoptionSettlementDeps,
+): void {
+  deps.recordAdoption([], deps.now());
+  recordFirstRunAdoptionFailure(failure, deps.recordDiagnostic);
+}
+
+/**
+ * Run the one-shot post-reconcile adoption sequence against a fresh catalog.
+ * React, query ownership, and transport construction stay in the lifecycle hook.
+ */
+export async function runFirstRunAuthAdoption(
+  input: Omit<FirstRunAuthAdoptionInput, "agents">,
+  deps: RunFirstRunAuthAdoptionDeps,
+): Promise<void> {
+  let freshCatalog: FreshAgentCatalogResult;
+  try {
+    freshCatalog = await deps.readFreshAgents();
+  } catch (error) {
+    settleFirstRunAuthAdoptionFailure(
+      { stage: "agent_catalog_query", error },
+      deps,
+    );
+    return;
+  }
+  if (freshCatalog.kind === "failure") {
+    settleFirstRunAuthAdoptionFailure(
+      { stage: "agent_catalog_query", error: freshCatalog.error },
+      deps,
+    );
+    return;
+  }
+
+  let planner: FirstRunAuthAdoptionPlanner;
+  try {
+    planner = await deps.loadPlanner();
+  } catch (error) {
+    settleFirstRunAuthAdoptionFailure({ stage: "planner_import", error }, deps);
+    return;
+  }
+
+  let actions: AuthAdoptionAction[];
+  try {
+    actions = planner({
+      agents: freshCatalog.agents,
+      selectionCount: input.selectionCount,
+      gatewayEnabled: input.gatewayEnabled,
+    });
+  } catch (error) {
+    settleFirstRunAuthAdoptionFailure({ stage: "planner", error }, deps);
+    return;
+  }
+
+  deps.recordAdoption(
+    actions.map((action) => action.harnessKind),
+    deps.now(),
+  );
+  for (const action of actions) {
+    deps.writeSelection(action, (error) => {
+      recordFirstRunAdoptionFailure(
+        {
+          stage: "selection_write",
+          error,
+          harnessKind: action.harnessKind,
+        },
+        deps.recordDiagnostic,
+      );
+    });
+  }
+}

--- a/apps/packages/product-client/src/stores/agents/auth-setup-onboarding-store.ts
+++ b/apps/packages/product-client/src/stores/agents/auth-setup-onboarding-store.ts
@@ -5,7 +5,8 @@ import { create } from "zustand";
  * ack-gated onboarding "setting up" step (agent-auth.md, Proof C7).
  *
  * `useFirstRunAuthAdoption` records its one-shot decision here — the adopted
- * harness kinds (possibly none) and when the writes fired. The step hook
+ * harness kinds (possibly none) and when that decision settled. For a
+ * nonempty decision, settlement is also when the writes fired. The step hook
  * (`useAuthSetupOnboardingStep`) watches those selections' `applied` flags
  * and latches `settled` once the step resolved ("applied") or the ~20s grace
  * window auto-advanced it ("advanced"), so a later manual auth edit going
@@ -21,7 +22,7 @@ export type AuthSetupSettledState = "applied" | "advanced";
 interface AuthSetupOnboardingStoreState {
   /** null until the adoption decision ran; [] when it adopted nothing. */
   adoptedHarnessKinds: string[] | null;
-  /** Epoch ms of the adoption writes — the grace window counts from here. */
+  /** Epoch ms when adoption settled; nonempty decisions dispatch writes then. */
   adoptionStartedAt: number | null;
   settled: AuthSetupSettledState | null;
   recordAdoption: (harnessKinds: readonly string[], startedAt: number) => void;

--- a/specs/FEATURE_DOCS/AGENT_AUTH.md
+++ b/specs/FEATURE_DOCS/AGENT_AUTH.md
@@ -375,14 +375,23 @@ pushes into its embedded runtime
   auth-state query. Sync requires only sign-in and a healthy local
   runtime — a self-hosted user with no cloud compute still gets gateway
   and BYOK routes locally.
+- **First-run adoption settles once.** Local auth adoption applies only to
+  Desktop. Web records a normal not-applicable empty decision without enabling
+  the adoption Cloud queries, refetching the local catalog, loading the planner,
+  or writing a selection. Desktop waits for the startup reconciliation job to
+  complete, reads one fresh post-reconcile agent catalog, and then adopts the
+  gateway for harnesses without native logins. A terminal runtime, query,
+  reconcile, catalog, or planner failure records an empty decision before a
+  bounded diagnostic; it has no user-facing error or automatic retry in that
+  app run. Settings remains the authoritative place to manage auth.
 - **Onboarding shows a card, never a block.** Account creation never
   waits on LiteLLM (enrollment is fire-and-forget at signup). The desktop
-  first-run flow — auto-install, then first-run adoption defaulting the
-  gateway for harnesses without native logins, then this sync loop — is
-  what delivers the first `state.json`, and a home-screen onboarding card
-  ("Setting up your agents…") awaits the runtime's ack with a short grace
-  window (~20s) before auto-advancing, degrading to a visible pending
-  badge and letting the user proceed. It never blocks.
+  first-run flow — auto-install, the settled adoption decision above, then this
+  sync loop — is what delivers the first `state.json`, and a home-screen
+  onboarding card ("Setting up your agents…") awaits the runtime's ack with a
+  short grace window (~20s) before auto-advancing, degrading to a visible
+  pending badge and letting the user proceed. It never blocks. An empty
+  adoption decision hides the card.
 - **Under `agentAuthEvidencePanes` the card is state-bound, not timed.**
   With the same flag that drives the evidence panes ON, the timer card is
   replaced by per-agent badges bound to the REAL states each adopted agent


### PR DESCRIPTION
## Summary

- settle first-run local auth adoption on every authoritative terminal path so `null` means pending and `[]` means a completed no-op
- make active Web settle silently without local-runtime work, while Desktop waits for healthy startup reconciliation and plans from one fresh post-reconcile catalog
- preserve the lazy planner, record-before-write ordering, and bounded diagnostic privacy contract

## Testing

Tier 1 only: this changes an invisible lifecycle invariant and has no browser interaction or visual surface.

Exact-head local lightweight proof:

- `git diff --check`
- `python3.12 scripts/check_docs.py`
- `python3.12 scripts/check_frontend_boundaries.py`
- `python3.12 scripts/report_frontend_structure.py --strict --summary-only` (0 violations)
- `python3.12 scripts/check_design_attribution.py`
- `python3.12 scripts/check_max_lines.py`
- commit-hook appearance-scaling check

Exact-head hosted proof is fully green: Shared package typecheck/build, Mobile ProductClient export resolution, ProductClient domain tests, the full ProductClient suite, workflow-authoring tests, Desktop/Web builds, login-runtime budgets, repo shape, intent, CodeQL, Cargo, and Chromium/WebKit transcript scroll. No Rust changed locally or ran locally; no Docker ran.

## Observability

The existing `renderer.agent_auth.first_run_adoption_failed` diagnostic gains only a fixed low-cardinality `failure_stage` and a sanitized error name. Selection-write failures retain `harness_kind`; no raw error, query payload, reconcile result, URL, ID, auth selection, or provider response is emitted. Settlement occurs before diagnostic delivery, and the normal Web no-op emits nothing.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md) for scope, title, labels, body, and readiness.

Independent review accepted exact head `ab6c0d93e86ab38a9b5bf71f60c769c329598ca2` after `SSA-001` and `SSA-002` were fixed. Greptile reviewed that head at 5/5 with no concrete finding. The shared WebKit prerequisite merged as #2079 at `9ce62e9f6828595f80e4a2e1bae9f6cac07bb4f9`; its seven transcript-only paths do not overlap this slice, and the current-main merge tree is clean.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker API. No tracker, report, user, or support IDs or private source data appear in this PR.

## Verification

- Reviewed base: `3f726d65a328abb71cba30bd25e664c198d57cac`
- Head: `ab6c0d93e86ab38a9b5bf71f60c769c329598ca2`
- Stable patch ID: `e0254f2cac779850600bdcd4df9bfa7120201106`
- Current main: `9ce62e9f6828595f80e4a2e1bae9f6cac07bb4f9`
- Clean current-main merge tree: `c6f69b028aee4f4c947cf7fcc0007331dfafecd1`
- Exact seven-file frozen scope; no Home, Mobile, server, SDK, runtime, or Rust changes
