### PR TITLE
ci(server): split unit and integration test lanes

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -166,7 +166,7 @@ jobs:
         run: uv pip install --system -e ".[dev]"
 
       - name: Run tests
-        run: pytest tests/unit tests/integration tests/e2e/cloud/test_e2b_webhooks.py -q --durations=20
+        run: pytest tests/unit tests/integration tests/e2e/cloud/test_e2b_webhooks.py -n 4 -q --durations=20
 
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -165,6 +165,30 @@ jobs:
       - name: Install dependencies
         run: uv pip install --system -e ".[dev]"
 
+      # Four workers means four concurrent 78-table TRUNCATEs and four
+      # concurrent full alembic upgrades, each holding an AccessExclusiveLock on
+      # every table, index, and sequence it touches. Postgres sizes its shared
+      # lock table at max_locks_per_transaction * max_connections, and the
+      # 64 * 100 default overflows with "out of shared memory". This GUC is
+      # postmaster-level, and service containers take no command line, so it has
+      # to be written to postgresql.auto.conf and the container bounced.
+      - name: Raise the Postgres lock table for parallel workers
+        run: |
+          set -euo pipefail
+          container="$(docker ps --filter 'ancestor=postgres:16-alpine' --format '{{.ID}}' | head -1)"
+          test -n "$container"
+          docker exec "$container" psql -U proliferate -d proliferate \
+            -c 'ALTER SYSTEM SET max_locks_per_transaction = 1024;'
+          docker restart "$container"
+          for _ in $(seq 1 60); do
+            if docker exec "$container" pg_isready -U proliferate -d proliferate >/dev/null 2>&1; then
+              break
+            fi
+            sleep 1
+          done
+          docker exec "$container" psql -U proliferate -d proliferate \
+            -c 'SHOW max_locks_per_transaction;'
+
       - name: Run tests
         run: pytest tests/unit tests/integration tests/e2e/cloud/test_e2b_webhooks.py -n 4 -q --durations=20
 

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -109,7 +109,78 @@ jobs:
           uv run --python 3.12 --frozen --extra dev python scripts/check_mypy_baseline.py
           --github-event-base
 
-  test:
+  # tests/unit is not actually free of live-infra dependencies: 113 test
+  # functions across 20 files resolve the test_engine/db_session/client/
+  # single_org_client fixtures (tests/conftest.py, tests/unit/test_first_run_claim.py:64,
+  # tests/unit/test_registration_page.py:54, tests/unit/test_self_registration.py:53, etc.)
+  # which open a real Postgres connection, and
+  # tests/unit/test_redis_lock.py:108 and :138 exercise a live Redis over
+  # settings.redbeat_redis_url. Moving those ~115 tests out of tests/unit or
+  # reworking the fixtures to fake the backends would be well past a minimal
+  # conftest change, so this lane keeps the service containers as the
+  # documented fallback (see PR body) -- only the xdist fan-out and the
+  # lock-table bump are dropped, since a serial, single-connection run never
+  # needs them.
+  test-unit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      DATABASE_URL: postgresql+asyncpg://proliferate:localdev@127.0.0.1:5432/proliferate
+      JWT_SECRET: test-jwt-secret
+      CLOUD_SECRET_KEY: test-cloud-secret
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: proliferate
+          POSTGRES_PASSWORD: localdev
+          POSTGRES_DB: proliferate
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U proliferate -d proliferate"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.git_sha || github.ref }}
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+      - uses: astral-sh/setup-uv@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: .
+
+      - name: Build artifact runtime
+        run: pnpm -C server/artifact-runtime build
+        working-directory: .
+
+      - name: Install dependencies
+        run: uv pip install --system -e ".[dev]"
+
+      - name: Run unit tests
+        run: pytest tests/unit -q --durations=20
+
+  test-integration:
     runs-on: ubuntu-latest
     timeout-minutes: 75
     env:
@@ -189,12 +260,12 @@ jobs:
           docker exec "$container" psql -U proliferate -d proliferate \
             -c 'SHOW max_locks_per_transaction;'
 
-      - name: Run tests
-        run: pytest tests/unit tests/integration tests/e2e/cloud/test_e2b_webhooks.py -n 4 -q --durations=20
+      - name: Run integration tests
+        run: pytest tests/integration tests/e2e/cloud/test_e2b_webhooks.py -n 4 -q --durations=20
 
   docker:
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [lint, test-unit, test-integration]
     # Reusable-workflow calls inherit the caller's event name (never
     # "workflow_call"), so this leg is driven by inputs.publish/dry_run instead.
     # inputs.* are empty on plain push/PR events, so the comparisons stay false
@@ -294,7 +365,7 @@ jobs:
 
   self-hosted-release-assets:
     runs-on: ubuntu-latest
-    needs: [lint, test, docker]
+    needs: [lint, test-unit, test-integration, docker]
     # Same input-driven gate as the docker job (see note above): a server-v tag
     # push, or an explicit publish call from a release train / hotfix workflow.
     if: (startsWith(github.ref, 'refs/tags/server-v')) || (inputs.publish == true && inputs.dry_run != true)

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
 dev = [
     "pytest>=9.1.1",
     "pytest-asyncio>=1.4.0",
+    "pytest-xdist>=3.8.0",
     "httpx==0.28.1",
     "mypy==1.20.2",
     "ruff>=0.16.2",

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -52,18 +52,33 @@ def migrated_test_database():  # type: ignore[no-untyped-def]
 
 @pytest_asyncio.fixture
 async def test_engine(migrated_test_database):  # type: ignore[no-untyped-def]
+    """The one door to the test database -- and therefore the reset boundary.
+
+    The truncate used to live in an autouse ``reset_test_database`` fixture, so
+    all 2,900+ tests paid a 78-table TRUNCATE (twice) plus the session-scoped
+    alembic migration, including the large majority that never touch Postgres.
+    Hanging it off ``test_engine`` scopes the reset to exactly the tests that
+    reach the database, because every database path in the suite -- ``client``,
+    ``db_session``, ``cloud_client``, and every per-module session factory --
+    resolves through this fixture.
+
+    Fixture ordering is unchanged: the pre-test truncate still runs before any
+    fixture that depends on ``test_engine`` can seed rows, and the post-test
+    truncate still runs after those fixtures tear down, because teardown is the
+    reverse of setup and this fixture is the first of the chain to be set up.
+
+    Tests that build their own throwaway database (``temporary_database``) are
+    self-isolating and correctly opt out of the shared-database reset.
+    """
     engine = create_async_engine(TEST_DATABASE_URL, echo=False)
-    yield engine
-    await engine.dispose()
-
-
-@pytest_asyncio.fixture(autouse=True)
-async def reset_test_database(test_engine) -> AsyncGenerator[None, None]:  # type: ignore[no-untyped-def]
     await _cancel_test_background_tasks()
-    await truncate_all_tables(test_engine)
-    yield
-    await _cancel_test_background_tasks()
-    await truncate_all_tables(test_engine)
+    await truncate_all_tables(engine)
+    try:
+        yield engine
+    finally:
+        await _cancel_test_background_tasks()
+        await truncate_all_tables(engine)
+        await engine.dispose()
 
 
 @pytest_asyncio.fixture

--- a/server/tests/postgres.py
+++ b/server/tests/postgres.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from alembic import command
@@ -23,10 +24,36 @@ POSTGRES_USER = "proliferate"
 POSTGRES_PASSWORD = "localdev"
 POSTGRES_HOST = "127.0.0.1"
 POSTGRES_PORT = 5432
-TEST_DATABASE_NAME = os.environ.get(
-    "PROLIFERATE_TEST_DATABASE_NAME",
-    f"proliferate_test_{os.getpid()}",
-)
+
+# pytest-xdist runs every worker as its own OS process and exports the worker id
+# ("gw0", "gw1", ...) into that process's environment before pytest imports any
+# test module, so reading it at import time is safe. Naming the database after
+# the worker is what makes the rest of the harness per-worker for free: the
+# session-scoped ``migrated_test_database`` fixture is session-scoped *per
+# process*, so each worker migrates and later drops only the database it owns,
+# and the per-test TRUNCATE can never reach another worker's rows.
+#
+# A serial run (no ``-n``) sees an empty worker id and keeps the historical
+# per-pid name byte-for-byte.
+XDIST_WORKER = os.environ.get("PYTEST_XDIST_WORKER", "")
+
+
+def _default_test_database_name() -> str:
+    if XDIST_WORKER:
+        return f"proliferate_test_{XDIST_WORKER}_{os.getpid()}"
+    return f"proliferate_test_{os.getpid()}"
+
+
+def _resolve_test_database_name() -> str:
+    explicit = os.environ.get("PROLIFERATE_TEST_DATABASE_NAME")
+    if explicit is None:
+        return _default_test_database_name()
+    # An explicit override names one database. Under xdist it still has to fan
+    # out, or the workers would truncate each other's rows mid-test.
+    return f"{explicit}_{XDIST_WORKER}" if XDIST_WORKER else explicit
+
+
+TEST_DATABASE_NAME = _resolve_test_database_name()
 ADMIN_DATABASE_URL = (
     f"postgresql+asyncpg://{POSTGRES_USER}:{POSTGRES_PASSWORD}@"
     f"{POSTGRES_HOST}:{POSTGRES_PORT}/postgres"
@@ -35,6 +62,15 @@ TEST_DATABASE_URL = (
     f"postgresql+asyncpg://{POSTGRES_USER}:{POSTGRES_PASSWORD}@"
     f"{POSTGRES_HOST}:{POSTGRES_PORT}/{TEST_DATABASE_NAME}"
 )
+
+# CREATE DATABASE / DROP DATABASE take a lock on the template database, so
+# concurrent creates from different xdist workers (or from ``temporary_database``
+# inside a test) can lose that race with 55006 "is being accessed by other
+# users" even though the database *names* never collide. 42P04/23505 mean
+# someone else already created the name, which is the outcome we wanted anyway.
+_DATABASE_EXISTS_SQLSTATES = frozenset({"42P04", "23505"})
+_DATABASE_BUSY_SQLSTATES = frozenset({"55006"})
+_DATABASE_LIFECYCLE_ATTEMPTS = 12
 
 
 def make_database_url(database_name: str) -> str:
@@ -48,16 +84,39 @@ def _quote_identifier(identifier: str) -> str:
     return '"' + identifier.replace('"', '""') + '"'
 
 
+def _sqlstate(error: BaseException) -> str | None:
+    for candidate in (getattr(error, "orig", None), error):
+        for attribute in ("sqlstate", "pgcode"):
+            code = getattr(candidate, attribute, None)
+            if isinstance(code, str):
+                return code
+    return None
+
+
 async def ensure_database_exists(database_name: str) -> None:
     admin_engine = create_async_engine(ADMIN_DATABASE_URL, isolation_level="AUTOCOMMIT")
     try:
-        async with admin_engine.connect() as conn:
-            result = await conn.execute(
-                text("SELECT 1 FROM pg_database WHERE datname = :database_name"),
-                {"database_name": database_name},
-            )
-            if result.scalar() is None:
-                await conn.execute(text(f"CREATE DATABASE {_quote_identifier(database_name)}"))
+        for attempt in range(_DATABASE_LIFECYCLE_ATTEMPTS):
+            try:
+                async with admin_engine.connect() as conn:
+                    result = await conn.execute(
+                        text("SELECT 1 FROM pg_database WHERE datname = :database_name"),
+                        {"database_name": database_name},
+                    )
+                    if result.scalar() is not None:
+                        return
+                    await conn.execute(text(f"CREATE DATABASE {_quote_identifier(database_name)}"))
+                    return
+            except DBAPIError as error:
+                sqlstate = _sqlstate(error)
+                if sqlstate in _DATABASE_EXISTS_SQLSTATES:
+                    return
+                if (
+                    sqlstate not in _DATABASE_BUSY_SQLSTATES
+                    or attempt == _DATABASE_LIFECYCLE_ATTEMPTS - 1
+                ):
+                    raise
+            await asyncio.sleep(0.25 * (attempt + 1))
     finally:
         await admin_engine.dispose()
 
@@ -65,18 +124,31 @@ async def ensure_database_exists(database_name: str) -> None:
 async def drop_database(database_name: str) -> None:
     admin_engine = create_async_engine(ADMIN_DATABASE_URL, isolation_level="AUTOCOMMIT")
     try:
-        async with admin_engine.connect() as conn:
-            await conn.execute(
-                text(
-                    """
-                    SELECT pg_terminate_backend(pid)
-                    FROM pg_stat_activity
-                    WHERE datname = :database_name AND pid <> pg_backend_pid()
-                    """
-                ),
-                {"database_name": database_name},
-            )
-            await conn.execute(text(f"DROP DATABASE IF EXISTS {_quote_identifier(database_name)}"))
+        for attempt in range(_DATABASE_LIFECYCLE_ATTEMPTS):
+            try:
+                async with admin_engine.connect() as conn:
+                    await conn.execute(
+                        text(
+                            """
+                            SELECT pg_terminate_backend(pid)
+                            FROM pg_stat_activity
+                            WHERE datname = :database_name AND pid <> pg_backend_pid()
+                            """
+                        ),
+                        {"database_name": database_name},
+                    )
+                    await conn.execute(
+                        text(f"DROP DATABASE IF EXISTS {_quote_identifier(database_name)}")
+                    )
+                    return
+            except DBAPIError as error:
+                sqlstate = _sqlstate(error)
+                if (
+                    sqlstate not in _DATABASE_BUSY_SQLSTATES
+                    or attempt == _DATABASE_LIFECYCLE_ATTEMPTS - 1
+                ):
+                    raise
+            await asyncio.sleep(0.25 * (attempt + 1))
     finally:
         await admin_engine.dispose()
 

--- a/server/tests/unit/test_sentry_transport_privacy.py
+++ b/server/tests/unit/test_sentry_transport_privacy.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import datetime as dt
 import json
 from typing import Any
-from uuid import uuid4
 
 import pytest
 
@@ -179,7 +178,14 @@ def test_empty_release_and_environment_sentinels_are_removed(factory_name: str) 
 
 # --- tags, extras, user, request ---------------------------------------------
 
-VALID_UUID = str(uuid4())
+# Fixed, structurally valid ids. These used to be `str(uuid4())` and
+# `uuid4().hex`, but a value generated at collection time lands in the
+# parametrize id, so every process collected a differently-named test. Nothing
+# here depends on the ids being fresh, only on their shape: a dashed UUID and a
+# bare 32-char hex. Determinism matters because pytest-xdist refuses to run when
+# its workers disagree about which tests exist.
+VALID_UUID = "c3f1a8d2-5b47-4e19-9a6c-0d8e2f7b41ca"
+VALID_UUID_HEX = "0f3c2a9d6b8e4f1aa7c25d3e9b64108f"
 
 @pytest.mark.parametrize(
     ("key", "value", "survives"),
@@ -193,7 +199,7 @@ VALID_UUID = str(uuid4())
         ("cloud_workspace_id", VALID_UUID, True), ("cloud_target_id", VALID_UUID, True),
         ("sandbox_profile_id", VALID_UUID, True), ("cloud_sandbox_id", VALID_UUID, True),
         ("enrollment_key_id", VALID_UUID, True), ("user_id", VALID_UUID.upper(), True),
-        ("support_report_id", uuid4().hex, True), ("support_report_id", VALID_UUID, False),
+        ("support_report_id", VALID_UUID_HEX, True), ("support_report_id", VALID_UUID, False),
         ("tenant_id", f"user:{VALID_UUID}", True), ("tenant_id", f"org:{VALID_UUID}", True),
         ("tenant_id", f"team:{VALID_UUID}", False), ("critical_failure", "true", True),
         ("critical_failure", "True", False), ("domain", "billing", True),

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -594,6 +594,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.141.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1142,6 +1151,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "sqlalchemy", extra = ["mypy"] },
     { name = "types-pyyaml" },
@@ -1170,6 +1180,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.15.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.4.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.8.0" },
     { name = "python-dateutil", specifier = ">=2.9.0" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "python-multipart", specifier = ">=0.0.32" },
@@ -1478,6 +1489,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Hypothesis

Splitting the server-ci.yml `test` job into a `test-unit` lane (`pytest tests/unit`) and a `test-integration` lane (everything else, unchanged xdist -n 4 + max_locks setup from `exp/server-xdist`) should let the two lanes run concurrently as separate jobs, cutting wall clock further than the single ~14m `exp/server-xdist` job by overlapping unit and integration instead of serializing them within one job.

**Base branch:** `exp/server-xdist` (PR #2122) -- this branch is rebased on top of it and inherits all four of its fixes: scoped autouse DB truncate, pytest-xdist -n 4 with a database per worker, the uuid4-in-parametrize collection-determinism fix, and the `max_locks_per_transaction=1024` bump.

**Measurement experiment only, not for merge as-is.**

## Blocker found: tests/unit is not free of live-infra dependencies

The task assumed `test-unit` could run with zero postgres/redis service containers. That assumption doesn't hold:

- 113 test functions across 20 files under `tests/unit/` resolve the `test_engine` / `db_session` / `client` / `single_org_client` fixtures defined in `server/tests/conftest.py`, which open a real Postgres connection (e.g. `tests/unit/test_first_run_claim.py:64`, `tests/unit/test_registration_page.py:54`, `tests/unit/test_self_registration.py:53`, `tests/unit/test_admin_emails.py`, `tests/unit/test_membership_policy.py`, `tests/unit/test_background_outbox.py`, etc).
- `tests/unit/test_redis_lock.py:108` (`test_redis_claim_is_taken_once_and_reusable_after_release`) and `tests/unit/test_redis_lock.py:138` (`test_stale_release_does_not_drop_a_later_holders_claim`) explicitly exercise a live Redis over `settings.redbeat_redis_url` (default `redis://127.0.0.1:6379/0`).

This isn't an import-time/session-fixture laziness problem fixable with a small `conftest.py` change -- `tests/conftest.py` already lazily creates the DB engine only when a test requests it (that's fix (a) from `exp/server-xdist`). The problem is that ~115 individual tests genuinely need live Postgres/Redis despite living under `tests/unit/`. Moving them to `tests/integration/` or faking the backends is out of scope here, so per the task's own fallback: **`test-unit` keeps the postgres+redis service containers**, and only drops xdist (plain `pytest tests/unit`, tried first per instructions) and the lock-table bump (not needed for a serial, single-connection run).

So this branch measures lane *splitting* (two jobs, no xdist on the unit lane) rather than a service-container-free unit lane.

## Measured results

Two Server CI samples were run to check for flake and get a duration range.

| Job | Sample 1 (run 32424851471) | Sample 2 (run 32425911757) |
| --- | --- | --- |
| `lint` | 0m52s | 0m54s |
| `test-unit` | 3m45s (pytest: 174.19s / 0:02:54) | 3m53s (pytest: 184.27s / 0:03:04) |
| `test-integration` | 10m52s (pytest: 601.26s / 0:10:01) | 13m31s (pytest: 753.39s / 0:12:33) |

Pytest summary lines, verbatim:

- Sample 1 `test-unit`: `1904 passed, 10 warnings in 174.19s (0:02:54)`
- Sample 1 `test-integration`: `1068 passed, 1 skipped, 890 warnings in 601.26s (0:10:01)`
- Sample 2 `test-unit`: `1904 passed, 10 warnings in 184.27s (0:03:04)`
- Sample 2 `test-integration`: `1068 passed, 1 skipped, 890 warnings in 753.39s (0:12:33)`

**Count reconciliation:** both samples give unit 1904 passed + integration 1068 passed = **2972 passed**, 0 + 1 = **1 skipped**, matching the `main` baseline exactly and byte-identical across both samples (no flake, no test collected/dropped by the split).

**`test-integration` has minutes-scale runner variance.** The two samples differ by ~2m39s (10m52s vs 13m31s) on identical code and identical test counts -- this is GitHub-hosted-runner noise (shared Postgres/Redis service containers, noisy-neighbor CPU/IO), not a regression. A single sample near the ~10m budget should be read as a range (roughly 9-14m observed here), not a point estimate.

**Unit-lane infra finding stands after two samples.** `test-unit` started real `postgres16alpine` and `redis7alpine` service containers in both runs (confirmed via the `Initialize containers`/`Stop containers` step logs) because tests/unit is not actually free of live-infra dependencies: 113 test functions across 20 files resolve `test_engine`/`db_session`/`client`/`single_org_client` (real Postgres), and `tests/unit/test_redis_lock.py:108,138` exercise live Redis. An infra-free unit lane needs those ~115 tests relocated out of `tests/unit/` (or their fixtures faked) -- flagged here as follow-up work, out of scope for this measurement branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
