### PR TITLE
fix(diagnostics): drop unusable desktop install ids

### DIFF
--- a/anyharness/crates/proliferate-diagnostics-collector/src/state/mod.rs
+++ b/anyharness/crates/proliferate-diagnostics-collector/src/state/mod.rs
@@ -290,6 +290,7 @@ mod install_id_tests {
     #[test]
     fn a_bounded_printable_install_id_is_accepted() {
         assert!(CollectorCore::new(&config(Some("2f6b1c8e-install"))).is_ok());
+        assert!(CollectorCore::new(&config(Some(&"x".repeat(128)))).is_ok());
     }
 
     /// The install id is stamped on every exported record, so an empty,
@@ -298,7 +299,13 @@ mod install_id_tests {
     /// it, because a silently rewritten identity is worse than no identity.
     #[test]
     fn an_empty_oversized_or_unprintable_install_id_is_refused() {
-        for rejected in ["", &"x".repeat(129), "has space", "has\nnewline"] {
+        for rejected in [
+            "",
+            &"x".repeat(129),
+            "has space",
+            "has\nnewline",
+            "non-ascii-é",
+        ] {
             assert!(
                 CollectorCore::new(&config(Some(rejected))).is_err(),
                 "install id {rejected:?} must be refused"

--- a/apps/desktop/src-tauri/src/diagnostics_collector/process.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/process.rs
@@ -176,7 +176,7 @@ impl CollectorProcessLauncher {
         // collector refuses an out-of-range `--install-id` outright, so
         // passing one through would trade a missing attribute for no
         // diagnostics at all.
-        let install_id = install_id.filter(|value| validate_label(value).is_ok());
+        let install_id = install_id.filter(|value| is_valid_install_id(value));
         Ok(Self {
             binary,
             release,
@@ -527,8 +527,8 @@ mod helpers;
 mod owned;
 
 use helpers::{
-    clear_cloexec_raw, drain_stderr, generate_capability, protected_pair, read_descriptor,
-    resolve_binary, supported_target, validate_binary, validate_label,
+    clear_cloexec_raw, drain_stderr, generate_capability, is_valid_install_id, protected_pair,
+    read_descriptor, resolve_binary, supported_target, validate_binary, validate_label,
 };
 #[cfg(test)]
 use owned::typed_shutdown_command;

--- a/apps/desktop/src-tauri/src/diagnostics_collector/process.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/process.rs
@@ -186,7 +186,7 @@ impl CollectorProcessLauncher {
         // collector refuses an out-of-range `--install-id` outright, so
         // passing one through would trade a missing attribute for no
         // diagnostics at all.
-        let install_id = install_id.filter(|value| is_valid_install_id(value));
+        let install_id = retain_valid_install_id(install_id);
         Ok(Self {
             binary,
             release,
@@ -537,8 +537,8 @@ mod helpers;
 mod owned;
 
 use helpers::{
-    clear_cloexec_raw, drain_stderr, generate_capability, is_valid_install_id, protected_pair,
-    read_descriptor, resolve_binary, supported_target, validate_binary, validate_label,
+    clear_cloexec_raw, drain_stderr, generate_capability, protected_pair, read_descriptor,
+    resolve_binary, retain_valid_install_id, supported_target, validate_binary, validate_label,
 };
 #[cfg(test)]
 use owned::typed_shutdown_command;

--- a/apps/desktop/src-tauri/src/diagnostics_collector/process.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/process.rs
@@ -169,6 +169,16 @@ impl CollectorProcessLauncher {
                 "collector binary is missing",
             )
         })?;
+        Self::discover_with_binary(binary, release, environment, install_id, fallback)
+    }
+
+    fn discover_with_binary(
+        binary: PathBuf,
+        release: String,
+        environment: String,
+        install_id: Option<String>,
+        fallback: FallbackDiagnosticsWriter,
+    ) -> Result<Self, CollectorLaunchError> {
         validate_binary(&binary)?;
         validate_label(&release)?;
         validate_label(&environment)?;

--- a/apps/desktop/src-tauri/src/diagnostics_collector/process/helpers.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/process/helpers.rs
@@ -35,8 +35,10 @@ pub(super) fn validate_label(value: &str) -> Result<(), CollectorLaunchError> {
     Ok(())
 }
 
-pub(super) fn is_valid_install_id(value: &str) -> bool {
-    !value.is_empty() && value.len() <= 128 && value.bytes().all(|byte| byte.is_ascii_graphic())
+pub(super) fn retain_valid_install_id(install_id: Option<String>) -> Option<String> {
+    install_id.filter(|value| {
+        !value.is_empty() && value.len() <= 128 && value.bytes().all(|byte| byte.is_ascii_graphic())
+    })
 }
 
 pub(super) fn supported_target(target: &str) -> bool {

--- a/apps/desktop/src-tauri/src/diagnostics_collector/process/helpers.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/process/helpers.rs
@@ -35,6 +35,10 @@ pub(super) fn validate_label(value: &str) -> Result<(), CollectorLaunchError> {
     Ok(())
 }
 
+pub(super) fn is_valid_install_id(value: &str) -> bool {
+    !value.is_empty() && value.len() <= 128 && value.bytes().all(|byte| byte.is_ascii_graphic())
+}
+
 pub(super) fn supported_target(target: &str) -> bool {
     matches!(target, "aarch64-apple-darwin" | "x86_64-apple-darwin")
 }

--- a/apps/desktop/src-tauri/src/diagnostics_collector/process_tests.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/process_tests.rs
@@ -283,17 +283,44 @@ async fn an_install_id_crosses_the_process_seam_to_the_real_collector() {
     std::fs::remove_dir_all(root).expect("cleanup");
 }
 
-/// The production discovery path applies the collector's exact
-/// bounded-graphic-ASCII domain. A bad persisted identity costs only the
-/// attribute, never the collector launch.
 #[test]
-fn discover_accepts_exactly_the_collectors_install_id_domain() {
+fn install_id_filter_accepts_exactly_the_collectors_domain() {
+    assert!(retain_valid_install_id(None).is_none());
+
+    for (install_id, accepted) in install_id_domain_cases() {
+        let retained = retain_valid_install_id(Some(install_id.clone()));
+        assert_eq!(
+            retained.as_deref(),
+            accepted.then_some(install_id.as_str()),
+            "unexpected filter result for install id {install_id:?}"
+        );
+    }
+}
+
+/// On the supported target, the real-binary discovery path delegates persisted
+/// install IDs to the platform-neutral filter before constructing the launcher.
+#[cfg(target_os = "macos")]
+#[test]
+fn discover_drops_an_unusable_persisted_install_id() {
     let root = std::env::temp_dir().join(format!("collector-bad-install-{}", uuid::Uuid::new_v4()));
     let fallback = FallbackDiagnosticsWriter::open_for_test(root.join("desktop-native.log"))
         .expect("fallback");
-    let binary = built_collector_binary();
+    let launcher = CollectorProcessLauncher::discover_with_binary(
+        built_collector_binary(),
+        "desktop-test".to_owned(),
+        "test".to_owned(),
+        Some("has space".to_owned()),
+        fallback.clone(),
+    )
+    .expect("discover real collector");
+    assert!(launcher.install_id.is_none());
 
-    let discovered = [
+    fallback.close().expect("close fallback");
+    std::fs::remove_dir_all(root).expect("cleanup");
+}
+
+fn install_id_domain_cases() -> [(String, bool); 7] {
+    [
         ("install-desktop-test-4b71".to_owned(), true),
         ("x".repeat(128), true),
         (String::new(), false),
@@ -302,28 +329,4 @@ fn discover_accepts_exactly_the_collectors_install_id_domain() {
         ("has\nnewline".to_owned(), false),
         ("non-ascii-é".to_owned(), false),
     ]
-    .into_iter()
-    .map(|(install_id, accepted)| {
-        let result = CollectorProcessLauncher::discover_with_binary(
-            binary.clone(),
-            "desktop-test".to_owned(),
-            "test".to_owned(),
-            Some(install_id.clone()),
-            fallback.clone(),
-        );
-        (install_id, accepted, result)
-    })
-    .collect::<Vec<_>>();
-
-    for (install_id, accepted, result) in discovered {
-        let launcher = result.expect("discover real collector");
-        assert_eq!(
-            launcher.install_id.as_deref(),
-            accepted.then_some(install_id.as_str()),
-            "unexpected discovery result for install id {install_id:?}"
-        );
-    }
-
-    fallback.close().expect("close fallback");
-    std::fs::remove_dir_all(root).expect("cleanup");
 }

--- a/apps/desktop/src-tauri/src/diagnostics_collector/process_tests.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/process_tests.rs
@@ -283,25 +283,52 @@ async fn an_install_id_crosses_the_process_seam_to_the_real_collector() {
     std::fs::remove_dir_all(root).expect("cleanup");
 }
 
-/// Negative control for the filter in `discover`. The collector refuses an
-/// out-of-range `--install-id` at startup rather than sanitizing it, so
-/// passing one through would cost the whole collector, not just the
-/// attribute. `discover` therefore drops an unusable identity instead.
-#[tokio::test]
-async fn an_unusable_install_id_would_cost_the_collector_so_discover_drops_it() {
+/// Discovery applies the collector's exact bounded-graphic-ASCII domain. A bad
+/// persisted identity costs only the attribute, never the collector launch.
+#[cfg(target_os = "macos")]
+#[test]
+fn discover_accepts_exactly_the_collectors_install_id_domain() {
     let root = std::env::temp_dir().join(format!("collector-bad-install-{}", uuid::Uuid::new_v4()));
     let fallback = FallbackDiagnosticsWriter::open_for_test(root.join("desktop-native.log"))
         .expect("fallback");
-    let unusable = "x".repeat(129);
+    let binary = built_collector_binary();
+    let previous_binary = std::env::var_os("PROLIFERATE_DIAGNOSTICS_COLLECTOR_BIN");
+    std::env::set_var("PROLIFERATE_DIAGNOSTICS_COLLECTOR_BIN", &binary);
 
-    let launcher = install_id_launcher(Some(&unusable), &fallback);
-    assert!(
-        launcher.launch().await.is_err(),
-        "the collector must refuse an out-of-range install id"
-    );
+    let discovered = [
+        ("install-desktop-test-4b71".to_owned(), true),
+        ("x".repeat(128), true),
+        (String::new(), false),
+        ("x".repeat(129), false),
+        ("has space".to_owned(), false),
+        ("has\nnewline".to_owned(), false),
+        ("non-ascii-é".to_owned(), false),
+    ]
+    .into_iter()
+    .map(|(install_id, accepted)| {
+        let result = CollectorProcessLauncher::discover(
+            "desktop-test".to_owned(),
+            "test".to_owned(),
+            Some(install_id.clone()),
+            fallback.clone(),
+        );
+        (install_id, accepted, result)
+    })
+    .collect::<Vec<_>>();
 
-    assert!(validate_label(&unusable).is_err());
-    assert!(validate_label("install-desktop-test-4b71").is_ok());
+    match previous_binary {
+        Some(value) => std::env::set_var("PROLIFERATE_DIAGNOSTICS_COLLECTOR_BIN", value),
+        None => std::env::remove_var("PROLIFERATE_DIAGNOSTICS_COLLECTOR_BIN"),
+    }
+
+    for (install_id, accepted, result) in discovered {
+        let launcher = result.expect("discover real collector");
+        assert_eq!(
+            launcher.install_id.as_deref(),
+            accepted.then_some(install_id.as_str()),
+            "unexpected discovery result for install id {install_id:?}"
+        );
+    }
 
     fallback.close().expect("close fallback");
     std::fs::remove_dir_all(root).expect("cleanup");

--- a/apps/desktop/src-tauri/src/diagnostics_collector/process_tests.rs
+++ b/apps/desktop/src-tauri/src/diagnostics_collector/process_tests.rs
@@ -283,17 +283,15 @@ async fn an_install_id_crosses_the_process_seam_to_the_real_collector() {
     std::fs::remove_dir_all(root).expect("cleanup");
 }
 
-/// Discovery applies the collector's exact bounded-graphic-ASCII domain. A bad
-/// persisted identity costs only the attribute, never the collector launch.
-#[cfg(target_os = "macos")]
+/// The production discovery path applies the collector's exact
+/// bounded-graphic-ASCII domain. A bad persisted identity costs only the
+/// attribute, never the collector launch.
 #[test]
 fn discover_accepts_exactly_the_collectors_install_id_domain() {
     let root = std::env::temp_dir().join(format!("collector-bad-install-{}", uuid::Uuid::new_v4()));
     let fallback = FallbackDiagnosticsWriter::open_for_test(root.join("desktop-native.log"))
         .expect("fallback");
     let binary = built_collector_binary();
-    let previous_binary = std::env::var_os("PROLIFERATE_DIAGNOSTICS_COLLECTOR_BIN");
-    std::env::set_var("PROLIFERATE_DIAGNOSTICS_COLLECTOR_BIN", &binary);
 
     let discovered = [
         ("install-desktop-test-4b71".to_owned(), true),
@@ -306,7 +304,8 @@ fn discover_accepts_exactly_the_collectors_install_id_domain() {
     ]
     .into_iter()
     .map(|(install_id, accepted)| {
-        let result = CollectorProcessLauncher::discover(
+        let result = CollectorProcessLauncher::discover_with_binary(
+            binary.clone(),
             "desktop-test".to_owned(),
             "test".to_owned(),
             Some(install_id.clone()),
@@ -315,11 +314,6 @@ fn discover_accepts_exactly_the_collectors_install_id_domain() {
         (install_id, accepted, result)
     })
     .collect::<Vec<_>>();
-
-    match previous_binary {
-        Some(value) => std::env::set_var("PROLIFERATE_DIAGNOSTICS_COLLECTOR_BIN", value),
-        None => std::env::remove_var("PROLIFERATE_DIAGNOSTICS_COLLECTOR_BIN"),
-    }
 
     for (install_id, accepted, result) in discovered {
         let launcher = result.expect("discover real collector");


### PR DESCRIPTION
## Summary

Fixes accepted blocker B-2186-01 from the post-merge review of #2186 and its regression-proof blocker B-2198-01.

Desktop discovery previously reused the release/environment label validator for `desktop_install_id`. That validator permits ASCII spaces, while CollectorCore accepts only 1-128 bytes of ASCII graphic data. A persisted value such as `has space` was therefore forwarded as `--install-id` and could prevent the collector from starting.

This fix gives Desktop an install-id-specific filter matching the collector domain exactly. `CollectorProcessLauncher::discover` delegates to that filter and degrades every other persisted value to `None`, so diagnostics start without the optional resource attribute.

The cross-platform test directly exercises the same production filter with absent, accepted normal and 128-byte boundary values, plus rejected empty, oversized, space-bearing, control-bearing, and non-ASCII values. A separate macOS-gated test runs the real built collector through the binary-validation discovery path and proves that the original space-bearing persisted value is omitted. CollectorCore tests pin the same boundary matrix. Target and binary validation remain unchanged.

## Testing

- `python3.12 scripts/check_max_lines.py` — pass
- `python3.12 scripts/lint_records.py` — pass
- `git diff --check` — pass
- Local Rust build/tests intentionally not run because the machine is under high swap pressure and the task requires remote CI for Rust proof.

Required CI proof:

- `cargo test -p proliferate --lib diagnostics_collector::process`
- `cargo test -p proliferate-diagnostics-collector`

## Observability

The delta is correctness-only: unusable persisted install IDs are omitted before collector launch. Producer ownership, install identity privacy, exporter admission policy, and release gates are unchanged.