### PR TITLE
fix(product): clear WebKit contextual word selection under replacement context menus (03B)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/files/viewer/FileViewerFrame.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/viewer/FileViewerFrame.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -263,6 +263,26 @@ describe("FileViewerFrame body/content slots", () => {
     const content = container.querySelector("[data-file-viewer-content]") as HTMLElement;
     expect(content.contains(dock)).toBe(false);
     expect(within(content).getByText("file content")).toBeTruthy();
+  });
+
+  // The DOM-fallback PopoverButton wraps the content area with
+  // preserveContextualSelection so real file text keeps platform
+  // select-word-then-menu behavior instead of the chrome-flash clear.
+  it("preserves a contextual selection in the content area (DOM-path opt-out)", () => {
+    const { container } = renderFrame();
+    const content = container.querySelector("[data-file-viewer-content]") as HTMLElement;
+    const textNode = within(content).getByText("file content");
+    const trigger = textNode.parentElement as HTMLElement;
+    const selection = window.getSelection()!;
+    const range = document.createRange();
+    range.selectNodeContents(textNode);
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    fireEvent.contextMenu(trigger);
+
+    expect(selection.rangeCount).toBe(1);
+    selection.removeAllRanges();
   });
 });
 

--- a/apps/packages/product-client/src/components/workspace/files/viewer/FileViewerFrame.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/viewer/FileViewerFrame.tsx
@@ -191,6 +191,9 @@ function FileViewerContentContextMenu({
   return (
     <PopoverButton
       triggerMode="contextMenu"
+      // Content, not chrome: real file text keeps the platform's
+      // select-word-then-menu behavior instead of the chrome-flash clear.
+      preserveContextualSelection
       // C4: a fixed width tuned for this menu's longest item ("Rich
       // preview" + trailing "On"/"Off"); narrower than
       // `POPOVER_SURFACE_CLASS`'s own `min-w-[240px]` deliberately, this is

--- a/apps/packages/product-client/src/hooks/ui/native/use-native-context-menu.test.tsx
+++ b/apps/packages/product-client/src/hooks/ui/native/use-native-context-menu.test.tsx
@@ -59,11 +59,15 @@ function makeDesktopBridge(showContextMenu: DesktopBridge["nativeUi"]["showConte
 function Harness({
   buildItems,
   onDomMenu,
+  preserveContextualSelection,
 }: {
   buildItems: () => Array<{ id: string; label: string }>;
   onDomMenu: () => void;
+  preserveContextualSelection?: boolean;
 }) {
-  const { onContextMenuCapture, showNativeMenu } = useNativeContextMenu(buildItems);
+  const { onContextMenuCapture, showNativeMenu } = useNativeContextMenu(buildItems, {
+    preserveContextualSelection,
+  });
 
   return (
     <div
@@ -86,19 +90,36 @@ function renderHarness({
   desktop,
   buildItems = () => [{ id: "item", label: "Item" }],
   onDomMenu = vi.fn(),
+  preserveContextualSelection,
 }: {
   desktop: DesktopBridge | null;
   buildItems?: () => Array<{ id: string; label: string }>;
   onDomMenu?: () => void;
+  preserveContextualSelection?: boolean;
 }) {
   return {
     onDomMenu,
     ...render(
       <ProductHostProvider host={makeHost(desktop)}>
-        <Harness buildItems={buildItems} onDomMenu={onDomMenu} />
+        <Harness
+          buildItems={buildItems}
+          onDomMenu={onDomMenu}
+          preserveContextualSelection={preserveContextualSelection}
+        />
       </ProductHostProvider>,
     ),
   };
+}
+
+function selectChildTextNode() {
+  const child = screen.getByTestId("child");
+  const selection = window.getSelection();
+  if (!selection) throw new Error("jsdom selection unavailable");
+  const range = document.createRange();
+  range.selectNodeContents(child);
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return selection;
 }
 
 describe("useNativeContextMenu", () => {
@@ -161,5 +182,64 @@ describe("useNativeContextMenu", () => {
     expect(showContextMenu).toHaveBeenCalledTimes(1);
     expect(buildItems).toHaveBeenCalledTimes(1);
     expect(onDomMenu).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears a contextual selection touching the target once it commits to replacing the menu", () => {
+    const showContextMenu = vi.fn().mockResolvedValue(true);
+    renderHarness({ desktop: makeDesktopBridge(showContextMenu) });
+    const selection = selectChildTextNode();
+    expect(selection.isCollapsed).toBe(false);
+
+    fireEvent.contextMenu(screen.getByTestId("child"));
+
+    expect(selection.rangeCount).toBe(0);
+  });
+
+  it("preserves the selection when preserveContextualSelection is true", () => {
+    const showContextMenu = vi.fn().mockResolvedValue(true);
+    renderHarness({
+      desktop: makeDesktopBridge(showContextMenu),
+      preserveContextualSelection: true,
+    });
+    const selection = selectChildTextNode();
+
+    fireEvent.contextMenu(screen.getByTestId("child"));
+
+    expect(selection.rangeCount).toBe(1);
+  });
+
+  it("does not clear the selection when there is no native UI to replace the menu", () => {
+    renderHarness({ desktop: null });
+    const selection = selectChildTextNode();
+
+    fireEvent.contextMenu(screen.getByTestId("child"));
+
+    expect(selection.rangeCount).toBe(1);
+  });
+
+  it("does not clear the selection when there are no items to show", () => {
+    const showContextMenu = vi.fn().mockResolvedValue(true);
+    renderHarness({
+      desktop: makeDesktopBridge(showContextMenu),
+      buildItems: () => [],
+    });
+    const selection = selectChildTextNode();
+
+    fireEvent.contextMenu(screen.getByTestId("child"));
+
+    expect(selection.rangeCount).toBe(1);
+    expect(showContextMenu).not.toHaveBeenCalled();
+  });
+
+  it("stays cleared when native display rejects and re-dispatches the DOM fallback", async () => {
+    const showContextMenu = vi.fn().mockResolvedValue(false);
+    const { onDomMenu } = renderHarness({ desktop: makeDesktopBridge(showContextMenu) });
+    const selection = selectChildTextNode();
+
+    fireEvent.contextMenu(screen.getByTestId("child"));
+
+    expect(selection.rangeCount).toBe(0);
+    await waitFor(() => expect(onDomMenu).toHaveBeenCalledTimes(1));
+    expect(selection.rangeCount).toBe(0);
   });
 });

--- a/apps/packages/product-client/src/hooks/ui/native/use-native-context-menu.ts
+++ b/apps/packages/product-client/src/hooks/ui/native/use-native-context-menu.ts
@@ -4,6 +4,16 @@ import type {
   NativeMenuItem,
 } from "@proliferate/product-client/host/desktop-bridge";
 import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
+import { clearContextualWordSelection } from "#product/primitives/overlays/contextual-word-selection";
+
+export interface UseNativeContextMenuOptions {
+  /**
+   * Skip clearing WebKit's contextual word selection once this handler
+   * commits to replacing the browser menu. Default false (clear). Set true
+   * only over real selectable content (e.g. the file viewer).
+   */
+  preserveContextualSelection?: boolean;
+}
 
 /**
  * Attach the host-provided native context menu to an element. Returns a
@@ -18,7 +28,11 @@ import { useProductHost } from "@proliferate/product-client/host/ProductHostProv
  * `buildItems` runs only when the menu is actually opened, so transient data
  * (e.g. which tab was right-clicked) can be captured via closure.
  */
-export function useNativeContextMenu(buildItems: () => NativeMenuItem[]) {
+export function useNativeContextMenu(
+  buildItems: () => NativeMenuItem[],
+  options: UseNativeContextMenuOptions = {},
+) {
+  const { preserveContextualSelection = false } = options;
   const { buildRef, disabledRef, nativeUi, showNativeMenu } = useNativeMenuController(buildItems);
 
   const onContextMenuCapture = useCallback((event: MouseEvent) => {
@@ -35,12 +49,19 @@ export function useNativeContextMenu(buildItems: () => NativeMenuItem[]) {
     const fallbackEvent = event.nativeEvent;
     event.preventDefault();
     event.stopPropagation();
+    // Committed to replacing the browser menu (non-empty items, native UI
+    // present) — clear before awaiting the bridge. If it rejects, the
+    // synthetic fallback re-dispatches to the DOM path, which re-clears
+    // against its own currentTarget: already-cleared state stays safe.
+    if (!preserveContextualSelection) {
+      clearContextualWordSelection(event.currentTarget);
+    }
     void showNativeMenu(undefined, items).then((shown) => {
       if (!shown) {
         dispatchFallbackContextMenu(fallbackTarget, fallbackEvent);
       }
     });
-  }, [buildRef, disabledRef, nativeUi, showNativeMenu]);
+  }, [buildRef, disabledRef, nativeUi, preserveContextualSelection, showNativeMenu]);
 
   return { onContextMenuCapture, showNativeMenu };
 }

--- a/apps/packages/product-client/src/hooks/workspaces/ui/files/use-file-viewer-native-menu.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/ui/files/use-file-viewer-native-menu.ts
@@ -61,7 +61,14 @@ export function useFileViewerNativeMenu(actions: FileViewerNativeMenuActions) {
   return useNativeMenu(() => buildFileViewerNativeMenuItems(actions));
 }
 
-/** Right-click variant for the viewer content area. */
+/**
+ * Right-click variant for the viewer content area. Source/rendered file text
+ * is content, not chrome: the contextual word selection is normal platform
+ * behavior here, so this opts out of the default clearing.
+ */
 export function useFileViewerNativeContextMenu(actions: FileViewerNativeMenuActions) {
-  return useNativeContextMenu(() => buildFileViewerNativeMenuItems(actions));
+  return useNativeContextMenu(
+    () => buildFileViewerNativeMenuItems(actions),
+    { preserveContextualSelection: true },
+  );
 }

--- a/apps/packages/product-client/src/primitives/PopoverButton.test.tsx
+++ b/apps/packages/product-client/src/primitives/PopoverButton.test.tsx
@@ -52,4 +52,99 @@ describe("PopoverButton", () => {
 
     expect(fireEvent.mouseDown(trigger, { button: 2 })).toBe(false);
   });
+
+  it("clears a contextual selection inside the trigger before opening", () => {
+    render(
+      <PopoverButton
+        trigger={<button type="button"><span>notes.md</span></button>}
+        triggerMode="contextMenu"
+      >
+        {() => <div>menu</div>}
+      </PopoverButton>,
+    );
+    const label = screen.getByText("notes.md");
+    const selection = window.getSelection()!;
+    const range = document.createRange();
+    range.selectNodeContents(label);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    expect(selection.isCollapsed).toBe(false);
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "notes.md" }));
+
+    expect(selection.rangeCount).toBe(0);
+  });
+
+  it("preserves a selection made elsewhere on right-click", () => {
+    render(
+      <div>
+        <p>prose the user selected</p>
+        <PopoverButton
+          trigger={<button type="button">target</button>}
+          triggerMode="contextMenu"
+        >
+          {() => <div>menu</div>}
+        </PopoverButton>
+      </div>,
+    );
+    const paragraph = screen.getByText("prose the user selected");
+    const selection = window.getSelection()!;
+    const range = document.createRange();
+    range.selectNodeContents(paragraph);
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "target" }));
+
+    expect(selection.isCollapsed).toBe(false);
+    expect(selection.rangeCount).toBe(1);
+  });
+
+  it("preserves a deliberate selection with one endpoint outside the trigger", () => {
+    render(
+      <div>
+        <p>before</p>
+        <PopoverButton
+          trigger={<button type="button">target</button>}
+          triggerMode="contextMenu"
+        >
+          {() => <div>menu</div>}
+        </PopoverButton>
+      </div>,
+    );
+    const paragraph = screen.getByText("before");
+    const trigger = screen.getByRole("button", { name: "target" });
+    const selection = window.getSelection()!;
+    const range = document.createRange();
+    range.setStart(paragraph, 0);
+    range.setEnd(trigger, trigger.childNodes.length);
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    fireEvent.contextMenu(trigger);
+
+    expect(selection.rangeCount).toBe(1);
+  });
+
+  it("does not clear the selection when preserveContextualSelection is true", () => {
+    render(
+      <PopoverButton
+        trigger={<button type="button"><span>notes.md</span></button>}
+        triggerMode="contextMenu"
+        preserveContextualSelection
+      >
+        {() => <div>menu</div>}
+      </PopoverButton>,
+    );
+    const label = screen.getByText("notes.md");
+    const selection = window.getSelection()!;
+    const range = document.createRange();
+    range.selectNodeContents(label);
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "notes.md" }));
+
+    expect(selection.rangeCount).toBe(1);
+  });
 });

--- a/apps/packages/product-client/src/primitives/PopoverButton.tsx
+++ b/apps/packages/product-client/src/primitives/PopoverButton.tsx
@@ -12,6 +12,7 @@ import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { Slot } from "@radix-ui/react-slot";
 import { Popover, PopoverTrigger } from "./Popover";
 import { useNativeOverlayRegistration } from "#product/primitives/overlays/overlay-presence";
+import { clearContextualWordSelection } from "#product/primitives/overlays/contextual-word-selection";
 import { POPOVER_SURFACE_CLASS } from "./popover-surface";
 
 type PopoverAlign = "start" | "end";
@@ -56,6 +57,13 @@ interface PopoverButtonProps {
   externalOpen?: boolean;
   /** Called when the popover closes (for controlled mode). */
   onOpenChange?: (open: boolean) => void;
+  /**
+   * Skip clearing WebKit's contextual word selection on `contextMenu`
+   * triggers. Default false (clear). Set true only over real selectable
+   * content, e.g. the file viewer's content area, where select-word-then-menu
+   * is normal platform behavior rather than a chrome flash.
+   */
+  preserveContextualSelection?: boolean;
 }
 
 export function PopoverButton({
@@ -70,6 +78,7 @@ export function PopoverButton({
   triggerMode = "click",
   externalOpen,
   onOpenChange,
+  preserveContextualSelection = false,
 }: PopoverButtonProps) {
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLElement>(null);
@@ -143,6 +152,9 @@ export function PopoverButton({
       event.stopPropagation();
     }
     if (triggerMode === "contextMenu") {
+      if (!preserveContextualSelection) {
+        clearContextualWordSelection(event.currentTarget);
+      }
       pointRef.current =
         typeof event.clientX === "number" && typeof event.clientY === "number"
           ? { x: event.clientX, y: event.clientY }

--- a/apps/packages/product-client/src/primitives/overlays/contextual-word-selection.test.ts
+++ b/apps/packages/product-client/src/primitives/overlays/contextual-word-selection.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+import { clearContextualWordSelection } from "#product/primitives/overlays/contextual-word-selection";
+
+function selectContents(element: Element) {
+  const selection = window.getSelection();
+  if (!selection) throw new Error("jsdom selection unavailable");
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return selection;
+}
+
+function selectAcross(start: Element, end: Element) {
+  const selection = window.getSelection();
+  if (!selection) throw new Error("jsdom selection unavailable");
+  const range = document.createRange();
+  range.setStart(start, 0);
+  range.setEnd(end, end.childNodes.length);
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return selection;
+}
+
+afterEach(() => {
+  window.getSelection()?.removeAllRanges();
+  document.body.innerHTML = "";
+});
+
+describe("clearContextualWordSelection", () => {
+  it("clears a selection fully inside the container", () => {
+    document.body.innerHTML = "<button><span>notes.md</span></button>";
+    const button = document.querySelector("button")!;
+    const selection = selectContents(button.firstElementChild!);
+    expect(selection.isCollapsed).toBe(false);
+
+    clearContextualWordSelection(button);
+
+    expect(selection.rangeCount).toBe(0);
+  });
+
+  it("clears a selection whose endpoint is a descendant of the container", () => {
+    document.body.innerHTML = "<button><span><em>notes.md</em></span></button>";
+    const button = document.querySelector("button")!;
+    selectContents(button.querySelector("em")!);
+
+    clearContextualWordSelection(button);
+
+    expect(window.getSelection()?.rangeCount).toBe(0);
+  });
+
+  it("leaves a selection made entirely elsewhere alone", () => {
+    document.body.innerHTML = "<p>prose the user selected</p><button>notes.md</button>";
+    const selection = selectContents(document.querySelector("p")!);
+
+    clearContextualWordSelection(document.querySelector("button")!);
+
+    expect(selection.isCollapsed).toBe(false);
+    expect(selection.rangeCount).toBe(1);
+  });
+
+  it("preserves a deliberate selection with one endpoint outside the container", () => {
+    document.body.innerHTML = "<p>before</p><button>notes.md</button>";
+    const paragraph = document.querySelector("p")!;
+    const button = document.querySelector("button")!;
+    const selection = selectAcross(paragraph, button);
+    expect(selection.isCollapsed).toBe(false);
+
+    clearContextualWordSelection(button);
+
+    expect(selection.rangeCount).toBe(1);
+  });
+
+  it("no-ops for a collapsed selection", () => {
+    document.body.innerHTML = "<button>notes.md</button>";
+    const button = document.querySelector("button")!;
+    const selection = window.getSelection()!;
+    const range = document.createRange();
+    range.selectNodeContents(button);
+    range.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    expect(selection.isCollapsed).toBe(true);
+
+    clearContextualWordSelection(button);
+
+    expect(selection.rangeCount).toBe(1);
+  });
+
+  it("tolerates no selection and non-element targets", () => {
+    document.body.innerHTML = "<button>notes.md</button>";
+    expect(() => clearContextualWordSelection(document.querySelector("button")!)).not.toThrow();
+    expect(() => clearContextualWordSelection(null)).not.toThrow();
+    expect(() => clearContextualWordSelection(window)).not.toThrow();
+  });
+});

--- a/apps/packages/product-client/src/primitives/overlays/contextual-word-selection.ts
+++ b/apps/packages/product-client/src/primitives/overlays/contextual-word-selection.ts
@@ -1,0 +1,31 @@
+/**
+ * macOS WebKit selects the word under the pointer while preparing a context
+ * menu — inside the platform's sendContextMenuEvent, after mousedown but
+ * before the DOM `contextmenu` event is dispatched — so no preventDefault on
+ * either event stops it. A handler that replaces the browser menu calls this
+ * synchronously to drop that just-made selection before it ever paints.
+ *
+ * Only a selection with BOTH endpoints inside `container` is cleared: the
+ * WebKit contextual word selection is always fully inside the right-clicked
+ * element, so a selection with one endpoint outside cannot be it — it is a
+ * deliberate selection that merely touches the trigger, and clearing it
+ * would destroy user intent.
+ */
+export function clearContextualWordSelection(container: EventTarget | null): void {
+  if (!(container instanceof Element)) {
+    return;
+  }
+  const selection = container.ownerDocument?.getSelection?.();
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+    return;
+  }
+  const { anchorNode, focusNode } = selection;
+  const containedBoth =
+    anchorNode !== null
+    && focusNode !== null
+    && container.contains(anchorNode)
+    && container.contains(focusNode);
+  if (containedBoth) {
+    selection.removeAllRanges();
+  }
+}

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -533,6 +533,16 @@ stats for `Review changes` on hover/focus. File headers retain the shared diff
 line-wrap context menu. Aggregate and file-row stats use the semantic dark-theme
 green/red tokens (`#40c977` and `#fa423e`) and roll changed digits over 300ms
 with the standard enter curve; reduced-motion users receive no digit transition.
+Right-clicking a transcript file reference, edit filename, or diff line-wrap
+trigger clears any WebKit contextual word selection synchronously in the
+`contextmenu` handler before the replacement menu opens, since macOS WebKit
+selects the word under the pointer inside its own context-menu path and
+`preventDefault` cannot stop it. The clear only fires when both the
+selection's anchor and focus nodes are contained by the right-clicked
+element; a selection made elsewhere, or one with an endpoint outside that
+element, is left untouched. This is chrome behavior; it does not apply to
+selecting or right-clicking transcript prose or code-block text itself.
+
 Single-file cards put the filename in the header and do not duplicate a file
 row underneath. Expanded multi-file cards collapse through `Collapse files`.
 The shell follows a restrained three-level surface hierarchy: its header

--- a/specs/codebase/systems/product/workspaces/files.md
+++ b/specs/codebase/systems/product/workspaces/files.md
@@ -258,7 +258,12 @@ subview, containing (left to right, via `FileViewerToolbar`):
   preview` (omitted for `fileDiff` and non-previewable targets). Native menus
   carry no checkmark state, so toggles read as "Enable/Disable …" verbs. The
   content-area context-menu trigger wraps only `[data-file-viewer-content]`,
-  never the docked file tree.
+  never the docked file tree. Both the native context-menu hook and its DOM
+  popover fallback pass `preserveContextualSelection: true` here, so
+  right-clicking real source or rendered file text keeps the platform's
+  select-word-then-open-menu behavior instead of the chrome-flash clear that
+  other context-menu triggers (toolbar, breadcrumbs, file tree) apply by
+  default.
 - **Open-in split action**: rendered only when Slice 01D's
   `useFileReferenceActions` reports a settled local `nativePathKind`,
   non-empty `openTargets`, and a non-null `defaultOpenTarget` — fail-closed,


### PR DESCRIPTION
Implements frozen spec **03B – Contextual Selection Hardening** (Frozen r1, base `c4f6a195` = the 03A merge). Replacing the browser context menu on transcript chrome no longer leaves WebKit's contextual word selection flashing under the Desktop native menu or the DOM fallback, while deliberate selections and real file-content selection behavior are preserved.

## What this does

- New pure DOM leaf `primitives/overlays/contextual-word-selection.ts` (31 lines): `clearContextualWordSelection(container)` no-ops for non-element/no-selection/zero-ranges/collapsed and clears only when **both** the selection anchor and focus nodes are contained by the handler's element — the r1 freeze ruling that supersedes the r0 "anchor or focus" wording so a deliberate selection merely touching the trigger survives. Never serializes or logs selection contents; missing Selection APIs are a no-op. No Radix, no barrel (mirrors the `overlay-presence.ts` precedent).
- `PopoverButton` gains `preserveContextualSelection?: boolean` (default false): the `contextMenu` trigger clears via the helper before opening. The existing secondary-mousedown prevention from #1885 is untouched and its pinning tests remain.
- `useNativeContextMenu(buildItems, { preserveContextualSelection? })`: clears only after committing to replace the browser menu (non-empty items, native UI available) and before awaiting the bridge; a non-replacing path never clears; the native-rejection synthetic fallback stays idempotent. All 9 other call sites keep the one-argument form and default behavior.
- File-viewer exception: the content-area menu opts out on both paths (`useFileViewerNativeContextMenu` passes the flag; `FileViewerFrame`'s DOM-fallback `PopoverButton` passes it), so right-click word selection in source/rendered file text keeps platform behavior. Toolbar, breadcrumbs, transcript file references, and tool rows keep the default clearing.
- Docs prose added to `specs/codebase/systems/product/chat/transcript.md` and `.../workspaces/files.md`.

## Verification

- 6 test files / 57 tests green; typecheck, strict structure report (TOTAL 0), boundary, max-lines, and docs checkers all rc=0.
- Negative controls: reverting the both-endpoints predicate to anchor-or-focus fails the endpoint-outside-preservation tests; moving the native clear after the bridge await fails the commit-ordering and rejection-idempotence tests. Both restored green.

## Follow-ups (ledgered)

- 03B-P2-01: whether `ChatDiffLineWrapContextMenu` (which wraps diff content) should also opt out as content rather than chrome — deliberately left on the default in this slice pending a product ruling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
