### PR TITLE
fix(product): remove redundant secrets actions

### DIFF
--- a/apps/packages/product-client/src/components/patterns/secrets/SecretList.tsx
+++ b/apps/packages/product-client/src/components/patterns/secrets/SecretList.tsx
@@ -30,6 +30,13 @@ export function SecretList({
   onEdit,
   onDelete,
 }: SecretListProps) {
+  const addAction = canManage && onAdd ? (
+    <Button type="button" variant="secondary" size="sm" onClick={onAdd}>
+      <Plus className="icon-paired" />
+      {addLabel}
+    </Button>
+  ) : null;
+
   if (items.length === 0) {
     return (
       <div className="flex flex-col items-center gap-2 rounded-md border border-dashed border-border-light px-4 py-6 text-center text-body">
@@ -40,28 +47,26 @@ export function SecretList({
             <div className="text-ui-sm text-muted-foreground">{emptyDescription}</div>
           ) : null}
         </div>
-        {canManage && onAdd ? (
-          <Button type="button" variant="secondary" size="sm" onClick={onAdd}>
-            <Plus className="icon-paired" />
-            {addLabel}
-          </Button>
-        ) : null}
+        {addAction}
       </div>
     );
   }
 
   return (
-    <div className="overflow-hidden rounded-md border border-border-light">
-      {items.map((item) => (
-        <SecretRow
-          key={item.id}
-          label={item.label}
-          detail={item.detail}
-          canManage={canManage}
-          onEdit={() => onEdit(item)}
-          onDelete={() => onDelete(item)}
-        />
-      ))}
+    <div className="space-y-2">
+      <div className="overflow-hidden rounded-md border border-border-light">
+        {items.map((item) => (
+          <SecretRow
+            key={item.id}
+            label={item.label}
+            detail={item.detail}
+            canManage={canManage}
+            onEdit={() => onEdit(item)}
+            onDelete={() => onDelete(item)}
+          />
+        ))}
+      </div>
+      {addAction ? <div className="flex justify-end">{addAction}</div> : null}
     </div>
   );
 }

--- a/apps/packages/product-client/src/components/patterns/secrets/SecretManagementPanel.test.tsx
+++ b/apps/packages/product-client/src/components/patterns/secrets/SecretManagementPanel.test.tsx
@@ -27,4 +27,34 @@ describe("SecretManagementPanel actions", () => {
     expect(screen.getByRole("button", { name: "Add file" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Add secret" })).toBeNull();
   });
+
+  it("keeps the type-specific add actions available when secrets exist", () => {
+    render(
+      <SecretManagementPanel
+        title="Organization secrets"
+        description="Available in every member's cloud sandbox."
+        filePathMode="absolute"
+        envVars={[{
+          id: "env-1",
+          name: "API_TOKEN",
+          byteSize: 12,
+          updatedAt: "2026-08-19T00:00:00.000Z",
+        }]}
+        files={[{
+          id: "file-1",
+          path: "/root/.config/service.json",
+          byteSize: 48,
+          updatedAt: "2026-08-19T00:00:00.000Z",
+        }]}
+        onSaveEnvVar={vi.fn()}
+        onDeleteEnvVar={vi.fn()}
+        onSaveFile={vi.fn()}
+        onDeleteFile={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Add variable" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Add file" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Add secret" })).toBeNull();
+  });
 });

--- a/apps/packages/product-client/src/components/patterns/secrets/SecretManagementPanel.test.tsx
+++ b/apps/packages/product-client/src/components/patterns/secrets/SecretManagementPanel.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SecretManagementPanel } from "./SecretManagementPanel";
+
+afterEach(cleanup);
+
+describe("SecretManagementPanel actions", () => {
+  it("uses the type-specific add actions without a redundant panel action", () => {
+    render(
+      <SecretManagementPanel
+        title="Organization secrets"
+        description="Available in every member's cloud sandbox."
+        filePathMode="absolute"
+        envVars={[]}
+        files={[]}
+        onSaveEnvVar={vi.fn()}
+        onDeleteEnvVar={vi.fn()}
+        onSaveFile={vi.fn()}
+        onDeleteFile={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Pending")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Add variable" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Add file" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Add secret" })).toBeNull();
+  });
+});

--- a/apps/packages/product-client/src/components/patterns/secrets/SecretManagementPanel.test.tsx
+++ b/apps/packages/product-client/src/components/patterns/secrets/SecretManagementPanel.test.tsx
@@ -22,7 +22,7 @@ describe("SecretManagementPanel actions", () => {
       />,
     );
 
-    expect(screen.getByText("Pending")).toBeTruthy();
+    expect(screen.queryByText("Pending")).toBeNull();
     expect(screen.getByRole("button", { name: "Add variable" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Add file" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Add secret" })).toBeNull();

--- a/apps/packages/product-client/src/components/patterns/secrets/SecretManagementPanel.tsx
+++ b/apps/packages/product-client/src/components/patterns/secrets/SecretManagementPanel.tsx
@@ -3,10 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { SettingsSection } from "#product/primitives/patterns/settings/SettingsSection";
 import { SettingsRow } from "#product/primitives/patterns/settings/SettingsRow";
 import type { CloudSecretsPanelModel } from "#product/hooks/access/cloud/use-cloud-secrets-panel";
-import type {
-  SecretMaterializationView,
-  SecretMetadata,
-} from "#product/lib/domain/secrets/secret-management-panel";
+import type { SecretMetadata } from "#product/lib/domain/secrets/secret-management-panel";
 import {
   SecretDeleteDialog,
   type SecretDeleteDialogState,
@@ -30,7 +27,6 @@ export function SecretManagementPanel({
   files,
   materialization = null,
   canManage = true,
-  loading = false,
   saving = false,
   error = null,
   onSaveEnvVar,
@@ -53,7 +49,6 @@ export function SecretManagementPanel({
   );
   const existingEnvKeys = useMemo(() => envItems.map((item) => item.label), [envItems]);
   const existingFileKeys = useMemo(() => fileItems.map((item) => item.label), [fileItems]);
-  const status = error ? "error" : materialization?.status ?? "pending";
 
   function handleEditorSave(input: SecretEditorSaveInput) {
     if (input.kind === "env") {
@@ -103,9 +98,7 @@ export function SecretManagementPanel({
         <SettingsRow
           label={title}
           description={<SecretScopeNotice description={description} />}
-        >
-          <span className="text-ui-sm text-muted-foreground">{statusLabel(status, loading)}</span>
-        </SettingsRow>
+        />
 
         <SettingsRow
           label="Environment variables"
@@ -193,18 +186,3 @@ function formatDate(value: string): string {
   return date.toLocaleString();
 }
 
-function statusLabel(status: SecretMaterializationView["status"], loading: boolean): string {
-  if (loading) {
-    return "Loading";
-  }
-  switch (status) {
-    case "ready":
-      return "Materialized";
-    case "running":
-      return "Syncing";
-    case "error":
-      return "Error";
-    case "pending":
-      return "Pending";
-  }
-}

--- a/apps/packages/product-client/src/components/patterns/secrets/SecretManagementPanel.tsx
+++ b/apps/packages/product-client/src/components/patterns/secrets/SecretManagementPanel.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Plus } from "#product/primitives/icons/core";
 
-import { Button } from "#product/primitives/Button";
 import { SettingsSection } from "#product/primitives/patterns/settings/SettingsSection";
 import { SettingsRow } from "#product/primitives/patterns/settings/SettingsRow";
 import type { CloudSecretsPanelModel } from "#product/hooks/access/cloud/use-cloud-secrets-panel";
@@ -106,20 +104,7 @@ export function SecretManagementPanel({
           label={title}
           description={<SecretScopeNotice description={description} />}
         >
-          <div className="flex items-center gap-2">
-            <span className="text-ui-sm text-muted-foreground">{statusLabel(status, loading)}</span>
-            {canManage ? (
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                onClick={() => setEditorState({ mode: "create", kind: "env" })}
-              >
-                <Plus className="icon-paired" />
-                Add secret
-              </Button>
-            ) : null}
-          </div>
+          <span className="text-ui-sm text-muted-foreground">{statusLabel(status, loading)}</span>
         </SettingsRow>
 
         <SettingsRow

--- a/apps/packages/product-client/src/components/settings/panes/PersonalSecretsPane.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/PersonalSecretsPane.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PersonalSecretsPane } from "./PersonalSecretsPane";
+
+vi.mock("#product/hooks/access/cloud/use-cloud-secrets-panel", () => ({
+  useCloudSecretsPanel: () => ({
+    title: "Personal secrets",
+    description: "Available in your cloud sandbox.",
+    filePathMode: "absolute",
+    envVars: [],
+    files: [],
+    onSaveEnvVar: vi.fn(),
+    onDeleteEnvVar: vi.fn(),
+    onSaveFile: vi.fn(),
+    onDeleteFile: vi.fn(),
+  }),
+}));
+
+afterEach(cleanup);
+
+describe("PersonalSecretsPane actions", () => {
+  it("does not render the redundant API-key shortcut", () => {
+    render(<PersonalSecretsPane />);
+
+    expect(screen.getByRole("heading", { name: "Personal secrets" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Add API key" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Add variable" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Add file" })).toBeTruthy();
+  });
+});

--- a/apps/packages/product-client/src/components/settings/panes/PersonalSecretsPane.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/PersonalSecretsPane.tsx
@@ -1,39 +1,12 @@
-import { useState } from "react";
-import { usePutCloudSecretEnvVar } from "@proliferate/cloud-sdk-react";
-import { Plus } from "#product/primitives/icons/core";
-import { Button } from "#product/primitives/Button";
 import { SecretManagementPanel } from "#product/components/patterns/secrets/SecretManagementPanel";
 import { PageHeader } from "#product/primitives/patterns/PageHeader";
 import { SettingsPageBody } from "#product/primitives/patterns/settings/SettingsPageBody";
-import { ApiKeyCreatorModal } from "#product/components/settings/panes/agent-auth/ApiKeyCreatorModal";
 import { useCloudSecretsPanel } from "#product/hooks/access/cloud/use-cloud-secrets-panel";
-import { useToastStore } from "#product/stores/toast/toast-store";
 
 const PERSONAL_SCOPE = { kind: "personal" } as const;
 
 export function PersonalSecretsPane() {
-  const [addKeyOpen, setAddKeyOpen] = useState(false);
-  const putEnvVar = usePutCloudSecretEnvVar();
-  const showToast = useToastStore((state) => state.show);
   const panel = useCloudSecretsPanel({ scope: PERSONAL_SCOPE });
-
-  function handleCreate(input: { value: string; envVarName: string }) {
-    // Secrets context: the env-var field maps to the secret NAME and we call the
-    // secrets putEnvVar path (create only, no agent binding). The shared modal
-    // shell is identical to the agent flow — only this submit differs.
-    putEnvVar.mutate(
-      { scope: PERSONAL_SCOPE, name: input.envVarName, value: input.value },
-      {
-        onSuccess: () => {
-          setAddKeyOpen(false);
-          showToast("Secret saved.", "info");
-        },
-        onError: (error) => {
-          showToast(error.message || "Could not save the secret.");
-        },
-      },
-    );
-  }
 
   return (
     <SettingsPageBody>
@@ -41,38 +14,9 @@ export function PersonalSecretsPane() {
         variant="flat"
         title="Personal secrets"
         description="Secrets available in your personal cloud sandbox"
-        action={
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            className="gap-1.5"
-            onClick={() => setAddKeyOpen(true)}
-          >
-            <Plus className="icon-paired" />
-            Add API key
-          </Button>
-        }
       />
 
       <SecretManagementPanel {...panel} />
-
-      <ApiKeyCreatorModal
-        open={addKeyOpen}
-        onClose={() => setAddKeyOpen(false)}
-        heading="Add API key"
-        description="Save a secret env var into your personal cloud sandbox."
-        showTitleField={false}
-        envVarField={{
-          label: "Environment variable",
-          placeholder: "API_TOKEN",
-          helpText: "The name this secret is exposed as in your sandbox.",
-        }}
-        submitLabel="Save secret"
-        submitting={putEnvVar.isPending}
-        error={null}
-        onSubmit={handleCreate}
-      />
     </SettingsPageBody>
   );
 }


### PR DESCRIPTION
## Summary

- remove the redundant panel-level Add secret action from secrets management
- remove the duplicate personal Add API key flow
- remove the secrets panel materialization status label ("Pending"/"Materialized"/"Syncing"/"Error"/"Loading") from the header row
- keep Add variable and Add file as the canonical entry points for empty and populated lists

## Testing

- Tier 1: `pnpm --dir apps/packages/product-client exec vitest run src/components/patterns/secrets/SecretManagementPanel.test.tsx src/components/settings/panes/PersonalSecretsPane.test.tsx`
- `pnpm --filter @proliferate/product-client typecheck`
- frontend boundary, component-library, appearance-scaling, structure, attribution, and diff checks

## Observability

- none; this removes duplicate UI entry points without changing data operations

## Readiness

- [x] I followed the pull-request procedure for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] Linked through the tracker API; no tracker or private source data appears in this PR.

## Verification

- focused secrets action regression tests pass for empty and populated states
- shared package typechecking passes
- repository frontend checks pass
- manually verified in a local desktop build on both Settings > User > Personal secrets and Settings > Org > Organization secrets: no status label, no Add secret / Add API key, Add variable and Add file present and functional; the error row path is untouched
- all pull request checks pass
- Greptile reports 5/5 with zero unresolved comments