### PR TITLE
docs(ci): gate timing probe, cheap path

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,5 @@ Contributing? See the [Contribution Guide](./CONTRIBUTING.md).
 ## License
 
 [AGPL-3.0](./LICENSE)
+
+<!-- Gate timing probe 2026-08-21, safe to close -->


### PR DESCRIPTION
Temporary CI gate timing probe. Measures click-to-mergeable wall time on the cheap (docs-only) path. Safe to close; will be closed and the branch deleted once numbers are recorded. Do not merge.