### PR TITLE
fix(anyharness): remove hardcoded posix shell and home assumptions

### DIFF
--- a/.github/workflows/windows-compile-check.yml
+++ b/.github/workflows/windows-compile-check.yml
@@ -1,0 +1,69 @@
+name: Windows compile check
+
+# The runtime already builds and ships for Windows on every release, but nothing
+# has compiled the desktop crate for Windows since desktop releases were
+# disabled on 2026-04-13. That makes every Windows estimate guesswork. This job
+# turns the unknown into an error list.
+#
+# Non-blocking on purpose: it is a probe, not a gate, until the errors are fixed.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "apps/desktop/src-tauri/**"
+      - "anyharness/crates/**"
+      - ".github/workflows/windows-compile-check.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  runtime:
+    # Known green: release-runtime.yml ships these targets today. Here as the
+    # control, so a red desktop job cannot be blamed on the toolchain.
+    name: runtime crates (control)
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo check
+        run: cargo check --target x86_64-pc-windows-msvc -p anyharness -p proliferate-worker -p proliferate-supervisor
+
+  desktop:
+    name: desktop crates (the unknown)
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo check
+        # Keep going past the first failure so one run yields the whole list
+        # rather than one error at a time.
+        run: cargo check --target x86_64-pc-windows-msvc -p proliferate --keep-going 2>&1 | tee check.log
+        shell: bash
+      - name: Error summary
+        if: always()
+        shell: bash
+        run: |
+          echo "### Windows desktop compile errors" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          grep -E '^error' check.log | sort | uniq -c | sort -rn | head -50 >> $GITHUB_STEP_SUMMARY || echo "no errors" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "total errors: $(grep -cE '^error' check.log || echo 0)" >> $GITHUB_STEP_SUMMARY
+          echo "files implicated:" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          grep -oE '\-\-> [^:]+' check.log | sed 's/--> //' | sort -u | head -60 >> $GITHUB_STEP_SUMMARY || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: windows-desktop-check-log
+          path: check.log

--- a/.github/workflows/windows-compile-check.yml
+++ b/.github/workflows/windows-compile-check.yml
@@ -14,6 +14,11 @@ on:
       - "apps/desktop/src-tauri/**"
       - "anyharness/crates/**"
       - ".github/workflows/windows-compile-check.yml"
+      - "Cargo.lock"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -24,9 +29,10 @@ jobs:
     # control, so a red desktop job cannot be blamed on the toolchain.
     name: runtime crates (control)
     runs-on: windows-latest
+    timeout-minutes: 45
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-msvc
@@ -37,9 +43,10 @@ jobs:
   desktop:
     name: desktop crates (the unknown)
     runs-on: windows-latest
+    timeout-minutes: 45
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-msvc
@@ -62,7 +69,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
           grep -oE '\-\-> [^:]+' check.log | sed 's/--> //' | sort -u | head -60 >> $GITHUB_STEP_SUMMARY || true
           echo '```' >> $GITHUB_STEP_SUMMARY
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: windows-desktop-check-log

--- a/anyharness/crates/anyharness-lib/src/host_shell.rs
+++ b/anyharness/crates/anyharness-lib/src/host_shell.rs
@@ -1,107 +1,104 @@
-//! The one place that answers "which shell does this host use, and how is it
-//! handed a command string?".
+//! The one place that decides how a user-authored command string reaches a
+//! shell.
 //!
-//! Everything that used to hardcode `/bin/sh` asks here instead. The unix
-//! answers are exactly the literals the call sites used before, so unix
-//! behaviour is unchanged; the windows answers are the equivalents that
-//! actually exist there. Written as `cfg(unix)` / `cfg(not(unix))` function
-//! pairs to match how the rest of this crate handles platform differences
-//! (see `process_kill`, `integrations::agent_cli::executable::make_executable`).
+//! Scope is deliberately narrow: this covers the *piped* command runner in
+//! `live::terminals::command_runs::setup_process`, which hands a command
+//! string to a shell, captures stdout/stderr and waits for exit under a
+//! deadline. It does NOT cover the PTY command-run path, and must not be
+//! wired into it. That path writes a POSIX sentinel wrapper into the terminal
+//! (`. <script>; anyharness_code=$?; printf ...` in
+//! `command_runs::pty::build_pty_command_wrapper`) and waits for the sentinel
+//! to come back, so an interpreter that cannot speak POSIX would leave a run
+//! that never completes. That path already refuses such shells up front:
+//! `command_runs::pty::run_terminal_command` bails with
+//! `unsupported_terminal_shell` whenever `ShellKind::is_posix()` is false, and
+//! `detect_shell_kind` classifies anything that is not bash/zsh/sh as
+//! `ShellKind::Other`. Terminal shell detection is therefore left resolving
+//! POSIX paths only, so the failure stays at PTY spawn rather than becoming a
+//! terminal that opens and then rejects every command.
+//!
+//! Written as a `cfg(unix)` / `cfg(not(unix))` function pair to match how the
+//! rest of this crate handles platform differences (see `process_kill`,
+//! `integrations::agent_cli::executable::make_executable`,
+//! `integrations::mcp::capability_token::write_secret_file`).
 
-use std::ffi::OsString;
-
-/// Program plus the single flag that makes it read the *next* argument as a
-/// whole command string to interpret.
+/// A `tokio` command that will run `command` through the host's shell.
 ///
-/// Used for command strings that are genuinely user-supplied and genuinely
-/// want shell semantics (pipes, globs, `&&`, environment expansion). A fixed
-/// program with fixed arguments should be spawned directly instead of going
-/// through here.
-#[derive(Debug, Clone)]
-pub struct CommandStringShell {
-    pub program: OsString,
-    pub command_flag: &'static str,
-}
-
-/// Unix: `/bin/sh -lc <command>`, byte-for-byte what the setup-command runner
-/// spawned before this module existed.
+/// The caller still owns cwd, stdio, environment and process-group setup; this
+/// only fixes the interpreter, the flag, and how the command string is quoted.
+///
+/// Unix: `/bin/sh -lc <command>`, byte-for-byte the invocation the setup
+/// runner built before this module existed.
 #[cfg(unix)]
-pub fn command_string_shell() -> CommandStringShell {
-    CommandStringShell {
-        program: OsString::from("/bin/sh"),
-        command_flag: "-lc",
-    }
+pub fn command_string_shell(command: &str) -> tokio::process::Command {
+    let mut cmd = tokio::process::Command::new("/bin/sh");
+    cmd.arg("-lc").arg(command);
+    cmd
 }
 
 /// Windows: the interpreter named by `ComSpec` (`cmd.exe` when unset) with
-/// `/C`, which is the closest equivalent of `sh -c` that is guaranteed to be
-/// present. There is no login-shell notion, so `-lc` collapses to `/C`.
-#[cfg(not(unix))]
-pub fn command_string_shell() -> CommandStringShell {
-    CommandStringShell {
-        program: std::env::var_os("ComSpec").unwrap_or_else(|| OsString::from("cmd.exe")),
-        command_flag: "/C",
-    }
-}
-
-/// Absolute interpreter paths probed, in order, when a managed run needs a
-/// shell and the caller did not name one. Unix keeps the original list and
-/// order; windows has no such fixed paths, so the probe is empty and the
-/// caller falls through to [`last_resort_shell`].
-#[cfg(unix)]
-pub fn well_known_shell_paths() -> &'static [&'static str] {
-    &[
-        "/bin/bash",
-        "/usr/bin/bash",
-        "/bin/zsh",
-        "/usr/bin/zsh",
-        "/bin/sh",
-        "/usr/bin/sh",
-    ]
-}
-
-#[cfg(not(unix))]
-pub fn well_known_shell_paths() -> &'static [&'static str] {
-    &[]
-}
-
-/// Interpreter paths tried after `$SHELL` when detecting the host's default
-/// interactive shell. Unix keeps the original list and order.
-#[cfg(unix)]
-pub fn default_shell_fallbacks() -> &'static [&'static str] {
-    &["/bin/bash", "/usr/bin/bash", "/bin/sh", "/usr/bin/sh"]
-}
-
-#[cfg(not(unix))]
-pub fn default_shell_fallbacks() -> &'static [&'static str] {
-    &[]
-}
-
-/// What to spawn when nothing else resolved. Unix returns `/bin/sh`, the same
-/// literal the terminal driver returned before. Windows returns `ComSpec`,
-/// which is the only shell guaranteed to exist there.
-#[cfg(unix)]
-pub fn last_resort_shell() -> String {
-    "/bin/sh".to_string()
-}
-
-#[cfg(not(unix))]
-pub fn last_resort_shell() -> String {
-    std::env::var_os("ComSpec")
-        .map(|value| value.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "cmd.exe".to_string())
-}
-
-/// Home directory of the current user, honouring `USERPROFILE` on windows
-/// where `HOME` is usually absent.
+/// `/C`, the closest guaranteed-present equivalent of `sh -c`. There is no
+/// login-shell notion, so `-lc` collapses to `/C`.
 ///
-/// `HOME` is consulted first and returned verbatim, so every unix host that
-/// sets it resolves exactly as before, empty value included. `USERPROFILE` is
-/// only reached when `HOME` is absent entirely, which is the case this exists
-/// to fix.
-pub fn home_dir_from_env() -> Option<std::path::PathBuf> {
-    if let Some(home) = std::env::var_os("HOME") {
-        return Some(std::path::PathBuf::from(home));
+/// The command string goes through `raw_arg`, not `arg`. `arg` applies the
+/// MSVCRT quoting rules on windows, which wrap anything containing a space in
+/// quotes; `cmd.exe` does not parse its argument that way, so a perfectly
+/// ordinary `npm run build --if-present` would arrive mangled. `raw_arg`
+/// passes the string through untouched, which is what `/C` expects.
+#[cfg(not(unix))]
+pub fn command_string_shell(command: &str) -> tokio::process::Command {
+    let program =
+        std::env::var_os("ComSpec").unwrap_or_else(|| std::ffi::OsString::from("cmd.exe"));
+    let mut cmd = tokio::process::Command::new(program);
+    cmd.arg("/C");
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.as_std_mut().raw_arg(command);
     }
-    std::env::var_os("USERPROFILE").map(std::path::PathBuf::from)
+    #[cfg(not(windows))]
+    cmd.arg(command);
+    cmd
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::ffi::OsStr;
+
+    /// Negative control for the "unix behaviour is unchanged" claim: these are
+    /// the exact program and flag the setup runner hardcoded before this
+    /// module existed. Changing either should fail here.
+    #[test]
+    fn unix_invocation_is_exactly_bin_sh_dash_lc() {
+        let command = super::command_string_shell("printf ok");
+        let std_command = command.as_std();
+
+        assert_eq!(std_command.get_program(), OsStr::new("/bin/sh"));
+        assert_eq!(
+            std_command.get_args().collect::<Vec<_>>(),
+            vec![OsStr::new("-lc"), OsStr::new("printf ok")]
+        );
+    }
+
+    #[tokio::test]
+    async fn the_command_string_is_interpreted_by_a_shell_and_its_status_is_returned() {
+        let status = super::command_string_shell("exit 7")
+            .status()
+            .await
+            .expect("spawn the host shell");
+
+        assert_eq!(status.code(), Some(7));
+    }
+
+    #[tokio::test]
+    async fn shell_syntax_in_the_command_string_is_honoured() {
+        // Proves a shell really is interpreting the string rather than the
+        // string being spawned as a program name with arguments.
+        let status = super::command_string_shell("false || true")
+            .status()
+            .await
+            .expect("spawn the host shell");
+
+        assert!(status.success());
+    }
 }

--- a/anyharness/crates/anyharness-lib/src/host_shell.rs
+++ b/anyharness/crates/anyharness-lib/src/host_shell.rs
@@ -1,0 +1,107 @@
+//! The one place that answers "which shell does this host use, and how is it
+//! handed a command string?".
+//!
+//! Everything that used to hardcode `/bin/sh` asks here instead. The unix
+//! answers are exactly the literals the call sites used before, so unix
+//! behaviour is unchanged; the windows answers are the equivalents that
+//! actually exist there. Written as `cfg(unix)` / `cfg(not(unix))` function
+//! pairs to match how the rest of this crate handles platform differences
+//! (see `process_kill`, `integrations::agent_cli::executable::make_executable`).
+
+use std::ffi::OsString;
+
+/// Program plus the single flag that makes it read the *next* argument as a
+/// whole command string to interpret.
+///
+/// Used for command strings that are genuinely user-supplied and genuinely
+/// want shell semantics (pipes, globs, `&&`, environment expansion). A fixed
+/// program with fixed arguments should be spawned directly instead of going
+/// through here.
+#[derive(Debug, Clone)]
+pub struct CommandStringShell {
+    pub program: OsString,
+    pub command_flag: &'static str,
+}
+
+/// Unix: `/bin/sh -lc <command>`, byte-for-byte what the setup-command runner
+/// spawned before this module existed.
+#[cfg(unix)]
+pub fn command_string_shell() -> CommandStringShell {
+    CommandStringShell {
+        program: OsString::from("/bin/sh"),
+        command_flag: "-lc",
+    }
+}
+
+/// Windows: the interpreter named by `ComSpec` (`cmd.exe` when unset) with
+/// `/C`, which is the closest equivalent of `sh -c` that is guaranteed to be
+/// present. There is no login-shell notion, so `-lc` collapses to `/C`.
+#[cfg(not(unix))]
+pub fn command_string_shell() -> CommandStringShell {
+    CommandStringShell {
+        program: std::env::var_os("ComSpec").unwrap_or_else(|| OsString::from("cmd.exe")),
+        command_flag: "/C",
+    }
+}
+
+/// Absolute interpreter paths probed, in order, when a managed run needs a
+/// shell and the caller did not name one. Unix keeps the original list and
+/// order; windows has no such fixed paths, so the probe is empty and the
+/// caller falls through to [`last_resort_shell`].
+#[cfg(unix)]
+pub fn well_known_shell_paths() -> &'static [&'static str] {
+    &[
+        "/bin/bash",
+        "/usr/bin/bash",
+        "/bin/zsh",
+        "/usr/bin/zsh",
+        "/bin/sh",
+        "/usr/bin/sh",
+    ]
+}
+
+#[cfg(not(unix))]
+pub fn well_known_shell_paths() -> &'static [&'static str] {
+    &[]
+}
+
+/// Interpreter paths tried after `$SHELL` when detecting the host's default
+/// interactive shell. Unix keeps the original list and order.
+#[cfg(unix)]
+pub fn default_shell_fallbacks() -> &'static [&'static str] {
+    &["/bin/bash", "/usr/bin/bash", "/bin/sh", "/usr/bin/sh"]
+}
+
+#[cfg(not(unix))]
+pub fn default_shell_fallbacks() -> &'static [&'static str] {
+    &[]
+}
+
+/// What to spawn when nothing else resolved. Unix returns `/bin/sh`, the same
+/// literal the terminal driver returned before. Windows returns `ComSpec`,
+/// which is the only shell guaranteed to exist there.
+#[cfg(unix)]
+pub fn last_resort_shell() -> String {
+    "/bin/sh".to_string()
+}
+
+#[cfg(not(unix))]
+pub fn last_resort_shell() -> String {
+    std::env::var_os("ComSpec")
+        .map(|value| value.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "cmd.exe".to_string())
+}
+
+/// Home directory of the current user, honouring `USERPROFILE` on windows
+/// where `HOME` is usually absent.
+///
+/// `HOME` is consulted first and returned verbatim, so every unix host that
+/// sets it resolves exactly as before, empty value included. `USERPROFILE` is
+/// only reached when `HOME` is absent entirely, which is the case this exists
+/// to fix.
+pub fn home_dir_from_env() -> Option<std::path::PathBuf> {
+    if let Some(home) = std::env::var_os("HOME") {
+        return Some(std::path::PathBuf::from(home));
+    }
+    std::env::var_os("USERPROFILE").map(std::path::PathBuf::from)
+}

--- a/anyharness/crates/anyharness-lib/src/lib.rs
+++ b/anyharness/crates/anyharness-lib/src/lib.rs
@@ -2,6 +2,7 @@ pub mod adapters;
 pub mod api;
 pub mod app;
 pub mod domains;
+pub mod host_shell;
 pub mod integrations;
 pub mod live;
 pub mod observability;

--- a/anyharness/crates/anyharness-lib/src/live/terminals/command_runs/setup_process.rs
+++ b/anyharness/crates/anyharness-lib/src/live/terminals/command_runs/setup_process.rs
@@ -62,13 +62,11 @@ pub(in crate::live::terminals) async fn run_setup_process(
     .await;
 
     // The setup command is a user-authored string that may use pipes, `&&`,
-    // globs and variable expansion, so it genuinely needs a shell. Which shell
-    // is the host's business, not this module's.
-    let shell = crate::host_shell::command_string_shell();
-    let mut cmd = tokio::process::Command::new(&shell.program);
-    cmd.arg(shell.command_flag)
-        .arg(&command)
-        .current_dir(&workspace_path)
+    // globs and variable expansion, so it genuinely needs a shell. Which shell,
+    // and how the string is quoted into it, is the host's business rather than
+    // this module's.
+    let mut cmd = crate::host_shell::command_string_shell(&command);
+    cmd.current_dir(&workspace_path)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
     cmd.kill_on_drop(true);

--- a/anyharness/crates/anyharness-lib/src/live/terminals/command_runs/setup_process.rs
+++ b/anyharness/crates/anyharness-lib/src/live/terminals/command_runs/setup_process.rs
@@ -61,8 +61,12 @@ pub(in crate::live::terminals) async fn run_setup_process(
     )
     .await;
 
-    let mut cmd = tokio::process::Command::new("/bin/sh");
-    cmd.arg("-lc")
+    // The setup command is a user-authored string that may use pipes, `&&`,
+    // globs and variable expansion, so it genuinely needs a shell. Which shell
+    // is the host's business, not this module's.
+    let shell = crate::host_shell::command_string_shell();
+    let mut cmd = tokio::process::Command::new(&shell.program);
+    cmd.arg(shell.command_flag)
         .arg(&command)
         .current_dir(&workspace_path)
         .stdout(std::process::Stdio::piped())

--- a/anyharness/crates/anyharness-lib/src/live/terminals/driver/shell.rs
+++ b/anyharness/crates/anyharness-lib/src/live/terminals/driver/shell.rs
@@ -56,15 +56,12 @@ pub(super) fn detect_shell_kind(shell: &str) -> ShellKind {
     }
 }
 
+/// The shell a managed run (setup / run terminals) is spawned under. Named
+/// for the POSIX shells it prefers; on hosts without them the probe list is
+/// empty and this falls through to `detect_default_shell`, which resolves the
+/// host's own interpreter.
 pub(in crate::live::terminals) fn detect_posix_shell() -> String {
-    for candidate in [
-        "/bin/bash",
-        "/usr/bin/bash",
-        "/bin/zsh",
-        "/usr/bin/zsh",
-        "/bin/sh",
-        "/usr/bin/sh",
-    ] {
+    for &candidate in crate::host_shell::well_known_shell_paths() {
         if is_executable_command(candidate, std::env::var_os("PATH").as_deref()) {
             return candidate.to_string();
         }
@@ -73,8 +70,8 @@ pub(in crate::live::terminals) fn detect_posix_shell() -> String {
 }
 
 fn ensure_bash_prompt_rcfile() -> Option<String> {
-    let home = std::env::var_os("HOME")?;
-    let rcfile = Path::new(&home)
+    let home = crate::host_shell::home_dir_from_env()?;
+    let rcfile = home
         .join(".proliferate")
         .join("anyharness")
         .join("terminal")
@@ -117,7 +114,7 @@ fn detect_default_shell_with_env(shell_env: Option<&str>, path_env: Option<&OsSt
         candidates.push(shell);
     }
 
-    for fallback in ["/bin/bash", "/usr/bin/bash", "/bin/sh", "/usr/bin/sh"] {
+    for &fallback in crate::host_shell::default_shell_fallbacks() {
         if !candidates.contains(&fallback) {
             candidates.push(fallback);
         }
@@ -129,7 +126,7 @@ fn detect_default_shell_with_env(shell_env: Option<&str>, path_env: Option<&OsSt
         }
     }
 
-    "/bin/sh".to_string()
+    crate::host_shell::last_resort_shell()
 }
 
 fn is_executable_command(command: &str, path_env: Option<&OsStr>) -> bool {

--- a/anyharness/crates/anyharness-lib/src/live/terminals/driver/shell.rs
+++ b/anyharness/crates/anyharness-lib/src/live/terminals/driver/shell.rs
@@ -56,12 +56,15 @@ pub(super) fn detect_shell_kind(shell: &str) -> ShellKind {
     }
 }
 
-/// The shell a managed run (setup / run terminals) is spawned under. Named
-/// for the POSIX shells it prefers; on hosts without them the probe list is
-/// empty and this falls through to `detect_default_shell`, which resolves the
-/// host's own interpreter.
 pub(in crate::live::terminals) fn detect_posix_shell() -> String {
-    for &candidate in crate::host_shell::well_known_shell_paths() {
+    for candidate in [
+        "/bin/bash",
+        "/usr/bin/bash",
+        "/bin/zsh",
+        "/usr/bin/zsh",
+        "/bin/sh",
+        "/usr/bin/sh",
+    ] {
         if is_executable_command(candidate, std::env::var_os("PATH").as_deref()) {
             return candidate.to_string();
         }
@@ -70,8 +73,8 @@ pub(in crate::live::terminals) fn detect_posix_shell() -> String {
 }
 
 fn ensure_bash_prompt_rcfile() -> Option<String> {
-    let home = crate::host_shell::home_dir_from_env()?;
-    let rcfile = home
+    let home = std::env::var_os("HOME")?;
+    let rcfile = Path::new(&home)
         .join(".proliferate")
         .join("anyharness")
         .join("terminal")
@@ -114,7 +117,7 @@ fn detect_default_shell_with_env(shell_env: Option<&str>, path_env: Option<&OsSt
         candidates.push(shell);
     }
 
-    for &fallback in crate::host_shell::default_shell_fallbacks() {
+    for fallback in ["/bin/bash", "/usr/bin/bash", "/bin/sh", "/usr/bin/sh"] {
         if !candidates.contains(&fallback) {
             candidates.push(fallback);
         }
@@ -126,7 +129,7 @@ fn detect_default_shell_with_env(shell_env: Option<&str>, path_env: Option<&OsSt
         }
     }
 
-    crate::host_shell::last_resort_shell()
+    "/bin/sh".to_string()
 }
 
 fn is_executable_command(command: &str, path_env: Option<&OsStr>) -> bool {

--- a/anyharness/crates/proliferate-supervisor/src/config.rs
+++ b/anyharness/crates/proliferate-supervisor/src/config.rs
@@ -112,8 +112,12 @@ fn default_config_path() -> PathBuf {
     supervisor_state_dir().join("config.toml")
 }
 
+/// `HOME` first on every platform, so unix resolution is unchanged; windows
+/// has no `HOME` by default, so `USERPROFILE` is consulted before giving up
+/// and using the process working directory.
 fn dirs_fallback_home() -> PathBuf {
     std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("."))
 }

--- a/anyharness/crates/proliferate-supervisor/src/install/layout.rs
+++ b/anyharness/crates/proliferate-supervisor/src/install/layout.rs
@@ -3,6 +3,10 @@ use std::path::PathBuf;
 pub fn default_home() -> PathBuf {
     std::env::var_os("PROLIFERATE_HOME")
         .map(PathBuf::from)
-        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".proliferate")))
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .or_else(|| std::env::var_os("USERPROFILE"))
+                .map(|home| PathBuf::from(home).join(".proliferate"))
+        })
         .unwrap_or_else(|| PathBuf::from(".proliferate"))
 }

--- a/anyharness/crates/proliferate-worker/src/anyharness_update.rs
+++ b/anyharness/crates/proliferate-worker/src/anyharness_update.rs
@@ -366,10 +366,7 @@ fn stop_runtime_script(binary_path: &str) -> String {
 
 fn stop_runtime(binary_path: &Path) -> Result<(), WorkerError> {
     let script = stop_runtime_script(&binary_path.to_string_lossy());
-    let status = std::process::Command::new("sh")
-        .arg("-c")
-        .arg(&script)
-        .status()
+    let status = crate::posix_shell::run_script(crate::posix_shell::ScriptShell::Sh, &script, None)
         .map_err(|error| WorkerError::AnyharnessUpdateStop {
             detail: format!("failed to spawn stop shell: {error}"),
         })?;
@@ -436,15 +433,12 @@ fn relaunch(launcher_path: &Path, workdir: &Path) -> Result<(), WorkerError> {
         shell_single_quote(&launcher),
         shell_single_quote(&log.to_string_lossy()),
     );
-    let status = std::process::Command::new("sh")
-        .arg("-c")
-        .arg(&script)
-        .current_dir(workdir)
-        .status()
-        .map_err(|error| WorkerError::AnyharnessUpdateRelaunch {
-            path: launcher_path.to_path_buf(),
-            detail: format!("failed to spawn launcher shell: {error}"),
-        })?;
+    let status =
+        crate::posix_shell::run_script(crate::posix_shell::ScriptShell::Sh, &script, Some(workdir))
+            .map_err(|error| WorkerError::AnyharnessUpdateRelaunch {
+                path: launcher_path.to_path_buf(),
+                detail: format!("failed to spawn launcher shell: {error}"),
+            })?;
     if !status.success() {
         return Err(WorkerError::AnyharnessUpdateRelaunch {
             path: launcher_path.to_path_buf(),

--- a/anyharness/crates/proliferate-worker/src/main.rs
+++ b/anyharness/crates/proliferate-worker/src/main.rs
@@ -8,6 +8,7 @@ mod launch_options_sync;
 mod lifecycle;
 mod logging;
 mod observability;
+mod posix_shell;
 mod process_lock;
 mod runtime;
 mod self_update;

--- a/anyharness/crates/proliferate-worker/src/posix_shell.rs
+++ b/anyharness/crates/proliferate-worker/src/posix_shell.rs
@@ -1,0 +1,67 @@
+//! The worker's process-supervision scripts are POSIX shell by construction:
+//! they use `pgrep`, `nohup`, `$$` and `$PPID`, none of which `cmd.exe` has.
+//! Rather than sprinkle `cfg` at every call site, every such script goes
+//! through here, so the platform question is answered once.
+//!
+//! On unix each helper builds exactly the `Command` the call site built
+//! before, so behaviour is unchanged. On any other platform the spawn is
+//! refused up front with an `Unsupported` error naming the reason, instead of
+//! surfacing a bare "program not found" for a missing `sh` that no reader can
+//! trace back to shell supervision.
+
+use std::path::Path;
+use std::process::ExitStatus;
+
+/// Which interpreter a script needs. `Sh` maps to `sh -c`, `BashLogin` to
+/// `bash -lc`; both are the exact invocations the call sites used before.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ScriptShell {
+    Sh,
+    BashLogin,
+}
+
+impl ScriptShell {
+    #[cfg(unix)]
+    fn program(self) -> &'static str {
+        match self {
+            Self::Sh => "sh",
+            Self::BashLogin => "bash",
+        }
+    }
+
+    #[cfg(unix)]
+    fn flag(self) -> &'static str {
+        match self {
+            Self::Sh => "-c",
+            Self::BashLogin => "-lc",
+        }
+    }
+}
+
+/// Run `script` to completion under `shell`, optionally in `cwd`.
+#[cfg(unix)]
+pub(crate) fn run_script(
+    shell: ScriptShell,
+    script: &str,
+    cwd: Option<&Path>,
+) -> std::io::Result<ExitStatus> {
+    let mut command = std::process::Command::new(shell.program());
+    command.arg(shell.flag()).arg(script);
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    command.status()
+}
+
+#[cfg(not(unix))]
+pub(crate) fn run_script(
+    _shell: ScriptShell,
+    _script: &str,
+    _cwd: Option<&Path>,
+) -> std::io::Result<ExitStatus> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "worker process supervision needs a POSIX shell (pgrep/nohup/$PPID), \
+         which this platform does not provide",
+    ))
+}

--- a/anyharness/crates/proliferate-worker/src/posix_shell.rs
+++ b/anyharness/crates/proliferate-worker/src/posix_shell.rs
@@ -65,3 +65,55 @@ pub(crate) fn run_script(
          which this platform does not provide",
     ))
 }
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::{run_script, ScriptShell};
+
+    /// Negative control for the "unix behaviour is unchanged" claim: these are
+    /// the exact programs and flags the three call sites hardcoded before this
+    /// module existed (`sh -c` twice, `bash -lc` once).
+    #[test]
+    fn programs_and_flags_are_the_original_literals() {
+        assert_eq!(ScriptShell::Sh.program(), "sh");
+        assert_eq!(ScriptShell::Sh.flag(), "-c");
+        assert_eq!(ScriptShell::BashLogin.program(), "bash");
+        assert_eq!(ScriptShell::BashLogin.flag(), "-lc");
+    }
+
+    #[test]
+    fn the_scripts_exit_status_is_returned_verbatim() {
+        let status = run_script(ScriptShell::Sh, "exit 3", None).expect("spawn sh");
+
+        assert_eq!(status.code(), Some(3));
+    }
+
+    #[test]
+    fn a_requested_working_directory_is_applied() {
+        let dir = std::env::temp_dir().join(format!(
+            "worker-posix-shell-cwd-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        std::fs::write(dir.join("marker"), b"").expect("write marker");
+
+        let status = run_script(ScriptShell::Sh, "test -f marker", Some(&dir)).expect("spawn sh");
+
+        assert!(status.success(), "the script ran outside the requested cwd");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn without_a_working_directory_the_script_inherits_the_process_cwd() {
+        let expected = std::env::current_dir().expect("process cwd");
+        let script = format!(
+            "test \"$(pwd -P)\" = \"$(cd '{}' && pwd -P)\"",
+            expected.display()
+        );
+
+        let status = run_script(ScriptShell::Sh, &script, None).expect("spawn sh");
+
+        assert!(status.success());
+    }
+}

--- a/anyharness/crates/proliferate-worker/src/supervisor_bridge/bridge/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/supervisor_bridge/bridge/mod.rs
@@ -397,6 +397,15 @@ fn detached_supervisor_launch_script(
 /// Escape a path for a `pgrep -f` pattern so the pgrep shell never matches its
 /// own command line — identical to the server bootstrap's
 /// `_pgrep_pattern_for_path` and `anyharness_update`'s escaper.
+///
+/// Still load-bearing for the two callers that build shell scripts
+/// (`detached_supervisor_launch_script` here and `stop_runtime_script` in
+/// `anyharness_update`): there the pattern is interpolated into a script whose
+/// own command line contains it, so an unescaped pattern would match the shell
+/// running the search. It is vestigial but harmless for `supervisor_live`,
+/// which now spawns `pgrep` directly with no shell in between and therefore
+/// has no such process to exclude. Kept uniform on purpose so all three
+/// callers pass byte-identical patterns.
 fn pgrep_pattern_for_path(path: &str) -> String {
     if let Some(rest) = path.strip_prefix('/') {
         format!("[/]{rest}")

--- a/anyharness/crates/proliferate-worker/src/supervisor_bridge/bridge/mod.rs
+++ b/anyharness/crates/proliferate-worker/src/supervisor_bridge/bridge/mod.rs
@@ -295,11 +295,18 @@ impl BridgeHost for RealBridgeHost {
     }
 
     fn supervisor_live(&self, supervisor_binary: &Path) -> bool {
+        // A fixed program with fixed arguments: no shell needed on any
+        // platform. The redirects the old `sh -c` wrapper carried are the null
+        // stdout/stderr below, and `pgrep`'s own exit status is unchanged, so
+        // the returned bool is identical on unix - including the "pgrep is
+        // missing" case, which was a non-zero shell status and is now a spawn
+        // error, both mapping to `false`.
         let pattern = pgrep_pattern_for_path(&supervisor_binary.to_string_lossy());
-        let script = format!("pgrep -f {} > /dev/null 2>&1", shell_single_quote(&pattern));
-        std::process::Command::new("sh")
-            .arg("-c")
-            .arg(&script)
+        std::process::Command::new("pgrep")
+            .arg("-f")
+            .arg(&pattern)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
             .status()
             .map(|status| status.success())
             .unwrap_or(false)
@@ -316,13 +323,14 @@ impl BridgeHost for RealBridgeHost {
             self.anyharness_binary.as_deref(),
             self.worker_binary.as_deref(),
         );
-        let status = std::process::Command::new("bash")
-            .arg("-lc")
-            .arg(&script)
-            .status()
-            .map_err(|error| WorkerError::BridgeSpawn {
-                detail: format!("failed to spawn supervisor launch shell: {error}"),
-            })?;
+        let status = crate::posix_shell::run_script(
+            crate::posix_shell::ScriptShell::BashLogin,
+            &script,
+            None,
+        )
+        .map_err(|error| WorkerError::BridgeSpawn {
+            detail: format!("failed to spawn supervisor launch shell: {error}"),
+        })?;
         if !status.success() {
             return Err(WorkerError::BridgeSpawn {
                 detail: format!("supervisor launch shell exited with {status}"),

--- a/apps/desktop/src-tauri/src/app_config.rs
+++ b/apps/desktop/src-tauri/src/app_config.rs
@@ -62,6 +62,20 @@ pub fn home_dir() -> Result<PathBuf, String> {
         .map_err(|_| "Home directory not available".to_string())
 }
 
+/// `HOME`, then `USERPROFILE`, kept as raw OS strings.
+///
+/// Deliberately `var_os` rather than `var`. A non-UTF-8 home path is a
+/// perfectly valid path on unix, and `std::env::var` rejects it with
+/// `VarError::NotUnicode`, which would turn a working `~/...` expansion into a
+/// spurious "HOME is not set". `home_dir` above keeps its `String` behaviour
+/// because its callers build the app directory and already accept that
+/// constraint; this is the variant for expanding user-supplied paths.
+pub fn home_dir_os() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
 pub fn app_dir_path() -> Result<PathBuf, String> {
     if let Some(path) = dev_home_override_path() {
         return Ok(path);

--- a/apps/desktop/src-tauri/src/app_config.rs
+++ b/apps/desktop/src-tauri/src/app_config.rs
@@ -306,6 +306,10 @@ fn set_app_config_api_base_url_at(
     ))
 }
 
+#[cfg(all(test, unix))]
+#[path = "app_config_home_env_tests.rs"]
+mod home_env_tests;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/apps/desktop/src-tauri/src/app_config_home_env_tests.rs
+++ b/apps/desktop/src-tauri/src/app_config_home_env_tests.rs
@@ -1,0 +1,106 @@
+//! Coverage for `app_config::home_dir_os`, the helper the two `expand_home_path`
+//! callers use to turn a leading `~` into a real path.
+//!
+//! The whole point of that helper is that it reads the environment with
+//! `var_os` rather than `var`. `std::env::var` rejects a non-UTF-8 value with
+//! `VarError::NotUnicode`, so routing `~` expansion through it turns a working
+//! latin-1 home directory on Linux or macOS into a spurious "HOME is not set".
+//! A happy-path test would stay green under that regression and would be worse
+//! than nothing, so the non-UTF-8 case is pinned explicitly below.
+//!
+//! Each case runs in a re-exec of this test binary rather than by mutating the
+//! process environment in place. `cloud_worker::tests` calls
+//! `app_config::home_dir().expect(..)` on two paths in this same binary, and
+//! libtest runs tests on parallel threads, so temporarily pointing `HOME` at
+//! invalid UTF-8 here would panic those tests at random.
+
+use std::ffi::OsString;
+use std::os::unix::ffi::OsStringExt;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Set by the parent on the child re-exec to name the case being checked.
+const SCENARIO: &str = "APP_CONFIG_HOME_DIR_OS_SCENARIO";
+
+/// Invalid UTF-8: `\xC3` opens a two-byte sequence that `(` does not continue,
+/// and `\xFF` is never valid. A real byte sequence a filesystem will accept.
+fn non_utf8_home() -> OsString {
+    OsString::from_vec(b"/home/caf\xC3(\xFF".to_vec())
+}
+
+#[test]
+fn home_dir_os_reads_the_environment_without_utf8_validation() {
+    if let Some(scenario) = std::env::var_os(SCENARIO) {
+        run_child_case(&scenario.to_string_lossy());
+        return;
+    }
+
+    for (scenario, home, userprofile) in [
+        ("non_utf8_home", Some(non_utf8_home()), None),
+        (
+            "userprofile_fallback",
+            None,
+            Some(OsString::from("/windows/style/home")),
+        ),
+        (
+            "home_wins_over_userprofile",
+            Some(OsString::from("/the/home")),
+            Some(OsString::from("/not/this/one")),
+        ),
+        ("neither_set", None, None),
+    ] {
+        run_case_in_child(scenario, home, userprofile);
+    }
+}
+
+/// The assertions themselves, executed inside the child against the
+/// environment the parent chose.
+fn run_child_case(scenario: &str) {
+    let observed = crate::app_config::home_dir_os();
+
+    match scenario {
+        // The regression guard. Under `var` this is `None`, because
+        // `VarError::NotUnicode` is discarded and `USERPROFILE` is unset.
+        "non_utf8_home" => assert_eq!(observed, Some(PathBuf::from(non_utf8_home()))),
+        "userprofile_fallback" => {
+            assert_eq!(observed, Some(PathBuf::from("/windows/style/home")))
+        }
+        "home_wins_over_userprofile" => assert_eq!(observed, Some(PathBuf::from("/the/home"))),
+        "neither_set" => assert_eq!(observed, None),
+        other => panic!("unknown scenario {other}"),
+    }
+}
+
+fn run_case_in_child(scenario: &str, home: Option<OsString>, userprofile: Option<OsString>) {
+    let mut child = Command::new(std::env::current_exe().expect("path to this test binary"));
+    child
+        .args([
+            "--exact",
+            "--nocapture",
+            "app_config::home_env_tests::home_dir_os_reads_the_environment_without_utf8_validation",
+        ])
+        .env(SCENARIO, scenario)
+        .env_remove("HOME")
+        .env_remove("USERPROFILE");
+    if let Some(home) = home {
+        child.env("HOME", home);
+    }
+    if let Some(userprofile) = userprofile {
+        child.env("USERPROFILE", userprofile);
+    }
+
+    let output = child.output().expect("re-run this test in a child process");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "scenario `{scenario}` failed in the child:\n{stdout}\n{stderr}"
+    );
+    // Without this a mistyped filter would match zero tests and the child would
+    // exit 0, leaving every scenario vacuously green.
+    assert!(
+        stdout.contains("1 passed"),
+        "scenario `{scenario}` matched no test, so nothing was actually checked:\n{stdout}"
+    );
+}

--- a/apps/desktop/src-tauri/src/commands/diagnostics.rs
+++ b/apps/desktop/src-tauri/src/commands/diagnostics.rs
@@ -262,10 +262,11 @@ pub fn save_diagnostic_json_to_absolute_path(
 }
 
 fn expand_home_path(path: &str) -> Result<PathBuf, String> {
-    // `app_config::home_dir` reads `HOME` first and only then `USERPROFILE`,
-    // so unix resolution is unchanged (including this error string) while
-    // windows, which has no `HOME`, stops failing outright.
-    let home = || crate::app_config::home_dir().map_err(|_| "HOME is not set".to_string());
+    // `app_config::home_dir_os` reads `HOME` first, verbatim and as an
+    // `OsString`, and only then `USERPROFILE`. Unix resolution is unchanged
+    // for every `HOME` value including non-UTF-8 ones, error string included,
+    // while windows, which has no `HOME`, stops failing outright.
+    let home = || crate::app_config::home_dir_os().ok_or_else(|| "HOME is not set".to_string());
 
     if path == "~" {
         return home();

--- a/apps/desktop/src-tauri/src/commands/diagnostics.rs
+++ b/apps/desktop/src-tauri/src/commands/diagnostics.rs
@@ -262,17 +262,17 @@ pub fn save_diagnostic_json_to_absolute_path(
 }
 
 fn expand_home_path(path: &str) -> Result<PathBuf, String> {
+    // `app_config::home_dir` reads `HOME` first and only then `USERPROFILE`,
+    // so unix resolution is unchanged (including this error string) while
+    // windows, which has no `HOME`, stops failing outright.
+    let home = || crate::app_config::home_dir().map_err(|_| "HOME is not set".to_string());
+
     if path == "~" {
-        return std::env::var_os("HOME")
-            .map(PathBuf::from)
-            .ok_or_else(|| "HOME is not set".to_string());
+        return home();
     }
 
     if let Some(rest) = path.strip_prefix("~/") {
-        let home = std::env::var_os("HOME")
-            .map(PathBuf::from)
-            .ok_or_else(|| "HOME is not set".to_string())?;
-        return Ok(home.join(rest));
+        return Ok(home()?.join(rest));
     }
 
     Ok(PathBuf::from(path))

--- a/apps/desktop/src-tauri/src/commands/ssh_tunnel.rs
+++ b/apps/desktop/src-tauri/src/commands/ssh_tunnel.rs
@@ -714,10 +714,11 @@ async fn wait_for_anyharness(local_url: &str) -> Result<(), String> {
 }
 
 fn expand_home_path(path: &str) -> Result<PathBuf, String> {
-    // `app_config::home_dir` reads `HOME` first and only then `USERPROFILE`,
-    // so unix resolution is unchanged (including this error string) while
-    // windows, which has no `HOME`, stops failing outright.
-    let home = || crate::app_config::home_dir().map_err(|_| "HOME is not set.".to_string());
+    // `app_config::home_dir_os` reads `HOME` first, verbatim and as an
+    // `OsString`, and only then `USERPROFILE`. Unix resolution is unchanged
+    // for every `HOME` value including non-UTF-8 ones, error string included,
+    // while windows, which has no `HOME`, stops failing outright.
+    let home = || crate::app_config::home_dir_os().ok_or_else(|| "HOME is not set.".to_string());
 
     if path == "~" {
         return home();

--- a/apps/desktop/src-tauri/src/commands/ssh_tunnel.rs
+++ b/apps/desktop/src-tauri/src/commands/ssh_tunnel.rs
@@ -714,10 +714,8 @@ async fn wait_for_anyharness(local_url: &str) -> Result<(), String> {
 }
 
 fn expand_home_path(path: &str) -> Result<PathBuf, String> {
-    // `app_config::home_dir_os` reads `HOME` first, verbatim and as an
-    // `OsString`, and only then `USERPROFILE`. Unix resolution is unchanged
-    // for every `HOME` value including non-UTF-8 ones, error string included,
-    // while windows, which has no `HOME`, stops failing outright.
+    // `home_dir_os` keeps `var_os` semantics (see its doc comment) and adds the
+    // windows `USERPROFILE` fallback; unix resolution is unchanged.
     let home = || crate::app_config::home_dir_os().ok_or_else(|| "HOME is not set.".to_string());
 
     if path == "~" {

--- a/apps/desktop/src-tauri/src/commands/ssh_tunnel.rs
+++ b/apps/desktop/src-tauri/src/commands/ssh_tunnel.rs
@@ -714,16 +714,16 @@ async fn wait_for_anyharness(local_url: &str) -> Result<(), String> {
 }
 
 fn expand_home_path(path: &str) -> Result<PathBuf, String> {
+    // `app_config::home_dir` reads `HOME` first and only then `USERPROFILE`,
+    // so unix resolution is unchanged (including this error string) while
+    // windows, which has no `HOME`, stops failing outright.
+    let home = || crate::app_config::home_dir().map_err(|_| "HOME is not set.".to_string());
+
     if path == "~" {
-        return std::env::var_os("HOME")
-            .map(PathBuf::from)
-            .ok_or_else(|| "HOME is not set.".to_string());
+        return home();
     }
     if let Some(rest) = path.strip_prefix("~/") {
-        let home = std::env::var_os("HOME")
-            .map(PathBuf::from)
-            .ok_or_else(|| "HOME is not set.".to_string())?;
-        return Ok(home.join(rest));
+        return Ok(home()?.join(rest));
     }
     Ok(PathBuf::from(path))
 }

--- a/lints/frontend/ratchets.toml
+++ b/lints/frontend/ratchets.toml
@@ -8,7 +8,7 @@
 
 [[max_lines]]
 path = "apps/desktop/src-tauri/src/commands/ssh_tunnel.rs"
-max_lines = 729
+max_lines = 728
 reason = "existing desktop native oversized file"
 
 [[max_lines]]


### PR DESCRIPTION
Stacked on `ci/windows-compile-check` (draft PR #2142), not `main`. That branch carries the Windows `cargo check` workflow, which is the only compile verdict available for this change. Retarget to `main` once #2142 lands.

## What this is

A sweep of `anyharness/crates/` (plus the in-scope parts of `apps/desktop/src-tauri`) for hardcoded POSIX shell and environment assumptions, and a fix for the ones that break the runtime on Windows.

None of these are compile errors. The runtime crates already build for `x86_64-pc-windows-msvc` on every release, so every `std::os::unix` use is already `cfg`-gated. These are runtime failures.

Two shared helpers rather than `cfg` at every call site, matching the `#[cfg(unix)] fn X` / `#[cfg(not(unix))] fn X` pairing the codebase already uses (`process_kill`, `integrations::agent_cli::executable::make_executable`, `integrations::mcp::capability_token::write_secret_file`):

- `anyharness-lib/src/host_shell.rs`: how a user-authored command string reaches a shell, for the piped setup runner only.
- `proliferate-worker/src/posix_shell.rs`: the worker's genuinely POSIX supervision scripts, refused up front on other platforms with an `Unsupported` error that names the reason.

## What this fixes on Windows today, and what it does not

Stated plainly because it is easy to read the table above and assume otherwise: the `setup_process.rs` change is correct but **not reachable on Windows today**. It is groundwork, not a live fix.

Both callers of `run_setup_process` first create a terminal, and that is where Windows stops:

- `live/terminals/manager.rs:194-214` calls `self.create_terminal_shell(..)` with `shell: Some(detect_posix_shell())`, then reaches `run_setup_process` at `manager.rs:254`.
- `live/terminals/command_runs/workspace_stop.rs:268-287` calls `driver::create_terminal_shell(..)` with the same `shell: Some(detect_posix_shell())`, then reaches `run_setup_process` at `workspace_stop.rs:328`.

`detect_posix_shell` (`driver/shell.rs:59`) probes `/bin/bash`, `/usr/bin/bash`, `/bin/zsh`, `/usr/bin/zsh`, `/bin/sh`, `/usr/bin/sh` and falls back to the literal `"/bin/sh"`. None of those exist on Windows, so the PTY spawn inside `create_terminal_shell` fails and `?` propagates out of both call sites before `run_setup_process`, and therefore before `host_shell`, is ever entered.

So on Windows the setup-command path fails at terminal creation, both before and after this PR. What changes is that when terminal creation is eventually made to work on Windows, the command string behind it is already quoted correctly instead of being handed to a shell that does not exist. Making terminal creation itself work on Windows is a separate and much larger change: it means a ConPTY-backed driver and a non-POSIX replacement for the sentinel wrapper protocol at `pty.rs:473`, which is deliberately out of scope here (see "Found and deliberately not changed").

The three worker sites are different. Those are genuinely POSIX supervision scripts and this PR makes them fail with a typed `Unsupported` error naming the reason rather than by trying to spawn `sh`. The four `HOME` / `USERPROFILE` sites are live fixes on Windows today, and the `home_dir_os` change is a live fix on unix today.

## Sites changed

| file:line (pre-change) | assumed | now | unix unchanged? | category |
| --- | --- | --- | --- | --- |
| `anyharness-lib/src/live/terminals/command_runs/setup_process.rs:64` | `/bin/sh -lc <setup command>` | `host_shell::command_string_shell()`: `/bin/sh -lc` on unix, `%ComSpec%` (default `cmd.exe`) `/C` with `raw_arg` elsewhere | yes. Same program, same flag, same `arg` quoting. Pinned by a test asserting `get_program()` is `/bin/sh` and `get_args()` is exactly `["-lc", <command>]` | shell genuinely needed: user-authored string that may use pipes, `&&`, globs, expansion |
| `proliferate-supervisor/src/config.rs:116` (`dirs_fallback_home`) | `HOME` only, else `"."`, so the supervisor state dir landed in the process cwd on Windows | `HOME`, then `USERPROFILE`, then `"."` | yes, `HOME` still wins whenever set, and `var_os` throughout | env assumption |
| `proliferate-supervisor/src/install/layout.rs:6` (`default_home`) | `PROLIFERATE_HOME`, then `HOME` only | `PROLIFERATE_HOME`, then `HOME`, then `USERPROFILE` | yes, both earlier keys keep priority, `var_os` throughout | env assumption |
| `proliferate-worker/src/supervisor_bridge/bridge/mod.rs:298-305` (`supervisor_live`) | `sh -c "pgrep -f '<pattern>' > /dev/null 2>&1"` | direct `Command::new("pgrep").arg("-f").arg(&pattern)` with null stdout and stderr, no shell, no quoting | yes. The function returns a bool. `pgrep`'s exit status is unchanged, the redirects become the null stdio, stdin stays inherited, and the "pgrep is missing" case moves from a non-zero shell status to a spawn error, which `unwrap_or(false)` maps to the same `false` | shell was not needed: fixed program, fixed arguments |
| `proliferate-worker/src/supervisor_bridge/bridge/mod.rs:319` (`spawn_supervisor`) | `bash -lc <detached nohup launch script>` | `posix_shell::run_script(BashLogin, ..)`, same `bash -lc` on unix, typed `Unsupported` error elsewhere | yes, same program, flag and script string; pinned by a test on the literals | shell genuinely needed and genuinely POSIX: `nohup`, `$$`, `$PPID`, `pgrep` |
| `proliferate-worker/src/anyharness_update.rs:369` (`stop_runtime`) | `sh -c <pgrep/kill script>` | `posix_shell::run_script(Sh, ..)` | yes, same program, flag, script string and error mapping | shell genuinely needed and genuinely POSIX |
| `proliferate-worker/src/anyharness_update.rs:439` (`relaunch`) | `sh -c <nohup relaunch script>` with `current_dir(workdir)` | `posix_shell::run_script(Sh, .., Some(workdir))` | yes, same program, flag, script, cwd and error mapping; cwd pinned by a test | shell genuinely needed and genuinely POSIX |
| `apps/desktop/src-tauri/src/commands/diagnostics.rs:265` (`expand_home_path`) | `var_os("HOME")`, error when unset | new `app_config::home_dir_os()`: `var_os("HOME")` then `var_os("USERPROFILE")`, original `"HOME is not set"` string preserved | yes, for every `HOME` value including non-UTF-8 and empty | env assumption |
| `apps/desktop/src-tauri/src/commands/ssh_tunnel.rs:716` (`expand_home_path`) | `var_os("HOME")`, error when unset | same, with the original `"HOME is not set."` string preserved | yes, same reasoning | env assumption |

## Review round 1: what changed

**B1, terminal shell substitution: withdrawn.** The first revision routed `driver/shell.rs` shell detection through the helper, so the `/bin/sh` last resort became `%ComSpec%` on Windows. That is reverted; `driver/shell.rs` is now byte-identical to the base branch, and `host_shell` no longer exposes shell detection at all.

The review's stated mechanism for why it was wrong does not hold, and it is worth recording why, because the conclusion is right for a different reason. The concern was that `cmd.exe` would spawn happily, the POSIX sentinel wrapper at `command_runs/pty.rs:473-477` would be written into it, the `__ANYHARNESS_CMD_END_..__` sentinel would never come back, and an untimed run would hang forever.

That cannot happen. `build_pty_command_wrapper` has exactly one caller, `run_terminal_command` at `command_runs/pty.rs:92`, and line 59 of the same function is:

```rust
if !h.shell_kind.is_posix() {
    anyhow::bail!("unsupported_terminal_shell");
}
```

`h.shell_kind` is `detect_shell_kind(&shell)` from `driver/pty.rs:69`. For `cmd.exe` that is `ShellKind::Other`, and `is_posix()` is `matches!(self, Bash | Zsh | Sh)`, so the bail fires roughly thirty lines before the wrapper is built. No script is written, no command-run row is inserted, nothing is written to the PTY. The other two paths that could have carried a POSIX payload are clear too: `startup_command` (`manager.rs:131`) funnels through the same guarded `run_terminal_command`, and both `run_setup_process` callers (`manager.rs:202`, `workspace_stop.rs:276`) use the piped runner, which is bounded by an unconditional `tokio::time::sleep_until(deadline)` arm at `setup_process.rs:206` with a non-optional `Duration`.

So the substitution could not hang. What it could do is worse than useless: it turned "PTY spawn fails at terminal creation" into "terminal opens, then every command run is refused with `unsupported_terminal_shell`". It bought nothing on Windows and moved the failure later and further from its cause. Reverting is the right call, and the review's posture point stands even though the mechanism does not: `host_shell` should not hand back an interpreter that the same crate's protocol will reject. `host_shell` is now scoped to the one path that does not use that protocol, and its module docs record the guard so nobody re-derives this.

**B2, non-UTF-8 `HOME`: accepted, real, fixed.** Routing the two desktop `expand_home_path` helpers through `app_config::home_dir()` silently moved them from `var_os` to `var` (`app_config.rs:59`). `std::env::var` returns `Err(VarError::NotUnicode)` for a non-UTF-8 value where `var_os` returns it intact, so a Linux or macOS user with a latin-1 home path would have gone from a working `~/Desktop/x.json` to "HOME is not set". Both sites now use a new `app_config::home_dir_os()` that keeps `var_os` semantics. `home_dir()` itself is left alone: its callers build the app directory and already live with the `String` constraint, and changing it would be an unrelated behaviour change.

Also taken from the review:

- `cmd.exe /C` needs `raw_arg`, not `arg`. `arg` applies the MSVCRT quoting rules on Windows, which `cmd.exe` does not parse, so `npm run build --if-present` would have arrived wrapped in quotes. `host_shell::command_string_shell` now returns a fully configured `tokio::process::Command` rather than a program-and-flag pair, so the quoting decision lives with the platform decision and no caller can miss it.
- The `[/]` escape at `bridge/mod.rs:398` is now vestigial for `supervisor_live`, which has no shell to exclude, while still load-bearing for the two callers that interpolate the pattern into a script. The doc comment says so, and the escape is kept uniform so all three callers pass byte-identical patterns.
- Both new modules now have tests, including negative controls that pin the exact unix program and flag literals (`/bin/sh` + `-lc`, `sh` + `-c`, `bash` + `-lc`). If someone changes one, the test fails.

## Found and deliberately not changed

| file:line | finding | why not now |
| --- | --- | --- |
| `anyharness-lib/src/live/terminals/command_runs/pty.rs:442-478` | `write_command_script` emits a `.sh` with `export K=V`, and `build_pty_command_wrapper` drives a POSIX sentinel protocol into the PTY | a Windows equivalent needs a `.cmd`, `set` instead of `export`, and a different sentinel protocol. A redesign, not a portability tweak. The existing `is_posix()` guard means the current behaviour is an explicit refusal, not a hang |
| `anyharness-lib/src/integrations/agent_cli/launcher.rs:86` | `generate_launcher_script` writes a `#!/bin/sh` wrapper and `chmod`s it | Windows needs a generated `.cmd`, plus every consumer of the launcher path must agree on the extension. `make_executable` is already a no-op on non-unix |
| `apps/desktop/src-tauri/src/sidecar.rs:176-178` | `format!("{home}/.cargo/bin/anyharness")` from bare `HOME`, plus an unconditional `/usr/local/bin/anyharness` candidate | the real Windows defect there is the missing `.exe` suffix across all six candidates and the bundled-sidecar lookup above them. Fixing only `HOME` leaves it equally broken, so it belongs with the desktop `.exe`-suffix pass |
| `anyharness/src/commands/catalog_probe/catalog_probe_auth.rs:139,209` | `format!("{}/.codex/auth.json", var("HOME"))` and the Grok equivalent | developer probe tooling, off the shipped runtime path. It also deliberately *sets* `HOME` for isolated child agents, which is correct as written |
| `anyharness-lib/src/app/config.rs:59`, `proliferate-worker/src/config.rs:106`, `apps/desktop/src-tauri/src/app_config.rs:59` | home lookups | already `HOME` then `USERPROFILE`. The scoping note's claim of a `HOME` vs `USERPROFILE` gap here does not hold; the real gaps were in the supervisor and the two desktop `expand_home_path` helpers |
| `anyharness-lib/src/domains/agents/installer/seed/quarantine.rs:74` | `/usr/bin/xattr` | already `#[cfg(target_os = "macos")]` |
| `apps/desktop/src-tauri/src/commands/shell.rs:73,92,112`, `.../google_workspace_mcp/auth.rs:258` | `Command::new("open")` | already `#[cfg(target_os = "macos")]` with an explicit unsupported error elsewhere |

Swept and clean: `env!("HOME")` (no hits); `/tmp`, `/usr/`, `/etc/` in non-test code (production code already uses `std::env::temp_dir()`; every `/tmp` hit is a test fixture); `:` as a PATH separator (every site uses `std::env::join_paths` / `split_paths`); `std::os::unix` and file mode bits (every non-test site is already behind a `cfg` pair, which is why the runtime crates already build for Windows).

## Left for other agents

Nothing found in the areas owned elsewhere. `anyharness-lib/src/process_kill_tests.rs:142,223,350` and `apps/desktop/src-tauri/src/sidecar/tests.rs:117,206` spawn `/bin/sh`, but those belong to the `process_kill` and desktop lanes and are test-only.

Separate from this PR and worth its own: `app/test_support.rs:152` does `.expect("expected env mutex")` on a crate-wide lock, so any single teardown panic blacks out every other test that touches the environment. See the CI note below for what that looked like in practice.

## Tests

Not run locally. CI must run them.

New in this PR:
- `anyharness-lib/src/host_shell.rs` (inline `#[cfg(all(test, unix))] mod tests`: pins `/bin/sh` + `-lc` exactly, asserts the status is returned verbatim, asserts shell syntax is actually interpreted)
- `proliferate-worker/src/posix_shell.rs` (inline `#[cfg(all(test, unix))] mod tests`: pins `sh`/`-c` and `bash`/`-lc`, exit status, requested cwd, inherited cwd)
- `apps/desktop/src-tauri/src/app_config_home_env_tests.rs` (registered from `app_config.rs` as `#[cfg(all(test, unix))] mod home_env_tests`: pins `home_dir_os` against the `var`-vs-`var_os` regression)

### Review round 2: `home_dir_os` had no coverage

Correct and worth taking seriously. Round 1 added `home_dir_os` to fix a real unix regression and then pinned nothing, so the fix could be reverted silently. It now has a test, and the test is verified by execution rather than by assertion (see the negative control below).

Four cases, covering the whole contract rather than the happy path: a non-UTF-8 `HOME` (the case that is the entire difference between `var` and `var_os`, built with `OsStringExt::from_vec(b"/home/caf\xC3(\xFF".to_vec())`), the `USERPROFILE` fallback, `HOME` winning over `USERPROFILE`, and neither set.

Each case runs in a re-exec of the test binary rather than by mutating the process environment in place. That is not incidental: `commands/cloud_worker/tests.rs:488` and `:515` call `app_config::home_dir().expect("resolve user home")` in this same test binary, and libtest runs tests on parallel threads, so pointing `HOME` at invalid UTF-8 in-process would panic those two tests at random. The parent also asserts the child's stdout contains `1 passed`, so a mistyped filter that matches zero tests cannot pass vacuously.

### Negative control for that test

Run [32444401834](https://github.com/proliferate-ai/proliferate/actions/runs/32444401834), with `home_dir_os` deliberately reverted to `std::env::var` and everything else identical. One job red, `Cargo check & test`, and exactly one test in the workspace red:

```
---- app_config::home_env_tests::home_dir_os_reads_the_environment_without_utf8_validation stdout ----

thread 'app_config::home_env_tests::home_dir_os_reads_the_environment_without_utf8_validation' (32909) panicked at apps/desktop/src-tauri/src/app_config_home_env_tests.rs:96:5:
scenario `non_utf8_home` failed in the child:

thread 'app_config::home_env_tests::home_dir_os_reads_the_environment_without_utf8_validation' (32912) panicked at apps/desktop/src-tauri/src/app_config_home_env_tests.rs:64:28:
assertion `left == right` failed
  left: None
 right: Some("/home/caf\xC3(\xFF")

test result: FAILED. 485 passed; 1 failed; 5 ignored; 0 measured; 0 filtered out; finished in 19.47s
error: test failed, to rerun pass `-p proliferate --lib`
```

`left: None` is the regression exactly: `var` returns `Err(VarError::NotUnicode)`, `.ok()` discards it, and `USERPROFILE` is unset. Note also that the same run reported `test result: ok. 2218 passed; 0 failed` for the anyharness crates, which is the reviewer's finding reproduced: nothing else in the workspace notices.

That commit was squashed out and is not in this branch. It exists only as the run linked above.

Existing coverage over touched code:
- `anyharness-lib/src/live/terminals/manager_tests.rs`
- `anyharness-lib/src/live/terminals/command_runs/pty_command_tests.rs`
- `anyharness-lib/src/live/terminals/driver/shell.rs` (inline `mod tests`; the file is now unchanged from base, so this is a no-op regression check)
- `proliferate-worker/src/anyharness_update.rs` (inline `mod tests`: `stop_runtime_script`, `pgrep_pattern_for_path`, `shell_single_quote`)
- `proliferate-worker/src/supervisor_bridge/bridge/tests.rs` (fake `BridgeHost`, so the rewritten `RealBridgeHost::supervisor_live` is not asserted against the old script text)
- `proliferate-supervisor/` config tests
- `apps/desktop/src-tauri/src/commands/diagnostics.rs` (inline `mod tests`)

`rustfmt --edition 2021 --check` was run over every touched file; no drift in any changed hunk.

## Windows CI result

`Windows compile check` run [32445075467](https://github.com/proliferate-ai/proliferate/actions/runs/32445075467) on this PR head, `cargo check --target x86_64-pc-windows-msvc` on `windows-latest`:

- `runtime crates (control)` (`-p anyharness -p proliferate-worker -p proliferate-supervisor`): job `success`, `cargo check` step `success`, 2m06s.
- `desktop crates (the unknown)` (`-p proliferate --keep-going`): job `success`, `cargo check` step `success`, 1m40s, no errors in the step summary.

Both jobs are `continue-on-error: true`, so those per-step conclusions were read from the jobs API rather than the check-run status, which reports `success` either way.

Baseline run [32438080854](https://github.com/proliferate-ai/proliferate/actions/runs/32438080854) on `ci/windows-compile-check` itself (PR #2142): both jobs `success`, both `cargo check` steps `success`. Windows was already compile-clean and this change keeps it clean. What it fixes is runtime behaviour, which no compiler can see.

## Full CI result

All 20 checks green on this head (run [32445075483](https://github.com/proliferate-ai/proliferate/actions/runs/32445075483)): `Cargo check & test`, `Repo shape checks`, `Build SDK`, `Desktop frontend build`, `Web frontend build`, `Shared frontend packages`, `Mobile typecheck`, `intent-tests`, `intent-billing`, `Workflow definition lifecycle (tier-2)`, `Transcript scroll physics (chromium + webkit)`, `Login first-load budget (phase-6)`, `Terraform validate (server/infra)`, `CI/CD config checks`, `Validate PR title and labels`, `Candidate build handoff`, `Vercel`, plus the two Windows jobs above.

All eight new tests ran and passed, confirmed from the job log rather than assumed:

```
test host_shell::tests::unix_invocation_is_exactly_bin_sh_dash_lc ... ok
test host_shell::tests::the_command_string_is_interpreted_by_a_shell_and_its_status_is_returned ... ok
test host_shell::tests::shell_syntax_in_the_command_string_is_honoured ... ok
test posix_shell::tests::programs_and_flags_are_the_original_literals ... ok
test posix_shell::tests::the_scripts_exit_status_is_returned_verbatim ... ok
test posix_shell::tests::a_requested_working_directory_is_applied ... ok
test posix_shell::tests::without_a_working_directory_the_script_inherits_the_process_cwd ... ok
test app_config::home_env_tests::home_dir_os_reads_the_environment_without_utf8_validation ... ok
```

The desktop lib suite on this head reports `test result: ok. 486 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out; finished in 19.51s`, against `test result: FAILED. 485 passed; 1 failed; 5 ignored` on the negative-control run above. Same 486 tests, one flipped.

`Shared frontend packages` went red once on this head and passed on rerun of that job alone, with no code change. The failing test was `ComposerCommandEditor.test.tsx > uses the caret-local slash trigger without replacing trailing text` with `AssertionError: expected false to be true`, a Lexical caret and selection test. This branch changes no JS, TS or JSON at all (`git diff --stat ci/windows-compile-check...HEAD -- '*.ts' '*.tsx' '*.js' '*.json'` is empty), and the same job was `success` on the negative-control run whose tree differed only by `var` versus `var_os` in one Rust file, so it cannot be caused by this change.

`Repo shape checks` went red once on this revision and is fixed: a four-line comment pushed `ssh_tunnel.rs` from 729 to 730 lines, one past its recorded `max_lines` ratchet. The comment moved onto `app_config::home_dir_os`'s own doc, taking the file to 728, and `lints/frontend/ratchets.toml` is ratcheted down to match. `check_max_lines.py`, `lint_records.py`, `test_lint_records.py`, `check_anyharness_old_paths.py` and `check_proliferate_worker_structure.py` were all run locally before pushing.

On the earlier revision, `Cargo check & test` failed once and passed on rerun. The root failure was `fork_dispatch_and_restart_tests.rs:579` doing `std::fs::remove_dir_all(&runtime_home).expect("remove runtime home")` and hitting `Os { code: 39, kind: DirectoryNotEmpty }`, a teardown race in a test this change does not touch. That panic poisoned the crate-wide `test_support::lock_env` mutex, and the other 73 of the 74 reported failures are all the same cascading `expected env mutex` panic at `app/test_support.rs:152`. The first `FAILED` line printed (`cold_restart_refuses_process_local_fork_children_without_r1_proof`) is a poison victim, not the root; test output order is not causal order here. It has not recurred across the two subsequent runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



