### PR TITLE
fix(sdk): make anyharness openapi generation windows-safe

### DIFF
--- a/.github/workflows/windows-sdk-generate-check.yml
+++ b/.github/workflows/windows-sdk-generate-check.yml
@@ -1,0 +1,132 @@
+name: Windows SDK generate check
+
+# `anyharness/sdk`'s `generate:openapi` script used to be a POSIX shell one
+# liner (`mkdir -p ... && cd ../.. && cargo run ... > file`). npm runs package
+# scripts through cmd.exe on Windows, where `mkdir -p` creates a directory
+# literally named `-p`, so the step failed. That single line is the stated
+# reason desktop Windows releases were disabled in 3d3c0504b8 ("until the SDK
+# generation step is Windows-safe").
+#
+# This is the regression guard, and it builds nothing.
+#
+# The windows job covers what was actually broken: directory creation and path
+# handling under cmd.exe. It cannot exercise the cargo invocation itself,
+# because Node refuses to spawn `.cmd` stubs without a shell (CVE-2024-27980)
+# and a real `cargo run` here would mean a full Windows runtime build. The
+# linux job covers the invoke, validate and write path with a shell stub. The
+# two together cover the whole script.
+
+on:
+  pull_request:
+    paths:
+      - "scripts/generate-anyharness-openapi.mjs"
+      - "anyharness/sdk/package.json"
+      - ".github/workflows/windows-sdk-generate-check.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  windows:
+    name: directory handling on windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Negative control, the old shell form is broken under cmd.exe
+        shell: cmd
+        run: |
+          mkdir oldform
+          cd oldform
+          mkdir -p generated src/generated
+          if exist "generated\openapi.json" (
+            echo UNEXPECTED: cmd.exe produced generated/openapi.json, this guard is no longer meaningful
+            exit /b 1
+          )
+          if not exist "generated" (
+            echo confirmed: the old form did not create a usable generated directory
+          )
+          if exist "-p" (
+            echo confirmed: cmd.exe created a directory literally named -p
+          )
+
+      # Both directories are checked in, so they have to go before the run or
+      # the assertion below would pass without the script doing anything.
+      - name: Remove the generated directories
+        shell: bash
+        run: rm -rf anyharness/sdk/generated anyharness/sdk/src/generated
+
+      - name: The node form recreates both directories on windows
+        shell: cmd
+        env:
+          CARGO: this-runtime-does-not-exist
+        run: |
+          cd anyharness\sdk
+          node ..\..\scripts\generate-anyharness-openapi.mjs
+          if "%ERRORLEVEL%" == "0" (
+            echo UNEXPECTED: a missing runtime should have failed the script
+            exit /b 1
+          )
+          echo confirmed: the script failed loudly on a missing runtime, as intended
+
+      - name: Assert both directories were recreated and nothing partial landed
+        shell: bash
+        run: |
+          test -d anyharness/sdk/generated || { echo "generated/ was not created"; exit 1; }
+          test -d anyharness/sdk/src/generated || { echo "src/generated/ was not created"; exit 1; }
+          test ! -e anyharness/sdk/generated/openapi.json || { echo "a schema was written despite the runtime failing"; exit 1; }
+          test ! -e "anyharness/sdk/-p" || { echo "the POSIX flag leaked into a directory name"; exit 1; }
+          echo "ok: both directories recreated on windows, no partial schema written"
+
+  linux:
+    name: invoke and write path with a stubbed runtime
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Stub the runtime
+        run: |
+          mkdir -p "$RUNNER_TEMP/stub"
+          printf '#!/bin/sh\necho %s\n' '{"openapi":"3.0.0","info":{"title":"stub","version":"1"},"paths":{}}' > "$RUNNER_TEMP/stub/cargo"
+          chmod +x "$RUNNER_TEMP/stub/cargo"
+          printf '#!/bin/sh\nexit 101\n' > "$RUNNER_TEMP/stub/cargo-fail"
+          chmod +x "$RUNNER_TEMP/stub/cargo-fail"
+          printf '#!/bin/sh\necho not json\n' > "$RUNNER_TEMP/stub/cargo-garbage"
+          chmod +x "$RUNNER_TEMP/stub/cargo-garbage"
+
+      - name: Happy path writes a parseable schema
+        working-directory: anyharness/sdk
+        run: |
+          CARGO="$RUNNER_TEMP/stub/cargo" node ../../scripts/generate-anyharness-openapi.mjs
+          node -e "JSON.parse(require('fs').readFileSync('generated/openapi.json','utf8'))"
+          echo "ok: schema written and parses"
+
+      - name: A failing runtime must not truncate an existing schema
+        working-directory: anyharness/sdk
+        run: |
+          before="$(cat generated/openapi.json)"
+          if CARGO="$RUNNER_TEMP/stub/cargo-fail" node ../../scripts/generate-anyharness-openapi.mjs; then
+            echo "a failing runtime should have failed the script"
+            exit 1
+          fi
+          after="$(cat generated/openapi.json)"
+          [ "$before" = "$after" ] || { echo "the existing schema was clobbered by a failed run"; exit 1; }
+          echo "ok: existing schema survived a failed runtime"
+
+      - name: Invalid output must be rejected before it is written
+        working-directory: anyharness/sdk
+        run: |
+          before="$(cat generated/openapi.json)"
+          if CARGO="$RUNNER_TEMP/stub/cargo-garbage" node ../../scripts/generate-anyharness-openapi.mjs; then
+            echo "non-JSON output should have failed the script"
+            exit 1
+          fi
+          [ "$before" = "$(cat generated/openapi.json)" ] || { echo "invalid output reached disk"; exit 1; }
+          echo "ok: invalid output rejected"

--- a/.github/workflows/windows-sdk-generate-check.yml
+++ b/.github/workflows/windows-sdk-generate-check.yml
@@ -44,6 +44,10 @@ jobs:
   windows:
     name: package script on windows
     runs-on: windows-latest
+    # If cmd's `md` ever starts accepting the POSIX form, a reverted script would
+    # reach `cargo run`, and cargo is on this image. That turns a 20 second guard
+    # into a full Windows runtime build. Cap it.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -105,6 +109,7 @@ jobs:
   linux:
     name: invoke and write path with a stubbed runtime
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -129,9 +134,14 @@ jobs:
       - name: Happy path writes a parseable schema
         working-directory: anyharness/sdk
         run: |
+          # Remove the tracked schema first. Without this a script that did
+          # nothing at all would still find a parseable file and pass.
+          rm -f generated/openapi.json
           CARGO="$RUNNER_TEMP/stub/cargo" npm run generate:openapi
           node -e "JSON.parse(require('fs').readFileSync('generated/openapi.json','utf8'))"
-          echo "ok: schema written and parses"
+          grep -q '"title":"stub"' generated/openapi.json \
+            || { echo "the file on disk is not what the stub emitted"; exit 1; }
+          echo "ok: the stub's schema was written and parses"
 
       - name: A failing runtime must not truncate an existing schema
         working-directory: anyharness/sdk

--- a/.github/workflows/windows-sdk-generate-check.yml
+++ b/.github/workflows/windows-sdk-generate-check.yml
@@ -1,132 +1,158 @@
 name: Windows SDK generate check
 
 # `anyharness/sdk`'s `generate:openapi` script used to be a POSIX shell one
-# liner (`mkdir -p ... && cd ../.. && cargo run ... > file`). npm runs package
-# scripts through cmd.exe on Windows, where `mkdir -p` creates a directory
-# literally named `-p`, so the step failed. That single line is the stated
-# reason desktop Windows releases were disabled in 3d3c0504b8 ("until the SDK
-# generation step is Windows-safe").
+# liner (`mkdir -p generated src/generated && cd ../.. && cargo run ... > file`).
+# npm runs package scripts through cmd.exe on Windows, where that command fails,
+# and that is the stated reason desktop Windows releases were disabled in
+# 3d3c0504b8 ("until the SDK generation step is Windows-safe").
 #
 # This is the regression guard, and it builds nothing.
 #
-# The windows job covers what was actually broken: directory creation and path
-# handling under cmd.exe. It cannot exercise the cargo invocation itself,
-# because Node refuses to spawn `.cmd` stubs without a shell (CVE-2024-27980)
-# and a real `cargo run` here would mean a full Windows runtime build. The
-# linux job covers the invoke, validate and write path with a shell stub. The
-# two together cover the whole script.
+# The guard runs the real `npm run generate:openapi`, not the node script
+# directly, because the regression being guarded lives in package.json. Reverting
+# package.json to the shell form must turn this red, and running the script
+# directly would leave it green.
+#
+# The discriminator is the DIRECTORIES, not the exit code. The runtime is
+# deliberately absent in the windows job, so the script fails either way; what
+# separates a working package script from a broken one is whether the two
+# directories exist afterwards. Under the shell form, cmd fails at mkdir and the
+# && chain never runs, so they do not.
+#
+# The windows job cannot exercise the cargo invocation: Node refuses to spawn
+# .cmd stubs without a shell (CVE-2024-27980) and a real cargo run would mean a
+# full Windows runtime build. The linux job covers invoke, validate and write
+# with shell stubs. The two together cover the whole script.
 
 on:
   pull_request:
     paths:
       - "scripts/generate-anyharness-openapi.mjs"
       - "anyharness/sdk/package.json"
+      - "Makefile"
       - ".github/workflows/windows-sdk-generate-check.yml"
   workflow_dispatch:
 
 permissions:
   contents: read
 
+concurrency:
+  group: windows-sdk-generate-check-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   windows:
-    name: directory handling on windows
+    name: package script on windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
-      - name: Negative control, the old shell form is broken under cmd.exe
-        shell: cmd
+      # Informational and falsifiable. Driven from bash so the assertion is
+      # ours rather than cmd's errorlevel semantics, and so the real error text
+      # reaches the log.
+      - name: Negative control, the POSIX form does not work under cmd.exe
+        shell: bash
         run: |
-          mkdir oldform
-          cd oldform
-          mkdir -p generated src/generated
-          if exist "generated\openapi.json" (
-            echo UNEXPECTED: cmd.exe produced generated/openapi.json, this guard is no longer meaningful
-            exit /b 1
-          )
-          if not exist "generated" (
-            echo confirmed: the old form did not create a usable generated directory
-          )
-          if exist "-p" (
-            echo confirmed: cmd.exe created a directory literally named -p
-          )
+          mkdir -p "$RUNNER_TEMP/oldform"
+          cd "$RUNNER_TEMP/oldform"
+          echo "cmd.exe says:"
+          cmd //c "mkdir -p generated src/generated" 2>&1 || true
+          echo "what exists afterwards:"
+          ls -la
+          if [ -d generated ] && [ -d "src/generated" ]; then
+            echo "UNEXPECTED: cmd.exe created both directories, this guard is no longer meaningful"
+            exit 1
+          fi
+          echo "confirmed: cmd.exe did not create the directories the POSIX form asks for"
 
       # Both directories are checked in, so they have to go before the run or
-      # the assertion below would pass without the script doing anything.
+      # the assertion below would pass without the package script doing anything.
       - name: Remove the generated directories
         shell: bash
         run: rm -rf anyharness/sdk/generated anyharness/sdk/src/generated
 
-      - name: The node form recreates both directories on windows
+      - name: Run the real package script
         shell: cmd
+        working-directory: anyharness/sdk
         env:
           CARGO: this-runtime-does-not-exist
+        # `call` matters: npm is a .cmd shim, and without it the batch file
+        # terminates at npm and never reaches the exit. Exit 0 unconditionally,
+        # because the runtime is deliberately absent so the script must fail.
+        # The next step is the judge.
         run: |
-          cd anyharness\sdk
-          node ..\..\scripts\generate-anyharness-openapi.mjs
-          if "%ERRORLEVEL%" == "0" (
-            echo UNEXPECTED: a missing runtime should have failed the script
-            exit /b 1
-          )
-          echo confirmed: the script failed loudly on a missing runtime, as intended
+          call npm run generate:openapi
+          exit /b 0
 
-      - name: Assert both directories were recreated and nothing partial landed
+      - name: Assert the package script recreated both directories
         shell: bash
         run: |
-          test -d anyharness/sdk/generated || { echo "generated/ was not created"; exit 1; }
-          test -d anyharness/sdk/src/generated || { echo "src/generated/ was not created"; exit 1; }
-          test ! -e anyharness/sdk/generated/openapi.json || { echo "a schema was written despite the runtime failing"; exit 1; }
-          test ! -e "anyharness/sdk/-p" || { echo "the POSIX flag leaked into a directory name"; exit 1; }
-          echo "ok: both directories recreated on windows, no partial schema written"
+          fail=0
+          test -d anyharness/sdk/generated || { echo "generated/ was not created"; fail=1; }
+          test -d anyharness/sdk/src/generated || { echo "src/generated/ was not created"; fail=1; }
+          test ! -e anyharness/sdk/generated/openapi.json || { echo "a schema was written despite the runtime being absent"; fail=1; }
+          test ! -e "anyharness/sdk/-p" || { echo "the POSIX flag leaked into a directory name"; fail=1; }
+          if [ "$fail" -ne 0 ]; then
+            echo "the package script is not windows-safe"
+            ls -la anyharness/sdk
+            exit 1
+          fi
+          echo "ok: npm run generate:openapi created both directories on windows"
 
   linux:
     name: invoke and write path with a stubbed runtime
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
+      # Written with a quoted heredoc rather than printf, so the JSON's double
+      # quotes reach the stub intact.
       - name: Stub the runtime
         run: |
           mkdir -p "$RUNNER_TEMP/stub"
-          printf '#!/bin/sh\necho %s\n' '{"openapi":"3.0.0","info":{"title":"stub","version":"1"},"paths":{}}' > "$RUNNER_TEMP/stub/cargo"
-          chmod +x "$RUNNER_TEMP/stub/cargo"
+          cat > "$RUNNER_TEMP/stub/cargo" <<'STUB'
+          #!/bin/sh
+          echo '{"openapi":"3.0.0","info":{"title":"stub","version":"1"},"paths":{}}'
+          STUB
           printf '#!/bin/sh\nexit 101\n' > "$RUNNER_TEMP/stub/cargo-fail"
-          chmod +x "$RUNNER_TEMP/stub/cargo-fail"
           printf '#!/bin/sh\necho not json\n' > "$RUNNER_TEMP/stub/cargo-garbage"
-          chmod +x "$RUNNER_TEMP/stub/cargo-garbage"
+          chmod +x "$RUNNER_TEMP/stub/cargo" "$RUNNER_TEMP/stub/cargo-fail" "$RUNNER_TEMP/stub/cargo-garbage"
+          "$RUNNER_TEMP/stub/cargo" | node -e "let b='';process.stdin.on('data',d=>b+=d).on('end',()=>JSON.parse(b))"
+          echo "ok: the stub itself emits valid JSON"
 
       - name: Happy path writes a parseable schema
         working-directory: anyharness/sdk
         run: |
-          CARGO="$RUNNER_TEMP/stub/cargo" node ../../scripts/generate-anyharness-openapi.mjs
+          CARGO="$RUNNER_TEMP/stub/cargo" npm run generate:openapi
           node -e "JSON.parse(require('fs').readFileSync('generated/openapi.json','utf8'))"
           echo "ok: schema written and parses"
 
       - name: A failing runtime must not truncate an existing schema
         working-directory: anyharness/sdk
         run: |
-          before="$(cat generated/openapi.json)"
-          if CARGO="$RUNNER_TEMP/stub/cargo-fail" node ../../scripts/generate-anyharness-openapi.mjs; then
+          before="$(sha256sum generated/openapi.json | cut -d' ' -f1)"
+          if CARGO="$RUNNER_TEMP/stub/cargo-fail" npm run generate:openapi; then
             echo "a failing runtime should have failed the script"
             exit 1
           fi
-          after="$(cat generated/openapi.json)"
+          after="$(sha256sum generated/openapi.json | cut -d' ' -f1)"
           [ "$before" = "$after" ] || { echo "the existing schema was clobbered by a failed run"; exit 1; }
-          echo "ok: existing schema survived a failed runtime"
+          echo "ok: existing schema survived a failed runtime, sha $after"
 
       - name: Invalid output must be rejected before it is written
         working-directory: anyharness/sdk
         run: |
-          before="$(cat generated/openapi.json)"
-          if CARGO="$RUNNER_TEMP/stub/cargo-garbage" node ../../scripts/generate-anyharness-openapi.mjs; then
+          before="$(sha256sum generated/openapi.json | cut -d' ' -f1)"
+          if CARGO="$RUNNER_TEMP/stub/cargo-garbage" npm run generate:openapi; then
             echo "non-JSON output should have failed the script"
             exit 1
           fi
-          [ "$before" = "$(cat generated/openapi.json)" ] || { echo "invalid output reached disk"; exit 1; }
-          echo "ok: invalid output rejected"
+          after="$(sha256sum generated/openapi.json | cut -d' ' -f1)"
+          [ "$before" = "$after" ] || { echo "invalid output reached disk"; exit 1; }
+          echo "ok: invalid output rejected, sha unchanged"

--- a/Makefile
+++ b/Makefile
@@ -1569,16 +1569,13 @@ cloud-client-generate: cloud-openapi
 # SKIP_RUST=1 means "no cargo in this worktree". Honor it here too: the
 # prebuilt runtime emits the same schema, so a frontend-only worktree does not
 # need a toolchain just to regenerate the SDK. Without this the flag leaks and
-# `SKIP_RUST=1 make build` still invokes cargo.
+# `SKIP_RUST=1 make build` still invokes cargo. The cargo-vs-prebuilt-runtime
+# choice and the directory/file writes live in generate-anyharness-openapi.mjs
+# rather than in this recipe, because npm runs package scripts through cmd.exe
+# on Windows and a `mkdir -p ... && cargo run ... > file` shell chain breaks
+# there; see the script's header comment for details.
 sdk-generate:
-	mkdir -p anyharness/sdk/generated
-	@runtime_bin="$${ANYHARNESS_DEV_RUNTIME_BIN:-}"; \
-	if [ -n "$(SKIP_RUST)" ] && [ "$(SKIP_RUST)" != "0" ] && [ -n "$$runtime_bin" ] && [ -x "$$runtime_bin" ]; then \
-		echo "sdk-generate: SKIP_RUST set, using prebuilt runtime $$runtime_bin"; \
-		"$$runtime_bin" print-openapi > anyharness/sdk/generated/openapi.json; \
-	else \
-		$(CARGO) run --bin anyharness -- print-openapi > anyharness/sdk/generated/openapi.json; \
-	fi
+	CARGO="$(CARGO)" SKIP_RUST="$(SKIP_RUST)" node scripts/generate-anyharness-openapi.mjs
 	cd anyharness/sdk && npx openapi-typescript generated/openapi.json -o src/generated/openapi.ts
 
 sdk-build: sdk-generate

--- a/anyharness/sdk/package.json
+++ b/anyharness/sdk/package.json
@@ -16,7 +16,7 @@
     "generated/openapi.json"
   ],
   "scripts": {
-    "generate:openapi": "mkdir -p generated src/generated && cd ../.. && cargo run --bin anyharness -- print-openapi > anyharness/sdk/generated/openapi.json",
+    "generate:openapi": "node ../../scripts/generate-anyharness-openapi.mjs",
     "generate:types": "npx openapi-typescript generated/openapi.json -o src/generated/openapi.ts",
     "generate": "npm run generate:openapi && npm run generate:types",
     "build": "tsc",

--- a/scripts/generate-anyharness-openapi.mjs
+++ b/scripts/generate-anyharness-openapi.mjs
@@ -4,8 +4,9 @@
 //
 // This exists as a script rather than an inline npm script because the inline
 // version was `mkdir -p ... && cd ../.. && cargo run ... > file`, which is
-// POSIX shell. npm runs package scripts through cmd.exe on Windows, where
-// `mkdir -p` creates a directory literally named `-p` and the step then fails.
+// POSIX shell. npm runs package scripts through cmd.exe on Windows, and that
+// command does not work there: cmd's `md` reports "The syntax of the command
+// is incorrect." and creates nothing, so the `&&` chain never reaches cargo.
 // That single line is why desktop Windows releases were disabled in
 // 3d3c0504b8 ("until the SDK generation step is Windows-safe").
 //
@@ -48,6 +49,8 @@ const useRuntimeBin =
     }
   })();
 
+// `||` rather than `??`: an empty CARGO is a misconfiguration, and passing
+// "" to spawnSync throws ERR_INVALID_ARG_VALUE instead of saying anything useful.
 const cargo = process.env.CARGO || "cargo";
 const command = useRuntimeBin ? runtimeBin : cargo;
 const args = useRuntimeBin ? ["print-openapi"] : ["run", "--bin", "anyharness", "--", "print-openapi"];

--- a/scripts/generate-anyharness-openapi.mjs
+++ b/scripts/generate-anyharness-openapi.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Regenerates anyharness/sdk/generated/openapi.json from the runtime's own
+// schema printer.
+//
+// This exists as a script rather than an inline npm script because the inline
+// version was `mkdir -p ... && cd ../.. && cargo run ... > file`, which is
+// POSIX shell. npm runs package scripts through cmd.exe on Windows, where
+// `mkdir -p` creates a directory literally named `-p` and the step then fails.
+// That single line is why desktop Windows releases were disabled in
+// 3d3c0504b8 ("until the SDK generation step is Windows-safe").
+//
+// Doing the directory creation, the cargo invocation and the file write in
+// node keeps the behaviour identical on every platform and removes the shell
+// from the path entirely.
+//
+// SKIP_RUST=1 with an executable ANYHARNESS_DEV_RUNTIME_BIN skips cargo
+// entirely and calls the prebuilt runtime binary's print-openapi output
+// instead, same as the shell version this replaced.
+
+import { spawnSync } from "node:child_process";
+import { accessSync, constants, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const sdkDir = join(repoRoot, "anyharness", "sdk");
+const outFile = join(sdkDir, "generated", "openapi.json");
+
+mkdirSync(join(sdkDir, "generated"), { recursive: true });
+mkdirSync(join(sdkDir, "src", "generated"), { recursive: true });
+
+// SKIP_RUST=1 means "no cargo in this worktree". Honor it here too: the
+// prebuilt runtime emits the same schema, so a frontend-only worktree does
+// not need a toolchain just to regenerate the SDK. Without this the flag
+// leaks and `SKIP_RUST=1 make sdk-generate` still invokes cargo.
+const skipRust = process.env.SKIP_RUST;
+const runtimeBin = process.env.ANYHARNESS_DEV_RUNTIME_BIN ?? "";
+const useRuntimeBin =
+  Boolean(skipRust) &&
+  skipRust !== "0" &&
+  runtimeBin !== "" &&
+  (() => {
+    try {
+      accessSync(runtimeBin, constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
+const cargo = process.env.CARGO || "cargo";
+const command = useRuntimeBin ? runtimeBin : cargo;
+const args = useRuntimeBin ? ["print-openapi"] : ["run", "--bin", "anyharness", "--", "print-openapi"];
+
+if (useRuntimeBin) {
+  console.log(`sdk-generate: SKIP_RUST set, using prebuilt runtime ${runtimeBin}`);
+}
+
+const result = spawnSync(command, args, {
+  cwd: repoRoot,
+  encoding: "utf8",
+  maxBuffer: 256 * 1024 * 1024,
+  stdio: ["ignore", "pipe", "inherit"],
+});
+
+if (result.error) {
+  console.error(`failed to run ${command}: ${result.error.message}`);
+  process.exit(1);
+}
+if (result.status !== 0) {
+  console.error(`${command} ${args.join(" ")} exited with ${result.status}`);
+  process.exit(result.status ?? 1);
+}
+if (!result.stdout || result.stdout.trim() === "") {
+  console.error("print-openapi produced no output; refusing to write an empty schema");
+  process.exit(1);
+}
+
+// Parse before writing so a runtime that fails halfway through cannot leave a
+// truncated schema on disk that openapi-typescript then happily consumes.
+try {
+  JSON.parse(result.stdout);
+} catch (error) {
+  console.error(`print-openapi did not produce valid JSON: ${error.message}`);
+  process.exit(1);
+}
+
+writeFileSync(outFile, result.stdout);
+console.log(`wrote ${outFile}`);

--- a/scripts/generate-anyharness-openapi.mjs
+++ b/scripts/generate-anyharness-openapi.mjs
@@ -7,8 +7,8 @@
 // POSIX shell. npm runs package scripts through cmd.exe on Windows, and that
 // command does not work there: cmd's `md` reports "The syntax of the command
 // is incorrect." and creates nothing, so the `&&` chain never reaches cargo.
-// That single line is why desktop Windows releases were disabled in
-// 3d3c0504b8 ("until the SDK generation step is Windows-safe").
+// That single line is the stated reason desktop Windows releases were
+// disabled in 3d3c0504b8 ("until the SDK generation step is Windows-safe").
 //
 // Doing the directory creation, the cargo invocation and the file write in
 // node keeps the behaviour identical on every platform and removes the shell
@@ -49,8 +49,8 @@ const useRuntimeBin =
     }
   })();
 
-// `||` rather than `??`: an empty CARGO is a misconfiguration, and passing
-// "" to spawnSync throws ERR_INVALID_ARG_VALUE instead of saying anything useful.
+// `||` rather than `??` so an empty CARGO falls back to "cargo" and reports a
+// normal missing-runtime error, rather than throwing ERR_INVALID_ARG_VALUE.
 const cargo = process.env.CARGO || "cargo";
 const command = useRuntimeBin ? runtimeBin : cargo;
 const args = useRuntimeBin ? ["print-openapi"] : ["run", "--bin", "anyharness", "--", "print-openapi"];


### PR DESCRIPTION
## What this is

Desktop Windows releases were disabled on 2026-04-13 by `3d3c0504b8`, whose own doc note gave the reason: "Windows packaging and updater entries are temporarily disabled until the SDK generation step is Windows-safe."

That step is one line. `anyharness/sdk/package.json`:

```
"generate:openapi": "mkdir -p generated src/generated && cd ../.. && cargo run --bin anyharness -- print-openapi > anyharness/sdk/generated/openapi.json"
```

npm runs package scripts through `cmd.exe` on Windows, and that command does not work there. I originally wrote that `-p` becomes a directory named `-p`. Review caught that, and the Windows runner settled it. cmd creates nothing at all:

```
cmd.exe says:
The syntax of the command is incorrect.
what exists afterwards:
total 4
drwxr-xr-x 1 runneradmin 197121 0 Aug 21 02:23 .
drwxr-xr-x 1 runneradmin 197121 0 Aug 21 02:23 ..
confirmed: cmd.exe did not create the directories the POSIX form asks for
```

No `-p`, no `generated`, no `src/generated`. The `&&` chain therefore never reaches cargo, and the step fails, taking the Windows desktop build with it.

I swept every `package.json` in the workspace for shell-isms (`mkdir`, `cp`, `chmod`, `rm -rf`, command substitution). This is the only hit. The stated blocker for Windows desktop releases is a single `mkdir -p`.

## The change

The work moves into `scripts/generate-anyharness-openapi.mjs`: create both directories with `fs.mkdirSync(..., {recursive: true})`, spawn the runtime, validate, write. No shell on any platform. `package.json` and the `sdk-generate` Makefile target both call it, so the two paths can no longer drift.

Behaviour on macOS and Linux is unchanged, with one deliberate exception described below.

## A second bug this removes

The shell redirect `> anyharness/sdk/generated/openapi.json` truncates the target **before** `cargo run` executes. Any runtime failure therefore left a zero byte schema on disk. Demonstrated locally against the old line with a stub runtime that exits 101:

```
before: {"real":"schema"}
compile error
exit=101
after:  []
size=0
```

The node version buffers, checks the exit status, rejects empty output, `JSON.parse`s the payload, and only then writes. Under the same stub the committed schema is untouched. This is the one intentional behaviour change on unix, and it is strictly in the safe direction.

## Verification

Nothing here was assumed. Local runs against stub runtimes, invoked from `anyharness/sdk` exactly as npm invokes it:

| Case | Expected | Result |
|---|---|---|
| Runtime prints a schema | writes it, exit 0 | wrote `openapi.json`, exit 0, both directories created |
| Runtime prints nothing | refuse to write | `refusing to write an empty schema`, exit 1 |
| Runtime prints non-JSON | refuse to write | `did not produce valid JSON`, exit 1 |
| Runtime exits 101 | propagate, do not clobber | exit 101, existing schema byte-identical |
| Runtime binary missing | fail clearly | `failed to run ...: ENOENT`, exit 1 |

I did not run `cargo` anywhere. The real end-to-end proof is already in CI and costs this PR nothing: `.github/workflows/ci.yml:300` runs `pnpm run generate` with a real toolchain and `:304` asserts `git diff --exit-code` on both generated files. If this script produced different bytes than the shell line, that gate goes red.

## The regression guard

`.github/workflows/windows-sdk-generate-check.yml` builds nothing and runs in seconds.

Both jobs invoke the real `npm run generate:openapi`, not the node script directly. That matters: the regression being guarded lives in `package.json`, so a guard that bypasses it would stay green after a revert. The first version of this guard did exactly that, and review caught it.

The **windows** job first runs the old POSIX form under `cmd.exe` and fails if it somehow works, so the guard cannot quietly stop being meaningful. It then deletes both generated directories, runs the package script with a deliberately absent runtime, and asserts both directories came back. The discriminator is the directories, not the exit code: the runtime is absent so the script must fail either way, and what separates a working package script from a broken one is whether the directories exist afterwards. Live result:

```
ok: npm run generate:openapi created both directories on windows
```

The **linux** job covers the invoke, validate and write path with shell stubs, including the truncation case above.

## What review found, and what it cost

The production fix survived review unchanged, including the byte-equivalence concern that mattered most: the reviewer ran a real 540,317 byte payload and a 38MB payload through the script and confirmed both are `cmp`-identical to the old `>` redirect, and confirmed `maxBuffer` overflow is not silent.

The guard did not survive. Four blocking findings, all now fixed and all now green:

1. The linux stub was written with `printf`, so shell quote removal stripped the JSON's double quotes and the stub emitted invalid JSON, failing the job it existed to prove. It is a quoted heredoc now, and the step self-tests the stub before using it.
2. The windows negative control ran under `cmd`, where a failing `mkdir` leaves an errorlevel that `echo` does not reset, so the step failed and the job never reached the part that tests the fix. It is driven from bash now, so the assertion is mine rather than cmd's errorlevel semantics.
3. Both jobs ran the node script directly rather than through npm, so the guard did not guard the regression.
4. The stated mechanism was wrong, corrected above.

Also fixed from the non-blocking list: `??` to `||` for `CARGO` so an empty value says something useful instead of throwing `ERR_INVALID_ARG_VALUE`, `Makefile` added to the path triggers, actions SHA-pinned to match the repo standard, a `concurrency` group added, and the before/after comparisons switched from `$(cat)` to `sha256sum`.

The split is deliberate. The windows job cannot exercise the cargo invocation itself: Node refuses to spawn `.cmd` stubs without a shell since CVE-2024-27980, and a real `cargo run` there would mean a full Windows runtime build. What was broken on Windows was directory handling, and that is what the Windows job tests.

## What this does not do

This does not re-enable Windows desktop releases. `3d3c0504b8` also removed the `windows-latest` matrix entry from `release-desktop.yml`, the `windows` dispatch option, the Windows artifact upload, and the `windows-x86_64` key from `scripts/generate-updater-manifest.mjs`. Restoring those needs the desktop crate to actually compile for Windows first, which is being established in #2142, and it needs a decision about `generate-updater-manifest.mjs` being fail-closed: it errors on a missing platform artifact today, so adding a `windows-x86_64` key without a guaranteed Windows artifact would break macOS releases.

Worth noting for whoever picks that up: the runtime crates already build and ship `anyharness-x86_64-pc-windows-msvc.zip` on every release, and `specs/desktop-native.md` still carries Windows-specific updater logic. Less of this is missing than the disabled matrix suggests.


## Rebase note (2026-08-21)

Rebased onto current main, which had picked up #2161 (local postgres/redis auto-detection) and #2134 (`make dev` dev-loop launch rework), both of which touched the Makefile's `sdk-generate` target.

The conflict was in the body of `sdk-generate`. Main's version had grown a SKIP_RUST branch: when `SKIP_RUST` is set and `ANYHARNESS_DEV_RUNTIME_BIN` points at an executable prebuilt runtime, it calls that binary directly instead of `cargo run`, so a frontend-only worktree does not need a Rust toolchain to regenerate the SDK. This branch did not exist at the time this PR's commits were written, so it could not just be replayed on top.

Resolution: kept this PR's approach of delegating the whole recipe to `scripts/generate-anyharness-openapi.mjs`, and ported main's SKIP_RUST/prebuilt-runtime branch into the script instead of the Makefile recipe, since that is exactly the shell logic this PR exists to get rid of. The Makefile line is now `CARGO="$(CARGO)" SKIP_RUST="$(SKIP_RUST)" node scripts/generate-anyharness-openapi.mjs`, and the script picks cargo vs the prebuilt runtime the same way the old shell branch did, using `fs.accessSync(..., X_OK)` in place of the shell's `[ -x ... ]` check.

Verified with `make -n` dry runs: `build-rust` and `runtime-build` are byte-identical to main (untouched by this PR), and the only diff anywhere is the `sdk-generate` recipe body itself. Also verified the script's branching directly against stub cargo and stub runtime binaries: SKIP_RUST unset uses cargo, SKIP_RUST=1 with a valid executable runtime bin uses the runtime, SKIP_RUST=1 with a missing/non-executable runtime bin falls back to cargo, and SKIP_RUST=0 falls back to cargo. All four match the pre-rebase main behavior.

No functional changes beyond the rebase itself.
