### PR TITLE
ci(cargo): combine sccache and nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,20 @@ jobs:
   cargo-check:
     name: Cargo check & test
     runs-on: ubuntu-latest
+    # EXPERIMENT (exp/rust-sccache-nextest, base ci/cargo-cache-and-dedupe):
+    # combine two independently-measured wins on this job. sccache targets
+    # the workspace-crate compile phase (Swatinem/rust-cache deliberately
+    # discards workspace-crate build artifacts, so unchanged crates still
+    # recompile on every PR; sccache keyed by rustc invocation inputs can hit
+    # for those even when the target-dir cache does not carry them forward).
+    # CARGO_INCREMENTAL=0 is required: incremental compilation defeats
+    # sccache's ability to reuse cached object output. nextest targets the
+    # test execution phase. The two wins are on different phases and should
+    # partially compose.
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -263,16 +277,23 @@ jobs:
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+
       - uses: Swatinem/rust-cache@v2
 
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
       - name: Cargo test
-        run: cargo test --workspace
+        run: cargo nextest run --workspace
 
       # The workspace run above builds this package with default features, so
       # the internal-only export path and its dogfood proof would never be
       # evaluated without this step.
       - name: Cargo test internal diagnostics export
-        run: cargo test -p proliferate-diagnostics-collector --features internal-dogfood-export
+        run: cargo nextest run -p proliferate-diagnostics-collector --features internal-dogfood-export
 
   sdk-build:
     name: Build SDK


### PR DESCRIPTION
## Summary

Experiment combining two independently-measured wins on the `cargo-check` job, each benchmarked against the 7m24s warm baseline of #2113 (branch `ci/cargo-cache-and-dedupe`):

- `exp/rust-nextest` (#2118): swap `cargo test` for `cargo nextest run` → 5m57s warm; win is on test execution (-111s on the test step).
- `exp/rust-sccache` (#2116): `mozilla-actions/sccache-action` + `RUSTC_WRAPPER=sccache` + `CARGO_INCREMENTAL=0` alongside `Swatinem/rust-cache` → 5m58s warm; win is on workspace-crate compile.

These target different phases (compile vs. test execution) and should partially compose. This branch applies both changes verbatim as implemented on their respective branches, based on `ci/cargo-cache-and-dedupe`.

## Expected sequence

- First run is expected to be double-cold (new env key invalidates the rust-cache key, and the sccache cache starts empty) — roughly 11m class, not representative.
- A rerun of the `cargo-check` job on the same commit gives the true warm number, to compare against 7m24s / 5m57s / 5m58s.

## Test plan

- [ ] First CI run completes (expected double-cold, ~11m class)
- [ ] Rerun `cargo-check` job for warm number
- [ ] Compare warm total + per-step durations vs baseline/nextest-only/sccache-only
- [ ] Confirm nextest summary counts match expected (3137 run + 8 skipped main, 59 diag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)