### PR TITLE
fix(anyharness): validate workflow node models at PUT and allow a redo override

### DIFF
--- a/anyharness/crates/anyharness-lib/src/api/http/workflow_run_commands.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/workflow_run_commands.rs
@@ -23,6 +23,8 @@ use crate::domains::workflows::transition::WorkflowCommand;
 pub struct WorkflowRunFailRedoRequest {
     #[serde(default)]
     pub prompt: Option<String>,
+    #[serde(default)]
+    pub model: Option<NodeModel>,
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -124,6 +126,7 @@ pub async fn fail_redo_workflow_node(
         WorkflowCommand::FailAndRedo {
             node_row_id: node_row_id.clone(),
             prompt: body.prompt,
+            model: body.model,
         },
     )
     .await

--- a/anyharness/crates/anyharness-lib/src/api/http/workflow_runs.rs
+++ b/anyharness/crates/anyharness-lib/src/api/http/workflow_runs.rs
@@ -21,6 +21,7 @@ use super::error::ApiError;
 use super::workflow_run_commands;
 use super::workspaces_contract::request_origin_or_api_default;
 use crate::app::AppState;
+use crate::domains::agents::launch_options::{LaunchSelection, LaunchSelectionUnsupported};
 use crate::domains::workflows::definition::{
     InvocationPlacement, InvocationSnapshot, PlacementMode, WorkflowDefinition,
 };
@@ -278,6 +279,108 @@ async fn compensate_placement(state: &AppState, placed: &PlacedWorkspace) {
     .await;
 }
 
+/// Fail-fast model admission for a NEW run's snapshot (#1898 defect 1).
+///
+/// A node's `modelId` was previously unchecked at PUT, so an unservable pick
+/// only surfaced minutes later when the chain reached that node — after the
+/// upstream nodes had already done their work. This walks every model-bearing
+/// node once and refuses the whole PUT, naming the offending node, before any
+/// row is inserted.
+///
+/// It does NOT replace the launch-time check and cannot: the observation is
+/// sampled here and the node launches later against a possibly-changed one
+/// (`domains/agents/launch_options/validation.rs` stays the authority). So the
+/// disposition is deliberately asymmetric — a model the observation
+/// AFFIRMATIVELY lacks is fail-closed, while a merely absent or unreadable
+/// observation (a cold runtime that has not probed yet) is fail-open and left
+/// to the launch check. Rejecting there would fail workflow creation for a
+/// reason that has nothing to do with the definition the author wrote.
+async fn admit_node_models(
+    state: &AppState,
+    definition: &WorkflowDefinition,
+) -> Result<(), ApiError> {
+    let picks: Vec<(String, String, LaunchSelection)> = definition
+        .nodes
+        .iter()
+        .filter_map(|node| {
+            let model = node.model.as_ref()?;
+            Some((
+                node.id.clone(),
+                model.agent_kind.clone(),
+                LaunchSelection {
+                    model_id: model.model_id.clone(),
+                    control_values: model.control_values.clone(),
+                },
+            ))
+        })
+        .collect();
+    if picks.is_empty() {
+        return Ok(());
+    }
+    let service = state.launch_options_service.clone();
+    let verdicts = run_blocking("workflow_snapshot_model_admission", move || {
+        anyhow::Ok(
+            picks
+                .into_iter()
+                .map(
+                    |(node_id, agent_kind, selection): (String, String, LaunchSelection)| {
+                        let verdict = service.validate_selection(&agent_kind, &selection);
+                        (node_id, agent_kind, verdict)
+                    },
+                )
+                .collect::<Vec<_>>(),
+        )
+    })
+    .await?
+    .map_err(|error| ApiError::internal(error.to_string()))?;
+    for (node_id, agent_kind, verdict) in verdicts {
+        match verdict {
+            Ok(_) => {}
+            // Fail-closed: the observation is present and does not offer this.
+            Err(LaunchSelectionUnsupported::Model { model_id, .. }) => {
+                return Err(ApiError::bad_request(
+                    format!(
+                        "invalid snapshot: node {node_id} requests model \
+                         '{model_id}' which {agent_kind} does not offer"
+                    ),
+                    SNAPSHOT_INVALID,
+                ));
+            }
+            Err(LaunchSelectionUnsupported::Control { control_id, .. }) => {
+                return Err(ApiError::bad_request(
+                    format!(
+                        "invalid snapshot: node {node_id} requests control \
+                         '{control_id}' which {agent_kind} does not offer"
+                    ),
+                    SNAPSHOT_INVALID,
+                ));
+            }
+            Err(LaunchSelectionUnsupported::ControlValue {
+                control_id, value, ..
+            }) => {
+                return Err(ApiError::bad_request(
+                    format!(
+                        "invalid snapshot: node {node_id} requests value '{value}' \
+                         for control '{control_id}', which {agent_kind} does not offer"
+                    ),
+                    SNAPSHOT_INVALID,
+                ));
+            }
+            // Fail-open: nothing authoritative to judge against yet.
+            Err(error @ LaunchSelectionUnsupported::ObservationUnavailable { .. })
+            | Err(error @ LaunchSelectionUnsupported::Internal(_)) => {
+                tracing::info!(
+                    node_id = %node_id,
+                    agent_kind = %agent_kind,
+                    %error,
+                    "workflow snapshot model admission deferred to launch",
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
 #[utoipa::path(
     put,
     path = "/v1/workflow-runs/{run_id}",
@@ -361,6 +464,11 @@ pub async fn put_workflow_run(
             return Ok((StatusCode::OK, Json(projection)));
         }
     }
+
+    // Model admission runs only on the create path, and only after the replay
+    // return above: an existing run keeps its verbatim custody even if its
+    // frozen picks no longer resolve on this machine.
+    admit_node_models(&state, &snapshot.definition).await?;
 
     // Disk before rows: placement, workspace, exclude entry, and context docs
     // all succeed before one row exists — a failure past this point

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/store_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/store_tests.rs
@@ -482,6 +482,7 @@ fn fail_and_redo_persists_a_running_replacement() {
     let redo = WorkflowEvent::Command(WorkflowCommand::FailAndRedo {
         node_row_id: plan_id.clone(),
         prompt: Some("plan again, smaller steps".into()),
+        model: None,
     });
     let applied = decide_and_apply(&store, "run-1", &applied.state, &redo);
     assert_healthy(&applied.state);
@@ -549,6 +550,7 @@ fn redo_from_a_parked_gate_marks_the_old_row_superseded() {
     let redo = WorkflowEvent::Command(WorkflowCommand::FailAndRedo {
         node_row_id: review_id.clone(),
         prompt: None,
+        model: None,
     });
     let applied = decide_and_apply(&store, "run-1", &applied.state, &redo);
     assert_healthy(&applied.state);
@@ -598,6 +600,7 @@ fn adhoc_redo_replaces_only_the_adhoc_row() {
     let redo = WorkflowEvent::Command(WorkflowCommand::FailAndRedo {
         node_row_id: adhoc_id.clone(),
         prompt: None,
+        model: None,
     });
     let applied = decide_and_apply(&store, "run-1", &applied.state, &redo);
     assert_healthy(&applied.state);
@@ -634,6 +637,7 @@ fn adhoc_redo_replaces_only_the_adhoc_row() {
         &WorkflowEvent::Command(WorkflowCommand::FailAndRedo {
             node_row_id: replacement_id,
             prompt: None,
+            model: None,
         }),
     );
     assert!(
@@ -783,10 +787,7 @@ fn cancel_from_running_disposes_the_session_and_persists_in_one_commit() {
 
     // A cancelled run is terminal: cancel again is illegal, same as any other
     // command save fail-and-redo.
-    assert!(matches!(
-        next(&reloaded, &cancel),
-        Decision::Illegal(_)
-    ));
+    assert!(matches!(next(&reloaded, &cancel), Decision::Illegal(_)));
 }
 
 /// HIGH finding: a running adhoc row is never `state.current_node()` (by
@@ -813,9 +814,17 @@ fn cancel_with_a_running_adhoc_row_disposes_both_sessions() {
         model: None,
     });
     let applied = decide_and_apply(&store, "run-1", &state, &add_adhoc);
-    let adhoc_id = applied.created_node_row_id.clone().expect("adhoc row minted");
+    let adhoc_id = applied
+        .created_node_row_id
+        .clone()
+        .expect("adhoc row minted");
     store
-        .stamp_session(&adhoc_id, "sess-adhoc", Some("prompt-adhoc"), Some("claude"))
+        .stamp_session(
+            &adhoc_id,
+            "sess-adhoc",
+            Some("prompt-adhoc"),
+            Some("claude"),
+        )
         .expect("stamp adhoc session");
 
     let state = store.load_run_state("run-1").expect("load").expect("run");
@@ -1133,6 +1142,7 @@ fn fence_spares_the_gate_and_fences_orphan_adhocs() {
     let redo = WorkflowEvent::Command(WorkflowCommand::FailAndRedo {
         node_row_id: adhoc_id.clone(),
         prompt: None,
+        model: None,
     });
     let applied = decide_and_apply(&store, "run-1", &applied.state, &redo);
     assert_healthy(&applied.state);
@@ -1473,8 +1483,7 @@ fn projection_serializes_camel_case_from_rows() {
     assert_eq!(json["run"]["status"], "running");
     // The definition rides the wire as the verbatim frozen string.
     let definition_json = json["run"]["definitionJson"].as_str().expect("raw string");
-    let definition: serde_json::Value =
-        serde_json::from_str(definition_json).expect("parseable");
+    let definition: serde_json::Value = serde_json::from_str(definition_json).expect("parseable");
     assert_eq!(definition["schemaVersion"], 2);
     let arguments: serde_json::Value =
         serde_json::from_str(json["run"]["argumentsJson"].as_str().expect("raw string"))
@@ -1571,9 +1580,8 @@ fn fail_node_transition_event_carries_named_target_and_failure_code() {
         queue_empty: true,
     });
 
-    let (applied, logged) = capture_tracing_output(|| {
-        decide_and_apply(&store, "run-obs", &created.state, &errored)
-    });
+    let (applied, logged) =
+        capture_tracing_output(|| decide_and_apply(&store, "run-obs", &created.state, &errored));
     assert_eq!(applied.state.run.status, WorkflowRunStatus::Failed);
 
     let transition_line = logged
@@ -1673,5 +1681,8 @@ fn node_launched_carries_session_id_for_the_session_plane_join() {
         .lines()
         .find(|line| line.contains("anyharness.workflow_node_launched"))
         .expect("named node_launched event captured");
-    assert!(launched_line.contains("session_id=sess-x"), "{launched_line}");
+    assert!(
+        launched_line.contains("session_id=sess-x"),
+        "{launched_line}"
+    );
 }

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/transition.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/transition.rs
@@ -89,6 +89,11 @@ pub enum WorkflowCommand {
     FailAndRedo {
         node_row_id: String,
         prompt: Option<String>,
+        /// A per-row model override for the replacement. `None` keeps the
+        /// row's inherited resolution (the frozen definition for a chain
+        /// row, the launch pick for an adhoc row); `Some` outranks it for
+        /// this replacement only and never rewrites the sealed snapshot.
+        model: Option<super::definition::NodeModel>,
     },
     FlipType {
         node_row_id: String,
@@ -504,6 +509,7 @@ fn on_command(state: &RunState, command: &WorkflowCommand) -> Decision {
         WorkflowCommand::FailAndRedo {
             node_row_id,
             prompt,
+            model,
         } => {
             let Some(node) = state.node(node_row_id) else {
                 return illegal(state, command.as_str(), None, "unknown node row");
@@ -572,9 +578,16 @@ fn on_command(state: &RunState, command: &WorkflowCommand) -> Decision {
                     } else {
                         node.rendered_envelope.clone()
                     },
-                    // An adhoc redo keeps its launch pick; a chain replacement
-                    // resolves through the frozen definition it inherits.
-                    model: if adhoc { node.model.clone() } else { None },
+                    // An explicit override outranks the inherited resolution
+                    // for this replacement only — the frozen definition is
+                    // never rewritten. Without one, an adhoc redo keeps its
+                    // launch pick and a chain replacement resolves through the
+                    // frozen definition it inherits.
+                    model: match model {
+                        Some(model) => Some(model.clone()),
+                        None if adhoc => node.model.clone(),
+                        None => None,
+                    },
                 },
                 // Ruling L: redo of a mid-flight node disposes the session it
                 // is taking over from; pause states hold no live turn to kill.

--- a/anyharness/crates/anyharness-lib/src/domains/workflows/transition_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/workflows/transition_tests.rs
@@ -453,6 +453,7 @@ fn fail_and_redo_from_failed_creates_replacement() {
         &WorkflowEvent::Command(WorkflowCommand::FailAndRedo {
             node_row_id: "n2".into(),
             prompt: None,
+            model: None,
         }),
     ));
     let Transition::Redo {
@@ -486,6 +487,7 @@ fn fail_and_redo_with_edited_prompt_drops_stored_envelope() {
         &WorkflowEvent::Command(WorkflowCommand::FailAndRedo {
             node_row_id: "n2".into(),
             prompt: Some("try again differently".into()),
+            model: None,
         }),
     ));
     let Transition::Redo { replacement, .. } = transition else {
@@ -493,6 +495,58 @@ fn fail_and_redo_with_edited_prompt_drops_stored_envelope() {
     };
     assert_eq!(replacement.prompt, "try again differently");
     assert!(replacement.rendered_envelope.is_none());
+}
+
+/// #1896: a chain replacement takes an explicit model override, so a node that
+/// died on an unservable model can be redone onto a servable one. Without the
+/// override a chain row still resolves through the frozen definition, which is
+/// never rewritten — the sealed snapshot keeps showing what was authored.
+#[test]
+fn fail_and_redo_model_override_lands_on_the_chain_replacement() {
+    let state = failed_run();
+    let override_model = super::definition::NodeModel {
+        agent_kind: "claude".into(),
+        model_id: Some("claude-sonnet-5".into()),
+        control_values: Default::default(),
+    };
+    let transition = expect_transition(next(
+        &state,
+        &WorkflowEvent::Command(WorkflowCommand::FailAndRedo {
+            node_row_id: "n2".into(),
+            prompt: None,
+            model: Some(override_model.clone()),
+        }),
+    ));
+    let Transition::Redo { replacement, .. } = transition else {
+        panic!("expected Redo");
+    };
+    assert_eq!(replacement.model.as_ref(), Some(&override_model));
+    // The envelope is prompt text only, so a model swap does not invalidate it.
+    assert_eq!(replacement.prompt, state.nodes[1].prompt);
+}
+
+/// The inherited resolution is unchanged when no override is supplied: a chain
+/// row defers to the frozen definition (None), never to a stale row pick.
+#[test]
+fn fail_and_redo_without_override_leaves_the_chain_replacement_inheriting() {
+    let mut state = failed_run();
+    state.nodes[1].model = Some(super::definition::NodeModel {
+        agent_kind: "claude".into(),
+        model_id: Some("stale-row-pick".into()),
+        control_values: Default::default(),
+    });
+    let transition = expect_transition(next(
+        &state,
+        &WorkflowEvent::Command(WorkflowCommand::FailAndRedo {
+            node_row_id: "n2".into(),
+            prompt: None,
+            model: None,
+        }),
+    ));
+    let Transition::Redo { replacement, .. } = transition else {
+        panic!("expected Redo");
+    };
+    assert!(replacement.model.is_none());
 }
 
 #[test]
@@ -517,6 +571,7 @@ fn fail_and_redo_applies_at_every_pause_state() {
                     &WorkflowEvent::Command(WorkflowCommand::FailAndRedo {
                         node_row_id: "n2".into(),
                         prompt: None,
+                        model: None,
                     })
                 ),
                 Decision::Transition(Transition::Redo { .. })
@@ -537,6 +592,7 @@ fn fail_and_redo_on_running_chain_node_disposes_the_live_session() {
         &WorkflowEvent::Command(WorkflowCommand::FailAndRedo {
             node_row_id: "n2".into(),
             prompt: None,
+            model: None,
         }),
     ));
     let Transition::Redo {
@@ -563,6 +619,7 @@ fn fail_and_redo_on_running_adhoc_is_illegal() {
             &WorkflowEvent::Command(WorkflowCommand::FailAndRedo {
                 node_row_id: "a1".into(),
                 prompt: None,
+                model: None,
             })
         ),
         Decision::Illegal(_)
@@ -589,6 +646,7 @@ fn fail_and_redo_on_superseded_node_is_illegal() {
             &WorkflowEvent::Command(WorkflowCommand::FailAndRedo {
                 node_row_id: "n2".into(),
                 prompt: None,
+                model: None,
             })
         ),
         Decision::Illegal(_)
@@ -980,6 +1038,7 @@ fn fail_and_redo_on_paused_adhoc_mints_an_adhoc_replacement() {
             &WorkflowEvent::Command(WorkflowCommand::FailAndRedo {
                 node_row_id: "a1".into(),
                 prompt: None,
+                model: None,
             }),
         ));
         let Transition::Redo {
@@ -995,7 +1054,10 @@ fn fail_and_redo_on_paused_adhoc_mints_an_adhoc_replacement() {
         assert_eq!(replacement.anchor_node_row_id.as_deref(), Some("n2"));
         assert_eq!(replacement.replaces_node_row_id.as_deref(), Some("a1"));
         assert_eq!(
-            replacement.model.as_ref().and_then(|model| model.model_id.as_deref()),
+            replacement
+                .model
+                .as_ref()
+                .and_then(|model| model.model_id.as_deref()),
             Some("adhoc-pick")
         );
         assert_eq!(disposed_session_id, None);
@@ -1013,6 +1075,7 @@ fn fail_and_redo_on_awaiting_human_adhoc_is_illegal() {
             &WorkflowEvent::Command(WorkflowCommand::FailAndRedo {
                 node_row_id: "a1".into(),
                 prompt: None,
+                model: None,
             })
         ),
         Decision::Illegal(_)

--- a/anyharness/crates/anyharness-lib/src/live/workflows/lifecycle_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/live/workflows/lifecycle_tests.rs
@@ -13,6 +13,7 @@ use crate::domains::sessions::runtime::prompt_message_actor_tests::{
     build_state, install_scripted_agent_env, prompt_texts, read_requests, temp_runtime_home,
     write_scripted_agent, EnvVarGuard, ScriptedAgent,
 };
+use crate::domains::sessions::runtime::SendPromptOutcome;
 use crate::domains::workflows::definition::{
     DefinitionEdge, DefinitionInput, DefinitionNode, DocTemplate, InvocationPlacement,
     InvocationSnapshot, PlacementMode, WorkflowDefinition, DEFINITION_SCHEMA_VERSION,
@@ -23,7 +24,6 @@ use crate::domains::workflows::model::{
     WorkflowInterruptionCode, WorkflowNodeFailureCode, WorkflowNodeKind, WorkflowNodeStatus,
     WorkflowNodeType, WorkflowRunStatus,
 };
-use crate::domains::sessions::runtime::SendPromptOutcome;
 use crate::domains::workflows::store::{CreatedRun, NewRunParams, WorkflowStore};
 use crate::domains::workflows::transition::{
     RunState, TurnFinished, TurnStopReason, WorkflowCommand,
@@ -145,8 +145,7 @@ fn create_run_rows(
 ) -> CreatedRun {
     // Production stores the courier's delivered JSON byte-verbatim; the tests
     // build the definition in code, so its serialization stands in for it.
-    let definition_json =
-        serde_json::to_string(&snapshot.definition).expect("definition json");
+    let definition_json = serde_json::to_string(&snapshot.definition).expect("definition json");
     let created = store
         .create_run_with_first_node(NewRunParams {
             run_id: run_id.into(),
@@ -156,8 +155,13 @@ fn create_run_rows(
             definition_json,
         })
         .expect("create run rows");
-    materialize_context(workspace_root, run_id, &created.docs, &snapshot.definition.doc_templates)
-        .expect("materialize context");
+    materialize_context(
+        workspace_root,
+        run_id,
+        &created.docs,
+        &snapshot.definition.doc_templates,
+    )
+    .expect("materialize context");
     created
 }
 
@@ -246,7 +250,10 @@ impl WorkflowFixture {
     }
 }
 
-pub(super) fn node_by_def<'a>(state: &'a RunState, definition_node_id: &str) -> &'a crate::domains::workflows::model::WorkflowRunNodeRecord {
+pub(super) fn node_by_def<'a>(
+    state: &'a RunState,
+    definition_node_id: &str,
+) -> &'a crate::domains::workflows::model::WorkflowRunNodeRecord {
     state
         .nodes
         .iter()
@@ -274,7 +281,10 @@ fn prompt_block_texts(path: &std::path::Path) -> Vec<Vec<String>> {
 
 fn assert_quiesced(state: &RunState) {
     let violations = invariants::sweep(state);
-    assert!(violations.is_empty(), "invariant violations: {violations:?}");
+    assert!(
+        violations.is_empty(),
+        "invariant violations: {violations:?}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -514,6 +524,7 @@ async fn a_refusal_fails_the_run_and_fail_and_redo_replaces_the_node() {
             WorkflowCommand::FailAndRedo {
                 node_row_id: failed.id.clone(),
                 prompt: Some("Redo this cleanly".into()),
+                model: None,
             },
         )
         .await;
@@ -535,8 +546,7 @@ async fn a_refusal_fails_the_run_and_fail_and_redo_replaces_the_node() {
         node_by_def(&state, "solo").status,
         WorkflowNodeStatus::Failed
     );
-    assert!(prompt_texts(&fixture.script.request_log)
-        .contains(&"Redo this cleanly".to_string()));
+    assert!(prompt_texts(&fixture.script.request_log).contains(&"Redo this cleanly".to_string()));
     assert_quiesced(&state);
 }
 
@@ -638,13 +648,9 @@ async fn an_adhoc_node_runs_beside_the_chain_and_never_moves_it() {
     // The adhoc node completes its own row while the chain node still runs.
     let state = fixture
         .wait_for("run-adhoc", "adhoc row completed", |state| {
-            state
-                .nodes
-                .iter()
-                .any(|node| {
-                    node.kind == WorkflowNodeKind::Adhoc
-                        && node.status == WorkflowNodeStatus::Completed
-                })
+            state.nodes.iter().any(|node| {
+                node.kind == WorkflowNodeKind::Adhoc && node.status == WorkflowNodeStatus::Completed
+            })
         })
         .await;
     assert_eq!(state.run.status, WorkflowRunStatus::Running);
@@ -661,12 +667,14 @@ async fn an_adhoc_node_runs_beside_the_chain_and_never_moves_it() {
         adhoc.anchor_node_row_id.as_deref(),
         Some(created.first_node_row_id.as_str())
     );
-    assert!(prompt_texts(&fixture.script.request_log)
-        .contains(&"adhoc side question".to_string()));
+    assert!(prompt_texts(&fixture.script.request_log).contains(&"adhoc side question".to_string()));
     // The pick persisted on the row and reached the minted session (F3): a
     // model choice the API accepted must never silently launch the default.
     assert_eq!(
-        adhoc.model.as_ref().and_then(|model| model.model_id.as_deref()),
+        adhoc
+            .model
+            .as_ref()
+            .and_then(|model| model.model_id.as_deref()),
         Some("haiku")
     );
     // Creation records the validated pick on the immutable launch intent.
@@ -695,7 +703,10 @@ async fn the_boot_fence_heals_the_crash_window_and_resume_completes_the_run() {
             &WorkflowStore::new(db.clone()),
             workspace_root,
             "run-fence",
-            snapshot_for(chain(vec![agent_node("solo", "heal me")]), serde_json::Map::new()),
+            snapshot_for(
+                chain(vec![agent_node("solo", "heal me")]),
+                serde_json::Map::new(),
+            ),
         );
     });
 
@@ -718,9 +729,7 @@ async fn the_boot_fence_heals_the_crash_window_and_resume_completes_the_run() {
 
     // Resume is always a human choice; it mints the session that never got
     // born, in the same workspace.
-    fixture
-        .command("run-fence", WorkflowCommand::Resume)
-        .await;
+    fixture.command("run-fence", WorkflowCommand::Resume).await;
     let state = fixture
         .wait_for("run-fence", "resumed run completes", |state| {
             state.run.status == WorkflowRunStatus::Completed
@@ -966,8 +975,7 @@ async fn turn_reports_never_block_even_while_the_actor_is_busy() {
     fixture
         .wait_for("run-wedge", "adhoc probe completed", |state| {
             state.nodes.iter().any(|node| {
-                node.kind == WorkflowNodeKind::Adhoc
-                    && node.status == WorkflowNodeStatus::Completed
+                node.kind == WorkflowNodeKind::Adhoc && node.status == WorkflowNodeStatus::Completed
             })
         })
         .await;
@@ -1012,6 +1020,7 @@ async fn fail_and_redo_from_running_disposes_the_wedged_session_and_relaunches()
             WorkflowCommand::FailAndRedo {
                 node_row_id: old_id.clone(),
                 prompt: Some("redo from running".into()),
+                model: None,
             },
         )
         .await;
@@ -1029,10 +1038,7 @@ async fn fail_and_redo_from_running_disposes_the_wedged_session_and_relaunches()
     assert_eq!(old.status, WorkflowNodeStatus::Failed);
     // Taken over from a running (non-failed) state: superseded, not a
     // turn-sourced failure code.
-    assert_eq!(
-        old.failure_code,
-        Some(WorkflowNodeFailureCode::Superseded)
-    );
+    assert_eq!(old.failure_code, Some(WorkflowNodeFailureCode::Superseded));
     // Disposed, not destroyed: the session row survives, but it no longer
     // reports into any workflow.
     assert!(
@@ -1060,7 +1066,6 @@ async fn fail_and_redo_from_running_disposes_the_wedged_session_and_relaunches()
         .expect("replacement row");
     assert_eq!(replacement.kind, WorkflowNodeKind::Replacement);
     assert_eq!(replacement.status, WorkflowNodeStatus::Completed);
-    assert!(prompt_texts(&fixture.script.request_log)
-        .contains(&"redo from running".to_string()));
+    assert!(prompt_texts(&fixture.script.request_log).contains(&"redo from running".to_string()));
     assert_quiesced(&state);
 }


### PR DESCRIPTION
## Summary

One reviewable outcome — workflow node model handling — covering the two halves of #1898 that are still live. Kept together because they share the same failure (an unservable `nodes[].model.modelId`), the same area, and the same call path: one stops it early, the other makes it recoverable when it slips through.

- **Defect 1 of #1898 — fail-fast admission at `PUT /v1/workflow-runs/{id}`.** The PUT validated only structure (JSON-ness, run-id UUID, `snapshot.validate()`), so an unservable `modelId` returned 201 and failed minutes later at node launch, after upstream nodes had done their work. Every model-bearing node is now admitted against the target-observed launch options before any row is inserted; the PUT 400s with `WORKFLOW_SNAPSHOT_INVALID` naming the offending node.
- Admission is deliberately asymmetric: a model, control, or value the observation affirmatively lacks is fail-closed, while a merely unavailable or unreadable observation (a cold runtime that has not probed yet) is fail-open and deferred to the launch-time check, which stays the authority (`launch_options/validation.rs`). PUT samples the observation minutes before launch, so it cannot replace that check — and rejecting on an absent observation would fail workflow creation for a reason unrelated to the authored definition. It runs only on the create path, after the idempotent-replay return, so an existing run keeps its verbatim custody.
- **#1896 — fail-redo model override.** `FailAndRedo` accepted only a `prompt` override, so redoing a node that died on an unservable model relaunched the same model. It now carries an optional per-row `model` that lands on the replacement. No schema change and no new state: the `workflow_run_nodes.model` column, `NewNodeSpec.model`, and the store read/write path all already existed — the only substantive change is `transition.rs`, which hardcoded `None` for chain rows. `launch_model` already prefers the row over the frozen definition, so the launch path is untouched and the sealed snapshot is never rewritten.
- **Pending R3 ruling.** #1896 asks whether replacements take a per-node model picker or inherit a run-level default, and says not to implement either way without a ruling. This implements the picker, hence draft. The plumbing is the same either way; only the source of the value changes. Note this is the first case of a chain row overriding its frozen definition — that is why the override is row-level rather than a snapshot edit, and why it deserves an explicit ruling.

Two corrections to #1898 while here, both from reading current `main`: defect 3 ("a launch failure kills the run") is not a redesign — fail-and-redo already recovers terminal runs (`transition.rs:431-436`), and the only gap was the missing override above. And defect 2's `opus` alias is obsolete: #2070 deleted `catalog/universe.rs` and the `ModelUnsupported`/`ObservedUniverse` types it describes, and bare `opus` is a first-class catalog id (`catalogs/agents/catalog.json:125`). That half needs a re-run, not a patch.

## Testing

<!-- State the tier(s) exercised per specs/TESTING.md, or why none is feasible. -->

- **Tier 1 (pure logic).** Two new cases in `transition_tests.rs`: the override lands on a chain replacement, and absent an override a chain row still resolves through the frozen definition rather than a stale row pick (asserted against a deliberately-seeded stale `node.model`). The transition table is a pure function, so this is the matrix cell the change adds.
- **Tier 1 (logic against real state).** `cargo test -p anyharness-lib workflow` — 188 passed, 0 failed, covering the store and lifecycle redo paths and the existing `workflow_runs` route tests.
- **Gap, stated plainly.** The route fixtures carry no probed launch-options observation, so they exercise admission's **fail-open** path only. The **fail-closed** path — the defect-1 fix itself — has no automated test yet; a route test needs a seeded observation row. Verified manually instead. Happy to add that fixture-seeded case here if you want it gated before merge.
- **Manual, local-runtime world.** A node that died with `LaunchValueUnsupported { key: "modelId", value: "totally-not-a-model", state: Observed }` was redone with a servable model; the replacement row persisted `{"agentKind":"claude","modelId":"opus[1m]"}` and reached `completed`, while the definition snapshot still recorded the bad model. No Tier 2 or Tier 3 addition: no new seam, no new release-runner scenario.

## Observability

<!-- State the observability delta per specs/OBSERVABILITY.md, or "none". -->

- One new `INFO` on admission's fail-open branch (`workflow snapshot model admission deferred to launch`) with `node_id`, `agent_kind`, and the underlying `LaunchSelectionUnsupported`. That branch intentionally does not refuse, so without a line it is silent — and "why did a bad model still reach launch?" is the first question a cold-runtime PUT raises.
- Nothing else: no new metrics or spans, the redo override adds no signal, and the existing `workflow run accepted`, `workflow_node_launch_failed`, and `workflow_transition` events are unchanged. Refusals surface through the existing `WORKFLOW_SNAPSHOT_INVALID` ProblemDetails.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md) for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker API. No tracker, report, user, or support IDs or private source data appear in this PR.

## Verification

- `cargo test -p anyharness-lib workflow` → 188 passed, 0 failed.
- `cargo check -p anyharness-lib --all-targets` → clean (pre-existing warnings only).
- Manual: a PUT naming `totally-not-a-model` on a probed runtime is refused before any row exists; the same body with a servable model starts normally; and the redo flow above completes.
- Unrelated pre-existing failure, flagged rather than hidden: full-crate `cargo test -p anyharness-lib` is 2220 passed / 1 failed, the failure being `launch_probe::install_poke_tests::an_install_completed_poke_reprobes_a_basis_that_changed_mid_probe` — fails in isolation, in a file this PR does not touch.

Closes #1896. Addresses defect 1 of #1898, and defect 3's stated remedy — the redo-able state already existed (`transition.rs:431-436`), so this supplies the missing model override. Deliberately out of scope: run terminality itself (a `node_launch_failed` run still reaches `status="failed"`; `resume` still 409s), and both items from the escalation comment — `human_in_loop` gates dying on model resolution, and the type-flip API not revalidating or clearing model config. Those want their own ruling; the gate case looks like it belongs on the same non-fatal branch `Adhoc` nodes already take, but that's a separate call.
