### PR TITLE
feat(desktop): allowlist auth_signed_in for signup funnel

### DIFF
--- a/apps/desktop/src/lib/integrations/telemetry/client.test.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/client.test.ts
@@ -219,4 +219,31 @@ describe("desktop telemetry client", () => {
       },
     );
   });
+
+  it("emits auth_signed_in to PostHog as the signup funnel anchor", async () => {
+    const client = await loadTelemetryClient();
+
+    expect(client.isVendorPostHogEventAllowed("auth_signed_in")).toBe(true);
+
+    client.trackProductEvent("auth_signed_in", {
+      provider: "google",
+      source: "desktop_callback",
+    });
+
+    expect(mocks.trackDesktopPostHogEventMock).toHaveBeenCalledWith(
+      "auth_signed_in",
+      {
+        provider: "google",
+        source: "desktop_callback",
+      },
+    );
+  });
+
+  it("does not emit auth_sign_in_failed to PostHog (diagnostic-only, stays in Sentry)", async () => {
+    const client = await loadTelemetryClient();
+
+    expect(client.isVendorPostHogEventAllowed("auth_sign_in_failed")).toBe(
+      false,
+    );
+  });
 });

--- a/apps/desktop/src/lib/integrations/telemetry/client.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/client.ts
@@ -49,6 +49,14 @@ const DESKTOP_POSTHOG_EVENT_ALLOWLIST = new Set<keyof DesktopProductEventMap>([
   // Low-volume reliability event (deduped per operation per app run); needed
   // in PostHog to measure how many installs cannot read keychain sessions.
   "desktop_keychain_access_failed",
+  // Signup anchor for the launch signup/activation funnel. Desktop has no
+  // distinct "account created" event (accounts are created server-side via
+  // OAuth), so the first successful sign-in is the funnel's top-of-funnel
+  // step; workspace_created / cloud_workspace_created / chat_session_created
+  // / chat_prompt_submitted (already allowlisted above) are the activation
+  // steps. auth_sign_in_failed stays out of PostHog on purpose: it is a
+  // diagnostic/failure signal, not a funnel step, and belongs to Sentry.
+  "auth_signed_in",
 ]);
 
 export function isVendorPostHogEventAllowed(


### PR DESCRIPTION
## Summary
- Adds `auth_signed_in` to the desktop PostHog event allowlist (`apps/desktop/src/lib/integrations/telemetry/client.ts:40-53`) so PostHog has a signup anchor for the launch signup + activation funnel.
- Desktop has no distinct "account created" event (accounts are created server-side via OAuth), so the first successful sign-in is the funnel's top-of-funnel step. The activation steps (`workspace_created`, `cloud_workspace_created`, `chat_session_created`, `chat_prompt_submitted`) are already allowlisted.
- `auth_sign_in_failed` is intentionally left out: it's a diagnostic/failure signal that belongs to Sentry, not a funnel step.

Part of the overnight observability push (Lane A2). No new PostHog project, no behavior change beyond what data an already-enabled vendor integration forwards — this only widens which already-typed product events reach PostHog.

## Test plan
- [x] `npx vitest run src/lib/integrations/telemetry/client.test.ts` — 6/6 pass (2 new: emits `auth_signed_in`, does not emit `auth_sign_in_failed`)
- [x] `npx vitest run src/lib/integrations/telemetry` — full telemetry suite, 42/42 pass
- [ ] CI

Per the overnight execution spec's hard rule, this lands as a pushed PR only — merge is Pablo's.