### PR TITLE
ci(workflows): experiment with cargo-nextest for cargo test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,14 +265,18 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
       - name: Cargo test
-        run: cargo test --workspace
+        run: cargo nextest run --workspace
 
       # The workspace run above builds this package with default features, so
       # the internal-only export path and its dogfood proof would never be
       # evaluated without this step.
       - name: Cargo test internal diagnostics export
-        run: cargo test -p proliferate-diagnostics-collector --features internal-dogfood-export
+        run: cargo nextest run -p proliferate-diagnostics-collector --features internal-dogfood-export
 
   sdk-build:
     name: Build SDK


### PR DESCRIPTION
## Summary

Experiment (not for merge): measure `cargo-nextest` vs plain `cargo test` for the CI cargo job. Branched from `ci/cargo-cache-and-dedupe` (#2113) so the warm `rust-cache` baseline (7m24s, https://github.com/proliferate-ai/proliferate/actions/runs/32405379745/job/96551626337) is the comparison point rather than a cold cache.

## Changes

- `.github/workflows/ci.yml` `cargo-check` job: install `cargo-nextest` via `taiki-e/install-action@v2`.
- `cargo test --workspace` -> `cargo nextest run --workspace`.
- `cargo test -p proliferate-diagnostics-collector --features internal-dogfood-export` -> `cargo nextest run -p proliferate-diagnostics-collector --features internal-dogfood-export`.

## Doctest coverage check

nextest does not run doctests. Checked whether this workspace has any to lose:

- On the base branch's warm run (job 96551626337), `cargo test --workspace` compiles Doc-tests binaries for 8 crates (`anyharness_contract`, `anyharness_credential_discovery`, `anyharness_lib`, `proliferate`, `proliferate_diagnostics_client`, `proliferate_diagnostics_collector`, `proliferate_diagnostics_protocol`, `proliferate_runtime_update_protocol`) and every one reports `test result: ok. 0 passed; ...` — zero actual doctests execute.
- `grep -rEn '^\s*(///|//!)\s*```' --include='*.rs' .` across the repo finds only 3 fenced blocks in doc comments, all ` ```text ` (non-executable), zero ` ```rust ` or bare fences.

Conclusion: this workspace has no doctests today, so switching to nextest loses zero test coverage. No `cargo test --workspace --doc` follow-up step added (would be a no-op).

## Baseline test count (for reconciliation)

From the same baseline job:
- `Cargo test` step: 3145 passed (8 ignored) across unit/integration binaries + 0 doctests.
- `Cargo test internal diagnostics export` step: 59 passed.
- Total: 3204 passed.

Will compare against nextest's summary count on this branch's runs.

## Never merge

This is a measurement PR only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)