### PR TITLE
fix(desktop): source-disable PostHog session recording (CP-C1PD)

### DIFF
--- a/apps/desktop/.env.example
+++ b/apps/desktop/.env.example
@@ -18,7 +18,6 @@ VITE_PROLIFERATE_SENTRY_TRACES_SAMPLE_RATE=1.0
 VITE_PROLIFERATE_SENTRY_ENABLE_LOGS=true
 VITE_PROLIFERATE_POSTHOG_KEY=
 VITE_PROLIFERATE_POSTHOG_HOST=https://us.i.posthog.com
-VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED=false
 
 # Native Tauri telemetry is compiled into release builds by desktop/src-tauri/build.rs.
 # Native Sentry only initializes in hosted_product mode after runtime config resolution.

--- a/apps/desktop/src/assets.d.ts
+++ b/apps/desktop/src/assets.d.ts
@@ -19,7 +19,6 @@ interface ImportMetaEnv {
   readonly VITE_PROLIFERATE_SENTRY_ENABLE_LOGS?: string;
   readonly VITE_PROLIFERATE_POSTHOG_KEY?: string;
   readonly VITE_PROLIFERATE_POSTHOG_HOST?: string;
-  readonly VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED?: string;
 }
 
 interface ImportMeta {

--- a/apps/desktop/src/lib/integrations/telemetry/client.test.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/client.test.ts
@@ -31,7 +31,6 @@ const mocks = vi.hoisted(() => {
         enabled: true,
         apiKey: "phc_test",
         apiHost: "https://us.i.posthog.com",
-        sessionRecordingEnabled: false,
       },
     })),
     isBuildTelemetryDisabledMock: vi.fn(() => false),

--- a/apps/desktop/src/lib/integrations/telemetry/config.test.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/config.test.ts
@@ -45,6 +45,38 @@ describe("getDesktopTelemetryConfig", () => {
       expect(configured.sentry).not.toHaveProperty("replaysOnErrorSampleRate");
     },
   );
+
+  it.each([
+    ["absent", undefined],
+    ["empty", ""],
+    ["boolean-looking true", "true"],
+    ["boolean-looking false", "false"],
+    ["numeric true", "1"],
+    ["numeric false", "0"],
+    ["numeric fractional", "0.5"],
+    ["numeric negative", "-1"],
+    ["malformed", "not-a-boolean"],
+  ] as const)(
+    "ignores the retired PostHog recording setting when its legacy value is %s",
+    async (_label, value) => {
+      const baselineModule = await loadConfigModule();
+      const baseline = baselineModule.getDesktopTelemetryConfig();
+
+      if (value !== undefined) {
+        vi.stubEnv("VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED", value);
+      }
+
+      const config = await loadConfigModule();
+      const configured = config.getDesktopTelemetryConfig();
+
+      expect(configured).toEqual(baseline);
+      expect(Object.keys(configured.posthog).sort()).toEqual([
+        "apiHost",
+        "apiKey",
+        "enabled",
+      ]);
+    },
+  );
 });
 
 describe("getAnonymousTelemetryEndpoint", () => {

--- a/apps/desktop/src/lib/integrations/telemetry/config.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/config.ts
@@ -29,7 +29,6 @@ export interface DesktopTelemetryConfig {
     enabled: boolean;
     apiKey: string | null;
     apiHost: string;
-    sessionRecordingEnabled: boolean;
   };
 }
 
@@ -62,10 +61,6 @@ export function getDesktopTelemetryConfig(): DesktopTelemetryConfig {
       apiHost:
         import.meta.env.VITE_PROLIFERATE_POSTHOG_HOST?.trim()
         || "https://us.i.posthog.com",
-      sessionRecordingEnabled: envFlagEnabled(
-        import.meta.env.VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED,
-        false,
-      ),
     },
   };
 }

--- a/apps/desktop/src/lib/integrations/telemetry/posthog.test.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/posthog.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   capture: vi.fn(),
   identify: vi.fn(),
   reset: vi.fn(),
+  startSessionRecording: vi.fn(),
 }));
 
 vi.mock("posthog-js", () => ({
@@ -24,7 +25,6 @@ const ENABLED_CONFIG = {
     enabled: true,
     apiKey: "phc_test",
     apiHost: "https://us.i.posthog.com",
-    sessionRecordingEnabled: false,
   },
 };
 
@@ -35,6 +35,52 @@ describe("desktop PostHog adapter", () => {
     mocks.capture.mockReset();
     mocks.identify.mockReset();
     mocks.reset.mockReset();
+    mocks.startSessionRecording.mockReset();
+  });
+
+  it("initializes once with recording disabled and no recording surfaces", async () => {
+    const adapter = await loadDesktopPostHog();
+    adapter.initializeDesktopPostHog(ENABLED_CONFIG);
+    adapter.initializeDesktopPostHog(ENABLED_CONFIG);
+
+    expect(mocks.init).toHaveBeenCalledOnce();
+
+    const [apiKey, options] = mocks.init.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(apiKey).toBe("phc_test");
+    const { before_send: beforeSend, ...rest } = options;
+    expect(rest).toEqual({
+      api_host: "https://us.i.posthog.com",
+      autocapture: false,
+      capture_pageview: false,
+      capture_pageleave: false,
+      person_profiles: "identified_only",
+      disable_session_recording: true,
+    });
+    const scrub = await import("./scrub");
+    expect(beforeSend).toBe(scrub.scrubPostHogPayload);
+    expect(Object.keys(options).sort()).toEqual([
+      "api_host",
+      "autocapture",
+      "before_send",
+      "capture_pageleave",
+      "capture_pageview",
+      "disable_session_recording",
+      "person_profiles",
+    ]);
+    expect(mocks.startSessionRecording).not.toHaveBeenCalled();
+  });
+
+  it("captures typed product events through the scrubber", async () => {
+    const adapter = await loadDesktopPostHog();
+    adapter.initializeDesktopPostHog(ENABLED_CONFIG);
+
+    adapter.trackDesktopPostHogEvent("app_update_available", { version: "1.2.3" });
+
+    expect(mocks.capture).toHaveBeenCalledOnce();
+    expect(mocks.capture.mock.calls[0]?.[0]).toBe("app_update_available");
   });
 
   it("identifies with the authenticated user id only", async () => {

--- a/apps/desktop/src/lib/integrations/telemetry/posthog.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/posthog.ts
@@ -27,19 +27,7 @@ export function initializeDesktopPostHog(config: DesktopPostHogInitConfig): void
     capture_pageleave: false,
     person_profiles: "identified_only",
     before_send: scrubPostHogPayload,
-    disable_session_recording: !config.posthog.sessionRecordingEnabled,
-    session_recording: config.posthog.sessionRecordingEnabled
-      ? {
-        maskAllInputs: true,
-        maskTextSelector: "[data-telemetry-mask]",
-        blockSelector: "[data-telemetry-block]",
-      }
-      : undefined,
-    loaded: config.posthog.sessionRecordingEnabled
-      ? (client) => {
-        client.startSessionRecording();
-      }
-      : undefined,
+    disable_session_recording: true,
   });
 
   posthog.register({

--- a/guides/operating/analytics/posthog.md
+++ b/guides/operating/analytics/posthog.md
@@ -48,11 +48,14 @@ network requests in screenshots.
    - sign-out produces a new anonymous identity on the next session;
    - no prompt, transcript, repo name, file path, raw URL, terminal text,
      token, or raw error is present.
-5. Replay should be absent by default. If a reviewed build intentionally
-   enables it, verify input masking and block/mask selectors with synthetic
-   data only. On Desktop and Web, inspect whether recorded page metadata
-   contains workflow, workspace, or chat route ids; that is a known current
-   gap even though event URL properties are scrubbed.
+5. Desktop replay is expected to be absent. Desktop PostHog session recording
+   is source-disabled, so any Desktop replay observed in the provider is a
+   code-or-provider truth mismatch to triage, not a gate to look for or enable.
+   Synthetic replay verification applies only to a surface whose reviewed
+   source currently permits replay. For such a surface, verify input masking
+   and block/mask selectors with synthetic data only, and inspect whether
+   recorded page metadata contains workflow, workspace, or chat route ids;
+   that is a known current gap even though event URL properties are scrubbed.
 
 ## Diagnose Missing Evidence
 
@@ -62,8 +65,9 @@ network requests in screenshots.
   in `apps/desktop/src/lib/integrations/telemetry/client.ts`.
 - Web/Mobile views missing: verify the provider initialized and the normalized
   route/screen hook ran; raw paths are intentionally not capture values.
-- Replay missing: confirm the separate replay gate. Mobile also needs the
-  optional native replay package in that build.
+- Replay missing on a surface whose source permits it: confirm that surface's
+  separate replay gate. Mobile also needs the optional native replay package in
+  that build. Missing Desktop replay is the expected result, not a defect.
 - Provider data differs from checked-in behavior: capture event name, surface,
   environment, release, observed time, and a redacted provider URL. Route
   ingestion or deduplication defects to Issue Lifecycle.

--- a/specs/OBSERVABILITY.md
+++ b/specs/OBSERVABILITY.md
@@ -181,8 +181,10 @@ change sits on:
   Re-enablement requires a separately reviewed synthetic privacy proof of the
   exact route/surface block-and-mask policy, metadata policy, provider arrival,
   and absence of prompt, transcript, terminal, file, repository, path, token,
-  workspace, session, and workflow identifiers. PostHog replay is off by
-  default; when explicitly enabled, recorded page metadata can contain route
+  workspace, session, and workflow identifiers. Desktop PostHog session
+  recording is likewise source-disabled and absent; every other surface's
+  current PostHog recording behavior is owned by the PostHog system contract,
+  and where recording is permitted, recorded page metadata can contain route
   ids even though capture-event URL properties are stripped. A new surface
   that can display prompts, files, paths, or credentials gets
   `[data-telemetry-block]` / `[data-telemetry-mask]` unless there is a

--- a/specs/codebase/systems/engineering/analytics/README.md
+++ b/specs/codebase/systems/engineering/analytics/README.md
@@ -53,7 +53,7 @@ deduplication boundary.
 | Destinations | The configured Proliferate Server/Postgres database, PostHog for enabled hosted clients, and an operator-selected read-only BI client such as Metabase. |
 | Enable, disable, or no-op | Vendor adapters require their client key and telemetry gates. Anonymous telemetry has build/runtime and Server disable gates. Provider ingestion skips a provider whose required configuration is absent. |
 | Privacy and replay | First-party payloads exclude prompts, transcripts, repo names, file paths, terminal text, raw URLs, errors, and secrets. Replay is off by default and its masking rules are owned by the PostHog contract. |
-| Known gaps | Desktop and Web replay can still expose route ids through recorded page URLs when explicitly enabled. Anonymous credential fields are accepted by the schema but currently have no Desktop emission directive. Live provider dashboards and data freshness are not enforced by repository code. |
+| Known gaps | Web replay can still expose route ids through recorded page URLs when explicitly enabled; Desktop PostHog recording is source-disabled and Mobile has its own contract. Anonymous credential fields are accepted by the schema but currently have no Desktop emission directive. Live provider dashboards and data freshness are not enforced by repository code. |
 
 ## Operating Routes
 

--- a/specs/codebase/systems/engineering/analytics/posthog.md
+++ b/specs/codebase/systems/engineering/analytics/posthog.md
@@ -12,9 +12,9 @@ initialized by the Server API.
 | Source components | Desktop `apps/desktop/src/lib/integrations/telemetry/{client,config,posthog}.ts`; Web `apps/web/src/lib/integrations/telemetry/{config,posthog}.ts`; Mobile `apps/mobile/src/lib/integrations/telemetry/{config,posthog}.ts`. |
 | Identity and data | Distinct id is the authenticated user UUID, and identify calls send that UUID only with no email, display name, or other person properties. Captured data is the fixed event surface below plus scrubbed low-cardinality properties and registered app/surface/environment/release context. |
 | Destination | The configured PostHog host, defaulting to `https://us.i.posthog.com`. |
-| Enable, disable, or no-op | A missing API key makes each adapter inert. Web/Mobile also honor their public telemetry-disable setting; Desktop additionally requires hosted-product routing. Replay has a separate false-by-default gate. |
-| Privacy and replay | Autocapture and automatic page views are off. Payload scrubbers remove sensitive values. Replay is off by default; enabled Desktop/Web replay masks inputs and honors block/mask selectors, and Mobile masks text, images, and sandboxed views. |
-| Known gap | When Desktop or Web replay is explicitly enabled, recorded page metadata can contain route ids even though capture-event URL properties are stripped. Mobile replay also requires the optional native replay dependency in the build. |
+| Enable, disable, or no-op | A missing API key makes each adapter inert. Web/Mobile also honor their public telemetry-disable setting; Desktop additionally requires hosted-product routing. Desktop recording is source-disabled; Web/Mobile replay has a separate false-by-default gate. |
+| Privacy and replay | Autocapture and automatic page views are off. Payload scrubbers remove sensitive values. Desktop recording is source-disabled and absent. Web replay is off by default and, when enabled, masks inputs and honors block/mask selectors; Mobile masks text, images, and sandboxed views. |
+| Known gap | When Web replay is explicitly enabled, recorded page metadata can contain route ids even though capture-event URL properties are stripped. Mobile replay also requires the optional native replay dependency in the build. |
 
 ## Desktop
 
@@ -25,14 +25,15 @@ autocapture=false
 capture_pageview=false
 capture_pageleave=false
 person_profiles=identified_only
-session recording disabled unless explicitly enabled
+disable_session_recording=true
 ```
 
-When `VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED` is true, the
-`loaded` callback explicitly starts Desktop recording. Inputs are masked and
-`[data-telemetry-mask]` / `[data-telemetry-block]` are respected. Those controls
-do not remove identifier-bearing workflow or workspace route segments from
-recorded page metadata.
+Desktop session recording is source-disabled, not false-by-default. The Desktop
+source carries no recording flag, recording options object, `loaded` callback,
+or `startSessionRecording` call, so no build value, environment value, or
+PostHog provider-side replay setting can start it. Re-enablement is a separate
+founder-approved change that must first prove a synthetic route, masking,
+metadata, and provider-arrival contract.
 
 Only these Desktop product events reach PostHog:
 
@@ -76,7 +77,17 @@ Sign-out resets the client.
 
 ## Configuration
 
-Desktop/Web:
+Desktop:
+
+```text
+VITE_PROLIFERATE_POSTHOG_KEY
+VITE_PROLIFERATE_POSTHOG_HOST
+VITE_PROLIFERATE_TELEMETRY_DISABLED
+VITE_PROLIFERATE_ENVIRONMENT
+VITE_PROLIFERATE_RELEASE
+```
+
+Web:
 
 ```text
 VITE_PROLIFERATE_POSTHOG_KEY

--- a/specs/developing/reference/env-vars.yaml
+++ b/specs/developing/reference/env-vars.yaml
@@ -1148,8 +1148,8 @@
 - name: VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED
   secret: false
   default: "false"
-  description: Desktop and Web PostHog session recording toggle
-  tags: [local-dev, ci, desktop, web]
+  description: Web PostHog session recording toggle (Web only; Desktop recording is source-disabled)
+  tags: [local-dev, ci, web]
 
 # ═══════════════════════════════════════════════════════════════════════
 # Mobile: Expo Public Build Vars


### PR DESCRIPTION
## Summary

CP-C1PD makes PostHog session recording impossible to enable on Desktop through any build or environment value. Desktop still initializes PostHog in `hosted_product` mode when its normal key and telemetry gates permit, but the single `posthog.init` call now passes `disable_session_recording: true` literally.

The dormant activation surfaces are deleted in the same PR:

- `VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED` removed from `apps/desktop/.env.example` and the `ImportMetaEnv` declaration in `assets.d.ts`
- `DesktopTelemetryConfig.posthog.sessionRecordingEnabled` and its `envFlagEnabled(...)` read removed from `config.ts` (the helper itself stays; it still owns other booleans)
- the conditional `session_recording` mask/block object and the `loaded` callback that called `startSessionRecording()` deleted from `posthog.ts`
- the stale fixture field removed from `posthog.test.ts` and `client.test.ts`

## Privacy rationale

The pinned SDK (`posthog-js` 1.386.8) defaults `disable_session_recording` to `false`, so omitting the option is not fail-closed. The recorder's `_isRecordingEnabled` requires both provider-side enablement and `!config.disable_session_recording`, and `startSessionRecording(...)` re-opens it via `set_config`. Explicitly passing `true` and closing both first-party reopening routes (no recording-start call, no `set_config`/`setConfig` in non-test Desktop source) means a PostHog project replay setting alone cannot start Desktop recording.

This is consistent with the landed CP-S2A identity truth (UUID-only `identify`) and the CP-C1S documentation truth that Desktop renderer Sentry replay is source-disabled and absent. Recorded page metadata can retain identifier-bearing route segments even with masking, which is why the fix is at the source and not a default value.

Re-enablement is a separate founder-approved behavior change that must first prove a synthetic sensitive-route, masking, metadata, and provider-arrival contract. No dormant Desktop switch or compatibility branch is retained.

Unchanged: typed product capture and the event allowlist, id-only `identify`, `reset(true)`, `getDesktopPostHogSupportRefs()` (including `get_session_id()`, an analytics correlation reference, not a recording signal), registered app/surface/environment/release context, `before_send` scrubbing, and the literal `false` values for autocapture, pageview, and pageleave. No package.json or lockfile change; Web and Mobile semantics untouched.

## Documentation

- `specs/OBSERVABILITY.md` — preserves CP-C1S's exact Sentry-replay sentence; the PostHog clause now states Desktop PostHog recording is source-disabled and absent and delegates other surfaces to the PostHog system contract (wording stays true when CP-C1PW source-disables Web).
- `specs/codebase/systems/engineering/analytics/README.md` — Desktop removed from the replay route-metadata gap; Web's gap and Mobile's contract remain.
- `specs/codebase/systems/engineering/analytics/posthog.md` — Desktop described as source-disabled rather than false-by-default, `disable_session_recording=true` in the init contract, enabling instructions and masking claim removed, configuration truth split so the shared legacy variable is listed for Web only.
- `guides/operating/analytics/posthog.md` — Desktop replay is expected to be absent and any observed Desktop replay is a code/provider-truth mismatch to triage; synthetic replay verification now applies only to a surface whose reviewed source permits replay.
- `specs/developing/reference/env-vars.yaml` — the shared variable is retained because Web still owns it, retagged and redescribed as Web-only. No Web code or Web `.env.example` change.

## Observability

No new logs, metrics, spans, Sentry events, PostHog events, or provider receipts. The change removes a telemetry activation path; a rejected legacy value is silent by design because the supported input no longer exists. Documentation truth for the Desktop PostHog surface is updated in the same PR.

## Testing

Run locally:

- 13 source-policy grep proofs from the spec, all passing: the legacy variable name occurs exactly once in `apps/desktop/src` (the `config.test.ts` tombstone); `posthog.ts` is the sole non-type runtime importer of `posthog-js` and the sole owner of exactly one `posthog.init`; no `startSessionRecording`/`set_config`/`setConfig` in non-test Desktop source; no `session_recording`/`loaded` property; `disable_session_recording: true` exactly once and no `false` occurrence; no replay/recording env pattern under `apps/desktop`, `release-desktop.yml`, or `scripts/ci-cd`.
- `python3 scripts/check_max_lines.py` — passed
- `python3 scripts/check_docs.py` — passed (234 Markdown files)
- `python3 scripts/report_frontend_structure.py --strict --summary-only` — passed, 0 violations
- `python3 scripts/check_frontend_boundaries.py` — passed
- Diff-scope proofs: exactly the 12 permitted files changed; the seven load-bearing evidence owners (`apps/desktop/package.json`, `pnpm-lock.yaml`, `.github/workflows/ci.yml`, and the four checkers) are byte-identical to the base; `git diff --check` clean.

Tests added:

- `config.test.ts` — a nine-class table test (absent, empty, `"true"`, `"false"`, `"1"`, `"0"`, `"0.5"`, `"-1"`, `"not-a-boolean"`) that loads a fresh config module per case and asserts the PostHog config equals the unstubbed baseline and has exactly the keys `apiHost`, `apiKey`, `enabled`. Property names are asserted through the exact key set rather than string literals so the spec's identifier-absence grep stays satisfiable.
- `posthog.test.ts` — captures the actual second argument to `posthog.init` and compares the complete object, proving init is called exactly once across two calls, the three capture flags are exactly `false`, `disable_session_recording` is exactly `true`, the option object has no own `session_recording` or `loaded` key, and a mocked `startSessionRecording` is never called. `before_send` identity is checked against the live `./scrub` module because `vi.resetModules()` makes a statically imported reference a different instance.

Skipped locally, deferred to CI: `pnpm --filter proliferate exec vitest run` on the three telemetry suites and `pnpm --filter proliferate exec tsc --noEmit`. The worktree has no `node_modules` and the machine was at swap-free 595MiB, below the 1GiB floor in the repository machine-resource rules; installing the workspace and running vitest/tsc there risks an OOM. CI covers both, including the required clean-checkout `Desktop frontend build` job.

## Spec reconciliation

Implemented from `e5b3dd1b` (CP-S2B, `fix(server): enforce Sentry transport privacy (#2087)`) rather than the spec's candidate base `3b602dbe`, per the required order `CP-C1S -> CP-S2B -> CP-C1PD`. Blobs repinned at the new base:

- Changed since the candidate base, all expected predecessor edits: `.env.example`, `config.ts`, `config.test.ts`, `specs/OBSERVABILITY.md` (CP-C1S/CP-S2B), and `.github/workflows/ci.yml` (#2080's Playwright apt helper). The ci.yml hunk only inserts an apt helper before three Playwright install steps; the `Desktop frontend build` job and command graph are unchanged, so the spec's classified invariant holds.
- `apps/desktop/package.json` and `pnpm-lock.yaml` unchanged: `posthog-js` remains pinned at 1.386.8, so the pinned-SDK reasoning stands.
- The four checker scripts are unchanged from the candidate-base pins.

CP-C1S's `config.test.ts` Sentry-replay tombstone and its `specs/OBSERVABILITY.md` Sentry sentence are preserved verbatim; the new PostHog tombstone and PostHog clause sit alongside them. No semantic contradiction with the spec was found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
