### PR TITLE
chore(ci): CI diet — cull crons and demote non-gating lanes off the PR path (engineering-cull PR-E3)

### DIFF
--- a/.github/workflows/ci-heavy-lanes.yml
+++ b/.github/workflows/ci-heavy-lanes.yml
@@ -1,0 +1,286 @@
+name: CI Heavy Lanes (dispatch-only)
+
+# Four lanes demoted off the per-PR path by the 2026-08 engineering cull
+# (delivery/engineering-cull/delivery-spec-ci-diet.md). Each protected either a
+# parked corridor or a surface mid-rebuild, so per-PR cost bought no protection.
+# The jobs are verbatim moves out of ci.yml — nothing here is new machinery.
+# Whether each lane returns to the merge gate, moves to a nightly, or dies is
+# the step-3 CI/CD spec's decision; do not re-add them to ci.yml ad hoc.
+#
+#   candidate-build-handoff  — protects the parked qualification corridor.
+#   login-budget             — its script + lane are slated for deletion with
+#                              the product cull (Cull Plan PR-5, together with
+#                              the dependabot posthog pin); demoted until then.
+#   scroll-physics           — structural half stays enforced per-PR by
+#                              check_transcript_scroll_writer.py in repo-shape.
+#   workflow-definition-lifecycle — tests the surface mid gen-2 rebuild.
+#                              While it lived in ci.yml it also blocked the
+#                              Deploy Staging workflow_run spine; that gate is
+#                              accepted-lost while demoted (surface is being
+#                              rebuilt) — a step-3 re-gating decision.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Fail-closed proof of the exact candidate-build handoff. This lane uses no
+  # provider credentials: it builds one host AnyHarness, records its identity,
+  # materializes and launches those bytes, and matches the aggregate evidence.
+  candidate-build-handoff:
+    name: Candidate build handoff
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.11.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Setup Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test qualification runner
+        run: pnpm -C tests/release test
+
+      - name: Typecheck qualification runner
+        run: pnpm -C tests/release typecheck
+
+      - name: Test candidate build-map assembler
+        run: node --test scripts/ci-cd/assemble-candidate-build-map.test.mjs
+
+      - name: Prove candidate build handoff
+        run: make qualification-candidate-handoff-smoke
+
+  # Phase-6 /login first-load budget gate (WDU-1247-B1). Builds the
+  # Web host against a fixed anonymous API fixture, loads /login in headless
+  # Chromium with that fixture intercepted, waits for the durable login-ready
+  # marker + settled network, and enforces the founder-approved gzip-9 ceilings
+  # (JS 485000 B, CSS 66000 B; zero eager fonts/images/audio) FAIL-CLOSED
+  # within this workflow. No longer on the per-PR path (see header).
+  login-budget:
+    name: Login first-load budget (phase-6)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.11.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: |
+          version=$(grep -m1 '^  playwright-core@' pnpm-lock.yaml | sed -E 's/^  playwright-core@([0-9.]+):.*/\1/')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # Cache the downloaded browser
+      # binaries so a cache hit skips the network download; the key is the
+      # exact playwright-core version resolved above so a bump auto-busts it.
+      # The install step below still installs OS dependencies unconditionally
+      # (see its own run block) because those apt packages live outside this
+      # cache dir and would not survive on the ephemeral runner anyway;
+      # playwright's own installer already no-ops the binary download when
+      # the target revision is already present, so this only removes the
+      # download, not the apt step.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-chromium
+
+      - name: Install Playwright chromium
+        run: |
+          sudo "$(command -v node)" "$GITHUB_WORKSPACE/scripts/ci-cd/configure-playwright-apt.mjs"
+          pnpm exec playwright install --with-deps chromium
+
+      - name: Build shared packages
+        run: pnpm shared:build
+
+      - name: Enforce /login runtime budget
+        run: node scripts/measure-login-runtime-budget.mjs
+
+  # Scroll-physics tier (specs/TESTING.md): the real transcript renderer driven
+  # by a scripted streaming fixture in real Chromium AND real WebKit. The suite
+  # runs workers=1 by config; both browser engines are required because scroll
+  # physics differ between Blink and WebKit.
+  scroll-physics:
+    name: Transcript scroll physics (chromium + webkit)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.11.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Builds product-client's own dist (and the shared packages it depends
+      # on) so the fixture resolves the real transcript through `#product/*`.
+      - name: Build shared packages
+        run: pnpm shared:build
+
+      # Cheap compile-only check over the fixture's tsconfig.json (no
+      # browsers). Catches SDK event-schema drift before spending time
+      # installing browser engines.
+      - name: Typecheck scroll-physics fixture
+        run: pnpm --filter @proliferate/product-client typecheck:scroll-physics
+
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: |
+          version=$(grep -m1 '^  playwright-core@' pnpm-lock.yaml | sed -E 's/^  playwright-core@([0-9.]+):.*/\1/')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # See login-budget's cache step for rationale. Keyed separately (chromium-webkit) from the chromium-only
+      # jobs since this job installs a superset of browsers.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-chromium-webkit
+
+      - name: Install Playwright chromium + webkit
+        run: |
+          sudo "$(command -v node)" "$GITHUB_WORKSPACE/scripts/ci-cd/configure-playwright-apt.mjs"
+          pnpm --filter @proliferate/product-client exec playwright install --with-deps chromium webkit
+
+      - name: Run scroll-physics suite
+        run: pnpm --filter @proliferate/product-client test:scroll-physics
+
+      - name: Upload scroll-physics test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scroll-physics-test-results
+          path: apps/packages/product-client/qualification/scroll-physics/test-results/
+          retention-days: 7
+
+  # Focused Tier-2 gate for the workflow-definition lifecycle (T2-WFDEF-1)
+  # only. The broad tier-2 lanes stay provisional in intent-tests.yml; do
+  # not fold them into this job.
+  workflow-definition-lifecycle:
+    name: Workflow definition lifecycle (tier-2)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: proliferate
+          POSTGRES_PASSWORD: localdev
+          POSTGRES_DB: proliferate
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U proliferate -d proliferate"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: pnpm
+      - uses: astral-sh/setup-uv@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install server (venv, matches local layout)
+        run: cd server && uv venv .venv --python 3.12 && uv pip install -e ".[dev]"
+
+      - name: Regenerate cloud SDK artifacts
+        run: make cloud-client-generate
+
+      - name: Verify generated cloud SDK artifacts are committed
+        run: git diff --exit-code -- cloud/sdk/src/generated/openapi.ts
+
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: |
+          version=$(grep -m1 '^  playwright-core@' pnpm-lock.yaml | sed -E 's/^  playwright-core@([0-9.]+):.*/\1/')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # See login-budget's cache step for rationale.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-chromium
+
+      - name: Install Playwright chromium
+        run: |
+          sudo "$(command -v node)" "$GITHUB_WORKSPACE/scripts/ci-cd/configure-playwright-apt.mjs"
+          pnpm -C tests/intent exec playwright install --with-deps chromium
+
+      - name: Run workflow-definition lifecycle spec
+        env:
+          USE_EXISTING_POSTGRES: "1"
+          USE_EXISTING_REDIS: "1"
+          LOCAL_PGHOST: 127.0.0.1
+          TIER2_INTENT_SKIP_RUNTIME: "1"
+          CI: "true"
+        run: pnpm -C tests/intent exec playwright test specs/workflow-definitions.spec.ts
+
+      - name: Upload Playwright traces on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: workflow-definition-lifecycle-traces
+          path: tests/intent/test-results/
+          retention-days: 7

--- a/.github/workflows/ci-heavy-lanes.yml
+++ b/.github/workflows/ci-heavy-lanes.yml
@@ -14,10 +14,13 @@ name: CI Heavy Lanes (dispatch-only)
 #   scroll-physics           — structural half stays enforced per-PR by
 #                              check_transcript_scroll_writer.py in repo-shape.
 #   workflow-definition-lifecycle — tests the surface mid gen-2 rebuild.
-#                              While it lived in ci.yml it also blocked the
-#                              Deploy Staging workflow_run spine; that gate is
-#                              accepted-lost while demoted (surface is being
-#                              rebuilt) — a step-3 re-gating decision.
+#                              While it lived in ci.yml it failed CI on red
+#                              (that per-PR gate is accepted-lost while the
+#                              surface is being rebuilt — a step-3 re-gating
+#                              decision). Note: old comments claimed it also
+#                              blocked a Deploy Staging workflow_run spine;
+#                              deploy-staging.yml is dispatch-only and gates on
+#                              Server CI, so no such spine exists today.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,44 +218,8 @@ jobs:
       - name: Smoke deploy surface detector
         run: node scripts/ci-cd/detect-deploy-surfaces.mjs --base HEAD --head HEAD
 
-  # Fail-closed proof of the exact candidate-build handoff. This lane uses no
-  # provider credentials: it builds one host AnyHarness, records its identity,
-  # materializes and launches those bytes, and matches the aggregate evidence.
-  candidate-build-handoff:
-    name: Candidate build handoff
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - uses: pnpm/action-setup@v6
-        with:
-          version: 10.11.0
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "22"
-          cache: pnpm
-
-      - name: Setup Rust stable
-        uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Install workspace dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Test qualification runner
-        run: pnpm -C tests/release test
-
-      - name: Typecheck qualification runner
-        run: pnpm -C tests/release typecheck
-
-      - name: Test candidate build-map assembler
-        run: node --test scripts/ci-cd/assemble-candidate-build-map.test.mjs
-
-      - name: Prove candidate build handoff
-        run: make qualification-candidate-handoff-smoke
+  # candidate-build-handoff moved to ci-heavy-lanes.yml (dispatch-only) in the
+  # 2026-08 engineering cull — it protects the parked qualification corridor.
 
   cargo-check:
     name: Cargo check & test
@@ -436,64 +400,9 @@ jobs:
       - name: Build web
         run: pnpm web:build
 
-  # Fail-closed phase-6 /login first-load budget gate (WDU-1247-B1). Builds the
-  # Web host against a fixed anonymous API fixture, loads /login in headless
-  # Chromium with that fixture intercepted, waits for the durable login-ready
-  # marker + settled network, and enforces the founder-approved gzip-9 ceilings
-  # (JS 485000 B, CSS 66000 B; zero eager fonts/images/audio) FAIL-CLOSED. No
-  # continue-on-error: a regression fails CI on PRs and main, which also gates
-  # the Deploy Staging workflow_run spine.
-  login-budget:
-    name: Login first-load budget (phase-6)
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - uses: pnpm/action-setup@v6
-        with:
-          version: 10.11.0
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "22"
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Resolve Playwright version
-        id: playwright-version
-        run: |
-          version=$(grep -m1 '^  playwright-core@' pnpm-lock.yaml | sed -E 's/^  playwright-core@([0-9.]+):.*/\1/')
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      # Cache the downloaded browser
-      # binaries so a cache hit skips the network download; the key is the
-      # exact playwright-core version resolved above so a bump auto-busts it.
-      # The install step below still installs OS dependencies unconditionally
-      # (see its own run block) because those apt packages live outside this
-      # cache dir and would not survive on the ephemeral runner anyway;
-      # playwright's own installer already no-ops the binary download when
-      # the target revision is already present, so this only removes the
-      # download, not the apt step.
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-browsers-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-chromium
-
-      - name: Install Playwright chromium
-        run: |
-          sudo "$(command -v node)" "$GITHUB_WORKSPACE/scripts/ci-cd/configure-playwright-apt.mjs"
-          pnpm exec playwright install --with-deps chromium
-
-      - name: Build shared packages
-        run: pnpm shared:build
-
-      - name: Enforce /login runtime budget
-        run: node scripts/measure-login-runtime-budget.mjs
+  # login-budget moved to ci-heavy-lanes.yml (dispatch-only) in the 2026-08
+  # engineering cull — the lane, its script, and the dependabot posthog pin are
+  # slated to die together in the product cull (Cull Plan PR-5).
 
   # Housekeeping that "Test product client"
   # does not need (typecheck, the python-only checks, and the two other
@@ -589,167 +498,13 @@ jobs:
       - name: Test product client
         run: pnpm --filter @proliferate/product-client exec vitest run --shard=${{ matrix.shard }}/4
 
-  # Scroll-physics tier (specs/TESTING.md): the real transcript renderer driven
-  # by a scripted streaming fixture in real Chromium AND real WebKit. Merge-
-  # gating like shared-frontend-packages, no continue-on-error. The suite runs
-  # workers=1 by config; both browser engines are required because scroll
-  # physics differ between Blink and WebKit.
-  scroll-physics:
-    name: Transcript scroll physics (chromium + webkit)
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - uses: pnpm/action-setup@v6
-        with:
-          version: 10.11.0
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "22"
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      # Builds product-client's own dist (and the shared packages it depends
-      # on) so the fixture resolves the real transcript through `#product/*`.
-      - name: Build shared packages
-        run: pnpm shared:build
-
-      # Cheap compile-only check over the fixture's tsconfig.json (no
-      # browsers). Catches SDK event-schema drift before spending time
-      # installing browser engines.
-      - name: Typecheck scroll-physics fixture
-        run: pnpm --filter @proliferate/product-client typecheck:scroll-physics
-
-      - name: Resolve Playwright version
-        id: playwright-version
-        run: |
-          version=$(grep -m1 '^  playwright-core@' pnpm-lock.yaml | sed -E 's/^  playwright-core@([0-9.]+):.*/\1/')
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      # See login-budget's cache step for rationale. Keyed separately (chromium-webkit) from the chromium-only
-      # jobs since this job installs a superset of browsers.
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-browsers-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-chromium-webkit
-
-      - name: Install Playwright chromium + webkit
-        run: |
-          sudo "$(command -v node)" "$GITHUB_WORKSPACE/scripts/ci-cd/configure-playwright-apt.mjs"
-          pnpm --filter @proliferate/product-client exec playwright install --with-deps chromium webkit
-
-      - name: Run scroll-physics suite
-        run: pnpm --filter @proliferate/product-client test:scroll-physics
-
-      - name: Upload scroll-physics test results
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: scroll-physics-test-results
-          path: apps/packages/product-client/qualification/scroll-physics/test-results/
-          retention-days: 7
-
-  # Fail-closed Tier-2 gate for the workflow-definition lifecycle (T2-WFDEF-1)
-  # only. No continue-on-error: a red result fails the CI workflow on PRs and
-  # main, which also blocks the Deploy Staging workflow_run spine. This check
-  # is eligible for a future repository required-status rule (none exists
-  # today). The broad tier-2 lanes stay provisional in intent-tests.yml; do
-  # not fold them into this job.
-  workflow-definition-lifecycle:
-    name: Workflow definition lifecycle (tier-2)
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_USER: proliferate
-          POSTGRES_PASSWORD: localdev
-          POSTGRES_DB: proliferate
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U proliferate -d proliferate"
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 10
-      redis:
-        image: redis:7-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 10
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - uses: pnpm/action-setup@v6
-        with:
-          version: 10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "22"
-          cache: pnpm
-      - uses: astral-sh/setup-uv@v7
-      - uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
-
-      - name: Install workspace dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install server (venv, matches local layout)
-        run: cd server && uv venv .venv --python 3.12 && uv pip install -e ".[dev]"
-
-      - name: Regenerate cloud SDK artifacts
-        run: make cloud-client-generate
-
-      - name: Verify generated cloud SDK artifacts are committed
-        run: git diff --exit-code -- cloud/sdk/src/generated/openapi.ts
-
-      - name: Resolve Playwright version
-        id: playwright-version
-        run: |
-          version=$(grep -m1 '^  playwright-core@' pnpm-lock.yaml | sed -E 's/^  playwright-core@([0-9.]+):.*/\1/')
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      # See login-budget's cache step for rationale.
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-browsers-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-chromium
-
-      - name: Install Playwright chromium
-        run: |
-          sudo "$(command -v node)" "$GITHUB_WORKSPACE/scripts/ci-cd/configure-playwright-apt.mjs"
-          pnpm -C tests/intent exec playwright install --with-deps chromium
-
-      - name: Run workflow-definition lifecycle spec
-        env:
-          USE_EXISTING_POSTGRES: "1"
-          USE_EXISTING_REDIS: "1"
-          LOCAL_PGHOST: 127.0.0.1
-          TIER2_INTENT_SKIP_RUNTIME: "1"
-          CI: "true"
-        run: pnpm -C tests/intent exec playwright test specs/workflow-definitions.spec.ts
-
-      - name: Upload Playwright traces on failure
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: workflow-definition-lifecycle-traces
-          path: tests/intent/test-results/
-          retention-days: 7
+  # scroll-physics and workflow-definition-lifecycle moved to
+  # ci-heavy-lanes.yml (dispatch-only) in the 2026-08 engineering cull.
+  # Scroll-physics' structural half stays enforced per-PR by repo-shape's
+  # check_transcript_scroll_writer.py; workflow-definition-lifecycle tested a
+  # surface mid gen-2 rebuild (and, while here, blocked the Deploy Staging
+  # workflow_run spine — accepted-lost while demoted). Re-gating either is the
+  # step-3 CI/CD spec's decision.
 
   # ---------------------------------------------------------------------------
   # THE REQUIRED STATUS CHECKS FOR `main`.
@@ -764,8 +519,12 @@ jobs:
   #   Analyze (python)                 (CodeQL)
   #   Analyze (rust)                   (CodeQL)
   #   Validate PR title and labels     (PR Metadata)
-  #   Detect smoke-relevant changes    (Self-Host Smoke)
-  #   Production compose smoke         (Self-Host Smoke)
+  #
+  # 2026-08 engineering cull: the two Self-Host Smoke checks ("Detect
+  # smoke-relevant changes", "Production compose smoke") left this list when
+  # self-host-smoke.yml came off the PR path (it still runs on push:main and
+  # dispatch). Removing them from branch protection is a founder settings
+  # action recorded in the cull PR description.
   #
   # Why rollups instead of the individual lanes: branch protection cannot tell
   # "no red X" from "actually verified". A required check that reports
@@ -786,7 +545,11 @@ jobs:
   #
   # Deliberately NOT required, with reasons:
   #   intent-tests (provisional) / intent-billing (provisional)
-  #       continue-on-error by design; intent-tests.yml says do not require yet.
+  #       continue-on-error by design; dispatch-only since the 2026-08 cull
+  #       (they no longer run on PRs at all).
+  #   CI Heavy Lanes (ci-heavy-lanes.yml)
+  #       dispatch-only demotions from this file (2026-08 cull); re-gating is a
+  #       step-3 CI/CD-spec decision.
   #   docker / self-hosted-release-assets (Build Server Artifacts)
   #       release-only, and no longer in Server CI at all: they moved to
   #       _build-server.yml, which release.yml calls directly so a release does
@@ -829,8 +592,8 @@ jobs:
   # this one file plus preinstalled bash/jq/ruby. Seconds of runner time.
   #
   # `needs:` cannot cross workflows, so this rolls up ci.yml ONLY. Server CI,
-  # CodeQL, PR Metadata, Self-Host Smoke, and Intent Tests are separate
-  # workflows and still need their own entries in the required-checks list.
+  # CodeQL, and PR Metadata are separate workflows and still need their own
+  # entries in the required-checks list.
   ci-ok:
     name: ci-ok
     runs-on: ubuntu-latest
@@ -840,17 +603,13 @@ jobs:
       - repo-shape
       - terraform-validate
       - ci-cd-config
-      - candidate-build-handoff
       - cargo-check
       - sdk-build
       - desktop-frontend
       - mobile-typecheck
       - web-frontend
-      - login-budget
       - shared-frontend-checks
       - shared-frontend-packages
-      - scroll-physics
-      - workflow-definition-lifecycle
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,9 +502,8 @@ jobs:
   # ci-heavy-lanes.yml (dispatch-only) in the 2026-08 engineering cull.
   # Scroll-physics' structural half stays enforced per-PR by repo-shape's
   # check_transcript_scroll_writer.py; workflow-definition-lifecycle tested a
-  # surface mid gen-2 rebuild (and, while here, blocked the Deploy Staging
-  # workflow_run spine — accepted-lost while demoted). Re-gating either is the
-  # step-3 CI/CD spec's decision.
+  # surface mid gen-2 rebuild (its per-PR fail-closed gate is accepted-lost
+  # while demoted). Re-gating either is the step-3 CI/CD spec's decision.
 
   # ---------------------------------------------------------------------------
   # THE REQUIRED STATUS CHECKS FOR `main`.

--- a/.github/workflows/intent-tests.yml
+++ b/.github/workflows/intent-tests.yml
@@ -3,17 +3,20 @@ name: Intent Tests
 # Tier-2 "mocked intent" suite (specs/TESTING.md §Tier 2):
 # real server + real desktop web frontend + real Postgres, Playwright driving
 # a browser. Both jobs here are PROVISIONAL and NON-blocking while the harness
-# earns trust — do NOT add them to required checks yet. Failures are signal to
-# read, not a merge gate; the broad suite joins the merge gate (per the
-# testing standard's CI mapping) once it has a demonstrated flake-free record.
+# earns trust — do NOT add them to required checks yet.
+#
+# Dispatch-only since the 2026-08 engineering cull: both lanes were
+# continue-on-error and gated nothing, so running them per-PR was cost without
+# protection. Their future home (nightly, or promoted into the merge gate once
+# flake-free) is the step-3 testing/CI spec's call
+# (delivery/engineering-cull/delivery-spec-ci-diet.md).
 #
 # The fail-closed exception lives elsewhere: the focused "Workflow definition
-# lifecycle (tier-2)" job in ci.yml runs exactly one spec (T2-WFDEF-1) with no
-# continue-on-error, so it fails CI — and therefore blocks the Deploy Staging
-# workflow_run spine — on a red result.
+# lifecycle (tier-2)" spec (T2-WFDEF-1) runs strictly, with no
+# continue-on-error, in the dispatch-only heavy-lanes workflow
+# (ci-heavy-lanes.yml).
 
 on:
-  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-e2e-selfhost.yml
+++ b/.github/workflows/release-e2e-selfhost.yml
@@ -6,9 +6,11 @@ name: Release E2E — Self-hosting (T3-SH / T4-SH)
 #   artifact-chain (T4-SH-2): the 2026-07-09 incident gate. Pure HTTP + git
 #     against the published desktop release — no box, no credentials — so it can
 #     and SHOULD go red when the artifact chain is broken (server advanced past
-#     the shipped desktop artifact). Exposed via workflow_call so the release
-#     pipeline can run it as a gate, per the spec ("must run in the release gate,
-#     not nightly-only"); also runs nightly for continuous coverage.
+#     the shipped desktop artifact). Dispatch-only since the 2026-08 engineering
+#     cull: the nightly cron and the never-called workflow_call interface were
+#     removed (zero callers ever wired it into the release pipeline). Where this
+#     gate should live — release pipeline, nightly, or both — is a step-3 CI/CD
+#     spec decision (delivery/engineering-cull/delivery-spec-ci-diet.md).
 #
 #   provisioning (T3-SH-1 cold boot, T4-SH-1 update motion): stand up a throwaway
 #     EC2 self-hosted control plane (production compose bundle, sslip.io + real
@@ -29,15 +31,6 @@ on:
         required: false
         type: choice
         options: ["false", "true"]
-  workflow_call:
-    inputs:
-      release_desktop_version:
-        description: Desktop version the release ships (defaults to the repo VERSION).
-        required: false
-        type: string
-  schedule:
-    # Nightly, after the release train + the main tier-3 runner.
-    - cron: "30 11 * * *"
 
 permissions:
   contents: read
@@ -77,8 +70,6 @@ jobs:
         with:
           version: 10
       - name: Run T4-SH-2
-        env:
-          RELEASE_E2E_RELEASE_DESKTOP_VERSION: ${{ inputs.release_desktop_version }}
         run: make release-e2e LANE=local DESKTOP=web AGENTS=all SCENARIOS=T4-SH-2
       - name: Upload Tier 4 preflight evidence
         if: always()
@@ -103,8 +94,7 @@ jobs:
         id: preflight
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          # 'true' on manual dispatch; nightly leaves it off so scheduled runs
-          # never spend on infra unattended.
+          # Only an explicit 'true' on manual dispatch spends on infra.
           PROVISION_INPUT: ${{ github.event.inputs.provision }}
         run: |
           provision=0

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -332,6 +332,10 @@ jobs:
   # it never runs Tier-2, controller-local, self-host, or Tier-4 bodies here.
   release-e2e-staging:
     name: tier-3 staging lane (provisional)
+    # NOTE: the 'schedule' clause below is dead since the 2026-08 cull removed
+    # the cron (this lane stays reachable via dispatch). Kept because the
+    # qualification-runner workflow test asserts this exact expression; clean it
+    # up with the step-3 cadence ruling.
     if: >-
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' &&

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -5,9 +5,11 @@ name: Release E2E (tier 3)
 # provision/pause/resume/connect, chat per cataloged agent, config apply,
 # secrets materialization, billing metering, repo settings.
 #
-# Cadence: release-train, NOT per-PR. It burns real money/time (E2B sandboxes,
-# gateway LLM calls) so it runs on a schedule and on demand, never on
-# `pull_request`. Tier 3 never gates ordinary merges. The scheduled legacy
+# Cadence: on demand only (workflow_dispatch), never on `pull_request`. It
+# burns real money/time (E2B sandboxes, gateway LLM calls); the daily cron was
+# removed in the 2026-08 engineering cull — re-establishing a cadence is a
+# step-3 CI/CD-spec decision (delivery/engineering-cull/delivery-spec-ci-diet.md).
+# Tier 3 never gates ordinary merges. The legacy
 # local/staging jobs remain provisional and `continue-on-error`; the manual
 # protected-Qualification jobs are strict, preserve red exits, and upload V4
 # evidence for their selected exact-head scope. Production promotion does not
@@ -103,11 +105,6 @@ on:
         default: ""
         required: false
         type: string
-  schedule:
-    # Nightly, offset after the release train (which runs at 09:00 UTC) so it
-    # exercises the freshly cut artifacts. README: "Nightly — Tier 3 lanes
-    # against whatever is on staging; failures file issues, never block merges."
-    - cron: "0 11 * * *"
 
 permissions:
   contents: read
@@ -118,6 +115,9 @@ env:
 jobs:
   release-e2e-local:
     name: tier-3 local lane (provisional)
+    # NOTE: with the daily cron removed (2026-08 cull) this schedule-only job is
+    # currently unreachable. Kept pending the step-3 CI/CD spec's ruling on the
+    # tier-3 cadence; delete or re-trigger it there, not here.
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/self-host-smoke.yml
+++ b/.github/workflows/self-host-smoke.yml
@@ -7,27 +7,27 @@ name: Self-Host Smoke
 # /meta, setup-token claim, desktop password login, invite, invited
 # registration, and membership checks (SMOKE_PHASE=1 restricts the script to
 # the health assertions). Nobody lives in the production-compose lane day to
-# day, so this is the check that keeps it from regressing silently. Designed
-# to be a blocking required check on PRs to main.
+# day, so this is the check that keeps it from regressing silently.
+#
+# Off the PR path since the 2026-08 engineering cull: it runs on push:main
+# (post-merge signal; that run also seeds the buildx layer cache) and on
+# dispatch, and is no longer a required check on PRs. The T4-SH-2 artifact-chain
+# incident gate in release-e2e-selfhost.yml is unaffected. Whether a per-PR
+# smoke returns is the step-3 CI/CD spec's call
+# (delivery/engineering-cull/delivery-spec-ci-diet.md).
 #
 # Before the heavy image/Compose smoke, this same required Ubuntu job runs the
 # no-network deploy/template suite, including the rendered GNU timeout proof
 # that a TERM-resistant CloudFormation bootstrap is hard-bounded and signaled.
 #
-# No on.*.paths filter: a path-skipped run of a required check never reports a
-# conclusion, so unrelated PRs would sit on a Pending check forever and be
-# unmergeable. Instead a cheap changes job always runs, diffs against the merge
-# base, and gates the heavy smoke job on the surfaces that change the smoke
-# result (server image inputs plus the deploy bundle and this workflow). A
-# skipped smoke job reports a "skipped" conclusion, which branch protection
-# treats as satisfied, so doc-only PRs still skip the image build while the
-# check always goes green. The push:main run seeds the buildx layer cache that
-# PR builds restore from, so steady-state runtime is dominated by the ~30s
-# stack boot, not the build.
+# A cheap changes job runs first, diffs the push against its previous head,
+# and gates the heavy smoke job on the surfaces that change the smoke result
+# (server image inputs plus the deploy bundle and this workflow), so doc-only
+# merges skip the image build. Dispatch always runs the smoke. The push:main
+# run seeds the buildx layer cache, so steady-state runtime is dominated by
+# the ~30s stack boot, not the build.
 
 on:
-  pull_request:
-    branches: [main]
   push:
     branches: [main]
   workflow_dispatch:
@@ -69,14 +69,10 @@ jobs:
       - name: Diff against merge base
         id: detect
         env:
-          BASE_REF: ${{ github.event.pull_request.base.ref || '' }}
           PUSH_BEFORE: ${{ github.event.before || '' }}
         run: |
           set -euo pipefail
           case "$GITHUB_EVENT_NAME" in
-            pull_request)
-              base="$(git merge-base "origin/${BASE_REF}" HEAD)"
-              ;;
             push)
               base="$PUSH_BEFORE"
               if [[ ! "$base" =~ ^[0-9a-f]{40}$ ]] || [[ "$base" =~ ^0+$ ]] \

--- a/delivery/engineering-cull/delivery-spec-ci-diet.md
+++ b/delivery/engineering-cull/delivery-spec-ci-diet.md
@@ -94,6 +94,14 @@ release/deploy lanes.
 
 ## Implementation notes (recorded at freeze)
 
+- **Scope amendment (raised, not silent):** the spec's "touches only
+  `.github/workflows/**` + docs" was impossible to satisfy literally — the
+  hosted-Playwright census in `scripts/ci-cd/configure-playwright-apt.test.mjs`
+  hardcodes per-workflow expectations and reds `ci-cd-config` (and therefore
+  `ci-ok`) unless its map follows the job moves. The map entry moved with the
+  jobs (ci.yml → ci-heavy-lanes.yml, same three commands); no expectation was
+  weakened. Caught by the adversarial review pass.
+
 - Terraform-validate measured well under 2 minutes on the latest CI run →
   **kept per-PR** per the spec's own conditional.
 - The four demoted lanes moved verbatim into dispatch-only

--- a/delivery/engineering-cull/delivery-spec-ci-diet.md
+++ b/delivery/engineering-cull/delivery-spec-ci-diet.md
@@ -1,0 +1,120 @@
+# Delivery spec — PR-E3: CI Diet (lite: cull only)
+
+Program: engineering-cull. Frozen from the founder-approved draft
+("PR-E3 CI Diet", 2026-08-25). Rescoped per founder principle: **the cull
+builds nothing** — everything constructive (change detection, nightly
+infrastructure) is deferred to the step-3 CI/CD spec. The Deferred section
+below is recorded so it isn't lost, not so it's done now.
+
+Touches only `.github/workflows/**` plus same-commit doc truth updates;
+revertible as a unit. **Founder actions:** branch-protection edit + C5 answer.
+
+## Intent
+
+Stop paying for machinery that gates nothing or protects parked systems: kill
+the daily provider-spend crons, take non-gating lanes off the PR path, and
+demote narrow heavyweight lanes to dispatch. Zero new machinery; every change
+is deleting a trigger, a schedule, or a job's place on the PR path.
+
+Expected effect: runner-minutes saved per PR and the daily E2B/AWS
+qualification spend stops. **Deliberately NOT achieved this week:** the
+≤12-min docs-PR gate — that needs the change-detection build, which is a
+step-3 design item.
+
+## Scope — changed (all deletions of triggers/schedules, no construction)
+
+### 1. Crons on the parked corridor
+- `release-e2e.yml`: delete the daily 11:00 `schedule:` → `workflow_dispatch`
+  only.
+- `release-e2e-selfhost.yml`: delete the daily 11:30 `schedule:` →
+  dispatch-only; also delete its dead `workflow_call:` interface (zero
+  callers).
+- `release-e2e-hard-cancel-cleanup.yml`: **keep** (cost backstop for
+  dispatched runs).
+- `catalog-probe.yml` cron and `release.yml` nightly: **keep** (live signal;
+  production lane).
+
+### 2. Non-gating lanes off the PR path
+- `intent-tests.yml`: remove the `pull_request` trigger → dispatch-only. Both
+  lanes are "(provisional)" and gate nothing today; running them per-PR is
+  cost without protection. Their future home (nightly? promoted to required?)
+  is the step-3 testing/CI spec's call.
+
+### 3. Narrow heavyweight lanes off the PR path
+Remove from the per-PR path (dispatch-only until step 3 redesigns the gate
+structure):
+- `candidate-build-handoff` (protects the parked qualification corridor)
+- `login-budget` (its script + lane + dependabot posthog pin die together in
+  the product cull's PR-5 — this just stops the per-PR cost until then)
+- `workflow-definition-lifecycle` (tests the surface mid gen-2 rebuild; while
+  in ci.yml it also blocked the Deploy Staging workflow_run spine —
+  accepted-lost while demoted)
+- `scroll-physics` (two browsers; its structural half stays enforced by
+  `check_transcript_scroll_writer.py` in repo-shape). *Note: the testing-fork
+  draft preferred keeping this merge-gating; founder cull-only principle
+  overrides for now — re-gate deliberately in step 3.*
+- `terraform-validate` → keep per-PR **only if** it is cheap (<2 min); else
+  dispatch-only.
+
+Mechanically: whichever is smaller per job — remove the job from `ci.yml`
+into a dispatch-only workflow, or condition it out — chosen at implementation
+for the *smallest diff*, with the `ci-ok` rollup updated so it neither waits
+on nor fails for the removed lanes.
+
+### 4. Self-host smoke
+Per-PR prod-compose smoke off the PR path. **Founder action:** remove
+`Production compose smoke` and `Detect smoke-relevant changes` from main's
+required checks in branch protection. T4-SH-2 incident gate kept;
+`server/deploy/**` untouched.
+
+### 5. Windows lanes (C5)
+If ruled non-blocking: confirm they're outside the required set and exclude
+from any rollup they feed. If blocking: no change. **Blocked on C5 — not
+implemented in this PR.**
+
+## Deferred to the step-3 CI/CD spec (recorded, not done)
+
+- `ci.yml` change detection (the 14-job gating table from this spec's v1
+  draft — preserved in the vault file's history) — designs together with the
+  lane model, since they are the same mechanism.
+- `nightly-checks.yml` + automatic issue-filing on failure — the proper home
+  for everything demoted above plus the anyharness suite
+  (`agent-runtime-compat.yml`).
+- The ≤12-min edge-gate budget as an enforced rule.
+- Re-gating decisions for scroll-physics / intent / candidate-handoff /
+  workflow-definition-lifecycle / self-host smoke, and the tier-3 cadence
+  (the schedule-only local lane in `release-e2e.yml` is unreachable until
+  then).
+
+## Non-goals
+
+Deleting workflows (PR-E4 owns the zombies) · any new workflow, detector, or
+filter machinery beyond the verbatim job moves · CodeQL · `server-ci.yml` ·
+release/deploy lanes.
+
+## Implementation notes (recorded at freeze)
+
+- Terraform-validate measured well under 2 minutes on the latest CI run →
+  **kept per-PR** per the spec's own conditional.
+- The four demoted lanes moved verbatim into dispatch-only
+  `ci-heavy-lanes.yml` (smallest diff that satisfies ci-ok's drift guard,
+  which requires every job in ci.yml to appear in its needs list).
+- Same-commit doc truth updated per repo law: the required-checks comment in
+  `ci.yml`, `specs/codebase/systems/engineering/delivery/README.md`,
+  `specs/TESTING.md`, `specs/TESTING/{self-hosting,flows,scenarios,core-release-validation}.md`.
+
+## Acceptance
+
+- Grep: no `schedule:` in `release-e2e.yml` / `release-e2e-selfhost.yml`; no
+  `workflow_call:` in the selfhost file; no `pull_request` trigger in
+  `intent-tests.yml` or `self-host-smoke.yml`.
+- A test PR shows the demoted lanes absent from its check list, and `ci-ok`
+  still resolves green.
+- `ci-ok` still fails on a genuinely failing covered lane (one deliberate red
+  on a scratch branch).
+- Branch-protection change confirmed by founder in the PR description.
+
+## Revert
+
+Single revert restores all triggers/schedules; branch protection reverts by
+hand (noted in PR description).

--- a/scripts/ci-cd/configure-playwright-apt.test.mjs
+++ b/scripts/ci-cd/configure-playwright-apt.test.mjs
@@ -240,7 +240,9 @@ test("rejects unknown two-stanza shapes without modifying the file", async (cont
 test("guards every hosted Playwright dependency install in its own run block", async () => {
   const expectedCommandsByWorkflow = new Map([
     [
-      ".github/workflows/ci.yml",
+      // The three browser-installing lanes moved from ci.yml to the
+      // dispatch-only ci-heavy-lanes.yml in the 2026-08 engineering cull.
+      ".github/workflows/ci-heavy-lanes.yml",
       [
         "pnpm exec playwright install --with-deps chromium",
         "pnpm --filter @proliferate/product-client exec playwright install --with-deps chromium webkit",

--- a/specs/TESTING.md
+++ b/specs/TESTING.md
@@ -61,7 +61,7 @@ where the boundary to fakes sits. Four tiers:
 | --- | --- | --- | --- | --- |
 | **1 — Unit / contract** | Logic; Postgres/SQLite where the guarantee lives in the DB | Everything across a network | Every PR, seconds | **Merge** |
 | **2 — Mocked intent** | Server + Desktop renderer in Chromium + real Postgres, booted on ports; real Stripe test mode for billing | AnyHarness, sandbox provider, LLM, IdP, email, Slack, and every other external provider | Every PR, minutes | **Merge** |
-| **3 — Live end-to-end** | The selected world's real candidate server/runtime/provider boundaries, real agents on cheap models, and exact deploy artifacts | Boundaries outside the selected world are absent rather than simulated | Release train + nightly | **Release** |
+| **3 — Live end-to-end** | The selected world's real candidate server/runtime/provider boundaries, real agents on cheap models, and exact deploy artifacts | Boundaries outside the selected world are absent rather than simulated | Release train + on demand (the nightly cron was removed in the 2026-08 engineering cull; re-establishing a cadence is a step-3 CI/CD-spec decision) | **Release** |
 | **4 — Packaged install / upgrade** | Exact signed candidate packages plus retained production N−1 state upgraded through shipped mechanisms to exact candidate N | No claimed product boundary; updater/control channels are isolated while their artifacts and verification remain real | Release train | **Release** |
 
 **The gate rule (hard):** the merge gate is tiers 1–2 only. No real LLM or
@@ -197,7 +197,10 @@ pnpm --filter @proliferate/product-client test:scroll-physics
 
 (`test:scroll-physics` builds the Vite fixture itself, then runs Playwright at
 `workers=1`; it does not rebuild `dist`.) CI runs it in the `scroll-physics`
-job, which builds the shared packages and installs both browser engines.
+job of the dispatch-only `ci-heavy-lanes.yml` (off the per-PR path since the
+2026-08 engineering cull; the structural half stays enforced per-PR by
+`check_transcript_scroll_writer.py` in repo-shape), which builds the shared
+packages and installs both browser engines.
 
 ### Workflow-canvas suite (builder graph surface)
 
@@ -281,8 +284,9 @@ answer to "which lower tier should have owned this," and that test lands with
 the fix.
 
 Named migration exceptions: desktop vitest is not yet wired into the merge
-gate; the broad tier-2 intent lanes (`intent-tests` + `intent-billing`) run
-provisional/non-blocking until they earn a flake-free record; and
+gate; the broad tier-2 intent lanes (`intent-tests` + `intent-billing`) are
+provisional and dispatch-only since the 2026-08 engineering cull (their return
+to a cadence or the merge gate is a step-3 CI/CD-spec decision); and
 `scripts/validate-agent-catalog.mjs` remains a hand-kept mirror of the Rust
 catalog validator until the contract-fixture pattern absorbs it. Target gate
 tables and the exception's closure order live in the same contract linked above.

--- a/specs/TESTING.md
+++ b/specs/TESTING.md
@@ -60,7 +60,7 @@ where the boundary to fakes sits. Four tiers:
 | Tier | What is real | What is faked or absent | Runs | Gates |
 | --- | --- | --- | --- | --- |
 | **1 — Unit / contract** | Logic; Postgres/SQLite where the guarantee lives in the DB | Everything across a network | Every PR, seconds | **Merge** |
-| **2 — Mocked intent** | Server + Desktop renderer in Chromium + real Postgres, booted on ports; real Stripe test mode for billing | AnyHarness, sandbox provider, LLM, IdP, email, Slack, and every other external provider | Every PR, minutes | **Merge** |
+| **2 — Mocked intent** | Server + Desktop renderer in Chromium + real Postgres, booted on ports; real Stripe test mode for billing | AnyHarness, sandbox provider, LLM, IdP, email, Slack, and every other external provider | On demand since the 2026-08 engineering cull (no tier-2 lane runs per-PR: the broad intent lanes and the focused workflow-definition cell are all dispatch-only; per-PR return is a step-3 CI/CD-spec decision) | **Merge (target)** |
 | **3 — Live end-to-end** | The selected world's real candidate server/runtime/provider boundaries, real agents on cheap models, and exact deploy artifacts | Boundaries outside the selected world are absent rather than simulated | Release train + on demand (the nightly cron was removed in the 2026-08 engineering cull; re-establishing a cadence is a step-3 CI/CD-spec decision) | **Release** |
 | **4 — Packaged install / upgrade** | Exact signed candidate packages plus retained production N−1 state upgraded through shipped mechanisms to exact candidate N | No claimed product boundary; updater/control channels are isolated while their artifacts and verification remain real | Release train | **Release** |
 

--- a/specs/TESTING/core-release-validation.md
+++ b/specs/TESTING/core-release-validation.md
@@ -658,7 +658,10 @@ The runner and the manual qualification worlds now enforce these foundations:
   jobs are not `continue-on-error`, run through the protected `Qualification`
   environment, preserve the runner's exit code, and upload their V4 evidence;
   and
-- the scheduled legacy local and staging lanes remain explicitly provisional,
+- the legacy local and staging lanes (dispatch-only since the 2026-08
+  engineering cull removed the nightly cron; the schedule-only local lane is
+  currently unreachable pending the step-3 cadence ruling) remain explicitly
+  provisional,
   `continue-on-error`, and capable of skipping their whole lane when a
   preflight dependency is absent. Their output is diagnostic signal, never
   qualification.
@@ -666,10 +669,13 @@ The runner and the manual qualification worlds now enforce these foundations:
 The remaining enforcement exceptions are:
 
 - the two broad Tier 2 jobs in `intent-tests.yml` remain
-  `continue-on-error`, and the broad billing job skips when
+  `continue-on-error` and are dispatch-only since the 2026-08 engineering
+  cull, and the broad billing job skips when
   `STRIPE_TEST_SECRET_KEY` is absent. The manual strict Tier 2 qualification
-  job fails closed on that missing key, while only the focused workflow
-  definition lifecycle cell currently gates ordinary CI;
+  job fails closed on that missing key. The focused workflow definition
+  lifecycle cell no longer gates ordinary CI: it runs strictly in the
+  dispatch-only `ci-heavy-lanes.yml`, with re-gating a step-3 CI/CD-spec
+  decision;
 - production promotion validates staging deployment evidence but does not
   invoke or verify a trusted Tier 3/4 qualification aggregate for the same
   source SHA and artifact digests;

--- a/specs/TESTING/flows.md
+++ b/specs/TESTING/flows.md
@@ -113,7 +113,7 @@ legacy implementation/evidence hand-off for the pointers below.
 
 | Flow | Tier | Test pointer |
 | --- | --- | --- |
-| Create, save, reload, reopen, edit, and delete a validated workflow definition through the Desktop web UI — API-seeded repo selected, exact ordered inputs/stages/steps asserted at every reload | 2 | `tests/intent/specs/workflow-definitions.spec.ts` (`T2-WFDEF-1`; real server + Postgres, AnyHarness skipped; fail-closed in the CI/deploy spine via the "Workflow definition lifecycle (tier-2)" job in ci.yml, eligible for a future required-status rule — the broad intent lane stays provisional) |
+| Create, save, reload, reopen, edit, and delete a validated workflow definition through the Desktop web UI — API-seeded repo selected, exact ordered inputs/stages/steps asserted at every reload | 2 | `tests/intent/specs/workflow-definitions.spec.ts` (`T2-WFDEF-1`; real server + Postgres, AnyHarness skipped; runs strictly in the dispatch-only `ci-heavy-lanes.yml` since the 2026-08 engineering cull — off the per-PR spine pending the step-3 re-gating decision; the broad intent lane stays provisional) |
 | Create/edit/trigger workflow via UI → run created, plan resolved, delivery attempted (up to the sandbox seam) | 2 | parked |
 | Workflow run reaches terminal state with a real agent | 3 | parked |
 | Poll trigger against stub feed: replay-safe, invalid items surfaced | 2 | parked |

--- a/specs/TESTING/scenarios.md
+++ b/specs/TESTING/scenarios.md
@@ -347,10 +347,11 @@ response, after a hard reload, after list reopen, on an authenticated GET, and
 again on the revision-2 update. Then delete and assert both the normal list
 and the authenticated API no longer expose it. The real server and Postgres
 are in scope; AnyHarness is skipped because this PR does not execute
-definitions. This scenario runs fail-closed in the CI/deploy spine (the
-"Workflow definition lifecycle (tier-2)" job in ci.yml — a red result fails CI
-and blocks Deploy Staging, and the check is eligible for a future repository
-required-status rule); the broad intent lane remains provisional.
+definitions. This scenario runs strictly (no continue-on-error) in the
+dispatch-only `ci-heavy-lanes.yml` since the 2026-08 engineering cull — it no
+longer runs per-PR or blocks Deploy Staging while the surface is mid gen-2
+rebuild; re-gating is a step-3 CI/CD-spec decision. The broad intent lane
+remains provisional.
 
 **PARKED (ruled 2026-07-08): the execution scenarios below remain deferred
 until their owning workflow-execution PRs. T2-WFDEF-1 above is active and

--- a/specs/TESTING/self-hosting.md
+++ b/specs/TESTING/self-hosting.md
@@ -39,7 +39,9 @@ Invariants: every self-hosted server is single-org
 telemetry mode); `/setup` is claimed exactly once and 404s forever after;
 invitees register in a browser via the invitation's registration token.
 
-What already exists: `self-host-smoke.yml` (required merge check) boots the
+What already exists: `self-host-smoke.yml` (push-to-`main` + dispatch; off the
+PR path and no longer a required merge check since the 2026-08 engineering
+cull) boots the
 real compose stack http-only and walks health → `/meta` → claim → password
 login → invite → register → membership at the **API** level, then proves
 self-hosted Web served from the exact production image: `/` and `/login` return

--- a/specs/codebase/systems/engineering/delivery/README.md
+++ b/specs/codebase/systems/engineering/delivery/README.md
@@ -231,13 +231,14 @@ gate.
 | --- | --- | --- |
 | `agent-runtime-compat.yml` | Manual | Exercise live local AnyHarness compatibility with configured agent credentials. |
 | `catalog-probe.yml` | Scheduled daily or manual | Probe agent/catalog pins through the protected `Catalog Probe` environment, pass sanitized outputs to a separate write-capable PR job, and create or update an owned GitHub issue on scheduled failure. |
-| `ci.yml` | Push to `main`, pull request, or manual | Run repository shape, configuration, candidate-handoff, Rust, SDK, client, and workflow checks. Required-check policy is external to this file. |
+| `ci-heavy-lanes.yml` | Manual | Run the four lanes demoted off the per-PR path in the 2026-08 engineering cull (candidate-build-handoff, login-budget, scroll-physics, workflow-definition-lifecycle), verbatim moves out of `ci.yml`. Re-gating is a step-3 CI/CD-spec decision. |
+| `ci.yml` | Push to `main`, pull request, or manual | Run repository shape, configuration, Rust, SDK, client, and workflow checks. Required-check policy is external to this file. |
 | `codeql.yml` | Push or pull request on `main`, plus weekly schedule | Run CodeQL security analysis. |
-| `intent-tests.yml` | Pull request or manual | Run the broad intent and billing suites; these lanes are currently provisional/non-blocking. |
+| `intent-tests.yml` | Manual | Run the broad intent and billing suites; provisional/non-blocking, and off the PR path since the 2026-08 cull. |
 | `pr-metadata.yml` | Pull-request metadata events | Enforce ready-PR title and label metadata mechanically. Human policy belongs to the PR procedure. |
-| `release-e2e-selfhost.yml` | Scheduled, manual, or reusable | Run self-host artifact-chain and optional provisioning qualification. Tier 4 and self-host provisioning use separate non-cancelling job groups; no current release coordinator calls it. |
-| `release-e2e.yml` | Scheduled or manual | Run live Tier 3 release qualification; it is not a per-PR merge gate. Local, staging, Tier 2, managed-cloud, and self-host use independent non-cancelling job groups, so unrelated worlds may overlap while same-world runs do not. These groups do not promise FIFO ordering. |
-| `self-host-smoke.yml` | Pull request, push to `main`, or manual | Smoke the production Compose path when relevant paths change. Branch-protection status is not encoded here. |
+| `release-e2e-selfhost.yml` | Manual | Run self-host artifact-chain and optional provisioning qualification. The nightly cron and never-called `workflow_call` interface were removed in the 2026-08 cull. Tier 4 and self-host provisioning use separate non-cancelling job groups. |
+| `release-e2e.yml` | Manual | Run live Tier 3 release qualification; it is not a per-PR merge gate. The daily cron was removed in the 2026-08 cull (the schedule-only local lane is currently unreachable, pending the step-3 cadence ruling). Local, staging, Tier 2, managed-cloud, and self-host use independent non-cancelling job groups, so unrelated worlds may overlap while same-world runs do not. These groups do not promise FIFO ordering. |
+| `self-host-smoke.yml` | Push to `main` or manual | Smoke the production Compose path when relevant paths change. Off the PR path since the 2026-08 cull; the push run also seeds the buildx layer cache. |
 | `server-ci.yml` | Relevant push/PR, manual, or reusable | Validate the server. It is a gate, not a publisher: the release image and asset build lives in `_build-server.yml`. |
 
 Server CI's shrink-only mypy census compares a pull request with its base SHA
@@ -331,8 +332,11 @@ The required status checks for `main` are:
 | `Analyze (python)` | CodeQL |
 | `Analyze (rust)` | CodeQL |
 | `Validate PR title and labels` | PR Metadata |
-| `Detect smoke-relevant changes` | Self-Host Smoke |
-| `Production compose smoke` | Self-Host Smoke |
+
+2026-08 engineering cull: the two Self-Host Smoke checks (`Detect
+smoke-relevant changes`, `Production compose smoke`) left this list when
+`self-host-smoke.yml` came off the PR path; removing them from branch
+protection is a founder settings action recorded in the cull PR description.
 
 Names are check-run display names, as `gh pr checks` prints them. No individual
 lane name from `ci.yml` or `server-ci.yml` belongs on the list: the rollups are
@@ -341,7 +345,9 @@ strictly stronger, and a per-lane name is a name that can rot. Because a
 lane never requires a branch-protection edit.
 
 Excluded on purpose: `intent-tests (provisional)` and `intent-billing
-(provisional)` are `continue-on-error` while the harness earns trust; the Vercel
+(provisional)` are `continue-on-error` while the harness earns trust and no
+longer run on PRs at all (dispatch-only since the 2026-08 cull); the CI Heavy
+Lanes jobs are dispatch-only demotions from `ci.yml` (same cull); the Vercel
 checks are third-party. `docker` and `self-hosted-release-assets` used to be
 excluded as release-only jobs inside Server CI; they now live in
 `_build-server.yml` and are outside the rollup's file entirely. Server CI's


### PR DESCRIPTION
Implements the frozen delivery spec `delivery/engineering-cull/delivery-spec-ci-diet.md` (engineering-cull PR-E3, rescoped lite: **cull only, builds nothing**).

## What changed

- **Crons deleted**: `release-e2e.yml` daily 11:00 and `release-e2e-selfhost.yml` daily 11:30 → dispatch-only; the selfhost file's never-called `workflow_call:` interface deleted. Kept per spec: `release-e2e-hard-cancel-cleanup.yml`, `catalog-probe.yml` cron, `release.yml` nightly.
- **`intent-tests.yml`** off the PR path → dispatch-only (both lanes were `continue-on-error` and gated nothing).
- **Four heavy lanes moved verbatim out of `ci.yml`** into the new dispatch-only `ci-heavy-lanes.yml`: `candidate-build-handoff`, `login-budget`, `scroll-physics`, `workflow-definition-lifecycle`. `ci-ok` needs list updated; its drift guard verified green. `terraform-validate` **kept per-PR**: measured <1 min, under the spec's 2-minute threshold.
- **`self-host-smoke.yml`** off the PR path (push:main + dispatch remain; the push run still seeds the buildx cache); dead `pull_request` script branch removed.
- Same-commit doc truth: `ci.yml` required-checks comment, delivery README tables, `specs/TESTING.md` + four `specs/TESTING/` docs.
- Scope amendment (raised in the frozen spec, not silent): the hosted-Playwright census in `scripts/ci-cd/configure-playwright-apt.test.mjs` had to follow the job moves or `ci-cd-config`/`ci-ok` would red every PR. Entry moved verbatim, no expectation weakened.

## FOUNDER ACTION — branch protection (settings, not code)

Remove from main's required checks: **`Production compose smoke`** and **`Detect smoke-relevant changes`** (Self-Host Smoke). Until this edit lands, PRs will strand on those two pending checks.

## C5 status (Windows lanes) — unanswered, untouched

No change made. Current state for the ruling: all three (`windows-compile-check`, `windows-process-kill-tests`, `windows-sdk-generate-check`) are path-filtered `pull_request` lanes and are **not** in `ci-ok` or any rollup — they gate nothing today. `windows-sdk-generate-check` has no `workflow_dispatch` trigger; the other two do.

## Flagged, not fixed (step-3 items)

- `release-e2e.yml`'s schedule-only `release-e2e-local` job is now unreachable (noted in-file; deleting a tier-3 lane wasn't in scope). The staging lane's dead `'schedule' ||` clause is annotated and kept verbatim — a release-runner test asserts the exact expression.
- Re-gating decisions for every demoted lane live in the frozen spec's Deferred section.

## Proof

- All 29 workflow YAMLs parse; `ci-ok` drift guard simulated locally (missing=[] extra=[]).
- `scripts/ci-cd` suite 234/234; `check_docs.py` green (239 files).
- Adversarial review: two fresh-context reviewers (spec fidelity + Actions semantics); one blocker found (the Playwright census) and fixed in e813b9770; verbatim moves confirmed YAML-deep-equal; no dangling refs; PR-E4's files untouched.
- Honest cost note: on a recent cached run the four demoted lanes took 2–4 min each (not their 20–30 min timeouts), so the per-PR saving is real but modest (~13 job-min + the daily E2B/AWS cron spend).

## Revert

Single revert restores all triggers/schedules; branch protection reverts by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)