### PR TITLE
fix(agent-auth): adopt gateway per harness lacking native login on first run

### DIFF
--- a/apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.ts
+++ b/apps/packages/product-client/src/hooks/agents/lifecycle/use-first-run-auth-adoption.ts
@@ -17,8 +17,10 @@ import { useHarnessConnectionStore } from "#product/stores/sessions/harness-conn
 
 /**
  * First-run adoption of the managed gateway into auth selections (spec §9).
- * Runs once per app run, and only when the user has zero selections, so a fresh
- * profile that detected no native credentials falls back to the gateway.
+ * Runs once per app run, and only when the user has zero selections, so a
+ * fresh profile falls back to the gateway for each gateway-capable harness
+ * that detected no native credentials — independently per harness, so a
+ * profile with SOME native credentials still falls back for the rest.
  * Harnesses with detected native creds are left on the implicit native state.
  *
  * Fire-and-forget: adoption failures are logged and never surfaced — the

--- a/apps/packages/product-client/src/lib/domain/agents/auth-onboarding.test.ts
+++ b/apps/packages/product-client/src/lib/domain/agents/auth-onboarding.test.ts
@@ -78,13 +78,28 @@ describe("resolveAgentAuthDisplay", () => {
 });
 
 describe("planFirstRunAuthAdoption", () => {
-  it("writes nothing when native creds are detected (native is implicit)", () => {
+  it("adopts the gateway ONLY for the non-native installed agents when credentials are mixed (THE BUG CASE)", () => {
+    // Regression guard for the fixed bug: adoption used to early-return []
+    // for the WHOLE list the moment any single agent had detected native
+    // auth. Per AGENT_AUTH.md ("adopts the gateway for harnesses without
+    // native logins"), each harness must decide independently — one
+    // harness's native login must not suppress adoption for the others.
     const actions = planFirstRunAuthAdoption({
       agents: [
-        agent({ kind: "claude" }),
-        agent({ kind: "codex" }),
-        agent({ kind: "grok", credentialState: "login_required" }),
+        agent({ kind: "claude" }), // native — excluded
+        agent({ kind: "codex" }), // native — excluded
+        agent({ kind: "grok", credentialState: "login_required" }), // not native, installed — adopts
       ],
+      selectionCount: 0,
+      gatewayEnabled: true,
+    });
+
+    expect(actions).toEqual([{ harnessKind: "grok", surface: "local" }]);
+  });
+
+  it("writes nothing when every installed agent already has native credentials (all-native)", () => {
+    const actions = planFirstRunAuthAdoption({
+      agents: [agent({ kind: "claude" }), agent({ kind: "codex" })],
       selectionCount: 0,
       gatewayEnabled: true,
     });
@@ -102,10 +117,11 @@ describe("planFirstRunAuthAdoption", () => {
     expect(actions).toEqual([]);
   });
 
-  it("preselects the gateway for installed harnesses when nothing is detected", () => {
+  it("preselects the gateway for EVERY installed harness when nothing is detected, excluding not-installed/install-required agents", () => {
     const actions = planFirstRunAuthAdoption({
       agents: [
         agent({ kind: "claude", credentialState: "login_required" }),
+        agent({ kind: "grok", credentialState: "login_required" }),
         agent({
           kind: "codex",
           credentialState: "unknown",
@@ -119,6 +135,7 @@ describe("planFirstRunAuthAdoption", () => {
 
     expect(actions).toEqual([
       { harnessKind: "claude", surface: "local" },
+      { harnessKind: "grok", surface: "local" },
     ]);
   });
 
@@ -143,9 +160,10 @@ describe("planFirstRunAuthAdoption", () => {
     ]);
   });
 
-  it("still defers to a genuine native login alongside a routed harness", () => {
-    // The other direction: one genuine native login still means "leave
-    // everything alone", even when a different harness is route-ready.
+  it("still adopts the gateway for the routed harness even when a different harness is genuinely native", () => {
+    // The other direction: a genuine native login on one harness (codex)
+    // must not suppress adoption for a route-ready harness (claude) that is
+    // NOT natively authed. Per-harness independence cuts both ways.
     const actions = planFirstRunAuthAdoption({
       agents: [
         agent({ kind: "claude", credentialsFromRoute: true }),
@@ -155,7 +173,7 @@ describe("planFirstRunAuthAdoption", () => {
       gatewayEnabled: true,
     });
 
-    expect(actions).toEqual([]);
+    expect(actions).toEqual([{ harnessKind: "claude", surface: "local" }]);
   });
 
   it("does nothing when nothing is detected and the gateway is disabled", () => {

--- a/apps/packages/product-client/src/lib/domain/agents/auth-onboarding.test.ts
+++ b/apps/packages/product-client/src/lib/domain/agents/auth-onboarding.test.ts
@@ -89,6 +89,14 @@ describe("planFirstRunAuthAdoption", () => {
         agent({ kind: "claude" }), // native — excluded
         agent({ kind: "codex" }), // native — excluded
         agent({ kind: "grok", credentialState: "login_required" }), // not native, installed — adopts
+        // not native, but NOT installed — excluded within the same mixed
+        // scenario (install exclusion must hold alongside native exclusion).
+        agent({
+          kind: "opencode",
+          credentialState: "login_required",
+          installState: "install_required",
+          readiness: "install_required",
+        }),
       ],
       selectionCount: 0,
       gatewayEnabled: true,
@@ -126,6 +134,14 @@ describe("planFirstRunAuthAdoption", () => {
           kind: "codex",
           credentialState: "unknown",
           installState: "install_required",
+          readiness: "install_required",
+        }),
+        // Genuinely NOT installed (distinct from "install_required" above) —
+        // still excluded, since the filter only admits installState==="installed".
+        agent({
+          kind: "opencode",
+          credentialState: "unknown",
+          installState: "failed",
           readiness: "install_required",
         }),
       ],
@@ -174,6 +190,55 @@ describe("planFirstRunAuthAdoption", () => {
     });
 
     expect(actions).toEqual([{ harnessKind: "claude", surface: "local" }]);
+  });
+
+  // A-R1: gateway-capability guard. cursor is single-source with only a
+  // "cursor" auth slot — no gateway recipe exists for it (agent-auth.md's
+  // per-harness recipe table; server-side selection_rules.py fails closed
+  // with "Harness 'cursor' has no gateway recipe"). Adoption must never hand
+  // a harness a gateway action it cannot service, mirroring the settings
+  // write path's isGatewayCapableHarness guard in buildDesiredSources.
+  it("does not adopt cursor even when it is the only non-native installed agent (mixed credentials)", () => {
+    const actions = planFirstRunAuthAdoption({
+      agents: [
+        agent({ kind: "claude" }), // native — excluded
+        agent({ kind: "cursor", credentialState: "login_required" }), // not native, installed, NOT gateway-capable — excluded
+      ],
+      selectionCount: 0,
+      gatewayEnabled: true,
+    });
+
+    expect(actions).toEqual([]);
+  });
+
+  it("adopts only the gateway-capable non-native installed agent alongside cursor", () => {
+    const actions = planFirstRunAuthAdoption({
+      agents: [
+        agent({ kind: "cursor", credentialState: "login_required" }), // not native, NOT gateway-capable — excluded
+        agent({ kind: "grok", credentialState: "login_required" }), // not native, gateway-capable — adopts
+      ],
+      selectionCount: 0,
+      gatewayEnabled: true,
+    });
+
+    expect(actions).toEqual([{ harnessKind: "grok", surface: "local" }]);
+  });
+
+  it("excludes cursor from a zero-native machine while still adopting the other installed harnesses", () => {
+    const actions = planFirstRunAuthAdoption({
+      agents: [
+        agent({ kind: "cursor", credentialState: "login_required" }),
+        agent({ kind: "claude", credentialState: "login_required" }),
+        agent({ kind: "codex", credentialState: "login_required" }),
+      ],
+      selectionCount: 0,
+      gatewayEnabled: true,
+    });
+
+    expect(actions).toEqual([
+      { harnessKind: "claude", surface: "local" },
+      { harnessKind: "codex", surface: "local" },
+    ]);
   });
 
   it("does nothing when nothing is detected and the gateway is disabled", () => {

--- a/apps/packages/product-client/src/lib/domain/agents/auth-onboarding.ts
+++ b/apps/packages/product-client/src/lib/domain/agents/auth-onboarding.ts
@@ -1,4 +1,5 @@
 import type { AgentSummary } from "@anyharness/sdk";
+import { isGatewayCapableHarness } from "#product/lib/domain/agents/bundled-agent-registry";
 import { agentNeedsInstall } from "#product/lib/domain/agents/status";
 
 /**
@@ -177,11 +178,17 @@ export function planFirstRunAuthAdoption(
   // Each harness adopts independently: detected native creds need no wiring
   // for THAT harness — native is the implicit empty state — but a harness
   // the scan already trusts must not suppress gateway preselection for any
-  // other harness on the machine.
+  // other harness on the machine. Existing gateway-support filtering still
+  // applies per-harness: a harness with no gateway recipe (cursor — single-
+  // source, its only slot is "cursor") can never be handed a gateway action,
+  // matching the settings write path's isGatewayCapableHarness guard and the
+  // server's selection_rules.py fail-closed ("no gateway recipe").
   return input.agents
     .filter(
       (agent) =>
-        agent.installState === "installed" && !hasDetectedNativeAuth(agent),
+        agent.installState === "installed"
+        && !hasDetectedNativeAuth(agent)
+        && isGatewayCapableHarness(agent.kind),
     )
     .map((agent) => ({
       harnessKind: agent.kind,

--- a/apps/packages/product-client/src/lib/domain/agents/auth-onboarding.ts
+++ b/apps/packages/product-client/src/lib/domain/agents/auth-onboarding.ts
@@ -5,11 +5,16 @@ import { agentNeedsInstall } from "#product/lib/domain/agents/status";
  * First-run auth adoption (spec §9, PR 12).
  *
  * When the user has NO selection rows yet, the desktop adopts what the local
- * AnyHarness credential scan already detected:
- * - each harness with detected native auth → nothing to write (native is the
- *   implicit empty state; the CLI's own login is used)
- * - nothing detected → preselect the managed gateway for installed harnesses
- *   (only when the gateway is enabled for the account)
+ * AnyHarness credential scan already detected, independently per harness:
+ * - a harness with detected native auth → nothing to write for that harness
+ *   (native is the implicit empty state; the CLI's own login is used)
+ * - a harness without detected native auth → preselect the managed gateway
+ *   for it, as long as it is installed and the gateway is enabled for the
+ *   account
+ *
+ * One harness's native login must not suppress adoption for any other
+ * harness (AGENT_AUTH.md, "First-run adoption settles once": Desktop "adopts
+ * the gateway for harnesses without native logins").
  *
  * The plan is only produced when zero selections exist, which keeps the whole
  * flow idempotent: after the first gateway write (or any manual choice in
@@ -165,20 +170,19 @@ export function planFirstRunAuthAdoption(
     return [];
   }
 
-  // Detected native creds need no wiring — native is the implicit empty state,
-  // so a harness the scan already trusts is left alone (and blocks a gateway
-  // preselection for the rest, matching the pre-rebuild adoption).
-  const detected = input.agents.filter(hasDetectedNativeAuth);
-  if (detected.length > 0) {
-    return [];
-  }
-
   if (!input.gatewayEnabled) {
     return [];
   }
 
+  // Each harness adopts independently: detected native creds need no wiring
+  // for THAT harness — native is the implicit empty state — but a harness
+  // the scan already trusts must not suppress gateway preselection for any
+  // other harness on the machine.
   return input.agents
-    .filter((agent) => agent.installState === "installed")
+    .filter(
+      (agent) =>
+        agent.installState === "installed" && !hasDetectedNativeAuth(agent),
+    )
     .map((agent) => ({
       harnessKind: agent.kind,
       surface: "local",


### PR DESCRIPTION
## What

`planFirstRunAuthAdoption` (`apps/packages/product-client/src/lib/domain/agents/auth-onboarding.ts`) previously early-returned `[]` for the **whole** agent list the moment **any** single agent had detected native auth. Fixed to decide per harness, independently.

## Contract

specs/FEATURE_DOCS/AGENT_AUTH.md, "First-run adoption settles once":

> Desktop waits for the startup reconciliation job to complete, reads one fresh post-reconcile agent catalog, and then **adopts the gateway for harnesses without native logins**.

The removed code comment admitted this was legacy parity: "blocks a gateway preselection for the rest, matching the pre-rebuild adoption." The contract wins.

## Old vs new behavior

| Scenario | Old | New |
| --- | --- | --- |
| Zero native creds, gateway on | action for every installed agent | action for every installed agent (unchanged) |
| **Mixed: one native, others not** | **`[]` for everyone (BUG)** | **action only for the non-native installed agents** |
| All agents native | `[]` | `[]` (unchanged) |
| Existing selections (`selectionCount > 0`) | `[]` | `[]` (unchanged) |
| Gateway disabled | `[]` | `[]` (unchanged) |
| Not-installed / install-required agent | excluded | excluded (unchanged) |
| Route-acknowledged (not native-detected) agent | adopts (already correct) | adopts (unchanged) |

New precedence order in the function:
1. `selectionCount > 0` → `[]`
2. `!gatewayEnabled` → `[]`
3. Otherwise: one action per agent that is `installState === "installed"` AND NOT `hasDetectedNativeAuth(agent)` AND `isGatewayCapableHarness(agent.kind)` (third conjunct added in review round 1 — see below). `hasDetectedNativeAuth` itself is untouched — route-derived readiness (`credentialsFromRoute`) still correctly does not count as native auth (existing regression test kept, plus the new mixed-case test pins the opposite direction).

## Tests

Extended `auth-onboarding.test.ts`'s `planFirstRunAuthAdoption` describe block. Two previously-passing tests are **replaced** because they deliberately pinned the pre-rebuild all-or-nothing suppression behavior as correct — under the fixed contract their scenarios now produce non-empty results:

- `"writes nothing when native creds are detected (native is implicit)"` → replaced by `"adopts the gateway ONLY for the non-native installed agents when credentials are mixed (THE BUG CASE)"` (same 3-agent shape, now asserts the non-native agent adopts instead of asserting the old blanket `[]`).
- `"still defers to a genuine native login alongside a routed harness"` → replaced by `"still adopts the gateway for the routed harness even when a different harness is genuinely native"` (same 2-agent shape, now asserts the routed, non-native harness adopts instead of asserting `[]`).

New/strengthened coverage:
- all-native → `[]` (new, isolates this case from the mixed case above)
- zero native creds + gateway on → action for every installed agent, not-installed/install-required excluded (strengthened to 2 adopting agents + 1 excluded, in one assertion)
- existing selections → `[]` (unchanged)
- gateway disabled → `[]` (unchanged)
- route-acknowledged agent still adopts, both directions of route-vs-native mixing (unchanged / new opposite direction)

### Negative control

Reverted only the source fix (kept the updated tests), reran the suite:

```
 ❯ src/lib/domain/agents/auth-onboarding.test.ts (27 tests | 2 failed) 6ms
   × planFirstRunAuthAdoption > adopts the gateway ONLY for the non-native installed agents when credentials are mixed (THE BUG CASE) 3ms
     → expected [] to deeply equal [ { harnessKind: 'grok', …(1) } ]
   × planFirstRunAuthAdoption > still adopts the gateway for the routed harness even when a different harness is genuinely native 0ms
     → expected [] to deeply equal [ { harnessKind: 'claude', …(1) } ]

 Test Files  1 failed (1)
      Tests  2 failed | 25 passed (27)
```

Restored the fix; full suite green again:

```
 ✓ src/lib/domain/agents/auth-onboarding.test.ts (27 tests) 3ms

 Test Files  1 passed (1)
      Tests  27 passed (27)
```

## Non-goals (unchanged, per spec)

No UI changes, no acknowledgement-card logic changes, no gateway enrollment changes, no edits outside `apps/packages/product-client`.


## Review round 1 fixes (A-R1, A-R2, A-R3)

**A-R1 (MEDIUM, coordinator-ruled in-spec)** — `planFirstRunAuthAdoption` never checked gateway-support filtering, so a non-native installed harness with no gateway recipe (`cursor` — single-source, its only auth slot is `"cursor"`) could be handed a gateway action the server rejects (`selection_rules.py`: `"Harness '{harness_kind}' has no gateway recipe"`). Added a third conjunct: an agent is now adopted only when `installState === "installed"` AND NOT `hasDetectedNativeAuth(agent)` AND `isGatewayCapableHarness(agent.kind)`.

**Which module the predicate was imported from, and why**: `#product/lib/domain/agents/bundled-agent-registry` (the predicate's defining module), not the `harness-auth-sources.ts` re-export. Reasoning:
- It's a sibling file in the same `lib/domain/agents/` layer as the planner — no dependency inversion from the agents domain into the settings domain (`harness-auth-sources.ts` lives in `lib/domain/settings/`).
- It's the minimal, single-purpose import (`isRegistryHarnessKind`, `isGatewayCapableHarness`, `isMultiSourceHarness`, `getRegistryHarnessKinds` — all thin wrappers over the registry JSON), vs. pulling in the settings-domain module's broader surface (env-var validation, `EditableApiKeyRow`, row-completeness helpers).
- Neither module was previously in the lazy planner's dependency cone, and both ultimately execute the same underlying `agent-registry.json?raw` import (11KB) regardless of which one is chosen, since `harness-auth-sources.ts` itself imports from `bundled-agent-registry.ts` — so importing directly avoids an unnecessary indirection layer without changing the actual bundle weight.
- The planner stays behind the existing dynamic `import()` boundary in `use-first-run-auth-adoption.ts:143-148` ("the planner stays out of the login first-load chunk and is loaded only after authenticated Desktop reconciliation completes") — that boundary is unchanged by this diff. Per the reviewer's note that the local gzip budget check under-reports vs CI by ~0.36%, this was not treated as proof on its own; CI's "Login first-load budget (phase-6)" gate is the actual verifier.

Tests added: (1) mixed credentials where the non-native installed agent is `cursor` → cursor NOT adopted; (2) a gateway-capable non-native installed agent alongside `cursor` → only the capable one adopted; (3) zero-native machine with `cursor` installed → cursor excluded, others adopted.

Negative control (dropped the `isGatewayCapableHarness` conjunct only, reran):
```
 FAIL  ... > does not adopt cursor even when it is the only non-native installed agent (mixed credentials)
AssertionError: expected [ { harnessKind: 'cursor', … } ] to deeply equal []
 FAIL  ... > adopts only the gateway-capable non-native installed agent alongside cursor
AssertionError: expected [ …(2) ] to deeply equal [ { harnessKind: 'grok', … } ]
 FAIL  ... > excludes cursor from a zero-native machine while still adopting the other installed harnesses
AssertionError: expected [ …(3) ] to deeply equal [ …(2) ]

 Test Files  1 failed (1)
      Tests  3 failed | 27 passed (30)
```
Restored the conjunct; full suite green again (30/30).

**A-R2 (LOW)** — fixed the stale docstring on `useFirstRunAuthAdoption` (`use-first-run-auth-adoption.ts:18-22`), which still described the pre-fix all-or-nothing behavior ("a fresh profile that detected no native credentials falls back to the gateway"). Now states the per-harness contract: a profile with SOME native credentials still falls back for the remaining gateway-capable harnesses. Docstring only, no behavior change.

**A-R3 (LOW)** — the "excluding not-installed/install-required agents" test only exercised `install_required`. Added a genuinely not-installed case (`installState: "failed"`, distinct from `install_required`) to that test, and added a not-installed, non-native agent inside the mixed-credentials bug-case test so install exclusion is proven to hold in the same scenario as native exclusion, not just in isolation.

### Full targeted suite after all three fixes

```
✓ src/lib/domain/agents/auth-onboarding.test.ts (30 tests) 2ms
Test Files  1 passed (1)
     Tests  30 passed (30)
```

Also reran `src/hooks/agents/lifecycle/use-first-run-auth-adoption.test.tsx` (touched for the A-R2 docstring) — unaffected since it mocks the planner: 27/27 passed.

Diff remains confined to `apps/packages/product-client` (3 files: `auth-onboarding.ts`, `auth-onboarding.test.ts`, `use-first-run-auth-adoption.ts`).

New head: `9152b52c5704e432549439345d5136b17847a4da`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

