### PR TITLE
docs(readme): restructure sections and trim content

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,24 @@ Each task gets an isolated git worktree — branch, terminal, conversation, and 
 
 <br />
 
-Proliferate is a desktop and web app for running coding agents in parallel.
+Proliferate is a desktop app for running coding agents in parallel.
 
 - **Run any mix of agents in parallel**, each in its own isolated worktree, with native tools, auth, and config intact
 - **Let your agents manage each other**, like having Codex hand design work to Claude Code
 - **Set up MCPs and skills once**, shared across every agent
 
-## Bring Your Agent
+## Features
+
+- 🤖 **[Native harnesses](https://proliferate.com/docs/product/agents)** - Claude Code, Codex, OpenCode, Cursor, Grok, and more
+- 🌳 **[Worktree workspaces](https://proliferate.com/docs/product/workspaces)** - an isolated branch and working directory for every task
+- 🔍 **[Git & diff review](https://proliferate.com/docs/product/workspaces/review-and-publish)** - inspect and edit agent changes without leaving the app
+- 🛡️ **[Plan & code review agents](https://proliferate.com/docs/product/workspaces/review-and-publish)** - reviewer agents check plans, diffs, risks, and branch readiness before you do
+- 🪆 **[Parallel agents & subagents](https://proliferate.com/docs/product/workspaces/parallel-agents)** - run agents side by side, or let them delegate scoped work to other agents
+- 🧩 **[Integrations](https://proliferate.com/docs/product/integrations)** - MCPs, skills, Computer Use, Browser Use, and custom tools, configured once and shared by every agent
+- ⏰ **[Workflows](https://proliferate.com/docs/product/workflows)** - recurring and event-driven agent runs: nightly review passes, triage on alerts, dependency bumps
+- 🖼️ **[Artifacts](https://proliferate.com/docs/product/learn/cowork-and-artifacts)** - docs, UI, demos, and components rendered inline as agents produce them
+
+## Supported agents
 
 Each agent runs through its native harness, so auth, tools, models, permissions, and transcript behavior stay intact. New harness features show up in Proliferate the day they ship.
 
@@ -85,78 +96,12 @@ Each agent runs through its native harness, so auth, tools, models, permissions,
   </tr>
 </table>
 
-## Features
-
-- 🤖 **[Native harnesses](https://proliferate.com/docs/product/agents)** - Claude Code, Codex, OpenCode, Cursor, Grok, and more
-- 🌳 **[Worktree workspaces](https://proliferate.com/docs/product/workspaces)** - an isolated branch and working directory for every task
-- 🔍 **[Git & diff review](https://proliferate.com/docs/product/workspaces/review-and-publish)** - inspect and edit agent changes without leaving the app
-- 🛡️ **[Plan & code review agents](https://proliferate.com/docs/product/workspaces/review-and-publish)** - reviewer agents check plans, diffs, risks, and branch readiness before you do
-- 🪆 **[Parallel agents & subagents](https://proliferate.com/docs/product/workspaces/parallel-agents)** - run agents side by side, or let them delegate scoped work to other agents
-- 🧩 **[Integrations](https://proliferate.com/docs/product/integrations)** - MCPs, skills, Computer Use, Browser Use, and custom tools, configured once and shared by every agent
-- ⏰ **[Workflows](https://proliferate.com/docs/product/workflows)** - recurring and event-driven agent runs: nightly review passes, triage on alerts, dependency bumps
-- 🖼️ **[Artifacts](https://proliferate.com/docs/product/learn/cowork-and-artifacts)** - docs, UI, demos, and components rendered inline as agents produce them
-
-## Open Source
+## Self-hosting
 
 Proliferate is AGPL-3.0 — the whole stack: desktop client, web app, and cloud
-control plane. See [Self-hosting](#self-hosting) below.
-
-## Getting Started
-
-### Quick Start
-
-Download Proliferate from [proliferate.com](https://proliferate.com) or follow
-the [quickstart](https://proliferate.com/docs/product/quickstart).
-
-<details>
-<summary>Run from source</summary>
-
-### Run Locally From Source
-
-Requirements:
-
-- Rust stable
-- Node.js 22+
-- pnpm
-
-Run the desktop app with the bundled local AnyHarness runtime:
-
-```bash
-make install
-make dev-local
-```
-
-### Local Full-Stack Development
-
-Requirements:
-
-- Rust stable
-- Node.js 22+
-- pnpm
-- Python 3.12+
-- `uv`
-- Docker, for the local control plane database
-
-Use named dev profiles for full-stack development when multiple worktrees run at
-the same time.
-
-```bash
-make server-install
-make setup PROFILE=main
-make build # first clean worktree, or after generated/Rust/frontend artifacts change
-make dev-list
-make run PROFILE=main
-```
-
-See [dev profiles](./guides/local/dev-profiles.md) for profile state, ports,
-generated Tauri config, and app labels.
-
-</details>
-
-<details id="self-hosting">
-<summary>Self-host Proliferate</summary>
-
-### Self-hosting
+control plane. Download the app from [proliferate.com](https://proliferate.com)
+or follow the [quickstart](https://proliferate.com/docs/product/quickstart) to
+get going in a minute.
 
 The full Proliferate control plane is self-hostable. Start with the
 [deployment docs](https://proliferate.com/docs/deployment) — Docker, AWS, GCP,
@@ -175,9 +120,42 @@ Point the desktop app at your control plane by following
 [Discord](https://discord.gg/2RVNNzEZnj) if you hit problems, and see
 [SECURITY.md](./SECURITY.md) for reporting vulnerabilities.
 
+<details>
+<summary>Run from source</summary>
+
+<br />
+
+Requirements:
+
+- Rust stable
+- Node.js 22+
+- pnpm
+
+Run the desktop app with the bundled local AnyHarness runtime:
+
+```bash
+make install
+make dev-local
+```
+
+**Local full-stack development** additionally requires Python 3.12+, `uv`, and
+Docker for the local control plane database. Use named dev profiles when
+multiple worktrees run at the same time.
+
+```bash
+make server-install
+make setup PROFILE=main
+make build # first clean worktree, or after generated/Rust/frontend artifacts change
+make dev-list
+make run PROFILE=main
+```
+
+See [dev profiles](./guides/local/dev-profiles.md) for profile state, ports,
+generated Tauri config, and app labels.
+
 </details>
 
-## Proliferate Cloud (Coming Soon)
+## Cloud Sandbox
 
 > Proliferate Cloud is not part of the initial launch — we're rebuilding the
 > sandbox infrastructure to remove the E2B dependency and will ship Cloud in a

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Each task gets an isolated git worktree for its branch, terminal, conversation, 
 - 🤖 **[Native harnesses](https://proliferate.com/docs/product/agents)** - Claude Code, Codex, OpenCode, Cursor, Grok, and more
 - 🌳 **[Worktree workspaces](https://proliferate.com/docs/product/workspaces)** - an isolated branch and working directory for every task
 - 🔀 **[Parallel agents](https://proliferate.com/docs/concepts/parallel-agents)** - run agents side by side in the same workspace, each on its own task
-- 🪆 **[Subagents](https://proliferate.com/docs/product/workspaces/parallel-agents)** - agents delegate scoped work to child agents and pick the results back up when they finish
+- 🪆 **[Subagents](https://proliferate.com/docs/features/subagents)** - agents delegate scoped work to child agents and pick the results back up when they finish
 - 🧩 **[Integrations](https://proliferate.com/docs/product/integrations)** - MCPs, skills, Computer Use, Browser Use, and custom tools, configured once and shared by every agent
 - ⏰ **[Workflows](https://proliferate.com/docs/product/workflows)** - recurring and event-driven agent runs: nightly review passes, triage on alerts, dependency bumps
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ Each task gets an isolated git worktree for its branch, terminal, conversation, 
 
 - 🤖 **[Native harnesses](https://proliferate.com/docs/product/agents)** - Claude Code, Codex, OpenCode, Cursor, Grok, and more
 - 🌳 **[Worktree workspaces](https://proliferate.com/docs/product/workspaces)** - an isolated branch and working directory for every task
-- 🔍 **[Git & diff review](https://proliferate.com/docs/product/workspaces/review-and-publish)** - inspect and edit agent changes without leaving the app
-- 🛡️ **[Plan & code review agents](https://proliferate.com/docs/product/workspaces/review-and-publish)** - reviewer agents check plans, diffs, risks, and branch readiness before you do
 - 🔀 **[Parallel agents](https://proliferate.com/docs/product/workspaces/parallel-agents)** - run agents side by side in the same workspace, each on its own task
 - 🪆 **[Subagents](https://proliferate.com/docs/product/workspaces/parallel-agents)** - agents delegate scoped work to child agents and pick the results back up when they finish
 - 🧩 **[Integrations](https://proliferate.com/docs/product/integrations)** - MCPs, skills, Computer Use, Browser Use, and custom tools, configured once and shared by every agent

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Each task gets an isolated git worktree for its branch, terminal, conversation, 
 - 🪆 **[Subagents](https://proliferate.com/docs/product/workspaces/parallel-agents)** - agents delegate scoped work to child agents and pick the results back up when they finish
 - 🧩 **[Integrations](https://proliferate.com/docs/product/integrations)** - MCPs, skills, Computer Use, Browser Use, and custom tools, configured once and shared by every agent
 - ⏰ **[Workflows](https://proliferate.com/docs/product/workflows)** - recurring and event-driven agent runs: nightly review passes, triage on alerts, dependency bumps
-- 🖼️ **[Artifacts](https://proliferate.com/docs/product/learn/cowork-and-artifacts)** - docs, UI, demos, and components rendered inline as agents produce them
 
 ## Supported agents
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Each task gets an isolated git worktree for its branch, terminal, conversation, 
 
 - 🤖 **[Native harnesses](https://proliferate.com/docs/product/agents)** - Claude Code, Codex, OpenCode, Cursor, Grok, and more
 - 🌳 **[Worktree workspaces](https://proliferate.com/docs/product/workspaces)** - an isolated branch and working directory for every task
-- 🔀 **[Parallel agents](https://proliferate.com/docs/product/workspaces/parallel-agents)** - run agents side by side in the same workspace, each on its own task
+- 🔀 **[Parallel agents](https://proliferate.com/docs/concepts/parallel-agents)** - run agents side by side in the same workspace, each on its own task
 - 🪆 **[Subagents](https://proliferate.com/docs/product/workspaces/parallel-agents)** - agents delegate scoped work to child agents and pick the results back up when they finish
 - 🧩 **[Integrations](https://proliferate.com/docs/product/integrations)** - MCPs, skills, Computer Use, Browser Use, and custom tools, configured once and shared by every agent
 - ⏰ **[Workflows](https://proliferate.com/docs/product/workflows)** - recurring and event-driven agent runs: nightly review passes, triage on alerts, dependency bumps

--- a/README.md
+++ b/README.md
@@ -39,14 +39,6 @@ Each task gets an isolated git worktree for its branch, terminal, conversation, 
 
 </div>
 
-<br />
-
-Proliferate is a desktop app for running coding agents in parallel.
-
-- **Run any mix of agents in parallel**, each in its own isolated worktree, with native tools, auth, and config intact
-- **Let your agents manage each other**, like having Codex hand design work to Claude Code
-- **Set up MCPs and skills once**, shared across every agent
-
 ## Features
 
 - 🤖 **[Native harnesses](https://proliferate.com/docs/product/agents)** - Claude Code, Codex, OpenCode, Cursor, Grok, and more
@@ -98,11 +90,6 @@ Each agent runs through its native harness, so auth, tools, models, permissions,
 </table>
 
 ## Self-hosting
-
-Proliferate is AGPL-3.0. That covers the whole stack, including the desktop
-client and the cloud control plane. Download the app from [proliferate.com](https://proliferate.com)
-or follow the [quickstart](https://proliferate.com/docs/product/quickstart) to
-get going in a minute.
 
 The full Proliferate control plane is self-hostable. Start with the
 [deployment docs](https://proliferate.com/docs/deployment), which cover Docker,

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 <br />
 
-Run Claude Code, Codex, OpenCode, and any other coding agent in parallel, in one workspace.<br />
+Run Claude Code, Codex, OpenCode, Grok, and any other coding agent in parallel, in one workspace.<br />
 Each task gets an isolated git worktree for its branch, terminal, conversation, and review state.
 
 <br />

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Proliferate is a desktop app for running coding agents in parallel.
 - 🌳 **[Worktree workspaces](https://proliferate.com/docs/product/workspaces)** - an isolated branch and working directory for every task
 - 🔍 **[Git & diff review](https://proliferate.com/docs/product/workspaces/review-and-publish)** - inspect and edit agent changes without leaving the app
 - 🛡️ **[Plan & code review agents](https://proliferate.com/docs/product/workspaces/review-and-publish)** - reviewer agents check plans, diffs, risks, and branch readiness before you do
-- 🪆 **[Parallel agents & subagents](https://proliferate.com/docs/product/workspaces/parallel-agents)** - run agents side by side, or let them delegate scoped work to other agents
+- 🔀 **[Parallel agents](https://proliferate.com/docs/product/workspaces/parallel-agents)** - run agents side by side in the same workspace, each on its own task
+- 🪆 **[Subagents](https://proliferate.com/docs/product/workspaces/parallel-agents)** - agents delegate scoped work to child agents and pick the results back up when they finish
 - 🧩 **[Integrations](https://proliferate.com/docs/product/integrations)** - MCPs, skills, Computer Use, Browser Use, and custom tools, configured once and shared by every agent
 - ⏰ **[Workflows](https://proliferate.com/docs/product/workflows)** - recurring and event-driven agent runs: nightly review passes, triage on alerts, dependency bumps
 - 🖼️ **[Artifacts](https://proliferate.com/docs/product/learn/cowork-and-artifacts)** - docs, UI, demos, and components rendered inline as agents produce them
@@ -98,7 +99,7 @@ Each agent runs through its native harness, so auth, tools, models, permissions,
 
 ## Self-hosting
 
-Proliferate is AGPL-3.0 — the whole stack: desktop client, web app, and cloud
+Proliferate is AGPL-3.0 — the whole stack: desktop client and cloud
 control plane. Download the app from [proliferate.com](https://proliferate.com)
 or follow the [quickstart](https://proliferate.com/docs/product/quickstart) to
 get going in a minute.
@@ -154,27 +155,6 @@ See [dev profiles](./guides/local/dev-profiles.md) for profile state, ports,
 generated Tauri config, and app labels.
 
 </details>
-
-## Cloud Sandbox
-
-> Proliferate Cloud is not part of the initial launch — we're rebuilding the
-> sandbox infrastructure to remove the E2B dependency and will ship Cloud in a
-> follow-up release. Everything local above is available today.
-
-- ☁️ **Cloud sandboxes** - isolated cloud environments that keep working after you close your laptop
-- 🔁 **Workspace mobility** - move a running workspace between your machine and the cloud, mid-task, with changes and history intact
-- 👥 **Multiplayer cloud chats** - live sessions your team can inspect, claim, and continue
-- 💬 **Team Slackbot** - turn a Slack message into shared agent work for the whole team
-- 🤝 **Team automations** - shared recurring fixes and reviews the whole team can run
-- 🛰️ **Remote dispatch** - kick off and steer work on your own machine from the web
-- 🔑 **SSH access** - drop into any cloud sandbox from your terminal
-- 🔐 **Credential gateway** - your keys and subscriptions never touch the sandbox; sandboxes only get short-lived tokens
-- 🏢 **Organizations** - team seats, shared settings, cloud limits, and governance controls
-- 📱 **Mobile** - coming soon: dispatch work, approve actions, and follow runs from your phone
-- 🏗️ **Self-hosted Proliferate Cloud** - run the full cloud control plane yourself ([docs](#self-hosting))
-
-Like everything else, Proliferate Cloud will be open source (AGPL-3.0) and
-self-hostable.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 <br />
 
 Run Claude Code, Codex, OpenCode, and any other coding agent in parallel, in one workspace.<br />
-Each task gets an isolated git worktree — branch, terminal, conversation, and review state kept together.
+Each task gets an isolated git worktree for its branch, terminal, conversation, and review state.
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Each task gets an isolated git worktree for its branch, terminal, conversation, 
 
 ## Supported agents
 
-Each agent runs through its native harness, so auth, tools, models, permissions, and transcript behavior stay intact. New harness features show up in Proliferate the day they ship.
+Proliferate runs each agent through its native harness.
 
 <table>
   <tr>

--- a/README.md
+++ b/README.md
@@ -99,19 +99,19 @@ Each agent runs through its native harness, so auth, tools, models, permissions,
 
 ## Self-hosting
 
-Proliferate is AGPL-3.0 — the whole stack: desktop client and cloud
-control plane. Download the app from [proliferate.com](https://proliferate.com)
+Proliferate is AGPL-3.0. That covers the whole stack, including the desktop
+client and the cloud control plane. Download the app from [proliferate.com](https://proliferate.com)
 or follow the [quickstart](https://proliferate.com/docs/product/quickstart) to
 get going in a minute.
 
 The full Proliferate control plane is self-hostable. Start with the
-[deployment docs](https://proliferate.com/docs/deployment) — Docker, AWS, GCP,
-Azure, Kubernetes, and air-gapped operation.
+[deployment docs](https://proliferate.com/docs/deployment), which cover Docker,
+AWS, GCP, Azure, Kubernetes, and air-gapped operation.
 
-- **Docker Compose:** [self-hosted-deploy.md](./guides/deploying/self-hosted-deploy.md) —
-  Caddy + Postgres + API, with bootstrap and update scripts
-- **AWS (one-click):** [self-hosted-aws.md](./guides/deploying/self-hosted-aws.md) —
-  CloudFormation wrapper that provisions the stack on EC2
+- **Docker Compose:** [self-hosted-deploy.md](./guides/deploying/self-hosted-deploy.md)
+  runs Caddy, Postgres, and the API, with bootstrap and update scripts
+- **AWS (one-click):** [self-hosted-aws.md](./guides/deploying/self-hosted-aws.md)
+  is a CloudFormation wrapper that provisions the stack on EC2
 - **Configuration:** [`server/deploy/.env.production.example`](./server/deploy/.env.production.example)
   documents every required and optional setting
 


### PR DESCRIPTION
Restructures the README into the new section order: Features → Supported agents → Self-hosting → Community → Contributing → License.

- `Bring Your Agent` renamed to `Supported agents` and moved below `Features`
- `Subagents` split out as its own Features bullet, following the same pattern as the rest
- `Open Source` and `Getting Started` folded into a single top-level `Self-hosting` section, which keeps the control-plane docs and the run-from-source `<details>`
- `Proliferate Cloud (Coming Soon)` section removed
- Intro blurb under the hero removed, so the page goes straight from the hero into Features
- All mentions of the web app removed
- Em dashes replaced with plain sentences
- Tagline reworded and Grok added: "Run Claude Code, Codex, OpenCode, Grok, and any other coding agent in parallel, in one workspace. Each task gets an isolated git worktree for its branch, terminal, conversation, and review state."

🤖 Generated with [Claude Code](https://claude.com/claude-code)