### PR TITLE
Enforce no-em-dash product copy rule (PRODUCT_SENSE.md) + fix 10 sites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,11 @@ jobs:
           python3 -m unittest scripts/test_check_toast_copy.py
           python3 scripts/check_toast_copy.py
 
+      - name: Check product copy style
+        run: |
+          python3 -m unittest scripts/test_check_copy_style.py
+          python3 scripts/check_copy_style.py
+
       - name: Check agent-auth secret logs
         run: |
           python3 -m unittest scripts/test_check_agent_auth_secret_logs.py

--- a/apps/packages/product-client/src/copy/settings/harness-pane.ts
+++ b/apps/packages/product-client/src/copy/settings/harness-pane.ts
@@ -75,7 +75,7 @@ export const HARNESS_PANE_COPY = {
   // staleness state.
   allModelsRefreshFailedBadge: "last refresh failed",
   allModelsSeedDescription:
-    "Showing shipped catalog models — not yet verified by a probe.",
+    "Showing shipped catalog models. Not yet verified by a probe.",
   // Diagnostics-only provenance (attestation + install identity) — never a gate.
   allModelsProvenance: (line: string) => `Observed by ${line}`,
   allModelsModes: (modes: readonly string[]) => `Modes: ${modes.join(", ")}`,

--- a/apps/packages/product-client/src/copy/workflows/workflow-builder-copy.ts
+++ b/apps/packages/product-client/src/copy/workflows/workflow-builder-copy.ts
@@ -121,7 +121,7 @@ export const WORKFLOW_BUILDER_COPY = {
   docProducingNodeLabel: "Written by",
   docProducingNodePlaceholder: "Select a step",
   docProducingNodeOption: (position: number, title: string) =>
-    title.trim().length > 0 ? `Step ${position} — ${title}` : `Step ${position}`,
+    title.trim().length > 0 ? `Step ${position}: ${title}` : `Step ${position}`,
   docProducingNodeUnavailableOption: (nodeId: string) => `Unavailable step (${nodeId})`,
   docBodyLabel: "Starting body",
   docBodyPlaceholder: "# Findings\n\n## Answers\n",

--- a/apps/packages/product-client/src/copy/workflows/workflow-main-copy.ts
+++ b/apps/packages/product-client/src/copy/workflows/workflow-main-copy.ts
@@ -49,7 +49,7 @@ export const WORKFLOW_MAIN_COPY = {
 
   legacyGroupTitle: "Legacy",
   legacyGroupDescription:
-    "Saved before workflows were rebuilt. These cannot be opened or run here — rebuild the ones you still want, then delete them.",
+    "Saved before workflows were rebuilt. These cannot be opened or run here. Rebuild the ones you still want, then delete them.",
   legacyBadgeLabel: "v1",
   legacyDeleteLabel: (title: string) => `Delete ${title}`,
 

--- a/apps/packages/product-client/src/copy/workflows/workflow-resume-copy.ts
+++ b/apps/packages/product-client/src/copy/workflows/workflow-resume-copy.ts
@@ -4,7 +4,7 @@ export const WORKFLOW_RESUME_COPY = {
   dismissLabel: "Dismiss",
   fallbackRunTitle: "Workflow run",
   moreRunsHint: (count: number) =>
-    `And ${count} more — resuming or dismissing a run reveals the next.`,
+    `And ${count} more. Resuming or dismissing a run reveals the next.`,
 
   /**
    * The resume request itself failed — a runtime mid-restart is the case that

--- a/apps/packages/product-client/src/copy/workspaces/archive-toast-copy.ts
+++ b/apps/packages/product-client/src/copy/workspaces/archive-toast-copy.ts
@@ -25,28 +25,28 @@ export const ARCHIVE_TOAST_COPY = {
   archiveFailedDescription:
     "Couldn't save the snapshot. Your files are untouched, but running sessions were stopped. Try again.",
   unbornHeadDescription:
-    "Make a first commit before archiving — there's no commit to anchor the snapshot to.",
+    "Make a first commit before archiving. There's no commit to anchor the snapshot to.",
   busyDescription: "Another operation is still running. Try again in a moment.",
   unarchiveFailedDescription:
-    "Something went wrong while restoring. Your archived snapshot is intact — try again.",
+    "Something went wrong while restoring. Your archived snapshot is intact, so try again.",
   hollowCheckoutDescription:
     "This workspace's folder isn't its own git checkout, so a snapshot would capture the wrong repository.",
   gitLockedDescription: (file: string) =>
     `A git lock file is blocking the snapshot (${file}). If no git command is running, remove it and try again.`,
   headMismatchDescription:
-    "The restored workspace doesn't match the archived snapshot. Your snapshot is fully preserved — unarchive again to resolve.",
+    "The restored workspace doesn't match the archived snapshot. Your snapshot is fully preserved, so unarchive again to resolve.",
 
   dirtySubmoduleDescription:
-    "Some submodules were left untouched — they weren't captured in the snapshot.",
+    "Some submodules were left untouched. They weren't captured in the snapshot.",
   embeddedRepoDescription:
-    "An embedded repository was left untouched — it wasn't captured in the snapshot.",
+    "An embedded repository was left untouched. It wasn't captured in the snapshot.",
   partialCaptureUntrackedDescription:
     "Some untracked files couldn't be captured and were left out of the snapshot.",
   partialCaptureTrackedDescription:
     "Some tracked changes couldn't be captured and were left out of the snapshot.",
   abortedGitOperationDescription:
     "An in-progress git operation was aborted so the snapshot could be taken safely.",
-  noSnapshotDescription: "No prior snapshot was found — the workspace was restored as-is.",
+  noSnapshotDescription: "No prior snapshot was found. The workspace was restored as-is.",
   historyIncompleteDescription:
     "Some history couldn't be restored. The workspace is usable, but a few commits may be missing.",
 } as const;

--- a/lints/product/copy-style.toml
+++ b/lints/product/copy-style.toml
@@ -1,0 +1,40 @@
+# Product copy-style (PROD-COPY-STYLE). Enforced by scripts/check_copy_style.py.
+#
+# PRODUCT_SENSE.md line 11 states the standard: "No em-dashes in ANY product
+# text. No AI tells." The em dash is the classic AI tell, and in a product whose
+# copy is largely model-drafted it is the one that slips through most often. The
+# rule's neighbours in that doc (the type ramp, design attribution, toast copy)
+# are each mechanically enforced; this one was not, so it had drifted into ten
+# shipped strings by the time this guard was written.
+#
+# The census was empty once the introducing sweep fixed those ten sites, so this
+# is an absolute ban with no ledger and no ratchet.
+#
+# In-code scope kept in the checker (structural, not grandfathering): SCANNED_ROOTS
+# (the product copy trees), EXTENSIONS, SKIPPED_DIR_NAMES, and the string-literal
+# scanner that skips comments so an em dash in a comment is never flagged.
+
+[[rule]]
+id = "PROD-COPY-STYLE-001"
+title = "no em-dash in user-facing product copy"
+owner = "product"
+status = "law"
+enforced_by = "scripts/check_copy_style.py"
+mode = "lint"
+scope = "apps/packages/product-client/src/copy/** (.ts/.tsx)"
+
+rule = """A string literal in the product copy trees must not contain an em dash
+(U+2014). Only string literals are scanned; an em dash in a code comment or in
+prose about a rule is untouched, because a comment is not product text."""
+
+alternative = """Split the sentence at the em dash, or use the punctuation the
+clause wants: a period between two full clauses, a colon before a list or an
+explanation, a comma for an aside."""
+
+why = """The em dash is the AI tell PRODUCT_SENSE.md line 11 bans from product
+text. Every neighbouring rule in that doc is enforced by a checker; leaving this
+one as prose is why it drifted into ten shipped strings. Enforcing it keeps the
+product's voice out of the uncanny valley its own taste doc names."""
+
+example_bad = "\"Showing shipped catalog models — not yet verified by a probe.\""
+example_good = "\"Showing shipped catalog models. Not yet verified by a probe.\""

--- a/lints/product/copy-style.toml
+++ b/lints/product/copy-style.toml
@@ -36,5 +36,6 @@ text. Every neighbouring rule in that doc is enforced by a checker; leaving this
 one as prose is why it drifted into ten shipped strings. Enforcing it keeps the
 product's voice out of the uncanny valley its own taste doc names."""
 
-example_bad = "\"Showing shipped catalog models — not yet verified by a probe.\""
-example_good = "\"Showing shipped catalog models. Not yet verified by a probe.\""
+[rule.example]
+bad = "\"Showing shipped catalog models — not yet verified by a probe.\""
+good = "\"Showing shipped catalog models. Not yet verified by a probe.\""

--- a/scripts/check_copy_style.py
+++ b/scripts/check_copy_style.py
@@ -9,11 +9,14 @@ rule's neighbours in that doc (the type ramp, design attribution, toast copy)
 are each mechanically enforced; this one was not, so it had drifted into ten
 shipped strings by the time this guard was written.
 
-This engine scans only *string literals* under the product copy trees. An em
-dash inside a `//` or `/* */` comment, or in prose describing a rule, is left
-alone: a comment is not product text. The rule itself is the record under
-`lints/product/copy-style.toml`; diagnostics are rendered from it via
-`scripts/lint_records.py`, the same shared loader the sibling checks use.
+This engine flags an em dash that lands in a *string or template literal* under
+the product copy trees, and ignores one inside a `//` or `/* */` comment: a
+comment is not product text. It is a small state machine rather than a regex so
+it stays correct through the cases a regex gets wrong — a `//` sequence inside a
+string is not a comment, and a nested template literal inside a `${...}`
+interpolation does not end the outer template early. The rule itself is the
+record under `lints/product/copy-style.toml`; diagnostics are rendered from it
+via `scripts/lint_records.py`, the shared loader the sibling checks use.
 """
 
 from __future__ import annotations
@@ -41,58 +44,106 @@ SCANNED_ROOTS = ["apps/packages/product-client/src/copy"]
 EXTENSIONS = {".ts", ".tsx"}
 SKIPPED_DIR_NAMES = {"node_modules", "dist", "build", ".next", "generated", "__fixtures__"}
 
+# Lexer states. A stack models nesting: a template literal can hold a `${...}`
+# expression (EXPR), and that expression can open another string or template.
+CODE, EXPR, SQ, DQ, TMPL, LINE_COMMENT, BLOCK_COMMENT = range(7)
+COPY_STATES = frozenset({SQ, DQ, TMPL})  # em dash here is product text
 
-def string_literal_spans(text: str):
-    """Yield (start, end) of every string-literal body, skipping comments.
 
-    A hand-rolled scanner rather than a regex: it has to track escapes and skip
-    `//` and `/* */` comments so an em dash in a comment is never seen. Template
-    literals are included (they hold copy too); `${...}` insides are copy-bearing
-    and left in the span, which is fine — we only look for the em-dash char.
+def em_dash_lines(text: str) -> list[int]:
+    """Return the 1-based line of every em dash that lands in a string literal.
+
+    Em dashes inside comments are ignored. The scanner tracks `${...}` depth so
+    a nested template does not end its parent early.
     """
+    stack = [CODE]
+    brace_depth = [0]  # parallel to EXPR frames; index by position in stack
+    hits: list[int] = []
+    line = 1
     i, n = 0, len(text)
     while i < n:
         c = text[i]
-        if c == "\\":
-            i += 2
-            continue
-        if c == "/" and i + 1 < n:
-            if text[i + 1] == "/":
-                j = text.find("\n", i)
-                i = n if j < 0 else j
+        nxt = text[i + 1] if i + 1 < n else ""
+        top = stack[-1]
+
+        if top in (CODE, EXPR):
+            if c == "/" and nxt == "/":
+                stack.append(LINE_COMMENT)
+                i += 2
                 continue
-            if text[i + 1] == "*":
-                j = text.find("*/", i + 2)
-                i = n if j < 0 else j + 2
+            if c == "/" and nxt == "*":
+                stack.append(BLOCK_COMMENT)
+                i += 2
                 continue
-        if c in "\"'`":
-            quote = c
-            start = i + 1
-            k = start
-            while k < n:
-                if text[k] == "\\":
-                    k += 2
-                    continue
-                if text[k] == quote:
-                    break
-                if quote != "`" and text[k] == "\n":
-                    break
-                k += 1
-            yield start, min(k, n)
-            i = k + 1
-            continue
+            if c == "'":
+                stack.append(SQ)
+            elif c == '"':
+                stack.append(DQ)
+            elif c == "`":
+                stack.append(TMPL)
+            elif top == EXPR and c == "{":
+                brace_depth[-1] += 1
+            elif top == EXPR and c == "}":
+                if brace_depth[-1] == 0:
+                    stack.pop()
+                    brace_depth.pop()
+                else:
+                    brace_depth[-1] -= 1
+            elif c == "\n":
+                line += 1
+        elif top == LINE_COMMENT:
+            if c == "\n":
+                stack.pop()
+                line += 1
+        elif top == BLOCK_COMMENT:
+            if c == "*" and nxt == "/":
+                stack.pop()
+                i += 2
+                continue
+            if c == "\n":
+                line += 1
+        elif top in (SQ, DQ):
+            if c == "\\":
+                i += 2
+                continue
+            if (top == SQ and c == "'") or (top == DQ and c == '"'):
+                stack.pop()
+            elif c == "\n":
+                stack.pop()  # unterminated single-line string; recover
+                line += 1
+            elif c == EM_DASH:
+                hits.append(line)
+        elif top == TMPL:
+            if c == "\\":
+                i += 2
+                continue
+            if c == "`":
+                stack.pop()
+            elif c == "$" and nxt == "{":
+                stack.append(EXPR)
+                brace_depth.append(0)
+                i += 2
+                continue
+            elif c == "\n":
+                line += 1
+            elif c == EM_DASH:
+                hits.append(line)
         i += 1
+    return hits
 
 
 @dataclass(frozen=True)
 class Finding:
     path: Path
     lineno: int
-    snippet: str
 
     @property
     def relative_path(self) -> str:
         return str(self.path.relative_to(REPO_ROOT))
+
+
+def scan_text(path: Path, text: str) -> list[Finding]:
+    return [Finding(path, ln) for ln in em_dash_lines(text)]
 
 
 def iter_files():
@@ -105,34 +156,23 @@ def iter_files():
                 continue
             if any(part in SKIPPED_DIR_NAMES for part in path.parts):
                 continue
-            if path.name.endswith(".test.ts") or path.name.endswith(".test.tsx"):
+            if path.name.endswith((".test.ts", ".test.tsx")):
                 continue
             yield path
-
-
-def scan_text(path: Path, text: str) -> list[Finding]:
-    findings: list[Finding] = []
-    for start, end in string_literal_spans(text):
-        body = text[start:end]
-        if EM_DASH in body:
-            lineno = text.count("\n", 0, start) + 1
-            findings.append(Finding(path, lineno, body.strip()[:100]))
-    return findings
 
 
 def main() -> int:
     if RULE_ID not in OWNED_RULE_IDS:
         print(f"{CHECKER}: rule record {RULE_ID} missing from lints/product", file=sys.stderr)
         return 2
+    rule = RULES.rules[RULE_ID]
     findings: list[Finding] = []
     for path in iter_files():
         findings.extend(scan_text(path, path.read_text(encoding="utf-8")))
     if not findings:
         return 0
-    rule = RULES.rules[RULE_ID]
     for f in findings:
-        location = f"{f.relative_path}:{f.lineno}"
-        print(lint_records.render_diagnostic(rule, location, f.snippet))
+        print(lint_records.render_diagnostic(rule, f"{f.relative_path}:{f.lineno}"))
     print(f"\n{len(findings)} em-dash violation(s) in product copy.", file=sys.stderr)
     return 1
 

--- a/scripts/check_copy_style.py
+++ b/scripts/check_copy_style.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+"""Keep the em-dash out of user-facing product copy.
+
+PRODUCT_SENSE.md line 11 states the standard: "No em-dashes in ANY product
+text. No AI tells." The em dash is the classic AI tell, and in a product whose
+copy is largely model-drafted it is the one that slips through most often. The
+rule's neighbours in that doc (the type ramp, design attribution, toast copy)
+are each mechanically enforced; this one was not, so it had drifted into ten
+shipped strings by the time this guard was written.
+
+This engine scans only *string literals* under the product copy trees. An em
+dash inside a `//` or `/* */` comment, or in prose describing a rule, is left
+alone: a comment is not product text. The rule itself is the record under
+`lints/product/copy-style.toml`; diagnostics are rendered from it via
+`scripts/lint_records.py`, the same shared loader the sibling checks use.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import lint_records  # noqa: E402
+
+CHECKER = "scripts/check_copy_style.py"
+RULES = lint_records.load("product")
+OWNED_RULE_IDS = frozenset(
+    rule.id for rule in RULES.rules.values() if rule.enforced_by == CHECKER
+)
+
+EM_DASH = "—"
+RULE_ID = "PROD-COPY-STYLE-001"
+
+SCANNED_ROOTS = ["apps/packages/product-client/src/copy"]
+EXTENSIONS = {".ts", ".tsx"}
+SKIPPED_DIR_NAMES = {"node_modules", "dist", "build", ".next", "generated", "__fixtures__"}
+
+
+def string_literal_spans(text: str):
+    """Yield (start, end) of every string-literal body, skipping comments.
+
+    A hand-rolled scanner rather than a regex: it has to track escapes and skip
+    `//` and `/* */` comments so an em dash in a comment is never seen. Template
+    literals are included (they hold copy too); `${...}` insides are copy-bearing
+    and left in the span, which is fine — we only look for the em-dash char.
+    """
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == "/" and i + 1 < n:
+            if text[i + 1] == "/":
+                j = text.find("\n", i)
+                i = n if j < 0 else j
+                continue
+            if text[i + 1] == "*":
+                j = text.find("*/", i + 2)
+                i = n if j < 0 else j + 2
+                continue
+        if c in "\"'`":
+            quote = c
+            start = i + 1
+            k = start
+            while k < n:
+                if text[k] == "\\":
+                    k += 2
+                    continue
+                if text[k] == quote:
+                    break
+                if quote != "`" and text[k] == "\n":
+                    break
+                k += 1
+            yield start, min(k, n)
+            i = k + 1
+            continue
+        i += 1
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: Path
+    lineno: int
+    snippet: str
+
+    @property
+    def relative_path(self) -> str:
+        return str(self.path.relative_to(REPO_ROOT))
+
+
+def iter_files():
+    for root in SCANNED_ROOTS:
+        base = REPO_ROOT / root
+        if not base.exists():
+            continue
+        for path in base.rglob("*"):
+            if path.suffix not in EXTENSIONS:
+                continue
+            if any(part in SKIPPED_DIR_NAMES for part in path.parts):
+                continue
+            if path.name.endswith(".test.ts") or path.name.endswith(".test.tsx"):
+                continue
+            yield path
+
+
+def scan_text(path: Path, text: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for start, end in string_literal_spans(text):
+        body = text[start:end]
+        if EM_DASH in body:
+            lineno = text.count("\n", 0, start) + 1
+            findings.append(Finding(path, lineno, body.strip()[:100]))
+    return findings
+
+
+def main() -> int:
+    if RULE_ID not in OWNED_RULE_IDS:
+        print(f"{CHECKER}: rule record {RULE_ID} missing from lints/product", file=sys.stderr)
+        return 2
+    findings: list[Finding] = []
+    for path in iter_files():
+        findings.extend(scan_text(path, path.read_text(encoding="utf-8")))
+    if not findings:
+        return 0
+    rule = RULES.rules[RULE_ID]
+    for f in findings:
+        location = f"{f.relative_path}:{f.lineno}"
+        print(lint_records.render_diagnostic(rule, location, f.snippet))
+    print(f"\n{len(findings)} em-dash violation(s) in product copy.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_copy_style.py
+++ b/scripts/test_check_copy_style.py
@@ -7,56 +7,63 @@ import unittest
 from scripts import check_copy_style as mod
 
 
-class StringLiteralSpans(unittest.TestCase):
-    def _bodies(self, text: str) -> list[str]:
-        return [text[s:e] for s, e in mod.string_literal_spans(text)]
+class EmDashLines(unittest.TestCase):
+    def hits(self, text: str) -> list[int]:
+        return mod.em_dash_lines(text)
 
-    def test_double_and_single_and_template(self):
-        self.assertEqual(self._bodies('a = "x"; b = \'y\'; c = `z`;'), ["x", "y", "z"])
+    def test_flags_em_dash_in_double_quoted_string(self):
+        self.assertEqual(self.hits('const s = "a — b";'), [1])
 
-    def test_line_comment_is_skipped(self):
-        self.assertEqual(self._bodies('const a = 1; // not a — string\n'), [])
-
-    def test_block_comment_is_skipped(self):
-        self.assertEqual(self._bodies('/* a — b */ const s = "ok";'), ["ok"])
-
-    def test_escaped_quote_does_not_end_literal(self):
-        self.assertEqual(self._bodies(r'"a\"b"'), [r'a\"b'])
-
-    def test_apostrophe_inside_double_quotes(self):
-        self.assertEqual(self._bodies('"there\'s one"'), ["there's one"])
-
-
-class ScanText(unittest.TestCase):
-    def _hits(self, text: str) -> int:
-        return len(mod.scan_text(mod.REPO_ROOT / "x.ts", text))
-
-    def test_flags_em_dash_in_string(self):
-        self.assertEqual(self._hits('const s = "a — b";'), 1)
-
-    def test_ignores_em_dash_in_line_comment(self):
-        self.assertEqual(self._hits('// a — b\nconst s = "ok";'), 0)
-
-    def test_ignores_em_dash_in_block_comment(self):
-        self.assertEqual(self._hits('/* a — b */\nconst s = "ok";'), 0)
+    def test_flags_em_dash_in_single_quoted_string(self):
+        self.assertEqual(self.hits("const s = 'a — b';"), [1])
 
     def test_flags_em_dash_in_template_literal(self):
-        self.assertEqual(self._hits('const s = `Step ${n} — ${t}`;'), 1)
+        self.assertEqual(self.hits("const s = `Step ${n} — ${t}`;"), [1])
 
-    def test_hyphen_and_en_dash_are_allowed(self):
-        self.assertEqual(self._hits('const s = "a-b"; const t = "1–2";'), 0)
+    def test_ignores_em_dash_in_line_comment(self):
+        self.assertEqual(self.hits("// a — b\nconst s = \"ok\";"), [])
 
-    def test_clean_string_passes(self):
-        self.assertEqual(self._hits('const s = "a. b: c, d";'), 0)
+    def test_ignores_em_dash_in_block_comment(self):
+        self.assertEqual(self.hits("/* a — b\n c — d */\nconst s = \"ok\";"), [])
 
-    def test_reports_line_number(self):
-        findings = mod.scan_text(mod.REPO_ROOT / "x.ts", '\n\nconst s = "a — b";')
-        self.assertEqual(findings[0].lineno, 3)
+    def test_slashes_inside_string_are_not_a_comment(self):
+        # the // is inside the string, so the em dash after it is still copy
+        self.assertEqual(self.hits('const s = "http:// — x";'), [1])
+
+    def test_nested_template_does_not_end_outer_early(self):
+        # em dash sits in the OUTER template, after a nested `${`...`}` template.
+        # The pre-fix scanner ended the outer template at the inner backtick and
+        # missed this. It must be caught.
+        self.assertEqual(self.hits("const s = `a ${`inner`} — b`;"), [1])
+
+    def test_em_dash_inside_nested_template_is_caught(self):
+        self.assertEqual(self.hits("const s = `a ${`in — ner`} b`;"), [1])
+
+    def test_hyphen_and_en_dash_allowed(self):
+        self.assertEqual(self.hits('const s = "a-b"; const t = "1–2";'), [])
+
+    def test_clean_copy_passes(self):
+        self.assertEqual(self.hits('const s = "a. b: c, d";'), [])
+
+    def test_reports_correct_line_number(self):
+        self.assertEqual(self.hits('\n\nconst s = "a — b";'), [3])
+
+    def test_multiple_hits_across_lines(self):
+        self.assertEqual(self.hits('const a = "x — y";\nconst b = "p — q";'), [1, 2])
+
+    def test_escaped_quote_does_not_end_string(self):
+        self.assertEqual(self.hits(r'const s = "a\" — b";'), [1])
 
 
 class RecordWiring(unittest.TestCase):
-    def test_rule_record_is_owned_by_this_checker(self):
+    def test_rule_record_owned_by_this_checker(self):
         self.assertIn(mod.RULE_ID, mod.OWNED_RULE_IDS)
+
+    def test_example_is_populated_from_record(self):
+        # Guards Greptile's finding: examples must load from [rule.example].
+        rule = mod.RULES.rules[mod.RULE_ID]
+        self.assertTrue(rule.example_good)
+        self.assertNotIn(mod.EM_DASH, rule.example_good)
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_copy_style.py
+++ b/scripts/test_check_copy_style.py
@@ -1,0 +1,63 @@
+"""Unit tests for scripts/check_copy_style.py."""
+
+from __future__ import annotations
+
+import unittest
+
+from scripts import check_copy_style as mod
+
+
+class StringLiteralSpans(unittest.TestCase):
+    def _bodies(self, text: str) -> list[str]:
+        return [text[s:e] for s, e in mod.string_literal_spans(text)]
+
+    def test_double_and_single_and_template(self):
+        self.assertEqual(self._bodies('a = "x"; b = \'y\'; c = `z`;'), ["x", "y", "z"])
+
+    def test_line_comment_is_skipped(self):
+        self.assertEqual(self._bodies('const a = 1; // not a — string\n'), [])
+
+    def test_block_comment_is_skipped(self):
+        self.assertEqual(self._bodies('/* a — b */ const s = "ok";'), ["ok"])
+
+    def test_escaped_quote_does_not_end_literal(self):
+        self.assertEqual(self._bodies(r'"a\"b"'), [r'a\"b'])
+
+    def test_apostrophe_inside_double_quotes(self):
+        self.assertEqual(self._bodies('"there\'s one"'), ["there's one"])
+
+
+class ScanText(unittest.TestCase):
+    def _hits(self, text: str) -> int:
+        return len(mod.scan_text(mod.REPO_ROOT / "x.ts", text))
+
+    def test_flags_em_dash_in_string(self):
+        self.assertEqual(self._hits('const s = "a — b";'), 1)
+
+    def test_ignores_em_dash_in_line_comment(self):
+        self.assertEqual(self._hits('// a — b\nconst s = "ok";'), 0)
+
+    def test_ignores_em_dash_in_block_comment(self):
+        self.assertEqual(self._hits('/* a — b */\nconst s = "ok";'), 0)
+
+    def test_flags_em_dash_in_template_literal(self):
+        self.assertEqual(self._hits('const s = `Step ${n} — ${t}`;'), 1)
+
+    def test_hyphen_and_en_dash_are_allowed(self):
+        self.assertEqual(self._hits('const s = "a-b"; const t = "1–2";'), 0)
+
+    def test_clean_string_passes(self):
+        self.assertEqual(self._hits('const s = "a. b: c, d";'), 0)
+
+    def test_reports_line_number(self):
+        findings = mod.scan_text(mod.REPO_ROOT / "x.ts", '\n\nconst s = "a — b";')
+        self.assertEqual(findings[0].lineno, 3)
+
+
+class RecordWiring(unittest.TestCase):
+    def test_rule_record_is_owned_by_this_checker(self):
+        self.assertIn(mod.RULE_ID, mod.OWNED_RULE_IDS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Enforce the one `PRODUCT_SENSE.md` copy rule that had no checker: **"No em-dashes in ANY product text"** (line 11). Its neighbours in that doc (type ramp, design attribution, toast copy) are each mechanically enforced; this one lived only as prose and had drifted into ten shipped strings.

This adds the missing guard and fixes the ten sites.

## Changes

- `scripts/check_copy_style.py` — scans **string literals** under `apps/packages/product-client/src/copy/**` for U+2014. It skips comments (a hand-rolled scanner, not a grep), so an em dash in a code comment or in prose about a rule is never flagged. Only user-facing copy is in scope.
- `lints/product/copy-style.toml` — the rule record (`PROD-COPY-STYLE-001`), rendered through the shared `lint_records` loader like the sibling checks.
- `scripts/test_check_copy_style.py` — 13 unit tests (literal vs comment, template literals, escapes, en-dash/hyphen allowed, line numbers).
- `.github/workflows/ci.yml` — runs the test + checker, right after the toast-copy step.
- Ten copy fixes: each em dash replaced with the punctuation the clause wanted (period between full clauses, colon before an explanation, comma for an aside). No wording lost.

## The ten sites

Six were in `archive-toast-copy.ts` (the archive/restore toasts); the rest in the workflow builder/main/resume copy and the harness settings pane. All are string values imported by rendering components (popovers, toasts, settings modals), verified by tracing each constant to its render site.

## Notes

- Census is empty after this sweep, so the rule is an absolute ban with no ledger and no ratchet.
- The checker only looks at string literals, so it will not fight engineers writing em dashes in comments or docs — only in copy users read.
- One label worth a maintainer's eye: I filed the rule under `owner = "product"`. If the copy trees are owned by a different segment in your taxonomy, say the word and I'll move it.