### PR TITLE
ci(cargo-cache): add sccache alongside rust-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,18 @@ jobs:
   cargo-check:
     name: Cargo check & test
     runs-on: ubuntu-latest
+    # EXPERIMENT (exp/rust-sccache, base ci/cargo-cache-and-dedupe): measure
+    # whether sccache eliminates the workspace-crate recompilation that
+    # Swatinem/rust-cache deliberately leaves on the table (it discards
+    # workspace-crate build artifacts by design, so unchanged crates still
+    # recompile on every PR). sccache keyed by rustc invocation inputs should
+    # hit for those crates even when the target dir cache does not carry them
+    # forward. CARGO_INCREMENTAL=0 is required: incremental compilation
+    # defeats sccache's ability to reuse cached object output.
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -262,6 +274,9 @@ jobs:
 
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
       - uses: Swatinem/rust-cache@v2
 

--- a/README.md
+++ b/README.md
@@ -209,3 +209,5 @@ Contributing? See the [Contribution Guide](./CONTRIBUTING.md).
 ## License
 
 [AGPL-3.0](./LICENSE)
+
+<!-- exp/rust-sccache: non-Rust no-op commit to measure sccache hit rate on run 2 -->


### PR DESCRIPTION
## Summary
- Experiment (never merge): measure whether `mozilla-actions/sccache-action` eliminates workspace-crate recompilation on non-Rust PRs, which `Swatinem/rust-cache` (base branch, #2113) deliberately does not cache.
- Adds sccache to the `cargo-check` job only: `RUSTC_WRAPPER=sccache`, `SCCACHE_GHA_ENABLED=true`, `CARGO_INCREMENTAL=0` (incremental defeats sccache), keeping `Swatinem/rust-cache` in place for the registry/deps cache.

## Test plan
- [ ] Run 1 (this commit): primes the sccache GHA cache from a cold/empty sccache state.
- [ ] Run 2: push a whitespace/comment-only commit touching a non-Rust file to simulate a docs/UI-only PR, and compare cargo-check wall time + sccache hit rate against the 7m24s warm `Swatinem/rust-cache`-only baseline from #2113.
- [ ] Record both run links and sccache stats output in the PR thread; do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)