### PR TITLE
fix(server): sign-in success-rate SLI end to end

### DIFF
--- a/guides/operating/production-alerts.md
+++ b/guides/operating/production-alerts.md
@@ -359,3 +359,146 @@ real topic, which the confirmed subscription then emails. This was run once
 live during the 2026-08-21 bootstrap with result `status: "ok"`; treat further
 test notifications (e.g. to close out the D2 acceptance criterion) as
 additional confirmations, not a first proof.
+
+## Sign-in success rate (SLI)
+
+Status: authoritative for the sign-in success-rate SLI alert rule, a separate
+`sli-alerts` rule group from the six rules above. Built 2026-08-20/21 as part
+of the observability overnight push (Lane D). This rule lives on the **NEW**
+Grafana workspace, `proliferate-ops-rebuild` (`g-48655e6419`), not the OLD
+workspace this runbook otherwise documents. See the accounts-and-wiring
+context doc for that workspace's own state; the essentials are repeated here
+so this runbook stays self-contained for on-call.
+
+### What it measures
+
+The token-exchange endpoints (`/auth/web/token`, `/auth/mobile/token`,
+`/auth/desktop/token`) previously emitted no outcome log line at all, so
+sign-in success/failure had no signal anywhere. `server/proliferate/auth/sign_in_observability.py`
+adds exactly one: every successful or failed token exchange now emits a
+structured JSON log line via `log_sign_in_success(surface)` /
+`log_sign_in_failure(surface, failure_code=...)`, called from
+`server/proliferate/server/accounts/identity/api.py` (`web_token`,
+`mobile_token`) and `server/proliferate/server/accounts/desktop/api.py`
+(`exchange_token`). Fields, stable and consumed by the metric filters below:
+
+- `event`: always `"auth.sign_in.outcome"`
+- `auth_sign_in_outcome`: `"success"` or `"failure"`
+- `auth_sign_in_surface`: `"web"`, `"mobile"`, or `"desktop"`
+- `auth_sign_in_failure_code`: the bounded `AuthFlowError.code` (failure only,
+  e.g. `identity_auth_code_invalid`, `desktop_pkce_verification_failed`) --
+  never the auth code, PKCE verifier, tokens, or the user's email.
+
+### CloudWatch metric filters
+
+Two Logs metric filters on `/ecs/proliferate-prod`, namespace `Proliferate/Prod`
+(same namespace as `CriticalFailureCount`/`ServerErrorLines` above):
+
+| Filter name | Pattern | Metric |
+| --- | --- | --- |
+| `sign-in-success` | `{ $.auth_sign_in_outcome = "success" }` | `SignInSuccessCount` |
+| `sign-in-failure` | `{ $.auth_sign_in_outcome = "failure" }` | `SignInFailureCount` |
+
+Live-verified 2026-08-21: two canary log events (`observability_canary_2026-08-21`,
+`"canary": true`) were injected into
+`observability-canary/sign-in-sli/2026-08-21` and both metrics registered a
+real `Sum=1.0` datapoint via `aws cloudwatch get-metric-statistics`. Ignore
+these two canary datapoints in triage; they are test artifacts, not real
+sign-ins, and predate any rotated build shipping real traffic.
+
+### Grafana alert rule
+
+`Sign-in failures > 5 in 10m` (uid `ffvtx33lbo5c0e`, rule group `sli-alerts`,
+folder `ops-folder`, severity `warning`): fires when `SignInFailureCount`
+(Sum, 10m window) exceeds 5. Live-verified 2026-08-21: rule created via
+`POST /api/v1/provisioning/alert-rules`, read back with the checksum matching
+the checked-in definition, and evaluating (`health: "ok"`, `state: "inactive"`,
+i.e. correctly not currently past threshold) per
+`GET /api/prometheus/grafana/api/v1/rules`.
+
+Delivery: this rule has no contact point or route of its own. The NEW
+workspace's root notification policy has no child routes, so every rule
+(including this one) routes to the workspace's one default receiver, which
+Lane A3 repointed at the real, confirmed SNS topic
+`arn:aws:sns:us-east-1:157466816238:grafana-proliferate-ops-alerts`
+(subscription: protocol `email`, endpoint `pablo@pablohansen.com`, confirmed --
+`aws sns get-subscription-attributes` shows `PendingConfirmation: false`).
+Independently re-verified 2026-08-21 by sending a second, separate test
+notification through that exact receiver
+(`POST /api/alertmanager/grafana/config/api/v1/receivers/test`), result
+`status: "ok"`. An alert on this rule, or on any of the five rules above once
+they are live on this workspace, reaches Pablo's email today.
+
+Repository artifacts:
+
+```text
+server/infra/observability/grafana/sli-alerts.json   # rule identity + query model, checksum-verified
+scripts/ops/grafana-sli-alerts.mjs                   # check / apply / verify (this rule only)
+```
+
+`grafana-sli-alerts.mjs` never touches the `production-alerts` rule group, the
+contact point, or the notification policy -- it assumes the `ops-folder`
+folder and the CloudWatch data source already exist (Lane A3's job) and only
+creates/verifies rules inside its own `sli-alerts` group:
+
+```bash
+node scripts/ops/grafana-sli-alerts.mjs check
+GRAFANA_ALERTING_LIVE=1 node scripts/ops/grafana-sli-alerts.mjs apply
+GRAFANA_ALERTING_LIVE=1 node scripts/ops/grafana-sli-alerts.mjs verify
+```
+
+`check` is offline: validates the target, the rule group, the runbook
+annotation, and that the checksum reproduces from the query model. `apply` is
+live and idempotent (creates only what is missing; a live rule that has
+drifted from the checked-in definition fails loudly rather than being
+overwritten). `verify` is live and read-only: reads the rule back, recomputes
+its checksum, and reports per-rule health/state from the Prometheus-shaped
+rules API.
+
+### What to do when it fires
+
+Look first at the correlated `auth.sign_in.outcome` log lines in
+`/ecs/proliferate-prod` (filter `auth_sign_in_outcome = "failure"`), grouped by
+`auth_sign_in_failure_code` and `auth_sign_in_surface`, to identify whether one
+surface or one failure code dominates. A spike concentrated in one
+`failure_code` usually points at a specific upstream cause (e.g. an expired
+client secret, a clock-skew-sensitive PKCE check, or a revoked-refresh
+cascade); a spike spread evenly across codes and surfaces more often points at
+an infra-level problem (DB connectivity, a bad deploy) rather than the auth
+logic itself.
+
+### Independent re-verification (Lane D continuation, 2026-08-21 ~01:xx PDT)
+
+Re-checked everything above from a fresh process, not by trusting the prior
+agent's write-up:
+
+- `aws logs describe-metric-filters --log-group-name /ecs/proliferate-prod`
+  shows both `sign-in-success` and `sign-in-failure` live, same shapes as
+  above. Neither the pre-existing `critical-failure`/`server-error-lines`
+  filters nor these two are Terraform-managed (`server/infra/*.tf` has no
+  matching resource for any of the four), so this is consistent with existing
+  practice, not a new gap.
+- `aws cloudwatch get-metric-statistics` for both `SignInSuccessCount` and
+  `SignInFailureCount` over the last 6h returned a real `Sum=1.0` datapoint at
+  `2026-08-21T00:30:00-07:00` for each (the canary pair) — the pipe carries a
+  real, non-zero number end to end, not just a rule with no data behind it.
+- `node scripts/ops/grafana-sli-alerts.mjs verify` (live, read-only): rule
+  `ffvtx33lbo5c0e` checksum `match`, health `ok`, state `inactive`.
+- Pulled the live alertmanager config directly
+  (`GET /api/alertmanager/grafana/config/api/v1/alerts`): the root route's
+  receiver is `grafana-default-sns`, and that receiver's one
+  `grafana_managed_receiver_configs` entry (name `sns receiver`, uid
+  `bfvtw9if8c3cwd`) has `settings.topic` =
+  `arn:aws:sns:us-east-1:157466816238:grafana-proliferate-ops-alerts` — the
+  same confirmed-subscription topic, not a different or drifted one. The
+  nested `__grafana_autogenerated__` route tree all resolves to this same
+  receiver, so a rule with no labels of its own (this one) inherits it.
+- Fired a fresh, independent test notification for this exact rule (not
+  reusing the prior agent's result) via
+  `POST /api/alertmanager/grafana/config/api/v1/receivers/test`, alert labels
+  `alertname: "Sign-in failures > 5 in 10m"`: HTTP 200,
+  `receivers[0].grafana_managed_receiver_configs[0].status: "ok"`,
+  `notified_at: "2026-08-21T08:02:55.226292503Z"`. This is proof that this
+  specific rule's notification path, not just the workspace's default path in
+  the abstract, reaches the SNS topic with Pablo's confirmed email
+  subscription.

--- a/lints/server/ratchets.toml
+++ b/lints/server/ratchets.toml
@@ -25,8 +25,8 @@ reason = "D1 adds get_default_organization_for_user (earliest active membership 
 
 [[max_lines]]
 path = "server/proliferate/server/accounts/identity/api.py"
-max_lines = 514
-reason = "desktop-surface provider callbacks now dispatch to an HTML handoff/error page instead of a raw 302 via a new _provider_callback_response helper (PRO-111); split pending"
+max_lines = 526
+reason = "desktop-surface provider callbacks now dispatch to an HTML handoff/error page instead of a raw 302 via a new _provider_callback_response helper (PRO-111); web_token/mobile_token now log the sign-in success-rate SLI outcome via sign_in_observability.py (observability overnight, Lane D, D1); split pending"
 
 [[max_lines]]
 path = "server/proliferate/server/billing/stripe_webhooks.py"

--- a/scripts/ops/grafana-sli-alerts.mjs
+++ b/scripts/ops/grafana-sli-alerts.mjs
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+
+// Operator tooling for the sign-in success-rate SLI alert rule (Lane D,
+// observability overnight push 2026-08-20/21). Lives in its own `sli-alerts`
+// ruleGroup inside the shared `ops-folder` folder on the NEW workspace
+// (proliferate-ops-rebuild, g-48655e6419), deliberately separate from the
+// five-rule `production-alerts` group that scripts/ops/grafana-alerting.mjs
+// (OLD workspace) and scripts/ops/grafana-rebuild-bootstrap.mjs (NEW
+// workspace) manage -- this script never reads or writes those rules, their
+// contact point, or the notification policy. It relies on both the
+// `ops-folder` folder and the CloudWatch datasource already existing (Lane
+// A3's job); it does not create either.
+//
+// Delivery: this rule has no per-rule contact point of its own. It rides the
+// NEW workspace's default notification policy / SNS contact point that Lane
+// A3 wired to arn:aws:sns:us-east-1:157466816238:grafana-proliferate-ops-alerts
+// (confirmed pablo@pablohansen.com email subscription). See
+// guides/operating/production-alerts.md#sign-in-success-rate.
+//
+// `check` is offline. `apply` and `verify` are live and refuse the network
+// unless GRAFANA_ALERTING_LIVE=1 (same gate as the other two scripts in this
+// directory). Every write is idempotent: it verifies current state first and
+// only creates what is missing; a live rule that has drifted from the
+// checked-in definition fails loudly rather than being silently overwritten.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { canonicalize, queryChecksum, redact, sha256 } from "./grafana-alerting.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(__filename), "..", "..");
+const OVERLAY_REL = "server/infra/observability/grafana/sli-alerts.json";
+
+// Fixed new-workspace target. Intentionally the same target constant shape as
+// grafana-rebuild-bootstrap.mjs's NEW_TARGET, kept as a separate literal here
+// (not imported) so this script has no dependency on that unmerged tool and
+// cannot be affected if its target definition ever changes.
+export const NEW_TARGET = Object.freeze({
+  awsAccount: "157466816238",
+  awsRegion: "us-east-1",
+  grafanaWorkspaceId: "g-48655e6419",
+  grafanaWorkspaceName: "proliferate-ops-rebuild",
+  grafanaVersion: "10.4",
+});
+
+export const WORKSPACE_BASE_URL = `https://${NEW_TARGET.grafanaWorkspaceId}.grafana-workspace.${NEW_TARGET.awsRegion}.amazonaws.com`;
+
+// Deliberately the rebuild-workspace admin token, never the OLD workspace's
+// ~/.proliferate-local/ops/grafana-admin.token.
+export const ADMIN_TOKEN_PATH = path.join(
+  os.homedir(),
+  ".proliferate-local/ops/grafana-admin-rebuild.token",
+);
+
+const RULE_GROUP = "sli-alerts";
+
+function safeLog(...parts) {
+  console.log(parts.map((p) => redact(String(p))).join(" "));
+}
+
+export function loadOverlay(repoRoot = REPO_ROOT) {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, OVERLAY_REL), "utf8"));
+}
+
+export function verifyTarget(target) {
+  const diffs = [];
+  for (const key of Object.keys(NEW_TARGET)) {
+    if (!target || target[key] !== NEW_TARGET[key]) {
+      diffs.push(`${key}: expected ${NEW_TARGET[key]}, got ${target ? target[key] : "<missing>"}`);
+    }
+  }
+  if (diffs.length > 0) {
+    throw new Error(`Refusing to operate on a non-matching target:\n  ${diffs.join("\n  ")}`);
+  }
+}
+
+// Full offline validation of the checked-in sli-alerts overlay: target pins
+// to the NEW workspace, every rule sits in the sli-alerts ruleGroup (never
+// production-alerts -- that would collide with the other two tools), every
+// checksum reproduces from its own queryModel, and every query stanza names
+// an actual datasource uid (or the built-in expression datasource).
+export function validateOverlayDocument(overlay) {
+  verifyTarget(overlay.target);
+  if (overlay.component !== "proliferate-server") {
+    throw new Error("Overlay component must be proliferate-server");
+  }
+  const rules = overlay.rules || [];
+  if (rules.length === 0) {
+    throw new Error("Overlay defines no rules");
+  }
+  const seen = new Set();
+  for (const rule of rules) {
+    if (seen.has(rule.uid)) {
+      throw new Error(`Duplicate rule UID: ${rule.uid}`);
+    }
+    seen.add(rule.uid);
+    const qm = rule.queryModel;
+    if (!qm || typeof qm !== "object") {
+      throw new Error(`Rule ${rule.uid} is missing its queryModel`);
+    }
+    if (qm.ruleGroup !== RULE_GROUP) {
+      throw new Error(`Rule ${rule.uid} must be in ruleGroup "${RULE_GROUP}", got "${qm.ruleGroup}"`);
+    }
+    if (qm.title !== rule.title) {
+      throw new Error(`Rule ${rule.uid} queryModel title does not match its identity title`);
+    }
+    const expected = queryChecksum(qm);
+    if (rule.queryChecksum !== expected) {
+      throw new Error(`Rule ${rule.uid} queryChecksum does not match its queryModel`);
+    }
+    for (const stanza of qm.data || []) {
+      if (!stanza.datasourceUid) {
+        throw new Error(`Rule ${rule.uid} query stanza ${stanza.refId} is missing datasourceUid`);
+      }
+    }
+    if (!rule.annotations?.runbook_url) {
+      throw new Error(`Rule ${rule.uid} is missing a runbook_url annotation`);
+    }
+  }
+  return true;
+}
+
+export function runCheck({ repoRoot = REPO_ROOT } = {}) {
+  const overlay = loadOverlay(repoRoot);
+  validateOverlayDocument(overlay);
+  return { overlay };
+}
+
+function assertLiveAllowed() {
+  if (process.env.GRAFANA_ALERTING_LIVE !== "1") {
+    throw new Error(
+      "Live Grafana operations require GRAFANA_ALERTING_LIVE=1 (same gate as scripts/ops/grafana-alerting.mjs).",
+    );
+  }
+}
+
+export function adminTokenProvider({ tokenPath = ADMIN_TOKEN_PATH } = {}) {
+  if (!fs.existsSync(tokenPath)) {
+    throw new Error(`Admin token not found at its named 0600 path (${tokenPath})`);
+  }
+  const mode = fs.statSync(tokenPath).mode & 0o777;
+  if (mode !== 0o600) {
+    throw new Error("Admin token file must be mode 0600");
+  }
+  const token = fs.readFileSync(tokenPath, "utf8").trim();
+  if (!token) {
+    throw new Error("Admin token file is empty");
+  }
+  return token;
+}
+
+function fixedWorkspaceUrl(apiPath) {
+  if (typeof apiPath !== "string" || !apiPath.startsWith("/api/") || apiPath.startsWith("//")) {
+    throw new Error("Invalid fixed Grafana API path");
+  }
+  const absolute = `${WORKSPACE_BASE_URL}${apiPath}`;
+  const url = new URL(absolute);
+  if (url.origin !== WORKSPACE_BASE_URL || url.username || url.password || url.hash) {
+    throw new Error("Invalid fixed Grafana API origin");
+  }
+  return absolute;
+}
+
+export function createClient({ fetchImpl = fetch, tokenProvider } = {}) {
+  if (typeof tokenProvider !== "function") {
+    throw new Error("createClient requires a tokenProvider function");
+  }
+  async function request(method, apiPath, body) {
+    const url = fixedWorkspaceUrl(apiPath);
+    const headers = { Authorization: `Bearer ${tokenProvider()}`, Accept: "application/json" };
+    const init = { method, headers, redirect: "manual" };
+    if (body !== undefined) {
+      headers["Content-Type"] = "application/json";
+      headers["X-Disable-Provenance"] = "true";
+      init.body = JSON.stringify(body);
+    }
+    const response = await fetchImpl(url, init);
+    if (!response.ok && response.status !== 404) {
+      throw new Error(`Grafana ${method} ${apiPath} failed with HTTP ${response.status}`);
+    }
+    if (response.status === 404) {
+      return { status: 404, body: null };
+    }
+    const text = await response.text();
+    return { status: response.status, body: text ? JSON.parse(text) : null };
+  }
+  return {
+    getAlertRule: (uid) => request("GET", `/api/v1/provisioning/alert-rules/${encodeURIComponent(uid)}`),
+    createAlertRule: (body) => request("POST", "/api/v1/provisioning/alert-rules", body),
+    getPrometheusRules: () => request("GET", "/api/prometheus/grafana/api/v1/rules"),
+  };
+}
+
+export async function ensureRules(client, overlay) {
+  const results = {};
+  for (const rule of overlay.rules) {
+    const existing = await client.getAlertRule(rule.uid);
+    if (existing.status === 404) {
+      const qm = rule.queryModel;
+      await client.createAlertRule({
+        uid: rule.uid,
+        title: qm.title,
+        ruleGroup: qm.ruleGroup,
+        folderUID: qm.folderUID,
+        condition: qm.condition,
+        data: qm.data,
+        noDataState: qm.noDataState,
+        execErrState: qm.execErrState,
+        for: qm.for,
+        labels: rule.labels,
+        annotations: rule.annotations,
+        isPaused: qm.isPaused ?? false,
+      });
+      results[rule.uid] = "created";
+    } else {
+      const liveChecksum = queryChecksum(existing.body);
+      if (liveChecksum !== rule.queryChecksum) {
+        throw new Error(
+          `Rule ${rule.uid} exists live but has drifted from the checked-in sli-alerts overlay ` +
+            "(never overwritten automatically; reconcile by hand).",
+        );
+      }
+      results[rule.uid] = "present";
+    }
+  }
+  return results;
+}
+
+export async function runApply({ client, repoRoot = REPO_ROOT } = {}) {
+  const overlay = loadOverlay(repoRoot);
+  validateOverlayDocument(overlay);
+  const rules = await ensureRules(client, overlay);
+  return { rules };
+}
+
+export async function runVerify({ client, repoRoot = REPO_ROOT } = {}) {
+  const overlay = loadOverlay(repoRoot);
+  const live = await Promise.all(overlay.rules.map((r) => client.getAlertRule(r.uid)));
+  const checksums = {};
+  for (let i = 0; i < overlay.rules.length; i += 1) {
+    const rule = overlay.rules[i];
+    const body = live[i].body;
+    checksums[rule.uid] = body ? (queryChecksum(body) === rule.queryChecksum ? "match" : "MISMATCH") : "MISSING";
+  }
+  const promRules = await client.getPrometheusRules();
+  const group = (promRules.body?.data?.groups || []).find((g) => g.name === RULE_GROUP);
+  const health = {};
+  for (const r of group?.rules || []) {
+    health[r.name] = { health: r.health, state: r.state };
+  }
+  return { checksums, health };
+}
+
+function buildLiveClient() {
+  return createClient({ tokenProvider: () => adminTokenProvider() });
+}
+
+function printBoundedReadback(result) {
+  safeLog("read-back:");
+  for (const [uid, state] of Object.entries(result.checksums || {})) {
+    safeLog(`  ${uid} ${state}`);
+  }
+  for (const [title, h] of Object.entries(result.health || {})) {
+    safeLog(`  "${title}" health=${h.health} state=${h.state}`);
+  }
+}
+
+async function main() {
+  const command = process.argv[2] || "";
+  switch (command) {
+    case "check": {
+      runCheck();
+      safeLog(`check passed: ${RULE_GROUP} overlay is internally consistent.`);
+      return;
+    }
+    case "apply": {
+      assertLiveAllowed();
+      const client = buildLiveClient();
+      const result = await runApply({ client });
+      safeLog("apply result:", JSON.stringify(result));
+      return;
+    }
+    case "verify": {
+      assertLiveAllowed();
+      const client = buildLiveClient();
+      const result = await runVerify({ client });
+      printBoundedReadback(result);
+      return;
+    }
+    default:
+      throw new Error("Usage: grafana-sli-alerts.mjs <check|apply|verify>");
+  }
+}
+
+const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirectly) {
+  main().catch((error) => {
+    console.error(redact(error instanceof Error ? error.message : String(error)));
+    process.exitCode = 1;
+  });
+}
+
+export { canonicalize, sha256 };

--- a/scripts/ops/grafana-sli-alerts.test.mjs
+++ b/scripts/ops/grafana-sli-alerts.test.mjs
@@ -1,0 +1,268 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  NEW_TARGET,
+  WORKSPACE_BASE_URL,
+  adminTokenProvider,
+  createClient,
+  ensureRules,
+  loadOverlay,
+  runApply,
+  runCheck,
+  runVerify,
+  validateOverlayDocument,
+  verifyTarget,
+} from "./grafana-sli-alerts.mjs";
+import { queryChecksum } from "./grafana-alerting.mjs";
+
+// --- Fixtures: a real base overlay shape mirroring the checked-in file ------
+
+function baseQueryModel(overrides = {}) {
+  return {
+    title: "Sign-in failures > 5 in 10m",
+    condition: "threshold",
+    data: [
+      { refId: "A", datasourceUid: "cfvtvusw9bd34d", model: { metricName: "SignInFailureCount" } },
+      { refId: "B", datasourceUid: "__expr__", model: { expression: "A", type: "reduce" } },
+      { refId: "threshold", datasourceUid: "__expr__", model: { expression: "B", type: "threshold" } },
+    ],
+    noDataState: "OK",
+    execErrState: "Alerting",
+    for: "10m",
+    ruleGroup: "sli-alerts",
+    folderUID: "ops-folder",
+    isPaused: false,
+    ...overrides,
+  };
+}
+
+function baseOverlay(overrides = {}) {
+  const queryModel = baseQueryModel(overrides.queryModel);
+  const rule = {
+    uid: "ffvtx33lbo5c0e",
+    title: "Sign-in failures > 5 in 10m",
+    severity: "warning",
+    labels: { proliferate_component: "proliferate-server", severity: "warning" },
+    annotations: {
+      runbook_url:
+        "https://github.com/proliferate-ai/proliferate/blob/main/guides/operating/production-alerts.md#sign-in-success-rate",
+    },
+    queryModel,
+    queryChecksum: queryChecksum(queryModel),
+    ...(overrides.rule || {}),
+  };
+  return {
+    schemaVersion: 1,
+    target: { ...NEW_TARGET },
+    component: "proliferate-server",
+    rules: [rule],
+    ...overrides.top,
+  };
+}
+
+// --- Offline validation ------------------------------------------------------
+
+test("verifyTarget accepts an exact match and rejects any drift", () => {
+  assert.doesNotThrow(() => verifyTarget({ ...NEW_TARGET }));
+  assert.throws(() => verifyTarget({ ...NEW_TARGET, grafanaWorkspaceId: "g-e532d030d8" }), /non-matching target/);
+  assert.throws(() => verifyTarget(null), /non-matching target/);
+});
+
+test("the real checked-in sli-alerts.json passes full offline validation", () => {
+  const overlay = loadOverlay();
+  assert.doesNotThrow(() => validateOverlayDocument(overlay));
+  assert.equal(overlay.rules[0].queryModel.ruleGroup, "sli-alerts");
+});
+
+test("runCheck loads and validates the real checked-in file", () => {
+  const { overlay } = runCheck();
+  assert.equal(overlay.target.grafanaWorkspaceId, "g-48655e6419");
+});
+
+test("validateOverlayDocument rejects a rule outside the sli-alerts ruleGroup", () => {
+  const overlay = baseOverlay({ queryModel: { ruleGroup: "production-alerts" } });
+  overlay.rules[0].queryChecksum = queryChecksum(overlay.rules[0].queryModel);
+  assert.throws(() => validateOverlayDocument(overlay), /must be in ruleGroup "sli-alerts"/);
+});
+
+test("validateOverlayDocument rejects a title mismatch between identity and queryModel", () => {
+  const overlay = baseOverlay();
+  overlay.rules[0].queryModel.title = "Something else";
+  assert.throws(() => validateOverlayDocument(overlay), /title does not match/);
+});
+
+test("validateOverlayDocument detects checksum drift against a tampered queryModel", () => {
+  const overlay = baseOverlay();
+  overlay.rules[0].queryModel.for = "1m"; // tamper after the checksum was computed
+  assert.throws(() => validateOverlayDocument(overlay), /queryChecksum does not match/);
+});
+
+test("validateOverlayDocument rejects a query stanza missing a datasourceUid", () => {
+  const overlay = baseOverlay();
+  delete overlay.rules[0].queryModel.data[0].datasourceUid;
+  overlay.rules[0].queryChecksum = queryChecksum(overlay.rules[0].queryModel);
+  assert.throws(() => validateOverlayDocument(overlay), /missing datasourceUid/);
+});
+
+test("validateOverlayDocument requires a runbook_url annotation on every rule", () => {
+  const overlay = baseOverlay();
+  overlay.rules[0].annotations = {};
+  assert.throws(() => validateOverlayDocument(overlay), /missing a runbook_url annotation/);
+});
+
+test("validateOverlayDocument rejects a duplicate rule UID", () => {
+  const overlay = baseOverlay();
+  overlay.rules.push({ ...overlay.rules[0] });
+  assert.throws(() => validateOverlayDocument(overlay), /Duplicate rule UID/);
+});
+
+test("validateOverlayDocument rejects an empty rule set", () => {
+  const overlay = baseOverlay();
+  overlay.rules = [];
+  assert.throws(() => validateOverlayDocument(overlay), /defines no rules/);
+});
+
+// --- Admin token loading ------------------------------------------------------
+
+test("adminTokenProvider throws when the token file is missing", () => {
+  const missing = path.join(os.tmpdir(), `grafana-sli-token-missing-${process.pid}`);
+  assert.throws(() => adminTokenProvider({ tokenPath: missing }), /not found/);
+});
+
+test("adminTokenProvider throws when the token file is not mode 0600", () => {
+  const tokenPath = path.join(os.tmpdir(), `grafana-sli-token-loose-${process.pid}`);
+  fs.writeFileSync(tokenPath, "sekret", { mode: 0o644 });
+  try {
+    assert.throws(() => adminTokenProvider({ tokenPath }), /mode 0600/);
+  } finally {
+    fs.rmSync(tokenPath, { force: true });
+  }
+});
+
+test("adminTokenProvider throws when the token file is empty", () => {
+  const tokenPath = path.join(os.tmpdir(), `grafana-sli-token-empty-${process.pid}`);
+  fs.writeFileSync(tokenPath, "", { mode: 0o600 });
+  try {
+    assert.throws(() => adminTokenProvider({ tokenPath }), /empty/);
+  } finally {
+    fs.rmSync(tokenPath, { force: true });
+  }
+});
+
+test("adminTokenProvider returns the trimmed token on a valid 0600 file", () => {
+  const tokenPath = path.join(os.tmpdir(), `grafana-sli-token-ok-${process.pid}`);
+  fs.writeFileSync(tokenPath, "glsa_abc123\n", { mode: 0o600 });
+  try {
+    assert.equal(adminTokenProvider({ tokenPath }), "glsa_abc123");
+  } finally {
+    fs.rmSync(tokenPath, { force: true });
+  }
+});
+
+// --- Fake-transport client: apply / verify without the network --------------
+
+function makeFakeGrafana(initialRules = {}) {
+  const rules = { ...initialRules };
+  const calls = [];
+  async function fetchImpl(url, init) {
+    calls.push({ url: String(url), method: init.method });
+    assert.ok(String(url).startsWith(WORKSPACE_BASE_URL), "requests must target the fixed workspace base URL");
+    const u = new URL(url);
+    const getMatch = u.pathname.match(/^\/api\/v1\/provisioning\/alert-rules\/(.+)$/);
+    if (init.method === "GET" && getMatch) {
+      const uid = decodeURIComponent(getMatch[1]);
+      if (!(uid in rules)) {
+        return { ok: false, status: 404, text: async () => "" };
+      }
+      return { ok: true, status: 200, text: async () => JSON.stringify(rules[uid]) };
+    }
+    if (init.method === "POST" && u.pathname === "/api/v1/provisioning/alert-rules") {
+      const body = JSON.parse(init.body);
+      rules[body.uid] = body;
+      return { ok: true, status: 201, text: async () => JSON.stringify(body) };
+    }
+    if (init.method === "GET" && u.pathname === "/api/prometheus/grafana/api/v1/rules") {
+      const groupRules = Object.values(rules).map((r) => ({ name: r.title, health: "ok", state: "inactive" }));
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ data: { groups: [{ name: "sli-alerts", rules: groupRules }] } }),
+      };
+    }
+    throw new Error(`Unhandled fake request: ${init.method} ${u.pathname}`);
+  }
+  return { fetchImpl, calls, rules };
+}
+
+test("createClient requires a tokenProvider function", () => {
+  assert.throws(() => createClient({ tokenProvider: undefined }), /requires a tokenProvider/);
+});
+
+test("createClient sends a Bearer header derived from the token provider", async () => {
+  const { fetchImpl, calls } = makeFakeGrafana();
+  const client = createClient({ fetchImpl, tokenProvider: () => "test-token" });
+  await client.getAlertRule("nope");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].method, "GET");
+});
+
+test("ensureRules creates a missing rule and reports it created", async () => {
+  const { fetchImpl, rules } = makeFakeGrafana();
+  const client = createClient({ fetchImpl, tokenProvider: () => "t" });
+  const overlay = baseOverlay();
+  const result = await ensureRules(client, overlay);
+  assert.deepEqual(result, { ffvtx33lbo5c0e: "created" });
+  assert.ok(rules.ffvtx33lbo5c0e);
+});
+
+test("ensureRules is idempotent: a matching live rule reports present, no second create", async () => {
+  const overlay = baseOverlay();
+  const liveRule = { uid: overlay.rules[0].uid, ...overlay.rules[0].queryModel };
+  const { fetchImpl, calls } = makeFakeGrafana({ [overlay.rules[0].uid]: liveRule });
+  const client = createClient({ fetchImpl, tokenProvider: () => "t" });
+  const result = await ensureRules(client, overlay);
+  assert.deepEqual(result, { ffvtx33lbo5c0e: "present" });
+  assert.ok(!calls.some((c) => c.method === "POST"), "must not attempt to recreate a present, matching rule");
+});
+
+test("ensureRules hard-fails rather than overwriting a live rule that has drifted", async () => {
+  const overlay = baseOverlay();
+  const drifted = { uid: overlay.rules[0].uid, ...overlay.rules[0].queryModel, for: "30m" };
+  const { fetchImpl } = makeFakeGrafana({ [overlay.rules[0].uid]: drifted });
+  const client = createClient({ fetchImpl, tokenProvider: () => "t" });
+  await assert.rejects(() => ensureRules(client, overlay), /has drifted from the checked-in sli-alerts overlay/);
+});
+
+test("runApply is a thin wrapper that validates then ensures every rule", async () => {
+  const { fetchImpl } = makeFakeGrafana();
+  const client = createClient({ fetchImpl, tokenProvider: () => "t" });
+  const result = await runApply({ client, repoRoot: undefined }).catch((e) => e);
+  // Uses the real checked-in overlay (repoRoot default), so this exercises the
+  // actual file end to end against the fake transport.
+  assert.ok(result.rules, "expected a rules result, not an error");
+  assert.equal(result.rules.ffvtx33lbo5c0e, "created");
+});
+
+test("runVerify reports checksum match/mismatch and per-rule health from the rules API", async () => {
+  // runVerify always reloads the real checked-in overlay from disk (same as
+  // runCheck/runApply), so the fake live rule must be built from that same
+  // on-disk queryModel for the checksums to align -- not a hand-rolled one.
+  const onDisk = loadOverlay();
+  const liveRule = { uid: onDisk.rules[0].uid, ...onDisk.rules[0].queryModel };
+  const { fetchImpl } = makeFakeGrafana({ [onDisk.rules[0].uid]: liveRule });
+  const client = createClient({ fetchImpl, tokenProvider: () => "t" });
+  const result = await runVerify({ client });
+  assert.equal(result.checksums[onDisk.rules[0].uid], "match");
+  assert.equal(result.health[onDisk.rules[0].title].health, "ok");
+});
+
+test("runVerify reports MISSING for a rule that does not exist live", async () => {
+  const { fetchImpl } = makeFakeGrafana();
+  const client = createClient({ fetchImpl, tokenProvider: () => "t" });
+  const result = await runVerify({ client });
+  assert.equal(result.checksums.ffvtx33lbo5c0e, "MISSING");
+});

--- a/server/alembic/env.py
+++ b/server/alembic/env.py
@@ -23,7 +23,21 @@ from proliferate.db.models.base import Base
 
 config = context.config
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    # disable_existing_loggers defaults to True, which silently sets
+    # `.disabled = True` on every logger that already exists at this point
+    # and is not itself named in alembic.ini's [loggers] section -- forever,
+    # for the life of the process, not just for the migration run. In the
+    # test suite this reliably disabled `proliferate.auth.sign_in` (created
+    # at import time by `proliferate.main` -> the desktop/identity auth
+    # routers -> `sign_in_observability.py`) the moment any test imported
+    # `proliferate.main` before the first migration ran in that pytest-xdist
+    # worker, permanently silencing the sign-in SLI log line for every later
+    # test in that worker (root-caused via PR #2181 CI: `test-integration`
+    # shard 3, two caplog assertions failing with zero captured records
+    # despite the log call demonstrably executing). False is the standard,
+    # documented fix: apply alembic.ini's own logger configuration
+    # additively instead of tearing down everything else already configured.
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 target_metadata = Base.metadata
 

--- a/server/infra/observability/grafana/sli-alerts.json
+++ b/server/infra/observability/grafana/sli-alerts.json
@@ -1,0 +1,117 @@
+{
+  "schemaVersion": 1,
+  "phase": "observability-overnight-2026-08-20-lane-d",
+  "description": "Checked-in, checksum-verified record of the sign-in success-rate SLI alert rule on the NEW workspace (proliferate-ops-rebuild). This is a separate ruleGroup ('sli-alerts') from the five-rule production-alerts.json allowlist and the rebuild copy of it in production-alerts-rebuild.json, so scripts/ops/grafana-sli-alerts.mjs can create/verify it without touching those rules, their contact point, or the notification policy. queryChecksum is sha256 of the canonical JSON serialization of the same {title, condition, data, noDataState, execErrState, for, ruleGroup, folderUID, isPaused} shape used by scripts/ops/grafana-alerting.mjs, captured 2026-08-21 via a live POST to /api/v1/provisioning/alert-rules followed by a GET read-back on the NEW workspace with the ADMIN rebuild token. Delivery for this rule rides the same default notification policy / SNS contact point that Lane A3 wired up for the five production rules (see guides/operating/production-alerts.md) -- this file does not define or touch a contact point.",
+  "target": {
+    "awsAccount": "157466816238",
+    "awsRegion": "us-east-1",
+    "grafanaWorkspaceId": "g-48655e6419",
+    "grafanaWorkspaceName": "proliferate-ops-rebuild",
+    "grafanaVersion": "10.4"
+  },
+  "component": "proliferate-server",
+  "runbook": "guides/operating/production-alerts.md",
+  "runbookUrlBase": "https://github.com/proliferate-ai/proliferate/blob/main/guides/operating/production-alerts.md",
+  "rules": [
+    {
+      "uid": "ffvtx33lbo5c0e",
+      "title": "Sign-in failures > 5 in 10m",
+      "severity": "warning",
+      "labels": {
+        "proliferate_component": "proliferate-server",
+        "severity": "warning"
+      },
+      "annotations": {
+        "runbook_url": "https://github.com/proliferate-ai/proliferate/blob/main/guides/operating/production-alerts.md#sign-in-success-rate"
+      },
+      "queryModel": {
+        "title": "Sign-in failures > 5 in 10m",
+        "condition": "threshold",
+        "data": [
+          {
+            "refId": "A",
+            "queryType": "",
+            "relativeTimeRange": {
+              "from": 600,
+              "to": 0
+            },
+            "datasourceUid": "cfvtvusw9bd34d",
+            "model": {
+              "dimensions": {},
+              "intervalMs": 1000,
+              "maxDataPoints": 43200,
+              "metricName": "SignInFailureCount",
+              "namespace": "Proliferate/Prod",
+              "period": "600",
+              "queryMode": "Metrics",
+              "refId": "A",
+              "region": "us-east-1",
+              "statistics": [
+                "Sum"
+              ]
+            }
+          },
+          {
+            "refId": "B",
+            "queryType": "",
+            "relativeTimeRange": {
+              "from": 600,
+              "to": 0
+            },
+            "datasourceUid": "__expr__",
+            "model": {
+              "expression": "A",
+              "intervalMs": 1000,
+              "maxDataPoints": 43200,
+              "reducer": "last",
+              "refId": "B",
+              "settings": {
+                "mode": "dropNN"
+              },
+              "type": "reduce"
+            }
+          },
+          {
+            "refId": "threshold",
+            "queryType": "",
+            "relativeTimeRange": {
+              "from": 600,
+              "to": 0
+            },
+            "datasourceUid": "__expr__",
+            "model": {
+              "conditions": [
+                {
+                  "evaluator": {
+                    "params": [
+                      5
+                    ],
+                    "type": "gt"
+                  },
+                  "operator": {
+                    "type": "and"
+                  },
+                  "reducer": {
+                    "type": "last"
+                  }
+                }
+              ],
+              "expression": "B",
+              "intervalMs": 1000,
+              "maxDataPoints": 43200,
+              "refId": "threshold",
+              "type": "threshold"
+            }
+          }
+        ],
+        "noDataState": "OK",
+        "execErrState": "Alerting",
+        "for": "10m",
+        "ruleGroup": "sli-alerts",
+        "folderUID": "ops-folder",
+        "isPaused": false
+      },
+      "queryChecksum": "4867f7c60185b939dee8e5c340f927af01f290717f7f3e7245b2e9f457f6185a"
+    }
+  ]
+}

--- a/server/proliferate/auth/sign_in_observability.py
+++ b/server/proliferate/auth/sign_in_observability.py
@@ -1,0 +1,61 @@
+"""Structured sign-in outcome logging for the sign-in success-rate SLI.
+
+The token-exchange endpoints (`/auth/web/token`, `/auth/mobile/token`,
+`/auth/desktop/token`) previously emitted no outcome log line at all — see
+[[Observability Context]] section 4.3. This module is the single place that
+emits one, so the CloudWatch metric filter and the field contract stay in
+sync with the code that produces them.
+
+Contract fields (stable; consumed by a CloudWatch Logs metric filter, see
+`guides/operating/production-alerts.md#sign-in-success-rate`):
+
+- `event`: always `"auth.sign_in.outcome"`
+- `auth_sign_in_outcome`: `"success"` or `"failure"`
+- `auth_sign_in_surface`: `"web"`, `"mobile"`, or `"desktop"`
+- `auth_sign_in_failure_code`: the bounded `AuthFlowError.code` (failure only)
+
+Never log the auth code, PKCE verifier, tokens, or the user's email — the
+`AuthFlowError.code` values are already bounded, non-PII identifiers (e.g.
+`identity_auth_code_invalid`, `desktop_pkce_verification_failed`).
+"""
+
+from __future__ import annotations
+
+import logging
+
+_logger = logging.getLogger("proliferate.auth.sign_in")
+
+SignInSurface = str
+_SURFACES = frozenset({"web", "mobile", "desktop"})
+
+
+def _validate_surface(surface: SignInSurface) -> None:
+    if surface not in _SURFACES:
+        raise ValueError(f"unknown sign-in surface: {surface!r}")
+
+
+def log_sign_in_success(surface: SignInSurface) -> None:
+    """Record a successful token exchange for the sign-in success-rate SLI."""
+    _validate_surface(surface)
+    _logger.info(
+        "auth sign-in succeeded",
+        extra={
+            "event": "auth.sign_in.outcome",
+            "auth_sign_in_outcome": "success",
+            "auth_sign_in_surface": surface,
+        },
+    )
+
+
+def log_sign_in_failure(surface: SignInSurface, *, failure_code: str) -> None:
+    """Record a failed token exchange for the sign-in success-rate SLI."""
+    _validate_surface(surface)
+    _logger.info(
+        "auth sign-in failed",
+        extra={
+            "event": "auth.sign_in.outcome",
+            "auth_sign_in_outcome": "failure",
+            "auth_sign_in_surface": surface,
+            "auth_sign_in_failure_code": failure_code,
+        },
+    )

--- a/server/proliferate/server/accounts/desktop/api.py
+++ b/server/proliferate/server/accounts/desktop/api.py
@@ -36,6 +36,7 @@ from proliferate.auth.errors import AuthFlowError
 from proliferate.auth.identity.models import PasswordLoginRequest
 from proliferate.auth.identity.password import request_client_ip
 from proliferate.auth.oauth import github_oauth_client
+from proliferate.auth.sign_in_observability import log_sign_in_failure, log_sign_in_success
 from proliferate.auth.users import UserManager, get_user_manager
 from proliferate.config import settings
 from proliferate.constants.auth import (
@@ -44,6 +45,7 @@ from proliferate.constants.auth import (
     SUPPORTED_CODE_CHALLENGE_METHODS,
 )
 from proliferate.db.engine import get_async_session
+from proliferate.errors import ProliferateError
 from proliferate.server.accounts.desktop.service import (
     build_github_callback_url,
     exchange_desktop_token,
@@ -255,7 +257,13 @@ async def exchange_token(
     db: AsyncSession = Depends(get_async_session),
 ) -> TokenResponse:
     """Exchange an authorization code + PKCE code_verifier for JWT tokens."""
-    return await exchange_desktop_token(db, body)
+    try:
+        result = await exchange_desktop_token(db, body)
+    except ProliferateError as exc:
+        log_sign_in_failure("desktop", failure_code=exc.code)
+        raise
+    log_sign_in_success("desktop")
+    return result
 
 
 # ── Refresh token endpoint ──

--- a/server/proliferate/server/accounts/identity/api.py
+++ b/server/proliferate/server/accounts/identity/api.py
@@ -57,6 +57,7 @@ from proliferate.auth.identity.web_beta import (
     WebBetaAccessDenied,
     ensure_web_beta_email_allowed,
 )
+from proliferate.auth.sign_in_observability import log_sign_in_failure, log_sign_in_success
 from proliferate.config import settings
 from proliferate.constants.auth import (
     DESKTOP_DEEP_LINK_LAUNCH_ENABLED,
@@ -64,6 +65,7 @@ from proliferate.constants.auth import (
 )
 from proliferate.db.engine import get_async_session
 from proliferate.db.models.auth import User
+from proliferate.errors import ProliferateError
 from proliferate.server.accounts.identity.service import (
     authenticate_password_login,
     complete_apple_mobile_login,
@@ -396,9 +398,14 @@ async def web_token(
     response: Response,
     db: AsyncSession = Depends(get_async_session),
 ) -> AuthSessionResponse:
-    session = await exchange_auth_code(db, code=body.code, code_verifier=body.code_verifier)
-    ensure_web_beta_email_allowed(session.email)
+    try:
+        session = await exchange_auth_code(db, code=body.code, code_verifier=body.code_verifier)
+        ensure_web_beta_email_allowed(session.email)
+    except ProliferateError as exc:
+        log_sign_in_failure("web", failure_code=exc.code)
+        raise
     await db.commit()
+    log_sign_in_success("web")
     _set_web_session_cookies(response, session.refresh_token)
     return auth_session_response(session, include_refresh_token=False)
 
@@ -408,8 +415,13 @@ async def mobile_token(
     body: AuthTokenRequest,
     db: AsyncSession = Depends(get_async_session),
 ) -> AuthSessionResponse:
-    session = await exchange_auth_code(db, code=body.code, code_verifier=body.code_verifier)
+    try:
+        session = await exchange_auth_code(db, code=body.code, code_verifier=body.code_verifier)
+    except ProliferateError as exc:
+        log_sign_in_failure("mobile", failure_code=exc.code)
+        raise
     await db.commit()
+    log_sign_in_success("mobile")
     return auth_session_response(session, include_refresh_token=True)
 
 

--- a/server/tests/integration/conftest.py
+++ b/server/tests/integration/conftest.py
@@ -1,6 +1,9 @@
-"""Shared fixtures for agent-gateway integration tests."""
+"""Shared fixtures for integration tests."""
 
 from __future__ import annotations
+
+import logging
+from collections.abc import Generator
 
 import pytest
 
@@ -28,3 +31,40 @@ def topup_settings(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "agent_gateway_llm_topup_price_id", "price_llm_topup")
     monkeypatch.setattr(settings, "agent_gateway_topup_threshold_usd", "2")
     monkeypatch.setattr(settings, "agent_gateway_topup_amount_usd", "10")
+
+
+@pytest.fixture
+def sign_in_log_records() -> Generator[list[logging.LogRecord], None, None]:
+    """Capture `proliferate.auth.sign_in` records directly on the leaf logger.
+
+    `caplog` only observes records once they propagate to the root logger,
+    and that path is contended: `configure_server_logging()` (invoked by
+    every `create_app()`, see `proliferate/middleware/logging.py`) flips the
+    ancestor `proliferate` logger's `propagate` to `False` process-wide the
+    first time it runs. Pytest's own workaround -- attaching its capture
+    handler directly to any logger it finds already at `propagate=False` --
+    is a snapshot taken once per test phase, and under `pytest -n` xdist
+    workers running hundreds of integration tests back to back on a shared
+    session-scoped event loop, that snapshot can race a concurrent fixture
+    teardown and miss the attach. The result is an intermittent empty
+    `caplog.records` for a correctly emitted record (root-caused on PR #2181,
+    shard 3: `assert 0 == 1`, reproduced locally only under `pytest -n 4`
+    across the full shard, never with these files run alone or serially).
+
+    Attaching a dedicated handler straight onto the leaf logger sidesteps all
+    of that: capture no longer depends on `propagate`, on root-logger
+    snapshotting, or on any other test's logging configuration.
+    """
+    records: list[logging.LogRecord] = []
+
+    class _RecordCollector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    logger = logging.getLogger("proliferate.auth.sign_in")
+    handler = _RecordCollector(level=logging.INFO)
+    logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)

--- a/server/tests/integration/test_desktop_auth_error_contract.py
+++ b/server/tests/integration/test_desktop_auth_error_contract.py
@@ -170,15 +170,13 @@ async def test_stale_refresh_generation_keeps_raw_detail(
 @pytest.mark.asyncio
 async def test_token_exchange_logs_sign_in_failure_outcome(
     client: AsyncClient,
-    caplog: pytest.LogCaptureFixture,
+    sign_in_log_records: list[logging.LogRecord],
 ) -> None:
     """The sign-in success-rate SLI depends on this log line existing.
 
     See `server/proliferate/auth/sign_in_observability.py` and
     `guides/operating/production-alerts.md#sign-in-success-rate`.
     """
-    caplog.set_level(logging.INFO, logger="proliferate.auth.sign_in")
-
     response = await client.post(
         "/auth/desktop/token",
         json={
@@ -189,7 +187,7 @@ async def test_token_exchange_logs_sign_in_failure_outcome(
     )
 
     assert response.status_code == 400
-    records = [r for r in caplog.records if r.name == "proliferate.auth.sign_in"]
+    records = sign_in_log_records
     assert len(records) == 1
     record = records[0]
     assert record.event == "auth.sign_in.outcome"
@@ -202,9 +200,8 @@ async def test_token_exchange_logs_sign_in_failure_outcome(
 async def test_token_exchange_logs_sign_in_success_outcome(
     client: AsyncClient,
     db_session: AsyncSession,
-    caplog: pytest.LogCaptureFixture,
+    sign_in_log_records: list[logging.LogRecord],
 ) -> None:
-    caplog.set_level(logging.INFO, logger="proliferate.auth.sign_in")
     user = await _create_active_user(db_session)
 
     payload = await mint_desktop_token_payload(
@@ -214,7 +211,7 @@ async def test_token_exchange_logs_sign_in_success_outcome(
     )
 
     assert "access_token" in payload
-    records = [r for r in caplog.records if r.name == "proliferate.auth.sign_in"]
+    records = sign_in_log_records
     assert len(records) == 1
     record = records[0]
     assert record.event == "auth.sign_in.outcome"

--- a/server/tests/integration/test_desktop_auth_error_contract.py
+++ b/server/tests/integration/test_desktop_auth_error_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from uuid import uuid4
 
 import pytest
@@ -11,6 +12,7 @@ from proliferate.auth.tokens import REFRESH_TOKEN_AUDIENCE
 from proliferate.config import settings
 from proliferate.constants.auth import REFRESH_TOKEN_LIFETIME_SECONDS
 from proliferate.db.models.auth import User
+from tests.helpers.desktop_auth import mint_desktop_token_payload
 
 
 def _signed_refresh_token(claims: dict[str, object]) -> str:
@@ -163,3 +165,59 @@ async def test_stale_refresh_generation_keeps_raw_detail(
         status_code=401,
         detail="Refresh token has been revoked",
     )
+
+
+@pytest.mark.asyncio
+async def test_token_exchange_logs_sign_in_failure_outcome(
+    client: AsyncClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The sign-in success-rate SLI depends on this log line existing.
+
+    See `server/proliferate/auth/sign_in_observability.py` and
+    `guides/operating/production-alerts.md#sign-in-success-rate`.
+    """
+    caplog.set_level(logging.INFO, logger="proliferate.auth.sign_in")
+
+    response = await client.post(
+        "/auth/desktop/token",
+        json={
+            "code": "missing-code",
+            "code_verifier": "unused-verifier",
+            "grant_type": "authorization_code",
+        },
+    )
+
+    assert response.status_code == 400
+    records = [r for r in caplog.records if r.name == "proliferate.auth.sign_in"]
+    assert len(records) == 1
+    record = records[0]
+    assert record.event == "auth.sign_in.outcome"
+    assert record.auth_sign_in_outcome == "failure"
+    assert record.auth_sign_in_surface == "desktop"
+    assert record.auth_sign_in_failure_code == "desktop_auth_code_invalid"
+
+
+@pytest.mark.asyncio
+async def test_token_exchange_logs_sign_in_success_outcome(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO, logger="proliferate.auth.sign_in")
+    user = await _create_active_user(db_session)
+
+    payload = await mint_desktop_token_payload(
+        client,
+        user_id=user.id,
+        state_prefix="sli-success",
+    )
+
+    assert "access_token" in payload
+    records = [r for r in caplog.records if r.name == "proliferate.auth.sign_in"]
+    assert len(records) == 1
+    record = records[0]
+    assert record.event == "auth.sign_in.outcome"
+    assert record.auth_sign_in_outcome == "success"
+    assert record.auth_sign_in_surface == "desktop"
+    assert not hasattr(record, "auth_sign_in_failure_code")

--- a/server/tests/integration/test_identity_auth_error_contract.py
+++ b/server/tests/integration/test_identity_auth_error_contract.py
@@ -431,15 +431,13 @@ async def test_provider_email_conflict_preserves_409_contract(
 async def test_mobile_token_logs_sign_in_outcome(
     client: AsyncClient,
     db_session: AsyncSession,
-    caplog: pytest.LogCaptureFixture,
+    sign_in_log_records: list[logging.LogRecord],
 ) -> None:
     """The sign-in success-rate SLI depends on this log line existing.
 
     See `server/proliferate/auth/sign_in_observability.py` and
     `guides/operating/production-alerts.md#sign-in-success-rate`.
     """
-    caplog.set_level(logging.INFO, logger="proliferate.auth.sign_in")
-
     failed = await client.post(
         "/auth/mobile/token",
         json={
@@ -467,7 +465,7 @@ async def test_mobile_token_logs_sign_in_outcome(
     )
     assert succeeded.status_code == 200
 
-    records = [r for r in caplog.records if r.name == "proliferate.auth.sign_in"]
+    records = sign_in_log_records
     assert len(records) == 2
     failure_record, success_record = records
     assert failure_record.event == "auth.sign_in.outcome"
@@ -483,10 +481,8 @@ async def test_mobile_token_logs_sign_in_outcome(
 async def test_web_token_logs_sign_in_outcome(
     client: AsyncClient,
     db_session: AsyncSession,
-    caplog: pytest.LogCaptureFixture,
+    sign_in_log_records: list[logging.LogRecord],
 ) -> None:
-    caplog.set_level(logging.INFO, logger="proliferate.auth.sign_in")
-
     failed = await client.post(
         "/auth/web/token",
         json={
@@ -497,7 +493,7 @@ async def test_web_token_logs_sign_in_outcome(
     )
     assert failed.status_code == 400
 
-    records = [r for r in caplog.records if r.name == "proliferate.auth.sign_in"]
+    records = sign_in_log_records
     assert len(records) == 1
     record = records[0]
     assert record.auth_sign_in_outcome == "failure"

--- a/server/tests/integration/test_identity_auth_error_contract.py
+++ b/server/tests/integration/test_identity_auth_error_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
@@ -424,3 +425,81 @@ async def test_provider_email_conflict_preserves_409_contract(
         status_code=409,
         detail="An account already exists for this email. Sign in with GitHub to link it.",
     )
+
+
+@pytest.mark.asyncio
+async def test_mobile_token_logs_sign_in_outcome(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The sign-in success-rate SLI depends on this log line existing.
+
+    See `server/proliferate/auth/sign_in_observability.py` and
+    `guides/operating/production-alerts.md#sign-in-success-rate`.
+    """
+    caplog.set_level(logging.INFO, logger="proliferate.auth.sign_in")
+
+    failed = await client.post(
+        "/auth/mobile/token",
+        json={
+            "code": "missing-code",
+            "codeVerifier": "missing-verifier",
+            "grantType": "authorization_code",
+        },
+    )
+    assert failed.status_code == 400
+
+    user = await _create_user(db_session, email="sli-mobile@example.com")
+    verifier, challenge = make_pkce_pair()
+    code = await create_desktop_auth_code(
+        user_id=user.id,
+        state="sli-mobile-state",
+        code_challenge=challenge,
+    )
+    succeeded = await client.post(
+        "/auth/mobile/token",
+        json={
+            "code": code,
+            "codeVerifier": verifier,
+            "grantType": "authorization_code",
+        },
+    )
+    assert succeeded.status_code == 200
+
+    records = [r for r in caplog.records if r.name == "proliferate.auth.sign_in"]
+    assert len(records) == 2
+    failure_record, success_record = records
+    assert failure_record.event == "auth.sign_in.outcome"
+    assert failure_record.auth_sign_in_outcome == "failure"
+    assert failure_record.auth_sign_in_surface == "mobile"
+    assert failure_record.auth_sign_in_failure_code == "identity_auth_code_invalid"
+    assert success_record.auth_sign_in_outcome == "success"
+    assert success_record.auth_sign_in_surface == "mobile"
+    assert not hasattr(success_record, "auth_sign_in_failure_code")
+
+
+@pytest.mark.asyncio
+async def test_web_token_logs_sign_in_outcome(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO, logger="proliferate.auth.sign_in")
+
+    failed = await client.post(
+        "/auth/web/token",
+        json={
+            "code": "missing-code",
+            "codeVerifier": "missing-verifier",
+            "grantType": "authorization_code",
+        },
+    )
+    assert failed.status_code == 400
+
+    records = [r for r in caplog.records if r.name == "proliferate.auth.sign_in"]
+    assert len(records) == 1
+    record = records[0]
+    assert record.auth_sign_in_outcome == "failure"
+    assert record.auth_sign_in_surface == "web"
+    assert record.auth_sign_in_failure_code == "identity_auth_code_invalid"


### PR DESCRIPTION
## Summary

Continuation of Lane D (observability overnight, D1) after the prior agent was
stopped mid-work. Adopted its uncommitted worktree changes, independently
re-verified every live claim, and committed.

- `server/proliferate/auth/sign_in_observability.py`: single place emitting
  `auth.sign_in.outcome` structured log lines (`auth_sign_in_outcome`,
  `auth_sign_in_surface`, `auth_sign_in_failure_code` on failure only) — no
  auth code, PKCE verifier, token, or email logged.
- Wired into `/auth/web/token`, `/auth/mobile/token` (`identity/api.py`) and
  `/auth/desktop/token` (`desktop/api.py`): success and `ProliferateError`
  failure paths both log now, where previously neither did.
- `guides/operating/production-alerts.md`: new "Sign-in success rate (SLI)"
  section documenting the CloudWatch metric filters, the Grafana rule, and
  what to do when it fires.
- `scripts/ops/grafana-sli-alerts.mjs` (+ tests): check/apply/verify tooling
  for the rule, scoped to its own `sli-alerts` rule group so it never touches
  the `production-alerts` group, contact point, or notification policy that
  `grafana-alerting.mjs` / `grafana-rebuild-bootstrap.mjs` (#2178) manage.
- `server/infra/observability/grafana/sli-alerts.json`: checksum-verified
  record of the live rule (uid `ffvtx33lbo5c0e`, new `proliferate-ops-rebuild`
  workspace).

**Builds on `obs/lane-a3-grafana-new-workspace` (#2178, unmerged)**: depends
on that PR's CloudWatch data source (`cfvtvusw9bd34d`) and unified-alerting
enablement on the new workspace to have already happened live tonight (they
have — verified below), but this PR touches none of #2178's files and can
land independently of it merging.

## Independent verification (not just re-stating the prior agent's claims)

- `aws logs describe-metric-filters --log-group-name /ecs/proliferate-prod`:
  both `sign-in-success` and `sign-in-failure` filters exist live, same shape
  as the two pre-existing filters in that log group (neither pair is
  Terraform-managed — consistent with existing practice).
- `aws cloudwatch get-metric-statistics` for `SignInSuccessCount` and
  `SignInFailureCount`: real `Sum=1.0` datapoint for each at
  `2026-08-21T00:30:00-07:00` — the pipe produces a real number, not just a
  configured-but-silent rule.
- `node scripts/ops/grafana-sli-alerts.mjs verify` (live): rule checksum
  `match`, health `ok`, state `inactive`.
- Pulled the live alertmanager config directly and confirmed the root route's
  receiver (`grafana-default-sns`) resolves to the SNS topic
  `arn:aws:sns:us-east-1:157466816238:grafana-proliferate-ops-alerts`, the
  same topic with the confirmed `pablo@pablohansen.com` subscription.
- Fired a **fresh** test notification for this exact rule
  (`POST /api/alertmanager/grafana/config/api/v1/receivers/test`, labels
  `alertname: "Sign-in failures > 5 in 10m"`): HTTP 200, receiver config
  `status: "ok"`, `notified_at: 2026-08-21T08:02:55Z`. This is proof this
  specific rule pages through, not just the workspace default in the
  abstract.
- Ran the new/changed test suites locally: `node --test
  scripts/ops/grafana-sli-alerts.test.mjs` (22/22 pass);
  `server/.venv/bin/python -m pytest tests/integration/test_desktop_auth_error_contract.py
  tests/integration/test_identity_auth_error_contract.py` with CI's env vars
  (24/24 pass); ruff + mypy clean on touched files.
- Negative control: commented out `log_sign_in_success("desktop")`, reran the
  new success test — it failed as expected (`assert 0 == 1`), confirming the
  test actually exercises the log line. Restored before committing.

## Test plan

- [x] `node --test scripts/ops/grafana-sli-alerts.test.mjs` — 22/22 pass
- [x] `pytest tests/integration/test_desktop_auth_error_contract.py tests/integration/test_identity_auth_error_contract.py` — 24/24 pass
- [x] `ruff check` clean on touched files
- [x] `mypy` clean on touched files
- [x] Negative control on the new success-path test
- [x] Live verify of the Grafana rule + a fresh live test notification (see above)
- [ ] CI green on this PR (pushed, not merged — merge is Pablo's per standing policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)