### PR TITLE
fix(anyharness): soft-drop per-model launch controls at session start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4240,7 +4240,7 @@ dependencies = [
 
 [[package]]
 name = "proliferate"
-version = "0.4.18"
+version = "0.4.20"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/handle.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/handle.rs
@@ -59,6 +59,7 @@ pub(in crate::live::sessions::actor) async fn apply_resolved_launch_intent(
     }
 
     let mut pending = intent.control_values.clone();
+    let mut dropped_control_ids: Vec<String> = Vec::new();
     let ordered_ids = startup_state
         .config_options
         .iter()
@@ -83,6 +84,24 @@ pub(in crate::live::sessions::actor) async fn apply_resolved_launch_intent(
                 return Err(error);
             }
         };
+        // Create-time validation runs against the harness-level observation,
+        // but some harnesses narrow a control's value set per model (codex
+        // reasoning_effort). A value the live session no longer offers after
+        // the model applied is dropped to the session default rather than
+        // failing the whole start; a refusal of an offered value stays fatal.
+        if matches!(outcome, ConfigApplyOutcome::NotApplied) {
+            log_initial_config_apply(session_id, agent_kind, &config_id, "membership_dropped");
+            tracing::warn!(
+                session_id,
+                harness_kind = agent_kind,
+                control_id = %config_id,
+                value = %value,
+                event = "session.initial_config.dropped",
+                "requested control value is absent from the live session; launching with its default"
+            );
+            dropped_control_ids.push(config_id);
+            continue;
+        }
         log_initial_config_apply(
             session_id,
             agent_kind,
@@ -99,51 +118,85 @@ pub(in crate::live::sessions::actor) async fn apply_resolved_launch_intent(
     // live statement and can positively confirm through set_mode/read-back.
     if let Some(value) = pending.remove("mode") {
         if !startup_state.legacy_mode_contains_value(&value) {
-            log_initial_config_apply(session_id, agent_kind, "mode", "membership_rejected");
-            anyhow::bail!("requested control 'mode' value '{value}' is absent from the live {agent_kind} session");
-        }
+            log_initial_config_apply(session_id, agent_kind, "mode", "membership_dropped");
+            tracing::warn!(
+                session_id,
+                harness_kind = agent_kind,
+                control_id = "mode",
+                value = %value,
+                event = "session.initial_config.dropped",
+                "requested control value is absent from the live session; launching with its default"
+            );
+            dropped_control_ids.push("mode".to_string());
+        } else {
         let outcome = match apply_mode_via_direct_setter_legacy(
-            conn,
-            native_session_id,
-            startup_state,
-            &value,
-        )
-        .await
-        {
-            Ok(outcome) => outcome,
-            Err(error) => {
-                log_initial_config_apply(session_id, agent_kind, "mode", "apply_failed");
-                return Err(error);
-            }
-        };
-        log_initial_config_apply(
-            session_id,
-            agent_kind,
-            "mode",
-            confirmed_result_code(outcome),
-        );
-        anyhow::ensure!(
-            matches!(outcome, ConfigApplyOutcome::NoChange | ConfigApplyOutcome::AppliedAuthoritative),
-            "requested control 'mode' value '{value}' was not confirmed by the live {agent_kind} session"
-        );
+                conn,
+                native_session_id,
+                startup_state,
+                &value,
+            )
+            .await
+            {
+                Ok(outcome) => outcome,
+                Err(error) => {
+                    log_initial_config_apply(session_id, agent_kind, "mode", "apply_failed");
+                    return Err(error);
+                }
+            };
+            log_initial_config_apply(
+                session_id,
+                agent_kind,
+                "mode",
+                confirmed_result_code(outcome),
+            );
+            anyhow::ensure!(
+                matches!(outcome, ConfigApplyOutcome::NoChange | ConfigApplyOutcome::AppliedAuthoritative),
+                "requested control 'mode' value '{value}' was not confirmed by the live {agent_kind} session"
+            );
+        }
     }
-    anyhow::ensure!(
-        pending.is_empty(),
-        "requested controls are absent from the live {agent_kind} session: {:?}",
-        pending.keys().collect::<Vec<_>>()
-    );
-    if let Err(error) = ensure_resolved_launch_intent_confirmed(startup_state, intent) {
+    // A control id the live statement never surfaced at all is the same
+    // per-model narrowing class: drop it rather than failing the start.
+    for (config_id, value) in pending {
+        log_initial_config_apply(session_id, agent_kind, &config_id, "membership_dropped");
+        tracing::warn!(
+            session_id,
+            harness_kind = agent_kind,
+            control_id = %config_id,
+            value = %value,
+            event = "session.initial_config.dropped",
+            "requested control is absent from the live session; launching with its default"
+        );
+        dropped_control_ids.push(config_id);
+    }
+    let confirmed_intent = intent_without_dropped_controls(intent, &dropped_control_ids);
+    if let Err(error) = ensure_resolved_launch_intent_confirmed(startup_state, &confirmed_intent) {
         log_initial_config_apply(session_id, agent_kind, "complete_intent", "final_mismatch");
         return Err(error);
     }
     tracing::info!(
         harness = agent_kind,
         selected_model = intent.model_id.is_some(),
-        selected_control_count = intent.control_values.len(),
+        selected_control_count = confirmed_intent.control_values.len(),
+        dropped_control_count = dropped_control_ids.len(),
         event = "session.launch_intent.confirmed",
-        "confirmed every explicit launch intent value"
+        "confirmed every applicable explicit launch intent value"
     );
     Ok(())
+}
+
+pub(in crate::live::sessions::actor) fn intent_without_dropped_controls(
+    intent: &ResolvedLaunchIntent,
+    dropped_control_ids: &[String],
+) -> ResolvedLaunchIntent {
+    if dropped_control_ids.is_empty() {
+        return intent.clone();
+    }
+    let mut confirmed = intent.clone();
+    confirmed
+        .control_values
+        .retain(|config_id, _| !dropped_control_ids.contains(config_id));
+    confirmed
 }
 
 pub(in crate::live::sessions::actor) fn ensure_resolved_launch_intent_confirmed(

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/handle.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/handle.rs
@@ -2,6 +2,8 @@ use agent_client_protocol as acp;
 use anyharness_contract::v1::ConfigApplyState;
 
 use crate::domains::sessions::launch_intent::ResolvedLaunchIntent;
+use crate::domains::sessions::live_config::controls::option_matches_key;
+use crate::domains::sessions::live_config::{NormalizedControlKind, LEGACY_MODE_COMPAT_CONFIG_ID};
 use crate::live::sessions::actor::config::apply::{
     apply_mode_via_direct_setter_legacy, apply_specific_config_option, try_apply_model_preference,
 };
@@ -9,7 +11,8 @@ use crate::live::sessions::actor::config::confirmation::config_value_matches_cur
 use crate::live::sessions::actor::config::persist::persist_requested_config_value_if_changed;
 use crate::live::sessions::actor::config::queue::queue_pending_config_change;
 use crate::live::sessions::actor::config::selection::{
-    find_select_option_by_purpose, find_select_option_for_request, select_option_values,
+    find_select_option_by_purpose, find_select_option_for_request, into_raw_pending_option,
+    select_option_values,
 };
 use crate::live::sessions::actor::config::types::{
     tracked_config_purpose, ConfigApplyOutcome, ConfigPurpose,
@@ -19,6 +22,12 @@ use crate::live::sessions::actor::state::{SessionActor, SessionStartupState};
 /// Applies the immutable create-time intent and accepts only a value that the
 /// live harness statement both advertises and positively confirms. Model is
 /// first; controls follow the harness-advertised order.
+///
+/// The one carve-out is per-model value narrowing on a NON-posture control: a
+/// quality knob the live statement still surfaces but whose requested value it
+/// no longer offers under the applied model launches at the session default
+/// instead of failing the start. Posture controls and control ids the live
+/// statement never surfaced at all stay fail-closed.
 pub(in crate::live::sessions::actor) async fn apply_resolved_launch_intent(
     conn: &acp::ConnectionTo<acp::Agent>,
     native_session_id: &str,
@@ -26,7 +35,7 @@ pub(in crate::live::sessions::actor) async fn apply_resolved_launch_intent(
     agent_kind: &str,
     intent: &ResolvedLaunchIntent,
     startup_state: &mut SessionStartupState,
-) -> anyhow::Result<Vec<String>> {
+) -> anyhow::Result<()> {
     if let Some(model_id) = intent.model_id.as_deref() {
         if !live_model_ids(startup_state).iter().any(|value| value == model_id) {
             log_initial_config_apply(session_id, agent_kind, "model", "membership_rejected");
@@ -86,6 +95,10 @@ pub(in crate::live::sessions::actor) async fn apply_resolved_launch_intent(
                 dropped_control_ids.push(config_id);
                 continue;
             }
+            InitialControlDisposition::Refuse => {
+                log_initial_config_apply(session_id, agent_kind, &config_id, "membership_rejected");
+                anyhow::bail!("requested control '{config_id}' value '{value}' is absent from the live {agent_kind} session");
+            }
             InitialControlDisposition::Apply => {}
         }
         let outcome = match try_apply_config_option_by_id(
@@ -117,57 +130,48 @@ pub(in crate::live::sessions::actor) async fn apply_resolved_launch_intent(
 
     // ACP's legacy mode surface has no config-option row but is still an exact
     // live statement and can positively confirm through set_mode/read-back.
-    if let Some(value) = pending.remove("mode") {
+    // The legacy mode surface is a posture control: it decides what the agent
+    // is allowed to do, so an absent value stays fatal rather than silently
+    // launching at the harness default.
+    if let Some(value) = pending.remove(LEGACY_MODE_COMPAT_CONFIG_ID) {
         if !startup_state.legacy_mode_contains_value(&value) {
-            log_initial_config_apply(session_id, agent_kind, "mode", "membership_dropped");
-            tracing::warn!(
-                session_id,
-                harness_kind = agent_kind,
-                control_id = "mode",
-                event = "session.initial_config.dropped",
-                "requested control value is absent from the live session; launching with its default"
-            );
-            dropped_control_ids.push("mode".to_string());
-        } else {
-            let outcome = match apply_mode_via_direct_setter_legacy(
-                conn,
-                native_session_id,
-                startup_state,
-                &value,
-            )
-            .await
-            {
-                Ok(outcome) => outcome,
-                Err(error) => {
-                    log_initial_config_apply(session_id, agent_kind, "mode", "apply_failed");
-                    return Err(error);
-                }
-            };
-            log_initial_config_apply(
-                session_id,
-                agent_kind,
-                "mode",
-                confirmed_result_code(outcome),
-            );
-            anyhow::ensure!(
-                matches!(outcome, ConfigApplyOutcome::NoChange | ConfigApplyOutcome::AppliedAuthoritative),
-                "requested control 'mode' value '{value}' was not confirmed by the live {agent_kind} session"
-            );
+            log_initial_config_apply(session_id, agent_kind, "mode", "membership_rejected");
+            anyhow::bail!("requested control 'mode' value '{value}' is absent from the live {agent_kind} session");
         }
-    }
-    // A control id the live statement never surfaced at all is the same
-    // per-model narrowing class: drop it rather than failing the start.
-    for (config_id, _value) in pending {
-        log_initial_config_apply(session_id, agent_kind, &config_id, "membership_dropped");
-        tracing::warn!(
+        let outcome = match apply_mode_via_direct_setter_legacy(
+            conn,
+            native_session_id,
+            startup_state,
+            &value,
+        )
+        .await
+        {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                log_initial_config_apply(session_id, agent_kind, "mode", "apply_failed");
+                return Err(error);
+            }
+        };
+        log_initial_config_apply(
             session_id,
-            harness_kind = agent_kind,
-            control_id = %config_id,
-            event = "session.initial_config.dropped",
-            "requested control is absent from the live session; launching with its default"
+            agent_kind,
+            "mode",
+            confirmed_result_code(outcome),
         );
-        dropped_control_ids.push(config_id);
+        anyhow::ensure!(
+            matches!(outcome, ConfigApplyOutcome::NoChange | ConfigApplyOutcome::AppliedAuthoritative),
+            "requested control 'mode' value '{value}' was not confirmed by the live {agent_kind} session"
+        );
     }
+    // A control id the live statement never surfaced at all is a vocabulary
+    // disagreement between the create-time observation and the live session,
+    // not per-model value narrowing. Dropping it would make every future user
+    // selection for that control a silent perpetual no-op, so it stays fatal.
+    anyhow::ensure!(
+        pending.is_empty(),
+        "requested controls are absent from the live {agent_kind} session: {:?}",
+        pending.keys().collect::<Vec<_>>()
+    );
     let confirmed_intent = intent_without_dropped_controls(intent, &dropped_control_ids);
     if let Err(error) = ensure_resolved_launch_intent_confirmed(startup_state, &confirmed_intent) {
         log_initial_config_apply(session_id, agent_kind, "complete_intent", "final_mismatch");
@@ -181,22 +185,28 @@ pub(in crate::live::sessions::actor) async fn apply_resolved_launch_intent(
         event = "session.launch_intent.confirmed",
         "confirmed every applicable explicit launch intent value"
     );
-    Ok(dropped_control_ids)
+    Ok(())
 }
 
 /// How the start path treats one explicit control value against the live
 /// statement. Create-time validation runs against the harness-level
-/// observation, but some harnesses narrow a control's value set per model
-/// (codex reasoning_effort). A value the live session does not OFFER after the
-/// model applied is dropped to the session default rather than failing the
-/// whole start. The membership check runs before anything is sent; an OFFERED
-/// value whose setter read-back refuses it stays fatal — the same invariant
-/// the legacy mode branch keeps.
+/// observation, but some harnesses narrow a QUALITY control's value set per
+/// model (codex reasoning_effort). A quality value the live session does not
+/// OFFER after the model applied is dropped to the session default rather than
+/// failing the whole start. The membership check runs before anything is sent;
+/// an OFFERED value whose setter read-back refuses it stays fatal — the same
+/// invariant the legacy mode branch keeps.
+///
+/// Posture controls are never dropped: launching a collaboration mode, mode /
+/// approval policy or sandbox mode at the harness default after the user
+/// explicitly selected against it is a silent behavior change, which is
+/// strictly worse than refusing the start.
 #[derive(Debug, PartialEq, Eq)]
 pub(in crate::live::sessions::actor) enum InitialControlDisposition {
     AlreadyLive,
     Apply,
     Drop,
+    Refuse,
 }
 
 pub(in crate::live::sessions::actor) fn initial_control_disposition(
@@ -213,9 +223,25 @@ pub(in crate::live::sessions::actor) fn initial_control_disposition(
         });
     if offered {
         InitialControlDisposition::Apply
+    } else if is_posture_control(startup_state, config_id) {
+        InitialControlDisposition::Refuse
     } else {
         InitialControlDisposition::Drop
     }
+}
+
+/// A posture control decides what the agent is allowed to DO — collaboration
+/// mode, the mode / approval-policy family, sandbox mode. Only quality and
+/// model-narrowing controls are eligible for the soft drop.
+fn is_posture_control(startup_state: &SessionStartupState, config_id: &str) -> bool {
+    if config_id == LEGACY_MODE_COMPAT_CONFIG_ID {
+        return true;
+    }
+    find_select_option_for_request(&startup_state.config_options, config_id).is_some_and(|option| {
+        let raw = into_raw_pending_option(option);
+        option_matches_key(&raw, NormalizedControlKind::Mode)
+            || option_matches_key(&raw, NormalizedControlKind::CollaborationMode)
+    })
 }
 
 pub(in crate::live::sessions::actor) fn intent_without_dropped_controls(

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/handle.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/config/handle.rs
@@ -26,7 +26,7 @@ pub(in crate::live::sessions::actor) async fn apply_resolved_launch_intent(
     agent_kind: &str,
     intent: &ResolvedLaunchIntent,
     startup_state: &mut SessionStartupState,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Vec<String>> {
     if let Some(model_id) = intent.model_id.as_deref() {
         if !live_model_ids(startup_state).iter().any(|value| value == model_id) {
             log_initial_config_apply(session_id, agent_kind, "model", "membership_rejected");
@@ -69,6 +69,25 @@ pub(in crate::live::sessions::actor) async fn apply_resolved_launch_intent(
         let Some(value) = pending.remove(&config_id) else {
             continue;
         };
+        match initial_control_disposition(startup_state, &config_id, &value) {
+            InitialControlDisposition::AlreadyLive => {
+                log_initial_config_apply(session_id, agent_kind, &config_id, "confirmed");
+                continue;
+            }
+            InitialControlDisposition::Drop => {
+                log_initial_config_apply(session_id, agent_kind, &config_id, "membership_dropped");
+                tracing::warn!(
+                    session_id,
+                    harness_kind = agent_kind,
+                    control_id = %config_id,
+                    event = "session.initial_config.dropped",
+                    "requested control value is absent from the live session; launching with its default"
+                );
+                dropped_control_ids.push(config_id);
+                continue;
+            }
+            InitialControlDisposition::Apply => {}
+        }
         let outcome = match try_apply_config_option_by_id(
             conn,
             native_session_id,
@@ -84,24 +103,6 @@ pub(in crate::live::sessions::actor) async fn apply_resolved_launch_intent(
                 return Err(error);
             }
         };
-        // Create-time validation runs against the harness-level observation,
-        // but some harnesses narrow a control's value set per model (codex
-        // reasoning_effort). A value the live session no longer offers after
-        // the model applied is dropped to the session default rather than
-        // failing the whole start; a refusal of an offered value stays fatal.
-        if matches!(outcome, ConfigApplyOutcome::NotApplied) {
-            log_initial_config_apply(session_id, agent_kind, &config_id, "membership_dropped");
-            tracing::warn!(
-                session_id,
-                harness_kind = agent_kind,
-                control_id = %config_id,
-                value = %value,
-                event = "session.initial_config.dropped",
-                "requested control value is absent from the live session; launching with its default"
-            );
-            dropped_control_ids.push(config_id);
-            continue;
-        }
         log_initial_config_apply(
             session_id,
             agent_kind,
@@ -123,13 +124,12 @@ pub(in crate::live::sessions::actor) async fn apply_resolved_launch_intent(
                 session_id,
                 harness_kind = agent_kind,
                 control_id = "mode",
-                value = %value,
                 event = "session.initial_config.dropped",
                 "requested control value is absent from the live session; launching with its default"
             );
             dropped_control_ids.push("mode".to_string());
         } else {
-        let outcome = match apply_mode_via_direct_setter_legacy(
+            let outcome = match apply_mode_via_direct_setter_legacy(
                 conn,
                 native_session_id,
                 startup_state,
@@ -157,13 +157,12 @@ pub(in crate::live::sessions::actor) async fn apply_resolved_launch_intent(
     }
     // A control id the live statement never surfaced at all is the same
     // per-model narrowing class: drop it rather than failing the start.
-    for (config_id, value) in pending {
+    for (config_id, _value) in pending {
         log_initial_config_apply(session_id, agent_kind, &config_id, "membership_dropped");
         tracing::warn!(
             session_id,
             harness_kind = agent_kind,
             control_id = %config_id,
-            value = %value,
             event = "session.initial_config.dropped",
             "requested control is absent from the live session; launching with its default"
         );
@@ -182,7 +181,41 @@ pub(in crate::live::sessions::actor) async fn apply_resolved_launch_intent(
         event = "session.launch_intent.confirmed",
         "confirmed every applicable explicit launch intent value"
     );
-    Ok(())
+    Ok(dropped_control_ids)
+}
+
+/// How the start path treats one explicit control value against the live
+/// statement. Create-time validation runs against the harness-level
+/// observation, but some harnesses narrow a control's value set per model
+/// (codex reasoning_effort). A value the live session does not OFFER after the
+/// model applied is dropped to the session default rather than failing the
+/// whole start. The membership check runs before anything is sent; an OFFERED
+/// value whose setter read-back refuses it stays fatal — the same invariant
+/// the legacy mode branch keeps.
+#[derive(Debug, PartialEq, Eq)]
+pub(in crate::live::sessions::actor) enum InitialControlDisposition {
+    AlreadyLive,
+    Apply,
+    Drop,
+}
+
+pub(in crate::live::sessions::actor) fn initial_control_disposition(
+    startup_state: &SessionStartupState,
+    config_id: &str,
+    value: &str,
+) -> InitialControlDisposition {
+    if config_value_matches_current_state(startup_state, config_id, value) {
+        return InitialControlDisposition::AlreadyLive;
+    }
+    let offered = find_select_option_for_request(&startup_state.config_options, config_id)
+        .is_some_and(|option| {
+            select_option_values(option).iter().any(|candidate| candidate == value)
+        });
+    if offered {
+        InitialControlDisposition::Apply
+    } else {
+        InitialControlDisposition::Drop
+    }
 }
 
 pub(in crate::live::sessions::actor) fn intent_without_dropped_controls(

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
@@ -13,7 +13,7 @@ use crate::live::sessions::actor::config::diagnostics::ConfigFailureStage;
 use crate::live::sessions::actor::config::handle::apply_resolved_launch_intent;
 use crate::live::sessions::actor::config::persist::{
     emit_live_config_update, emit_startup_state, load_startup_restore_snapshot,
-    log_config_stage_result,
+    log_config_stage_result, persist_session_config_state_if_changed,
 };
 use crate::live::sessions::actor::config::restore::restore_persisted_live_config_if_needed;
 use crate::live::sessions::actor::config::types::PersistedSessionConfigState;
@@ -340,7 +340,7 @@ impl SessionActor {
         // Established sessions instead restore their already-confirmed full
         // snapshot so later live mutations remain authoritative.
         if startup_restore_snapshot.is_none() {
-            if let Err(error) = apply_resolved_launch_intent(
+            match apply_resolved_launch_intent(
                 &conn,
                 &native_session_id,
                 &session_id,
@@ -350,10 +350,35 @@ impl SessionActor {
             )
             .await
             {
-                tracing::warn!(session_id = %session_id, error = %error, "failed to apply and confirm launch intent");
-                queue_launch_observation_refresh(&config.caps, &source_agent_kind, &session_id);
-                let _ = ready_tx.send(Err(startup_config_failure(&startup_strategy, &error)));
-                return Err(error);
+                Err(error) => {
+                    tracing::warn!(session_id = %session_id, error = %error, "failed to apply and confirm launch intent");
+                    queue_launch_observation_refresh(&config.caps, &source_agent_kind, &session_id);
+                    let _ = ready_tx.send(Err(startup_config_failure(&startup_strategy, &error)));
+                    return Err(error);
+                }
+                Ok(dropped_control_ids) => {
+                    // A dropped mode leaves no pending change behind, so the
+                    // requested projection must not keep stating the dropped
+                    // value forever against a diverging current value.
+                    if dropped_control_ids.iter().any(|id| id == "mode") {
+                        let mut next = persisted_config_state.clone();
+                        next.requested_mode_id = None;
+                        if let Err(error) = persist_session_config_state_if_changed(
+                            config.caps.state.as_ref(),
+                            &event_sink,
+                            &session_id,
+                            &mut persisted_config_state,
+                            next,
+                            chrono::Utc::now().to_rfc3339(),
+                        )
+                        .await
+                        {
+                            let _ = ready_tx
+                                .send(Err(startup_config_failure(&startup_strategy, &error)));
+                            return Err(error);
+                        }
+                    }
+                }
             }
         }
         // This is the first snapshot write for a newly-created session. At this

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/startup.rs
@@ -13,7 +13,7 @@ use crate::live::sessions::actor::config::diagnostics::ConfigFailureStage;
 use crate::live::sessions::actor::config::handle::apply_resolved_launch_intent;
 use crate::live::sessions::actor::config::persist::{
     emit_live_config_update, emit_startup_state, load_startup_restore_snapshot,
-    log_config_stage_result, persist_session_config_state_if_changed,
+    log_config_stage_result,
 };
 use crate::live::sessions::actor::config::restore::restore_persisted_live_config_if_needed;
 use crate::live::sessions::actor::config::types::PersistedSessionConfigState;
@@ -340,7 +340,10 @@ impl SessionActor {
         // Established sessions instead restore their already-confirmed full
         // snapshot so later live mutations remain authoritative.
         if startup_restore_snapshot.is_none() {
-            match apply_resolved_launch_intent(
+            // Only non-posture controls are ever dropped here, so the mode
+            // projection can never diverge from a dropped value and needs no
+            // compensating clear.
+            if let Err(error) = apply_resolved_launch_intent(
                 &conn,
                 &native_session_id,
                 &session_id,
@@ -350,35 +353,10 @@ impl SessionActor {
             )
             .await
             {
-                Err(error) => {
-                    tracing::warn!(session_id = %session_id, error = %error, "failed to apply and confirm launch intent");
-                    queue_launch_observation_refresh(&config.caps, &source_agent_kind, &session_id);
-                    let _ = ready_tx.send(Err(startup_config_failure(&startup_strategy, &error)));
-                    return Err(error);
-                }
-                Ok(dropped_control_ids) => {
-                    // A dropped mode leaves no pending change behind, so the
-                    // requested projection must not keep stating the dropped
-                    // value forever against a diverging current value.
-                    if dropped_control_ids.iter().any(|id| id == "mode") {
-                        let mut next = persisted_config_state.clone();
-                        next.requested_mode_id = None;
-                        if let Err(error) = persist_session_config_state_if_changed(
-                            config.caps.state.as_ref(),
-                            &event_sink,
-                            &session_id,
-                            &mut persisted_config_state,
-                            next,
-                            chrono::Utc::now().to_rfc3339(),
-                        )
-                        .await
-                        {
-                            let _ = ready_tx
-                                .send(Err(startup_config_failure(&startup_strategy, &error)));
-                            return Err(error);
-                        }
-                    }
-                }
+                tracing::warn!(session_id = %session_id, error = %error, "failed to apply and confirm launch intent");
+                queue_launch_observation_refresh(&config.caps, &source_agent_kind, &session_id);
+                let _ = ready_tx.send(Err(startup_config_failure(&startup_strategy, &error)));
+                return Err(error);
             }
         }
         // This is the first snapshot write for a newly-created session. At this

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/config_direct_setter.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/config_direct_setter.rs
@@ -49,13 +49,13 @@ impl acp::JsonRpcRequest for LegacySetModelRequest {
     type Response = serde_json::Value;
 }
 
-struct FakeAcpConnection {
-    conn: acp::ConnectionTo<acp::Agent>,
+pub(super) struct FakeAcpConnection {
+    pub(super) conn: acp::ConnectionTo<acp::Agent>,
     _client_shutdown: oneshot::Sender<()>,
     _agent_shutdown: oneshot::Sender<()>,
 }
 
-async fn fake_connection(response: serde_json::Value) -> FakeAcpConnection {
+pub(super) async fn fake_connection(response: serde_json::Value) -> FakeAcpConnection {
     let (client_io, agent_io) = tokio::io::duplex(64 * 1024);
     let (client_read, client_write) = tokio::io::split(client_io);
     let (agent_read, agent_write) = tokio::io::split(agent_io);

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/config_launch_intent.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/config_launch_intent.rs
@@ -109,9 +109,157 @@ fn disposition_drops_only_values_the_live_statement_does_not_offer() {
         initial_control_disposition(&startup_state, "reasoning_effort", "max"),
         InitialControlDisposition::Drop,
     );
-    // A control the live statement never surfaced at all.
+}
+
+#[test]
+fn disposition_refuses_posture_controls_the_live_statement_does_not_offer() {
+    // Posture controls decide what the agent is allowed to do; an unoffered
+    // value must refuse the start rather than launch at the harness default.
+    let startup_state = SessionStartupState {
+        current_mode_id: None,
+        legacy_mode_state: None,
+        config_options: vec![
+            approval_policy_option(),
+            collaboration_mode_option(),
+            reasoning_effort_option(),
+        ],
+        current_model_id: Some("gpt-5.5".to_string()),
+        available_models: session_model_options(&["gpt-5.5"]),
+        prompt_capabilities: anyharness_contract::v1::PromptCapabilities::default(),
+    };
+
     assert_eq!(
-        initial_control_disposition(&startup_state, "fast-mode", "on"),
+        initial_control_disposition(&startup_state, "approval_policy", "never"),
+        InitialControlDisposition::Refuse,
+    );
+    assert_eq!(
+        initial_control_disposition(&startup_state, "collaboration_mode", "plan"),
+        InitialControlDisposition::Refuse,
+    );
+    // Negative control for the carve-out scope: the quality knob in the very
+    // same live statement is still eligible for the soft drop.
+    assert_eq!(
+        initial_control_disposition(&startup_state, "reasoning_effort", "max"),
         InitialControlDisposition::Drop,
     );
+}
+
+fn reasoning_effort_option() -> acp::schema::SessionConfigOption {
+    acp::schema::SessionConfigOption::select(
+        "reasoning_effort",
+        "Reasoning effort",
+        "xhigh",
+        vec![
+            acp::schema::SessionConfigSelectOption::new("low", "Low"),
+            acp::schema::SessionConfigSelectOption::new("xhigh", "Xhigh"),
+        ],
+    )
+}
+
+fn approval_policy_option() -> acp::schema::SessionConfigOption {
+    acp::schema::SessionConfigOption::select(
+        "approval_policy",
+        "Approval policy",
+        "on-request",
+        vec![
+            acp::schema::SessionConfigSelectOption::new("on-request", "On request"),
+            acp::schema::SessionConfigSelectOption::new("on-failure", "On failure"),
+        ],
+    )
+}
+
+fn collaboration_mode_option() -> acp::schema::SessionConfigOption {
+    acp::schema::SessionConfigOption::select(
+        "collaboration_mode",
+        "Collaboration",
+        "chat",
+        vec![acp::schema::SessionConfigSelectOption::new("chat", "Chat")],
+    )
+}
+
+fn seam_startup_state() -> SessionStartupState {
+    SessionStartupState {
+        current_mode_id: None,
+        legacy_mode_state: None,
+        config_options: vec![approval_policy_option(), reasoning_effort_option()],
+        current_model_id: Some("gpt-5.5".to_string()),
+        available_models: session_model_options(&["gpt-5.5"]),
+        prompt_capabilities: anyharness_contract::v1::PromptCapabilities::default(),
+    }
+}
+
+fn seam_intent(config_id: &str, value: &str) -> ResolvedLaunchIntent {
+    ResolvedLaunchIntent {
+        model_id: None,
+        control_values: [(config_id.to_string(), value.to_string())]
+            .into_iter()
+            .collect(),
+        created_at: "2026-08-19T00:00:00Z".to_string(),
+    }
+}
+
+/// Seam coverage for `apply_resolved_launch_intent` itself. Every case here is
+/// decided by the pre-wire membership check, so the fake connection is never
+/// asked to answer a request.
+#[tokio::test(flavor = "current_thread")]
+async fn launch_intent_seam_drops_only_unoffered_quality_values() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let fake = super::config_direct_setter::fake_connection(
+                serde_json::json!({ "ok": true }),
+            )
+            .await;
+
+            // A control id the live statement never surfaced at all is a
+            // vocabulary disagreement and stays fatal.
+            let mut startup_state = seam_startup_state();
+            let error = apply_resolved_launch_intent(
+                &fake.conn,
+                "native-1",
+                "session-1",
+                "codex",
+                &seam_intent("web_search", "on"),
+                &mut startup_state,
+            )
+            .await
+            .expect_err("a never-surfaced control id must refuse the start");
+            assert!(
+                error.to_string().contains("web_search"),
+                "unexpected error: {error}"
+            );
+
+            // A posture control whose value the live statement does not offer
+            // stays fatal rather than launching at the harness default.
+            let mut startup_state = seam_startup_state();
+            let error = apply_resolved_launch_intent(
+                &fake.conn,
+                "native-1",
+                "session-1",
+                "codex",
+                &seam_intent("approval_policy", "never"),
+                &mut startup_state,
+            )
+            .await
+            .expect_err("an unoffered posture value must refuse the start");
+            assert!(
+                error.to_string().contains("approval_policy"),
+                "unexpected error: {error}"
+            );
+
+            // Negative control for both branches above: the same seam, same
+            // live statement, with a quality control whose requested value the
+            // applied model no longer offers, starts cleanly on the default.
+            let mut startup_state = seam_startup_state();
+            apply_resolved_launch_intent(
+                &fake.conn,
+                "native-1",
+                "session-1",
+                "codex",
+                &seam_intent("reasoning_effort", "max"),
+                &mut startup_state,
+            )
+            .await
+            .expect("an unoffered quality value must be dropped, not fatal");
+        })
+        .await;
 }

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/config_launch_intent.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/config_launch_intent.rs
@@ -72,3 +72,46 @@ fn intent_without_dropped_controls_keeps_undropped_values() {
     );
     assert!(!confirmed.control_values.contains_key("reasoning_effort"));
 }
+
+#[test]
+fn disposition_drops_only_values_the_live_statement_does_not_offer() {
+    let effort = acp::schema::SessionConfigOption::select(
+        "reasoning_effort",
+        "Reasoning effort",
+        "xhigh",
+        vec![
+            acp::schema::SessionConfigSelectOption::new("low", "Low"),
+            acp::schema::SessionConfigSelectOption::new("xhigh", "Xhigh"),
+        ],
+    );
+    let startup_state = SessionStartupState {
+        current_mode_id: None,
+        legacy_mode_state: None,
+        config_options: vec![effort],
+        current_model_id: Some("gpt-5.5".to_string()),
+        available_models: session_model_options(&["gpt-5.5"]),
+        prompt_capabilities: anyharness_contract::v1::PromptCapabilities::default(),
+    };
+
+    // Negative control: an OFFERED value must go through the setter path so a
+    // read-back refusal stays fatal; it must never be silently dropped.
+    assert_eq!(
+        initial_control_disposition(&startup_state, "reasoning_effort", "low"),
+        InitialControlDisposition::Apply,
+    );
+    // A value the live statement already states needs no round-trip.
+    assert_eq!(
+        initial_control_disposition(&startup_state, "reasoning_effort", "xhigh"),
+        InitialControlDisposition::AlreadyLive,
+    );
+    // The per-model narrowing class: not offered under the applied model.
+    assert_eq!(
+        initial_control_disposition(&startup_state, "reasoning_effort", "max"),
+        InitialControlDisposition::Drop,
+    );
+    // A control the live statement never surfaced at all.
+    assert_eq!(
+        initial_control_disposition(&startup_state, "fast-mode", "on"),
+        InitialControlDisposition::Drop,
+    );
+}

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/config_launch_intent.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/config_launch_intent.rs
@@ -1,0 +1,74 @@
+use super::*;
+
+fn session_model_options(ids: &[&str]) -> Vec<SessionModelOption> {
+    ids.iter()
+        .map(|id| SessionModelOption {
+            id: (*id).to_string(),
+            name: (*id).to_string(),
+            description: None,
+        })
+        .collect()
+}
+
+#[test]
+fn dropped_per_model_control_is_excluded_from_the_final_aggregate_check() {
+    // The live codex statement after applying gpt-5.5 narrows reasoning_effort
+    // and no longer offers 'max'; the start path drops that control and the
+    // final aggregate must confirm the remaining intent instead of failing.
+    let effort = acp::schema::SessionConfigOption::select(
+        "reasoning_effort",
+        "Reasoning effort",
+        "xhigh",
+        vec![
+            acp::schema::SessionConfigSelectOption::new("low", "Low"),
+            acp::schema::SessionConfigSelectOption::new("xhigh", "Xhigh"),
+        ],
+    );
+    let startup_state = SessionStartupState {
+        current_mode_id: None,
+        legacy_mode_state: None,
+        config_options: vec![effort],
+        current_model_id: Some("gpt-5.5".to_string()),
+        available_models: session_model_options(&["gpt-5.5"]),
+        prompt_capabilities: anyharness_contract::v1::PromptCapabilities::default(),
+    };
+    let intent = ResolvedLaunchIntent {
+        model_id: Some("gpt-5.5".to_string()),
+        control_values: [("reasoning_effort".to_string(), "max".to_string())]
+            .into_iter()
+            .collect(),
+        created_at: "2026-08-19T00:00:00Z".to_string(),
+    };
+
+    // Negative control: the unfiltered intent still fails the aggregate.
+    ensure_resolved_launch_intent_confirmed(&startup_state, &intent)
+        .expect_err("the undropped value must keep failing the aggregate");
+
+    let confirmed =
+        intent_without_dropped_controls(&intent, &["reasoning_effort".to_string()]);
+    assert!(confirmed.control_values.is_empty());
+    assert_eq!(confirmed.model_id.as_deref(), Some("gpt-5.5"));
+    ensure_resolved_launch_intent_confirmed(&startup_state, &confirmed)
+        .expect("the filtered intent must confirm cleanly");
+}
+
+#[test]
+fn intent_without_dropped_controls_keeps_undropped_values() {
+    let intent = ResolvedLaunchIntent {
+        model_id: None,
+        control_values: [
+            ("mode".to_string(), "agent".to_string()),
+            ("reasoning_effort".to_string(), "max".to_string()),
+        ]
+        .into_iter()
+        .collect(),
+        created_at: "2026-08-19T00:00:00Z".to_string(),
+    };
+    let confirmed =
+        intent_without_dropped_controls(&intent, &["reasoning_effort".to_string()]);
+    assert_eq!(
+        confirmed.control_values.get("mode").map(String::as_str),
+        Some("agent")
+    );
+    assert!(!confirmed.control_values.contains_key("reasoning_effort"));
+}

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/mod.rs
@@ -9,8 +9,8 @@ use super::config::confirmation::{
     select_setter_response_outcome,
 };
 use super::config::handle::{
-    ensure_resolved_launch_intent_confirmed, initial_control_disposition,
-    intent_without_dropped_controls, InitialControlDisposition,
+    apply_resolved_launch_intent, ensure_resolved_launch_intent_confirmed,
+    initial_control_disposition, intent_without_dropped_controls, InitialControlDisposition,
 };
 use super::config::persist::{emit_live_config_update, load_startup_restore_snapshot};
 use super::config::queue::{

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/mod.rs
@@ -8,7 +8,9 @@ use super::config::confirmation::{
     ensure_config_values_confirmed, select_option_current_value_matches,
     select_setter_response_outcome,
 };
-use super::config::handle::ensure_resolved_launch_intent_confirmed;
+use super::config::handle::{
+    ensure_resolved_launch_intent_confirmed, intent_without_dropped_controls,
+};
 use super::config::persist::{emit_live_config_update, load_startup_restore_snapshot};
 use super::config::queue::{
     pending_model_is_in_latest_live_snapshot, queue_pending_config_change,
@@ -61,6 +63,7 @@ use tokio::sync::{broadcast, mpsc, Mutex};
 mod conditional_cancel;
 mod config;
 mod config_direct_setter;
+mod config_launch_intent;
 mod config_restore;
 mod config_variants;
 mod domain_ops;

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/mod.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/tests/mod.rs
@@ -9,7 +9,8 @@ use super::config::confirmation::{
     select_setter_response_outcome,
 };
 use super::config::handle::{
-    ensure_resolved_launch_intent_confirmed, intent_without_dropped_controls,
+    ensure_resolved_launch_intent_confirmed, initial_control_disposition,
+    intent_without_dropped_controls, InitialControlDisposition,
 };
 use super::config::persist::{emit_live_config_update, load_startup_restore_snapshot};
 use super::config::queue::{

--- a/specs/FEATURE_DOCS/MODELS.md
+++ b/specs/FEATURE_DOCS/MODELS.md
@@ -183,17 +183,35 @@ then:
    explicit intent.
 
 The explicit model stays fail-closed: an absent or unconfirmed model fails
-startup and cleans up the incomplete native session. Controls carry one
-carve-out for per-model narrowing: some harnesses shrink a control's allowed
-values under the applied model (codex `reasoning_effort`), so a control value
-the live statement does not offer is dropped to the live session default with a
-`membership_dropped` result and a `session.initial_config.dropped` event, and
-the final aggregate check runs against the intent minus the dropped controls. A
-dropped mode also clears the session's requested-mode projection. An OFFERED
-value that is rejected, timed out, or unconfirmed by its setter read-back still
-fails startup and cleans up the incomplete native session. A contradiction
-queues a new override-free target probe; configured session values never become
-target defaults.
+startup and cleans up the incomplete native session.
+
+Controls carry exactly one carve-out, for per-model value narrowing on quality
+controls. Some harnesses shrink a control's allowed values under the applied
+model (codex `reasoning_effort` loses `max` under some models), which the
+harness-level observation cannot see at create time. A control that the live
+statement still surfaces, whose requested value that statement no longer
+offers, and that is not a posture control, is therefore dropped to the live
+session default with a `membership_dropped` result and a
+`session.initial_config.dropped` event; the final aggregate check then runs
+against the intent minus the dropped controls.
+
+Everything else stays fail-closed, because a silent default is worse than a
+refused start:
+
+- Posture controls are never dropped. Collaboration mode, the mode and
+  approval-policy family, and sandbox mode decide what the agent is allowed to
+  do, so launching one at the harness default after the user explicitly
+  selected against it would silently change behavior. An unoffered posture
+  value fails startup.
+- A control id the live statement never surfaced at all fails startup. That is
+  a vocabulary disagreement between the create-time observation and the live
+  session, not per-model narrowing, and dropping it would make every future
+  selection for that control a silent perpetual no-op.
+- An OFFERED value that is rejected, timed out, or unconfirmed by its setter
+  read-back fails startup and cleans up the incomplete native session.
+
+A contradiction queues a new override-free target probe; configured session
+values never become target defaults.
 
 ## Active session configuration
 

--- a/specs/FEATURE_DOCS/MODELS.md
+++ b/specs/FEATURE_DOCS/MODELS.md
@@ -182,9 +182,18 @@ then:
 4. publishes ready only when the complete live current statement matches the
    explicit intent.
 
-Missing, rejected, timed-out, or unconfirmed values fail startup and clean up
-the incomplete native session. A contradiction queues a new override-free
-target probe; configured session values never become target defaults.
+The explicit model stays fail-closed: an absent or unconfirmed model fails
+startup and cleans up the incomplete native session. Controls carry one
+carve-out for per-model narrowing: some harnesses shrink a control's allowed
+values under the applied model (codex `reasoning_effort`), so a control value
+the live statement does not offer is dropped to the live session default with a
+`membership_dropped` result and a `session.initial_config.dropped` event, and
+the final aggregate check runs against the intent minus the dropped controls. A
+dropped mode also clears the session's requested-mode projection. An OFFERED
+value that is rejected, timed out, or unconfirmed by its setter read-back still
+fails startup and cleans up the incomplete native session. A contradiction
+queues a new override-free target probe; configured session values never become
+target defaults.
 
 ## Active session configuration
 
@@ -212,6 +221,7 @@ credentials, descriptions, provider output, or filesystem paths:
 - `agent.launch_options.served`
 - `session.launch_selection.validated`
 - `session.initial_config.apply`
+- `session.initial_config.dropped`
 - `session.live_config.changed`
 
 Events include safe identifiers, basis/revision or source sequence, state,

--- a/specs/OBSERVABILITY.md
+++ b/specs/OBSERVABILITY.md
@@ -17,7 +17,8 @@ records:
 | `agent.launch_options_probe.completed` | harness kind, basis/revision, result/state, counts, duration, bounded failure code |
 | `agent.launch_options.served` | harness kind, basis/revision, state, counts |
 | `session.launch_selection.validated` | session/correlation identity, harness kind, result, selected key names/counts, bounded rejection code |
-| `session.initial_config.apply` | session identity, config key, membership/apply/confirmation result |
+| `session.initial_config.apply` | session identity, config key, membership/apply/confirmation result (`confirmed`, `unconfirmed`, `membership_rejected`, `membership_dropped`, `apply_failed`) |
+| `session.initial_config.dropped` | session identity, config key |
 | `session.live_config.changed` | session identity, source sequence, changed key, apply result |
 
 These events never contain selected values, model IDs, descriptions, provider

--- a/specs/OBSERVABILITY.md
+++ b/specs/OBSERVABILITY.md
@@ -17,7 +17,7 @@ records:
 | `agent.launch_options_probe.completed` | harness kind, basis/revision, result/state, counts, duration, bounded failure code |
 | `agent.launch_options.served` | harness kind, basis/revision, state, counts |
 | `session.launch_selection.validated` | session/correlation identity, harness kind, result, selected key names/counts, bounded rejection code |
-| `session.initial_config.apply` | session identity, config key, membership/apply/confirmation result (`confirmed`, `unconfirmed`, `membership_rejected`, `membership_dropped`, `apply_failed`) |
+| `session.initial_config.apply` | session identity, config key, membership/apply/confirmation result (`confirmed`, `unconfirmed`, `membership_rejected`, `membership_dropped`, `apply_failed`, `final_mismatch`) |
 | `session.initial_config.dropped` | session identity, config key |
 | `session.live_config.changed` | session identity, source sequence, changed key, apply result |
 


### PR DESCRIPTION
## Problem

Codex narrows a control's value set per model: the harness-level observation (probed under the default `gpt-5.6-sol`) advertises `reasoning_effort` values including `max`/`ultra`, but a live session running `gpt-5.5` offers a smaller set. Create-time validation correctly accepts `reasoning_effort=max` against the observation, then the fail-closed exact-confirmation at ACP session start gets `membership_rejected` from the live statement and kills the whole session:

```
Not sent: ACP session start failed: requested control 'reasoning_effort' value 'max' was not confirmed by the live codex session
```

Live repro on a dev profile: session `ced42481` — model confirmed, mode confirmed, collaboration_mode confirmed, `reasoning_effort` membership_rejected, session dead.

## Fix (ruled by Pablo: soft-drop at start) — scoped to quality controls

The drop decision is a pure pre-send function `initial_control_disposition` → `AlreadyLive | Apply | Drop | Refuse`.

**Dropped — exactly one carve-out.** A control that the live statement still surfaces, whose requested value that statement no longer offers under the applied model, and that is *not* a posture control. It launches at the live session default, warns `session.initial_config.dropped` (no value in the record, per the bounded-event contract), and logs result code `membership_dropped`. The final aggregate check runs against the intent minus the dropped controls, so it still catches a later setter resetting a confirmed value.

**Still fatal — a silent default is worse than a refused start:**

- **Posture controls.** Collaboration mode, the mode / approval-policy family, and sandbox mode (`NormalizedControlKind::Mode` or `CollaborationMode`) decide what the agent is allowed to *do*. Launching one at the harness default after the user explicitly selected against it is a silent behavior change, so an unoffered posture value takes the new `Refuse` disposition and fails the start. The legacy ACP `mode` surface is posture too and keeps its original bail.
- **Control ids the live statement never surfaced at all.** That is a vocabulary disagreement between the create-time observation and the live session, not per-model narrowing; dropping it would make every future selection for that control a silent perpetual no-op. The `pending.is_empty()` guard is retained.
- **The model**, and any OFFERED value whose setter read-back refuses, times out, or goes unconfirmed.

**AlreadyLive** short-circuits without a setter round-trip.

Because posture controls now refuse rather than drop, the mode projection can never diverge from a dropped value: the `requested_mode_id` clear that round 2 added at startup is dead and is removed, and `apply_resolved_launch_intent` returns `()` again.

## Specs

- `specs/FEATURE_DOCS/MODELS.md`: actor-startup section states the final policy — what is dropped, what stays fatal, and why.
- `specs/OBSERVABILITY.md`: table row for the dropped event + enumerated result codes.

Observability delta: new bounded event `session.initial_config.dropped` (session identity + config key only) and new `membership_dropped` result code on `session.initial_config.apply`.

## Tests

- `launch_intent_seam_drops_only_unoffered_quality_values` — seam-level, exercises `apply_resolved_launch_intent` itself: a never-surfaced control id is fatal, an unoffered posture value is fatal, and an unoffered quality value is dropped so the start succeeds. The third case is the negative control for the first two — same seam, same live statement.
- `disposition_refuses_posture_controls_the_live_statement_does_not_offer` — posture `Refuse` vs quality `Drop` in the same live statement.
- `disposition_drops_only_values_the_live_statement_does_not_offer` — negative control: an OFFERED value must resolve `Apply` (never silently drop), plus AlreadyLive and per-model-narrowed Drop.
- `dropped_per_model_control_is_excluded_from_the_final_aggregate_check` — negative control: the unfiltered intent still fails the aggregate.
- `intent_without_dropped_controls_keeps_undropped_values`.

## Live verification (dev runtime, round-2 binary)

- codex `gpt-5.5` + `reasoning_effort=max` (the exact production failure): create + start succeed, `reasoning_effort` logs `membership_dropped`, everything else `confirmed`.
- codex `gpt-5.5` + `reasoning_effort=low` (offered): applies and logs `confirmed` — the fatal path for refused offered values remains reachable.

## Review round 3

Addresses the fresh adversarial review (findings 1, 2, 3, 6). Not addressed, deliberately: finding 4 (no user-facing notice that a selection was dropped — needs a notice channel the sink does not expose, out of scope here), finding 5 (defensive model-purpose guard in `initial_control_disposition` — unreachable today), and finding 7 (transient half-updated `session_state_update`, moot now that the block emitting it is deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
