### PR TITLE
ci(cargo): add mold linker to cargo-check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,9 @@ jobs:
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Setup mold linker
+        uses: rui314/setup-mold@v1
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,14 @@ jobs:
 
       # Experiment proof step (mold-linker measurement, never to be merged):
       # confirm mold actually performed the link for a real test binary,
-      # rather than just observing that the setup-mold step executed.
+      # rather than just observing that the setup-mold step executed. A
+      # first pass here picked an arbitrary (alphabetically-first) binary
+      # in target/debug/deps and it turned out to be apps/desktop/src-tauri
+      # ("proliferate"/proliferate_supervisor), which tauri-build links with
+      # LLD explicitly regardless of the system `ld` -- so check that one
+      # BY NAME to document the bypass, and separately check the
+      # anyharness-lib unittest binary (the 226k-line crate this experiment
+      # is actually about) to see whether mold linked it.
       - name: Verify mold linked the test binaries
         run: |
           echo "cc's default linker binary:"
@@ -295,17 +302,26 @@ jobs:
           echo "resolved /usr/bin/ld:"
           readlink -f /usr/bin/ld
           mold --version
-          echo "---"
-          bin=$(find target/debug/deps -maxdepth 1 -type f -executable ! -name "*.d" | head -n 1)
-          echo "Inspecting built test binary: $bin"
-          file "$bin"
-          echo "readelf -p .comment (MOLD_DEBUG embeds mold's invocation here):"
-          readelf -p .comment "$bin" || true
-          if readelf -p .comment "$bin" | grep -qi mold; then
-            echo "RESULT: mold confirmed as the linker for $bin"
-          else
-            echo "RESULT: mold string NOT found in .comment for $bin"
-          fi
+          echo "==="
+          check_comment() {
+            local label="$1" glob="$2"
+            local bin
+            bin=$(find target/debug/deps -maxdepth 1 -type f -executable -name "$glob" ! -name "*.d" | head -n 1)
+            if [ -z "$bin" ]; then
+              echo "$label: no binary matched $glob"
+              return
+            fi
+            echo "--- $label: $bin ---"
+            readelf -p .comment "$bin" || true
+            if readelf -p .comment "$bin" | grep -qi mold; then
+              echo "RESULT ($label): mold confirmed as the linker"
+            else
+              echo "RESULT ($label): mold string NOT found in .comment (some other linker was used)"
+            fi
+          }
+          check_comment "anyharness-lib (the crate this experiment targets)" "anyharness_lib-*"
+          check_comment "apps/desktop/src-tauri (tauri-build may force LLD)" "proliferate_supervisor-*"
+          check_comment "anyharness-contract" "anyharness_contract-*"
 
   sdk-build:
     name: Build SDK

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Cargo test
+        env:
+          # Embeds mold's own command-line invocation into the .comment
+          # section of every linked binary, so the verification step below
+          # can prove mold (not the stock ld) actually performed the link,
+          # beyond just observing that the setup-mold step ran.
+          MOLD_DEBUG: "1"
         run: cargo test --workspace
 
       # The workspace run above builds this package with default features, so
@@ -276,6 +282,30 @@ jobs:
       # evaluated without this step.
       - name: Cargo test internal diagnostics export
         run: cargo test -p proliferate-diagnostics-collector --features internal-dogfood-export
+
+      # Experiment proof step (mold-linker measurement, never to be merged):
+      # confirm mold actually performed the link for a real test binary,
+      # rather than just observing that the setup-mold step executed.
+      - name: Verify mold linked the test binaries
+        run: |
+          echo "cc's default linker binary:"
+          cc -print-prog-name=ld
+          readlink -f "$(cc -print-prog-name=ld)" || true
+          echo "---"
+          echo "resolved /usr/bin/ld:"
+          readlink -f /usr/bin/ld
+          mold --version
+          echo "---"
+          bin=$(find target/debug/deps -maxdepth 1 -type f -executable ! -name "*.d" | head -n 1)
+          echo "Inspecting built test binary: $bin"
+          file "$bin"
+          echo "readelf -p .comment (MOLD_DEBUG embeds mold's invocation here):"
+          readelf -p .comment "$bin" || true
+          if readelf -p .comment "$bin" | grep -qi mold; then
+            echo "RESULT: mold confirmed as the linker for $bin"
+          else
+            echo "RESULT: mold string NOT found in .comment for $bin"
+          fi
 
   sdk-build:
     name: Build SDK


### PR DESCRIPTION
## Summary
- Experiment (do not merge): measure whether the mold linker cuts wall time on the `Cargo check & test` job.
- Base is `ci/cargo-cache-and-dedupe` (#2113) to inherit its rust-cache setup and 7m24s warm baseline, and to reuse its cargo cache so the mold swap is the only variable.
- Adds `rui314/setup-mold@v1` immediately after the `Setup Rust stable` step in `cargo-check`; it self-configures as the default Linux linker (symlinks the resolved `/usr/bin/ld` target to `mold`). No other changes.

## Why
The workspace links many test binaries (12 crates, one 226k-line lib), so link time is suspected to be a first-order cost in the ~7m24s warm job time from #2113. This isolates that one variable.

## Test plan
- [ ] Run CI twice (rerun / empty commit) so the second run is fully warm; record both `Cargo check & test` wall times.
- [ ] Confirm mold was actually invoked (job log + a `readelf -p .comment` check on a built test binary, since MOLD_DEBUG embeds the mold invocation there).
- [ ] Compare against the 7m24s baseline from #2113 and report a verdict.
- [ ] Never merge — this PR exists to produce a measurement, not to ship.