### PR TITLE
fix(anyharness): scope dev-run cleanup to owned processes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,9 @@ jobs:
       - name: Test background launcher config
         run: node --test scripts/dev-background-launch.test.mjs
 
+      - name: Test dev-run process ownership
+        run: node --test scripts/dev-run-cleanup.test.mjs
+
       - name: Validate agent catalog generation discipline
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '' }}

--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,12 @@ dev-artifacts-ready:
 # Cleanup gives TERM-respecting processes five seconds before escalating only
 # the still-owned snapshot to KILL; each grace pass re-scans tracked roots for
 # launcher children created during shutdown.
+# Each retained root/descendant also retains a process identity. Linux uses
+# /proc start ticks; the POSIX fallback uses `ps lstart` at its one-second
+# granularity, so same-second reuse remains a documented fallback limitation.
+# Missing or changed identities are never signaled or traversed.
+# The check is repeated immediately before each numeric-PID signal; portable
+# shell cannot make that check-and-signal operation atomic.
 run: dev-artifacts-ready
 	@set -e; \
 	if [ -z "$(PROFILE)" ]; then \
@@ -238,53 +244,107 @@ run: dev-artifacts-ready
 	); \
 	database_url_override_set="$${DATABASE_URL+x}"; \
 	database_url_override_value="$${DATABASE_URL:-}"; \
+	process_identity() { \
+		pid="$$1"; \
+		case "$$pid" in \
+			''|*[!0-9]*) return 1 ;; \
+		esac; \
+		if [ "$$(uname -s 2>/dev/null || true)" = "Linux" ] && [ -r "/proc/$$pid/stat" ]; then \
+			stat=$$(cat "/proc/$$pid/stat" 2>/dev/null || true); \
+			rest="$${stat##*) }"; \
+			start_time=$$(printf '%s\n' "$$rest" | awk '{ print $$20 }'); \
+			if [ -n "$$start_time" ]; then \
+				printf 'linux-starttime:%s\n' "$$start_time"; \
+				return 0; \
+			fi; \
+			return 1; \
+		fi; \
+		start_time=$$(LC_ALL=C ps -o lstart= -p "$$pid" 2>/dev/null | awk 'NF { $$1=$$1; print; exit }'); \
+		if [ -z "$$start_time" ]; then return 1; fi; \
+		start_time=$$(printf '%s' "$$start_time" | tr ' ' '_'); \
+		printf 'posix-lstart:%s\n' "$$start_time"; \
+	}; \
 	owned_pids=""; \
+	owned_processes=""; \
 	last_owned_pid=""; \
 	run_lock_path="$$(dirname "$$launch_env")/run.lock"; \
 	start_owned_process() { \
 		"$$@" & \
 		last_owned_pid=$$!; \
+		pid_identity=$$(process_identity "$$last_owned_pid" 2>/dev/null || true); \
+		if [ -z "$$pid_identity" ]; then \
+			echo "Could not establish process identity for owned PID $$last_owned_pid; refusing to continue." >&2; \
+			return 1; \
+		fi; \
 		owned_pids="$$owned_pids $$last_owned_pid"; \
+		owned_processes="$$owned_processes $$last_owned_pid|$$pid_identity"; \
 	}; \
 	collect_owned_tree() { \
 		pid="$$1"; \
+		expected_identity="$$2"; \
 		case "$$pid" in \
-			''|*[!0-9]*) return ;; \
+			''|*[!0-9]*) return 1 ;; \
 		esac; \
-		case " $$owned_tree_pids " in \
-			*" $$pid "*) ;; \
-			*) owned_tree_pids="$$owned_tree_pids $$pid" ;; \
-		esac; \
+		current_identity=$$(process_identity "$$pid" 2>/dev/null || true); \
+		if [ -z "$$current_identity" ] || [ "$$current_identity" != "$$expected_identity" ]; then return 0; fi; \
+		retained_identity=""; \
+		for record in $$owned_tree_records; do \
+			record_pid="$${record%%|*}"; \
+			if [ "$$record_pid" = "$$pid" ]; then \
+				retained_identity="$${record#*|}"; \
+				break; \
+			fi; \
+		done; \
+		if [ -n "$$retained_identity" ]; then \
+			if [ "$$retained_identity" != "$$expected_identity" ] || [ "$$retained_identity" != "$$current_identity" ]; then return 0; fi; \
+		else \
+			owned_tree_records="$$owned_tree_records $$pid|$$expected_identity"; \
+		fi; \
 		children=$$(ps -eo pid=,ppid= 2>/dev/null | awk -v parent="$$pid" '$$2 == parent { print $$1 }' || true); \
 		for child_pid in $$children; do \
-			collect_owned_tree "$$child_pid"; \
+			child_identity=$$(process_identity "$$child_pid" 2>/dev/null || true); \
+			if [ -n "$$child_identity" ]; then \
+				collect_owned_tree "$$child_pid" "$$child_identity"; \
+			fi; \
 		done; \
 	}; \
 	signal_owned_processes() { \
 		signal="$$1"; \
-		for pid in $$owned_tree_pids; do \
-			kill "-$$signal" "$$pid" >/dev/null 2>&1 || true; \
+		for record in $$owned_tree_records; do \
+			pid="$${record%%|*}"; \
+			expected_identity="$${record#*|}"; \
+			current_identity=$$(process_identity "$$pid" 2>/dev/null || true); \
+			if [ -n "$$current_identity" ] && [ "$$current_identity" = "$$expected_identity" ]; then \
+				kill "-$$signal" "$$pid" >/dev/null 2>&1 || true; \
+			fi; \
 		done; \
 	}; \
 	cleanup() { \
 		status=$$?; \
 		trap - EXIT; \
 		trap ':' INT TERM; \
-		owned_tree_pids=""; \
-		for pid in $$owned_pids; do \
-			collect_owned_tree "$$pid"; \
+		owned_tree_records=""; \
+		for record in $$owned_processes; do \
+			pid="$${record%%|*}"; \
+			expected_identity="$${record#*|}"; \
+			collect_owned_tree "$$pid" "$$expected_identity"; \
 		done; \
 		signal_owned_processes TERM; \
 		attempt=0; \
 		pending=1; \
 		while [ "$$pending" = "1" ] && [ "$$attempt" -lt 50 ]; do \
-			for pid in $$owned_pids; do \
-				collect_owned_tree "$$pid"; \
+			for record in $$owned_processes; do \
+				pid="$${record%%|*}"; \
+				expected_identity="$${record#*|}"; \
+				collect_owned_tree "$$pid" "$$expected_identity"; \
 			done; \
 			signal_owned_processes TERM; \
 			pending=0; \
-			for pid in $$owned_tree_pids; do \
-				if kill -0 "$$pid" >/dev/null 2>&1; then \
+			for record in $$owned_tree_records; do \
+				pid="$${record%%|*}"; \
+				expected_identity="$${record#*|}"; \
+				current_identity=$$(process_identity "$$pid" 2>/dev/null || true); \
+				if [ -n "$$current_identity" ] && [ "$$current_identity" = "$$expected_identity" ] && kill -0 "$$pid" >/dev/null 2>&1; then \
 					state=$$(ps -o stat= -p "$$pid" 2>/dev/null || true); \
 					case "$$state" in Z*) ;; *) pending=1 ;; esac; \
 				fi; \

--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,13 @@ dev-artifacts-ready:
 		exit 1; \
 	fi
 
+# Each tracked PID is a root started by this recipe. Cleanup walks only those
+# parent trees so profiles sharing the recipe shell's process group stay safe.
+# Desktop still blocks on Tauri via `wait`; the background launch only captures
+# its root PID so its launcher tree can be cleaned up without shared-group kills.
+# Cleanup gives TERM-respecting processes five seconds before escalating only
+# the still-owned snapshot to KILL; each grace pass re-scans tracked roots for
+# launcher children created during shutdown.
 run: dev-artifacts-ready
 	@set -e; \
 	if [ -z "$(PROFILE)" ]; then \
@@ -231,16 +238,72 @@ run: dev-artifacts-ready
 	); \
 	database_url_override_set="$${DATABASE_URL+x}"; \
 	database_url_override_value="$${DATABASE_URL:-}"; \
+	owned_pids=""; \
+	last_owned_pid=""; \
+	run_lock_path="$$(dirname "$$launch_env")/run.lock"; \
+	start_owned_process() { \
+		"$$@" & \
+		last_owned_pid=$$!; \
+		owned_pids="$$owned_pids $$last_owned_pid"; \
+	}; \
+	collect_owned_tree() { \
+		pid="$$1"; \
+		case "$$pid" in \
+			''|*[!0-9]*) return ;; \
+		esac; \
+		case " $$owned_tree_pids " in \
+			*" $$pid "*) ;; \
+			*) owned_tree_pids="$$owned_tree_pids $$pid" ;; \
+		esac; \
+		children=$$(ps -eo pid=,ppid= 2>/dev/null | awk -v parent="$$pid" '$$2 == parent { print $$1 }' || true); \
+		for child_pid in $$children; do \
+			collect_owned_tree "$$child_pid"; \
+		done; \
+	}; \
+	signal_owned_processes() { \
+		signal="$$1"; \
+		for pid in $$owned_tree_pids; do \
+			kill "-$$signal" "$$pid" >/dev/null 2>&1 || true; \
+		done; \
+	}; \
 	cleanup() { \
 		status=$$?; \
-		trap - EXIT INT TERM; \
-		if [ -n "$${PROLIFERATE_DEV_HOME:-}" ]; then \
-			rm -f "$$(dirname "$$PROLIFERATE_DEV_HOME")/run.lock"; \
+		trap - EXIT; \
+		trap ':' INT TERM; \
+		owned_tree_pids=""; \
+		for pid in $$owned_pids; do \
+			collect_owned_tree "$$pid"; \
+		done; \
+		signal_owned_processes TERM; \
+		attempt=0; \
+		pending=1; \
+		while [ "$$pending" = "1" ] && [ "$$attempt" -lt 50 ]; do \
+			for pid in $$owned_pids; do \
+				collect_owned_tree "$$pid"; \
+			done; \
+			signal_owned_processes TERM; \
+			pending=0; \
+			for pid in $$owned_tree_pids; do \
+				if kill -0 "$$pid" >/dev/null 2>&1; then \
+					state=$$(ps -o stat= -p "$$pid" 2>/dev/null || true); \
+					case "$$state" in Z*) ;; *) pending=1 ;; esac; \
+				fi; \
+			done; \
+			if [ "$$pending" = "1" ]; then sleep 0.1; fi; \
+			attempt=$$((attempt + 1)); \
+		done; \
+		if [ "$$pending" = "1" ]; then \
+			signal_owned_processes KILL; \
 		fi; \
-		kill 0 >/dev/null 2>&1 || true; \
+		for pid in $$owned_pids; do \
+			wait "$$pid" 2>/dev/null || true; \
+		done; \
+		rm -f "$$run_lock_path"; \
 		exit $$status; \
 	}; \
-	trap cleanup EXIT INT TERM; \
+	trap cleanup EXIT; \
+	trap 'exit 130' INT; \
+	trap 'exit 143' TERM; \
 	$(SERVER_ENV_SOURCE) \
 	. "$$launch_env"; \
 	$(AUTH_PROFILE_ENV_SOURCE) \
@@ -281,7 +344,7 @@ run: dev-artifacts-ready
 		cloud_worker_ngrok_url=$$(node scripts/dev-ngrok-tunnel-url.mjs --port "$$PROLIFERATE_API_PORT" 2>/dev/null || true); \
 		if [ -z "$$cloud_worker_ngrok_url" ]; then \
 			echo "Starting ngrok tunnel for Cloud worker callbacks :$$PROLIFERATE_API_PORT"; \
-			ngrok http "$$PROLIFERATE_API_PORT" --log=stdout --log-format=json > "/tmp/proliferate-cloud-worker-$$PROLIFERATE_DEV_PROFILE-ngrok.log" 2>&1 & \
+			start_owned_process ngrok http "$$PROLIFERATE_API_PORT" --log=stdout --log-format=json > "/tmp/proliferate-cloud-worker-$$PROLIFERATE_DEV_PROFILE-ngrok.log" 2>&1; \
 			cloud_worker_ngrok_url=$$(node scripts/dev-ngrok-tunnel-url.mjs --port "$$PROLIFERATE_API_PORT" --wait-ms 45000); \
 		else \
 			echo "Using existing ngrok tunnel for Cloud worker callbacks: $$cloud_worker_ngrok_url"; \
@@ -358,20 +421,24 @@ run: dev-artifacts-ready
 		if [ -n "$$stripe_webhook_secret" ]; then \
 			export STRIPE_WEBHOOK_SECRET="$$stripe_webhook_secret"; \
 		fi; \
-		stripe listen --events "$(STRIPE_SNAPSHOT_EVENTS)" --forward-to "$$STRIPE_FORWARD_TO" & \
+		start_owned_process stripe listen --events "$(STRIPE_SNAPSHOT_EVENTS)" --forward-to "$$STRIPE_FORWARD_TO"; \
 	fi; \
 	runtime_bin="$${ANYHARNESS_DEV_RUNTIME_BIN:-$(DEV_ANYHARNESS_TARGET_DIR)/debug/anyharness}"; \
 	echo "Starting profile $$PROLIFERATE_DEV_PROFILE: runtime :$$ANYHARNESS_PORT, backend :$$PROLIFERATE_API_PORT, desktop :$$PROLIFERATE_WEB_PORT, web :$$PROLIFERATE_HOSTED_WEB_PORT, mobile web :$$PROLIFERATE_MOBILE_WEB_PORT"; \
-	RUST_LOG=info ANYHARNESS_DEV_CORS=1 "$$runtime_bin" serve --port "$$ANYHARNESS_PORT" --runtime-home "$$ANYHARNESS_RUNTIME_HOME" & \
-	(cd server && .venv/bin/uvicorn proliferate.main:app --reload --host 127.0.0.1 --port "$$PROLIFERATE_API_PORT") & \
+	start_owned_process env RUST_LOG=info ANYHARNESS_DEV_CORS=1 "$$runtime_bin" serve --port "$$ANYHARNESS_PORT" --runtime-home "$$ANYHARNESS_RUNTIME_HOME"; \
+	start_owned_process sh -c 'cd server && exec .venv/bin/uvicorn "$$@"' sh proliferate.main:app --reload --host 127.0.0.1 --port "$$PROLIFERATE_API_PORT"; \
 	echo "Starting hosted web app..."; \
-	(cd apps/web && VITE_PROLIFERATE_API_BASE_URL="$$API_BASE_URL" VITE_PROLIFERATE_DEV_TOKEN_LOGIN="$${VITE_PROLIFERATE_DEV_TOKEN_LOGIN:-true}" exec ./node_modules/.bin/vite --host 127.0.0.1 --port "$$PROLIFERATE_HOSTED_WEB_PORT" --strictPort) & \
+	start_owned_process env VITE_PROLIFERATE_API_BASE_URL="$$API_BASE_URL" VITE_PROLIFERATE_DEV_TOKEN_LOGIN="$${VITE_PROLIFERATE_DEV_TOKEN_LOGIN:-true}" sh -c 'cd apps/web && exec ./node_modules/.bin/vite "$$@"' sh --host 127.0.0.1 --port "$$PROLIFERATE_HOSTED_WEB_PORT" --strictPort; \
 	if [ "$(HEADLESS)" = "1" ]; then \
 		echo "HEADLESS=1: Desktop app not started. Runtime, API, and hosted Web are running; Ctrl-C stops them."; \
 		wait; \
 	else \
 		sleep 2; \
-		(cd apps/desktop && pnpm tauri dev --runner "$$(dirname "$$PROLIFERATE_DEV_HOME")/tauri-runner.sh" --config "$$(dirname "$$PROLIFERATE_DEV_HOME")/tauri.dev.json"); \
+		start_owned_process sh -c 'cd apps/desktop && exec pnpm tauri dev --runner "$$1" --config "$$2"' sh \
+			"$$(dirname "$$PROLIFERATE_DEV_HOME")/tauri-runner.sh" \
+			"$$(dirname "$$PROLIFERATE_DEV_HOME")/tauri.dev.json"; \
+		tauri_pid="$$last_owned_pid"; \
+		wait "$$tauri_pid"; \
 	fi
 
 setup: git-hooks

--- a/scripts/dev-run-cleanup.test.mjs
+++ b/scripts/dev-run-cleanup.test.mjs
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const makefilePath = path.join(repoRoot, "Makefile");
+
+function extractRunRecipe() {
+  const lines = readFileSync(makefilePath, "utf8").split("\n");
+  const start = lines.findIndex((line) => /^run:/.test(line));
+  assert.ok(start >= 0, "run: target must exist in the Makefile");
+  const body = [];
+  for (let index = start + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (line === "" || /^[^\t]/.test(line)) {
+      break;
+    }
+    body.push(line.replace(/^\t/, ""));
+  }
+  return body.join("\n");
+}
+
+function extractOwnedLifecycle() {
+  const recipe = extractRunRecipe();
+  const start = recipe.indexOf('owned_pids="";');
+  const end = recipe.indexOf("$(SERVER_ENV_SOURCE)", start);
+  assert.ok(start >= 0, "run recipe must initialize owned process tracking");
+  assert.ok(end > start, "run recipe must place cleanup before environment startup");
+  return recipe.slice(start, end).replaceAll("$$", "$");
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
+
+test("run cleanup owns process trees without owning the caller's process group", {
+  skip: process.platform === "win32",
+}, () => {
+  const tempRoot = mkdtempSync(path.join(os.tmpdir(), "proliferate-run-cleanup-"));
+  const ownedFixture = path.join(tempRoot, "owned-tree.sh");
+  const harness = path.join(tempRoot, "harness.sh");
+  const caller = path.join(tempRoot, "caller.sh");
+  const resultFile = path.join(tempRoot, "result");
+  const ownedGrandchildPid = path.join(tempRoot, "owned-grandchild.pid");
+  const ownedRootPid = path.join(tempRoot, "owned-root.pid");
+  const bystanderStart = path.join(tempRoot, "bystander-start");
+  const bystanderTerm = path.join(tempRoot, "bystander-term");
+  const bystanderPid = path.join(tempRoot, "bystander.pid");
+  const callerPgid = path.join(tempRoot, "caller.pgid");
+  const harnessPgid = path.join(tempRoot, "harness.pgid");
+  const bystanderPgid = path.join(tempRoot, "bystander.pgid");
+  const runLock = path.join(tempRoot, "profile", "run.lock");
+
+  writeFileSync(
+    ownedFixture,
+    `#!/bin/sh
+grandchild_pid_file="$1"
+(
+  sleep 60
+) &
+grandchild_pid=$!
+printf '%s\\n' "$grandchild_pid" > "$grandchild_pid_file"
+wait "$grandchild_pid"
+`,
+    { mode: 0o755 },
+  );
+
+  const lifecycle = extractOwnedLifecycle();
+  assert.doesNotMatch(lifecycle, /kill 0/, "cleanup must not signal the shared process group");
+  assert.match(lifecycle, /collect_owned_tree/, "cleanup must account for owned descendants");
+
+  writeFileSync(
+    harness,
+    `#!/bin/sh
+set -eu
+printf '%s\\n' "$(ps -o pgid= -p "$$" | tr -d ' ')" > ${shellQuote(harnessPgid)}
+launch_env=${shellQuote(path.join(tempRoot, "profile", "launch.env"))}
+${lifecycle}
+mkdir -p ${shellQuote(path.dirname(runLock))}
+touch ${shellQuote(runLock)}
+start_owned_process sh ${shellQuote(ownedFixture)} \
+  ${shellQuote(ownedGrandchildPid)}
+printf '%s\\n' "$last_owned_pid" > ${shellQuote(ownedRootPid)}
+while [ ! -f ${shellQuote(ownedGrandchildPid)} ]; do sleep 0.01; done
+exit 37
+`,
+    { mode: 0o755 },
+  );
+
+  writeFileSync(
+    caller,
+    `#!/bin/sh
+set +e
+bystander_term=${shellQuote(bystanderTerm)}
+export bystander_term
+(
+  trap 'printf TERM > "$bystander_term"; exit 143' TERM
+  touch ${shellQuote(bystanderStart)}
+  while :; do :; done
+) &
+bystander_pid=$!
+printf '%s\\n' "$bystander_pid" > ${shellQuote(bystanderPid)}
+printf '%s\\n' "$(ps -o pgid= -p "$$" | tr -d ' ')" > ${shellQuote(callerPgid)}
+printf '%s\\n' "$(ps -o pgid= -p "$bystander_pid" | tr -d ' ')" > ${shellQuote(bystanderPgid)}
+while [ ! -f ${shellQuote(bystanderStart)} ]; do sleep 0.01; done
+cleanup_bystander() {
+  kill -TERM "$(cat ${shellQuote(bystanderPid)})" 2>/dev/null || true
+  wait "$(cat ${shellQuote(bystanderPid)})" 2>/dev/null || true
+}
+trap cleanup_bystander EXIT
+sh ${shellQuote(harness)}
+status="$?"
+if [ "$status" -ne 37 ]; then
+  printf 'STATUS=%s\\n' "$status" > ${shellQuote(resultFile)}
+  exit 1
+fi
+if [ "$(cat ${shellQuote(callerPgid)})" != "$(cat ${shellQuote(harnessPgid)})" ] || \
+   [ "$(cat ${shellQuote(callerPgid)})" != "$(cat ${shellQuote(bystanderPgid)})" ]; then
+  printf 'SAME_PROCESS_GROUP=0\\n' > ${shellQuote(resultFile)}
+  exit 1
+fi
+printf 'SAME_PROCESS_GROUP=1\\n' > ${shellQuote(resultFile)}
+if [ -f ${shellQuote(bystanderTerm)} ]; then
+  printf 'BYSTANDER_TERM=1\\n' >> ${shellQuote(resultFile)}
+else
+  printf 'BYSTANDER_TERM=0\\n' >> ${shellQuote(resultFile)}
+fi
+if kill -0 "$(cat ${shellQuote(bystanderPid)})" 2>/dev/null; then
+  printf 'BYSTANDER_ALIVE=1\\n' >> ${shellQuote(resultFile)}
+else
+  printf 'BYSTANDER_ALIVE=0\\n' >> ${shellQuote(resultFile)}
+fi
+printf 'CALLER_SURVIVED=1\\n' >> ${shellQuote(resultFile)}
+if kill -0 "$(cat ${shellQuote(ownedRootPid)})" 2>/dev/null; then
+  printf 'OWNED_ROOT_ALIVE=1\\n' >> ${shellQuote(resultFile)}
+else
+  printf 'OWNED_ROOT_ALIVE=0\\n' >> ${shellQuote(resultFile)}
+fi
+if kill -0 "$(cat ${shellQuote(ownedGrandchildPid)})" 2>/dev/null; then
+  printf 'OWNED_GRANDCHILD_ALIVE=1\\n' >> ${shellQuote(resultFile)}
+else
+  printf 'OWNED_GRANDCHILD_ALIVE=0\\n' >> ${shellQuote(resultFile)}
+fi
+kill -TERM "$(cat ${shellQuote(bystanderPid)})" 2>/dev/null || true
+exit 0
+`,
+    { mode: 0o755 },
+  );
+
+  try {
+    const completed = spawnSync("sh", [caller], {
+      cwd: repoRoot,
+      detached: true,
+      encoding: "utf8",
+      timeout: 10_000,
+    });
+    assert.equal(completed.error, undefined, completed.error?.message);
+    assert.equal(completed.status, 0, completed.stderr || completed.stdout);
+    const result = readFileSync(resultFile, "utf8");
+    assert.match(result, /SAME_PROCESS_GROUP=1/);
+    assert.match(result, /BYSTANDER_TERM=0/);
+    assert.match(result, /BYSTANDER_ALIVE=1/);
+    assert.match(result, /CALLER_SURVIVED=1/);
+    assert.match(result, /STATUS=37/);
+    assert.match(result, /OWNED_ROOT_ALIVE=0/);
+    assert.match(result, /OWNED_GRANDCHILD_ALIVE=0/);
+    assert.equal(existsSync(runLock), false);
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("run tracks every long-running launcher and keeps Desktop blocking", () => {
+  const recipe = extractRunRecipe();
+  assert.doesNotMatch(recipe, /kill 0/);
+  for (const command of [
+    "start_owned_process env RUST_LOG=info",
+    "start_owned_process sh -c 'cd server && exec .venv/bin/uvicorn",
+    "start_owned_process env VITE_PROLIFERATE_API_BASE_URL",
+    "start_owned_process stripe listen",
+    "start_owned_process ngrok http",
+    "start_owned_process sh -c 'cd apps/desktop && exec pnpm tauri dev",
+  ]) {
+    assert.match(recipe, new RegExp(command.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+  assert.match(recipe, /tauri_pid="\$\$last_owned_pid";/);
+  assert.match(recipe, /wait "\$\$tauri_pid"/);
+  assert.match(recipe, /trap 'exit 130' INT/);
+  assert.match(recipe, /trap 'exit 143' TERM/);
+});

--- a/scripts/dev-run-cleanup.test.mjs
+++ b/scripts/dev-run-cleanup.test.mjs
@@ -32,7 +32,7 @@ function extractRunRecipe() {
 
 function extractOwnedLifecycle() {
   const recipe = extractRunRecipe();
-  const start = recipe.indexOf('owned_pids="";');
+  const start = recipe.indexOf("process_identity()");
   const end = recipe.indexOf("$(SERVER_ENV_SOURCE)", start);
   assert.ok(start >= 0, "run recipe must initialize owned process tracking");
   assert.ok(end > start, "run recipe must place cleanup before environment startup");
@@ -55,7 +55,9 @@ test("run cleanup owns process trees without owning the caller's process group",
   const ownedRootPid = path.join(tempRoot, "owned-root.pid");
   const bystanderStart = path.join(tempRoot, "bystander-start");
   const bystanderTerm = path.join(tempRoot, "bystander-term");
+  const bystanderChildTerm = path.join(tempRoot, "bystander-child-term");
   const bystanderPid = path.join(tempRoot, "bystander.pid");
+  const bystanderChildPid = path.join(tempRoot, "bystander-child.pid");
   const callerPgid = path.join(tempRoot, "caller.pgid");
   const harnessPgid = path.join(tempRoot, "harness.pgid");
   const bystanderPgid = path.join(tempRoot, "bystander.pgid");
@@ -78,6 +80,10 @@ wait "$grandchild_pid"
   const lifecycle = extractOwnedLifecycle();
   assert.doesNotMatch(lifecycle, /kill 0/, "cleanup must not signal the shared process group");
   assert.match(lifecycle, /collect_owned_tree/, "cleanup must account for owned descendants");
+  assert.match(lifecycle, /process_identity/, "cleanup must validate retained process identities");
+  assert.match(lifecycle, /\/proc\/\$pid\/stat/, "Linux cleanup must use process start ticks");
+  assert.match(lifecycle, /ps -o lstart=/, "POSIX cleanup must use a start-time token");
+  assert.match(lifecycle, /retained_identity/, "cleanup must retain identities for rescanned PIDs");
 
   writeFileSync(
     harness,
@@ -86,6 +92,11 @@ set -eu
 printf '%s\\n' "$(ps -o pgid= -p "$$" | tr -d ' ')" > ${shellQuote(harnessPgid)}
 launch_env=${shellQuote(path.join(tempRoot, "profile", "launch.env"))}
 ${lifecycle}
+bystander_identity=$(process_identity "$bystander_pid")
+owned_tree_records="$bystander_pid|stale-identity"
+collect_owned_tree "$bystander_pid" "$bystander_identity"
+signal_owned_processes TERM
+owned_tree_records=""
 mkdir -p ${shellQuote(path.dirname(runLock))}
 touch ${shellQuote(runLock)}
 start_owned_process sh ${shellQuote(ownedFixture)} \
@@ -102,34 +113,51 @@ exit 37
     `#!/bin/sh
 set +e
 bystander_term=${shellQuote(bystanderTerm)}
+bystander_child_term=${shellQuote(bystanderChildTerm)}
 export bystander_term
+export bystander_child_term
 (
   trap 'printf TERM > "$bystander_term"; exit 143' TERM
   touch ${shellQuote(bystanderStart)}
-  while :; do :; done
+  (
+    trap 'printf TERM > "$bystander_child_term"; exit 143' TERM
+    while :; do :; done
+  ) &
+  bystander_child_pid=$!
+  printf '%s\\n' "$bystander_child_pid" > ${shellQuote(bystanderChildPid)}
+  wait "$bystander_child_pid"
 ) &
 bystander_pid=$!
 printf '%s\\n' "$bystander_pid" > ${shellQuote(bystanderPid)}
+export bystander_pid
 printf '%s\\n' "$(ps -o pgid= -p "$$" | tr -d ' ')" > ${shellQuote(callerPgid)}
 printf '%s\\n' "$(ps -o pgid= -p "$bystander_pid" | tr -d ' ')" > ${shellQuote(bystanderPgid)}
 while [ ! -f ${shellQuote(bystanderStart)} ]; do sleep 0.01; done
+while [ ! -f ${shellQuote(bystanderChildPid)} ]; do sleep 0.01; done
 cleanup_bystander() {
+  kill -TERM "$(cat ${shellQuote(bystanderChildPid)})" 2>/dev/null || true
+  wait "$(cat ${shellQuote(bystanderChildPid)})" 2>/dev/null || true
   kill -TERM "$(cat ${shellQuote(bystanderPid)})" 2>/dev/null || true
   wait "$(cat ${shellQuote(bystanderPid)})" 2>/dev/null || true
 }
 trap cleanup_bystander EXIT
 sh ${shellQuote(harness)}
 status="$?"
+printf 'STATUS=%s\\n' "$status" > ${shellQuote(resultFile)}
 if [ "$status" -ne 37 ]; then
-  printf 'STATUS=%s\\n' "$status" > ${shellQuote(resultFile)}
   exit 1
 fi
 if [ "$(cat ${shellQuote(callerPgid)})" != "$(cat ${shellQuote(harnessPgid)})" ] || \
    [ "$(cat ${shellQuote(callerPgid)})" != "$(cat ${shellQuote(bystanderPgid)})" ]; then
-  printf 'SAME_PROCESS_GROUP=0\\n' > ${shellQuote(resultFile)}
+  printf 'SAME_PROCESS_GROUP=0\\n' >> ${shellQuote(resultFile)}
   exit 1
 fi
-printf 'SAME_PROCESS_GROUP=1\\n' > ${shellQuote(resultFile)}
+printf 'SAME_PROCESS_GROUP=1\\n' >> ${shellQuote(resultFile)}
+if [ -f ${shellQuote(bystanderChildTerm)} ] || ! kill -0 "$(cat ${shellQuote(bystanderChildPid)})" 2>/dev/null; then
+  printf 'STALE_IDENTITY_SAFE=0\\n' >> ${shellQuote(resultFile)}
+  exit 1
+fi
+printf 'STALE_IDENTITY_SAFE=1\\n' >> ${shellQuote(resultFile)}
 if [ -f ${shellQuote(bystanderTerm)} ]; then
   printf 'BYSTANDER_TERM=1\\n' >> ${shellQuote(resultFile)}
 else
@@ -172,6 +200,7 @@ exit 0
     assert.match(result, /BYSTANDER_ALIVE=1/);
     assert.match(result, /CALLER_SURVIVED=1/);
     assert.match(result, /STATUS=37/);
+    assert.match(result, /STALE_IDENTITY_SAFE=1/);
     assert.match(result, /OWNED_ROOT_ALIVE=0/);
     assert.match(result, /OWNED_GRANDCHILD_ALIVE=0/);
     assert.equal(existsSync(runLock), false);


### PR DESCRIPTION
Fixes #2163

## Summary
- Replaces shared process-group signaling with explicit per-run process-root tracking and owned descendant cleanup.
- Keeps HEADLESS behavior and the blocking Desktop launch while tracking optional listener and tunnel roots.
- Adds a deterministic POSIX regression for owned child/grandchild termination, same-group bystander and caller survival, exit status, and run.lock cleanup.

## Verification
- node --test scripts/dev-run-cleanup.test.mjs (static case passed; POSIX case runs in CI and is skipped by the native Windows runner).
- make -n run PROFILE=cleanup-proof HEADLESS=1 followed by bash -n of the expanded recipe.
- Manual WSL same-process-group reproduction and post-fix ownership proof.