### PR TITLE
perf(release): build server artifacts without re-running tests

### DIFF
--- a/.github/workflows/_build-server.yml
+++ b/.github/workflows/_build-server.yml
@@ -1,0 +1,296 @@
+name: Build Server Artifacts
+
+# Release build brick for the server surface: the GHCR images and the
+# self-hosted release assets, and nothing else.
+#
+# THERE ARE DELIBERATELY NO TEST OR LINT JOBS HERE.
+#
+# Per the delivery state machine
+# (specs/codebase/systems/engineering/delivery/README.md), tests gate the
+# PR -> main transition; the main -> production transition builds artifacts and
+# deploys them. Every SHA this workflow can be called with has already reached
+# `main`, which means `server-ci-ok` -- the required rollup covering `lint`,
+# `test-unit`, and the three `test-integration` shards -- already concluded
+# success on it, and release.yml's `prepare` job independently refuses to
+# release a head that is not an ancestor of `main`. Re-running the identical
+# suite here proves nothing branch protection has not already proven, and it
+# cost 5.5 minutes of wall clock on the critical path of every server release
+# (measured on run 32450223908).
+#
+# So if you are about to add `needs: [lint, test-unit, ...]` to a job in this
+# file, the thing you actually want is a stronger PR gate in server-ci.yml.
+#
+# Reusable-only, like the `_deploy-*.yml` lanes. The job-level `if:` gates below
+# are carried over verbatim from server-ci.yml, so a caller triggered by a
+# `server-v*` tag push keeps the exact publish semantics it had there.
+
+on:
+  workflow_call:
+    inputs:
+      git_sha:
+        description: "Commit SHA to package. Defaults to the caller ref."
+        required: false
+        type: string
+      version:
+        description: "Server/self-hosted version to release. Required for reusable release calls."
+        required: false
+        type: string
+      dry_run:
+        description: "Run packaging without publishing release artifacts."
+        type: boolean
+        default: false
+      publish:
+        description: "Publish GHCR image and GitHub Release assets."
+        type: boolean
+        default: true
+
+defaults:
+  run:
+    working-directory: server
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    # Reusable-workflow calls inherit the caller's event name (never
+    # "workflow_call"), so this leg is driven by inputs.publish/dry_run instead.
+    # Verbatim from server-ci.yml, where this job used to live: an unset input
+    # leaves the comparison false, so the gate is true only under a caller
+    # triggered by a server-v tag push or an explicit publish call.
+    if: (startsWith(github.ref, 'refs/tags/server-v')) || (inputs.publish == true && inputs.dry_run != true)
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.git_sha || github.ref }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: tags
+        env:
+          INPUT_VERSION: ${{ inputs.version || '' }}
+        run: |
+          set -euo pipefail
+          GHCR_IMAGE="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/proliferate-server"
+          LITELLM_IMAGE="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/proliferate-litellm"
+          TAGS=()
+          LITELLM_TAGS=()
+
+          if [[ "${GITHUB_REF:-}" == refs/tags/server-v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/server-v}"
+          else
+            VERSION="${INPUT_VERSION:?A server version input is required for reusable releases.}"
+          fi
+          # Push both the immutable version tag and the rolling :stable tag that the
+          # self-host compose bundle (server/deploy/) defaults to.
+          TAGS+=("${GHCR_IMAGE}:${VERSION}" "${GHCR_IMAGE}:stable")
+          LITELLM_TAGS+=("${LITELLM_IMAGE}:${VERSION}" "${LITELLM_IMAGE}:stable")
+
+          {
+            echo "tags<<EOF"
+            printf '%s\n' "${TAGS[@]}"
+            echo "EOF"
+            echo "litellm_tags<<EOF"
+            printf '%s\n' "${LITELLM_TAGS[@]}"
+            echo "EOF"
+            echo "version=${VERSION}"
+          } >> "$GITHUB_OUTPUT"
+
+      # Version pins stamped into the image and reported by /health and /meta.
+      # serverVersion is the release version (server-v tag / input). The desktop,
+      # runtime, and worker pins are read from their tracked package manifests
+      # at this commit; minDesktopVersion defaults to the pinned desktop version.
+      - name: Resolve version pins
+        id: pins
+        run: |
+          set -euo pipefail
+          desktop_version="$(jq -r '.version' apps/desktop/package.json)"
+          runtime_version="$(jq -r '.version' anyharness/sdk/package.json)"
+          worker_version="$(sed -n 's/^version = "\([^"]*\)"$/\1/p' anyharness/crates/proliferate-worker/Cargo.toml | head -n 1)"
+          : "${worker_version:?Failed to read the proliferate-worker crate version.}"
+          {
+            echo "desktop_version=${desktop_version}"
+            echo "runtime_version=${runtime_version}"
+            echo "worker_version=${worker_version}"
+            echo "min_desktop_version=${desktop_version}"
+          } >> "$GITHUB_OUTPUT"
+        working-directory: .
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: server/Dockerfile
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            SERVER_VERSION=${{ steps.tags.outputs.version }}
+            DESKTOP_VERSION=${{ steps.pins.outputs.desktop_version }}
+            RUNTIME_VERSION=${{ steps.pins.outputs.runtime_version }}
+            WORKER_VERSION=${{ steps.pins.outputs.worker_version }}
+            MIN_DESKTOP_VERSION=${{ steps.pins.outputs.min_desktop_version }}
+
+      # The self-host compose bundle also defaults the LiteLLM gateway to
+      # ghcr.io/OWNER/proliferate-litellm:stable, which no workflow built before.
+      # Build it here symmetrically with the server image (same GHCR login, same
+      # version/:stable tags) so self-host operators can pull it.
+      - name: Build and push LiteLLM gateway
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: server/litellm/Dockerfile
+          push: true
+          tags: ${{ steps.tags.outputs.litellm_tags }}
+
+  self-hosted-release-assets:
+    runs-on: ubuntu-latest
+    needs: [docker]
+    # Same input-driven gate as the docker job (see note above): a server-v tag
+    # push, or an explicit publish call from a release train / hotfix workflow.
+    if: (startsWith(github.ref, 'refs/tags/server-v')) || (inputs.publish == true && inputs.dry_run != true)
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.git_sha || github.ref }}
+
+      - name: Setup Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: |
+            x86_64-unknown-linux-musl
+            aarch64-unknown-linux-musl
+
+      # This job compiles the same 3 crates (anyharness, proliferate-worker,
+      # proliferate-supervisor) for 2 targets with no cache today, so every run
+      # pays a full from-scratch registry download plus workspace-dependency
+      # compile twice. `cross` (used for the aarch64 build below) bind-mounts
+      # the repo root, including target/, into its build container by default,
+      # so a host-side target/ cache benefits both the native x86_64 build and
+      # the cross-compiled aarch64 build. Same pattern already used for
+      # `cross` builds elsewhere in this repo (see release-e2e.yml).
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "."
+
+      - name: Install musl-tools
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+        working-directory: .
+
+      - name: Install cross for aarch64
+        run: cargo install cross --git https://github.com/cross-rs/cross --locked
+        working-directory: .
+
+      - name: Build self-hosted Linux runtime (x86_64)
+        run: cargo build --release --target x86_64-unknown-linux-musl -p anyharness -p proliferate-worker -p proliferate-supervisor
+        working-directory: .
+
+      - name: Build self-hosted Linux runtime (aarch64)
+        run: cross build --release --target aarch64-unknown-linux-musl -p anyharness -p proliferate-worker -p proliferate-supervisor
+        working-directory: .
+
+      - name: Prepare release assets
+        env:
+          INPUT_VERSION: ${{ inputs.version || '' }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          if [[ "${GITHUB_REF:-}" == refs/tags/server-v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/server-v}"
+          else
+            VERSION="${INPUT_VERSION:?A server version input is required for reusable releases.}"
+          fi
+          # Archive as root:root so a root extraction on the operator host does
+          # not hand ownership of executables to the runner's unprivileged uid.
+          tar czf artifacts/anyharness-x86_64-unknown-linux-musl.tar.gz \
+            --owner=0 --group=0 --numeric-owner \
+            -C target/x86_64-unknown-linux-musl/release \
+            anyharness \
+            proliferate-worker \
+            proliferate-supervisor
+          tar czf artifacts/anyharness-aarch64-unknown-linux-musl.tar.gz \
+            --owner=0 --group=0 --numeric-owner \
+            -C target/aarch64-unknown-linux-musl/release \
+            anyharness \
+            proliferate-worker \
+            proliferate-supervisor
+          cp server/infra/self-hosted-aws/template.yaml \
+            artifacts/proliferate-self-hosted-aws-template.yaml
+          # Standalone entrypoints operators fetch before they have the bundle:
+          # the guided installer and the AWS launch action. Published (and
+          # checksummed) so they can be pinned to a release and verified.
+          cp server/deploy/install.sh artifacts/proliferate-selfhost-install.sh
+          cp server/infra/self-hosted-aws/launch-stack.sh \
+            artifacts/proliferate-selfhost-aws-launch.sh
+          bundle_root="$(mktemp -d)"
+          mkdir -p "$bundle_root/proliferate-deploy"
+          cp -R server/deploy/. "$bundle_root/proliferate-deploy/"
+          # smoke/ and tests/ are CI-only; the operator bundle ships just the
+          # scripts, compose, and config the running stack needs.
+          rm -rf "$bundle_root/proliferate-deploy/smoke"
+          rm -rf "$bundle_root/proliferate-deploy/tests"
+          rm -f "$bundle_root/proliferate-deploy/.bootstrap-progress.log"
+          printf '%s\n' "$VERSION" > "$bundle_root/proliferate-deploy/VERSION"
+          tar czf artifacts/proliferate-deploy.tar.gz \
+            --owner=0 --group=0 --numeric-owner \
+            -C "$bundle_root" proliferate-deploy
+          rm -rf "$bundle_root"
+          (
+            cd artifacts
+            sha256sum \
+              anyharness-x86_64-unknown-linux-musl.tar.gz \
+              anyharness-aarch64-unknown-linux-musl.tar.gz \
+              proliferate-self-hosted-aws-template.yaml \
+              proliferate-selfhost-install.sh \
+              proliferate-selfhost-aws-launch.sh \
+              proliferate-deploy.tar.gz \
+              > self-hosted-assets.SHA256SUMS
+          )
+        working-directory: .
+
+      - name: Ensure server release tag exists
+        # Only publish calls need to create the tag; on a real server-v tag push
+        # the tag already exists. Input-driven, not event-name-driven.
+        if: inputs.publish == true && inputs.dry_run != true
+        env:
+          RELEASE_TAG: ${{ format('server-v{0}', inputs.version) }}
+          RELEASE_TARGET: ${{ inputs.git_sha }}
+        run: |
+          set -euo pipefail
+          : "${RELEASE_TAG:?Missing server release tag.}"
+          : "${RELEASE_TARGET:?Missing server release target.}"
+          existing_target="$(git ls-remote --tags origin "refs/tags/$RELEASE_TAG" | awk '{ print $1 }' | head -n 1)"
+          if [[ -n "$existing_target" && "$existing_target" != "$RELEASE_TARGET" ]]; then
+            echo "::error::Server tag $RELEASE_TAG already exists at $existing_target, not $RELEASE_TARGET."
+            exit 1
+          fi
+          if [[ -z "$existing_target" ]]; then
+            git tag "$RELEASE_TAG" "$RELEASE_TARGET"
+            git push origin "refs/tags/$RELEASE_TAG"
+          fi
+        working-directory: .
+
+      - name: Publish self-hosted release assets
+        uses: softprops/action-gh-release@v3
+        with:
+          target_commitish: ${{ inputs.git_sha || github.sha }}
+          tag_name: ${{ github.event_name == 'push' && github.ref_name || format('server-v{0}', inputs.version) }}
+          files: |
+            artifacts/anyharness-x86_64-unknown-linux-musl.tar.gz
+            artifacts/anyharness-aarch64-unknown-linux-musl.tar.gz
+            artifacts/proliferate-self-hosted-aws-template.yaml
+            artifacts/proliferate-selfhost-install.sh
+            artifacts/proliferate-selfhost-aws-launch.sh
+            artifacts/proliferate-deploy.tar.gz
+            artifacts/self-hosted-assets.SHA256SUMS

--- a/.github/workflows/_build-server.yml
+++ b/.github/workflows/_build-server.yml
@@ -21,8 +21,12 @@ name: Build Server Artifacts
 # file, the thing you actually want is a stronger PR gate in server-ci.yml.
 #
 # Reusable-only, like the `_deploy-*.yml` lanes. The job-level `if:` gates below
-# are carried over verbatim from server-ci.yml, so a caller triggered by a
-# `server-v*` tag push keeps the exact publish semantics it had there.
+# are carried over verbatim from server-ci.yml. The `startsWith(github.ref,
+# 'refs/tags/server-v')` leg of those gates (and the `github.event_name ==
+# 'push'` check further down) is currently unreachable: no caller triggers this
+# workflow from a tag push today. It is kept, unchanged, only to stay
+# byte-comparable with the code it was moved from and to support a possible
+# future tag-triggered caller, should one be added.
 
 on:
   workflow_call:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -770,9 +770,13 @@ jobs:
   # Deliberately NOT required, with reasons:
   #   intent-tests (provisional) / intent-billing (provisional)
   #       continue-on-error by design; intent-tests.yml says do not require yet.
-  #   docker / self-hosted-release-assets (Server CI)
-  #       release-only, `skipped` on every PR; server-ci-ok exempts them by
-  #       detecting their `server-v` tag gate, not by name.
+  #   docker / self-hosted-release-assets (Build Server Artifacts)
+  #       release-only, and no longer in Server CI at all: they moved to
+  #       _build-server.yml, which release.yml calls directly so a release does
+  #       not re-run the suite its SHA already passed to reach main. They never
+  #       run on a PR. server-ci-ok still derives a release-only exemption from
+  #       a `server-v` tag gate rather than by name, so a release-gated job
+  #       cannot silently reappear inside Server CI outside the rollup.
   #   Vercel / Vercel Preview Comments
   #       third-party.
   #

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,10 +309,12 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: ./.github/workflows/server-ci.yml
+    # `_build-server.yml`, not `server-ci.yml`: this head is already on `main`,
+    # so `server-ci-ok` has already gated it. The build brick carries no lint or
+    # test jobs on purpose -- see the note at the top of that file.
+    uses: ./.github/workflows/_build-server.yml
     with:
       git_sha: ${{ needs.prepare.outputs.head_sha }}
-      comparison_sha: ${{ needs.prepare.outputs.base_sha }}
       version: ${{ needs.prepare.outputs.server_version }}
       dry_run: false
       publish: true

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -1,9 +1,15 @@
 name: Server CI
 
 on:
+  # No `tags: ["server-v*"]` here any more. The two jobs that reacted to a
+  # server release tag (`docker`, `self-hosted-release-assets`) moved to
+  # `_build-server.yml`, so a tag push has nothing left to trigger in this file
+  # -- it would only re-run the suite the tagged commit already passed on `main`.
+  # (It never actually fired either: a `paths:` filter alongside a tag push
+  # matches nothing, and this workflow has zero tag-triggered runs in its
+  # history despite server-v0.4.4 through server-v0.4.9 all existing.)
   push:
     branches: [main]
-    tags: ["server-v*"]
     paths:
       - ".dockerignore"
       - ".github/workflows/server-ci.yml"
@@ -33,28 +39,19 @@ on:
         description: "Trusted base SHA for the shrink-only mypy baseline comparison."
         required: true
         type: string
+  # Validation only. Release packaging inputs (`version`, `dry_run`, `publish`)
+  # live on `_build-server.yml`, which is what release.yml calls; this workflow
+  # no longer publishes anything and takes no publishing inputs.
   workflow_call:
     inputs:
       git_sha:
-        description: "Commit SHA to validate and package. Defaults to the caller ref."
+        description: "Commit SHA to validate. Defaults to the caller ref."
         required: false
         type: string
       comparison_sha:
         description: "Trusted base SHA for the shrink-only mypy baseline comparison."
         required: true
         type: string
-      version:
-        description: "Server/self-hosted version to release. Required for reusable release calls."
-        required: false
-        type: string
-      dry_run:
-        description: "Run validation and packaging without publishing release artifacts."
-        type: boolean
-        default: false
-      publish:
-        description: "Publish GHCR image and GitHub Release assets."
-        type: boolean
-        default: true
 
 defaults:
   run:
@@ -70,8 +67,8 @@ jobs:
   # whose server lanes actually execute is unchanged; only the reporting
   # behaviour on the other PRs changes (a real green instead of no conclusion).
   #
-  # Every non-pull_request caller -- main/tag pushes, workflow_dispatch, and the
-  # release/hotfix workflow_call entrypoints -- is unconditionally relevant.
+  # Every non-pull_request caller -- main pushes, workflow_dispatch, and any
+  # workflow_call entrypoint -- is unconditionally relevant.
   #
   # This job is lane-agnostic on purpose: it publishes ONE `relevant` flag and
   # any number of downstream lanes consume it. A new lane needs exactly three
@@ -102,11 +99,11 @@ jobs:
           set -euo pipefail
 
           # A reusable-workflow call inherits the CALLER's event name and never
-          # reports "workflow_call" (see the docker job's comment below), so the
-          # event name alone cannot identify a release invocation. Both callers
-          # today are non-PR (hotfix-production.yml is workflow_dispatch,
-          # nightly-release-train.yml is schedule/workflow_dispatch), but a
-          # future PR-triggered caller would otherwise compute relevance from
+          # reports "workflow_call" (the same quirk `_build-server.yml` documents
+          # on its job gates), so the event name alone cannot identify a
+          # reusable invocation. There is no checked-in caller today -- release.yml
+          # calls `_build-server.yml`, not this file -- but a future PR-triggered
+          # caller would otherwise compute relevance from
           # the PR's diff and could ship with the server lanes no-opped. A
           # non-empty inputs.git_sha only ever comes from a workflow_call, so
           # treat it as unconditionally relevant regardless of event name.
@@ -539,249 +536,6 @@ jobs:
         if: needs.changes.outputs.relevant != 'false'
         run: xargs -r -a shard_files.txt pytest -n 4 -q --durations=20
 
-  docker:
-    runs-on: ubuntu-latest
-    needs: [lint, test-unit, test-integration]
-    # Reusable-workflow calls inherit the caller's event name (never
-    # "workflow_call"), so this leg is driven by inputs.publish/dry_run instead.
-    # inputs.* are empty on plain push/PR events, so the comparisons stay false
-    # there and true only on a server-v tag push or an explicit publish call.
-    if: (startsWith(github.ref, 'refs/tags/server-v')) || (inputs.publish == true && inputs.dry_run != true)
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ inputs.git_sha || github.ref }}
-
-      - name: Login to GHCR
-        uses: docker/login-action@v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Compute image tags
-        id: tags
-        env:
-          INPUT_VERSION: ${{ inputs.version || '' }}
-        run: |
-          set -euo pipefail
-          GHCR_IMAGE="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/proliferate-server"
-          LITELLM_IMAGE="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/proliferate-litellm"
-          TAGS=()
-          LITELLM_TAGS=()
-
-          if [[ "${GITHUB_REF:-}" == refs/tags/server-v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/server-v}"
-          else
-            VERSION="${INPUT_VERSION:?A server version input is required for reusable releases.}"
-          fi
-          # Push both the immutable version tag and the rolling :stable tag that the
-          # self-host compose bundle (server/deploy/) defaults to.
-          TAGS+=("${GHCR_IMAGE}:${VERSION}" "${GHCR_IMAGE}:stable")
-          LITELLM_TAGS+=("${LITELLM_IMAGE}:${VERSION}" "${LITELLM_IMAGE}:stable")
-
-          {
-            echo "tags<<EOF"
-            printf '%s\n' "${TAGS[@]}"
-            echo "EOF"
-            echo "litellm_tags<<EOF"
-            printf '%s\n' "${LITELLM_TAGS[@]}"
-            echo "EOF"
-            echo "version=${VERSION}"
-          } >> "$GITHUB_OUTPUT"
-
-      # Version pins stamped into the image and reported by /health and /meta.
-      # serverVersion is the release version (server-v tag / input). The desktop,
-      # runtime, and worker pins are read from their tracked package manifests
-      # at this commit; minDesktopVersion defaults to the pinned desktop version.
-      - name: Resolve version pins
-        id: pins
-        run: |
-          set -euo pipefail
-          desktop_version="$(jq -r '.version' apps/desktop/package.json)"
-          runtime_version="$(jq -r '.version' anyharness/sdk/package.json)"
-          worker_version="$(sed -n 's/^version = "\([^"]*\)"$/\1/p' anyharness/crates/proliferate-worker/Cargo.toml | head -n 1)"
-          : "${worker_version:?Failed to read the proliferate-worker crate version.}"
-          {
-            echo "desktop_version=${desktop_version}"
-            echo "runtime_version=${runtime_version}"
-            echo "worker_version=${worker_version}"
-            echo "min_desktop_version=${desktop_version}"
-          } >> "$GITHUB_OUTPUT"
-        working-directory: .
-
-      - name: Build and push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: server/Dockerfile
-          push: true
-          tags: ${{ steps.tags.outputs.tags }}
-          build-args: |
-            SERVER_VERSION=${{ steps.tags.outputs.version }}
-            DESKTOP_VERSION=${{ steps.pins.outputs.desktop_version }}
-            RUNTIME_VERSION=${{ steps.pins.outputs.runtime_version }}
-            WORKER_VERSION=${{ steps.pins.outputs.worker_version }}
-            MIN_DESKTOP_VERSION=${{ steps.pins.outputs.min_desktop_version }}
-
-      # The self-host compose bundle also defaults the LiteLLM gateway to
-      # ghcr.io/OWNER/proliferate-litellm:stable, which no workflow built before.
-      # Build it here symmetrically with the server image (same GHCR login, same
-      # version/:stable tags) so self-host operators can pull it.
-      - name: Build and push LiteLLM gateway
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: server/litellm/Dockerfile
-          push: true
-          tags: ${{ steps.tags.outputs.litellm_tags }}
-
-  self-hosted-release-assets:
-    runs-on: ubuntu-latest
-    needs: [lint, test-unit, test-integration, docker]
-    # Same input-driven gate as the docker job (see note above): a server-v tag
-    # push, or an explicit publish call from a release train / hotfix workflow.
-    if: (startsWith(github.ref, 'refs/tags/server-v')) || (inputs.publish == true && inputs.dry_run != true)
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ inputs.git_sha || github.ref }}
-
-      - name: Setup Rust stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: |
-            x86_64-unknown-linux-musl
-            aarch64-unknown-linux-musl
-
-      # This job compiles the same 3 crates (anyharness, proliferate-worker,
-      # proliferate-supervisor) for 2 targets with no cache today, so every run
-      # pays a full from-scratch registry download plus workspace-dependency
-      # compile twice. `cross` (used for the aarch64 build below) bind-mounts
-      # the repo root, including target/, into its build container by default,
-      # so a host-side target/ cache benefits both the native x86_64 build and
-      # the cross-compiled aarch64 build. Same pattern already used for
-      # `cross` builds elsewhere in this repo (see release-e2e.yml).
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "."
-
-      - name: Install musl-tools
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
-        working-directory: .
-
-      - name: Install cross for aarch64
-        run: cargo install cross --git https://github.com/cross-rs/cross --locked
-        working-directory: .
-
-      - name: Build self-hosted Linux runtime (x86_64)
-        run: cargo build --release --target x86_64-unknown-linux-musl -p anyharness -p proliferate-worker -p proliferate-supervisor
-        working-directory: .
-
-      - name: Build self-hosted Linux runtime (aarch64)
-        run: cross build --release --target aarch64-unknown-linux-musl -p anyharness -p proliferate-worker -p proliferate-supervisor
-        working-directory: .
-
-      - name: Prepare release assets
-        env:
-          INPUT_VERSION: ${{ inputs.version || '' }}
-        run: |
-          set -euo pipefail
-          mkdir -p artifacts
-          if [[ "${GITHUB_REF:-}" == refs/tags/server-v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/server-v}"
-          else
-            VERSION="${INPUT_VERSION:?A server version input is required for reusable releases.}"
-          fi
-          # Archive as root:root so a root extraction on the operator host does
-          # not hand ownership of executables to the runner's unprivileged uid.
-          tar czf artifacts/anyharness-x86_64-unknown-linux-musl.tar.gz \
-            --owner=0 --group=0 --numeric-owner \
-            -C target/x86_64-unknown-linux-musl/release \
-            anyharness \
-            proliferate-worker \
-            proliferate-supervisor
-          tar czf artifacts/anyharness-aarch64-unknown-linux-musl.tar.gz \
-            --owner=0 --group=0 --numeric-owner \
-            -C target/aarch64-unknown-linux-musl/release \
-            anyharness \
-            proliferate-worker \
-            proliferate-supervisor
-          cp server/infra/self-hosted-aws/template.yaml \
-            artifacts/proliferate-self-hosted-aws-template.yaml
-          # Standalone entrypoints operators fetch before they have the bundle:
-          # the guided installer and the AWS launch action. Published (and
-          # checksummed) so they can be pinned to a release and verified.
-          cp server/deploy/install.sh artifacts/proliferate-selfhost-install.sh
-          cp server/infra/self-hosted-aws/launch-stack.sh \
-            artifacts/proliferate-selfhost-aws-launch.sh
-          bundle_root="$(mktemp -d)"
-          mkdir -p "$bundle_root/proliferate-deploy"
-          cp -R server/deploy/. "$bundle_root/proliferate-deploy/"
-          # smoke/ and tests/ are CI-only; the operator bundle ships just the
-          # scripts, compose, and config the running stack needs.
-          rm -rf "$bundle_root/proliferate-deploy/smoke"
-          rm -rf "$bundle_root/proliferate-deploy/tests"
-          rm -f "$bundle_root/proliferate-deploy/.bootstrap-progress.log"
-          printf '%s\n' "$VERSION" > "$bundle_root/proliferate-deploy/VERSION"
-          tar czf artifacts/proliferate-deploy.tar.gz \
-            --owner=0 --group=0 --numeric-owner \
-            -C "$bundle_root" proliferate-deploy
-          rm -rf "$bundle_root"
-          (
-            cd artifacts
-            sha256sum \
-              anyharness-x86_64-unknown-linux-musl.tar.gz \
-              anyharness-aarch64-unknown-linux-musl.tar.gz \
-              proliferate-self-hosted-aws-template.yaml \
-              proliferate-selfhost-install.sh \
-              proliferate-selfhost-aws-launch.sh \
-              proliferate-deploy.tar.gz \
-              > self-hosted-assets.SHA256SUMS
-          )
-        working-directory: .
-
-      - name: Ensure server release tag exists
-        # Only publish calls need to create the tag; on a real server-v tag push
-        # the tag already exists. Input-driven, not event-name-driven.
-        if: inputs.publish == true && inputs.dry_run != true
-        env:
-          RELEASE_TAG: ${{ format('server-v{0}', inputs.version) }}
-          RELEASE_TARGET: ${{ inputs.git_sha }}
-        run: |
-          set -euo pipefail
-          : "${RELEASE_TAG:?Missing server release tag.}"
-          : "${RELEASE_TARGET:?Missing server release target.}"
-          existing_target="$(git ls-remote --tags origin "refs/tags/$RELEASE_TAG" | awk '{ print $1 }' | head -n 1)"
-          if [[ -n "$existing_target" && "$existing_target" != "$RELEASE_TARGET" ]]; then
-            echo "::error::Server tag $RELEASE_TAG already exists at $existing_target, not $RELEASE_TARGET."
-            exit 1
-          fi
-          if [[ -z "$existing_target" ]]; then
-            git tag "$RELEASE_TAG" "$RELEASE_TARGET"
-            git push origin "refs/tags/$RELEASE_TAG"
-          fi
-        working-directory: .
-
-      - name: Publish self-hosted release assets
-        uses: softprops/action-gh-release@v3
-        with:
-          target_commitish: ${{ inputs.git_sha || github.sha }}
-          tag_name: ${{ github.event_name == 'push' && github.ref_name || format('server-v{0}', inputs.version) }}
-          files: |
-            artifacts/anyharness-x86_64-unknown-linux-musl.tar.gz
-            artifacts/anyharness-aarch64-unknown-linux-musl.tar.gz
-            artifacts/proliferate-self-hosted-aws-template.yaml
-            artifacts/proliferate-selfhost-install.sh
-            artifacts/proliferate-selfhost-aws-launch.sh
-            artifacts/proliferate-deploy.tar.gz
-            artifacts/self-hosted-assets.SHA256SUMS
-
   # ---------------------------------------------------------------------------
   # Absence gate for this workflow, mirroring `ci-ok` in ci.yml. `needs:` cannot
   # cross workflows, so each workflow that carries required checks needs its own
@@ -822,16 +576,21 @@ jobs:
       # but not to `needs:` above would sit outside the rollup, which is the
       # same absence hole one level up.
       #
-      # Two job classes are legitimately outside the rollup, and the exemption
-      # is DERIVED rather than hardcoded so it cannot rot: `docker` and
-      # `self-hosted-release-assets` publish release artifacts and carry a
-      # job-level `if:` gated on the `server-v` tag, so they are `skipped` on
-      # every pull request by design. Rolling them up would make this check
-      # permanently red on PRs. Identifying them by that gate -- rather than by
-      # name -- means that if anyone ever removes the release gate from one of
-      # them, it stops being exempt and the drift guard demands it join
-      # `needs:`. The exempt set is printed on every run so the exemption is
-      # visible rather than implied.
+      # The exemption for release-only jobs is DERIVED rather than hardcoded so
+      # it cannot rot: any job carrying a job-level `if:` gated on the
+      # `server-v` tag publishes release artifacts, is `skipped` on every pull
+      # request by design, and would make this check permanently red if rolled
+      # up. Identifying such a job by that gate -- rather than by name -- means
+      # that if anyone ever removes the release gate from one, it stops being
+      # exempt and the drift guard demands it join `needs:`. The exempt set is
+      # printed on every run so the exemption is visible rather than implied.
+      #
+      # That set is EMPTY today, and the guard's arithmetic is what proves it:
+      # `docker` and `self-hosted-release-assets` moved to `_build-server.yml`,
+      # which release.yml calls directly, so every job left in this file is a
+      # validation lane and every one of them is in `needs:` below. The
+      # derivation stays because a future release-gated job must not silently
+      # join the rollup, not because anything is exempt right now.
       #
       # `working-directory: .` on both run steps: this file sets
       # `defaults.run.working-directory: server`, and the sparse checkout above

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -1,13 +1,20 @@
 name: Server CI
 
 on:
-  # No `tags: ["server-v*"]` here any more. The two jobs that reacted to a
-  # server release tag (`docker`, `self-hosted-release-assets`) moved to
-  # `_build-server.yml`, so a tag push has nothing left to trigger in this file
-  # -- it would only re-run the suite the tagged commit already passed on `main`.
-  # (It never actually fired either: a `paths:` filter alongside a tag push
-  # matches nothing, and this workflow has zero tag-triggered runs in its
-  # history despite server-v0.4.4 through server-v0.4.9 all existing.)
+  # No `tags: ["server-v*"]` here any more. This is a deliberate retirement,
+  # not a no-op cleanup -- the tag trigger DID fire historically: three
+  # human-pushed tags (server-v0.1.1/0.1.2/0.1.3, 2026-05-29, runs
+  # 26621290094/26621446218/26622403422) ran this workflow, including the two
+  # jobs that reacted to a server release tag (`docker`,
+  # `self-hosted-release-assets`), which have since moved to
+  # `_build-server.yml`. (GitHub does not evaluate `paths:` filters for tag
+  # pushes at all, so the `paths:` list below never suppressed those runs.)
+  # server-v0.4.x tags produced no runs for an unrelated reason: those tags
+  # are minted by a workflow using the default `GITHUB_TOKEN`
+  # (`_build-server.yml`'s tag-creation step), and `GITHUB_TOKEN` pushes do
+  # not trigger new workflow runs. The trigger is being retired now because
+  # releases flow exclusively through `release.yml` -> `_build-server.yml`;
+  # a human-pushed `server-v*` tag no longer runs anything in this repo.
   push:
     branches: [main]
     paths:

--- a/scripts/ci-cd/build-selfhost-qualification-candidates.mjs
+++ b/scripts/ci-cd/build-selfhost-qualification-candidates.mjs
@@ -5,7 +5,7 @@
 //   allocate the controller-local ports the renderer/AnyHarness use
 //   -> build the candidate Server image for the BOX arch and docker-save it
 //   -> build the release-shaped proliferate-deploy.tar.gz + its SHA256SUMS
-//      EXACTLY the way server-ci.yml `self-hosted-release-assets` builds them
+//      EXACTLY the way `_build-server.yml`'s `self-hosted-release-assets` builds them
 //   -> for the arm64 CFN posture, build the exact aarch64 musl runtime archive
 //      and add it to that same SHA256SUMS (the shipped template consumes it
 //      through RuntimeBinaryUrl/RuntimeBinaryChecksumUrl overrides)
@@ -177,7 +177,7 @@ export function buildServerImageArchive({ outputPath, version, platform, exec = 
 
 /**
  * Builds `proliferate-deploy.tar.gz` + `self-hosted-assets.SHA256SUMS` EXACTLY
- * the way `server-ci.yml self-hosted-release-assets` builds the release bundle:
+ * the way `_build-server.yml self-hosted-release-assets` builds the release bundle:
  * `cp -R server/deploy/. proliferate-deploy/`, drop the CI-only trees and
  * host-local progress file, write `VERSION`, then a reproducible root-owned tar
  * and a bare-name checksum. This is never reconstructed ad-hoc from loose
@@ -200,17 +200,17 @@ export function buildSelfHostDeployBundle({
     log(`cp -R ${deployDir}/. ${stageDir}/`);
     exec("cp", ["-R", `${deployDir}/.`, `${stageDir}/`]);
     // smoke/ and tests/ are CI-only; the operator bundle ships just the scripts,
-    // compose, and config the running stack needs (server-ci parity).
+    // compose, and config the running stack needs (release-bundle parity).
     exec("rm", ["-rf", path.join(stageDir, "smoke")]);
     exec("rm", ["-rf", path.join(stageDir, "tests")]);
     exec("rm", ["-f", path.join(stageDir, ".bootstrap-progress.log")]);
     writeFileSync(path.join(stageDir, "VERSION"), `${version}\n`);
-    // Archive as root:root, numeric owner (server-ci parity) so a root
+    // Archive as root:root, numeric owner (release-bundle parity) so a root
     // extraction on the box does not hand ownership to the builder's uid.
     log(`tar czf ${bundleOutputPath} --owner=0 --group=0 --numeric-owner -C ${bundleRoot} proliferate-deploy`);
     // COPYFILE_DISABLE=1 stops macOS bsdtar from injecting `._*` AppleDouble
     // entries into the archive (harmless/ignored on Linux). Without it the
-    // qualification bundle diverges from the Linux server-ci release bundle and
+    // qualification bundle diverges from the Linux release bundle and
     // extracts junk `._Caddyfile`/`._bootstrap.sh` files onto the box.
     exec(
       "tar",

--- a/scripts/ci-cd/build-selfhost-qualification-candidates.test.mjs
+++ b/scripts/ci-cd/build-selfhost-qualification-candidates.test.mjs
@@ -101,7 +101,7 @@ test("buildServerImageArchive uses buildx --load for the box platform and docker
   }
 });
 
-test("buildSelfHostDeployBundle mirrors server-ci (drop CI/runtime files, VERSION, root-owned tar, sibling SHA256SUMS)", () => {
+test("buildSelfHostDeployBundle mirrors the release bundle (drop CI/runtime files, VERSION, root-owned tar, sibling SHA256SUMS)", () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), "selfhost-bundle-"));
   try {
     const { exec, calls } = fakeExecFactory();
@@ -124,7 +124,7 @@ test("buildSelfHostDeployBundle mirrors server-ci (drop CI/runtime files, VERSIO
     assert.ok(rmTargets.some((t) => t.endsWith("/smoke")));
     assert.ok(rmTargets.some((t) => t.endsWith("/tests")));
     assert.ok(rmTargets.some((t) => t.endsWith("/.bootstrap-progress.log")));
-    // Reproducible root-owned archive (server-ci parity).
+    // Reproducible root-owned archive (release-bundle parity).
     const tarCall = calls.find((c) => c.command === "tar");
     assert.ok(tarCall.args.includes("--owner=0"));
     assert.ok(tarCall.args.includes("--group=0"));

--- a/scripts/ci-cd/detect-deploy-surfaces.mjs
+++ b/scripts/ci-cd/detect-deploy-surfaces.mjs
@@ -120,6 +120,10 @@ export function classifyFile(path) {
     matches(path, ["server", "catalogs"]) ||
     path === ".dockerignore" ||
     path === ".github/workflows/server-ci.yml" ||
+    // The release-time image/asset build for this surface. Split out of
+    // server-ci.yml so a release does not re-run the suite the SHA already
+    // passed to reach main; it classifies the same way its parent did.
+    path === ".github/workflows/_build-server.yml" ||
     path === "scripts/validate-agent-catalog.mjs"
   ) {
     touched.add("server");

--- a/scripts/ci-cd/server-release-build-separation.test.mjs
+++ b/scripts/ci-cd/server-release-build-separation.test.mjs
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+// Tests gate the PR -> main transition. The main -> production transition
+// builds artifacts and deploys them; it does not re-test. Release run
+// 32450223908 spent 5m17s of its critical path re-running lint, test-unit, and
+// three test-integration shards on a head that had already passed the identical
+// suite as `server-ci-ok` on its way into main. `_build-server.yml` is the
+// separation: it is the release build for the server surface with no test lane
+// in it, and this file is what keeps a test lane from creeping back in.
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const workflowDir = path.join(repoRoot, ".github/workflows");
+
+function read(name) {
+  return readFileSync(path.join(workflowDir, name), "utf8");
+}
+
+const buildServer = read("_build-server.yml");
+const serverCi = read("server-ci.yml");
+const release = read("release.yml");
+
+// Splits a workflow's `jobs:` mapping into { name -> body } without a YAML
+// dependency. A top-level job header is the only `^  <name>:$` line inside the
+// jobs block; everything until the next such line is that job's body.
+function jobs(source, name) {
+  const start = source.indexOf("\njobs:\n");
+  assert.notEqual(start, -1, `${name}: no jobs: block`);
+  const block = source.slice(start);
+  const headers = [...block.matchAll(/^ {2}([A-Za-z][A-Za-z0-9_-]*):$/gm)];
+  assert.ok(headers.length > 0, `${name}: parsed zero jobs`);
+  return new Map(
+    headers.map((match, index) => {
+      const bodyStart = match.index + match[0].length;
+      const bodyEnd = index + 1 < headers.length ? headers[index + 1].index : block.length;
+      return [match[1], block.slice(bodyStart, bodyEnd)];
+    }),
+  );
+}
+
+// The literal publish gate both release jobs carry. Kept verbatim from
+// server-ci.yml so a `server-v` tag-triggered caller keeps identical semantics.
+const PUBLISH_GATE =
+  "if: (startsWith(github.ref, 'refs/tags/server-v')) || " +
+  "(inputs.publish == true && inputs.dry_run != true)";
+
+test("the release build brick carries no lint or test lane", () => {
+  const buildJobs = jobs(buildServer, "_build-server.yml");
+
+  // Pinned, not merely "no test job": a renamed suite must trip this too.
+  assert.deepEqual([...buildJobs.keys()], ["docker", "self-hosted-release-assets"]);
+
+  for (const [name, body] of buildJobs) {
+    assert.doesNotMatch(
+      body,
+      /\b(pytest|ruff|mypy|check_mypy_baseline|vitest|cargo test)\b/,
+      `${name}: the release build must not run a test or lint suite. ` +
+        `Tests gate PR -> main; this SHA is already on main.`,
+    );
+    assert.doesNotMatch(
+      body,
+      /needs:.*\b(lint|test-unit|test-integration)\b/,
+      `${name}: must not depend on a validation lane`,
+    );
+  }
+
+  // The rationale is load-bearing documentation, not decoration: it is the only
+  // place that explains why re-adding a test job here is the wrong fix.
+  assert.match(buildServer, /THERE ARE DELIBERATELY NO TEST OR LINT JOBS HERE\./);
+  assert.match(buildServer, /PR -> main transition/);
+  assert.match(buildServer, /server-ci-ok/);
+});
+
+test("the release build brick is reusable-only, like the other lane bricks", () => {
+  const triggers = buildServer.slice(
+    buildServer.indexOf("\non:"),
+    buildServer.indexOf("\ndefaults:"),
+  );
+
+  assert.match(triggers, /^  workflow_call:$/m);
+  assert.doesNotMatch(triggers, /^  push:$/m);
+  assert.doesNotMatch(triggers, /^  pull_request:$/m);
+  assert.doesNotMatch(triggers, /^  schedule:$/m);
+  assert.doesNotMatch(triggers, /^  workflow_dispatch:$/m);
+});
+
+test("release.yml builds the server through the brick, never through Server CI", () => {
+  const releaseJobs = jobs(release, "release.yml");
+  const server = releaseJobs.get("release-server");
+  assert.ok(server, "release.yml must still have a release-server job");
+
+  assert.match(server, /uses: \.\/\.github\/workflows\/_build-server\.yml/);
+  assert.doesNotMatch(
+    release,
+    /uses: \.\/\.github\/workflows\/server-ci\.yml/,
+    "a production release must not re-run the PR gate it already passed",
+  );
+
+  // Permissions the brick's jobs need, declared at the caller.
+  assert.match(server, /^ {6}contents: write$/m);
+  assert.match(server, /^ {6}packages: write$/m);
+  assert.match(server, /^ {4}secrets: inherit$/m);
+});
+
+test("every input release.yml passes is one the brick declares, and vice versa", () => {
+  // A reusable call with an undeclared input is a hard workflow error at
+  // dispatch time, and a required input the caller drops is the same. This is
+  // the wiring proof a dry run cannot give us, because a dry run skips this job.
+  const declared = [
+    ...buildServer
+      .slice(buildServer.indexOf("  workflow_call:"), buildServer.indexOf("\ndefaults:"))
+      .matchAll(/^ {6}([a-z_]+):$/gm),
+  ].map((match) => match[1]);
+  assert.deepEqual(declared.sort(), ["dry_run", "git_sha", "publish", "version"]);
+
+  const server = jobs(release, "release.yml").get("release-server");
+  const withBlock = server.slice(server.indexOf("    with:"), server.indexOf("    secrets:"));
+  const passed = [...withBlock.matchAll(/^ {6}([a-z_]+):/gm)].map((match) => match[1]);
+  assert.deepEqual(passed.sort(), ["dry_run", "git_sha", "publish", "version"]);
+
+  assert.match(withBlock, /git_sha: \$\{\{ needs\.prepare\.outputs\.head_sha \}\}/);
+  assert.match(withBlock, /version: \$\{\{ needs\.prepare\.outputs\.server_version \}\}/);
+  assert.match(withBlock, /dry_run: false/);
+  assert.match(withBlock, /publish: true/);
+});
+
+test("the brick preserves the publish gate, image tags, and release tag semantics", () => {
+  const buildJobs = jobs(buildServer, "_build-server.yml");
+
+  for (const [name, body] of buildJobs) {
+    assert.ok(body.includes(PUBLISH_GATE), `${name}: publish gate changed`);
+  }
+
+  // self-hosted-release-assets consumes the image build, and nothing else.
+  assert.match(buildJobs.get("self-hosted-release-assets"), /^ {4}needs: \[docker\]$/m);
+
+  // Immutable version tag plus the rolling :stable tag the self-host compose
+  // bundle defaults to, for both the server and the LiteLLM wrapper.
+  const docker = buildJobs.get("docker");
+  assert.match(docker, /TAGS\+=\("\$\{GHCR_IMAGE\}:\$\{VERSION\}" "\$\{GHCR_IMAGE\}:stable"\)/);
+  assert.match(
+    docker,
+    /LITELLM_TAGS\+=\("\$\{LITELLM_IMAGE\}:\$\{VERSION\}" "\$\{LITELLM_IMAGE\}:stable"\)/,
+  );
+  assert.match(docker, /file: server\/Dockerfile/);
+  assert.match(docker, /file: server\/litellm\/Dockerfile/);
+
+  // The server-v tag is minted by the publish path only, and never moved onto a
+  // different commit than the one being released.
+  const assets = buildJobs.get("self-hosted-release-assets");
+  const tagStep = assets.slice(
+    assets.indexOf("- name: Ensure server release tag exists"),
+    assets.indexOf("- name: Publish self-hosted release assets"),
+  );
+  assert.notEqual(tagStep, "", "the release tag step must survive the move");
+  assert.match(tagStep, /if: inputs\.publish == true && inputs\.dry_run != true/);
+  assert.match(tagStep, /RELEASE_TAG: \$\{\{ format\('server-v\{0\}', inputs\.version\) \}\}/);
+  assert.match(tagStep, /already exists at \$existing_target/);
+});
+
+test("Server CI is now a gate only and publishes nothing", () => {
+  const ciJobs = jobs(serverCi, "server-ci.yml");
+
+  assert.deepEqual(
+    [...ciJobs.keys()],
+    ["changes", "lint", "test-unit", "test-integration", "server-ci-ok"],
+  );
+  assert.doesNotMatch(serverCi, /docker\/build-push-action/);
+  assert.doesNotMatch(serverCi, /softprops\/action-gh-release/);
+  assert.doesNotMatch(serverCi, /packages: write/);
+  // No publishing inputs left on a workflow that cannot publish.
+  assert.doesNotMatch(serverCi, /^ {6}(publish|dry_run|version):$/m);
+});
+
+test("server-ci-ok still rolls up every non-release lane in its own file", () => {
+  // Mirrors the drift guard's own ruby: a job is exempt from the rollup only by
+  // carrying the server-v release gate, never by name. Nothing is exempt today,
+  // so the rollup must cover every job in the file except itself.
+  const ciJobs = jobs(serverCi, "server-ci.yml");
+  const exempt = [...ciJobs]
+    .filter(([, body]) => /^ {4}if:.*refs\/tags\/server-v/m.test(body))
+    .map(([name]) => name);
+  assert.deepEqual(exempt, []);
+
+  const rollup = ciJobs.get("server-ci-ok");
+  const needs = [...rollup.matchAll(/^ {6}- ([a-z-]+)$/gm)].map((match) => match[1]);
+  assert.deepEqual(
+    needs.sort(),
+    [...ciJobs.keys()].filter((name) => name !== "server-ci-ok").sort(),
+  );
+
+  // The gating contract itself: always-run, and the required check keeps its
+  // name so branch protection keeps resolving it.
+  assert.match(rollup, /^ {4}name: server-ci-ok$/m);
+  assert.match(rollup, /^ {4}if: always\(\)$/m);
+  for (const [name, body] of ciJobs) {
+    if (name === "changes") continue;
+    assert.match(body, /^ {4}if: always\(\)$/m, `${name}: lane must not become skippable`);
+  }
+});
+
+test("production can still only ship a commit that reached main", () => {
+  // The whole separation rests on this: if a release could build a head that
+  // never landed on main, dropping the test lane would drop the only gate.
+  const prepare = jobs(release, "release.yml").get("prepare");
+  assert.match(prepare, /git merge-base --is-ancestor "\$head_sha" refs\/remotes\/origin\/main/);
+});

--- a/scripts/ci-cd/server-release-build-separation.test.mjs
+++ b/scripts/ci-cd/server-release-build-separation.test.mjs
@@ -42,7 +42,10 @@ function jobs(source, name) {
 }
 
 // The literal publish gate both release jobs carry. Kept verbatim from
-// server-ci.yml so a `server-v` tag-triggered caller keeps identical semantics.
+// server-ci.yml. Its `server-v` tag-push leg is currently unreachable (no
+// caller triggers this workflow from a tag push today) and is retained
+// unchanged only to stay byte-comparable with server-ci.yml and to support a
+// possible future tag-triggered caller.
 const PUBLISH_GATE =
   "if: (startsWith(github.ref, 'refs/tags/server-v')) || " +
   "(inputs.publish == true && inputs.dry_run != true)";

--- a/specs/codebase/systems/engineering/delivery/README.md
+++ b/specs/codebase/systems/engineering/delivery/README.md
@@ -215,10 +215,11 @@ Each checked-in workflow appears exactly once below. Trigger posture describes
 how the file can run; it does not imply that the workflow is a merge or release
 gate.
 
-### Reusable deploy lanes
+### Reusable build and deploy lanes
 
 | Workflow | Trigger and posture | Role |
 | --- | --- | --- |
+| `_build-server.yml` | Reusable only | Build and publish the server and LiteLLM GHCR images and the self-hosted release assets for one already-gated commit, and mint its `server-v` tag. Carries no lint or test job: tests gate the PR to `main` transition, and this lane only ever runs on a commit that already reached `main`. |
 | `_deploy-desktop.yml` | Reusable only | Validate/build Desktop for staging or call the Desktop publisher for production. |
 | `_deploy-litellm.yml` | Reusable only | Build and roll the LiteLLM ECS service when its environment switch is enabled. |
 | `_deploy-server.yml` | Reusable only | Build the exact-SHA server image, migrate, conditionally roll the Celery worker and Beat before the API, roll the API, and verify health. API, worker, and Beat are all pinned to the one candidate image by its **immutable `repo@sha256:` digest** (resolved from the build/push output), never a mutable tag, so all three planes run the byte-identical image and a later tag move cannot change what a rolled service runs. The rendered task enables strict release identity, strips inherited stale runtime-identity variables, preserves the support-feed secret, and explicitly authors the API's checked-in environment-bound Redis and E2B-key field references after account, region, secret-identity, DNS-safe Redis, and nonempty-key preflights. The conditional background re-image authors the same exact key projection plus the reviewed template, and asserts the full contract before and after registration. |
@@ -239,13 +240,11 @@ gate.
 | `release-e2e-selfhost.yml` | Scheduled, manual, or reusable | Run self-host artifact-chain and optional provisioning qualification. Tier 4 and self-host provisioning use separate non-cancelling job groups; no current release coordinator calls it. |
 | `release-e2e.yml` | Scheduled or manual | Run live Tier 3 release qualification; it is not a per-PR merge gate. Local, staging, Tier 2, managed-cloud, and self-host use independent non-cancelling job groups, so unrelated worlds may overlap while same-world runs do not. These groups do not promise FIFO ordering. |
 | `self-host-smoke.yml` | Pull request, push to `main`, or manual | Smoke the production Compose path when relevant paths change. Branch-protection status is not encoded here. |
-| `server-ci.yml` | Relevant push/PR, `server-v*` tag, manual, or reusable | Validate/package the server and publish self-host images/assets when invoked as a release. |
+| `server-ci.yml` | Relevant push/PR, manual, or reusable | Validate the server. It is a gate, not a publisher: the release image and asset build lives in `_build-server.yml`. |
 
 Server CI's shrink-only mypy census compares a pull request with its base SHA
 and a push with the event's pre-push SHA. Manual and reusable invocations must
-supply an explicit comparison SHA; the release coordinator passes the base
-selected by its prepare job. A new release tag uses its source commit's
-parent because that source commit already passed the `main` push gate.
+supply an explicit comparison SHA.
 
 ### Hosted deployment and release coordinators
 
@@ -348,10 +347,14 @@ strictly stronger, and a per-lane name is a name that can rot. Because a
 lane never requires a branch-protection edit.
 
 Excluded on purpose: `intent-tests (provisional)` and `intent-billing
-(provisional)` are `continue-on-error` while the harness earns trust;
-`docker` and `self-hosted-release-assets` are release-only jobs that skip on
-every pull request, and `server-ci-ok` exempts them by detecting their
-`server-v` tag gate rather than by name; the Vercel checks are third-party.
+(provisional)` are `continue-on-error` while the harness earns trust; the Vercel
+checks are third-party. `docker` and `self-hosted-release-assets` used to be
+excluded as release-only jobs inside Server CI; they now live in
+`_build-server.yml` and are outside the rollup's file entirely. Server CI's
+drift guard still derives a release-only exemption from a job's `server-v` tag
+gate rather than by name, so a future release-gated job cannot silently join or
+leave the rollup, but the exempt set is empty today and every job in the file is
+covered.
 
 Server CI carries no `on.pull_request.paths` filter, because a path-skipped
 workflow never reports a conclusion at all and a required check pointing into it

--- a/specs/codebase/systems/engineering/issue-lifecycle/support-loop.md
+++ b/specs/codebase/systems/engineering/issue-lifecycle/support-loop.md
@@ -123,7 +123,7 @@ the emitting artifact's version and build SHA.
 
 Every production build path receives those tracked values explicitly. In
 particular, `release-runtime.yml`, `build-template.mjs`,
-`release-cloud-template.yml`, `release-desktop.yml`, and `server-ci.yml`'s
+`release-cloud-template.yml`, `release-desktop.yml`, and `_build-server.yml`'s
 `self-hosted-release-assets` path all use the tracked runtime version and
 current build SHA for AnyHarness, worker, or supervisor. A no-version E2B hotfix
 keeps the tracked semver and changes the SHA, but it is lane-scoped operational


### PR DESCRIPTION
## The redundancy

Release run [32450223908](https://github.com/proliferate-ai/proliferate/actions/runs/32450223908) re-ran the entire server test suite on a `main` SHA that had already passed the identical suite as `server-ci-ok` on its way into `main`.

| `release-server` job | started | finished |
| --- | --- | --- |
| `Detect server-relevant changes` | 05:21:42 | 05:21:53 |
| `lint` | 05:21:55 | 05:22:56 |
| `test-unit` | 05:21:55 | 05:25:04 |
| `test-integration (1..3)` | 05:21:55 | **05:27:12** |
| `docker` | 05:27:16 | 05:30:34 |
| `self-hosted-release-assets` | 05:30:37 | 05:42:40 |

`docker` could not start until 05:27:16 because it declared `needs: [lint, test-unit, test-integration]`. That is **5m34s** of wall clock on the critical path of the release, spent re-proving what branch protection had already proven.

## The ruling

Tests gate the `PR -> main` transition. The `main -> production` transition builds artifacts and deploys them; it does not re-test. (Pablo, 2026-08-20, reaffirmed 08-21.)

The safety invariant behind that: production can only ever ship a commit that reached `main`. `release.yml`'s `prepare` job already enforces it directly (`git merge-base --is-ancestor "$head_sha" refs/remotes/origin/main`), and any such commit necessarily has a green `server-ci-ok` — the required rollup covering `lint`, `test-unit`, and the three `test-integration` shards.

## What moved where

**New: `.github/workflows/_build-server.yml`** (reusable-only, matching the `_deploy-*.yml` brick convention). It contains the `docker` and `self-hosted-release-assets` jobs and nothing else, with a header comment stating that tests are intentionally absent because the SHA already passed the PR gate to reach `main`, per the delivery spec's state machine.

The two job bodies are a **byte-identical move**. `diff` of the extracted range against `HEAD:server-ci.yml` lines 542-783 reports exactly three hunks:

```
< needs: [lint, test-unit, test-integration]          (dropped from docker)
< needs: [lint, test-unit, test-integration, docker]  ->  needs: [docker]
< two comment lines rewritten to say "verbatim from server-ci.yml"
```

Everything else is unchanged: the same `if: (startsWith(github.ref, 'refs/tags/server-v')) || (inputs.publish == true && inputs.dry_run != true)` gate on both jobs, the same per-job `permissions` (`contents: read` + `packages: write` on `docker`, `contents: write` on the assets job), the same `defaults.run.working-directory: server` plus every per-step `working-directory: .` override, the same `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env, the same `:${VERSION}` + `:stable` tag pair for both the server and LiteLLM images, the same version-pin build args, the same `server-v` tag-creation step gated on `inputs.publish == true && inputs.dry_run != true` with its "tag already exists at a different target" refusal, and the same seven published assets plus `SHA256SUMS`.

**`release.yml`**: `release-server` now does `uses: ./.github/workflows/_build-server.yml`. It drops `comparison_sha` (a mypy-baseline input the build brick has no use for) and keeps `git_sha`, `version`, `dry_run: false`, `publish: true`, `secrets: inherit`, and its `contents: write` + `packages: write` permissions. Nothing else in the file changed.

**`server-ci.yml`**: the `docker` and `self-hosted-release-assets` jobs are **deleted, not delegated**. Reasons:

- Nothing but `release.yml` ever called this workflow's `workflow_call` entrypoint, so the release path is the only path those jobs ever ran on.
- On `pull_request` they were always `skipped` by their own tag/publish gate, so the PR gate never used them.
- The `server-v*` tag-push path that nominally reached them **was not inert** — a reviewer correctly caught an earlier, false version of this bullet. Two corrections: (1) GitHub does not evaluate `paths:` filters on tag pushes at all (they only apply to branch pushes), so the `paths:` list alongside `tags:` never suppressed a tag-triggered run here. (2) `gh run list --workflow server-ci.yml --event push --limit 60` only reaches back to 2026-07-09; paginating the full history shows three tag-triggered runs — `server-v0.1.1`/`0.1.2`/`0.1.3` (2026-05-29, runs [26621290094](https://github.com/proliferate-ai/proliferate/actions/runs/26621290094)/[26621446218](https://github.com/proliferate-ai/proliferate/actions/runs/26621446218)/[26622403422](https://github.com/proliferate-ai/proliferate/actions/runs/26622403422)), all human-pushed. `server-v0.4.4` through `server-v0.4.9` produced no runs for an unrelated reason: those tags are created *inside* a workflow via `git push origin "refs/tags/$RELEASE_TAG"` using the default `GITHUB_TOKEN`, and `GITHUB_TOKEN` pushes do not trigger new workflow runs. So the trigger was dead for pipeline-minted tags but live for a human-pushed one.

Consequently, removing `tags: ["server-v*"]` from the push trigger **is a real behaviour change, not a no-op cleanup**: this PR deliberately retires the manual `server-v*` tag publish path. After this PR, `git push origin server-vX.Y.Z` run by a human triggers nothing — no Server CI run, no `docker` build, no `self-hosted-release-assets` publish. The now-unused `version` / `dry_run` / `publish` workflow_call inputs were removed for the same reason. `git_sha` and `comparison_sha` stay, so the workflow is still callable/dispatchable as a validation lane. See "Open ruling for Pablo" below for whether that retirement should stand as-is or get a thin replacement caller.

**`scripts/ci-cd/detect-deploy-surfaces.mjs`**: `.github/workflows/_build-server.yml` classifies as the `server` surface, exactly as `server-ci.yml` did, so editing the release build still selects the surface it builds.

**Comments** in `scripts/ci-cd/build-selfhost-qualification-candidates.mjs` (and one test name) named `server-ci.yml self-hosted-release-assets` as the thing the qualification bundle must byte-match. The job kept its name but changed file, so those now point at `_build-server.yml`. No behaviour change.

**Docs** (`specs/.../delivery/README.md`, `specs/.../support-loop.md`, and the required-checks comment block in `ci.yml`) updated in the same commit, as the required-checks comment in `ci.yml` demands.

## Proof the PR-gate behaviour is unchanged

The `server-ci-ok` contract from #2138 is untouched:

- Same required check name (`server-ci-ok`), same `if: always()`, same two steps in the same order with the same polarity.
- Same `needs:` list — `[changes, lint, test-unit, test-integration]` — **not edited**.
- Every lane keeps `if: always()` and its `!= 'false'` per-step gating with the `== 'false'` no-op step, so a non-server PR still reports a real green rather than `skipped`.
- Same `pull_request` trigger with no `paths:` filter.

The drift guard's ruby was **not modified**. Its exemption is derived (`spec["if"].to_s.include?("refs/tags/server-v")`), not enumerated, so removing the two release jobs needs no change to it. Running the guard's exact ruby against the new file:

```
Release-only jobs exempt from the rollup:
declared=["changes","lint","test-integration","test-unit"]
covered=["changes","lint","test-integration","test-unit"]
missing=   extra=   DRIFT GUARD: PASS
```

And the real thing, from this PR's own `server-ci-ok` run ([job 96692501470](https://github.com/proliferate-ai/proliferate/actions/runs/32455349248/job/96692501470), green in 4s):

```
Release-only jobs exempt from the rollup:
server-ci-ok covers all 4 non-release job(s) in server-ci.yml.
changes  success / lint  success / test-unit  success / test-integration  success
All 4 Server CI lanes concluded success.
```

The exempt set is now empty and the rollup covers every job in the file — strictly more coverage than before, with the derivation kept so a future release-gated job still cannot silently sit outside the rollup.

## Tests

`node --test scripts/ci-cd/*.test.mjs`: **217 pass, 0 fail** (was 209; the 8 new ones are the file below). No pre-existing assertion needed changing — `deploy-staging-trigger.test.mjs`'s dry-run assertion on `  release-server:` slices up to `    uses:`, which still resolves, and its `release.yml`-has-3-`environment:`-inputs count is unaffected.

New: `scripts/ci-cd/server-release-build-separation.test.mjs`

1. the release build brick carries no lint or test lane — job set pinned to `["docker", "self-hosted-release-assets"]`, no `pytest`/`ruff`/`mypy`/`vitest`/`cargo test` in any body, no `needs:` on a validation lane, and the rationale comment is present
2. the brick is reusable-only (`workflow_call` and nothing else)
3. `release.yml` builds the server through the brick, never through Server CI (and no `uses: ./.github/workflows/server-ci.yml` survives anywhere in `release.yml`)
4. every input `release.yml` passes is one the brick declares, and vice versa — the wiring proof a dry run cannot give, since a dry run skips this job
5. the brick preserves the publish gate, image tags, and release-tag semantics
6. Server CI is now a gate only — no `build-push-action`, no `action-gh-release`, no `packages: write`, no publish inputs
7. `server-ci-ok` still rolls up every non-release lane, mirroring the drift guard's own derivation, plus the always-run contract on every lane
8. production can still only ship a commit that reached main (`--is-ancestor` guard intact)

### Negative control

Each mutation applied to a clean tree, suite run, tree restored:

| Mutation | Result |
| --- | --- |
| point `release-server` back at `server-ci.yml` | `not ok 3 - release.yml builds the server through the brick, never through Server CI` |
| re-add `needs: [lint, test-unit, test-integration]` to the brick's `docker` job | `not ok 1 - the release build brick carries no lint or test lane` |
| drop `version:` from the caller's `with:` | `not ok 4 - every input release.yml passes is one the brick declares, and vice versa` |
| drop `test-unit` from the `server-ci-ok` rollup | `not ok 7 - server-ci-ok still rolls up every non-release lane in its own file` |
| add a `pytest -q` step to the release build | `not ok 1 - the release build brick carries no lint or test lane` |

Baseline before and after every mutation: `# pass 8 # fail 0`.

Also run locally: `python3 scripts/check_docs.py` (pass, 235 files), `python3 scripts/check_max_lines.py` (pass), `python3 scripts/lint_records.py` (pass), `python3 scripts/check_workflow_managed_boundaries.py` (pass), and a `ruby -ryaml` parse of all five touched/adjacent workflow files.

## deploy-staging.yml: not switched, and nothing to switch

`deploy-staging.yml` never calls `server-ci.yml` as a build. Its only reference is a `gh run list --workflow server-ci.yml --commit "$head_sha"` poll in `Wait for Server CI if present`, which waits for whatever Server CI run already exists for the head. Server CI still runs on every `main` push, so that poll finds the same run it finds today and its behaviour is byte-identical. No change, no follow-up owed.

## Open ruling for Pablo: manual tag publish path

This PR retires the ability to publish a server release by pushing a `server-v*` tag by hand (see the corrected bullet above — that path was live for a human-pushed tag, unlike the pipeline-minted `server-v0.4.x` tags, which never worked for an unrelated `GITHUB_TOKEN` reason). Two ways to resolve that:

- **(a) Accept the retirement.** Releases only ever flow through `release.yml` -> `_build-server.yml` going forward. Nobody has used the manual tag path since May 2026, so this may already be the de facto state; this PR just makes it the only state.
- **(b) Keep the escape hatch.** Follow-up PR adds a thin `on: push: tags: ["server-v*"]` caller of `_build-server.yml` (mirroring the `if:` gate it already carries) so a human-pushed tag still works as a publish path, independent of `release.yml`.

Either is defensible; this PR does not choose for you. Flagging it explicitly rather than letting the retirement happen silently.

## Validation

The standing wiring proof for `release.yml` is a `dry_run: true` dispatch. State plainly what that does and does not cover here:

- A dry run **skips** `release-server` entirely (`needs.prepare.outputs.dry_run != 'true'`), by design — the reusable build lanes have no cheap no-op switch, so a dry run has never exercised them. It therefore cannot prove this rewiring.
- The full proof is consequently: (a) the YAML parse of `_build-server.yml`, `server-ci.yml`, and `release.yml`; (b) the input-parity and gate-preservation assertions in the new test file, which is what stands in for the dispatch a dry run cannot make; (c) the drift-guard simulation above; and (d) the next real release, where `release-server / docker` should start within ~15s of `prepare` instead of after a 5.5-minute suite *in that lane*.
- A `skip_build` promote is unaffected: it skips `release-server` on the same condition and only walks the deploy lanes.
- Every PR in flight is unaffected: Server CI's `pull_request` trigger, lanes, and rollup are unchanged, so `server-ci-ok` keeps resolving under the same name with the same semantics. No branch-protection edit is required or implied by this PR.

Projected saving: **~5.5 minutes off the `release-server` lane** of every server release, and ~5 runner-job-minutes of lint/unit/3-shard-integration compute per release. That is lane-scoped, not necessarily run-critical-path: in run [32450223908](https://github.com/proliferate-ai/proliferate/actions/runs/32450223908), `release-desktop / build-desktop` ran until 06:44:43 and `publish-product-release` waited behind it, so on that specific release the run-level wall-clock saving would have been zero. The saving is real whenever `release-server` is on the critical path (no desktop build in the surface set, or desktop finishes first); it is a lane-cost reduction always, a run-time reduction situationally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

