### PR TITLE
fix(workflows): omit empty controlValues from stored and frozen v2 definitions

### DIFF
--- a/fixtures/contracts/workflow-definition/run-snapshot-v2.json
+++ b/fixtures/contracts/workflow-definition/run-snapshot-v2.json
@@ -23,7 +23,10 @@
         "id": "n_synthesize",
         "type": "agent",
         "title": "Synthesize a proposal",
-        "prompt": "Read @doc:research-findings and write a proposal into @doc:proposal covering @input:topic."
+        "prompt": "Read @doc:research-findings and write a proposal into @doc:proposal covering @input:topic.",
+        "model": {
+          "agentKind": "codex"
+        }
       },
       {
         "id": "n_review",

--- a/fixtures/contracts/workflow-definition/v2-full.json
+++ b/fixtures/contracts/workflow-definition/v2-full.json
@@ -24,7 +24,10 @@
         "id": "n_synthesize",
         "type": "agent",
         "title": "Synthesize a proposal",
-        "prompt": "Read @doc:research-findings and write a proposal into @doc:proposal covering @input:topic."
+        "prompt": "Read @doc:research-findings and write a proposal into @doc:proposal covering @input:topic.",
+        "model": {
+          "agentKind": "codex"
+        }
       },
       {
         "id": "n_review",

--- a/server/proliferate/server/workflows/api.py
+++ b/server/proliferate/server/workflows/api.py
@@ -195,7 +195,7 @@ async def put_workflow_invocation_endpoint(
         response_v2 = workflow_invocation_response_v2(result.value)
         return JSONResponse(
             status_code=status.HTTP_201_CREATED if result.created else status.HTTP_200_OK,
-            content=response_v2.model_dump(by_alias=True, mode="json", exclude_none=True),
+            content=response_v2.frozen_json(),
         )
     result = await put_workflow_invocation(
         db,
@@ -244,9 +244,7 @@ async def get_workflow_invocation_endpoint(
 ) -> JSONResponse:
     if invocation.schema_version == 2:
         frozen = workflow_invocation_response_v2(invocation)
-        return JSONResponse(
-            content=frozen.model_dump(by_alias=True, mode="json", exclude_none=True)
-        )
+        return JSONResponse(content=frozen.frozen_json())
     value = await read_managed_workflow(db, invocation=invocation)
     response = managed_workflow_invocation_response(
         value.invocation,

--- a/server/proliferate/server/workflows/models_v2.py
+++ b/server/proliferate/server/workflows/models_v2.py
@@ -108,9 +108,19 @@ class WorkflowDefinitionDocumentV2(WorkflowDefinitionWireModel):
         return value
 
     def document_json(self) -> dict[str, object]:
-        """The normalized stored/frozen form of this document."""
+        """The normalized stored/frozen form of this document.
 
-        return self.model_dump(by_alias=True, mode="json", exclude_none=True)
+        Omitted model/control values stay omitted: an empty map serializes as
+        absent, matching the runtime serializer's ``skip_serializing_if`` —
+        installed runtimes reject definition fields they do not know yet, so
+        the document must never grow a field the author left out.
+        """
+
+        data = self.model_dump(by_alias=True, mode="json", exclude_none=True)
+        for node, dumped in zip(self.nodes, data["nodes"], strict=True):
+            if node.model is not None and not node.model.control_values:
+                dumped["model"].pop("controlValues")
+        return data
 
 
 class WorkflowDefinitionCreateRequestV2(WorkflowDefinitionWireModel):
@@ -188,6 +198,16 @@ class WorkflowInvocationResponseV2(WorkflowInvocationWireModel):
     arguments: dict[str, WorkflowInvocationScalar]
     placement: WorkflowInvocationPlacementV2
     created_at: datetime
+
+    def frozen_json(self) -> dict[str, object]:
+        """The stored/delivered form of this invocation: the wire dump with
+        the definition in its normalized ``document_json`` form, so the
+        courier never hands the runtime a model field the author left empty
+        — including definitions frozen before that rule existed."""
+
+        data: dict[str, object] = self.model_dump(by_alias=True, mode="json", exclude_none=True)
+        data["definition"] = self.definition.document_json()
+        return data
 
 
 def workflow_definition_response_v2(

--- a/server/proliferate/server/workflows/service_v2.py
+++ b/server/proliferate/server/workflows/service_v2.py
@@ -204,10 +204,7 @@ async def put_workflow_invocation_v2(
                 updated_at=created_at,
             )
         )
-        normalized_invocation_json = cast(
-            dict[str, object],
-            response.model_dump(by_alias=True, mode="json", exclude_none=True),
-        )
+        normalized_invocation_json = response.frozen_json()
         canonical_json(normalized_invocation_json)
     except ValueError as error:
         raise InvalidWorkflowInvocation("Workflow invocation could not be normalized.") from error

--- a/server/tests/integration/test_workflow_invocations_v2_api.py
+++ b/server/tests/integration/test_workflow_invocations_v2_api.py
@@ -346,6 +346,40 @@ async def test_v2_invocation_freezes_the_definition_at_trigger_time(
 
 
 @pytest.mark.asyncio
+async def test_v2_invocation_freeze_drops_a_stored_empty_control_values_map(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Definitions saved before empty maps were omitted carry
+    `controlValues: {}` in their stored rows. The freeze normalization strips
+    it, so those saved workflows still produce a snapshot every runtime's
+    strict definition parser accepts."""
+
+    owner = await register_and_login(client, "wf2-inv-legacy@example.com")
+    repo = await _seed_repo(db_session, user_id=owner["user_id"], name="legacy-repo")
+    definition = await _create_v2_definition(client, owner)
+    definition_id = str(definition["id"])
+
+    row = (
+        await db_session.execute(
+            select(WorkflowDefinition).where(WorkflowDefinition.id == UUID(definition_id))
+        )
+    ).scalar_one()
+    legacy = deepcopy(row.definition_json)
+    legacy["nodes"][1]["model"] = {"agentKind": "codex", "controlValues": {}}
+    row.definition_json = legacy
+    await db_session.commit()
+
+    created = await client.put(
+        f"/v1/workflow-invocations/{uuid4()}",
+        headers=_headers(owner),
+        json=_invocation_body(definition_id, str(repo.id)),
+    )
+    assert created.status_code == 201
+    assert created.json()["definition"]["nodes"][1]["model"] == {"agentKind": "codex"}
+
+
+@pytest.mark.asyncio
 async def test_v2_referenced_optional_input_needs_an_argument(
     client: AsyncClient,
     db_session: AsyncSession,

--- a/server/tests/unit/test_workflow_definition_v2_validation.py
+++ b/server/tests/unit/test_workflow_definition_v2_validation.py
@@ -85,8 +85,48 @@ def test_run_snapshot_fixture_parses_as_frozen_invocation() -> None:
     assert response.schema_version == 2
     assert response.placement.mode == "worktree"
     assert validate_definition_v2_document(response.definition) is None
-    round_tripped = response.model_dump(by_alias=True, mode="json", exclude_none=True)
-    assert round_tripped == fixture
+    # The fixture is the frozen/delivered form, so it round-trips through
+    # `frozen_json` — the dump whose definition omits empty control values.
+    assert response.frozen_json() == fixture
+
+
+def test_empty_control_values_stay_omitted_in_the_stored_form() -> None:
+    """An explicit `controlValues: {}` (what pre-fix saves stored) normalizes
+    to an absent key, so the stored/frozen document matches what the runtime
+    serializer would emit and never carries a field the author left out."""
+    document = WorkflowDefinitionDocumentV2.model_validate(
+        {
+            "schemaVersion": 2,
+            "nodes": [
+                {
+                    "id": "n_only",
+                    "type": "agent",
+                    "title": "Do the job",
+                    "prompt": "Do the job.",
+                    "model": {
+                        "agentKind": "codex",
+                        "modelId": "codex-large",
+                        "controlValues": {},
+                    },
+                }
+            ],
+        }
+    )
+    assert document.document_json() == {
+        "schemaVersion": 2,
+        "nodes": [
+            {
+                "id": "n_only",
+                "type": "agent",
+                "title": "Do the job",
+                "prompt": "Do the job.",
+                "model": {"agentKind": "codex", "modelId": "codex-large"},
+            }
+        ],
+        "edges": [],
+        "inputs": [],
+        "docTemplates": [],
+    }
 
 
 def test_schema_version_must_be_exact_integer() -> None:

--- a/specs/FEATURE_DOCS/WORKFLOWS.md
+++ b/specs/FEATURE_DOCS/WORKFLOWS.md
@@ -326,6 +326,12 @@ When the editor has an execution target, it renders that target's copied
 longer present, but it never rewrites the saved intent or selects the first row.
 Omitted model/control values stay omitted.
 
+An empty `controlValues` map is the same as an omitted one: the stored and
+frozen document omit the key on every plane, matching the runtime serializer.
+Invocation-freeze normalization also strips it from definitions stored before
+this rule, so a saved workflow never delivers a model field its author left
+empty to a runtime whose strict definition parser predates that field.
+
 At execution, each node's complete selection goes through the runtime's normal
 session-create validator against the execution target's current matching-basis
 launch options. Exact current membership succeeds; missing options fail with the


### PR DESCRIPTION
## Summary

- A gen-2 workflow saved with any per-node model override could not start: the trigger PUT to the local runtime failed with `WORKFLOW_SNAPSHOT_INVALID` and the dialog showed "This workflow cannot run as saved" even though the definition was valid and saved cleanly.
- Root cause: the CP's pydantic dumps emitted `controlValues: {}` for every node model because `exclude_none` does not exclude empty defaults, while the runtime's serde serializer skips empty maps (`skip_serializing_if`) and parses definitions with `deny_unknown_fields`. Installed runtimes built before the `modeId` → `controlValues` rename (#2070) therefore reject the frozen snapshot outright.
- Fix, at the two explicit normalization seams (no pydantic schema change, so the generated OpenAPI artifacts are untouched):
  - `WorkflowDefinitionDocumentV2.document_json()` — the stored/frozen normal form — now omits an empty control-values map, matching the runtime serializer.
  - New `WorkflowInvocationResponseV2.frozen_json()` — the wire dump with the definition in its `document_json` form — used by the invocation freeze in `service_v2` and by the hand-serialized invocation PUT/GET endpoints. Because the freeze and the responses re-normalize, definitions and invocations stored **before** this rule also heal at trigger/delivery time — no re-save needed.
- Extends the cross-plane contract fixtures (`v2-full.json`, `run-snapshot-v2.json`) with a controls-free node model, so the byte-for-byte round-trip tests pin the omission on the CP plane and the parse/validate tests pin tolerance on the runtime and client planes.
- One deliberate deviation, called out in `WORKFLOWS.md`: for pre-fix stored rows the frozen definition is the stored bytes minus the CP-injected empty default, not byte-identical custody. New saves remain byte-verbatim.

Follow-ups (not this PR): the runtime's `deny_unknown_fields` on the definition makes every additive CP schema field a hard break for older installed runtimes (needs an ADR); the trigger dialog drops the ProblemDetails `detail` and tells users to fix steps in the editor even for repo-root/schema failures.

## Testing

- Unit (CP): `tests/unit/test_workflow_definition_v2_validation.py` — new `test_empty_control_values_stay_omitted_in_the_stored_form`; the run-snapshot round-trip now pins `frozen_json()`; the fixture round-trips fail without the fix (37 passed).
- Integration (CP, real PostgreSQL): `tests/integration/test_workflow_invocations_v2_api.py` — new `test_v2_invocation_freeze_drops_a_stored_empty_control_values_map` seeds a pre-fix row shape and proves the frozen snapshot omits the key; existing freeze-contract byte-for-byte tests re-pin the edited fixtures (10 passed with `test_workflow_definitions_v2_api.py`).
- Contract corpus (runtime): `cargo test -p anyharness-lib contract_fixture` — the edited fixtures parse and validate (8 passed).
- Contract corpus (client): `pnpm vitest run src/domain/workflows/definition-v2.test.ts` — the three-plane exemplar still validates (27 passed).
- Generated artifacts: `make cloud-client-generate` produces zero diff in `cloud/sdk/src/generated/openapi.ts`.
- Live reproduction before the fix: replaying the affected saved definition against an installed runtime (anyharness@0.1.0+49ac4e79551f) returned `400 WORKFLOW_SNAPSHOT_INVALID: unknown field controlValues`; the identical snapshot without the key passed deserialization and validation.

## Observability

- none — the failure surface (`WORKFLOW_SNAPSHOT_INVALID` ProblemDetails) is unchanged; this removes the input that triggered it.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- `make lint-server` — ruff check, ruff format, mypy shrink-only ratchet all pass.
- `python3 scripts/check_docs.py` — 234 Markdown files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)