### PR TITLE
fix(anyharness): keep emulated loops armed across transient fire failures

### DIFF
--- a/anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs
@@ -589,7 +589,7 @@ struct LoopFireRecordOp {
     fired_at_ms: i64,
 }
 struct LoopFireRecordOutput {
-    report: Option<LoopFireReport>,
+    result: anyhow::Result<Option<LoopFireReport>>,
 }
 impl SessionDomainOp for LoopFireRecordOp {
     fn begin(self: Box<Self>, emitter: &mut SessionOpEmitter<'_>) -> SessionOpStep {
@@ -599,21 +599,18 @@ impl SessionDomainOp for LoopFireRecordOp {
             fired_at_ms,
         } = *self;
         let context = loop_event_context(&emitter.event_ctx());
-        let report = match loop_service.record_emulated_fire(context, loop_id, fired_at_ms) {
+        let result = match loop_service.record_emulated_fire(context, loop_id, fired_at_ms) {
             Ok(Some(outcome)) => {
                 emitter.publish(outcome.batch.envelopes);
-                Some(LoopFireReport {
+                Ok(Some(LoopFireReport {
                     still_armed: outcome.still_armed,
                     next_fire_at_ms: outcome.next_fire_at_ms,
-                })
+                }))
             }
-            Ok(None) => None,
-            Err(error) => {
-                tracing::warn!(error = %error, "failed to record emulated loop fire");
-                None
-            }
+            Ok(None) => Ok(None),
+            Err(error) => Err(anyhow::anyhow!(error.to_string())),
         };
-        SessionOpStep::Done(Box::new(LoopFireRecordOutput { report }) as Box<dyn Any + Send>)
+        SessionOpStep::Done(Box::new(LoopFireRecordOutput { result }) as Box<dyn Any + Send>)
     }
 }
 

--- a/anyharness/crates/anyharness-lib/src/domains/loops/runtime/fire_executor.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/loops/runtime/fire_executor.rs
@@ -53,7 +53,11 @@ impl LoopFireExecutor for SessionLoopFireExecutor {
         }
     }
 
-    async fn fire(&self, session_id: &str, loop_id: &str) -> Option<LoopFireReport> {
+    async fn fire(
+        &self,
+        session_id: &str,
+        loop_id: &str,
+    ) -> anyhow::Result<Option<LoopFireReport>> {
         // Reversible Close either wins first and rejects this fire, or waits
         // until this accepted prompt and its accounting have completed.
         let _permit = self
@@ -64,20 +68,27 @@ impl LoopFireExecutor for SessionLoopFireExecutor {
                 &SessionMutationSource::external(),
             )
             .await
-            .ok()?;
+            .map_err(|conflict| {
+                anyhow::anyhow!("loop fire rejected by session admission: {conflict:?}")
+            })?;
         // Preserve the original live-only contract: an emulated fire never
-        // cold-starts a dead actor merely to deliver its scheduled prompt.
-        let handle = self.acp_manager.get_handle(session_id).await?;
-        let record = self
-            .loop_service
-            .store()
-            .find_one(session_id, loop_id)
-            .ok()
-            .flatten()?;
+        // cold-starts a dead actor merely to deliver its scheduled prompt. The
+        // next pass observes Dead and disarms; fire itself must not disarm.
+        let Some(handle) = self.acp_manager.get_handle(session_id).await else {
+            return Err(anyhow::anyhow!("session is not live"));
+        };
+        let Some(record) = self.loop_service.store().find_one(session_id, loop_id)? else {
+            return Ok(None);
+        };
         if !record.is_active() || record.native {
-            return None;
+            return Ok(None);
         }
-        let runtime = self.session_runtime.get()?.upgrade()?;
+        let runtime = self
+            .session_runtime
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("session runtime unavailable"))?
+            .upgrade()
+            .ok_or_else(|| anyhow::anyhow!("session runtime unavailable"))?;
         runtime
             .send_text_prompt_with_provenance_on_existing_handle(
                 session_id,
@@ -88,14 +99,24 @@ impl LoopFireExecutor for SessionLoopFireExecutor {
                 handle.clone(),
             )
             .await
-            .ok()?;
+            .map_err(|error| anyhow::anyhow!("loop prompt delivery failed: {error:?}"))?;
+        // When the prompt was delivered but accounting fails, we return Err so
+        // the arm is kept — a retry may duplicate one prompt turn, which is
+        // preferred over silently disarming a live loop (and over leaving a
+        // stale next_fire that re-fires past max_fires on the next attach).
         let op = Box::new(LoopFireRecordOp {
             loop_service: self.loop_service.clone(),
             loop_id: loop_id.to_string(),
             fired_at_ms: chrono::Utc::now().timestamp_millis(),
         });
-        let reply = handle.run_domain_op(op).await.ok()?;
-        reply.downcast::<LoopFireRecordOutput>().ok()?.report
+        let reply = handle
+            .run_domain_op(op)
+            .await
+            .map_err(|error| anyhow::anyhow!("loop fire accounting op failed: {error:?}"))?;
+        let output = reply
+            .downcast::<LoopFireRecordOutput>()
+            .map_err(|_| anyhow::anyhow!("loop fire record op returned unexpected reply"))?;
+        output.result
     }
 }
 
@@ -217,7 +238,7 @@ mod tests {
         assert!(state.acp_manager.get_handle("target").await.is_none());
         assert!(read_requests(&scripted_agent.request_log).is_empty());
 
-        let report = executor.fire("target", "dead-loop").await;
+        let result = executor.fire("target", "dead-loop").await;
         let cold_started = state.acp_manager.get_handle("target").await.is_some();
         let requests = read_requests(&scripted_agent.request_log);
         let record = state
@@ -232,7 +253,10 @@ mod tests {
         drop(state);
         std::fs::remove_dir_all(&runtime_home).expect("remove runtime home");
 
-        assert!(report.is_none(), "a dead session cannot accept a loop fire");
+        assert!(
+            result.is_err(),
+            "a dead session cannot accept a loop fire and the failure must not read as loop-cleared"
+        );
         assert!(!cold_started, "a loop fire must not cold-start its session");
         assert!(
             requests.is_empty(),

--- a/anyharness/crates/anyharness-lib/src/domains/loops/runtime/fire_executor.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/loops/runtime/fire_executor.rs
@@ -101,9 +101,10 @@ impl LoopFireExecutor for SessionLoopFireExecutor {
             .await
             .map_err(|error| anyhow::anyhow!("loop prompt delivery failed: {error:?}"))?;
         // When the prompt was delivered but accounting fails, we return Err so
-        // the arm is kept — a retry may duplicate one prompt turn, which is
-        // preferred over silently disarming a live loop (and over leaving a
-        // stale next_fire that re-fires past max_fires on the next attach).
+        // the arm is kept — a retry may duplicate a prompt turn (bounded by the
+        // scheduler's consecutive-failure cap), which is preferred over
+        // silently disarming a live loop (and over leaving a stale next_fire
+        // that re-fires past max_fires on the next attach).
         let op = Box::new(LoopFireRecordOp {
             loop_service: self.loop_service.clone(),
             loop_id: loop_id.to_string(),

--- a/anyharness/crates/anyharness-lib/src/domains/loops/scheduler.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/loops/scheduler.rs
@@ -69,6 +69,13 @@ const BUSY_RETRY: Duration = Duration::from_secs(3);
 /// clock drift on long-interval loops).
 const MAX_SLEEP: Duration = Duration::from_secs(30);
 
+/// How many consecutive failed fires a loop may accumulate before its
+/// in-memory arm is dropped (the sqlite row survives and re-arms on the next
+/// attach). Bounds duplicate prompt turns when delivery succeeded but the
+/// accounting keeps failing — without a cap, a persistently failing fire would
+/// re-deliver its prompt on every idle pass, ignoring cadence and `max_fires`.
+const MAX_CONSECUTIVE_FIRE_FAILURES: u32 = 3;
+
 type ArmKey = (String, String);
 
 /// What one due loop did in a pass (surfaced for tests + tracing).
@@ -79,12 +86,14 @@ pub enum FireOutcome {
     FailedTransient,
     DisarmedDead,
     DisarmedRetired,
+    DisarmedFailing,
     Gone,
 }
 
 pub struct LoopScheduler {
     executor: Arc<dyn LoopFireExecutor>,
     armed: Mutex<HashMap<ArmKey, i64>>,
+    fire_failures: Mutex<HashMap<ArmKey, u32>>,
     wake: Notify,
 }
 
@@ -93,25 +102,25 @@ impl LoopScheduler {
         Self {
             executor,
             armed: Mutex::new(HashMap::new()),
+            fire_failures: Mutex::new(HashMap::new()),
             wake: Notify::new(),
         }
     }
 
-    /// Arm (or re-arm) one emulated loop at its next fire instant.
+    /// Arm (or re-arm) one emulated loop at its next fire instant. A fresh arm
+    /// starts with a fresh consecutive-failure budget.
     pub async fn arm(&self, session_id: &str, loop_id: &str, next_fire_at_ms: i64) {
-        self.armed.lock().await.insert(
-            (session_id.to_string(), loop_id.to_string()),
-            next_fire_at_ms,
-        );
+        let key = (session_id.to_string(), loop_id.to_string());
+        self.fire_failures.lock().await.remove(&key);
+        self.armed.lock().await.insert(key, next_fire_at_ms);
         self.wake.notify_one();
     }
 
     /// Drop one loop from the in-memory schedule (clear / cap / non-recurring).
     pub async fn disarm(&self, session_id: &str, loop_id: &str) {
-        self.armed
-            .lock()
-            .await
-            .remove(&(session_id.to_string(), loop_id.to_string()));
+        let key = (session_id.to_string(), loop_id.to_string());
+        self.fire_failures.lock().await.remove(&key);
+        self.armed.lock().await.remove(&key);
         self.wake.notify_one();
     }
 
@@ -124,6 +133,10 @@ impl LoopScheduler {
     /// Drop every loop for a session (called when a session detaches — the
     /// timers are mortal; the sqlite rows re-arm on the next attach).
     pub async fn disarm_session(&self, session_id: &str) {
+        self.fire_failures
+            .lock()
+            .await
+            .retain(|(sid, _), _| sid != session_id);
         self.armed
             .lock()
             .await
@@ -162,6 +175,7 @@ impl LoopScheduler {
             let (session_id, loop_id) = (&key.0, &key.1);
             let outcome = match self.executor.liveness(session_id).await {
                 LoopSessionLiveness::Dead => {
+                    self.fire_failures.lock().await.remove(&key);
                     self.armed.lock().await.remove(&key);
                     FireOutcome::DisarmedDead
                 }
@@ -170,23 +184,41 @@ impl LoopScheduler {
                 LoopSessionLiveness::Busy => FireOutcome::SkippedBusy,
                 LoopSessionLiveness::Idle => match self.executor.fire(session_id, loop_id).await {
                     Err(error) => {
-                        tracing::warn!(session_id, loop_id, error = %error, "emulated loop fire failed transiently; keeping the arm for retry");
-                        FireOutcome::FailedTransient
-                    }
-                    Ok(None) => {
-                        self.armed.lock().await.remove(&key);
-                        FireOutcome::Gone
-                    }
-                    Ok(Some(report)) => match (report.still_armed, report.next_fire_at_ms) {
-                        (true, Some(next)) => {
-                            self.armed.lock().await.insert(key.clone(), next);
-                            FireOutcome::Fired
-                        }
-                        _ => {
+                        let failures = {
+                            let mut fire_failures = self.fire_failures.lock().await;
+                            let count = fire_failures.entry(key.clone()).or_insert(0);
+                            *count += 1;
+                            *count
+                        };
+                        if failures >= MAX_CONSECUTIVE_FIRE_FAILURES {
+                            self.fire_failures.lock().await.remove(&key);
                             self.armed.lock().await.remove(&key);
-                            FireOutcome::DisarmedRetired
+                            tracing::warn!(session_id, loop_id, error = %error, failures, "emulated loop fire failed repeatedly; dropping the in-memory arm (the persisted loop re-arms on the next attach)");
+                            FireOutcome::DisarmedFailing
+                        } else {
+                            tracing::warn!(session_id, loop_id, error = %error, failures, "emulated loop fire failed transiently; keeping the arm for retry");
+                            FireOutcome::FailedTransient
                         }
-                    },
+                    }
+                    Ok(result) => {
+                        self.fire_failures.lock().await.remove(&key);
+                        match result {
+                            None => {
+                                self.armed.lock().await.remove(&key);
+                                FireOutcome::Gone
+                            }
+                            Some(report) => match (report.still_armed, report.next_fire_at_ms) {
+                                (true, Some(next)) => {
+                                    self.armed.lock().await.insert(key.clone(), next);
+                                    FireOutcome::Fired
+                                }
+                                _ => {
+                                    self.armed.lock().await.remove(&key);
+                                    FireOutcome::DisarmedRetired
+                                }
+                            },
+                        }
+                    }
                 },
             };
             outcomes.push((key, outcome));
@@ -437,6 +469,50 @@ mod tests {
             5_000
         );
         assert_eq!(flaky.fires.load(Ordering::SeqCst), 2);
+        assert!(
+            scheduler.fire_failures.lock().await.is_empty(),
+            "a successful fire resets the consecutive-failure budget"
+        );
+    }
+
+    #[tokio::test]
+    async fn repeated_fire_failures_drop_the_arm_at_the_cap() {
+        struct AlwaysFailingExecutor {
+            fires: AtomicUsize,
+        }
+        #[async_trait]
+        impl LoopFireExecutor for AlwaysFailingExecutor {
+            async fn liveness(&self, _session_id: &str) -> LoopSessionLiveness {
+                LoopSessionLiveness::Idle
+            }
+            async fn fire(
+                &self,
+                _session_id: &str,
+                _loop_id: &str,
+            ) -> anyhow::Result<Option<LoopFireReport>> {
+                self.fires.fetch_add(1, Ordering::SeqCst);
+                Err(anyhow::anyhow!("persistent sqlite failure"))
+            }
+        }
+
+        let failing = Arc::new(AlwaysFailingExecutor {
+            fires: AtomicUsize::new(0),
+        });
+        let scheduler = LoopScheduler::new(failing.clone());
+        scheduler.arm("s1", "l1", 1_000).await;
+
+        // The arm survives up to the cap, then drops so a persistently failing
+        // fire cannot re-deliver its prompt on every idle pass.
+        for now in [1_500, 1_600] {
+            let outcomes = scheduler.run_due_pass(now).await;
+            assert_eq!(outcomes[0].1, FireOutcome::FailedTransient);
+            assert!(scheduler.is_armed("s1", "l1").await);
+        }
+        let outcomes = scheduler.run_due_pass(1_700).await;
+        assert_eq!(outcomes[0].1, FireOutcome::DisarmedFailing);
+        assert!(!scheduler.is_armed("s1", "l1").await);
+        assert_eq!(failing.fires.load(Ordering::SeqCst), 3);
+        assert!(scheduler.fire_failures.lock().await.is_empty());
     }
 
     #[tokio::test]

--- a/anyharness/crates/anyharness-lib/src/domains/loops/scheduler.rs
+++ b/anyharness/crates/anyharness-lib/src/domains/loops/scheduler.rs
@@ -54,8 +54,12 @@ pub trait LoopFireExecutor: Send + Sync {
     async fn liveness(&self, session_id: &str) -> LoopSessionLiveness;
 
     /// Enqueue the loop's prompt as a loop-fired user turn and record the fire.
-    /// `None` = the loop record is gone/cleared and should be disarmed.
-    async fn fire(&self, session_id: &str, loop_id: &str) -> Option<LoopFireReport>;
+    ///
+    /// `Ok(None)` = the loop record is gone/cleared and should be disarmed;
+    /// `Err` = a transient failure — the arm must be kept so the fire retries
+    /// on a later pass.
+    async fn fire(&self, session_id: &str, loop_id: &str)
+        -> anyhow::Result<Option<LoopFireReport>>;
 }
 
 /// How long to wait before re-checking a due loop whose session was busy.
@@ -72,6 +76,7 @@ type ArmKey = (String, String);
 pub enum FireOutcome {
     Fired,
     SkippedBusy,
+    FailedTransient,
     DisarmedDead,
     DisarmedRetired,
     Gone,
@@ -94,10 +99,10 @@ impl LoopScheduler {
 
     /// Arm (or re-arm) one emulated loop at its next fire instant.
     pub async fn arm(&self, session_id: &str, loop_id: &str, next_fire_at_ms: i64) {
-        self.armed
-            .lock()
-            .await
-            .insert((session_id.to_string(), loop_id.to_string()), next_fire_at_ms);
+        self.armed.lock().await.insert(
+            (session_id.to_string(), loop_id.to_string()),
+            next_fire_at_ms,
+        );
         self.wake.notify_one();
     }
 
@@ -164,11 +169,15 @@ impl LoopScheduler {
                 // short backoff — the driver's sleep floor handles the cadence.
                 LoopSessionLiveness::Busy => FireOutcome::SkippedBusy,
                 LoopSessionLiveness::Idle => match self.executor.fire(session_id, loop_id).await {
-                    None => {
+                    Err(error) => {
+                        tracing::warn!(session_id, loop_id, error = %error, "emulated loop fire failed transiently; keeping the arm for retry");
+                        FireOutcome::FailedTransient
+                    }
+                    Ok(None) => {
                         self.armed.lock().await.remove(&key);
                         FireOutcome::Gone
                     }
-                    Some(report) => match (report.still_armed, report.next_fire_at_ms) {
+                    Ok(Some(report)) => match (report.still_armed, report.next_fire_at_ms) {
                         (true, Some(next)) => {
                             self.armed.lock().await.insert(key.clone(), next);
                             FireOutcome::Fired
@@ -186,9 +195,9 @@ impl LoopScheduler {
     }
 
     /// Sleep duration until the next actionable moment: the earliest future
-    /// fire, floored by [`BUSY_RETRY`] when a due loop was just skipped busy,
-    /// capped by [`MAX_SLEEP`].
-    async fn next_sleep(&self, now_ms: i64, skipped_busy: bool) -> Duration {
+    /// fire, floored by [`BUSY_RETRY`] when a due loop was skipped busy or
+    /// failed transiently, capped by [`MAX_SLEEP`].
+    async fn next_sleep(&self, now_ms: i64, retry_soon: bool) -> Duration {
         let earliest_future = {
             let armed = self.armed.lock().await;
             armed.values().copied().filter(|next| *next > now_ms).min()
@@ -196,7 +205,7 @@ impl LoopScheduler {
         let mut sleep = earliest_future
             .map(|next| Duration::from_millis((next - now_ms).max(0) as u64))
             .unwrap_or(MAX_SLEEP);
-        if skipped_busy {
+        if retry_soon {
             sleep = sleep.min(BUSY_RETRY);
         }
         sleep.min(MAX_SLEEP)
@@ -208,10 +217,13 @@ impl LoopScheduler {
             loop {
                 let now = now_ms();
                 let outcomes = self.run_due_pass(now).await;
-                let skipped_busy = outcomes
-                    .iter()
-                    .any(|(_, outcome)| *outcome == FireOutcome::SkippedBusy);
-                let sleep = self.next_sleep(now, skipped_busy).await;
+                let retry_soon = outcomes.iter().any(|(_, outcome)| {
+                    matches!(
+                        *outcome,
+                        FireOutcome::SkippedBusy | FireOutcome::FailedTransient
+                    )
+                });
+                let sleep = self.next_sleep(now, retry_soon).await;
                 tokio::select! {
                     _ = tokio::time::sleep(sleep) => {}
                     _ = self.wake.notified() => {}
@@ -252,9 +264,13 @@ mod tests {
         async fn liveness(&self, _session_id: &str) -> LoopSessionLiveness {
             self.liveness
         }
-        async fn fire(&self, _session_id: &str, _loop_id: &str) -> Option<LoopFireReport> {
+        async fn fire(
+            &self,
+            _session_id: &str,
+            _loop_id: &str,
+        ) -> anyhow::Result<Option<LoopFireReport>> {
             self.fires.fetch_add(1, Ordering::SeqCst);
-            Some(self.report.clone())
+            Ok(Some(self.report.clone()))
         }
     }
 
@@ -295,7 +311,12 @@ mod tests {
         assert_eq!(idle.fires.load(Ordering::SeqCst), 1);
         // Rescheduled to the reported next fire.
         assert_eq!(
-            *scheduler.armed.lock().await.get(&("s1".into(), "l1".into())).unwrap(),
+            *scheduler
+                .armed
+                .lock()
+                .await
+                .get(&("s1".into(), "l1".into()))
+                .unwrap(),
             5_000
         );
     }
@@ -349,6 +370,109 @@ mod tests {
         let outcomes = scheduler.run_due_pass(1_500).await;
         assert_eq!(outcomes[0].1, FireOutcome::DisarmedRetired);
         assert!(!scheduler.is_armed("s1", "l1").await);
+    }
+
+    #[tokio::test]
+    async fn transient_fire_failure_keeps_the_arm_and_retries() {
+        struct FlakyExecutor {
+            fires: AtomicUsize,
+        }
+        impl FlakyExecutor {
+            fn new() -> Arc<Self> {
+                Arc::new(Self {
+                    fires: AtomicUsize::new(0),
+                })
+            }
+        }
+        #[async_trait]
+        impl LoopFireExecutor for FlakyExecutor {
+            async fn liveness(&self, _session_id: &str) -> LoopSessionLiveness {
+                LoopSessionLiveness::Idle
+            }
+            async fn fire(
+                &self,
+                _session_id: &str,
+                _loop_id: &str,
+            ) -> anyhow::Result<Option<LoopFireReport>> {
+                if self.fires.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Err(anyhow::anyhow!("sqlite blip"))
+                } else {
+                    Ok(Some(LoopFireReport {
+                        still_armed: true,
+                        next_fire_at_ms: Some(5_000),
+                    }))
+                }
+            }
+        }
+
+        let flaky = FlakyExecutor::new();
+        let scheduler = LoopScheduler::new(flaky.clone());
+        scheduler.arm("s1", "l1", 1_000).await;
+
+        // Transient failure -> FailedTransient, the arm stays at the original
+        // next_fire (1_000) so the next pass retries it.
+        let outcomes = scheduler.run_due_pass(1_500).await;
+        assert_eq!(outcomes[0].1, FireOutcome::FailedTransient);
+        assert_eq!(
+            *scheduler
+                .armed
+                .lock()
+                .await
+                .get(&("s1".into(), "l1".into()))
+                .unwrap(),
+            1_000
+        );
+        assert_eq!(flaky.fires.load(Ordering::SeqCst), 1);
+
+        // Retry succeeds -> Fired, rearmed to the reported next fire.
+        let outcomes = scheduler.run_due_pass(1_600).await;
+        assert_eq!(outcomes[0].1, FireOutcome::Fired);
+        assert_eq!(
+            *scheduler
+                .armed
+                .lock()
+                .await
+                .get(&("s1".into(), "l1".into()))
+                .unwrap(),
+            5_000
+        );
+        assert_eq!(flaky.fires.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn gone_loop_disarms() {
+        struct GoneExecutor {
+            fires: AtomicUsize,
+        }
+        impl GoneExecutor {
+            fn new() -> Arc<Self> {
+                Arc::new(Self {
+                    fires: AtomicUsize::new(0),
+                })
+            }
+        }
+        #[async_trait]
+        impl LoopFireExecutor for GoneExecutor {
+            async fn liveness(&self, _session_id: &str) -> LoopSessionLiveness {
+                LoopSessionLiveness::Idle
+            }
+            async fn fire(
+                &self,
+                _session_id: &str,
+                _loop_id: &str,
+            ) -> anyhow::Result<Option<LoopFireReport>> {
+                self.fires.fetch_add(1, Ordering::SeqCst);
+                Ok(None)
+            }
+        }
+
+        let gone = GoneExecutor::new();
+        let scheduler = LoopScheduler::new(gone.clone());
+        scheduler.arm("s1", "l1", 1_000).await;
+        let outcomes = scheduler.run_due_pass(1_500).await;
+        assert_eq!(outcomes[0].1, FireOutcome::Gone);
+        assert!(!scheduler.is_armed("s1", "l1").await);
+        assert_eq!(gone.fires.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/lints/anyharness/ratchets.toml
+++ b/lints/anyharness/ratchets.toml
@@ -50,7 +50,7 @@ reason = "goal service regression tests for pending_op idempotency"
 
 [[max_lines]]
 path = "anyharness/crates/anyharness-lib/src/domains/loops/runtime.rs"
-max_lines = 706
+max_lines = 703
 reason = "loops runtime — native write path + emulated Codex scheduler (+2b derived-safe classification comment at the fire seam; fire executor moved to its owning module in PR5; unit tests split to runtime_tests.rs to fit the extension-response decode diagnostic)"
 
 [[max_lines]]


### PR DESCRIPTION
## Summary

- `LoopFireExecutor::fire` signaled "loop cleared → disarm" by returning `None`, but every fallible step (session admission, handle lookup, sqlite `find_one`, prompt send, fire-accounting domain op) also collapsed to `None` via `.ok()?`. Any transient SQLite or actor failure silently disarmed a still-live loop; a delivered-but-unrecorded fire additionally left a stale `next_fire_at_ms` that re-fires past `max_fires` when `rearm_emulated` runs on the next attach.
- The fire contract now distinguishes the two: `fire` returns `anyhow::Result<Option<LoopFireReport>>` — `Ok(None)` still means the loop record is gone/cleared (disarm, `FireOutcome::Gone`), while `Err` means a transient failure: the scheduler keeps the arm, logs a warning, and retries on the existing busy-retry floor (new `FireOutcome::FailedTransient`, included in the driver's sleep-floor trigger).
- `LoopFireRecordOp` had a second conflation layer that swallowed store errors into `report: None`; it now propagates them (`result: anyhow::Result<Option<LoopFireReport>>`, matching the sibling arm/clear op outputs).
- When the prompt was delivered but accounting fails, the fire returns `Err` so the arm is kept: a retry may duplicate a prompt turn, which is preferred over silently disarming a live loop or double-firing past `max_fires` on reattach (noted in a comment at the accounting step). Duplicates are bounded: after `MAX_CONSECUTIVE_FIRE_FAILURES` (3) consecutive failed fires the in-memory arm is dropped with a warning (`FireOutcome::DisarmedFailing`); the persisted loop re-arms on the next attach, and a successful fire or re-arm resets the budget.
- The liveness TOCTOU between `run_due_pass`'s check and dispatch now resolves safely: a handle that disappears mid-fire returns `Err` (arm kept) and the next pass observes `Dead` and disarms, instead of the fire itself reading as loop-cleared.

Fixes PRO-348

## Testing

- Unit (tier 1, per specs/TESTING.md): `cargo test -p anyharness-lib --lib domains::loops` — 46 passed.
- New `transient_fire_failure_keeps_the_arm_and_retries` pins the regression: a first-`Err` executor leaves the loop armed at its original instant (`FailedTransient`), and the retry pass fires and rearms.
- New `gone_loop_disarms` pins that `Ok(None)` still disarms as `Gone`.
- New `repeated_fire_failures_drop_the_arm_at_the_cap` pins the consecutive-failure cap: two `FailedTransient` passes keep the arm, the third drops it as `DisarmedFailing`.
- `dead_session_fire_is_a_noop_and_does_not_cold_start` updated: a dead-session fire is now an `Err` (arm retained) rather than reading as loop-cleared; no-cold-start and untouched-record assertions unchanged.

## Observability

- The transient-failure path now logs `tracing::warn!(session_id, loop_id, error, ...)` from the scheduler pass, replacing the narrower warn inside `LoopFireRecordOp`. No metrics or scrubber delta.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- `cargo check -p anyharness-lib` clean; `rustfmt --edition 2021 --check` clean on the three touched files.
- Pre-existing, untouched: clippy `never_loop` error in `live/sessions/actor/turn/active.rs` (also present on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
