### PR TITLE
fix(build): normalise line endings so check-theme survives a Windows checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Force LF line endings for text files on checkout, regardless of the
+# checking-out platform's git config. Without this, GitHub's windows-latest
+# runner (core.autocrlf=true by default, no repo override before this file)
+# converts LF to CRLF on checkout for every text file, including
+# apps/packages/design/src/css/product.css. check-theme.mjs asserts that
+# product.css contains several multi-line CSS declarations as exact,
+# hardcoded LF-joined string literals (see the `productCss.includes(...)`
+# loop around line 592), so a CRLF checkout makes those substring matches
+# fail even though the CSS content is byte-for-byte the same modulo line
+# endings. This broke `pnpm run build` -> check-theme.mjs on the first-ever
+# Windows desktop build attempt (windows-latest), independent of and in
+# addition to the separate Sentry credential issue.
+* text=auto eol=lf

--- a/apps/packages/design/scripts/check-theme.mjs
+++ b/apps/packages/design/scripts/check-theme.mjs
@@ -127,18 +127,25 @@ ${["hover", "enter", "exit", "disclosure", "panel", "pop", "emphasized"]
 ].join("\n\n");
 
 /**
- * Read a text file with line endings normalised to LF.
+ * Read a CHECKED-OUT source file with line endings normalised to LF.
  *
- * Several assertions below compare against literals joined with `\n`. A
- * working tree carrying CRLF (a Windows editor, or a checkout predating
+ * Several assertions below compare against literals joined with `\n`. A working
+ * tree carrying CRLF (a Windows editor, or a checkout predating
  * `.gitattributes`) would fail those with a message that names the CSS rather
  * than the line endings, so normalise at the read instead.
+ *
+ * Only for files that come out of git. Generated output is read raw, so its
+ * byte-identity check stays exact.
  */
 async function readText(path) {
   return (await readFile(path, "utf8")).replace(/\r\n/g, "\n");
 }
 
-const generated = await readText(resolve(root, "dist/theme.css"));
+// Deliberately NOT readText: dist/theme.css is untracked, gitignored, and
+// written fresh by generate-theme.mjs from an in-memory string moments earlier,
+// so a git checkout can never give it CRLF. Normalising here would only loosen
+// the byte-identity check this script exists to make.
+const generated = await readFile(resolve(root, "dist/theme.css"), "utf8");
 assert(
   generated === `${expectedCss}\n`,
   "dist/theme.css drifted from an independent projection of the token authority",

--- a/apps/packages/design/scripts/check-theme.mjs
+++ b/apps/packages/design/scripts/check-theme.mjs
@@ -126,7 +126,19 @@ ${["hover", "enter", "exit", "disclosure", "panel", "pop", "emphasized"]
 }`,
 ].join("\n\n");
 
-const generated = await readFile(resolve(root, "dist/theme.css"), "utf8");
+/**
+ * Read a text file with line endings normalised to LF.
+ *
+ * Several assertions below compare against literals joined with `\n`. A
+ * working tree carrying CRLF (a Windows editor, or a checkout predating
+ * `.gitattributes`) would fail those with a message that names the CSS rather
+ * than the line endings, so normalise at the read instead.
+ */
+async function readText(path) {
+  return (await readFile(path, "utf8")).replace(/\r\n/g, "\n");
+}
+
+const generated = await readText(resolve(root, "dist/theme.css"));
 assert(
   generated === `${expectedCss}\n`,
   "dist/theme.css drifted from an independent projection of the token authority",
@@ -523,7 +535,7 @@ assert(
   "the generated theme must contain exactly one flattened light root",
 );
 
-const productCss = await readFile(resolve(root, "src/css/product.css"), "utf8");
+const productCss = await readText(resolve(root, "src/css/product.css"));
 for (const { selector, body } of topLevelBlocks(productCss)) {
   const ownsGlobalScope =
     selector.startsWith("@theme") ||
@@ -627,7 +639,7 @@ checkRawMotionAuthority(generated, "dist/theme.css");
  * 7. One authority entry per token name in the source manifest
  * ------------------------------------------------------------------ */
 
-const tokenSource = await readFile(resolve(root, "src/tokens.ts"), "utf8");
+const tokenSource = await readText(resolve(root, "src/tokens.ts"));
 const manifest =
   tokenSource
     .split("export const themeTokens = {")[1]


### PR DESCRIPTION
## What this is

Two commits, one concern: a checkout on Windows silently corrupts `apps/packages/design/src/css/product.css` into CRLF, and `check-theme.mjs` asserts against `\n`-joined literals, so the design gate fails with a message that blames the CSS.

This surfaced while getting the first real Windows `tauri build` to run. It is not Windows-specific in effect: the repo has no `.gitattributes` at all, so line-ending behaviour is left to each contributor's `core.autocrlf`.

- `917b77705d` `.gitattributes` with `* text=auto eol=lf` (13 lines). Fixes the checkout.
- `e19c87f67e` `check-theme.mjs` reads through a `readText()` helper that normalises CRLF. Fixes the working tree, which `.gitattributes` does not.

## Renormalisation is provably a no-op

Not asserted, measured, over all 8065 tracked files at the PR head:

- `git ls-files --eol`: 7852 `i/lf`, 111 `i/-text`, 102 `i/none`. **Zero `crlf`, zero `mixed`.**
- `git grep -I -l -P '\r' HEAD` returns **0 files**.
- Zero tracked `.bat`, `.cmd`, `.ps1`, `.sln`, `.vcxproj`, `.reg`, `.rc`, `.nsi`, `.wxs`, `.iss` files, so nothing in-tree needs CRLF preserved.

(An earlier revision of this body cited 7960 / 7774 / 84. Those numbers were wrong; the counts above are the measured ones and were independently reproduced during review. The conclusion is unchanged, since what matters is that `crlf`, `mixed`, and literal-CR counts are all zero.)

## Generated output is read raw

Review found that normalising `dist/theme.css` was a no-op that only loosened a check, and it has been reverted in `9eaee53626`. That file is untracked, gitignored at `.gitignore:14`, and written by `generate-theme.mjs` from an in-memory string (`writeFile` at `:163`, no `readFile` anywhere in that script), so a git checkout can never hand it CRLF. The script exists to assert the generated CSS is byte-identical to the committed generator output, and normalising that read weakened exactly that.

`readText` now applies only to the two files that actually come out of git, `src/css/product.css` and `src/tokens.ts`. Reverified after the revert: LF tree `check-theme: ok (309 live tokens)`, CRLF tree `check-theme: ok (309 live tokens)`.

## Negative control

Run locally against a prebuilt `dist/`, three cells:

| working tree | script | result |
|---|---|---|
| CRLF | unpatched | `check-theme: product.css lost the exact motion declaration: background-color var(--duration-hover) ...` |
| CRLF | patched | `check-theme: ok (309 live tokens)` |
| LF | patched | `check-theme: ok (309 live tokens)` |

The failing string is character-identical to the one CI run `32445871270` produced on Windows, so the local reproduction is the same defect, not an analogue.

## Dropped from this PR

An earlier commit (`9924a7da79`) added an opt-in `workflow_dispatch` Sentry bypass to `release-desktop.yml`, so Windows packaging could be verified while `SENTRY_AUTH_TOKEN` is broken. **It has been dropped.** Review found it puts a permanent manually-dispatchable "ship without sourcemaps" switch on the release surface with no CI guard keeping it out of `workflow_call`, and its shape was wrong regardless: it unset the auth vars but left `VITE_PROLIFERATE_SENTRY_DSN`, so a build made that way would still report to Sentry with `sourcemap: false` — silent unsymbolicatable noise rather than a loud absence.

Packaging verification therefore depends on fixing `SENTRY_AUTH_TOKEN`, not on bypassing it. That token was rotated at `2026-08-20T19:51:01Z` and the new one cannot read `proliferate-desktop`; this is org-wide and would break a macOS release dispatched today. Tracked in #2150.

## Branch name

The branch is still `diag/windows-installer-packaging` from when this carried the bypass. Renaming it would close the PR, so it stays; the title and contents are the accurate description.

