### PR TITLE
perf(dev): use a local postgres or redis that is already listening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,35 @@ LOCAL_PGPORT ?= 5432
 LOCAL_PGUSER ?= proliferate
 LOCAL_PGPASSWORD ?= localdev
 LOCAL_PGDATABASE ?= proliferate
-USE_EXISTING_POSTGRES ?= 0
 LOCAL_REDIS_HOST ?= 127.0.0.1
 LOCAL_REDIS_PORT ?= 6379
-USE_EXISTING_REDIS ?= 0
+# A local service already bound to the port is the one to use. Shell wrappers
+# around `make` exist largely to prefix every invocation with
+# USE_EXISTING_POSTGRES=1 / USE_EXISTING_REDIS=1, so make does not bring up a
+# Docker Postgres or Redis on top of a native one. Probing here instead is what
+# lets `make dev PROFILE=x` be the whole launch, with nothing left for a wrapper
+# to add.
+#
+# The probe runs ONLY for a variable the caller left unset. An explicit 0 still
+# forces the Docker path and an explicit 1 still skips the probe, so every CI
+# workflow, all of which set both to "1", is unaffected by construction. A
+# missing or failing probe yields an empty word and falls back to 0, the
+# behaviour that existed before this block.
+#
+# Both services are probed in one invocation: this file is parsed once per
+# recursive make, and two separate python3 probes cost about 70ms each parse
+# against 10ms for one bash run.
+ifneq ($(filter undefined,$(origin USE_EXISTING_POSTGRES) $(origin USE_EXISTING_REDIS)),)
+LOCAL_SERVICE_PROBE := $(shell scripts/probe-local-services.sh '$(LOCAL_PGHOST)' '$(LOCAL_PGPORT)' '$(LOCAL_REDIS_HOST)' '$(LOCAL_REDIS_PORT)' 2>/dev/null)
+endif
+
+ifeq ($(origin USE_EXISTING_POSTGRES), undefined)
+USE_EXISTING_POSTGRES := $(or $(word 1,$(LOCAL_SERVICE_PROBE)),0)
+endif
+
+ifeq ($(origin USE_EXISTING_REDIS), undefined)
+USE_EXISTING_REDIS := $(or $(word 2,$(LOCAL_SERVICE_PROBE)),0)
+endif
 STRIPE_FORWARD_TO ?= http://127.0.0.1:8000/v1/billing/webhooks/stripe
 STRIPE_SNAPSHOT_EVENTS ?= checkout.session.completed,customer.subscription.created,customer.subscription.updated,customer.subscription.deleted,invoice.paid,invoice.payment_failed
 AGENT_GATEWAY ?= 0
@@ -1623,3 +1648,4 @@ catalog-update:
 	cd scripts/agent-catalog && node build-catalog.mjs --require-complete-probe \
 		&& cp catalog.draft.json ../../catalogs/agents/catalog.json
 	node scripts/validate-agent-catalog.mjs
+

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,16 @@ LOCAL_REDIS_PORT ?= 6379
 # Both services are probed in one invocation: this file is parsed once per
 # recursive make, and two separate python3 probes cost about 70ms each parse
 # against 10ms for one bash run.
+# Never probe under CI. A CI job's service topology is a property of its
+# workflow file, so it must not depend on what happens to be listening: several
+# jobs publish postgres on 5432 and redis on 6379 while running `make` steps
+# that leave both variables unset, and those steps must keep resolving the way
+# they did before this block existed. GitHub Actions always sets CI, and any
+# job that genuinely wants the native services already says so explicitly.
+ifndef CI
 ifneq ($(filter undefined,$(origin USE_EXISTING_POSTGRES) $(origin USE_EXISTING_REDIS)),)
 LOCAL_SERVICE_PROBE := $(shell scripts/probe-local-services.sh '$(LOCAL_PGHOST)' '$(LOCAL_PGPORT)' '$(LOCAL_REDIS_HOST)' '$(LOCAL_REDIS_PORT)' 2>/dev/null)
+endif
 endif
 
 ifeq ($(origin USE_EXISTING_POSTGRES), undefined)
@@ -1648,4 +1656,3 @@ catalog-update:
 	cd scripts/agent-catalog && node build-catalog.mjs --require-complete-probe \
 		&& cp catalog.draft.json ../../catalogs/agents/catalog.json
 	node scripts/validate-agent-catalog.mjs
-

--- a/guides/local/README.md
+++ b/guides/local/README.md
@@ -74,16 +74,30 @@ flows unless their focused command or flag is used.
 
 ## Existing Postgres And Redis
 
-By default, `setup` starts or reuses the repository's Docker Postgres service,
-and `run` starts or reuses the Docker Postgres and Redis services. To use
-services already running on the same host instead, select the existing-service
-paths on every command that touches them:
+A Postgres or Redis already listening on the configured loopback port is used
+as-is. `make` probes for one whenever `USE_EXISTING_POSTGRES` or
+`USE_EXISTING_REDIS` is unset, so a host running native services needs no flags
+at all:
+
+```bash
+make dev PROFILE=<name>
+```
+
+Both flags remain available and still win over the probe. Set either to `1` to
+skip probing, and to `0` to force the repository's Docker service even when a
+native one is listening:
 
 ```bash
 make setup PROFILE=<name> USE_EXISTING_POSTGRES=1
 make build # if this worktree needs artifacts
 make run PROFILE=<name> USE_EXISTING_POSTGRES=1 USE_EXISTING_REDIS=1
 ```
+
+The probe only looks at loopback hosts (`127.0.0.1`, `::1`, `localhost`), where
+a connection is either accepted or refused immediately. Point `LOCAL_PGHOST` or
+`LOCAL_REDIS_HOST` at anything else and the probe reports nothing, selecting the
+Docker service, so a slow or unreachable remote host can never stall a `make`
+parse.
 
 The existing-Postgres path requires `psql` on `PATH`. Its default login role is
 `proliferate`. Create that dedicated local role once from a PostgreSQL

--- a/scripts/probe-local-services.sh
+++ b/scripts/probe-local-services.sh
@@ -16,6 +16,19 @@
 
 set -u
 
+# The Postgres half additionally requires a client. `make`'s existing-Postgres
+# path does not just open a socket: scripts/dev.mjs `ensureDatabase` shells out
+# to `psql -h <host> -p <port>` when USE_EXISTING_POSTGRES is 1, and without
+# psql on PATH spawnSync fails ENOENT and surfaces as a bare
+# "psql ... failed" with no stdout or stderr to explain it. The repo's own
+# docker-compose publishes its db on the same 5432 by default, so a plain socket
+# probe would flip a working Docker setup onto a psql path that is not there.
+# Report 0 instead: Docker keeps talking to Docker.
+probe_postgres() {
+  command -v psql >/dev/null 2>&1 || { printf '0'; return; }
+  probe "$1" "$2"
+}
+
 probe() {
   local host="$1" port="$2"
   case "$host" in
@@ -32,4 +45,4 @@ probe() {
   fi
 }
 
-printf '%s %s\n' "$(probe "${1:-}" "${2:-}")" "$(probe "${3:-}" "${4:-}")"
+printf '%s %s\n' "$(probe_postgres "${1:-}" "${2:-}")" "$(probe "${3:-}" "${4:-}")"

--- a/scripts/probe-local-services.sh
+++ b/scripts/probe-local-services.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Report whether a local Postgres and Redis are already listening.
+#
+# Prints two words, "<postgres> <redis>", each 1 or 0, for the Makefile to read
+# when the caller has not set USE_EXISTING_POSTGRES / USE_EXISTING_REDIS. The
+# point is that `make dev PROFILE=x` should use a native service that is already
+# bound to the port rather than bringing up a Docker one on top of it, without
+# every invocation needing a shell wrapper to say so.
+#
+# /dev/tcp is a bash builtin and has no connect timeout, so probing is limited
+# to loopback hosts, where a connect either succeeds or is refused immediately
+# and can never hang a make parse. Any other host reports 0, which selects the
+# Docker path: the same answer make gave before this script existed.
+#
+# Usage: probe-local-services.sh <pg-host> <pg-port> <redis-host> <redis-port>
+
+set -u
+
+probe() {
+  local host="$1" port="$2"
+  case "$host" in
+    127.0.0.1 | ::1 | localhost) ;;
+    *)
+      printf '0'
+      return
+      ;;
+  esac
+  if (exec 3<>"/dev/tcp/$host/$port") 2>/dev/null; then
+    printf '1'
+  else
+    printf '0'
+  fi
+}
+
+printf '%s %s\n' "$(probe "${1:-}" "${2:-}")" "$(probe "${3:-}" "${4:-}")"


### PR DESCRIPTION
## Why

`make dev PROFILE=x` cannot be the whole launch while `USE_EXISTING_POSTGRES ?= 0`. On a host running native Postgres and Redis (brew services, apt packages), that default makes `make` bring up a Docker Postgres on top of one already bound to 5432. That single default is the main reason a shell wrapper has to sit in front of `make` and prefix every invocation with `USE_EXISTING_POSTGRES=1 USE_EXISTING_REDIS=1`.

On a 24GB machine it is worse than redundant: starting Docker relaunches a roughly 1.7GB VM and re-conflicts the ports.

## What changed

`make` probes for a listening service, but **only for a variable the caller left unset**, decided with `$(origin ...)` rather than by inspecting the value. An explicit `1` skips the probe. An explicit `0` still forces the Docker path even when a native service is listening.

**The probe is skipped entirely under `CI`.** An earlier revision of this body claimed CI was safe because every workflow sets both variables explicitly. Review showed that was false: `ci.yml:592-593` is a *step-level* `env:` on the workflow-definition lifecycle step, not on the `make` steps at `:249` and `:580`, and that job publishes postgres on 5432 and redis on 6379, so `make cloud-client-generate` ran with both variables undefined and both ports listening. `cloud-tests.yml:16` and `cloud-live-webhook.yml:18` set only `USE_EXISTING_POSTGRES`, leaving the redis probe live. No consumer actually broke, but that was circumstance, which is precisely what the claim denied.

An `ifndef CI` guard now makes it true rather than lucky. A job's service topology is a property of its workflow file and must not depend on what happens to be listening. GitHub Actions always sets `CI`, and any job that wants the native services already says so explicitly.

Verified rather than asserted: under `CI=true`, `make -n server-db-ready` and `make -n server-redis-ready` are byte-identical to `main`, including the partial `ci.yml` shape where only `USE_EXISTING_POSTGRES` is set.

## Why a script, and why loopback only

`/dev/tcp` is a bash builtin with no connect timeout. Probing an unreachable remote host would hang the make parse with no way to interrupt it cleanly, so `scripts/probe-local-services.sh` refuses any host that is not `127.0.0.1`, `::1`, or `localhost`, where a connect is either accepted or refused immediately.

Anything else, a missing script, or a failing script all yield an empty word, and `$(or $(word 1,...),0)` falls back to `0`. Every degraded path lands on the Docker service, which is exactly the behaviour that existed before this change.

The Postgres half additionally requires `psql` on `PATH`. The existing-Postgres path does not merely open a socket: `scripts/dev.mjs` `ensureDatabase` shells out to `psql -h <host> -p <port>` when the flag is 1. The repo's own `server/docker-compose.yml` publishes its db on that same 5432 (`Makefile:307` defaults `PROLIFERATE_DB_HOST_PORT` to `LOCAL_PGPORT`), so a bare socket probe would flip a working Docker setup onto a psql path that is not installed, where `spawnSync` fails ENOENT and surfaces as a bare `psql ... failed` with no stdout or stderr to explain it. `probe_postgres` therefore requires psql first, mirroring the guard already at `Makefile:550`. Docker keeps talking to Docker.

Both services are probed in one bash invocation because this file is parsed once per recursive make. Two separate `python3` socket probes measured 70ms per parse against 10ms for one bash run.

## Cost

| variant | ms per make parse |
|---|---|
| `main` today | 17 |
| both flags set, probe skipped | 17 |
| both unset, probe runs | 30 |

(Independently re-measured during review. An earlier revision of this body said 18 / 20 / 31; the skipped case is in fact indistinguishable from `main`, so the old table overstated the cost.)

## Verification

An important trap first: **this shell already had `USE_EXISTING_POSTGRES=1` in its environment**, so my first run of the matrix reported `origin=environment` in every cell and never exercised the new code at all. Every result below was re-run under `env -u USE_EXISTING_POSTGRES -u USE_EXISTING_REDIS`.

Read through the real consumers, `make -n server-db-ready` and `make -n server-redis-ready`, rather than by printing the variable:

| case | selected | wanted |
|---|---|---|
| pg unset, Postgres listening | EXISTING | EXISTING |
| pg unset, port 5399 empty | DOCKER | DOCKER |
| pg explicit `0`, Postgres listening | DOCKER | DOCKER |
| pg explicit `1` | EXISTING | EXISTING |
| redis unset, Redis listening | EXISTING | EXISTING |
| redis unset, port 6399 empty | DOCKER | DOCKER |
| redis explicit `0` | DOCKER | DOCKER |

The probe script on its own:

```
loopback, both up            : 1 1
loopback, pg port empty      : 0 1
loopback, redis port empty   : 1 0
non-loopback host (no hang)  : 0 0
localhost spelling           : 1 1
```

### Negative control

Delete the probe script and re-resolve:

```
probe=[] pg=0 redis=0
server-db-ready -> DOCKER
```

That is `main`'s behaviour exactly, which is the point: the fallback is the old default, not a new failure mode. Forcing the script to print `0 0` gives the same, confirming the wiring reads the probe rather than ignoring it.

`shellcheck scripts/probe-local-services.sh` is clean.

## Relationship to #2134

Complementary, no overlap. #2134 makes `dev` recursive (`setup`, `dev-build`, `run`), adds `HEADLESS`, and stops the double cargo build. This removes the last reason the launch still needs an env prefix. Together, `make dev PROFILE=x` is the entire command.

Still not absorbed into `make` from a wrapper: nothing. `dev-init` is `setup`, and `setup` already runs the per-profile `ensure-db` at `Makefile:343` on this branch, `:318` on `main`, so with this change a wrapper has nothing left to contribute.

## Not for merge

Draft, and nothing here has been merged or self-approved.

