### PR TITLE
fix(desktop): compile the desktop crate for windows

### DIFF
--- a/.github/workflows/windows-compile-check.yml
+++ b/.github/workflows/windows-compile-check.yml
@@ -67,3 +67,40 @@ jobs:
         with:
           name: windows-desktop-check-log
           path: check.log
+
+  desktop-all-targets:
+    # The `desktop` job above checks only the default target set: lib plus bin,
+    # default features. That set is already green, which is the surprise. This
+    # job widens the probe to every target and every feature so the remaining
+    # Windows gaps show up as errors instead of hiding in unchecked test
+    # modules.
+    name: desktop crate, all targets and features
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo check
+        run: cargo check --target x86_64-pc-windows-msvc -p proliferate --all-targets --all-features --keep-going 2>&1 | tee check-all-targets.log
+        shell: bash
+      - name: Error summary
+        if: always()
+        shell: bash
+        run: |
+          echo "### Windows desktop compile errors (all targets, all features)" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          grep -E '^error' check-all-targets.log | sort | uniq -c | sort -rn | head -50 >> $GITHUB_STEP_SUMMARY || echo "no errors" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "total errors: $(grep -cE '^error' check-all-targets.log || echo 0)" >> $GITHUB_STEP_SUMMARY
+          echo "files implicated:" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          grep -oE '\-\-> [^:]+' check-all-targets.log | sed 's/--> //' | sort -u | head -60 >> $GITHUB_STEP_SUMMARY || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: windows-desktop-check-all-targets-log
+          path: check-all-targets.log


### PR DESCRIPTION
Work in progress. The before and after error counts, quoted from the Windows CI job, land here once the first run on this branch reports.

Stacked on `ci/windows-compile-check` (draft PR #2142). Merge this after that one, or rebase onto main once it lands.
