### PR TITLE
ci(windows): probe whether the desktop crates compile for Windows

### DIFF
--- a/.github/workflows/windows-compile-check.yml
+++ b/.github/workflows/windows-compile-check.yml
@@ -1,0 +1,69 @@
+name: Windows compile check
+
+# The runtime already builds and ships for Windows on every release, but nothing
+# has compiled the desktop crate for Windows since desktop releases were
+# disabled on 2026-04-13. That makes every Windows estimate guesswork. This job
+# turns the unknown into an error list.
+#
+# Non-blocking on purpose: it is a probe, not a gate, until the errors are fixed.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "apps/desktop/src-tauri/**"
+      - "anyharness/crates/**"
+      - ".github/workflows/windows-compile-check.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  runtime:
+    # Known green: release-runtime.yml ships these targets today. Here as the
+    # control, so a red desktop job cannot be blamed on the toolchain.
+    name: runtime crates (control)
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo check
+        run: cargo check --target x86_64-pc-windows-msvc -p anyharness -p proliferate-worker -p proliferate-supervisor
+
+  desktop:
+    name: desktop crates (the unknown)
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo check
+        # Keep going past the first failure so one run yields the whole list
+        # rather than one error at a time.
+        run: cargo check --target x86_64-pc-windows-msvc -p proliferate --keep-going 2>&1 | tee check.log
+        shell: bash
+      - name: Error summary
+        if: always()
+        shell: bash
+        run: |
+          echo "### Windows desktop compile errors" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          grep -E '^error' check.log | sort | uniq -c | sort -rn | head -50 >> $GITHUB_STEP_SUMMARY || echo "no errors" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "total errors: $(grep -cE '^error' check.log || echo 0)" >> $GITHUB_STEP_SUMMARY
+          echo "files implicated:" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          grep -oE '\-\-> [^:]+' check.log | sed 's/--> //' | sort -u | head -60 >> $GITHUB_STEP_SUMMARY || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: windows-desktop-check-log
+          path: check.log

--- a/.github/workflows/windows-compile-check.yml
+++ b/.github/workflows/windows-compile-check.yml
@@ -14,6 +14,11 @@ on:
       - "apps/desktop/src-tauri/**"
       - "anyharness/crates/**"
       - ".github/workflows/windows-compile-check.yml"
+      - "Cargo.lock"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -24,9 +29,10 @@ jobs:
     # control, so a red desktop job cannot be blamed on the toolchain.
     name: runtime crates (control)
     runs-on: windows-latest
+    timeout-minutes: 45
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-msvc
@@ -37,9 +43,10 @@ jobs:
   desktop:
     name: desktop crates (the unknown)
     runs-on: windows-latest
+    timeout-minutes: 45
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-msvc
@@ -62,7 +69,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
           grep -oE '\-\-> [^:]+' check.log | sed 's/--> //' | sort -u | head -60 >> $GITHUB_STEP_SUMMARY || true
           echo '```' >> $GITHUB_STEP_SUMMARY
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: windows-desktop-check-log


### PR DESCRIPTION
## What this check actually covers, and what it does not

Read directly from `.github/workflows/windows-compile-check.yml` at this PR's head (`58f07c205d8fa518e947bb6468ac347e37555e14`):

- The `runtime` job runs exactly: `cargo check --target x86_64-pc-windows-msvc -p anyharness -p proliferate-worker -p proliferate-supervisor`.
- The `desktop` job runs exactly: `cargo check --target x86_64-pc-windows-msvc -p proliferate --keep-going`.

Neither invocation passes `--all-targets`, and neither is `cargo test`. So neither job compiles any test code: not the crates' `#[cfg(test)]` unit tests, and not any `tests/*.rs` integration tests. A green run here is a verdict on the ordinary build targets only, and says nothing about whether test code compiles for Windows.

That gap is not hypothetical. `.github/workflows/windows-process-kill-tests.yml` (added in #2147) documents in its own header that `cargo check --all-targets --target x86_64-pc-windows-msvc` reports ten pre-existing errors in `anyharness-lib`, every one a test-only POSIX assumption in an unrelated module, and that this is exactly why that workflow routes through an integration test at `tests/windows_process_tree.rs` rather than the crate's unit tests: an integration test compiles as its own crate against the library's public surface, so it never pulls in the crate's `#[cfg(test)]` modules, and can get a real Windows runtime verdict without that port being done first. So a green `windows-compile-check.yml` run does not mean `cargo test --lib` compiles for `anyharness-lib` on Windows. This workflow does not even attempt that build, in either job.

The single most important thing to know about this workflow: both jobs are `continue-on-error: true`, confirmed by reading the file at this PR's head, on both the `runtime` job and the `desktop` job. That means this workflow's outcome is unconditional: it can never fail the overall PR check run, and a real cargo error inside either job still leaves that job's, and the run's, conclusion `success`. A green check mark next to "Windows compile check" on a PR does not mean cargo succeeded; it means the job finished, which happens whether cargo passed or failed. The only way to know whether it actually passed is to open the job and read whether `cargo check` reported errors (the `desktop` job's step summary lists them; the `runtime` job's do not get a summary step, so its raw log is the only source there).

## Result: the desktop crate already compiles for Windows

This job was a probe, not a fix. Every Windows estimate anyone gave was guesswork because nothing had compiled the desktop crate for Windows since desktop Windows releases were disabled on 2026-04-13 by `3d3c0504b8`. This turns the unknown into an error list.

The error list is empty.

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 31s
```

`cargo check --target x86_64-pc-windows-msvc -p proliferate --keep-going` on `windows-latest`: zero errors, dead-code warnings only. The control job over the runtime crates is green as expected, so the toolchain is not flattering the result.

## What I predicted, and why I was wrong

I wrote in the original body that the first failure would be `apps/desktop/src-tauri/src/diagnostics_collector/mod.rs:3`, where `pub(crate) mod child_bridge;` is declared with no cfg gate over roughly ten files of POSIX code: `std::os::fd`, `UnixStream`, `pre_exec`, socketpair.

The declaration really is ungated and the POSIX code really is there. The gating is one level further down, which reading only `mod.rs` does not show. `child_bridge/mod.rs` says so in its own doc comment:

> Each submodule self-gates to supported macOS targets, so unsupported Unix and non-Unix builds compile these declarations to empty modules and expose no Unix bridge types.

So the module compiles to nothing on Windows and there is nothing to fix. This is the general lesson from the run: static reading of a Rust module tree systematically over-predicts platform breakage, because `#[cfg]` composes downward and you cannot see it from the parent. Three and a half minutes of a Windows runner settled what a careful read got wrong.

## What this changes

The remaining work for a Windows beta is smaller than the disabled release matrix suggests, and none of it is "port the desktop app".

- The runtime crates already build and ship `anyharness-x86_64-pc-windows-msvc.zip` on every release. That never stopped.
- The stated reason for the April disable, from that commit's own doc note, was "until the SDK generation step is Windows-safe". That step turns out to be a single `mkdir -p` in `anyharness/sdk`'s `generate:openapi` npm script, which fails under `cmd.exe`. Fixed in #2146.
- `specs/desktop-native.md` still carries Windows-specific updater logic, so the code was never actually stripped of Windows awareness.

## Genuinely still broken on Windows, found by reading rather than compiling

Compiling clean is not the same as working. These are runtime defects a compile check cannot catch, each now owned by its own change:

1. `anyharness/crates/anyharness-lib/src/process_kill.rs:352-362` returns `(0, 0)` from both `kill_group_and_await` and `kill_session_and_await` under `cfg(not(unix))`. That is the identical tuple a successful kill of zero processes returns, so stop and cancel report clean quiescence while the whole agent process tree keeps running.
2. The agent catalog resolved no Windows pins at all, so no agent could install. Fixed in #2145, which also uncovered that `installer/pinned.rs:41` writes the downloaded binary to an extension-less path, so a Windows pin would verify its checksum and then land somewhere Windows cannot execute.
3. Hardcoded `/bin/sh` spawns and `HOME` reads in the runtime.
4. `release-desktop.yml` has no Windows matrix entry and `scripts/generate-updater-manifest.mjs` has no `windows-x86_64` key, so a Windows build would never be produced and, if produced, would never update.

## Should this workflow merge?

It is `continue-on-error` on both jobs and non-blocking by design, so it cannot fail anyone's PR. Its value now inverts: it started as a probe and its result makes it a regression guard, because the thing it proves green is exactly the thing nobody was watching for four months. Keeping it costs about three and a half minutes on PRs that touch `apps/desktop/src-tauri/**` or `anyharness/crates/**`.

Worth flipping off `continue-on-error` once the surrounding Windows work lands, so it becomes a real gate rather than a probe.
