### PR TITLE
perf(server): split CI lanes and shard integration tests 3-way

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -270,8 +270,20 @@ jobs:
       # this shard's offset. Whole files stay together -- xdist distributes
       # within a shard -- so no test can land in two shards or in none, and
       # the partition is identical across workers, runs, and reruns because
-      # it depends only on the sorted file list, never on collection or
-      # runtime order.
+      # it depends only on the file list sorted under LC_ALL=C, never on
+      # collection or runtime order. Collation is pinned explicitly: the
+      # shard a file lands in is a function of its index in the sorted list,
+      # so a locale that ordered punctuation or case differently would move
+      # files between shards. The three shards would still union to the whole
+      # suite, so such a drift is invisible in the pass/fail signal -- pinning
+      # LC_ALL=C is what makes reruns comparable rather than merely green.
+      #
+      # `mapfile < <(...)` reads from a process substitution, which is not a
+      # pipeline, so `set -o pipefail` cannot observe a failing `find` and the
+      # step would happily continue with a short or empty list. The floor
+      # checks below are the actual guard: a rename or move under
+      # tests/integration that collapses the list fails the shard loudly
+      # instead of silently testing almost nothing.
       - name: Partition integration test files (shard ${{ matrix.shard }} of 3)
         id: partition
         env:
@@ -280,21 +292,32 @@ jobs:
           set -euo pipefail
           mapfile -t files < <(
             { find tests/integration -type f \( -name 'test_*.py' -o -name '*_test.py' \); \
-              echo tests/e2e/cloud/test_e2b_webhooks.py; } | sort -u
+              echo tests/e2e/cloud/test_e2b_webhooks.py; } | LC_ALL=C sort -u
           )
           echo "Total integration test files: ${#files[@]}"
+          if (( ${#files[@]} < 100 )); then
+            echo "Refusing to shard: discovered only ${#files[@]} integration test files (expected >= 100)." >&2
+            echo "The find over tests/integration collapsed -- check for a moved or renamed test tree." >&2
+            exit 1
+          fi
           shard_files=()
           for i in "${!files[@]}"; do
             if (( i % 3 == SHARD - 1 )); then
               shard_files+=("${files[$i]}")
             fi
           done
+          if (( ${#shard_files[@]} == 0 )); then
+            echo "Refusing to run: shard ${SHARD} of 3 was assigned no files out of ${#files[@]}." >&2
+            exit 1
+          fi
           echo "Shard ${SHARD} owns ${#shard_files[@]} files:"
           printf '  %s\n' "${shard_files[@]}"
           printf '%s\n' "${shard_files[@]}" > shard_files.txt
 
+      # -r so that an empty shard_files.txt runs nothing and fails, rather
+      # than invoking a bare `pytest` that would collect the entire suite.
       - name: Run integration tests (shard ${{ matrix.shard }} of 3)
-        run: xargs -a shard_files.txt pytest -n 4 -q --durations=20
+        run: xargs -r -a shard_files.txt pytest -n 4 -q --durations=20
 
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -183,6 +183,10 @@ jobs:
   test-integration:
     runs-on: ubuntu-latest
     timeout-minutes: 75
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     env:
       DATABASE_URL: postgresql+asyncpg://proliferate:localdev@127.0.0.1:5432/proliferate
       JWT_SECRET: test-jwt-secret
@@ -260,8 +264,37 @@ jobs:
           docker exec "$container" psql -U proliferate -d proliferate \
             -c 'SHOW max_locks_per_transaction;'
 
-      - name: Run integration tests
-        run: pytest tests/integration tests/e2e/cloud/test_e2b_webhooks.py -n 4 -q --durations=20
+      # Deterministic file-level partition: list every integration test file
+      # plus the one e2e file this lane also carries, sort them (independent
+      # of filesystem traversal order), and take every third file starting at
+      # this shard's offset. Whole files stay together -- xdist distributes
+      # within a shard -- so no test can land in two shards or in none, and
+      # the partition is identical across workers, runs, and reruns because
+      # it depends only on the sorted file list, never on collection or
+      # runtime order.
+      - name: Partition integration test files (shard ${{ matrix.shard }} of 3)
+        id: partition
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(
+            { find tests/integration -type f \( -name 'test_*.py' -o -name '*_test.py' \); \
+              echo tests/e2e/cloud/test_e2b_webhooks.py; } | sort -u
+          )
+          echo "Total integration test files: ${#files[@]}"
+          shard_files=()
+          for i in "${!files[@]}"; do
+            if (( i % 3 == SHARD - 1 )); then
+              shard_files+=("${files[$i]}")
+            fi
+          done
+          echo "Shard ${SHARD} owns ${#shard_files[@]} files:"
+          printf '  %s\n' "${shard_files[@]}"
+          printf '%s\n' "${shard_files[@]}" > shard_files.txt
+
+      - name: Run integration tests (shard ${{ matrix.shard }} of 3)
+        run: xargs -a shard_files.txt pytest -n 4 -q --durations=20
 
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -109,7 +109,78 @@ jobs:
           uv run --python 3.12 --frozen --extra dev python scripts/check_mypy_baseline.py
           --github-event-base
 
-  test:
+  # tests/unit is not actually free of live-infra dependencies: 113 test
+  # functions across 20 files resolve the test_engine/db_session/client/
+  # single_org_client fixtures (tests/conftest.py, tests/unit/test_first_run_claim.py:64,
+  # tests/unit/test_registration_page.py:54, tests/unit/test_self_registration.py:53, etc.)
+  # which open a real Postgres connection, and
+  # tests/unit/test_redis_lock.py:108 and :138 exercise a live Redis over
+  # settings.redbeat_redis_url. Moving those ~115 tests out of tests/unit or
+  # reworking the fixtures to fake the backends would be well past a minimal
+  # conftest change, so this lane keeps the service containers as the
+  # documented fallback (see PR body) -- only the xdist fan-out and the
+  # lock-table bump are dropped, since a serial, single-connection run never
+  # needs them.
+  test-unit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      DATABASE_URL: postgresql+asyncpg://proliferate:localdev@127.0.0.1:5432/proliferate
+      JWT_SECRET: test-jwt-secret
+      CLOUD_SECRET_KEY: test-cloud-secret
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: proliferate
+          POSTGRES_PASSWORD: localdev
+          POSTGRES_DB: proliferate
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U proliferate -d proliferate"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.git_sha || github.ref }}
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+      - uses: astral-sh/setup-uv@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: .
+
+      - name: Build artifact runtime
+        run: pnpm -C server/artifact-runtime build
+        working-directory: .
+
+      - name: Install dependencies
+        run: uv pip install --system -e ".[dev]"
+
+      - name: Run unit tests
+        run: pytest tests/unit -q --durations=20
+
+  test-integration:
     runs-on: ubuntu-latest
     timeout-minutes: 75
     env:
@@ -189,12 +260,12 @@ jobs:
           docker exec "$container" psql -U proliferate -d proliferate \
             -c 'SHOW max_locks_per_transaction;'
 
-      - name: Run tests
-        run: pytest tests/unit tests/integration tests/e2e/cloud/test_e2b_webhooks.py -n 4 -q --durations=20
+      - name: Run integration tests
+        run: pytest tests/integration tests/e2e/cloud/test_e2b_webhooks.py -n 4 -q --durations=20
 
   docker:
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [lint, test-unit, test-integration]
     # Reusable-workflow calls inherit the caller's event name (never
     # "workflow_call"), so this leg is driven by inputs.publish/dry_run instead.
     # inputs.* are empty on plain push/PR events, so the comparisons stay false
@@ -294,7 +365,7 @@ jobs:
 
   self-hosted-release-assets:
     runs-on: ubuntu-latest
-    needs: [lint, test, docker]
+    needs: [lint, test-unit, test-integration, docker]
     # Same input-driven gate as the docker job (see note above): a server-v tag
     # push, or an explicit publish call from a release train / hotfix workflow.
     if: (startsWith(github.ref, 'refs/tags/server-v')) || (inputs.publish == true && inputs.dry_run != true)

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -63,9 +63,14 @@ async def test_engine(migrated_test_database):  # type: ignore[no-untyped-def]
     resolves through this fixture.
 
     Fixture ordering is unchanged: the pre-test truncate still runs before any
-    fixture that depends on ``test_engine`` can seed rows, and the post-test
-    truncate still runs after those fixtures tear down, because teardown is the
-    reverse of setup and this fixture is the first of the chain to be set up.
+    fixture that depends on ``test_engine`` can seed rows.
+
+    The truncate runs before each test only, not after: every test already
+    starts from a clean slate via this same call, so an after-test truncate
+    only ever cleaned the database at process exit -- which the CI job never
+    reads back. The Postgres service container is torn down with the runner,
+    and the session-scoped ``migrated_test_database`` fixture drops the whole
+    database unconditionally regardless of its contents.
 
     Tests that build their own throwaway database (``temporary_database``) are
     self-isolating and correctly opt out of the shared-database reset.
@@ -76,8 +81,6 @@ async def test_engine(migrated_test_database):  # type: ignore[no-untyped-def]
     try:
         yield engine
     finally:
-        await _cancel_test_background_tasks()
-        await truncate_all_tables(engine)
         await engine.dispose()
 
 


### PR DESCRIPTION
## What

Splits Server CI's single `test` job into a fast unit lane and a 3-way-sharded integration lane, on top of the per-worker-DB xdist work already merged in #2122. Three measured experiments composed into one change:

| Experiment | PR | What it measured |
| --- | --- | --- |
| Lane split | #2129 (`exp/server-lane-split`) | `test` → `test-unit` + `test-integration` |
| Before-only truncate | #2130 (`exp/server-split-before-only`) | drop the post-test TRUNCATE in `test_engine` |
| Integration sharding | #2131 (`exp/server-integration-shard`) | `test-integration` fanned out to 3 shards |

## Measured baseline

Main at `56dd6ebf` (run [32434848206](https://github.com/proliferate-ai/proliferate/actions/runs/32434848206)), the merged-#2122 shape:

```
test | Run tests | 2972 passed, 1 skipped, 903 warnings in 920.17s (0:15:20)
```

Job wall `16m15s`, and it is the pole of the whole PR gate — the next-slowest check on that commit is `Cargo check & test` at `8m01s`.

## Receipts

### 1. Lane split — #2129, runs [32424851471](https://github.com/proliferate-ai/proliferate/actions/runs/32424851471) / [32425911757](https://github.com/proliferate-ai/proliferate/actions/runs/32425911757)

```
test-unit        | 1904 passed, 10 warnings in 174.19s (0:02:54)
test-integration | 1068 passed, 1 skipped, 890 warnings in 601.26s (0:10:01)
test-unit        | 1904 passed, 10 warnings in 184.27s (0:03:04)
test-integration | 1068 passed, 1 skipped, 890 warnings in 753.39s (0:12:33)
```

**Measured correction to the naive split.** `tests/unit` is not free of live infrastructure: 113 test functions across 20 files resolve the `test_engine` / `db_session` / `client` / `single_org_client` fixtures and open a real Postgres connection, and `tests/unit/test_redis_lock.py:108,:138` exercise a live Redis over `settings.redbeat_redis_url`. So the unit lane **keeps** the postgres and redis service containers. What it drops is the xdist fan-out and the `max_locks_per_transaction` bump — a serial single-connection run never needs either, and it still finishes in ~3m.

### 2. Before-only truncate — #2130, runs [32424923992](https://github.com/proliferate-ai/proliferate/actions/runs/32424923992) / [32425925280](https://github.com/proliferate-ai/proliferate/actions/runs/32425925280)

`test-integration` wall `9m09s` / `10m09s` against `10m52s` / `13m31s` for the same lanes without it. Every test already starts from a clean slate through the same `test_engine` call, so the post-test TRUNCATE only ever cleaned the database at process exit — which the job never reads back.

> [!NOTE]
> **Semantics change — ratified by Pablo on 2026-08-20.** This is a semantics change, not a pure optimization: tables now keep residue after each test instead of being wiped on teardown. Any future test that inspects the database *outside* a `test_engine`-scoped fixture, or any debugging workflow that relied on a clean database at process exit, sees different behavior. The ratified contract is **clean-at-start**: `test_engine` guarantees every test begins against a truncated database, and post-teardown residue is accepted. Write tests against that guarantee — do not rely on the database being clean *after* a test finishes.

### 3. Integration sharding — #2131, runs [32428452217](https://github.com/proliferate-ai/proliferate/actions/runs/32428452217) / [32429121218](https://github.com/proliferate-ai/proliferate/actions/runs/32429121218)

Deterministic file-level partition: all `tests/integration` test files plus `tests/e2e/cloud/test_e2b_webhooks.py`, sorted, `index % 3 == shard - 1`. Identical partition across both samples:

```
Total integration test files: 132   ->   Shard 1 owns 44 / Shard 2 owns 44 / Shard 3 owns 44
```

| Shard | Sample A ([32428452217](https://github.com/proliferate-ai/proliferate/actions/runs/32428452217)) | Sample B ([32429121218](https://github.com/proliferate-ai/proliferate/actions/runs/32429121218)) |
| --- | --- | --- |
| 1 | `286 passed, 1 skipped, 237 warnings in 233.23s (0:03:53)` | `286 passed, 1 skipped, 237 warnings in 216.77s (0:03:36)` |
| 2 | `397 passed, 261 warnings in 439.95s (0:07:19)` | `397 passed, 261 warnings in 176.12s (0:02:56)` |
| 3 | `385 passed, 389 warnings in 255.55s (0:04:15)` | `385 passed, 389 warnings in 255.68s (0:04:15)` |

Test counts are byte-identical across the two samples; only the wall times move. Shard 2's `7m19s`/`8m28s` in sample A is **runner variance, not partition imbalance** — the same 397 tests ran in `2m56s` in sample B on the identical partition.

Each shard keeps postgres + redis, the `max_locks_per_transaction = 1024` step, and `pytest -n 4`.

## Count reconciliation

```
test-unit                     1904 passed
test-integration shard 1       286 passed,  1 skipped
test-integration shard 2       397 passed
test-integration shard 3       385 passed
                              ---------------------
                              2972 passed,  1 skipped
main baseline (single job)    2972 passed,  1 skipped
```

No test is dropped, duplicated, or double-counted. Whole files stay together, so xdist distributes only *within* a shard and the partition depends solely on the sorted file list — never on collection or runtime order.

## Gate effect

The server pole drops from `16m15s` to the slowest integration shard, ~`4-5m` (`test-unit` ~`3m` runs alongside it). With server no longer the long pole, the PR gate becomes rust-bound at `Cargo check & test`, ~`7-8m`.

## Wiring

- `docker` → `needs: [lint, test-unit, test-integration]`
- `self-hosted-release-assets` → `needs: [lint, test-unit, test-integration, docker]`
- No other consumer of the old `test` job name exists. The reusable-workflow callers (`hotfix-production.yml`, `nightly-release-train.yml`) invoke `./.github/workflows/server-ci.yml` as a whole and never name inner jobs; `server-ci.yml` declares no `workflow_call` outputs; `deploy-staging.yml`'s "Wait for Server CI" polls the run's overall conclusion, not a job name. Verified there is no branch protection or ruleset pinning `test` as a required check.

## Files

- `.github/workflows/server-ci.yml`
- `server/tests/conftest.py`

## Validation on this PR

Server CI run [32436380473](https://github.com/proliferate-ai/proliferate/actions/runs/32436380473) at `4d9fffdd1`, all lanes green — a third sample with counts identical to the two experiment samples:

```
test-unit            | 1904 passed, 10 warnings in 123.92s (0:02:03)
test-integration (1) | 286 passed, 1 skipped, 237 warnings in 228.03s (0:03:48)
test-integration (2) | 397 passed, 261 warnings in 175.86s (0:02:55)
test-integration (3) | 385 passed, 389 warnings in 247.37s (0:04:07)
lint                 | All checks passed! / Mypy diagnostic ratchet passed (480 existing diagnostics).
```

All three shards again report `Total integration test files: 132` and `owns 44 files`. Job walls: `test-unit` 2m51s, shards 4m45s / 3m41s / 5m04s — the whole server lane now completes in ~5m against the `16m15s` baseline. `docker` and `self-hosted-release-assets` correctly resolved their new `needs` and skipped (input-driven gate, not a PR event).

Gate effect confirmed on this PR's head `4d9fffdd1`. Slowest checks, measured:

```
7m10  Cargo check & test        <- new pole
6m35  intent-tests (provisional)
5m19  intent-billing (provisional)
5m04  test-integration (3)      <- slowest server lane
4m45  test-integration (1)
```

Server is no longer the long pole. The gate is rust-bound at ~`7m`, down from the `16m15s` `test` job it replaces.

## Review hardening

Applied from review on `4d9fffdd1`, in `399a7f7a1`, scoped to the partition step only:

- **`LC_ALL=C sort -u`.** The shard a file lands in is its index in the sorted list mod 3, so collation is part of the partition contract. Reproduced the reviewer's proof against the real tree: under `en_US.UTF-8` rather than `LC_ALL=C`, **13 of the 132** discovered files land in a different shard. Both collations yield the identical *set*, so the three shards still union to the whole suite and the drift never surfaces as a failure — it just makes two runs incomparable while both stay green. Pinning `LC_ALL=C` is what makes reruns comparable rather than merely green. Shard sizes under `LC_ALL=C` remain 44/44/44.
- **Floor checks on the discovered list.** `mapfile -t files < <(...)` reads a process substitution, not a pipeline, so `set -o pipefail` cannot observe a failing `find`; a moved or renamed `tests/integration` tree would give a short or empty list and the shard would pass by testing almost nothing. Now fails loudly with the observed count if fewer than 100 files are discovered, or if a shard is assigned none.
- **`xargs -r`.** An empty `shard_files.txt` now runs nothing and fails, instead of invoking a bare `pytest` that would collect the entire suite.
- Comment at the partition step updated to state the dependency on the `LC_ALL=C`-sorted list and to explain why the process-substitution guard is needed.

## Follow-ups (not in this PR, to keep the diff minimal)

- `_cancel_test_background_tasks` in `server/tests/conftest.py` is an inert stub (`return None`) — flagged by both reviews. It is still called on the pre-test path, so it is not dead code, but it does nothing and should be removed in a separate cleanup rather than widening this diff.
- The `id: partition` on the partition step is unused; no step consumes its outputs.
