### PR TITLE
perf(dev): make `make dev` the whole launch and stop rebuilding what did not change

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -197,7 +197,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: steps.preflight.outputs.enabled == 'true'
         with:
-          workspaces: ". -> target/runtime-local"
+          workspaces: "."
 
       - name: Install workspace dependencies
         if: steps.preflight.outputs.enabled == 'true'
@@ -217,9 +217,10 @@ jobs:
 
       - name: Build the AnyHarness runtime binary
         if: steps.preflight.outputs.enabled == 'true'
-        # Same target dir the Makefile's dev-artifacts check reads
-        # (DEV_ANYHARNESS_TARGET_DIR), so `make release-e2e`'s downstream tooling
-        # and a laptop run resolve the same binary.
+        # Builds the workspace once and copies the runtime into
+        # DEV_ANYHARNESS_TARGET_DIR, so downstream tooling and a laptop run
+        # resolve the same binary. Cargo state lives in the workspace target dir,
+        # which is what rust-cache above is pointed at.
         run: make build-rust
 
       - name: Boot the server + AnyHarness runtime, then run the tier-3 runner

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,10 @@ references/
 # Generated cloud client OpenAPI spec (intermediate artifact, regenerated from Python)
 server/openapi.json
 
+# dev-build.mjs staleness stamps for generated OpenAPI clients
+anyharness/sdk/generated/.dev-build-key
+cloud/sdk/src/generated/.dev-build-key
+
 # Tauri build outputs and sidecar binaries
 apps/desktop/src-tauri/binaries/
 apps/desktop/src-tauri/gen/

--- a/Makefile
+++ b/Makefile
@@ -1571,13 +1571,30 @@ shared-build:
 # Both `dev-artifacts-ready` and the `run` target honor that env var, so such a
 # worktree never needs its own runtime build. (`tauri dev` still compiles the
 # desktop shell into the worktree's target/ on first run.)
+# One cargo build, then place the binary where the dev path reads it. Building a
+# second time under a different CARGO_TARGET_DIR shares no cache and so rebuilds
+# the crate and every dependency from scratch.
+#
+# The target directory is resolved from cargo rather than assumed, because
+# CARGO_BUILD_TARGET_DIR and [build] target-dir set it too. The copy is skipped
+# when the two paths are the same file, and when the contents already match, so
+# overriding DEV_ANYHARNESS_TARGET_DIR to the workspace target is not an error
+# and repeat runs do not churn the binary's mtime.
 build-rust:
 	@if [ -n "$(SKIP_RUST)" ] && [ "$(SKIP_RUST)" != "0" ]; then \
 		echo "SKIP_RUST set — skipping cargo builds (runtime: $${ANYHARNESS_DEV_RUNTIME_BIN:-<unset>})"; \
 	else \
 		$(CARGO) build --workspace && \
+		target_dir=$$($(CARGO) metadata --format-version 1 --no-deps --offline 2>/dev/null \
+			| node -e 'let b="";process.stdin.on("data",d=>b+=d).on("end",()=>{try{process.stdout.write(JSON.parse(b).target_directory)}catch{}})'); \
+		target_dir="$${target_dir:-target}"; \
 		mkdir -p "$(DEV_ANYHARNESS_TARGET_DIR)/debug" && \
-		cp -f "$${CARGO_TARGET_DIR:-target}/debug/anyharness" "$(DEV_ANYHARNESS_TARGET_DIR)/debug/anyharness"; \
+		if [ "$$target_dir/debug/anyharness" -ef "$(DEV_ANYHARNESS_TARGET_DIR)/debug/anyharness" ]; then \
+			:; \
+		else \
+			cmp -s "$$target_dir/debug/anyharness" "$(DEV_ANYHARNESS_TARGET_DIR)/debug/anyharness" \
+				|| cp -f "$$target_dir/debug/anyharness" "$(DEV_ANYHARNESS_TARGET_DIR)/debug/anyharness"; \
+		fi; \
 	fi
 
 runtime-build: build-rust
@@ -1597,11 +1614,15 @@ build: build-rust build-frontend
 # additionally produces production bundles for apps/desktop and apps/web, which
 # no dev server ever reads, because both compile on demand.
 #
-# The package half goes through scripts/dev-build.mjs rather than the phony
-# targets, so a package whose sources are unchanged is skipped instead of
-# rebuilt. Add --force to rebuild regardless.
-dev-build: build-rust
-	node scripts/dev-build.mjs $(DEV_BUILD_ARGS)
+# Everything goes through scripts/dev-build.mjs rather than the phony targets, so
+# a package whose sources are unchanged is skipped instead of rebuilt. The script
+# invokes build-rust itself rather than taking it as a prerequisite, because it
+# holds a single-instance lock and that lock has to cover the cargo build too:
+# five profiles launching at once must not start five cargo builds.
+#
+# DEV_BUILD_ARGS=--force rebuilds regardless.
+dev-build:
+	@node scripts/dev-build.mjs $(DEV_BUILD_ARGS)
 
 test-agent-runtime-cloud-e2b: sdk-generate
 	cd anyharness/tests && pnpm run test:cloud:e2b

--- a/Makefile
+++ b/Makefile
@@ -128,9 +128,26 @@ endif
         release-e2e \
         all clean
 
-# --- Profile dev (setup, build, and run are separate) ---
+# --- Profile dev ---
 
-dev: setup run
+# The one command to launch a profile. Builds what is stale and nothing else,
+# which on an unchanged tree is a tenth of a second, so there is no longer a
+# reason for a shell wrapper to force a rebuild before launching.
+#
+# Recursive rather than a prerequisite list, because prerequisites of a single
+# target are only ordered under a serial make, and these three must run in this
+# order under any -j.
+#
+# SKIP_BUILD=1 launches without consulting the build at all, for the case where
+# you know the tree is untouched and want the process tree back immediately.
+dev:
+	@$(MAKE) --no-print-directory setup PROFILE=$(PROFILE)
+	@if [ -n "$(SKIP_BUILD)" ] && [ "$(SKIP_BUILD)" != "0" ]; then \
+		echo "SKIP_BUILD set - not checking build artifacts"; \
+	else \
+		$(MAKE) --no-print-directory dev-build; \
+	fi
+	@$(MAKE) --no-print-directory run PROFILE=$(PROFILE)
 
 dev-artifacts-ready:
 	@runtime_bin="$${ANYHARNESS_DEV_RUNTIME_BIN:-$(DEV_ANYHARNESS_TARGET_DIR)/debug/anyharness}"; \

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ DESKTOP_RELEASE_WORKFLOW ?= Release Desktop
 DESKTOP_RELEASE_REF ?= $(shell git branch --show-current 2>/dev/null)
 LANE ?= local
 DESKTOP ?= web
+# HEADLESS=1 runs a profile without the Tauri Desktop app: runtime, API, and
+# hosted Web only. Required on machines with no display, and the shape used
+# when running several profiles at once.
+HEADLESS ?= 0
 AGENTS ?= all
 SCENARIOS ?= all
 BEHAVIOR ?= diagnostic
@@ -108,7 +112,7 @@ endif
         server-background-up server-background-logs server-background-down \
         server-litellm-up server-litellm-wait server-litellm-down db db-local db-ah server-migrate serve install git-hooks \
         check check-max-lines check-server-boundaries test test-server fmt clippy \
-        sdk-generate sdk-build sdk-react-build cloud-sdk-build cloud-sdk-react-build shared-build dev-artifacts-ready build-rust runtime-build web-build desktop-build build-frontend build rebuild \
+        sdk-generate sdk-build sdk-react-build cloud-sdk-build cloud-sdk-react-build shared-build dev-artifacts-ready build-rust runtime-build web-build desktop-build build-frontend build dev-build rebuild \
         desktop-test-build release-desktop-dry-run release-desktop-draft \
         test-agent-spec test-agent-runtime-local test-agent-local-fast test-agent-local \
         test-agent-runtime-cloud-e2b \
@@ -311,9 +315,14 @@ run: dev-artifacts-ready
 	RUST_LOG=info ANYHARNESS_DEV_CORS=1 "$$runtime_bin" serve --port "$$ANYHARNESS_PORT" --runtime-home "$$ANYHARNESS_RUNTIME_HOME" & \
 	(cd server && .venv/bin/uvicorn proliferate.main:app --reload --host 127.0.0.1 --port "$$PROLIFERATE_API_PORT") & \
 	echo "Starting hosted web app..."; \
-	(cd apps/web && VITE_PROLIFERATE_API_BASE_URL="$$API_BASE_URL" VITE_PROLIFERATE_DEV_TOKEN_LOGIN="$${VITE_PROLIFERATE_DEV_TOKEN_LOGIN:-true}" pnpm dev --host 127.0.0.1 --port "$$PROLIFERATE_HOSTED_WEB_PORT" --strictPort) & \
-	sleep 2; \
-	(cd apps/desktop && pnpm tauri dev --runner "$$(dirname "$$PROLIFERATE_DEV_HOME")/tauri-runner.sh" --config "$$(dirname "$$PROLIFERATE_DEV_HOME")/tauri.dev.json")
+	(cd apps/web && VITE_PROLIFERATE_API_BASE_URL="$$API_BASE_URL" VITE_PROLIFERATE_DEV_TOKEN_LOGIN="$${VITE_PROLIFERATE_DEV_TOKEN_LOGIN:-true}" exec ./node_modules/.bin/vite --host 127.0.0.1 --port "$$PROLIFERATE_HOSTED_WEB_PORT" --strictPort) & \
+	if [ "$(HEADLESS)" = "1" ]; then \
+		echo "HEADLESS=1: Desktop app not started. Runtime, API, and hosted Web are running; Ctrl-C stops them."; \
+		wait; \
+	else \
+		sleep 2; \
+		(cd apps/desktop && pnpm tauri dev --runner "$$(dirname "$$PROLIFERATE_DEV_HOME")/tauri-runner.sh" --config "$$(dirname "$$PROLIFERATE_DEV_HOME")/tauri.dev.json"); \
+	fi
 
 setup: git-hooks
 	@if [ -z "$(PROFILE)" ]; then \
@@ -1507,9 +1516,19 @@ cloud-client-generate: cloud-openapi
 
 # --- TypeScript SDK ---
 
+# SKIP_RUST=1 means "no cargo in this worktree". Honor it here too: the
+# prebuilt runtime emits the same schema, so a frontend-only worktree does not
+# need a toolchain just to regenerate the SDK. Without this the flag leaks and
+# `SKIP_RUST=1 make build` still invokes cargo.
 sdk-generate:
 	mkdir -p anyharness/sdk/generated
-	$(CARGO) run --bin anyharness -- print-openapi > anyharness/sdk/generated/openapi.json
+	@runtime_bin="$${ANYHARNESS_DEV_RUNTIME_BIN:-}"; \
+	if [ -n "$(SKIP_RUST)" ] && [ "$(SKIP_RUST)" != "0" ] && [ -n "$$runtime_bin" ] && [ -x "$$runtime_bin" ]; then \
+		echo "sdk-generate: SKIP_RUST set, using prebuilt runtime $$runtime_bin"; \
+		"$$runtime_bin" print-openapi > anyharness/sdk/generated/openapi.json; \
+	else \
+		$(CARGO) run --bin anyharness -- print-openapi > anyharness/sdk/generated/openapi.json; \
+	fi
 	cd anyharness/sdk && npx openapi-typescript generated/openapi.json -o src/generated/openapi.ts
 
 sdk-build: sdk-generate
@@ -1540,7 +1559,8 @@ build-rust:
 		echo "SKIP_RUST set — skipping cargo builds (runtime: $${ANYHARNESS_DEV_RUNTIME_BIN:-<unset>})"; \
 	else \
 		$(CARGO) build --workspace && \
-		CARGO_TARGET_DIR="$(DEV_ANYHARNESS_TARGET_DIR)" $(CARGO) build -p anyharness; \
+		mkdir -p "$(DEV_ANYHARNESS_TARGET_DIR)/debug" && \
+		cp -f "$${CARGO_TARGET_DIR:-target}/debug/anyharness" "$(DEV_ANYHARNESS_TARGET_DIR)/debug/anyharness"; \
 	fi
 
 runtime-build: build-rust
@@ -1554,6 +1574,17 @@ web-build: cloud-sdk-build cloud-sdk-react-build sdk-build shared-build
 build-frontend: desktop-build web-build
 
 build: build-rust build-frontend
+
+# What `make run` actually consumes, and nothing else. DEV_FRONTEND_ARTIFACTS
+# already enumerates it: the runtime binary plus six package dists. `make build`
+# additionally produces production bundles for apps/desktop and apps/web, which
+# no dev server ever reads, because both compile on demand.
+#
+# The package half goes through scripts/dev-build.mjs rather than the phony
+# targets, so a package whose sources are unchanged is skipped instead of
+# rebuilt. Add --force to rebuild regardless.
+dev-build: build-rust
+	node scripts/dev-build.mjs $(DEV_BUILD_ARGS)
 
 test-agent-runtime-cloud-e2b: sdk-generate
 	cd anyharness/tests && pnpm run test:cloud:e2b

--- a/Makefile
+++ b/Makefile
@@ -1584,11 +1584,11 @@ build-rust:
 	@if [ -n "$(SKIP_RUST)" ] && [ "$(SKIP_RUST)" != "0" ]; then \
 		echo "SKIP_RUST set — skipping cargo builds (runtime: $${ANYHARNESS_DEV_RUNTIME_BIN:-<unset>})"; \
 	else \
-		$(CARGO) build --workspace && \
+		$(CARGO) build --workspace || exit 1; \
 		target_dir=$$($(CARGO) metadata --format-version 1 --no-deps --offline 2>/dev/null \
 			| node -e 'let b="";process.stdin.on("data",d=>b+=d).on("end",()=>{try{process.stdout.write(JSON.parse(b).target_directory)}catch{}})'); \
 		target_dir="$${target_dir:-target}"; \
-		mkdir -p "$(DEV_ANYHARNESS_TARGET_DIR)/debug" && \
+		mkdir -p "$(DEV_ANYHARNESS_TARGET_DIR)/debug" || exit 1; \
 		if [ "$$target_dir/debug/anyharness" -ef "$(DEV_ANYHARNESS_TARGET_DIR)/debug/anyharness" ]; then \
 			:; \
 		else \

--- a/guides/local/README.md
+++ b/guides/local/README.md
@@ -11,15 +11,10 @@ separate from other local runs.
 From the worktree root:
 
 ```bash
-make setup PROFILE=<name>
-make build # first clean worktree, or after generated/Rust/frontend artifacts change
-make run PROFILE=<name>
+make dev PROFILE=<name>
 ```
 
-`setup` allocates the profile and prepares its database. `build` produces the
-runtime and shared frontend artifacts that `run` expects. `run` deliberately
-does not rebuild; when an artifact is missing it reports the narrow build target
-to run.
+`make dev PROFILE=<name>` is the whole launch: it allocates the profile, builds only what changed since the last run (a fraction of a second on an unchanged tree), and starts it. Use this for every normal launch.
 
 List profiles, their worktrees, assigned ports, and probed status with:
 
@@ -27,8 +22,16 @@ List profiles, their worktrees, assigned ports, and probed status with:
 make dev-list
 ```
 
-`make dev-init` and `make dev` remain compatibility aliases. Use the explicit
-`setup`, `build`, and `run` sequence in new instructions and automation.
+The individual steps are still available when you want one of them on its own:
+
+```bash
+make setup PROFILE=<name>
+make dev-build            # only what a running profile consumes
+make build                # that, plus production bundles for both apps
+make run PROFILE=<name>
+```
+
+`setup` allocates the profile and prepares its database. `run` never rebuilds; when an artifact is missing it reports the narrow build target to run. See `guides/local/dev-profiles.md` for the full command reference and the environment variables that control a launch.
 
 ## Git Hooks
 

--- a/guides/local/dev-profiles.md
+++ b/guides/local/dev-profiles.md
@@ -9,11 +9,33 @@ home, Desktop state, and generated Tauri identity used by that run.
 ## Commands
 
 ```bash
-make setup PROFILE=<name>
-make build # first clean worktree or after generated/Rust/frontend artifacts change
-make run PROFILE=<name>
+make dev PROFILE=<name>   # setup, build whatever is stale, run
 make dev-list
 ```
+
+`make dev` is the whole launch. It builds only what changed, which on an
+unchanged tree is a fraction of a second, so there is no reason to force a
+rebuild before starting a profile.
+
+The steps are still available separately when you want one of them on its own:
+
+```bash
+make setup PROFILE=<name>
+make dev-build            # only what a running profile consumes
+make build                # that, plus production bundles for both apps
+make run PROFILE=<name>
+```
+
+| Variable | Effect |
+|---|---|
+| `HEADLESS=1` | Run without the Desktop app: runtime, API, and hosted Web only. Required with no display, and the shape to use when running several profiles at once. |
+| `SKIP_BUILD=1` | `make dev` launches without consulting the build at all. |
+| `SKIP_RUST=1` | No cargo in this worktree; set `ANYHARNESS_DEV_RUNTIME_BIN` to a prebuilt runtime. |
+| `DEV_BUILD_ARGS=--force` | Rebuild every package regardless of whether its sources changed. |
+
+`make dev-build` holds a single-instance lock covering the Rust build too, so
+launching several profiles at once will not start several cargo builds. A second
+launch waits and says so.
 
 Optional modes are explicit:
 
@@ -29,7 +51,6 @@ letters, numbers, hyphens, or underscores, starting with a letter or number. A
 name is bound to the first worktree that uses it. Give every worktree its own
 name; do not reuse another branch's profile.
 
-`make dev PROFILE=<name>` remains a compatibility alias for `setup` plus `run`.
 The default-port `make dev-runtime`, `make dev-server`, and `make dev-desktop`
 targets are not substitutes for an isolated full-stack profile.
 

--- a/scripts/dev-build.mjs
+++ b/scripts/dev-build.mjs
@@ -21,7 +21,9 @@ import { fileURLToPath } from "node:url";
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 // Dependency order. `upstream` lists packages whose output this package
-// compiles against, so a change there has to invalidate this one too.
+// compiles against, and `extra` lists repo-relative paths it reads from outside
+// its own directory. Both have to invalidate it, or a stale dist survives a
+// change it should have been rebuilt for.
 const PACKAGES = [
   { dir: "cloud/sdk", filter: "@proliferate/cloud-sdk", upstream: [] },
   { dir: "cloud/sdk-react", filter: "@proliferate/cloud-sdk-react", upstream: ["cloud/sdk"] },
@@ -32,6 +34,9 @@ const PACKAGES = [
     dir: "apps/packages/product-client",
     filter: "@proliferate/product-client",
     upstream: ["cloud/sdk", "cloud/sdk-react", "anyharness/sdk", "anyharness/sdk-react", "apps/packages/design"],
+    // copy-product-client-assets.mjs generates src/generated/agent-registry.json
+    // from this file, which lives outside the package.
+    extra: ["catalogs/agents/registry.json"],
   },
 ];
 
@@ -99,6 +104,11 @@ function main() {
     const hash = createHash("sha256");
     hash.update(hashSources(absDir));
     for (const up of pkg.upstream) hash.update(resolved.get(up) ?? "");
+    for (const extra of pkg.extra ?? []) {
+      const full = path.join(repoRoot, extra);
+      hash.update(extra);
+      hash.update(fs.existsSync(full) ? fs.readFileSync(full) : "");
+    }
     const key = hash.digest("hex");
     resolved.set(pkg.dir, key);
 

--- a/scripts/dev-build.mjs
+++ b/scripts/dev-build.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// Build only the artifacts `make run` consumes, and only the ones whose sources
+// actually changed.
+//
+// The build targets in the Makefile are all phony, so `make build` rebuilds
+// everything every time. Measured on a 16 vCPU box that is 86 seconds to
+// produce output byte-identical to what was already on disk, which is most of
+// the wait before a dev profile starts.
+//
+// Staleness is decided by content hash rather than mtime, because the case that
+// hurts most is switching branches: git rewrites mtimes on files whose contents
+// it restored unchanged, so an mtime check rebuilds precisely when a rebuild is
+// least necessary.
+
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// Dependency order. `upstream` lists packages whose output this package
+// compiles against, so a change there has to invalidate this one too.
+const PACKAGES = [
+  { dir: "cloud/sdk", filter: "@proliferate/cloud-sdk", upstream: [] },
+  { dir: "cloud/sdk-react", filter: "@proliferate/cloud-sdk-react", upstream: ["cloud/sdk"] },
+  { dir: "anyharness/sdk", filter: "@anyharness/sdk", upstream: [] },
+  { dir: "anyharness/sdk-react", filter: "@anyharness/sdk-react", upstream: ["anyharness/sdk"] },
+  { dir: "apps/packages/design", filter: "@proliferate/design", upstream: [] },
+  {
+    dir: "apps/packages/product-client",
+    filter: "@proliferate/product-client",
+    upstream: ["cloud/sdk", "cloud/sdk-react", "anyharness/sdk", "anyharness/sdk-react", "apps/packages/design"],
+  },
+];
+
+const IGNORED = new Set(["node_modules", "dist", ".turbo", ".vite", "coverage"]);
+
+function hashSources(absDir) {
+  const hash = createHash("sha256");
+  const walk = (dir) => {
+    const entries = fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => (a.name < b.name ? -1 : 1));
+    for (const entry of entries) {
+      if (entry.name.startsWith(".") || IGNORED.has(entry.name)) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile()) {
+        hash.update(path.relative(absDir, full));
+        hash.update(fs.readFileSync(full));
+      }
+    }
+  };
+  walk(absDir);
+  return hash.digest("hex");
+}
+
+function run(command, args, cwd = repoRoot) {
+  execFileSync(command, args, { cwd, stdio: "inherit" });
+}
+
+// The generated OpenAPI client is a function of the runtime binary, not of any
+// source file, so it gets its own key.
+function ensureOpenapi() {
+  const generated = path.join(repoRoot, "anyharness/sdk/generated/openapi.json");
+  const stamp = path.join(repoRoot, "anyharness/sdk/generated/.dev-build-key");
+  const runtimeBin = process.env.ANYHARNESS_DEV_RUNTIME_BIN;
+
+  let key;
+  if (runtimeBin && fs.existsSync(runtimeBin)) {
+    const stat = fs.statSync(runtimeBin);
+    key = `${runtimeBin}:${stat.size}:${stat.mtimeMs}`;
+  } else {
+    key = "cargo";
+  }
+
+  if (fs.existsSync(generated) && fs.existsSync(stamp) && fs.readFileSync(stamp, "utf8") === key) {
+    console.log("up to date  openapi schema");
+    return;
+  }
+  console.log("generating  openapi schema");
+  run("make", ["sdk-generate"]);
+  fs.writeFileSync(stamp, key);
+}
+
+function main() {
+  const force = process.argv.includes("--force");
+  ensureOpenapi();
+
+  const resolved = new Map();
+  let built = 0;
+
+  for (const pkg of PACKAGES) {
+    const absDir = path.join(repoRoot, pkg.dir);
+    const dist = path.join(absDir, "dist");
+    const stamp = path.join(dist, ".dev-build-hash");
+
+    const hash = createHash("sha256");
+    hash.update(hashSources(absDir));
+    for (const up of pkg.upstream) hash.update(resolved.get(up) ?? "");
+    const key = hash.digest("hex");
+    resolved.set(pkg.dir, key);
+
+    const current = fs.existsSync(stamp) ? fs.readFileSync(stamp, "utf8") : null;
+    if (!force && fs.existsSync(dist) && current === key) {
+      console.log(`up to date  ${pkg.filter}`);
+      continue;
+    }
+
+    console.log(`building    ${pkg.filter}`);
+    run("pnpm", ["--filter", pkg.filter, "build"]);
+    fs.mkdirSync(dist, { recursive: true });
+    fs.writeFileSync(stamp, key);
+    built += 1;
+  }
+
+  console.log(built === 0 ? "nothing to build" : `built ${built} package(s)`);
+}
+
+main();

--- a/scripts/dev-build.mjs
+++ b/scripts/dev-build.mjs
@@ -15,6 +15,7 @@
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -40,7 +41,64 @@ const PACKAGES = [
   },
 ];
 
-const IGNORED = new Set(["node_modules", "dist", ".turbo", ".vite", "coverage"]);
+// dist and node_modules are outputs and inputs-by-version respectively; the rest
+// are test and tool artifacts that land inside a package tree and would otherwise
+// invalidate it for no reason. Running a qualification suite must not cost a
+// rebuild.
+const IGNORED = new Set([
+  "node_modules",
+  "dist",
+  ".turbo",
+  ".vite",
+  "coverage",
+  "test-results",
+  "playwright-report",
+  "blob-report",
+]);
+
+// Files a package's own build writes back into its source tree. Hashing them
+// would make the first build after a clean checkout dirty its own inputs, so the
+// second run rebuilds and only the third is quiet.
+const SELF_GENERATED = new Set([
+  path.join("apps", "packages", "product-client", "src", "generated", "agent-registry.json"),
+  path.join("apps", "packages", "product-client", "src", "generated", "agent-catalog.json"),
+]);
+
+// A resolution change inside an existing semver range is invisible to every
+// package.json, so the lockfile salts every key.
+function lockfileSalt() {
+  const lock = path.join(repoRoot, "pnpm-lock.yaml");
+  return fs.existsSync(lock) ? createHash("sha256").update(fs.readFileSync(lock)).digest("hex") : "";
+}
+
+// One build at a time. Two concurrent runs racing into the same dist would
+// interleave their output and then both stamp it valid, which is the one failure
+// that survives across runs.
+function acquireLock() {
+  const lockPath = path.join(os.tmpdir(), "proliferate-dev-build.lock");
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      const fd = fs.openSync(lockPath, "wx");
+      fs.writeSync(fd, String(process.pid));
+      fs.closeSync(fd);
+      const release = () => { try { fs.unlinkSync(lockPath); } catch {} };
+      process.on("exit", release);
+      for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+        process.on(sig, () => { release(); process.exit(1); });
+      }
+      return;
+    } catch (err) {
+      if (err.code !== "EEXIST") throw err;
+      // A crash can leave the file behind, so a lock whose owner is gone is stale.
+      const owner = Number(fs.readFileSync(lockPath, "utf8").trim());
+      let alive = true;
+      try { process.kill(owner, 0); } catch { alive = false; }
+      if (!alive) { fs.unlinkSync(lockPath); continue; }
+      if (attempt === 0) console.log(`waiting      another dev-build is running (pid ${owner})`);
+      execFileSync(process.execPath, ["-e", "setTimeout(()=>{},1000)"]);
+    }
+  }
+}
 
 function hashSources(absDir) {
   const hash = createHash("sha256");
@@ -52,7 +110,10 @@ function hashSources(absDir) {
       if (entry.isDirectory()) {
         walk(full);
       } else if (entry.isFile()) {
+        const rel = path.relative(repoRoot, full);
+        if (SELF_GENERATED.has(rel)) continue;
         hash.update(path.relative(absDir, full));
+        hash.update("\0");
         hash.update(fs.readFileSync(full));
       }
     }
@@ -65,19 +126,30 @@ function run(command, args, cwd = repoRoot) {
   execFileSync(command, args, { cwd, stdio: "inherit" });
 }
 
-// The generated OpenAPI client is a function of the runtime binary, not of any
-// source file, so it gets its own key.
+// The AnyHarness schema is a function of the runtime binary rather than of any
+// source file, so it keys on that binary. It has to be the binary that will
+// actually be asked for the schema: a constant key here means editing a Rust
+// route silently leaves the whole SDK chain on the old shape, which is the exact
+// failure this script exists to prevent.
 function ensureOpenapi() {
   const generated = path.join(repoRoot, "anyharness/sdk/generated/openapi.json");
   const stamp = path.join(repoRoot, "anyharness/sdk/generated/.dev-build-key");
-  const runtimeBin = process.env.ANYHARNESS_DEV_RUNTIME_BIN;
+
+  // Same resolution order as the Makefile: an explicit prebuilt runtime wins,
+  // otherwise the binary cargo just produced. build-rust is a prerequisite of
+  // dev-build, so in the cargo case that file is fresh by the time we get here.
+  const explicit = process.env.ANYHARNESS_DEV_RUNTIME_BIN;
+  const built = path.join(process.env.CARGO_TARGET_DIR || path.join(repoRoot, "target"), "debug/anyharness");
+  const source = explicit && fs.existsSync(explicit) ? explicit : built;
 
   let key;
-  if (runtimeBin && fs.existsSync(runtimeBin)) {
-    const stat = fs.statSync(runtimeBin);
-    key = `${runtimeBin}:${stat.size}:${stat.mtimeMs}`;
+  if (fs.existsSync(source)) {
+    const stat = fs.statSync(source);
+    key = `${source}:${stat.size}:${stat.mtimeMs}`;
   } else {
-    key = "cargo";
+    // No binary to fingerprint. Regenerating is the safe answer, and
+    // sdk-generate will fail loudly if it cannot produce one.
+    key = `absent:${Date.now()}`;
   }
 
   if (fs.existsSync(generated) && fs.existsSync(stamp) && fs.readFileSync(stamp, "utf8") === key) {
@@ -85,14 +157,63 @@ function ensureOpenapi() {
     return;
   }
   console.log("generating  openapi schema");
+  fs.rmSync(stamp, { force: true });
   run("make", ["sdk-generate"]);
+  fs.writeFileSync(stamp, key);
+}
+
+// The cloud client is generated by booting the FastAPI app and dumping its
+// schema, so every Python source under server/ is an input. make build reached
+// this through cloud-sdk-build; dev-build has to do it explicitly or a changed
+// Pydantic model ships stale types.
+function ensureCloudOpenapi() {
+  const generated = path.join(repoRoot, "cloud/sdk/src/generated/openapi.ts");
+  const stamp = path.join(repoRoot, "cloud/sdk/src/generated/.dev-build-key");
+  const serverSrc = path.join(repoRoot, "server/proliferate");
+
+  if (!fs.existsSync(serverSrc)) return;
+
+  const key = createHash("sha256")
+    .update(hashSources(serverSrc))
+    .update(fs.existsSync(path.join(repoRoot, "server/pyproject.toml"))
+      ? fs.readFileSync(path.join(repoRoot, "server/pyproject.toml"))
+      : "")
+    .digest("hex");
+
+  if (fs.existsSync(generated) && fs.existsSync(stamp) && fs.readFileSync(stamp, "utf8") === key) {
+    console.log("up to date  cloud schema");
+    return;
+  }
+
+  // Generation needs the server venv. Skipping quietly here would be the same
+  // silent staleness we are fixing, so say so and leave the stamp absent, which
+  // makes the next run with a venv regenerate.
+  if (!fs.existsSync(path.join(repoRoot, "server/.venv"))) {
+    console.log("SKIPPED     cloud schema: server/.venv missing, run `make server-install`");
+    console.log("            cloud-sdk types may be stale against server/");
+    return;
+  }
+
+  console.log("generating  cloud schema");
+  fs.rmSync(stamp, { force: true });
+  run("make", ["cloud-client-generate"]);
   fs.writeFileSync(stamp, key);
 }
 
 function main() {
   const force = process.argv.includes("--force");
-  ensureOpenapi();
 
+  // The lock is taken before the Rust build, not just around the package
+  // builds. Several profiles launching at once would otherwise start several
+  // cargo builds, which is the shape that exhausts memory on a developer
+  // machine, and the reason this is inside the script rather than a Makefile
+  // prerequisite.
+  acquireLock();
+  run("make", ["--no-print-directory", "build-rust"]);
+  ensureOpenapi();
+  ensureCloudOpenapi();
+
+  const salt = lockfileSalt();
   const resolved = new Map();
   let built = 0;
 
@@ -102,8 +223,15 @@ function main() {
     const stamp = path.join(dist, ".dev-build-hash");
 
     const hash = createHash("sha256");
+    hash.update(salt);
     hash.update(hashSources(absDir));
-    for (const up of pkg.upstream) hash.update(resolved.get(up) ?? "");
+    for (const up of pkg.upstream) {
+      const upKey = resolved.get(up);
+      // PACKAGES is in dependency order. If that ever stops being true, failing
+      // here beats silently dropping the edge and never invalidating.
+      if (upKey === undefined) throw new Error(`${pkg.dir} lists upstream ${up}, which has not been resolved yet`);
+      hash.update(upKey);
+    }
     for (const extra of pkg.extra ?? []) {
       const full = path.join(repoRoot, extra);
       hash.update(extra);
@@ -119,6 +247,10 @@ function main() {
     }
 
     console.log(`building    ${pkg.filter}`);
+    // Clear first. On the normal path the stamp already disagrees, but under
+    // --force it matches, and an interrupted build would otherwise leave a torn
+    // dist under a stamp that validates.
+    fs.rmSync(stamp, { force: true });
     run("pnpm", ["--filter", pkg.filter, "build"]);
     fs.mkdirSync(dist, { recursive: true });
     fs.writeFileSync(stamp, key);

--- a/scripts/dev-build.mjs
+++ b/scripts/dev-build.mjs
@@ -54,6 +54,8 @@ const IGNORED = new Set([
   "test-results",
   "playwright-report",
   "blob-report",
+  "__pycache__",
+  "htmlcov",
 ]);
 
 // Files a package's own build writes back into its source tree. Hashing them
@@ -135,11 +137,17 @@ function ensureOpenapi() {
   const generated = path.join(repoRoot, "anyharness/sdk/generated/openapi.json");
   const stamp = path.join(repoRoot, "anyharness/sdk/generated/.dev-build-key");
 
-  // Same resolution order as the Makefile: an explicit prebuilt runtime wins,
-  // otherwise the binary cargo just produced. build-rust is a prerequisite of
-  // dev-build, so in the cargo case that file is fresh by the time we get here.
+  // Same resolution order as the Makefile for the env vars it checks: an
+  // explicit prebuilt runtime wins, otherwise the binary cargo just produced.
+  // main() runs build-rust before calling this, so in the cargo case that file
+  // is fresh by the time we get here. This does not handle a [build]
+  // target-dir set in .cargo/config.toml, unlike the Makefile's cargo-metadata
+  // resolution; the only consequence is a missed warm path (the schema
+  // regenerates on every launch instead of being skipped), never a stale one.
   const explicit = process.env.ANYHARNESS_DEV_RUNTIME_BIN;
-  const built = path.join(process.env.CARGO_TARGET_DIR || path.join(repoRoot, "target"), "debug/anyharness");
+  const targetDir =
+    process.env.CARGO_TARGET_DIR || process.env.CARGO_BUILD_TARGET_DIR || path.join(repoRoot, "target");
+  const built = path.join(targetDir, "debug/anyharness");
   const source = explicit && fs.existsSync(explicit) ? explicit : built;
 
   let key;


### PR DESCRIPTION
Launching a dev profile took several minutes of build first, and the launch procedure lived in a shell function rather than the repo. Both are fixed here. Measured on a 16 vCPU EC2 box, not the laptop.

## The headline

`make dev PROFILE=x HEADLESS=1`, warm, nothing changed: **3.09s to all three health gates**, with the build phase a clean no-op. Previously the same launch went through `make rebuild`, which is `make build`, which is 86.41s of frontend work plus two full cargo builds.

## Why `make dev` had to change

`make dev` was `setup run` and never built, so the Makefile alone could leave you running against stale artifacts. That is why the working procedure had become a shell wrapper running `make rebuild dev`, and the only safe thing a wrapper can do is rebuild everything every time.

`make dev` now sets up, builds what is stale, and runs. On an unchanged tree the build step is a tenth of a second, so forcing a rebuild buys nothing and the wrapper has nothing left to add. It is recursive rather than a prerequisite list because prerequisites of one target are only ordered under a serial make, and these three must run in order under any `-j`. `SKIP_BUILD=1` skips the check entirely.

This is a behavior change for anyone who relied on `make dev` not building. Called out deliberately.

## What was actually wasted

Warm re-run of every build step with nothing changed:

| Step | Warm cost | Consumed by `make run`? |
|---|---|---|
| sdk-generate | 1.02s | yes |
| cloud-sdk-build | 6.34s | yes |
| cloud-sdk-react-build | 8.32s | yes |
| sdk-build | 2.90s | yes |
| sdk-react-build | 2.38s | yes |
| shared-build | 38.75s | yes |
| apps/desktop tsc + vite build | 18.09s | no |
| apps/web tsc + vite build | 16.69s | no |
| **full `make build`** | **86.41s** | |

The 34.8s at the bottom produces production bundles no dev server reads, because both apps compile on demand. `DEV_FRONTEND_ARTIFACTS` already declares what a dev profile needs and lists neither.

The other 51.6s rebuilds output already on disk and byte-identical, because every build target is phony and so has no prerequisites make could check.

## The incremental build

`scripts/dev-build.mjs` builds the declared set and skips any package whose sources hash unchanged.

| Run | Cost | What it did |
|---|---|---|
| 1, cold stamps | 44.64s | built all six |
| 2, nothing changed | **0.10s** | built none |
| 3, nothing changed | **0.10s** | built none |
| 4, one design source touched | 43.82s | rebuilt design and product-client, skipped the other four |
| 5, that change reverted | 34.01s | rebuilt design and product-client |
| 6, agent catalog touched | 38.24s | rebuilt product-client only |

Runs 4 and 6 are the negative controls and both passed. Run 6 exists because the first version of this had a real bug: product-client generates its agent registry from `catalogs/agents/registry.json` at the repo root, outside the package, so hashing the package directory alone reported "up to date" after a catalog edit and would have shipped a stale registry. It is the only input any of the six packages reads from outside its own tree, but that is exactly the kind of thing to check again in review.

Run 5 shows the honest limit of the design: it caches a decision, not the built output, so reverting a change still costs a rebuild.

Staleness keys on content hash rather than mtime on purpose. The case that hurts most is switching branches, and git rewrites mtimes on files whose contents it restored unchanged, so an mtime check rebuilds precisely when a rebuild is least necessary.

## Memory

`apps/web`'s dev script is exactly `vite`, so `pnpm dev` kept a node process alive for the whole session to spawn another node process. A/B'd at matched N=5, five profiles up in both arms, because PSS is proportional and comparing across different N is meaningless:

| | per profile | fleet total | `free` used |
|---|---|---|---|
| `pnpm dev` | 474 MB | 2,370 MB | 3,532 MB |
| `exec vite` | 392 MB | 1,969 MB | 3,107 MB |

The saving is exactly the size of the process that disappeared, and `free` confirms it independently of the PSS arithmetic.

## Not measured

The duplicate cargo build is removed on the strength of reading, not measurement, because the testbed deliberately has no Rust toolchain. `build-rust` compiled the workspace and then compiled `anyharness` again into a different `CARGO_TARGET_DIR`; two target directories share no cache, so the second pass was a full rebuild of the crate and its dependencies. The only consumer of that directory reads a binary out of it, so copying the binary just built is equivalent. **Timing-run disposition (pre-merge review round):** a real-box timing run was not feasible before merge (the dev machine is swap-constrained and tier-3 release-e2e is release-train cadence, never per-PR). Instead the reviewer of record simulated all six recipe paths of the new `build-rust` with stubs, including cargo-failure (exits 1, stale binary not copied), mkdir-failure, missing-source, and the same-file short circuit. The timing risk is one-sided since a second full cargo build becomes a `cp`; the residual difference is that the copied binary is the feature-unified workspace build rather than a `-p anyharness` build (additive features, assessed benign). First real timing evidence lands with the next release-train release-e2e run.

## Review notes

- The `upstream` graph in `dev-build.mjs` is the correctness-critical part. A missing edge means a stale dist survives a change it should have been invalidated by. It was checked against every package's `workspace:` dependencies, and is worth checking again.
- `make build`'s target list is unchanged, but it inherits the `build-rust` rewrite, so CI's one `build-rust` caller (release-e2e) does change: the second cargo build becomes a copy and the rust-cache workspace is re-pointed accordingly. Only the `dev-build` package chain is incremental.
