### PR TITLE
fix(agent-auth): decouple agent auth from cloud compute

### DIFF
--- a/apps/packages/product-client/src/components/settings/panes/agents/api-keys/ApiKeysPane.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/api-keys/ApiKeysPane.test.tsx
@@ -8,7 +8,13 @@ import { ApiKeysPane } from "#product/components/settings/panes/agents/api-keys/
 import { AGENT_API_KEYS_COPY } from "#product/copy/settings/agent-api-keys-copy";
 
 const state = vi.hoisted(() => ({
-  cloudActive: true,
+  // Cloud COMPUTE is off for this entire suite, deliberately. The API key vault
+  // is a control-plane feature (ADR FM6/Q9), so the pane must render normally
+  // for a signed-in user on a reachable control plane even with cloud compute
+  // switched off. Re-couple the pane to `cloudActive` and the whole file fails.
+  cloudActive: false,
+  authStatus: "authenticated" as "authenticated" | "anonymous" | "loading",
+  controlPlaneReachable: true,
   keys: {
     data: [] as Array<Record<string, unknown>> | undefined,
     isLoading: false,
@@ -18,16 +24,24 @@ const state = vi.hoisted(() => ({
 const createMutate = vi.hoisted(() => vi.fn());
 const revokeMutate = vi.hoisted(() => vi.fn());
 const refetchKeys = vi.hoisted(() => vi.fn());
+const keysEnabled = vi.hoisted(() => vi.fn());
 const showToast = vi.hoisted(() => vi.fn());
 
 vi.mock("@proliferate/cloud-sdk-react", () => ({
-  useAgentApiKeys: () => ({ ...state.keys, refetch: refetchKeys }),
+  useAgentApiKeys: (enabled: boolean) => {
+    keysEnabled(enabled);
+    return { ...state.keys, refetch: refetchKeys };
+  },
   useCreateAgentApiKey: () => ({ mutate: createMutate, isPending: false }),
   useRevokeAgentApiKey: () => ({ mutate: revokeMutate, isPending: false }),
 }));
 
 vi.mock("#product/hooks/cloud/derived/use-cloud-availability-state", () => ({
-  useCloudAvailabilityState: () => ({ cloudActive: state.cloudActive }),
+  useCloudAvailabilityState: () => ({
+    cloudActive: state.cloudActive,
+    authStatus: state.authStatus,
+    controlPlaneReachable: state.controlPlaneReachable,
+  }),
 }));
 
 vi.mock("#product/stores/toast/toast-store", () => ({
@@ -86,7 +100,9 @@ vi.mock("#product/components/settings/panes/agent-auth/ApiKeyCreatorModal", () =
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
-  state.cloudActive = true;
+  state.cloudActive = false;
+  state.authStatus = "authenticated";
+  state.controlPlaneReachable = true;
   state.keys.data = [];
   state.keys.isLoading = false;
   state.keys.isError = false;
@@ -114,6 +130,37 @@ function deferred<T>() {
 }
 
 describe("ApiKeysPane", () => {
+  it("renders the vault with cloud compute disabled (launch posture)", () => {
+    state.cloudActive = false;
+    state.keys.data = [key()];
+    const { container } = render(<ApiKeysPane />);
+
+    expect(container.querySelector('[data-api-keys-state="ready"]')).not.toBeNull();
+    expect(screen.queryByText("Work key")).not.toBeNull();
+    expect(keysEnabled).toHaveBeenLastCalledWith(true);
+  });
+
+  it("prompts a signed-out user to sign in, without querying the vault", () => {
+    state.authStatus = "anonymous";
+    const { container } = render(<ApiKeysPane />);
+
+    expect(container.querySelector('[data-api-keys-state="gated"]')).not.toBeNull();
+    expect(screen.queryByText(AGENT_API_KEYS_COPY.signInRequiredTitle)).not.toBeNull();
+    expect(screen.queryByText(AGENT_API_KEYS_COPY.signInRequired)).not.toBeNull();
+    expect(keysEnabled).toHaveBeenLastCalledWith(false);
+  });
+
+  it("tells a signed-in user the server is unreachable, not to sign in", () => {
+    state.controlPlaneReachable = false;
+    const { container } = render(<ApiKeysPane />);
+
+    expect(container.querySelector('[data-api-keys-state="gated"]')).not.toBeNull();
+    expect(screen.queryByText(AGENT_API_KEYS_COPY.serverUnreachableTitle)).not.toBeNull();
+    expect(screen.queryByText(AGENT_API_KEYS_COPY.serverUnreachable)).not.toBeNull();
+    expect(screen.queryByText(AGENT_API_KEYS_COPY.signInRequiredTitle)).toBeNull();
+    expect(keysEnabled).toHaveBeenLastCalledWith(false);
+  });
+
   it("lists vault keys by title and redacted hint", () => {
     state.keys.data = [key(), key({ id: "key-2", title: "Backup", redactedHint: "sk-...wxyz" })];
     render(<ApiKeysPane />);

--- a/apps/packages/product-client/src/components/settings/panes/agents/api-keys/ApiKeysPane.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/api-keys/ApiKeysPane.tsx
@@ -38,10 +38,19 @@ function formatCreatedAt(value: string): string {
 }
 
 export function ApiKeysPane() {
-  const { cloudActive, authStatus, cloudComputeEnabled } = useCloudAvailabilityState();
+  const { authStatus, controlPlaneReachable } = useCloudAvailabilityState();
   const showToast = useToastStore((state) => state.show);
 
-  const keysQuery = useAgentApiKeys(cloudActive);
+  // The API key vault is a control-plane feature, not a cloud-compute one: it
+  // must stay usable whenever the control plane is reachable and the user is
+  // signed in, independent of `cloudComputeEnabled` (ADR FM6/Q9). The settings
+  // router already routes this pane through exactly that gate
+  // (render-settings-section.tsx `authGate`); gating the pane body on
+  // `cloudActive` re-coupled it to cloud compute and slammed the door the
+  // router had just opened.
+  const authReady = authStatus === "authenticated" && controlPlaneReachable;
+
+  const keysQuery = useAgentApiKeys(authReady);
   const createKey = useCreateAgentApiKey();
   const revokeKey = useRevokeAgentApiKey();
 
@@ -123,11 +132,11 @@ export function ApiKeysPane() {
     })();
   }
 
-  if (!cloudActive) {
-    // Truthful cause: a signed-in user on a compute-unconfigured deployment
-    // gets the operator explanation, not a "sign in" prompt they can't act on
+  if (!authReady) {
+    // Truthful cause: a signed-in user whose control plane is unreachable gets
+    // a connectivity explanation, not a "sign in" prompt they can't act on
     // (PR2-GATING-01 class). Anonymous users still get the sign-in prompt.
-    const operatorGated = authStatus === "authenticated" && !cloudComputeEnabled;
+    const unreachable = authStatus === "authenticated" && !controlPlaneReachable;
     return (
       <SettingsPageBody data-api-keys-pane="" data-api-keys-state="gated">
         <PageHeader
@@ -137,11 +146,11 @@ export function ApiKeysPane() {
         />
         <SettingsEmptyState
           size="compact"
-          title={operatorGated
-            ? AGENT_API_KEYS_COPY.cloudNotConfiguredTitle
+          title={unreachable
+            ? AGENT_API_KEYS_COPY.serverUnreachableTitle
             : AGENT_API_KEYS_COPY.signInRequiredTitle}
-          description={operatorGated
-            ? AGENT_API_KEYS_COPY.cloudNotConfigured
+          description={unreachable
+            ? AGENT_API_KEYS_COPY.serverUnreachable
             : AGENT_API_KEYS_COPY.signInRequired}
         />
       </SettingsPageBody>

--- a/apps/packages/product-client/src/copy/settings/agent-api-keys-copy.ts
+++ b/apps/packages/product-client/src/copy/settings/agent-api-keys-copy.ts
@@ -11,11 +11,13 @@ export const AGENT_API_KEYS_COPY = {
   emptyDescription: "Add a key to wire it into a harness later.",
   signInRequiredTitle: "Sign in required",
   signInRequired: "Sign in to Proliferate Cloud to manage your API key vault.",
-  cloudNotConfiguredTitle: "Cloud is not configured",
-  // Signed in, but the operator has not configured cloud compute — never a
-  // sign-in prompt to someone already signed in (PR2-GATING-01 class).
-  cloudNotConfigured:
-    "Cloud is not configured on this deployment. An operator must finish configuring it before the API key vault is available.",
+  // Signed in, but the control plane is unreachable. Never a sign-in prompt to
+  // someone already signed in (PR2-GATING-01 class), and never a "cloud is not
+  // configured" claim: the vault is a control-plane feature, so cloud compute
+  // being off is not a reason it is unavailable (ADR FM6/Q9).
+  serverUnreachableTitle: "Can't reach the server",
+  serverUnreachable:
+    "Your API key vault lives on the server. Reconnect to manage your keys.",
   addAction: "Add key",
   addModalHeading: "Add API key",
   addModalDescription:

--- a/apps/packages/product-client/src/hooks/agents/lifecycle/use-auth-setup-onboarding-step.test.tsx
+++ b/apps/packages/product-client/src/hooks/agents/lifecycle/use-auth-setup-onboarding-step.test.tsx
@@ -12,7 +12,13 @@ import { AUTH_SETUP_GRACE_MS } from "#product/lib/domain/agents/auth-onboarding"
 import { useAuthSetupOnboardingStore } from "#product/stores/agents/auth-setup-onboarding-store";
 
 const state = vi.hoisted(() => ({
-  cloudActive: true,
+  // Cloud COMPUTE is off for this entire suite, deliberately: that is the
+  // shipped production posture, and this step watches control-plane state
+  // (auth selections + gateway enrollment) that must resolve regardless.
+  // Re-couple the hook to `cloudActive` and the whole file fails.
+  cloudActive: false,
+  authStatus: "authenticated" as "authenticated" | "anonymous" | "loading",
+  controlPlaneReachable: true,
   selections: {
     data: undefined as Array<Record<string, unknown>> | undefined,
   },
@@ -36,7 +42,11 @@ vi.mock("@proliferate/cloud-sdk-react", () => ({
 }));
 
 vi.mock("#product/hooks/cloud/derived/use-cloud-availability-state", () => ({
-  useCloudAvailabilityState: () => ({ cloudActive: state.cloudActive }),
+  useCloudAvailabilityState: () => ({
+    cloudActive: state.cloudActive,
+    authStatus: state.authStatus,
+    controlPlaneReachable: state.controlPlaneReachable,
+  }),
 }));
 
 function recordAdoption(harnessKinds: string[]) {
@@ -56,7 +66,9 @@ afterEach(() => {
   vi.useRealTimers();
   vi.clearAllMocks();
   useAuthSetupOnboardingStore.getState().resetForTests();
-  state.cloudActive = true;
+  state.cloudActive = false;
+  state.authStatus = "authenticated";
+  state.controlPlaneReachable = true;
   state.selections.data = undefined;
   state.enrollment.data = undefined;
   state.enrollment.isError = false;
@@ -203,6 +215,26 @@ describe("useAuthSetupOnboardingStep", () => {
       vi.advanceTimersByTime(AUTH_SETUP_GRACE_MS + 1);
     });
     expect(result.current).toBe("advanced");
+  });
+
+  it("watches with cloud compute disabled, and stops watching when signed out", () => {
+    // Launch posture: cloud compute off, signed in, control plane reachable.
+    // The step must still enable both watch queries.
+    recordAdoption(["claude"]);
+    const { rerender } = renderHook(() => useAuthSetupOnboardingStep());
+    expect(state.selectionsArgs.at(-1)?.enabled).toBe(true);
+    expect(state.enrollmentArgs.at(-1)?.enabled).toBe(true);
+
+    state.authStatus = "anonymous";
+    rerender();
+    expect(state.selectionsArgs.at(-1)?.enabled).toBe(false);
+    expect(state.enrollmentArgs.at(-1)?.enabled).toBe(false);
+
+    state.authStatus = "authenticated";
+    state.controlPlaneReachable = false;
+    rerender();
+    expect(state.selectionsArgs.at(-1)?.enabled).toBe(false);
+    expect(state.enrollmentArgs.at(-1)?.enabled).toBe(false);
   });
 
   it("advances immediately when the app observes an already-expired grace window", () => {

--- a/apps/packages/product-client/src/hooks/agents/lifecycle/use-auth-setup-onboarding-step.ts
+++ b/apps/packages/product-client/src/hooks/agents/lifecycle/use-auth-setup-onboarding-step.ts
@@ -45,7 +45,12 @@ const AUTH_SETUP_POLL_MS = 3000;
  * edit going pending never resurrects the onboarding card.
  */
 export function useAuthSetupOnboardingStep(): AuthSetupStepState {
-  const { cloudActive } = useCloudAvailabilityState();
+  const { authStatus, controlPlaneReachable } = useCloudAvailabilityState();
+  // Control-plane gate, NOT a cloud-compute gate: this step watches auth
+  // selections and gateway enrollment, both control-plane state independent of
+  // cloud COMPUTE. Matches `useFirstRunAuthAdoption` — if adoption ran, the
+  // step that watches its acks must be able to run too.
+  const authReady = authStatus === "authenticated" && controlPlaneReachable;
   const adoptedHarnessKinds = useAuthSetupOnboardingStore(
     (store) => store.adoptedHarnessKinds,
   );
@@ -83,13 +88,13 @@ export function useAuthSetupOnboardingStep(): AuthSetupStepState {
     return () => clearTimeout(timer);
   }, [watching, adoptionStartedAt]);
 
-  const selectionsQuery = useAuthSelections("local", cloudActive && watching, {
+  const selectionsQuery = useAuthSelections("local", authReady && watching, {
     refetchInterval: watching ? AUTH_SETUP_POLL_MS : false,
   });
   // Enrollment sync (keys minted) is part of the same pending truth: a state
   // acked before sync lacks the key, and sync bumps the revision back to
   // pending — so resolution requires synced AND applied.
-  const enrollmentQuery = useAgentGatewayEnrollment(cloudActive && watching, {
+  const enrollmentQuery = useAgentGatewayEnrollment(authReady && watching, {
     refetchInterval: watching ? AUTH_SETUP_POLL_MS : false,
   });
   // An errored enrollment read (e.g. the 404 before the row exists, or

--- a/apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.test.tsx
+++ b/apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.test.tsx
@@ -12,7 +12,15 @@ import {
 } from "#product/lib/infra/diagnostics/renderer-diagnostics-port";
 
 const state = vi.hoisted(() => ({
-  cloudActive: true,
+  // Cloud COMPUTE is off for this entire suite, deliberately. That is the
+  // shipped production posture (CLOUD_COMPUTE_TEMPORARILY_DISABLED makes
+  // `cloudActive` false for every signed-in production user), and adoption is a
+  // control-plane concern that must run regardless. Every test below therefore
+  // doubles as the regression guard: re-couple the hook to `cloudActive` and
+  // the whole file fails.
+  cloudActive: false,
+  authStatus: "authenticated" as "authenticated" | "anonymous" | "loading",
+  controlPlaneReachable: true,
   isDesktop: true,
   connectionState: "healthy" as "connecting" | "healthy" | "failed",
   capabilities: {
@@ -55,7 +63,11 @@ vi.mock("@proliferate/cloud-sdk-react", () => ({
 }));
 
 vi.mock("#product/hooks/cloud/derived/use-cloud-availability-state", () => ({
-  useCloudAvailabilityState: () => ({ cloudActive: state.cloudActive }),
+  useCloudAvailabilityState: () => ({
+    cloudActive: state.cloudActive,
+    authStatus: state.authStatus,
+    controlPlaneReachable: state.controlPlaneReachable,
+  }),
 }));
 
 vi.mock("#product/host/ProductHostProvider", () => ({
@@ -121,7 +133,9 @@ beforeEach(() => {
   mocks.planner.mockReset();
   mocks.putMutate.mockReset();
 
-  state.cloudActive = true;
+  state.cloudActive = false;
+  state.authStatus = "authenticated";
+  state.controlPlaneReachable = true;
   state.isDesktop = true;
   state.connectionState = "healthy";
   state.capabilities.data = { gatewayEnabled: true };
@@ -186,8 +200,8 @@ describe("useFirstRunAuthAdoption", () => {
       .toBe(1_723_456_789);
   });
 
-  it("keeps inactive Cloud pending and can adopt after active Desktop transition", async () => {
-    state.cloudActive = false;
+  it("keeps a signed-out user pending and adopts after sign-in", async () => {
+    state.authStatus = "anonymous";
     const { rerender } = renderHook(() => useFirstRunAuthAdoption());
     await flushAdoption();
 
@@ -196,12 +210,43 @@ describe("useFirstRunAuthAdoption", () => {
     expect(useAuthSetupOnboardingStore.getState().adoptedHarnessKinds).toBeNull();
     expect(mocks.refetchAgents).not.toHaveBeenCalled();
 
-    state.cloudActive = true;
+    state.authStatus = "authenticated";
     rerender();
     await waitFor(() => expect(mocks.putMutate).toHaveBeenCalledTimes(1));
 
     expect(mocks.capabilitiesEnabled).toHaveBeenLastCalledWith(true);
     expect(mocks.selectionsEnabled).toHaveBeenLastCalledWith(true);
+  });
+
+  it("keeps an unreachable control plane pending and adopts once it returns", async () => {
+    state.controlPlaneReachable = false;
+    const { rerender } = renderHook(() => useFirstRunAuthAdoption());
+    await flushAdoption();
+
+    expect(mocks.capabilitiesEnabled).toHaveBeenLastCalledWith(false);
+    expect(mocks.selectionsEnabled).toHaveBeenLastCalledWith(false);
+    expect(useAuthSetupOnboardingStore.getState().adoptedHarnessKinds).toBeNull();
+
+    state.controlPlaneReachable = true;
+    rerender();
+    await waitFor(() => expect(mocks.putMutate).toHaveBeenCalledTimes(1));
+  });
+
+  it("adopts the gateway with cloud compute disabled (launch posture)", async () => {
+    // The explicit statement of what the suite-wide `cloudActive: false` proves:
+    // a signed-in user on a reachable control plane gets first-run gateway
+    // adoption even though cloud compute (E2B sandboxes) is switched off.
+    state.cloudActive = false;
+    state.authStatus = "authenticated";
+    state.controlPlaneReachable = true;
+
+    renderHook(() => useFirstRunAuthAdoption());
+    await waitFor(() => expect(mocks.putMutate).toHaveBeenCalledTimes(1));
+
+    expect(mocks.capabilitiesEnabled).toHaveBeenLastCalledWith(true);
+    expect(mocks.selectionsEnabled).toHaveBeenLastCalledWith(true);
+    expect(useAuthSetupOnboardingStore.getState().adoptedHarnessKinds)
+      .toEqual(["claude"]);
   });
 
   it("waits while the Desktop runtime is connecting", async () => {

--- a/apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.test.tsx
+++ b/apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.test.tsx
@@ -12,12 +12,9 @@ import {
 } from "#product/lib/infra/diagnostics/renderer-diagnostics-port";
 
 const state = vi.hoisted(() => ({
-  // Cloud COMPUTE is off for this entire suite, deliberately. That is the
-  // shipped production posture (CLOUD_COMPUTE_TEMPORARILY_DISABLED makes
-  // `cloudActive` false for every signed-in production user), and adoption is a
-  // control-plane concern that must run regardless. Every test below therefore
-  // doubles as the regression guard: re-couple the hook to `cloudActive` and
-  // the whole file fails.
+  // Cloud COMPUTE is off for this whole suite on purpose: that is the shipped
+  // production posture, and adoption is a control-plane concern that must run
+  // regardless. Re-couple the hook to `cloudActive` and every test here fails.
   cloudActive: false,
   authStatus: "authenticated" as "authenticated" | "anonymous" | "loading",
   controlPlaneReachable: true,
@@ -233,13 +230,9 @@ describe("useFirstRunAuthAdoption", () => {
   });
 
   it("adopts the gateway with cloud compute disabled (launch posture)", async () => {
-    // The explicit statement of what the suite-wide `cloudActive: false` proves:
-    // a signed-in user on a reachable control plane gets first-run gateway
-    // adoption even though cloud compute (E2B sandboxes) is switched off.
-    state.cloudActive = false;
-    state.authStatus = "authenticated";
-    state.controlPlaneReachable = true;
-
+    // Explicit statement of what the suite-wide `cloudActive: false` proves: a
+    // signed-in user on a reachable control plane gets gateway adoption even
+    // though cloud compute (E2B sandboxes) is off.
     renderHook(() => useFirstRunAuthAdoption());
     await waitFor(() => expect(mocks.putMutate).toHaveBeenCalledTimes(1));
 

--- a/apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.ts
+++ b/apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.ts
@@ -27,10 +27,20 @@ import { useHarnessConnectionStore } from "#product/stores/sessions/harness-conn
  * settings page stays the authoritative place to manage auth.
  */
 export function useFirstRunAuthAdoption() {
-  const { cloudActive } = useCloudAvailabilityState();
+  const { authStatus, controlPlaneReachable } = useCloudAvailabilityState();
   const isDesktop = useProductHost().desktop !== null;
   const connectionState = useHarnessConnectionStore((state) => state.connectionState);
-  const workflowQueriesEnabled = cloudActive && isDesktop;
+  // Control-plane gate, NOT a cloud-compute gate. Adoption writes auth
+  // selections through the control plane; it has nothing to do with cloud
+  // COMPUTE (E2B sandboxes). The previous `cloudActive = cloudComputeEnabled &&
+  // authenticated` coupling meant a deployment with cloud compute off never ran
+  // first-run adoption at all, so a fresh profile that detected no native
+  // credentials kept zero selections and every gateway harness reported "no
+  // launchable model". Same decoupling as `shouldSyncLocalAuthState`
+  // (lib/domain/agents/local-auth-state.ts) and the settings `authGate`
+  // (components/settings/screen/render-settings-section.tsx, ADR FM6/Q9).
+  const authReady = authStatus === "authenticated" && controlPlaneReachable;
+  const workflowQueriesEnabled = authReady && isDesktop;
   const capabilitiesQuery = useAgentGatewayCapabilities(workflowQueriesEnabled);
   const selectionsQuery = useAuthSelections(null, workflowQueriesEnabled);
   const {
@@ -49,7 +59,7 @@ export function useFirstRunAuthAdoption() {
   const putMutate = putSelections.mutate;
 
   useEffect(() => {
-    if (attemptedRef.current || !cloudActive) {
+    if (attemptedRef.current || !authReady) {
       return;
     }
 
@@ -164,7 +174,7 @@ export function useFirstRunAuthAdoption() {
     capabilitiesQuery.data,
     capabilitiesQuery.error,
     capabilitiesQuery.isError,
-    cloudActive,
+    authReady,
     connectionState,
     isDesktop,
     reconcileError,


### PR DESCRIPTION
## The bug

Three agent-auth surfaces gate on `cloudActive`:

```ts
// hooks/cloud/derived/use-cloud-availability-state.ts:33
const cloudActive = cloudComputeEnabled && authStatus === "authenticated";
```

`cloudComputeEnabled` folds in the launch kill switch:

```ts
// lib/domain/capabilities/app-capabilities.ts:165
cloudComputeEnabled:
  reachable && contract.cloudWorkspaces && !CLOUD_COMPUTE_TEMPORARILY_DISABLED,

// lib/domain/capabilities/cloud-compute.ts:9
export const CLOUD_COMPUTE_TEMPORARILY_DISABLED = true;
```

Verified live against production at the time of writing: `https://app.proliferate.com/api/meta` returns `cloudWorkspaces: true` and `agentGateway: true`. The server says cloud is on. The client constant overrides it, so `cloudActive` evaluates to `true && true && !true` = **false for every signed-in production user**, and all three surfaces are unreachable code in the shipped app.

## Why it matters for launch

The damage lands on the fresh-account path:

- `useFirstRunAuthAdoption` never runs. A new profile that detects no native credentials keeps **zero auth selections** and never adopts the managed gateway, so every gateway harness reports "no launchable model".
- `useAuthSetupOnboardingStep`, which watches that adoption's acks, never runs either.
- `ApiKeysPane` renders a dead gate instead of the BYOK vault.

## The fix

None of the three has anything to do with cloud **compute** (E2B sandboxes). They are control-plane features. They now gate on `authenticated && controlPlaneReachable`.

This is not a new pattern. It is the same decoupling already applied and documented twice in this codebase:

- **`lib/domain/agents/local-auth-state.ts`** — `shouldSyncLocalAuthState`, written for the identical failure mode on the local auth state sync. Its rationale block describes this exact bug.
- **`components/settings/screen/render-settings-section.tsx:57-67`** — the `authGate`, which per **ADR FM6/Q9** already routes the API keys pane through the control-plane gate and names the vault as a control-plane feature. The pane's own body then re-coupled itself to `cloudActive` and slammed the door the router had just opened.

## Copy correction

The pane's empty state carried a claim that stops being true after the decoupling. Reaching that branch while authenticated now means the control plane is unreachable, not that an operator failed to configure cloud. `cloudNotConfigured` is replaced with `serverUnreachable`, so:

| State | Before | After |
|---|---|---|
| Anonymous | Sign in required | Sign in required |
| Signed in, unreachable | "Cloud is not configured" (wrong) | "Can't reach the server" |
| Signed in, reachable, compute off | Dead gate | The vault |

## Testing

All three suites now run with `cloudActive: false` for the entire file. That is the shipped production posture, so **every existing test in those files doubles as the regression guard**: re-couple any of the three to `cloudActive` and the whole file fails.

Four tests added, covering launch posture, sign-out, and unreachable control plane.

**Negative control** — source reverted, tests kept:

```
26 of 55 fail, including all four new tests
```

**With the fix:**

```
Test Files  3 passed (3)
     Tests  55 passed (55)
```

**Full package suite:**

```
Test Files  1095 passed (1095)
     Tests  8177 passed (8177)
```

`pnpm --filter @proliferate/product-client typecheck` clean.

## Out of scope

This does not touch `CLOUD_COMPUTE_TEMPORARILY_DISABLED` or any genuine cloud-compute surface. Cloud compute stays off. The change is strictly about surfaces that were never about compute in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
