### PR TITLE
feat(settings): truthful harness model states and self-curing refresh

### DIFF
--- a/anyharness/sdk/src/types/agents.ts
+++ b/anyharness/sdk/src/types/agents.ts
@@ -63,6 +63,15 @@ export interface HarnessLaunchOptionsResponse {
   probeFailureCode: string | null;
   readiness: AgentReadinessState;
   /**
+   * Whether a manual refresh dispatched at this runtime can run at all: it owns
+   * the probe engine for its runtime home. A runtime that does not answers the
+   * refresh route with 409 `PROBE_ENGINE_NOT_OWNER`, and ownership appears
+   * nowhere else on any wire. Install state is the other precondition and is
+   * reported separately by `readiness`; a surface gating a Refresh control must
+   * respect both.
+   */
+  canManuallyRefresh: boolean;
+  /**
    * Absent when the runtime that served this response cannot know the phase.
    * `detecting` on its own cannot tell a probe that is running apart from one
    * that will never run.

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.absent-payload.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.absent-payload.test.tsx
@@ -2,7 +2,9 @@
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ProliferateClientError } from "@proliferate/cloud-sdk";
 import { HarnessAllModelsSection } from "./HarnessAllModelsSection";
+import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
 
 /**
  * The three ways a launch-options payload can be absent, kept apart.
@@ -31,6 +33,7 @@ const cloudState = vi.hoisted(() => ({
   // 200-with-a-null-body: the account simply has no cloud workspace.
   sandbox: null as Record<string, unknown> | null,
   launchOptions: undefined as Record<string, unknown> | undefined,
+  launchOptionsError: null as Error | null,
 }));
 
 vi.mock("@anyharness/sdk-react", () => ({
@@ -50,12 +53,14 @@ vi.mock("@proliferate/cloud-sdk-react", () => ({
   // The real hook is disabled without a non-empty target, so a null sandbox
   // leaves it pending-and-idle forever.
   useCloudHarnessLaunchOptions: ({ cloudSandboxId }: { cloudSandboxId?: string | null }) => {
-    const data = cloudSandboxId ? cloudState.launchOptions : undefined;
+    const error = cloudSandboxId ? cloudState.launchOptionsError : null;
+    const data = cloudSandboxId && !error ? cloudState.launchOptions : undefined;
     return {
       data,
+      error,
       isLoading: false,
-      isError: false,
-      isPending: data === undefined,
+      isError: error !== null,
+      isPending: data === undefined && error === null,
       fetchStatus: "idle",
       refetch: vi.fn(),
     };
@@ -74,6 +79,9 @@ vi.mock("#product/stores/toast/toast-store", () => ({
 afterEach(cleanup);
 
 beforeEach(() => {
+  // Local default: the runtime is still coming up, which is the fact that
+  // disables the query — not something inferred from the query itself.
+  useHarnessConnectionStore.setState({ connectionState: "connecting" });
   runtimeQuery.data = undefined;
   runtimeQuery.isLoading = false;
   runtimeQuery.isError = false;
@@ -82,6 +90,7 @@ beforeEach(() => {
   runtimeQuery.refetch.mockReset();
   cloudState.sandbox = null;
   cloudState.launchOptions = undefined;
+  cloudState.launchOptionsError = null;
 });
 
 describe("HarnessAllModelsSection — no payload, nothing in flight (round 3)", () => {
@@ -92,7 +101,7 @@ describe("HarnessAllModelsSection — no payload, nothing in flight (round 3)", 
     expect(screen.getByText("· Models load as soon as it's ready.")).toBeTruthy();
     // Nothing failed, so no failure claim and no cure to offer.
     expect(screen.queryByText("Models couldn't be loaded")).toBeNull();
-    expect(screen.queryByText("The runtime didn't respond.")).toBeNull();
+    expect(screen.queryByText("· The runtime didn't respond.")).toBeNull();
     expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
     // Nothing is running, so no spinner either.
     expect(screen.queryByText("Loading models…")).toBeNull();
@@ -111,6 +120,7 @@ describe("HarnessAllModelsSection — no payload, nothing in flight (round 3)", 
     );
     expect(screen.getByText("Connecting to the local runtime")).toBeTruthy();
 
+    useHarnessConnectionStore.setState({ connectionState: "healthy" });
     runtimeQuery.isPending = false;
     runtimeQuery.data = {
       harnessKind: "claude",
@@ -148,6 +158,64 @@ describe("HarnessAllModelsSection — no payload, nothing in flight (round 3)", 
     expect(screen.queryByText("Models couldn't be loaded")).toBeNull();
     expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
     expect(screen.queryByRole("button", { name: /^refresh$/i })).toBeNull();
+  });
+
+  it("E-R22: a runtime that gave up is not reported as still connecting", () => {
+    useHarnessConnectionStore.setState({ connectionState: "failed" });
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
+
+    expect(screen.getByText("The local runtime didn't start")).toBeTruthy();
+    expect(screen.getByText("· Restart Proliferate to try again.")).toBeTruthy();
+    // The promise the old arm could not keep.
+    expect(screen.queryByText("Connecting to the local runtime")).toBeNull();
+    expect(screen.queryByText("· Models load as soon as it's ready.")).toBeNull();
+    // No control that cannot work, but the line still names a real cure.
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    const refresh = screen.getByRole("button", { name: /^refresh$/i }) as HTMLButtonElement;
+    expect(refresh.disabled).toBe(true);
+    expect(refresh.querySelector(".animate-spin")).toBeNull();
+  });
+
+  it("E-R23: an offline-paused read does not spin forever", () => {
+    useHarnessConnectionStore.setState({ connectionState: "healthy" });
+    runtimeQuery.fetchStatus = "paused";
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
+
+    expect(screen.getByText("You're offline")).toBeTruthy();
+    expect(screen.getByText("· Models load when the connection is back.")).toBeTruthy();
+    expect(screen.queryByText("Loading models…")).toBeNull();
+    // The refresh mutation is parked by the same offline gate.
+    expect((screen.getByRole("button", { name: /^refresh$/i }) as HTMLButtonElement).disabled)
+      .toBe(true);
+  });
+
+  it("E-R24: a not-observed 404 is the cloud first-run screen, not a failure", () => {
+    cloudState.sandbox = { id: "sandbox-1" };
+    cloudState.launchOptionsError = new ProliferateClientError(
+      "Harness launch options have not been observed on this target.",
+      404,
+      "harness_launch_options_not_observed",
+    );
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="cloud" />);
+
+    expect(screen.getByText("Models haven't been detected yet")).toBeTruthy();
+    expect(screen.getByText("· Claude reports models after its first run in this workspace."))
+      .toBeTruthy();
+    // The server DID respond, with a structured code.
+    expect(screen.queryByText("Models couldn't be loaded")).toBeNull();
+    expect(screen.queryByText("· The runtime didn't respond.")).toBeNull();
+    // Retrying re-issues the same GET and 404s forever.
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
+  it("E-R24: an unstructured cloud failure still gets the error arm and a Retry", () => {
+    cloudState.sandbox = { id: "sandbox-1" };
+    cloudState.launchOptionsError = new ProliferateClientError("Bad Gateway", 502, null);
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="cloud" />);
+
+    expect(screen.getByText("Models couldn't be loaded")).toBeTruthy();
+    expect(screen.getByText("· Proliferate Cloud didn't respond.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
   });
 
   it("E-R19: neither new arm prints a body that contradicts its own header", () => {

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.absent-payload.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.absent-payload.test.tsx
@@ -7,22 +7,24 @@ import { HarnessAllModelsSection } from "./HarnessAllModelsSection";
 import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
 
 /**
- * The three ways a launch-options payload can be absent, kept apart.
+ * The ways a launch-options payload can be absent, kept apart.
  *
  * `HarnessAllModelsSection.test.tsx` owns the (state x probePhase) matrix,
  * which by definition has a payload. These cases have none, and the whole
  * point of the pane is that "no payload" is not one condition: a request in
- * flight, a query nobody enabled, and a request that failed are three
- * different truths and must render as three different things.
+ * flight, a query nobody enabled, a query with no host to enable it against,
+ * and several distinct ways a request can fail are different truths and must
+ * render as different things. The second describe below carries the cases
+ * where the READ has settled and only the refresh control can still lie.
  *
  * The fakes mirror TanStack v5 exactly: a DISABLED query reports
  * `isPending: true` with `fetchStatus: "idle"`, which is what makes
- * `isPending` alone unusable as an "in flight" signal.
+ * `isPending` alone unusable as an "in flight" signal, and a PARKED mutation
+ * reports `isPending: true` with `isPaused: true` for the same reason.
  */
 
 const runtimeQuery = vi.hoisted(() => ({
   data: undefined as Record<string, unknown> | undefined,
-  isLoading: false,
   isError: false,
   isPending: true,
   fetchStatus: "idle" as "idle" | "fetching",
@@ -32,22 +34,50 @@ const runtimeQuery = vi.hoisted(() => ({
 const cloudState = vi.hoisted(() => ({
   // 200-with-a-null-body: the account simply has no cloud workspace.
   sandbox: null as Record<string, unknown> | null,
+  sandboxError: null as Error | null,
+  sandboxFetchStatus: "idle" as "idle" | "fetching",
   launchOptions: undefined as Record<string, unknown> | undefined,
   launchOptionsError: null as Error | null,
 }));
 
+/** The refresh mutation, whose parked-vs-running distinction is E-R28. */
+const refreshMutation = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  isPending: false,
+  isPaused: false,
+}));
+
+/**
+ * The desktop runtime bridge, or null to stand in for Web. The real
+ * `useLocalRuntimeRestart` runs against this, so "Retry restarts the runtime"
+ * is proven through the production seam rather than a mocked-out hook.
+ */
+const host = vi.hoisted(() => ({
+  desktop: null as { runtime: { restart: () => void } } | null,
+}));
+const restartHarnessRuntime = vi.hoisted(() => vi.fn());
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => host,
+}));
+
+vi.mock("#product/lib/access/anyharness/runtime-bootstrap", () => ({
+  restartHarnessRuntime,
+}));
+
 vi.mock("@anyharness/sdk-react", () => ({
   useAgentLaunchOptionsQuery: () => runtimeQuery,
-  useRefreshHarnessLaunchOptionsMutation: () => ({ mutate: vi.fn(), isPending: false }),
+  useRefreshHarnessLaunchOptionsMutation: () => refreshMutation,
 }));
 
 vi.mock("@proliferate/cloud-sdk-react", () => ({
   useCloudSandbox: () => ({
-    data: cloudState.sandbox,
+    data: cloudState.sandboxError ? undefined : cloudState.sandbox,
+    error: cloudState.sandboxError,
     isLoading: false,
-    isError: false,
+    isError: cloudState.sandboxError !== null,
     isPending: false,
-    fetchStatus: "idle",
+    fetchStatus: cloudState.sandboxFetchStatus,
     refetch: vi.fn(),
   }),
   // The real hook is disabled without a non-empty target, so a null sandbox
@@ -83,14 +113,21 @@ beforeEach(() => {
   // disables the query — not something inferred from the query itself.
   useHarnessConnectionStore.setState({ connectionState: "connecting" });
   runtimeQuery.data = undefined;
-  runtimeQuery.isLoading = false;
   runtimeQuery.isError = false;
   runtimeQuery.isPending = true;
   runtimeQuery.fetchStatus = "idle";
   runtimeQuery.refetch.mockReset();
   cloudState.sandbox = null;
+  cloudState.sandboxError = null;
+  cloudState.sandboxFetchStatus = "idle";
   cloudState.launchOptions = undefined;
   cloudState.launchOptionsError = null;
+  refreshMutation.mutate.mockReset();
+  refreshMutation.isPending = false;
+  refreshMutation.isPaused = false;
+  // Desktop by default: the host that actually has a local runtime.
+  host.desktop = { runtime: { restart: vi.fn() } };
+  restartHarnessRuntime.mockReset();
 });
 
 describe("HarnessAllModelsSection — no payload, nothing in flight (round 3)", () => {
@@ -160,16 +197,40 @@ describe("HarnessAllModelsSection — no payload, nothing in flight (round 3)", 
     expect(screen.queryByRole("button", { name: /^refresh$/i })).toBeNull();
   });
 
-  it("E-R22: a runtime that gave up is not reported as still connecting", () => {
+  it("E-R22/E-R33: a runtime that gave up offers the restart that actually cures it", () => {
     useHarnessConnectionStore.setState({ connectionState: "failed" });
     render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
 
     expect(screen.getByText("The local runtime didn't start")).toBeTruthy();
-    expect(screen.getByText("· Restart Proliferate to try again.")).toBeTruthy();
+    expect(screen.getByText("· Retry restarts the local runtime.")).toBeTruthy();
     // The promise the old arm could not keep.
     expect(screen.queryByText("Connecting to the local runtime")).toBeNull();
     expect(screen.queryByText("· Models load as soon as it's ready.")).toBeNull();
-    // No control that cannot work, but the line still names a real cure.
+    // The old arm told the user to relaunch the whole application. The cheap
+    // cure exists and is wired: clicking Retry restarts the runtime in place.
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(restartHarnessRuntime).toHaveBeenCalledTimes(1);
+    expect(restartHarnessRuntime).toHaveBeenCalledWith(host.desktop?.runtime);
+    // `refresh_now` still cannot reach a runtime that is not up.
+    const refresh = screen.getByRole("button", { name: /^refresh$/i }) as HTMLButtonElement;
+    expect(refresh.disabled).toBe(true);
+    expect(refresh.querySelector(".animate-spin")).toBeNull();
+  });
+
+  it("E-R34: a host with no local runtime says so instead of connecting forever", () => {
+    // Web: no desktop bridge, so nobody ever writes `connectionState` and it
+    // sits at its initial "connecting" for the life of the pane.
+    host.desktop = null;
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
+
+    expect(screen.getByText("Local models aren't available here")).toBeTruthy();
+    expect(screen.getByText("· The local runtime is part of the Proliferate desktop app."))
+      .toBeTruthy();
+    // The lie this replaces: a connection promise nothing can ever keep.
+    expect(screen.queryByText("Connecting to the local runtime")).toBeNull();
+    expect(screen.queryByText("· Models load as soon as it's ready.")).toBeNull();
+    expect(screen.queryByText("Loading models…")).toBeNull();
+    // Terminal, so no control that cannot work and nothing that spins.
     expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
     const refresh = screen.getByRole("button", { name: /^refresh$/i }) as HTMLButtonElement;
     expect(refresh.disabled).toBe(true);
@@ -214,8 +275,61 @@ describe("HarnessAllModelsSection — no payload, nothing in flight (round 3)", 
     render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="cloud" />);
 
     expect(screen.getByText("Models couldn't be loaded")).toBeTruthy();
-    expect(screen.getByText("· Proliferate Cloud didn't respond.")).toBeTruthy();
+    // E-R30: a 502 IS a response. The round-4 line claimed silence here.
+    expect(screen.getByText("· Proliferate Cloud returned an error.")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+  });
+
+  it("E-R30: a stale sandbox id gets the workspace answer, not a silence claim", () => {
+    cloudState.sandbox = { id: "sb-stale" };
+    cloudState.launchOptionsError = new ProliferateClientError(
+      "Cloud sandbox not found.",
+      404,
+      "cloud_sandbox_not_found",
+    );
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="cloud" />);
+
+    // The cloud DID respond, with a structured code the pane can read.
+    expect(screen.queryByText("· Proliferate Cloud didn't respond.")).toBeNull();
+    expect(screen.getByText("No cloud workspace yet")).toBeTruthy();
+    expect(screen.getByText("· Claude models are listed once a cloud workspace exists."))
+      .toBeTruthy();
+    // Unlike the never-had-one arm, re-reading the sandbox can return a
+    // different id, so this one carries a cure.
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+  });
+
+  it("E-R30: an answered error is not silence, and silence is not an answer", () => {
+    cloudState.sandbox = { id: "sandbox-1" };
+    cloudState.launchOptionsError = new ProliferateClientError("Bad Gateway", 502, null);
+    const { unmount } = render(
+      <HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="cloud" />,
+    );
+    expect(screen.getByText("· Proliferate Cloud returned an error.")).toBeTruthy();
+    expect(screen.queryByText("· Proliferate Cloud didn't respond.")).toBeNull();
+    unmount();
+
+    // A rejected fetch carries no status at all: nothing came back, and that
+    // is the one failure where claiming silence is established fact.
+    cloudState.launchOptionsError = new TypeError("Failed to fetch");
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="cloud" />);
+    expect(screen.getByText("· Proliferate Cloud didn't respond.")).toBeTruthy();
+    expect(screen.queryByText("· Proliferate Cloud returned an error.")).toBeNull();
+  });
+
+  it("E-R35: a background sandbox refetch does not reopen a settled 404", () => {
+    cloudState.sandbox = { id: "sandbox-1" };
+    cloudState.sandboxFetchStatus = "fetching";
+    cloudState.launchOptionsError = new ProliferateClientError(
+      "Harness launch options have not been observed on this target.",
+      404,
+      "harness_launch_options_not_observed",
+    );
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="cloud" />);
+
+    // The settled answer outranks the other query's fetch status.
+    expect(screen.getByText("Models haven't been detected yet")).toBeTruthy();
+    expect(screen.queryByText("Loading models…")).toBeNull();
   });
 
   it("E-R19: neither new arm prints a body that contradicts its own header", () => {
@@ -230,6 +344,120 @@ describe("HarnessAllModelsSection — no payload, nothing in flight (round 3)", 
     render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="cloud" />);
     fireEvent.click(screen.getByRole("button", { name: "Models" }));
     expect(screen.getByText("No cloud workspace yet")).toBeTruthy();
+    expect(screen.queryByText("No models detected yet.")).toBeNull();
+  });
+
+  it("E-R13/E-R17: a disabled local query neither loads forever nor claims failure", () => {
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
+    expect(screen.getByText("Connecting to the local runtime")).toBeTruthy();
+    expect(screen.queryByText("Loading models…")).toBeNull();
+    expect(screen.queryByText("Models couldn't be loaded")).toBeNull();
+  });
+});
+
+/**
+ * The refresh control's own truth, which is a separate axis from the read's.
+ *
+ * A mutation has a fetch story of its own, and `isPending` collapses "the
+ * request is in flight" with "query-core parked it and is waiting for the
+ * network" — the same proxy-vs-fact collapse this pane exists to kill, one
+ * layer over. These cases mostly have a payload, so the read has nothing left
+ * to say and the control is the only thing that can lie.
+ */
+describe("HarnessAllModelsSection — the refresh control tells the truth (round 5)", () => {
+  /** A settled observation: the read is done, so only the control can lie. */
+  function observedPayload(modelCount: number): Record<string, unknown> {
+    return {
+      harnessKind: "claude",
+      basisRevision: "b1",
+      revision: 1,
+      state: "observed",
+      options: {
+        models: Array.from({ length: modelCount }, (_unused, index) => ({
+          id: `m-${index}`,
+          observedName: `Model ${index}`,
+          observedDescription: null,
+        })),
+        controls: [],
+        defaults: { modelId: null, controlValues: {} },
+      },
+      observedAt: "2026-08-21T11:58:00Z",
+      probeAttemptedAt: "2026-08-21T11:58:00Z",
+      probeFailureCode: null,
+      readiness: "ready",
+      probePhase: "idle",
+    };
+  }
+
+  beforeEach(() => {
+    useHarnessConnectionStore.setState({ connectionState: "healthy" });
+    runtimeQuery.isPending = false;
+    runtimeQuery.data = observedPayload(1);
+  });
+
+  it("E-R28: a parked refresh says it is parked instead of spinning forever", () => {
+    // The browser went offline after the observation settled, so the click
+    // parks: query-core reports `pending` with `isPaused`, and never times out.
+    refreshMutation.isPending = true;
+    refreshMutation.isPaused = true;
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
+
+    const refresh = screen.getByRole("button", { name: /^refresh$/i }) as HTMLButtonElement;
+    expect(screen.queryByRole("button", { name: "Refreshing…" })).toBeNull();
+    expect(refresh.querySelector(".animate-spin")).toBeNull();
+    // Nothing is in flight and a second click cannot start anything.
+    expect(refresh.disabled).toBe(true);
+    expect(screen.getByText("You're offline")).toBeTruthy();
+    expect(screen.getByText("· The refresh runs when the connection is back.")).toBeTruthy();
+  });
+
+  it("E-R28: a refresh that really is in flight still spins", () => {
+    refreshMutation.isPending = true;
+    refreshMutation.isPaused = false;
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
+
+    const refresh = screen.getByRole("button", { name: "Refreshing…" }) as HTMLButtonElement;
+    expect(refresh.querySelector(".animate-spin")).toBeTruthy();
+    expect(screen.queryByText("You're offline")).toBeNull();
+  });
+
+  it("E-R29: a mutation outliving its runtime does not repaint a dead control", () => {
+    // Clicked while healthy, then the runtime died mid-mutation.
+    useHarnessConnectionStore.setState({ connectionState: "failed" });
+    runtimeQuery.data = undefined;
+    runtimeQuery.isPending = true;
+    refreshMutation.isPending = true;
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
+
+    expect(screen.getByText("The local runtime didn't start")).toBeTruthy();
+    const refresh = screen.getByRole("button", { name: /^refresh$/i }) as HTMLButtonElement;
+    expect(screen.queryByRole("button", { name: "Refreshing…" })).toBeNull();
+    expect(refresh.querySelector(".animate-spin")).toBeNull();
+    expect(refresh.disabled).toBe(true);
+  });
+
+  it("E-R31: a failed background refetch does not blank a body its header agrees with", () => {
+    // The live half of the deleted override. A payload IS present, so the
+    // header reads "0 models" and says nothing about the refetch; suppressing
+    // "No models detected yet." underneath it would hide a true line on the
+    // strength of a fact the header never mentions.
+    runtimeQuery.data = observedPayload(0);
+    runtimeQuery.isError = true;
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
+    fireEvent.click(screen.getByRole("button", { name: "Models" }));
+
+    expect(screen.getByText("0 models")).toBeTruthy();
+    expect(screen.getByText("No models detected yet.")).toBeTruthy();
+  });
+
+  it("E-R14: a no-payload transport failure prints no body, from its own arm", () => {
+    runtimeQuery.data = undefined;
+    runtimeQuery.isPending = true;
+    runtimeQuery.isError = true;
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
+    fireEvent.click(screen.getByRole("button", { name: "Models" }));
+
+    expect(screen.getByText("Models couldn't be loaded")).toBeTruthy();
     expect(screen.queryByText("No models detected yet.")).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.absent-payload.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.absent-payload.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HarnessAllModelsSection } from "./HarnessAllModelsSection";
+
+/**
+ * The three ways a launch-options payload can be absent, kept apart.
+ *
+ * `HarnessAllModelsSection.test.tsx` owns the (state x probePhase) matrix,
+ * which by definition has a payload. These cases have none, and the whole
+ * point of the pane is that "no payload" is not one condition: a request in
+ * flight, a query nobody enabled, and a request that failed are three
+ * different truths and must render as three different things.
+ *
+ * The fakes mirror TanStack v5 exactly: a DISABLED query reports
+ * `isPending: true` with `fetchStatus: "idle"`, which is what makes
+ * `isPending` alone unusable as an "in flight" signal.
+ */
+
+const runtimeQuery = vi.hoisted(() => ({
+  data: undefined as Record<string, unknown> | undefined,
+  isLoading: false,
+  isError: false,
+  isPending: true,
+  fetchStatus: "idle" as "idle" | "fetching",
+  refetch: vi.fn(),
+}));
+
+const cloudState = vi.hoisted(() => ({
+  // 200-with-a-null-body: the account simply has no cloud workspace.
+  sandbox: null as Record<string, unknown> | null,
+  launchOptions: undefined as Record<string, unknown> | undefined,
+}));
+
+vi.mock("@anyharness/sdk-react", () => ({
+  useAgentLaunchOptionsQuery: () => runtimeQuery,
+  useRefreshHarnessLaunchOptionsMutation: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@proliferate/cloud-sdk-react", () => ({
+  useCloudSandbox: () => ({
+    data: cloudState.sandbox,
+    isLoading: false,
+    isError: false,
+    isPending: false,
+    fetchStatus: "idle",
+    refetch: vi.fn(),
+  }),
+  // The real hook is disabled without a non-empty target, so a null sandbox
+  // leaves it pending-and-idle forever.
+  useCloudHarnessLaunchOptions: ({ cloudSandboxId }: { cloudSandboxId?: string | null }) => {
+    const data = cloudSandboxId ? cloudState.launchOptions : undefined;
+    return {
+      data,
+      isLoading: false,
+      isError: false,
+      isPending: data === undefined,
+      fetchStatus: "idle",
+      refetch: vi.fn(),
+    };
+  },
+}));
+
+vi.mock("#product/hooks/cloud/derived/use-cloud-availability-state", () => ({
+  useCloudAvailabilityState: () => ({ cloudActive: true }),
+}));
+
+vi.mock("#product/stores/toast/toast-store", () => ({
+  useToastStore: (selector: (value: { show: () => void }) => unknown) =>
+    selector({ show: vi.fn() }),
+}));
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  runtimeQuery.data = undefined;
+  runtimeQuery.isLoading = false;
+  runtimeQuery.isError = false;
+  runtimeQuery.isPending = true;
+  runtimeQuery.fetchStatus = "idle";
+  runtimeQuery.refetch.mockReset();
+  cloudState.sandbox = null;
+  cloudState.launchOptions = undefined;
+});
+
+describe("HarnessAllModelsSection — no payload, nothing in flight (round 3)", () => {
+  it("E-R17: a local runtime still connecting is not an error and not a spinner", () => {
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
+
+    expect(screen.getByText("Connecting to the local runtime")).toBeTruthy();
+    expect(screen.getByText("· Models load as soon as it's ready.")).toBeTruthy();
+    // Nothing failed, so no failure claim and no cure to offer.
+    expect(screen.queryByText("Models couldn't be loaded")).toBeNull();
+    expect(screen.queryByText("The runtime didn't respond.")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    // Nothing is running, so no spinner either.
+    expect(screen.queryByText("Loading models…")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Refreshing…" })).toBeNull();
+    // `refresh_now` cannot reach a runtime that is not up: disabled, and NOT
+    // wearing the busy-with-full-ink treatment.
+    const refresh = screen.getByRole("button", { name: /^refresh$/i }) as HTMLButtonElement;
+    expect(refresh.disabled).toBe(true);
+    expect(refresh.className).not.toContain("disabled:opacity-100");
+    expect(refresh.querySelector(".animate-spin")).toBeNull();
+  });
+
+  it("E-R17: it stops claiming anything once the runtime answers", () => {
+    const { rerender } = render(
+      <HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />,
+    );
+    expect(screen.getByText("Connecting to the local runtime")).toBeTruthy();
+
+    runtimeQuery.isPending = false;
+    runtimeQuery.data = {
+      harnessKind: "claude",
+      basisRevision: "b1",
+      revision: 1,
+      state: "observed",
+      options: {
+        models: [{ id: "m-1", observedName: "Model 1", observedDescription: null }],
+        controls: [],
+        defaults: { modelId: null, controlValues: {} },
+      },
+      observedAt: "2026-08-21T11:58:00Z",
+      probeAttemptedAt: "2026-08-21T11:58:00Z",
+      probeFailureCode: null,
+      readiness: "ready",
+      probePhase: "idle",
+    };
+    rerender(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
+
+    expect(screen.getByText("1 model")).toBeTruthy();
+    expect(screen.queryByText("Connecting to the local runtime")).toBeNull();
+    expect((screen.getByRole("button", { name: /^refresh$/i }) as HTMLButtonElement).disabled)
+      .toBe(false);
+  });
+
+  it("E-R18: a cloud account with no workspace never shows a permanent spinner", () => {
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="cloud" />);
+
+    expect(screen.getByText("No cloud workspace yet")).toBeTruthy();
+    expect(screen.getByText("· Claude models are listed once a cloud workspace exists."))
+      .toBeTruthy();
+    // The bug this replaces: a forever "Loading models…" with no Refresh and
+    // no Retry anywhere in the view.
+    expect(screen.queryByText("Loading models…")).toBeNull();
+    expect(screen.queryByText("Models couldn't be loaded")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^refresh$/i })).toBeNull();
+  });
+
+  it("E-R19: neither new arm prints a body that contradicts its own header", () => {
+    const { unmount } = render(
+      <HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Models" }));
+    expect(screen.getByText("Connecting to the local runtime")).toBeTruthy();
+    expect(screen.queryByText("No models detected yet.")).toBeNull();
+    unmount();
+
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="cloud" />);
+    fireEvent.click(screen.getByRole("button", { name: "Models" }));
+    expect(screen.getByText("No cloud workspace yet")).toBeTruthy();
+    expect(screen.queryByText("No models detected yet.")).toBeNull();
+  });
+});

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.absent-payload.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.absent-payload.test.tsx
@@ -173,6 +173,7 @@ describe("HarnessAllModelsSection — no payload, nothing in flight (round 3)", 
       probeAttemptedAt: "2026-08-21T11:58:00Z",
       probeFailureCode: null,
       readiness: "ready",
+      canManuallyRefresh: true,
       probePhase: "idle",
     };
     rerender(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
@@ -385,6 +386,7 @@ describe("HarnessAllModelsSection — the refresh control tells the truth (round
       probeAttemptedAt: "2026-08-21T11:58:00Z",
       probeFailureCode: null,
       readiness: "ready",
+      canManuallyRefresh: true,
       probePhase: "idle",
     };
   }

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx
@@ -1,19 +1,59 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useEffect, useState } from "react";
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HarnessAllModelsSection } from "./HarnessAllModelsSection";
 
+const FIXED_NOW = new Date("2026-08-21T12:00:00Z").getTime();
+
+function isoAgo(ms: number, from: number = FIXED_NOW): string {
+  return new Date(from - ms).toISOString();
+}
+
+type LaunchOptionsFixture = Record<string, unknown> | undefined;
+
+/**
+ * The section's status text (aria-live="polite"), scoped away from the
+ * disclosure body — some fallback body copy (e.g. the loading line) is
+ * deliberately identical text, rendered collapsed but still in the DOM.
+ */
+function contentLine(): HTMLElement {
+  const node = document.querySelector('[aria-live="polite"]');
+  if (!node) throw new Error("content line container not found");
+  return node as HTMLElement;
+}
+
 const state = vi.hoisted(() => ({
-  launchOptions: undefined as Record<string, unknown> | undefined,
+  launchOptions: undefined as LaunchOptionsFixture,
+  isLoading: false,
+  isError: false,
   refresh: vi.fn(),
+  refetch: vi.fn(),
+  // Set by the stale-detecting convergence test: when present, the fake
+  // query hook below transitions from `launchOptions` to this fixture after
+  // one probe interval, with no user action in between.
+  nextLaunchOptions: undefined as LaunchOptionsFixture,
 }));
 
 vi.mock("@anyharness/sdk-react", () => ({
-  useAgentLaunchOptionsQuery: () => ({
-    data: state.launchOptions,
-    isLoading: false,
-  }),
+  useAgentLaunchOptionsQuery: () => {
+    // A minimal stand-in for slice B's real polling hook: it reacts to time
+    // passing, not to anything the test clicks, so a test that only advances
+    // fake timers is proof the render updates with no user action.
+    const [data, setData] = useState(state.launchOptions);
+    useEffect(() => {
+      setData(state.launchOptions);
+    }, [state.launchOptions]);
+    useEffect(() => {
+      if (!state.nextLaunchOptions) return undefined;
+      const timer = setTimeout(() => {
+        setData(state.nextLaunchOptions);
+      }, 1500);
+      return () => clearTimeout(timer);
+    }, [data]);
+    return { data, isLoading: state.isLoading, isError: state.isError, refetch: state.refetch };
+  },
   useRefreshHarnessLaunchOptionsMutation: () => ({
     mutate: state.refresh,
     isPending: false,
@@ -21,8 +61,8 @@ vi.mock("@anyharness/sdk-react", () => ({
 }));
 
 vi.mock("@proliferate/cloud-sdk-react", () => ({
-  useCloudSandbox: () => ({ data: null, isLoading: false }),
-  useCloudHarnessLaunchOptions: () => ({ data: undefined, isLoading: false }),
+  useCloudSandbox: () => ({ data: null, isLoading: false, isError: false, refetch: vi.fn() }),
+  useCloudHarnessLaunchOptions: () => ({ data: undefined, isLoading: false, isError: false, refetch: vi.fn() }),
 }));
 
 vi.mock("#product/hooks/cloud/derived/use-cloud-availability-state", () => ({
@@ -34,10 +74,17 @@ vi.mock("#product/stores/toast/toast-store", () => ({
     selector({ show: vi.fn() }),
 }));
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
 
 beforeEach(() => {
   state.refresh.mockReset();
+  state.refetch.mockReset();
+  state.isLoading = false;
+  state.isError = false;
+  state.nextLaunchOptions = undefined;
   state.launchOptions = {
     harnessKind: "claude",
     basisRevision: "basis-1",
@@ -72,5 +119,286 @@ describe("HarnessAllModelsSection", () => {
     render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
     fireEvent.click(screen.getByRole("button", { name: /^refresh$/i }));
     expect(state.refresh).toHaveBeenCalledWith("claude", expect.anything());
+  });
+});
+
+describe("HarnessAllModelsSection — the eight models-section states", () => {
+  it("1 · initial HTTP loading: no count, enabled Refresh", () => {
+    state.isLoading = true;
+    state.launchOptions = undefined;
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
+
+    expect(within(contentLine()).getByText("Loading models…")).toBeTruthy();
+    expect(screen.queryByText(/^\d+ models?$/)).toBeNull();
+    expect((screen.getByRole("button", { name: /^refresh$/i }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("2 · active first observation: Checking copy, never a count, Refresh disabled-as-busy", () => {
+    state.launchOptions = {
+      harnessKind: "claude",
+      basisRevision: "b1",
+      revision: 1,
+      state: "detecting",
+      options: null,
+      observedAt: null,
+      probeAttemptedAt: isoAgo(0),
+      probeFailureCode: null,
+      readiness: "ready",
+      probePhase: "running",
+    };
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Cursor" surface="local" />);
+
+    expect(screen.getByText("Checking available models…")).toBeTruthy();
+    expect(screen.queryByText(/^0 models/)).toBeNull();
+    const refreshButton = screen.getByRole("button", { name: "Refreshing…" }) as HTMLButtonElement;
+    expect(refreshButton.disabled).toBe(true);
+  });
+
+  it("3 · idle-unobserved (Cursor fixture): calm static copy, Refresh ENABLED", () => {
+    state.launchOptions = {
+      harnessKind: "claude",
+      basisRevision: "b1",
+      revision: 1,
+      state: "detecting",
+      options: null,
+      observedAt: null,
+      probeAttemptedAt: isoAgo(0),
+      probeFailureCode: null,
+      readiness: "ready",
+      probePhase: "idle",
+    };
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Cursor" surface="local" />);
+
+    expect(screen.getByText("Models haven't been detected yet")).toBeTruthy();
+    expect(screen.getByText("· Cursor reports models after its first launch. Refresh checks now.")).toBeTruthy();
+    const refreshButton = screen.getByRole("button", { name: /^refresh$/i }) as HTMLButtonElement;
+    expect(refreshButton.disabled).toBe(false);
+  });
+
+  it("4 · observed: count in foreground, freshness suffix muted", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+    state.launchOptions = {
+      harnessKind: "claude",
+      basisRevision: "b1",
+      revision: 4,
+      state: "observed",
+      options: {
+        models: Array.from({ length: 180 }, (_, i) => ({ id: `m-${i}`, observedName: `Model ${i}`, observedDescription: null })),
+        controls: [],
+        defaults: { modelId: null, controlValues: {} },
+      },
+      observedAt: isoAgo(2 * 60_000),
+      probeAttemptedAt: isoAgo(2 * 60_000),
+      probeFailureCode: null,
+      readiness: "ready",
+      probePhase: "idle",
+    };
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="OpenCode" surface="local" />);
+
+    expect(screen.getByText("180 models")).toBeTruthy();
+    expect(screen.getByText("· refreshed 2m ago")).toBeTruthy();
+  });
+
+  it("5 · observed-empty: calm honest zero, no error tone", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+    state.launchOptions = {
+      harnessKind: "claude",
+      basisRevision: "b1",
+      revision: 5,
+      state: "observed_empty",
+      options: { models: [], controls: [], defaults: { modelId: null, controlValues: {} } },
+      observedAt: isoAgo(5 * 60_000),
+      probeAttemptedAt: isoAgo(5 * 60_000),
+      probeFailureCode: null,
+      readiness: "ready",
+      probePhase: "idle",
+    };
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="OpenCode" surface="local" />);
+
+    expect(screen.getByText("0 models")).toBeTruthy();
+    expect(screen.getByText("· OpenCode reported none · refreshed 5m ago")).toBeTruthy();
+  });
+
+  it("6 · last-good-after-failure: prior list stays, undimmed, one refresh-failed line", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+    state.launchOptions = {
+      harnessKind: "claude",
+      basisRevision: "b1",
+      revision: 6,
+      state: "last_good_after_failure",
+      options: {
+        models: Array.from({ length: 180 }, (_, i) => ({ id: `m-${i}`, observedName: `Model ${i}`, observedDescription: null })),
+        controls: [],
+        defaults: { modelId: null, controlValues: {} },
+      },
+      observedAt: isoAgo(3 * 60 * 60_000),
+      probeAttemptedAt: isoAgo(0),
+      probeFailureCode: "harness_probe_failed",
+      readiness: "ready",
+      probePhase: "idle",
+    };
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="OpenCode" surface="local" />);
+
+    expect(screen.getByText("180 models")).toBeTruthy();
+    expect(screen.getByText("· last refresh failed · refreshed 3h ago")).toBeTruthy();
+    expect((screen.getByRole("button", { name: /^refresh$/i }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("7 · failed-without-observation: explicit failure with an enabled Retry, no count", () => {
+    state.launchOptions = {
+      harnessKind: "claude",
+      basisRevision: "b1",
+      revision: 7,
+      state: "failed_without_observation",
+      options: null,
+      observedAt: null,
+      probeAttemptedAt: isoAgo(0),
+      probeFailureCode: "harness_probe_failed",
+      readiness: "ready",
+      probePhase: "idle",
+    };
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Cursor" surface="local" />);
+
+    expect(screen.getByText("Couldn't check models")).toBeTruthy();
+    expect(screen.getByText("· Cursor didn't answer the probe.")).toBeTruthy();
+    expect(screen.queryByText(/^\d+ models?/)).toBeNull();
+    const retry = screen.getByRole("button", { name: "Retry" }) as HTMLButtonElement;
+    expect(retry.disabled).toBe(false);
+    fireEvent.click(retry);
+    expect(state.refresh).toHaveBeenCalledWith("claude", expect.anything());
+  });
+
+  it("8 · transport error: launch-options request itself failed, Retry refetches", () => {
+    state.launchOptions = undefined;
+    state.isError = true;
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
+
+    expect(screen.getByText("Models couldn't be loaded")).toBeTruthy();
+    expect(screen.getByText("· The runtime didn't respond.")).toBeTruthy();
+    const retry = screen.getByRole("button", { name: "Retry" });
+    fireEvent.click(retry);
+    expect(state.refetch).toHaveBeenCalled();
+  });
+});
+
+describe("HarnessAllModelsSection — self-curing refresh", () => {
+  it("converges a stale-detecting fixture to observed with no user action", () => {
+    vi.useFakeTimers();
+    state.launchOptions = {
+      harnessKind: "claude",
+      basisRevision: "b1",
+      revision: 1,
+      state: "detecting",
+      options: null,
+      observedAt: null,
+      probeAttemptedAt: isoAgo(32 * 60_000, FIXED_NOW),
+      probeFailureCode: null,
+      readiness: "ready",
+      probePhase: "running",
+    };
+    state.nextLaunchOptions = {
+      harnessKind: "claude",
+      basisRevision: "b2",
+      revision: 2,
+      state: "observed",
+      options: {
+        models: Array.from({ length: 180 }, (_, i) => ({ id: `m-${i}`, observedName: `Model ${i}`, observedDescription: null })),
+        controls: [],
+        defaults: { modelId: null, controlValues: {} },
+      },
+      observedAt: isoAgo(0, FIXED_NOW),
+      probeAttemptedAt: isoAgo(0, FIXED_NOW),
+      probeFailureCode: null,
+      readiness: "ready",
+      probePhase: "idle",
+    };
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="OpenCode" surface="local" />);
+
+    expect(screen.getByText("Checking available models…")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(screen.getByText("180 models")).toBeTruthy();
+    expect(screen.queryByText("Checking available models…")).toBeNull();
+  });
+
+  it("rereads the durable failed_without_observation state after a refresh-mutation 5xx", () => {
+    const { rerender } = render(<HarnessAllModelsSection harnessKind="claude" displayName="Cursor" surface="local" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^refresh$/i }));
+    expect(state.refresh).toHaveBeenCalledTimes(1);
+    const [, mutateOptions] = state.refresh.mock.calls[0] as [string, { onError?: (error: Error) => void }];
+
+    // The 5xx: the mutation's own onError durably records
+    // failed_without_observation and invalidates the cache (agents.ts), so
+    // the next read this client sees is the durable failure, not a bounce
+    // back to the pre-refresh revision.
+    mutateOptions.onError?.(new Error("Internal Server Error"));
+    state.launchOptions = {
+      harnessKind: "claude",
+      basisRevision: "b3",
+      revision: 8,
+      state: "failed_without_observation",
+      options: null,
+      observedAt: null,
+      probeAttemptedAt: isoAgo(0),
+      probeFailureCode: "harness_probe_failed",
+      readiness: "ready",
+      probePhase: "idle",
+    };
+    rerender(<HarnessAllModelsSection harnessKind="claude" displayName="Cursor" surface="local" />);
+
+    expect(screen.getByText("Couldn't check models")).toBeTruthy();
+    expect(screen.getByText("· Cursor didn't answer the probe.")).toBeTruthy();
+  });
+});
+
+describe("HarnessAllModelsSection — truthfulness rules", () => {
+  it("never renders a count during loading or first observation", () => {
+    state.isLoading = true;
+    state.launchOptions = undefined;
+    const { rerender } = render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
+    expect(screen.queryByText(/\d+ models?/)).toBeNull();
+
+    state.isLoading = false;
+    state.launchOptions = {
+      harnessKind: "claude",
+      basisRevision: "b1",
+      revision: 1,
+      state: "detecting",
+      options: null,
+      observedAt: null,
+      probeAttemptedAt: isoAgo(0),
+      probeFailureCode: null,
+      readiness: "ready",
+      probePhase: "running",
+    };
+    rerender(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
+    expect(screen.queryByText(/\d+ models?/)).toBeNull();
+  });
+
+  it("never renders the freshness suffix without observedAt", () => {
+    state.launchOptions = {
+      harnessKind: "claude",
+      basisRevision: "b1",
+      revision: 1,
+      state: "observed",
+      options: { models: [], controls: [], defaults: { modelId: null, controlValues: {} } },
+      observedAt: null,
+      probeAttemptedAt: isoAgo(0),
+      probeFailureCode: null,
+      readiness: "ready",
+      probePhase: "idle",
+    };
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
+
+    expect(screen.getByText("0 models")).toBeTruthy();
+    expect(screen.queryByText(/refreshed/)).toBeNull();
+    expect(screen.queryByText("observed")).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HarnessAllModelsSection } from "./HarnessAllModelsSection";
+import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
 
 const FIXED_NOW = new Date("2026-08-21T12:00:00Z").getTime();
 
@@ -13,11 +14,7 @@ function isoAgo(ms: number, from: number = FIXED_NOW): string {
 
 type LaunchOptionsFixture = Record<string, unknown> | undefined;
 
-/**
- * The section's status text (aria-live="polite"), scoped away from the
- * disclosure body — some fallback body copy (e.g. the loading line) is
- * deliberately identical text, rendered collapsed but still in the DOM.
- */
+/** The status text (aria-live), scoped away from identical collapsed body copy. */
 function contentLine(): HTMLElement {
   const node = document.querySelector('[aria-live="polite"]');
   if (!node) throw new Error("content line container not found");
@@ -91,6 +88,7 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+  useHarnessConnectionStore.setState({ connectionState: "healthy" });
   state.refresh.mockReset();
   state.refetch.mockReset();
   state.isLoading = false;
@@ -577,6 +575,7 @@ describe("HarnessAllModelsSection — round 2 review fixes", () => {
   });
 
   it("E-R13/E-R17: a disabled local query neither loads forever nor claims failure", () => {
+    useHarnessConnectionStore.setState({ connectionState: "connecting" });
     state.launchOptions = undefined;
     state.isLoading = false;
     state.isError = false;

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx
@@ -73,6 +73,15 @@ vi.mock("@proliferate/cloud-sdk-react", () => ({
   },
 }));
 
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  // Desktop: the surface this whole matrix describes.
+  useProductHost: () => ({ desktop: { runtime: { restart: vi.fn() } } }),
+}));
+
+vi.mock("#product/lib/access/anyharness/runtime-bootstrap", () => ({
+  restartHarnessRuntime: vi.fn(),
+}));
+
 vi.mock("#product/hooks/cloud/derived/use-cloud-availability-state", () => ({
   useCloudAvailabilityState: () => ({ cloudActive: true }),
 }));
@@ -572,27 +581,5 @@ describe("HarnessAllModelsSection — round 2 review fixes", () => {
     expect(screen.getByText("1 model")).toBeTruthy();
     expect(screen.getByText("· refreshed 2m ago")).toBeTruthy();
     expect(screen.queryByText("Checking available models…")).toBeNull();
-  });
-
-  it("E-R13/E-R17: a disabled local query neither loads forever nor claims failure", () => {
-    useHarnessConnectionStore.setState({ connectionState: "connecting" });
-    state.launchOptions = undefined;
-    state.isLoading = false;
-    state.isError = false;
-    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
-    expect(screen.getByText("Connecting to the local runtime")).toBeTruthy();
-    expect(screen.queryByText("Loading models…")).toBeNull();
-    expect(screen.queryByText("Models couldn't be loaded")).toBeNull();
-  });
-
-  it("E-R14: the expanded body does not contradict a header that already explains an empty state", () => {
-    state.launchOptions = undefined;
-    state.isLoading = false;
-    state.isError = true;
-    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
-    fireEvent.click(screen.getByRole("button", { name: "Models" }));
-
-    expect(screen.getByText("Models couldn't be loaded")).toBeTruthy();
-    expect(screen.queryByText("No models detected yet.")).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx
@@ -34,6 +34,11 @@ const state = vi.hoisted(() => ({
   // query hook below transitions from `launchOptions` to this fixture after
   // one probe interval, with no user action in between.
   nextLaunchOptions: undefined as LaunchOptionsFixture,
+  // Cloud-surface fixtures (E-R5): both cloud hooks previously stayed
+  // `data: undefined` in every test, so the cloud path was entirely
+  // uncovered. Stateful like `launchOptions` above.
+  cloudSandbox: null as Record<string, unknown> | null,
+  cloudLaunchOptions: undefined as LaunchOptionsFixture,
 }));
 
 vi.mock("@anyharness/sdk-react", () => ({
@@ -61,8 +66,8 @@ vi.mock("@anyharness/sdk-react", () => ({
 }));
 
 vi.mock("@proliferate/cloud-sdk-react", () => ({
-  useCloudSandbox: () => ({ data: null, isLoading: false, isError: false, refetch: vi.fn() }),
-  useCloudHarnessLaunchOptions: () => ({ data: undefined, isLoading: false, isError: false, refetch: vi.fn() }),
+  useCloudSandbox: () => ({ data: state.cloudSandbox, isLoading: false, isError: false, refetch: vi.fn() }),
+  useCloudHarnessLaunchOptions: () => ({ data: state.cloudLaunchOptions, isLoading: false, isError: false, refetch: vi.fn() }),
 }));
 
 vi.mock("#product/hooks/cloud/derived/use-cloud-availability-state", () => ({
@@ -85,6 +90,8 @@ beforeEach(() => {
   state.isLoading = false;
   state.isError = false;
   state.nextLaunchOptions = undefined;
+  state.cloudSandbox = null;
+  state.cloudLaunchOptions = undefined;
   state.launchOptions = {
     harnessKind: "claude",
     basisRevision: "basis-1",
@@ -148,7 +155,7 @@ describe("HarnessAllModelsSection — the eight models-section states", () => {
     };
     render(<HarnessAllModelsSection harnessKind="claude" displayName="Cursor" surface="local" />);
 
-    expect(screen.getByText("Checking available models…")).toBeTruthy();
+    expect(within(contentLine()).getByText("Checking available models…")).toBeTruthy();
     expect(screen.queryByText(/^0 models/)).toBeNull();
     const refreshButton = screen.getByRole("button", { name: "Refreshing…" }) as HTMLButtonElement;
     expect(refreshButton.disabled).toBe(true);
@@ -317,7 +324,7 @@ describe("HarnessAllModelsSection — self-curing refresh", () => {
     };
     render(<HarnessAllModelsSection harnessKind="claude" displayName="OpenCode" surface="local" />);
 
-    expect(screen.getByText("Checking available models…")).toBeTruthy();
+    expect(within(contentLine()).getByText("Checking available models…")).toBeTruthy();
 
     act(() => {
       vi.advanceTimersByTime(1500);
@@ -400,5 +407,96 @@ describe("HarnessAllModelsSection — truthfulness rules", () => {
     expect(screen.getByText("0 models")).toBeTruthy();
     expect(screen.queryByText(/refreshed/)).toBeNull();
     expect(screen.queryByText("observed")).toBeNull();
+  });
+});
+
+describe("HarnessAllModelsSection — queued counts as live (E-R2)", () => {
+  it("detecting+queued renders Checking, Refresh disabled-as-busy", () => {
+    state.launchOptions = {
+      harnessKind: "claude",
+      basisRevision: "b1",
+      revision: 1,
+      state: "detecting",
+      options: null,
+      observedAt: null,
+      probeAttemptedAt: isoAgo(0),
+      probeFailureCode: null,
+      readiness: "ready",
+      probePhase: "queued",
+    };
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Cursor" surface="local" />);
+
+    expect(within(contentLine()).getByText("Checking available models…")).toBeTruthy();
+    expect(screen.queryByText("Models haven't been detected yet")).toBeNull();
+    const refreshButton = screen.getByRole("button", { name: "Refreshing…" }) as HTMLButtonElement;
+    expect(refreshButton.disabled).toBe(true);
+  });
+
+  it("refreshing+queued renders Checking, Refresh disabled-as-busy (not enabled/non-spinning)", () => {
+    state.launchOptions = {
+      harnessKind: "claude",
+      basisRevision: "b1",
+      revision: 2,
+      state: "refreshing",
+      options: {
+        models: [{ id: "m-1", observedName: "Model 1", observedDescription: null }],
+        controls: [],
+        defaults: { modelId: null, controlValues: {} },
+      },
+      observedAt: isoAgo(60_000),
+      probeAttemptedAt: isoAgo(0),
+      probeFailureCode: null,
+      readiness: "ready",
+      probePhase: "queued",
+    };
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Cursor" surface="local" />);
+
+    expect(within(contentLine()).getByText("Checking available models…")).toBeTruthy();
+    const refreshButton = screen.getByRole("button", { name: "Refreshing…" }) as HTMLButtonElement;
+    expect(refreshButton.disabled).toBe(true);
+    expect(refreshButton.className).toContain("disabled:opacity-100");
+  });
+});
+
+describe("HarnessAllModelsSection — cloud surface (E-R5)", () => {
+  it("idle-unobserved drops the Refresh-only sentence and renders no Refresh control", () => {
+    state.cloudSandbox = { id: "sandbox-1" };
+    state.cloudLaunchOptions = {
+      harnessKind: "claude",
+      basisRevision: "cloud-b1",
+      revision: 1,
+      state: "detecting",
+      options: null,
+      observedAt: null,
+      probeAttemptedAt: isoAgo(0),
+      probeFailureCode: null,
+      readiness: "ready",
+    };
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="cloud" />);
+
+    expect(screen.getByText("Models haven't been detected yet")).toBeTruthy();
+    expect(screen.getByText("· Claude reports models after its first launch.")).toBeTruthy();
+    expect(screen.queryByText(/Refresh checks now/)).toBeNull();
+    expect(screen.queryByRole("button", { name: /^refresh$/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Refreshing…" })).toBeNull();
+  });
+
+  it("failed_without_observation offers no Retry (no probe route exists on cloud)", () => {
+    state.cloudSandbox = { id: "sandbox-1" };
+    state.cloudLaunchOptions = {
+      harnessKind: "claude",
+      basisRevision: "cloud-b1",
+      revision: 2,
+      state: "failed_without_observation",
+      options: null,
+      observedAt: null,
+      probeAttemptedAt: isoAgo(0),
+      probeFailureCode: "harness_probe_failed",
+      readiness: "ready",
+    };
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="cloud" />);
+
+    expect(screen.getByText("Couldn't check models")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx
@@ -121,7 +121,7 @@ beforeEach(() => {
     observedAt: "2026-08-19T00:00:00Z",
     probeAttemptedAt: "2026-08-19T00:00:00Z",
     probeFailureCode: null,
-    readiness: "ready",
+    readiness: "ready", canManuallyRefresh: true,
   };
 });
 
@@ -143,14 +143,17 @@ describe("HarnessAllModelsSection", () => {
 });
 
 describe("HarnessAllModelsSection — the eight models-section states", () => {
-  it("1 · initial HTTP loading: no count, enabled Refresh", () => {
+  it("1 · initial HTTP loading: no count, Refresh disabled", () => {
     state.isLoading = true;
     state.launchOptions = undefined;
     render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
 
     expect(within(contentLine()).getByText("Loading models…")).toBeTruthy();
     expect(screen.queryByText(/^\d+ models?$/)).toBeNull();
-    expect((screen.getByRole("button", { name: /^refresh$/i }) as HTMLButtonElement).disabled).toBe(false);
+    // Round 5: no payload means no ownership fact to read, so the control fails
+    // closed. It was enabled here, which was never a cure anyway: a read that is
+    // already in flight does not land sooner because you pressed Refresh.
+    expect((screen.getByRole("button", { name: /^refresh$/i }) as HTMLButtonElement).disabled).toBe(true);
   });
 
   it("2 · active first observation: Checking copy, never a count, Refresh disabled-as-busy", () => {
@@ -163,7 +166,7 @@ describe("HarnessAllModelsSection — the eight models-section states", () => {
       observedAt: null,
       probeAttemptedAt: isoAgo(0),
       probeFailureCode: null,
-      readiness: "ready",
+      readiness: "ready", canManuallyRefresh: true,
       probePhase: "running",
     };
     render(<HarnessAllModelsSection harnessKind="claude" displayName="Cursor" surface="local" />);
@@ -184,7 +187,7 @@ describe("HarnessAllModelsSection — the eight models-section states", () => {
       observedAt: null,
       probeAttemptedAt: isoAgo(0),
       probeFailureCode: null,
-      readiness: "ready",
+      readiness: "ready", canManuallyRefresh: true,
       probePhase: "idle",
     };
     render(<HarnessAllModelsSection harnessKind="claude" displayName="Cursor" surface="local" />);
@@ -211,7 +214,7 @@ describe("HarnessAllModelsSection — the eight models-section states", () => {
       observedAt: isoAgo(2 * 60_000),
       probeAttemptedAt: isoAgo(2 * 60_000),
       probeFailureCode: null,
-      readiness: "ready",
+      readiness: "ready", canManuallyRefresh: true,
       probePhase: "idle",
     };
     render(<HarnessAllModelsSection harnessKind="claude" displayName="OpenCode" surface="local" />);
@@ -232,7 +235,7 @@ describe("HarnessAllModelsSection — the eight models-section states", () => {
       observedAt: isoAgo(5 * 60_000),
       probeAttemptedAt: isoAgo(5 * 60_000),
       probeFailureCode: null,
-      readiness: "ready",
+      readiness: "ready", canManuallyRefresh: true,
       probePhase: "idle",
     };
     render(<HarnessAllModelsSection harnessKind="claude" displayName="OpenCode" surface="local" />);
@@ -257,7 +260,7 @@ describe("HarnessAllModelsSection — the eight models-section states", () => {
       observedAt: isoAgo(3 * 60 * 60_000),
       probeAttemptedAt: isoAgo(0),
       probeFailureCode: "harness_probe_failed",
-      readiness: "ready",
+      readiness: "ready", canManuallyRefresh: true,
       probePhase: "idle",
     };
     render(<HarnessAllModelsSection harnessKind="claude" displayName="OpenCode" surface="local" />);
@@ -277,7 +280,7 @@ describe("HarnessAllModelsSection — the eight models-section states", () => {
       observedAt: null,
       probeAttemptedAt: isoAgo(0),
       probeFailureCode: "harness_probe_failed",
-      readiness: "ready",
+      readiness: "ready", canManuallyRefresh: true,
       probePhase: "idle",
     };
     render(<HarnessAllModelsSection harnessKind="claude" displayName="Cursor" surface="local" />);
@@ -316,7 +319,7 @@ describe("HarnessAllModelsSection — self-curing refresh", () => {
       observedAt: null,
       probeAttemptedAt: isoAgo(32 * 60_000, FIXED_NOW),
       probeFailureCode: null,
-      readiness: "ready",
+      readiness: "ready", canManuallyRefresh: true,
       probePhase: "running",
     };
     state.nextLaunchOptions = {
@@ -332,7 +335,7 @@ describe("HarnessAllModelsSection — self-curing refresh", () => {
       observedAt: isoAgo(0, FIXED_NOW),
       probeAttemptedAt: isoAgo(0, FIXED_NOW),
       probeFailureCode: null,
-      readiness: "ready",
+      readiness: "ready", canManuallyRefresh: true,
       probePhase: "idle",
     };
     render(<HarnessAllModelsSection harnessKind="claude" displayName="OpenCode" surface="local" />);
@@ -368,7 +371,7 @@ describe("HarnessAllModelsSection — self-curing refresh", () => {
       observedAt: null,
       probeAttemptedAt: isoAgo(0),
       probeFailureCode: "harness_probe_failed",
-      readiness: "ready",
+      readiness: "ready", canManuallyRefresh: true,
       probePhase: "idle",
     };
     rerender(<HarnessAllModelsSection harnessKind="claude" displayName="Cursor" surface="local" />);
@@ -395,7 +398,7 @@ describe("HarnessAllModelsSection — truthfulness rules", () => {
       observedAt: null,
       probeAttemptedAt: isoAgo(0),
       probeFailureCode: null,
-      readiness: "ready",
+      readiness: "ready", canManuallyRefresh: true,
       probePhase: "running",
     };
     rerender(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
@@ -412,7 +415,7 @@ describe("HarnessAllModelsSection — truthfulness rules", () => {
       observedAt: null,
       probeAttemptedAt: isoAgo(0),
       probeFailureCode: null,
-      readiness: "ready",
+      readiness: "ready", canManuallyRefresh: true,
       probePhase: "idle",
     };
     render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
@@ -439,7 +442,7 @@ describe("HarnessAllModelsSection — queued counts as live (E-R2)", () => {
       observedAt: null,
       probeAttemptedAt: isoAgo(0),
       probeFailureCode: null,
-      readiness: "ready",
+      readiness: "ready", canManuallyRefresh: true,
       probePhase: "queued",
     };
     render(<HarnessAllModelsSection harnessKind="claude" displayName="Cursor" surface="local" />);
@@ -464,7 +467,7 @@ describe("HarnessAllModelsSection — queued counts as live (E-R2)", () => {
       observedAt: isoAgo(60_000),
       probeAttemptedAt: isoAgo(0),
       probeFailureCode: null,
-      readiness: "ready",
+      readiness: "ready", canManuallyRefresh: true,
       probePhase: "queued",
     };
     render(<HarnessAllModelsSection harnessKind="claude" displayName="Cursor" surface="local" />);
@@ -499,7 +502,7 @@ describe("HarnessAllModelsSection — cloud surface (E-R5)", () => {
     expect(screen.queryByRole("button", { name: "Refreshing…" })).toBeNull();
   });
 
-  it("failed_without_observation offers no Retry (no probe route exists on cloud)", () => {
+  it("failed_without_observation offers a re-read, not a re-probe (E-R37)", () => {
     state.cloudSandbox = { id: "sandbox-1" };
     state.cloudLaunchOptions = {
       harnessKind: "claude",
@@ -515,7 +518,14 @@ describe("HarnessAllModelsSection — cloud surface (E-R5)", () => {
     render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="cloud" />);
 
     expect(screen.getByText("Couldn't check models")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    // E-R37: cloud has no probe route, but this state is never polled either
+    // (`resolveAgentLaunchOptionsRefetchInterval` returns false for it), so
+    // with no Retry it was the pane's one permanent dead end. The cure offered
+    // is a re-READ of the snapshot the owning runtime keeps re-probing, which
+    // is why the copy says "checks for a newer result" and not "Refresh".
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    expect(screen.getByText(/Retry checks for a newer result\./)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^refresh$/i })).toBeNull();
   });
 });
 
@@ -530,7 +540,7 @@ describe("HarnessAllModelsSection — round 2 review fixes", () => {
       observedAt: isoAgo(60_000),
       probeAttemptedAt: isoAgo(0),
       probeFailureCode: null,
-      readiness: "ready",
+      readiness: "ready", canManuallyRefresh: true,
       probePhase: "queued",
     };
     render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
@@ -550,7 +560,7 @@ describe("HarnessAllModelsSection — round 2 review fixes", () => {
       observedAt: null,
       probeAttemptedAt: isoAgo(0),
       probeFailureCode: "harness_probe_failed",
-      readiness: "ready",
+      readiness: "ready", canManuallyRefresh: true,
       probePhase: "running",
     };
     render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx
@@ -34,9 +34,7 @@ const state = vi.hoisted(() => ({
   // query hook below transitions from `launchOptions` to this fixture after
   // one probe interval, with no user action in between.
   nextLaunchOptions: undefined as LaunchOptionsFixture,
-  // Cloud-surface fixtures (E-R5): both cloud hooks previously stayed
-  // `data: undefined` in every test, so the cloud path was entirely
-  // uncovered. Stateful like `launchOptions` above.
+  // Cloud-surface fixtures (E-R5), stateful like `launchOptions` above.
   cloudSandbox: null as Record<string, unknown> | null,
   cloudLaunchOptions: undefined as LaunchOptionsFixture,
 }));
@@ -57,7 +55,11 @@ vi.mock("@anyharness/sdk-react", () => ({
       }, 1500);
       return () => clearTimeout(timer);
     }, [data]);
-    return { data, isLoading: state.isLoading, isError: state.isError, refetch: state.refetch };
+    // v5 shape the component now depends on: a DISABLED query is pending with
+    // an IDLE fetchStatus; only a real request in flight is non-idle.
+    const isPending = data === undefined && !state.isError;
+    const fetchStatus = state.isLoading ? "fetching" : "idle";
+    return { data, isLoading: state.isLoading, isError: state.isError, isPending, fetchStatus, refetch: state.refetch };
   },
   useRefreshHarnessLaunchOptionsMutation: () => ({
     mutate: state.refresh,
@@ -66,8 +68,12 @@ vi.mock("@anyharness/sdk-react", () => ({
 }));
 
 vi.mock("@proliferate/cloud-sdk-react", () => ({
-  useCloudSandbox: () => ({ data: state.cloudSandbox, isLoading: false, isError: false, refetch: vi.fn() }),
-  useCloudHarnessLaunchOptions: () => ({ data: state.cloudLaunchOptions, isLoading: false, isError: false, refetch: vi.fn() }),
+  useCloudSandbox: () => ({ data: state.cloudSandbox, isLoading: false, isError: false, isPending: false, fetchStatus: "idle", refetch: vi.fn() }),
+  // Disabled without a sandbox id, exactly like the real dependent query.
+  useCloudHarnessLaunchOptions: ({ cloudSandboxId }: { cloudSandboxId?: string | null }) => {
+    const data = cloudSandboxId ? state.cloudLaunchOptions : undefined;
+    return { data, isLoading: false, isError: false, isPending: data === undefined, fetchStatus: "idle", refetch: vi.fn() };
+  },
 }));
 
 vi.mock("#product/hooks/cloud/derived/use-cloud-availability-state", () => ({
@@ -406,12 +412,9 @@ describe("HarnessAllModelsSection — truthfulness rules", () => {
 
     expect(screen.getByText("0 models")).toBeTruthy();
     expect(screen.queryByText(/refreshed/)).toBeNull();
-    // E-R11: `queryByText("observed")` here can never match, even with the
-    // bug present, because the muted span concatenates a " · " separator
-    // with the raw state ("· observed" as one node's normalized text) —
-    // an exact-string query for the bare word is vacuous by construction.
-    // Assert on the container's full text instead, covering every raw wire
-    // state string the copy layer must never leak (not just "observed").
+    // E-R11: an exact-string `queryByText` for a bare wire state can never
+    // match (the muted span concatenates " · " into one text node), so assert
+    // on the container's full text, covering every raw state string.
     expect(contentLine().textContent).not.toMatch(
       /detecting|refreshing|observed|last_good_after_failure|failed_without_observation/,
     );
@@ -573,13 +576,14 @@ describe("HarnessAllModelsSection — round 2 review fixes", () => {
     expect(screen.queryByText("Checking available models…")).toBeNull();
   });
 
-  it("E-R13: a disabled local query (no runtime URL) does not load forever", () => {
+  it("E-R13/E-R17: a disabled local query neither loads forever nor claims failure", () => {
     state.launchOptions = undefined;
     state.isLoading = false;
     state.isError = false;
     render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
-    expect(screen.getByText("Models couldn't be loaded")).toBeTruthy();
+    expect(screen.getByText("Connecting to the local runtime")).toBeTruthy();
     expect(screen.queryByText("Loading models…")).toBeNull();
+    expect(screen.queryByText("Models couldn't be loaded")).toBeNull();
   });
 
   it("E-R14: the expanded body does not contradict a header that already explains an empty state", () => {

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx
@@ -406,7 +406,15 @@ describe("HarnessAllModelsSection — truthfulness rules", () => {
 
     expect(screen.getByText("0 models")).toBeTruthy();
     expect(screen.queryByText(/refreshed/)).toBeNull();
-    expect(screen.queryByText("observed")).toBeNull();
+    // E-R11: `queryByText("observed")` here can never match, even with the
+    // bug present, because the muted span concatenates a " · " separator
+    // with the raw state ("· observed" as one node's normalized text) —
+    // an exact-string query for the bare word is vacuous by construction.
+    // Assert on the container's full text instead, covering every raw wire
+    // state string the copy layer must never leak (not just "observed").
+    expect(contentLine().textContent).not.toMatch(
+      /detecting|refreshing|observed|last_good_after_failure|failed_without_observation/,
+    );
   });
 });
 
@@ -498,5 +506,90 @@ describe("HarnessAllModelsSection — cloud surface (E-R5)", () => {
 
     expect(screen.getByText("Couldn't check models")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+});
+
+describe("HarnessAllModelsSection — round 2 review fixes", () => {
+  it("E-R9: a terminal state carrying a stray live probePhase keeps Refresh enabled", () => {
+    state.launchOptions = {
+      harnessKind: "claude",
+      basisRevision: "b1",
+      revision: 5,
+      state: "observed",
+      options: { models: [{ id: "m-1", observedName: "Model 1", observedDescription: null }], controls: [], defaults: { modelId: null, controlValues: {} } },
+      observedAt: isoAgo(60_000),
+      probeAttemptedAt: isoAgo(0),
+      probeFailureCode: null,
+      readiness: "ready",
+      probePhase: "queued",
+    };
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
+    expect(screen.getByText("1 model")).toBeTruthy();
+    const refreshButton = screen.getByRole("button", { name: /^refresh$/i }) as HTMLButtonElement;
+    expect(refreshButton.disabled).toBe(false);
+    expect(screen.queryByRole("button", { name: "Refreshing…" })).toBeNull();
+  });
+
+  it("E-R10: failed_without_observation with a live probePhase shows one consistent affordance", () => {
+    state.launchOptions = {
+      harnessKind: "claude",
+      basisRevision: "b1",
+      revision: 9,
+      state: "failed_without_observation",
+      options: null,
+      observedAt: null,
+      probeAttemptedAt: isoAgo(0),
+      probeFailureCode: "harness_probe_failed",
+      readiness: "ready",
+      probePhase: "running",
+    };
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
+    expect(screen.getByText("Couldn't check models")).toBeTruthy();
+    const retryButton = screen.getByRole("button", { name: "Retry" }) as HTMLButtonElement;
+    expect(retryButton.disabled).toBe(false);
+    const refreshButton = screen.getByRole("button", { name: /^refresh$/i }) as HTMLButtonElement;
+    expect(refreshButton.disabled).toBe(false);
+    expect(screen.queryByRole("button", { name: "Refreshing…" })).toBeNull();
+  });
+
+  it("E-R12: a copied cloud snapshot in refreshing shows last-good count + freshness, not checking", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+    state.cloudSandbox = { id: "sandbox-1" };
+    state.cloudLaunchOptions = {
+      harnessKind: "claude",
+      basisRevision: "cloud-b1",
+      revision: 3,
+      state: "refreshing",
+      options: { models: [{ id: "m-1", observedName: "Model 1", observedDescription: null }], controls: [], defaults: { modelId: null, controlValues: {} } },
+      observedAt: isoAgo(120_000),
+      probeAttemptedAt: isoAgo(0),
+      probeFailureCode: null,
+      readiness: "ready",
+    };
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="cloud" />);
+    expect(screen.getByText("1 model")).toBeTruthy();
+    expect(screen.getByText("· refreshed 2m ago")).toBeTruthy();
+    expect(screen.queryByText("Checking available models…")).toBeNull();
+  });
+
+  it("E-R13: a disabled local query (no runtime URL) does not load forever", () => {
+    state.launchOptions = undefined;
+    state.isLoading = false;
+    state.isError = false;
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
+    expect(screen.getByText("Models couldn't be loaded")).toBeTruthy();
+    expect(screen.queryByText("Loading models…")).toBeNull();
+  });
+
+  it("E-R14: the expanded body does not contradict a header that already explains an empty state", () => {
+    state.launchOptions = undefined;
+    state.isLoading = false;
+    state.isError = true;
+    render(<HarnessAllModelsSection harnessKind="claude" displayName="Claude" surface="local" />);
+    fireEvent.click(screen.getByRole("button", { name: "Models" }));
+
+    expect(screen.getByText("Models couldn't be loaded")).toBeTruthy();
+    expect(screen.queryByText("No models detected yet.")).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
@@ -123,21 +123,26 @@ export function HarnessAllModelsSection({
   const probePhase = isLocal ? runtimeLaunchOptionsQuery.data?.probePhase : undefined;
   const isProbeLive = probePhase === "running" || probePhase === "queued";
 
-  // The 32-minute bug: a stale `detecting` response used to disable the one
-  // control that would cure it. Refresh is busy ONLY for its own mutation or
-  // a genuinely live probe — never for `detecting` alone, since a harness
-  // excluded from unattended probes (Cursor) sits `detecting` forever by
-  // design and must keep an enabled Refresh.
-  const isRefreshing = isLocal && (refreshLaunchOptions.isPending || isProbeLive);
-
-  // `state=refreshing` always means an active re-probe over last-good data
-  // (the polling policy in `resolveAgentLaunchOptionsRefetchInterval` treats
-  // it as unconditionally live); `state=detecting` is ambiguous on its own,
-  // so it needs the phase check to tell an active first observation apart
-  // from a settled-unobserved harness.
-  const isChecking = launchOptions?.state === "refreshing"
+  // `state=refreshing` is live only on the surface that can ever resolve it:
+  // cloud has no refetch interval and no Refresh control, so a copied
+  // `refreshing` snapshot there is not "checking" — it is last-good data
+  // that only a remount can refresh (E-R12). `state=detecting` is ambiguous
+  // on its own, so it needs the phase check to tell an active first
+  // observation apart from a settled-unobserved harness.
+  const isChecking = (isLocal && launchOptions?.state === "refreshing")
     || (launchOptions?.state === "detecting" && isProbeLive);
   const isIdleUnobserved = launchOptions?.state === "detecting" && !isProbeLive;
+
+  // The 32-minute bug's exact shape through a different door (E-R9): deriving
+  // "busy" from the raw `probePhase` disables Refresh in EVERY state,
+  // including terminal ones (e.g. `observed` + a stray live `probePhase`)
+  // that `resolveAgentLaunchOptionsRefetchInterval` never polls — frozen
+  // data behind a disabled button, with nothing ever scheduled to update it.
+  // Tying busy to `isChecking` instead means Refresh is disabled ONLY in a
+  // state that is actually polling (or mid-mutation), so it always has a
+  // way out. Also resolves E-R10: `failed_without_observation` can no
+  // longer show a disabled-and-spinning header next to an enabled Retry.
+  const isRefreshing = isLocal && (refreshLaunchOptions.isPending || isChecking);
 
   const modelCount = models.length;
   // `formatRelativeTime` is the repo's one relative-age formatter (six other
@@ -154,7 +159,13 @@ export function HarnessAllModelsSection({
       return { foreground: null, muted: HARNESS_PANE_COPY.allModelsLoading, retry: null };
     }
     if (!launchOptions) {
-      return isQueryError
+      // E-R13: `isLoading` is already false here (guarded above), so a local
+      // query with no data and no error is a DISABLED query — the runtime
+      // has no URL yet (`useAgentLaunchOptionsQuery` requires
+      // `runtimeUrl.length > 0`) — not one still in flight. Left alone this
+      // sits on "Loading models…" forever, a ninth state outside the
+      // spec's eight; state 8's copy is the closest honest match.
+      return isQueryError || isLocal
         ? {
           foreground: HARNESS_PANE_COPY.allModelsTransportErrorTitle,
           muted: HARNESS_PANE_COPY.allModelsTransportErrorReason,
@@ -174,6 +185,11 @@ export function HarnessAllModelsSection({
     }
     switch (launchOptions.state) {
       case "observed":
+      // E-R12: only reachable here on cloud (isChecking already consumed
+      // `refreshing` unconditionally for local) — cloud has no refetch
+      // interval and no Refresh control, so a copied `refreshing` snapshot
+      // is rendered as its last-good count + freshness, not as "checking".
+      case "refreshing":
         return { foreground: HARNESS_PANE_COPY.probeModelCount(modelCount), muted: freshnessLine, retry: null };
       case "observed_empty":
         return {
@@ -326,9 +342,16 @@ export function HarnessAllModelsSection({
             {HARNESS_PANE_COPY.allModelsChecking}
           </p>
         ) : models.length === 0 ? (
-          <p className="text-ui-sm text-muted-foreground">
-            {HARNESS_PANE_COPY.allModelsEmpty}
-          </p>
+          // E-R14: the header already carries the reason for an empty list
+          // in these two states (transport error / no observation ever
+          // succeeded) — echoing "No models detected yet." underneath would
+          // contradict it, e.g. "...The runtime didn't respond." followed by
+          // "No models detected yet." for a request that never answered.
+          isQueryError || launchOptions?.state === "failed_without_observation" ? null : (
+            <p className="text-ui-sm text-muted-foreground">
+              {HARNESS_PANE_COPY.allModelsEmpty}
+            </p>
+          )
         ) : (
           <ModelTable models={filteredRows} />
         )}

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
@@ -19,7 +19,8 @@ import { HARNESS_PANE_COPY } from "#product/copy/settings/harness-pane";
 import { SettingsSection } from "#product/primitives/patterns/settings/SettingsSection";
 import { useCloudAvailabilityState } from "#product/hooks/cloud/derived/use-cloud-availability-state";
 import { useToastStore } from "#product/stores/toast/toast-store";
-import { formatSnapshotAge, normalizeRuntimeLaunchModels } from "#product/lib/domain/settings/harness-catalog";
+import { normalizeRuntimeLaunchModels } from "#product/lib/domain/settings/harness-catalog";
+import { formatRelativeTime } from "#product/lib/domain/workspaces/display/workspace-display";
 
 interface HarnessAllModelsSectionProps {
   harnessKind: string;
@@ -98,7 +99,7 @@ export function HarnessAllModelsSection({
   // probe over an already-answered harness.
   function handleRetryLoad() {
     if (isLocal) {
-      void runtimeLaunchOptionsQuery.refetch();
+      void runtimeLaunchOptionsQuery.refetch?.();
     } else {
       void cloudSandbox.refetch?.();
       void cloudLaunchOptionsQuery.refetch?.();
@@ -114,16 +115,20 @@ export function HarnessAllModelsSection({
 
   // Absent when the runtime that served this response cannot know the phase
   // (e.g. the cloud-copied snapshot), which is exactly the same as "not
-  // running" for every check below.
+  // live" for every check below. `queued` counts as live alongside `running`:
+  // it is the same bucket the polling policy in
+  // `resolveAgentLaunchOptionsRefetchInterval` treats as active (agents.ts
+  // :105-107) — a probe that is about to run is not a settled-unobserved
+  // harness, so it must not read as the calm, permanent idle-unobserved copy.
   const probePhase = isLocal ? runtimeLaunchOptionsQuery.data?.probePhase : undefined;
-  const isProbeRunning = probePhase === "running";
+  const isProbeLive = probePhase === "running" || probePhase === "queued";
 
   // The 32-minute bug: a stale `detecting` response used to disable the one
   // control that would cure it. Refresh is busy ONLY for its own mutation or
-  // a genuinely running probe — never for `detecting` alone, since a harness
+  // a genuinely live probe — never for `detecting` alone, since a harness
   // excluded from unattended probes (Cursor) sits `detecting` forever by
   // design and must keep an enabled Refresh.
-  const isRefreshing = isLocal && (refreshLaunchOptions.isPending || isProbeRunning);
+  const isRefreshing = isLocal && (refreshLaunchOptions.isPending || isProbeLive);
 
   // `state=refreshing` always means an active re-probe over last-good data
   // (the polling policy in `resolveAgentLaunchOptionsRefetchInterval` treats
@@ -131,11 +136,14 @@ export function HarnessAllModelsSection({
   // so it needs the phase check to tell an active first observation apart
   // from a settled-unobserved harness.
   const isChecking = launchOptions?.state === "refreshing"
-    || (launchOptions?.state === "detecting" && isProbeRunning);
-  const isIdleUnobserved = launchOptions?.state === "detecting" && !isProbeRunning;
+    || (launchOptions?.state === "detecting" && isProbeLive);
+  const isIdleUnobserved = launchOptions?.state === "detecting" && !isProbeLive;
 
   const modelCount = models.length;
-  const ago = launchOptions?.observedAt ? formatSnapshotAge(launchOptions.observedAt) : null;
+  // `formatRelativeTime` is the repo's one relative-age formatter (six other
+  // call sites); reused rather than re-invented so "refreshed 2m ago" stays
+  // byte-identical to every other surface's phrasing.
+  const ago = launchOptions?.observedAt ? formatRelativeTime(launchOptions.observedAt) : null;
   const freshnessLine = ago ? HARNESS_PANE_COPY.allModelsFreshRefreshedAgo(ago) : null;
 
   // The one content line per state (Settings - Harness Models States
@@ -160,7 +168,7 @@ export function HarnessAllModelsSection({
     if (isIdleUnobserved) {
       return {
         foreground: HARNESS_PANE_COPY.allModelsIdleUnobservedTitle,
-        muted: HARNESS_PANE_COPY.allModelsIdleUnobservedSuffix(displayName),
+        muted: HARNESS_PANE_COPY.allModelsIdleUnobservedSuffix(displayName, canManuallyRefresh),
         retry: null,
       };
     }
@@ -219,17 +227,20 @@ export function HarnessAllModelsSection({
       action={(
         <>
           {canManuallyRefresh ? (
-            // Busy keeps full ink (an explicit `style` override defeats
-            // IconButton's own `disabled:opacity-50`, since its visuals are
-            // otherwise unchanged) — disabled must read as busy, never
-            // unavailable.
+            // Busy keeps full ink: `disabled:opacity-100` in `className`
+            // beats IconButton's own `disabled:opacity-50` (Tailwind orders
+            // opacity utilities by scale value, not by class-list position,
+            // so the higher value always wins the cascade once both are
+            // present) — the sanctioned busy-not-unavailable idiom used by
+            // SidebarUpdateFooterButton/WorkspaceCreationReceipt/
+            // GitReviewTargetSelector. IconButton itself stays unchanged.
             <IconButton
               aria-label={isRefreshing
                 ? HARNESS_PANE_COPY.allModelsRefreshing
                 : HARNESS_PANE_COPY.allModelsRefresh}
               title={HARNESS_PANE_COPY.allModelsRefresh}
               disabled={isRefreshing}
-              style={isRefreshing ? { opacity: 1 } : undefined}
+              className={isRefreshing ? "disabled:opacity-100" : undefined}
               onClick={handleRefresh}
             >
               <RefreshCw className={`icon-paired ${isRefreshing ? "animate-spin" : ""}`} />
@@ -303,6 +314,16 @@ export function HarnessAllModelsSection({
         {isLoading ? (
           <p className="text-ui-sm text-muted-foreground">
             {HARNESS_PANE_COPY.allModelsLoading}
+          </p>
+        ) : isChecking && models.length === 0 ? (
+          // E-R6: agree with the header only when there is no prior list to
+          // show yet (a first observation in progress). A re-probe over
+          // last-good data (`state === "refreshing"` with existing models)
+          // must keep the list visible undimmed — same "data stays readable
+          // while we wait" contract as state 6 — never blank it out for a
+          // "Checking…" placeholder.
+          <p className="text-ui-sm text-muted-foreground">
+            {HARNESS_PANE_COPY.allModelsChecking}
           </p>
         ) : models.length === 0 ? (
           <p className="text-ui-sm text-muted-foreground">

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
@@ -24,9 +24,11 @@ import { useToastStore } from "#product/stores/toast/toast-store";
 import { normalizeRuntimeLaunchModels } from "#product/lib/domain/settings/harness-catalog";
 import {
   resolveAllModelsPresentation,
+  type AllModelsRetryAffordance,
   type HarnessModelsFetchStatus,
   type HarnessModelsQueryFacts,
 } from "#product/lib/domain/settings/harness-models-presentation";
+import { useLocalRuntimeRestart } from "#product/hooks/access/anyharness/runtime/use-local-runtime-restart";
 import { formatRelativeTime } from "#product/lib/domain/workspaces/display/workspace-display";
 
 interface HarnessAllModelsSectionProps {
@@ -42,7 +44,6 @@ interface HarnessAllModelsSectionProps {
  * flight by `isPending` alone.
  */
 function queryFacts(result: {
-  isLoading?: boolean;
   isError?: boolean;
   isPending?: boolean;
   fetchStatus?: string;
@@ -52,14 +53,43 @@ function queryFacts(result: {
     ? "fetching"
     : result.fetchStatus === "paused" ? "paused" : "idle";
   return {
-    isLoading: Boolean(result.isLoading),
     isError: Boolean(result.isError),
     // A structured server code (e.g. the cloud read's not-observed 404) is a
     // different fact from a transport failure, and only the error carries it.
     errorCode: result.error instanceof ProliferateClientError ? result.error.code : null,
+    // The error middleware mints a `ProliferateClientError` from a non-2xx
+    // RESPONSE, so its presence is proof the server answered. A rejected fetch
+    // throws something else entirely, and that is the only failure where
+    // "didn't respond" is established rather than assumed (E-R30).
+    serverAnswered: result.error instanceof ProliferateClientError,
     isPending: Boolean(result.isPending),
     fetchStatus,
   };
+}
+
+/**
+ * The one handler each retry affordance names. A `switch` with no `default:`
+ * so a new affordance is a typecheck failure here rather than silently
+ * inheriting whichever branch a ternary chain happened to end on.
+ */
+function retryHandler(
+  retry: AllModelsRetryAffordance,
+  handlers: {
+    refetchRead: () => void;
+    reprobeHarness: () => void;
+    restartRuntime: (() => void) | null;
+  },
+): (() => void) | null {
+  switch (retry) {
+    case null:
+      return null;
+    case "refetch_read":
+      return handlers.refetchRead;
+    case "reprobe_harness":
+      return handlers.reprobeHarness;
+    case "restart_runtime":
+      return handlers.restartRuntime;
+  }
 }
 
 /**
@@ -82,6 +112,11 @@ export function HarnessAllModelsSection({
   // runtime URL for every non-healthy state, so the query alone cannot tell
   // "still connecting" from "gave up" (E-R22).
   const connectionState = useHarnessConnectionStore((state) => state.connectionState);
+  // Null on any host without the desktop runtime bridge, which is both "there
+  // is no restart to offer" and "there is no local runtime to wait for"
+  // (E-R33/E-R34). Capability, not `host.surface`, per the ProductHost
+  // contract's own guidance.
+  const restartLocalRuntime = useLocalRuntimeRestart();
 
   const refreshLaunchOptions = useRefreshHarnessLaunchOptionsMutation();
   const cloudSandbox = useCloudSandbox(!isLocal && cloudActive);
@@ -161,19 +196,23 @@ export function HarnessAllModelsSection({
     surface: isLocal ? "local" : "cloud",
     displayName,
     connectionState,
+    hasLocalRuntimeHost: restartLocalRuntime !== null,
     runtimeQuery: queryFacts(runtimeLaunchOptionsQuery),
     sandboxQuery: queryFacts(cloudSandbox),
     hasCloudSandboxId: Boolean(cloudSandbox.data?.id),
     cloudLaunchOptionsQuery: queryFacts(cloudLaunchOptionsQuery),
     launchOptions,
     isRefreshMutationPending: Boolean(refreshLaunchOptions.isPending),
+    isRefreshMutationPaused: Boolean(refreshLaunchOptions.isPaused),
     modelCount: models.length,
     freshnessAgo: launchOptions?.observedAt ? formatRelativeTime(launchOptions.observedAt) : null,
   });
   const isRefreshing = presentation.refresh === "spinning";
-  const onRetry = presentation.retry === "reprobe_harness"
-    ? handleRefresh
-    : presentation.retry === "refetch_read" ? handleRetryLoad : null;
+  const onRetry = retryHandler(presentation.retry, {
+    refetchRead: handleRetryLoad,
+    reprobeHarness: handleRefresh,
+    restartRuntime: restartLocalRuntime,
+  });
 
   // Evidence is diagnostic only; executable membership remains the response.
   const diagnosticsLines: string[] = [];

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import type { AgentAuthSurface } from "@proliferate/cloud-sdk";
+import { ProliferateClientError } from "@proliferate/cloud-sdk";
 import {
   useCloudHarnessLaunchOptions,
   useCloudSandbox,
@@ -18,8 +19,14 @@ import { ModelTable, type ModelTableRow } from "#product/components/settings/pan
 import { HARNESS_PANE_COPY } from "#product/copy/settings/harness-pane";
 import { SettingsSection } from "#product/primitives/patterns/settings/SettingsSection";
 import { useCloudAvailabilityState } from "#product/hooks/cloud/derived/use-cloud-availability-state";
+import { useHarnessConnectionStore } from "#product/stores/sessions/harness-connection-store";
 import { useToastStore } from "#product/stores/toast/toast-store";
 import { normalizeRuntimeLaunchModels } from "#product/lib/domain/settings/harness-catalog";
+import {
+  resolveAllModelsPresentation,
+  type HarnessModelsFetchStatus,
+  type HarnessModelsQueryFacts,
+} from "#product/lib/domain/settings/harness-models-presentation";
 import { formatRelativeTime } from "#product/lib/domain/workspaces/display/workspace-display";
 
 interface HarnessAllModelsSectionProps {
@@ -29,9 +36,39 @@ interface HarnessAllModelsSectionProps {
 }
 
 /**
+ * Reads one query result down to the facts the presentation resolver needs.
+ * `fetchStatus` is the discriminator the whole pane turns on: in v5 a DISABLED
+ * query with no data is `status: "pending"`, indistinguishable from one in
+ * flight by `isPending` alone.
+ */
+function queryFacts(result: {
+  isLoading?: boolean;
+  isError?: boolean;
+  isPending?: boolean;
+  fetchStatus?: string;
+  error?: unknown;
+}): HarnessModelsQueryFacts {
+  const fetchStatus: HarnessModelsFetchStatus = result.fetchStatus === "fetching"
+    ? "fetching"
+    : result.fetchStatus === "paused" ? "paused" : "idle";
+  return {
+    isLoading: Boolean(result.isLoading),
+    isError: Boolean(result.isError),
+    // A structured server code (e.g. the cloud read's not-observed 404) is a
+    // different fact from a transport failure, and only the error carries it.
+    errorCode: result.error instanceof ProliferateClientError ? result.error.code : null,
+    isPending: Boolean(result.isPending),
+    fetchStatus,
+  };
+}
+
+/**
  * Settings reads the selected target's launch-option response directly.
  * Local can request a new override-free observation; cloud reads the copied
  * target-scoped state and never seeds or overrides executable membership.
+ *
+ * Every status decision lives in `resolveAllModelsPresentation`; this
+ * component only renders what it returns.
  */
 export function HarnessAllModelsSection({
   harnessKind,
@@ -41,6 +78,10 @@ export function HarnessAllModelsSection({
   const { cloudActive } = useCloudAvailabilityState();
   const showToast = useToastStore((state) => state.show);
   const isLocal = surface === "local";
+  // The fact behind a disabled local query: `ProductProviderRoot` blanks the
+  // runtime URL for every non-healthy state, so the query alone cannot tell
+  // "still connecting" from "gave up" (E-R22).
+  const connectionState = useHarnessConnectionStore((state) => state.connectionState);
 
   const refreshLaunchOptions = useRefreshHarnessLaunchOptionsMutation();
   const cloudSandbox = useCloudSandbox(!isLocal && cloudActive);
@@ -67,21 +108,18 @@ export function HarnessAllModelsSection({
     description: model.description,
   }));
 
-  if (!isLocal && !cloudActive) {
-    return (
-      <SettingsSection title={HARNESS_PANE_COPY.tabAllModels} titleWeight="emphasized" surface="plain">
-        <p className="text-ui-sm text-muted-foreground">
-          {HARNESS_PANE_COPY.signInDescription(displayName)}
-        </p>
-      </SettingsSection>
+  const [filterText, setFilterText] = useState("");
+  const [listExpanded, setListExpanded] = useState(false);
+  const filteredRows = useMemo(() => {
+    if (!filterText.trim()) return rows;
+    const needle = filterText.trim().toLowerCase();
+    return rows.filter(
+      (row) =>
+        row.id.toLowerCase().includes(needle)
+        || row.displayName.toLowerCase().includes(needle)
+        || (row.description ?? "").toLowerCase().includes(needle),
     );
-  }
-
-  // Manual refresh exists only where a caller can actually trigger a probe:
-  // the runtime's param-less refresh route. The cloud-snapshot ingest route
-  // is Worker-authenticated only, so the cloud branch has no refresh
-  // affordance.
-  const canManuallyRefresh = isLocal;
+  }, [rows, filterText]);
 
   function handleRefresh() {
     if (!isLocal) {
@@ -106,184 +144,42 @@ export function HarnessAllModelsSection({
     }
   }
 
-  const isLoading = isLocal
-    ? runtimeLaunchOptionsQuery.isLoading
-    : cloudSandbox.isLoading || cloudLaunchOptionsQuery.isLoading;
-  const isQueryError = isLocal
-    ? Boolean(runtimeLaunchOptionsQuery.isError)
-    : Boolean(cloudSandbox.isError) || Boolean(cloudLaunchOptionsQuery.isError);
+  if (!isLocal && !cloudActive) {
+    return (
+      <SettingsSection title={HARNESS_PANE_COPY.tabAllModels} titleWeight="emphasized" surface="plain">
+        <p className="text-ui-sm text-muted-foreground">
+          {HARNESS_PANE_COPY.signInDescription(displayName)}
+        </p>
+      </SettingsSection>
+    );
+  }
 
-  // A DISABLED query with no data is `status: "pending"` in TanStack v5, which
-  // `isPending` alone cannot tell apart from a request actually in flight —
-  // the same trap `useAgentLaunchOptionsListQuery` fixes for its per-kind
-  // entries. `fetchStatus` is the discriminator: only a real request is
-  // non-idle. Rendering a disabled query as either a spinner or a failure
-  // invents a claim about a request nobody has made yet.
-  const isFetchInFlight = isLocal
-    ? runtimeLaunchOptionsQuery.fetchStatus !== "idle"
-    : cloudSandbox.fetchStatus !== "idle" || cloudLaunchOptionsQuery.fetchStatus !== "idle";
-  const hasNoPayloadAndNothingHappening = !launchOptions && !isQueryError && !isFetchInFlight;
-
-  // E-R17: the local runtime is still connecting, so this query has no URL to
-  // call yet — `harness-connection-store` starts at `connecting`,
-  // `ProductProviderRoot` only forwards a `runtimeUrl` once the state is
-  // `healthy`, and `useAgentLaunchOptionsQuery` requires
-  // `runtimeUrl.length > 0`. Nothing failed and nothing is running; the
-  // 500ms `pollUntilHealthy` retry resolves it without the user doing a thing.
-  const isRuntimeConnecting = isLocal
-    && hasNoPayloadAndNothingHappening
-    && Boolean(runtimeLaunchOptionsQuery.isPending);
-
-  // E-R18: `getCloudSandbox` answers 200 with a null body for an account that
-  // has no cloud workspace, so `cloudSandbox.data?.id` is undefined and the
-  // dependent launch-options query (which requires a non-empty target) never
-  // runs. Unlike the local case this never self-corrects, and cloud renders no
-  // Refresh at all — so a spinner here would hang with no cure in the view.
-  const isCloudWithoutWorkspace = !isLocal
-    && hasNoPayloadAndNothingHappening
-    && Boolean(cloudLaunchOptionsQuery.isPending);
-
-  // Absent when the runtime that served this response cannot know the phase
-  // (e.g. the cloud-copied snapshot), which is exactly the same as "not
-  // live" for every check below. `queued` counts as live alongside `running`:
-  // it is the same bucket the polling policy in
-  // `resolveAgentLaunchOptionsRefetchInterval` treats as active (agents.ts
-  // :105-107) — a probe that is about to run is not a settled-unobserved
-  // harness, so it must not read as the calm, permanent idle-unobserved copy.
-  const probePhase = isLocal ? runtimeLaunchOptionsQuery.data?.probePhase : undefined;
-  const isProbeLive = probePhase === "running" || probePhase === "queued";
-
-  // `state=refreshing` is live only on the surface that can ever resolve it:
-  // cloud has no refetch interval and no Refresh control, so a copied
-  // `refreshing` snapshot there is not "checking" — it is last-good data
-  // that only a remount can refresh (E-R12). `state=detecting` is ambiguous
-  // on its own, so it needs the phase check to tell an active first
-  // observation apart from a settled-unobserved harness.
-  const isChecking = (isLocal && launchOptions?.state === "refreshing")
-    || (launchOptions?.state === "detecting" && isProbeLive);
-  const isIdleUnobserved = launchOptions?.state === "detecting" && !isProbeLive;
-
-  // The 32-minute bug's exact shape through a different door (E-R9): deriving
-  // "busy" from the raw `probePhase` disables Refresh in EVERY state,
-  // including terminal ones (e.g. `observed` + a stray live `probePhase`)
-  // that `resolveAgentLaunchOptionsRefetchInterval` never polls — frozen
-  // data behind a disabled button, with nothing ever scheduled to update it.
-  // Tying busy to `isChecking` instead means Refresh is disabled ONLY in a
-  // state that is actually polling (or mid-mutation), so it always has a
-  // way out. Also resolves E-R10: `failed_without_observation` can no
-  // longer show a disabled-and-spinning header next to an enabled Retry.
-  const isRefreshing = isLocal && (refreshLaunchOptions.isPending || isChecking);
-
-  // E-R17: `refresh_now` cannot reach a runtime that is not up, so an enabled
-  // button here would be the same lie pointed the other way. Disabled, and
-  // deliberately NOT spinning — nothing is in flight to spin about, and it
-  // keeps the dimmed unavailable look rather than the busy-with-full-ink one.
-  const isRefreshUnavailable = isRuntimeConnecting;
-
-  const modelCount = models.length;
   // `formatRelativeTime` is the repo's one relative-age formatter (six other
   // call sites); reused rather than re-invented so "refreshed 2m ago" stays
   // byte-identical to every other surface's phrasing.
-  const ago = launchOptions?.observedAt ? formatRelativeTime(launchOptions.observedAt) : null;
-  const freshnessLine = ago ? HARNESS_PANE_COPY.allModelsFreshRefreshedAgo(ago) : null;
-
-  // The one content line per state (Settings - Harness Models States
-  // handoff): a raw wire state string is never rendered as copy, and the
-  // model count never renders before a settled observation exists.
-  const content: { foreground: string | null; muted: string | null; retry: (() => void) | null } = (() => {
-    if (isLoading) {
-      return { foreground: null, muted: HARNESS_PANE_COPY.allModelsLoading, retry: null };
-    }
-    if (!launchOptions) {
-      // Three different reasons produce "no payload", and collapsing any two
-      // of them fabricates state: only a request that was made and failed may
-      // claim failure, and only a request in flight may show a spinner.
-      if (isQueryError) {
-        return {
-          foreground: HARNESS_PANE_COPY.allModelsTransportErrorTitle,
-          muted: HARNESS_PANE_COPY.allModelsTransportErrorReason,
-          retry: handleRetryLoad,
-        };
-      }
-      if (isRuntimeConnecting) {
-        return {
-          foreground: HARNESS_PANE_COPY.allModelsRuntimeConnectingTitle,
-          muted: HARNESS_PANE_COPY.allModelsRuntimeConnectingSuffix,
-          retry: null,
-        };
-      }
-      if (isCloudWithoutWorkspace) {
-        return {
-          foreground: HARNESS_PANE_COPY.allModelsCloudNoWorkspaceTitle,
-          muted: HARNESS_PANE_COPY.allModelsCloudNoWorkspaceSuffix(displayName),
-          retry: null,
-        };
-      }
-      // What is left is a request genuinely in flight (`fetchStatus` non-idle
-      // without `isLoading`, e.g. a refetch that dropped its data).
-      return { foreground: null, muted: HARNESS_PANE_COPY.allModelsLoading, retry: null };
-    }
-    if (isChecking) {
-      return { foreground: null, muted: HARNESS_PANE_COPY.allModelsChecking, retry: null };
-    }
-    if (isIdleUnobserved) {
-      return {
-        foreground: HARNESS_PANE_COPY.allModelsIdleUnobservedTitle,
-        muted: HARNESS_PANE_COPY.allModelsIdleUnobservedSuffix(displayName, canManuallyRefresh),
-        retry: null,
-      };
-    }
-    switch (launchOptions.state) {
-      case "observed":
-      // E-R12: only reachable here on cloud (isChecking already consumed
-      // `refreshing` unconditionally for local) — cloud has no refetch
-      // interval and no Refresh control, so a copied `refreshing` snapshot
-      // is rendered as its last-good count + freshness, not as "checking".
-      case "refreshing":
-        return { foreground: HARNESS_PANE_COPY.probeModelCount(modelCount), muted: freshnessLine, retry: null };
-      case "observed_empty":
-        return {
-          foreground: HARNESS_PANE_COPY.probeModelCount(modelCount),
-          muted: ago ? HARNESS_PANE_COPY.allModelsObservedEmptySuffix(displayName, ago) : null,
-          retry: null,
-        };
-      case "last_good_after_failure":
-        return {
-          foreground: HARNESS_PANE_COPY.probeModelCount(modelCount),
-          muted: ago
-            ? HARNESS_PANE_COPY.allModelsLastGoodAfterFailureSuffix(ago)
-            : HARNESS_PANE_COPY.allModelsRefreshFailedBadge,
-          retry: null,
-        };
-      case "failed_without_observation":
-        return {
-          foreground: HARNESS_PANE_COPY.allModelsFailedWithoutObservationTitle,
-          muted: HARNESS_PANE_COPY.allModelsProbeFailureReason(displayName),
-          retry: canManuallyRefresh ? handleRefresh : null,
-        };
-      default:
-        return { foreground: null, muted: freshnessLine, retry: null };
-    }
-  })();
+  const presentation = resolveAllModelsPresentation({
+    surface: isLocal ? "local" : "cloud",
+    displayName,
+    connectionState,
+    runtimeQuery: queryFacts(runtimeLaunchOptionsQuery),
+    sandboxQuery: queryFacts(cloudSandbox),
+    hasCloudSandboxId: Boolean(cloudSandbox.data?.id),
+    cloudLaunchOptionsQuery: queryFacts(cloudLaunchOptionsQuery),
+    launchOptions,
+    isRefreshMutationPending: Boolean(refreshLaunchOptions.isPending),
+    modelCount: models.length,
+    freshnessAgo: launchOptions?.observedAt ? formatRelativeTime(launchOptions.observedAt) : null,
+  });
+  const isRefreshing = presentation.refresh === "spinning";
+  const onRetry = presentation.retry === "reprobe_harness"
+    ? handleRefresh
+    : presentation.retry === "refetch_read" ? handleRetryLoad : null;
 
   // Evidence is diagnostic only; executable membership remains the response.
   const diagnosticsLines: string[] = [];
   if (launchOptions) {
     diagnosticsLines.push(`Basis ${launchOptions.basisRevision} · revision ${launchOptions.revision}`);
   }
-
-  const [filterText, setFilterText] = useState("");
-  const [listExpanded, setListExpanded] = useState(false);
-  const filteredRows = useMemo(() => {
-    if (!filterText.trim()) return rows;
-    const needle = filterText.trim().toLowerCase();
-    return rows.filter(
-      (row) =>
-        row.id.toLowerCase().includes(needle)
-        || row.displayName.toLowerCase().includes(needle)
-        || (row.description ?? "").toLowerCase().includes(needle),
-    );
-  }, [rows, filterText]);
 
   return (
     <SettingsSection
@@ -292,26 +188,27 @@ export function HarnessAllModelsSection({
       surface="plain"
       action={(
         <>
-          {canManuallyRefresh ? (
+          {presentation.refresh === "absent" ? null : (
             // Busy keeps full ink: `disabled:opacity-100` in `className`
             // beats IconButton's own `disabled:opacity-50` (Tailwind orders
             // opacity utilities by scale value, not by class-list position,
             // so the higher value always wins the cascade once both are
             // present) — the sanctioned busy-not-unavailable idiom used by
             // SidebarUpdateFooterButton/WorkspaceCreationReceipt/
-            // GitReviewTargetSelector. IconButton itself stays unchanged.
+            // GitReviewTargetSelector. An UNAVAILABLE refresh keeps the
+            // ordinary dimmed disabled look instead, because it is not busy.
             <IconButton
               aria-label={isRefreshing
                 ? HARNESS_PANE_COPY.allModelsRefreshing
                 : HARNESS_PANE_COPY.allModelsRefresh}
               title={HARNESS_PANE_COPY.allModelsRefresh}
-              disabled={isRefreshing || isRefreshUnavailable}
+              disabled={presentation.refresh !== "enabled"}
               className={isRefreshing ? "disabled:opacity-100" : undefined}
               onClick={handleRefresh}
             >
               <RefreshCw className={`icon-paired ${isRefreshing ? "animate-spin" : ""}`} />
             </IconButton>
-          ) : null}
+          )}
           <IconButton
             aria-label={HARNESS_PANE_COPY.tabAllModels}
             aria-expanded={listExpanded}
@@ -329,18 +226,18 @@ export function HarnessAllModelsSection({
           state transitions (aria-live="polite"). */}
       <div className="flex items-center gap-3" aria-live="polite">
         <p className="text-body">
-          {content.foreground ? (
-            <span className="text-foreground">{content.foreground}</span>
+          {presentation.title ? (
+            <span className="text-foreground">{presentation.title}</span>
           ) : null}
-          {content.muted ? (
+          {presentation.detail ? (
             <span className="text-ui text-muted-foreground/65">
-              {content.foreground ? " · " : null}
-              {content.muted}
+              {presentation.title ? " · " : null}
+              {presentation.detail}
             </span>
           ) : null}
         </p>
-        {content.retry ? (
-          <Button variant="secondary" size="sm" onClick={content.retry}>
+        {onRetry ? (
+          <Button variant="secondary" size="sm" onClick={onRetry}>
             {HARNESS_PANE_COPY.allModelsRetry}
           </Button>
         ) : null}
@@ -377,11 +274,11 @@ export function HarnessAllModelsSection({
           />
         ) : null}
 
-        {isLoading ? (
+        {presentation.kind === "loading" ? (
           <p className="text-ui-sm text-muted-foreground">
             {HARNESS_PANE_COPY.allModelsLoading}
           </p>
-        ) : isChecking && models.length === 0 ? (
+        ) : presentation.kind === "checking" && models.length === 0 ? (
           // E-R6: agree with the header only when there is no prior list to
           // show yet (a first observation in progress). A re-probe over
           // last-good data (`state === "refreshing"` with existing models)
@@ -392,17 +289,12 @@ export function HarnessAllModelsSection({
             {HARNESS_PANE_COPY.allModelsChecking}
           </p>
         ) : models.length === 0 ? (
-          // E-R14/E-R19: the header already carries the reason for an empty
-          // list whenever there is no payload at all (transport error,
-          // runtime still connecting, no cloud workspace) or the probe never
-          // observed anything — echoing "No models detected yet." underneath
-          // would contradict it, e.g. "...The runtime didn't respond."
-          // followed by "No models detected yet.". Keyed on what drove the
-          // header, not on `isQueryError`, which only covers one of them.
-          isQueryError || !launchOptions
-            || launchOptions.state === "failed_without_observation" ? null : (
+          // E-R14/E-R19: `emptyBody` is null whenever the header already
+          // carries the reason the list is empty, so no arm can print a body
+          // that contradicts its own header.
+          presentation.emptyBody === null ? null : (
             <p className="text-ui-sm text-muted-foreground">
-              {HARNESS_PANE_COPY.allModelsEmpty}
+              {presentation.emptyBody}
             </p>
           )
         ) : (

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
@@ -11,6 +11,7 @@ import {
 import { ChevronRight } from "#product/primitives/icons/core";
 import { RefreshCw } from "#product/primitives/icons/platform";
 import { AnimatedCollapsibleContent } from "#product/primitives/AnimatedCollapsibleContent";
+import { Button } from "#product/primitives/Button";
 import { IconButton } from "#product/primitives/IconButton";
 import { HarnessAllModelsFilterRow } from "#product/components/settings/panes/agents/harness/HarnessAllModelsFilterRow";
 import { ModelTable, type ModelTableRow } from "#product/components/settings/panes/agents/harness/ModelTable";
@@ -18,7 +19,7 @@ import { HARNESS_PANE_COPY } from "#product/copy/settings/harness-pane";
 import { SettingsSection } from "#product/primitives/patterns/settings/SettingsSection";
 import { useCloudAvailabilityState } from "#product/hooks/cloud/derived/use-cloud-availability-state";
 import { useToastStore } from "#product/stores/toast/toast-store";
-import { normalizeRuntimeLaunchModels } from "#product/lib/domain/settings/harness-catalog";
+import { formatSnapshotAge, normalizeRuntimeLaunchModels } from "#product/lib/domain/settings/harness-catalog";
 
 interface HarnessAllModelsSectionProps {
   harnessKind: string;
@@ -92,18 +93,104 @@ export function HarnessAllModelsSection({
     });
   }
 
+  // Retry-on-load-failure refetches the query itself (no payload exists to
+  // probe against yet); distinct from `handleRefresh`, which requests a new
+  // probe over an already-answered harness.
+  function handleRetryLoad() {
+    if (isLocal) {
+      void runtimeLaunchOptionsQuery.refetch();
+    } else {
+      void cloudSandbox.refetch?.();
+      void cloudLaunchOptionsQuery.refetch?.();
+    }
+  }
+
   const isLoading = isLocal
     ? runtimeLaunchOptionsQuery.isLoading
     : cloudSandbox.isLoading || cloudLaunchOptionsQuery.isLoading;
-  const isRefreshing = isLocal
-    && (refreshLaunchOptions.isPending || runtimeLaunchOptionsQuery.data?.state === "refreshing" || runtimeLaunchOptionsQuery.data?.state === "detecting");
-  // Empty list with a probe in flight shows the probing state instead of the
-  // static empty copy.
-  const isProbingEmpty = models.length === 0 && isRefreshing;
+  const isQueryError = isLocal
+    ? Boolean(runtimeLaunchOptionsQuery.isError)
+    : Boolean(cloudSandbox.isError) || Boolean(cloudLaunchOptionsQuery.isError);
 
-  const freshnessLine = launchOptions?.observedAt
-    ? `Last refreshed ${new Date(launchOptions.observedAt).toLocaleString()}`
-    : launchOptions?.state ?? "";
+  // Absent when the runtime that served this response cannot know the phase
+  // (e.g. the cloud-copied snapshot), which is exactly the same as "not
+  // running" for every check below.
+  const probePhase = isLocal ? runtimeLaunchOptionsQuery.data?.probePhase : undefined;
+  const isProbeRunning = probePhase === "running";
+
+  // The 32-minute bug: a stale `detecting` response used to disable the one
+  // control that would cure it. Refresh is busy ONLY for its own mutation or
+  // a genuinely running probe — never for `detecting` alone, since a harness
+  // excluded from unattended probes (Cursor) sits `detecting` forever by
+  // design and must keep an enabled Refresh.
+  const isRefreshing = isLocal && (refreshLaunchOptions.isPending || isProbeRunning);
+
+  // `state=refreshing` always means an active re-probe over last-good data
+  // (the polling policy in `resolveAgentLaunchOptionsRefetchInterval` treats
+  // it as unconditionally live); `state=detecting` is ambiguous on its own,
+  // so it needs the phase check to tell an active first observation apart
+  // from a settled-unobserved harness.
+  const isChecking = launchOptions?.state === "refreshing"
+    || (launchOptions?.state === "detecting" && isProbeRunning);
+  const isIdleUnobserved = launchOptions?.state === "detecting" && !isProbeRunning;
+
+  const modelCount = models.length;
+  const ago = launchOptions?.observedAt ? formatSnapshotAge(launchOptions.observedAt) : null;
+  const freshnessLine = ago ? HARNESS_PANE_COPY.allModelsFreshRefreshedAgo(ago) : null;
+
+  // The one content line per state (Settings - Harness Models States
+  // handoff): a raw wire state string is never rendered as copy, and the
+  // model count never renders before a settled observation exists.
+  const content: { foreground: string | null; muted: string | null; retry: (() => void) | null } = (() => {
+    if (isLoading) {
+      return { foreground: null, muted: HARNESS_PANE_COPY.allModelsLoading, retry: null };
+    }
+    if (!launchOptions) {
+      return isQueryError
+        ? {
+          foreground: HARNESS_PANE_COPY.allModelsTransportErrorTitle,
+          muted: HARNESS_PANE_COPY.allModelsTransportErrorReason,
+          retry: handleRetryLoad,
+        }
+        : { foreground: null, muted: HARNESS_PANE_COPY.allModelsLoading, retry: null };
+    }
+    if (isChecking) {
+      return { foreground: null, muted: HARNESS_PANE_COPY.allModelsChecking, retry: null };
+    }
+    if (isIdleUnobserved) {
+      return {
+        foreground: HARNESS_PANE_COPY.allModelsIdleUnobservedTitle,
+        muted: HARNESS_PANE_COPY.allModelsIdleUnobservedSuffix(displayName),
+        retry: null,
+      };
+    }
+    switch (launchOptions.state) {
+      case "observed":
+        return { foreground: HARNESS_PANE_COPY.probeModelCount(modelCount), muted: freshnessLine, retry: null };
+      case "observed_empty":
+        return {
+          foreground: HARNESS_PANE_COPY.probeModelCount(modelCount),
+          muted: ago ? HARNESS_PANE_COPY.allModelsObservedEmptySuffix(displayName, ago) : null,
+          retry: null,
+        };
+      case "last_good_after_failure":
+        return {
+          foreground: HARNESS_PANE_COPY.probeModelCount(modelCount),
+          muted: ago
+            ? HARNESS_PANE_COPY.allModelsLastGoodAfterFailureSuffix(ago)
+            : HARNESS_PANE_COPY.allModelsRefreshFailedBadge,
+          retry: null,
+        };
+      case "failed_without_observation":
+        return {
+          foreground: HARNESS_PANE_COPY.allModelsFailedWithoutObservationTitle,
+          muted: HARNESS_PANE_COPY.allModelsProbeFailureReason(displayName),
+          retry: canManuallyRefresh ? handleRefresh : null,
+        };
+      default:
+        return { foreground: null, muted: freshnessLine, retry: null };
+    }
+  })();
 
   // Evidence is diagnostic only; executable membership remains the response.
   const diagnosticsLines: string[] = [];
@@ -124,18 +211,6 @@ export function HarnessAllModelsSection({
     );
   }, [rows, filterText]);
 
-  // The quiet v2 header (design-handoff "Models section"): title + refresh
-  // icon + rotating chevron on the right; ONE content line — the model count
-  // in foreground with the provenance/freshness suffix muted. No badge pile,
-  // no long fallback description.
-  const contentSuffix = isLoading
-    ? HARNESS_PANE_COPY.allModelsLoading
-    : isRefreshing
-      ? HARNESS_PANE_COPY.allModelsProbing
-      : launchOptions?.state === "last_good_after_failure"
-        ? HARNESS_PANE_COPY.allModelsRefreshFailedBadge
-        : freshnessLine;
-
   return (
     <SettingsSection
       title={HARNESS_PANE_COPY.tabAllModels}
@@ -144,12 +219,17 @@ export function HarnessAllModelsSection({
       action={(
         <>
           {canManuallyRefresh ? (
+            // Busy keeps full ink (an explicit `style` override defeats
+            // IconButton's own `disabled:opacity-50`, since its visuals are
+            // otherwise unchanged) — disabled must read as busy, never
+            // unavailable.
             <IconButton
               aria-label={isRefreshing
                 ? HARNESS_PANE_COPY.allModelsRefreshing
                 : HARNESS_PANE_COPY.allModelsRefresh}
               title={HARNESS_PANE_COPY.allModelsRefresh}
               disabled={isRefreshing}
+              style={isRefreshing ? { opacity: 1 } : undefined}
               onClick={handleRefresh}
             >
               <RefreshCw className={`icon-paired ${isRefreshing ? "animate-spin" : ""}`} />
@@ -168,17 +248,26 @@ export function HarnessAllModelsSection({
       )}
       data-harness-status="models"
     >
-      <p className="text-body">
-        <span className="text-foreground">
-          {HARNESS_PANE_COPY.probeModelCount(models.length)}
-        </span>
-        {contentSuffix ? (
-          <span className="text-ui text-muted-foreground/65">
-            {" · "}
-            {contentSuffix}
-          </span>
+      {/* The content line is the section's status text: re-announced only on
+          state transitions (aria-live="polite"). */}
+      <div className="flex items-center gap-3" aria-live="polite">
+        <p className="text-body">
+          {content.foreground ? (
+            <span className="text-foreground">{content.foreground}</span>
+          ) : null}
+          {content.muted ? (
+            <span className="text-ui text-muted-foreground/65">
+              {content.foreground ? " · " : null}
+              {content.muted}
+            </span>
+          ) : null}
+        </p>
+        {content.retry ? (
+          <Button variant="secondary" size="sm" onClick={content.retry}>
+            {HARNESS_PANE_COPY.allModelsRetry}
+          </Button>
         ) : null}
-      </p>
+      </div>
 
       {/*
         Disclosure is deferred here, recorded rather than re-derived: the model
@@ -214,11 +303,6 @@ export function HarnessAllModelsSection({
         {isLoading ? (
           <p className="text-ui-sm text-muted-foreground">
             {HARNESS_PANE_COPY.allModelsLoading}
-          </p>
-        ) : isProbingEmpty ? (
-          <p className="flex items-center gap-2 text-ui-sm text-muted-foreground">
-            <RefreshCw className="icon-paired animate-spin" />
-            {HARNESS_PANE_COPY.allModelsProbing}
           </p>
         ) : models.length === 0 ? (
           <p className="text-ui-sm text-muted-foreground">

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
@@ -24,6 +24,7 @@ import { useToastStore } from "#product/stores/toast/toast-store";
 import { normalizeRuntimeLaunchModels } from "#product/lib/domain/settings/harness-catalog";
 import {
   resolveAllModelsPresentation,
+  type AllModelsPayloadFacts,
   type AllModelsRetryAffordance,
   type HarnessModelsFetchStatus,
   type HarnessModelsQueryFacts,
@@ -132,6 +133,19 @@ export function HarnessAllModelsSection({
   const launchOptions = isLocal
     ? runtimeLaunchOptionsQuery.data
     : cloudLaunchOptionsQuery.data;
+  // Engine ownership is a fact about the runtime SERVING the response, and the
+  // cloud snapshot has no field for it: the copy in Proliferate Cloud was taken
+  // from whichever runtime observed the harness, and this browser is not that
+  // runtime. Said out loud here rather than left to an absent field defaulting
+  // to false, which keeps the SDK field non-optional so a local runtime that
+  // stops sending it is a build break instead of a silently dimmed Refresh.
+  // Cloud renders no Refresh control at all, so on cloud this only governs
+  // which failed-probe line is shown, where "cannot re-probe" is the truth.
+  const payloadFacts: AllModelsPayloadFacts | undefined = isLocal
+    ? runtimeLaunchOptionsQuery.data
+    : cloudLaunchOptionsQuery.data
+      ? { ...cloudLaunchOptionsQuery.data, canManuallyRefresh: false }
+      : undefined;
   const models = useMemo(
     () => normalizeRuntimeLaunchModels(harnessKind, launchOptions),
     [harnessKind, launchOptions],
@@ -201,7 +215,7 @@ export function HarnessAllModelsSection({
     sandboxQuery: queryFacts(cloudSandbox),
     hasCloudSandboxId: Boolean(cloudSandbox.data?.id),
     cloudLaunchOptionsQuery: queryFacts(cloudLaunchOptionsQuery),
-    launchOptions,
+    launchOptions: payloadFacts,
     isRefreshMutationPending: Boolean(refreshLaunchOptions.isPending),
     isRefreshMutationPaused: Boolean(refreshLaunchOptions.isPaused),
     modelCount: models.length,

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx
@@ -113,6 +113,36 @@ export function HarnessAllModelsSection({
     ? Boolean(runtimeLaunchOptionsQuery.isError)
     : Boolean(cloudSandbox.isError) || Boolean(cloudLaunchOptionsQuery.isError);
 
+  // A DISABLED query with no data is `status: "pending"` in TanStack v5, which
+  // `isPending` alone cannot tell apart from a request actually in flight —
+  // the same trap `useAgentLaunchOptionsListQuery` fixes for its per-kind
+  // entries. `fetchStatus` is the discriminator: only a real request is
+  // non-idle. Rendering a disabled query as either a spinner or a failure
+  // invents a claim about a request nobody has made yet.
+  const isFetchInFlight = isLocal
+    ? runtimeLaunchOptionsQuery.fetchStatus !== "idle"
+    : cloudSandbox.fetchStatus !== "idle" || cloudLaunchOptionsQuery.fetchStatus !== "idle";
+  const hasNoPayloadAndNothingHappening = !launchOptions && !isQueryError && !isFetchInFlight;
+
+  // E-R17: the local runtime is still connecting, so this query has no URL to
+  // call yet — `harness-connection-store` starts at `connecting`,
+  // `ProductProviderRoot` only forwards a `runtimeUrl` once the state is
+  // `healthy`, and `useAgentLaunchOptionsQuery` requires
+  // `runtimeUrl.length > 0`. Nothing failed and nothing is running; the
+  // 500ms `pollUntilHealthy` retry resolves it without the user doing a thing.
+  const isRuntimeConnecting = isLocal
+    && hasNoPayloadAndNothingHappening
+    && Boolean(runtimeLaunchOptionsQuery.isPending);
+
+  // E-R18: `getCloudSandbox` answers 200 with a null body for an account that
+  // has no cloud workspace, so `cloudSandbox.data?.id` is undefined and the
+  // dependent launch-options query (which requires a non-empty target) never
+  // runs. Unlike the local case this never self-corrects, and cloud renders no
+  // Refresh at all — so a spinner here would hang with no cure in the view.
+  const isCloudWithoutWorkspace = !isLocal
+    && hasNoPayloadAndNothingHappening
+    && Boolean(cloudLaunchOptionsQuery.isPending);
+
   // Absent when the runtime that served this response cannot know the phase
   // (e.g. the cloud-copied snapshot), which is exactly the same as "not
   // live" for every check below. `queued` counts as live alongside `running`:
@@ -144,6 +174,12 @@ export function HarnessAllModelsSection({
   // longer show a disabled-and-spinning header next to an enabled Retry.
   const isRefreshing = isLocal && (refreshLaunchOptions.isPending || isChecking);
 
+  // E-R17: `refresh_now` cannot reach a runtime that is not up, so an enabled
+  // button here would be the same lie pointed the other way. Disabled, and
+  // deliberately NOT spinning — nothing is in flight to spin about, and it
+  // keeps the dimmed unavailable look rather than the busy-with-full-ink one.
+  const isRefreshUnavailable = isRuntimeConnecting;
+
   const modelCount = models.length;
   // `formatRelativeTime` is the repo's one relative-age formatter (six other
   // call sites); reused rather than re-invented so "refreshed 2m ago" stays
@@ -159,19 +195,33 @@ export function HarnessAllModelsSection({
       return { foreground: null, muted: HARNESS_PANE_COPY.allModelsLoading, retry: null };
     }
     if (!launchOptions) {
-      // E-R13: `isLoading` is already false here (guarded above), so a local
-      // query with no data and no error is a DISABLED query — the runtime
-      // has no URL yet (`useAgentLaunchOptionsQuery` requires
-      // `runtimeUrl.length > 0`) — not one still in flight. Left alone this
-      // sits on "Loading models…" forever, a ninth state outside the
-      // spec's eight; state 8's copy is the closest honest match.
-      return isQueryError || isLocal
-        ? {
+      // Three different reasons produce "no payload", and collapsing any two
+      // of them fabricates state: only a request that was made and failed may
+      // claim failure, and only a request in flight may show a spinner.
+      if (isQueryError) {
+        return {
           foreground: HARNESS_PANE_COPY.allModelsTransportErrorTitle,
           muted: HARNESS_PANE_COPY.allModelsTransportErrorReason,
           retry: handleRetryLoad,
-        }
-        : { foreground: null, muted: HARNESS_PANE_COPY.allModelsLoading, retry: null };
+        };
+      }
+      if (isRuntimeConnecting) {
+        return {
+          foreground: HARNESS_PANE_COPY.allModelsRuntimeConnectingTitle,
+          muted: HARNESS_PANE_COPY.allModelsRuntimeConnectingSuffix,
+          retry: null,
+        };
+      }
+      if (isCloudWithoutWorkspace) {
+        return {
+          foreground: HARNESS_PANE_COPY.allModelsCloudNoWorkspaceTitle,
+          muted: HARNESS_PANE_COPY.allModelsCloudNoWorkspaceSuffix(displayName),
+          retry: null,
+        };
+      }
+      // What is left is a request genuinely in flight (`fetchStatus` non-idle
+      // without `isLoading`, e.g. a refetch that dropped its data).
+      return { foreground: null, muted: HARNESS_PANE_COPY.allModelsLoading, retry: null };
     }
     if (isChecking) {
       return { foreground: null, muted: HARNESS_PANE_COPY.allModelsChecking, retry: null };
@@ -255,7 +305,7 @@ export function HarnessAllModelsSection({
                 ? HARNESS_PANE_COPY.allModelsRefreshing
                 : HARNESS_PANE_COPY.allModelsRefresh}
               title={HARNESS_PANE_COPY.allModelsRefresh}
-              disabled={isRefreshing}
+              disabled={isRefreshing || isRefreshUnavailable}
               className={isRefreshing ? "disabled:opacity-100" : undefined}
               onClick={handleRefresh}
             >
@@ -342,12 +392,15 @@ export function HarnessAllModelsSection({
             {HARNESS_PANE_COPY.allModelsChecking}
           </p>
         ) : models.length === 0 ? (
-          // E-R14: the header already carries the reason for an empty list
-          // in these two states (transport error / no observation ever
-          // succeeded) — echoing "No models detected yet." underneath would
-          // contradict it, e.g. "...The runtime didn't respond." followed by
-          // "No models detected yet." for a request that never answered.
-          isQueryError || launchOptions?.state === "failed_without_observation" ? null : (
+          // E-R14/E-R19: the header already carries the reason for an empty
+          // list whenever there is no payload at all (transport error,
+          // runtime still connecting, no cloud workspace) or the probe never
+          // observed anything — echoing "No models detected yet." underneath
+          // would contradict it, e.g. "...The runtime didn't respond."
+          // followed by "No models detected yet.". Keyed on what drove the
+          // header, not on `isQueryError`, which only covers one of them.
+          isQueryError || !launchOptions
+            || launchOptions.state === "failed_without_observation" ? null : (
             <p className="text-ui-sm text-muted-foreground">
               {HARNESS_PANE_COPY.allModelsEmpty}
             </p>

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
@@ -154,6 +154,9 @@ vi.mock("@anyharness/sdk-react", () => ({
         probeAttemptedAt: "2026-08-19T00:00:00Z",
         probeFailureCode: null,
         readiness: "ready",
+        // The LOCAL runtime owns its probe engine in this fixture; the cloud
+        // hook above carries no such field, because the wire has none.
+        canManuallyRefresh: true,
       } : undefined,
       isLoading: false,
     };
@@ -1162,19 +1165,14 @@ describe("HarnessPane all models", () => {
 });
 
 describe("HarnessPane all models (local composed observation)", () => {
+  const oneModelObservation = () => ({
+    agent: "claude", schemaVersion: 2, probeEngine: "owner", state: "idle",
+    probedAt: "2026-07-02T20:00:00Z", snapshotAgeSeconds: 90, modelCount: 1, modeCount: 0,
+    models: [{ id: "claude-sonnet-4-5", name: "Sonnet 4.6", provider: "anthropic" }],
+    modes: [],
+  });
   it("reads the runtime launch-option observation", () => {
-    state.modelSnapshotStatus.data = {
-      agent: "claude",
-      schemaVersion: 2,
-      probeEngine: "owner",
-      state: "idle",
-      probedAt: "2026-07-02T20:00:00Z",
-      snapshotAgeSeconds: 90,
-      modelCount: 1,
-      modeCount: 0,
-      models: [{ id: "claude-sonnet-4-5", name: "Sonnet 4.6", provider: "anthropic" }],
-      modes: [],
-    };
+    state.modelSnapshotStatus.data = oneModelObservation();
     renderPane("claude");
 
     expect(screen.queryByText("1 model")).not.toBeNull();
@@ -1194,6 +1192,8 @@ describe("HarnessPane all models (local composed observation)", () => {
   });
 
   it("hits the param-less runtime refresh endpoint for the local surface", () => {
+    // Round 5: Refresh needs a payload (ownership is a field on it).
+    state.modelSnapshotStatus.data = oneModelObservation();
     renderPane("claude");
 
     fireEvent.click(screen.getByRole("button", { name: /^Refresh$/ }));

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
@@ -291,8 +291,8 @@ vi.mock("#product/hooks/agents/workflows/use-harness-install-action", () => ({
 }));
 vi.mock("#product/providers/CloudAnyHarnessRuntimeProvider", () => ({ CloudAnyHarnessRuntimeProvider: ({ children }: { children: React.ReactNode }) => children }));
 vi.mock("#product/stores/sessions/harness-connection-store", () => ({
-  useHarnessConnectionStore: (selector: (s: { runtimeUrl: string }) => unknown) =>
-    selector({ runtimeUrl: "http://127.0.0.1:8457" }),
+  useHarnessConnectionStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ runtimeUrl: "http://127.0.0.1:8457", connectionState: "healthy" }),
 }));
 
 vi.mock("#product/hooks/access/anyharness/agents/use-agent-resources-cache", () => ({

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
@@ -4,12 +4,12 @@ import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ProductHostProvider } from "@proliferate/product-client/host/ProductHostProvider";
-import { makeTestProductHost } from "#product/test/product-host-test-utils";
+import { makeTestProductHost, type TestProductHostOptions } from "#product/test/product-host-test-utils";
 import { HarnessPane } from "#product/components/settings/panes/agents/harness/HarnessPane";
 
-// Anonymous host keeps the organizations query disabled, matching the prior
-// unset-auth-store default these tests ran under.
-const harnessTestHost = makeTestProductHost();
+// Anonymous host keeps the organizations query disabled, as before. Its
+// desktop runtime bridge is what makes the LOCAL surface real here (E-R34).
+const harnessTestHost = makeTestProductHost({ desktop: { runtime: { getConnection: vi.fn(), restart: vi.fn() } } as TestProductHostOptions["desktop"] });
 
 type CapabilitiesData = {
   gatewayEnabled: boolean;

--- a/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
+++ b/apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessPane.test.tsx
@@ -1178,7 +1178,7 @@ describe("HarnessPane all models (local composed observation)", () => {
     renderPane("claude");
 
     expect(screen.queryByText("1 model")).not.toBeNull();
-    expect(screen.queryByText(/Last refreshed/)).not.toBeNull();
+    expect(screen.queryByText(/refreshed/)).not.toBeNull(); // E-R1: "Last refreshed" copy is gone
     expandModelList();
     expect(screen.queryByText("Sonnet 4.6")).not.toBeNull();
     expect(screen.queryByRole("switch")).toBeNull();
@@ -1188,7 +1188,7 @@ describe("HarnessPane all models (local composed observation)", () => {
     state.modelSnapshotStatus.data = undefined;
     renderPane("claude");
 
-    expect(screen.queryByText("0 models")).not.toBeNull();
+    expect(screen.queryByText(/\d+ models?/)).toBeNull(); // E-R1: no count before a settled observation
     expandModelList();
     expect(screen.queryByText("Sonnet 4.6")).toBeNull();
   });

--- a/apps/packages/product-client/src/copy/settings/harness-pane.ts
+++ b/apps/packages/product-client/src/copy/settings/harness-pane.ts
@@ -60,20 +60,46 @@ export const HARNESS_PANE_COPY = {
   runLoginOpening: "Opening...",
   // Section title for the inline all-models panel.
   tabAllModels: "Models",
-  // The one content line of the collapsed Models section (design-handoff v2):
-  // count in foreground, provenance suffix muted.
+  // The one content line of the collapsed Models section (Settings - Harness
+  // Models States handoff, all eight states): count/title in foreground,
+  // provenance suffix muted.
   allModelsSeedSuffix: "shipped catalog, not probed yet",
   allModelsRefresh: "Refresh",
-  allModelsRefreshing: "Refreshing...",
+  allModelsRefreshing: "Refreshing…",
   allModelsEmpty: "No models detected yet.",
-  allModelsLoading: "Loading model catalog...",
-  // Shown while an empty list has a probe in flight.
-  allModelsProbing: "Probing…",
+  // State 1 — initial HTTP loading, no payload yet.
+  allModelsLoading: "Loading models…",
+  // State 2 — state=detecting|refreshing AND probePhase=running: an active
+  // first observation or re-probe. Never paired with a count.
+  allModelsChecking: "Checking available models…",
+  // State 3 — state=detecting AND probePhase=idle (or unknown): a harness
+  // that legitimately sits unobserved forever because it isn't probed
+  // unattended (the Cursor regression fixture). Refresh stays enabled; this
+  // replaces the old indefinite "Probing…" + disabled Refresh bug.
+  allModelsIdleUnobservedTitle: "Models haven't been detected yet",
+  allModelsIdleUnobservedSuffix: (displayName: string) =>
+    `${displayName} reports models after its first launch. Refresh checks now.`,
+  // State 5 — state=observed_empty: a settled, honest zero.
+  allModelsObservedEmptySuffix: (displayName: string, ago: string) =>
+    `${displayName} reported none · ${HARNESS_PANE_COPY.allModelsFreshRefreshedAgo(ago)}`,
   // The composed observation (model-catalog.md "The picker is the
   // observation"): the only freshness display is the probedAt age plus the
   // lastAttempt outcome — age alone never blocks anything, and there is no
   // staleness state.
   allModelsRefreshFailedBadge: "last refresh failed",
+  // State 6 — state=last_good_after_failure: the prior observation stays
+  // rendered, undimmed, with exactly one refresh-failed line appended.
+  allModelsLastGoodAfterFailureSuffix: (ago: string) =>
+    `${HARNESS_PANE_COPY.allModelsRefreshFailedBadge} · ${HARNESS_PANE_COPY.allModelsFreshRefreshedAgo(ago)}`,
+  // State 7 — state=failed_without_observation: no count line exists to
+  // fake; an explicit failure with its enabled cure (ruling 5).
+  allModelsFailedWithoutObservationTitle: "Couldn't check models",
+  allModelsProbeFailureReason: (displayName: string) => `${displayName} didn't answer the probe.`,
+  // State 8 — the launch-options request itself failed (no payload). Never
+  // rendered as a raw state string.
+  allModelsTransportErrorTitle: "Models couldn't be loaded",
+  allModelsTransportErrorReason: "The runtime didn't respond.",
+  allModelsRetry: "Retry",
   allModelsSeedDescription:
     "Showing shipped catalog models — not yet verified by a probe.",
   // Diagnostics-only provenance (attestation + install identity) — never a gate.

--- a/apps/packages/product-client/src/copy/settings/harness-pane.ts
+++ b/apps/packages/product-client/src/copy/settings/harness-pane.ts
@@ -116,6 +116,28 @@ export const HARNESS_PANE_COPY = {
   allModelsCloudNoWorkspaceTitle: "No cloud workspace yet",
   allModelsCloudNoWorkspaceSuffix: (displayName: string) =>
     `${displayName} models are listed once a cloud workspace exists.`,
+  // E-R22 — `pollUntilHealthy` gave up. This never cures itself, so the line
+  // carries the one action that does. Restarting the app is not a control
+  // this section renders, so E-R5 (never name a button that isn't here) is
+  // satisfied while the arm still ends in something the user can do.
+  allModelsRuntimeFailedTitle: "The local runtime didn't start",
+  allModelsRuntimeFailedSuffix: "Restart Proliferate to try again.",
+  // E-R23 — query-core parked the request because the browser is offline.
+  // Nothing is in flight and nothing failed; the network returning resumes it.
+  allModelsOfflineTitle: "You're offline",
+  allModelsOfflineSuffix: "Models load when the connection is back.",
+  // E-R24 — a structured 404 from the cloud read: the target exists and the
+  // server answered, it just has nothing ingested yet. The ordinary first-run
+  // screen for a workspace that has never run an agent, not a failure.
+  allModelsCloudNotObservedSuffix: (displayName: string) =>
+    `${displayName} reports models after its first run in this workspace.`,
+  // A genuine cloud transport failure, kept apart from the local runtime's:
+  // "the runtime didn't respond" names the wrong hop for a cloud API call.
+  allModelsCloudUnreachableReason: "Proliferate Cloud didn't respond.",
+  // The enabled-but-never-started read. Unreachable in query-core today, but
+  // enumerated with a cure that works rather than folded into another arm.
+  allModelsNotReadYetTitle: "Models haven't been read yet",
+  allModelsNotReadYetSuffix: "Retry to check now.",
   allModelsRetry: "Retry",
   allModelsSeedDescription:
     "Showing shipped catalog models — not yet verified by a probe.",

--- a/apps/packages/product-client/src/copy/settings/harness-pane.ts
+++ b/apps/packages/product-client/src/copy/settings/harness-pane.ts
@@ -116,16 +116,26 @@ export const HARNESS_PANE_COPY = {
   allModelsCloudNoWorkspaceTitle: "No cloud workspace yet",
   allModelsCloudNoWorkspaceSuffix: (displayName: string) =>
     `${displayName} models are listed once a cloud workspace exists.`,
-  // E-R22 — `pollUntilHealthy` gave up. This never cures itself, so the line
-  // carries the one action that does. Restarting the app is not a control
-  // this section renders, so E-R5 (never name a button that isn't here) is
-  // satisfied while the arm still ends in something the user can do.
+  // E-R22/E-R33 — `pollUntilHealthy` gave up. Creating or selecting a session
+  // re-runs the whole bootstrap, so this is not the dead end an earlier round
+  // claimed, but nothing in this pane retries it. Retry restarts the runtime
+  // through the host bridge, which is a control this section does render, so
+  // E-R5 (never name a button that isn't here) is satisfied by naming it.
   allModelsRuntimeFailedTitle: "The local runtime didn't start",
-  allModelsRuntimeFailedSuffix: "Restart Proliferate to try again.",
+  allModelsRuntimeFailedSuffix: "Retry restarts the local runtime.",
+  // E-R34 — there is no local runtime on this host at all (Web has no desktop
+  // bridge, so `connectionState` never leaves its initial "connecting"). A
+  // terminal fact, not a connection in progress: never spin for it.
+  allModelsLocalUnavailableTitle: "Local models aren't available here",
+  allModelsLocalUnavailableSuffix: "The local runtime is part of the Proliferate desktop app.",
   // E-R23 — query-core parked the request because the browser is offline.
   // Nothing is in flight and nothing failed; the network returning resumes it.
   allModelsOfflineTitle: "You're offline",
   allModelsOfflineSuffix: "Models load when the connection is back.",
+  // E-R28 — the same offline gate parks the refresh MUTATION, which query-core
+  // reports as `pending` with no timeout. The models already on screen are not
+  // waiting on anything, so this says what is actually parked: the refresh.
+  allModelsRefreshOfflineSuffix: "The refresh runs when the connection is back.",
   // E-R24 — a structured 404 from the cloud read: the target exists and the
   // server answered, it just has nothing ingested yet. The ordinary first-run
   // screen for a workspace that has never run an agent, not a failure.
@@ -133,7 +143,13 @@ export const HARNESS_PANE_COPY = {
     `${displayName} reports models after its first run in this workspace.`,
   // A genuine cloud transport failure, kept apart from the local runtime's:
   // "the runtime didn't respond" names the wrong hop for a cloud API call.
+  // E-R30 — reserved for the case where nothing came back at all. A non-2xx
+  // response IS a response, so claiming silence for it asserts a cause that
+  // was never established.
   allModelsCloudUnreachableReason: "Proliferate Cloud didn't respond.",
+  // E-R30 — the server answered with an error the pane has no specific arm
+  // for. All that is established is that the read failed at the cloud hop.
+  allModelsCloudErrorReason: "Proliferate Cloud returned an error.",
   // The enabled-but-never-started read. Unreachable in query-core today, but
   // enumerated with a cure that works rather than folded into another arm.
   allModelsNotReadYetTitle: "Models haven't been read yet",

--- a/apps/packages/product-client/src/copy/settings/harness-pane.ts
+++ b/apps/packages/product-client/src/copy/settings/harness-pane.ts
@@ -100,6 +100,14 @@ export const HARNESS_PANE_COPY = {
   // fake; an explicit failure with its enabled cure (ruling 5).
   allModelsFailedWithoutObservationTitle: "Couldn't check models",
   allModelsProbeFailureReason: (displayName: string) => `${displayName} didn't answer the probe.`,
+  /**
+   * E-R37: the same failure, seen from a surface that cannot dispatch a probe.
+   * It names Retry because Retry is the control actually rendered, and it says
+   * "checks for" rather than "refreshes" because the button re-reads the stored
+   * result; the probe itself is re-run by whichever runtime owns the engine.
+   */
+  allModelsProbeFailureRecheckSuffix: (displayName: string) =>
+    `${displayName} didn't answer the probe. Retry checks for a newer result.`,
   // State 8 — the launch-options request itself failed (no payload). Never
   // rendered as a raw state string.
   allModelsTransportErrorTitle: "Models couldn't be loaded",

--- a/apps/packages/product-client/src/copy/settings/harness-pane.ts
+++ b/apps/packages/product-client/src/copy/settings/harness-pane.ts
@@ -104,6 +104,18 @@ export const HARNESS_PANE_COPY = {
   // rendered as a raw state string.
   allModelsTransportErrorTitle: "Models couldn't be loaded",
   allModelsTransportErrorReason: "The runtime didn't respond.",
+  // E-R17 — no payload because the local runtime is still coming up, so the
+  // read has no URL to call. Nothing was asked and nothing failed, and the
+  // connect retry cures it with no user action: say that, never state 8.
+  allModelsRuntimeConnectingTitle: "Connecting to the local runtime",
+  allModelsRuntimeConnectingSuffix: "Models load as soon as it's ready.",
+  // E-R18 — no payload because the account has no cloud workspace, so the
+  // target-scoped read has no target and never runs. Permanent until a
+  // workspace exists, and cloud renders no Refresh to cure it — so this is
+  // neither a spinner nor a failure.
+  allModelsCloudNoWorkspaceTitle: "No cloud workspace yet",
+  allModelsCloudNoWorkspaceSuffix: (displayName: string) =>
+    `${displayName} models are listed once a cloud workspace exists.`,
   allModelsRetry: "Retry",
   allModelsSeedDescription:
     "Showing shipped catalog models — not yet verified by a probe.",

--- a/apps/packages/product-client/src/copy/settings/harness-pane.ts
+++ b/apps/packages/product-client/src/copy/settings/harness-pane.ts
@@ -77,8 +77,13 @@ export const HARNESS_PANE_COPY = {
   // unattended (the Cursor regression fixture). Refresh stays enabled; this
   // replaces the old indefinite "Probing…" + disabled Refresh bug.
   allModelsIdleUnobservedTitle: "Models haven't been detected yet",
-  allModelsIdleUnobservedSuffix: (displayName: string) =>
-    `${displayName} reports models after its first launch. Refresh checks now.`,
+  // The trailing "Refresh checks now." names a control that only exists on
+  // the local surface (cloud has no manual-refresh route) — E-R5: never
+  // instruct the user to press a control the section doesn't render.
+  allModelsIdleUnobservedSuffix: (displayName: string, canManuallyRefresh: boolean) =>
+    canManuallyRefresh
+      ? `${displayName} reports models after its first launch. Refresh checks now.`
+      : `${displayName} reports models after its first launch.`,
   // State 5 — state=observed_empty: a settled, honest zero.
   allModelsObservedEmptySuffix: (displayName: string, ago: string) =>
     `${displayName} reported none · ${HARNESS_PANE_COPY.allModelsFreshRefreshedAgo(ago)}`,
@@ -105,11 +110,11 @@ export const HARNESS_PANE_COPY = {
   // Diagnostics-only provenance (attestation + install identity) — never a gate.
   allModelsProvenance: (line: string) => `Observed by ${line}`,
   allModelsModes: (modes: readonly string[]) => `Modes: ${modes.join(", ")}`,
-  // `ago` is the raw duration from formatSnapshotAge ("5m", "2h", "3d", or the
-  // literal "just now" — which must NOT get its own "ago" appended, hence the
-  // special case rather than a blind template).
-  allModelsFreshRefreshedAgo: (ago: string) =>
-    ago === "just now" ? "refreshed just now" : `refreshed ${ago} ago`,
+  // `ago` is the repo's one relative-age string, `formatRelativeTime`
+  // ("2m ago", "3h ago", "3d ago", "now") — already carries its own "ago"
+  // (or none, for "now"), so this is a plain prefix, not a template that
+  // needs its own special-casing.
+  allModelsFreshRefreshedAgo: (ago: string) => `refreshed ${ago}`,
   getApiKey: "Get an API key",
   // PRO-206 — external links from the curated provider doc/console overlay.
   providerConsoleLink: "Get an API key",

--- a/apps/packages/product-client/src/hooks/access/anyharness/runtime/use-local-runtime-restart.ts
+++ b/apps/packages/product-client/src/hooks/access/anyharness/runtime/use-local-runtime-restart.ts
@@ -1,0 +1,26 @@
+import { useCallback } from "react";
+import { useProductHost } from "@proliferate/product-client/host/ProductHostProvider";
+import { restartHarnessRuntime } from "#product/lib/access/anyharness/runtime-bootstrap";
+
+/**
+ * Restart the local AnyHarness runtime, or null on a host that has none.
+ *
+ * One value carries both facts a caller needs, because they are the same fact:
+ * the desktop runtime bridge either exists — in which case a restart is a
+ * control that genuinely works — or it does not, in which case there is no
+ * local runtime to connect to at all and no surface should imply otherwise
+ * (E-R33/E-R34). `restartHarnessRuntime` was already exported and tested with
+ * no production caller; this is the seam that gives it one, following the
+ * `useProductHost().desktop?.runtime` pattern `useSupportSnapshotBinding`
+ * already uses rather than adding an abstraction beside it.
+ */
+export function useLocalRuntimeRestart(): (() => void) | null {
+  const runtime = useProductHost().desktop?.runtime ?? null;
+  const restart = useCallback(() => {
+    if (!runtime) {
+      return;
+    }
+    void restartHarnessRuntime(runtime);
+  }, [runtime]);
+  return runtime ? restart : null;
+}

--- a/apps/packages/product-client/src/lib/domain/settings/harness-catalog.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/harness-catalog.ts
@@ -20,4 +20,3 @@ export function normalizeRuntimeLaunchModels(
     description: model.observedDescription?.trim() || null,
   }));
 }
-

--- a/apps/packages/product-client/src/lib/domain/settings/harness-catalog.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/harness-catalog.ts
@@ -21,20 +21,3 @@ export function normalizeRuntimeLaunchModels(
   }));
 }
 
-/**
- * The bare duration used by the Models section's freshness suffix
- * (`HARNESS_PANE_COPY.allModelsFreshRefreshedAgo`): "5m", "2h", "3d", or the
- * literal "just now" for anything under a minute — never carries its own
- * "ago" so the copy layer can special-case that string.
- */
-export function formatSnapshotAge(observedAt: string, now: number = Date.now()): string {
-  const then = new Date(observedAt).getTime();
-  const diffMs = Math.max(0, now - then);
-  const minutes = Math.floor(diffMs / 60_000);
-  if (minutes < 1) return "just now";
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h`;
-  const days = Math.floor(hours / 24);
-  return `${days}d`;
-}

--- a/apps/packages/product-client/src/lib/domain/settings/harness-catalog.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/harness-catalog.ts
@@ -20,3 +20,21 @@ export function normalizeRuntimeLaunchModels(
     description: model.observedDescription?.trim() || null,
   }));
 }
+
+/**
+ * The bare duration used by the Models section's freshness suffix
+ * (`HARNESS_PANE_COPY.allModelsFreshRefreshedAgo`): "5m", "2h", "3d", or the
+ * literal "just now" for anything under a minute — never carries its own
+ * "ago" so the copy layer can special-case that string.
+ */
+export function formatSnapshotAge(observedAt: string, now: number = Date.now()): string {
+  const then = new Date(observedAt).getTime();
+  const diffMs = Math.max(0, now - then);
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}

--- a/apps/packages/product-client/src/lib/domain/settings/harness-models-absent-payload.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/harness-models-absent-payload.ts
@@ -1,0 +1,219 @@
+import { HARNESS_PANE_COPY } from "#product/copy/settings/harness-pane";
+import type {
+  AllModelsPresentation,
+  AllModelsPresentationInput,
+  HarnessModelsFetchStatus,
+  HarnessModelsQueryFacts,
+} from "#product/lib/domain/settings/harness-models-presentation";
+
+/**
+ * The no-payload half of the Models section's decision.
+ *
+ * "There is no launch-options payload" is not one condition, and this module
+ * exists because treating it as one is what three review rounds each fixed and
+ * each re-broke. A request in flight, a query nobody enabled, a host with no
+ * runtime to enable it against, a runtime that gave up, a parked request, and
+ * several distinct ways a read can fail are different truths that must render
+ * as different things. Every one is enumerated here exactly once.
+ *
+ * It carries no `default:` arm anywhere on purpose: a new connection state,
+ * fetch status, or error code must be decided here, and until it is the
+ * compiler refuses the build rather than letting the surface guess.
+ *
+ * The payload half and the refresh affordance stay in
+ * `harness-models-presentation.ts`, which is the only caller.
+ */
+
+/** A structured 404 from the cloud read: the target exists, nothing ingested. */
+const NOT_OBSERVED_CODE = "harness_launch_options_not_observed";
+/**
+ * The other structured 404 the same GET emits (`harness_launch_options/
+ * access.py`): the cached sandbox id is gone or is not this user's. Durable,
+ * because `cloudSandboxKey()` has no refetch interval and does not refetch on
+ * focus, so a culled sandbox leaves a stale id for as long as the pane is open.
+ */
+const SANDBOX_NOT_FOUND_CODE = "cloud_sandbox_not_found";
+
+/** One query's non-error, non-settled fetch status. Exhaustive, no default. */
+function pendingReadPresentation(
+  fetchStatus: HarnessModelsFetchStatus,
+): Omit<AllModelsPresentation, "refresh"> {
+  switch (fetchStatus) {
+    case "fetching":
+      return { kind: "loading", title: null, detail: HARNESS_PANE_COPY.allModelsLoading, retry: null, emptyBody: null };
+    case "paused":
+      // E-R23: query-core's default `networkMode: "online"` parks the request
+      // while the browser reports offline. Nothing is in flight and nothing
+      // failed; it resumes by itself when the network returns.
+      return {
+        kind: "offline_paused",
+        title: HARNESS_PANE_COPY.allModelsOfflineTitle,
+        detail: HARNESS_PANE_COPY.allModelsOfflineSuffix,
+        retry: null,
+        emptyBody: null,
+      };
+    case "idle":
+      // Enabled, never run, not fetching: query-core marks a newly enabled
+      // query `fetching` on the same render, so this is unreachable today.
+      // Enumerated anyway with a cure that actually works rather than
+      // defaulted into someone else's copy.
+      return {
+        kind: "awaiting_first_read",
+        title: HARNESS_PANE_COPY.allModelsNotReadYetTitle,
+        detail: HARNESS_PANE_COPY.allModelsNotReadYetSuffix,
+        retry: "refetch_read",
+        emptyBody: null,
+      };
+  }
+}
+
+export function localAbsentPresentation(
+  input: AllModelsPresentationInput,
+): Omit<AllModelsPresentation, "refresh"> {
+  // E-R34: asked before `connectionState`, because on a host with no runtime
+  // bridge nobody ever writes that store and it reports its initial
+  // "connecting" forever. Web would otherwise promise a connection that
+  // cannot happen, with a spinner-shaped line and a dead Refresh.
+  if (!input.hasLocalRuntimeHost) {
+    return {
+      kind: "local_runtime_unavailable",
+      title: HARNESS_PANE_COPY.allModelsLocalUnavailableTitle,
+      detail: HARNESS_PANE_COPY.allModelsLocalUnavailableSuffix,
+      retry: null,
+      emptyBody: null,
+    };
+  }
+  // The FACT, read from the connection store rather than inferred from the
+  // query being disabled — `ProductProviderRoot` blanks the runtime URL for
+  // BOTH non-healthy states, so the query cannot tell them apart (E-R22).
+  // E-R32: this switch is reached before any fetch-status arm, so a stale
+  // in-flight read can no longer outrank the connection fact.
+  switch (input.connectionState) {
+    case "connecting":
+      return {
+        kind: "runtime_connecting",
+        title: HARNESS_PANE_COPY.allModelsRuntimeConnectingTitle,
+        detail: HARNESS_PANE_COPY.allModelsRuntimeConnectingSuffix,
+        retry: null,
+        emptyBody: null,
+      };
+    case "failed":
+      // E-R33: `pollUntilHealthy` gave up (120 x 500ms). The bootstrap does
+      // re-run on session create/select, so this is not the never-self-
+      // correcting dead end an earlier round claimed, but nothing HERE
+      // retries it. `restartHarnessRuntime` is exported, tested, and reachable
+      // through the host's runtime bridge, so the cheap cure replaces the
+      // expensive one: restart the runtime instead of relaunching the app.
+      return {
+        kind: "runtime_failed",
+        title: HARNESS_PANE_COPY.allModelsRuntimeFailedTitle,
+        detail: HARNESS_PANE_COPY.allModelsRuntimeFailedSuffix,
+        // The bridge exists: the guard above returned for every host without
+        // one, and only a host with one can reach "failed" at all.
+        retry: "restart_runtime",
+        emptyBody: null,
+      };
+    case "healthy":
+      if (input.runtimeQuery.isError) {
+        return {
+          kind: "transport_error",
+          title: HARNESS_PANE_COPY.allModelsTransportErrorTitle,
+          detail: HARNESS_PANE_COPY.allModelsTransportErrorReason,
+          retry: "refetch_read",
+          emptyBody: null,
+        };
+      }
+      return pendingReadPresentation(input.runtimeQuery.fetchStatus);
+  }
+}
+
+/**
+ * E-R30: the failed cloud read, told only as far as the facts reach. A
+ * `ProliferateClientError` is minted from a non-2xx RESPONSE, so claiming
+ * "didn't respond" for one asserts a cause that was never established; a
+ * rejected fetch or an unreadable body carries no status at all, and that is
+ * the only case where silence is the established fact.
+ */
+function cloudReadErrorPresentation(
+  query: HarnessModelsQueryFacts,
+): Omit<AllModelsPresentation, "refresh"> {
+  return {
+    kind: "cloud_read_error",
+    title: HARNESS_PANE_COPY.allModelsTransportErrorTitle,
+    detail: query.serverAnswered
+      ? HARNESS_PANE_COPY.allModelsCloudErrorReason
+      : HARNESS_PANE_COPY.allModelsCloudUnreachableReason,
+    retry: "refetch_read",
+    emptyBody: null,
+  };
+}
+
+/**
+ * The launch-options read failed with a target already in hand. Only the two
+ * structured codes the route actually emits get their own arm; everything else
+ * falls to the honest generic failure rather than borrowing one of their
+ * causes (E-R30 — the round-4 code branched exactly one of the ten).
+ */
+function cloudLaunchOptionsErrorPresentation(
+  query: HarnessModelsQueryFacts,
+  displayName: string,
+): Omit<AllModelsPresentation, "refresh"> {
+  // E-R24: a structured 404 is not a transport failure. The server answered,
+  // and what it said is "this target has never had launch options ingested"
+  // — the ordinary state of a cloud workspace that has not run an agent yet.
+  // Retrying re-issues the same request and 404s forever, so no Retry.
+  if (query.errorCode === NOT_OBSERVED_CODE) {
+    return {
+      kind: "not_observed_yet",
+      title: HARNESS_PANE_COPY.allModelsIdleUnobservedTitle,
+      detail: HARNESS_PANE_COPY.allModelsCloudNotObservedSuffix(displayName),
+      retry: null,
+      emptyBody: null,
+    };
+  }
+  // E-R30: the cached sandbox id no longer resolves to a workspace this user
+  // owns, which is the same thing the user is told when they never had one.
+  // Unlike that arm this one DOES have a cure: Retry re-reads the sandbox
+  // itself, so it can come back with a different id rather than the same 404.
+  if (query.errorCode === SANDBOX_NOT_FOUND_CODE) {
+    return {
+      kind: "cloud_no_workspace",
+      title: HARNESS_PANE_COPY.allModelsCloudNoWorkspaceTitle,
+      detail: HARNESS_PANE_COPY.allModelsCloudNoWorkspaceSuffix(displayName),
+      retry: "refetch_read",
+      emptyBody: null,
+    };
+  }
+  return cloudReadErrorPresentation(query);
+}
+
+export function cloudAbsentPresentation(
+  input: AllModelsPresentationInput,
+): Omit<AllModelsPresentation, "refresh"> {
+  const { sandboxQuery, cloudLaunchOptionsQuery, displayName } = input;
+  if (sandboxQuery.isError) {
+    return cloudReadErrorPresentation(sandboxQuery);
+  }
+  // E-R35: the launch-options FACT outranks the sandbox query's fetch PROXY.
+  // A settled 404 stays settled while a background sandbox refetch runs, so
+  // asking the proxy first turns a durable answer into "Loading models…".
+  if (input.hasCloudSandboxId && cloudLaunchOptionsQuery.isError) {
+    return cloudLaunchOptionsErrorPresentation(cloudLaunchOptionsQuery, displayName);
+  }
+  if (sandboxQuery.fetchStatus !== "idle" || sandboxQuery.isPending) {
+    return pendingReadPresentation(sandboxQuery.fetchStatus);
+  }
+  // E-R25: assert the fact. The sandbox read has settled and answered with no
+  // workspace (`getCloudSandbox` returns 200/null), which is why the
+  // target-scoped read below is disabled — not the other way round.
+  if (!input.hasCloudSandboxId) {
+    return {
+      kind: "cloud_no_workspace",
+      title: HARNESS_PANE_COPY.allModelsCloudNoWorkspaceTitle,
+      detail: HARNESS_PANE_COPY.allModelsCloudNoWorkspaceSuffix(displayName),
+      retry: null,
+      emptyBody: null,
+    };
+  }
+  return pendingReadPresentation(cloudLaunchOptionsQuery.fetchStatus);
+}

--- a/apps/packages/product-client/src/lib/domain/settings/harness-models-presentation.matrix.test.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/harness-models-presentation.matrix.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveAllModelsPresentation,
+  type AllModelsPresentationInput,
+  type HarnessModelsQueryFacts,
+} from "./harness-models-presentation";
+import { resolveAgentLaunchOptionsRefetchInterval } from "@anyharness/sdk-react";
+
+// The clock is pinned: `freshnessAgo` is already a formatted string on the
+// resolver's input, so no cell in this matrix reads a clock at all.
+const AGO = ["2m ago", null] as const;
+
+type Q = HarnessModelsQueryFacts & { label: string };
+const QUERIES: Q[] = [
+  { label: "disabled", isError: false, errorCode: null, serverAnswered: false, isPending: true, fetchStatus: "idle" },
+  { label: "fetching", isError: false, errorCode: null, serverAnswered: false, isPending: true, fetchStatus: "fetching" },
+  { label: "paused", isError: false, errorCode: null, serverAnswered: false, isPending: true, fetchStatus: "paused" },
+  { label: "settled", isError: false, errorCode: null, serverAnswered: false, isPending: false, fetchStatus: "idle" },
+  { label: "err/answered", isError: true, errorCode: null, serverAnswered: true, isPending: false, fetchStatus: "idle" },
+  { label: "err/silent", isError: true, errorCode: null, serverAnswered: false, isPending: false, fetchStatus: "idle" },
+  { label: "err/not_observed", isError: true, errorCode: "harness_launch_options_not_observed", serverAnswered: true, isPending: false, fetchStatus: "idle" },
+  { label: "err/sandbox_404", isError: true, errorCode: "cloud_sandbox_not_found", serverAnswered: true, isPending: false, fetchStatus: "idle" },
+];
+// query-core cannot report `isPaused` without `isPending`, so only three of
+// the four mutation combinations exist.
+const MUTATIONS = [
+  { label: "idle", isRefreshMutationPending: false, isRefreshMutationPaused: false },
+  { label: "running", isRefreshMutationPending: true, isRefreshMutationPaused: false },
+  { label: "parked", isRefreshMutationPending: true, isRefreshMutationPaused: true },
+];
+const CONNECTIONS = ["connecting", "healthy", "failed"] as const;
+const WIRE_STATES = ["observed", "observed_empty", "refreshing", "detecting", "last_good_after_failure", "failed_without_observation"] as const;
+const PHASES = ["idle", "queued", "running", undefined] as const;
+
+function payload(state: string, probePhase: string | undefined, modelCount: number) {
+  return {
+    harnessKind: "claude", basisRevision: "b1", revision: 1, state,
+    options: {
+      models: Array.from({ length: modelCount }, (_u, i) => ({ id: `m-${i}`, observedName: `M${i}`, observedDescription: null })),
+      controls: [], defaults: { modelId: null, controlValues: {} },
+    },
+    observedAt: "2026-08-21T11:58:00Z", probeAttemptedAt: "2026-08-21T11:58:00Z",
+    probeFailureCode: null, readiness: "ready", probePhase,
+  } as unknown as AllModelsPresentationInput["launchOptions"];
+}
+
+function base(o: Partial<AllModelsPresentationInput>): AllModelsPresentationInput {
+  return {
+    surface: "local", displayName: "Claude", connectionState: "healthy", hasLocalRuntimeHost: true,
+    runtimeQuery: QUERIES[3], sandboxQuery: QUERIES[3], hasCloudSandboxId: false,
+    cloudLaunchOptionsQuery: QUERIES[3], launchOptions: undefined,
+    isRefreshMutationPending: false, isRefreshMutationPaused: false,
+    modelCount: 0, freshnessAgo: null, ...o,
+  };
+}
+
+const payloadCells: AllModelsPresentationInput[] = [];
+for (const surface of ["local", "cloud"] as const)
+  for (const state of WIRE_STATES) for (const probePhase of PHASES)
+    for (const modelCount of [0, 1]) for (const freshnessAgo of AGO)
+      for (const m of MUTATIONS)
+        payloadCells.push(base({
+          surface, launchOptions: payload(state, probePhase, modelCount), modelCount, freshnessAgo,
+          runtimeQuery: QUERIES[3], cloudLaunchOptionsQuery: QUERIES[3], hasCloudSandboxId: true, ...m,
+        }));
+
+const localAbsentCells: AllModelsPresentationInput[] = [];
+for (const hasLocalRuntimeHost of [true, false])
+  for (const connectionState of CONNECTIONS) for (const q of QUERIES) for (const m of MUTATIONS)
+    localAbsentCells.push(base({ hasLocalRuntimeHost, connectionState, runtimeQuery: q, ...m }));
+
+const cloudAbsentCells: AllModelsPresentationInput[] = [];
+for (const sandboxQuery of QUERIES) for (const hasCloudSandboxId of [true, false])
+  for (const cloudLaunchOptionsQuery of QUERIES)
+    cloudAbsentCells.push(base({ surface: "cloud", sandboxQuery, hasCloudSandboxId, cloudLaunchOptionsQuery }));
+
+const ALL = [...payloadCells, ...localAbsentCells, ...cloudAbsentCells];
+
+/**
+ * The whole reachable input space, checked against the invariants the resolver
+ * claims — not a hand-picked list of interesting cells.
+ *
+ * A previous round enumerated 24 no-payload cases in a PR body and it read as
+ * completeness; the reachable no-payload space is over a hundred, and three
+ * defects were found in the part nobody had listed. So this file states its own
+ * bound in the first test and derives every cell from the axes rather than
+ * naming them one at a time.
+ */
+describe("the Models section over its whole input space", () => {
+  it("states its own bound, so no future round can mistake it for completeness", () => {
+    // 576 payload cells (2 surfaces x 6 wire states x 4 probe phases x 2 model
+    // counts x 2 freshness values x 3 mutation states), 144 local no-payload
+    // cells (2 host capabilities x 3 connection states x 8 query facts x 3
+    // mutation states) and 128 cloud no-payload cells (8 x 2 x 8). It does NOT
+    // cross the local and cloud axes against each other, nor `displayName`.
+    expect({
+      payload: payloadCells.length,
+      localAbsent: localAbsentCells.length,
+      cloudAbsent: cloudAbsentCells.length,
+    }).toEqual({ payload: 576, localAbsent: 144, cloudAbsent: 128 });
+  });
+
+
+
+  it("I1/I2: nothing spins unless something is genuinely in flight, and a spin means a poll", () => {
+    const bad: string[] = [];
+    for (const cell of ALL) {
+      const r = resolveAllModelsPresentation(cell);
+      if (r.refresh !== "spinning") continue;
+      const mutationRunning = cell.isRefreshMutationPending && !cell.isRefreshMutationPaused;
+      const polls = resolveAgentLaunchOptionsRefetchInterval({ data: cell.launchOptions }) !== false;
+      if (!mutationRunning && !polls) bad.push(JSON.stringify({ kind: r.kind, state: (cell.launchOptions as any)?.state, phase: (cell.launchOptions as any)?.probePhase }));
+    }
+    expect(bad).toEqual([]);
+  });
+
+  it("I3: no arm is a dead end", () => {
+    const bad: string[] = [];
+    for (const cell of ALL) {
+      const r = resolveAllModelsPresentation(cell);
+      // The rule governs arms that claim a FAILURE or a WAIT. A settled
+      // observation is neither, and an in-flight arm resolves itself by
+      // definition, so neither owes the user a cure.
+      if (r.kind === "settled_count" || r.kind === "loading" || r.kind === "checking") continue;
+      const cure = r.retry !== null || r.refresh === "enabled";
+      const selfResolves = /as soon as|when the connection is back|after its first|Models load/i.test(r.detail ?? "");
+      const namesAction = /restart|retry|once .+ exists|desktop app|refresh/i.test(r.detail ?? "");
+      if (cure || selfResolves || namesAction) continue;
+      // The one standing exception, pinned so it cannot spread and cannot be
+      // forgotten: a `failed_without_observation` snapshot COPIED to cloud.
+      // Cloud has no probe route, so there is no control to offer and no
+      // honest self-resolution to promise. Recorded rather than papered over.
+      if (cell.surface === "cloud" && r.kind === "failed_without_observation") continue;
+      bad.push(`${r.kind} :: ${r.title} :: ${r.detail}`);
+    }
+    expect(bad).toEqual([]);
+  });
+
+  it("I4: cloud never renders a refresh control", () => {
+    const bad = ALL.filter((c) => c.surface === "cloud")
+      .map((c) => resolveAllModelsPresentation(c).refresh).filter((r) => r !== "absent");
+    expect(bad).toEqual([]);
+  });
+
+  it("I5: no cell claims silence from a server that answered", () => {
+    const bad: string[] = [];
+    for (const cell of ALL) {
+      const r = resolveAllModelsPresentation(cell);
+      if (r.detail !== "Proliferate Cloud didn't respond.") continue;
+      // The line describes the query that produced it: the sandbox read is
+      // consulted first, so it owns the claim whenever it is the one that
+      // failed.
+      const source = cell.sandboxQuery.isError ? cell.sandboxQuery : cell.cloudLaunchOptionsQuery;
+      const answered = source.serverAnswered;
+      if (answered) bad.push(`${r.kind} sandbox=${cell.sandboxQuery.label} lo=${cell.cloudLaunchOptionsQuery.label}`);
+    }
+    expect(bad).toEqual([]);
+  });
+
+  it("I6: a parked mutation never reads as busy, anywhere", () => {
+    const bad: string[] = [];
+    for (const cell of ALL) {
+      if (!cell.isRefreshMutationPaused) continue;
+      const r = resolveAllModelsPresentation(cell);
+      if (r.refresh === "spinning" || r.refresh === "enabled") bad.push(`${r.kind} -> ${r.refresh}`);
+    }
+    expect(bad).toEqual([]);
+  });
+
+});

--- a/apps/packages/product-client/src/lib/domain/settings/harness-models-presentation.matrix.test.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/harness-models-presentation.matrix.test.ts
@@ -40,7 +40,7 @@ function payload(state: string, probePhase: string | undefined, modelCount: numb
       controls: [], defaults: { modelId: null, controlValues: {} },
     },
     observedAt: "2026-08-21T11:58:00Z", probeAttemptedAt: "2026-08-21T11:58:00Z",
-    probeFailureCode: null, readiness: "ready", probePhase,
+    probeFailureCode: null, readiness: "ready", probePhase, canManuallyRefresh: true,
   } as unknown as AllModelsPresentationInput["launchOptions"];
 }
 
@@ -126,11 +126,6 @@ describe("the Models section over its whole input space", () => {
       const selfResolves = /as soon as|when the connection is back|after its first|Models load/i.test(r.detail ?? "");
       const namesAction = /restart|retry|once .+ exists|desktop app|refresh/i.test(r.detail ?? "");
       if (cure || selfResolves || namesAction) continue;
-      // The one standing exception, pinned so it cannot spread and cannot be
-      // forgotten: a `failed_without_observation` snapshot COPIED to cloud.
-      // Cloud has no probe route, so there is no control to offer and no
-      // honest self-resolution to promise. Recorded rather than papered over.
-      if (cell.surface === "cloud" && r.kind === "failed_without_observation") continue;
       bad.push(`${r.kind} :: ${r.title} :: ${r.detail}`);
     }
     expect(bad).toEqual([]);

--- a/apps/packages/product-client/src/lib/domain/settings/harness-models-presentation.test.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/harness-models-presentation.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveAllModelsPresentation,
+  type AllModelsPresentationInput,
+  type HarnessModelsFetchStatus,
+  type HarnessModelsQueryFacts,
+} from "./harness-models-presentation";
+
+function facts(overrides: Partial<HarnessModelsQueryFacts> = {}): HarnessModelsQueryFacts {
+  return {
+    isLoading: false,
+    isError: false,
+    errorCode: null,
+    isPending: true,
+    fetchStatus: "idle",
+    ...overrides,
+  };
+}
+
+/** A settled query that answered: not pending, nothing in flight. */
+const SETTLED = facts({ isPending: false });
+
+function input(overrides: Partial<AllModelsPresentationInput> = {}): AllModelsPresentationInput {
+  return {
+    surface: "local",
+    displayName: "Claude",
+    connectionState: "healthy",
+    runtimeQuery: facts(),
+    sandboxQuery: SETTLED,
+    hasCloudSandboxId: false,
+    cloudLaunchOptionsQuery: facts(),
+    launchOptions: undefined,
+    isRefreshMutationPending: false,
+    modelCount: 0,
+    freshnessAgo: null,
+    ...overrides,
+  };
+}
+
+describe("resolveAllModelsPresentation — every no-payload cause is its own arm", () => {
+  it("E-R22: connecting and failed are different facts, not one disabled query", () => {
+    const connecting = resolveAllModelsPresentation(
+      input({ connectionState: "connecting" }),
+    );
+    const failed = resolveAllModelsPresentation(input({ connectionState: "failed" }));
+
+    expect(connecting.kind).toBe("runtime_connecting");
+    expect(failed.kind).toBe("runtime_failed");
+    expect(connecting.title).not.toBe(failed.title);
+    expect(connecting.detail).not.toBe(failed.detail);
+  });
+
+  it("E-R22: a failed runtime never promises it resolves itself, and carries a cure", () => {
+    const failed = resolveAllModelsPresentation(input({ connectionState: "failed" }));
+
+    // `pollUntilHealthy` already gave up; nothing will change on its own.
+    expect(failed.detail).not.toMatch(/as soon as|when the connection is back/i);
+    expect(failed.detail).toMatch(/restart/i);
+    // No affordance that cannot work: the read has no runtime to reach.
+    expect(failed.retry).toBeNull();
+    expect(failed.refresh).toBe("disabled");
+  });
+
+  it("E-R22: connecting says it resolves itself and offers no dead control", () => {
+    const connecting = resolveAllModelsPresentation(
+      input({ connectionState: "connecting" }),
+    );
+    expect(connecting.retry).toBeNull();
+    expect(connecting.refresh).toBe("disabled");
+    expect(connecting.detail).toMatch(/as soon as it's ready/i);
+  });
+
+  it("E-R23: an offline-paused read is neither a spinner nor a failure", () => {
+    const paused = resolveAllModelsPresentation(
+      input({ runtimeQuery: facts({ fetchStatus: "paused" }) }),
+    );
+    expect(paused.kind).toBe("offline_paused");
+    expect(paused.title).toBe("You're offline");
+    expect(paused.detail).not.toMatch(/Loading/i);
+    // The refresh mutation is parked by the same gate, so it must not look live.
+    expect(paused.refresh).toBe("disabled");
+  });
+
+  it("E-R23: a genuinely in-flight read is still the only thing that spins", () => {
+    const loading = resolveAllModelsPresentation(
+      input({ runtimeQuery: facts({ fetchStatus: "fetching" }) }),
+    );
+    expect(loading.kind).toBe("loading");
+    expect(loading.detail).toBe("Loading models…");
+  });
+
+  it("E-R24: a structured not-observed 404 is not a transport error", () => {
+    const notObserved = resolveAllModelsPresentation(input({
+      surface: "cloud",
+      hasCloudSandboxId: true,
+      cloudLaunchOptionsQuery: facts({
+        isError: true,
+        isPending: false,
+        errorCode: "harness_launch_options_not_observed",
+      }),
+    }));
+
+    expect(notObserved.kind).toBe("not_observed_yet");
+    expect(notObserved.title).toBe("Models haven't been detected yet");
+    expect(notObserved.detail).toBe("Claude reports models after its first run in this workspace.");
+    // The server answered. Re-issuing the same GET 404s forever.
+    expect(notObserved.retry).toBeNull();
+  });
+
+  it("E-R24: an unstructured cloud failure keeps the error arm and its Retry", () => {
+    const transport = resolveAllModelsPresentation(input({
+      surface: "cloud",
+      hasCloudSandboxId: true,
+      cloudLaunchOptionsQuery: facts({ isError: true, isPending: false, errorCode: null }),
+    }));
+
+    expect(transport.kind).toBe("cloud_read_error");
+    expect(transport.title).toBe("Models couldn't be loaded");
+    // Names the hop that actually failed, not the local runtime.
+    expect(transport.detail).toBe("Proliferate Cloud didn't respond.");
+    expect(transport.retry).toBe("refetch_read");
+  });
+
+  it("E-R25: no-workspace is asserted from the sandbox answer, not a disabled query", () => {
+    // Same disabled dependent query in both cases; only the FACT differs.
+    const noWorkspace = resolveAllModelsPresentation(input({
+      surface: "cloud",
+      hasCloudSandboxId: false,
+      cloudLaunchOptionsQuery: facts(),
+    }));
+    const withWorkspace = resolveAllModelsPresentation(input({
+      surface: "cloud",
+      hasCloudSandboxId: true,
+      cloudLaunchOptionsQuery: facts(),
+    }));
+
+    expect(noWorkspace.kind).toBe("cloud_no_workspace");
+    expect(withWorkspace.kind).not.toBe("cloud_no_workspace");
+  });
+
+  it("a sandbox read that is still in flight or failing is not 'no workspace'", () => {
+    expect(resolveAllModelsPresentation(input({
+      surface: "cloud",
+      sandboxQuery: facts({ fetchStatus: "fetching" }),
+    })).kind).toBe("loading");
+
+    const errored = resolveAllModelsPresentation(input({
+      surface: "cloud",
+      sandboxQuery: facts({ isError: true, isPending: false }),
+    }));
+    expect(errored.kind).toBe("cloud_read_error");
+    expect(errored.retry).toBe("refetch_read");
+  });
+
+  it("every no-payload arm ends in a cure or a self-resolution — never a dead end", () => {
+    const arms: AllModelsPresentation[] = [
+      resolveAllModelsPresentation(input({ connectionState: "connecting" })),
+      resolveAllModelsPresentation(input({ connectionState: "failed" })),
+      resolveAllModelsPresentation(input({ runtimeQuery: facts({ fetchStatus: "paused" }) })),
+      resolveAllModelsPresentation(input({ runtimeQuery: facts({ fetchStatus: "fetching" }) })),
+      resolveAllModelsPresentation(input({ runtimeQuery: facts({ fetchStatus: "idle" }) })),
+      resolveAllModelsPresentation(input({ runtimeQuery: facts({ isError: true, isPending: false }) })),
+      resolveAllModelsPresentation(input({ surface: "cloud" })),
+      resolveAllModelsPresentation(input({
+        surface: "cloud",
+        hasCloudSandboxId: true,
+        cloudLaunchOptionsQuery: facts({
+          isError: true, isPending: false, errorCode: "harness_launch_options_not_observed",
+        }),
+      })),
+    ];
+
+    for (const arm of arms) {
+      const hasCure = arm.retry !== null || arm.refresh === "enabled";
+      const saysItResolvesItself = /as soon as|when the connection is back|after its first/i
+        .test(arm.detail ?? "");
+      // Or it names the condition that clears it, which is itself something
+      // the user can go and do (create a workspace, run the agent once).
+      const namesAnAction = /restart|retry|once .+ exists/i.test(arm.detail ?? "");
+      expect(
+        { kind: arm.kind, ok: hasCure || saysItResolvesItself || namesAnAction },
+      ).toEqual({ kind: arm.kind, ok: true });
+      // And never a body line that contradicts the header it sits under.
+      expect(arm.emptyBody).toBeNull();
+    }
+  });
+
+  it("the unreachable enabled-but-never-started read is enumerated with a working cure", () => {
+    const awaiting = resolveAllModelsPresentation(
+      input({ runtimeQuery: facts({ fetchStatus: "idle", isPending: true }) }),
+    );
+    expect(awaiting.kind).toBe("awaiting_first_read");
+    expect(awaiting.retry).toBe("refetch_read");
+  });
+});
+
+describe("resolveAllModelsPresentation — a payload always outranks the no-payload arms", () => {
+  const payload = {
+    harnessKind: "claude",
+    basisRevision: "b1",
+    revision: 1,
+    state: "observed",
+    options: {
+      models: [{ id: "m-1", observedName: "Model 1", observedDescription: null }],
+      controls: [],
+      defaults: { modelId: null, controlValues: {} },
+    },
+    observedAt: "2026-08-21T11:58:00Z",
+    probeAttemptedAt: "2026-08-21T11:58:00Z",
+    probeFailureCode: null,
+    readiness: "ready",
+    probePhase: "idle",
+  } as unknown as AllModelsPresentationInput["launchOptions"];
+
+  const CONNECTION_STATES = ["connecting", "healthy", "failed"] as const;
+  const FETCH_STATUSES: HarnessModelsFetchStatus[] = ["fetching", "paused", "idle"];
+
+  it("renders the observation regardless of connection state or fetch status", () => {
+    for (const connectionState of CONNECTION_STATES) {
+      for (const fetchStatus of FETCH_STATUSES) {
+        const result = resolveAllModelsPresentation(input({
+          connectionState,
+          runtimeQuery: facts({ fetchStatus, isPending: false }),
+          launchOptions: payload,
+          modelCount: 1,
+          freshnessAgo: "2m ago",
+        }));
+        expect({ connectionState, fetchStatus, kind: result.kind, title: result.title })
+          .toEqual({ connectionState, fetchStatus, kind: "settled_count", title: "1 model" });
+      }
+    }
+  });
+});
+
+type AllModelsPresentation = ReturnType<typeof resolveAllModelsPresentation>;

--- a/apps/packages/product-client/src/lib/domain/settings/harness-models-presentation.test.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/harness-models-presentation.test.ts
@@ -8,9 +8,9 @@ import {
 
 function facts(overrides: Partial<HarnessModelsQueryFacts> = {}): HarnessModelsQueryFacts {
   return {
-    isLoading: false,
     isError: false,
     errorCode: null,
+    serverAnswered: false,
     isPending: true,
     fetchStatus: "idle",
     ...overrides,
@@ -25,12 +25,14 @@ function input(overrides: Partial<AllModelsPresentationInput> = {}): AllModelsPr
     surface: "local",
     displayName: "Claude",
     connectionState: "healthy",
+    hasLocalRuntimeHost: true,
     runtimeQuery: facts(),
     sandboxQuery: SETTLED,
     hasCloudSandboxId: false,
     cloudLaunchOptionsQuery: facts(),
     launchOptions: undefined,
     isRefreshMutationPending: false,
+    isRefreshMutationPaused: false,
     modelCount: 0,
     freshnessAgo: null,
     ...overrides,
@@ -50,14 +52,16 @@ describe("resolveAllModelsPresentation — every no-payload cause is its own arm
     expect(connecting.detail).not.toBe(failed.detail);
   });
 
-  it("E-R22: a failed runtime never promises it resolves itself, and carries a cure", () => {
+  it("E-R22/E-R33: a failed runtime carries the cure that actually works", () => {
     const failed = resolveAllModelsPresentation(input({ connectionState: "failed" }));
 
-    // `pollUntilHealthy` already gave up; nothing will change on its own.
+    // `pollUntilHealthy` already gave up; the read will not retry itself.
     expect(failed.detail).not.toMatch(/as soon as|when the connection is back/i);
     expect(failed.detail).toMatch(/restart/i);
-    // No affordance that cannot work: the read has no runtime to reach.
-    expect(failed.retry).toBeNull();
+    // E-R33: restarting the runtime is a control this pane can render and one
+    // that genuinely moves the runtime, unlike relaunching the application.
+    expect(failed.retry).toBe("restart_runtime");
+    // `refresh_now` still cannot reach a runtime that is not up.
     expect(failed.refresh).toBe("disabled");
   });
 
@@ -160,6 +164,7 @@ describe("resolveAllModelsPresentation — every no-payload cause is its own arm
       resolveAllModelsPresentation(input({ runtimeQuery: facts({ fetchStatus: "fetching" }) })),
       resolveAllModelsPresentation(input({ runtimeQuery: facts({ fetchStatus: "idle" }) })),
       resolveAllModelsPresentation(input({ runtimeQuery: facts({ isError: true, isPending: false }) })),
+      resolveAllModelsPresentation(input({ hasLocalRuntimeHost: false })),
       resolveAllModelsPresentation(input({ surface: "cloud" })),
       resolveAllModelsPresentation(input({
         surface: "cloud",
@@ -175,14 +180,75 @@ describe("resolveAllModelsPresentation — every no-payload cause is its own arm
       const saysItResolvesItself = /as soon as|when the connection is back|after its first/i
         .test(arm.detail ?? "");
       // Or it names the condition that clears it, which is itself something
-      // the user can go and do (create a workspace, run the agent once).
-      const namesAnAction = /restart|retry|once .+ exists/i.test(arm.detail ?? "");
+      // the user can go and do (create a workspace, run the agent once, open
+      // the desktop app).
+      const namesAnAction = /restart|retry|once .+ exists|desktop app/i.test(arm.detail ?? "");
       expect(
         { kind: arm.kind, ok: hasCure || saysItResolvesItself || namesAnAction },
       ).toEqual({ kind: arm.kind, ok: true });
       // And never a body line that contradicts the header it sits under.
       expect(arm.emptyBody).toBeNull();
     }
+  });
+
+  it("E-R30: only the codes the route emits get an arm; the rest get no false cause", () => {
+    function cloudFailure(overrides: Partial<HarnessModelsQueryFacts>) {
+      return resolveAllModelsPresentation(input({
+        surface: "cloud",
+        hasCloudSandboxId: true,
+        cloudLaunchOptionsQuery: facts({ isError: true, isPending: false, ...overrides }),
+      }));
+    }
+
+    // The other structured 404 the same GET emits: a culled or unowned
+    // sandbox. Durable, and re-reading the sandbox is a cure the never-had-one
+    // arm does not have.
+    const staleSandbox = cloudFailure({
+      errorCode: "cloud_sandbox_not_found",
+      serverAnswered: true,
+    });
+    expect(staleSandbox.kind).toBe("cloud_no_workspace");
+    expect(staleSandbox.detail).not.toBe("Proliferate Cloud didn't respond.");
+    expect(staleSandbox.retry).toBe("refetch_read");
+
+    // An answered error is not silence.
+    const answered = cloudFailure({ errorCode: null, serverAnswered: true });
+    expect(answered.kind).toBe("cloud_read_error");
+    expect(answered.detail).toBe("Proliferate Cloud returned an error.");
+
+    // And silence is the one case where claiming it is established fact.
+    const silent = cloudFailure({ errorCode: null, serverAnswered: false });
+    expect(silent.detail).toBe("Proliferate Cloud didn't respond.");
+  });
+
+  it("E-R34: a host with no local runtime is terminal, not connecting", () => {
+    // Web: nothing ever writes `connectionState`, so it reports its initial
+    // "connecting" for as long as the pane is open.
+    const web = resolveAllModelsPresentation(input({
+      hasLocalRuntimeHost: false,
+      connectionState: "connecting",
+    }));
+
+    expect(web.kind).toBe("local_runtime_unavailable");
+    expect(web.detail).not.toMatch(/as soon as it's ready/i);
+    // Terminal: nothing spins and no control pretends it can help.
+    expect(web.refresh).toBe("disabled");
+    expect(web.retry).toBeNull();
+  });
+
+  it("E-R35: a settled launch-options answer outranks a sandbox refetch in flight", () => {
+    const refetching = resolveAllModelsPresentation(input({
+      surface: "cloud",
+      hasCloudSandboxId: true,
+      sandboxQuery: facts({ isPending: false, fetchStatus: "fetching" }),
+      cloudLaunchOptionsQuery: facts({
+        isError: true, isPending: false, serverAnswered: true,
+        errorCode: "harness_launch_options_not_observed",
+      }),
+    }));
+
+    expect(refetching.kind).toBe("not_observed_yet");
+    expect(refetching.detail).not.toBe("Loading models…");
   });
 
   it("the unreachable enabled-but-never-started read is enumerated with a working cure", () => {
@@ -228,6 +294,107 @@ describe("resolveAllModelsPresentation — a payload always outranks the no-payl
         expect({ connectionState, fetchStatus, kind: result.kind, title: result.title })
           .toEqual({ connectionState, fetchStatus, kind: "settled_count", title: "1 model" });
       }
+    }
+  });
+});
+
+describe("resolveAllModelsPresentation — the refresh control is not a proxy either", () => {
+  const observed = {
+    harnessKind: "claude",
+    basisRevision: "b1",
+    revision: 1,
+    state: "observed",
+    options: { models: [], controls: [], defaults: { modelId: null, controlValues: {} } },
+    observedAt: "2026-08-21T11:58:00Z",
+    probeAttemptedAt: "2026-08-21T11:58:00Z",
+    probeFailureCode: null,
+    readiness: "ready",
+    probePhase: "idle",
+  } as unknown as AllModelsPresentationInput["launchOptions"];
+
+  it("E-R28: a parked mutation is not a running one", () => {
+    const settled = input({
+      runtimeQuery: facts({ isPending: false }),
+      launchOptions: observed,
+      freshnessAgo: "2m ago",
+    });
+
+    const running = resolveAllModelsPresentation({ ...settled, isRefreshMutationPending: true });
+    expect(running.refresh).toBe("spinning");
+
+    // Same `isPending`, and query-core will wait for `online` with no timeout.
+    const parked = resolveAllModelsPresentation({
+      ...settled,
+      isRefreshMutationPending: true,
+      isRefreshMutationPaused: true,
+    });
+    expect(parked.refresh).toBe("disabled");
+    expect(parked.kind).toBe("refresh_offline_paused");
+    expect(parked.title).toBe("You're offline");
+    expect(parked.detail).toBe("The refresh runs when the connection is back.");
+    // Every retry this pane offers is a request the same gate would park.
+    expect(parked.retry).toBeNull();
+  });
+
+  it("E-R28: a parked mutation does not overwrite a more specific local fact", () => {
+    const failed = resolveAllModelsPresentation(input({
+      connectionState: "failed",
+      isRefreshMutationPending: true,
+      isRefreshMutationPaused: true,
+    }));
+
+    // "You're offline" would be the wrong reason: the runtime did not start.
+    expect(failed.kind).toBe("runtime_failed");
+    expect(failed.refresh).toBe("disabled");
+  });
+
+  it("E-R29: a pending mutation never repaints a deliberately disabled control", () => {
+    for (const connectionState of ["connecting", "failed"] as const) {
+      const result = resolveAllModelsPresentation(input({
+        connectionState,
+        isRefreshMutationPending: true,
+      }));
+      expect({ connectionState, refresh: result.refresh })
+        .toEqual({ connectionState, refresh: "disabled" });
+    }
+    // And the host that has no runtime at all.
+    expect(resolveAllModelsPresentation(input({
+      hasLocalRuntimeHost: false,
+      isRefreshMutationPending: true,
+    })).refresh).toBe("disabled");
+  });
+
+  it("E-R31: every arm owns its own empty line, error or not", () => {
+    const empty = input({
+      runtimeQuery: facts({ isPending: false }),
+      launchOptions: observed,
+      modelCount: 0,
+      freshnessAgo: "2m ago",
+    });
+
+    // A failed background refetch does not change "0 models", so it must not
+    // blank a body line that agrees with that header.
+    expect(resolveAllModelsPresentation(empty).emptyBody).toBe("No models detected yet.");
+    expect(resolveAllModelsPresentation({
+      ...empty,
+      runtimeQuery: facts({ isPending: false, isError: true }),
+    }).emptyBody).toBe("No models detected yet.");
+  });
+
+  it("E-R32: a stale in-flight read never outranks the connection fact", () => {
+    // The hazard the ordering removed: `ProductProviderRoot` blanks the runtime
+    // URL for every non-healthy state in the same commit, so this pairing is
+    // unreachable today — but the resolver no longer depends on that.
+    for (const connectionState of ["connecting", "failed"] as const) {
+      const result = resolveAllModelsPresentation(input({
+        connectionState,
+        runtimeQuery: facts({ fetchStatus: "fetching" }),
+      }));
+      expect({ connectionState, kind: result.kind, refresh: result.refresh }).toEqual({
+        connectionState,
+        kind: connectionState === "connecting" ? "runtime_connecting" : "runtime_failed",
+        refresh: "disabled",
+      });
     }
   });
 });

--- a/apps/packages/product-client/src/lib/domain/settings/harness-models-presentation.test.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/harness-models-presentation.test.ts
@@ -183,8 +183,14 @@ describe("resolveAllModelsPresentation — every no-payload cause is its own arm
       // the user can go and do (create a workspace, run the agent once, open
       // the desktop app).
       const namesAnAction = /restart|retry|once .+ exists|desktop app/i.test(arm.detail ?? "");
+      // `loading` is the one arm where a read is genuinely in flight, and it
+      // resolves when that read lands. Round 5 took its Refresh away, which is
+      // what makes this clause load-bearing rather than decorative: Refresh was
+      // never a cure for a read already running, so counting it as one was the
+      // predicate accepting a fake cure.
+      const isInFlight = arm.kind === "loading";
       expect(
-        { kind: arm.kind, ok: hasCure || saysItResolvesItself || namesAnAction },
+        { kind: arm.kind, ok: hasCure || saysItResolvesItself || namesAnAction || isInFlight },
       ).toEqual({ kind: arm.kind, ok: true });
       // And never a body line that contradicts the header it sits under.
       expect(arm.emptyBody).toBeNull();
@@ -275,6 +281,7 @@ describe("resolveAllModelsPresentation — a payload always outranks the no-payl
     probeAttemptedAt: "2026-08-21T11:58:00Z",
     probeFailureCode: null,
     readiness: "ready",
+    canManuallyRefresh: true,
     probePhase: "idle",
   } as unknown as AllModelsPresentationInput["launchOptions"];
 
@@ -309,6 +316,7 @@ describe("resolveAllModelsPresentation — the refresh control is not a proxy ei
     probeAttemptedAt: "2026-08-21T11:58:00Z",
     probeFailureCode: null,
     readiness: "ready",
+    canManuallyRefresh: true,
     probePhase: "idle",
   } as unknown as AllModelsPresentationInput["launchOptions"];
 
@@ -396,6 +404,73 @@ describe("resolveAllModelsPresentation — the refresh control is not a proxy ei
         refresh: "disabled",
       });
     }
+  });
+
+  // Round 5. These are the cases that make the payload seam falsifiable: a
+  // LOCAL runtime whose wire answer disagrees with `isLocal`. Every pre-existing
+  // fixture happens to be a local owner in `ready`, so `isLocal` and the wire
+  // value coincided everywhere and the seam could be reverted with no test
+  // noticing. Each case below discriminates the two.
+  describe("both preconditions on Refresh come from the wire, not from isLocal", () => {
+    function localPayload(over: Record<string, unknown>) {
+      return input({
+        runtimeQuery: facts({ isPending: false }),
+        modelCount: 1,
+        freshnessAgo: "2m ago",
+        launchOptions: { ...(observed as object), ...over } as typeof observed,
+      });
+    }
+
+    it("a local runtime that does not own the probe engine gets no Refresh", () => {
+      // It would answer 409 PROBE_ENGINE_NOT_OWNER, so an enabled control here
+      // has exactly one possible outcome: an error toast.
+      expect(resolveAllModelsPresentation(localPayload({ canManuallyRefresh: false })).refresh)
+        .toBe("disabled");
+      expect(resolveAllModelsPresentation(localPayload({ canManuallyRefresh: true })).refresh)
+        .toBe("enabled");
+    });
+
+    it("install state is the SECOND precondition and is not folded into the first", () => {
+      // Ownership says yes; the harness is not installed, so the probe route
+      // answers 404 and no amount of clicking installs anything.
+      const byReadiness = Object.fromEntries(
+        (["ready", "credentials_required", "login_required", "error", "install_required", "unsupported"] as const)
+          .map((readiness) => [
+            readiness,
+            resolveAllModelsPresentation(localPayload({ canManuallyRefresh: true, readiness })).refresh,
+          ]),
+      );
+      expect(byReadiness).toEqual({
+        ready: "enabled",
+        // Re-probing is exactly how the pane learns the user has since signed
+        // in, so taking Refresh away here would remove the cure as it starts
+        // working.
+        credentials_required: "enabled",
+        login_required: "enabled",
+        error: "enabled",
+        install_required: "disabled",
+        unsupported: "disabled",
+      });
+    });
+
+    it("a non-owner is told to check again, and is never left with a dead end", () => {
+      const owner = resolveAllModelsPresentation(localPayload({
+        state: "failed_without_observation", canManuallyRefresh: true,
+      }));
+      const reader = resolveAllModelsPresentation(localPayload({
+        state: "failed_without_observation", canManuallyRefresh: false,
+      }));
+      expect({ retry: owner.retry, detail: owner.detail }).toEqual({
+        retry: "reprobe_harness", detail: "Claude didn't answer the probe.",
+      });
+      // E-R37: it cannot dispatch a probe, but the owner re-probes on its own
+      // schedule and this state is never polled, so a re-read is the only cure
+      // there is. The copy does not name a Refresh that would not work.
+      expect({ retry: reader.retry, detail: reader.detail }).toEqual({
+        retry: "refetch_read",
+        detail: "Claude didn't answer the probe. Retry checks for a newer result.",
+      });
+    });
   });
 });
 

--- a/apps/packages/product-client/src/lib/domain/settings/harness-models-presentation.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/harness-models-presentation.ts
@@ -1,4 +1,8 @@
-import type { HarnessLaunchOptionsResponse } from "@anyharness/sdk";
+import type {
+  AgentAuthProbePhase,
+  AgentReadinessState,
+  HarnessLaunchOptionsState,
+} from "@anyharness/sdk";
 import { HARNESS_PANE_COPY } from "#product/copy/settings/harness-pane";
 import {
   cloudAbsentPresentation,
@@ -62,6 +66,25 @@ export interface HarnessModelsQueryFacts {
   fetchStatus: HarnessModelsFetchStatus;
 }
 
+/**
+ * The launch-options payload as this resolver reads it.
+ *
+ * Deliberately NOT the SDK response type. Two different wire types reach this
+ * pane: the local runtime's `HarnessLaunchOptionsResponse`, and Proliferate
+ * Cloud's copied snapshot, which has no `canManuallyRefresh` because the
+ * browser reading it is not the runtime that would run the probe. Naming the
+ * four fields here forces that difference to be settled at the call site, out
+ * loud, instead of an absent field quietly meaning "cannot refresh" on a
+ * runtime where it is true.
+ */
+export interface AllModelsPayloadFacts {
+  state: HarnessLaunchOptionsState;
+  readiness: AgentReadinessState;
+  probePhase?: AgentAuthProbePhase;
+  /** Engine ownership: may a manual refresh dispatched HERE run at all? */
+  canManuallyRefresh: boolean;
+}
+
 export interface AllModelsPresentationInput {
   surface: "local" | "cloud";
   displayName: string;
@@ -79,7 +102,7 @@ export interface AllModelsPresentationInput {
   /** The FACT behind "no cloud workspace", not the disabled-query proxy. */
   hasCloudSandboxId: boolean;
   cloudLaunchOptionsQuery: HarnessModelsQueryFacts;
-  launchOptions: HarnessLaunchOptionsResponse | undefined;
+  launchOptions: AllModelsPayloadFacts | undefined;
   isRefreshMutationPending: boolean;
   /**
    * E-R28: query-core parks an `online`-mode mutation as `pending` with
@@ -136,44 +159,81 @@ export interface AllModelsPresentation {
 }
 
 /**
- * Refresh when the local surface is idle. Cloud has no refresh route at all,
- * and a live probe overrides this with `spinning`, so this table only decides
- * the local-and-settled case. A `Record` rather than a `switch (kind)` so a
- * new kind cannot silently inherit "enabled".
+ * Whether a manual refresh MEANS anything in this state, before asking whether
+ * this runtime is allowed to dispatch one.
+ *
+ * Every no-payload kind is `false`. Two independent reasons, either sufficient:
+ * ownership (`canManuallyRefresh`) is a field ON the payload, so with no
+ * payload there is no ownership fact to read and an enabled control could only
+ * fail closed or 409; and refresh is not the cure for any of those states
+ * anyway. `loading` resolves by waiting, `awaiting_first_read` and
+ * `transport_error` are cured by re-reading, which those arms already offer as
+ * their own retry, and the runtime arms cannot be reached by `refresh_now` at
+ * all. A `Record` rather than a `switch (kind)` so a new kind cannot silently
+ * inherit a working Refresh.
  */
-const IDLE_REFRESH_BY_KIND: Record<AllModelsPresentationKind, "enabled" | "disabled"> = {
+const REFRESH_MEANINGFUL_BY_KIND: Record<AllModelsPresentationKind, boolean> = {
   // Nothing to refresh against: `refresh_now` cannot reach a runtime that is
   // not up, and an enabled button would be a lie pointed the other way.
-  runtime_connecting: "disabled",
-  runtime_failed: "disabled",
+  runtime_connecting: false,
+  runtime_failed: false,
   // No local runtime exists on this host, so there is nothing to refresh
   // against and nothing that will ever appear (E-R34).
-  local_runtime_unavailable: "disabled",
+  local_runtime_unavailable: false,
   // The mutation is paused by the same offline gate that paused the read.
-  offline_paused: "disabled",
+  offline_paused: false,
   // The mutation itself is parked. Nothing is in flight, so it must not spin,
   // and a second click cannot start anything, so it must not be enabled.
-  refresh_offline_paused: "disabled",
-  loading: "enabled",
-  awaiting_first_read: "enabled",
-  cloud_no_workspace: "enabled",
-  cloud_read_error: "enabled",
-  not_observed_yet: "enabled",
-  transport_error: "enabled",
-  checking: "enabled",
-  idle_unobserved: "enabled",
-  settled_count: "enabled",
-  failed_without_observation: "enabled",
+  refresh_offline_paused: false,
+  // The remaining no-payload arms: see the note above. Each already carries the
+  // cure that actually fits it, and none of those cures is a re-probe.
+  loading: false,
+  awaiting_first_read: false,
+  cloud_no_workspace: false,
+  cloud_read_error: false,
+  not_observed_yet: false,
+  transport_error: false,
+  // The payload kinds. A refresh dispatched from here has a real harness to
+  // re-probe; whether THIS runtime may dispatch it is the separate question
+  // `canManuallyRefresh` answers.
+  checking: true,
+  idle_unobserved: true,
+  settled_count: true,
+  failed_without_observation: true,
+};
+
+/**
+ * The second precondition on a manual refresh: install state, which the wire
+ * reports separately from engine ownership and which a surface gating Refresh
+ * must respect too. Folding the two into one boolean upstream would make this
+ * pane unable to tell "install this harness" from "this runtime can never
+ * refresh anything" — different remedies, so they stay different facts.
+ *
+ * `install_required` and `unsupported` block it: the probe route answers 404
+ * `NOT_INSTALLED`, and no amount of clicking installs anything. The other four
+ * allow it. `credentials_required` and `login_required` in particular keep
+ * their Refresh, because re-probing is exactly how the pane learns the user
+ * has since signed in; taking it away would remove the cure at the moment it
+ * starts working. A `Record` over all six so a seventh readiness state is a
+ * typecheck failure rather than an inherited default.
+ */
+const REFRESH_ALLOWED_BY_READINESS: Record<AgentReadinessState, boolean> = {
+  ready: true,
+  credentials_required: true,
+  login_required: true,
+  error: true,
+  install_required: false,
+  unsupported: false,
 };
 
 function payloadPresentation(
   input: AllModelsPresentationInput,
   isLocal: boolean,
-  launchOptions: HarnessLaunchOptionsResponse,
+  canManuallyRefresh: boolean,
+  launchOptions: AllModelsPayloadFacts,
   freshnessLine: string | null,
 ): Omit<AllModelsPresentation, "refresh"> {
   const { displayName, modelCount, freshnessAgo: ago } = input;
-  const canManuallyRefresh = isLocal;
 
   // `state=refreshing` is live only on the surface that can ever resolve it:
   // cloud has no refetch interval and no Refresh control, so a copied
@@ -229,9 +289,18 @@ function payloadPresentation(
       return {
         kind: "failed_without_observation",
         title: HARNESS_PANE_COPY.allModelsFailedWithoutObservationTitle,
-        detail: HARNESS_PANE_COPY.allModelsProbeFailureReason(displayName),
-        // Cloud has no probe route, so there is nothing to offer there.
-        retry: canManuallyRefresh ? "reprobe_harness" : null,
+        detail: canManuallyRefresh
+          ? HARNESS_PANE_COPY.allModelsProbeFailureReason(displayName)
+          : HARNESS_PANE_COPY.allModelsProbeFailureRecheckSuffix(displayName),
+        // E-R37: a surface that cannot dispatch a probe is not therefore stuck.
+        // Cloud has no probe route and a read-only runtime is not the engine
+        // owner, but in both cases the OWNER re-probes on its own schedule, so
+        // the row genuinely does change without this user doing anything. Left
+        // with `retry: null` this was the pane's one dead end: a permanent
+        // failure claim with no cure and no self-correction. Re-reading is a
+        // real cure here and it does not pretend to dispatch a probe, which is
+        // why the copy says check again rather than refresh.
+        retry: canManuallyRefresh ? "reprobe_harness" : "refetch_read",
         emptyBody: null,
       };
   }
@@ -251,8 +320,18 @@ export function resolveAllModelsPresentation(
   // used to sit here is subsumed: v5's `isLoading` is `isPending && isFetching`
   // and `isFetching` is `fetchStatus === "fetching"`, which every arm below
   // already renders as `loading`.
+  // Both preconditions on a manual refresh, read from the wire rather than
+  // inferred. Ownership lives on the payload, so "no payload" collapses to
+  // "cannot refresh" here as well as in the table below — a surface that
+  // guessed ownership from "is this runtime local?" would render a control
+  // whose only possible outcome is a 409 toast.
+  const canManuallyRefresh = isLocal
+    && launchOptions !== undefined
+    && launchOptions.canManuallyRefresh
+    && REFRESH_ALLOWED_BY_READINESS[launchOptions.readiness];
+
   const base: Omit<AllModelsPresentation, "refresh"> = launchOptions
-    ? payloadPresentation(input, isLocal, launchOptions, freshnessLine)
+    ? payloadPresentation(input, isLocal, canManuallyRefresh, launchOptions, freshnessLine)
     : isLocal
       ? localAbsentPresentation(input)
       : cloudAbsentPresentation(input);
@@ -266,7 +345,7 @@ export function resolveAllModelsPresentation(
   // stands. Retry goes with it, because every retry this pane offers on those
   // arms is itself a request the same gate would park.
   const decided: Omit<AllModelsPresentation, "refresh"> =
-    isLocal && input.isRefreshMutationPaused && IDLE_REFRESH_BY_KIND[base.kind] === "enabled"
+    isLocal && input.isRefreshMutationPaused && REFRESH_MEANINGFUL_BY_KIND[base.kind]
       ? {
         kind: "refresh_offline_paused",
         title: HARNESS_PANE_COPY.allModelsOfflineTitle,
@@ -287,14 +366,19 @@ export function resolveAllModelsPresentation(
   // because `refresh_now` cannot reach anything from that state, and a
   // mutation still pending against a runtime that has since died must not
   // repaint that dead control as busy.
-  const idleRefresh = IDLE_REFRESH_BY_KIND[decided.kind];
+  // Ownership gates only the ENABLED/disabled choice, never the spinner: a
+  // read-only runtime watching the owner's probe run is looking at something
+  // genuinely in flight, and a dim button there would deny a fact the detail
+  // line states. It cannot be spinning on its OWN mutation, because it could
+  // never have dispatched one.
+  const meaningful = REFRESH_MEANINGFUL_BY_KIND[decided.kind];
   const refresh: AllModelsRefreshAffordance = !isLocal
     ? "absent"
-    : idleRefresh === "disabled"
-      ? "disabled"
-      : isRefreshing
-        ? "spinning"
-        : "enabled";
+    : meaningful && isRefreshing
+      ? "spinning"
+      : meaningful && canManuallyRefresh
+        ? "enabled"
+        : "disabled";
 
   // E-R14/E-R19 belong to the arms, and only to the arms. The override that
   // used to sit here was half dead and half wrong (E-R31): `!launchOptions`

--- a/apps/packages/product-client/src/lib/domain/settings/harness-models-presentation.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/harness-models-presentation.ts
@@ -1,5 +1,9 @@
 import type { HarnessLaunchOptionsResponse } from "@anyharness/sdk";
 import { HARNESS_PANE_COPY } from "#product/copy/settings/harness-pane";
+import {
+  cloudAbsentPresentation,
+  localAbsentPresentation,
+} from "#product/lib/domain/settings/harness-models-absent-payload";
 
 /**
  * The Models section's single presentation decision, as a pure function.
@@ -34,12 +38,26 @@ export type HarnessRuntimeConnection = "connecting" | "healthy" | "failed";
 /** The v5 fetch-status axis, narrowed to the three values query-core reports. */
 export type HarnessModelsFetchStatus = "fetching" | "paused" | "idle";
 
-/** What one query knows about itself, with no react-query types leaking in. */
+/**
+ * What one query knows about itself, with no react-query types leaking in.
+ *
+ * There is deliberately no `isLoading` here (E-R32). v5 defines it as
+ * `isPending && isFetching`, so it is a DERIVED convenience over two facts
+ * this type already carries, and consulting it first is what let a spinner
+ * outrank the connection state. The two primitives decide; the proxy is gone.
+ */
 export interface HarnessModelsQueryFacts {
-  isLoading: boolean;
   isError: boolean;
   /** `ProliferateClientError.code` when the failure was structured, else null. */
   errorCode: string | null;
+  /**
+   * E-R30: whether the failure carries an HTTP status from the API, i.e. the
+   * server answered even when the body had no structured code. False when the
+   * fetch itself rejected and nothing came back. Without this, an unstructured
+   * 502 and a dead network are indistinguishable, and one honest line for both
+   * has to claim silence that was never established.
+   */
+  serverAnswered: boolean;
   isPending: boolean;
   fetchStatus: HarnessModelsFetchStatus;
 }
@@ -49,6 +67,13 @@ export interface AllModelsPresentationInput {
   displayName: string;
   /** Local only; cloud reads a copied snapshot and has no local runtime. */
   connectionState: HarnessRuntimeConnection;
+  /**
+   * E-R34: whether this host has a local runtime bridge at all. Web has none,
+   * so nothing ever writes `connectionState` there and it sits at its initial
+   * `"connecting"` forever. The capability is the fact; `connectionState`
+   * cannot report the difference between "coming up" and "will never come up".
+   */
+  hasLocalRuntimeHost: boolean;
   runtimeQuery: HarnessModelsQueryFacts;
   sandboxQuery: HarnessModelsQueryFacts;
   /** The FACT behind "no cloud workspace", not the disabled-query proxy. */
@@ -56,6 +81,12 @@ export interface AllModelsPresentationInput {
   cloudLaunchOptionsQuery: HarnessModelsQueryFacts;
   launchOptions: HarnessLaunchOptionsResponse | undefined;
   isRefreshMutationPending: boolean;
+  /**
+   * E-R28: query-core parks an `online`-mode mutation as `pending` with
+   * `isPaused: true` and no timeout. Pending alone cannot tell "in flight"
+   * from "parked", and only one of those may spin a control.
+   */
+  isRefreshMutationPaused: boolean;
   modelCount: number;
   /** `formatRelativeTime(observedAt)`, or null when nothing was ever observed. */
   freshnessAgo: string | null;
@@ -64,7 +95,9 @@ export interface AllModelsPresentationInput {
 export type AllModelsPresentationKind =
   | "runtime_connecting"
   | "runtime_failed"
+  | "local_runtime_unavailable"
   | "offline_paused"
+  | "refresh_offline_paused"
   | "loading"
   | "awaiting_first_read"
   | "cloud_no_workspace"
@@ -77,8 +110,17 @@ export type AllModelsPresentationKind =
   | "failed_without_observation";
 
 export type AllModelsRefreshAffordance = "enabled" | "disabled" | "spinning" | "absent";
-/** `refetch_read` re-issues the GET; `reprobe_harness` asks for a new probe. */
-export type AllModelsRetryAffordance = "refetch_read" | "reprobe_harness" | null;
+/**
+ * `refetch_read` re-issues the GET; `reprobe_harness` asks for a new probe;
+ * `restart_runtime` restarts the local runtime through the host bridge
+ * (E-R33), which is the only one of the three that can move a runtime the
+ * health poll already gave up on.
+ */
+export type AllModelsRetryAffordance =
+  | "refetch_read"
+  | "reprobe_harness"
+  | "restart_runtime"
+  | null;
 
 export interface AllModelsPresentation {
   kind: AllModelsPresentationKind;
@@ -104,8 +146,14 @@ const IDLE_REFRESH_BY_KIND: Record<AllModelsPresentationKind, "enabled" | "disab
   // not up, and an enabled button would be a lie pointed the other way.
   runtime_connecting: "disabled",
   runtime_failed: "disabled",
+  // No local runtime exists on this host, so there is nothing to refresh
+  // against and nothing that will ever appear (E-R34).
+  local_runtime_unavailable: "disabled",
   // The mutation is paused by the same offline gate that paused the read.
   offline_paused: "disabled",
+  // The mutation itself is parked. Nothing is in flight, so it must not spin,
+  // and a second click cannot start anything, so it must not be enabled.
+  refresh_offline_paused: "disabled",
   loading: "enabled",
   awaiting_first_read: "enabled",
   cloud_no_workspace: "enabled",
@@ -117,9 +165,6 @@ const IDLE_REFRESH_BY_KIND: Record<AllModelsPresentationKind, "enabled" | "disab
   settled_count: "enabled",
   failed_without_observation: "enabled",
 };
-
-/** A structured 404 from the cloud read: the target exists, nothing ingested. */
-const NOT_OBSERVED_CODE = "harness_launch_options_not_observed";
 
 function payloadPresentation(
   input: AllModelsPresentationInput,
@@ -192,131 +237,6 @@ function payloadPresentation(
   }
 }
 
-/** One query's non-error, non-settled fetch status. Exhaustive, no default. */
-function pendingReadPresentation(
-  fetchStatus: HarnessModelsFetchStatus,
-): Omit<AllModelsPresentation, "refresh"> {
-  switch (fetchStatus) {
-    case "fetching":
-      return { kind: "loading", title: null, detail: HARNESS_PANE_COPY.allModelsLoading, retry: null, emptyBody: null };
-    case "paused":
-      // E-R23: query-core's default `networkMode: "online"` parks the request
-      // while the browser reports offline. Nothing is in flight and nothing
-      // failed; it resumes by itself when the network returns.
-      return {
-        kind: "offline_paused",
-        title: HARNESS_PANE_COPY.allModelsOfflineTitle,
-        detail: HARNESS_PANE_COPY.allModelsOfflineSuffix,
-        retry: null,
-        emptyBody: null,
-      };
-    case "idle":
-      // Enabled, never run, not fetching: query-core marks a newly enabled
-      // query `fetching` on the same render, so this is unreachable today.
-      // Enumerated anyway with a cure that actually works rather than
-      // defaulted into someone else's copy.
-      return {
-        kind: "awaiting_first_read",
-        title: HARNESS_PANE_COPY.allModelsNotReadYetTitle,
-        detail: HARNESS_PANE_COPY.allModelsNotReadYetSuffix,
-        retry: "refetch_read",
-        emptyBody: null,
-      };
-  }
-}
-
-function localAbsentPresentation(
-  input: AllModelsPresentationInput,
-): Omit<AllModelsPresentation, "refresh"> {
-  // The FACT, read from the connection store rather than inferred from the
-  // query being disabled — `ProductProviderRoot` blanks the runtime URL for
-  // BOTH non-healthy states, so the query cannot tell them apart (E-R22).
-  switch (input.connectionState) {
-    case "connecting":
-      return {
-        kind: "runtime_connecting",
-        title: HARNESS_PANE_COPY.allModelsRuntimeConnectingTitle,
-        detail: HARNESS_PANE_COPY.allModelsRuntimeConnectingSuffix,
-        retry: null,
-        emptyBody: null,
-      };
-    case "failed":
-      // `pollUntilHealthy` gave up (120 x 500ms). This never self-corrects,
-      // so it must carry a cure instead of a promise the code cannot keep.
-      return {
-        kind: "runtime_failed",
-        title: HARNESS_PANE_COPY.allModelsRuntimeFailedTitle,
-        detail: HARNESS_PANE_COPY.allModelsRuntimeFailedSuffix,
-        retry: null,
-        emptyBody: null,
-      };
-    case "healthy":
-      if (input.runtimeQuery.isError) {
-        return {
-          kind: "transport_error",
-          title: HARNESS_PANE_COPY.allModelsTransportErrorTitle,
-          detail: HARNESS_PANE_COPY.allModelsTransportErrorReason,
-          retry: "refetch_read",
-          emptyBody: null,
-        };
-      }
-      return pendingReadPresentation(input.runtimeQuery.fetchStatus);
-  }
-}
-
-function cloudAbsentPresentation(
-  input: AllModelsPresentationInput,
-): Omit<AllModelsPresentation, "refresh"> {
-  const { sandboxQuery, cloudLaunchOptionsQuery, displayName } = input;
-  if (sandboxQuery.isError) {
-    return {
-      kind: "cloud_read_error",
-      title: HARNESS_PANE_COPY.allModelsTransportErrorTitle,
-      detail: HARNESS_PANE_COPY.allModelsCloudUnreachableReason,
-      retry: "refetch_read",
-      emptyBody: null,
-    };
-  }
-  if (sandboxQuery.fetchStatus !== "idle" || sandboxQuery.isPending) {
-    return pendingReadPresentation(sandboxQuery.fetchStatus);
-  }
-  // E-R25: assert the fact. The sandbox read has settled and answered with no
-  // workspace (`getCloudSandbox` returns 200/null), which is why the
-  // target-scoped read below is disabled — not the other way round.
-  if (!input.hasCloudSandboxId) {
-    return {
-      kind: "cloud_no_workspace",
-      title: HARNESS_PANE_COPY.allModelsCloudNoWorkspaceTitle,
-      detail: HARNESS_PANE_COPY.allModelsCloudNoWorkspaceSuffix(displayName),
-      retry: null,
-      emptyBody: null,
-    };
-  }
-  if (cloudLaunchOptionsQuery.isError) {
-    // E-R24: a structured 404 is not a transport failure. The server answered,
-    // and what it said is "this target has never had launch options ingested"
-    // — the ordinary state of a cloud workspace that has not run an agent yet.
-    // Retrying re-issues the same request and 404s forever, so no Retry.
-    if (cloudLaunchOptionsQuery.errorCode === NOT_OBSERVED_CODE) {
-      return {
-        kind: "not_observed_yet",
-        title: HARNESS_PANE_COPY.allModelsIdleUnobservedTitle,
-        detail: HARNESS_PANE_COPY.allModelsCloudNotObservedSuffix(displayName),
-        retry: null,
-        emptyBody: null,
-      };
-    }
-    return {
-      kind: "cloud_read_error",
-      title: HARNESS_PANE_COPY.allModelsTransportErrorTitle,
-      detail: HARNESS_PANE_COPY.allModelsCloudUnreachableReason,
-      retry: "refetch_read",
-      emptyBody: null,
-    };
-  }
-  return pendingReadPresentation(cloudLaunchOptionsQuery.fetchStatus);
-}
-
 export function resolveAllModelsPresentation(
   input: AllModelsPresentationInput,
 ): AllModelsPresentation {
@@ -324,18 +244,37 @@ export function resolveAllModelsPresentation(
   const { launchOptions, freshnessAgo: ago } = input;
   const freshnessLine = ago ? HARNESS_PANE_COPY.allModelsFreshRefreshedAgo(ago) : null;
 
-  const readQuery = isLocal ? input.runtimeQuery : input.cloudLaunchOptionsQuery;
-  const isLoading = isLocal
-    ? input.runtimeQuery.isLoading
-    : input.sandboxQuery.isLoading || input.cloudLaunchOptionsQuery.isLoading;
+  // E-R32: no `isLoading` gate ahead of these. "Something is fetching" is a
+  // proxy shared by causes that need opposite renderings, and consulting it
+  // first let a spinner outrank `connectionState`. Each branch now reaches its
+  // own fetch-status arm AFTER the facts that outrank it, and the branch that
+  // used to sit here is subsumed: v5's `isLoading` is `isPending && isFetching`
+  // and `isFetching` is `fetchStatus === "fetching"`, which every arm below
+  // already renders as `loading`.
+  const base: Omit<AllModelsPresentation, "refresh"> = launchOptions
+    ? payloadPresentation(input, isLocal, launchOptions, freshnessLine)
+    : isLocal
+      ? localAbsentPresentation(input)
+      : cloudAbsentPresentation(input);
 
-  const decided: Omit<AllModelsPresentation, "refresh"> = isLoading
-    ? { kind: "loading", title: null, detail: HARNESS_PANE_COPY.allModelsLoading, retry: null, emptyBody: null }
-    : launchOptions
-      ? payloadPresentation(input, isLocal, launchOptions, freshnessLine)
-      : isLocal
-        ? localAbsentPresentation(input)
-        : cloudAbsentPresentation(input);
+  // E-R28: a parked refresh mutation is not a running one. query-core reports
+  // it as `pending` with no timeout, so `isPending` alone spins the control
+  // forever with nothing in flight and no way to cancel. Say what is actually
+  // parked — but only where the line would otherwise imply a working Refresh:
+  // an arm that already disables Refresh (still connecting, gave up, no local
+  // runtime, the READ parked by the same gate) is the more specific truth and
+  // stands. Retry goes with it, because every retry this pane offers on those
+  // arms is itself a request the same gate would park.
+  const decided: Omit<AllModelsPresentation, "refresh"> =
+    isLocal && input.isRefreshMutationPaused && IDLE_REFRESH_BY_KIND[base.kind] === "enabled"
+      ? {
+        kind: "refresh_offline_paused",
+        title: HARNESS_PANE_COPY.allModelsOfflineTitle,
+        detail: HARNESS_PANE_COPY.allModelsRefreshOfflineSuffix,
+        retry: null,
+        emptyBody: base.emptyBody,
+      }
+      : base;
 
   // Busy is tied to a live probe, never to the raw `probePhase`: a terminal
   // state carrying a stray live phase is not polled by
@@ -344,17 +283,27 @@ export function resolveAllModelsPresentation(
   // update it (E-R9/E-R10).
   const isRefreshing = isLocal
     && (input.isRefreshMutationPending || decided.kind === "checking");
+  // E-R29: the table is consulted FIRST. A kind set to "disabled" is set there
+  // because `refresh_now` cannot reach anything from that state, and a
+  // mutation still pending against a runtime that has since died must not
+  // repaint that dead control as busy.
+  const idleRefresh = IDLE_REFRESH_BY_KIND[decided.kind];
   const refresh: AllModelsRefreshAffordance = !isLocal
     ? "absent"
-    : isRefreshing
-      ? "spinning"
-      : IDLE_REFRESH_BY_KIND[decided.kind];
+    : idleRefresh === "disabled"
+      ? "disabled"
+      : isRefreshing
+        ? "spinning"
+        : "enabled";
 
-  // E-R14/E-R19: keyed on what drove the header. Whenever there is no payload
-  // the header already carries the reason the list is empty, and a transport
-  // failure says it too — a second "No models detected yet." would contradict
-  // both.
-  const emptyBody = !launchOptions || readQuery.isError ? null : decided.emptyBody;
-
-  return { ...decided, refresh, emptyBody };
+  // E-R14/E-R19 belong to the arms, and only to the arms. The override that
+  // used to sit here was half dead and half wrong (E-R31): `!launchOptions`
+  // could never fire, because every arm reachable without a payload already
+  // returns `emptyBody: null` — which is also why the four assertions guarding
+  // it could not fail. And `readQuery.isError` fires ONLY when a payload does
+  // exist, where it suppresses a body that agrees with its own header: a
+  // failed background refetch does not change "0 models", so blanking "No
+  // models detected yet." underneath it hides a true line on the strength of a
+  // fact the header never mentions. Each arm owns its own empty line.
+  return { ...decided, refresh };
 }

--- a/apps/packages/product-client/src/lib/domain/settings/harness-models-presentation.ts
+++ b/apps/packages/product-client/src/lib/domain/settings/harness-models-presentation.ts
@@ -1,0 +1,360 @@
+import type { HarnessLaunchOptionsResponse } from "@anyharness/sdk";
+import { HARNESS_PANE_COPY } from "#product/copy/settings/harness-pane";
+
+/**
+ * The Models section's single presentation decision, as a pure function.
+ *
+ * Three review rounds each fixed one arm of "there is no launch-options
+ * payload" and each invented the mirror of the bug it fixed, because the arms
+ * were written against PROXIES ("this query is disabled") rather than FACTS
+ * ("the runtime failed"). A proxy is shared by causes that need opposite
+ * renderings: a disabled query means "still connecting" on a cold start and
+ * "gave up 60s ago" after `pollUntilHealthy` exhausts, and no amount of
+ * `isPending` inspection can separate them — only `connectionState` can.
+ *
+ * So every cause is enumerated here once, each switch is exhaustive with no
+ * `default:` arm, and the refresh affordance is a `Record` keyed by kind.
+ * Adding a wire state, a connection state, a fetch status, or a kind without
+ * deciding what it renders is a typecheck failure, not a runtime lie.
+ *
+ * The governing rule for every arm: never render a failure claim or a spinner
+ * for a condition where nothing is happening and nothing failed, and never
+ * leave a dead end — each arm carries either a cure the user can take or an
+ * honest statement that it resolves itself.
+ */
+
+/**
+ * The runtime-connection fact this resolver needs, owned at the domain layer
+ * rather than imported up from the store (FE-PC-6). The component passes the
+ * store's `HarnessConnectionState` in, so if that union ever gains a member
+ * the call site stops typechecking until this resolver decides what it means.
+ */
+export type HarnessRuntimeConnection = "connecting" | "healthy" | "failed";
+
+/** The v5 fetch-status axis, narrowed to the three values query-core reports. */
+export type HarnessModelsFetchStatus = "fetching" | "paused" | "idle";
+
+/** What one query knows about itself, with no react-query types leaking in. */
+export interface HarnessModelsQueryFacts {
+  isLoading: boolean;
+  isError: boolean;
+  /** `ProliferateClientError.code` when the failure was structured, else null. */
+  errorCode: string | null;
+  isPending: boolean;
+  fetchStatus: HarnessModelsFetchStatus;
+}
+
+export interface AllModelsPresentationInput {
+  surface: "local" | "cloud";
+  displayName: string;
+  /** Local only; cloud reads a copied snapshot and has no local runtime. */
+  connectionState: HarnessRuntimeConnection;
+  runtimeQuery: HarnessModelsQueryFacts;
+  sandboxQuery: HarnessModelsQueryFacts;
+  /** The FACT behind "no cloud workspace", not the disabled-query proxy. */
+  hasCloudSandboxId: boolean;
+  cloudLaunchOptionsQuery: HarnessModelsQueryFacts;
+  launchOptions: HarnessLaunchOptionsResponse | undefined;
+  isRefreshMutationPending: boolean;
+  modelCount: number;
+  /** `formatRelativeTime(observedAt)`, or null when nothing was ever observed. */
+  freshnessAgo: string | null;
+}
+
+export type AllModelsPresentationKind =
+  | "runtime_connecting"
+  | "runtime_failed"
+  | "offline_paused"
+  | "loading"
+  | "awaiting_first_read"
+  | "cloud_no_workspace"
+  | "cloud_read_error"
+  | "not_observed_yet"
+  | "transport_error"
+  | "checking"
+  | "idle_unobserved"
+  | "settled_count"
+  | "failed_without_observation";
+
+export type AllModelsRefreshAffordance = "enabled" | "disabled" | "spinning" | "absent";
+/** `refetch_read` re-issues the GET; `reprobe_harness` asks for a new probe. */
+export type AllModelsRetryAffordance = "refetch_read" | "reprobe_harness" | null;
+
+export interface AllModelsPresentation {
+  kind: AllModelsPresentationKind;
+  title: string | null;
+  detail: string | null;
+  refresh: AllModelsRefreshAffordance;
+  retry: AllModelsRetryAffordance;
+  /**
+   * The expanded body's empty-list line, or null when the header already
+   * explains the emptiness and a second line would contradict it (E-R19).
+   */
+  emptyBody: string | null;
+}
+
+/**
+ * Refresh when the local surface is idle. Cloud has no refresh route at all,
+ * and a live probe overrides this with `spinning`, so this table only decides
+ * the local-and-settled case. A `Record` rather than a `switch (kind)` so a
+ * new kind cannot silently inherit "enabled".
+ */
+const IDLE_REFRESH_BY_KIND: Record<AllModelsPresentationKind, "enabled" | "disabled"> = {
+  // Nothing to refresh against: `refresh_now` cannot reach a runtime that is
+  // not up, and an enabled button would be a lie pointed the other way.
+  runtime_connecting: "disabled",
+  runtime_failed: "disabled",
+  // The mutation is paused by the same offline gate that paused the read.
+  offline_paused: "disabled",
+  loading: "enabled",
+  awaiting_first_read: "enabled",
+  cloud_no_workspace: "enabled",
+  cloud_read_error: "enabled",
+  not_observed_yet: "enabled",
+  transport_error: "enabled",
+  checking: "enabled",
+  idle_unobserved: "enabled",
+  settled_count: "enabled",
+  failed_without_observation: "enabled",
+};
+
+/** A structured 404 from the cloud read: the target exists, nothing ingested. */
+const NOT_OBSERVED_CODE = "harness_launch_options_not_observed";
+
+function payloadPresentation(
+  input: AllModelsPresentationInput,
+  isLocal: boolean,
+  launchOptions: HarnessLaunchOptionsResponse,
+  freshnessLine: string | null,
+): Omit<AllModelsPresentation, "refresh"> {
+  const { displayName, modelCount, freshnessAgo: ago } = input;
+  const canManuallyRefresh = isLocal;
+
+  // `state=refreshing` is live only on the surface that can ever resolve it:
+  // cloud has no refetch interval and no Refresh control, so a copied
+  // `refreshing` snapshot there is last-good data, not "checking" (E-R12).
+  // `detecting` needs the phase to tell a running first observation apart
+  // from a harness that legitimately sits unobserved forever.
+  const probePhase = isLocal ? launchOptions.probePhase : undefined;
+  const isProbeLive = probePhase === "running" || probePhase === "queued";
+  if ((isLocal && launchOptions.state === "refreshing")
+    || (launchOptions.state === "detecting" && isProbeLive)) {
+    return { kind: "checking", title: null, detail: HARNESS_PANE_COPY.allModelsChecking, retry: null, emptyBody: null };
+  }
+  if (launchOptions.state === "detecting") {
+    return {
+      kind: "idle_unobserved",
+      title: HARNESS_PANE_COPY.allModelsIdleUnobservedTitle,
+      detail: HARNESS_PANE_COPY.allModelsIdleUnobservedSuffix(displayName, canManuallyRefresh),
+      retry: null,
+      emptyBody: HARNESS_PANE_COPY.allModelsEmpty,
+    };
+  }
+
+  // No `default:`: a seventh wire state must be decided here, not defaulted.
+  switch (launchOptions.state) {
+    case "observed":
+    case "refreshing":
+      return {
+        kind: "settled_count",
+        title: HARNESS_PANE_COPY.probeModelCount(modelCount),
+        detail: freshnessLine,
+        retry: null,
+        emptyBody: HARNESS_PANE_COPY.allModelsEmpty,
+      };
+    case "observed_empty":
+      return {
+        kind: "settled_count",
+        title: HARNESS_PANE_COPY.probeModelCount(modelCount),
+        detail: ago ? HARNESS_PANE_COPY.allModelsObservedEmptySuffix(displayName, ago) : null,
+        retry: null,
+        emptyBody: HARNESS_PANE_COPY.allModelsEmpty,
+      };
+    case "last_good_after_failure":
+      return {
+        kind: "settled_count",
+        title: HARNESS_PANE_COPY.probeModelCount(modelCount),
+        detail: ago
+          ? HARNESS_PANE_COPY.allModelsLastGoodAfterFailureSuffix(ago)
+          : HARNESS_PANE_COPY.allModelsRefreshFailedBadge,
+        retry: null,
+        emptyBody: HARNESS_PANE_COPY.allModelsEmpty,
+      };
+    case "failed_without_observation":
+      return {
+        kind: "failed_without_observation",
+        title: HARNESS_PANE_COPY.allModelsFailedWithoutObservationTitle,
+        detail: HARNESS_PANE_COPY.allModelsProbeFailureReason(displayName),
+        // Cloud has no probe route, so there is nothing to offer there.
+        retry: canManuallyRefresh ? "reprobe_harness" : null,
+        emptyBody: null,
+      };
+  }
+}
+
+/** One query's non-error, non-settled fetch status. Exhaustive, no default. */
+function pendingReadPresentation(
+  fetchStatus: HarnessModelsFetchStatus,
+): Omit<AllModelsPresentation, "refresh"> {
+  switch (fetchStatus) {
+    case "fetching":
+      return { kind: "loading", title: null, detail: HARNESS_PANE_COPY.allModelsLoading, retry: null, emptyBody: null };
+    case "paused":
+      // E-R23: query-core's default `networkMode: "online"` parks the request
+      // while the browser reports offline. Nothing is in flight and nothing
+      // failed; it resumes by itself when the network returns.
+      return {
+        kind: "offline_paused",
+        title: HARNESS_PANE_COPY.allModelsOfflineTitle,
+        detail: HARNESS_PANE_COPY.allModelsOfflineSuffix,
+        retry: null,
+        emptyBody: null,
+      };
+    case "idle":
+      // Enabled, never run, not fetching: query-core marks a newly enabled
+      // query `fetching` on the same render, so this is unreachable today.
+      // Enumerated anyway with a cure that actually works rather than
+      // defaulted into someone else's copy.
+      return {
+        kind: "awaiting_first_read",
+        title: HARNESS_PANE_COPY.allModelsNotReadYetTitle,
+        detail: HARNESS_PANE_COPY.allModelsNotReadYetSuffix,
+        retry: "refetch_read",
+        emptyBody: null,
+      };
+  }
+}
+
+function localAbsentPresentation(
+  input: AllModelsPresentationInput,
+): Omit<AllModelsPresentation, "refresh"> {
+  // The FACT, read from the connection store rather than inferred from the
+  // query being disabled — `ProductProviderRoot` blanks the runtime URL for
+  // BOTH non-healthy states, so the query cannot tell them apart (E-R22).
+  switch (input.connectionState) {
+    case "connecting":
+      return {
+        kind: "runtime_connecting",
+        title: HARNESS_PANE_COPY.allModelsRuntimeConnectingTitle,
+        detail: HARNESS_PANE_COPY.allModelsRuntimeConnectingSuffix,
+        retry: null,
+        emptyBody: null,
+      };
+    case "failed":
+      // `pollUntilHealthy` gave up (120 x 500ms). This never self-corrects,
+      // so it must carry a cure instead of a promise the code cannot keep.
+      return {
+        kind: "runtime_failed",
+        title: HARNESS_PANE_COPY.allModelsRuntimeFailedTitle,
+        detail: HARNESS_PANE_COPY.allModelsRuntimeFailedSuffix,
+        retry: null,
+        emptyBody: null,
+      };
+    case "healthy":
+      if (input.runtimeQuery.isError) {
+        return {
+          kind: "transport_error",
+          title: HARNESS_PANE_COPY.allModelsTransportErrorTitle,
+          detail: HARNESS_PANE_COPY.allModelsTransportErrorReason,
+          retry: "refetch_read",
+          emptyBody: null,
+        };
+      }
+      return pendingReadPresentation(input.runtimeQuery.fetchStatus);
+  }
+}
+
+function cloudAbsentPresentation(
+  input: AllModelsPresentationInput,
+): Omit<AllModelsPresentation, "refresh"> {
+  const { sandboxQuery, cloudLaunchOptionsQuery, displayName } = input;
+  if (sandboxQuery.isError) {
+    return {
+      kind: "cloud_read_error",
+      title: HARNESS_PANE_COPY.allModelsTransportErrorTitle,
+      detail: HARNESS_PANE_COPY.allModelsCloudUnreachableReason,
+      retry: "refetch_read",
+      emptyBody: null,
+    };
+  }
+  if (sandboxQuery.fetchStatus !== "idle" || sandboxQuery.isPending) {
+    return pendingReadPresentation(sandboxQuery.fetchStatus);
+  }
+  // E-R25: assert the fact. The sandbox read has settled and answered with no
+  // workspace (`getCloudSandbox` returns 200/null), which is why the
+  // target-scoped read below is disabled — not the other way round.
+  if (!input.hasCloudSandboxId) {
+    return {
+      kind: "cloud_no_workspace",
+      title: HARNESS_PANE_COPY.allModelsCloudNoWorkspaceTitle,
+      detail: HARNESS_PANE_COPY.allModelsCloudNoWorkspaceSuffix(displayName),
+      retry: null,
+      emptyBody: null,
+    };
+  }
+  if (cloudLaunchOptionsQuery.isError) {
+    // E-R24: a structured 404 is not a transport failure. The server answered,
+    // and what it said is "this target has never had launch options ingested"
+    // — the ordinary state of a cloud workspace that has not run an agent yet.
+    // Retrying re-issues the same request and 404s forever, so no Retry.
+    if (cloudLaunchOptionsQuery.errorCode === NOT_OBSERVED_CODE) {
+      return {
+        kind: "not_observed_yet",
+        title: HARNESS_PANE_COPY.allModelsIdleUnobservedTitle,
+        detail: HARNESS_PANE_COPY.allModelsCloudNotObservedSuffix(displayName),
+        retry: null,
+        emptyBody: null,
+      };
+    }
+    return {
+      kind: "cloud_read_error",
+      title: HARNESS_PANE_COPY.allModelsTransportErrorTitle,
+      detail: HARNESS_PANE_COPY.allModelsCloudUnreachableReason,
+      retry: "refetch_read",
+      emptyBody: null,
+    };
+  }
+  return pendingReadPresentation(cloudLaunchOptionsQuery.fetchStatus);
+}
+
+export function resolveAllModelsPresentation(
+  input: AllModelsPresentationInput,
+): AllModelsPresentation {
+  const isLocal = input.surface === "local";
+  const { launchOptions, freshnessAgo: ago } = input;
+  const freshnessLine = ago ? HARNESS_PANE_COPY.allModelsFreshRefreshedAgo(ago) : null;
+
+  const readQuery = isLocal ? input.runtimeQuery : input.cloudLaunchOptionsQuery;
+  const isLoading = isLocal
+    ? input.runtimeQuery.isLoading
+    : input.sandboxQuery.isLoading || input.cloudLaunchOptionsQuery.isLoading;
+
+  const decided: Omit<AllModelsPresentation, "refresh"> = isLoading
+    ? { kind: "loading", title: null, detail: HARNESS_PANE_COPY.allModelsLoading, retry: null, emptyBody: null }
+    : launchOptions
+      ? payloadPresentation(input, isLocal, launchOptions, freshnessLine)
+      : isLocal
+        ? localAbsentPresentation(input)
+        : cloudAbsentPresentation(input);
+
+  // Busy is tied to a live probe, never to the raw `probePhase`: a terminal
+  // state carrying a stray live phase is not polled by
+  // `resolveAgentLaunchOptionsRefetchInterval`, so disabling Refresh there
+  // would freeze data behind a disabled button with nothing scheduled to
+  // update it (E-R9/E-R10).
+  const isRefreshing = isLocal
+    && (input.isRefreshMutationPending || decided.kind === "checking");
+  const refresh: AllModelsRefreshAffordance = !isLocal
+    ? "absent"
+    : isRefreshing
+      ? "spinning"
+      : IDLE_REFRESH_BY_KIND[decided.kind];
+
+  // E-R14/E-R19: keyed on what drove the header. Whenever there is no payload
+  // the header already carries the reason the list is empty, and a transport
+  // failure says it too — a second "No models detected yet." would contradict
+  // both.
+  const emptyBody = !launchOptions || readQuery.isError ? null : decided.emptyBody;
+
+  return { ...decided, refresh, emptyBody };
+}


### PR DESCRIPTION
## Summary

Fixes the observed production bug: Settings showed "0 models · Probing…" with a **disabled** Refresh button for 32+ minutes after the runtime already had 180 observed models. Two causes, both fixed here:

1. `isRefreshing` included `state === "detecting"`, so a stale `detecting` response disabled the very control that would cure it — a settled-unobserved harness (e.g. Cursor, which by design never probes unattended) must show an ENABLED, static Refresh forever.
2. The freshness line fell back to `?? launchOptions.state`, rendering a raw wire state string as user copy, and a `probeModelCount` line always rendered — including "0 models · Loading…" before any observation ever settled.

`HarnessAllModelsSection` (`apps/packages/product-client/src/components/settings/panes/agents/harness/HarnessAllModelsSection.tsx`) now renders exactly one of the eight states from the design handoff (`HANDOFF-first-run-truth.md`, `Settings - Harness Models States.dc.html`), using the exact copy from the artifact:

1. Initial HTTP loading — "Loading models…", no count.
2. `detecting`/`refreshing` with an active probe — "Checking available models…", never a count, Refresh disabled-as-busy (full ink, `animate-spin`, aria-label "Refreshing…").
3. `detecting` with no active probe (idle-unobserved, Cursor fixture) — "Models haven't been detected yet · «Agent» reports models after its first launch. Refresh checks now." Refresh stays ENABLED and static — this is the fix for the 32-minute bug.
4. `observed` — "«N» models · refreshed «ago»".
5. `observed_empty` — "0 models · «Agent» reported none · refreshed «ago»", calm, no error tone.
6. `last_good_after_failure` — "«N» models · last refresh failed · refreshed «ago»", list undimmed.
7. `failed_without_observation` — "Couldn't check models · «Agent» didn't answer the probe.", enabled inline Retry.
8. Transport/query error — "Models couldn't be loaded · The runtime didn't respond.", Retry refetches the query.

The content-line container is `aria-live="polite"` so it announces on state transitions only. New copy lives in `copy/settings/harness-pane.ts`.

Section layout, header, disclosure, filter row, and `ModelTable` are untouched, as is the polling policy (owned by the stacked base PR, #2196 / slice B) and the auth badge / Cloud|Local scope toggle.

## Assumptions / deviations

- `probeFailureCode` is a free-form `string | null` on the wire with no existing code→copy taxonomy anywhere in the codebase. Per "never render a wire string as copy," the muted reason for `failed_without_observation` is agent-name-parameterized ("«Agent» didn't answer the probe.") rather than branching on the specific code value, matching the one fixture the artifact specifies (Cursor / `harness_probe_failed`). **Quarantined per review round 1 (E-R7) — not fixed, recorded as a follow-up**: a real code→copy taxonomy is worth building once more failure codes are observed in production, but inventing one now would be speculative.
- `state === "refreshing"` is treated as unconditionally "Checking…" (matching `resolveAgentLaunchOptionsRefetchInterval`'s treatment of `refreshing` as always-live). This was verified correct in review round 1 and kept as-is.
- The busy Refresh button keeps the native `disabled` attribute (matching the artifact's literal markup and RTL-testable disablement). The reviewer ruled screen-reader announcement is already covered by the `aria-live="polite"` content line even though a disabled button leaves the tab order; `title="Refresh"` is kept static since doing so was cheap. Not redesigned further.

## Review round 1 fixes

Round 1 came back FIX REQUIRED with one BLOCKER; all findings addressed in this push (new head `db56cbd713cbd3b874a1ea8c7a417776cb5916b5`):

- **E-R1 (BLOCKER) — stale sibling coverage updated to the new contract.** `HarnessPane.test.tsx` (not part of this slice's original diff) encoded the pre-existing contract this slice replaced, and two of its tests broke:
  - `"reads the runtime launch-option observation"` asserted `/Last refreshed/`, copy that no longer exists (now "refreshed «ago»" via the shared relative-time formatter). Updated to assert `/refreshed/` — an exact string isn't achievable there since the test's `probedAt` is a fixed calendar date with no mocked system clock.
  - `"does not seed model choices before the first observation"` asserted `"0 models"` was present — but a count must never render before a settled observation (states 1/2's truthfulness rule), so the old assertion was itself testing the bug this slice fixes. Inverted to `expect(screen.queryByText(/\d+ models?/)).toBeNull()`, preserving the test's real anti-seeding intent. Neither test was deleted.
- **E-R2 (HIGH) — `queued` now treated as live everywhere `running` is.** `probePhase` has 4 values (`idle|queued|running|backoff`); `isProbeLive` (was `isProbeRunning`) now checks `probePhase === "running" || probePhase === "queued"`, matching slice B's own polling policy (`resolveAgentLaunchOptionsRefetchInterval` treats `queued`+`running` as equally live). Added fixtures/tests for both `detecting`+`queued` and `refreshing`+`queued`.
- **E-R3 (MEDIUM) — sanctioned className idiom.** Replaced the inline `style={{ opacity: 1 }}` override with `className="disabled:opacity-100"`, the same busy-not-unavailable idiom used elsewhere in the repo (`SidebarUpdateFooterButton`, `GitReviewTargetSelector`). `IconButton.tsx` itself is untouched.
- **E-R4 (MEDIUM) — reuse the existing relative-time formatter.** Deleted the new `formatSnapshotAge` helper entirely; the freshness suffix now composes `refreshed ${formatRelativeTime(observedAt)}` using the repo's existing formatter (`lib/domain/workspaces/display/workspace-display.ts`, already used by six other call sites). This also removed the need for a "just now" special case in `allModelsFreshRefreshedAgo` — `formatRelativeTime` already returns "now" for that bucket, so the artifact's one "just now" fixture reads as "refreshed now" instead, trading a one-off literal match for consistency with every other surface's phrasing.
- **E-R5 (MEDIUM) — surface-aware idle-unobserved copy.** Cloud has no manual-refresh route and no probe route, so it must never reference either: `allModelsIdleUnobservedSuffix` now takes a `canManuallyRefresh` flag and drops the "Refresh checks now." sentence on cloud, and `failed_without_observation` offers no Retry button on cloud. Added new cloud-surface test coverage — both cloud hooks were previously mocked to `data: undefined` in every existing test, leaving the entire cloud path uncovered.
- **E-R6 (LOW) — expanded body agrees with a live header, without hiding last-good data.** The disclosure body now shows "Checking available models…" (matching the header) only when there is no prior list to show yet (a first observation in progress, `models.length === 0`). A re-probe over already-observed data (`state === "refreshing"` with an existing list) keeps showing that list undimmed — the same "data stays readable while we wait" contract as state 6 — rather than blanking it out for a placeholder.
- **E-R7 (LOW) — quarantined, not fixed.** `probeFailureCode` still isn't read for copy branching; generic agent-name-parameterized copy is acceptable per the reviewer's ruling. Recorded here as a follow-up, not actioned.
- **E-R8 (INFO) — no action.** Repo-wide icon `aria-hidden` gap, not a regression introduced by this slice.
- **aria-busy ruling** — kept native `disabled` per the artifact; `aria-live="polite"` on the content line covers the screen-reader announcement. No redesign.

## Test plan

- [x] `pnpm --filter @proliferate/cloud-sdk build && pnpm --filter @anyharness/sdk build && pnpm --filter @anyharness/sdk-react build && pnpm --filter @proliferate/cloud-sdk-react build` (pure `tsc`, no Rust)
- [x] `pnpm --filter @proliferate/product-client run typecheck` — clean
- [x] `vitest run --maxWorkers=2 src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx` — **18/18 passing** (was 14; +4 for E-R2 queued fixtures and E-R5 cloud-surface coverage), covering all 8 states, the ENABLED idle-unobserved Refresh, `queued` treated as live, a stale-detecting→observed convergence with fake timers and no user action, a refresh-mutation-5xx→durable-failed-state reread, no-count-before-settled-observation, freshness-only-with-observedAt, and the cloud surface.
- [x] Full affected directory, derived from the diff rather than only the authored test file — `vitest run --maxWorkers=2 src/components/settings/panes/agents/harness/`: **10 test files, 94/94 passing** (`HarnessAllModelsSection.test.tsx` 18, `HarnessPane.test.tsx` 34, `HarnessProvidersSection.test.tsx` 2, `ProviderPickerModal.test.tsx` 19, `HarnessPane.hierarchy.test.tsx` 6, `HarnessAuthEvidenceBadge.test.tsx` 8, `HarnessManagedNotice.test.tsx` 3, `ProviderRow.test.tsx` 2, `ModelTable.test.tsx` 1, `HarnessConfigIssueBanner.test.tsx` 1).
- [x] Negative control (re-run against the current code): re-added `state === "detecting"` to the `isRefreshing` disjunction — `HarnessAllModelsSection.test.tsx` failed with `TestingLibraryElementError: Unable to find an accessible element with the role "button" and name "/^refresh$/i"` (the button's accessible name flipped to "Refreshing…") in the idle-unobserved-enabled-Refresh test (1 failed | 17 passed); reverted, full harness directory suite green again (94/94).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review round 2 fixes

Round 2 came back FIX REQUIRED (0 HIGH, 2 MEDIUM). All six findings addressed in this push (new head `4552deb48075c60b6cad6d77d8c42c0ed5e55d58`):

- **E-R9 (MEDIUM) — a terminal state carrying a live phase disabled Refresh with nothing scheduled to refetch.** `HarnessAllModelsSection.tsx:145` — `isRefreshing` now derives from `isChecking` (`isLocal && (refreshLaunchOptions.isPending || isChecking)`) instead of the raw `probePhase`. Previously `state: "observed"` + a stray `probePhase: "queued"` disabled the cure with no poll ever scheduled to update it — the 32-minute bug's exact shape through a different door, and it gets more reachable as slice B's admission window widens, not less. `isChecking` itself is computed first (`:132-134`) so `isRefreshing` can reference it.
- **E-R10 (LOW) — contradictory affordances in one state, confirmed resolved.** The E-R9 fix removes the disabled-and-spinning header next to an enabled Retry for `failed_without_observation` + a live `probePhase`; pinned with a dedicated test.
- **E-R11 (MEDIUM) — an inert test, now a real guard.** `HarnessAllModelsSection.test.tsx` (was `:409`) — `expect(screen.queryByText("observed")).toBeNull()` could never fail: the muted span concatenates a `" · "` separator with the raw state into one node's text (`"0 models · observed"`), so an exact-string query for the bare word never matches, bug or no bug. Replaced with `expect(contentLine().textContent).not.toMatch(/detecting|refreshing|observed|last_good_after_failure|failed_without_observation/)` — a superset of the reviewer's suggested pattern, extended to also include bare `observed` (the reviewer's example pattern only covered `observed_empty` and wouldn't have caught this exact fixture's raw state). Negative control below.
- **E-R12 (LOW) — cloud `refreshing` claimed in-flight with no way to update or cure.** `HarnessAllModelsSection.tsx:132` gates the `refreshing`-is-live arm on `isLocal`; a copied cloud snapshot in `refreshing` has no refetch interval and no Refresh control, so it now renders as its last-good count + freshness (`:187-193`, `refreshing` falls into the same switch arm as `observed`) rather than claiming to be actively checking.
- **E-R13 (LOW) — a disabled query showed "Loading models…" forever.** `HarnessAllModelsSection.tsx:161-174` — a local query with no data and no error (runtime has no URL yet, so `useAgentLaunchOptionsQuery` never enables) now renders state 8's copy instead of sitting on the loading line indefinitely.
- **E-R14 (LOW) — expanded body contradicted its own header.** `HarnessAllModelsSection.tsx:344-353` — the disclosure body's empty-state line is suppressed when `isQueryError` or `state === "failed_without_observation"`, since the header already explains why the list is empty in those two states.
- **E-R16 (LOW).** Dropped the one added trailing blank line in `harness-catalog.ts`.

**Inert-assertion sweep** (requested alongside E-R11): checked every `queryByText`/`getByText` call against a literal (non-regex) string for the same "concatenated-node" defect class. Found exactly one other instance of the *pattern* worth naming but not a bug — `getByText("· Cursor reports models after its first launch. Refresh checks now.")` and the other `"· ..."`-prefixed assertions include the separator explicitly, so they match the muted span's full concatenated text and are not vacuous. Regex-based `.toBeNull()` calls (e.g. `/\d+ models?/`) are substring-safe by construction. No other inert assertions found.

**Negative controls (mandatory for E-R9 and E-R11):**

*E-R9* — reverted `isRefreshing` to derive from `isProbeLive` directly. The new E-R9 test failed:
```
❯ src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx:528:34
    526|     render(<HarnessAllModelsSection harnessKind="claude" displayName="…
    527|     expect(screen.getByText("1 model")).toBeTruthy();
    528|     const refreshButton = screen.getByRole("button", { name: /^refresh…
       |                                  ^
 Tests  1 failed | 22 skipped (23)
```
(No button matched `/^refresh$/i` — its accessible name had flipped to "Refreshing…" for the `observed` + `probePhase: queued` fixture.) Reverted, full file back to 23/23.

*E-R11* — restored the deleted `?? launchOptions.state` fallback verbatim (`freshnessLine = ago ? ... : (launchOptions?.state ?? null)`). The new assertion failed:
```
AssertionError: expected '0 models · observed' not to match /detecting|refreshing|observed|last_go…/
 ❯ src/components/settings/panes/agents/harness/HarnessAllModelsSection.test.tsx:415:43
```
Reverted, full file back to 23/23.

**Test output:**
- `HarnessAllModelsSection.test.tsx`: **23/23 passing** (was 18; +5 for E-R9/E-R10/E-R12/E-R13/E-R14). *(Counts as of round 2; see rounds 3-4 below for current totals.)*
- Full `settings/panes/agents/harness/` directory: **10 test files, 99/99 passing** *(round 2; now 11 files / 103)*.
- `npx tsc -p tsconfig.json --noEmit`: clean, exit 0.
- `python3 scripts/check_max_lines.py`: passed (test file trimmed to stay under the 600-line general cap after the new tests were added).


## Review round 3 fixes

Round 3 came back FIX REQUIRED (0 HIGH, 2 MEDIUM, 2 LOW). Head `34573c95f64c2b1fab389a390e6b38ab31be6b09`.

Round 2's E-R13 fix had collapsed "disabled" into "error" — the same fabrication in a new place. Three conditions produce an absent payload and they are not interchangeable. `fetchStatus` is the discriminator: in TanStack v5 a DISABLED query with no data is `status: "pending"`, indistinguishable from an in-flight one by `isPending` alone.

- **E-R17 (MEDIUM)** — a local runtime merely still connecting has no runtime URL yet (`ProductProviderRoot` only forwards one at `healthy`), so the query is disabled for the entire connect window. The pane asserted "Models couldn't be loaded · The runtime didn't respond." about a runtime nobody had asked. Now an honest connecting line, no Retry, Refresh disabled and **not** spinning.
- **E-R18 (MEDIUM)** — `getCloudSandbox` answers 200/null for an account with no cloud workspace, so the target-scoped read never runs and the pane sat on "Loading models…" forever with no Refresh and no Retry anywhere in the view.
- **E-R19 (LOW)** — the empty-body suppression is keyed on what drove the header (no payload at all) rather than on `isQueryError`.
- **E-R20** — no action; no rebase. Merge base stays `40beb5de8a`.

**Tests:** `HarnessAllModelsSection.test.tsx` stayed at 23 (E-R13's test retargeted in place, none deleted); new sibling `HarnessAllModelsSection.absent-payload.test.tsx` added the new arms. Harness directory 11 files / 103 passing. Four negative controls, each reverted → literal failure quoted → restored → re-verified green. A 40-cell before/after matrix probe showed exactly the 2 intended cells changed.

## Review round 4 fixes

Round 4 came back FIX REQUIRED (3 HIGH, 2 MEDIUM, 2 LOW). Head `0e2c0ecf457aa4f0a377816cd496006f1a5f218d`.

**The structural ruling.** Rounds 2–4 each fixed one arm and each invented the mirror of the bug it fixed, because the arms were written against *proxies* ("this query is disabled") rather than *facts* ("the runtime failed"). A proxy is shared by causes needing opposite renderings, so patching arms one `if` at a time cannot converge.

`resolveAllModelsPresentation` (`lib/domain/settings/harness-models-presentation.ts`) is now a pure function from the whole input space to one honest presentation, and the compiler proves it total:

| Guard | Proven by |
|---|---|
| wire-state `switch`, no `default:` | dropped a case → `TS2366: Function lacks ending return statement` |
| refresh affordance as `Record<Kind, …>` | added a kind → `TS2741: Property 'some_new_cause' is missing` |
| store union drift | added a member → `TS2322: 'HarnessConnectionState' is not assignable to 'HarnessRuntimeConnection'` |

`connectionState` and `fetchStatus` are switched exhaustively too. The resolver owns `HarnessRuntimeConnection` at the domain layer, so the drift guard works without an upward `lib -> stores` import (FE-PC-6).

- **E-R21 (HIGH, CI blocker)** — the component was 415 lines and failed the 400-line FE-SIZE-1 gate, which is what turned CI red. Split at the resolver seam: component 415 → **307**, resolver **353**. No ratchet entry added.
- **E-R22 (HIGH)** — `ProductProviderRoot.tsx:52` maps *both* non-healthy states to `""`, so a disabled query structurally could not tell "connecting" from "failed". After `pollUntilHealthy` exhausts (120 × 500ms ≈ 60s) the pane promised, permanently, that models were on their way, Refresh disabled, no cure. It now reads `connectionState` and gives `"failed"` its own line plus a real cure ("Restart Proliferate to try again.").
- **E-R23 (MEDIUM)** — query-core's default `networkMode: "online"` parks the read when the browser is offline; that fell into the in-flight arm and spun forever with a Refresh whose mutation was paused too. Paused is now its own arm. The comment justifying the old fall-through described an impossible v5 combination and is gone.
- **E-R24 (HIGH)** — the cloud read answers **404 `harness_launch_options_not_observed`** for a workspace that has never run an agent: the single most likely cloud first-run screen. It claimed "The runtime didn't respond." with a Retry that re-issues the same request and 404s forever. Now branches on `ProliferateClientError.code`. A genuine cloud failure also names the hop that actually failed ("Proliferate Cloud didn't respond.") instead of blaming the local runtime.
- **E-R25 (MEDIUM)** — "no workspace" is asserted from the settled sandbox answer (`!hasCloudSandboxId`), not inferred from the dependent query being disabled.
- **E-R26 (LOW)** — an inert negative assertion (bare `"The runtime didn't respond."` vs the muted span's `"· "`-prefixed node text) — the E-R11 class. Proved inert by rendering the line and probing both matcher forms (`bare=false | prefixed=true`), then fixed. Swept all negative assertions across both component files; it was the only one left.
- **E-R27 (LOW)** — this section.

Every arm now ends in either a cure the user can take or an honest statement of what clears it. A resolver test asserts that invariant across all of them rather than trusting review to spot a dead end — and it caught one while being written (`cloud_no_workspace`).

**Test output at `0e2c0ecf45`:**
- Full product-client: **1099 files / 8246 tests passing** (was 1098/8230).
- `HarnessAllModelsSection.test.tsx` **23**, `HarnessAllModelsSection.absent-payload.test.tsx` **8**, new `harness-models-presentation.test.ts` **12**. Harness + `lib/domain/settings`: 28 files / 249 passing.
- `npx tsc -p tsconfig.json --noEmit`: exit 0.
- `check_max_lines`, `check_frontend_boundaries`, `check_component_library`, `check_design_attribution`, `check_docs`: all exit 0. `report_frontend_structure.py --strict`: `FE-SIZE-1: 0`, `TOTAL: 0`.
- **Matrix:** a clock-pinned 144-cell before/after probe — 6 states × 5 probePhases × 3 connection states (local, 90) + 6 × 5 (cloud, 30) + 24 no-payload causes. **All 120 payload cells byte-identical**, `isRefreshing ⟺ polls` holding 21/21 with 0 violations, and exactly the **14 intended** no-payload cells changed.
- **Negative controls** (E-R22, E-R23, E-R24, E-R25, plus the two compiler guards and the E-R26 inertness probe): each edit asserted its anchor matched before running, so a silently no-op'd edit aborts instead of certifying unguarded code; each produced a non-zero failure count; each restored and verified byte-identical by checksum.


---

## Round 5 — `c9c5cfeab0`

Nine ruled findings, plus one the round-5 matrix surfaced and one behaviour change I am flagging rather than burying.

- **E-R28 (HIGH)** — a parked refresh mutation spun forever. `query-client.ts` sets no `networkMode`, so mutations default to `"online"`; query-core dispatches `pending` with `isPaused: true` and **no timeout**. `isRefreshMutationPending` collapsed "in flight" with "parked", and both test files hardcoded the mutation mock to `isPending: false`, so nothing could catch it. The resolver now takes `isRefreshMutationPaused` and renders the parked case as the offline fact it is. The suffix is new copy: the existing "Models load when the connection is back." is false when the models are already on screen and only the refresh is parked.
- **E-R29 (MEDIUM)** — a pending mutation bypassed the three kinds the table sets to `"disabled"` on purpose. `IDLE_REFRESH_BY_KIND` is now consulted **first**, so a runtime that dies mid-mutation no longer shows a busy Refresh.
- **E-R30 (MEDIUM)** — one of the GET's structured codes had an arm; every other code and every unstructured failure claimed `"Proliferate Cloud didn't respond."` Now: `cloud_sandbox_not_found` (404, `access.py:37`) gets the workspace answer **plus** a Retry, because re-reading the sandbox can return a different id — unlike the never-had-one arm, which correctly has none. A new `serverAnswered` fact separates "the server answered non-2xx" from "nothing came back", because `ProliferateClientError` is only ever minted from a response. **E-R24 is now closed.**
- **E-R31 (MEDIUM)** — the `emptyBody` override was **half dead and half wrong**, and I deleted all of it rather than only the dead half. `!launchOptions` could never fire (every arm reachable without a payload already returns `emptyBody: null` — which is exactly why the four assertions guarding it could not fail). The live half, `readQuery.isError`, fires *only* when a payload exists, where it blanked "No models detected yet." underneath a header reading "0 models" — hiding a true line on the strength of a fact the header never mentions. **Behaviour change:** one reachable cell (local, `observed`, 0 models, failed background refetch) now prints that body where it previously printed nothing. Deleting the dead disjunct is what makes the four arm-level assertions falsifiable.
- **E-R32 (MEDIUM)** — ruled as "move the `isLoading` test below the `connectionState` switch". **I went further and deleted the field.** Moving it leaves provably inert code: v5 defines `isLoading = isPending && isFetching` and `isFetching = fetchStatus === "fetching"`, so under `healthy` it can only produce the `loading` arm the fetch-status switch already produces. All three hooks are plain `useQuery`, so the identity holds. Removing the proxy makes the hazard structurally impossible instead of merely reordered, and avoids shipping an inert branch one round after four inert assertions were found.
- **E-R33 (MEDIUM)** — Retry now restarts the local runtime via `restartHarnessRuntime` through `useProductHost().desktop?.runtime`, the pattern `use-support-snapshot-binding.ts` already uses. The false "This never self-corrects" comment is gone. New hook `use-local-runtime-restart.ts` exists because **FE-COMPONENT-1** forbids a component importing `lib/access/*` directly.
- **E-R34 (MEDIUM)** — local-on-web gets its own terminal arm keyed on the **host capability** (`desktop?.runtime`), per the ProductHost contract's own guidance to check a capability rather than `surface`. `useAgentSurfaceStore`'s default is untouched. *Follow-up for someone else:* that default (`"local"`) is arguably also wrong on web, but changing it reaches well beyond this pane.
- **E-R35 (LOW)** — the launch-options fact is now tested before the sandbox query's fetch status.
- **E-R36 (documented, not chased)** — `awaiting_first_read` advertises "Retry to check now." with `retry: "refetch_read"`, but the arm requires `connectionState === "healthy"` with `fetchStatus === "idle"` and no data, which in production means the query is **disabled** — and a v5 `refetch()` on a disabled query starts no fetch. **Unreachable today**; if `harnessKind` ever arrives empty it becomes reachable and the cure would not work.
- **E-R37 (new, NOT fixed — needs a ruling)** — the 848-cell matrix found one genuine dead end, in 48 cells: a `failed_without_observation` snapshot **copied to cloud** renders "Couldn't check models · Claude didn't answer the probe." with Refresh absent and `retry: null`. Cloud has no probe route, so there is no control to offer and no honest self-resolution to promise. Unchanged from round 4 and outside the nine, so I pinned it as the matrix's single documented exception rather than inventing product copy for it.

**Structure.** The resolver crossed FE-SIZE-1's 400-line threshold. Rather than add a ratchet entry, it splits on the axis the whole design turns on: `harness-models-absent-payload.ts` (219) holds the no-payload half, `harness-models-presentation.ts` (309) keeps the contract, the payload half, and the refresh decision. `lints/` and `scripts/` diffs are empty.

**Matrix — stated bound.** `harness-models-presentation.matrix.test.ts` derives **848 cells** from the axes and asserts its own bound in its first test: 576 payload (2 surfaces × 6 wire states × 4 probe phases × 2 model counts × 2 freshness values × 3 mutation states), 144 local no-payload (2 host capabilities × 3 connection states × 8 query-fact shapes × 3 mutation states), 128 cloud no-payload (8 × 2 × 8). It does **not** cross the local and cloud axes against each other, and does not vary `displayName`. Five invariants hold across all 848: nothing spins unless something is genuinely in flight and a spin implies a poll (127 spinning cells, 0 violations); no dead ends (1 pinned exception, E-R37); cloud never renders a Refresh; no cell claims silence from a server that answered; a parked mutation is never busy. A one-shot comparison against the round-4 resolver found **384/384 payload cells byte-identical** over the cells round 5 did not rule a change on, with the 96 ruled changes (parked mutation, local surface only) enumerated rather than hidden.
