### PR TITLE
perf(ci): shard product-client tests 4-way

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,7 +420,7 @@ jobs:
       - name: Enforce /login runtime budget
         run: node scripts/measure-login-runtime-budget.mjs
 
-  # EXPERIMENT (exp/frontend-shard): housekeeping that "Test product client"
+  # Housekeeping that "Test product client"
   # does not need (typecheck, the python-only checks, and the two other
   # focused vitest invocations) lives in its own job here so every matrix
   # shard below is pure install+build+test. Runs in parallel with the shards;
@@ -475,10 +475,10 @@ jobs:
       - name: Test workflow authoring surface
         run: pnpm --filter @proliferate/product-client exec vitest run src/components/workflows/builder-v2/WorkflowBuilderSurface.test.tsx src/components/workflows/main/WorkflowsMainSurface.test.tsx
 
-  # EXPERIMENT (exp/frontend-shard): "Test product client" was the pole of the
-  # combined job (~338s of ~8m38s-9m13s wall clock). Sharded 4-way via
-  # vitest's native --shard (3-way landed at 227s max shard wall clock, still
-  # over the 3-minute target — see PR body for the measured numbers). Every
+  # "Test product client" was the pole of the combined job (~338s of
+  # ~8m38s-9m13s wall clock). Sharded 4-way via vitest's native --shard
+  # (3-way still exceeded the 3-minute target; measured numbers in PR #2120).
+  # Every
   # other step this job used to run (typecheck, python checks, the two other
   # focused vitest invocations) moved to shared-frontend-checks above, so
   # every shard here is pure install+build+test. "Install dependencies" and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,23 +420,14 @@ jobs:
       - name: Enforce /login runtime budget
         run: node scripts/measure-login-runtime-budget.mjs
 
-  # EXPERIMENT (exp/frontend-shard): "Test product client" is the pole of this
-  # job (~338s of the job's ~8m38s-9m13s wall clock). Sharded 3-way via
-  # vitest's native --shard to see whether the job's wall clock drops below
-  # 3 minutes. Only "Install dependencies" and "Build shared packages" are
-  # true prerequisites of "Test product client" (product-client imports
-  # @proliferate/design/@proliferate/cloud-sdk(-react) through package.json
-  # `exports` that resolve to `dist`, so the build must precede every shard).
-  # Typecheck, the python-only checks, and the two other focused vitest
-  # invocations are independent of sharding and gated to shard 1 only so
-  # shards 2-3 do not re-run work "Test product client" does not need.
-  shared-frontend-packages:
-    name: Shared frontend packages
+  # EXPERIMENT (exp/frontend-shard): housekeeping that "Test product client"
+  # does not need (typecheck, the python-only checks, and the two other
+  # focused vitest invocations) lives in its own job here so every matrix
+  # shard below is pure install+build+test. Runs in parallel with the shards;
+  # merge-gating exactly like shared-frontend-packages was before the split.
+  shared-frontend-checks:
+    name: Shared frontend checks
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -452,7 +443,6 @@ jobs:
         run: pnpm install
 
       - name: Typecheck shared packages
-        if: matrix.shard == 1
         run: pnpm shared:typecheck
 
       - name: Build shared packages
@@ -462,26 +452,19 @@ jobs:
       # sit with the python guards in repo-shape (that job installs no node and
       # has no dist/theme.css to read). Both modes are checked in one pass.
       - uses: actions/setup-python@v7
-        if: matrix.shard == 1
         with:
           python-version: "3.12"
 
       - name: Check Mobile ProductClient export resolution
-        if: matrix.shard == 1
         run: python3 scripts/check_mobile_product_client_export.py --preflight
 
       - name: Check theme contrast floors
-        if: matrix.shard == 1
         run: |
           python3 -m unittest scripts/test_check_theme_contrast.py
           python3 scripts/check_theme_contrast.py --table
 
       - name: Test ProductClient domain
-        if: matrix.shard == 1
         run: pnpm --filter @proliferate/product-client exec vitest run src/domain
-
-      - name: Test product client
-        run: pnpm --filter @proliferate/product-client exec vitest run --shard=${{ matrix.shard }}/3
 
       # Focused Tier-1 gate for the workflow authoring surface: builder save
       # gating (title + unresolved-reference blocks), schema-version refusal,
@@ -490,8 +473,45 @@ jobs:
       # Tier 1). Keep this exact-file signal in addition to the package suite
       # so regressions remain immediately named.
       - name: Test workflow authoring surface
-        if: matrix.shard == 1
         run: pnpm --filter @proliferate/product-client exec vitest run src/components/workflows/builder-v2/WorkflowBuilderSurface.test.tsx src/components/workflows/main/WorkflowsMainSurface.test.tsx
+
+  # EXPERIMENT (exp/frontend-shard): "Test product client" was the pole of the
+  # combined job (~338s of ~8m38s-9m13s wall clock). Sharded 4-way via
+  # vitest's native --shard (3-way landed at 227s max shard wall clock, still
+  # over the 3-minute target — see PR body for the measured numbers). Every
+  # other step this job used to run (typecheck, python checks, the two other
+  # focused vitest invocations) moved to shared-frontend-checks above, so
+  # every shard here is pure install+build+test. "Install dependencies" and
+  # "Build shared packages" stay ungated: product-client imports
+  # @proliferate/design/@proliferate/cloud-sdk(-react) through package.json
+  # `exports` that resolve only to `dist`, so the build is a real
+  # prerequisite of every shard, not just of the steps that moved out.
+  shared-frontend-packages:
+    name: Shared frontend packages
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.11.0
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build shared packages
+        run: pnpm shared:build
+
+      - name: Test product client
+        run: pnpm --filter @proliferate/product-client exec vitest run --shard=${{ matrix.shard }}/4
 
   # Scroll-physics tier (specs/TESTING.md): the real transcript renderer driven
   # by a scripted streaming fixture in real Chromium AND real WebKit. Merge-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,9 +420,23 @@ jobs:
       - name: Enforce /login runtime budget
         run: node scripts/measure-login-runtime-budget.mjs
 
+  # EXPERIMENT (exp/frontend-shard): "Test product client" is the pole of this
+  # job (~338s of the job's ~8m38s-9m13s wall clock). Sharded 3-way via
+  # vitest's native --shard to see whether the job's wall clock drops below
+  # 3 minutes. Only "Install dependencies" and "Build shared packages" are
+  # true prerequisites of "Test product client" (product-client imports
+  # @proliferate/design/@proliferate/cloud-sdk(-react) through package.json
+  # `exports` that resolve to `dist`, so the build must precede every shard).
+  # Typecheck, the python-only checks, and the two other focused vitest
+  # invocations are independent of sharding and gated to shard 1 only so
+  # shards 2-3 do not re-run work "Test product client" does not need.
   shared-frontend-packages:
     name: Shared frontend packages
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -438,6 +452,7 @@ jobs:
         run: pnpm install
 
       - name: Typecheck shared packages
+        if: matrix.shard == 1
         run: pnpm shared:typecheck
 
       - name: Build shared packages
@@ -447,22 +462,26 @@ jobs:
       # sit with the python guards in repo-shape (that job installs no node and
       # has no dist/theme.css to read). Both modes are checked in one pass.
       - uses: actions/setup-python@v7
+        if: matrix.shard == 1
         with:
           python-version: "3.12"
 
       - name: Check Mobile ProductClient export resolution
+        if: matrix.shard == 1
         run: python3 scripts/check_mobile_product_client_export.py --preflight
 
       - name: Check theme contrast floors
+        if: matrix.shard == 1
         run: |
           python3 -m unittest scripts/test_check_theme_contrast.py
           python3 scripts/check_theme_contrast.py --table
 
       - name: Test ProductClient domain
+        if: matrix.shard == 1
         run: pnpm --filter @proliferate/product-client exec vitest run src/domain
 
       - name: Test product client
-        run: pnpm --filter @proliferate/product-client test
+        run: pnpm --filter @proliferate/product-client test -- --shard=${{ matrix.shard }}/3
 
       # Focused Tier-1 gate for the workflow authoring surface: builder save
       # gating (title + unresolved-reference blocks), schema-version refusal,
@@ -471,6 +490,7 @@ jobs:
       # Tier 1). Keep this exact-file signal in addition to the package suite
       # so regressions remain immediately named.
       - name: Test workflow authoring surface
+        if: matrix.shard == 1
         run: pnpm --filter @proliferate/product-client exec vitest run src/components/workflows/builder-v2/WorkflowBuilderSurface.test.tsx src/components/workflows/main/WorkflowsMainSurface.test.tsx
 
   # Scroll-physics tier (specs/TESTING.md): the real transcript renderer driven

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,7 +481,7 @@ jobs:
         run: pnpm --filter @proliferate/product-client exec vitest run src/domain
 
       - name: Test product client
-        run: pnpm --filter @proliferate/product-client test -- --shard=${{ matrix.shard }}/3
+        run: pnpm --filter @proliferate/product-client exec vitest run --shard=${{ matrix.shard }}/3
 
       # Focused Tier-1 gate for the workflow authoring surface: builder save
       # gating (title + unresolved-reference blocks), schema-version refusal,


### PR DESCRIPTION
## Summary

Shard the slowest step in the `shared-frontend-packages` CI job 4-way so the job's wall clock drops from ~8m38s-9m13s to ~3m07s.

**Latest state (housekeeping split out + 4-way shard): max shard job wall clock 187s (3m07s), down from the ~338s "Test product client" step / ~7m34s-9m13s combined job baseline. 7s over the 3-minute target — see "Round 3" below.**

### Round 1 — 3-way shard, steps left in the same job

- Job `shared-frontend-packages` originally ran 8m38s-9m13s; one step, "Test product client" (~338s), was the pole.
- Added `strategy: matrix: shard: [1, 2, 3]`, ran "Test product client" with `--shard=${{ matrix.shard }}/3`, gated the steps that step doesn't need (typecheck, the two python-only checks, "Test ProductClient domain", "Test workflow authoring surface") to `if: matrix.shard == 1`.

**Bug found and fixed:** `pnpm --filter @proliferate/product-client test -- --shard=N/3` resolved to `vitest run -- --shard=N/3` — pnpm inserts its own `--` ahead of forwarded script args, and vitest's CLI parser treats that leading `--` as an end-of-options marker, so `--shard` was never applied. All 3 "shards" silently ran the **full** `1093 files / 8168 tests` each; wall clock got *worse* (up to 522s) from 3x redundant work plus runner variance. Fixed by invoking vitest directly — `pnpm --filter @proliferate/product-client exec vitest run --shard=${{ matrix.shard }}/3` — same pattern the sibling "Test ProductClient domain" step already used.

After the fix, 3-way sharding measured correctly:

| Shard | Job wall clock | vitest summary |
|---|---|---|
| 1 | 227s (3m47s) | 365 files / 2692 tests, vitest duration 113.82s |
| 2 | 217s (3m37s) | 365 files / 2843 tests, vitest duration 147.04s |
| 3 | 216s (3m36s) | 363 files / 2633 tests, vitest duration 148.48s |

Reconciliation: 365+365+363 = 1093 files, 2692+2843+2633 = 8168 tests — matches baseline exactly. Max (new lane time) = 227s, still over the 3-minute target. Shard 1 was the pole because it alone carried the gated housekeeping steps (typecheck, python checks, the two other vitest invocations) on top of its own shard.

### Round 2 (this push) — split housekeeping into its own job + widen to 4 shards

Per follow-up direction: moved all housekeeping (Typecheck shared packages, both python-only checks, "Test ProductClient domain", "Test workflow authoring surface") into a new `shared-frontend-checks` job with its own checkout/install/build, so every `shared-frontend-packages` matrix shard is pure install+build+test. Since the fixed per-shard setup+build overhead (~65-70s) plus a 3-way shard's own vitest time (~148s) was already going to clear 180s regardless of the housekeeping move, widened to 4 shards in the same push rather than spending a second CI round-trip confirming that.

**Measured (run [32413118164](https://github.com/proliferate-ai/proliferate/actions/runs/32413118164)):**

| Job | Wall clock | vitest summary |
|---|---|---|
| Shared frontend checks | 133s | domain: 83 files/940 tests; workflow authoring: 2 files/29 tests |
| Shard 1/4 | 187s (3m07s) | 274 files / 2035 tests, vitest duration 110.24s |
| Shard 2/4 | 164s (2m44s) | 274 files / 1990 tests, vitest duration 90.72s |
| Shard 3/4 | 186s (3m06s) | 274 files / 2242 tests, vitest duration 118.71s |
| Shard 4/4 | 175s (2m55s) | 271 files / 1901 tests, vitest duration 108.86s |

**Reconciliation:** product-client shards: 274+274+274+271 = **1093 files**, 2035+1990+2242+1901 = **8168 tests** — matches the unsharded baseline exactly. Housekeeping job: 83/940 + 2/29 — also matches baseline exactly. No dropped tests across either job.

**New lane time = max(187, 164, 186, 175) = 187s (3m07s).** Still 7s over the 180s target. Per-shard vitest test time is now down to 91-119s (well under target on its own); the remaining pole is each shard's fixed checkout+install+build overhead (~64-71s, dominated by "Build shared packages" fluctuating 35-47s run to run) — i.e. we're now bound by per-job GitHub Actions runner setup/build variance rather than by the test suite itself. Closing the last ~7s would mean caching the build output across shards (e.g. build once in a separate job and pass `dist/` as an artifact into each shard) rather than more sharding — not attempted here to avoid over-engineering the experiment further.

## Shard-safety audit

- `vitest.config.ts`: no `sequence`/`singleFork`/`singleThread`/custom `poolOptions` — default vitest parallelism already runs test files concurrently within one invocation, so `--shard` just narrows the file set handed to that same machinery.
- `vitest.global-setup.ts` regenerates the gitignored `src/generated/agent-*.json` copies before collection. Idempotent and file-content-identical regardless of which shard runs it; each shard is a separate checkout/process, so there's no write race.
- `vitest.setup.ts` calls `setMeasurementSink(...)` per test file (last-writer-wins, explicitly documented as such) — no shared external state across files or shards.
- No `process.env` mutation, no fixed-path `writeFileSync`/`tmpdir()` usage, and no cross-file ordering dependency found in `src/**/*.test.{ts,tsx}` (1093 files).
- "Install dependencies" and "Build shared packages" stay ungated in every product-client shard: product-client imports `@proliferate/design`, `@proliferate/cloud-sdk`, and `@proliferate/cloud-sdk-react` through `package.json` `exports` that resolve only to `dist`, so the build is a real prerequisite of the sharded step.

## Caveat

Turning this job into a matrix (and splitting housekeeping into its own job) changes check name(s) (e.g. `Shared frontend packages (1)` instead of `Shared frontend packages`, plus a new `Shared frontend checks` check), which needs the branch-protection required-checks list updated when it is set (tracked in the rollout plan).

## Test plan

- [x] Compare per-shard wall time (max = new lane time) against the ~8m38s-9m13s baseline
- [x] Sum vitest "Tests" counts across the shards and confirm it equals the unsharded "Test product client" count (no silently dropped tests)
- [x] Confirm whether the job wall clock lands at or under the 3-minute target — landed at 187s, 7s over

🤖 Generated with [Claude Code](https://claude.com/claude-code)

