### PR TITLE
feat(product): safe transcript markdown file destinations (03A)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.test.tsx
@@ -119,6 +119,48 @@ describe("MarkdownBody presentation", () => {
     expect(html).not.toContain("(/tmp/project/config");
   });
 
+  it("repairs a settled local-file link in the render copy only", () => {
+    const source = "Open [notes](/repo/My Notes.md \"Read it\")";
+    const renderLink = vi.fn(({ href }: MarkdownLinkRenderInput) => (
+      <span data-workspace-file={href}>notes</span>
+    ));
+    const html = renderMarkdown(source, { renderLink });
+
+    expect(source).toBe("Open [notes](/repo/My Notes.md \"Read it\")");
+    expect(renderLink).toHaveBeenCalledWith(expect.objectContaining({
+      href: "/repo/My%20Notes.md",
+    }));
+    expect(html).toContain('data-workspace-file="/repo/My%20Notes.md"');
+  });
+
+  it("repairs a streaming local-file link after stabilizing it", () => {
+    const source = "Open [notes](/repo/My Notes.md";
+    const renderLink = vi.fn(({ href }: MarkdownLinkRenderInput) => (
+      <span data-workspace-file={href}>notes</span>
+    ));
+    const html = renderMarkdown(source, { isStreaming: true, renderLink });
+
+    expect(source).toBe("Open [notes](/repo/My Notes.md");
+    expect(html).toContain('data-workspace-file="/repo/My%20Notes.md"');
+  });
+
+  it.each([false, true])(
+    "runs neither transformation on the file-content surface (streaming: %s)",
+    (isStreaming) => {
+      const renderLink = vi.fn(() => null);
+      const html = renderMarkdown("Open [notes](/repo/My Notes.md \"Read it\")", {
+        surface: "file-content",
+        isStreaming,
+        renderLink,
+      });
+
+      // The viewer shows the file's own bytes: no repair, no synthetic close.
+      expect(html).toContain("(/repo/My Notes.md &quot;Read it&quot;)");
+      expect(renderLink).not.toHaveBeenCalled();
+      expect(html).not.toContain("%20");
+    },
+  );
+
   it("keeps content-search marks inside the presentation DOM", () => {
     const html = renderToStaticMarkup(
       <ChatContentSearchQueryContext.Provider value="readable">

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.tsx
@@ -19,6 +19,7 @@ import {
   ChatContentSearchQueryContext,
 } from "./ChatContentSearchContext";
 import { stabilizeStreamingMarkdown } from "#product/lib/domain/chat/transcript/streaming-markdown";
+import { repairTranscriptFileLinks } from "#product/lib/domain/chat/transcript/file-link-markdown";
 import { MarkdownRevealContext } from "./MarkdownRevealText";
 import {
   MarkdownCodeBlockContext,
@@ -161,10 +162,16 @@ export const MarkdownBody = memo(function MarkdownBody({
   enableContentSearch = false,
   surface = "message",
 }: MarkdownBodyProps) {
-  const parsedContent = useMemo(
-    () => (isStreaming ? stabilizeStreamingMarkdown(content) : content),
-    [content, isStreaming],
-  );
+  const parsedContent = useMemo(() => {
+    // A file viewer displays the file's own bytes: neither transformation may
+    // run there, settled or streaming. This bypass is explicit rather than an
+    // accident of which surface happens to pass isStreaming.
+    if (surface !== "message") return content;
+    // Render copy only. `content` is the authoritative transcript text and is
+    // never mutated; both passes are pure and return a new string.
+    const stabilized = isStreaming ? stabilizeStreamingMarkdown(content) : content;
+    return repairTranscriptFileLinks(stabilized);
+  }, [content, isStreaming, surface]);
   const markdownClassName = [
     // Single measure: the thread column (config/chat-layout.ts) uses the same 48rem
     // --container-transcript-thread token as the new-chat flow, and BOTH

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.tsx
@@ -1,15 +1,7 @@
 import {
-  Children,
-  cloneElement,
-  createContext,
-  createElement,
-  isValidElement,
   memo,
   useContext,
   useMemo,
-  type ContextType,
-  type HTMLAttributes,
-  type ReactElement,
   type ReactNode,
 } from "react";
 import ReactMarkdown from "react-markdown";
@@ -25,16 +17,15 @@ import {
 } from "./MarkdownInlineCode";
 import {
   ChatContentSearchQueryContext,
-  useChatContentSearchPaint,
-  type ChatContentSearchPaint,
 } from "./ChatContentSearchContext";
-import { markSearchChildren } from "./MarkdownContentSearchMarks";
 import { stabilizeStreamingMarkdown } from "#product/lib/domain/chat/transcript/streaming-markdown";
+import { MarkdownRevealContext } from "./MarkdownRevealText";
 import {
-  type HastNode,
-  MarkdownRevealContext,
-  revealChildren,
-} from "./MarkdownRevealText";
+  MarkdownCodeBlockContext,
+  STATIC_MARKDOWN_COMPONENTS,
+  type MdElementProps,
+} from "./MarkdownHtmlElement";
+import { GridTaskListItem } from "./MarkdownTaskListItem";
 
 interface MarkdownBodyProps {
   content: string;
@@ -101,124 +92,11 @@ export type MarkdownCodeBlockRenderer = (
   input: MarkdownCodeBlockRenderInput,
 ) => ReactNode | null | undefined;
 
-type MdElementProps = HTMLAttributes<HTMLElement> & {
-  node?: unknown;
-};
-
-type MdTag =
-  | "blockquote"
-  | "del"
-  | "em"
-  | "h1"
-  | "h2"
-  | "h3"
-  | "h4"
-  | "h5"
-  | "h6"
-  | "li"
-  | "ol"
-  | "p"
-  | "strong"
-  | "table"
-  | "td"
-  | "th"
-  | "ul";
-
 type MdCodeProps = MdElementProps & {
   children?: ReactNode;
   className?: string;
   renderInlineCode?: MarkdownInlineCodeRenderer;
   renderCodeBlock?: MarkdownCodeBlockRenderer;
-};
-
-const MarkdownCodeBlockContext = createContext(false);
-
-// Message prose reads at --prose-text-size, which the assistant/user message
-// wrappers set to --text-message (the composer size). Every other MarkdownBody
-// context — tool-row detail bodies, plan cards, work history — leaves the var
-// unset, so the fallback keeps that secondary chrome on --text-chat while
-// conversation bodies grow to match the composer. Authenticated CSS owns the
-// scoped font-size and line-height so chat rules stay out of the login bundle.
-const LI_CLASSNAME = "pl-0.5";
-// Prose elements (paragraphs, headings, lists, blockquotes) fill the full
-// shared 40rem thread column — the same width as wide blocks (tables, code),
-// the composer below, and the new-chat flow — so the measure does not change
-// when a session starts. See the single-measure note on `markdownClassName`.
-const PROSE_MEASURE_CLASSNAME = "max-w-full";
-
-// Markdown component overrides are the React element *types* for every
-// rendered node. They must be referentially stable across renders: a fresh
-// arrow function per render is a new component type, which makes React
-// unmount and remount the whole markdown DOM (visible as transcript jumps
-// while streams/sends re-render rows).
-
-// Factory: creates a stable component that reads the search context and
-// delegates without rebuilding the components map (see the identity comment).
-function mdComponent(tag: MdTag, className: string) {
-  return (props: MdElementProps) => {
-    const revealState = useContext(MarkdownRevealContext);
-    const searchPaint = useChatContentSearchPaint();
-    return mdHtmlElement(tag, className, props, revealState, searchPaint);
-  };
-}
-
-const STATIC_MARKDOWN_COMPONENTS = {
-  h1: mdComponent("h1", `mb-2.5 mt-5 ${PROSE_MEASURE_CLASSNAME} text-title font-semibold text-foreground`),
-  h2: mdComponent("h2", `mb-2.5 mt-5 ${PROSE_MEASURE_CLASSNAME} text-heading font-semibold text-foreground`),
-  h3: mdComponent("h3", `mb-2.5 mt-5 ${PROSE_MEASURE_CLASSNAME} text-body-emphasis font-semibold text-foreground`),
-  h4: mdComponent("h4", `mb-2 mt-4 ${PROSE_MEASURE_CLASSNAME} text-body-emphasis font-semibold text-foreground`),
-  h5: mdComponent("h5", `mb-1.5 mt-4 ${PROSE_MEASURE_CLASSNAME} font-semibold uppercase tracking-wide text-muted-foreground`),
-  h6: mdComponent("h6", `mb-1.5 mt-4 ${PROSE_MEASURE_CLASSNAME} font-semibold uppercase tracking-wide text-muted-foreground`),
-  strong: mdComponent("strong", "font-semibold"),
-  em: mdComponent("em", "italic"),
-  del: mdComponent("del", "line-through"),
-  p: mdComponent("p", `mb-[0.6875rem] mt-0 ${PROSE_MEASURE_CLASSNAME} text-foreground`),
-  ul: mdComponent("ul", `mb-[0.6875rem] mt-0 ${PROSE_MEASURE_CLASSNAME} list-disc pl-[1.3125rem] text-foreground [&>li+li]:mt-2`),
-  ol: mdComponent("ol", `mb-[0.6875rem] mt-0 ${PROSE_MEASURE_CLASSNAME} list-decimal pl-[1.3125rem] text-foreground [&>li+li]:mt-2`),
-  li: mdComponent("li", LI_CLASSNAME),
-  blockquote: mdComponent("blockquote", `my-3 ${PROSE_MEASURE_CLASSNAME} border-l-4 border-border pl-6 py-2 text-foreground`),
-  hr: () => <hr className="my-3 border-border" />,
-  table: (props: MdElementProps) => (
-    // ui-foundation-escalation: [CHAT-04]'s RULED block adopts
-    // --container-transcript-wide (56rem) for wide blocks like this table.
-    // This table uses the full 48rem --container-transcript-thread column
-    // (like all prose — see markdownClassName), but 56rem exceeds that column
-    // — reaching it would need a breakout (negative-margin / container-
-    // query) restructure applied at every MarkdownBody consumer (transcript
-    // rows, plan cards, tool-detail panels). That restructure is out of
-    // scope for this pass; this table stays at max-w-full
-    // (container-relative to the 48rem shared chat column) as a conscious
-    // partial adoption rather than an unreachable cap.
-    <div
-      className="my-4 min-w-0 max-w-full overflow-hidden rounded-lg border"
-      data-markdown-table-shell="true"
-      data-wide-markdown-block="true"
-      data-wide-markdown-block-kind="table"
-    >
-      <div
-        className="max-w-full overflow-x-auto overscroll-x-none"
-        data-markdown-table-scroll="true"
-      >
-        {mdHtmlElement(
-          "table",
-          "w-max min-w-full max-w-none border-collapse [&_tbody_tr:nth-child(2n)]:bg-surface-elevated-secondary [&_tbody_tr:last-child_td]:border-b-0",
-          props,
-        )}
-      </div>
-    </div>
-  ),
-  th: mdComponent("th", "border-b bg-surface-elevated-secondary px-3 py-2 text-left font-medium text-foreground"),
-  td: mdComponent("td", "border-b px-3 py-2 align-top"),
-  pre: ({ children, dangerouslySetInnerHTML, node: _node, ...rest }: MdElementProps & { children?: ReactNode }) => {
-    if (dangerouslySetInnerHTML) {
-      return <pre {...rest} dangerouslySetInnerHTML={dangerouslySetInnerHTML} />;
-    }
-    return (
-      <MarkdownCodeBlockContext.Provider value>
-        {children}
-      </MarkdownCodeBlockContext.Provider>
-    );
-  },
 };
 
 function createMarkdownAnchor(renderLink: MarkdownLinkRenderer | undefined) {
@@ -268,89 +146,6 @@ function createMarkdownAnchor(renderLink: MarkdownLinkRenderer | undefined) {
       </a>
     );
   };
-}
-
-// Plan-view task-list grid: checkbox column sized auto, content column
-// minmax(0,1fr). react-markdown emits tight task items as
-// `li > input + <inline content>` (and loose ones with the input inside the
-// leading <p>), so a pure-CSS grid would scatter the inline runs across
-// cells; instead the item is restructured into checkbox + content wrapper.
-function GridTaskListItem(props: MdElementProps & { children?: ReactNode }) {
-  const { children, dangerouslySetInnerHTML, className, node: _node, ...rest } = props;
-  const isTaskListItem =
-    typeof className === "string" && className.includes("task-list-item");
-  const split = isTaskListItem && !dangerouslySetInnerHTML
-    ? splitTaskListItemChildren(children)
-    : null;
-  if (!split) {
-    return mdHtmlElement("li", LI_CLASSNAME, props);
-  }
-  const mergedClassName = [
-    LI_CLASSNAME,
-    "grid grid-cols-[auto_minmax(0,1fr)]",
-    className,
-  ].filter(Boolean).join(" ");
-  return (
-    <li {...rest} className={mergedClassName}>
-      {cloneElement(split.checkbox, {
-        // Nudge: drop the checkbox 0.25rem so it optically centers on
-        // the first text line.
-        className: [split.checkbox.props.className, "mt-1"].filter(Boolean).join(" "),
-      })}
-      <div className="min-w-0">{split.content}</div>
-    </li>
-  );
-}
-
-interface SplitTaskListItem {
-  checkbox: ReactElement<{ className?: string }>;
-  content: ReactNode[];
-}
-
-function splitTaskListItemChildren(children: ReactNode): SplitTaskListItem | null {
-  const nodes = Children.toArray(children);
-  // Tight items: the checkbox input is a direct child of the <li>.
-  const inputIndex = nodes.findIndex(isCheckboxElement);
-  if (inputIndex >= 0) {
-    return {
-      checkbox: nodes[inputIndex] as SplitTaskListItem["checkbox"],
-      content: [...nodes.slice(0, inputIndex), ...nodes.slice(inputIndex + 1)],
-    };
-  }
-  // Loose items: the checkbox sits at the head of the leading paragraph.
-  const paragraphIndex = nodes.findIndex(
-    (node) => isValidElement(node) && hastTagName(node) === "p",
-  );
-  if (paragraphIndex < 0) {
-    return null;
-  }
-  const paragraph = nodes[paragraphIndex] as ReactElement<{ children?: ReactNode }>;
-  const paragraphChildren = Children.toArray(paragraph.props.children);
-  const nestedInputIndex = paragraphChildren.findIndex(isCheckboxElement);
-  if (nestedInputIndex < 0) {
-    return null;
-  }
-  const strippedParagraph = cloneElement(paragraph, undefined, ...[
-    ...paragraphChildren.slice(0, nestedInputIndex),
-    ...paragraphChildren.slice(nestedInputIndex + 1),
-  ]);
-  return {
-    checkbox: paragraphChildren[nestedInputIndex] as SplitTaskListItem["checkbox"],
-    content: [
-      ...nodes.slice(0, paragraphIndex),
-      strippedParagraph,
-      ...nodes.slice(paragraphIndex + 1),
-    ],
-  };
-}
-
-function isCheckboxElement(node: ReactNode): boolean {
-  return isValidElement(node) && node.type === "input";
-}
-
-function hastTagName(node: ReactElement): string | null {
-  const hast = (node.props as { node?: { tagName?: unknown } }).node;
-  return typeof hast?.tagName === "string" ? hast.tagName : null;
 }
 
 export const MarkdownBody = memo(function MarkdownBody({
@@ -489,37 +284,4 @@ function markdownUrlTransform(value: string): string {
     return "";
   }
   return value;
-}
-
-// Re-export for downstream consumers that import from this module.
-
-// mdHtmlElement is called from within STATIC_MARKDOWN_COMPONENTS entries,
-// which ARE React component functions (hooks-valid call site).
-function mdHtmlElement(
-  tag: MdTag,
-  baseClassName: string,
-  props: MdElementProps,
-  revealState: ContextType<typeof MarkdownRevealContext> = null,
-  searchPaint: ChatContentSearchPaint | null = null,
-) {
-  const {
-    children,
-    dangerouslySetInnerHTML,
-    className,
-    node,
-    ...rest
-  } = props;
-  const mergedClassName = [baseClassName, className].filter(Boolean).join(" ");
-
-  if (dangerouslySetInnerHTML) {
-    return createElement(tag, {
-      ...rest,
-      className: mergedClassName,
-      dangerouslySetInnerHTML,
-    });
-  }
-  const finalChildren = searchPaint
-    ? markSearchChildren(children, searchPaint.query, searchPaint.rowUnitId)
-    : revealChildren(children, node as HastNode | undefined, revealState);
-  return createElement(tag, { ...rest, className: mergedClassName }, finalChildren);
 }

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownHtmlElement.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownHtmlElement.tsx
@@ -1,0 +1,162 @@
+import {
+  createContext,
+  createElement,
+  useContext,
+  type ContextType,
+  type HTMLAttributes,
+  type ReactNode,
+} from "react";
+import {
+  useChatContentSearchPaint,
+  type ChatContentSearchPaint,
+} from "./ChatContentSearchContext";
+import { markSearchChildren } from "./MarkdownContentSearchMarks";
+import {
+  type HastNode,
+  MarkdownRevealContext,
+  revealChildren,
+} from "./MarkdownRevealText";
+
+export type MdElementProps = HTMLAttributes<HTMLElement> & {
+  node?: unknown;
+};
+
+export type MdTag =
+  | "blockquote"
+  | "del"
+  | "em"
+  | "h1"
+  | "h2"
+  | "h3"
+  | "h4"
+  | "h5"
+  | "h6"
+  | "li"
+  | "ol"
+  | "p"
+  | "strong"
+  | "table"
+  | "td"
+  | "th"
+  | "ul";
+
+export const MarkdownCodeBlockContext = createContext(false);
+
+// Message prose reads at --prose-text-size, which the assistant/user message
+// wrappers set to --text-message (the composer size). Every other MarkdownBody
+// context — tool-row detail bodies, plan cards, work history — leaves the var
+// unset, so the fallback keeps that secondary chrome on --text-chat while
+// conversation bodies grow to match the composer. Authenticated CSS owns the
+// scoped font-size and line-height so chat rules stay out of the login bundle.
+export const LI_CLASSNAME = "pl-0.5";
+// Prose elements (paragraphs, headings, lists, blockquotes) fill the full
+// shared 40rem thread column — the same width as wide blocks (tables, code),
+// the composer below, and the new-chat flow — so the measure does not change
+// when a session starts. See the single-measure note on `markdownClassName`.
+export const PROSE_MEASURE_CLASSNAME = "max-w-full";
+
+// Markdown component overrides are the React element *types* for every
+// rendered node. They must be referentially stable across renders: a fresh
+// arrow function per render is a new component type, which makes React
+// unmount and remount the whole markdown DOM (visible as transcript jumps
+// while streams/sends re-render rows).
+
+// Factory: creates a stable component that reads the search context and
+// delegates without rebuilding the components map (see the identity comment).
+function mdComponent(tag: MdTag, className: string) {
+  return (props: MdElementProps) => {
+    const revealState = useContext(MarkdownRevealContext);
+    const searchPaint = useChatContentSearchPaint();
+    return mdHtmlElement(tag, className, props, revealState, searchPaint);
+  };
+}
+
+export const STATIC_MARKDOWN_COMPONENTS = {
+  h1: mdComponent("h1", `mb-2.5 mt-5 ${PROSE_MEASURE_CLASSNAME} text-title font-semibold text-foreground`),
+  h2: mdComponent("h2", `mb-2.5 mt-5 ${PROSE_MEASURE_CLASSNAME} text-heading font-semibold text-foreground`),
+  h3: mdComponent("h3", `mb-2.5 mt-5 ${PROSE_MEASURE_CLASSNAME} text-body-emphasis font-semibold text-foreground`),
+  h4: mdComponent("h4", `mb-2 mt-4 ${PROSE_MEASURE_CLASSNAME} text-body-emphasis font-semibold text-foreground`),
+  h5: mdComponent("h5", `mb-1.5 mt-4 ${PROSE_MEASURE_CLASSNAME} font-semibold uppercase tracking-wide text-muted-foreground`),
+  h6: mdComponent("h6", `mb-1.5 mt-4 ${PROSE_MEASURE_CLASSNAME} font-semibold uppercase tracking-wide text-muted-foreground`),
+  strong: mdComponent("strong", "font-semibold"),
+  em: mdComponent("em", "italic"),
+  del: mdComponent("del", "line-through"),
+  p: mdComponent("p", `mb-[0.6875rem] mt-0 ${PROSE_MEASURE_CLASSNAME} text-foreground`),
+  ul: mdComponent("ul", `mb-[0.6875rem] mt-0 ${PROSE_MEASURE_CLASSNAME} list-disc pl-[1.3125rem] text-foreground [&>li+li]:mt-2`),
+  ol: mdComponent("ol", `mb-[0.6875rem] mt-0 ${PROSE_MEASURE_CLASSNAME} list-decimal pl-[1.3125rem] text-foreground [&>li+li]:mt-2`),
+  li: mdComponent("li", LI_CLASSNAME),
+  blockquote: mdComponent("blockquote", `my-3 ${PROSE_MEASURE_CLASSNAME} border-l-4 border-border pl-6 py-2 text-foreground`),
+  hr: () => <hr className="my-3 border-border" />,
+  table: (props: MdElementProps) => (
+    // ui-foundation-escalation: [CHAT-04]'s RULED block adopts
+    // --container-transcript-wide (56rem) for wide blocks like this table.
+    // This table uses the full 48rem --container-transcript-thread column
+    // (like all prose — see markdownClassName), but 56rem exceeds that column
+    // — reaching it would need a breakout (negative-margin / container-
+    // query) restructure applied at every MarkdownBody consumer (transcript
+    // rows, plan cards, tool-detail panels). That restructure is out of
+    // scope for this pass; this table stays at max-w-full
+    // (container-relative to the 48rem shared chat column) as a conscious
+    // partial adoption rather than an unreachable cap.
+    <div
+      className="my-4 min-w-0 max-w-full overflow-hidden rounded-lg border"
+      data-markdown-table-shell="true"
+      data-wide-markdown-block="true"
+      data-wide-markdown-block-kind="table"
+    >
+      <div
+        className="max-w-full overflow-x-auto overscroll-x-none"
+        data-markdown-table-scroll="true"
+      >
+        {mdHtmlElement(
+          "table",
+          "w-max min-w-full max-w-none border-collapse [&_tbody_tr:nth-child(2n)]:bg-surface-elevated-secondary [&_tbody_tr:last-child_td]:border-b-0",
+          props,
+        )}
+      </div>
+    </div>
+  ),
+  th: mdComponent("th", "border-b bg-surface-elevated-secondary px-3 py-2 text-left font-medium text-foreground"),
+  td: mdComponent("td", "border-b px-3 py-2 align-top"),
+  pre: ({ children, dangerouslySetInnerHTML, node: _node, ...rest }: MdElementProps & { children?: ReactNode }) => {
+    if (dangerouslySetInnerHTML) {
+      return <pre {...rest} dangerouslySetInnerHTML={dangerouslySetInnerHTML} />;
+    }
+    return (
+      <MarkdownCodeBlockContext.Provider value>
+        {children}
+      </MarkdownCodeBlockContext.Provider>
+    );
+  },
+};
+
+// mdHtmlElement is called from within STATIC_MARKDOWN_COMPONENTS entries,
+// which ARE React component functions (hooks-valid call site).
+export function mdHtmlElement(
+  tag: MdTag,
+  baseClassName: string,
+  props: MdElementProps,
+  revealState: ContextType<typeof MarkdownRevealContext> = null,
+  searchPaint: ChatContentSearchPaint | null = null,
+) {
+  const {
+    children,
+    dangerouslySetInnerHTML,
+    className,
+    node,
+    ...rest
+  } = props;
+  const mergedClassName = [baseClassName, className].filter(Boolean).join(" ");
+
+  if (dangerouslySetInnerHTML) {
+    return createElement(tag, {
+      ...rest,
+      className: mergedClassName,
+      dangerouslySetInnerHTML,
+    });
+  }
+  const finalChildren = searchPaint
+    ? markSearchChildren(children, searchPaint.query, searchPaint.rowUnitId)
+    : revealChildren(children, node as HastNode | undefined, revealState);
+  return createElement(tag, { ...rest, className: mergedClassName }, finalChildren);
+}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownTaskListItem.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownTaskListItem.tsx
@@ -1,0 +1,91 @@
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { LI_CLASSNAME, mdHtmlElement, type MdElementProps } from "./MarkdownHtmlElement";
+
+// Plan-view task-list grid: checkbox column sized auto, content column
+// minmax(0,1fr). react-markdown emits tight task items as
+// `li > input + <inline content>` (and loose ones with the input inside the
+// leading <p>), so a pure-CSS grid would scatter the inline runs across
+// cells; instead the item is restructured into checkbox + content wrapper.
+export function GridTaskListItem(props: MdElementProps & { children?: ReactNode }) {
+  const { children, dangerouslySetInnerHTML, className, node: _node, ...rest } = props;
+  const isTaskListItem =
+    typeof className === "string" && className.includes("task-list-item");
+  const split = isTaskListItem && !dangerouslySetInnerHTML
+    ? splitTaskListItemChildren(children)
+    : null;
+  if (!split) {
+    return mdHtmlElement("li", LI_CLASSNAME, props);
+  }
+  const mergedClassName = [
+    LI_CLASSNAME,
+    "grid grid-cols-[auto_minmax(0,1fr)]",
+    className,
+  ].filter(Boolean).join(" ");
+  return (
+    <li {...rest} className={mergedClassName}>
+      {cloneElement(split.checkbox, {
+        // Nudge: drop the checkbox 0.25rem so it optically centers on
+        // the first text line.
+        className: [split.checkbox.props.className, "mt-1"].filter(Boolean).join(" "),
+      })}
+      <div className="min-w-0">{split.content}</div>
+    </li>
+  );
+}
+
+interface SplitTaskListItem {
+  checkbox: ReactElement<{ className?: string }>;
+  content: ReactNode[];
+}
+
+function splitTaskListItemChildren(children: ReactNode): SplitTaskListItem | null {
+  const nodes = Children.toArray(children);
+  // Tight items: the checkbox input is a direct child of the <li>.
+  const inputIndex = nodes.findIndex(isCheckboxElement);
+  if (inputIndex >= 0) {
+    return {
+      checkbox: nodes[inputIndex] as SplitTaskListItem["checkbox"],
+      content: [...nodes.slice(0, inputIndex), ...nodes.slice(inputIndex + 1)],
+    };
+  }
+  // Loose items: the checkbox sits at the head of the leading paragraph.
+  const paragraphIndex = nodes.findIndex(
+    (node) => isValidElement(node) && hastTagName(node) === "p",
+  );
+  if (paragraphIndex < 0) {
+    return null;
+  }
+  const paragraph = nodes[paragraphIndex] as ReactElement<{ children?: ReactNode }>;
+  const paragraphChildren = Children.toArray(paragraph.props.children);
+  const nestedInputIndex = paragraphChildren.findIndex(isCheckboxElement);
+  if (nestedInputIndex < 0) {
+    return null;
+  }
+  const strippedParagraph = cloneElement(paragraph, undefined, ...[
+    ...paragraphChildren.slice(0, nestedInputIndex),
+    ...paragraphChildren.slice(nestedInputIndex + 1),
+  ]);
+  return {
+    checkbox: paragraphChildren[nestedInputIndex] as SplitTaskListItem["checkbox"],
+    content: [
+      ...nodes.slice(0, paragraphIndex),
+      strippedParagraph,
+      ...nodes.slice(paragraphIndex + 1),
+    ],
+  };
+}
+
+function isCheckboxElement(node: ReactNode): boolean {
+  return isValidElement(node) && node.type === "input";
+}
+
+function hastTagName(node: ReactElement): string | null {
+  const hast = (node.props as { node?: { tagName?: unknown } }).node;
+  return typeof hast?.tagName === "string" ? hast.tagName : null;
+}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptTurnRow.test.tsx
@@ -12,6 +12,7 @@ import {
   shouldHoldAssistantRevealFrontier,
 } from "#product/hooks/chat/ui/use-assistant-reveal-frontier";
 import { resolveCompletedHistoryDisclosureLabel } from "#product/components/workspace/chat/transcript/TranscriptTurnChrome";
+import { resolveAssistantMarkdownEndResource } from "#product/lib/domain/chat/assistant-markdown-end-resource";
 
 describe("resolveTranscriptTurnDiffPanelKind", () => {
   it("uses current git diffs only for the latest completed turn row", () => {
@@ -166,6 +167,23 @@ describe("assistant end resource placement", () => {
       visualTurnCompleted: true,
       hasResource: true,
     })).toBe(true);
+  });
+
+  it("never turns a synthetic streaming closure into a card", () => {
+    // The row calls the extractor on the raw tail content and gates the render
+    // on visual turn completion. Streaming stabilization is a MarkdownBody
+    // render-copy concern and never reaches the extractor, so an unterminated
+    // tail yields no resource at all — the gate is not the only thing standing
+    // between a half-written destination and a card.
+    const streamingTail = "The result is [decision](/repo/specs/My Decision.md";
+    expect(resolveAssistantMarkdownEndResource(streamingTail)).toBeNull();
+    expect(shouldRenderAssistantEndResource({
+      rowIsLastTurnRow: true,
+      visualTurnCompleted: false,
+      hasResource: resolveAssistantMarkdownEndResource(streamingTail) !== null,
+    })).toBe(false);
+    expect(resolveAssistantMarkdownEndResource(`${streamingTail})`)?.path)
+      .toBe("/repo/specs/My Decision.md");
   });
 });
 

--- a/apps/packages/product-client/src/lib/domain/chat/assistant-markdown-end-resource.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/assistant-markdown-end-resource.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { resolveAssistantMarkdownEndResource } from "#product/lib/domain/chat/assistant-markdown-end-resource";
+import {
+  repairTranscriptFileLinks,
+  stabilizeStreamingFileLink,
+} from "#product/lib/domain/chat/transcript/file-link-markdown";
 
 describe("resolveAssistantMarkdownEndResource", () => {
   it("selects the final unique Markdown file reference", () => {
+    // `Final%20Decision.md:42` still resolves to a space-bearing name, but for
+    // a different reason than it used to: the shared raw-reference decoder does
+    // one case-insensitive `%20` pass, not `decodeURIComponent`.
     expect(resolveAssistantMarkdownEndResource([
       "See [the implementation](/repo/src/app.ts:12).",
       "Read [the spec](/repo/specs/first.md:8).",
@@ -23,6 +30,11 @@ describe("resolveAssistantMarkdownEndResource", () => {
       "```md",
       "[also fake](also-fake.md)",
       "```",
+      "~~~",
+      "[tilde fake](tilde-fake.md)",
+      "~~~",
+      "",
+      "    [indented fake](indented-fake.md)",
     ].join("\n"))).toBeNull();
   });
 
@@ -30,5 +42,58 @@ describe("resolveAssistantMarkdownEndResource", () => {
     expect(resolveAssistantMarkdownEndResource("[guide](docs/guide.mdx)")?.displayName)
       .toBe("guide.mdx");
     expect(resolveAssistantMarkdownEndResource("[source](src/app.ts)")).toBeNull();
+  });
+
+  it("matches .md/.mdx case-insensitively on the exact decoded path", () => {
+    expect(resolveAssistantMarkdownEndResource("[a](/repo/Notes.MD)")?.path)
+      .toBe("/repo/Notes.MD");
+    expect(resolveAssistantMarkdownEndResource("[a](/repo/Notes.MdX:3)")?.path)
+      .toBe("/repo/Notes.MdX");
+  });
+
+  it("reads the same repaired destination the inline mention renders", () => {
+    const source = "Result: [decision](/repo/specs/My Decision.md \"Read it\")";
+    expect(repairTranscriptFileLinks(source))
+      .toBe("Result: [decision](</repo/specs/My%20Decision.md> \"Read it\")");
+    expect(resolveAssistantMarkdownEndResource(source)).toMatchObject({
+      path: "/repo/specs/My Decision.md",
+      displayName: "My Decision.md",
+    });
+  });
+
+  it("keeps encoded separators literal instead of reinterpreting them", () => {
+    expect(resolveAssistantMarkdownEndResource("[a](/repo/a%2Fb.md)")?.path)
+      .toBe("/repo/a%2Fb.md");
+    expect(resolveAssistantMarkdownEndResource("[a](/repo/%2E%2E/secret.md)")?.path)
+      .toBe("/repo/%2E%2E/secret.md");
+  });
+
+  it("treats ? and # as literal path characters rather than delimiters", () => {
+    expect(resolveAssistantMarkdownEndResource("[a](/repo/What is it?.md)")?.path)
+      .toBe("/repo/What is it?.md");
+    expect(resolveAssistantMarkdownEndResource("[a](/repo/notes.md#section)")).toBeNull();
+    expect(resolveAssistantMarkdownEndResource("[a](#section)")).toBeNull();
+  });
+
+  it("returns the last newly encountered unique document", () => {
+    expect(resolveAssistantMarkdownEndResource([
+      "[first](/repo/one.md)",
+      "[second](/repo/two.md)",
+      "[first again](/repo/one.md)",
+    ].join("\n\n"))?.path).toBe("/repo/two.md");
+  });
+
+  it("produces no card for an incomplete or malformed link", () => {
+    expect(resolveAssistantMarkdownEndResource("[a](/repo/notes.md")).toBeNull();
+    expect(resolveAssistantMarkdownEndResource("[a](/repo/My Notes.md \"unclosed")).toBeNull();
+  });
+
+  it("never consumes a synthetic streaming closure", () => {
+    const streaming = "The result is [decision](/repo/specs/My Decision.md";
+    expect(stabilizeStreamingFileLink(streaming))
+      .toBe("The result is [decision](/repo/specs/My Decision.md)");
+    // Extraction reads the settled source, so the tail yields no card until the
+    // author's own `)` arrives.
+    expect(resolveAssistantMarkdownEndResource(streaming)).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/lib/domain/chat/assistant-markdown-end-resource.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/assistant-markdown-end-resource.ts
@@ -1,7 +1,13 @@
 import {
+  repairTranscriptFileLinks,
+  scanTranscriptMarkdownLinks,
+  unescapeMarkdownDestination,
+} from "#product/lib/domain/chat/transcript/file-link-markdown";
+import {
   looksLikeFileReferenceHref,
   splitPathLineSuffix,
 } from "#product/lib/domain/files/path-detection";
+import { decodeFileReferenceSpaces } from "#product/lib/domain/files/path-references";
 
 export interface AssistantMarkdownEndResource {
   rawPath: string;
@@ -10,68 +16,53 @@ export interface AssistantMarkdownEndResource {
   typeLabel: "Document · MD";
 }
 
-const MARKDOWN_LINK_DESTINATION = /(!?)\[[^\]]*\]\(\s*(?:<([^>]+)>|((?:\\.|[^\s)])+))/g;
-
 /**
  * Resolve the last unique Markdown document linked by final assistant prose.
  * This is render-time presentation data, matching inline file-mention
  * ownership: nothing is persisted back into transcript state.
+ *
+ * It reads the same settled repaired copy and the same complete-balanced-link
+ * scan the inline mentions render from, so the card and the prose can never
+ * disagree about which document was named. It never runs streaming
+ * stabilization, so a synthetic closing delimiter can never produce a card.
+ *
+ * Decoding is the shared raw-reference `%20` rule and nothing more: encoded
+ * separators and traversal stay literal, and `?`/`#` are literal path
+ * characters rather than URL delimiters, so the card cannot be steered to a
+ * different target than the link text names.
  */
 export function resolveAssistantMarkdownEndResource(
   markdown: string | null | undefined,
 ): AssistantMarkdownEndResource | null {
   if (!markdown) return null;
 
-  const visibleMarkdown = stripMarkdownCode(markdown);
   const seen = new Set<string>();
   let resolved: AssistantMarkdownEndResource | null = null;
 
-  for (const match of visibleMarkdown.matchAll(MARKDOWN_LINK_DESTINATION)) {
-    if (match[1] === "!") continue;
-    const escapedDestination = match[2] ?? match[3] ?? "";
-    const rawPath = unescapeMarkdownDestination(escapedDestination.trim());
+  for (const link of scanTranscriptMarkdownLinks(repairTranscriptFileLinks(markdown))) {
+    if (link.isImage) continue;
+    const rawPath = decodeFileReferenceSpaces(
+      unescapeMarkdownDestination(link.destination).trim(),
+    );
     if (!looksLikeFileReferenceHref(rawPath)) continue;
 
-    const destinationPath = stripQueryAndFragment(rawPath);
-    const { path: pathWithoutLine } = splitPathLineSuffix(destinationPath);
-    const displayPath = safelyDecodePath(pathWithoutLine);
-    if (!/\.mdx?$/i.test(displayPath)) continue;
+    const { path } = splitPathLineSuffix(rawPath);
+    // Case-insensitive, and on the exact decoded path — never on a stripped or
+    // separately decoded variant.
+    if (!/\.mdx?$/i.test(path)) continue;
 
-    const key = displayPath.replace(/\\/g, "/");
+    const key = path.replace(/\\/g, "/");
     if (seen.has(key)) continue;
     seen.add(key);
     resolved = {
-      rawPath: safelyDecodePath(rawPath),
-      path: displayPath,
-      displayName: basename(displayPath),
+      rawPath,
+      path,
+      displayName: basename(path),
       typeLabel: "Document · MD",
     };
   }
 
   return resolved;
-}
-
-function stripMarkdownCode(markdown: string): string {
-  return markdown
-    .replace(/```[\s\S]*?(?:```|$)/g, "")
-    .replace(/`[^`\n]*`/g, "");
-}
-
-function unescapeMarkdownDestination(value: string): string {
-  return value.replace(/\\([\\()<>])/g, "$1");
-}
-
-function stripQueryAndFragment(value: string): string {
-  const suffixIndex = value.search(/[?#]/);
-  return suffixIndex >= 0 ? value.slice(0, suffixIndex) : value;
-}
-
-function safelyDecodePath(value: string): string {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
-  }
 }
 
 function basename(path: string): string {

--- a/apps/packages/product-client/src/lib/domain/chat/transcript/file-link-markdown.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/transcript/file-link-markdown.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import {
+  isEligibleLocalFileDestination,
+  repairTranscriptFileLinks,
+  scanTranscriptMarkdownLinks,
+  stabilizeStreamingFileLink,
+} from "./file-link-markdown";
+
+describe("repairTranscriptFileLinks eligible prefixes", () => {
+  it.each([
+    ["[a](/repo/My Notes.md)", "[a](</repo/My%20Notes.md>)"],
+    ["[a](~/repo/My Notes.md)", "[a](<~/repo/My%20Notes.md>)"],
+    ["[a](./My Notes.md)", "[a](<./My%20Notes.md>)"],
+    ["[a](../My Notes.md)", "[a](<../My%20Notes.md>)"],
+    ["[a](C:/repo/My Notes.md)", "[a](<C:/repo/My%20Notes.md>)"],
+    ["[a](C:\\repo\\My Notes.md)", "[a](<C:\\repo\\My%20Notes.md>)"],
+  ])("repairs %s", (source, expected) => {
+    expect(repairTranscriptFileLinks(source)).toBe(expected);
+  });
+
+  it("replaces every literal space and only literal spaces", () => {
+    expect(repairTranscriptFileLinks("[a](/repo/A B C.md)"))
+      .toBe("[a](</repo/A%20B%20C.md>)");
+  });
+
+  it("is idempotent", () => {
+    const once = repairTranscriptFileLinks("[a](/repo/My Notes.md \"Read it\")");
+    expect(once).toBe("[a](</repo/My%20Notes.md> \"Read it\")");
+    expect(repairTranscriptFileLinks(once)).toBe(once);
+  });
+});
+
+describe("repairTranscriptFileLinks non-local destinations", () => {
+  it.each([
+    "[a](//cdn.example.com/My Notes.md)",
+    "[a](https://example.com/My Notes.md)",
+    "[a](http://example.com/My Notes.md)",
+    "[a](www.example.com/My Notes.md)",
+    "[a](file:///repo/My Notes.md)",
+    "[a](vscode://file/My Notes.md)",
+    "[a](docs/My Notes.md)",
+    "[a](/repo/My Notes.md)".replace("/repo", "*repo"),
+    "[a](/repo/glob *.md)",
+    "[a](/repo/[set].md)",
+    "[a](/repo/{a,b}.md)",
+  ])("leaves %s unchanged", (source) => {
+    expect(repairTranscriptFileLinks(source)).toBe(source);
+  });
+
+  it("leaves a destination without any literal space unchanged", () => {
+    expect(repairTranscriptFileLinks("[a](/repo/Notes.md)")).toBe("[a](/repo/Notes.md)");
+  });
+
+  it("treats ? and # as literal path characters", () => {
+    expect(repairTranscriptFileLinks("[a](/repo/What is it?.md)"))
+      .toBe("[a](</repo/What%20is%20it?.md>)");
+    expect(repairTranscriptFileLinks("[a](/repo/Note #3.md)"))
+      .toBe("[a](</repo/Note%20#3.md>)");
+  });
+});
+
+describe("repairTranscriptFileLinks titles", () => {
+  it.each([
+    ["[a](/repo/My Notes.md \"Read it\")", "[a](</repo/My%20Notes.md> \"Read it\")"],
+    ["[a](/repo/My Notes.md 'Read it')", "[a](</repo/My%20Notes.md> 'Read it')"],
+    ["[a](/repo/My Notes.md (Read it))", "[a](</repo/My%20Notes.md> (Read it))"],
+    [
+      "[a](/repo/My Notes.md \"Read (it\")",
+      "[a](</repo/My%20Notes.md> \"Read (it\")",
+    ],
+  ])("moves a complete title outside the wrapper for %s", (source, expected) => {
+    expect(repairTranscriptFileLinks(source)).toBe(expected);
+  });
+
+  it("keeps balanced destination parentheses as destination content", () => {
+    expect(repairTranscriptFileLinks("[a](/repo/Final (copy).md)"))
+      .toBe("[a](</repo/Final%20(copy).md>)");
+    expect(repairTranscriptFileLinks("[a](/repo/Final (copy).md \"T\")"))
+      .toBe("[a](</repo/Final%20(copy).md> \"T\")");
+  });
+
+  it("keeps escaped destination parentheses", () => {
+    expect(repairTranscriptFileLinks("[a](/repo/Final \\(copy.md)"))
+      .toBe("[a](</repo/Final%20\\(copy.md>)");
+  });
+
+  it("does not mistake a quoted filename fragment for a title", () => {
+    expect(repairTranscriptFileLinks("[a](/repo/say \"hi\".md)"))
+      .toBe("[a](</repo/say%20\"hi\".md>)");
+  });
+});
+
+describe("repairTranscriptFileLinks malformed input", () => {
+  it.each([
+    "[a](/repo/My Notes.md \"unclosed)",
+    "[a](/repo/My Notes.md 'unclosed)",
+    "[a](/repo/My\nNotes.md)",
+    "[a](/repo/My Notes.md",
+    "[a](/repo/My <Notes>.md)",
+    "[a](/repo/My Notes.md (unbalanced)",
+  ])("leaves the entire source unchanged for %s", (source) => {
+    expect(repairTranscriptFileLinks(source)).toBe(source);
+  });
+
+  it("leaves an already angle-wrapped destination unchanged", () => {
+    expect(repairTranscriptFileLinks("[a](</repo/My Notes.md>)"))
+      .toBe("[a](</repo/My Notes.md>)");
+  });
+});
+
+describe("repairTranscriptFileLinks code and image context", () => {
+  it.each([
+    "`[a](/repo/My Notes.md)`",
+    "``[a](/repo/My `Notes.md)``",
+    "```\n[a](/repo/My Notes.md)\n```",
+    "````\n```\n[a](/repo/My Notes.md)\n````",
+    "~~~\n[a](/repo/My Notes.md)\n~~~",
+    "~~~~\n~~~\n[a](/repo/My Notes.md)\n~~~~",
+    "```md\n[a](/repo/My Notes.md)\n```",
+    "```\n``` info\n[a](/repo/My Notes.md)\n```",
+    "text\n\n    [a](/repo/My Notes.md)\n",
+    "![a](/repo/My Notes.md)",
+  ])("leaves %s unchanged", (source) => {
+    expect(repairTranscriptFileLinks(source)).toBe(source);
+    expect(scanTranscriptMarkdownLinks(source).filter((link) => !link.isImage))
+      .toHaveLength(0);
+  });
+});
+
+describe("repairTranscriptFileLinks lists and escapes", () => {
+  it("repairs a nested-list continuation, which is not indented code", () => {
+    const source = "- item\n\n    [a](/repo/My Notes.md)\n";
+    expect(repairTranscriptFileLinks(source))
+      .toBe("- item\n\n    [a](</repo/My%20Notes.md>)\n");
+  });
+
+  it("repairs a plain list item", () => {
+    expect(repairTranscriptFileLinks("- see [a](/repo/My Notes.md)"))
+      .toBe("- see [a](</repo/My%20Notes.md>)");
+  });
+
+  it("honours the backslash run before the opener", () => {
+    expect(repairTranscriptFileLinks("\\[a](/repo/My Notes.md)"))
+      .toBe("\\[a](/repo/My Notes.md)");
+    expect(repairTranscriptFileLinks("\\\\[a](/repo/My Notes.md)"))
+      .toBe("\\\\[a](</repo/My%20Notes.md>)");
+  });
+});
+
+describe("stabilizeStreamingFileLink", () => {
+  it.each([
+    ["[config](/Users/pablo/.codex/conf", "[config](/Users/pablo/.codex/conf)"],
+    ["[config](../.codex/conf", "[config](../.codex/conf)"],
+    ["[config](C:\\Users\\pablo\\conf", "[config](C:\\Users\\pablo\\conf)"],
+    ["[a](/repo/My Notes", "[a](/repo/My Notes)"],
+    ["[a](</repo/My Notes", "[a](</repo/My Notes>)"],
+  ])("closes an unambiguous eligible tail: %s", (source, expected) => {
+    expect(stabilizeStreamingFileLink(source)).toBe(expected);
+  });
+
+  it("feeds the closed tail into a normal repair pass", () => {
+    expect(repairTranscriptFileLinks(stabilizeStreamingFileLink("[a](/repo/My Notes.md")))
+      .toBe("[a](</repo/My%20Notes.md>)");
+  });
+
+  it.each([
+    "[site](https://example.com/part",
+    "[asset](//cdn.example.com/part",
+    "[config](file:///Users/pablo/.codex/conf",
+    "[config](<file:///Users/pablo/My%20Project/conf",
+    "[config](vscode://file/conf",
+    "![preview](/Users/pablo/image.png",
+    "[config](/Users/pablo/.codex/config.toml)",
+    "plain [unfinished label",
+    "`[config](/Users/pablo/conf",
+    "```\n[config](/Users/pablo/conf",
+    "[a](/repo/My Notes.md \"open",
+    "[a](/repo/My (Notes.md",
+    "[a](/repo/glob *.md",
+  ])("refuses to stabilize %s", (source) => {
+    expect(stabilizeStreamingFileLink(source)).toBe(source);
+  });
+});
+
+describe("isEligibleLocalFileDestination", () => {
+  it("rejects control characters, tabs, and non-space whitespace", () => {
+    expect(isEligibleLocalFileDestination("/repo/a\u0000b.md")).toBe(false);
+    expect(isEligibleLocalFileDestination("/repo/a\tb.md")).toBe(false);
+    expect(isEligibleLocalFileDestination("/repo/a\u007Fb.md")).toBe(false);
+    expect(isEligibleLocalFileDestination("/repo/a\u00A0b.md")).toBe(false);
+    expect(isEligibleLocalFileDestination("/repo/a b.md")).toBe(true);
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/chat/transcript/file-link-markdown.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/transcript/file-link-markdown.ts
@@ -1,0 +1,320 @@
+import { buildMarkdownCodeMask } from "./markdown-code-context";
+
+/**
+ * Shared transcript scanner and render-copy repair for local-file Markdown
+ * links.
+ *
+ * An assistant routinely writes `[notes](/repo/My Notes.md)`. CommonMark stops
+ * the destination at the first space, so the parser hands the renderer a
+ * truncated href and leaks the remainder as text. This module produces a pure
+ * render copy in which such a destination is angle-wrapped and its literal
+ * U+0020 spaces are written as `%20`, leaving the authoritative transcript
+ * bytes untouched.
+ *
+ * Settled repair, streaming-tail stabilization, and the end-resource card all
+ * consume the one scanner here so their link, code, image, escape, title, and
+ * malformed-input decisions cannot drift apart.
+ *
+ * Everything exported is pure, and `repairTranscriptFileLinks` is idempotent:
+ * a repaired destination is angle-wrapped, and wrapped destinations are never
+ * rewritten again.
+ */
+
+/** One complete, well-formed inline link found outside code context. */
+export interface TranscriptMarkdownLink {
+  /** Index of `[` in the source. */
+  start: number;
+  /** Exclusive index just past the closing `)`. */
+  end: number;
+  isImage: boolean;
+  /** Label source between the brackets, escapes preserved. */
+  label: string;
+  /** Destination source, escapes preserved, without any `<`/`>` wrapper. */
+  destination: string;
+  destinationWrapped: boolean;
+  /** Complete title including its delimiters, or null. */
+  title: string | null;
+  /** True when the link token spans a line break. */
+  multiline: boolean;
+}
+
+/**
+ * Explicit local-path syntax. A single leading ASCII letter plus `:` plus one
+ * slash is the sole colon-prefix exception: it is drive-root path syntax, not
+ * an authority grant, so every URI scheme (including `file:`) stays excluded.
+ */
+const ELIGIBLE_LOCAL_PREFIX = /^(?:\/(?!\/)|~\/|\.\/|\.\.\/|[A-Za-z]:[\\/])/;
+/** `?` and `#` are literal path characters in an explicit Markdown destination. */
+const GLOB_METACHARACTER = /[*[\]{}]/;
+const CONTROL_CHARACTER = /[\u0000-\u001F\u007F]/;
+/** Any whitespace other than U+0020, which is the one space we accept. */
+const DISALLOWED_WHITESPACE = /[^\S ]/;
+
+/** Does this unwrapped destination qualify for local-file repair? */
+export function isEligibleLocalFileDestination(destination: string): boolean {
+  if (!destination) return false;
+  if (!ELIGIBLE_LOCAL_PREFIX.test(destination)) return false;
+  if (destination.includes("<") || destination.includes(">")) return false;
+  if (GLOB_METACHARACTER.test(destination)) return false;
+  if (CONTROL_CHARACTER.test(destination)) return false;
+  if (DISALLOWED_WHITESPACE.test(destination)) return false;
+  return true;
+}
+
+/** Resolve the CommonMark backslash escapes a destination may carry. */
+export function unescapeMarkdownDestination(value: string): string {
+  return value.replace(/\\([\\()<>])/g, "$1");
+}
+
+/** Every complete, well-formed inline link outside code context, in source order. */
+export function scanTranscriptMarkdownLinks(source: string): TranscriptMarkdownLink[] {
+  const masked = buildMarkdownCodeMask(source);
+  const links: TranscriptMarkdownLink[] = [];
+  let index = 0;
+  while (index < source.length) {
+    if (masked[index] || source[index] !== "[" || isEscaped(source, index)) {
+      index += 1;
+      continue;
+    }
+    const link = readLink(source, masked, index);
+    if (!link) {
+      index += 1;
+      continue;
+    }
+    links.push(link);
+    index = link.end;
+  }
+  return links;
+}
+
+/**
+ * Angle-wrap eligible local destinations and encode their literal spaces.
+ * Ambiguous, malformed, multiline, image, already-wrapped, and non-local
+ * tokens are left byte-identical.
+ */
+export function repairTranscriptFileLinks(source: string): string {
+  let result = "";
+  let cursor = 0;
+  for (const link of scanTranscriptMarkdownLinks(source)) {
+    if (link.isImage || link.destinationWrapped || link.multiline) continue;
+    if (!link.destination.includes(" ")) continue;
+    if (!isEligibleLocalFileDestination(link.destination)) continue;
+    const encoded = link.destination.replaceAll(" ", "%20");
+    const title = link.title ? ` ${link.title}` : "";
+    result += `${source.slice(cursor, link.start)}[${link.label}](<${encoded}>${title})`;
+    cursor = link.end;
+  }
+  return result + source.slice(cursor);
+}
+
+/**
+ * Synthetically close an unambiguous trailing local-file link so the live
+ * render copy can paint the mention before the real `)` arrives. Refuses code,
+ * image, scheme, open-title, unbalanced-paren, and multiline tails.
+ */
+export function stabilizeStreamingFileLink(source: string): string {
+  const masked = buildMarkdownCodeMask(source);
+  // An unmatched backtick left in the live source may still close into a code
+  // span around the tail once more text arrives, so stay out of that source
+  // entirely. Closed spans and fences are already masked.
+  for (let index = 0; index < source.length; index += 1) {
+    if (source[index] === "`" && !masked[index]) return source;
+  }
+  for (let index = source.length - 1; index >= 0; index -= 1) {
+    if (masked[index] || source[index] !== "[" || isEscaped(source, index)) continue;
+    const closer = openTailCloser(source, masked, index);
+    if (closer !== null) return `${source}${closer}`;
+  }
+  return source;
+}
+
+/** The characters that would close an eligible incomplete tail at `index`. */
+function openTailCloser(source: string, masked: boolean[], index: number): string | null {
+  if (index > 0 && source[index - 1] === "!" && !isEscaped(source, index - 1)) return null;
+  const labelEnd = findLabelEnd(source, masked, index);
+  if (labelEnd === null || source[labelEnd + 1] !== "(") return null;
+  const tail = source.slice(labelEnd + 2);
+  // Only an unterminated tail is stabilized; a closed link is already parseable.
+  if (tail.includes("\n") || masked.slice(labelEnd + 2).some(Boolean)) return null;
+  if (findDestinationEnd(source, masked, labelEnd + 2) !== null) return null;
+
+  const wrapped = tail.startsWith("<");
+  const inner = wrapped ? tail.slice(1) : tail;
+  if (wrapped && (inner.includes("<") || inner.includes(">"))) return null;
+  if (parenDepth(inner) !== 0) return null;
+  const split = splitDestinationAndTitle(inner.trimStart());
+  if (split === null) return null;
+  if (!isEligibleLocalFileDestination(split.destination.trimEnd())) return null;
+  return wrapped ? ">)" : ")";
+}
+
+function readLink(
+  source: string,
+  masked: boolean[],
+  index: number,
+): TranscriptMarkdownLink | null {
+  const labelEnd = findLabelEnd(source, masked, index);
+  if (labelEnd === null || source[labelEnd + 1] !== "(") return null;
+  const innerStart = labelEnd + 2;
+  const closeIndex = findDestinationEnd(source, masked, innerStart);
+  if (closeIndex === null) return null;
+
+  const rawInner = source.slice(innerStart, closeIndex);
+  const split = splitDestinationAndTitle(rawInner.trim());
+  if (split === null) return null;
+  const destination = split.destination.trimEnd();
+  const wrapped = destination.startsWith("<") && destination.endsWith(">");
+  const isImage = index > 0 && source[index - 1] === "!" && !isEscaped(source, index - 1);
+  return {
+    start: index,
+    end: closeIndex + 1,
+    isImage,
+    label: source.slice(index + 1, labelEnd),
+    destination: wrapped ? destination.slice(1, -1) : destination,
+    destinationWrapped: wrapped,
+    title: split.title,
+    multiline: source.slice(index, closeIndex + 1).includes("\n"),
+  };
+}
+
+/** Index of the `]` closing the label opened at `index`, honouring nesting. */
+function findLabelEnd(source: string, masked: boolean[], index: number): number | null {
+  let depth = 0;
+  for (let cursor = index; cursor < source.length; cursor += 1) {
+    if (masked[cursor]) return null;
+    const char = source[cursor];
+    if (char === "\\") {
+      cursor += 1;
+      continue;
+    }
+    if (char === "[") depth += 1;
+    else if (char === "]") {
+      depth -= 1;
+      if (depth === 0) return cursor;
+    }
+  }
+  return null;
+}
+
+/**
+ * Index of the `)` closing the destination that starts at `from`.
+ *
+ * Runs quote-aware first so a quoted title may hold an unmatched `(` — the
+ * quote, not the parenthesis, delimits a title. Falls back to plain balancing
+ * so an unclosed quote still yields a token, which the title split then
+ * rejects as malformed rather than silently repairing.
+ */
+function findDestinationEnd(source: string, masked: boolean[], from: number): number | null {
+  return balancedCloseParen(source, masked, from, true)
+    ?? balancedCloseParen(source, masked, from, false);
+}
+
+function balancedCloseParen(
+  source: string,
+  masked: boolean[],
+  from: number,
+  quoteAware: boolean,
+): number | null {
+  let depth = 1;
+  let cursor = from;
+  while (cursor < source.length) {
+    if (masked[cursor]) return null;
+    const char = source[cursor];
+    if (char === "\\") {
+      cursor += 2;
+      continue;
+    }
+    if (quoteAware && isTitleQuoteStart(source, cursor, from)) {
+      const close = findMatchingDelimiter(source, cursor);
+      if (close === null) return null;
+      cursor = close + 1;
+      continue;
+    }
+    if (char === "(") depth += 1;
+    else if (char === ")") {
+      depth -= 1;
+      if (depth === 0) return cursor;
+    }
+    cursor += 1;
+  }
+  return null;
+}
+
+function isTitleQuoteStart(source: string, cursor: number, from: number): boolean {
+  const char = source[cursor];
+  if (char !== "\"" && char !== "'") return false;
+  return cursor > from && (source[cursor - 1] === " " || source[cursor - 1] === "\t");
+}
+
+/**
+ * Split a link's inner text into destination and optional complete title.
+ *
+ * Returns null when a title-position delimiter opens and never closes: an
+ * ambiguous token is left entirely unchanged rather than partially repaired.
+ */
+function splitDestinationAndTitle(
+  inner: string,
+): { destination: string; title: string | null } | null {
+  for (let cursor = 0; cursor < inner.length; cursor += 1) {
+    if (inner[cursor] !== " " && inner[cursor] !== "\t") continue;
+    let start = cursor;
+    while (start < inner.length && (inner[start] === " " || inner[start] === "\t")) start += 1;
+    if (start >= inner.length) break;
+    if (!"\"'(".includes(inner[start])) continue;
+    const close = findMatchingDelimiter(inner, start);
+    if (close === null) return null;
+    if (inner.slice(close + 1).trim().length === 0) {
+      return { destination: inner.slice(0, cursor), title: inner.slice(start, close + 1) };
+    }
+  }
+  return { destination: inner, title: null };
+}
+
+/** Index of the delimiter closing the one opened at `start`, or null. */
+function findMatchingDelimiter(value: string, start: number): number | null {
+  const open = value[start];
+  const close = open === "(" ? ")" : open;
+  let depth = 1;
+  for (let cursor = start + 1; cursor < value.length; cursor += 1) {
+    const char = value[cursor];
+    if (char === "\\") {
+      cursor += 1;
+      continue;
+    }
+    if (open === "(" && char === "(") depth += 1;
+    else if (char === close) {
+      depth -= 1;
+      if (depth === 0) return cursor;
+    }
+  }
+  return null;
+}
+
+/** Net unescaped parenthesis depth, ignoring text inside title-position quotes. */
+function parenDepth(value: string): number {
+  let depth = 0;
+  for (let cursor = 0; cursor < value.length; cursor += 1) {
+    const char = value[cursor];
+    if (char === "\\") {
+      cursor += 1;
+      continue;
+    }
+    if (isTitleQuoteStart(value, cursor, 0)) {
+      const close = findMatchingDelimiter(value, cursor);
+      if (close === null) return depth;
+      cursor = close;
+      continue;
+    }
+    if (char === "(") depth += 1;
+    else if (char === ")") depth -= 1;
+  }
+  return depth;
+}
+
+function isEscaped(source: string, index: number): boolean {
+  let backslashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && source[cursor] === "\\"; cursor -= 1) {
+    backslashes += 1;
+  }
+  return backslashes % 2 === 1;
+}

--- a/apps/packages/product-client/src/lib/domain/chat/transcript/markdown-code-context.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/transcript/markdown-code-context.ts
@@ -1,0 +1,176 @@
+/**
+ * Character-level code-context mask for transcript Markdown.
+ *
+ * The transcript file-link scanner must never rewrite, close, or extract a
+ * link that only *looks* like a link because it sits inside code. Building one
+ * shared mask keeps the settled repair, the streaming-tail stabilizer, and the
+ * end-resource extractor from drifting apart on that judgement.
+ *
+ * Masked regions are, in the order they are computed:
+ *  - fenced code, by opener character and opener run length (backtick or
+ *    tilde). A fence-like line carrying an info string while a fence is open is
+ *    content, not a closer;
+ *  - blank-line-introduced indented code, measured against the enclosing list
+ *    item's content indent so nested-list continuation alone is not code;
+ *  - inline code spans of one or more backticks, closed by a run of exactly the
+ *    same length, never crossing a blank line.
+ *
+ * This is a deliberately small subset of CommonMark block parsing: it only has
+ * to be conservative in the direction of "leave the source alone".
+ */
+
+const FENCE_OPEN = /^( {0,3})(`{3,}|~{3,})(.*)$/;
+const LIST_MARKER = /^( *)(?:[-*+]|\d{1,9}[.)])( +)/;
+
+interface OpenFence {
+  char: string;
+  length: number;
+}
+
+/** One boolean per source character: true when that character is code context. */
+export function buildMarkdownCodeMask(source: string): boolean[] {
+  const masked = new Array<boolean>(source.length).fill(false);
+  maskBlockCode(source, masked);
+  maskInlineCode(source, masked);
+  return masked;
+}
+
+function maskBlockCode(source: string, masked: boolean[]): void {
+  let offset = 0;
+  let fence: OpenFence | null = null;
+  let previousBlank = true;
+  let indentedCode = false;
+  let listContentIndent = 0;
+
+  for (const line of source.split("\n")) {
+    const lineStart = offset;
+    offset += line.length + 1;
+
+    if (fence) {
+      maskRange(masked, lineStart, lineStart + line.length);
+      if (closesFence(line, fence)) fence = null;
+      continue;
+    }
+
+    const opened = openFence(line);
+    if (opened) {
+      fence = opened;
+      maskRange(masked, lineStart, lineStart + line.length);
+      previousBlank = false;
+      indentedCode = false;
+      continue;
+    }
+
+    if (line.trim().length === 0) {
+      previousBlank = true;
+      indentedCode = false;
+      continue;
+    }
+
+    const indent = leadingIndentWidth(line);
+    const codeIndent = listContentIndent + 4;
+    if (previousBlank && indent >= codeIndent) {
+      indentedCode = true;
+    } else if (indent < codeIndent) {
+      indentedCode = false;
+    }
+
+    if (indentedCode) {
+      maskRange(masked, lineStart, lineStart + line.length);
+    } else {
+      const marker = LIST_MARKER.exec(line);
+      if (marker) {
+        listContentIndent = marker[0].length;
+      } else if (indent <= listContentIndent && indent < codeIndent) {
+        listContentIndent = 0;
+      }
+    }
+    previousBlank = false;
+  }
+}
+
+function openFence(line: string): OpenFence | null {
+  const match = FENCE_OPEN.exec(line);
+  if (!match) return null;
+  const run = match[2];
+  const info = match[3];
+  // A backtick fence's info string may not contain a backtick; a tilde one may.
+  if (run.startsWith("`") && info.includes("`")) return null;
+  return { char: run[0], length: run.length };
+}
+
+function closesFence(line: string, fence: OpenFence): boolean {
+  const match = /^ {0,3}(`+|~+)[ \t]*$/.exec(line);
+  if (!match) return false;
+  return match[1][0] === fence.char && match[1].length >= fence.length;
+}
+
+function leadingIndentWidth(line: string): number {
+  let width = 0;
+  for (const char of line) {
+    if (char === " ") width += 1;
+    else if (char === "\t") width += 4 - (width % 4);
+    else break;
+  }
+  return width;
+}
+
+function maskInlineCode(source: string, masked: boolean[]): void {
+  let index = 0;
+  while (index < source.length) {
+    if (masked[index] || source[index] !== "`") {
+      index += 1;
+      continue;
+    }
+    const openLength = backtickRunLength(source, index, masked);
+    const close = findClosingBacktickRun(source, index + openLength, openLength, masked);
+    if (close === null) {
+      index += openLength;
+      continue;
+    }
+    maskRange(masked, index, close + openLength);
+    index = close + openLength;
+  }
+}
+
+function backtickRunLength(source: string, start: number, masked: boolean[]): number {
+  let end = start;
+  while (end < source.length && source[end] === "`" && !masked[end]) end += 1;
+  return end - start;
+}
+
+function findClosingBacktickRun(
+  source: string,
+  from: number,
+  length: number,
+  masked: boolean[],
+): number | null {
+  let index = from;
+  let consecutiveNewlines = 0;
+  while (index < source.length) {
+    if (masked[index]) return null;
+    if (source[index] === "\n") {
+      consecutiveNewlines += 1;
+      // An inline code span never spans a blank line.
+      if (consecutiveNewlines > 1) return null;
+      index += 1;
+      continue;
+    }
+    if (source[index] !== "`") {
+      consecutiveNewlines = 0;
+      index += 1;
+      continue;
+    }
+    const run = backtickRunLength(source, index, masked);
+    if (run === length) return index;
+    index += run;
+    consecutiveNewlines = 0;
+  }
+  return null;
+}
+
+function maskRange(masked: boolean[], start: number, end: number): void {
+  for (let index = start; index < end && index < masked.length; index += 1) {
+    masked[index] = true;
+  }
+}

--- a/apps/packages/product-client/src/lib/domain/chat/transcript/streaming-markdown.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/transcript/streaming-markdown.test.ts
@@ -4,18 +4,12 @@ import { stabilizeStreamingMarkdown } from "./streaming-markdown";
 describe("stabilizeStreamingMarkdown", () => {
   it.each([
     ["[config](/Users/pablo/.codex/conf", "[config](/Users/pablo/.codex/conf)"],
-    [
-      "[config](file:///Users/pablo/.codex/conf",
-      "[config](file:///Users/pablo/.codex/conf)",
-    ],
     ["[config](../.codex/conf", "[config](../.codex/conf)"],
+    ["[config](~/.codex/conf", "[config](~/.codex/conf)"],
+    ["[config](./conf", "[config](./conf)"],
     [
-      "[config](<file:///Users/pablo/My%20Project/conf",
-      "[config](<file:///Users/pablo/My%20Project/conf>)",
-    ],
-    [
-      "[config](<file:///Users/pablo/My%20Project/conf>",
-      "[config](<file:///Users/pablo/My%20Project/conf>)",
+      "[config](</Users/pablo/My Project/conf",
+      "[config](</Users/pablo/My Project/conf>)",
     ],
     ["[config](C:\\Users\\pablo\\conf", "[config](C:\\Users\\pablo\\conf)"],
   ])("temporarily closes an incomplete local-file link", (input, expected) => {
@@ -29,6 +23,19 @@ describe("stabilizeStreamingMarkdown", () => {
     "[config](/Users/pablo/.codex/config.toml)",
     "plain [unfinished label",
   ])("leaves non-target markdown untouched", (content) => {
+    expect(stabilizeStreamingMarkdown(content)).toBe(content);
+  });
+
+  it.each([
+    "[config](file:///Users/pablo/.codex/conf",
+    "[config](<file:///Users/pablo/My%20Project/conf",
+    "[config](<file:///Users/pablo/My%20Project/conf>",
+  ])("no longer stabilizes a file: destination", (content) => {
+    // Intentional contract change from the previous behaviour, which closed
+    // `file:` tails. A scheme is an authority grant rather than a local path,
+    // so every scheme — `file:` included — is now excluded from stabilization
+    // and from local-link repair. Only the exact drive-root colon form is
+    // treated as path syntax.
     expect(stabilizeStreamingMarkdown(content)).toBe(content);
   });
 });

--- a/apps/packages/product-client/src/lib/domain/chat/transcript/streaming-markdown.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/transcript/streaming-markdown.ts
@@ -1,4 +1,4 @@
-const TRAILING_INCOMPLETE_INLINE_LINK = /\[([^\]\n]+)\]\(([^)\n]*)$/;
+import { stabilizeStreamingFileLink } from "./file-link-markdown";
 
 /**
  * Keep a trailing local-file link parseable while its destination is still
@@ -10,32 +10,13 @@ const TRAILING_INCOMPLETE_INLINE_LINK = /\[([^\]\n]+)\]\(([^)\n]*)$/;
  * render copy lets the injected file-link renderer paint the final mention
  * immediately, so later destination chunks update behavior without replacing
  * a long raw path on screen.
+ *
+ * The decision of what counts as a stabilizable tail belongs to the shared
+ * transcript scanner, so streaming and settled repair cannot disagree about
+ * code spans, fences, images, escapes, titles, or nested parentheses. Only an
+ * explicit local-path prefix qualifies: every URI scheme, `file:` included, is
+ * excluded because a scheme is an authority grant rather than a path.
  */
 export function stabilizeStreamingMarkdown(content: string): string {
-  const match = TRAILING_INCOMPLETE_INLINE_LINK.exec(content);
-  if (!match || (match.index > 0 && content[match.index - 1] === "!")) {
-    return content;
-  }
-
-  const destination = match[2]?.trim() ?? "";
-  const unwrappedDestination = destination.startsWith("<")
-    ? destination.slice(1)
-    : destination;
-  if (!looksLikeLocalFileDestination(unwrappedDestination)) {
-    return content;
-  }
-
-  if (destination.startsWith("<") && !destination.endsWith(">")) {
-    return `${content}>)`;
-  }
-  return `${content})`;
-}
-
-function looksLikeLocalFileDestination(destination: string): boolean {
-  return (destination.startsWith("/") && !destination.startsWith("//"))
-    || destination.startsWith("~/")
-    || destination.startsWith("./")
-    || destination.startsWith("../")
-    || destination.startsWith("file:")
-    || /^[a-zA-Z]:[\\/]/.test(destination);
+  return stabilizeStreamingFileLink(content);
 }

--- a/apps/packages/product-client/src/lib/domain/files/path-detection.test.ts
+++ b/apps/packages/product-client/src/lib/domain/files/path-detection.test.ts
@@ -101,6 +101,78 @@ describe("looksLikeFileReferenceHref", () => {
     expect(looksLikeFileReferenceHref("mailto:team@example.com")).toBe(false);
     expect(looksLikeFileReferenceHref("#section")).toBe(false);
   });
+
+  it("accepts a literal U+0020 space handed back by the Markdown parser", () => {
+    expect(looksLikeFileReferenceHref("/repo/My Notes.md")).toBe(true);
+    expect(looksLikeFileReferenceHref("/repo/My Notes.md:42")).toBe(true);
+    expect(looksLikeFileReferenceHref("docs/My Notes.md")).toBe(true);
+  });
+
+  it.each([
+    ["NUL", "/repo/a\u0000b.md"],
+    ["a C0 control", "/repo/a\u0001b.md"],
+    ["DEL", "/repo/a\u007Fb.md"],
+    ["a tab", "/repo/a\tb.md"],
+    ["a newline", "/repo/a\nb.md"],
+    ["a carriage return", "/repo/a\rb.md"],
+    ["a non-breaking space", "/repo/a\u00A0b.md"],
+  ])("rejects %s", (_label, value) => {
+    expect(looksLikeFileReferenceHref(value)).toBe(false);
+  });
+
+  it.each([
+    "file:///repo/README.md",
+    "vscode://file/repo/README.md",
+    "data:text/plain,x",
+    "tel:+15550000",
+    "custom-scheme:whatever",
+    "//cdn.example.com/README.md",
+    "www.example.com/README.md",
+  ])("rejects the non-local destination %s", (value) => {
+    expect(looksLikeFileReferenceHref(value)).toBe(false);
+  });
+
+  it("refuses an executable scheme even when it wears a :digits tail", () => {
+    // `name:12` is ambiguous between a scheme and a line suffix; the schemes
+    // that can carry executable or out-of-workspace meaning lose the tie.
+    expect(looksLikeFileReferenceHref("javascript:1")).toBe(false);
+    expect(looksLikeFileReferenceHref("file:1")).toBe(false);
+    expect(looksLikeFileReferenceHref("Makefile:12")).toBe(true);
+  });
+
+  it("accepts the exact drive-root form syntactically only", () => {
+    // Syntactic acceptance grants no filesystem authority: the canonical
+    // locator still decides whether a drive-root reference resolves.
+    expect(looksLikeFileReferenceHref("C:/repo/My Notes.md")).toBe(true);
+    expect(looksLikeFileReferenceHref("C:\\repo\\My Notes.md")).toBe(true);
+    expect(looksLikeFileReferenceHref("CC:/repo/notes.md")).toBe(false);
+    expect(looksLikeFileReferenceHref("C:repo/notes.md")).toBe(false);
+  });
+
+  it("treats ? and # as literal path characters, and rejects glob syntax", () => {
+    expect(looksLikeFileReferenceHref("/repo/What is it?.md")).toBe(true);
+    expect(looksLikeFileReferenceHref("/repo/Note #3.md")).toBe(true);
+    expect(looksLikeFileReferenceHref("/repo/*.md")).toBe(false);
+    expect(looksLikeFileReferenceHref("/repo/[set].md")).toBe(false);
+    expect(looksLikeFileReferenceHref("/repo/{a,b}.md")).toBe(false);
+  });
+
+  it("does not strip a query- or fragment-looking suffix off the reference", () => {
+    // The card and the mention must resolve the same target, so `?`/`#` may
+    // never truncate the destination into a different path.
+    expect(looksLikeFileReferenceHref("?onlyquery")).toBe(true);
+    expect(looksLikeFileReferenceHref("#onlyfragment")).toBe(false);
+  });
+});
+
+describe("looksLikePath stays unchanged for non-href callers", () => {
+  it("still rejects whitespace and ? for inline-code detection", () => {
+    // Inline-code path detection has no explicit "this is a link" signal, so
+    // its stricter grammar is intentionally untouched by the href change.
+    expect(looksLikePath("/repo/My Notes.md")).toBe(false);
+    expect(looksLikePath("src/What is it?.md")).toBe(false);
+    expect(looksLikePath("src/foo.ts")).toBe(true);
+  });
 });
 
 describe("splitPathLineSuffix", () => {

--- a/apps/packages/product-client/src/lib/domain/files/path-detection.ts
+++ b/apps/packages/product-client/src/lib/domain/files/path-detection.ts
@@ -42,26 +42,67 @@ export function looksLikePath(value: string): boolean {
   return false;
 }
 
+/** One ASCII letter, `:`, then one slash — drive-root syntax, not a scheme. */
+const DRIVE_ROOT_PREFIX = /^[A-Za-z]:[\\/]/;
+/** Any scheme at all. Drive roots are exempted before this runs. */
+const ANY_URI_SCHEME = /^[A-Za-z][A-Za-z0-9+.-]*:/;
+/** Schemes refused even when they wear a `:digits` tail. */
+const EXECUTABLE_OR_FOREIGN_SCHEME =
+  /^(?:javascript|mailto|data|tel|vbscript|file|about|blob|http|https|ftp|ws|wss|vscode):/i;
+/** The whole reference is one path plus a terminal `:line[:column]`. */
+const TERMINAL_LINE_SUFFIX_ONLY = /^[^:]+:\d+(?::\d+)?$/;
+const CONTROL_CHARACTER = /[\u0000-\u001F\u007F]/;
+/** Every whitespace character except U+0020, the one the parser may hand us. */
+const DISALLOWED_WHITESPACE = /[^\S ]/;
+/** `?` and `#` are literal path characters inside an explicit link destination. */
+const GLOB_METACHARACTER = /[*[\]{}]/;
+
 /**
  * Heuristic for explicit markdown link destinations. Because the markdown
  * syntax already says "this is a link", this accepts bare filenames that would
- * be too noisy to detect in free text or inline code.
+ * be too noisy to detect in free text or inline code, and it accepts a literal
+ * U+0020 space because a repaired local destination legitimately carries one.
+ *
+ * The rejections run before the `looksLikePath` delegation on purpose: this
+ * grammar is strictly narrower than the free-text one on schemes, controls, and
+ * non-space whitespace, so no delegated `true` may escape them. `looksLikePath`
+ * itself is unchanged and still rejects all whitespace for its own callers.
+ *
+ * Detection grants no filesystem authority: everything accepted here still
+ * passes through the canonical locator, which is where traversal, drive-root
+ * availability, and workspace containment are decided.
  */
 export function looksLikeFileReferenceHref(value: string): boolean {
-  if (looksLikePath(value)) return true;
-
   const trimmed = value.trim();
   if (trimmed.length === 0 || trimmed.length > 512) return false;
-  if (/\s/.test(trimmed)) return false;
-  if (/[*?[\]{}]/.test(trimmed)) return false;
-  // Any scheme (https://, mailto:, vscode:) is not a workspace path.
-  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return false;
-  if (/^(javascript|mailto|data|tel|vbscript|file|about|blob):/i.test(trimmed)) return false;
+  if (CONTROL_CHARACTER.test(trimmed)) return false;
+  if (DISALLOWED_WHITESPACE.test(trimmed)) return false;
+  if (GLOB_METACHARACTER.test(trimmed)) return false;
   if (trimmed.startsWith("//")) return false;
+  if (/^www\./i.test(trimmed)) return false;
   if (trimmed.startsWith("#")) return false;
 
-  const destinationPath = stripUrlSuffix(trimmed);
-  const { path } = splitPathLineSuffix(destinationPath);
+  // A scheme is an authority grant, not a workspace path. The exact drive-root
+  // form is the sole colon exception.
+  //
+  // `name:12` is genuinely ambiguous between a scheme and a `:line` suffix
+  // (`Makefile:12` versus `javascript:1`), so the terminal-line-suffix shape
+  // reads as a file reference while the schemes that can carry executable or
+  // out-of-workspace meaning are refused outright either way.
+  if (EXECUTABLE_OR_FOREIGN_SCHEME.test(trimmed)) return false;
+  const terminalLineSuffixOnly = TERMINAL_LINE_SUFFIX_ONLY.test(trimmed);
+  if (
+    !DRIVE_ROOT_PREFIX.test(trimmed)
+    && !terminalLineSuffixOnly
+    && ANY_URI_SCHEME.test(trimmed)
+  ) {
+    return false;
+  }
+
+  if (looksLikePath(trimmed)) return true;
+
+  const { path } = splitPathLineSuffix(trimmed);
+
   const basename = path.split(/[\\/]/).filter(Boolean).pop() ?? path;
   if (!basename) return false;
   // The markdown link syntax is already an explicit file-reference signal,
@@ -119,11 +160,6 @@ function hasFileExtension(basename: string): boolean {
   const ext = basename.slice(dot + 1);
   // 1..8 chars, alphanumeric — covers .ts, .tsx, .py, .yaml, .toml, .lock, etc.
   return /^[a-z0-9]{1,8}$/i.test(ext);
-}
-
-function stripUrlSuffix(value: string): string {
-  const suffixIndex = value.search(/[?#]/);
-  return suffixIndex >= 0 ? value.slice(0, suffixIndex) : value;
 }
 
 /**

--- a/apps/packages/product-client/src/lib/domain/files/path-references.test.ts
+++ b/apps/packages/product-client/src/lib/domain/files/path-references.test.ts
@@ -58,6 +58,67 @@ describe("resolveFileReference", () => {
     expect(fileReferenceCopyPath(reference)).toBe("/repo/src/App.tsx");
   });
 
+  it.each([
+    ["/repo/My%20Notes.md:7", "/repo/My Notes.md", 7, null],
+    ["/repo/My%20Notes.md:7:3", "/repo/My Notes.md", 7, 3],
+    ["/repo/my%20notes.md", "/repo/my notes.md", null, null],
+    ["/repo/My%2520Notes.md", "/repo/My%2520Notes.md", null, null],
+    ["/repo/a%2Fb.md", "/repo/a%2Fb.md", null, null],
+    ["/repo/a%5Cb.md", "/repo/a%5Cb.md", null, null],
+    ["/repo/a%00b.md", "/repo/a%00b.md", null, null],
+    ["/repo/a%23b.md", "/repo/a%23b.md", null, null],
+    ["/repo/a+b.md", "/repo/a+b.md", null, null],
+    ["/repo/literal%2520name.md", "/repo/literal%2520name.md", null, null],
+  ])("decodes %s with one case-insensitive %%20 pass and nothing else", (
+    rawPath,
+    parsedPath,
+    line,
+    column,
+  ) => {
+    expect(resolve({ rawPath })).toMatchObject({ parsedPath, line, column });
+  });
+
+  it("keeps an encoded terminal filename space, because nothing trims after decode", () => {
+    // `%20` immediately before `:7` becomes a real trailing space in the parsed
+    // path; a second trim would silently rename the file being opened.
+    expect(resolve({ rawPath: "/repo/Notes%20:7" })).toMatchObject({
+      parsedPath: "/repo/Notes ",
+      line: 7,
+    });
+    expect(resolve({ rawPath: "  /repo/Notes%20  " })).toMatchObject({
+      // The outer trim happens once, before the decode; the space the decode
+      // produces at the end of the name is part of the filename and survives.
+      parsedPath: "/repo/Notes ",
+    });
+  });
+
+  it("never manufactures a separator or traversal out of an encoding", () => {
+    expect(resolve({ rawPath: "/repo/%2E%2E/secret" }).locator).toEqual({
+      authority: "workspace",
+      workspacePath: "%2E%2E/secret",
+      localCompanionPath: "/repo/%2E%2E/secret",
+    });
+    // A repaired `../` reference is only syntactically parseable; the canonical
+    // locator is what refuses it.
+    expect(resolve({ rawPath: "../My%20Notes.md" }).locator).toEqual({
+      authority: "unavailable",
+      reason: "traversal",
+    });
+  });
+
+  it("leaves an authoritative structured workspace path byte-identical", () => {
+    // The compatibility decoder applies to raw references only. A runtime
+    // workspacePath is already authoritative data.
+    expect(resolve({
+      rawPath: "ignored/raw.md",
+      workspacePathOverride: "docs/literal%20name.md",
+    }).locator).toEqual({
+      authority: "workspace",
+      workspacePath: "docs/literal%20name.md",
+      localCompanionPath: "/repo/docs/literal%20name.md",
+    });
+  });
+
   it("uses runtime root and provenance only for native companion capability", () => {
     expect(resolve({ filesystemOrigin: REMOTE }).locator).toEqual({
       authority: "workspace",

--- a/apps/packages/product-client/src/lib/domain/files/path-references.ts
+++ b/apps/packages/product-client/src/lib/domain/files/path-references.ts
@@ -63,9 +63,33 @@ interface ResolveFileReferenceInput {
   homeDirectory?: string | null;
 }
 
+/**
+ * The one decode a raw file reference gets: a single case-insensitive `%20`
+ * pass, nothing else.
+ *
+ * A Markdown destination that survives the transcript repair carries its spaces
+ * as `%20`, so this is what turns a rendered mention back into the name the
+ * author wrote. It is deliberately not `decodeURIComponent`: general URI
+ * decoding would let `%2F`, `%5C`, `%2E%2E`, and `%00` manufacture separators,
+ * traversal, or NUL out of an inert literal. `+` is not a space here, and
+ * nothing is decoded twice, so `%2520` stays `%2520`.
+ *
+ * Accepted compatibility tradeoff: a real filename containing the literal
+ * characters `%20` resolves as a space-bearing name at this seam. That
+ * ambiguity is narrower and safer than general decoding, and it is the only
+ * meaning-changing case.
+ */
+export function decodeFileReferenceSpaces(rawReference: string): string {
+  return rawReference.replace(/%20/gi, " ");
+}
+
 /** Classify one rendered reference into exactly one filesystem authority. */
 export function resolveFileReference(args: ResolveFileReferenceInput): ResolvedFileReference {
-  const { path: parsedPath, line, column } = splitPathLineSuffix(args.rawPath.trim());
+  // Ordered exactly: trim once, decode `%20` once, never trim again, then split
+  // the terminal `:line[:column]`. Skipping the second trim is what lets an
+  // encoded terminal filename space survive into the parsed path.
+  const decodedReference = decodeFileReferenceSpaces(args.rawPath.trim());
+  const { path: parsedPath, line, column } = splitPathLineSuffix(decodedReference);
   const locator = typeof args.workspacePathOverride === "string"
     ? classifyStructuredWorkspacePath(args.workspacePathOverride, args)
     : classifyRawPath(parsedPath, args);

--- a/lints/frontend/ratchets.toml
+++ b/lints/frontend/ratchets.toml
@@ -94,11 +94,6 @@ reason = "product-owned measurement port barrel (R1 ruling) mirroring the retain
 # Same shrink-only contract as [[max_lines]]: growth fails, and so does an entry
 # whose file dropped back under the soft threshold or is gone.
 
-[[frontend_structure]]
-path = "apps/packages/product-client/src/components/workspace/chat/transcript/MarkdownBody.tsx"
-max_lines = 525
-reason = "existing markdown transcript renderer pending split"
-
 # Relocated from apps/desktop/src by the Desktop-product move into product-client
 # (web-desktop-unification slice 04). Same files, same counts/reasons — relocation,
 # not gate-weakening; product-client/src is a structure-report scan root. Counts

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -126,10 +126,20 @@ apps/packages/product-client/src/components/workspace/chat/transcript/ProviderLi
   (isExternalHttpLink, linkHost); rendered by MarkdownBody's default anchor, so
   every surface (web + cloud chat included) gets icon links
 
+apps/packages/product-client/src/lib/domain/chat/transcript/file-link-markdown.ts
+  the one transcript scanner: complete balanced inline links, code/image
+  context, escape counting, CommonMark title grammar, eligible local-path
+  grammar, the pure render-copy repair, and streaming-tail stabilization
+  (markdown-code-context.ts holds the code mask it builds on)
+
 apps/packages/product-client/src/lib/domain/files/path-detection.ts
   pure path heuristics (looksLikePath, looksLikeFileReferenceHref,
   splitPathLineSuffix); move to product-client/src/domain/files only when
   Mobile also needs the same rule
+
+apps/packages/product-client/src/lib/domain/files/path-references.ts
+  the shared reference resolution seam, including the one raw-reference
+  decode (decodeFileReferenceSpaces) that every mention and card goes through
 
 anyharness .../domains/sessions/response_formatting.rs
   the prompt-side instruction (FILE_REFERENCE_INSTRUCTIONS) requiring markdown
@@ -168,6 +178,43 @@ Rules:
   only in the Markdown render copy so its file mention appears as soon as the
   destination begins. Never persist the synthetic delimiter or expose the raw
   partial absolute destination while waiting for the real closing delimiter.
+  A tail is stabilized only when it is unambiguous: outside code and image
+  syntax, on an explicit local-path prefix, with no open title, no unmatched
+  nested parenthesis, and no line break.
+- An explicit local-file Markdown link whose destination carries literal
+  U+0020 spaces is repaired in the render copy: the destination is wrapped in
+  angle brackets and only its literal spaces become `%20`, with a valid
+  complete title moved outside the wrapper. Anything ambiguous, malformed,
+  multiline, already wrapped, image-shaped, or non-local is left byte-identical
+  rather than partially repaired. The repair is pure and idempotent, and the
+  stored transcript, stream buffer, search source, clipboard source, and
+  persisted history keep the original bytes.
+- Eligible local syntax is `/` (not `//`), `~/`, `./`, `../`, or an exact
+  drive root of one ASCII letter plus `:` plus one slash. Every URI scheme is
+  excluded, `file:` included, because a scheme is an authority grant rather
+  than path syntax. Glob metacharacters disqualify a destination; `?` and `#`
+  are literal path characters in this grammar and are never treated as query
+  or fragment delimiters.
+- Both transformations run only for `surface="message"`, and stabilization
+  additionally only while `isStreaming`. A `surface="file-content"` body runs
+  neither: a Markdown file viewer shows the file's own bytes and must never
+  silently rewrite them.
+- A raw file reference gets exactly one decode on its way to the canonical
+  locator: trim once, replace `%20` case-insensitively once, do not trim
+  again, then split the terminal `:line[:column]`. Nothing else is decoded, so
+  `%2F`, `%5C`, `%2E%2E`, `%00`, `%23`, `+`, and `%2520` stay literal and no
+  encoding can manufacture a separator or traversal. The accepted tradeoff is
+  that a real filename containing the literal characters `%20` resolves as a
+  space-bearing name. An authoritative structured `workspacePath` skips this
+  decode entirely and stays byte-identical.
+- Syntax repair and href detection grant no filesystem authority. Every
+  accepted reference still enters the canonical locator, which is what rejects
+  a repaired `../My Notes.md` as traversal and decides whether a drive-root
+  reference resolves at all.
+- The end-resource card reads the same settled repaired copy, the same
+  complete-balanced-link scan, and the same raw-reference decoder as the
+  inline mentions, so prose and card can never name different documents. It
+  never sees a synthetic streaming closure.
 - Mention labels display the workspace-relative path plus a `(line N)` suffix;
   raw absolute hrefs must not be shown as label text.
 - External/web link hrefs render as a shared inline provider-icon mention


### PR DESCRIPTION
Implements frozen spec **03A – Safe Transcript Markdown File Destinations** (Frozen r3, base `c9909ee1` = the 02B merge, program base `88ab1331` = 01D). An explicit local-file Markdown link containing literal spaces now renders and opens as a file reference, as a pure render-copy repair that never mutates stored or streamed transcript text.

## What this does

- **Shared scanner/repair** (`lib/domain/chat/transcript/file-link-markdown.ts` + `markdown-code-context.ts`): one pure, idempotent scanner shared by settled repair, streaming stabilization, and end-resource extraction. Eligible local prefixes only (`/` not `//`, `~/`, `./`, `../`, exact drive root); full CommonMark title grammar and balanced-destination parsing; escape counting before `[`; inline-code/fence/indented-code/image exclusion; glob metacharacters rejected; ambiguous or malformed tokens left entirely unchanged. The repair wraps the destination in `<…>` and replaces only literal U+0020 with `%20`.
- **Streaming stabilization reworked** on the shared scanner: only an unambiguous trailing eligible link is synthetically closed, never inside code/image, never with a URI scheme. This intentionally removes the previous `file:` tail acceptance (a disclosed contract change; the old pinning assertions are inverted with a negative-control receipt). Stabilization bails on any source with an unmatched backtick run rather than guessing.
- **Surface gating made explicit**: `surface="message"` gets repair (+stabilization when streaming); `surface="file-content"` runs neither — a Markdown file viewer shows the file's own bytes.
- **Href detection** (`path-detection.ts`): `looksLikeFileReferenceHref` accepts literal U+0020 and rejects NUL/all other C0/DEL/tab/newline/other whitespace, protocol-relative, `www.`, fragment-only, and glob syntax; `?`/`#` are literal path characters (no more `stripUrlSuffix` query stripping in this grammar). `looksLikePath` stays byte-identical for non-href callers (pinned). Scheme policy: an explicit executable/foreign scheme list is refused unconditionally; other `name:` prefixes are refused unless the whole reference is exactly `path:line[:column]` (documented and pinned — `README.md:12` still works).
- **`%20`-only decode contract** (`path-references.ts`): trim once → case-insensitive `%20`→space once → no second trim → terminal `:line[:column]` split → 01D classification. No `decodeURIComponent`, no `+`, no repeat decode, no query/fragment stripping — `%2F`, `%2E%2E`, `%5C`, `%00`, `%23`, `%2520` all stay literal, so encoded traversal/separators cannot be manufactured. Structured `workspacePathOverride` stays byte-identical. The literal-`%20`-filename compatibility tradeoff is recorded in code and tests.
- **End-resource card rework** (`assistant-markdown-end-resource.ts`, 70 lines): the independent regex, `stripMarkdownCode`, `unescapeMarkdownDestination`, `stripQueryAndFragment`, and the sole `decodeURIComponent` are deleted; the card consumes the shared scanner and the same exported `decodeFileReferenceSpaces`, with case-insensitive `.md`/`.mdx` on the exact decoded path after line/column parsing and unchanged last-unique-document behavior. Render gating in `TranscriptTurnRow` is untouched per the r3 freeze; extraction provably never consumes synthetic streaming closure.
- **MarkdownBody shrink ratchet retired** (prior commit `6b86dcb864`): mechanical extraction of `MarkdownHtmlElement.tsx` and `MarkdownTaskListItem.tsx` takes `MarkdownBody.tsx` from 525 to 294 lines; the exact `ratchets.toml` entry is deleted and no new entries were needed (structure report TOTAL 0).
- `specs/codebase/systems/product/chat/transcript.md` updated truthfully. `transcript-markdown.tsx` and `TurnDocumentReferenceCard.tsx` needed no edits — external-web-first classification and the 01D card path already held.

## Verification

- Domain batch: 5 files / 192 tests; component batch: 5 files / 43 tests; typecheck, strict structure report (TOTAL 0), and check_docs all rc=0. Every row of the spec's acceptance matrix is covered (68 scanner tests alone).
- Negative controls: repair eligibility guard (10 tests fail on revert), `file:` streaming exclusion (2 fail), decode contract vs `decodeURIComponent` (7 fail) and vs a second trim (1 fail, after hardening the fixture so a trailing decoded space is observable). All restored green.

## Follow-ups

- The non-listed-scheme `custom-scheme:1234` case reads as a file reference with a line suffix under the documented `path:line` resolution rule; flagged for reviewer judgment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
