### PR TITLE
perf(ci): run cargo tests under nextest with sccache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,19 +284,27 @@ jobs:
       # process across a work-stealing pool instead of one thread pool per test
       # binary, which is where the wall-clock win comes from. It does not run
       # doctests; this workspace has none (every Doc-tests binary reports zero
-      # tests), so nothing is dropped.
+      # tests), so nothing is dropped. Pinned rather than floating so the runner
+      # version is deterministic: rust-cache's paths include ~/.cargo/bin, which
+      # is where install-action puts the binary, so an unpinned tool can ride
+      # along in a restored target-dir cache.
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-nextest
+          tool: cargo-nextest@0.9.143
 
+      # --no-fail-fast restores libtest's diagnostic behaviour: nextest stops
+      # scheduling new tests after the first failure, while cargo test reports
+      # every failure in the binary it is running. Pass/fail is identical either
+      # way; without this a red run surfaces one failing test instead of the
+      # whole failing set.
       - name: Cargo test
-        run: cargo nextest run --workspace
+        run: cargo nextest run --workspace --no-fail-fast
 
       # The workspace run above builds this package with default features, so
       # the internal-only export path and its dogfood proof would never be
       # evaluated without this step.
       - name: Cargo test internal diagnostics export
-        run: cargo nextest run -p proliferate-diagnostics-collector --features internal-dogfood-export
+        run: cargo nextest run -p proliferate-diagnostics-collector --features internal-dogfood-export --no-fail-fast
 
   sdk-build:
     name: Build SDK

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,17 @@ jobs:
   cargo-check:
     name: Cargo check & test
     runs-on: ubuntu-latest
+    # Two caches with different jobs. Swatinem/rust-cache carries the registry
+    # and dependency artifacts, but deliberately discards workspace-crate build
+    # output, so our own crates recompile on every run. sccache is keyed on
+    # rustc invocation inputs, so it can hit for unchanged workspace crates that
+    # the target-dir cache never carries forward. CARGO_INCREMENTAL=0 is
+    # required, not incidental: incremental compilation makes rustc invocations
+    # sccache-uncacheable.
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -264,16 +275,28 @@ jobs:
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+
       - uses: Swatinem/rust-cache@v2
 
+      # nextest replaces the libtest runner: it schedules each test in its own
+      # process across a work-stealing pool instead of one thread pool per test
+      # binary, which is where the wall-clock win comes from. It does not run
+      # doctests; this workspace has none (every Doc-tests binary reports zero
+      # tests), so nothing is dropped.
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
       - name: Cargo test
-        run: cargo test --workspace
+        run: cargo nextest run --workspace
 
       # The workspace run above builds this package with default features, so
       # the internal-only export path and its dogfood proof would never be
       # evaluated without this step.
       - name: Cargo test internal diagnostics export
-        run: cargo test -p proliferate-diagnostics-collector --features internal-dogfood-export
+        run: cargo nextest run -p proliferate-diagnostics-collector --features internal-dogfood-export
 
   sdk-build:
     name: Build SDK


### PR DESCRIPTION
## Summary

Composes two independently measured CI wins onto the `cargo-check` job, on top of the `rust-cache` + check-step removal that landed in #2113. Only that one job in `ci.yml` changes; nothing else in the workflow is touched.

- **sccache** (`mozilla-actions/sccache-action`, `RUSTC_WRAPPER=sccache`, `SCCACHE_GHA_ENABLED=true`, `CARGO_INCREMENTAL=0`) attacks the **compile** phase. `Swatinem/rust-cache` deliberately discards workspace-crate build artifacts, so our own crates recompile on every run even when unchanged; sccache is keyed on rustc invocation inputs and can hit for exactly those. `CARGO_INCREMENTAL=0` is load-bearing, not cosmetic — incremental compilation makes rustc invocations sccache-uncacheable.
- **cargo-nextest** (`taiki-e/install-action@v2`, pinned to `cargo-nextest@0.9.143`) attacks the **test execution** phase, running each test in its own process across a work-stealing pool rather than one thread pool per test binary.

The two hit different phases, so they compose. `rust-cache` stays in place for the registry/dependency cache.

## Receipts

All measurements are the `Cargo check & test` job. The direct A/B control is the warm run on `ci/cargo-cache-and-dedupe` (the #2113 branch), which is the same job shape as current `main`.

| Config | Run | Job wall | `Cargo test` step |
| --- | --- | --- | --- |
| Baseline (#2113 shape, warm) | [32405379745](https://github.com/proliferate-ai/proliferate/actions/runs/32405379745/job/96551626337) | **444s** (7m24s) | 367s |
| sccache only (#2116, warm) | [32411990807](https://github.com/proliferate-ai/proliferate/actions/runs/32411990807) | **358s** (5m58s) | 277s |
| nextest only (#2118, warm) | [32410913141](https://github.com/proliferate-ai/proliferate/actions/runs/32410913141) | **357s** (5m57s) | 256s |
| Both — best case (#2128, warm) | [32413255083](https://github.com/proliferate-ai/proliferate/actions/runs/32413255083) | **287s** (4m47s) | 203s |
| **Both — representative (this branch, warm)** | [32437875664](https://github.com/proliferate-ai/proliferate/actions/runs/32437875664/job/96642619918) | **334s** (5m34s) | **254s** |

**Quote 334s/254s, not 287s/203s.** Both are real warm runs of the same config; 287s is the best of the samples and 334s is the more representative one, measured on this branch's own head after the caches had primed. Against a 444-548s baseline that is still a solid win, and it is the number to plan against.

## Variance caveat — quote the win as a range, not a point

Baseline job wall time on this runner class is noisy. Post-#2113 baseline-shape samples:

| Run | Job wall | `Cargo test` step | State |
| --- | --- | --- | --- |
| [32405379745](https://github.com/proliferate-ai/proliferate/actions/runs/32405379745) (control branch) | 444s | 367s | warm |
| [32434848272](https://github.com/proliferate-ai/proliferate/actions/runs/32434848272) (`main`) | 481s | 382s | warm |
| [32434957396](https://github.com/proliferate-ai/proliferate/actions/runs/32434957396) (`main`) | 548s | 438s | warm |
| [32434682251](https://github.com/proliferate-ai/proliferate/actions/runs/32434682251) (`main`, #2113 merge commit) | 583s | 493s | **priming** — its `rust-cache` entry was being filled |

So the honest claim is **roughly 2-3.5 minutes off the Cargo job** taking 334s as the expected warm figure, not a single point estimate. The `Cargo test` step is the tighter signal: **367-438s across the three post-priming baseline samples** (the 493s sample is excluded because it is the cache-priming run) vs 254s here.

## Where the 287s → 334s softness actually comes from — one slow test, not cache pressure

The nextest execution phase (the `Summary [...]` figure, which excludes compilation) moved between samples, and it is worth being precise about why, because the obvious explanation is the wrong one.

| Run | Execution phase | `internal_poke_waits_for_compatible_job...` | Rest of suite |
| --- | --- | --- | --- |
| #2128 combo, warm | 121.351s | 83.660s | 37.7s |
| This branch, cold | 152.640s | 112.475s | 40.2s |
| This branch, warm | 152.360s | 110.417s | 41.9s |

A single test — `anyharness-lib domains::agents::installer::reconcile::execution::tests::internal_poke_waits_for_compatible_job_then_runs_a_fresh_pass_on_active_pins`, the only test nextest flags `SLOW [> 60.000s]` — accounts for **92.1% of the cold delta and 86.3% of the warm delta**. Excluding it, the remaining 3136 tests are stable at 37.7 / 40.2 / 41.9s across all three runs.

Two consequences:

- **This is not cache pressure and should not be read as such.** It is a wall-clock floor: nextest cannot finish the suite faster than its longest single test, so ~110s of the 254s step is one test that everything else waits behind.
- **That test is the next optimization target for this lane.** Bringing it under control is worth more to this job than further caching work, and it would tighten the variance at the same time. Out of scope here.

## Count reconciliation — 3204 selected / 8 skipped, identical on both sides

Baseline `cargo test` ([job 96551626337](https://github.com/proliferate-ai/proliferate/actions/runs/32405379745/job/96551626337)), summing every `test result:` line:

- `cargo test --workspace`: 3145 passed, 8 ignored
- `cargo test -p proliferate-diagnostics-collector --features internal-dogfood-export`: 59 passed, 0 ignored
- Naive total: **3204 passed / 8 ignored**

nextest on this branch:

```
Starting 3137 tests across 18 binaries (8 tests skipped)
Summary [ 152.360s] 3137 tests run: 3137 passed (1 slow), 8 skipped
Summary [   4.716s] 59 tests run: 59 passed, 0 skipped
```

3137 + 59 = 3196 executed, which is 8 short of the naive 3204. That gap is fully accounted for and is **not** lost coverage: 8 of the baseline's "passed" lines are re-executions of a single `#[ignore]`d self-re-exec fixture, `diagnostics_collector::process::tests::cloexec_child_fixture` (`apps/desktop/src-tauri/src/diagnostics_collector/process_tests.rs`). Each parent test spawns the test binary again with a filter, and the child's `test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 489 filtered out` line gets interleaved into the same log. Those 8 lines are subprocess invocations of one already-counted test, not 8 distinct tests.

Reconciled properly, both sides select the same set:

- workspace: 3137 real tests + 8 ignored/skipped = 3145 selected (both runners)
- diagnostics export: 59 selected, 59 run (both runners)
- **total: 3204 selected, 8 skipped, 3196 executed — identical under `cargo test` and `cargo nextest run`**

## Doctests

nextest does not run doctests. This workspace has none to lose. On the baseline run, `cargo test --workspace` compiles Doc-tests binaries for 8 crates (`anyharness_contract`, `anyharness_credential_discovery`, `anyharness_lib`, `proliferate`, `proliferate_diagnostics_client`, `proliferate_diagnostics_collector`, `proliferate_diagnostics_protocol`, `proliferate_runtime_update_protocol`) and every one reports `0 passed`. Grepping doc comments for fenced blocks finds 3, all ` ```text ` (non-executable). No `--doc` follow-up step is added because it would be a no-op.

## Behaviour parity — `--no-fail-fast`

nextest stops scheduling new tests after the first failure; `cargo test` instead reports every failure within the binary it is executing. Pass/fail semantics are identical either way, but without `--no-fail-fast` a red run would surface roughly one failing test instead of the whole failing set across 3137 tests / 18 binaries. Both invocations carry the flag.

## Cold-priming caveat

Introducing job-level `env:` changes the `Swatinem/rust-cache` key, and the sccache GHA cache starts empty. **The first run after this merges will be slow — roughly 11 minutes** — while both caches prime. That is expected and one-time. On #2116 the priming run was [32410803549](https://github.com/proliferate-ai/proliferate/actions/runs/32410803549) at 702s wall (600s `Cargo test`) before dropping to 358s warm; this branch's own first run was [32436452456](https://github.com/proliferate-ai/proliferate/actions/runs/32436452456) at 675s wall (565s `Cargo test`) before dropping to 334s.

## How much is sccache actually carrying?

Less than the headline hit rate suggests, and this should be read carefully. On the warm run, sccache reported:

```
Compile requests                      49
Compile requests executed             10
Cache hits                            10
Cache misses                           0
Cache hits rate                   100.00 %
```

**100% is a denominator artifact: 10 hits out of 10 requests that reached rustc at all.** This PR touches only `ci.yml`, so no Rust source changed and `rust-cache` restored the target directory with `full match: true` — which meant there was almost nothing left to compile. sccache served the 10 invocations that remained. That is a correct result, but it is not evidence of sccache carrying weight on this run; the target-dir cache did the work. sccache's value shows up on runs where `rust-cache` restores but workspace crates still need rebuilding, which is the case #2116 measured independently (358s vs 444s).

## Cache-budget caveat — measured risk

sccache's GHA backend writes one cache entry per cached object, which is a large number of entries against a shared, capped pool (GitHub's LRU ceiling is 10 GB per repo). Three readings, each pinned to when it was taken, because **the pool is churning and the numbers are not monotonic**:

| Reading | `cache/usage` size | `cache/usage` count | sccache entries on `refs/pull/2139/merge` |
| --- | --- | --- | --- |
| ~01:50Z (review) | 11.31 GB | 1236 | 1047 entries / 585 MiB |
| ~01:57Z | 10.44 GB | 1224 | 1032 entries / 575.8 MiB |
| 02:06:11Z | 10.75 GB | 1225 | 1032 entries / 575.8 MiB |

Two caveats on reading that table: the figures are **net movement of a pool being written and evicted concurrently**, not a drain — it fell then rose again. And `cache/usage` disagrees with a full enumeration taken at the same moment (at 02:06:11Z the enumeration totalled 1208 entries / 10.50 GB against usage's 1225 / 10.75 GB), so treat any single figure as approximate. Units are pinned explicitly above because MB-decimal and MiB readings of the same bytes differ by ~5% and account for the 604-vs-575 discrepancy in earlier comments (603,796,539 bytes = 603.8 MB = 575.8 MiB).

The sharp fact is narrower than "the pool shrank", and it is about sccache specifically:

> **sccache's own objects were already evicted between enumerations — 1047 entries / 585 MiB down to 1032 / 575.8 MiB — while no new run was writing them.**

That is the mechanism that matters, because it directly caps the achievable steady-state hit rate: objects sccache needs resident to score a hit are being aged out of a pool it is simultaneously the largest entry-count contributor to (1032 of ~1208-1228 entries, ~84% of entries though only ~5.8% of bytes). Once this is on `main`, every ref running this job adds another ~1000 entries competing in the same budget, and sccache's footprint grows rather than shrinks as its hit rate improves, since hits still require residency. If pressure evicts `main`'s `v0-rust-cargo-check-*` entry (745-756 MB), both `Cargo check & test` **and** `Candidate build handoff` go cold.

Neither of these blocks this PR:

- **Watch item:** re-check `actions/cache/usage` and `main`'s `v0-rust-cargo-check-*` hit rate about a week after merge. Eviction of `main`'s rust-cache entry is the signal.
- **Follow-up, separate PR:** a repo-wide cache-budget strategy — `save-if` scoping so PR refs restore without writing, and/or a prune job — is under discussion and deliberately out of scope, being repo-wide policy rather than a Cargo-job change.

## Provenance

Config is transplanted from the measured combo branch `exp/rust-sccache-nextest` (#2128) onto current `main`, so it composes with #2113 rather than reverting it. The env block, step list and step ordering are identical to what was measured. Two deltas were added in review, neither of which affects the measurement:

- `--no-fail-fast` on both invocations — only changes behaviour on a **failing** run; every timed run above was green.
- `cargo-nextest@0.9.143` instead of floating latest — pins *exactly* the version the measured runs resolved (`cargo-nextest 0.9.143 (60fa45f63 2026-08-04)` appears in the #2118, #2128 and both of this PR's logs), so it makes the measurement reproducible rather than altering it. It also matches the diff's own SHA-pinning of `sccache-action`, and closes a determinism hole: `rust-cache`'s cached paths include `~/.cargo/bin`, where `install-action` writes the binary, so an unpinned tool can ride along inside a restored target-dir cache.

Experiment PRs #2116, #2118, #2128 are measurement-only and should be closed unmerged once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
