### PR TITLE
fix(release): push version bump with bypass-capable token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,7 @@ jobs:
           RELEASE_ID: ${{ steps.meta.outputs.release_id }}
           SKIP_BUILD: ${{ steps.meta.outputs.skip_build }}
           DRY_RUN: ${{ steps.meta.outputs.dry_run }}
+          RELEASE_PUSH_TOKEN: ${{ secrets.RELEASE_PUSH_TOKEN }}
         run: |
           set -euo pipefail
           # A dry run computes the bump so the plan is real, then throws it away:
@@ -218,11 +219,26 @@ jobs:
             echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # main is branch protected and the workflow's GITHUB_TOKEN cannot
+          # satisfy required status checks on a direct push (GH006, run
+          # 32446272831). This is the only branch push in the release
+          # pipeline, so it alone authenticates with RELEASE_PUSH_TOKEN, an
+          # admin fine-grained PAT that bypasses the checks while
+          # enforce_admins stays off. Fail loudly before committing if the
+          # secret is missing instead of dying opaquely at the push.
+          if [[ -z "$RELEASE_PUSH_TOKEN" ]]; then
+            echo "::error::RELEASE_PUSH_TOKEN secret is not set; the version-bump push to protected main needs a bypass-capable token."
+            exit 1
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add VERSION apps/desktop/package.json apps/desktop/src-tauri/tauri.conf.json apps/desktop/src-tauri/Cargo.toml anyharness/sdk/package.json
           git commit -m "release: prepare $RELEASE_ID"
-          git push origin HEAD:main
+          # actions/checkout persists GITHUB_TOKEN as an http.extraheader in
+          # .git/config; blank it for this one command so the PAT in the URL
+          # is the credential that reaches GitHub.
+          git -c "http.https://github.com/.extraheader=" \
+            push "https://x-access-token:${RELEASE_PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main
           echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Create release tags

--- a/guides/deploying/releases.md
+++ b/guides/deploying/releases.md
@@ -25,6 +25,8 @@ selects an exact set. Its prepare job resolves the train, public product, and
 artifact versions; may commit version bumps to `main`; and creates the selected
 train/product/artifact tags.
 
+The version-bump push to `main` authenticates with the `RELEASE_PUSH_TOKEN` repository secret, an admin fine-grained PAT (Contents: Read and write on this repository) that bypasses the required status checks on `main`. The prepare job fails loudly before committing if the secret is missing, and every release including the daily cron fails until it is restored, so renew the PAT before it expires.
+
 The train then:
 
 1. releases selected Runtime/SDK, Server/self-host, and Desktop artifacts;

--- a/scripts/ci-cd/deploy-staging-trigger.test.mjs
+++ b/scripts/ci-cd/deploy-staging-trigger.test.mjs
@@ -106,10 +106,13 @@ test("a dry run walks the graph without any externally visible effect", () => {
   // Nothing is pushed to main and no tag is minted.
   const commit = section("- name: Commit version bumps", "- name: Create release tags");
   assert.match(commit, /if \[\[ "\$SKIP_BUILD" == "true" \|\| "\$DRY_RUN" == "true" \]\]; then/);
-  assert.ok(
-    commit.indexOf('exit 0') < commit.indexOf("git push origin HEAD:main"),
-    "the dry-run early return must precede the push to main",
+  const earlyReturn = commit.indexOf("exit 0");
+  const pushToMain = commit.indexOf(
+    'push "https://x-access-token:${RELEASE_PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main',
   );
+  assert.notEqual(earlyReturn, -1, "the commit step must keep its dry-run early return");
+  assert.notEqual(pushToMain, -1, "the commit step must push to main with RELEASE_PUSH_TOKEN");
+  assert.ok(earlyReturn < pushToMain, "the dry-run early return must precede the push to main");
   for (const step of ["- name: Verify version tags are free", "- name: Create release tags"]) {
     assert.match(
       section(step, "\n      - name:"),


### PR DESCRIPTION
## Problem

The first real dispatch of release.yml (run 32446272831) failed in `prepare` step "Commit version bumps":

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: 8 of 8 required status checks are expected.
```

`git push origin HEAD:main` authenticates with the checkout's persisted GITHUB_TOKEN (github-actions[bot]), which cannot satisfy the required checks that branch protection now demands on a direct push. The dry run cannot catch this: it short-circuits before the push by design. Every release, including the daily 09:00 UTC cron, fails at this step until fixed. Fail-closed held: everything downstream skipped, zero side effects.

## Fix

The version-bump push is the only push to a branch of this repository in the release pipeline (release-desktop.yml also pushes a branch, but to the external Homebrew tap repo with its own token; everything else is tag pushes, which no protection rule covers). This PR authenticates that one command with a new `RELEASE_PUSH_TOKEN` secret, an admin fine-grained PAT (contents: read and write on this repo) that bypasses required checks while `enforce_admins` stays off. Everything else in the workflow keeps using GITHUB_TOKEN.

Mechanics:
- Guard first: if the secret is unset, fail with an explicit `::error` before committing, rather than dying opaquely at the push. The guard sits after the dry-run/skip-build/no-diff early exits, so those paths never require the secret.
- actions/checkout persists GITHUB_TOKEN as an `http.https://github.com/.extraheader` in `.git/config`, and that header would override URL basic-auth credentials. The push blanks it with `-c` for that one command so the PAT in the URL is the credential that reaches GitHub.
- The secret value is masked in logs by Actions secret masking, and git anonymizes URL userinfo in transport errors.
- `scripts/ci-cd/deploy-staging-trigger.test.mjs` updated: the dry-run-precedes-push assertion now anchors on the new push literal and asserts both indices are found, so it can no longer degrade to a silent pass if either line disappears.
- `guides/deploying/releases.md` documents the secret, its scope, and the failure mode when it is missing or expired.

## Behavior change worth knowing

GITHUB_TOKEN pushes do not trigger workflows, so historical bump commits got no CI run on main. PAT pushes do trigger them: each bump commit will now run ci.yml, codeql.yml, and self-host-smoke.yml on main (server-ci.yml and publish-agent-catalog.yml are path-filtered away from the bump files). None of those push or deploy, so there is no loop, but every release now also pays for a main CI + CodeQL + smoke run.

## Operational prerequisite

`RELEASE_PUSH_TOKEN` must exist as a repo-level secret before the next dispatch or cron (the prepare job has no `environment:`). The PAT owner must be a repo admin, or the push fails with the identical GH006 that the guard cannot detect. Known residual risks, accepted for tonight and queued as follow-ups: a long-lived admin PAT in a repo secret is readable by same-repo-branch workflow runs, and an expired PAT presents as set-but-rejected, which the `-z` guard cannot catch. Durable alternatives (GitHub App installation token, or a ruleset bypass actor) are in the follow-up queue.

## Verification

- `ruby -ryaml` parse: clean.
- The failing run is the negative control for the workflow change: identical push, bot credential, GH006. This PR changes only the credential path for that push.
- Test negative control: the updated assertion run against main's release.yml fails on "must push to main with RELEASE_PUSH_TOKEN"; against this branch, 6/6 pass.
- Guard path: with the secret unset the step exits 1 at the `::error` line before `git commit`, leaving nothing to clean up.
- End-to-end proof is the next real dispatch after `RELEASE_PUSH_TOKEN` lands in repo secrets (dry run structurally cannot exercise the push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)