### PR TITLE
fix(anyharness): terminate agent process trees on windows

### DIFF
--- a/.github/workflows/windows-compile-check.yml
+++ b/.github/workflows/windows-compile-check.yml
@@ -1,0 +1,69 @@
+name: Windows compile check
+
+# The runtime already builds and ships for Windows on every release, but nothing
+# has compiled the desktop crate for Windows since desktop releases were
+# disabled on 2026-04-13. That makes every Windows estimate guesswork. This job
+# turns the unknown into an error list.
+#
+# Non-blocking on purpose: it is a probe, not a gate, until the errors are fixed.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "apps/desktop/src-tauri/**"
+      - "anyharness/crates/**"
+      - ".github/workflows/windows-compile-check.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  runtime:
+    # Known green: release-runtime.yml ships these targets today. Here as the
+    # control, so a red desktop job cannot be blamed on the toolchain.
+    name: runtime crates (control)
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo check
+        run: cargo check --target x86_64-pc-windows-msvc -p anyharness -p proliferate-worker -p proliferate-supervisor
+
+  desktop:
+    name: desktop crates (the unknown)
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo check
+        # Keep going past the first failure so one run yields the whole list
+        # rather than one error at a time.
+        run: cargo check --target x86_64-pc-windows-msvc -p proliferate --keep-going 2>&1 | tee check.log
+        shell: bash
+      - name: Error summary
+        if: always()
+        shell: bash
+        run: |
+          echo "### Windows desktop compile errors" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          grep -E '^error' check.log | sort | uniq -c | sort -rn | head -50 >> $GITHUB_STEP_SUMMARY || echo "no errors" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "total errors: $(grep -cE '^error' check.log || echo 0)" >> $GITHUB_STEP_SUMMARY
+          echo "files implicated:" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          grep -oE '\-\-> [^:]+' check.log | sed 's/--> //' | sort -u | head -60 >> $GITHUB_STEP_SUMMARY || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: windows-desktop-check-log
+          path: check.log

--- a/.github/workflows/windows-compile-check.yml
+++ b/.github/workflows/windows-compile-check.yml
@@ -14,6 +14,11 @@ on:
       - "apps/desktop/src-tauri/**"
       - "anyharness/crates/**"
       - ".github/workflows/windows-compile-check.yml"
+      - "Cargo.lock"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -24,9 +29,10 @@ jobs:
     # control, so a red desktop job cannot be blamed on the toolchain.
     name: runtime crates (control)
     runs-on: windows-latest
+    timeout-minutes: 45
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-msvc
@@ -37,9 +43,10 @@ jobs:
   desktop:
     name: desktop crates (the unknown)
     runs-on: windows-latest
+    timeout-minutes: 45
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-msvc
@@ -62,7 +69,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
           grep -oE '\-\-> [^:]+' check.log | sed 's/--> //' | sort -u | head -60 >> $GITHUB_STEP_SUMMARY || true
           echo '```' >> $GITHUB_STEP_SUMMARY
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: windows-desktop-check-log

--- a/.github/workflows/windows-process-kill-tests.yml
+++ b/.github/workflows/windows-process-kill-tests.yml
@@ -21,6 +21,8 @@ on:
   pull_request:
     paths:
       - "anyharness/crates/anyharness-lib/src/process_kill.rs"
+      - "anyharness/crates/anyharness-lib/src/process_kill_tree.rs"
+      - "anyharness/crates/anyharness-lib/src/process_kill_tree_tests.rs"
       - "anyharness/crates/anyharness-lib/src/process_kill_windows.rs"
       - "anyharness/crates/anyharness-lib/tests/windows_process_tree.rs"
       - ".github/workflows/windows-process-kill-tests.yml"

--- a/.github/workflows/windows-process-kill-tests.yml
+++ b/.github/workflows/windows-process-kill-tests.yml
@@ -1,0 +1,48 @@
+name: Windows process-kill tests
+
+# `windows-compile-check.yml` proves the Windows code TYPECHECKS. Nothing
+# proves it RUNS, and `process_kill_windows.rs` is `unsafe` FFI against
+# Toolhelp and TerminateProcess, which is exactly the kind of code where
+# typechecking establishes very little.
+#
+# This deliberately runs ONE integration test target rather than the crate's
+# unit tests. `anyharness-lib`'s `lib test` target does not build for Windows
+# today: `cargo check --all-targets --target x86_64-pc-windows-msvc` reports
+# ten pre-existing errors, all test-only POSIX assumptions in unrelated
+# modules. An integration test compiles as its own crate against the library's
+# public surface, so it never pulls those in and gives a real runtime verdict
+# without absorbing that port into this change.
+#
+# Kept separate from `windows-compile-check.yml` on purpose: other branches
+# stack on that file and it must not be destabilised.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "anyharness/crates/anyharness-lib/src/process_kill.rs"
+      - "anyharness/crates/anyharness-lib/src/process_kill_windows.rs"
+      - "anyharness/crates/anyharness-lib/tests/windows_process_tree.rs"
+      - ".github/workflows/windows-process-kill-tests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  process-kill:
+    name: process-kill tests (windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo test
+        # Serial: each test spawns a real process tree and asserts against the
+        # machine-wide process table, so parallel runs would read each other's
+        # children.
+        run: >
+          cargo test --target x86_64-pc-windows-msvc
+          -p anyharness-lib --test windows_process_tree
+          -- --nocapture --test-threads=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
+ "windows-sys 0.61.2",
  "zip 8.6.0",
  "zstd",
 ]

--- a/anyharness/crates/anyharness-lib/Cargo.toml
+++ b/anyharness/crates/anyharness-lib/Cargo.toml
@@ -49,6 +49,18 @@ minisign-verify.workspace = true
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
 
+# Toolhelp process enumeration plus OpenProcess/TerminateProcess for
+# `process_kill_windows.rs`. Target-gated so no other platform pays for it,
+# and pinned to the 0.61 line the workspace already resolves (mio, async-io,
+# polling and others pull windows-sys 0.61.2 today) so this adds no new
+# package to the lock.
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_Threading",
+] }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber.workspace = true

--- a/anyharness/crates/anyharness-lib/src/process_kill.rs
+++ b/anyharness/crates/anyharness-lib/src/process_kill.rs
@@ -11,11 +11,22 @@
 //! `DOMAIN_LIVE_VALVE` boundary rule. See the R3 delivery spec's
 //! Contradictions C4.
 //!
-//! Everything here is unix-only: the enumeration is genuinely two
-//! implementations (macOS via libproc, Linux via `/proc`) behind one
-//! `#[cfg]`, and the escalation always runs on a detached task so a dropped
-//! or timed-out caller future can never strand a TERM-ignoring process
-//! between the TERM and the KILL.
+//! The enumeration is genuinely one implementation per platform - macOS via
+//! libproc, Linux via `/proc`, Windows via a `CreateToolhelp32Snapshot`
+//! parent-link walk in [`process_kill_windows`](crate::process_kill_windows) -
+//! behind one `#[cfg]`, and on every platform the escalation runs on a
+//! detached task so a dropped or timed-out caller future can never strand a
+//! half-killed target between the first signal and the last.
+//!
+//! What a caller passes differs by platform and the two functions below name
+//! the unix concepts because that is where the distinction is real. Windows
+//! has neither process groups nor sessions, and every call site derives its
+//! integer from a direct child's pid (`process_group(0)` at the spawn sites is
+//! `#[cfg(unix)]`), so both entry points collapse to one descendant-tree kill
+//! rooted at that pid. The CONTRACT is identical on both platforms: the
+//! returned `(total, git)` is the census taken before anything is signaled,
+//! `(0, 0)` means nothing was running, and the call resolves only once the
+//! target is confirmed dead or the confirmation budget is spent.
 
 use std::time::Duration;
 
@@ -349,13 +360,52 @@ mod unix_impl {
 #[cfg(unix)]
 pub use unix_impl::{kill_group_and_await, kill_session_and_await};
 
-#[cfg(not(unix))]
-pub async fn kill_group_and_await(_pgid: i32) -> (usize, usize) {
+#[cfg(windows)]
+#[path = "process_kill_windows.rs"]
+mod windows_impl;
+
+/// Windows: the pgid a caller holds is only ever the direct child's pid (see
+/// this module's header), so this kills the descendant tree rooted at it.
+/// Same `(total, git)` census, same detached escalation, same deadline
+/// semantics as the unix path; the one behavioral difference is that
+/// `TerminateProcess` is unconditional, so there is no graceful rung before
+/// it (`process_kill_windows.rs` explains why one is not reachable from the
+/// current spawn sites).
+#[cfg(windows)]
+pub async fn kill_group_and_await(pgid: i32) -> (usize, usize) {
+    windows_impl::kill_tree_and_await(pgid).await
+}
+
+/// Windows: PTY sessions do not exist as a kernel concept, and portable-pty's
+/// ConPTY backend has no `setsid()` to make the child a session leader, so
+/// `sid` here is just the PTY child's pid and the shell's jobs are its
+/// ordinary descendants. Same tree kill as [`kill_group_and_await`].
+#[cfg(windows)]
+pub async fn kill_session_and_await(sid: i32) -> (usize, usize) {
+    windows_impl::kill_tree_and_await(sid).await
+}
+
+/// No other platform is a build target for this runtime. Returning the bare
+/// `(0, 0)` here would be indistinguishable from a successful kill of nothing,
+/// so the stub is loud instead of silent: a caller that believes a live plane
+/// has quiesced when nothing was killed is worse than an error, because
+/// archive then proceeds against a workspace whose processes are still
+/// holding it.
+#[cfg(not(any(unix, windows)))]
+pub async fn kill_group_and_await(pgid: i32) -> (usize, usize) {
+    tracing::error!(
+        pgid,
+        "process_kill: no process-kill implementation for this platform; NOTHING was killed"
+    );
     (0, 0)
 }
 
-#[cfg(not(unix))]
-pub async fn kill_session_and_await(_sid: i32) -> (usize, usize) {
+#[cfg(not(any(unix, windows)))]
+pub async fn kill_session_and_await(sid: i32) -> (usize, usize) {
+    tracing::error!(
+        sid,
+        "process_kill: no process-kill implementation for this platform; NOTHING was killed"
+    );
     (0, 0)
 }
 

--- a/anyharness/crates/anyharness-lib/src/process_kill.rs
+++ b/anyharness/crates/anyharness-lib/src/process_kill.rs
@@ -13,10 +13,10 @@
 //!
 //! The enumeration is genuinely one implementation per platform - macOS via
 //! libproc, Linux via `/proc`, Windows via a `CreateToolhelp32Snapshot`
-//! parent-link walk in [`process_kill_windows`](crate::process_kill_windows) -
-//! behind one `#[cfg]`, and on every platform the escalation runs on a
-//! detached task so a dropped or timed-out caller future can never strand a
-//! half-killed target between the first signal and the last.
+//! parent-link walk in `process_kill_windows.rs` - behind one `#[cfg]`, and
+//! on every platform the escalation runs on a detached task so a dropped or
+//! timed-out caller future can never strand a half-killed target between the
+//! first signal and the last.
 //!
 //! What a caller passes differs by platform and the two functions below name
 //! the unix concepts because that is where the distinction is real. Windows
@@ -26,7 +26,11 @@
 //! rooted at that pid. The CONTRACT is identical on both platforms: the
 //! returned `(total, git)` is the census taken before anything is signaled,
 //! `(0, 0)` means nothing was running, and the call resolves only once the
-//! target is confirmed dead or the confirmation budget is spent.
+//! target is confirmed dead or the confirmation budget is spent. Two places
+//! where Windows is genuinely weaker, both documented in
+//! `process_kill_windows.rs`: the kill is not atomic against a tree that
+//! grows mid-kill (unix's `kill(-pgid)` is), and an adoption whose identity
+//! cannot be proven is refused rather than guessed at.
 
 use std::time::Duration;
 
@@ -359,6 +363,15 @@ mod unix_impl {
 
 #[cfg(unix)]
 pub use unix_impl::{kill_group_and_await, kill_session_and_await};
+
+/// The tree bookkeeping the Windows kill path runs on. It contains no FFI, so
+/// it is compiled under `test` on every platform and its unit tests run on the
+/// ordinary Linux and macOS jobs - which is where the multi-pass escalation
+/// logic actually gets exercised, since a real-process Windows test never
+/// reaches the second pass.
+#[cfg(any(windows, test))]
+#[path = "process_kill_tree.rs"]
+mod tree;
 
 #[cfg(windows)]
 #[path = "process_kill_windows.rs"]

--- a/anyharness/crates/anyharness-lib/src/process_kill_tree.rs
+++ b/anyharness/crates/anyharness-lib/src/process_kill_tree.rs
@@ -1,0 +1,244 @@
+//! Process-tree bookkeeping for the Windows kill path, with no FFI in it.
+//!
+//! Split out from `process_kill_windows.rs` deliberately. Everything here is
+//! `std::collections`, `String` and a `[u16; 260]` decode, so gating it
+//! `#[cfg(any(windows, test))]` lets the whole of it compile and RUN on the
+//! ordinary Linux and macOS test jobs, on every PR. That matters more than it
+//! looks: the two bugs this module exists to prevent (adopting a stranger
+//! through a stale parent link, and stranding a grandchild whose parent died
+//! mid-kill) both live in the multi-pass escalation rung, which a real-process
+//! Windows test never reaches because its tree dies on the first pass. Pure
+//! logic tested everywhere beats FFI logic tested nowhere.
+//!
+//! `process_kill_windows.rs` supplies the two things that genuinely need
+//! Windows - the Toolhelp enumeration and the creation-time read - and hands
+//! them in.
+
+use std::collections::{HashMap, HashSet};
+
+/// Cap on the parent-chain walk that orders a pass deepest-first. A chain
+/// longer than this is truncated for ordering purposes; a chain that CYCLES
+/// is reported separately (see [`TreeTracker::depth_of`]).
+const DEPTH_LIMIT: u32 = 64;
+
+/// A process's creation time in FILETIME ticks. This is the generation
+/// counter a bare pid does not have: two processes can share a pid over time
+/// but never a (pid, creation time) pair.
+pub(super) type Generation = u64;
+
+/// One row of a Toolhelp process snapshot. The base executable name comes
+/// back in the same read as the parent link, so unlike the unix path the
+/// `git` census costs no extra per-pid syscall.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ProcessEntry {
+    pub(super) pid: u32,
+    pub(super) parent: u32,
+    pub(super) exe: String,
+}
+
+/// `szExeFile` is a fixed 260-wide buffer holding a NUL-terminated base name;
+/// decoding the whole array would append the padding.
+pub(super) fn executable_name(raw: &[u16; 260]) -> String {
+    let end = raw.iter().position(|&unit| unit == 0).unwrap_or(raw.len());
+    String::from_utf16_lossy(&raw[..end])
+}
+
+/// Whether a snapshot's base name is `git`. Windows file names are
+/// case-insensitive and the executable carries an extension, so the unix
+/// path's exact `"git"` comparison would count zero every time and quietly
+/// change `repair_kill_debris`'s refusal behavior.
+pub(super) fn is_git_executable(name: &str) -> bool {
+    let lowered = name.to_ascii_lowercase();
+    lowered == "git.exe" || lowered == "git"
+}
+
+/// The `(total, git)` census over an already-enumerated pass, taken BEFORE
+/// anything is signaled for the same reason the unix path does it: counting
+/// afterwards undercounts exactly the processes that died fastest.
+pub(super) fn census(entries: &[ProcessEntry]) -> (usize, usize) {
+    let git = entries
+        .iter()
+        .filter(|entry| is_git_executable(&entry.exe))
+        .count();
+    (entries.len(), git)
+}
+
+/// The set of pids belonging to one target tree, carried ACROSS enumeration
+/// passes and keyed on identity rather than on a bare pid.
+///
+/// Two hazards this exists to close, both of them ways a plain
+/// `th32ParentProcessID` walk gets the wrong answer:
+///
+/// **Stale parent links.** A pid is not an identity. A long-lived process
+/// whose creator exited keeps pointing at that freed number, and when Windows
+/// hands the number to our agent child the stranger looks like a descendant
+/// and gets terminated. Adoption therefore requires the child's creation time
+/// to be at or after the parent's. That test is exactly right, not merely
+/// conservative: a genuine child is always created after its parent, and a
+/// stranger's dangling link can only name a pid whose previous owner was
+/// alive when the stranger started and had to exit before our root could
+/// acquire the number, so the stranger is always OLDER than our root. An
+/// adoption whose generations cannot be read is refused, because terminating
+/// a stranger is worse than leaking a descendant.
+///
+/// A pid can also be recycled while it is ALREADY tracked, if it dies and is
+/// reassigned between two passes so we never observe it missing. Adoption
+/// checks cannot help there, because an already-tracked pid is never a
+/// candidate for adoption. Every pass therefore re-verifies the identity of
+/// the pids it already holds and drops any whose creation time has changed.
+/// That subsumes the weaker "never re-adopt a pid we have seen die" rule this
+/// started with, which was redundant once identity is checked and which
+/// leaked a genuine child that happened to reuse a retired number.
+///
+/// **Orphans are not re-parented.** Re-deriving the tree from the root each
+/// pass would lose every survivor the moment the root died, so the set is
+/// remembered. Growth runs BEFORE the vanished are dropped, so a grandchild
+/// whose parent died inside that same interval is still adopted through the
+/// parent's last known membership; dropping first would strand it forever,
+/// which is this module's own defect narrowed to a window.
+pub(super) struct TreeTracker {
+    tracked: HashMap<u32, Option<Generation>>,
+    self_pid: u32,
+}
+
+impl TreeTracker {
+    pub(super) fn new(root: u32, root_generation: Option<Generation>, self_pid: u32) -> Self {
+        let mut tracked = HashMap::new();
+        tracked.insert(root, root_generation);
+        Self { tracked, self_pid }
+    }
+
+    /// Adopt any provable new descendant, retire what vanished, and return
+    /// the tracked processes this snapshot still lists, ordered root-first.
+    ///
+    /// `created_at` resolves a pid's creation time. It is a parameter rather
+    /// than a direct syscall so this whole function is testable off Windows,
+    /// and so the caller can memoize it: it costs an `OpenProcess` each.
+    pub(super) fn absorb(
+        &mut self,
+        snapshot: &[ProcessEntry],
+        created_at: &mut dyn FnMut(u32) -> Option<Generation>,
+    ) -> Vec<ProcessEntry> {
+        // VERIFY IDENTITY FIRST, so a number that changed hands between
+        // passes can neither be terminated nor used as a parent. A stored
+        // generation of `None` means the identity was never establishable, so
+        // there is nothing to compare against and nothing may be adopted
+        // through it anyway.
+        let live_ids: Vec<u32> = snapshot
+            .iter()
+            .map(|entry| entry.pid)
+            .filter(|pid| self.tracked.contains_key(pid))
+            .collect();
+        for pid in live_ids {
+            let Some(Some(stored)) = self.tracked.get(&pid).copied() else {
+                continue;
+            };
+            if created_at(pid) != Some(stored) {
+                self.tracked.remove(&pid);
+            }
+        }
+
+        // GROW SECOND. A parent that died during this interval is still
+        // tracked right now, and that is the only thing that lets its orphan
+        // be adopted at all.
+        loop {
+            let mut grew = false;
+            for entry in snapshot {
+                if !self.may_adopt(entry) {
+                    continue;
+                }
+                let Some(Some(parent_generation)) = self.tracked.get(&entry.parent).copied() else {
+                    // Either the parent is not ours, or its identity was
+                    // never established. Refuse rather than guess.
+                    continue;
+                };
+                let Some(child_generation) = created_at(entry.pid) else {
+                    continue;
+                };
+                if child_generation < parent_generation {
+                    // A stale link: this process predates the pid it claims
+                    // as its parent, so that number has been recycled since.
+                    continue;
+                }
+                self.tracked.insert(entry.pid, Some(child_generation));
+                grew = true;
+            }
+            if !grew {
+                break;
+            }
+        }
+
+        // DROP THE VANISHED LAST, after they have had their one chance to
+        // pass on their orphans.
+        let live: HashSet<u32> = snapshot.iter().map(|entry| entry.pid).collect();
+        let vanished: Vec<u32> = self
+            .tracked
+            .keys()
+            .copied()
+            .filter(|pid| !live.contains(pid))
+            .collect();
+        for pid in vanished {
+            self.tracked.remove(&pid);
+        }
+
+        let parents: HashMap<u32, u32> = snapshot
+            .iter()
+            .map(|entry| (entry.pid, entry.parent))
+            .collect();
+        let mut alive: Vec<ProcessEntry> = snapshot
+            .iter()
+            .filter(|entry| self.tracked.contains_key(&entry.pid))
+            .cloned()
+            .collect();
+        alive.sort_by_key(|entry| {
+            // An unresolvable chain sorts last, so it is terminated first.
+            let depth = self
+                .depth_of(entry.pid, &parents)
+                .map_or((1u8, u32::MAX), |depth| (0u8, depth));
+            (depth, entry.pid)
+        });
+        alive
+    }
+
+    /// Whether `entry` is even a candidate for adoption, before its identity
+    /// is checked.
+    fn may_adopt(&self, entry: &ProcessEntry) -> bool {
+        // pid 0 is the idle process and is every unparented row's "parent";
+        // letting it into the set would sweep the machine.
+        entry.pid != 0
+            && entry.pid != self.self_pid
+            && entry.parent != entry.pid
+            && !self.tracked.contains_key(&entry.pid)
+    }
+
+    /// Hops from `pid` up to the shallowest tracked ancestor, or `None` when
+    /// the chain CYCLES. Ordering is the only consumer, so a chain deeper
+    /// than [`DEPTH_LIMIT`] is truncated to it rather than treated as an
+    /// error. A cycle is reported distinctly because it is a corrupt reading
+    /// of the table, and because without the visited set the walk would not
+    /// terminate at all.
+    pub(super) fn depth_of(&self, pid: u32, parents: &HashMap<u32, u32>) -> Option<u32> {
+        let mut seen = HashSet::new();
+        seen.insert(pid);
+        let mut depth = 0;
+        let mut cursor = pid;
+        for _ in 0..DEPTH_LIMIT {
+            let Some(&parent) = parents.get(&cursor) else {
+                return Some(depth);
+            };
+            if !self.tracked.contains_key(&parent) {
+                return Some(depth);
+            }
+            if !seen.insert(parent) {
+                return None;
+            }
+            depth += 1;
+            cursor = parent;
+        }
+        Some(DEPTH_LIMIT)
+    }
+}
+
+#[cfg(test)]
+#[path = "process_kill_tree_tests.rs"]
+mod tests;

--- a/anyharness/crates/anyharness-lib/src/process_kill_tree.rs
+++ b/anyharness/crates/anyharness-lib/src/process_kill_tree.rs
@@ -73,19 +73,39 @@ pub(super) fn census(entries: &[ProcessEntry]) -> (usize, usize) {
 /// whose creator exited keeps pointing at that freed number, and when Windows
 /// hands the number to our agent child the stranger looks like a descendant
 /// and gets terminated. Adoption therefore requires the child's creation time
-/// to be at or after the parent's. That test is exactly right, not merely
-/// conservative: a genuine child is always created after its parent, and a
-/// stranger's dangling link can only name a pid whose previous owner was
-/// alive when the stranger started and had to exit before our root could
-/// acquire the number, so the stranger is always OLDER than our root. An
-/// adoption whose generations cannot be read is refused, because terminating
-/// a stranger is worse than leaking a descendant.
+/// to be at or after the parent's.
+///
+/// What that buys, precisely: for a link to be stale, the number's previous
+/// owner had to be alive when the stranger started and had to exit before our
+/// root could acquire the number, so in real time the stranger STARTED before
+/// our root did. A genuine child always starts after its parent. So the
+/// comparison separates the two cases whenever the clock separates them.
+///
+/// What it does not buy: the comparison is on REPORTED `GetProcessTimes`
+/// values, not on real time, and it admits equality. At an equal reported
+/// timestamp a stranger is adopted. Equality has to be admitted anyway, or a
+/// genuine child created inside the same tick as its parent leaks, so the
+/// code is deliberately this way and the residual is the same-tick window
+/// rather than a bug. How wide that window is depends on the sampling
+/// resolution `GetProcessTimes` actually reports on a given machine, which
+/// nothing here has measured; do not assume it is the 100ns the FILETIME
+/// encoding suggests. Job Objects (see the module header's follow-up note)
+/// remove the question rather than narrowing it.
+///
+/// An adoption whose generations cannot be read is refused outright, because
+/// terminating a stranger is worse than leaking a descendant.
 ///
 /// A pid can also be recycled while it is ALREADY tracked, if it dies and is
 /// reassigned between two passes so we never observe it missing. Adoption
 /// checks cannot help there, because an already-tracked pid is never a
 /// candidate for adoption. Every pass therefore re-verifies the identity of
-/// the pids it already holds and drops any whose creation time has changed.
+/// the pids it already holds and drops any whose creation time has CHANGED.
+/// A time it cannot read is a different thing from a time that differs: the
+/// pid keeps its place in the set, and only loses its ability to prove
+/// adoptions. Treating unreadable as changed would let one transient failure
+/// against the root drop it permanently and report a live root as dead, which
+/// is the same shape of bug as reading a failed enumeration as an empty
+/// process table.
 /// That subsumes the weaker "never re-adopt a pid we have seen die" rule this
 /// started with, which was redundant once identity is checked and which
 /// leaked a genuine child that happened to reuse a retired number.
@@ -133,8 +153,23 @@ impl TreeTracker {
             let Some(Some(stored)) = self.tracked.get(&pid).copied() else {
                 continue;
             };
-            if created_at(pid) != Some(stored) {
-                self.tracked.remove(&pid);
+            match created_at(pid) {
+                // Same process we have been tracking all along.
+                Some(current) if current == stored => {}
+                // A different process holds this number now. Drop it: it is
+                // not ours and must not be terminated or adopted through.
+                Some(_) => {
+                    self.tracked.remove(&pid);
+                }
+                // Unreadable, which is NOT evidence of a change. Keep it in
+                // the set so a transient failure cannot report a live process
+                // dead, but downgrade it so nothing can be adopted through an
+                // identity we can no longer confirm. The downgrade is
+                // permanent by design: a later successful read cannot tell us
+                // whether it is reading the same process.
+                None => {
+                    self.tracked.insert(pid, None);
+                }
             }
         }
 

--- a/anyharness/crates/anyharness-lib/src/process_kill_tree_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/process_kill_tree_tests.rs
@@ -1,0 +1,291 @@
+//! Unit tests for the Windows kill path's tree bookkeeping.
+//!
+//! These are NOT gated on Windows. The logic under test is pure `std`, so
+//! `process_kill_tree.rs` is compiled under `cfg(any(windows, test))` and
+//! every case here runs on the ordinary Linux and macOS test jobs on every
+//! PR. That is deliberate: all of this covers the multi-pass escalation rung,
+//! which the real-process Windows integration test never reaches because its
+//! tree dies on the first `TerminateProcess` pass.
+//!
+//! Every test below states the mechanism it pins and what deleting that
+//! mechanism does to it. A test that still passes with the mechanism removed
+//! is not evidence, and two earlier versions of this file were exactly that.
+
+use std::collections::HashMap;
+
+use super::*;
+
+fn entry(pid: u32, parent: u32, exe: &str) -> ProcessEntry {
+    ProcessEntry {
+        pid,
+        parent,
+        exe: exe.to_string(),
+    }
+}
+
+/// A creation-time oracle: whatever is not listed is unreadable.
+fn clock(pairs: &[(u32, Generation)]) -> impl FnMut(u32) -> Option<Generation> {
+    let times: HashMap<u32, Generation> = pairs.iter().copied().collect();
+    move |pid| times.get(&pid).copied()
+}
+
+fn pids(entries: &[ProcessEntry]) -> Vec<u32> {
+    entries.iter().map(|entry| entry.pid).collect()
+}
+
+#[test]
+fn executable_name_stops_at_the_nul_terminator() {
+    let mut raw = [0u16; 260];
+    for (slot, unit) in raw.iter_mut().zip("git.exe".encode_utf16()) {
+        *slot = unit;
+    }
+    assert_eq!(executable_name(&raw), "git.exe");
+}
+
+/// Pins the `git.exe` comparison. The unix path compares the base name
+/// against exactly `"git"`; this asserts directly that doing so here would
+/// count zero, which is what would silently flip `repair_kill_debris`'s
+/// refusal (it branches on `killed_git > 0`).
+#[test]
+fn the_census_counts_git_exe_where_an_exact_git_comparison_would_count_zero() {
+    let tree = vec![
+        entry(100, 1, "cmd.exe"),
+        entry(200, 100, "git.exe"),
+        entry(300, 100, "GIT.EXE"),
+    ];
+    assert_eq!(census(&tree), (3, 2));
+
+    let unix_style = tree.iter().filter(|entry| entry.exe == "git").count();
+    assert_eq!(
+        unix_style, 0,
+        "the unix comparison must be shown to fail here, or this test proves nothing"
+    );
+
+    // ...and it must not over-match either.
+    assert!(!is_git_executable("gitk.exe"));
+    assert!(!is_git_executable("legit.exe"));
+    assert!(!is_git_executable("git.exe.bak"));
+}
+
+#[test]
+fn absorb_collects_the_whole_descendant_tree_root_first() {
+    let snapshot = vec![
+        entry(1, 0, "System.exe"),
+        entry(400, 1, "unrelated.exe"),
+        entry(100, 1, "agent.exe"),
+        entry(300, 200, "git.exe"),
+        entry(200, 100, "cmd.exe"),
+    ];
+    let mut tracker = TreeTracker::new(100, Some(10), 9999);
+    let alive = tracker.absorb(
+        &snapshot,
+        &mut clock(&[(100, 10), (200, 20), (300, 30), (400, 5)]),
+    );
+    // Root first, then each generation: the pass is terminated in reverse, so
+    // the grandchild dies before the shell that owns it.
+    assert_eq!(pids(&alive), vec![100, 200, 300]);
+    assert_eq!(census(&alive), (3, 1));
+}
+
+#[test]
+fn absorb_never_adopts_the_runtimes_own_process() {
+    let snapshot = vec![
+        entry(100, 1, "agent.exe"),
+        entry(9999, 100, "anyharness.exe"),
+    ];
+    let mut tracker = TreeTracker::new(100, Some(10), 9999);
+    let alive = tracker.absorb(&snapshot, &mut clock(&[(100, 10), (9999, 20)]));
+    assert_eq!(pids(&alive), vec![100]);
+}
+
+/// B1. A stale `th32ParentProcessID` must not make a stranger a descendant.
+///
+/// A long-lived process whose creator exited keeps pointing at that freed
+/// number. When Windows hands the number to our agent child, a walk that
+/// trusts the link adopts the stranger and terminates it. Reproduced before
+/// the fix as `TerminateProcess` on `[8432, 5000, 5001, 5002]` with a census
+/// of `(4, 1)`.
+///
+/// NEGATIVE CONTROL: delete the `child_generation < parent_generation`
+/// rejection in `absorb` and this returns exactly that list and that census.
+#[test]
+fn absorb_refuses_a_stranger_reached_through_a_stale_parent_link() {
+    // The strangers are all far OLDER than the root, which is the invariant
+    // the fix leans on: for the link to be stale, the number's previous owner
+    // had to exit before our root could acquire it, so anything it spawned
+    // predates our root.
+    let snapshot = vec![
+        entry(8432, 1, "agent.exe"),
+        entry(5000, 8432, "stranger.exe"),
+        entry(5001, 5000, "stranger-child.exe"),
+        entry(5002, 5001, "git.exe"),
+    ];
+    let mut tracker = TreeTracker::new(8432, Some(1000), 9999);
+    let alive = tracker.absorb(
+        &snapshot,
+        &mut clock(&[(8432, 1000), (5000, 10), (5001, 11), (5002, 12)]),
+    );
+    assert_eq!(pids(&alive), vec![8432]);
+    assert_eq!(census(&alive), (1, 0));
+}
+
+/// The complement of the test above, and the reason the B1 fix is a
+/// generation COMPARISON rather than a blanket refusal: a real descendant is
+/// always created after its parent and must still be adopted.
+///
+/// NEGATIVE CONTROL: "fix" B1 by refusing every adoption and this goes red.
+#[test]
+fn absorb_still_adopts_a_genuine_child_created_after_its_parent() {
+    let snapshot = vec![entry(8432, 1, "agent.exe"), entry(9000, 8432, "git.exe")];
+    let mut tracker = TreeTracker::new(8432, Some(1000), 9999);
+    let alive = tracker.absorb(&snapshot, &mut clock(&[(8432, 1000), (9000, 1001)]));
+    assert_eq!(pids(&alive), vec![8432, 9000]);
+    assert_eq!(census(&alive), (2, 1));
+}
+
+/// B1, second hole: a pid can be recycled while it is ALREADY tracked, if it
+/// dies and is reassigned between two passes so we never observe it missing.
+/// Adoption checks cannot catch that, because an already-tracked pid is never
+/// an adoption candidate. Only re-verifying identity every pass does.
+///
+/// NEGATIVE CONTROL: delete the identity-verification block at the top of
+/// `absorb` and pid 200 stays tracked, so the stranger is terminated.
+#[test]
+fn absorb_drops_a_tracked_pid_that_was_recycled_between_passes() {
+    let mut tracker = TreeTracker::new(100, Some(10), 9999);
+    let first = tracker.absorb(
+        &[entry(100, 1, "agent.exe"), entry(200, 100, "cmd.exe")],
+        &mut clock(&[(100, 10), (200, 20)]),
+    );
+    assert_eq!(pids(&first), vec![100, 200]);
+
+    // pid 200 died and was handed to something unrelated before we looked
+    // again, so we never saw it vanish. Its creation time is the only thing
+    // that gives it away.
+    let second = tracker.absorb(
+        &[entry(100, 1, "agent.exe"), entry(200, 999, "stranger.exe")],
+        &mut clock(&[(100, 10), (200, 500)]),
+    );
+    assert_eq!(pids(&second), vec![100]);
+}
+
+/// B3. A grandchild whose parent died inside the same interval must still be
+/// adopted, through the parent's last known membership.
+///
+/// Reproduced before the fix as the confirmation pass returning `[]` and
+/// reporting the tree DEAD while `git.exe` was still running, which is this
+/// module's whole reason for existing, narrowed to a window.
+///
+/// NEGATIVE CONTROL: move the "drop the vanished" block back above the growth
+/// loop in `absorb` and this returns `[100]`, losing pid 300 forever.
+#[test]
+fn absorb_adopts_a_grandchild_whose_parent_died_in_the_same_interval() {
+    let mut tracker = TreeTracker::new(100, Some(10), 9999);
+    tracker.absorb(
+        &[entry(100, 1, "agent.exe"), entry(200, 100, "cmd.exe")],
+        &mut clock(&[(100, 10), (200, 20)]),
+    );
+
+    // pid 200 is gone from this snapshot, but it spawned 300 before it died.
+    let second = tracker.absorb(
+        &[entry(100, 1, "agent.exe"), entry(300, 200, "git.exe")],
+        &mut clock(&[(100, 10), (300, 30)]),
+    );
+    assert_eq!(pids(&second), vec![100, 300]);
+    assert_eq!(census(&second), (2, 1));
+}
+
+/// The escalation rung end to end, which is the loop none of the real-process
+/// tests reach: the tree is enumerated, partly dies, grows a new descendant
+/// while the kill is in flight, and only then empties. Every pass must report
+/// exactly what is still alive and ours.
+#[test]
+fn the_escalation_rung_tracks_a_tree_across_passes_until_it_empties() {
+    let mut tracker = TreeTracker::new(100, Some(10), 9999);
+
+    let pass_one = tracker.absorb(
+        &[
+            entry(100, 1, "agent.exe"),
+            entry(200, 100, "cmd.exe"),
+            entry(700, 1, "unrelated.exe"),
+        ],
+        &mut clock(&[(100, 10), (200, 20), (700, 5)]),
+    );
+    assert_eq!(pids(&pass_one), vec![100, 200]);
+
+    // The shell survived the first TerminateProcess and started a new child.
+    let pass_two = tracker.absorb(
+        &[
+            entry(100, 1, "agent.exe"),
+            entry(200, 100, "cmd.exe"),
+            entry(400, 200, "git.exe"),
+            entry(700, 1, "unrelated.exe"),
+        ],
+        &mut clock(&[(100, 10), (200, 20), (400, 40), (700, 5)]),
+    );
+    assert_eq!(pids(&pass_two), vec![100, 200, 400]);
+
+    // The root and the shell die; the grandchild is still up.
+    let pass_three = tracker.absorb(
+        &[entry(400, 200, "git.exe"), entry(700, 1, "unrelated.exe")],
+        &mut clock(&[(400, 40), (700, 5)]),
+    );
+    assert_eq!(pids(&pass_three), vec![400]);
+
+    // Everything ours is gone. The unrelated process must never be reported.
+    let pass_four = tracker.absorb(&[entry(700, 1, "unrelated.exe")], &mut clock(&[(700, 5)]));
+    assert!(pass_four.is_empty());
+}
+
+/// Fail-closed: with no provable identity for the root, no descendant can be
+/// proven either, so the kill degrades to the root alone rather than guessing.
+#[test]
+fn absorb_adopts_nothing_when_the_roots_identity_is_unknown() {
+    let snapshot = vec![entry(100, 1, "agent.exe"), entry(200, 100, "cmd.exe")];
+    let mut tracker = TreeTracker::new(100, None, 9999);
+    let alive = tracker.absorb(&snapshot, &mut clock(&[(200, 20)]));
+    assert_eq!(pids(&alive), vec![100]);
+}
+
+/// A parent chain that cycles must be REPORTED as a cycle, not walked.
+///
+/// NEGATIVE CONTROL: delete the `seen` visited set in `depth_of` and the walk
+/// runs to `DEPTH_LIMIT` and returns `Some(64)` instead of `None`, so this
+/// goes red. Delete the loop bound as well and it does not terminate at all,
+/// which is the reason both guards are there.
+#[test]
+fn depth_of_reports_a_cycle_rather_than_walking_it() {
+    // 100 and 200 each claim the other as parent, and both end up tracked.
+    let snapshot = vec![entry(100, 200, "agent.exe"), entry(200, 100, "cmd.exe")];
+    let mut tracker = TreeTracker::new(100, Some(10), 9999);
+    let alive = tracker.absorb(&snapshot, &mut clock(&[(100, 10), (200, 20)]));
+    assert_eq!(pids(&alive), vec![100, 200]);
+
+    let parents: HashMap<u32, u32> = snapshot
+        .iter()
+        .map(|entry| (entry.pid, entry.parent))
+        .collect();
+    assert_eq!(tracker.depth_of(100, &parents), None);
+    assert_eq!(tracker.depth_of(200, &parents), None);
+}
+
+/// The acyclic counterpart, so the test above cannot be satisfied by a
+/// `depth_of` that simply always returns `None`.
+#[test]
+fn depth_of_measures_an_ordinary_chain() {
+    let snapshot = vec![
+        entry(100, 1, "agent.exe"),
+        entry(200, 100, "cmd.exe"),
+        entry(300, 200, "git.exe"),
+    ];
+    let mut tracker = TreeTracker::new(100, Some(10), 9999);
+    tracker.absorb(&snapshot, &mut clock(&[(100, 10), (200, 20), (300, 30)]));
+
+    let parents: HashMap<u32, u32> = snapshot
+        .iter()
+        .map(|entry| (entry.pid, entry.parent))
+        .collect();
+    assert_eq!(tracker.depth_of(100, &parents), Some(0));
+    assert_eq!(tracker.depth_of(200, &parents), Some(1));
+    assert_eq!(tracker.depth_of(300, &parents), Some(2));
+}

--- a/anyharness/crates/anyharness-lib/src/process_kill_tree_tests.rs
+++ b/anyharness/crates/anyharness-lib/src/process_kill_tree_tests.rs
@@ -169,6 +169,39 @@ fn absorb_drops_a_tracked_pid_that_was_recycled_between_passes() {
     assert_eq!(pids(&second), vec![100]);
 }
 
+/// An identity that cannot be READ is not an identity that has CHANGED. One
+/// transient failure against the root must not drop it and report a live root
+/// as dead - the same shape of bug as reading a failed enumeration as an empty
+/// process table. The pid keeps its place and only loses the ability to prove
+/// adoptions.
+///
+/// NEGATIVE CONTROL: change the `None` arm of the identity check back to
+/// `self.tracked.remove(&pid)` and the first assertion goes red, because the
+/// root vanishes from a pass in which it is plainly alive.
+#[test]
+fn absorb_keeps_a_tracked_pid_whose_identity_cannot_be_read() {
+    let mut tracker = TreeTracker::new(100, Some(10), 9999);
+    tracker.absorb(
+        &[entry(100, 1, "agent.exe")],
+        &mut clock(&[(100, 10), (200, 20)]),
+    );
+
+    // The creation-time read fails for the root this pass. It is still right
+    // there in the snapshot.
+    let snapshot = vec![entry(100, 1, "agent.exe"), entry(200, 100, "cmd.exe")];
+    let degraded = tracker.absorb(&snapshot, &mut clock(&[(200, 20)]));
+    assert_eq!(
+        pids(&degraded),
+        vec![100],
+        "a live root must not be dropped"
+    );
+
+    // ...and the downgrade is real: nothing may be adopted through an
+    // identity we can no longer confirm, even once reads start working again.
+    let later = tracker.absorb(&snapshot, &mut clock(&[(100, 10), (200, 20)]));
+    assert_eq!(pids(&later), vec![100]);
+}
+
 /// B3. A grandchild whose parent died inside the same interval must still be
 /// adopted, through the parent's last known membership.
 ///

--- a/anyharness/crates/anyharness-lib/src/process_kill_windows.rs
+++ b/anyharness/crates/anyharness-lib/src/process_kill_windows.rs
@@ -1,6 +1,7 @@
-//! The Windows half of [`crate::process_kill`]: a descendant-tree walk over a
-//! Toolhelp snapshot, standing in for the unix process-group and session
-//! enumeration.
+//! The Windows half of [`crate::process_kill`]: the Toolhelp enumeration, the
+//! creation-time read, and the terminate/confirm escalation. The bookkeeping
+//! those feed lives in `process_kill_tree.rs`, which has no FFI in it so that
+//! it can be tested on every platform.
 //!
 //! Windows has neither process groups nor sessions in the POSIX sense, so
 //! there is no id a caller could hand us that names a set of processes. What
@@ -14,229 +15,171 @@
 //! calls at those spawn sites are all `#[cfg(unix)]`, so on Windows the
 //! integer is only ever a plain pid. This module therefore reads it as the
 //! ROOT of a process tree and reaches the descendants by walking
-//! `th32ParentProcessID` - the same two-phase "enumerate the whole target,
-//! census it, then act on it" structure the unix path uses, with
-//! `CreateToolhelp32Snapshot` in the place of libproc and `/proc`.
+//! `th32ParentProcessID`.
 //!
-//! Two Windows facts shape the escalation, and both are behavioral
-//! differences from unix that callers should know about:
+//! Three Windows facts shape this, and all three are behavioral differences
+//! from unix rather than implementation detail:
 //!
 //! 1. There is no portable graceful signal. `TerminateProcess` is
 //!    unconditional, so it is the equivalent of `SIGKILL`, not `SIGTERM`. A
 //!    graceful first rung would need `GenerateConsoleCtrlEvent`, which only
 //!    works against a group created with `CREATE_NEW_PROCESS_GROUP` at spawn
 //!    and only for console processes sharing our console. No spawn site sets
-//!    that today, so the TERM rung is not available and the ladder starts at
-//!    the unconditional rung. `GRACE` is still honored as the deadline for
-//!    the OS to finish tearing the tree down before survivors are retried.
+//!    that today, so the ladder starts at the unconditional rung. `GRACE` is
+//!    still honored as the deadline for the OS to finish tearing the tree
+//!    down before survivors are retried.
 //!
-//! 2. Windows does not re-parent orphans; `th32ParentProcessID` simply keeps
-//!    pointing at a pid that no longer exists and may be recycled. Killing
-//!    the root first would therefore make its surviving children unreachable
-//!    on the next enumeration pass. [`TreeTracker`] fixes that by REMEMBERING
-//!    the tree across passes rather than re-deriving it from the root each
-//!    time, and terminating deepest-first so the parent outlives its children.
+//! 2. **The kill is not atomic against a growing tree, and unix's is.**
+//!    `kill(-pgid)` signals a group, so a child created between the unix
+//!    enumeration and the signal is already a group member and still gets
+//!    hit. Here the pass acts on a pid list read from a snapshot, so a
+//!    descendant born after that snapshot is missed by THAT pass and is
+//!    picked up by the next confirmation pass, up to `CONFIRM_POLL` later.
+//!    The tracker is what makes the next pass able to see it. The census
+//!    returned to the caller is still the one taken before the first pass, so
+//!    a tree that grew mid-kill is under-reported even though it is killed.
+//!
+//! 3. **A pid is not an identity.** Windows does not re-parent orphans; a
+//!    dead process leaves its children's `th32ParentProcessID` pointing at a
+//!    freed number that the kernel will hand to someone else. Every pid this
+//!    module acts on is therefore checked against its creation time, and an
+//!    adoption that cannot be proven is refused. This is the one place where
+//!    the safe failure is to under-kill rather than over-kill.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::time::Duration;
 
-use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+use windows_sys::Win32::Foundation::{
+    CloseHandle, GetLastError, ERROR_BAD_LENGTH, FILETIME, INVALID_HANDLE_VALUE,
+};
 use windows_sys::Win32::System::Diagnostics::ToolHelp::{
     CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W, TH32CS_SNAPPROCESS,
 };
 use windows_sys::Win32::System::Threading::{
-    GetCurrentProcessId, OpenProcess, TerminateProcess, PROCESS_TERMINATE,
+    GetCurrentProcessId, GetProcessTimes, OpenProcess, TerminateProcess,
+    PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE,
 };
 
+use super::tree::{census, executable_name, Generation, ProcessEntry, TreeTracker};
 use super::{CONFIRM_BUDGET, CONFIRM_POLL, GRACE};
 
-/// Cap on the parent-chain walk that orders a pass deepest-first. A snapshot
-/// whose parent links form a cycle (only reachable through pid reuse) must
-/// not spin forever.
-const DEPTH_LIMIT: u32 = 64;
+/// `CreateToolhelp32Snapshot` and `Process32FirstW` fail transiently under
+/// process-table churn - `ERROR_BAD_LENGTH` is documented as retryable - and
+/// a failed enumeration here would report a live tree dead, so it is retried
+/// before it is believed.
+const SNAPSHOT_ATTEMPTS: u32 = 5;
+const SNAPSHOT_RETRY_PAUSE: Duration = Duration::from_millis(10);
 
 /// The exit code a terminated member reports. Nonzero so a caller reading the
 /// child's status cannot mistake a kill for a clean exit.
 const KILL_EXIT_CODE: u32 = 1;
 
-/// One row of a Toolhelp process snapshot. The base executable name comes
-/// back in the same read as the parent link, so unlike the unix path the
-/// `git` census costs no extra per-pid syscall.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct ProcessEntry {
-    pub(super) pid: u32,
-    pub(super) parent: u32,
-    pub(super) exe: String,
+/// Every live process on the system, or `None` when the enumeration failed
+/// every attempt. The distinction is the whole point: an empty `Vec` means
+/// "nothing is running", and folding a failed enumeration into that is
+/// exactly the silent lie this module exists to remove.
+fn snapshot_processes() -> Option<Vec<ProcessEntry>> {
+    for attempt in 1..=SNAPSHOT_ATTEMPTS {
+        match try_snapshot_processes() {
+            Ok(entries) => return Some(entries),
+            Err(code) => {
+                if attempt == SNAPSHOT_ATTEMPTS {
+                    tracing::error!(
+                        error_code = code,
+                        attempts = SNAPSHOT_ATTEMPTS,
+                        retryable = code == ERROR_BAD_LENGTH,
+                        "process_kill: the Windows process enumeration failed every attempt"
+                    );
+                    return None;
+                }
+                // Bounded, and only on the failure path: at most
+                // (SNAPSHOT_ATTEMPTS - 1) * SNAPSHOT_RETRY_PAUSE.
+                std::thread::sleep(SNAPSHOT_RETRY_PAUSE);
+            }
+        }
+    }
+    None
 }
 
-/// Every live process on the system, or `None` when the snapshot itself
-/// failed. The distinction is the whole point: an empty `Vec` means "nothing
-/// is running", and folding a failed enumeration into that is exactly the
-/// silent lie this module exists to remove.
-fn snapshot_processes() -> Option<Vec<ProcessEntry>> {
+/// One enumeration attempt. `Err` carries `GetLastError` so the caller can
+/// tell a retryable `ERROR_BAD_LENGTH` from a real failure.
+fn try_snapshot_processes() -> Result<Vec<ProcessEntry>, u32> {
     // SAFETY: a kernel32 read of the running process table. The handle is
     // checked against both failure encodings before use and closed on every
     // exit path below.
-    let handle = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
-    if handle.is_null() || handle == INVALID_HANDLE_VALUE {
-        return None;
-    }
-    let mut entry = PROCESSENTRY32W {
-        dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
-        ..Default::default()
-    };
-    // SAFETY: `entry` is a live, correctly sized `PROCESSENTRY32W`; `dwSize`
-    // is set as `Process32FirstW` requires.
-    let mut have_entry = unsafe { Process32FirstW(handle, &mut entry) } != 0;
-    let mut entries = Vec::new();
-    while have_entry {
-        entries.push(ProcessEntry {
-            pid: entry.th32ProcessID,
-            parent: entry.th32ParentProcessID,
-            exe: executable_name(&entry.szExeFile),
-        });
-        // SAFETY: same live `entry`; the snapshot handle stays valid until the
-        // `CloseHandle` below.
-        have_entry = unsafe { Process32NextW(handle, &mut entry) } != 0;
-    }
-    // SAFETY: `handle` came from `CreateToolhelp32Snapshot` and is not used
-    // after this point.
     unsafe {
-        let _ = CloseHandle(handle);
-    }
-    Some(entries)
-}
-
-/// `szExeFile` is a fixed 260-wide buffer holding a NUL-terminated base name;
-/// decoding the whole array would append the padding.
-pub(super) fn executable_name(raw: &[u16; 260]) -> String {
-    let end = raw.iter().position(|&unit| unit == 0).unwrap_or(raw.len());
-    String::from_utf16_lossy(&raw[..end])
-}
-
-/// Whether a snapshot's base name is `git`. Windows file names are
-/// case-insensitive and the executable carries an extension, so the unix
-/// path's exact `"git"` comparison would count zero every time and quietly
-/// change `repair_kill_debris`'s refusal behavior (it aborts a conflict
-/// sentinel only when `killed_git > 0`).
-pub(super) fn is_git_executable(name: &str) -> bool {
-    let lowered = name.to_ascii_lowercase();
-    lowered == "git.exe" || lowered == "git"
-}
-
-/// The `(total, git)` census over an already-enumerated pass, taken BEFORE
-/// anything is signaled for the same reason the unix path does it: counting
-/// afterwards undercounts exactly the processes that died fastest.
-pub(super) fn census(entries: &[ProcessEntry]) -> (usize, usize) {
-    let git = entries
-        .iter()
-        .filter(|entry| is_git_executable(&entry.exe))
-        .count();
-    (entries.len(), git)
-}
-
-/// The set of pids belonging to one target tree, carried ACROSS enumeration
-/// passes.
-///
-/// Re-deriving the tree from the root every pass would lose every survivor
-/// the moment the root died, because Windows leaves an orphan's
-/// `th32ParentProcessID` pointing at the freed pid instead of re-parenting
-/// it. Remembering the set instead is also what makes re-signaling safe: a
-/// tracked pid that disappears from a snapshot is RETIRED and never trusted
-/// again, so if Windows recycles that number for an unrelated process we
-/// neither terminate it nor adopt its children.
-pub(super) struct TreeTracker {
-    tracked: HashSet<u32>,
-    retired: HashSet<u32>,
-    self_pid: u32,
-}
-
-impl TreeTracker {
-    pub(super) fn new(root: u32, self_pid: u32) -> Self {
-        let mut tracked = HashSet::new();
-        tracked.insert(root);
-        Self {
-            tracked,
-            retired: HashSet::new(),
-            self_pid,
+        let handle = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+        if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+            return Err(GetLastError());
         }
-    }
-
-    /// Take a fresh snapshot and fold it in. `None` means the snapshot
-    /// failed, which is NOT the same as an empty tree.
-    fn refresh(&mut self) -> Option<Vec<ProcessEntry>> {
-        let snapshot = snapshot_processes()?;
-        Some(self.absorb(&snapshot))
-    }
-
-    /// The pure half of [`Self::refresh`]: retire what vanished, adopt any
-    /// new descendant of a still-tracked member, and return the tracked
-    /// processes this snapshot still lists, ordered root-first.
-    pub(super) fn absorb(&mut self, snapshot: &[ProcessEntry]) -> Vec<ProcessEntry> {
-        let live: HashSet<u32> = snapshot.iter().map(|entry| entry.pid).collect();
-        let vanished: Vec<u32> = self
-            .tracked
-            .iter()
-            .copied()
-            .filter(|pid| !live.contains(pid))
-            .collect();
-        for pid in vanished {
-            self.tracked.remove(&pid);
-            self.retired.insert(pid);
+        let mut entry = PROCESSENTRY32W {
+            dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+            ..Default::default()
+        };
+        // The enumeration START can fail too. Reading that as an empty table
+        // would drop the whole tree and report a live tree dead.
+        if Process32FirstW(handle, &mut entry) == 0 {
+            let code = GetLastError();
+            let _ = CloseHandle(handle);
+            return Err(code);
         }
-
-        // Grow to a fixpoint rather than in one sweep: a snapshot may list a
-        // grandchild before the child that adopts it into the set.
+        let mut entries = Vec::new();
         loop {
-            let mut grew = false;
-            for entry in snapshot {
-                // pid 0 is the idle process and is every unparented row's
-                // "parent"; letting it into the set would sweep the machine.
-                if entry.pid == 0 || entry.pid == self.self_pid {
-                    continue;
-                }
-                if entry.parent == entry.pid || self.retired.contains(&entry.pid) {
-                    continue;
-                }
-                if self.tracked.contains(&entry.parent) && self.tracked.insert(entry.pid) {
-                    grew = true;
-                }
-            }
-            if !grew {
+            entries.push(ProcessEntry {
+                pid: entry.th32ProcessID,
+                parent: entry.th32ParentProcessID,
+                exe: executable_name(&entry.szExeFile),
+            });
+            if Process32NextW(handle, &mut entry) == 0 {
                 break;
             }
         }
-
-        let parents: HashMap<u32, u32> = snapshot
-            .iter()
-            .map(|entry| (entry.pid, entry.parent))
-            .collect();
-        let mut alive: Vec<ProcessEntry> = snapshot
-            .iter()
-            .filter(|entry| self.tracked.contains(&entry.pid))
-            .cloned()
-            .collect();
-        alive.sort_by_key(|entry| (self.depth_of(entry.pid, &parents), entry.pid));
-        alive
+        let _ = CloseHandle(handle);
+        Ok(entries)
     }
+}
 
-    /// Hops from `pid` up to the shallowest tracked ancestor. Used only to
-    /// order a pass; an unresolvable chain simply sorts shallow.
-    fn depth_of(&self, pid: u32, parents: &HashMap<u32, u32>) -> u32 {
-        let mut depth = 0;
-        let mut cursor = pid;
-        for _ in 0..DEPTH_LIMIT {
-            let Some(&parent) = parents.get(&cursor) else {
-                return depth;
-            };
-            if parent == cursor || !self.tracked.contains(&parent) {
-                return depth;
-            }
-            depth += 1;
-            cursor = parent;
+/// A process's creation time, or `None` when it cannot be read (the process
+/// is gone, or is not ours to open). Callers must treat `None` as "cannot
+/// prove this pid's identity" and refuse to act on it.
+fn process_creation_time(pid: u32) -> Option<Generation> {
+    if pid == 0 {
+        return None;
+    }
+    // SAFETY: `OpenProcess` validates the pid and returns NULL on failure;
+    // the handle is closed on the one path that obtains it. The four
+    // `FILETIME` out-params are live locals for the duration of the call.
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return None;
         }
-        depth
+        let mut created = FILETIME::default();
+        let mut exited = FILETIME::default();
+        let mut kernel = FILETIME::default();
+        let mut user = FILETIME::default();
+        let ok = GetProcessTimes(handle, &mut created, &mut exited, &mut kernel, &mut user);
+        let _ = CloseHandle(handle);
+        if ok == 0 {
+            return None;
+        }
+        Some(((created.dwHighDateTime as u64) << 32) | created.dwLowDateTime as u64)
     }
+}
+
+/// One enumeration pass folded into `tracker`. `None` means the enumeration
+/// failed, which is NOT the same as an empty tree.
+fn refresh(tracker: &mut TreeTracker) -> Option<Vec<ProcessEntry>> {
+    let snapshot = snapshot_processes()?;
+    // Creation times cost an `OpenProcess` each, so they are resolved only
+    // for the pids that need proving and memoized within the pass.
+    let mut memo: HashMap<u32, Option<Generation>> = HashMap::new();
+    let mut created_at = |pid: u32| -> Option<Generation> {
+        *memo
+            .entry(pid)
+            .or_insert_with(|| process_creation_time(pid))
+    };
+    Some(tracker.absorb(&snapshot, &mut created_at))
 }
 
 /// Terminate one pid. A handle we cannot open means the process is already
@@ -259,8 +202,7 @@ fn terminate(pid: u32) {
 }
 
 /// Deepest-first, so a parent shell outlives the children it would otherwise
-/// be able to notice dying. `entries` arrives root-first from
-/// [`TreeTracker::absorb`].
+/// be able to notice dying. `entries` arrives root-first from the tracker.
 fn terminate_pass(entries: &[ProcessEntry]) {
     for entry in entries.iter().rev() {
         terminate(entry.pid);
@@ -273,17 +215,17 @@ fn terminate_pass(entries: &[ProcessEntry]) {
 /// than a fixed cost: a tree that dies immediately must not burn the window a
 /// plane holding several targets needs to fit R4's 8s `QUIESCE_DEADLINE`.
 ///
-/// A failed snapshot is logged and retried, never read as "empty" - reading
-/// it as empty would reintroduce the false quiescence this module removes.
+/// A failed enumeration is retried and never read as "empty" - reading it as
+/// empty would reintroduce the false quiescence this module removes.
 async fn wait_until_empty_within(tracker: &mut TreeTracker, budget: Duration, root: u32) -> bool {
     let deadline = tokio::time::Instant::now() + budget;
     loop {
-        match tracker.refresh() {
+        match refresh(tracker) {
             Some(remaining) if remaining.is_empty() => return true,
             Some(_) => {}
             None => tracing::warn!(
                 root,
-                "process_kill: a confirmation snapshot failed; the tree may still be alive"
+                "process_kill: a confirmation enumeration failed; the tree may still be alive"
             ),
         }
         if tokio::time::Instant::now() >= deadline {
@@ -295,16 +237,18 @@ async fn wait_until_empty_within(tracker: &mut TreeTracker, budget: Duration, ro
 
 /// Kill the process tree rooted at `root` and await its confirmed death.
 ///
-/// Contract-identical to the unix [`super::kill_group_and_await`]: returns
-/// the `(total, git)` census taken over the tree BEFORE anything is
-/// terminated, `(0, 0)` means nothing was running, the escalation runs on a
-/// DETACHED task so a dropped or timed-out caller future can never strand a
-/// half-killed tree, and `GRACE` is a deadline rather than a fixed cost so a
-/// tree that dies immediately resolves the call in milliseconds.
+/// Returns the `(total, git)` census taken over the tree BEFORE anything is
+/// terminated, `(0, 0)` means nothing was running, and the escalation runs on
+/// a DETACHED task so a dropped or timed-out caller future can never strand a
+/// half-killed tree - all as on unix. `GRACE` is a deadline, not a fixed
+/// cost. See this module's header for the two places the Windows contract is
+/// genuinely WEAKER than unix's: the pass is not atomic against a tree that
+/// grows mid-kill, and an adoption whose identity cannot be proven is
+/// refused.
 ///
 /// The one thing it cannot report through this signature is an enumeration
-/// failure, so a failed snapshot is logged at ERROR rather than folded into
-/// the `(0, 0)` that means success.
+/// failure, so a failed enumeration is retried and then logged at ERROR
+/// rather than folded into the `(0, 0)` that means success.
 pub async fn kill_tree_and_await(root: i32) -> (usize, usize) {
     if root <= 0 {
         return (0, 0);
@@ -320,11 +264,22 @@ pub async fn kill_tree_and_await(root: i32) -> (usize, usize) {
         return (0, 0);
     }
 
-    let mut tracker = TreeTracker::new(root, self_pid);
-    let Some(initial) = tracker.refresh() else {
+    // Read the root's identity BEFORE anything is killed. Without it no
+    // adoption can be proven and the kill degrades to the root alone.
+    let root_generation = process_creation_time(root);
+    if root_generation.is_none() {
+        tracing::warn!(
+            root,
+            "process_kill: could not read the root's creation time; descendants cannot be \
+             proven and will NOT be killed"
+        );
+    }
+
+    let mut tracker = TreeTracker::new(root, root_generation, self_pid);
+    let Some(initial) = refresh(&mut tracker) else {
         tracing::error!(
             root,
-            "process_kill: the Windows process snapshot failed; the tree was NOT killed"
+            "process_kill: the Windows process enumeration failed; the tree was NOT killed"
         );
         return (0, 0);
     };
@@ -340,10 +295,10 @@ pub async fn kill_tree_and_await(root: i32) -> (usize, usize) {
         }
         let deadline = tokio::time::Instant::now() + CONFIRM_BUDGET;
         loop {
-            let Some(remaining) = tracker.refresh() else {
+            let Some(remaining) = refresh(&mut tracker) else {
                 tracing::warn!(
                     root,
-                    "process_kill: a confirmation snapshot failed; the tree may still be alive"
+                    "process_kill: a confirmation enumeration failed; the tree may still be alive"
                 );
                 if tokio::time::Instant::now() >= deadline {
                     return;
@@ -373,112 +328,4 @@ pub async fn kill_tree_and_await(root: i32) -> (usize, usize) {
     });
     let _ = escalation.await;
     counted
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn entry(pid: u32, parent: u32, exe: &str) -> ProcessEntry {
-        ProcessEntry {
-            pid,
-            parent,
-            exe: exe.to_string(),
-        }
-    }
-
-    #[test]
-    fn executable_name_stops_at_the_nul_terminator() {
-        let mut raw = [0u16; 260];
-        for (slot, unit) in raw.iter_mut().zip("git.exe".encode_utf16()) {
-            *slot = unit;
-        }
-        assert_eq!(executable_name(&raw), "git.exe");
-    }
-
-    #[test]
-    fn git_census_matches_the_windows_executable_name() {
-        // The unix path compares against a bare "git"; on Windows that would
-        // count zero forever and silently change archive's refusal behavior.
-        assert!(is_git_executable("git.exe"));
-        assert!(is_git_executable("GIT.EXE"));
-        assert!(!is_git_executable("gitk.exe"));
-        assert!(!is_git_executable("legit.exe"));
-    }
-
-    #[test]
-    fn absorb_collects_the_whole_descendant_tree() {
-        let snapshot = vec![
-            entry(1, 0, "System.exe"),
-            entry(400, 1, "unrelated.exe"),
-            entry(100, 1, "agent.exe"),
-            entry(300, 200, "git.exe"),
-            entry(200, 100, "cmd.exe"),
-        ];
-        let mut tracker = TreeTracker::new(100, 9999);
-        let alive = tracker.absorb(&snapshot);
-        let pids: Vec<u32> = alive.iter().map(|entry| entry.pid).collect();
-        // Root first, then each generation: the pass is terminated in
-        // reverse, so the grandchild dies before the shell that owns it.
-        assert_eq!(pids, vec![100, 200, 300]);
-        assert_eq!(census(&alive), (3, 1));
-    }
-
-    #[test]
-    fn absorb_never_adopts_the_runtimes_own_process() {
-        let snapshot = vec![
-            entry(100, 1, "agent.exe"),
-            entry(9999, 100, "anyharness.exe"),
-        ];
-        let mut tracker = TreeTracker::new(100, 9999);
-        let pids: Vec<u32> = tracker
-            .absorb(&snapshot)
-            .iter()
-            .map(|entry| entry.pid)
-            .collect();
-        assert_eq!(pids, vec![100]);
-    }
-
-    #[test]
-    fn a_retired_pid_is_never_readopted_when_windows_recycles_it() {
-        let mut tracker = TreeTracker::new(100, 9999);
-        tracker.absorb(&[entry(100, 1, "agent.exe"), entry(200, 100, "cmd.exe")]);
-        // The whole tree dies.
-        assert!(tracker.absorb(&[entry(1, 0, "System.exe")]).is_empty());
-        // Windows hands pid 200 to something unrelated, which spawns a child.
-        let recycled = vec![
-            entry(1, 0, "System.exe"),
-            entry(200, 1, "notepad.exe"),
-            entry(201, 200, "innocent.exe"),
-        ];
-        assert!(tracker.absorb(&recycled).is_empty());
-    }
-
-    #[test]
-    fn absorb_adopts_descendants_started_after_the_first_pass() {
-        let mut tracker = TreeTracker::new(100, 9999);
-        tracker.absorb(&[entry(100, 1, "agent.exe")]);
-        let later = vec![
-            entry(100, 1, "agent.exe"),
-            entry(250, 240, "git.exe"),
-            entry(240, 100, "sh.exe"),
-        ];
-        let pids: Vec<u32> = tracker.absorb(&later).iter().map(|e| e.pid).collect();
-        assert_eq!(pids, vec![100, 240, 250]);
-    }
-
-    #[test]
-    fn absorb_terminates_on_a_parent_cycle() {
-        // Only reachable through pid reuse, but a cycle must not hang the
-        // ordering walk.
-        let snapshot = vec![
-            entry(100, 1, "agent.exe"),
-            entry(200, 100, "a.exe"),
-            entry(210, 220, "b.exe"),
-            entry(220, 210, "c.exe"),
-        ];
-        let mut tracker = TreeTracker::new(100, 9999);
-        let pids: Vec<u32> = tracker.absorb(&snapshot).iter().map(|e| e.pid).collect();
-        assert_eq!(pids, vec![100, 200]);
-    }
 }

--- a/anyharness/crates/anyharness-lib/src/process_kill_windows.rs
+++ b/anyharness/crates/anyharness-lib/src/process_kill_windows.rs
@@ -1,0 +1,484 @@
+//! The Windows half of [`crate::process_kill`]: a descendant-tree walk over a
+//! Toolhelp snapshot, standing in for the unix process-group and session
+//! enumeration.
+//!
+//! Windows has neither process groups nor sessions in the POSIX sense, so
+//! there is no id a caller could hand us that names a set of processes. What
+//! every caller of [`super::kill_group_and_await`] and
+//! [`super::kill_session_and_await`] actually passes on Windows is the direct
+//! child's own pid: the session actor passes `self.child.id()`
+//! (`live/sessions/actor/run.rs`), the setup/archive runs pass the pid they
+//! stored at spawn (`live/terminals/command_runs/setup_process.rs`), and the
+//! terminal close path passes the PTY child's `process_id()`
+//! (`live/terminals/command_runs/workspace_stop.rs`). The `process_group(0)`
+//! calls at those spawn sites are all `#[cfg(unix)]`, so on Windows the
+//! integer is only ever a plain pid. This module therefore reads it as the
+//! ROOT of a process tree and reaches the descendants by walking
+//! `th32ParentProcessID` - the same two-phase "enumerate the whole target,
+//! census it, then act on it" structure the unix path uses, with
+//! `CreateToolhelp32Snapshot` in the place of libproc and `/proc`.
+//!
+//! Two Windows facts shape the escalation, and both are behavioral
+//! differences from unix that callers should know about:
+//!
+//! 1. There is no portable graceful signal. `TerminateProcess` is
+//!    unconditional, so it is the equivalent of `SIGKILL`, not `SIGTERM`. A
+//!    graceful first rung would need `GenerateConsoleCtrlEvent`, which only
+//!    works against a group created with `CREATE_NEW_PROCESS_GROUP` at spawn
+//!    and only for console processes sharing our console. No spawn site sets
+//!    that today, so the TERM rung is not available and the ladder starts at
+//!    the unconditional rung. `GRACE` is still honored as the deadline for
+//!    the OS to finish tearing the tree down before survivors are retried.
+//!
+//! 2. Windows does not re-parent orphans; `th32ParentProcessID` simply keeps
+//!    pointing at a pid that no longer exists and may be recycled. Killing
+//!    the root first would therefore make its surviving children unreachable
+//!    on the next enumeration pass. [`TreeTracker`] fixes that by REMEMBERING
+//!    the tree across passes rather than re-deriving it from the root each
+//!    time, and terminating deepest-first so the parent outlives its children.
+
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
+
+use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+    CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W, TH32CS_SNAPPROCESS,
+};
+use windows_sys::Win32::System::Threading::{
+    GetCurrentProcessId, OpenProcess, TerminateProcess, PROCESS_TERMINATE,
+};
+
+use super::{CONFIRM_BUDGET, CONFIRM_POLL, GRACE};
+
+/// Cap on the parent-chain walk that orders a pass deepest-first. A snapshot
+/// whose parent links form a cycle (only reachable through pid reuse) must
+/// not spin forever.
+const DEPTH_LIMIT: u32 = 64;
+
+/// The exit code a terminated member reports. Nonzero so a caller reading the
+/// child's status cannot mistake a kill for a clean exit.
+const KILL_EXIT_CODE: u32 = 1;
+
+/// One row of a Toolhelp process snapshot. The base executable name comes
+/// back in the same read as the parent link, so unlike the unix path the
+/// `git` census costs no extra per-pid syscall.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ProcessEntry {
+    pub(super) pid: u32,
+    pub(super) parent: u32,
+    pub(super) exe: String,
+}
+
+/// Every live process on the system, or `None` when the snapshot itself
+/// failed. The distinction is the whole point: an empty `Vec` means "nothing
+/// is running", and folding a failed enumeration into that is exactly the
+/// silent lie this module exists to remove.
+fn snapshot_processes() -> Option<Vec<ProcessEntry>> {
+    // SAFETY: a kernel32 read of the running process table. The handle is
+    // checked against both failure encodings before use and closed on every
+    // exit path below.
+    let handle = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
+    if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+        return None;
+    }
+    let mut entry = PROCESSENTRY32W {
+        dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+        ..Default::default()
+    };
+    // SAFETY: `entry` is a live, correctly sized `PROCESSENTRY32W`; `dwSize`
+    // is set as `Process32FirstW` requires.
+    let mut have_entry = unsafe { Process32FirstW(handle, &mut entry) } != 0;
+    let mut entries = Vec::new();
+    while have_entry {
+        entries.push(ProcessEntry {
+            pid: entry.th32ProcessID,
+            parent: entry.th32ParentProcessID,
+            exe: executable_name(&entry.szExeFile),
+        });
+        // SAFETY: same live `entry`; the snapshot handle stays valid until the
+        // `CloseHandle` below.
+        have_entry = unsafe { Process32NextW(handle, &mut entry) } != 0;
+    }
+    // SAFETY: `handle` came from `CreateToolhelp32Snapshot` and is not used
+    // after this point.
+    unsafe {
+        let _ = CloseHandle(handle);
+    }
+    Some(entries)
+}
+
+/// `szExeFile` is a fixed 260-wide buffer holding a NUL-terminated base name;
+/// decoding the whole array would append the padding.
+pub(super) fn executable_name(raw: &[u16; 260]) -> String {
+    let end = raw.iter().position(|&unit| unit == 0).unwrap_or(raw.len());
+    String::from_utf16_lossy(&raw[..end])
+}
+
+/// Whether a snapshot's base name is `git`. Windows file names are
+/// case-insensitive and the executable carries an extension, so the unix
+/// path's exact `"git"` comparison would count zero every time and quietly
+/// change `repair_kill_debris`'s refusal behavior (it aborts a conflict
+/// sentinel only when `killed_git > 0`).
+pub(super) fn is_git_executable(name: &str) -> bool {
+    let lowered = name.to_ascii_lowercase();
+    lowered == "git.exe" || lowered == "git"
+}
+
+/// The `(total, git)` census over an already-enumerated pass, taken BEFORE
+/// anything is signaled for the same reason the unix path does it: counting
+/// afterwards undercounts exactly the processes that died fastest.
+pub(super) fn census(entries: &[ProcessEntry]) -> (usize, usize) {
+    let git = entries
+        .iter()
+        .filter(|entry| is_git_executable(&entry.exe))
+        .count();
+    (entries.len(), git)
+}
+
+/// The set of pids belonging to one target tree, carried ACROSS enumeration
+/// passes.
+///
+/// Re-deriving the tree from the root every pass would lose every survivor
+/// the moment the root died, because Windows leaves an orphan's
+/// `th32ParentProcessID` pointing at the freed pid instead of re-parenting
+/// it. Remembering the set instead is also what makes re-signaling safe: a
+/// tracked pid that disappears from a snapshot is RETIRED and never trusted
+/// again, so if Windows recycles that number for an unrelated process we
+/// neither terminate it nor adopt its children.
+pub(super) struct TreeTracker {
+    tracked: HashSet<u32>,
+    retired: HashSet<u32>,
+    self_pid: u32,
+}
+
+impl TreeTracker {
+    pub(super) fn new(root: u32, self_pid: u32) -> Self {
+        let mut tracked = HashSet::new();
+        tracked.insert(root);
+        Self {
+            tracked,
+            retired: HashSet::new(),
+            self_pid,
+        }
+    }
+
+    /// Take a fresh snapshot and fold it in. `None` means the snapshot
+    /// failed, which is NOT the same as an empty tree.
+    fn refresh(&mut self) -> Option<Vec<ProcessEntry>> {
+        let snapshot = snapshot_processes()?;
+        Some(self.absorb(&snapshot))
+    }
+
+    /// The pure half of [`Self::refresh`]: retire what vanished, adopt any
+    /// new descendant of a still-tracked member, and return the tracked
+    /// processes this snapshot still lists, ordered root-first.
+    pub(super) fn absorb(&mut self, snapshot: &[ProcessEntry]) -> Vec<ProcessEntry> {
+        let live: HashSet<u32> = snapshot.iter().map(|entry| entry.pid).collect();
+        let vanished: Vec<u32> = self
+            .tracked
+            .iter()
+            .copied()
+            .filter(|pid| !live.contains(pid))
+            .collect();
+        for pid in vanished {
+            self.tracked.remove(&pid);
+            self.retired.insert(pid);
+        }
+
+        // Grow to a fixpoint rather than in one sweep: a snapshot may list a
+        // grandchild before the child that adopts it into the set.
+        loop {
+            let mut grew = false;
+            for entry in snapshot {
+                // pid 0 is the idle process and is every unparented row's
+                // "parent"; letting it into the set would sweep the machine.
+                if entry.pid == 0 || entry.pid == self.self_pid {
+                    continue;
+                }
+                if entry.parent == entry.pid || self.retired.contains(&entry.pid) {
+                    continue;
+                }
+                if self.tracked.contains(&entry.parent) && self.tracked.insert(entry.pid) {
+                    grew = true;
+                }
+            }
+            if !grew {
+                break;
+            }
+        }
+
+        let parents: HashMap<u32, u32> = snapshot
+            .iter()
+            .map(|entry| (entry.pid, entry.parent))
+            .collect();
+        let mut alive: Vec<ProcessEntry> = snapshot
+            .iter()
+            .filter(|entry| self.tracked.contains(&entry.pid))
+            .cloned()
+            .collect();
+        alive.sort_by_key(|entry| (self.depth_of(entry.pid, &parents), entry.pid));
+        alive
+    }
+
+    /// Hops from `pid` up to the shallowest tracked ancestor. Used only to
+    /// order a pass; an unresolvable chain simply sorts shallow.
+    fn depth_of(&self, pid: u32, parents: &HashMap<u32, u32>) -> u32 {
+        let mut depth = 0;
+        let mut cursor = pid;
+        for _ in 0..DEPTH_LIMIT {
+            let Some(&parent) = parents.get(&cursor) else {
+                return depth;
+            };
+            if parent == cursor || !self.tracked.contains(&parent) {
+                return depth;
+            }
+            depth += 1;
+            cursor = parent;
+        }
+        depth
+    }
+}
+
+/// Terminate one pid. A handle we cannot open means the process is already
+/// gone or is not ours to kill; neither is actionable here, exactly as the
+/// unix path ignores a failed `kill`.
+fn terminate(pid: u32) {
+    if pid == 0 {
+        return;
+    }
+    // SAFETY: `OpenProcess` validates the pid itself and returns NULL on
+    // failure; the handle is closed on the one path that obtains it.
+    unsafe {
+        let handle = OpenProcess(PROCESS_TERMINATE, 0, pid);
+        if handle.is_null() {
+            return;
+        }
+        let _ = TerminateProcess(handle, KILL_EXIT_CODE);
+        let _ = CloseHandle(handle);
+    }
+}
+
+/// Deepest-first, so a parent shell outlives the children it would otherwise
+/// be able to notice dying. `entries` arrives root-first from
+/// [`TreeTracker::absorb`].
+fn terminate_pass(entries: &[ProcessEntry]) {
+    for entry in entries.iter().rev() {
+        terminate(entry.pid);
+    }
+}
+
+/// Polls the tracker until it reports nothing alive or `budget` elapses,
+/// returning `true` when the tree emptied inside the budget. The unix
+/// counterpart's early exit is the whole reason `GRACE` is a deadline rather
+/// than a fixed cost: a tree that dies immediately must not burn the window a
+/// plane holding several targets needs to fit R4's 8s `QUIESCE_DEADLINE`.
+///
+/// A failed snapshot is logged and retried, never read as "empty" - reading
+/// it as empty would reintroduce the false quiescence this module removes.
+async fn wait_until_empty_within(tracker: &mut TreeTracker, budget: Duration, root: u32) -> bool {
+    let deadline = tokio::time::Instant::now() + budget;
+    loop {
+        match tracker.refresh() {
+            Some(remaining) if remaining.is_empty() => return true,
+            Some(_) => {}
+            None => tracing::warn!(
+                root,
+                "process_kill: a confirmation snapshot failed; the tree may still be alive"
+            ),
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(CONFIRM_POLL).await;
+    }
+}
+
+/// Kill the process tree rooted at `root` and await its confirmed death.
+///
+/// Contract-identical to the unix [`super::kill_group_and_await`]: returns
+/// the `(total, git)` census taken over the tree BEFORE anything is
+/// terminated, `(0, 0)` means nothing was running, the escalation runs on a
+/// DETACHED task so a dropped or timed-out caller future can never strand a
+/// half-killed tree, and `GRACE` is a deadline rather than a fixed cost so a
+/// tree that dies immediately resolves the call in milliseconds.
+///
+/// The one thing it cannot report through this signature is an enumeration
+/// failure, so a failed snapshot is logged at ERROR rather than folded into
+/// the `(0, 0)` that means success.
+pub async fn kill_tree_and_await(root: i32) -> (usize, usize) {
+    if root <= 0 {
+        return (0, 0);
+    }
+    let root = root as u32;
+    // SAFETY: a parameterless kernel32 read of our own pid.
+    let self_pid = unsafe { GetCurrentProcessId() };
+    if root == self_pid {
+        tracing::error!(
+            root,
+            "process_kill: refusing to kill the runtime's own process tree"
+        );
+        return (0, 0);
+    }
+
+    let mut tracker = TreeTracker::new(root, self_pid);
+    let Some(initial) = tracker.refresh() else {
+        tracing::error!(
+            root,
+            "process_kill: the Windows process snapshot failed; the tree was NOT killed"
+        );
+        return (0, 0);
+    };
+    let counted = census(&initial);
+    if counted.0 == 0 {
+        return counted;
+    }
+    terminate_pass(&initial);
+
+    let escalation = tokio::spawn(async move {
+        if wait_until_empty_within(&mut tracker, GRACE, root).await {
+            return;
+        }
+        let deadline = tokio::time::Instant::now() + CONFIRM_BUDGET;
+        loop {
+            let Some(remaining) = tracker.refresh() else {
+                tracing::warn!(
+                    root,
+                    "process_kill: a confirmation snapshot failed; the tree may still be alive"
+                );
+                if tokio::time::Instant::now() >= deadline {
+                    return;
+                }
+                tokio::time::sleep(CONFIRM_POLL).await;
+                continue;
+            };
+            if remaining.is_empty() {
+                return;
+            }
+            // Survivors past the grace deadline are either processes the first
+            // pass could not open or descendants started since it ran, so this
+            // re-enumerates and re-terminates every iteration rather than
+            // terminating once - the same reason the unix session loop
+            // re-signals every distinct group on every pass.
+            terminate_pass(&remaining);
+            if tokio::time::Instant::now() >= deadline {
+                tracing::warn!(
+                    root,
+                    remaining = remaining.len(),
+                    "process_kill: confirmation budget exceeded; tree may still be alive"
+                );
+                return;
+            }
+            tokio::time::sleep(CONFIRM_POLL).await;
+        }
+    });
+    let _ = escalation.await;
+    counted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(pid: u32, parent: u32, exe: &str) -> ProcessEntry {
+        ProcessEntry {
+            pid,
+            parent,
+            exe: exe.to_string(),
+        }
+    }
+
+    #[test]
+    fn executable_name_stops_at_the_nul_terminator() {
+        let mut raw = [0u16; 260];
+        for (slot, unit) in raw.iter_mut().zip("git.exe".encode_utf16()) {
+            *slot = unit;
+        }
+        assert_eq!(executable_name(&raw), "git.exe");
+    }
+
+    #[test]
+    fn git_census_matches_the_windows_executable_name() {
+        // The unix path compares against a bare "git"; on Windows that would
+        // count zero forever and silently change archive's refusal behavior.
+        assert!(is_git_executable("git.exe"));
+        assert!(is_git_executable("GIT.EXE"));
+        assert!(!is_git_executable("gitk.exe"));
+        assert!(!is_git_executable("legit.exe"));
+    }
+
+    #[test]
+    fn absorb_collects_the_whole_descendant_tree() {
+        let snapshot = vec![
+            entry(1, 0, "System.exe"),
+            entry(400, 1, "unrelated.exe"),
+            entry(100, 1, "agent.exe"),
+            entry(300, 200, "git.exe"),
+            entry(200, 100, "cmd.exe"),
+        ];
+        let mut tracker = TreeTracker::new(100, 9999);
+        let alive = tracker.absorb(&snapshot);
+        let pids: Vec<u32> = alive.iter().map(|entry| entry.pid).collect();
+        // Root first, then each generation: the pass is terminated in
+        // reverse, so the grandchild dies before the shell that owns it.
+        assert_eq!(pids, vec![100, 200, 300]);
+        assert_eq!(census(&alive), (3, 1));
+    }
+
+    #[test]
+    fn absorb_never_adopts_the_runtimes_own_process() {
+        let snapshot = vec![
+            entry(100, 1, "agent.exe"),
+            entry(9999, 100, "anyharness.exe"),
+        ];
+        let mut tracker = TreeTracker::new(100, 9999);
+        let pids: Vec<u32> = tracker
+            .absorb(&snapshot)
+            .iter()
+            .map(|entry| entry.pid)
+            .collect();
+        assert_eq!(pids, vec![100]);
+    }
+
+    #[test]
+    fn a_retired_pid_is_never_readopted_when_windows_recycles_it() {
+        let mut tracker = TreeTracker::new(100, 9999);
+        tracker.absorb(&[entry(100, 1, "agent.exe"), entry(200, 100, "cmd.exe")]);
+        // The whole tree dies.
+        assert!(tracker.absorb(&[entry(1, 0, "System.exe")]).is_empty());
+        // Windows hands pid 200 to something unrelated, which spawns a child.
+        let recycled = vec![
+            entry(1, 0, "System.exe"),
+            entry(200, 1, "notepad.exe"),
+            entry(201, 200, "innocent.exe"),
+        ];
+        assert!(tracker.absorb(&recycled).is_empty());
+    }
+
+    #[test]
+    fn absorb_adopts_descendants_started_after_the_first_pass() {
+        let mut tracker = TreeTracker::new(100, 9999);
+        tracker.absorb(&[entry(100, 1, "agent.exe")]);
+        let later = vec![
+            entry(100, 1, "agent.exe"),
+            entry(250, 240, "git.exe"),
+            entry(240, 100, "sh.exe"),
+        ];
+        let pids: Vec<u32> = tracker.absorb(&later).iter().map(|e| e.pid).collect();
+        assert_eq!(pids, vec![100, 240, 250]);
+    }
+
+    #[test]
+    fn absorb_terminates_on_a_parent_cycle() {
+        // Only reachable through pid reuse, but a cycle must not hang the
+        // ordering walk.
+        let snapshot = vec![
+            entry(100, 1, "agent.exe"),
+            entry(200, 100, "a.exe"),
+            entry(210, 220, "b.exe"),
+            entry(220, 210, "c.exe"),
+        ];
+        let mut tracker = TreeTracker::new(100, 9999);
+        let pids: Vec<u32> = tracker.absorb(&snapshot).iter().map(|e| e.pid).collect();
+        assert_eq!(pids, vec![100, 200]);
+    }
+}

--- a/anyharness/crates/anyharness-lib/tests/windows_process_tree.rs
+++ b/anyharness/crates/anyharness-lib/tests/windows_process_tree.rs
@@ -196,6 +196,12 @@ async fn the_census_counts_a_real_git_exe_grandchild() {
     // independent oracle: every git process in the tree is named `git.exe`,
     // never a bare `git`. The unix path's exact `"git"` comparison would
     // therefore have counted ZERO here while looking entirely correct.
+    //
+    // `Win32_Process.Name` is deliberately the field read here: it is the
+    // same base image name that `szExeFile` carries into the census, so this
+    // control compares the string the code actually matches on rather than a
+    // differently-derived one (`Get-Process`'s `ProcessName`, for instance,
+    // strips the extension and would hide the whole defect).
     let tree = descendants_of(root_pid);
     let git_names: Vec<String> = tree
         .iter()
@@ -212,15 +218,17 @@ async fn the_census_counts_a_real_git_exe_grandchild() {
     );
 
     let (total, git) = kill_group_and_await(root_pid as i32).await;
-    // NOT `== 1`. Git for Windows resolves `git` to a shim in `cmd\git.exe`
-    // that launches the real `git.exe` from `mingw64\bin`, so a single `git`
-    // invocation is two `git.exe` processes and this tree is three deep. The
-    // load-bearing claim is that the count is NONZERO, because that is exactly
-    // what R2's `repair_kill_debris` branches on (`killed_git > 0`); an exact
-    // `"git"` comparison would have made it zero forever.
-    assert!(
-        git >= 1,
-        "the census counted {git} git processes out of {total}; the real git.exe at pid {git_pid} must be recognised (oracle saw {git_names:?})"
+    // Not a hardcoded count: Git for Windows resolves `git` to a shim in
+    // `cmd\git.exe` that launches the real `git.exe` from `mingw64\bin`, so a
+    // single `git` invocation is two `git.exe` processes and this tree is
+    // three deep. Asserted against the oracle's own tally rather than a floor,
+    // so this catches OVER-matching (a census that counted `gitk.exe` or the
+    // shell) as well as under-matching.
+    assert_eq!(
+        git,
+        git_names.len(),
+        "the census counted {git} git processes out of {total}, but the CIM oracle saw {} ({git_names:?}); the real git.exe at pid {git_pid} must be recognised exactly once each",
+        git_names.len()
     );
     assert!(
         total >= 2,

--- a/anyharness/crates/anyharness-lib/tests/windows_process_tree.rs
+++ b/anyharness/crates/anyharness-lib/tests/windows_process_tree.rs
@@ -83,6 +83,30 @@ fn wait_for_children(pid: u32) -> Vec<(u32, String)> {
     }
 }
 
+/// The whole descendant tree of `pid` per the CIM process table. Git for
+/// Windows layers a shim, so "the git process" is not one process.
+fn descendants_of(pid: u32) -> Vec<(u32, String)> {
+    let mut found: Vec<(u32, String)> = Vec::new();
+    let mut frontier = vec![pid];
+    for _ in 0..8 {
+        let mut next = Vec::new();
+        for parent in frontier {
+            for (child, name) in children_of(parent) {
+                if found.iter().any(|(seen, _)| *seen == child) {
+                    continue;
+                }
+                found.push((child, name));
+                next.push(child);
+            }
+        }
+        if next.is_empty() {
+            break;
+        }
+        frontier = next;
+    }
+    found
+}
+
 fn wait_for_named_child(pid: u32, name: &str) -> Option<u32> {
     let deadline = Instant::now() + CHILD_START_BUDGET;
     loop {
@@ -168,10 +192,35 @@ async fn the_census_counts_a_real_git_exe_grandchild() {
     let git_pid = wait_for_named_child(root_pid, "git.exe")
         .unwrap_or_else(|| panic!("cmd.exe never started git.exe under pid {root_pid}"));
 
+    // The negative control for the whole point of this test, read from the
+    // independent oracle: every git process in the tree is named `git.exe`,
+    // never a bare `git`. The unix path's exact `"git"` comparison would
+    // therefore have counted ZERO here while looking entirely correct.
+    let tree = descendants_of(root_pid);
+    let git_names: Vec<String> = tree
+        .iter()
+        .map(|(_, name)| name.clone())
+        .filter(|name| name.to_ascii_lowercase().starts_with("git"))
+        .collect();
+    assert!(
+        !git_names.is_empty(),
+        "the CIM oracle saw no git process under pid {root_pid}; tree was {tree:?}"
+    );
+    assert!(
+        git_names.iter().all(|name| name != "git"),
+        "expected Windows-shaped names that an exact \"git\" comparison would miss, saw {git_names:?}"
+    );
+
     let (total, git) = kill_group_and_await(root_pid as i32).await;
-    assert_eq!(
-        git, 1,
-        "the census must recognise the real git.exe at pid {git_pid} as git; total was {total}"
+    // NOT `== 1`. Git for Windows resolves `git` to a shim in `cmd\git.exe`
+    // that launches the real `git.exe` from `mingw64\bin`, so a single `git`
+    // invocation is two `git.exe` processes and this tree is three deep. The
+    // load-bearing claim is that the count is NONZERO, because that is exactly
+    // what R2's `repair_kill_debris` branches on (`killed_git > 0`); an exact
+    // `"git"` comparison would have made it zero forever.
+    assert!(
+        git >= 1,
+        "the census counted {git} git processes out of {total}; the real git.exe at pid {git_pid} must be recognised (oracle saw {git_names:?})"
     );
     assert!(
         total >= 2,

--- a/anyharness/crates/anyharness-lib/tests/windows_process_tree.rs
+++ b/anyharness/crates/anyharness-lib/tests/windows_process_tree.rs
@@ -1,0 +1,187 @@
+//! Real-process proof for the Windows half of `process_kill`.
+//!
+//! Why this is an INTEGRATION test and not a `#[cfg(test)]` module next to the
+//! code it exercises: `anyharness-lib`'s `lib test` target does not build for
+//! `x86_64-pc-windows-msvc` today. `cargo check --all-targets` on Windows
+//! reports ten pre-existing errors, all of them test-only POSIX assumptions in
+//! unrelated modules (`std::os::unix` imports, `Permissions::from_mode`, and
+//! helpers behind `cfg(unix)` parents). A test filter does not help, because
+//! the whole test target still has to build. An integration test is compiled
+//! as its own crate against the library's PUBLIC surface, so it never pulls in
+//! those `#[cfg(test)]` modules and can run on Windows today without absorbing
+//! someone else's port into this change.
+//!
+//! What it buys: the unit tests inside `process_kill_windows.rs` cover the
+//! pure logic but cannot be compiled on Windows for the reason above, so
+//! without this file every line of `unsafe` FFI in that module would ship
+//! typechecked and never executed. These tests spawn REAL process trees and
+//! kill them through the real public entry point, which exercises
+//! `CreateToolhelp32Snapshot`, the `PROCESSENTRY32W` walk, `TreeTracker`, the
+//! census, `OpenProcess`/`TerminateProcess`, and the confirmation loop against
+//! the actual kernel.
+//!
+//! Every assertion is checked with an oracle INDEPENDENT of the code under
+//! test: `std::process::Child` for the direct child, and PowerShell's CIM
+//! process table for descendants. Asserting a Toolhelp walk against itself
+//! would prove nothing.
+
+#![cfg(windows)]
+
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use anyharness_lib::process_kill::kill_group_and_await;
+
+/// How long a spawned `cmd.exe` is given to start its own child.
+const CHILD_START_BUDGET: Duration = Duration::from_secs(20);
+const CHILD_POLL: Duration = Duration::from_millis(250);
+
+fn powershell(script: &str) -> String {
+    let output = Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", script])
+        .output()
+        .expect("run powershell");
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+/// The direct children of `pid` as `(pid, image name)`, read from the CIM
+/// process table rather than from the Toolhelp walk under test.
+fn children_of(pid: u32) -> Vec<(u32, String)> {
+    let script = format!(
+        "Get-CimInstance Win32_Process -Filter \"ParentProcessId={pid}\" | ForEach-Object {{ \"$($_.ProcessId) $($_.Name)\" }}"
+    );
+    powershell(&script)
+        .lines()
+        .filter_map(|line| {
+            let mut parts = line.trim().splitn(2, ' ');
+            let pid = parts.next()?.parse::<u32>().ok()?;
+            Some((pid, parts.next().unwrap_or_default().to_string()))
+        })
+        .collect()
+}
+
+fn pid_is_alive(pid: u32) -> bool {
+    let script = format!(
+        "if (Get-Process -Id {pid} -ErrorAction SilentlyContinue) {{ 'ALIVE' }} else {{ 'DEAD' }}"
+    );
+    powershell(&script) == "ALIVE"
+}
+
+/// Waits for `pid` to have at least one child, returning them. Spawning is not
+/// instant, so asserting immediately after `spawn()` would be a race.
+fn wait_for_children(pid: u32) -> Vec<(u32, String)> {
+    let deadline = Instant::now() + CHILD_START_BUDGET;
+    loop {
+        let children = children_of(pid);
+        if !children.is_empty() {
+            return children;
+        }
+        if Instant::now() >= deadline {
+            return Vec::new();
+        }
+        std::thread::sleep(CHILD_POLL);
+    }
+}
+
+fn wait_for_named_child(pid: u32, name: &str) -> Option<u32> {
+    let deadline = Instant::now() + CHILD_START_BUDGET;
+    loop {
+        if let Some((child, _)) = children_of(pid)
+            .into_iter()
+            .find(|(_, image)| image.eq_ignore_ascii_case(name))
+        {
+            return Some(child);
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        std::thread::sleep(CHILD_POLL);
+    }
+}
+
+/// The core claim this whole change exists to make true: a stop reaches the
+/// grandchild, not just the process we spawned. Before this change
+/// `kill_group_and_await` returned `(0, 0)` on Windows without touching
+/// anything, so this test would have failed on BOTH the census and the
+/// liveness assertion - which is the negative control for it.
+#[tokio::test]
+async fn kills_a_real_process_tree_including_the_grandchild() {
+    let mut root = Command::new("cmd.exe")
+        .args(["/c", "ping", "-n", "120", "127.0.0.1"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn cmd.exe");
+    let root_pid = root.id();
+
+    let children = wait_for_children(root_pid);
+    assert!(
+        !children.is_empty(),
+        "cmd.exe never started its ping.exe child, so there is no tree to prove anything about"
+    );
+    let (grandchild_pid, grandchild_name) = children[0].clone();
+
+    let (total, _git) = kill_group_and_await(root_pid as i32).await;
+    assert!(
+        total >= 2,
+        "the census counted {total}; it must include cmd.exe (pid {root_pid}) and its {grandchild_name} child (pid {grandchild_pid})"
+    );
+
+    // `Child::wait` is the OS's own answer about the direct child, entirely
+    // separate from the snapshot code under test.
+    let status = root.wait().expect("wait on cmd.exe");
+    assert!(
+        !status.success(),
+        "cmd.exe exited cleanly ({status:?}); it should have been terminated"
+    );
+    assert!(
+        !pid_is_alive(grandchild_pid),
+        "the {grandchild_name} grandchild (pid {grandchild_pid}) outlived the kill"
+    );
+}
+
+/// The `git` half of the census, against a REAL `git.exe`.
+///
+/// This is not a detail. `PlaneKills::git` is evidence, not telemetry: R2's
+/// `repair_kill_debris` aborts a conflict sentinel only when `killed_git > 0`.
+/// The unix enumeration compares the base name against exactly `"git"`, and on
+/// Windows the base name is `git.exe`, so reusing that comparison would have
+/// counted zero forever and silently changed a product decision while looking
+/// entirely correct.
+///
+/// `git stripspace` is a plumbing filter that needs no repository and blocks
+/// reading stdin, which keeps a genuine `git.exe` alive as a grandchild for as
+/// long as we hold the pipe open.
+#[tokio::test]
+async fn the_census_counts_a_real_git_exe_grandchild() {
+    let mut root = Command::new("cmd.exe")
+        .args(["/c", "git", "stripspace"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn cmd.exe");
+    let root_pid = root.id();
+    // Held, not dropped: closing this pipe would let git exit on EOF.
+    let stdin = root.stdin.take().expect("cmd.exe stdin");
+
+    let git_pid = wait_for_named_child(root_pid, "git.exe")
+        .unwrap_or_else(|| panic!("cmd.exe never started git.exe under pid {root_pid}"));
+
+    let (total, git) = kill_group_and_await(root_pid as i32).await;
+    assert_eq!(
+        git, 1,
+        "the census must recognise the real git.exe at pid {git_pid} as git; total was {total}"
+    );
+    assert!(
+        total >= 2,
+        "the census counted {total}; it must include cmd.exe and its git.exe child"
+    );
+
+    assert!(
+        !pid_is_alive(git_pid),
+        "the git.exe grandchild (pid {git_pid}) outlived the kill"
+    );
+    drop(stdin);
+    let _ = root.wait();
+}

--- a/specs/anyharness/live-runtime.md
+++ b/specs/anyharness/live-runtime.md
@@ -708,6 +708,18 @@ still works. `process_kill` itself lives at the crate root, not under
 `domains/workspaces::setup_runtime` need to name `PlaneKills` and either
 domain-side placement would force a second `live::` import in one of them.
 
+The escalation above describes unix, where the integer a caller holds names a
+process group (or, for a PTY, a session) because the spawn site called
+`process_group(0)`. Windows has neither concept and those spawn calls are
+`#[cfg(unix)]`, so on Windows the same integer is just the direct child's pid
+and `process_kill_windows.rs` reads it as the ROOT of a process tree, reaching
+the descendants through a `CreateToolhelp32Snapshot` walk over
+`th32ParentProcessID`. The contract is identical - the same `(total, git)`
+census taken before anything is signaled, the same detached escalation, the
+same grace-as-deadline and confirmation budget - with one behavioral
+difference: `TerminateProcess` is unconditional, so the Windows ladder has no
+graceful rung before it.
+
 Two timing rules make the stop fit an archive's quiesce budget:
 
 - The 5s grace is a DEADLINE, not a fixed cost. Each escalation polls for its

--- a/specs/anyharness/live-runtime.md
+++ b/specs/anyharness/live-runtime.md
@@ -714,11 +714,17 @@ process group (or, for a PTY, a session) because the spawn site called
 `#[cfg(unix)]`, so on Windows the same integer is just the direct child's pid
 and `process_kill_windows.rs` reads it as the ROOT of a process tree, reaching
 the descendants through a `CreateToolhelp32Snapshot` walk over
-`th32ParentProcessID`. The contract is identical - the same `(total, git)`
-census taken before anything is signaled, the same detached escalation, the
-same grace-as-deadline and confirmation budget - with one behavioral
-difference: `TerminateProcess` is unconditional, so the Windows ladder has no
-graceful rung before it.
+`th32ParentProcessID`. The return contract is the same - the same
+`(total, git)` census taken before anything is signaled, the same detached
+escalation, the same grace-as-deadline and confirmation budget - but the
+guarantee is weaker in three ways. `TerminateProcess` is unconditional, so the
+Windows ladder has no graceful rung before it. The kill is not atomic against
+a tree that grows mid-kill: `kill(-pgid)` still reaches a child created
+between the unix enumeration and the signal, whereas Windows acts on a pid
+list and picks such a child up only on the next confirmation pass. And a pid
+is not an identity, so a descendant whose creation time cannot be read is
+refused rather than killed, on the grounds that terminating a stranger is
+worse than leaking a descendant.
 
 Two timing rules make the stop fit an archive's quiesce budget:
 


### PR DESCRIPTION
## The defect

`anyharness/crates/anyharness-lib/src/process_kill.rs:352-360` (pre-change) gated the entire real implementation behind `#[cfg(unix)] mod unix_impl` and handed every other platform this:

```rust
#[cfg(not(unix))]
pub async fn kill_group_and_await(_pgid: i32) -> (usize, usize) { (0, 0) }
#[cfg(not(unix))]
pub async fn kill_session_and_await(_sid: i32) -> (usize, usize) { (0, 0) }
```

`(0, 0)` is not an error value. It is the exact tuple a *successful* kill of zero processes returns, and the unix path returns it deliberately at `process_kill.rs:284` and `:314` to mean "the target was already empty". Every caller reads it that way. `SessionActor::kill_process_group_and_reap` (`live/sessions/actor/run.rs:117`) sends it back as the stop response. `close_all_for_workspace` and `kill_active_run_for_workspace` (`live/terminals/command_runs/workspace_stop.rs:113`, `:168`) fold it into `PlaneKills`. R2's `repair_kill_debris` aborts a conflict sentinel only when `killed_git > 0`, so a stub zero is also a positive claim that no `git` was running.

The result on Windows was not a missing feature but a lie: stop and cancel reported clean quiescence, archive believed the session had quiesced, and the whole agent process tree kept running with nothing left that could reach it. Orphaned trees accumulate for the lifetime of the machine.

## What the callers can actually provide

I traced every call site and every value that reaches these functions:

| Call site | Value passed | Produced by |
| --- | --- | --- |
| `live/sessions/actor/run.rs:130` | `self.child.id() as i32` | `spawn_agent_process` (`live/sessions/driver/process.rs:109`) |
| `live/terminals/command_runs/workspace_stop.rs:110` | `handle.child.process_id() as i32` | portable-pty's PTY child |
| `live/terminals/command_runs/workspace_stop.rs:167` and `:466` | `ActiveSetupTask::pgid` (an `AtomicI32`) | `run_setup_process` stores `child.id()` (`setup_process.rs:118`) |
| `live/terminals/command_runs/setup_process.rs:210` | the same atomic | same |

On unix every one of those integers is a process *group* id only because the spawn site calls `process_group(0)`, which makes the child its own group leader so the pid and the pgid are the same number. Both of those calls (`driver/process.rs:109`, `setup_process.rs:76`) are `#[cfg(unix)]`, and portable-pty's `setsid()` is in its unix backend only. So on Windows the integer that arrives is unambiguously a plain pid, and nothing more is available today.

## Approach: Toolhelp descendant walk. Job Objects rejected.

**Chosen:** a pure-Rust `CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS)` enumeration that walks `th32ParentProcessID` to build the descendant tree rooted at the pid the caller already passes. New file `anyharness/crates/anyharness-lib/src/process_kill_windows.rs`.

This is the option that actually matches the existing structure. The unix path is two-phase by design: enumerate the whole target, census it *before* signaling (`census()` resolves each pid's executable first, because enumerating after the TERM undercounts exactly the processes that died fastest), then act. A Toolhelp snapshot returns pid, parent pid, and base executable name in one read, so the Windows census is the same two-phase shape and is actually cheaper than the unix one, which needs a `proc_pidpath`/`readlink` per pid. It also needs zero spawn-site changes, which means it covers all four call sites uniformly.

**Rejected: Job Objects.** `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` plus `TerminateJobObject` is the correct Windows primitive in the abstract: atomic, and it cannot leak. It is not reachable here.

- ~~It requires touching the spawn site, and one of the three spawn sites is inside portable-pty's ConPTY backend. There is no hook to assign the PTY child to a job without forking the crate.~~ **This was wrong and review caught it.** portable-pty 0.9.0 exposes `as_raw_handle()` on the public `Child` trait (`lib.rs:141-145`, `win/mod.rs:118`, documented "Only available on Windows"), and `AssignProcessToJobObject` needs only a handle, not a spawn hook. The PTY child is reachable. The conclusion below still holds on the two remaining grounds, but not on this one.
- It changes the interface. A job handle is not an `i32`, so `ActiveSetupTask::pgid: Arc<AtomicI32>` and the `(i32) -> (usize, usize)` signature every caller uses would all have to change. That is a restructure of the spawn path across three modules, and `setup_process.rs` is currently owned by a parallel `/bin/sh` portability change.
- It cannot produce the `(total, git)` census. `TerminateJobObject` kills the set without telling you what was in it, so the `killed_git` evidence `repair_kill_debris` depends on would have to be enumerated separately anyway, which is the Toolhelp walk again.

Job Objects remain the better long-term answer, and now for all three spawn sites rather than two, since the PTY child turns out to be reachable after all. They compose with this change rather than replacing it: assigning the children to kill-on-close jobs would make the tree walk a backstop instead of the only mechanism, and would remove the pid-identity problem at the root rather than defending against it. That is a follow-up, not this PR.

**Rejected: `taskkill /PID <pid> /T /F`.** The module's own doc comment already rules out the equivalent move on unix ("an implementer reaching for a shelled-out `ps` here ships a fragile, slow kill"). It also spawns a process in order to kill processes, gives no census at all, and its `/T` walk is the same parent-link walk with a process spawn and output parsing bolted on top.

## What the Windows path does

The RETURN contract is the same: same `(total, git)` tuple meaning, same `(0, 0)`-means-nothing-was-running, same detached-task escalation so a dropped or timed-out caller future can never strand a half-killed tree, same `GRACE` (5s) as an early-exiting deadline rather than a fixed cost, same `CONFIRM_POLL` (50ms) and `CONFIRM_BUDGET` (10s).

An earlier version of this body claimed the contract was identical full stop. That was wrong and review was right to reject it. The GUARANTEE is weaker in three ways, all now documented in the file and in the spec:

1. **No graceful rung.** `TerminateProcess` is unconditional, so it is the equivalent of `SIGKILL`, not `SIGTERM`. A graceful first rung would need `GenerateConsoleCtrlEvent`, which only works against a group created with `CREATE_NEW_PROCESS_GROUP` at spawn and only for console processes sharing our console. No spawn site sets that flag, so the ladder starts at the unconditional rung. `GRACE` is still honored, as the deadline for the OS to finish tearing the tree down before survivors are retried.
2. **The kill is not atomic against a growing tree, and unix's is.** `kill(-pgid)` signals a group, so a child created between the unix enumeration and the signal is already a member and still gets hit. Here the pass acts on a pid list read from a snapshot, so a descendant born after that snapshot is missed by *that* pass and picked up by the next confirmation pass, up to `CONFIRM_POLL` later. The census returned to the caller is the one taken before the first pass, so a tree that grew mid-kill is under-reported even though it is killed.
3. **A pid is not an identity, so an unprovable descendant is refused rather than killed.** Windows does not re-parent orphans: a dead process leaves its children's `th32ParentProcessID` pointing at a freed number the kernel will hand to someone else. Every pid acted on is checked against its creation time, and a descendant whose identity cannot be read is left alone. Terminating a stranger is worse than leaking a descendant, so this fails toward under-killing. The runtime's own pid is excluded, and a root equal to our own pid is refused outright.

`git` detection compares against `git.exe` case-insensitively. The unix path's exact `"git"` comparison would have counted zero forever on Windows and silently changed archive's refusal behavior.

A failed snapshot is the one thing the `(usize, usize)` signature cannot report, so it is logged at ERROR and never folded into `(0, 0)`. The `#[cfg(not(any(unix, windows)))]` stub that remains still returns `(0, 0)` because no such platform is a build target, but it now logs at ERROR on every call so it can never be a silent lie again.

## Dependency

`windows-sys` is already in `Cargo.lock` at five versions; 0.61.2 is pulled by `mio`, `async-io`, `polling`, `signal-hook`, and others. This adds `windows-sys = "0.61"` with `Win32_Foundation`, `Win32_System_Diagnostics_ToolHelp`, and `Win32_System_Threading`, under `[target.'cfg(windows)'.dependencies]` so no other platform pays for it. It resolves to the 0.61.2 already in the lock, so the only lock change is one line added to the `anyharness-lib` dependency list. No new package.

## Review round 2: what changed

All four blocking findings are fixed, and the fix for B1 grew a fifth case the review did not name.

- **B1, stale parent links terminate unrelated processes.** Adoption now requires the child's creation time (`GetProcessTimes`) to be at or after the parent's. What that buys, precisely: for a link to be stale, the number's previous owner had to be alive when the stranger started and had to exit before our root could acquire the number, so in real time the stranger started before our root did, and a genuine child always starts after its parent. So the comparison separates the two cases whenever the clock separates them. What it does not buy: the comparison is on *reported* `GetProcessTimes` values and it admits equality, so at an equal reported timestamp a stranger is adopted. Equality has to be admitted, or a genuine child created inside the same tick as its parent leaks, so the same-tick window is the deliberate residual rather than a bug. How wide it is depends on the sampling resolution `GetProcessTimes` actually reports on a given machine, which nothing here has measured; it is not safe to assume the 100ns the FILETIME encoding suggests. The check also does not protect the root itself, only what is adopted beneath it. The reviewer's repro (root 8432, `TerminateProcess` on `[8432, 5000, 5001, 5002]`, census `(4, 1)`) is now a test that asserts `[8432]` and `(1, 0)`, and deleting the comparison restores exactly the reviewer's numbers.
- **B1, second hole, found while fixing the first.** `may_adopt` skips pids that are already tracked, so a pid recycled *while tracked* (dies and is reassigned between two passes, so we never observe it missing) was never re-checked by anything. The `retired` set could not help; nor could the generation check, because an already-tracked pid is not an adoption candidate. Every pass now re-verifies the identity of the pids it holds and drops any whose creation time has changed. That **subsumes** `retired`, which is removed: with identity checked, the only thing `retired` still did was refuse a genuine child that happened to reuse a number we had seen die, which is a leak.
- **B3, grandchild lost inside the kill window.** Growth now runs before the vanished are dropped, so an orphan is adopted through its parent's last known membership.
- **B2, `Process32FirstW` failure read as an empty table.** Now returns `Err(GetLastError())`.
- **B4, no retry on a transient enumeration failure.** Five attempts, 10ms apart, bounded and only on the failure path, with `GetLastError` read and `ERROR_BAD_LENGTH` reported as retryable in the log.

**The uncompiled unit tests are now compiled and running, on Linux, on every PR.** Review was right that this needed no Windows at all. The bookkeeping is pure `std`, so it moved to `process_kill_tree.rs` under `#[cfg(any(windows, test))]`, and its thirteen tests run under the existing `cargo test --workspace`. This is the coverage that matters most, because all four blocking findings live in the multi-pass escalation rung and both real-process Windows tests die on the first `TerminateProcess` pass, so no amount of green Windows CI was ever going to reach them.

**Both vacuous tests are rewritten with real negative controls**, and every test in the new file states the mechanism it pins and what deleting that mechanism does to it. The cycle test now builds a cycle that actually enters the tracked set, and `depth_of` distinguishes a cycle (`None`) from a truncated deep chain (`Some(DEPTH_LIMIT)`), so deleting the visited set returns `Some(64)` and the test goes red rather than passing. The pid-reuse test is replaced by the identity-verification test above, which goes red by terminating a stranger.

**One correction back.** The heads-up about `lifecycle_tests.rs:113` and `:182` does not hold. Those assertions are driven by a *scripted* live handle, not a real process: the file's own module doc says it "does not need a real spawned process", and the census comes from `ScriptedSessionSpec`, never from `process_kill`. They are also not unix-gated (`runtime/mod.rs:64-65` is a bare `#[cfg(test)]`). So they will neither fail on Windows for the Git-for-Windows shim reason nor need touching during the `lib test` port. Flagging so nobody spends time on it.

## Verified vs unverified

**Verified:**

- **Windows compiles.** Literal result from `.github/workflows/windows-compile-check.yml` on [run 32450924720](https://github.com/proliferate-ai/proliferate/actions/runs/32450924720), at head `6c48750e186ba14fb8daf020f74bbda29b674720`:

  ```
  runtime crates (control):   success   (cargo check --target x86_64-pc-windows-msvc
                                         -p anyharness -p proliferate-worker -p proliferate-supervisor)
      Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 00s
  desktop crates (the unknown): success
  ```

  Zero errors. `anyharness-lib`'s warnings are all pre-existing unix-side dead code that the Windows cfg leaves unreferenced; grepping the full job log for `process_kill` returns nothing, so the new files and the new `windows-sys` dependency compile warning-free.
- **The tree bookkeeping is unit-tested on every PR, on Linux.** Thirteen tests under `process_kill::tree::tests`, all green in `Cargo check & test` at head `6c48750e186ba14fb8daf020f74bbda29b674720` ([job 96679172461](https://github.com/proliferate-ai/proliferate/actions/runs/32450924690/job/96679172461)), covering stale-parent-link refusal, recycled-pid identity, unreadable-identity fail-open, grandchild adoption across a parent's death, the full multi-pass escalation sequence, cycle detection, self-pid exclusion, fail-closed behaviour with an unknown root identity, and the `git.exe` census. Literal lines from that job, by name, all thirteen: `absorb_adopts_a_grandchild_whose_parent_died_in_the_same_interval`, `absorb_adopts_nothing_when_the_roots_identity_is_unknown`, `absorb_collects_the_whole_descendant_tree_root_first`, `absorb_drops_a_tracked_pid_that_was_recycled_between_passes`, `absorb_keeps_a_tracked_pid_whose_identity_cannot_be_read`, `absorb_never_adopts_the_runtimes_own_process`, `absorb_refuses_a_stranger_reached_through_a_stale_parent_link`, `absorb_still_adopts_a_genuine_child_created_after_its_parent`, `depth_of_measures_an_ordinary_chain`, `depth_of_reports_a_cycle_rather_than_walking_it`, `executable_name_stops_at_the_nul_terminator`, `the_census_counts_git_exe_where_an_exact_git_comparison_would_count_zero`, `the_escalation_rung_tracks_a_tree_across_passes_until_it_empties`, each logged as `PASS`. The job's full-suite summary line: `3160 tests run: 3160 passed (1 slow), 8 skipped`.
- **The `unsafe` FFI has been EXECUTED on Windows against real process trees.** A dedicated job (`.github/workflows/windows-process-kill-tests.yml`, kept separate so the shared `windows-compile-check.yml` other branches stack on is not touched) runs `cargo test --target x86_64-pc-windows-msvc -p anyharness-lib --test windows_process_tree` on `windows-latest`. Literal result at head `6c48750e186ba14fb8daf020f74bbda29b674720` ([job 96679171510](https://github.com/proliferate-ai/proliferate/actions/runs/32450924588/job/96679171510)):

  ```
  running 2 tests
  test kills_a_real_process_tree_including_the_grandchild ... ok
  test the_census_counts_a_real_git_exe_grandchild ... ok
  test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.20s
  ```

  That covers `CreateToolhelp32Snapshot`, the `PROCESSENTRY32W` walk and its `dwSize` handshake, `TreeTracker`, the census, `OpenProcess`/`TerminateProcess`, and the confirmation loop, against the real kernel. Every assertion uses an oracle independent of the code under test: `Child::wait` for the direct child, PowerShell's CIM process table for descendants.

- **The runner found a real defect that reading could not.** First run was red: `assertion left == right failed ... left: 2, right: 1`. Git for Windows resolves `git` to a shim in `cmd\git.exe` that launches the real `git.exe` from `mingw64\bin`, so one `git` invocation is *two* `git.exe` processes and the tree is three deep. The census counted both correctly; my test had asserted exactly one. The fix was to the test, not the implementation: it now asserts the load-bearing property (the count is nonzero, which is exactly what `repair_kill_debris` branches on) plus an oracle-backed negative control that every git process is named `git.exe`, so the unix path's exact `"git"` comparison would have counted zero.
- The unix side is unaffected: `Cargo check & test` passed on this PR, and `process_kill_tests.rs` is unmodified. Mechanically, every line of CODE changed in `process_kill.rs` sits inside `#[cfg(windows)]`, `#[cfg(any(windows, test))]`, or `#[cfg(not(any(unix, windows)))]` (the module-level `//!` doc lines are in no cfg and are unix-visible, but are behaviourally inert; a broken intra-doc link introduced there has been removed); nothing inside `#[cfg(unix)] mod unix_impl` or its `pub use` changed. `process_kill_windows.rs` is reachable only through `#[cfg(windows)] mod windows_impl`, so it is not compiled on unix at all, and `tests/windows_process_tree.rs` is `#![cfg(windows)]`, so it is an empty crate there. `process_kill_tree.rs` is `#[cfg(any(windows, test))]`, so on unix it exists only under `cargo test`, which is the point of it.
- `rustfmt --edition 2021 --check` clean on both changed Rust files.
- The caller/spawn-site trace in the table above, read from source.

**Not verified.** The core kill path HAS been executed on Windows, and that includes more than the FFI calls: the confirmation polls re-enumerate and re-`absorb` on every 50ms tick, so `absorb`, the per-pass identity re-verification, and the `GetProcessTimes` generation comparison all execute against the real kernel on every Windows run, not only against the Linux fakes. The one part of the Windows path that no test reaches is the post-`GRACE` escalation loop at `process_kill_windows.rs:296-327`. What follows is what has not been verified.

- **The FFI functions themselves have no unit tests**, only the real-process integration tests. `snapshot_processes`, `process_creation_time`, `terminate`, and the retry loop are exercised end to end or not at all; the B2 and B4 guards specifically have no test, because faking a `CreateToolhelp32Snapshot` failure needs injection this does not have.
- **`anyharness-lib`'s `lib test` target still does not build for `x86_64-pc-windows-msvc`**, so the new unit tests run on Linux and macOS but not on Windows. Ten pre-existing errors, every one a test-only POSIX assumption in an unrelated module. Not absorbed here. The logic is platform-independent, so this costs coverage of the *target* platform rather than of the logic.
- **Timing under load is untested.** The two integration tests finished in 3.93s, so the happy path clearly resolves well inside `GRACE`. What is unverified is the escalation: no test has produced a tree that survives the first `TerminateProcess` pass, so the re-enumerate-and-re-terminate loop at `process_kill_windows.rs:296-327` and the `CONFIRM_BUDGET` exhaustion warning have not executed. That loop is the only Windows-path code no test reaches.
- **Only a two-and-three-process tree has been killed for real.** Nothing has exercised a deep or wide agent tree, a ConPTY session, or a real tree spawning new descendants during the kill. The tracker logic that handles those does run against the real kernel through the confirmation polls, but always on a tree that dies on the first pass, so what is untested is the escalation rung specifically rather than the bookkeeping. I did not add a growing-tree integration test because there is no deterministic way to make a real tree survive the first pass, and a flaky test asserting the escalation rung is worse than an honest gap.
- **`kill_active_run_for_workspace` (`workspace_stop.rs:163`) still aborts the owning task before killing**, which drops the `Child` and unreserves the pid, handing this code a possibly-recycled root. The other two call sites correctly hold the handle across the kill. I did not reorder it: aborting after the kill lets the task observe its child dying and overwrite the "Run interrupted by workspace stop" status that was just written, so this is a real trade between a certain status regression and a rare pid race, on a path with existing unix test coverage. The race is Windows-only: on unix the un-reaped zombie reserves the pid, so nothing can recycle it. It deserves its own PR with the unix suite as arbiter, not a drive-by inside a Windows change.
- **The spec paragraph added to `specs/anyharness/live-runtime.md`** describes the design; it is not a verification of it.

The honest summary: this is a real implementation, not a stub. Its core path has been executed on Windows against real process trees including a real `git.exe`, and its escalation and identity logic is unit-tested on every PR on Linux. What remains untested is the escalation rung, which no real tree has been made to reach.

## Follow-ups

1. Unblock `anyharness-lib`'s `lib test` target on Windows by cfg-gating the ten pre-existing test-only POSIX assumptions, then add `--lib` to the new job so the tree tests run on the target platform too.
2. Reorder `kill_active_run_for_workspace` to hold the `Child` across the kill, resolving the status-overwrite trade above properly.
3. A real-kernel test that forces the escalation rung, if a deterministic way to make a tree survive the first pass can be found.
4. Assign all three spawn sites to kill-on-close Job Objects via `as_raw_handle()`, so a runtime crash cannot leak a tree at all, the walk becomes a backstop, and the pid-identity problem disappears rather than being defended against. Needs the `AtomicI32` pgid slot in `ActiveSetupTask` to carry a handle instead.

## Stacking

Based on `ci/windows-compile-check` (draft PR #2142), not `main`, so the `pull_request` path trigger on `anyharness/crates/**` fires and this gets a genuine Windows compile verdict. That job is `continue-on-error: true` by design, so read the job conclusion, not the check mark. Retarget to `main` once #2142 lands.



