### PR TITLE
ci(workflows): cache cargo builds and drop redundant check step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,8 +263,7 @@ jobs:
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cargo check
-        run: cargo check --workspace
+      - uses: Swatinem/rust-cache@v2
 
       - name: Cargo test
         run: cargo test --workspace


### PR DESCRIPTION
## Summary

- `cargo-check` ("Cargo check & test") is the only Rust job in `ci.yml` with no `rust-cache`, so it compiles all 750 external dependency crates from scratch on every run.
- Cold, the job takes 11m31s (run 32335721001): 2m59s "Cargo check" + 7m15s "Cargo test" + 33s "Cargo test internal diagnostics export".
- `cargo test --workspace` already compiles the same code as `cargo check --workspace`, so the check step is pure duplication of the test step's compilation.

## Changes

1. Add `- uses: Swatinem/rust-cache@v2` right after "Setup Rust stable", matching the unpinned `@v2` form already used in the `qualification` job.
2. Delete the "Cargo check" step. "Cargo test" and "Cargo test internal diagnostics export" (and its explanatory comment) are untouched.

## Expected impact

Expected warm time is ~4m (inference). `rust-cache` only saves on a *green* job, so the first green run after this merges will prime the cache; the second green run is what actually measures the warm time — that number should be confirmed there, not assumed from this PR's own first run.

## Test semantics

No test semantics change. `cargo test` subsumes `cargo check` diagnostics (compiling test code is a superset of compiling non-test code), so removing the standalone check step does not reduce coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
