### PR TITLE
ci(server-ci): move migration round-trip tests off the PR path

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -165,7 +165,17 @@ jobs:
       - name: Install dependencies
         run: uv pip install --system -e ".[dev]"
 
-      - name: Run tests
+      # Migration round-trip tests (marker: migration) re-run full alembic
+      # chains and guard deploy-time upgrade/downgrade promises, not PR
+      # correctness. They're ~7% of this job's runtime (20 of the 20 slowest
+      # tests, 16-30s each), so PRs skip them and push-to-main / release
+      # builds (workflow_call) still run the full suite.
+      - name: Run tests (pull request - migration round-trips deferred to push)
+        if: github.event_name == 'pull_request'
+        run: pytest tests/unit tests/integration tests/e2e/cloud/test_e2b_webhooks.py -q --durations=20 -m "not migration"
+
+      - name: Run tests (full suite)
+        if: github.event_name != 'pull_request'
         run: pytest tests/unit tests/integration tests/e2e/cloud/test_e2b_webhooks.py -q --durations=20
 
   docker:

--- a/lints/server/ratchets.toml
+++ b/lints/server/ratchets.toml
@@ -70,8 +70,8 @@ reason = "C-train composition re-lands the C-1 poke coverage adapted org-only; D
 
 [[max_lines]]
 path = "server/tests/integration/test_agent_gateway_migration.py"
-max_lines = 619
-reason = "NEW in D-3: the legacy-enrollment migration proofs (D6) + the org-only grep-gates (D8)"
+max_lines = 621
+reason = "NEW in D-3: the legacy-enrollment migration proofs (D6) + the org-only grep-gates (D8); +2: server-ci migration-marker experiment adds a module-level pytestmark = pytest.mark.migration so this file's round-trips can be deselected on pull_request"
 
 [[max_lines]]
 path = "server/tests/integration/test_agent_gateway_store.py"

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -125,6 +125,7 @@ markers = [
     "cloud_e2e: live cloud lifecycle tests that require real provider credentials",
     "e2b: tests specific to the E2B provider",
     "live_webhook: tests that require a real externally reachable E2B webhook target",
+    "migration: alembic migration round-trip tests that guard deploy-time upgrade/downgrade behavior, not PR correctness",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/server/tests/integration/test_agent_gateway_migration.py
+++ b/server/tests/integration/test_agent_gateway_migration.py
@@ -56,6 +56,8 @@ from proliferate.server.cloud.materialization.materialize.agent_auth import (
 )
 from proliferate.lib.infra.time.wall_clock import utcnow
 
+pytestmark = pytest.mark.migration
+
 # Two harness kinds keep the mint/revoke ledgers legible; the mechanism is
 # per-harness and identical for the full four-kind tuple.
 _HARNESSES = ("claude", "codex")

--- a/server/tests/integration/test_agent_model_snapshot_composed_rekey_migration.py
+++ b/server/tests/integration/test_agent_model_snapshot_composed_rekey_migration.py
@@ -15,12 +15,15 @@ import asyncio
 import uuid
 from datetime import UTC, datetime
 
+import pytest
 from sqlalchemy import inspect, text
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from alembic import command
 from proliferate.db.migrations import build_alembic_config
 from tests.postgres import temporary_database
+
+pytestmark = pytest.mark.migration
 
 _REVISION = "c8d2e5f7a913"
 _DOWN_REVISION = "ab5316095737"

--- a/server/tests/integration/test_agent_model_snapshot_rekey_migration.py
+++ b/server/tests/integration/test_agent_model_snapshot_rekey_migration.py
@@ -18,12 +18,15 @@ import asyncio
 import uuid
 from datetime import UTC, datetime
 
+import pytest
 from sqlalchemy import inspect, text
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from alembic import command
 from proliferate.db.migrations import build_alembic_config
 from tests.postgres import temporary_database
+
+pytestmark = pytest.mark.migration
 
 _REVISION = "b7c1e4d9f082"
 _DOWN_REVISION = "28adf1a9e376"

--- a/server/tests/integration/test_cloud_sandbox_desired_versions_migration.py
+++ b/server/tests/integration/test_cloud_sandbox_desired_versions_migration.py
@@ -13,12 +13,15 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
 from alembic import command
 from sqlalchemy import inspect
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from proliferate.db.migrations import build_alembic_config
 from tests.postgres import run_migrations_async, temporary_database
+
+pytestmark = pytest.mark.migration
 
 _REVISION = "6f545e279264"
 _DOWN_REVISION = "ecffa1106847"

--- a/server/tests/integration/test_cloud_sandbox_last_error_migration.py
+++ b/server/tests/integration/test_cloud_sandbox_last_error_migration.py
@@ -6,12 +6,15 @@ import asyncio
 import uuid
 from datetime import UTC, datetime
 
+import pytest
 from alembic import command
 from sqlalchemy import inspect, text
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from proliferate.db.migrations import build_alembic_config
 from tests.postgres import temporary_database
+
+pytestmark = pytest.mark.migration
 
 _REVISION = "f2c4a6e8b0d1"
 _DOWN_REVISION = "e94a7c1d6b20"

--- a/server/tests/integration/test_cloud_workspace_backing_kind_migration.py
+++ b/server/tests/integration/test_cloud_workspace_backing_kind_migration.py
@@ -30,6 +30,8 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from proliferate.db.migrations import build_alembic_config
 from tests.postgres import run_migrations_async, temporary_database
 
+pytestmark = pytest.mark.migration
+
 _REVISION = "c3a7b8d9e0f1"
 _DOWN_REVISION = "6f545e279264"
 _BRANCH_INDEX = "ux_cloud_workspace_active_repo_environment_branch"

--- a/server/tests/integration/test_cloud_workspace_materialization_migration.py
+++ b/server/tests/integration/test_cloud_workspace_materialization_migration.py
@@ -22,6 +22,7 @@ import asyncio
 import uuid
 from datetime import UTC, datetime, timedelta
 
+import pytest
 from sqlalchemy import inspect, text
 from sqlalchemy.ext.asyncio import create_async_engine
 
@@ -29,6 +30,8 @@ from alembic import command
 from proliferate.db.migrations import build_alembic_config
 from proliferate.server.cloud.workspaces.service import MATERIALIZATION_STALL_SECONDS
 from tests.postgres import temporary_database
+
+pytestmark = pytest.mark.migration
 
 _REVISION = "c705e3784eb4"
 _DOWN_REVISION = "c3a7b8d9e0f1"

--- a/server/tests/integration/test_integration_admission_revocation_migration.py
+++ b/server/tests/integration/test_integration_admission_revocation_migration.py
@@ -12,6 +12,8 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from proliferate.db.migrations import build_alembic_config
 from tests.postgres import temporary_database
 
+pytestmark = pytest.mark.migration
+
 _REVISION = "b32d45e67f89"
 _DOWN_REVISION = "a21c34d56e78"
 

--- a/server/tests/integration/test_integration_lifecycle_schema_migration.py
+++ b/server/tests/integration/test_integration_lifecycle_schema_migration.py
@@ -15,6 +15,8 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from proliferate.db.migrations import build_alembic_config
 from tests.postgres import temporary_database
 
+pytestmark = pytest.mark.migration
+
 _REVISION = "a21c34d56e78"
 _DOWN_REVISION = "e7f1a3c9d20b"
 

--- a/server/tests/integration/test_schema_migrations.py
+++ b/server/tests/integration/test_schema_migrations.py
@@ -16,6 +16,8 @@ from proliferate.main import create_app
 from tests.integration.schema_migration_assertions import assert_current_schema
 from tests.postgres import run_migrations_async, temporary_database
 
+pytestmark = pytest.mark.migration
+
 HEAD_REVISION = get_head_revision()
 
 

--- a/server/tests/integration/test_webhook_event_receipt_pkey_migration.py
+++ b/server/tests/integration/test_webhook_event_receipt_pkey_migration.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
 from alembic import command
 from sqlalchemy import inspect
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -27,6 +28,8 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from proliferate.db.migrations import build_alembic_config
 from proliferate.db.models.base import Base
 from tests.postgres import temporary_database
+
+pytestmark = pytest.mark.migration
 
 _REVISION = "ab5316095737"
 _DOWN_REVISION = "a1c2f4d6b8e0"

--- a/server/tests/integration/test_workflow_managed_execution_migration.py
+++ b/server/tests/integration/test_workflow_managed_execution_migration.py
@@ -13,6 +13,8 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from proliferate.db.migrations import build_alembic_config
 from tests.postgres import temporary_database
 
+pytestmark = pytest.mark.migration
+
 _REVISION = "d816f4895fc5"
 _DOWN_REVISION = "c705e3784eb4"
 


### PR DESCRIPTION
## Summary
- Experiment: move the slow alembic migration round-trip tests off the PR path, keep them on push-to-main, and measure the PR-path delta.
- Adds a `migration` pytest marker (server/pyproject.toml) and applies `pytestmark = pytest.mark.migration` at module level to the 12 migration round-trip test files under `server/tests/integration/` (all `*_migration.py` files plus `test_schema_migrations.py`).
- `.github/workflows/server-ci.yml`'s `test` job is now event-aware: `pull_request` runs `pytest ... -m "not migration"`; `push` (main) and `workflow_call` (release builds) still run the full suite.
- Sibling experiment (truncate overhead) owns `server/tests/conftest.py` and `server/tests/postgres.py` — untouched here.

## Baseline
- server-ci `test` job baseline: 74.7m serial.
- The 20 slowest tests (16-30s each) are all migration round-trips — ~7% of runtime. This is a modest, mechanism-proving experiment, not the big win.

## Local verification (collection only, no tests executed)
```
$ pytest tests/unit tests/integration tests/e2e/cloud/test_e2b_webhooks.py --collect-only -q -m migration
32/2973 tests collected (2941 deselected) in 4.91s

$ pytest tests/unit tests/integration tests/e2e/cloud/test_e2b_webhooks.py --collect-only -q -m "not migration"
2941/2973 tests collected (32 deselected) in 1.03s
```
32 tests carry the `migration` marker across the 12 files.

## Test plan
- [ ] This PR's own `server-ci` run (triggered as `pull_request`) demonstrates the deselect path — compare its `test` job wall time and pytest summary line against the 74.7m baseline.
- [ ] Confirm the full suite still runs unmarked-filtered on `push`/`workflow_call` (code review of the workflow diff; not exercised by this PR's own run since it's a `pull_request` event).
- [ ] Never merge — this is an experiment to measure the PR-path delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)