### PR TITLE
perf(release): combine desktop cargo builds behind a shared rust cache

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -210,11 +210,27 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Build AnyHarness runtime for target
+      # Cache the cargo registry/git checkouts and target/ artifacts, keyed per
+      # matrix target so the macOS arches (and any dormant windows entry) never
+      # share or collide on a cache key. Paired with the single combined cargo
+      # invocation below: one build graph, one cache, instead of four sequential
+      # `cargo build -p <pkg>` steps that each re-resolved the same workspace
+      # dependencies.
+      - name: Rust cache
+        if: steps.filter.outputs.skip != 'true'
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build Rust binaries for target
         if: steps.filter.outputs.skip != 'true'
         shell: bash
         run: |
-          cargo build --release -p anyharness --target "${{ matrix.target }}"
+          cargo build --release --target "${{ matrix.target }}" \
+            -p anyharness \
+            -p proliferate-diagnostics-collector \
+            -p proliferate-debug \
+            -p proliferate-worker
           mkdir -p apps/desktop/src-tauri/binaries
           if [[ "${{ matrix.runner_os }}" == "windows" ]]; then
             cp "target/${{ matrix.target }}/release/anyharness.exe" "apps/desktop/src-tauri/binaries/anyharness-${{ matrix.target }}.exe"
@@ -253,11 +269,10 @@ jobs:
           codesign --verify --verbose "$EXTRACTED_NODE_BIN"
           spctl --assess --verbose=4 --type open --context context:primary-signature "$EXTRACTED_NODE_BIN"
 
-      - name: Build diagnostics collector for target
+      - name: Stage diagnostics collector for target
         if: steps.filter.outputs.skip != 'true'
         shell: bash
         run: |
-          cargo build --release -p proliferate-diagnostics-collector --target "${{ matrix.target }}"
           mkdir -p apps/desktop/src-tauri/binaries
           collector="target/${{ matrix.target }}/release/proliferate-diagnostics-collector"
           staged="apps/desktop/src-tauri/binaries/proliferate-diagnostics-collector-${{ matrix.target }}"
@@ -266,11 +281,10 @@ jobs:
           chmod +x "$staged"
           cmp "$collector" "$staged"
 
-      - name: Build Proliferate debug helper for target
+      - name: Stage Proliferate debug helper for target
         if: steps.filter.outputs.skip != 'true'
         shell: bash
         run: |
-          cargo build --release -p proliferate-debug --target "${{ matrix.target }}"
           mkdir -p apps/desktop/src-tauri/binaries
           if [[ "${{ matrix.runner_os }}" == "windows" ]]; then
             cp "target/${{ matrix.target }}/release/proliferate-debug.exe" "apps/desktop/src-tauri/binaries/proliferate-debug-${{ matrix.target }}.exe"
@@ -279,11 +293,10 @@ jobs:
             chmod +x "apps/desktop/src-tauri/binaries/proliferate-debug-${{ matrix.target }}"
           fi
 
-      - name: Build Proliferate worker for target
+      - name: Stage Proliferate worker for target
         if: steps.filter.outputs.skip != 'true'
         shell: bash
         run: |
-          cargo build --release -p proliferate-worker --target "${{ matrix.target }}"
           mkdir -p apps/desktop/src-tauri/binaries
           if [[ "${{ matrix.runner_os }}" == "windows" ]]; then
             cp "target/${{ matrix.target }}/release/proliferate-worker.exe" "apps/desktop/src-tauri/binaries/proliferate-worker-${{ matrix.target }}.exe"

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -221,6 +221,15 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.target }}
+          # Actions caches are ref-scoped. This workflow also triggers on
+          # `push: tags: desktop-v*`, and a save made under `refs/tags/...` can
+          # only ever be restored by that same tag, so it is a pure write into
+          # an already-tight repo cache pool. Only branch / dispatch runs save.
+          save-if: ${{ github.ref_type != 'tag' }}
+          # Notarization and publish are the late, occasionally-failing part of
+          # this job. A failure there should still bank the compile cache the
+          # preceding ~12 minutes produced.
+          cache-on-failure: true
 
       - name: Build Rust binaries for target
         if: steps.filter.outputs.skip != 'true'


### PR DESCRIPTION
## What changed

`.github/workflows/release-desktop.yml`, `build-desktop` job only. Two edits:

1. **One cargo invocation instead of four.** The job compiled `anyharness`, `proliferate-diagnostics-collector`, `proliferate-debug`, and `proliferate-worker` in four separate `cargo build --release -p <pkg> --target <target>` steps. They are now a single `cargo build --release --target <target> -p ... -p ... -p ... -p ...`.
2. **`Swatinem/rust-cache@v2`, keyed per matrix target.** Added right after `Setup Rust stable`, with `key: ${{ matrix.target }}` so each arch gets its own cache entry and the macOS arches (plus any dormant windows/Intel entry) never collide. Same action and version already used in `ci.yml`, `server-ci.yml`, `release-e2e.yml`, and `catalog-probe.yml`. The step also sets `save-if: ${{ github.ref_type != 'tag' }}` and `cache-on-failure: true` — see "Cache-write hygiene" below.

The three downstream steps keep their copy / `chmod` / `cmp` / `test -x` verification verbatim and only lose their `cargo build` line, so they are renamed `Build ... for target` -> `Stage ... for target` to describe what they now do. The combined build step keeps the AnyHarness staging block it already had, so `Build bundled agent seed` still finds `target/<target>/release/anyharness` at the same path.

Deliberately untouched: signing, notarization, bundling, publish, and updater-manifest steps. No step ids or step outputs changed; nothing in the repo referenced the renamed step names.

### Matrix / platform notes

- Main is ARM-only right now (#2126 commented out the `x86_64-apple-darwin` entry on 2026-08-20). The change is written against `${{ matrix.target }}`, so it works for the live `aarch64-apple-darwin` entry and stays correct if the Intel entry is restored — each target simply gets its own cache key.
- The dormant `runner_os == 'windows'` branches inside the affected steps are preserved byte-for-byte. The combined `cargo build` is target-parameterised and runs under `shell: bash`, so it is windows-safe if that leg is ever added.
- Every added/modified step carries the existing `if: steps.filter.outputs.skip != 'true'` guard, matching its neighbours.

### Cache-write hygiene

- **`save-if: ${{ github.ref_type != 'tag' }}`.** This workflow also triggers on `push: tags: desktop-v*`, and `Validate release ref` forces manual non-dry-run releases onto a `desktop-v*` tag ref. Actions caches are ref-scoped, so a save made under `refs/tags/desktop-v0.4.21` can only ever be restored by that same tag — a pure write, never a read. Tag-scoped releases are a live path in the run history (`desktop-v0.3.49`, `desktop-v0.3.14`, `desktop-v0.2.10`), so without this gate every release would burn a multi-hundred-MB write into the shared pool for zero future benefit. Branch and dispatch runs still save, and tag runs still *restore* via default-branch fallback.
- **`cache-on-failure: true`.** Notarization and publish are the late, occasionally-failing part of this job (three late failures/cancellations in recent history). Without this, a failure after the build discards exactly the ~12 minutes of compile the cache exists to preserve, and "one priming run" silently becomes "one *successful* priming run".

## Measured before/after

All figures are the **cargo portion of the ARM `build-desktop` job**, measured on real `macos-15` runners.

| | cargo time | source |
| --- | --- | --- |
| Before: 4 separate steps, no cache | **12m35s** | live nightly train run [32167413474](https://github.com/proliferate-ai/proliferate/actions/runs/32167413474), ARM `build-desktop` job, 2026-08-18 |
| After, priming run: combined, cold cache | 12m18s | [32410829381](https://github.com/proliferate-ai/proliferate/actions/runs/32410829381) |
| After, warm cache | **5m23s** | [32412144015](https://github.com/proliferate-ai/proliferate/actions/runs/32412144015), cache restore 13s |

The 12m35s baseline is the sum of the four existing steps in that live job: `anyharness` 5m54s + `proliferate-diagnostics-collector` 50s + `proliferate-debug` 4m52s + `proliferate-worker` 60s.

The two "after" numbers were measured on `exp/desktop-build-speed` with a throwaway workflow that mirrored only checkout -> toolchain setup -> rust-cache -> combined build for `aarch64-apple-darwin` on `macos-15` (no signing secrets, no bundling). **That experiment workflow is not part of this PR**; only the `release-desktop.yml` config is transplanted here.

**Where the win actually comes from.** Combining the four invocations on a cold cache is roughly neutral (12m35s -> 12m18s) — cargo was already reusing the shared dependency artifacts in `target/` across the four steps inside a single job. The 7m12s comes from rust-cache carrying `target/` and the cargo registry *across* runs. Combining still earns its place (one build graph for the cache to restore against, three fewer redundant resolve/link passes), but the caching is the load-bearing half, which makes the caveats below the important ones.

## Caveats — read before trusting the warm number

**1. The warm number is conditional on the cache surviving between daily runs, and this repo's cache pool does not guarantee that.**

`GET /repos/proliferate-ai/proliferate/actions/cache/usage` returned `{"active_caches_size_in_bytes":10521040818,"active_caches_count":216}` at 2026-08-20T23:12Z — **10.52 GB against the 10 GB repo limit**. Size is the trustworthy half of that response; `active_caches_count` lags and should not be read as a live entry count. The store is over quota and evicting LRU continuously. The experiment's own entry proves the exposure: the post step of run `32410829381` saved 661 MB (`Sent 693585475 of 693585475`) at 2026-08-20T20:03:22Z, and `GET .../actions/caches?ref=refs/heads/exp/desktop-build-speed` returned `total_count: 0` a few hours later — **evicted in under 6 hours**, with the branch still alive.

`release-desktop` runs at most once a day via the nightly train, and only when `needs.prepare.outputs.desktop == 'true'`. Its entry is therefore the coldest LRU candidate in the pool, competing against `v0-rust-cargo-check` (745 MB) and `v0-rust-candidate-build-handoff` (405 MB), which are rewritten on essentially every PR — 3 and 10 live copies respectively, 6.2 GB between them, in a paginated listing taken 2026-08-21T01:47Z. GitHub's 7-day unused-entry eviction is a second way to lose it.

So: **5m23s is the number when the cache is warm, not a number the release train is guaranteed to see.** The ~27.5m steady state derived below (34m44s - 7m12s) depends on the entry surviving from one daily run to the next, which the current pool does not assure. What this PR does about it: `save-if` stops the tag-triggered releases from wasting writes into the same pool. Actually pruning the stale/duplicate entries is a **follow-up**, not part of this PR — the top-15-by-size listing is in the review thread for whoever picks it up. Worst realistic case if the cache keeps missing: the job pays the old cost plus ~25-60s of cache save.

**2. The real cache entry will be larger than the measured 661 MB — and the real win may be larger than 7m12s. Neither was measured.**

The experiment job ended right after the combined cargo build. In the real `build-desktop`, rust-cache's post step runs at the *end* of the job, after `Build Tauri app`, which runs `pnpm tauri build --target ${{ matrix.target }}` from `apps/desktop` into the same root `target/`. Both directions follow:

- The saved entry will be materially bigger than 661 MB, because tauri's dep graph is not in that number. That makes the quota pressure in caveat 1 worse than it looks.
- `Build Tauri app` will *also* be partly warmed on a restore. That step was 12m29s on ARM in run `32167413474`, so the real upside may exceed the measured 7m12s. **Unmeasured potential, not a claim.**

**3. The very next release after merge looks unchanged.** rust-cache writes on the first qualifying run; that run pays roughly the old cost plus the save. Only a subsequent run that restores the entry lands at 5m23s. Cache keys also rotate on `Cargo.lock` / toolchain changes, so a dependency bump re-primes.

**4. Not claimed: byte-identical artifacts.** Under `resolver = "2"`, `cargo build -p a -p b -p c -p d` unifies features across the four packages' graphs where four separate `-p` builds resolved each alone. Unification is additive, so a shipped binary can carry dep features it previously did not. Risk is low (shared deps are centrally pinned in the root `[workspace.dependencies]`, and `ci.yml` already runs `cargo test --workspace` over a strictly wider member set), but this PR did not diff the produced binaries against the four-step output.

## Expected effect on the release train

The ARM `build-desktop` job in the 2026-08-18 train ran **34m44s** wall (17:47:26Z -> 18:22:10Z). On a run that restores a warm cache, subtracting the 7m12s saved on the cargo portion puts it near **~27.5m**, possibly better if `Build Tauri app` is warmed too (caveat 2). On a run that misses, it stays at ~34m44s plus the save. Signing, notarization, and publish are unchanged, so the rest of the desktop leg and every other train stage are unaffected either way.

## Follow-ups (not in this PR)

- Prune stale / duplicate Actions cache entries so the pool sits under the 10 GB limit; without that, the desktop entry's survival between daily runs stays a coin flip.
- Consider `--locked` on the release build (pre-existing: neither the old four steps nor the combined one passes it, so a release can silently resolve a `Cargo.lock` update).
