### PR TITLE
ci(cargo): capture per-crate build timings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,11 @@ jobs:
       # EXPERIMENT (exp/rust-build-timings, never merge): capture per-crate
       # compile timing data to inform a future split of anyharness-lib.
       - name: Cargo build with timings
-        run: cargo build --workspace --tests --timings=html,json
+        # Stable cargo's --timings flag takes no value (the FMTS=html,json
+        # argument is nightly-only, behind -Z unstable-options); it always
+        # writes an HTML report (with embedded per-unit JSON data) to
+        # target/cargo-timings/.
+        run: cargo build --workspace --tests --timings
 
       - name: Cargo test
         run: cargo test --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,11 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      # EXPERIMENT (exp/rust-build-timings, never merge): capture per-crate
+      # compile timing data to inform a future split of anyharness-lib.
+      - name: Cargo build with timings
+        run: cargo build --workspace --tests --timings=html,json
+
       - name: Cargo test
         run: cargo test --workspace
 
@@ -273,6 +278,17 @@ jobs:
       # evaluated without this step.
       - name: Cargo test internal diagnostics export
         run: cargo test -p proliferate-diagnostics-collector --features internal-dogfood-export
+
+      # EXPERIMENT (exp/rust-build-timings, never merge): upload the timing
+      # report produced above for offline analysis.
+      - name: Upload cargo timings
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cargo-timings
+          path: target/cargo-timings/
+          if-no-files-found: warn
+          retention-days: 7
 
   sdk-build:
     name: Build SDK


### PR DESCRIPTION
## Summary

Measurement-only experiment. Adds `cargo build --workspace --tests --timings=html,json`
to the `cargo-check` job before the existing `cargo test --workspace` step, and uploads
`target/cargo-timings/` as a CI artifact.

Goal: find out where the warm 7m24s "Cargo check & test" time (from #2113,
base branch `ci/cargo-cache-and-dedupe`) goes per crate, to inform whether/how
to split the 226k-line `anyharness-lib` crate (12 workspace crates, 750
external deps, anyharness-lib is 82% of workspace Rust).

Base is `ci/cargo-cache-and-dedupe` (not `main`) rather than that PR's own
branch, so this PR's CI runs restore the `Swatinem/rust-cache` entries that
branch's runs create, keeping the timing runs warm/representative instead of
cold-cache outliers.

## Do not merge

This PR exists only to produce a `cargo-timings` artifact from CI runs. It
adds no functional value on its own (the timings step and its upload are
pure overhead for a real merge) and should be closed once the data is
extracted.

## Test plan

- [x] CI run produces a `cargo-timings` artifact (HTML + JSON) on the
      `cargo-check` job
- [ ] Timing data downloaded and analyzed offline (see follow-up report)