### PR TITLE
feat(dev): disposable EC2 testbed for multi-profile measurement

### DIFF
--- a/scripts/fleet-testbed/lib.sh
+++ b/scripts/fleet-testbed/lib.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Shared configuration for the fleet concurrency testbed.
+#
+# Every resource this lane creates carries TAG_KEY=TAG_VALUE and lives inside a
+# dedicated VPC. Teardown requires BOTH predicates to match, so no single
+# mistake can select a production instance in the same account.
+
+set -euo pipefail
+
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+
+TAG_KEY="Project"
+TAG_VALUE="proliferate-fleet-testbed"
+NAME_PREFIX="proliferate-fleet-testbed"
+
+VPC_CIDR="10.42.0.0/16"
+SUBNET_CIDR="10.42.1.0/24"
+
+KEY_NAME="${NAME_PREFIX}"
+KEY_PATH="${HOME}/.ssh/${NAME_PREFIX}.pem"
+ROLE_NAME="${NAME_PREFIX}"
+PROFILE_NAME="${NAME_PREFIX}"
+SSM_PREFIX="/${NAME_PREFIX}"
+
+# Architecture. The agent_process sidecar the runtime installs is pinned for
+# linux_x64 only, so x86_64 is the default: on arm64 the install endpoint fails
+# with AGENT_NO_PIN_FOR_PLATFORM and no session can run a turn.
+ARCH="${ARCH:-x86_64}"
+case "$ARCH" in
+  x86_64) AMI_ARCH=amd64;  AWSCLI_ARCH=x86_64;  MUSL_ARCH=x86_64;  DEFAULT_TYPE=m7i.4xlarge ;;
+  arm64)  AMI_ARCH=arm64;  AWSCLI_ARCH=aarch64; MUSL_ARCH=aarch64; DEFAULT_TYPE=m8g.4xlarge ;;
+  *) echo "unsupported ARCH: $ARCH (want x86_64 or arm64)" >&2; exit 1 ;;
+esac
+
+# Ubuntu 24.04, resolved from Canonical's public SSM parameter so the AMI is
+# never a stale literal.
+AMI_SSM_PARAM="/aws/service/canonical/ubuntu/server/24.04/stable/current/${AMI_ARCH}/hvm/ebs-gp3/ami-id"
+
+# Prebuilt runtime. Pinning the repo to this release's own commit keeps binary
+# and source exactly in step, so no schema skew can be mistaken for a finding.
+RELEASE_TAG="${RELEASE_TAG:-server-v0.4.20}"
+RELEASE_COMMIT="${RELEASE_COMMIT:-be045d63dafc7a74838aa17f00dfb2f6a4e18ed7}"
+
+# Branch carrying the dev-loop fixes the testbed needs (HEADLESS, dev-build).
+# Cherry-picked onto RELEASE_COMMIT rather than checked out, so the tree stays
+# at the release and binary and source cannot disagree.
+FIX_BRANCH="${FIX_BRANCH:-perf/dev-loop-launch}"
+
+# Deadman. The instance shuts itself down after this long and terminates,
+# because run-instances sets instance-initiated-shutdown-behavior=terminate.
+DEADMAN_HOURS="${DEADMAN_HOURS:-12}"
+
+tag_spec() {
+  # $1 = resource type
+  echo "ResourceType=$1,Tags=[{Key=${TAG_KEY},Value=${TAG_VALUE}},{Key=Name,Value=${NAME_PREFIX}}]"
+}
+
+log() { printf '[fleet-testbed] %s\n' "$*" >&2; }
+
+die() { printf '[fleet-testbed] ERROR: %s\n' "$*" >&2; exit 1; }
+
+require_testbed_vpc() {
+  # Resolves the dedicated VPC id, failing loudly rather than falling back to
+  # the default VPC, which in this account holds production instances.
+  local vpc_id
+  vpc_id=$(aws ec2 describe-vpcs \
+    --filters "Name=tag:${TAG_KEY},Values=${TAG_VALUE}" \
+    --query 'Vpcs[0].VpcId' --output text)
+  [ "$vpc_id" != "None" ] && [ -n "$vpc_id" ] || die "no testbed VPC found; run provision.sh first"
+  echo "$vpc_id"
+}

--- a/scripts/fleet-testbed/lib.sh
+++ b/scripts/fleet-testbed/lib.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 # Shared configuration for the fleet concurrency testbed.
 #
-# Every resource this lane creates carries TAG_KEY=TAG_VALUE and lives inside a
-# dedicated VPC. Teardown requires BOTH predicates to match, so no single
-# mistake can select a production instance in the same account.
+# This account also runs production, and production lives in the DEFAULT VPC.
+# Every resource this lane creates therefore carries TAG_KEY=TAG_VALUE and lives
+# inside a dedicated non-default VPC whose CIDR nothing else uses. Selection for
+# any destructive operation asserts all three: the tag, the CIDR, and
+# IsDefault=false. See find_testbed_vpc.
+
+# Every value defined below is consumed by the scripts that source this file,
+# which a per-file unused-variable check cannot see.
+# shellcheck disable=SC2034
 
 set -euo pipefail
 
@@ -21,6 +27,12 @@ KEY_PATH="${HOME}/.ssh/${NAME_PREFIX}.pem"
 ROLE_NAME="${NAME_PREFIX}"
 PROFILE_NAME="${NAME_PREFIX}"
 SSM_PREFIX="/${NAME_PREFIX}"
+
+# The account this lane is expected to run in. The safety story is "this account
+# also holds production", so running the scripts anywhere else is a mistake
+# worth stopping on. Override deliberately with FLEET_TESTBED_ACCOUNT_ID when
+# someone is legitimately using a different account.
+EXPECTED_ACCOUNT_ID="${FLEET_TESTBED_ACCOUNT_ID:-157466816238}"
 
 # Architecture. The agent_process sidecar the runtime installs is pinned for
 # linux_x64 only, so x86_64 is the default: on arm64 the install endpoint fails
@@ -59,13 +71,72 @@ log() { printf '[fleet-testbed] %s\n' "$*" >&2; }
 
 die() { printf '[fleet-testbed] ERROR: %s\n' "$*" >&2; exit 1; }
 
-require_testbed_vpc() {
-  # Resolves the dedicated VPC id, failing loudly rather than falling back to
-  # the default VPC, which in this account holds production instances.
-  local vpc_id
-  vpc_id=$(aws ec2 describe-vpcs \
+require_expected_account() {
+  # Everything below assumes production shares this account. Assert it, so the
+  # tag/CIDR/default-VPC guards are being applied where they were designed.
+  local account
+  account=$(aws sts get-caller-identity --query Account --output text) \
+    || die "could not read the caller identity; are AWS credentials configured?"
+  [ -n "$account" ] && [ "$account" != "None" ] \
+    || die "sts get-caller-identity returned no account"
+  if [ "$account" != "$EXPECTED_ACCOUNT_ID" ]; then
+    die "refusing to run in account ${account}; expected ${EXPECTED_ACCOUNT_ID}. Set FLEET_TESTBED_ACCOUNT_ID=${account} if that is deliberate."
+  fi
+  ACCOUNT_ID="$account"
+}
+
+require_safe_ref() {
+  # $1 = label, $2 = value. Values templated into a root-executed user-data
+  # script must not be able to close a quote or introduce shell metacharacters,
+  # and sed would silently mangle `&` and the `|` delimiter besides. Git refs,
+  # release tags, and commit shas all fit inside this class.
+  local label="$1" value="$2"
+  [ -n "$value" ] || die "${label} is empty"
+  case "$value" in
+    *[!A-Za-z0-9._/@+-]*) die "${label} contains characters that are unsafe to template into user-data: ${value}" ;;
+  esac
+  case "$value" in
+    -*) die "${label} must not start with a dash: ${value}" ;;
+  esac
+}
+
+require_positive_int() {
+  local label="$1" value="$2"
+  case "$value" in
+    ''|*[!0-9]*) die "${label} must be a positive integer, got: ${value}" ;;
+  esac
+  [ "$value" -gt 0 ] || die "${label} must be greater than zero"
+}
+
+find_testbed_vpc() {
+  # Echoes the testbed VPC id, or nothing when it does not exist yet. Three
+  # independent predicates, not one applied twice: the project tag, an exact
+  # match on the dedicated CIDR (EC2's `cidr` filter is an exact primary-CIDR
+  # match), and IsDefault=false, because production lives in the default VPC.
+  # Anything other than exactly one match is an error rather than a pick.
+  local rows count vpc_id cidr is_default
+  rows=$(aws ec2 describe-vpcs \
     --filters "Name=tag:${TAG_KEY},Values=${TAG_VALUE}" \
-    --query 'Vpcs[0].VpcId' --output text)
-  [ "$vpc_id" != "None" ] && [ -n "$vpc_id" ] || die "no testbed VPC found; run provision.sh first"
+              "Name=cidr,Values=${VPC_CIDR}" \
+              "Name=is-default,Values=false" \
+    --query 'Vpcs[].[VpcId,CidrBlock,IsDefault]' --output text)
+
+  rows=$(printf '%s\n' "$rows" | grep -v '^[[:space:]]*$' || true)
+  [ -n "$rows" ] || return 0
+
+  count=$(printf '%s\n' "$rows" | wc -l | tr -d '[:space:]')
+  [ "$count" = "1" ] \
+    || die "expected exactly one VPC tagged ${TAG_KEY}=${TAG_VALUE} with CIDR ${VPC_CIDR}, found ${count}; resolve by hand before running anything destructive"
+
+  read -r vpc_id cidr is_default <<<"$rows"
+
+  # Re-assert on the returned attributes rather than trusting the filters alone.
+  case "$vpc_id" in vpc-*) ;; *) die "unexpected VPC id: ${vpc_id}" ;; esac
+  [ "$cidr" = "$VPC_CIDR" ] || die "VPC ${vpc_id} has CIDR ${cidr}, expected ${VPC_CIDR}"
+  case "$is_default" in
+    [Ff]alse) ;;
+    *) die "VPC ${vpc_id} reports IsDefault=${is_default}; the default VPC holds production and is never a teardown target" ;;
+  esac
+
   echo "$vpc_id"
 }

--- a/scripts/fleet-testbed/lib.sh
+++ b/scripts/fleet-testbed/lib.sh
@@ -5,7 +5,7 @@
 # Every resource this lane creates therefore carries TAG_KEY=TAG_VALUE and lives
 # inside a dedicated non-default VPC whose CIDR nothing else uses. Selection for
 # any destructive operation asserts all three: the tag, the CIDR, and
-# IsDefault=false. See find_testbed_vpc.
+# IsDefault=false. See resolve_testbed_vpc.
 
 # Every value defined below is consumed by the scripts that source this file,
 # which a per-file unused-variable check cannot see.
@@ -108,18 +108,34 @@ require_positive_int() {
   [ "$value" -gt 0 ] || die "${label} must be greater than zero"
 }
 
-find_testbed_vpc() {
-  # Echoes the testbed VPC id, or nothing when it does not exist yet. Three
-  # independent predicates, not one applied twice: the project tag, an exact
-  # match on the dedicated CIDR (EC2's `cidr` filter is an exact primary-CIDR
-  # match), and IsDefault=false, because production lives in the default VPC.
-  # Anything other than exactly one match is an error rather than a pick.
+# Result of resolve_testbed_vpc. Empty means "does not exist", and it is only
+# ever meaningful immediately after a successful call.
+TESTBED_VPC_ID=""
+
+resolve_testbed_vpc() {
+  # Sets TESTBED_VPC_ID to the testbed VPC id, or to "" when it does not exist
+  # yet. Deliberately NOT a function whose value is captured with $(...): bash
+  # unsets errexit inside a command substitution unless inherit_errexit is on,
+  # and inherit_errexit does not exist at all in the bash 3.2 that macOS ships.
+  # Captured that way, a throttled or denied describe-vpcs would return an empty
+  # string with status 0 and every caller would read it as "no testbed VPC" --
+  # which silently turns `teardown --network` into a no-op that leaves the
+  # instance and the token alive, and turns provision into a second VPC at the
+  # same CIDR. Running in the caller's shell keeps errexit and `die` real.
+  #
+  # Three independent predicates, not one applied twice: the project tag, an
+  # exact match on the dedicated CIDR (EC2's `cidr` filter is an exact
+  # primary-CIDR match), and IsDefault=false, because production lives in the
+  # default VPC. Anything other than exactly one match is an error, not a pick.
+  TESTBED_VPC_ID=""
+
   local rows count vpc_id cidr is_default
   rows=$(aws ec2 describe-vpcs \
     --filters "Name=tag:${TAG_KEY},Values=${TAG_VALUE}" \
               "Name=cidr,Values=${VPC_CIDR}" \
               "Name=is-default,Values=false" \
-    --query 'Vpcs[].[VpcId,CidrBlock,IsDefault]' --output text)
+    --query 'Vpcs[].[VpcId,CidrBlock,IsDefault]' --output text) \
+    || die "describe-vpcs failed while resolving the testbed VPC; refusing to guess whether it exists"
 
   rows=$(printf '%s\n' "$rows" | grep -v '^[[:space:]]*$' || true)
   [ -n "$rows" ] || return 0
@@ -138,5 +154,65 @@ find_testbed_vpc() {
     *) die "VPC ${vpc_id} reports IsDefault=${is_default}; the default VPC holds production and is never a teardown target" ;;
   esac
 
-  echo "$vpc_id"
+  TESTBED_VPC_ID="$vpc_id"
+}
+
+require_ipv4() {
+  # $1 = label, $2 = value. Rejects anything that is not four plain decimal
+  # octets, including the shapes a dot-count check waves through: `1.2.3.`,
+  # `1.2.3.4.5`, `00.0.0.0`, and `999.0.0.1`. An SSH allowlist entry is not a
+  # place to accept a string AWS might interpret differently than this script.
+  local label="$1" value="$2"
+  local o1 o2 o3 o4 rest octet
+  IFS=. read -r o1 o2 o3 o4 rest <<<"$value"
+  [ -z "${rest:-}" ] || die "${label} is not a dotted-quad IPv4: ${value}"
+  for octet in "$o1" "$o2" "$o3" "$o4"; do
+    case "$octet" in
+      ''|*[!0-9]*) die "${label} is not a dotted-quad IPv4: ${value}" ;;
+      0) ;;
+      0*) die "${label} has a leading-zero octet, which is ambiguous: ${value}" ;;
+    esac
+    [ "${#octet}" -le 3 ] && [ "$octet" -le 255 ] \
+      || die "${label} has an out-of-range octet: ${value}"
+  done
+  [ "$value" != "0.0.0.0" ] || die "${label} is 0.0.0.0; refusing to use it in a rule"
+}
+
+read_github_token() {
+  # Prints the GitHub token on stdout, with no trailing newline, from whichever
+  # source the operator configured. Call it with a redirect, never as $(...):
+  # inside a command substitution `die` would only kill the subshell and the
+  # caller would proceed with an empty token. See resolve_testbed_vpc.
+  #
+  # Deliberately pluggable: the default is the
+  # personal `gh` credential, which is broader than this box needs, so a
+  # narrower fine-grained PAT can be supplied without editing the scripts.
+  #
+  #   FLEET_TESTBED_TOKEN_FILE=/path/to/pat     read a token from a file
+  #   FLEET_TESTBED_TOKEN_COMMAND='op read ...' run a command that prints one
+  #   (neither set)                             `gh auth token`
+  local token=""
+  if [ -n "${FLEET_TESTBED_TOKEN_FILE:-}" ]; then
+    [ -r "$FLEET_TESTBED_TOKEN_FILE" ] \
+      || die "FLEET_TESTBED_TOKEN_FILE is not readable: ${FLEET_TESTBED_TOKEN_FILE}"
+    token=$(cat "$FLEET_TESTBED_TOKEN_FILE") \
+      || die "could not read FLEET_TESTBED_TOKEN_FILE"
+  elif [ -n "${FLEET_TESTBED_TOKEN_COMMAND:-}" ]; then
+    token=$(eval "$FLEET_TESTBED_TOKEN_COMMAND") \
+      || die "FLEET_TESTBED_TOKEN_COMMAND failed"
+  else
+    token=$(gh auth token) \
+      || die "gh auth token failed; run 'gh auth login', or set FLEET_TESTBED_TOKEN_FILE to a scoped PAT"
+  fi
+
+  # Trim surrounding whitespace, so the SecureString holds exactly the token and
+  # not the trailing newline `file://` would otherwise carry into it.
+  token="${token#"${token%%[![:space:]]*}"}"
+  token="${token%"${token##*[![:space:]]}"}"
+
+  [ -n "$token" ] || die "the configured GitHub token source produced an empty token"
+  case "$token" in
+    *[[:space:]]*) die "the configured GitHub token source produced whitespace inside the token" ;;
+  esac
+  printf '%s' "$token"
 }

--- a/scripts/fleet-testbed/provision.sh
+++ b/scripts/fleet-testbed/provision.sh
@@ -5,9 +5,12 @@
 #   ./provision.sh [--arch x86_64|arm64] [--type <instance-type>] [--disk 200]
 #                  [--ref <git-ref>] [--with-rust] [--no-wait]
 #
-# Idempotent: network, key pair, and IAM role are created once and reused.
-# Everything is tagged and lives in a dedicated VPC so teardown can require two
-# independent predicates before terminating anything.
+# Idempotent: network, key pair, IAM role, and the SSM token are created or
+# refreshed on every run and reused. Everything is tagged and lives in a
+# dedicated non-default VPC, so teardown can assert tag, CIDR, and non-default
+# together before deleting anything in an account that also holds production.
+
+set -euo pipefail
 
 # --arch selects the AMI, the awscli build, and the musl artifact, so it has to
 # be known before lib.sh derives them.
@@ -19,7 +22,7 @@ export ARCH="${ARCH:-x86_64}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
-source "${SCRIPT_DIR}/lib.sh"
+source "${SCRIPT_DIR}/lib.sh" || { echo "fatal: cannot source ${SCRIPT_DIR}/lib.sh" >&2; exit 1; }
 
 INSTANCE_TYPE="$DEFAULT_TYPE"
 DISK_GB="200"
@@ -29,9 +32,9 @@ WAIT_READY="1"
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --type) INSTANCE_TYPE="$2"; shift 2 ;;
-    --disk) DISK_GB="$2"; shift 2 ;;
-    --ref) REPO_REF="$2"; shift 2 ;;
+    --type) INSTANCE_TYPE="${2:-}"; shift 2 ;;
+    --disk) DISK_GB="${2:-}"; shift 2 ;;
+    --ref) REPO_REF="${2:-}"; shift 2 ;;
     --with-rust) WITH_RUST="1"; shift ;;
     --arch) shift 2 ;;
     --no-wait) WAIT_READY="0"; shift ;;
@@ -39,15 +42,36 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+# Everything below is templated into a script that cloud-init runs as root, so
+# validate before substituting rather than hoping a ref never contains a quote.
+require_safe_ref "--ref" "$REPO_REF"
+require_safe_ref "--type" "$INSTANCE_TYPE"
+require_safe_ref "FIX_BRANCH" "$FIX_BRANCH"
+require_safe_ref "RELEASE_TAG" "$RELEASE_TAG"
+require_safe_ref "SSM_PREFIX" "$SSM_PREFIX"
+require_safe_ref "AWS_DEFAULT_REGION" "$AWS_DEFAULT_REGION"
+require_safe_ref "AWSCLI_ARCH" "$AWSCLI_ARCH"
+require_safe_ref "MUSL_ARCH" "$MUSL_ARCH"
+require_positive_int "--disk" "$DISK_GB"
+require_positive_int "DEADMAN_HOURS" "$DEADMAN_HOURS"
+
+# The whole safety design assumes production shares this account.
+require_expected_account
+log "account ${ACCOUNT_ID}, region ${AWS_DEFAULT_REGION}"
+
 MY_IP="$(curl -fsS --max-time 10 https://checkip.amazonaws.com | tr -d '[:space:]')"
-[ -n "$MY_IP" ] || die "could not determine public IP for the SSH allowlist"
+case "$MY_IP" in
+  *[!0-9.]*|'') die "could not determine a public IPv4 for the SSH allowlist (got '${MY_IP}')" ;;
+esac
+[ "$(printf '%s' "$MY_IP" | tr -cd '.' | wc -c | tr -d '[:space:]')" = "3" ] \
+  || die "public IP is not dotted-quad IPv4: ${MY_IP}"
+[ "$MY_IP" != "0.0.0.0" ] || die "refusing to allowlist 0.0.0.0"
 
 # --- network -----------------------------------------------------------------
 
-VPC_ID=$(aws ec2 describe-vpcs --filters "Name=tag:${TAG_KEY},Values=${TAG_VALUE}" \
-  --query 'Vpcs[0].VpcId' --output text)
+VPC_ID="$(find_testbed_vpc)"
 
-if [ "$VPC_ID" = "None" ] || [ -z "$VPC_ID" ]; then
+if [ -z "$VPC_ID" ]; then
   log "creating dedicated VPC ${VPC_CIDR}"
   VPC_ID=$(aws ec2 create-vpc --cidr-block "$VPC_CIDR" \
     --tag-specifications "$(tag_spec vpc)" --query 'Vpc.VpcId' --output text)
@@ -69,8 +93,11 @@ if [ "$VPC_ID" = "None" ] || [ -z "$VPC_ID" ]; then
   aws ec2 associate-route-table --route-table-id "$RT_ID" --subnet-id "$SUBNET_ID" >/dev/null
 else
   log "reusing VPC ${VPC_ID}"
-  SUBNET_ID=$(aws ec2 describe-subnets --filters "Name=vpc-id,Values=${VPC_ID}" \
+  SUBNET_ID=$(aws ec2 describe-subnets \
+    --filters "Name=vpc-id,Values=${VPC_ID}" "Name=tag:${TAG_KEY},Values=${TAG_VALUE}" \
     --query 'Subnets[0].SubnetId' --output text)
+  [ -n "$SUBNET_ID" ] && [ "$SUBNET_ID" != "None" ] \
+    || die "VPC ${VPC_ID} has no tagged testbed subnet; delete it with teardown.sh --network and re-provision"
 fi
 
 SG_ID=$(aws ec2 describe-security-groups \
@@ -84,58 +111,124 @@ if [ "$SG_ID" = "None" ] || [ -z "$SG_ID" ]; then
     --tag-specifications "$(tag_spec security-group)" --query 'GroupId' --output text)
 fi
 
-# Refresh the SSH rule for the current IP; harmless when it already exists.
+# Replace the SSH rule rather than adding one. Authorizing on every run without
+# revoking accumulates stale /32s until the 60-rule quota is hit, at which point
+# new authorizes fail and the caller silently cannot SSH in.
+EXISTING_SSH=$(aws ec2 describe-security-groups --group-ids "$SG_ID" \
+  --query 'SecurityGroups[0].IpPermissions[?FromPort==`22` && ToPort==`22`]' \
+  --output json)
+if [ "$(printf '%s' "$EXISTING_SSH" | tr -d '[:space:]')" != "[]" ]; then
+  log "revoking existing port-22 rules on ${SG_ID}"
+  aws ec2 revoke-security-group-ingress --group-id "$SG_ID" \
+    --ip-permissions "$EXISTING_SSH" >/dev/null
+fi
+log "authorizing SSH from ${MY_IP}/32"
 aws ec2 authorize-security-group-ingress --group-id "$SG_ID" --protocol tcp \
-  --port 22 --cidr "${MY_IP}/32" >/dev/null 2>&1 || true
+  --port 22 --cidr "${MY_IP}/32" >/dev/null
 
 # --- key pair ----------------------------------------------------------------
 
-if ! aws ec2 describe-key-pairs --key-names "$KEY_NAME" >/dev/null 2>&1; then
+KEY_IN_AWS="0"
+if aws ec2 describe-key-pairs --key-names "$KEY_NAME" >/dev/null 2>&1; then
+  KEY_IN_AWS="1"
+fi
+KEY_ON_DISK="0"
+if [ -s "$KEY_PATH" ]; then
+  KEY_ON_DISK="1"
+fi
+
+if [ "$KEY_IN_AWS" = "1" ] && [ "$KEY_ON_DISK" = "0" ]; then
+  die "key pair ${KEY_NAME} exists in AWS but ${KEY_PATH} is missing or empty; any instance launched with it would be unreachable. Restore the file, or delete the pair with: aws ec2 delete-key-pair --key-name ${KEY_NAME}"
+elif [ "$KEY_IN_AWS" = "0" ] && [ "$KEY_ON_DISK" = "1" ]; then
+  die "${KEY_PATH} exists but AWS has no key pair named ${KEY_NAME}; move the stale file aside before re-provisioning"
+elif [ "$KEY_IN_AWS" = "0" ]; then
   log "creating key pair, private key at ${KEY_PATH}"
-  aws ec2 create-key-pair --key-name "$KEY_NAME" --key-type ed25519 \
-    --tag-specifications "$(tag_spec key-pair)" \
-    --query 'KeyMaterial' --output text > "$KEY_PATH"
-  chmod 600 "$KEY_PATH"
+  mkdir -p "$(dirname "$KEY_PATH")"
+  chmod 700 "$(dirname "$KEY_PATH")" 2>/dev/null || true
+  # Write mode-600 from the first byte and only move into place on success, so a
+  # failed create can never truncate a private key that is still live in AWS.
+  KEY_TMP="${KEY_PATH}.tmp.$$"
+  trap 'rm -f "$KEY_TMP"' EXIT
+  (
+    umask 077
+    aws ec2 create-key-pair --key-name "$KEY_NAME" --key-type ed25519 \
+      --tag-specifications "$(tag_spec key-pair)" \
+      --query 'KeyMaterial' --output text > "$KEY_TMP"
+  )
+  [ -s "$KEY_TMP" ] || die "create-key-pair returned no key material"
+  mv "$KEY_TMP" "$KEY_PATH"
+  trap - EXIT
 fi
 
 # --- IAM role: SSM parameter read + Bedrock invoke ---------------------------
 
+CREATED_IAM="0"
 if ! aws iam get-role --role-name "$ROLE_NAME" >/dev/null 2>&1; then
   log "creating IAM role ${ROLE_NAME}"
   aws iam create-role --role-name "$ROLE_NAME" \
     --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}' \
     --tags "Key=${TAG_KEY},Value=${TAG_VALUE}" >/dev/null
+  CREATED_IAM="1"
+fi
 
-  ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-  aws iam put-role-policy --role-name "$ROLE_NAME" --policy-name testbed-access \
-    --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[
-      {\"Effect\":\"Allow\",\"Action\":[\"ssm:GetParameter\"],\"Resource\":\"arn:aws:ssm:${AWS_DEFAULT_REGION}:${ACCOUNT_ID}:parameter${SSM_PREFIX}/*\"},
-      {\"Effect\":\"Allow\",\"Action\":[\"kms:Decrypt\"],\"Resource\":\"*\",\"Condition\":{\"StringEquals\":{\"kms:ViaService\":\"ssm.${AWS_DEFAULT_REGION}.amazonaws.com\"}}},
-      {\"Effect\":\"Allow\",\"Action\":[\"bedrock:InvokeModel\",\"bedrock:InvokeModelWithResponseStream\"],\"Resource\":\"*\"},
-      {\"Effect\":\"Allow\",\"Action\":[\"ec2:TerminateInstances\"],\"Resource\":\"*\",\"Condition\":{\"StringEquals\":{\"ec2:ResourceTag/${TAG_KEY}\":\"${TAG_VALUE}\"}}}
-    ]}" >/dev/null
+# Unconditional, and idempotent: gating these on get-role means a run that died
+# between create-role and put-role-policy never self-repairs, and an edit to the
+# policy below never reaches an existing deployment.
+#
+# Bedrock is scoped to the Anthropic Claude models the agent actually invokes,
+# both as foundation models (a cross-region inference profile resolves to the
+# destination region's foundation-model ARN) and as the region-prefixed
+# inference profiles the catalog uses. It is not `Resource: "*"`, because this
+# account's Bedrock is what production agent auth runs on and a testbed agent
+# has no business reaching anything else in it.
+aws iam put-role-policy --role-name "$ROLE_NAME" --policy-name testbed-access \
+  --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[
+    {\"Effect\":\"Allow\",\"Action\":[\"ssm:GetParameter\"],\"Resource\":\"arn:aws:ssm:${AWS_DEFAULT_REGION}:${ACCOUNT_ID}:parameter${SSM_PREFIX}/*\"},
+    {\"Effect\":\"Allow\",\"Action\":[\"kms:Decrypt\"],\"Resource\":\"*\",\"Condition\":{\"StringEquals\":{\"kms:ViaService\":\"ssm.${AWS_DEFAULT_REGION}.amazonaws.com\"}}},
+    {\"Effect\":\"Allow\",\"Action\":[\"bedrock:InvokeModel\",\"bedrock:InvokeModelWithResponseStream\"],\"Resource\":[
+      \"arn:aws:bedrock:*::foundation-model/anthropic.claude-*\",
+      \"arn:aws:bedrock:*:${ACCOUNT_ID}:inference-profile/*anthropic.claude-*\"
+    ]}
+  ]}" >/dev/null
 
+if ! aws iam get-instance-profile --instance-profile-name "$PROFILE_NAME" >/dev/null 2>&1; then
+  log "creating instance profile ${PROFILE_NAME}"
   aws iam create-instance-profile --instance-profile-name "$PROFILE_NAME" >/dev/null
-  aws iam add-role-to-instance-profile --instance-profile-name "$PROFILE_NAME" --role-name "$ROLE_NAME"
+  CREATED_IAM="1"
+fi
+
+# Also unconditional. add-role-to-instance-profile returns LimitExceeded when the
+# role is already attached, which is the only already-done case and is benign.
+if ! aws iam add-role-to-instance-profile \
+    --instance-profile-name "$PROFILE_NAME" --role-name "$ROLE_NAME" 2>/dev/null; then
+  aws iam get-instance-profile --instance-profile-name "$PROFILE_NAME" \
+    --query "InstanceProfile.Roles[?RoleName=='${ROLE_NAME}'].RoleName" --output text \
+    | grep -q "$ROLE_NAME" \
+    || die "could not attach role ${ROLE_NAME} to instance profile ${PROFILE_NAME}"
+fi
+
+if [ "$CREATED_IAM" = "1" ]; then
   log "waiting for instance profile to propagate"
   sleep 15
 fi
 
 # --- GitHub token in SSM (never in user-data) --------------------------------
 
-if ! aws ssm get-parameter --name "${SSM_PREFIX}/github-token" >/dev/null 2>&1; then
-  log "storing GitHub token in SSM SecureString"
-  # Via a mode-600 temp file rather than an argv value, so the token never
-  # appears in the process table.
-  TOKEN_FILE="$(mktemp)"
-  chmod 600 "$TOKEN_FILE"
-  trap 'rm -f "$TOKEN_FILE"' EXIT
-  gh auth token > "$TOKEN_FILE"
-  aws ssm put-parameter --name "${SSM_PREFIX}/github-token" \
-    --type SecureString --value "file://${TOKEN_FILE}" --overwrite >/dev/null
-  rm -f "$TOKEN_FILE"
-  trap - EXIT
-fi
+# Written on every run, not only when absent. A revoked or rotated token left in
+# SSM otherwise breaks every future clone with an authentication error that
+# looks nothing like its cause.
+log "refreshing GitHub token in SSM SecureString"
+TOKEN_FILE="$(mktemp)"
+chmod 600 "$TOKEN_FILE"
+trap 'rm -f "$TOKEN_FILE"' EXIT
+# Via a mode-600 temp file rather than an argv value, so the token never
+# appears in the process table.
+gh auth token > "$TOKEN_FILE" || die "gh auth token failed; run 'gh auth login' first"
+[ -s "$TOKEN_FILE" ] || die "gh auth token produced an empty token"
+aws ssm put-parameter --name "${SSM_PREFIX}/github-token" \
+  --type SecureString --value "file://${TOKEN_FILE}" --overwrite >/dev/null
+rm -f "$TOKEN_FILE"
+trap - EXIT
 
 # --- launch ------------------------------------------------------------------
 
@@ -153,6 +246,11 @@ USER_DATA=$(sed \
   -e "s|__FIX_BRANCH__|${FIX_BRANCH}|g" \
   "${SCRIPT_DIR}/user-data.sh")
 
+case "$USER_DATA" in
+  *__REPO_REF__*|*__FIX_BRANCH__*|*__SSM_PREFIX__*|*__AWS_REGION__*)
+    die "user-data still contains unsubstituted placeholders" ;;
+esac
+
 log "launching ${INSTANCE_TYPE} (${ARCH}) from ${AMI_ID} (ref ${REPO_REF}, rust=${WITH_RUST}, deadman ${DEADMAN_HOURS}h)"
 INSTANCE_ID=$(aws ec2 run-instances \
   --image-id "$AMI_ID" \
@@ -162,6 +260,7 @@ INSTANCE_ID=$(aws ec2 run-instances \
   --security-group-ids "$SG_ID" \
   --iam-instance-profile "Name=${PROFILE_NAME}" \
   --instance-initiated-shutdown-behavior terminate \
+  --metadata-options "HttpEndpoint=enabled,HttpTokens=required,HttpPutResponseHopLimit=1" \
   --block-device-mappings "[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"VolumeSize\":${DISK_GB},\"VolumeType\":\"gp3\",\"DeleteOnTermination\":true}}]" \
   --tag-specifications "$(tag_spec instance)" "$(tag_spec volume)" \
   --user-data "$USER_DATA" \
@@ -179,7 +278,7 @@ instance   ${INSTANCE_ID}
 type       ${INSTANCE_TYPE}
 ip         ${PUBLIC_IP}
 ssh        ssh -i ${KEY_PATH} ubuntu@${PUBLIC_IP}
-setup log  ssh -i ${KEY_PATH} ubuntu@${PUBLIC_IP} 'tail -f /var/log/fleet-testbed-setup.log'
+setup log  ssh -i ${KEY_PATH} ubuntu@${PUBLIC_IP} 'sudo tail -f /var/log/fleet-testbed-setup.log'
 ready when /var/lib/fleet-testbed-ready exists
 deadman    self-terminates after ${DEADMAN_HOURS}h
 teardown   ${SCRIPT_DIR}/teardown.sh
@@ -201,5 +300,5 @@ if [ "$WAIT_READY" = "1" ]; then
     fi
     sleep 30
   done
-  die "setup did not finish within 60 minutes; check /var/log/fleet-testbed-setup.log"
+  die "setup did not finish within 60 minutes; check 'sudo tail /var/log/fleet-testbed-setup.log' on ${PUBLIC_IP}"
 fi

--- a/scripts/fleet-testbed/provision.sh
+++ b/scripts/fleet-testbed/provision.sh
@@ -59,17 +59,16 @@ require_positive_int "DEADMAN_HOURS" "$DEADMAN_HOURS"
 require_expected_account
 log "account ${ACCOUNT_ID}, region ${AWS_DEFAULT_REGION}"
 
-MY_IP="$(curl -fsS --max-time 10 https://checkip.amazonaws.com | tr -d '[:space:]')"
-case "$MY_IP" in
-  *[!0-9.]*|'') die "could not determine a public IPv4 for the SSH allowlist (got '${MY_IP}')" ;;
-esac
-[ "$(printf '%s' "$MY_IP" | tr -cd '.' | wc -c | tr -d '[:space:]')" = "3" ] \
-  || die "public IP is not dotted-quad IPv4: ${MY_IP}"
-[ "$MY_IP" != "0.0.0.0" ] || die "refusing to allowlist 0.0.0.0"
+MY_IP="$(curl -fsS --max-time 10 https://checkip.amazonaws.com | tr -d '[:space:]')" \
+  || die "could not reach checkip.amazonaws.com to determine the SSH allowlist address"
+require_ipv4 "the caller's public IP" "$MY_IP"
 
 # --- network -----------------------------------------------------------------
 
-VPC_ID="$(find_testbed_vpc)"
+# Sets TESTBED_VPC_ID in this shell rather than through $(...), so a failing
+# describe cannot masquerade as "no testbed VPC" and create a second one.
+resolve_testbed_vpc
+VPC_ID="$TESTBED_VPC_ID"
 
 if [ -z "$VPC_ID" ]; then
   log "creating dedicated VPC ${VPC_CIDR}"
@@ -111,16 +110,21 @@ if [ "$SG_ID" = "None" ] || [ -z "$SG_ID" ]; then
     --tag-specifications "$(tag_spec security-group)" --query 'GroupId' --output text)
 fi
 
-# Replace the SSH rule rather than adding one. Authorizing on every run without
-# revoking accumulates stale /32s until the 60-rule quota is hit, at which point
-# new authorizes fail and the caller silently cannot SSH in.
-EXISTING_SSH=$(aws ec2 describe-security-groups --group-ids "$SG_ID" \
-  --query 'SecurityGroups[0].IpPermissions[?FromPort==`22` && ToPort==`22`]' \
-  --output json)
-if [ "$(printf '%s' "$EXISTING_SSH" | tr -d '[:space:]')" != "[]" ]; then
-  log "revoking existing port-22 rules on ${SG_ID}"
+# Replace the whole ingress rule set rather than adding to it. Authorizing on
+# every run without revoking accumulates stale /32s until the 60-rule quota is
+# hit, at which point new authorizes fail and the caller silently cannot SSH in.
+#
+# Every rule goes, not only the ones with FromPort and ToPort both exactly 22: a
+# range rule, or an IpProtocol of -1, reaches port 22 without matching an
+# exact-22 predicate. This security group exists solely to carry this lane's SSH
+# rule, so its contents being a pure function of this script is the point. A
+# port opened here by hand does not survive the next provision, deliberately.
+EXISTING_INGRESS=$(aws ec2 describe-security-groups --group-ids "$SG_ID" \
+  --query 'SecurityGroups[0].IpPermissions' --output json)
+if [ "$(printf '%s' "$EXISTING_INGRESS" | tr -d '[:space:]')" != "[]" ]; then
+  log "revoking every existing ingress rule on ${SG_ID}"
   aws ec2 revoke-security-group-ingress --group-id "$SG_ID" \
-    --ip-permissions "$EXISTING_SSH" >/dev/null
+    --ip-permissions "$EXISTING_INGRESS" >/dev/null
 fi
 log "authorizing SSH from ${MY_IP}/32"
 aws ec2 authorize-security-group-ingress --group-id "$SG_ID" --protocol tcp \
@@ -221,10 +225,12 @@ log "refreshing GitHub token in SSM SecureString"
 TOKEN_FILE="$(mktemp)"
 chmod 600 "$TOKEN_FILE"
 trap 'rm -f "$TOKEN_FILE"' EXIT
-# Via a mode-600 temp file rather than an argv value, so the token never
-# appears in the process table.
-gh auth token > "$TOKEN_FILE" || die "gh auth token failed; run 'gh auth login' first"
-[ -s "$TOKEN_FILE" ] || die "gh auth token produced an empty token"
+# Via a mode-600 temp file rather than an argv value, so the token never appears
+# in the process table. Redirected rather than captured, so the value never
+# becomes a variable in this shell and a failure inside the reader is fatal
+# instead of yielding an empty token.
+read_github_token > "$TOKEN_FILE"
+[ -s "$TOKEN_FILE" ] || die "the configured GitHub token source produced nothing"
 aws ssm put-parameter --name "${SSM_PREFIX}/github-token" \
   --type SecureString --value "file://${TOKEN_FILE}" --overwrite >/dev/null
 rm -f "$TOKEN_FILE"
@@ -246,10 +252,10 @@ USER_DATA=$(sed \
   -e "s|__FIX_BRANCH__|${FIX_BRANCH}|g" \
   "${SCRIPT_DIR}/user-data.sh")
 
-case "$USER_DATA" in
-  *__REPO_REF__*|*__FIX_BRANCH__*|*__SSM_PREFIX__*|*__AWS_REGION__*)
-    die "user-data still contains unsubstituted placeholders" ;;
-esac
+# Every placeholder, not a hand-maintained subset of them: an unsubstituted one
+# reaches the instance as a literal and fails somewhere far from its cause.
+LEFTOVER=$(printf '%s\n' "$USER_DATA" | grep -oE '__[A-Z][A-Z0-9_]*__' | sort -u | tr '\n' ' ' || true)
+[ -z "$LEFTOVER" ] || die "user-data still contains unsubstituted placeholders: ${LEFTOVER}"
 
 log "launching ${INSTANCE_TYPE} (${ARCH}) from ${AMI_ID} (ref ${REPO_REF}, rust=${WITH_RUST}, deadman ${DEADMAN_HOURS}h)"
 INSTANCE_ID=$(aws ec2 run-instances \

--- a/scripts/fleet-testbed/provision.sh
+++ b/scripts/fleet-testbed/provision.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Provision one fleet concurrency testbed instance.
+#
+# Usage:
+#   ./provision.sh [--arch x86_64|arm64] [--type <instance-type>] [--disk 200]
+#                  [--ref <git-ref>] [--with-rust] [--no-wait]
+#
+# Idempotent: network, key pair, and IAM role are created once and reused.
+# Everything is tagged and lives in a dedicated VPC so teardown can require two
+# independent predicates before terminating anything.
+
+# --arch selects the AMI, the awscli build, and the musl artifact, so it has to
+# be known before lib.sh derives them.
+for _i in "$@"; do
+  case "${_prev:-}" in --arch) ARCH="$_i" ;; esac
+  _prev="$_i"
+done
+export ARCH="${ARCH:-x86_64}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+INSTANCE_TYPE="$DEFAULT_TYPE"
+DISK_GB="200"
+REPO_REF="$RELEASE_COMMIT"
+WITH_RUST="0"
+WAIT_READY="1"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --type) INSTANCE_TYPE="$2"; shift 2 ;;
+    --disk) DISK_GB="$2"; shift 2 ;;
+    --ref) REPO_REF="$2"; shift 2 ;;
+    --with-rust) WITH_RUST="1"; shift ;;
+    --arch) shift 2 ;;
+    --no-wait) WAIT_READY="0"; shift ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+MY_IP="$(curl -fsS --max-time 10 https://checkip.amazonaws.com | tr -d '[:space:]')"
+[ -n "$MY_IP" ] || die "could not determine public IP for the SSH allowlist"
+
+# --- network -----------------------------------------------------------------
+
+VPC_ID=$(aws ec2 describe-vpcs --filters "Name=tag:${TAG_KEY},Values=${TAG_VALUE}" \
+  --query 'Vpcs[0].VpcId' --output text)
+
+if [ "$VPC_ID" = "None" ] || [ -z "$VPC_ID" ]; then
+  log "creating dedicated VPC ${VPC_CIDR}"
+  VPC_ID=$(aws ec2 create-vpc --cidr-block "$VPC_CIDR" \
+    --tag-specifications "$(tag_spec vpc)" --query 'Vpc.VpcId' --output text)
+  aws ec2 modify-vpc-attribute --vpc-id "$VPC_ID" --enable-dns-hostnames
+
+  IGW_ID=$(aws ec2 create-internet-gateway \
+    --tag-specifications "$(tag_spec internet-gateway)" \
+    --query 'InternetGateway.InternetGatewayId' --output text)
+  aws ec2 attach-internet-gateway --vpc-id "$VPC_ID" --internet-gateway-id "$IGW_ID"
+
+  SUBNET_ID=$(aws ec2 create-subnet --vpc-id "$VPC_ID" --cidr-block "$SUBNET_CIDR" \
+    --tag-specifications "$(tag_spec subnet)" --query 'Subnet.SubnetId' --output text)
+  aws ec2 modify-subnet-attribute --subnet-id "$SUBNET_ID" --map-public-ip-on-launch
+
+  RT_ID=$(aws ec2 create-route-table --vpc-id "$VPC_ID" \
+    --tag-specifications "$(tag_spec route-table)" --query 'RouteTable.RouteTableId' --output text)
+  aws ec2 create-route --route-table-id "$RT_ID" --destination-cidr-block 0.0.0.0/0 \
+    --gateway-id "$IGW_ID" >/dev/null
+  aws ec2 associate-route-table --route-table-id "$RT_ID" --subnet-id "$SUBNET_ID" >/dev/null
+else
+  log "reusing VPC ${VPC_ID}"
+  SUBNET_ID=$(aws ec2 describe-subnets --filters "Name=vpc-id,Values=${VPC_ID}" \
+    --query 'Subnets[0].SubnetId' --output text)
+fi
+
+SG_ID=$(aws ec2 describe-security-groups \
+  --filters "Name=vpc-id,Values=${VPC_ID}" "Name=group-name,Values=${NAME_PREFIX}" \
+  --query 'SecurityGroups[0].GroupId' --output text)
+
+if [ "$SG_ID" = "None" ] || [ -z "$SG_ID" ]; then
+  log "creating security group (SSH from ${MY_IP}/32 only)"
+  SG_ID=$(aws ec2 create-security-group --group-name "$NAME_PREFIX" \
+    --description "Fleet concurrency testbed" --vpc-id "$VPC_ID" \
+    --tag-specifications "$(tag_spec security-group)" --query 'GroupId' --output text)
+fi
+
+# Refresh the SSH rule for the current IP; harmless when it already exists.
+aws ec2 authorize-security-group-ingress --group-id "$SG_ID" --protocol tcp \
+  --port 22 --cidr "${MY_IP}/32" >/dev/null 2>&1 || true
+
+# --- key pair ----------------------------------------------------------------
+
+if ! aws ec2 describe-key-pairs --key-names "$KEY_NAME" >/dev/null 2>&1; then
+  log "creating key pair, private key at ${KEY_PATH}"
+  aws ec2 create-key-pair --key-name "$KEY_NAME" --key-type ed25519 \
+    --tag-specifications "$(tag_spec key-pair)" \
+    --query 'KeyMaterial' --output text > "$KEY_PATH"
+  chmod 600 "$KEY_PATH"
+fi
+
+# --- IAM role: SSM parameter read + Bedrock invoke ---------------------------
+
+if ! aws iam get-role --role-name "$ROLE_NAME" >/dev/null 2>&1; then
+  log "creating IAM role ${ROLE_NAME}"
+  aws iam create-role --role-name "$ROLE_NAME" \
+    --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}' \
+    --tags "Key=${TAG_KEY},Value=${TAG_VALUE}" >/dev/null
+
+  ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+  aws iam put-role-policy --role-name "$ROLE_NAME" --policy-name testbed-access \
+    --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[
+      {\"Effect\":\"Allow\",\"Action\":[\"ssm:GetParameter\"],\"Resource\":\"arn:aws:ssm:${AWS_DEFAULT_REGION}:${ACCOUNT_ID}:parameter${SSM_PREFIX}/*\"},
+      {\"Effect\":\"Allow\",\"Action\":[\"kms:Decrypt\"],\"Resource\":\"*\",\"Condition\":{\"StringEquals\":{\"kms:ViaService\":\"ssm.${AWS_DEFAULT_REGION}.amazonaws.com\"}}},
+      {\"Effect\":\"Allow\",\"Action\":[\"bedrock:InvokeModel\",\"bedrock:InvokeModelWithResponseStream\"],\"Resource\":\"*\"},
+      {\"Effect\":\"Allow\",\"Action\":[\"ec2:TerminateInstances\"],\"Resource\":\"*\",\"Condition\":{\"StringEquals\":{\"ec2:ResourceTag/${TAG_KEY}\":\"${TAG_VALUE}\"}}}
+    ]}" >/dev/null
+
+  aws iam create-instance-profile --instance-profile-name "$PROFILE_NAME" >/dev/null
+  aws iam add-role-to-instance-profile --instance-profile-name "$PROFILE_NAME" --role-name "$ROLE_NAME"
+  log "waiting for instance profile to propagate"
+  sleep 15
+fi
+
+# --- GitHub token in SSM (never in user-data) --------------------------------
+
+if ! aws ssm get-parameter --name "${SSM_PREFIX}/github-token" >/dev/null 2>&1; then
+  log "storing GitHub token in SSM SecureString"
+  # Via a mode-600 temp file rather than an argv value, so the token never
+  # appears in the process table.
+  TOKEN_FILE="$(mktemp)"
+  chmod 600 "$TOKEN_FILE"
+  trap 'rm -f "$TOKEN_FILE"' EXIT
+  gh auth token > "$TOKEN_FILE"
+  aws ssm put-parameter --name "${SSM_PREFIX}/github-token" \
+    --type SecureString --value "file://${TOKEN_FILE}" --overwrite >/dev/null
+  rm -f "$TOKEN_FILE"
+  trap - EXIT
+fi
+
+# --- launch ------------------------------------------------------------------
+
+AMI_ID=$(aws ssm get-parameter --name "$AMI_SSM_PARAM" --query 'Parameter.Value' --output text)
+
+USER_DATA=$(sed \
+  -e "s|__DEADMAN_HOURS__|${DEADMAN_HOURS}|g" \
+  -e "s|__WITH_RUST__|${WITH_RUST}|g" \
+  -e "s|__REPO_REF__|${REPO_REF}|g" \
+  -e "s|__SSM_PREFIX__|${SSM_PREFIX}|g" \
+  -e "s|__AWS_REGION__|${AWS_DEFAULT_REGION}|g" \
+  -e "s|__AWSCLI_ARCH__|${AWSCLI_ARCH}|g" \
+  -e "s|__MUSL_ARCH__|${MUSL_ARCH}|g" \
+  -e "s|__RELEASE_TAG__|${RELEASE_TAG}|g" \
+  -e "s|__FIX_BRANCH__|${FIX_BRANCH}|g" \
+  "${SCRIPT_DIR}/user-data.sh")
+
+log "launching ${INSTANCE_TYPE} (${ARCH}) from ${AMI_ID} (ref ${REPO_REF}, rust=${WITH_RUST}, deadman ${DEADMAN_HOURS}h)"
+INSTANCE_ID=$(aws ec2 run-instances \
+  --image-id "$AMI_ID" \
+  --instance-type "$INSTANCE_TYPE" \
+  --key-name "$KEY_NAME" \
+  --subnet-id "$SUBNET_ID" \
+  --security-group-ids "$SG_ID" \
+  --iam-instance-profile "Name=${PROFILE_NAME}" \
+  --instance-initiated-shutdown-behavior terminate \
+  --block-device-mappings "[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"VolumeSize\":${DISK_GB},\"VolumeType\":\"gp3\",\"DeleteOnTermination\":true}}]" \
+  --tag-specifications "$(tag_spec instance)" "$(tag_spec volume)" \
+  --user-data "$USER_DATA" \
+  --query 'Instances[0].InstanceId' --output text)
+
+log "waiting for ${INSTANCE_ID} to run"
+aws ec2 wait instance-running --instance-ids "$INSTANCE_ID"
+
+PUBLIC_IP=$(aws ec2 describe-instances --instance-ids "$INSTANCE_ID" \
+  --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)
+
+cat <<SUMMARY
+
+instance   ${INSTANCE_ID}
+type       ${INSTANCE_TYPE}
+ip         ${PUBLIC_IP}
+ssh        ssh -i ${KEY_PATH} ubuntu@${PUBLIC_IP}
+setup log  ssh -i ${KEY_PATH} ubuntu@${PUBLIC_IP} 'tail -f /var/log/fleet-testbed-setup.log'
+ready when /var/lib/fleet-testbed-ready exists
+deadman    self-terminates after ${DEADMAN_HOURS}h
+teardown   ${SCRIPT_DIR}/teardown.sh
+
+SUMMARY
+
+if [ "$WAIT_READY" = "1" ]; then
+  log "waiting for setup to finish (clone, install, build, profile setup)"
+  SSH="ssh -i ${KEY_PATH} -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 ubuntu@${PUBLIC_IP}"
+  for _ in $(seq 1 120); do
+    if $SSH 'test -f /var/lib/fleet-testbed-ready' 2>/dev/null; then
+      log "ready"
+      $SSH 'set -a; . /etc/environment; set +a; cd ~/proliferate; \
+        echo "commit  $(git rev-parse --short HEAD)"; \
+        echo "runtime $(~/bin/anyharness --version 2>&1 | head -1)"; \
+        echo "claude  $(claude --version 2>&1 | head -1)"; \
+        echo "cargo   $(command -v cargo || echo "not installed")"'
+      exit 0
+    fi
+    sleep 30
+  done
+  die "setup did not finish within 60 minutes; check /var/log/fleet-testbed-setup.log"
+fi

--- a/scripts/fleet-testbed/teardown.sh
+++ b/scripts/fleet-testbed/teardown.sh
@@ -2,7 +2,7 @@
 # Terminate fleet concurrency testbed resources.
 #
 # Safety: nothing is ever selected by the project tag alone. The VPC is resolved
-# by tag AND exact CIDR AND IsDefault=false (see lib.sh find_testbed_vpc),
+# by tag AND exact CIDR AND IsDefault=false (see lib.sh resolve_testbed_vpc),
 # the caller's account is asserted, and every delete below is additionally
 # filtered on the tag as well as VPC membership. This account also runs
 # production, and production lives in the default VPC, so one predicate is not
@@ -27,7 +27,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --network) DELETE_NETWORK="1"; shift ;;
     --all) DELETE_NETWORK="1"; DELETE_IDENTITY="1"; shift ;;
-    -h|--help) sed -n '2,20p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    -h|--help) sed -n '2,16p' "${BASH_SOURCE[0]}"; exit 0 ;;
     *) die "unknown argument: $1" ;;
   esac
 done
@@ -56,14 +56,20 @@ with_retry() {
   "$@" >/dev/null
 }
 
-# Empty when the testbed VPC does not exist. That is not an error: with no
-# testbed VPC there is nothing this script is allowed to select, so instance and
+# Resolved into this shell, not through $(...), so a failing describe aborts
+# instead of reading as "no testbed VPC" -- which would make --network a silent
+# no-op over a live instance and let --all delete the key pair out from under
+# one. Empty genuinely means the VPC does not exist, which is not an error:
+# there is then nothing this script is allowed to select, so instance and
 # network teardown are skipped rather than falling back to a looser predicate.
-VPC_ID="$(find_testbed_vpc)"
+resolve_testbed_vpc
+VPC_ID="$TESTBED_VPC_ID"
 
 if [ -z "$VPC_ID" ]; then
   log "no testbed VPC (tag ${TAG_KEY}=${TAG_VALUE}, CIDR ${VPC_CIDR}, non-default); skipping instances and network"
-  if [ "$DELETE_IDENTITY" != "1" ]; then
+  # Only the VPC-scoped work is skipped. The SSM token and the IAM/key-pair
+  # resources outlive the VPC, so their blocks below must stay reachable.
+  if [ "$DELETE_NETWORK" != "1" ] && [ "$DELETE_IDENTITY" != "1" ]; then
     log "nothing to do"
     exit 0
   fi
@@ -184,15 +190,27 @@ if [ "$DELETE_IDENTITY" = "1" ]; then
     aws iam delete-role --role-name "$ROLE_NAME" || fail "delete role ${ROLE_NAME}"
   fi
 
-  if aws ec2 describe-key-pairs --key-names "$KEY_NAME" >/dev/null 2>&1; then
-    aws ec2 delete-key-pair --key-name "$KEY_NAME" >/dev/null \
-      || fail "delete key pair ${KEY_NAME}"
-  fi
-  # Deleted together with the AWS side, so the next provision does not trip the
-  # both-sides guard on a private key whose pair no longer exists.
-  if [ -e "$KEY_PATH" ]; then
-    log "removing local private key ${KEY_PATH}"
-    rm -f "$KEY_PATH" || fail "remove ${KEY_PATH}"
+  # Deleting the key pair while something is still running with it is
+  # unrecoverable: there is no second way onto the box. Checked account-wide on
+  # the key name rather than within the VPC, because by this point the VPC may
+  # already be gone.
+  KEY_USERS=$(aws ec2 describe-instances \
+    --filters "Name=key-name,Values=${KEY_NAME}" \
+              "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+    --query 'Reservations[].Instances[].InstanceId' --output text)
+  if [ -n "$KEY_USERS" ]; then
+    fail "refusing to delete key pair ${KEY_NAME}: still in use by ${KEY_USERS}"
+  else
+    if aws ec2 describe-key-pairs --key-names "$KEY_NAME" >/dev/null 2>&1; then
+      aws ec2 delete-key-pair --key-name "$KEY_NAME" >/dev/null \
+        || fail "delete key pair ${KEY_NAME}"
+    fi
+    # Deleted together with the AWS side, so the next provision does not trip
+    # the both-sides guard on a private key whose pair no longer exists.
+    if [ -e "$KEY_PATH" ]; then
+      log "removing local private key ${KEY_PATH}"
+      rm -f "$KEY_PATH" || fail "remove ${KEY_PATH}"
+    fi
   fi
 fi
 

--- a/scripts/fleet-testbed/teardown.sh
+++ b/scripts/fleet-testbed/teardown.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Terminate fleet concurrency testbed instances.
+#
+# Safety: an instance is only ever terminated when it matches BOTH the testbed
+# tag AND membership of the dedicated testbed VPC. This account also runs
+# production, so one predicate is not enough.
+#
+# Usage:
+#   ./teardown.sh              terminate instances, leave network in place
+#   ./teardown.sh --network    also delete the VPC and its dependencies
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
+DELETE_NETWORK="0"
+[ "${1:-}" = "--network" ] && DELETE_NETWORK="1"
+
+VPC_ID="$(require_testbed_vpc)"
+
+INSTANCE_IDS=$(aws ec2 describe-instances \
+  --filters "Name=tag:${TAG_KEY},Values=${TAG_VALUE}" \
+            "Name=vpc-id,Values=${VPC_ID}" \
+            "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+  --query 'Reservations[].Instances[].InstanceId' --output text)
+
+if [ -z "$INSTANCE_IDS" ]; then
+  log "no testbed instances to terminate"
+else
+  log "terminating: ${INSTANCE_IDS}"
+  # shellcheck disable=SC2086
+  aws ec2 terminate-instances --instance-ids $INSTANCE_IDS >/dev/null
+  # shellcheck disable=SC2086
+  aws ec2 wait instance-terminated --instance-ids $INSTANCE_IDS
+  log "terminated"
+fi
+
+if [ "$DELETE_NETWORK" = "1" ]; then
+  log "deleting network for ${VPC_ID}"
+  for sg in $(aws ec2 describe-security-groups --filters "Name=vpc-id,Values=${VPC_ID}" \
+      --query "SecurityGroups[?GroupName!='default'].GroupId" --output text); do
+    aws ec2 delete-security-group --group-id "$sg" || true
+  done
+  for subnet in $(aws ec2 describe-subnets --filters "Name=vpc-id,Values=${VPC_ID}" \
+      --query 'Subnets[].SubnetId' --output text); do
+    aws ec2 delete-subnet --subnet-id "$subnet" || true
+  done
+  for rt in $(aws ec2 describe-route-tables --filters "Name=vpc-id,Values=${VPC_ID}" \
+      --query 'RouteTables[?length(Associations[?Main==`true`])==`0`].RouteTableId' --output text); do
+    aws ec2 delete-route-table --route-table-id "$rt" || true
+  done
+  for igw in $(aws ec2 describe-internet-gateways \
+      --filters "Name=attachment.vpc-id,Values=${VPC_ID}" \
+      --query 'InternetGateways[].InternetGatewayId' --output text); do
+    aws ec2 detach-internet-gateway --internet-gateway-id "$igw" --vpc-id "$VPC_ID" || true
+    aws ec2 delete-internet-gateway --internet-gateway-id "$igw" || true
+  done
+  aws ec2 delete-vpc --vpc-id "$VPC_ID" || true
+  log "network deleted"
+fi

--- a/scripts/fleet-testbed/teardown.sh
+++ b/scripts/fleet-testbed/teardown.sh
@@ -1,60 +1,203 @@
 #!/usr/bin/env bash
-# Terminate fleet concurrency testbed instances.
+# Terminate fleet concurrency testbed resources.
 #
-# Safety: an instance is only ever terminated when it matches BOTH the testbed
-# tag AND membership of the dedicated testbed VPC. This account also runs
-# production, so one predicate is not enough.
+# Safety: nothing is ever selected by the project tag alone. The VPC is resolved
+# by tag AND exact CIDR AND IsDefault=false (see lib.sh find_testbed_vpc),
+# the caller's account is asserted, and every delete below is additionally
+# filtered on the tag as well as VPC membership. This account also runs
+# production, and production lives in the default VPC, so one predicate is not
+# enough and neither is one predicate applied twice.
 #
 # Usage:
-#   ./teardown.sh              terminate instances, leave network in place
-#   ./teardown.sh --network    also delete the VPC and its dependencies
+#   ./teardown.sh              terminate instances, leave everything else
+#   ./teardown.sh --network    also delete the VPC, its dependencies, and the
+#                              GitHub token in SSM
+#   ./teardown.sh --all        also delete the IAM role, instance profile, and
+#                              key pair, including the local private key
+
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
-source "${SCRIPT_DIR}/lib.sh"
+source "${SCRIPT_DIR}/lib.sh" || { echo "fatal: cannot source ${SCRIPT_DIR}/lib.sh" >&2; exit 1; }
 
 DELETE_NETWORK="0"
-[ "${1:-}" = "--network" ] && DELETE_NETWORK="1"
+DELETE_IDENTITY="0"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --network) DELETE_NETWORK="1"; shift ;;
+    --all) DELETE_NETWORK="1"; DELETE_IDENTITY="1"; shift ;;
+    -h|--help) sed -n '2,20p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
 
-VPC_ID="$(require_testbed_vpc)"
+require_expected_account
 
-INSTANCE_IDS=$(aws ec2 describe-instances \
-  --filters "Name=tag:${TAG_KEY},Values=${TAG_VALUE}" \
-            "Name=vpc-id,Values=${VPC_ID}" \
-            "Name=instance-state-name,Values=pending,running,stopping,stopped" \
-  --query 'Reservations[].Instances[].InstanceId' --output text)
+FAILURES=0
+fail() {
+  FAILURES=$((FAILURES + 1))
+  log "FAILED: $*"
+}
 
-if [ -z "$INSTANCE_IDS" ]; then
-  log "no testbed instances to terminate"
-else
-  log "terminating: ${INSTANCE_IDS}"
-  # shellcheck disable=SC2086
-  aws ec2 terminate-instances --instance-ids $INSTANCE_IDS >/dev/null
-  # shellcheck disable=SC2086
-  aws ec2 wait instance-terminated --instance-ids $INSTANCE_IDS
-  log "terminated"
+with_retry() {
+  # Deletes right after a termination routinely fail while the ENI drains, so a
+  # first failure is not yet a failure. The last attempt is not silenced, so the
+  # operator sees the real AWS error rather than a bare exit code.
+  local desc="$1"; shift
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    if "$@" >/dev/null 2>&1; then
+      return 0
+    fi
+    log "${desc}: not ready (attempt ${attempt}/6), waiting 10s for dependencies to drain"
+    sleep 10
+  done
+  "$@" >/dev/null
+}
+
+# Empty when the testbed VPC does not exist. That is not an error: with no
+# testbed VPC there is nothing this script is allowed to select, so instance and
+# network teardown are skipped rather than falling back to a looser predicate.
+VPC_ID="$(find_testbed_vpc)"
+
+if [ -z "$VPC_ID" ]; then
+  log "no testbed VPC (tag ${TAG_KEY}=${TAG_VALUE}, CIDR ${VPC_CIDR}, non-default); skipping instances and network"
+  if [ "$DELETE_IDENTITY" != "1" ]; then
+    log "nothing to do"
+    exit 0
+  fi
 fi
 
+if [ -n "$VPC_ID" ]; then
+  log "testbed VPC ${VPC_ID} (${VPC_CIDR}) in account ${ACCOUNT_ID}"
+
+  INSTANCE_IDS=$(aws ec2 describe-instances \
+    --filters "Name=tag:${TAG_KEY},Values=${TAG_VALUE}" \
+              "Name=vpc-id,Values=${VPC_ID}" \
+              "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+    --query 'Reservations[].Instances[].InstanceId' --output text)
+
+  if [ -z "$INSTANCE_IDS" ]; then
+    log "no testbed instances to terminate"
+  else
+    log "terminating: ${INSTANCE_IDS}"
+    # shellcheck disable=SC2086
+    aws ec2 terminate-instances --instance-ids $INSTANCE_IDS >/dev/null
+    # shellcheck disable=SC2086
+    aws ec2 wait instance-terminated --instance-ids $INSTANCE_IDS
+    log "terminated"
+  fi
+
+  if [ "$DELETE_NETWORK" = "1" ]; then
+    log "deleting network for ${VPC_ID}"
+
+    # Every one of these was created with tag_spec, so the tag filter costs
+    # nothing and removes the single-mistake path where a wrong VPC id enumerates
+    # somebody else's networking. Verified against provision.sh: vpc,
+    # internet-gateway, subnet, route-table, and security-group all carry it.
+    # Resolved into variables first, so a failing describe aborts under `set -e`
+    # instead of quietly yielding an empty list that looks like "nothing to do".
+    SG_IDS=$(aws ec2 describe-security-groups \
+      --filters "Name=vpc-id,Values=${VPC_ID}" "Name=tag:${TAG_KEY},Values=${TAG_VALUE}" \
+      --query "SecurityGroups[?GroupName!='default'].GroupId" --output text)
+    SUBNET_IDS=$(aws ec2 describe-subnets \
+      --filters "Name=vpc-id,Values=${VPC_ID}" "Name=tag:${TAG_KEY},Values=${TAG_VALUE}" \
+      --query 'Subnets[].SubnetId' --output text)
+    RT_IDS=$(aws ec2 describe-route-tables \
+      --filters "Name=vpc-id,Values=${VPC_ID}" "Name=tag:${TAG_KEY},Values=${TAG_VALUE}" \
+      --query 'RouteTables[?length(Associations[?Main==`true`])==`0`].RouteTableId' --output text)
+    IGW_IDS=$(aws ec2 describe-internet-gateways \
+      --filters "Name=attachment.vpc-id,Values=${VPC_ID}" "Name=tag:${TAG_KEY},Values=${TAG_VALUE}" \
+      --query 'InternetGateways[].InternetGatewayId' --output text)
+
+    # shellcheck disable=SC2086
+    for sg in $SG_IDS; do
+      with_retry "delete security group ${sg}" \
+        aws ec2 delete-security-group --group-id "$sg" || fail "delete security group ${sg}"
+    done
+
+    # shellcheck disable=SC2086
+    for subnet in $SUBNET_IDS; do
+      with_retry "delete subnet ${subnet}" \
+        aws ec2 delete-subnet --subnet-id "$subnet" || fail "delete subnet ${subnet}"
+    done
+
+    # shellcheck disable=SC2086
+    for rt in $RT_IDS; do
+      with_retry "delete route table ${rt}" \
+        aws ec2 delete-route-table --route-table-id "$rt" || fail "delete route table ${rt}"
+    done
+
+    # shellcheck disable=SC2086
+    for igw in $IGW_IDS; do
+      with_retry "detach internet gateway ${igw}" \
+        aws ec2 detach-internet-gateway --internet-gateway-id "$igw" --vpc-id "$VPC_ID" \
+        || fail "detach internet gateway ${igw}"
+      with_retry "delete internet gateway ${igw}" \
+        aws ec2 delete-internet-gateway --internet-gateway-id "$igw" \
+        || fail "delete internet gateway ${igw}"
+    done
+
+    with_retry "delete VPC ${VPC_ID}" aws ec2 delete-vpc --vpc-id "$VPC_ID" \
+      || fail "delete VPC ${VPC_ID}"
+
+    if [ "$FAILURES" -eq 0 ]; then
+      log "network deleted"
+    fi
+  fi
+fi
+
+# Outside the VPC guard on purpose: the token outlives the network, and leaving
+# a live GitHub credential in the production account is the failure mode this
+# whole lane is trying not to create.
 if [ "$DELETE_NETWORK" = "1" ]; then
-  log "deleting network for ${VPC_ID}"
-  for sg in $(aws ec2 describe-security-groups --filters "Name=vpc-id,Values=${VPC_ID}" \
-      --query "SecurityGroups[?GroupName!='default'].GroupId" --output text); do
-    aws ec2 delete-security-group --group-id "$sg" || true
-  done
-  for subnet in $(aws ec2 describe-subnets --filters "Name=vpc-id,Values=${VPC_ID}" \
-      --query 'Subnets[].SubnetId' --output text); do
-    aws ec2 delete-subnet --subnet-id "$subnet" || true
-  done
-  for rt in $(aws ec2 describe-route-tables --filters "Name=vpc-id,Values=${VPC_ID}" \
-      --query 'RouteTables[?length(Associations[?Main==`true`])==`0`].RouteTableId' --output text); do
-    aws ec2 delete-route-table --route-table-id "$rt" || true
-  done
-  for igw in $(aws ec2 describe-internet-gateways \
-      --filters "Name=attachment.vpc-id,Values=${VPC_ID}" \
-      --query 'InternetGateways[].InternetGatewayId' --output text); do
-    aws ec2 detach-internet-gateway --internet-gateway-id "$igw" --vpc-id "$VPC_ID" || true
-    aws ec2 delete-internet-gateway --internet-gateway-id "$igw" || true
-  done
-  aws ec2 delete-vpc --vpc-id "$VPC_ID" || true
-  log "network deleted"
+  if aws ssm get-parameter --name "${SSM_PREFIX}/github-token" >/dev/null 2>&1; then
+    log "deleting SSM parameter ${SSM_PREFIX}/github-token"
+    aws ssm delete-parameter --name "${SSM_PREFIX}/github-token" >/dev/null \
+      || fail "delete SSM parameter ${SSM_PREFIX}/github-token"
+  else
+    log "no SSM token parameter to delete"
+  fi
 fi
+
+if [ "$DELETE_IDENTITY" = "1" ]; then
+  log "deleting IAM role, instance profile, and key pair"
+
+  if aws iam get-instance-profile --instance-profile-name "$PROFILE_NAME" >/dev/null 2>&1; then
+    if aws iam get-instance-profile --instance-profile-name "$PROFILE_NAME" \
+        --query "InstanceProfile.Roles[?RoleName=='${ROLE_NAME}'].RoleName" --output text \
+        | grep -q "$ROLE_NAME"; then
+      aws iam remove-role-from-instance-profile \
+        --instance-profile-name "$PROFILE_NAME" --role-name "$ROLE_NAME" \
+        || fail "remove role from instance profile ${PROFILE_NAME}"
+    fi
+    aws iam delete-instance-profile --instance-profile-name "$PROFILE_NAME" \
+      || fail "delete instance profile ${PROFILE_NAME}"
+  fi
+
+  if aws iam get-role --role-name "$ROLE_NAME" >/dev/null 2>&1; then
+    if aws iam get-role-policy --role-name "$ROLE_NAME" --policy-name testbed-access >/dev/null 2>&1; then
+      aws iam delete-role-policy --role-name "$ROLE_NAME" --policy-name testbed-access \
+        || fail "delete inline policy on ${ROLE_NAME}"
+    fi
+    aws iam delete-role --role-name "$ROLE_NAME" || fail "delete role ${ROLE_NAME}"
+  fi
+
+  if aws ec2 describe-key-pairs --key-names "$KEY_NAME" >/dev/null 2>&1; then
+    aws ec2 delete-key-pair --key-name "$KEY_NAME" >/dev/null \
+      || fail "delete key pair ${KEY_NAME}"
+  fi
+  # Deleted together with the AWS side, so the next provision does not trip the
+  # both-sides guard on a private key whose pair no longer exists.
+  if [ -e "$KEY_PATH" ]; then
+    log "removing local private key ${KEY_PATH}"
+    rm -f "$KEY_PATH" || fail "remove ${KEY_PATH}"
+  fi
+fi
+
+if [ "$FAILURES" -ne 0 ]; then
+  die "${FAILURES} teardown step(s) failed; resources may remain. Re-run after resolving the errors above."
+fi
+
+log "teardown complete"

--- a/scripts/fleet-testbed/user-data.sh
+++ b/scripts/fleet-testbed/user-data.sh
@@ -5,9 +5,20 @@
 # without a Rust toolchain unless FLEET_WITH_RUST=1, since the testbed runs the
 # prebuilt musl release binaries. Ends at a booted, buildable profile, so the
 # whole path from nothing to a running product is one unattended command.
+#
+# No secret is ever a variable in this script. The GitHub token stays in SSM and
+# is fetched on demand by a git askPass helper, so it reaches neither xtrace,
+# nor argv, nor .git/config. See "repo clone" below.
 
-set -euxo pipefail
+set -euo pipefail
+
+# Logs first, mode-restricted before a single line is written to them. xtrace is
+# on for everything after this, and cloud-init's own log captures the same
+# stream, so both files are treated as sensitive by default.
+install -m 600 /dev/null /var/log/fleet-testbed-setup.log
+chmod 600 /var/log/cloud-init-output.log 2>/dev/null || true
 exec > >(tee -a /var/log/fleet-testbed-setup.log) 2>&1
+set -x
 
 DEADMAN_HOURS="__DEADMAN_HOURS__"
 WITH_RUST="__WITH_RUST__"
@@ -19,8 +30,88 @@ RELEASE_TAG="__RELEASE_TAG__"
 FIX_BRANCH="__FIX_BRANCH__"
 AWS_REGION="__AWS_REGION__"
 
-# Deadman first, before anything can fail, so a broken setup still terminates.
-systemd-run --on-active="${DEADMAN_HOURS}h" --unit=fleet-deadman /sbin/shutdown -h now
+# --- deadman -----------------------------------------------------------------
+#
+# First, before anything can fail, so a broken setup still terminates. The
+# deadline is a timestamp on disk and the check is a persistent systemd timer
+# plus a cron.d entry, because the original transient `systemd-run` unit lived
+# in /run and a reboot silently disarmed it on a 16 vCPU instance.
+#
+# Arming is wrapped so that its own failure degrades rather than aborting the
+# setup at the exact line meant to be the safety net.
+
+DEADLINE_EPOCH="$(( $(date +%s) + DEADMAN_HOURS * 3600 ))"
+install -m 644 /dev/null /etc/fleet-testbed-deadline
+echo "$DEADLINE_EPOCH" > /etc/fleet-testbed-deadline
+
+cat > /usr/local/bin/fleet-deadman <<'DEADMAN_EOF'
+#!/bin/sh
+# Shuts the testbed down once its deadline passes. run-instances set
+# instance-initiated-shutdown-behavior=terminate, so a shutdown is a terminate.
+#
+# Fails closed: a missing or unparseable deadline file means the deadman cannot
+# prove the box is still within its budget, so it shuts down.
+set -u
+DEADLINE_FILE=/etc/fleet-testbed-deadline
+deadline=""
+[ -r "$DEADLINE_FILE" ] && deadline="$(cat "$DEADLINE_FILE" 2>/dev/null || true)"
+case "$deadline" in
+  ''|*[!0-9]*)
+    logger -t fleet-deadman "deadline file missing or unreadable; shutting down"
+    exec /sbin/shutdown -h now
+    ;;
+esac
+now="$(date +%s)"
+[ "$now" -ge "$deadline" ] || exit 0
+logger -t fleet-deadman "deadline reached; shutting down (shutdown behavior = terminate)"
+exec /sbin/shutdown -h now
+DEADMAN_EOF
+chmod 700 /usr/local/bin/fleet-deadman
+
+arm_deadman() {
+  # cron.d first: it is the simplest of the two and needs no daemon-reload, so
+  # it is armed even if the systemd path below fails.
+  cat > /etc/cron.d/fleet-deadman <<'CRON_EOF'
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+*/2 * * * * root /usr/local/bin/fleet-deadman
+CRON_EOF
+  chmod 644 /etc/cron.d/fleet-deadman
+
+  cat > /etc/systemd/system/fleet-deadman.service <<'SVC_EOF'
+[Unit]
+Description=Fleet testbed deadman shutdown
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/fleet-deadman
+SVC_EOF
+
+  cat > /etc/systemd/system/fleet-deadman.timer <<'TIMER_EOF'
+[Unit]
+Description=Fleet testbed deadman check
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=1min
+AccuracySec=30s
+
+[Install]
+WantedBy=timers.target
+TIMER_EOF
+
+  systemctl daemon-reload
+  systemctl enable --now fleet-deadman.timer
+}
+
+if arm_deadman; then
+  echo "deadman armed: shutdown at $(date -u -d "@${DEADLINE_EPOCH}" 2>/dev/null || echo "$DEADLINE_EPOCH")"
+else
+  echo "WARNING: could not arm the persistent deadman; falling back to a one-shot shutdown"
+  # Last resort. Does not survive a reboot, which is exactly why it is not the
+  # primary mechanism, but it is better than an unbounded 16 vCPU instance.
+  shutdown -h "+$((DEADMAN_HOURS * 60))" || echo "WARNING: fallback shutdown could not be scheduled either"
+fi
 
 export DEBIAN_FRONTEND=noninteractive
 
@@ -43,8 +134,19 @@ apt_install_retry() {
   return 1
 }
 
+# A C toolchain is only needed for --with-rust, and it is the slow half of
+# provisioning. The default path compiles nothing: pnpm's onlyBuiltDependencies
+# allowlist in pnpm-workspace.yaml is closed and none of its five entries build
+# from source on linux (they ship prebuilt platform packages), and every
+# platform-specific wheel in server/uv.lock has a manylinux build for both
+# x86_64 and aarch64, so uv never falls back to an sdist.
+BUILD_PKGS=()
+if [ "$WITH_RUST" = "1" ]; then
+  BUILD_PKGS=(build-essential pkg-config libssl-dev)
+fi
+
 apt_install_retry \
-  git curl jq build-essential pkg-config libssl-dev \
+  git curl jq "${BUILD_PKGS[@]}" \
   postgresql-16 postgresql-client-16 redis-server \
   python3 python3-venv unzip ca-certificates
 
@@ -97,11 +199,48 @@ cp /etc/environment /tmp/fleet-env
 sed -i 's/^/export /' /tmp/fleet-env
 install -m 644 /tmp/fleet-env /etc/profile.d/fleet-testbed.sh
 
-# Repo clone. The token lives in SSM SecureString and is read with the instance
-# role, so it never appears in user-data (which is readable via IMDS).
-GH_TOKEN=$(aws ssm get-parameter --with-decryption --region "$AWS_REGION" \
-  --name "${SSM_PREFIX}/github-token" --query 'Parameter.Value' --output text)
-su - ubuntu -c "git clone https://x-access-token:${GH_TOKEN}@github.com/proliferate-ai/proliferate.git ~/proliferate"
+# --- repo clone --------------------------------------------------------------
+#
+# The token never enters this script. A mode-700 askPass helper owned by ubuntu
+# reads the SSM SecureString with the instance role each time git needs a
+# credential, which keeps it out of three places a URL-embedded token lands in:
+#
+#   - xtrace and the setup/cloud-init logs, which are not secret stores
+#   - argv, since /proc/<pid>/cmdline is world readable on Ubuntu
+#   - .git/config, where `git clone https://user:token@...` persists it at 0644
+#     forever, and where later fetches would then depend on it
+#
+# xtrace is off across the whole credential region regardless, so that a future
+# edit that does touch the token cannot quietly start logging it.
+
+set +x
+
+install -m 700 -o ubuntu -g ubuntu /dev/null /usr/local/bin/fleet-gh-askpass
+cat > /usr/local/bin/fleet-gh-askpass <<ASKPASS_EOF
+#!/bin/sh
+# git core.askPass helper for the testbed. Prints a GitHub credential on stdout
+# and nothing anywhere else. Invoked by git with the prompt text as \$1.
+set -u
+case "\${1:-}" in
+  Username*) printf '%s\n' 'x-access-token' ;;
+  *) exec aws ssm get-parameter --with-decryption --region '${AWS_REGION}' \\
+       --name '${SSM_PREFIX}/github-token' --query 'Parameter.Value' --output text ;;
+esac
+ASKPASS_EOF
+
+su - ubuntu -c "git config --global core.askPass /usr/local/bin/fleet-gh-askpass"
+
+# Tokenless remote URL. git prompts for a username and a password, the helper
+# supplies both, and nothing is written to .git/config.
+su - ubuntu -c "git clone https://github.com/proliferate-ai/proliferate.git ~/proliferate"
+
+set -x
+
+# Fail loudly if a credential ever ends up persisted anyway.
+if grep -qE '://[^/@[:space:]]*:[^/@[:space:]]+@' /home/ubuntu/proliferate/.git/config; then
+  echo "FATAL: a credential was persisted into .git/config" >&2
+  exit 1
+fi
 
 # Pin to the release's own commit so the prebuilt runtime and the source tree
 # cannot disagree, then cherry-pick only the dev-loop fixes on top.
@@ -110,7 +249,6 @@ su - ubuntu -c "cd ~/proliferate && \
   git fetch origin ${FIX_BRANCH} main && \
   git -c user.name=fleet -c user.email=fleet@local cherry-pick -x \
     \$(git rev-list --reverse origin/${FIX_BRANCH} --not origin/main)"
-unset GH_TOKEN
 
 # Prebuilt runtime binaries: no cargo required for the product itself.
 su - ubuntu -c "mkdir -p ~/bin && cd ~/bin && \

--- a/scripts/fleet-testbed/user-data.sh
+++ b/scripts/fleet-testbed/user-data.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# cloud-init user-data for a fleet concurrency testbed instance.
+#
+# Installs the stack the local dev profile path expects (guides/local/README.md)
+# without a Rust toolchain unless FLEET_WITH_RUST=1, since the testbed runs the
+# prebuilt musl release binaries. Ends at a booted, buildable profile, so the
+# whole path from nothing to a running product is one unattended command.
+
+set -euxo pipefail
+exec > >(tee -a /var/log/fleet-testbed-setup.log) 2>&1
+
+DEADMAN_HOURS="__DEADMAN_HOURS__"
+WITH_RUST="__WITH_RUST__"
+REPO_REF="__REPO_REF__"
+SSM_PREFIX="__SSM_PREFIX__"
+AWSCLI_ARCH="__AWSCLI_ARCH__"
+MUSL_ARCH="__MUSL_ARCH__"
+RELEASE_TAG="__RELEASE_TAG__"
+FIX_BRANCH="__FIX_BRANCH__"
+AWS_REGION="__AWS_REGION__"
+
+# Deadman first, before anything can fail, so a broken setup still terminates.
+systemd-run --on-active="${DEADMAN_HOURS}h" --unit=fleet-deadman /sbin/shutdown -h now
+
+export DEBIAN_FRONTEND=noninteractive
+
+# The ec2 ports mirror returns intermittent 503s. Without retries a single bad
+# fetch kills the whole setup under `set -e`, which is what happened on the
+# first provision.
+cat > /etc/apt/apt.conf.d/80-retries <<'APT_EOF'
+Acquire::Retries "8";
+Acquire::http::Timeout "30";
+Acquire::https::Timeout "30";
+APT_EOF
+
+apt_install_retry() {
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    apt-get update -y && apt-get install -y --no-install-recommends --fix-missing "$@" && return 0
+    echo "apt attempt ${attempt} failed, retrying in $((attempt * 15))s"
+    sleep $((attempt * 15))
+  done
+  return 1
+}
+
+apt_install_retry \
+  git curl jq build-essential pkg-config libssl-dev \
+  postgresql-16 postgresql-client-16 redis-server \
+  python3 python3-venv unzip ca-certificates
+
+systemctl enable --now postgresql redis-server
+
+# The dev profile path expects a `proliferate` login role that can create
+# databases. Local-only password, matching the documented default.
+sudo -u postgres psql -v ON_ERROR_STOP=1 -c \
+  "DO \$\$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='proliferate') THEN CREATE ROLE proliferate LOGIN CREATEDB PASSWORD 'localdev'; END IF; END \$\$;"
+
+# Concurrent TRUNCATE across many profile databases exhausts the default lock
+# table; the CI lane hit exactly this under xdist.
+sudo -u postgres psql -v ON_ERROR_STOP=1 -c "ALTER SYSTEM SET max_locks_per_transaction = 1024;"
+systemctl restart postgresql
+
+# Node via nodesource, pnpm via corepack.
+curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+apt_install_retry nodejs
+corepack enable
+
+# uv for the server venv, same as CI.
+curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+
+# AWS CLI, for SSM parameter reads and self-identification.
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWSCLI_ARCH}.zip" -o /tmp/awscliv2.zip
+unzip -oq /tmp/awscliv2.zip -d /tmp && /tmp/aws/install --update
+
+if [ "$WITH_RUST" = "1" ]; then
+  su - ubuntu -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal"
+fi
+
+# The Claude CLI is the native component of the claude agent. Installed as root
+# so it lands on the default PATH: installing under ~/.npm-global instead means
+# the runtime only sees it if the profile happened to be started after that
+# directory joined PATH, which is a silent and confusing failure.
+npm install -g @anthropic-ai/claude-code
+
+# Environment for every session, interactive or not. /etc/environment is read by
+# pam_env, so `ssh host 'cmd'` gets these too; the bottom of ~/.bashrc does not
+# work there, because Ubuntu's default returns early for non-interactive shells.
+cat >> /etc/environment <<ENV_EOF
+ANYHARNESS_DEV_RUNTIME_BIN=/home/ubuntu/bin/anyharness
+CLAUDE_CODE_USE_BEDROCK=1
+AWS_REGION=${AWS_REGION}
+SKIP_RUST=1
+USE_EXISTING_POSTGRES=1
+USE_EXISTING_REDIS=1
+ENV_EOF
+cp /etc/environment /tmp/fleet-env
+sed -i 's/^/export /' /tmp/fleet-env
+install -m 644 /tmp/fleet-env /etc/profile.d/fleet-testbed.sh
+
+# Repo clone. The token lives in SSM SecureString and is read with the instance
+# role, so it never appears in user-data (which is readable via IMDS).
+GH_TOKEN=$(aws ssm get-parameter --with-decryption --region "$AWS_REGION" \
+  --name "${SSM_PREFIX}/github-token" --query 'Parameter.Value' --output text)
+su - ubuntu -c "git clone https://x-access-token:${GH_TOKEN}@github.com/proliferate-ai/proliferate.git ~/proliferate"
+
+# Pin to the release's own commit so the prebuilt runtime and the source tree
+# cannot disagree, then cherry-pick only the dev-loop fixes on top.
+su - ubuntu -c "cd ~/proliferate && \
+  git -c advice.detachedHead=false checkout ${REPO_REF} && \
+  git fetch origin ${FIX_BRANCH} main && \
+  git -c user.name=fleet -c user.email=fleet@local cherry-pick -x \
+    \$(git rev-list --reverse origin/${FIX_BRANCH} --not origin/main)"
+unset GH_TOKEN
+
+# Prebuilt runtime binaries: no cargo required for the product itself.
+su - ubuntu -c "mkdir -p ~/bin && cd ~/bin && \
+  curl -fsSL -o anyharness.tar.gz https://github.com/proliferate-ai/proliferate/releases/download/${RELEASE_TAG}/anyharness-${MUSL_ARCH}-unknown-linux-musl.tar.gz && \
+  tar xzf anyharness.tar.gz && chmod +x anyharness proliferate-worker proliferate-supervisor"
+
+# Build once at image-setup time so a measured boot never pays for it. SKIP_RUST
+# is honored end to end here, including sdk-generate, so cargo is never invoked.
+su - ubuntu -c "cd ~/proliferate && set -a && . /etc/environment && set +a && \
+  corepack pnpm install --frozen-lockfile && \
+  uv sync --project server && \
+  make build"
+
+# One profile prepared, so `make run PROFILE=fleet-1 HEADLESS=1` is the whole
+# boot. Additional profiles are `make setup PROFILE=fleet-N`.
+su - ubuntu -c "cd ~/proliferate && set -a && . /etc/environment && set +a && \
+  make setup PROFILE=fleet-1"
+
+chown -R ubuntu:ubuntu /home/ubuntu
+touch /var/lib/fleet-testbed-ready
+echo "fleet-testbed setup complete"

--- a/scripts/fleet-testbed/user-data.sh
+++ b/scripts/fleet-testbed/user-data.sh
@@ -12,9 +12,14 @@
 
 set -euo pipefail
 
-# Logs first, mode-restricted before a single line is written to them. xtrace is
-# on for everything after this, and cloud-init's own log captures the same
-# stream, so both files are treated as sensitive by default.
+# Logs first. The setup log is created 0600 before it has a single byte in it.
+# cloud-init-output.log is not ours to create: cloud-init opens it early in boot
+# and has already written its own module output there by the time user-data
+# runs, so the honest claim is narrower -- it is tightened to 0600 before ANY
+# output of THIS script reaches it, which is what matters, since cloud-init's
+# own boot chatter holds nothing of ours. xtrace is on for everything after
+# this, and this script's stream lands in both files, so both are treated as
+# sensitive from here on.
 install -m 600 /dev/null /var/log/fleet-testbed-setup.log
 chmod 600 /var/log/cloud-init-output.log 2>/dev/null || true
 exec > >(tee -a /var/log/fleet-testbed-setup.log) 2>&1
@@ -140,15 +145,26 @@ apt_install_retry() {
 # from source on linux (they ship prebuilt platform packages), and every
 # platform-specific wheel in server/uv.lock has a manylinux build for both
 # x86_64 and aarch64, so uv never falls back to an sdist.
+#
+# `make` is NOT in that gated set. The Ubuntu 24.04 cloud image does not ship
+# it, build-essential was the only thing dragging it in, and `make build` and
+# `make setup` below are the whole point of the box -- so it is installed
+# unconditionally, next to the other tools this script invokes by name.
 BUILD_PKGS=()
 if [ "$WITH_RUST" = "1" ]; then
   BUILD_PKGS=(build-essential pkg-config libssl-dev)
 fi
 
 apt_install_retry \
-  git curl jq "${BUILD_PKGS[@]}" \
+  git curl jq make "${BUILD_PKGS[@]}" \
   postgresql-16 postgresql-client-16 redis-server \
   python3 python3-venv unzip ca-certificates
+
+# Assert the tools this script goes on to invoke by name, so a missing one fails
+# here in seconds rather than twenty minutes later inside a build step.
+for _tool in git curl jq make psql unzip; do
+  command -v "$_tool" >/dev/null || { echo "FATAL: ${_tool} is not installed" >&2; exit 1; }
+done
 
 systemctl enable --now postgresql redis-server
 
@@ -236,19 +252,48 @@ su - ubuntu -c "git clone https://github.com/proliferate-ai/proliferate.git ~/pr
 
 set -x
 
-# Fail loudly if a credential ever ends up persisted anyway.
-if grep -qE '://[^/@[:space:]]*:[^/@[:space:]]+@' /home/ubuntu/proliferate/.git/config; then
+# Fail loudly if a credential ever ends up persisted anyway. Any userinfo at all
+# in a remote URL is a finding here, not just the `user:secret@host` form: a
+# bare `token@host` is equally a persisted credential, and this script writes no
+# userinfo of any kind, so there is nothing legitimate for this to catch.
+if grep -qE '://[^/@[:space:]]+@' /home/ubuntu/proliferate/.git/config; then
   echo "FATAL: a credential was persisted into .git/config" >&2
+  exit 1
+fi
+if grep -qsE '(gh[pousr]_|github_pat_)' \
+    /home/ubuntu/proliferate/.git/config /home/ubuntu/.git-credentials; then
+  echo "FATAL: a GitHub token was persisted to disk" >&2
   exit 1
 fi
 
 # Pin to the release's own commit so the prebuilt runtime and the source tree
 # cannot disagree, then cherry-pick only the dev-loop fixes on top.
-su - ubuntu -c "cd ~/proliferate && \
-  git -c advice.detachedHead=false checkout ${REPO_REF} && \
-  git fetch origin ${FIX_BRANCH} main && \
-  git -c user.name=fleet -c user.email=fleet@local cherry-pick -x \
-    \$(git rev-list --reverse origin/${FIX_BRANCH} --not origin/main)"
+#
+# Written to a file rather than squeezed into `su -c "..."`, because the empty
+# case needs a conditional and nesting one inside that quoting is how mistakes
+# get made. The empty case is not hypothetical: once FIX_BRANCH merges,
+# rev-list returns nothing and `git cherry-pick -x` with no arguments exits 129
+# rather than doing nothing, which would turn the intended no-op into a boot
+# failure twenty minutes in.
+install -m 700 -o ubuntu -g ubuntu /dev/null /usr/local/bin/fleet-pin-repo
+cat > /usr/local/bin/fleet-pin-repo <<PIN_EOF
+#!/bin/bash
+set -euo pipefail
+cd ~/proliferate
+git -c advice.detachedHead=false checkout ${REPO_REF}
+git fetch origin ${FIX_BRANCH} main
+picks=\$(git rev-list --reverse origin/${FIX_BRANCH} --not origin/main)
+if [ -z "\$picks" ]; then
+  echo "nothing to cherry-pick: ${FIX_BRANCH} is already contained in main"
+  exit 0
+fi
+echo "cherry-picking \$(printf '%s\\n' \$picks | wc -l) commit(s) from ${FIX_BRANCH}"
+# Intentional word splitting: rev-list emits one sha per line.
+# shellcheck disable=SC2086
+git -c user.name=fleet -c user.email=fleet@local cherry-pick -x \$picks
+PIN_EOF
+
+su - ubuntu -c /usr/local/bin/fleet-pin-repo
 
 # Prebuilt runtime binaries: no cargo required for the product itself.
 su - ubuntu -c "mkdir -p ~/bin && cd ~/bin && \


### PR DESCRIPTION
Measuring how the product behaves at five concurrent profiles needs a machine that can be wrecked and rebuilt, which the laptop is not. `scripts/fleet-testbed/provision.sh --arch x86_64` produces one, and blocks until the instance reports ready with the resolved commit, runtime version, agent CLI version, and the absence of cargo, so the box is proven to match its pin rather than merely booted.

## Safety, and why it is shaped this way

AWS account 157466816238 is both the Bedrock/YC-credit account and production. It holds ECS `proliferate-production`, RDS `proliferate-production`, and the metabase tunnel host, and production lives in the DEFAULT VPC. A teardown that selected on a tag alone would be one typo from terminating production.

So the testbed lives in a dedicated non-default VPC at `10.42.0.0/16`, which nothing else uses, and every resource in it carries `Project=proliferate-fleet-testbed`. Resolution for any destructive operation asserts three things and refuses anything but exactly one match: the tag, an exact match on that CIDR, and `IsDefault=false`. Both entry points additionally assert the caller's AWS account before touching anything, overridable with `FLEET_TESTBED_ACCOUNT_ID`. Every teardown delete carries the tag filter as well as VPC membership, so no single wrong value widens a selection.

Rules the scripts enforce rather than document:

- No GitHub token is ever a variable in `user-data.sh`. It stays in an SSM SecureString and is fetched on demand by a mode-700 `core.askPass` helper running under the instance role. That keeps it out of xtrace and the setup logs, out of argv, and out of `.git/config`, and the clone is followed by an assertion that no credential got persisted anyway. `put-parameter` reads the token from a mode-600 temp file via `file://`, so it is not in the operator's process table either.
- No agent API key is written to the box. Agent auth is Bedrock through the instance IAM role, which the runtime already supports as a first-class provider, and the role's `bedrock:InvokeModel` is scoped to Anthropic Claude foundation-model and inference-profile ARNs rather than `*`.
- IMDSv2 is required with a hop limit of 1.
- Before anything that can fail, user-data arms a deadman against an instance launched with `--instance-initiated-shutdown-behavior terminate`. The deadline is a timestamp on disk, checked by a persistent systemd timer and a `cron.d` entry, so a reboot cannot disarm it, and a failure to arm degrades to a one-shot `shutdown` rather than aborting the setup at the exact line meant to be the safety net.

SSH is open to the caller's public IP as a /32 and nowhere else, and the security group's entire ingress set is revoked before the current rule is authorized, so /32s do not accumulate toward the 60-rule quota. The IAM policy scopes `ssm:GetParameter` to the prefix and `kms:Decrypt` to `ssm.*` via-service.

## Residual risk, stated plainly

Three things this design does not solve, which earlier revisions of this description overstated:

**The token is still a broad personal PAT, and the box still runs untrusted code as the user that can read it.** Moving the credential out of `.git/config` and into SSM moves it from "readable by `ubuntu` off disk" to "fetchable by `ubuntu` through the instance role". That is a real improvement against the leak paths that actually bit here (logs, argv, a credential persisted at 0644 forever, and a token that survives the box in a git config), but it is not confinement. `HttpTokens=required` costs a local process one extra PUT, and `HttpPutResponseHopLimit=1` restricts other hosts, not other processes on this one. The machine exists to run agent profiles executing model-generated code as `ubuntu`. The default token is Pablo's `gh` credential carrying `repo, workflow, gist, read:org`, which is far more than a clone of one repository needs. The right answer is a fine-grained read-only PAT scoped to `proliferate-ai/proliferate`, which needs Pablo to mint it. This PR does not block on that: `FLEET_TESTBED_TOKEN_FILE=/path/to/pat` or `FLEET_TESTBED_TOKEN_COMMAND='...'` supplies one with no edit to the scripts, and `gh auth token` remains the default until a scoped PAT exists. Treat any box provisioned before then as holding a credential with write access to the org.

**Scoping the Bedrock ARNs narrows reach, not quota.** Bedrock's on-demand limits are per account and per model, so a runaway testbed agent still draws on the same capacity production inference uses. The ARN scoping means the box cannot reach non-Anthropic models at all, which is worth having, but genuine quota isolation would need a separate account or provisioned throughput and is out of scope here.

**One of the two log files is tightened rather than born locked.** `/var/log/fleet-testbed-setup.log` is created 0600 before it has a byte in it. `/var/log/cloud-init-output.log` is not ours to create: cloud-init opens it early in boot and has already written its own module output there before user-data runs. It is chmodded 0600 as the second statement of the script, which is before any output of *this* script reaches it, and that is the accurate claim.

## Why x86_64 is the default

Graviton is cheaper per core and the runtime ships an aarch64 musl build, so arm64 was the obvious choice and it is wrong. The `agent_process` sidecar has no arm64 pin, so `POST /v1/agents/claude/install` returns `AGENT_NO_PIN_FOR_PLATFORM` for `linux_arm64` and every session sits at `install_required`. `--arch arm64` still works and is fine for memory and boot measurement, but no agent can run a turn on it. Filing that separately as a product defect, since it also means a self-hosted Graviton customer cannot install the agent.

## Repeatability

The instance is pinned to the commit behind release `server-v0.4.20` and the prebuilt musl binary from that same release, so the runtime and the source tree cannot disagree and no schema skew can be mistaken for a finding. The dev-loop fixes are cherry-picked on top rather than checked out, so the tree stays at the release. That branch is #2134; `FIX_BRANCH` points at it, and once it merges the cherry-pick step logs that there is nothing to pick and moves on. It does not become a no-op by accident: `git cherry-pick` with no arguments exits 129, so the empty case is handled explicitly.

Everything but the instance is idempotent. VPC, subnet, gateway, route table, security group, key pair, IAM role, and instance profile are created on first run and reused, the inline policy and role attachment are re-applied on every run so an edit here reaches an existing deployment, and the SSM token is rewritten every run so a rotated or revoked token cannot silently break future clones.

## Review round 1 findings

| # | Finding | Fix |
| --- | --- | --- |
| S1 | The token leaked three ways: `set -x` plus `tee` wrote `GH_TOKEN=gho_...` and the full clone command into two unrestricted logs, one of which the summary told the operator to tail; the token was expanded into a `su -c` argv visible in `/proc/<pid>/cmdline`; and `git clone` with the credential in the URL persisted it into `.git/config` at 0644, which the later `git fetch` then depended on. | The token is no longer referenced in `user-data.sh` at all. A mode-700 `/usr/local/bin/fleet-gh-askpass` owned by `ubuntu` reads the SSM SecureString with the instance role and prints the credential on stdout; the remote URL is fully tokenless, so nothing is persisted and later fetches work through the same helper. xtrace is disabled across the whole credential region, the log files are locked down before any of this script's output reaches them, the summary says `sudo tail`, and the clone is followed by assertions that fail the setup if any userinfo appears in `.git/config` or a token prefix appears on disk. |
| S2 | The resolver filtered on `tag:Project` alone and took `Vpcs[0]`, which has no ordering guarantee; `VPC_CIDR` was declared and never used (SC2034), so the "two independent predicates" claim was one predicate applied twice. | `resolve_testbed_vpc` filters on tag, `cidr` (an exact primary-CIDR match), and `is-default=false`, then re-asserts the id prefix, the CIDR, and `IsDefault` on the returned row, and dies on anything other than exactly one match instead of picking. |
| S3 | `teardown.sh --network` enumerated security groups, subnets, route tables, and internet gateways by VPC id only, with no tag filter. | Verified against `provision.sh` that all four are created with `tag_spec`, then added the tag filter to each describe. The ids are resolved into variables first, so a failing describe aborts instead of yielding an empty list that reads as "nothing to do". |
| S4 | Six `\|\| true`s meant `log "network deleted"` printed even when every delete failed. | Failures are counted and reported by name, the success line prints only at zero failures, and the script exits non-zero. Deletes go through a bounded retry that waits for ENIs to drain, with the last attempt un-silenced so the operator sees the real AWS error. |
| S5 | Teardown never removed the SSM SecureString, the IAM role, the instance profile, or the key pair; `provision.sh` also skipped the token when the parameter already existed, so a revoked token silently broke every future clone. | `--network` deletes the SSM parameter and `--all` additionally deletes the inline policy, role, instance profile, and key pair including the local private key. `provision.sh` writes the token on every run. |
| S6 | SSH /32s accumulated forever behind an `\|\| true`, and at the 60-rule quota new authorizes failed silently. | The ingress set is revoked before the current /32 is authorized, and the authorize no longer swallows its exit status. |
| S7 | Key-pair idempotency checked only the AWS side, and `> "$KEY_PATH"` truncated the file before `create-key-pair` ran; `chmod 600` came after creation. | Both sides are checked with a specific remedy per mismatch. Creation happens under `umask 077` into a temp file in the same directory, `mv`d into place only after the material is confirmed non-empty. |
| S8 | IAM idempotency was gated on `get-role`, so a run that died mid-way never self-repaired and policy edits never reached an existing deployment. | `put-role-policy` and `add-role-to-instance-profile` run unconditionally; an `add-role` failure is verified against the actual attachment before being treated as benign. |
| S9 | IMDSv1 was enabled. | `--metadata-options HttpEndpoint=enabled,HttpTokens=required,HttpPutResponseHopLimit=1`. See the residual-risk note on what this does and does not buy. |
| S10 | `bedrock:InvokeModel` on `Resource: "*"`, plus an `ec2:TerminateInstances` grant with no consumer. | Scoped to `arn:aws:bedrock:*::foundation-model/anthropic.claude-*` and `arn:aws:bedrock:*:<account>:inference-profile/*anthropic.claude-*`. `ec2:TerminateInstances` deleted: the deadman uses `shutdown -h` against `instance-initiated-shutdown-behavior=terminate`. Quota is still shared with production; see residual risk. |
| S11 | Nothing checked which account the caller was in. | `require_expected_account`, called first by both entry points, overridable with `FLEET_TESTBED_ACCOUNT_ID`. |
| S12 | Unquoted `sed` templating of refs into a root-executed script. | `require_safe_ref` restricts every templated value to `[A-Za-z0-9._/@+-]` and rejects a leading dash; `require_positive_int` covers the numeric ones. |
| S13 | Neither entry point set `set -euo pipefail` itself. | Both set it before sourcing, and the source line fails hard with its own message. |
| S14 | The deadman was a transient `systemd-run` unit in `/run`, disarmed by any reboot, and armed under `set -e` so its own failure aborted the setup. | An on-disk deadline plus a persistent `fleet-deadman.timer` and a `/etc/cron.d/fleet-deadman` entry, with a checker that fails closed. Arming runs inside an `if` and falls back to a one-shot `shutdown -h +N`. |

## Review round 2 findings

Round 2 confirmed ten of the fourteen above and found five blocking defects, two of them introduced by the round-1 commit.

| # | Finding | Fix |
| --- | --- | --- |
| B1 | Gating `build-essential` behind `--with-rust` also removed `make`, which `make build` and `make setup` need. The failure lands about twenty minutes in and then `provision.sh` waits the full hour before a generic timeout. | `make` is installed unconditionally and the compilers stay gated. Independently confirmed against both release manifests (`ubuntu-24.04-server-cloudimg-{amd64,arm64}.manifest`, 664 and 663 packages): no `make`, no `build-essential`, no compiler driver on either arch, though `libc6-dev` and `patch` are present. A `command -v` check over every tool this script invokes by name (`git curl jq make psql unzip`) now fails in seconds rather than mid-build. |
| B2 | `VPC_ID="$(find_testbed_vpc)"` ran the resolver in a command-substitution subshell where bash unsets errexit, so a failing `describe-vpcs` returned empty with status 0. That made `teardown --network` a silent no-op over a live instance, let `teardown --all` delete the key pair out from under a running m7i.4xlarge while printing "teardown complete", and made `provision.sh` create a second VPC at the same CIDR. | The resolver is now `resolve_testbed_vpc`, which sets `TESTBED_VPC_ID` in the caller's shell and dies on a failed describe. `inherit_errexit` is not the fix: macOS ships bash 3.2, where the option does not exist at all, which is verified in the harness. Every other function-in-a-capture was checked for the same shape; `read_github_token` is written to be called with a redirect for the same reason, which also keeps the token from ever becoming a variable in `provision.sh`. `tag_spec` is a bare `echo` and cannot fail. Teardown additionally refuses to delete a key pair while any instance is still using it. |
| B3 | The early `exit 0` for "no testbed VPC" preceded the SSM deletion block, so `--network` never deleted the token once the VPC was already gone, directly contradicting S5 and the comment above the block it skipped. | The early exit fires only when neither `--network` nor `--all` was requested. The VPC-scoped work stays inside the VPC guard; the SSM and IAM blocks sit outside it. |
| B4 | `git cherry-pick` with no arguments exits 129, so an empty `rev-list` is a hard failure, not the no-op the description claimed, the moment #2134 merges. | The pin step is a small generated script with the empty case handled and logged. The old and new forms were run against a fixture repo in both states: old exits 129, new exits 0 with "nothing to cherry-pick". The Repeatability section above is corrected. |
| B5 | Moving the token from `.git/config` to SSM is a smaller improvement than the description implied, given the box runs model-generated code as the user that can fetch it, and the token is a broad personal PAT. | Code part done: the token source is pluggable via `FLEET_TESTBED_TOKEN_FILE` or `FLEET_TESTBED_TOKEN_COMMAND`, defaulting to `gh auth token`. Minting a scoped fine-grained PAT is Pablo's call and is not blocking this PR. The claim is corrected in the Residual risk section rather than restated. |

Non-blocking items from the same round, all taken: the placeholder guard now matches `__[A-Z][A-Z0-9_]*__` rather than four named placeholders; the SSH revoke drops the entire ingress set, because a range rule or an `IpProtocol` of `-1` reaches port 22 without matching an exact-22 predicate; `require_ipv4` rejects `00.0.0.0`, `1.2.3.`, `1.2.3.4.5`, and out-of-range octets instead of counting dots; the `.git/config` assertion flags any userinfo rather than only the `user:secret@` form, and a second check scans for `gh[pousr]_`/`github_pat_` on disk; the SecureString no longer carries the trailing newline `file://` was putting in it; the Bedrock quota point is stated above; and the `cloud-init-output.log` claim is corrected in the code comment as well as here.

## Verification

Static, since running these against the account is the thing worth not getting wrong.

- `bash -n` on all four files, and on the rendered `user-data.sh`, the generated askPass helper, and the generated pin script after templating.
- `shellcheck -x` clean at warning level and above. Two SC2016 infos remain, both intentional (a JMESPath literal and one remote command string).
- The inline IAM policy parsed as JSON with representative substitutions.
- An offline harness stubbing `aws` and `gh`, 41 cases, no network and no AWS: a `describe-vpcs` that exits 254, 1, 143, or prints a production-shaped row and then fails must all abort, and must abort before any delete runs; genuine absence yields empty with status 0; default VPC, wrong CIDR, three matches, a non-`vpc-` id, and a blank `IsDefault` are each refused; sixteen IPv4 cases; and the token reader trims, rejects empty/whitespace/unreadable/failing sources, honours both override variables, and propagates failure through the redirect form. That last one carries its own negative control showing the `$(...)` form would have swallowed it.
- Control-flow runs of `teardown.sh` against a fake `aws` on `PATH`, asserting both status and the exact set of API calls made: `--network` with no VPC deletes the token, a failing describe deletes nothing and leaves the private key on disk, and a live instance holding the key pair blocks its deletion. The pre-fix `teardown.sh` from the previous commit was run against the same scenario as a negative control and printed "nothing to do" without ever calling `ssm delete-parameter`.
- The same treatment for `provision.sh`: a failing describe aborts before `create-vpc`, and genuine absence reaches it.

## Review notes

- `teardown.sh` with no flag removes instances only, which is the normal case, because leaving the network makes the next provision faster and costs nothing. `--network` adds the VPC, its dependencies, and the SSM token. `--all` adds the IAM role, instance profile, and key pair.
- The measurement scripts themselves (`boot.sh`, `measure.sh`) are still living on the instance rather than in the repo. They belong here in a follow-up so the whole loop is version controlled.
- The `--with-rust` path exists but is unexercised, so the concurrent-cargo-build experiment is not yet runnable.
