### PR TITLE
test(server): scope db truncation and shard the suite with pytest-xdist

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -166,7 +166,7 @@ jobs:
         run: uv pip install --system -e ".[dev]"
 
       - name: Run tests
-        run: pytest tests/unit tests/integration tests/e2e/cloud/test_e2b_webhooks.py -q --durations=20
+        run: pytest tests/unit tests/integration tests/e2e/cloud/test_e2b_webhooks.py -n 4 -q --durations=20
 
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -165,6 +165,30 @@ jobs:
       - name: Install dependencies
         run: uv pip install --system -e ".[dev]"
 
+      # Four workers means four concurrent 78-table TRUNCATEs and four
+      # concurrent full alembic upgrades, each holding an AccessExclusiveLock on
+      # every table, index, and sequence it touches. Postgres sizes its shared
+      # lock table at max_locks_per_transaction * max_connections, and the
+      # 64 * 100 default overflows with "out of shared memory". This GUC is
+      # postmaster-level, and service containers take no command line, so it has
+      # to be written to postgresql.auto.conf and the container bounced.
+      - name: Raise the Postgres lock table for parallel workers
+        run: |
+          set -euo pipefail
+          container="$(docker ps --filter 'ancestor=postgres:16-alpine' --format '{{.ID}}' | head -1)"
+          test -n "$container"
+          docker exec "$container" psql -U proliferate -d proliferate \
+            -c 'ALTER SYSTEM SET max_locks_per_transaction = 1024;'
+          docker restart "$container"
+          for _ in $(seq 1 60); do
+            if docker exec "$container" pg_isready -U proliferate -d proliferate >/dev/null 2>&1; then
+              break
+            fi
+            sleep 1
+          done
+          docker exec "$container" psql -U proliferate -d proliferate \
+            -c 'SHOW max_locks_per_transaction;'
+
       - name: Run tests
         run: pytest tests/unit tests/integration tests/e2e/cloud/test_e2b_webhooks.py -n 4 -q --durations=20
 

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
 dev = [
     "pytest>=9.1.1",
     "pytest-asyncio>=1.4.0",
+    "pytest-xdist>=3.8.0",
     "httpx==0.28.1",
     "mypy==1.20.2",
     "ruff>=0.16.2",

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -52,18 +52,33 @@ def migrated_test_database():  # type: ignore[no-untyped-def]
 
 @pytest_asyncio.fixture
 async def test_engine(migrated_test_database):  # type: ignore[no-untyped-def]
+    """The one door to the test database -- and therefore the reset boundary.
+
+    The truncate used to live in an autouse ``reset_test_database`` fixture, so
+    all 2,900+ tests paid a 78-table TRUNCATE (twice) plus the session-scoped
+    alembic migration, including the large majority that never touch Postgres.
+    Hanging it off ``test_engine`` scopes the reset to exactly the tests that
+    reach the database, because every database path in the suite -- ``client``,
+    ``db_session``, ``cloud_client``, and every per-module session factory --
+    resolves through this fixture.
+
+    Fixture ordering is unchanged: the pre-test truncate still runs before any
+    fixture that depends on ``test_engine`` can seed rows, and the post-test
+    truncate still runs after those fixtures tear down, because teardown is the
+    reverse of setup and this fixture is the first of the chain to be set up.
+
+    Tests that build their own throwaway database (``temporary_database``) are
+    self-isolating and correctly opt out of the shared-database reset.
+    """
     engine = create_async_engine(TEST_DATABASE_URL, echo=False)
-    yield engine
-    await engine.dispose()
-
-
-@pytest_asyncio.fixture(autouse=True)
-async def reset_test_database(test_engine) -> AsyncGenerator[None, None]:  # type: ignore[no-untyped-def]
     await _cancel_test_background_tasks()
-    await truncate_all_tables(test_engine)
-    yield
-    await _cancel_test_background_tasks()
-    await truncate_all_tables(test_engine)
+    await truncate_all_tables(engine)
+    try:
+        yield engine
+    finally:
+        await _cancel_test_background_tasks()
+        await truncate_all_tables(engine)
+        await engine.dispose()
 
 
 @pytest_asyncio.fixture

--- a/server/tests/postgres.py
+++ b/server/tests/postgres.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from alembic import command
@@ -23,10 +24,36 @@ POSTGRES_USER = "proliferate"
 POSTGRES_PASSWORD = "localdev"
 POSTGRES_HOST = "127.0.0.1"
 POSTGRES_PORT = 5432
-TEST_DATABASE_NAME = os.environ.get(
-    "PROLIFERATE_TEST_DATABASE_NAME",
-    f"proliferate_test_{os.getpid()}",
-)
+
+# pytest-xdist runs every worker as its own OS process and exports the worker id
+# ("gw0", "gw1", ...) into that process's environment before pytest imports any
+# test module, so reading it at import time is safe. Naming the database after
+# the worker is what makes the rest of the harness per-worker for free: the
+# session-scoped ``migrated_test_database`` fixture is session-scoped *per
+# process*, so each worker migrates and later drops only the database it owns,
+# and the per-test TRUNCATE can never reach another worker's rows.
+#
+# A serial run (no ``-n``) sees an empty worker id and keeps the historical
+# per-pid name byte-for-byte.
+XDIST_WORKER = os.environ.get("PYTEST_XDIST_WORKER", "")
+
+
+def _default_test_database_name() -> str:
+    if XDIST_WORKER:
+        return f"proliferate_test_{XDIST_WORKER}_{os.getpid()}"
+    return f"proliferate_test_{os.getpid()}"
+
+
+def _resolve_test_database_name() -> str:
+    explicit = os.environ.get("PROLIFERATE_TEST_DATABASE_NAME")
+    if explicit is None:
+        return _default_test_database_name()
+    # An explicit override names one database. Under xdist it still has to fan
+    # out, or the workers would truncate each other's rows mid-test.
+    return f"{explicit}_{XDIST_WORKER}" if XDIST_WORKER else explicit
+
+
+TEST_DATABASE_NAME = _resolve_test_database_name()
 ADMIN_DATABASE_URL = (
     f"postgresql+asyncpg://{POSTGRES_USER}:{POSTGRES_PASSWORD}@"
     f"{POSTGRES_HOST}:{POSTGRES_PORT}/postgres"
@@ -35,6 +62,15 @@ TEST_DATABASE_URL = (
     f"postgresql+asyncpg://{POSTGRES_USER}:{POSTGRES_PASSWORD}@"
     f"{POSTGRES_HOST}:{POSTGRES_PORT}/{TEST_DATABASE_NAME}"
 )
+
+# CREATE DATABASE / DROP DATABASE take a lock on the template database, so
+# concurrent creates from different xdist workers (or from ``temporary_database``
+# inside a test) can lose that race with 55006 "is being accessed by other
+# users" even though the database *names* never collide. 42P04/23505 mean
+# someone else already created the name, which is the outcome we wanted anyway.
+_DATABASE_EXISTS_SQLSTATES = frozenset({"42P04", "23505"})
+_DATABASE_BUSY_SQLSTATES = frozenset({"55006"})
+_DATABASE_LIFECYCLE_ATTEMPTS = 12
 
 
 def make_database_url(database_name: str) -> str:
@@ -48,16 +84,39 @@ def _quote_identifier(identifier: str) -> str:
     return '"' + identifier.replace('"', '""') + '"'
 
 
+def _sqlstate(error: BaseException) -> str | None:
+    for candidate in (getattr(error, "orig", None), error):
+        for attribute in ("sqlstate", "pgcode"):
+            code = getattr(candidate, attribute, None)
+            if isinstance(code, str):
+                return code
+    return None
+
+
 async def ensure_database_exists(database_name: str) -> None:
     admin_engine = create_async_engine(ADMIN_DATABASE_URL, isolation_level="AUTOCOMMIT")
     try:
-        async with admin_engine.connect() as conn:
-            result = await conn.execute(
-                text("SELECT 1 FROM pg_database WHERE datname = :database_name"),
-                {"database_name": database_name},
-            )
-            if result.scalar() is None:
-                await conn.execute(text(f"CREATE DATABASE {_quote_identifier(database_name)}"))
+        for attempt in range(_DATABASE_LIFECYCLE_ATTEMPTS):
+            try:
+                async with admin_engine.connect() as conn:
+                    result = await conn.execute(
+                        text("SELECT 1 FROM pg_database WHERE datname = :database_name"),
+                        {"database_name": database_name},
+                    )
+                    if result.scalar() is not None:
+                        return
+                    await conn.execute(text(f"CREATE DATABASE {_quote_identifier(database_name)}"))
+                    return
+            except DBAPIError as error:
+                sqlstate = _sqlstate(error)
+                if sqlstate in _DATABASE_EXISTS_SQLSTATES:
+                    return
+                if (
+                    sqlstate not in _DATABASE_BUSY_SQLSTATES
+                    or attempt == _DATABASE_LIFECYCLE_ATTEMPTS - 1
+                ):
+                    raise
+            await asyncio.sleep(0.25 * (attempt + 1))
     finally:
         await admin_engine.dispose()
 
@@ -65,18 +124,31 @@ async def ensure_database_exists(database_name: str) -> None:
 async def drop_database(database_name: str) -> None:
     admin_engine = create_async_engine(ADMIN_DATABASE_URL, isolation_level="AUTOCOMMIT")
     try:
-        async with admin_engine.connect() as conn:
-            await conn.execute(
-                text(
-                    """
-                    SELECT pg_terminate_backend(pid)
-                    FROM pg_stat_activity
-                    WHERE datname = :database_name AND pid <> pg_backend_pid()
-                    """
-                ),
-                {"database_name": database_name},
-            )
-            await conn.execute(text(f"DROP DATABASE IF EXISTS {_quote_identifier(database_name)}"))
+        for attempt in range(_DATABASE_LIFECYCLE_ATTEMPTS):
+            try:
+                async with admin_engine.connect() as conn:
+                    await conn.execute(
+                        text(
+                            """
+                            SELECT pg_terminate_backend(pid)
+                            FROM pg_stat_activity
+                            WHERE datname = :database_name AND pid <> pg_backend_pid()
+                            """
+                        ),
+                        {"database_name": database_name},
+                    )
+                    await conn.execute(
+                        text(f"DROP DATABASE IF EXISTS {_quote_identifier(database_name)}")
+                    )
+                    return
+            except DBAPIError as error:
+                sqlstate = _sqlstate(error)
+                if (
+                    sqlstate not in _DATABASE_BUSY_SQLSTATES
+                    or attempt == _DATABASE_LIFECYCLE_ATTEMPTS - 1
+                ):
+                    raise
+            await asyncio.sleep(0.25 * (attempt + 1))
     finally:
         await admin_engine.dispose()
 

--- a/server/tests/unit/test_sentry_transport_privacy.py
+++ b/server/tests/unit/test_sentry_transport_privacy.py
@@ -178,12 +178,8 @@ def test_empty_release_and_environment_sentinels_are_removed(factory_name: str) 
 
 # --- tags, extras, user, request ---------------------------------------------
 
-# Fixed, structurally valid ids. These used to be `str(uuid4())` and
-# `uuid4().hex`, but a value generated at collection time lands in the
-# parametrize id, so every process collected a differently-named test. Nothing
-# here depends on the ids being fresh, only on their shape: a dashed UUID and a
-# bare 32-char hex. Determinism matters because pytest-xdist refuses to run when
-# its workers disagree about which tests exist.
+# Fixed ids (were uuid4() at collection time, which lands in parametrize ids and
+# breaks pytest-xdist's requirement that workers agree on collected test names).
 VALID_UUID = "c3f1a8d2-5b47-4e19-9a6c-0d8e2f7b41ca"
 VALID_UUID_HEX = "0f3c2a9d6b8e4f1aa7c25d3e9b64108f"
 

--- a/server/tests/unit/test_sentry_transport_privacy.py
+++ b/server/tests/unit/test_sentry_transport_privacy.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import datetime as dt
 import json
 from typing import Any
-from uuid import uuid4
 
 import pytest
 
@@ -179,7 +178,14 @@ def test_empty_release_and_environment_sentinels_are_removed(factory_name: str) 
 
 # --- tags, extras, user, request ---------------------------------------------
 
-VALID_UUID = str(uuid4())
+# Fixed, structurally valid ids. These used to be `str(uuid4())` and
+# `uuid4().hex`, but a value generated at collection time lands in the
+# parametrize id, so every process collected a differently-named test. Nothing
+# here depends on the ids being fresh, only on their shape: a dashed UUID and a
+# bare 32-char hex. Determinism matters because pytest-xdist refuses to run when
+# its workers disagree about which tests exist.
+VALID_UUID = "c3f1a8d2-5b47-4e19-9a6c-0d8e2f7b41ca"
+VALID_UUID_HEX = "0f3c2a9d6b8e4f1aa7c25d3e9b64108f"
 
 @pytest.mark.parametrize(
     ("key", "value", "survives"),
@@ -193,7 +199,7 @@ VALID_UUID = str(uuid4())
         ("cloud_workspace_id", VALID_UUID, True), ("cloud_target_id", VALID_UUID, True),
         ("sandbox_profile_id", VALID_UUID, True), ("cloud_sandbox_id", VALID_UUID, True),
         ("enrollment_key_id", VALID_UUID, True), ("user_id", VALID_UUID.upper(), True),
-        ("support_report_id", uuid4().hex, True), ("support_report_id", VALID_UUID, False),
+        ("support_report_id", VALID_UUID_HEX, True), ("support_report_id", VALID_UUID, False),
         ("tenant_id", f"user:{VALID_UUID}", True), ("tenant_id", f"org:{VALID_UUID}", True),
         ("tenant_id", f"team:{VALID_UUID}", False), ("critical_failure", "true", True),
         ("critical_failure", "True", False), ("domain", "billing", True),

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -594,6 +594,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.141.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1142,6 +1151,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "sqlalchemy", extra = ["mypy"] },
     { name = "types-pyyaml" },
@@ -1170,6 +1180,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.15.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.4.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.8.0" },
     { name = "python-dateutil", specifier = ">=2.9.0" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "python-multipart", specifier = ">=0.0.32" },
@@ -1478,6 +1489,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Scope the per-test DB truncate to tests that actually reach the database, and run the suite under `pytest-xdist -n 4` with a database per worker: the `test` job drops from 74.7m to ~14m with a pass set identical to main across three runs.

## Result

Combined truncate-scoping + `pytest-xdist -n 4`, three green `server-ci` runs, all with a pass set identical to main:

| run | `test` job wall | pytest summary |
| --- | --- | --- |
| [B](https://github.com/proliferate-ai/proliferate/actions/runs/32412638503/job/96566398648) | **13m33s** | `2972 passed, 1 skipped, 903 warnings in 765.91s (0:12:45)` |
| [C](https://github.com/proliferate-ai/proliferate/actions/runs/32412638503/job/96570576815) | **35m55s** | `2972 passed, 1 skipped, 904 warnings in 2080.78s (0:34:40)` |
| [D](https://github.com/proliferate-ai/proliferate/actions/runs/32412638503/job/96581108035) | **14m35s** | `2972 passed, 1 skipped, 904 warnings in 811.24s (0:13:31)` |

Baseline (main, run 32380718513): **74.7m**, `2972 passed, 1 skipped, 901 warnings in 4402.64s (1:13:22)`.

Typical case ~14m against 74.7m: **about 5x, roughly 60 minutes saved per run**. Even run C, the outlier, beat every serial `test` job observed in the last two days (47.2m-69.6m, median 57.8m).

Run C is runner hardware, not the change: *every* step in that job ran about twice as slow, including ones that never touch the suite (checkout 2.0s -> 5.1s, pnpm setup 3.5s -> 9.8s, dependency install 2.0s -> 4.6s, container init 11.0s -> 19.7s). The test step degraded slightly worse than that ratio (2.7x vs ~2.0x), which is what a shared Postgres bottleneck under four writers does on a slow host.

## What changed

1. **Truncate scoping.** The autouse `reset_test_database` fixture folded into `test_engine`, the single door every database path in the suite goes through. Audit of all three `conftest.py` files, plus a grep for direct engine creation, found no fixture-less database access: the only tests that build their own engines use `tests.postgres.temporary_database`, a throwaway uuid-named database that correctly opts out of the shared reset. A `--setup-plan` dump confirms 1,050 of 2,847 parseable tests resolve `test_engine`, and that zero tests reach `db_session`, `client`, or `cloud_client` without it. The other ~1,800 tests stop paying two 78-table `TRUNCATE`s each.

   Fixture ordering is preserved. `test_engine` is the first of its chain to be set up, so the pre-test truncate still lands before any dependent fixture can seed rows; teardown is the reverse of setup, so the post-test truncate still lands after those fixtures unwind.

2. **Per-worker databases.** Each xdist worker is its own OS process, so the session-scoped `migrated_test_database` fixture is session-scoped *per worker*. Deriving the database name from `PYTEST_XDIST_WORKER` gives each worker a database it alone migrates, truncates, and drops. An empty worker id (any run without `-n`) keeps the historical per-pid name byte-for-byte.

   The worker id is exported into the worker environment before pytest imports any test module, so reading it at `tests/postgres.py` import time is safe. Verified in an isolated harness, with a negative control that asserted the id was *not* visible and duly failed with `worker id WAS visible ('gw0')`.

   `CREATE DATABASE` and `DROP DATABASE` lock the template database, so concurrent worker startup can lose that race with SQLSTATE 55006 even though names never collide. Both are retried with backoff on 55006; `CREATE` treats 42P04/23505 as already-satisfied.

## Two things `-n 4` broke that had to be fixed

**Non-deterministic collection.** The first `-n 4` run aborted with "Different tests were collected between gw0 and gw3". `tests/unit/test_sentry_transport_privacy.py` built its parametrize table from `str(uuid4())` and `uuid4().hex` evaluated at import time, so the random value landed in the test id and each worker collected 44 differently-named tests. Serial runs never noticed because only one process ever collected. Both are now fixed literals; nothing in that matrix depends on the ids being fresh, only on their shape.

Verified by collecting the CI test set twice in independent processes: 2,973 node ids, byte-identical. Negative control on the unfixed file: 44 ids differ between the same two collections.

**Postgres lock table.** The second run died with 1,057 setup errors, all one cause:

```
asyncpg.exceptions.OutOfMemoryError: out of shared memory
HINT:  You might need to increase max_locks_per_transaction.
```

Postgres sizes its shared lock table at `max_locks_per_transaction * max_connections`, so the stock 64 * 100 leaves 6,400 slots. One 78-table `TRUNCATE ... CASCADE` takes an AccessExclusiveLock on every table, index, toast relation, and sequence it touches, and a full alembic upgrade in a single transaction takes one per object it creates. Serially that peaks at one such transaction; with four workers the truncates and the per-worker and per-temporary-database migrations overlap and exhaust the table.

The GUC is postmaster-level and Actions service containers accept no command line, so the workflow writes it via `ALTER SYSTEM` and restarts the container (which preserves port publishing). **Any real adoption of `-n` needs this, or an equivalent Postgres config change.**

## Redis

No per-worker partitioning needed. `proliferate.integrations.redis_lock` is the suite's only Redis client, and every test that reaches it monkeypatches `Redis.from_url`. All other `redis` references in tests are URL-rendering assertions against deploy manifests. The CI `redis` service container is never contacted by this test command.

## Other shared state

No module-, class-, or package-scoped fixtures exist in the suite (three session-scoped ones, all per-process). No test writes outside `tmp_path`. No test binds a fixed port on the CI path. The only cross-worker resource is the Postgres instance itself.

## Caveat

`-q` prints counts, not node ids, so the pass-set comparison is on `2972 passed, 1 skipped` matching main exactly, plus deterministic collection of the same 2,973 ids. Zero tests failed on any of the three runs, so no main-green test regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

