### PR TITLE
fix(product): normalize raw launch-control ids for composer presentation

### DIFF
--- a/apps/packages/product-client/src/hooks/chat/facade/use-chat-model-selector-state.ts
+++ b/apps/packages/product-client/src/hooks/chat/facade/use-chat-model-selector-state.ts
@@ -163,8 +163,12 @@ export function useChatModelSelectorState(options?: {
   const activeLaunchAgentKind = scopedActiveSessionId ? currentSelection?.kind ?? null : null;
   const selectLaunchControl = useChatLaunchControlActions({ activeLaunchAgentKind });
 
+  // Launch descriptors stay built while a session is active: between create
+  // and the first live snapshot the composer would otherwise render a bare
+  // model pill with no controls. ChatInput merges these with the live
+  // descriptors and the live statement wins per key the moment it arrives.
   const launchControls = useMemo(
-    () => scopedActiveSessionId ? [] : buildLaunchControlDescriptors({
+    () => buildLaunchControlDescriptors({
       selection: currentSelection,
       launchAgents: launchCatalog.launchAgents,
       pendingConfigChanges: scopedPendingConfigChanges,
@@ -174,7 +178,6 @@ export function useChatModelSelectorState(options?: {
       currentSelection,
       launchCatalog.launchAgents,
       selectLaunchControl,
-      scopedActiveSessionId,
       scopedPendingConfigChanges,
     ],
   );

--- a/apps/packages/product-client/src/lib/domain/chat/models/launch-control-descriptors.test.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/models/launch-control-descriptors.test.ts
@@ -404,3 +404,50 @@ describe("buildLaunchControlDescriptors", () => {
     });
   });
 });
+
+describe("buildLaunchControlDescriptors raw-id normalization", () => {
+  it("normalizes raw observed control ids to composer presentation keys", () => {
+    // Post-cutover projections carry RAW ids in `key` too (key === liveConfigId).
+    const controls = buildLaunchControlDescriptors({
+      selection: { kind: "codex", modelId: "gpt-5.5" },
+      launchAgents: [
+        {
+          kind: "codex",
+          launchControls: [
+            control("reasoning_effort", "Reasoning effort", "medium", "reasoning_effort"),
+            control("fast-mode", "Fast mode", "off", "fast-mode"),
+          ],
+          models: [{ id: "gpt-5.5" }],
+        },
+      ],
+      pendingConfigChanges: null,
+      onSelect: vi.fn(),
+    });
+
+    // Negative control against the cutover regression: raw ids must land on
+    // the promoted composer keys, not fall into overflow chips.
+    expect(controls.map((c) => c.key)).toEqual(["effort", "fast_mode"]);
+    // The wire truth stays the raw observed id.
+    expect(controls.map((c) => c.rawConfigId)).toEqual(["reasoning_effort", "fast-mode"]);
+  });
+
+  it("preserves an unknown raw control id instead of filtering it", () => {
+    const [descriptor] = buildLaunchControlDescriptors({
+      selection: { kind: "codex", modelId: "gpt-5.5" },
+      launchAgents: [
+        {
+          kind: "codex",
+          launchControls: [
+            control("web-search", "Web search", "off", "web-search"),
+          ],
+          models: [{ id: "gpt-5.5" }],
+        },
+      ],
+      pendingConfigChanges: null,
+      onSelect: vi.fn(),
+    });
+
+    expect(descriptor?.key).toBe("web-search");
+    expect(descriptor?.rawConfigId).toBe("web-search");
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/chat/models/launch-control-descriptors.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/models/launch-control-descriptors.ts
@@ -140,9 +140,26 @@ function launchControlToDescriptor(input: {
 function normalizeLaunchControlKey(
   key: string,
 ): SupportedLiveControlKey | null {
-  // The observed id is executable truth. The type predates arbitrary ACP
-  // controls, but dropping an unknown id here would turn a rendering helper
-  // into an availability filter. Preserve it until the view-model types are
-  // generalized in their owning package.
-  return key as SupportedLiveControlKey;
+  // Post-cutover the projection carries RAW observed control ids (codex
+  // `reasoning_effort`, `fast-mode`). The descriptor `key` is presentation
+  // identity only — composer promotion (effort stepper, fast-mode toggle) and
+  // preference round-trips match on the normalized spelling, while the wire
+  // truth stays `rawConfigId`. Map the known raw shapes; an unknown id is
+  // preserved because dropping it here would turn a rendering helper into an
+  // availability filter.
+  switch (key.toLowerCase().replace(/-/g, "_")) {
+    case "effort":
+    case "reasoning_effort":
+      return "effort";
+    case "fast_mode":
+      return "fast_mode";
+    case "collaboration_mode":
+      return "collaboration_mode";
+    case "mode":
+      return "mode";
+    case "reasoning":
+      return "reasoning";
+    default:
+      return key as SupportedLiveControlKey;
+  }
 }


### PR DESCRIPTION
## Problem (reported by Pablo with screenshots)

The NEW-CHAT launch composer renders codex controls as generic overflow chips — `Reasoning effort · Xhigh`, `Fast mode · Off` — while the in-session composer for the same harness shows the proper compact controls (six-bar reasoning-effort stepper, ⚡ Fast toggle).

## Root cause

Post-cutover, `projectHarnessLaunchOptions` carries RAW observed control ids in both `key` and `liveConfigId` (codex `reasoning_effort`, `fast-mode`), and `normalizeLaunchControlKey` in `launch-control-descriptors.ts` had become an identity cast. Composer promotion (`buildComposerSessionControlGroups`) and preference round-trips match on the NORMALIZED keys (`effort`, `fast_mode`), so raw-keyed launch controls fell through to overflow chips. Active sessions read normalized keys from the live snapshot, which is why only the launch composer diverged.

## Fix

`normalizeLaunchControlKey` maps the known raw shapes (case/separator-insensitive) to the normalized presentation keys: `reasoning_effort`→`effort`, `fast-mode`→`fast_mode`, plus identity for `mode`/`collaboration_mode`/`reasoning`/`effort`. `rawConfigId` remains the wire truth everywhere (create requests and persisted preferences keep raw ids per #2103), and unknown ids are still preserved rather than filtered.

## Tests

- `normalizes raw observed control ids to composer presentation keys` — negative control: raw ids must land on the promoted keys (pre-fix this yields `["reasoning_effort", "fast-mode"]` and the test fails) while `rawConfigId` stays raw.
- `preserves an unknown raw control id instead of filtering it`.
- Targeted vitest: descriptor + home-derived suites, 28 passed.

## Live verification (dev profile, rebuilt product-client dist)

Headless webkit against the running launch composer: after picking a codex model, `[data-reasoning-effort-trigger]` renders with `xhigh` selected, the compact `Fast` toggle renders, and zero `label · value` overflow chips remain — matching the in-session composer. The pre-fix state is the reported screenshot itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Second fix (same report thread): bare pill during the create→live-snapshot window

Pablo's follow-up screenshot showed the composer with ONLY the model pill (no stepper, no Fast toggle) between pressing send in a new chat and the session loading. Root cause: #2070 gated `launchControls` in `use-chat-model-selector-state.ts` behind `scopedActiveSessionId ? [] : build(...)` — so the instant a session id existed the launch descriptors vanished, but the live descriptors only arrive with the first live config snapshot. `ChatInput` already merges launch + live descriptors with live winning per key (`mergeSessionConfigControlDescriptors`), so the gate only starved that merge. Commit 72d1dbaeb7 removes the gate; the merge dedup depends on this PR's key normalization (raw-keyed launch controls would otherwise duplicate normalized live controls).

Live verification: headless webkit sampled the composer every 150ms through a real new-chat send on the dev profile — `[data-reasoning-effort-trigger]` and the Fast toggle stayed mounted for the entire create→live-snapshot transition (pre-fix this window renders the bare pill in the screenshot).

Known follow-up (pre-existing, NOT addressed here): for ~1s mid-transition the composer identity blips to the configured default agent (pill "Fable", claude-shaped controls) before the session's launch identity persists — same flicker class Pablo reported earlier ("Sonnet 4.5" transient). Controls no longer unmount; the identity blip is a separate seam (`currentLaunchIdentity` null-window falling back to `configuredLaunch.selection`).
