### PR TITLE
chore(server): gate timing probe, full path

### DIFF
--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -111,3 +111,6 @@ async def client(test_engine) -> AsyncGenerator[AsyncClient, None]:  # type: ign
 
     engine_module.engine = original_engine
     engine_module.async_session_factory = original_session_factory
+
+
+# Gate timing probe 2026-08-21, safe to close


### PR DESCRIPTION
Temporary CI gate timing probe. Measures click-to-mergeable wall time on the full (server-touching) path. Safe to close; will be closed and the branch deleted once numbers are recorded. Do not merge.