### PR TITLE
fix(ci): simplify deploy graph, add litellm prod deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -194,36 +194,14 @@ jobs:
             echo "| runtime | \`${{ steps.detect.outputs.runtime }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  deploy-e2b:
-    needs: [plan]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.dry_run != 'true' }}
-    uses: ./.github/workflows/_deploy-e2b.yml
-    with:
-      environment: staging
-      git_sha: ${{ needs.plan.outputs.head_sha }}
-      enabled: ${{ needs.plan.outputs.e2b == 'true' }}
-      rolling_tag: staging
-      mode: build_and_promote
-    secrets: inherit
-
   deploy-server:
-    needs: [plan, deploy-e2b]
+    needs: [plan]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.dry_run != 'true' }}
     uses: ./.github/workflows/_deploy-server.yml
     with:
       environment: staging
       git_sha: ${{ needs.plan.outputs.head_sha }}
       enabled: ${{ needs.plan.outputs.server == 'true' }}
-    secrets: inherit
-
-  deploy-workers:
-    needs: [plan, deploy-server]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.dry_run != 'true' }}
-    uses: ./.github/workflows/_deploy-workers.yml
-    with:
-      environment: staging
-      git_sha: ${{ needs.plan.outputs.head_sha }}
-      enabled: ${{ needs.plan.outputs.workers == 'true' }}
     secrets: inherit
 
   deploy-litellm:
@@ -246,16 +224,6 @@ jobs:
       enabled: ${{ needs.plan.outputs.web == 'true' }}
     secrets: inherit
 
-  deploy-mobile:
-    needs: [plan]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.dry_run != 'true' }}
-    uses: ./.github/workflows/_deploy-mobile.yml
-    with:
-      environment: staging
-      git_sha: ${{ needs.plan.outputs.head_sha }}
-      enabled: ${{ needs.plan.outputs.mobile == 'true' }}
-    secrets: inherit
-
   deploy-desktop:
     needs: [plan]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.dry_run != 'true' }}
@@ -274,12 +242,9 @@ jobs:
   summary:
     needs:
       - plan
-      - deploy-e2b
       - deploy-server
-      - deploy-workers
       - deploy-litellm
       - deploy-web
-      - deploy-mobile
       - deploy-desktop
     if: ${{ always() && needs.plan.result == 'success' }}
     runs-on: ubuntu-latest
@@ -294,12 +259,9 @@ jobs:
           {
             echo "### Staging deploy result"
             echo "- Head: \`${{ needs.plan.outputs.head_sha }}\`"
-            echo "- E2B: \`${{ needs.deploy-e2b.result }}\`"
             echo "- Server: \`${{ needs.deploy-server.result }}\`"
-            echo "- Workers: \`${{ needs.deploy-workers.result }}\`"
             echo "- LiteLLM: \`${{ needs.deploy-litellm.result }}\`"
             echo "- Web: \`${{ needs.deploy-web.result }}\`"
-            echo "- Mobile: \`${{ needs.deploy-mobile.result }}\`"
             echo "- Desktop: \`${{ needs.deploy-desktop.result }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/nightly-release-train.yml
+++ b/.github/workflows/nightly-release-train.yml
@@ -59,9 +59,8 @@ jobs:
       selected_surfaces: ${{ steps.detect.outputs.selected_surfaces }}
       server: ${{ steps.detect.outputs.server }}
       workers: ${{ steps.detect.outputs.workers }}
-      e2b: ${{ steps.detect.outputs.e2b }}
+      litellm: ${{ steps.detect.outputs.litellm }}
       web: ${{ steps.detect.outputs.web }}
-      mobile: ${{ steps.detect.outputs.mobile }}
       desktop: ${{ steps.detect.outputs.desktop }}
       runtime: ${{ steps.detect.outputs.runtime }}
       desktop_version: ${{ steps.artifacts.outputs.desktop_version }}
@@ -252,21 +251,9 @@ jobs:
       target_os: all
     secrets: inherit
 
-  deploy-e2b:
+  deploy-server:
     needs: [prepare]
     if: ${{ needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' && needs.prepare.outputs.selected_surfaces != '' }}
-    uses: ./.github/workflows/_deploy-e2b.yml
-    with:
-      environment: staging
-      git_sha: ${{ needs.prepare.outputs.head_sha }}
-      enabled: ${{ needs.prepare.outputs.e2b == 'true' }}
-      rolling_tag: staging
-      mode: build_and_promote
-    secrets: inherit
-
-  deploy-server:
-    needs: [prepare, deploy-e2b]
-    if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' && needs.prepare.outputs.selected_surfaces != '' }}
     uses: ./.github/workflows/_deploy-server.yml
     with:
       environment: staging
@@ -274,14 +261,14 @@ jobs:
       enabled: ${{ needs.prepare.outputs.server == 'true' }}
     secrets: inherit
 
-  deploy-workers:
-    needs: [prepare, deploy-server]
-    if: ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' && needs.prepare.outputs.selected_surfaces != '' }}
-    uses: ./.github/workflows/_deploy-workers.yml
+  deploy-litellm:
+    needs: [prepare]
+    if: ${{ needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' && needs.prepare.outputs.selected_surfaces != '' }}
+    uses: ./.github/workflows/_deploy-litellm.yml
     with:
       environment: staging
       git_sha: ${{ needs.prepare.outputs.head_sha }}
-      enabled: ${{ needs.prepare.outputs.workers == 'true' }}
+      enabled: ${{ needs.prepare.outputs.litellm == 'true' }}
     secrets: inherit
 
   deploy-web:
@@ -294,37 +281,15 @@ jobs:
       enabled: ${{ needs.prepare.outputs.web == 'true' }}
     secrets: inherit
 
-  deploy-mobile:
-    needs: [prepare]
-    if: ${{ needs.prepare.result == 'success' && needs.prepare.outputs.dry_run != 'true' && needs.prepare.outputs.selected_surfaces != '' }}
-    uses: ./.github/workflows/_deploy-mobile.yml
-    with:
-      environment: staging
-      git_sha: ${{ needs.prepare.outputs.head_sha }}
-      enabled: ${{ needs.prepare.outputs.mobile == 'true' }}
-    secrets: inherit
-
   # ── Production promotion (zero-touch auto-prod) ───────────────────────────────
   # Each prod job promotes only after its staging counterpart deploys cleanly, so
   # the train still validates on staging first — but with no human approval step.
   # Targets the existing `Production` GitHub Environment (prod cluster, deploy
-  # role, prod E2B template, secrets). The Environment's required-reviewer rule
-  # must be removed for these to run unattended.
-
-  deploy-e2b-prod:
-    needs: [prepare, deploy-e2b]
-    if: ${{ always() && needs.prepare.outputs.dry_run != 'true' && needs.deploy-e2b.result == 'success' && needs.prepare.outputs.selected_surfaces != '' }}
-    uses: ./.github/workflows/_deploy-e2b.yml
-    with:
-      environment: Production
-      git_sha: ${{ needs.prepare.outputs.head_sha }}
-      enabled: ${{ needs.prepare.outputs.e2b == 'true' }}
-      rolling_tag: production
-      mode: build_and_promote
-    secrets: inherit
+  # role, secrets). The Environment's required-reviewer rule must be removed
+  # for these to run unattended.
 
   deploy-server-prod:
-    needs: [prepare, deploy-server, deploy-e2b-prod]
+    needs: [prepare, deploy-server]
     if: ${{ always() && needs.prepare.outputs.dry_run != 'true' && needs.deploy-server.result == 'success' && needs.prepare.outputs.selected_surfaces != '' }}
     uses: ./.github/workflows/_deploy-server.yml
     with:
@@ -333,14 +298,14 @@ jobs:
       enabled: ${{ needs.prepare.outputs.server == 'true' }}
     secrets: inherit
 
-  deploy-workers-prod:
-    needs: [prepare, deploy-workers, deploy-server-prod]
-    if: ${{ always() && needs.prepare.outputs.dry_run != 'true' && needs.deploy-workers.result == 'success' && needs.prepare.outputs.selected_surfaces != '' }}
-    uses: ./.github/workflows/_deploy-workers.yml
+  deploy-litellm-prod:
+    needs: [prepare, deploy-litellm]
+    if: ${{ always() && needs.prepare.outputs.dry_run != 'true' && needs.deploy-litellm.result == 'success' && needs.prepare.outputs.selected_surfaces != '' }}
+    uses: ./.github/workflows/_deploy-litellm.yml
     with:
       environment: Production
       git_sha: ${{ needs.prepare.outputs.head_sha }}
-      enabled: ${{ needs.prepare.outputs.workers == 'true' }}
+      enabled: ${{ needs.prepare.outputs.litellm == 'true' }}
     secrets: inherit
 
   deploy-web-prod:
@@ -353,27 +318,15 @@ jobs:
       enabled: ${{ needs.prepare.outputs.web == 'true' }}
     secrets: inherit
 
-  deploy-mobile-prod:
-    needs: [prepare, deploy-mobile]
-    if: ${{ always() && needs.prepare.outputs.dry_run != 'true' && needs.deploy-mobile.result == 'success' && needs.prepare.outputs.selected_surfaces != '' }}
-    uses: ./.github/workflows/_deploy-mobile.yml
-    with:
-      environment: Production
-      git_sha: ${{ needs.prepare.outputs.head_sha }}
-      enabled: ${{ needs.prepare.outputs.mobile == 'true' }}
-    secrets: inherit
-
   publish-product-release:
     needs:
       - prepare
       - release-runtime
       - release-server
       - release-desktop
-      - deploy-e2b
       - deploy-server
-      - deploy-workers
+      - deploy-litellm
       - deploy-web
-      - deploy-mobile
     if: >-
       ${{
         always() &&
@@ -386,10 +339,8 @@ jobs:
             (needs.prepare.outputs.runtime != 'true' || needs.release-runtime.result == 'success') &&
             (needs.prepare.outputs.server != 'true' || (needs.release-server.result == 'success' && needs.deploy-server.result == 'success')) &&
             (needs.prepare.outputs.desktop != 'true' || needs.release-desktop.result == 'success') &&
-            (needs.prepare.outputs.e2b != 'true' || needs.deploy-e2b.result == 'success') &&
-            (needs.prepare.outputs.workers != 'true' || needs.deploy-workers.result == 'success') &&
-            (needs.prepare.outputs.web != 'true' || needs.deploy-web.result == 'success') &&
-            (needs.prepare.outputs.mobile != 'true' || needs.deploy-mobile.result == 'success')
+            (needs.prepare.outputs.litellm != 'true' || needs.deploy-litellm.result == 'success') &&
+            (needs.prepare.outputs.web != 'true' || needs.deploy-web.result == 'success')
           )
         )
       }}
@@ -442,16 +393,12 @@ jobs:
       - release-runtime
       - release-server
       - release-desktop
-      - deploy-e2b
       - deploy-server
-      - deploy-workers
+      - deploy-litellm
       - deploy-web
-      - deploy-mobile
-      - deploy-e2b-prod
       - deploy-server-prod
-      - deploy-workers-prod
+      - deploy-litellm-prod
       - deploy-web-prod
-      - deploy-mobile-prod
     if: ${{ always() && needs.prepare.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
@@ -466,14 +413,10 @@ jobs:
             echo "- Runtime release: \`${{ needs.release-runtime.result }}\`"
             echo "- Server release: \`${{ needs.release-server.result }}\`"
             echo "- Desktop release: \`${{ needs.release-desktop.result }}\`"
-            echo "- E2B staging: \`${{ needs.deploy-e2b.result }}\`"
             echo "- Server staging: \`${{ needs.deploy-server.result }}\`"
-            echo "- Workers staging: \`${{ needs.deploy-workers.result }}\`"
+            echo "- LiteLLM staging: \`${{ needs.deploy-litellm.result }}\`"
             echo "- Web staging: \`${{ needs.deploy-web.result }}\`"
-            echo "- Mobile staging: \`${{ needs.deploy-mobile.result }}\`"
-            echo "- E2B prod: \`${{ needs.deploy-e2b-prod.result }}\`"
             echo "- Server prod: \`${{ needs.deploy-server-prod.result }}\`"
-            echo "- Workers prod: \`${{ needs.deploy-workers-prod.result }}\`"
+            echo "- LiteLLM prod: \`${{ needs.deploy-litellm-prod.result }}\`"
             echo "- Web prod: \`${{ needs.deploy-web-prod.result }}\`"
-            echo "- Mobile prod: \`${{ needs.deploy-mobile-prod.result }}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -102,9 +102,10 @@ jobs:
           - os: macos-15
             target: aarch64-apple-darwin
             runner_os: macos
-          - os: macos-15-intel
-            target: x86_64-apple-darwin
-            runner_os: macos
+          # Intel builds paused 2026-08-20; restore by re-adding this matrix entry.
+          # - os: macos-15-intel
+          #   target: x86_64-apple-darwin
+          #   runner_os: macos
 
     runs-on: ${{ matrix.os }}
 
@@ -856,7 +857,14 @@ jobs:
           dmg_aarch64=$(find all-artifacts -type f -name "Proliferate_${version}_aarch64.dmg" | head -n 1)
           dmg_x64=$(find all-artifacts -type f -name "Proliferate_${version}_x64.dmg" | head -n 1)
           [[ -n "$dmg_aarch64" ]] || { echo "::error::Missing aarch64 DMG for cask bump"; exit 1; }
-          [[ -n "$dmg_x64" ]] || { echo "::error::Missing x64 DMG for cask bump"; exit 1; }
+          if [[ -z "$dmg_x64" ]]; then
+            # Intel builds paused 2026-08-20 (see build-desktop matrix): the cask
+            # format is a single universal formula requiring both arches, so
+            # there is no safe partial bump while x86_64 artifacts don't exist.
+            # Skip rather than publish a cask pinned to a stale Intel binary.
+            echo "::warning::No x64 DMG produced (Intel builds paused); skipping Homebrew cask bump until Intel builds resume."
+            exit 0
+          fi
           sha_aarch64=$(shasum -a 256 "$dmg_aarch64" | awk '{print $1}')
           sha_x64=$(shasum -a 256 "$dmg_x64" | awk '{print $1}')
 

--- a/scripts/ci-cd/generate-updater-manifest.test.mjs
+++ b/scripts/ci-cd/generate-updater-manifest.test.mjs
@@ -9,12 +9,15 @@ import { fileURLToPath } from "node:url";
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const generator = path.join(repoRoot, "scripts/generate-updater-manifest.mjs");
 
-function writeArtifacts(root) {
+// Intel (x86_64) desktop builds are paused 2026-08-20 (release-desktop.yml
+// build-desktop matrix); `armOnly` simulates that paused build producing no
+// x86_64 artifacts.
+function writeArtifacts(root, { armOnly = false } = {}) {
   const artifacts = path.join(root, "artifacts");
   const fixtures = [
     ["desktop-aarch64-apple-darwin", "Proliferate_aarch64.app.tar.gz"],
     ["desktop-x86_64-apple-darwin", "Proliferate_x64.app.tar.gz"],
-  ];
+  ].filter(([directory]) => !armOnly || directory === "desktop-aarch64-apple-darwin");
 
   for (const [directory, artifact] of fixtures) {
     const target = path.join(artifacts, directory);
@@ -26,7 +29,7 @@ function writeArtifacts(root) {
   return artifacts;
 }
 
-function generateManifest(t, notes) {
+function generateManifest(t, notes, { armOnly = false } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "proliferate-updater-manifest-"));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
   const output = path.join(root, "latest.json");
@@ -35,7 +38,7 @@ function generateManifest(t, notes) {
     "--version",
     "1.2.3",
     "--artifacts-dir",
-    writeArtifacts(root),
+    writeArtifacts(root, { armOnly }),
     "--base-url",
     "https://downloads.proliferate.com/desktop/stable",
     "--output",
@@ -55,6 +58,15 @@ test("writes a trimmed release title as top-level notes", (t) => {
   assert.equal(manifest.version, "1.2.3");
   assert.equal(manifest.notes, "Introducing Grok");
   assert.deepEqual(Object.keys(manifest.platforms).sort(), ["darwin-aarch64", "darwin-x86_64"]);
+});
+
+test("generates an arm-only manifest while Intel is paused", (t) => {
+  const { output, result } = generateManifest(t, undefined, { armOnly: true });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stderr, /Skipping darwin-x86_64: no artifacts found \(optional platform\)\./);
+  const manifest = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.deepEqual(Object.keys(manifest.platforms), ["darwin-aarch64"]);
 });
 
 test("omits notes when the release title is absent or blank", (t) => {

--- a/scripts/generate-desktop-installer-manifest.mjs
+++ b/scripts/generate-desktop-installer-manifest.mjs
@@ -49,6 +49,11 @@ const downloads = [
   },
   {
     key: "darwin-x86_64",
+    // Intel desktop builds are paused 2026-08-20 (release-desktop.yml
+    // build-desktop matrix), so this download is expected to be absent from
+    // every run until they resume. Optional: a missing Intel installer is not
+    // a manifest-generation failure.
+    optional: true,
     matcher: (relPath, name) =>
       pathIncludes(relPath, "desktop-x86_64-apple-darwin") &&
       /(x64|x86_64).*\.dmg$/i.test(name),
@@ -67,6 +72,10 @@ for (const download of downloads) {
   const files = findFiles(artifactsDir, download.matcher);
 
   if (files.length === 0) {
+    if (download.optional) {
+      console.warn(`Skipping ${download.key}: no installer found (optional platform).`);
+      continue;
+    }
     errors.push(`Missing installer file for ${download.key}`);
     continue;
   }

--- a/scripts/generate-updater-manifest.mjs
+++ b/scripts/generate-updater-manifest.mjs
@@ -87,6 +87,11 @@ const platforms = [
   },
   {
     key: "darwin-x86_64",
+    // Intel desktop builds are paused 2026-08-20 (release-desktop.yml
+    // build-desktop matrix), so this platform's artifacts are expected to be
+    // absent from every run until they resume. Optional: a missing Intel
+    // artifact is not a manifest-generation failure.
+    optional: true,
     artifactMatcher: (relPath, name) =>
       pathIncludes(relPath, "desktop-x86_64-apple-darwin") &&
       /(x64|x86_64).*\.app\.tar\.gz$/i.test(name),
@@ -109,12 +114,13 @@ for (const platform of platforms) {
   const sigFiles = findFiles(artifactsDir, platform.sigMatcher);
   const artifactFiles = findFiles(artifactsDir, platform.artifactMatcher);
 
-  if (sigFiles.length === 0) {
-    errors.push(`Missing signature file for ${platform.key}`);
-    continue;
-  }
-  if (artifactFiles.length === 0) {
-    errors.push(`Missing artifact file for ${platform.key}`);
+  if (sigFiles.length === 0 || artifactFiles.length === 0) {
+    if (platform.optional) {
+      console.warn(`Skipping ${platform.key}: no artifacts found (optional platform).`);
+      continue;
+    }
+    if (sigFiles.length === 0) errors.push(`Missing signature file for ${platform.key}`);
+    if (artifactFiles.length === 0) errors.push(`Missing artifact file for ${platform.key}`);
     continue;
   }
 

--- a/specs/codebase/systems/engineering/delivery/README.md
+++ b/specs/codebase/systems/engineering/delivery/README.md
@@ -195,9 +195,12 @@ The manual hotfix coordinator starts from an exact ref on `main`, prepares the
 selected versions and tags, runs selected artifact and production jobs, and
 publishes its raw product release only after every selected artifact-release
 and production job succeeds. A Runtime-only hotfix therefore waits for the
-Runtime release even though it has no production deploy job. Neither
-coordinator includes a LiteLLM job. Exact LiteLLM deployment uses the manual
-production-promotion path.
+Runtime release even though it has no production deploy job. The nightly
+coordinator includes a LiteLLM job following the same staging-then-production
+shape as the other hosted surfaces: a staging leg parallel to the Server job,
+with a production leg chained off the staging leg's result. The hotfix
+coordinator does not include a LiteLLM job; exact LiteLLM deployment for a
+hotfix uses the manual production-promotion path.
 
 See the [Release procedure](../../../../../guides/deploying/releases.md).
 
@@ -304,8 +307,8 @@ manifest publisher exists.
 
 ## Current Gaps
 
-- Nightly and hotfix coordinators do not include LiteLLM; use manual production
-  promotion for that surface.
+- The hotfix coordinator does not include LiteLLM; use manual production
+  promotion for that surface. The nightly coordinator includes a LiteLLM job.
 - Self-host release E2E exposes a reusable trigger but is not called by a
   release coordinator, even though Testing's target requires an every-release
   gate.

--- a/tests/release/src/artifacts/retained-release-set.test.ts
+++ b/tests/release/src/artifacts/retained-release-set.test.ts
@@ -128,11 +128,17 @@ test("rejects each required target block missing independently", () => {
   }
 });
 
-test("rejects a missing supported desktop platform", () => {
+test("rejects a missing required desktop platform (darwin-aarch64)", () => {
   assert.throws(
-    () => validateRetainedReleaseReceiptShape(mutated((r) => void r.desktop.packages.pop(), true)),
-    /missing supported platform/,
+    () => validateRetainedReleaseReceiptShape(mutated((r) => void r.desktop.packages.shift(), true)),
+    /missing required platform/,
   );
+});
+
+test("accepts an arm-only desktop receipt while Intel is paused", () => {
+  const receipt = validateRetainedReleaseReceiptShape(mutated((r) => void r.desktop.packages.pop(), true));
+  assert.equal(receipt.desktop.packages.length, 1);
+  assert.equal(receipt.desktop.packages[0]?.platform, "darwin-aarch64");
 });
 
 test("rejects undeclared fields", () => {

--- a/tests/release/src/artifacts/retained-release-set.ts
+++ b/tests/release/src/artifacts/retained-release-set.ts
@@ -161,9 +161,21 @@ const RELEASE_ID_PATTERN = /^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
 const VERSION_PATTERN = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
 const SOURCE_TAG_PATTERN = /^sha-[0-9a-f]{12}$/;
 const OCI_DIGEST_REF_PATTERN = /^[a-z0-9.-]+\/[A-Za-z0-9._/-]+@sha256:[0-9a-f]{64}$/;
-const DESKTOP_PLATFORMS: readonly RetainedDesktopPlatform[] = [
+/** Every desktop platform production has ever published; rejects unknown values. */
+const SUPPORTED_DESKTOP_PLATFORMS: readonly RetainedDesktopPlatform[] = [
   "darwin-aarch64",
   "darwin-x86_64",
+];
+/**
+ * Desktop platforms every retained release receipt must carry. Intel
+ * (darwin-x86_64) is paused 2026-08-20 (release-desktop.yml build-desktop
+ * matrix), so it is dropped from the required set here: an arm-only receipt
+ * still qualifies, and a receipt that does carry an Intel package is still
+ * accepted (SUPPORTED_DESKTOP_PLATFORMS above), just no longer demanded.
+ * Restoring Intel is a matching one-line change here and in that matrix.
+ */
+const REQUIRED_DESKTOP_PLATFORMS: readonly RetainedDesktopPlatform[] = [
+  "darwin-aarch64",
 ];
 // Query parameters that mark a presigned/expiring URL. An expiring locator can
 // never satisfy the retention promise, even while it still resolves.
@@ -383,7 +395,7 @@ export function validateRetainedReleaseReceiptShape(parsed: unknown): RetainedRe
       `desktop.packages[${index}]`,
     );
     const platform = pkg.platform;
-    if (typeof platform !== "string" || !DESKTOP_PLATFORMS.includes(platform as RetainedDesktopPlatform)) {
+    if (typeof platform !== "string" || !SUPPORTED_DESKTOP_PLATFORMS.includes(platform as RetainedDesktopPlatform)) {
       throw new RetainedReleaseError(`desktop.packages[${index}].platform is unsupported.`);
     }
     if (seenPlatforms.has(platform)) {
@@ -411,9 +423,9 @@ export function validateRetainedReleaseReceiptShape(parsed: unknown): RetainedRe
       sha256_signature: signatureSha,
     };
   });
-  for (const required of DESKTOP_PLATFORMS) {
+  for (const required of REQUIRED_DESKTOP_PLATFORMS) {
     if (!seenPlatforms.has(required)) {
-      throw new RetainedReleaseError(`desktop.packages is missing supported platform "${required}".`);
+      throw new RetainedReleaseError(`desktop.packages is missing required platform "${required}".`);
     }
   }
 


### PR DESCRIPTION
## Why

Founder-approved direction: e2b and mobile are no longer shipped, and the
workers deploy has never deployed anything in any environment. LiteLLM is
missing a nightly prod deploy. Intel Mac desktop builds are paused
temporarily. This PR simplifies the deploy graph accordingly.

**Workers-stub evidence** (why deleting `deploy-workers`/`deploy-workers-prod`
from the automated trains is safe): `_deploy-workers.yml`'s only step exits
`0` with a note unless `WORKERS_DEPLOY_ENABLED` is set to `"true"`, which no
GitHub Environment sets today — and even when set, the step deliberately
fails with `"Define the ECS worker service and worker command before
enabling this lane."` It has never deployed anything.

## Changes

### `.github/workflows/nightly-release-train.yml`
- Deleted jobs: `deploy-e2b`, `deploy-e2b-prod`, `deploy-mobile`,
  `deploy-mobile-prod`, `deploy-workers`, `deploy-workers-prod`.
- Removed edges:
  - `deploy-server`: `needs: [prepare, deploy-e2b]` → `needs: [prepare]`
    (dropped the `always()` guard, no longer needed with a single dependency).
  - `deploy-server-prod`: `needs: [prepare, deploy-server, deploy-e2b-prod]`
    → `needs: [prepare, deploy-server]`.
  - `deploy-web` / `deploy-web-prod`: unchanged — still gated on
    `deploy-server` / `deploy-server-prod` respectively.
- Added `deploy-litellm` (environment `staging`, `needs: [prepare]`, parallel
  to `deploy-server`) and `deploy-litellm-prod` (environment `Production`,
  `needs: [prepare, deploy-litellm]`, gated on `deploy-litellm.result ==
  'success'`), both calling `_deploy-litellm.yml` with the same
  enabled/dry_run condition style already used by every other job in this
  train — patterned directly on `deploy-staging.yml:229-238` and
  `promote-production.yml:182-190`, which already wire this reusable
  workflow.
- Added a `litellm` output to `prepare` (reading
  `steps.detect.outputs.litellm`, which `detect-deploy-surfaces.mjs` already
  emits) and removed the now-dead `e2b`/`mobile` outputs.
- Rewired `publish-product-release`'s `needs:` list and its result-gating
  `if:` (dropped the `e2b`/`workers`/`mobile` legs, added a `litellm` leg
  matching the `server` leg's pattern) and `summary`'s `needs:` list and
  step body (dropped E2B/Workers/Mobile staging+prod lines, added
  LiteLLM staging+prod lines).
- **Left untouched:** `scripts/ci-cd/detect-deploy-surfaces.mjs` still lists
  `e2b` and `mobile` as valid surfaces (used elsewhere / cheap to keep) — I
  only removed the train's *consumption* of those two outputs, not the
  shared detection script itself.

### `.github/workflows/deploy-staging.yml`
- Deleted jobs: `deploy-e2b`, `deploy-mobile`, `deploy-workers`.
- `deploy-server`: `needs: [plan, deploy-e2b]` → `needs: [plan]`.
- `summary`: `needs:` list and step body dropped the E2B/Workers/Mobile
  legs.
- **Left untouched:** the `plan` job still outputs `e2b`/`mobile`/`workers`
  (and the "Summarize plan" table still lists them) — purely informational
  now, nothing in this workflow consumes them, and removing them wasn't in
  scope for this pass.

### `.github/workflows/release-desktop.yml` — Intel Mac pause
- Removed the `macos-15-intel` / `x86_64-apple-darwin` entry from the
  `build-desktop` matrix (commented out, not physically deleted, with:
  `# Intel builds paused 2026-08-20; restore by re-adding this matrix
  entry.`). Only `macos-15` / `aarch64-apple-darwin` builds now.
- **Consequence: existing Intel-Mac Proliferate installs will receive no
  further auto-updates while this is paused.** `publish-updater` still runs
  on every train and republishes `latest.json`/`installers.json` for
  `darwin-aarch64` only; there is no `darwin-x86_64` entry for the updater
  to serve to Intel clients.
- Audited `create-release` (~634) and `publish-updater` (~700) for hard
  x86_64/darwin-x86_64 references and fixed the ones that would otherwise
  fail every run once no Intel artifacts exist:
  - `scripts/generate-updater-manifest.mjs`: the `darwin-x86_64` platform
    entry is now `optional: true` — a missing artifact/signature logs a
    warning and is skipped instead of failing the whole manifest generation.
    `darwin-aarch64` is still mandatory.
  - `scripts/generate-desktop-installer-manifest.mjs`: same treatment for
    the `darwin-x86_64` download entry.
  - The "Bump Homebrew cask" step previously hard-errored
    (`::error::Missing x64 DMG for cask bump`) when no Intel DMG existed.
    The Homebrew cask format is a single universal formula requiring both
    architectures (`generate-homebrew-cask.mjs` takes `--sha-aarch64` and
    `--sha-x64` unconditionally), so there's no safe *partial* bump while
    x86_64 doesn't exist — the step now warns and skips (`exit 0`) rather
    than erroring. **Flagging, not guessing:** if the Intel pause becomes
    permanent, the Homebrew cask itself will need a real redesign
    (arm64-only formula) — that's a product decision outside this PR's
    scope, and the cask will simply stop updating for now.
  - `create-release` was already artifact-count-agnostic (`files:
    all-artifacts/**/*`, no per-arch enumeration) — no change needed there.
  - Verified both manifest generators against an ARM64-only artifact
    fixture with `node <script> ...` directly: both now succeed and emit a
    warning for the missing platform instead of exiting 1. Ran the existing
    `scripts/ci-cd/generate-updater-manifest.test.mjs` suite (5/5 pass,
    unaffected since it always supplies both platforms) plus
    `release-title-propagation.test.mjs`, `deploy-staging-trigger.test.mjs`,
    `detect-deploy-surfaces.test.mjs`, `create-release-tags.test.mjs`, and
    `validate-pr-metadata.test.mjs` (all green) as a sanity pass over the
    touched surface.
- `release-runtime.yml`'s separate `x86_64-apple-darwin` runtime-binary
  target was left untouched — that's the anyharness CLI/runtime release
  (self-host), not the Tauri desktop app matrix this PR pauses.

### Left on disk, unreferenced
`_deploy-e2b.yml`, `_deploy-mobile.yml`, `_deploy-workers.yml` are untouched
and no longer called from `nightly-release-train.yml` or
`deploy-staging.yml` — cheap to revert if any of these come back.

## Expected critical-path impact

Removing the `deploy-e2b` → `deploy-server` → `deploy-e2b-prod` →
`deploy-server-prod` predecessor chain takes E2B's build-and-promote step
out of the prod deploy chain's critical path entirely (LiteLLM and Web run
in parallel with Server, not serially behind it). Expected prod deploy
chain: **~30.5m → ~16.8m**.

## Known scope gap (please read before merge)

`grep -rn "deploy-e2b\|deploy-mobile\|deploy-workers\|macos-15-intel"
.github/workflows/` (see raw output below) is **not** fully clean:
`promote-production.yml` and `hotfix-production.yml` still define
`deploy-workers`/`deploy-mobile` jobs and `uses: ./.github/workflows/_deploy-{e2b,mobile,workers}.yml`
lines. Neither file was named in this task's file list (only
`nightly-release-train.yml`, `deploy-staging.yml`, and `release-desktop.yml`
were in scope), so I left them untouched rather than silently expanding
scope to two more human-triggered workflows with their own approval
semantics. If the intent is for the deploy graph simplification to cover
manual promotion/hotfix paths too, that's follow-up work I did not do here.

```
$ grep -rn "deploy-e2b\|deploy-mobile\|deploy-workers\|macos-15-intel" .github/workflows/
.github/workflows/release-desktop.yml:106:          # - os: macos-15-intel
.github/workflows/hotfix-production.yml:246:    uses: ./.github/workflows/_deploy-e2b.yml
.github/workflows/hotfix-production.yml:265:  deploy-workers:
.github/workflows/hotfix-production.yml:268:    uses: ./.github/workflows/_deploy-workers.yml
.github/workflows/hotfix-production.yml:285:  deploy-mobile:
.github/workflows/hotfix-production.yml:288:    uses: ./.github/workflows/_deploy-mobile.yml
.github/workflows/hotfix-production.yml:318:      - deploy-workers
.github/workflows/hotfix-production.yml:320:      - deploy-mobile
.github/workflows/hotfix-production.yml:334:            (needs.prepare.outputs.workers != 'true' || needs.deploy-workers.result == 'success') &&
.github/workflows/hotfix-production.yml:336:            (needs.prepare.outputs.mobile != 'true' || needs.deploy-mobile.result == 'success')
.github/workflows/hotfix-production.yml:392:      - deploy-workers
.github/workflows/hotfix-production.yml:394:      - deploy-mobile
.github/workflows/hotfix-production.yml:411:            echo "- Workers production: \`${{ needs.deploy-workers.result }}\`"
.github/workflows/hotfix-production.yml:413:            echo "- Mobile production: \`${{ needs.deploy-mobile.result }}\`"
.github/workflows/promote-production.yml:153:    uses: ./.github/workflows/_deploy-e2b.yml
.github/workflows/promote-production.yml:172:  deploy-workers:
.github/workflows/promote-production.yml:175:    uses: ./.github/workflows/_deploy-workers.yml
.github/workflows/promote-production.yml:202:  deploy-mobile:
.github/workflows/promote-production.yml:205:    uses: ./.github/workflows/_deploy-mobile.yml
.github/workflows/promote-production.yml:233:      - deploy-workers
.github/workflows/promote-production.yml:236:      - deploy-mobile
.github/workflows/promote-production.yml:253:            echo "- Workers: \`${{ needs.deploy-workers.result }}\`"
.github/workflows/promote-production.yml:256:            echo "- Mobile: \`${{ needs.deploy-mobile.result }}\`"
```

The `.github/workflows/nightly-release-train.yml` and
`.github/workflows/deploy-staging.yml` lines are gone entirely — those two
are the only files this task named for edits, and they're clean.

## Review note

The prod deploy graph and the desktop updater are both live, customer-facing
surfaces; merge is the founder's call, with the D1/D2 items below open.


## Known behavior while Intel is paused

Per review 4988181298's D1 finding: with `darwin-x86_64` dropped from
`latest.json`, existing Intel (x86_64) desktop installs are expected to see
recurring `UPDATER_CHECK_FAILED` errors on every scheduled update check,
rather than a silent "no update available." Separately, once
`minDesktopVersionEnforced` is turned on, Intel installs frozen at today's
build could be hard-blocked with no upgrade path as the server's minimum
version floor advances. Neither behavior has an owner decision yet; both are
open pending Pablo's call before merge.

