### PR TITLE
test(anyharness): NEGATIVE CONTROL for #2165, do not merge

### DIFF
--- a/.github/workflows/windows-acp-handshake.yml
+++ b/.github/workflows/windows-acp-handshake.yml
@@ -85,7 +85,8 @@ jobs:
         # That transcript IS the finding.
         env:
           RUST_BACKTRACE: "1"
-          ACP_HANDSHAKE_NEGATIVE_CONTROL: ${{ inputs.negative_control && '1' || '0' }}
+          # TEMPORARY, THIS BRANCH ONLY: forced on so the run goes red on purpose.
+          ACP_HANDSHAKE_NEGATIVE_CONTROL: "1"
         run: >
           cargo test --target ${{ matrix.target }}
           -p anyharness-lib --test windows_acp_handshake


### PR DESCRIPTION
Throwaway proof branch for #2165, to be closed as soon as its logs are quoted there.

Forces `ACP_HANDSHAKE_NEGATIVE_CONTROL=1` in the workflow. The real handshake test still does the real install and still spawns the real emitted launcher; the only change is that the npm bin shim the launcher invokes is replaced with a program that starts, holds stdin and never answers. Both legs must go red with `ACP-HANDSHAKE-TIMEOUT`.

If this were to go green, #2165's green would mean nothing.