### PR TITLE
fix(release): publish windows desktop artifacts in the installer and updater manifests

### DIFF
--- a/scripts/ci-cd/generate-desktop-installer-manifest.test.mjs
+++ b/scripts/ci-cd/generate-desktop-installer-manifest.test.mjs
@@ -9,19 +9,34 @@ import { fileURLToPath } from "node:url";
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const generator = path.join(repoRoot, "scripts/generate-desktop-installer-manifest.mjs");
 
+const WINDOWS_DIR = "desktop-x86_64-pc-windows-msvc";
+
 // download-artifact@v8 nests each artifact in a directory named after it only
 // when two or more artifacts match the download pattern; a single match
 // extracts flat, and merge-multiple: true (the release-desktop.yml publish
-// jobs) merges flat regardless of count. `flat` reproduces those layouts.
+// jobs) merges flat regardless of count. `flat` reproduces those layouts, and
+// applies to the Windows fixture too since the publish jobs merge every
+// artifact, Windows included, into one flat directory.
 // Intel (x86_64) desktop builds are paused 2026-08-20 (release-desktop.yml
 // build-desktop matrix); `armOnly` simulates that paused lane producing no
-// x86_64 installer.
-function writeInstallers(root, { armOnly = false, flat = false } = {}) {
+// x86_64 installer. `windows`/`omitDarwinAarch64` simulate the Windows beta
+// leg (release.yml's enable_windows_beta, defaulted false) producing an
+// installer, and a genuinely broken required mac build respectively.
+function writeInstallers(
+  root,
+  { armOnly = false, flat = false, windows = false, omitDarwinAarch64 = false } = {},
+) {
   const artifacts = path.join(root, "artifacts");
   const fixtures = [
     ["desktop-aarch64-apple-darwin", "Proliferate_aarch64.dmg"],
     ["desktop-x86_64-apple-darwin", "Proliferate_x64.dmg"],
-  ].filter(([directory]) => !armOnly || directory === "desktop-aarch64-apple-darwin");
+  ]
+    .filter(([directory]) => !armOnly || directory === "desktop-aarch64-apple-darwin")
+    .filter(([directory]) => !omitDarwinAarch64 || directory !== "desktop-aarch64-apple-darwin");
+
+  if (windows) {
+    fixtures.push([WINDOWS_DIR, "Proliferate_1.2.3_x64-setup.exe"]);
+  }
 
   for (const [directory, installer] of fixtures) {
     const target = flat ? artifacts : path.join(artifacts, directory);
@@ -32,7 +47,7 @@ function writeInstallers(root, { armOnly = false, flat = false } = {}) {
   return artifacts;
 }
 
-function generateManifest(t, { armOnly = false, flat = false, empty = false } = {}) {
+function generateManifest(t, { empty = false, ...installerOptions } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "proliferate-installer-manifest-"));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
   const output = path.join(root, "installers.json");
@@ -42,7 +57,7 @@ function generateManifest(t, { armOnly = false, flat = false, empty = false } = 
         fs.mkdirSync(dir, { recursive: true });
         return dir;
       })()
-    : writeInstallers(root, { armOnly, flat });
+    : writeInstallers(root, installerOptions);
 
   const result = spawnSync(
     process.execPath,
@@ -97,6 +112,72 @@ test("generates both downloads from a merged flat layout", (t) => {
 
 test("fails when the required darwin-aarch64 installer is missing", (t) => {
   const { output, result } = generateManifest(t, { empty: true });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Missing installer file for darwin-aarch64/);
+  assert.equal(fs.existsSync(output), false);
+});
+
+test("generates an arm-only manifest while Intel is paused", (t) => {
+  const { output, result } = generateManifest(t, { armOnly: true });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stderr, /Skipping darwin-x86_64: no installer found \(optional platform\)\./);
+  const manifest = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.deepEqual(Object.keys(manifest.downloads), ["darwin-aarch64"]);
+});
+
+test("mac-only artifacts still produce a valid manifest with no windows entry (regression: Windows must never be required)", (t) => {
+  const { output, result } = generateManifest(t, { windows: false });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stderr, /Skipping windows-x86_64: no installer found \(optional platform\)\./);
+  const manifest = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.deepEqual(Object.keys(manifest.downloads).sort(), ["darwin-aarch64", "darwin-x86_64"]);
+});
+
+test("mac+windows artifacts produce all three download entries with the windows URL", (t) => {
+  const { output, result } = generateManifest(t, { windows: true });
+
+  assert.equal(result.status, 0, result.stderr);
+  const manifest = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.deepEqual(Object.keys(manifest.downloads).sort(), [
+    "darwin-aarch64",
+    "darwin-x86_64",
+    "windows-x86_64",
+  ]);
+  assert.equal(
+    manifest.downloads["windows-x86_64"].url,
+    "https://downloads.proliferate.com/desktop/stable/Proliferate_1.2.3_x64-setup.exe",
+  );
+});
+
+test("mac+windows downloads resolve from the merged flat layout the publish jobs produce", (t) => {
+  // release-desktop.yml's publish jobs download with merge-multiple: true, so
+  // the Windows setup.exe lands in the same flat directory as the darwin
+  // dmgs. Only the "-setup.exe" filename suffix separates windows-x86_64 from
+  // darwin-x86_64 here; there is no directory segment left to lean on.
+  const { output, result } = generateManifest(t, { windows: true, flat: true });
+
+  assert.equal(result.status, 0, result.stderr);
+  const manifest = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.deepEqual(Object.keys(manifest.downloads).sort(), [
+    "darwin-aarch64",
+    "darwin-x86_64",
+    "windows-x86_64",
+  ]);
+  assert.equal(
+    manifest.downloads["windows-x86_64"].url,
+    "https://downloads.proliferate.com/desktop/stable/Proliferate_1.2.3_x64-setup.exe",
+  );
+  assert.equal(
+    manifest.downloads["darwin-x86_64"].url,
+    "https://downloads.proliferate.com/desktop/stable/Proliferate_x64.dmg",
+  );
+});
+
+test("a required darwin platform missing its installer is still fatal even when windows is present", (t) => {
+  const { output, result } = generateManifest(t, { windows: true, omitDarwinAarch64: true });
 
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /Missing installer file for darwin-aarch64/);

--- a/scripts/ci-cd/generate-updater-manifest.test.mjs
+++ b/scripts/ci-cd/generate-updater-manifest.test.mjs
@@ -9,31 +9,54 @@ import { fileURLToPath } from "node:url";
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const generator = path.join(repoRoot, "scripts/generate-updater-manifest.mjs");
 
+const WINDOWS_DIR = "desktop-x86_64-pc-windows-msvc";
+
 // Intel (x86_64) desktop builds are paused 2026-08-20 (release-desktop.yml
 // build-desktop matrix); `armOnly` simulates that paused build producing no
-// x86_64 artifacts.
+// x86_64 artifacts. `windows`/`omitWindowsSig`/`omitDarwinAarch64` simulate
+// the Windows beta leg (release.yml's enable_windows_beta, defaulted false)
+// producing artifacts, a broken partial publish, and a genuinely broken
+// mac build respectively.
 // download-artifact@v8 nests each artifact in a directory named after it only
 // when two or more artifacts match the download pattern; a single match
 // extracts flat, and merge-multiple: true (the release-desktop.yml publish
-// jobs) merges flat regardless of count. `flat` reproduces those layouts.
-function writeArtifacts(root, { armOnly = false, flat = false } = {}) {
+// jobs) merges flat regardless of count. `flat` reproduces those layouts, and
+// applies to the Windows fixture too since the publish jobs merge every
+// artifact, Windows included, into one flat directory.
+function writeArtifacts(
+  root,
+  {
+    armOnly = false,
+    flat = false,
+    windows = false,
+    omitWindowsSig = false,
+    omitDarwinAarch64 = false,
+  } = {},
+) {
   const artifacts = path.join(root, "artifacts");
   const fixtures = [
     ["desktop-aarch64-apple-darwin", "Proliferate_aarch64.app.tar.gz"],
     ["desktop-x86_64-apple-darwin", "Proliferate_x64.app.tar.gz"],
-  ].filter(([directory]) => !armOnly || directory === "desktop-aarch64-apple-darwin");
+  ]
+    .filter(([directory]) => !armOnly || directory === "desktop-aarch64-apple-darwin")
+    .filter(([directory]) => !omitDarwinAarch64 || directory !== "desktop-aarch64-apple-darwin");
+
+  if (windows) {
+    fixtures.push([WINDOWS_DIR, "Proliferate_1.2.3_x64-setup.exe"]);
+  }
 
   for (const [directory, artifact] of fixtures) {
     const target = flat ? artifacts : path.join(artifacts, directory);
     fs.mkdirSync(target, { recursive: true });
     fs.writeFileSync(path.join(target, artifact), "archive");
+    if (directory === WINDOWS_DIR && omitWindowsSig) continue;
     fs.writeFileSync(path.join(target, `${artifact}.sig`), `signature-${directory}\n`);
   }
 
   return artifacts;
 }
 
-function generateManifest(t, notes, { armOnly = false, flat = false } = {}) {
+function generateManifest(t, notes, artifactOptions) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "proliferate-updater-manifest-"));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
   const output = path.join(root, "latest.json");
@@ -42,7 +65,7 @@ function generateManifest(t, notes, { armOnly = false, flat = false } = {}) {
     "--version",
     "1.2.3",
     "--artifacts-dir",
-    writeArtifacts(root, { armOnly, flat }),
+    writeArtifacts(root, artifactOptions),
     "--base-url",
     "https://downloads.proliferate.com/desktop/stable",
     "--output",
@@ -144,4 +167,71 @@ test("rejects multiline, control-character, and overlong release titles", (t) =>
     assert.match(result.stderr, expectedError);
     assert.equal(fs.existsSync(output), false);
   }
+});
+
+test("mac-only artifacts still produce a valid manifest with no windows entry (regression: Windows must never be required)", (t) => {
+  const { output, result } = generateManifest(t, undefined, { windows: false });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stderr, /Skipping windows-x86_64: no artifacts found \(optional platform\)\./);
+  const manifest = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.deepEqual(Object.keys(manifest.platforms).sort(), ["darwin-aarch64", "darwin-x86_64"]);
+});
+
+test("mac+windows artifacts produce all three platform entries with the windows URL and signature", (t) => {
+  const { output, result } = generateManifest(t, undefined, { windows: true });
+
+  assert.equal(result.status, 0, result.stderr);
+  const manifest = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.deepEqual(Object.keys(manifest.platforms).sort(), [
+    "darwin-aarch64",
+    "darwin-x86_64",
+    "windows-x86_64",
+  ]);
+  assert.equal(
+    manifest.platforms["windows-x86_64"].url,
+    "https://downloads.proliferate.com/desktop/stable/Proliferate_1.2.3_x64-setup.exe",
+  );
+  assert.equal(manifest.platforms["windows-x86_64"].signature, `signature-${WINDOWS_DIR}`);
+});
+
+test("mac+windows artifacts resolve from the merged flat layout the publish jobs produce", (t) => {
+  // release-desktop.yml's publish jobs download with merge-multiple: true, so
+  // the Windows setup.exe lands in the same flat directory as the darwin
+  // tarballs. Only the "-setup.exe" filename suffix separates windows-x86_64
+  // from darwin-x86_64 here; there is no directory segment left to lean on.
+  const { output, result } = generateManifest(t, undefined, { windows: true, flat: true });
+
+  assert.equal(result.status, 0, result.stderr);
+  const manifest = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.deepEqual(Object.keys(manifest.platforms).sort(), [
+    "darwin-aarch64",
+    "darwin-x86_64",
+    "windows-x86_64",
+  ]);
+  assert.equal(
+    manifest.platforms["windows-x86_64"].url,
+    "https://downloads.proliferate.com/desktop/stable/Proliferate_1.2.3_x64-setup.exe",
+  );
+  assert.equal(
+    manifest.platforms["darwin-x86_64"].url,
+    "https://downloads.proliferate.com/desktop/stable/Proliferate_x64.app.tar.gz",
+  );
+});
+
+test("a windows artifact present without its .sig is a fatal error, never a silent skip", (t) => {
+  const { output, result } = generateManifest(t, undefined, { windows: true, omitWindowsSig: true });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Missing signature file for windows-x86_64/);
+  assert.equal(fs.existsSync(output), false);
+});
+
+test("a required darwin platform missing artifacts is still fatal even when windows is present", (t) => {
+  const { output, result } = generateManifest(t, undefined, { windows: true, omitDarwinAarch64: true });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Missing signature file for darwin-aarch64/);
+  assert.match(result.stderr, /Missing artifact file for darwin-aarch64/);
+  assert.equal(fs.existsSync(output), false);
 });

--- a/scripts/generate-desktop-installer-manifest.mjs
+++ b/scripts/generate-desktop-installer-manifest.mjs
@@ -55,6 +55,22 @@ const downloads = [
     matcher: (relPath, name) =>
       /(x64|x86_64).*\.dmg$/i.test(name),
   },
+  {
+    key: "windows-x86_64",
+    // The NSIS setup.exe is the canonical Windows download, not the MSI:
+    // release-desktop.yml's publish-updater job only copies "*-setup.exe"
+    // (not "*.msi") to the downloads bucket this manifest's --base-url
+    // points at, and it is the artifact the Tauri updater expects for a
+    // "windows-x86_64" platform entry. The "-setup.exe" suffix is what
+    // separates this download from darwin-x86_64 under the filename-only
+    // matching above; no directory segment is required, so a flat extraction
+    // resolves it just as well as a nested one.
+    // Optional: the Windows leg is an opt-in beta gated behind release.yml's
+    // enable_windows_beta input (defaulted false), so a missing or failed
+    // Windows build must never fail a mac-only release.
+    optional: true,
+    matcher: (relPath, name) => /(x64|x86_64).*-setup\.exe$/i.test(name),
+  },
 ];
 
 const manifest = {

--- a/scripts/generate-updater-manifest.mjs
+++ b/scripts/generate-updater-manifest.mjs
@@ -96,6 +96,26 @@ const platforms = [
     sigMatcher: (relPath, name) =>
       /(x64|x86_64).*\.app\.tar\.gz\.sig$/i.test(name),
   },
+  {
+    key: "windows-x86_64",
+    // "windows-x86_64" is the exact platform key Tauri v2's updater expects
+    // for this target: it follows the same <os>-<arch> shape as the darwin-*
+    // keys above, and apps/desktop/src-tauri/tauri.conf.json already carries
+    // an updater.windows block for this same build. The artifact matched
+    // here is the NSIS setup.exe, not the MSI: it is what Tauri's updater
+    // downloads and verifies, and per release-desktop.yml's publish-updater
+    // job only "*-setup.exe"/"*-setup.exe.sig" (not "*.msi") are copied to
+    // the downloads bucket this manifest's --base-url points at. The
+    // "-setup.exe" suffix is what separates this platform from darwin-x86_64
+    // under the filename-only matching above; no directory segment is
+    // required, so a flat extraction resolves it just as well as a nested one.
+    // Optional: the Windows leg is an opt-in beta gated behind release.yml's
+    // enable_windows_beta input (defaulted false), so a missing or failed
+    // Windows build must never fail a mac-only release.
+    optional: true,
+    artifactMatcher: (relPath, name) => /(x64|x86_64).*-setup\.exe$/i.test(name),
+    sigMatcher: (relPath, name) => /(x64|x86_64).*-setup\.exe\.sig$/i.test(name),
+  },
 ];
 
 const manifest = {
@@ -112,7 +132,11 @@ for (const platform of platforms) {
   const artifactFiles = findFiles(artifactsDir, platform.artifactMatcher);
 
   if (sigFiles.length === 0 || artifactFiles.length === 0) {
-    if (platform.optional) {
+    // Only a fully absent optional platform is a silent skip. A platform
+    // with just one of the two present is never skipped, optional or not: a
+    // signed updater feed must never carry an unsigned entry, and a
+    // signature with no matching artifact is equally a broken publish.
+    if (platform.optional && sigFiles.length === 0 && artifactFiles.length === 0) {
       console.warn(`Skipping ${platform.key}: no artifacts found (optional platform).`);
       continue;
     }


### PR DESCRIPTION
## What was missing

`scripts/generate-desktop-installer-manifest.mjs` and `scripts/generate-updater-manifest.mjs` only matched `darwin-aarch64` / `darwin-x86_64`. The Windows beta build stack (open PRs #2147, #2148, #2149, #2150, #2152, #2157) makes the desktop app build, package, and install on Windows, and run https://github.com/proliferate-ai/proliferate/actions/runs/32447570745 proved `tauri build` on `windows-latest` produces `Proliferate_0.4.21_x64_en-US.msi` and `Proliferate_0.4.21_x64-setup.exe`, each with a `.sig`. But even with that whole stack merged and the Windows leg enabled, the `.exe` would upload to S3 and never appear in `installers.json` (the landing site's download source) or `latest.json` (the Tauri updater feed), because neither manifest script knew a `windows-x86_64` platform existed.

## Rebased onto post-#2170 main (2026-08-21)

This PR was originally written against `6aa2f298f`, before #2170 (`fix(release): publish desktop updater from flat artifact layouts`, merge commit `dedb89187`) landed on `main` at 2026-08-21T07:23:17Z. #2170 touches all four of the same files. The branch is now rebased onto `fe6780e00`, and the conflict was resolved by adapting this PR's intent onto #2170's structure rather than replaying its original lines.

**The dangerous part is what did NOT conflict.** #2170 deleted the `pathIncludes(relPath, segment)` helper from both generators and rewrote every matcher to test filenames only, because `download-artifact@v8` extracts FLAT when exactly one artifact matches, and the publish jobs now download with `merge-multiple: true` so the layout is flat at every artifact count. This PR's `windows-x86_64` descriptors called `pathIncludes(relPath, "desktop-x86_64-pc-windows-msvc")`. Git auto-merged both generator files with **zero conflict markers** and produced code that calls a function that no longer exists. That is a `ReferenceError` thrown on the first matcher invocation of every single manifest run, mac-only releases included. Only the two test files conflicted textually; the actual breakage was in the two files git thought were clean.

Resolution:

- **Both generators**: dropped the `pathIncludes` guard from the `windows-x86_64` descriptors so they match by filename only, exactly like main's darwin descriptors now do. The `-setup.exe` suffix is what separates `windows-x86_64` from `darwin-x86_64` under filename-only matching, and it is a strictly stronger discriminator than the directory segment was: the darwin matchers require `.dmg` / `.app.tar.gz`, so no cross-platform collision is possible even in one flat directory. This also means the Windows entry now resolves under the flat layout that is the only layout production produces after #2170, which the original directory-segment version would not have done.
- **`scripts/generate-updater-manifest.mjs` both-absent fix**: re-applied on top of main's current OR-based logic, which #2170 left untouched. Verified directly against `dedb89187`: the bug is still there at line 114 of main.
- **`scripts/ci-cd/generate-updater-manifest.test.mjs`** (CONFLICT content): unioned. Main's `flat` option and this PR's `windows` / `omitWindowsSig` / `omitDarwinAarch64` options are now all parameters of one `writeArtifacts`, and `generateManifest(t, notes, artifactOptions)` passes the whole bag through. All 8 of main's tests and all 4 of this PR's tests are retained verbatim.
- **`scripts/ci-cd/generate-desktop-installer-manifest.test.mjs`** (CONFLICT add/add): both sides created this file from scratch, so it was rewritten as a union. All 4 of main's tests keep main's fixture names (`Proliferate_aarch64.dmg`, `Proliferate_x64.dmg`) and main's `empty` option; all 4 of this PR's tests are retained.
- **One test added per file** that neither side had: `mac+windows` resolving from the merged flat layout. #2170 made flat the production layout, so Windows needed flat coverage that this PR's original nested-only fixtures did not provide.

No test was dropped from either side.

## Correction to an earlier claim in this PR body

The section below originally cited `desktop-x86_64-pc-windows-msvc` as a value the matchers depend on. After #2170 that is no longer true of the matchers: no descriptor in either generator tests directory layout any more. The artifact directory name still matters to `release-desktop.yml`'s `upload-artifact` step (`name: desktop-${{ matrix.target }}`), and the verification below still stands as evidence for the filenames, which is what the matchers now key on.

## The fail-closed trap, and why Windows had to be optional not required

Both scripts already fail closed: any platform in their list with a missing artifact pushes an error and calls `process.exit(1)`. From the code, unchanged by this PR:

```js
// scripts/generate-updater-manifest.mjs
if (errors.length > 0) {
  console.error("Manifest generation failed:");
  for (const err of errors) console.error(`  - ${err}`);
  process.exit(1);
}
```

```js
// scripts/generate-desktop-installer-manifest.mjs
if (errors.length > 0) {
  console.error("Installer manifest generation failed:");
  for (const err of errors) console.error(`  - ${err}`);
  process.exit(1);
}
```

Adding `windows-x86_64` as a plain required platform would turn every mac-only release into a hard failure the moment this PR merged, since the Windows leg does not exist on `main` yet (see below) and, once it does, is an opt-in beta behind `enable_windows_beta` (defaulted `false` in `release.yml`, per #2150's description). Mac-only releases are the norm until that beta stabilizes.

## Found while implementing: `main` already has the mechanism, just not for Windows

The task brief assumed a green field, but reading the actual current `scripts/generate-updater-manifest.mjs` on `main` shows Intel (`darwin-x86_64`) builds were paused on 2026-08-20 and already carry an `optional: true` platform-descriptor property with matching skip-not-fail logic:

```js
{
  key: "darwin-x86_64",
  optional: true,
  ...
}
...
if (sigFiles.length === 0 || artifactFiles.length === 0) {
  if (platform.optional) {
    console.warn(`Skipping ${platform.key}: no artifacts found (optional platform).`);
    continue;
  }
  ...
}
```

That is exactly the "first-class property on the platform descriptor" the task asked for (it suggested `required: false` as an example name). Rather than invent a second, parallel mechanism, I reused the existing `optional: true` convention verbatim for `windows-x86_64` in both scripts. Promoting Windows to required later is a one-line change: delete `optional: true` from its entry.

**A gap I found and fixed while extending this convention:** the existing skip check treated *either* file missing as grounds for an optional skip (`sigFiles.length === 0 || artifactFiles.length === 0`), which means a platform with the artifact but no signature (or vice versa) would have silently skipped instead of failing. That is unsafe for a signed updater feed: a half-published platform must never look identical to "cleanly absent". I tightened the guard so the optional skip only fires when *both* are missing; a partial state is always a fatal error, optional or not. This also improves the existing `darwin-x86_64` (Intel-paused) entry, not just the new Windows one, and is covered by the "a required darwin platform missing artifacts is still fatal even when windows is present" and "a windows artifact present without its .sig is a fatal error" tests below.

**This applies to the updater generator only.** `scripts/generate-desktop-installer-manifest.mjs` has one file class per platform (`installers.json` carries no signatures), so its guard is a single `files.length === 0` check with no OR to get wrong. There is no equivalent bug there to fix. Re-verified against `dedb89187`: the OR-based optional skip exists in `generate-updater-manifest.mjs` and nowhere else.

Darwin's `darwin-aarch64` entry (no `optional`, so treated as required) is untouched.

## exe vs msi decision

Publish the NSIS `Proliferate_<version>_x64-setup.exe`, not the MSI, in both manifests. Verified two ways:

- `release-desktop.yml`'s `publish-updater` job's S3 upload filter (the bucket `installers.json`/`latest.json`'s `--base-url` points at) only copies files matching `*.dmg`, `*.app.tar.gz`, `*.app.tar.gz.sig`, `*-setup.exe`, `*-setup.exe.sig`. There is no `*.msi` in that filter. An MSI reaches the GitHub Release, never the downloads bucket, so a manifest entry pointing at it would 404.
- The Tauri v2 updater on Windows installs and relaunches via the NSIS installer; the MSI is a separate, standalone install path Tauri's own bundler documentation does not wire to the updater.

This decision got more load-bearing after #2170. #2150's Windows `upload-artifact` step uploads `*.msi` alongside `*-setup.exe` and `*-setup.exe.sig`, and with `merge-multiple: true` all of it lands in one flat directory next to the darwin `.dmg` and `.app.tar.gz`. The matchers here anchor on `-setup\.exe$` and `-setup\.exe\.sig$`, so the MSI is never selected and never collides with `darwin-x86_64`.

## The exact windows-x86_64 platform key

Confirmed by reading `apps/desktop/src-tauri/tauri.conf.json`, which already has an `updater.windows.installMode` block, and by the shape already in use in both scripts for the existing darwin entries (`darwin-aarch64`, `darwin-x86_64`: `<os>-<arch>`). Tauri v2's updater platform keys follow that same `<os>-<arch>` convention for every target, so `windows-x86_64` is the correct, non-invented key.

## The exact Windows artifact filenames, and where I verified them

The matchers key on filenames, not directories (see the correction above). Verified two independent ways:

1. **`release-desktop.yml`'s build matrix and upload step**, read directly (`target: x86_64-pc-windows-msvc`, and `actions/upload-artifact` with `name: desktop-${{ matrix.target }}`). Note: as of this PR, `main`'s `build-desktop` matrix has *no* Windows entry at all yet, only `aarch64-apple-darwin` / `x86_64-apple-darwin`, despite scattered `matrix.runner_os == 'windows'` conditionals already present as dormant code. The Windows matrix entry, `continue-on-error`, and `enable_windows_beta` gate all live in open PR #2150 (`fix(release): restore the windows desktop release path`, based on draft PR #2146, not yet mergeable to `main`). This PR's manifest changes are therefore currently inert on `main` (no Windows leg exists to produce artifacts) and will activate the moment a Windows leg lands.
2. **Run https://github.com/proliferate-ai/proliferate/actions/runs/32447570745** (`gh run view 32447570745 --repo proliferate-ai/proliferate`), a real `windows-latest` dispatch from PR #2157's branch, confirms the NSIS output name is exactly `Proliferate_{version}_x64-setup.exe` (only the MSI carries an extra `_en-US` locale infix, which is why no matcher depends on it) and that both artifacts ship with a `.sig`.

## Overlap with PR #2150, and what #2150 must do when it rebases

PR #2150 (`fix/desktop-windows-release`, head `83333cfe3`) carries a duplicate `windows-x86_64` addition to both of these same scripts. It is stacked on draft PR #2146 (`fix/sdk-generate-windows-safe`), not `main`, so its "MERGEABLE / CLEAN" status on GitHub is measured against its stack base and says nothing about `main`.

**#2150 must DROP its `scripts/generate-updater-manifest.mjs` and `scripts/generate-desktop-installer-manifest.mjs` hunks entirely when it rebases past this PR. It must not merge them.** Its hunks were written against pre-#2170 `main` and carry two defects:

1. They call `pathIncludes(...)`, the helper #2170 deleted. `git merge-tree main fix/desktop-windows-release` reports **no conflict on either generator**, so those hunks will auto-merge silently into a `ReferenceError` that fires on every manifest run, exactly the trap this PR hit and describes above.
2. They retain the OR-based optional skip and add no partial-artifact test, so merging them reintroduces the silent-skip-on-half-published-platform bug this PR fixes.

Verified conflict surface of `fix/desktop-windows-release` against current `main` (`git merge-tree --write-tree --messages main pr2150`):

```
CONFLICT (content): Merge conflict in Makefile
CONFLICT (add/add): Merge conflict in scripts/ci-cd/generate-desktop-installer-manifest.test.mjs
CONFLICT (content): Merge conflict in scripts/ci-cd/generate-updater-manifest.test.mjs
```

**`.github/workflows/release-desktop.yml` does NOT conflict.** #2170's two hunks are at old lines 706 and 746, both inside the `create-release` and `publish-updater` download steps (`merge-multiple: false` to `true`). #2150's hunks in that file stop at old line 656, all inside the `on:` inputs block and the `build-desktop` job. Disjoint regions, and #2150 never touches `merge-multiple`, so the two changes compose. #2150 does need to stay aware that its Windows `upload-artifact` output now arrives flat-merged rather than in a `desktop-x86_64-pc-windows-msvc/` directory.

## Tests

Extended `scripts/ci-cd/generate-updater-manifest.test.mjs` and `scripts/ci-cd/generate-desktop-installer-manifest.test.mjs`. CI runs these via `node --test scripts/ci-cd/*.test.mjs` (`.github/workflows/ci.yml:188`).

```
$ node --test scripts/ci-cd/generate-desktop-installer-manifest.test.mjs scripts/ci-cd/generate-updater-manifest.test.mjs
ok 1 - generates both downloads from the nested per-artifact layout
ok 2 - generates an arm-only manifest from the flat single-artifact layout
ok 3 - generates both downloads from a merged flat layout
ok 4 - fails when the required darwin-aarch64 installer is missing
ok 5 - generates an arm-only manifest while Intel is paused
ok 6 - mac-only artifacts still produce a valid manifest with no windows entry (regression: Windows must never be required)
ok 7 - mac+windows artifacts produce all three download entries with the windows URL
ok 8 - mac+windows downloads resolve from the merged flat layout the publish jobs produce
ok 9 - a required darwin platform missing its installer is still fatal even when windows is present
ok 10 - writes a trimmed release title as top-level notes
ok 11 - generates an arm-only manifest while Intel is paused
ok 12 - generates an arm-only manifest from the flat single-artifact layout
ok 13 - generates both platforms from a merged flat layout
ok 14 - omits notes when the release title is absent or blank
ok 15 - accepts an 80-character release title
ok 16 - validates and previews a release title without build artifacts
ok 17 - rejects multiline, control-character, and overlong release titles
ok 18 - mac-only artifacts still produce a valid manifest with no windows entry (regression: Windows must never be required)
ok 19 - mac+windows artifacts produce all three platform entries with the windows URL and signature
ok 20 - mac+windows artifacts resolve from the merged flat layout the publish jobs produce
ok 21 - a windows artifact present without its .sig is a fatal error, never a silent skip
ok 22 - a required darwin platform missing artifacts is still fatal even when windows is present
1..22
# tests 22
# suites 0
# pass 22
# fail 0
```

Full CI glob, which is what actually gates:

```
$ node --test scripts/ci-cd/*.test.mjs
# tests 225
# pass 225
# fail 0
```

`python3 scripts/check_max_lines.py` also passes (`Max-lines check passed (repo max 600, component max 500, server layer maxes enabled).`).

Coverage added on top of #2170's tests:
- mac-only artifacts still produce a valid manifest with no Windows entry, exit 0 (the regression that must never happen), for both scripts
- mac+windows artifacts produce all three entries, with the correct Windows URL (and signature, for the updater manifest), in both the nested and the merged-flat layout
- a Windows artifact present without its `.sig` is a fatal error, not a silent skip, for the updater manifest
- a required darwin platform missing its artifact is still fatal even when Windows is present, for both scripts
- every #2170 test (flat single-artifact, merged flat, nested) and the pre-existing Intel-pause test are preserved and still pass

## Negative control

Two behavioural mutations, each run against the rebased tree.

**A. Revert the both-absent fix to main's OR-based optional skip** (`if (platform.optional && sigFiles.length === 0 && artifactFiles.length === 0)` back to `if (platform.optional)`):

```
ok 20 - mac+windows artifacts resolve from the merged flat layout the publish jobs produce
not ok 21 - a windows artifact present without its .sig is a fatal error, never a silent skip
ok 22 - a required darwin platform missing artifacts is still fatal even when windows is present
# tests 22
# pass 21
# fail 1
```

Exactly the one named test that guards this fix fails, and nothing else moves.

**B. Delete the `windows-x86_64` descriptor from both generators:**

```
ok 5 - generates an arm-only manifest while Intel is paused
not ok 6 - mac-only artifacts still produce a valid manifest with no windows entry (regression: Windows must never be required)
not ok 7 - mac+windows artifacts produce all three download entries with the windows URL
not ok 8 - mac+windows downloads resolve from the merged flat layout the publish jobs produce
ok 9 - a required darwin platform missing its installer is still fatal even when windows is present
...
not ok 18 - mac-only artifacts still produce a valid manifest with no windows entry (regression: Windows must never be required)
not ok 19 - mac+windows artifacts produce all three platform entries with the windows URL and signature
not ok 20 - mac+windows artifacts resolve from the merged flat layout the publish jobs produce
not ok 21 - a windows artifact present without its .sig is a fatal error, never a silent skip
ok 22 - a required darwin platform missing artifacts is still fatal even when windows is present
# tests 22
# pass 15
# fail 7
```

Both mutations restored, re-run: `# tests 22`, `# pass 22`, `# fail 0`.

Neither mutation is a syntax or import error; both leave the scripts runnable and change only behaviour.

## Unverified / what the first real Windows release should watch for

This has not been exercised by a real release dispatch of these two scripts against genuine Windows build output; only unit tests with synthetic fixtures. It has also not been exercised against a real merge of the Windows build matrix (#2150 is still stacked on #2146). When the Windows leg first runs for real through `publish-updater`, watch for:

- The Windows artifact actually appearing under `all-artifacts/` with the exact NSIS filename these matchers expect (`(x64|x86_64).*-setup\.exe$`). Run 32447570745 proved this for a `pnpm tauri build` invocation, not for a full `publish-updater` run. After #2170 it will arrive flat-merged, not in its own directory.
- Whether `continue-on-error` on a failed Windows leg (as #2150 proposes) makes `create-release`/`publish-updater` still run with an empty Windows contribution rather than skipping outright; that interaction is owned by the workflow, not by these two scripts, but it determines whether "optional" ever actually gets exercised in production.
- That the MSI-vs-exe decision still holds once Authenticode signing (currently absent per #2150, accepted for the beta) or any other Windows-specific packaging change is made; if the artifact naming changes, both regexes here need to move with it. With `merge-multiple: true` the MSI now sits in the same directory as everything else, so the `-setup.exe` anchor is the only thing keeping it out of the manifests.

## Labels

`release:fix` (this is a fix to a fail-closed publish path, not a new feature) + `area:release` (updater/installer manifest generation) + `area:desktop` (Tauri desktop distribution).
