### PR TITLE
fix(product): make support save-copy cleanup truthful

### DIFF
--- a/apps/packages/product-client/src/components/support/SupportSnapshotConsentField.test.tsx
+++ b/apps/packages/product-client/src/components/support/SupportSnapshotConsentField.test.tsx
@@ -26,9 +26,14 @@ function consentState(
     setScope: vi.fn(),
     activeSessionAvailable: true,
     isPreparing: false,
+    isBusy: false,
+    snapshotActionsBlocked: false,
     error: null,
     prepare: vi.fn(async () => ({ state: "none" as const })),
-    saveCopy: vi.fn(async () => {}),
+    saveCopy: vi.fn(async () => ({
+      state: "not_started" as const,
+      reason: "unavailable_or_not_consented" as const,
+    })),
     cancel: vi.fn(),
     ...overrides,
   };
@@ -118,7 +123,10 @@ describe("SupportSnapshotSaveCopyButton", () => {
   });
 
   it("saves a copy from the same live consent", () => {
-    const saveCopy = vi.fn(async () => {});
+    const saveCopy = vi.fn(async () => ({
+      state: "saved" as const,
+      cleanup: "confirmed" as const,
+    }));
     render(
       <SupportSnapshotSaveCopyButton
         snapshot={consentState({ consent: true, saveCopy })}
@@ -128,5 +136,30 @@ describe("SupportSnapshotSaveCopyButton", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save a copy…" }));
 
     expect(saveCopy).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/cleanup/i)).toBeNull();
+  });
+
+  it("loads for the whole busy action and disables for the cleanup latch", () => {
+    const rendered = render(
+      <SupportSnapshotSaveCopyButton
+        snapshot={consentState({ consent: true, isBusy: true })}
+      />,
+    );
+    const button = screen.getByRole("button", { name: "Save a copy…" });
+    expect(button.hasAttribute("disabled")).toBe(true);
+    expect(button.querySelector("[data-loading-spinner]")).toBeTruthy();
+
+    rendered.rerender(
+      <SupportSnapshotSaveCopyButton
+        snapshot={consentState({
+          consent: true,
+          isBusy: false,
+          snapshotActionsBlocked: true,
+        })}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Save a copy…" }).hasAttribute("disabled"))
+      .toBe(true);
+    expect(document.querySelector("[data-loading-spinner]")).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/components/support/SupportSnapshotSaveCopyButton.tsx
+++ b/apps/packages/product-client/src/components/support/SupportSnapshotSaveCopyButton.tsx
@@ -24,7 +24,8 @@ export function SupportSnapshotSaveCopyButton({
     <Button
       type="button"
       variant="secondary"
-      loading={snapshot.isPreparing}
+      loading={snapshot.isBusy}
+      disabled={snapshot.snapshotActionsBlocked}
       onClick={() => { void snapshot.saveCopy(); }}
     >
       Save a copy…

--- a/apps/packages/product-client/src/hooks/support/facade/use-support-modal-state.test.tsx
+++ b/apps/packages/product-client/src/hooks/support/facade/use-support-modal-state.test.tsx
@@ -97,6 +97,9 @@ const PREPARED_ARTIFACT = {
 /** Put the hook on a host that can actually prepare a snapshot. */
 function enableSupportSnapshotHost() {
   diagnosticsMocks.supportSnapshot = snapshotBridge;
+  snapshotBridge.cancelPreparation.mockResolvedValue(undefined);
+  snapshotBridge.saveArchive.mockResolvedValue("diagnostics.zip");
+  snapshotBridge.deleteArtifact.mockResolvedValue(undefined);
   snapshotBridge.beginPreparation.mockResolvedValue({
     preparationId: "prep-1",
     preparationOperationId: "op-1",
@@ -341,21 +344,22 @@ describe("useSupportModalState", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("holds Send while a Save a copy preparation owns the admission slot", async () => {
+  it("holds Send through Save preparation, archive, and cleanup", async () => {
     enableSupportSnapshotHost();
-    let releaseEvidence: (() => void) | null = null;
-    access.collectResolvedSupportSessionEvidence.mockImplementation(() =>
-      new Promise((resolve) => {
-        releaseEvidence = () => resolve({
-          state: "omitted",
-          sessionEvidenceJson: null,
-          sessionCollection: {
-            state: "omitted",
-            reason: "no_selected_bundled_local_workspace",
-          },
-        });
-      })
-    );
+    const evidence = deferred<{
+      state: "omitted";
+      sessionEvidenceJson: null;
+      sessionCollection: {
+        state: "omitted";
+        reason: "no_selected_bundled_local_workspace";
+      };
+    }>();
+    const archive = deferred<string | null>();
+    const deletion = deferred<void>();
+    access.collectResolvedSupportSessionEvidence.mockReturnValue(evidence.promise);
+    snapshotBridge.saveArchive.mockReturnValue(archive.promise);
+    snapshotBridge.deleteArtifact.mockReturnValue(deletion.promise);
+    const captured = captureDispatchedJob();
     const rendered = renderHook(() =>
       useSupportModalState({ kind: "bug", onClose: vi.fn() })
     );
@@ -365,8 +369,9 @@ describe("useSupportModalState", () => {
       rendered.result.current.snapshotConsent.setConsent(true);
     });
     expect(rendered.result.current.canSend).toBe(true);
+    const staleSend = rendered.result.current.handleSend;
 
-    let saving: Promise<void> | null = null;
+    let saving: Promise<unknown> | null = null;
     act(() => {
       saving = rendered.result.current.snapshotConsent.saveCopy();
     });
@@ -376,12 +381,69 @@ describe("useSupportModalState", () => {
     expect(rendered.result.current.canSend).toBe(false);
 
     await act(async () => {
-      releaseEvidence?.();
-      await saving;
+      await staleSend();
     });
+    expect(snapshotBridge.beginPreparation).toHaveBeenCalledTimes(1);
+    expect(snapshotBridge.finishPreparation).not.toHaveBeenCalled();
+    expect(captured.current).toBeNull();
+    expect(rendered.result.current.message).toBe("It broke");
+
+    evidence.resolve({
+      state: "omitted",
+      sessionEvidenceJson: null,
+      sessionCollection: {
+        state: "omitted",
+        reason: "no_selected_bundled_local_workspace",
+      },
+    });
+    await waitFor(() => expect(snapshotBridge.saveArchive).toHaveBeenCalledTimes(1));
+    expect(rendered.result.current.snapshotConsent.isPreparing).toBe(false);
+    expect(rendered.result.current.snapshotConsent.isBusy).toBe(true);
+    expect(rendered.result.current.canSend).toBe(false);
+
+    archive.resolve("diagnostics.zip");
+    await waitFor(() => expect(snapshotBridge.deleteArtifact).toHaveBeenCalledTimes(1));
+    expect(rendered.result.current.canSend).toBe(false);
+
+    deletion.resolve();
+    await act(async () => { await saving; });
 
     expect(snapshotBridge.saveArchive).toHaveBeenCalledTimes(1);
+    expect(snapshotBridge.deleteArtifact).toHaveBeenCalledTimes(1);
     expect(rendered.result.current.canSend).toBe(true);
+  });
+
+  it("blocks consented Send after unconfirmed cleanup but permits text-only Send", async () => {
+    enableSupportSnapshotHost();
+    snapshotBridge.deleteArtifact.mockRejectedValue(new Error("directory sync failed"));
+    const captured = captureDispatchedJob();
+    const onClose = vi.fn();
+    const rendered = renderHook(() =>
+      useSupportModalState({ kind: "bug", onClose })
+    );
+
+    act(() => {
+      rendered.result.current.setMessage("It broke");
+      rendered.result.current.snapshotConsent.setConsent(true);
+    });
+    await act(async () => {
+      expect(await rendered.result.current.snapshotConsent.saveCopy()).toEqual({
+        state: "saved",
+        cleanup: "unconfirmed",
+      });
+    });
+
+    expect(rendered.result.current.snapshotConsent.snapshotActionsBlocked).toBe(true);
+    expect(rendered.result.current.canSend).toBe(false);
+    const beginCount = snapshotBridge.beginPreparation.mock.calls.length;
+    act(() => { rendered.result.current.snapshotConsent.setConsent(false); });
+    expect(rendered.result.current.canSend).toBe(true);
+
+    await act(async () => { await rendered.result.current.handleSend(); });
+    expect(captured.current).toMatchObject({ supportSnapshot: { kind: "none" } });
+    expect(snapshotBridge.beginPreparation).toHaveBeenCalledTimes(beginCount);
+    expect(snapshotBridge.finishPreparation).toHaveBeenCalledTimes(beginCount);
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it("supersedes an in-flight preparation when the modal is cancelled", async () => {
@@ -425,3 +487,13 @@ describe("useSupportModalState", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 });
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}

--- a/apps/packages/product-client/src/hooks/support/facade/use-support-modal-state.ts
+++ b/apps/packages/product-client/src/hooks/support/facade/use-support-modal-state.ts
@@ -141,12 +141,13 @@ export function useSupportModalState({ kind, onClose }: UseSupportModalStateOpti
     }
   }
 
-  // A Save a copy… preparation already owns the single admission slot, so Send
-  // waits for it rather than racing a second preparation on the same epoch.
+  const hasContent = message.trim().length > 0 || attachments.length > 0;
   const canSend = (
-    message.trim().length > 0
-    || attachments.length > 0
-  ) && !isSubmitting && !snapshotConsent.isPreparing;
+    hasContent
+    && !isSubmitting
+    && !snapshotConsent.isBusy
+    && (!snapshotConsent.consent || !snapshotConsent.snapshotActionsBlocked)
+  );
 
   async function handleSend() {
     if (!canSend || submittingRef.current) {

--- a/apps/packages/product-client/src/hooks/support/workflows/use-support-snapshot-consent.save-copy.test.tsx
+++ b/apps/packages/product-client/src/hooks/support/workflows/use-support-snapshot-consent.save-copy.test.tsx
@@ -1,0 +1,550 @@
+/* @vitest-environment jsdom */
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  PreparedSupportSnapshotV1,
+  SupportSnapshotPreparation,
+} from "@proliferate/product-client/host/desktop-bridge";
+import { useSupportSnapshotConsent } from "#product/hooks/support/workflows/use-support-snapshot-consent";
+import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
+import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+
+const bridge = vi.hoisted(() => ({
+  beginPreparation: vi.fn(),
+  finishPreparation: vi.fn(),
+  cancelPreparation: vi.fn(async () => {}),
+  saveArchive: vi.fn(async () => "diagnostics.zip" as string | null),
+  readArtifact: vi.fn(),
+  deleteArtifact: vi.fn(async () => {}),
+  reconcileArtifacts: vi.fn(),
+  beginSubmission: vi.fn(),
+  finishSubmission: vi.fn(),
+}));
+
+const host = vi.hoisted(() => ({ supportSnapshot: bridge as unknown as null | typeof bridge }));
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => ({
+    desktop: {
+      runtime: { getConnection: vi.fn(), restart: vi.fn() },
+      diagnostics: { supportSnapshot: host.supportSnapshot },
+    },
+  }),
+}));
+
+const access = vi.hoisted(() => ({
+  resolveSupportSnapshotAccess: vi.fn(),
+  collectResolvedSupportSessionEvidence: vi.fn(),
+}));
+
+vi.mock("#product/lib/access/anyharness/support-snapshot-connection", () => access);
+
+const PREPARATION: SupportSnapshotPreparation = {
+  preparationId: "prep-1",
+  preparationOperationId: "op-1",
+  capturedAt: "2026-08-13T00:00:00.000Z",
+  window: {
+    sourceTimeFrom: "2026-08-12T23:45:00.000Z",
+    sourceTimeTo: "2026-08-13T00:00:00.000Z",
+  },
+};
+
+const ARTIFACT: PreparedSupportSnapshotV1 = {
+  artifactSchemaVersion: 3,
+  artifactId: "artifact-1",
+  snapshotId: "snapshot-1",
+  preparationOperationId: "op-1",
+  generatedAt: "2026-08-13T00:00:01.000Z",
+  sizeBytes: 2048,
+  sha256: "a".repeat(64),
+  summary: {
+    collectorRecords: 4,
+    fallbackRecords: 0,
+    sessions: 1,
+    omissions: 0,
+    truncations: 0,
+  },
+};
+
+const INCLUDED_EVIDENCE = {
+  state: "included" as const,
+  sessionEvidenceJson: "{}",
+  sessionCollection: {
+    state: "included" as const,
+    workspaceId: "ws-1",
+    anyharnessWorkspaceId: "ws-1",
+    selectedSessions: 1,
+    sessionIncludedBytes: 10,
+    eventIncludedBytes: 10,
+    rawNotificationIncludedBytes: 0,
+    limitUncertainEndpoints: 0,
+  },
+};
+const CLEANUP_NOT_STARTED = { state: "not_started", reason: "cleanup_unconfirmed" } as const;
+const CLEANUP_BLOCKED = { state: "blocked", reason: "cleanup_unconfirmed" } as const;
+
+function resolvedAccess() {
+  return {
+    state: "resolved" as const,
+    selection: {
+      kind: "active_session" as const,
+      workspace: {
+        kind: "bundled_local" as const,
+        workspaceId: "ws-1",
+        anyharnessWorkspaceId: "ws-1",
+      },
+      uiSessionId: "session-1",
+      materializedSessionId: "materialized-1",
+    },
+  };
+}
+
+function configureDefaults() {
+  vi.clearAllMocks();
+  host.supportSnapshot = bridge;
+  bridge.beginPreparation.mockResolvedValue(PREPARATION);
+  bridge.finishPreparation.mockResolvedValue(ARTIFACT);
+  bridge.cancelPreparation.mockResolvedValue(undefined);
+  bridge.saveArchive.mockResolvedValue("diagnostics.zip");
+  bridge.deleteArtifact.mockResolvedValue(undefined);
+  access.resolveSupportSnapshotAccess.mockResolvedValue(resolvedAccess());
+  access.collectResolvedSupportSessionEvidence.mockResolvedValue(INCLUDED_EVIDENCE);
+}
+
+function renderConsent() {
+  return renderHook(() => useSupportSnapshotConsent({
+    clientJobId: "job-1",
+    reportOpenedAt: "2026-08-13T00:00:00.000Z",
+  }));
+}
+
+function renderConsented() {
+  const rendered = renderConsent();
+  act(() => { rendered.result.current.setConsent(true); });
+  return rendered;
+}
+
+type RenderedConsent = ReturnType<typeof renderConsent>;
+
+beforeEach(() => {
+  configureDefaults();
+  useHarnessConnectionStore.setState({
+    runtimeUrl: "http://127.0.0.1:8457",
+    runtimeUrlSource: "native_capture",
+    connectionState: "healthy",
+    error: null,
+  });
+  useSessionSelectionStore.setState({
+    selectedWorkspaceId: "ws-1",
+    activeSessionId: "session-1",
+  });
+  useSessionDirectoryStore.setState({
+    entriesById: {
+      "session-1": {
+        sessionId: "session-1",
+        workspaceId: "ws-1",
+        materializedSessionId: "materialized-1",
+      },
+    } as never,
+  });
+});
+
+afterEach(cleanup);
+
+describe("useSupportSnapshotConsent Save a copy", () => {
+  it("returns bounded not-started results without a bridge or live consent", async () => {
+    host.supportSnapshot = null;
+    const unavailable = renderConsent();
+    expect(await unavailable.result.current.saveCopy()).toEqual({
+      state: "not_started",
+      reason: "unavailable_or_not_consented",
+    });
+    unavailable.unmount();
+
+    host.supportSnapshot = bridge;
+    const unchecked = renderConsent();
+    expect(await unchecked.result.current.saveCopy()).toEqual({
+      state: "not_started",
+      reason: "unavailable_or_not_consented",
+    });
+    expect(bridge.beginPreparation).not.toHaveBeenCalled();
+    expect(bridge.saveArchive).not.toHaveBeenCalled();
+  });
+
+  it("maps preparation failure exactly and never archives", async () => {
+    bridge.finishPreparation.mockRejectedValueOnce(new Error("stage_failed"));
+    const rendered = renderConsented();
+
+    expect(await act(async () => rendered.result.current.saveCopy())).toEqual({
+      state: "preparation_failed",
+    });
+    expect(bridge.saveArchive).not.toHaveBeenCalled();
+    expect(bridge.deleteArtifact).not.toHaveBeenCalled();
+    expect(rendered.result.current.isBusy).toBe(false);
+  });
+
+  it("keeps one Promise and one action through preparation, archive, and cleanup", async () => {
+    const evidence = deferred<typeof INCLUDED_EVIDENCE>();
+    const archive = deferred<string | null>();
+    const deletion = deferred<void>();
+    access.collectResolvedSupportSessionEvidence.mockReturnValue(evidence.promise);
+    bridge.saveArchive.mockReturnValue(archive.promise);
+    bridge.deleteArtifact.mockReturnValue(deletion.promise);
+    const rendered = renderConsented();
+
+    const saving = start(() => rendered.result.current.saveCopy());
+    expect(rendered.result.current.saveCopy()).toBe(saving);
+    await waitFor(() => expect(rendered.result.current.isPreparing).toBe(true));
+    expect(rendered.result.current.isBusy).toBe(true);
+    expect(await rendered.result.current.prepare()).toEqual({ state: "blocked", reason: "busy" });
+    evidence.resolve(INCLUDED_EVIDENCE);
+
+    await waitFor(() => expect(bridge.saveArchive).toHaveBeenCalledTimes(1));
+    expect(rendered.result.current.isPreparing).toBe(false);
+    expect(rendered.result.current.isBusy).toBe(true);
+    expect(rendered.result.current.saveCopy()).toBe(saving);
+    archive.resolve("diagnostics.zip");
+
+    await waitFor(() => expect(bridge.deleteArtifact).toHaveBeenCalledTimes(1));
+    expect(rendered.result.current.isBusy).toBe(true);
+    expect(rendered.result.current.saveCopy()).toBe(saving);
+    deletion.resolve();
+    expect(await settle(saving)).toEqual({ state: "saved", cleanup: "confirmed" });
+    await waitFor(() => expect(rendered.result.current.isBusy).toBe(false));
+    expect(bridge.beginPreparation).toHaveBeenCalledTimes(1);
+    expect(bridge.finishPreparation).toHaveBeenCalledTimes(1);
+    expect(bridge.saveArchive).toHaveBeenCalledWith({
+      artifactId: "artifact-1",
+      consentEpoch: bridge.beginPreparation.mock.calls[0]![0].consentEpoch,
+    });
+    expect(bridge.deleteArtifact).toHaveBeenCalledWith("artifact-1");
+  });
+
+  it("rejects Save while Send preparation owns the action slot", async () => {
+    const evidence = deferred<typeof INCLUDED_EVIDENCE>();
+    access.collectResolvedSupportSessionEvidence.mockReturnValue(evidence.promise);
+    const rendered = renderConsented();
+
+    const preparing = start(() => rendered.result.current.prepare());
+    await waitFor(() => expect(bridge.beginPreparation).toHaveBeenCalledTimes(1));
+    expect(await rendered.result.current.saveCopy()).toEqual({
+      state: "not_started",
+      reason: "busy",
+    });
+    expect(await rendered.result.current.prepare()).toEqual({ state: "blocked", reason: "busy" });
+    expect(bridge.beginPreparation).toHaveBeenCalledTimes(1);
+    evidence.resolve(INCLUDED_EVIDENCE);
+    expect(await settle(preparing)).toMatchObject({ state: "prepared" });
+    expect(bridge.saveArchive).not.toHaveBeenCalled();
+  });
+
+  it("awaits one cached cancellation before returning and latches the job", async () => {
+    const { cancellation, evidence, rendered, saving } = await startHeldCancellation();
+
+    act(() => { rendered.result.current.cancel(); rendered.result.current.cancel(); });
+    evidence.resolve({ state: "cancelled" });
+    await expectCancellationPending(rendered, saving);
+    cancellation.resolve();
+
+    expect(await settle(saving)).toEqual({ state: "preparation_cancelled" });
+    await waitFor(() => expect(rendered.result.current.snapshotActionsBlocked).toBe(true));
+    expect(rendered.result.current.isPreparing).toBe(false);
+    expect(rendered.result.current.isBusy).toBe(false);
+    await expectLatchBlocksSnapshotWork(rendered, saving);
+  });
+
+  it("holds spontaneous evidence cancellation until native settlement", async () => {
+    const { cancellation, evidence, rendered, saving } = await startHeldCancellation();
+
+    evidence.resolve({ state: "cancelled" });
+    await expectCancellationPending(rendered, saving);
+    const [{ cancellationSignal }] = access.collectResolvedSupportSessionEvidence.mock.calls[0]!;
+    expect(cancellationSignal.aborted).toBe(false);
+    act(() => { rendered.result.current.cancel(); });
+    expect(cancellationSignal.aborted).toBe(true);
+    expect(bridge.cancelPreparation).toHaveBeenCalledTimes(1);
+    cancellation.resolve();
+
+    expect(await settle(saving)).toEqual({ state: "preparation_cancelled" });
+    expect(rendered.result.current.snapshotActionsBlocked).toBe(true);
+  });
+
+  it("cancels an admission that returns after supersession", async () => {
+    const admission = deferred<SupportSnapshotPreparation>();
+    const cancellation = deferred<void>();
+    bridge.beginPreparation.mockReturnValue(admission.promise);
+    bridge.cancelPreparation.mockReturnValue(cancellation.promise);
+    const rendered = renderConsented();
+    const saving = start(() => rendered.result.current.saveCopy());
+    await waitFor(() => expect(bridge.beginPreparation).toHaveBeenCalledTimes(1));
+
+    act(() => { rendered.result.current.cancel(); });
+    admission.resolve(PREPARATION);
+    await expectCancellationPending(rendered, saving);
+    cancellation.resolve();
+    expect(await settle(saving)).toEqual({ state: "preparation_cancelled" });
+    expect(rendered.result.current.snapshotActionsBlocked).toBe(true);
+  });
+
+  it.each(["resolve", "reject"] as const)(
+    "awaits cancellation when a pending finish races a %s",
+    async (finishOutcome) => {
+      const finish = deferred<PreparedSupportSnapshotV1>();
+      const cancellation = deferred<void>();
+      bridge.finishPreparation.mockReturnValue(finish.promise);
+      bridge.cancelPreparation.mockReturnValue(cancellation.promise);
+      const rendered = renderConsented();
+      const saving = start(() => rendered.result.current.saveCopy());
+      await waitFor(() => expect(bridge.finishPreparation).toHaveBeenCalledTimes(1));
+
+      act(() => { rendered.result.current.cancel(); });
+      if (finishOutcome === "resolve") finish.resolve(ARTIFACT);
+      else finish.reject(new Error("late finish failure"));
+      await expectCancellationPending(rendered, saving);
+      cancellation.resolve();
+
+      expect(await settle(saving)).toEqual({ state: "preparation_cancelled" });
+      expect(rendered.result.current.snapshotActionsBlocked).toBe(true);
+    },
+  );
+
+  it("awaits cancellation after unmount during admitted preparation", async () => {
+    const { cancellation, evidence, rendered, saving } = await startHeldCancellation();
+
+    rendered.unmount();
+    evidence.resolve({ state: "cancelled" });
+    await waitFor(() => expect(bridge.cancelPreparation).toHaveBeenCalledTimes(1));
+    let settled = false;
+    void saving.then(() => { settled = true; }, () => { settled = true; });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    cancellation.resolve();
+    expect(await settle(saving)).toEqual({ state: "preparation_cancelled" });
+    expect(bridge.cancelPreparation).toHaveBeenCalledTimes(1);
+  });
+
+  it("holds and consumes rejected cancellation without exposing a raw error", async () => {
+    const unhandled: unknown[] = [];
+    const listener = (reason: unknown) => { unhandled.push(reason); };
+    process.on("unhandledRejection", listener);
+    try {
+      const { cancellation, evidence, rendered, saving } = await startHeldCancellation();
+      act(() => { rendered.result.current.cancel(); });
+      evidence.resolve({ state: "cancelled" });
+      await expectCancellationPending(rendered, saving);
+      cancellation.reject(new Error("raw cancellation failure"));
+
+      expect(await settle(saving)).toEqual({ state: "preparation_cancelled" });
+      expect(rendered.result.current.error).toBeNull();
+      expect(rendered.result.current.snapshotActionsBlocked).toBe(true);
+      expect(rendered.result.current.isPreparing).toBe(false);
+      expect(rendered.result.current.isBusy).toBe(false);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", listener);
+    }
+  });
+
+  it("keeps Save identity through supersession and suppresses stale errors", async () => {
+    const archive = deferred<string | null>();
+    bridge.saveArchive.mockReturnValue(archive.promise);
+    const rendered = renderConsented();
+    const saving = start(() => rendered.result.current.saveCopy());
+    await waitFor(() => expect(bridge.saveArchive).toHaveBeenCalledTimes(1));
+
+    act(() => { rendered.result.current.setScope("recent_activity"); });
+    expect(rendered.result.current.saveCopy()).toBe(saving);
+    act(() => { rendered.result.current.setConsent(false); });
+    expect(rendered.result.current.saveCopy()).toBe(saving);
+    archive.reject(new Error("raw archive failure"));
+    expect(await settle(saving)).toEqual({ state: "save_failed", cleanup: "confirmed" });
+    expect(bridge.deleteArtifact).toHaveBeenCalledWith("artifact-1");
+    expect(rendered.result.current.error).toBeNull();
+
+    rendered.unmount();
+    configureDefaults();
+    bridge.saveArchive.mockRejectedValueOnce(new Error("current archive failure"));
+    const current = renderConsented();
+    expect(await settle(start(() => current.result.current.saveCopy()))).toEqual({
+      state: "save_failed",
+      cleanup: "confirmed",
+    });
+    expect(current.result.current.error).toBe(
+      "Couldn't save a copy of the diagnostic snapshot.",
+    );
+  });
+
+  it("finishes exact cleanup after unmount", async () => {
+    const deletion = deferred<void>();
+    bridge.deleteArtifact.mockReturnValue(deletion.promise);
+    const rendered = renderConsented();
+    const saving = start(() => rendered.result.current.saveCopy());
+    await waitFor(() => expect(bridge.deleteArtifact).toHaveBeenCalledWith("artifact-1"));
+
+    rendered.unmount();
+    deletion.resolve();
+    expect(await settle(saving)).toEqual({ state: "saved", cleanup: "confirmed" });
+    expect(bridge.deleteArtifact).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["saved", "diagnostics.zip", { state: "saved", cleanup: "unconfirmed" }],
+    ["cancelled", null, { state: "cancelled", cleanup: "unconfirmed" }],
+    ["save_failed", new Error("archive failed"), {
+      state: "save_failed",
+      cleanup: "unconfirmed",
+    }],
+  ] as const)("latches every %s / unconfirmed result", async (_name, archive, expected) => {
+    if (archive instanceof Error) bridge.saveArchive.mockRejectedValue(archive);
+    else bridge.saveArchive.mockResolvedValue(archive);
+    bridge.deleteArtifact.mockRejectedValue(new Error("cleanup failed"));
+    const rendered = renderConsented();
+    const first = start(() => rendered.result.current.saveCopy());
+
+    expect(await settle(first)).toEqual(expected);
+    expect(rendered.result.current.isBusy).toBe(false);
+    expect(rendered.result.current.snapshotActionsBlocked).toBe(true);
+    await expectLatchBlocksSnapshotWork(rendered, first);
+  });
+
+  it("lets a newly opened modal use its own fresh latch", async () => {
+    bridge.deleteArtifact.mockRejectedValueOnce(new Error("cleanup failed"));
+    const first = renderConsented();
+    await settle(start(() => first.result.current.saveCopy()));
+    expect(first.result.current.snapshotActionsBlocked).toBe(true);
+    first.unmount();
+
+    configureDefaults();
+    const reopened = renderConsented();
+    expect(reopened.result.current.snapshotActionsBlocked).toBe(false);
+    expect(await settle(start(() => reopened.result.current.saveCopy()))).toEqual({
+      state: "saved",
+      cleanup: "confirmed",
+    });
+    expect(bridge.beginPreparation).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["preparation_failed", "saved", "cancelled", "save_failed"] as const)(
+    "releases admission after retryable %s",
+    async (terminal) => {
+      if (terminal === "preparation_failed") {
+        bridge.finishPreparation.mockRejectedValueOnce(new Error("stage failed"));
+      } else if (terminal === "cancelled") {
+        bridge.saveArchive.mockResolvedValueOnce(null);
+      } else if (terminal === "save_failed") {
+        bridge.saveArchive.mockRejectedValueOnce(new Error("archive failed"));
+      }
+      const rendered = renderConsented();
+      await settle(start(() => rendered.result.current.saveCopy()));
+      expect(rendered.result.current.isBusy).toBe(false);
+
+      const next = await settle(start(() => rendered.result.current.prepare()));
+      expect(next).toMatchObject({ state: "prepared" });
+      expect(bridge.beginPreparation).toHaveBeenCalledTimes(2);
+      expect(bridge.finishPreparation).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each(["saved", "save_failed"] as const)(
+    "uses a distinct Promise and full second sequence after %s",
+    async (firstOutcome) => {
+      if (firstOutcome === "save_failed") {
+        bridge.saveArchive.mockRejectedValueOnce(new Error("archive failed"));
+      }
+      const rendered = renderConsented();
+      const first = start(() => rendered.result.current.saveCopy());
+      const firstResult = await settle(first);
+      expect(firstResult.state).toBe(firstOutcome);
+      expect(rendered.result.current.isBusy).toBe(false);
+      if (firstOutcome === "save_failed") {
+        expect(rendered.result.current.error).toBe(
+          "Couldn't save a copy of the diagnostic snapshot.",
+        );
+      }
+
+      const second = start(() => rendered.result.current.saveCopy());
+      expect(second).not.toBe(first);
+      expect(await settle(second)).toEqual({ state: "saved", cleanup: "confirmed" });
+      expect(bridge.beginPreparation).toHaveBeenCalledTimes(2);
+      expect(bridge.finishPreparation).toHaveBeenCalledTimes(2);
+      expect(bridge.saveArchive).toHaveBeenCalledTimes(2);
+      expect(bridge.deleteArtifact).toHaveBeenCalledTimes(2);
+    },
+  );
+});
+
+async function expectCancellationPending(rendered: RenderedConsent, saving: Promise<unknown>) {
+  await waitFor(() => expect(bridge.cancelPreparation).toHaveBeenCalledTimes(1));
+  let settled = false;
+  void saving.then(() => { settled = true; }, () => { settled = true; });
+  await Promise.resolve();
+  expect(settled).toBe(false);
+  expect(rendered.result.current.isPreparing).toBe(true);
+  expect(rendered.result.current.isBusy).toBe(true);
+  expect(rendered.result.current.saveCopy()).toBe(saving);
+  expect(await rendered.result.current.prepare()).toEqual({ state: "blocked", reason: "busy" });
+  expect(bridge.saveArchive).not.toHaveBeenCalled();
+  expect(bridge.deleteArtifact).not.toHaveBeenCalled();
+}
+
+async function expectLatchBlocksSnapshotWork(
+  rendered: RenderedConsent,
+  previousSave: Promise<unknown>,
+) {
+  const before = snapshotCallCounts();
+  const later = rendered.result.current.saveCopy();
+  expect(later).not.toBe(previousSave);
+  expect(await later).toEqual(CLEANUP_NOT_STARTED);
+  expect(await rendered.result.current.prepare()).toEqual(CLEANUP_BLOCKED);
+  act(() => { rendered.result.current.setConsent(false); });
+  expect(rendered.result.current.snapshotActionsBlocked).toBe(true);
+  expect(await rendered.result.current.prepare()).toEqual({ state: "none" });
+  act(() => { rendered.result.current.setConsent(true); });
+  act(() => { rendered.result.current.setScope("recent_activity"); });
+  expect(await rendered.result.current.saveCopy()).toEqual(CLEANUP_NOT_STARTED);
+  expect(snapshotCallCounts()).toEqual(before);
+}
+
+function snapshotCallCounts() {
+  return [
+    access.resolveSupportSnapshotAccess,
+    access.collectResolvedSupportSessionEvidence,
+    ...Object.values(bridge),
+  ].map((operation) => operation.mock.calls.length);
+}
+
+async function startHeldCancellation() {
+  const evidence = deferred<{ state: "cancelled" }>();
+  const cancellation = deferred<void>();
+  access.collectResolvedSupportSessionEvidence.mockReturnValue(evidence.promise);
+  bridge.cancelPreparation.mockReturnValue(cancellation.promise);
+  const rendered = renderConsented();
+  const saving = start(() => rendered.result.current.saveCopy());
+  await waitFor(() => expect(bridge.beginPreparation).toHaveBeenCalledTimes(1));
+  return { cancellation, evidence, rendered, saving };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function start<T>(action: () => Promise<T>): Promise<T> {
+  let promise!: Promise<T>;
+  act(() => { promise = action(); });
+  return promise;
+}
+
+async function settle<T>(promise: Promise<T>): Promise<T> {
+  let value!: T;
+  await act(async () => { value = await promise; });
+  return value;
+}

--- a/apps/packages/product-client/src/hooks/support/workflows/use-support-snapshot-consent.test.tsx
+++ b/apps/packages/product-client/src/hooks/support/workflows/use-support-snapshot-consent.test.tsx
@@ -254,69 +254,6 @@ describe("useSupportSnapshotConsent", () => {
     expect(bridge.beginPreparation).not.toHaveBeenCalled();
   });
 
-  it("cancels in-flight preparation and refuses to answer a superseded epoch", async () => {
-    let releaseEvidence: (() => void) | null = null;
-    access.collectResolvedSupportSessionEvidence.mockImplementation(() =>
-      new Promise((resolve) => {
-        releaseEvidence = () => resolve({ state: "cancelled" });
-      })
-    );
-    const rendered = renderConsent();
-
-    act(() => { rendered.result.current.setConsent(true); });
-    let pending: Promise<unknown> | null = null;
-    await act(async () => {
-      pending = rendered.result.current.prepare();
-      await waitFor(() => expect(bridge.beginPreparation).toHaveBeenCalled());
-    });
-
-    await act(async () => {
-      rendered.result.current.cancel();
-      releaseEvidence?.();
-      await pending;
-    });
-
-    expect(await pending!).toEqual({ state: "cancelled" });
-    expect(bridge.finishPreparation).not.toHaveBeenCalled();
-    expect(bridge.cancelPreparation).toHaveBeenCalledWith({
-      clientJobId: "job-1",
-      consentEpoch: expect.any(String),
-      preparationId: "prep-1",
-    });
-  });
-
-  it("releases a preparation superseded while native was still admitting it", async () => {
-    let admit: (() => void) | null = null;
-    bridge.beginPreparation.mockImplementation(() =>
-      new Promise((resolve) => {
-        admit = () => resolve(PREPARATION);
-      })
-    );
-    const rendered = renderConsent();
-
-    act(() => { rendered.result.current.setConsent(true); });
-    let pending: Promise<unknown> | null = null;
-    await act(async () => {
-      pending = rendered.result.current.prepare();
-      await waitFor(() => expect(bridge.beginPreparation).toHaveBeenCalled());
-    });
-
-    await act(async () => {
-      // Superseded before the admitted preparation ever came back.
-      rendered.result.current.cancel();
-      admit?.();
-      await pending;
-    });
-
-    expect(await pending!).toEqual({ state: "cancelled" });
-    expect(bridge.finishPreparation).not.toHaveBeenCalled();
-    expect(bridge.cancelPreparation).toHaveBeenCalledWith({
-      clientJobId: "job-1",
-      consentEpoch: expect.any(String),
-      preparationId: "prep-1",
-    });
-  });
-
   it("surfaces a fatal preparation failure instead of downgrading intent", async () => {
     bridge.finishPreparation.mockRejectedValueOnce(new Error("stage_failed"));
     const rendered = renderConsent();
@@ -348,25 +285,4 @@ describe("useSupportSnapshotConsent", () => {
     expect(bridge.beginPreparation).not.toHaveBeenCalled();
   });
 
-  it("writes the archive from the same staged artifact on Save a copy", async () => {
-    const rendered = renderConsent();
-
-    act(() => { rendered.result.current.setConsent(true); });
-    await act(async () => { await rendered.result.current.saveCopy(); });
-
-    expect(bridge.saveArchive).toHaveBeenCalledWith({
-      artifactId: "artifact-1",
-      consentEpoch: bridge.beginPreparation.mock.calls[0]![0].consentEpoch,
-    });
-    expect(bridge.deleteArtifact).toHaveBeenCalledWith("artifact-1");
-  });
-
-  it("never saves an archive without live consent", async () => {
-    const rendered = renderConsent();
-
-    await act(async () => { await rendered.result.current.saveCopy(); });
-
-    expect(bridge.beginPreparation).not.toHaveBeenCalled();
-    expect(bridge.saveArchive).not.toHaveBeenCalled();
-  });
 });

--- a/apps/packages/product-client/src/hooks/support/workflows/use-support-snapshot-consent.ts
+++ b/apps/packages/product-client/src/hooks/support/workflows/use-support-snapshot-consent.ts
@@ -2,6 +2,11 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type {
   DesktopSupportSnapshotBridge,
 } from "@proliferate/product-client/host/desktop-bridge";
+import { useSupportSnapshotBinding } from "#product/hooks/support/derived/use-support-snapshot-binding";
+import {
+  collectResolvedSupportSessionEvidence,
+  resolveSupportSnapshotAccess,
+} from "#product/lib/access/anyharness/support-snapshot-connection";
 import type { SupportReportSnapshotIntent } from "#product/lib/domain/support/report-types";
 import {
   supportSnapshotConsent,
@@ -9,10 +14,9 @@ import {
   type SupportSnapshotScopeChoice,
 } from "#product/lib/domain/support/support-snapshot-consent";
 import {
-  collectResolvedSupportSessionEvidence,
-  resolveSupportSnapshotAccess,
-} from "#product/lib/access/anyharness/support-snapshot-connection";
-import { useSupportSnapshotBinding } from "#product/hooks/support/derived/use-support-snapshot-binding";
+  saveSupportSnapshotCopy,
+  type SupportSnapshotSaveCopyWorkflowResult,
+} from "#product/lib/workflows/support/save-support-snapshot-copy";
 
 const PREPARATION_FAILED_MESSAGE =
   "Couldn't prepare the diagnostic snapshot. Try again, or clear the box to "
@@ -28,7 +32,17 @@ export type SupportSnapshotPreparationResult =
       intent: Extract<SupportReportSnapshotIntent, { kind: "prepared" }>;
     }
   | { state: "failed" }
-  | { state: "cancelled" };
+  | { state: "cancelled" }
+  | { state: "blocked"; reason: "busy" | "cleanup_unconfirmed" };
+
+export type SupportSnapshotSaveCopyResult =
+  | {
+      state: "not_started";
+      reason: "unavailable_or_not_consented" | "busy" | "cleanup_unconfirmed";
+    }
+  | { state: "preparation_failed" }
+  | { state: "preparation_cancelled" }
+  | SupportSnapshotSaveCopyWorkflowResult;
 
 export interface SupportSnapshotConsentState {
   /** False on every host without the native coordinator; nothing renders. */
@@ -38,12 +52,17 @@ export interface SupportSnapshotConsentState {
   scope: SupportSnapshotScopeChoice;
   setScope: (next: SupportSnapshotScopeChoice) => void;
   activeSessionAvailable: boolean;
+  /** Preparation only; false while an already-prepared Save archives or cleans up. */
   isPreparing: boolean;
+  /** True for an admitted Send preparation and the full Save action. */
+  isBusy: boolean;
+  /** Same-modal/client-job latch after artifact cleanup is unconfirmed. */
+  snapshotActionsBlocked: boolean;
   error: string | null;
   /** Explicit Send: prepares only while consent is still true. */
   prepare: () => Promise<SupportSnapshotPreparationResult>;
-  /** Explicit **Save a copy…**: prepares, writes the ZIP, keeps the modal open. */
-  saveCopy: () => Promise<void>;
+  /** Explicit **Save a copy…**: prepares, archives, then settles exact cleanup. */
+  saveCopy: () => Promise<SupportSnapshotSaveCopyResult>;
   /** Supersedes the epoch and cancels in-flight preparation. */
   cancel: () => void;
 }
@@ -53,16 +72,20 @@ interface UseSupportSnapshotConsentOptions {
   reportOpenedAt: string;
 }
 
-/**
- * The per-report snapshot consent epoch.
- *
- * Consent starts unchecked on every open and is never persisted or inherited.
- * Nothing native runs while the user reads the disclosure, checks the box, or
- * changes scope: only an explicit Send or **Save a copy…** while consent is
- * still true starts a preparation. A binding change, a scope change, clearing
- * the box, or cancelling supersedes the epoch, so a late result from a
- * superseded epoch can never reach the queue.
- */
+interface SnapshotActionToken {
+  readonly kind: "prepare" | "save_copy";
+}
+
+interface InFlightPreparation {
+  bridge: DesktopSupportSnapshotBridge;
+  clientJobId: string;
+  consentEpoch: string;
+  preparationId: string;
+  controller: AbortController;
+  cancellationPromise: Promise<void> | null;
+}
+
+/** Owns React admission, epoch, UI state, and stale-write policy for one report. */
 export function useSupportSnapshotConsent(
   options: UseSupportSnapshotConsentOptions,
 ): SupportSnapshotConsentState {
@@ -71,32 +94,68 @@ export function useSupportSnapshotConsent(
   const [consent, setConsentState] = useState(false);
   const [scope, setScopeState] = useState<SupportSnapshotScopeChoice>(defaultScope);
   const [isPreparing, setIsPreparing] = useState(false);
+  const [isBusy, setIsBusy] = useState(false);
+  const [snapshotActionsBlocked, setSnapshotActionsBlocked] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+  const bridgeRef = useRef(bridge);
+  const bindingRef = useRef(binding);
+  const consentRef = useRef(false);
+  const scopeRef = useRef(scope);
   const epochRef = useRef(crypto.randomUUID());
   const grantedAtRef = useRef<string | null>(null);
-  const scopeRef = useRef(scope);
+  const busyRef = useRef(false);
+  const actionRef = useRef<SnapshotActionToken | null>(null);
+  const activeSavePromiseRef = useRef<Promise<SupportSnapshotSaveCopyResult> | null>(null);
+  const snapshotActionsBlockedRef = useRef(false);
   const inFlightRef = useRef<InFlightPreparation | null>(null);
+  bridgeRef.current = bridge;
+  bindingRef.current = binding;
 
-  const supersede = useCallback(() => {
-    const previous = inFlightRef.current;
-    inFlightRef.current = null;
-    epochRef.current = crypto.randomUUID();
-    if (previous) {
-      previous.controller.abort();
-      void previous.cancel();
-    }
+  const setBlocked = useCallback(() => {
+    if (!mountedRef.current) return;
+    snapshotActionsBlockedRef.current = true;
+    setSnapshotActionsBlocked(true);
   }, []);
 
-  // A binding change supersedes the epoch even mid-preparation. Consent is
-  // specific to one exact workspace/session binding, so it is cleared rather
-  // than silently re-pointed at whatever the user just selected.
+  const acquireAction = useCallback((kind: SnapshotActionToken["kind"]) => {
+    if (busyRef.current) return null;
+    const token: SnapshotActionToken = { kind };
+    actionRef.current = token;
+    busyRef.current = true;
+    if (mountedRef.current) setIsBusy(true);
+    return token;
+  }, []);
+
+  const releaseAction = useCallback((token: SnapshotActionToken) => {
+    if (actionRef.current !== token) return;
+    actionRef.current = null;
+    busyRef.current = false;
+    if (mountedRef.current) setIsBusy(false);
+  }, []);
+
+  const supersede = useCallback(() => {
+    epochRef.current = crypto.randomUUID();
+    const admitted = inFlightRef.current;
+    if (!admitted) return;
+    admitted.controller.abort();
+    void settleCancellation(admitted);
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      supersede();
+    };
+  }, [supersede]);
+
   const bindingKeyRef = useRef(bindingKey);
   useEffect(() => {
-    if (bindingKeyRef.current === bindingKey) {
-      return;
-    }
+    if (bindingKeyRef.current === bindingKey) return;
     bindingKeyRef.current = bindingKey;
     supersede();
+    consentRef.current = false;
     grantedAtRef.current = null;
     setConsentState(false);
     setError(null);
@@ -104,19 +163,19 @@ export function useSupportSnapshotConsent(
 
   const setConsent = useCallback((next: boolean) => {
     supersede();
-    setError(null);
+    consentRef.current = next;
     grantedAtRef.current = next ? new Date().toISOString() : null;
+    setError(null);
     setConsentState(next);
     if (next) {
-      scopeRef.current = defaultScope;
-      setScopeState(defaultScope);
+      const nextScope = bindingRef.current.defaultScope;
+      scopeRef.current = nextScope;
+      setScopeState(nextScope);
     }
-  }, [defaultScope, supersede]);
+  }, [supersede]);
 
   const setScope = useCallback((next: SupportSnapshotScopeChoice) => {
-    if (scopeRef.current === next) {
-      return;
-    }
+    if (scopeRef.current === next) return;
     scopeRef.current = next;
     supersede();
     setError(null);
@@ -124,99 +183,173 @@ export function useSupportSnapshotConsent(
     setScopeState(next);
   }, [supersede]);
 
-  const prepare = useCallback(async (): Promise<SupportSnapshotPreparationResult> => {
-    if (!bridge || !consent) {
-      return { state: "none" };
-    }
+  const runPreparation = useCallback(async (
+    token: SnapshotActionToken,
+    activeBridge: DesktopSupportSnapshotBridge,
+  ): Promise<SupportSnapshotPreparationResult> => {
     const epoch = epochRef.current;
     const controller = new AbortController();
-    const isCurrent = () => epochRef.current === epoch && !controller.signal.aborted;
-    setError(null);
-    setIsPreparing(true);
-    try {
-      const access = await resolveSupportSnapshotAccess(binding.accessInput(scope));
-      if (!isCurrent()) {
-        return { state: "cancelled" };
+    let admitted: InFlightPreparation | null = null;
+    const epochIsCurrent = () =>
+      epochRef.current === epoch && !controller.signal.aborted;
+    const uiIsCurrent = () =>
+      mountedRef.current && actionRef.current === token && epochIsCurrent();
+    const cancelAdmitted = async (): Promise<SupportSnapshotPreparationResult> => {
+      if (admitted) {
+        await settleCancellation(admitted);
+        setBlocked();
       }
+      return { state: "cancelled" };
+    };
+
+    if (mountedRef.current && actionRef.current === token) {
+      setError(null);
+      setIsPreparing(true);
+    }
+    try {
+      const liveBinding = bindingRef.current;
+      const access = await resolveSupportSnapshotAccess(
+        liveBinding.accessInput(scopeRef.current),
+      );
+      if (!epochIsCurrent()) return await cancelAdmitted();
       const selection = supportSnapshotSelection(access);
       if (!selection) {
-        setError(PREPARATION_FAILED_MESSAGE);
+        if (uiIsCurrent()) setError(PREPARATION_FAILED_MESSAGE);
         return { state: "failed" };
       }
       const grantedConsent = supportSnapshotConsent({
         grantedAt: grantedAtRef.current ?? new Date().toISOString(),
         selection,
       });
-      const preparation = await bridge.beginPreparation({
+      const preparation = await activeBridge.beginPreparation({
         clientJobId: options.clientJobId,
         reportOpenedAt: options.reportOpenedAt,
         consentEpoch: epoch,
         consent: grantedConsent,
       });
-      const cancel = () =>
-        cancelPreparation(bridge, options.clientJobId, epoch, preparation.preparationId);
-      inFlightRef.current = { controller, cancel };
-      if (!isCurrent()) {
-        // Superseded while native was admitting it: release the preparation
-        // rather than leaving an admitted operation without a terminal.
-        void cancel();
-        return { state: "cancelled" };
-      }
+      admitted = {
+        bridge: activeBridge,
+        clientJobId: options.clientJobId,
+        consentEpoch: epoch,
+        preparationId: preparation.preparationId,
+        controller,
+        cancellationPromise: null,
+      };
+      inFlightRef.current = admitted;
+      if (!epochIsCurrent()) return await cancelAdmitted();
+
       const evidence = await collectResolvedSupportSessionEvidence({
         preparation,
         access,
         cancellationSignal: controller.signal,
-        isSelectionCurrent: isCurrent,
+        isSelectionCurrent: epochIsCurrent,
       });
-      if (evidence.state === "cancelled" || !isCurrent()) {
-        return { state: "cancelled" };
+      if (evidence.state === "cancelled" || !epochIsCurrent()) {
+        return await cancelAdmitted();
       }
-      const artifact = await bridge.finishPreparation({
+      const artifact = await activeBridge.finishPreparation({
         preparationId: preparation.preparationId,
         consentEpoch: epoch,
         sessionEvidenceJson: evidence.sessionEvidenceJson,
         sessionCollection: evidence.sessionCollection,
       });
-      inFlightRef.current = null;
-      if (!isCurrent()) {
-        void bridge.deleteArtifact(artifact.artifactId).catch(() => {});
-        return { state: "cancelled" };
-      }
+      if (!epochIsCurrent()) return await cancelAdmitted();
       return {
         state: "prepared",
         consentEpoch: epoch,
         intent: { kind: "prepared", consent: grantedConsent, artifact },
       };
     } catch {
-      if (isCurrent()) {
-        setError(PREPARATION_FAILED_MESSAGE);
-        return { state: "failed" };
-      }
-      return { state: "cancelled" };
+      if (!epochIsCurrent()) return await cancelAdmitted();
+      if (uiIsCurrent()) setError(PREPARATION_FAILED_MESSAGE);
+      return { state: "failed" };
     } finally {
-      if (inFlightRef.current?.controller === controller) {
-        inFlightRef.current = null;
-      }
-      setIsPreparing(false);
+      if (inFlightRef.current === admitted) inFlightRef.current = null;
+      if (mountedRef.current && actionRef.current === token) setIsPreparing(false);
     }
-  }, [binding, bridge, consent, options.clientJobId, options.reportOpenedAt, scope]);
+  }, [options.clientJobId, options.reportOpenedAt, setBlocked]);
 
-  const saveCopy = useCallback(async () => {
-    const prepared = await prepare();
-    if (prepared.state !== "prepared" || !bridge) {
-      return;
+  const prepare = useCallback(async (): Promise<SupportSnapshotPreparationResult> => {
+    if (busyRef.current) return { state: "blocked", reason: "busy" };
+    const activeBridge = bridgeRef.current;
+    if (!activeBridge || !consentRef.current) return { state: "none" };
+    if (snapshotActionsBlockedRef.current) {
+      return { state: "blocked", reason: "cleanup_unconfirmed" };
     }
-    const artifactId = prepared.intent.artifact.artifactId;
+    const token = acquireAction("prepare");
+    if (!token) return { state: "blocked", reason: "busy" };
     try {
-      await bridge.saveArchive({ artifactId, consentEpoch: prepared.consentEpoch });
-    } catch {
-      setError(SAVE_FAILED_MESSAGE);
+      return await runPreparation(token, activeBridge);
     } finally {
-      // The saved ZIP is the user's copy. The staged artifact backs no queued
-      // job, so it is released instead of waiting for the next startup sweep.
-      void bridge.deleteArtifact(artifactId).catch(() => {});
+      releaseAction(token);
     }
-  }, [bridge, prepare]);
+  }, [acquireAction, releaseAction, runPreparation]);
+
+  const saveCopy = useCallback((): Promise<SupportSnapshotSaveCopyResult> => {
+    const active = activeSavePromiseRef.current;
+    if (active) return active;
+    const activeBridge = bridgeRef.current;
+    if (!activeBridge || !consentRef.current) {
+      return Promise.resolve({
+        state: "not_started",
+        reason: "unavailable_or_not_consented",
+      });
+    }
+    if (busyRef.current) {
+      return Promise.resolve({ state: "not_started", reason: "busy" });
+    }
+    if (snapshotActionsBlockedRef.current) {
+      return Promise.resolve({
+        state: "not_started",
+        reason: "cleanup_unconfirmed",
+      });
+    }
+    const token = acquireAction("save_copy");
+    if (!token) return Promise.resolve({ state: "not_started", reason: "busy" });
+
+    const promise: Promise<SupportSnapshotSaveCopyResult> = (async (): Promise<SupportSnapshotSaveCopyResult> => {
+      try {
+        const prepared = await runPreparation(token, activeBridge);
+        if (prepared.state === "failed") return { state: "preparation_failed" };
+        if (prepared.state === "cancelled") return { state: "preparation_cancelled" };
+        if (prepared.state !== "prepared") {
+          return {
+            state: "not_started",
+            reason: prepared.state === "blocked"
+              ? prepared.reason
+              : "unavailable_or_not_consented",
+          };
+        }
+        const artifactId = prepared.intent.artifact.artifactId;
+        const result = await saveSupportSnapshotCopy(
+          { artifactId, consentEpoch: prepared.consentEpoch },
+          {
+            saveArchive: (input) => activeBridge.saveArchive(input),
+            deleteArtifact: (id) => activeBridge.deleteArtifact(id),
+          },
+        );
+        if (
+          result.state === "save_failed"
+          && mountedRef.current
+          && actionRef.current === token
+          && epochRef.current === prepared.consentEpoch
+        ) {
+          setError(SAVE_FAILED_MESSAGE);
+        }
+        if (result.cleanup === "unconfirmed") setBlocked();
+        return result;
+      } finally {
+        releaseAction(token);
+      }
+    })();
+    activeSavePromiseRef.current = promise;
+    void promise.finally(() => {
+      if (activeSavePromiseRef.current === promise) {
+        activeSavePromiseRef.current = null;
+      }
+    });
+    return promise;
+  }, [acquireAction, releaseAction, runPreparation, setBlocked]);
 
   return {
     available: bridge !== null,
@@ -226,6 +359,8 @@ export function useSupportSnapshotConsent(
     setScope,
     activeSessionAvailable: binding.activeSessionAvailable,
     isPreparing,
+    isBusy,
+    snapshotActionsBlocked,
     error,
     prepare,
     saveCopy,
@@ -233,18 +368,13 @@ export function useSupportSnapshotConsent(
   };
 }
 
-interface InFlightPreparation {
-  controller: AbortController;
-  cancel: () => Promise<void>;
-}
-
-function cancelPreparation(
-  bridge: DesktopSupportSnapshotBridge,
-  clientJobId: string,
-  consentEpoch: string,
-  preparationId: string,
-): Promise<void> {
-  return bridge
-    .cancelPreparation({ clientJobId, consentEpoch, preparationId })
-    .catch(() => {});
+function settleCancellation(record: InFlightPreparation): Promise<void> {
+  if (!record.cancellationPromise) {
+    record.cancellationPromise = record.bridge.cancelPreparation({
+      clientJobId: record.clientJobId,
+      consentEpoch: record.consentEpoch,
+      preparationId: record.preparationId,
+    }).catch(() => {});
+  }
+  return record.cancellationPromise;
 }

--- a/apps/packages/product-client/src/lib/workflows/support/save-support-snapshot-copy.test.ts
+++ b/apps/packages/product-client/src/lib/workflows/support/save-support-snapshot-copy.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  saveSupportSnapshotCopy,
+  type SupportSnapshotSaveCopyWorkflowResult,
+} from "#product/lib/workflows/support/save-support-snapshot-copy";
+
+interface MatrixCase {
+  name: string;
+  archive: "saved" | "cancelled" | "rejected";
+  deletion: "resolved" | "rejected";
+  expected: SupportSnapshotSaveCopyWorkflowResult;
+}
+
+const MATRIX: MatrixCase[] = [
+  {
+    name: "saved archive and confirmed cleanup",
+    archive: "saved",
+    deletion: "resolved",
+    expected: { state: "saved", cleanup: "confirmed" },
+  },
+  {
+    name: "saved archive and unconfirmed cleanup",
+    archive: "saved",
+    deletion: "rejected",
+    expected: { state: "saved", cleanup: "unconfirmed" },
+  },
+  {
+    name: "cancelled dialog and confirmed cleanup",
+    archive: "cancelled",
+    deletion: "resolved",
+    expected: { state: "cancelled", cleanup: "confirmed" },
+  },
+  {
+    name: "cancelled dialog and unconfirmed cleanup",
+    archive: "cancelled",
+    deletion: "rejected",
+    expected: { state: "cancelled", cleanup: "unconfirmed" },
+  },
+  {
+    name: "failed archive and confirmed cleanup",
+    archive: "rejected",
+    deletion: "resolved",
+    expected: { state: "save_failed", cleanup: "confirmed" },
+  },
+  {
+    name: "failed archive and unconfirmed cleanup",
+    archive: "rejected",
+    deletion: "rejected",
+    expected: { state: "save_failed", cleanup: "unconfirmed" },
+  },
+];
+
+describe("saveSupportSnapshotCopy", () => {
+  it.each(MATRIX)("settles $name only after exact cleanup", async ({
+    archive,
+    deletion,
+    expected,
+  }) => {
+    const unhandled: unknown[] = [];
+    const listener = (reason: unknown) => { unhandled.push(reason); };
+    process.on("unhandledRejection", listener);
+    try {
+      const archiveResult = deferred<string | null>();
+      const cleanup = deferred<void>();
+      const archiveFailure = new Error("raw archive path /private/report.zip");
+      const cleanupFailure = new Error("raw staged path /private/artifact.json");
+      const saveArchive = vi.fn(() => archiveResult.promise);
+      const deleteArtifact = vi.fn(() => cleanup.promise);
+
+      const resultPromise = saveSupportSnapshotCopy(
+        { artifactId: "artifact-1", consentEpoch: "epoch-1" },
+        { saveArchive, deleteArtifact },
+      );
+      let settled = false;
+      void resultPromise.then(() => { settled = true; });
+
+      expect(deleteArtifact).not.toHaveBeenCalled();
+      if (archive === "rejected") archiveResult.reject(archiveFailure);
+      else archiveResult.resolve(archive === "saved" ? "diagnostics.zip" : null);
+      await vi.waitFor(() => expect(deleteArtifact).toHaveBeenCalledTimes(1));
+      expect(settled).toBe(false);
+      expect(saveArchive).toHaveBeenCalledTimes(1);
+      expect(saveArchive).toHaveBeenCalledWith({
+        artifactId: "artifact-1",
+        consentEpoch: "epoch-1",
+      });
+      expect(deleteArtifact).toHaveBeenCalledWith("artifact-1");
+
+      if (deletion === "resolved") cleanup.resolve();
+      else cleanup.reject(cleanupFailure);
+
+      const result = await resultPromise;
+      expect(result).toEqual(expected);
+      expect(Object.keys(result).sort()).toEqual(["cleanup", "state"]);
+      expect(JSON.stringify(result)).not.toContain("diagnostics.zip");
+      expect(JSON.stringify(result)).not.toContain("/private/");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", listener);
+    }
+  });
+});
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}

--- a/apps/packages/product-client/src/lib/workflows/support/save-support-snapshot-copy.ts
+++ b/apps/packages/product-client/src/lib/workflows/support/save-support-snapshot-copy.ts
@@ -1,0 +1,42 @@
+export type SupportSnapshotCleanupConfirmation = "confirmed" | "unconfirmed";
+
+export type SupportSnapshotSaveCopyWorkflowResult = {
+  state: "saved" | "cancelled" | "save_failed";
+  cleanup: SupportSnapshotCleanupConfirmation;
+};
+
+export interface SaveSupportSnapshotCopyInput {
+  artifactId: string;
+  consentEpoch: string;
+}
+
+export interface SaveSupportSnapshotCopyDependencies {
+  saveArchive: (input: {
+    artifactId: string;
+    consentEpoch: string;
+  }) => Promise<string | null>;
+  deleteArtifact: (artifactId: string) => Promise<void>;
+}
+
+/** Settles archive truth before exact staged-artifact cleanup truth. */
+export async function saveSupportSnapshotCopy(
+  input: SaveSupportSnapshotCopyInput,
+  deps: SaveSupportSnapshotCopyDependencies,
+): Promise<SupportSnapshotSaveCopyWorkflowResult> {
+  let state: SupportSnapshotSaveCopyWorkflowResult["state"];
+  try {
+    const savedFileName = await deps.saveArchive(input);
+    state = savedFileName === null ? "cancelled" : "saved";
+  } catch {
+    state = "save_failed";
+  }
+
+  let cleanup: SupportSnapshotCleanupConfirmation;
+  try {
+    await deps.deleteArtifact(input.artifactId);
+    cleanup = "confirmed";
+  } catch {
+    cleanup = "unconfirmed";
+  }
+  return { state, cleanup };
+}

--- a/specs/codebase/systems/product/support/README.md
+++ b/specs/codebase/systems/product/support/README.md
@@ -139,9 +139,20 @@ still succeeds. The artifact is atomically staged under an owner-only root with
 a durable job-bound opaque ID, exact size, and SHA-256; no path or capability is
 returned to JavaScript.
 
-**Save a copy…** writes a user-chosen ZIP containing exactly those staged
-`diagnostics.json` bytes. The archive is never enqueued as an attachment and is
-not removed by queue cleanup.
+One serialized **Save a copy…** action owns preparation, the native archive,
+and settlement of exact staged-artifact deletion. Save and Send remain
+unavailable for that whole action. The user-chosen ZIP and cleanup confirmation
+are independent: cancelling the native save dialog is not an error, a written
+ZIP remains successful when deletion rejects, and deletion rejection means
+durable cleanup is unconfirmed rather than proving bytes remain. The archive is
+never enqueued as an attachment and is not removed by queue cleanup.
+
+Cleanup-unconfirmed and an admitted preparation cancellation conservatively
+block further consented snapshot work for the same modal and client job. This
+does not add an in-session cleanup retry or guarantee later reconciliation.
+Clearing consent still permits the existing text-only Send path. Cleanup truth
+is internal-only here: it adds no user message, log, lifecycle record, metric,
+Sentry event, PostHog event, or other telemetry signal.
 
 ## Artifact contents at a glance
 


### PR DESCRIPTION
## Summary

Scope: 10 files in the Desktop support-feedback "Save a copy" path.

- `apps/packages/product-client/src/lib/workflows/support/save-support-snapshot-copy.ts` (+test) — new pure archive-then-exact-cleanup workflow.
- `apps/packages/product-client/src/hooks/support/workflows/use-support-snapshot-consent.ts` (+test, +save-copy test) — action serialization/dedupe, cancellation await, latch wiring.
- `apps/packages/product-client/src/hooks/support/facade/use-support-modal-state.{ts,test.tsx}` — facade plumbing for the new truthful result shape.
- `apps/packages/product-client/src/components/support/SupportSnapshotSaveCopyButton.tsx` (+ `SupportSnapshotConsentField.test.tsx`) — whole-action busy state, text-only escape for the unconfirmed-cleanup case.
- `specs/codebase/systems/product/support/README.md` — doc update to match the new contract.

### Behavior change

- The save-copy workflow now returns **independent archive/cleanup truth** instead of collapsing both into a single success/failure status. A saved ZIP is reported as saved even if the follow-up artifact cleanup could not be confirmed — the UI no longer claims cleanup succeeded when it didn't.
- The save-copy action is **serialized**: repeated clicks while an action is in flight dedupe onto the same in-flight Promise rather than racing a second save.
- Cached cancellation is now **awaited** before a new action proceeds, closing a race where a stale prepare could clobber a fresh one.
- The button now reflects a **whole-action busy state** (prepare + save + cleanup) rather than flickering between narrower sub-states.
- When cleanup truth can't be established, the workflow **latches to a conservative "cleanup unconfirmed" state** and blocks further snapshot actions until resolved, instead of assuming success.
- No new telemetry/observability surfaces were added; existing error messaging (`SAVE_FAILED_MESSAGE`) and blocked-state UI are reused, presented as **text-only** (no new iconography) for the unconfirmed-cleanup escape hatch.

## Rebase note

Rebased onto `main` @ 36ffc263. Rebase itself was conflict-free; while proving the build post-rebase (`pnpm --filter @proliferate/product-client build`, required because Cloud SDK source changed on main), tsc caught a real `TS2454: 'promise' used before being assigned` in `use-support-snapshot-consent.ts` (a `let`/reassign pattern that referenced the variable from within its own initializer's closure). Fixed by declaring `promise` as a single `const` from the async IIFE and moving the activeSavePromiseRef-clearing cleanup into a `.finally()` attached after assignment, so the closure only ever reads `promise` once it is definitely assigned. No behavior change from this fix — same dedupe/clearing semantics, just TS-legal.

## Testing

Done locally (machine had swap headroom, so full local proof was safe this run):
- `python3 scripts/check_docs.py` — passed (232 Markdown files).
- `CI=1 pnpm install --offline --frozen-lockfile --ignore-scripts` — passed.
- `CI=1 pnpm --filter @proliferate/product-client build` — passed after the tsc fix above.
- Focused vitest on the four changed/new test files plus the new save-copy test:
  - `use-support-snapshot-consent.test.tsx` (10 tests)
  - `use-support-snapshot-consent.save-copy.test.tsx` (23 tests, new)
  - `save-support-snapshot-copy.test.ts` (6 tests, new)
  - `use-support-modal-state.test.tsx` (11 tests)
  - `SupportSnapshotConsentField.test.tsx` (9 tests)
  - All 59 tests passed.
- `npx tsc -p tsconfig.json --noEmit` in `apps/packages/product-client` — passed.

Not run locally (rely on remote CI): full monorepo build/test/lint matrix outside the product-client package and its direct build deps (cloud-sdk, anyharness sdk, design) already exercised by the build step above.

## Observability

No new logs, metrics, or traces added. Existing error surface (`SAVE_FAILED_MESSAGE`) and the new conservative "cleanup unconfirmed" blocked state are user-facing text only; no telemetry emitted for either path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)