### PR TITLE
feat(diagnostics): stamp the install id on exported records

### DIFF
--- a/anyharness/crates/proliferate-diagnostics-collector/README.md
+++ b/anyharness/crates/proliferate-diagnostics-collector/README.md
@@ -16,8 +16,21 @@ proliferate-diagnostics-collector \
   --capability-fd <inherited-fd> \
   [--control-fd <inherited-fd>] \
   [--release <non-secret-release>] \
-  [--environment <non-secret-environment>]
+  [--environment <non-secret-environment>] \
+  [--install-id <non-secret-install-identity>]
 ```
+
+`--install-id` is the stable identity of the installation. The collector never
+derives, generates, or persists one; the host that owns the identity passes it
+in, which is why no producer can set, spoof, or omit it. It is stamped on every
+exported record as the `proliferate.install_id` resource attribute, so it is
+the field that turns per-record counts into per-install counts. A present value
+must be 1 to 128 printable ASCII bytes and startup refuses anything else rather
+than sanitizing it. Omitting it means the attribute is absent, not empty.
+
+`--print-export-policy` prints this binary's compiled export policy and exits
+zero. The desktop release job runs the packaged collector with it and requires
+`lifecycle_only`.
 
 The capability descriptor contains one newline-terminated, visible-ASCII
 bearer capability and is closed after startup. The raw capability is not an
@@ -151,12 +164,13 @@ resource attribute.
 Accepted records are offered to a bounded queue as they are accepted and
 converted to OTLP/HTTP JSON logs: one resource per producer boot
 (`service.name`, `service.version`, `service.instance.id`,
-`deployment.environment.name`, and `dev.user` when a developer tag is
-configured), one scope per admitted schema version, a detailed message or the
-stable record name as the body, and every remaining contract field as a
-`proliferate.*` attribute. Typed arguments become `proliferate.argument.<name>`.
-A record classified `secret` is refused rather than encoded, which is a second
-fence behind ingest admission rather than a new privacy path.
+`deployment.environment.name`, `proliferate.install_id` when the host supplied
+one, and `dev.user` when a developer tag is configured), one scope per admitted
+schema version, a detailed message or the stable record name as the body, and
+every remaining contract field as a `proliferate.*` attribute. Typed arguments
+become `proliferate.argument.<name>`. A record the compiled export policy does
+not admit is refused rather than encoded, which is a second fence behind ingest
+admission rather than a new privacy path.
 
 The export bounds are internal-only and independent of the runtime caps above:
 a 512-record queue, a 128-record or 512 KiB batch, a 250 ms batch linger, a

--- a/anyharness/crates/proliferate-diagnostics-collector/src/config.rs
+++ b/anyharness/crates/proliferate-diagnostics-collector/src/config.rs
@@ -81,6 +81,15 @@ pub struct CollectorConfig {
     pub capability: Vec<u8>,
     pub release: String,
     pub environment: String,
+    /// Stable identity of this installation, stamped onto exported records as
+    /// the `proliferate.install_id` resource attribute.
+    ///
+    /// It is not a wire-protocol field and no producer can set it. The host
+    /// that owns the identity passes it in, so a record cannot claim to come
+    /// from an install other than the one whose collector accepted it.
+    /// `None` means the host had no identity to give, and the attribute is
+    /// then absent rather than empty or invented.
+    pub install_id: Option<String>,
     pub runtime_limits: RuntimeLimits,
     pub auto_ready: bool,
 }
@@ -92,6 +101,7 @@ impl std::fmt::Debug for CollectorConfig {
             .field("capability", &"[REDACTED]")
             .field("release", &self.release)
             .field("environment", &self.environment)
+            .field("install_id", &self.install_id)
             .field("runtime_limits", &self.runtime_limits)
             .field("auto_ready", &self.auto_ready)
             .finish()
@@ -110,6 +120,7 @@ impl CollectorConfig {
             capability: capability.into(),
             release: "standalone".to_owned(),
             environment: "local".to_owned(),
+            install_id: None,
             runtime_limits: RuntimeLimits::default(),
             auto_ready: true,
         }

--- a/anyharness/crates/proliferate-diagnostics-collector/src/export/handle.rs
+++ b/anyharness/crates/proliferate-diagnostics-collector/src/export/handle.rs
@@ -37,7 +37,10 @@ pub(crate) struct ExporterHandle {
 }
 
 impl ExporterHandle {
-    pub(crate) fn from_environment() -> Self {
+    /// `install_id` is the host-supplied identity of this installation. It is
+    /// carried to the encoder rather than read from the environment, because
+    /// only the host that owns the identity may assert it.
+    pub(crate) fn from_environment(install_id: Option<String>) -> Self {
         let metrics = Arc::new(ExporterMetrics::default());
         match target::from_environment() {
             TargetConfiguration::Absent => Self::inert(Sink::Off, metrics),
@@ -49,7 +52,7 @@ impl ExporterHandle {
             }
             TargetConfiguration::Configured(target) => {
                 let (sender, receiver) = mpsc::channel(QUEUE_RECORDS);
-                let worker = Worker::new(receiver, target, Arc::clone(&metrics));
+                let worker = Worker::new(receiver, target, Arc::clone(&metrics), install_id);
                 Self {
                     sink: Sink::Queue(sender),
                     metrics,

--- a/anyharness/crates/proliferate-diagnostics-collector/src/export/otlp.rs
+++ b/anyharness/crates/proliferate-diagnostics-collector/src/export/otlp.rs
@@ -39,8 +39,11 @@ struct ResourceKey {
 /// reaches this check; it exists so a future call site that finds another way
 /// into the encoder still cannot smuggle one past. The count of what it
 /// refused is returned so exporter health can report it.
-pub(super) fn encode_batch(records: &[CollectorAcceptedRecordV1]) -> (Value, u64) {
-    encode_batch_with_policy(EXPORT_POLICY, records)
+pub(super) fn encode_batch(
+    install_id: Option<&str>,
+    records: &[CollectorAcceptedRecordV1],
+) -> (Value, u64) {
+    encode_batch_with_policy(EXPORT_POLICY, install_id, records)
 }
 
 /// The policy-parameterised encoder. Production always passes the compiled
@@ -49,6 +52,7 @@ pub(super) fn encode_batch(records: &[CollectorAcceptedRecordV1]) -> (Value, u64
 /// customer build refuses it.
 pub(super) fn encode_batch_with_policy(
     policy: ExportPolicy,
+    install_id: Option<&str>,
     records: &[CollectorAcceptedRecordV1],
 ) -> (Value, u64) {
     let dev_tag = super::dev_tag();
@@ -77,7 +81,7 @@ pub(super) fn encode_batch_with_policy(
         .into_iter()
         .map(|(key, scopes)| {
             json!({
-                "resource": { "attributes": resource_attributes(&key, dev_tag) },
+                "resource": { "attributes": resource_attributes(&key, dev_tag, install_id) },
                 "scopeLogs": scopes
                     .into_iter()
                     .map(|(version, log_records)| json!({
@@ -94,7 +98,11 @@ pub(super) fn encode_batch_with_policy(
     (json!({ "resourceLogs": resource_logs }), refused)
 }
 
-fn resource_attributes(key: &ResourceKey, dev_tag: Option<&str>) -> Vec<Value> {
+fn resource_attributes(
+    key: &ResourceKey,
+    dev_tag: Option<&str>,
+    install_id: Option<&str>,
+) -> Vec<Value> {
     let mut attributes = vec![
         attribute("service.name", string_value(component_name(key.component))),
         attribute("service.version", string_value(&key.release)),
@@ -105,6 +113,18 @@ fn resource_attributes(key: &ResourceKey, dev_tag: Option<&str>) -> Vec<Value> {
         ),
         attribute("telemetry.sdk.name", string_value(SCOPE_NAME)),
     ];
+    if let Some(install) = install_id {
+        // The stable identity of the installation, stamped by the collector
+        // from a value its host passed in. It is not a wire-protocol field, so
+        // no producer can set, spoof, or omit it, and every record from one
+        // install carries the same value whatever the producer boot. It is
+        // what turns per-record counts into "how many installs saw this".
+        //
+        // Pseudonymous by construction: a locally generated UUID with no
+        // account, machine, or user identity in it, and absent entirely when
+        // the host has none to give.
+        attributes.push(attribute("proliferate.install_id", string_value(install)));
+    }
     if let Some(tag) = dev_tag {
         // Identifies whose desktop produced the record when teammates share
         // one dogfood environment. Absent unless configured.

--- a/anyharness/crates/proliferate-diagnostics-collector/src/export/otlp_tests.rs
+++ b/anyharness/crates/proliferate-diagnostics-collector/src/export/otlp_tests.rs
@@ -42,7 +42,7 @@ fn attribute_of<'a>(log: &'a Value, key: &str) -> Option<&'a Value> {
 /// policy they are asserting about. Only the tests whose subject is "what does
 /// THIS build do" call [`encode_batch`] and pick up the compiled policy.
 fn encode_all(records: &[CollectorAcceptedRecordV1]) -> (Value, u64) {
-    encode_batch_with_policy(ExportPolicy::All, records)
+    encode_batch_with_policy(ExportPolicy::All, None, records)
 }
 
 fn all_log_records(payload: &Value) -> Vec<&Value> {
@@ -198,7 +198,7 @@ fn lifecycle_record_carries_phase_outcome_and_finalizer() {
         })
         .expect("terminal fixture record")
         .clone();
-    let (payload, _) = encode_batch(std::slice::from_ref(&terminal));
+    let (payload, _) = encode_batch(None, std::slice::from_ref(&terminal));
     let log = all_log_records(&payload)[0];
     assert_eq!(
         attribute_of(log, "proliferate.lifecycle.phase"),
@@ -232,7 +232,7 @@ fn model_metadata_survives_as_bounded_scalar_attributes() {
         })
         .expect("model fixture record")
         .clone();
-    let (payload, _) = encode_batch(std::slice::from_ref(&model));
+    let (payload, _) = encode_batch(None, std::slice::from_ref(&model));
     let log = all_log_records(&payload)[0];
     assert!(attribute_of(log, "proliferate.lifecycle.model.model_id").is_some());
     for key in [
@@ -278,7 +278,7 @@ fn only_a_hex_trace_id_is_promoted_to_the_otlp_trace_field() {
 fn a_secret_classified_record_is_refused_instead_of_encoded() {
     let mut record = fixture_records()[0].clone();
     record.record.privacy = PrivacyClassificationV1::Secret;
-    let (payload, refused) = encode_batch(std::slice::from_ref(&record));
+    let (payload, refused) = encode_batch(None, std::slice::from_ref(&record));
     assert_eq!(refused, 1);
     assert!(all_log_records(&payload).is_empty());
 }
@@ -312,7 +312,7 @@ fn assert_base_resource_attributes(attributes: &[Value], key: &ResourceKey) {
 #[test]
 fn a_configured_dev_tag_is_added_to_resource_attributes_without_disturbing_the_rest() {
     let key = sample_resource_key();
-    let attributes = resource_attributes(&key, Some("alice"));
+    let attributes = resource_attributes(&key, Some("alice"), None);
     assert_eq!(attributes.len(), 6, "the five base attributes plus dev.user");
     assert_eq!(
         attributes
@@ -327,7 +327,7 @@ fn a_configured_dev_tag_is_added_to_resource_attributes_without_disturbing_the_r
 #[test]
 fn an_absent_dev_tag_omits_dev_user_and_leaves_the_rest_unchanged() {
     let key = sample_resource_key();
-    let attributes = resource_attributes(&key, None);
+    let attributes = resource_attributes(&key, None, None);
     assert_eq!(attributes.len(), 5, "no dev.user attribute is added");
     assert!(attributes
         .iter()
@@ -350,7 +350,7 @@ fn a_secret_classified_argument_is_dropped_from_an_otherwise_exportable_record()
             value: ArgumentValueV1::String("never-exported".to_owned()),
         },
     ];
-    let (payload, refused) = encode_batch(std::slice::from_ref(&record));
+    let (payload, refused) = encode_batch(None, std::slice::from_ref(&record));
     assert_eq!(refused, 0);
     let log = all_log_records(&payload)[0];
     assert!(attribute_of(log, "proliferate.argument.kept").is_some());
@@ -377,7 +377,7 @@ fn the_customer_policy_refuses_every_detailed_record_in_the_fixture() {
         .count();
     assert!(detailed > 0, "the fixture must exercise the refusal path");
 
-    let (payload, refused) = encode_batch_with_policy(ExportPolicy::LifecycleOnly, &records);
+    let (payload, refused) = encode_batch_with_policy(ExportPolicy::LifecycleOnly, None, &records);
     assert_eq!(refused as usize, detailed);
     assert_eq!(all_log_records(&payload).len(), records.len() - detailed);
     for log in all_log_records(&payload) {
@@ -424,7 +424,7 @@ fn the_customer_policy_drops_a_non_operational_argument_a_dogfood_build_keeps() 
     ];
 
     let (customer, refused) =
-        encode_batch_with_policy(ExportPolicy::LifecycleOnly, std::slice::from_ref(&record));
+        encode_batch_with_policy(ExportPolicy::LifecycleOnly, None, std::slice::from_ref(&record));
     assert_eq!(refused, 0, "the record itself is still exportable");
     let log = all_log_records(&customer)[0];
     assert!(attribute_of(log, "proliferate.argument.kept").is_some());
@@ -444,8 +444,8 @@ fn the_customer_policy_drops_a_non_operational_argument_a_dogfood_build_keeps() 
 #[test]
 fn encode_batch_applies_the_compiled_policy() {
     let records = fixture_records();
-    let (compiled, compiled_refused) = encode_batch(&records);
-    let (expected, expected_refused) = encode_batch_with_policy(EXPORT_POLICY, &records);
+    let (compiled, compiled_refused) = encode_batch(None, &records);
+    let (expected, expected_refused) = encode_batch_with_policy(EXPORT_POLICY, None, &records);
     assert_eq!(compiled_refused, expected_refused);
     assert_eq!(compiled, expected);
 
@@ -459,4 +459,55 @@ fn encode_batch_applies_the_compiled_policy() {
         compiled_refused, 0,
         "a dogfood build exports every non-secret fixture record"
     );
+}
+
+#[test]
+fn the_install_id_is_stamped_as_a_resource_attribute_when_the_host_supplies_one() {
+    let key = sample_resource_key();
+    let attributes = resource_attributes(&key, None, Some("install-9f2c"));
+    assert_eq!(attributes.len(), 6, "the five base attributes plus install id");
+    assert_eq!(
+        attributes
+            .iter()
+            .find(|attribute| attribute["key"] == "proliferate.install_id")
+            .expect("proliferate.install_id attribute")["value"],
+        serde_json::json!({ "stringValue": "install-9f2c" })
+    );
+    assert_base_resource_attributes(&attributes, &key);
+}
+
+/// Absent rather than empty or invented. A host with no identity to give
+/// produces records with no install attribute at all, so a consumer can tell
+/// "unknown install" from "install whose id is the empty string".
+#[test]
+fn an_absent_install_id_omits_the_attribute_entirely() {
+    let key = sample_resource_key();
+    let attributes = resource_attributes(&key, None, None);
+    assert!(attributes
+        .iter()
+        .all(|attribute| attribute["key"] != "proliferate.install_id"));
+    assert_base_resource_attributes(&attributes, &key);
+}
+
+/// One install id covers every resource stream in a batch, whatever producer
+/// boot or component each record came from. That is the whole point: it is the
+/// only field in the payload that is stable across producer restarts.
+#[test]
+fn every_resource_stream_in_a_batch_carries_the_same_install_id() {
+    let (payload, _) = encode_batch_with_policy(
+        ExportPolicy::All,
+        Some("install-9f2c"),
+        &fixture_records(),
+    );
+    let resources = payload["resourceLogs"].as_array().expect("resource logs");
+    assert!(resources.len() > 1, "the fixture must span several resource streams");
+    for resource in resources {
+        let value = resource["resource"]["attributes"]
+            .as_array()
+            .expect("resource attributes")
+            .iter()
+            .find(|attribute| attribute["key"] == "proliferate.install_id")
+            .expect("proliferate.install_id attribute");
+        assert_eq!(value["value"], serde_json::json!({ "stringValue": "install-9f2c" }));
+    }
 }

--- a/anyharness/crates/proliferate-diagnostics-collector/src/export/worker.rs
+++ b/anyharness/crates/proliferate-diagnostics-collector/src/export/worker.rs
@@ -98,6 +98,7 @@ pub(super) struct Worker {
     receiver: mpsc::Receiver<Arc<[u8]>>,
     target: ExportTarget,
     metrics: Arc<ExporterMetrics>,
+    install_id: Option<String>,
     consecutive_failures: u32,
     cooldown_until: Option<Instant>,
 }
@@ -107,11 +108,13 @@ impl Worker {
         receiver: mpsc::Receiver<Arc<[u8]>>,
         target: ExportTarget,
         metrics: Arc<ExporterMetrics>,
+        install_id: Option<String>,
     ) -> Self {
         Self {
             receiver,
             target,
             metrics,
+            install_id,
             consecutive_failures: 0,
             cooldown_until: None,
         }
@@ -202,7 +205,7 @@ impl Worker {
         if records.is_empty() {
             return;
         }
-        let (payload, refused) = otlp::encode_batch(&records);
+        let (payload, refused) = otlp::encode_batch(self.install_id.as_deref(), &records);
         if refused > 0 {
             self.metrics.note_dropped(refused);
         }

--- a/anyharness/crates/proliferate-diagnostics-collector/src/main.rs
+++ b/anyharness/crates/proliferate-diagnostics-collector/src/main.rs
@@ -27,6 +27,13 @@ struct Args {
     release: String,
     #[arg(long, default_value = "local")]
     environment: String,
+    /// Stable identity of this installation, stamped on exported records as
+    /// the `proliferate.install_id` resource attribute.
+    ///
+    /// The host that owns the identity passes it in; the collector never
+    /// derives, generates, or persists one. Omitted means no attribute.
+    #[arg(long)]
+    install_id: Option<String>,
 }
 
 #[tokio::main]
@@ -52,6 +59,7 @@ async fn main() -> anyhow::Result<()> {
     let mut config = CollectorConfig::standalone(capability.clone());
     config.release = args.release;
     config.environment = args.environment;
+    config.install_id = args.install_id;
     let server = CollectorServer::start(config).await?;
     let descriptor = server.connection_descriptor(capability_fd as u32)?;
     let core = server.core();

--- a/anyharness/crates/proliferate-diagnostics-collector/src/state/mod.rs
+++ b/anyharness/crates/proliferate-diagnostics-collector/src/state/mod.rs
@@ -137,6 +137,20 @@ impl CollectorCore {
                 "release and environment must be 1-128 bytes",
             ));
         }
+        // An install id is optional, but a present one must be a bounded
+        // printable label. It is stamped on every exported record, so an
+        // unbounded or control-character value would be an unbounded,
+        // unescaped field on the wire.
+        if let Some(install_id) = config.install_id.as_deref() {
+            if install_id.is_empty()
+                || install_id.len() > 128
+                || !install_id.bytes().all(|byte| byte.is_ascii_graphic())
+            {
+                return Err(CoreError::InvalidConfig(
+                    "install id must be 1-128 printable ASCII bytes",
+                ));
+            }
+        }
         let boot_id = format!("collector-{}", uuid::Uuid::new_v4());
         let boot_operation_id = format!("collector-boot-{}", uuid::Uuid::new_v4());
         let (tail_tx, _) = broadcast::channel(config.runtime_limits.tail_queue_frames);
@@ -165,7 +179,7 @@ impl CollectorCore {
             tail_tx,
             tail_slots: Arc::new(Semaphore::new(config.runtime_limits.tail_readers)),
             export_slots: Arc::new(Semaphore::new(config.runtime_limits.concurrent_exports)),
-            exporter: ExporterHandle::from_environment(),
+            exporter: ExporterHandle::from_environment(config.install_id.clone()),
         });
         {
             let mut inner = core.lock();
@@ -255,5 +269,40 @@ impl CollectorCore {
             inner.gaps.pop_front();
         }
         inner.gaps.push_back(gap);
+    }
+}
+
+#[cfg(test)]
+mod install_id_tests {
+    use super::*;
+
+    fn config(install_id: Option<&str>) -> CollectorConfig {
+        let mut config = CollectorConfig::standalone("install-id-test-capability");
+        config.install_id = install_id.map(str::to_owned);
+        config
+    }
+
+    #[test]
+    fn an_absent_install_id_is_accepted_because_a_host_may_have_none() {
+        assert!(CollectorCore::new(&config(None)).is_ok());
+    }
+
+    #[test]
+    fn a_bounded_printable_install_id_is_accepted() {
+        assert!(CollectorCore::new(&config(Some("2f6b1c8e-install"))).is_ok());
+    }
+
+    /// The install id is stamped on every exported record, so an empty,
+    /// oversized, or control-character value would put an unbounded or
+    /// unescaped field on the wire. Startup refuses it rather than sanitizing
+    /// it, because a silently rewritten identity is worse than no identity.
+    #[test]
+    fn an_empty_oversized_or_unprintable_install_id_is_refused() {
+        for rejected in ["", &"x".repeat(129), "has space", "has\nnewline"] {
+            assert!(
+                CollectorCore::new(&config(Some(rejected))).is_err(),
+                "install id {rejected:?} must be refused"
+            );
+        }
     }
 }

--- a/anyharness/crates/proliferate-diagnostics-collector/tests/otlp_dogfood.rs
+++ b/anyharness/crates/proliferate-diagnostics-collector/tests/otlp_dogfood.rs
@@ -123,6 +123,10 @@ fn clear_cloexec(fd: i32) {
 
 /// Starts the packaged collector binary with the destination supplied exactly
 /// the way an internal build receives it: out of band, never in the contract.
+/// The install id the suite passes through the real `--install-id` process
+/// seam, the same way the desktop host passes the one it owns.
+const INSTALL_ID: &str = "install-dogfood-4b71";
+
 fn spawn_collector(destination: Option<(&str, &str)>) -> CollectorChild {
     let (mut capability_writer, capability_reader) = UnixStream::pair().expect("capability pair");
     let (control_writer, control_reader) = UnixStream::pair().expect("control pair");
@@ -134,6 +138,8 @@ fn spawn_collector(destination: Option<(&str, &str)>) -> CollectorChild {
         .arg(capability_reader.as_raw_fd().to_string())
         .arg("--control-fd")
         .arg(control_reader.as_raw_fd().to_string())
+        .arg("--install-id")
+        .arg(INSTALL_ID)
         .env_remove("PROLIFERATE_DIAGNOSTICS_OTLP_ENDPOINT")
         .env_remove("PROLIFERATE_DIAGNOSTICS_OTLP_HEADERS")
         .stdin(Stdio::null())
@@ -309,6 +315,25 @@ async fn accepted_records_reach_the_destination_as_conformant_otlp_with_its_head
         state.header_values(DATASET_HEADER).first().map(String::as_str),
         Some("proliferate")
     );
+
+    // The install id is stamped by the collector from the value the host
+    // passed on the process seam, so it rides every resource stream regardless
+    // of which producer boot each record came from. No producer sent it, and
+    // no producer could have.
+    let resource_sets = state.resource_attribute_sets();
+    assert!(
+        resource_sets.len() > 1,
+        "the fixture must span several resource streams"
+    );
+    for attributes in &resource_sets {
+        let stamped = attributes
+            .as_array()
+            .expect("resource attributes")
+            .iter()
+            .find(|attribute| attribute["key"] == "proliferate.install_id")
+            .expect("proliferate.install_id resource attribute");
+        assert_eq!(stamped["value"]["stringValue"], Value::from(INSTALL_ID));
+    }
 
     let health = health(&collector).await;
     assert_eq!(health.status, HealthStatusV1::Ready);

--- a/anyharness/crates/proliferate-diagnostics-collector/tests/otlp_receiver/mod.rs
+++ b/anyharness/crates/proliferate-diagnostics-collector/tests/otlp_receiver/mod.rs
@@ -40,6 +40,24 @@ impl ReceiverState {
             .collect()
     }
 
+    /// Every resource-attribute set the receiver has accepted, one per
+    /// resource stream per request, in arrival order.
+    pub fn resource_attribute_sets(&self) -> Vec<Value> {
+        self.requests
+            .lock()
+            .expect("receiver requests")
+            .iter()
+            .flat_map(|request| {
+                request.payload["resourceLogs"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .map(|resource| resource["resource"]["attributes"].clone())
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
     pub fn request_count(&self) -> usize {
         self.requests.lock().expect("receiver requests").len()
     }

--- a/apps/desktop/src-tauri/src/commands/desktop_identity.rs
+++ b/apps/desktop/src-tauri/src/commands/desktop_identity.rs
@@ -2,7 +2,12 @@ use uuid::Uuid;
 
 use crate::app_config::{desktop_install_id_path, write_string_file_atomic};
 
-fn load_or_create_desktop_install_id() -> Result<String, String> {
+/// The stable identity of this desktop installation, created on first use.
+///
+/// One value serves both the renderer command and the diagnostics collector,
+/// so a record exported by the collector and an event reported by the app
+/// describe the same install rather than two unrelated identities.
+pub(crate) fn load_or_create_desktop_install_id() -> Result<String, String> {
     let path = desktop_install_id_path()?;
     let existing = match std::fs::read_to_string(&path) {
         Ok(value) => value.trim().to_string(),

--- a/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/tests.rs
+++ b/apps/desktop/src-tauri/src/diagnostics/support_snapshot/coordinator/tests.rs
@@ -36,6 +36,7 @@ pub(super) fn test_coordinator(
         fallback,
         "test".to_string(),
         "test".to_string(),
+        None,
     );
     SupportSnapshotCoordinator::with_test_parts(
         supervisor,

--- a/apps/desktop/src-tauri/src/diagnostics_collector/process.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/process.rs
@@ -130,6 +130,11 @@ pub(crate) struct CollectorProcessLauncher {
     binary: PathBuf,
     release: String,
     environment: String,
+    /// Identity of this installation, handed to the collector so it can stamp
+    /// exported records with it. `None` when the identity could not be read or
+    /// created, which is an observability degradation and never a launch
+    /// failure: the collector then exports records with no install attribute.
+    install_id: Option<String>,
     fallback: FallbackDiagnosticsWriter,
 }
 
@@ -140,6 +145,7 @@ impl fmt::Debug for CollectorProcessLauncher {
             .field("binary", &self.binary.file_name())
             .field("release", &self.release)
             .field("environment", &self.environment)
+            .field("install_id", &self.install_id)
             .finish_non_exhaustive()
     }
 }
@@ -148,6 +154,7 @@ impl CollectorProcessLauncher {
     pub(crate) fn discover(
         release: String,
         environment: String,
+        install_id: Option<String>,
         fallback: FallbackDiagnosticsWriter,
     ) -> Result<Self, CollectorLaunchError> {
         if !supported_target(current_target_triple()) {
@@ -165,10 +172,16 @@ impl CollectorProcessLauncher {
         validate_binary(&binary)?;
         validate_label(&release)?;
         validate_label(&environment)?;
+        // An unusable identity is dropped rather than failing the launch. The
+        // collector refuses an out-of-range `--install-id` outright, so
+        // passing one through would trade a missing attribute for no
+        // diagnostics at all.
+        let install_id = install_id.filter(|value| validate_label(value).is_ok());
         Ok(Self {
             binary,
             release,
             environment,
+            install_id,
             fallback,
         })
     }
@@ -188,6 +201,7 @@ impl CollectorProcessLauncher {
             binary,
             release,
             environment,
+            install_id: None,
             fallback,
         }
     }
@@ -218,6 +232,13 @@ impl CollectorProcessLauncher {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
+        // Optional, and passed as an argument rather than an environment
+        // value so it travels the same audited seam as `--release` and
+        // `--environment` and cannot be inherited by anything else the child
+        // spawns.
+        if let Some(install_id) = self.install_id.as_deref() {
+            command.args(["--install-id", install_id]);
+        }
 
         // SAFETY: after fork and before exec this closure performs only two raw,
         // checked fcntl calls. It allocates, formats, logs, and locks nothing.

--- a/apps/desktop/src-tauri/src/diagnostics_collector/process_tests.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/process_tests.rs
@@ -103,6 +103,7 @@ async fn accepted_collector_binary_round_trips_protected_launch_health_and_shutd
         binary: built_collector_binary(),
         release: "desktop-test".to_string(),
         environment: "test".to_string(),
+        install_id: None,
         fallback: fallback.clone(),
     };
     assert!(launcher.binary.is_file(), "collector binary must be built");
@@ -241,6 +242,66 @@ async fn rv_2_05_oversized_control_causes_child_exit_not_graceful_shutdown() {
         .expect("observe oversized control exit");
     assert!(!status.success());
     assert!(!process.orderly_shutdown_requested);
+
+    fallback.close().expect("close fallback");
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+fn install_id_launcher(
+    install_id: Option<&str>,
+    fallback: &FallbackDiagnosticsWriter,
+) -> CollectorProcessLauncher {
+    CollectorProcessLauncher {
+        binary: built_collector_binary(),
+        release: "desktop-test".to_string(),
+        environment: "test".to_string(),
+        install_id: install_id.map(str::to_owned),
+        fallback: fallback.clone(),
+    }
+}
+
+/// The install id crosses the process seam as an argument, the same way
+/// `--release` and `--environment` do, and the real collector binary accepts
+/// it. This is the desktop half of the `proliferate.install_id` resource
+/// attribute; the collector half is proven in `otlp_dogfood.rs`.
+#[tokio::test]
+async fn an_install_id_crosses_the_process_seam_to_the_real_collector() {
+    let root = std::env::temp_dir().join(format!("collector-install-id-{}", uuid::Uuid::new_v4()));
+    let fallback = FallbackDiagnosticsWriter::open_for_test(root.join("desktop-native.log"))
+        .expect("fallback");
+    let launcher = install_id_launcher(Some("install-desktop-test-4b71"), &fallback);
+
+    let mut process = launcher.launch().await.expect("launch with an install id");
+    let health = process.client().health().await.expect("authenticated health");
+    assert_eq!(health.status, HealthStatusV1::Ready);
+    assert_eq!(
+        process.orderly_shutdown().await.expect("shutdown"),
+        CollectorShutdownOutcome::Graceful
+    );
+
+    fallback.close().expect("close fallback");
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+/// Negative control for the filter in `discover`. The collector refuses an
+/// out-of-range `--install-id` at startup rather than sanitizing it, so
+/// passing one through would cost the whole collector, not just the
+/// attribute. `discover` therefore drops an unusable identity instead.
+#[tokio::test]
+async fn an_unusable_install_id_would_cost_the_collector_so_discover_drops_it() {
+    let root = std::env::temp_dir().join(format!("collector-bad-install-{}", uuid::Uuid::new_v4()));
+    let fallback = FallbackDiagnosticsWriter::open_for_test(root.join("desktop-native.log"))
+        .expect("fallback");
+    let unusable = "x".repeat(129);
+
+    let launcher = install_id_launcher(Some(&unusable), &fallback);
+    assert!(
+        launcher.launch().await.is_err(),
+        "the collector must refuse an out-of-range install id"
+    );
+
+    assert!(validate_label(&unusable).is_err());
+    assert!(validate_label("install-desktop-test-4b71").is_ok());
 
     fallback.close().expect("close fallback");
     std::fs::remove_dir_all(root).expect("cleanup");

--- a/apps/desktop/src-tauri/src/diagnostics_collector/supervisor/initialization.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/supervisor/initialization.rs
@@ -20,8 +20,10 @@ impl DiagnosticsCollectorSupervisor {
         fallback: FallbackDiagnosticsWriter,
         release: String,
         environment: String,
+        install_id: Option<String>,
     ) -> Arc<Self> {
-        let launcher = CollectorProcessLauncher::discover(release, environment, fallback.clone());
+        let launcher =
+            CollectorProcessLauncher::discover(release, environment, install_id, fallback.clone());
         Self::with_launcher(producer, fallback, launcher)
     }
 

--- a/apps/desktop/src-tauri/src/diagnostics_collector/supervisor_renderer_ingest_tests.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/supervisor_renderer_ingest_tests.rs
@@ -15,6 +15,7 @@ async fn renderer_ingest_forced_write_failure_preserves_the_stopped_error() {
         fallback.clone(),
         "test".to_string(),
         "test".to_string(),
+        None,
     );
 
     assert_eq!(
@@ -50,6 +51,7 @@ async fn renderer_ingest_post_dispatch_unavailable_never_writes_fallback() {
         fallback.clone(),
         "test".to_string(),
         "test".to_string(),
+        None,
     );
     let generation = 7;
     let collector_boot_id = uuid::Uuid::new_v4().to_string();
@@ -96,6 +98,7 @@ async fn renderer_ingest_ready_coherent_success_writes_no_fallback() {
         fallback.clone(),
         "test".to_string(),
         "test".to_string(),
+        None,
     );
     let collector_boot_id = uuid::Uuid::new_v4().to_string();
     let generation = 9;
@@ -151,6 +154,7 @@ async fn renderer_ingest_post_dispatch_rejected_protocol_boot_and_replaced_write
         fallback.clone(),
         "test".to_string(),
         "test".to_string(),
+        None,
     );
 
     let collector_boot_id = uuid::Uuid::new_v4().to_string();
@@ -267,6 +271,7 @@ async fn renderer_ingest_post_dispatch_deadline_writes_no_fallback() {
         fallback.clone(),
         "test".to_string(),
         "test".to_string(),
+        None,
     );
     let collector_boot_id = uuid::Uuid::new_v4().to_string();
     let generation = 13;

--- a/apps/desktop/src-tauri/src/diagnostics_collector/supervisor_tests.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/supervisor_tests.rs
@@ -489,6 +489,7 @@ async fn renderer_ingest_pre_dispatch_states_write_once_and_return_the_original_
         fallback.clone(),
         "test".to_string(),
         "test".to_string(),
+        None,
     );
     fallback.set_active(false);
     let cases = [

--- a/apps/desktop/src-tauri/src/diagnostics_collector/supervisor_unsupported.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/supervisor_unsupported.rs
@@ -107,6 +107,11 @@ impl DiagnosticsCollectorSupervisor {
         fallback: FallbackDiagnosticsWriter,
         _release: String,
         _environment: String,
+        // Targets that reach this file ship a placeholder collector, so there
+        // is no process to stamp the install id onto and nothing to export it
+        // on. The parameter exists so both supervisors present one signature
+        // to `lib.rs`, which cannot know which one it compiled against.
+        _install_id: Option<String>,
     ) -> Arc<Self> {
         let (startup_tx, _) = watch::channel(StartupBarrierResult::Pending);
         let (generation_tx, _) = watch::channel(0);

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -216,6 +216,11 @@ pub fn run() {
             } else {
                 "production".to_string()
             },
+            // The same identity the renderer reads through
+            // `get_desktop_install_id`, so an exported record and an app event
+            // describe one install. A failure to read or create it degrades
+            // the attribute, never the launch.
+            desktop_identity::load_or_create_desktop_install_id().ok(),
         );
     let support_snapshot_coordinator =
         diagnostics::support_snapshot::coordinator::SupportSnapshotCoordinator::new(

--- a/specs/OBSERVABILITY.md
+++ b/specs/OBSERVABILITY.md
@@ -103,7 +103,13 @@ per-developer `dev.user` tag. The release job refuses a bundle whose packaged
 collector does not report `lifecycle_only`, or whose binaries carry the
 dogfood-only marker or dev-tag literals. Independently of the policy, any build
 exports nothing until a destination is configured out of band, so customer
-export stays dark until that configuration is a deliberate decision. The adapter is bounded best effort —
+export stays dark until that configuration is a deliberate decision. Exported
+records carry `proliferate.install_id`, a resource attribute the collector
+stamps from a value its host passes on the process seam as `--install-id`; the
+desktop passes the `desktop_install_id` it already owns. It is not a
+wire-protocol field, so no producer can set or spoof it, and it is what
+distinguishes one install failing forty times from forty installs failing once.
+It is absent rather than invented when the host has no identity to give. The adapter is bounded best effort —
 a fixed queue that drops rather than grows, a fixed batch, one attempt plus two
 retries, a cooldown, and no disk outbox or replay — so a failing destination
 changes only `exporter.state`, `exporter.dropped_records`, and a fixed-table


### PR DESCRIPTION
## The gap

An exported record could say which producer boot and which release it came from, but nothing that survived a restart. So "40 launch failures" could equally be forty installs or one install failing forty times, and no field told them apart. That is the difference between a launch-blocking bug and one broken machine.

## What this adds

`proliferate.install_id`, a resource attribute stamped by the collector onto every exported record.

It is deliberately **not** a wire-protocol field. The value arrives on the collector's process seam as `--install-id`, alongside the existing `--release` and `--environment`, from the host that owns the identity. No producer can set it, spoof it, or omit it, and every record from one install carries the same value whatever producer emitted it or how many times that producer restarted.

The desktop passes the identity it already owns: the `desktop_install_id` file behind the renderer's existing `get_desktop_install_id` command (`apps/desktop/src-tauri/src/commands/desktop_identity.rs`). One value now serves both, so an exported record and an app event describe the same install rather than two unrelated identities. It is a locally generated UUID with no account, machine, or user identity in it, and it is pseudonymous by construction.

## Absent rather than invented, at every step

- A host with no identity to give passes nothing, and the attribute does not appear at all. A consumer can distinguish "unknown install" from "install whose id is the empty string".
- The collector **refuses** an empty, oversized, or unprintable `--install-id` at startup rather than sanitizing it. A silently rewritten identity is worse than no identity, and the value is stamped on every exported record, so an unbounded or control-character value would put an unbounded, unescaped field on the wire.
- Because startup refuses it, the desktop launcher drops an unusable value instead of passing it through. Passing it would trade a missing attribute for no diagnostics at all. An unreadable identity file is an observability degradation, never a launch failure.

## Tests

| test | what it proves |
| --- | --- |
| `an_install_id_crosses_the_process_seam_to_the_real_collector` | the real collector binary accepts `--install-id` from the real launcher and reaches `Ready` |
| `an_unusable_install_id_would_cost_the_collector_so_discover_drops_it` | negative control: the real binary refuses an out-of-range id, which is why `discover` filters |
| `accepted_records_reach_the_destination_as_conformant_otlp_with_its_headers` | the attribute is on **every** resource stream of the real OTLP payload at a real receiver, across several producer boots |
| `install_id_tests` (3 cases) | core startup accepts absent and bounded-printable, refuses empty, 129-byte, spaced, and newline-bearing |
| `the_install_id_is_stamped_as_a_resource_attribute_when_the_host_supplies_one`, `an_absent_install_id_omits_the_attribute_entirely` | the encoder's two branches |

## Testing

- `cargo test -p proliferate-diagnostics-collector` (default): 52 unit tests pass.
- `cargo test -p proliferate-diagnostics-collector --features internal-dogfood-export --test otlp_dogfood`: 4 pass, including the wire assertion above.
- `cargo test -p proliferate --lib diagnostics_collector::process`: 12 pass, including both new seam tests.
- `python3 scripts/check_max_lines.py`, `scripts/lint_records.py`, `scripts/check_docs.py`: pass.

Based on #2185, which is based on #2180. **Do not merge**; merges are Pablo's.
