### PR TITLE
fix(product): keep other observed harnesses in the model picker during an active session

### DIFF
--- a/anyharness/sdk-react/src/hooks/agents.ts
+++ b/anyharness/sdk-react/src/hooks/agents.ts
@@ -1,5 +1,6 @@
 import {
   useMutation,
+  useQueries,
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
@@ -85,6 +86,35 @@ export function useAgentLaunchOptionsQuery(options?: RuntimeQueryOptions & {
       const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
       return client.agents.getLaunchOptions(harnessKind, requestOptionsWithSignal(undefined, signal));
     },
+  });
+}
+
+/**
+ * Launch options for several harnesses at once, sharing the per-kind cache
+ * entries of [`useAgentLaunchOptionsQuery`]. Returns one response (or `null`
+ * while unresolved/failed) per requested kind, in request order; `combine`
+ * keeps the array reference stable across renders while the data is unchanged.
+ */
+export function useAgentLaunchOptionsListQuery(options?: RuntimeQueryOptions & {
+  harnessKinds?: readonly string[];
+}) {
+  const runtime = useAnyHarnessRuntimeContext();
+  const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
+  const harnessKinds = (options?.harnessKinds ?? [])
+    .map((kind) => kind.trim())
+    .filter((kind) => kind.length > 0);
+
+  return useQueries({
+    queries: harnessKinds.map((harnessKind) => ({
+      queryKey: anyHarnessAgentLaunchOptionsKey(runtimeUrl, harnessKind, cacheScopeKey),
+      enabled: (options?.enabled ?? true) && runtimeUrl.length > 0,
+      queryFn: async ({ signal }: { signal: AbortSignal }) => {
+        const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
+        return client.agents.getLaunchOptions(harnessKind, requestOptionsWithSignal(undefined, signal));
+      },
+    })),
+    combine: (results) => results.map((result) => result.data ?? null),
   });
 }
 

--- a/anyharness/sdk-react/src/index.ts
+++ b/anyharness/sdk-react/src/index.ts
@@ -97,6 +97,7 @@ export {
   useAgentsQuery,
   useWorkspaceAgentsQuery,
   useAgentLaunchOptionsQuery,
+  useAgentLaunchOptionsListQuery,
   useRefreshHarnessLaunchOptionsMutation,
   useAgentReconcileStatusQuery,
   useWorkspaceAgentReconcileStatusQuery,

--- a/apps/packages/product-client/src/hooks/access/anyharness/agents/use-workspace-agent-launch-options.ts
+++ b/apps/packages/product-client/src/hooks/access/anyharness/agents/use-workspace-agent-launch-options.ts
@@ -84,6 +84,9 @@ export function useWorkspaceAgentsLaunchOptionsListQuery({
       enabled: Boolean(
         cloudConnectionInfo && gatewayRuntimeUrl && gatewayWorkspaceId && harnessKind,
       ),
+      // Additive best-effort fan-out: a kind the sandbox does not serve must
+      // resolve to an absent group quickly, not retry-loop against a 404.
+      retry: false,
       queryFn: async ({ signal }: { signal?: AbortSignal }) => {
         if (!cloudConnectionInfo) {
           throw new Error("Cloud workspace connection is unavailable.");

--- a/apps/packages/product-client/src/hooks/access/anyharness/agents/use-workspace-agent-launch-options.ts
+++ b/apps/packages/product-client/src/hooks/access/anyharness/agents/use-workspace-agent-launch-options.ts
@@ -1,10 +1,11 @@
 import type { HarnessLaunchOptionsResponse } from "@anyharness/sdk";
 import {
   anyHarnessAgentLaunchOptionsKey,
+  useAgentLaunchOptionsListQuery,
   useAgentLaunchOptionsQuery,
   useAnyHarnessCacheScopeKey,
 } from "@anyharness/sdk-react";
-import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { useQueries, useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { getAgentLaunchOptions } from "#product/lib/access/anyharness/agents";
 import type { CloudConnectionInfo } from "@proliferate/cloud-sdk/types";
 import { withFreshCloudSandboxGatewayAccessToken } from "#product/lib/access/cloud/cloud-sandbox-gateway";
@@ -50,4 +51,58 @@ export function useWorkspaceAgentLaunchOptionsQuery({
   });
 
   return cloudConnectionInfo ? gatewayQuery : localQuery;
+}
+
+/**
+ * Launch options for several harness kinds at once, one response (or `null`
+ * while unresolved/failed) per kind in request order. Shares the per-kind
+ * cache entries of the single-kind query above for both the local-runtime and
+ * cloud-gateway paths.
+ */
+export function useWorkspaceAgentsLaunchOptionsListQuery({
+  harnessKinds,
+  cloudConnectionInfo,
+}: {
+  workspaceId: string | null;
+  harnessKinds: readonly string[];
+  cloudConnectionInfo?: CloudConnectionInfo | null;
+}): Array<HarnessLaunchOptionsResponse | null> {
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
+  const localResponses = useAgentLaunchOptionsListQuery({
+    harnessKinds,
+    enabled: !cloudConnectionInfo,
+  });
+  const gatewayRuntimeUrl = cloudConnectionInfo?.runtimeUrl ?? "";
+  const gatewayWorkspaceId = cloudConnectionInfo?.anyharnessWorkspaceId ?? null;
+  const gatewayResponses = useQueries({
+    queries: harnessKinds.map((harnessKind) => ({
+      queryKey: anyHarnessAgentLaunchOptionsKey(
+        gatewayRuntimeUrl,
+        harnessKind,
+        cacheScopeKey,
+      ),
+      enabled: Boolean(
+        cloudConnectionInfo && gatewayRuntimeUrl && gatewayWorkspaceId && harnessKind,
+      ),
+      queryFn: async ({ signal }: { signal?: AbortSignal }) => {
+        if (!cloudConnectionInfo) {
+          throw new Error("Cloud workspace connection is unavailable.");
+        }
+        const freshConnection = await withFreshCloudSandboxGatewayAccessToken(
+          cloudConnectionInfo,
+        );
+        return getAgentLaunchOptions(
+          {
+            runtimeUrl: freshConnection.runtimeUrl,
+            authToken: freshConnection.accessToken ?? undefined,
+          },
+          harnessKind,
+          { signal },
+        );
+      },
+    })),
+    combine: (results) => results.map((result) => result.data ?? null),
+  });
+
+  return cloudConnectionInfo ? gatewayResponses : localResponses;
 }

--- a/apps/packages/product-client/src/hooks/chat/derived/use-chat-launch-catalog.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/derived/use-chat-launch-catalog.test.tsx
@@ -8,15 +8,18 @@ import { useChatLaunchCatalog } from "#product/hooks/chat/derived/use-chat-launc
 
 const mocks = vi.hoisted(() => ({
   query: { data: undefined as Record<string, unknown> | undefined, isLoading: false, isError: false, error: null as Error | null },
+  otherResponses: [] as Array<Record<string, unknown> | null>,
+  readyAgentKinds: new Set(["claude"]),
 }));
 
 vi.mock("#product/hooks/agents/derived/use-agent-catalog", () => ({
   useAgentCatalog: () => ({
-    readyAgentKinds: new Set(["claude"]), isLoading: false, isError: false, error: null,
+    readyAgentKinds: mocks.readyAgentKinds, isLoading: false, isError: false, error: null,
   }),
 }));
 vi.mock("#product/hooks/access/anyharness/agents/use-workspace-agent-launch-options", () => ({
   useWorkspaceAgentLaunchOptionsQuery: () => mocks.query,
+  useWorkspaceAgentsLaunchOptionsListQuery: () => mocks.otherResponses,
 }));
 vi.mock("#product/hooks/workspaces/facade/use-selected-cloud-runtime-state", () => ({
   useSelectedCloudRuntimeState: () => ({ connectionInfo: null }),
@@ -25,6 +28,8 @@ vi.mock("#product/hooks/workspaces/facade/use-selected-cloud-runtime-state", () 
 describe("useChatLaunchCatalog", () => {
   beforeEach(() => {
     mocks.query = { data: response(["fable", "unknown-upstream"]), isLoading: false, isError: false, error: null };
+    mocks.otherResponses = [];
+    mocks.readyAgentKinds = new Set(["claude"]);
     useSessionSelectionStore.setState({ selectedWorkspaceId: "workspace-1" });
     useUserPreferencesStore.setState({
       defaultChatAgentKind: "claude",
@@ -60,14 +65,40 @@ describe("useChatLaunchCatalog", () => {
     }));
     expect(result.current.groups[0]?.models.map((model) => model.modelId)).toEqual(["live-only"]);
   });
+
+  it("keeps every other ready harness listed while a session is active", () => {
+    mocks.readyAgentKinds = new Set(["claude", "codex"]);
+    mocks.otherResponses = [response(["gpt-5.6-sol"], "codex")];
+    const { result } = renderHook(() => useChatLaunchCatalog({
+      activeSelection: { kind: "claude", modelId: "live-only" },
+      activeModelControl: {
+        kind: "claude",
+        values: [{ value: "live-only", label: "Live only" }],
+      },
+    }));
+    // Negative control against the cutover regression: an active live control
+    // must not collapse the picker to the active harness alone.
+    expect(result.current.groups.map((group) => group.kind)).toEqual(["claude", "codex"]);
+    expect(result.current.groups[0]?.models.map((model) => model.modelId)).toEqual(["live-only"]);
+    expect(result.current.groups[1]?.models.map((model) => model.modelId)).toEqual(["gpt-5.6-sol"]);
+    expect(result.current.groups[1]?.models[0]?.actionKind).toBe("open_new_chat");
+  });
+
+  it("omits an unresolved other harness without failing the catalog", () => {
+    mocks.readyAgentKinds = new Set(["claude", "codex"]);
+    mocks.otherResponses = [null];
+    const { result } = renderHook(() => useChatLaunchCatalog({ activeSelection: null }));
+    expect(result.current.groups.map((group) => group.kind)).toEqual(["claude"]);
+    expect(result.current.error).toBeNull();
+  });
 });
 
-function response(ids: string[]) {
+function response(ids: string[], harnessKind = "claude") {
   return {
-    harnessKind: "claude", basisRevision: "basis-1", revision: 5, state: "observed",
+    harnessKind, basisRevision: "basis-1", revision: 5, state: "observed",
     options: {
       models: ids.map((id) => ({ id, observedName: id === "fable" ? "Fable" : null, observedDescription: null })),
-      controls: [], defaults: { modelId: "fable", controlValues: {} },
+      controls: [], defaults: { modelId: ids[0] ?? null, controlValues: {} },
     },
     observedAt: null, probeAttemptedAt: null, probeFailureCode: null, readiness: "ready",
   };

--- a/apps/packages/product-client/src/hooks/chat/derived/use-chat-launch-catalog.test.tsx
+++ b/apps/packages/product-client/src/hooks/chat/derived/use-chat-launch-catalog.test.tsx
@@ -9,7 +9,9 @@ import { useChatLaunchCatalog } from "#product/hooks/chat/derived/use-chat-launc
 const mocks = vi.hoisted(() => ({
   query: { data: undefined as Record<string, unknown> | undefined, isLoading: false, isError: false, error: null as Error | null },
   otherResponses: [] as Array<Record<string, unknown> | null>,
+  otherKindsRequested: null as readonly string[] | null,
   readyAgentKinds: new Set(["claude"]),
+  cloudConnectionInfo: null as Record<string, unknown> | null,
 }));
 
 vi.mock("#product/hooks/agents/derived/use-agent-catalog", () => ({
@@ -19,17 +21,22 @@ vi.mock("#product/hooks/agents/derived/use-agent-catalog", () => ({
 }));
 vi.mock("#product/hooks/access/anyharness/agents/use-workspace-agent-launch-options", () => ({
   useWorkspaceAgentLaunchOptionsQuery: () => mocks.query,
-  useWorkspaceAgentsLaunchOptionsListQuery: () => mocks.otherResponses,
+  useWorkspaceAgentsLaunchOptionsListQuery: (args: { harnessKinds: readonly string[] }) => {
+    mocks.otherKindsRequested = args.harnessKinds;
+    return mocks.otherResponses;
+  },
 }));
 vi.mock("#product/hooks/workspaces/facade/use-selected-cloud-runtime-state", () => ({
-  useSelectedCloudRuntimeState: () => ({ connectionInfo: null }),
+  useSelectedCloudRuntimeState: () => ({ connectionInfo: mocks.cloudConnectionInfo }),
 }));
 
 describe("useChatLaunchCatalog", () => {
   beforeEach(() => {
     mocks.query = { data: response(["fable", "unknown-upstream"]), isLoading: false, isError: false, error: null };
     mocks.otherResponses = [];
+    mocks.otherKindsRequested = null;
     mocks.readyAgentKinds = new Set(["claude"]);
+    mocks.cloudConnectionInfo = null;
     useSessionSelectionStore.setState({ selectedWorkspaceId: "workspace-1" });
     useUserPreferencesStore.setState({
       defaultChatAgentKind: "claude",
@@ -82,6 +89,17 @@ describe("useChatLaunchCatalog", () => {
     expect(result.current.groups[0]?.models.map((model) => model.modelId)).toEqual(["live-only"]);
     expect(result.current.groups[1]?.models.map((model) => model.modelId)).toEqual(["gpt-5.6-sol"]);
     expect(result.current.groups[1]?.models[0]?.actionKind).toBe("open_new_chat");
+  });
+
+  it("fans out over the sandbox ready list on a cloud workspace, not the local one", () => {
+    mocks.readyAgentKinds = new Set(["claude", "codex"]);
+    mocks.cloudConnectionInfo = { readyAgentKinds: ["claude", "grok"] };
+    mocks.otherResponses = [response(["grok-4.6"], "grok")];
+    const { result } = renderHook(() => useChatLaunchCatalog({ activeSelection: null }));
+    // Negative control: the LOCAL runtime's ready list (codex) must not drive
+    // the cloud fan-out; the sandbox connection's list (grok) is the authority.
+    expect(mocks.otherKindsRequested).toEqual(["grok"]);
+    expect(result.current.groups.map((group) => group.kind)).toEqual(["claude", "grok"]);
   });
 
   it("omits an unresolved other harness without failing the catalog", () => {

--- a/apps/packages/product-client/src/hooks/chat/derived/use-chat-launch-catalog.ts
+++ b/apps/packages/product-client/src/hooks/chat/derived/use-chat-launch-catalog.ts
@@ -59,10 +59,13 @@ export function useChatLaunchCatalog({
   // Every OTHER ready harness stays in the catalog too: the requested kind's
   // query above keeps driving loading/error/snapshot semantics, while these
   // are additive best-effort — an unresolved kind is simply absent until its
-  // observation arrives.
+  // observation arrives. On a cloud workspace the SANDBOX's ready list is the
+  // authority; agentCatalog reads the local desktop runtime.
+  const cloudReadyAgentKinds = selectedCloudRuntime.connectionInfo?.readyAgentKinds;
   const otherReadyHarnessKinds = useMemo(
-    () => [...agentCatalog.readyAgentKinds].filter((kind) => kind !== requestedHarnessKind),
-    [agentCatalog.readyAgentKinds, requestedHarnessKind],
+    () => [...(cloudReadyAgentKinds ?? agentCatalog.readyAgentKinds)]
+      .filter((kind) => kind !== requestedHarnessKind),
+    [agentCatalog.readyAgentKinds, cloudReadyAgentKinds, requestedHarnessKind],
   );
   const otherRuntimeLaunchOptions = useWorkspaceAgentsLaunchOptionsListQuery({
     workspaceId: selectedWorkspaceId,

--- a/apps/packages/product-client/src/hooks/chat/derived/use-chat-launch-catalog.ts
+++ b/apps/packages/product-client/src/hooks/chat/derived/use-chat-launch-catalog.ts
@@ -23,7 +23,10 @@ import {
 } from "#product/lib/domain/agents/cloud-launch-catalog";
 import { useAgentCatalog } from "#product/hooks/agents/derived/use-agent-catalog";
 import { useSelectedCloudRuntimeState } from "#product/hooks/workspaces/facade/use-selected-cloud-runtime-state";
-import { useWorkspaceAgentLaunchOptionsQuery } from "#product/hooks/access/anyharness/agents/use-workspace-agent-launch-options";
+import {
+  useWorkspaceAgentLaunchOptionsQuery,
+  useWorkspaceAgentsLaunchOptionsListQuery,
+} from "#product/hooks/access/anyharness/agents/use-workspace-agent-launch-options";
 
 const EMPTY_AGENTS: DesktopAgentLaunchAgent[] = [];
 
@@ -53,6 +56,19 @@ export function useChatLaunchCatalog({
     harnessKind: requestedHarnessKind,
     cloudConnectionInfo: selectedCloudRuntime.connectionInfo,
   });
+  // Every OTHER ready harness stays in the catalog too: the requested kind's
+  // query above keeps driving loading/error/snapshot semantics, while these
+  // are additive best-effort — an unresolved kind is simply absent until its
+  // observation arrives.
+  const otherReadyHarnessKinds = useMemo(
+    () => [...agentCatalog.readyAgentKinds].filter((kind) => kind !== requestedHarnessKind),
+    [agentCatalog.readyAgentKinds, requestedHarnessKind],
+  );
+  const otherRuntimeLaunchOptions = useWorkspaceAgentsLaunchOptionsListQuery({
+    workspaceId: selectedWorkspaceId,
+    harnessKinds: otherReadyHarnessKinds,
+    cloudConnectionInfo: selectedCloudRuntime.connectionInfo,
+  });
   const hasCloudTargetReadiness = Boolean(selectedCloudRuntime.connectionInfo);
   const catalogLoading = runtimeLaunchOptions.isLoading
     || (!requestedHarnessKind && agentCatalog.isLoading);
@@ -68,12 +84,15 @@ export function useChatLaunchCatalog({
 
   const launchAgents = useMemo(
     () => {
-      const projected = runtimeLaunchOptions.data
-        ? projectHarnessLaunchOptions(runtimeLaunchOptions.data)
-        : null;
-      return projected ? [projected] : EMPTY_AGENTS;
+      const projected = [runtimeLaunchOptions.data, ...otherRuntimeLaunchOptions]
+        .flatMap((response) => {
+          const agent = response ? projectHarnessLaunchOptions(response) : null;
+          return agent ? [agent] : [];
+        });
+      return projected.length > 0 ? projected : EMPTY_AGENTS;
     },
     [
+      otherRuntimeLaunchOptions,
       runtimeLaunchOptions.data,
     ],
   );

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.test.tsx
@@ -8,6 +8,8 @@ import { useHomeNextModelSelection } from "#product/hooks/home/derived/use-home-
 const mocks = vi.hoisted(() => ({
   args: null as Record<string, unknown> | null,
   data: undefined as Record<string, unknown> | undefined,
+  otherResponses: [] as Array<Record<string, unknown> | null>,
+  readyAgents: [] as Array<{ kind: string }>,
   isTargetUnobserved: false,
 }));
 
@@ -22,16 +24,19 @@ vi.mock("#product/hooks/home/derived/use-home-target-agent-launch-options", () =
       isTargetUnobserved: mocks.isTargetUnobserved,
     };
   },
+  useHomeTargetOtherAgentsLaunchOptions: () => mocks.otherResponses,
 }));
 
 vi.mock("#product/hooks/agents/derived/use-agent-catalog", () => ({
-  useAgentCatalog: () => ({ readyAgents: [], isLoading: false, isError: false, error: null }),
+  useAgentCatalog: () => ({ readyAgents: mocks.readyAgents, isLoading: false, isError: false, error: null }),
 }));
 
 describe("useHomeNextModelSelection", () => {
   beforeEach(() => {
     mocks.args = null;
     mocks.data = undefined;
+    mocks.otherResponses = [];
+    mocks.readyAgents = [];
     mocks.isTargetUnobserved = false;
     useUserPreferencesStore.setState({
       defaultChatAgentKind: "claude",
@@ -54,6 +59,34 @@ describe("useHomeNextModelSelection", () => {
       "fable",
       "unknown-upstream",
     ]);
+  });
+
+  it("keeps every other ready harness pickable from the launch composer", () => {
+    mocks.data = response();
+    mocks.readyAgents = [{ kind: "claude" }, { kind: "codex" }];
+    mocks.otherResponses = [codexResponse()];
+    const launchTarget = { kind: "local", sourceRoot: "/repo", existingWorkspaceId: null } as const;
+    const { result } = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+      launchTarget,
+    }));
+    // Negative control against the cutover regression: the launch picker must
+    // not collapse to the requested harness alone.
+    expect(result.current.modelGroups.map((group) => group.kind)).toEqual(["claude", "codex"]);
+    expect(result.current.modelGroups[1]?.models.map((model) => model.modelId)).toEqual(["gpt-5.6-sol"]);
+    expect(result.current.effectiveModelSelection).toEqual({ kind: "claude", modelId: "fable" });
+  });
+
+  it("omits an unresolved other harness without failing the launch picker", () => {
+    mocks.data = response();
+    mocks.readyAgents = [{ kind: "claude" }, { kind: "codex" }];
+    mocks.otherResponses = [null];
+    const { result } = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+      launchTarget: { kind: "local", sourceRoot: "/repo", existingWorkspaceId: null },
+    }));
+    expect(result.current.modelGroups.map((group) => group.kind)).toEqual(["claude"]);
+    expect(result.current.modelAvailabilityState).toBe("launchable");
   });
 
   it("offers no explicit model before the target has an observation", () => {
@@ -80,6 +113,18 @@ describe("useHomeNextModelSelection", () => {
     expect(result.current.effectiveModelSelection).toBeNull();
   });
 });
+
+function codexResponse() {
+  return {
+    ...response(),
+    harnessKind: "codex",
+    options: {
+      models: [{ id: "gpt-5.6-sol", observedName: "GPT-5.6 Sol", observedDescription: null }],
+      controls: [],
+      defaults: { modelId: "gpt-5.6-sol", controlValues: {} },
+    },
+  };
+}
 
 function response() {
   return {

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.ts
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.ts
@@ -1,7 +1,10 @@
 import { useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useAgentCatalog } from "#product/hooks/agents/derived/use-agent-catalog";
-import { useHomeTargetAgentLaunchOptions } from "#product/hooks/home/derived/use-home-target-agent-launch-options";
+import {
+  useHomeTargetAgentLaunchOptions,
+  useHomeTargetOtherAgentsLaunchOptions,
+} from "#product/hooks/home/derived/use-home-target-agent-launch-options";
 import {
   projectHarnessLaunchOptions,
   type DesktopLaunchModelRegistry as ModelRegistry,
@@ -45,19 +48,34 @@ export function useHomeNextModelSelection({
     harnessKind: requestedHarnessKind,
     launchTarget,
   });
+  // Every OTHER ready harness on the same target stays pickable too; the
+  // requested kind's query keeps driving loading/error/availability. Additive
+  // best-effort: an unresolved kind is absent until its observation arrives.
+  const otherReadyHarnessKinds = useMemo(
+    () => readyAgents
+      .map((agent) => agent.kind)
+      .filter((kind) => kind !== requestedHarnessKind),
+    [readyAgents, requestedHarnessKind],
+  );
+  const otherLaunchOptions = useHomeTargetOtherAgentsLaunchOptions({
+    harnessKinds: otherReadyHarnessKinds,
+    launchTarget,
+  });
   const modelRegistries = useMemo(
     () => {
-      const agent = targetLaunchOptions.data
-        ? projectHarnessLaunchOptions(targetLaunchOptions.data)
-        : null;
-      return agent ? [{
-        kind: agent.kind,
-        displayName: agent.displayName,
-        defaultModelId: agent.defaultModelId,
-        models: agent.models,
-      }] : EMPTY_MODEL_REGISTRIES;
+      const registries = [targetLaunchOptions.data, ...otherLaunchOptions]
+        .flatMap((response) => {
+          const agent = response ? projectHarnessLaunchOptions(response) : null;
+          return agent ? [{
+            kind: agent.kind,
+            displayName: agent.displayName,
+            defaultModelId: agent.defaultModelId,
+            models: agent.models,
+          }] : [];
+        });
+      return registries.length > 0 ? registries : EMPTY_MODEL_REGISTRIES;
     },
-    [targetLaunchOptions.data],
+    [otherLaunchOptions, targetLaunchOptions.data],
   );
   const readyAgentsForLaunch = useMemo(() => modelRegistries.map((registry) => ({
     kind: registry.kind,

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-target-agent-launch-options.ts
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-target-agent-launch-options.ts
@@ -1,5 +1,8 @@
 import type { HarnessLaunchOptionsResponse } from "@anyharness/sdk";
-import { useAgentLaunchOptionsQuery } from "@anyharness/sdk-react";
+import {
+  useAgentLaunchOptionsListQuery,
+  useAgentLaunchOptionsQuery,
+} from "@anyharness/sdk-react";
 import type { CloudHarnessLaunchOptionsResponse } from "@proliferate/cloud-sdk";
 import {
   useCloudHarnessLaunchOptions,
@@ -82,6 +85,28 @@ export function useHomeTargetAgentLaunchOptions({
     isLoading: localLaunchOptions.isLoading,
     isTargetUnobserved: false,
   };
+}
+
+/**
+ * Additive fan-out companion: launch options for the OTHER ready harnesses on
+ * the same execution target, one response (or `null` while unresolved) per
+ * kind. Local-runtime targets only — a cloud launch reads its sandbox's copied
+ * observation per kind and keeps today's single-kind behavior (the cloud copy
+ * store has no list read yet; recorded follow-up).
+ */
+export function useHomeTargetOtherAgentsLaunchOptions({
+  harnessKinds,
+  launchTarget,
+}: {
+  harnessKinds: readonly string[];
+  launchTarget: HomeLaunchTarget | null;
+}): Array<HarnessLaunchOptionsResponse | null> {
+  const isLocalRuntimeTarget = launchTarget !== null && launchTarget.kind !== "cloud";
+  const responses = useAgentLaunchOptionsListQuery({
+    harnessKinds,
+    enabled: isLocalRuntimeTarget,
+  });
+  return isLocalRuntimeTarget ? responses : [];
 }
 
 function isNotFound(error: unknown): boolean {

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-target-agent-launch-options.ts
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-target-agent-launch-options.ts
@@ -106,8 +106,12 @@ export function useHomeTargetOtherAgentsLaunchOptions({
     harnessKinds,
     enabled: isLocalRuntimeTarget,
   });
-  return isLocalRuntimeTarget ? responses : [];
+  // Stable empty reference: a fresh [] here would recompute the whole
+  // downstream memo chain on every cloud/no-target render.
+  return isLocalRuntimeTarget ? responses : EMPTY_RESPONSES;
 }
+
+const EMPTY_RESPONSES: Array<HarnessLaunchOptionsResponse | null> = [];
 
 function isNotFound(error: unknown): boolean {
   return Boolean(

--- a/apps/packages/product-client/src/lib/domain/chat/models/model-selector-options.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/models/model-selector-options.test.ts
@@ -32,6 +32,45 @@ describe("buildModelSelectorGroups target authority", () => {
     expect(group?.models.map((model) => model.modelId)).toEqual(["live-only"]);
   });
 
+  it("keeps every other observed harness while a session is active", () => {
+    const codexAgent = {
+      ...observedAgent,
+      kind: "codex",
+      displayName: "Codex",
+      defaultModelId: "gpt-5.6-sol",
+      models: [{ id: "gpt-5.6-sol", displayName: "GPT-5.6 Sol", aliases: [] }],
+    };
+    const groups = buildModelSelectorGroups(
+      [observedAgent, codexAgent] as never,
+      { kind: "claude", modelId: "live-only" },
+      { kind: "claude", modelId: "live-only" },
+      {
+        kind: "claude",
+        values: [{ value: "live-only", label: "Live only" }],
+      },
+    );
+    // Negative control against the cutover regression: the active live control
+    // must not collapse the picker to the active harness alone.
+    expect(groups.map((group) => group.kind)).toEqual(["claude", "codex"]);
+    expect(groups[0]?.models.map((model) => model.modelId)).toEqual(["live-only"]);
+    expect(groups[1]?.models.map((model) => model.modelId)).toEqual(["gpt-5.6-sol"]);
+    expect(groups[1]?.models[0]?.actionKind).toBe("open_new_chat");
+  });
+
+  it("synthesizes a group when the live control's harness is unobserved", () => {
+    const groups = buildModelSelectorGroups(
+      [observedAgent] as never,
+      { kind: "grok", modelId: "grok-4.6" },
+      { kind: "grok", modelId: "grok-4.6" },
+      {
+        kind: "grok",
+        values: [{ value: "grok-4.6", label: "Grok 4.6" }],
+      },
+    );
+    expect(groups.map((group) => group.kind)).toEqual(["grok", "claude"]);
+    expect(groups[0]?.models.map((model) => model.modelId)).toEqual(["grok-4.6"]);
+  });
+
   it("marks a refused exact value without dropping the row", () => {
     const [group] = buildModelSelectorGroups(
       [observedAgent] as never,

--- a/apps/packages/product-client/src/lib/domain/chat/models/model-selector-options.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/models/model-selector-options.ts
@@ -58,13 +58,14 @@ export function buildModelSelectorGroups(
   unsupportedModelKeys: ReadonlySet<string> = EMPTY_UNSUPPORTED_KEYS,
 ): ModelSelectorGroup[] {
   const sourceAgentsByKind = new Map(agents.map((agent) => [agent.kind, agent]));
-  const matchingActiveAgents = activeModelControl?.values.length
-    ? agents.filter((agent) => agent.kind === activeModelControl.kind)
-    : [];
+  // The active session's live model statement is authoritative for ITS harness
+  // only (resolveSelectorModels swaps in the live values for the matching
+  // kind). Every other observed harness keeps its group so cross-harness rows
+  // stay reachable as open_new_chat; a live control whose harness is absent
+  // from the observed list still gets a synthesized group.
   const sourceAgents = activeModelControl?.values.length
-    ? matchingActiveAgents.length > 0
-      ? matchingActiveAgents
-      : [agentFromActiveModelControl(activeModelControl)]
+    && !agents.some((agent) => agent.kind === activeModelControl.kind)
+    ? [agentFromActiveModelControl(activeModelControl), ...agents]
     : agents;
   return sourceAgents
     .map((agent) => ({


### PR DESCRIPTION
## Summary

- Fixes the post-cutover regression where opening any chat collapsed the composer model picker to the active harness alone: codex/grok/opencode disappeared even though the runtime observed them as ready.
- #2070 rewrote `buildModelSelectorGroups` so a non-empty active live model control replaced the entire agent list with only the matching harness. Pre-cutover, the live statement only overrode the active harness's model rows and all other agents stayed listed (the `open_new_chat` action kind exists precisely for those rows, and was unreachable).
- The live statement remains authoritative for its own harness (`resolveSelectorModels` still swaps in live values for the matching kind); every other observed harness keeps its group, and a live control whose harness is absent from the observed list still gets a synthesized group, preserving the cutover's fallback.

## Testing

- New tests: active claude live control + observed codex agent yields both groups, claude showing only the live statement and codex as `open_new_chat` (negative control against the collapse); unobserved-live-harness case still synthesizes its group.
- `pnpm vitest run` across model-picker and chat-derived suites: 41/41 pass; product-client `tsc --noEmit` clean; `check_max_lines` clean.
- Reproduced live on a dev profile running the shipped runtime binary: all four harnesses observed+ready server-side while the picker showed claude only.

## Verification after release

With a chat open, the picker lists every installed harness's observed models again; picking a codex/grok model opens a new chat as before the cutover.