### PR TITLE
fix(dev): restore the runtime binary after the workspace build clobbers it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1615,6 +1615,7 @@ build-rust:
 		echo "SKIP_RUST set — skipping cargo builds (runtime: $${ANYHARNESS_DEV_RUNTIME_BIN:-<unset>})"; \
 	else \
 		$(CARGO) build --workspace || exit 1; \
+		$(CARGO) build -p anyharness || exit 1; \
 		target_dir=$$($(CARGO) metadata --format-version 1 --no-deps --offline 2>/dev/null \
 			| node -e 'let b="";process.stdin.on("data",d=>b+=d).on("end",()=>{try{process.stdout.write(JSON.parse(b).target_directory)}catch{}})'); \
 		target_dir="$${target_dir:-target}"; \


### PR DESCRIPTION
Fixes #2188. `make dev PROFILE=<name>` is currently unrecoverable on any worktree where the desktop crate has been built, which is the command #2134 made canonical.

## What breaks

`build-rust` runs `cargo build --workspace` and then copies `target/debug/anyharness` into `$(DEV_ANYHARNESS_TARGET_DIR)`. The workspace build includes the desktop crate, and after it runs, `target/debug/anyharness` is the 106-byte Tauri sidecar placeholder rather than the runtime:

```
$ cargo build -p anyharness && ls -la target/debug/anyharness
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 12.45s
    138493688 bytes

$ cargo build --workspace   && ls -la target/debug/anyharness
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 10.51s
    106 bytes
```

The copy then propagates the placeholder. Because the copy is guarded by `cmp -s ... || cp -f ...`, once both sides hold the placeholder they compare equal and the copy never runs again, so `target/runtime-local` keeps the bad binary. `dev-artifacts-ready` rejects it with `Run: make build-rust`, and running that re-clobbers `target/debug` and re-confirms the match. The instruction the tool gives you cannot fix the problem it reports.

## The fix

One line: re-run `cargo build -p anyharness` after the workspace build, before the copy reads the path. Cargo re-uplifts the real binary from `target/debug/deps`, which costs 0.36s warm because nothing recompiles.

## Proof

Both sides poisoned to the placeholder, then `make build-rust`, on this branch and on `main`:

| | poisoned state | after `make build-rust` | `dev-artifacts-ready` |
|---|---|---|---|
| this branch | `debug=106  runtime-local=106` | `debug=138493688  runtime-local=138493688` | passes, and `./target/runtime-local/debug/anyharness --version` prints `anyharness 0.1.0` |
| `main` (control) | `debug=106  runtime-local=106` | `debug=106  runtime-local=106` | fails: `Run: make build-rust` |

Both invocations exit 0, which is what makes the shipped behaviour hard to notice: the build reports success while leaving an unusable binary in place.

## Scope

This addresses the symptom where it breaks the dev loop. The root cause is that the desktop build writes a placeholder over a path that is also the runtime's build output, which is worth fixing separately rather than in a change that needs to land quickly.

Found by running a real profile launch, which is the check #2134 shipped without.
