### PR TITLE
feat(home): truthful model gate, selection-required, and blocked states

### DIFF
--- a/anyharness/sdk-react/src/hooks/agents-launch-options.test.tsx
+++ b/anyharness/sdk-react/src/hooks/agents-launch-options.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import type { HarnessLaunchOptionsResponse } from "@anyharness/sdk";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, onlineManager } from "@tanstack/react-query";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -140,6 +140,27 @@ describe("launch-option convergence", () => {
       resolveAgentLaunchOptionsRefetchInterval({ data: response({ state: "refreshing" }) }),
     ).toBe(AGENT_LAUNCH_OPTIONS_PROBE_INTERVAL_MS);
     expect(resolveAgentLaunchOptionsRefetchInterval({})).toBe(false);
+  });
+
+  it("probes the local runtime even when the browser reports offline", async () => {
+    // The probe targets localhost. Under react-query's default "online" mode
+    // an offline browser parks the mutation WITHOUT invoking `mutationFn`, so
+    // `mutateAsync` never settles and every caller awaiting it hangs — on a
+    // machine where the refresh would have worked.
+    mocks.getLaunchOptions.mockResolvedValue(response({ revision: 1, state: "observed" }));
+    mocks.refreshLaunchOptions.mockResolvedValue(response({ revision: 2, state: "observed" }));
+    onlineManager.setOnline(false);
+    try {
+      const { result } = renderHook(() => useRefreshHarnessLaunchOptionsMutation(), {
+        wrapper: wrapper(),
+      });
+      await act(async () => {
+        await result.current.mutateAsync("claude");
+      });
+      expect(mocks.refreshLaunchOptions).toHaveBeenCalledWith("claude");
+    } finally {
+      onlineManager.setOnline(true);
+    }
   });
 
   it("rereads the harness after a failed refresh", async () => {

--- a/anyharness/sdk-react/src/hooks/agents.ts
+++ b/anyharness/sdk-react/src/hooks/agents.ts
@@ -199,6 +199,12 @@ export function useRefreshHarnessLaunchOptionsMutation() {
   const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
   const cacheScopeKey = resolveRuntimeCacheScopeKey(runtime);
   return useMutation({
+    // The probe targets the LOCAL runtime, so react-query's default "online"
+    // gate is simply wrong for it: offline, the mutation is parked without
+    // ever invoking `mutationFn`, so `mutateAsync` never settles and any
+    // caller awaiting it waits forever — on a machine where the refresh would
+    // have succeeded.
+    networkMode: "always",
     mutationFn: async (harnessKind: string) => {
       const client = getAnyHarnessClient(resolveRuntimeConnection(runtime));
       return client.agents.refreshLaunchOptions(harnessKind);

--- a/apps/packages/product-client/src/components/home/screen/HomeComposerCommandEditor.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeComposerCommandEditor.tsx
@@ -29,6 +29,8 @@ interface HomeComposerCommandEditorProps {
   onKeyDown: (event: ChatComposerKeyboardEvent) => void;
   canSubmit: boolean;
   onSubmit: () => void;
+  /** Enter pressed while sending is refused (no model chosen yet). */
+  onSubmitRefused: () => void;
   placeholder: string;
   /** Raw per-harness catalog; the policy filter is applied by the menu hook. */
   availableCommands: readonly AvailableSessionCommand[];
@@ -49,6 +51,7 @@ export function HomeComposerCommandEditor({
   onKeyDown,
   canSubmit,
   onSubmit,
+  onSubmitRefused,
   placeholder,
   availableCommands,
   overlayHostElement,
@@ -174,6 +177,7 @@ export function HomeComposerCommandEditor({
         activeDescendantId={slashTrigger ? search.activeDescendantId : undefined}
         canSubmit={canSubmit}
         onSubmit={onSubmit}
+        onSubmitRefused={onSubmitRefused}
         editorRef={(editor) => { editorRef.current = editor; }}
         placeholder={placeholder}
         disabled={false}

--- a/apps/packages/product-client/src/components/home/screen/HomeComposerForm.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeComposerForm.tsx
@@ -19,10 +19,10 @@ import {
 } from "#product/lib/infra/measurement/measurement-port";
 import { recordTypingKeystrokeLatency } from "#product/lib/infra/measurement/measurement-port";
 import type { MeasurementOperationId } from "#product/lib/domain/telemetry/debug-measurement-catalog";
+import type { HomeModelGate } from "#product/lib/domain/home/home-model-gate";
 import type {
   HomeLaunchTarget,
   HomeNextModelSelection,
-  ModelAvailabilityState,
 } from "#product/lib/domain/home/home-next-launch";
 import type { ChatComposerEditorSnapshot } from "#product/lib/domain/chat/composer/file-mention-draft-model";
 
@@ -57,7 +57,7 @@ const HOME_TYPING_SURFACES = [
 interface HomeComposerFormProps {
   // --- launch readiness (inputs to the composer state hook) ---
   targetDisabledReason: string | null;
-  modelAvailabilityState: ModelAvailabilityState;
+  modelGate: HomeModelGate;
   canLaunchTarget: boolean;
   modelSelection: HomeNextModelSelection | null;
   launchControlValues: Record<string, string>;
@@ -81,7 +81,7 @@ interface HomeComposerFormProps {
 
 export function HomeComposerForm({
   targetDisabledReason,
-  modelAvailabilityState,
+  modelGate,
   canLaunchTarget,
   modelSelection,
   launchControlValues,
@@ -95,7 +95,7 @@ export function HomeComposerForm({
 }: HomeComposerFormProps) {
   const composer = useHomeNextComposerState({
     targetDisabledReason,
-    modelAvailabilityState,
+    modelGate,
     canLaunchTarget,
     modelSelection,
     launchControlValues,
@@ -212,6 +212,7 @@ export function HomeComposerForm({
                   onKeyDown={composer.handleKeyDown}
                   canSubmit={composer.canSubmit}
                   onSubmit={() => { void composer.submit(); }}
+                  onSubmitRefused={composer.refuseSubmit}
                   placeholder={CHAT_COMPOSER_LABELS.placeholder}
                   availableCommands={availableCommands}
                   overlayHostElement={composerOverlayHost}
@@ -230,6 +231,7 @@ export function HomeComposerForm({
                     isRunning={false}
                     isEmpty={composer.isEmpty}
                     isDisabled={!composer.canSubmit}
+                    disabledReason={composer.sendBlockedReason}
                     onSubmit={() => { void composer.submit(); }}
                     onCancel={composer.cancel}
                   />
@@ -239,6 +241,19 @@ export function HomeComposerForm({
           </ChatComposerSurface>
         </div>
       </DebugProfiler>
+
+      {/* selection_required has no visible notice (owner revision r2), so this
+          region is the ONLY thing that reports a refused Enter. It is mounted
+          unconditionally: a live region created at the same moment its text
+          appears is not reliably announced. */}
+      <div
+        className="sr-only"
+        role="status"
+        aria-live="polite"
+        data-home-model-gate-announcement
+      >
+        {composer.refusalAnnouncement}
+      </div>
 
       {modelAvailabilityNoticeSlot}
 

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.model-gate.test.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.model-gate.test.tsx
@@ -500,15 +500,19 @@ describe("HomeNextScreen model gate", () => {
     expect(screen.queryByText("Couldn't refresh your models.")).toBeNull();
   });
 
-  it("offers nothing to press when no agent can ever run here", () => {
-    // The only terminal gate: a Refresh would re-read an identical built-in
-    // registry forever, so a button would be the dead end, not the cure.
+  it("navigates rather than probing when no agent can ever run here", () => {
+    // The only gate with no cure. A Refresh would re-read an identical
+    // built-in registry forever, so the action is navigation to the pane that
+    // shows WHICH agents are unsupported — never repair vocabulary, and never
+    // a probe.
     screenMocks.homeNext.modelGate = { kind: "blocked", reason: "agents_unsupported" };
     render(<HomeNextScreen />);
     expect(screen.getByText("No agents are supported on this machine.")).toBeTruthy();
-    for (const name of ["Refresh", "Retry", "Check again", "Agents"]) {
+    for (const name of ["Refresh", "Retry", "Check again"]) {
       expect(screen.queryByRole("button", { name })).toBeNull();
     }
+    fireEvent.click(screen.getByRole("button", { name: "See agents" }));
+    expect(screenMocks.handleHomeAction).toHaveBeenCalledWith("agent-settings");
     expect(screenMocks.retryModelObservation).not.toHaveBeenCalled();
   });
 });

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.model-gate.test.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.model-gate.test.tsx
@@ -341,7 +341,7 @@ describe("HomeNextScreen model gate", () => {
     expect(cure.disabled).toBe(false);
     fireEvent.click(cure);
     expect(screenMocks.retryModelObservation).toHaveBeenCalled();
-    expect(screenMocks.handleHomeAction).not.toHaveBeenCalledWith("agent-settings");
+    expect(screenMocks.handleHomeAction).not.toHaveBeenCalledWith("agent-settings", expect.anything());
   });
 
   it("labels the disabled Send with the reason while a model is unchosen", () => {
@@ -524,15 +524,28 @@ describe("HomeNextScreen model gate", () => {
     expect(screenMocks.retryModelObservation).not.toHaveBeenCalled();
   });
 
-  it("keeps the notice action inert while its own probe is still running", () => {
-    // Pressing again mid-flight starts an overlapping batch, and two batches
-    // settling out of order report the wrong outcome for the wrong press.
+  it("never hands the unsupported harness to the setup notice", () => {
+    // Both gates share the `agent_settings` action but mean different agents:
+    // one Cursor that can never run, one Claude that needs a login. Routing
+    // setup to the unsupported pane opens something that cannot be set up.
+    screenMocks.homeNext.modelGate = { kind: "blocked", reason: "agent_setup_required" };
+    screenMocks.homeNext.unsupportedHarnessKind = null;
+    render(<HomeNextScreen />);
+    fireEvent.click(screen.getByRole("button", { name: "Agents" }));
+    expect(screenMocks.handleHomeAction)
+      .toHaveBeenCalledWith("agent-settings", { harnessKind: null });
+  });
+
+  it("keeps the notice action pressable while its own probe is running", () => {
+    // A refresh has no guaranteed exit, so disabling the control here removes
+    // the only affordance the state has and the user is stranded. Overlap is
+    // refused inside the hook instead, which cannot strand anyone.
     screenMocks.homeNext.modelGate = { kind: "blocked", reason: "observation_idle" };
     screenMocks.homeNext.retryPending = true;
     render(<HomeNextScreen />);
     const action = screen.getByRole("button", { name: "Refresh" });
-    expect(action.hasAttribute("disabled")).toBe(true);
+    expect(action.hasAttribute("disabled")).toBe(false);
     fireEvent.click(action);
-    expect(screenMocks.retryModelObservation).not.toHaveBeenCalled();
+    expect(screenMocks.retryModelObservation).toHaveBeenCalled();
   });
 });

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.model-gate.test.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.model-gate.test.tsx
@@ -46,6 +46,7 @@ const screenMocks = vi.hoisted(() => {
     hasKnownAgents: true,
     retryModelObservation: () => {},
     retryRejected: false,
+    retryPending: false,
     canLaunchTarget: true,
     effectiveModelSelection: { kind: "codex", modelId: "gpt-5.4" },
     launchTarget: { kind: "cowork" },
@@ -254,6 +255,7 @@ function resetHomeNext() {
   screenMocks.homeNext.hasKnownAgents = true;
   screenMocks.homeNext.retryModelObservation = screenMocks.retryModelObservation;
   screenMocks.homeNext.retryRejected = false;
+  screenMocks.homeNext.retryPending = false;
   screenMocks.homeNext.canLaunchTarget = true;
   screenMocks.homeNext.effectiveModelSelection = { kind: "codex", modelId: "gpt-5.4" };
   screenMocks.homeNext.launchTarget = { kind: "cowork" };
@@ -297,6 +299,9 @@ describe("HomeNextScreen model gate", () => {
     expect(screen.queryByText(/Couldn't check your models/i)).toBeNull();
     expect(screen.queryByText(/Models couldn't be loaded/i)).toBeNull();
     expect(screen.queryByText(/hasn't reported launch options/i)).toBeNull();
+    expect(screen.queryByText(/Models haven't been detected/i)).toBeNull();
+    expect(screen.queryByText(/Couldn't refresh your models/i)).toBeNull();
+    expect(screen.queryByText(/No agents are supported/i)).toBeNull();
   });
 
   it("renders setup guidance only for agent_setup_required", () => {
@@ -472,5 +477,38 @@ describe("HomeNextScreen model gate", () => {
     render(<HomeNextScreen />);
     expect(screen.getByText("Finish agent setup to start a chat.")).toBeTruthy();
     expect(screen.queryByText("Couldn't refresh your models.")).toBeNull();
+  });
+
+  it("keeps the sentence that says a probe RAN and failed", () => {
+    // "Couldn't check your models." carries strictly more than a refusal does.
+    screenMocks.homeNext.modelGate = { kind: "blocked", reason: "observation_failed" };
+    screenMocks.homeNext.retryRejected = true;
+    render(<HomeNextScreen />);
+    expect(screen.getByText("Couldn't check your models.")).toBeTruthy();
+    expect(screen.queryByText("Couldn't refresh your models.")).toBeNull();
+  });
+
+  it("says a refresh is running rather than that nothing was detected", () => {
+    // Serialized probes, up to 45s per kind, and no polling of a settled row:
+    // the terminal sentence would otherwise sit over live work.
+    screenMocks.homeNext.modelGate = { kind: "blocked", reason: "observation_idle" };
+    screenMocks.homeNext.retryPending = true;
+    screenMocks.homeNext.retryRejected = true;
+    render(<HomeNextScreen />);
+    expect(screen.getByText("Refreshing your models…")).toBeTruthy();
+    expect(screen.queryByText("Models haven't been detected yet.")).toBeNull();
+    expect(screen.queryByText("Couldn't refresh your models.")).toBeNull();
+  });
+
+  it("offers nothing to press when no agent can ever run here", () => {
+    // The only terminal gate: a Refresh would re-read an identical built-in
+    // registry forever, so a button would be the dead end, not the cure.
+    screenMocks.homeNext.modelGate = { kind: "blocked", reason: "agents_unsupported" };
+    render(<HomeNextScreen />);
+    expect(screen.getByText("No agents are supported on this machine.")).toBeTruthy();
+    for (const name of ["Refresh", "Retry", "Check again", "Agents"]) {
+      expect(screen.queryByRole("button", { name })).toBeNull();
+    }
+    expect(screenMocks.retryModelObservation).not.toHaveBeenCalled();
   });
 });

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.model-gate.test.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.model-gate.test.tsx
@@ -45,6 +45,7 @@ const screenMocks = vi.hoisted(() => {
     isCatalogLoading: false,
     hasKnownAgents: true,
     retryModelObservation: () => {},
+    retryRejected: false,
     canLaunchTarget: true,
     effectiveModelSelection: { kind: "codex", modelId: "gpt-5.4" },
     launchTarget: { kind: "cowork" },
@@ -252,6 +253,7 @@ function resetHomeNext() {
   screenMocks.homeNext.isCatalogLoading = false;
   screenMocks.homeNext.hasKnownAgents = true;
   screenMocks.homeNext.retryModelObservation = screenMocks.retryModelObservation;
+  screenMocks.homeNext.retryRejected = false;
   screenMocks.homeNext.canLaunchTarget = true;
   screenMocks.homeNext.effectiveModelSelection = { kind: "codex", modelId: "gpt-5.4" };
   screenMocks.homeNext.launchTarget = { kind: "cowork" };
@@ -303,7 +305,9 @@ describe("HomeNextScreen model gate", () => {
     expect(screen.getByText("Finish agent setup to start a chat.")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Agents" }));
     expect(screenMocks.handleHomeAction).toHaveBeenCalledWith("agent-settings");
-    expect(screen.queryByText(/configured/i)).toBeNull();
+    // A string the notice slot CAN emit, so the exclusivity has teeth: an
+    // earlier `/configured/i` here matched nothing Home is able to render.
+    expect(screen.queryByText(/Models haven't been detected/i)).toBeNull();
     // Ruling 2, at the seam Home actually builds: the notice is on screen, so
     // the picker it is paired with cannot be an enabled "Select model".
     expect(screenMocks.leadingControlsProps.modelSelectorProps.availability)
@@ -431,16 +435,42 @@ describe("HomeNextScreen model gate", () => {
     expect(screenMocks.launch).not.toHaveBeenCalled();
   });
 
-  it("renders observation_idle with an honest sentence and a Refresh that probes", () => {
+  it("renders observation_idle with an honest sentence and an enabled Refresh", () => {
     screenMocks.homeNext.modelGate = { kind: "blocked", reason: "observation_idle" };
     render(<HomeNextScreen />);
     expect(screen.getByText("Models haven't been detected yet.")).toBeTruthy();
-    // Never "Probing…": nothing is probing, which is the whole problem.
-    expect(screen.queryByText(/Probing/i)).toBeNull();
+    // The state must not be dressed as in-flight. Asserted on the prop the
+    // trigger actually reads: no Home path emits the string "Probing", so a
+    // `queryByText(/Probing/i)` here could never have failed.
+    expect(screenMocks.leadingControlsProps.modelSelectorProps.availability)
+      .not.toBe("observation_pending");
     expect(screen.queryByText(/Finish agent setup/i)).toBeNull();
     const cure = screen.getByRole("button", { name: "Refresh" }) as HTMLButtonElement;
     expect(cure.disabled).toBe(false);
     fireEvent.click(cure);
+    // That this dispatches a real probe rather than a re-read is asserted in
+    // use-home-next-model-selection.test.tsx; here it is the wiring.
     expect(screenMocks.retryModelObservation).toHaveBeenCalled();
+  });
+
+  it("says the refresh was refused rather than re-rendering the same sentence", () => {
+    // A rejected probe writes no durable state, so the gate cannot move: the
+    // button would otherwise appear to do nothing, forever.
+    screenMocks.homeNext.modelGate = { kind: "blocked", reason: "observation_idle" };
+    screenMocks.homeNext.retryRejected = true;
+    render(<HomeNextScreen />);
+    expect(screen.getByText("Couldn't refresh your models.")).toBeTruthy();
+    expect(screen.queryByText("Models haven't been detected yet.")).toBeNull();
+    // Still curable: the action survives the rejection.
+    expect((screen.getByRole("button", { name: "Refresh" }) as HTMLButtonElement).disabled)
+      .toBe(false);
+  });
+
+  it("does not blame a refused refresh for a notice that never fires a probe", () => {
+    screenMocks.homeNext.modelGate = { kind: "blocked", reason: "agent_setup_required" };
+    screenMocks.homeNext.retryRejected = true;
+    render(<HomeNextScreen />);
+    expect(screen.getByText("Finish agent setup to start a chat.")).toBeTruthy();
+    expect(screen.queryByText("Couldn't refresh your models.")).toBeNull();
   });
 });

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.model-gate.test.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.model-gate.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HomeNextScreen } from "#product/components/home/screen/HomeNextScreen";
 import { installLocalStorageMock } from "#product/components/home/screen/HomeNextScreen.test-support";
+import { resolveModelSelectorEnabled } from "#product/lib/domain/chat/models/model-selector-types";
 
 /**
  * Home's model gate at the screen seam: which notice each gate renders, which
@@ -143,10 +144,21 @@ vi.mock("#product/components/workspace/chat/input/ChatInputControlRow", () => ({
     // Stands in for ComposerModelSelectorControl's trigger. The real control's
     // ownership of this attribute is pinned in
     // ComposerModelSelectorControl.test.tsx; here it is the focus destination
-    // a refused Enter must land on.
+    // a refused Enter must land on — and it honours the SAME enablement rule
+    // the real control does, because an always-enabled stand-in would hide
+    // exactly the bug where a refusal focuses a control the user cannot use.
+    const enabled = resolveModelSelectorEnabled({
+      disabled: false,
+      connectionState: props.modelSelectorProps?.connectionState ?? "healthy",
+      isLoading: props.modelSelectorProps?.isLoading ?? false,
+      hasAgents: props.modelSelectorProps?.hasAgents ?? true,
+      availability: props.modelSelectorProps?.availability ?? "ready",
+    });
     return (
       <div data-testid="composer-leading-controls">
-        <button type="button" data-composer-model-trigger>Select model</button>
+        <button type="button" data-composer-model-trigger disabled={!enabled}>
+          Select model
+        </button>
       </div>
     );
   },
@@ -358,5 +370,77 @@ describe("HomeNextScreen model gate", () => {
     expect(second.trim()).toBe("Choose a model before sending");
     expect(/\d/.test(second)).toBe(false);
     expect(prompt.value).toBe("Add retry logic to the sync worker");
+  });
+
+  it("clears the refusal sentence once a model can be launched", () => {
+    screenMocks.homeNext.modelGate = { kind: "selection_required" };
+    const view = render(<HomeNextScreen />);
+    const prompt = screen.getByLabelText("Prompt") as HTMLTextAreaElement;
+    fireEvent.change(prompt, { target: { value: "ship it" } });
+    fireEvent.keyDown(prompt, { key: "Enter" });
+
+    const region = document.querySelector("[data-home-model-gate-announcement]") as HTMLElement;
+    expect((region.textContent ?? "").trim()).toBe("Choose a model before sending");
+
+    // A sentence that stays in the accessibility tree after the reason is gone
+    // is read out on every subsequent visit to the region.
+    screenMocks.homeNext.modelGate = { kind: "launchable" };
+    view.rerender(<HomeNextScreen />);
+    expect(document.querySelector("[data-home-model-gate-announcement]")?.textContent).toBe("");
+  });
+
+  it("does not refuse an EMPTY composer out of the editor", () => {
+    // Home autofocuses the composer, so Enter before typing is a real first
+    // keystroke. It did nothing before this slice and must keep doing nothing:
+    // parking the caret on a button turns the next keypress into a menu.
+    screenMocks.homeNext.modelGate = { kind: "selection_required" };
+    render(<HomeNextScreen />);
+    const prompt = screen.getByLabelText("Prompt") as HTMLTextAreaElement;
+    prompt.focus();
+    fireEvent.keyDown(prompt, { key: "Enter" });
+
+    expect(document.activeElement).toBe(prompt);
+    expect(document.querySelector("[data-home-model-gate-announcement]")?.textContent).toBe("");
+    // The Send button is disabled because it is EMPTY, so it must not claim
+    // the unchosen model is the reason — this string is its accessible name.
+    expect(screen.queryByRole("button", { name: "Choose a model" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Submit" })).toBeTruthy();
+  });
+
+  it("does not announce an unchoosable model or focus a disabled trigger", () => {
+    // agent_setup_required has no model to choose and a DISABLED trigger, so
+    // "Choose a model before sending" would be false and `focus()` a no-op.
+    // The state's own notice is already on screen and says the true thing.
+    screenMocks.homeNext.modelGate = { kind: "blocked", reason: "agent_setup_required" };
+    screenMocks.homeNext.hasKnownAgents = true;
+    render(<HomeNextScreen />);
+    const prompt = screen.getByLabelText("Prompt") as HTMLTextAreaElement;
+    fireEvent.change(prompt, { target: { value: "ship it" } });
+    prompt.focus();
+
+    const trigger = document.querySelector(
+      "[data-composer-model-trigger]",
+    ) as HTMLButtonElement;
+    expect(trigger.disabled).toBe(true);
+
+    fireEvent.keyDown(prompt, { key: "Enter" });
+
+    expect(document.activeElement).toBe(prompt);
+    expect(document.querySelector("[data-home-model-gate-announcement]")?.textContent).toBe("");
+    expect(screen.getByText("Finish agent setup to start a chat.")).toBeTruthy();
+    expect(screenMocks.launch).not.toHaveBeenCalled();
+  });
+
+  it("renders observation_idle with an honest sentence and a Refresh that probes", () => {
+    screenMocks.homeNext.modelGate = { kind: "blocked", reason: "observation_idle" };
+    render(<HomeNextScreen />);
+    expect(screen.getByText("Models haven't been detected yet.")).toBeTruthy();
+    // Never "Probing…": nothing is probing, which is the whole problem.
+    expect(screen.queryByText(/Probing/i)).toBeNull();
+    expect(screen.queryByText(/Finish agent setup/i)).toBeNull();
+    const cure = screen.getByRole("button", { name: "Refresh" }) as HTMLButtonElement;
+    expect(cure.disabled).toBe(false);
+    fireEvent.click(cure);
+    expect(screenMocks.retryModelObservation).toHaveBeenCalled();
   });
 });

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.model-gate.test.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.model-gate.test.tsx
@@ -47,6 +47,7 @@ const screenMocks = vi.hoisted(() => {
     retryModelObservation: () => {},
     retryRejected: false,
     retryPending: false,
+    unsupportedHarnessKind: null,
     canLaunchTarget: true,
     effectiveModelSelection: { kind: "codex", modelId: "gpt-5.4" },
     launchTarget: { kind: "cowork" },
@@ -256,6 +257,7 @@ function resetHomeNext() {
   screenMocks.homeNext.retryModelObservation = screenMocks.retryModelObservation;
   screenMocks.homeNext.retryRejected = false;
   screenMocks.homeNext.retryPending = false;
+  screenMocks.homeNext.unsupportedHarnessKind = null;
   screenMocks.homeNext.canLaunchTarget = true;
   screenMocks.homeNext.effectiveModelSelection = { kind: "codex", modelId: "gpt-5.4" };
   screenMocks.homeNext.launchTarget = { kind: "cowork" };
@@ -309,7 +311,8 @@ describe("HomeNextScreen model gate", () => {
     render(<HomeNextScreen />);
     expect(screen.getByText("Finish agent setup to start a chat.")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Agents" }));
-    expect(screenMocks.handleHomeAction).toHaveBeenCalledWith("agent-settings");
+    expect(screenMocks.handleHomeAction)
+      .toHaveBeenCalledWith("agent-settings", { harnessKind: null });
     // A string the notice slot CAN emit, so the exclusivity has teeth: an
     // earlier `/configured/i` here matched nothing Home is able to render.
     expect(screen.queryByText(/Models haven't been detected/i)).toBeNull();
@@ -506,13 +509,30 @@ describe("HomeNextScreen model gate", () => {
     // shows WHICH agents are unsupported — never repair vocabulary, and never
     // a probe.
     screenMocks.homeNext.modelGate = { kind: "blocked", reason: "agents_unsupported" };
+    screenMocks.homeNext.unsupportedHarnessKind = "cursor";
     render(<HomeNextScreen />);
     expect(screen.getByText("No agents are supported on this machine.")).toBeTruthy();
     for (const name of ["Refresh", "Retry", "Check again"]) {
       expect(screen.queryByRole("button", { name })).toBeNull();
     }
     fireEvent.click(screen.getByRole("button", { name: "See agents" }));
-    expect(screenMocks.handleHomeAction).toHaveBeenCalledWith("agent-settings");
+    // Routed to the harness that IS unsupported. Sending every caller to the
+    // Claude pane made the ruling false whenever Claude was not the
+    // unsupported one: that pane just says it has not reported.
+    expect(screenMocks.handleHomeAction)
+      .toHaveBeenCalledWith("agent-settings", { harnessKind: "cursor" });
+    expect(screenMocks.retryModelObservation).not.toHaveBeenCalled();
+  });
+
+  it("keeps the notice action inert while its own probe is still running", () => {
+    // Pressing again mid-flight starts an overlapping batch, and two batches
+    // settling out of order report the wrong outcome for the wrong press.
+    screenMocks.homeNext.modelGate = { kind: "blocked", reason: "observation_idle" };
+    screenMocks.homeNext.retryPending = true;
+    render(<HomeNextScreen />);
+    const action = screen.getByRole("button", { name: "Refresh" });
+    expect(action.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(action);
     expect(screenMocks.retryModelObservation).not.toHaveBeenCalled();
   });
 });

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.model-gate.test.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.model-gate.test.tsx
@@ -1,0 +1,362 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HomeNextScreen } from "#product/components/home/screen/HomeNextScreen";
+import { installLocalStorageMock } from "#product/components/home/screen/HomeNextScreen.test-support";
+
+/**
+ * Home's model gate at the screen seam: which notice each gate renders, which
+ * of them may say "Finish agent setup", and what a refused Enter does. Split
+ * from HomeNextScreen.test.tsx, which owns the composer/target/attachment
+ * batteries.
+ */
+
+const screenMocks = vi.hoisted(() => {
+  const handleHomeAction = vi.fn();
+  const launch = vi.fn();
+  const clearDraftText = vi.fn();
+  const retryModelObservation = vi.fn();
+  const navigate = vi.fn();
+  const onboardingCards: any[] = [];
+  const homeNext = {
+    selectedRepository: null,
+    repositories: [],
+    selectedBranchName: null,
+    branchOptions: [],
+    branchQuery: {
+      isLoading: false,
+      isError: false,
+    },
+    sshTargetOptions: [],
+    sshTargetsLoading: false,
+    cloudRepoActionBySourceRoot: {},
+    cloudRepoTarget: null,
+    cloudRepoAction: { kind: "create" },
+    modelGroups: [],
+    selectedModel: null,
+    modeOptions: [],
+    effectiveMode: null,
+    effectiveModeId: null,
+    targetDisabledReason: null,
+    modelGate: { kind: "launchable" },
+    isCatalogLoading: false,
+    hasKnownAgents: true,
+    retryModelObservation: () => {},
+    canLaunchTarget: true,
+    effectiveModelSelection: { kind: "codex", modelId: "gpt-5.4" },
+    launchTarget: { kind: "cowork" },
+  } as any;
+
+  return {
+    handleHomeAction,
+    launch,
+    clearDraftText,
+    retryModelObservation,
+    navigate,
+    onboardingCards,
+    homeNext,
+    homeNextStateArgs: null as any,
+    targetPickerProps: null as any,
+    leadingControlsProps: null as any,
+    trailingControlsProps: null as any,
+    productHost: { desktop: {} as object | null },
+  };
+});
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => screenMocks.navigate,
+}));
+
+vi.mock("@proliferate/product-client/host/ProductHostProvider", () => ({
+  useProductHost: () => screenMocks.productHost,
+}));
+
+vi.mock("#product/hooks/home/derived/use-home-next-state", () => ({
+  useHomeNextState: (args: any) => {
+    screenMocks.homeNextStateArgs = args;
+    return screenMocks.homeNext;
+  },
+}));
+
+vi.mock("#product/hooks/home/derived/use-home-next-launch-controls", () => ({
+  useHomeNextLaunchControls: () => ({
+    controls: [],
+    launchControlValues: {},
+  }),
+}));
+
+vi.mock("#product/hooks/home/workflows/use-home-next-launch", () => ({
+  useHomeNextLaunch: () => ({
+    isLaunching: false,
+    launch: screenMocks.launch,
+  }),
+}));
+
+vi.mock("#product/hooks/home/facade/use-home-screen", () => ({
+  useHomeScreen: () => ({
+    onboardingCards: screenMocks.onboardingCards,
+    isAddingRepo: false,
+    handleHomeAction: screenMocks.handleHomeAction,
+  }),
+}));
+
+vi.mock("#product/stores/home/home-draft-handoff-store", () => ({
+  useHomeDraftHandoffStore: (selector: (state: {
+    draftText: string | null;
+    clearDraftText: () => void;
+  }) => unknown) => selector({
+    draftText: null,
+    clearDraftText: screenMocks.clearDraftText,
+  }),
+}));
+
+vi.mock("#product/components/home/screen/HomeTargetPicker", () => ({
+  HomeTargetPicker: (props: any) => {
+    screenMocks.targetPickerProps = props;
+    return (
+      <div data-testid="target-picker">
+        {props.desktopTargetsAvailable ? (
+          <>
+            <button type="button" onClick={() => props.onSelectCowork()}>Mock cowork</button>
+            <button type="button" onClick={() => props.onSelectRuntime("local")}>Mock local</button>
+            <button type="button" onClick={() => props.onSelectRuntime("ssh", "ssh-target-1")}>
+              Mock ssh
+            </button>
+          </>
+        ) : null}
+        <button type="button" onClick={() => props.onSelectRepository("/repo-b")}>
+          Mock repo
+        </button>
+        <button type="button" onClick={() => props.onSelectBranch("feature/sticky")}>
+          Mock branch
+        </button>
+      </div>
+    );
+  },
+}));
+
+vi.mock("#product/components/workspace/chat/input/ChatInputControlRow", () => ({
+  ComposerLeadingControls: (props: any) => {
+    screenMocks.leadingControlsProps = props;
+    // Stands in for ComposerModelSelectorControl's trigger. The real control's
+    // ownership of this attribute is pinned in
+    // ComposerModelSelectorControl.test.tsx; here it is the focus destination
+    // a refused Enter must land on.
+    return (
+      <div data-testid="composer-leading-controls">
+        <button type="button" data-composer-model-trigger>Select model</button>
+      </div>
+    );
+  },
+  ComposerTrailingControls: (props: any) => {
+    screenMocks.trailingControlsProps = props;
+    return <div data-testid="composer-trailing-controls" />;
+  },
+}));
+
+vi.mock("#product/components/workspace/chat/composer/ChatComposerSurface", () => ({
+  ChatComposerSurface: ({ children }: { children: ReactNode }) => (
+    <div data-testid="composer-surface">{children}</div>
+  ),
+}));
+
+vi.mock("#product/components/workspace/chat/content/PromptContentRenderer", () => ({
+  DraftAttachmentPreviewList: ({ attachments, onRemove }: any) => (
+    <div data-testid="draft-attachment-list">
+      {attachments.map((attachment: any) => (
+        <button
+          key={attachment.id}
+          type="button"
+          onClick={() => onRemove(attachment.id)}
+        >
+          {`attachment:${attachment.name}`}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("#product/components/workspace/chat/input/ComposerRichTextEditor", () => ({
+  ComposerRichTextEditor: ({
+    value,
+    snapshot,
+    onChange,
+    onKeyDown,
+    canSubmit,
+    onSubmit,
+    onSubmitRefused,
+    disabled,
+  }: any) => (
+    <textarea
+      aria-label="Prompt"
+      data-editor-snapshot={snapshot?.payload}
+      value={value}
+      onChange={(event) => onChange(event.target.value, event.timeStamp, { version: 1, payload: "home-editor-snapshot" })}
+      onKeyDown={(event) => {
+        // Mirrors ComposerBehaviorPlugin: plain Enter is always swallowed, and
+        // it either submits or reports the refusal.
+        if (event.key === "Enter" && !event.shiftKey) {
+          event.preventDefault();
+          if (canSubmit) onSubmit?.();
+          else onSubmitRefused?.();
+          return;
+        }
+        onKeyDown?.(event);
+      }}
+      disabled={disabled}
+    />
+  ),
+}));
+
+vi.mock("#product/components/workspace/chat/input/ChatComposerActions", () => ({
+  ChatComposerActions: ({
+    isDisabled,
+    disabledReason,
+    onSubmit,
+  }: {
+    isDisabled: boolean;
+    disabledReason?: string | null;
+    onSubmit: () => void;
+  }) => (
+    <button
+      type="button"
+      disabled={isDisabled}
+      title={disabledReason ?? undefined}
+      aria-label={disabledReason ?? undefined}
+      onClick={onSubmit}
+      data-chat-send-button
+    >
+      Submit
+    </button>
+  ),
+}));
+
+function resetHomeNext() {
+  screenMocks.productHost.desktop = {};
+  screenMocks.homeNext.targetDisabledReason = null;
+  screenMocks.homeNext.modelGate = { kind: "launchable" };
+  screenMocks.homeNext.isCatalogLoading = false;
+  screenMocks.homeNext.hasKnownAgents = true;
+  screenMocks.homeNext.retryModelObservation = screenMocks.retryModelObservation;
+  screenMocks.homeNext.canLaunchTarget = true;
+  screenMocks.homeNext.effectiveModelSelection = { kind: "codex", modelId: "gpt-5.4" };
+  screenMocks.homeNext.launchTarget = { kind: "cowork" };
+  screenMocks.onboardingCards.splice(0);
+  screenMocks.homeNext.sshTargetOptions = [];
+  screenMocks.homeNext.sshTargetsLoading = false;
+  screenMocks.homeNextStateArgs = null;
+  screenMocks.targetPickerProps = null;
+  screenMocks.leadingControlsProps = null;
+  screenMocks.trailingControlsProps = null;
+}
+
+
+describe("HomeNextScreen model gate", () => {
+  beforeEach(() => {
+    installLocalStorageMock();
+    resetHomeNext();
+    window.localStorage.clear();
+    screenMocks.handleHomeAction.mockClear();
+    screenMocks.retryModelObservation.mockClear();
+    screenMocks.launch.mockClear();
+    screenMocks.launch.mockResolvedValue("launched");
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it.each([
+    [{ kind: "launchable" }],
+    [{ kind: "selection_required" }],
+    [{ kind: "blocked", reason: "target_missing" }],
+    [{ kind: "blocked", reason: "querying" }],
+    [{ kind: "blocked", reason: "observation_pending" }],
+    [{ kind: "blocked", reason: "observed_empty" }],
+  ] as const)("renders no notice for %j", (modelGate) => {
+    screenMocks.homeNext.modelGate = modelGate;
+    render(<HomeNextScreen />);
+
+    expect(screen.queryByText(/Finish agent setup/i)).toBeNull();
+    expect(screen.queryByText(/Couldn't check your models/i)).toBeNull();
+    expect(screen.queryByText(/Models couldn't be loaded/i)).toBeNull();
+    expect(screen.queryByText(/hasn't reported launch options/i)).toBeNull();
+  });
+
+  it("renders setup guidance only for agent_setup_required", () => {
+    screenMocks.homeNext.modelGate = { kind: "blocked", reason: "agent_setup_required" };
+    render(<HomeNextScreen />);
+    expect(screen.getByText("Finish agent setup to start a chat.")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Agents" }));
+    expect(screenMocks.handleHomeAction).toHaveBeenCalledWith("agent-settings");
+    expect(screen.queryByText(/configured/i)).toBeNull();
+    // Ruling 2, at the seam Home actually builds: the notice is on screen, so
+    // the picker it is paired with cannot be an enabled "Select model".
+    expect(screenMocks.leadingControlsProps.modelSelectorProps.availability)
+      .toBe("unavailable");
+  });
+
+  it.each([
+    [{ kind: "blocked", reason: "observation_failed" }, "Couldn't check your models.", "Retry"],
+    [{ kind: "blocked", reason: "transport_error" }, "Models couldn't be loaded.", "Retry"],
+    [
+      { kind: "blocked", reason: "target_unobserved" },
+      "Proliferate Cloud hasn't reported launch options yet.",
+      "Check again",
+    ],
+  ] as const)("renders %j with an enabled cure and no setup CTA", (modelGate, notice, action) => {
+    screenMocks.homeNext.modelGate = modelGate;
+    render(<HomeNextScreen />);
+    expect(screen.getByText(notice)).toBeTruthy();
+    expect(screen.queryByText(/Finish agent setup/i)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Agents" })).toBeNull();
+
+    const cure = screen.getByRole("button", { name: action }) as HTMLButtonElement;
+    expect(cure.disabled).toBe(false);
+    fireEvent.click(cure);
+    expect(screenMocks.retryModelObservation).toHaveBeenCalled();
+    expect(screenMocks.handleHomeAction).not.toHaveBeenCalledWith("agent-settings");
+  });
+
+  it("labels the disabled Send with the reason while a model is unchosen", () => {
+    screenMocks.homeNext.modelGate = { kind: "selection_required" };
+    render(<HomeNextScreen />);
+    fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "ship it" } });
+
+    const send = screen.getByRole("button", { name: "Choose a model" }) as HTMLButtonElement;
+    expect(send.disabled).toBe(true);
+    expect(send.title).toBe("Choose a model");
+  });
+
+  it("preserves the draft, moves focus to the picker trigger and re-announces on repeated Enter", () => {
+    screenMocks.homeNext.modelGate = { kind: "selection_required" };
+    render(<HomeNextScreen />);
+    const prompt = screen.getByLabelText("Prompt") as HTMLTextAreaElement;
+    fireEvent.change(prompt, { target: { value: "Add retry logic to the sync worker" } });
+
+    const region = document.querySelector("[data-home-model-gate-announcement]") as HTMLElement;
+    expect(region.getAttribute("role")).toBe("status");
+    expect(region.getAttribute("aria-live")).toBe("polite");
+    expect(region.textContent).toBe("");
+
+    fireEvent.keyDown(prompt, { key: "Enter" });
+
+    expect(prompt.value).toBe("Add retry logic to the sync worker");
+    expect(screenMocks.launch).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(
+      document.querySelector("[data-composer-model-trigger]"),
+    );
+    const first = region.textContent ?? "";
+    expect(first.trim()).toBe("Choose a model before sending");
+
+    fireEvent.keyDown(prompt, { key: "Enter" });
+    const second = region.textContent ?? "";
+    // Re-committed, not stacked, and never a numeral.
+    expect(second).not.toBe(first);
+    expect(second.trim()).toBe("Choose a model before sending");
+    expect(/\d/.test(second)).toBe(false);
+    expect(prompt.value).toBe("Add retry logic to the sync worker");
+  });
+});

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.test.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.test.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HomeNextScreen } from "#product/components/home/screen/HomeNextScreen";
+import { HOME_MODEL_GATE_SEND_BLOCKED_REASON } from "#product/lib/domain/home/home-model-gate";
 import {
   HOME_NEXT_TARGET_SELECTION_STORAGE_KEY,
   hydrateHomeNextTargetSelection,
@@ -176,16 +177,13 @@ vi.mock("#product/components/workspace/chat/input/ComposerRichTextEditor", () =>
     <textarea aria-label="Prompt" data-editor-snapshot={snapshot?.payload} value={value} onChange={(event) => onChange(event.target.value, event.timeStamp, { version: 1, payload: "home-editor-snapshot" })} onKeyDown={onKeyDown} disabled={disabled} />
   ),
 }));
-
 vi.mock("#product/components/workspace/chat/input/ChatComposerActions", () => ({
-  ChatComposerActions: ({
-    isDisabled,
-    onSubmit,
-  }: {
-    isDisabled: boolean;
-    onSubmit: () => void;
+  // `disabledReason` is the accessible NAME on the real control.
+  ChatComposerActions: (props: {
+    isDisabled: boolean; disabledReason?: string | null; onSubmit: () => void;
   }) => (
-    <button type="button" disabled={isDisabled} onClick={onSubmit}>
+    <button type="button" disabled={props.isDisabled} onClick={props.onSubmit}
+      aria-label={props.disabledReason ?? undefined}>
       Submit
     </button>
   ),
@@ -231,15 +229,17 @@ describe("HomeNextScreen model availability notices", () => {
     cleanup();
   });
 
-  it("does not render model-derived submit-disabled reasons after typing", () => {
-    screenMocks.homeNext.modelGate = { kind: "blocked", reason: "agent_setup_required" };
+  // Was three queries for deleted ModelAvailabilityState copy no source emits.
+  it.each([
+    [{ kind: "blocked", reason: "agent_setup_required" }, false],
+    [{ kind: "selection_required" }, true],
+  ] as const)("names the unchosen model on Send for %j", (modelGate, named) => {
+    screenMocks.homeNext.modelGate = modelGate;
     render(<HomeNextScreen />);
-
     fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "hello" } });
+    const name = HOME_MODEL_GATE_SEND_BLOCKED_REASON;
+    expect(screen.queryByRole("button", { name }) !== null).toBe(named);
 
-    expect(screen.queryByText("No ready models")).toBeNull();
-    expect(screen.queryByText("Loading models")).toBeNull();
-    expect(screen.queryByText("Couldn't load models")).toBeNull();
   });
 
   it("caps the home composer using the scaled textarea line-height", () => {

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.test.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.test.tsx
@@ -342,12 +342,12 @@ describe("HomeNextScreen model availability notices", () => {
     expect(document.querySelector("[data-home-onboarding-region]")).toBeTruthy();
     expect(document.querySelector("[data-home-composer-dock]")).toBeTruthy();
 
-    expect(screen.getByText("Add a GitHub repo")).toBeTruthy();
-    expect(screen.getByText("Configure default harnesses")).toBeTruthy();
-    expect(screen.queryByText("Manage agents")).toBeNull();
-    expect(screen.queryByText("Add another repository")).toBeNull();
-    expect(screen.queryByText(/Choose a local GitHub clone/i)).toBeNull();
-
+    // Was three negations of literals nothing emits; the live form is the list.
+    const cards = document.querySelectorAll("[data-home-onboarding-region] button");
+    expect(Array.from(cards).map((card) => card.getAttribute("aria-label"))).toEqual([
+      "Add a GitHub repo",
+      "Configure default harnesses",
+    ]);
     fireEvent.click(screen.getByRole("button", { name: "Add a GitHub repo" }));
     expect(screenMocks.handleHomeAction).toHaveBeenCalledWith("add-repository");
 

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.test.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.test.tsx
@@ -42,7 +42,10 @@ const screenMocks = vi.hoisted(() => {
     effectiveMode: null,
     effectiveModeId: null,
     targetDisabledReason: null,
-    modelAvailabilityState: "launchable",
+    modelGate: { kind: "launchable" },
+    isCatalogLoading: false,
+    hasKnownAgents: true,
+    retryModelObservation: () => {},
     canLaunchTarget: true,
     effectiveModelSelection: { kind: "codex", modelId: "gpt-5.4" },
     launchTarget: { kind: "cowork" },
@@ -191,7 +194,9 @@ vi.mock("#product/components/workspace/chat/input/ChatComposerActions", () => ({
 function resetHomeNext() {
   screenMocks.productHost.desktop = {};
   screenMocks.homeNext.targetDisabledReason = null;
-  screenMocks.homeNext.modelAvailabilityState = "launchable";
+  screenMocks.homeNext.modelGate = { kind: "launchable" };
+  screenMocks.homeNext.isCatalogLoading = false;
+  screenMocks.homeNext.hasKnownAgents = true;
   screenMocks.homeNext.canLaunchTarget = true;
   screenMocks.homeNext.effectiveModelSelection = { kind: "codex", modelId: "gpt-5.4" };
   screenMocks.homeNext.launchTarget = { kind: "cowork" };
@@ -226,41 +231,8 @@ describe("HomeNextScreen model availability notices", () => {
     cleanup();
   });
 
-  it("renders no agent/model notice for launchable and loading states", () => {
-    const { rerender } = render(<HomeNextScreen />);
-
-    expect(screen.queryByText(/Finish agent setup/i)).toBeNull();
-    expect(screen.queryByText(/Models are unavailable/i)).toBeNull();
-
-    screenMocks.homeNext.modelAvailabilityState = "loading";
-    rerender(<HomeNextScreen />);
-
-    expect(screen.queryByText(/Finish agent setup/i)).toBeNull();
-    expect(screen.queryByText(/Models are unavailable/i)).toBeNull();
-  });
-
-  it("renders setup guidance only for no launchable model", () => {
-    screenMocks.homeNext.modelAvailabilityState = "no_launchable_model";
-    render(<HomeNextScreen />);
-    expect(screen.getByText("Finish agent setup to start a chat.")).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Agents" }));
-    expect(screenMocks.handleHomeAction).toHaveBeenCalledWith("agent-settings");
-    expect(screen.queryByText(/configured/i)).toBeNull();
-  });
-
-  it.each([
-    ["load_error", "Models are unavailable right now. Try again in a moment."],
-    ["target_unobserved", "This cloud target hasn't reported launch options yet."],
-  ] as const)("renders %s copy with no local setup CTA", (availabilityState, notice) => {
-    screenMocks.homeNext.modelAvailabilityState = availabilityState;
-    render(<HomeNextScreen />);
-    expect(screen.getByText(notice)).toBeTruthy();
-    expect(screen.queryByText(/Finish agent setup/i)).toBeNull();
-    expect(screen.queryByRole("button", { name: "Agents" })).toBeNull();
-  });
-
   it("does not render model-derived submit-disabled reasons after typing", () => {
-    screenMocks.homeNext.modelAvailabilityState = "no_launchable_model";
+    screenMocks.homeNext.modelGate = { kind: "blocked", reason: "agent_setup_required" };
     render(<HomeNextScreen />);
 
     fireEvent.change(screen.getByLabelText("Prompt"), { target: { value: "hello" } });
@@ -427,8 +399,11 @@ describe("HomeNextScreen composer control-row parity", () => {
     });
     expect(screenMocks.leadingControlsProps.modelSelectorProps).toMatchObject({
       connectionState: "healthy",
-      hasAgents: false,
+      // From the agent CATALOG, not from the group list: an agent that has
+      // reported no models yet still exists.
+      hasAgents: true,
       isLoading: false,
+      availability: "ready",
     });
     expect(screenMocks.trailingControlsProps).toMatchObject({
       runtimeControlsDisabled: false,

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx
@@ -139,6 +139,7 @@ export function HomeNextScreen() {
   // A refused probe writes no durable state, so the gate cannot move and the
   // same sentence would render again unchanged. The notice says so instead.
   const modelAvailabilityNotice = resolveHomeModelGateNotice(homeNext.modelGate, {
+    refreshPending: homeNext.retryPending,
     refreshRejected: homeNext.retryRejected,
   });
   const runModelGateNoticeAction = () => {
@@ -322,16 +323,20 @@ export function HomeNextScreen() {
               modelAvailabilityNoticeSlot={modelAvailabilityNotice ? (
                 <div className="mx-auto mt-2 flex max-w-2xl items-center justify-center gap-2 px-2 text-center text-ui-sm text-muted-foreground">
                   <span>{modelAvailabilityNotice.text}</span>
-                  {/* Ruling 5: every notice carries an ENABLED action that
-                      cures the state it describes. */}
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={runModelGateNoticeAction}
-                    className="h-auto px-0 py-0 text-foreground underline underline-offset-4 hover:text-muted-foreground"
-                  >
-                    {modelAvailabilityNotice.actionLabel}
-                  </Button>
+                  {/* Ruling 5: a notice that names a cure carries an ENABLED
+                      action for it. The single terminal state names none —
+                      a button that cannot change anything is the dead end
+                      this gate removes, not a cure. */}
+                  {modelAvailabilityNotice.action ? (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={runModelGateNoticeAction}
+                      className="h-auto px-0 py-0 text-foreground underline underline-offset-4 hover:text-muted-foreground"
+                    >
+                      {modelAvailabilityNotice.actionLabel}
+                    </Button>
+                  ) : null}
                 </div>
               ) : null}
               submitDisabledReasonCtaSlot={

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx
@@ -24,6 +24,7 @@ import {
   buildHomeModelSelectorProps,
   buildHomeSessionConfigControls,
 } from "#product/lib/domain/home/home-composer-controls";
+import { resolveHomeModelGateNotice } from "#product/lib/domain/home/home-model-gate";
 import { type HomeNextModelSelection } from "#product/lib/domain/home/home-next-launch";
 import { resolveHomeModelProbeCardState } from "#product/lib/domain/home/home-screen";
 import { resolveHomeTargetLaunchKindForRepository } from "#product/lib/domain/home/home-target-picker";
@@ -93,7 +94,9 @@ export function HomeNextScreen() {
   const homeModelSelectorProps = buildHomeModelSelectorProps({
     groups: homeNext.modelGroups,
     selectedModel: homeNext.selectedModel,
-    availabilityState: homeNext.modelAvailabilityState,
+    gate: homeNext.modelGate,
+    isCatalogLoading: homeNext.isCatalogLoading,
+    hasKnownAgents: homeNext.hasKnownAgents,
     onSelect: (selection) => {
       setModelSelectionOverride(selection);
       setLaunchControlOverrides({});
@@ -127,23 +130,20 @@ export function HomeNextScreen() {
     || authSetupStep === "settingUp"
     || (authSetupEvidence !== undefined && authSetupEvidence !== null)
     || (modelProbeState !== undefined && modelProbeState.kind !== "hidden");
-  const modelAvailabilityNotice =
-    homeNext.modelAvailabilityState === "target_unobserved"
-      ? {
-        text: "This cloud target hasn't reported launch options yet.",
-        actionLabel: null,
-      }
-      : homeNext.modelAvailabilityState === "no_launchable_model"
-        ? {
-          text: "Finish agent setup to start a chat.",
-          actionLabel: "Agents",
-        }
-        : homeNext.modelAvailabilityState === "load_error"
-          ? {
-            text: "Models are unavailable right now. Try again in a moment.",
-            actionLabel: null,
-          }
-          : null;
+  // One mapping, keyed on the gate. Every silent arm is silent on purpose:
+  // selection_required and observed_empty are cured by the enabled picker
+  // itself (owner revisions r2/r3), and the in-flight arms belong to the
+  // install toast. "Finish agent setup to start a chat." can only be reached
+  // through blocked(agent_setup_required), which requires real
+  // install_required/login_required readiness.
+  const modelAvailabilityNotice = resolveHomeModelGateNotice(homeNext.modelGate);
+  const runModelGateNoticeAction = () => {
+    if (modelAvailabilityNotice?.action === "agent_settings") {
+      handleHomeAction("agent-settings");
+      return;
+    }
+    homeNext.retryModelObservation();
+  };
   return (
     <div
       className="relative flex h-full w-full min-w-0 flex-1 overflow-hidden bg-background text-foreground"
@@ -251,7 +251,7 @@ export function HomeNextScreen() {
           <div className="mx-auto w-full max-w-transcript-thread">
             <HomeComposerForm
               targetDisabledReason={homeNext.targetDisabledReason}
-              modelAvailabilityState={homeNext.modelAvailabilityState}
+              modelGate={homeNext.modelGate}
               canLaunchTarget={homeNext.canLaunchTarget}
               modelSelection={homeNext.effectiveModelSelection}
               launchControlValues={homeLaunchControls.launchControlValues}
@@ -318,16 +318,16 @@ export function HomeNextScreen() {
               modelAvailabilityNoticeSlot={modelAvailabilityNotice ? (
                 <div className="mx-auto mt-2 flex max-w-2xl items-center justify-center gap-2 px-2 text-center text-ui-sm text-muted-foreground">
                   <span>{modelAvailabilityNotice.text}</span>
-                  {modelAvailabilityNotice.actionLabel ? (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => handleHomeAction("agent-settings")}
-                      className="h-auto px-0 py-0 text-foreground underline underline-offset-4 hover:text-muted-foreground"
-                    >
-                      {modelAvailabilityNotice.actionLabel}
-                    </Button>
-                  ) : null}
+                  {/* Ruling 5: every notice carries an ENABLED action that
+                      cures the state it describes. */}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={runModelGateNoticeAction}
+                    className="h-auto px-0 py-0 text-foreground underline underline-offset-4 hover:text-muted-foreground"
+                  >
+                    {modelAvailabilityNotice.actionLabel}
+                  </Button>
                 </div>
               ) : null}
               submitDisabledReasonCtaSlot={

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx
@@ -136,7 +136,11 @@ export function HomeNextScreen() {
   // install toast. "Finish agent setup to start a chat." can only be reached
   // through blocked(agent_setup_required), which requires real
   // install_required/login_required readiness.
-  const modelAvailabilityNotice = resolveHomeModelGateNotice(homeNext.modelGate);
+  // A refused probe writes no durable state, so the gate cannot move and the
+  // same sentence would render again unchanged. The notice says so instead.
+  const modelAvailabilityNotice = resolveHomeModelGateNotice(homeNext.modelGate, {
+    refreshRejected: homeNext.retryRejected,
+  });
   const runModelGateNoticeAction = () => {
     if (modelAvailabilityNotice?.action === "agent_settings") {
       handleHomeAction("agent-settings");

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx
@@ -327,13 +327,12 @@ export function HomeNextScreen() {
                       action for it. The single terminal state names none —
                       a button that cannot change anything is the dead end
                       this gate removes, not a cure. */}
-                  {/* Disabled while a probe is running: a second press would
-                      start an overlapping batch whose out-of-order settle
-                      could report the wrong outcome for the wrong press. */}
+                  {/* Never disabled: this is the only affordance on states
+                      with no guaranteed exit, and the hook already ignores a
+                      press while its own batch is in flight. */}
                   <Button
                     variant="ghost"
                     size="sm"
-                    disabled={homeNext.retryPending}
                     onClick={runModelGateNoticeAction}
                     className="h-auto px-0 py-0 text-foreground underline underline-offset-4 hover:text-muted-foreground"
                   >

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx
@@ -327,16 +327,14 @@ export function HomeNextScreen() {
                       action for it. The single terminal state names none —
                       a button that cannot change anything is the dead end
                       this gate removes, not a cure. */}
-                  {modelAvailabilityNotice.action ? (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={runModelGateNoticeAction}
-                      className="h-auto px-0 py-0 text-foreground underline underline-offset-4 hover:text-muted-foreground"
-                    >
-                      {modelAvailabilityNotice.actionLabel}
-                    </Button>
-                  ) : null}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={runModelGateNoticeAction}
+                    className="h-auto px-0 py-0 text-foreground underline underline-offset-4 hover:text-muted-foreground"
+                  >
+                    {modelAvailabilityNotice.actionLabel}
+                  </Button>
                 </div>
               ) : null}
               submitDisabledReasonCtaSlot={

--- a/apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx
+++ b/apps/packages/product-client/src/components/home/screen/HomeNextScreen.tsx
@@ -144,7 +144,7 @@ export function HomeNextScreen() {
   });
   const runModelGateNoticeAction = () => {
     if (modelAvailabilityNotice?.action === "agent_settings") {
-      handleHomeAction("agent-settings");
+      handleHomeAction("agent-settings", { harnessKind: homeNext.unsupportedHarnessKind });
       return;
     }
     homeNext.retryModelObservation();
@@ -327,9 +327,13 @@ export function HomeNextScreen() {
                       action for it. The single terminal state names none —
                       a button that cannot change anything is the dead end
                       this gate removes, not a cure. */}
+                  {/* Disabled while a probe is running: a second press would
+                      start an overlapping batch whose out-of-order settle
+                      could report the wrong outcome for the wrong press. */}
                   <Button
                     variant="ghost"
                     size="sm"
+                    disabled={homeNext.retryPending}
                     onClick={runModelGateNoticeAction}
                     className="h-auto px-0 py-0 text-foreground underline underline-offset-4 hover:text-muted-foreground"
                   >

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelPickerPopover.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelPickerPopover.tsx
@@ -5,6 +5,7 @@ import { splitProviderDisplayName } from "#product/lib/domain/chat/models/model-
 import { orderModelGroupsActiveFirst } from "#product/lib/domain/chat/models/order-model-groups";
 import { MODEL_UNSUPPORTED_ROW_HINT } from "#product/lib/domain/chat/models/model-support-refusals";
 import type {
+  ModelSelectorAvailability,
   ModelSelectorGroup,
   ModelSelectorProps,
   ModelSelectorSelection,
@@ -17,6 +18,8 @@ import { ProviderIcon } from "#product/primitives/icons/provider-icons";
 
 interface ComposerModelPickerPopoverProps {
   groups: ModelSelectorGroup[];
+  /** Why the group list is what it is; only changes the empty body. */
+  availability?: ModelSelectorAvailability;
   currentModel: ModelSelectorProps["currentModel"];
   onKeyboardClose: () => void;
   onSelect: (selection: ModelSelectorSelection) => void;
@@ -26,6 +29,7 @@ interface ComposerModelPickerPopoverProps {
 
 export function ComposerModelPickerPopover({
   groups,
+  availability = "ready",
   currentModel,
   onKeyboardClose,
   onSelect,
@@ -102,9 +106,15 @@ export function ComposerModelPickerPopover({
           />
         ))}
 
+        {/* Two ways to be empty, two sentences. `observed_empty` means the
+            catalog loaded, agents exist, and every group came back empty —
+            telling that user to add a harness would point at the wrong fix,
+            so the footer's Add provider / Settings carry the cures instead. */}
         {orderedGroups.length === 0 && (
           <p className="px-3 py-4 text-center text-ui text-muted-foreground">
-            {CHAT_MODEL_SELECTOR_LABELS.noProviders}
+            {availability === "observed_empty"
+              ? CHAT_MODEL_SELECTOR_LABELS.observedEmpty
+              : CHAT_MODEL_SELECTOR_LABELS.noProviders}
           </p>
         )}
 

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.availability.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.availability.test.tsx
@@ -1,0 +1,165 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, expect, it, vi } from "vitest";
+import { ComposerModelSelectorControl } from "#product/components/workspace/chat/input/ComposerModelSelectorControl";
+import type { ModelSelectorProps } from "#product/lib/domain/chat/models/model-selector-types";
+
+/**
+ * The trigger's `availability` contract: which sentence it may claim, and
+ * which states may disable it. Split from ComposerModelSelectorControl.test
+ * so neither file carries two unrelated concerns past the size cap.
+ */
+
+Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
+  configurable: true,
+  value: vi.fn(),
+});
+
+afterEach(cleanup);
+
+function openModelOptions(container: HTMLElement) {
+  const trigger = container.querySelector<HTMLElement>("[data-composer-model-trigger]")!;
+  fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+  fireEvent.click(trigger);
+}
+
+function availabilityProps(overrides: Partial<ModelSelectorProps> = {}): ModelSelectorProps {
+  return {
+    connectionState: "healthy",
+    currentModel: null,
+    groups: [],
+    hasAgents: true,
+    isLoading: false,
+    onSelect: vi.fn(),
+    ...overrides,
+  };
+}
+
+it("reads 'Select model' while an observation is pending, never 'No agents'", () => {
+  // The first-run bug: agents are installing, so they exist and the catalog is
+  // not loading. "No agents" would be false and "Loading agents..." would
+  // misname the install.
+  const { container } = render(
+    <MemoryRouter>
+      <ComposerModelSelectorControl
+        modelSelectorProps={availabilityProps({ availability: "observation_pending" })}
+      />
+    </MemoryRouter>,
+  );
+
+  const trigger = container.querySelector<HTMLButtonElement>("[data-composer-model-trigger]")!;
+  expect(trigger.textContent).toContain("Select model");
+  expect(trigger.textContent).not.toContain("No agents");
+  expect(trigger.textContent).not.toContain("Loading agents");
+  expect(trigger.disabled).toBe(true);
+});
+
+it("keeps 'Loading agents...' for a genuine catalog load and 'No agents' for an empty one", () => {
+  const loading = render(
+    <MemoryRouter>
+      <ComposerModelSelectorControl
+        modelSelectorProps={availabilityProps({ isLoading: true, hasAgents: false })}
+      />
+    </MemoryRouter>,
+  );
+  expect(
+    loading.container.querySelector("[data-composer-model-trigger]")?.textContent,
+  ).toContain("Loading agents...");
+  cleanup();
+
+  const { container } = render(
+    <MemoryRouter>
+      <ComposerModelSelectorControl
+        modelSelectorProps={availabilityProps({ hasAgents: false })}
+      />
+    </MemoryRouter>,
+  );
+  expect(
+    container.querySelector("[data-composer-model-trigger]")?.textContent,
+  ).toContain("No agents");
+});
+
+it("keeps the trigger enabled for observed_empty and disabled for a failed observation", () => {
+  const empty = render(
+    <MemoryRouter>
+      <ComposerModelSelectorControl
+        modelSelectorProps={availabilityProps({ availability: "observed_empty" })}
+      />
+    </MemoryRouter>,
+  );
+  const enabledTrigger = empty.container.querySelector<HTMLButtonElement>(
+    "[data-composer-model-trigger]",
+  )!;
+  expect(enabledTrigger.disabled).toBe(false);
+  expect(enabledTrigger.textContent).toContain("Select model");
+  cleanup();
+
+  // Ruling 2's other half at the DOM: `unavailable` is what the gate maps
+  // agent_setup_required to, so an enabled "Select model" cannot appear beside
+  // a "Finish agent setup" notice.
+  const { container } = render(
+    <MemoryRouter>
+      <ComposerModelSelectorControl
+        modelSelectorProps={availabilityProps({ availability: "unavailable" })}
+      />
+    </MemoryRouter>,
+  );
+  expect(
+    container.querySelector<HTMLButtonElement>("[data-composer-model-trigger]")!.disabled,
+  ).toBe(true);
+});
+
+it("says the agents reported nothing in the observed_empty picker body", () => {
+  const { container } = render(
+    <MemoryRouter>
+      <ComposerModelSelectorControl
+        modelSelectorProps={availabilityProps({ availability: "observed_empty" })}
+      />
+    </MemoryRouter>,
+  );
+  openModelOptions(container);
+
+  expect(document.body.textContent).toContain("Your agents reported no models yet.");
+  expect(document.body.textContent).not.toContain("No harnesses yet.");
+  // The footer cures stay exactly as they are.
+  expect(document.body.textContent).toContain("Add provider");
+  expect(document.body.textContent).toContain("Settings");
+});
+
+it("keeps the no-harnesses copy when the catalog is genuinely empty", () => {
+  const { container } = render(
+    <MemoryRouter>
+      <ComposerModelSelectorControl modelSelectorProps={availabilityProps()} />
+    </MemoryRouter>,
+  );
+  openModelOptions(container);
+
+  expect(document.body.textContent).toContain("No harnesses yet.");
+  expect(document.body.textContent).not.toContain("Your agents reported no models yet.");
+});
+
+it("returns focus to the composer editor on Escape from the closed trigger", () => {
+  const { container } = render(
+    <MemoryRouter initialEntries={["/"]}>
+      <div data-focus-zone="chat">
+        <textarea data-chat-composer-editor defaultValue="Draft kept" />
+        <ComposerModelSelectorControl
+          modelSelectorProps={availabilityProps({ availability: "observed_empty" })}
+          keyboardShortcutEnabled
+        />
+      </div>
+    </MemoryRouter>,
+  );
+
+  const trigger = container.querySelector<HTMLButtonElement>("[data-composer-model-trigger]")!;
+  trigger.focus();
+  expect(document.activeElement).toBe(trigger);
+
+  fireEvent.keyDown(trigger, { key: "Escape", code: "Escape" });
+
+  const editor = container.querySelector<HTMLTextAreaElement>("[data-chat-composer-editor]")!;
+  expect(document.activeElement).toBe(editor);
+  expect(editor.value).toBe("Draft kept");
+});

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.availability.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.availability.test.tsx
@@ -111,6 +111,51 @@ it("keeps the trigger enabled for observed_empty and disabled for a failed obser
   ).toBe(true);
 });
 
+it("never says 'No agents' about a sandbox the gate already explained", () => {
+  // The cloud shape: `hasAgents` is derived from an answer that carried zero
+  // rows, so it can be false in exactly the states the gate has a truer story
+  // for. "No agents" is a claim about the CATALOG, and beside a notice saying
+  // the cloud has not reported yet it is the second of two contradictory
+  // stories about the same sandbox.
+  for (const availability of ["observed_empty", "unavailable"] as const) {
+    const { container } = render(
+      <MemoryRouter>
+        <ComposerModelSelectorControl
+          modelSelectorProps={availabilityProps({ hasAgents: false, availability })}
+        />
+      </MemoryRouter>,
+    );
+    const trigger = container.querySelector<HTMLButtonElement>(
+      "[data-composer-model-trigger]",
+    )!;
+    expect(trigger.textContent).not.toContain("No agents");
+    expect(trigger.textContent).toContain("Select model");
+    cleanup();
+  }
+});
+
+it("keeps an observed_empty cloud picker openable once its agents are known", () => {
+  // Ruling 3 depends on `hasAgents`, which is outside the gate: an
+  // `observed_empty` sandbox whose agents were counted from its (empty) rows
+  // produced a DISABLED picker, turning the one cure path into a dead end.
+  const { container } = render(
+    <MemoryRouter>
+      <ComposerModelSelectorControl
+        modelSelectorProps={availabilityProps({
+          hasAgents: true,
+          availability: "observed_empty",
+        })}
+      />
+    </MemoryRouter>,
+  );
+  const trigger = container.querySelector<HTMLButtonElement>(
+    "[data-composer-model-trigger]",
+  )!;
+  expect(trigger.disabled).toBe(false);
+  openModelOptions(container);
+  expect(document.body.textContent).toContain("Your agents reported no models yet.");
+});
+
 it("says the agents reported nothing in the observed_empty picker body", () => {
   const { container } = render(
     <MemoryRouter>

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
@@ -5,7 +5,10 @@ import { CHAT_MODEL_SELECTOR_LABELS } from "#product/copy/chat/chat-copy";
 import { buildSettingsHref } from "#product/lib/domain/settings/navigation";
 import { getSettingsSectionForHarnessKind } from "#product/lib/domain/settings/navigation-presentation";
 import { splitProviderDisplayName } from "#product/lib/domain/chat/models/model-display-name-parts";
-import type { ModelSelectorProps } from "#product/lib/domain/chat/models/model-selector-types";
+import {
+  resolveModelSelectorEnabled,
+  type ModelSelectorProps,
+} from "#product/lib/domain/chat/models/model-selector-types";
 import { ComposerControlButton } from "#product/primitives/patterns/composer/ComposerControlButton";
 import { PopoverButton } from "#product/primitives/PopoverButton";
 import { ProviderIcon } from "#product/primitives/icons/provider-icons";
@@ -42,16 +45,14 @@ export function ComposerModelSelectorControl({
     availability = "ready",
     unsupportedSelectionMessage = null,
   } = modelSelectorProps;
-  // `observed_empty` deliberately stays ENABLED (owner revision r3): the picker
-  // is that state's cure path, and greying out the one control that explains
-  // what happened turns a recoverable state into a dead end. Only a missing or
-  // failed observation disables the trigger — those have nothing to show.
-  const selectorEnabled = !disabled
-    && connectionState === "healthy"
-    && !isLoading
-    && hasAgents
-    && availability !== "observation_pending"
-    && availability !== "unavailable";
+  // Shared with the coexistence tests, so neither can drift from the other.
+  const selectorEnabled = resolveModelSelectorEnabled({
+    disabled,
+    connectionState,
+    isLoading,
+    hasAgents,
+    availability,
+  });
   // The picker opens itself after a refusal so the marked rows are in front of
   // the user rather than one click away. Nonce-driven: two refusals in a row
   // each reopen it, and nothing has to reset a flag.
@@ -239,7 +240,13 @@ function resolveTriggerLabel(modelSelectorProps: ModelSelectorProps): string {
   if (availability === "observation_pending") {
     return CHAT_MODEL_SELECTOR_LABELS.empty;
   }
-  if (!hasAgents) {
+  // "No agents" is a claim about the CATALOG, and it is only this control's to
+  // make when the catalog is the reason there is nothing to show. Under any
+  // non-ready availability the gate already knows the real reason — a cloud
+  // sandbox that reported zero models, or one that has not reported at all —
+  // and the pill saying "No agents" beside a notice saying otherwise is two
+  // contradictory stories about the same sandbox.
+  if (!hasAgents && availability === "ready") {
     return "No agents";
   }
   return CHAT_MODEL_SELECTOR_LABELS.empty;

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerModelSelectorControl.tsx
@@ -39,9 +39,19 @@ export function ComposerModelSelectorControl({
     hasAgents,
     isLoading,
     onSelect,
+    availability = "ready",
     unsupportedSelectionMessage = null,
   } = modelSelectorProps;
-  const selectorEnabled = !disabled && connectionState === "healthy" && !isLoading && hasAgents;
+  // `observed_empty` deliberately stays ENABLED (owner revision r3): the picker
+  // is that state's cure path, and greying out the one control that explains
+  // what happened turns a recoverable state into a dead end. Only a missing or
+  // failed observation disables the trigger — those have nothing to show.
+  const selectorEnabled = !disabled
+    && connectionState === "healthy"
+    && !isLoading
+    && hasAgents
+    && availability !== "observation_pending"
+    && availability !== "unavailable";
   // The picker opens itself after a refusal so the marked rows are in front of
   // the user rather than one click away. Nonce-driven: two refusals in a row
   // each reopen it, and nothing has to reset a flag.
@@ -147,6 +157,16 @@ export function ComposerModelSelectorControl({
             aria-describedby={unsupportedSelectionMessage
               ? MODEL_UNSUPPORTED_MESSAGE_ID
               : undefined}
+            onKeyDown={(event) => {
+              // Escape from the closed trigger hands the caret back to the
+              // editor: a refused Enter parks focus here, and Escape is how
+              // the user says "not now" without losing their place.
+              if (event.key !== "Escape" || pickerOpen || !keyboardFocusRestoreEnabled) {
+                return;
+              }
+              event.preventDefault();
+              focusChatInput();
+            }}
             className="max-w-[min(15rem,100%)]"
           />
         )}
@@ -160,6 +180,7 @@ export function ComposerModelSelectorControl({
         {(close) => (
           <ComposerModelPickerPopover
             groups={groups}
+            availability={availability}
             currentModel={currentModel}
             onKeyboardClose={handleKeyboardClose}
             onSelect={(selection) => {
@@ -193,6 +214,7 @@ const MODEL_UNSUPPORTED_MESSAGE_ID = "composer-model-unsupported";
 
 function resolveTriggerLabel(modelSelectorProps: ModelSelectorProps): string {
   const {
+    availability = "ready",
     connectionState,
     currentModel,
     hasAgents,
@@ -202,12 +224,20 @@ function resolveTriggerLabel(modelSelectorProps: ModelSelectorProps): string {
   if (connectionState === "connecting") {
     return "Connecting...";
   }
+  // "Loading agents..." belongs to a genuine catalog HTTP read and nothing
+  // else. An install in flight is not the catalog loading.
   if (isLoading && !currentModel) {
     return "Loading agents...";
   }
   if (currentModel?.displayName) {
     // Show only the leaf name on the pill — the provider icon already carries harness identity.
     return splitProviderDisplayName(currentModel.displayName).leaf;
+  }
+  // Before the first observation the disabled trigger reads "Select model":
+  // "No agents" would be false (they are installing) and "Loading agents..."
+  // would misname an install as a catalog fetch.
+  if (availability === "observation_pending") {
+    return CHAT_MODEL_SELECTOR_LABELS.empty;
   }
   if (!hasAgents) {
     return "No agents";

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.submit-refusal.test.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.submit-refusal.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { KEY_ENTER_COMMAND, type LexicalEditor } from "lexical";
+import {
+  ComposerRichTextEditor,
+  type ComposerRichTextEditorProps,
+} from "#product/components/workspace/chat/input/ComposerRichTextEditor";
+
+/**
+ * The refusal seam: Enter with sending refused is still swallowed, but the
+ * surface now hears about it. Home turns that into a focus move and an
+ * announcement; without it a refused Enter is indistinguishable from a
+ * keystroke that went nowhere.
+ */
+
+afterEach(cleanup);
+
+describe("ComposerRichTextEditor submit refusal", () => {
+  it("reports a refused Enter instead of silently swallowing it", async () => {
+    const onSubmit = vi.fn();
+    const onSubmitRefused = vi.fn();
+    const harness = renderEditor({ canSubmit: false, onSubmit, onSubmitRefused });
+    await harness.ready();
+
+    const enter = keyEvent("Enter", { cancelable: true });
+    act(() => {
+      harness.editor.dispatchCommand(KEY_ENTER_COMMAND, enter);
+    });
+
+    // Still swallowed — a refused send must never insert a newline — but the
+    // surface now learns the user asked, which is what Home announces on.
+    expect(enter.defaultPrevented).toBe(true);
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onSubmitRefused).toHaveBeenCalledTimes(1);
+
+    const again = keyEvent("Enter", { cancelable: true });
+    act(() => {
+      harness.editor.dispatchCommand(KEY_ENTER_COMMAND, again);
+    });
+    expect(onSubmitRefused).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not report a refusal when the send goes through", async () => {
+    const onSubmitRefused = vi.fn();
+    const harness = renderEditor({ canSubmit: true, onSubmitRefused });
+    await harness.ready();
+
+    act(() => {
+      harness.editor.dispatchCommand(KEY_ENTER_COMMAND, keyEvent("Enter", { cancelable: true }));
+    });
+    expect(onSubmitRefused).not.toHaveBeenCalled();
+  });
+});
+
+function renderEditor(overrides: Partial<ComposerRichTextEditorProps> = {}) {
+  let editor: LexicalEditor | null = null;
+  const props: ComposerRichTextEditorProps = {
+    value: "seed",
+    onChange: vi.fn(),
+    canSubmit: true,
+    onSubmit: vi.fn(),
+    placeholder: "Message",
+    disabled: false,
+    editorRef: (next) => { editor = next; },
+    ...overrides,
+  };
+  render(<ComposerRichTextEditor {...props} />);
+  return {
+    get editor() { return editor!; },
+    ready: () => waitFor(() => expect(editor).toBeTruthy()),
+  };
+}
+
+function keyEvent(key: string, init: KeyboardEventInit = {}): KeyboardEvent {
+  return new KeyboardEvent("keydown", { key, bubbles: true, ...init });
+}

--- a/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
+++ b/apps/packages/product-client/src/components/workspace/chat/input/ComposerRichTextEditor.tsx
@@ -63,6 +63,13 @@ export interface ComposerRichTextEditorProps {
   activeDescendantId?: string;
   canSubmit: boolean;
   onSubmit: () => void;
+  /**
+   * Enter arrived while `canSubmit` was false. The keystroke is swallowed
+   * either way; this is the only signal a surface gets that the user asked to
+   * send and was refused, which is what Home needs to announce the reason and
+   * move focus to the cure.
+   */
+  onSubmitRefused?: () => void;
   editorRef?: (editor: LexicalEditor) => void;
   rootRef?: Ref<HTMLDivElement>; surface?: "workspace" | "home";
   placeholder: string;
@@ -80,6 +87,7 @@ export function ComposerRichTextEditor({
   activeDescendantId,
   canSubmit,
   onSubmit,
+  onSubmitRefused,
   editorRef, rootRef, surface = "workspace",
   placeholder,
   disabled,
@@ -181,6 +189,7 @@ export function ComposerRichTextEditor({
       <ComposerBehaviorPlugin
         canSubmit={canSubmit}
         onSubmit={onSubmit}
+        onSubmitRefused={onSubmitRefused}
         onKeyDown={onKeyDown}
         onCommandKey={onCommandKey}
       />
@@ -315,9 +324,13 @@ function ComposerEditorBridge({
 function ComposerBehaviorPlugin({
   canSubmit,
   onSubmit,
+  onSubmitRefused,
   onKeyDown,
   onCommandKey,
-}: Pick<ComposerRichTextEditorProps, "canSubmit" | "onSubmit" | "onKeyDown" | "onCommandKey">) {
+}: Pick<
+  ComposerRichTextEditorProps,
+  "canSubmit" | "onSubmit" | "onSubmitRefused" | "onKeyDown" | "onCommandKey"
+>) {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
@@ -333,7 +346,10 @@ function ComposerBehaviorPlugin({
       }
       if (!plainEnter && !primaryEnter) return false;
       event.preventDefault();
-      if (!event.repeat && canSubmit) onSubmit();
+      if (!event.repeat) {
+        if (canSubmit) onSubmit();
+        else onSubmitRefused?.();
+      }
       return true;
     }, COMMAND_PRIORITY_HIGH);
     const unregisterTab = editor.registerCommand(KEY_TAB_COMMAND, (event) => {
@@ -351,7 +367,7 @@ function ComposerBehaviorPlugin({
       );
     }, COMMAND_PRIORITY_HIGH);
     return () => { unregisterEnter(); unregisterTab(); };
-  }, [canSubmit, editor, onCommandKey, onKeyDown, onSubmit]);
+  }, [canSubmit, editor, onCommandKey, onKeyDown, onSubmit, onSubmitRefused]);
 
   return null;
 }

--- a/apps/packages/product-client/src/copy/chat/chat-copy.ts
+++ b/apps/packages/product-client/src/copy/chat/chat-copy.ts
@@ -50,5 +50,10 @@ export const CHAT_PRE_MESSAGE_LABELS = {
 export const CHAT_MODEL_SELECTOR_LABELS = {
   empty: "Select model",
   unknownModel: "Unknown model",
+  // Genuinely no harnesses: there is nothing to have reported anything.
   noProviders: "No harnesses yet. Add one to get started.",
+  // Harnesses exist and answered — with nothing. A different fact, so a
+  // different sentence: telling a user with five agents installed that they
+  // have none sends them to fix the wrong thing.
+  observedEmpty: "Your agents reported no models yet.",
 } as const;

--- a/apps/packages/product-client/src/hooks/access/anyharness/agents/use-refetch-agent-launch-options-kind.ts
+++ b/apps/packages/product-client/src/hooks/access/anyharness/agents/use-refetch-agent-launch-options-kind.ts
@@ -1,0 +1,29 @@
+import {
+  anyHarnessAgentLaunchOptionsKey,
+  useAnyHarnessCacheScopeKey,
+  useAnyHarnessRuntimeContext,
+} from "@anyharness/sdk-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+/**
+ * Re-issues ONE fan-out kind's launch-option read.
+ *
+ * The list query is a `useQueries` combine, so its entries carry no `refetch`
+ * of their own — but they do share the per-kind cache entries of the
+ * single-kind query, and that key is the seam a failed kind can be re-asked
+ * through. Without this, a Retry offered because a FAN-OUT kind's read failed
+ * would re-ask the requested kind instead, and the notice would never clear.
+ */
+export function useRefetchAgentLaunchOptionsKind(): (harnessKind: string) => void {
+  const runtime = useAnyHarnessRuntimeContext();
+  const cacheScopeKey = useAnyHarnessCacheScopeKey();
+  const queryClient = useQueryClient();
+  const runtimeUrl = runtime.runtimeUrl?.trim() ?? "";
+  return useCallback((harnessKind: string) => {
+    void queryClient.refetchQueries({
+      queryKey: anyHarnessAgentLaunchOptionsKey(runtimeUrl, harnessKind, cacheScopeKey),
+      exact: true,
+    });
+  }, [cacheScopeKey, queryClient, runtimeUrl]);
+}

--- a/apps/packages/product-client/src/hooks/home/derived/home-model-selection.fixtures.tsx
+++ b/apps/packages/product-client/src/hooks/home/derived/home-model-selection.fixtures.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+/** Launch-options wire fixtures and the query host shared by the Home model
+ *  selection tests. Extracted so the suite stays under the line cap without
+ *  trimming the rationale on the assertions themselves. */
+
+export const LOCAL_TARGET = {
+  kind: "local",
+  sourceRoot: "/repo",
+  existingWorkspaceId: null,
+} as const;
+
+export const CLOUD_TARGET = {
+  kind: "cloud",
+  gitOwner: "owner",
+  gitRepoName: "repo",
+  baseBranch: "main",
+} as const;
+
+export function response() {
+  return {
+    harnessKind: "claude",
+    basisRevision: "basis-1",
+    revision: 2,
+    state: "observed",
+    probePhase: "idle",
+    options: {
+      models: [
+        { id: "fable", observedName: "Fable", observedDescription: null },
+        { id: "unknown-upstream", observedName: null, observedDescription: null },
+      ],
+      controls: [],
+      defaults: { modelId: "fable", controlValues: {} },
+    },
+    observedAt: "2026-08-19T00:00:00Z",
+    probeAttemptedAt: "2026-08-19T00:00:00Z",
+    probeFailureCode: null,
+    readiness: "ready",
+  };
+}
+
+export function codexResponse() {
+  return {
+    ...response(),
+    harnessKind: "codex",
+    options: {
+      models: [{ id: "gpt-5.6-sol", observedName: "GPT-5.6 Sol", observedDescription: null }],
+      controls: [],
+      defaults: { modelId: "gpt-5.6-sol", controlValues: {} },
+    },
+  };
+}
+
+export function entry(
+  harnessKind: string,
+  data: Record<string, unknown> | null,
+  flags?: { isPending?: boolean; isError?: boolean },
+) {
+  return {
+    harnessKind,
+    data,
+    isPending: flags?.isPending ?? false,
+    isError: flags?.isError ?? false,
+  };
+}
+
+/** Mutations must not retry: a refused probe has to stay refused so the
+ *  all-refused tally is reached. */
+export function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.test.tsx
@@ -533,6 +533,21 @@ describe("useHomeNextModelSelection", () => {
     expect(result.current.unsupportedHarnessKind).toBe("claude");
   });
 
+  it("withholds the unsupported harness from every gate but its own", () => {
+    // `agent_setup_required` shares the `agent_settings` action and means a
+    // DIFFERENT agent. Handing it the unsupported kind opened a pane that can
+    // never be set up while the agent actually needing login went unopened —
+    // the ordinary first-run state of any machine with one unsupported agent.
+    mocks.agents = [
+      { kind: "cursor", readiness: "unsupported" },
+      { kind: "claude", readiness: "login_required" },
+    ];
+    const { result } = renderSelection(LOCAL_TARGET);
+    expect(result.current.modelGate)
+      .toEqual({ kind: "blocked", reason: "agent_setup_required" });
+    expect(result.current.unsupportedHarnessKind).toBeNull();
+  });
+
   it("keeps a cloud sandbox that reported no models from claiming it has no agents", () => {
     // `observed_empty` is the one blocked state ruling 3 keeps the picker
     // ENABLED for, and an enabled picker labelled "No agents" is false: the

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   refetchKind: vi.fn(),
   refetchAgents: vi.fn(),
   refreshMutate: vi.fn(),
+  refreshIsError: false,
   otherEntries: [] as Array<{
     harnessKind: string;
     data: Record<string, unknown> | null;
@@ -49,7 +50,10 @@ vi.mock("#product/hooks/access/anyharness/agents/use-refetch-agent-launch-option
 }));
 
 vi.mock("@anyharness/sdk-react", () => ({
-  useRefreshHarnessLaunchOptionsMutation: () => ({ mutate: mocks.refreshMutate }),
+  useRefreshHarnessLaunchOptionsMutation: () => ({
+    mutate: mocks.refreshMutate,
+    isError: mocks.refreshIsError,
+  }),
 }));
 
 vi.mock("#product/hooks/agents/derived/use-agent-catalog", () => ({
@@ -83,6 +87,7 @@ describe("useHomeNextModelSelection", () => {
     mocks.refetchKind = vi.fn();
     mocks.refetchAgents = vi.fn();
     mocks.refreshMutate = vi.fn();
+    mocks.refreshIsError = false;
     mocks.otherEntries = [];
     mocks.agents = [];
     mocks.readyAgents = [];
@@ -391,6 +396,78 @@ describe("useHomeNextModelSelection", () => {
     });
     catalog.result.current.retryModelObservation();
     expect(mocks.refetchAgents).toHaveBeenCalled();
+  });
+
+  it.each([
+    ["a backed-off probe", { state: "detecting", probePhase: "backoff" }],
+    ["a runtime that owns no probe engine", { state: "detecting", probePhase: null }],
+    ["an observation with zero models", { state: "observed", probePhase: "idle" }],
+    ["a zero-model last_good_after_failure", { state: "last_good_after_failure", probePhase: "idle" }],
+  ])("fires a real probe for observation_idle reached via %s", (_label, overrides) => {
+    // Every one of these lands on `observation_idle` through the RESIDUAL arm,
+    // not the settled-unobserved one. They were promised a Refresh and handed
+    // a re-read of the same durable row, which can never change what it says.
+    mocks.agents = [{ kind: "claude", readiness: "ready" }];
+    mocks.readyAgents = [{ kind: "claude" }];
+    mocks.data = { ...response(), ...overrides, options: null };
+    const { result } = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+      launchTarget: LOCAL_TARGET,
+    }));
+    expect(result.current.modelGate).toEqual({
+      kind: "blocked",
+      reason: "observation_idle",
+    });
+    result.current.retryModelObservation();
+    expect(mocks.refreshMutate).toHaveBeenCalledWith("claude");
+    expect(mocks.refetch).not.toHaveBeenCalled();
+  });
+
+  it("re-reads the catalog when observation_idle has no kind to probe", () => {
+    // With no requested kind the single-kind query is DISABLED, so refetching
+    // it is a literal no-op: a permanent sentence and a button that does
+    // nothing. Only the catalog can produce a kind to probe.
+    useUserPreferencesStore.setState({
+      defaultChatAgentKind: "",
+      defaultChatModelIdByAgentKind: {},
+    });
+    const { result } = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+      launchTarget: LOCAL_TARGET,
+    }));
+    expect(result.current.modelGate).toEqual({
+      kind: "blocked",
+      reason: "observation_idle",
+    });
+    result.current.retryModelObservation();
+    expect(mocks.refetchAgents).toHaveBeenCalled();
+    expect(mocks.refetch).not.toHaveBeenCalled();
+  });
+
+  it("keeps the cloud check-again path on the generic target re-ask", () => {
+    // A cloud response carries no probePhase, so cloud always lands in the
+    // residual — and there the sandbox re-read genuinely IS the cure.
+    mocks.data = undefined;
+    const { result } = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+      launchTarget: CLOUD_TARGET,
+    }));
+    expect(result.current.modelGate).toEqual({
+      kind: "blocked",
+      reason: "observation_idle",
+    });
+    result.current.retryModelObservation();
+    expect(mocks.refetch).toHaveBeenCalled();
+    expect(mocks.refreshMutate).not.toHaveBeenCalled();
+  });
+
+  it("reports a refused refresh so the notice can stop repeating itself", () => {
+    mocks.refreshIsError = true;
+    const { result } = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+      launchTarget: LOCAL_TARGET,
+    }));
+    expect(result.current.retryRejected).toBe(true);
   });
 
   it("keeps a cloud sandbox that reported no models from claiming it has no agents", () => {

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.test.tsx
@@ -472,9 +472,9 @@ describe("useHomeNextModelSelection", () => {
 
   it("never carries a local refusal onto a cloud target", async () => {
     // Cloud never calls the mutation, so nothing there could clear a stale
-    // refusal. Two mechanisms stop it (the `!isCloudTarget` read mask and the
-    // reset of the counters on target kind); this proves the OUTCOME, not
-    // either alone — removing just one still passes, removing both fails.
+    // refusal. The `!isCloudTarget` read mask is now the ONLY mechanism —
+    // the counter reset that used to back it up was over-broad and is gone —
+    // so removing it alone is what this test fails on.
     mocks.agents = [{ kind: "claude", readiness: "ready" }];
     mocks.readyAgents = [{ kind: "claude" }];
     mocks.data = { ...response(), state: "observed", probePhase: "idle", options: null };
@@ -494,9 +494,11 @@ describe("useHomeNextModelSelection", () => {
     expect(view.result.current.retryRejected).toBe(false);
   });
 
-  it("drops a batch that settles after the target changed", async () => {
-    // Without the run-id guard, a late `allSettled` overwrites the reset and
-    // resurrects a refusal on a target nothing was ever asked of.
+  it("still reports a refusal owed from before the target flipped", async () => {
+    // The probe is keyed on `harnessKind` and is machine-global, so a
+    // local->cloud->local flip does not make an owed tally stale. Discarding
+    // it left a refused refresh with NO receipt at all, and the settled
+    // sentence rendering while the probes were still running.
     mocks.agents = [{ kind: "claude", readiness: "ready" }];
     mocks.readyAgents = [{ kind: "claude" }];
     mocks.data = { ...response(), state: "observed", probePhase: "idle", options: null };
@@ -513,7 +515,7 @@ describe("useHomeNextModelSelection", () => {
     view.rerender({ target: LOCAL_TARGET });
     await settleProbes(["refuse"]);
     expect(view.result.current.retryPending).toBe(false);
-    expect(view.result.current.retryRejected).toBe(false);
+    expect(view.result.current.retryRejected).toBe(true);
   });
 
   it("states an all-unsupported catalog terminally instead of offering a probe", () => {
@@ -526,6 +528,9 @@ describe("useHomeNextModelSelection", () => {
       kind: "blocked",
       reason: "agents_unsupported",
     });
+    // Navigation has to land on an agent that IS unsupported, or the notice's
+    // whole justification ("see which ones and why") is false.
+    expect(result.current.unsupportedHarnessKind).toBe("claude");
   });
 
   it("keeps a cloud sandbox that reported no models from claiming it has no agents", () => {

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.test.tsx
@@ -11,6 +11,8 @@ const mocks = vi.hoisted(() => ({
   targetIsLoading: false,
   targetIsError: false,
   refetch: vi.fn(),
+  refetchKind: vi.fn(),
+  refetchAgents: vi.fn(),
   refreshMutate: vi.fn(),
   otherEntries: [] as Array<{
     harnessKind: string;
@@ -42,6 +44,10 @@ vi.mock("#product/hooks/home/derived/use-home-target-agent-launch-options", () =
   useHomeTargetOtherAgentsLaunchOptions: () => mocks.otherEntries,
 }));
 
+vi.mock("#product/hooks/access/anyharness/agents/use-refetch-agent-launch-options-kind", () => ({
+  useRefetchAgentLaunchOptionsKind: () => mocks.refetchKind,
+}));
+
 vi.mock("@anyharness/sdk-react", () => ({
   useRefreshHarnessLaunchOptionsMutation: () => ({ mutate: mocks.refreshMutate }),
 }));
@@ -55,6 +61,7 @@ vi.mock("#product/hooks/agents/derived/use-agent-catalog", () => ({
     isLoading: mocks.agentsLoading,
     isError: mocks.agentsError,
     error: null,
+    refetch: mocks.refetchAgents,
   }),
 }));
 
@@ -73,6 +80,8 @@ describe("useHomeNextModelSelection", () => {
     mocks.targetIsLoading = false;
     mocks.targetIsError = false;
     mocks.refetch = vi.fn();
+    mocks.refetchKind = vi.fn();
+    mocks.refetchAgents = vi.fn();
     mocks.refreshMutate = vi.fn();
     mocks.otherEntries = [];
     mocks.agents = [];
@@ -209,7 +218,12 @@ describe("useHomeNextModelSelection", () => {
       modelSelectionOverride: null,
       launchTarget: CLOUD_TARGET,
     }));
-    expect(result.current.modelGate).toEqual({ kind: "blocked", reason: "querying" });
+    // Neither the local readiness nor the local catalog's failure reaches it:
+    // the honest answer is that nothing has looked at the sandbox yet.
+    expect(result.current.modelGate).toEqual({
+      kind: "blocked",
+      reason: "observation_idle",
+    });
   });
 
   it("keeps rows offered and nothing selected when no valid default resolves", () => {
@@ -308,6 +322,92 @@ describe("useHomeNextModelSelection", () => {
     });
     broken.result.current.retryModelObservation();
     expect(mocks.refetch).toHaveBeenCalled();
+  });
+
+  it("reports a settled unprobed harness as observation_idle and refreshes it", () => {
+    // A harness excluded from automatic probing answers `detecting` + `idle`
+    // and stays there. Nothing is in flight, so the cure is a NEW probe.
+    mocks.agents = [{ kind: "cursor", readiness: "ready" }];
+    mocks.readyAgents = [{ kind: "cursor" }];
+    useUserPreferencesStore.setState({
+      defaultChatAgentKind: "cursor",
+      defaultChatModelIdByAgentKind: {},
+    });
+    mocks.data = {
+      ...response(),
+      harnessKind: "cursor",
+      state: "detecting",
+      probePhase: "idle",
+      options: null,
+    };
+    const { result } = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+      launchTarget: LOCAL_TARGET,
+    }));
+    expect(result.current.modelGate).toEqual({
+      kind: "blocked",
+      reason: "observation_idle",
+    });
+    result.current.retryModelObservation();
+    expect(mocks.refreshMutate).toHaveBeenCalledWith("cursor");
+    expect(mocks.refetch).not.toHaveBeenCalled();
+  });
+
+  it("repairs the query that actually failed, not the one it can reach", () => {
+    // A FAN-OUT kind's read failed. Re-asking the requested kind would re-read
+    // an endpoint that was never the problem and leave the notice up.
+    mocks.agents = [
+      { kind: "claude", readiness: "ready" },
+      { kind: "codex", readiness: "ready" },
+    ];
+    mocks.readyAgents = [{ kind: "claude" }, { kind: "codex" }];
+    mocks.data = {
+      ...response(),
+      state: "observed_empty",
+      options: { models: [], controls: [], defaults: { modelId: null, controlValues: {} } },
+    };
+    mocks.otherEntries = [entry("codex", null, { isError: true })];
+    const fanout = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+      launchTarget: LOCAL_TARGET,
+    }));
+    fanout.result.current.retryModelObservation();
+    expect(mocks.refetchKind).toHaveBeenCalledWith("codex");
+    expect(mocks.refetch).not.toHaveBeenCalled();
+    fanout.unmount();
+
+    // The AGENT CATALOG's own read failed. It is a third query, and nothing in
+    // the launch-options family can repair it.
+    mocks.otherEntries = [];
+    mocks.data = undefined;
+    mocks.agentsError = true;
+    const catalog = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+      launchTarget: LOCAL_TARGET,
+    }));
+    expect(catalog.result.current.modelGate).toEqual({
+      kind: "blocked",
+      reason: "transport_error",
+    });
+    catalog.result.current.retryModelObservation();
+    expect(mocks.refetchAgents).toHaveBeenCalled();
+  });
+
+  it("keeps a cloud sandbox that reported no models from claiming it has no agents", () => {
+    // `observed_empty` is the one blocked state ruling 3 keeps the picker
+    // ENABLED for, and an enabled picker labelled "No agents" is false: the
+    // sandbox's agents are there, they reported nothing.
+    mocks.data = {
+      ...response(),
+      state: "observed_empty",
+      options: { models: [], controls: [], defaults: { modelId: null, controlValues: {} } },
+    };
+    const { result } = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+      launchTarget: CLOUD_TARGET,
+    }));
+    expect(result.current.modelGate).toEqual({ kind: "blocked", reason: "observed_empty" });
+    expect(result.current.hasKnownAgents).toBe(true);
   });
 
   it("reports observed_empty when the harness answered with no models", () => {

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.test.tsx
@@ -8,8 +8,22 @@ import { useHomeNextModelSelection } from "#product/hooks/home/derived/use-home-
 const mocks = vi.hoisted(() => ({
   args: null as Record<string, unknown> | null,
   data: undefined as Record<string, unknown> | undefined,
-  otherResponses: [] as Array<Record<string, unknown> | null>,
+  targetIsLoading: false,
+  targetIsError: false,
+  refetch: vi.fn(),
+  refreshMutate: vi.fn(),
+  otherEntries: [] as Array<{
+    harnessKind: string;
+    data: Record<string, unknown> | null;
+    isPending: boolean;
+    isError: boolean;
+  }>,
+  agents: [] as Array<{ kind: string; readiness: string }>,
   readyAgents: [] as Array<{ kind: string }>,
+  installingAgents: [] as Array<{ kind: string }>,
+  isReconciling: false,
+  agentsLoading: false,
+  agentsError: false,
   isTargetUnobserved: false,
 }));
 
@@ -18,25 +32,55 @@ vi.mock("#product/hooks/home/derived/use-home-target-agent-launch-options", () =
     mocks.args = args;
     return {
       data: mocks.data,
-      isLoading: false,
-      isError: false,
+      isLoading: mocks.targetIsLoading,
+      isError: mocks.targetIsError,
       error: null,
       isTargetUnobserved: mocks.isTargetUnobserved,
+      refetch: mocks.refetch,
     };
   },
-  useHomeTargetOtherAgentsLaunchOptions: () => mocks.otherResponses,
+  useHomeTargetOtherAgentsLaunchOptions: () => mocks.otherEntries,
+}));
+
+vi.mock("@anyharness/sdk-react", () => ({
+  useRefreshHarnessLaunchOptionsMutation: () => ({ mutate: mocks.refreshMutate }),
 }));
 
 vi.mock("#product/hooks/agents/derived/use-agent-catalog", () => ({
-  useAgentCatalog: () => ({ readyAgents: mocks.readyAgents, isLoading: false, isError: false, error: null }),
+  useAgentCatalog: () => ({
+    agents: mocks.agents,
+    readyAgents: mocks.readyAgents,
+    installingAgents: mocks.installingAgents,
+    isReconciling: mocks.isReconciling,
+    isLoading: mocks.agentsLoading,
+    isError: mocks.agentsError,
+    error: null,
+  }),
 }));
+
+const LOCAL_TARGET = { kind: "local", sourceRoot: "/repo", existingWorkspaceId: null } as const;
+const CLOUD_TARGET = {
+  kind: "cloud",
+  gitOwner: "owner",
+  gitRepoName: "repo",
+  baseBranch: "main",
+} as const;
 
 describe("useHomeNextModelSelection", () => {
   beforeEach(() => {
     mocks.args = null;
     mocks.data = undefined;
-    mocks.otherResponses = [];
+    mocks.targetIsLoading = false;
+    mocks.targetIsError = false;
+    mocks.refetch = vi.fn();
+    mocks.refreshMutate = vi.fn();
+    mocks.otherEntries = [];
+    mocks.agents = [];
     mocks.readyAgents = [];
+    mocks.installingAgents = [];
+    mocks.isReconciling = false;
+    mocks.agentsLoading = false;
+    mocks.agentsError = false;
     mocks.isTargetUnobserved = false;
     useUserPreferencesStore.setState({
       defaultChatAgentKind: "claude",
@@ -47,13 +91,12 @@ describe("useHomeNextModelSelection", () => {
 
   it("uses the exact observed default and keeps an unknown upstream id reachable", () => {
     mocks.data = response();
-    const launchTarget = { kind: "local", sourceRoot: "/repo", existingWorkspaceId: null } as const;
     const { result } = renderHook(() => useHomeNextModelSelection({
       modelSelectionOverride: null,
-      launchTarget,
+      launchTarget: LOCAL_TARGET,
     }));
-    expect(result.current.modelAvailabilityState).toBe("launchable");
-    expect(mocks.args).toEqual({ harnessKind: "claude", launchTarget });
+    expect(result.current.modelGate).toEqual({ kind: "launchable" });
+    expect(mocks.args).toEqual({ harnessKind: "claude", launchTarget: LOCAL_TARGET });
     expect(result.current.effectiveModelSelection).toEqual({ kind: "claude", modelId: "fable" });
     expect(result.current.modelGroups[0]?.models.map((model) => model.modelId)).toEqual([
       "fable",
@@ -64,11 +107,10 @@ describe("useHomeNextModelSelection", () => {
   it("keeps every other ready harness pickable from the launch composer", () => {
     mocks.data = response();
     mocks.readyAgents = [{ kind: "claude" }, { kind: "codex" }];
-    mocks.otherResponses = [codexResponse()];
-    const launchTarget = { kind: "local", sourceRoot: "/repo", existingWorkspaceId: null } as const;
+    mocks.otherEntries = [entry("codex", codexResponse())];
     const { result } = renderHook(() => useHomeNextModelSelection({
       modelSelectionOverride: null,
-      launchTarget,
+      launchTarget: LOCAL_TARGET,
     }));
     // Negative control against the cutover regression: the launch picker must
     // not collapse to the requested harness alone.
@@ -80,27 +122,22 @@ describe("useHomeNextModelSelection", () => {
   it("omits an unresolved other harness without failing the launch picker", () => {
     mocks.data = response();
     mocks.readyAgents = [{ kind: "claude" }, { kind: "codex" }];
-    mocks.otherResponses = [null];
+    mocks.otherEntries = [entry("codex", null, { isPending: true })];
     const { result } = renderHook(() => useHomeNextModelSelection({
       modelSelectionOverride: null,
-      launchTarget: { kind: "local", sourceRoot: "/repo", existingWorkspaceId: null },
+      launchTarget: LOCAL_TARGET,
     }));
     expect(result.current.modelGroups.map((group) => group.kind)).toEqual(["claude"]);
-    expect(result.current.modelAvailabilityState).toBe("launchable");
+    expect(result.current.modelGate).toEqual({ kind: "launchable" });
   });
 
   it("offers no explicit model before the target has an observation", () => {
     mocks.isTargetUnobserved = true;
     const { result } = renderHook(() => useHomeNextModelSelection({
       modelSelectionOverride: null,
-      launchTarget: {
-        kind: "cloud",
-        gitOwner: "owner",
-        gitRepoName: "repo",
-        baseBranch: "main",
-      },
+      launchTarget: CLOUD_TARGET,
     }));
-    expect(result.current.modelAvailabilityState).toBe("target_unobserved");
+    expect(result.current.modelGate).toEqual({ kind: "blocked", reason: "target_unobserved" });
     expect(result.current.effectiveModelSelection).toBeNull();
   });
 
@@ -109,10 +146,200 @@ describe("useHomeNextModelSelection", () => {
       modelSelectionOverride: null,
       launchTarget: null,
     }));
-    expect(result.current.modelAvailabilityState).toBe("no_launchable_model");
+    expect(result.current.modelGate).toEqual({ kind: "blocked", reason: "target_missing" });
     expect(result.current.effectiveModelSelection).toBeNull();
   });
+
+  // The two reasons PR B's list-hook flags exist to keep apart. `data === null`
+  // is identical in both; only isPending/isError separate them.
+  it("reads querying from a pending list entry and transport_error from a failed one", () => {
+    mocks.agents = [{ kind: "claude", readiness: "ready" }, { kind: "codex", readiness: "ready" }];
+    mocks.readyAgents = [{ kind: "claude" }, { kind: "codex" }];
+    mocks.otherEntries = [entry("codex", null, { isPending: true })];
+    const querying = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+      launchTarget: LOCAL_TARGET,
+    }));
+    expect(querying.result.current.modelGate).toEqual({ kind: "blocked", reason: "querying" });
+    querying.unmount();
+
+    mocks.otherEntries = [entry("codex", null, { isError: true })];
+    const failed = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+      launchTarget: LOCAL_TARGET,
+    }));
+    expect(failed.result.current.modelGate).toEqual({
+      kind: "blocked",
+      reason: "transport_error",
+    });
+  });
+
+  it("reads observation_pending from a running probe on the requested kind", () => {
+    mocks.agents = [{ kind: "claude", readiness: "ready" }];
+    mocks.readyAgents = [{ kind: "claude" }];
+    mocks.data = { ...response(), state: "detecting", probePhase: "running", options: null };
+    const { result } = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+      launchTarget: LOCAL_TARGET,
+    }));
+    expect(result.current.modelGate).toEqual({
+      kind: "blocked",
+      reason: "observation_pending",
+    });
+  });
+
+  it("reads agent_setup_required only from real install/login readiness", () => {
+    mocks.agents = [{ kind: "claude", readiness: "install_required" }];
+    const { result } = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+      launchTarget: LOCAL_TARGET,
+    }));
+    expect(result.current.modelGate).toEqual({
+      kind: "blocked",
+      reason: "agent_setup_required",
+    });
+  });
+
+  it("never lets a cloud target read the desktop catalog's readiness", () => {
+    // Local agents needing install would say agent_setup_required on a local
+    // target; on a cloud target they are a different machine's business.
+    mocks.agents = [{ kind: "claude", readiness: "install_required" }];
+    mocks.agentsError = true;
+    const { result } = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+      launchTarget: CLOUD_TARGET,
+    }));
+    expect(result.current.modelGate).toEqual({ kind: "blocked", reason: "querying" });
+  });
+
+  it("keeps rows offered and nothing selected when no valid default resolves", () => {
+    // Both defaults name models this target does not offer: the persisted user
+    // default AND the runtime's own observed default. Nothing exact resolves.
+    useUserPreferencesStore.setState({
+      defaultChatAgentKind: "claude",
+      defaultChatModelIdByAgentKind: { claude: "model-that-was-uninstalled" },
+    });
+    mocks.agents = [{ kind: "claude", readiness: "ready" }];
+    mocks.readyAgents = [{ kind: "claude" }];
+    mocks.data = {
+      ...response(),
+      options: {
+        ...response().options,
+        defaults: { modelId: "also-gone", controlValues: {} },
+      },
+    };
+    const { result } = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+      launchTarget: LOCAL_TARGET,
+    }));
+    // No first-model fallback: the rows stay on offer, the selection does not
+    // happen, and the gate says so.
+    expect(result.current.modelGate).toEqual({ kind: "selection_required" });
+    expect(result.current.effectiveModelSelection).toBeNull();
+    expect(result.current.modelGroups[0]?.models.map((model) => model.modelId)).toEqual([
+      "fable",
+      "unknown-upstream",
+    ]);
+    expect(result.current.modelGroups[0]?.models.some((model) => model.isSelected)).toBe(false);
+  });
+
+  it("stays selection_required when the preferred harness has not reported yet", () => {
+    // The Partial Ready wire: Grok observed two models, Claude still
+    // installing, the user's default kind is Claude. Grok's rows are offered
+    // and NOT auto-picked.
+    useUserPreferencesStore.setState({
+      defaultChatAgentKind: "claude",
+      defaultChatModelIdByAgentKind: {},
+    });
+    mocks.agents = [
+      { kind: "claude", readiness: "ready" },
+      { kind: "codex", readiness: "ready" },
+    ];
+    mocks.readyAgents = [{ kind: "claude" }, { kind: "codex" }];
+    mocks.data = { ...response(), state: "detecting", probePhase: "idle", options: null };
+    mocks.otherEntries = [entry("codex", codexResponse())];
+    const { result } = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+      launchTarget: LOCAL_TARGET,
+    }));
+    expect(result.current.modelGate).toEqual({ kind: "selection_required" });
+    expect(result.current.effectiveModelSelection).toBeNull();
+    expect(result.current.modelGroups.map((group) => group.kind)).toEqual(["codex"]);
+  });
+
+  it("keeps refreshing and last_good_after_failure launchable", () => {
+    for (const state of ["refreshing", "last_good_after_failure"] as const) {
+      mocks.data = { ...response(), state, probePhase: "running" };
+      const { result, unmount } = renderHook(() => useHomeNextModelSelection({
+        modelSelectionOverride: null,
+        launchTarget: LOCAL_TARGET,
+      }));
+      expect(result.current.modelGate).toEqual({ kind: "launchable" });
+      unmount();
+    }
+  });
+
+  it("requests a new probe for a failed observation and refetches otherwise", () => {
+    mocks.agents = [{ kind: "claude", readiness: "ready" }];
+    mocks.readyAgents = [{ kind: "claude" }];
+    mocks.data = { ...response(), state: "failed_without_observation", options: null };
+    const failed = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+      launchTarget: LOCAL_TARGET,
+    }));
+    expect(failed.result.current.modelGate).toEqual({
+      kind: "blocked",
+      reason: "observation_failed",
+    });
+    failed.result.current.retryModelObservation();
+    expect(mocks.refreshMutate).toHaveBeenCalledWith("claude");
+    expect(mocks.refetch).not.toHaveBeenCalled();
+    failed.unmount();
+
+    mocks.data = undefined;
+    mocks.targetIsError = true;
+    const broken = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+      launchTarget: LOCAL_TARGET,
+    }));
+    expect(broken.result.current.modelGate).toEqual({
+      kind: "blocked",
+      reason: "transport_error",
+    });
+    broken.result.current.retryModelObservation();
+    expect(mocks.refetch).toHaveBeenCalled();
+  });
+
+  it("reports observed_empty when the harness answered with no models", () => {
+    mocks.agents = [{ kind: "claude", readiness: "ready" }];
+    mocks.readyAgents = [{ kind: "claude" }];
+    mocks.data = {
+      ...response(),
+      state: "observed_empty",
+      options: { models: [], controls: [], defaults: { modelId: null, controlValues: {} } },
+    };
+    const { result } = renderHook(() => useHomeNextModelSelection({
+      modelSelectionOverride: null,
+      launchTarget: LOCAL_TARGET,
+    }));
+    expect(result.current.modelGate).toEqual({ kind: "blocked", reason: "observed_empty" });
+    // The catalog still knows the agent, so the picker keeps a truthful label.
+    expect(result.current.hasKnownAgents).toBe(true);
+  });
 });
+
+function entry(
+  harnessKind: string,
+  data: Record<string, unknown> | null,
+  flags?: { isPending?: boolean; isError?: boolean },
+) {
+  return {
+    harnessKind,
+    data,
+    isPending: flags?.isPending ?? false,
+    isError: flags?.isError ?? false,
+  };
+}
 
 function codexResponse() {
   return {
@@ -132,6 +359,7 @@ function response() {
     basisRevision: "basis-1",
     revision: 2,
     state: "observed",
+    probePhase: "idle",
     options: {
       models: [
         { id: "fable", observedName: "Fable", observedDescription: null },

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store";
 import { useHomeNextModelSelection } from "#product/hooks/home/derived/use-home-next-model-selection";
@@ -14,7 +14,10 @@ const mocks = vi.hoisted(() => ({
   refetchKind: vi.fn(),
   refetchAgents: vi.fn(),
   refreshMutate: vi.fn(),
-  refreshIsError: false,
+  refreshCalls: [] as Array<{
+    kind: string;
+    options?: { onSuccess?: () => void; onError?: () => void };
+  }>,
   otherEntries: [] as Array<{
     harnessKind: string;
     data: Record<string, unknown> | null;
@@ -50,10 +53,7 @@ vi.mock("#product/hooks/access/anyharness/agents/use-refetch-agent-launch-option
 }));
 
 vi.mock("@anyharness/sdk-react", () => ({
-  useRefreshHarnessLaunchOptionsMutation: () => ({
-    mutate: mocks.refreshMutate,
-    isError: mocks.refreshIsError,
-  }),
+  useRefreshHarnessLaunchOptionsMutation: () => ({ mutate: mocks.refreshMutate }),
 }));
 
 vi.mock("#product/hooks/agents/derived/use-agent-catalog", () => ({
@@ -77,6 +77,12 @@ const CLOUD_TARGET = {
   baseBranch: "main",
 } as const;
 
+type LaunchTarget = typeof LOCAL_TARGET | typeof CLOUD_TARGET | null;
+
+function renderSelection(launchTarget: LaunchTarget) {
+  return renderHook(() => useHomeNextModelSelection({ modelSelectionOverride: null, launchTarget }));
+}
+
 describe("useHomeNextModelSelection", () => {
   beforeEach(() => {
     mocks.args = null;
@@ -86,8 +92,10 @@ describe("useHomeNextModelSelection", () => {
     mocks.refetch = vi.fn();
     mocks.refetchKind = vi.fn();
     mocks.refetchAgents = vi.fn();
-    mocks.refreshMutate = vi.fn();
-    mocks.refreshIsError = false;
+    mocks.refreshCalls = [];
+    mocks.refreshMutate = vi.fn((kind: string, options?: Record<string, () => void>) => {
+      mocks.refreshCalls.push({ kind, options });
+    });
     mocks.otherEntries = [];
     mocks.agents = [];
     mocks.readyAgents = [];
@@ -105,10 +113,7 @@ describe("useHomeNextModelSelection", () => {
 
   it("uses the exact observed default and keeps an unknown upstream id reachable", () => {
     mocks.data = response();
-    const { result } = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: LOCAL_TARGET,
-    }));
+    const { result } = renderSelection(LOCAL_TARGET);
     expect(result.current.modelGate).toEqual({ kind: "launchable" });
     expect(mocks.args).toEqual({ harnessKind: "claude", launchTarget: LOCAL_TARGET });
     expect(result.current.effectiveModelSelection).toEqual({ kind: "claude", modelId: "fable" });
@@ -122,10 +127,7 @@ describe("useHomeNextModelSelection", () => {
     mocks.data = response();
     mocks.readyAgents = [{ kind: "claude" }, { kind: "codex" }];
     mocks.otherEntries = [entry("codex", codexResponse())];
-    const { result } = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: LOCAL_TARGET,
-    }));
+    const { result } = renderSelection(LOCAL_TARGET);
     // Negative control against the cutover regression: the launch picker must
     // not collapse to the requested harness alone.
     expect(result.current.modelGroups.map((group) => group.kind)).toEqual(["claude", "codex"]);
@@ -137,29 +139,20 @@ describe("useHomeNextModelSelection", () => {
     mocks.data = response();
     mocks.readyAgents = [{ kind: "claude" }, { kind: "codex" }];
     mocks.otherEntries = [entry("codex", null, { isPending: true })];
-    const { result } = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: LOCAL_TARGET,
-    }));
+    const { result } = renderSelection(LOCAL_TARGET);
     expect(result.current.modelGroups.map((group) => group.kind)).toEqual(["claude"]);
     expect(result.current.modelGate).toEqual({ kind: "launchable" });
   });
 
   it("offers no explicit model before the target has an observation", () => {
     mocks.isTargetUnobserved = true;
-    const { result } = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: CLOUD_TARGET,
-    }));
+    const { result } = renderSelection(CLOUD_TARGET);
     expect(result.current.modelGate).toEqual({ kind: "blocked", reason: "target_unobserved" });
     expect(result.current.effectiveModelSelection).toBeNull();
   });
 
   it("offers no explicit model when no launch target is selected", () => {
-    const { result } = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: null,
-    }));
+    const { result } = renderSelection(null);
     expect(result.current.modelGate).toEqual({ kind: "blocked", reason: "target_missing" });
     expect(result.current.effectiveModelSelection).toBeNull();
   });
@@ -170,18 +163,12 @@ describe("useHomeNextModelSelection", () => {
     mocks.agents = [{ kind: "claude", readiness: "ready" }, { kind: "codex", readiness: "ready" }];
     mocks.readyAgents = [{ kind: "claude" }, { kind: "codex" }];
     mocks.otherEntries = [entry("codex", null, { isPending: true })];
-    const querying = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: LOCAL_TARGET,
-    }));
+    const querying = renderSelection(LOCAL_TARGET);
     expect(querying.result.current.modelGate).toEqual({ kind: "blocked", reason: "querying" });
     querying.unmount();
 
     mocks.otherEntries = [entry("codex", null, { isError: true })];
-    const failed = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: LOCAL_TARGET,
-    }));
+    const failed = renderSelection(LOCAL_TARGET);
     expect(failed.result.current.modelGate).toEqual({
       kind: "blocked",
       reason: "transport_error",
@@ -192,10 +179,7 @@ describe("useHomeNextModelSelection", () => {
     mocks.agents = [{ kind: "claude", readiness: "ready" }];
     mocks.readyAgents = [{ kind: "claude" }];
     mocks.data = { ...response(), state: "detecting", probePhase: "running", options: null };
-    const { result } = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: LOCAL_TARGET,
-    }));
+    const { result } = renderSelection(LOCAL_TARGET);
     expect(result.current.modelGate).toEqual({
       kind: "blocked",
       reason: "observation_pending",
@@ -204,10 +188,7 @@ describe("useHomeNextModelSelection", () => {
 
   it("reads agent_setup_required only from real install/login readiness", () => {
     mocks.agents = [{ kind: "claude", readiness: "install_required" }];
-    const { result } = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: LOCAL_TARGET,
-    }));
+    const { result } = renderSelection(LOCAL_TARGET);
     expect(result.current.modelGate).toEqual({
       kind: "blocked",
       reason: "agent_setup_required",
@@ -219,10 +200,7 @@ describe("useHomeNextModelSelection", () => {
     // target; on a cloud target they are a different machine's business.
     mocks.agents = [{ kind: "claude", readiness: "install_required" }];
     mocks.agentsError = true;
-    const { result } = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: CLOUD_TARGET,
-    }));
+    const { result } = renderSelection(CLOUD_TARGET);
     // Neither the local readiness nor the local catalog's failure reaches it:
     // the honest answer is that nothing has looked at the sandbox yet.
     expect(result.current.modelGate).toEqual({
@@ -247,10 +225,7 @@ describe("useHomeNextModelSelection", () => {
         defaults: { modelId: "also-gone", controlValues: {} },
       },
     };
-    const { result } = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: LOCAL_TARGET,
-    }));
+    const { result } = renderSelection(LOCAL_TARGET);
     // No first-model fallback: the rows stay on offer, the selection does not
     // happen, and the gate says so.
     expect(result.current.modelGate).toEqual({ kind: "selection_required" });
@@ -277,10 +252,7 @@ describe("useHomeNextModelSelection", () => {
     mocks.readyAgents = [{ kind: "claude" }, { kind: "codex" }];
     mocks.data = { ...response(), state: "detecting", probePhase: "idle", options: null };
     mocks.otherEntries = [entry("codex", codexResponse())];
-    const { result } = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: LOCAL_TARGET,
-    }));
+    const { result } = renderSelection(LOCAL_TARGET);
     expect(result.current.modelGate).toEqual({ kind: "selection_required" });
     expect(result.current.effectiveModelSelection).toBeNull();
     expect(result.current.modelGroups.map((group) => group.kind)).toEqual(["codex"]);
@@ -289,10 +261,7 @@ describe("useHomeNextModelSelection", () => {
   it("keeps refreshing and last_good_after_failure launchable", () => {
     for (const state of ["refreshing", "last_good_after_failure"] as const) {
       mocks.data = { ...response(), state, probePhase: "running" };
-      const { result, unmount } = renderHook(() => useHomeNextModelSelection({
-        modelSelectionOverride: null,
-        launchTarget: LOCAL_TARGET,
-      }));
+      const { result, unmount } = renderSelection(LOCAL_TARGET);
       expect(result.current.modelGate).toEqual({ kind: "launchable" });
       unmount();
     }
@@ -302,25 +271,19 @@ describe("useHomeNextModelSelection", () => {
     mocks.agents = [{ kind: "claude", readiness: "ready" }];
     mocks.readyAgents = [{ kind: "claude" }];
     mocks.data = { ...response(), state: "failed_without_observation", options: null };
-    const failed = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: LOCAL_TARGET,
-    }));
+    const failed = renderSelection(LOCAL_TARGET);
     expect(failed.result.current.modelGate).toEqual({
       kind: "blocked",
       reason: "observation_failed",
     });
     failed.result.current.retryModelObservation();
-    expect(mocks.refreshMutate).toHaveBeenCalledWith("claude");
+    expect(mocks.refreshMutate).toHaveBeenCalledWith("claude", expect.anything());
     expect(mocks.refetch).not.toHaveBeenCalled();
     failed.unmount();
 
     mocks.data = undefined;
     mocks.targetIsError = true;
-    const broken = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: LOCAL_TARGET,
-    }));
+    const broken = renderSelection(LOCAL_TARGET);
     expect(broken.result.current.modelGate).toEqual({
       kind: "blocked",
       reason: "transport_error",
@@ -345,16 +308,13 @@ describe("useHomeNextModelSelection", () => {
       probePhase: "idle",
       options: null,
     };
-    const { result } = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: LOCAL_TARGET,
-    }));
+    const { result } = renderSelection(LOCAL_TARGET);
     expect(result.current.modelGate).toEqual({
       kind: "blocked",
       reason: "observation_idle",
     });
     result.current.retryModelObservation();
-    expect(mocks.refreshMutate).toHaveBeenCalledWith("cursor");
+    expect(mocks.refreshMutate).toHaveBeenCalledWith("cursor", expect.anything());
     expect(mocks.refetch).not.toHaveBeenCalled();
   });
 
@@ -372,10 +332,7 @@ describe("useHomeNextModelSelection", () => {
       options: { models: [], controls: [], defaults: { modelId: null, controlValues: {} } },
     };
     mocks.otherEntries = [entry("codex", null, { isError: true })];
-    const fanout = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: LOCAL_TARGET,
-    }));
+    const fanout = renderSelection(LOCAL_TARGET);
     fanout.result.current.retryModelObservation();
     expect(mocks.refetchKind).toHaveBeenCalledWith("codex");
     expect(mocks.refetch).not.toHaveBeenCalled();
@@ -386,10 +343,7 @@ describe("useHomeNextModelSelection", () => {
     mocks.otherEntries = [];
     mocks.data = undefined;
     mocks.agentsError = true;
-    const catalog = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: LOCAL_TARGET,
-    }));
+    const catalog = renderSelection(LOCAL_TARGET);
     expect(catalog.result.current.modelGate).toEqual({
       kind: "blocked",
       reason: "transport_error",
@@ -399,7 +353,9 @@ describe("useHomeNextModelSelection", () => {
   });
 
   it.each([
-    ["a backed-off probe", { state: "detecting", probePhase: "backoff" }],
+    // `probe_phase` forces queued/running for an in-flight row, so backoff can
+    // only arrive on a SETTLED one — `{detecting, backoff}` is not a wire shape.
+    ["a backed-off retry on a settled row", { state: "observed", probePhase: "backoff" }],
     ["a runtime that owns no probe engine", { state: "detecting", probePhase: null }],
     ["an observation with zero models", { state: "observed", probePhase: "idle" }],
     ["a zero-model last_good_after_failure", { state: "last_good_after_failure", probePhase: "idle" }],
@@ -410,16 +366,13 @@ describe("useHomeNextModelSelection", () => {
     mocks.agents = [{ kind: "claude", readiness: "ready" }];
     mocks.readyAgents = [{ kind: "claude" }];
     mocks.data = { ...response(), ...overrides, options: null };
-    const { result } = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: LOCAL_TARGET,
-    }));
+    const { result } = renderSelection(LOCAL_TARGET);
     expect(result.current.modelGate).toEqual({
       kind: "blocked",
       reason: "observation_idle",
     });
     result.current.retryModelObservation();
-    expect(mocks.refreshMutate).toHaveBeenCalledWith("claude");
+    expect(mocks.refreshMutate).toHaveBeenCalledWith("claude", expect.anything());
     expect(mocks.refetch).not.toHaveBeenCalled();
   });
 
@@ -431,10 +384,7 @@ describe("useHomeNextModelSelection", () => {
       defaultChatAgentKind: "",
       defaultChatModelIdByAgentKind: {},
     });
-    const { result } = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: LOCAL_TARGET,
-    }));
+    const { result } = renderSelection(LOCAL_TARGET);
     expect(result.current.modelGate).toEqual({
       kind: "blocked",
       reason: "observation_idle",
@@ -448,10 +398,7 @@ describe("useHomeNextModelSelection", () => {
     // A cloud response carries no probePhase, so cloud always lands in the
     // residual — and there the sandbox re-read genuinely IS the cure.
     mocks.data = undefined;
-    const { result } = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: CLOUD_TARGET,
-    }));
+    const { result } = renderSelection(CLOUD_TARGET);
     expect(result.current.modelGate).toEqual({
       kind: "blocked",
       reason: "observation_idle",
@@ -461,13 +408,72 @@ describe("useHomeNextModelSelection", () => {
     expect(mocks.refreshMutate).not.toHaveBeenCalled();
   });
 
-  it("reports a refused refresh so the notice can stop repeating itself", () => {
-    mocks.refreshIsError = true;
-    const { result } = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: LOCAL_TARGET,
-    }));
+  it("claims refusal only when nothing got through, and reports the wait", () => {
+    // One `useMutation` observer tracks only its last call, so reading `isError`
+    // off it made the claim depend on which kind finished last, not on truth.
+    mocks.agents = [
+      { kind: "claude", readiness: "ready" },
+      { kind: "codex", readiness: "ready" },
+    ];
+    mocks.readyAgents = [{ kind: "claude" }, { kind: "codex" }];
+    mocks.data = { ...response(), state: "observed", probePhase: "idle", options: null };
+    mocks.otherEntries = [entry("codex", { ...codexResponse(), state: "observed", options: null })];
+    const { result } = renderSelection(LOCAL_TARGET);
+    expect(result.current.retryPending).toBe(false);
+
+    act(() => result.current.retryModelObservation());
+    expect(mocks.refreshCalls.map((call) => call.kind)).toEqual(["claude", "codex"]);
+    // Still running: the settled sentence must not be rendered over live work.
+    expect(result.current.retryPending).toBe(true);
+    expect(result.current.retryRejected).toBe(false);
+
+    act(() => mocks.refreshCalls[0].options?.onError?.());
+    expect(result.current.retryPending).toBe(true);
+    act(() => mocks.refreshCalls[1].options?.onSuccess?.());
+    // One kind refused, one succeeded: the refresh DID something.
+    expect(result.current.retryPending).toBe(false);
+    expect(result.current.retryRejected).toBe(false);
+
+    act(() => result.current.retryModelObservation());
+    act(() => {
+      mocks.refreshCalls[2].options?.onError?.();
+      mocks.refreshCalls[3].options?.onError?.();
+    });
     expect(result.current.retryRejected).toBe(true);
+  });
+
+  it("never carries a local refusal onto a cloud target", () => {
+    // Cloud never calls the mutation, so nothing on that path could clear a
+    // stale refusal: it would be a permanent, uncurable false failure claim.
+    // Two mechanisms stop it (the `!isCloudTarget` scope and the reset on
+    // target kind) and this proves the OUTCOME, not either one alone: removing
+    // just one still passes, removing both fails.
+    mocks.agents = [{ kind: "claude", readiness: "ready" }];
+    mocks.readyAgents = [{ kind: "claude" }];
+    mocks.data = { ...response(), state: "observed", probePhase: "idle", options: null };
+    const view = renderHook(
+      ({ target }: { target: typeof LOCAL_TARGET | typeof CLOUD_TARGET }) =>
+        useHomeNextModelSelection({ modelSelectionOverride: null, launchTarget: target }),
+      { initialProps: { target: LOCAL_TARGET as typeof LOCAL_TARGET | typeof CLOUD_TARGET } },
+    );
+    act(() => view.result.current.retryModelObservation());
+    act(() => mocks.refreshCalls[0].options?.onError?.());
+    expect(view.result.current.retryRejected).toBe(true);
+
+    view.rerender({ target: CLOUD_TARGET });
+    expect(view.result.current.retryRejected).toBe(false);
+  });
+
+  it("states an all-unsupported catalog terminally instead of offering a probe", () => {
+    mocks.agents = [
+      { kind: "claude", readiness: "unsupported" },
+      { kind: "codex", readiness: "unsupported" },
+    ];
+    const { result } = renderSelection(LOCAL_TARGET);
+    expect(result.current.modelGate).toEqual({
+      kind: "blocked",
+      reason: "agents_unsupported",
+    });
   });
 
   it("keeps a cloud sandbox that reported no models from claiming it has no agents", () => {
@@ -479,10 +485,7 @@ describe("useHomeNextModelSelection", () => {
       state: "observed_empty",
       options: { models: [], controls: [], defaults: { modelId: null, controlValues: {} } },
     };
-    const { result } = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: CLOUD_TARGET,
-    }));
+    const { result } = renderSelection(CLOUD_TARGET);
     expect(result.current.modelGate).toEqual({ kind: "blocked", reason: "observed_empty" });
     expect(result.current.hasKnownAgents).toBe(true);
   });
@@ -495,10 +498,7 @@ describe("useHomeNextModelSelection", () => {
       state: "observed_empty",
       options: { models: [], controls: [], defaults: { modelId: null, controlValues: {} } },
     };
-    const { result } = renderHook(() => useHomeNextModelSelection({
-      modelSelectionOverride: null,
-      launchTarget: LOCAL_TARGET,
-    }));
+    const { result } = renderSelection(LOCAL_TARGET);
     expect(result.current.modelGate).toEqual({ kind: "blocked", reason: "observed_empty" });
     // The catalog still knows the agent, so the picker keeps a truthful label.
     expect(result.current.hasKnownAgents).toBe(true);

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.test.tsx
@@ -2,6 +2,14 @@
 
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CLOUD_TARGET,
+  LOCAL_TARGET,
+  codexResponse,
+  entry,
+  response,
+  wrapper,
+} from "#product/hooks/home/derived/home-model-selection.fixtures";
 import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store";
 import { useHomeNextModelSelection } from "#product/hooks/home/derived/use-home-next-model-selection";
 
@@ -13,11 +21,9 @@ const mocks = vi.hoisted(() => ({
   refetch: vi.fn(),
   refetchKind: vi.fn(),
   refetchAgents: vi.fn(),
-  refreshMutate: vi.fn(),
-  refreshCalls: [] as Array<{
-    kind: string;
-    options?: { onSuccess?: () => void; onError?: () => void };
-  }>,
+  refreshFn: vi.fn(),
+  // Settled by hand, one entry per real `mutateAsync` call.
+  refreshProbes: [] as Array<{ kind: string; succeed: () => void; refuse: () => void }>,
   otherEntries: [] as Array<{
     harnessKind: string;
     data: Record<string, unknown> | null;
@@ -52,9 +58,19 @@ vi.mock("#product/hooks/access/anyharness/agents/use-refetch-agent-launch-option
   useRefetchAgentLaunchOptionsKind: () => mocks.refetchKind,
 }));
 
-vi.mock("@anyharness/sdk-react", () => ({
-  useRefreshHarnessLaunchOptionsMutation: () => ({ mutate: mocks.refreshMutate }),
-}));
+// A REAL `useMutation`, not a hand-written stand-in. The previous mock let the
+// tests invoke all N per-call callbacks themselves, encoding a contract
+// react-query does not honour — one `#mutateOptions` slot means only the LAST
+// call's callbacks run — which hid a refresh that never stopped claiming to be
+// in flight.
+vi.mock("@anyharness/sdk-react", async () => {
+  const { useMutation } = await import("@tanstack/react-query");
+  return {
+    useRefreshHarnessLaunchOptionsMutation: () => useMutation({
+      mutationFn: (harnessKind: string) => mocks.refreshFn(harnessKind) as Promise<unknown>,
+    }),
+  };
+});
 
 vi.mock("#product/hooks/agents/derived/use-agent-catalog", () => ({
   useAgentCatalog: () => ({
@@ -69,18 +85,26 @@ vi.mock("#product/hooks/agents/derived/use-agent-catalog", () => ({
   }),
 }));
 
-const LOCAL_TARGET = { kind: "local", sourceRoot: "/repo", existingWorkspaceId: null } as const;
-const CLOUD_TARGET = {
-  kind: "cloud",
-  gitOwner: "owner",
-  gitRepoName: "repo",
-  baseBranch: "main",
-} as const;
-
 type LaunchTarget = typeof LOCAL_TARGET | typeof CLOUD_TARGET | null;
 
 function renderSelection(launchTarget: LaunchTarget) {
-  return renderHook(() => useHomeNextModelSelection({ modelSelectionOverride: null, launchTarget }));
+  return renderHook(
+    () => useHomeNextModelSelection({ modelSelectionOverride: null, launchTarget }),
+    { wrapper },
+  );
+}
+
+/** `mutationFn` runs in a microtask: a probe has not started synchronously
+ *  with the call that requested it. */
+async function startProbes(start: () => void) {
+  await act(async () => { start(); });
+}
+
+/** Settle every probe started so far and flush the batch's promise chain. */
+async function settleProbes(outcomes: Array<"succeed" | "refuse">) {
+  await act(async () => {
+    outcomes.forEach((outcome, i) => mocks.refreshProbes[i][outcome]());
+  });
 }
 
 describe("useHomeNextModelSelection", () => {
@@ -92,10 +116,14 @@ describe("useHomeNextModelSelection", () => {
     mocks.refetch = vi.fn();
     mocks.refetchKind = vi.fn();
     mocks.refetchAgents = vi.fn();
-    mocks.refreshCalls = [];
-    mocks.refreshMutate = vi.fn((kind: string, options?: Record<string, () => void>) => {
-      mocks.refreshCalls.push({ kind, options });
-    });
+    mocks.refreshProbes = [];
+    mocks.refreshFn = vi.fn((kind: string) => new Promise((resolve, reject) => {
+      mocks.refreshProbes.push({
+        kind,
+        succeed: () => resolve({ harnessKind: kind }),
+        refuse: () => reject(new Error("refresh refused")),
+      });
+    }));
     mocks.otherEntries = [];
     mocks.agents = [];
     mocks.readyAgents = [];
@@ -267,7 +295,7 @@ describe("useHomeNextModelSelection", () => {
     }
   });
 
-  it("requests a new probe for a failed observation and refetches otherwise", () => {
+  it("requests a new probe for a failed observation and refetches otherwise", async () => {
     mocks.agents = [{ kind: "claude", readiness: "ready" }];
     mocks.readyAgents = [{ kind: "claude" }];
     mocks.data = { ...response(), state: "failed_without_observation", options: null };
@@ -276,8 +304,8 @@ describe("useHomeNextModelSelection", () => {
       kind: "blocked",
       reason: "observation_failed",
     });
-    failed.result.current.retryModelObservation();
-    expect(mocks.refreshMutate).toHaveBeenCalledWith("claude", expect.anything());
+    await startProbes(() => failed.result.current.retryModelObservation());
+    expect(mocks.refreshFn).toHaveBeenCalledWith("claude");
     expect(mocks.refetch).not.toHaveBeenCalled();
     failed.unmount();
 
@@ -288,11 +316,11 @@ describe("useHomeNextModelSelection", () => {
       kind: "blocked",
       reason: "transport_error",
     });
-    broken.result.current.retryModelObservation();
+    await startProbes(() => broken.result.current.retryModelObservation());
     expect(mocks.refetch).toHaveBeenCalled();
   });
 
-  it("reports a settled unprobed harness as observation_idle and refreshes it", () => {
+  it("reports a settled unprobed harness as observation_idle and refreshes it", async () => {
     // A harness excluded from automatic probing answers `detecting` + `idle`
     // and stays there. Nothing is in flight, so the cure is a NEW probe.
     mocks.agents = [{ kind: "cursor", readiness: "ready" }];
@@ -313,12 +341,12 @@ describe("useHomeNextModelSelection", () => {
       kind: "blocked",
       reason: "observation_idle",
     });
-    result.current.retryModelObservation();
-    expect(mocks.refreshMutate).toHaveBeenCalledWith("cursor", expect.anything());
+    await startProbes(() => result.current.retryModelObservation());
+    expect(mocks.refreshFn).toHaveBeenCalledWith("cursor");
     expect(mocks.refetch).not.toHaveBeenCalled();
   });
 
-  it("repairs the query that actually failed, not the one it can reach", () => {
+  it("repairs the query that actually failed, not the one it can reach", async () => {
     // A FAN-OUT kind's read failed. Re-asking the requested kind would re-read
     // an endpoint that was never the problem and leave the notice up.
     mocks.agents = [
@@ -333,7 +361,7 @@ describe("useHomeNextModelSelection", () => {
     };
     mocks.otherEntries = [entry("codex", null, { isError: true })];
     const fanout = renderSelection(LOCAL_TARGET);
-    fanout.result.current.retryModelObservation();
+    await startProbes(() => fanout.result.current.retryModelObservation());
     expect(mocks.refetchKind).toHaveBeenCalledWith("codex");
     expect(mocks.refetch).not.toHaveBeenCalled();
     fanout.unmount();
@@ -348,7 +376,7 @@ describe("useHomeNextModelSelection", () => {
       kind: "blocked",
       reason: "transport_error",
     });
-    catalog.result.current.retryModelObservation();
+    await startProbes(() => catalog.result.current.retryModelObservation());
     expect(mocks.refetchAgents).toHaveBeenCalled();
   });
 
@@ -359,7 +387,7 @@ describe("useHomeNextModelSelection", () => {
     ["a runtime that owns no probe engine", { state: "detecting", probePhase: null }],
     ["an observation with zero models", { state: "observed", probePhase: "idle" }],
     ["a zero-model last_good_after_failure", { state: "last_good_after_failure", probePhase: "idle" }],
-  ])("fires a real probe for observation_idle reached via %s", (_label, overrides) => {
+  ])("fires a real probe for observation_idle reached via %s", async (_label, overrides) => {
     // Every one of these lands on `observation_idle` through the RESIDUAL arm,
     // not the settled-unobserved one. They were promised a Refresh and handed
     // a re-read of the same durable row, which can never change what it says.
@@ -371,12 +399,12 @@ describe("useHomeNextModelSelection", () => {
       kind: "blocked",
       reason: "observation_idle",
     });
-    result.current.retryModelObservation();
-    expect(mocks.refreshMutate).toHaveBeenCalledWith("claude", expect.anything());
+    await startProbes(() => result.current.retryModelObservation());
+    expect(mocks.refreshFn).toHaveBeenCalledWith("claude");
     expect(mocks.refetch).not.toHaveBeenCalled();
   });
 
-  it("re-reads the catalog when observation_idle has no kind to probe", () => {
+  it("re-reads the catalog when observation_idle has no kind to probe", async () => {
     // With no requested kind the single-kind query is DISABLED, so refetching
     // it is a literal no-op: a permanent sentence and a button that does
     // nothing. Only the catalog can produce a kind to probe.
@@ -389,12 +417,12 @@ describe("useHomeNextModelSelection", () => {
       kind: "blocked",
       reason: "observation_idle",
     });
-    result.current.retryModelObservation();
+    await startProbes(() => result.current.retryModelObservation());
     expect(mocks.refetchAgents).toHaveBeenCalled();
     expect(mocks.refetch).not.toHaveBeenCalled();
   });
 
-  it("keeps the cloud check-again path on the generic target re-ask", () => {
+  it("keeps the cloud check-again path on the generic target re-ask", async () => {
     // A cloud response carries no probePhase, so cloud always lands in the
     // residual — and there the sandbox re-read genuinely IS the cure.
     mocks.data = undefined;
@@ -403,12 +431,12 @@ describe("useHomeNextModelSelection", () => {
       kind: "blocked",
       reason: "observation_idle",
     });
-    result.current.retryModelObservation();
+    await startProbes(() => result.current.retryModelObservation());
     expect(mocks.refetch).toHaveBeenCalled();
-    expect(mocks.refreshMutate).not.toHaveBeenCalled();
+    expect(mocks.refreshFn).not.toHaveBeenCalled();
   });
 
-  it("claims refusal only when nothing got through, and reports the wait", () => {
+  it("claims refusal only when nothing got through, and reports the wait", async () => {
     // One `useMutation` observer tracks only its last call, so reading `isError`
     // off it made the claim depend on which kind finished last, not on truth.
     mocks.agents = [
@@ -421,46 +449,70 @@ describe("useHomeNextModelSelection", () => {
     const { result } = renderSelection(LOCAL_TARGET);
     expect(result.current.retryPending).toBe(false);
 
-    act(() => result.current.retryModelObservation());
-    expect(mocks.refreshCalls.map((call) => call.kind)).toEqual(["claude", "codex"]);
+    await startProbes(() => result.current.retryModelObservation());
+    expect(mocks.refreshProbes.map((probe) => probe.kind)).toEqual(["claude", "codex"]);
     // Still running: the settled sentence must not be rendered over live work.
     expect(result.current.retryPending).toBe(true);
     expect(result.current.retryRejected).toBe(false);
 
-    act(() => mocks.refreshCalls[0].options?.onError?.());
-    expect(result.current.retryPending).toBe(true);
-    act(() => mocks.refreshCalls[1].options?.onSuccess?.());
-    // One kind refused, one succeeded: the refresh DID something.
+    await settleProbes(["refuse", "succeed"]);
+    // Two kinds through ONE observer. Counting per-call callbacks stalled here
+    // at settled=1 of 2 and pinned "Refreshing your models…" permanently.
     expect(result.current.retryPending).toBe(false);
+    // One kind refused, one succeeded: the refresh DID something.
     expect(result.current.retryRejected).toBe(false);
 
-    act(() => result.current.retryModelObservation());
-    act(() => {
-      mocks.refreshCalls[2].options?.onError?.();
-      mocks.refreshCalls[3].options?.onError?.();
-    });
+    await startProbes(() => result.current.retryModelObservation());
+    expect(result.current.retryPending).toBe(true);
+    await settleProbes(["refuse", "refuse", "refuse", "refuse"]);
+    // All refused, and reachable at N=2 rather than only at N=1.
+    expect(result.current.retryPending).toBe(false);
     expect(result.current.retryRejected).toBe(true);
   });
 
-  it("never carries a local refusal onto a cloud target", () => {
-    // Cloud never calls the mutation, so nothing on that path could clear a
-    // stale refusal: it would be a permanent, uncurable false failure claim.
-    // Two mechanisms stop it (the `!isCloudTarget` scope and the reset on
-    // target kind) and this proves the OUTCOME, not either one alone: removing
-    // just one still passes, removing both fails.
+  it("never carries a local refusal onto a cloud target", async () => {
+    // Cloud never calls the mutation, so nothing there could clear a stale
+    // refusal. Two mechanisms stop it (the `!isCloudTarget` read mask and the
+    // reset of the counters on target kind); this proves the OUTCOME, not
+    // either alone — removing just one still passes, removing both fails.
     mocks.agents = [{ kind: "claude", readiness: "ready" }];
     mocks.readyAgents = [{ kind: "claude" }];
     mocks.data = { ...response(), state: "observed", probePhase: "idle", options: null };
     const view = renderHook(
       ({ target }: { target: typeof LOCAL_TARGET | typeof CLOUD_TARGET }) =>
         useHomeNextModelSelection({ modelSelectionOverride: null, launchTarget: target }),
-      { initialProps: { target: LOCAL_TARGET as typeof LOCAL_TARGET | typeof CLOUD_TARGET } },
+      {
+        initialProps: { target: LOCAL_TARGET as typeof LOCAL_TARGET | typeof CLOUD_TARGET },
+        wrapper,
+      },
     );
-    act(() => view.result.current.retryModelObservation());
-    act(() => mocks.refreshCalls[0].options?.onError?.());
+    await startProbes(() => view.result.current.retryModelObservation());
+    await settleProbes(["refuse"]);
     expect(view.result.current.retryRejected).toBe(true);
 
     view.rerender({ target: CLOUD_TARGET });
+    expect(view.result.current.retryRejected).toBe(false);
+  });
+
+  it("drops a batch that settles after the target changed", async () => {
+    // Without the run-id guard, a late `allSettled` overwrites the reset and
+    // resurrects a refusal on a target nothing was ever asked of.
+    mocks.agents = [{ kind: "claude", readiness: "ready" }];
+    mocks.readyAgents = [{ kind: "claude" }];
+    mocks.data = { ...response(), state: "observed", probePhase: "idle", options: null };
+    const view = renderHook(
+      ({ target }: { target: typeof LOCAL_TARGET | typeof CLOUD_TARGET }) =>
+        useHomeNextModelSelection({ modelSelectionOverride: null, launchTarget: target }),
+      {
+        initialProps: { target: LOCAL_TARGET as typeof LOCAL_TARGET | typeof CLOUD_TARGET },
+        wrapper,
+      },
+    );
+    await startProbes(() => view.result.current.retryModelObservation());
+    view.rerender({ target: CLOUD_TARGET });
+    view.rerender({ target: LOCAL_TARGET });
+    await settleProbes(["refuse"]);
+    expect(view.result.current.retryPending).toBe(false);
     expect(view.result.current.retryRejected).toBe(false);
   });
 
@@ -505,49 +557,3 @@ describe("useHomeNextModelSelection", () => {
   });
 });
 
-function entry(
-  harnessKind: string,
-  data: Record<string, unknown> | null,
-  flags?: { isPending?: boolean; isError?: boolean },
-) {
-  return {
-    harnessKind,
-    data,
-    isPending: flags?.isPending ?? false,
-    isError: flags?.isError ?? false,
-  };
-}
-
-function codexResponse() {
-  return {
-    ...response(),
-    harnessKind: "codex",
-    options: {
-      models: [{ id: "gpt-5.6-sol", observedName: "GPT-5.6 Sol", observedDescription: null }],
-      controls: [],
-      defaults: { modelId: "gpt-5.6-sol", controlValues: {} },
-    },
-  };
-}
-
-function response() {
-  return {
-    harnessKind: "claude",
-    basisRevision: "basis-1",
-    revision: 2,
-    state: "observed",
-    probePhase: "idle",
-    options: {
-      models: [
-        { id: "fable", observedName: "Fable", observedDescription: null },
-        { id: "unknown-upstream", observedName: null, observedDescription: null },
-      ],
-      controls: [],
-      defaults: { modelId: "fable", controlValues: {} },
-    },
-    observedAt: "2026-08-19T00:00:00Z",
-    probeAttemptedAt: "2026-08-19T00:00:00Z",
-    probeFailureCode: null,
-    readiness: "ready",
-  };
-}

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.ts
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import type {
   AgentAuthProbePhase,
@@ -30,6 +30,26 @@ import {
 import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store";
 
 const EMPTY_MODEL_REGISTRIES: ModelRegistry[] = [];
+
+interface RefreshAttempt {
+  attempted: number;
+  settled: number;
+  refused: number;
+}
+
+const IDLE_REFRESH_ATTEMPT: RefreshAttempt = { attempted: 0, settled: 0, refused: 0 };
+
+function isRefreshInFlight(attempt: RefreshAttempt): boolean {
+  return attempt.attempted > 0 && attempt.settled < attempt.attempted;
+}
+
+/** Refused only when NOTHING got through: one kind succeeding means the
+ * refresh did something, whatever another kind answered. */
+function isRefreshRefused(attempt: RefreshAttempt): boolean {
+  return attempt.attempted > 0
+    && attempt.settled === attempt.attempted
+    && attempt.refused === attempt.attempted;
+}
 
 interface UseHomeNextModelSelectionArgs {
   modelSelectionOverride: HomeNextModelSelection | null;
@@ -205,6 +225,22 @@ export function useHomeNextModelSelection({
     targetLaunchOptions.isTargetUnobserved,
   ]);
 
+  /**
+   * The outcome of the probes THIS notice's action started.
+   *
+   * Counted here rather than read off the mutation, because one `useMutation`
+   * observer tracks only its most recent call: fire two kinds, have one
+   * refused and one succeed, and `isError` reports whichever finished last.
+   * The user would be told the refresh was refused because of start order.
+   */
+  const [refreshAttempt, setRefreshAttempt] = useState(IDLE_REFRESH_ATTEMPT);
+  // A refusal belongs to the target it was refused on. Switching targets must
+  // not carry "Couldn't refresh your models." to a target nothing was ever
+  // asked of — and on cloud nothing can clear it, since cloud never probes.
+  const launchTargetKind = launchTarget?.kind ?? null;
+  useEffect(() => {
+    setRefreshAttempt(IDLE_REFRESH_ATTEMPT);
+  }, [launchTargetKind]);
   const refreshLaunchOptions = useRefreshHarnessLaunchOptionsMutation();
   const refetchTargetLaunchOptions = targetLaunchOptions.refetch;
   const refetchLaunchOptionsKind = useRefetchAgentLaunchOptionsKind();
@@ -246,13 +282,13 @@ export function useHomeNextModelSelection({
       void refetchAgents();
       return;
     }
+    const probeKinds: string[] = [];
     for (const observation of observations) {
       if (
         !isCloudTarget
         && (awaitsFirstProbe || observation.state === "failed_without_observation")
       ) {
-        refreshMutate(observation.harnessKind);
-        repaired = true;
+        probeKinds.push(observation.harnessKind);
         continue;
       }
       if (!observation.isError) {
@@ -262,6 +298,23 @@ export function useHomeNextModelSelection({
         refetchTargetLaunchOptions();
       } else {
         refetchLaunchOptionsKind(observation.harnessKind);
+      }
+      repaired = true;
+    }
+    if (probeKinds.length > 0) {
+      setRefreshAttempt({ attempted: probeKinds.length, settled: 0, refused: 0 });
+      for (const harnessKind of probeKinds) {
+        refreshMutate(harnessKind, {
+          onError: () => setRefreshAttempt((attempt) => ({
+            ...attempt,
+            settled: attempt.settled + 1,
+            refused: attempt.refused + 1,
+          })),
+          onSuccess: () => setRefreshAttempt((attempt) => ({
+            ...attempt,
+            settled: attempt.settled + 1,
+          })),
+        });
       }
       repaired = true;
     }
@@ -310,9 +363,14 @@ export function useHomeNextModelSelection({
     error: (isCloudTarget ? null : agentsQueryError) ?? targetLaunchOptions.error,
     modelGate,
     retryModelObservation,
-    /** The last refresh was REFUSED by the runtime. A rejection writes no
-     * durable state, so nothing else on screen would ever change. */
-    retryRejected: refreshLaunchOptions.isError,
+    /** A probe this notice started is still running. Serialized, up to 45s per
+     * kind, and the launch-options query does not poll a settled row — so
+     * without this the settled sentence is rendered over live work. */
+    retryPending: !isCloudTarget && isRefreshInFlight(refreshAttempt),
+    /** EVERY kind attempted was refused. A rejection writes no durable state,
+     * so nothing else on screen would ever change. Scoped to local: cloud
+     * never calls the mutation, so nothing there could clear it. */
+    retryRejected: !isCloudTarget && isRefreshRefused(refreshAttempt),
   };
 }
 

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.ts
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import type {
   AgentAuthProbePhase,
@@ -27,29 +27,14 @@ import {
   type HomeLaunchTarget,
   type HomeNextModelSelection,
 } from "#product/lib/domain/home/home-next-launch";
+import {
+  IDLE_REFRESH_ATTEMPT,
+  isRefreshInFlight,
+  isRefreshRefused,
+} from "#product/lib/domain/home/home-model-refresh-attempt";
 import { useUserPreferencesStore } from "#product/stores/preferences/user-preferences-store";
 
 const EMPTY_MODEL_REGISTRIES: ModelRegistry[] = [];
-
-interface RefreshAttempt {
-  attempted: number;
-  settled: number;
-  refused: number;
-}
-
-const IDLE_REFRESH_ATTEMPT: RefreshAttempt = { attempted: 0, settled: 0, refused: 0 };
-
-function isRefreshInFlight(attempt: RefreshAttempt): boolean {
-  return attempt.attempted > 0 && attempt.settled < attempt.attempted;
-}
-
-/** Refused only when NOTHING got through: one kind succeeding means the
- * refresh did something, whatever another kind answered. */
-function isRefreshRefused(attempt: RefreshAttempt): boolean {
-  return attempt.attempted > 0
-    && attempt.settled === attempt.attempted
-    && attempt.refused === attempt.attempted;
-}
 
 interface UseHomeNextModelSelectionArgs {
   modelSelectionOverride: HomeNextModelSelection | null;
@@ -228,23 +213,25 @@ export function useHomeNextModelSelection({
   /**
    * The outcome of the probes THIS notice's action started.
    *
-   * Counted here rather than read off the mutation, because one `useMutation`
-   * observer tracks only its most recent call: fire two kinds, have one
-   * refused and one succeed, and `isError` reports whichever finished last.
-   * The user would be told the refresh was refused because of start order.
+   * See `home-model-refresh-attempt` for why this is counted per attempt and
+   * attributed from `mutateAsync`'s promise rather than per-call callbacks.
    */
   const [refreshAttempt, setRefreshAttempt] = useState(IDLE_REFRESH_ATTEMPT);
   // A refusal belongs to the target it was refused on. Switching targets must
   // not carry "Couldn't refresh your models." to a target nothing was ever
   // asked of — and on cloud nothing can clear it, since cloud never probes.
   const launchTargetKind = launchTarget?.kind ?? null;
+  // Bumped by both the reset and each new batch, so a batch that settles after
+  // either one cannot write its stale tally over the current state.
+  const refreshRunId = useRef(0);
   useEffect(() => {
+    refreshRunId.current += 1;
     setRefreshAttempt(IDLE_REFRESH_ATTEMPT);
   }, [launchTargetKind]);
   const refreshLaunchOptions = useRefreshHarnessLaunchOptionsMutation();
   const refetchTargetLaunchOptions = targetLaunchOptions.refetch;
   const refetchLaunchOptionsKind = useRefetchAgentLaunchOptionsKind();
-  const refreshMutate = refreshLaunchOptions.mutate;
+  const refreshMutateAsync = refreshLaunchOptions.mutateAsync;
   /**
    * The cure behind every blocked notice's action (ruling 5: a state must
    * never disable the control that would cure it).
@@ -302,20 +289,24 @@ export function useHomeNextModelSelection({
       repaired = true;
     }
     if (probeKinds.length > 0) {
+      refreshRunId.current += 1;
+      const runId = refreshRunId.current;
       setRefreshAttempt({ attempted: probeKinds.length, settled: 0, refused: 0 });
-      for (const harnessKind of probeKinds) {
-        refreshMutate(harnessKind, {
-          onError: () => setRefreshAttempt((attempt) => ({
-            ...attempt,
-            settled: attempt.settled + 1,
-            refused: attempt.refused + 1,
-          })),
-          onSuccess: () => setRefreshAttempt((attempt) => ({
-            ...attempt,
-            settled: attempt.settled + 1,
-          })),
+      // `allSettled` never rejects, so a refused probe is a tally entry rather
+      // than an unhandled rejection. Probes are serialized runtime-side, so
+      // there is no partial-progress state worth rendering between them.
+      void Promise.allSettled(
+        probeKinds.map((harnessKind) => refreshMutateAsync(harnessKind)),
+      ).then((results) => {
+        if (refreshRunId.current !== runId) {
+          return;
+        }
+        setRefreshAttempt({
+          attempted: results.length,
+          settled: results.length,
+          refused: results.filter((result) => result.status === "rejected").length,
         });
-      }
+      });
       repaired = true;
     }
     if (hasCatalogError) {
@@ -335,7 +326,7 @@ export function useHomeNextModelSelection({
     refetchAgents,
     refetchLaunchOptionsKind,
     refetchTargetLaunchOptions,
-    refreshMutate,
+    refreshMutateAsync,
     requestedHarnessKind,
   ]);
 

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.ts
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.ts
@@ -16,7 +16,7 @@ import {
   type DesktopLaunchModelRegistry as ModelRegistry,
 } from "#product/lib/domain/agents/cloud-launch-catalog";
 import {
-  isSettledUnobservedHarness,
+  homeModelGateNeedsNewProbe,
   resolveHomeModelGate,
   type HomeModelGateObservation,
 } from "#product/lib/domain/home/home-model-gate";
@@ -213,26 +213,43 @@ export function useHomeNextModelSelection({
    * The cure behind every blocked notice's action (ruling 5: a state must
    * never disable the control that would cure it).
    *
-   * Three different things can be broken, and each needs its own repair aimed
+   * Four different things can be broken, and each needs its own repair aimed
    * at the query that actually failed — a Retry that re-asks something which
    * was never the problem leaves the notice on screen forever:
    *
-   *  - A harness that failed without an observation, or one that settled
-   *    without ever being probed, needs a NEW probe. Refetching would just
-   *    re-read the recorded failure, or re-read the same "nobody looked".
+   *  - A gate that says nothing has looked yet needs a NEW probe, for EVERY
+   *    kind it knows about. Keyed on the gate rather than re-derived from the
+   *    observations: `observation_idle` is reached from a settled-unobserved
+   *    harness AND from the residual, and a retry that re-tested only the
+   *    first arm's predicate promised a Refresh to a backed-off harness, a
+   *    non-owner runtime and a zero-model `last_good_after_failure` and then
+   *    delivered a re-read of the row that already said so.
+   *  - A harness that failed without an observation needs a new probe too;
+   *    refetching would just re-read the recorded failure.
    *  - A read that failed at the transport layer needs THAT read again: the
    *    requested kind through its own query, a fanned-out kind through its
    *    shared cache key.
    *  - The agent catalog's own read is a third query entirely, and it is the
    *    one `hasCatalogError` reports. Nothing else here touches it.
+   *
+   * Cloud is deliberately none of the above: a cloud response carries no
+   * `probePhase`, so a cloud target always lands in the residual, where
+   * re-asking the sandbox and its launch options genuinely IS the cure.
    */
   const retryModelObservation = useCallback(() => {
     let repaired = false;
+    const awaitsFirstProbe = !isCloudTarget && homeModelGateNeedsNewProbe(modelGate);
+    if (awaitsFirstProbe && observations.length === 0) {
+      // No kind to probe: the requested kind is null, which also means the
+      // single-kind query is DISABLED and refetching it is a no-op. The only
+      // thing that can produce a kind is the catalog.
+      void refetchAgents();
+      return;
+    }
     for (const observation of observations) {
       if (
         !isCloudTarget
-        && (observation.state === "failed_without_observation"
-          || isSettledUnobservedHarness(observation))
+        && (awaitsFirstProbe || observation.state === "failed_without_observation")
       ) {
         refreshMutate(observation.harnessKind);
         repaired = true;
@@ -260,6 +277,7 @@ export function useHomeNextModelSelection({
   }, [
     hasCatalogError,
     isCloudTarget,
+    modelGate,
     observations,
     refetchAgents,
     refetchLaunchOptionsKind,
@@ -292,6 +310,9 @@ export function useHomeNextModelSelection({
     error: (isCloudTarget ? null : agentsQueryError) ?? targetLaunchOptions.error,
     modelGate,
     retryModelObservation,
+    /** The last refresh was REFUSED by the runtime. A rejection writes no
+     * durable state, so nothing else on screen would ever change. */
+    retryRejected: refreshLaunchOptions.isError,
   };
 }
 

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.ts
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import type {
   AgentAuthProbePhase,
@@ -217,17 +217,12 @@ export function useHomeNextModelSelection({
    * attributed from `mutateAsync`'s promise rather than per-call callbacks.
    */
   const [refreshAttempt, setRefreshAttempt] = useState(IDLE_REFRESH_ATTEMPT);
-  // A refusal belongs to the target it was refused on. Switching targets must
-  // not carry "Couldn't refresh your models." to a target nothing was ever
-  // asked of — and on cloud nothing can clear it, since cloud never probes.
-  const launchTargetKind = launchTarget?.kind ?? null;
-  // Bumped by both the reset and each new batch, so a batch that settles after
-  // either one cannot write its stale tally over the current state.
-  const refreshRunId = useRef(0);
-  useEffect(() => {
-    refreshRunId.current += 1;
-    setRefreshAttempt(IDLE_REFRESH_ATTEMPT);
-  }, [launchTargetKind]);
+  // A refusal belongs to the target it was refused on, and the `!isCloudTarget`
+  // read mask below is what keeps it there. Resetting the counters on target
+  // kind as well was over-broad: the probe is keyed on `harnessKind` only and
+  // is machine-global, so a local->cloud->local flip discarded a tally that
+  // was still legitimately owed, leaving a refused refresh with NO receipt and
+  // the settled sentence rendering over probes that were still running.
   const refreshLaunchOptions = useRefreshHarnessLaunchOptionsMutation();
   const refetchTargetLaunchOptions = targetLaunchOptions.refetch;
   const refetchLaunchOptionsKind = useRefetchAgentLaunchOptionsKind();
@@ -289,8 +284,6 @@ export function useHomeNextModelSelection({
       repaired = true;
     }
     if (probeKinds.length > 0) {
-      refreshRunId.current += 1;
-      const runId = refreshRunId.current;
       setRefreshAttempt({ attempted: probeKinds.length, settled: 0, refused: 0 });
       // `allSettled` never rejects, so a refused probe is a tally entry rather
       // than an unhandled rejection. Probes are serialized runtime-side, so
@@ -298,9 +291,6 @@ export function useHomeNextModelSelection({
       void Promise.allSettled(
         probeKinds.map((harnessKind) => refreshMutateAsync(harnessKind)),
       ).then((results) => {
-        if (refreshRunId.current !== runId) {
-          return;
-        }
         setRefreshAttempt({
           attempted: results.length,
           settled: results.length,
@@ -357,6 +347,10 @@ export function useHomeNextModelSelection({
     /** A probe this notice started is still running. Serialized, up to 45s per
      * kind, and the launch-options query does not poll a settled row — so
      * without this the settled sentence is rendered over live work. */
+    /** The harness the terminal `agents_unsupported` notice should open. The
+     * gate knows the readiness list, so navigation lands on an agent that IS
+     * unsupported instead of a hardcoded pane that may report nothing. */
+    unsupportedHarnessKind: agents.find((agent) => agent.readiness === "unsupported")?.kind ?? null,
     retryPending: !isCloudTarget && isRefreshInFlight(refreshAttempt),
     /** EVERY kind attempted was refused. A rejection writes no durable state,
      * so nothing else on screen would ever change. Scoped to local: cloud

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.ts
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.ts
@@ -1,5 +1,10 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
+import type {
+  AgentAuthProbePhase,
+  HarnessLaunchOptionsState,
+} from "@anyharness/sdk";
+import { useRefreshHarnessLaunchOptionsMutation } from "@anyharness/sdk-react";
 import { useAgentCatalog } from "#product/hooks/agents/derived/use-agent-catalog";
 import {
   useHomeTargetAgentLaunchOptions,
@@ -10,8 +15,11 @@ import {
   type DesktopLaunchModelRegistry as ModelRegistry,
 } from "#product/lib/domain/agents/cloud-launch-catalog";
 import {
+  resolveHomeModelGate,
+  type HomeModelGateObservation,
+} from "#product/lib/domain/home/home-model-gate";
+import {
   buildHomeNextModelGroups,
-  resolveHomeModelAvailabilityState,
   resolveEffectiveHomeModelSelection,
   resolveHomeNextModelInfo,
   type HomeLaunchTarget,
@@ -31,10 +39,13 @@ export function useHomeNextModelSelection({
   launchTarget,
 }: UseHomeNextModelSelectionArgs) {
   const {
+    agents,
     readyAgents,
     isLoading: agentsLoading,
     isError: agentsError,
     error: agentsQueryError,
+    isReconciling,
+    installingAgents,
   } = useAgentCatalog();
   const preferences = useUserPreferencesStore(useShallow((state) => ({
     defaultChatAgentKind: state.defaultChatAgentKind,
@@ -63,7 +74,10 @@ export function useHomeNextModelSelection({
   });
   const modelRegistries = useMemo(
     () => {
-      const registries = [targetLaunchOptions.data, ...otherLaunchOptions]
+      const registries = [
+        targetLaunchOptions.data,
+        ...otherLaunchOptions.map((entry) => entry.data),
+      ]
         .flatMap((response) => {
           const agent = response ? projectHarnessLaunchOptions(response) : null;
           return agent ? [{
@@ -112,34 +126,135 @@ export function useHomeNextModelSelection({
     [effectiveModelSelection, modelGroups, modelRegistries],
   );
 
-  const isLoading =
-    (launchTarget?.kind === "cloud" ? false : agentsLoading)
-    || targetLaunchOptions.isLoading;
-  const hasLoadError =
-    (launchTarget?.kind === "cloud" ? false : agentsError)
-    || targetLaunchOptions.isError;
-  const hasLaunchableModel =
-    modelGroups.length > 0
-    && effectiveModelSelection !== null
-    && selectedModel !== null;
-  const modelAvailabilityState = useMemo(() => (
-    targetLaunchOptions.isTargetUnobserved
-      ? "target_unobserved" as const
-      : resolveHomeModelAvailabilityState({
-        isLoading,
-        hasLoadError,
-        hasLaunchableModel,
-      })
-  ), [hasLoadError, hasLaunchableModel, isLoading, targetLaunchOptions.isTargetUnobserved]);
+  // One observation row per launch-option read the target actually performed.
+  // The requested kind is folded in from its own query; the fan-out kinds come
+  // from the list query, whose per-kind flags are what keep `querying` and
+  // `transport_error` apart. Cloud responses carry no `probePhase` — a cloud
+  // target's probe engine is not this client's to report on.
+  const observations = useMemo<HomeModelGateObservation[]>(() => {
+    const rows: HomeModelGateObservation[] = [];
+    if (requestedHarnessKind) {
+      rows.push({
+        harnessKind: requestedHarnessKind,
+        state: launchOptionsState(targetLaunchOptions.data),
+        probePhase: launchOptionsProbePhase(targetLaunchOptions.data),
+        isPending: targetLaunchOptions.isLoading,
+        isError: targetLaunchOptions.isError,
+      });
+    }
+    for (const entry of otherLaunchOptions) {
+      rows.push({
+        harnessKind: entry.harnessKind,
+        state: launchOptionsState(entry.data),
+        probePhase: launchOptionsProbePhase(entry.data),
+        isPending: entry.isPending,
+        isError: entry.isError,
+      });
+    }
+    return rows;
+  }, [
+    otherLaunchOptions,
+    requestedHarnessKind,
+    targetLaunchOptions.data,
+    targetLaunchOptions.isError,
+    targetLaunchOptions.isLoading,
+  ]);
+
+  const isCloudTarget = launchTarget?.kind === "cloud";
+  const agentReadiness = useMemo(
+    // A cloud launch runs against the sandbox's agents, so the desktop
+    // catalog's readiness says nothing about it and must not block it.
+    () => (isCloudTarget ? [] : agents.map((agent) => agent.readiness)),
+    [agents, isCloudTarget],
+  );
+  const offeredModelCount = useMemo(
+    () => modelGroups.reduce((count, group) => count + group.models.length, 0),
+    [modelGroups],
+  );
+  const modelGate = useMemo(() => resolveHomeModelGate({
+    hasLaunchTarget: launchTarget !== null,
+    isTargetUnobserved: targetLaunchOptions.isTargetUnobserved,
+    // Both halves are required: a persisted default naming a model this target
+    // never observed resolves to nothing, and the gate must then keep offering
+    // the rows it does have rather than silently substituting one of them.
+    hasExactSelection: effectiveModelSelection !== null && selectedModel !== null,
+    offeredModelCount,
+    observations,
+    agentReadiness,
+    isInstalling: !isCloudTarget && (isReconciling || installingAgents.length > 0),
+    isCatalogLoading: !isCloudTarget && agentsLoading,
+    hasCatalogError: !isCloudTarget && agentsError,
+  }), [
+    agentReadiness,
+    agentsError,
+    agentsLoading,
+    effectiveModelSelection,
+    installingAgents.length,
+    isCloudTarget,
+    isReconciling,
+    launchTarget,
+    observations,
+    offeredModelCount,
+    selectedModel,
+    targetLaunchOptions.isTargetUnobserved,
+  ]);
+
+  const refreshLaunchOptions = useRefreshHarnessLaunchOptionsMutation();
+  const refetchTargetLaunchOptions = targetLaunchOptions.refetch;
+  const refreshMutate = refreshLaunchOptions.mutate;
+  /**
+   * The cure behind every blocked notice's action (ruling 5: a state must
+   * never disable the control that would cure it).
+   *
+   * A harness that failed without an observation needs a NEW probe — refetching
+   * would just re-read the recorded failure — while a request that never landed
+   * needs the request again.
+   */
+  const retryModelObservation = useCallback(() => {
+    const failedKinds = observations
+      .filter((observation) => observation.state === "failed_without_observation")
+      .map((observation) => observation.harnessKind);
+    if (!isCloudTarget && failedKinds.length > 0) {
+      for (const harnessKind of failedKinds) {
+        refreshMutate(harnessKind);
+      }
+      return;
+    }
+    refetchTargetLaunchOptions();
+  }, [isCloudTarget, observations, refetchTargetLaunchOptions, refreshMutate]);
 
   return {
     modelGroups,
     modelRegistries,
     effectiveModelSelection,
     selectedModel,
-    isLoading,
-    error: (launchTarget?.kind === "cloud" ? null : agentsQueryError)
-      ?? targetLaunchOptions.error,
-    modelAvailabilityState,
+    /** True only while the AGENT CATALOG's own HTTP read is in flight. Never
+     * an install and never a probe — the trigger label depends on the
+     * difference. */
+    isCatalogLoading: !isCloudTarget && agentsLoading,
+    /** The catalog knows of at least one agent. Independent of whether any of
+     * them has reported models yet. */
+    hasKnownAgents: isCloudTarget ? modelGroups.length > 0 : agents.length > 0,
+    error: (isCloudTarget ? null : agentsQueryError) ?? targetLaunchOptions.error,
+    modelGate,
+    retryModelObservation,
   };
+}
+
+function launchOptionsState(
+  response: { state: string } | null | undefined,
+): HarnessLaunchOptionsState | null {
+  return (response?.state as HarnessLaunchOptionsState | undefined) ?? null;
+}
+
+function launchOptionsProbePhase(
+  response: object | null | undefined,
+): AgentAuthProbePhase | null {
+  // The cloud response type has no `probePhase` at all: a cloud sandbox's
+  // probe scheduler is not this client's to report on, so it reads as absent
+  // rather than as a settled `idle`.
+  if (!response || !("probePhase" in response)) {
+    return null;
+  }
+  return (response as { probePhase?: AgentAuthProbePhase | null }).probePhase ?? null;
 }

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.ts
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.ts
@@ -6,6 +6,7 @@ import type {
 } from "@anyharness/sdk";
 import { useRefreshHarnessLaunchOptionsMutation } from "@anyharness/sdk-react";
 import { useAgentCatalog } from "#product/hooks/agents/derived/use-agent-catalog";
+import { useRefetchAgentLaunchOptionsKind } from "#product/hooks/access/anyharness/agents/use-refetch-agent-launch-options-kind";
 import {
   useHomeTargetAgentLaunchOptions,
   useHomeTargetOtherAgentsLaunchOptions,
@@ -15,6 +16,7 @@ import {
   type DesktopLaunchModelRegistry as ModelRegistry,
 } from "#product/lib/domain/agents/cloud-launch-catalog";
 import {
+  isSettledUnobservedHarness,
   resolveHomeModelGate,
   type HomeModelGateObservation,
 } from "#product/lib/domain/home/home-model-gate";
@@ -46,6 +48,7 @@ export function useHomeNextModelSelection({
     error: agentsQueryError,
     isReconciling,
     installingAgents,
+    refetch: refetchAgents,
   } = useAgentCatalog();
   const preferences = useUserPreferencesStore(useShallow((state) => ({
     defaultChatAgentKind: state.defaultChatAgentKind,
@@ -161,6 +164,9 @@ export function useHomeNextModelSelection({
   ]);
 
   const isCloudTarget = launchTarget?.kind === "cloud";
+  // The agent catalog is a different query from every launch-option read, so
+  // its failure is a different thing to repair.
+  const hasCatalogError = !isCloudTarget && agentsError;
   const agentReadiness = useMemo(
     // A cloud launch runs against the sandbox's agents, so the desktop
     // catalog's readiness says nothing about it and must not block it.
@@ -183,11 +189,11 @@ export function useHomeNextModelSelection({
     agentReadiness,
     isInstalling: !isCloudTarget && (isReconciling || installingAgents.length > 0),
     isCatalogLoading: !isCloudTarget && agentsLoading,
-    hasCatalogError: !isCloudTarget && agentsError,
+    hasCatalogError,
   }), [
     agentReadiness,
-    agentsError,
     agentsLoading,
+    hasCatalogError,
     effectiveModelSelection,
     installingAgents.length,
     isCloudTarget,
@@ -201,27 +207,66 @@ export function useHomeNextModelSelection({
 
   const refreshLaunchOptions = useRefreshHarnessLaunchOptionsMutation();
   const refetchTargetLaunchOptions = targetLaunchOptions.refetch;
+  const refetchLaunchOptionsKind = useRefetchAgentLaunchOptionsKind();
   const refreshMutate = refreshLaunchOptions.mutate;
   /**
    * The cure behind every blocked notice's action (ruling 5: a state must
    * never disable the control that would cure it).
    *
-   * A harness that failed without an observation needs a NEW probe — refetching
-   * would just re-read the recorded failure — while a request that never landed
-   * needs the request again.
+   * Three different things can be broken, and each needs its own repair aimed
+   * at the query that actually failed — a Retry that re-asks something which
+   * was never the problem leaves the notice on screen forever:
+   *
+   *  - A harness that failed without an observation, or one that settled
+   *    without ever being probed, needs a NEW probe. Refetching would just
+   *    re-read the recorded failure, or re-read the same "nobody looked".
+   *  - A read that failed at the transport layer needs THAT read again: the
+   *    requested kind through its own query, a fanned-out kind through its
+   *    shared cache key.
+   *  - The agent catalog's own read is a third query entirely, and it is the
+   *    one `hasCatalogError` reports. Nothing else here touches it.
    */
   const retryModelObservation = useCallback(() => {
-    const failedKinds = observations
-      .filter((observation) => observation.state === "failed_without_observation")
-      .map((observation) => observation.harnessKind);
-    if (!isCloudTarget && failedKinds.length > 0) {
-      for (const harnessKind of failedKinds) {
-        refreshMutate(harnessKind);
+    let repaired = false;
+    for (const observation of observations) {
+      if (
+        !isCloudTarget
+        && (observation.state === "failed_without_observation"
+          || isSettledUnobservedHarness(observation))
+      ) {
+        refreshMutate(observation.harnessKind);
+        repaired = true;
+        continue;
       }
-      return;
+      if (!observation.isError) {
+        continue;
+      }
+      if (observation.harnessKind === requestedHarnessKind) {
+        refetchTargetLaunchOptions();
+      } else {
+        refetchLaunchOptionsKind(observation.harnessKind);
+      }
+      repaired = true;
     }
-    refetchTargetLaunchOptions();
-  }, [isCloudTarget, observations, refetchTargetLaunchOptions, refreshMutate]);
+    if (hasCatalogError) {
+      void refetchAgents();
+      repaired = true;
+    }
+    // Nothing named itself: the cloud "Check again", whose whole story is that
+    // the target has not answered at all, so re-asking the target IS the cure.
+    if (!repaired) {
+      refetchTargetLaunchOptions();
+    }
+  }, [
+    hasCatalogError,
+    isCloudTarget,
+    observations,
+    refetchAgents,
+    refetchLaunchOptionsKind,
+    refetchTargetLaunchOptions,
+    refreshMutate,
+    requestedHarnessKind,
+  ]);
 
   return {
     modelGroups,
@@ -233,8 +278,17 @@ export function useHomeNextModelSelection({
      * difference. */
     isCatalogLoading: !isCloudTarget && agentsLoading,
     /** The catalog knows of at least one agent. Independent of whether any of
-     * them has reported models yet. */
-    hasKnownAgents: isCloudTarget ? modelGroups.length > 0 : agents.length > 0,
+     * them has reported models yet.
+     *
+     * A cloud sandbox's agents are not in the desktop catalog, so their
+     * existence has to come from the sandbox's own answer — the presence of a
+     * response, not the rows in it. Reading it off `modelGroups.length` said
+     * "No agents" for an `observed_empty` sandbox, which is exactly the state
+     * ruling 3 keeps the picker ENABLED for, and which is false: the agents
+     * are there, they reported nothing. */
+    hasKnownAgents: isCloudTarget
+      ? targetLaunchOptions.data !== undefined
+      : agents.length > 0,
     error: (isCloudTarget ? null : agentsQueryError) ?? targetLaunchOptions.error,
     modelGate,
     retryModelObservation,

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.ts
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-model-selection.ts
@@ -255,6 +255,12 @@ export function useHomeNextModelSelection({
    * re-asking the sandbox and its launch options genuinely IS the cure.
    */
   const retryModelObservation = useCallback(() => {
+    // The door on overlapping batches. Disabling the control was tried and was
+    // worse: it removes the only affordance on a state with no guaranteed
+    // exit, so a refresh that never settles leaves nothing to press.
+    if (isRefreshInFlight(refreshAttempt)) {
+      return;
+    }
     let repaired = false;
     const awaitsFirstProbe = !isCloudTarget && homeModelGateNeedsNewProbe(modelGate);
     if (awaitsFirstProbe && observations.length === 0) {
@@ -316,6 +322,7 @@ export function useHomeNextModelSelection({
     refetchAgents,
     refetchLaunchOptionsKind,
     refetchTargetLaunchOptions,
+    refreshAttempt,
     refreshMutateAsync,
     requestedHarnessKind,
   ]);
@@ -347,10 +354,14 @@ export function useHomeNextModelSelection({
     /** A probe this notice started is still running. Serialized, up to 45s per
      * kind, and the launch-options query does not poll a settled row — so
      * without this the settled sentence is rendered over live work. */
-    /** The harness the terminal `agents_unsupported` notice should open. The
-     * gate knows the readiness list, so navigation lands on an agent that IS
-     * unsupported instead of a hardcoded pane that may report nothing. */
-    unsupportedHarnessKind: agents.find((agent) => agent.readiness === "unsupported")?.kind ?? null,
+    /** The harness the terminal `agents_unsupported` notice should open, and
+     * `null` for every other gate — including `agent_setup_required`, which
+     * shares the `agent_settings` action but means a DIFFERENT agent: the one
+     * needing login, never the unsupported one. Bound to the gate here so the
+     * wrong pairing cannot be expressed by a caller at all. */
+    unsupportedHarnessKind: modelGate.kind === "blocked" && modelGate.reason === "agents_unsupported"
+      ? agents.find((agent) => agent.readiness === "unsupported")?.kind ?? null
+      : null,
     retryPending: !isCloudTarget && isRefreshInFlight(refreshAttempt),
     /** EVERY kind attempted was refused. A rejection writes no durable state,
      * so nothing else on screen would ever change. Scoped to local: cloud

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-state.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-state.test.tsx
@@ -164,10 +164,10 @@ describe("useHomeNextState", () => {
       stateMocks.model.modelGate = modelGate;
       const { result, unmount } = renderHomeNextState();
 
+      // `toBeNull()` is the whole assertion: it dominates any not.toBe on the
+      // same value, and the three literals that used to follow it appear
+      // nowhere in the repo, so no render could ever have failed them.
       expect(result.current.targetDisabledReason).toBeNull();
-      expect(result.current.targetDisabledReason).not.toBe("Loading models");
-      expect(result.current.targetDisabledReason).not.toBe("Couldn't load models");
-      expect(result.current.targetDisabledReason).not.toBe("No ready models");
 
       unmount();
     }

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-next-state.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-next-state.test.tsx
@@ -2,10 +2,13 @@
 
 import { cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  HOME_MODEL_GATE_BLOCKED_REASONS,
+  type HomeModelGate,
+} from "#product/lib/domain/home/home-model-gate";
 import type {
   HomeNextDestination,
   HomeNextRepoLaunchKind,
-  ModelAvailabilityState,
 } from "#product/lib/domain/home/home-next-launch";
 import { useHomeNextState } from "#product/hooks/home/derived/use-home-next-state";
 
@@ -15,9 +18,11 @@ const stateMocks = vi.hoisted(() => {
     modelRegistries: [],
     effectiveModelSelection: { kind: "codex", modelId: "gpt-5.4" },
     selectedModel: null,
-    isLoading: false,
+    isCatalogLoading: false,
+    hasKnownAgents: true,
     error: null,
-    modelAvailabilityState: "launchable",
+    modelGate: { kind: "launchable" },
+    retryModelObservation: () => {},
   } as any;
   const repository = {
     repositories: [],
@@ -85,7 +90,7 @@ vi.mock("#product/hooks/compute/derived/use-compute-target-options", () => ({
 }));
 
 function resetMocks() {
-  stateMocks.model.modelAvailabilityState = "launchable";
+  stateMocks.model.modelGate = { kind: "launchable" };
   stateMocks.model.effectiveModelSelection = { kind: "codex", modelId: "gpt-5.4" };
   stateMocks.repository.selectedRepository = {
     sourceRoot: "/repo",
@@ -148,14 +153,15 @@ describe("useHomeNextState", () => {
   });
 
   it("does not surface model availability as target disabled copy", () => {
-    for (const modelAvailabilityState of [
-      "loading",
-      "load_error",
-      "target_unobserved",
-      "no_launchable_model",
-      "launchable",
-    ] satisfies ModelAvailabilityState[]) {
-      stateMocks.model.modelAvailabilityState = modelAvailabilityState;
+    const gates: HomeModelGate[] = [
+      { kind: "launchable" },
+      { kind: "selection_required" },
+      ...HOME_MODEL_GATE_BLOCKED_REASONS.map((reason) => (
+        { kind: "blocked", reason } as const
+      )),
+    ];
+    for (const modelGate of gates) {
+      stateMocks.model.modelGate = modelGate;
       const { result, unmount } = renderHomeNextState();
 
       expect(result.current.targetDisabledReason).toBeNull();

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-target-agent-launch-options.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-target-agent-launch-options.test.tsx
@@ -2,7 +2,10 @@
 
 import { cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useHomeTargetAgentLaunchOptions } from "#product/hooks/home/derived/use-home-target-agent-launch-options";
+import {
+  useHomeTargetAgentLaunchOptions,
+  useHomeTargetOtherAgentsLaunchOptions,
+} from "#product/hooks/home/derived/use-home-target-agent-launch-options";
 
 const mocks = vi.hoisted(() => ({
   cloudLaunchArgs: null as Record<string, unknown> | null,
@@ -19,6 +22,8 @@ const mocks = vi.hoisted(() => ({
     isError: false,
     isLoading: false,
   },
+  listArgs: null as Record<string, unknown> | null,
+  listEntries: [] as unknown[],
   localArgs: null as Record<string, unknown> | null,
   localResult: {
     data: undefined as unknown,
@@ -32,6 +37,10 @@ vi.mock("@anyharness/sdk-react", () => ({
   useAgentLaunchOptionsQuery: (args: Record<string, unknown>) => {
     mocks.localArgs = args;
     return mocks.localResult;
+  },
+  useAgentLaunchOptionsListQuery: (args: Record<string, unknown>) => {
+    mocks.listArgs = args;
+    return mocks.listEntries;
   },
 }));
 
@@ -57,6 +66,8 @@ describe("useHomeTargetAgentLaunchOptions", () => {
       isError: false,
       isLoading: false,
     };
+    mocks.listArgs = null;
+    mocks.listEntries = [];
     mocks.localArgs = null;
     mocks.localResult = queryResult();
   });
@@ -136,6 +147,37 @@ describe("useHomeTargetAgentLaunchOptions", () => {
     expect(mocks.cloudLaunchArgs).toMatchObject({ enabled: false });
     expect(result.current.data).toBeUndefined();
   });
+
+  it("hands the fan-out kinds their per-kind pending and error flags", () => {
+    // `data === null` reads the same for a kind still being asked and a kind
+    // whose read failed; only these flags separate them, and the Home gate
+    // reports them as different states.
+    mocks.listEntries = [
+      { harnessKind: "codex", data: null, isPending: true, isError: false },
+      { harnessKind: "cursor", data: null, isPending: false, isError: true },
+    ];
+    const { result } = renderHook(() => useHomeTargetOtherAgentsLaunchOptions({
+      harnessKinds: ["codex", "cursor"],
+      launchTarget: { kind: "local", sourceRoot: "/repo", existingWorkspaceId: null },
+    }));
+
+    expect(mocks.listArgs).toEqual({ harnessKinds: ["codex", "cursor"], enabled: true });
+    expect(result.current).toEqual(mocks.listEntries);
+  });
+
+  it("returns a stable empty list for a cloud target", () => {
+    mocks.listEntries = [
+      { harnessKind: "codex", data: null, isPending: true, isError: false },
+    ];
+    const { result, rerender } = renderHook(() => useHomeTargetOtherAgentsLaunchOptions({
+      harnessKinds: ["codex"],
+      launchTarget: { kind: "cloud", gitOwner: "owner", gitRepoName: "repo", baseBranch: "main" },
+    }));
+    const first = result.current;
+    expect(first).toEqual([]);
+    rerender();
+    expect(result.current).toBe(first);
+  });
 });
 
 function queryResult(overrides: Partial<{
@@ -149,6 +191,7 @@ function queryResult(overrides: Partial<{
     error: null,
     isError: false,
     isLoading: false,
+    refetch: vi.fn(),
     ...overrides,
   };
 }

--- a/apps/packages/product-client/src/hooks/home/derived/use-home-target-agent-launch-options.ts
+++ b/apps/packages/product-client/src/hooks/home/derived/use-home-target-agent-launch-options.ts
@@ -2,13 +2,13 @@ import type { HarnessLaunchOptionsResponse } from "@anyharness/sdk";
 import {
   useAgentLaunchOptionsListQuery,
   useAgentLaunchOptionsQuery,
+  type AgentLaunchOptionsListEntry,
 } from "@anyharness/sdk-react";
 import type { CloudHarnessLaunchOptionsResponse } from "@proliferate/cloud-sdk";
 import {
   useCloudHarnessLaunchOptions,
   useCloudSandbox,
 } from "@proliferate/cloud-sdk-react";
-import { useMemo } from "react";
 import type { HomeLaunchTarget } from "#product/lib/domain/home/home-next-launch";
 
 type HomeTargetLaunchOptions =
@@ -35,6 +35,9 @@ export function useHomeTargetAgentLaunchOptions({
   isError: boolean;
   isLoading: boolean;
   isTargetUnobserved: boolean;
+  /** Re-asks the target. The cure behind the blocked notices' Retry / Check
+   * again — a state that offers an action must be able to perform it. */
+  refetch: () => void;
 } {
   const isCloudTarget = launchTarget?.kind === "cloud";
   const isLocalRuntimeTarget = launchTarget !== null && !isCloudTarget;
@@ -66,6 +69,13 @@ export function useHomeTargetAgentLaunchOptions({
         && (cloudSandbox.isError || cloudLaunchOptions.isError),
       isLoading: cloudSandbox.isLoading || cloudLaunchOptions.isLoading,
       isTargetUnobserved,
+      refetch: () => {
+        // The sandbox read comes first: a missing sandbox is one of the two
+        // ways a cloud target reads unobserved, and re-asking only for launch
+        // options could never cure it.
+        void cloudSandbox.refetch();
+        void cloudLaunchOptions.refetch();
+      },
     };
   }
 
@@ -76,6 +86,7 @@ export function useHomeTargetAgentLaunchOptions({
       isError: false,
       isLoading: false,
       isTargetUnobserved: false,
+      refetch: () => {},
     };
   }
 
@@ -85,15 +96,24 @@ export function useHomeTargetAgentLaunchOptions({
     isError: localLaunchOptions.isError,
     isLoading: localLaunchOptions.isLoading,
     isTargetUnobserved: false,
+    refetch: () => {
+      void localLaunchOptions.refetch();
+    },
   };
 }
 
 /**
  * Additive fan-out companion: launch options for the OTHER ready harnesses on
- * the same execution target, one response (or `null` while unresolved) per
- * kind. Local-runtime targets only — a cloud launch reads its sandbox's copied
- * observation per kind and keeps today's single-kind behavior (the cloud copy
- * store has no list read yet; recorded follow-up).
+ * the same execution target, one entry per kind. Local-runtime targets only —
+ * a cloud launch reads its sandbox's copied observation per kind and keeps
+ * today's single-kind behavior (the cloud copy store has no list read yet;
+ * recorded follow-up).
+ *
+ * The entries carry the list query's per-kind pending/error flags, not just
+ * `data`: `data === null` alone cannot tell a kind still being asked apart
+ * from a kind whose read failed, and the Home gate reports those as different
+ * states (`querying` vs `transport_error`). `useQueries` structurally shares
+ * `combine`'s result, so unchanged entries keep their reference.
  */
 export function useHomeTargetOtherAgentsLaunchOptions({
   harnessKinds,
@@ -101,22 +121,18 @@ export function useHomeTargetOtherAgentsLaunchOptions({
 }: {
   harnessKinds: readonly string[];
   launchTarget: HomeLaunchTarget | null;
-}): Array<HarnessLaunchOptionsResponse | null> {
+}): AgentLaunchOptionsListEntry[] {
   const isLocalRuntimeTarget = launchTarget !== null && launchTarget.kind !== "cloud";
   const entries = useAgentLaunchOptionsListQuery({
     harnessKinds,
     enabled: isLocalRuntimeTarget,
   });
-  // The per-kind pending/error flags belong to a later slice; this hook still
-  // answers in responses. The entries are reference-stable, so this memo holds
-  // the downstream chain steady exactly as the raw array used to.
-  const responses = useMemo(() => entries.map((entry) => entry.data), [entries]);
   // Stable empty reference: a fresh [] here would recompute the whole
   // downstream memo chain on every cloud/no-target render.
-  return isLocalRuntimeTarget ? responses : EMPTY_RESPONSES;
+  return isLocalRuntimeTarget ? entries : EMPTY_ENTRIES;
 }
 
-const EMPTY_RESPONSES: Array<HarnessLaunchOptionsResponse | null> = [];
+const EMPTY_ENTRIES: AgentLaunchOptionsListEntry[] = [];
 
 function isNotFound(error: unknown): boolean {
   return Boolean(

--- a/apps/packages/product-client/src/hooks/home/facade/use-home-screen.test.tsx
+++ b/apps/packages/product-client/src/hooks/home/facade/use-home-screen.test.tsx
@@ -151,6 +151,33 @@ async function resolveDeferredRead(
   });
 }
 
+describe("useHomeScreen agent-settings routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.readyAgents = [{ kind: "claude" }, { kind: "codex" }];
+    mocks.agentsLoading = false;
+    mocks.isReconciling = false;
+    mocks.storageContext = null;
+  });
+  afterEach(() => cleanup());
+
+  it("opens the pane of the harness it was handed, not always Claude", () => {
+    // The terminal "no agents are supported" notice justifies itself by
+    // showing WHICH agents are unsupported. Sending every caller to the
+    // Claude pane makes that false whenever Claude is not the one: that pane
+    // only reports it has not been observed.
+    installStorage({ getItem: async () => null });
+    const { result } = renderHook(() => useHomeScreen());
+    act(() => result.current.handleHomeAction("agent-settings", { harnessKind: "cursor" }));
+    expect(mocks.navigate).toHaveBeenCalledWith("/settings?section=agent-cursor");
+
+    // No harness named, and an unmappable one, both keep the old default.
+    act(() => result.current.handleHomeAction("agent-settings"));
+    act(() => result.current.handleHomeAction("agent-settings", { harnessKind: "nope" }));
+    expect(mocks.navigate).toHaveBeenLastCalledWith("/settings?section=agent-claude");
+  });
+});
+
 describe("useHomeScreen model-probe dismissal hydration", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/packages/product-client/src/hooks/home/facade/use-home-screen.ts
+++ b/apps/packages/product-client/src/hooks/home/facade/use-home-screen.ts
@@ -13,6 +13,7 @@ import {
   buildHomeOnboardingCards,
   findHomeUnconfiguredGitHubRepository,
 } from "#product/lib/domain/home/home-screen";
+import { getSettingsSectionForHarnessKind } from "#product/lib/domain/settings/navigation-presentation";
 import { buildSettingsRepositoryEntries } from "#product/lib/domain/settings/repositories";
 import {
   buildCloudRepoSettingsHref,
@@ -118,7 +119,7 @@ export function useHomeScreen() {
     }),
     [repoConfigs?.repositories, repositories],
   );
-  function handleHomeAction(actionId: HomeActionId) {
+  function handleHomeAction(actionId: HomeActionId, options?: { harnessKind?: string | null }) {
     switch (actionId) {
       case "add-repository":
         openAddRepoFlow();
@@ -126,9 +127,16 @@ export function useHomeScreen() {
       case "agent-defaults":
         navigate(buildSettingsHref({ section: "agent-claude" }));
         return;
-      case "agent-settings":
-        navigate(buildSettingsHref({ section: "agent-claude" }));
+      case "agent-settings": {
+        // Land on an agent the caller actually means. The terminal
+        // "no agents are supported" notice is only honest if the pane it
+        // opens shows an unsupported agent, not whatever Claude reports.
+        const section = options?.harnessKind
+          ? getSettingsSectionForHarnessKind(options.harnessKind)
+          : null;
+        navigate(buildSettingsHref({ section: section ?? "agent-claude" }));
         return;
+      }
       case "repository-settings": {
         const firstRepository = repositoryToConfigure ?? repositories[0];
         if (firstRepository?.gitOwner && firstRepository.gitRepoName) {

--- a/apps/packages/product-client/src/hooks/home/ui/use-home-next-composer-state.ts
+++ b/apps/packages/product-client/src/hooks/home/ui/use-home-next-composer-state.ts
@@ -3,17 +3,22 @@ import { flushSync } from "react-dom";
 import type { PromptAttachmentController } from "#product/hooks/chat/ui/use-chat-prompt-attachments";
 import { useHomeNextLaunch } from "#product/hooks/home/workflows/use-home-next-launch";
 import { useHomeDraftHandoffStore } from "#product/stores/home/home-draft-handoff-store";
+import {
+  HOME_MODEL_GATE_SEND_BLOCKED_REASON,
+  HOME_MODEL_TRIGGER_SELECTOR,
+  resolveHomeModelGateRefusalAnnouncement,
+  type HomeModelGate,
+} from "#product/lib/domain/home/home-model-gate";
 import type {
   HomeLaunchTarget,
   HomeNextModelSelection,
-  ModelAvailabilityState,
 } from "#product/lib/domain/home/home-next-launch";
 import type { ChatComposerEditorSnapshot } from "#product/lib/domain/chat/composer/file-mention-draft-model";
 import type { ChatComposerKeyboardEvent } from "#product/hooks/chat/ui/use-chat-composer-keyboard";
 
 interface UseHomeNextComposerStateArgs {
   targetDisabledReason: string | null;
-  modelAvailabilityState: ModelAvailabilityState;
+  modelGate: HomeModelGate;
   canLaunchTarget: boolean;
   modelSelection: HomeNextModelSelection | null;
   launchControlValues: Record<string, string>;
@@ -23,7 +28,7 @@ interface UseHomeNextComposerStateArgs {
 
 export function useHomeNextComposerState({
   targetDisabledReason,
-  modelAvailabilityState,
+  modelGate,
   canLaunchTarget,
   modelSelection,
   launchControlValues,
@@ -38,6 +43,9 @@ export function useHomeNextComposerState({
   const restoredDraftText = useHomeDraftHandoffStore((state) => state.draftText);
   const clearRestoredDraftText = useHomeDraftHandoffStore((state) => state.clearDraftText);
   const { isLaunching, launch } = useHomeNextLaunch();
+  // Counts refusals only so the live region's text can differ between two of
+  // them; the count itself never reaches the region (ruling 6).
+  const [refusalCount, setRefusalCount] = useState(0);
 
   useEffect(() => {
     if (restoredDraftText !== null) {
@@ -56,10 +64,22 @@ export function useHomeNextComposerState({
   const submitDisabledReason = isEmpty ? null : targetDisabledReason;
   const canSubmit =
     !isEmpty
-    && modelAvailabilityState === "launchable"
+    && modelGate.kind === "launchable"
     && canLaunchTarget
     && !!modelSelection
     && !!launchTarget;
+  /**
+   * The disabled Send's tooltip AND accessible name while a model is unchosen.
+   *
+   * selection_required carries no visible notice (owner revision r2), so this
+   * reason and the enabled picker pill are the whole of the state's visual
+   * story — a Send that still reads "Send (Cmd+Enter)" would be the only thing
+   * on screen saying nothing is wrong.
+   */
+  const sendBlockedReason = modelGate.kind === "selection_required"
+    ? HOME_MODEL_GATE_SEND_BLOCKED_REASON
+    : null;
+  const refusalAnnouncement = resolveHomeModelGateRefusalAnnouncement(refusalCount);
 
   const setDraft = useCallback((
     value: string,
@@ -120,6 +140,26 @@ export function useHomeNextComposerState({
     modelSelection,
   ]);
 
+  /**
+   * Enter with a draft and no model (ruling 3).
+   *
+   * The draft is untouched — not cleared, not restored, simply left alone —
+   * focus moves to the picker trigger, and the reason is re-committed to the
+   * status region. The picker is NOT opened: auto-opening a menu under a
+   * keystroke the user did not aim at it steals the caret, and the focused
+   * trigger is already one keypress from the same menu.
+   */
+  const refuseSubmit = useCallback(() => {
+    if (canSubmit || modelGate.kind === "launchable") {
+      return;
+    }
+    setRefusalCount((count) => count + 1);
+    const trigger = typeof document === "undefined"
+      ? null
+      : document.querySelector<HTMLElement>(HOME_MODEL_TRIGGER_SELECTOR);
+    trigger?.focus();
+  }, [canSubmit, modelGate.kind]);
+
   const cancel = useCallback(() => {
     if (!isLaunching) {
       setDraftState({ value: "" });
@@ -144,6 +184,9 @@ export function useHomeNextComposerState({
     editorSnapshot: draftState.snapshot,
     setDraft,
     submitDisabledReason,
+    sendBlockedReason,
+    refusalAnnouncement,
+    refuseSubmit,
     canSubmit,
     isEmpty,
     isLaunching,

--- a/apps/packages/product-client/src/hooks/home/ui/use-home-next-composer-state.ts
+++ b/apps/packages/product-client/src/hooks/home/ui/use-home-next-composer-state.ts
@@ -47,6 +47,15 @@ export function useHomeNextComposerState({
   // them; the count itself never reaches the region (ruling 6).
   const [refusalCount, setRefusalCount] = useState(0);
 
+  // A refusal sentence is only true while the gate is still asking for a
+  // selection. Left alone it would sit in the accessibility tree for the rest
+  // of the session, including after a model was chosen and Send worked.
+  useEffect(() => {
+    if (modelGate.kind !== "selection_required") {
+      setRefusalCount(0);
+    }
+  }, [modelGate.kind]);
+
   useEffect(() => {
     if (restoredDraftText !== null) {
       setDraftState({ value: restoredDraftText });
@@ -71,12 +80,18 @@ export function useHomeNextComposerState({
   /**
    * The disabled Send's tooltip AND accessible name while a model is unchosen.
    *
+   * Empty-guarded exactly as `submitDisabledReason` above is: this string
+   * becomes the button's accessible NAME, so on an empty composer — where the
+   * button is disabled because there is nothing to send — it would name the
+   * wrong reason. The component renders whatever reason it is handed; deciding
+   * that the reason applies is this hook's job.
+   *
    * selection_required carries no visible notice (owner revision r2), so this
    * reason and the enabled picker pill are the whole of the state's visual
    * story — a Send that still reads "Send (Cmd+Enter)" would be the only thing
    * on screen saying nothing is wrong.
    */
-  const sendBlockedReason = modelGate.kind === "selection_required"
+  const sendBlockedReason = !isEmpty && modelGate.kind === "selection_required"
     ? HOME_MODEL_GATE_SEND_BLOCKED_REASON
     : null;
   const refusalAnnouncement = resolveHomeModelGateRefusalAnnouncement(refusalCount);
@@ -148,9 +163,24 @@ export function useHomeNextComposerState({
    * status region. The picker is NOT opened: auto-opening a menu under a
    * keystroke the user did not aim at it steals the caret, and the focused
    * trigger is already one keypress from the same menu.
+   *
+   * Scoped to `selection_required`, and to that gate ONLY, for two reasons
+   * that both have to hold:
+   *
+   *  - "Choose a model before sending" is only true when there is a model to
+   *    choose. Under `agent_setup_required` there is not, and the screen is
+   *    already showing the sentence that IS true.
+   *  - It is the only gate whose trigger is enabled. Every other blocked
+   *    reason renders the trigger as a native `<button disabled>`, which is
+   *    not focusable, so `focus()` would be a silent no-op aimed at a control
+   *    the user cannot use.
+   *
+   * An empty composer is not a refusal at all: Enter on an empty Home composer
+   * did nothing before this slice and must keep doing nothing, rather than
+   * throwing the caret out of the editor the page just autofocused.
    */
   const refuseSubmit = useCallback(() => {
-    if (canSubmit || modelGate.kind === "launchable") {
+    if (isEmpty || canSubmit || modelGate.kind !== "selection_required") {
       return;
     }
     setRefusalCount((count) => count + 1);
@@ -158,7 +188,7 @@ export function useHomeNextComposerState({
       ? null
       : document.querySelector<HTMLElement>(HOME_MODEL_TRIGGER_SELECTOR);
     trigger?.focus();
-  }, [canSubmit, modelGate.kind]);
+  }, [canSubmit, isEmpty, modelGate.kind]);
 
   const cancel = useCallback(() => {
     if (!isLaunching) {

--- a/apps/packages/product-client/src/lib/domain/chat/models/model-selector-types.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/models/model-selector-types.ts
@@ -51,6 +51,21 @@ export interface ModelSelectorCurrentModel {
   pendingState: PendingSessionConfigChangeStatus | null;
 }
 
+/**
+ * Why the offered rows look the way they do.
+ *
+ * `groups.length === 0` cannot say it: no observation yet, an observation that
+ * found nothing, and a failed observation are three different facts, and the
+ * trigger label, the enabled state and the picker's empty body each differ
+ * between them. Chat has a live session and omits this (defaulting to
+ * `ready`); Home derives it from its model gate.
+ */
+export type ModelSelectorAvailability =
+  | "ready"
+  | "observation_pending"
+  | "observed_empty"
+  | "unavailable";
+
 export interface ModelSelectorProps {
   connectionState: string;
   currentModel: ModelSelectorCurrentModel | null;
@@ -58,6 +73,8 @@ export interface ModelSelectorProps {
   hasAgents: boolean;
   isLoading: boolean;
   onSelect: (selection: ModelSelectorSelection) => void;
+  /** Defaults to `ready`, which is exactly today's behavior. */
+  availability?: ModelSelectorAvailability;
   /**
    * Set when the model the composer is currently on is one the target refused.
    * Pinned under the control as an inline error — the condition belongs to this

--- a/apps/packages/product-client/src/lib/domain/chat/models/model-selector-types.ts
+++ b/apps/packages/product-client/src/lib/domain/chat/models/model-selector-types.ts
@@ -66,6 +66,33 @@ export type ModelSelectorAvailability =
   | "observed_empty"
   | "unavailable";
 
+/**
+ * Whether the trigger may be opened, as ONE expression both the component and
+ * the coexistence tests read.
+ *
+ * It lives here rather than inside the component so no test can re-implement
+ * it and then quietly agree with itself while the real control diverges.
+ *
+ * `observed_empty` deliberately stays enabled (owner revision r3): the picker
+ * is that state's cure path, and greying out the one control that explains
+ * what happened turns a recoverable state into a dead end. Only a missing or
+ * failed observation disables the trigger — those have nothing to show.
+ */
+export function resolveModelSelectorEnabled(input: {
+  disabled: boolean;
+  connectionState: string;
+  isLoading: boolean;
+  hasAgents: boolean;
+  availability: ModelSelectorAvailability;
+}): boolean {
+  return !input.disabled
+    && input.connectionState === "healthy"
+    && !input.isLoading
+    && input.hasAgents
+    && input.availability !== "observation_pending"
+    && input.availability !== "unavailable";
+}
+
 export interface ModelSelectorProps {
   connectionState: string;
   currentModel: ModelSelectorCurrentModel | null;

--- a/apps/packages/product-client/src/lib/domain/home/home-composer-controls.test.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-composer-controls.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import type { LiveSessionControlDescriptor } from "#product/lib/domain/chat/session-controls/session-controls";
-import { buildHomeSessionConfigControls } from "#product/lib/domain/home/home-composer-controls";
+import {
+  buildHomeModelSelectorProps,
+  buildHomeSessionConfigControls,
+} from "#product/lib/domain/home/home-composer-controls";
 
 describe("home composer controls", () => {
   it("preserves every target-observed control without singleton mode handling", () => {
@@ -14,6 +17,53 @@ describe("home composer controls", () => {
     expect(buildHomeSessionConfigControls({
       launchControls: [access, collaboration, unknown],
     })).toEqual([access, collaboration, unknown]);
+  });
+
+  it("derives hasAgents from the catalog, not from the observed group list", () => {
+    // First run: five agents installing, zero groups. The old
+    // `groups.length > 0` reading made the trigger claim "No agents".
+    const props = buildHomeModelSelectorProps({
+      groups: [],
+      selectedModel: null,
+      gate: { kind: "blocked", reason: "observation_pending" },
+      isCatalogLoading: false,
+      hasKnownAgents: true,
+      onSelect: vi.fn(),
+    });
+
+    expect(props.hasAgents).toBe(true);
+    expect(props.isLoading).toBe(false);
+    expect(props.availability).toBe("observation_pending");
+    expect(props.currentModel).toBeNull();
+  });
+
+  it("passes the catalog HTTP load through as isLoading and maps every gate", () => {
+    expect(buildHomeModelSelectorProps({
+      groups: [],
+      selectedModel: null,
+      gate: { kind: "blocked", reason: "querying" },
+      isCatalogLoading: true,
+      hasKnownAgents: false,
+      onSelect: vi.fn(),
+    }).isLoading).toBe(true);
+
+    expect(buildHomeModelSelectorProps({
+      groups: [],
+      selectedModel: null,
+      gate: { kind: "selection_required" },
+      isCatalogLoading: false,
+      hasKnownAgents: true,
+      onSelect: vi.fn(),
+    }).availability).toBe("ready");
+
+    expect(buildHomeModelSelectorProps({
+      groups: [],
+      selectedModel: null,
+      gate: { kind: "blocked", reason: "observed_empty" },
+      isCatalogLoading: false,
+      hasKnownAgents: true,
+      onSelect: vi.fn(),
+    }).availability).toBe("observed_empty");
   });
 });
 

--- a/apps/packages/product-client/src/lib/domain/home/home-composer-controls.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-composer-controls.ts
@@ -8,7 +8,10 @@ import type {
   ModelSelectorSelection,
 } from "#product/lib/domain/chat/models/model-selector-types";
 import type { LiveSessionControlDescriptor } from "#product/lib/domain/chat/session-controls/session-controls";
-import type { ModelAvailabilityState } from "#product/lib/domain/home/home-next-launch";
+import {
+  resolveHomeModelSelectorAvailability,
+  type HomeModelGate,
+} from "#product/lib/domain/home/home-model-gate";
 
 /**
  * Adapters that let the home screen drive the SAME composer controls the chat
@@ -33,12 +36,18 @@ export const HOME_COMPOSER_PROMPT_CAPABILITIES: PromptCapabilities = {
 export function buildHomeModelSelectorProps({
   groups,
   selectedModel,
-  availabilityState,
+  gate,
+  isCatalogLoading,
+  hasKnownAgents,
   onSelect,
 }: {
   groups: AgentModelGroup[];
   selectedModel: AgentModelInfo | null;
-  availabilityState: ModelAvailabilityState;
+  gate: HomeModelGate;
+  /** The agent catalog's own HTTP read — NOT an install and NOT a probe. */
+  isCatalogLoading: boolean;
+  /** The catalog knows of at least one agent, observed models or not. */
+  hasKnownAgents: boolean;
   onSelect: (selection: ModelSelectorSelection) => void;
 }): ModelSelectorProps {
   return {
@@ -67,8 +76,12 @@ export function buildHomeModelSelectorProps({
         isUnsupported: false,
       })),
     })),
-    hasAgents: groups.length > 0,
-    isLoading: availabilityState === "loading",
+    // Deliberately NOT `groups.length > 0`: an agent that has not reported
+    // models yet still exists, and deriving "No agents" from an empty group
+    // list is what made a first-run machine claim it had none.
+    hasAgents: hasKnownAgents,
+    isLoading: isCatalogLoading,
+    availability: resolveHomeModelSelectorAvailability(gate),
     onSelect,
   };
 }

--- a/apps/packages/product-client/src/lib/domain/home/home-model-gate-notice.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-model-gate-notice.ts
@@ -40,11 +40,14 @@ export const HOME_MODEL_GATE_REFRESH_REJECTED_NOTICE = "Couldn't refresh your mo
 export const HOME_MODEL_GATE_REFRESHING_NOTICE = "Refreshing your models…";
 
 /**
- * The one notice with no action, because there is genuinely nothing to press.
+ * The one notice whose action is navigation rather than a cure.
  *
  * Every agent the runtime knows about is unsupported here, so no probe can
  * ever produce a model and a Refresh would re-read an identical list forever.
- * A terminal fact stated plainly beats a button that quietly does nothing.
+ * Stating the fact and leaving nothing to press was the first shape and was
+ * wrong for a different reason: with the picker unavailable it left the
+ * screen with no affordance at all. So the action goes where the user can see
+ * WHICH agents are unsupported and why — it claims to fix nothing.
  */
 export const HOME_MODEL_GATE_AGENTS_UNSUPPORTED_NOTICE =
   "No agents are supported on this machine.";

--- a/apps/packages/product-client/src/lib/domain/home/home-model-gate-notice.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-model-gate-notice.ts
@@ -16,10 +16,11 @@ export type HomeModelGateNoticeAction =
 
 export interface HomeModelGateNotice {
   text: string;
-  /** `null` for a terminal state with nothing to press. Offering a button that
-   * cannot change anything is the dead end this gate exists to remove. */
-  actionLabel: string | null;
-  action: HomeModelGateNoticeAction | null;
+  /** Non-optional on purpose. Every notice a user can reach must give them
+   * something to do — a cure where one exists, and navigation where none
+   * does. A notice with no action is a dead end, so it must not typecheck. */
+  actionLabel: string;
+  action: HomeModelGateNoticeAction;
 }
 
 export const HOME_MODEL_GATE_AGENT_SETUP_NOTICE = "Finish agent setup to start a chat.";
@@ -123,11 +124,16 @@ function resolveGateNotice(gate: HomeModelGate): HomeModelGateNotice | null {
         actionLabel: "Check again",
         action: "check_target_again",
       };
+    // The one gate with no cure: no probe can change it, and the picker is
+    // unavailable, so without this the state has nothing at all to act on.
+    // The action is NAVIGATION, deliberately not Refresh/Retry vocabulary —
+    // it does not claim to fix anything, it takes the user to the pane that
+    // shows WHICH agents are unsupported and why.
     case "agents_unsupported":
       return {
         text: HOME_MODEL_GATE_AGENTS_UNSUPPORTED_NOTICE,
-        actionLabel: null,
-        action: null,
+        actionLabel: "See agents",
+        action: "agent_settings",
       };
     case "target_missing":
     case "querying":

--- a/apps/packages/product-client/src/lib/domain/home/home-model-gate-notice.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-model-gate-notice.ts
@@ -1,0 +1,138 @@
+import type { HomeModelGate } from "#product/lib/domain/home/home-model-gate";
+
+/**
+ * The sentence under the Home composer, and the button beside it.
+ *
+ * Split out of `home-model-gate.ts` for size only. That file re-exports every
+ * name here, and remains the one import path consumers use.
+ */
+
+/** The action a blocked notice offers. Each one cures its own state. */
+export type HomeModelGateNoticeAction =
+  | "agent_settings"
+  | "retry_probe"
+  | "refetch_launch_options"
+  | "check_target_again";
+
+export interface HomeModelGateNotice {
+  text: string;
+  /** `null` for a terminal state with nothing to press. Offering a button that
+   * cannot change anything is the dead end this gate exists to remove. */
+  actionLabel: string | null;
+  action: HomeModelGateNoticeAction | null;
+}
+
+export const HOME_MODEL_GATE_AGENT_SETUP_NOTICE = "Finish agent setup to start a chat.";
+
+/**
+ * Shown in place of a probe-cured notice when the probe itself was REFUSED.
+ *
+ * A rejected refresh writes no durable state, so the underlying gate does not
+ * move and the same sentence would render again unchanged — a button that
+ * appears to do nothing, forever. (A probe that runs and FAILS is already
+ * visible: the runtime records `failed_without_observation` and the gate flips
+ * to "Couldn't check your models.")
+ */
+export const HOME_MODEL_GATE_REFRESH_REJECTED_NOTICE = "Couldn't refresh your models.";
+
+/** Shown while a refresh this notice started is still running. */
+export const HOME_MODEL_GATE_REFRESHING_NOTICE = "Refreshing your models…";
+
+/**
+ * The one notice with no action, because there is genuinely nothing to press.
+ *
+ * Every agent the runtime knows about is unsupported here, so no probe can
+ * ever produce a model and a Refresh would re-read an identical list forever.
+ * A terminal fact stated plainly beats a button that quietly does nothing.
+ */
+export const HOME_MODEL_GATE_AGENTS_UNSUPPORTED_NOTICE =
+  "No agents are supported on this machine.";
+
+/**
+ * The visible line under the composer, or `null` for the states that must stay
+ * silent.
+ *
+ * `selection_required` and `observed_empty` are deliberately silent (owner
+ * revisions r2 and r3): both are cured by the enabled picker itself, and a
+ * sentence next to a control that already says what to do reads as a dead end
+ * rather than an instruction. `querying` / `observation_pending` are silent
+ * because work is in flight and the toast already owns that story.
+ */
+export function resolveHomeModelGateNotice(
+  gate: HomeModelGate,
+  options: { refreshPending?: boolean; refreshRejected?: boolean } = {},
+): HomeModelGateNotice | null {
+  const notice = resolveGateNotice(gate);
+  // Only a notice whose action FIRES a probe can report on that probe; the
+  // others never call the mutation, so its state says nothing about them.
+  if (!notice || notice.action !== "retry_probe") {
+    return notice;
+  }
+  // In flight beats refused, and both beat the settled sentence. A probe can
+  // take 45s per kind and they run one at a time, so rendering "Models haven't
+  // been detected yet." throughout is a terminal claim about work that is
+  // still happening — the same lie as the dead end, pointed the other way.
+  if (options.refreshPending) {
+    return { ...notice, text: HOME_MODEL_GATE_REFRESHING_NOTICE };
+  }
+  // Only the state whose sentence carries NO information about a probe having
+  // run gets overwritten. "Couldn't check your models." already says a probe
+  // ran and failed, which is strictly more than a refusal says; replacing it
+  // would trade a fact for a weaker one.
+  if (options.refreshRejected && gate.kind === "blocked" && gate.reason === "observation_idle") {
+    return { ...notice, text: HOME_MODEL_GATE_REFRESH_REJECTED_NOTICE };
+  }
+  return notice;
+}
+
+function resolveGateNotice(gate: HomeModelGate): HomeModelGateNotice | null {
+  if (gate.kind !== "blocked") {
+    return null;
+  }
+  switch (gate.reason) {
+    case "agent_setup_required":
+      return {
+        text: HOME_MODEL_GATE_AGENT_SETUP_NOTICE,
+        actionLabel: "Agents",
+        action: "agent_settings",
+      };
+    case "observation_failed":
+      return {
+        text: "Couldn't check your models.",
+        actionLabel: "Retry",
+        action: "retry_probe",
+      };
+    // Same words and the same cure as the Settings models section, which
+    // solved this state first: an honest "nobody has looked yet" plus a
+    // Refresh that looks. Never "Probing…" — nothing is probing.
+    case "observation_idle":
+      return {
+        text: "Models haven't been detected yet.",
+        actionLabel: "Refresh",
+        action: "retry_probe",
+      };
+    case "transport_error":
+      return {
+        text: "Models couldn't be loaded.",
+        actionLabel: "Retry",
+        action: "refetch_launch_options",
+      };
+    case "target_unobserved":
+      return {
+        text: "Proliferate Cloud hasn't reported launch options yet.",
+        actionLabel: "Check again",
+        action: "check_target_again",
+      };
+    case "agents_unsupported":
+      return {
+        text: HOME_MODEL_GATE_AGENTS_UNSUPPORTED_NOTICE,
+        actionLabel: null,
+        action: null,
+      };
+    case "target_missing":
+    case "querying":
+    case "observation_pending":
+    case "observed_empty":
+      return null;
+  }
+}

--- a/apps/packages/product-client/src/lib/domain/home/home-model-gate.test.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-model-gate.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vitest";
+import {
+  HOME_MODEL_GATE_AGENT_SETUP_NOTICE,
+  HOME_MODEL_GATE_BLOCKED_REASONS,
+  HOME_MODEL_GATE_REFUSAL_ANNOUNCEMENT,
+  resolveHomeModelGate,
+  resolveHomeModelGateNotice,
+  resolveHomeModelGateRefusalAnnouncement,
+  resolveHomeModelSelectorAvailability,
+  type HomeModelGate,
+  type HomeModelGateInput,
+  type HomeModelGateObservation,
+} from "#product/lib/domain/home/home-model-gate";
+
+function input(overrides: Partial<HomeModelGateInput> = {}): HomeModelGateInput {
+  return {
+    hasLaunchTarget: true,
+    isTargetUnobserved: false,
+    hasExactSelection: false,
+    offeredModelCount: 0,
+    observations: [],
+    agentReadiness: ["ready"],
+    isInstalling: false,
+    isCatalogLoading: false,
+    hasCatalogError: false,
+    ...overrides,
+  };
+}
+
+function observation(
+  overrides: Partial<HomeModelGateObservation> = {},
+): HomeModelGateObservation {
+  return {
+    harnessKind: "claude",
+    state: null,
+    probePhase: null,
+    isPending: false,
+    isError: false,
+    ...overrides,
+  };
+}
+
+const ALL_GATES: HomeModelGate[] = [
+  { kind: "launchable" },
+  { kind: "selection_required" },
+  ...HOME_MODEL_GATE_BLOCKED_REASONS.map((reason) => ({ kind: "blocked", reason } as const)),
+];
+
+describe("resolveHomeModelGate precedence", () => {
+  it("reports target_missing before anything else can be true", () => {
+    expect(resolveHomeModelGate(input({
+      hasLaunchTarget: false,
+      hasExactSelection: true,
+      offeredModelCount: 4,
+    }))).toEqual({ kind: "blocked", reason: "target_missing" });
+  });
+
+  it("reports target_unobserved for a cloud target and never falls back to local rows", () => {
+    // Local observations exist and are launchable; the cloud target still has
+    // not reported, and borrowing the local answer would be a lie about which
+    // machine will run the session.
+    expect(resolveHomeModelGate(input({
+      isTargetUnobserved: true,
+      hasExactSelection: true,
+      offeredModelCount: 12,
+      observations: [observation({ state: "observed" })],
+    }))).toEqual({ kind: "blocked", reason: "target_unobserved" });
+  });
+
+  it("is launchable on an exact selection even while a probe runs", () => {
+    expect(resolveHomeModelGate(input({
+      hasExactSelection: true,
+      offeredModelCount: 2,
+      observations: [observation({ state: "refreshing", probePhase: "running" })],
+    }))).toEqual({ kind: "launchable" });
+  });
+
+  it("keeps last_good_after_failure launchable-capable", () => {
+    expect(resolveHomeModelGate(input({
+      hasExactSelection: true,
+      offeredModelCount: 3,
+      observations: [observation({ state: "last_good_after_failure" })],
+    }))).toEqual({ kind: "launchable" });
+    // Same rows, nothing selected: still not a failure state.
+    expect(resolveHomeModelGate(input({
+      offeredModelCount: 3,
+      observations: [observation({ state: "last_good_after_failure" })],
+    }))).toEqual({ kind: "selection_required" });
+  });
+
+  it("never fabricates a selection when rows exist", () => {
+    // Every settled failure signal is present at once. Rows still exist, so
+    // the truthful answer is "you have not chosen", not "something is broken"
+    // and above all not "here, I chose for you".
+    expect(resolveHomeModelGate(input({
+      offeredModelCount: 1,
+      agentReadiness: ["install_required"],
+      hasCatalogError: true,
+      observations: [
+        observation({ state: "failed_without_observation" }),
+        observation({ harnessKind: "codex", isError: true }),
+      ],
+    }))).toEqual({ kind: "selection_required" });
+  });
+
+  it("reports querying while a read has never answered", () => {
+    expect(resolveHomeModelGate(input({
+      observations: [observation({ isPending: true })],
+    }))).toEqual({ kind: "blocked", reason: "querying" });
+    expect(resolveHomeModelGate(input({ isCatalogLoading: true })))
+      .toEqual({ kind: "blocked", reason: "querying" });
+  });
+
+  it("reports observation_pending for a queued or running probe, and for an install", () => {
+    for (const probePhase of ["queued", "running"] as const) {
+      expect(resolveHomeModelGate(input({
+        observations: [observation({ state: "detecting", probePhase })],
+      }))).toEqual({ kind: "blocked", reason: "observation_pending" });
+    }
+    expect(resolveHomeModelGate(input({
+      isInstalling: true,
+      agentReadiness: ["install_required"],
+    }))).toEqual({ kind: "blocked", reason: "observation_pending" });
+  });
+
+  it("does not treat a settled detecting harness as pending", () => {
+    // A manual-refresh-only harness sits `detecting` by design. Reporting that
+    // as in-flight is the 32-minute "Probing..." bug.
+    expect(resolveHomeModelGate(input({
+      observations: [observation({ state: "detecting", probePhase: "idle" })],
+    }))).toEqual({ kind: "blocked", reason: "querying" });
+  });
+
+  it("reports agent_setup_required only for install_required or login_required", () => {
+    for (const readiness of ["install_required", "login_required"] as const) {
+      expect(resolveHomeModelGate(input({ agentReadiness: [readiness] })))
+        .toEqual({ kind: "blocked", reason: "agent_setup_required" });
+    }
+    for (const readiness of ["ready", "credentials_required", "unsupported", "error"] as const) {
+      expect(resolveHomeModelGate(input({ agentReadiness: [readiness] })))
+        .not.toEqual({ kind: "blocked", reason: "agent_setup_required" });
+    }
+  });
+
+  it("reports the settled observation reasons", () => {
+    expect(resolveHomeModelGate(input({
+      observations: [observation({ state: "observed_empty" })],
+    }))).toEqual({ kind: "blocked", reason: "observed_empty" });
+    expect(resolveHomeModelGate(input({
+      observations: [observation({ state: "failed_without_observation" })],
+    }))).toEqual({ kind: "blocked", reason: "observation_failed" });
+    expect(resolveHomeModelGate(input({
+      observations: [observation({ isError: true })],
+    }))).toEqual({ kind: "blocked", reason: "transport_error" });
+    expect(resolveHomeModelGate(input({ hasCatalogError: true })))
+      .toEqual({ kind: "blocked", reason: "transport_error" });
+  });
+
+  it("every reason is reachable", () => {
+    const reached = new Set<string>();
+    const cases: HomeModelGateInput[] = [
+      input({ hasLaunchTarget: false }),
+      input({ isTargetUnobserved: true }),
+      input({ observations: [observation({ isPending: true })] }),
+      input({ observations: [observation({ probePhase: "running" })] }),
+      input({ agentReadiness: ["login_required"] }),
+      input({ observations: [observation({ state: "observed_empty" })] }),
+      input({ observations: [observation({ state: "failed_without_observation" })] }),
+      input({ observations: [observation({ isError: true })] }),
+    ];
+    for (const testCase of cases) {
+      const gate = resolveHomeModelGate(testCase);
+      if (gate.kind === "blocked") reached.add(gate.reason);
+    }
+    expect([...reached].sort()).toEqual([...HOME_MODEL_GATE_BLOCKED_REASONS].sort());
+  });
+});
+
+describe("home model gate presentation", () => {
+  // Ruling 2, asserted structurally rather than per-screen: whatever the gate
+  // is, an enabled picker and the setup sentence cannot both be produced.
+  it("never enables the model selector alongside the Finish agent setup notice", () => {
+    for (const gate of ALL_GATES) {
+      const availability = resolveHomeModelSelectorAvailability(gate);
+      const notice = resolveHomeModelGateNotice(gate);
+      const selectorEnabled =
+        availability !== "observation_pending" && availability !== "unavailable";
+      expect(
+        selectorEnabled && notice?.text === HOME_MODEL_GATE_AGENT_SETUP_NOTICE,
+        `gate ${JSON.stringify(gate)} produced a coexistence`,
+      ).toBe(false);
+    }
+  });
+
+  it("says Finish agent setup for agent_setup_required and nothing else", () => {
+    const saying = ALL_GATES.filter((gate) =>
+      resolveHomeModelGateNotice(gate)?.text === HOME_MODEL_GATE_AGENT_SETUP_NOTICE
+    );
+    expect(saying).toEqual([{ kind: "blocked", reason: "agent_setup_required" }]);
+  });
+
+  it("stays silent for selection_required, observed_empty and the in-flight reasons", () => {
+    for (const gate of [
+      { kind: "launchable" },
+      { kind: "selection_required" },
+      { kind: "blocked", reason: "target_missing" },
+      { kind: "blocked", reason: "querying" },
+      { kind: "blocked", reason: "observation_pending" },
+      { kind: "blocked", reason: "observed_empty" },
+    ] satisfies HomeModelGate[]) {
+      expect(resolveHomeModelGateNotice(gate)).toBeNull();
+    }
+  });
+
+  it("carries the frozen copy and an enabled cure for every blocked notice", () => {
+    expect(resolveHomeModelGateNotice({ kind: "blocked", reason: "observation_failed" }))
+      .toEqual({ text: "Couldn't check your models.", actionLabel: "Retry", action: "retry_probe" });
+    expect(resolveHomeModelGateNotice({ kind: "blocked", reason: "transport_error" }))
+      .toEqual({
+        text: "Models couldn't be loaded.",
+        actionLabel: "Retry",
+        action: "refetch_launch_options",
+      });
+    expect(resolveHomeModelGateNotice({ kind: "blocked", reason: "target_unobserved" }))
+      .toEqual({
+        text: "Proliferate Cloud hasn't reported launch options yet.",
+        actionLabel: "Check again",
+        action: "check_target_again",
+      });
+  });
+
+  it("keeps the picker enabled for observed_empty and disabled for the failures", () => {
+    expect(resolveHomeModelSelectorAvailability({ kind: "selection_required" })).toBe("ready");
+    expect(resolveHomeModelSelectorAvailability({ kind: "blocked", reason: "observed_empty" }))
+      .toBe("observed_empty");
+    expect(resolveHomeModelSelectorAvailability({ kind: "blocked", reason: "observation_pending" }))
+      .toBe("observation_pending");
+    for (const reason of ["observation_failed", "transport_error", "target_unobserved"] as const) {
+      expect(resolveHomeModelSelectorAvailability({ kind: "blocked", reason }))
+        .toBe("unavailable");
+    }
+  });
+});
+
+describe("refusal announcement", () => {
+  it("re-announces on repeat refusals without stacking or numerals", () => {
+    const first = resolveHomeModelGateRefusalAnnouncement(1);
+    const second = resolveHomeModelGateRefusalAnnouncement(2);
+    const third = resolveHomeModelGateRefusalAnnouncement(3);
+
+    expect(resolveHomeModelGateRefusalAnnouncement(0)).toBe("");
+    // Different string each time, so the live region re-commits...
+    expect(second).not.toBe(first);
+    expect(third).not.toBe(second);
+    // ...but always the same sentence, never appended to.
+    for (const text of [first, second, third]) {
+      expect(text.trim()).toBe(HOME_MODEL_GATE_REFUSAL_ANNOUNCEMENT);
+      expect(/\d/.test(text)).toBe(false);
+    }
+    expect(third.length).toBe(first.length);
+  });
+});

--- a/apps/packages/product-client/src/lib/domain/home/home-model-gate.test.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-model-gate.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   HOME_MODEL_GATE_AGENT_SETUP_NOTICE,
   HOME_MODEL_GATE_BLOCKED_REASONS,
+  HOME_MODEL_GATE_AGENTS_UNSUPPORTED_NOTICE,
+  HOME_MODEL_GATE_REFRESHING_NOTICE,
   HOME_MODEL_GATE_REFRESH_REJECTED_NOTICE,
   HOME_MODEL_GATE_REFUSAL_ANNOUNCEMENT,
   homeModelGateNeedsNewProbe,
@@ -162,9 +164,26 @@ describe("resolveHomeModelGate precedence", () => {
   });
 
   it("resolves the residual to observation_idle rather than a query nobody is running", () => {
-    // Nothing loading, nothing failed, nothing observed, and an all-unsupported
-    // catalog that will never produce a model: the honest answer is "ask me".
-    expect(resolveHomeModelGate(input({ agentReadiness: ["unsupported"] })))
+    expect(resolveHomeModelGate(input({ agentReadiness: ["ready"] })))
+      .toEqual({ kind: "blocked", reason: "observation_idle" });
+  });
+
+  it("states an all-unsupported catalog terminally and offers nothing to press", () => {
+    // No probe can ever produce a model here, and `refetchAgents` re-reads an
+    // identical built-in registry — so a Refresh would be a button that does
+    // nothing, forever, without even the honesty of being refused.
+    const gate = resolveHomeModelGate(input({ agentReadiness: ["unsupported", "unsupported"] }));
+    expect(gate).toEqual({ kind: "blocked", reason: "agents_unsupported" });
+    expect(resolveHomeModelGateNotice(gate)).toEqual({
+      text: HOME_MODEL_GATE_AGENTS_UNSUPPORTED_NOTICE,
+      actionLabel: null,
+      action: null,
+    });
+    // One unsupported agent beside a working one must never claim it.
+    expect(resolveHomeModelGate(input({ agentReadiness: ["unsupported", "ready"] })))
+      .not.toEqual({ kind: "blocked", reason: "agents_unsupported" });
+    // An empty catalog has not established anything about support.
+    expect(resolveHomeModelGate(input({ agentReadiness: [] })))
       .toEqual({ kind: "blocked", reason: "observation_idle" });
   });
 
@@ -216,6 +235,7 @@ describe("resolveHomeModelGate precedence", () => {
       input({ observations: [observation({ state: "failed_without_observation" })] }),
       input({ observations: [observation({ isError: true })] }),
       input({ observations: [observation({ state: "detecting", probePhase: "idle" })] }),
+      input({ agentReadiness: ["unsupported"] }),
       input({ isCatalogLoading: true }),
     ];
     for (const testCase of cases) {
@@ -310,10 +330,12 @@ describe("home model gate presentation", () => {
       actionLabel: "Refresh",
       action: "retry_probe",
     });
+    // "Couldn't check your models." already says a probe RAN and failed, which
+    // is strictly more than "it was refused" says. Trading it away loses a fact.
     expect(resolveHomeModelGateNotice(
       { kind: "blocked", reason: "observation_failed" },
       { refreshRejected: true },
-    )?.text).toBe(HOME_MODEL_GATE_REFRESH_REJECTED_NOTICE);
+    )?.text).toBe("Couldn't check your models.");
 
     // A notice whose action never calls the mutation cannot be blamed for it.
     for (const reason of ["agent_setup_required", "transport_error", "target_unobserved"] as const) {
@@ -324,6 +346,29 @@ describe("home model gate presentation", () => {
     // And a silent gate stays silent.
     expect(resolveHomeModelGateNotice({ kind: "selection_required" }, { refreshRejected: true }))
       .toBeNull();
+  });
+
+  it("reports a refresh that is still running instead of a settled sentence", () => {
+    // A probe can take 45s per kind and they are serialized, and the query does
+    // not poll a settled row — so the terminal sentence would otherwise sit
+    // over live work for a minute at a time.
+    const running = resolveHomeModelGateNotice(
+      { kind: "blocked", reason: "observation_idle" },
+      { refreshPending: true, refreshRejected: true },
+    );
+    expect(running?.text).toBe(HOME_MODEL_GATE_REFRESHING_NOTICE);
+    expect(running?.action).toBe("retry_probe");
+    // In flight beats refused: a rejection from the previous attempt must not
+    // outrank the attempt happening now.
+    expect(resolveHomeModelGateNotice(
+      { kind: "blocked", reason: "observation_idle" },
+      { refreshRejected: true },
+    )?.text).toBe(HOME_MODEL_GATE_REFRESH_REJECTED_NOTICE);
+    // And a notice that never fires a probe says nothing about one.
+    expect(resolveHomeModelGateNotice(
+      { kind: "blocked", reason: "agents_unsupported" },
+      { refreshPending: true },
+    )?.text).toBe(HOME_MODEL_GATE_AGENTS_UNSUPPORTED_NOTICE);
   });
 
   it("keeps the picker enabled for observed_empty and disabled for the failures", () => {
@@ -338,6 +383,7 @@ describe("home model gate presentation", () => {
         "transport_error",
         "target_unobserved",
         "observation_idle",
+        "agents_unsupported",
       ] as const satisfies readonly HomeModelGateBlockedReason[]
     ) {
       expect(resolveHomeModelSelectorAvailability({ kind: "blocked", reason }))

--- a/apps/packages/product-client/src/lib/domain/home/home-model-gate.test.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-model-gate.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   HOME_MODEL_GATE_AGENT_SETUP_NOTICE,
   HOME_MODEL_GATE_BLOCKED_REASONS,
+  HOME_MODEL_GATE_REFRESH_REJECTED_NOTICE,
   HOME_MODEL_GATE_REFUSAL_ANNOUNCEMENT,
+  homeModelGateNeedsNewProbe,
   resolveHomeModelGate,
   resolveHomeModelGateNotice,
   resolveHomeModelGateRefusalAnnouncement,
@@ -288,6 +290,40 @@ describe("home model gate presentation", () => {
         actionLabel: "Check again",
         action: "check_target_again",
       });
+  });
+
+  it("names a new probe as the cure for exactly the gate that promises one", () => {
+    // The retry path reads THIS, so it cannot disagree with the arm that chose
+    // the reason — which is how a Refresh got promised to states the retry
+    // then answered with a re-read of the row that already said so.
+    const needing = ALL_GATES.filter(homeModelGateNeedsNewProbe);
+    expect(needing).toEqual([{ kind: "blocked", reason: "observation_idle" }]);
+  });
+
+  it("says a refused refresh instead of repeating a sentence that cannot change", () => {
+    const rejected = resolveHomeModelGateNotice(
+      { kind: "blocked", reason: "observation_idle" },
+      { refreshRejected: true },
+    );
+    expect(rejected).toEqual({
+      text: HOME_MODEL_GATE_REFRESH_REJECTED_NOTICE,
+      actionLabel: "Refresh",
+      action: "retry_probe",
+    });
+    expect(resolveHomeModelGateNotice(
+      { kind: "blocked", reason: "observation_failed" },
+      { refreshRejected: true },
+    )?.text).toBe(HOME_MODEL_GATE_REFRESH_REJECTED_NOTICE);
+
+    // A notice whose action never calls the mutation cannot be blamed for it.
+    for (const reason of ["agent_setup_required", "transport_error", "target_unobserved"] as const) {
+      const untouched = resolveHomeModelGateNotice({ kind: "blocked", reason });
+      expect(resolveHomeModelGateNotice({ kind: "blocked", reason }, { refreshRejected: true }))
+        .toEqual(untouched);
+    }
+    // And a silent gate stays silent.
+    expect(resolveHomeModelGateNotice({ kind: "selection_required" }, { refreshRejected: true }))
+      .toBeNull();
   });
 
   it("keeps the picker enabled for observed_empty and disabled for the failures", () => {

--- a/apps/packages/product-client/src/lib/domain/home/home-model-gate.test.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-model-gate.test.ts
@@ -8,9 +8,11 @@ import {
   resolveHomeModelGateRefusalAnnouncement,
   resolveHomeModelSelectorAvailability,
   type HomeModelGate,
+  type HomeModelGateBlockedReason,
   type HomeModelGateInput,
   type HomeModelGateObservation,
 } from "#product/lib/domain/home/home-model-gate";
+import { resolveModelSelectorEnabled } from "#product/lib/domain/chat/models/model-selector-types";
 
 function input(overrides: Partial<HomeModelGateInput> = {}): HomeModelGateInput {
   return {
@@ -123,20 +125,64 @@ describe("resolveHomeModelGate precedence", () => {
     }))).toEqual({ kind: "blocked", reason: "observation_pending" });
   });
 
-  it("does not treat a settled detecting harness as pending", () => {
-    // A manual-refresh-only harness sits `detecting` by design. Reporting that
-    // as in-flight is the 32-minute "Probing..." bug.
-    expect(resolveHomeModelGate(input({
+  it("reports a settled detecting harness as observation_idle, with a cure", () => {
+    // A harness excluded from automatic probing sits `detecting` + `idle`
+    // forever. Calling that in-flight is the "Probing…" that never ends;
+    // calling it `querying` is a silent dead end with nothing to press.
+    const gate = resolveHomeModelGate(input({
       observations: [observation({ state: "detecting", probePhase: "idle" })],
-    }))).toEqual({ kind: "blocked", reason: "querying" });
+    }));
+    expect(gate).toEqual({ kind: "blocked", reason: "observation_idle" });
+    expect(resolveHomeModelSelectorAvailability(gate)).not.toBe("observation_pending");
+    const notice = resolveHomeModelGateNotice(gate);
+    expect(notice).toEqual({
+      text: "Models haven't been detected yet.",
+      actionLabel: "Refresh",
+      action: "retry_probe",
+    });
   });
 
-  it("reports agent_setup_required only for install_required or login_required", () => {
-    for (const readiness of ["install_required", "login_required"] as const) {
+  it("leaves no gate silent and actionless", () => {
+    // The whole point of the slice: every state either shows a notice whose
+    // action cures it, or leaves a control enabled that does.
+    for (const gate of ALL_GATES) {
+      const notice = resolveHomeModelGateNotice(gate);
+      const availability = resolveHomeModelSelectorAvailability(gate);
+      const pickerUsable = availability === "ready" || availability === "observed_empty";
+      const inFlight = gate.kind === "blocked"
+        && (gate.reason === "querying" || gate.reason === "observation_pending");
+      const noTarget = gate.kind === "blocked" && gate.reason === "target_missing";
+      expect(
+        notice !== null || pickerUsable || inFlight || noTarget,
+        `gate ${JSON.stringify(gate)} is silent with nothing to press`,
+      ).toBe(true);
+    }
+  });
+
+  it("resolves the residual to observation_idle rather than a query nobody is running", () => {
+    // Nothing loading, nothing failed, nothing observed, and an all-unsupported
+    // catalog that will never produce a model: the honest answer is "ask me".
+    expect(resolveHomeModelGate(input({ agentReadiness: ["unsupported"] })))
+      .toEqual({ kind: "blocked", reason: "observation_idle" });
+  });
+
+  it("reports agent_setup_required for every readiness the Agents pane can cure", () => {
+    // The product's own `getAgentsNeedingSetup` rule: not ready, not
+    // unsupported. `credentials_required` was missing before, which regressed
+    // against main — those users used to get the notice and its Agents link.
+    for (const readiness of [
+      "install_required",
+      "login_required",
+      "credentials_required",
+      "error",
+    ] as const) {
       expect(resolveHomeModelGate(input({ agentReadiness: [readiness] })))
         .toEqual({ kind: "blocked", reason: "agent_setup_required" });
     }
-    for (const readiness of ["ready", "credentials_required", "unsupported", "error"] as const) {
+    // `unsupported` is not setup and can never be cured, so it must not speak
+    // for the catalog — one unsupported agent alongside working ones would
+    // otherwise pin Home to a setup notice forever.
+    for (const readiness of ["ready", "unsupported"] as const) {
       expect(resolveHomeModelGate(input({ agentReadiness: [readiness] })))
         .not.toEqual({ kind: "blocked", reason: "agent_setup_required" });
     }
@@ -167,6 +213,8 @@ describe("resolveHomeModelGate precedence", () => {
       input({ observations: [observation({ state: "observed_empty" })] }),
       input({ observations: [observation({ state: "failed_without_observation" })] }),
       input({ observations: [observation({ isError: true })] }),
+      input({ observations: [observation({ state: "detecting", probePhase: "idle" })] }),
+      input({ isCatalogLoading: true }),
     ];
     for (const testCase of cases) {
       const gate = resolveHomeModelGate(testCase);
@@ -183,8 +231,15 @@ describe("home model gate presentation", () => {
     for (const gate of ALL_GATES) {
       const availability = resolveHomeModelSelectorAvailability(gate);
       const notice = resolveHomeModelGateNotice(gate);
-      const selectorEnabled =
-        availability !== "observation_pending" && availability !== "unavailable";
+      // The component's own expression, imported rather than restated, so the
+      // assertion cannot quietly agree with a copy of the rule.
+      const selectorEnabled = resolveModelSelectorEnabled({
+        disabled: false,
+        connectionState: "healthy",
+        isLoading: false,
+        hasAgents: true,
+        availability,
+      });
       expect(
         selectorEnabled && notice?.text === HOME_MODEL_GATE_AGENT_SETUP_NOTICE,
         `gate ${JSON.stringify(gate)} produced a coexistence`,
@@ -221,6 +276,12 @@ describe("home model gate presentation", () => {
         actionLabel: "Retry",
         action: "refetch_launch_options",
       });
+    expect(resolveHomeModelGateNotice({ kind: "blocked", reason: "observation_idle" }))
+      .toEqual({
+        text: "Models haven't been detected yet.",
+        actionLabel: "Refresh",
+        action: "retry_probe",
+      });
     expect(resolveHomeModelGateNotice({ kind: "blocked", reason: "target_unobserved" }))
       .toEqual({
         text: "Proliferate Cloud hasn't reported launch options yet.",
@@ -235,7 +296,14 @@ describe("home model gate presentation", () => {
       .toBe("observed_empty");
     expect(resolveHomeModelSelectorAvailability({ kind: "blocked", reason: "observation_pending" }))
       .toBe("observation_pending");
-    for (const reason of ["observation_failed", "transport_error", "target_unobserved"] as const) {
+    for (
+      const reason of [
+        "observation_failed",
+        "transport_error",
+        "target_unobserved",
+        "observation_idle",
+      ] as const satisfies readonly HomeModelGateBlockedReason[]
+    ) {
       expect(resolveHomeModelSelectorAvailability({ kind: "blocked", reason }))
         .toBe("unavailable");
     }

--- a/apps/packages/product-client/src/lib/domain/home/home-model-gate.test.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-model-gate.test.ts
@@ -168,16 +168,18 @@ describe("resolveHomeModelGate precedence", () => {
       .toEqual({ kind: "blocked", reason: "observation_idle" });
   });
 
-  it("states an all-unsupported catalog terminally and offers nothing to press", () => {
+  it("states an all-unsupported catalog terminally and offers only navigation", () => {
     // No probe can ever produce a model here, and `refetchAgents` re-reads an
     // identical built-in registry — so a Refresh would be a button that does
-    // nothing, forever, without even the honesty of being refused.
+    // nothing, forever, without even the honesty of being refused. The action
+    // is navigation instead: it makes no claim to fix anything, and it is the
+    // only thing standing between this state and a dead end.
     const gate = resolveHomeModelGate(input({ agentReadiness: ["unsupported", "unsupported"] }));
     expect(gate).toEqual({ kind: "blocked", reason: "agents_unsupported" });
     expect(resolveHomeModelGateNotice(gate)).toEqual({
       text: HOME_MODEL_GATE_AGENTS_UNSUPPORTED_NOTICE,
-      actionLabel: null,
-      action: null,
+      actionLabel: "See agents",
+      action: "agent_settings",
     });
     // One unsupported agent beside a working one must never claim it.
     expect(resolveHomeModelGate(input({ agentReadiness: ["unsupported", "ready"] })))
@@ -185,6 +187,21 @@ describe("resolveHomeModelGate precedence", () => {
     // An empty catalog has not established anything about support.
     expect(resolveHomeModelGate(input({ agentReadiness: [] })))
       .toEqual({ kind: "blocked", reason: "observation_idle" });
+  });
+
+  it("prefers agents_unsupported over a stale observed_empty row", () => {
+    // Both arms are live at once when an agent was installed, reported no
+    // models, and an OS or arch upgrade then made it unsupported. The row
+    // still says observed_empty, but nothing on this machine can ever answer
+    // again — so the terminal sentence is the true one, and the ENABLED empty
+    // picker `observed_empty` would keep is the false one. Ordering, not
+    // reachability: swap the two arms and this is the assertion that moves.
+    const gate = resolveHomeModelGate(input({
+      agentReadiness: ["unsupported", "unsupported"],
+      observations: [observation({ state: "observed_empty" })],
+    }));
+    expect(gate).toEqual({ kind: "blocked", reason: "agents_unsupported" });
+    expect(resolveHomeModelSelectorAvailability(gate)).toBe("unavailable");
   });
 
   it("reports agent_setup_required for every readiness the Agents pane can cure", () => {

--- a/apps/packages/product-client/src/lib/domain/home/home-model-gate.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-model-gate.ts
@@ -1,0 +1,297 @@
+import type {
+  AgentAuthProbePhase,
+  AgentReadinessState,
+  HarnessLaunchOptionsState,
+} from "@anyharness/sdk";
+
+/**
+ * Why Home cannot start a chat right now.
+ *
+ * The old `ModelAvailabilityState` collapsed every reason into
+ * `no_launchable_model`, and Home rendered "Finish agent setup to start a
+ * chat." for all of them. That sentence is a lie in most of them: an install
+ * still running is not unfinished setup, a harness that observed zero models
+ * is not unfinished setup, and a picker that already offers rows the user has
+ * simply not chosen from is the opposite of unfinished setup. Each reason
+ * below is a distinct thing that is true about the world, and each one has its
+ * own truthful surface (a notice, an enabled picker, or deliberate silence).
+ */
+export type HomeModelGateBlockedReason =
+  /** No execution target resolves yet, so nothing has been asked for models. */
+  | "target_missing"
+  /** A cloud target that has not reported launch options. Never inferred from
+   * a local observation — the cloud sandbox's copy is the only truth for it. */
+  | "target_unobserved"
+  /** A launch-option read is in flight and has never answered. */
+  | "querying"
+  /** The runtime answered, and says a probe or install is still working. */
+  | "observation_pending"
+  /** Agents are genuinely not set up: readiness is install_required or
+   * login_required. The ONLY reason that may say "Finish agent setup". */
+  | "agent_setup_required"
+  /** A settled observation that found no models. The agents are fine; they
+   * reported nothing. */
+  | "observed_empty"
+  /** The probe ran and failed without ever producing an observation. */
+  | "observation_failed"
+  /** The launch-option request itself failed; there is no state to read. */
+  | "transport_error";
+
+export type HomeModelGate =
+  | { kind: "launchable" }
+  | { kind: "selection_required" }
+  | { kind: "blocked"; reason: HomeModelGateBlockedReason };
+
+/** One harness's launch-option read, as the gate needs to see it. */
+export interface HomeModelGateObservation {
+  harnessKind: string;
+  /** `null` while the read has produced no response at all. */
+  state: HarnessLaunchOptionsState | null;
+  /** `null` when the runtime does not own the probe engine (or is not local). */
+  probePhase: AgentAuthProbePhase | null;
+  /** The read has never answered. */
+  isPending: boolean;
+  /** The read failed at the transport layer. */
+  isError: boolean;
+}
+
+export interface HomeModelGateInput {
+  /** False when no execution target resolves. */
+  hasLaunchTarget: boolean;
+  /** Cloud-only: the target exists but has never reported launch options. */
+  isTargetUnobserved: boolean;
+  /** The effective selection names a model that actually exists in a group. */
+  hasExactSelection: boolean;
+  /** How many model rows the picker can offer across every group. */
+  offeredModelCount: number;
+  observations: readonly HomeModelGateObservation[];
+  /** Readiness of every agent the catalog knows about. */
+  agentReadiness: readonly AgentReadinessState[];
+  /** An install/reconcile job is working right now. */
+  isInstalling: boolean;
+  /** The agent catalog's own HTTP read has never answered. */
+  isCatalogLoading: boolean;
+  /** The agent catalog's own HTTP read failed. */
+  hasCatalogError: boolean;
+}
+
+/**
+ * Resolves the one gate Home renders from.
+ *
+ * Precedence, and why it is this order:
+ *  1. No target, or a target that never reported: nothing downstream can be
+ *     true about models yet, and a cloud target must never read a local
+ *     observation to fill the gap.
+ *  2. An exact valid selection wins over every diagnostic. A refresh in flight
+ *     or a last-good-after-failure snapshot still has real, launchable rows.
+ *  3. Rows exist but nothing is selected: selection_required. There is NO
+ *     first-model fallback anywhere in this file — offering rows and selecting
+ *     one are different acts, and the product only performs the first.
+ *  4. In-flight reasons, so a running probe is never reported as a settled
+ *     failure or as unfinished setup.
+ *  5. Settled reasons, most specific first.
+ */
+export function resolveHomeModelGate(input: HomeModelGateInput): HomeModelGate {
+  if (!input.hasLaunchTarget) {
+    return blocked("target_missing");
+  }
+  if (input.isTargetUnobserved) {
+    return blocked("target_unobserved");
+  }
+  if (input.hasExactSelection) {
+    return { kind: "launchable" };
+  }
+  if (input.offeredModelCount > 0) {
+    return { kind: "selection_required" };
+  }
+
+  if (
+    input.isCatalogLoading
+    || input.observations.some((observation) =>
+      observation.isPending && !observation.isError
+    )
+  ) {
+    return blocked("querying");
+  }
+  if (input.isInstalling || input.observations.some(isProbeInFlight)) {
+    return blocked("observation_pending");
+  }
+
+  if (input.agentReadiness.some(readinessNeedsSetup)) {
+    return blocked("agent_setup_required");
+  }
+  if (input.observations.some((observation) => observation.state === "observed_empty")) {
+    return blocked("observed_empty");
+  }
+  if (
+    input.observations.some((observation) =>
+      observation.state === "failed_without_observation"
+    )
+  ) {
+    return blocked("observation_failed");
+  }
+  if (input.hasCatalogError || input.observations.some((observation) => observation.isError)) {
+    return blocked("transport_error");
+  }
+
+  // Residual: a target exists, nothing is loading, nothing failed, and no
+  // harness has said anything. The runtime lists every supported agent with a
+  // readiness state, so this is the gap before the first answer arrives, not a
+  // settled emptiness — and it must never be reported as one.
+  return blocked("querying");
+}
+
+/** `readiness` values that make "Finish agent setup to start a chat." true. */
+export function readinessNeedsSetup(readiness: AgentReadinessState): boolean {
+  return readiness === "install_required" || readiness === "login_required";
+}
+
+function isProbeInFlight(observation: HomeModelGateObservation): boolean {
+  return observation.probePhase === "queued" || observation.probePhase === "running";
+}
+
+function blocked(reason: HomeModelGateBlockedReason): HomeModelGate {
+  return { kind: "blocked", reason };
+}
+
+/** Every gate value, for exhaustive table-driven tests. */
+export const HOME_MODEL_GATE_BLOCKED_REASONS = [
+  "target_missing",
+  "target_unobserved",
+  "querying",
+  "observation_pending",
+  "agent_setup_required",
+  "observed_empty",
+  "observation_failed",
+  "transport_error",
+] as const satisfies readonly HomeModelGateBlockedReason[];
+
+/**
+ * What the picker trigger is allowed to claim, derived from the gate.
+ *
+ * Keeping this a function OF the gate is what makes ruling 2 structural: an
+ * enabled trigger and a "Finish agent setup" notice cannot both be rendered,
+ * because `agent_setup_required` maps to `unavailable` here and to the notice
+ * in `resolveHomeModelGateNotice`, and `unavailable` disables the trigger.
+ */
+export type HomeModelSelectorAvailability =
+  /** Rows are exactly what the target observed; choose freely. */
+  | "ready"
+  /** No observation exists yet; choice is impossible by construction. */
+  | "observation_pending"
+  /** Agents answered and reported no models. The picker is the cure path. */
+  | "observed_empty"
+  /** A failed or missing observation: the picker has nothing truthful to show. */
+  | "unavailable";
+
+export function resolveHomeModelSelectorAvailability(
+  gate: HomeModelGate,
+): HomeModelSelectorAvailability {
+  if (gate.kind !== "blocked") {
+    return "ready";
+  }
+  switch (gate.reason) {
+    case "observed_empty":
+      return "observed_empty";
+    case "querying":
+    case "observation_pending":
+      return "observation_pending";
+    case "target_missing":
+    case "target_unobserved":
+    case "agent_setup_required":
+    case "observation_failed":
+    case "transport_error":
+      return "unavailable";
+  }
+}
+
+/** The action a blocked notice offers. Each one cures its own state. */
+export type HomeModelGateNoticeAction =
+  | "agent_settings"
+  | "retry_probe"
+  | "refetch_launch_options"
+  | "check_target_again";
+
+export interface HomeModelGateNotice {
+  text: string;
+  actionLabel: string;
+  action: HomeModelGateNoticeAction;
+}
+
+export const HOME_MODEL_GATE_AGENT_SETUP_NOTICE = "Finish agent setup to start a chat.";
+
+/**
+ * The visible line under the composer, or `null` for the states that must stay
+ * silent.
+ *
+ * `selection_required` and `observed_empty` are deliberately silent (owner
+ * revisions r2 and r3): both are cured by the enabled picker itself, and a
+ * sentence next to a control that already says what to do reads as a dead end
+ * rather than an instruction. `querying` / `observation_pending` are silent
+ * because work is in flight and the toast already owns that story.
+ */
+export function resolveHomeModelGateNotice(gate: HomeModelGate): HomeModelGateNotice | null {
+  if (gate.kind !== "blocked") {
+    return null;
+  }
+  switch (gate.reason) {
+    case "agent_setup_required":
+      return {
+        text: HOME_MODEL_GATE_AGENT_SETUP_NOTICE,
+        actionLabel: "Agents",
+        action: "agent_settings",
+      };
+    case "observation_failed":
+      return {
+        text: "Couldn't check your models.",
+        actionLabel: "Retry",
+        action: "retry_probe",
+      };
+    case "transport_error":
+      return {
+        text: "Models couldn't be loaded.",
+        actionLabel: "Retry",
+        action: "refetch_launch_options",
+      };
+    case "target_unobserved":
+      return {
+        text: "Proliferate Cloud hasn't reported launch options yet.",
+        actionLabel: "Check again",
+        action: "check_target_again",
+      };
+    case "target_missing":
+    case "querying":
+    case "observation_pending":
+    case "observed_empty":
+      return null;
+  }
+}
+
+/** The disabled Send's tooltip and accessible name while a model is unchosen. */
+export const HOME_MODEL_GATE_SEND_BLOCKED_REASON = "Choose a model";
+
+/** What the sr-only status region says when Enter is refused. */
+export const HOME_MODEL_GATE_REFUSAL_ANNOUNCEMENT = "Choose a model before sending";
+
+/**
+ * The live-region text for the Nth refusal.
+ *
+ * A screen reader announces a status region when its text CHANGES, so a second
+ * identical refusal would be silent. Appending anything (a count, a bullet)
+ * would stack and would put numerals into a region ruling 6 keeps free of
+ * them, so the two renderings differ only by a trailing no-break space: the
+ * same sentence, a different string, nothing read out that is not the reason.
+ * The nudge is a NO-BREAK space: accessible-name computation collapses a
+ * trailing ordinary space, which would make the two renderings identical.
+ */
+export function resolveHomeModelGateRefusalAnnouncement(refusalCount: number): string {
+  if (refusalCount <= 0) {
+    return "";
+  }
+  return refusalCount % 2 === 1
+    ? HOME_MODEL_GATE_REFUSAL_ANNOUNCEMENT
+    : `${HOME_MODEL_GATE_REFUSAL_ANNOUNCEMENT}\u00a0`;
+}
+
+/** The picker trigger the refusal moves focus to. */
+export const HOME_MODEL_TRIGGER_SELECTOR = "[data-composer-model-trigger]";

--- a/apps/packages/product-client/src/lib/domain/home/home-model-gate.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-model-gate.ts
@@ -32,6 +32,13 @@ export type HomeModelGateBlockedReason =
   /** A settled observation that found no models. The agents are fine; they
    * reported nothing. */
   | "observed_empty"
+  /**
+   * Every agent the runtime knows about is unsupported on this machine. The
+   * only terminal state in the union: no probe can produce a model and no
+   * button can change that, so it is the one reason whose notice offers no
+   * action rather than one that quietly does nothing.
+   */
+  | "agents_unsupported"
   /** The probe ran and failed without ever producing an observation. */
   | "observation_failed"
   /**
@@ -42,12 +49,15 @@ export type HomeModelGateBlockedReason =
    * until a user asks. Reporting it as in-flight is the "Probing…" that never
    * ends; reporting nothing at all is a dead end with no cure on screen.
    *
-   * This is also where a `backoff` probe phase lands, deliberately. A retry IS
-   * armed for a future time, so it is tempting to call it in flight — but
-   * `observation_pending` is not polled, so classifying it that way would
-   * manufacture a new permanently-silent state, which is the exact bug this
-   * reason exists to remove. "Models haven't been detected yet." is literally
-   * true of a backed-off harness, and the Refresh does not wait for the timer.
+   * A `backoff` probe phase lands here too, deliberately. `probe_phase` only
+   * returns `Backoff` when the durable row is NOT in flight — an in-flight row
+   * is forced to `queued`/`running` — so backoff always arrives on a SETTLED
+   * row (an `observed` or `last_good_after_failure` row with zero models and a
+   * retry armed for a future time), never on a `detecting` one. Calling it
+   * in-flight would map it to `observation_pending`, which is not polled, and
+   * so would manufacture a new permanently-silent state — the exact bug this
+   * reason removes. The sentence is true of it, and `refresh_now` never
+   * consults the backoff timer, so the cure works immediately.
    */
   | "observation_idle"
   /** The launch-option request itself failed; there is no state to read. */
@@ -136,6 +146,14 @@ export function resolveHomeModelGate(input: HomeModelGateInput): HomeModelGate {
   if (input.agentReadiness.some(readinessNeedsSetup)) {
     return blocked("agent_setup_required");
   }
+  // Before any "nobody has looked" story: nothing CAN look. Requires at least
+  // one known agent, so an empty catalog never claims this.
+  if (
+    input.agentReadiness.length > 0
+    && input.agentReadiness.every((readiness) => readiness === "unsupported")
+  ) {
+    return blocked("agents_unsupported");
+  }
   if (input.observations.some((observation) => observation.state === "observed_empty")) {
     return blocked("observed_empty");
   }
@@ -200,8 +218,9 @@ export function isSettledUnobservedHarness(
  *  - `unsupported`: NOT setup. Nothing the user can do makes this agent run on
  *    this machine, so it must never speak for the whole catalog — a single
  *    unsupported agent alongside working ones would otherwise pin Home to a
- *    setup notice forever. It falls through to `observation_idle`, which has
- *    a real cure, so it is never silent.
+ *    setup notice forever. When it is the ONLY thing the catalog holds, the
+ *    dedicated `agents_unsupported` reason states that plainly instead of
+ *    offering a Refresh that re-reads the same list forever.
  */
 export function readinessNeedsSetup(readiness: AgentReadinessState): boolean {
   switch (readiness) {
@@ -247,6 +266,7 @@ export const HOME_MODEL_GATE_BLOCKED_REASONS = [
   "observation_pending",
   "agent_setup_required",
   "observed_empty",
+  "agents_unsupported",
   "observation_failed",
   "observation_idle",
   "transport_error",
@@ -289,6 +309,7 @@ export function resolveHomeModelSelectorAvailability(
     case "target_missing":
     case "target_unobserved":
     case "agent_setup_required":
+    case "agents_unsupported":
     case "observation_failed":
     case "observation_idle":
     case "transport_error":
@@ -296,100 +317,19 @@ export function resolveHomeModelSelectorAvailability(
   }
 }
 
-/** The action a blocked notice offers. Each one cures its own state. */
-export type HomeModelGateNoticeAction =
-  | "agent_settings"
-  | "retry_probe"
-  | "refetch_launch_options"
-  | "check_target_again";
-
-export interface HomeModelGateNotice {
-  text: string;
-  actionLabel: string;
-  action: HomeModelGateNoticeAction;
-}
-
-export const HOME_MODEL_GATE_AGENT_SETUP_NOTICE = "Finish agent setup to start a chat.";
-
-/**
- * Shown in place of a probe-cured notice when the probe itself was REFUSED.
- *
- * A rejected refresh writes no durable state, so the underlying gate does not
- * move and the same sentence would render again unchanged — a button that
- * appears to do nothing, forever. (A probe that runs and FAILS is already
- * visible: the runtime records `failed_without_observation` and the gate flips
- * to "Couldn't check your models.")
- */
-export const HOME_MODEL_GATE_REFRESH_REJECTED_NOTICE = "Couldn't refresh your models.";
-
-/**
- * The visible line under the composer, or `null` for the states that must stay
- * silent.
- *
- * `selection_required` and `observed_empty` are deliberately silent (owner
- * revisions r2 and r3): both are cured by the enabled picker itself, and a
- * sentence next to a control that already says what to do reads as a dead end
- * rather than an instruction. `querying` / `observation_pending` are silent
- * because work is in flight and the toast already owns that story.
- */
-export function resolveHomeModelGateNotice(
-  gate: HomeModelGate,
-  options: { refreshRejected?: boolean } = {},
-): HomeModelGateNotice | null {
-  const notice = resolveGateNotice(gate);
-  // Only a notice whose action FIRES a probe can have that probe refused; the
-  // others never call the mutation, so its error says nothing about them.
-  if (notice && options.refreshRejected && notice.action === "retry_probe") {
-    return { ...notice, text: HOME_MODEL_GATE_REFRESH_REJECTED_NOTICE };
-  }
-  return notice;
-}
-
-function resolveGateNotice(gate: HomeModelGate): HomeModelGateNotice | null {
-  if (gate.kind !== "blocked") {
-    return null;
-  }
-  switch (gate.reason) {
-    case "agent_setup_required":
-      return {
-        text: HOME_MODEL_GATE_AGENT_SETUP_NOTICE,
-        actionLabel: "Agents",
-        action: "agent_settings",
-      };
-    case "observation_failed":
-      return {
-        text: "Couldn't check your models.",
-        actionLabel: "Retry",
-        action: "retry_probe",
-      };
-    // Same words and the same cure as the Settings models section, which
-    // solved this state first: an honest "nobody has looked yet" plus a
-    // Refresh that looks. Never "Probing…" — nothing is probing.
-    case "observation_idle":
-      return {
-        text: "Models haven't been detected yet.",
-        actionLabel: "Refresh",
-        action: "retry_probe",
-      };
-    case "transport_error":
-      return {
-        text: "Models couldn't be loaded.",
-        actionLabel: "Retry",
-        action: "refetch_launch_options",
-      };
-    case "target_unobserved":
-      return {
-        text: "Proliferate Cloud hasn't reported launch options yet.",
-        actionLabel: "Check again",
-        action: "check_target_again",
-      };
-    case "target_missing":
-    case "querying":
-    case "observation_pending":
-    case "observed_empty":
-      return null;
-  }
-}
+// Notice resolution lives in a sibling module purely for size; this file stays
+// the one import path every consumer uses, so nothing downstream moves.
+export {
+  HOME_MODEL_GATE_AGENT_SETUP_NOTICE,
+  HOME_MODEL_GATE_AGENTS_UNSUPPORTED_NOTICE,
+  HOME_MODEL_GATE_REFRESHING_NOTICE,
+  HOME_MODEL_GATE_REFRESH_REJECTED_NOTICE,
+  resolveHomeModelGateNotice,
+} from "#product/lib/domain/home/home-model-gate-notice";
+export type {
+  HomeModelGateNotice,
+  HomeModelGateNoticeAction,
+} from "#product/lib/domain/home/home-model-gate-notice";
 
 /** The disabled Send's tooltip and accessible name while a model is unchosen. */
 export const HOME_MODEL_GATE_SEND_BLOCKED_REASON = "Choose a model";

--- a/apps/packages/product-client/src/lib/domain/home/home-model-gate.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-model-gate.ts
@@ -34,9 +34,9 @@ export type HomeModelGateBlockedReason =
   | "observed_empty"
   /**
    * Every agent the runtime knows about is unsupported on this machine. The
-   * only terminal state in the union: no probe can produce a model and no
-   * button can change that, so it is the one reason whose notice offers no
-   * action rather than one that quietly does nothing.
+   * only state in the union with no cure: no probe can produce a model and no
+   * button can change that, so its notice offers NAVIGATION to the agents
+   * pane rather than a repair that would quietly do nothing.
    */
   | "agents_unsupported"
   /** The probe ran and failed without ever producing an observation. */

--- a/apps/packages/product-client/src/lib/domain/home/home-model-gate.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-model-gate.ts
@@ -41,6 +41,13 @@ export type HomeModelGateBlockedReason =
    * automatic probing (`AUTO_PROBE_EXCLUDED_HARNESSES`) live here permanently
    * until a user asks. Reporting it as in-flight is the "Probing…" that never
    * ends; reporting nothing at all is a dead end with no cure on screen.
+   *
+   * This is also where a `backoff` probe phase lands, deliberately. A retry IS
+   * armed for a future time, so it is tempting to call it in flight — but
+   * `observation_pending` is not polled, so classifying it that way would
+   * manufacture a new permanently-silent state, which is the exact bug this
+   * reason exists to remove. "Models haven't been detected yet." is literally
+   * true of a backed-off harness, and the Refresh does not wait for the timer.
    */
   | "observation_idle"
   /** The launch-option request itself failed; there is no state to read. */
@@ -213,6 +220,21 @@ function isProbeInFlight(observation: HomeModelGateObservation): boolean {
   return observation.probePhase === "queued" || observation.probePhase === "running";
 }
 
+/**
+ * Whether this gate's cure is a NEW probe rather than another read.
+ *
+ * The retry path reads THIS, keyed on the gate the resolver already produced,
+ * rather than re-deriving the condition from the observations. `observation_idle`
+ * is reached from two arms — a settled-unobserved harness and the residual —
+ * and a retry that re-checked only the first arm's predicate promised a
+ * Refresh to everything arriving through the second and then delivered a
+ * re-read of the same durable row. One fact, read once, cannot disagree with
+ * itself; two predicates over the same inputs can, and did.
+ */
+export function homeModelGateNeedsNewProbe(gate: HomeModelGate): boolean {
+  return gate.kind === "blocked" && gate.reason === "observation_idle";
+}
+
 function blocked(reason: HomeModelGateBlockedReason): HomeModelGate {
   return { kind: "blocked", reason };
 }
@@ -290,6 +312,17 @@ export interface HomeModelGateNotice {
 export const HOME_MODEL_GATE_AGENT_SETUP_NOTICE = "Finish agent setup to start a chat.";
 
 /**
+ * Shown in place of a probe-cured notice when the probe itself was REFUSED.
+ *
+ * A rejected refresh writes no durable state, so the underlying gate does not
+ * move and the same sentence would render again unchanged — a button that
+ * appears to do nothing, forever. (A probe that runs and FAILS is already
+ * visible: the runtime records `failed_without_observation` and the gate flips
+ * to "Couldn't check your models.")
+ */
+export const HOME_MODEL_GATE_REFRESH_REJECTED_NOTICE = "Couldn't refresh your models.";
+
+/**
  * The visible line under the composer, or `null` for the states that must stay
  * silent.
  *
@@ -299,7 +332,20 @@ export const HOME_MODEL_GATE_AGENT_SETUP_NOTICE = "Finish agent setup to start a
  * rather than an instruction. `querying` / `observation_pending` are silent
  * because work is in flight and the toast already owns that story.
  */
-export function resolveHomeModelGateNotice(gate: HomeModelGate): HomeModelGateNotice | null {
+export function resolveHomeModelGateNotice(
+  gate: HomeModelGate,
+  options: { refreshRejected?: boolean } = {},
+): HomeModelGateNotice | null {
+  const notice = resolveGateNotice(gate);
+  // Only a notice whose action FIRES a probe can have that probe refused; the
+  // others never call the mutation, so its error says nothing about them.
+  if (notice && options.refreshRejected && notice.action === "retry_probe") {
+    return { ...notice, text: HOME_MODEL_GATE_REFRESH_REJECTED_NOTICE };
+  }
+  return notice;
+}
+
+function resolveGateNotice(gate: HomeModelGate): HomeModelGateNotice | null {
   if (gate.kind !== "blocked") {
     return null;
   }

--- a/apps/packages/product-client/src/lib/domain/home/home-model-gate.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-model-gate.ts
@@ -34,6 +34,15 @@ export type HomeModelGateBlockedReason =
   | "observed_empty"
   /** The probe ran and failed without ever producing an observation. */
   | "observation_failed"
+  /**
+   * The target settled without ever observing this harness, and nothing will
+   * change that on its own: the read answered, no probe is queued or running,
+   * and the runtime is not going to schedule one. Harnesses excluded from
+   * automatic probing (`AUTO_PROBE_EXCLUDED_HARNESSES`) live here permanently
+   * until a user asks. Reporting it as in-flight is the "Probing…" that never
+   * ends; reporting nothing at all is a dead end with no cure on screen.
+   */
+  | "observation_idle"
   /** The launch-option request itself failed; there is no state to read. */
   | "transport_error";
 
@@ -133,17 +142,71 @@ export function resolveHomeModelGate(input: HomeModelGateInput): HomeModelGate {
   if (input.hasCatalogError || input.observations.some((observation) => observation.isError)) {
     return blocked("transport_error");
   }
+  if (input.observations.some(isSettledUnobservedHarness)) {
+    return blocked("observation_idle");
+  }
 
-  // Residual: a target exists, nothing is loading, nothing failed, and no
-  // harness has said anything. The runtime lists every supported agent with a
-  // readiness state, so this is the gap before the first answer arrives, not a
-  // settled emptiness — and it must never be reported as one.
-  return blocked("querying");
+  // Residual: a target exists, nothing is in flight, nothing failed, and no
+  // harness has produced an observation. Whatever combination of inputs got
+  // here, the world is not going to move without the user, so the residual is
+  // the state that says exactly that AND offers the cure. It is deliberately
+  // NOT `querying`: a silent, actionless "still asking" that no longer asks is
+  // the dead end this gate exists to remove.
+  return blocked("observation_idle");
 }
 
-/** `readiness` values that make "Finish agent setup to start a chat." true. */
+/**
+ * A harness the target has settled on without ever observing it.
+ *
+ * `detecting` is the runtime's pre-observation state, and `probePhase` is what
+ * says whether anything is still working on it. `idle` means nothing is: no
+ * probe is queued, none is running, and none will be scheduled automatically
+ * for an excluded harness. Combined with a read that has answered and did not
+ * fail, that is an unambiguous "ask me and I will look".
+ */
+export function isSettledUnobservedHarness(
+  observation: HomeModelGateObservation,
+): boolean {
+  return observation.state === "detecting"
+    && observation.probePhase === "idle"
+    && !observation.isPending
+    && !observation.isError;
+}
+
+/**
+ * `readiness` values that make "Finish agent setup to start a chat." true.
+ *
+ * Deliberately an exhaustive `switch` with NO `default:` arm: a new
+ * `AgentReadinessState` variant must fail to compile here rather than fall
+ * silently into whichever residual happens to be last. The mapping below is
+ * today's answer; the exhaustiveness is the durable part.
+ *
+ * The rule is the product's own `getAgentsNeedingSetup` rule — not ready and
+ * not unsupported — and it is the same rule for the same reason: every one of
+ * these four states is a thing the user resolves in the Agents pane, which is
+ * exactly where the notice's action sends them.
+ *
+ *  - `credentials_required`: the user holds the missing key. Leaving it out
+ *    was a regression against main, which said "Finish agent setup" here.
+ *  - `error`: the runtime could not evaluate the agent. Re-probing it would
+ *    loop on the same failure; the Agents pane is where the error is shown.
+ *  - `unsupported`: NOT setup. Nothing the user can do makes this agent run on
+ *    this machine, so it must never speak for the whole catalog — a single
+ *    unsupported agent alongside working ones would otherwise pin Home to a
+ *    setup notice forever. It falls through to `observation_idle`, which has
+ *    a real cure, so it is never silent.
+ */
 export function readinessNeedsSetup(readiness: AgentReadinessState): boolean {
-  return readiness === "install_required" || readiness === "login_required";
+  switch (readiness) {
+    case "install_required":
+    case "login_required":
+    case "credentials_required":
+    case "error":
+      return true;
+    case "ready":
+    case "unsupported":
+      return false;
+  }
 }
 
 function isProbeInFlight(observation: HomeModelGateObservation): boolean {
@@ -163,16 +226,21 @@ export const HOME_MODEL_GATE_BLOCKED_REASONS = [
   "agent_setup_required",
   "observed_empty",
   "observation_failed",
+  "observation_idle",
   "transport_error",
 ] as const satisfies readonly HomeModelGateBlockedReason[];
 
 /**
  * What the picker trigger is allowed to claim, derived from the gate.
  *
- * Keeping this a function OF the gate is what makes ruling 2 structural: an
- * enabled trigger and a "Finish agent setup" notice cannot both be rendered,
- * because `agent_setup_required` maps to `unavailable` here and to the notice
- * in `resolveHomeModelGateNotice`, and `unavailable` disables the trigger.
+ * Both this and `resolveHomeModelGateNotice` are functions of the SAME gate,
+ * which is what keeps ruling 2 checkable in one place: `agent_setup_required`
+ * maps to `unavailable` here and to the setup notice there. That is a property
+ * of these two mappings, ENFORCED BY TESTS at both seams — the notice/trigger
+ * pairing and the trigger's own enablement rule — not by the union's shape.
+ * Nothing in the types stops a caller passing no `availability` at all (it
+ * defaults to `"ready"`) or passing `hasAgents: false` next to a notice, so
+ * the tests, not the compiler, are the guarantee.
  */
 export type HomeModelSelectorAvailability =
   /** Rows are exactly what the target observed; choose freely. */
@@ -200,6 +268,7 @@ export function resolveHomeModelSelectorAvailability(
     case "target_unobserved":
     case "agent_setup_required":
     case "observation_failed":
+    case "observation_idle":
     case "transport_error":
       return "unavailable";
   }
@@ -245,6 +314,15 @@ export function resolveHomeModelGateNotice(gate: HomeModelGate): HomeModelGateNo
       return {
         text: "Couldn't check your models.",
         actionLabel: "Retry",
+        action: "retry_probe",
+      };
+    // Same words and the same cure as the Settings models section, which
+    // solved this state first: an honest "nobody has looked yet" plus a
+    // Refresh that looks. Never "Probing…" — nothing is probing.
+    case "observation_idle":
+      return {
+        text: "Models haven't been detected yet.",
+        actionLabel: "Refresh",
         action: "retry_probe",
       };
     case "transport_error":

--- a/apps/packages/product-client/src/lib/domain/home/home-model-refresh-attempt.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-model-refresh-attempt.ts
@@ -1,0 +1,34 @@
+/**
+ * One Refresh press, counted per attempted harness kind.
+ *
+ * Counted rather than read off the mutation because a single `useMutation`
+ * observer tracks only its most recent call: fire two kinds, have one refused
+ * and one succeed, and `isError` reports whichever finished last. The user
+ * would be told the refresh was refused because of start order.
+ *
+ * Outcomes must therefore be attributed from each call's own promise. That
+ * observer keeps ONE `#mutateOptions` slot and removes the previous observer
+ * on every `mutate`, so with N kinds only the LAST call's per-call callbacks
+ * run — `settled` would stop at 1 while `attempted` was N, pinning the
+ * in-flight sentence on screen forever and making the all-refused sentence
+ * unreachable for N >= 2.
+ */
+export interface RefreshAttempt {
+  attempted: number;
+  settled: number;
+  refused: number;
+}
+
+export const IDLE_REFRESH_ATTEMPT: RefreshAttempt = { attempted: 0, settled: 0, refused: 0 };
+
+export function isRefreshInFlight(attempt: RefreshAttempt): boolean {
+  return attempt.attempted > 0 && attempt.settled < attempt.attempted;
+}
+
+/** Refused only when NOTHING got through: one kind succeeding means the
+ * refresh did something, whatever another kind answered. */
+export function isRefreshRefused(attempt: RefreshAttempt): boolean {
+  return attempt.attempted > 0
+    && attempt.settled === attempt.attempted
+    && attempt.refused === attempt.attempted;
+}

--- a/apps/packages/product-client/src/lib/domain/home/home-next-launch.test.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-next-launch.test.ts
@@ -17,7 +17,6 @@ import {
   localBranchNames,
   resolveEffectiveHomeModelSelection,
   resolveHomeLaunchTarget,
-  resolveHomeModelAvailabilityState,
   resolveHomeNextDefaultBranchName,
   resolveSelectedHomeNextAgentOption,
 } from "#product/lib/domain/home/home-next-launch";
@@ -242,29 +241,6 @@ describe("home-next agent helpers", () => {
 });
 
 describe("home-next model helpers", () => {
-  it("resolves model availability with launchable data before pending or failed refreshes", () => {
-    expect(resolveHomeModelAvailabilityState({
-      isLoading: true,
-      hasLoadError: true,
-      hasLaunchableModel: true,
-    })).toBe("launchable");
-    expect(resolveHomeModelAvailabilityState({
-      isLoading: false,
-      hasLoadError: true,
-      hasLaunchableModel: true,
-    })).toBe("launchable");
-    expect(resolveHomeModelAvailabilityState({
-      isLoading: false,
-      hasLoadError: false,
-      hasLaunchableModel: true,
-    })).toBe("launchable");
-    expect(resolveHomeModelAvailabilityState({
-      isLoading: false,
-      hasLoadError: false,
-      hasLaunchableModel: false,
-    })).toBe("no_launchable_model");
-  });
-
   it("builds all ready registry models and treats encoded model ids as opaque", () => {
     const groups = buildHomeNextModelGroups(
       [

--- a/apps/packages/product-client/src/lib/domain/home/home-next-launch.ts
+++ b/apps/packages/product-client/src/lib/domain/home/home-next-launch.ts
@@ -53,13 +53,6 @@ export type HomeNextModelSelection = AgentModelSelection;
 export type HomeNextModelOption = AgentModelOption;
 export type HomeNextModelGroup = AgentModelGroup;
 export type HomeNextModelInfo = AgentModelInfo;
-export type ModelAvailabilityState =
-  | "loading"
-  | "load_error"
-  | "target_unobserved"
-  | "no_launchable_model"
-  | "launchable";
-
 export interface HomeNextLaunchPreferences {
   defaultChatAgentKind: string;
   defaultChatModelIdByAgentKind: Record<string, string>;
@@ -102,26 +95,6 @@ export type HomeNextLaunchOutcome =
   | "duplicate"
   /** Never attempted: no launch slot, no such target on this host, no prompt. */
   | "refused";
-
-export function resolveHomeModelAvailabilityState(input: {
-  isLoading: boolean;
-  hasLoadError: boolean;
-  hasLaunchableModel: boolean;
-}): ModelAvailabilityState {
-  if (input.hasLaunchableModel) {
-    return "launchable";
-  }
-  if (input.isLoading) {
-    return "loading";
-  }
-  if (input.hasLoadError) {
-    return "load_error";
-  }
-  if (input.hasLaunchableModel) {
-    return "launchable";
-  }
-  return "no_launchable_model";
-}
 
 export function buildHomeNextAgentOptions(
   agents: AgentCatalogSummary[],

--- a/lints/frontend/ratchets.toml
+++ b/lints/frontend/ratchets.toml
@@ -28,7 +28,7 @@ reason = "Desktop diagnostics broker server: the accept loop, per-request admiss
 
 [[max_lines]]
 path = "apps/packages/product-client/src/components/home/screen/HomeNextScreen.test.tsx"
-max_lines = 769
+max_lines = 744
 reason = "home screen suite: unified-composer/target-persistence coverage joined by the PRO-165 home-attachment battery (+ button snapshot payload, whole-screen drop, dropped-path local_ref recovery, local/remote target-flip clearing, attachment-only launch, failure retention, chip removal)"
 
 [[max_lines]]


### PR DESCRIPTION
Slice C of the first-run-truth program. Stacked on `feat/launch-options-probe-phase` (slice B) — review that first; this PR's diff is only the Home-side commit.

## Why

Home derived one `ModelAvailabilityState` that collapsed every possible reason into `no_launchable_model`, and then rendered **"Finish agent setup to start a chat."** for all of them. That sentence is false in most of them: an install still running is not unfinished setup, a harness that observed zero models is not unfinished setup, and a picker that already offers rows the user simply has not chosen from is the *opposite* of unfinished setup. Worse, the enabled "Select model" pill and that notice could render side by side, telling the user two contradictory things at once.

## What

A single `HomeModelGate` discriminated union — `launchable | selection_required | blocked{reason}` over eight reasons — is now the one thing Home renders from, and both the notice and the picker availability are pure functions of it.

| gate | notice | picker |
| --- | --- | --- |
| `launchable` | none | ready |
| `selection_required` | **none** (r2) | ready |
| `blocked: target_missing` | none | unavailable |
| `blocked: target_unobserved` | "Proliferate Cloud hasn't reported launch options yet." + Check again | unavailable |
| `blocked: querying` | none | observation_pending |
| `blocked: observation_pending` | none | observation_pending |
| `blocked: agent_setup_required` | "Finish agent setup to start a chat." + Agents | unavailable |
| `blocked: observed_empty` | **none** (r3) | **enabled**, empty body "Your agents reported no models yet." |
| `blocked: observation_failed` | "Couldn't check your models." + Retry | unavailable |
| `blocked: observation_idle` | "Models haven't been detected yet." + Refresh | unavailable |
| `blocked: agents_unsupported` | "No agents are supported on this machine." + See agents (navigation to that harness's pane) | unavailable |
| any probe-cured notice while a probe is **running** | "Refreshing your models…" + same action | unchanged |
| `observation_idle` after an **all-refused** probe | "Couldn't refresh your models." + same action | unchanged |
| `blocked: transport_error` | "Models couldn't be loaded." + Retry | unavailable |

Governed by owner revisions **r2** (the selection-required visible notice is dropped — the pill, the disabled-Send tooltip and an sr-only announcement carry it) and **r3** (`observed_empty` shows no notice and keeps the picker enabled with an empty-body message). Copy is grepped from the frozen `.dc.html` Home renders, not invented.

### Correctness properties, each with a test

- **No first-model fallback anywhere.** A persisted default naming a model this target never observed resolves to nothing, and the gate then keeps offering the rows it does have rather than substituting one. `hasExactSelection` requires both an effective selection *and* a model info that resolves from it.
- **Coexistence is impossible by construction.** `agent_setup_required` maps to the notice *and* to `availability: "unavailable"`, so an enabled pill next to "Finish agent setup" is unreachable. Asserted as a table over **every** gate value, not per screen.
- **Readiness is an exhaustive `switch` with no `default:` arm**, so a new `AgentReadinessState` variant cannot compile until someone decides what it means. Today it answers the product's own `getAgentsNeedingSetup` rule — not ready and not unsupported — which is what makes the notice legal for `install_required`, `login_required`, `credentials_required` and `error`, all four being things the Agents pane cures. `unsupported` is deliberately excluded: it can never be cured, so one unsupported agent beside working ones must not pin Home to a setup notice.
- **Cloud `target_unobserved` never falls back to local observations.** The cloud branch also contributes an empty `agentReadiness`, so the desktop catalog's readiness can never block a cloud launch.
- **`querying` vs `transport_error` come from slice B's per-kind flags.** `data === null` alone cannot tell "still being asked" from "the read failed"; the list query's `isPending` / `isError` can.
- **A settled `detecting` harness is neither pending nor silent.** A harness excluded from automatic probing sits at `detecting` + `probePhase: idle` permanently, so it gets its own reason, `observation_idle`, which maps to a real notice with an enabled Refresh — the same sentence and cure the Settings models section already uses. It is deliberately **not** `observation_pending`: renaming the state while still rendering a disabled trigger and no action would have left the "Probing…" that never ends exactly as it was.
- **No gate is silent and actionless.** The residual arm resolves to `observation_idle` too, so "nothing is in flight and nothing will be without the user" always comes with the button that changes it.
- **The Refresh is a real probe for every state that is offered one.** `observation_idle` is reached from two arms — a settled-unobserved harness and the residual — so the retry keys on the GATE through one exported helper rather than re-deriving the condition. Re-testing only the first arm's predicate had promised a Refresh to a backed-off harness, a runtime that owns no probe engine, an observation with zero models and a zero-model `last_good_after_failure`, then answered each with a re-read of the durable row that already said so. With no requested kind at all the single-kind query is *disabled*, so that re-read was a literal no-op behind a permanent sentence; the catalog read is the fallback there. Cloud is deliberately unchanged: a cloud response carries no `probePhase`, so it always lands in the residual, where re-asking the sandbox genuinely is the cure.
- **A `backoff` phase stays `observation_idle` on purpose.** `probe_phase` forces a durably in-flight row to `queued`/`running`, so `Backoff` only ever arrives on a row that is **not** in flight — `{state: "detecting", probePhase: "backoff"}` is not a producible wire shape, and the fixture that claimed it was has been corrected to a settled row. Classifying backoff as `observation_pending` would manufacture a new permanently-silent state (that arm is not polled), which is the bug this reason exists to remove. "Models haven't been detected yet." is true of a backed-off harness, and `refresh_now` never consults `backoff_admits`, so the Refresh does not wait for the timer.
- **Navigation lands on an agent that is actually unsupported.** `agent-settings` takes the harness kind the caller means, so the terminal notice opens the pane of the first unsupported harness rather than always Claude's — the justification for offering navigation at all is that the pane shows *which* agents are unsupported and why, which is false if it opens a pane reporting only that it has not been observed. An unmapped or absent kind keeps the previous default.
- **The one gate with no cure navigates instead of pretending.** A catalog whose every known agent is `unsupported` gets `agents_unsupported`: a probe there would re-read an identical built-in registry forever. It therefore carries navigation ("See agents") and deliberately not Refresh/Retry vocabulary — navigation claims to fix nothing, it takes the user where they can see which agents are unsupported and why. A buttonless sentence was the first attempt and was rejected on review: with the picker `unavailable`, it left Home with no interactive affordance at all. `HomeModelGateNotice.action` is non-optional, so a notice with nothing to press cannot typecheck.
- **`agents_unsupported` outranks `observed_empty`, and the order is pinned.** Both arms are live at once when an agent was installed, reported no models, and an OS or arch upgrade then made it unsupported: the row still says `observed_empty`, but nothing here can answer again. The terminal sentence with a disabled picker is the true rendering; the enabled empty picker is the false one. It also requires at least one known agent, so an empty catalog can never claim it.
- **A running refresh says it is running, and can stop saying it.** Probes are serialized at `max_concurrent_probes: 1` and allowed 45s per kind, and the query does not poll a `detecting` + `idle` row, so without this the terminal sentence would sit over live work for minutes. Pending and refused are a per-attempt count — `{attempted, settled, refused}` — because one `useMutation` observer only remembers its last call. The outcomes come from `mutateAsync` promises through `Promise.allSettled`, **not** from per-call `onSuccess`/`onError`: that observer keeps a single `#mutateOptions` slot and removes the previous observer on every `mutate`, so with N kinds only the last call's callbacks ever run. Counting those stalled at `settled = 1` of N, which pinned "Refreshing your models…" permanently for two ready harnesses and made the all-refused sentence unreachable for N ≥ 2. The tally is never discarded once owed: an earlier run-id guard, added to drop batches settling after a target switch, turned out to drop legitimate ones — the probe is keyed on `harnessKind` and is machine-global, so a local→cloud→local flip left a refused refresh with no receipt at all and the settled sentence rendering over probes still in flight. Overlap is closed at the source instead: the notice action is **disabled while `retryPending`**, so a second press cannot start a batch that settles out of order against the first.
- **Refusal is claimed only when nothing got through.** Two kinds where one succeeds is a refresh that did something, so it is not reported as a failure. Both `retryPending` and `retryRejected` are scoped to local targets and reset when the launch-target kind changes, so a refusal raised on the desktop cannot follow the user to Cloud, where no mutation runs that could ever clear it.
- **`observation_failed` keeps its own sentence when a refresh is refused.** "Couldn't check your models." says a probe ran and failed; overwriting it with "Couldn't refresh your models." would trade information for uniformity.
- **A refused probe says so.** A rejection writes no durable state, so the gate cannot move and the same sentence would render forever behind a button that appears to work. Only notices whose action actually fires the mutation are affected; a probe that runs and *fails* is already visible as "Couldn't check your models."
- **Every blocked notice has an enabled cure** (r5). `observation_failed` fires a *new* probe via the refresh mutation — refetching would just re-read the recorded failure — while `transport_error` and the cloud check re-issue the request (cloud re-reads the sandbox first, since a missing sandbox is one of the two ways it reads unobserved).
- **Refused Enter** preserves the draft, moves focus to `[data-composer-model-trigger]`, does **not** open the popover, and re-commits the sr-only announcement. The two renderings differ only by a trailing U+00A0 — a screen reader re-announces on change, nothing stacks, and no numeral ever enters the live region (r6). An ordinary trailing space was rejected: accessible-name computation collapses it, making both renderings identical.

## Deviations from the spec's expected-files list

1. The gate lives in a **new** `lib/domain/home/home-model-gate.ts` rather than being appended to `home-next-launch.ts` (that file is already 357 lines against a 600 cap, and the gate is a self-contained domain concept). The dead `ModelAvailabilityState` / `resolveHomeModelAvailabilityState` were deleted from `home-next-launch.ts`.
2. Three files beyond the list were needed to thread the two new seams: `ComposerRichTextEditor.tsx` and `HomeComposerCommandEditor.tsx` for `onSubmitRefused`, and `model-selector-types.ts` for `availability`.
3. `hooks/chat/ui/use-chat-composer-keyboard.ts` was **not** touched. Home does not use it — Enter is owned by the Lexical `KEY_ENTER_COMMAND` handler in `ComposerBehaviorPlugin`, which swallows the key regardless, so a new `onSubmitRefused` callback was the only place a refusal is observable.
4. `availability` defaults to `"ready"` on `ModelSelectorProps`, so workspace chat is behaviourally unchanged.
5. Two more modules split out for the same size reason, same rule — the refresh tally in `lib/domain/home/home-model-refresh-attempt.ts` (34 lines) keeps the selection hook at 378 under FE-SIZE-1's 400, and the launch-options wire fixtures in `hooks/home/derived/home-model-selection.fixtures.tsx` (73 lines) keep its test at 564 under the 600-line cap. No ratchet entry was added or raised for either.
6. Notice resolution lives in a **new** `lib/domain/home/home-model-gate-notice.ts` (147 lines as of this head), purely so `home-model-gate.ts` clears the 400-line `FE-SIZE-1` threshold at 361 rather than taking a ratchet entry. `home-model-gate.ts` remains the single public import path and re-exports all 20 exports it had before the split; the sibling is imported by nothing else, and no consumer path moved. `use-home-next-model-selection.test.tsx` was likewise brought back under the 600-line cap by collapsing repeated `renderHook` boilerplate into one local helper, not by ratcheting.
7. Test-file splits to stay under the size checkers: the new assertions live in `HomeNextScreen.model-gate.test.tsx`, `ComposerModelSelectorControl.availability.test.tsx` and `ComposerRichTextEditor.submit-refusal.test.tsx` rather than growing the existing files. `HomeNextScreen.test.tsx` shrank 769 → 744, and its ratchet in `lints/frontend/ratchets.toml` was shrunk to match.
8. `useRefetchAgentLaunchOptionsKind` lives in `hooks/access/anyharness/agents/` because `FE-CACHE-1` reserves `useQueryClient` for the cache-owning layers; it is imported from there rather than sitting next to the other Home launch-option hooks.
9. Behaviour change worth flagging in review: `hasAgents` on the Home selector props now comes from the **agent catalog** rather than `groups.length > 0`. Deriving it from groups meant a catalog full of agents that had not yet reported models rendered "No agents", which is the same class of lie this slice exists to remove.

## Tests

Env-scrubbed, `--maxWorkers=2`, scope derived from `git diff --stat` against the base.

```
$ npx tsc --noEmit
TSC_EXIT=0

$ npx vitest run --maxWorkers=2 src/components/workspace/chat src/components/home \
    src/hooks/chat src/hooks/home src/hooks/access/anyharness src/lib/domain/chat \
    src/lib/domain/home src/copy

 Test Files  220 passed (220)
      Tests  1704 passed (1704)

$ npx vitest run --maxWorkers=4          # the whole product-client suite
 Test Files  1101 passed (1101)
      Tests  8284 passed (8284)

$ python3 scripts/report_frontend_structure.py
  FE-SIZE-1: 0
  TOTAL: 0
```

`src/hooks/access/anyharness` is in scope because it consumes the same list hook and now owns the per-kind refetch.

Repo checkers: `check_max_lines`, `check_frontend_boundaries`, `check_component_library`, `check_design_attribution`, `check_docs` — all PASS. No rule and no ratchet was edited in round 4: `git diff lints/ scripts/` is empty.

### Negative control

Reverting each fix and watching the specific test fail, then restoring.

**Round 1** — re-collapsed the gate to the old `no_launchable_model` mapping (`offeredModelCount > 0` returns `agent_setup_required`, and `agent_setup_required` maps back to an enabled picker): `Tests 6 failed | 37 passed (43)`, failing the coexistence invariant, both selection-required tests, the `last_good_after_failure` case and the screen-level pairing.

**Round 2** — restored the silent residual (`observation_idle` removed from both the settled check and the residual, `credentials_required`/`error` dropped back out of `readinessNeedsSetup`) and re-widened `refuseSubmit` to every non-launchable gate with no empty guard:

```
 Test Files  3 failed (3)
      Tests  8 failed | 44 passed (52)

 FAIL  HomeNextScreen.model-gate.test.tsx > does not refuse an EMPTY composer out of the editor
AssertionError: expected <button data-composer-model-trigger /> to be <textarea aria-label="Prompt" />
 FAIL  HomeNextScreen.model-gate.test.tsx > does not announce an unchoosable model or focus a disabled trigger
AssertionError: expected 'Choose a model before sending' to be ''
 FAIL  use-home-next-model-selection.test.tsx > reports a settled unprobed harness as observation_idle and refreshes it
AssertionError: expected { reason: 'querying' } to deeply equal { reason: 'observation_idle' }
 FAIL  use-home-next-model-selection.test.tsx > never lets a cloud target read the desktop catalog's readiness
AssertionError: expected { reason: 'querying' } to deeply equal { reason: 'observation_idle' }
 FAIL  home-model-gate.test.ts > reports a settled detecting harness as observation_idle, with a cure
AssertionError: expected { reason: 'querying' } to deeply equal { reason: 'observation_idle' }
 FAIL  home-model-gate.test.ts > resolves the residual to observation_idle rather than a query nobody is running
AssertionError: expected { reason: 'querying' } to deeply equal { reason: 'observation_idle' }
 FAIL  home-model-gate.test.ts > reports agent_setup_required for every readiness the Agents pane can cure
AssertionError: expected { reason: 'querying' } to deeply equal { reason: 'agent_setup_required' }
 FAIL  home-model-gate.test.ts > every reason is reachable
AssertionError: expected [ 'agent_setup_required', ...(7) ] to deeply equal [ 'agent_setup_required', ...(8) ]
-   "observation_idle",
```

**Round 3** — reverted the gate-keyed retry to re-deriving `isSettledUnobservedHarness`, and stopped passing the rejection to the notice:

```
 Test Files  2 failed | 1 passed (3)
      Tests  6 failed | 57 passed (63)

FAIL fires a real probe for observation_idle reached via a backed-off probe
FAIL fires a real probe for observation_idle reached via a runtime that owns no probe engine
FAIL fires a real probe for observation_idle reached via an observation with zero models
FAIL fires a real probe for observation_idle reached via a zero-model last_good_after_failure
  AssertionError: expected "spy" to be called with arguments: [ 'claude' ]
FAIL re-reads the catalog when observation_idle has no kind to probe
  AssertionError: expected "spy" to be called at least once
FAIL says the refresh was refused rather than re-rendering the same sentence
  TestingLibraryElementError: Unable to find an element with the text: Couldn't refresh your models.
```

Restored, and the same three suites are green again:

```
 Test Files  3 passed (3)
      Tests  63 passed (63)
```

**Round 4** — each fix reverted, the literal failure quoted, then restored and re-verified.

| Fix | Revert | Literal result |
| --- | --- | --- |
| C-R21 split | restore the 421-line file | `home-model-gate.ts:1: FE-SIZE-1 … TOTAL: 1` |
| C-R23 Send name | `=== "selection_required"` → `!== "launchable"` | `AssertionError: expected true to be false` |
| C-R24 gate arm | drop the `agents_unsupported` arm | `expected { kind: 'blocked', …(1) } to deeply equal …` |
| C-R24 no button | give the terminal notice a Refresh | `expected <button …(1)></button> to be null` |
| C-R25 pending | `retryPending: false` | `AssertionError: expected false to be true` |
| C-R26 all-refused | `refused === attempted` → `refused > 0` | `AssertionError: expected true to be false` |
| C-R28 negations | leak a notice into a no-notice gate | `expected <span></span> to be null` |

**C-R22 is reported honestly as redundant, not proven.** Reverting the prescribed `!isCloudTarget` scope alone still passes, because the reset on launch-target kind (added in the same round) already clears the attempt; reverting the reset alone also passes, because the scope covers it. Only removing **both** fails, with `AssertionError: expected true to be false`. Both are kept — the scope is what makes the property structural rather than dependent on an effect firing — and the test's comment now states exactly that, instead of implying it pins either mechanism on its own.

**C-R27 has no behavioural negative control**, and that is the finding: the fixture asserted the same gate either way, which is why an impossible wire shape survived review. It is corrected as a truth fix grounded in `launch_probe/mod.rs:269-301`, not a behaviour fix.

**Round 5** — anchor-asserted (the edit is confirmed landed before the control is trusted) and every restore verified byte-identical with `cmp`.

| Fix | Revert | Literal result |
| --- | --- | --- |
| C-R29 promises | per-call `onSuccess`/`onError` on the shared observer | `AssertionError: expected true to be false` (`retryPending` never clears) |
| C-R29 run id | drop the `refreshRunId` comparison | `AssertionError: expected true to be false` |
| C-R30 card list | seed a third card | `expected [ 'Add a GitHub repo', …(2) ] to deeply equal [ 'Add a GitHub repo', …(1) ]` |
| C-R31 ordering | move `agents_unsupported` below `observed_empty` | `expected { kind: 'blocked', …(1) } to deeply equal { kind: 'blocked', …(1) }` |
| C-R32 navigation | swap to `Refresh` / `retry_probe` | `expected <button …(1)></button> to be null` |

One control **passed** and was investigated rather than banked: replacing `allSettled` with a per-promise `.then` counter still passes, which is correct — promises are attributable however many callers share the observer, so that variant is also sound. The defect is specific to per-call *callbacks*, and the control that isolates it is the one above.

**Round 6** — every control anchor-asserted (`matched=1` plus a changed file sha) before the suite ran, and every restore proven byte-identical with `cmp`.

| Fix | Revert | Literal result |
| --- | --- | --- |
| C-R34 tally | restore the reset + run-id guard | `AssertionError: expected false to be true` (owed refusal dropped) |
| C-R34 overlap | re-enable the action while pending | `AssertionError: expected false to be true` |
| C-R35 deletion | swap `toBeNull()` for two never-emitted literals | `Tests 4 passed` — proving the deleted lines asserted nothing |
| C-R36 routing | hardcode the section back to `null` | `expected "spy" to be called with arguments: [ '/settings?section=agent-cursor' ]` |

The C-R36 control **passed on its first run**, which was a defect in the test, not a pass: the screen suite mocks `handleHomeAction`, so it never executed the routing at all. A test was added in the facade's own suite that calls the real `handleHomeAction`, and the control then fails as above.

### Inert-assertion sweep

**Bound of the sweep, stated plainly.** Round 5 searched one space: string and regex literals passed to a `query*By*` call **on a line that also carried a negative matcher**, in the ten test files this slice touches, grepped against `apps/`, `anyharness/` and `cloud/`. That method found and fixed three at `HomeNextScreen.test.tsx:347-349`, and correctly cleared five more (`Mock cowork`/`Mock local`/`Mock ssh`, `attachment:notes.txt`, `attachment:shot.png`) as live, since the file's own mocks emit them at lines 124-127 and 168 with positive assertions at 454, 503, 686 and 710.

It also **missed three**, and the miss was in the method rather than the execution: `use-home-next-state.test.tsx:168-170` negated `"Loading models"`, `"Couldn't load models"` and `"No ready models"` via `expect(...).not.toBe(...)` on a plain hook value, with no `query*By*` call anywhere on the line, so the pattern never saw them. They are deleted; the `toBeNull()` above them was always the real assertion and dominated all three. The only repo-wide occurrence of any of the three is `model_discovery.rs:137` matching CLI stdout, which can never be a disabled reason.

The claim this round is therefore narrow: no inert negation remains **that either the literal sweep or a `not.toBe` scan over this slice's ten test files can find**. Assertions negating a non-literal, or living in files this slice does not touch, were not searched.

Two assertions in `HomeNextScreen.model-gate.test.tsx` could never have failed, and both are replaced: `queryByText(/Probing/i)` (no Home path emits that string — "Probing" lives only under `settings/`, and Home's own copy is "Processing your models…") and `queryByText(/configured/i)` (only settings panes emit it). The rest of the new assertions were checked and do have teeth: every negated notice sentence is one the same slot can render, and the picker-body checks use `document.body.textContent`, so node splitting cannot silently pass them.

## Follow-ups (not in scope here)

- **C-R16**: the notice slot renders one sentence at a time by construction, so a state that is simultaneously refreshing and refused shows only the refreshing sentence. That is the correct precedence today, but if a future state needs to stack two facts the slot will need to become a list rather than a single node. Not attempted here.

- The cloud copy store has no list read, so the other-harness fan-out is local-runtime only; a cloud launch keeps today's single-kind behaviour.
- `ChatComposerActions` still renders whatever `disabledReason` it is handed, including on an empty composer. Home now nulls the reason when empty, matching the convention `submitDisabledReason` already followed one line above it; workspace chat's own `sendBlockedReason` has the same shape and is outside this slice.
- `leaves no gate silent and actionless` currently exempts `querying` and `observation_pending` on the assumption that in-flight states are transient. Once the restack picks up slice B's fix, tighten the exemption to require that an in-flight state carries a polling interval, so a permanently-pending state fails the invariant. Not attempted from this base, where B's fixed behaviour is not visible.
- Routed to slice B by the reviewer, not touched here: `combine` forwarding raw `isPending` for a disabled query, the polling policy stopping on `detecting + idle`, and the stale-basis option discarding in `launch_options/service.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



