### PR TITLE
fix(scripts): normalize agent-catalog manifest generator direct-run guard

### DIFF
--- a/scripts/ci-cd/generate-agent-catalog-manifest.test.mjs
+++ b/scripts/ci-cd/generate-agent-catalog-manifest.test.mjs
@@ -90,3 +90,32 @@ test("rejects a registry document missing registryVersion", (t) => {
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /missing a string registryVersion/);
 });
+
+test("runs main() when the script path needs URL percent-encoding (space in path)", (t) => {
+  // realpath: macOS tmpdir sits behind the /var → /private/var symlink, and
+  // node realpaths import.meta.url but not argv[1]; this test targets URL
+  // percent-encoding, not symlink resolution.
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "agent catalog manifest ")));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const copiedGenerator = path.join(root, "generate-agent-catalog-manifest.mjs");
+  fs.copyFileSync(generator, copiedGenerator);
+  const { catalogPath, registryPath } = writeFixtures(root);
+  const output = path.join(root, "manifest.json");
+  const result = spawnSync(
+    process.execPath,
+    [
+      copiedGenerator,
+      "--catalog",
+      catalogPath,
+      "--registry",
+      registryPath,
+      "--output",
+      output,
+    ],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  const manifest = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.equal(manifest.catalogVersion, "2026.08.15-1");
+});

--- a/scripts/generate-agent-catalog-manifest.mjs
+++ b/scripts/generate-agent-catalog-manifest.mjs
@@ -10,6 +10,7 @@
 import { createHash } from "node:crypto";
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 function parseArgs(argv) {
   const args = {};
@@ -75,6 +76,6 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   main();
 }


### PR DESCRIPTION
## Summary

- Replace the agent-catalog manifest generator's direct-run guard (`import.meta.url === \`file://${process.argv[1]}\``) with the repo's established pattern `process.argv[1] === fileURLToPath(import.meta.url)` (as in `scripts/agent-catalog/check-version-discipline.mjs`).
- Add a regression test that copies the generator into a temp directory whose name contains a space and asserts it still writes the manifest. Against the old guard this fails: `import.meta.url` percent-encodes the space (`%20`) while the raw `file://` concatenation does not, so the strings never match, `main()` is silently skipped, and the script exits 0 without writing anything.

**Correction to the ticket's severity claim:** PRO-353 states the relative invocation in `.github/workflows/publish-agent-catalog.yml` never runs `main()`. That does not reproduce — Node resolves `process.argv[1]` to an absolute path for the main module, so the old guard fires under the workflow's relative invocation. Verified locally on Node 22 and in production: the "Generate publisher manifest" step succeeded in the latest main run (32294958625; that run fails later, at the intentionally-failing unprovisioned-signing-secrets step). The workflow also cannot silently proceed without a manifest: the very next line reads `manifest.json` and would fail the step on ENOENT. This PR is therefore a robustness/consistency fix for the percent-encoding edge case (e.g. a checkout path containing a space), not a repair of a broken publish lane.

Fixes PRO-353

## Testing

- Tier 1 (`node --test scripts/ci-cd/generate-agent-catalog-manifest.test.mjs`): 6/6 pass with the fix; the new regression test fails (5/6) with the fix reverted, proving it pins the old guard's silent no-op.
- Manual: `node scripts/generate-agent-catalog-manifest.mjs --catalog catalogs/agents/catalog.json --registry catalogs/agents/registry.json --output /tmp/manifest.json` from the repo root (the workflow's exact relative form) prints the `Generated …` line and writes the manifest.

## Observability

- none

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Verification

- New regression test fails against the old guard and passes against the new one (verified both directions locally).
- Real-catalog relative-path invocation generates the manifest (`catalogVersion=2026-08-19.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)