### PR TITLE
test(anyharness): drive a real ACP initialize over the windows launcher

### DIFF
--- a/.github/workflows/windows-acp-handshake.yml
+++ b/.github/workflows/windows-acp-handshake.yml
@@ -1,0 +1,92 @@
+name: Windows managed-agent ACP handshake
+
+# The question `windows-managed-agent-install.yml` could not answer.
+#
+# That job proved the managed claude install produces a `.cmd` launcher that
+# `CreateProcess` can spawn and that exits 0 on stdin EOF. It never wrote a
+# byte to the launcher's stdin and never read a byte back, so "exit 0, empty
+# stdout, empty stderr" was the whole finding. A `.cmd` containing only
+# `@echo off` would have produced exactly that.
+#
+# This job writes a real ACP `initialize` request into the launcher and
+# requires a well-formed JSON-RPC response back, twice, before a clean
+# shutdown. No credential is involved: `initialize` is the handshake that
+# precedes authentication on both sides (see the test's module docs for the
+# source reading that establishes it).
+#
+# Ubuntu runs the identical test as the discriminating control, so a green
+# Windows leg cannot be explained by the test being vacuous.
+#
+# Deliberately NOT `continue-on-error`: the point is a verdict. Note that
+# `windows-compile-check.yml` IS `continue-on-error` on both of its jobs and
+# `ci-ok`'s `needs:` list covers only `ci.yml` jobs, so neither of those tells
+# you anything about this one. Read this workflow's own result.
+
+on:
+  workflow_dispatch:
+    inputs:
+      negative_control:
+        description: >-
+          Sabotage the handshake on purpose. Replaces the npm bin shim the
+          emitted launcher invokes with a process that starts, holds stdin and
+          never answers, leaving the launcher, the spawn and the assertions
+          untouched. The run MUST go red with ACP-HANDSHAKE-TIMEOUT. Used to
+          prove the test can fail.
+        type: boolean
+        default: false
+  pull_request:
+    paths:
+      - "anyharness/crates/anyharness-lib/tests/windows_acp_handshake.rs"
+      - "anyharness/crates/anyharness-lib/src/domains/agents/installer/**"
+      - "anyharness/crates/anyharness-lib/src/integrations/agent_cli/**"
+      - "catalogs/agents/**"
+      - ".github/workflows/windows-acp-handshake.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  acp-handshake:
+    name: acp initialize (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    # A handshake test that hangs is worse than no test: it would burn the
+    # runner's default 6h and report nothing. Every read inside the test is
+    # already deadline-bounded; this is the belt to that pair of braces.
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # The control: this path is exercised on unix every day.
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          # The unknown.
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Node / npm as the runner ships them
+        # The install shells out to npm, and the in-suite discriminators spawn
+        # `node -e`. Record what is on PATH so a spawn failure can be read
+        # against the real layout rather than an assumption about it.
+        shell: bash
+        run: |
+          node --version || true
+          npm --version || true
+          echo "which node: $(which node || true)"
+          echo "PATHEXT: ${PATHEXT:-<unset>}"
+      - name: cargo test
+        # Serial and uncaptured: the test runs a real `npm install`, spawns a
+        # real agent, and prints the actual JSON-RPC lines in both directions.
+        # That transcript IS the finding.
+        env:
+          RUST_BACKTRACE: "1"
+          ACP_HANDSHAKE_NEGATIVE_CONTROL: ${{ inputs.negative_control && '1' || '0' }}
+        run: >
+          cargo test --target ${{ matrix.target }}
+          -p anyharness-lib --test windows_acp_handshake
+          -- --nocapture --test-threads=1

--- a/anyharness/crates/anyharness-lib/tests/acp_stdio/mod.rs
+++ b/anyharness/crates/anyharness-lib/tests/acp_stdio/mod.rs
@@ -1,0 +1,300 @@
+//! A deadline-bounded newline-delimited-JSON peer for driving a spawned ACP
+//! agent over stdio, shared by the tests in `windows_acp_handshake.rs`.
+//!
+//! The framing is hand-rolled rather than driven through
+//! `acp::ClientSideConnection` on purpose: that client owns its own async
+//! runtime and its own unbounded read loop, and a hang inside it would give no
+//! diagnosis. The BYTES are identical (the adapter reads the stream with
+//! `ndJsonStream(...)` over `process.stdin`), and the request and response
+//! payloads still go through the real `acp::schema` types at the call sites, so
+//! the only thing reimplemented here is "one JSON value per line".
+//!
+//! Every read is bounded. There is no code path here that waits forever and no
+//! code path that turns silence into success: silence is
+//! `ACP-HANDSHAKE-TIMEOUT`, a closed stream is `ACP-HANDSHAKE-EOF`, and an
+//! unusable stdin handle is `ACP-HANDSHAKE-WRITE-FAILED`.
+//!
+//! This lives in a subdirectory, not at `tests/acp_stdio.rs`, so cargo does not
+//! pick it up as a second integration-test target.
+
+// Not every test in the suite touches every helper; the module is shared
+// support code, not a public API.
+#![allow(dead_code)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+#[derive(Debug)]
+pub enum HandshakeFailure {
+    /// Nothing came back in time. The loud one.
+    Timeout {
+        method: String,
+        waited: Duration,
+        stderr: String,
+        transcript: Vec<String>,
+    },
+    /// stdout closed (or errored) without ever carrying our response.
+    Eof {
+        method: String,
+        stderr: String,
+        transcript: Vec<String>,
+    },
+    /// The request could not even be handed to the child.
+    WriteFailed { method: String, error: String },
+}
+
+impl std::fmt::Display for HandshakeFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Timeout {
+                method,
+                waited,
+                stderr,
+                transcript,
+            } => write!(
+                f,
+                "ACP-HANDSHAKE-TIMEOUT: no JSON-RPC response to `{method}` arrived on stdout \
+                 within {waited:?}. The process was spawned and accepted the request but never \
+                 answered it. This is a failure, not a skip.\n\
+                 lines received on stdout ({} total): {transcript:#?}\n\
+                 stderr so far:\n{stderr}",
+                transcript.len()
+            ),
+            Self::Eof {
+                method,
+                stderr,
+                transcript,
+            } => write!(
+                f,
+                "ACP-HANDSHAKE-EOF: stdout closed before any JSON-RPC response to `{method}` \
+                 arrived. The process exited or dropped the stream instead of answering. An \
+                 empty response is a failure, not a pass.\n\
+                 lines received on stdout ({} total): {transcript:#?}\n\
+                 stderr so far:\n{stderr}",
+                transcript.len()
+            ),
+            Self::WriteFailed { method, error } => write!(
+                f,
+                "ACP-HANDSHAKE-WRITE-FAILED: could not write the `{method}` request to the \
+                 child's stdin: {error}. The stdio handle the launcher handed us is not usable."
+            ),
+        }
+    }
+}
+
+/// Owns a spawned process and reads newline-delimited JSON off its stdout with
+/// a deadline on every read.
+///
+/// The framing is hand-rolled rather than driven through
+/// `acp::ClientSideConnection` on purpose: that client owns its own async
+/// runtime and its own (unbounded) read loop, and a hang inside it would give
+/// no diagnosis. The BYTES are identical — the adapter reads this stream with
+/// `ndJsonStream(...)` over `process.stdin` — and the request and response
+/// payloads below still go through the real `acp::schema` types, so the only
+/// thing reimplemented here is "one JSON value per line".
+pub struct AcpPeer {
+    child: Child,
+    stdin: Option<std::process::ChildStdin>,
+    lines: Receiver<String>,
+    stderr: Arc<Mutex<String>>,
+    transcript: Vec<String>,
+}
+
+impl AcpPeer {
+    pub fn attach(mut child: Child) -> Self {
+        let stdin = child.stdin.take().expect("piped stdin");
+        let stdout = child.stdout.take().expect("piped stdout");
+        let mut stderr = child.stderr.take().expect("piped stderr");
+
+        let (tx, lines) = mpsc::channel();
+        std::thread::spawn(move || {
+            let reader = BufReader::new(stdout);
+            for line in reader.lines() {
+                match line {
+                    Ok(line) => {
+                        if tx.send(line).is_err() {
+                            return;
+                        }
+                    }
+                    // A read error is EOF for our purposes; dropping `tx` on
+                    // the way out is what signals it.
+                    Err(_) => return,
+                }
+            }
+        });
+
+        let stderr_buffer = Arc::new(Mutex::new(String::new()));
+        let stderr_sink = Arc::clone(&stderr_buffer);
+        std::thread::spawn(move || {
+            // Drained continuously so the child can never wedge on a full
+            // stderr pipe while we are waiting on stdout.
+            let mut chunk = [0u8; 4096];
+            loop {
+                match std::io::Read::read(&mut stderr, &mut chunk) {
+                    Ok(0) | Err(_) => return,
+                    Ok(n) => {
+                        let text = String::from_utf8_lossy(&chunk[..n]).into_owned();
+                        if let Ok(mut sink) = stderr_sink.lock() {
+                            sink.push_str(&text);
+                        }
+                    }
+                }
+            }
+        });
+
+        Self {
+            child,
+            stdin: Some(stdin),
+            lines,
+            stderr: stderr_buffer,
+            transcript: Vec::new(),
+        }
+    }
+
+    pub fn stderr_snapshot(&self) -> String {
+        self.stderr
+            .lock()
+            .map(|sink| sink.clone())
+            .unwrap_or_else(|_| "<stderr buffer poisoned>".to_string())
+    }
+
+    /// Write one JSON-RPC request and read until its response, or until the
+    /// deadline. Never blocks without a bound.
+    pub fn request(
+        &mut self,
+        id: u64,
+        method: &str,
+        params: serde_json::Value,
+        timeout: Duration,
+    ) -> Result<serde_json::Value, HandshakeFailure> {
+        let line = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        })
+        .to_string();
+        println!("--> {line}");
+
+        let stdin = self.stdin.as_mut().expect("stdin still open");
+        if let Err(error) = stdin
+            .write_all(line.as_bytes())
+            .and_then(|()| stdin.write_all(b"\n"))
+            .and_then(|()| stdin.flush())
+        {
+            return Err(HandshakeFailure::WriteFailed {
+                method: method.to_string(),
+                error: format!("{error} (kind {:?})", error.kind()),
+            });
+        }
+
+        let started = Instant::now();
+        let deadline = started + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(HandshakeFailure::Timeout {
+                    method: method.to_string(),
+                    waited: started.elapsed(),
+                    stderr: self.stderr_snapshot(),
+                    transcript: self.transcript.clone(),
+                });
+            }
+            match self.lines.recv_timeout(remaining) {
+                Ok(line) => {
+                    println!("<-- {line}");
+                    self.transcript.push(line.clone());
+                    let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+                        // Not JSON at all. Recorded, not fatal on its own: the
+                        // deadline is what ends the loop. If cmd.exe ever
+                        // injects a banner line into the stream this is where
+                        // it will show up in the log.
+                        continue;
+                    };
+                    // A response, not an agent-initiated request: responses
+                    // carry no `method`.
+                    if value.get("method").is_some() {
+                        continue;
+                    }
+                    if value.get("id").and_then(serde_json::Value::as_u64) != Some(id) {
+                        continue;
+                    }
+                    println!(
+                        "response to `{method}` (id {id}) arrived after {:?}",
+                        started.elapsed()
+                    );
+                    return Ok(value);
+                }
+                Err(RecvTimeoutError::Timeout) => {
+                    return Err(HandshakeFailure::Timeout {
+                        method: method.to_string(),
+                        waited: started.elapsed(),
+                        stderr: self.stderr_snapshot(),
+                        transcript: self.transcript.clone(),
+                    })
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    return Err(HandshakeFailure::Eof {
+                        method: method.to_string(),
+                        stderr: self.stderr_snapshot(),
+                        transcript: self.transcript.clone(),
+                    })
+                }
+            }
+        }
+    }
+
+    /// Close stdin and wait, bounded, for the process to exit.
+    pub fn close_stdin_and_wait(mut self, timeout: Duration) -> (Option<ExitStatus>, String) {
+        drop(self.stdin.take());
+        let deadline = Instant::now() + timeout;
+        let mut status = None;
+        while Instant::now() < deadline {
+            match self.child.try_wait() {
+                Ok(Some(exited)) => {
+                    status = Some(exited);
+                    break;
+                }
+                Ok(None) => std::thread::sleep(Duration::from_millis(100)),
+                Err(error) => panic!("try_wait on the managed agent failed: {error}"),
+            }
+        }
+        if status.is_none() {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+        (status, self.stderr_snapshot())
+    }
+
+    pub fn kill(mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Spawn a node one-liner with all three handles piped.
+///
+/// Node is not optional and is never skipped past: the managed install these
+/// tests exercise runs `npm install`, so a runner without node cannot run any
+/// test in this suite at all. A missing node is a hard failure with its own
+/// message, never a skip.
+pub fn spawn_node(label: &str, script: &str) -> Child {
+    Command::new("node")
+        .arg("-e")
+        .arg(script)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap_or_else(|error| {
+            panic!(
+                "could not spawn the `{label}` discriminator process (`node -e ...`): {error} \
+                 (kind {:?}). node is required by the managed install path this file tests, so \
+                 this is a failure, not a reason to skip.",
+                error.kind()
+            )
+        })
+}

--- a/anyharness/crates/anyharness-lib/tests/windows_acp_handshake.rs
+++ b/anyharness/crates/anyharness-lib/tests/windows_acp_handshake.rs
@@ -1,0 +1,555 @@
+//! Does a managed agent launched through the Windows `.cmd` launcher actually
+//! SPEAK ACP?
+//!
+//! `tests/windows_managed_agent_install.rs` proved the layer under this one:
+//! the pinned installer downloads and sha256-verifies `claude.exe`, runs a real
+//! `npm install`, emits `claude-launcher.cmd`, and `CreateProcess` can spawn
+//! it. It proved that by spawning the launcher, immediately closing stdin, and
+//! observing exit 0.
+//!
+//! Exit 0 with empty stdout AND empty stderr is a much weaker statement than it
+//! looks. Nothing was ever written to the launcher's stdin and nothing was ever
+//! read back, so the only thing established was "the process starts and exits
+//! cleanly on EOF". A `.cmd` file containing nothing but `@echo off` would pass
+//! that test. Every layer above spawn — whether the batch wrapper forwards the
+//! stdio handles to its grandchild node process, whether cmd.exe injects
+//! anything into the stream, whether newline-delimited JSON survives a Windows
+//! pipe intact in both directions — was untested.
+//!
+//! This test closes that gap. It drives a real ACP `initialize` request over
+//! stdio into the launcher the real installer emitted, and requires a
+//! well-formed JSON-RPC response back:
+//!
+//!   bundled catalog -> `install_agent_with_pins` -> emitted `.cmd` launcher
+//!   -> spawn -> write `initialize` -> read + validate the response
+//!   -> write a second `initialize` -> read it -> close stdin -> clean exit
+//!
+//! ## Why claude
+//!
+//! `claude` is the only agent that can answer this question today.
+//! `cursor` and `opencode` declare no `windows_*` pins at all and fail
+//! `NoPinForPlatform` before anything is installed. `codex` has Windows pins
+//! but reaches them through a `.tar.gz` extraction branch nothing has ever
+//! executed on Windows, so a red result there would be ambiguous between the
+//! extraction branch and the handshake. `grok` installs and spawns on Windows
+//! (proved in run 32450488248) but its ACP surface is a different adapter, and
+//! it is not the default agent. `claude` is the default agent, has proven
+//! Windows pins (#2149), a proven Windows install and spawn (#2152 +
+//! run 32450488248), and is the one that has to work for a Windows beta.
+//!
+//! ## Why no credential is needed, and how that was checked
+//!
+//! `initialize` is the handshake that PRECEDES authentication: the runtime's
+//! own `initialize_connection` sends it first and only then inspects
+//! `auth_methods` to decide whether to call `authenticate`
+//! (`live/sessions/driver/session_lifecycle.rs`). That is the client side.
+//! The agent side was checked too, by reading the pinned adapter at the exact
+//! sha the catalog installs (`claude-agent-acp`
+//! @ 65f6205329daea4a521ee0f0c042722b0feb306a): `ClaudeAcpAgent.initialize`
+//! reads `request.clientCapabilities` and a handful of `process.env` remote
+//! hints, then returns a literal response object. It reads no credential file,
+//! makes no network call, and cannot fail for lack of auth. `src/index.ts`'s
+//! startup path is likewise credential-free.
+//!
+//! No API key is used, needed, or accepted by this test.
+//!
+//! ## Why an integration test target
+//!
+//! `anyharness-lib`'s `--lib` test target does not build for Windows (ten
+//! pre-existing test-only POSIX assumptions in unrelated modules). An
+//! integration test compiles as its own crate against the public surface and
+//! never pulls those in. Same reason, same shape as
+//! `tests/windows_managed_agent_install.rs` and `tests/windows_process_tree.rs`.
+//!
+//! The deadline-bounded stdio peer these tests drive lives in
+//! `tests/acp_stdio/mod.rs`.
+//!
+//! ## Anti-skip and anti-hang
+//!
+//! There is no skip path. A missing agent, a failed install, an empty
+//! response, a malformed response, a JSON-RPC error response, an early EOF and
+//! a silent process are each a distinct, loud panic. Every read is bounded by
+//! a deadline and a timeout is `ACP-HANDSHAKE-TIMEOUT`, never a pass.
+//!
+//! The timeout and EOF discriminators are not taken on faith either:
+//! `the_handshake_timeout_is_a_loud_failure_not_a_pass` and
+//! `an_immediate_exit_is_a_loud_failure_not_a_pass` run the same reader
+//! against a process that never answers and a process that answers nothing and
+//! exits, on every run, on both operating systems.
+//!
+//! Setting `ACP_HANDSHAKE_NEGATIVE_CONTROL=1` sabotages the real path end to
+//! end: after the real install, the npm bin shim the emitted launcher invokes
+//! is replaced with a program that starts, holds stdin, and never writes. The
+//! launcher, the spawn and the assertions are untouched, so the run must go red
+//! with `ACP-HANDSHAKE-TIMEOUT`. It can only ever turn a pass into a failure.
+
+mod acp_stdio;
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use agent_client_protocol as acp;
+use anyharness_lib::domains::agents::catalog::service::AgentCatalogService;
+use anyharness_lib::domains::agents::catalog::sync::CatalogSyncService;
+use anyharness_lib::domains::agents::installer::{install_agent_with_pins, InstallOptions};
+use anyharness_lib::domains::agents::model::ArtifactRole;
+use anyharness_lib::domains::agents::registry;
+
+use acp_stdio::{spawn_node, AcpPeer, HandshakeFailure};
+
+/// Deliberately not 0 or 1. The agent may issue its own client-bound requests
+/// on the same stream, and its id space is independent of ours; a distinctive
+/// id plus the "responses have no `method` member" check below means a
+/// collision cannot be mistaken for our answer.
+const FIRST_REQUEST_ID: u64 = 4242;
+const SECOND_REQUEST_ID: u64 = 4243;
+
+/// Generous, because the runner is slow and the install that precedes this took
+/// about seven minutes on windows-latest in run 32450488248. Generous is fine;
+/// unbounded is not. Node cold start plus the adapter's SDK import is the thing
+/// being waited on.
+const FIRST_RESPONSE_TIMEOUT: Duration = Duration::from_secs(180);
+/// The process is warm by now. If the stream survived one round trip and dies
+/// on the second, that is a framing bug, and it should be reported in a minute,
+/// not in three.
+const SECOND_RESPONSE_TIMEOUT: Duration = Duration::from_secs(60);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(60);
+/// The in-suite discriminators talk to a process that is known never to answer,
+/// so there is nothing to wait for.
+const DISCRIMINATOR_TIMEOUT: Duration = Duration::from_secs(15);
+
+const NEGATIVE_CONTROL_ENV: &str = "ACP_HANDSHAKE_NEGATIVE_CONTROL";
+
+// ---------------------------------------------------------------------------
+// The real thing.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_managed_claude_launcher_answers_a_real_acp_initialize_handshake() {
+    let negative_control = negative_control_requested();
+    if negative_control {
+        println!(
+            "!!! NEGATIVE CONTROL ENGAGED ({NEGATIVE_CONTROL_ENV}=1): the npm bin shim the \
+             emitted launcher invokes will be replaced with a process that starts, holds stdin \
+             and never answers. This run MUST fail with ACP-HANDSHAKE-TIMEOUT."
+        );
+    }
+
+    let runtime_home = scratch_runtime_home("handshake");
+    println!("runtime_home = {}", runtime_home.display());
+
+    // Real bundled catalog + real bundled registry: the two documents the
+    // shipped runtime boots with. No fixture, no override.
+    let catalog = AgentCatalogService::new(Arc::new(CatalogSyncService::from_bundled()));
+    let pins = catalog
+        .pin_overrides("claude")
+        .expect("claude must have catalog pins; without them there is nothing to install");
+    println!("catalog pins = {pins:?}");
+    let descriptor =
+        registry::descriptor("claude").expect("claude must have a registry descriptor");
+    println!(
+        "descriptor.launch.executable_name = {}",
+        descriptor.launch.executable_name
+    );
+
+    let options = InstallOptions {
+        reinstall: true,
+        ..InstallOptions::default()
+    };
+    let installed = install_agent_with_pins(&descriptor, &runtime_home, &options, Some(&pins))
+        .unwrap_or_else(|error| {
+            panic!(
+                "install_agent_with_pins failed for claude: {error} (kind {:?}). The handshake \
+                 was never reached; this is an install failure, not a handshake result.",
+                error.kind()
+            )
+        });
+    for artifact in &installed {
+        println!(
+            "installed role={:?} source={} version={:?} path={}",
+            artifact.role,
+            artifact.source,
+            artifact.version,
+            artifact.path.display()
+        );
+    }
+
+    let launcher = installed
+        .iter()
+        .find(|artifact| matches!(artifact.role, ArtifactRole::AgentProcess))
+        .map(|artifact| artifact.path.clone())
+        .expect("the install must report an agent-process artifact; there is nothing to spawn");
+    assert!(
+        launcher.is_file(),
+        "the installer reported a launcher at {} but no such file exists",
+        launcher.display()
+    );
+    match std::fs::read_to_string(&launcher) {
+        Ok(script) => println!("--- launcher script ({})\n{script}", launcher.display()),
+        Err(error) => println!("--- launcher is not UTF-8 text: {error}"),
+    }
+
+    let managed_dir = runtime_home
+        .join("agents")
+        .join("claude")
+        .join("agent_process");
+    if negative_control {
+        sabotage_npm_bin_shim(&managed_dir, "claude-agent-acp");
+    }
+
+    // Spawned exactly the way `live::sessions::driver::process` spawns a
+    // managed agent: the launcher path as the program, no extra args (the
+    // launcher already bakes the catalog's ACP args), all three handles piped.
+    let mut command = Command::new(&launcher);
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .current_dir(&runtime_home);
+    let child = command.spawn().unwrap_or_else(|error| {
+        panic!(
+            "spawning the managed launcher {} failed: {error} (kind {:?}, raw os error {:?})",
+            launcher.display(),
+            error.kind(),
+            error.raw_os_error()
+        )
+    });
+    println!("spawned pid {}", child.id());
+    let mut peer = AcpPeer::attach(child);
+
+    // ---- Round trip 1: the handshake itself. --------------------------------
+    let first_outcome = peer.request(
+        FIRST_REQUEST_ID,
+        "initialize",
+        initialize_params(),
+        FIRST_RESPONSE_TIMEOUT,
+    );
+    let first = match first_outcome {
+        Ok(value) => value,
+        Err(failure) => {
+            peer.kill();
+            let _ = std::fs::remove_dir_all(&runtime_home);
+            panic!("{failure}");
+        }
+    };
+    assert_well_formed_initialize_response(&first, FIRST_REQUEST_ID);
+
+    // ---- Round trip 2: the stream is still framed. --------------------------
+    // One answered request could in principle be a single flush that happened
+    // to land. A second answered request on the same pipe rules that out and
+    // proves ndjson framing holds across messages through the `.cmd` wrapper.
+    let second_outcome = peer.request(
+        SECOND_REQUEST_ID,
+        "initialize",
+        initialize_params(),
+        SECOND_RESPONSE_TIMEOUT,
+    );
+    let second = match second_outcome {
+        Ok(value) => value,
+        Err(failure) => {
+            peer.kill();
+            let _ = std::fs::remove_dir_all(&runtime_home);
+            panic!("the FIRST handshake succeeded but the second request on the same stream did not: {failure}");
+        }
+    };
+    assert_well_formed_initialize_response(&second, SECOND_REQUEST_ID);
+
+    // ---- Shutdown: still clean after real traffic. --------------------------
+    let (status, stderr) = peer.close_stdin_and_wait(SHUTDOWN_TIMEOUT);
+    println!("--- agent stderr (full)\n{stderr}");
+    println!("--- exit status after stdin close: {status:?}");
+    let _ = std::fs::remove_dir_all(&runtime_home);
+
+    let status = status.unwrap_or_else(|| {
+        panic!(
+            "the managed agent answered the handshake but did not exit within {SHUTDOWN_TIMEOUT:?} \
+             of stdin EOF; it was killed. stderr:\n{stderr}"
+        )
+    });
+    assert!(
+        status.success(),
+        "the managed agent answered the handshake but exited unsuccessfully: {status:?}\nstderr:\n{stderr}"
+    );
+
+    assert!(
+        !negative_control,
+        "NEGATIVE CONTROL DID NOT DISCRIMINATE: {NEGATIVE_CONTROL_ENV}=1 replaced the launcher's \
+         target with a process that never answers, and the handshake still passed. Either the \
+         sabotage did not take effect or the assertions above do not depend on a real response."
+    );
+}
+
+/// The exact `initialize` payload the runtime sends, built from the real
+/// `acp::schema` types rather than a hand-written object, so a schema change
+/// that would break production breaks this too.
+///
+/// The client capabilities mirror
+/// `live::sessions::driver::session_lifecycle::build_client_capabilities` for
+/// `claude` (that function is `pub(in crate::live::sessions)` and unreachable
+/// from an integration test). Notably it advertises no terminal-auth
+/// capability, so the adapter has no auth method to offer back and
+/// `authMethods` comes back empty — which is itself the evidence that
+/// `initialize` completes with no credential in play.
+fn initialize_params() -> serde_json::Value {
+    let claude_meta = serde_json::Map::from_iter([(
+        "claude".to_string(),
+        serde_json::Value::Object(serde_json::Map::from_iter([(
+            "mcpElicitation".to_string(),
+            serde_json::Value::Bool(true),
+        )])),
+    )]);
+    let capabilities =
+        acp::schema::ClientCapabilities::new().meta(acp::schema::Meta::from_iter(claude_meta));
+    let request = acp::schema::InitializeRequest::new(acp::schema::ProtocolVersion::V1)
+        .client_info(acp::schema::Implementation::new("anyharness", "0.1.0"))
+        .client_capabilities(capabilities);
+    serde_json::to_value(request).expect("InitializeRequest must serialize")
+}
+
+/// Every way this response could be hollow is a named failure.
+fn assert_well_formed_initialize_response(response: &serde_json::Value, expected_id: u64) {
+    assert_eq!(
+        response.get("jsonrpc").and_then(serde_json::Value::as_str),
+        Some("2.0"),
+        "response is not JSON-RPC 2.0: {response}"
+    );
+    assert_eq!(
+        response.get("id").and_then(serde_json::Value::as_u64),
+        Some(expected_id),
+        "response id does not match the request: {response}"
+    );
+    assert!(
+        response.get("error").is_none(),
+        "ACP-HANDSHAKE-ERROR-RESPONSE: the agent answered `initialize` with a JSON-RPC error \
+         rather than a result. If this is an auth error then the premise that `initialize` is \
+         credential-free is wrong and must be reported as such. Full response: {response}"
+    );
+    let result = response
+        .get("result")
+        .unwrap_or_else(|| panic!("response has neither `error` nor `result`: {response}"));
+    assert!(
+        result.is_object() && !result.as_object().expect("object").is_empty(),
+        "ACP-HANDSHAKE-EMPTY-RESULT: `initialize` returned an empty result. An empty response is \
+         a failure, not a pass. Full response: {response}"
+    );
+
+    // Raw-JSON assertions first, because the typed model below is deliberately
+    // lenient: `InitializeResponse` deserializes `agentInfo` and `authMethods`
+    // with `DefaultOnError`, so a typed round trip alone would silently accept
+    // a response with a garbage `agentInfo`.
+    assert_eq!(
+        result
+            .get("protocolVersion")
+            .and_then(serde_json::Value::as_u64),
+        Some(1),
+        "the agent did not negotiate ACP protocol version 1: {result}"
+    );
+    let agent_name = result
+        .get("agentInfo")
+        .and_then(|info| info.get("name"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_else(|| panic!("`result.agentInfo.name` is missing or not a string: {result}"));
+    assert!(
+        !agent_name.trim().is_empty(),
+        "`result.agentInfo.name` is blank: {result}"
+    );
+    let capabilities = result
+        .get("agentCapabilities")
+        .unwrap_or_else(|| panic!("`result.agentCapabilities` is missing: {result}"));
+    assert!(
+        capabilities.is_object(),
+        "`result.agentCapabilities` is not an object: {result}"
+    );
+    assert!(
+        result
+            .get("authMethods")
+            .map(serde_json::Value::is_array)
+            .unwrap_or(false),
+        "`result.authMethods` is missing or not an array: {result}"
+    );
+
+    // And now the same bytes through the type the runtime actually decodes
+    // into. If this fails, production would have failed on the same response.
+    let typed: acp::schema::InitializeResponse = serde_json::from_value(result.clone())
+        .unwrap_or_else(|error| {
+            panic!(
+                "the response does not deserialize into the runtime's own \
+                 `acp::schema::InitializeResponse`: {error}. Full result: {result}"
+            )
+        });
+    assert_eq!(
+        typed.protocol_version,
+        acp::schema::ProtocolVersion::V1,
+        "typed protocol version mismatch: {result}"
+    );
+    let typed_info = typed
+        .agent_info
+        .unwrap_or_else(|| panic!("typed `agent_info` decoded to None: {result}"));
+    println!(
+        "handshake OK: agent {:?} version {:?}, {} auth method(s) advertised",
+        typed_info.name,
+        typed_info.version,
+        typed.auth_methods.len()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// In-suite discriminators. These run on every run, on both operating systems.
+// ---------------------------------------------------------------------------
+
+/// A process that spawns, holds stdin open and never writes must produce
+/// `ACP-HANDSHAKE-TIMEOUT`. If this test ever passes by returning `Ok`, the
+/// green result of the handshake test above means nothing.
+#[test]
+fn the_handshake_timeout_is_a_loud_failure_not_a_pass() {
+    let mut peer = AcpPeer::attach(spawn_node(
+        "silent",
+        // Holds the stdin handle open forever; writes nothing, ever.
+        "process.stdin.resume();",
+    ));
+    let started = Instant::now();
+    let outcome = peer.request(
+        FIRST_REQUEST_ID,
+        "initialize",
+        initialize_params(),
+        DISCRIMINATOR_TIMEOUT,
+    );
+    let elapsed = started.elapsed();
+    peer.kill();
+
+    match outcome {
+        Ok(value) => panic!(
+            "a process that never writes anything produced a handshake response: {value}. The \
+             reader is not reading what it claims to read."
+        ),
+        Err(failure) => {
+            let rendered = failure.to_string();
+            println!("discriminator produced: {rendered}");
+            assert!(
+                matches!(failure, HandshakeFailure::Timeout { .. }),
+                "expected a timeout against a silent process, got: {rendered}"
+            );
+            assert!(
+                rendered.contains("ACP-HANDSHAKE-TIMEOUT"),
+                "the timeout failure does not carry its marker: {rendered}"
+            );
+            assert!(
+                elapsed >= DISCRIMINATOR_TIMEOUT,
+                "the timeout fired after {elapsed:?}, before its {DISCRIMINATOR_TIMEOUT:?} bound; \
+                 the deadline is not being honoured"
+            );
+            assert!(
+                elapsed < DISCRIMINATOR_TIMEOUT * 4,
+                "the timeout took {elapsed:?} against a {DISCRIMINATOR_TIMEOUT:?} bound; the read \
+                 is not actually bounded"
+            );
+        }
+    }
+}
+
+/// A process that answers nothing and exits immediately — which is precisely
+/// what run 32450488248 observed and what this whole test file exists to stop
+/// counting as success — must produce `ACP-HANDSHAKE-EOF`.
+#[test]
+fn an_immediate_exit_is_a_loud_failure_not_a_pass() {
+    let mut peer = AcpPeer::attach(spawn_node("immediate-exit", "process.exit(0);"));
+    let outcome = peer.request(
+        FIRST_REQUEST_ID,
+        "initialize",
+        initialize_params(),
+        DISCRIMINATOR_TIMEOUT,
+    );
+    peer.kill();
+
+    match outcome {
+        Ok(value) => panic!(
+            "a process that exits immediately produced a handshake response: {value}. The reader \
+             is not reading what it claims to read."
+        ),
+        Err(failure) => {
+            let rendered = failure.to_string();
+            println!("discriminator produced: {rendered}");
+            // An immediate `process.exit(0)` can lose the race against our
+            // write, in which case the failure surfaces as a broken pipe on
+            // the write rather than as EOF on the read. Both are correct and
+            // both are loud; what must never happen is a pass.
+            assert!(
+                matches!(
+                    failure,
+                    HandshakeFailure::Eof { .. } | HandshakeFailure::WriteFailed { .. }
+                ),
+                "expected EOF or a failed write against a process that exits immediately, got: {rendered}"
+            );
+            assert!(
+                rendered.contains("ACP-HANDSHAKE-EOF")
+                    || rendered.contains("ACP-HANDSHAKE-WRITE-FAILED"),
+                "the failure does not carry a marker: {rendered}"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers.
+// ---------------------------------------------------------------------------
+
+fn negative_control_requested() -> bool {
+    matches!(
+        std::env::var(NEGATIVE_CONTROL_ENV).as_deref(),
+        Ok("1") | Ok("true")
+    )
+}
+
+/// Replace the npm `.bin` shim the emitted launcher invokes with a program that
+/// starts, holds stdin and never answers. The launcher itself, the installer
+/// output around it, and the spawn are all left exactly as the real code
+/// produced them.
+fn sabotage_npm_bin_shim(managed_dir: &Path, executable_name: &str) {
+    let bin_dir = managed_dir.join("node_modules").join(".bin");
+    let mut replaced = Vec::new();
+
+    if cfg!(windows) {
+        let shim = bin_dir.join(format!("{executable_name}.cmd"));
+        std::fs::write(&shim, "@echo off\r\nnode -e \"process.stdin.resume()\"\r\n")
+            .unwrap_or_else(|error| panic!("could not sabotage {}: {error}", shim.display()));
+        replaced.push(shim);
+    } else {
+        let shim = bin_dir.join(executable_name);
+        std::fs::write(&shim, "#!/bin/sh\nexec node -e 'process.stdin.resume()'\n")
+            .unwrap_or_else(|error| panic!("could not sabotage {}: {error}", shim.display()));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755))
+                .expect("chmod the sabotaged shim");
+        }
+        replaced.push(shim);
+    }
+
+    for shim in &replaced {
+        println!(
+            "negative control: replaced {} with a silent stub",
+            shim.display()
+        );
+    }
+    assert!(
+        !replaced.is_empty(),
+        "the negative control was requested but nothing was replaced"
+    );
+}
+
+fn scratch_runtime_home(label: &str) -> PathBuf {
+    let unique = format!(
+        "anyharness-acp-handshake-{label}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    );
+    let path = std::env::temp_dir().join(unique);
+    std::fs::create_dir_all(&path).expect("create scratch runtime home");
+    path
+}


### PR DESCRIPTION
## What is now proven that was not before

A managed `claude` agent, installed by the real pinned installer and launched through the emitted Windows `claude-launcher.cmd`, **completes a real ACP `initialize` handshake over stdio on a real `windows-latest` runner**, twice on the same pipe, and then exits cleanly. No credential of any kind is involved.

Before this, the furthest anything had gone on Windows was spawn plus clean exit.

## Why that was not already proven

Run [32450488248](https://github.com/proliferate-ai/proliferate/actions/runs/32450488248) proved the layer underneath: the installer downloads and sha256-verifies a 324 MB `claude.exe`, runs a real `npm install` of the git-pinned adapter, emits `claude-launcher.cmd`, and `CreateProcess` spawns it. Its literal verdict for claude was:

```
--- launcher stdout

--- launcher stderr

--- launcher status: Some(ExitStatus(ExitStatus(0))) (still_running=false)
```

Nothing was ever written to that launcher's stdin and nothing was ever read back. Exit 0 with empty stdout and empty stderr establishes only "the process starts and exits cleanly on EOF"; a `.cmd` containing nothing but `@echo off` produces exactly that. Whether the batch wrapper forwards its stdio handles to the grandchild node process, whether cmd.exe injects anything into the stream, and whether newline-delimited JSON survives a Windows pipe in both directions were all untested.

## The evidence, literal

Passing run: [32454309124](https://github.com/proliferate-ai/proliferate/actions/runs/32454309124), both legs green, `acp initialize (ubuntu-latest)=success, acp initialize (windows-latest)=success`.

From `acp initialize (windows-latest)`, the launcher the real installer emitted:

```
installed role=NativeCli source=pinned_binary version=Some("2.1.234") path=C:\Users\RUNNER~1\AppData\Local\Temp\anyharness-acp-handshake-handshake-4320-1787293798899735000\agents\claude\native\claude.exe
installed role=AgentProcess source=pinned_git version=Some("65f6205329daea4a521ee0f0c042722b0feb306a") path=C:\Users\RUNNER~1\AppData\Local\Temp\anyharness-acp-handshake-handshake-4320-1787293798899735000\agents\claude\agent_process\claude-launcher.cmd
@echo off
set "PATH=C:\Users\RUNNER~1\AppData\Local\Temp\anyharness-acp-handshake-handshake-4320-1787293798899735000\agents\claude\native;%PATH%"
set "DISABLE_AUTOUPDATER=1"
"C:\Users\RUNNER~1\AppData\Local\Temp\anyharness-acp-handshake-handshake-4320-1787293798899735000\agents\claude\agent_process\node_modules/.bin/claude-agent-acp.cmd" %*
exit /b %ERRORLEVEL%
```

The request that went into that launcher's stdin:

```
--> {"id":4242,"jsonrpc":"2.0","method":"initialize","params":{"clientCapabilities":{"_meta":{"claude":{"mcpElicitation":true}},"auth":{"terminal":false},"fs":{"readTextFile":false,"writeTextFile":false},"terminal":false},"clientInfo":{"name":"anyharness","version":"0.1.0"},"protocolVersion":1}}
```

And what came back out of it:

```
<-- {"jsonrpc":"2.0","id":4242,"result":{"protocolVersion":1,"agentCapabilities":{"_meta":{"claudeCode":{"promptQueueing":true}},"promptCapabilities":{"image":true,"embeddedContext":true},"mcpCapabilities":{"http":true,"sse":true},"auth":{"logout":{}},"providers":{},"loadSession":true,"sessionCapabilities":{"additionalDirectories":{},"close":{},"delete":{},"fork":{},"list":{},"resume":{}}},"agentInfo":{"name":"@proliferate/claude-agent-acp","title":"Claude Agent","version":"0.66.0-proliferate.2"},"authMethods":[],"_meta":{"steering":{"supported":true},"goal":{"version":1,"controlMethod":"_session/goal","actions":["set","clear"]},"anyharness":{"fork":{"version":1,"anchor":"upToMessageId"},"rewindFiles":{"version":1,"controlMethod":"_anyharness/rewindFiles","scope":"writeEditNotebookEdit","requiresCheckpointingOptIn":true},"activity":{"version":1,"listMethod":"_anyharness/activity/list"}}}}}
response to `initialize` (id 4242) arrived after 443.5497ms
handshake OK: agent "@proliferate/claude-agent-acp" version "0.66.0-proliferate.2", 0 auth method(s) advertised
```

Second request on the same pipe, which is what rules out a one-shot flush and shows ndjson framing holds across messages through the `.cmd` wrapper:

```
response to `initialize` (id 4243) arrived after 1.1066ms
handshake OK: agent "@proliferate/claude-agent-acp" version "0.66.0-proliferate.2", 0 auth method(s) advertised
--- exit status after stdin close: Some(ExitStatus(ExitStatus(0)))
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 333.53s
```

Note `"authMethods":[]`. The handshake completed with the agent advertising no authentication method, which is the direct observation that `initialize` needs no credential.

The `acp initialize (ubuntu-latest)` control leg produced the same handshake against the same code path and reported `test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 86.57s`, so a green Windows leg cannot be blamed on the test being unix-specific, and a red one could not have been blamed on the test.

## Negative control, both directions

**In-suite, on every run, on both operating systems.** The same reader is driven against a process that never answers and a process that exits without answering, and both must fail. From the passing Windows leg:

```
discriminator produced: ACP-HANDSHAKE-EOF: stdout closed before any JSON-RPC response to `initialize` arrived. The process exited or dropped the stream instead of answering. An empty response is a failure, not a pass.
discriminator produced: ACP-HANDSHAKE-TIMEOUT: no JSON-RPC response to `initialize` arrived on stdout within 15.0116037s. The process was spawned and accepted the request but never answered it. This is a failure, not a skip.
```

The EOF case is not hypothetical. It is precisely the behaviour run 32450488248 observed and counted as success.

**The real path, deliberately broken.** Run [32454334149](https://github.com/proliferate-ai/proliferate/actions/runs/32454334149) is the identical test with `ACP_HANDSHAKE_NEGATIVE_CONTROL=1`, which replaces the npm bin shim the emitted launcher invokes with a program that starts, holds stdin and never answers. The launcher, the install, the spawn and the assertions are untouched. Both legs went red for exactly the intended reason.

`acp initialize (windows-latest)`:

```
!!! NEGATIVE CONTROL ENGAGED (ACP_HANDSHAKE_NEGATIVE_CONTROL=1): the npm bin shim the emitted launcher invokes will be replaced with a process that starts, holds stdin and never answers. This run MUST fail with ACP-HANDSHAKE-TIMEOUT.
negative control: replaced C:\Users\RUNNER~1\AppData\Local\Temp\anyharness-acp-handshake-handshake-6508-1787293847094123400\agents\claude\agent_process\node_modules\.bin\claude-agent-acp.cmd with a silent stub
thread 'the_managed_claude_launcher_answers_a_real_acp_initialize_handshake' (7276) panicked at anyharness\crates\anyharness-lib\tests\windows_acp_handshake.rs:234:13:
ACP-HANDSHAKE-TIMEOUT: no JSON-RPC response to `initialize` arrived on stdout within 180.0010135s. The process was spawned and accepted the request but never answered it. This is a failure, not a skip.
test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 533.62s
```

`acp initialize (ubuntu-latest)`:

```
negative control: replaced /tmp/anyharness-acp-handshake-handshake-6369-1787293691053863990/agents/claude/agent_process/node_modules/.bin/claude-agent-acp with a silent stub
thread 'the_managed_claude_launcher_answers_a_real_acp_initialize_handshake' (6392) panicked at anyharness/crates/anyharness-lib/tests/windows_acp_handshake.rs:234:13:
ACP-HANDSHAKE-TIMEOUT: no JSON-RPC response to `initialize` arrived on stdout within 180.000100931s. The process was spawned and accepted the request but never answered it. This is a failure, not a skip.
test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 257.79s
```

Note that the two in-suite discriminators still passed in the sabotaged run (`2 passed; 1 failed`), so the failure is attributable to the sabotage and not to a broken harness.

That control lives on [#2166](https://github.com/proliferate-ai/proliferate/pull/2166), a throwaway branch that exists only to produce the failing half of this proof and is not for merge.

## What the test does

```mermaid
flowchart TD
  A[bundled catalog and registry] --> B[install_agent_with_pins]
  B --> C[claude.exe, sha256 verified]
  B --> D[npm install of the git-pinned adapter]
  D --> E[emitted claude-launcher.cmd]
  E --> F[spawn with all three handles piped]
  F --> G[write initialize as ndjson to stdin]
  G --> H[read and validate the JSON-RPC response]
  H --> I[write a second initialize on the same pipe]
  I --> J[read and validate again]
  J --> K[close stdin, require a clean exit]
```

Validation of each response is done twice over: on the raw JSON (`jsonrpc`, matching `id`, no `error` member, non-empty `result`, `protocolVersion == 1`, a non-blank `result.agentInfo.name`, an object `agentCapabilities`, an array `authMethods`) and then again by deserializing into the runtime's own `acp::schema::InitializeResponse`. The raw pass comes first on purpose: that type deserializes `agentInfo` and `authMethods` with `DefaultOnError`, so a typed round trip alone would silently accept a garbage `agentInfo`.

## Which agent, and why

`claude`. It is the default agent, it is the one that has to work for a Windows beta, and it is the only agent that can answer this question today.

- `cursor` and `opencode` pin their agent process as a platform archive whose `targets` map contains only `macos_arm64`, `macos_x64` and `linux_x64`. There is no `windows_*` target, so `installer/pinned.rs` raises `NoPinForPlatform` before anything is installed.
- `codex` does have `windows_x64` and `windows_arm64` native pins, but they point at `codex-x86_64-pc-windows-msvc.exe.tar.gz`, a tarball extraction branch nothing has executed on Windows. A red result there would be ambiguous between the extraction branch and the handshake.
- `grok` installs and spawns on Windows (proved in run 32450488248) but its ACP surface is a different adapter and it is not the default.

## Credentials: verified, not assumed

No API key is used, needed, added as a secret, or written to any file, PR or log. That was checked on both sides of the wire before the test was written.

Client side, `live/sessions/driver/session_lifecycle.rs::initialize_connection` sends `initialize` first and only then inspects the response's `auth_methods` to decide whether to call `authenticate`. Authentication is strictly downstream of the handshake.

Agent side, the pinned adapter was read at the exact sha the catalog installs, `proliferate-ai/claude-agent-acp@65f6205329daea4a521ee0f0c042722b0feb306a`. `ClaudeAcpAgent.initialize` in `src/acp-agent.ts` reads `request.clientCapabilities` and a handful of `process.env` remote hints, then returns a literal response object; it opens no credential file and makes no network call. `src/index.ts`'s startup path is likewise credential-free.

The client capabilities the test sends mirror what the runtime sends for claude, which advertise no terminal-auth capability, so the adapter has no auth method to offer back. The test therefore asserts `authMethods` is an array and deliberately does not assert it is non-empty. The observed `"authMethods":[]` above is the confirmation.

## Where the test lives, and hangs and skips

`anyharness/crates/anyharness-lib/tests/windows_acp_handshake.rs`, an integration test target, with its stdio peer in `tests/acp_stdio/mod.rs` (a subdirectory, so cargo does not pick it up as a second test target). The prior lane recorded that the crate's `--lib` test target does not build on Windows because of ten pre-existing test-only POSIX assumptions; I did not re-verify that count. What I did verify is that the integration-test shape compiles and runs on `windows-latest`, in run 32450488248 and again here.

Every read is bounded by a deadline, and the job carries `timeout-minutes: 45` as a second bound. There is no skip path in the file. A missing catalog pin, a missing registry descriptor, a failed install, a missing launcher, a failed spawn and a missing node each panic with their own message. The five hollow-result modes each have a distinct marker: `ACP-HANDSHAKE-TIMEOUT`, `ACP-HANDSHAKE-EOF`, `ACP-HANDSHAKE-WRITE-FAILED`, `ACP-HANDSHAKE-ERROR-RESPONSE` (whose message says plainly that if the error is an auth error then the credential-free premise is wrong and must be reported as such), and `ACP-HANDSHAKE-EMPTY-RESULT`.

## How to read the checks

`Windows compile check` sets `continue-on-error: true` on both of its jobs, so its green is unconditional and means nothing. `ci-ok`'s `needs:` list covers only `ci.yml` jobs, so a Windows workflow sits outside that rollup gate. Read `Windows managed-agent ACP handshake` directly.

## One inherited red, not mine

`Repo shape checks` and therefore `ci-ok` are red on this PR. They are red for `anyharness/crates/anyharness-lib/src/domains/agents/installer/npm.rs: PROD-SIZE-1 ... found: 628 lines (max 600)`, a file this PR does not touch. The same two checks are already red on the base branch #2153 for the same reason ([run 32450488265](https://github.com/proliferate-ai/proliferate/actions/runs/32450488265)). This PR's diff is three added files and nothing else, and both of its Rust files pass `scripts/check_max_lines.py`.

## Base branch, and why this is not mergeable as-is

This targets `ci/windows-managed-agent-e2e` ([#2153](https://github.com/proliferate-ai/proliferate/pull/2153)), the combination branch that composes [#2149](https://github.com/proliferate-ai/proliferate/pull/2149) and [#2152](https://github.com/proliferate-ai/proliferate/pull/2152) and is itself explicitly marked not for merge. Those two carry the production fixes this test depends on: without #2149 there are no Windows pins for claude, without #2152 there is no `.cmd` launcher to speak to. This PR is a proof, not a merge candidate; the test and the workflow should ride along with whichever branch eventually lands those fixes.

## Still unproven

- **A full prompt round trip.** `session/new` and `session/prompt` need a real Anthropic credential and a model call. Nothing here says a Windows user can get a completion.
- **`authenticate` on Windows.** Not exercised. The capabilities sent advertise no auth method, so the adapter offered none.
- **Every other agent on Windows.** `cursor` and `opencode` have no `windows_*` target in their agent-process pins at all. `codex` has native Windows pins but its `.exe.tar.gz` extraction path has never run on Windows. `grok` installs and spawns but its ACP handshake is untested.
- **Windows ARM64.** Only `x86_64-pc-windows-msvc` is exercised, even though `windows_arm64` pins exist for both claude and codex.
- **Everything above the runtime.** The desktop shell, the updater, process-tree kill under real load, and long-lived session behaviour are all out of scope here.
