### PR TITLE
fix(sessions): PRO-351 keep ingest freshness in sync with history hydration

### DIFF
--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-history-hydration-helpers.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-history-hydration-helpers.test.ts
@@ -11,6 +11,7 @@ import {
   putSessionRecord,
 } from "#product/stores/sessions/session-records";
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import { useSessionIngestStore } from "#product/stores/sessions/session-ingest-store";
 import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
 import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
 
@@ -18,12 +19,14 @@ describe("applyHistoryStateToStores", () => {
   beforeEach(() => {
     useSessionDirectoryStore.getState().clearEntries();
     useSessionIntentStore.getState().clear();
+    useSessionIngestStore.getState().clear();
     useSessionTranscriptStore.getState().clearEntries();
   });
 
   afterEach(() => {
     useSessionDirectoryStore.getState().clearEntries();
     useSessionIntentStore.getState().clear();
+    useSessionIngestStore.getState().clear();
     useSessionTranscriptStore.getState().clearEntries();
   });
 
@@ -86,6 +89,45 @@ describe("applyHistoryStateToStores", () => {
     expect(updated.status).toBe(expectedStatus);
     expect(updated.executionSummary?.phase).toBe(expectedPhase);
     expect(resolveSessionViewState(updated)).toBe(expectedViewState);
+  });
+
+  it("marks the ingest store current when a history refill repairs a recorded gap", () => {
+    const currentState = replaySessionHistory("session-1", [turnStarted(1)]);
+    const currentRecord = {
+      ...createEmptySessionRecord("session-1", "codex", {
+        workspaceId: "workspace-1",
+      }),
+      events: currentState.events,
+      transcript: currentState.transcript,
+      status: "running" as const,
+      executionSummary: {
+        phase: "running" as const,
+        hasLiveHandle: true,
+        pendingInteractions: [],
+        updatedAt: "2026-04-04T00:00:01Z",
+      },
+      streamConnectionState: "disconnected" as const,
+      transcriptHydrated: true,
+    };
+    putSessionRecord(currentRecord);
+    useSessionIngestStore.getState().markStale("session-1", {
+      lastAppliedSeq: 1,
+      lastObservedSeq: 3,
+      gapAfterSeq: 1,
+    });
+    const nextState = replaySessionHistory("session-1", [turnStarted(1), turnEnded(2)]);
+
+    applyHistoryStateToStores("session-1", currentRecord, {
+      events: nextState.events,
+      transcript: nextState.transcript,
+      reconcileEnvelopes: [turnEnded(2)],
+    });
+
+    expect(useSessionIngestStore.getState().freshnessByClientSessionId["session-1"])
+      .toMatchObject({
+        freshness: "current",
+        gapAfterSeq: null,
+      });
   });
 
   it("does not let prepended older history overwrite newer running activity", () => {

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-history-hydration-helpers.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-history-hydration-helpers.ts
@@ -24,6 +24,7 @@ import { batchSessionStoreWrites } from "#product/lib/infra/scheduling/react-bat
 import { activityFromTranscript } from "#product/lib/domain/sessions/directory/directory-activity";
 import { buildSessionStreamBatchPatch } from "#product/lib/domain/sessions/stream-patch";
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
+import { useSessionIngestStore } from "#product/stores/sessions/session-ingest-store";
 import { useSessionIntentStore } from "#product/stores/sessions/session-intent-store";
 import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
 import type { SessionRuntimeRecord } from "#product/stores/sessions/session-types";
@@ -220,6 +221,14 @@ export function applyHistoryStateToStores(
         executionSummary,
       }),
     });
+    // Without this write, a gap refill applied through the history path leaves
+    // the ingest store stale/gapped forever (markCurrentIfContiguous no-ops
+    // while gapAfterSeq is set), forcing a redundant full refetch on every
+    // reopen.
+    useSessionIngestStore.getState().applyHistoryHydration(
+      sessionId,
+      nextState.transcript.lastSeq,
+    );
   });
 }
 

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-flush-apply.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/session-stream-flush-apply.ts
@@ -210,10 +210,15 @@ export function applySessionStreamFlushBatch(
       slotState.transcript,
     );
     input.reconcileWorkspacePinIntents(result.duplicateEnvelopes);
+    // A duplicate-only flush repaired nothing, so it must not clear a gap
+    // recorded earlier — clearing it would let the reopen flow skip the history
+    // refill that repairs the hole.
+    const recordedGapAfterSeq = useSessionIngestStore.getState()
+      .freshnessByClientSessionId[input.sessionId]?.gapAfterSeq ?? null;
     useSessionIngestStore.getState().applyStreamProgress(input.sessionId, {
       lastAppliedSeq: slotState.transcript.lastSeq,
       lastObservedSeq,
-      gapAfterSeq: null,
+      gapAfterSeq: recordedGapAfterSeq,
     });
     finishOrCancelMeasurementOperation(streamEventBatchOperationId, "completed");
     return {

--- a/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-stream-flush.test.ts
+++ b/apps/packages/product-client/src/hooks/sessions/lifecycle/use-session-stream-flush.test.ts
@@ -9,6 +9,7 @@ import {
 } from "#product/stores/sessions/session-records";
 import { useSessionDirectoryStore } from "#product/stores/sessions/session-directory-store";
 import { useSessionSelectionStore } from "#product/stores/sessions/session-selection-store";
+import { useSessionIngestStore } from "#product/stores/sessions/session-ingest-store";
 import { useSessionTranscriptStore } from "#product/stores/sessions/session-transcript-store";
 import { clearPendingConfigRollbackCheck } from "#product/hooks/sessions/lifecycle/session-runtime-pending-config";
 import {
@@ -24,6 +25,7 @@ const originalPatchTranscriptEntry = useSessionTranscriptStore.getState().patchE
 describe("session stream flush controller", () => {
   afterEach(() => {
     clearPendingConfigRollbackCheck("session-1");
+    useSessionIngestStore.getState().clear();
     useSessionTranscriptStore.setState({ patchEntry: originalPatchTranscriptEntry });
     vi.useRealTimers();
     vi.unstubAllGlobals();
@@ -36,6 +38,7 @@ describe("session stream flush controller", () => {
       activeSessionId: "session-1",
     });
     useSessionDirectoryStore.getState().clearEntries();
+    useSessionIngestStore.getState().clear();
     useSessionTranscriptStore.getState().clearEntries();
     putSessionRecord({
       ...createEmptySessionRecord("session-1", "codex", {
@@ -74,6 +77,25 @@ describe("session stream flush controller", () => {
     expect(reconcileWorkspacePinIntents).toHaveBeenCalledTimes(1);
     expect(reconcileWorkspacePinIntents.mock.calls[0]?.[0].map((event) => event.seq))
       .toEqual([2, 3, 4, 5]);
+  });
+
+  it("does not clear a recorded gap on a duplicate-only flush", () => {
+    useSessionIngestStore.getState().markStale("session-1", {
+      lastAppliedSeq: 1,
+      lastObservedSeq: 3,
+      gapAfterSeq: 1,
+    });
+    const scheduled = createManualScheduler();
+    const controller = createTestController({ scheduler: scheduled.scheduler });
+
+    controller.enqueue(turnStarted(1));
+    scheduled.flush();
+
+    expect(useSessionIngestStore.getState().freshnessByClientSessionId["session-1"])
+      .toMatchObject({
+        freshness: "stale",
+        gapAfterSeq: 1,
+      });
   });
 
   it("clears optimistic prompt when the stream echoes the user message", () => {

--- a/apps/packages/product-client/src/stores/sessions/session-ingest-store.test.ts
+++ b/apps/packages/product-client/src/stores/sessions/session-ingest-store.test.ts
@@ -87,6 +87,112 @@ describe("session ingest store invariants", () => {
     expect(isHotSessionTargetCurrent("session-a", "runtime-a")).toBe(false);
   });
 
+  it("applyHistoryHydration clears a repaired gap and marks the session current", () => {
+    const store = useSessionIngestStore.getState();
+    store.markStale("session-a", {
+      lastAppliedSeq: 1,
+      lastObservedSeq: 3,
+      gapAfterSeq: 1,
+      lastErrorAt: "2026-04-04T00:00:10.000Z",
+    });
+
+    store.applyHistoryHydration("session-a", 5);
+
+    expect(useSessionIngestStore.getState().freshnessByClientSessionId["session-a"])
+      .toMatchObject({
+        freshness: "current",
+        lastAppliedSeq: 5,
+        lastObservedSeq: 5,
+        gapAfterSeq: null,
+        lastErrorAt: null,
+      });
+  });
+
+  it("applyHistoryHydration preserves the gap when the refill does not reach past it", () => {
+    const store = useSessionIngestStore.getState();
+    store.markStale("session-a", {
+      lastAppliedSeq: 1,
+      lastObservedSeq: 3,
+      gapAfterSeq: 4,
+    });
+
+    store.applyHistoryHydration("session-a", 3);
+
+    expect(useSessionIngestStore.getState().freshnessByClientSessionId["session-a"])
+      .toMatchObject({
+        freshness: "stale",
+        lastAppliedSeq: 3,
+        lastObservedSeq: 3,
+        gapAfterSeq: 4,
+      });
+
+    store.applyHistoryHydration("session-a", 4);
+    expect(useSessionIngestStore.getState().freshnessByClientSessionId["session-a"])
+      .toMatchObject({
+        freshness: "stale",
+        gapAfterSeq: 4,
+      });
+
+    store.applyHistoryHydration("session-a", 5);
+    expect(useSessionIngestStore.getState().freshnessByClientSessionId["session-a"])
+      .toMatchObject({
+        freshness: "current",
+        gapAfterSeq: null,
+      });
+  });
+
+  it("applyHistoryHydration never regresses the applied or observed watermarks", () => {
+    const store = useSessionIngestStore.getState();
+    store.applyStreamProgress("session-a", {
+      lastAppliedSeq: 10,
+      lastObservedSeq: 12,
+      gapAfterSeq: null,
+    });
+
+    store.applyHistoryHydration("session-a", 5);
+
+    expect(useSessionIngestStore.getState().freshnessByClientSessionId["session-a"])
+      .toMatchObject({
+        freshness: "current",
+        lastAppliedSeq: 10,
+        lastObservedSeq: 12,
+      });
+  });
+
+  it("applyHistoryHydration marks an untracked session current with the given watermarks", () => {
+    useSessionIngestStore.getState().applyHistoryHydration("session-a", 5);
+
+    expect(useSessionIngestStore.getState().freshnessByClientSessionId["session-a"])
+      .toEqual({
+        freshness: "current",
+        lastAppliedSeq: 5,
+        lastObservedSeq: 5,
+        gapAfterSeq: null,
+        lastErrorAt: null,
+      });
+  });
+
+  it("markStale keeps the applied and observed watermarks monotonic", () => {
+    const store = useSessionIngestStore.getState();
+    store.applyStreamProgress("session-a", {
+      lastAppliedSeq: 10,
+      lastObservedSeq: 10,
+      gapAfterSeq: null,
+    });
+
+    store.markStale("session-a", {
+      lastAppliedSeq: 3,
+      lastObservedSeq: 3,
+    });
+
+    expect(useSessionIngestStore.getState().freshnessByClientSessionId["session-a"])
+      .toMatchObject({
+        freshness: "stale",
+        lastAppliedSeq: 10,
+        lastObservedSeq: 10,
+      });
+  });
+
   it("does not mark gapped progress current until the gap clears", () => {
     const store = useSessionIngestStore.getState();
     store.markStale("session-a", {

--- a/apps/packages/product-client/src/stores/sessions/session-ingest-store.ts
+++ b/apps/packages/product-client/src/stores/sessions/session-ingest-store.ts
@@ -25,6 +25,7 @@ interface SessionIngestStoreState {
     >>,
   ) => void;
   markCold: (clientSessionId: string) => void;
+  applyHistoryHydration: (clientSessionId: string, lastAppliedSeq: number) => void;
   applyStreamProgress: (
     clientSessionId: string,
     progress: {
@@ -130,6 +131,8 @@ export const useSessionIngestStore = create<SessionIngestStoreState>((set) => ({
         [clientSessionId]: {
           ...existing,
           ...patch,
+          lastAppliedSeq: Math.max(existing.lastAppliedSeq, patch?.lastAppliedSeq ?? 0),
+          lastObservedSeq: Math.max(existing.lastObservedSeq, patch?.lastObservedSeq ?? 0),
           freshness: "stale",
           lastErrorAt: patch?.lastErrorAt ?? existing.lastErrorAt ?? new Date().toISOString(),
         },
@@ -145,6 +148,30 @@ export const useSessionIngestStore = create<SessionIngestStoreState>((set) => ({
         [clientSessionId]: {
           ...existing,
           freshness: "cold",
+        },
+      },
+    };
+  }),
+
+  // History replay is authoritative and contiguous, so a refill that advances
+  // the applied watermark past a recorded gap has repaired that hole; a refill
+  // that does not reach past the gap must leave it recorded.
+  applyHistoryHydration: (clientSessionId, lastAppliedSeq) => set((state) => {
+    const existing = state.freshnessByClientSessionId[clientSessionId] ?? COLD_FRESHNESS;
+    const gapAfterSeq = existing.gapAfterSeq !== null && lastAppliedSeq > existing.gapAfterSeq
+      ? null
+      : existing.gapAfterSeq;
+    const freshness: SessionIngestFreshness = gapAfterSeq === null ? "current" : "stale";
+    return {
+      freshnessByClientSessionId: {
+        ...state.freshnessByClientSessionId,
+        [clientSessionId]: {
+          ...existing,
+          freshness,
+          lastAppliedSeq: Math.max(existing.lastAppliedSeq, lastAppliedSeq),
+          lastObservedSeq: Math.max(existing.lastObservedSeq, lastAppliedSeq),
+          gapAfterSeq,
+          lastErrorAt: freshness === "current" ? null : existing.lastErrorAt,
         },
       },
     };

--- a/apps/packages/product-client/src/stores/sessions/session-ingest-store.ts
+++ b/apps/packages/product-client/src/stores/sessions/session-ingest-store.ts
@@ -3,6 +3,17 @@ import type { HotSessionTarget } from "#product/lib/domain/sessions/hot-session-
 
 export type SessionIngestFreshness = "current" | "warming" | "stale" | "cold";
 
+/**
+ * Freshness contract: `gapAfterSeq` records the applied watermark at the
+ * moment a stream gap was detected — events after it were missed. Only a
+ * repair that advances `lastAppliedSeq` past the recorded gap may clear it:
+ * an authoritative history refill (`applyHistoryHydration`) or a stream batch
+ * that reduced past it (`applyStreamProgress`). Writes that repaired nothing
+ * (duplicate-only flushes, reconnects, error marks) must preserve it, or the
+ * reopen flow skips the history refill that repairs the hole. A session is
+ * `current` only while no gap is recorded, and the `lastAppliedSeq` /
+ * `lastObservedSeq` watermarks never move backwards.
+ */
 export interface SessionIngestFreshnessState {
   freshness: SessionIngestFreshness;
   lastAppliedSeq: number;


### PR DESCRIPTION
## Summary

Fixes PRO-351 — two inverse bugs in the session gap-tracking subsystem plus a watermark hardening, all in `apps/packages/product-client`:

- **Hydration never updated the ingest store (Bug A).** `applyHistoryStateToStores` wrote the transcript, intent, and directory stores but never `useSessionIngestStore`, so after a gap refill the store kept `gapAfterSeq` set / `"stale"` forever (`markCurrentIfContiguous` no-ops while a gap is recorded). Every workspace reopen refetched full history redundantly and the `slotStreamLive` gate in `use-hot-workspace-reconcile-action.ts` wrongly rejected live slots. New store action `applyHistoryHydration` encodes the invariant: history replay is authoritative and contiguous, so a refill advancing the applied watermark past the recorded gap clears it and marks the session current; a refill that falls short preserves the gap.
- **Duplicate-only flush erased real gaps (Bug B).** The `appliedEnvelopes.length === 0 && !gapEnvelope` branch in `session-stream-flush-apply.ts` called `applyStreamProgress` with `gapAfterSeq: null`, clearing a hole it did not repair; the reopen flow then skipped the refill and the missing events were never recovered. It now preserves the previously recorded `gapAfterSeq`.
- **Monotonic watermarks.** `markStale` now applies `Math.max` to `lastAppliedSeq`/`lastObservedSeq` (matching `applyStreamProgress` discipline) instead of writing patch values verbatim; `applyHistoryHydration` follows the same rule.

## Testing

- Unit (vitest, real zustand stores): 5 new ingest-store cases (gap repaired → current, gap preserved when refill falls short, watermark monotonicity for both `applyHistoryHydration` and `markStale`, untracked-session hydration); Bug A regression in `session-history-hydration-helpers.test.ts` (pre-seeded gap → `applyHistoryStateToStores` past it → current/gap cleared); Bug B regression in `use-session-stream-flush.test.ts` (duplicate-only flush keeps the recorded gap and stays stale).
- Full product-client suite: 8208 passed / 4 skipped; the only 3 failing files launch local `channel: "chrome"` Playwright browsers absent on this machine (pre-existing, unrelated).
- `tsc -p tsconfig.json --noEmit` clean after building the SDK/design dist prerequisites.

## Observability

- none (existing gap-detection diagnostics and latency logs unchanged).

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Verification

- `pnpm vitest run` on the three touched test files: 24 passed.
- Repo shape checks: max-lines and frontend boundary checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)