### PR TITLE
fix(observability): model AMG provisioning normalization

### DIFF
--- a/guides/operating/production-alerts.md
+++ b/guides/operating/production-alerts.md
@@ -308,8 +308,12 @@ Discovered live 2026-08-21 (Lane A3), not previously documented:
    `grafana-default-sns` with a provisioning `PUT`; the `name` field selects
    the outer receiver group. There is no contact-point `POST` and no policy
    write. Before that `PUT`, the tool requires the exact authored root policy,
-   SNS UID/config, both partial Slack UIDs, generated routes, six unrouted
-   rules, and `0600` credential files. After it, the tool requires the full
+   SNS UID/config, both partial Slack UIDs, generated routes, all six rules to
+   carry their provider-normalized `notification_settings: null`, and `0600`
+   credential files. On AMG, the own `notification_settings` key is always
+   present; `null` means the rule has no direct receiver and the root policy is
+   authoritative. A missing key or non-null value fails closed. After the PUT,
+   the tool requires the full
    provider readback to equal the prior state minus only the generated
    `sns receiver` child. It then runs one isolated Slack-only receiver test.
    Only after that structural and delivery proof does it delete the other
@@ -317,6 +321,25 @@ Discovered live 2026-08-21 (Lane A3), not previously documented:
    `dfvuf540l7ym8d`). A lost response resumes only from an exact readback; a
    verification or test failure moves `efvuhlsl31mo0e` back to `sns receiver`
    and verifies the original state without deleting `dfvuf540l7ym8d`.
+
+   Grafana 10.4.7 exposes two different safe readback shapes for the same Slack
+   integration. The provisioning contact contains exactly `uid`, `name`,
+   `type`, `disableResolveMessage`, and `settings`; `settings` contains the
+   exact title/text plus `token` and `url` set to the literal ten-byte sentinel
+   `[REDACTED]`. It contains no `secureFields` or `provenance`. The full
+   Alertmanager receiver config instead contains title/text only and proves the
+   stored webhook through `secureFields.url: true`. The SNS provisioning
+   contact likewise has no `secureFields` or `provenance` and contains only its
+   exact `authProvider`, `messageFormat`, and `topic` settings. The reconciler
+   pins each surface independently and rejects plaintext, empty or malformed
+   sentinels, extra settings, or cross-surface drift.
+
+   The first post-#2204 live attempt on 2026-08-21 stopped in preflight with
+   `Default SNS provisioning contact is missing or drifted`: the then-reviewed
+   validator expected a `secureFields` property that AMG does not return on the
+   provisioning surface. No PUT, receiver test, delete, policy write, or Slack
+   delivery occurred. This safe stop is why provider-normalized GET fixtures
+   are part of the deterministic suite before the next live attempt.
 
 ### Repository artifacts
 

--- a/scripts/ops/grafana-rebuild-bootstrap.mjs
+++ b/scripts/ops/grafana-rebuild-bootstrap.mjs
@@ -82,6 +82,7 @@ const SLACK_RULE_UIDS = Object.freeze([...KNOWN_UIDS, SIGN_IN_RULE_UID]);
 const DEFAULT_GROUP_BY = Object.freeze(["grafana_folder", "alertname"]);
 const SLACK_TITLE = "{{ template \"slack.default.title\" . }}";
 const SLACK_TEXT = "{{ template \"slack.default.text\" . }}";
+const REDACTED_SENTINEL = "[REDACTED]";
 
 function safeLog(...parts) {
   console.log(parts.map((p) => redact(String(p))).join(" "));
@@ -560,18 +561,6 @@ function assertSlackConfig(config, uid, name) {
   }
 }
 
-function contactWithoutStableProvenance(contact) {
-  if (!contact || typeof contact !== "object" || Array.isArray(contact)) return contact;
-  const normalized = structuredClone(contact);
-  if (Object.hasOwn(normalized, "provenance")) {
-    if (normalized.provenance !== "api" && normalized.provenance !== "") {
-      throw new Error("Provisioning contact has unexpected provenance");
-    }
-    delete normalized.provenance;
-  }
-  return normalized;
-}
-
 function assertSnsProvisioningContact(contact, overlay) {
   const expected = {
     uid: overlay.contactPoint.uid,
@@ -579,9 +568,8 @@ function assertSnsProvisioningContact(contact, overlay) {
     type: overlay.contactPoint.type,
     disableResolveMessage: overlay.contactPoint.disableResolveMessage,
     settings: overlay.contactPoint.settings,
-    secureFields: {},
   };
-  if (!isDeepStrictEqual(contactWithoutStableProvenance(contact), expected)) {
+  if (!isDeepStrictEqual(contact, expected)) {
     throw new Error("Default SNS provisioning contact is missing or drifted");
   }
 }
@@ -592,10 +580,14 @@ function assertProvisioningContact(contact, uid, name) {
     name,
     type: "slack",
     disableResolveMessage: false,
-    settings: { title: SLACK_TITLE, text: SLACK_TEXT },
-    secureFields: { url: true },
+    settings: {
+      text: SLACK_TEXT,
+      title: SLACK_TITLE,
+      token: REDACTED_SENTINEL,
+      url: REDACTED_SENTINEL,
+    },
   };
-  if (!isDeepStrictEqual(contactWithoutStableProvenance(contact), expected)) {
+  if (!isDeepStrictEqual(contact, expected)) {
     throw new Error(`Slack provisioning contact ${uid} is missing or drifted`);
   }
 }
@@ -630,8 +622,11 @@ function assertRulesUnrouted(ruleReadbacks) {
     if (readback.status === 404 || !readback.body) {
       throw new Error(`Grafana rule ${uid} is missing`);
     }
-    if (Object.hasOwn(readback.body, "notification_settings")) {
-      throw new Error(`Grafana rule ${uid} has notification_settings; default routing is no longer authoritative`);
+    if (!Object.hasOwn(readback.body, "notification_settings")) {
+      throw new Error(`Grafana rule ${uid} is missing its normalized notification_settings field`);
+    }
+    if (readback.body.notification_settings !== null) {
+      throw new Error(`Grafana rule ${uid} has non-null notification_settings; default routing is not authoritative`);
     }
   }
 }

--- a/scripts/ops/grafana-rebuild-bootstrap.test.mjs
+++ b/scripts/ops/grafana-rebuild-bootstrap.test.mjs
@@ -381,6 +381,7 @@ function slackWorkspace({
   testConfigStatus = "ok",
   testResponseField = "configs",
   ruleNotificationUid = null,
+  missingRuleNotificationUid = null,
   mutateSnsAfterTargetWrite = false,
   mutateRouteAfterTargetWrite = false,
   targetContactUid,
@@ -408,11 +409,11 @@ function slackWorkspace({
       type: "slack",
       disableResolveMessage: false,
       settings: {
-        title: "{{ template \"slack.default.title\" . }}",
         text: "{{ template \"slack.default.text\" . }}",
+        title: "{{ template \"slack.default.title\" . }}",
+        token: "[REDACTED]",
+        url: "[REDACTED]",
       },
-      secureFields: { url: true },
-      provenance: "api",
     };
   }
   const state = {
@@ -422,8 +423,6 @@ function slackWorkspace({
       type: "sns",
       disableResolveMessage: false,
       settings: structuredClone(overlay.contactPoint.settings),
-      secureFields: {},
-      provenance: "api",
     }],
     calls: [],
     updatePayload: null,
@@ -583,14 +582,13 @@ function slackWorkspace({
     },
     getAlertRule: async (uid) => {
       state.calls.push(`getAlertRule:${uid}`);
-      return {
-        status: 200,
-        body: {
-          uid,
-          title: `rule-${uid}`,
-          ...(uid === ruleNotificationUid ? { notification_settings: { receiver: "drifted" } } : {}),
-        },
+      const body = {
+        uid,
+        title: `rule-${uid}`,
+        notification_settings: uid === ruleNotificationUid ? { receiver: "drifted" } : null,
       };
+      if (uid === missingRuleNotificationUid) delete body.notification_settings;
+      return { status: 200, body };
     },
     getAlertmanagerConfig: async () => {
       state.calls.push("getAlertmanagerConfig");
@@ -882,19 +880,31 @@ test("provisioning contact normalization drift blocks preflight with zero mutati
       contact.settings.text = "drifted";
     },
     (contact) => {
-      delete contact.secureFields;
+      contact.settings.token = "[redacted]";
     },
     (contact) => {
-      contact.secureFields.url = false;
+      contact.settings.url = "https://example.invalid/not-a-secret";
     },
     (contact) => {
-      contact.settings.url = "[REDACTED]";
+      contact.settings.token = "";
+    },
+    (contact) => {
+      delete contact.settings.url;
+    },
+    (contact) => {
+      delete contact.settings.token;
     },
     (contact) => {
       contact.settings.extra = "drifted";
     },
     (contact) => {
-      contact.provenance = "file";
+      contact.secureFields = { url: true };
+    },
+    (contact) => {
+      contact.provenance = "api";
+    },
+    (contact) => {
+      contact.extra = "drifted";
     },
   ];
 
@@ -916,10 +926,21 @@ test("both standalone provisioning contacts and the SNS contact must match their
     ({ overlay, state }) => {
       state.contacts.find((contact) => contact.uid === overlay.contactPoint.uid).settings.messageFormat = "drifted";
     },
+    ({ overlay, state }) => {
+      state.contacts.find((contact) => contact.uid === overlay.contactPoint.uid).secureFields = {};
+    },
+    ({ overlay, state }) => {
+      state.contacts.find((contact) => contact.uid === overlay.contactPoint.uid).provenance = "api";
+    },
+    ({ overlay, state }) => {
+      state.am.alertmanager_config.receivers
+        .find((receiver) => receiver.name === overlay.slackContactPoint.partialName)
+        .grafana_managed_receiver_configs[0].secureFields.url = false;
+    },
   ]) {
     const workspace = slackWorkspace({ withLegacy: true });
     mutate(workspace);
-    await assert.rejects(runSlackApply(slackRunArgs(workspace.client)), /provisioning contact/);
+    await assert.rejects(runSlackApply(slackRunArgs(workspace.client)), /provisioning contact|receiver config/);
     for (const call of ["updateContactPoint", "testReceiver", "deleteContactPoint", "postAlertmanagerConfig"]) {
       assert.equal(workspace.state.calls.includes(call), false);
     }
@@ -931,7 +952,7 @@ test("contact drift cannot pass combined-state resume or final verify/test", asy
   await assert.rejects(runSlackApply(slackRunArgs(combined.client)), /synthetic delete interruption/);
   combined.state.contacts.find(
     (contact) => contact.uid === combined.overlay.slackContactPoint.uid,
-  ).secureFields.url = false;
+  ).settings.url = "";
   combined.state.calls = [];
   await assert.rejects(runSlackApply(slackRunArgs(combined.client)), /provisioning contact/);
   for (const call of ["updateContactPoint", "testReceiver", "deleteContactPoint", "postAlertmanagerConfig"]) {
@@ -1014,6 +1035,22 @@ test("assertSlackCredentialModes requires both protected files to be mode 0600",
     );
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("all six rule readbacks require an own null notification_settings field", async () => {
+  for (const options of [
+    { missingRuleNotificationUid: "dfrmh7bc4yqrkf" },
+    { ruleNotificationUid: "ffvtx33lbo5c0e" },
+  ]) {
+    const { state, client } = slackWorkspace({ withLegacy: true, ...options });
+    await assert.rejects(
+      runSlackApply(slackRunArgs(client)),
+      /missing its normalized notification_settings field|non-null notification_settings/,
+    );
+    for (const call of ["updateContactPoint", "deleteContactPoint", "postAlertmanagerConfig", "testReceiver"]) {
+      assert.equal(state.calls.includes(call), false, `${call} must not run for rule-routing drift`);
+    }
   }
 });
 


### PR DESCRIPTION
## Summary

- Model the exact Grafana 10.4.7 provisioning-contact GET shape observed during the safe post-#2204 preflight stop.
- Require Slack provisioning settings to contain exact title/text plus literal `[REDACTED]` sentinels for token and URL, with no plaintext, extra fields, `secureFields`, or `provenance`.
- Require the exact SNS provisioning shape while retaining the separate full Alertmanager receiver contract of title/text plus `secureFields.url: true`.
- Treat an own `notification_settings: null` on all six rule GETs as provider-normalized absence of direct routing; reject missing or non-null values.
- Document the normalization seam and the prior fail-closed attempt.

Frozen base: 3aa07261d34f42cecfde6428f3dd83644816a553

Head: aa45026eaa999374a0fa454012dd24a319251117

Frozen scope: provider-normalized readback assertions, deterministic fakes/tests, and their operator documentation only. The canonical policy phases, PUT/test/delete order, response-loss handling, rollback behavior, protected payload, and production IDs are unchanged.

## Safe-stop evidence

- The first live attempt from merged #2204 exited during preflight with `Default SNS provisioning contact is missing or drifted` because the provisioning endpoint omits the `secureFields` property expected by that revision.
- GET-only evidence established the exact target shapes used in this PR: provisioning Slack contacts expose redacted token/URL sentinels, full Alertmanager Slack configs expose the secure marker, SNS provisioning has no secure/provenance properties, and rule `notification_settings` is present with value null.
- That attempt reached no PUT, receiver test, DELETE, policy write, or Slack delivery. This PR performed no live provider calls or tests.

## Testing

- Tier 1: `node --test scripts/ops/grafana-rebuild-bootstrap.test.mjs` (46/46 pass)
- `node --check scripts/ops/grafana-rebuild-bootstrap.mjs`
- `node --check scripts/ops/grafana-rebuild-bootstrap.test.mjs`
- `node scripts/ops/grafana-rebuild-bootstrap.mjs check`
- `python3.12 scripts/check_docs.py`
- `git diff --check`

## Observability

- Operator alert-delivery tooling only. No signal schema or production alert routing changes in this PR.
- Secret values remain absent from source, fixtures, logs, docs, and the PR; tests use only the provider's literal redaction sentinel.

## Readiness

- [x] I followed the [pull-request procedure](https://github.com/proliferate-ai/proliferate/blob/main/guides/process/pull-requests.md)
  for scope, title, labels, body, and readiness.

## Support and attribution (optional)

- [ ] If this PR has support relationships, I linked them through the tracker
  API. No tracker, report, user, or support IDs or private source data appear
  in this PR.

## Verification

- Negative coverage rejects wrong/redacted/plaintext/empty/missing/extra Slack settings, unexpected provisioning `secureFields`/`provenance`, SNS drift, missing/non-null rule normalization, and full-receiver secure-marker drift before any mutation or provider test.
- No Docker, Rust, Cargo, broad build, live Grafana mutation, or receiver test was run.
