### PR TITLE
fix(sessions): stop history replay at the first sequence hole (PRO-352)

### DIFF
--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-history-hydration.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-history-hydration.ts
@@ -252,7 +252,7 @@ export function useSessionHistoryHydration() {
 
         const storeStartedAt = performance.now();
         applyHistoryStateToStores(sessionId, currentSlot, {
-          events: replacementEvents,
+          events: nextState.events,
           transcript: nextState.transcript,
           reconcileEnvelopes: events,
         });
@@ -265,7 +265,7 @@ export function useSessionHistoryHydration() {
           recordHistoryStateCounts(
             operationId,
             "after",
-            replacementEvents,
+            nextState.events,
             nextState.transcript,
           );
         }
@@ -291,7 +291,7 @@ export function useSessionHistoryHydration() {
           sessionId,
           eventCount: events.length,
           prepended: true,
-          totalEventCount: replacementEvents.length,
+          totalEventCount: nextState.events.length,
           elapsedMs: Math.round(performance.now() - startedAt),
         });
         return events.length > 0;

--- a/apps/packages/product-client/src/lib/domain/sessions/stream/stream-state.test.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/stream/stream-state.test.ts
@@ -48,6 +48,57 @@ describe("session-stream-state", () => {
     });
   });
 
+  describe("replaySessionHistory", () => {
+    it("stops replay at the first hole and lets the live stream recover the tail", () => {
+      const state = replaySessionHistory("session-1", [
+        turnStarted(1),
+        assistantStarted(2, "assistant-1", "Hello"),
+        turnEnded(4),
+      ]);
+
+      expect(state.events.map((event) => event.seq)).toEqual([1, 2]);
+      expect(state.transcript.lastSeq).toBe(2);
+
+      const result = applyStreamEnvelope(state, turnEnded(3));
+
+      expect(result.status).toBe("applied");
+    });
+
+    it("does not treat a mid-stream replay start as a gap", () => {
+      const state = replaySessionHistory("session-1", [
+        turnStarted(6),
+        assistantStarted(7, "assistant-1", "Hello"),
+        assistantCompleted(8, "assistant-1", "Hello"),
+      ]);
+
+      expect(state.events.map((event) => event.seq)).toEqual([6, 7, 8]);
+      expect(state.transcript.lastSeq).toBe(8);
+    });
+
+    it("sorts unsorted input before replaying", () => {
+      const state = replaySessionHistory("session-1", [
+        turnStarted(2),
+        turnStarted(3),
+        turnStarted(1),
+      ]);
+
+      expect(state.events.map((event) => event.seq)).toEqual([1, 2, 3]);
+      expect(state.transcript.lastSeq).toBe(3);
+    });
+
+    it("skips duplicate seqs within input without breaking the run", () => {
+      const state = replaySessionHistory("session-1", [
+        turnStarted(1),
+        turnStarted(2),
+        turnStarted(2),
+        turnStarted(3),
+      ]);
+
+      expect(state.events.map((event) => event.seq)).toEqual([1, 2, 3]);
+      expect(state.transcript.lastSeq).toBe(3);
+    });
+  });
+
   it("ignores duplicate stream envelopes", () => {
     const state = replaySessionHistory("session-1", [turnStarted(1)]);
 

--- a/apps/packages/product-client/src/lib/domain/sessions/stream/stream-state.ts
+++ b/apps/packages/product-client/src/lib/domain/sessions/stream/stream-state.ts
@@ -31,12 +31,28 @@ export function replaySessionHistory(
   sessionId: string,
   events: SessionEventEnvelope[],
 ): SessionStreamState {
+  const sortedEvents = [...events].sort((a, b) => a.seq - b.seq);
+  const contiguousPrefix: SessionEventEnvelope[] = [];
+  let previousSeq: number | null = null;
+
+  for (const envelope of sortedEvents) {
+    // Break the run at the first hole so lastSeq never lands past missing events.
+    if (previousSeq != null && envelope.seq > previousSeq + 1) {
+      break;
+    }
+    if (previousSeq != null && envelope.seq <= previousSeq) {
+      continue;
+    }
+    contiguousPrefix.push(envelope);
+    previousSeq = envelope.seq;
+  }
+
   const transcript =
-    events.length > 0
-      ? reduceEvents(events, sessionId, { replayMode: true })
+    contiguousPrefix.length > 0
+      ? reduceEvents(contiguousPrefix, sessionId, { replayMode: true })
       : createTranscriptState(sessionId);
   return {
-    events: [...events],
+    events: contiguousPrefix,
     transcript,
   };
 }


### PR DESCRIPTION
Fixes PRO-352

## Problem

`replaySessionHistory` reduced whatever event list it was given; the SDK reducer sets `transcript.lastSeq` to the max seq present with no contiguity check. When a replace hydration returned a gapped list (e.g. seqs 6,7,9 with 8 missing), `lastSeq` landed past the hole. A later live event inside the hole (seq 8) satisfied `seq <= lastSeq`, was classified **duplicate**, and was dropped in `session-stream-flush-apply.ts` with no `gapEnvelope` raised — the event was lost forever with no repair.

The sibling paths already enforce contiguity: `appendHistoryTail` and `applyStreamEnvelopeBatch` both skip duplicates and stop at the first hole.

## Fix

- `replaySessionHistory` now mirrors that discipline: sort a copy by seq, replay only the leading contiguous run (first event anchors the run so turn-limited mid-stream fetches are not misclassified as holes), skip in-list duplicates, and break at the first hole. `lastSeq` never jumps past missing events, so a live event inside the hole applies (or raises a gap → disconnect → rehydrate) instead of being dropped as a duplicate.
- The `beforeSeq` (prepend) hydration branch now stores `nextState.events` instead of the raw merged `replacementEvents`, keeping the stored event list consistent with the transcript it was reduced from.

Scoped to the replay/contiguity path only; ingest-store gap tracking is owned by the sibling ticket PRO-351 and is untouched.

## Testing

- New regression tests in `stream-state.test.ts`: gapped replay `[1,2,4]` stops at the hole and the formerly-dropped seq 3 live event now returns `"applied"`; mid-stream start `[6,7,8]` is not treated as a gap; unsorted input is sorted; in-list duplicate seqs are skipped without breaking the run.
- `pnpm exec vitest run` over the five suites touching `replaySessionHistory` (stream-state, hydration hook, hydration helpers, stream flush, SessionTranscriptPane): 43/43 pass.
- `pnpm run typecheck` (product-client), `check_max_lines.py`, `check_frontend_boundaries.py`: clean.

## Observability

No new telemetry; existing `session.history.rehydrate.*` latency logs and history state counts now report the replayed (contiguous) event counts in the prepend branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)