### PR TITLE
fix(anyharness): observe the swapped harness basis in workflow lifecycle tests

### DIFF
--- a/anyharness/crates/anyharness-lib/src/app/test_support.rs
+++ b/anyharness/crates/anyharness-lib/src/app/test_support.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::domains::agents::launch_options::{
-    HarnessLaunchDefaults, HarnessLaunchModel, HarnessLaunchOptions,
-    HarnessLaunchOptionsService,
+    HarnessLaunchDefaults, HarnessLaunchModel, HarnessLaunchOptions, HarnessLaunchOptionsService,
+    HarnessLaunchOptionsState,
 };
 use crate::domains::agents::route_auth::{apply_state_file, AgentAuthState};
 use crate::domains::sessions::attachment_storage::PromptAttachmentStorage;
@@ -48,6 +48,11 @@ pub(crate) fn seed_scripted_claude_launch_options(service: &HarnessLaunchOptions
 
 /// Seed one target-observed launch-option statement for `harness_kind` so
 /// intent validation at the start seam has a current-basis observation.
+///
+/// A stored row whose basis no longer matches projects as `Detecting`, so the
+/// guard tests observation state rather than row presence: a fixture that
+/// swaps the harness program after boot must be able to re-observe the new
+/// basis instead of silently keeping a stale statement.
 pub(crate) fn seed_observed_launch_options(
     service: &HarnessLaunchOptionsService,
     harness_kind: &str,
@@ -55,7 +60,7 @@ pub(crate) fn seed_observed_launch_options(
     if service
         .read(harness_kind)
         .expect("read launch options")
-        .is_some()
+        .is_some_and(|response| response.state == HarnessLaunchOptionsState::Observed)
     {
         return;
     }

--- a/anyharness/crates/anyharness-lib/src/live/workflows/lifecycle_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/lifecycle_tests.rs
@@ -669,16 +669,13 @@ async fn an_adhoc_node_runs_beside_the_chain_and_never_moves_it() {
         adhoc.model.as_ref().and_then(|model| model.model_id.as_deref()),
         Some("haiku")
     );
-    let adhoc_session = fixture
-        .state
-        .session_service
-        .get_session(adhoc.session_id.as_deref().expect("adhoc session"))
-        .expect("load adhoc session")
-        .expect("adhoc session exists");
-    assert_eq!(
-        adhoc_session.requested_model_id.as_deref(),
-        Some("haiku")
-    );
+    // Creation records the validated pick on the immutable launch intent.
+    let store = fixture.state.session_service.store();
+    let adhoc_intent = store
+        .find_launch_intent(adhoc.session_id.as_deref().expect("adhoc session"))
+        .expect("load adhoc launch intent")
+        .expect("adhoc session owns a launch intent");
+    assert_eq!(adhoc_intent.model_id.as_deref(), Some("haiku"));
 
     fixture.touch_control("release-turn");
     let state = fixture
@@ -878,6 +875,9 @@ async fn a_failed_launch_fails_the_run_and_compensates_the_half_born_session() {
     std::fs::write(&dud, "#!/bin/sh\nexit 0\n").expect("write dud agent");
     make_executable(&dud).expect("make dud agent executable");
     std::env::set_var("ANYHARNESS_CLAUDE_AGENT_PROGRAM", &dud);
+    // The swap moves the harness basis, so re-observe: admission must pass on
+    // target-observed options and the launch must fail at spawn instead.
+    test_support::seed_scripted_claude_launch_options(&fixture.state.launch_options_service);
     let definition = chain(vec![agent_node("solo", "never launches")]);
     fixture.start("run-launchfail", definition);
 


### PR DESCRIPTION
## Root cause

#2070 (`11c1399ba2`, "make harness launch options target-observed") changed launch admission: `create_durable_session` now refuses a launch whose harness basis has no matching *observed* launch-options row, and the model pick is recorded on the session's immutable **launch intent** rather than on `SessionRecord::requested_model_id` (which creation now deliberately leaves `None`).

Two `live::workflows::lifecycle_tests` cases still encoded the pre-#2070 world:

- **`a_failed_launch_fails_the_run_and_compensates_the_half_born_session`** — the fixture boots (and observes) with the scripted agent, then swaps `ANYHARNESS_CLAUDE_AGENT_PROGRAM` to a dud binary to force a spawn-time failure. The swap changes `compute_harness_basis_revision`, so the boot-time observation no longer matches and the launch was refused with `LaunchOptionsUnavailable { state: Some(Observed) }` **before** stamping the session. The test asserts the stamp happened (`lifecycle_tests.rs:905`, "the launch stamped the session before starting it"), so it panicked — poisoning the crate-wide env mutex and cascading the whole module (3 failures locally serial, the entire module on CI's parallel run).
- **`an_adhoc_node_runs_beside_the_chain_and_never_moves_it`** — read the launch pick back from `requested_model_id`, which is now always `None`.

## Fix (test-only — no product/admission change)

- Re-observe launch options after the program swap, so the dud binary's basis is target-observed: admission passes and the launch fails at spawn, which is the compensation window the test is about. The assertion is untouched.
- `seed_observed_launch_options` now keys its idempotence on observation *state* (`Observed`) rather than row presence — a stale-basis row projects as `Detecting`, so the old `is_some()` guard silently kept the stale statement.
- The adhoc test reads the pick from the session's launch intent (`find_launch_intent`), the post-#2070 home of a validated launch selection.

## Verification

```
cargo test -p anyharness-lib -j 1 --lib -- --test-threads=1 live::workflows::lifecycle_tests
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 2125 filtered out

cargo test -p anyharness-lib -j 1 --lib -- --test-threads=1 launch
test result: ok. 124 passed; 0 failed; 0 ignored; 0 measured; 2013 filtered out

cargo test -p anyharness-lib -j 1 --lib -- --test-threads=1 workflows
test result: ok. 166 passed; 0 failed; 0 ignored; 0 measured; 1971 filtered out
```

Negative control: with the change stashed, `live::workflows::lifecycle_tests` returns to `0 passed; 12 failed` — the original `LaunchOptionsUnavailable` panic plus the env-mutex poison cascade.

`scripts/check_max_lines.py` passes (the lifecycle module stays exactly at its ratcheted 1066 lines); `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
