### PR TITLE
fix(product-client): cancel the virtualizer debounce before jsdom teardown

### DIFF
--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx
@@ -68,6 +68,19 @@ const ROWS: TranscriptVirtualRow[] = [
   { kind: "pending_prompt", key: "pending-prompt:session-1" },
 ];
 
+// @tanstack/virtual-core's isScrolling-reset debounce (`utils.ts`
+// `debounce`) arms a real `targetWindow.setTimeout` on "scroll" and never
+// cancels it on unmount, so a late scroll leaves it pending past
+// `cleanup()`. If it fires after vitest tears down jsdom's `window`,
+// react-dom's `resolveUpdatePriority` throws, failing the whole CI shard
+// even though every test passed (CI run 32450933492, job 96679196436).
+//
+// Track every timer armed on `window` per test and cancel whatever is still
+// outstanding before `cleanup()`, so it is cancelled outright, not raced.
+let pendingWindowTimeoutIds: Set<ReturnType<typeof setTimeout>>;
+let realWindowSetTimeout: typeof window.setTimeout;
+let realWindowClearTimeout: typeof window.clearTimeout;
+
 beforeEach(() => {
   observedVirtualizerOptions.length = 0;
   completedTurnAnchorRef.current = null;
@@ -78,9 +91,31 @@ beforeEach(() => {
     disconnect() {}
   }
   vi.stubGlobal("ResizeObserver", TestResizeObserver);
+
+  pendingWindowTimeoutIds = new Set();
+  realWindowSetTimeout = window.setTimeout.bind(window);
+  realWindowClearTimeout = window.clearTimeout.bind(window);
+  window.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+    const id = realWindowSetTimeout(() => {
+      pendingWindowTimeoutIds.delete(id);
+      (handler as (...a: unknown[]) => void)(...args);
+    }, timeout);
+    pendingWindowTimeoutIds.add(id);
+    return id;
+  }) as typeof window.setTimeout;
+  window.clearTimeout = ((id?: Parameters<typeof window.clearTimeout>[0]) => {
+    if (id !== undefined) {
+      pendingWindowTimeoutIds.delete(id as ReturnType<typeof setTimeout>);
+    }
+    return realWindowClearTimeout(id);
+  }) as typeof window.clearTimeout;
 });
 
 afterEach(() => {
+  pendingWindowTimeoutIds.forEach((id) => realWindowClearTimeout(id));
+  pendingWindowTimeoutIds.clear();
+  window.setTimeout = realWindowSetTimeout;
+  window.clearTimeout = realWindowClearTimeout;
   cleanup();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();

--- a/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx
@@ -112,11 +112,18 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Drain, unmount, drain again, and only then restore. cleanup() runs
+  // unmount-time effect cleanups, and one of those could itself arm a timer;
+  // restoring the native functions before cleanup() would let such a timer
+  // slip through untracked, reopening the exact bug class this file guards
+  // against from a different source (review finding on #2162).
+  pendingWindowTimeoutIds.forEach((id) => realWindowClearTimeout(id));
+  pendingWindowTimeoutIds.clear();
+  cleanup();
   pendingWindowTimeoutIds.forEach((id) => realWindowClearTimeout(id));
   pendingWindowTimeoutIds.clear();
   window.setTimeout = realWindowSetTimeout;
   window.clearTimeout = realWindowClearTimeout;
-  cleanup();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });


### PR DESCRIPTION
## Mechanism (verified this session)

I read the installed source directly: `node_modules/.pnpm/@tanstack+virtual-core@3.17.7/node_modules/@tanstack/virtual-core/dist/esm/utils.js` and `.../index.js`.

`debounce` in `utils.js` is exactly:

```js
const debounce = (targetWindow, fn, ms) => {
  let timeoutId;
  return function(...args) {
    targetWindow.clearTimeout(timeoutId);
    timeoutId = targetWindow.setTimeout(() => fn.apply(this, args), ms);
  };
};
```

It is armed inside `observeOffset` in `index.js`:

```js
const fallback = registerScrollendEvent ? null : debounce(
  targetWindow,
  () => cb(offset, false),
  instance.options.isScrollingResetDelay
);
```

`isScrollingResetDelay` defaults to `150` (confirmed in `index.js`'s `defaultOptions`, and I grepped `VirtualizedTranscriptRowList.tsx`'s `useVirtualizer` call, which does not override it). Every native `scroll` event on the observed element calls this `fallback()`, rearming the timer.

The critical detail: `observeOffset`'s returned unsub function only does `element.removeEventListener("scroll", handler)`. It does not clear the debounce's `timeoutId`, and that id lives in a closure private to `observeOffset`/`debounce`, unreachable from the virtualizer's own public `cleanup()`, from React's unmount, or from a test. Once a test fires a "scroll" event and ends before the delay passes, unmounting via `cleanup()` (testing-library) does not cancel the pending timer. It survives.

Pablo's read was correct on every point I could verify (mechanism, delay, unmount does not cancel it).

## Why zero failing tests still failed the shard

Vitest's jsdom environment is torn down (its `window`/`document` globals removed) once a test file's tests finish. If the debounce timer above is still pending at that moment, it later calls its callback, which flows into React's `dispatchReducerAction -> requestUpdateLane -> resolveUpdatePriority` (react-dom-client.development.js), and that code reads the bare global `window` unconditionally. With `window` gone, that is a `ReferenceError: window is not defined`, thrown as an uncaught error with no test in progress to attribute it to. Vitest reports it separately from the per-test results, and a shard fails on any uncaught error regardless of how many tests passed. That is exactly what CI run 32450933492, job 96679196436 shows: 2005/2005 tests and 274/274 files green, shard red on 2 of these post-teardown errors.

## Fix chosen, and why the shared-setup option was rejected

I checked `apps/packages/product-client/vitest.config.ts`: it has a shared `setupFiles: ["./vitest.setup.ts"]`. I grep'd the package for every test file that touches `@tanstack/react-virtual` (`FileTreeOverlay.test.tsx`, `WorkflowsMainSurface.test.tsx`, `VirtualizedTranscriptRowList.test.tsx`) and every test file that calls `fireEvent.scroll` (`AutoHideScrollArea.test.tsx`, `FullTranscriptRowList.test.tsx`, `VirtualizedTranscriptRowList.test.tsx`). `FileTreeOverlay` and `WorkflowsMainSurface` fully replace `useVirtualizer` with their own fake, so no real timer is ever armed there. `AutoHideScrollArea` and `FullTranscriptRowList` do not import `@tanstack/react-virtual` at all. `VirtualizedTranscriptRowList.test.tsx` is the only file in the package today that both mounts the real virtualizer (it wraps `useVirtualizer` for instrumentation but delegates to `actual.useVirtualizer`) and fires real `scroll` events at the observed element, so the bug class is confined to one file right now, and a package-wide hook would tax roughly 2000 unrelated tests to protect one file. The fix is local to this file's own hooks.

## Why the fix cancels the timer instead of waiting for it (this was reworked after review)

My first version of this fix `await`ed a real 200ms wait in `afterEach` before `cleanup()`, hoping to let a pending debounce fire safely while `window` still existed. That was rejected, correctly: the debounce is armed at some point T during the test, and fires at T+150. The wait starts at T+e, where e is however long the rest of the test body and vitest's own hook dispatch happen to take, and only beats the debounce while e stays under 50ms. On a CI runner running four vitest workers competing for cores, a scheduling stall past 50ms is ordinary, which is exactly the load this bug already depends on to surface. That version made the failure rarer, not impossible, and it also silently depended on `isScrollingResetDelay` staying at its current default of 150, and added roughly 2.6s of pure wait time across this file's tests for a wait that does nothing in the common case.

The shipped fix instead wraps `window.setTimeout`/`window.clearTimeout` for the duration of each test (in `beforeEach`), recording every timer id armed on `window`. In `afterEach` it clears every id still outstanding, runs `cleanup()`, clears again (an unmount-time effect cleanup could itself arm a timer, and review correctly flagged that restoring the natives before `cleanup()` would let such a timer slip through untracked), and only then restores the originals (`4e17952ce4`). A pending debounce is cancelled outright, not raced against: it cannot fire before or after teardown regardless of scheduler load, and the fix has no dependency on what the debounce's delay actually is.

## Negative control (literal output, both ways)

I appended a temporary two-test pair to the real file, tied to the real, shared hooks: an outer observer (installed once via `beforeAll`, sitting below whatever the per-test hooks do) tracks every real timer id armed and cleared on `window` for the whole file, independent of which version of the per-test hooks is active. The first throwaway test arms the debounce and ends immediately; the second asserts the armed id is no longer in the outer observer's pending set.

**Reverted to the original, unfixed hooks** (`afterEach(() => { cleanup(); vi.restoreAllMocks(); vi.unstubAllGlobals(); })`, temporary tests appended):

```
 × VirtualizedTranscriptRowList > THROWAWAY: by the next test, the previous test's afterEach must already have cancelled the debounce 12ms
   → expected true to be false // Object.is equality

AssertionError: expected true to be false

 Test Files  1 failed (1)
      Tests  1 failed | 14 passed (15)
```

**With the shipped cancellation fix** (same temporary tests):

```
 ✓ src/components/workspace/chat/transcript/VirtualizedTranscriptRowList.test.tsx (15 tests) 102ms

 Test Files  1 passed (1)
      Tests  15 passed (15)
```

I additionally proved the determinism claim directly rather than inferring it from a passing suite, in a separate throwaway spec: it spies on `window.setTimeout` filtered to `ms === 150` (the debounce's exact delay) to record whether the callback actually ran. Without cancellation, arming the debounce and unmounting, then waiting 200ms past the delay, shows the callback firing anyway:

```
 ✓ WITHOUT cancellation: the debounce fires ~150ms after arming even though the tree already unmounted
```

(assertions inside: `fired` is `false` immediately after unmount, then `true` after the 200ms wait, proving it fired post-unmount on its own schedule)

With the same cancellation sequence the shipped fix uses (track ids, clear everything outstanding, then unmount), the callback never runs even after the same 200ms wait:

```
 ✓ WITH cancellation (the fix): the same debounce can never fire, checked directly rather than inferred
```

(assertion inside: `fired` stays `false` after the 200ms wait, checked directly, not inferred from the suite being green)

I also proved the second half of the causal chain in an earlier throwaway spec (kept from the first pass at this fix): `vi.useFakeTimers()`, arm the same real component's debounce, unmount without draining, delete `globalThis.window` (simulating vitest's own environment teardown), advance the fake timer, and catch `ReferenceError: window is not defined` from the callback, matching the CI stack exactly.

All throwaway files and appended test pairs were deleted before this PR's commits; only the one-file `beforeEach`/`afterEach` change ships.

## Diagram

```mermaid
sequenceDiagram
    participant Test as fireEvent.scroll(viewport)
    participant VC as virtual-core observeOffset
    participant Timer as window.setTimeout(150ms)
    participant BE as beforeEach / afterEach
    participant Vitest as vitest jsdom teardown

    Test->>VC: scroll event
    VC->>Timer: arm debounce (isScrollingResetDelay: 150)
    Note over BE: beforeEach already wrapped window.setTimeout/clearTimeout,<br/>so Timer's id is recorded in a per-test Set
    BE->>Timer: afterEach clears every id still in the Set
    Note over Timer: cancelled outright, cannot fire, no wait involved
    BE->>Vitest: cleanup() unmounts a quiescent tree
    Vitest->>Vitest: delete global.window (env teardown)
    Note over Timer: nothing left pending to collide with the missing window
```

