### PR TITLE
fix(web): source-disable PostHog session recording (CP-C1PW)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -11,9 +11,6 @@ VITE_PROLIFERATE_SENTRY_TRACES_SAMPLE_RATE=1.0
 VITE_PROLIFERATE_SENTRY_ENABLE_LOGS=true
 VITE_PROLIFERATE_POSTHOG_KEY=
 VITE_PROLIFERATE_POSTHOG_HOST=https://us.i.posthog.com
-# Set true to start session replay in production builds.
-# See docs/dev/analytics/posthog.md for masking + URL caveats.
-VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED=false
 
 # Optional build-time Sentry sourcemap upload (CI only, normally set by Vercel).
 SENTRY_AUTH_TOKEN=

--- a/apps/web/src/browser/telemetry/install-web-telemetry.ts
+++ b/apps/web/src/browser/telemetry/install-web-telemetry.ts
@@ -46,7 +46,6 @@ interface WebTelemetryConfig {
     enabled: boolean;
     apiKey: string | null;
     apiHost: string;
-    sessionRecordingEnabled: boolean;
   };
 }
 
@@ -101,10 +100,6 @@ function getWebTelemetryConfig(): WebTelemetryConfig {
       apiHost:
         import.meta.env.VITE_PROLIFERATE_POSTHOG_HOST?.trim()
         || "https://us.i.posthog.com",
-      sessionRecordingEnabled: envFlagEnabled(
-        import.meta.env.VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED,
-        false,
-      ),
     },
   };
 }
@@ -326,15 +321,13 @@ function initializeWebPostHog(config: WebTelemetryConfig): void {
     capture_pageleave: false,
     person_profiles: "identified_only",
     before_send: scrubPostHogCapture,
-    disable_session_recording: !config.posthog.sessionRecordingEnabled,
-    session_recording: {
-      maskAllInputs: true,
-      maskTextSelector: "[data-telemetry-mask]",
-      blockSelector: "[data-telemetry-block]",
-      recordHeaders: false,
-      recordBody: false,
-      maskCapturedNetworkRequestFn: () => null,
-    },
+    // Source-disabled (CP-C1PW): no build value, environment value, or
+    // PostHog provider-side replay setting can start Web session recording.
+    // Re-enablement is a separate founder-approved source change that must
+    // first prove a synthetic route, masking, metadata, and provider-arrival
+    // contract. Do not add a recorder options object, a `loaded` callback, or
+    // any recorder start call here.
+    disable_session_recording: true,
   });
   posthog.register({
     app: "proliferate-web",

--- a/apps/web/src/browser/telemetry/telemetry-privacy.test.ts
+++ b/apps/web/src/browser/telemetry/telemetry-privacy.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
     capture: vi.fn(),
     identify: vi.fn(),
     reset: vi.fn(),
+    startSessionRecording: vi.fn(),
     get_distinct_id: vi.fn(() => "distinct-123"),
     get_session_id: vi.fn(() => "session-123"),
   },
@@ -86,7 +87,6 @@ describe("web telemetry privacy", () => {
     );
     vi.stubEnv("VITE_PROLIFERATE_SENTRY_TRACES_SAMPLE_RATE", "0.25");
     vi.stubEnv("VITE_PROLIFERATE_TELEMETRY_DISABLED", "false");
-    vi.stubEnv("VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED", "false");
   });
 
   afterEach(() => {
@@ -277,5 +277,82 @@ describe("web telemetry privacy", () => {
     expect(installWebTelemetry()).toEqual({});
     expect(mocks.sentryInit).not.toHaveBeenCalled();
     expect(mocks.posthog.init).not.toHaveBeenCalled();
+  });
+
+  it("keeps telemetry uninitialized when telemetry is disabled", async () => {
+    vi.stubEnv("VITE_PROLIFERATE_TELEMETRY_DISABLED", "true");
+    vi.resetModules();
+    const { installWebTelemetry } = await import("./install-web-telemetry");
+
+    expect(installWebTelemetry()).toEqual({});
+    expect(mocks.sentryInit).not.toHaveBeenCalled();
+    expect(mocks.posthog.init).not.toHaveBeenCalled();
+  });
+
+  it("still sends intentional product events with scrubbed properties", async () => {
+    vi.resetModules();
+    const { webProductTelemetry } = await import("./web-telemetry");
+
+    webProductTelemetry.track({
+      name: "workspace_opened",
+      properties: { surface: "web", email: EMAIL_SENTINEL },
+    } as Parameters<typeof webProductTelemetry.track>[0]);
+
+    expect(mocks.posthog.capture).toHaveBeenCalledOnce();
+    const [name, properties] = mocks.posthog.capture.mock.calls[0]!;
+    expect(name).toBe("workspace_opened");
+    expect(properties).toMatchObject({ surface: "web" });
+    expectNoPrivateSentinels(properties);
+  });
+
+  // CP-C1PW tombstone: `VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED` is
+  // retired. It survives only here, to prove every parser equivalence class of
+  // a legacy build value is inert. The source scan proves no runtime reader
+  // remains in app-owned code.
+  describe.each([
+    ["undefined", undefined],
+    ["empty", ""],
+    ["blank", "   "],
+    ["0", "0"],
+    ["false", "false"],
+    ["no", "no"],
+    ["off", "off"],
+    ["1", "1"],
+    ["true", "true"],
+    ["TRUE", "TRUE"],
+    ["padded yes", " yes "],
+    ["on", "on"],
+    ["-1", "-1"],
+    ["0.5", "0.5"],
+    ["2", "2"],
+    ["enabled", "enabled"],
+    ["malformed", "malformed"],
+  ])("retired recording variable = %s", (_label, value) => {
+    it("initializes PostHog fail-closed and never starts a recorder", async () => {
+      if (value !== undefined) {
+        vi.stubEnv("VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED", value);
+      }
+      vi.resetModules();
+      const { installWebTelemetry } = await import("./install-web-telemetry");
+      installWebTelemetry();
+
+      expect(mocks.posthog.init).toHaveBeenCalledOnce();
+      const options = mocks.posthog.init.mock.calls[0]![1] as Record<string, unknown>;
+      expect(options.disable_session_recording).toBe(true);
+      expect(options.autocapture).toBe(false);
+      expect(options.capture_pageview).toBe(false);
+      expect(options.capture_pageleave).toBe(false);
+      expect(Object.hasOwn(options, "session_recording")).toBe(false);
+      expect(Object.hasOwn(options, "loaded")).toBe(false);
+      expect(typeof options.before_send).toBe("function");
+      expect(mocks.posthog.startSessionRecording).not.toHaveBeenCalled();
+      expect(mocks.posthog.capture).not.toHaveBeenCalled();
+      expect(mocks.posthog.register).toHaveBeenCalledWith({
+        app: "proliferate-web",
+        surface: "web",
+        environment: "production",
+        release: "proliferate-web@1.2.3+abcdef123456",
+      });
+    });
   });
 });

--- a/guides/operating/analytics/posthog.md
+++ b/guides/operating/analytics/posthog.md
@@ -48,9 +48,10 @@ network requests in screenshots.
    - sign-out produces a new anonymous identity on the next session;
    - no prompt, transcript, repo name, file path, raw URL, terminal text,
      token, or raw error is present.
-5. Desktop replay is expected to be absent. Desktop PostHog session recording
-   is source-disabled, so any Desktop replay observed in the provider is a
-   code-or-provider truth mismatch to triage, not a gate to look for or enable.
+5. Desktop and Web replay are expected to be absent. Desktop and Web PostHog
+   session recording are source-disabled, so any Desktop or Web replay observed
+   in the provider is a code-or-provider truth mismatch to triage, not a gate to
+   look for or enable.
    Synthetic replay verification applies only to a surface whose reviewed
    source currently permits replay. For such a surface, verify input masking
    and block/mask selectors with synthetic data only, and inspect whether
@@ -67,7 +68,8 @@ network requests in screenshots.
   route/screen hook ran; raw paths are intentionally not capture values.
 - Replay missing on a surface whose source permits it: confirm that surface's
   separate replay gate. Mobile also needs the optional native replay package in
-  that build. Missing Desktop replay is the expected result, not a defect.
+  that build. Missing Desktop or Web replay is the expected result, not a
+  defect.
 - Provider data differs from checked-in behavior: capture event name, surface,
   environment, release, observed time, and a redacted provider URL. Route
   ingestion or deduplication defects to Issue Lifecycle.

--- a/specs/codebase/systems/engineering/analytics/README.md
+++ b/specs/codebase/systems/engineering/analytics/README.md
@@ -52,8 +52,8 @@ deduplication boundary.
 | Identity and data | Anonymous install UUIDs; authenticated user UUIDs for daily activity; low-cardinality route/screen, version, platform, telemetry mode, activation, usage, and aggregate provider facts. |
 | Destinations | The configured Proliferate Server/Postgres database, PostHog for enabled hosted clients, and an operator-selected read-only BI client such as Metabase. |
 | Enable, disable, or no-op | Vendor adapters require their client key and telemetry gates. Anonymous telemetry has build/runtime and Server disable gates. Provider ingestion skips a provider whose required configuration is absent. |
-| Privacy and replay | First-party payloads exclude prompts, transcripts, repo names, file paths, terminal text, raw URLs, errors, and secrets. Replay is off by default and its masking rules are owned by the PostHog contract. |
-| Known gaps | Web replay can still expose route ids through recorded page URLs when explicitly enabled; Desktop PostHog recording is source-disabled and Mobile has its own contract. Anonymous credential fields are accepted by the schema but currently have no Desktop emission directive. Live provider dashboards and data freshness are not enforced by repository code. |
+| Privacy and replay | First-party payloads exclude prompts, transcripts, repo names, file paths, terminal text, raw URLs, errors, and secrets. Desktop and Web recording are source-disabled; remaining replay is off by default and its masking rules are owned by the PostHog contract. |
+| Known gaps | Desktop and Web PostHog recording are source-disabled, so neither can expose route ids through recorded page URLs; Mobile has its own contract. Anonymous credential fields are accepted by the schema but currently have no Desktop emission directive. Live provider dashboards and data freshness are not enforced by repository code. |
 
 ## Operating Routes
 

--- a/specs/codebase/systems/engineering/analytics/posthog.md
+++ b/specs/codebase/systems/engineering/analytics/posthog.md
@@ -12,9 +12,9 @@ initialized by the Server API.
 | Source components | Desktop `apps/desktop/src/lib/integrations/telemetry/{client,config,posthog}.ts`; Web `apps/web/src/lib/integrations/telemetry/{config,posthog}.ts`; Mobile `apps/mobile/src/lib/integrations/telemetry/{config,posthog}.ts`. |
 | Identity and data | Distinct id is the authenticated user UUID, and identify calls send that UUID only with no email, display name, or other person properties. Captured data is the fixed event surface below plus scrubbed low-cardinality properties and registered app/surface/environment/release context. |
 | Destination | The configured PostHog host, defaulting to `https://us.i.posthog.com`. |
-| Enable, disable, or no-op | A missing API key makes each adapter inert. Web/Mobile also honor their public telemetry-disable setting; Desktop additionally requires hosted-product routing. Desktop recording is source-disabled; Web/Mobile replay has a separate false-by-default gate. |
-| Privacy and replay | Autocapture and automatic page views are off. Payload scrubbers remove sensitive values. Desktop recording is source-disabled and absent. Web replay is off by default and, when enabled, masks inputs and honors block/mask selectors; Mobile masks text, images, and sandboxed views. |
-| Known gap | When Web replay is explicitly enabled, recorded page metadata can contain route ids even though capture-event URL properties are stripped. Mobile replay also requires the optional native replay dependency in the build. |
+| Enable, disable, or no-op | A missing API key makes each adapter inert. Web/Mobile also honor their public telemetry-disable setting; Desktop additionally requires hosted-product routing. Desktop and Web recording are source-disabled; Mobile replay has a separate false-by-default gate. |
+| Privacy and replay | Autocapture and automatic page views are off. Payload scrubbers remove sensitive values. Desktop and Web recording are source-disabled and absent. Mobile replay is off by default and, when enabled, masks text, images, and sandboxed views. |
+| Known gap | Mobile replay requires the optional native replay dependency in the build, and when it is explicitly enabled its recorded metadata is governed by the Mobile contract below. Desktop and Web no longer carry a recorded page-URL route-id gap because neither can record. |
 
 ## Desktop
 
@@ -62,10 +62,13 @@ It disables autocapture and automatic pageview/pageleave capture. Before-send
 scrubbing removes URL-shaped PostHog properties including `$current_url`,
 `$pathname`, `$host`, `$referrer`, and `$referring_domain`.
 
-Web replay is disabled by default. When enabled, it masks inputs, honors the
-block/mask selectors, and does not record request headers or bodies. This does
-not remove the known rrweb page-URL gap described above. Sign-out calls
-`reset(true)`.
+Web session recording is source-disabled, not false-by-default. The Web source
+carries no recording flag, recording options object, `loaded` callback, or
+`startSessionRecording` call, and its PostHog initialization passes
+`disable_session_recording=true` unconditionally. No environment value, build
+setting, or PostHog provider-side replay setting can enable it. Re-enablement is
+a separate reviewed source change that must first prove a synthetic route,
+masking, metadata, and provider-arrival contract. Sign-out calls `reset(true)`.
 
 ## Mobile
 
@@ -92,7 +95,6 @@ Web:
 ```text
 VITE_PROLIFERATE_POSTHOG_KEY
 VITE_PROLIFERATE_POSTHOG_HOST
-VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED
 VITE_PROLIFERATE_TELEMETRY_DISABLED
 VITE_PROLIFERATE_ENVIRONMENT
 VITE_PROLIFERATE_RELEASE

--- a/specs/developing/reference/env-vars.yaml
+++ b/specs/developing/reference/env-vars.yaml
@@ -1145,12 +1145,6 @@
   description: Desktop/web PostHog ingest host
   tags: [local-dev, ci, desktop, web]
 
-- name: VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED
-  secret: false
-  default: "false"
-  description: Web PostHog session recording toggle (Web only; Desktop recording is source-disabled)
-  tags: [local-dev, ci, web]
-
 # ═══════════════════════════════════════════════════════════════════════
 # Mobile: Expo Public Build Vars
 # ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Makes Web PostHog **session recording impossible to enable through a build or environment value**. The Web host now passes `disable_session_recording: true` unconditionally, carries no recorder options object, no `loaded` callback, and no recorder start call. Re-enablement requires a separate founder-approved source PR with synthetic privacy qualification; changing a deployment variable is never sufficient.

Slice `CP-C1PW` of the Control Plane observability program. Semantic predecessor is `CP-C1PD` (Desktop, merged as `7a9bb9af273656fa2ff70eae43d14cb5d626f2b1`, PR #2093); this branch is based directly on that squash and preserves its landed Desktop truth.

## Privacy rationale

The pinned `posthog-js` 1.386.8 default config has `disable_session_recording: false`, and its recorder enables when server-side recording is on **and** `!config.disable_session_recording`. So simply deleting the environment read would inherit the unsafe SDK default. Hardcoding `true`, deleting every app-owned start path, and keeping the exact SDK pin together form the source-level fail-closed contract.

This PR does not claim the third-party package lacks replay code. It proves Proliferate's Web source has no configuration or call path that enables it.

## Scope (exactly seven files)

| File | Change |
| --- | --- |
| `apps/web/src/browser/telemetry/install-web-telemetry.ts` | Delete `WebTelemetryConfig.posthog.sessionRecordingEnabled` and its `VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED` read; hardcode `disable_session_recording: true`; delete the dormant `session_recording` options object |
| `apps/web/src/browser/telemetry/telemetry-privacy.test.ts` | Add the 17-row retired-variable tombstone matrix, a preserved intentional-capture test, and a telemetry-disabled no-init test |
| `apps/web/.env.example` | Delete the retired variable and its enablement comments (no commented compatibility setting left) |
| `specs/developing/reference/env-vars.yaml` | Delete the now-unowned catalog entry |
| `specs/codebase/systems/engineering/analytics/posthog.md` | Web section becomes source-disabled truth; Web configuration list drops the retired variable; table rows advance to Desktop-and-Web |
| `specs/codebase/systems/engineering/analytics/README.md` | Remove the resolved Desktop/Web route-id replay gap, preserving the anonymous-credential and live-provider gaps |
| `guides/operating/analytics/posthog.md` | Desktop **and Web** replay absence is the expected state, not a missing-signal incident |

Deliberately unchanged: `web-telemetry.ts`, `apps/web/package.json`, `pnpm-lock.yaml`, `vite.config.ts`, `vercel.json`, CI workflows, `specs/OBSERVABILITY.md`, `specs/frontend/telemetry.md`. No package, lockfile, or generated-artifact change.

Mobile keeps its separately named Expo replay variable and its own contract; `CP-C1PM` owns the eventual cross-platform wording reconciliation.

## Observability

- **Removed:** Web PostHog session recording enablement and its dormant recorder options.
- **Preserved:** intentional PostHog product capture, ID-only identity, sign-out `reset(true)`, support correlation references, release/environment registration, payload scrubbing, `autocapture: false`, `capture_pageview: false`, `capture_pageleave: false`, `person_profiles: "identified_only"`, `before_send`, and every Web Sentry signal (including `replaysSessionSampleRate: 0` / `replaysOnErrorSampleRate: 0`).
- **Expected state:** Web recording is absent by design, not degraded.
- **New signals:** none. This privacy reduction creates no product event, log, exception, metric, or delivery receipt.
- **Deferred proof:** a future re-enable PR must use synthetic sensitive content to prove route/surface blocking, input/text masking, metadata policy, absence of prompt/transcript/terminal/file/repository/path/token/workspace/session/workflow identifiers, and controlled provider arrival.

## Testing

The tombstone matrix feeds every relevant parser equivalence class under the retired exact name (`undefined`, `""`, `"   "`, `0/false/no/off`, `1/true/TRUE/" yes "/on`, `-1/0.5/2`, `enabled/malformed`), reloading the module between cases. For each row, with a configured key and telemetry enabled, it proves `posthog.init` is called exactly once, the options contain `disable_session_recording: true` plus the three `false` capture options, the options have **no own** `session_recording` or `loaded` property, the mock's `startSessionRecording` is never called, init emits no `posthog.capture`, and the registered app/surface/environment/release context is unchanged.

The retired name deliberately survives only in that test; the source scan proves no runtime reader remains.

### Proofs run locally (green)

```
python3 scripts/check_docs.py                                  # 234 Markdown files, passed
python3 scripts/check_frontend_boundaries.py                   # passed
python3 scripts/check_max_lines.py                             # passed
python3 scripts/report_frontend_structure.py --strict --summary-only   # TOTAL: 0
rg 'VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED' <test>  # present (tombstone only)
rg 'disable_session_recording: true' <installer>                # present
! rg <recording readers/calls/options> apps/web vercel.json .github/workflows   # no match
! rg <retired name> <the four doc/catalog owners>                              # no match
git diff --check                                               # clean
wc -l install-web-telemetry.ts   # 370 (gate ≤ 370)
wc -l telemetry-privacy.test.ts  # 358 (gate ≤ 360)
```

### Proofs skipped locally (machine gate)

Sustained `kern.memorystatus_vm_pressure_level: 2` (gate requires ≤ 1) blocked the Node proofs, so these were **not** run locally:

```
pnpm --filter @proliferate/web --fail-if-no-match exec vitest run src/browser/telemetry/telemetry-privacy.test.ts
pnpm web:typecheck
VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED=true pnpm web:build
! rg -a 'VITE_PROLIFERATE_POSTHOG_SESSION_RECORDING_ENABLED' apps/web/dist
```

**Coverage note for reviewers:** required CI runs `pnpm web:typecheck` and `pnpm web:build`, which covers the typecheck and the hostile-build proof. CI runs **no `apps/web` vitest job** — the only vitest invocations in `ci.yml` are two `@proliferate/product-client` filters. The focused `telemetry-privacy.test.ts` suite therefore needs a remote run arranged before merge; it is not covered by any required check.

## Not in scope

Desktop (CP-C1PD, landed) and Mobile (CP-C1PM) recording; Sentry replay or any Sentry change; PostHog event-catalog closure or destination changes; fail-soft SDK wrappers; removing or repinning `posthog-js`; global observability/frontend doctrine while Mobile retains its separate switch; any deploy, provider call, historical recording cleanup, or production canary.

## Reviewer flag (pre-existing, out of frozen scope)

`specs/codebase/systems/engineering/analytics/posthog.md` still lists the Web source components as `apps/web/src/lib/integrations/telemetry/{config,posthog}.ts`. That path no longer exists — the real owner is `apps/web/src/browser/telemetry/install-web-telemetry.ts`. This inaccuracy predates both CP-C1PD and this slice and is not a permitted change under the frozen scope, so it is flagged rather than fixed. It is a good candidate for CP-C1PM's cross-surface pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
