### PR TITLE
fix(server): PRO-350 require desktop install ownership in save_local_environment

### DIFF
--- a/server/proliferate/server/cloud/repositories/service.py
+++ b/server/proliferate/server/cloud/repositories/service.py
@@ -10,6 +10,7 @@ from proliferate.db.store import automation_environment_references as automation
 from proliferate.db.store import cloud_repo_environment_materializations as repo_mat_store
 from proliferate.db.store import cloud_sandboxes as cloud_sandboxes_store
 from proliferate.db.store import cloud_workspaces as cloud_workspaces_store
+from proliferate.db.store import runtime_workers as runtime_workers_store
 from proliferate.db.store.cloud_repo_environment_materializations import (
     CloudRepoEnvironmentMaterializationValue,
 )
@@ -132,6 +133,17 @@ async def save_local_environment(
             "desktop_install_id_required",
             "A desktop install id is required for local environments.",
             status_code=400,
+        )
+    worker = await runtime_workers_store.get_active_desktop_worker_for_user(
+        db,
+        owner_user_id=user_id,
+        desktop_install_id=desktop_install_id,
+    )
+    if worker is None:
+        raise CloudApiError(
+            "desktop_install_not_owned",
+            "This desktop installation is not registered to your account.",
+            status_code=403,
         )
     return await upsert_local_repo_environment(
         db,

--- a/server/tests/integration/cloud_api_helpers.py
+++ b/server/tests/integration/cloud_api_helpers.py
@@ -15,6 +15,7 @@ from proliferate.constants.organizations import (
     ORGANIZATION_STATUS_ACTIVE,
 )
 from proliferate.db.models.auth import OAuthAccount
+from proliferate.db.models.cloud.runtime_workers import CloudRuntimeWorker
 from proliferate.db.models.organizations import Organization, OrganizationMembership
 from proliferate.db.store import github_app as github_app_store
 from proliferate.integrations.github import GitHubAppInstallationInfo
@@ -186,6 +187,28 @@ async def create_organization_for_user(db_session: AsyncSession, user_id: str) -
     )
     await db_session.commit()
     return str(organization.id)
+
+
+async def seed_desktop_worker(
+    db_session: AsyncSession,
+    *,
+    user_id: str,
+    desktop_install_id: str,
+) -> None:
+    """Register a non-revoked desktop worker so local-environment saves pass ownership."""
+    now = datetime.now(UTC)
+    db_session.add(
+        CloudRuntimeWorker(
+            owner_user_id=uuid.UUID(user_id),
+            runtime_kind="desktop",
+            desktop_install_id=desktop_install_id,
+            token_hash=uuid.uuid4().hex,
+            status="online",
+            enrolled_at=now,
+            last_seen_at=now,
+        )
+    )
+    await db_session.commit()
 
 
 async def add_organization_member(

--- a/server/tests/integration/test_cloud_api.py
+++ b/server/tests/integration/test_cloud_api.py
@@ -16,6 +16,7 @@ from proliferate.server.cloud.repos import service as repos_service
 from tests.integration.cloud_api_helpers import (
     link_github_account,
     register_and_login,
+    seed_desktop_worker,
     seed_github_app_repo_authority,
 )
 
@@ -313,6 +314,40 @@ class TestCloudRepoCatalog:
         ]
 
 
+class TestLocalEnvironmentInstallOwnership:
+    """PUT of a local environment must reject a desktop install the caller does not own."""
+
+    @pytest.mark.asyncio
+    async def test_put_local_environment_rejects_other_users_install(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+    ) -> None:
+        victim = await register_and_login(client, "install-ownership-victim@example.com")
+        await seed_desktop_worker(
+            db_session, user_id=victim["user_id"], desktop_install_id="install-victim"
+        )
+        attacker = await register_and_login(client, "install-ownership-attacker@example.com")
+        headers = {"Authorization": f"Bearer {attacker['access_token']}"}
+
+        response = await client.put(
+            "/v1/cloud/repositories/acme/rocket/environment",
+            headers=headers,
+            json={
+                "kind": "local",
+                "gitProvider": "github",
+                "desktopInstallId": "install-victim",
+                "localPath": "/Users/tester/rocket",
+                "defaultBranch": None,
+                "setupScript": "",
+                "runCommand": "",
+            },
+        )
+
+        assert response.status_code == 403
+        assert response.json()["detail"]["code"] == "desktop_install_not_owned"
+
+
 class TestRepoEnvironmentArchivingKnobs:
     """PUT/GET round-trip for archive_script + rerun_setup_on_unarchive (R6)."""
 
@@ -323,6 +358,9 @@ class TestRepoEnvironmentArchivingKnobs:
         db_session: AsyncSession,
     ) -> None:
         session = await register_and_login(client, "archiving-knobs-local@example.com")
+        await seed_desktop_worker(
+            db_session, user_id=session["user_id"], desktop_install_id="install-1"
+        )
         headers = {"Authorization": f"Bearer {session['access_token']}"}
 
         response = await client.put(
@@ -395,6 +433,9 @@ class TestRepoEnvironmentArchivingKnobs:
         db_session: AsyncSession,
     ) -> None:
         session = await register_and_login(client, "archiving-knobs-defaults@example.com")
+        await seed_desktop_worker(
+            db_session, user_id=session["user_id"], desktop_install_id="install-1"
+        )
         headers = {"Authorization": f"Bearer {session['access_token']}"}
 
         response = await client.put(
@@ -423,6 +464,9 @@ class TestRepoEnvironmentArchivingKnobs:
         db_session: AsyncSession,
     ) -> None:
         session = await register_and_login(client, "archiving-knobs-explicit-false@example.com")
+        await seed_desktop_worker(
+            db_session, user_id=session["user_id"], desktop_install_id="install-1"
+        )
         headers = {"Authorization": f"Bearer {session['access_token']}"}
         body = {
             "kind": "local",
@@ -459,6 +503,9 @@ class TestRepoEnvironmentArchivingKnobs:
         """Negative control: revert the None-guard in _upsert_environment and this fails."""
 
         session = await register_and_login(client, "archiving-knobs-preserve@example.com")
+        await seed_desktop_worker(
+            db_session, user_id=session["user_id"], desktop_install_id="install-1"
+        )
         headers = {"Authorization": f"Bearer {session['access_token']}"}
 
         first = await client.put(

--- a/server/tests/unit/test_repo_environment_save.py
+++ b/server/tests/unit/test_repo_environment_save.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from proliferate.server.cloud.errors import CloudApiError
+from proliferate.server.cloud.repositories import service
+from proliferate.server.cloud.repositories.models import SaveRepoEnvironmentRequest
+
+
+def _local_body(install_id: str) -> SaveRepoEnvironmentRequest:
+    return SaveRepoEnvironmentRequest.model_validate(
+        {"kind": "local", "desktopInstallId": install_id, "localPath": "/tmp/rocket"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_local_environment_rejects_unowned_desktop_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    upserted = False
+
+    async def get_worker(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        return None
+
+    async def upsert(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        nonlocal upserted
+        upserted = True
+
+    monkeypatch.setattr(
+        service.runtime_workers_store, "get_active_desktop_worker_for_user", get_worker
+    )
+    monkeypatch.setattr(service, "upsert_local_repo_environment", upsert)
+
+    with pytest.raises(CloudApiError) as raised:
+        await service.save_local_environment(
+            object(),
+            user_id=uuid.uuid4(),
+            git_owner="acme",
+            git_repo_name="rocket",
+            body=_local_body("someone-elses-install"),
+        )
+
+    assert raised.value.code == "desktop_install_not_owned"
+    assert raised.value.status_code == 403
+    assert upserted is False
+
+
+@pytest.mark.asyncio
+async def test_save_local_environment_persists_owned_desktop_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid.uuid4()
+    ownership_lookups: list[tuple[uuid.UUID, str]] = []
+    upsert_calls: list[str] = []
+
+    async def get_worker(*args: object, **kwargs: object) -> SimpleNamespace:
+        del args
+        ownership_lookups.append((kwargs["owner_user_id"], kwargs["desktop_install_id"]))
+        return SimpleNamespace(id=uuid.uuid4())
+
+    async def upsert(*args: object, **kwargs: object) -> SimpleNamespace:
+        del args
+        upsert_calls.append(kwargs["desktop_install_id"])
+        return SimpleNamespace(id=uuid.uuid4())
+
+    monkeypatch.setattr(
+        service.runtime_workers_store, "get_active_desktop_worker_for_user", get_worker
+    )
+    monkeypatch.setattr(service, "upsert_local_repo_environment", upsert)
+
+    await service.save_local_environment(
+        object(),
+        user_id=user_id,
+        git_owner="acme",
+        git_repo_name="rocket",
+        body=_local_body("  desktop-a  "),
+    )
+
+    assert ownership_lookups == [(user_id, "desktop-a")]
+    assert upsert_calls == ["desktop-a"]

--- a/tests/intent/specs/workflow-trigger-seam.spec.ts
+++ b/tests/intent/specs/workflow-trigger-seam.spec.ts
@@ -340,6 +340,24 @@ async function convergedAdminLogin(): Promise<{ access_token: string }> {
  * definition's own (always-null) `defaultRepoConfigId`.
  */
 async function seedRepositoryThroughProductApi(): Promise<string> {
+  // Saving a local environment requires the desktop install to be enrolled to
+  // the caller (403 desktop_install_not_owned otherwise), so enroll it through
+  // the same worker-enrollment surface the desktop app drives.
+  const installId = `t2-wf-trigger-install-${RUN_ID}`;
+  const enrollment = await apiRequest<{ enrollmentToken?: string }>(
+    "/v1/cloud/workers/desktop/enrollment",
+    { method: "POST", token: ownerToken, body: { desktopInstallId: installId } },
+  );
+  if (enrollment.status !== 200 || !enrollment.body.enrollmentToken) {
+    throw new Error(`Desktop enrollment ticket failed (${enrollment.status}): ${JSON.stringify(enrollment.body)}`);
+  }
+  const enrolled = await apiRequest("/v1/cloud/worker/enroll", {
+    method: "POST",
+    body: { enrollmentToken: enrollment.body.enrollmentToken },
+  });
+  if (enrolled.status !== 200) {
+    throw new Error(`Worker enrollment failed (${enrolled.status}): ${JSON.stringify(enrolled.body)}`);
+  }
   const saved = await apiRequest<{ repoConfigId?: string }>(
     `/v1/cloud/repositories/${REPO_OWNER}/${REPO_NAME}/environment`,
     {
@@ -347,7 +365,7 @@ async function seedRepositoryThroughProductApi(): Promise<string> {
       token: ownerToken,
       body: {
         kind: "local",
-        desktopInstallId: `t2-wf-trigger-install-${RUN_ID}`,
+        desktopInstallId: installId,
         localPath: `/tmp/t2-wf-trigger-${RUN_ID}`,
       },
     },


### PR DESCRIPTION
## Summary

- `save_local_environment` validated `desktop_install_id` only for non-emptiness, so any authenticated user could bind their local repo environment to another user's device (Linear PRO-350).
- Apply the codebase's established ownership assertion before persisting: look up the caller's non-revoked desktop worker via `get_active_desktop_worker_for_user` and raise 403 `desktop_install_not_owned` when it is missing, matching `_require_owned_install` in the materializations access layer. This is the only path that persists a caller-supplied `desktop_install_id` into repo environments.
- Existing local-environment integration tests now register the install via a new `seed_desktop_worker` helper, mirroring how real clients enroll before saving.

Fixes PRO-350

## Testing

- Unit (`server/tests/unit/test_repo_environment_save.py`): unowned install → 403 with no persist; owned install → ownership lookup runs with the stripped id and persist proceeds.
- Integration (`server/tests/integration/test_cloud_api.py`): new cross-party regression — user A PUTting user B's install id gets 403 `desktop_install_not_owned`; full `tests/unit` suite and `tests/integration/test_cloud_api.py` pass locally against Postgres.

## Observability

- none

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Verification

- `uv run pytest tests/unit -q` — all pass
- `uv run pytest tests/integration/test_cloud_api.py -q` — 12 passed
- `ruff check`, `ruff format --check`, `mypy` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)