### PR TITLE
ci(workflows): cache the pnpm store across jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,13 +220,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "22"
-
       - uses: pnpm/action-setup@v6
         with:
           version: 10.11.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: pnpm
 
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -281,13 +282,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "22"
-
       - uses: pnpm/action-setup@v6
         with:
           version: 10.11.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: pnpm
 
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -320,13 +322,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "22"
-
       - uses: pnpm/action-setup@v6
         with:
           version: 10.11.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: pnpm
 
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -347,13 +350,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "22"
-
       - uses: pnpm/action-setup@v6
         with:
           version: 10.11.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install
@@ -367,13 +371,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "22"
-
       - uses: pnpm/action-setup@v6
         with:
           version: 10.11.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install
@@ -398,13 +403,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "22"
-
       - uses: pnpm/action-setup@v6
         with:
           version: 10.11.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install
@@ -426,13 +432,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "22"
-
       - uses: pnpm/action-setup@v6
         with:
           version: 10.11.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install
@@ -485,13 +492,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "22"
-
       - uses: pnpm/action-setup@v6
         with:
           version: 10.11.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -559,12 +567,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "22"
       - uses: pnpm/action-setup@v6
         with:
           version: 10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: pnpm
       - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v7
         with:


### PR DESCRIPTION
## Summary
- Every job that runs `pnpm install` currently downloads the full pnpm store from scratch. Adds `actions/setup-node`'s built-in `cache: pnpm`, keyed on `pnpm-lock.yaml`, to all of them: `candidate-build-handoff`, `sdk-build`, `desktop-frontend`, `mobile-typecheck`, `web-frontend`, `login-budget`, `shared-frontend-packages`, `scroll-physics`, and `workflow-definition-lifecycle`.
- Where `pnpm/action-setup` ran after `actions/setup-node`, moved it before, since `cache: pnpm` needs pnpm on PATH when setup-node runs.
- Expected savings are modest per job (~30-60s), but it's on every lane including the 7.6m `shared-frontend-packages` pole.
- Install-time only, zero test-semantics change.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — workflow YAML parses
- [ ] CI green on this PR across all touched jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)