### PR TITLE
fix(product): confirm transcript prepend seat

### DIFF
--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.seat-confirmation.test.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.seat-confirmation.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import {
+  TranscriptFramePipeline,
+  type TranscriptFramePassOutcome,
+} from "#product/hooks/chat/ui/transcript-frame-pipeline";
+
+class FakeFrames {
+  cancelled: number[] = [];
+  maxPending = 0;
+  private nextHandle = 0;
+  private queue: Array<{ handle: number; callback: () => void }> = [];
+
+  raf = (callback: () => void): number => {
+    const handle = (this.nextHandle += 1);
+    this.queue.push({ handle, callback });
+    this.maxPending = Math.max(this.maxPending, this.queue.length);
+    return handle;
+  };
+
+  caf = (handle: number): void => {
+    this.cancelled.push(handle);
+    this.queue = this.queue.filter((entry) => entry.handle !== handle);
+  };
+
+  flushFrame(): void {
+    const batch = this.queue;
+    this.queue = [];
+    for (const entry of batch) {
+      entry.callback();
+    }
+  }
+
+  get pending(): number {
+    return this.queue.length;
+  }
+}
+
+describe("TranscriptFramePipeline seat acknowledgment", () => {
+  it("keeps quiet glue alive through corrections until a later settled pass", () => {
+    const frames = new FakeFrames();
+    const pipeline = new TranscriptFramePipeline(frames.raf, frames.caf, () => 0);
+    const outcomes: TranscriptFramePassOutcome[] = [
+      "corrective_position_write",
+      "corrective_position_write",
+      "settled",
+    ];
+    let passes = 0;
+    pipeline.setWriter({
+      runFramePass: () => outcomes[passes++] ?? "settled",
+      measureContentHeight: () => 6_908,
+      shouldContinueGlue: () => true,
+    });
+
+    pipeline.beginGlue();
+    while (pipeline.isGluing) {
+      const passesBeforeFrame = passes;
+      expect(frames.pending).toBe(1);
+      frames.flushFrame();
+      expect(passes - passesBeforeFrame).toBe(1);
+    }
+
+    expect(passes).toBe(3);
+    expect(frames.maxPending).toBe(1);
+    expect(frames.cancelled).toEqual([]);
+    expect(frames.pending).toBe(0);
+  });
+
+  it("coalesces multiple corrective outcomes onto one synchronous-pass verifier", () => {
+    const frames = new FakeFrames();
+    const pipeline = new TranscriptFramePipeline(frames.raf, frames.caf, () => 0);
+    let height = 1;
+    let outcome: TranscriptFramePassOutcome = "corrective_position_write";
+    let passes = 0;
+    pipeline.setWriter({
+      runFramePass: () => {
+        passes += 1;
+        return outcome;
+      },
+      measureContentHeight: () => height,
+      shouldContinueGlue: () => true,
+    });
+
+    pipeline.requestFrame();
+    for (height = 2; height <= 3; height += 1) {
+      pipeline.requestFrame();
+      expect(frames.pending).toBe(2); // one guard reset plus one verifier
+    }
+    expect(passes).toBe(3);
+
+    outcome = "settled";
+    frames.flushFrame();
+    expect(passes).toBe(4);
+    expect(frames.maxPending).toBe(2);
+    expect(frames.pending).toBe(0);
+  });
+
+  it("does not acknowledge a correction with a same-frame settled reentrant pass", () => {
+    const frames = new FakeFrames();
+    const pipeline = new TranscriptFramePipeline(frames.raf, frames.caf, () => 0);
+    let height = 1;
+    let outcome: TranscriptFramePassOutcome = "corrective_position_write";
+    let passes = 0;
+    pipeline.setWriter({
+      runFramePass: () => {
+        passes += 1;
+        return outcome;
+      },
+      measureContentHeight: () => height,
+      shouldContinueGlue: () => true,
+    });
+
+    pipeline.requestFrame();
+    height = 2;
+    outcome = "settled";
+    pipeline.requestFrame();
+    expect(passes).toBe(2);
+    expect(frames.pending).toBe(2);
+
+    frames.flushFrame();
+    expect(passes).toBe(3); // a distinct-frame verifier still ran
+    expect(frames.pending).toBe(0);
+  });
+
+  it("does not acknowledge a continuation correction from a same-refresh resize pass", () => {
+    const frames = new FakeFrames();
+    const pipeline = new TranscriptFramePipeline(frames.raf, frames.caf, () => 0);
+    const outcomes: TranscriptFramePassOutcome[] = [
+      "corrective_position_write",
+      "corrective_position_write",
+      "settled",
+      "corrective_position_write",
+      "settled",
+    ];
+    let height = 1;
+    let passes = 0;
+    pipeline.setWriter({
+      runFramePass: () => outcomes[passes++] ?? "settled",
+      measureContentHeight: () => height,
+      shouldContinueGlue: () => true,
+    });
+
+    pipeline.requestFrame();
+    // This callback represents ResizeObserver delivery later in the same
+    // refresh as the first shared-continuation callback.
+    frames.raf(() => {
+      height += 1;
+      pipeline.requestFrame();
+    });
+    frames.flushFrame();
+    expect(passes).toBe(3); // correction, correction, same-refresh settled RO
+
+    // The compositor silently loses the continuation's correction after that
+    // settled RO pass. A later writer frame must still run and correct again.
+    frames.flushFrame();
+    expect(passes).toBe(4);
+    frames.flushFrame();
+    expect(passes).toBe(5); // later-frame settled acknowledgment
+    expect(frames.pending).toBe(0);
+  });
+
+  it("beginGlue, cancel, and writer replacement clear stale acknowledgment", () => {
+    const makeCorrectivePipeline = () => {
+      const frames = new FakeFrames();
+      const pipeline = new TranscriptFramePipeline(frames.raf, frames.caf, () => 0);
+      let passes = 0;
+      let allowed = true;
+      pipeline.setWriter({
+        runFramePass: () => {
+          passes += 1;
+          return "corrective_position_write";
+        },
+        measureContentHeight: () => 1,
+        shouldContinueGlue: () => allowed,
+      });
+      return {
+        frames,
+        pipeline,
+        get passes() { return passes; },
+        disallowGlue() { allowed = false; },
+      };
+    };
+
+    const restarted = makeCorrectivePipeline();
+    restarted.pipeline.requestFrame();
+    restarted.pipeline.beginGlue();
+    restarted.disallowGlue();
+    restarted.frames.flushFrame();
+    expect(restarted.passes).toBe(1);
+    expect(restarted.frames.pending).toBe(0);
+
+    const cancelled = makeCorrectivePipeline();
+    cancelled.pipeline.requestFrame();
+    cancelled.pipeline.cancel();
+    cancelled.disallowGlue();
+    cancelled.pipeline.beginGlue();
+    cancelled.frames.flushFrame();
+    expect(cancelled.passes).toBe(1);
+    expect(cancelled.frames.pending).toBe(0);
+
+    const replaced = makeCorrectivePipeline();
+    replaced.pipeline.requestFrame();
+    let replacementPasses = 0;
+    replaced.pipeline.setWriter({
+      runFramePass: () => {
+        replacementPasses += 1;
+        return "settled";
+      },
+      measureContentHeight: () => 1,
+      shouldContinueGlue: () => false,
+    });
+    replaced.frames.flushFrame();
+    expect(replacementPasses).toBe(0);
+    expect(replaced.frames.pending).toBe(0);
+  });
+});

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.test.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.test.ts
@@ -5,12 +5,7 @@ import {
   type TranscriptFrameWriter,
 } from "#product/hooks/chat/ui/transcript-frame-pipeline";
 
-/**
- * Deterministic frame/clock harness. rAF callbacks are queued, not fired, until
- * a test explicitly flushes a frame; `now` advances only when a frame is
- * flushed. This lets the ordering / one-pass-per-frame / settle-cap invariants
- * be asserted without any real animation-frame timing.
- */
+/** Queued frame/clock harness for deterministic ordering and cap assertions. */
 class FakeFrames {
   time = 0;
   cancelled: number[] = [];
@@ -67,23 +62,20 @@ describe("TranscriptFramePipeline", () => {
       runFramePass: () => {
         events.push("snap");
         snappedToHeight = committedHeight;
+        return "settled";
       },
       measureContentHeight: () => committedHeight,
       shouldContinueGlue: () => true,
     };
     pipeline.setWriter(writer);
 
-    // Mutation source: the height grows, THEN the source requests a frame. The
-    // content ResizeObserver fires post-layout / pre-paint, so the snap must run
-    // synchronously in THIS frame — NOT deferred to the next rAF. Re-deferring
-    // (scheduling runFramePass inside the guard rAF) is the pinned-follow drift
-    // regression: it leaves the viewport a frame behind a growing stream and
-    // fails this assertion (and the Playwright pinned-follow gate).
+    // ResizeObserver reports committed layout, so snap synchronously before
+    // paint; deferring to rAF would leave pinned follow one frame behind.
     committedHeight = 420;
     events.push("mutate");
     pipeline.requestFrame();
 
-    // The snap already ran, in-line, against the committed height.
+    // The snap already ran inline against committed height.
     expect(events).toEqual(["mutate", "snap"]);
     expect(snappedToHeight).toBe(420);
 
@@ -99,6 +91,7 @@ describe("TranscriptFramePipeline", () => {
     pipeline.setWriter({
       runFramePass: () => {
         passes += 1;
+        return "settled";
       },
       measureContentHeight: () => 0,
       shouldContinueGlue: () => true,
@@ -135,6 +128,7 @@ describe("TranscriptFramePipeline", () => {
     pipeline.setWriter({
       runFramePass: () => {
         passes += 1;
+        return "settled";
       },
       measureContentHeight: () => heights[Math.min(frameIndex, heights.length - 1)],
       shouldContinueGlue: () => true,
@@ -148,8 +142,7 @@ describe("TranscriptFramePipeline", () => {
     }
 
     expect(pipeline.isGluing).toBe(false);
-    // Snapped on the growth frames plus the first quiet frame — a tight window,
-    // nowhere near the 20-frame ceiling. Never runs unbounded.
+    // Growth frames plus the first quiet frame; never the generous ceiling.
     expect(passes).toBeGreaterThan(0);
     expect(passes).toBeLessThanOrEqual(5);
     // Terminated on quiet, well before the time cap.
@@ -163,6 +156,7 @@ describe("TranscriptFramePipeline", () => {
     pipeline.setWriter({
       runFramePass: () => {
         passes += 1;
+        return "settled";
       },
       // Never stable: height changes every frame, so quiet never fires.
       measureContentHeight: () => (height += 1),
@@ -187,6 +181,7 @@ describe("TranscriptFramePipeline", () => {
     pipeline.setWriter({
       runFramePass: () => {
         passes += 1;
+        return "settled";
       },
       measureContentHeight: () => passes, // always changing → never quiet
       shouldContinueGlue: () => allowed,
@@ -208,6 +203,7 @@ describe("TranscriptFramePipeline", () => {
     pipeline.setWriter({
       runFramePass: () => {
         passes += 1;
+        return "settled";
       },
       measureContentHeight: () => passes,
       shouldContinueGlue: () => true,
@@ -237,6 +233,7 @@ describe("TranscriptFramePipeline", () => {
     pipeline.setWriter({
       runFramePass: () => {
         passes += 1;
+        return "settled";
       },
       measureContentHeight: () => 500, // immediately quiet after first frame
       shouldContinueGlue: () => true,
@@ -255,6 +252,7 @@ describe("TranscriptFramePipeline", () => {
     pipeline.setWriter({
       runFramePass: () => {
         passes += 1;
+        return "settled";
       },
       measureContentHeight: () => 500,
       shouldContinueGlue: () => true,
@@ -275,7 +273,7 @@ describe("TranscriptFramePipeline", () => {
   it("beginGlue still restarts a fresh owner window", () => {
     const { frames, pipeline } = makePipeline();
     pipeline.setWriter({
-      runFramePass: () => undefined,
+      runFramePass: () => "settled",
       measureContentHeight: () => 500,
       shouldContinueGlue: () => true,
     });
@@ -287,10 +285,7 @@ describe("TranscriptFramePipeline", () => {
     expect(frames.pending).toBe(1);
   });
 
-  // PRO-168 (rung 12, Q16): the eased-follow motion writer's continuation seam.
-  // The instant writer never implements `hasPendingMotion`, so these prove the
-  // seam is additive: absent it, existing behavior above is untouched (asserted
-  // by every prior test in this file, none of which define it).
+  // PRO-168 (rung 12, Q16): eased-follow's optional continuation seam.
   describe("hasPendingMotion continuation (PRO-168, rung 12)", () => {
     it("requestFrame schedules ONE more frame per pass while motion is pending, then stops", () => {
       const { frames, pipeline } = makePipeline();
@@ -299,6 +294,7 @@ describe("TranscriptFramePipeline", () => {
       pipeline.setWriter({
         runFramePass: () => {
           passes += 1;
+          return "settled";
         },
         measureContentHeight: () => 0,
         shouldContinueGlue: () => true,
@@ -327,6 +323,7 @@ describe("TranscriptFramePipeline", () => {
       pipeline.setWriter({
         runFramePass: () => {
           passes += 1;
+          return "settled";
         },
         measureContentHeight: () => 0,
         shouldContinueGlue: () => true,
@@ -348,6 +345,7 @@ describe("TranscriptFramePipeline", () => {
       pipeline.setWriter({
         runFramePass: () => {
           passes += 1;
+          return "settled";
         },
         measureContentHeight: () => 500,
         shouldContinueGlue: () => true,
@@ -377,6 +375,7 @@ describe("TranscriptFramePipeline", () => {
       pipeline.setWriter({
         runFramePass: () => {
           passes += 1;
+          return "settled";
         },
         measureContentHeight: () => 0,
         shouldContinueGlue: () => true,

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.trailing-edge.test.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.trailing-edge.test.ts
@@ -56,6 +56,7 @@ describe("TranscriptFramePipeline trailing-edge ensure", () => {
             pipeline.ensureGlue();
           }
         }
+        return "settled";
       },
       measureContentHeight: () => 6_908,
       shouldContinueGlue: () => true,

--- a/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/transcript-frame-pipeline.ts
@@ -42,6 +42,9 @@ export const TRANSCRIPT_GLUE_MAX_MS = 250;
 // window tight.
 const GLUE_SETTLE_QUIET_FRAMES = 1;
 
+/** Geometry-owned result of the sole transcript writer pass. */
+export type TranscriptFramePassOutcome = "corrective_position_write" | "settled";
+
 /**
  * The single snap/compensation writer the pipeline drives. Supplied once by the
  * stick-to-bottom engine, which owns pin state and the follow target.
@@ -52,7 +55,7 @@ export interface TranscriptFrameWriter {
    * apply the active above-change compensation delta while unpinned, or do
    * nothing. All writes flow through the rung-3 ownership markers inside.
    */
-  runFramePass: () => void;
+  runFramePass: () => TranscriptFramePassOutcome;
   /**
    * Current content height, used only to detect the content ResizeObserver
    * going quiet during a forced-glue window. Returns the live `scrollHeight`.
@@ -127,10 +130,12 @@ export class TranscriptFramePipeline {
   // pass; requests already present when a pass starts are satisfied by it.
   private glueDemandGeneration = 0;
   private glueServedGeneration = 0;
-  // PRO-168 (rung 12): the motion writer's own continuation handle, separate
-  // from frameHandle/glueHandle so it never contends with either's guard
-  // bookkeeping. Only ever armed when the writer reports pending motion.
-  private motionHandle: number | null = null;
+  // One continuation serves both eased motion and verification that a
+  // compensation correction survived into a later writer pass.
+  private writerContinuationHandle: number | null = null;
+  private seatAckPending = false;
+  private writerFrameTurn = 0;
+  private seatAckEligibleTurn = 0;
 
   constructor(
     private readonly raf: RafFn = defaultRaf,
@@ -140,7 +145,25 @@ export class TranscriptFramePipeline {
 
   /** Wire the single snap/compensation writer. */
   setWriter(writer: TranscriptFrameWriter): void {
+    if (this.writerContinuationHandle != null) {
+      this.caf(this.writerContinuationHandle);
+      this.writerContinuationHandle = null;
+    }
+    this.seatAckPending = false;
+    this.seatAckEligibleTurn = 0;
     this.writer = writer;
+  }
+
+  /** Run and centrally consume the geometry owner's narrow pass result. */
+  private runWriterPass(writer: TranscriptFrameWriter): void {
+    const outcome = writer.runFramePass();
+    if (outcome === "corrective_position_write") {
+      this.seatAckPending = true;
+      this.seatAckEligibleTurn = this.writerFrameTurn + 1;
+    } else if (this.writerFrameTurn >= this.seatAckEligibleTurn) {
+      this.seatAckPending = false;
+      this.seatAckEligibleTurn = 0;
+    }
   }
 
   /**
@@ -184,44 +207,40 @@ export class TranscriptFramePipeline {
         this.framePassHeight = -1;
       });
     }
-    writer.runFramePass();
+    this.runWriterPass(writer);
     // Record the height the snap just settled against so a later same-frame
     // notify re-runs only on further growth (a scrollTop write leaves it equal).
     this.framePassHeight = writer.measureContentHeight();
-    // PRO-168 (rung 12): the instant writer never reports pending motion, so
-    // this is a no-op for v1. An eased writer still mid-step keeps this
-    // pipeline (and only this pipeline) ticking until it converges.
-    this.continueMotionIfPending();
+    // Arm the shared continuation for an owed seat verifier or eased motion.
+    this.continueWriterIfPending();
   }
 
   /**
-   * PRO-168 (rung 12): while the writer's motion policy has not yet converged
-   * (`hasPendingMotion` true), keep scheduling exactly one frame at a time so
-   * the SAME writer can finish its catch-up — a self-perpetuating chain owned
-   * by this pipeline, not a second animator. Idempotent: a handle already
-   * armed is left alone.
+   * Schedule exactly one continuation while seat acknowledgment or eased
+   * motion is pending. The same writer serves both; an armed handle is reused.
    */
-  private continueMotionIfPending(): void {
+  private continueWriterIfPending(): void {
     const writer = this.writer;
-    if (writer?.hasPendingMotion?.() !== true) {
+    if (writer == null || (!this.seatAckPending && writer.hasPendingMotion?.() !== true)) {
       return;
     }
-    if (this.motionHandle != null) {
+    if (this.writerContinuationHandle != null) {
       return;
     }
-    this.motionHandle = this.raf(() => {
-      this.motionHandle = null;
+    this.writerContinuationHandle = this.raf(() => {
+      this.writerContinuationHandle = null;
+      this.writerFrameTurn += 1;
       const current = this.writer;
       // Re-check pending AT FIRE TIME, not just when this frame was armed: the
       // pass that ran since (glue, or an earlier motion tick) may have already
       // converged the writer, and re-running would waste a frame on a motion
       // step nobody needs. Mirrors glueTick's shouldContinueGlue gate, checked
       // before running rather than only after.
-      if (current == null || current.hasPendingMotion?.() !== true) {
+      if (current == null || (!this.seatAckPending && current.hasPendingMotion?.() !== true)) {
         return;
       }
-      current.runFramePass();
-      this.continueMotionIfPending();
+      this.runWriterPass(current);
+      this.continueWriterIfPending();
     });
   }
 
@@ -236,13 +255,13 @@ export class TranscriptFramePipeline {
     if (this.writer == null) {
       return;
     }
-    // Fold any pending motion continuation into the glue window: the glue
-    // loop below runs every frame regardless, so a separately-scheduled
-    // motion tick would double the same writer's pass in one frame.
-    if (this.motionHandle != null) {
-      this.caf(this.motionHandle);
-      this.motionHandle = null;
+    // Fold any writer continuation into the restarted glue owner.
+    if (this.writerContinuationHandle != null) {
+      this.caf(this.writerContinuationHandle);
+      this.writerContinuationHandle = null;
     }
+    this.seatAckPending = false;
+    this.seatAckEligibleTurn = 0;
     // Fold the pending guard-reset frame into the window and re-arm from scratch.
     if (this.frameHandle != null) {
       this.caf(this.frameHandle);
@@ -271,18 +290,16 @@ export class TranscriptFramePipeline {
   }
 
   private glueTick = (): void => {
+    this.writerFrameTurn += 1;
     const writer = this.writer;
     if (writer == null || !writer.shouldContinueGlue()) {
       this.glueActive = false;
-      // PRO-168 (rung 12): the glue window ending mid-motion (the user
-      // reclaimed control, or the viewport vanished) still hands off to the
-      // motion continuation below when the writer itself still has motion
-      // pending; when the writer is gone that check is a safe no-op.
-      this.continueMotionIfPending();
+      // Hand any still-owed writer continuation off as glue ends.
+      this.continueWriterIfPending();
       return;
     }
     const passGeneration = this.glueDemandGeneration;
-    writer.runFramePass();
+    this.runWriterPass(writer);
     this.glueServedGeneration = passGeneration;
 
     const height = writer.measureContentHeight();
@@ -298,6 +315,7 @@ export class TranscriptFramePipeline {
     if (
       (this.glueQuietFrames >= GLUE_SETTLE_QUIET_FRAMES || capElapsed)
       && !trailingEnsurePending
+      && !this.seatAckPending
     ) {
       this.glueActive = false;
       // PRO-168 (rung 12): the height-quiet/hard-cap glue terminator is about
@@ -307,7 +325,7 @@ export class TranscriptFramePipeline {
       // position trailing). Hand off to the motion continuation so it keeps
       // converging without turning glue's window into a second countdown for
       // the same thing.
-      this.continueMotionIfPending();
+      this.continueWriterIfPending();
       return;
     }
     this.glueHandle = this.raf(this.glueTick);
@@ -331,10 +349,12 @@ export class TranscriptFramePipeline {
     }
     this.glueActive = false;
     this.glueHandle = null;
-    if (this.motionHandle != null) {
-      this.caf(this.motionHandle);
+    if (this.writerContinuationHandle != null) {
+      this.caf(this.writerContinuationHandle);
     }
-    this.motionHandle = null;
+    this.writerContinuationHandle = null;
+    this.seatAckPending = false;
+    this.seatAckEligibleTurn = 0;
     this.glueServedGeneration = this.glueDemandGeneration;
   }
 

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-frame-pipeline-lifecycle.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-frame-pipeline-lifecycle.ts
@@ -1,26 +1,16 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, type RefObject } from "react";
 import type { ContentHeightScrollAnchor } from "#product/hooks/chat/ui/transcript-row-list-model";
-import type { TranscriptFramePipeline } from "#product/hooks/chat/ui/transcript-frame-pipeline";
+import type {
+  TranscriptFramePassOutcome,
+  TranscriptFramePipeline,
+} from "#product/hooks/chat/ui/transcript-frame-pipeline";
 import type { TranscriptRestoreResolution } from "#product/hooks/chat/ui/transcript-reading-position-store";
 import { resolveEasedFollowStep } from "#product/hooks/chat/ui/transcript-eased-follow";
 
-// While an above-change compensation anchor is live, each estimate-to-measured
-// correction of a freshly-prepended older row grows the total above the reader
-// and must be absorbed into scrollTop. On a slow/CPU-throttled runner those
-// corrections do not all land inside the fixed initial deadline
-// (ABOVE_CHANGE_COMPENSATION_MAX_MS in use-transcript-stick-to-bottom.ts) — they
-// trickle in over a second or more, spaced out by hundreds of ms. So instead of
-// letting the initial deadline end the window while corrections are still
-// arriving, extend it by this quiet window every time a fresh growth is observed
-// (see runFramePass). The window therefore stays open as long as the prepended
-// rows keep correcting taller, and closes only once they go quiet — the fix for
-// the r5 prepend under-compensation (chromium scrollTop 120 vs > 150 / delta 528
-// vs > 576 on the throttled runner, and the severe near-top landing).
+// Each fresh measured-height growth extends prepend compensation by one quiet
+// window so throttled corrections remain anchored after the initial deadline.
 const ABOVE_CHANGE_COMPENSATION_QUIET_EXTENSION_MS = 1_000;
-// Absolute ceiling on the extended window, measured from the anchor's first
-// frame pass, so a pathological never-quiet growth source can never hold the
-// reader anchored forever and later below-the-viewport growth is eventually free
-// to move it again.
+// A pathological never-quiet source must still release the reader.
 const ABOVE_CHANGE_COMPENSATION_ABSOLUTE_MAX_MS = 3_000;
 
 export interface UseTranscriptFramePipelineLifecycleOptions {
@@ -29,16 +19,18 @@ export interface UseTranscriptFramePipelineLifecycleOptions {
   scrollRef: RefObject<HTMLDivElement | null>;
   /** Live pin state. */
   pinnedRef: RefObject<boolean>;
-  /** Active above-change compensation anchor, applied while unpinned + within deadline. */
+  /** Active above-change compensation anchor, including any owed seat acknowledgment. */
   compensationAnchorRef: RefObject<ContentHeightScrollAnchor | null>;
   /**
-   * Deadline (interactionNow ms) past which the compensation anchor is stale.
-   * The single frame pass compensates every measurement correction that arrives
-   * before it — whether the eager glue window is still open or a later, isolated
-   * ResizeObserver growth drives the pass — and clears the anchor once the
-   * deadline passes so ordinary below-the-viewport growth can move the reader.
+   * Growth deadline (interactionNow ms). A displaced seat retains ownership
+   * after this deadline until a later pass acknowledges it or the absolute cap.
    */
   compensationDeadlineRef: RefObject<number>;
+  /** Lifecycle-owned absolute ceiling, keyed to the active anchor. */
+  compensationAbsoluteDeadlineRef: RefObject<{
+    anchor: ContentHeightScrollAnchor | null;
+    deadline: number;
+  }>;
   /**
    * FR-2 restore (rung 6): while unpinned on a finalized-session revisit, this
    * resolves the saved reading anchor to a scrollTop (or null when the saved
@@ -87,11 +79,8 @@ export interface UseTranscriptFramePipelineLifecycleOptions {
 
 /**
  * Wire the frame pipeline's single writer and its lifecycle. The writer is the
- * one snap/compensation pass the pipeline drives each frame: snap to the follow
- * target while pinned; apply the above-change compensation delta while unpinned
- * with a live anchor (until its deadline lapses); otherwise do nothing. Every
- * write still flows through
- * the rung-3 ownership markers (WHO wrote) — the pipeline owns only WHEN.
+ * one snap/compensation pass the pipeline drives each frame. Every write still
+ * flows through rung-3 ownership markers (WHO); the pipeline owns only WHEN.
  *
  * Also owns the tab/window resume glue (re-show while pinned collapses the
  * suspended-then-resumed measurement backlog into one jump) and disposal.
@@ -102,6 +91,7 @@ export function useTranscriptFramePipelineLifecycle({
   pinnedRef,
   compensationAnchorRef,
   compensationDeadlineRef,
+  compensationAbsoluteDeadlineRef,
   restoreResolverRef,
   restoreDeadlineRef,
   scrollToBottom,
@@ -138,19 +128,21 @@ export function useTranscriptFramePipelineLifecycle({
     everMounted: boolean;
   }>({ resolver: null, everMounted: false });
 
-  const runFramePass = useCallback(() => {
+  const runFramePass = useCallback((): TranscriptFramePassOutcome => {
     const viewport = scrollRef.current;
     if (!viewport) {
-      return;
+      return "settled";
     }
     if (pinnedRef.current) {
+      compensationAnchorRef.current = null;
+      compensationAbsoluteDeadlineRef.current = { anchor: null, deadline: 0 };
       // PRO-168 (rung 12, Q16): flag off takes the original instant path
       // verbatim — byte-identical to pre-rung-12 v1. Flag on substitutes the
       // eased writer, which still writes exclusively through
       // `notifyProgrammaticScroll` (classification is untouched, FR-1).
       if (!easedFollowEnabled) {
         scrollToBottom();
-        return;
+        return "settled";
       }
       const targetTop = resolveFollowTargetTop(viewport);
       const step = resolveEasedFollowStep(viewport.scrollTop, targetTop);
@@ -160,7 +152,7 @@ export function useTranscriptFramePipelineLifecycle({
           viewport.scrollTop = step.nextTop;
         });
       }
-      return;
+      return "settled";
     }
     // PRO-168 (rung 12): unpinned takes over from here; the eased writer's
     // pending flag only ever describes a PINNED catch-up, so clear it rather
@@ -219,20 +211,15 @@ export function useTranscriptFramePipelineLifecycle({
             });
           }
         }
-        return;
+        return "settled";
       }
     }
     const anchor = compensationAnchorRef.current;
     if (!anchor) {
-      return;
+      compensationAbsoluteDeadlineRef.current = { anchor: null, deadline: 0 };
+      return "settled";
     }
-    // Compensate every measurement correction until the deadline, whichever pass
-    // (eager glue tick or a later isolated ResizeObserver growth) drives it. The
-    // freshly-mounted older rows keep correcting their estimated heights taller
-    // for several frames after a prepend — more, and more spread out, on a slow
-    // runner — often past the forced-glue window's quiet-frame end. Gating on the
-    // deadline instead of `isGluing` keeps this single writer absorbing the full
-    // added-above height so the reading row stays fixed on every engine.
+    // Glue ticks and isolated ResizeObserver passes share this same writer.
     const now = typeof performance === "undefined" ? Date.now() : performance.now();
     // Rung 5: composition-derived estimates plus the write-through
     // measured-height cache make the virtualizer's reported total scrollHeight
@@ -252,6 +239,10 @@ export function useTranscriptFramePipelineLifecycle({
       floor.anchor = anchor;
       floor.maxScrollHeight = anchor.scrollHeight;
       floor.absoluteDeadline = now + ABOVE_CHANGE_COMPENSATION_ABSOLUTE_MAX_MS;
+      compensationAbsoluteDeadlineRef.current = {
+        anchor,
+        deadline: floor.absoluteDeadline,
+      };
     }
     // Where the reading row already belongs, computed against the max observed
     // SO FAR (before this pass folds in any new growth). The reader is DISPLACED
@@ -263,15 +254,9 @@ export function useTranscriptFramePipelineLifecycle({
     const seatedTarget = anchor.scrollTop + (floor.maxScrollHeight - anchor.scrollHeight);
     const displacedAboveTarget = seatedTarget - viewport.scrollTop > 1;
     if (now >= compensationDeadlineRef.current) {
-      // Release the anchor once the growth deadline lapses — UNLESS the reader
-      // is still displaced above the already-established seat. On a slow
-      // runner a late downward clamp can land in the same window the growth
-      // deadline lapses; releasing silently then strands the reader near the
-      // freshly-prepended top (CI webkit prepend "scrollTop Received 0"). Emit
-      // one last forward-only corrective write against the established floor
-      // BEFORE releasing, whether or not we are still within the absolute
-      // ceiling, so a late dip can never leave the reader displaced merely
-      // because the window closed on the same tick that observed it.
+      // An ordinary-deadline correction retains the anchor until a later pass
+      // observes the seat held. The absolute ceiling still releases immediately.
+      const topBeforeCorrection = viewport.scrollTop;
       if (displacedAboveTarget) {
         notifyProgrammaticScroll(() => {
           if (seatedTarget > viewport.scrollTop) {
@@ -279,8 +264,17 @@ export function useTranscriptFramePipelineLifecycle({
           }
         });
       }
-      compensationAnchorRef.current = null;
-      return;
+      const outcome = viewport.scrollTop > topBeforeCorrection
+        ? "corrective_position_write"
+        : "settled";
+      // A clamped no-advance attempt is settled as a writer outcome, but it did
+      // not observe the established seat held. Retain ownership until height
+      // recovery makes the seat reachable, unless the absolute ceiling wins.
+      if (!displacedAboveTarget || now >= floor.absoluteDeadline) {
+        compensationAnchorRef.current = null;
+        compensationAbsoluteDeadlineRef.current = { anchor: null, deadline: 0 };
+      }
+      return outcome;
     }
     // A fresh above-anchor growth this pass is a late estimate-to-measured
     // correction still arriving; keep the compensation window open past the
@@ -298,6 +292,7 @@ export function useTranscriptFramePipelineLifecycle({
     }
     const effectiveScrollHeight = floor.maxScrollHeight;
     const target = anchor.scrollTop + (effectiveScrollHeight - anchor.scrollHeight);
+    const topBeforeCorrection = viewport.scrollTop;
     notifyProgrammaticScroll(() => {
       // Above-change compensation only ever absorbs growth ABOVE the reader, so
       // the anchored scrollTop moves DOWN (increases) or holds as those rows
@@ -313,8 +308,12 @@ export function useTranscriptFramePipelineLifecycle({
         viewport.scrollTop = target;
       }
     });
+    return viewport.scrollTop > topBeforeCorrection
+      ? "corrective_position_write"
+      : "settled";
   }, [
     compensationAnchorRef,
+    compensationAbsoluteDeadlineRef,
     compensationDeadlineRef,
     restoreResolverRef,
     restoreDeadlineRef,

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.seat-confirmation.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.seat-confirmation.test.tsx
@@ -1,0 +1,515 @@
+/* @vitest-environment jsdom */
+
+import { useRef } from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useTranscriptStickToBottom,
+  type TranscriptStickToBottom,
+} from "#product/hooks/chat/ui/use-transcript-stick-to-bottom";
+
+interface QueuedFrame {
+  handle: number;
+  callback: FrameRequestCallback;
+}
+
+let cancelledHandles: number[];
+let nextHandle: number;
+let rafQueue: QueuedFrame[];
+
+beforeEach(() => {
+  cancelledHandles = [];
+  nextHandle = 0;
+  rafQueue = [];
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    const handle = (nextHandle += 1);
+    rafQueue.push({ handle, callback });
+    return handle;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (handle: number) => {
+    cancelledHandles.push(handle);
+    rafQueue = rafQueue.filter((entry) => entry.handle !== handle);
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function flushRafRound(): void {
+  const batch = rafQueue;
+  rafQueue = [];
+  for (const entry of batch) {
+    entry.callback(performance.now());
+  }
+}
+
+function flushRafToEmpty(limit = 20): void {
+  for (let round = 0; rafQueue.length > 0; round += 1) {
+    if (round >= limit) {
+      throw new Error(`frame scheduler did not drain after ${limit} rounds`);
+    }
+    act(() => {
+      flushRafRound();
+    });
+  }
+}
+
+interface HarnessHandle {
+  api: TranscriptStickToBottom;
+  viewport: HTMLDivElement;
+}
+
+function renderHarness(): { current: HarnessHandle } {
+  const handle: { current: HarnessHandle | null } = { current: null };
+
+  function Harness() {
+    const scrollRef = useRef<HTMLDivElement>(null);
+    const api = useTranscriptStickToBottom({ scrollRef, onScrollSample: vi.fn() });
+    return (
+      <div
+        ref={(node) => {
+          scrollRef.current = node;
+          if (node) {
+            handle.current = { api, viewport: node };
+          }
+        }}
+      />
+    );
+  }
+
+  render(<Harness />);
+  return {
+    get current() {
+      return handle.current!;
+    },
+  };
+}
+
+function setContentHeight(viewport: HTMLElement, scrollHeight: number, clientHeight = 400): void {
+  Object.defineProperty(viewport, "scrollHeight", { value: scrollHeight, configurable: true });
+  Object.defineProperty(viewport, "clientHeight", { value: clientHeight, configurable: true });
+}
+
+function installCssomScrollTopClamp(viewport: HTMLElement, initialTop: number): void {
+  let top = initialTop;
+  Object.defineProperty(viewport, "scrollTop", {
+    configurable: true,
+    get: () => {
+      top = Math.min(top, Math.max(0, viewport.scrollHeight - viewport.clientHeight));
+      return top;
+    },
+    set: (nextTop: number) => {
+      const maxTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+      top = Math.min(Math.max(0, nextTop), maxTop);
+    },
+  });
+}
+
+describe("non-cancelable prepend seat confirmation", () => {
+  it("reconciles capture/install erosion and two event-silent post-pass overwrites", () => {
+    const handle = renderHarness();
+    const { api, viewport } = handle.current;
+    setContentHeight(viewport, 5_552);
+    viewport.scrollTop = 425;
+    const capturedAnchor = {
+      rowCount: 5,
+      scrollHeight: viewport.scrollHeight,
+      scrollTop: viewport.scrollTop,
+    };
+
+    // Match the hosted WebKit trace: native position erosion begins before the
+    // layout effect installs the captured prepend anchor.
+    viewport.scrollTop = 97;
+    setContentHeight(viewport, 6_908);
+    act(() => {
+      api.setPinned(false);
+      api.startAboveChangeCompensation(capturedAnchor, false);
+    });
+
+    // The first writer establishes 425 + (6908 - 5552) = 1781. The compositor
+    // silently overwrites it after the callback, without a scroll/resize signal.
+    act(() => {
+      flushRafRound();
+    });
+    expect(viewport.scrollTop).toBe(1_781);
+    viewport.scrollTop = 0;
+
+    // Overwrite the stable-height quiet-ending pass too. Current v1.2 stops
+    // here; v1.3 must keep the sole writer alive until a later seated pass
+    // acknowledges that the correction survived.
+    act(() => {
+      flushRafRound();
+    });
+    expect(viewport.scrollTop).toBe(1_781);
+    viewport.scrollTop = 0;
+    flushRafToEmpty();
+
+    expect(handle.current.api.isPinnedToBottom).toBe(false);
+    expect(cancelledHandles).toEqual([]);
+    expect(rafQueue).toEqual([]);
+    expect(viewport.scrollTop).toBe(1_781);
+  });
+
+  it("protects a non-cancelable owner before its first writer pass", () => {
+    const handle = renderHarness();
+    const { api, viewport } = handle.current;
+    setContentHeight(viewport, 5_552);
+    viewport.scrollTop = 425;
+    act(() => {
+      api.setPinned(false);
+      api.startAboveChangeCompensation(
+        { rowCount: 5, scrollHeight: 5_552, scrollTop: 425 },
+        false,
+      );
+      api.notifyUserScrollIntent(-1);
+      api.cancelFramePipeline();
+    });
+
+    expect(cancelledHandles).toEqual([]);
+    expect(rafQueue.length).toBeGreaterThan(0);
+    setContentHeight(viewport, 6_908);
+    flushRafToEmpty();
+    expect(viewport.scrollTop).toBe(1_781);
+    expect(rafQueue).toEqual([]);
+  });
+
+  it("expires a never-initialized owner at its ordinary deadline", () => {
+    let clock = 0;
+    const nowSpy = vi.spyOn(performance, "now").mockImplementation(() => clock);
+    try {
+      const handle = renderHarness();
+      const { api, viewport } = handle.current;
+      setContentHeight(viewport, 5_552);
+      viewport.scrollTop = 425;
+      act(() => {
+        api.setPinned(false);
+        api.startAboveChangeCompensation(
+          { rowCount: 5, scrollHeight: 5_552, scrollTop: 425 },
+          false,
+        );
+      });
+
+      // No writer initialized an absolute record. Once the ordinary deadline
+      // lapses, genuine input clears this anchor rather than granting it a new
+      // three-second window from a delayed first pass.
+      clock = 600;
+      viewport.scrollTop = 200;
+      const cancellationsBeforeTakeover = cancelledHandles.length;
+      act(() => {
+        api.notifyUserScrollIntent(-1);
+        api.cancelFramePipeline();
+        api.onViewportScroll(viewport);
+      });
+      expect(cancelledHandles.length).toBeGreaterThan(cancellationsBeforeTakeover);
+      expect(rafQueue).toEqual([]);
+
+      setContentHeight(viewport, 6_908);
+      act(() => {
+        api.notifyContentResize();
+      });
+      flushRafToEmpty();
+      expect(viewport.scrollTop).toBe(200);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("retains an ordinary-deadline correction through silent overwrite until acknowledgment", () => {
+    let clock = 0;
+    const nowSpy = vi.spyOn(performance, "now").mockImplementation(() => clock);
+    try {
+      const handle = renderHarness();
+      const { api, viewport } = handle.current;
+      setContentHeight(viewport, 5_552);
+      viewport.scrollTop = 425;
+
+      act(() => {
+        api.setPinned(false);
+        api.startAboveChangeCompensation(
+          { rowCount: 5, scrollHeight: 5_552, scrollTop: 425 },
+          false,
+        );
+      });
+      setContentHeight(viewport, 6_908);
+      flushRafToEmpty();
+      expect(viewport.scrollTop).toBe(1_781);
+
+      // Growth extended the ordinary deadline to t=1000. At t=1100 the browser
+      // has displaced the viewport below the established seat. The synchronous
+      // deadline pass corrects, then its write is silently lost after return.
+      clock = 1_100;
+      viewport.scrollTop = 0;
+      act(() => {
+        api.notifyContentResize();
+      });
+      expect(viewport.scrollTop).toBe(1_781);
+      // A trailing input listener can run after the ordinary deadline pass.
+      // Non-cancelable ownership must protect the owed verifier until the
+      // lifecycle itself acknowledges or absolutely releases the anchor.
+      act(() => {
+        api.cancelFramePipeline();
+      });
+      viewport.scrollTop = 0;
+
+      flushRafToEmpty();
+
+      expect(handle.current.api.isPinnedToBottom).toBe(false);
+      expect(rafQueue).toEqual([]);
+      expect(viewport.scrollTop).toBe(1_781);
+      expect(cancelledHandles).toEqual([]);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("retains a clamped deadline seat through cancel until height recovery", () => {
+    let clock = 0;
+    const nowSpy = vi.spyOn(performance, "now").mockImplementation(() => clock);
+    try {
+      const handle = renderHarness();
+      const { api, viewport } = handle.current;
+      setContentHeight(viewport, 5_552);
+      installCssomScrollTopClamp(viewport, 425);
+
+      act(() => {
+        api.setPinned(false);
+        api.startAboveChangeCompensation(
+          { rowCount: 5, scrollHeight: 5_552, scrollTop: 425 },
+          false,
+        );
+      });
+      setContentHeight(viewport, 6_908);
+      flushRafToEmpty();
+      expect(viewport.scrollTop).toBe(1_781);
+
+      // A temporary measured-height dip makes the established seat unreachable:
+      // CSSOM clamps both the live position and the attempted forward write to
+      // 1600. No position write landed, but the non-cancelable owner remains.
+      clock = 1_100;
+      setContentHeight(viewport, 2_000);
+      act(() => {
+        api.notifyContentResize();
+      });
+      expect(viewport.scrollTop).toBe(1_600);
+      const queuedBeforeCancel = rafQueue.map((entry) => entry.handle);
+      expect(queuedBeforeCancel.length).toBeGreaterThan(0);
+      act(() => {
+        api.cancelFramePipeline();
+      });
+      expect(cancelledHandles).toEqual([]);
+      expect(rafQueue.map((entry) => entry.handle)).toEqual(queuedBeforeCancel);
+
+      // The normal ResizeObserver notification for height recovery re-enters
+      // the retained owner. Its correction advances, then a later pass observes
+      // the seat held and releases ownership.
+      setContentHeight(viewport, 6_908);
+      act(() => {
+        api.notifyContentResize();
+      });
+      expect(viewport.scrollTop).toBe(1_781);
+      flushRafToEmpty();
+      expect(rafQueue).toEqual([]);
+
+      // Once acknowledged, a later resize has no prepend owner and the normal
+      // synchronous cancel seam may discard its frame guard.
+      viewport.scrollTop = 0;
+      act(() => {
+        api.notifyContentResize();
+        api.cancelFramePipeline();
+      });
+      expect(viewport.scrollTop).toBe(0);
+      expect(rafQueue).toEqual([]);
+      expect(cancelledHandles.length).toBeGreaterThan(0);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("clears a prepend owner when deliberate repin supersedes it", () => {
+    let clock = 0;
+    const nowSpy = vi.spyOn(performance, "now").mockImplementation(() => clock);
+    try {
+      const handle = renderHarness();
+      const { api, viewport } = handle.current;
+      setContentHeight(viewport, 5_552);
+      viewport.scrollTop = 425;
+      act(() => {
+        api.setPinned(false);
+        api.startAboveChangeCompensation(
+          { rowCount: 5, scrollHeight: 5_552, scrollTop: 425 },
+          false,
+        );
+      });
+      setContentHeight(viewport, 6_908);
+      act(() => {
+        flushRafRound();
+      });
+      expect(viewport.scrollTop).toBe(1_781);
+
+      act(() => {
+        api.setPinned(true);
+      });
+      flushRafToEmpty();
+      expect(viewport.scrollTop).toBe(6_908);
+
+      // Past the original absolute ceiling, queue a normal pinned frame guard,
+      // then deliberately unpin. The old prepend owner must neither protect the
+      // cancel seam nor revive its seat on a later ResizeObserver delivery.
+      clock = 3_100;
+      act(() => {
+        api.notifyContentResize();
+      });
+      const cancellationsBeforeUnpin = cancelledHandles.length;
+      viewport.scrollTop = 300;
+      act(() => {
+        api.notifyUserScrollIntent(-1);
+        api.cancelFramePipeline();
+      });
+      expect(cancelledHandles.length).toBeGreaterThan(cancellationsBeforeUnpin);
+      flushRafToEmpty();
+      setContentHeight(viewport, 7_000);
+      act(() => {
+        api.notifyContentResize();
+      });
+      flushRafToEmpty();
+      expect(viewport.scrollTop).toBe(300);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("clears a drained owner at the event-silent scroll-to-bottom boundary", () => {
+    let clock = 0;
+    const nowSpy = vi.spyOn(performance, "now").mockImplementation(() => clock);
+    try {
+      const handle = renderHarness();
+      const { api, viewport } = handle.current;
+      setContentHeight(viewport, 5_552);
+      viewport.scrollTop = 425;
+      act(() => {
+        api.setPinned(false);
+        api.startAboveChangeCompensation(
+          { rowCount: 5, scrollHeight: 5_552, scrollTop: 425 },
+          false,
+        );
+      });
+      setContentHeight(viewport, 6_908);
+      flushRafToEmpty();
+      expect(viewport.scrollTop).toBe(1_781);
+      expect(rafQueue).toEqual([]);
+
+      // The real button repins after glue is fully drained. Do not deliver a
+      // scroll event or request a writer pass; synchronous repin itself must
+      // supersede the dormant prepend owner.
+      act(() => {
+        api.handleScrollToBottomClick();
+      });
+      expect(viewport.scrollTop).toBe(6_908);
+      flushRafToEmpty();
+
+      clock = 1_100; // post-ordinary but still inside the old absolute record
+      viewport.scrollTop = 300;
+      const cancellationsBeforeUnpin = cancelledHandles.length;
+      act(() => {
+        api.notifyUserScrollIntent(-1);
+        api.cancelFramePipeline();
+      });
+      expect(cancelledHandles.length).toBeGreaterThan(cancellationsBeforeUnpin);
+
+      setContentHeight(viewport, 7_000);
+      act(() => {
+        api.notifyContentResize();
+      });
+      flushRafToEmpty();
+      expect(viewport.scrollTop).toBe(300);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("expires an acknowledged dormant owner before genuine upward takeover", () => {
+    let clock = 0;
+    const nowSpy = vi.spyOn(performance, "now").mockImplementation(() => clock);
+    try {
+      const handle = renderHarness();
+      const { api, viewport } = handle.current;
+      setContentHeight(viewport, 5_552);
+      viewport.scrollTop = 425;
+      act(() => {
+        api.setPinned(false);
+        api.startAboveChangeCompensation(
+          { rowCount: 5, scrollHeight: 5_552, scrollTop: 425 },
+          false,
+        );
+      });
+      setContentHeight(viewport, 6_908);
+      flushRafToEmpty();
+      expect(viewport.scrollTop).toBe(1_781);
+
+      // Glue ended before the ordinary deadline, leaving the anchor dormant for
+      // possible growth. Genuine input after its absolute record must clear it
+      // before onViewportScroll can rearm glue or a later resize can revive it.
+      clock = 3_100;
+      viewport.scrollTop = 200;
+      const cancellationsBeforeTakeover = cancelledHandles.length;
+      act(() => {
+        api.notifyUserScrollIntent(-1);
+        api.cancelFramePipeline();
+        api.onViewportScroll(viewport);
+      });
+      expect(cancelledHandles.length).toBeGreaterThan(cancellationsBeforeTakeover);
+      expect(rafQueue).toEqual([]);
+
+      setContentHeight(viewport, 7_000);
+      act(() => {
+        api.notifyContentResize();
+      });
+      flushRafToEmpty();
+      expect(viewport.scrollTop).toBe(200);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("releases at the absolute ceiling instead of retrying silent erosion indefinitely", () => {
+    let clock = 0;
+    const nowSpy = vi.spyOn(performance, "now").mockImplementation(() => clock);
+    try {
+      const handle = renderHarness();
+      const { api, viewport } = handle.current;
+      setContentHeight(viewport, 5_552);
+      viewport.scrollTop = 425;
+      act(() => {
+        api.setPinned(false);
+        api.startAboveChangeCompensation(
+          { rowCount: 5, scrollHeight: 5_552, scrollTop: 425 },
+          false,
+        );
+      });
+      setContentHeight(viewport, 6_908);
+      flushRafToEmpty();
+      expect(viewport.scrollTop).toBe(1_781);
+
+      // The lifecycle's three-second ceiling wins even if its final correction
+      // is silently overwritten. The scheduler may consume the already-owed
+      // verifier, but must not start an unbounded position-only retry loop.
+      clock = 3_100;
+      viewport.scrollTop = 0;
+      act(() => {
+        api.notifyContentResize();
+      });
+      expect(viewport.scrollTop).toBe(1_781);
+      viewport.scrollTop = 0;
+      flushRafToEmpty();
+
+      expect(handle.current.api.isPinnedToBottom).toBe(false);
+      expect(rafQueue).toEqual([]);
+      expect(viewport.scrollTop).toBe(0);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+});

--- a/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
+++ b/apps/packages/product-client/src/hooks/chat/ui/use-transcript-stick-to-bottom.ts
@@ -70,34 +70,30 @@ export function useTranscriptStickToBottom({
     reset: resetNewContentSignal,
   } = useTranscriptNewContentSignal();
   const lastScrollTopRef = useRef(0);
-  // Last observed content height: lets a scroll event tell a genuine user
-  // displacement apart from our own snap lagging a growing stream. See onViewportScroll.
+  // Distinguishes user displacement from follow lag during content growth.
   const lastContentHeightRef = useRef(0);
-  // Ownership markers: the PRIMARY signal telling our own writes apart from a
-  // user scroll. See transcript-scroll-ownership.ts.
+  // Primary signal separating owned writes from user scrolls.
   const ownershipMarkersRef = useRef(new TranscriptScrollOwnershipMarkers());
-  // One per-frame mutate-then-snap pipeline (rung 4 / PRO-187): replaces the
-  // session-entry / submit / tab-resume / above-change rAF loops with one
-  // owned scheduler and ONE snap writer.
+  // One scheduler and writer replace the former independent frame loops.
   const pipelineRef = useRef(new TranscriptFramePipeline());
-  // Active above-change compensation anchor, applied while unpinned until its deadline lapses.
   const compensationAnchorRef = useRef<ContentHeightScrollAnchor | null>(null);
-  // Cancels on upward intent: true for a completed-turn split, false for a history prepend (reader-asked).
   const compensationCancelableRef = useRef(false);
-  // Deadline (interactionNow ms) past which the anchor is stale and released; wall-clock, not glue's quiet-frame end.
   const compensationDeadlineRef = useRef(0);
-  // FR-2 restore (rung 6): frame writer re-resolves this each glued frame so the saved reading row holds as heights settle.
+  const compensationAbsoluteDeadlineRef = useRef<{
+    anchor: ContentHeightScrollAnchor | null;
+    deadline: number;
+  }>({ anchor: null, deadline: 0 });
+  // FR-2 restore re-resolves the saved row while mounted heights settle.
   const restoreResolverRef = useRef<((viewport: HTMLElement) => TranscriptRestoreResolution | null) | null>(null);
   const restoreDeadlineRef = useRef(0);
   const userScrollIntentUntilRef = useRef(0);
 
-  // Rung 11: `cause` is observation-only for the diagnostics record below;
-  // it never changes what setPinned does. Defaults to "unspecified".
+  // `cause` labels diagnostics only; it never changes pin behavior.
   const setPinned = useCallback((next: boolean, cause: TranscriptPinTransitionCause = "unspecified") => {
     if (next) {
-      // Re-pinning (any path: repin band, submit, button click) means the
-      // reader is at the bottom seeing the new content, so the announcement
-      // is done regardless of whether pin state itself changed.
+      compensationAnchorRef.current = null;
+      compensationAbsoluteDeadlineRef.current = { anchor: null, deadline: 0 };
+      // Any repin consumes the new-content announcement.
       clearNewContentSignal();
     }
     if (pinnedRef.current === next) {
@@ -114,14 +110,10 @@ export function useTranscriptStickToBottom({
 
   const markNonUserScrollPosition = useCallback((viewport: HTMLDivElement) => {
     const expectedTop = viewport.scrollTop;
-    // Record ownership without disturbing markers already in flight: several
-    // programmatic writes can await their events at once (see
-    // transcript-scroll-ownership.ts).
+    // Preserve markers for other programmatic writes still awaiting events.
     ownershipMarkersRef.current.record(expectedTop);
     lastScrollTopRef.current = expectedTop;
-    // Baseline the content-size detector to the height we just snapped against,
-    // so a later scroll event only counts as a resize when the content actually
-    // changed size past this write (not merely because this write settled).
+    // Baseline resize detection to the height this owned write used.
     lastContentHeightRef.current = viewport.scrollHeight;
   }, []);
 
@@ -134,7 +126,24 @@ export function useTranscriptStickToBottom({
     markNonUserScrollPosition(viewport);
   }, [markNonUserScrollPosition, scrollRef]);
 
+  const resolveNonCancelableCompensationProtection = useCallback((clearExpired: boolean) => {
+    const anchor = compensationAnchorRef.current;
+    if (anchor == null || compensationCancelableRef.current) {
+      return false;
+    }
+    const absolute = compensationAbsoluteDeadlineRef.current;
+    const now = interactionNow();
+    const isProtected = now < compensationDeadlineRef.current
+      || (absolute.anchor === anchor && now < absolute.deadline);
+    if (!isProtected && clearExpired) {
+      compensationAnchorRef.current = null;
+      compensationAbsoluteDeadlineRef.current = { anchor: null, deadline: 0 };
+    }
+    return isProtected;
+  }, []);
+
   const notifyUserScrollIntent = useCallback((direction: -1 | 1) => {
+    resolveNonCancelableCompensationProtection(true);
     userScrollIntentUntilRef.current = interactionNow() + TRANSCRIPT_USER_SCROLL_SETTLE_MS;
     // The reader is driving: end any in-flight FR-2 restore (rung 6).
     restoreResolverRef.current = null;
@@ -146,12 +155,13 @@ export function useTranscriptStickToBottom({
       // use-transcript-stick-to-bottom.compensation.test.tsx.
       if (compensationCancelableRef.current) {
         compensationAnchorRef.current = null;
+        compensationAbsoluteDeadlineRef.current = { anchor: null, deadline: 0 };
       }
       setPinned(false, "user_intent_unpin");
     }
     // Claim the frame at input time so it can't race a stream/reveal animation frame.
     onScrollSample({ programmatic: false, userInitiated: true });
-  }, [onScrollSample, sessionKey, setPinned]);
+  }, [onScrollSample, resolveNonCancelableCompensationProtection, sessionKey, setPinned]);
 
   // Owns the consumed-inset machine, follow-target math, and scroll-to-bottom
   // callbacks. See use-transcript-auto-follow-bottom.ts.
@@ -181,13 +191,8 @@ export function useTranscriptStickToBottom({
     const previousTop = lastScrollTopRef.current;
     lastScrollTopRef.current = top;
 
-    // A live NON-cancelable history prepend remains invariant after height settles.
-    // Re-arm before marker precedence; WebKit momentum can keep eroding through its marker.
-    const hasLiveNonCancelableCompensation = (
-      compensationAnchorRef.current != null
-      && !compensationCancelableRef.current
-      && interactionNow() < compensationDeadlineRef.current
-    );
+    // Re-arm a bounded prepend owner before marker precedence.
+    const hasLiveNonCancelableCompensation = resolveNonCancelableCompensationProtection(false);
     if (hasLiveNonCancelableCompensation) {
       pipelineRef.current.ensureGlue();
     }
@@ -198,6 +203,7 @@ export function useTranscriptStickToBottom({
       onScrollSample({ programmatic: true });
       return;
     }
+    resolveNonCancelableCompensationProtection(true);
 
     // No live marker: user scroll (intent-attributed below) or unattributed; the
     // user-scroll-wins pin logic runs unchanged either way.
@@ -244,19 +250,15 @@ export function useTranscriptStickToBottom({
         : { programmatic: false },
     );
   }, [
-    compensationAnchorRef,
-    compensationCancelableRef,
-    compensationDeadlineRef,
     dispatchInsetEvent,
     onScrollSample,
     pinnedRef,
     repinThresholdPx,
+    resolveNonCancelableCompensationProtection,
     setPinned,
   ]);
 
-  // Session re-entry / submit / tab-resume "glue": snap each frame while a
-  // freshly mounted or resumed measurement backlog lands, terminating when the
-  // content ResizeObserver goes quiet or the hard cap elapses.
+  // Glue snaps while a mounted/resumed measurement backlog settles.
   const beginGlue = useCallback(() => {
     if (typeof window === "undefined") {
       return;
@@ -276,18 +278,11 @@ export function useTranscriptStickToBottom({
   }, [notifyContentGrew, scrollRef]);
 
   const cancelFramePipeline = useCallback(() => {
-    // A trailing input listener may run after onViewportScroll re-armed the
-    // prepend reconciliation above. Preserve that one queued pass while the
-    // non-cancelable anchor is live; every other owner remains cancelable.
-    if (
-      compensationAnchorRef.current != null
-      && !compensationCancelableRef.current
-      && interactionNow() < compensationDeadlineRef.current
-    ) {
+    if (resolveNonCancelableCompensationProtection(true)) {
       return;
     }
     pipelineRef.current.cancel();
-  }, []);
+  }, [resolveNonCancelableCompensationProtection]);
 
   // Hold anchored content in place while a row inserted ABOVE it measures in.
   // Sets the compensation anchor and starts a glue window; the single frame
@@ -300,6 +295,7 @@ export function useTranscriptStickToBottom({
     compensationAnchorRef.current = anchor;
     compensationCancelableRef.current = cancelableByUpwardIntent;
     compensationDeadlineRef.current = interactionNow() + ABOVE_CHANGE_COMPENSATION_MAX_MS;
+    compensationAbsoluteDeadlineRef.current = { anchor: null, deadline: 0 };
     beginGlue();
   }, [beginGlue]);
 
@@ -323,6 +319,7 @@ export function useTranscriptStickToBottom({
     compensationAnchorRef.current = null;
     compensationCancelableRef.current = false;
     compensationDeadlineRef.current = 0;
+    compensationAbsoluteDeadlineRef.current = { anchor: null, deadline: 0 };
     restoreResolverRef.current = null;
     restoreDeadlineRef.current = 0;
     lastScrollTopRef.current = 0;
@@ -368,6 +365,7 @@ export function useTranscriptStickToBottom({
     pinnedRef,
     compensationAnchorRef,
     compensationDeadlineRef,
+    compensationAbsoluteDeadlineRef,
     restoreResolverRef,
     restoreDeadlineRef,
     scrollToBottom,


### PR DESCRIPTION
## Summary

- Confirm an older-history prepend correction from a later animation-frame writer turn before releasing the reader seat.
- Keep clamped or post-deadline reconciliation owned within the existing absolute ceiling, while expired dormant ownership yields to real user input.
- Make every repin synchronously supersede the prepend owner, including event-silent scroll-to-bottom actions.
- Reuse the existing single frame-pipeline writer and shared continuation; add no timer, polling loop, second writer, or scroll listener.
- This standalone shared-owner follow-up blocks the held Changes, Sandbox, and Files stacks.

## Evidence

- Merged #2076 passed once, but byte-identical Sandbox C2 head `52307e6009` failed WebKit again in run `32261179982`, job `96094549657`, artifact `9368458018` at `425/5552 -> 0/6908`.
- Files #2077 exact head `85e9d49658` independently failed the same unchanged WebKit assertion in run `32265923280`, job `96110265323`, artifact `9370708773`; Chromium passed and aggregate result was 32 pass / 1 intentional skip / 1 failure.
- Trace/source comparison isolates an event-silent compositor overwrite after the JavaScript writer pass; no source, fixture, workflow, lockfile, toolchain, or bundle drift explains the failure.

## Testing

- Tier 1: seven relevant unit files, 53/53 passed serially on the exact reviewed source.
- Tier 1: transcript single-writer checker, strict frontend structure and FE-SIZE, frontend boundaries, max-lines, docs, design attribution, and diff hygiene passed.
- Red-first controls cover capture/install erosion, repeated event-silent overwrite, ordinary-deadline cancel, clamped height recovery, same-refresh false acknowledgment, repin, expired dormant takeover, never-initialized ownership, and the real event-silent scroll-to-bottom action.
- The unchanged Chromium + WebKit fixture and full repository matrix are delegated to hosted CI under the machine-pressure guard. Acceptance requires two independent green executions of the unchanged current-head scroll-physics job; a failure is preserved and diagnosed, not retried green.

## Observability

- None. The repair adds no telemetry or geometry logging. Existing renderer diagnostics remain unchanged.

## Readiness

- [x] I followed the pull-request procedure for scope, title, labels, body, and readiness.

## Verification

- Frozen contract: `CS-PREPEND-v1.3.5`.
- Exact base: `3f726d65a328abb71cba30bd25e664c198d57cac`.
- Independently accepted pre-commit patch: `204ab923219d23c76c8c7f848d88944d85a98a66f5a2854b15ac3cfc931f71c8`, no findings.
- Current head: `0ff7da8b0fad1646b1d822cf3c30f08cdbbc5583`.
- Scope is seven ProductClient hook/pipeline test and owner files. Browser fixture, assertions, thresholds, timers, retry policy, workflow, packages, lockfile, telemetry, Rust, and product-lane heads are untouched.