### PR TITLE
fix(anyharness): re-observe launch options after the dud agent-program swap

### DIFF
--- a/anyharness/crates/anyharness-lib/src/app/test_support.rs
+++ b/anyharness/crates/anyharness-lib/src/app/test_support.rs
@@ -52,10 +52,13 @@ pub(crate) fn seed_observed_launch_options(
     service: &HarnessLaunchOptionsService,
     harness_kind: &str,
 ) {
+    // Re-seed when the stored observation is basis-stale (`options: None`,
+    // e.g. after a test swaps the agent program): admission needs a
+    // current-basis observation, not just any row.
     if service
         .read(harness_kind)
         .expect("read launch options")
-        .is_some()
+        .is_some_and(|response| response.options.is_some())
     {
         return;
     }

--- a/anyharness/crates/anyharness-lib/src/live/workflows/lifecycle_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/lifecycle_tests.rs
@@ -878,6 +878,11 @@ async fn a_failed_launch_fails_the_run_and_compensates_the_half_born_session() {
     std::fs::write(&dud, "#!/bin/sh\nexit 0\n").expect("write dud agent");
     make_executable(&dud).expect("make dud agent executable");
     std::env::set_var("ANYHARNESS_CLAUDE_AGENT_PROGRAM", &dud);
+    // The program swap changed the spawn spec, so the boot-time observation is
+    // basis-stale and admission would refuse the create BEFORE the row exists.
+    // Re-observe at the dud basis: this test's failure must land AFTER the
+    // stamp, in the compensation window.
+    test_support::seed_observed_launch_options(&fixture.state.launch_options_service, "claude");
     let definition = chain(vec![agent_node("solo", "never launches")]);
     fixture.start("run-launchfail", definition);
 

--- a/anyharness/crates/anyharness-lib/src/live/workflows/lifecycle_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/lifecycle_tests.rs
@@ -669,16 +669,13 @@ async fn an_adhoc_node_runs_beside_the_chain_and_never_moves_it() {
         adhoc.model.as_ref().and_then(|model| model.model_id.as_deref()),
         Some("haiku")
     );
-    let adhoc_session = fixture
-        .state
-        .session_service
-        .get_session(adhoc.session_id.as_deref().expect("adhoc session"))
-        .expect("load adhoc session")
-        .expect("adhoc session exists");
-    assert_eq!(
-        adhoc_session.requested_model_id.as_deref(),
-        Some("haiku")
-    );
+    // The cutover moved the requested pick into the immutable launch intent.
+    let store = fixture.state.session_service.store();
+    let intent = store
+        .find_launch_intent(adhoc.session_id.as_deref().expect("adhoc session"))
+        .expect("load adhoc launch intent")
+        .expect("adhoc launch intent exists");
+    assert_eq!(intent.model_id.as_deref(), Some("haiku"));
 
     fixture.touch_control("release-turn");
     let state = fixture
@@ -878,10 +875,8 @@ async fn a_failed_launch_fails_the_run_and_compensates_the_half_born_session() {
     std::fs::write(&dud, "#!/bin/sh\nexit 0\n").expect("write dud agent");
     make_executable(&dud).expect("make dud agent executable");
     std::env::set_var("ANYHARNESS_CLAUDE_AGENT_PROGRAM", &dud);
-    // The program swap changed the spawn spec, so the boot-time observation is
-    // basis-stale and admission would refuse the create BEFORE the row exists.
-    // Re-observe at the dud basis: this test's failure must land AFTER the
-    // stamp, in the compensation window.
+    // The swap changed the spawn spec (= observation basis); re-observe so the
+    // create is admitted and the failure lands AFTER the stamp, as intended.
     test_support::seed_observed_launch_options(&fixture.state.launch_options_service, "claude");
     let definition = chain(vec![agent_node("solo", "never launches")]);
     fixture.start("run-launchfail", definition);


### PR DESCRIPTION
## Summary

- The launch-options cutover (#2070) makes the agent spawn spec part of the observation basis. The lifecycle test `a_failed_launch_fails_the_run_and_compensates_the_half_born_session` swaps `ANYHARNESS_CLAUDE_AGENT_PROGRAM` to a dud after fixture boot, so the boot-time observation became basis-stale and the create was refused BEFORE the session row existed — the test's point is a failure landing AFTER the stamp, in the compensation window. It now re-observes at the dud basis after the swap.
- `test_support::seed_observed_launch_options` now re-seeds when the stored row is basis-stale (`options: None`) instead of early-returning on any row.
- The adhoc lifecycle test asserted the model pick on the legacy `sessions.requested_model_id` column; the cutover deliberately persists the pick in the immutable launch intent, so the assert now reads `find_launch_intent` (the node-row pick assert is unchanged).
- Test-only change; no production code. Cures the red `live::workflows::lifecycle_tests` on main (two stale-contract roots + env-mutex poison victims).

## Testing

- Remote CI on this PR head is the verdict (no local Cargo per machine build policy). `scripts/check_max_lines.py` passes locally after keeping `lifecycle_tests.rs` at its 1066 ratchet.
