### PR TITLE
perf(server-tests): scope DB truncate to DB-using tests

### DIFF
--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -52,18 +52,26 @@ def migrated_test_database():  # type: ignore[no-untyped-def]
 
 @pytest_asyncio.fixture
 async def test_engine(migrated_test_database):  # type: ignore[no-untyped-def]
+    """The migrated test database, truncated clean before and after the test.
+
+    Every route a test has into Postgres runs through this fixture: `db_session`
+    and `client` here, `cloud_client` in `tests/e2e/cloud/conftest.py`, and the
+    per-module app/session fixtures that request one of those. Owning the reset
+    here means the truncate fires exactly for the tests whose fixture closure
+    reaches the database. It used to run from an autouse fixture instead, so all
+    2,973 collected tests paid it; only 1,057 of them ever open a connection, and
+    truncating 79 tables twice around the other 1,916 is pure overhead.
+
+    The reset itself is unchanged: `truncate_all_tables` before the test and
+    again after it, on the same engine, over the same tables in the same order.
+    """
     engine = create_async_engine(TEST_DATABASE_URL, echo=False)
+    await _cancel_test_background_tasks()
+    await truncate_all_tables(engine)
     yield engine
+    await _cancel_test_background_tasks()
+    await truncate_all_tables(engine)
     await engine.dispose()
-
-
-@pytest_asyncio.fixture(autouse=True)
-async def reset_test_database(test_engine) -> AsyncGenerator[None, None]:  # type: ignore[no-untyped-def]
-    await _cancel_test_background_tasks()
-    await truncate_all_tables(test_engine)
-    yield
-    await _cancel_test_background_tasks()
-    await truncate_all_tables(test_engine)
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
## Experiment, not a proposal yet

Draft on purpose. This is a timing experiment: does scoping the server suite's
database truncate to the tests that actually use the database make `server-ci /
test` meaningfully faster without changing a single test outcome? The PR carries
the truncate change and nothing else — no `pytest-xdist`, no lane split, no
`server-ci.yml` edit.

## The cost being removed

`server/tests/conftest.py` declared `reset_test_database` as `autouse=True`, so
`truncate_all_tables` — one `TRUNCATE TABLE … RESTART IDENTITY CASCADE` over all
79 mapped tables — ran twice around every test in the suite:

| | tests |
|---|---|
| collected by the CI invocation | 2,973 |
| whose fixture closure reaches Postgres | 1,057 |
| that never open a connection | **1,916** (1,789 `tests/unit`, 127 `tests/integration`) |

Those 1,916 tests paid 3,832 truncate round-trips for nothing.

## The change

The reset moves into `test_engine`, the one fixture every database route in the
suite passes through:

- `db_session` and `client` (`server/tests/conftest.py`)
- `cloud_client` (`server/tests/e2e/cloud/conftest.py`)
- every per-module app/session fixture, which requests one of the above

pytest resolves the gate for us: the truncate now fires exactly when
`test_engine` appears in a test's fixture closure. That is strictly more
accurate than a hand-maintained fixture-name list, and it cannot drift when
someone adds a new DB fixture.

Behaviour for a DB test is unchanged — `truncate_all_tables` before the test and
again after it, on the same engine, over the same tables in the same order, with
the teardown truncate still running after the test's other fixtures have torn
down and before the engine is disposed.

## Safety audit

Every way a test could reach the shared test database (`proliferate_test_<pid>`)
was enumerated before the change:

- **Fixtures.** There is no `pytest_plugins` registration anywhere under
  `server/tests/`, and no module outside the three conftests defines a fixture.
  The full closure of every collected test was dumped at collection time and
  cross-checked against the classification above.
- **Migration suites.** The `*_migration.py` files and `test_schema_migrations.py`
  build their own throwaway databases through `temporary_database(...)`, which
  the shared truncate never touched anyway.
- **Global-engine access.** Every non-DB test whose source mentions
  `get_async_session`, `async_session_factory`, `engine_module`,
  `TEST_DATABASE_URL` or `db_session` was read individually. All of them either
  install a fake (dependency override, `monkeypatch.setattr`) or repoint the
  global engine at a `temporary_database` URL. None reaches the shared test
  database.

No fixture-less route into the shared database exists.

## Verdict criteria

Two `test` job runs on this branch, compared against each other and against the
`main` baseline of `2972 passed, 1 skipped`. Any test that passes on main and
fails here, or any run-to-run variation, fails the experiment.
