### PR TITLE
fix(release): restore the windows desktop release path

### DIFF
--- a/.github/workflows/_deploy-desktop.yml
+++ b/.github/workflows/_deploy-desktop.yml
@@ -24,6 +24,10 @@ on:
       target_os:
         default: all
         type: string
+      enable_windows_beta:
+        description: "Opt into building the Windows beta leg (never on by default; see B2 in PR #2150)"
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -166,6 +170,7 @@ jobs:
               echo "- Dry run: \`${{ inputs.dry_run }}\`"
               echo "- Publish updater: \`${{ inputs.publish_updater }}\`"
               echo "- Target OS: \`${{ inputs.target_os }}\`"
+              echo "- Windows beta enabled: \`${{ inputs.enable_windows_beta }}\`"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -183,4 +188,5 @@ jobs:
       publish_updater: ${{ inputs.publish_updater }}
       release_title: ${{ inputs.release_title }}
       target_os: ${{ inputs.target_os }}
+      enable_windows_beta: ${{ inputs.enable_windows_beta }}
     secrets: inherit

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -22,6 +22,10 @@ on:
           - macos
           - windows
         default: all
+      enable_windows_beta:
+        description: "Opt into building the Windows beta leg (never on by default; see B2 in PR #2150)"
+        type: boolean
+        default: false
       allow_unsigned:
         description: "Allow ad-hoc (unsigned) macOS builds when APPLE_SIGNING_IDENTITY is not configured"
         type: boolean
@@ -53,6 +57,10 @@ on:
         description: "Target OS"
         type: string
         default: all
+      enable_windows_beta:
+        description: "Opt into building the Windows beta leg (never on by default; see B2 in PR #2150)"
+        type: boolean
+        default: false
       allow_unsigned:
         description: "Allow ad-hoc (unsigned) macOS builds when APPLE_SIGNING_IDENTITY is not configured"
         type: boolean
@@ -109,7 +117,11 @@ jobs:
           #   runner_os: macos
           # Windows was removed 2026-04-13 by 3d3c0504b8 because the SDK
           # generate step was POSIX-shell only. That step is node now, so the
-          # leg is back for the beta.
+          # leg is back for the beta. The matrix entry itself is unconditional;
+          # "Decide whether to build this matrix entry" below is what actually
+          # keeps it from running unless `enable_windows_beta` is explicitly
+          # true, so it never rides along on push, workflow_call or
+          # unattended workflow_dispatch runs.
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             runner_os: windows
@@ -133,12 +145,21 @@ jobs:
         shell: bash
         env:
           TARGET_OS: ${{ inputs.target_os || 'all' }}
+          # `inputs.enable_windows_beta` is only populated on workflow_dispatch
+          # and workflow_call. A `push` (desktop-v* tag) event carries no
+          # inputs at all, so this is empty/false there too, and the Windows
+          # leg cannot ride along on a tag push. Every workflow_call caller
+          # must opt in explicitly; none does today (see guides/deploying/releases.md).
+          ENABLE_WINDOWS_BETA: ${{ inputs.enable_windows_beta && 'true' || 'false' }}
         run: |
+          skip=false
           if [[ "${{ github.event_name }}" != "push" ]] && [[ "$TARGET_OS" != "all" ]] && [[ "$TARGET_OS" != "${{ matrix.runner_os }}" ]]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
+            skip=true
           fi
+          if [[ "${{ matrix.runner_os }}" == "windows" ]] && [[ "$ENABLE_WINDOWS_BETA" != "true" ]]; then
+            skip=true
+          fi
+          echo "skip=$skip" >> "$GITHUB_OUTPUT"
 
       - name: Validate release ref
         if: steps.filter.outputs.skip != 'true' && github.event_name == 'workflow_dispatch' && !inputs.dry_run && !inputs.git_sha
@@ -326,7 +347,7 @@ jobs:
         shell: bash
         run: |
           echo "::warning::Windows beta ships a placeholder diagnostics collector. proliferate-diagnostics-collector does not compile for x86_64-pc-windows-msvc, so in-app diagnostics capture, the support-report snapshot and the collector-backed export path are all unavailable in this build."
-          echo "::warning::Windows beta ships no bundled agent seed. agent-seed.inputs.json pins Node only for the two Apple targets and build-agent-seed.mjs is native-macOS-only, so this build sets PROLIFERATE_AGENT_SEED_EXPECTED with no seed present and agents fall back to whatever Node the machine already has."
+          echo "::warning::Windows beta ships no bundled agent seed. agent-seed.inputs.json pins Node only for the two Apple targets and build-agent-seed.mjs is native-macOS-only, so this build sets ANYHARNESS_AGENT_SEED_EXPECTED with no seed present. No managed agent launcher can run on Windows yet (see PR body), so there is no fallback to \"whatever Node the machine already has\" either."
           echo "::warning::Windows installers are not Authenticode signed. First launch shows a click-through SmartScreen warning. The Tauri updater minisign signature is separate and is applied."
 
       - name: Stage Proliferate debug helper for target

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -20,6 +20,7 @@ on:
         options:
           - all
           - macos
+          - windows
         default: all
       allow_unsigned:
         description: "Allow ad-hoc (unsigned) macOS builds when APPLE_SIGNING_IDENTITY is not configured"
@@ -106,8 +107,20 @@ jobs:
           # - os: macos-15-intel
           #   target: x86_64-apple-darwin
           #   runner_os: macos
+          # Windows was removed 2026-04-13 by 3d3c0504b8 because the SDK
+          # generate step was POSIX-shell only. That step is node now, so the
+          # leg is back for the beta.
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            runner_os: windows
 
     runs-on: ${{ matrix.os }}
+
+    # Beta posture: Windows is best effort. A failed Windows leg must not take
+    # the macOS release down with it, and `needs: build-desktop` on
+    # create-release would do exactly that if this job reported failure. Delete
+    # this line to make Windows release-blocking.
+    continue-on-error: ${{ matrix.runner_os == 'windows' }}
 
     env:
       # The desktop renderer (vite) build OOMs the default Node heap on the
@@ -173,6 +186,7 @@ jobs:
 
       - name: Validate release title
         if: steps.filter.outputs.skip != 'true'
+        shell: bash
         env:
           RELEASE_TITLE: ${{ inputs.release_title || '' }}
         run: |
@@ -235,11 +249,24 @@ jobs:
         if: steps.filter.outputs.skip != 'true'
         shell: bash
         run: |
-          cargo build --release --target "${{ matrix.target }}" \
-            -p anyharness \
-            -p proliferate-diagnostics-collector \
-            -p proliferate-debug \
-            -p proliferate-worker
+          # proliferate-diagnostics-collector is POSIX-only: process.rs reads an
+          # inherited descriptor through an unconditional `use std::os::fd`, so
+          # the crate does not compile for x86_64-pc-windows-msvc at all. The
+          # desktop build script already recognizes Windows as an unsupported
+          # collector target and stages an explicit placeholder sidecar, so
+          # asking cargo for the real one here would only fail the leg.
+          if [[ "${{ matrix.runner_os }}" == "windows" ]]; then
+            cargo build --release --target "${{ matrix.target }}" \
+              -p anyharness \
+              -p proliferate-debug \
+              -p proliferate-worker
+          else
+            cargo build --release --target "${{ matrix.target }}" \
+              -p anyharness \
+              -p proliferate-diagnostics-collector \
+              -p proliferate-debug \
+              -p proliferate-worker
+          fi
           mkdir -p apps/desktop/src-tauri/binaries
           if [[ "${{ matrix.runner_os }}" == "windows" ]]; then
             cp "target/${{ matrix.target }}/release/anyharness.exe" "apps/desktop/src-tauri/binaries/anyharness-${{ matrix.target }}.exe"
@@ -279,7 +306,7 @@ jobs:
           spctl --assess --verbose=4 --type open --context context:primary-signature "$EXTRACTED_NODE_BIN"
 
       - name: Stage diagnostics collector for target
-        if: steps.filter.outputs.skip != 'true'
+        if: steps.filter.outputs.skip != 'true' && matrix.runner_os != 'windows'
         shell: bash
         run: |
           mkdir -p apps/desktop/src-tauri/binaries
@@ -289,6 +316,18 @@ jobs:
           cp "$collector" "$staged"
           chmod +x "$staged"
           cmp "$collector" "$staged"
+
+      # Say the losses out loud rather than letting a placeholder sidecar and an
+      # empty resource directory pass for working ones. The desktop build script
+      # writes the collector placeholder; this step exists so the release log
+      # records what a Windows user does not get.
+      - name: Report Windows beta gaps
+        if: steps.filter.outputs.skip != 'true' && matrix.runner_os == 'windows'
+        shell: bash
+        run: |
+          echo "::warning::Windows beta ships a placeholder diagnostics collector. proliferate-diagnostics-collector does not compile for x86_64-pc-windows-msvc, so in-app diagnostics capture, the support-report snapshot and the collector-backed export path are all unavailable in this build."
+          echo "::warning::Windows beta ships no bundled agent seed. agent-seed.inputs.json pins Node only for the two Apple targets and build-agent-seed.mjs is native-macOS-only, so this build sets PROLIFERATE_AGENT_SEED_EXPECTED with no seed present and agents fall back to whatever Node the machine already has."
+          echo "::warning::Windows installers are not Authenticode signed. First launch shows a click-through SmartScreen warning. The Tauri updater minisign signature is separate and is applied."
 
       - name: Stage Proliferate debug helper for target
         if: steps.filter.outputs.skip != 'true'
@@ -651,6 +690,21 @@ jobs:
           name: proliferate-dmg-${{ matrix.target }}
           path: |
             target/${{ matrix.target }}/release/release-artifacts/*.dmg
+          if-no-files-found: error
+          compression-level: 0
+
+      # Restored from 3d3c0504b8. There is no name-normalization step on this
+      # path: the updater and installer manifests match Tauri's own NSIS output
+      # name, which already carries the x64 arch token.
+      - name: Upload build artifacts (Windows)
+        if: steps.filter.outputs.skip != 'true' && matrix.runner_os == 'windows'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: desktop-${{ matrix.target }}
+          path: |
+            target/${{ matrix.target }}/release/bundle/**/*.msi
+            target/${{ matrix.target }}/release/bundle/**/*-setup.exe
+            target/${{ matrix.target }}/release/bundle/**/*-setup.exe.sig
           if-no-files-found: error
           compression-level: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,6 +336,13 @@ jobs:
       # to a GitHub Environment, so there is no approval gate on this step.
       publish_updater: true
       target_os: all
+      # Deliberately not opted into the Windows beta leg (see B2 in PR #2150):
+      # this is the unattended zero-touch auto-prod path with no approval
+      # gate, and the Windows leg has never completed a real build. Leaving
+      # this at its `false` default means `target_os: all` still only builds
+      # macOS here. Flip to `true` only once the Windows leg has a proven
+      # green dry run and B1 (continue-on-error run-conclusion) is resolved.
+      enable_windows_beta: false
     secrets: inherit
 
   # ── Production deploys ────────────────────────────────────────────────────────

--- a/apps/desktop/src-tauri/src/agent_seed_env.rs
+++ b/apps/desktop/src-tauri/src/agent_seed_env.rs
@@ -28,6 +28,10 @@ pub(crate) fn current_target_triple() -> &'static str {
     {
         "x86_64-pc-windows-msvc"
     }
+    #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
+    {
+        "aarch64-pc-windows-msvc"
+    }
 }
 
 pub(crate) fn launch_env<R: Runtime>(app: &AppHandle<R>) -> HashMap<String, String> {

--- a/guides/deploying/releases.md
+++ b/guides/deploying/releases.md
@@ -67,8 +67,8 @@ the Desktop package, Tauri configuration, and Cargo package. A manual dry run
 can build from the selected ref without publishing. A manual non-dry run must
 be dispatched from an existing `desktop-v*` tag ref; a branch ref fails release
 validation. Tag pushes and publishing release-coordinator calls can build the
-current macOS matrix and create a draft GitHub Release. Updater/download
-publication is separate:
+current macOS and Windows matrix and create a draft GitHub Release.
+Updater/download publication is separate:
 
 - a `desktop-v*` tag push publishes it automatically;
 - a reusable production or train call can request it explicitly;
@@ -85,6 +85,35 @@ collector package first and stages that exact executable into the app. Verify
 the app's `Contents/MacOS` inventory contains executable, signed AnyHarness,
 Worker, `proliferate-debug`, and `proliferate-diagnostics-collector` binaries;
 the collector must not contain the debug placeholder marker.
+
+### Windows Beta
+
+Windows (`x86_64-pc-windows-msvc`) returned to the matrix on 2026-08-20, having
+been removed on 2026-04-13 while the SDK generation step was POSIX-shell only.
+It is a beta leg and is deliberately not release-blocking:
+
+- the Windows matrix entry runs `continue-on-error`, so a failed Windows build
+  leaves the macOS release and the updater publish intact;
+- `windows-x86_64` is an `optional` platform in both
+  `scripts/generate-updater-manifest.mjs` and
+  `scripts/generate-desktop-installer-manifest.mjs`, so a release with no
+  Windows artifact publishes without a Windows entry rather than failing;
+- the Windows installer is not Authenticode signed, so first launch shows a
+  SmartScreen warning that the user clicks through. The Tauri updater's
+  minisign signature is a separate mechanism and is applied, so in-app updates
+  still verify;
+- `proliferate-diagnostics-collector` does not compile for Windows, so the
+  Windows build ships a placeholder sidecar and has no in-app diagnostics
+  capture or support snapshot;
+- there is no bundled agent seed on Windows. `agent-seed.inputs.json` pins Node
+  only for the two Apple targets and `scripts/build-agent-seed.mjs` is
+  native-macOS-only, so a Windows build sets `PROLIFERATE_AGENT_SEED_EXPECTED`
+  with no seed present and agents use whatever Node the machine already has.
+
+The build logs a warning annotation for each of those gaps.
+
+To make Windows release-blocking, delete the `continue-on-error` line from
+`build-desktop` and drop `optional` from the `windows-x86_64` entries.
 
 ## Runtime And SDK
 

--- a/guides/deploying/releases.md
+++ b/guides/deploying/releases.md
@@ -88,32 +88,18 @@ the collector must not contain the debug placeholder marker.
 
 ### Windows Beta
 
-Windows (`x86_64-pc-windows-msvc`) returned to the matrix on 2026-08-20, having
-been removed on 2026-04-13 while the SDK generation step was POSIX-shell only.
-It is a beta leg and is deliberately not release-blocking:
+Windows (`x86_64-pc-windows-msvc`) returned to the matrix on 2026-08-20, having been removed on 2026-04-13 while the SDK generation step was POSIX-shell only. It is a beta leg, it is deliberately not release-blocking, and it is opt-in only:
 
-- the Windows matrix entry runs `continue-on-error`, so a failed Windows build
-  leaves the macOS release and the updater publish intact;
-- `windows-x86_64` is an `optional` platform in both
-  `scripts/generate-updater-manifest.mjs` and
-  `scripts/generate-desktop-installer-manifest.mjs`, so a release with no
-  Windows artifact publishes without a Windows entry rather than failing;
-- the Windows installer is not Authenticode signed, so first launch shows a
-  SmartScreen warning that the user clicks through. The Tauri updater's
-  minisign signature is a separate mechanism and is applied, so in-app updates
-  still verify;
-- `proliferate-diagnostics-collector` does not compile for Windows, so the
-  Windows build ships a placeholder sidecar and has no in-app diagnostics
-  capture or support snapshot;
-- there is no bundled agent seed on Windows. `agent-seed.inputs.json` pins Node
-  only for the two Apple targets and `scripts/build-agent-seed.mjs` is
-  native-macOS-only, so a Windows build sets `PROLIFERATE_AGENT_SEED_EXPECTED`
-  with no seed present and agents use whatever Node the machine already has.
+- the Windows matrix entry is skipped unless the caller explicitly sets `enable_windows_beta: true`. Every automatic caller (`deploy-staging.yml`, `promote-production.yml`, `hotfix-production.yml` through `_deploy-desktop.yml`, and `nightly-release-train.yml` directly) leaves it at its `false` default, and a plain `desktop-v*` tag push carries no inputs at all, so it also defaults to `false`. Only an explicit `workflow_dispatch` run with `enable_windows_beta: true` builds Windows;
+- the Windows matrix entry also runs `continue-on-error`, so on the runs where it is enabled, a failed Windows build leaves the macOS release and the updater publish intact;
+- `windows-x86_64` is an `optional` platform in both `scripts/generate-updater-manifest.mjs` and `scripts/generate-desktop-installer-manifest.mjs`, so a release with no Windows artifact publishes without a Windows entry rather than failing;
+- the Windows installer is not Authenticode signed, so first launch shows a SmartScreen warning that the user clicks through. The Tauri updater's minisign signature is a separate mechanism and is applied, so in-app updates still verify;
+- `proliferate-diagnostics-collector` does not compile for Windows, so the Windows build ships a placeholder sidecar and has no in-app diagnostics capture or support snapshot;
+- there is no bundled agent seed on Windows. `agent-seed.inputs.json` pins Node only for the two Apple targets and `scripts/build-agent-seed.mjs` is native-macOS-only, so a Windows build sets `ANYHARNESS_AGENT_SEED_EXPECTED` with no seed present. There is also no managed agent launcher that can run on Windows yet (the launcher is a `#!/bin/sh` script), so there is no fallback to "whatever Node the machine already has": no agent session can start on a Windows build today regardless of seed state.
 
 The build logs a warning annotation for each of those gaps.
 
-To make Windows release-blocking, delete the `continue-on-error` line from
-`build-desktop` and drop `optional` from the `windows-x86_64` entries.
+To make Windows release-blocking, delete the `continue-on-error` line from `build-desktop` and drop `optional` from the `windows-x86_64` entries. To make it build automatically on one of the existing pipelines, pass `enable_windows_beta: true` from that caller.
 
 ## Runtime And SDK
 


### PR DESCRIPTION
## What was broken

Commit `3d3c0504b8` ("Disable Windows desktop releases", 2026-04-13) removed the Windows leg from the desktop release lane. The stated reason, recorded in the doc note it added, was that Windows stayed off "until the SDK generation step is Windows-safe". That step was `anyharness/sdk`'s `generate:openapi`, a POSIX shell one liner starting `mkdir -p generated src/generated`, which fails under `cmd.exe`. It is a node script now, so the reason no longer holds.

Worth recording because it redirected this work: the desktop crate itself was never the blocker. A `cargo check --target x86_64-pc-windows-msvc -p proliferate --keep-going` on a real `windows-latest` runner finishes clean today, with only dead-code warnings. The desktop crate has compiled for Windows the whole time. The blocker is purely the release path.

## What `3d3c0504b8` removed, and what came back

The April commit removed exactly four things. All four are restored:

1. the `windows` option on the `target_os` workflow_dispatch input;
2. the `os: windows-latest / target: x86_64-pc-windows-msvc / runner_os: windows` matrix entry;
3. the "Upload build artifacts (Windows)" step collecting `*.msi`, `*-setup.exe` and `*-setup.exe.sig`;
4. the `windows-x86_64` platform entry in `scripts/generate-updater-manifest.mjs`.

It also touched `Cargo.lock`, `desktop/package.json`, `desktop/src-tauri/Cargo.toml` and `desktop/src-tauri/tauri.conf.json`. Verified rather than assumed: those four are a pure `0.1.12` to `0.1.14` version bump with nothing Windows-related in them, so nothing there needed restoring.

## What changed because the repo moved on

A blind revert would not have applied and would not have been correct. Beyond `desktop/` becoming `apps/desktop/`:

- **The upload step needed re-siting.** The macOS path now stages into a `release-artifacts` directory with normalized names and uses a SHA-pinned `actions/upload-artifact` with `compression-level: 0`. The restored Windows step uses the same pinned action but keeps the April approach of uploading straight from the bundle directory, because both manifests match Tauri's own NSIS output name and that name already carries the `x64` arch token. No normalization step is needed on this path.
- **`proliferate-diagnostics-collector` cannot be built for Windows.** Its `src/process.rs` line 3 is an unconditional `use std::os::fd::FromRawFd`, so the crate does not compile for `x86_64-pc-windows-msvc` at all. The combined `cargo build` step therefore drops that package on Windows, and the "Stage diagnostics collector for target" step is now `matrix.runner_os != 'windows'`. This is not an improvised workaround: `build_packaging.rs` already treats Windows as an unsupported collector target, writes an explicit placeholder sidecar for it, and `validate_staged_sidecars` already allows a placeholder for exactly that case. The Windows path was designed, just never exercised.
- **A new `windows-x86_64` entry in `scripts/generate-desktop-installer-manifest.mjs`.** That sibling script did not exist in April. It points at the NSIS `setup.exe` rather than the MSI, because the publish job's S3 upload filter copies `*-setup.exe` and `*-setup.exe.sig` but not `*.msi`. The MSI reaches the GitHub Release only.
- **`shell: bash` added to the "Validate release title" step.** It is the only ungated `run:` step in `build-desktop` with no explicit shell, so on a Windows runner it would have executed its backslash-continued, `$RELEASE_TITLE`-interpolating script under `pwsh`. Every other ungated step already declares bash.
- **A first test file for the installer manifest script.** It had none.

## What survived the disable

Grepping the whole workflow for `windows` before touching it, more had survived than expected, which is why this is mostly restoration rather than new work:

- `matrix.runner_os == "windows"` `.exe` branches already exist in the anyharness copy step, the `proliferate-debug` staging step, the `proliferate-worker` staging step, and the `ANYHARNESS_BIN` export in the Tauri build step;
- the Tauri build step already falls through to `pnpm tauri build --bundles msi,nsis` for non-macOS;
- "Verify updater artifacts" already has an `else` branch asserting `nsis/*-setup.exe` and `nsis/*-setup.exe.sig`;
- the S3 upload filter in `publish-updater` already includes `*-setup.exe` and `*-setup.exe.sig`;
- the rust cache step's own comment refers to "any dormant windows entry";
- `apps/desktop/src-tauri/build.rs` and `build_packaging.rs` are thoroughly Windows-aware, with `.exe` suffixing throughout;
- `tauri.conf.json` already carries `icons/icon.ico` and an updater `windows.installMode`.

## Decision for you: the fail-closed manifest

`scripts/generate-updater-manifest.mjs` is fail-closed by design. A declared platform with no matching artifact pushes to `errors` and exits non-zero, so naively restoring `windows-x86_64` would make any Windows build failure kill the whole release, macOS included.

The mechanism to avoid that already exists and I did not invent a new one. When Intel builds were paused on 2026-08-20, `darwin-x86_64` was given `optional: true`, which downgrades a missing artifact to a skip with a warning. I reused it verbatim for `windows-x86_64` in both manifest scripts.

`optional` alone is not sufficient, and this is the part that needs your ruling. `create-release` and `publish-updater` both declare `needs: build-desktop`, so a failed Windows matrix leg would skip them outright no matter what the manifest script does. To make the beta posture real I also set `continue-on-error: ${{ matrix.runner_os == 'windows' }}` on `build-desktop`.

The tradeoff, stated plainly:

- **As implemented (Windows non-blocking).** A broken Windows build produces a release with no Windows update entry and no Windows download entry. macOS ships. The cost is that a Windows regression is a warning annotation on a green run, so it can go unnoticed for a release or two if nobody reads the log.
- **The alternative (Windows blocking).** Drop `continue-on-error` and drop `optional` from both `windows-x86_64` entries. A Windows regression then stops every desktop release until it is fixed. Correct once Windows is a supported platform, too strict for a first beta on a leg that has never once run.

I recommend the non-blocking posture for the beta and flipping it the moment Windows has shipped one clean release. Both switches are one line each and are named in the code comments and in the docs so the reversal is obvious. If you want the stricter posture now, say so and I will pull both lines.

## What a Windows user loses, stated loudly rather than stubbed silently

Three warning annotations are emitted from a `Report Windows beta gaps` step so the release log records the losses instead of a placeholder passing for a working component:

1. **No diagnostics collector.** The crate does not compile for Windows, so a placeholder sidecar ships. In-app diagnostics capture, the support-report snapshot, and the collector-backed export path are all unavailable.
2. **No bundled agent seed.** See the blocker below.
3. **No Authenticode signature.** First launch shows a click-through SmartScreen warning, per your explicit acceptance for the beta.

## Blocker left deliberately untouched: the Windows agent seed

This one is genuinely a separate change and I stopped rather than half-doing it.

`Build bundled agent seed` is gated `matrix.runner_os == 'macos'`, so a Windows build produces no seed archive. At runtime `agent_seed_env.rs` finds no bundled seed, `bundled_seed_dir` returns `None`, and in a release build it still sets `ANYHARNESS_AGENT_SEED_EXPECTED=1`. See "Hard runtime dependency" below for what that actually means on Windows today: not a fallback to whatever Node the machine has, but no managed agent launcher that can run at all yet.

Fixing it means three things that do not belong in a workflow restoration PR:

- `apps/desktop/src-tauri/agent-seed.inputs.json` pins Node only for `aarch64-apple-darwin` and `x86_64-apple-darwin`, so a Windows Node distribution and its checksum need adding;
- `installNode` in `scripts/build-agent-seed.mjs` unpacks a tarball, and the Windows Node distribution is a zip;
- `hostTarget()` maps only `darwin`, and `assertNativeTarget` hard-fails any other host, so the seed builder cannot currently run on a Windows runner at all.

Also out of scope by assignment, noted in case the dispatch surfaces them: `anyharness/crates/anyharness-lib/src/process_kill.rs` Windows support and the agent catalog Windows pins are owned by other agents in parallel.

## Signing

No Authenticode signing was added, per your acceptance of the SmartScreen click-through. The Tauri updater's minisign signature is a separate mechanism and does apply to the Windows artifact: `TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` are set at workflow `env:` level, not inside a macOS-gated step, so they reach the Windows `pnpm tauri build` unchanged, and `bundle.createUpdaterArtifacts` is `true` for every target. That is what produces the `*-setup.exe.sig` the restored upload step and the existing "Verify updater artifacts" Windows branch both expect.

## Verified

- `actionlint .github/workflows/release-desktop.yml` exits 0.
- `node --check` passes on both modified manifest scripts.
- `node --test scripts/ci-cd/generate-updater-manifest.test.mjs scripts/ci-cd/generate-desktop-installer-manifest.test.mjs` reports `# pass 11 / # fail 0`.
- Negative control on the new coverage: deleting `optional: true` from the `windows-x86_64` entry in each script turns exactly the three intended tests red (`still generates a manifest when the Windows beta leg produced nothing` in both files, plus the Intel-paused test), and restoring it returns all 11 to green.
- `python3 scripts/check_docs.py` and `python3 scripts/check_max_lines.py` both pass.
- `git show 3d3c0504b8` read in full to confirm the four removals and that the remaining four touched files are a version bump only.

## Unverified

Updated twice now: once after the first dry run (B1 section above), and again after a follow-up run once the Sentry blocker below was cleared. Still unproven:

- that `resources: ["agent-seeds/"]` bundles cleanly when the directory holds only its `.gitignore`;
- that the transparent, `titleBarStyle: Overlay` window config produces a usable window on Windows.

Now confirmed rather than assumed:

- `cargo build --release --target x86_64-pc-windows-msvc -p anyharness -p proliferate-debug -p proliferate-worker` succeeds on `windows-latest` (PR #2146's territory, first exercised for real here);
- `pnpm install` and the SDK `generate`/`build` steps succeed on a Windows runner;
- the `continue-on-error` run-conclusion question from B1, resolved as described in that section;
- **`pnpm tauri build --bundles msi,nsis` succeeds on `windows-latest`, and the NSIS naming assumption was correct.** Run **https://github.com/proliferate-ai/proliferate/actions/runs/32447570745** is the first `pnpm tauri build` this repo has ever run on Windows. Tauri's bundler log reports `Finished 2 bundles`, producing `Proliferate_0.4.21_x64_en-US.msi` and `Proliferate_0.4.21_x64-setup.exe`, each with a `.sig` file. The NSIS installer name is exactly `Proliferate_{version}_x64-setup.exe`, which matches both the `compgen -G "$base/nsis/*-setup.exe"` glob in `release-desktop.yml` and the `/(x64|x86_64).*setup\.exe$/i` regex in both manifest scripts. Only the MSI carries an extra `_en-US` locale infix, and no matcher depends on the MSI name, so it does not matter.

## Review findings addressed

### B2 (blocking): the Windows leg was not opt-in

The reviewer is right: the matrix entry at `release-desktop.yml:112-115` was unconditional, and the filter step only skipped a leg on `event_name != 'push'` with an explicit `target_os` override. Every caller passed `all`, and a `desktop-v*` tag push bypassed the filter entirely (a push event carries no `inputs` at all, so `target_os` fell back to its `'all'` default with no way to override it). On merge as originally written, Windows would have started building on every staging deploy, every nightly zero-touch auto-prod train, every promote, and every hotfix, on a leg that had never once completed.

Fixed by adding a new `enable_windows_beta` input, declared identically to `dry_run` and `target_os` on both `workflow_dispatch` and `workflow_call`, defaulting to `false`. The "Decide whether to build this matrix entry" step now also skips the Windows leg whenever `enable_windows_beta` is not explicitly `true`, regardless of event type.

**Note: this branch was rebased during review, and PR #2140 landed in that window.** #2140 unified `nightly-release-train.yml`, `promote-production.yml` and `hotfix-production.yml` into a single `release.yml` (hotfix and promote are now inputs on that one workflow: `ref` + `surfaces` for hotfix, `skip_build` for promote, per its own header comment). Git's rename-follow reapplied the `enable_windows_beta: false` hunk from my original three-file version onto the sole surviving `release-desktop` call site at `release.yml:321-343`, and it landed correctly there. Traced through the two real paths that exist post-#2140, plus the tag push:

- **`deploy-staging.yml` -> `_deploy-desktop.yml` -> `release-desktop.yml`.** `_deploy-desktop.yml` gained the same `enable_windows_beta` input (default `false`), threaded straight through. Neither `deploy-staging.yml` nor `_deploy-desktop.yml` overrides it, so it resolves to `false`. **Windows no longer builds on staging deploy.**
- **`release.yml` -> `release-desktop.yml`.** This is the unified pipeline that replaced the nightly train, promote, and hotfix: the daily cron and the `workflow_dispatch` covering all three modes. It calls `release-desktop.yml` directly, already passed `target_os: all` explicitly, and now carries `enable_windows_beta: false` explicitly too, with a comment saying not to flip it until the Windows leg has a proven green dry run and B1 is resolved. `release.yml`'s own `workflow_dispatch` exposes no `enable_windows_beta` input at all, which is stricter than before rather than a regression: there is no way to opt into the Windows beta through this pipeline's public surface at all right now. **Windows no longer builds on the cron train, on promote, or on a hotfix.**
- **A raw `desktop-v*` tag push.** `push` events carry no `inputs` context at all, so `inputs.enable_windows_beta` is empty/falsy there regardless of what any caller does. **Windows no longer builds on a bare tag push.**

The only path left that builds Windows is an explicit `workflow_dispatch` run against `release-desktop.yml` itself with `enable_windows_beta: true` set by a human, in addition to selecting `target_os: windows` or `all`. That is the dispatch used for the B1 experiment below.

Also fixed while in there (non-blocking, N1/N5 in the review):

- The warning annotation at `release-desktop.yml:329` and the paragraph in `guides/deploying/releases.md` both said `PROLIFERATE_AGENT_SEED_EXPECTED`. The real name, confirmed against `agent_seed_env.rs:7` and `installer/seed/mod.rs:44`, is `ANYHARNESS_AGENT_SEED_EXPECTED`. Fixed in both places, and the accompanying claim that Windows "falls back to whatever Node the machine already has" is also corrected: per the seed-tracing below, no managed agent launcher can run on Windows at all yet, so there is no fallback, there is nothing.
- `agent_seed_env.rs:10-30`'s `current_target_triple()` had no `cfg` arm for `aarch64-pc-windows-msvc`. Added one. It was unreachable today since only `x86_64-pc-windows-msvc` is in the release matrix, but #2145 already adds `windows_arm64` catalog pins, and without this arm the function would fail to compile the moment an ARM Windows target actually gets built, because none of its `cfg`-gated blocks would produce the required `&'static str` return value.

### B1 (blocking): the continue-on-error run-conclusion question, resolved by running it

Job-level `continue-on-error: ${{ matrix.runner_os == 'windows' }}` on `build-desktop` is confirmed to make `needs.build-desktop.result` report `success` to `create-release` and `publish-updater` even when the Windows leg fails, so those jobs do run. What was unresolved is whether a `continue-on-error` failure turns the *overall run's* conclusion red, which is the value the caller actually gates on through `needs.release-desktop.result` (post-#2140 this is `release.yml:321-343`; before the rebase it was the now-retired `nightly-release-train.yml:341` and `hotfix-production.yml:332`, gating the equivalent `needs.deploy-desktop.result`).

I dispatched `release-desktop.yml` on this branch (after the B2 fix above) with `dry_run: true`, `target_os: windows`, `enable_windows_beta: true`, `publish_updater: false`:

**Run: https://github.com/proliferate-ai/proliferate/actions/runs/32442203866**

The Windows leg genuinely failed on this run, which turns out to be exactly the experiment B1 asked for, with a real failure instead of a staged one:

- **`build-desktop (windows-latest, x86_64-pc-windows-msvc, windows)` job conclusion: `failure`.**
- **Overall run conclusion: `success`.**

That answers B1. A `continue-on-error` job failing does not turn the overall run conclusion red; the run reports green exactly as the GitHub syntax reference and discussion #15452 say, not as Ken Muse's writeup says. `needs.<workflow-call-job>.result` is what a caller reads for a reusable-workflow call, and it reflects this same run-level conclusion, so the caller gate (`release.yml:321-343` today, `nightly-release-train.yml:341` / `hotfix-production.yml:332` before #2140 retired them) would have read `success` here and proceeded to `publish-product-release` even though Windows was broken. The failure scenario in the original B1 finding is real: absent the B2 gate now landed, a Windows-only failure on the unified release pipeline would not have blocked the macOS release from finalizing.

**What actually failed, so it is not mistaken for a packaging problem.** The Windows Rust cross-compile succeeded: `cargo build --release --target x86_64-pc-windows-msvc -p anyharness -p proliferate-debug -p proliferate-worker` completed in the `Build Rust binaries for target` step (18 minutes on a cold cache), and `Generate and build SDK` also completed. The job then died in `Build frontend`, before `pnpm tauri build` ever ran:

```
##[error]Sentry desktop renderer project 'proliferate-desktop' is not accessible in org 'proliferate' (HTTP 403). Update SENTRY_DESKTOP_RENDERER_PROJECT before releasing.
```

This is a Sentry API access check, not a Windows-specific defect and not a build or packaging failure, and the root cause is now established rather than theorized. There is no `environment:` binding anywhere on any call path of `release-desktop.yml`, so a secret-scoping difference between a bare `workflow_dispatch` and an environment-gated caller (my first guess) cannot be the explanation. The actual cause is a token rotation. `SENTRY_AUTH_TOKEN` was rotated at `2026-08-20T19:51:01Z`, the same timestamp as the DSN variables, and the new token cannot read the `proliferate-desktop` project. Two independent calls on that token fail: the project API returns this 403, and `sentry-cli debug-files upload` separately returns "Project not found" against the same project. An unauthenticated control request returned a normal 401, which rules out a WAF or IP block as the explanation. This is org-wide on the current token, not specific to this dispatch's secret scope, and it would break a macOS release dispatched right now, not just this Windows run. Flagging as a separate, unrelated finding rather than fixing it here: **`SENTRY_AUTH_TOKEN` needs read access to `proliferate-desktop` restored before any desktop release, macOS or Windows, can get past `Build frontend` again.**

**Net effect on Unverified below at the time: unresolved.** Because `Build frontend` failed first, `Build Tauri app` and every step after it were skipped on this run. See the Unverified section: a follow-up run, dispatched once the Sentry blocker above was worked around, got past this step and resolved the NSIS naming question for real.

## Hard runtime dependency, stated plainly

The Stacking section below only names #2146. That is incomplete. **This PR has a hard runtime dependency on #2149 and #2145 as well, not just on #2146.**

- Without #2149, `installer/pinned.rs` writes the pinned agent binary to an extension-less path on Windows (`<runtime_home>/agents/claude/native/claude` instead of `claude.exe`), which Windows will not execute. With no bundled agent seed on Windows (see below) and no working pinned installer either, there is no path at all by which an agent binary reaches a Windows machine built from this PR.
- Even with #2149 merged, **no Windows session can start.** Claude's `agentProcess` in `catalogs/agents/registry.json` is a `managed_npm_package`, and what actually gets spawned for a session is the managed launcher `integrations/agent_cli/launcher.rs:86` generates, which is a `#!/bin/sh` script. Windows cannot execute that, and `make_executable` is a no-op there. A separate PR is in flight for the `/bin/sh` managed-launcher work; until it lands, this is the honest state.

Net: this PR produces an installable, launchable Windows app. It is not yet something a user can try, because no agent turn can run on it. Do not read a green merge here as "Windows agents work now."

## Stacking

Based on `fix/sdk-generate-windows-safe` (draft PR #2146), which this depends on: without its node port of `generate:openapi`, the Windows leg fails at the SDK generation step. Merge after #2146, or rebase onto main once it lands. It also depends on #2149 and #2145 for the reasons above, even though neither is a build-time dependency of this PR's own diff.


