### PR TITLE
perf(release-desktop): one notarized bundling pass and a concurrent agent seed

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -376,7 +376,8 @@ jobs:
               --anyharness-bin "$PWD/target/${{ matrix.target }}/release/anyharness" \
               --runtime-home "$seed_runtime" \
               --output-dir "$PWD/apps/desktop/src-tauri/agent-seeds" || seed_exit=$?
-            echo "$seed_exit" > "$RUNNER_TEMP/agent-seed.status"
+            echo "$seed_exit" > "$RUNNER_TEMP/agent-seed.status.tmp"
+            mv -f "$RUNNER_TEMP/agent-seed.status.tmp" "$RUNNER_TEMP/agent-seed.status"
           ) </dev/null > "$RUNNER_TEMP/agent-seed.log" 2>&1 &
           disown 2>/dev/null || true
           echo "Agent seed build started in the background (pid $!)."
@@ -701,18 +702,26 @@ jobs:
       # notarized builds of the same commit. One pass makes them the same
       # stapled bundle. These assertions are the standing proof that the single
       # notarization actually covered every shipped payload; if a future change
-      # reintroduces a second pass, or drops the app bundle type (which is what
-      # silently disables updater artifacts in tauri-bundler 2.9.4), the counts
-      # below stop matching and the release fails here instead of shipping.
+      # reintroduces a second pass, the counts below stop matching and the
+      # release fails here instead of shipping. Dropping the `app` bundle type
+      # does NOT trip this count — a dmg-only build notarizes its own
+      # throwaway `.app` once, so submits stays 1 — that regression is instead
+      # caught below, by the missing-`.app`-on-disk check and the missing
+      # updater tarball check.
       - name: Verify macOS notarization and stapling
         if: steps.filter.outputs.skip != 'true' && matrix.runner_os == 'macos'
         shell: bash
         env:
           _SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          _API_KEY: ${{ secrets.APPLE_API_KEY }}
         run: |
-          if [[ -z "$_SIGNING_IDENTITY" || -z "$_API_KEY" ]]; then
-            echo "No Apple signing identity / notary key configured (ad-hoc build); skipping notarization assertions."
+          # Keyed on the same condition "Build Tauri app" uses to choose its
+          # signed vs. ad-hoc path (`-n "$_SIGNING_IDENTITY"`). A signing
+          # identity with no notary key is a misconfiguration, not a
+          # legitimate skip case, so it must fall through and hard-fail below
+          # on the missing "Notarizing"/"Stapling" log lines rather than
+          # no-op here.
+          if [[ -z "$_SIGNING_IDENTITY" ]]; then
+            echo "No Apple signing identity configured (ad-hoc build); skipping notarization assertions."
             exit 0
           fi
 
@@ -748,7 +757,7 @@ jobs:
           assert_notarized "$app" "built .app"
 
           # 2. The .app actually inside the DMG customers download.
-          dmg=$(compgen -G "$base/dmg/*.dmg" | head -n 1)
+          dmg=$(compgen -G "$base/dmg/*.dmg" | head -n 1 || true)
           [[ -n "$dmg" ]] || { echo "::error::No DMG to inspect"; exit 1; }
           mount_dir=$(mktemp -d)
           attach_out=$(hdiutil attach "$dmg" -readonly -nobrowse -noautoopen -mountpoint "$mount_dir")
@@ -771,8 +780,9 @@ jobs:
           # stuck volume must never turn a passing gate into a red release:
           # try the device, then the mount point, then force, then warn. The
           # retry is worth keeping — Spotlight can hold a fresh volume busy.
-          # Every branch is an `if` condition so errexit can never fire inside
-          # the function, whatever the call site looks like.
+          # Every branch here is an `if`, so the function always reaches its
+          # own `return`; the `|| ::warning::` at the call site below is what
+          # makes a failed detach non-fatal — do not remove it.
           detach_dmg() {
             if [[ -n "$dmg_dev" ]] && hdiutil detach "$dmg_dev" -quiet; then return 0; fi
             if hdiutil detach "$mount_dir" -quiet; then return 0; fi
@@ -788,7 +798,7 @@ jobs:
           #    whether a stapled ticket survives tar/untar is a property of the
           #    upstream updater format that predates this change, and the
           #    updater's own minisign signature is what gates an update.
-          tarball=$(compgen -G "$base/macos/*.app.tar.gz" | head -n 1)
+          tarball=$(compgen -G "$base/macos/*.app.tar.gz" | head -n 1 || true)
           [[ -n "$tarball" ]] || { echo "::error::No updater tarball to inspect"; exit 1; }
           extract=$(mktemp -d)
           tar -xzf "$tarball" -C "$extract"
@@ -846,13 +856,36 @@ jobs:
             # during bundling. Tauri skips that script when CI=true unless
             # TAURI_BUNDLER_DMG_IGNORE_CI=true, so assert it actually landed to
             # keep the unstyled-DMG regression from ever shipping again (PRO-110).
-            dmg=$(compgen -G "$base/dmg/*.dmg" | head -n 1)
+            dmg=$(compgen -G "$base/dmg/*.dmg" | head -n 1 || true)
             mount_dir=$(mktemp -d)
-            hdiutil attach "$dmg" -readonly -nobrowse -noautoopen -mountpoint "$mount_dir"
+            attach_out=$(hdiutil attach "$dmg" -readonly -nobrowse -noautoopen -mountpoint "$mount_dir")
+            echo "$attach_out"
+            # Detaching by device node is more reliable than by mount point:
+            # the mount point is a $TMPDIR path under /var, and hdiutil
+            # resolves it against /private/var, which intermittently comes
+            # back as "No such file or directory" even while the volume is up
+            # (seen in release run 32457679562). Duplicated verbatim from the
+            # "Verify macOS notarization and stapling" step's detach_dmg —
+            # each `run:` block is its own shell, so functions/vars cannot be
+            # shared between steps.
+            dmg_dev=$(printf '%s\n' "$attach_out" | awk '$1 ~ /^\/dev\// { print $1; exit }')
             styling_ok=true
             [[ -f "$mount_dir/.DS_Store" ]] || styling_ok=false
-            # Retry the detach once: Spotlight can hold the fresh volume busy.
-            hdiutil detach "$mount_dir" -quiet || { sleep 2; hdiutil detach "$mount_dir" -force; }
+            # Cleanup only. The styling assertion above has already been made,
+            # so a stuck volume must never turn a passing gate into a red
+            # release: try the device, then the mount point, then force, then
+            # warn. Every branch here is an `if`, so the function always
+            # reaches its own `return`; the `|| ::warning::` at the call site
+            # below is what makes a failed detach non-fatal — do not remove it.
+            detach_dmg() {
+              if [[ -n "$dmg_dev" ]] && hdiutil detach "$dmg_dev" -quiet; then return 0; fi
+              if hdiutil detach "$mount_dir" -quiet; then return 0; fi
+              sleep 2
+              if [[ -n "$dmg_dev" ]] && hdiutil detach "$dmg_dev" -force; then return 0; fi
+              if hdiutil detach "$mount_dir" -force; then return 0; fi
+              return 1
+            }
+            detach_dmg || echo "::warning::Could not detach $dmg (dev ${dmg_dev:-unknown}); leaving it mounted. The styling assertion above already ran."
             $styling_ok || { echo "::error::DMG has no .DS_Store — Finder styling was skipped (see PRO-110)"; exit 1; }
           else
             compgen -G "$base/nsis/*-setup.exe" > /dev/null || { echo "::error::Missing Windows NSIS installer"; exit 1; }

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -335,30 +335,51 @@ jobs:
       # release would silently ship a stale Codex CLI. Only the node/native
       # halves are sha256-pinned. Re-open this if the git sources are moved to
       # sha-pinned tarballs or a committed lockfile.
-      - name: Build bundled agent seed
+      #
+      # Started here, collected in "Finish bundled agent seed" after the
+      # renderer build. The seed and the SDK/renderer builds are the only two
+      # chunks of this job that can overlap: both need nothing but the release
+      # `anyharness` the step above produced, neither reads the other's
+      # outputs (the seed writes `src-tauri/agent-seeds/` plus an npm prefix
+      # under a mktemp runtime home; the JS side writes `node_modules`,
+      # `anyharness/sdk*/dist` and `apps/desktop/dist`), and they load
+      # different resources — the seed is npm/network followed by one
+      # `tar | zstd` pipe, the JS side is node/esbuild. Run serially they were
+      # 97s + 36s + 69s in release-desktop run 32454795006.
+      #
+      # Doing this as a GitHub job fan-out instead was measured and rejected:
+      # the seed cannot start until the Rust build has produced `anyharness`,
+      # so the only overlap on offer is those same ~97s, while two extra macOS
+      # job setups plus a second Rust-capable setup on the joining job cost
+      # ~76s of it before a single artifact byte moves. See the PR for the
+      # per-step arithmetic.
+      - name: Start bundled agent seed
         if: steps.filter.outputs.skip != 'true' && matrix.runner_os == 'macos'
         shell: bash
         run: |
-          TMP_SEED_RUNTIME="$(mktemp -d)"
-          node scripts/build-agent-seed.mjs \
-            --target "${{ matrix.target }}" \
-            --anyharness-bin "$PWD/target/${{ matrix.target }}/release/anyharness" \
-            --runtime-home "$TMP_SEED_RUNTIME" \
-            --output-dir "$PWD/apps/desktop/src-tauri/agent-seeds"
+          seed_runtime="$(mktemp -d)"
+          {
+            echo "SEED_RUNTIME_HOME=$seed_runtime"
+            echo "SEED_LOG=$RUNNER_TEMP/agent-seed.log"
+            echo "SEED_STATUS=$RUNNER_TEMP/agent-seed.status"
+          } >> "$GITHUB_ENV"
+          rm -f "$RUNNER_TEMP/agent-seed.status"
 
-          test -s "apps/desktop/src-tauri/agent-seeds/agent-seed-${{ matrix.target }}.tar.zst"
-          test -s "apps/desktop/src-tauri/agent-seeds/agent-seed-${{ matrix.target }}.sha256"
-          seed_count=$(find apps/desktop/src-tauri/agent-seeds -maxdepth 1 -type f -name 'agent-seed-*.tar.zst' | wc -l | tr -d ' ')
-          [[ "$seed_count" == "1" ]] || { echo "::error::Expected one target seed archive, found $seed_count"; exit 1; }
-          NODE_BIN="$TMP_SEED_RUNTIME/node/${{ matrix.target }}/bin/node"
-          codesign --verify --verbose "$NODE_BIN"
-          spctl --assess --verbose=4 --type open --context context:primary-signature "$NODE_BIN"
-
-          TMP_SEED_EXTRACT="$(mktemp -d)"
-          zstd -dc "apps/desktop/src-tauri/agent-seeds/agent-seed-${{ matrix.target }}.tar.zst" | tar -xf - -C "$TMP_SEED_EXTRACT"
-          EXTRACTED_NODE_BIN="$TMP_SEED_EXTRACT/node/${{ matrix.target }}/bin/node"
-          codesign --verify --verbose "$EXTRACTED_NODE_BIN"
-          spctl --assess --verbose=4 --type open --context context:primary-signature "$EXTRACTED_NODE_BIN"
+          # stdin from /dev/null and both output streams into a file. The
+          # runner reads a step's stdout to EOF, so a background child holding
+          # the inherited pipe open would block the step until the child
+          # exited — which is exactly the overlap this is buying.
+          (
+            seed_exit=0
+            node scripts/build-agent-seed.mjs \
+              --target "${{ matrix.target }}" \
+              --anyharness-bin "$PWD/target/${{ matrix.target }}/release/anyharness" \
+              --runtime-home "$seed_runtime" \
+              --output-dir "$PWD/apps/desktop/src-tauri/agent-seeds" || seed_exit=$?
+            echo "$seed_exit" > "$RUNNER_TEMP/agent-seed.status"
+          ) </dev/null > "$RUNNER_TEMP/agent-seed.log" 2>&1 &
+          disown 2>/dev/null || true
+          echo "Agent seed build started in the background (pid $!)."
 
       - name: Stage diagnostics collector for target
         if: steps.filter.outputs.skip != 'true'
@@ -453,6 +474,50 @@ jobs:
           export VITE_PROLIFERATE_DISABLE_CLOUD_COMPUTE=1
 
           pnpm run build
+
+      # Collects the background seed build started before the SDK/renderer
+      # steps. Everything below the wait is the verification the single
+      # "Build bundled agent seed" step used to run inline, unchanged.
+      - name: Finish bundled agent seed
+        if: steps.filter.outputs.skip != 'true' && matrix.runner_os == 'macos'
+        shell: bash
+        run: |
+          # The background subshell writes the status file on success *and* on
+          # failure, so a file that never appears means the child died without
+          # reaching its own tail (or the runner reaped it). That has to fail
+          # loudly: a release with no agent seed must never reach the bundler.
+          deadline=$(( SECONDS + 1500 ))
+          while [[ ! -f "$SEED_STATUS" ]]; do
+            if (( SECONDS > deadline )); then
+              echo "::group::agent seed log (incomplete)"
+              cat "$SEED_LOG" || true
+              echo "::endgroup::"
+              echo "::error::Agent seed build did not finish within 25 minutes."
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "::group::agent seed log"
+          cat "$SEED_LOG"
+          echo "::endgroup::"
+          seed_exit="$(cat "$SEED_STATUS")"
+          [[ "$seed_exit" == "0" ]] || { echo "::error::Agent seed build failed with exit status $seed_exit"; exit 1; }
+
+          TMP_SEED_RUNTIME="$SEED_RUNTIME_HOME"
+          test -s "apps/desktop/src-tauri/agent-seeds/agent-seed-${{ matrix.target }}.tar.zst"
+          test -s "apps/desktop/src-tauri/agent-seeds/agent-seed-${{ matrix.target }}.sha256"
+          seed_count=$(find apps/desktop/src-tauri/agent-seeds -maxdepth 1 -type f -name 'agent-seed-*.tar.zst' | wc -l | tr -d ' ')
+          [[ "$seed_count" == "1" ]] || { echo "::error::Expected one target seed archive, found $seed_count"; exit 1; }
+          NODE_BIN="$TMP_SEED_RUNTIME/node/${{ matrix.target }}/bin/node"
+          codesign --verify --verbose "$NODE_BIN"
+          spctl --assess --verbose=4 --type open --context context:primary-signature "$NODE_BIN"
+
+          TMP_SEED_EXTRACT="$(mktemp -d)"
+          zstd -dc "apps/desktop/src-tauri/agent-seeds/agent-seed-${{ matrix.target }}.tar.zst" | tar -xf - -C "$TMP_SEED_EXTRACT"
+          EXTRACTED_NODE_BIN="$TMP_SEED_EXTRACT/node/${{ matrix.target }}/bin/node"
+          codesign --verify --verbose "$EXTRACTED_NODE_BIN"
+          spctl --assess --verbose=4 --type open --context context:primary-signature "$EXTRACTED_NODE_BIN"
+          rm -rf "$TMP_SEED_EXTRACT"
 
       - name: Import Apple Developer Certificate
         if: steps.filter.outputs.skip != 'true' && matrix.runner_os == 'macos'

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -542,13 +542,38 @@ jobs:
               echo "::error::APPLE_SIGNING_IDENTITY secret is not configured. Refusing to produce an ad-hoc-signed macOS release; ad-hoc builds break keychain persistence for every user who logs in on them. Dispatch with allow_unsigned=true to deliberately build unsigned."
               exit 1
             fi
-            # Build the DMG in the known-good path first, then build the updater-
-            # enabled app bundle separately so the mac updater tarball is emitted.
+            # One invocation emits the app bundle, the DMG and the updater
+            # tarball. This used to be two passes — `--bundles dmg` then
+            # `--bundles app` — because a dmg-only pass emits no updater
+            # tarball. That is real, but the fix is to ask for both bundle
+            # types at once, not to run the bundler twice. In tauri-bundler
+            # 2.9.4 (pinned via @tauri-apps/cli 2.11.4, see its Cargo.lock):
+            #
+            #   * bundle.rs sorts the requested package types by
+            #     `PackageType::priority()` (settings.rs): MacOsBundle=0,
+            #     Dmg=1, Updater=2. So `--bundles app,dmg` always runs
+            #     app -> dmg, whatever order the flag lists them in.
+            #   * The updater artifact is appended by bundle.rs only when
+            #     `MacOsBundle` is among the requested types — that is the
+            #     whole reason dmg-only produced no tarball. `app,dmg`
+            #     satisfies it.
+            #   * dmg/mod.rs rebuilds (and separately signs + notarizes) its
+            #     own throwaway `.app` *only* when MacOsBundle was not already
+            #     built in the same run; otherwise it reuses the one on disk.
+            #     Two passes therefore paid two full `notarytool submit`
+            #     round trips and two Rust link steps for one release.
+            #   * macos/app.rs holds the only `notarize()` call site in the
+            #     macOS path; dmg/mod.rs and updater_bundle.rs never notarize.
+            #     One pass = exactly one notarization, asserted below.
+            #   * updater_bundle.rs tars the same on-disk `.app` the app step
+            #     notarized and stapled, so the DMG payload and the updater
+            #     payload are now the same stapled bundle instead of two
+            #     independently notarized builds.
             #
             # `-c '{"build":{"beforeBuildCommand":""}}'` blanks tauri.conf.json's
-            # `beforeBuildCommand: "pnpm build"` for these two invocations only
+            # `beforeBuildCommand: "pnpm build"` for this invocation only
             # (tauri-cli merges the inline JSON over the file config, and treats
-            # an empty hook script as "no hook"). Without it each pass re-runs
+            # an empty hook script as "no hook"). Without it the pass re-runs
             # the entire renderer build that the "Build frontend" step above
             # already ran: 3m43s + 2m58s of pure duplicate work in release run
             # 30240922004. `frontendDist` is `../dist`, which is exactly what
@@ -560,9 +585,13 @@ jobs:
             # VITE_PROLIFERATE_RELEASE, so the shipped renderer's release name
             # never matched the uploaded artifacts.
             tauri_config='{"build":{"beforeBuildCommand":""}}'
-            test -d dist || { echo "::error::apps/desktop/dist is missing; the Build frontend step must run before the tauri passes."; exit 1; }
-            pnpm tauri build --target ${{ matrix.target }} --bundles dmg -c "$tauri_config"
-            pnpm tauri build --target ${{ matrix.target }} --bundles app -c "$tauri_config"
+            test -d dist || { echo "::error::apps/desktop/dist is missing; the Build frontend step must run before the tauri pass."; exit 1; }
+            # Tee the bundler output so the notarization-count assertion in
+            # "Verify macOS notarization and stapling" can read it. `shell:
+            # bash` runs with `-o pipefail`, so a bundler failure still fails
+            # the step.
+            pnpm tauri build --target ${{ matrix.target }} --bundles app,dmg -c "$tauri_config" \
+              2>&1 | tee "$RUNNER_TEMP/tauri-build.log"
           else
             pnpm tauri build --target ${{ matrix.target }} --bundles msi,nsis
           fi
@@ -599,6 +628,93 @@ jobs:
               exit 1
             fi
           done
+
+      # Added with the single-pass `--bundles app,dmg` cutover. The two-pass
+      # build notarized twice: once for the throwaway `.app` the dmg pass built
+      # and then deleted, and once for the `.app` the updater tarball was made
+      # from — so the DMG payload and the updater payload were two separately
+      # notarized builds of the same commit. One pass makes them the same
+      # stapled bundle. These assertions are the standing proof that the single
+      # notarization actually covered every shipped payload; if a future change
+      # reintroduces a second pass, or drops the app bundle type (which is what
+      # silently disables updater artifacts in tauri-bundler 2.9.4), the counts
+      # below stop matching and the release fails here instead of shipping.
+      - name: Verify macOS notarization and stapling
+        if: steps.filter.outputs.skip != 'true' && matrix.runner_os == 'macos'
+        shell: bash
+        env:
+          _SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          _API_KEY: ${{ secrets.APPLE_API_KEY }}
+        run: |
+          if [[ -z "$_SIGNING_IDENTITY" || -z "$_API_KEY" ]]; then
+            echo "No Apple signing identity / notary key configured (ad-hoc build); skipping notarization assertions."
+            exit 0
+          fi
+
+          log="$RUNNER_TEMP/tauri-build.log"
+          test -s "$log" || { echo "::error::Missing tauri build log at $log"; exit 1; }
+
+          # tauri-macos-sign 2.3.4 prints exactly one `Notarizing <path>.app`
+          # immediately before each `xcrun notarytool submit`, and exactly one
+          # `Stapling app...` after each accepted submission.
+          submits=$(grep -cE 'Notarizing .*\.app$' "$log" || true)
+          staples=$(grep -cE 'Stapling app\.\.\.' "$log" || true)
+          echo "notarytool submissions=$submits staplings=$staples"
+          [[ "$submits" == "1" ]] || { echo "::error::Expected exactly 1 notarization round trip, saw $submits"; exit 1; }
+          [[ "$staples" == "1" ]] || { echo "::error::Expected exactly 1 stapling, saw $staples"; exit 1; }
+
+          base="target/${{ matrix.target }}/release/bundle"
+
+          # Explicit `|| return 1` on every command: bash suppresses errexit
+          # inside a function body when the call site is part of a `||` list
+          # (the DMG check below is), so a bare command's failure would
+          # otherwise be swallowed and only the last command's status would
+          # surface.
+          assert_notarized() {
+            echo "--- $2: $1"
+            xcrun stapler validate "$1" || return 1
+            spctl --assess --verbose=4 --type execute "$1" || return 1
+          }
+
+          # 1. The bundle left on disk. This is the one the updater tarball was
+          #    made from and the one copied into the DMG.
+          app=$(find "$base/macos" -maxdepth 1 -type d -name '*.app' | head -n 1)
+          [[ -n "$app" ]] || { echo "::error::No .app bundle on disk"; exit 1; }
+          assert_notarized "$app" "built .app"
+
+          # 2. The .app actually inside the DMG customers download.
+          dmg=$(compgen -G "$base/dmg/*.dmg" | head -n 1)
+          [[ -n "$dmg" ]] || { echo "::error::No DMG to inspect"; exit 1; }
+          mount_dir=$(mktemp -d)
+          hdiutil attach "$dmg" -readonly -nobrowse -noautoopen -mountpoint "$mount_dir"
+          status=0
+          dmg_app=$(find "$mount_dir" -maxdepth 1 -type d -name '*.app' | head -n 1)
+          if [[ -n "$dmg_app" ]]; then
+            assert_notarized "$dmg_app" "DMG-embedded .app" || status=1
+          else
+            echo "::error::DMG contains no .app bundle"
+            status=1
+          fi
+          # Retry the detach once: Spotlight can hold the fresh volume busy.
+          hdiutil detach "$mount_dir" -quiet || { sleep 2; hdiutil detach "$mount_dir" -force; }
+          [[ "$status" == "0" ]] || exit 1
+
+          # 3. The .app inside the updater tarball. Reported, not enforced:
+          #    whether a stapled ticket survives tar/untar is a property of the
+          #    upstream updater format that predates this change, and the
+          #    updater's own minisign signature is what gates an update.
+          tarball=$(compgen -G "$base/macos/*.app.tar.gz" | head -n 1)
+          [[ -n "$tarball" ]] || { echo "::error::No updater tarball to inspect"; exit 1; }
+          extract=$(mktemp -d)
+          tar -xzf "$tarball" -C "$extract"
+          updater_app=$(find "$extract" -maxdepth 1 -type d -name '*.app' | head -n 1)
+          [[ -n "$updater_app" ]] || { echo "::error::Updater tarball contains no .app"; exit 1; }
+          echo "--- updater tarball .app: $updater_app"
+          xcrun stapler validate "$updater_app" || echo "::warning::Updater tarball .app is not stapled after extraction"
+          spctl --assess --verbose=4 --type execute "$updater_app" || echo "::warning::Updater tarball .app failed offline Gatekeeper assessment"
+          # The extracted bundle is another ~700MB next to an already-large
+          # target/ tree; drop it before the artifact upload steps run.
+          rm -rf "$extract"
 
       - name: Upload native Sentry debug files
         if: steps.filter.outputs.skip != 'true'

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -751,7 +751,14 @@ jobs:
           dmg=$(compgen -G "$base/dmg/*.dmg" | head -n 1)
           [[ -n "$dmg" ]] || { echo "::error::No DMG to inspect"; exit 1; }
           mount_dir=$(mktemp -d)
-          hdiutil attach "$dmg" -readonly -nobrowse -noautoopen -mountpoint "$mount_dir"
+          attach_out=$(hdiutil attach "$dmg" -readonly -nobrowse -noautoopen -mountpoint "$mount_dir")
+          echo "$attach_out"
+          # Detaching by device node is more reliable than by mount point: the
+          # mount point is a $TMPDIR path under /var, and hdiutil resolves it
+          # against /private/var, which intermittently comes back as "No such
+          # file or directory" even while the volume is up (seen in release
+          # run 32457679562).
+          dmg_dev=$(printf '%s\n' "$attach_out" | awk '$1 ~ /^\/dev\// { print $1; exit }')
           status=0
           dmg_app=$(find "$mount_dir" -maxdepth 1 -type d -name '*.app' | head -n 1)
           if [[ -n "$dmg_app" ]]; then
@@ -760,8 +767,21 @@ jobs:
             echo "::error::DMG contains no .app bundle"
             status=1
           fi
-          # Retry the detach once: Spotlight can hold the fresh volume busy.
-          hdiutil detach "$mount_dir" -quiet || { sleep 2; hdiutil detach "$mount_dir" -force; }
+          # Cleanup only. Every assertion above has already been made, so a
+          # stuck volume must never turn a passing gate into a red release:
+          # try the device, then the mount point, then force, then warn. The
+          # retry is worth keeping — Spotlight can hold a fresh volume busy.
+          # Every branch is an `if` condition so errexit can never fire inside
+          # the function, whatever the call site looks like.
+          detach_dmg() {
+            if [[ -n "$dmg_dev" ]] && hdiutil detach "$dmg_dev" -quiet; then return 0; fi
+            if hdiutil detach "$mount_dir" -quiet; then return 0; fi
+            sleep 2
+            if [[ -n "$dmg_dev" ]] && hdiutil detach "$dmg_dev" -force; then return 0; fi
+            if hdiutil detach "$mount_dir" -force; then return 0; fi
+            return 1
+          }
+          detach_dmg || echo "::warning::Could not detach $dmg (dev ${dmg_dev:-unknown}); leaving it mounted. The notarization assertions above already ran."
           [[ "$status" == "0" ]] || exit 1
 
           # 3. The .app inside the updater tarball. Reported, not enforced:


### PR DESCRIPTION
Stacks on #2167 (`perf/release-desktop-caches`) and must merge after it.

Two changes to the macOS `build-desktop` job, both proven by real
`release-desktop.yml` dispatches (`dry_run=true`, `publish_updater=false`,
`target_os=macos`):

1. bundle the app, the DMG and the updater tarball in **one** `tauri build`
   invocation instead of two;
2. run the bundled agent seed **concurrently** with the SDK and renderer
   builds instead of before them.

Measured end to end: **1271s -> 1065s**, and the "after" runner was the slower
of the two on every shared phase.

## Runs

All warm-cache macOS arm64 dispatches. "Rust step" is the unchanged
`Build Rust binaries for target`, used below as a runner-speed index — GitHub's
macOS runners varied by up to 37% across these six runs, which is larger than
some of the effects being measured.

| run | contents | Rust step | total | outcome |
| --- | --- | ---: | ---: | --- |
| [32454795006](https://github.com/proliferate-ai/proliferate/actions/runs/32454795006) | baseline (#2167 as it stands) | 258s | 1271s | success |
| [32455891679](https://github.com/proliferate-ai/proliferate/actions/runs/32455891679) | change 1 only | 353s | 1228s | success |
| [32457679562](https://github.com/proliferate-ai/proliferate/actions/runs/32457679562) | changes 1 + 2 | 358s | 1032s | red in the new gate's cleanup — fixed, see below |
| [32459142319](https://github.com/proliferate-ai/proliferate/actions/runs/32459142319) | + cleanup fix | 302s | 948s | red in `bundle_dmg.sh` — pre-existing flake, see below |
| [32460475100](https://github.com/proliferate-ai/proliferate/actions/runs/32460475100) | + cleanup fix | 334s | **1065s** | **success** |

Baseline phase breakdown:

| phase | baseline |
| --- | ---: |
| job setup, checkout, toolchains, rust cache restore | 40s |
| build Rust binaries for target | 258s |
| bundled agent seed (incl. seed packaging tools) | 99s |
| stage sidecars | 1s |
| generate + build SDK | 36s |
| build frontend | 69s |
| **build Tauri app** | **700s** |
| verify, sourcemaps, normalize, upload | 32s |
| post-job cache saves | 33s |
| **total** | **1271s** |

The bundler is 55% of the job, so that is where the work went first.

## 1. One bundling pass

The workflow ran the bundler twice:

```
pnpm tauri build --target <t> --bundles dmg -c "$tauri_config"
pnpm tauri build --target <t> --bundles app -c "$tauri_config"
```

The comment said the second pass was there "so the mac updater tarball is
emitted". That constraint is real, but the fix is to ask for both bundle types
in one invocation. From the pinned sources — `tauri-bundler` 2.9.4, pinned by
`@tauri-apps/cli` 2.11.4 via its `Cargo.lock`:

- `bundle.rs` appends `PackageType::Updater` only when `PackageType::MacOsBundle`
  is among the requested types. That is exactly why the dmg-only pass emitted
  no tarball. `app,dmg` satisfies the condition.
- `bundle.rs` sorts requested types by `PackageType::priority()`
  (`settings.rs`: `MacOsBundle=0`, `Dmg=1`, `Updater=2`), so the order is fixed
  regardless of flag order: app, then dmg, then updater.
- `dmg/mod.rs` builds — and separately signs and notarizes — its own throwaway
  `.app` *only* when `MacOsBundle` was not already built in the same run. It
  reuses the on-disk bundle otherwise, and `bundle.rs` deletes that throwaway
  afterwards when `MacOsBundle` was not requested.
- `macos/app.rs` holds the only `notarize()` call site in the macOS path;
  `dmg/mod.rs` and `updater_bundle.rs` never notarize. Two passes therefore
  paid **two** `notarytool submit` round trips per release.
- `updater_bundle.rs` tars the same on-disk `.app` that `app.rs` notarized and
  stapled, so the DMG payload and the updater payload are now provably the same
  stapled bundle rather than two independently notarized builds of one commit.

`bundle_dmg.sh` runs exactly once per release either way — in the old flow it
ran in the dmg pass, in the new one it runs after the app bundle — so exposure
to it is unchanged.

Measured inside the step, from the bundler's own log timestamps:

| bundler phase | before (2 passes) | after (1 pass) |
| --- | ---: | ---: |
| pass 1 compile + link | 320.9s | 286.0s |
| pass 1 app bundle + sign | 20.3s | 16.2s |
| pass 1 notarize round trip | 66.1s | 69.2s |
| pass 1 staple | 2.0s | 1.3s |
| DMG bundle | 33.5s | 39.2s |
| pass 2 compile + link | 159.8s | — |
| pass 2 app bundle + sign | 19.6s | — |
| pass 2 notarize round trip | 65.0s | — |
| pass 2 staple | 2.0s | — |
| updater tar + minisign | 11.6s | 0.7s |
| **step total** | **699.6s** | **412.6s** |

The three successful single-pass runs measured 466.1s, 408.5s and 412.6s
(mean 429s) against the baseline's 699.6s, so **−233s to −291s**. The
structural floor agrees: the deleted second pass was 246.4s of work, of which
only ~11.6s (staple, tar, minisign) was not a duplicate of the first pass.

Note that the tauri compile phase is much less sensitive to runner speed than
the `Build Rust binaries` step (320.9s / 335.7s / 279.7s / 286.0s across runs
whose Rust step ranged 258s to 358s), so these bundler numbers are close to
comparable as measured, without normalization.

### Verification added

`Verify macOS notarization and stapling` is new and strictly additive — no
existing verification step was changed or weakened:

1. asserts exactly one `Notarizing <path>.app` and one `Stapling app...` in the
   bundler output (the two lines `tauri-macos-sign` 2.3.4 emits per round
   trip), so reintroducing a second pass fails here. (Dropping the `app`
   bundle type does *not* trip this count — a dmg-only build notarizes its
   own throwaway `.app` once, so `submits` stays 1 — that regression is
   instead caught by the missing-`.app`-on-disk check and the missing
   updater-tarball check further down this same step.)
2. `xcrun stapler validate` + `spctl --assess --type execute` on the built
   `.app` and on the `.app` mounted out of the DMG — both hard gates;
3. the same two checks on the `.app` extracted from the updater tarball,
   reported rather than enforced: whether a stapled ticket survives tar/untar
   is an upstream property that predates this change, and the updater's
   minisign signature is what gates an update. (It does survive — see below.)

It no-ops when no Apple signing identity / notary key is configured, so
`allow_unsigned=true` builds are unaffected. It costs 9s.

Output from the final green run
[32460475100](https://github.com/proliferate-ai/proliferate/actions/runs/32460475100):

```
notarytool submissions=1 staplings=1
--- built .app: target/aarch64-apple-darwin/release/bundle/macos/Proliferate.app
Proliferate.app: The validate action worked!
Proliferate.app: accepted
source=Notarized Developer ID
--- DMG-embedded .app: /var/folders/.../Proliferate.app
Proliferate.app: The validate action worked!
Proliferate.app: accepted
source=Notarized Developer ID
--- updater tarball .app: /var/folders/.../Proliferate.app
Proliferate.app: The validate action worked!
Proliferate.app: accepted
source=Notarized Developer ID
```

The pre-normalization bundle inventory is identical to the baseline's, path for
path (26 entries: `Proliferate_0.4.22_aarch64.dmg`, `Proliferate.app.tar.gz`,
`Proliferate.app.tar.gz.sig`, and the same 23 files inside `Proliferate.app`),
all three normalize / verify-normalized-name steps pass unchanged, and the two
uploaded artifacts keep their names and land within 1.7KB of the baseline's
sizes — the delta is the branch name inside the dry-run version string.

The first version of this gate went red on run 32457679562 *after* making every
assertion successfully: `hdiutil detach` answered "No such file or directory"
for the `$TMPDIR` mount point and errexit took the step down. Cleanup now
detaches the device node reported by `hdiutil attach`, falls back to the mount
point and to a forced detach of each, and warns rather than failing if none
take — a volume left in `$TMPDIR` costs a later step nothing, a false red costs
a re-run of the whole job. The assertions are unchanged and still hard-fail.

Note on scope: the DMG *container* is signed but not itself notarized, both
before and after this change (tauri-apps/tauri#7533, #15822). What Gatekeeper
evaluates on first launch is the `.app` inside it, which is notarized and
stapled in both. This PR does not change that behaviour either way.

## 2. Agent seed concurrent with the SDK and renderer builds

The seed and the SDK/renderer builds are the only two chunks of this job that
can overlap. Both need nothing beyond the release `anyharness` the Rust step
produces; neither reads the other's outputs; the seed is npm/network followed
by one `tar | zstd` pipe while the JS side is node/esbuild.

The seed now starts in the background as soon as the Rust build has produced
`anyharness` (before the sidecar staging steps) and is collected after the
renderer build, just before the signing steps. Failure handling is explicit: the
background subshell writes its exit status to a file on success *and* on
failure, the collecting step fails on a non-zero status, and a status file that
never appears fails the job at a 25-minute deadline with the partial log
printed. All three paths were exercised locally before dispatch. Every existing
seed assertion (archive present, exactly one target archive, `codesign
--verify` and `spctl` on the seeded node binary both in place and after
re-extracting the archive) moves into the collecting step unchanged; the
collecting step also deletes the ~1GB re-extraction the old step left on disk.

The clean comparison is run 32455891679 (serial) against run 32457679562
(overlapped), whose Rust steps were 353s and 358s — the same runner speed to
within 1.4%:

| step | serial | overlapped |
| --- | ---: | ---: |
| install seed packaging tools | 5s | 3s |
| build / start bundled agent seed | 137s | 0s |
| stage sidecars | 0s | 0s |
| generate + build SDK | 45s | 23s |
| build frontend | 102s | 139s |
| finish bundled agent seed | — | 9s |
| **block total** | **289s** | **175s** |

**−114s.** The frontend build gets slower (102s -> 139s) because the seed is
competing for CPU and network, and that cost is already inside the 175s.
Normalizing all five runs by the Rust-step index instead of using the matched
pair gives a more conservative −36s to −79s (mean −52s), the spread being how
much the renderer build happens to contend with the seed on a given runner.
Either way it is free: no extra jobs, no artifacts, no cache entries.

### Why not a job fan-out

Splitting into parallel GitHub jobs was costed against the same measurements
and rejected:

- The seed cannot start until the Rust build has produced `anyharness`
  (`--anyharness-bin`), and the SDK generate step needs the same binary
  (`ANYHARNESS_OPENAPI_BIN`, from #2167). So a fan-out is
  `rust -> {seed, sdk+renderer} -> tauri`, and the overlap on offer is the same
  ~97s the in-job version already captures.
- Against that: two extra macOS job setups (~15s each) plus a second
  Rust-capable setup on the joining job (checkout 6-8s + pnpm 4-7s + node 1-2s +
  rust toolchain 7-10s + rust cache restore 17-19s ≈ 40s) ≈ 70s, before any
  artifact moves.
- Artifact transfer is cheap but not free: measured on this job at 759MB up in
  9s and 379MB up in 5s (~85 MB/s), ~8s down on the consumer side.
  Round-tripping the sidecar binaries, the ~380MB seed archive and `dist` costs
  another ~20s.
- Net expected gain ≈ 0s, for two more jobs, a second multi-GB `rust-cache`
  entry competing in a repo cache pool that is already at its 10GB limit (178
  entries), and a fan-in that has to reassemble the exact tree the bundler
  validates today. Runner-to-runner variance on this job is up to 37%, so a ~0s
  effect is not even measurable.

Moving an Ubuntu runner into the fan-out does not help either: `generate:openapi`
shells out to the `anyharness` binary, so an Ubuntu job would have to build the
Rust workspace itself — 10-15 minutes cold, plus a third large cache entry.

## Result

| phase | baseline (32454795006) | final (32460475100) |
| --- | ---: | ---: |
| setup, checkout, toolchains, cache restore | 40s | 57s |
| build Rust binaries | 258s | 334s |
| seed + SDK + renderer | 205s | 219s (overlapped) |
| **build Tauri app** | **700s** | **413s** |
| verify, sourcemaps, normalize, upload | 32s | 38s |
| post-job | 33s | 2s |
| **total** | **1271s (21m11s)** | **1065s (17m45s)** |

−206s measured, on a runner whose Rust step was 29% slower than the baseline's.
On a runner matched to the baseline — keeping the bundler as measured, since it
barely tracks runner speed, and scaling the rest by the Rust-step index —
the same configuration projects to roughly:

```
 40s  setup
258s  rust
153s  seed + SDK + renderer (overlapped, normalized mean)
429s  tauri (mean of three single-pass runs)
 40s  verify + upload, including the 9s notarization gate
 33s  post-job
----
953s  ~15m53s
```

### Known flake, not introduced here

Run 32459142319 died inside `bundle_dmg.sh` 5.8s in, after a successful
notarization and stapling. That script is `create-dmg`, driven through Finder
AppleScript because the workflow sets `TAURI_BUNDLER_DMG_IGNORE_CI=true` to
keep the DMG styling that PRO-110 / #1858 restored — the exact path upstream
disables under CI by default (tauri-apps/tauri#592). It runs once per release
before and after this change, on an identically-built and stapled `.app`, so
this PR neither causes nor worsens it. `tauri-bundler` swallows the script's
stderr unless the bundler runs with `-v`, which is why the log shows only
`failed to run bundle_dmg.sh`; worth a separate look, but out of scope here.


## Review follow-ups (2026-08-21)

Addressing the reviewer's findings on this PR:

- **F1** — `Verify updater artifacts` mounted the same DMG a second time with
  the un-hardened `hdiutil detach "$mount_dir" -quiet || { sleep 2; hdiutil
  detach "$mount_dir" -force; }`, the exact pattern that reddened run
  32457679562. It now duplicates the `Verify macOS notarization and
  stapling` step's hardened `detach_dmg` (device node, then mount point, then
  forced, then warn) verbatim — steps run in separate shells, so the
  function can't be shared, only copied. The `.DS_Store` styling assertion
  itself is unchanged.
- **F2** — the background seed's exit-status handoff (`echo "$seed_exit" >
  "$RUNNER_TEMP/agent-seed.status"`) is non-atomic: `>` creates the file at
  `open(2)` before the byte lands, so a poll landing in that window reads an
  empty status and false-reds a successful seed. Fixed to write to `.status.tmp`
  and `mv -f` it into place; `mv` is atomic within a filesystem. The reader's
  missing-file-means-still-running semantics are unchanged.
- **F3** — `dmg=$(compgen -G … | head -n 1)` / `tarball=$(compgen -G … | head
  -n 1)` under `set -e -o pipefail` exit silently on no match (compgen's
  exit 1 propagates through the pipeline into the assignment), so the
  following `::error::No DMG to inspect` / `::error::No updater tarball to
  inspect` could never print. Both now end in `| head -n 1 || true`, matching
  the pattern the `app=$(find … | head -n 1)` line above already used, so the
  intended error message actually surfaces.
- **F4** — the `detach_dmg` comment claimed errexit "can never fire ...
  whatever the call site looks like," which is false at a bare call site
  (`return 1` still kills an unprotected step). Corrected to say the function
  always reaches its own `return`, and it's the `|| ::warning::` at the call
  site that makes a failed detach non-fatal.
- **F5** — the step comment and the "Verification added" item 1 above both
  claimed the `submits==1` count assertion catches dropping the `app` bundle
  type. It doesn't — a dmg-only build notarizes its own throwaway `.app`
  once, so the count still passes. That regression is actually caught later,
  by the missing-`.app`-on-disk check and the missing-updater-tarball check.
  Both the step comment and the claim above are corrected.
- **F6** — commit 5807a100e's message says the seed starts "right after the
  sidecar staging steps"; it actually starts *before* them (`Start bundled
  agent seed` is step 14, the three `Stage …` steps are 15-17), matching what
  this PR description already says under "Agent seed concurrent with the SDK
  and renderer builds." The commit is already pushed to a shared branch and
  its message can't be safely rewritten here; noting the discrepancy so it
  doesn't get treated as authoritative.
- **F8** (gate skip condition) — `Verify macOS notarization and stapling`
  skipped on `-z "$_SIGNING_IDENTITY" || -z "$_API_KEY"`, broader than the
  build's own unsigned branch (`-z "$_SIGNING_IDENTITY"` alone, in `Build
  Tauri app`). A signing identity configured with no notary key is a
  misconfiguration, not a legitimate skip case — it previously no-opped the
  gate instead of failing. Narrowed the skip to `-z "$_SIGNING_IDENTITY"` so
  it now falls through and hard-fails on the missing "Notarizing"/"Stapling"
  log lines. Fork/dry-run paths that legitimately lack both secrets are
  unaffected — they still hit the same `-z "$_SIGNING_IDENTITY"` skip.
