### PR TITLE
fix(product): send raw target-observed control ids at session create

### DIFF
--- a/apps/packages/product-client/src/hooks/chat/workflows/use-chat-launch-control-actions.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/workflows/use-chat-launch-control-actions.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatLaunchControlActions } from "#product/hooks/chat/workflows/use-chat-launch-control-actions";
+import { USER_PREFERENCE_DEFAULTS } from "#product/lib/domain/preferences/user/model";
+import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store";
+
+const setActiveSessionConfigOption = vi.fn<() => Promise<void>>();
+
+vi.mock("#product/hooks/sessions/workflows/use-session-config-actions", () => ({
+  useSessionConfigActions: () => ({ setActiveSessionConfigOption }),
+}));
+
+describe("useChatLaunchControlActions", () => {
+  beforeEach(() => {
+    setActiveSessionConfigOption.mockReset();
+    useUserPreferencesStore.setState({
+      ...USER_PREFERENCE_DEFAULTS,
+      _hydrated: false,
+      _persistedMetadata: {},
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("persists default launch controls under the raw target-observed id", () => {
+    const { result } = renderHook(() =>
+      useChatLaunchControlActions({ activeLaunchAgentKind: null }));
+
+    act(() => {
+      result.current("codex", "effort", "reasoning_effort", "xhigh");
+    });
+
+    const persisted = useUserPreferencesStore.getState()
+      .defaultLiveSessionControlValuesByAgentKind;
+    expect(persisted).toEqual({ codex: { reasoning_effort: "xhigh" } });
+    // Negative control: the normalized key must never reach the persisted map
+    // (the create seam exact-validates raw observed ids).
+    expect(persisted.codex).not.toHaveProperty("effort");
+  });
+
+  it("falls back to persisting the raw id when the live update fails", async () => {
+    setActiveSessionConfigOption.mockRejectedValueOnce(new Error("live update failed"));
+    const { result } = renderHook(() =>
+      useChatLaunchControlActions({ activeLaunchAgentKind: "codex" }));
+
+    await act(async () => {
+      result.current("codex", "fast_mode", "fast-mode", "on");
+      await Promise.resolve();
+    });
+
+    expect(setActiveSessionConfigOption).toHaveBeenCalledWith(
+      "fast-mode",
+      "on",
+      { controlKey: "fast_mode" },
+    );
+    const persisted = useUserPreferencesStore.getState()
+      .defaultLiveSessionControlValuesByAgentKind;
+    expect(persisted).toEqual({ codex: { "fast-mode": "on" } });
+    expect(persisted.codex).not.toHaveProperty("fast_mode");
+  });
+});

--- a/apps/packages/product-client/src/hooks/chat/workflows/use-chat-launch-control-actions.ts
+++ b/apps/packages/product-client/src/hooks/chat/workflows/use-chat-launch-control-actions.ts
@@ -19,19 +19,22 @@ export function useChatLaunchControlActions({
     value: string,
   ) => {
     if (!activeLaunchAgentKind) {
-      updateDefaultLaunchControlPreference(agentKind, controlKey, value);
+      updateDefaultLaunchControlPreference(agentKind, rawConfigId, value);
       return;
     }
 
     void setActiveSessionConfigOption(rawConfigId, value, { controlKey }).catch(() => {
-      updateDefaultLaunchControlPreference(activeLaunchAgentKind, controlKey, value);
+      updateDefaultLaunchControlPreference(activeLaunchAgentKind, rawConfigId, value);
     });
   }, [activeLaunchAgentKind, setActiveSessionConfigOption]);
 }
 
+// Persisted launch defaults are keyed by the RAW target-observed control id
+// (the create seam exact-validates keys against the harness observation), so
+// this must receive `rawConfigId`, never the normalized control key.
 function updateDefaultLaunchControlPreference(
   agentKind: string,
-  controlKey: string,
+  rawConfigId: string,
   value: string,
 ): void {
   const state = useUserPreferencesStore.getState();
@@ -39,7 +42,7 @@ function updateDefaultLaunchControlPreference(
     ...state.defaultLiveSessionControlValuesByAgentKind,
     [agentKind]: {
       ...state.defaultLiveSessionControlValuesByAgentKind[agentKind],
-      [controlKey]: value,
+      [rawConfigId]: value,
     },
   });
 }

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts
@@ -35,10 +35,12 @@ import {
   sessionIntentsForSession,
 } from "#product/domain/sessions/intents/session-intent-state";
 import {
-  configValuesFromIntentSnapshot,
   planCreationConfigIntentSettlement,
+  rawConfigValuesFromIntentSnapshot,
   snapshotPreMaterializationConfigIntents,
 } from "#product/lib/domain/sessions/creation/config-intent-settlement";
+import { filterControlValuesToObservation } from "#product/lib/domain/sessions/creation/launch-control-observation-filter";
+import { getAgentLaunchOptions } from "#product/lib/access/anyharness/agents";
 import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
 import type { CreateSessionWithResolvedConfigOptions } from "#product/hooks/sessions/workflows/session-creation-types";
 import { resolveDesktopRuntimeUrlForWorkspace } from "#product/hooks/sessions/workflows/session-creation-runtime";
@@ -196,11 +198,21 @@ async function runSessionCreationMaterialization({
   const configIntentSnapshot = snapshotPreMaterializationConfigIntents(
     sessionIntentsForSession(useSessionIntentStore.getState(), pendingSessionId),
   );
-  const controlValues = {
+  // Run-time refresh of the target's observed launch options: the runtime
+  // exact-validates control keys against raw observed ids, so the merged
+  // selection (which may carry pre-cutover normalized keys from persisted
+  // preferences) is filtered to the current observation. Omission remains
+  // omission; on fetch failure nothing validatable exists, so send none.
+  const launchOptionsObservation = await getAgentLaunchOptions(
+    targetConnection,
+    options.agentKind,
+    requestOptions,
+  ).catch(() => null);
+  const controlValues = filterControlValuesToObservation({
     ...(frozenDefaultLiveSessionControlValuesByAgentKind[options.agentKind] ?? {}),
     ...(options.launchControlValues ?? {}),
-    ...configValuesFromIntentSnapshot(configIntentSnapshot),
-  };
+    ...rawConfigValuesFromIntentSnapshot(configIntentSnapshot),
+  }, launchOptionsObservation);
   assertDirectSessionCreateSupported(target);
   const session: Session = await createSession(targetConnection, {
     ...(options.runtimeSessionId ? { sessionId: options.runtimeSessionId } : {}),

--- a/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts
+++ b/apps/packages/product-client/src/hooks/sessions/workflows/session-creation-materialization.ts
@@ -213,6 +213,11 @@ async function runSessionCreationMaterialization({
     ...(options.launchControlValues ?? {}),
     ...rawConfigValuesFromIntentSnapshot(configIntentSnapshot),
   }, launchOptionsObservation);
+  // The options fetch widened the window since the last supersession check;
+  // re-check before committing a runtime session.
+  if (await discardIfSuperseded(pendingSessionId, lifecycle)) {
+    return pendingSessionId;
+  }
   assertDirectSessionCreateSupported(target);
   const session: Session = await createSession(targetConnection, {
     ...(options.runtimeSessionId ? { sessionId: options.runtimeSessionId } : {}),

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/config-intent-settlement.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/config-intent-settlement.ts
@@ -87,16 +87,6 @@ export function resolvePreMaterializationConfigIntentControlKeys(input: {
   });
 }
 
-export function configValuesFromIntentSnapshot(
-  snapshot: PreMaterializationConfigIntentSnapshot,
-): Record<string, string> {
-  const values: Record<string, string> = {};
-  for (const entry of snapshot) {
-    values[entry.controlKey] = entry.value;
-  }
-  return values;
-}
-
 export function rawConfigValuesFromIntentSnapshot(
   snapshot: PreMaterializationConfigIntentSnapshot,
 ): Record<string, string> {

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/launch-control-observation-filter.test.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/launch-control-observation-filter.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import type { HarnessLaunchOptionsResponse } from "@anyharness/sdk";
+import { filterControlValuesToObservation } from "#product/lib/domain/sessions/creation/launch-control-observation-filter";
+
+function observation(overrides: Partial<HarnessLaunchOptionsResponse> = {}): HarnessLaunchOptionsResponse {
+  return {
+    harnessKind: "codex",
+    basisRevision: "basis-1",
+    revision: 3,
+    state: "observed",
+    options: {
+      models: [{ id: "gpt-5.6-sol", observedName: null, observedDescription: null }],
+      controls: [
+        {
+          id: "reasoning_effort",
+          observedLabel: null,
+          observedDescription: null,
+          values: [
+            { value: "high", observedLabel: null, observedDescription: null },
+            { value: "xhigh", observedLabel: null, observedDescription: null },
+          ],
+        },
+        {
+          id: "fast-mode",
+          observedLabel: null,
+          observedDescription: null,
+          values: [
+            { value: "on", observedLabel: null, observedDescription: null },
+            { value: "off", observedLabel: null, observedDescription: null },
+          ],
+        },
+      ],
+      defaults: { modelId: "gpt-5.6-sol", controlValues: {} },
+    },
+    observedAt: "2026-08-19T00:00:00Z",
+    probeAttemptedAt: "2026-08-19T00:00:00Z",
+    probeFailureCode: null,
+    readiness: "ready" as HarnessLaunchOptionsResponse["readiness"],
+    ...overrides,
+  };
+}
+
+describe("filterControlValuesToObservation", () => {
+  it("keeps raw observed control ids and drops pre-cutover normalized keys", () => {
+    const filtered = filterControlValuesToObservation(
+      {
+        // Legacy persisted defaults written before the raw-id cutover.
+        effort: "xhigh",
+        fast_mode: "off",
+        // Correct raw-id entries.
+        reasoning_effort: "xhigh",
+        "fast-mode": "off",
+      },
+      observation(),
+    );
+
+    expect(filtered).toEqual({ reasoning_effort: "xhigh", "fast-mode": "off" });
+    // Negative control: the normalized keys the deployed bug leaked must not
+    // survive filtering.
+    expect(filtered).not.toHaveProperty("effort");
+    expect(filtered).not.toHaveProperty("fast_mode");
+  });
+
+  it("drops values outside the observed value set", () => {
+    expect(
+      filterControlValuesToObservation(
+        { reasoning_effort: "ultra" },
+        observation(),
+      ),
+    ).toEqual({});
+  });
+
+  it("sends nothing for a harness that observes no controls", () => {
+    const grokShaped = observation({
+      harnessKind: "grok",
+      options: {
+        models: [{ id: "grok-4", observedName: null, observedDescription: null }],
+        controls: [],
+        defaults: { modelId: "grok-4", controlValues: {} },
+      },
+    });
+    expect(
+      filterControlValuesToObservation({ effort: "high", mode: "agent" }, grokShaped),
+    ).toEqual({});
+  });
+
+  it("sends nothing when the observation fetch failed", () => {
+    expect(
+      filterControlValuesToObservation({ reasoning_effort: "xhigh" }, null),
+    ).toEqual({});
+  });
+
+  it("sends nothing while the target is not currently observed", () => {
+    expect(
+      filterControlValuesToObservation(
+        { reasoning_effort: "xhigh" },
+        observation({ state: "detecting", options: null }),
+      ),
+    ).toEqual({});
+    expect(
+      filterControlValuesToObservation(
+        { reasoning_effort: "xhigh" },
+        observation({ state: "failed_without_observation" }),
+      ),
+    ).toEqual({});
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/launch-control-observation-filter.test.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/launch-control-observation-filter.test.ts
@@ -90,7 +90,7 @@ describe("filterControlValuesToObservation", () => {
     ).toEqual({});
   });
 
-  it("sends nothing while the target is not currently observed", () => {
+  it("sends nothing when no options were ever observed", () => {
     expect(
       filterControlValuesToObservation(
         { reasoning_effort: "xhigh" },
@@ -100,8 +100,21 @@ describe("filterControlValuesToObservation", () => {
     expect(
       filterControlValuesToObservation(
         { reasoning_effort: "xhigh" },
-        observation({ state: "failed_without_observation" }),
+        observation({ state: "failed_without_observation", options: null }),
       ),
     ).toEqual({});
+  });
+
+  it("keeps valid raw keys during refreshing and last-good-after-failure", () => {
+    // The runtime validates against `options` whenever present regardless of
+    // state; dropping here would silently lose picks it would accept.
+    for (const state of ["refreshing", "last_good_after_failure"] as const) {
+      expect(
+        filterControlValuesToObservation(
+          { reasoning_effort: "xhigh", effort: "xhigh" },
+          observation({ state }),
+        ),
+      ).toEqual({ reasoning_effort: "xhigh" });
+    }
   });
 });

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/launch-control-observation-filter.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/launch-control-observation-filter.ts
@@ -9,18 +9,19 @@ import type { HarnessLaunchOptionsResponse } from "@anyharness/sdk";
  * observed, values outside the observed set) must be dropped before create.
  * Omission remains omission: dropped entries fall back to observed defaults.
  *
- * When the observation is unavailable (fetch failure upstream passes `null`)
- * or not currently observed, no key can be validated, so nothing is sent.
+ * When the observation is unavailable (fetch failure upstream passes `null`,
+ * or a state whose `options` is null), no key can be validated, so nothing is
+ * sent. The gate is options presence, not state: the runtime validates against
+ * `options` whenever present (including `refreshing` and
+ * `last_good_after_failure`), so dropping valid raw keys in those states would
+ * silently lose user picks the runtime would accept.
  */
 export function filterControlValuesToObservation(
   controlValues: Record<string, string>,
   observation: HarnessLaunchOptionsResponse | null,
 ): Record<string, string> {
   const controls = observation?.options?.controls;
-  if (
-    !controls
-    || (observation.state !== "observed" && observation.state !== "observed_empty")
-  ) {
+  if (!controls) {
     return {};
   }
   const filtered: Record<string, string> = {};

--- a/apps/packages/product-client/src/lib/domain/sessions/creation/launch-control-observation-filter.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/creation/launch-control-observation-filter.ts
@@ -1,0 +1,35 @@
+import type { HarnessLaunchOptionsResponse } from "@anyharness/sdk";
+
+/**
+ * Filter a merged control-value map down to the target's current observation.
+ *
+ * The runtime exact-validates every `controlValues` key against the raw
+ * observed control ids for the harness, so anything else (legacy normalized
+ * keys persisted before the raw-id cutover, controls a given harness never
+ * observed, values outside the observed set) must be dropped before create.
+ * Omission remains omission: dropped entries fall back to observed defaults.
+ *
+ * When the observation is unavailable (fetch failure upstream passes `null`)
+ * or not currently observed, no key can be validated, so nothing is sent.
+ */
+export function filterControlValuesToObservation(
+  controlValues: Record<string, string>,
+  observation: HarnessLaunchOptionsResponse | null,
+): Record<string, string> {
+  const controls = observation?.options?.controls;
+  if (
+    !controls
+    || (observation.state !== "observed" && observation.state !== "observed_empty")
+  ) {
+    return {};
+  }
+  const filtered: Record<string, string> = {};
+  for (const control of controls) {
+    const value = controlValues[control.id];
+    if (value !== undefined
+      && control.values.some((candidate) => candidate.value === value)) {
+      filtered[control.id] = value;
+    }
+  }
+  return filtered;
+}


### PR DESCRIPTION
## Summary

- Fixes the deployed-product breakage where every new codex chat send failed with `Not sent: launch value '<unknown-control>' for 'effort' is not supported`.
- Root cause: two client paths violated the raw-id contract of the target-observed launch-options cutover (#2070). `useChatLaunchControlActions` persisted normalized control keys (`effort`, `fast_mode`) into `defaultLiveSessionControlValuesByAgentKind`, and session-creation materialization spread that map plus the normalized-keyed intent projection straight into `createSession`'s `controlValues`. The runtime exact-validates keys against raw observed control ids (`reasoning_effort`, `fast-mode` for codex); claude worked only because its raw id happens to be `effort`.
- Writers now persist `rawConfigId` in both branches; creation swaps to the already-existing `rawConfigValuesFromIntentSnapshot`; and per the agent-run-config spec's "run time: refresh the same target runtime's options and validate", the merged selection is fetched-and-filtered against the target's current observation before create. Keys or values outside the observation are dropped silently (omission remains omission), and a failed or unobserved options fetch sends `controlValues: {}` fail-safe.
- No disk migration: stale normalized keys already persisted on user machines are filtered out at the create seam and rewritten as raw ids on the next pick.

## Testing

- `pnpm vitest run` on the two new test files: 7/7 pass (raw-id persistence with negative controls asserting the normalized key is absent; legacy-key filtering with a codex-shaped observation; out-of-set value drop; grok zero-controls -> `{}`; fetch-failure -> `{}`; unobserved states -> `{}`).
- Full product-client typecheck chain (`pnpm run typecheck`) passes locally; `scripts/check_max_lines.py` passes.
- Tier-2 intent tests run with `TIER2_INTENT_SKIP_RUNTIME=1` and cannot cover runtime exact-validation; follow-up recorded to add a scripted-runtime scenario under `anyharness/tests/` covering a persisted-normalized-key session create.
- Remote CI on this head is the verdict for everything else.

## Verification after release

A new codex chat with a remembered effort/fast-mode preference must create successfully, sending either `reasoning_effort`/`fast-mode` or no control keys; the `<unknown-control>` error class disappears. Grok chats with any stale remembered control also recover.
