### PR TITLE
feat(product): file reference line navigation (03D r2)

### DIFF
--- a/apps/packages/product-client/src/components/workspace/files/FileEditorView.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/FileEditorView.test.tsx
@@ -471,4 +471,41 @@ describe("FileEditorView", () => {
     });
     expect(useWorkspaceViewerTabsStore.getState().modeByTargetKey[targetKey]).toBe("rendered");
   });
+
+  it("forces source mode on mount when a location request is already pending (closed-target reopen)", () => {
+    const target = fileViewerTarget("README.md");
+    const targetKey = viewerTargetKey(target);
+    useWorkspaceViewerTabsStore.setState({
+      materializedWorkspaceId: "workspace-1",
+    });
+    // Mirrors useFileReferenceActions.openViewer: the location request token
+    // is minted synchronously with activation, so by the time FileEditorView
+    // mounts (e.g. RightPanelContent remounting it for a previously closed
+    // target) a non-zero token is already present on first render.
+    useWorkspaceViewerTabsStore.getState().openTarget(target);
+    useWorkspaceViewerTabsStore.getState().requestViewerLocation(targetKey, 3);
+    readWorkspaceFileQuery.mockReturnValue({
+      data: {
+        content: "# Hello\n\nBody line.\n",
+        isText: true,
+        path: "README.md",
+        sizeBytes: 20,
+        tooLarge: false,
+        versionToken: "v1",
+      },
+      error: null,
+      isLoading: false,
+    });
+
+    render(createElement(FileEditorView, {
+      filePath: "README.md",
+      targetKey,
+    }));
+
+    // With the old ref seeding (useRef(viewerLocationRequestToken)), the
+    // pending token at mount is indistinguishable from "already seen" and the
+    // force never fires, leaving rendered Markdown stuck with no source-line
+    // geometry to jump to.
+    expect(useWorkspaceViewerTabsStore.getState().modeByTargetKey[targetKey]).toBe("source");
+  });
 });

--- a/apps/packages/product-client/src/components/workspace/files/FileEditorView.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/FileEditorView.test.tsx
@@ -428,4 +428,47 @@ describe("FileEditorView", () => {
 
     expect(useWorkspaceViewerTabsStore.getState().modeByTargetKey[targetKey]).toBe("source");
   });
+
+  it("forces a rendered target to source once on a location request, without fighting a later user toggle", () => {
+    const target = fileViewerTarget("README.md");
+    const targetKey = viewerTargetKey(target);
+    useWorkspaceViewerTabsStore.setState({
+      materializedWorkspaceId: "workspace-1",
+    });
+    useWorkspaceViewerTabsStore.getState().openTarget(target);
+    readWorkspaceFileQuery.mockReturnValue({
+      data: {
+        content: "# Hello\n\nBody line.\n",
+        isText: true,
+        path: "README.md",
+        sizeBytes: 20,
+        tooLarge: false,
+        versionToken: "v1",
+      },
+      error: null,
+      isLoading: false,
+    });
+    render(createElement(FileEditorView, {
+      filePath: "README.md",
+      targetKey,
+    }));
+
+    // Markdown defaults to the rendered view until a location request forces
+    // source mode once, because rendered Markdown has no source-line geometry.
+    expect(useWorkspaceViewerTabsStore.getState().modeByTargetKey[targetKey]).toBe("rendered");
+
+    act(() => {
+      useWorkspaceViewerTabsStore.getState().requestViewerLocation(targetKey, 2);
+    });
+
+    expect(useWorkspaceViewerTabsStore.getState().modeByTargetKey[targetKey]).toBe("source");
+    // The consuming FileSourceView applies and clears the request itself.
+    expect(useWorkspaceViewerTabsStore.getState().viewerLocationRequest).toBeNull();
+
+    // A later explicit user choice back to rendered is never fought.
+    act(() => {
+      useWorkspaceViewerTabsStore.getState().setTargetMode(targetKey, "rendered");
+    });
+    expect(useWorkspaceViewerTabsStore.getState().modeByTargetKey[targetKey]).toBe("rendered");
+  });
 });

--- a/apps/packages/product-client/src/components/workspace/files/FileEditorView.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/FileEditorView.tsx
@@ -214,7 +214,13 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
   // consumption, with the same only-on-transition discipline as the two
   // forcers above — rendered Markdown has no stable source-line geometry, but
   // a later explicit user toggle back to rendered is never fought.
-  const prevLocationRequestTokenRef = useRef(viewerLocationRequestToken);
+  // Seed at 0 (not the current token) so a location request already pending
+  // at mount time — e.g. the viewer remounting via useFileReferenceActions
+  // .openViewer, which mints the token synchronously with activation — still
+  // counts as a new request and forces source mode. Mirrors
+  // FileSourceView's appliedLocationTokenRef, which starts at 0 for the same
+  // reason.
+  const prevLocationRequestTokenRef = useRef(0);
   useEffect(() => {
     const isNewRequest = viewerLocationRequestToken !== 0
       && viewerLocationRequestToken !== prevLocationRequestTokenRef.current;

--- a/apps/packages/product-client/src/components/workspace/files/FileEditorView.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/FileEditorView.tsx
@@ -107,6 +107,24 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
     (s) => s.consumeViewerFocusRequest,
   );
 
+  // Mirrors the focus-token selector above, but the location request is
+  // consumed by the mounted FileSourceView (ruling 03D-4), not this frame —
+  // this component only reads the two primitives it needs for the
+  // once-on-transition source-mode force below and to forward to the view.
+  const viewerLocationRequestToken = useWorkspaceViewerTabsStore((s) => (
+    s.viewerLocationRequest?.targetKey === targetKey && s.activeTargetKey === targetKey
+      ? s.viewerLocationRequest.token
+      : 0
+  ));
+  const viewerLocationRequestLine = useWorkspaceViewerTabsStore((s) => (
+    s.viewerLocationRequest?.targetKey === targetKey && s.activeTargetKey === targetKey
+      ? s.viewerLocationRequest.line
+      : null
+  ));
+  const consumeViewerLocationRequest = useWorkspaceViewerTabsStore(
+    (s) => s.consumeViewerLocationRequest,
+  );
+
   const [wordWrap, setWordWrap] = useState(false);
   const changedPaths = useGitChangedPaths(materializedWorkspaceId);
   const activeDiffTarget = diffTarget ?? null;
@@ -191,6 +209,21 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
       setTargetMode(targetKey, "source");
     }
   }, [fileSearchActive, canFindInFile, normalizedEffectiveMode, setTargetMode, targetKey]);
+
+  // Ruling 03D-9: a valid location request forces source mode once, at
+  // consumption, with the same only-on-transition discipline as the two
+  // forcers above — rendered Markdown has no stable source-line geometry, but
+  // a later explicit user toggle back to rendered is never fought.
+  const prevLocationRequestTokenRef = useRef(viewerLocationRequestToken);
+  useEffect(() => {
+    const isNewRequest = viewerLocationRequestToken !== 0
+      && viewerLocationRequestToken !== prevLocationRequestTokenRef.current;
+    prevLocationRequestTokenRef.current = viewerLocationRequestToken;
+    if (!isNewRequest || normalizedEffectiveMode !== "rendered") {
+      return;
+    }
+    setTargetMode(targetKey, "source");
+  }, [viewerLocationRequestToken, normalizedEffectiveMode, setTargetMode, targetKey]);
 
   const fileTreeDock = dockVisible ? (
     <DockedFileTree
@@ -287,6 +320,9 @@ export function FileEditorView({ filePath, targetKey, diffTarget }: FileEditorVi
       diffLayout={diffLayout}
       canShowRichPreview={canShowRichPreview}
       wordWrap={wordWrap}
+      locationRequestToken={viewerLocationRequestToken}
+      locationRequestLine={viewerLocationRequestLine}
+      onLocationRequestConsumed={consumeViewerLocationRequest}
     />,
   );
 }

--- a/apps/packages/product-client/src/components/workspace/files/FileViewerContent.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/FileViewerContent.tsx
@@ -18,6 +18,10 @@ interface FileViewerContentProps {
   diffLayout: "unified" | "split";
   canShowRichPreview: boolean;
   wordWrap: boolean;
+  /** See `FileSourceView`'s matching props; forwarded only to that view. */
+  locationRequestToken?: number;
+  locationRequestLine?: number | null;
+  onLocationRequestConsumed?: (token: number) => void;
 }
 
 export function FileViewerContent({
@@ -29,6 +33,9 @@ export function FileViewerContent({
   diffLayout,
   canShowRichPreview,
   wordWrap,
+  locationRequestToken,
+  locationRequestLine,
+  onLocationRequestConsumed,
 }: FileViewerContentProps) {
   return (
     <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
@@ -53,6 +60,9 @@ export function FileViewerContent({
           code={read.content ?? ""}
           filePath={filePath}
           wordWrap={wordWrap}
+          locationRequestToken={locationRequestToken}
+          locationRequestLine={locationRequestLine}
+          onLocationRequestConsumed={onLocationRequestConsumed}
         />
       )}
     </div>

--- a/apps/packages/product-client/src/components/workspace/files/viewer/FileSourceView.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/viewer/FileSourceView.test.tsx
@@ -1,0 +1,219 @@
+/* @vitest-environment jsdom */
+
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FileSourceView } from "#product/components/workspace/files/viewer/FileSourceView";
+
+const scrollToIndexMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tanstack/react-virtual", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-virtual")>();
+  return {
+    ...actual,
+    useVirtualizer: (options: Parameters<typeof actual.useVirtualizer>[0]) => {
+      const instance = actual.useVirtualizer(options);
+      instance.scrollToIndex = scrollToIndexMock;
+      return instance;
+    },
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function codeWithLines(count: number): string {
+  return Array.from({ length: count }, (_, index) => `line ${index + 1}`).join("\n");
+}
+
+describe("FileSourceView location jump (03D)", () => {
+  it("centers the clamped line via virtualizer.scrollToIndex on the virtualized path", () => {
+    const code = codeWithLines(3000);
+    const onConsumed = vi.fn();
+
+    render(
+      <FileSourceView
+        code={code}
+        filePath="big.ts"
+        wordWrap={false}
+        locationRequestToken={1}
+        locationRequestLine={2500}
+        onLocationRequestConsumed={onConsumed}
+      />,
+    );
+
+    expect(scrollToIndexMock).toHaveBeenCalledWith(2499, { align: "center" });
+    expect(onConsumed).toHaveBeenCalledWith(1);
+  });
+
+  it("clamps an out-of-range line to the last row on the virtualized path", () => {
+    const code = codeWithLines(3000);
+
+    render(
+      <FileSourceView
+        code={code}
+        filePath="big.ts"
+        wordWrap={false}
+        locationRequestToken={1}
+        locationRequestLine={999999}
+        onLocationRequestConsumed={vi.fn()}
+      />,
+    );
+
+    expect(scrollToIndexMock).toHaveBeenCalledWith(2999, { align: "center" });
+  });
+
+  it("queries the [data-source-line] row and calls scrollIntoView on the non-virtualized path", () => {
+    const scrollIntoViewMock = vi.fn();
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+    try {
+      const code = codeWithLines(50);
+      const onConsumed = vi.fn();
+
+      const { container } = render(
+        <FileSourceView
+          code={code}
+          filePath="small.ts"
+          wordWrap={false}
+          locationRequestToken={7}
+          locationRequestLine={12}
+          onLocationRequestConsumed={onConsumed}
+        />,
+      );
+
+      const row = container.querySelector('[data-source-line][data-line="12"]');
+      expect(row).not.toBeNull();
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "center" });
+      expect(scrollIntoViewMock.mock.instances[0]).toBe(row);
+      expect(onConsumed).toHaveBeenCalledWith(7);
+    } finally {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+
+  it("clamps an out-of-range line to the last displayed row on the non-virtualized path", () => {
+    const scrollIntoViewMock = vi.fn();
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+    try {
+      const code = codeWithLines(10);
+
+      const { container } = render(
+        <FileSourceView
+          code={code}
+          filePath="small.ts"
+          wordWrap={false}
+          locationRequestToken={1}
+          locationRequestLine={999}
+          onLocationRequestConsumed={vi.fn()}
+        />,
+      );
+
+      const row = container.querySelector('[data-source-line][data-line="10"]');
+      expect(row).not.toBeNull();
+      expect(scrollIntoViewMock.mock.instances[0]).toBe(row);
+    } finally {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+
+  it("does not jump when no location request is pending", () => {
+    const scrollIntoViewMock = vi.fn();
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+    try {
+      render(
+        <FileSourceView
+          code={codeWithLines(10)}
+          filePath="small.ts"
+          wordWrap={false}
+        />,
+      );
+
+      expect(scrollIntoViewMock).not.toHaveBeenCalled();
+    } finally {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+
+  it("consumes a request exactly once and a re-render with the same token does not re-jump", () => {
+    const scrollIntoViewMock = vi.fn();
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+    try {
+      const onConsumed = vi.fn();
+      const { rerender } = render(
+        <FileSourceView
+          code={codeWithLines(10)}
+          filePath="small.ts"
+          wordWrap={false}
+          locationRequestToken={3}
+          locationRequestLine={5}
+          onLocationRequestConsumed={onConsumed}
+        />,
+      );
+      expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+      expect(onConsumed).toHaveBeenCalledTimes(1);
+
+      // A store-level consume nulls the request (token stays the same prop
+      // value only until the parent re-renders); simulate a re-render that
+      // still carries the same not-yet-invalidated token (e.g. an unrelated
+      // prop change) and confirm it is inert.
+      rerender(
+        <FileSourceView
+          code={codeWithLines(10)}
+          filePath="small.ts"
+          wordWrap
+          locationRequestToken={3}
+          locationRequestLine={5}
+          onLocationRequestConsumed={onConsumed}
+        />,
+      );
+
+      expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+      expect(onConsumed).toHaveBeenCalledTimes(1);
+    } finally {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+
+  it("a new token re-centers even onto the identical line (repeat activation)", () => {
+    const scrollIntoViewMock = vi.fn();
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+    try {
+      const onConsumed = vi.fn();
+      const { rerender } = render(
+        <FileSourceView
+          code={codeWithLines(10)}
+          filePath="small.ts"
+          wordWrap={false}
+          locationRequestToken={1}
+          locationRequestLine={5}
+          onLocationRequestConsumed={onConsumed}
+        />,
+      );
+      expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        rerender(
+          <FileSourceView
+            code={codeWithLines(10)}
+            filePath="small.ts"
+            wordWrap={false}
+            locationRequestToken={2}
+            locationRequestLine={5}
+            onLocationRequestConsumed={onConsumed}
+          />,
+        );
+      });
+
+      expect(scrollIntoViewMock).toHaveBeenCalledTimes(2);
+      expect(onConsumed).toHaveBeenLastCalledWith(2);
+    } finally {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+});

--- a/apps/packages/product-client/src/components/workspace/files/viewer/FileSourceView.tsx
+++ b/apps/packages/product-client/src/components/workspace/files/viewer/FileSourceView.tsx
@@ -49,12 +49,22 @@ interface FileSourceViewProps {
   code: string;
   filePath: string;
   wordWrap: boolean;
+  /**
+   * A one-shot source-line jump for the active target, or `0` when none is
+   * pending; `locationRequestLine` only matters alongside a non-zero token.
+   */
+  locationRequestToken?: number;
+  locationRequestLine?: number | null;
+  onLocationRequestConsumed?: (token: number) => void;
 }
 
 export function FileSourceView({
   code,
   filePath,
   wordWrap,
+  locationRequestToken = 0,
+  locationRequestLine = null,
+  onLocationRequestConsumed,
 }: FileSourceViewProps) {
   const highlightedLines = useHighlightedLines(code, filePath);
   const fallbackLines = useMemo(
@@ -148,6 +158,44 @@ export function FileSourceView({
 
     virtualizer.scrollToIndex(lineNumber - 1, { align: "center" });
   }, [activeMatchId, contentSearchUnitId, virtualizer]);
+
+  // 03D: sole consumer of a pending viewer location request. Content is
+  // always present once mounted, so no extra readiness gate is needed. A ref
+  // (not the effect deps) gates re-application: only a new token re-fires,
+  // so an unrelated re-render never re-scrolls, while a repeat activation
+  // with a new token always re-centers even onto an unchanged line.
+  const appliedLocationTokenRef = useRef(0);
+  useEffect(() => {
+    if (!locationRequestToken || locationRequestToken === appliedLocationTokenRef.current) {
+      return;
+    }
+    if (locationRequestLine === null) {
+      return;
+    }
+    appliedLocationTokenRef.current = locationRequestToken;
+    const clampedLine = Math.min(Math.max(1, locationRequestLine), Math.max(lines.length, 1));
+
+    // Virtualized branch trusts the virtualizer's own offsets; the
+    // non-virtualized (<2000 line) branch lays rows out in normal document
+    // flow instead, so it queries the rendered row and centers it directly.
+    if (shouldVirtualize) {
+      virtualizer.scrollToIndex(clampedLine - 1, { align: "center" });
+    } else {
+      const row = scrollRef.current?.querySelector<HTMLElement>(
+        `[data-source-line][data-line="${clampedLine}"]`,
+      );
+      row?.scrollIntoView({ block: "center" });
+    }
+
+    onLocationRequestConsumed?.(locationRequestToken);
+  }, [
+    locationRequestToken,
+    locationRequestLine,
+    lines.length,
+    shouldVirtualize,
+    virtualizer,
+    onLocationRequestConsumed,
+  ]);
 
   useEffect(() => {
     registerContentSearchUnit({

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.location.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.location.test.tsx
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+
+import { AnyHarnessError } from "@anyharness/sdk";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useFileReferenceActions } from "#product/hooks/workspaces/workflows/files/use-file-reference-actions";
+import { fileViewerTarget, viewerTargetKey } from "#product/lib/domain/workspaces/viewer/viewer-target";
+
+// This file holds the "location request enqueue (03D)" cases split out of
+// use-file-reference-actions.test.tsx to keep both files under the
+// PROD-SIZE-1 line cap (600). Setup below is duplicated (not shared) from
+// that file's mocks, trimmed to what these cases need.
+
+const pathMocks = vi.hoisted(() => ({
+  value: {
+    materializedWorkspaceId: "workspace-1" as string | null,
+    filesystemOrigin: { status: "settled" as const, origin: "desktop-local" as const },
+    workspaceRoot: { status: "settled" as const, path: "/repo" as string | null },
+  },
+}));
+
+const selectionMocks = vi.hoisted(() => ({
+  selectedWorkspaceId: "workspace-1",
+  selectedLogicalWorkspaceId: "workspace-1",
+}));
+
+const statMocks = vi.hoisted(() => ({
+  calls: vi.fn(),
+  data: { kind: "file" as "file" | "directory" | "symlink" },
+  error: null as unknown,
+  isPending: false,
+  isFetching: false,
+}));
+
+const fuzzyMocks = vi.hoisted(() => ({
+  resolve: vi.fn(async () => ({ status: "no-match" as const })),
+}));
+
+const lookupMocks = vi.hoisted(() => ({
+  statFile: vi.fn(async ({ path }: { path: string }) => ({ path, kind: "file" as const })),
+}));
+
+const editorMocks = vi.hoisted(() => ({
+  kinds: vi.fn(),
+  openInDefaultEditor: vi.fn(async () => true),
+  targets: [{ id: "cursor", label: "Cursor", kind: "editor" as const }],
+}));
+
+const viewerMocks = vi.hoisted(() => ({
+  openTarget: vi.fn(),
+  activateViewerTarget: vi.fn(),
+  requestViewerLocation: vi.fn(),
+}));
+
+const bridgeMocks = vi.hoisted(() => ({
+  desktopAvailable: true,
+  writeText: vi.fn(async () => undefined),
+  getHomeDirectory: vi.fn(async () => "/Users/pablo"),
+  inspectPath: vi.fn(async () => ({ kind: "file" as const })),
+  openTarget: vi.fn(async () => undefined),
+  reveal: vi.fn(async () => undefined),
+  files: null as unknown as Record<string, unknown>,
+}));
+
+vi.mock("#product/providers/WorkspacePathProvider", () => ({
+  useWorkspacePath: () => pathMocks.value,
+}));
+
+vi.mock("@anyharness/sdk-react", () => ({
+  useStatWorkspaceFileQuery: (input: unknown) => {
+    statMocks.calls(input);
+    return {
+      data: statMocks.data,
+      error: statMocks.error,
+      isPending: statMocks.isPending,
+      isFetching: statMocks.isFetching,
+    };
+  },
+}));
+
+vi.mock("#product/hooks/access/anyharness/files/use-workspace-file-lookup", () => ({
+  useWorkspaceFileLookup: () => ({ statFile: lookupMocks.statFile }),
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/files/use-fuzzy-file-resolver", () => ({
+  useFuzzyFileResolver: () => fuzzyMocks.resolve,
+}));
+
+vi.mock("#product/hooks/editor/workflows/use-open-in-default-editor", () => ({
+  useOpenInDefaultEditor: (kind: "file" | "directory" | null) => {
+    editorMocks.kinds(kind);
+    return {
+      defaultTarget: kind ? editorMocks.targets[0] : null,
+      openInDefaultEditor: editorMocks.openInDefaultEditor,
+      targets: kind ? editorMocks.targets : [],
+    };
+  },
+}));
+
+vi.mock("#product/hooks/workspaces/workflows/tabs/use-workspace-shell-activation", () => ({
+  useWorkspaceShellActivation: () => ({
+    activateViewerTarget: viewerMocks.activateViewerTarget,
+  }),
+}));
+
+vi.mock("#product/stores/editor/workspace-viewer-tabs-store", () => ({
+  useWorkspaceViewerTabsStore: (
+    selector: (state: {
+      openTarget: typeof viewerMocks.openTarget;
+      requestViewerLocation: typeof viewerMocks.requestViewerLocation;
+    }) => unknown,
+  ) => selector({
+    openTarget: viewerMocks.openTarget,
+    requestViewerLocation: viewerMocks.requestViewerLocation,
+  }),
+}));
+
+vi.mock("#product/stores/sessions/session-selection-store", () => ({
+  useSessionSelectionStore: (
+    selector: (state: {
+      selectedWorkspaceId: string;
+      selectedLogicalWorkspaceId: string;
+    }) => unknown,
+  ) => selector(selectionMocks),
+}));
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => ({
+    clipboard: { writeText: bridgeMocks.writeText },
+    desktop: bridgeMocks.desktopAvailable ? { files: bridgeMocks.files } : null,
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  pathMocks.value = {
+    materializedWorkspaceId: "workspace-1",
+    filesystemOrigin: { status: "settled", origin: "desktop-local" },
+    workspaceRoot: { status: "settled", path: "/repo" },
+  };
+  selectionMocks.selectedWorkspaceId = "workspace-1";
+  selectionMocks.selectedLogicalWorkspaceId = "workspace-1";
+  statMocks.data = { kind: "file" };
+  statMocks.error = null;
+  statMocks.isPending = false;
+  statMocks.isFetching = false;
+  fuzzyMocks.resolve.mockResolvedValue({ status: "no-match" });
+  lookupMocks.statFile.mockImplementation(async ({ path }) => ({ path, kind: "file" }));
+  editorMocks.openInDefaultEditor.mockResolvedValue(true);
+  bridgeMocks.desktopAvailable = true;
+  bridgeMocks.getHomeDirectory.mockResolvedValue("/Users/pablo");
+  bridgeMocks.inspectPath.mockResolvedValue({ kind: "file" });
+  bridgeMocks.files = {
+    getHomeDirectory: bridgeMocks.getHomeDirectory,
+    inspectPath: bridgeMocks.inspectPath,
+    openTarget: bridgeMocks.openTarget,
+    reveal: bridgeMocks.reveal,
+  };
+});
+
+describe("location request enqueue (03D)", () => {
+  beforeEach(() => {
+    viewerMocks.activateViewerTarget.mockReturnValue({
+      result: "completed",
+      surface: "viewer",
+      shellActivationEpoch: 1,
+    });
+  });
+
+  it("enqueues the final target's location for an exact workspace file with a valid line", async () => {
+    const { result } = renderHook(() => useFileReferenceActions({ rawPath: "src/App.tsx:40" }));
+
+    await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
+
+    expect(viewerMocks.requestViewerLocation).toHaveBeenCalledWith(
+      viewerTargetKey(fileViewerTarget("src/App.tsx")),
+      40,
+    );
+  });
+
+  it("enqueues again on an identical repeat activation", async () => {
+    const { result } = renderHook(() => useFileReferenceActions({ rawPath: "src/App.tsx:40" }));
+
+    await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
+    await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
+
+    expect(viewerMocks.requestViewerLocation).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ["src/App.tsx", null],
+    ["src/App.tsx:0", 0],
+    ["src/App.tsx:", null],
+  ])("does not enqueue for an absent or non-positive line (%s)", async (rawPath) => {
+    const { result } = renderHook(() => useFileReferenceActions({ rawPath }));
+
+    await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
+
+    expect(viewerMocks.requestViewerLocation).not.toHaveBeenCalled();
+  });
+
+  it("does not enqueue for a directory target", async () => {
+    statMocks.data = { kind: "directory" };
+    const { result } = renderHook(() => useFileReferenceActions({
+      rawPath: "src:12",
+      workspacePath: "src",
+    }));
+
+    await result.current.openPrimary();
+
+    expect(viewerMocks.openTarget).not.toHaveBeenCalled();
+    expect(viewerMocks.requestViewerLocation).not.toHaveBeenCalled();
+  });
+
+  it("does not enqueue when the shell activation outcome is stale", async () => {
+    viewerMocks.activateViewerTarget.mockReturnValue({
+      result: "stale",
+      surface: "viewer",
+      reason: "workspace-changed",
+    });
+    const { result } = renderHook(() => useFileReferenceActions({ rawPath: "src/App.tsx:40" }));
+
+    await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
+
+    expect(viewerMocks.requestViewerLocation).not.toHaveBeenCalled();
+  });
+
+  it("enqueues only the corrected target's location after fuzzy recovery", async () => {
+    statMocks.data = undefined as never;
+    statMocks.error = problem("FILE_NOT_FOUND", 404);
+    fuzzyMocks.resolve.mockResolvedValue({
+      status: "match",
+      workspacePath: "Apps/Web/SRC/App.tsx",
+    });
+    const { result } = renderHook(() => useFileReferenceActions({ rawPath: "src/App.tsx:40" }));
+
+    await act(async () => {
+      await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
+    });
+    await waitFor(() => expect(result.current.accessState.status).toBe("settled"));
+
+    expect(viewerMocks.requestViewerLocation).toHaveBeenCalledTimes(1);
+    expect(viewerMocks.requestViewerLocation).toHaveBeenCalledWith(
+      viewerTargetKey(fileViewerTarget("Apps/Web/SRC/App.tsx")),
+      40,
+    );
+  });
+});
+
+function problem(code: string, status: number): AnyHarnessError {
+  return new AnyHarnessError({
+    type: "about:blank",
+    title: "File request failed",
+    status,
+    code,
+  });
+}

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.test.tsx
@@ -2,8 +2,9 @@
 
 import { AnyHarnessError } from "@anyharness/sdk";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useFileReferenceActions } from "#product/hooks/workspaces/workflows/files/use-file-reference-actions";
+import { fileViewerTarget, viewerTargetKey } from "#product/lib/domain/workspaces/viewer/viewer-target";
 
 const pathMocks = vi.hoisted(() => ({
   value: {
@@ -43,6 +44,7 @@ const editorMocks = vi.hoisted(() => ({
 const viewerMocks = vi.hoisted(() => ({
   openTarget: vi.fn(),
   activateViewerTarget: vi.fn(),
+  requestViewerLocation: vi.fn(),
 }));
 
 const bridgeMocks = vi.hoisted(() => ({
@@ -98,8 +100,14 @@ vi.mock("#product/hooks/workspaces/workflows/tabs/use-workspace-shell-activation
 
 vi.mock("#product/stores/editor/workspace-viewer-tabs-store", () => ({
   useWorkspaceViewerTabsStore: (
-    selector: (state: { openTarget: typeof viewerMocks.openTarget }) => unknown,
-  ) => selector({ openTarget: viewerMocks.openTarget }),
+    selector: (state: {
+      openTarget: typeof viewerMocks.openTarget;
+      requestViewerLocation: typeof viewerMocks.requestViewerLocation;
+    }) => unknown,
+  ) => selector({
+    openTarget: viewerMocks.openTarget,
+    requestViewerLocation: viewerMocks.requestViewerLocation,
+  }),
 }));
 
 vi.mock("#product/stores/sessions/session-selection-store", () => ({
@@ -577,6 +585,95 @@ describe("useFileReferenceActions", () => {
     expect(editorMocks.openInDefaultEditor).not.toHaveBeenCalled();
     expect(bridgeMocks.openTarget).not.toHaveBeenCalled();
     expect(bridgeMocks.reveal).not.toHaveBeenCalled();
+  });
+
+  describe("location request enqueue (03D)", () => {
+    beforeEach(() => {
+      viewerMocks.activateViewerTarget.mockReturnValue({
+        result: "completed",
+        surface: "viewer",
+        shellActivationEpoch: 1,
+      });
+    });
+
+    it("enqueues the final target's location for an exact workspace file with a valid line", async () => {
+      const { result } = renderHook(() => useFileReferenceActions({ rawPath: "src/App.tsx:40" }));
+
+      await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
+
+      expect(viewerMocks.requestViewerLocation).toHaveBeenCalledWith(
+        viewerTargetKey(fileViewerTarget("src/App.tsx")),
+        40,
+      );
+    });
+
+    it("enqueues again on an identical repeat activation", async () => {
+      const { result } = renderHook(() => useFileReferenceActions({ rawPath: "src/App.tsx:40" }));
+
+      await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
+      await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
+
+      expect(viewerMocks.requestViewerLocation).toHaveBeenCalledTimes(2);
+    });
+
+    it.each([
+      ["src/App.tsx", null],
+      ["src/App.tsx:0", 0],
+      ["src/App.tsx:", null],
+    ])("does not enqueue for an absent or non-positive line (%s)", async (rawPath) => {
+      const { result } = renderHook(() => useFileReferenceActions({ rawPath }));
+
+      await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
+
+      expect(viewerMocks.requestViewerLocation).not.toHaveBeenCalled();
+    });
+
+    it("does not enqueue for a directory target", async () => {
+      statMocks.data = { kind: "directory" };
+      const { result } = renderHook(() => useFileReferenceActions({
+        rawPath: "src:12",
+        workspacePath: "src",
+      }));
+
+      await result.current.openPrimary();
+
+      expect(viewerMocks.openTarget).not.toHaveBeenCalled();
+      expect(viewerMocks.requestViewerLocation).not.toHaveBeenCalled();
+    });
+
+    it("does not enqueue when the shell activation outcome is stale", async () => {
+      viewerMocks.activateViewerTarget.mockReturnValue({
+        result: "stale",
+        surface: "viewer",
+        reason: "workspace-changed",
+      });
+      const { result } = renderHook(() => useFileReferenceActions({ rawPath: "src/App.tsx:40" }));
+
+      await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
+
+      expect(viewerMocks.requestViewerLocation).not.toHaveBeenCalled();
+    });
+
+    it("enqueues only the corrected target's location after fuzzy recovery", async () => {
+      statMocks.data = undefined as never;
+      statMocks.error = problem("FILE_NOT_FOUND", 404);
+      fuzzyMocks.resolve.mockResolvedValue({
+        status: "match",
+        workspacePath: "Apps/Web/SRC/App.tsx",
+      });
+      const { result } = renderHook(() => useFileReferenceActions({ rawPath: "src/App.tsx:40" }));
+
+      await act(async () => {
+        await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
+      });
+      await waitFor(() => expect(result.current.accessState.status).toBe("settled"));
+
+      expect(viewerMocks.requestViewerLocation).toHaveBeenCalledTimes(1);
+      expect(viewerMocks.requestViewerLocation).toHaveBeenCalledWith(
+        viewerTargetKey(fileViewerTarget("Apps/Web/SRC/App.tsx")),
+        40,
+      );
+    });
   });
 });
 

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.test.tsx
@@ -4,7 +4,6 @@ import { AnyHarnessError } from "@anyharness/sdk";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useFileReferenceActions } from "#product/hooks/workspaces/workflows/files/use-file-reference-actions";
-import { fileViewerTarget, viewerTargetKey } from "#product/lib/domain/workspaces/viewer/viewer-target";
 
 const pathMocks = vi.hoisted(() => ({
   value: {
@@ -586,112 +585,16 @@ describe("useFileReferenceActions", () => {
     expect(bridgeMocks.openTarget).not.toHaveBeenCalled();
     expect(bridgeMocks.reveal).not.toHaveBeenCalled();
   });
-
-  describe("location request enqueue (03D)", () => {
-    beforeEach(() => {
-      viewerMocks.activateViewerTarget.mockReturnValue({
-        result: "completed",
-        surface: "viewer",
-        shellActivationEpoch: 1,
-      });
-    });
-
-    it("enqueues the final target's location for an exact workspace file with a valid line", async () => {
-      const { result } = renderHook(() => useFileReferenceActions({ rawPath: "src/App.tsx:40" }));
-
-      await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
-
-      expect(viewerMocks.requestViewerLocation).toHaveBeenCalledWith(
-        viewerTargetKey(fileViewerTarget("src/App.tsx")),
-        40,
-      );
-    });
-
-    it("enqueues again on an identical repeat activation", async () => {
-      const { result } = renderHook(() => useFileReferenceActions({ rawPath: "src/App.tsx:40" }));
-
-      await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
-      await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
-
-      expect(viewerMocks.requestViewerLocation).toHaveBeenCalledTimes(2);
-    });
-
-    it.each([
-      ["src/App.tsx", null],
-      ["src/App.tsx:0", 0],
-      ["src/App.tsx:", null],
-    ])("does not enqueue for an absent or non-positive line (%s)", async (rawPath) => {
-      const { result } = renderHook(() => useFileReferenceActions({ rawPath }));
-
-      await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
-
-      expect(viewerMocks.requestViewerLocation).not.toHaveBeenCalled();
-    });
-
-    it("does not enqueue for a directory target", async () => {
-      statMocks.data = { kind: "directory" };
-      const { result } = renderHook(() => useFileReferenceActions({
-        rawPath: "src:12",
-        workspacePath: "src",
-      }));
-
-      await result.current.openPrimary();
-
-      expect(viewerMocks.openTarget).not.toHaveBeenCalled();
-      expect(viewerMocks.requestViewerLocation).not.toHaveBeenCalled();
-    });
-
-    it("does not enqueue when the shell activation outcome is stale", async () => {
-      viewerMocks.activateViewerTarget.mockReturnValue({
-        result: "stale",
-        surface: "viewer",
-        reason: "workspace-changed",
-      });
-      const { result } = renderHook(() => useFileReferenceActions({ rawPath: "src/App.tsx:40" }));
-
-      await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
-
-      expect(viewerMocks.requestViewerLocation).not.toHaveBeenCalled();
-    });
-
-    it("enqueues only the corrected target's location after fuzzy recovery", async () => {
-      statMocks.data = undefined as never;
-      statMocks.error = problem("FILE_NOT_FOUND", 404);
-      fuzzyMocks.resolve.mockResolvedValue({
-        status: "match",
-        workspacePath: "Apps/Web/SRC/App.tsx",
-      });
-      const { result } = renderHook(() => useFileReferenceActions({ rawPath: "src/App.tsx:40" }));
-
-      await act(async () => {
-        await expect(result.current.openPrimary()).resolves.toBe("open-viewer");
-      });
-      await waitFor(() => expect(result.current.accessState.status).toBe("settled"));
-
-      expect(viewerMocks.requestViewerLocation).toHaveBeenCalledTimes(1);
-      expect(viewerMocks.requestViewerLocation).toHaveBeenCalledWith(
-        viewerTargetKey(fileViewerTarget("Apps/Web/SRC/App.tsx")),
-        40,
-      );
-    });
-  });
 });
 
+// "location request enqueue (03D)" moved to use-file-reference-actions.location.test.tsx (600-line cap).
 function problem(code: string, status: number): AnyHarnessError {
-  return new AnyHarnessError({
-    type: "about:blank",
-    title: "File request failed",
-    status,
-    code,
-  });
+  return new AnyHarnessError({ type: "about:blank", title: "File request failed", status, code });
 }
 
-async function consumeMissingRecovery(result: {
-  readonly current: ReturnType<typeof useFileReferenceActions>;
-}) {
+async function consumeMissingRecovery(
+  result: { readonly current: ReturnType<typeof useFileReferenceActions> },
+) {
   await act(async () => void await result.current.openPrimary());
-  await waitFor(() => expect(result.current.accessState).toEqual({
-    status: "unavailable",
-    reason: "not_found",
-  }));
+  await waitFor(() => expect(result.current.accessState).toEqual({ status: "unavailable", reason: "not_found" }));
 }

--- a/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.ts
+++ b/apps/packages/product-client/src/hooks/workspaces/workflows/files/use-file-reference-actions.ts
@@ -26,7 +26,7 @@ import {
   type FileReferencePrimaryAction,
 } from "#product/lib/domain/files/path-references";
 import { resolveSelectedWorkspaceIdentity } from "#product/lib/domain/workspaces/selection/workspace-ui-key";
-import { fileViewerTarget } from "#product/lib/domain/workspaces/viewer/viewer-target";
+import { fileViewerTarget, viewerTargetKey } from "#product/lib/domain/workspaces/viewer/viewer-target";
 import { useWorkspacePath } from "#product/providers/WorkspacePathProvider";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
 import { useWorkspaceViewerTabsStore } from "#product/stores/editor/workspace-viewer-tabs-store";
@@ -46,6 +46,7 @@ export function useFileReferenceActions({
   const host = useProductHost();
   const files = host.desktop?.files ?? null;
   const openTarget = useWorkspaceViewerTabsStore((state) => state.openTarget);
+  const requestViewerLocation = useWorkspaceViewerTabsStore((state) => state.requestViewerLocation);
   const selectedWorkspaceId = useSessionSelectionStore((state) => state.selectedWorkspaceId);
   const selectedLogicalWorkspaceId = useSessionSelectionStore(
     (state) => state.selectedLogicalWorkspaceId,
@@ -211,20 +212,35 @@ export function useFileReferenceActions({
     await clipboardRef.current.writeText(current);
   }, []);
 
-  const openViewer = useCallback((path: string, snapshot: typeof latestRef.current) => {
+  // Ruling 03D-6: `:0` and negatives never enqueue a jump; the path still
+  // opens ordinarily. `splitPathLineSuffix` only ever parses `\d+`, but this
+  // stays defensive against any non-integer/non-positive value reaching here.
+  const openViewer = useCallback((
+    path: string,
+    snapshot: typeof latestRef.current,
+    line: number | null,
+  ) => {
     if (
       currentRouteRevisionRef.current !== snapshot.routeRevision
       || !snapshot.materializedWorkspaceId
     ) return false;
     const target = fileViewerTarget(path);
     openTarget(target);
-    activateViewerTarget({
+    const outcome = activateViewerTarget({
       workspaceId: snapshot.materializedWorkspaceId,
       shellWorkspaceId: snapshot.workspaceUiKey,
       target,
     });
+    if (
+      outcome?.result === "completed"
+      && typeof line === "number"
+      && Number.isInteger(line)
+      && line > 0
+    ) {
+      requestViewerLocation(viewerTargetKey(target), line);
+    }
     return true;
-  }, [activateViewerTarget, openTarget]);
+  }, [activateViewerTarget, openTarget, requestViewerLocation]);
 
   const openInSidebar = useCallback(async () => {
     const snapshot = latestRef.current;
@@ -234,7 +250,7 @@ export function useFileReferenceActions({
       || snapshot.accessState.kind !== "file"
       || snapshot.accessState.locator.authority !== "workspace"
     ) return;
-    openViewer(snapshot.accessState.locator.workspacePath, snapshot);
+    openViewer(snapshot.accessState.locator.workspacePath, snapshot, snapshot.reference.line);
   }, [openViewer, routeRevision]);
 
   const recoverMissing = useCallback(async (
@@ -273,13 +289,18 @@ export function useFileReferenceActions({
         });
         return "unavailable";
       }
-      const corrected = resolveFileReference({
+      // Ruling 03D-3: keep the full resolved reference (not just `.locator`)
+      // so the corrected reference's parsed `line` survives to enqueue for
+      // the corrected target only — the discarded-`.locator` shape used to
+      // silently drop it here.
+      const correctedReference = resolveFileReference({
         rawPath: snapshot.reference.rawPath,
         workspacePathOverride: outcome.workspacePath,
         workspaceRoot,
         filesystemOrigin,
         desktopBridgeAvailable: files !== null,
-      }).locator;
+      });
+      const corrected = correctedReference.locator;
       if (corrected.authority !== "workspace") {
         setRecovery({
           recoveryRevision: snapshot.recoveryRevision,
@@ -293,7 +314,9 @@ export function useFileReferenceActions({
         status: "settled",
         locator: corrected,
       });
-      return openViewer(corrected.workspacePath, snapshot) ? "open-viewer" : "unavailable";
+      return openViewer(corrected.workspacePath, snapshot, correctedReference.line)
+        ? "open-viewer"
+        : "unavailable";
     } catch (error) {
       setRecovery({
         recoveryRevision: snapshot.recoveryRevision,
@@ -317,7 +340,9 @@ export function useFileReferenceActions({
     if (state.status !== "settled") return "unavailable";
     if (state.locator.authority === "workspace") {
       if (state.kind !== "file") return "unavailable";
-      return openViewer(state.locator.workspacePath, snapshot) ? "open-viewer" : "unavailable";
+      return openViewer(state.locator.workspacePath, snapshot, snapshot.reference.line)
+        ? "open-viewer"
+        : "unavailable";
     }
     if (state.kind === "directory") {
       await nativeActions.reveal();

--- a/apps/packages/product-client/src/stores/editor/workspace-viewer-tabs-store.test.ts
+++ b/apps/packages/product-client/src/stores/editor/workspace-viewer-tabs-store.test.ts
@@ -105,4 +105,73 @@ describe("workspace viewer tabs store", () => {
 
     expect(useWorkspaceViewerTabsStore.getState().viewerFocusRequest).toBeNull();
   });
+
+  it("mints monotonic location requests and consumes them exactly once", () => {
+    const store = useWorkspaceViewerTabsStore.getState();
+    const key = store.openTarget(fileViewerTarget("src/app.ts"));
+
+    store.requestViewerLocation(key, 40);
+    const first = useWorkspaceViewerTabsStore.getState().viewerLocationRequest;
+    expect(first).toEqual({ targetKey: key, line: 40, token: 1 });
+
+    store.consumeViewerLocationRequest(first!.token);
+    expect(useWorkspaceViewerTabsStore.getState().viewerLocationRequest).toBeNull();
+
+    // A repeat activation onto the identical line still mints a new token, so
+    // the same-location repeat can retrigger the jump.
+    store.requestViewerLocation(key, 40);
+    expect(useWorkspaceViewerTabsStore.getState().viewerLocationRequest)
+      .toEqual({ targetKey: key, line: 40, token: 2 });
+  });
+
+  it("a newer location request supersedes an unconsumed older one", () => {
+    const store = useWorkspaceViewerTabsStore.getState();
+    const key = store.openTarget(fileViewerTarget("src/app.ts"));
+
+    store.requestViewerLocation(key, 10);
+    const stale = useWorkspaceViewerTabsStore.getState().viewerLocationRequest!;
+    store.requestViewerLocation(key, 20);
+    const live = useWorkspaceViewerTabsStore.getState().viewerLocationRequest!;
+
+    expect(live).toEqual({ targetKey: key, line: 20, token: stale.token + 1 });
+
+    // The stale token from the superseded request is inert.
+    store.consumeViewerLocationRequest(stale.token);
+    expect(useWorkspaceViewerTabsStore.getState().viewerLocationRequest).toEqual(live);
+  });
+
+  it("invalidates an unconsumed location request when the active target changes", () => {
+    const store = useWorkspaceViewerTabsStore.getState();
+    const first = store.openTarget(fileViewerTarget("src/first.ts"));
+    store.requestViewerLocation(first, 5);
+
+    const second = store.openTarget(fileViewerTarget("src/second.ts"));
+    expect(useWorkspaceViewerTabsStore.getState().viewerLocationRequest).toBeNull();
+
+    // A stale consume for the invalidated token is inert.
+    store.requestViewerLocation(second, 8);
+    const live = useWorkspaceViewerTabsStore.getState().viewerLocationRequest!;
+    store.consumeViewerLocationRequest(live.token - 1);
+    expect(useWorkspaceViewerTabsStore.getState().viewerLocationRequest).toEqual(live);
+  });
+
+  it("drops a pending location request when its target is closed", () => {
+    const store = useWorkspaceViewerTabsStore.getState();
+    const key = store.openTarget(fileViewerTarget("src/app.ts"));
+    store.requestViewerLocation(key, 12);
+
+    store.closeTarget(key);
+
+    expect(useWorkspaceViewerTabsStore.getState().viewerLocationRequest).toBeNull();
+  });
+
+  it("clears a pending location request on workspace reset", () => {
+    const store = useWorkspaceViewerTabsStore.getState();
+    const key = store.openTarget(fileViewerTarget("src/app.ts"));
+    store.requestViewerLocation(key, 3);
+
+    store.reset();
+
+    expect(useWorkspaceViewerTabsStore.getState().viewerLocationRequest).toBeNull();
+  });
 });

--- a/apps/packages/product-client/src/stores/editor/workspace-viewer-tabs-store.ts
+++ b/apps/packages/product-client/src/stores/editor/workspace-viewer-tabs-store.ts
@@ -33,6 +33,33 @@ function focusRequestForActiveTarget(
   return request && request.targetKey === activeTargetKey ? request : null;
 }
 
+/**
+ * A session-only request that the mounted `FileSourceView` for the active
+ * target perform a one-shot source-line jump.
+ *
+ * Unlike `ViewerFocusRequest` (consumed by the frame the instant it names the
+ * active target, even before content loads), this request can only be
+ * applied by a mounted source view that already has file content and a
+ * requested source row to scroll to — so it is deliberately left pending
+ * across a loading target instead of being invalidated. It carries the
+ * target key, the 1-based line, and a monotonic token; nothing path-bearing
+ * beyond the key is persisted, rendered, logged, or emitted. Any active-target
+ * change before a source view consumes it invalidates it the same way a
+ * focus request does.
+ */
+export interface ViewerLocationRequest {
+  targetKey: ViewerTargetKey;
+  line: number;
+  token: number;
+}
+
+function locationRequestForActiveTarget(
+  request: ViewerLocationRequest | null,
+  activeTargetKey: ViewerTargetKey | null,
+): ViewerLocationRequest | null {
+  return request && request.targetKey === activeTargetKey ? request : null;
+}
+
 export interface WorkspaceViewerRestoreMarker {
   workspaceUiKey: string;
   materializedWorkspaceId: string;
@@ -51,6 +78,8 @@ interface WorkspaceViewerTabsState {
   layoutByTargetKey: Record<ViewerTargetKey, DiffViewerLayout>;
   viewerFocusRequest: ViewerFocusRequest | null;
   viewerFocusRequestSeq: number;
+  viewerLocationRequest: ViewerLocationRequest | null;
+  viewerLocationRequestSeq: number;
 
   prepareWorkspace: (args: {
     workspaceUiKey: string;
@@ -67,6 +96,8 @@ interface WorkspaceViewerTabsState {
   setActiveTarget: (targetKey: ViewerTargetKey | null) => void;
   requestViewerFocus: (targetKey: ViewerTargetKey) => void;
   consumeViewerFocusRequest: (token: number) => void;
+  requestViewerLocation: (targetKey: ViewerTargetKey, line: number) => void;
+  consumeViewerLocationRequest: (token: number) => void;
   setTargetMode: (targetKey: ViewerTargetKey, mode: FileViewerMode) => void;
   setTargetLayout: (targetKey: ViewerTargetKey, layout: DiffViewerLayout) => void;
 }
@@ -78,6 +109,7 @@ function emptyViewerState() {
     modeByTargetKey: {} as Record<ViewerTargetKey, FileViewerMode>,
     layoutByTargetKey: {} as Record<ViewerTargetKey, DiffViewerLayout>,
     viewerFocusRequest: null as ViewerFocusRequest | null,
+    viewerLocationRequest: null as ViewerLocationRequest | null,
   };
 }
 
@@ -94,6 +126,7 @@ export const useWorkspaceViewerTabsStore = create<WorkspaceViewerTabsState>((set
   initVersion: 0,
   viewerRestoreMarker: null,
   viewerFocusRequestSeq: 0,
+  viewerLocationRequestSeq: 0,
   ...emptyViewerState(),
 
   prepareWorkspace: (args) => {
@@ -145,6 +178,7 @@ export const useWorkspaceViewerTabsStore = create<WorkspaceViewerTabsState>((set
       openTargets: exists ? current.openTargets : [...current.openTargets, target],
       activeTargetKey: targetKey,
       viewerFocusRequest: focusRequestForActiveTarget(current.viewerFocusRequest, targetKey),
+      viewerLocationRequest: locationRequestForActiveTarget(current.viewerLocationRequest, targetKey),
       modeByTargetKey: current.modeByTargetKey[targetKey]
         ? current.modeByTargetKey
         : {
@@ -172,6 +206,7 @@ export const useWorkspaceViewerTabsStore = create<WorkspaceViewerTabsState>((set
       modeByTargetKey: nextModes,
       layoutByTargetKey: nextLayouts,
       viewerFocusRequest: focusRequestForActiveTarget(get().viewerFocusRequest, nextActive),
+      viewerLocationRequest: locationRequestForActiveTarget(get().viewerLocationRequest, nextActive),
     });
   },
 
@@ -209,6 +244,10 @@ export const useWorkspaceViewerTabsStore = create<WorkspaceViewerTabsState>((set
         current.viewerFocusRequest,
         nextActiveTargetKey,
       ),
+      viewerLocationRequest: locationRequestForActiveTarget(
+        current.viewerLocationRequest,
+        nextActiveTargetKey,
+      ),
     });
   },
 
@@ -242,6 +281,7 @@ export const useWorkspaceViewerTabsStore = create<WorkspaceViewerTabsState>((set
       modeByTargetKey: nextModes,
       layoutByTargetKey: nextLayouts,
       viewerFocusRequest: focusRequestForActiveTarget(current.viewerFocusRequest, nextActive),
+      viewerLocationRequest: locationRequestForActiveTarget(current.viewerLocationRequest, nextActive),
     });
   },
 
@@ -272,6 +312,7 @@ export const useWorkspaceViewerTabsStore = create<WorkspaceViewerTabsState>((set
     set((current) => ({
       activeTargetKey: targetKey,
       viewerFocusRequest: focusRequestForActiveTarget(current.viewerFocusRequest, targetKey),
+      viewerLocationRequest: locationRequestForActiveTarget(current.viewerLocationRequest, targetKey),
     }));
   },
 
@@ -289,6 +330,28 @@ export const useWorkspaceViewerTabsStore = create<WorkspaceViewerTabsState>((set
     set((current) => (
       current.viewerFocusRequest?.token === token
         ? { viewerFocusRequest: null }
+        : current
+    ));
+  },
+
+  // Sole caller is the file-reference activation seam
+  // (useFileReferenceActions.openViewer); a fresh number is minted on every
+  // enqueue so repeat-activating the same line still retriggers the jump.
+  requestViewerLocation: (targetKey, line) => {
+    set((current) => ({
+      viewerLocationRequestSeq: current.viewerLocationRequestSeq + 1,
+      viewerLocationRequest: { targetKey, line, token: current.viewerLocationRequestSeq + 1 },
+    }));
+  },
+
+  // Consumed only by a mounted FileSourceView that has already applied the
+  // scroll — unlike the focus token, this is deliberately not consumed by a
+  // loading/error placeholder, so a request may remain pending across a slow
+  // file read.
+  consumeViewerLocationRequest: (token) => {
+    set((current) => (
+      current.viewerLocationRequest?.token === token
+        ? { viewerLocationRequest: null }
         : current
     ));
   },

--- a/lints/frontend/ratchets.toml
+++ b/lints/frontend/ratchets.toml
@@ -242,6 +242,10 @@ path = "apps/packages/product-client/src/hooks/chat/ui/use-composer-menu-navigat
 reason = "pre-existing non-transcript scroller: composer menu keyboard-nav scrollTo/scrollIntoView; held so no net-new writer is added"
 
 [[transcript_scroll_writer]]
+path = "apps/packages/product-client/src/components/workspace/files/viewer/FileSourceView.tsx"
+reason = "non-transcript scroller: file-viewer line-navigation scrollIntoView on the non-virtualized source path (frozen spec 03D ruling 5); the virtualized path uses the virtualizer's own scrollToIndex"
+
+[[transcript_scroll_writer]]
 path = "apps/packages/product-client/src/hooks/chat/ui/use-model-picker-keyboard-nav.ts"
 reason = "pre-existing non-transcript scroller: model-picker keyboard-nav scrollIntoView; held so no net-new writer is added"
 

--- a/specs/codebase/systems/product/workspaces/files.md
+++ b/specs/codebase/systems/product/workspaces/files.md
@@ -261,10 +261,13 @@ active target, even before content loads — a location request can only be
 applied by a mounted `FileSourceView` that already has file content and a
 requested row, so it is deliberately left pending across a loading target
 rather than invalidated. `FileEditorView` forces the target to source mode
-once, on the request's transition to a new token, exactly like the two
-landed find-in-file forcers — because rendered Markdown has no stable
-source-line geometry — and never fights a later explicit user toggle back to
-rendered. `FileSourceView` itself clamps the requested line to the last
+once, on the request's transition to a new token — including the transition
+observed on mount, when the viewer remounts onto a target that already has a
+pending request (e.g. `useFileReferenceActions.openViewer` minting the token
+synchronously with activation while `RightPanelContent` mounts a fresh
+`FileEditorView`) — exactly like the two landed find-in-file forcers, because
+rendered Markdown has no stable source-line geometry, and never fights a
+later explicit user toggle back to rendered. `FileSourceView` itself clamps the requested line to the last
 displayed row, centers it (`virtualizer.scrollToIndex(…, {align:"center"})`
 when virtualized; `[data-source-line][data-line]…scrollIntoView({block:
 "center"})` on the non-virtualized `<2000`-line path, which does not trust

--- a/specs/codebase/systems/product/workspaces/files.md
+++ b/specs/codebase/systems/product/workspaces/files.md
@@ -129,7 +129,8 @@ Remote filesystem and git data belongs to SDK-react/TanStack Query:
 Zustand stores only local UI/editor state:
 
 - `workspace-viewer-tabs-store.ts`: open targets, active target, per-target
-  mode/layout
+  mode/layout, and the session-only `viewerFocusRequest`/`viewerLocationRequest`
+  one-shot tokens (see File Viewing's Source-location navigation)
 - `workspace-file-tree-ui-store.ts`: expanded folders, selected folder,
   create draft
 - `workspace-file-buffers-store.ts`: local editable drafts, base version token,
@@ -236,6 +237,42 @@ neither wired nor deleted here, and removing them (plus their pinning tests)
 requires a separately scoped constitution review because it crosses
 tab-close/right-panel owners. Do not read that scaffolding as evidence the
 viewer is or was editable.
+
+### Source-location navigation
+
+Activating a workspace file reference carrying `:line` (`:line:column` also
+parses, but column is unconsumed) opens/focuses the ordinary path-only
+`fileViewerTarget` and, separately, enqueues a one-shot source-line jump on
+`workspace-viewer-tabs-store.ts`'s `viewerLocationRequest` — a sibling of the
+landed `viewerFocusRequest` token (same session-only, non-persisted,
+monotonic-token, target-key-gated shape). The target's public identity and
+key stay path-only; the line is never encoded into `ViewerTargetKey`, tab
+keys, right-panel keys, or persisted preferences.
+
+`useFileReferenceActions.openViewer` is the sole enqueue seam: it mints the
+request only after a non-`stale` shell activation outcome, only for a
+positive-integer parsed line (`:0` and an absent suffix never enqueue — the
+path still opens ordinarily), and only for `kind: "file"` targets (never
+`fileDiff`). A fuzzy-corrected reference enqueues the corrected target's line,
+not the originally typed path's.
+
+Unlike the focus token — consumable by the frame the instant it names the
+active target, even before content loads — a location request can only be
+applied by a mounted `FileSourceView` that already has file content and a
+requested row, so it is deliberately left pending across a loading target
+rather than invalidated. `FileEditorView` forces the target to source mode
+once, on the request's transition to a new token, exactly like the two
+landed find-in-file forcers — because rendered Markdown has no stable
+source-line geometry — and never fights a later explicit user toggle back to
+rendered. `FileSourceView` itself clamps the requested line to the last
+displayed row, centers it (`virtualizer.scrollToIndex(…, {align:"center"})`
+when virtualized; `[data-source-line][data-line]…scrollIntoView({block:
+"center"})` on the non-virtualized `<2000`-line path, which does not trust
+virtualizer offsets), and consumes the request only after applying the jump.
+A repeat activation — even onto the identical line — mints a fresh token and
+re-centers. There is no jumped-line highlight; rows keep their existing
+hover-only styling. Column is parsed and threaded nowhere: it stays a
+deferred, unconsumed field pending stable per-line column geometry.
 
 ### Header
 


### PR DESCRIPTION
Implements frozen spec **03D – File Reference Location Navigation** (Frozen r2, base `e94c4db1` = the 03C merge). Activating a file reference with a line suffix (`path:42`) now scrolls the viewer to that line, centered. Line-only: column reveal (03D-DEFER-01) and jumped-line highlight (03D-DEFER-02) are ledgered founder deferrals.

## What this does

- **Store**: `workspace-viewer-tabs-store.ts` gains a `ViewerLocationRequest` (`targetKey`, `line`, session-monotonic `token`) beside the landed 02B `viewerFocusRequest` machinery — `requestViewerLocation` / `consumeViewerLocationRequest`, invalidated on the same active-target-change and reset paths (spec ruling 1: reuse the token machinery, no new store).
- **Enqueue**: `useFileReferenceActions.openViewer` takes the parsed line and enqueues only after `activateViewerTarget` reports a non-stale `"completed"` outcome and the line is a positive integer. The fuzzy-recovery branch now retains the full resolved reference (previously only `.locator`), so a corrected path's line survives recovery (ruling 3).
- **Jump**: `FileSourceView` consumes the request one-shot — clamped, centered via `virtualizer.scrollToIndex` when virtualization is active (≥2000 lines) or `[data-source-line]` `scrollIntoView({block:"center"})` on the non-virtualized path (rulings 4-6). `FileEditorView` forces source mode once per token (mirroring the landed find-in-file forcers, ruling 9) and threads props through `FileViewerContent`.
- **Docs**: `specs/codebase/systems/product/workspaces/files.md` gains a "Source-location navigation" subsection.

## Tests

- New `FileSourceView.test.tsx` (7 tests): virtualized/non-virtualized centering + clamping, no-request no-op, one-shot and stale-token invalidation, repeat token re-centers.
- Store +6 (mint/consume/supersede/invalidate/close/reset), `use-file-reference-actions` +6 (enqueue, repeat, invalid line, directory, stale outcome, fuzzy correction), `FileEditorView` +1 (mode-force once, then doesn't fight the user).

## Verification

- 5 test files / 70 tests green via `exec vitest run`; typecheck rc=0; strict structure report TOTAL 0; boundary and docs checkers rc=0.
- Negative control: commenting out the `requestViewerLocation` call failed exactly the 3 enqueue-asserting tests (0 calls) while negative-path tests stayed green; restored green.

## Follow-ups (ledgered)

- 03D-DEFER-01 column reveal, 03D-DEFER-02 jumped-line highlight (founder decisions).
- 03D-P2-01 search-scroll shares the non-virtualized offset flaw; 03D-P2-02 `C:12:34` parse oddity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
