### PR TITLE
fix(desktop): redact route ids from PostHog payloads and re-enable internal replay

### DIFF
--- a/apps/desktop/src/lib/integrations/telemetry/client.test.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/client.test.ts
@@ -53,6 +53,8 @@ const mocks = vi.hoisted(() => {
     identifyDesktopPostHogUserMock: vi.fn(),
     resetDesktopPostHogUserMock: vi.fn(),
     trackDesktopPostHogEventMock: vi.fn(),
+    startDesktopPostHogSessionReplayMock: vi.fn(),
+    stopDesktopPostHogSessionReplayMock: vi.fn(),
   };
 });
 
@@ -90,6 +92,8 @@ vi.mock("./posthog", () => ({
   identifyDesktopPostHogUser: mocks.identifyDesktopPostHogUserMock,
   resetDesktopPostHogUser: mocks.resetDesktopPostHogUserMock,
   trackDesktopPostHogEvent: mocks.trackDesktopPostHogEventMock,
+  startDesktopPostHogSessionReplay: mocks.startDesktopPostHogSessionReplayMock,
+  stopDesktopPostHogSessionReplay: mocks.stopDesktopPostHogSessionReplayMock,
 }));
 
 async function loadTelemetryClient() {
@@ -123,6 +127,8 @@ describe("desktop telemetry client", () => {
     mocks.identifyDesktopPostHogUserMock.mockClear();
     mocks.resetDesktopPostHogUserMock.mockClear();
     mocks.trackDesktopPostHogEventMock.mockClear();
+    mocks.startDesktopPostHogSessionReplayMock.mockClear();
+    mocks.stopDesktopPostHogSessionReplayMock.mockClear();
   });
 
   it("initializes vendor telemetry only when vendor routing is enabled", async () => {
@@ -197,6 +203,72 @@ describe("desktop telemetry client", () => {
         mocks.identifyDesktopPostHogUserMock.mock.calls,
       ]),
     ).not.toContain("Test User");
+  });
+
+  it("leaves session replay off for a customer account", async () => {
+    const client = await loadTelemetryClient();
+
+    client.setTelemetryUser({
+      id: "user-123",
+      email: "someone@customer.example",
+      display_name: null,
+    });
+
+    expect(mocks.identifyDesktopPostHogUserMock).toHaveBeenCalledWith("user-123");
+    expect(mocks.startDesktopPostHogSessionReplayMock).not.toHaveBeenCalled();
+  });
+
+  it("starts session replay for the internal audience only", async () => {
+    const client = await loadTelemetryClient();
+
+    client.setTelemetryUser({
+      id: "user-456",
+      email: "pablo@proliferate.com",
+      display_name: null,
+    });
+
+    expect(mocks.startDesktopPostHogSessionReplayMock).toHaveBeenCalledOnce();
+    // The address is a local decision input, never a transmitted property.
+    expect(
+      JSON.stringify(mocks.startDesktopPostHogSessionReplayMock.mock.calls),
+    ).not.toContain("pablo@proliferate.com");
+    expect(
+      JSON.stringify(mocks.identifyDesktopPostHogUserMock.mock.calls),
+    ).not.toContain("pablo@proliferate.com");
+  });
+
+  it("does not start replay when vendor routing is off", async () => {
+    mocks.runtimeState = {
+      disabled: false,
+      telemetryMode: "self_managed",
+      anonymousEnabled: true,
+      vendorEnabled: false,
+    };
+
+    const client = await loadTelemetryClient();
+    client.setTelemetryUser({
+      id: "user-456",
+      email: "pablo@proliferate.com",
+      display_name: null,
+    });
+
+    expect(mocks.startDesktopPostHogSessionReplayMock).not.toHaveBeenCalled();
+  });
+
+  it("stops replay before clearing identity on sign-out", async () => {
+    const client = await loadTelemetryClient();
+
+    client.setTelemetryUser({
+      id: "user-456",
+      email: "pablo@proliferate.dev",
+      display_name: null,
+    });
+    client.clearTelemetryUser();
+
+    expect(mocks.stopDesktopPostHogSessionReplayMock).toHaveBeenCalledOnce();
+    expect(
+      mocks.stopDesktopPostHogSessionReplayMock.mock.invocationCallOrder[0],
+    ).toBeLessThan(mocks.resetDesktopPostHogUserMock.mock.invocationCallOrder[0]);
   });
 
   it("emits desktop_keychain_access_failed to PostHog", async () => {

--- a/apps/desktop/src/lib/integrations/telemetry/client.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/client.ts
@@ -8,6 +8,7 @@ import {
   resolveDesktopTelemetryRoutingState,
 } from "@proliferate/product-client/internal/lib/domain/telemetry/mode";
 import type { AuthUser } from "@proliferate/product-client/internal/lib/domain/auth/auth-user";
+import { isInternalReplayAudience } from "@proliferate/product-client/internal/domain/telemetry/replay-audience";
 import {
   getProliferateApiBaseUrl,
   getProliferateApiOrigin,
@@ -22,6 +23,8 @@ import {
   initializeDesktopPostHog,
   getDesktopPostHogSupportRefs,
   resetDesktopPostHogUser,
+  startDesktopPostHogSessionReplay,
+  stopDesktopPostHogSessionReplay,
   trackDesktopPostHogEvent,
 } from "./posthog";
 import {
@@ -144,6 +147,15 @@ export function setTelemetryUser(user: AuthUser): void {
 
   setDesktopSentryUser(user.id);
   identifyDesktopPostHogUser(user.id);
+
+  // Session replay is staged: the route-identifier leak that caused the
+  // 2026-08-18 disable is fixed and proven at the payload level, but the live
+  // synthetic qualification #2093/#2096 required has not run, so recording is
+  // limited to the internal audience. The address is read locally to make this
+  // decision and is never sent: PostHog identity stays UUID-only above.
+  if (isInternalReplayAudience(user.email)) {
+    startDesktopPostHogSessionReplay();
+  }
 }
 
 export function clearTelemetryUser(): void {
@@ -151,6 +163,8 @@ export function clearTelemetryUser(): void {
     return;
   }
 
+  // Stop before reset so no frames are recorded against a signed-out session.
+  stopDesktopPostHogSessionReplay();
   clearDesktopSentryUser();
   resetDesktopPostHogUser();
 }

--- a/apps/desktop/src/lib/integrations/telemetry/posthog.test.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/posthog.test.ts
@@ -64,6 +64,8 @@ describe("desktop PostHog adapter", () => {
       capture_pageleave: false,
       person_profiles: "identified_only",
       disable_session_recording: true,
+      // Local literal, so the PostHog project cannot start console capture.
+      enable_recording_console_log: false,
     });
     const scrub = await import("./scrub");
     expect(beforeSend).toBe(scrub.scrubPostHogPayload);
@@ -75,6 +77,7 @@ describe("desktop PostHog adapter", () => {
       "capture_pageleave",
       "capture_pageview",
       "disable_session_recording",
+      "enable_recording_console_log",
       "person_profiles",
       "session_recording",
     ]);
@@ -95,6 +98,12 @@ describe("desktop PostHog adapter", () => {
     expect(options.recordHeaders).toBe(false);
     expect(options.recordBody).toBe(false);
     expect(options.maskCapturedNetworkRequestFn()).toBeNull();
+
+    // Canvas frames are pixels; `maskTextSelector: "*"` does not reach them,
+    // and `@xterm/addon-canvas` renders terminal output to a canvas. This must
+    // stay a local literal `false` or the PostHog project's
+    // `canvasRecording.enabled` decides on its own.
+    expect(options.captureCanvas).toEqual({ recordCanvas: false });
 
     // Dormant forward-compatibility, NOT coverage: the pinned
     // posthog-js@1.386.8 forwards only maskAllInputs/maskTextSelector/

--- a/apps/desktop/src/lib/integrations/telemetry/posthog.test.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/posthog.test.ts
@@ -96,7 +96,12 @@ describe("desktop PostHog adapter", () => {
     expect(options.recordBody).toBe(false);
     expect(options.maskCapturedNetworkRequestFn()).toBeNull();
 
-    // The recorder-boundary half of the route-id fix.
+    // Dormant forward-compatibility, NOT coverage: the pinned
+    // posthog-js@1.386.8 forwards only maskAllInputs/maskTextSelector/
+    // blockSelector to rrweb and never invokes this callback. It is asserted
+    // so the wiring stays correct for a future SDK pin. The live proof that
+    // route ids never reach a payload is the before_send boundary, in
+    // product-client's route-id-redaction.test.ts.
     expect(options.maskAttributeFn("href", "/workflows/wf-secret-id")).toBe(
       "/workflows/:workflowId",
     );

--- a/apps/desktop/src/lib/integrations/telemetry/posthog.test.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/posthog.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   identify: vi.fn(),
   reset: vi.fn(),
   startSessionRecording: vi.fn(),
+  stopSessionRecording: vi.fn(),
 }));
 
 vi.mock("posthog-js", () => ({
@@ -36,9 +37,10 @@ describe("desktop PostHog adapter", () => {
     mocks.identify.mockReset();
     mocks.reset.mockReset();
     mocks.startSessionRecording.mockReset();
+    mocks.stopSessionRecording.mockReset();
   });
 
-  it("initializes once with recording disabled and no recording surfaces", async () => {
+  it("initializes once with recording disabled and no auto-start surface", async () => {
     const adapter = await loadDesktopPostHog();
     adapter.initializeDesktopPostHog(ENABLED_CONFIG);
     adapter.initializeDesktopPostHog(ENABLED_CONFIG);
@@ -50,7 +52,11 @@ describe("desktop PostHog adapter", () => {
       Record<string, unknown>,
     ];
     expect(apiKey).toBe("phc_test");
-    const { before_send: beforeSend, ...rest } = options;
+    const {
+      before_send: beforeSend,
+      session_recording: sessionRecording,
+      ...rest
+    } = options;
     expect(rest).toEqual({
       api_host: "https://us.i.posthog.com",
       autocapture: false,
@@ -61,6 +67,7 @@ describe("desktop PostHog adapter", () => {
     });
     const scrub = await import("./scrub");
     expect(beforeSend).toBe(scrub.scrubPostHogPayload);
+    expect(sessionRecording).toBe(adapter.DESKTOP_SESSION_RECORDING_OPTIONS);
     expect(Object.keys(options).sort()).toEqual([
       "api_host",
       "autocapture",
@@ -69,8 +76,148 @@ describe("desktop PostHog adapter", () => {
       "capture_pageview",
       "disable_session_recording",
       "person_profiles",
+      "session_recording",
     ]);
+    // No `loaded` callback and no start call: recording cannot begin at init.
+    expect(options.loaded).toBeUndefined();
     expect(mocks.startSessionRecording).not.toHaveBeenCalled();
+  });
+
+  it("pins the recorder to mask content and redact route identifiers", async () => {
+    const adapter = await loadDesktopPostHog();
+    const options = adapter.DESKTOP_SESSION_RECORDING_OPTIONS;
+
+    expect(options.maskAllInputs).toBe(true);
+    expect(options.maskTextSelector).toBe("*");
+    expect(options.blockSelector).toBe("[data-telemetry-block]");
+    expect(options.collectFonts).toBe(false);
+    expect(options.recordCrossOriginIframes).toBe(false);
+    expect(options.recordHeaders).toBe(false);
+    expect(options.recordBody).toBe(false);
+    expect(options.maskCapturedNetworkRequestFn()).toBeNull();
+
+    // The recorder-boundary half of the route-id fix.
+    expect(options.maskAttributeFn("href", "/workflows/wf-secret-id")).toBe(
+      "/workflows/:workflowId",
+    );
+    expect(
+      options.maskAttributeFn("src", "https://app.proliferate.com/workspaces/ws-secret"),
+    ).toBe("https://app.proliferate.com/workspaces/:workspaceId");
+  });
+
+  it("starts replay only when explicitly asked, and only once", async () => {
+    const adapter = await loadDesktopPostHog();
+    adapter.initializeDesktopPostHog(ENABLED_CONFIG);
+
+    adapter.startDesktopPostHogSessionReplay();
+    adapter.startDesktopPostHogSessionReplay();
+
+    expect(mocks.startSessionRecording).toHaveBeenCalledOnce();
+
+    adapter.stopDesktopPostHogSessionReplay();
+    adapter.stopDesktopPostHogSessionReplay();
+
+    expect(mocks.stopSessionRecording).toHaveBeenCalledOnce();
+  });
+
+  it("refuses to start or stop replay before initialization", async () => {
+    const adapter = await loadDesktopPostHog();
+
+    adapter.startDesktopPostHogSessionReplay();
+    adapter.stopDesktopPostHogSessionReplay();
+
+    expect(mocks.startSessionRecording).not.toHaveBeenCalled();
+    expect(mocks.stopSessionRecording).not.toHaveBeenCalled();
+  });
+
+  it("refuses to stop a replay that never started", async () => {
+    const adapter = await loadDesktopPostHog();
+    adapter.initializeDesktopPostHog(ENABLED_CONFIG);
+
+    adapter.stopDesktopPostHogSessionReplay();
+
+    expect(mocks.stopSessionRecording).not.toHaveBeenCalled();
+  });
+
+  it("strips route identifiers from the replay payload posthog would send", async () => {
+    const adapter = await loadDesktopPostHog();
+    adapter.initializeDesktopPostHog(ENABLED_CONFIG);
+
+    const [, options] = mocks.init.mock.calls[0] as [string, Record<string, unknown>];
+    const beforeSend = options.before_send as (
+      event: Record<string, unknown> | null,
+    ) => Record<string, unknown> | null;
+
+    const workflowId = "wf-8e1c4a92-route-id-leak-probe";
+    const workspaceId = "ws-c30a6e75-route-id-leak-probe";
+
+    // Nested past the shared scrubber's depth cap so this also proves the
+    // replay stream is not shredded on its way through `before_send`.
+    let node: Record<string, unknown> = {
+      type: 2,
+      tagName: "a",
+      attributes: { href: `/workspaces/${workspaceId}`, class: "deep-link" },
+      childNodes: [],
+    };
+    for (let depth = 0; depth < 14; depth += 1) {
+      node = {
+        type: 2,
+        tagName: "div",
+        attributes: { class: `layer-${depth}` },
+        childNodes: [node],
+      };
+    }
+
+    const sent = beforeSend({
+      event: "$snapshot",
+      properties: {
+        $current_url: `https://app.proliferate.com/workflows/${workflowId}`,
+        $pathname: `/workflows/${workflowId}`,
+        $snapshot_data: [
+          {
+            type: 4,
+            data: { href: `https://app.proliferate.com/workflows/${workflowId}` },
+          },
+          { type: 2, data: { node } },
+        ],
+      },
+    });
+
+    const serialized = JSON.stringify(sent);
+    expect(serialized).not.toContain(workflowId);
+    expect(serialized).not.toContain(workspaceId);
+    expect(serialized).toContain("/workflows/:workflowId");
+    expect(serialized).toContain("/workspaces/:workspaceId");
+    // The replay stream survives the scrubber intact enough to play back.
+    expect(serialized).not.toContain("[truncated]");
+    expect(serialized).toContain("layer-13");
+    expect(serialized).toContain("deep-link");
+  });
+
+  it("still scrubs non-replay captures through the shared scrubber", async () => {
+    const adapter = await loadDesktopPostHog();
+    adapter.initializeDesktopPostHog(ENABLED_CONFIG);
+
+    const [, options] = mocks.init.mock.calls[0] as [string, Record<string, unknown>];
+    const beforeSend = options.before_send as (
+      event: Record<string, unknown> | null,
+    ) => Record<string, unknown> | null;
+
+    const sent = beforeSend({
+      event: "chat_prompt_submitted",
+      properties: {
+        agent_kind: "claude",
+        prompt: "write my private code",
+        $current_url: "https://app.proliferate.com/workspaces/ws-secret",
+      },
+    });
+
+    const properties = sent?.properties as Record<string, unknown>;
+    expect(properties.prompt).toBe("[redacted]");
+    expect(properties.agent_kind).toBe("claude");
+    expect(properties.$current_url).toBe(
+      "https://app.proliferate.com/workspaces/:workspaceId",
+    );
   });
 
   it("captures typed product events through the scrubber", async () => {

--- a/apps/desktop/src/lib/integrations/telemetry/posthog.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/posthog.ts
@@ -14,9 +14,21 @@ let sessionReplayStarted = false;
  * (`maskAllInputs`, `maskTextSelector: "*"`, `blockSelector`) hides rendered
  * page *content*. It does nothing about URLs, which is exactly why the
  * 2026-08-18 disable (#2093) could not be answered with masking alone.
- * `maskAttributeFn` closes the attribute half of that gap at the recorder
- * boundary, and `before_send` closes the event-property and rrweb Meta-event
- * half. Network capture is refused outright rather than masked.
+ * Network capture is refused outright rather than masked.
+ *
+ * `before_send` is the single load-bearing boundary for route identifiers.
+ * It must keep covering URL-valued DOM attributes inside `$snapshot_data`,
+ * not only the rrweb Meta event and the `$current_url`-style properties. Do
+ * not narrow it on the assumption that `maskAttributeFn` covers attributes:
+ * the pinned `posthog-js@1.386.8` never invokes that callback. Its bundled
+ * recorder contains zero occurrences of the name, and the SDK forwards
+ * exactly three masking keys to rrweb (`maskAllInputs`, `maskTextSelector`,
+ * `blockSelector`) in the `Th` getter of `dist/lazy-recorder.js`. The option
+ * is declared only by the newer transitive `@posthog/types@1.404.1`, which is
+ * why it typechecks. It is kept here so the recorder boundary starts working
+ * on its own the day the SDK pin moves to a version that honors it, and
+ * `route-id-redaction.test.ts` asserts the capture boundary closes the leak
+ * without it.
  */
 export const DESKTOP_SESSION_RECORDING_OPTIONS = {
   maskAllInputs: true,

--- a/apps/desktop/src/lib/integrations/telemetry/posthog.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/posthog.ts
@@ -41,6 +41,14 @@ export const DESKTOP_SESSION_RECORDING_OPTIONS = {
   recordHeaders: false,
   recordBody: false,
   maskCapturedNetworkRequestFn: () => null,
+  // Pins canvas recording off against the provider. Without this key the
+  // resolution in the `Rh` getter of posthog-js `dist/lazy-recorder.js` is
+  // `config.session_recording.captureCanvas?.recordCanvas ??
+  // remoteConfig.canvasRecording?.enabled`, so the PostHog project alone could
+  // turn it on. That matters here: `@xterm/addon-canvas` renders terminal
+  // output to a canvas, and canvas frames are captured as pixels, which
+  // `maskTextSelector: "*"` does not reach. A literal `false` wins the `??`.
+  captureCanvas: { recordCanvas: false },
 } as const;
 
 interface DesktopPostHogInitConfig {
@@ -73,6 +81,14 @@ export function initializeDesktopPostHog(config: DesktopPostHogInitConfig): void
     // requires `enabled_server_side && !disable_session_recording`).
     disable_session_recording: true,
     session_recording: DESKTOP_SESSION_RECORDING_OPTIONS,
+    // Pins console capture off against the provider. The `xh` getter in
+    // posthog-js `dist/lazy-recorder.js` resolves
+    // `config.enable_recording_console_log ??
+    // remoteConfig.consoleLogRecordingEnabled`, so leaving it unset would let
+    // the PostHog project alone start recording console output into the replay
+    // stream. Console arguments are arbitrary app strings that the route-id
+    // redactor deliberately does not rewrite, so this has to be a local literal.
+    enable_recording_console_log: false,
   });
 
   posthog.register({

--- a/apps/desktop/src/lib/integrations/telemetry/posthog.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/posthog.ts
@@ -1,9 +1,35 @@
 import posthog from "posthog-js";
 import type { DesktopTelemetryConfig } from "./config";
 import type { DesktopProductEventMap } from "@proliferate/product-client/internal/lib/domain/telemetry/events";
+import { redactRouteIdentifiersInAttribute } from "@proliferate/product-client/internal/domain/telemetry/route-id-redaction";
 import { scrubPostHogPayload, scrubTelemetryData } from "./scrub";
 
 let posthogInitialized = false;
+let sessionReplayStarted = false;
+
+/**
+ * Recorder configuration for Desktop session replay.
+ *
+ * Masking and redaction are separate concerns and both are required. Masking
+ * (`maskAllInputs`, `maskTextSelector: "*"`, `blockSelector`) hides rendered
+ * page *content*. It does nothing about URLs, which is exactly why the
+ * 2026-08-18 disable (#2093) could not be answered with masking alone.
+ * `maskAttributeFn` closes the attribute half of that gap at the recorder
+ * boundary, and `before_send` closes the event-property and rrweb Meta-event
+ * half. Network capture is refused outright rather than masked.
+ */
+export const DESKTOP_SESSION_RECORDING_OPTIONS = {
+  maskAllInputs: true,
+  maskTextSelector: "*",
+  blockSelector: "[data-telemetry-block]",
+  maskAttributeFn: (name: string, value: string) =>
+    redactRouteIdentifiersInAttribute(name, value),
+  collectFonts: false,
+  recordCrossOriginIframes: false,
+  recordHeaders: false,
+  recordBody: false,
+  maskCapturedNetworkRequestFn: () => null,
+} as const;
 
 interface DesktopPostHogInitConfig {
   environment: string;
@@ -27,7 +53,14 @@ export function initializeDesktopPostHog(config: DesktopPostHogInitConfig): void
     capture_pageleave: false,
     person_profiles: "identified_only",
     before_send: scrubPostHogPayload,
+    // Recording never auto-starts. It begins only when
+    // `startDesktopPostHogSessionReplay()` is called for a signed-in member of
+    // the internal replay audience, and only if the PostHog project has replay
+    // enabled server-side as well (posthog-js
+    // `src/extensions/replay/session-recording.ts` `_isRecordingEnabled`
+    // requires `enabled_server_side && !disable_session_recording`).
     disable_session_recording: true,
+    session_recording: DESKTOP_SESSION_RECORDING_OPTIONS,
   });
 
   posthog.register({
@@ -50,6 +83,23 @@ export function identifyDesktopPostHogUser(userId: string): void {
   if (!posthogInitialized) return;
 
   posthog.identify(userId);
+}
+
+/**
+ * Begin recording. Only `client.ts` calls this, and only after checking
+ * `isInternalReplayAudience(user.email)`; there is no configuration surface
+ * that reaches it.
+ */
+export function startDesktopPostHogSessionReplay(): void {
+  if (!posthogInitialized || sessionReplayStarted) return;
+  sessionReplayStarted = true;
+  posthog.startSessionRecording();
+}
+
+export function stopDesktopPostHogSessionReplay(): void {
+  if (!posthogInitialized || !sessionReplayStarted) return;
+  sessionReplayStarted = false;
+  posthog.stopSessionRecording();
 }
 
 export function resetDesktopPostHogUser(): void {

--- a/apps/desktop/src/lib/integrations/telemetry/scrub.ts
+++ b/apps/desktop/src/lib/integrations/telemetry/scrub.ts
@@ -5,6 +5,9 @@ import {
   scrubTelemetryEvent as scrubSharedTelemetryEvent,
   scrubTelemetryText,
 } from "@proliferate/product-client/internal/domain/telemetry/scrub";
+import {
+  redactRouteIdentifiersInCapture,
+} from "@proliferate/product-client/internal/domain/telemetry/route-id-redaction";
 import type { CaptureResult } from "posthog-js/lib/src/types";
 
 export function scrubTelemetryData<T>(value: T): T {
@@ -152,9 +155,41 @@ function scrubPostHogProperties<T>(value: T): T {
   return scrubSharedTelemetryData(value, { preservePostHogInternalKeys: true });
 }
 
+/**
+ * The single `before_send` for Desktop PostHog. Two passes, in order:
+ *
+ * 1. the shared scrubber, which removes sensitive keys and secret-shaped text;
+ * 2. route-identifier redaction, which reduces every URL and every rrweb
+ *    `href`/`src` to a bounded route template.
+ *
+ * Pass 2 is not redundant. The shared scrubber exempts `$`-prefixed PostHog
+ * keys from key redaction and `scrubTelemetryUrl` deliberately keeps the URL
+ * path, so `$current_url` and the rrweb Meta event `href` reach the provider
+ * with `/workflows/<id>` intact without it. See
+ * `product-client/src/domain/telemetry/route-id-redaction.ts`.
+ *
+ * The replay stream is deliberately held out of pass 1. The shared scrubber
+ * bounds container depth, array positions, and object properties, so a real
+ * rrweb DOM snapshot would come back as `[truncated]` markers rather than a
+ * playable recording. Pass 2 owns that stream instead: it walks it without a
+ * depth cap and rewrites only URL-bearing and content-bearing fields. rrweb
+ * text and input content is controlled by the recorder's masking
+ * configuration, not by this scrubber.
+ */
 export function scrubPostHogPayload(
   event: CaptureResult | null,
 ): CaptureResult | null {
   if (!event) return event;
-  return scrubPostHogProperties(event);
+
+  const snapshotData = event.properties?.$snapshot_data;
+  if (snapshotData === undefined) {
+    return redactRouteIdentifiersInCapture(scrubPostHogProperties(event));
+  }
+
+  const { $snapshot_data: heldStream, ...restProperties } = event.properties;
+  const scrubbed = scrubPostHogProperties({ ...event, properties: restProperties });
+  return redactRouteIdentifiersInCapture({
+    ...scrubbed,
+    properties: { ...scrubbed.properties, $snapshot_data: heldStream },
+  });
 }

--- a/apps/packages/product-client/src/domain/telemetry/replay-audience.test.ts
+++ b/apps/packages/product-client/src/domain/telemetry/replay-audience.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  INTERNAL_REPLAY_EMAIL_DOMAINS,
+  isInternalReplayAudience,
+} from "./replay-audience";
+
+describe("isInternalReplayAudience", () => {
+  it.each(INTERNAL_REPLAY_EMAIL_DOMAINS)("admits an address at %s", (domain) => {
+    expect(isInternalReplayAudience(`pablo@${domain}`)).toBe(true);
+    expect(isInternalReplayAudience(`  Pablo@${domain.toUpperCase()}  `)).toBe(true);
+  });
+
+  it.each([
+    ["a customer address", "someone@customer.example"],
+    ["a look-alike domain", "someone@notproliferate.com"],
+    ["a suffixed look-alike", "someone@proliferate.com.attacker.net"],
+    ["a subdomain", "someone@mail.proliferate.com"],
+    ["a domain in the local part", "proliferate.com@customer.example"],
+    ["an address with no domain", "someone@"],
+    ["an address with no local part", "@proliferate.com"],
+    ["a bare domain", "proliferate.com"],
+    ["an embedded address", "someone@customer.example someone@proliferate.com"],
+    ["an empty string", ""],
+    ["whitespace", "   "],
+  ])("rejects %s", (_case, email) => {
+    expect(isInternalReplayAudience(email)).toBe(false);
+  });
+
+  it.each([null, undefined])("rejects %p", (email) => {
+    expect(isInternalReplayAudience(email)).toBe(false);
+  });
+
+  it("keeps the audience a closed source-owned list", () => {
+    expect(INTERNAL_REPLAY_EMAIL_DOMAINS).toEqual(["proliferate.com", "proliferate.dev"]);
+  });
+});

--- a/apps/packages/product-client/src/domain/telemetry/replay-audience.ts
+++ b/apps/packages/product-client/src/domain/telemetry/replay-audience.ts
@@ -1,0 +1,49 @@
+/**
+ * Who session replay is allowed to record.
+ *
+ * Replay re-enablement is staged. The route-identifier leak that caused the
+ * 2026-08-18 source disable (#2083, #2093, #2096, #2097) is fixed and proven
+ * at the payload level by `./route-id-redaction`, but the live synthetic
+ * qualification that #2093 and #2096 named as the re-enable bar (real rrweb
+ * output from the real app, plus controlled provider arrival) has not been
+ * executed. Until it has, recording starts only for the internal audience.
+ *
+ * This is a source-owned closed list, not a configuration surface: there is no
+ * environment variable, build value, or provider setting that widens it.
+ * Widening it to customers is a reviewed source change to this file.
+ *
+ * The address is evaluated locally and never transmitted. PostHog identity
+ * stays UUID-only (`identify(user.id)`), and `./scrub` redacts any `email`
+ * key that reaches a payload.
+ */
+
+/**
+ * Email domains treated as internal for replay purposes. Exact host match
+ * only, so a look-alike domain (`notproliferate.com`,
+ * `proliferate.com.example.net`) and a subdomain (`sub.proliferate.com`) are
+ * both outside the audience.
+ */
+export const INTERNAL_REPLAY_EMAIL_DOMAINS: readonly string[] = [
+  "proliferate.com",
+  "proliferate.dev",
+];
+
+/**
+ * True when this signed-in address belongs to the internal replay audience.
+ * Anything ambiguous is false: replay stays off unless the address clearly
+ * matches.
+ */
+export function isInternalReplayAudience(email: string | null | undefined): boolean {
+  if (typeof email !== "string") return false;
+
+  const normalized = email.trim().toLowerCase();
+  const separatorIndex = normalized.lastIndexOf("@");
+  if (separatorIndex <= 0 || separatorIndex === normalized.length - 1) return false;
+
+  const localPart = normalized.slice(0, separatorIndex);
+  const domain = normalized.slice(separatorIndex + 1);
+  // A whitespace-bearing address is malformed; treat it as untrusted input.
+  if (/\s/.test(normalized) || localPart.length === 0) return false;
+
+  return INTERNAL_REPLAY_EMAIL_DOMAINS.includes(domain);
+}

--- a/apps/packages/product-client/src/domain/telemetry/route-id-redaction.test.ts
+++ b/apps/packages/product-client/src/domain/telemetry/route-id-redaction.test.ts
@@ -235,6 +235,39 @@ describe("redactRouteIdentifiersInCapture", () => {
     expect(serialized).not.toContain("[truncated]");
   });
 
+  it("closes the DOM-attribute half without the recorder callback", () => {
+    // Guards the one thing a reader is most likely to get wrong. Desktop also
+    // wires this module as posthog-js `session_recording.maskAttributeFn`, but
+    // the pinned posthog-js@1.386.8 never invokes it: the option is declared
+    // only by the newer transitive @posthog/types@1.404.1, and the SDK
+    // forwards exactly maskAllInputs/maskTextSelector/blockSelector to rrweb.
+    // So `before_send` alone has to reach serialized DOM attributes. If this
+    // test is ever weakened because "the recorder masks attributes", the
+    // 2026-08-18 leak reopens.
+    const redacted = redactRouteIdentifiersInCapture(buildSnapshotCapture());
+    const stream = (redacted?.properties as Record<string, unknown>)
+      .$snapshot_data as Array<Record<string, unknown>>;
+
+    const documentNode = (stream[1].data as { node: Record<string, unknown> }).node;
+    const html = (documentNode.childNodes as Array<Record<string, unknown>>)[1];
+    const head = (html.childNodes as Array<Record<string, unknown>>)[0];
+    const link = (head.childNodes as Array<Record<string, unknown>>)[0];
+
+    // `<link rel="canonical" href>` in the serialized head.
+    expect((link.attributes as Record<string, string>).href).toBe(
+      `${ORIGIN}/workflows/:workflowId`,
+    );
+
+    // `<a href>` fourteen levels below the shared scrubber's depth cap.
+    let node = (html.childNodes as Array<Record<string, unknown>>)[1];
+    while ((node.tagName as string) !== "a") {
+      node = (node.childNodes as Array<Record<string, unknown>>)[0];
+    }
+    expect((node.attributes as Record<string, string>).href).toBe(
+      "/workspaces/:workspaceId",
+    );
+  });
+
   it("redacts attribute-mutation and custom rrweb events", () => {
     const redacted = redactRouteIdentifiersInCapture(buildSnapshotCapture());
     const stream = (redacted?.properties as Record<string, unknown>)

--- a/apps/packages/product-client/src/domain/telemetry/route-id-redaction.test.ts
+++ b/apps/packages/product-client/src/domain/telemetry/route-id-redaction.test.ts
@@ -1,0 +1,449 @@
+import { describe, expect, it } from "vitest";
+
+import { scrubTelemetryData } from "./scrub";
+import {
+  BOUNDED_ROUTE_TEMPLATES,
+  MAX_REDACTION_VISITS,
+  REDACTED_URL,
+  UNKNOWN_BOUNDED_ROUTE,
+  boundRoutePathname,
+  boundRouteUrl,
+  redactRouteIdentifiersInAttribute,
+  redactRouteIdentifiersInCapture,
+  redactRouteIdentifiersInText,
+} from "./route-id-redaction";
+
+// Distinctive so an absence assertion cannot pass by accident on a substring
+// of some other value in the payload.
+const WORKFLOW_ID = "wf-8e1c4a92-route-id-leak-probe";
+const RUN_ID = "run-5b7d0f31-route-id-leak-probe";
+const WORKSPACE_ID = "ws-c30a6e75-route-id-leak-probe";
+const ORG_SLUG = "acme-holdings-route-id-leak-probe";
+
+const ORIGIN = "https://app.proliferate.com";
+const LEAKING_URL = `${ORIGIN}/workflows/${WORKFLOW_ID}/runs/${RUN_ID}?invite=secret#panel`;
+const BOUNDED_URL = `${ORIGIN}/workflows/:workflowId/runs/:runId`;
+
+const ALL_IDENTIFIERS = [WORKFLOW_ID, RUN_ID, WORKSPACE_ID, ORG_SLUG];
+
+/**
+ * A serialized rrweb DOM deep enough that the shared scrubber's depth cap
+ * (`MAX_SCRUB_DEPTH = 10` in `./scrub`) would replace it with a truncation
+ * marker. The leaking `href` sits at the bottom.
+ */
+function buildDeepSerializedDom() {
+  let node: Record<string, unknown> = {
+    type: 2,
+    tagName: "a",
+    attributes: {
+      class: "sidebar-link",
+      href: `/workspaces/${WORKSPACE_ID}`,
+      "data-testid": "workspace-link",
+      title: "Open /Users/pablo/proliferate/apps/desktop",
+    },
+    childNodes: [{ type: 3, id: 991, textContent: "***** ****" }],
+    id: 990,
+  };
+
+  for (let depth = 0; depth < 14; depth += 1) {
+    node = {
+      type: 2,
+      tagName: "div",
+      attributes: { class: `layer-${depth}` },
+      childNodes: [node],
+      id: 900 - depth,
+    };
+  }
+
+  return {
+    type: 0,
+    childNodes: [
+      { type: 1, name: "html", publicId: "", systemId: "", id: 2 },
+      {
+        type: 2,
+        tagName: "html",
+        attributes: {},
+        id: 3,
+        childNodes: [
+          {
+            type: 2,
+            tagName: "head",
+            attributes: {},
+            id: 4,
+            childNodes: [
+              {
+                type: 2,
+                tagName: "link",
+                attributes: {
+                  rel: "canonical",
+                  href: `${ORIGIN}/workflows/${WORKFLOW_ID}`,
+                },
+                childNodes: [],
+                id: 5,
+              },
+            ],
+          },
+          {
+            type: 2,
+            tagName: "body",
+            attributes: {},
+            id: 6,
+            childNodes: [node],
+          },
+        ],
+      },
+    ],
+    id: 1,
+  };
+}
+
+/**
+ * The shape posthog-js hands to `before_send` for a replay chunk: the rrweb
+ * stream under `properties.$snapshot_data`, plus the URL properties that
+ * `calculateEventProperties` attaches to every event.
+ */
+function buildSnapshotCapture() {
+  return {
+    event: "$snapshot",
+    properties: {
+      $session_id: "0198f0c2-1111-7000-8000-aaaaaaaaaaaa",
+      $window_id: "0198f0c2-2222-7000-8000-bbbbbbbbbbbb",
+      $current_url: LEAKING_URL,
+      $pathname: `/workflows/${WORKFLOW_ID}/runs/${RUN_ID}`,
+      $host: "app.proliferate.com",
+      $referrer: `${ORIGIN}/workspaces/${WORKSPACE_ID}`,
+      $session_entry_url: `${ORIGIN}/join/${ORG_SLUG}`,
+      $prev_pageview_pathname: `/workspaces/${WORKSPACE_ID}`,
+      $set_once: {
+        $initial_current_url: `${ORIGIN}/login/${ORG_SLUG}`,
+        $initial_pathname: `/login/${ORG_SLUG}`,
+      },
+      $snapshot_bytes: 4096,
+      $snapshot_data: [
+        {
+          type: 4,
+          timestamp: 1_755_000_000_000,
+          data: { href: LEAKING_URL, width: 1440, height: 900 },
+        },
+        {
+          type: 2,
+          timestamp: 1_755_000_000_010,
+          data: { node: buildDeepSerializedDom(), initialOffset: { top: 0, left: 0 } },
+        },
+        {
+          type: 3,
+          timestamp: 1_755_000_000_020,
+          data: {
+            source: 0,
+            attributes: [
+              { id: 990, attributes: { href: `/workflows/${WORKFLOW_ID}` } },
+            ],
+            texts: [],
+            removes: [],
+            adds: [],
+          },
+        },
+        {
+          type: 5,
+          timestamp: 1_755_000_000_030,
+          data: {
+            tag: "$pageview",
+            payload: { href: `${ORIGIN}/workspaces/${WORKSPACE_ID}` },
+          },
+        },
+        {
+          type: 5,
+          timestamp: 1_755_000_000_040,
+          data: {
+            tag: "performance",
+            payload: {
+              name: `${ORIGIN}/api/v1/workflows/${WORKFLOW_ID}`,
+              initiatorType: "fetch",
+            },
+          },
+        },
+      ],
+    },
+  };
+}
+
+describe("the leak this module exists to close", () => {
+  it("shows the shared scrubber leaves every route identifier in the payload", () => {
+    // Executable record of the 2026-08-18 finding. `preservePostHogInternalKeys`
+    // exempts `$`-prefixed keys from key redaction, and `scrubTelemetryUrl`
+    // keeps the path, so the shared scrubber is a no-op for this class.
+    const scrubbed = scrubTelemetryData(buildSnapshotCapture(), {
+      preservePostHogInternalKeys: true,
+    });
+    const serialized = JSON.stringify(scrubbed);
+
+    for (const identifier of ALL_IDENTIFIERS) {
+      expect(serialized).toContain(identifier);
+    }
+  });
+
+  it("shows the shared scrubber would also shred the rrweb payload", () => {
+    const scrubbed = scrubTelemetryData(buildSnapshotCapture(), {
+      preservePostHogInternalKeys: true,
+    });
+
+    expect(JSON.stringify(scrubbed)).toContain("[truncated]");
+  });
+});
+
+describe("redactRouteIdentifiersInCapture", () => {
+  it("removes every route identifier from a replay capture", () => {
+    const redacted = redactRouteIdentifiersInCapture(buildSnapshotCapture());
+    const serialized = JSON.stringify(redacted);
+
+    for (const identifier of ALL_IDENTIFIERS) {
+      expect(serialized).not.toContain(identifier);
+    }
+  });
+
+  it("replaces the recorded page URL with a bounded route template", () => {
+    const redacted = redactRouteIdentifiersInCapture(buildSnapshotCapture());
+    const properties = redacted?.properties as Record<string, unknown>;
+
+    expect(properties.$current_url).toBe(BOUNDED_URL);
+    expect(properties.$pathname).toBe("/workflows/:workflowId/runs/:runId");
+    expect(properties.$referrer).toBe(`${ORIGIN}/workspaces/:workspaceId`);
+    expect(properties.$session_entry_url).toBe(`${ORIGIN}/join/:orgId`);
+    expect(properties.$prev_pageview_pathname).toBe("/workspaces/:workspaceId");
+    expect(properties.$set_once).toEqual({
+      $initial_current_url: `${ORIGIN}/login/:slug`,
+      $initial_pathname: "/login/:slug",
+    });
+  });
+
+  it("redacts the rrweb Meta event href, which no property deletion reaches", () => {
+    const redacted = redactRouteIdentifiersInCapture(buildSnapshotCapture());
+    const stream = (redacted?.properties as Record<string, unknown>)
+      .$snapshot_data as Array<Record<string, unknown>>;
+
+    expect((stream[0].data as Record<string, unknown>).href).toBe(BOUNDED_URL);
+    // Non-URL Meta fields are untouched, so the replay still knows its viewport.
+    expect((stream[0].data as Record<string, unknown>).width).toBe(1440);
+  });
+
+  it("redacts href attributes nested below the shared scrubber's depth cap", () => {
+    const redacted = redactRouteIdentifiersInCapture(buildSnapshotCapture());
+    const serialized = JSON.stringify(redacted);
+
+    expect(serialized).toContain("/workspaces/:workspaceId");
+    expect(serialized).toContain(`${ORIGIN}/workflows/:workflowId`);
+    expect(serialized).not.toContain("[truncated]");
+  });
+
+  it("redacts attribute-mutation and custom rrweb events", () => {
+    const redacted = redactRouteIdentifiersInCapture(buildSnapshotCapture());
+    const stream = (redacted?.properties as Record<string, unknown>)
+      .$snapshot_data as Array<Record<string, unknown>>;
+
+    const mutation = stream[2].data as { attributes: Array<{ attributes: Record<string, string> }> };
+    expect(mutation.attributes[0].attributes.href).toBe("/workflows/:workflowId");
+
+    const pageview = stream[3].data as { payload: Record<string, string> };
+    expect(pageview.payload.href).toBe(`${ORIGIN}/workspaces/:workspaceId`);
+
+    const performance = stream[4].data as { payload: Record<string, string> };
+    expect(performance.payload.name).toBe(`${ORIGIN}${UNKNOWN_BOUNDED_ROUTE}`);
+    expect(performance.payload.initiatorType).toBe("fetch");
+  });
+
+  it("preserves the replay structure it redacts", () => {
+    const original = buildSnapshotCapture();
+    const redacted = redactRouteIdentifiersInCapture(original);
+    const stream = (redacted?.properties as Record<string, unknown>)
+      .$snapshot_data as unknown[];
+
+    expect(redacted?.event).toBe("$snapshot");
+    expect(stream).toHaveLength(original.properties.$snapshot_data.length);
+    expect((redacted?.properties as Record<string, unknown>).$session_id)
+      .toBe(original.properties.$session_id);
+    expect((redacted?.properties as Record<string, unknown>).$host)
+      .toBe("app.proliferate.com");
+    expect((redacted?.properties as Record<string, unknown>).$snapshot_bytes).toBe(4096);
+
+    // Class names and test ids are rendering fidelity, not identity: they stay.
+    expect(JSON.stringify(redacted)).toContain("sidebar-link");
+    expect(JSON.stringify(redacted)).toContain("layer-13");
+  });
+
+  it("scrubs content-bearing attributes that recorder masking does not cover", () => {
+    const redacted = redactRouteIdentifiersInCapture(buildSnapshotCapture());
+    const serialized = JSON.stringify(redacted);
+
+    // `title` is not a text node or an input, so `maskTextSelector`/
+    // `maskAllInputs` never touch it.
+    expect(serialized).not.toContain("/Users/pablo/proliferate");
+    expect(serialized).toContain("[redacted-path]");
+  });
+
+  it("does not mutate the capture it was handed", () => {
+    const original = buildSnapshotCapture();
+    redactRouteIdentifiersInCapture(original);
+
+    expect(original.properties.$current_url).toBe(LEAKING_URL);
+  });
+
+  it("redacts ordinary product events, not only replay snapshots", () => {
+    const redacted = redactRouteIdentifiersInCapture({
+      event: "chat_prompt_submitted",
+      properties: {
+        agent_kind: "claude",
+        reuse_session: true,
+        $current_url: `${ORIGIN}/workspaces/${WORKSPACE_ID}`,
+      },
+    });
+
+    const properties = redacted?.properties as Record<string, unknown>;
+    expect(properties.$current_url).toBe(`${ORIGIN}/workspaces/:workspaceId`);
+    expect(properties.agent_kind).toBe("claude");
+    expect(properties.reuse_session).toBe(true);
+  });
+
+  it("redacts the top-level $set and $set_once siblings of properties", () => {
+    const redacted = redactRouteIdentifiersInCapture({
+      event: "$identify",
+      properties: { $current_url: `${ORIGIN}/workspaces/${WORKSPACE_ID}` },
+      $set: { $current_url: `${ORIGIN}/workflows/${WORKFLOW_ID}` },
+      $set_once: { $initial_current_url: `${ORIGIN}/join/${ORG_SLUG}` },
+    });
+
+    expect(redacted?.$set).toEqual({ $current_url: `${ORIGIN}/workflows/:workflowId` });
+    expect(redacted?.$set_once).toEqual({
+      $initial_current_url: `${ORIGIN}/join/:orgId`,
+    });
+    expect(JSON.stringify(redacted)).not.toContain(ORG_SLUG);
+  });
+
+  it("passes through a capture with no properties", () => {
+    expect(redactRouteIdentifiersInCapture(null)).toBeNull();
+    expect(redactRouteIdentifiersInCapture({ event: "x" })).toEqual({ event: "x" });
+  });
+
+  it("drops a capture that exceeds the redaction budget rather than sending it", () => {
+    const oversized = {
+      event: "$snapshot",
+      properties: {
+        $snapshot_data: Array.from({ length: MAX_REDACTION_VISITS + 10 }, () => ({
+          href: `/workflows/${WORKFLOW_ID}`,
+        })),
+      },
+    };
+
+    expect(redactRouteIdentifiersInCapture(oversized)).toBeNull();
+  });
+});
+
+describe("boundRoutePathname", () => {
+  it("maps every declared template back to itself", () => {
+    for (const template of BOUNDED_ROUTE_TEMPLATES) {
+      const concrete = template
+        .split("/")
+        .map((segment) => (segment.startsWith(":") ? "0198f0c2-dead-beef" : segment))
+        .join("/");
+      expect(boundRoutePathname(concrete)).toBe(template);
+    }
+  });
+
+  it.each([
+    ["/", "/"],
+    ["", "/"],
+    ["/workflows", "/workflows"],
+    ["/workflows/", "/workflows"],
+    ["/WorkFlows/abc", "/workflows/:workflowId"],
+    ["/workspaces/abc?tab=files#top", "/workspaces/:workspaceId"],
+    ["/automations/abc", "/automations/:workflowId"],
+  ])("bounds %s to %s", (input, expected) => {
+    expect(boundRoutePathname(input)).toBe(expected);
+  });
+
+  it.each([
+    "/workflows/a/b",
+    "/workflows/a/runs",
+    "/workflows/a/runs/b/c",
+    "/playground/chat",
+    "/admin/users/42",
+    "/workspaces//",
+    "/.env",
+    "/Users/pablo/proliferate/secret.txt",
+  ])("fails closed on %s", (input) => {
+    expect(boundRoutePathname(input)).toBe(UNKNOWN_BOUNDED_ROUTE);
+  });
+});
+
+describe("boundRouteUrl", () => {
+  it.each([
+    [LEAKING_URL, BOUNDED_URL],
+    [`${ORIGIN}/`, `${ORIGIN}/`],
+    [ORIGIN, `${ORIGIN}/`],
+    ["tauri://localhost/workflows/abc", "tauri://localhost/workflows/:workflowId"],
+    ["http://localhost:1420/workspaces/abc", "http://localhost:1420/workspaces/:workspaceId"],
+    [`/workflows/${WORKFLOW_ID}`, "/workflows/:workflowId"],
+    ["/does/not/exist", UNKNOWN_BOUNDED_ROUTE],
+  ])("bounds %s", (input, expected) => {
+    expect(boundRouteUrl(input)).toBe(expected);
+  });
+
+  it.each(["", "   ", "not a url", "./relative/path", "mailto:support@proliferate.com"])(
+    "returns null for the unboundable value %p",
+    (input) => {
+      expect(boundRouteUrl(input)).toBeNull();
+    },
+  );
+});
+
+describe("redactRouteIdentifiersInText", () => {
+  it("leaves non-URL text alone", () => {
+    expect(redactRouteIdentifiersInText("chat_prompt_submitted")).toBe(
+      "chat_prompt_submitted",
+    );
+  });
+
+  it("bounds a URL embedded as a whole value", () => {
+    expect(redactRouteIdentifiersInText(LEAKING_URL)).toBe(BOUNDED_URL);
+  });
+});
+
+describe("redactRouteIdentifiersInAttribute", () => {
+  it("bounds a URL-valued attribute", () => {
+    expect(redactRouteIdentifiersInAttribute("href", `/workflows/${WORKFLOW_ID}`)).toBe(
+      "/workflows/:workflowId",
+    );
+    expect(redactRouteIdentifiersInAttribute("HREF", LEAKING_URL)).toBe(BOUNDED_URL);
+  });
+
+  it("fails closed on a URL-valued attribute it cannot bound", () => {
+    expect(
+      redactRouteIdentifiersInAttribute("srcset", `a-${WORKFLOW_ID}.png 1x, b.png 2x`),
+    ).toBe(REDACTED_URL);
+    expect(redactRouteIdentifiersInAttribute("src", `assets/${WORKFLOW_ID}.png`)).toBe(
+      REDACTED_URL,
+    );
+  });
+
+  it("keeps in-page fragments and inline schemes so replay still renders", () => {
+    expect(redactRouteIdentifiersInAttribute("href", "#main")).toBe("#main");
+    expect(redactRouteIdentifiersInAttribute("src", "data:image/png;base64,AAAA")).toBe(
+      "data:image/png;base64,AAAA",
+    );
+    expect(redactRouteIdentifiersInAttribute("href", "mailto:support@proliferate.com")).toBe(
+      "mailto:support@proliferate.com",
+    );
+  });
+
+  it("leaves rendering attributes untouched", () => {
+    expect(redactRouteIdentifiersInAttribute("class", "flex items-center")).toBe(
+      "flex items-center",
+    );
+    expect(redactRouteIdentifiersInAttribute("id", "chat-composer")).toBe("chat-composer");
+  });
+
+  it("still bounds a URL that shows up under a non-URL attribute name", () => {
+    expect(redactRouteIdentifiersInAttribute("data-return-to", LEAKING_URL)).toBe(
+      BOUNDED_URL,
+    );
+  });
+});

--- a/apps/packages/product-client/src/domain/telemetry/route-id-redaction.ts
+++ b/apps/packages/product-client/src/domain/telemetry/route-id-redaction.ts
@@ -232,9 +232,16 @@ export function redactRouteIdentifiersInText(value: string): string {
 }
 
 /**
- * Redact one serialized DOM attribute. Passed to posthog-js as
- * `session_recording.maskAttributeFn`, which is invoked for every non-empty
- * string-valued attribute in the final serialized representation.
+ * Redact one serialized DOM attribute.
+ *
+ * Called from two places, and only one of them runs today. The capture
+ * boundary (`before_send` -> `redactRouteIdentifiersInCapture`) reaches every
+ * attribute inside `$snapshot_data` and is what actually closes the leak. It
+ * is also wired as posthog-js `session_recording.maskAttributeFn`, which the
+ * pinned `posthog-js@1.386.8` never invokes: the option is declared by the
+ * newer transitive `@posthog/types@1.404.1` but the SDK forwards only
+ * `maskAllInputs`, `maskTextSelector`, and `blockSelector` to rrweb. Treat the
+ * recorder boundary as dormant forward-compatibility, never as coverage.
  */
 export function redactRouteIdentifiersInAttribute(name: string, value: string): string {
   const normalizedName = name.toLowerCase();

--- a/apps/packages/product-client/src/domain/telemetry/route-id-redaction.ts
+++ b/apps/packages/product-client/src/domain/telemetry/route-id-redaction.ts
@@ -1,0 +1,355 @@
+/**
+ * Route-identifier redaction for PostHog payloads.
+ *
+ * Why this exists: PostHog attaches the live page URL to *every* captured
+ * event (`$current_url`, `$pathname`, `$session_entry_url`, `$initial_*`, and
+ * more added by future SDK versions), and session replay additionally carries
+ * the URL inside the rrweb stream (`$snapshot_data`) as the Meta event `href`
+ * and as `href`/`src` attributes on serialized DOM nodes. Several product
+ * routes embed opaque resource identifiers in the path
+ * (`/workflows/<workflowId>/runs/<runId>`, `/workspaces/<workspaceId>`), so
+ * those identifiers reach the provider verbatim unless the path itself is
+ * reduced.
+ *
+ * The shared scrubber in `./scrub` cannot do this job. `scrubTelemetryUrl`
+ * deliberately keeps the path and only strips query/hash, and
+ * `preservePostHogInternalKeys` exempts every `$`-prefixed key from
+ * key-based redaction, so it is a no-op for exactly this class. Its depth,
+ * array, and property caps would also shred an rrweb DOM snapshot into
+ * `[truncated]` markers rather than redact it.
+ *
+ * The policy here is allowlist-shaped, not pattern-shaped: a pathname is
+ * matched against a closed table of bounded route templates and replaced by
+ * the template it matched. A path that matches nothing becomes
+ * `UNKNOWN_BOUNDED_ROUTE`. Nothing that was not already a literal in this
+ * file can survive the reduction, so a new id-bearing route added tomorrow
+ * fails closed to `/unknown` instead of leaking.
+ */
+
+import { scrubTelemetryText } from "./scrub";
+
+/** Emitted for any pathname that does not match a bounded route template. */
+export const UNKNOWN_BOUNDED_ROUTE = "/unknown";
+
+/** Emitted for a URL-valued attribute that cannot be reduced to a bounded route. */
+export const REDACTED_URL = "[redacted-url]";
+
+/**
+ * Closed table of client route templates. Segments beginning with `:` match
+ * exactly one path segment and are emitted as the placeholder itself, so the
+ * identifier value never survives. Keep this sorted by specificity within a
+ * prefix; matching is exact on segment count so ordering is not load bearing.
+ *
+ * Sources: `src/pages/AuthenticatedAppHost.tsx`, `src/App.tsx`,
+ * `apps/web/src/WebHostApp.tsx`, and the bounded route vocabulary in
+ * `src/lib/domain/telemetry/routes.ts`. Development-only `/playground/*`
+ * routes are deliberately absent: they fail closed to `/unknown`.
+ */
+export const BOUNDED_ROUTE_TEMPLATES: readonly string[] = [
+  "/",
+  "/index.html",
+  "/login",
+  "/login/:slug",
+  "/auth/callback",
+  "/auth/error",
+  "/join/:orgId",
+  "/plugins",
+  "/plugins/connect/complete",
+  "/integrations",
+  "/settings",
+  "/settings/cloud",
+  "/settings/billing",
+  "/setup",
+  "/workflows",
+  "/workflows/:workflowId",
+  "/workflows/:workflowId/runs/:runId",
+  "/automations",
+  "/automations/:workflowId",
+  "/workspaces",
+  "/workspaces/:workspaceId",
+];
+
+/**
+ * Names whose value is a URL by definition. These fail closed: a value that
+ * cannot be reduced to a bounded route becomes `REDACTED_URL` rather than
+ * being passed through.
+ *
+ * The DOM attributes cover serialized nodes inside a full snapshot; `href`
+ * additionally covers the rrweb Meta event (`{ type: 4, data: { href } }`),
+ * which is where the recorded page URL actually lives. `currenturl`,
+ * `pathname`, `url`, and `initiatorurl` cover PostHog's own custom rrweb
+ * events and network-capture payloads.
+ */
+const URL_VALUED_NAMES = new Set([
+  "action",
+  "background",
+  "cite",
+  "currenturl",
+  "data",
+  "formaction",
+  "href",
+  "initiatorurl",
+  "longdesc",
+  "pathname",
+  "ping",
+  "poster",
+  "src",
+  "srcset",
+  "url",
+  "usemap",
+  "xlink:href",
+]);
+
+/**
+ * rrweb keys that *may* hold a URL. They are reduced when the value looks like
+ * one and passed through otherwise, because they also legitimately hold plain
+ * text (`name` is both a form-control attribute and the request URL on a
+ * captured network entry).
+ */
+const RRWEB_SOFT_URL_KEYS = new Set(["name"]);
+
+/**
+ * Serialized attributes that carry human-readable content and are *not*
+ * covered by the recorder's text masking, which only masks text nodes and
+ * input values. These get the shared text scrubber, so an absolute filesystem
+ * path or a token that reached a tooltip or label is redacted.
+ */
+const RRWEB_CONTENT_KEYS = new Set([
+  "alt",
+  "aria-description",
+  "aria-label",
+  "aria-placeholder",
+  "aria-valuetext",
+  "content",
+  "download",
+  "placeholder",
+  "title",
+  "value",
+]);
+
+/**
+ * Schemes whose values carry inline or opaque content rather than a route
+ * path, so reducing them would cost replay fidelity for no privacy gain.
+ */
+const NON_ROUTE_SCHEME_PATTERN = /^(?:data|blob|mailto|tel|javascript|about):/i;
+
+/**
+ * Splits `scheme://authority` from the path. The path group must start with
+ * `/` so it cannot overlap the authority group, matching the anti-backtracking
+ * shape already used in `./scrub`.
+ */
+const ABSOLUTE_URL_PARTS_PATTERN =
+  /^([a-z][a-z0-9+.-]*:\/\/[^/?#]*)(\/[^?#]*)?(?:[?#].*)?$/i;
+
+/**
+ * Upper bound on values visited while redacting a single capture. A real full
+ * DOM snapshot is tens of thousands of nodes; this is an order of magnitude
+ * above that. Exceeding it means the payload is not the shape this module
+ * understands, so the capture is dropped rather than forwarded unredacted.
+ */
+export const MAX_REDACTION_VISITS = 250_000;
+
+interface RedactionBudget {
+  remaining: number;
+}
+
+export interface CaptureLike {
+  properties?: Record<string, unknown> | undefined;
+  $set?: Record<string, unknown> | undefined;
+  $set_once?: Record<string, unknown> | undefined;
+}
+
+function splitPathSegments(pathname: string): string[] {
+  const segments = pathname.split("/");
+  // A leading `/` yields an empty first segment, and a trailing `/` yields an
+  // empty last one. Both are path punctuation, not content.
+  if (segments.length > 0 && segments[0] === "") segments.shift();
+  if (segments.length > 0 && segments[segments.length - 1] === "") segments.pop();
+  return segments;
+}
+
+function templateMatches(templateSegments: string[], pathSegments: string[]): boolean {
+  if (templateSegments.length !== pathSegments.length) return false;
+  for (let index = 0; index < templateSegments.length; index += 1) {
+    const templateSegment = templateSegments[index];
+    if (templateSegment.startsWith(":")) {
+      // A parameter must consume exactly one non-empty segment.
+      if (pathSegments[index].length === 0) return false;
+      continue;
+    }
+    // React Router matches path literals case-insensitively.
+    if (templateSegment !== pathSegments[index].toLowerCase()) return false;
+  }
+  return true;
+}
+
+/**
+ * Reduce a pathname to the bounded route template it matched, or
+ * `UNKNOWN_BOUNDED_ROUTE` when it matched nothing.
+ */
+export function boundRoutePathname(pathname: string): string {
+  const withoutQuery = pathname.split(/[?#]/, 1)[0];
+  const pathSegments = splitPathSegments(withoutQuery);
+  if (pathSegments.length === 0) return "/";
+
+  for (const template of BOUNDED_ROUTE_TEMPLATES) {
+    if (templateMatches(splitPathSegments(template), pathSegments)) {
+      return template;
+    }
+  }
+  return UNKNOWN_BOUNDED_ROUTE;
+}
+
+/**
+ * Reduce a URL to `origin + bounded route`, dropping query and fragment.
+ * Returns `null` when the value is not a URL or path this module can bound,
+ * which lets callers decide between passing the value through (free text) and
+ * failing closed (a URL-valued attribute).
+ */
+export function boundRouteUrl(value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+
+  const absolute = ABSOLUTE_URL_PARTS_PATTERN.exec(trimmed);
+  if (absolute) {
+    return `${absolute[1]}${boundRoutePathname(absolute[2] ?? "/")}`;
+  }
+
+  if (trimmed.startsWith("/")) {
+    return boundRoutePathname(trimmed);
+  }
+
+  return null;
+}
+
+/**
+ * Redact a free-text value: reduce it when it is a URL or absolute path, and
+ * otherwise return it unchanged. Used for event property values, where most
+ * strings are not URLs and must survive intact.
+ */
+export function redactRouteIdentifiersInText(value: string): string {
+  return boundRouteUrl(value) ?? value;
+}
+
+/**
+ * Redact one serialized DOM attribute. Passed to posthog-js as
+ * `session_recording.maskAttributeFn`, which is invoked for every non-empty
+ * string-valued attribute in the final serialized representation.
+ */
+export function redactRouteIdentifiersInAttribute(name: string, value: string): string {
+  const normalizedName = name.toLowerCase();
+  if (!URL_VALUED_NAMES.has(normalizedName)) {
+    return redactRouteIdentifiersInText(value);
+  }
+
+  const trimmed = value.trim();
+  // In-page fragments and inline/opaque schemes carry no route path.
+  if (trimmed.startsWith("#")) return value;
+  if (NON_ROUTE_SCHEME_PATTERN.test(trimmed)) return value;
+
+  return boundRouteUrl(trimmed) ?? REDACTED_URL;
+}
+
+function redactRrwebValue(value: unknown, key: string | undefined, budget: RedactionBudget): unknown {
+  budget.remaining -= 1;
+  if (budget.remaining < 0) return value;
+
+  if (typeof value === "string") {
+    // Only URL-bearing rrweb keys are rewritten. Text nodes are already masked
+    // by the recorder's masking configuration, and rewriting arbitrary strings
+    // here would corrupt the replay without adding privacy.
+    if (key === undefined) return value;
+    const normalizedKey = key.toLowerCase();
+    if (URL_VALUED_NAMES.has(normalizedKey)) {
+      return redactRouteIdentifiersInAttribute(key, value);
+    }
+    if (RRWEB_SOFT_URL_KEYS.has(normalizedKey)) {
+      return redactRouteIdentifiersInText(value);
+    }
+    if (RRWEB_CONTENT_KEYS.has(normalizedKey)) {
+      return redactRouteIdentifiersInText(scrubTelemetryText(value));
+    }
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactRrwebValue(entry, undefined, budget));
+  }
+
+  if (value !== null && typeof value === "object") {
+    const redacted: Record<string, unknown> = {};
+    for (const [entryKey, entryValue] of Object.entries(value as Record<string, unknown>)) {
+      redacted[entryKey] = redactRrwebValue(entryValue, entryKey, budget);
+    }
+    return redacted;
+  }
+
+  return value;
+}
+
+function redactPropertyValue(value: unknown, budget: RedactionBudget): unknown {
+  budget.remaining -= 1;
+  if (budget.remaining < 0) return value;
+
+  if (typeof value === "string") return redactRouteIdentifiersInText(value);
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactPropertyValue(entry, budget));
+  }
+
+  if (value !== null && typeof value === "object") {
+    const redacted: Record<string, unknown> = {};
+    for (const [entryKey, entryValue] of Object.entries(value as Record<string, unknown>)) {
+      redacted[entryKey] = redactPropertyValue(entryValue, budget);
+    }
+    return redacted;
+  }
+
+  return value;
+}
+
+/**
+ * Redact route identifiers out of a PostHog capture, in place of the payload
+ * that would otherwise be transmitted. Applies to every event, not only
+ * `$snapshot`: ordinary product events carry the same `$current_url` and
+ * `$pathname` properties.
+ *
+ * Returns `null` when the payload exceeds `MAX_REDACTION_VISITS`, which drops
+ * the capture. posthog-js treats a `null` from `before_send` as a rejected
+ * event (`posthog-core.ts` `_runBeforeSend`), so an unrecognisably large
+ * payload is discarded rather than sent unredacted.
+ */
+export function redactRouteIdentifiersInCapture<T extends CaptureLike>(
+  event: T | null,
+): T | null {
+  if (!event) return event;
+
+  const budget: RedactionBudget = { remaining: MAX_REDACTION_VISITS };
+  const redacted = { ...event } as T & Record<string, unknown>;
+
+  if (event.properties) {
+    const properties: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(event.properties)) {
+      properties[key] = key === "$snapshot_data"
+        ? redactRrwebValue(value, undefined, budget)
+        : redactPropertyValue(value, budget);
+    }
+    redacted.properties = properties;
+  }
+
+  // `$set` and `$set_once` are siblings of `properties` on a PostHog capture,
+  // and `$set_once.$initial_current_url` carries the entry URL.
+  for (const personKey of ["$set", "$set_once"] as const) {
+    const personProperties = event[personKey];
+    if (personProperties) {
+      redacted[personKey] = redactPropertyValue(personProperties, budget) as Record<
+        string,
+        unknown
+      >;
+    }
+  }
+
+  if (budget.remaining < 0) return null;
+
+  return redacted;
+}

--- a/guides/operating/analytics/posthog.md
+++ b/guides/operating/analytics/posthog.md
@@ -3,8 +3,9 @@
 Status: current procedure
 
 Use this procedure to verify hosted-client analytics without changing project
-configuration. Session replay is source-disabled on every client surface, so
-there is no replay routing to verify or flip. The system contract is
+configuration. Session replay is source-disabled on Web and Mobile and
+internal-audience-only on Desktop, so the only replay that can appear belongs
+to an internal account. The system contract is
 [PostHog](../../../specs/codebase/systems/engineering/analytics/posthog.md).
 
 ## Applicability
@@ -14,7 +15,7 @@ there is no replay routing to verify or flip. The system contract is
 - **Self-hosters:** packaged Desktop does not initialize PostHog when pointed
   at a self-managed API. A fork that supplies its own Web/Mobile PostHog
   configuration owns its provider project and should still preserve the code
-  privacy posture and the source-disabled replay boundary.
+  privacy posture and the replay boundary.
 
 ## Secret Safety
 
@@ -28,7 +29,9 @@ network requests in screenshots.
 
 1. Identify the exact client build and surface. Record its canonical release
    id, environment, and whether the telemetry gate was enabled, without
-   recording any secret value. There is no replay gate on any surface.
+   recording any secret value. The only replay gate is the Desktop internal
+   audience plus the PostHog project's own replay setting; neither is a build
+   or environment value.
 2. For a named Desktop local profile, inspect only the non-secret runtime
    routing fields in:
 
@@ -49,10 +52,17 @@ network requests in screenshots.
    - sign-out produces a new anonymous identity on the next session;
    - no prompt, transcript, repo name, file path, raw URL, terminal text,
      token, or raw error is present.
-5. Replay is expected to be absent on every surface. Desktop, Web, and Mobile
-   PostHog session recording are all source-disabled and expose no toggle in any
-   build, environment, or project setting, so replay observed in the provider is
-   a code-or-provider truth mismatch to triage.
+5. Replay expectations by surface. Web and Mobile PostHog session recording
+   are source-disabled and expose no toggle in any build, environment, or
+   project setting, so replay observed there is a code-or-provider truth
+   mismatch to triage. Desktop replay is expected only for a signed-in internal
+   account and only while the PostHog project has replay enabled; a Desktop
+   replay attributed to a customer account is a truth mismatch to triage
+   immediately. In any Desktop replay, every recorded URL must read as a
+   bounded route template such as `/workflows/:workflowId` or `/unknown`. A raw
+   identifier in a recorded URL is a privacy regression: capture the release
+   and route template, stop replay in the PostHog project, and route it as a
+   defect.
 
 ## Diagnose Missing Evidence
 
@@ -62,11 +72,14 @@ network requests in screenshots.
   in `apps/desktop/src/lib/integrations/telemetry/client.ts`.
 - Web/Mobile views missing: verify the provider initialized and the normalized
   route/screen hook ran; raw paths are intentionally not capture values.
-- Replay missing anywhere: expected, not a defect; there is no gate to confirm.
+- Replay missing on Web or Mobile: expected, not a defect; there is no gate to
+  confirm. Replay missing on Desktop: check that the account is in the internal
+  audience list and that the PostHog project has replay enabled.
 - Provider data differs from checked-in behavior: capture event name, surface,
   environment, release, observed time, and a redacted provider URL. Route
   ingestion or deduplication defects to Issue Lifecycle.
 
 Any project setting, retention, person/profile, or provider write requires a
-separate reviewed change; re-enabling replay additionally requires a synthetic
-privacy qualification. This procedure does not authorize one.
+separate reviewed change; widening Desktop replay beyond the internal audience,
+or re-enabling Web or Mobile replay, additionally requires a synthetic privacy
+qualification. This procedure does not authorize one.

--- a/specs/OBSERVABILITY.md
+++ b/specs/OBSERVABILITY.md
@@ -176,13 +176,18 @@ change sits on:
 - **Structural, not length, bounds:** client payload scrubbing bounds depth,
   array positions, and object properties (`[circular]`, `[truncated]`) but
   does not truncate strings by length — what you put in a string field ships.
-- **Replay is off everywhere, in source:** Web/Mobile Sentry replay rates are
-  zero; Desktop renderer Sentry replay and Desktop/Web/Mobile PostHog session
-  recording are source-disabled and absent. No build value, environment value,
-  optional native package, or provider-side setting can start a recording, so
-  the recorded page-URL route-id gap is closed because nothing records.
-  Re-enablement anywhere requires the reviewed synthetic privacy proof in
-  [`frontend/telemetry.md`](frontend/telemetry.md); a new surface that can
+- **Replay is off for customers, and internal-only on Desktop:** Web/Mobile
+  Sentry replay rates are zero; Desktop renderer Sentry replay and Web/Mobile
+  PostHog session recording are source-disabled and absent. Desktop PostHog
+  recording never auto-starts and begins only for the closed internal audience
+  in `product-client/src/domain/telemetry/replay-audience.ts`, and only when
+  the PostHog project also enables replay server-side. The recorded page-URL
+  route-id gap is closed by
+  `product-client/src/domain/telemetry/route-id-redaction.ts`, which reduces
+  every URL and every rrweb `href`/`src` to a bounded route template from a
+  closed table and fails closed to `/unknown`. Widening to customers, or
+  re-enabling any other surface, requires the reviewed synthetic privacy proof
+  in [`frontend/telemetry.md`](frontend/telemetry.md); a new surface that can
   display prompts, files, paths, or credentials gets `[data-telemetry-block]` /
   `[data-telemetry-mask]` unless there is a reviewed reason not to.
 - **Child-agent stderr never reaches Sentry:** AnyHarness marks it with a

--- a/specs/codebase/systems/engineering/analytics/README.md
+++ b/specs/codebase/systems/engineering/analytics/README.md
@@ -11,7 +11,8 @@ messaging.
 - [Anonymous telemetry](anonymous-telemetry.md) owns install-level version,
   activation, and usage records from Desktop and Server.
 - [PostHog](posthog.md) owns hosted-client event capture, identity, and the
-  source-disabled replay boundary.
+  replay boundary: source-disabled on Web and Mobile, internal-audience-only on
+  Desktop.
 - [Metabase](metabase.md) owns the checked-in analytics tables and views that a
   read-only BI client may query.
 - [Observability](../observability/README.md) owns logs, exceptions, Sentry,
@@ -52,8 +53,8 @@ deduplication boundary.
 | Identity and data | Anonymous install UUIDs; authenticated user UUIDs for daily activity; low-cardinality route/screen, version, platform, telemetry mode, activation, usage, and aggregate provider facts. |
 | Destinations | The configured Proliferate Server/Postgres database, PostHog for enabled hosted clients, and an operator-selected read-only BI client such as Metabase. |
 | Enable, disable, or no-op | Vendor adapters require their client key and telemetry gates. Anonymous telemetry has build/runtime and Server disable gates. Provider ingestion skips a provider whose required configuration is absent. |
-| Privacy and replay | First-party payloads exclude prompts, transcripts, repo names, file paths, terminal text, raw URLs, errors, and secrets. Desktop, Web, and Mobile recording are source-disabled; no client surface records, and the re-enablement contract is owned by the PostHog contract. |
-| Known gaps | Desktop, Web, and Mobile PostHog recording are source-disabled, so no client can expose route ids through recorded page URLs. Anonymous credential fields are accepted by the schema but currently have no Desktop emission directive. Live provider dashboards and data freshness are not enforced by repository code. |
+| Privacy and replay | First-party payloads exclude prompts, transcripts, repo names, file paths, terminal text, raw URLs, errors, and secrets. Web and Mobile recording are source-disabled. Desktop recording is start-gated to the internal audience, masks all text and inputs, and reduces every URL to a bounded route template; the re-enablement and widening contract is owned by the PostHog contract. |
+| Known gaps | The recorded-page-URL route-id leak is closed in source and proven by unit tests over a synthetic rrweb payload, but the live recorder-output and provider-arrival qualification has not run, so Desktop recording is internal-audience-only and customer recording is off. Anonymous credential fields are accepted by the schema but currently have no Desktop emission directive. Live provider dashboards and data freshness are not enforced by repository code. |
 
 ## Operating Routes
 

--- a/specs/codebase/systems/engineering/analytics/posthog.md
+++ b/specs/codebase/systems/engineering/analytics/posthog.md
@@ -50,9 +50,13 @@ The recorder is pinned to `maskAllInputs`, `maskTextSelector="*"` (all text
 masked), `blockSelector="[data-telemetry-block]"`, no font collection, no
 cross-origin iframes, no network headers or bodies, and a
 `maskCapturedNetworkRequestFn` that drops every captured request. URLs are
-handled separately from masking: `maskAttributeFn` reduces URL-valued DOM
-attributes at the recorder boundary, and the `before_send` scrubber reduces
-event properties and the rrweb Meta event `href`.
+handled separately from masking, and entirely at the `before_send` boundary:
+the scrubber reduces event properties, the rrweb Meta event `href`, and every
+URL-valued DOM attribute inside `$snapshot_data`. The same reducer is also
+wired as the recorder-boundary `maskAttributeFn`, but the pinned
+`posthog-js@1.386.8` forwards only `maskAllInputs`, `maskTextSelector`, and
+`blockSelector` to rrweb and never invokes the callback, so that boundary is
+dormant forward-compatibility rather than live coverage.
 
 Only these Desktop product events reach PostHog:
 

--- a/specs/codebase/systems/engineering/analytics/posthog.md
+++ b/specs/codebase/systems/engineering/analytics/posthog.md
@@ -1,8 +1,9 @@
 # PostHog
 
 PostHog is the hosted-product vendor path for client analytics. Session replay
-is source-disabled on every client surface. It is separate from first-party
-anonymous telemetry and is not initialized by the Server API.
+is source-disabled on Web and Mobile. On Desktop it is start-gated to the
+internal replay audience and never auto-starts. It is separate from
+first-party anonymous telemetry and is not initialized by the Server API.
 
 ## Applicability And Data Contract
 
@@ -12,12 +13,13 @@ anonymous telemetry and is not initialized by the Server API.
 | Source components | Desktop `apps/desktop/src/lib/integrations/telemetry/{client,config,posthog}.ts`; Web `apps/web/src/browser/telemetry/install-web-telemetry.ts`; Mobile `apps/mobile/src/lib/integrations/telemetry/{config,posthog}.ts`. |
 | Identity and data | Distinct id is the authenticated user UUID, and identify calls send that UUID only with no email, display name, or other person properties. Captured data is the fixed event surface below plus scrubbed low-cardinality properties and registered app/surface/environment/release context. |
 | Destination | The configured PostHog host, defaulting to `https://us.i.posthog.com`. |
-| Enable, disable, or no-op | A missing API key makes each adapter inert. Web/Mobile also honor their public telemetry-disable setting; Desktop additionally requires hosted-product routing. Desktop, Web, and Mobile recording are source-disabled and have no gate to set. |
-| Privacy and replay | Autocapture and automatic page views are off. Payload scrubbers remove sensitive values. Desktop, Web, and Mobile recording are source-disabled and absent. |
-| Known gap | No client PostHog recording gap remains: Desktop, Web, and Mobile cannot record, so none can expose route ids through recorded page URLs. |
+| Enable, disable, or no-op | A missing API key makes each adapter inert. Web/Mobile also honor their public telemetry-disable setting; Desktop additionally requires hosted-product routing. Web and Mobile recording are source-disabled and have no gate to set. Desktop recording additionally requires an internal-audience sign-in and PostHog project-side replay enablement; there is no build or environment value that starts it. |
+| Privacy and replay | Autocapture and automatic page views are off. Payload scrubbers remove sensitive values, and route-identifier redaction reduces every URL and rrweb `href`/`src` to a bounded route template. Web and Mobile recording are source-disabled and absent. Desktop recording masks all text and inputs and starts only for the internal audience. |
+| Known gap | The route-id leak is closed at the payload level by `apps/packages/product-client/src/domain/telemetry/route-id-redaction.ts`, proven by unit tests over a synthetic rrweb payload. The live qualification (real recorder output from the running app, plus controlled provider arrival) has not been executed, which is why Desktop recording is limited to the internal audience and customer recording stays off. |
 
-Re-enabling recording on any surface is a separate founder-approved source
-change that must first satisfy the synthetic privacy qualification in
+Widening recording to customers on any surface, and re-enabling Web or Mobile
+recording at all, is a separate founder-approved source change that must first
+satisfy the synthetic privacy qualification in
 [`specs/frontend/telemetry.md`](../../../../frontend/telemetry.md).
 
 ## Desktop
@@ -30,12 +32,27 @@ capture_pageview=false
 capture_pageleave=false
 person_profiles=identified_only
 disable_session_recording=true
+session_recording=<masking and route-redaction options>
 ```
 
-Desktop session recording is source-disabled, not false-by-default. The Desktop
-source carries no recording flag, recording options object, `loaded` callback,
-or `startSessionRecording` call, so no build value, environment value, or
-PostHog provider-side replay setting can start it.
+Desktop recording never auto-starts. `disable_session_recording` is a literal
+`true` at init, there is no `loaded` callback, and the Desktop source carries
+no recording flag readable from a build or environment value. Recording begins
+only when `client.ts` calls `startDesktopPostHogSessionReplay()` after
+`isInternalReplayAudience(user.email)` returns true for the signed-in account,
+and even then only if the PostHog project has replay enabled server-side
+(posthog-js `_isRecordingEnabled` requires both). The audience is a closed
+source-owned list in
+`apps/packages/product-client/src/domain/telemetry/replay-audience.ts`; the
+address is read locally and never transmitted.
+
+The recorder is pinned to `maskAllInputs`, `maskTextSelector="*"` (all text
+masked), `blockSelector="[data-telemetry-block]"`, no font collection, no
+cross-origin iframes, no network headers or bodies, and a
+`maskCapturedNetworkRequestFn` that drops every captured request. URLs are
+handled separately from masking: `maskAttributeFn` reduces URL-valued DOM
+attributes at the recorder boundary, and the `before_send` scrubber reduces
+event properties and the rrweb Meta event `href`.
 
 Only these Desktop product events reach PostHog:
 

--- a/specs/codebase/systems/engineering/analytics/posthog.md
+++ b/specs/codebase/systems/engineering/analytics/posthog.md
@@ -49,7 +49,20 @@ address is read locally and never transmitted.
 The recorder is pinned to `maskAllInputs`, `maskTextSelector="*"` (all text
 masked), `blockSelector="[data-telemetry-block]"`, no font collection, no
 cross-origin iframes, no network headers or bodies, and a
-`maskCapturedNetworkRequestFn` that drops every captured request. URLs are
+`maskCapturedNetworkRequestFn` that drops every captured request.
+
+Three recorder capabilities resolve local-config-first and fall back to the
+PostHog project's remote flags response, so leaving them unset would hand the
+provider a decision the source is supposed to own. Each is therefore a local
+literal: `captureCanvas: { recordCanvas: false }` and
+`enable_recording_console_log: false`. Canvas matters specifically because
+`@xterm/addon-canvas` renders terminal output to a canvas and canvas frames are
+captured as pixels, which text masking does not reach; console capture matters
+because console arguments are arbitrary strings that route-id redaction
+deliberately does not rewrite. Network header and body capture resolves
+remote-OR-local rather than local-first and so cannot be pinned that way, but
+`maskCapturedNetworkRequestFn` returning `null` drops every captured request
+regardless of what the provider enables. URLs are
 handled separately from masking, and entirely at the `before_send` boundary:
 the scrubber reduces event properties, the rrweb Meta event `href`, and every
 URL-valued DOM attribute inside `$snapshot_data`. The same reducer is also

--- a/specs/frontend/telemetry.md
+++ b/specs/frontend/telemetry.md
@@ -119,10 +119,13 @@ session replay, and telemetry-related provider and hook ownership.
 - Route identifiers never reach a replay payload. Masking hides page content
   and does nothing about URLs, so URL reduction is a separate mechanism:
   `product-client/src/domain/telemetry/route-id-redaction.ts` reduces every URL
-  to a bounded route template from a closed table, at the recorder boundary
-  (`maskAttributeFn`) and at the capture boundary (`before_send`, which also
-  covers the rrweb Meta event `href` and every `$current_url`-style property).
-  A pathname matching no template becomes `/unknown`.
+  to a bounded route template from a closed table. The load-bearing boundary is
+  `before_send`, which covers every `$current_url`-style property, the rrweb
+  Meta event `href`, and every URL-valued DOM attribute inside
+  `$snapshot_data`. The same reducer is also wired as the recorder-boundary
+  `maskAttributeFn`, but the pinned `posthog-js@1.386.8` never invokes it, so
+  that boundary is dormant forward-compatibility and must not be counted as
+  coverage. A pathname matching no template becomes `/unknown`.
 - Widening Desktop recording to customers, or re-enabling replay on any other
   surface, requires a new reviewed source change that first proves, with
   synthetic sensitive content, the route/screen block-and-mask policy,

--- a/specs/frontend/telemetry.md
+++ b/specs/frontend/telemetry.md
@@ -139,6 +139,13 @@ session replay, and telemetry-related provider and hook ownership.
   scrubbed value for repeated references, and redacts enumerable accessors
   without evaluating them. These are structural bounds; strings retain their
   existing redaction behavior and are not truncated by length.
+- Recorder capabilities that resolve against the provider's remote flags are
+  pinned in source, not left unset. Canvas recording
+  (`captureCanvas: { recordCanvas: false }`) and console capture
+  (`enable_recording_console_log: false`) both resolve local-first, so an unset
+  value would let the PostHog project turn them on by itself. Canvas frames are
+  pixels and console arguments are arbitrary strings; neither is reached by
+  text masking or by route-id redaction.
 - Recorded content control is masking plus blocking, and the two have
   different coverage. Desktop recording masks all text (`maskTextSelector="*"`)
   and all inputs, so rendered prompts, transcripts, terminal text, and paths

--- a/specs/frontend/telemetry.md
+++ b/specs/frontend/telemetry.md
@@ -105,16 +105,30 @@ session replay, and telemetry-related provider and hook ownership.
 
 ## Replay and Privacy
 
-- Client session replay is source-disabled on every surface: Desktop/Web/Mobile
-  PostHog recording and Desktop renderer Sentry replay carry no enabling flag,
-  options object, or start call, and Web/Mobile Sentry replay rates are zero.
-  No build value, environment value, optional native package, or provider-side
-  setting turns recording on.
-- Re-enabling replay anywhere requires a new reviewed source change that first
-  proves, with synthetic sensitive content, the route/screen block-and-mask
-  policy, metadata policy, log/network policy, provider arrival, and the
-  absence of prompts, transcripts, terminal text, file contents, repo/path
-  data, tokens, credentials, identity beyond the permitted opaque ID, and
+- Web and Mobile PostHog recording and Desktop renderer Sentry replay stay
+  source-disabled: no enabling flag, options object, or start call, and
+  Web/Mobile Sentry replay rates are zero. No build value, environment value,
+  optional native package, or provider-side setting turns any of them on.
+- Desktop PostHog recording is start-gated, not source-disabled.
+  `disable_session_recording` is a literal `true` at init and there is no
+  `loaded` callback, so nothing auto-starts. Recording begins only when the
+  signed-in address matches the closed internal audience in
+  `product-client/src/domain/telemetry/replay-audience.ts`, and only if the
+  PostHog project also has replay enabled server-side. Customer recording is
+  off.
+- Route identifiers never reach a replay payload. Masking hides page content
+  and does nothing about URLs, so URL reduction is a separate mechanism:
+  `product-client/src/domain/telemetry/route-id-redaction.ts` reduces every URL
+  to a bounded route template from a closed table, at the recorder boundary
+  (`maskAttributeFn`) and at the capture boundary (`before_send`, which also
+  covers the rrweb Meta event `href` and every `$current_url`-style property).
+  A pathname matching no template becomes `/unknown`.
+- Widening Desktop recording to customers, or re-enabling replay on any other
+  surface, requires a new reviewed source change that first proves, with
+  synthetic sensitive content, the route/screen block-and-mask policy,
+  metadata policy, log/network policy, provider arrival, and the absence of
+  prompts, transcripts, terminal text, file contents, repo/path data, tokens,
+  credentials, identity beyond the permitted opaque ID, and
   workspace/session/workflow identifiers. The rules below are its contract.
 - Shared client payload scrubbing bounds container traversal by depth, array
   positions, and object properties. It replaces cyclic back-edges with
@@ -122,8 +136,15 @@ session replay, and telemetry-related provider and hook ownership.
   scrubbed value for repeated references, and redacts enumerable accessors
   without evaluating them. These are structural bounds; strings retain their
   existing redaction behavior and are not truncated by length.
-- If replay is ever re-enabled, workspace and settings surfaces are blocked by
-  default.
+- Recorded content control is masking plus blocking, and the two have
+  different coverage. Desktop recording masks all text (`maskTextSelector="*"`)
+  and all inputs, so rendered prompts, transcripts, terminal text, and paths
+  are masked wherever they appear. `[data-telemetry-block]` removes a subtree
+  entirely and is currently applied by `ProductPageShell` (when
+  `telemetryBlocked` is set, as the workflows surfaces do), `SettingsScreen`,
+  `ModalShell`, and `CommandPalette`. The main workspace/chat surface is masked
+  but not blocked; widening replay beyond the internal audience should settle
+  whether it must also be blocked.
 - Continue using explicit masking for input areas that may contain sensitive
   text.
 - If a new surface can display prompts, files, paths, repo metadata, tokens,


### PR DESCRIPTION
## Verdict up front

**Customer replay stays OFF.** Desktop PostHog session replay is re-enabled for the **internal audience only**. The route-id leak is fixed and proven at the payload level with negative controls, but the live qualification that #2093 and #2096 named as the re-enable bar (real recorder output from the running app, plus controlled provider arrival) was not executed tonight, so it is not widened to customers. Per Lane C's binding rule, that is the fallback, and it is stated plainly rather than argued away.

Nothing here is live. This is a pushed PR, not merged. Even if merged, nothing records until the PostHog project also enables replay server-side (see "Two independent gates" below).

Reviewed end to end by a second agent after the implementation commit. That review found and fixed two real defects: the original narrative claimed a recorder boundary that does not execute (`d76b9bba14`, section 2), and canvas plus console capture were left resolvable by the PostHog project rather than pinned in source (`aae0842cf3`, section 3). Neither changed the verdict; both are closed.

## 1. What the leak actually was

The disable PRs recorded the finding as one line in the analytics contract, deleted by #2093 at `specs/codebase/systems/engineering/analytics/README.md:56`:

> Desktop and Web replay can still expose route ids through recorded page URLs when explicitly enabled.

Reconstructed precisely, it is two channels, and **masking does not touch either one** — which is the answer to "why disable rather than mask". `maskAllInputs`, `maskTextSelector`, and `blockSelector` hide rendered page *content*. A URL is not page content. #2093's body says exactly this: "Recorded page metadata can retain identifier-bearing route segments even with masking, which is why the fix is at the source and not a default value."

**What leaks.** Opaque resource identifiers embedded in the path by these routes (`apps/packages/product-client/src/pages/AuthenticatedAppHost.tsx:79-85`, `apps/web/src/WebHostApp.tsx:45-46`):

```
/workflows/:workflowId
/workflows/:workflowId/runs/:runId
/workspaces/:workspaceId
/automations/:workflowId
/join/:orgId
/login/:slug
```

**Channel 1 — event properties.** posthog-js attaches the page URL to *every* capture, `$snapshot` included, in `calculateEventProperties` (`posthog-js@1.386.8` `src/posthog-core.ts:1490-1560`, read from the shipped sourcemap): `$current_url`, `$pathname`, `$referrer`, `$session_entry_url`, `$prev_pageview_pathname`, `$initial_current_url` under `$set_once`, and more the SDK adds over time.

Desktop's `before_send` did not remove any of them, and could not have. `scrubPostHogPayload` calls the shared scrubber with `preservePostHogInternalKeys: true`, and `isPostHogInternalKey` (`apps/packages/product-client/src/domain/telemetry/scrub.ts:83-85`) exempts every `$`-prefixed key from key redaction. The value then goes through `scrubTelemetryUrl` (`scrub.ts:52-68`), which **deliberately keeps the path** and only strips query and hash:

```ts
const absoluteMatch = ABSOLUTE_URL_PARTS_PATTERN.exec(value);
if (absoluteMatch) {
  return `${absoluteMatch[1]}${absoluteMatch[2] || ""}`;   // scheme://host + PATH
}
```

So `https://app.proliferate.com/workflows/<uuid>/runs/<uuid>` survived verbatim.

**Sibling leak, live today, independent of replay:** this same channel means **shipped Desktop builds have been sending `$current_url` and `$pathname` with raw workflow, run, and workspace ids on every allowlisted product event**, with replay off. Confirmed against `main`: `git show origin/main:apps/desktop/src/lib/integrations/telemetry/scrub.ts` contains no URL-property deletion, while Web deletes five keys at `apps/web/src/browser/telemetry/install-web-telemetry.ts:294-300` (`$current_url`, `$pathname`, `$host`, `$referrer`, `$referring_domain`). Desktop never did. This PR closes it as a side effect, because the redaction runs on every capture and not only on `$snapshot`.

**Channel 2 — the rrweb stream.** Deleting URL properties, as Web did, still would not have fixed replay, because the recorded page URL is *also* inside `properties.$snapshot_data`:

- the rrweb Meta event, `{ type: 4, data: { href } }`, emitted at recording start and at every full snapshot;
- serialized DOM nodes, as `attributes.href` on `<a>`/`<link>` and `attributes.src` on media;
- PostHog's own custom rrweb events (`type: 5`) and network-capture entries.

`$snapshot` reaches `before_send` (`_captureSnapshot` -> `capture('$snapshot', ...)` at `src/extensions/replay/external/lazy-loaded-session-recorder.ts:1656-1664`, and `_runBeforeSend` at `src/posthog-core.ts:1410-1415`), so `before_send` is the right chokepoint. But the shared scrubber cannot be that fix: `MAX_SCRUB_DEPTH = 10`, `MAX_SCRUB_ARRAY_ITEMS = 100`, `MAX_SCRUB_OBJECT_PROPERTIES = 100` (`scrub.ts:23-26`) turn a real DOM snapshot into `[truncated]` markers while still leaving shallow `href`s intact. **It leaks and destroys the recording at the same time.** Both halves are asserted as executable evidence in `route-id-redaction.test.ts` under `describe("the leak this module exists to close")`.

## 2. The fix

New shared module `apps/packages/product-client/src/domain/telemetry/route-id-redaction.ts`. Allowlist-shaped, not pattern-shaped: a pathname is matched against a closed table of route templates and **replaced by the template it matched**. Nothing that is not already a literal in that file can survive. A pathname matching nothing becomes `/unknown`, so a new id-bearing route added tomorrow fails closed instead of leaking.

### One live boundary, not two (corrected in review)

The original version of this PR described the fix as applied at two boundaries, recorder (`session_recording.maskAttributeFn`) and capture (`before_send`), "because neither alone is sufficient". **That was wrong. The recorder boundary does not execute at the pinned SDK version.**

Evidence, all against `node_modules/.pnpm/posthog-js@1.386.8/node_modules/posthog-js`:

| Option | `lazy-recorder.js` | `recorder.js` | `module.js` | `main.js` |
| --- | --- | --- | --- | --- |
| `maskAllInputs` | 11 | 3 | 0 | 0 |
| `maskTextSelector` | 23 | 15 | 0 | 0 |
| `blockSelector` | 38 | 30 | 0 | 0 |
| `maskCapturedNetworkRequestFn` | 8 | 0 | 0 | 0 |
| `recordHeaders` / `recordBody` | 15 / 20 | 7 / 12 | 0 | 0 |
| **`maskAttributeFn`** | **0** | **0** | **0** | **0** |

`maskAttributeFn` occurs **zero times in the entire package**. The SDK builds its rrweb masking object from exactly three keys, in the `Th` getter of `dist/lazy-recorder.js`:

```js
u = {
  maskAllInputs:    config.session_recording?.maskAllInputs,
  maskTextSelector: config.session_recording?.maskTextSelector,
  blockSelector:    config.session_recording?.blockSelector
}
```

It typechecks only because the transitive `@posthog/types@1.404.1` is newer than the `posthog-js@1.386.8` runtime pin (`apps/desktop/package.json:51`, exact, no caret) and declares the option. Excess-property checking does not catch it either, because `DESKTOP_SESSION_RECORDING_OPTIONS` is a named const rather than an inline object literal.

**The leak is still closed**, because `before_send` independently walks `$snapshot_data` and reduces URL-valued DOM attributes, and the CI-enforced payload test never invokes the recorder callback. But a reader who believed the recorder covered DOM attributes could narrow `before_send` to the Meta event and reopen the 2026-08-18 leak. Commit `d76b9bba14` therefore corrects the claim in source (`posthog.ts`, `route-id-redaction.ts`), in both specs, and in the desktop test comment, and adds a CI-enforced regression test that pins the invariant. `maskAttributeFn` stays wired as dormant forward-compatibility for a future SDK pin; it is a no-op today, and enabling it later is additive.

### What actually runs

| Boundary | Mechanism | Status | Covers |
| --- | --- | --- | --- |
| Capture | `before_send` | **live, load-bearing** | `$current_url`-style properties, `$set`/`$set_once`, the rrweb Meta `href`, DOM attribute `href`/`src` inside `$snapshot_data`, custom-event payloads |
| Recorder | `session_recording.maskAttributeFn` | **dormant** (not invoked by posthog-js 1.386.8) | nothing today |

Behaviour worth reviewing:

- **URL-valued names fail closed.** `href`, `src`, `srcset`, `action`, `poster`, `url`, `pathname`, … that cannot be bounded become `[redacted-url]` rather than passing through. Free text is only rewritten when it actually parses as a URL or absolute path.
- **`data:`, `blob:`, `mailto:`, `tel:`, and `#fragment` pass through.** They carry no route path and reducing them would cost fidelity for no privacy gain. Flagged as a deliberate residual.
- **The replay stream is held out of the generic scrubber** in `apps/desktop/src/lib/integrations/telemetry/scrub.ts`. Running `$snapshot_data` through the depth-capped scrubber shreds it. The stream gets the rrweb-aware walk instead, which has no depth cap and rewrites only URL-bearing and content-bearing fields. Negative control 3 below proves this hold-out is load-bearing.
- **Content-bearing attributes get the shared text scrubber.** `title`, `alt`, `placeholder`, `aria-label`, `value`, `content`, `download` are not text nodes or inputs, so recorder masking never touches them; an absolute path or token that reached a tooltip is now redacted.
- **Budget, fail-closed.** Above `MAX_REDACTION_VISITS` (250,000) the capture is dropped (`before_send` returns `null`) rather than forwarded unredacted.

Recorder configuration, pinned in source at `apps/desktop/src/lib/integrations/telemetry/posthog.ts` as `DESKTOP_SESSION_RECORDING_OPTIONS`: `maskAllInputs: true`, `maskTextSelector: "*"` (**all** text masked), `blockSelector: "[data-telemetry-block]"`, no fonts, no cross-origin iframes, `recordHeaders: false`, `recordBody: false`, and `maskCapturedNetworkRequestFn: () => null` (network capture refused outright). Every one of those is honored by the pinned runtime per the table above.

## 3. Capabilities the provider could otherwise decide (found in review)

The #2093/#2096 doctrine is that no provider setting alone can start recording. The audience gate holds that line for *whether* recording starts. Review found that two settings for *what gets recorded* were still the provider's to decide, because Desktop left them unset and posthog-js resolves them local-config-first with a remote-flags fallback.

**Canvas**, `Rh` getter in `posthog-js@1.386.8` `dist/lazy-recorder.js`:

```js
config.session_recording.captureCanvas?.recordCanvas ?? remoteConfig.canvasRecording?.enabled
```

**Console**, `xh` getter in the same file:

```js
config.enable_recording_console_log != null
  ? config.enable_recording_console_log
  : remoteConfig.consoleLogRecordingEnabled
```

Both matter for this app specifically:

- `@xterm/addon-canvas` (`apps/desktop/package.json:44`, `apps/packages/product-client/package.json:102`) renders terminal output to a canvas. Canvas frames are captured as **pixels**, which `maskTextSelector: "*"` does not reach. Flipping canvas recording in the PostHog UI would have captured terminal contents.
- Console arguments are arbitrary app strings, and the route-id redactor deliberately does **not** rewrite free text inside the rrweb stream, because doing so would corrupt the replay. Console capture would therefore have been both remotely enableable and unredacted.

`aae0842cf3` pins both as local literals, which win their respective resolutions: `captureCanvas: { recordCanvas: false }` and `enable_recording_console_log: false`. The `@posthog/types@1.404.1` doc comment on `captureCanvas` confirms the intent verbatim: "Allows local config to override remote canvas recording settings from the flags response."

Negative control, both pins removed:

```
× desktop PostHog adapter > initializes once with recording disabled and no auto-start surface
  → expected { …(6) } to deeply equal { …(7) }
× desktop PostHog adapter > pins the recorder to mask content and redact route identifiers
  → expected undefined to deeply equal { recordCanvas: false }

Tests  2 failed | 48 passed (50)
```

Restored, 50/50 green. Both options were typechecked against the real `posthog-js` `PostHogConfig` with a scratch probe (deleted, not in the diff).

**Network headers and bodies resolve the other way** (`Oh` getter: `local.recordHeaders || remote.recordHeaders`), so a local `false` cannot pin them. It does not matter: `maskCapturedNetworkRequestFn: () => null` is honored, and `h.maskRequestFn` maps a `null` return to `undefined`, dropping every captured request whatever the provider enables. Documented rather than "fixed" with a value that would not have worked.

## 4. Per-surface status

| Surface | Product | Disabled by | State after this PR |
| --- | --- | --- | --- |
| Desktop | PostHog replay | #2093 | **Internal audience only.** Start-gated in source, customer recording off |
| Web | PostHog replay | #2096 | **Still source-disabled, untouched.** `install-web-telemetry.ts:330` `disable_session_recording: true`; `telemetry-privacy.test.ts:341-348` asserts no `session_recording` key and `startSessionRecording` never called |
| Mobile | PostHog replay | #2097 | **Still source-disabled, untouched.** `apps/mobile/src/lib/integrations/telemetry/posthog.ts:45` `enableSessionReplay: false` |
| Desktop renderer | **Sentry** replay | #2083 | **Still source-disabled, untouched.** `sentry.ts:83-84` both sample rates `0`. Different product from the three above; this PR does not go near it |

`git diff --name-only origin/main...HEAD` touches no `apps/web` and no `apps/mobile` file. The shared redactor is in place for whenever those come back.

## 5. The proof, and the negative controls

Tests live in `apps/packages/product-client/src/domain/telemetry/` because that is the only place CI actually runs vitest for this code (`ci.yml:526` runs `vitest run src/domain`, `ci.yml:573` runs the full sharded suite). There is **no `apps/desktop` and no `apps/web` vitest job in CI** — same gap #2096 reported — so the desktop suites below were run locally and are reported as such.

The load-bearing test builds a realistic `$snapshot` capture with four distinctive identifiers, a Meta event, a DOM snapshot nested 16 levels deep, an attribute mutation, and two custom events, then asserts the identifiers are **absent from `JSON.stringify` of the whole redacted payload** and that the structure survives.

```
pnpm --filter @proliferate/product-client exec vitest run src/domain/telemetry
  route-id-redaction.test.ts   50 passed
  replay-audience.test.ts      16 passed
  scrub.test.ts                15 passed   (unchanged, still green)
  Tests  81 passed (81)

pnpm --filter proliferate exec vitest run src/lib/integrations/telemetry
  Tests  50 passed (50)   (local only; not a CI job)
```

### Negative controls — re-run independently by the reviewing agent on the final tree

Every one below was executed, its literal failure captured, and the source restored with `git checkout --` (never `git stash`). Working tree confirmed clean after each.

**1. Domain redaction disabled** (`redactRouteIdentifiersInCapture` returns the event unchanged). This is the privacy control that matters:

```
× redactRouteIdentifiersInCapture > removes every route identifier from a replay capture
  → expected '{"event":"$snapshot","properties":{"$…' not to contain 'wf-8e1c4a92-route-id-leak-probe'
× redactRouteIdentifiersInCapture > closes the DOM-attribute half without the recorder callback
× redactRouteIdentifiersInCapture > replaces the recorded page URL with a bounded route template
  → expected 'https://app.proliferate.com/workflows…' to be 'https://app.proliferate.com/workflows…'
× redactRouteIdentifiersInCapture > redacts the rrweb Meta event href, which no property deletion reaches
× redactRouteIdentifiersInCapture > redacts href attributes nested below the shared scrubber's depth cap
  → expected '{"event":"$snapshot","properties":{"$…' to contain '/workspaces/:workspaceId'
× redactRouteIdentifiersInCapture > redacts attribute-mutation and custom rrweb events
× redactRouteIdentifiersInCapture > scrubs content-bearing attributes that recorder masking does not cover
  → expected '{"event":"$snapshot","properties":{"$…' not to contain '/Users/pablo/proliferate'
× redactRouteIdentifiersInCapture > redacts ordinary product events, not only replay snapshots
× redactRouteIdentifiersInCapture > redacts the top-level $set and $set_once siblings of properties
× redactRouteIdentifiersInCapture > drops a capture that exceeds the redaction budget rather than sending it
  → expected { event: '$snapshot', …(1) } to be null

Tests  10 failed | 71 passed (81)
```

**2. Desktop `before_send` wiring reverted** (`scrubPostHogPayload` back to `scrubPostHogProperties(event)` only):

```
× desktop PostHog adapter > strips route identifiers from the replay payload posthog would send
  → expected '{"event":"$snapshot","properties":{"$…' not to contain 'wf-8e1c4a92-route-id-leak-probe'
× desktop PostHog adapter > still scrubs non-replay captures through the shared scrubber
  → expected 'https://app.proliferate.com/workspace…' to be 'https://app.proliferate.com/workspace…'

Tests  2 failed | 48 passed (50)
```

Reverting the `maskAttributeFn` wiring to identity on top of that adds exactly one more failure (`Tests 3 failed | 47 passed (50)`) — and that third failure is a direct unit call on the callback, not a payload assertion, which is consistent with the recorder boundary being dormant.

**3. Snapshot hold-out removed** (replay stream sent back through the depth-capped scrubber):

```
× desktop PostHog adapter > strips route identifiers from the replay payload posthog would send
  → expected '{"event":"$snapshot","properties":{"$…' to contain '/workspaces/:workspaceId'

Tests  1 failed | 49 passed (50)
```

The deep `href` never reaches the redactor because the scrubber already replaced that subtree with `[truncated]`.

After restoring each, both suites are green again (81/81 and 50/50, re-run and shown above).

## 6. Two independent gates before anything records

1. **Audience gate, in source.** `disable_session_recording: true` is a literal at init and there is no `loaded` callback, so nothing auto-starts. `client.ts:setTelemetryUser` calls `startDesktopPostHogSessionReplay()` only when `isInternalReplayAudience(user.email)` is true. The audience is a closed source-owned list (`replay-audience.ts`, currently `proliferate.com` and `proliferate.dev`) — **no environment variable, build value, or provider setting widens it**, which keeps the #2093/#2096/#2097 doctrine intact. The address is evaluated locally and never transmitted; PostHog identity stays UUID-only, and a test asserts the address never appears in any call payload. Sign-out stops recording before `reset(true)`.

   **Pablo: confirm the two domains are right, and add any others you want recording.**

2. **Provider gate, outside source.** `_isRecordingEnabled` requires `enabled_server_side && !disable_session_recording && !optedOut` (`posthog-js@1.386.8` `src/extensions/replay/session-recording.ts:81-86`). Nothing records until the PostHog project itself enables replay. Merging this PR does not start a single recording on its own.

## 7. What is NOT done, and why

- **Customer replay.** Off. Requires the live qualification: drive the real app through a sensitive route, capture the real recorder output, and confirm arrival in the PostHog project. Not runnable tonight, and the posture is not certified on a synthetic payload alone.
- **Web and Mobile.** Untouched, still source-disabled. See the per-surface table in section 3.
- **Pre-disable builds.** 0.4.14 / 0.4.17 are still sending replays with the leak. Nothing in this PR reaches them; that exposure ages out with the installs.
- **The main workspace/chat surface is masked but not blocked.** `[data-telemetry-block]` is applied by `ProductPageShell` (when `telemetryBlocked` is set, as the workflows surfaces do), `SettingsScreen`, `ModalShell`, and `CommandPalette` — not by the workspace shell. With `maskTextSelector: "*"` every text node and input is masked, but images and canvas are not. Acceptable for internal-only recording; **must be settled before customer replay**. The docs now say this instead of the previous "workspace and settings surfaces are blocked by default", which was not true.
- **`data:`/`blob:` URL passthrough** in URL-valued attributes, described above.
- **CPU cost.** The rrweb walk allocates a redacted copy per capture. Bounded by the visit budget and only meaningful on full snapshots; not measured on device. [unverified]

## 8. Sibling leaks and defects spotted

1. **Desktop `$current_url` on ordinary events, live in production right now.** Described in section 1, confirmed against `origin/main`. Closed by this PR.
2. **`maskAttributeFn` was inert dead config presented as live coverage.** Section 2. Corrected in `d76b9bba14`; no behavior change, but the narrative and the docs were wrong and a future reader could have reopened the leak on the strength of them.
3. **Canvas and console capture were the PostHog project's to decide.** Section 3. Canvas is the sharper one, because xterm renders the terminal to a canvas and canvas is pixels. Closed by `aae0842cf3`.
4. **The generic scrubber destroys any large nested payload it is pointed at.** Not specific to replay: any deeply nested telemetry container hits `MAX_SCRUB_DEPTH = 10` and comes back as `[truncated]`. Worth knowing before anyone routes another structured payload through it.
5. **`apps/web` and `apps/desktop` have no vitest job in CI** (`ci.yml` only runs `@proliferate/product-client` filters), so `apps/web/src/browser/telemetry/telemetry-privacy.test.ts` — the file that proves Web recording stays disabled — is not enforced by any required check, and neither is the desktop `before_send` wiring proof (negative control 2). The redaction *logic* is CI-enforced in product-client; the desktop *wiring* is not. Worth a separate fix.
6. **`npx tsc` in this repo does not run TypeScript.** It resolves to the `tsc` tab-completer package and prints "This is not the tsc command you are looking for", exiting non-zero without compiling. An earlier revision of this PR body cited `npx tsc -p …` as passing evidence; that line was false and is corrected below. Use `pnpm --filter <pkg> exec tsc` instead.

## Testing

Run locally, green:

```
pnpm --filter @proliferate/product-client exec vitest run src/domain/telemetry   # 81 passed
pnpm --filter proliferate exec vitest run src/lib/integrations/telemetry         # 50 passed
pnpm --filter @proliferate/product-client exec tsc -p tsconfig.domain.json --noEmit
    # 215 errors, 0 in telemetry/ — all pre-existing "Cannot find module
    # '@proliferate/cloud-sdk'" from the un-generated SDK (generate needs cargo,
    # and Lane B holds the build lock). CI runs the real typecheck with the SDK built.
python3 scripts/check_max_lines.py                                               # passed
python3 scripts/check_docs.py                                                    # passed, 235 files
python3 scripts/check_frontend_boundaries.py                                     # passed
python3 scripts/report_frontend_structure.py --strict --summary-only             # TOTAL: 0
git diff --check                                                                 # clean
```

Full `pnpm shared:typecheck`, `Desktop frontend build`, and the sharded product-client suite were **not** run locally: they need the SDK generate step (cargo, and Lane B holds that lock all night). CI covers all three, and all three were green on the parent commit.

## Test plan

- [x] CI on `3f5878666c`: all 39 checks pass (run 32460112478), including `Shared frontend checks`, sharded `Shared frontend packages (1-4)`, `Desktop frontend build`, `Web frontend build`, `Mobile typecheck`, `Repo shape checks`, `CodeQL`, `Validate PR title and labels`
- [x] CI on `aae0842cf3` (head): **36/36 pass, 0 fail**, rest skipping
- [ ] Pablo: confirm the internal email-domain list (`proliferate.com`, `proliferate.dev`)
- [ ] Pablo: rule on whether the workspace shell must be blocked before customer replay

🤖 Generated with [Claude Code](https://claude.com/claude-code)
