### PR TITLE
ci(server): shard the integration lane 3-way

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -183,6 +183,10 @@ jobs:
   test-integration:
     runs-on: ubuntu-latest
     timeout-minutes: 75
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     env:
       DATABASE_URL: postgresql+asyncpg://proliferate:localdev@127.0.0.1:5432/proliferate
       JWT_SECRET: test-jwt-secret
@@ -260,8 +264,37 @@ jobs:
           docker exec "$container" psql -U proliferate -d proliferate \
             -c 'SHOW max_locks_per_transaction;'
 
-      - name: Run integration tests
-        run: pytest tests/integration tests/e2e/cloud/test_e2b_webhooks.py -n 4 -q --durations=20
+      # Deterministic file-level partition: list every integration test file
+      # plus the one e2e file this lane also carries, sort them (independent
+      # of filesystem traversal order), and take every third file starting at
+      # this shard's offset. Whole files stay together -- xdist distributes
+      # within a shard -- so no test can land in two shards or in none, and
+      # the partition is identical across workers, runs, and reruns because
+      # it depends only on the sorted file list, never on collection or
+      # runtime order.
+      - name: Partition integration test files (shard ${{ matrix.shard }} of 3)
+        id: partition
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(
+            { find tests/integration -type f \( -name 'test_*.py' -o -name '*_test.py' \); \
+              echo tests/e2e/cloud/test_e2b_webhooks.py; } | sort -u
+          )
+          echo "Total integration test files: ${#files[@]}"
+          shard_files=()
+          for i in "${!files[@]}"; do
+            if (( i % 3 == SHARD - 1 )); then
+              shard_files+=("${files[$i]}")
+            fi
+          done
+          echo "Shard ${SHARD} owns ${#shard_files[@]} files:"
+          printf '  %s\n' "${shard_files[@]}"
+          printf '%s\n' "${shard_files[@]}" > shard_files.txt
+
+      - name: Run integration tests (shard ${{ matrix.shard }} of 3)
+        run: xargs -a shard_files.txt pytest -n 4 -q --durations=20
 
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Hypothesis

`test-integration` on `exp/server-split-before-only` runs 1068 tests + 1 skip
under xdist `-n 4` and measured 9m9s-10m9s wall clock. Splitting it into a
3-way matrix, with each shard keeping its own postgres+redis services and
`max_locks_per_transaction=1024` setup but running only a third of the test
files, should bring the integration lane down to roughly 4-5 minutes per
shard while the total job-minutes stay similar.

## What changed

`test-integration` gains `strategy: matrix: shard: [1, 2, 3]`. A new step
lists every file under `tests/integration` (`test_*.py` / `*_test.py`) plus
the one e2e file this lane also carries (`tests/e2e/cloud/test_e2b_webhooks.py`),
sorts them for a stable order independent of filesystem traversal, and keeps
every third file (`index % 3 == shard - 1`) for that shard. Whole files stay
together so no test can land in two shards or in none, and the partition is
fully deterministic across runs. `pytest -n 4 -q --durations=20` then runs
against just that shard's files.

`pytest-split` was considered but a plain file-level partition was judged
safer here: no new pinned dependency, no `.test_durations` cache to keep in
sync, and the union-equals-original-set property is trivially true by
construction rather than needing separate verification.

## Base branch

Based on `exp/server-split-before-only` (#2130), which has not merged yet.
This PR is layered on top of that split for measurement purposes.

## Status

Measurement-only. This is a CI experiment branch to quantify the effect of
sharding the integration lane, not a mergeable change as-is — the matrix
jobs would need to be reconciled with branch-protection required-check names
before this could land for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)