### PR TITLE
feat(product): transcript reference consistency (03C narrowed r2)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundSubagentView.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundSubagentView.test.tsx
@@ -34,6 +34,12 @@ vi.mock("#product/hooks/chat/derived/use-active-session-transcript-state", () =>
 vi.mock("#product/hooks/activity/derived/use-feed-stream", () => ({
   useFeedStream: (...args: unknown[]) => useFeedStreamMock(...args),
 }));
+const renderTranscriptLinkMock = vi.fn(() => null);
+const renderTranscriptInlineCodeMock = vi.fn(() => null);
+vi.mock("#product/components/workspace/chat/transcript/transcript-markdown", () => ({
+  renderTranscriptLink: (...args: unknown[]) => renderTranscriptLinkMock(...args),
+  renderTranscriptInlineCode: (...args: unknown[]) => renderTranscriptInlineCodeMock(...args),
+}));
 // Mirrors AgentsPaneDetail.test.tsx's convention: MessageList's own row
 // rendering is its own test's responsibility. Here we assert on the
 // `transcript` prop it receives, which is where BackgroundSubagentView's
@@ -142,6 +148,8 @@ afterEach(() => {
   sessionAgentKind = "claude";
   useFeedStreamMock.mockClear();
   messageListPropsSpy.mockClear();
+  renderTranscriptLinkMock.mockClear();
+  renderTranscriptInlineCodeMock.mockClear();
   cleanup();
 });
 
@@ -178,6 +186,32 @@ describe("BackgroundSubagentView", () => {
 
     expect(screen.getByText("Initial prompt")).toBeTruthy();
     expect(screen.getByText("Inspect the transcript pipeline.")).toBeTruthy();
+  });
+
+  it("wires only the link transcript renderer into the initial-prompt body (user-authored)", () => {
+    const transcript = createTranscriptState("session-1");
+    const item = launchToolCallItem({
+      rawInput: {
+        run_in_background: true,
+        prompt: "See [config](/repo/config.json) and `src/index.ts`.",
+      },
+    });
+    transcript.itemsById[item.itemId] = item;
+    transcriptState = { transcript };
+
+    render(
+      <BackgroundSubagentView
+        subagent={makeSubagent()}
+        sessionId="session-1"
+        workspaceId="workspace-1"
+        onBack={() => {}}
+      />,
+    );
+
+    expect(renderTranscriptLinkMock).toHaveBeenCalled();
+    // The prompt is user-authored: backticked text must stay inert, so the
+    // inline-code renderer is never injected even though the content has one.
+    expect(renderTranscriptInlineCodeMock).not.toHaveBeenCalled();
   });
 
   it("omits the initial-prompt panel when no launch tool call correlates", () => {

--- a/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundSubagentView.tsx
+++ b/apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundSubagentView.tsx
@@ -8,6 +8,7 @@ import { ToolActionDetailsPanel } from "#product/components/workspace/chat/tool-
 import { MarkdownBody } from "#product/components/workspace/chat/transcript/MarkdownBody";
 import { MessageList } from "#product/components/workspace/chat/transcript/MessageList";
 import { renderDesktopCodeBlock } from "#product/components/content/ui/desktop-markdown-code-block";
+import { renderTranscriptLink } from "#product/components/workspace/chat/transcript/transcript-markdown";
 import { TOOL_CALL_BODY_MAX_HEIGHT_CLASS } from "#product/domain/chats/tools/tool-call-layout";
 import {
   subagentDisplayTitle,
@@ -148,6 +149,7 @@ export function BackgroundSubagentView({
                     content={promptText}
                     className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
                     renderCodeBlock={renderDesktopCodeBlock}
+                    renderLink={renderTranscriptLink}
                   />
                 </div>
               </AutoHideScrollArea>

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/CollapsedEditActionRows.test.tsx
@@ -165,6 +165,28 @@ describe("CollapsedEditActionRows", () => {
     });
   });
 
+  it("keeps an unavailable filename as inert text, not a pointer dead zone over the row's toggle layer", () => {
+    fileReferenceOpenState.canOpenPrimary = false;
+
+    render(<EditRows item={editItem({ patch: true })} />);
+
+    // Unavailable: the filename is inert text, not a button — clicking it
+    // does not open the file.
+    expect(screen.queryByRole("button", { name: "edit-1.ts" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Open edit-1.ts" })).toBeNull();
+    const filenameLabel = screen.getByText("edit-1.ts");
+    expect(filenameLabel.tagName).toBe("SPAN");
+    // Never re-enables pointer events over the row's toggle layer: the
+    // ancestor wraps everything in `pointer-events-none`, and only the
+    // actionable Button variants opt back in with `pointer-events-auto`.
+    // The inert label carries no such override, so a real click on its
+    // screen position still hits the toggle overlay underneath.
+    expect(filenameLabel.className).not.toContain("pointer-events-auto");
+
+    fireEvent.click(filenameLabel);
+    expect(openPrimaryMock).not.toHaveBeenCalled();
+  });
+
   it("keeps workspacePath for a plain edit with no newPath", () => {
     const item = editItem();
     const part = item.contentParts[0];

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileReadCall.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/FileReadCall.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { FileReadCall } from "#product/components/workspace/chat/tool-calls/FileReadCall";
 
 const chipInputs = vi.hoisted(() => ([] as Array<Record<string, unknown>>));
+const codeBlockInputs = vi.hoisted(() => ([] as Array<Record<string, unknown>>));
 
 vi.mock("#product/components/workspace/chat/tool-calls/ToolFileChip", () => ({
   ToolFileChip: (props: Record<string, unknown>) => {
@@ -13,9 +14,20 @@ vi.mock("#product/components/workspace/chat/tool-calls/ToolFileChip", () => ({
   },
 }));
 
+// Highlighting/clipboard/host wiring is HighlightedCodeBlock's own concern;
+// this test is only about FileReadCall wiring the right line-numbering
+// props into it.
+vi.mock("#product/components/content/ui/HighlightedCodeBlock", () => ({
+  HighlightedCodeBlock: (props: Record<string, unknown>) => {
+    codeBlockInputs.push(props);
+    return <div data-mocked-highlighted-code-block />;
+  },
+}));
+
 afterEach(() => {
   cleanup();
   chipInputs.length = 0;
+  codeBlockInputs.length = 0;
 });
 
 describe("FileReadCall", () => {
@@ -40,5 +52,62 @@ describe("FileReadCall", () => {
       rawPath: "src/raw.ts",
       workspacePath: null,
     }));
+  });
+
+  // 03C r2: regression pinning only, demoted from new work by the freeze
+  // audit — do NOT switch the ASCII hyphen to an en dash.
+  describe("scope labels (FileReadCall.tsx:84-99)", () => {
+    it("renders a single-line scope as 'line N'", () => {
+      const { getByText } = render(
+        <FileReadCall path="src/a.ts" scope="line" line={12} />,
+      );
+      expect(getByText("line 12")).not.toBeNull();
+    });
+
+    it("renders a full range scope with an ASCII hyphen, not an en dash", () => {
+      const { getByText, queryByText } = render(
+        <FileReadCall path="src/a.ts" scope="range" startLine={10} endLine={20} />,
+      );
+      expect(getByText("lines 10-20")).not.toBeNull();
+      expect(queryByText("lines 10–20")).toBeNull();
+    });
+
+    it("renders an open-ended range as 'from line N'", () => {
+      const { getByText } = render(
+        <FileReadCall path="src/a.ts" scope="range" startLine={10} endLine={null} />,
+      );
+      expect(getByText("from line 10")).not.toBeNull();
+    });
+
+    it("has no scope label for a full-file read", () => {
+      const { container } = render(<FileReadCall path="src/a.ts" scope={null} />);
+      expect(container.textContent).not.toContain("line");
+    });
+  });
+
+  describe("preview line numbering", () => {
+    it("shows line numbers starting at the scoped start line for a partial read", () => {
+      render(
+        <FileReadCall
+          path="src/a.ts"
+          scope="range"
+          startLine={5}
+          endLine={7}
+          preview={"one\ntwo\nthree"}
+          defaultExpanded
+        />,
+      );
+      expect(codeBlockInputs).toContainEqual(expect.objectContaining({
+        showLineNumbers: true,
+        lineNumberStart: 5,
+      }));
+    });
+
+    it("does not show line numbers for a full-file preview", () => {
+      render(<FileReadCall path="src/a.ts" scope={null} preview={"one\ntwo"} defaultExpanded />);
+      expect(codeBlockInputs).toContainEqual(expect.objectContaining({
+        showLineNumbers: false,
+      }));
+    });
   });
 });

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/SkillsToolResultRow.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/SkillsToolResultRow.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SkillsToolResultRow } from "#product/components/workspace/chat/tool-calls/SkillsToolResultRow";
+import type { SkillsToolResultPresentation } from "#product/domain/chats/tools/skills-tool-result";
+
+const renderTranscriptLinkMock = vi.fn(() => null);
+const renderTranscriptInlineCodeMock = vi.fn(() => null);
+
+vi.mock("#product/components/workspace/chat/transcript/transcript-markdown", () => ({
+  renderTranscriptLink: (...args: unknown[]) => renderTranscriptLinkMock(...args),
+  renderTranscriptInlineCode: (...args: unknown[]) => renderTranscriptInlineCodeMock(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  renderTranscriptLinkMock.mockClear();
+  renderTranscriptInlineCodeMock.mockClear();
+});
+
+function activatePresentation(instructions: string): SkillsToolResultPresentation {
+  return {
+    kind: "activate",
+    skillId: "repo-explorer",
+    displayName: "Repo Explorer",
+    description: "Explores the repository.",
+    instructions,
+    requiredMcpServers: [],
+    credentialBindingIds: [],
+    resources: [],
+  };
+}
+
+function resourcePresentation(content: string): SkillsToolResultPresentation {
+  return {
+    kind: "resource",
+    skillId: "repo-explorer",
+    resourceId: "readme",
+    displayName: "README",
+    contentType: "text/markdown",
+    content,
+  };
+}
+
+describe("SkillsToolResultRow", () => {
+  it("labels and hints a skill-activation row", () => {
+    render(
+      <SkillsToolResultRow presentation={activatePresentation("Read `src/index.ts`.")} status="completed" />,
+    );
+    expect(screen.getByText("Skill activated")).toBeTruthy();
+  });
+
+  it("wires both link and inline-code transcript renderers into the instructions body (assistant-authored)", () => {
+    render(
+      <SkillsToolResultRow
+        presentation={activatePresentation("See [config](/repo/config.json) and `src/index.ts`.")}
+        status="completed"
+      />,
+    );
+    fireEvent.click(screen.getByText("Skill activated"));
+
+    expect(renderTranscriptLinkMock).toHaveBeenCalledWith(
+      expect.objectContaining({ href: "/repo/config.json" }),
+    );
+    expect(renderTranscriptInlineCodeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "src/index.ts" }),
+    );
+  });
+
+  it("wires both link and inline-code transcript renderers into the resource body (assistant-authored)", () => {
+    render(
+      <SkillsToolResultRow
+        presentation={resourcePresentation("See [config](/repo/config.json) and `src/index.ts`.")}
+        status="completed"
+      />,
+    );
+    fireEvent.click(screen.getByText("Skill resource loaded"));
+
+    expect(renderTranscriptLinkMock).toHaveBeenCalledWith(
+      expect.objectContaining({ href: "/repo/config.json" }),
+    );
+    expect(renderTranscriptInlineCodeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "src/index.ts" }),
+    );
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/SkillsToolResultRow.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/SkillsToolResultRow.tsx
@@ -2,6 +2,10 @@ import { AutoHideScrollArea } from "#product/primitives/patterns/AutoHideScrollA
 import { ProliferateIcon } from "#product/primitives/icons/proliferate-icons";
 import { MarkdownBody } from "#product/components/workspace/chat/transcript/MarkdownBody";
 import { renderDesktopCodeBlock } from "#product/components/content/ui/desktop-markdown-code-block";
+import {
+  renderTranscriptInlineCode,
+  renderTranscriptLink,
+} from "#product/components/workspace/chat/transcript/transcript-markdown";
 import { TOOL_CALL_BODY_MAX_HEIGHT_CLASS } from "#product/domain/chats/tools/tool-call-layout";
 import type { SkillsToolResultPresentation } from "#product/domain/chats/tools/skills-tool-result";
 import { ToolActionDetailsPanel } from "#product/components/workspace/chat/tool-calls/ToolActionDetailsPanel";
@@ -97,6 +101,8 @@ function SkillsToolResultDetails({
             content={presentation.instructions}
             className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
             renderCodeBlock={renderDesktopCodeBlock}
+            renderLink={renderTranscriptLink}
+            renderInlineCode={renderTranscriptInlineCode}
           />
           {presentation.resources.length > 0 ? (
             <div className="flex flex-wrap gap-1.5 border-t border-border/60 pt-2">
@@ -123,6 +129,8 @@ function SkillsToolResultDetails({
               content={presentation.content}
               className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
               renderCodeBlock={renderDesktopCodeBlock}
+              renderLink={renderTranscriptLink}
+              renderInlineCode={renderTranscriptInlineCode}
             />
           ) : (
             <pre className="m-0 whitespace-pre-wrap font-mono text-readable-code text-foreground">

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/cowork/CoworkCodingToolLedger.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/cowork/CoworkCodingToolLedger.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CoworkCodingLedger,
+  shouldShowCoworkCodingLedger,
+} from "#product/components/workspace/chat/tool-calls/cowork/CoworkCodingToolLedger";
+
+const renderTranscriptLinkMock = vi.fn(() => null);
+const renderTranscriptInlineCodeMock = vi.fn(() => null);
+
+vi.mock("#product/components/workspace/chat/transcript/transcript-markdown", () => ({
+  renderTranscriptLink: (...args: unknown[]) => renderTranscriptLinkMock(...args),
+  renderTranscriptInlineCode: (...args: unknown[]) => renderTranscriptInlineCodeMock(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  renderTranscriptLinkMock.mockClear();
+  renderTranscriptInlineCodeMock.mockClear();
+});
+
+describe("shouldShowCoworkCodingLedger", () => {
+  it("shows for the coding actions, not for unrelated ones", () => {
+    expect(shouldShowCoworkCodingLedger("create_workspace")).toBe(true);
+    expect(shouldShowCoworkCodingLedger("create_session")).toBe(true);
+    expect(shouldShowCoworkCodingLedger("send_message")).toBe(true);
+    expect(shouldShowCoworkCodingLedger("schedule_wake")).toBe(true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(shouldShowCoworkCodingLedger("other" as any)).toBe(false);
+  });
+});
+
+describe("CoworkCodingLedger prompt disclosure (user-authored)", () => {
+  it("wires renderLink only into the prompt Markdown; user backticks stay inert", () => {
+    render(
+      <CoworkCodingLedger
+        action="send_message"
+        prompt="See [config](/repo/config.json) and `src/index.ts`."
+        promptStatus="running"
+        canOpenCodingSession
+        canOpenWorkspace={false}
+        failed={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Sent coding message/ }));
+
+    expect(renderTranscriptLinkMock).toHaveBeenCalledWith(
+      expect.objectContaining({ href: "/repo/config.json" }),
+    );
+    // No renderInlineCode is wired for this user-authored surface: the
+    // shared MarkdownBody default handling renders the backtick literally
+    // instead of ever reaching our transcript renderer.
+    expect(renderTranscriptInlineCodeMock).not.toHaveBeenCalled();
+    expect(screen.getByText("src/index.ts", { exact: false })).toBeTruthy();
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/chat/tool-calls/cowork/CoworkCodingToolLedger.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/tool-calls/cowork/CoworkCodingToolLedger.tsx
@@ -5,6 +5,7 @@ import { MessageSquare } from "#product/primitives/icons/product";
 import { Button } from "#product/primitives/Button";
 import { MarkdownBody } from "#product/components/workspace/chat/transcript/MarkdownBody";
 import { renderDesktopCodeBlock } from "#product/components/content/ui/desktop-markdown-code-block";
+import { renderTranscriptLink } from "#product/components/workspace/chat/transcript/transcript-markdown";
 import { ToolActionDetailsPanel } from "#product/components/workspace/chat/tool-calls/ToolActionDetailsPanel";
 import { TOOL_CALL_BODY_MAX_HEIGHT_CLASS } from "#product/domain/chats/tools/tool-call-layout";
 import type { CoworkCodingAction } from "#product/domain/chats/tools/cowork-coding-tool-presentation";
@@ -147,6 +148,7 @@ function PromptActionRow({
                   content={prompt}
                   className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
                   renderCodeBlock={renderDesktopCodeBlock}
+                  renderLink={renderTranscriptLink}
                 />
               </div>
             </AutoHideScrollArea>

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
@@ -14,6 +14,10 @@ import { ChevronRight } from "#product/primitives/icons/core";
 import { Robot } from "#product/primitives/icons/product";
 import { MarkdownBody } from "#product/components/workspace/chat/transcript/MarkdownBody";
 import { renderDesktopCodeBlock } from "#product/components/content/ui/desktop-markdown-code-block";
+import {
+  renderTranscriptInlineCode,
+  renderTranscriptLink,
+} from "#product/components/workspace/chat/transcript/transcript-markdown";
 import { AgentIdentityChip } from "#product/components/patterns/AgentIdentityChip";
 import { buildDelegatedAgentIdentity } from "#product/lib/domain/delegated-work/identity";
 import { SubagentLaunchLedger } from "#product/components/workspace/chat/transcript/SubagentLaunchLedger";
@@ -357,6 +361,8 @@ function AgentResultBlock({ content }: { content: string }) {
             content={content}
             className="[&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
             renderCodeBlock={renderDesktopCodeBlock}
+            renderLink={renderTranscriptLink}
+            renderInlineCode={renderTranscriptInlineCode}
           />
         </div>
         {!resultExpanded && needsTruncation && (

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/transcript-markdown.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/transcript-markdown.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import { createElement } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTranscriptState } from "@anyharness/sdk";
+import type { ToolCallItem } from "@anyharness/sdk";
+import { toolItem } from "#product/domain/chats/transcript/transcript-presentation-test-fixtures";
+import { TranscriptAgentGroupBlock } from "#product/components/workspace/chat/transcript/TranscriptAgentGroupBlock";
+import { PromptContentRenderer } from "#product/components/workspace/chat/content/PromptContentRenderer";
+
+// This file pins the authorship matrix — which transcript-owned surfaces
+// wire which of transcript-markdown's two renderers, per 03C r2's
+// authorized scope. Assistant/skill-authored surfaces (`SkillsToolResultRow`,
+// `TranscriptAgentGroupBlock` delegated result) wire both `renderLink` and
+// `renderInlineCode`; user-authored surfaces (`CoworkCodingToolLedger`
+// prompt, `BackgroundSubagentView` initial prompt) wire `renderLink` only,
+// so user backticked text stays inert per the standing product rule the
+// r1 body itself defers. `SkillsToolResultRow.test.tsx` and
+// `cowork/CoworkCodingToolLedger.test.tsx` cover those two surfaces
+// directly; this file covers the remaining owner (`TranscriptAgentGroupBlock`)
+// plus the shared `PromptContentRenderer` precedent the matrix is modeled
+// on, and pins the renderers' own external-web-first classification.
+
+afterEach(cleanup);
+
+describe("renderTranscriptLink (real implementation, unmocked)", () => {
+  it("does not convert an ordinary external web link (external-web-first)", async () => {
+    const { renderTranscriptLink } = await vi.importActual<
+      typeof import("#product/components/workspace/chat/transcript/transcript-markdown")
+    >("#product/components/workspace/chat/transcript/transcript-markdown");
+
+    expect(renderTranscriptLink({ href: "https://example.com/docs", children: "docs" })).toBeNull();
+    const fileResult = renderTranscriptLink({ href: "/repo/src/index.ts", children: "index.ts" });
+    expect(fileResult).not.toBeNull();
+  });
+});
+
+const renderTranscriptLinkMock = vi.fn(() => null);
+const renderTranscriptInlineCodeMock = vi.fn(() => null);
+
+vi.mock("#product/components/workspace/chat/transcript/transcript-markdown", () => ({
+  renderTranscriptLink: (...args: unknown[]) => renderTranscriptLinkMock(...args),
+  renderTranscriptInlineCode: (...args: unknown[]) => renderTranscriptInlineCodeMock(...args),
+  renderTranscriptCodeBlock: () => null,
+}));
+
+vi.mock("#product/hooks/access/anyharness/sessions/use-prompt-attachment-url", () => ({
+  usePromptAttachmentUrl: () => ({ data: null, blob: null, isLoading: false, isError: false }),
+}));
+vi.mock("#product/components/workspace/chat/content/PlanReferenceAttachmentCard", () => ({
+  PlanReferenceAttachmentCard: () => null,
+}));
+
+describe("authorship matrix: TranscriptAgentGroupBlock delegated result (assistant-authored)", () => {
+  afterEach(() => {
+    renderTranscriptLinkMock.mockClear();
+    renderTranscriptInlineCodeMock.mockClear();
+  });
+
+  it("wires both renderLink and renderInlineCode into the delegated-agent result Markdown", () => {
+    const transcript = createTranscriptState("session-1");
+    const item: ToolCallItem = {
+      ...toolItem("native-task", "turn-1", 1, "subagent", "completed"),
+      title: "Inspect the repository",
+      nativeToolName: "Task",
+      rawInput: { prompt: "Inspect the transcript pipeline" },
+      rawOutput: { summary: "See [config](/repo/config.json) and `src/index.ts`." },
+    };
+    transcript.itemsById[item.itemId] = item;
+
+    render(
+      createElement(TranscriptAgentGroupBlock, {
+        item,
+        childIds: [],
+        transcript,
+        childrenByParentId: new Map(),
+        renderChild: () => null,
+      }),
+    );
+
+    fireEvent.click(screen.getByText("Inspect the repository"));
+
+    expect(renderTranscriptLinkMock).toHaveBeenCalledWith(
+      expect.objectContaining({ href: "/repo/config.json" }),
+    );
+    expect(renderTranscriptInlineCodeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "src/index.ts" }),
+    );
+  });
+});
+
+describe("authorship matrix: PromptContentRenderer (user-authored precedent)", () => {
+  afterEach(() => {
+    renderTranscriptLinkMock.mockClear();
+    renderTranscriptInlineCodeMock.mockClear();
+  });
+
+  it("wires renderLink only; user backticks stay inert (the precedent CoworkCodingToolLedger/BackgroundSubagentView follow)", () => {
+    render(
+      createElement(PromptContentRenderer, {
+        sessionId: null,
+        parts: [{ type: "text", text: "See [config](/repo/config.json) and `src/index.ts`." }],
+      }),
+    );
+
+    expect(renderTranscriptLinkMock).toHaveBeenCalledWith(
+      expect.objectContaining({ href: "/repo/config.json" }),
+    );
+    expect(renderTranscriptInlineCodeMock).not.toHaveBeenCalled();
+  });
+});

--- a/specs/codebase/systems/product/chat/transcript.md
+++ b/specs/codebase/systems/product/chat/transcript.md
@@ -146,6 +146,35 @@ anyharness .../domains/sessions/response_formatting.rs
   file links with the complete workspace-root path, never abbreviated
 ```
 
+`transcript-markdown.tsx`'s `renderTranscriptLink`/`renderTranscriptInlineCode`
+pair is injected across every current transcript-owned Markdown surface, with
+the injection matched to whether the surface's text is assistant/skill-authored
+or user-authored. Assistant/skill-authored bodies wire both renderers, so
+path-like inline code becomes a file reference the same as an explicit link.
+User-authored bodies wire `renderLink` only, so a link a user actually typed
+still opens the file but a backticked path a user typed stays inert code —
+never reinterpreted without a separate product decision:
+
+```text
+apps/packages/product-client/src/components/workspace/chat/tool-calls/SkillsToolResultRow.tsx
+  assistant/skill-authored — instructions and resource-body MarkdownBody
+  calls wire both renderLink and renderInlineCode
+
+apps/packages/product-client/src/components/workspace/chat/transcript/TranscriptAgentGroupBlock.tsx
+  assistant-authored — the delegated-agent result MarkdownBody wires both
+  renderLink and renderInlineCode
+
+apps/packages/product-client/src/components/workspace/chat/tool-calls/cowork/CoworkCodingToolLedger.tsx
+  user-authored — the disclosed coding prompt wires renderLink only
+
+apps/packages/product-client/src/components/workspace/activity/background-pane/BackgroundSubagentView.tsx
+  user-authored — the "Initial prompt" panel wires renderLink only;
+  SubagentLaunchLedger no longer owns any prompt Markdown
+
+apps/packages/product-client/src/components/workspace/chat/content/PromptContentRenderer.tsx
+  user-authored precedent the matrix above follows — wires renderLink only
+```
+
 Rules:
 
 - Detection happens at render time from raw markdown; do not store parsed file


### PR DESCRIPTION
Implements frozen spec **03C – Transcript Reference Consistency** (Frozen r2 NARROWED, base `dd2a5a0d` = the 03B merge). Every transcript-owned Markdown surface now renders the same resolvable file link (and, where assistant-authored, inline-code path) treatment as assistant prose. The r1 body's founder-level product reversals (plain badge variant, chip→plain, ink reversal, edit-menu narrowing, tooltip change, user inline-code reinterpretation) are explicitly deferred (03C-DEFER-01..06) and NOT in this PR.

## What this does

- **Renderer injections per the authorship matrix**, matching the landed `PromptContentRenderer` precedent:
  - `SkillsToolResultRow.tsx` (instructions + resource body, assistant/skill-authored): `renderLink` + `renderInlineCode`.
  - `TranscriptAgentGroupBlock.tsx` (delegated result, assistant-authored): both renderers.
  - `CoworkCodingToolLedger.tsx` (prompt) and `BackgroundSubagentView.tsx` (initial prompt), user-authored: `renderLink` ONLY — user backticked text stays inert per the standing product rule.
- **New tests**: table-driven `transcript-markdown.test.tsx` (authorship matrix + unmocked external-web-first `renderTranscriptLink` check), new `SkillsToolResultRow.test.tsx` and `cowork/CoworkCodingToolLedger.test.tsx` (injection wiring).
- **Regression pinning** of previously unpinned landed behavior: `FileReadCall.test.tsx` scope labels (`line N`, ASCII-hyphen `lines N-M`, `from line N`, none for full read) and preview line-numbering wiring; `CollapsedEditActionRows.test.tsx` unavailable-filename inertness (plain span, no `pointer-events-auto`, no `openPrimary`).
- **Docs**: `specs/codebase/systems/product/chat/transcript.md` gains a truthful surface/authorship injection matrix. No ink/menu doctrine touched.

## Verification

- 9 test files / 63 tests green via `exec vitest run`; typecheck rc=0; strict structure report TOTAL 0; docs, boundary, and design-attribution checkers rc=0.
- Negative control: removing the `SkillsToolResultRow` injections failed the corresponding test; restored green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
