### PR TITLE
fix(release): publish desktop updater from flat artifact layouts

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -703,7 +703,13 @@ jobs:
         with:
           path: all-artifacts
           pattern: desktop-*
-          merge-multiple: false
+          # merge-multiple keeps the extracted layout deterministic: with
+          # `false`, download-artifact@v8 nests each artifact in its own
+          # directory ONLY when two or more artifacts match — a single match
+          # (ARM-only, since Intel is paused) extracts flat and broke the
+          # 0.4.22 publish. Merged-flat is the one layout every artifact
+          # count produces.
+          merge-multiple: true
 
       - name: List artifacts
         run: find all-artifacts -type f | sort
@@ -743,7 +749,13 @@ jobs:
         with:
           path: all-artifacts
           pattern: desktop-*
-          merge-multiple: false
+          # merge-multiple keeps the extracted layout deterministic: with
+          # `false`, download-artifact@v8 nests each artifact in its own
+          # directory ONLY when two or more artifacts match — a single match
+          # (ARM-only, since Intel is paused) extracts flat and broke the
+          # 0.4.22 publish. Merged-flat is the one layout every artifact
+          # count produces.
+          merge-multiple: true
 
       - name: List artifacts
         run: find all-artifacts -type f | sort

--- a/scripts/ci-cd/generate-desktop-installer-manifest.test.mjs
+++ b/scripts/ci-cd/generate-desktop-installer-manifest.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const generator = path.join(repoRoot, "scripts/generate-desktop-installer-manifest.mjs");
+
+// download-artifact@v8 nests each artifact in a directory named after it only
+// when two or more artifacts match the download pattern; a single match
+// extracts flat, and merge-multiple: true (the release-desktop.yml publish
+// jobs) merges flat regardless of count. `flat` reproduces those layouts.
+// Intel (x86_64) desktop builds are paused 2026-08-20 (release-desktop.yml
+// build-desktop matrix); `armOnly` simulates that paused lane producing no
+// x86_64 installer.
+function writeInstallers(root, { armOnly = false, flat = false } = {}) {
+  const artifacts = path.join(root, "artifacts");
+  const fixtures = [
+    ["desktop-aarch64-apple-darwin", "Proliferate_aarch64.dmg"],
+    ["desktop-x86_64-apple-darwin", "Proliferate_x64.dmg"],
+  ].filter(([directory]) => !armOnly || directory === "desktop-aarch64-apple-darwin");
+
+  for (const [directory, installer] of fixtures) {
+    const target = flat ? artifacts : path.join(artifacts, directory);
+    fs.mkdirSync(target, { recursive: true });
+    fs.writeFileSync(path.join(target, installer), "dmg");
+  }
+
+  return artifacts;
+}
+
+function generateManifest(t, { armOnly = false, flat = false, empty = false } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "proliferate-installer-manifest-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const output = path.join(root, "installers.json");
+  const artifactsDir = empty
+    ? (() => {
+        const dir = path.join(root, "artifacts");
+        fs.mkdirSync(dir, { recursive: true });
+        return dir;
+      })()
+    : writeInstallers(root, { armOnly, flat });
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      generator,
+      "--version",
+      "1.2.3",
+      "--artifacts-dir",
+      artifactsDir,
+      "--base-url",
+      "https://downloads.proliferate.com/desktop/stable",
+      "--output",
+      output,
+    ],
+    { encoding: "utf8" },
+  );
+  return { output, result };
+}
+
+test("generates both downloads from the nested per-artifact layout", (t) => {
+  const { output, result } = generateManifest(t);
+
+  assert.equal(result.status, 0, result.stderr);
+  const manifest = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.equal(manifest.version, "1.2.3");
+  assert.deepEqual(Object.keys(manifest.downloads).sort(), ["darwin-aarch64", "darwin-x86_64"]);
+});
+
+test("generates an arm-only manifest from the flat single-artifact layout", (t) => {
+  // Regression companion to generate-updater-manifest.test.mjs: the 0.4.22
+  // publish failed because download-artifact@v8 extracted the single ARM
+  // artifact flat and the matchers required a per-artifact directory segment.
+  const { output, result } = generateManifest(t, { armOnly: true, flat: true });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stderr, /Skipping darwin-x86_64: no installer found \(optional platform\)\./);
+  const manifest = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.deepEqual(Object.keys(manifest.downloads), ["darwin-aarch64"]);
+  assert.equal(
+    manifest.downloads["darwin-aarch64"].url,
+    "https://downloads.proliferate.com/desktop/stable/Proliferate_aarch64.dmg",
+  );
+});
+
+test("generates both downloads from a merged flat layout", (t) => {
+  const { output, result } = generateManifest(t, { flat: true });
+
+  assert.equal(result.status, 0, result.stderr);
+  const manifest = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.deepEqual(Object.keys(manifest.downloads).sort(), ["darwin-aarch64", "darwin-x86_64"]);
+});
+
+test("fails when the required darwin-aarch64 installer is missing", (t) => {
+  const { output, result } = generateManifest(t, { empty: true });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Missing installer file for darwin-aarch64/);
+  assert.equal(fs.existsSync(output), false);
+});

--- a/scripts/ci-cd/generate-updater-manifest.test.mjs
+++ b/scripts/ci-cd/generate-updater-manifest.test.mjs
@@ -12,7 +12,11 @@ const generator = path.join(repoRoot, "scripts/generate-updater-manifest.mjs");
 // Intel (x86_64) desktop builds are paused 2026-08-20 (release-desktop.yml
 // build-desktop matrix); `armOnly` simulates that paused build producing no
 // x86_64 artifacts.
-function writeArtifacts(root, { armOnly = false } = {}) {
+// download-artifact@v8 nests each artifact in a directory named after it only
+// when two or more artifacts match the download pattern; a single match
+// extracts flat, and merge-multiple: true (the release-desktop.yml publish
+// jobs) merges flat regardless of count. `flat` reproduces those layouts.
+function writeArtifacts(root, { armOnly = false, flat = false } = {}) {
   const artifacts = path.join(root, "artifacts");
   const fixtures = [
     ["desktop-aarch64-apple-darwin", "Proliferate_aarch64.app.tar.gz"],
@@ -20,7 +24,7 @@ function writeArtifacts(root, { armOnly = false } = {}) {
   ].filter(([directory]) => !armOnly || directory === "desktop-aarch64-apple-darwin");
 
   for (const [directory, artifact] of fixtures) {
-    const target = path.join(artifacts, directory);
+    const target = flat ? artifacts : path.join(artifacts, directory);
     fs.mkdirSync(target, { recursive: true });
     fs.writeFileSync(path.join(target, artifact), "archive");
     fs.writeFileSync(path.join(target, `${artifact}.sig`), `signature-${directory}\n`);
@@ -29,7 +33,7 @@ function writeArtifacts(root, { armOnly = false } = {}) {
   return artifacts;
 }
 
-function generateManifest(t, notes, { armOnly = false } = {}) {
+function generateManifest(t, notes, { armOnly = false, flat = false } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "proliferate-updater-manifest-"));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
   const output = path.join(root, "latest.json");
@@ -38,7 +42,7 @@ function generateManifest(t, notes, { armOnly = false } = {}) {
     "--version",
     "1.2.3",
     "--artifacts-dir",
-    writeArtifacts(root, { armOnly }),
+    writeArtifacts(root, { armOnly, flat }),
     "--base-url",
     "https://downloads.proliferate.com/desktop/stable",
     "--output",
@@ -67,6 +71,37 @@ test("generates an arm-only manifest while Intel is paused", (t) => {
   assert.match(result.stderr, /Skipping darwin-x86_64: no artifacts found \(optional platform\)\./);
   const manifest = JSON.parse(fs.readFileSync(output, "utf8"));
   assert.deepEqual(Object.keys(manifest.platforms), ["darwin-aarch64"]);
+});
+
+test("generates an arm-only manifest from the flat single-artifact layout", (t) => {
+  // Regression: the 0.4.22 publish failed because download-artifact@v8
+  // extracted the single ARM artifact flat (no desktop-aarch64-apple-darwin/
+  // directory) and the matchers required that path segment.
+  const { output, result } = generateManifest(t, undefined, { armOnly: true, flat: true });
+
+  assert.equal(result.status, 0, result.stderr);
+  const manifest = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.deepEqual(Object.keys(manifest.platforms), ["darwin-aarch64"]);
+  assert.equal(
+    manifest.platforms["darwin-aarch64"].url,
+    "https://downloads.proliferate.com/desktop/stable/Proliferate_aarch64.app.tar.gz",
+  );
+  assert.equal(
+    manifest.platforms["darwin-aarch64"].signature,
+    "signature-desktop-aarch64-apple-darwin",
+  );
+});
+
+test("generates both platforms from a merged flat layout", (t) => {
+  const { output, result } = generateManifest(t, undefined, { flat: true });
+
+  assert.equal(result.status, 0, result.stderr);
+  const manifest = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.deepEqual(Object.keys(manifest.platforms).sort(), ["darwin-aarch64", "darwin-x86_64"]);
+  assert.equal(
+    manifest.platforms["darwin-x86_64"].url,
+    "https://downloads.proliferate.com/desktop/stable/Proliferate_x64.app.tar.gz",
+  );
 });
 
 test("omits notes when the release title is absent or blank", (t) => {

--- a/scripts/generate-desktop-installer-manifest.mjs
+++ b/scripts/generate-desktop-installer-manifest.mjs
@@ -25,10 +25,6 @@ function findFiles(dir, matcher) {
   return files;
 }
 
-function pathIncludes(relPath, segment) {
-  return relPath.split("/").includes(segment);
-}
-
 const args = parseArgs();
 const version = args.version;
 const artifactsDir = args["artifacts-dir"];
@@ -40,11 +36,13 @@ if (!version || !artifactsDir || !baseUrl || !output) {
   process.exit(1);
 }
 
+// Matchers test filenames only, never directory layout: download-artifact@v8
+// extracts a single matching artifact flat (no per-artifact directory), so a
+// path-segment requirement fails exactly when only the ARM artifact exists.
 const downloads = [
   {
     key: "darwin-aarch64",
     matcher: (relPath, name) =>
-      pathIncludes(relPath, "desktop-aarch64-apple-darwin") &&
       /(aarch64|arm64).*\.dmg$/i.test(name),
   },
   {
@@ -55,7 +53,6 @@ const downloads = [
     // a manifest-generation failure.
     optional: true,
     matcher: (relPath, name) =>
-      pathIncludes(relPath, "desktop-x86_64-apple-darwin") &&
       /(x64|x86_64).*\.dmg$/i.test(name),
   },
 ];

--- a/scripts/generate-updater-manifest.mjs
+++ b/scripts/generate-updater-manifest.mjs
@@ -25,10 +25,6 @@ function findFiles(dir, matcher) {
   return files;
 }
 
-function pathIncludes(relPath, segment) {
-  return relPath.split("/").includes(segment);
-}
-
 const args = parseArgs();
 const version = args.version;
 const artifactsDir = args["artifacts-dir"];
@@ -74,15 +70,18 @@ if (!version || !artifactsDir || !baseUrl || !output) {
   process.exit(1);
 }
 
-// Platform mapping: Tauri platform key -> artifact patterns
+// Platform mapping: Tauri platform key -> artifact filename patterns.
+// Matchers test filenames only, never directory layout: download-artifact@v8
+// nests each artifact in a directory named after it when several artifacts
+// match the pattern, but extracts FLAT when exactly one matches (or when
+// merge-multiple is set). Requiring a path segment here is what broke the
+// 0.4.22 publish after the paused Intel lane left a single artifact.
 const platforms = [
   {
     key: "darwin-aarch64",
     artifactMatcher: (relPath, name) =>
-      pathIncludes(relPath, "desktop-aarch64-apple-darwin") &&
       /(aarch64|arm64).*\.app\.tar\.gz$/i.test(name),
     sigMatcher: (relPath, name) =>
-      pathIncludes(relPath, "desktop-aarch64-apple-darwin") &&
       /(aarch64|arm64).*\.app\.tar\.gz\.sig$/i.test(name),
   },
   {
@@ -93,10 +92,8 @@ const platforms = [
     // artifact is not a manifest-generation failure.
     optional: true,
     artifactMatcher: (relPath, name) =>
-      pathIncludes(relPath, "desktop-x86_64-apple-darwin") &&
       /(x64|x86_64).*\.app\.tar\.gz$/i.test(name),
     sigMatcher: (relPath, name) =>
-      pathIncludes(relPath, "desktop-x86_64-apple-darwin") &&
       /(x64|x86_64).*\.app\.tar\.gz\.sig$/i.test(name),
   },
 ];


### PR DESCRIPTION
## Problem

The v0.4.22 desktop publish failed in `release-desktop / publish-updater` (run 32450223908, job 96692480347):

```
Manifest generation failed:
  - Missing signature file for darwin-aarch64
  - Missing artifact file for darwin-aarch64
```

…while the download step in the same job listed the files as present:

```
all-artifacts/Proliferate_0.4.22_aarch64.app.tar.gz
all-artifacts/Proliferate_0.4.22_aarch64.app.tar.gz.sig
all-artifacts/Proliferate_0.4.22_aarch64.dmg
```

Result: the 0.4.22 app is built/signed/notarized but downloads and auto-update still serve 0.4.21, and `publish-product-release` was skipped. Nothing was half-published — the failure happened before any S3 upload, and the immutable-manifest guard for `desktop/stable/0.4.22/latest.json` was never tripped.

## Root cause

`actions/download-artifact@v8` decides the extraction path per artifact ([src/download-artifact.ts @ 3e5f45b2](https://github.com/actions/download-artifact/blob/3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c/src/download-artifact.ts)):

```js
path: isSingleArtifactDownload || inputs.mergeMultiple || artifacts.length === 1
  ? resolvedPath                              // flat
  : path.join(resolvedPath, artifact.name)    // per-artifact directory
```

With `merge-multiple: false` and a pattern, you get per-artifact directories **only when 2+ artifacts match**. Every prior release had two desktop artifacts (aarch64 + x86_64), e.g. the 08-18 train (job 95839976547) downloaded into `all-artifacts/desktop-aarch64-apple-darwin/…` + `all-artifacts/desktop-x86_64-apple-darwin/…`. Tonight was the first release since the Intel lane was paused: exactly one artifact matched `desktop-*`, the layout flattened, and both manifest generators require a `desktop-<target>` path segment via `pathIncludes(...)` — so they found nothing.

## Fix

- **Deterministic layout**: `merge-multiple: true` on both `desktop-*` downloads (create-release + publish-updater). Merged-flat is the one layout every artifact count produces. create-release's `all-artifacts/**/*` glob already handled flat (it succeeded tonight).
- **Filename-only matching**: `generate-updater-manifest.mjs` and `generate-desktop-installer-manifest.mjs` drop the `pathIncludes` directory requirement; the aarch64/x64 filename regexes already disambiguate platforms and work under both layouts.

## Tests

- `generate-updater-manifest.test.mjs`: fixtures gain a `flat` layout; new cases for the flat single-artifact repro (tonight's failure) and the merged-flat two-platform layout.
- New `generate-desktop-installer-manifest.test.mjs` (the installer generator had no tests): nested, flat-arm-only, merged-flat, and missing-required-installer failure.
- `node --test` on both files: **12 pass / 0 fail**.
- **Negative control**: with the two generator scripts reverted to main, exactly the 4 new flat-layout tests fail (`not ok`), all 8 pre-existing tests still pass.

## After merge

Re-dispatch `release-desktop.yml` (publish path) to put 0.4.22 downloads + updater manifest + product release page live. The S3 guard permits it: `desktop/stable/0.4.22/latest.json` was never created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)