### PR TITLE
perf(server-tests): truncate before tests only

### DIFF
--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -59,11 +59,15 @@ async def test_engine(migrated_test_database):  # type: ignore[no-untyped-def]
 
 @pytest_asyncio.fixture(autouse=True)
 async def reset_test_database(test_engine) -> AsyncGenerator[None, None]:  # type: ignore[no-untyped-def]
+    # Truncating only before each test (not after) is sufficient for isolation:
+    # every test already starts from a clean slate via this same call. The
+    # after-test truncate only left the DB clean at process exit, which the
+    # CI job never reads (the Postgres service container is torn down with
+    # the runner, and the session-scoped `migrated_test_database` fixture
+    # drops the whole database unconditionally regardless of its contents).
     await _cancel_test_background_tasks()
     await truncate_all_tables(test_engine)
     yield
-    await _cancel_test_background_tasks()
-    await truncate_all_tables(test_engine)
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
## Summary

CI experiment (see sibling experiments `exp/server-truncate-scope` and `exp/server-xdist` for related, non-overlapping angles on server-ci runtime).

The autouse `reset_test_database` fixture in `server/tests/conftest.py` truncates all 78 tables both before and after every test — roughly 5,944 `TRUNCATE ... RESTART IDENTITY CASCADE` round-trips across the 2,972-test suite. This drops the after-test truncate and keeps only the before-test truncate.

## Reasoning

- Every test already truncates before it runs (`reset_test_database` setup), so the after-test truncate is redundant for isolation — the next test's own setup truncate makes the DB clean regardless.
- The after-truncate's only remaining value would be leaving the DB clean at process/session end. Nothing in `server-ci` depends on that:
  - The `test` job runs `pytest tests/unit tests/integration tests/e2e/cloud/test_e2b_webhooks.py -q --durations=20` with no xdist, no pytest-randomly/order plugin, and no custom session-finish reporting hook that reads DB state.
  - `tests/integration/conftest.py` and `tests/e2e/cloud/conftest.py` do not do their own truncation or read DB state independently — they ride the same root autouse fixture.
  - The session-scoped `migrated_test_database` fixture tears down via `drop_database()`, which does a hard `DROP DATABASE IF EXISTS ...` regardless of table contents — it doesn't care whether the DB was truncated first.
  - The Postgres service container itself is destroyed with the GitHub Actions runner at job end.

## Test plan

- [ ] Let `server-ci` run the full suite once on this PR.
- [ ] Compare `test` job wall time against the current baseline (~74.7m).
- [ ] Confirm pass/fail set matches main's baseline (2972 passed, 1 skipped) — no test should newly fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)