### PR TITLE
fix(desktop): launch deep-link drain aborts on first handler rejection (PRO-354)

### DIFF
--- a/apps/desktop/src/lib/access/tauri/deep-link.test.ts
+++ b/apps/desktop/src/lib/access/tauri/deep-link.test.ts
@@ -73,6 +73,32 @@ describe("deep-link raw source", () => {
     expect(receivedB).toEqual(["proliferate://live"])
   })
 
+  it("retries live-listener registration after a transient failure and delivers to both subscribers", async () => {
+    deepLinkMocks.getCurrent.mockResolvedValue(null)
+    let openUrlCallback: ((urls: string[]) => void) | undefined
+    deepLinkMocks.onOpenUrl
+      .mockRejectedValueOnce(new Error("no tauri"))
+      .mockImplementation(async (cb: (urls: string[]) => void) => {
+        openUrlCallback = cb
+        return () => {}
+      })
+
+    const { subscribeDeepLinkUrls } = await loadDeepLink()
+    const receivedA: string[] = []
+    const receivedB: string[] = []
+    subscribeDeepLinkUrls((url) => receivedA.push(url))
+    await vi.waitFor(() => expect(deepLinkMocks.onOpenUrl).toHaveBeenCalledTimes(1))
+
+    subscribeDeepLinkUrls((url) => receivedB.push(url))
+    await vi.waitFor(() => expect(deepLinkMocks.onOpenUrl).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(openUrlCallback).toBeDefined())
+
+    openUrlCallback?.(["proliferate://live"])
+
+    expect(receivedA).toEqual(["proliferate://live"])
+    expect(receivedB).toEqual(["proliferate://live"])
+  })
+
   it("is race-safe when unsubscribed before native registration and the initial snapshot settle", async () => {
     const current = deferred<string[]>()
     deepLinkMocks.getCurrent.mockReturnValue(current.promise)
@@ -217,6 +243,38 @@ describe("deep-link raw source", () => {
         expect(handler).toHaveBeenLastCalledWith("proliferate://live")
 
         // Give any escaped rejection two macrotask turns to reach the hook.
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        expect(unhandled).toEqual([])
+      } finally {
+        process.off("unhandledRejection", onUnhandled)
+      }
+    })
+
+    it("drains every queued url when an earlier handler rejects", async () => {
+      deepLinkMocks.getCurrent.mockResolvedValue([
+        "proliferate://auth-callback",
+        "proliferate://workspace",
+      ])
+      deepLinkMocks.onOpenUrl.mockImplementation(async () => () => {})
+
+      const unhandled: unknown[] = []
+      const onUnhandled = (reason: unknown) => {
+        unhandled.push(reason)
+      }
+      process.on("unhandledRejection", onUnhandled)
+      try {
+        const { ensureDeepLinkBridge } = await loadDeepLink()
+        const handler = vi
+          .fn()
+          .mockRejectedValueOnce(new Error("first failed"))
+          .mockResolvedValueOnce(true)
+        await expect(ensureDeepLinkBridge(handler)).resolves.toBeUndefined()
+
+        expect(handler).toHaveBeenCalledTimes(2)
+        expect(handler).toHaveBeenNthCalledWith(1, "proliferate://auth-callback")
+        expect(handler).toHaveBeenNthCalledWith(2, "proliferate://workspace")
+
         await new Promise((resolve) => setTimeout(resolve, 0))
         await new Promise((resolve) => setTimeout(resolve, 0))
         expect(unhandled).toEqual([])

--- a/apps/desktop/src/lib/access/tauri/deep-link.ts
+++ b/apps/desktop/src/lib/access/tauri/deep-link.ts
@@ -16,12 +16,13 @@ interface DeepLinkSubscription {
 const subscriptions = new Set<DeepLinkSubscription>()
 
 // At most one native live listener is ever registered; this memoizes the
-// in-flight/settled registration so concurrent subscribers share it.
+// in-flight/successful registration so concurrent subscribers share it. A
+// rejected attempt resets the memo so the next subscriber retries.
 let liveListenerPromise: Promise<void> | null = null
 
 function ensureLiveListener(): Promise<void> {
   if (!liveListenerPromise) {
-    liveListenerPromise = Promise.resolve()
+    const attempt = Promise.resolve()
       .then(() =>
         onOpenUrl((urls) => {
           for (const url of urls) {
@@ -34,6 +35,14 @@ function ensureLiveListener(): Promise<void> {
         }),
       )
       .then(() => undefined)
+    attempt.catch(() => {
+      // A transient registration failure must not be cached for the process;
+      // reset so the next subscriber retries.
+      if (liveListenerPromise === attempt) {
+        liveListenerPromise = null
+      }
+    })
+    liveListenerPromise = attempt
   }
   return liveListenerPromise
 }
@@ -109,13 +118,17 @@ export function ensureDeepLinkBridge(handler: DeepLinkUrlHandler): Promise<void>
   if (!deepLinkBridgePromise) {
     deepLinkBridgePromise = (async () => {
       // Drain the initial snapshot exactly like the pre-multiplex bridge: each
-      // URL is awaited in order and a handler rejection is contained here rather
-      // than escaping as an unhandled rejection.
+      // URL is awaited in order and rejections are contained per-URL so a single
+      // failing handler cannot drop the rest of the queued urls.
       try {
         const currentUrls = await getCurrent()
         if (currentUrls?.length) {
           for (const url of currentUrls) {
-            await handler(url)
+            try {
+              await handler(url)
+            } catch {
+              // A failing handler must not drop the remaining queued urls.
+            }
           }
         }
       } catch {


### PR DESCRIPTION
Fixes PRO-354

## Problem

Two related defects in [`apps/desktop/src/lib/access/tauri/deep-link.ts`](https://github.com/proliferate-ai/proliferate/blob/main/apps/desktop/src/lib/access/tauri/deep-link.ts):

- **Snapshot drain aborts on first rejection.** `ensureDeepLinkBridge` drained the launch `getCurrent()` snapshot with `await handler(url)` inside a single try/catch, so the first handler rejection aborted the loop. Launching with two queued deep links (an auth callback that fails its exchange, followed by a `workspaces/:id` URL) dropped the second one silently — the user was never routed.
- **Rejected live-listener registration cached for the process.** `liveListenerPromise` memoized the `onOpenUrl` registration but never reset on rejection, so a transient plugin-init failure permanently disabled native live deep-link forwarding for the session.

## Fix

- Per-URL try/catch in the drain loop: one failing handler no longer drops the remaining queued URLs, and rejections are still contained (no unhandled rejections).
- `ensureLiveListener` now uses success-only caching: a rejected registration attempt resets the memo (identity-guarded) so the next subscriber retries — matching the `getPreferencesStore` pattern in `store.ts`.

## Testing

Two regression tests added to `deep-link.test.ts`:
- drain continues past a rejecting handler and delivers every queued URL in order, with no escaped unhandled rejection;
- `onOpenUrl` registration retries after a transient failure and live URLs reach all subscribers.

`pnpm exec tsc --noEmit` clean and full desktop suite green (47 files, 409 tests) in `apps/desktop`.

## Observability

No telemetry changes; failures remain intentionally contained in this legacy adapter, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)