### PR TITLE
chore(product): drop the beta mark from the Workflows sidebar row

### DIFF
--- a/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarPrimaryNavigation.tsx
+++ b/apps/packages/product-client/src/components/workspace/shell/sidebar/SidebarPrimaryNavigation.tsx
@@ -88,11 +88,6 @@ export function SidebarScrollingNavigation({
         active: workflowsActive,
         icon: <Fork />,
         label: "Workflows",
-        status: (
-          <span className="font-mono text-ui-sm uppercase tracking-[0.06em] text-sidebar-muted-foreground">
-            beta
-          </span>
-        ),
       }]
       : []),
     {


### PR DESCRIPTION
## Summary

- Remove the trailing `beta` status from the Workflows row in the sidebar's primary navigation, so it reads like the Workspaces and Support rows beside it.
- Keep `SidebarNavRow`'s `status` slot: it is a general nav-row affordance with its own covered behaviour (the shortcut reveal overlays a trailing status rather than displacing it), not a workflows-specific hook.

## Testing

- Tier 1 frontend rendering coverage.
- `pnpm --filter @proliferate/product-client exec vitest run src/components/workspace/shell/sidebar src/primitives/patterns/sidebar` — 14 files, 134 tests passed.
- `pnpm --filter @proliferate/product-client typecheck` — passed, zero errors.
- No test or specification asserted the mark; `git log --all -S` over the file confirms nothing else consumed it.

## Observability

- None. This removes a static piece of navigation chrome with no runtime path or telemetry surface.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [x] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- The row renders with no trailing text; the Support row's shortcut reveal is unaffected, since only the workflows item passed a status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)