### PR TITLE
ci(playwright): cache browser binaries in browser CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,27 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: |
+          version=$(grep -m1 '^  playwright-core@' pnpm-lock.yaml | sed -E 's/^  playwright-core@([0-9.]+):.*/\1/')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # EXPERIMENT (exp/playwright-cache): cache the downloaded browser
+      # binaries so a cache hit skips the network download; the key is the
+      # exact playwright-core version resolved above so a bump auto-busts it.
+      # --with-deps still runs unconditionally below because the OS-level apt
+      # packages it installs live outside this cache dir and would not
+      # survive on the ephemeral runner anyway; playwright's own installer
+      # already no-ops the binary download when the target revision is
+      # already present, so this only removes the download, not the apt step.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-chromium
+
       - name: Install Playwright chromium
         run: |
           sudo "$(command -v node)" "$GITHUB_WORKSPACE/scripts/ci-cd/configure-playwright-apt.mjs"
@@ -507,6 +528,22 @@ jobs:
       - name: Typecheck scroll-physics fixture
         run: pnpm --filter @proliferate/product-client typecheck:scroll-physics
 
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: |
+          version=$(grep -m1 '^  playwright-core@' pnpm-lock.yaml | sed -E 's/^  playwright-core@([0-9.]+):.*/\1/')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # EXPERIMENT (exp/playwright-cache): see login-budget's cache step for
+      # rationale. Keyed separately (chromium-webkit) from the chromium-only
+      # jobs since this job installs a superset of browsers.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-chromium-webkit
+
       - name: Install Playwright chromium + webkit
         run: |
           sudo "$(command -v node)" "$GITHUB_WORKSPACE/scripts/ci-cd/configure-playwright-apt.mjs"
@@ -581,6 +618,21 @@ jobs:
 
       - name: Verify generated cloud SDK artifacts are committed
         run: git diff --exit-code -- cloud/sdk/src/generated/openapi.ts
+
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: |
+          version=$(grep -m1 '^  playwright-core@' pnpm-lock.yaml | sed -E 's/^  playwright-core@([0-9.]+):.*/\1/')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # EXPERIMENT (exp/playwright-cache): see login-budget's cache step for
+      # rationale.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-chromium
 
       - name: Install Playwright chromium
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,7 +415,7 @@ jobs:
           version=$(grep -m1 '^  playwright-core@' pnpm-lock.yaml | sed -E 's/^  playwright-core@([0-9.]+):.*/\1/')
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      # EXPERIMENT (exp/playwright-cache): cache the downloaded browser
+      # Cache the downloaded browser
       # binaries so a cache hit skips the network download; the key is the
       # exact playwright-core version resolved above so a bump auto-busts it.
       # The install step below still installs OS dependencies unconditionally
@@ -535,8 +535,7 @@ jobs:
           version=$(grep -m1 '^  playwright-core@' pnpm-lock.yaml | sed -E 's/^  playwright-core@([0-9.]+):.*/\1/')
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      # EXPERIMENT (exp/playwright-cache): see login-budget's cache step for
-      # rationale. Keyed separately (chromium-webkit) from the chromium-only
+      # See login-budget's cache step for rationale. Keyed separately (chromium-webkit) from the chromium-only
       # jobs since this job installs a superset of browsers.
       - name: Cache Playwright browsers
         id: playwright-cache
@@ -626,8 +625,7 @@ jobs:
           version=$(grep -m1 '^  playwright-core@' pnpm-lock.yaml | sed -E 's/^  playwright-core@([0-9.]+):.*/\1/')
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      # EXPERIMENT (exp/playwright-cache): see login-budget's cache step for
-      # rationale.
+      # See login-budget's cache step for rationale.
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,11 +418,12 @@ jobs:
       # EXPERIMENT (exp/playwright-cache): cache the downloaded browser
       # binaries so a cache hit skips the network download; the key is the
       # exact playwright-core version resolved above so a bump auto-busts it.
-      # --with-deps still runs unconditionally below because the OS-level apt
-      # packages it installs live outside this cache dir and would not
-      # survive on the ephemeral runner anyway; playwright's own installer
-      # already no-ops the binary download when the target revision is
-      # already present, so this only removes the download, not the apt step.
+      # The install step below still installs OS dependencies unconditionally
+      # (see its own run block) because those apt packages live outside this
+      # cache dir and would not survive on the ephemeral runner anyway;
+      # playwright's own installer already no-ops the binary download when
+      # the target revision is already present, so this only removes the
+      # download, not the apt step.
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0


### PR DESCRIPTION
## Summary
- Cache `~/.cache/ms-playwright` in the three browser-driving CI jobs (`login-budget`, `scroll-physics`, `workflow-definition-lifecycle`), keyed on the `playwright-core` version resolved from `pnpm-lock.yaml` so an upgrade auto-busts the cache.
- `--with-deps` keeps running unconditionally on every run: the apt-installed OS shared libraries it also provides live outside `~/.cache/ms-playwright` and would not survive anyway on GitHub's ephemeral runner VM, so caching only removes the browser-binary download; Playwright's installer already no-ops that download when the target revision is present.

## Baseline (3 recent successful `main` runs, install-step wall time only)
| Job | Run 1 | Run 2 | Run 3 |
| --- | --- | --- | --- |
| login-budget (chromium) | 26s | 26s | 31s |
| workflow-definition-lifecycle (chromium) | 26s | 31s | 31s |
| scroll-physics (chromium+webkit) | 46s | 46s | 51s |
| **Total across jobs** | **98s** | **103s** | **113s** |

Well above the 30s "not worth it" floor, so proceeding with the cache.

## Test plan
- [ ] Run this workflow twice on this PR (prime + warm) and record before/after install-step timings in a follow-up comment.
- [ ] Confirm cache hit on the second run via the `actions/cache` step log ("Cache restored from key...").
- [ ] Confirm all three jobs still pass green on the warm run (no missing shared-lib failures from browsers launched against a cached-binary/fresh-OS-deps combination).

Generated with Claude Code.

