### PR TITLE
fix(chat): improve provider model errors

### DIFF
--- a/anyharness/crates/anyharness-lib/src/integrations/acp/provider_errors.rs
+++ b/anyharness/crates/anyharness-lib/src/integrations/acp/provider_errors.rs
@@ -1,8 +1,12 @@
+use agent_client_protocol as acp;
 use anyharness_contract::v1::ErrorEventDetails;
 
 const ANTHROPIC_PROVIDER: &str = "anthropic";
 pub const PROVIDER_RATE_LIMIT_CODE: &str = "provider_rate_limit";
 pub const NETWORK_CONNECTION_CODE: &str = "network_connection";
+pub const PROVIDER_MODEL_UNAVAILABLE_CODE: &str = "provider_model_unavailable";
+pub const PROVIDER_MODEL_CONFIGURATION_UNSUPPORTED_CODE: &str =
+    "provider_model_configuration_unsupported";
 pub const OPUS_4_7_MODEL_ID: &str = "claude-opus-4-7";
 pub const OPUS_4_6_FALLBACK_MODEL_ID: &str = "claude-opus-4-6";
 
@@ -70,6 +74,43 @@ pub fn classify_network_connection_error(message: &str) -> Option<ErrorEventDeta
     Some(ErrorEventDetails::NetworkConnection {
         provider: extract_claude_model_id(message).map(|_| ANTHROPIC_PROVIDER.to_string()),
     })
+}
+
+/// Reduces the two bounded provider-model failures exposed by OpenCode's ACP
+/// adapter to stable product error codes. The adapter currently preserves the
+/// provider message and an `APIError`/`session` discriminator, but not the
+/// provider HTTP status or retryability. Require that full surviving envelope
+/// so similar prose from another harness cannot acquire this classification.
+pub fn classify_provider_model_error(agent_kind: &str, error: &acp::Error) -> Option<&'static str> {
+    if agent_kind != "opencode"
+        || !matches!(error.code, acp::ErrorCode::InternalError)
+        || !has_opencode_session_api_error_data(error.data.as_ref())
+    {
+        return None;
+    }
+
+    let message = error.message.to_ascii_lowercase();
+    if message.contains("provided model identifier is invalid") {
+        return Some(PROVIDER_MODEL_UNAVAILABLE_CODE);
+    }
+    if message.contains("the model returned the following errors")
+        && message.contains("thinking.type.enabled")
+        && message.contains("is not supported for this model")
+        && message.contains("thinking.type.adaptive")
+        && message.contains("output_config.effort")
+    {
+        return Some(PROVIDER_MODEL_CONFIGURATION_UNSUPPORTED_CODE);
+    }
+
+    None
+}
+
+fn has_opencode_session_api_error_data(data: Option<&serde_json::Value>) -> bool {
+    data.and_then(serde_json::Value::as_object)
+        .is_some_and(|data| {
+            data.get("errorName").and_then(serde_json::Value::as_str) == Some("APIError")
+                && data.get("service").and_then(serde_json::Value::as_str) == Some("session")
+        })
 }
 
 fn extract_claude_model_id(message: &str) -> Option<String> {
@@ -165,9 +206,7 @@ mod tests {
     #[test]
     fn network_classifier_populates_provider_when_model_present() {
         let Some(ErrorEventDetails::NetworkConnection { provider }) =
-            classify_network_connection_error(
-                "fetch failed while streaming from claude-opus-4-7",
-            )
+            classify_network_connection_error("fetch failed while streaming from claude-opus-4-7")
         else {
             panic!("expected network connection details");
         };
@@ -186,10 +225,82 @@ mod tests {
     #[test]
     fn network_classifier_rejects_false_positives() {
         // "dns" as a bare substring should NOT match (e.g. CDN URLs, library names)
-        assert!(classify_network_connection_error("failed to load from cdns.cloudflare.com").is_none());
+        assert!(
+            classify_network_connection_error("failed to load from cdns.cloudflare.com").is_none()
+        );
         assert!(classify_network_connection_error("adns library error").is_none());
         // Server-initiated stream close is NOT a client-side network failure
-        assert!(classify_network_connection_error("connection closed by server after max_duration").is_none());
-        assert!(classify_network_connection_error("SSE connection closed due to load shedding").is_none());
+        assert!(classify_network_connection_error(
+            "connection closed by server after max_duration"
+        )
+        .is_none());
+        assert!(
+            classify_network_connection_error("SSE connection closed due to load shedding")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn classifies_opencode_provider_model_failures() {
+        let invalid_model = opencode_session_api_error(
+            "Internal error: undefined: The provided model identifier is invalid.",
+        );
+        assert_eq!(
+            classify_provider_model_error("opencode", &invalid_model),
+            Some(PROVIDER_MODEL_UNAVAILABLE_CODE),
+        );
+
+        let unsupported_configuration = opencode_session_api_error(
+            "Internal error: undefined: The model returned the following errors: \"thinking.type.enabled\" is not supported for this model. Use \"thinking.type.adaptive\" and \"output_config.effort\" to control thinking behavior.",
+        );
+        assert_eq!(
+            classify_provider_model_error("opencode", &unsupported_configuration),
+            Some(PROVIDER_MODEL_CONFIGURATION_UNSUPPORTED_CODE),
+        );
+    }
+
+    #[test]
+    fn provider_model_classifier_requires_the_opencode_session_api_envelope() {
+        let message = "Internal error: undefined: The provided model identifier is invalid.";
+        let exact = opencode_session_api_error(message);
+        assert_eq!(classify_provider_model_error("claude", &exact), None);
+
+        let wrong_service = acp::Error::internal_error().data(serde_json::json!({
+            "errorName": "APIError",
+            "service": "auth",
+        }));
+        assert_eq!(
+            classify_provider_model_error("opencode", &wrong_service),
+            None,
+        );
+
+        let wrong_code = acp::Error::new(-32602, message).data(serde_json::json!({
+            "errorName": "APIError",
+            "service": "session",
+        }));
+        assert_eq!(classify_provider_model_error("opencode", &wrong_code), None,);
+        assert_eq!(
+            classify_provider_model_error(
+                "opencode",
+                &opencode_session_api_error("Internal error: undefined: Request failed."),
+            ),
+            None,
+        );
+        assert_eq!(
+            classify_provider_model_error(
+                "opencode",
+                &opencode_session_api_error(
+                    "Internal error: undefined: The model returned the following errors: tools are not supported for this model.",
+                ),
+            ),
+            None,
+        );
+    }
+
+    fn opencode_session_api_error(message: &str) -> acp::Error {
+        acp::Error::new(-32603, message).data(serde_json::json!({
+            "errorName": "APIError",
+            "service": "session",
+        }))
     }
 }

--- a/anyharness/crates/anyharness-lib/src/integrations/acp/provider_errors.rs
+++ b/anyharness/crates/anyharness-lib/src/integrations/acp/provider_errors.rs
@@ -76,8 +76,8 @@ pub fn classify_network_connection_error(message: &str) -> Option<ErrorEventDeta
     })
 }
 
-/// Reduces the two bounded provider-model failures exposed by OpenCode's ACP
-/// adapter to stable product error codes. The adapter currently preserves the
+/// Reduces the two bounded provider-model failures exposed by the ACP adapter
+/// to stable product error codes. The adapter currently preserves the
 /// provider message and an `APIError`/`session` discriminator, but not the
 /// provider HTTP status or retryability. Require that full surviving envelope
 /// so similar prose from another harness cannot acquire this classification.

--- a/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/finish.rs
+++ b/anyharness/crates/anyharness-lib/src/live/sessions/actor/turn/finish.rs
@@ -4,8 +4,8 @@ use tokio::sync::mpsc;
 
 use crate::domains::sessions::extensions::SessionTurnOutcome;
 use crate::integrations::acp::provider_errors::{
-    classify_network_connection_error, classify_provider_rate_limit_error, NETWORK_CONNECTION_CODE,
-    PROVIDER_RATE_LIMIT_CODE,
+    classify_network_connection_error, classify_provider_model_error,
+    classify_provider_rate_limit_error, NETWORK_CONNECTION_CODE, PROVIDER_RATE_LIMIT_CODE,
 };
 use crate::live::sessions::actor::config::queue::apply_pending_config_changes_if_idle;
 use crate::live::sessions::actor::state::SessionActor;
@@ -280,22 +280,22 @@ impl SessionActor {
                     let sink = self.event_sink.lock().await;
                     sink.debug_snapshot()
                 };
-                // Classify before logging: the turn-failure record is the one
-                // place the provider/network class is visible, and the sink
-                // path below consumes the classification by value.
+                // Inspect the structured ACP error before flattening it for
+                // diagnostics. The sink path below consumes the bounded
+                // classification by value and preserves the raw cause.
+                let provider_model_code = classify_provider_model_error(&self.agent_kind, &e);
                 let error_message = e.to_string();
-                let (error_details, error_code) =
-                    match classify_provider_rate_limit_error(&error_message) {
-                        Some(details) => {
-                            (Some(details), Some(PROVIDER_RATE_LIMIT_CODE.to_string()))
-                        }
-                        None => match classify_network_connection_error(&error_message) {
-                            Some(details) => {
-                                (Some(details), Some(NETWORK_CONNECTION_CODE.to_string()))
-                            }
-                            None => (None, None),
-                        },
-                    };
+                let (error_details, error_code) = if let Some(details) =
+                    classify_provider_rate_limit_error(&error_message)
+                {
+                    (Some(details), Some(PROVIDER_RATE_LIMIT_CODE.to_string()))
+                } else if let Some(code) = provider_model_code {
+                    (None, Some(code.to_string()))
+                } else if let Some(details) = classify_network_connection_error(&error_message) {
+                    (Some(details), Some(NETWORK_CONNECTION_CODE.to_string()))
+                } else {
+                    (None, None)
+                };
                 tracing::warn!(
                     target: "anyharness.turn.failed",
                     session_id = %self.session_id,

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/SessionErrorItem.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/SessionErrorItem.test.tsx
@@ -1,0 +1,69 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ErrorItem } from "@anyharness/sdk";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SessionErrorItem } from "#product/components/workspace/chat/transcript/SessionErrorItem";
+import { useModelSupportStore } from "#product/stores/chat/model-support-store";
+
+vi.mock("#product/hooks/sessions/workflows/use-session-model-fallback-action", () => ({
+  useSessionModelFallbackAction: () => vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  useModelSupportStore.setState({ refusalsByKey: {}, pickerRequestNonce: 0 });
+});
+
+describe("SessionErrorItem", () => {
+  it("keeps provider diagnostics behind Details and opens model recovery", () => {
+    const raw = `Internal error: undefined: The provided model identifier is invalid.: {
+  "errorName": "APIError",
+  "service": "session"
+}`;
+    const { container } = render(
+      <SessionErrorItem
+        item={errorItem({
+          code: "provider_model_unavailable",
+          message: raw,
+          sourceAgentKind: "opencode",
+        })}
+        sessionId="session-1"
+      />,
+    );
+
+    expect(screen.getByText("Model unavailable")).toBeTruthy();
+    expect(container.textContent).not.toContain("Internal error: undefined");
+
+    fireEvent.click(screen.getByRole("button", { name: "Details" }));
+    expect(container.textContent).toContain("Internal error: undefined");
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose model" }));
+    expect(useModelSupportStore.getState().pickerRequestNonce).toBe(1);
+    expect(useModelSupportStore.getState().refusalsByKey).toEqual({});
+  });
+});
+
+function errorItem(overrides: Partial<ErrorItem>): ErrorItem {
+  return {
+    kind: "error",
+    itemId: "error-1",
+    turnId: "turn-1",
+    status: "failed",
+    sourceAgentKind: "opencode",
+    messageId: null,
+    title: null,
+    nativeToolName: null,
+    parentToolCallId: null,
+    contentParts: [],
+    timestamp: "2026-08-21T00:00:00Z",
+    startedSeq: 1,
+    lastUpdatedSeq: 1,
+    completedSeq: 1,
+    completedAt: "2026-08-21T00:00:00Z",
+    message: "Something failed",
+    code: null,
+    details: null,
+    ...overrides,
+  };
+}

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/SessionErrorItem.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/SessionErrorItem.tsx
@@ -8,6 +8,7 @@ import { useSessionModelFallbackAction } from "#product/hooks/sessions/workflows
 import { presentSessionError } from "#product/domain/chats/transcript/session-error-presentation";
 import { useToastStore } from "#product/stores/toast/toast-store";
 import { useChatInputStore } from "#product/stores/chat/chat-input-store";
+import { useModelSupportStore } from "#product/stores/chat/model-support-store";
 import { getSessionRecord } from "#product/stores/sessions/session-records";
 import { useConnectivityStore } from "#product/stores/infra/connectivity-store";
 
@@ -23,6 +24,7 @@ export function SessionErrorItem({
   const setFallbackModel = useSessionModelFallbackAction();
   const showToast = useToastStore((state) => state.show);
   const showErrorToast = useToastStore((state) => state.showError);
+  const requestModelPicker = useModelSupportStore((state) => state.requestPicker);
   const [isApplyingFallback, setIsApplyingFallback] = useState(false);
   const [detailsExpanded, setDetailsExpanded] = useState(false);
 
@@ -109,7 +111,10 @@ export function SessionErrorItem({
           <div className="mt-0.5 text-muted-foreground">{presentation.description}</div>
         </div>
       </div>
-      {(fallback && sessionId) || isNetworkError || presentation.technicalDetail ? (
+      {(fallback && sessionId)
+        || isNetworkError
+        || presentation.recoveryAction
+        || presentation.technicalDetail ? (
         <div className="mt-2 flex flex-wrap items-center gap-2 pl-6">
           {isNetworkError && sessionId && (
             <Button
@@ -136,6 +141,17 @@ export function SessionErrorItem({
             >
               <RefreshCw className="icon-paired" />
               Switch to {presentation.fallbackModelLabel ?? "fallback model"}
+            </Button>
+          )}
+          {presentation.recoveryAction === "choose_model" && (
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={requestModelPicker}
+              className="px-2.5 text-chat"
+            >
+              Choose model
             </Button>
           )}
           {presentation.technicalDetail && (

--- a/apps/packages/product-client/src/domain/chats/transcript/session-error-presentation.test.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/session-error-presentation.test.ts
@@ -23,8 +23,113 @@ describe("presentSessionError", () => {
       title: "Anthropic rate limit reached",
       description: "This chat exceeded the provider limit for Opus 4.7. Try again later or switch to Opus 4.6.",
       fallbackModelLabel: "Opus 4.6",
-      technicalDetail: "provider returned 429 with a long upstream explanation",
+      technicalDetail: "Error: provider returned 429 with a long upstream explanation",
+      recoveryAction: null,
     });
+  });
+
+  it("turns the bounded unavailable-model code into an actionable recovery", () => {
+    const presentation = presentSessionError(errorItem({
+      code: "provider_model_unavailable",
+      message: "An updated harness message that does not need phrase matching",
+      sourceAgentKind: "opencode",
+    }));
+
+    expect(presentation).toMatchObject({
+      title: "Model unavailable",
+      description:
+        "The selected model isn't available from this provider. Choose another model, then try again.",
+      recoveryAction: "choose_model",
+    });
+    expect(presentation.technicalDetail).toContain(
+      "Error code: provider_model_unavailable",
+    );
+  });
+
+  it("uses the bounded configuration code when provider wording changes", () => {
+    const presentation = presentSessionError(errorItem({
+      code: "provider_model_configuration_unsupported",
+      message: "A future provider message",
+      sourceAgentKind: "opencode",
+    }));
+
+    expect(presentation).toMatchObject({
+      title: "Model settings unsupported",
+      description:
+        "The provider rejected the reasoning settings for this model. Choose another model, then try again.",
+      recoveryAction: "choose_model",
+    });
+  });
+
+  it("recognizes a legacy invalid-model error without promoting diagnostics into copy", () => {
+    const raw = `Internal error: undefined: The provided model identifier is invalid.: {
+  "errorName": "APIError",
+  "service": "session"
+}`;
+    const presentation = presentSessionError(errorItem({
+      message: raw,
+      sourceAgentKind: "opencode",
+    }));
+
+    expect(presentation).toMatchObject({
+      title: "Model unavailable",
+      description:
+        "The selected model isn't available from this provider. Choose another model, then try again.",
+      technicalDetail: raw,
+      recoveryAction: "choose_model",
+    });
+    expect(presentation.description).not.toContain("undefined");
+    expect(presentation.description).not.toContain("APIError");
+  });
+
+  it("recognizes a legacy unsupported-reasoning error and keeps the cause in details", () => {
+    const raw = `Internal error: undefined: The model returned the following errors: "thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.: {
+  "errorName": "APIError",
+  "service": "session"
+}`;
+    const presentation = presentSessionError(errorItem({
+      message: raw,
+      sourceAgentKind: "opencode",
+    }));
+
+    expect(presentation).toMatchObject({
+      title: "Model settings unsupported",
+      description:
+        "The provider rejected the reasoning settings for this model. Choose another model, then try again.",
+      technicalDetail: raw,
+      recoveryAction: "choose_model",
+    });
+    expect(presentation.description).not.toContain("thinking.type.enabled");
+    expect(presentation.description).not.toContain("undefined");
+  });
+
+  it("sanitizes transport wrappers in generic copy without discarding technical detail", () => {
+    const raw = `Internal error: undefined: Something else failed.: {
+  "errorName": "APIError",
+  "service": "session"
+}`;
+    const presentation = presentSessionError(errorItem({
+      message: raw,
+      sourceAgentKind: "claude",
+    }));
+
+    expect(presentation).toMatchObject({
+      title: "Chat stopped",
+      description: "Something else failed.",
+      technicalDetail: raw,
+      recoveryAction: null,
+    });
+  });
+
+  it("does not misclassify unrelated unsupported model capabilities", () => {
+    const presentation = presentSessionError(errorItem({
+      message:
+        "Internal error: undefined: The model returned the following errors: tools are not supported for this model.",
+      sourceAgentKind: "opencode",
+    }));
+
+    expect(presentation.title).toBe("Chat stopped");
+    expect(presentation.recoveryAction).toBeNull();
   });
 
   it("keeps generic failures short and moves long text into details", () => {

--- a/apps/packages/product-client/src/domain/chats/transcript/session-error-presentation.ts
+++ b/apps/packages/product-client/src/domain/chats/transcript/session-error-presentation.ts
@@ -5,22 +5,32 @@ export interface SessionErrorPresentation {
   description: string;
   technicalDetail: string | null;
   fallbackModelLabel: string | null;
+  recoveryAction: "choose_model" | null;
 }
 
 const GENERIC_ERROR_TITLE = "Chat stopped";
 const GENERIC_ERROR_DESCRIPTION = "The session stopped before it could continue.";
 const MAX_DESCRIPTION_LENGTH = 180;
+const PROVIDER_MODEL_UNAVAILABLE_CODE = "provider_model_unavailable";
+const PROVIDER_MODEL_CONFIGURATION_UNSUPPORTED_CODE =
+  "provider_model_configuration_unsupported";
+
+type ProviderModelFailure = "unavailable" | "configuration_unsupported";
 
 export function presentSessionError(item: ErrorItem): SessionErrorPresentation {
+  const technicalMessage = readTechnicalDetail(item.message);
+  const summaryMessage = normalizeSummaryMessage(item.message);
+
   // Defensively feature-detect the "network_connection" kind string — the Rust
   // contract variant may ship after this code, so we check by string value.
   if ((item.details as { kind?: string } | null)?.kind === "network_connection") {
     return {
       title: "Connection interrupted",
       description:
-        "The connection to the model was lost. Your work is saved — retry to continue.",
-      technicalDetail: normalizeTechnicalDetail(item.message),
+        "The connection to the model was lost. Your work is saved. Retry to continue.",
+      technicalDetail: technicalMessage,
       fallbackModelLabel: null,
+      recoveryAction: null,
     };
   }
 
@@ -35,18 +45,38 @@ export function presentSessionError(item: ErrorItem): SessionErrorPresentation {
     return {
       title: `${provider} rate limit reached`,
       description: `This chat exceeded the provider limit${model ? ` for ${model}` : ""}. ${retryGuidance}`,
-      technicalDetail: normalizeTechnicalDetail(item.message),
+      technicalDetail: technicalMessage,
       fallbackModelLabel,
+      recoveryAction: null,
     };
   }
 
-  const normalizedMessage = normalizeTechnicalDetail(item.message);
-  const description = normalizedMessage
-    ? truncateSentence(normalizedMessage, MAX_DESCRIPTION_LENGTH)
+  const providerModelFailure = resolveProviderModelFailure(item, summaryMessage);
+  if (providerModelFailure) {
+    const description = providerModelFailure === "unavailable"
+      ? "The selected model isn't available from this provider. Choose another model, then try again."
+      : "The provider rejected the reasoning settings for this model. Choose another model, then try again.";
+    return {
+      title: providerModelFailure === "unavailable"
+        ? "Model unavailable"
+        : "Model settings unsupported",
+      description,
+      technicalDetail: buildGenericTechnicalDetail({
+        code: item.code,
+        message: technicalMessage,
+        description,
+      }),
+      fallbackModelLabel: null,
+      recoveryAction: "choose_model",
+    };
+  }
+
+  const description = summaryMessage
+    ? truncateSentence(summaryMessage, MAX_DESCRIPTION_LENGTH)
     : GENERIC_ERROR_DESCRIPTION;
   const technicalDetail = buildGenericTechnicalDetail({
     code: item.code,
-    message: normalizedMessage,
+    message: technicalMessage,
     description,
   });
 
@@ -55,6 +85,7 @@ export function presentSessionError(item: ErrorItem): SessionErrorPresentation {
     description,
     technicalDetail,
     fallbackModelLabel: null,
+    recoveryAction: null,
   };
 }
 
@@ -93,12 +124,54 @@ function formatProviderLabel(provider: string | null | undefined): string {
     .join(" ");
 }
 
-function normalizeTechnicalDetail(message: string | null | undefined): string | null {
+function resolveProviderModelFailure(
+  item: ErrorItem,
+  summaryMessage: string | null,
+): ProviderModelFailure | null {
+  if (item.code === PROVIDER_MODEL_UNAVAILABLE_CODE) {
+    return "unavailable";
+  }
+  if (item.code === PROVIDER_MODEL_CONFIGURATION_UNSUPPORTED_CODE) {
+    return "configuration_unsupported";
+  }
+
+  if (item.sourceAgentKind !== "opencode" || !summaryMessage) {
+    return null;
+  }
+  const normalized = summaryMessage.toLowerCase();
+  if (normalized.includes("provided model identifier is invalid")) {
+    return "unavailable";
+  }
+  if (
+    normalized.includes("the model returned the following errors")
+    && normalized.includes("thinking.type.enabled")
+    && normalized.includes("is not supported for this model")
+    && normalized.includes("thinking.type.adaptive")
+    && normalized.includes("output_config.effort")
+  ) {
+    return "configuration_unsupported";
+  }
+  return null;
+}
+
+function normalizeSummaryMessage(message: string | null | undefined): string | null {
   const normalized = message
     ?.replace(/\s+/g, " ")
-    .replace(/^(error|runtime error|anyharness error):\s*/i, "")
+    .replace(
+      /^(?:(?:error|runtime error|anyharness error|internal error|undefined):\s*)+/i,
+      "",
+    )
+    .replace(
+      /\s*:\s*\{\s*"errorName"\s*:\s*"[^"]+"\s*,\s*"service"\s*:\s*"[^"]+"\s*\}\s*$/i,
+      "",
+    )
     .trim();
   return normalized || null;
+}
+
+function readTechnicalDetail(message: string | null | undefined): string | null {
+  const detail = message?.trim();
+  return detail || null;
 }
 
 function buildGenericTechnicalDetail({

--- a/specs/FEATURE_DOCS/MODELS.md
+++ b/specs/FEATURE_DOCS/MODELS.md
@@ -264,6 +264,13 @@ Events include safe identifiers, basis/revision or source sequence, state,
 counts, duration, and result/error codes. See
 [Observability](../OBSERVABILITY.md) for the repository-wide scrubber contract.
 
+Prompt-time provider rejection is not executable-membership authority. Known
+model-unavailable and model-configuration failures receive bounded error codes
+for actionable client presentation, while the original diagnostic stays behind
+the error's technical-details disclosure. Clients may offer the model picker;
+they do not remove an observed model, rewrite the saved selection, or retry the
+same non-retryable request automatically.
+
 Release coverage includes sparse/unknown Claude identifiers, model-scoped
 Claude controls (including the absence of `fast` under Fable), current Grok
 identifiers, both Codex controls, empty/failure/basis-change states, exact

--- a/specs/anyharness/acp.md
+++ b/specs/anyharness/acp.md
@@ -365,6 +365,12 @@ When that happens the actor is responsible for:
 - updating durable session status
 - emitting normalized error or session-ended events
 
+Known provider-model rejections exposed through ACP are reduced to bounded
+`ErrorEvent.code` values at the integration boundary. The original provider
+message remains the technical detail; clients use the bounded code for
+authored, actionable copy. A classification never changes launch-option
+membership, retries a non-retryable request, or selects another model.
+
 ## Extension Points
 
 Add behavior under `live/sessions/**` when it changes live ACP execution itself,


### PR DESCRIPTION
## Summary

- classify the two known OpenCode ACP provider-model failures into bounded session error codes without changing model membership or retry behavior
- present clear model-unavailable and unsupported-settings messages with a direct Choose model action
- keep the original diagnostic behind Details and clean up transport wrappers for legacy events
- document the ACP boundary and prompt-time model-authority behavior

## Testing

- `CARGO_BUILD_JOBS=1 cargo test -p anyharness-lib --lib integrations::acp::provider_errors`
- `pnpm --filter @proliferate/product-client exec vitest run src/domain/chats/transcript/session-error-presentation.test.ts src/components/workspace/chat/transcript/SessionErrorItem.test.tsx`
- `pnpm --filter @proliferate/product-client typecheck`
- `python3.12 scripts/check_docs.py`
- `git diff --check`

## Observability

No new telemetry fields or payloads. The existing bounded `error_class` field receives the new session error codes; this PR does not add provider payloads to telemetry.