### PR TITLE
fix(release): resolve the dispatched release ref to a full SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,10 +87,36 @@ jobs:
       server_tag: ${{ steps.artifacts.outputs.server_tag }}
       artifact_tags: ${{ steps.artifacts.outputs.artifact_tags }}
     steps:
+      # actions/checkout resolves a branch, a tag, or a full 40-character SHA.
+      # It cannot resolve an abbreviated SHA: it fetches the ref by name and
+      # dies with "A branch or tag with the name '<ref>' could not be found".
+      # An abbreviated SHA is exactly what an operator copies out of
+      # `git log --oneline` or a GitHub commit listing when driving the hotfix
+      # or promote path by hand, so run 32452508826 was dispatched with
+      # `ref: 6eac131a47` and failed here 9s in, before any release step ran.
+      # Re-dispatching the identical commit as its full SHA (run 32453354501)
+      # then worked, which is the whole difference. Resolve the input through
+      # the API first so every spelling of a commit that exists in this
+      # repository reaches checkout as the one spelling it accepts, and so an
+      # unresolvable ref fails with a message naming the ref.
+      - name: Resolve the release ref to a full commit SHA
+        id: ref
+        env:
+          INPUT_REF: ${{ github.event.inputs.ref || 'main' }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if ! sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${INPUT_REF}" --jq .sha)"; then
+            echo "::error::Release ref '${INPUT_REF}' does not resolve to a commit in ${GITHUB_REPOSITORY}. Pass a branch, a tag, or a commit SHA (abbreviated or full) that exists on this repository."
+            exit 1
+          fi
+          echo "Resolved release ref '${INPUT_REF}' to ${sha}."
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          ref: ${{ github.event.inputs.ref || 'main' }}
+          ref: ${{ steps.ref.outputs.sha }}
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -270,7 +296,7 @@ jobs:
             echo "### Release plan"
             echo "- Product: \`${{ steps.artifacts.outputs.product_tag || 'no release' }}\`"
             echo "- Checkpoint: \`${{ steps.meta.outputs.release_id }}\`"
-            echo "- Ref: \`${{ github.event.inputs.ref || 'main' }}\`"
+            echo "- Ref: \`${{ github.event.inputs.ref || 'main' }}\` (resolved to \`${{ steps.ref.outputs.sha }}\`)"
             echo "- Base: \`${{ steps.meta.outputs.base_sha }}\`"
             echo "- Head: \`${{ steps.commit.outputs.head_sha }}\`"
             echo "- Skip build: \`${{ steps.meta.outputs.skip_build }}\`"

--- a/scripts/ci-cd/deploy-staging-trigger.test.mjs
+++ b/scripts/ci-cd/deploy-staging-trigger.test.mjs
@@ -71,6 +71,36 @@ test("release.yml is the only entrypoint into a production deploy lane", () => {
   assert.deepEqual(coordinators, ["release.yml"]);
 });
 
+test("release refs resolve to a full commit SHA before checkout", () => {
+  // Release run 32452508826 failed before prepare because actions/checkout
+  // treated the abbreviated commit SHA as a ref name. Keep the lower-tier
+  // contract explicit: resolve every accepted spelling through the commits API,
+  // write the returned full SHA, and give checkout only that output.
+  const release = read("release.yml");
+  const resolveStart = release.indexOf(
+    "- name: Resolve the release ref to a full commit SHA",
+  );
+  const checkoutStart = release.indexOf("- uses: actions/checkout@", resolveStart);
+  const setupNodeStart = release.indexOf("- uses: actions/setup-node@", checkoutStart);
+
+  assert.notEqual(resolveStart, -1, "release.yml must resolve its input ref");
+  assert.notEqual(checkoutStart, -1, "release.yml must still check out the release commit");
+  assert.notEqual(setupNodeStart, -1, "release.yml prepare step boundaries changed");
+  assert.ok(resolveStart < checkoutStart, "release ref resolution must precede checkout");
+
+  const resolver = release.slice(resolveStart, checkoutStart);
+  assert.match(resolver, /INPUT_REF: \$\{\{ github\.event\.inputs\.ref \|\| 'main' \}\}/);
+  assert.match(
+    resolver,
+    /gh api "repos\/\$\{GITHUB_REPOSITORY\}\/commits\/\$\{INPUT_REF\}" --jq \.sha/,
+  );
+  assert.match(resolver, /echo "sha=\$sha" >> "\$GITHUB_OUTPUT"/);
+
+  const checkout = release.slice(checkoutStart, setupNodeStart);
+  assert.match(checkout, /ref: \$\{\{ steps\.ref\.outputs\.sha \}\}/);
+  assert.doesNotMatch(checkout, /github\.event\.inputs\.ref/);
+});
+
 test("staging never targets the production environment", () => {
   assert.doesNotMatch(workflow, PRODUCTION_ENVIRONMENT);
   assert.match(workflow, /environment: staging/);


### PR DESCRIPTION
## Summary

Resolve the operator-supplied release ref through GitHub's commits API before `actions/checkout`, then give checkout the returned full 40-character SHA. This makes branch names, tags, abbreviated SHAs, and full SHAs converge on the one commit spelling checkout reliably accepts.

An unresolvable ref now fails before checkout with an actionable error naming the input and accepted forms.

## Failure and root cause

Release run [32452508826](https://github.com/proliferate-ai/proliferate/actions/runs/32452508826) was dispatched with `ref: 6eac131a47`. That abbreviation identifies commit `6eac131a470637f2e3d327b02147e65bcfba9dc8`, but checkout treated it as a branch or tag name and failed nine seconds into `prepare`:

```text
A branch or tag with the name '6eac131a47' could not be found
```

Every downstream release, deploy, and publish job skipped. Nothing was built, tagged, deployed, or published by that run.

The controlled comparison is [run 32453354501](https://github.com/proliferate-ai/proliferate/actions/runs/32453354501): the same commit supplied as a full SHA checked out successfully and `prepare` completed. The spelling of the ref was the material difference.

## Safety

The resolved commit remains subject to the existing `git merge-base --is-ancestor` main-lineage gate. Checkout remains detached, which the existing full-SHA path already exercises, and the version-bump path already pushes `HEAD:main` explicitly.

This PR does not change Desktop packaging, signing, updater publication, or the packaged diagnostics collector privacy gate. It does not publish or rerun a release.

## Testing and evidence

The lower-tier owner is the CI/CD workflow-contract suite. A regression test now pins all three required edges: commits-API resolution precedes checkout, the resolver writes the returned full SHA, and checkout consumes only that output.

- `node --test scripts/ci-cd/deploy-staging-trigger.test.mjs` — 8/8 passed
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'` — passed
- `git diff --check` — passed
- Live read-only commits-API resolution: the exact failing abbreviation, `main`, `desktop-v0.4.23`, a full SHA, and a slash-containing branch all resolved to full 40-character SHAs; a bogus ref failed as expected
- Negative control: run 32452508826 failed at direct abbreviated-SHA checkout
- Positive control: run 32453354501 checked out the same commit by full SHA and completed `prepare`

## Observability

None. This changes release-input resolution only and adds no runtime signal, telemetry field, provider configuration, or customer data path.
