### PR TITLE
ci(release): normalize hosted Playwright apt source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,7 @@ jobs:
 
       - name: Install system deps (Tauri)
         run: |
+          sudo "$(command -v node)" "$GITHUB_WORKSPACE/scripts/ci-cd/configure-playwright-apt.mjs"
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,7 +409,9 @@ jobs:
         run: pnpm install
 
       - name: Install Playwright chromium
-        run: pnpm exec playwright install --with-deps chromium
+        run: |
+          sudo "$(command -v node)" "$GITHUB_WORKSPACE/scripts/ci-cd/configure-playwright-apt.mjs"
+          pnpm exec playwright install --with-deps chromium
 
       - name: Build shared packages
         run: pnpm shared:build
@@ -505,7 +507,9 @@ jobs:
         run: pnpm --filter @proliferate/product-client typecheck:scroll-physics
 
       - name: Install Playwright chromium + webkit
-        run: pnpm --filter @proliferate/product-client exec playwright install --with-deps chromium webkit
+        run: |
+          sudo "$(command -v node)" "$GITHUB_WORKSPACE/scripts/ci-cd/configure-playwright-apt.mjs"
+          pnpm --filter @proliferate/product-client exec playwright install --with-deps chromium webkit
 
       - name: Run scroll-physics suite
         run: pnpm --filter @proliferate/product-client test:scroll-physics
@@ -578,7 +582,9 @@ jobs:
         run: git diff --exit-code -- cloud/sdk/src/generated/openapi.ts
 
       - name: Install Playwright chromium
-        run: pnpm -C tests/intent exec playwright install --with-deps chromium
+        run: |
+          sudo "$(command -v node)" "$GITHUB_WORKSPACE/scripts/ci-cd/configure-playwright-apt.mjs"
+          pnpm -C tests/intent exec playwright install --with-deps chromium
 
       - name: Run workflow-definition lifecycle spec
         env:

--- a/.github/workflows/intent-tests.yml
+++ b/.github/workflows/intent-tests.yml
@@ -74,7 +74,9 @@ jobs:
         run: cd server && uv venv .venv --python 3.12 && uv pip install -e ".[dev]"
 
       - name: Install Playwright chromium
-        run: pnpm -C tests/intent exec playwright install --with-deps chromium
+        run: |
+          sudo "$(command -v node)" "$GITHUB_WORKSPACE/scripts/ci-cd/configure-playwright-apt.mjs"
+          pnpm -C tests/intent exec playwright install --with-deps chromium
 
       - name: Run tier-2 fixture unit tests
         run: pnpm -C tests/intent test:unit
@@ -150,7 +152,9 @@ jobs:
       - name: Install server (venv, matches local layout)
         run: cd server && uv venv .venv --python 3.12 && uv pip install -e ".[dev]"
       - name: Install Playwright chromium
-        run: pnpm -C tests/intent exec playwright install --with-deps chromium
+        run: |
+          sudo "$(command -v node)" "$GITHUB_WORKSPACE/scripts/ci-cd/configure-playwright-apt.mjs"
+          pnpm -C tests/intent exec playwright install --with-deps chromium
 
       - name: Install Stripe CLI
         run: |

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -473,7 +473,9 @@ jobs:
       - name: Install server (venv, matches local layout)
         run: cd server && uv venv .venv --python 3.12 && uv pip install -e ".[dev]"
       - name: Install Playwright chromium
-        run: pnpm -C tests/intent exec playwright install --with-deps chromium
+        run: |
+          sudo "$(command -v node)" "$GITHUB_WORKSPACE/scripts/ci-cd/configure-playwright-apt.mjs"
+          pnpm -C tests/intent exec playwright install --with-deps chromium
 
       - name: Install Stripe CLI
         run: |

--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -136,6 +136,7 @@ jobs:
       - name: Install Playwright chromium
         run: |
           npm install --no-save playwright@1.61.0
+          sudo "$(command -v node)" "$GITHUB_WORKSPACE/scripts/ci-cd/configure-playwright-apt.mjs"
           npx playwright install --with-deps chromium
 
       - name: Set up Docker Buildx

--- a/scripts/ci-cd/configure-playwright-apt.mjs
+++ b/scripts/ci-cd/configure-playwright-apt.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+export const DEFAULT_UBUNTU_SOURCE_PATH =
+  "/etc/apt/sources.list.d/ubuntu.sources";
+export const RUNNER_MIRROR_URI =
+  "mirror+file:/etc/apt/apt-mirrors.txt";
+export const CANONICAL_UBUNTU_URI =
+  "https://archive.ubuntu.com/ubuntu/";
+
+export function normalizePlaywrightAptSource(source) {
+  const uriFields = [...source.matchAll(/^URIs:[^\r\n]*(?=\r?$)/gm)];
+  if (uriFields.length !== 1) {
+    throw new Error(
+      `expected exactly one Ubuntu deb822 URIs field, found ${uriFields.length}`,
+    );
+  }
+
+  const field = uriFields[0];
+  const parsed = /^(URIs:[ \t]+)(\S+)([ \t]*)$/.exec(field[0]);
+  if (!parsed) {
+    throw new Error("expected the Ubuntu deb822 URIs field to contain one URI");
+  }
+
+  const uri = parsed[2];
+  if (uri === CANONICAL_UBUNTU_URI) {
+    return { changed: false, source };
+  }
+  if (uri !== RUNNER_MIRROR_URI) {
+    throw new Error("Ubuntu deb822 URIs field does not match a supported source");
+  }
+
+  const uriStart = field.index + parsed[1].length;
+  return {
+    changed: true,
+    source:
+      source.slice(0, uriStart) +
+      CANONICAL_UBUNTU_URI +
+      source.slice(uriStart + RUNNER_MIRROR_URI.length),
+  };
+}
+
+export async function configurePlaywrightAptSource(
+  sourcePath = DEFAULT_UBUNTU_SOURCE_PATH,
+) {
+  const current = await readFile(sourcePath, "utf8");
+  const normalized = normalizePlaywrightAptSource(current);
+  if (normalized.changed) {
+    await writeFile(sourcePath, normalized.source, "utf8");
+  }
+  return normalized.changed;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length > 1) {
+    throw new Error("usage: configure-playwright-apt.mjs [ubuntu.sources]");
+  }
+
+  const sourcePath = args[0] || DEFAULT_UBUNTU_SOURCE_PATH;
+  const changed = await configurePlaywrightAptSource(sourcePath);
+  console.log(
+    changed
+      ? "configure-playwright-apt: normalized hosted Ubuntu source"
+      : "configure-playwright-apt: hosted Ubuntu source already canonical",
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`configure-playwright-apt: ${message.slice(0, 500)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ci-cd/configure-playwright-apt.mjs
+++ b/scripts/ci-cd/configure-playwright-apt.mjs
@@ -9,36 +9,178 @@ export const RUNNER_MIRROR_URI =
   "mirror+file:/etc/apt/apt-mirrors.txt";
 export const CANONICAL_UBUNTU_URI =
   "https://archive.ubuntu.com/ubuntu/";
+const ARCHIVE_SUITES = "noble noble-updates noble-backports";
+const SECURITY_SUITES = "noble-security";
+const UBUNTU_COMPONENTS = "main universe restricted multiverse";
+const UBUNTU_ARCHIVE_KEY =
+  "/usr/share/keyrings/ubuntu-archive-keyring.gpg";
+const CRITICAL_FIELDS = new Map(
+  ["Types", "URIs", "Suites", "Components", "Signed-By"].map((name) => [
+    name.toLowerCase(),
+    name,
+  ]),
+);
 
-export function normalizePlaywrightAptSource(source) {
-  const uriFields = [...source.matchAll(/^URIs:[^\r\n]*(?=\r?$)/gm)];
-  if (uriFields.length !== 1) {
+function sourceLines(source) {
+  if (source.replaceAll("\r\n", "").includes("\r")) {
+    throw new Error("Ubuntu deb822 source uses an unsupported line ending");
+  }
+
+  return [...source.matchAll(/[^\r\n]*(?:\r\n|\n|$)/g)]
+    .filter((match) => match[0].length > 0)
+    .map((match) => {
+      const raw = match[0];
+      const endingLength = raw.endsWith("\r\n")
+        ? 2
+        : raw.endsWith("\n")
+          ? 1
+          : 0;
+      return {
+        start: match.index,
+        text: endingLength === 0 ? raw : raw.slice(0, -endingLength),
+      };
+    });
+}
+
+function deb822Stanzas(source) {
+  const stanzas = [];
+  let current = null;
+  for (const line of sourceLines(source)) {
+    if (/^[ \t]*$/.test(line.text)) {
+      current = null;
+      continue;
+    }
+    if (line.text.startsWith("#")) {
+      continue;
+    }
+    if (current === null) {
+      current = [];
+      stanzas.push(current);
+    }
+    current.push(line);
+  }
+  return stanzas;
+}
+
+function criticalFields(stanza, stanzaNumber) {
+  const fields = new Map();
+
+  for (const line of stanza) {
+    if (line.text.startsWith("#")) {
+      continue;
+    }
+    if (/^[ \t]/.test(line.text)) {
+      throw new Error(
+        `Ubuntu deb822 stanza ${stanzaNumber} has an unknown continuation line`,
+      );
+    }
+
+    const parsed = /^([A-Za-z0-9][A-Za-z0-9-]*):([ \t]*)(.*?)([ \t]*)$/.exec(
+      line.text,
+    );
+    if (!parsed) {
+      throw new Error(
+        `Ubuntu deb822 stanza ${stanzaNumber} has an unknown field shape`,
+      );
+    }
+
+    const exactName = CRITICAL_FIELDS.get(parsed[1].toLowerCase());
+    if (exactName && parsed[1] !== exactName) {
+      throw new Error(
+        `Ubuntu deb822 stanza ${stanzaNumber} has an unknown critical field shape`,
+      );
+    }
+    if (!exactName) {
+      throw new Error(
+        `Ubuntu deb822 stanza ${stanzaNumber} has unknown field ${parsed[1]}`,
+      );
+    }
+    if (fields.has(exactName)) {
+      throw new Error(
+        `Ubuntu deb822 stanza ${stanzaNumber} duplicates critical field ${exactName}`,
+      );
+    }
+
+    const valueStart = line.start + parsed[1].length + 1 + parsed[2].length;
+    fields.set(exactName, {
+      value: parsed[3],
+      valueStart,
+      valueEnd: valueStart + parsed[3].length,
+    });
+  }
+
+  for (const name of CRITICAL_FIELDS.values()) {
+    if (!fields.has(name)) {
+      throw new Error(
+        `Ubuntu deb822 stanza ${stanzaNumber} is missing critical field ${name}`,
+      );
+    }
+  }
+  if (
+    fields.get("Types").value !== "deb" ||
+    fields.get("Components").value !== UBUNTU_COMPONENTS ||
+    fields.get("Signed-By").value !== UBUNTU_ARCHIVE_KEY
+  ) {
     throw new Error(
-      `expected exactly one Ubuntu deb822 URIs field, found ${uriFields.length}`,
+      `Ubuntu deb822 stanza ${stanzaNumber} has an unknown critical field value`,
     );
   }
 
-  const field = uriFields[0];
-  const parsed = /^(URIs:[ \t]+)(\S+)([ \t]*)$/.exec(field[0]);
-  if (!parsed) {
-    throw new Error("expected the Ubuntu deb822 URIs field to contain one URI");
+  return fields;
+}
+
+export function normalizePlaywrightAptSource(source) {
+  const stanzas = deb822Stanzas(source);
+  if (stanzas.length !== 2) {
+    throw new Error(
+      `expected exactly two Ubuntu deb822 stanzas, found ${stanzas.length}`,
+    );
   }
 
-  const uri = parsed[2];
-  if (uri === CANONICAL_UBUNTU_URI) {
+  const fields = stanzas.map((stanza, index) =>
+    criticalFields(stanza, index + 1),
+  );
+  const suiteOwners = new Set(
+    fields.map((stanza) => stanza.get("Suites").value),
+  );
+  if (
+    suiteOwners.size !== 2 ||
+    !suiteOwners.has(ARCHIVE_SUITES) ||
+    !suiteOwners.has(SECURITY_SUITES)
+  ) {
+    throw new Error("Ubuntu deb822 stanzas do not own the expected suite sets");
+  }
+
+  const uriFields = fields.map((stanza) => stanza.get("URIs"));
+  if (
+    uriFields.some(
+      (field) =>
+        field.value !== RUNNER_MIRROR_URI &&
+        field.value !== CANONICAL_UBUNTU_URI,
+    )
+  ) {
+    throw new Error("Ubuntu deb822 URIs fields do not match a supported source");
+  }
+  const uriValues = new Set(uriFields.map((field) => field.value));
+  if (uriValues.size !== 1) {
+    throw new Error("Ubuntu deb822 URIs fields must use one uniform source");
+  }
+  if (uriFields[0].value === CANONICAL_UBUNTU_URI) {
     return { changed: false, source };
   }
-  if (uri !== RUNNER_MIRROR_URI) {
-    throw new Error("Ubuntu deb822 URIs field does not match a supported source");
-  }
 
-  const uriStart = field.index + parsed[1].length;
+  let normalized = source;
+  for (const field of uriFields.sort(
+    (left, right) => right.valueStart - left.valueStart,
+  )) {
+    normalized =
+      normalized.slice(0, field.valueStart) +
+      CANONICAL_UBUNTU_URI +
+      normalized.slice(field.valueEnd);
+  }
   return {
     changed: true,
-    source:
-      source.slice(0, uriStart) +
-      CANONICAL_UBUNTU_URI +
-      source.slice(uriStart + RUNNER_MIRROR_URI.length),
+    source: normalized,
   };
 }
 

--- a/scripts/ci-cd/configure-playwright-apt.test.mjs
+++ b/scripts/ci-cd/configure-playwright-apt.test.mjs
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import {
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  CANONICAL_UBUNTU_URI,
+  configurePlaywrightAptSource,
+  normalizePlaywrightAptSource,
+  RUNNER_MIRROR_URI,
+} from "./configure-playwright-apt.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const WORKFLOWS_ROOT = join(REPO_ROOT, ".github", "workflows");
+const WITH_DEPS_MARKER = "--with-deps";
+const HELPER_COMMAND =
+  'sudo "$(command -v node)" "$GITHUB_WORKSPACE/scripts/ci-cd/configure-playwright-apt.mjs"';
+
+async function withTemporarySource(source, callback) {
+  const directory = await mkdtemp(join(tmpdir(), "configure-playwright-apt-"));
+  const sourcePath = join(directory, "ubuntu.sources");
+  try {
+    await writeFile(sourcePath, source, "utf8");
+    await callback(sourcePath);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+async function workflowFiles(directory) {
+  const files = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await workflowFiles(path)));
+    } else if (entry.isFile() && /\.ya?ml$/.test(entry.name)) {
+      files.push(path);
+    }
+  }
+  return files.sort();
+}
+
+function indentation(line) {
+  return line.length - line.trimStart().length;
+}
+
+test("normalizes the known hosted-runner mirror without changing unrelated bytes", () => {
+  const input = [
+    "# runner-owned source",
+    "Types: deb",
+    `URIs: ${RUNNER_MIRROR_URI}  `,
+    "Suites: noble noble-updates noble-backports",
+    "Components: main universe restricted multiverse",
+    "Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg",
+    "",
+  ].join("\r\n");
+
+  const normalized = normalizePlaywrightAptSource(input);
+
+  assert.equal(normalized.changed, true);
+  assert.equal(
+    normalized.source,
+    input.replace(RUNNER_MIRROR_URI, CANONICAL_UBUNTU_URI),
+  );
+});
+
+test("accepts the canonical source without rewriting the file", async () => {
+  const input = [
+    "Types: deb",
+    `URIs: ${CANONICAL_UBUNTU_URI}`,
+    "Suites: noble noble-updates noble-backports",
+    "Components: main universe restricted multiverse",
+    "",
+  ].join("\n");
+
+  await withTemporarySource(input, async (sourcePath) => {
+    const fixedTime = new Date("2000-01-01T00:00:00.000Z");
+    await utimes(sourcePath, fixedTime, fixedTime);
+    const before = await stat(sourcePath, { bigint: true });
+
+    assert.equal(await configurePlaywrightAptSource(sourcePath), false);
+
+    const after = await stat(sourcePath, { bigint: true });
+    assert.equal(after.mtimeNs, before.mtimeNs);
+    assert.equal(await readFile(sourcePath, "utf8"), input);
+  });
+});
+
+test("rejects unknown source shapes without modifying the file", async (context) => {
+  const cases = {
+    missing: "Types: deb\nSuites: noble\n",
+    duplicate: `URIs: ${RUNNER_MIRROR_URI}\nURIs: ${RUNNER_MIRROR_URI}\n`,
+    mixed: `URIs: ${RUNNER_MIRROR_URI}\nURIs: ${CANONICAL_UBUNTU_URI}\n`,
+    "multiple values": `URIs: ${RUNNER_MIRROR_URI} ${CANONICAL_UBUNTU_URI}\n`,
+    unknown: "URIs: https://regional.example.invalid/ubuntu/\n",
+  };
+
+  for (const [name, input] of Object.entries(cases)) {
+    await context.test(name, async () => {
+      await withTemporarySource(input, async (sourcePath) => {
+        await assert.rejects(configurePlaywrightAptSource(sourcePath));
+        assert.equal(await readFile(sourcePath, "utf8"), input);
+      });
+    });
+  }
+});
+
+test("guards every hosted Playwright dependency install in its own run block", async () => {
+  const expectedCommandsByWorkflow = new Map([
+    [
+      ".github/workflows/ci.yml",
+      [
+        "pnpm exec playwright install --with-deps chromium",
+        "pnpm --filter @proliferate/product-client exec playwright install --with-deps chromium webkit",
+        "pnpm -C tests/intent exec playwright install --with-deps chromium",
+      ],
+    ],
+    [
+      ".github/workflows/intent-tests.yml",
+      [
+        "pnpm -C tests/intent exec playwright install --with-deps chromium",
+        "pnpm -C tests/intent exec playwright install --with-deps chromium",
+      ],
+    ],
+    [
+      ".github/workflows/release-e2e.yml",
+      ["pnpm -C tests/intent exec playwright install --with-deps chromium"],
+    ],
+    [
+      ".github/workflows/self-host-smoke.yml",
+      ["npx playwright install --with-deps chromium"],
+    ],
+  ]);
+  const installs = [];
+  const helpers = [];
+
+  for (const path of await workflowFiles(WORKFLOWS_ROOT)) {
+    const workflow = relative(REPO_ROOT, path);
+    const lines = (await readFile(path, "utf8")).split("\n");
+    for (const [index, line] of lines.entries()) {
+      if (line.includes(WITH_DEPS_MARKER)) {
+        installs.push({ workflow, index, line, lines });
+      }
+      if (line.trim() === HELPER_COMMAND) {
+        helpers.push({ workflow, index });
+      }
+    }
+  }
+
+  assert.equal(installs.length, 7, "hosted --with-deps call-site census changed");
+  assert.equal(helpers.length, 7, "each hosted --with-deps call needs one helper");
+  assert.deepEqual(
+    new Map(
+      [...expectedCommandsByWorkflow.keys()].map((workflow) => [
+        workflow,
+        installs
+          .filter((install) => install.workflow === workflow)
+          .map((install) => install.line.trim())
+          .sort(),
+      ]),
+    ),
+    new Map(
+      [...expectedCommandsByWorkflow].map(([workflow, commands]) => [
+        workflow,
+        [...commands].sort(),
+      ]),
+    ),
+  );
+  assert.deepEqual(
+    new Set(installs.map((install) => install.workflow)),
+    new Set(expectedCommandsByWorkflow.keys()),
+  );
+
+  for (const install of installs) {
+    const { workflow, index, line, lines } = install;
+    assert.equal(
+      lines[index - 1]?.trim(),
+      HELPER_COMMAND,
+      `${workflow}:${index + 1} is not immediately guarded`,
+    );
+    assert.equal(
+      indentation(lines[index - 1]),
+      indentation(line),
+      `${workflow}:${index + 1} helper is outside the install run block`,
+    );
+
+    let runLine = index - 2;
+    while (runLine >= 0 && indentation(lines[runLine]) >= indentation(line)) {
+      runLine -= 1;
+    }
+    assert.equal(
+      lines[runLine]?.trim(),
+      "run: |",
+      `${workflow}:${index + 1} install is not in a guarded multiline run block`,
+    );
+  }
+});

--- a/scripts/ci-cd/configure-playwright-apt.test.mjs
+++ b/scripts/ci-cd/configure-playwright-apt.test.mjs
@@ -25,6 +25,9 @@ const WORKFLOWS_ROOT = join(REPO_ROOT, ".github", "workflows");
 const WITH_DEPS_MARKER = "--with-deps";
 const HELPER_COMMAND =
   'sudo "$(command -v node)" "$GITHUB_WORKSPACE/scripts/ci-cd/configure-playwright-apt.mjs"';
+const CARGO_APT_UPDATE_COMMAND = "sudo apt-get update";
+const CARGO_APT_INSTALL_COMMAND =
+  "sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf";
 const HOSTED_TWO_STANZA_SOURCE = [
   "# Hosted runner Ubuntu source configuration",
   `# The mirror indirection remains documented as ${RUNNER_MIRROR_URI}`,
@@ -277,7 +280,11 @@ test("guards every hosted Playwright dependency install in its own run block", a
   }
 
   assert.equal(installs.length, 7, "hosted --with-deps call-site census changed");
-  assert.equal(helpers.length, 7, "each hosted --with-deps call needs one helper");
+  assert.equal(
+    helpers.length,
+    8,
+    "seven hosted --with-deps calls and Cargo need one helper each",
+  );
   assert.deepEqual(
     new Map(
       [...expectedCommandsByWorkflow.keys()].map((workflow) => [
@@ -323,4 +330,37 @@ test("guards every hosted Playwright dependency install in its own run block", a
       `${workflow}:${index + 1} install is not in a guarded multiline run block`,
     );
   }
+});
+
+test("guards Cargo Tauri apt dependencies before the unchanged install commands", async () => {
+  const path = join(WORKFLOWS_ROOT, "ci.yml");
+  const lines = (await readFile(path, "utf8")).split("\n");
+  const cargoJobs = lines
+    .map((line, index) => ({ line, index }))
+    .filter(({ line }) => line === "  cargo-check:");
+  const tauriSteps = lines
+    .map((line, index) => ({ line, index }))
+    .filter(({ line }) => line.trim() === "- name: Install system deps (Tauri)");
+
+  assert.equal(cargoJobs.length, 1, "expected exactly one cargo-check job");
+  assert.equal(tauriSteps.length, 1, "expected exactly one Tauri dependency step");
+
+  const [{ index: cargoJobIndex }] = cargoJobs;
+  const [{ index: tauriStepIndex }] = tauriSteps;
+  const nextJobIndex = lines.findIndex(
+    (line, index) => index > cargoJobIndex && /^  [a-z0-9-]+:$/.test(line),
+  );
+  assert.ok(tauriStepIndex > cargoJobIndex, "Tauri step is outside cargo-check");
+  assert.ok(
+    nextJobIndex === -1 || tauriStepIndex < nextJobIndex,
+    "Tauri step is outside cargo-check",
+  );
+  assert.equal(lines[tauriStepIndex + 1]?.trim(), "run: |");
+  assert.deepEqual(
+    lines.slice(tauriStepIndex + 2, tauriStepIndex + 5).map((line) => line.trim()),
+    [HELPER_COMMAND, CARGO_APT_UPDATE_COMMAND, CARGO_APT_INSTALL_COMMAND],
+  );
+  assert.equal(indentation(lines[tauriStepIndex + 2]), 10);
+  assert.equal(indentation(lines[tauriStepIndex + 3]), 10);
+  assert.equal(indentation(lines[tauriStepIndex + 4]), 10);
 });

--- a/scripts/ci-cd/configure-playwright-apt.test.mjs
+++ b/scripts/ci-cd/configure-playwright-apt.test.mjs
@@ -25,6 +25,54 @@ const WORKFLOWS_ROOT = join(REPO_ROOT, ".github", "workflows");
 const WITH_DEPS_MARKER = "--with-deps";
 const HELPER_COMMAND =
   'sudo "$(command -v node)" "$GITHUB_WORKSPACE/scripts/ci-cd/configure-playwright-apt.mjs"';
+const HOSTED_TWO_STANZA_SOURCE = [
+  "# Hosted runner Ubuntu source configuration",
+  `# The mirror indirection remains documented as ${RUNNER_MIRROR_URI}`,
+  "",
+  "Types: deb",
+  `URIs: ${RUNNER_MIRROR_URI}`,
+  "Suites: noble noble-updates noble-backports",
+  "Components: main universe restricted multiverse",
+  "Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg",
+  "",
+  "Types: deb",
+  `URIs: ${RUNNER_MIRROR_URI}`,
+  "Suites: noble-security",
+  "Components: main universe restricted multiverse",
+  "Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg",
+  "",
+].join("\n");
+
+function twoStanzaSource({
+  archiveUri = RUNNER_MIRROR_URI,
+  securityUri = RUNNER_MIRROR_URI,
+  owners = ["archive", "security"],
+  lineEnding = "\n",
+  includeComments = false,
+} = {}) {
+  const stanzaByOwner = {
+    archive: {
+      uri: archiveUri,
+      suites: "noble noble-updates noble-backports",
+    },
+    security: {
+      uri: securityUri,
+      suites: "noble-security",
+    },
+  };
+  const stanzas = owners.map((owner) => {
+    const stanza = stanzaByOwner[owner];
+    return [
+      ...(includeComments ? [`# ${owner} suite owner`] : []),
+      "Types: deb",
+      `URIs: ${stanza.uri}`,
+      `Suites: ${stanza.suites}`,
+      "Components: main universe restricted multiverse",
+      "Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg",
+    ].join(lineEnding);
+  });
+  return `${stanzas.join(`${lineEnding}${lineEnding}`)}${lineEnding}`;
+}
 
 async function withTemporarySource(source, callback) {
   const directory = await mkdtemp(join(tmpdir(), "configure-playwright-apt-"));
@@ -54,34 +102,43 @@ function indentation(line) {
   return line.length - line.trimStart().length;
 }
 
-test("normalizes the known hosted-runner mirror without changing unrelated bytes", () => {
-  const input = [
-    "# runner-owned source",
-    "Types: deb",
-    `URIs: ${RUNNER_MIRROR_URI}  `,
-    "Suites: noble noble-updates noble-backports",
-    "Components: main universe restricted multiverse",
-    "Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg",
-    "",
-  ].join("\r\n");
+test("normalizes both hosted archive and security mirror stanzas", async () => {
+  const expected = HOSTED_TWO_STANZA_SOURCE.replaceAll(
+    `URIs: ${RUNNER_MIRROR_URI}`,
+    `URIs: ${CANONICAL_UBUNTU_URI}`,
+  );
+  const normalized = normalizePlaywrightAptSource(HOSTED_TWO_STANZA_SOURCE);
+
+  assert.equal(normalized.changed, true);
+  assert.equal(normalized.source, expected);
+
+  await withTemporarySource(HOSTED_TWO_STANZA_SOURCE, async (sourcePath) => {
+    assert.equal(await configurePlaywrightAptSource(sourcePath), true);
+    assert.equal(await readFile(sourcePath, "utf8"), expected);
+  });
+});
+
+test("preserves comments, critical fields, CRLF bytes, and reversed stanza order", () => {
+  const input = twoStanzaSource({
+    owners: ["security", "archive"],
+    lineEnding: "\r\n",
+    includeComments: true,
+  });
 
   const normalized = normalizePlaywrightAptSource(input);
 
   assert.equal(normalized.changed, true);
   assert.equal(
     normalized.source,
-    input.replace(RUNNER_MIRROR_URI, CANONICAL_UBUNTU_URI),
+    input.replaceAll(RUNNER_MIRROR_URI, CANONICAL_UBUNTU_URI),
   );
 });
 
-test("accepts the canonical source without rewriting the file", async () => {
-  const input = [
-    "Types: deb",
-    `URIs: ${CANONICAL_UBUNTU_URI}`,
-    "Suites: noble noble-updates noble-backports",
-    "Components: main universe restricted multiverse",
-    "",
-  ].join("\n");
+test("accepts both canonical stanzas without rewriting the file", async () => {
+  const input = twoStanzaSource({
+    archiveUri: CANONICAL_UBUNTU_URI,
+    securityUri: CANONICAL_UBUNTU_URI,
+  });
 
   await withTemporarySource(input, async (sourcePath) => {
     const fixedTime = new Date("2000-01-01T00:00:00.000Z");
@@ -96,19 +153,81 @@ test("accepts the canonical source without rewriting the file", async () => {
   });
 });
 
-test("rejects unknown source shapes without modifying the file", async (context) => {
+test("rejects unknown two-stanza shapes without modifying the file", async (context) => {
   const cases = {
-    missing: "Types: deb\nSuites: noble\n",
-    duplicate: `URIs: ${RUNNER_MIRROR_URI}\nURIs: ${RUNNER_MIRROR_URI}\n`,
-    mixed: `URIs: ${RUNNER_MIRROR_URI}\nURIs: ${CANONICAL_UBUNTU_URI}\n`,
-    "multiple values": `URIs: ${RUNNER_MIRROR_URI} ${CANONICAL_UBUNTU_URI}\n`,
-    unknown: "URIs: https://regional.example.invalid/ubuntu/\n",
+    "missing security stanza": twoStanzaSource({ owners: ["archive"] }),
+    "extra Ubuntu stanza": twoStanzaSource({
+      owners: ["archive", "security", "archive"],
+    }),
+    "duplicate archive suite owner": twoStanzaSource({
+      owners: ["archive", "archive"],
+    }),
+    "unexpected suite ownership": HOSTED_TWO_STANZA_SOURCE.replace(
+      "Suites: noble-security",
+      "Suites: noble-security noble-updates",
+    ),
+    "mirror plus canonical": twoStanzaSource({
+      securityUri: CANONICAL_UBUNTU_URI,
+    }),
+    "multiple URI values": twoStanzaSource({
+      archiveUri: `${RUNNER_MIRROR_URI} ${CANONICAL_UBUNTU_URI}`,
+    }),
+    "unknown URI": twoStanzaSource({
+      securityUri: "https://regional.example.invalid/ubuntu/",
+    }),
+    "unknown Types value": HOSTED_TWO_STANZA_SOURCE.replace(
+      "Types: deb",
+      "Types: deb deb-src",
+    ),
+    "unknown Components value": HOSTED_TWO_STANZA_SOURCE.replace(
+      "Components: main universe restricted multiverse",
+      "Components: main universe",
+    ),
+    "unknown Signed-By value": HOSTED_TWO_STANZA_SOURCE.replace(
+      "/usr/share/keyrings/ubuntu-archive-keyring.gpg",
+      "/tmp/unknown-key.gpg",
+    ),
+    "missing critical field": HOSTED_TWO_STANZA_SOURCE.replace(
+      "Components: main universe restricted multiverse\n",
+      "",
+    ),
+    "duplicate critical field": HOSTED_TWO_STANZA_SOURCE.replace(
+      "Types: deb\n",
+      "Types: deb\nTypes: deb\n",
+    ),
+    "folded critical field": HOSTED_TWO_STANZA_SOURCE.replace(
+      "Suites: noble-security",
+      "Suites: noble-security\n noble-updates",
+    ),
+    "unknown critical field casing": HOSTED_TWO_STANZA_SOURCE.replace(
+      "Signed-By:",
+      "Signed-by:",
+    ),
+    "extra Enabled field": HOSTED_TWO_STANZA_SOURCE.replace(
+      "Types: deb\n",
+      "Enabled: no\nTypes: deb\n",
+    ),
+    "extra Architectures field": HOSTED_TWO_STANZA_SOURCE.replace(
+      "Types: deb\n",
+      "Types: deb\nArchitectures: arm64\n",
+    ),
+    "orphan continuation": HOSTED_TWO_STANZA_SOURCE.replace(
+      "Types: deb\n",
+      " unexpected\nTypes: deb\n",
+    ),
   };
 
   for (const [name, input] of Object.entries(cases)) {
     await context.test(name, async () => {
       await withTemporarySource(input, async (sourcePath) => {
+        const fixedTime = new Date("2000-01-01T00:00:00.000Z");
+        await utimes(sourcePath, fixedTime, fixedTime);
+        const before = await stat(sourcePath, { bigint: true });
+
         await assert.rejects(configurePlaywrightAptSource(sourcePath));
+
+        const after = await stat(sourcePath, { bigint: true });
+        assert.equal(after.mtimeNs, before.mtimeNs);
         assert.equal(await readFile(sourcePath, "utf8"), input);
       });
     });

--- a/specs/codebase/systems/engineering/delivery/README.md
+++ b/specs/codebase/systems/engineering/delivery/README.md
@@ -58,6 +58,10 @@ staging, the nightly train, or production promotion. The Worker reusable lane
 is a configured no-op while `WORKERS_DEPLOY_ENABLED` is false and deliberately
 fails if enabled before a canonical worker service and command exist.
 
+Hosted Playwright jobs normalize the known Ubuntu runner mirror indirection to
+the canonical archive immediately before `--with-deps`; the required
+browser/runtime dependency set is unchanged.
+
 See the [Hosted procedure](../../../../../guides/deploying/hosted.md).
 
 ### Background plane topology

--- a/specs/codebase/systems/engineering/delivery/README.md
+++ b/specs/codebase/systems/engineering/delivery/README.md
@@ -58,9 +58,9 @@ staging, the nightly train, or production promotion. The Worker reusable lane
 is a configured no-op while `WORKERS_DEPLOY_ENABLED` is false and deliberately
 fails if enabled before a canonical worker service and command exist.
 
-Hosted Playwright jobs normalize the known Ubuntu runner mirror indirection to
-the canonical archive immediately before `--with-deps`; the required
-browser/runtime dependency set is unchanged.
+Hosted Playwright and Cargo Tauri dependency steps normalize the known Ubuntu
+runner mirror indirection to the canonical archive immediately before
+apt-managed installs; the required dependency sets are unchanged.
 
 See the [Hosted procedure](../../../../../guides/deploying/hosted.md).
 


### PR DESCRIPTION
## Summary

- Normalize both of GitHub-hosted Ubuntu's known archive/security deb822 stanzas from `mirror+file:/etc/apt/apt-mirrors.txt` to `https://archive.ubuntu.com/ubuntu/` immediately before every hosted Playwright `--with-deps` install and Cargo's Tauri apt-managed dependency step.
- Validate exactly one archive suite owner and one security suite owner with the runner's five exact fields. Fail closed for missing, extra, duplicate, mixed, folded, extended, or unknown shapes; canonical input is idempotent and every unrelated source byte is preserved.
- Guard all seven existing Playwright call sites plus Cargo's existing Tauri apt block without changing install commands, package/browser sets, fixtures, assertions, Rust commands, retries, timeouts, concurrency, or check classification.

This is a standalone delivery-system prerequisite. It fixes an infrastructure failure where independent PR jobs stalled in the runner's regional apt mirror path before their assertions ran. It contains no product, package manifest, lockfile, browser-version, Docker, or Rust source change.

Frozen contract: `CI-PLAYWRIGHT-APT-v1.2`.

## Testing

Original red-first on exact base `ed98ef656fe79fe3b78415b99b14e307abe4db28`:

- transform/source-shape cases passed;
- workflow census failed as expected with seven `--with-deps` calls and zero guards.

Published v1 head `5ecb0ba4b987599b6eca680f4bb5991d24260d3e` supplied the hosted shape red receipt: all six Playwright jobs failed closed with `expected exactly one Ubuntu deb822 URIs field, found 2` before installation or assertions. No job was rerun. The official runner image and those logs establish two expected data stanzas whose archive and security suites both use the mirror-file URI.

Repaired v1.1 head `704f2c76b992d709ffe965f70b772a09d0428f64` then proved all six Playwright-backed assertions green on first-run CI `32278299771`, Intent `32278299724`, and Self-Host `32278299706`: Login, Chromium/Linux-WebKit scroll physics, Workflow definition lifecycle, Production compose smoke, intent, and billing. Its unguarded Cargo job `96150793904` remained in `Install system deps (Tauri)` / `sudo apt-get update` for more than 19 minutes with Setup Rust and all Cargo assertions unrun. That exact run is preserved and was not rerun.

Cargo amendment red-first on exact `704f2c76b9`:

- focused helper suite: 21/23 passed;
- failures were exactly the missing eighth helper census and missing helper-before-Cargo command order.

Final exact head `f994ce76e64b42b13691bed1ff2f851346316587`:

- `node --test scripts/ci-cd/configure-playwright-apt.test.mjs` — 23/23 passed
- `node --test scripts/ci-cd/*.test.mjs` — 203/203 passed
- all changed workflow YAML parsed
- `node --check scripts/ci-cd/configure-playwright-apt.mjs` — passed
- `python3.12 scripts/check_workflow_managed_boundaries.py` — passed
- `python3.12 scripts/check_docs.py` — 231 Markdown files passed
- `git diff --check` — passed

The v1.2 amendment is exactly three paths, candidate tree `7a362c2982862bf6429e2b94fd6974bb419fbd20`, and stable incremental patch ID `cb85f4f538bf60346766f0fe2f5c7a9ee1343b31`. Fresh independent spec-to-code review: ACCEPT, no findings. It verified exact helper placement and Node ownership, fail-closed source behavior, the sole Cargo job/step and exact command/package order, eight-helper census closure, unchanged Rust/assertion/timeout policy, truthful docs, and clean current-main composition.

Current-main drift through #2074 has zero path or semantic interaction with the aggregate seven-path PR. The reviewed current-main merge tree is clean.

Hosted acceptance is one first-run exact-head matrix. Cargo must log successful normalization, complete the unchanged Tauri apt update/install, and then execute Setup Rust, workspace `cargo check`, workspace `cargo test`, and the internal diagnostics export test successfully. Every other emitted policy context must also finish green/neutral. A failed, cancelled, or stalled gate is causal evidence, not authorization to rerun.

## Observability

No runtime or product telemetry changes. The helper emits one bounded success message and a bounded fail-closed diagnostic without printing source content or repository identities.
