### PR TITLE
fix(lints): wave-0 follow-up — build-output fence exclusion, stale workflows importers

### DIFF
--- a/scripts/check_frontend_fences.py
+++ b/scripts/check_frontend_fences.py
@@ -48,6 +48,11 @@ INTERNAL_SUBPATH = "internal/"
 # (src-root files are a known limit: the fence governs top-level directories
 # only, and src/App.tsx + src/ProductClient.tsx sit above them).
 SELF_EXPORT_TOPS = {"host": "host", "infra": "lib"}
+# Gitignored build output under src/ (written by
+# apps/packages/product-client/scripts/copy-product-client-assets.mjs). It is
+# data, not a source directory, and it exists only on a built checkout — a
+# top set that included it would differ between a developer machine and CI.
+BUILD_OUTPUT_DIRS = {"generated"}
 SOURCE_SUFFIXES = {".ts", ".tsx"}
 
 RULES = lint_records.load("frontend")
@@ -133,7 +138,11 @@ def collect_violations(
         raise SystemExit(f"{CHECKER}: missing package tree {src}")
     if baseline is None:
         baseline = load_edge_baseline(base)
-    tops = {entry.name for entry in src.iterdir() if entry.is_dir()}
+    tops = {
+        entry.name
+        for entry in src.iterdir()
+        if entry.is_dir() and entry.name not in BUILD_OUTPUT_DIRS
+    }
     violations: list[Violation] = []
     edges_seen: set[tuple[str, str]] = set()
 

--- a/scripts/test_check_frontend_fences.py
+++ b/scripts/test_check_frontend_fences.py
@@ -112,6 +112,22 @@ class EdgeBaselineTest(FenceTestCase):
         self.assertEqual(result.violations, [])
         self.assertEqual(result.edges_seen, set())
 
+    def test_build_output_directory_is_not_a_top(self) -> None:
+        """src/generated/ exists only on a built checkout; it must never
+        become a fence target, or the graph would differ between a developer
+        machine and CI."""
+        result = self.scan(
+            {
+                "lib/domain/agents/registry.ts": (
+                    'import registry from "../../../generated/agent-registry.json?raw";\n'
+                ),
+                "generated/agent-registry.json": "{}\n",
+            },
+            baseline=set(),
+        )
+        self.assertEqual(result.violations, [])
+        self.assertEqual(result.edges_seen, set())
+
 
 class SelfPackageExportTest(FenceTestCase):
     def test_host_export_subpath_counts_as_an_edge(self) -> None:

--- a/server/proliferate/server/workflows/MANIFEST.toml
+++ b/server/proliferate/server/workflows/MANIFEST.toml
@@ -15,7 +15,5 @@ public_surface = [
 ]
 
 allowed_importers = [
-    "background",
     "main.py",
-    "meta.py",
 ]


### PR DESCRIPTION
Follow-up to #2217 (cull-sweep Track G), fixing the two warn-mode reports surfaced by the other tracks after merge. Warn-mode only; nothing was blocking.

## What changed

**1. `check_frontend_fences.py` — build output is not a fence target.** Track C reported `lib→generated` edges (`bundled-agent-registry.ts`, `provider-config-fields.ts`) as unbaselined. Root cause: `src/generated/` is gitignored build output written by `copy-product-client-assets.mjs`, so on a built checkout it became a top-level directory that CI (unbuilt) never sees. Seeding the edges would have been wrong — the rows would be stale on every CI run and the graph would differ by machine. Fix: `BUILD_OUTPUT_DIRS` excluded from the top set, pinned by a unit test. Verified: the checker reports "matches reality exactly" both with and without the generated file present.

**2. `server/workflows/MANIFEST.toml` — two stale importer rows dropped.** `background` and `meta.py` stopped importing `proliferate.server.workflows` when #2221 deleted the gen-1 lane; PROD-MANIFEST-002 reported both as stale — the same-PR maintenance case the record describes. `cloud/` manifests deliberately untouched (Track A owns their rewrite).

## Proof

- `python3 -m unittest` over the four lint suites — 58 tests OK
- `check_frontend_fences.py`, `check_manifests.py`, `check_anyharness_fences.py`, `lint_records.py`, `check_docs.py` — all green on current main, in enforce mode
- FE checker also exit 0 with `src/generated/agent-registry.json` created locally, then removed

## Testing / Observability

Unit test added for the build-output exclusion; no runtime behavior change (CI-only checkers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)