### PR TITLE
perf(release): cache cargo artifacts for self-hosted asset builds

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -288,12 +288,24 @@ jobs:
             x86_64-unknown-linux-musl
             aarch64-unknown-linux-musl
 
+      # This job compiles the same 3 crates (anyharness, proliferate-worker,
+      # proliferate-supervisor) for 2 targets with no cache today, so every run
+      # pays a full from-scratch registry download plus workspace-dependency
+      # compile twice. `cross` (used for the aarch64 build below) bind-mounts
+      # the repo root, including target/, into its build container by default,
+      # so a host-side target/ cache benefits both the native x86_64 build and
+      # the cross-compiled aarch64 build. Same pattern already used for
+      # `cross` builds elsewhere in this repo (see release-e2e.yml).
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "."
+
       - name: Install musl-tools
         run: sudo apt-get update && sudo apt-get install -y musl-tools
         working-directory: .
 
       - name: Install cross for aarch64
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        run: cargo install cross --git https://github.com/cross-rs/cross --locked
         working-directory: .
 
       - name: Build self-hosted Linux runtime (x86_64)


### PR DESCRIPTION
## Summary

Targets the `self-hosted-release-assets` job in `server-ci.yml`,
which sits on the release train's critical-path tail at ~16.1m
(release-server chain: lint / test -> docker 3.0m -> self-hosted-release-assets 16.1m).

Step-time attribution from the last nightly train run (job: [self-hosted-release-assets](https://github.com/proliferate-ai/proliferate/actions/runs/32167413474/job/95827482227), total 16:06):

| Step | Duration | % of job |
|---|---|---|
| Build self-hosted Linux runtime (aarch64), via `cross` | 7:10 | 44% |
| Build self-hosted Linux runtime (x86_64), native cargo | 6:57 | 43% |
| Install cross for aarch64 (`cargo install cross --git ...`) | 0:51 | 5% |
| Publish self-hosted release assets | 0:25 | 3% |
| Install musl-tools | 0:20 | 2% |
| Prepare release assets (tar + sha256) | 0:10 | 1% |
| Setup Rust / checkout / misc | ~0:13 | 1% |

Top costs: the two from-scratch Rust release builds are ~87% of the job
(14:07 of 16:06). Both builds compile the full dependency graph for
`anyharness`, `proliferate-worker`, and `proliferate-supervisor` with zero
registry/target caching, so every run re-downloads and re-compiles every
crate dependency from nothing.

### Bigger finding (not fixed here, flagging for the planned graph work)

`nightly-release-train.yml` and `hotfix-production.yml` both fan out
`release-runtime` and `release-server` as parallel siblings off `prepare`.
`release-runtime`'s `build-binaries` matrix already builds these exact same
3 crates for these exact same 2 targets (`x86_64-unknown-linux-musl`,
`aarch64-unknown-linux-musl`) and finished in ~7 min each in the same train
run, roughly 50 minutes before `self-hosted-release-assets` even starts. That
means ~14 of the 16 minutes here are a straight duplicate of work the train
already paid for elsewhere in the same run.

I didn't implement that fix in this PR: `self-hosted-release-assets` can also
run standalone on a bare `server-v*` tag push (no sibling `release-runtime`
job in that run at all), and `hotfix-production.yml` can select `server` only
and skip `release-runtime` entirely, so consuming the sibling artifact needs
a conditional download-or-build fallback plus a real graph dependency between
`release-server` and `release-runtime` in both callers. That's graph-topology
surgery best done as part of the release train's already-planned graph
simplification, not as a standalone low-risk patch. Flagging it here as the
higher-value follow-up (worth ~14 min vs. the few minutes this PR targets).

## This PR

Add `Swatinem/rust-cache@v2` (same pattern already used alongside `cross` in
`release-e2e.yml`) so the cargo registry and `target/` persist across runs.
`cross` bind-mounts the repo root, including `target/`, into its build
container by default, so the cache should benefit both the native x86_64
build and the cross-compiled aarch64 build, not just one of them. Also pins
`cargo install cross --git ...` with `--locked` to match the existing
`release-e2e.yml` convention.

## Measurement caveat

`self-hosted-release-assets` only runs on a `refs/tags/server-v*` push or a
`workflow_call` with `publish == true && dry_run != true` (from
`nightly-release-train.yml` or `hotfix-production.yml`). A plain PR against
`main` cannot trigger it; it stays skipped on this PR's own CI. Per the hard
limits on this task, I did not push a tag or dispatch a publish run to force
it live.

Validated instead by:
- YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- `actionlint .github/workflows/server-ci.yml` passes clean
- Reasoning: this is an additive, non-semantic change (a cache step plus a
  `--locked` flag); it changes nothing about what gets built, tagged, or
  published, only whether cargo can skip work it already did.

Expected saving: the ~51s `cross` self-install is unaffected (still rebuilds
from git source; `--locked` only pins its own deps). The real win is on the
two build steps. A warm cache should let cargo skip recompiling any crate
whose source and dependency closure haven't changed since the last run: no
`Cargo.lock` change and no changes to `anyharness`/`proliferate-worker`/
`proliferate-supervisor`/their local dependencies should give close to a
full 14-minute skip on cache hit; a partial dependency bump gives a partial
win proportional to what actually changed. Cold cache (the first run after
this merges, or after any `Cargo.lock` change) sees no improvement and pays
a small cache-upload tax on top.

## How/when this can actually be measured

This can only be measured on a real run that reaches this job: the next
nightly release train, a hotfix train with the server surface selected, or a
`server-v*` tag push. Compare the `self-hosted-release-assets` job duration
of that run against the 16:06 baseline (run 32167413474):

```
gh run view <new_run_id> --json jobs \
  --jq '.jobs[] | select(.name | contains("self-hosted-release-assets"))'
```

The first post-merge run is the cold-cache case (expect little to no
improvement, possibly a small regression from the cache-save step); the
following run is the real signal.

## Test plan

- [x] `actionlint .github/workflows/server-ci.yml`
- [x] YAML parses via `yaml.safe_load`
- [ ] `lint`/`test` jobs green on this PR (path-triggered, doesn't exercise
      the changed job)
- [ ] First post-merge train run is the cold-cache case; the run after it
      shows the real saving (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

