### PR TITLE
feat(observability): stage Grafana rebuild Slack receiver

### DIFF
--- a/guides/operating/production-alerts.md
+++ b/guides/operating/production-alerts.md
@@ -301,11 +301,13 @@ Discovered live 2026-08-21 (Lane A3), not previously documented:
    Slack is an optional, separately gated additive path. Its webhook is read
    only from `SLACK_ALERTS_WEBHOOK_URL` in the protected local observability
    environment file; it is never checked in. The Slack operation creates a
-   new `grafana-rebuild-slack` receiver and prepends an all-alert child route
-   with `continue: true`. The root `grafana-default-sns` receiver and its
-   existing child route stay untouched, so SNS/email delivery continues beside
-   Slack. The operation refuses a changed root receiver or a drifted Slack
-   route instead of overwriting either.
+   new `grafana-rebuild-slack` receiver (or updates its persisted webhook from
+   the protected environment value) and prepends an all-alert child route with
+   `continue: true`. It first requires the live matcherless SNS child that
+   makes the two sibling routes a real fan-out. The root
+   `grafana-default-sns` receiver, its complete SNS configuration, and every
+   pre-existing non-Slack child route are snapshotted and must survive each
+   write exactly. Any loss, ambiguity, or drift fails the operation.
 
 ### Repository artifacts
 
@@ -345,8 +347,11 @@ GRAFANA_ALERTING_LIVE=1 node scripts/ops/grafana-rebuild-bootstrap.mjs slack-tes
   confirms the dashboard exists. Use this, not a clean `apply` exit code, as
   the proof that alerting actually works.
 - `slack-apply`, `slack-verify`, and `slack-test` are separately live-gated
-  and require `SLACK_ALERTS_WEBHOOK_URL`. The test sends a real Grafana Slack
-  notification; record only its success status and timestamp, never the URL.
+  and require `SLACK_ALERTS_WEBHOOK_URL` before any provider request.
+  `slack-verify` throws on missing, duplicate, or drifted receiver/route state;
+  it does not report partial boolean success. The test sends a real Grafana
+  Slack notification; record only its success status and timestamp, never the
+  URL.
 - Admin credential: a dedicated ADMIN-role service-account token for this
   workspace only, minted via `aws grafana create-workspace-service-account`
   (role `ADMIN`) + `create-workspace-service-account-token`, stored at

--- a/guides/operating/production-alerts.md
+++ b/guides/operating/production-alerts.md
@@ -298,12 +298,14 @@ Discovered live 2026-08-21 (Lane A3), not previously documented:
    edit the route. `ensureContactRouting` in the bootstrap script does exactly
    this and is idempotent.
 
-   This is an intentionally different delivery design from the OLD
-   workspace's Slack routing (`slack-ops-alerts` / `slack-eng-triage`)
-   documented earlier in this runbook — that design predates the D2 revision.
-   If the new workspace should also route to Slack, that is a separate,
-   reviewed change to `production-alerts-rebuild.json`'s `notificationPolicy`
-   / `contactPoint` blocks.
+   Slack is an optional, separately gated additive path. Its webhook is read
+   only from `SLACK_ALERTS_WEBHOOK_URL` in the protected local observability
+   environment file; it is never checked in. The Slack operation creates a
+   new `grafana-rebuild-slack` receiver and prepends an all-alert child route
+   with `continue: true`. The root `grafana-default-sns` receiver and its
+   existing child route stay untouched, so SNS/email delivery continues beside
+   Slack. The operation refuses a changed root receiver or a drifted Slack
+   route instead of overwriting either.
 
 ### Repository artifacts
 
@@ -319,6 +321,9 @@ scripts/ops/grafana-rebuild-bootstrap.mjs                            # check / a
 node scripts/ops/grafana-rebuild-bootstrap.mjs check
 GRAFANA_ALERTING_LIVE=1 node scripts/ops/grafana-rebuild-bootstrap.mjs apply
 GRAFANA_ALERTING_LIVE=1 node scripts/ops/grafana-rebuild-bootstrap.mjs verify
+GRAFANA_ALERTING_LIVE=1 node scripts/ops/grafana-rebuild-bootstrap.mjs slack-apply
+GRAFANA_ALERTING_LIVE=1 node scripts/ops/grafana-rebuild-bootstrap.mjs slack-verify
+GRAFANA_ALERTING_LIVE=1 node scripts/ops/grafana-rebuild-bootstrap.mjs slack-test
 ```
 
 - `check` is offline: validates the rule set still matches the shared
@@ -339,6 +344,9 @@ GRAFANA_ALERTING_LIVE=1 node scripts/ops/grafana-rebuild-bootstrap.mjs verify
   checksum, confirms the root route receiver and the SNS topic wiring, and
   confirms the dashboard exists. Use this, not a clean `apply` exit code, as
   the proof that alerting actually works.
+- `slack-apply`, `slack-verify`, and `slack-test` are separately live-gated
+  and require `SLACK_ALERTS_WEBHOOK_URL`. The test sends a real Grafana Slack
+  notification; record only its success status and timestamp, never the URL.
 - Admin credential: a dedicated ADMIN-role service-account token for this
   workspace only, minted via `aws grafana create-workspace-service-account`
   (role `ADMIN`) + `create-workspace-service-account-token`, stored at

--- a/scripts/ops/grafana-rebuild-bootstrap.mjs
+++ b/scripts/ops/grafana-rebuild-bootstrap.mjs
@@ -71,6 +71,8 @@ export const ADMIN_TOKEN_PATH = path.join(
   ".proliferate-local/ops/grafana-admin-rebuild.token",
 );
 
+const SLACK_WEBHOOK_ENV = "SLACK_ALERTS_WEBHOOK_URL";
+
 function safeLog(...parts) {
   console.log(parts.map((p) => redact(String(p))).join(" "));
 }
@@ -167,6 +169,12 @@ export function validateOverlayDocument(overlay) {
   if (!/^arn:aws:sns:/.test(overlay.contactPoint?.settings?.topic || "")) {
     throw new Error("Overlay contactPoint.settings.topic must be a real SNS topic ARN, not the AMG placeholder");
   }
+  if (overlay.slackContactPoint?.name !== "grafana-rebuild-slack" || overlay.slackContactPoint?.type !== "slack") {
+    throw new Error("Overlay must define the fixed Grafana rebuild Slack contact point");
+  }
+  if (overlay.slackContactPoint?.webhookEnvironmentVariable !== SLACK_WEBHOOK_ENV) {
+    throw new Error(`Overlay Slack webhook must be supplied only by ${SLACK_WEBHOOK_ENV}`);
+  }
   return true;
 }
 
@@ -251,6 +259,9 @@ export function createClient({ fetchImpl = fetch, tokenProvider } = {}) {
     createAlertRule: (body) => request("POST", "/api/v1/provisioning/alert-rules", body),
     getAlertmanagerConfig: () => request("GET", "/api/alertmanager/grafana/config/api/v1/alerts"),
     postAlertmanagerConfig: (body) => request("POST", "/api/alertmanager/grafana/config/api/v1/alerts", body),
+    listContactPoints: () => request("GET", "/api/v1/provisioning/contact-points"),
+    createContactPoint: (body) => request("POST", "/api/v1/provisioning/contact-points", body),
+    testReceiver: (body) => request("POST", "/api/alertmanager/grafana/config/api/v1/receivers/test", body),
     getDashboard: (uid) => request("GET", `/api/dashboards/uid/${encodeURIComponent(uid)}`),
     createDashboard: (body) => request("POST", "/api/dashboards/db", body),
   };
@@ -364,6 +375,136 @@ export async function ensureContactRouting(client, overlay) {
   return "repointed";
 }
 
+function slackWebhook(env = process.env) {
+  const webhook = env[SLACK_WEBHOOK_ENV];
+  if (!webhook) {
+    throw new Error(`${SLACK_WEBHOOK_ENV} must be present for a live Slack operation`);
+  }
+  let url;
+  try {
+    url = new URL(webhook);
+  } catch {
+    throw new Error(`${SLACK_WEBHOOK_ENV} must be a valid Slack incoming-webhook URL`);
+  }
+  if (url.protocol !== "https:" || url.hostname !== "hooks.slack.com" || !url.pathname.startsWith("/services/")) {
+    throw new Error(`${SLACK_WEBHOOK_ENV} must be an https://hooks.slack.com/services/... URL`);
+  }
+  return webhook;
+}
+
+function slackPayload(overlay, webhook, uid) {
+  return {
+    ...(uid ? { uid } : {}),
+    name: overlay.slackContactPoint.name,
+    type: "slack",
+    disableResolveMessage: false,
+    settings: {
+      title: "{{ template \"slack.default.title\" . }}",
+      text: "{{ template \"slack.default.text\" . }}",
+    },
+    secureSettings: { url: webhook },
+  };
+}
+
+function findSlackContact(points, overlay) {
+  const matches = (points || []).filter((point) => point.name === overlay.slackContactPoint.name);
+  if (matches.length > 1) {
+    throw new Error(`Found multiple contact points named ${overlay.slackContactPoint.name}`);
+  }
+  const contact = matches[0];
+  if (contact && contact.type !== "slack") {
+    throw new Error(`Slack contact point exists with unexpected type ${contact.type}`);
+  }
+  return contact || null;
+}
+
+// Add a child route only. The root receiver remains the existing SNS receiver;
+// continue=true lets its existing child branch notify SNS/email too.
+export async function ensureSlackContactAndRoute(client, overlay, { env = process.env } = {}) {
+  const webhook = slackWebhook(env);
+  let contact = findSlackContact((await client.listContactPoints()).body, overlay);
+  let contactPoint = "present";
+  if (!contact) {
+    await client.createContactPoint(slackPayload(overlay, webhook));
+    contact = findSlackContact((await client.listContactPoints()).body, overlay);
+    if (!contact?.uid) {
+      throw new Error("Post-write verification failed: Slack contact point is missing");
+    }
+    contactPoint = "created";
+  }
+  if (!contact.uid) {
+    throw new Error("Slack contact point is missing its Grafana uid");
+  }
+
+  const before = await client.getAlertmanagerConfig();
+  const am = before.body.alertmanager_config;
+  if (am.route?.receiver !== overlay.notificationPolicy.receiver) {
+    throw new Error("Root route receiver changed; refusing to alter the default SNS route");
+  }
+  const receiver = (am.receivers || []).find((entry) => entry.name === overlay.slackContactPoint.name);
+  if (!receiver?.grafana_managed_receiver_configs?.some((entry) => entry.type === "slack")) {
+    throw new Error("Slack contact point is absent from the live alertmanager receiver list");
+  }
+  const expected = { receiver: overlay.slackContactPoint.name, continue: true };
+  const matches = (am.route.routes || []).filter((route) => route.receiver === overlay.slackContactPoint.name);
+  if (matches.length > 1 || (matches.length === 1 && JSON.stringify(matches[0]) !== JSON.stringify(expected))) {
+    throw new Error("Live Slack route is ambiguous or drifted; refusing to overwrite it");
+  }
+  if (matches.length === 1) {
+    return { contactPoint, route: "present", uid: contact.uid };
+  }
+  const next = JSON.parse(JSON.stringify(before.body));
+  next.alertmanager_config.route.routes = [expected, ...(next.alertmanager_config.route.routes || [])];
+  await client.postAlertmanagerConfig(next);
+  const after = await client.getAlertmanagerConfig();
+  if (after.body.alertmanager_config.route?.receiver !== overlay.notificationPolicy.receiver) {
+    throw new Error("Post-write verification failed: default SNS root receiver changed");
+  }
+  if (JSON.stringify(after.body.alertmanager_config.route?.routes?.[0]) !== JSON.stringify(expected)) {
+    throw new Error("Post-write verification failed: additive Slack child route did not stick");
+  }
+  return { contactPoint, route: "created", uid: contact.uid };
+}
+
+export async function runSlackApply({ client, repoRoot = REPO_ROOT, env = process.env } = {}) {
+  const overlay = loadOverlay(repoRoot);
+  validateOverlayDocument(overlay);
+  return ensureSlackContactAndRoute(client, overlay, { env });
+}
+
+export async function runSlackVerify({ client, repoRoot = REPO_ROOT } = {}) {
+  const overlay = loadOverlay(repoRoot);
+  validateOverlayDocument(overlay);
+  const contact = findSlackContact((await client.listContactPoints()).body, overlay);
+  const config = await client.getAlertmanagerConfig();
+  const expected = { receiver: overlay.slackContactPoint.name, continue: true };
+  const route = (config.body.alertmanager_config.route?.routes || []).find(
+    (entry) => entry.receiver === overlay.slackContactPoint.name,
+  );
+  return {
+    defaultSnsRoutePreserved: config.body.alertmanager_config.route?.receiver === overlay.notificationPolicy.receiver,
+    slackContactPresent: Boolean(contact?.uid),
+    additiveSlackRoutePresent: JSON.stringify(route) === JSON.stringify(expected),
+  };
+}
+
+export async function runSlackTest({ client, repoRoot = REPO_ROOT, env = process.env } = {}) {
+  const overlay = loadOverlay(repoRoot);
+  validateOverlayDocument(overlay);
+  const contact = findSlackContact((await client.listContactPoints()).body, overlay);
+  if (!contact?.uid) {
+    throw new Error("Slack contact point is missing; run slack-apply first");
+  }
+  const result = await client.testReceiver({
+    receivers: [{ name: overlay.slackContactPoint.name, grafana_managed_receiver_configs: [slackPayload(overlay, slackWebhook(env), contact.uid)] }],
+  });
+  const configs = result.body?.receivers?.[0]?.grafana_managed_receiver_configs || result.body?.receivers?.[0]?.configs || [];
+  if (!configs.some((config) => config.uid === contact.uid && config.status === "ok")) {
+    throw new Error("Grafana Slack test delivery did not report status ok");
+  }
+  return { delivery: "ok" };
+}
+
 export async function ensureDashboard(client, overlay, dashboard) {
   const existing = await client.getDashboard(overlay.dashboard.uid);
   if (existing.status === 404) {
@@ -446,8 +587,24 @@ async function main() {
       printBoundedReadback(result);
       return;
     }
+    case "slack-apply": {
+      assertLiveAllowed();
+      const result = await runSlackApply({ client: buildLiveClient() });
+      safeLog("Slack apply:", JSON.stringify({ contactPoint: result.contactPoint, route: result.route }));
+      return;
+    }
+    case "slack-verify": {
+      assertLiveAllowed();
+      safeLog("Slack verify:", JSON.stringify(await runSlackVerify({ client: buildLiveClient() })));
+      return;
+    }
+    case "slack-test": {
+      assertLiveAllowed();
+      safeLog("Slack test:", JSON.stringify(await runSlackTest({ client: buildLiveClient() })));
+      return;
+    }
     default:
-      throw new Error("Usage: grafana-rebuild-bootstrap.mjs <check|apply|verify>");
+      throw new Error("Usage: grafana-rebuild-bootstrap.mjs <check|apply|verify|slack-apply|slack-verify|slack-test>");
   }
 }
 

--- a/scripts/ops/grafana-rebuild-bootstrap.mjs
+++ b/scripts/ops/grafana-rebuild-bootstrap.mjs
@@ -31,6 +31,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { isDeepStrictEqual } from "node:util";
 
 import {
   KNOWN_RULES,
@@ -261,6 +262,7 @@ export function createClient({ fetchImpl = fetch, tokenProvider } = {}) {
     postAlertmanagerConfig: (body) => request("POST", "/api/alertmanager/grafana/config/api/v1/alerts", body),
     listContactPoints: () => request("GET", "/api/v1/provisioning/contact-points"),
     createContactPoint: (body) => request("POST", "/api/v1/provisioning/contact-points", body),
+    updateContactPoint: (uid, body) => request("PUT", `/api/v1/provisioning/contact-points/${encodeURIComponent(uid)}`, body),
     testReceiver: (body) => request("POST", "/api/alertmanager/grafana/config/api/v1/receivers/test", body),
     getDashboard: (uid) => request("GET", `/api/dashboards/uid/${encodeURIComponent(uid)}`),
     createDashboard: (body) => request("POST", "/api/dashboards/db", body),
@@ -399,10 +401,10 @@ function slackPayload(overlay, webhook, uid) {
     type: "slack",
     disableResolveMessage: false,
     settings: {
+      url: webhook,
       title: "{{ template \"slack.default.title\" . }}",
       text: "{{ template \"slack.default.text\" . }}",
     },
-    secureSettings: { url: webhook },
   };
 }
 
@@ -418,88 +420,169 @@ function findSlackContact(points, overlay) {
   return contact || null;
 }
 
-// Add a child route only. The root receiver remains the existing SNS receiver;
-// continue=true lets its existing child branch notify SNS/email too.
-export async function ensureSlackContactAndRoute(client, overlay, { env = process.env } = {}) {
-  const webhook = slackWebhook(env);
-  let contact = findSlackContact((await client.listContactPoints()).body, overlay);
-  let contactPoint = "present";
-  if (!contact) {
-    await client.createContactPoint(slackPayload(overlay, webhook));
-    contact = findSlackContact((await client.listContactPoints()).body, overlay);
-    if (!contact?.uid) {
-      throw new Error("Post-write verification failed: Slack contact point is missing");
-    }
-    contactPoint = "created";
-  }
-  if (!contact.uid) {
-    throw new Error("Slack contact point is missing its Grafana uid");
-  }
+function isMatcherlessRoute(route) {
+  const arrays = [route.matchers, route.object_matchers];
+  const objects = [route.match, route.match_re];
+  return arrays.every((value) => value == null || (Array.isArray(value) && value.length === 0)) &&
+    objects.every(
+      (value) => value == null || (typeof value === "object" && !Array.isArray(value) && Object.keys(value).length === 0),
+    );
+}
 
-  const before = await client.getAlertmanagerConfig();
-  const am = before.body.alertmanager_config;
-  if (am.route?.receiver !== overlay.notificationPolicy.receiver) {
+function isExpectedSlackRoute(route, overlay) {
+  return route?.receiver === overlay.slackContactPoint.name &&
+    route.continue === true &&
+    isMatcherlessRoute(route) &&
+    (route.routes == null || (Array.isArray(route.routes) && route.routes.length === 0));
+}
+
+function captureSnsBaseline(config, overlay) {
+  const am = config?.alertmanager_config;
+  if (am?.route?.receiver !== overlay.notificationPolicy.receiver) {
     throw new Error("Root route receiver changed; refusing to alter the default SNS route");
   }
-  const receiver = (am.receivers || []).find((entry) => entry.name === overlay.slackContactPoint.name);
-  if (!receiver?.grafana_managed_receiver_configs?.some((entry) => entry.type === "slack")) {
-    throw new Error("Slack contact point is absent from the live alertmanager receiver list");
+  const receivers = (am.receivers || []).filter((entry) => entry.name === overlay.contactPoint.name);
+  if (receivers.length !== 1) {
+    throw new Error("Default SNS receiver is missing or ambiguous");
   }
-  const expected = { receiver: overlay.slackContactPoint.name, continue: true };
-  const matches = (am.route.routes || []).filter((route) => route.receiver === overlay.slackContactPoint.name);
-  if (matches.length > 1 || (matches.length === 1 && JSON.stringify(matches[0]) !== JSON.stringify(expected))) {
+  const snsConfigs = (receivers[0].grafana_managed_receiver_configs || []).filter((entry) => entry.type === "sns");
+  if (snsConfigs.length !== 1 || snsConfigs[0].settings?.topic !== overlay.contactPoint.settings.topic) {
+    throw new Error("Default SNS receiver configuration is missing or drifted");
+  }
+  const nonSlackRoutes = (am.route.routes || []).filter(
+    (route) => route.receiver !== overlay.slackContactPoint.name,
+  );
+  if (!nonSlackRoutes.some(
+    (route) => route.receiver === overlay.notificationPolicy.receiver && isMatcherlessRoute(route),
+  )) {
+    throw new Error("Default SNS matcherless child route is missing; additive Slack fan-out is not safe");
+  }
+  return {
+    receiver: structuredClone(receivers[0]),
+    childRoutes: structuredClone(nonSlackRoutes),
+  };
+}
+
+function assertSnsBaselinePreserved(config, baseline, overlay) {
+  const current = captureSnsBaseline(config, overlay);
+  if (!isDeepStrictEqual(current.receiver, baseline.receiver)) {
+    throw new Error("Default SNS receiver/config changed during Slack reconciliation");
+  }
+  if (!isDeepStrictEqual(current.childRoutes, baseline.childRoutes)) {
+    throw new Error("A pre-existing non-Slack child route changed during Slack reconciliation");
+  }
+}
+
+function assertSlackReceiverAndRoute(config, contact, overlay) {
+  const am = config?.alertmanager_config;
+  const receivers = (am?.receivers || []).filter((entry) => entry.name === overlay.slackContactPoint.name);
+  if (receivers.length !== 1) {
+    throw new Error("Slack alertmanager receiver is missing or ambiguous");
+  }
+  const configs = (receivers[0].grafana_managed_receiver_configs || []).filter((entry) => entry.type === "slack");
+  if (configs.length !== 1 || configs[0].uid !== contact.uid) {
+    throw new Error("Slack alertmanager receiver configuration is missing or drifted");
+  }
+  const routes = (am?.route?.routes || []).filter((route) => route.receiver === overlay.slackContactPoint.name);
+  if (routes.length !== 1 || !isExpectedSlackRoute(routes[0], overlay)) {
+    throw new Error("Slack child route is missing, ambiguous, or drifted");
+  }
+}
+
+// Add one child route only after proving that a later matcherless SNS child
+// already exists. The root receiver and every pre-existing non-Slack child
+// route are snapshotted and compared after each write.
+export async function ensureSlackContactAndRoute(client, overlay, { env = process.env } = {}) {
+  const webhook = slackWebhook(env);
+  const before = await client.getAlertmanagerConfig();
+  const snsBaseline = captureSnsBaseline(before.body, overlay);
+  let contact = findSlackContact((await client.listContactPoints()).body, overlay);
+  let contactPoint;
+  if (!contact) {
+    await client.createContactPoint(slackPayload(overlay, webhook));
+    contactPoint = "created";
+  } else {
+    if (!contact.uid) {
+      throw new Error("Slack contact point is missing its Grafana uid");
+    }
+    await client.updateContactPoint(contact.uid, slackPayload(overlay, webhook, contact.uid));
+    contactPoint = "updated";
+  }
+  contact = findSlackContact((await client.listContactPoints()).body, overlay);
+  if (!contact?.uid) {
+    throw new Error("Post-write verification failed: Slack contact point is missing");
+  }
+
+  const afterContact = await client.getAlertmanagerConfig();
+  assertSnsBaselinePreserved(afterContact.body, snsBaseline, overlay);
+  const am = afterContact.body.alertmanager_config;
+  const matchingRoutes = (am.route.routes || []).filter(
+    (route) => route.receiver === overlay.slackContactPoint.name,
+  );
+  if (matchingRoutes.length > 1 || (matchingRoutes.length === 1 && !isExpectedSlackRoute(matchingRoutes[0], overlay))) {
     throw new Error("Live Slack route is ambiguous or drifted; refusing to overwrite it");
   }
-  if (matches.length === 1) {
+  const slackReceivers = (am.receivers || []).filter((entry) => entry.name === overlay.slackContactPoint.name);
+  const slackConfigs = slackReceivers[0]?.grafana_managed_receiver_configs?.filter((entry) => entry.type === "slack") || [];
+  if (slackReceivers.length !== 1 || slackConfigs.length !== 1 || slackConfigs[0].uid !== contact.uid) {
+    throw new Error("Slack alertmanager receiver configuration is missing or drifted");
+  }
+  if (matchingRoutes.length === 1) {
+    assertSlackReceiverAndRoute(afterContact.body, contact, overlay);
     return { contactPoint, route: "present", uid: contact.uid };
   }
-  const next = JSON.parse(JSON.stringify(before.body));
+
+  const expected = { receiver: overlay.slackContactPoint.name, continue: true };
+  const next = structuredClone(afterContact.body);
   next.alertmanager_config.route.routes = [expected, ...(next.alertmanager_config.route.routes || [])];
   await client.postAlertmanagerConfig(next);
-  const after = await client.getAlertmanagerConfig();
-  if (after.body.alertmanager_config.route?.receiver !== overlay.notificationPolicy.receiver) {
-    throw new Error("Post-write verification failed: default SNS root receiver changed");
-  }
-  if (JSON.stringify(after.body.alertmanager_config.route?.routes?.[0]) !== JSON.stringify(expected)) {
-    throw new Error("Post-write verification failed: additive Slack child route did not stick");
-  }
+  const afterRoute = await client.getAlertmanagerConfig();
+  assertSnsBaselinePreserved(afterRoute.body, snsBaseline, overlay);
+  assertSlackReceiverAndRoute(afterRoute.body, contact, overlay);
   return { contactPoint, route: "created", uid: contact.uid };
 }
 
 export async function runSlackApply({ client, repoRoot = REPO_ROOT, env = process.env } = {}) {
   const overlay = loadOverlay(repoRoot);
   validateOverlayDocument(overlay);
+  slackWebhook(env);
   return ensureSlackContactAndRoute(client, overlay, { env });
 }
 
-export async function runSlackVerify({ client, repoRoot = REPO_ROOT } = {}) {
+export async function runSlackVerify({ client, repoRoot = REPO_ROOT, env = process.env } = {}) {
   const overlay = loadOverlay(repoRoot);
   validateOverlayDocument(overlay);
+  slackWebhook(env);
   const contact = findSlackContact((await client.listContactPoints()).body, overlay);
+  if (!contact?.uid) {
+    throw new Error("Slack contact point is missing its Grafana uid");
+  }
   const config = await client.getAlertmanagerConfig();
-  const expected = { receiver: overlay.slackContactPoint.name, continue: true };
-  const route = (config.body.alertmanager_config.route?.routes || []).find(
-    (entry) => entry.receiver === overlay.slackContactPoint.name,
-  );
-  return {
-    defaultSnsRoutePreserved: config.body.alertmanager_config.route?.receiver === overlay.notificationPolicy.receiver,
-    slackContactPresent: Boolean(contact?.uid),
-    additiveSlackRoutePresent: JSON.stringify(route) === JSON.stringify(expected),
-  };
+  captureSnsBaseline(config.body, overlay);
+  assertSlackReceiverAndRoute(config.body, contact, overlay);
+  return { status: "verified" };
 }
 
 export async function runSlackTest({ client, repoRoot = REPO_ROOT, env = process.env } = {}) {
   const overlay = loadOverlay(repoRoot);
   validateOverlayDocument(overlay);
+  const webhook = slackWebhook(env);
   const contact = findSlackContact((await client.listContactPoints()).body, overlay);
   if (!contact?.uid) {
     throw new Error("Slack contact point is missing; run slack-apply first");
   }
+  const config = await client.getAlertmanagerConfig();
+  captureSnsBaseline(config.body, overlay);
+  assertSlackReceiverAndRoute(config.body, contact, overlay);
   const result = await client.testReceiver({
-    receivers: [{ name: overlay.slackContactPoint.name, grafana_managed_receiver_configs: [slackPayload(overlay, slackWebhook(env), contact.uid)] }],
+    receivers: [{
+      name: overlay.slackContactPoint.name,
+      grafana_managed_receiver_configs: [slackPayload(overlay, webhook, contact.uid)],
+    }],
   });
-  const configs = result.body?.receivers?.[0]?.grafana_managed_receiver_configs || result.body?.receivers?.[0]?.configs || [];
-  if (!configs.some((config) => config.uid === contact.uid && config.status === "ok")) {
+  const configs = result.body?.receivers?.[0]?.grafana_managed_receiver_configs ||
+    result.body?.receivers?.[0]?.configs || [];
+  if (!configs.some((entry) => entry.uid === contact.uid && entry.status === "ok")) {
     throw new Error("Grafana Slack test delivery did not report status ok");
   }
   return { delivery: "ok" };

--- a/scripts/ops/grafana-rebuild-bootstrap.test.mjs
+++ b/scripts/ops/grafana-rebuild-bootstrap.test.mjs
@@ -19,6 +19,9 @@ import {
   ensureDashboard,
   runApply,
   runVerify,
+  runSlackApply,
+  runSlackVerify,
+  runSlackTest,
 } from "./grafana-rebuild-bootstrap.mjs";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "..", "..");
@@ -330,4 +333,59 @@ test("this tool's fixed target is the new workspace, never the OLD workspace", (
   assert.equal(NEW_TARGET.grafanaWorkspaceId, "g-48655e6419");
   assert.equal(NEW_TARGET.grafanaWorkspaceName, "proliferate-ops-rebuild");
   assert.equal(WORKSPACE_BASE_URL, "https://g-48655e6419.grafana-workspace.us-east-1.amazonaws.com");
+});
+
+test("Slack receiver is additive, preserves the SNS root route, and proves a test delivery", async () => {
+  const overlay = baseOverlay();
+  const originalRoutes = [{ receiver: overlay.notificationPolicy.receiver, routes: [{ receiver: overlay.notificationPolicy.receiver }] }];
+  const state = {
+    contacts: [],
+    am: {
+      alertmanager_config: {
+        route: { receiver: overlay.notificationPolicy.receiver, routes: structuredClone(originalRoutes) },
+        receivers: [{ name: overlay.contactPoint.name, grafana_managed_receiver_configs: [{ type: "sns" }] }],
+      },
+    },
+  };
+  const client = {
+    listContactPoints: async () => ({ status: 200, body: structuredClone(state.contacts) }),
+    createContactPoint: async (body) => {
+      state.contacts.push({ name: body.name, type: body.type, uid: "slack-uid" });
+      state.am.alertmanager_config.receivers.push({
+        name: body.name,
+        grafana_managed_receiver_configs: [{ type: body.type, uid: "slack-uid" }],
+      });
+      return { status: 201, body: {} };
+    },
+    getAlertmanagerConfig: async () => ({ status: 200, body: structuredClone(state.am) }),
+    postAlertmanagerConfig: async (body) => {
+      state.am = structuredClone(body);
+      return { status: 202, body: {} };
+    },
+    testReceiver: async (body) => ({
+      status: 200,
+      body: { receivers: [{ configs: [{ uid: body.receivers[0].grafana_managed_receiver_configs[0].uid, status: "ok" }] }] },
+    }),
+  };
+  const env = { SLACK_ALERTS_WEBHOOK_URL: "https://hooks.slack.com/services/test/unit/webhook" };
+
+  const applied = await runSlackApply({ client, repoRoot: REPO_ROOT, env });
+  assert.deepEqual(applied, { contactPoint: "created", route: "created", uid: "slack-uid" });
+  assert.equal(state.am.alertmanager_config.route.receiver, overlay.notificationPolicy.receiver);
+  assert.deepEqual(state.am.alertmanager_config.route.routes.slice(1), originalRoutes);
+  assert.deepEqual(state.am.alertmanager_config.route.routes[0], { receiver: overlay.slackContactPoint.name, continue: true });
+
+  assert.deepEqual(await runSlackVerify({ client, repoRoot: REPO_ROOT }), {
+    defaultSnsRoutePreserved: true,
+    slackContactPresent: true,
+    additiveSlackRoutePresent: true,
+  });
+  assert.deepEqual(await runSlackTest({ client, repoRoot: REPO_ROOT, env }), { delivery: "ok" });
+});
+
+test("Slack apply refuses to operate without the protected webhook environment variable", async () => {
+  await assert.rejects(
+    runSlackApply({ client: {}, repoRoot: REPO_ROOT, env: {} }),
+    /SLACK_ALERTS_WEBHOOK_URL must be present/,
+  );
 });

--- a/scripts/ops/grafana-rebuild-bootstrap.test.mjs
+++ b/scripts/ops/grafana-rebuild-bootstrap.test.mjs
@@ -335,57 +335,217 @@ test("this tool's fixed target is the new workspace, never the OLD workspace", (
   assert.equal(WORKSPACE_BASE_URL, "https://g-48655e6419.grafana-workspace.us-east-1.amazonaws.com");
 });
 
-test("Slack receiver is additive, preserves the SNS root route, and proves a test delivery", async () => {
+const TEST_SLACK_ENV = {
+  SLACK_ALERTS_WEBHOOK_URL: "https://hooks.slack.com/services/synthetic/test/value",
+};
+
+function slackWorkspace({ dropSnsReceiverOnRouteWrite = false, dropExistingRoutesOnRouteWrite = false } = {}) {
   const overlay = baseOverlay();
-  const originalRoutes = [{ receiver: overlay.notificationPolicy.receiver, routes: [{ receiver: overlay.notificationPolicy.receiver }] }];
+  const originalRoutes = [
+    {
+      receiver: overlay.notificationPolicy.receiver,
+      routes: [{ receiver: overlay.notificationPolicy.receiver, group_by: ["grafana_folder", "alertname"] }],
+    },
+    { receiver: "pre-existing-triage", matchers: [["severity", "=", "warning"]], continue: true },
+  ];
+  const snsReceiver = {
+    name: overlay.contactPoint.name,
+    grafana_managed_receiver_configs: [{
+      type: "sns",
+      uid: "sns-uid",
+      settings: structuredClone(overlay.contactPoint.settings),
+    }],
+  };
   const state = {
     contacts: [],
+    calls: [],
+    createPayload: null,
+    updatePayload: null,
+    testPayload: null,
     am: {
       alertmanager_config: {
         route: { receiver: overlay.notificationPolicy.receiver, routes: structuredClone(originalRoutes) },
-        receivers: [{ name: overlay.contactPoint.name, grafana_managed_receiver_configs: [{ type: "sns" }] }],
+        receivers: [structuredClone(snsReceiver)],
       },
     },
   };
   const client = {
-    listContactPoints: async () => ({ status: 200, body: structuredClone(state.contacts) }),
+    listContactPoints: async () => {
+      state.calls.push("listContactPoints");
+      return { status: 200, body: structuredClone(state.contacts) };
+    },
     createContactPoint: async (body) => {
+      state.calls.push("createContactPoint");
+      state.createPayload = structuredClone(body);
       state.contacts.push({ name: body.name, type: body.type, uid: "slack-uid" });
       state.am.alertmanager_config.receivers.push({
         name: body.name,
-        grafana_managed_receiver_configs: [{ type: body.type, uid: "slack-uid" }],
+        grafana_managed_receiver_configs: [{ ...structuredClone(body), uid: "slack-uid" }],
       });
       return { status: 201, body: {} };
     },
-    getAlertmanagerConfig: async () => ({ status: 200, body: structuredClone(state.am) }),
-    postAlertmanagerConfig: async (body) => {
-      state.am = structuredClone(body);
+    updateContactPoint: async (uid, body) => {
+      state.calls.push("updateContactPoint");
+      state.updatePayload = structuredClone(body);
+      const receiver = state.am.alertmanager_config.receivers.find((entry) => entry.name === body.name);
+      receiver.grafana_managed_receiver_configs = [{ ...structuredClone(body), uid }];
       return { status: 202, body: {} };
     },
-    testReceiver: async (body) => ({
-      status: 200,
-      body: { receivers: [{ configs: [{ uid: body.receivers[0].grafana_managed_receiver_configs[0].uid, status: "ok" }] }] },
-    }),
+    getAlertmanagerConfig: async () => {
+      state.calls.push("getAlertmanagerConfig");
+      return { status: 200, body: structuredClone(state.am) };
+    },
+    postAlertmanagerConfig: async (body) => {
+      state.calls.push("postAlertmanagerConfig");
+      state.am = structuredClone(body);
+      if (dropSnsReceiverOnRouteWrite) {
+        state.am.alertmanager_config.receivers = state.am.alertmanager_config.receivers.filter(
+          (entry) => entry.name !== overlay.contactPoint.name,
+        );
+      }
+      if (dropExistingRoutesOnRouteWrite) {
+        state.am.alertmanager_config.route.routes = state.am.alertmanager_config.route.routes.slice(0, 1);
+      }
+      return { status: 202, body: {} };
+    },
+    testReceiver: async (body) => {
+      state.calls.push("testReceiver");
+      state.testPayload = structuredClone(body);
+      return {
+        status: 200,
+        body: {
+          receivers: [{
+            configs: [{ uid: body.receivers[0].grafana_managed_receiver_configs[0].uid, status: "ok" }],
+          }],
+        },
+      };
+    },
   };
-  const env = { SLACK_ALERTS_WEBHOOK_URL: "https://hooks.slack.com/services/test/unit/webhook" };
+  return { overlay, originalRoutes, snsReceiver, state, client };
+}
 
-  const applied = await runSlackApply({ client, repoRoot: REPO_ROOT, env });
+test("Slack create/test payloads put the webhook only in settings.url", async () => {
+  const { overlay, state, client } = slackWorkspace();
+  await runSlackApply({ client, repoRoot: REPO_ROOT, env: TEST_SLACK_ENV });
+
+  const expectedContactPayload = {
+    name: overlay.slackContactPoint.name,
+    type: "slack",
+    disableResolveMessage: false,
+    settings: {
+      url: TEST_SLACK_ENV.SLACK_ALERTS_WEBHOOK_URL,
+      title: "{{ template \"slack.default.title\" . }}",
+      text: "{{ template \"slack.default.text\" . }}",
+    },
+  };
+  assert.deepEqual(state.createPayload, expectedContactPayload);
+
+  await runSlackTest({ client, repoRoot: REPO_ROOT, env: TEST_SLACK_ENV });
+  assert.deepEqual(state.testPayload, {
+    receivers: [{
+      name: overlay.slackContactPoint.name,
+      grafana_managed_receiver_configs: [{ uid: "slack-uid", ...expectedContactPayload }],
+    }],
+  });
+});
+
+test("Slack receiver is additive and preserves the exact SNS receiver and every existing route", async () => {
+  const { overlay, originalRoutes, snsReceiver, state, client } = slackWorkspace();
+
+  const applied = await runSlackApply({ client, repoRoot: REPO_ROOT, env: TEST_SLACK_ENV });
   assert.deepEqual(applied, { contactPoint: "created", route: "created", uid: "slack-uid" });
   assert.equal(state.am.alertmanager_config.route.receiver, overlay.notificationPolicy.receiver);
   assert.deepEqual(state.am.alertmanager_config.route.routes.slice(1), originalRoutes);
+  assert.deepEqual(state.am.alertmanager_config.receivers[0], snsReceiver);
   assert.deepEqual(state.am.alertmanager_config.route.routes[0], { receiver: overlay.slackContactPoint.name, continue: true });
 
-  assert.deepEqual(await runSlackVerify({ client, repoRoot: REPO_ROOT }), {
-    defaultSnsRoutePreserved: true,
-    slackContactPresent: true,
-    additiveSlackRoutePresent: true,
+  state.am.alertmanager_config.route.routes[0] = {
+    matchers: [],
+    continue: true,
+    routes: [],
+    receiver: overlay.slackContactPoint.name,
+  };
+  assert.deepEqual(await runSlackVerify({ client, repoRoot: REPO_ROOT, env: TEST_SLACK_ENV }), {
+    status: "verified",
   });
-  assert.deepEqual(await runSlackTest({ client, repoRoot: REPO_ROOT, env }), { delivery: "ok" });
+
+  const reapplied = await runSlackApply({ client, repoRoot: REPO_ROOT, env: TEST_SLACK_ENV });
+  assert.deepEqual(reapplied, { contactPoint: "updated", route: "present", uid: "slack-uid" });
+  assert.equal(state.updatePayload.settings.url, TEST_SLACK_ENV.SLACK_ALERTS_WEBHOOK_URL);
+  assert.equal(Object.hasOwn(state.updatePayload, "secureSettings"), false);
+  assert.deepEqual(state.am.alertmanager_config.route.routes.slice(1), originalRoutes);
+  assert.deepEqual(state.am.alertmanager_config.receivers[0], snsReceiver);
 });
 
-test("Slack apply refuses to operate without the protected webhook environment variable", async () => {
+test("Slack route write fails closed if Grafana loses SNS config or any existing child route", async () => {
+  for (const options of [
+    { dropSnsReceiverOnRouteWrite: true },
+    { dropExistingRoutesOnRouteWrite: true },
+  ]) {
+    const { client } = slackWorkspace(options);
+    await assert.rejects(
+      runSlackApply({ client, repoRoot: REPO_ROOT, env: TEST_SLACK_ENV }),
+      /SNS receiver|non-Slack child route|matcherless child route/,
+    );
+  }
+});
+
+test("Slack commands refuse a missing webhook before any provider call", async () => {
+  for (const run of [runSlackApply, runSlackVerify, runSlackTest]) {
+    const { state, client } = slackWorkspace();
+    await assert.rejects(run({ client, repoRoot: REPO_ROOT, env: {} }), /SLACK_ALERTS_WEBHOOK_URL must be present/);
+    assert.deepEqual(state.calls, []);
+  }
+});
+
+test("Slack verify throws on missing, duplicate, or drifted receiver and route state", async () => {
+  const missing = slackWorkspace();
   await assert.rejects(
-    runSlackApply({ client: {}, repoRoot: REPO_ROOT, env: {} }),
-    /SLACK_ALERTS_WEBHOOK_URL must be present/,
+    runSlackVerify({ client: missing.client, repoRoot: REPO_ROOT, env: TEST_SLACK_ENV }),
+    /contact point is missing/,
+  );
+
+  const duplicateContact = slackWorkspace();
+  await runSlackApply({ client: duplicateContact.client, repoRoot: REPO_ROOT, env: TEST_SLACK_ENV });
+  duplicateContact.state.contacts.push(structuredClone(duplicateContact.state.contacts[0]));
+  await assert.rejects(
+    runSlackVerify({ client: duplicateContact.client, repoRoot: REPO_ROOT, env: TEST_SLACK_ENV }),
+    /multiple contact points/,
+  );
+
+  const driftedRoute = slackWorkspace();
+  await runSlackApply({ client: driftedRoute.client, repoRoot: REPO_ROOT, env: TEST_SLACK_ENV });
+  driftedRoute.state.am.alertmanager_config.route.routes[0].continue = false;
+  await assert.rejects(
+    runSlackVerify({ client: driftedRoute.client, repoRoot: REPO_ROOT, env: TEST_SLACK_ENV }),
+    /route is missing, ambiguous, or drifted/,
+  );
+
+  const duplicateReceiver = slackWorkspace();
+  await runSlackApply({ client: duplicateReceiver.client, repoRoot: REPO_ROOT, env: TEST_SLACK_ENV });
+  duplicateReceiver.state.am.alertmanager_config.receivers.push(
+    structuredClone(duplicateReceiver.state.am.alertmanager_config.receivers.at(-1)),
+  );
+  await assert.rejects(
+    runSlackVerify({ client: duplicateReceiver.client, repoRoot: REPO_ROOT, env: TEST_SLACK_ENV }),
+    /receiver is missing or ambiguous/,
+  );
+
+  const missingReceiver = slackWorkspace();
+  await runSlackApply({ client: missingReceiver.client, repoRoot: REPO_ROOT, env: TEST_SLACK_ENV });
+  missingReceiver.state.am.alertmanager_config.receivers.pop();
+  await assert.rejects(
+    runSlackVerify({ client: missingReceiver.client, repoRoot: REPO_ROOT, env: TEST_SLACK_ENV }),
+    /receiver is missing or ambiguous/,
+  );
+
+  const duplicateRoute = slackWorkspace();
+  await runSlackApply({ client: duplicateRoute.client, repoRoot: REPO_ROOT, env: TEST_SLACK_ENV });
+  duplicateRoute.state.am.alertmanager_config.route.routes.unshift(
+    structuredClone(duplicateRoute.state.am.alertmanager_config.route.routes[0]),
+  );
+  await assert.rejects(
+    runSlackVerify({ client: duplicateRoute.client, repoRoot: REPO_ROOT, env: TEST_SLACK_ENV }),
+    /route is missing, ambiguous, or drifted/,
   );
 });

--- a/server/infra/observability/grafana/production-alerts-rebuild.json
+++ b/server/infra/observability/grafana/production-alerts-rebuild.json
@@ -34,6 +34,11 @@
       "messageFormat": "json"
     }
   },
+  "slackContactPoint": {
+    "name": "grafana-rebuild-slack",
+    "type": "slack",
+    "webhookEnvironmentVariable": "SLACK_ALERTS_WEBHOOK_URL"
+  },
   "dashboard": {
     "uid": "prod-overview",
     "folderUid": "ops-folder",


### PR DESCRIPTION
## Summary

Stages a separately gated Slack delivery path for the rebuild Grafana workspace. It creates or updates the `grafana-rebuild-slack` receiver only when the protected `SLACK_ALERTS_WEBHOOK_URL` is available, then prepends an all-alert child route with `continue: true` only after proving a later matcherless SNS child already exists. The `grafana-default-sns` root receiver, its complete receiver configuration, and every pre-existing non-Slack child route are snapshotted and must survive each write exactly.

No live provider configuration was applied and no Slack delivery was attempted: the webhook variable is absent. `slack-apply`, `slack-verify`, and `slack-test` remain explicit live-gated commands for the later authorized provider step.

## Review repair mapping

- `GRAFANA-SLACK-001`: contact creation, update, and receiver-test payloads now place the synthetic webhook only at `settings.url`; exact payload-shape tests cover create and test without any live value.
- `GRAFANA-SLACK-002`: apply captures the exact SNS receiver/config and every non-Slack child route before writes, requires the matcherless SNS sibling used for fan-out, and fails closed if any baseline state is lost or changed. Tests inject SNS receiver loss and child-route loss.
- `GRAFANA-SLACK-003`: apply, verify, and test validate the webhook before any provider method. A call-recorder test proves zero provider calls for all three commands when absent.
- `GRAFANA-SLACK-004`: verify throws on missing, duplicate, wrong, or drifted contact/receiver/route state and returns only one complete success status. Focused tests cover missing contact and receiver, duplicate contact/receiver/route, and route drift.

## Proof

- `node --check scripts/ops/grafana-rebuild-bootstrap.mjs`
- `node scripts/ops/grafana-rebuild-bootstrap.mjs check`
- `node --test scripts/ops/grafana-rebuild-bootstrap.test.mjs` (26 passing)
- `python3.12 scripts/check_docs.py`
- `python3.12 scripts/check_max_lines.py`
- `git diff --check`

## Observability

This is observability delivery configuration. It adds no product signal and preserves the SNS/email path as the existing default delivery route.

## Frozen re-review scope

Review only the four accepted findings above at head `60f57966b73588fdcfcf6ca2a51be04dd443ae07`. Live apply, live test delivery, provider credentials, merge, and any non-Grafana integration remain out of scope.